### PR TITLE
feat(e2e): enable failOnFlakyTests on release-gating projects

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -433,6 +433,7 @@ jobs:
           # when secrets aren't inherited.
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENCODE_E2E_ENABLED: ${{ inputs.suite == 'online' && '1' || '' }}
+          FAIL_ON_FLAKY_TESTS: ${{ (inputs.suite == 'core' || inputs.suite == 'online') && 'true' || 'false' }}
         run: |
           set -euo pipefail
           npx playwright test ${{ steps.test-cmd.outputs.args }} ${SHARD_ARGS:-} ${LAST_FAILED_ARGS:-}
@@ -443,6 +444,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENCODE_E2E_ENABLED: ${{ inputs.suite == 'online' && '1' || '' }}
+          FAIL_ON_FLAKY_TESTS: ${{ (inputs.suite == 'core' || inputs.suite == 'online') && 'true' || 'false' }}
         run: |
           set -euo pipefail
           xvfb-run --auto-servernum npx playwright test ${{ steps.test-cmd.outputs.args }} ${SHARD_ARGS:-} ${LAST_FAILED_ARGS:-}
@@ -460,6 +462,7 @@ jobs:
           ELECTRON_ENABLE_LOGGING: "1"
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENCODE_E2E_ENABLED: ${{ inputs.suite == 'online' && '1' || '' }}
+          FAIL_ON_FLAKY_TESTS: ${{ (inputs.suite == 'core' || inputs.suite == 'online') && 'true' || 'false' }}
         run: |
           set -euo pipefail
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -50,6 +50,7 @@ Tests are split into nine Playwright projects:
 | full-resilience | `./e2e/full/resilience` | 2            | false            | 1-2     |
 | online          | `./e2e/online`          | 2            | true             | 1-2     |
 | nightly         | `./e2e/nightly`         | 0            | false            | 1       |
+| screenshots     | `./e2e/screenshots`     | 0            | false            | 1-2     |
 
 ## Directory Structure
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -39,17 +39,17 @@ Tests are split into nine Playwright projects:
 
 `playwright.config.ts` at the project root defines the projects. All `full-*` buckets share `coreTimeout` and `retries: 2 (CI)`. `core` and `online` keep their own timeouts; `nightly` runs at workers=1 with no retries.
 
-| Project         | testDir                 | retries (CI) | workers |
-| --------------- | ----------------------- | ------------ | ------- |
-| core            | `./e2e/core`            | 2            | 1-2     |
-| full-terminal   | `./e2e/full/terminal`   | 2            | 1-2     |
-| full-worktree   | `./e2e/full/worktree`   | 2            | 1-2     |
-| full-presets    | `./e2e/full/presets`    | 2            | 1-2     |
-| full-platform   | `./e2e/full/platform`   | 2            | 1-2     |
-| full-panels     | `./e2e/full/panels`     | 2            | 1-2     |
-| full-resilience | `./e2e/full/resilience` | 2            | 1-2     |
-| online          | `./e2e/online`          | 1            | 1-2     |
-| nightly         | `./e2e/nightly`         | 0            | 1       |
+| Project         | testDir                 | retries (CI) | failOnFlakyTests | workers |
+| --------------- | ----------------------- | ------------ | ---------------- | ------- |
+| core            | `./e2e/core`            | 2            | true             | 1-2     |
+| full-terminal   | `./e2e/full/terminal`   | 2            | false            | 1-2     |
+| full-worktree   | `./e2e/full/worktree`   | 2            | false            | 1-2     |
+| full-presets    | `./e2e/full/presets`    | 2            | false            | 1-2     |
+| full-platform   | `./e2e/full/platform`   | 2            | false            | 1-2     |
+| full-panels     | `./e2e/full/panels`     | 2            | false            | 1-2     |
+| full-resilience | `./e2e/full/resilience` | 2            | false            | 1-2     |
+| online          | `./e2e/online`          | 2            | true             | 1-2     |
+| nightly         | `./e2e/nightly`         | 0            | false            | 1       |
 
 ## Directory Structure
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
       testDir: "./e2e/core",
       timeout: coreTimeout,
       retries: isCI ? 2 : 0,
+      failOnFlakyTests: true,
     },
     {
       name: "full-terminal",
@@ -81,6 +82,7 @@ export default defineConfig({
       testDir: "./e2e/online",
       timeout: onlineTimeout,
       retries: isCI ? 2 : 0,
+      failOnFlakyTests: true,
     },
     {
       name: "nightly",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,6 +26,10 @@ export default defineConfig({
   workers: e2eWorkers,
   fullyParallel: false,
   timeout: 180_000,
+  // failOnFlakyTests is top-level only (not per-project). Gate it behind
+  // FAIL_ON_FLAKY_TESTS so only release-gating suites (core, online) enable
+  // it in CI. full-* buckets keep retries without a flake gate for PR velocity.
+  failOnFlakyTests: process.env.FAIL_ON_FLAKY_TESTS === "true",
   expect: { timeout: isWindowsCI ? 15_000 : isCI ? 10_000 : 5_000 },
   outputDir: "./test-results",
   ...(reporter ? { reporter } : {}),
@@ -39,7 +43,6 @@ export default defineConfig({
       testDir: "./e2e/core",
       timeout: coreTimeout,
       retries: isCI ? 2 : 0,
-      failOnFlakyTests: true,
     },
     {
       name: "full-terminal",
@@ -82,7 +85,6 @@ export default defineConfig({
       testDir: "./e2e/online",
       timeout: onlineTimeout,
       retries: isCI ? 2 : 0,
-      failOnFlakyTests: true,
     },
     {
       name: "nightly",


### PR DESCRIPTION
## Summary
Enables Playwright's `failOnFlakyTests` for the test projects that gate releases (`core` and `online`). A test that fails on the first attempt and passes on a retry ships as a green CI run today — that's the kind of intermittent we want release-gating tiers to surface, not absorb.

- Adds `failOnFlakyTests` at the top-level Playwright config, gated by `FAIL_ON_FLAKY_TESTS` so it only activates when CI explicitly opts in.
- Passes `FAIL_ON_FLAKY_TESTS` in the CI workflow for `core` and `online` suites only.
- `full-*` buckets keep retries without the flake gate for PR velocity.

Resolves #9119

## Changes
- **playwright.config.ts** — top-level `failOnFlakyTests` behind `FAIL_ON_FLAKY_TESTS` env var
- **.github/workflows/e2e.yml** — sets `FAIL_ON_FLAKY_TESTS=true` for `core` and `online` in all three OS jobs
- **docs/e2e-testing.md** — fixed online retries (was listed as 1, code says 2), added `failOnFlakyTests` column, added missing screenshots row

## Testing
Config parses cleanly. The env-var gate is a no-op locally and in `full-*` CI runs. Release-gating suites (`core`, `online`) will enforce the gate on this PR's CI run.