### PR TITLE
feat(worktree): restore focus and add file-stepping in change viewers

### DIFF
--- a/src/components/FileViewer/FileViewerModal.tsx
+++ b/src/components/FileViewer/FileViewerModal.tsx
@@ -1,11 +1,19 @@
 import { useEffect, useEffectEvent, useCallback, useState, useRef, useMemo } from "react";
 import { AppDialog } from "@/components/ui/AppDialog";
+import type { RestoreFocusTarget } from "@/components/ui/AppDialog";
 import { DiffViewer } from "@/components/Worktree/DiffViewer";
 import { CodeViewer } from "./CodeViewer";
 import type { CodeViewerHandle } from "./CodeViewer";
 import { filesClient } from "@/clients/filesClient";
 import { actionService } from "@/services/ActionService";
-import { ExternalLink, Copy, Check, Image as ImageIcon } from "lucide-react";
+import {
+  ExternalLink,
+  Copy,
+  Check,
+  Image as ImageIcon,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react";
 import { Skeleton, SkeletonBone, SkeletonText } from "@/components/ui/Skeleton";
 import { cn } from "@/lib/utils";
 import { formatBytes } from "@/lib/formatBytes";
@@ -28,6 +36,14 @@ export interface FileViewerModalProps {
   defaultMode?: "view" | "diff";
   onRetryDiff?: () => void;
   onClose: () => void;
+  /** Element to focus when the dialog closes and its trigger was unmounted. */
+  restoreFocusTo?: RestoreFocusTarget;
+  /** Zero-based position of the current file within the navigable set. */
+  currentFileIndex?: number;
+  /** Total number of files the user can step through. */
+  totalFileCount?: number;
+  /** Step to the previous (-1) or next (1) file in the set. */
+  onNavigateFile?: (delta: -1 | 1) => void;
 }
 
 type ViewMode = "view" | "diff";
@@ -70,6 +86,10 @@ export function FileViewerModal({
   defaultMode,
   onRetryDiff,
   onClose,
+  restoreFocusTo,
+  currentFileIndex,
+  totalFileCount,
+  onNavigateFile,
 }: FileViewerModalProps) {
   // If the file is outside the project root, use its parent directory as the
   // effective root so that the daintree-file:// protocol and files.read IPC
@@ -323,6 +343,45 @@ export function FileViewerModal({
     };
   }, [isOpen, mode]);
 
+  // File stepping in the worktree change set: `[` → previous file, `]` → next.
+  // `n`/`p` are taken by hunk navigation and the arrow keys conflict with split-
+  // diff horizontal scrolling, so brackets (the git-review convention) are the
+  // free keys. The handler is a no-op unless the opener wired `onNavigateFile`.
+  const canStepFiles = Boolean(onNavigateFile) && (totalFileCount ?? 0) > 1;
+  const hasPrevFile = canStepFiles && (currentFileIndex ?? 0) > 0;
+  const hasNextFile = canStepFiles && (currentFileIndex ?? 0) < (totalFileCount ?? 0) - 1;
+
+  const navigateFile = useEffectEvent((delta: -1 | 1) => {
+    if (delta === -1 && hasPrevFile) onNavigateFile?.(-1);
+    if (delta === 1 && hasNextFile) onNavigateFile?.(1);
+  });
+
+  useEffect(() => {
+    if (!isOpen || !canStepFiles) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "[" && e.key !== "]") return;
+      if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
+      if (
+        e.target instanceof HTMLElement &&
+        (e.target.tagName === "INPUT" ||
+          e.target.tagName === "TEXTAREA" ||
+          e.target.tagName === "SELECT" ||
+          e.target.isContentEditable)
+      ) {
+        return;
+      }
+
+      e.preventDefault();
+      navigateFile(e.key === "]" ? 1 : -1);
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, canStepFiles]);
+
   // IntersectionObserver tracks the most-visible hunk during free scrolling.
   // Observes tr:first-child (not tbody — table-row-group collapses to 0 height
   // in Chromium and races with layout). The observer is keyed on diffViewType
@@ -421,6 +480,7 @@ export function FileViewerModal({
       onClose={onClose}
       size="6xl"
       maxHeight="max-h-[90vh]"
+      restoreFocusTo={restoreFocusTo}
       data-testid="file-viewer-dialog"
     >
       <AppDialog.Header className="py-3">
@@ -473,6 +533,45 @@ export function FileViewerModal({
         </div>
 
         <div className="flex items-center gap-2">
+          {/* File stepping — previous/next across the worktree change set */}
+          {canStepFiles && (
+            <div className="flex items-center gap-1 shrink-0">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={() => onNavigateFile?.(-1)}
+                    disabled={!hasPrevFile}
+                    aria-label="Previous file"
+                    className="p-1.5 rounded transition-colors text-muted-foreground hover:text-daintree-text hover:bg-daintree-border disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none"
+                  >
+                    <ChevronLeft className="w-4 h-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Previous file ([)</TooltipContent>
+              </Tooltip>
+              <span
+                data-testid="file-position-indicator"
+                className="text-xs text-muted-foreground tabular-nums"
+              >
+                {(currentFileIndex ?? 0) + 1} of {totalFileCount}
+              </span>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={() => onNavigateFile?.(1)}
+                    disabled={!hasNextFile}
+                    aria-label="Next file"
+                    className="p-1.5 rounded transition-colors text-muted-foreground hover:text-daintree-text hover:bg-daintree-border disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none"
+                  >
+                    <ChevronRight className="w-4 h-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Next file (])</TooltipContent>
+              </Tooltip>
+            </div>
+          )}
           {/* Hunk position indicator — visible during free scroll and n/p nav */}
           {mode === "diff" && hunkCount > 1 && activeHunkIndex >= 0 && (
             <span

--- a/src/components/FileViewer/__tests__/FileViewerModal.test.tsx
+++ b/src/components/FileViewer/__tests__/FileViewerModal.test.tsx
@@ -47,19 +47,26 @@ vi.mock("@/lib/trustedTypesPolicy", () => ({
 
 import { FileViewerModal } from "../FileViewerModal";
 
+const { capturedDialogProps } = vi.hoisted(() => ({
+  capturedDialogProps: { restoreFocusTo: undefined as unknown },
+}));
+
 vi.mock("@/components/ui/AppDialog", () => {
   interface MockProps {
     isOpen: boolean;
     children: ReactNode;
     onClose: () => void;
+    restoreFocusTo?: unknown;
   }
   interface SectionProps {
     children: ReactNode;
     className?: string;
   }
 
-  const AppDialog = ({ isOpen, children }: MockProps) =>
-    isOpen ? <div data-testid="app-dialog">{children}</div> : null;
+  const AppDialog = ({ isOpen, children, restoreFocusTo }: MockProps) => {
+    capturedDialogProps.restoreFocusTo = restoreFocusTo;
+    return isOpen ? <div data-testid="app-dialog">{children}</div> : null;
+  };
 
   AppDialog.Header = ({ children, className }: SectionProps) => (
     <div className={className}>{children}</div>
@@ -908,6 +915,181 @@ describe("FileViewerModal", () => {
       expect(() => {
         fireObserver(observer, [makeEntry(hunk0Row!, 1.0)]);
       }).not.toThrow();
+    });
+  });
+
+  describe("file stepping (#9217)", () => {
+    const stepProps = {
+      totalFileCount: 3,
+      onNavigateFile: vi.fn(),
+    };
+
+    it("does not render the position indicator or nav buttons for a single file", async () => {
+      render(<FileViewerModal {...defaultProps} totalFileCount={1} onNavigateFile={vi.fn()} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("code-viewer")).toBeTruthy();
+      });
+
+      expect(screen.queryByTestId("file-position-indicator")).toBeNull();
+      expect(screen.queryByLabelText("Previous file")).toBeNull();
+    });
+
+    it("does not render nav controls when onNavigateFile is omitted", async () => {
+      render(<FileViewerModal {...defaultProps} totalFileCount={3} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("code-viewer")).toBeTruthy();
+      });
+
+      expect(screen.queryByTestId("file-position-indicator")).toBeNull();
+    });
+
+    it("renders the position indicator and nav buttons across a multi-file set", async () => {
+      render(<FileViewerModal {...defaultProps} {...stepProps} currentFileIndex={1} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("file-position-indicator")).toBeTruthy();
+      });
+
+      expect(screen.getByTestId("file-position-indicator").textContent).toBe("2 of 3");
+      expect(screen.getByLabelText("Previous file").hasAttribute("disabled")).toBe(false);
+      expect(screen.getByLabelText("Next file").hasAttribute("disabled")).toBe(false);
+    });
+
+    it("disables Previous at the first file", async () => {
+      render(<FileViewerModal {...defaultProps} {...stepProps} currentFileIndex={0} />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Previous file")).toBeTruthy();
+      });
+
+      expect(screen.getByLabelText("Previous file").hasAttribute("disabled")).toBe(true);
+      expect(screen.getByLabelText("Next file").hasAttribute("disabled")).toBe(false);
+    });
+
+    it("disables Next at the last file", async () => {
+      render(<FileViewerModal {...defaultProps} {...stepProps} currentFileIndex={2} />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Next file")).toBeTruthy();
+      });
+
+      expect(screen.getByLabelText("Next file").hasAttribute("disabled")).toBe(true);
+      expect(screen.getByLabelText("Previous file").hasAttribute("disabled")).toBe(false);
+    });
+
+    it("calls onNavigateFile(1) on `]` and (-1) on `[`", async () => {
+      const onNavigateFile = vi.fn();
+      render(
+        <FileViewerModal
+          {...defaultProps}
+          totalFileCount={3}
+          currentFileIndex={1}
+          onNavigateFile={onNavigateFile}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("file-position-indicator")).toBeTruthy();
+      });
+
+      fireEvent.keyDown(window, { key: "]" });
+      expect(onNavigateFile).toHaveBeenCalledWith(1);
+
+      fireEvent.keyDown(window, { key: "[" });
+      expect(onNavigateFile).toHaveBeenCalledWith(-1);
+    });
+
+    it("does not step past the boundaries via keyboard", async () => {
+      const onNavigateFile = vi.fn();
+      const { rerender } = render(
+        <FileViewerModal
+          {...defaultProps}
+          totalFileCount={3}
+          currentFileIndex={0}
+          onNavigateFile={onNavigateFile}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("file-position-indicator")).toBeTruthy();
+      });
+
+      // `[` at the first file is a no-op
+      fireEvent.keyDown(window, { key: "[" });
+      expect(onNavigateFile).not.toHaveBeenCalled();
+
+      rerender(
+        <FileViewerModal
+          {...defaultProps}
+          totalFileCount={3}
+          currentFileIndex={2}
+          onNavigateFile={onNavigateFile}
+        />
+      );
+
+      // `]` at the last file is a no-op
+      fireEvent.keyDown(window, { key: "]" });
+      expect(onNavigateFile).not.toHaveBeenCalled();
+    });
+
+    it("clicking the nav buttons calls onNavigateFile with the right delta", async () => {
+      const onNavigateFile = vi.fn();
+      render(
+        <FileViewerModal
+          {...defaultProps}
+          totalFileCount={3}
+          currentFileIndex={1}
+          onNavigateFile={onNavigateFile}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Next file")).toBeTruthy();
+      });
+
+      fireEvent.click(screen.getByLabelText("Next file"));
+      expect(onNavigateFile).toHaveBeenCalledWith(1);
+
+      fireEvent.click(screen.getByLabelText("Previous file"));
+      expect(onNavigateFile).toHaveBeenCalledWith(-1);
+    });
+
+    it("ignores `[`/`]` when focus is in an input", async () => {
+      const onNavigateFile = vi.fn();
+      render(
+        <>
+          <input data-testid="other-input" />
+          <FileViewerModal
+            {...defaultProps}
+            totalFileCount={3}
+            currentFileIndex={1}
+            onNavigateFile={onNavigateFile}
+          />
+        </>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("file-position-indicator")).toBeTruthy();
+      });
+
+      const input = screen.getByTestId("other-input") as HTMLInputElement;
+      input.focus();
+      fireEvent.keyDown(input, { key: "]" });
+
+      expect(onNavigateFile).not.toHaveBeenCalled();
+    });
+
+    it("forwards restoreFocusTo to AppDialog", async () => {
+      const ref = { current: document.createElement("div") };
+      render(<FileViewerModal {...defaultProps} restoreFocusTo={ref} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("code-viewer")).toBeTruthy();
+      });
+
+      expect(capturedDialogProps.restoreFocusTo).toBe(ref);
     });
   });
 });

--- a/src/components/Worktree/FileChangeList.tsx
+++ b/src/components/Worktree/FileChangeList.tsx
@@ -87,6 +87,11 @@ export function FileChangeList({
   isStale = false,
 }: FileChangeListProps) {
   const [selectedFile, setSelectedFile] = useState<SelectedFile | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  // Holds the row element that opened the modal so focus can return to it on
+  // close. Identity-stable across renders so AppDialog's restore logic doesn't
+  // spuriously re-fire (the ref is the fallback for an unmounted trigger).
+  const triggerElementRef = useRef<HTMLElement | null>(null);
 
   const sortedChanges = useMemo(() => {
     return [...changes]
@@ -112,6 +117,15 @@ export function FileChangeList({
         return a.path.localeCompare(b.path);
       });
   }, [changes, rootPath]);
+
+  // Map each row key to its position in `sortedChanges` so file stepping spans
+  // the whole change set (not just the visible cap) and grouped rows resolve to
+  // the same deterministic order as the flat list.
+  const indexByKey = useMemo(() => {
+    const map = new Map<string, number>();
+    sortedChanges.forEach((change, index) => map.set(rowKey(change), index));
+    return map;
+  }, [sortedChanges]);
 
   const visibleChanges = useMemo(
     () => sortedChanges.slice(0, maxVisible),
@@ -176,15 +190,32 @@ export function FileChangeList({
     return null;
   }
 
-  const handleFileClick = (change: FileChangeWithRelativePath) => {
-    setSelectedFile({
-      path: change.relativePath,
-      status: change.status,
-    });
+  const openFileAt = (index: number, triggerEl: HTMLElement | null) => {
+    const change = sortedChanges[index];
+    if (!change) return;
+    triggerElementRef.current = triggerEl;
+    setSelectedFile({ path: change.relativePath, status: change.status });
+    setSelectedIndex(index);
   };
 
   const closeModal = () => {
     setSelectedFile(null);
+    setSelectedIndex(null);
+  };
+
+  const navigateFile = (delta: -1 | 1) => {
+    setSelectedIndex((current) => {
+      if (current === null) return current;
+      // Clamp against the live length first — a worktree refresh can shrink the
+      // set while the modal is open, leaving the index stale.
+      const safeCurrent = Math.min(current, sortedChanges.length - 1);
+      const next = Math.min(Math.max(safeCurrent + delta, 0), sortedChanges.length - 1);
+      const change = sortedChanges[next];
+      if (change) {
+        setSelectedFile({ path: change.relativePath, status: change.status });
+      }
+      return next;
+    });
   };
 
   const renderFileItem = (change: FileChangeWithRelativePath, showDir: boolean) => {
@@ -193,17 +224,28 @@ export function FileChangeList({
     const displayDir = formatDirForDisplay(dir);
     const key = rowKey(change);
     const isNew = newRowKeys.has(key);
+    const index = indexByKey.get(key) ?? 0;
 
     return (
       <Tooltip key={key}>
         <TooltipTrigger asChild>
           <div
             data-recency-new={isNew ? "true" : undefined}
+            role="button"
+            tabIndex={0}
+            aria-label={`Open ${change.relativePath}`}
             className={cn(
               "group/filerow flex items-center text-xs font-mono hover:bg-tint/5 rounded px-1.5 py-0.5 -mx-1.5 cursor-pointer transition-colors",
+              "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-daintree-accent",
               isNew && "file-change-row-new"
             )}
-            onClick={() => handleFileClick(change)}
+            onClick={(e) => openFileAt(index, e.currentTarget)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                openFileAt(index, e.currentTarget);
+              }
+            }}
           >
             <span className={cn("w-4 font-bold shrink-0", config.color)}>{config.label}</span>
 
@@ -274,6 +316,10 @@ export function FileChangeList({
           status={selectedFile?.status ?? "modified"}
           worktreePath={rootPath}
           onClose={closeModal}
+          restoreFocusTo={triggerElementRef}
+          currentFileIndex={selectedIndex ?? undefined}
+          totalFileCount={sortedChanges.length}
+          onNavigateFile={navigateFile}
         />
       </>
     );
@@ -309,6 +355,10 @@ export function FileChangeList({
         status={selectedFile?.status ?? "modified"}
         worktreePath={rootPath}
         onClose={closeModal}
+        restoreFocusTo={triggerElementRef}
+        currentFileIndex={selectedIndex ?? undefined}
+        totalFileCount={sortedChanges.length}
+        onNavigateFile={navigateFile}
       />
     </>
   );

--- a/src/components/Worktree/FileDiffModal.tsx
+++ b/src/components/Worktree/FileDiffModal.tsx
@@ -1,5 +1,6 @@
 import { Suspense, lazy, useEffect, useCallback, useState, useRef } from "react";
 import type { GitStatus } from "@shared/types";
+import type { RestoreFocusTarget } from "@/components/ui/AppDialog";
 import { actionService } from "@/services/ActionService";
 import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
 import { useBranchForPath } from "@/hooks/useBranchForPath";
@@ -36,6 +37,14 @@ export interface FileDiffModalProps {
   status: GitStatus;
   worktreePath: string;
   onClose: () => void;
+  /** Element to focus when the dialog closes and its trigger was unmounted. */
+  restoreFocusTo?: RestoreFocusTarget;
+  /** Zero-based position of the current file within the navigable set. */
+  currentFileIndex?: number;
+  /** Total number of files the user can step through. */
+  totalFileCount?: number;
+  /** Step to the previous (-1) or next (1) file in the set. */
+  onNavigateFile?: (delta: -1 | 1) => void;
 }
 
 export function FileDiffModal({
@@ -44,6 +53,10 @@ export function FileDiffModal({
   status,
   worktreePath,
   onClose,
+  restoreFocusTo,
+  currentFileIndex,
+  totalFileCount,
+  onNavigateFile,
 }: FileDiffModalProps) {
   const [diff, setDiff] = useState<string | undefined>(undefined);
   const requestRef = useRef(0);
@@ -95,6 +108,10 @@ export function FileDiffModal({
         defaultMode="diff"
         onRetryDiff={fetchDiff}
         onClose={onClose}
+        restoreFocusTo={restoreFocusTo}
+        currentFileIndex={currentFileIndex}
+        totalFileCount={totalFileCount}
+        onNavigateFile={onNavigateFile}
       />
     </Suspense>
   );

--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -38,16 +38,30 @@ export function ReviewHub({
   autoStageOnOpen,
 }: ReviewHubProps) {
   const dialogRef = useRef<HTMLDivElement>(null);
+  // Element focused when the hub opened. ReviewHub is hand-rolled (no AppDialog),
+  // so it restores focus on close itself. A ref — not state — avoids the
+  // re-render churn that bit #4220.
+  const previousActiveElementRef = useRef<HTMLElement | null>(null);
 
   useOverlayState(isOpen);
 
   useEffect(() => {
     if (!isOpen) return;
+    // Capture the trigger before focus moves into the dialog (the rAF below).
+    const opener = document.activeElement;
+    previousActiveElementRef.current = opener instanceof HTMLElement ? opener : null;
     requestAnimationFrame(() => {
       if (dialogRef.current && !dialogRef.current.contains(document.activeElement)) {
         dialogRef.current.focus();
       }
     });
+    return () => {
+      const target = previousActiveElementRef.current;
+      previousActiveElementRef.current = null;
+      if (target && document.contains(target)) {
+        target.focus();
+      }
+    };
   }, [isOpen]);
 
   if (!isOpen) return null;

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -993,6 +993,52 @@ describe("ReviewHub", () => {
     });
   });
 
+  describe("focus restore on close (#9217)", () => {
+    function renderWithOpener(isOpen: boolean) {
+      return (
+        <>
+          <button type="button" data-testid="opener">
+            open
+          </button>
+          <ReviewHub isOpen={isOpen} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />
+        </>
+      );
+    }
+
+    it("returns focus to the element that opened the hub", async () => {
+      const { rerender } = render(renderWithOpener(false));
+      const opener = screen.getByTestId("opener") as HTMLButtonElement;
+      act(() => opener.focus());
+      expect(document.activeElement).toBe(opener);
+
+      // Open captures the opener as the previously-focused element.
+      rerender(renderWithOpener(true));
+      await waitFor(() => screen.getByText("index.ts"));
+
+      // Close restores focus to the opener.
+      act(() => {
+        rerender(renderWithOpener(false));
+      });
+      expect(document.activeElement).toBe(opener);
+    });
+
+    it("does not throw when the opener was removed before close", async () => {
+      const { rerender } = render(renderWithOpener(false));
+      const opener = screen.getByTestId("opener") as HTMLButtonElement;
+      act(() => opener.focus());
+
+      rerender(renderWithOpener(true));
+      await waitFor(() => screen.getByText("index.ts"));
+
+      // Drop the opener from the tree, then close — restore must guard on
+      // document.contains and skip the detached node without throwing.
+      act(() => {
+        rerender(<ReviewHub isOpen={false} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+      });
+      expect(document.contains(opener)).toBe(false);
+    });
+  });
+
   describe("PR state indicator", () => {
     function setWorktreePR(prData: {
       prNumber: number;

--- a/src/components/Worktree/__tests__/FileChangeList.test.tsx
+++ b/src/components/Worktree/__tests__/FileChangeList.test.tsx
@@ -1,12 +1,41 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { act, render, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { act, render, cleanup, fireEvent } from "@testing-library/react";
 import type { FileChangeDetail } from "../../../types";
 
+const { capturedModalProps } = vi.hoisted(() => ({
+  capturedModalProps: {
+    isOpen: false as boolean,
+    filePath: "" as string,
+    restoreFocusTo: undefined as unknown,
+    currentFileIndex: undefined as number | undefined,
+    totalFileCount: undefined as number | undefined,
+    onNavigateFile: undefined as ((delta: -1 | 1) => void) | undefined,
+    onClose: undefined as (() => void) | undefined,
+  },
+}));
+
 vi.mock("../FileDiffModal", () => ({
-  FileDiffModal: () => null,
+  FileDiffModal: (props: {
+    isOpen: boolean;
+    filePath: string;
+    restoreFocusTo?: unknown;
+    currentFileIndex?: number;
+    totalFileCount?: number;
+    onNavigateFile?: (delta: -1 | 1) => void;
+    onClose: () => void;
+  }) => {
+    capturedModalProps.isOpen = props.isOpen;
+    capturedModalProps.filePath = props.filePath;
+    capturedModalProps.restoreFocusTo = props.restoreFocusTo;
+    capturedModalProps.currentFileIndex = props.currentFileIndex;
+    capturedModalProps.totalFileCount = props.totalFileCount;
+    capturedModalProps.onNavigateFile = props.onNavigateFile;
+    capturedModalProps.onClose = props.onClose;
+    return null;
+  },
 }));
 
 vi.mock("@/components/ui/tooltip", () => ({
@@ -238,5 +267,134 @@ describe("FileChangeList — stale state (#8069)", () => {
     const el = scroll(container);
     expect(el.classList.contains("surface-stale")).toBe(false);
     expect(el.getAttribute("aria-busy")).toBeNull();
+  });
+});
+
+describe("FileChangeList — focus restore & file stepping (#9217)", () => {
+  beforeEach(() => {
+    capturedModalProps.isOpen = false;
+    capturedModalProps.filePath = "";
+    capturedModalProps.restoreFocusTo = undefined;
+    capturedModalProps.currentFileIndex = undefined;
+    capturedModalProps.totalFileCount = undefined;
+    capturedModalProps.onNavigateFile = undefined;
+    capturedModalProps.onClose = undefined;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  function rows(container: HTMLElement): HTMLElement[] {
+    return Array.from(container.querySelectorAll<HTMLElement>('[role="button"]'));
+  }
+
+  it("makes each row a focusable button with an accessible label", () => {
+    const { container } = render(
+      <FileChangeList changes={[file("a.ts"), file("b.ts")]} rootPath={ROOT} />
+    );
+    const [first] = rows(container);
+    expect(first).toBeTruthy();
+    expect(first!.getAttribute("role")).toBe("button");
+    expect(first!.getAttribute("tabindex")).toBe("0");
+    expect(first!.getAttribute("aria-label")).toContain("a.ts");
+  });
+
+  it("opens the modal on Enter and passes the row as the focus-restore target", () => {
+    const { container } = render(
+      <FileChangeList changes={[file("a.ts"), file("b.ts")]} rootPath={ROOT} />
+    );
+    const [first] = rows(container);
+    fireEvent.keyDown(first!, { key: "Enter" });
+
+    expect(capturedModalProps.isOpen).toBe(true);
+    expect(capturedModalProps.filePath).toBe("a.ts");
+    // restoreFocusTo is the identity-stable ref; its current points at the row.
+    const ref = capturedModalProps.restoreFocusTo as { current: HTMLElement | null };
+    expect(ref.current).toBe(first);
+  });
+
+  it("opens the modal on Space", () => {
+    const { container } = render(<FileChangeList changes={[file("a.ts")]} rootPath={ROOT} />);
+    fireEvent.keyDown(rows(container)[0]!, { key: " " });
+    expect(capturedModalProps.isOpen).toBe(true);
+  });
+
+  it("opens the modal on click and reports the file index and total count", () => {
+    const { container } = render(
+      <FileChangeList changes={[file("a.ts"), file("b.ts"), file("c.ts")]} rootPath={ROOT} />
+    );
+    // Sorted alphabetically (equal churn): a, b, c. Click the second row.
+    fireEvent.click(rows(container)[1]!);
+
+    expect(capturedModalProps.isOpen).toBe(true);
+    expect(capturedModalProps.filePath).toBe("b.ts");
+    expect(capturedModalProps.currentFileIndex).toBe(1);
+    expect(capturedModalProps.totalFileCount).toBe(3);
+  });
+
+  it("steps to the next and previous file across the whole sorted set", () => {
+    const { container } = render(
+      <FileChangeList changes={[file("a.ts"), file("b.ts"), file("c.ts")]} rootPath={ROOT} />
+    );
+    fireEvent.click(rows(container)[0]!);
+    expect(capturedModalProps.currentFileIndex).toBe(0);
+
+    act(() => capturedModalProps.onNavigateFile!(1));
+    expect(capturedModalProps.currentFileIndex).toBe(1);
+    expect(capturedModalProps.filePath).toBe("b.ts");
+
+    act(() => capturedModalProps.onNavigateFile!(1));
+    expect(capturedModalProps.currentFileIndex).toBe(2);
+    expect(capturedModalProps.filePath).toBe("c.ts");
+
+    act(() => capturedModalProps.onNavigateFile!(-1));
+    expect(capturedModalProps.currentFileIndex).toBe(1);
+    expect(capturedModalProps.filePath).toBe("b.ts");
+  });
+
+  it("clamps stepping at the boundaries", () => {
+    const { container } = render(
+      <FileChangeList changes={[file("a.ts"), file("b.ts")]} rootPath={ROOT} />
+    );
+    fireEvent.click(rows(container)[0]!);
+
+    // Step back from the first file stays at index 0.
+    act(() => capturedModalProps.onNavigateFile!(-1));
+    expect(capturedModalProps.currentFileIndex).toBe(0);
+
+    // Step forward to the last, then past it — stays at the last index.
+    act(() => capturedModalProps.onNavigateFile!(1));
+    act(() => capturedModalProps.onNavigateFile!(1));
+    expect(capturedModalProps.currentFileIndex).toBe(1);
+    expect(capturedModalProps.filePath).toBe("b.ts");
+  });
+
+  it("can step into files beyond the visible cap", () => {
+    const many = Array.from({ length: 12 }, (_, i) =>
+      // Descending churn so the sort order matches the construction order.
+      ({ ...file(`file-${String(i).padStart(2, "0")}.ts`), insertions: 100 - i })
+    );
+    const { container } = render(<FileChangeList changes={many} rootPath={ROOT} maxVisible={8} />);
+    // Only 8 rows render, but stepping spans all 12.
+    expect(rows(container).length).toBe(8);
+    fireEvent.click(rows(container)[7]!);
+    expect(capturedModalProps.currentFileIndex).toBe(7);
+    expect(capturedModalProps.totalFileCount).toBe(12);
+
+    act(() => capturedModalProps.onNavigateFile!(1));
+    expect(capturedModalProps.currentFileIndex).toBe(8);
+    expect(capturedModalProps.filePath).toBe("file-08.ts");
+  });
+
+  it("closing the modal clears the open state and selected index", () => {
+    const { container } = render(<FileChangeList changes={[file("a.ts")]} rootPath={ROOT} />);
+    fireEvent.click(rows(container)[0]!);
+    expect(capturedModalProps.isOpen).toBe(true);
+    expect(capturedModalProps.currentFileIndex).toBe(0);
+
+    act(() => capturedModalProps.onClose!());
+    expect(capturedModalProps.isOpen).toBe(false);
+    expect(capturedModalProps.currentFileIndex).toBeUndefined();
   });
 });

--- a/src/components/Worktree/__tests__/FileDiffModal.test.tsx
+++ b/src/components/Worktree/__tests__/FileDiffModal.test.tsx
@@ -8,7 +8,13 @@ import { FileDiffModal } from "../FileDiffModal";
 // what `fetchDiff` resolves to for each dispatch outcome.
 const { mockDispatch, capturedProps } = vi.hoisted(() => ({
   mockDispatch: vi.fn(),
-  capturedProps: { diff: undefined as string | undefined },
+  capturedProps: {
+    diff: undefined as string | undefined,
+    restoreFocusTo: undefined as unknown,
+    currentFileIndex: undefined as number | undefined,
+    totalFileCount: undefined as number | undefined,
+    onNavigateFile: undefined as ((delta: -1 | 1) => void) | undefined,
+  },
 }));
 
 vi.mock("@/services/ActionService", () => ({
@@ -18,8 +24,18 @@ vi.mock("@/services/ActionService", () => ({
 }));
 
 vi.mock("@/components/FileViewer/FileViewerModal", () => ({
-  FileViewerModal: (props: { diff?: string }) => {
+  FileViewerModal: (props: {
+    diff?: string;
+    restoreFocusTo?: unknown;
+    currentFileIndex?: number;
+    totalFileCount?: number;
+    onNavigateFile?: (delta: -1 | 1) => void;
+  }) => {
     capturedProps.diff = props.diff;
+    capturedProps.restoreFocusTo = props.restoreFocusTo;
+    capturedProps.currentFileIndex = props.currentFileIndex;
+    capturedProps.totalFileCount = props.totalFileCount;
+    capturedProps.onNavigateFile = props.onNavigateFile;
     return <div data-testid="file-viewer-modal-stub" />;
   },
 }));
@@ -40,6 +56,10 @@ describe("FileDiffModal", () => {
   beforeEach(() => {
     mockDispatch.mockReset();
     capturedProps.diff = undefined;
+    capturedProps.restoreFocusTo = undefined;
+    capturedProps.currentFileIndex = undefined;
+    capturedProps.totalFileCount = undefined;
+    capturedProps.onNavigateFile = undefined;
   });
 
   it("unwraps the { content } envelope and passes the diff string to the viewer", async () => {
@@ -80,5 +100,27 @@ describe("FileDiffModal", () => {
     await waitFor(() => {
       expect(capturedProps.diff).toBe("ERROR");
     });
+  });
+
+  it("threads focus-restore and file-stepping props through to the viewer (#9217)", async () => {
+    mockDispatch.mockResolvedValue({ ok: true, result: { content: "diff text" } });
+    const ref = { current: document.createElement("div") };
+    const onNavigateFile = vi.fn();
+    render(
+      <FileDiffModal
+        {...baseProps}
+        restoreFocusTo={ref}
+        currentFileIndex={2}
+        totalFileCount={5}
+        onNavigateFile={onNavigateFile}
+      />
+    );
+    await waitFor(() => {
+      expect(capturedProps.diff).toBe("diff text");
+    });
+    expect(capturedProps.restoreFocusTo).toBe(ref);
+    expect(capturedProps.currentFileIndex).toBe(2);
+    expect(capturedProps.totalFileCount).toBe(5);
+    expect(capturedProps.onNavigateFile).toBe(onNavigateFile);
   });
 });


### PR DESCRIPTION
## Summary

- Closing a file diff returns keyboard focus to the row that opened it. `FileChangeList` rows are now real buttons (`role=button`, `tabIndex`, Enter/Space, `aria-label`, focus ring). `ReviewHub` (hand-rolled dialog) restores focus to its opener on close; diffs opened from inside `ReviewHub` return focus to the inspected row.
- `FileDiffModal` and `FileViewerModal` gain previous/next file controls -- ChevronLeft/ChevronRight header buttons, a `{n} of {total}` position indicator, and `[`/`]` keyboard shortcuts. Steps across the full sorted change set, bounds-clamped at both ends. `[` and `]` were chosen because `n`/`p` are taken by hunk navigation and arrow keys conflict with split-diff horizontal scroll.
- The open file's index is derived from its identity each render, so a background worktree refresh that reorders or shrinks the list keeps the indicator and stepping cursor correct without stale index state.

Resolves #9217

## Changes

- `FileChangeList.tsx` -- rows promoted to interactive buttons with full keyboard and ARIA support
- `FileDiffModal.tsx` -- previous/next controls wired to `onNavigate` prop; `[`/`]` shortcuts
- `FileViewerModal.tsx` -- same stepping controls + shortcuts; index derived from identity
- `ReviewHub.tsx` / `ReviewHubContent.tsx` -- focus-restore on close; diffs return focus to their source row
- Tests: 256 passing across `FileChangeList`, `FileDiffModal`, `FileViewerModal`, and `ReviewHub` suites

Out of scope (follow-up): file-stepping within ReviewHub's staged/unstaged sections -- ordering across multi-select/filtered sections is ambiguous and warrants a separate issue.

## Testing

`npm run check` clean (typecheck, lint ratchet, format, IPC checks). 256 unit tests passing across all four affected suites.