### PR TITLE
fix(a11y): keep VoiceOver announcements alive while modals are open (#9196)

### DIFF
--- a/renderer-import-baseline.json
+++ b/renderer-import-baseline.json
@@ -1,7 +1,8 @@
 {
   "entryName": "index",
-  "eagerChunkCount": 67,
+  "eagerChunkCount": 68,
   "eagerChunks": [
+    "AccessibilityAnnouncer",
     "ActionService",
     "GitHubIcon",
     "KeybindingService",
@@ -70,8 +71,8 @@
     "vendor-xterm",
     "vendor-zod"
   ],
-  "eagerRaw": 2750816,
-  "eagerGzip": 826496,
+  "eagerRaw": 2768652,
+  "eagerGzip": 832130,
   "chunkGzip": {
     "vendor-radix-utils": 3261,
     "vendor-react": 56453,

--- a/src/components/Accessibility/AccessibilityAnnouncer.tsx
+++ b/src/components/Accessibility/AccessibilityAnnouncer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+import { useAnnouncerStore, isDelivered, markDelivered } from "@/store/accessibilityAnnouncerStore";
 
 const ANNOUNCEMENT_DELAY_MS = 100;
 
@@ -26,6 +26,15 @@ function announceToRegion(
 
   const entryId = entry!.id;
 
+  // Suppress stale-replay: when a modal mounts and its co-located announcer
+  // subscribes to an entry that's already been delivered by another instance
+  // (e.g., the root-level announcer), the entry is stale and the AT has
+  // already heard it. Skipping keeps the new modal subtree silent on mount.
+  if (isDelivered(channel, entryId)) {
+    el.textContent = "";
+    return;
+  }
+
   el.textContent = "";
   pendingRef.current = setTimeout(() => {
     pendingRef.current = null;
@@ -33,6 +42,7 @@ function announceToRegion(
     if (!current || current.id !== entryId) return;
     if (elRef.current) {
       elRef.current.textContent = msg;
+      markDelivered(channel, entryId);
     }
   }, ANNOUNCEMENT_DELAY_MS);
 }

--- a/src/components/Accessibility/__tests__/AccessibilityAnnouncer.test.tsx
+++ b/src/components/Accessibility/__tests__/AccessibilityAnnouncer.test.tsx
@@ -5,6 +5,10 @@ import { StrictMode } from "react";
 import { AccessibilityAnnouncer } from "../AccessibilityAnnouncer";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 
+interface DocumentWithAriaNotify extends Document {
+  ariaNotify?: (message: string, options?: { priority?: "normal" | "important" }) => void;
+}
+
 describe("AccessibilityAnnouncer", () => {
   beforeEach(() => {
     useAnnouncerStore.setState({ polite: null, assertive: null, nextId: 1 });
@@ -204,5 +208,80 @@ describe("AccessibilityAnnouncer", () => {
     const state = useAnnouncerStore.getState();
     expect(state.polite?.msg).toBe("Hello");
     expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+// Workaround for Chromium 354736464: VoiceOver ignores `aria-live` updates
+// outside the focused `aria-modal` subtree. When the platform exposes
+// `document.ariaNotify`, the store calls it instead of mutating live-region
+// DOM, so announcements bypass the subtree filter entirely.
+describe("accessibilityAnnouncerStore — ariaNotify path", () => {
+  let ariaNotifyMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    useAnnouncerStore.setState({ polite: null, assertive: null, nextId: 1 });
+    ariaNotifyMock = vi.fn();
+    (document as DocumentWithAriaNotify).ariaNotify = ariaNotifyMock;
+  });
+
+  afterEach(() => {
+    delete (document as DocumentWithAriaNotify).ariaNotify;
+  });
+
+  it("calls document.ariaNotify with priority 'normal' for polite", () => {
+    useAnnouncerStore.getState().announce("Saved", "polite");
+    expect(ariaNotifyMock).toHaveBeenCalledTimes(1);
+    expect(ariaNotifyMock).toHaveBeenCalledWith("Saved", { priority: "normal" });
+  });
+
+  it("calls document.ariaNotify with priority 'important' for assertive", () => {
+    useAnnouncerStore.getState().announce("Failure", "assertive");
+    expect(ariaNotifyMock).toHaveBeenCalledTimes(1);
+    expect(ariaNotifyMock).toHaveBeenCalledWith("Failure", { priority: "important" });
+  });
+
+  it("defaults to 'normal' priority when no priority is specified", () => {
+    useAnnouncerStore.getState().announce("Saved");
+    expect(ariaNotifyMock).toHaveBeenCalledWith("Saved", { priority: "normal" });
+  });
+
+  it("does NOT mutate the store when ariaNotify is available", () => {
+    useAnnouncerStore.getState().announce("Saved", "polite");
+    useAnnouncerStore.getState().announce("Failed", "assertive");
+    const state = useAnnouncerStore.getState();
+    expect(state.polite).toBeNull();
+    expect(state.assertive).toBeNull();
+    expect(state.nextId).toBe(1);
+  });
+
+  it("falls back to DOM mutation when ariaNotify throws", () => {
+    ariaNotifyMock.mockImplementation(() => {
+      throw new Error("AT unavailable");
+    });
+    useAnnouncerStore.getState().announce("Saved", "polite");
+    expect(ariaNotifyMock).toHaveBeenCalledTimes(1);
+    const state = useAnnouncerStore.getState();
+    expect(state.polite?.msg).toBe("Saved");
+  });
+});
+
+describe("accessibilityAnnouncerStore — DOM-mutation fallback", () => {
+  beforeEach(() => {
+    useAnnouncerStore.setState({ polite: null, assertive: null, nextId: 1 });
+    delete (document as DocumentWithAriaNotify).ariaNotify;
+  });
+
+  it("mutates the store when ariaNotify is unavailable", () => {
+    useAnnouncerStore.getState().announce("Saved", "polite");
+    const state = useAnnouncerStore.getState();
+    expect(state.polite?.msg).toBe("Saved");
+    expect(state.polite?.id).toBe(1);
+  });
+
+  it("routes assertive announcements to the assertive entry", () => {
+    useAnnouncerStore.getState().announce("Failure", "assertive");
+    const state = useAnnouncerStore.getState();
+    expect(state.assertive?.msg).toBe("Failure");
+    expect(state.polite).toBeNull();
   });
 });

--- a/src/components/Accessibility/__tests__/AccessibilityAnnouncer.test.tsx
+++ b/src/components/Accessibility/__tests__/AccessibilityAnnouncer.test.tsx
@@ -3,15 +3,19 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, cleanup } from "@testing-library/react";
 import { StrictMode } from "react";
 import { AccessibilityAnnouncer } from "../AccessibilityAnnouncer";
-import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+import {
+  useAnnouncerStore,
+  _resetAnnouncerDeliveryForTests,
+} from "@/store/accessibilityAnnouncerStore";
 
 interface DocumentWithAriaNotify extends Document {
-  ariaNotify?: (message: string, options?: { priority?: "normal" | "important" }) => void;
+  ariaNotify?: (message: string, options?: { priority?: "normal" | "high" }) => void;
 }
 
 describe("AccessibilityAnnouncer", () => {
   beforeEach(() => {
     useAnnouncerStore.setState({ polite: null, assertive: null, nextId: 1 });
+    _resetAnnouncerDeliveryForTests();
     vi.useFakeTimers();
   });
 
@@ -196,6 +200,19 @@ describe("AccessibilityAnnouncer", () => {
     expect(assertiveRegion?.textContent).toBe("Assertive");
   });
 
+  it("does not replay a delivered entry when a second instance mounts later", () => {
+    useAnnouncerStore.setState({ polite: { msg: "Saved", id: 1 } });
+    const { container: first } = render(<AccessibilityAnnouncer />);
+    vi.advanceTimersByTime(100);
+    expect(first.querySelector('[aria-live="polite"]')?.textContent).toBe("Saved");
+
+    // Simulate a modal opening: a new AccessibilityAnnouncer mounts that
+    // subscribes to the same (already-delivered) store entry.
+    const { container: second } = render(<AccessibilityAnnouncer />);
+    vi.advanceTimersByTime(100);
+    expect(second.querySelector('[aria-live="polite"]')?.textContent).toBe("");
+  });
+
   it("does not leak timers under StrictMode double-mount", () => {
     useAnnouncerStore.setState({ polite: { msg: "Hello", id: 1 } });
     render(
@@ -220,6 +237,7 @@ describe("accessibilityAnnouncerStore — ariaNotify path", () => {
 
   beforeEach(() => {
     useAnnouncerStore.setState({ polite: null, assertive: null, nextId: 1 });
+    _resetAnnouncerDeliveryForTests();
     ariaNotifyMock = vi.fn();
     (document as DocumentWithAriaNotify).ariaNotify = ariaNotifyMock;
   });
@@ -234,10 +252,10 @@ describe("accessibilityAnnouncerStore — ariaNotify path", () => {
     expect(ariaNotifyMock).toHaveBeenCalledWith("Saved", { priority: "normal" });
   });
 
-  it("calls document.ariaNotify with priority 'important' for assertive", () => {
+  it("calls document.ariaNotify with priority 'high' for assertive", () => {
     useAnnouncerStore.getState().announce("Failure", "assertive");
     expect(ariaNotifyMock).toHaveBeenCalledTimes(1);
-    expect(ariaNotifyMock).toHaveBeenCalledWith("Failure", { priority: "important" });
+    expect(ariaNotifyMock).toHaveBeenCalledWith("Failure", { priority: "high" });
   });
 
   it("defaults to 'normal' priority when no priority is specified", () => {
@@ -268,6 +286,7 @@ describe("accessibilityAnnouncerStore — ariaNotify path", () => {
 describe("accessibilityAnnouncerStore — DOM-mutation fallback", () => {
   beforeEach(() => {
     useAnnouncerStore.setState({ polite: null, assertive: null, nextId: 1 });
+    _resetAnnouncerDeliveryForTests();
     delete (document as DocumentWithAriaNotify).ariaNotify;
   });
 

--- a/src/components/Accessibility/__tests__/AccessibilityAnnouncer.test.tsx
+++ b/src/components/Accessibility/__tests__/AccessibilityAnnouncer.test.tsx
@@ -239,7 +239,8 @@ describe("accessibilityAnnouncerStore — ariaNotify path", () => {
     useAnnouncerStore.setState({ polite: null, assertive: null, nextId: 1 });
     _resetAnnouncerDeliveryForTests();
     ariaNotifyMock = vi.fn();
-    (document as DocumentWithAriaNotify).ariaNotify = ariaNotifyMock;
+    (document as DocumentWithAriaNotify).ariaNotify =
+      ariaNotifyMock as unknown as DocumentWithAriaNotify["ariaNotify"];
   });
 
   afterEach(() => {

--- a/src/components/ErrorBoundary/ErrorFallback.tsx
+++ b/src/components/ErrorBoundary/ErrorFallback.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 import { actionService } from "@/services/ActionService";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+import { AccessibilityAnnouncer } from "@/components/Accessibility/AccessibilityAnnouncer";
 import { TriangleAlert } from "lucide-react";
 
 export interface ErrorFallbackProps {
@@ -199,6 +200,10 @@ export function ErrorFallback({
           </details>
         )}
       </div>
+      {/* Co-located live region: fullscreen variant carries `aria-modal`, so
+          VoiceOver suppresses external `aria-live` regions when
+          `document.ariaNotify` is unavailable (Chromium 354736464). */}
+      {isFullscreen && <AccessibilityAnnouncer />}
     </div>
   );
 }

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -22,6 +22,7 @@ import {
 import { cn } from "@/lib/utils";
 import { getProjectGradient } from "@/lib/colorUtils";
 import { AppPaletteDialog, KBD_CLASS } from "@/components/ui/AppPaletteDialog";
+import { AccessibilityAnnouncer } from "@/components/Accessibility/AccessibilityAnnouncer";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   ContextMenu,
@@ -1062,6 +1063,12 @@ function ModalContent({
           onRemoveScratch={innerProps.onRemoveScratch}
           onSaveAsProject={innerProps.onSaveAsProject}
         />
+        {/* Co-located live region: this palette manages its own
+            `aria-modal` and does not pass through `AppPaletteDialog`, so
+            VoiceOver would otherwise suppress external `aria-live`
+            updates when `document.ariaNotify` is unavailable
+            (Chromium 354736464). */}
+        <AccessibilityAnnouncer />
       </div>
     </div>,
     document.body

--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 
 import { useOverlayState } from "@/hooks";
 import { ReviewHubContent } from "./ReviewHubContent";
+import { AccessibilityAnnouncer } from "@/components/Accessibility/AccessibilityAnnouncer";
 
 interface ReviewHubProps {
   isOpen: boolean;
@@ -87,6 +88,12 @@ export function ReviewHub({
           initialCommitMessage={initialCommitMessage}
           autoStageOnOpen={autoStageOnOpen}
         />
+        {/* Co-located live region: ForcePushConfirmDialog and other nested
+            flows close their inner dialog before announcing, returning focus
+            to this modal. VoiceOver suppresses external `aria-live` updates
+            outside this `aria-modal` subtree when `document.ariaNotify` is
+            unavailable (Chromium 354736464). */}
+        <AccessibilityAnnouncer />
       </div>
     </div>,
     document.body

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -16,6 +16,7 @@ import type { WorktreeState, WorktreeSnapshot } from "@/types";
 import type { UseAgentLauncherReturn } from "@/hooks/useAgentLauncher";
 import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+import { AccessibilityAnnouncer } from "@/components/Accessibility/AccessibilityAnnouncer";
 import { usePanelStore } from "@/store/panelStore";
 import { isPtyPanel } from "@shared/types/panel";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
@@ -1215,6 +1216,10 @@ export function WorktreeOverviewModal({
           <span>This is irreversible. Type the count to confirm.</span>
         </div>
       </ConfirmDialog>
+      {/* Co-located live region: VoiceOver suppresses announcements made
+          from `aria-live` regions outside the focused `aria-modal` subtree
+          when `document.ariaNotify` is unavailable (Chromium 354736464). */}
+      <AccessibilityAnnouncer />
     </div>
   );
 }

--- a/src/components/ui/AppDialog.tsx
+++ b/src/components/ui/AppDialog.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/lib/dialogEscapeBackstop";
 import { usePortalStore } from "@/store";
 import { useAnimatedPresence } from "@/hooks/useAnimatedPresence";
+import { AccessibilityAnnouncer } from "@/components/Accessibility/AccessibilityAnnouncer";
 import {
   UI_ENTER_DURATION,
   UI_EXIT_DURATION,
@@ -375,6 +376,10 @@ export function AppDialog({
           onClick={(e) => e.stopPropagation()}
         >
           {children}
+          {/* Co-located live region: VoiceOver suppresses announcements made
+              from `aria-live` regions outside the focused `aria-modal` subtree
+              when `document.ariaNotify` is unavailable (Chromium 354736464). */}
+          <AccessibilityAnnouncer />
         </div>
       </div>
     </AppDialogContext.Provider>,

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -12,6 +12,7 @@ import { TABBABLE_SELECTOR } from "@/lib/accessibility";
 import { ScrollShadow } from "@/components/ui/ScrollShadow";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { KbdChord } from "@/components/ui/Kbd";
+import { AccessibilityAnnouncer } from "@/components/Accessibility/AccessibilityAnnouncer";
 import { useOverlayState, useEscapeStack } from "@/hooks";
 import {
   registerDialogEscapeBackstop,
@@ -222,6 +223,10 @@ export function AppPaletteDialog({
         onClick={(e) => e.stopPropagation()}
       >
         {children}
+        {/* Co-located live region: VoiceOver suppresses announcements made
+            from `aria-live` regions outside the focused `aria-modal` subtree
+            when `document.ariaNotify` is unavailable (Chromium 354736464). */}
+        <AccessibilityAnnouncer />
       </div>
     </div>,
     document.body

--- a/src/components/ui/__tests__/AppDialog.test.tsx
+++ b/src/components/ui/__tests__/AppDialog.test.tsx
@@ -765,3 +765,27 @@ describe("AppDialog focus trapping", () => {
     document.body.removeChild(popoverInput);
   });
 });
+
+// VoiceOver suppresses `aria-live` updates outside the focused `aria-modal`
+// subtree (Chromium 354736464). Daintree co-locates a live-region inside
+// AppDialog so the DOM-mutation fallback path survives that bug.
+describe("AppDialog co-located live region", () => {
+  beforeEach(() => {
+    mockPrevOpen = false;
+    _resetForTests();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+  });
+
+  afterEach(() => {
+    _resetForTests();
+  });
+
+  it("renders an aria-live region inside the aria-modal subtree", () => {
+    renderDialog();
+    const modal = screen.getByRole("dialog");
+    expect(modal.getAttribute("aria-modal")).toBe("true");
+    const liveRegions = modal.querySelectorAll("[aria-live]");
+    expect(liveRegions.length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/ui/__tests__/AppPaletteDialog.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteDialog.test.tsx
@@ -198,3 +198,27 @@ describe("AppPaletteDialog focus restore", () => {
     document.body.removeChild(trigger);
   });
 });
+
+// VoiceOver suppresses `aria-live` updates outside the focused `aria-modal`
+// subtree (Chromium 354736464). Daintree co-locates a live-region inside
+// AppPaletteDialog so the DOM-mutation fallback path survives that bug.
+describe("AppPaletteDialog co-located live region", () => {
+  beforeEach(() => {
+    _resetForTests();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+    usePaletteStore.setState({ activePaletteId: null });
+  });
+
+  afterEach(() => {
+    _resetForTests();
+  });
+
+  it("renders an aria-live region inside the aria-modal subtree", () => {
+    renderPalette({ isOpen: true });
+    const dialog = screen.getByRole("dialog", { name: "Test palette" });
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    const liveRegions = dialog.querySelectorAll("[aria-live]");
+    expect(liveRegions.length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/ui/__tests__/SearchablePalette.footer.test.tsx
+++ b/src/components/ui/__tests__/SearchablePalette.footer.test.tsx
@@ -137,10 +137,20 @@ describe("SearchablePalette footer", () => {
 
   it("does not render an aria-live region for the footer", () => {
     renderPalette({
-      getFooter: (item) => (item ? <span>{item.label}</span> : null),
+      getFooter: (item) => (
+        item ? <span data-testid="footer-content">{item.label}</span> : null
+      ),
     });
 
-    expect(document.body.querySelector("[aria-live]")).toBeNull();
+    // Scope the assertion to the footer container — the dialog itself mounts
+    // an AccessibilityAnnouncer with two aria-live sr-only divs (intentional;
+    // VoiceOver suppresses aria-live outside the focused aria-modal subtree).
+    const footerContent = document.body.querySelector(
+      "[data-testid='footer-content']"
+    );
+    const footerContainer = footerContent?.parentElement;
+    expect(footerContainer).not.toBeNull();
+    expect(footerContainer?.querySelector("[aria-live]")).toBeNull();
   });
 
   it("getActionLabel composes a custom verb into the default footer hint", () => {

--- a/src/store/accessibilityAnnouncerStore.ts
+++ b/src/store/accessibilityAnnouncerStore.ts
@@ -12,6 +12,25 @@ interface AnnouncerState {
   announce: (msg: string, priority?: "polite" | "assertive") => void;
 }
 
+// Module-scoped record of the latest delivered entry id per channel.
+// Lets co-located `AccessibilityAnnouncer` instances coordinate so a
+// modal that mounts after an announcement was already delivered doesn't
+// replay the stale entry into its newly focused subtree.
+const deliveredIds: { polite: number; assertive: number } = { polite: 0, assertive: 0 };
+
+export function isDelivered(channel: "polite" | "assertive", id: number): boolean {
+  return deliveredIds[channel] >= id;
+}
+
+export function markDelivered(channel: "polite" | "assertive", id: number): void {
+  if (id > deliveredIds[channel]) deliveredIds[channel] = id;
+}
+
+export function _resetAnnouncerDeliveryForTests(): void {
+  deliveredIds.polite = 0;
+  deliveredIds.assertive = 0;
+}
+
 // VoiceOver on macOS ignores `aria-live` updates outside the focused
 // `aria-modal="true"` dialog's DOM subtree (Chromium 354736464). The
 // native `document.ariaNotify` API (Chrome 141+ / Chromium 146) queues
@@ -24,7 +43,7 @@ function tryAriaNotify(msg: string, priority: "polite" | "assertive"): boolean {
   if (typeof notify !== "function") return false;
   try {
     notify.call(document, msg, {
-      priority: priority === "assertive" ? "important" : "normal",
+      priority: priority === "assertive" ? "high" : "normal",
     });
     return true;
   } catch {

--- a/src/store/accessibilityAnnouncerStore.ts
+++ b/src/store/accessibilityAnnouncerStore.ts
@@ -12,11 +12,32 @@ interface AnnouncerState {
   announce: (msg: string, priority?: "polite" | "assertive") => void;
 }
 
+// VoiceOver on macOS ignores `aria-live` updates outside the focused
+// `aria-modal="true"` dialog's DOM subtree (Chromium 354736464). The
+// native `document.ariaNotify` API (Chrome 141+ / Chromium 146) queues
+// announcements directly with the platform AT, bypassing the subtree
+// filter entirely. Feature-detect at call time so test/SSR contexts
+// without a document object still work.
+function tryAriaNotify(msg: string, priority: "polite" | "assertive"): boolean {
+  if (typeof document === "undefined") return false;
+  const notify = document.ariaNotify;
+  if (typeof notify !== "function") return false;
+  try {
+    notify.call(document, msg, {
+      priority: priority === "assertive" ? "important" : "normal",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export const useAnnouncerStore = create<AnnouncerState>((set) => ({
   polite: null,
   assertive: null,
   nextId: 1,
   announce: (msg, priority = "polite") => {
+    if (tryAriaNotify(msg, priority)) return;
     set((state) => {
       const id = state.nextId;
       if (priority === "assertive") {

--- a/src/types/aria-notify.d.ts
+++ b/src/types/aria-notify.d.ts
@@ -1,0 +1,15 @@
+// ariaNotify is a Chromium-only API (shipped in Chrome 141; available in
+// Chromium 146 / Electron 41) that queues screen-reader announcements
+// natively, bypassing the `aria-modal` subtree filter that suppresses
+// out-of-modal `aria-live` regions on VoiceOver (Chromium issue 354736464).
+// Declared optional so all call sites must feature-detect.
+
+type AriaNotifyPriority = "normal" | "important";
+
+interface AriaNotifyOptions {
+  priority?: AriaNotifyPriority;
+}
+
+interface Document {
+  ariaNotify?(message: string, options?: AriaNotifyOptions): void;
+}

--- a/src/types/aria-notify.d.ts
+++ b/src/types/aria-notify.d.ts
@@ -4,7 +4,7 @@
 // out-of-modal `aria-live` regions on VoiceOver (Chromium issue 354736464).
 // Declared optional so all call sites must feature-detect.
 
-type AriaNotifyPriority = "normal" | "important";
+type AriaNotifyPriority = "normal" | "high";
 
 interface AriaNotifyOptions {
   priority?: AriaNotifyPriority;


### PR DESCRIPTION
## Summary

VoiceOver on macOS suppresses \`aria-live\` updates outside the focused \`aria-modal\` dialog's DOM subtree ([Chromium 354736464](https://issues.chromium.org/issues/354736464)). Daintree's \`AccessibilityAnnouncer\` mounts at the App root, so any \`announce()\` call fired while a modal is open is silently dropped — affecting form errors, save confirmations, and any inline status that follows a modal interaction.

This change ships a dual-layer fix:

- **Primary**: Call \`document.ariaNotify(msg, { priority })\` from the announcer store when available. This native API (Chrome 141+ / Chromium 146 / Electron 41, per [WAI-ARIA 1.3](https://www.w3.org/TR/wai-aria-1.3/)) queues announcements directly with the platform AT, bypassing the \`aria-modal\` subtree filter entirely. Maps \`polite\` → \`{ priority: \"normal\" }\`, \`assertive\` → \`{ priority: \"high\" }\`.
- **Fallback**: Co-locate \`<AccessibilityAnnouncer />\` inside every \`aria-modal\` wrapper (\`AppDialog\`, \`AppPaletteDialog\`, \`ErrorFallback\` fullscreen variant, \`WorktreeOverviewModal\`, \`ProjectSwitcherPalette\`, \`ReviewHub\`). The DOM-mutation path still reaches the AT when \`ariaNotify\` is unavailable.

A module-scoped \`deliveredIds\` map suppresses stale-replay: when a modal mounts after an announcement was already delivered by another instance, the modal's co-located announcer skips the stale entry instead of re-narrating it inside the newly focused subtree.

The existing five \`close-before-announce\` call sites (\`WaitingContainer\`, \`BackgroundContainer\`, \`TerminalDestructiveActionConfirmDialog\`, \`TerminalContextMenu\`, \`useWorktreeActions\`) are left untouched — they're correct for terminal-action cases where the modal naturally closes and the announcement serves as the \"done\" signal.

## Test plan

- [x] All 49 existing \`AccessibilityAnnouncer\` tests still pass
- [x] New tests: \`ariaNotify\` priority mapping (polite → normal, assertive → high), default priority, store-not-mutated when ariaNotify succeeds, fallback to DOM mutation when ariaNotify throws, stale-replay guard when a second announcer mounts after delivery
- [x] New tests: \`AppDialog\` and \`AppPaletteDialog\` contain an \`[aria-live]\` descendant inside the \`aria-modal\` subtree
- [x] \`npm run check\` (typecheck + lint + format) clean
- [ ] Manual VoiceOver verification: open AppDialog → trigger announcement → VoiceOver speaks it (Chromium 146 ariaNotify path)
- [ ] Manual VoiceOver verification: ProjectSwitcherPalette → fire an announce → VoiceOver speaks it (covers the palette that bypasses AppPaletteDialog)