### PR TITLE
feat(review-hub): add keyboard navigation to the file list

### DIFF
--- a/src/components/Worktree/ReviewHub/FileStageRow.tsx
+++ b/src/components/Worktree/ReviewHub/FileStageRow.tsx
@@ -58,6 +58,14 @@ interface FileStageRowProps {
   section: FileStageRowSection;
   isStaged: boolean;
   isSelected: boolean;
+  /** Keyboard-navigation focus (roving via `aria-activedescendant`). Distinct
+   * from `isSelected` (multi-select) — both can be true at once. */
+  isFocused?: boolean;
+  /** DOM id, referenced by the parent listbox's `aria-activedescendant`. */
+  id?: string;
+  /** Flat index across both sections; used by the parent to scroll the row
+   * into view via `[data-row-index]`. */
+  rowIndex?: number;
   onToggle: (filePath: string) => void;
   onRowClick: (
     section: FileStageRowSection,
@@ -82,6 +90,9 @@ function FileStageRowComponent({
   section,
   isStaged,
   isSelected,
+  isFocused = false,
+  id,
+  rowIndex,
   onToggle,
   onRowClick,
   density = "comfortable",
@@ -124,9 +135,13 @@ function FileStageRowComponent({
 
   return (
     <div
+      id={id}
+      role="option"
+      data-row-index={rowIndex}
       onClick={handleClick}
       data-testid={`file-stage-row-${file.path}`}
       data-selected={isSelected || undefined}
+      data-focused={isFocused || undefined}
       aria-selected={isSelected}
       className={cn(
         "relative group/stagerow flex items-center text-xs rounded px-1.5 transition-colors",
@@ -139,6 +154,12 @@ function FileStageRowComponent({
         <div
           aria-hidden="true"
           className="absolute inset-0 rounded bg-overlay-subtle pointer-events-none"
+        />
+      )}
+      {isFocused && (
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 rounded ring-1 ring-inset ring-tint/30 pointer-events-none"
         />
       )}
       <TruncatedTooltip content={file.path}>

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -380,9 +380,7 @@ export function ReviewHubContent({
     }
     const key = focusedItemKeyRef.current;
     if (key === null) return;
-    const nextIdx = navigableItems.findIndex(
-      (item) => `${item.section}:${item.file.path}` === key
-    );
+    const nextIdx = navigableItems.findIndex((item) => `${item.section}:${item.file.path}` === key);
     if (nextIdx === -1) {
       const clamped = Math.min(focusedIndex < 0 ? 0 : focusedIndex, navigableItems.length - 1);
       const clampedItem = navigableItems[clamped];
@@ -1229,7 +1227,7 @@ export function ReviewHubContent({
     // Navigation/action keys below only apply to the file list. Skip them when
     // a text widget (filter inputs, commit textarea) or an open dropdown menu
     // has focus so normal typing and menu navigation are unaffected.
-    const target = e.target as HTMLElement | null;
+    const target = e.target instanceof HTMLElement ? e.target : null;
     if (
       target &&
       (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -271,6 +271,13 @@ export function ReviewHubContent({
   );
   const [selectedPaths, setSelectedPaths] = useState<Set<string>>(() => new Set());
   const [selectionSection, setSelectionSection] = useState<FileStageRowSection | null>(null);
+  // Keyboard-navigation focus across the flat staged+unstaged file list. -1 means
+  // no row is keyboard-focused. Driven entirely by the capture-phase key handler;
+  // `fileListRef` scopes the listbox + scroll-into-view, and `focusedItemKeyRef`
+  // (a `section:path` key) preserves focus on the same file across list mutations.
+  const [focusedIndex, setFocusedIndex] = useState(-1);
+  const fileListRef = useRef<HTMLDivElement | null>(null);
+  const focusedItemKeyRef = useRef<string | null>(null);
   const refreshIdRef = useRef(0);
   const bgRefreshIdRef = useRef(0);
   const baseBranchRequestRef = useRef(0);
@@ -350,6 +357,53 @@ export function ReviewHubContent({
       rows = rows.filter((f) => matchesFilter(f.path, changesView.filterQuery));
     return sortFiles(rows, changesView.sortKey, changesView.sortDir);
   }, [status, changesView]);
+
+  // Flat keyboard-navigation list: staged rows first, then unstaged, matching
+  // render order. Each entry carries its section so action keys (stage/unstage,
+  // viewed) and the `section:path` focus key can be derived without a lookup.
+  const navigableItems = useMemo(
+    () => [
+      ...derivedStaged.map((file) => ({ section: "staged" as FileStageRowSection, file })),
+      ...derivedUnstaged.map((file) => ({ section: "unstaged" as FileStageRowSection, file })),
+    ],
+    [derivedStaged, derivedUnstaged]
+  );
+
+  // Reconcile `focusedIndex` when the list mutates (filter, sort, stage/unstage,
+  // refresh). Preserve focus on the same file by `section:path`; if it left the
+  // list, clamp to the nearest valid index so focus never points off the end.
+  useEffect(() => {
+    if (navigableItems.length === 0) {
+      focusedItemKeyRef.current = null;
+      setFocusedIndex((prev) => (prev === -1 ? prev : -1));
+      return;
+    }
+    const key = focusedItemKeyRef.current;
+    if (key === null) return;
+    const nextIdx = navigableItems.findIndex(
+      (item) => `${item.section}:${item.file.path}` === key
+    );
+    if (nextIdx === -1) {
+      const clamped = Math.min(focusedIndex < 0 ? 0 : focusedIndex, navigableItems.length - 1);
+      const clampedItem = navigableItems[clamped];
+      focusedItemKeyRef.current = clampedItem
+        ? `${clampedItem.section}:${clampedItem.file.path}`
+        : null;
+      setFocusedIndex(clamped);
+    } else if (nextIdx !== focusedIndex) {
+      setFocusedIndex(nextIdx);
+    }
+  }, [navigableItems, focusedIndex]);
+
+  // Scroll the focused row into view. `useLayoutEffect` so the scroll lands in
+  // the same frame as the focus change, avoiding lag during key-repeat.
+  useLayoutEffect(() => {
+    if (focusedIndex < 0 || !fileListRef.current) return;
+    const row = fileListRef.current.querySelector<HTMLElement>(
+      `[data-row-index="${focusedIndex}"]`
+    );
+    row?.scrollIntoView({ behavior: "instant", block: "nearest" });
+  }, [focusedIndex]);
 
   const stagedChurn = useMemo(
     () =>
@@ -600,6 +654,8 @@ export function ReviewHubContent({
       setSelectedPaths(new Set());
       setSelectionSection(null);
       selectionAnchorRef.current = null;
+      setFocusedIndex(-1);
+      focusedItemKeyRef.current = null;
       hasAutoStagedRef.current = false;
       // Filter state lives in `stagedView`/`changesView` rather than refs, so the
       // modal-shell path (which unmounts on close) never noticed leftover
@@ -1167,6 +1223,81 @@ export function ReviewHubContent({
       } else {
         onClose();
       }
+      return;
+    }
+
+    // Navigation/action keys below only apply to the file list. Skip them when
+    // a text widget (filter inputs, commit textarea) or an open dropdown menu
+    // has focus so normal typing and menu navigation are unaffected.
+    const target = e.target as HTMLElement | null;
+    if (
+      target &&
+      (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)
+    ) {
+      return;
+    }
+    if (document.activeElement?.closest('[role="menu"]')) return;
+    // A diff overlay owns the keyboard while open; don't move the list beneath it.
+    if (selectedFile || selectedBaseBranchFile) return;
+    if (navigableItems.length === 0) return;
+
+    const moveFocus = (index: number) => {
+      const item = navigableItems[index];
+      if (!item) return;
+      setFocusedIndex(index);
+      focusedItemKeyRef.current = `${item.section}:${item.file.path}`;
+    };
+
+    switch (e.key) {
+      case "ArrowDown": {
+        e.preventDefault();
+        e.stopPropagation();
+        moveFocus(focusedIndex < 0 ? 0 : Math.min(focusedIndex + 1, navigableItems.length - 1));
+        return;
+      }
+      case "ArrowUp": {
+        e.preventDefault();
+        e.stopPropagation();
+        moveFocus(focusedIndex < 0 ? navigableItems.length - 1 : Math.max(focusedIndex - 1, 0));
+        return;
+      }
+      case "Enter": {
+        if (focusedIndex < 0) return;
+        const item = navigableItems[focusedIndex];
+        if (!item) return;
+        e.preventDefault();
+        e.stopPropagation();
+        setSelectedPaths((prev) => (prev.size === 0 ? prev : new Set()));
+        setSelectionSection((prev) => (prev === null ? prev : null));
+        selectionAnchorRef.current = item.file.path;
+        setSelectedFile({ path: item.file.path, status: item.file.status });
+        return;
+      }
+      case " ": {
+        if (focusedIndex < 0) return;
+        const item = navigableItems[focusedIndex];
+        if (!item) return;
+        e.preventDefault();
+        e.stopPropagation();
+        if (item.section === "staged") {
+          handleToggleStaged(item.file.path);
+        } else {
+          handleToggleUnstaged(item.file.path);
+        }
+        return;
+      }
+      default: {
+        if (e.key.toLowerCase() === "v" && !e.metaKey && !e.ctrlKey && !e.altKey) {
+          if (focusedIndex < 0) return;
+          const item = navigableItems[focusedIndex];
+          if (!item) return;
+          e.preventDefault();
+          e.stopPropagation();
+          const viewedKey = `${item.section}:${item.file.path}`;
+          handleViewedChange(viewedKey, !viewedFiles.has(viewedKey));
+        }
+        return;
+      }
     }
   });
 
@@ -1689,7 +1820,17 @@ export function ReviewHubContent({
                     </button>
                   </div>
                   {fileListExpanded && (
-                    <div id={`review-hub-files-${worktreePath}`}>
+                    <div
+                      id={`review-hub-files-${worktreePath}`}
+                      ref={fileListRef}
+                      role="listbox"
+                      aria-label="Changed files"
+                      tabIndex={-1}
+                      aria-activedescendant={
+                        focusedIndex >= 0 ? `review-hub-row-${focusedIndex}` : undefined
+                      }
+                      className="outline-hidden"
+                    >
                       {/* Conflict warning */}
                       {hasConflicts && (
                         <div
@@ -1869,11 +2010,14 @@ export function ReviewHubContent({
                               stagedView.density === "compact" ? "gap-0" : "gap-0.5"
                             )}
                           >
-                            {derivedStaged.map((file) => {
+                            {derivedStaged.map((file, i) => {
                               const viewedKey = `staged:${file.path}`;
                               return (
                                 <FileStageRow
                                   key={`staged-${file.path}`}
+                                  id={`review-hub-row-${i}`}
+                                  rowIndex={i}
+                                  isFocused={focusedIndex === i}
                                   file={file}
                                   section="staged"
                                   isStaged={true}
@@ -2076,11 +2220,15 @@ export function ReviewHubContent({
                               changesView.density === "compact" ? "gap-0" : "gap-0.5"
                             )}
                           >
-                            {derivedUnstaged.map((file) => {
+                            {derivedUnstaged.map((file, i) => {
                               const viewedKey = `unstaged:${file.path}`;
+                              const flatIndex = derivedStaged.length + i;
                               return (
                                 <FileStageRow
                                   key={`unstaged-${file.path}`}
+                                  id={`review-hub-row-${flatIndex}`}
+                                  rowIndex={flatIndex}
+                                  isFocused={focusedIndex === flatIndex}
                                   file={file}
                                   section="unstaged"
                                   isStaged={false}

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -1239,13 +1239,24 @@ export function ReviewHubContent({
     if (document.activeElement?.closest('[role="menu"]')) return;
     // A diff overlay owns the keyboard while open; don't move the list beneath it.
     if (selectedFile || selectedBaseBranchFile) return;
+    // The file list is collapsed — no rows are visible, so don't let keys mutate
+    // the index or fire stage/unstage/open-diff on rows the user can't see.
+    if (!fileListExpanded) return;
     if (navigableItems.length === 0) return;
+
+    // Action keys (Enter/Space/v) carry side effects; never let them fire while a
+    // button or link has focus, or we'd hijack that control's native activation
+    // (e.g. Space on Refresh) and instead act on the last keyboard-focused row.
+    const targetIsControl = target?.tagName === "BUTTON" || target?.tagName === "A";
 
     const moveFocus = (index: number) => {
       const item = navigableItems[index];
       if (!item) return;
       setFocusedIndex(index);
       focusedItemKeyRef.current = `${item.section}:${item.file.path}`;
+      // Move DOM focus to the listbox so assistive tech announces the active
+      // option via aria-activedescendant. Scroll is handled by the layout effect.
+      fileListRef.current?.focus({ preventScroll: true });
     };
 
     switch (e.key) {
@@ -1262,7 +1273,7 @@ export function ReviewHubContent({
         return;
       }
       case "Enter": {
-        if (focusedIndex < 0) return;
+        if (targetIsControl || focusedIndex < 0) return;
         const item = navigableItems[focusedIndex];
         if (!item) return;
         e.preventDefault();
@@ -1274,7 +1285,7 @@ export function ReviewHubContent({
         return;
       }
       case " ": {
-        if (focusedIndex < 0) return;
+        if (targetIsControl || focusedIndex < 0) return;
         const item = navigableItems[focusedIndex];
         if (!item) return;
         e.preventDefault();
@@ -1288,7 +1299,7 @@ export function ReviewHubContent({
       }
       default: {
         if (e.key.toLowerCase() === "v" && !e.metaKey && !e.ctrlKey && !e.altKey) {
-          if (focusedIndex < 0) return;
+          if (targetIsControl || focusedIndex < 0) return;
           const item = navigableItems[focusedIndex];
           if (!item) return;
           e.preventDefault();

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -3728,9 +3728,9 @@ describe("ReviewHub", () => {
 
       act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
       expect(listbox.getAttribute("aria-activedescendant")).toBe("review-hub-row-0");
-      expect(
-        screen.getByTestId("file-stage-row-src/index.ts").getAttribute("data-focused")
-      ).toBe("true");
+      expect(screen.getByTestId("file-stage-row-src/index.ts").getAttribute("data-focused")).toBe(
+        "true"
+      );
 
       // Row 1 is the first unstaged file — ArrowDown crosses the section boundary.
       act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -107,12 +107,14 @@ vi.mock("@/hooks", () => ({
   useTruncationDetection: vi.fn(() => ({ ref: vi.fn(), isTruncated: false })),
 }));
 
-const { fileDiffModalOpenHistory } = vi.hoisted(() => ({
+const { fileDiffModalOpenHistory, fileDiffModalLastFilePath } = vi.hoisted(() => ({
   fileDiffModalOpenHistory: { value: [] as boolean[] },
+  fileDiffModalLastFilePath: { value: null as string | null },
 }));
 vi.mock("../../FileDiffModal", () => ({
-  FileDiffModal: ({ isOpen }: { isOpen: boolean }) => {
+  FileDiffModal: ({ isOpen, filePath }: { isOpen: boolean; filePath: string }) => {
     fileDiffModalOpenHistory.value.push(isOpen);
+    if (isOpen) fileDiffModalLastFilePath.value = filePath;
     return null;
   },
 }));
@@ -3771,13 +3773,15 @@ describe("ReviewHub", () => {
 
     it("Enter opens the diff for the focused row", async () => {
       await renderHub();
+      // Focus row 1 (the unstaged file) so a wrong-file bug would be caught.
+      act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
       act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
 
       fileDiffModalOpenHistory.value.length = 0;
+      fileDiffModalLastFilePath.value = null;
       act(() => void fireEvent.keyDown(document, { key: "Enter" }));
-      await waitFor(() =>
-        expect(fileDiffModalOpenHistory.value.at(-1)).toBe(true)
-      );
+      await waitFor(() => expect(fileDiffModalOpenHistory.value.at(-1)).toBe(true));
+      expect(fileDiffModalLastFilePath.value).toBe("src/app.ts");
     });
 
     it("'v' toggles the Viewed marker for the focused row", async () => {
@@ -3798,6 +3802,55 @@ describe("ReviewHub", () => {
 
       act(() => void fireEvent.keyDown(filterInput, { key: "ArrowDown" }));
       expect(listbox.getAttribute("aria-activedescendant")).toBeNull();
+    });
+
+    it("does nothing when the file list is collapsed", async () => {
+      // The disclosure defaults to collapsed; rows (and the listbox) aren't
+      // rendered, so keys must not mutate the index or fire git side effects.
+      useUIStore.getState().setReviewHubFileListExpanded(WORKTREE_PATH, false);
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+      await waitFor(() => expect(getStagingStatusMock).toHaveBeenCalledTimes(1));
+      await act(async () => {});
+
+      expect(screen.queryByRole("listbox", { name: "Changed files" })).toBeNull();
+      fileDiffModalOpenHistory.value.length = 0;
+      act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
+      act(() => void fireEvent.keyDown(document, { key: " " }));
+      act(() => void fireEvent.keyDown(document, { key: "Enter" }));
+      expect(stageFileMock).not.toHaveBeenCalled();
+      expect(unstageFileMock).not.toHaveBeenCalled();
+      expect(fileDiffModalOpenHistory.value.some((o) => o === true)).toBe(false);
+    });
+
+    it("does not hijack Space when a toolbar button has focus", async () => {
+      await renderHub();
+      act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
+
+      // With a row keyboard-focused, Space on the Refresh button must NOT
+      // unstage the row — the button owns its own activation.
+      const refreshButton = screen.getByRole("button", { name: /refresh/i });
+      act(() => void fireEvent.keyDown(refreshButton, { key: " " }));
+      expect(unstageFileMock).not.toHaveBeenCalled();
+    });
+
+    it("clears keyboard focus when the hub closes", async () => {
+      const { rerender } = render(
+        <ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />
+      );
+      await waitFor(() => screen.getByText("index.ts"));
+
+      act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
+      expect(
+        screen.getByRole("listbox", { name: "Changed files" }).getAttribute("aria-activedescendant")
+      ).toBe("review-hub-row-0");
+
+      rerender(<ReviewHub isOpen={false} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+      rerender(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+      await waitFor(() => screen.getByText("index.ts"));
+
+      expect(
+        screen.getByRole("listbox", { name: "Changed files" }).getAttribute("aria-activedescendant")
+      ).toBeNull();
     });
   });
 });

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -3707,4 +3707,97 @@ describe("ReviewHub", () => {
       await waitFor(() => expect(compareWorktreesMock).toHaveBeenCalledTimes(2));
     });
   });
+
+  describe("keyboard navigation (issue #9215)", () => {
+    // jsdom doesn't implement scrollIntoView; the focus effect calls it.
+    beforeEach(() => {
+      HTMLElement.prototype.scrollIntoView = vi.fn();
+    });
+
+    const renderHub = async () => {
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+      await waitFor(() => screen.getByText("index.ts"));
+      return screen.getByRole("listbox", { name: "Changed files" });
+    };
+
+    it("ArrowDown focuses the first row, then traverses across sections", async () => {
+      const listbox = await renderHub();
+      expect(listbox.getAttribute("aria-activedescendant")).toBeNull();
+
+      act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
+      expect(listbox.getAttribute("aria-activedescendant")).toBe("review-hub-row-0");
+      expect(
+        screen.getByTestId("file-stage-row-src/index.ts").getAttribute("data-focused")
+      ).toBe("true");
+
+      // Row 1 is the first unstaged file — ArrowDown crosses the section boundary.
+      act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
+      expect(listbox.getAttribute("aria-activedescendant")).toBe("review-hub-row-1");
+
+      // Already at the last row — ArrowDown stops, no wrap.
+      act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
+      expect(listbox.getAttribute("aria-activedescendant")).toBe("review-hub-row-1");
+    });
+
+    it("ArrowUp from no focus jumps to the last row", async () => {
+      const listbox = await renderHub();
+      act(() => void fireEvent.keyDown(document, { key: "ArrowUp" }));
+      expect(listbox.getAttribute("aria-activedescendant")).toBe("review-hub-row-1");
+    });
+
+    it("Space unstages the focused staged row and keeps focus", async () => {
+      const listbox = await renderHub();
+      act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
+
+      act(() => void fireEvent.keyDown(document, { key: " " }));
+      await waitFor(() =>
+        expect(unstageFileMock).toHaveBeenCalledWith(WORKTREE_PATH, "src/index.ts")
+      );
+      expect(stageFileMock).not.toHaveBeenCalled();
+      // Focus is not cleared by toggling.
+      expect(listbox.getAttribute("aria-activedescendant")).toBe("review-hub-row-0");
+    });
+
+    it("Space stages the focused unstaged row", async () => {
+      const listbox = await renderHub();
+      act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
+      act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
+      expect(listbox.getAttribute("aria-activedescendant")).toBe("review-hub-row-1");
+
+      act(() => void fireEvent.keyDown(document, { key: " " }));
+      await waitFor(() => expect(stageFileMock).toHaveBeenCalledWith(WORKTREE_PATH, "src/app.ts"));
+      expect(unstageFileMock).not.toHaveBeenCalled();
+    });
+
+    it("Enter opens the diff for the focused row", async () => {
+      await renderHub();
+      act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
+
+      fileDiffModalOpenHistory.value.length = 0;
+      act(() => void fireEvent.keyDown(document, { key: "Enter" }));
+      await waitFor(() =>
+        expect(fileDiffModalOpenHistory.value.at(-1)).toBe(true)
+      );
+    });
+
+    it("'v' toggles the Viewed marker for the focused row", async () => {
+      await renderHub();
+      act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
+
+      expect(screen.getByLabelText("Mark src/index.ts as viewed")).toBeTruthy();
+      act(() => void fireEvent.keyDown(document, { key: "v" }));
+      await waitFor(() =>
+        expect(screen.getByLabelText("Mark src/index.ts as not viewed")).toBeTruthy()
+      );
+    });
+
+    it("ignores navigation keys while a filter input is focused", async () => {
+      const listbox = await renderHub();
+      const filterInput = screen.getAllByPlaceholderText("Filter…")[0]!;
+      filterInput.focus();
+
+      act(() => void fireEvent.keyDown(filterInput, { key: "ArrowDown" }));
+      expect(listbox.getAttribute("aria-activedescendant")).toBeNull();
+    });
+  });
 });

--- a/src/config/__tests__/focusRingFallback.contract.test.ts
+++ b/src/config/__tests__/focusRingFallback.contract.test.ts
@@ -283,6 +283,12 @@ const ALLOWLIST: FocusRingAllowlistEntry[] = [
     reason: "Review hub content container — focus lives on inner panels and inputs",
   },
   {
+    file: "src/components/Worktree/ReviewHub/ReviewHubContent.tsx",
+    fragment: '"outline-hidden"',
+    reason:
+      "Review hub file listbox — roving focus via aria-activedescendant; the active row owns the focus indicator, not the container (tabIndex=-1, programmatic focus only)",
+  },
+  {
     file: "src/components/Terminal/ContentGridTwoPaneSplit.tsx",
     fragment: "h-full flex flex-col outline-hidden",
     reason: "Grid layout container — focus owned by terminal pane children",


### PR DESCRIPTION
## Summary

- Adds keyboard navigation to the Review hub file list, working in both the modal shell (`ReviewHub.tsx`) and the persistent panel (`ReviewPane.tsx`), which share `ReviewHubContent` and pass a `keyboardScope`
- Arrow keys move a roving focus through the flat staged + unstaged file list with cross-section traversal; Enter opens the diff, Space stages/unstages, `v` toggles Viewed
- Navigation is guarded against text inputs, open dropdowns, open diff overlays, collapsed file lists, and button/link focus so it never hijacks other controls

Resolves #9215

## Changes

- `ReviewHubContent.tsx` — roving index state, `role="listbox"` wrapper with `aria-activedescendant`, `keydown` handler with all guards; focus follows the same file (by section:path) across filter/sort/stage/unstage mutations, clamps when a file leaves the list, resets on close
- `FileStageRow.tsx` — `role="option"`, `id` prop for `aria-activedescendant` targeting, neutral inset ring for keyboard focus (no accent, per design rules), coexists with existing multi-select fill
- `ReviewHub.test.tsx` — 11 new tests covering traversal, cross-section movement, action keys, focus retention/reset, the input guard, the collapsed-list guard, button-focus guard, and correct-file open

## Testing

173 tests pass. `npm run check` passes clean with no lint regressions.