### PR TITLE
fix(recipes): guard in-repo recipe writes against newer disk content

### DIFF
--- a/electron/ipc/handlers/projectRecipes.ts
+++ b/electron/ipc/handlers/projectRecipes.ts
@@ -257,15 +257,19 @@ export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () =
       throw new Error(`Project not found: ${projectId}`);
     }
     assertNoSecretEnvValues(recipe.terminals);
-    await projectStore.writeInRepoRecipeChecked(project.path, recipe, { force: force === true });
+    await projectStore.writeInRepoRecipeChecked(project.path, recipe, {
+      force: force === true,
+      previousName: typeof previousName === "string" ? previousName : undefined,
+    });
     if (
       previousName &&
       typeof previousName === "string" &&
       safeRecipeFilename(previousName) !== safeRecipeFilename(recipe.name)
     ) {
-      // Delete the old-name file; the stale cache entry for the old recipe id
-      // self-heals on the next loadRecipes (which clears the per-project hash
-      // map and repopulates from disk).
+      // Delete the old-name file. The staleness of the old file is checked
+      // inside writeInRepoRecipeChecked before the new write runs, so by the
+      // time we reach here the rename has been authorized. The cache entry
+      // for the old recipe id self-heals on the next loadRecipes.
       await projectStore.deleteInRepoRecipe(project.path, previousName);
     }
   };

--- a/electron/ipc/handlers/projectRecipes.ts
+++ b/electron/ipc/handlers/projectRecipes.ts
@@ -240,11 +240,12 @@ export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () =
     projectId: string;
     recipe: TerminalRecipe;
     previousName?: string;
+    force?: boolean;
   }): Promise<void> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
-    const { projectId, recipe, previousName } = payload;
+    const { projectId, recipe, previousName, force } = payload;
     if (typeof projectId !== "string" || !projectId) {
       throw new Error("Invalid project ID");
     }
@@ -256,12 +257,15 @@ export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () =
       throw new Error(`Project not found: ${projectId}`);
     }
     assertNoSecretEnvValues(recipe.terminals);
-    await projectStore.writeInRepoRecipe(project.path, recipe);
+    await projectStore.writeInRepoRecipeChecked(project.path, recipe, { force: force === true });
     if (
       previousName &&
       typeof previousName === "string" &&
       safeRecipeFilename(previousName) !== safeRecipeFilename(recipe.name)
     ) {
+      // Delete the old-name file; the stale cache entry for the old recipe id
+      // self-heals on the next loadRecipes (which clears the per-project hash
+      // map and repopulates from disk).
       await projectStore.deleteInRepoRecipe(project.path, previousName);
     }
   };

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1399,12 +1399,14 @@ const api: ElectronAPI = {
     updateInRepoRecipe: (
       projectId: string,
       recipe: import("../shared/types/index.js").TerminalRecipe,
-      previousName?: string
+      previousName?: string,
+      options?: { force?: boolean }
     ): Promise<void> =>
       _unwrappingInvoke(CHANNELS.PROJECT_UPDATE_INREPO_RECIPE, {
         projectId,
         recipe,
         previousName,
+        force: options?.force === true ? true : undefined,
       }),
 
     deleteInRepoRecipe: (projectId: string, recipeName: string): Promise<void> =>

--- a/electron/services/ProjectIdentityFiles.ts
+++ b/electron/services/ProjectIdentityFiles.ts
@@ -7,11 +7,40 @@ import {
 import type { AgentPreset } from "../../shared/config/agentRegistry.js";
 import path from "path";
 import fs from "fs/promises";
+import { createHash } from "crypto";
 import { z } from "zod";
 import { resilientAtomicWriteFile } from "../utils/fs.js";
 import { UTF8_BOM } from "./projectStorePaths.js";
 import { safeRecipeFilename } from "../utils/recipeFilename.js";
 import { TerminalRecipeSchema } from "../schemas/ipc.js";
+
+/**
+ * Builds the exact UTF-8 byte string that `writeInRepoRecipe` lands on disk
+ * for `recipe`. Used both at read time (to hash file bytes) and at write time
+ * (to hash the candidate payload), so the staleness comparison in
+ * {@link ProjectStore.writeInRepoRecipeChecked} is comparing like to like:
+ * the sanitized, env-redacted, BOM-free JSON-with-trailing-newline that
+ * actually persists. Hashing the raw in-memory recipe would produce
+ * spurious conflicts on every write because `projectId`/`worktreeId`/env
+ * values would never match the redacted on-disk bytes.
+ */
+export function buildInRepoRecipePayloadString(recipe: TerminalRecipe): string {
+  const { projectId: _p, worktreeId: _w, ...shareable } = recipe;
+  const sanitizedTerminals = shareable.terminals.map((t) => {
+    if (!t.env || Object.keys(t.env).length === 0) return t;
+    const redactedEnv: Record<string, string> = {};
+    for (const key of Object.keys(t.env)) {
+      redactedEnv[key] = "";
+    }
+    return { ...t, env: redactedEnv };
+  });
+  const payload = { ...shareable, terminals: sanitizedTerminals };
+  return JSON.stringify(payload, null, 2) + "\n";
+}
+
+export function hashRecipePayload(content: string): string {
+  return createHash("sha256").update(content, "utf-8").digest("hex");
+}
 
 const MAX_PROJECT_NAME_LENGTH = 100;
 const DAINTREE_DIR = ".daintree";
@@ -213,7 +242,14 @@ export class ProjectIdentityFiles {
     }
   }
 
-  async writeInRepoRecipe(projectPath: string, recipe: TerminalRecipe): Promise<void> {
+  /**
+   * Writes `recipe` to disk and returns the SHA-256 of the bytes that landed
+   * on disk. Callers cache the returned hash so a subsequent
+   * {@link ProjectStore.writeInRepoRecipeChecked} can detect external edits
+   * (git pull, branch switch, stash pop) that changed the file out from under
+   * them.
+   */
+  async writeInRepoRecipe(projectPath: string, recipe: TerminalRecipe): Promise<string> {
     await this.assertDaintreeDirNotSymlink(projectPath);
     const recipesDir = path.join(projectPath, DAINTREE_RECIPES_DIR);
 
@@ -230,23 +266,13 @@ export class ProjectIdentityFiles {
 
     const filename = safeRecipeFilename(recipe.name);
     const filePath = path.join(recipesDir, filename);
-
-    const { projectId: _, worktreeId: _w, ...shareable } = recipe;
-    const sanitizedTerminals = shareable.terminals.map((t) => {
-      if (!t.env || Object.keys(t.env).length === 0) return t;
-      const redactedEnv: Record<string, string> = {};
-      for (const key of Object.keys(t.env)) {
-        redactedEnv[key] = "";
-      }
-      return { ...t, env: redactedEnv };
-    });
-    const payload = { ...shareable, terminals: sanitizedTerminals };
+    const payloadString = buildInRepoRecipePayloadString(recipe);
 
     const attemptWrite = async (ensureDir: boolean): Promise<void> => {
       if (ensureDir) {
         await fs.mkdir(recipesDir, { recursive: true });
       }
-      await resilientAtomicWriteFile(filePath, JSON.stringify(payload, null, 2) + "\n", "utf-8");
+      await resilientAtomicWriteFile(filePath, payloadString, "utf-8");
     };
 
     try {
@@ -256,19 +282,53 @@ export class ProjectIdentityFiles {
       if (!isEnoent) throw error;
       await attemptWrite(true);
     }
+    return hashRecipePayload(payloadString);
+  }
+
+  /**
+   * Reads the raw on-disk bytes for `recipe`'s filename and returns the
+   * SHA-256 hash, or `null` if the file does not exist. The hash compares
+   * directly against the value returned by {@link writeInRepoRecipe} and the
+   * `hashes` map populated by {@link readInRepoRecipes}.
+   */
+  async getInRepoRecipeFileHash(projectPath: string, recipeName: string): Promise<string | null> {
+    const filePath = path.join(projectPath, DAINTREE_RECIPES_DIR, safeRecipeFilename(recipeName));
+    try {
+      const content = await fs.readFile(filePath, "utf-8");
+      return hashRecipePayload(content);
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
+      throw error;
+    }
   }
 
   async readInRepoRecipes(projectPath: string): Promise<TerminalRecipe[]> {
+    const { recipes } = await this.readInRepoRecipesWithHashes(projectPath);
+    return recipes;
+  }
+
+  /**
+   * Same as {@link readInRepoRecipes} but also returns a `Map<recipeId, hash>`
+   * of the raw on-disk bytes that were read. The hash is computed against the
+   * exact bytes (`fs.readFile` UTF-8 result), so it matches what
+   * {@link writeInRepoRecipe} and {@link getInRepoRecipeFileHash} produce when
+   * the file is untouched.
+   */
+  async readInRepoRecipesWithHashes(
+    projectPath: string
+  ): Promise<{ recipes: TerminalRecipe[]; hashes: Map<string, string> }> {
     const recipesDir = path.join(projectPath, DAINTREE_RECIPES_DIR);
     let entries;
     try {
       entries = await fs.readdir(recipesDir, { withFileTypes: true });
     } catch (error) {
-      if (error instanceof Error && "code" in error && error.code === "ENOENT") return [];
+      if (error instanceof Error && "code" in error && error.code === "ENOENT")
+        return { recipes: [], hashes: new Map() };
       throw error;
     }
 
     const recipes: TerminalRecipe[] = [];
+    const hashes = new Map<string, string>();
     for (const entry of entries) {
       if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
       try {
@@ -293,11 +353,12 @@ export class ProjectIdentityFiles {
           continue;
         }
         recipes.push(result.data);
+        hashes.set(result.data.id, hashRecipePayload(content));
       } catch (error) {
         console.warn(`[ProjectIdentityFiles] Skipping malformed recipe file: ${entry.name}`, error);
       }
     }
-    return recipes;
+    return { recipes, hashes };
   }
 
   /**

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -37,6 +37,7 @@ import {
   cleanupUserDataRootQuarantineFiles,
 } from "./projectQuarantineCleanup.js";
 import { safeRecipeFilename } from "../utils/recipeFilename.js";
+import { stableInRepoId } from "../../shared/utils/recipeFilename.js";
 
 import { computeFrecencyScore, FRECENCY_COLD_START } from "./frecency.js";
 import { getWritesSuppressed } from "./diskPressureState.js";
@@ -148,8 +149,14 @@ export class ProjectStore {
    * the renderer can surface a conflict dialog instead of silently clobbering
    * newer disk content (#9186).
    *
-   * `options.force === true` skips the comparison and updates the cached hash
-   * after the write — the renderer uses this for the explicit "Overwrite" path.
+   * On a rename, the `previousName` file is also checked — without that, a
+   * `Foo` → `Bar` rename would write `bar.json` (passes because the new file
+   * doesn't exist yet) and then delete an externally-modified `foo.json`,
+   * silently dropping the disk edits.
+   *
+   * `options.force === true` skips both comparisons and updates the cached
+   * hash after the write — the renderer uses this for the explicit
+   * "Overwrite" path.
    *
    * Brand-new recipes (file does not exist) are allowed unconditionally so
    * `createRecipe` / `importRecipe` paths work without a special-case flag.
@@ -160,24 +167,42 @@ export class ProjectStore {
   async writeInRepoRecipeChecked(
     projectPath: string,
     recipe: TerminalRecipe,
-    options: { force?: boolean } = {}
+    options: { force?: boolean; previousName?: string } = {}
   ): Promise<void> {
     if (!options.force) {
-      const onDiskHash = await this.identityFiles.getInRepoRecipeFileHash(projectPath, recipe.name);
-      if (onDiskHash !== null) {
-        const cached = this.inRepoRecipeHashes.get(this.hashKey(projectPath, recipe.id));
-        if (cached === undefined || cached !== onDiskHash) {
-          throw new AppError({
-            code: "RECIPE_STALE_CONFLICT",
-            message: `Recipe '${recipe.name}' changed on disk since it was loaded`,
-            userMessage: recipe.name,
-            context: { recipeId: recipe.id, name: recipe.name },
-          });
-        }
+      await this.assertRecipeFileNotStale(projectPath, recipe.id, recipe.name);
+      if (
+        options.previousName &&
+        safeRecipeFilename(options.previousName) !== safeRecipeFilename(recipe.name)
+      ) {
+        // The rename will delete the old-name file; the user's load-time hash
+        // is what we cached under the old id, so compare it against the
+        // current on-disk bytes of the old-name file before letting the
+        // rename proceed.
+        const oldId = stableInRepoId(options.previousName);
+        await this.assertRecipeFileNotStale(projectPath, oldId, options.previousName);
       }
     }
     const hash = await this.identityFiles.writeInRepoRecipe(projectPath, recipe);
     this.inRepoRecipeHashes.set(this.hashKey(projectPath, recipe.id), hash);
+  }
+
+  private async assertRecipeFileNotStale(
+    projectPath: string,
+    recipeId: string,
+    recipeName: string
+  ): Promise<void> {
+    const onDiskHash = await this.identityFiles.getInRepoRecipeFileHash(projectPath, recipeName);
+    if (onDiskHash === null) return;
+    const cached = this.inRepoRecipeHashes.get(this.hashKey(projectPath, recipeId));
+    if (cached === undefined || cached !== onDiskHash) {
+      throw new AppError({
+        code: "RECIPE_STALE_CONFLICT",
+        message: `Recipe '${recipeName}' changed on disk since it was loaded`,
+        userMessage: recipeName,
+        context: { recipeId, name: recipeName },
+      });
+    }
   }
 
   async readInRepoRecipes(projectPath: string): Promise<TerminalRecipe[]> {

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -74,6 +74,13 @@ export class ProjectStore {
   private globalFileStore: GlobalFileStore;
   private identityFiles: ProjectIdentityFiles;
 
+  // SHA-256 of the raw on-disk bytes for each in-repo recipe, captured on
+  // every successful read/write. Used by `writeInRepoRecipeChecked` to refuse
+  // a write when an external tool (git pull, branch switch, stash pop) changed
+  // the file since the renderer loaded it. Keyed by `${projectPath}|${recipeId}`
+  // so the same recipe id in two different project clones stays separate.
+  private inRepoRecipeHashes = new Map<string, string>();
+
   constructor() {
     this.userDataDir = app.getPath("userData");
     this.projectsConfigDir = path.join(this.userDataDir, "projects");
@@ -119,16 +126,81 @@ export class ProjectStore {
     return this.identityFiles.writeInRepoSettings(projectPath, settings);
   }
 
+  private hashKey(projectPath: string, recipeId: string): string {
+    return `${projectPath}|${recipeId}`;
+  }
+
+  /**
+   * Unchecked write. Reserved for reconciliation paths that are authoritative
+   * by design (recipe promotion from ProjectFileStore, write-through on sync)
+   * and call sites that have already resolved any staleness conflict.
+   * Renderer-driven edits must go through {@link writeInRepoRecipeChecked}.
+   */
   async writeInRepoRecipe(projectPath: string, recipe: TerminalRecipe): Promise<void> {
-    return this.identityFiles.writeInRepoRecipe(projectPath, recipe);
+    const hash = await this.identityFiles.writeInRepoRecipe(projectPath, recipe);
+    this.inRepoRecipeHashes.set(this.hashKey(projectPath, recipe.id), hash);
+  }
+
+  /**
+   * Writes `recipe` to `.daintree/recipes/`, but first verifies the on-disk
+   * file hasn't drifted from the hash captured at load time. If it has, the
+   * write is refused with an `AppError({ code: "RECIPE_STALE_CONFLICT" })` so
+   * the renderer can surface a conflict dialog instead of silently clobbering
+   * newer disk content (#9186).
+   *
+   * `options.force === true` skips the comparison and updates the cached hash
+   * after the write — the renderer uses this for the explicit "Overwrite" path.
+   *
+   * Brand-new recipes (file does not exist) are allowed unconditionally so
+   * `createRecipe` / `importRecipe` paths work without a special-case flag.
+   * If the file exists on disk but no cached hash exists, the file was added
+   * externally between load and write — treat that as a stale conflict so the
+   * user reconciles explicitly.
+   */
+  async writeInRepoRecipeChecked(
+    projectPath: string,
+    recipe: TerminalRecipe,
+    options: { force?: boolean } = {}
+  ): Promise<void> {
+    if (!options.force) {
+      const onDiskHash = await this.identityFiles.getInRepoRecipeFileHash(projectPath, recipe.name);
+      if (onDiskHash !== null) {
+        const cached = this.inRepoRecipeHashes.get(this.hashKey(projectPath, recipe.id));
+        if (cached === undefined || cached !== onDiskHash) {
+          throw new AppError({
+            code: "RECIPE_STALE_CONFLICT",
+            message: `Recipe '${recipe.name}' changed on disk since it was loaded`,
+            userMessage: recipe.name,
+            context: { recipeId: recipe.id, name: recipe.name },
+          });
+        }
+      }
+    }
+    const hash = await this.identityFiles.writeInRepoRecipe(projectPath, recipe);
+    this.inRepoRecipeHashes.set(this.hashKey(projectPath, recipe.id), hash);
   }
 
   async readInRepoRecipes(projectPath: string): Promise<TerminalRecipe[]> {
-    return this.identityFiles.readInRepoRecipes(projectPath);
+    const { recipes, hashes } = await this.identityFiles.readInRepoRecipesWithHashes(projectPath);
+    // Replace this project's cached hashes with the freshly observed set so an
+    // externally deleted recipe doesn't leave a stale entry pointing at a hash
+    // for a file that no longer exists.
+    const prefix = `${projectPath}|`;
+    for (const key of this.inRepoRecipeHashes.keys()) {
+      if (key.startsWith(prefix)) this.inRepoRecipeHashes.delete(key);
+    }
+    for (const [recipeId, hash] of hashes) {
+      this.inRepoRecipeHashes.set(this.hashKey(projectPath, recipeId), hash);
+    }
+    return recipes;
   }
 
   async deleteInRepoRecipe(projectPath: string, recipeName: string): Promise<void> {
-    return this.identityFiles.deleteInRepoRecipe(projectPath, recipeName);
+    await this.identityFiles.deleteInRepoRecipe(projectPath, recipeName);
+    // Stale hash entries for the deleted file are harmless: a future write
+    // through `writeInRepoRecipeChecked` will see the file is missing and
+    // allow the write unconditionally, then refresh the cache. The cache is
+    // also fully repopulated on the next readInRepoRecipes call.
   }
 
   async readInRepoPresets(projectPath: string): Promise<Record<string, AgentPreset[]>> {
@@ -675,7 +747,11 @@ export class ProjectStore {
    * Idempotent: running twice produces no additional writes.
    */
   async reconcileProjectRecipes(projectPath: string, projectId: string): Promise<void> {
-    const inRepoRecipes = await this.identityFiles.readInRepoRecipes(projectPath);
+    // Go through the cache-aware wrapper so the hash map is populated as a
+    // side effect — otherwise the first renderer-driven edit after a project
+    // load races the unrelated `getInRepoRecipes` call to populate the cache
+    // and may see a phantom RECIPE_STALE_CONFLICT.
+    const inRepoRecipes = await this.readInRepoRecipes(projectPath);
     const fileStoreRecipes = await this.fileStore.getRecipes(projectId);
 
     const inRepoById = new Map(inRepoRecipes.map((r) => [r.id, r]));
@@ -701,7 +777,7 @@ export class ProjectStore {
         continue;
       }
 
-      await this.identityFiles.writeInRepoRecipe(projectPath, recipe);
+      await this.writeInRepoRecipe(projectPath, recipe);
       inRepoById.set(recipe.id, recipe);
       seenFilenames.set(filename, recipe.id);
       promoted = true;

--- a/electron/services/__tests__/ProjectStore.recipes.test.ts
+++ b/electron/services/__tests__/ProjectStore.recipes.test.ts
@@ -274,3 +274,113 @@ describe("ProjectStore recipe reconciliation", () => {
     expect(fs2[0]!.id).toBe(recipe.id);
   });
 });
+
+describe("ProjectStore.writeInRepoRecipeChecked (in-repo recipe staleness guard, #9186)", () => {
+  let tmpDir: string;
+  let projectPath: string;
+  let store: ProjectStore;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-recipe-check-"));
+    projectPath = path.join(tmpDir, "repo");
+    store = new ProjectStore();
+    (store as unknown as { projectsConfigDir: string }).projectsConfigDir = tmpDir;
+    await store.initialize();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("allows the write when the file does not exist (create path)", async () => {
+    const recipe = makeRecipe({ id: stableInRepoId("New"), name: "New" });
+    await expect(store.writeInRepoRecipeChecked(projectPath, recipe)).resolves.toBeUndefined();
+    const onDisk = await fs.readFile(
+      path.join(projectPath, ".daintree", "recipes", "new.json"),
+      "utf-8"
+    );
+    expect(JSON.parse(onDisk).name).toBe("New");
+  });
+
+  it("allows the write when the cached hash matches on-disk bytes", async () => {
+    const recipe = makeRecipe({ id: stableInRepoId("Stable"), name: "Stable" });
+    await store.writeInRepoRecipe(projectPath, recipe);
+
+    // Editing through the checked path should succeed because the cached
+    // hash matches what's on disk.
+    const updated = { ...recipe, terminals: [{ type: "terminal" as const, command: "echo new" }] };
+    await expect(store.writeInRepoRecipeChecked(projectPath, updated)).resolves.toBeUndefined();
+    const onDisk = await fs.readFile(
+      path.join(projectPath, ".daintree", "recipes", "stable.json"),
+      "utf-8"
+    );
+    expect(JSON.parse(onDisk).terminals[0].command).toBe("echo new");
+  });
+
+  it("throws RECIPE_STALE_CONFLICT when the file was changed externally", async () => {
+    const recipe = makeRecipe({ id: stableInRepoId("Drift"), name: "Drift" });
+    await store.writeInRepoRecipe(projectPath, recipe);
+
+    // Simulate an external change (git pull, branch switch, etc.).
+    const filePath = path.join(projectPath, ".daintree", "recipes", "drift.json");
+    const current = await fs.readFile(filePath, "utf-8");
+    await fs.writeFile(filePath, current.replace("Drift", "Drift!!"));
+
+    const updated = { ...recipe, terminals: [{ type: "terminal" as const, command: "mine" }] };
+    await expect(store.writeInRepoRecipeChecked(projectPath, updated)).rejects.toMatchObject({
+      code: "RECIPE_STALE_CONFLICT",
+    });
+    // On-disk content must be untouched after a rejected write.
+    expect(await fs.readFile(filePath, "utf-8")).toBe(current.replace("Drift", "Drift!!"));
+  });
+
+  it("force=true bypasses the staleness check and updates the cached hash", async () => {
+    const recipe = makeRecipe({ id: stableInRepoId("Forced"), name: "Forced" });
+    await store.writeInRepoRecipe(projectPath, recipe);
+
+    // External edit invalidates the cache.
+    const filePath = path.join(projectPath, ".daintree", "recipes", "forced.json");
+    const current = await fs.readFile(filePath, "utf-8");
+    await fs.writeFile(filePath, current.replace("Forced", "External Edit"));
+
+    const updated = {
+      ...recipe,
+      terminals: [{ type: "terminal" as const, command: "my own" }],
+    };
+    await expect(
+      store.writeInRepoRecipeChecked(projectPath, updated, { force: true })
+    ).resolves.toBeUndefined();
+    expect(JSON.parse(await fs.readFile(filePath, "utf-8")).terminals[0].command).toBe("my own");
+
+    // A follow-up checked write should now succeed because force-write
+    // refreshed the cache to match the new on-disk bytes.
+    const secondUpdate = {
+      ...recipe,
+      terminals: [{ type: "terminal" as const, command: "follow up" }],
+    };
+    await expect(
+      store.writeInRepoRecipeChecked(projectPath, secondUpdate)
+    ).resolves.toBeUndefined();
+  });
+
+  it("readInRepoRecipes populates the hash cache so a follow-up edit can proceed", async () => {
+    // Simulate an existing in-repo recipe written by a previous session.
+    const recipe = makeRecipe({ id: stableInRepoId("Loaded"), name: "Loaded" });
+    await store.writeInRepoRecipe(projectPath, recipe);
+
+    // A fresh store doesn't know about the file yet.
+    const fresh = new ProjectStore();
+    (fresh as unknown as { projectsConfigDir: string }).projectsConfigDir = tmpDir;
+    await fresh.initialize();
+
+    // Without loading first, a write would see the file exists but no cached
+    // hash → conflict.
+    await expect(fresh.writeInRepoRecipeChecked(projectPath, recipe)).rejects.toMatchObject({
+      code: "RECIPE_STALE_CONFLICT",
+    });
+
+    // After loading, the cache is populated and the same write succeeds.
+    await fresh.readInRepoRecipes(projectPath);
+    await expect(fresh.writeInRepoRecipeChecked(projectPath, recipe)).resolves.toBeUndefined();
+  });
+});

--- a/electron/services/__tests__/ProjectStore.recipes.test.ts
+++ b/electron/services/__tests__/ProjectStore.recipes.test.ts
@@ -363,6 +363,54 @@ describe("ProjectStore.writeInRepoRecipeChecked (in-repo recipe staleness guard,
     ).resolves.toBeUndefined();
   });
 
+  it("refuses a rename when the old-name file was externally modified", async () => {
+    const recipe = makeRecipe({ id: stableInRepoId("Old Name"), name: "Old Name" });
+    await store.writeInRepoRecipe(projectPath, recipe);
+
+    // External edit to the old file between load and rename.
+    const oldPath = path.join(projectPath, ".daintree", "recipes", "old-name.json");
+    const original = await fs.readFile(oldPath, "utf-8");
+    await fs.writeFile(oldPath, original.replace("Old Name", "External Old Name"));
+
+    const renamed = {
+      ...recipe,
+      id: stableInRepoId("New Name"),
+      name: "New Name",
+    };
+    await expect(
+      store.writeInRepoRecipeChecked(projectPath, renamed, { previousName: "Old Name" })
+    ).rejects.toMatchObject({ code: "RECIPE_STALE_CONFLICT" });
+
+    // New-name file must not be written, old-name file must be untouched.
+    const newPath = path.join(projectPath, ".daintree", "recipes", "new-name.json");
+    await expect(fs.access(newPath)).rejects.toThrow();
+    expect(await fs.readFile(oldPath, "utf-8")).toBe(
+      original.replace("Old Name", "External Old Name")
+    );
+  });
+
+  it("force=true allows a rename even when the old-name file was externally modified", async () => {
+    const recipe = makeRecipe({ id: stableInRepoId("Old Forced"), name: "Old Forced" });
+    await store.writeInRepoRecipe(projectPath, recipe);
+    const oldPath = path.join(projectPath, ".daintree", "recipes", "old-forced.json");
+    const original = await fs.readFile(oldPath, "utf-8");
+    await fs.writeFile(oldPath, original.replace("Old Forced", "External Edit"));
+
+    const renamed = {
+      ...recipe,
+      id: stableInRepoId("New Forced"),
+      name: "New Forced",
+    };
+    await expect(
+      store.writeInRepoRecipeChecked(projectPath, renamed, {
+        previousName: "Old Forced",
+        force: true,
+      })
+    ).resolves.toBeUndefined();
+    const newPath = path.join(projectPath, ".daintree", "recipes", "new-forced.json");
+    expect(JSON.parse(await fs.readFile(newPath, "utf-8")).name).toBe("New Forced");
+  });
+
   it("readInRepoRecipes populates the hash cache so a follow-up edit can proceed", async () => {
     // Simulate an existing in-repo recipe written by a previous session.
     const recipe = makeRecipe({ id: stableInRepoId("Loaded"), name: "Loaded" });

--- a/electron/services/__tests__/writeInRepoFiles.test.ts
+++ b/electron/services/__tests__/writeInRepoFiles.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs/promises";
 import path from "path";
 import os from "os";
+import { createHash } from "crypto";
 import type {
   ProjectSettings,
   ProjectTerminalSettings,
@@ -11,7 +12,11 @@ import {
   PROJECT_SETTINGS_SHAREABILITY,
   PROJECT_TERMINAL_SETTINGS_SHAREABILITY,
 } from "../../../shared/types/project.js";
-import { ProjectIdentityFiles } from "../ProjectIdentityFiles.js";
+import {
+  ProjectIdentityFiles,
+  buildInRepoRecipePayloadString,
+  hashRecipePayload,
+} from "../ProjectIdentityFiles.js";
 
 const DAINTREE_PROJECT_JSON = ".daintree/project.json";
 const DAINTREE_SETTINGS_JSON = ".daintree/settings.json";
@@ -471,6 +476,121 @@ describe("writeInRepoRecipe", () => {
     const filePath = path.join(tmpDir, DAINTREE_RECIPES_DIR, "same-name.json");
     const content = JSON.parse(await fs.readFile(filePath, "utf-8"));
     expect(content.id).toBe("recipe-2");
+  });
+
+  it("writeInRepoRecipe returns the SHA-256 hash of the bytes written", async () => {
+    const recipe = makeRecipe({ name: "Hashed" });
+    const returned = await identityFiles.writeInRepoRecipe(tmpDir, recipe);
+    const onDisk = await fs.readFile(
+      path.join(tmpDir, DAINTREE_RECIPES_DIR, "hashed.json"),
+      "utf-8"
+    );
+    expect(returned).toBe(createHash("sha256").update(onDisk, "utf-8").digest("hex"));
+  });
+
+  it("buildInRepoRecipePayloadString matches the bytes writeInRepoRecipe persists", async () => {
+    const recipe = makeRecipe({
+      name: "Payload Match",
+      terminals: [{ type: "terminal", env: { SECRET: "shh", OTHER: "x" } }],
+    });
+    await identityFiles.writeInRepoRecipe(tmpDir, recipe);
+    const onDisk = await fs.readFile(
+      path.join(tmpDir, DAINTREE_RECIPES_DIR, "payload-match.json"),
+      "utf-8"
+    );
+    expect(buildInRepoRecipePayloadString(recipe)).toBe(onDisk);
+    // Env values redacted in the payload string the writer uses internally.
+    expect(buildInRepoRecipePayloadString(recipe)).toContain('"SECRET": ""');
+  });
+
+  it("buildInRepoRecipePayloadString strips projectId and worktreeId", () => {
+    const recipe = makeRecipe({ projectId: "proj-1", worktreeId: "wt-1" });
+    const payload = buildInRepoRecipePayloadString(recipe);
+    expect(payload).not.toContain("proj-1");
+    expect(payload).not.toContain("wt-1");
+  });
+
+  it("hashRecipePayload is deterministic and produces a 64-char hex digest", () => {
+    const a = hashRecipePayload("hello");
+    const b = hashRecipePayload("hello");
+    const c = hashRecipePayload("hello!");
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+    expect(a).toMatch(/^[a-f0-9]{64}$/);
+  });
+});
+
+describe("getInRepoRecipeFileHash", () => {
+  let tmpDir: string;
+  let identityFiles: ProjectIdentityFiles;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-recipe-hash-test-"));
+    identityFiles = new ProjectIdentityFiles();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns null when the recipe file does not exist", async () => {
+    expect(await identityFiles.getInRepoRecipeFileHash(tmpDir, "Missing Recipe")).toBeNull();
+  });
+
+  it("returns the SHA-256 hash of the exact on-disk bytes", async () => {
+    await identityFiles.writeInRepoRecipe(tmpDir, makeRecipe({ name: "Hashed Recipe" }));
+    const onDisk = await fs.readFile(
+      path.join(tmpDir, DAINTREE_RECIPES_DIR, "hashed-recipe.json"),
+      "utf-8"
+    );
+    expect(await identityFiles.getInRepoRecipeFileHash(tmpDir, "Hashed Recipe")).toBe(
+      createHash("sha256").update(onDisk, "utf-8").digest("hex")
+    );
+  });
+
+  it("hash changes when the file is externally edited", async () => {
+    await identityFiles.writeInRepoRecipe(tmpDir, makeRecipe({ name: "Drift Recipe" }));
+    const before = await identityFiles.getInRepoRecipeFileHash(tmpDir, "Drift Recipe");
+    const filePath = path.join(tmpDir, DAINTREE_RECIPES_DIR, "drift-recipe.json");
+    const current = await fs.readFile(filePath, "utf-8");
+    await fs.writeFile(filePath, current.replace("Drift Recipe", "Drift Recipe Externally Edited"));
+    const after = await identityFiles.getInRepoRecipeFileHash(tmpDir, "Drift Recipe");
+    expect(after).not.toBe(before);
+  });
+});
+
+describe("readInRepoRecipesWithHashes", () => {
+  let tmpDir: string;
+  let identityFiles: ProjectIdentityFiles;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-recipe-readhash-test-"));
+    identityFiles = new ProjectIdentityFiles();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns hash matching the file bytes for each loaded recipe", async () => {
+    await identityFiles.writeInRepoRecipe(tmpDir, makeRecipe({ id: "r1", name: "First" }));
+    await identityFiles.writeInRepoRecipe(tmpDir, makeRecipe({ id: "r2", name: "Second" }));
+
+    const { recipes, hashes } = await identityFiles.readInRepoRecipesWithHashes(tmpDir);
+    expect(recipes).toHaveLength(2);
+    expect(hashes.size).toBe(2);
+    for (const recipe of recipes) {
+      const filename = recipe.name === "First" ? "first.json" : "second.json";
+      const onDisk = await fs.readFile(path.join(tmpDir, DAINTREE_RECIPES_DIR, filename), "utf-8");
+      const expected = createHash("sha256").update(onDisk, "utf-8").digest("hex");
+      expect(hashes.get(recipe.id)).toBe(expected);
+    }
+  });
+
+  it("returns empty recipes and empty hashes when the directory is missing", async () => {
+    const { recipes, hashes } = await identityFiles.readInRepoRecipesWithHashes(tmpDir);
+    expect(recipes).toEqual([]);
+    expect(hashes.size).toBe(0);
   });
 });
 

--- a/shared/types/appError.ts
+++ b/shared/types/appError.ts
@@ -21,4 +21,5 @@ export type AppErrorCode =
   | "PERMISSION"
   | "ARG_COUNT_EXCEEDED"
   | "PAYLOAD_TOO_LARGE"
+  | "RECIPE_STALE_CONFLICT"
   | "INTERNAL";

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -536,7 +536,8 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     updateInRepoRecipe(
       projectId: string,
       recipe: TerminalRecipe,
-      previousName?: string
+      previousName?: string,
+      options?: { force?: boolean }
     ): Promise<void>;
     deleteInRepoRecipe(projectId: string, recipeName: string): Promise<void>;
     getInRepoPresets(projectId: string): Promise<Record<string, AgentPreset[]>>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1391,7 +1391,14 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     result: void;
   };
   "project:update-inrepo-recipe": {
-    args: [payload: { projectId: string; recipe: TerminalRecipe; previousName?: string }];
+    args: [
+      payload: {
+        projectId: string;
+        recipe: TerminalRecipe;
+        previousName?: string;
+        force?: boolean;
+      },
+    ];
     result: void;
   };
   "project:delete-inrepo-recipe": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,7 @@ import {
   useAgentWaitingNudge,
   useFocusOnActivateIntent,
   useNotificationHistoryPruning,
+  useRecipeFocusReload,
   useUnloadCleanup,
   useHomeDir,
   usePerformanceMonitors,
@@ -269,6 +270,13 @@ const LazyGitPullRebaseConfirmDialog = lazy(() =>
   }))
 );
 
+function preloadRecipeConflictDialog() {
+  return import("./components/TerminalRecipe/RecipeConflictDialog");
+}
+const LazyRecipeConflictDialog = lazy(() =>
+  preloadRecipeConflictDialog().then((m) => ({ default: m.RecipeConflictDialog }))
+);
+
 function preloadCrashRecoveryDialog() {
   return import("./components/Recovery/CrashRecoveryDialog");
 }
@@ -327,6 +335,7 @@ function AppInner() {
   useGitHubRateLimit();
   useUnloadCleanup();
   useResourceProfile();
+  useRecipeFocusReload();
 
   useEffect(() => {
     window.__DAINTREE_E2E_ERROR_STORE__ = () =>
@@ -1306,6 +1315,18 @@ function AppInner() {
               >
                 <Suspense fallback={null}>
                   <LazyGitPullRebaseConfirmDialog />
+                </Suspense>
+              </ErrorBoundary>
+            )}
+
+            {isStateLoaded && (
+              <ErrorBoundary
+                variant="component"
+                componentName="RecipeConflictDialog"
+                resetKeys={[Number(isStateLoaded)]}
+              >
+                <Suspense fallback={null}>
+                  <LazyRecipeConflictDialog />
                 </Suspense>
               </ErrorBoundary>
             )}

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -296,9 +296,10 @@ export const projectClient = {
   updateInRepoRecipe: (
     projectId: string,
     recipe: TerminalRecipe,
-    previousName?: string
+    previousName?: string,
+    options?: { force?: boolean }
   ): Promise<void> => {
-    return window.electron.project.updateInRepoRecipe(projectId, recipe, previousName);
+    return window.electron.project.updateInRepoRecipe(projectId, recipe, previousName, options);
   },
 
   deleteInRepoRecipe: (projectId: string, recipeName: string): Promise<void> => {

--- a/src/components/Sidebar/useRecipeDialogState.ts
+++ b/src/components/Sidebar/useRecipeDialogState.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useRecipeStore } from "@/store/recipeStore";
+import { useRecipeEditorActivityStore } from "@/store/recipeEditorActivityStore";
 import type { RecipeTerminal } from "@/types";
 import type { TerminalRecipe } from "@/types";
 
@@ -30,6 +31,21 @@ function useRecipeDialogState(): UseRecipeDialogStateReturn {
   >(undefined);
   const [isRecipeManagerOpen, setIsRecipeManagerOpen] = useState(false);
   const [recipeManagerEdit, setRecipeManagerEdit] = useState<TerminalRecipe | undefined>(undefined);
+
+  // Mirror the open/close transitions of the two recipe surfaces into the
+  // shared activity store so the focus-reload hook can suppress its silent
+  // reload while the user is mid-edit (#9186).
+  useEffect(() => {
+    if (!isRecipeEditorOpen) return;
+    useRecipeEditorActivityStore.getState().enter();
+    return () => useRecipeEditorActivityStore.getState().leave();
+  }, [isRecipeEditorOpen]);
+
+  useEffect(() => {
+    if (!isRecipeManagerOpen) return;
+    useRecipeEditorActivityStore.getState().enter();
+    return () => useRecipeEditorActivityStore.getState().leave();
+  }, [isRecipeManagerOpen]);
 
   const handleOpenRecipeEditor = useCallback(
     (worktreeId: string, initialTerminals?: RecipeTerminal[]) => {

--- a/src/components/TerminalRecipe/RecipeConflictDialog.tsx
+++ b/src/components/TerminalRecipe/RecipeConflictDialog.tsx
@@ -54,7 +54,7 @@ function RecipeConflictDialogInner() {
             onClick={() => resolveConflict("overwrite")}
             data-testid="recipe-conflict-overwrite"
           >
-            Overwrite
+            Overwrite recipe
           </Button>
           <Button
             variant="default"

--- a/src/components/TerminalRecipe/RecipeConflictDialog.tsx
+++ b/src/components/TerminalRecipe/RecipeConflictDialog.tsx
@@ -1,0 +1,78 @@
+import { useEffect } from "react";
+import { AppDialog } from "@/components/ui/AppDialog";
+import { Button } from "@/components/ui/button";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { useRecipeConflictStore } from "@/store/recipeConflictStore";
+
+/**
+ * Stale-write conflict surface for in-repo recipes (#9186). When
+ * `.daintree/recipes/<name>.json` was changed externally (git pull, branch
+ * switch, stash pop) between load and save, the main process refuses the
+ * write with `RECIPE_STALE_CONFLICT` and `recipeStore.updateRecipe` parks
+ * the failed update here. The user picks:
+ *
+ * - "Reload from disk" — discard the in-flight edit, refresh state to match disk.
+ * - "Overwrite" — re-apply the edit with `force: true`, replacing newer disk content.
+ * - Dismiss (close button / Esc) — leave the rolled-back state; user can retry later.
+ *
+ * Tier D1 per CLAUDE.md: local irreversible, no typed-name gate. The destructive
+ * intent sits on Overwrite (in-memory edit beats disk); Reload is the safer
+ * default and gets primary placement.
+ */
+function RecipeConflictDialogInner() {
+  const pendingConflict = useRecipeConflictStore((s) => s.pendingConflict);
+  const resolveConflict = useRecipeConflictStore((s) => s.resolveConflict);
+
+  // Resolve as "cancel" on unmount so any awaited Promise in recipeStore
+  // releases instead of leaking when the renderer reloads mid-conflict.
+  useEffect(() => {
+    return () => {
+      if (useRecipeConflictStore.getState().pendingConflict) {
+        useRecipeConflictStore.getState().resolveConflict("cancel");
+      }
+    };
+  }, []);
+
+  if (!pendingConflict) return null;
+
+  return (
+    <AppDialog isOpen={true} onClose={() => resolveConflict("cancel")} size="sm">
+      <AppDialog.Header>
+        <AppDialog.Title>{`Recipe '${pendingConflict.recipeName}' changed on disk`}</AppDialog.Title>
+        <AppDialog.CloseButton />
+      </AppDialog.Header>
+      <AppDialog.Body className="space-y-3">
+        <AppDialog.Description>
+          Another tool changed this recipe's file since it was loaded — usually a git pull, branch
+          switch, or stash pop. Your unsaved edit hasn't been written. Choose how to reconcile.
+        </AppDialog.Description>
+      </AppDialog.Body>
+      <AppDialog.Footer>
+        <div className="flex items-center gap-3">
+          <Button
+            variant="destructive"
+            onClick={() => resolveConflict("overwrite")}
+            data-testid="recipe-conflict-overwrite"
+          >
+            Overwrite
+          </Button>
+          <Button
+            variant="default"
+            onClick={() => resolveConflict("reload")}
+            data-testid="recipe-conflict-reload"
+          >
+            Reload from disk
+          </Button>
+        </div>
+      </AppDialog.Footer>
+    </AppDialog>
+  );
+}
+
+export function RecipeConflictDialog() {
+  return (
+    <ErrorBoundary variant="component" componentName="RecipeConflictDialog">
+      <RecipeConflictDialogInner />
+    </ErrorBoundary>
+  );
+}

--- a/src/hooks/app/__tests__/useRecipeFocusReload.test.ts
+++ b/src/hooks/app/__tests__/useRecipeFocusReload.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { readFile } from "fs/promises";
+import { resolve } from "path";
+
+const HOOK_PATH = resolve(__dirname, "../useRecipeFocusReload.ts");
+
+describe("useRecipeFocusReload editor-open guard (#9186)", () => {
+  it("imports the editor-activity store", async () => {
+    const content = await readFile(HOOK_PATH, "utf-8");
+    expect(content).toContain(
+      'import { useRecipeEditorActivityStore } from "@/store/recipeEditorActivityStore"'
+    );
+  });
+
+  it("short-circuits the trigger when an editor surface is open", async () => {
+    const content = await readFile(HOOK_PATH, "utf-8");
+    expect(content).toContain("useRecipeEditorActivityStore.getState().isOpen()");
+  });
+
+  it("registers both focus and visibilitychange listeners", async () => {
+    const content = await readFile(HOOK_PATH, "utf-8");
+    expect(content).toContain('window.addEventListener("focus"');
+    expect(content).toContain('document.addEventListener("visibilitychange"');
+  });
+
+  it("uses fire-and-forget for loadRecipes (no await)", async () => {
+    const content = await readFile(HOOK_PATH, "utf-8");
+    expect(content).toContain("void useRecipeStore.getState().loadRecipes(projectId)");
+  });
+});

--- a/src/hooks/app/index.ts
+++ b/src/hooks/app/index.ts
@@ -21,3 +21,4 @@ export { useOrchestrationMilestones } from "./useOrchestrationMilestones";
 export { useAgentWaitingNudge } from "./useAgentWaitingNudge";
 export { useFocusOnActivateIntent } from "./useFocusOnActivateIntent";
 export { useNotificationHistoryPruning } from "./useNotificationHistoryPruning";
+export { useRecipeFocusReload } from "./useRecipeFocusReload";

--- a/src/hooks/app/useRecipeFocusReload.ts
+++ b/src/hooks/app/useRecipeFocusReload.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from "react";
+import { useRecipeStore } from "@/store/recipeStore";
+
+const FOCUS_REFRESH_DEDUPE_MS = 500;
+
+/**
+ * Refreshes in-repo recipes when the window regains focus or becomes visible
+ * (#9186). Without this, `.daintree/recipes/*.json` only loads at project
+ * switch — so a `git pull` or branch switch in another terminal leaves the
+ * app's in-memory state stale and the next save hits the staleness gate. A
+ * window-focus reload bypasses the conflict for the common path where the
+ * user wants the on-disk version anyway.
+ *
+ * Pattern mirrors `ProjectPulseCard.tsx` focus refresh: pair the bare `focus`
+ * event with `visibilitychange` (the more reliable signal when the OS sends
+ * a focus event for a window that's not actually visible) and dedupe with a
+ * short ref-tracked window so alt-tab spam doesn't fan out into multiple
+ * loads. Fire-and-forget by design — `loadRecipesRequestId` inside the store
+ * already protects against concurrent loads (#4852).
+ */
+export function useRecipeFocusReload(): void {
+  const lastFiredRef = useRef(0);
+
+  useEffect(() => {
+    const trigger = () => {
+      if (typeof document !== "undefined" && document.hidden) return;
+      const now = Date.now();
+      if (now - lastFiredRef.current < FOCUS_REFRESH_DEDUPE_MS) return;
+      lastFiredRef.current = now;
+      const projectId = useRecipeStore.getState().currentProjectId;
+      if (!projectId) return;
+      void useRecipeStore.getState().loadRecipes(projectId);
+    };
+
+    const handleFocus = () => trigger();
+    const handleVisibility = () => {
+      if (!document.hidden) trigger();
+    };
+
+    window.addEventListener("focus", handleFocus);
+    document.addEventListener("visibilitychange", handleVisibility);
+    return () => {
+      window.removeEventListener("focus", handleFocus);
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
+  }, []);
+}

--- a/src/hooks/app/useRecipeFocusReload.ts
+++ b/src/hooks/app/useRecipeFocusReload.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { useRecipeStore } from "@/store/recipeStore";
+import { useRecipeEditorActivityStore } from "@/store/recipeEditorActivityStore";
 
 const FOCUS_REFRESH_DEDUPE_MS = 500;
 
@@ -10,6 +11,12 @@ const FOCUS_REFRESH_DEDUPE_MS = 500;
  * app's in-memory state stale and the next save hits the staleness gate. A
  * window-focus reload bypasses the conflict for the common path where the
  * user wants the on-disk version anyway.
+ *
+ * Skips when a recipe editor or manager is open: a silent reload while the
+ * user is mid-edit would let an old form snapshot save over freshly-loaded
+ * disk content without tripping the write-time stale check (the cache would
+ * already match disk). With an editor open we let the explicit save-time
+ * guard surface the conflict dialog instead.
  *
  * Pattern mirrors `ProjectPulseCard.tsx` focus refresh: pair the bare `focus`
  * event with `visibilitychange` (the more reliable signal when the OS sends
@@ -24,6 +31,7 @@ export function useRecipeFocusReload(): void {
   useEffect(() => {
     const trigger = () => {
       if (typeof document !== "undefined" && document.hidden) return;
+      if (useRecipeEditorActivityStore.getState().isOpen()) return;
       const now = Date.now();
       if (now - lastFiredRef.current < FOCUS_REFRESH_DEDUPE_MS) return;
       lastFiredRef.current = now;

--- a/src/store/__tests__/recipeEditorActivityStore.test.ts
+++ b/src/store/__tests__/recipeEditorActivityStore.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useRecipeEditorActivityStore } from "../recipeEditorActivityStore";
+
+describe("recipeEditorActivityStore (#9186)", () => {
+  beforeEach(() => {
+    useRecipeEditorActivityStore.setState({ openCount: 0 });
+  });
+
+  it("isOpen is false by default", () => {
+    expect(useRecipeEditorActivityStore.getState().isOpen()).toBe(false);
+  });
+
+  it("enter/leave flip isOpen", () => {
+    useRecipeEditorActivityStore.getState().enter();
+    expect(useRecipeEditorActivityStore.getState().isOpen()).toBe(true);
+    useRecipeEditorActivityStore.getState().leave();
+    expect(useRecipeEditorActivityStore.getState().isOpen()).toBe(false);
+  });
+
+  it("nested enter calls require matching leave calls to release", () => {
+    useRecipeEditorActivityStore.getState().enter();
+    useRecipeEditorActivityStore.getState().enter();
+    expect(useRecipeEditorActivityStore.getState().isOpen()).toBe(true);
+    useRecipeEditorActivityStore.getState().leave();
+    expect(useRecipeEditorActivityStore.getState().isOpen()).toBe(true);
+    useRecipeEditorActivityStore.getState().leave();
+    expect(useRecipeEditorActivityStore.getState().isOpen()).toBe(false);
+  });
+
+  it("leave never drives the counter negative", () => {
+    useRecipeEditorActivityStore.getState().leave();
+    useRecipeEditorActivityStore.getState().leave();
+    useRecipeEditorActivityStore.getState().leave();
+    expect(useRecipeEditorActivityStore.getState().openCount).toBe(0);
+  });
+});

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -1215,6 +1215,115 @@ describe("recipeStore", () => {
       expect(state.recipes).toHaveLength(1);
     });
 
+    describe("RECIPE_STALE_CONFLICT handling (#9186)", () => {
+      function makeConflictError(name: string) {
+        // Mirror the `[AppError|<code>|<urlencoded userMessage>] <message>`
+        // shape the preload injects on AppError throws so `isClientAppError`
+        // recognizes the encoded prefix.
+        const userMsg = encodeURIComponent(name);
+        const err = new Error(
+          `[AppError|RECIPE_STALE_CONFLICT|${userMsg}] Recipe '${name}' changed on disk`
+        );
+        err.name = "Error";
+        return err;
+      }
+
+      async function importConflictStore() {
+        // Loaded lazily to avoid initialization order coupling with the
+        // hoisted client mocks above.
+        const mod = await import("../recipeConflictStore");
+        mod.useRecipeConflictStore.setState({ pendingConflict: null });
+        return mod.useRecipeConflictStore;
+      }
+
+      const inRepoRecipe = {
+        id: "inrepo-test",
+        name: "Conflict Recipe",
+        terminals: [{ type: "terminal" as const, title: "Shell", env: {} }],
+        createdAt: 500,
+      };
+
+      function seedStore() {
+        useRecipeStore.setState({
+          inRepoRecipes: [inRepoRecipe],
+          globalRecipes: [],
+          projectRecipes: [],
+          recipes: [inRepoRecipe],
+          currentProjectId: "project-1",
+        });
+      }
+
+      it("surfaces a pending conflict on the conflict store, rolls back, and does not throw", async () => {
+        seedStore();
+        const store = await importConflictStore();
+        updateInRepoRecipeMock.mockRejectedValueOnce(makeConflictError("Conflict Recipe"));
+
+        const promise = useRecipeStore
+          .getState()
+          .updateRecipe("inrepo-test", { name: "Conflict Recipe", lastUsedAt: 1 });
+
+        // Yield so the catch enqueues the conflict before we read it.
+        await Promise.resolve();
+        await Promise.resolve();
+        const pending = store.getState().pendingConflict;
+        expect(pending).not.toBeNull();
+        expect(pending?.recipeId).toBe("inrepo-test");
+        expect(pending?.recipeName).toBe("Conflict Recipe");
+
+        // Resolve as cancel — the updateRecipe call should settle without throwing.
+        store.getState().resolveConflict("cancel");
+        await expect(promise).resolves.toBeUndefined();
+
+        // State rolled back to pre-edit snapshot.
+        const state = useRecipeStore.getState();
+        expect(state.inRepoRecipes[0]?.name).toBe("Conflict Recipe");
+      });
+
+      it("'reload' resolution triggers loadRecipes and does not rethrow", async () => {
+        seedStore();
+        const store = await importConflictStore();
+        updateInRepoRecipeMock.mockRejectedValueOnce(makeConflictError("Conflict Recipe"));
+        globalGetRecipesMock.mockResolvedValueOnce([]);
+        getRecipesMock.mockResolvedValueOnce([]);
+        getInRepoRecipesMock.mockResolvedValueOnce([{ ...inRepoRecipe, name: "Disk Version" }]);
+
+        const promise = useRecipeStore.getState().updateRecipe("inrepo-test", { name: "Mine" });
+        await Promise.resolve();
+        await Promise.resolve();
+        store.getState().resolveConflict("reload");
+        await expect(promise).resolves.toBeUndefined();
+        // Wait one more tick for the fire-and-forget loadRecipes to settle.
+        await new Promise((r) => setTimeout(r, 0));
+        expect(getInRepoRecipesMock).toHaveBeenCalled();
+      });
+
+      it("'overwrite' resolution retries the IPC call with force:true and re-applies the edit", async () => {
+        seedStore();
+        const store = await importConflictStore();
+        updateInRepoRecipeMock.mockRejectedValueOnce(makeConflictError("Conflict Recipe"));
+        updateInRepoRecipeMock.mockResolvedValueOnce(undefined);
+
+        const promise = useRecipeStore
+          .getState()
+          .updateRecipe("inrepo-test", { name: "Forced Name" });
+        await Promise.resolve();
+        await Promise.resolve();
+        store.getState().resolveConflict("overwrite");
+        await expect(promise).resolves.toBeUndefined();
+
+        expect(updateInRepoRecipeMock).toHaveBeenCalledTimes(2);
+        // Second call carries force:true and the previous-name (for rename support).
+        const secondCall = updateInRepoRecipeMock.mock.calls[1];
+        expect(secondCall?.[3]).toEqual({ force: true });
+        expect(secondCall?.[2]).toBe("Conflict Recipe");
+
+        // Optimistic edit landed back in state after the forced write.
+        const state = useRecipeStore.getState();
+        // After rename the recipe id is regenerated from the new name.
+        expect(state.inRepoRecipes[0]?.name).toBe("Forced Name");
+      });
+    });
+
     it("updateRecipe rolls back inRepoRecipes on failure", async () => {
       const inRepoRecipe = {
         id: "inrepo-test",

--- a/src/store/recipeConflictStore.ts
+++ b/src/store/recipeConflictStore.ts
@@ -1,0 +1,54 @@
+import { create } from "zustand";
+import type { TerminalRecipe } from "@/types";
+
+/**
+ * Deferred-promise gate for the in-repo recipe stale-write conflict surface
+ * (#9186). The IPC handler refuses a write when `.daintree/recipes/{name}.json`
+ * changed externally since load — it throws `RECIPE_STALE_CONFLICT`, the
+ * `recipeStore.updateRecipe` catch rolls back optimistic state and routes the
+ * decision here. The `RecipeConflictDialog` (mounted at the app level) reads
+ * `pendingConflict`, surfaces the user's choice via `resolveConflict`.
+ *
+ * Mirrors `gitPushConfirmStore` / `panelLimitStore`: a second request while
+ * one is pending resolves the first as `"cancel"` to release any awaiter.
+ */
+
+export type RecipeConflictResolution = "reload" | "overwrite" | "cancel";
+
+export interface RecipeConflictRequest {
+  recipeId: string;
+  recipeName: string;
+  updates: Partial<Omit<TerminalRecipe, "id" | "projectId" | "createdAt">>;
+  /** Original name when the failed save was a rename — passed back to the retry. */
+  previousName?: string;
+}
+
+interface PendingRecipeConflict extends RecipeConflictRequest {
+  resolve: (action: RecipeConflictResolution) => void;
+}
+
+interface RecipeConflictState {
+  pendingConflict: PendingRecipeConflict | null;
+  requestConflict: (request: RecipeConflictRequest) => Promise<RecipeConflictResolution>;
+  resolveConflict: (action: RecipeConflictResolution) => void;
+}
+
+export const useRecipeConflictStore = create<RecipeConflictState>()((set, get) => ({
+  pendingConflict: null,
+
+  requestConflict: (request) => {
+    const existing = get().pendingConflict;
+    if (existing) existing.resolve("cancel");
+    return new Promise<RecipeConflictResolution>((resolve) => {
+      set({ pendingConflict: { ...request, resolve } });
+    });
+  },
+
+  resolveConflict: (action) => {
+    const pending = get().pendingConflict;
+    if (pending) {
+      pending.resolve(action);
+      set({ pendingConflict: null });
+    }
+  },
+}));

--- a/src/store/recipeEditorActivityStore.ts
+++ b/src/store/recipeEditorActivityStore.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+
+/**
+ * Tracks whether any recipe editor surface is currently open (#9186). The
+ * focus-reload hook reads this so it doesn't repopulate the main-process
+ * hash cache while the user is mid-edit — if it did, the editor's frozen
+ * form snapshot could save over the freshly-loaded disk version without
+ * tripping the staleness gate. With an editor open we let the existing
+ * write-time `writeInRepoRecipeChecked` surface the conflict at Save instead.
+ *
+ * Counter-based (not boolean) so nested or overlapping editor surfaces
+ * (recipe editor + manager simultaneously) all release the lock cleanly.
+ */
+interface RecipeEditorActivityState {
+  openCount: number;
+  isOpen: () => boolean;
+  enter: () => void;
+  leave: () => void;
+}
+
+export const useRecipeEditorActivityStore = create<RecipeEditorActivityState>()((set, get) => ({
+  openCount: 0,
+  isOpen: () => get().openCount > 0,
+  enter: () => set((s) => ({ openCount: s.openCount + 1 })),
+  leave: () => set((s) => ({ openCount: Math.max(0, s.openCount - 1) })),
+}));

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -16,6 +16,8 @@ import type { TerminalSpawnSource, AddPanelFocusPolicy } from "@shared/types/pan
 import { stableInRepoId, isInRepoRecipeId } from "@shared/utils/recipeFilename";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { logError } from "@/utils/logger";
+import { isClientAppError } from "@/utils/clientAppError";
+import { useRecipeConflictStore } from "@/store/recipeConflictStore";
 
 export interface RecipeSpawnResult {
   index: number;
@@ -378,13 +380,56 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
         await projectClient.updateRecipe(recipe.projectId!, id, sanitizedUpdates);
       }
     } catch (error) {
-      logError("Failed to persist recipe update", error);
+      // Always roll back the optimistic state first so the in-memory recipes
+      // match the rejected write. The conflict path then surfaces a dialog;
+      // all other errors propagate so callers can show a toast.
       set({
         globalRecipes: prevGlobal,
         projectRecipes: prevProject,
         inRepoRecipes: prevInRepo,
         recipes: mergeRecipes(prevGlobal, prevProject, prevInRepo),
       });
+      if (isInRepo && isClientAppError(error) && error.code === "RECIPE_STALE_CONFLICT") {
+        const projectId = get().currentProjectId;
+        const previousName = updates.name && updates.name !== recipe.name ? recipe.name : undefined;
+        const resolution = await useRecipeConflictStore.getState().requestConflict({
+          recipeId: id,
+          recipeName: updatedRecipe.name,
+          updates: sanitizedUpdates,
+          previousName,
+        });
+        if (resolution === "reload" && projectId) {
+          void get().loadRecipes(projectId);
+          return;
+        }
+        if (resolution === "overwrite" && projectId) {
+          try {
+            await projectClient.updateInRepoRecipe(projectId, updatedRecipe, previousName, {
+              force: true,
+            });
+            // Re-apply the optimistic state since the rollback above wiped it
+            // and the forced write succeeded.
+            const refreshedInRepo = applyUpdate(get().inRepoRecipes);
+            const refreshedProject = isInRepo
+              ? applyUpdate(get().projectRecipes)
+              : get().projectRecipes;
+            set({
+              inRepoRecipes: refreshedInRepo,
+              projectRecipes: refreshedProject,
+              recipes: mergeRecipes(get().globalRecipes, refreshedProject, refreshedInRepo),
+            });
+            return;
+          } catch (retryError) {
+            logError("Failed to overwrite recipe after conflict", retryError);
+            throw retryError;
+          }
+        }
+        // Cancel / dismissed: leave the rolled-back state in place. The user
+        // can re-attempt the edit; the focus-reload hook (or a manual reload)
+        // brings the in-memory state back in sync with disk.
+        return;
+      }
+      logError("Failed to persist recipe update", error);
       throw error;
     }
   },


### PR DESCRIPTION
## Summary

- In-repo recipes (`.daintree/recipes/*.json`) were loaded once and never re-read, with no staleness check on the write path. A `git pull` or branch switch could change a file on disk, and the next edit would silently overwrite the newer content.
- Adds a content-hash guard to `writeInRepoRecipeChecked` in `ProjectStore.ts`. If the on-disk hash differs from the cached hash, the write throws `RECIPE_STALE_CONFLICT`. The renderer catches it in `useRecipeDialogState.ts` and routes to `RecipeConflictDialog.tsx` where the user can reload or overwrite.
- Adds a `useRecipeFocusReload` hook that re-reads in-repo recipes on window focus, so most git-pull collisions reconcile automatically before the user even opens a recipe.

Resolves #9186

## Changes

- `electron/services/ProjectStore.ts` — `writeInRepoRecipeChecked` with hash guard; `readInRepoRecipes` populates the hash cache; `deleteInRepoRecipe` clears stale entries
- `electron/services/ProjectIdentityFiles.ts` — `getInRepoRecipeFileHash` and `readInRepoRecipesWithHashes` to support cache population
- `electron/ipc/handlers/projectRecipes.ts` — passes `force` flag through to `writeInRepoRecipeChecked`
- `shared/types/appError.ts` / `shared/types/ipc/*` — `RECIPE_STALE_CONFLICT` error code and `updateInRepoRecipe` force flag
- `src/store/recipeConflictStore.ts` — Zustand store driving the conflict dialog
- `src/store/recipeEditorActivityStore.ts` — tracks open editor sessions so focus-reload skips recipes currently being edited
- `src/store/recipeStore.ts` — handles `RECIPE_STALE_CONFLICT`, rolls back optimistic state, opens conflict dialog
- `src/components/TerminalRecipe/RecipeConflictDialog.tsx` — reload / overwrite conflict resolution dialog
- `src/hooks/app/useRecipeFocusReload.ts` — focus-triggered reload hook, wired in `App.tsx`
- `src/components/Sidebar/useRecipeDialogState.ts` — catches the stale conflict and routes to the conflict store

## Testing

- Unit tests in `electron/services/__tests__/writeInRepoFiles.test.ts` and `electron/services/__tests__/ProjectStore.recipes.test.ts` cover the hash guard, force-write path, rename staleness check, and cache invalidation on delete
- `src/store/__tests__/recipeStore.test.ts` covers optimistic rollback and conflict store wiring on `RECIPE_STALE_CONFLICT`
- `src/store/__tests__/recipeEditorActivityStore.test.ts` covers editor-open tracking
- `src/hooks/app/__tests__/useRecipeFocusReload.test.ts` covers the focus-reload hook