### PR TITLE
feat(plugins): implement host.settings API

### DIFF
--- a/docs/plugins/contribution-points.md
+++ b/docs/plugins/contribution-points.md
@@ -229,28 +229,23 @@ Keybindings map a key combination to an action.
 
 Conflicts with user overrides or other plugins' bindings are resolved by Daintree's existing keybinding service — plugin bindings are low-priority and yield to user overrides. See `src/services/KeybindingService.ts:325` for the registration API.
 
-## Settings schema — _Planned_
+## Settings schema
 
-> Not yet present in the manifest schema. Documented here as a design preview; the shape is not yet locked.
-
-Declares user-configurable settings for your plugin.
+Declares the setting keys your plugin may persist. `host.settings.set()` rejects any key not listed here; `get()` and `onDidChange()` accept any key.
 
 ```json
 {
   "contributes": {
     "settings": [
       {
-        "id": "linear.apiToken",
-        "type": "secret",
-        "scope": "user",
-        "title": "Linear API Token",
-        "description": "Personal API token from linear.app/settings/api"
+        "key": "apiToken",
+        "type": "string",
+        "description": "Personal API token from linear.app/settings/api",
+        "secret": true
       },
       {
-        "id": "linear.defaultTeam",
+        "key": "defaultTeam",
         "type": "string",
-        "scope": "project",
-        "title": "Default team",
         "description": "Team slug to use when opening a new planning session",
         "default": ""
       }
@@ -259,17 +254,24 @@ Declares user-configurable settings for your plugin.
 }
 ```
 
-**Field types:** `string`, `number`, `boolean`, `secret`, `enum`, `json`.
+| Field | Required | Notes |
+| --- | --- | --- |
+| `key` | yes | Setting identifier. Must start with a letter (`[a-zA-Z][a-zA-Z0-9._-]*`, ≤ 128). |
+| `type` | yes | One of `string`, `number`, `boolean`, `object`, `array`. Advisory (for UI forms). |
+| `description` | no | Human-readable description. |
+| `default` | no | Default value. |
+| `secret` | no | Marks the value as sensitive. **Advisory only** — see the storage note below. |
 
-**Scopes:** `user` (global, persisted in Daintree config), `project` (per-project, persisted with project state).
+**Scope** is chosen per call, not per declaration: `host.settings.get/set/onDidChange` take an optional `{ scope }` of `"user"` (default) or `"project"`. User settings persist to `~/.daintree/plugin-settings/{pluginId}.json`; project settings to `<projectRoot>/.daintree/plugin-settings/{pluginId}.json` for the active project.
 
-Settings appear in Preferences → Plugins → `{pluginId}` as a generated form. Values are read via the host API:
+**Storage:** plaintext JSON, written with `0o600` permissions on macOS/Linux. There is no OS keychain — the `secret` flag is advisory (it lets the UI warn the user); the host does not encrypt secret values. Values are read and written via the host API:
 
 ```ts
-const token = await host.settings.get<string>("linear.apiToken");
+const token = await host.settings.get<string>("apiToken");
+await host.settings.set("defaultTeam", "engineering");
 ```
 
-Changes fire a subscription callback, so you don't need to reactivate to pick them up.
+In-process writes fire `onDidChange` subscriptions for the same key and scope, so you don't need to reactivate to pick them up. See [Host API → settings](./host-api.md#settings) for the full reference.
 
 ## Context menus — _Planned_
 

--- a/docs/plugins/host-api.md
+++ b/docs/plugins/host-api.md
@@ -46,7 +46,7 @@ interface PluginHostApi {
   ): () => void;
   onDidChangeWorktrees(callback: (snapshots: PluginWorktreeSnapshot[]) => void): () => void;
 
-  // Settings (planned)
+  // Settings
   settings: SettingsApi;
 
   // UI helpers
@@ -208,26 +208,43 @@ const dispose = host.registerForgeProvider({ id: "linear", name: "Linear" }, imp
 
 For the end-to-end walkthrough — manifest entry, implementing `ForgeProviderImpl`, state normalization, capabilities, and tests — see [Implementing a forge provider](./forge-provider.md).
 
-## `settings` — _Planned_
+## `settings`
 
-Reads and subscribes to plugin-declared settings.
+Reads, writes, and subscribes to plugin-declared settings.
 
 ```ts
-// Current value
-const token = await host.settings.get<string>("linear.apiToken");
+// Read the current value (user scope by default)
+const token = await host.settings.get<string>("apiToken");
 
-// Update (user scope usually not writable from plugin code)
-await host.settings.set("linear.defaultTeam", "engineering");
+// Write a value — the key must be declared in contributes.settings
+await host.settings.set("defaultTeam", "engineering");
 
-// Subscribe to changes
-const dispose = host.settings.onDidChange("linear.apiToken", (newValue) => {
+// Project scope
+await host.settings.set("defaultTeam", "platform", { scope: "project" });
+
+// Subscribe to in-process changes
+const dispose = host.settings.onDidChange<string>("apiToken", (newValue) => {
   reconnect(newValue);
 });
 ```
 
-Scope resolution: `project` scope reads from the active project's config; if no project is active, returns undefined. `user` scope reads from Daintree's global config.
+**Declaration:** every key a plugin writes must be declared in `contributes.settings`:
 
-Secret-type settings are stored in the OS keychain via `keytar`. They're returned from `get()` transparently but never logged or included in error reports.
+```json
+{
+  "contributes": {
+    "settings": [{ "key": "apiToken", "type": "string", "secret": true }]
+  }
+}
+```
+
+`set()` rejects keys that aren't declared. `get()` and `onDidChange()` accept any key (a plugin may read or subscribe before the first write). `set()` also rejects an `undefined` value — JSON can't round-trip it and deletion is out of scope.
+
+**Scope:** `scope` defaults to `"user"`. User-scoped settings persist to `~/.daintree/plugin-settings/{pluginId}.json`; project-scoped settings persist to `<projectRoot>/.daintree/plugin-settings/{pluginId}.json` for the currently-active project. Project-scoped reads return `undefined` and writes reject when no project is active.
+
+**Storage:** settings are stored as plaintext JSON, one file per plugin per scope, written with `0o600` permissions on macOS/Linux (skipped on Windows). There is no OS keychain — the `secret` flag on a setting is advisory only (it lets the UI surface a warning); the host does not encrypt secret values. Don't store credentials you wouldn't accept on disk in plaintext.
+
+**Change notifications:** `onDidChange` fires only for writes made through this app instance for the same key and scope. External edits to the JSON file don't trigger the callback. The returned disposer is idempotent, and all subscriptions are automatically disposed when the plugin is unloaded.
 
 ## `showToast`
 

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -9,6 +9,7 @@ import type {
   ViewContribution,
   McpServerContribution,
   PluginPermission,
+  SettingContribution,
 } from "../../shared/types/plugin.js";
 import type {
   FileDecorationContribution,
@@ -113,6 +114,21 @@ export const FileDecorationContributionSchema = z
   })
   .strict();
 
+/**
+ * `settings` manifest entry. Declares the keys a plugin may persist via
+ * `host.settings.set()` (undeclared keys are rejected at write time). Strict
+ * so unknown fields from plugin authors are rejected loudly.
+ */
+export const SettingContributionSchema = z
+  .object({
+    key: z.string().min(1).max(128).regex(SAFE_ID_PATTERN),
+    type: z.enum(["string", "number", "boolean", "object", "array"]),
+    description: z.string().optional(),
+    default: z.any().optional(),
+    secret: z.boolean().optional(),
+  })
+  .strict();
+
 export const PluginPermissionSchema = z.enum(BUILT_IN_PLUGIN_PERMISSIONS);
 
 export const PluginManifestSchema = z
@@ -146,6 +162,7 @@ export const PluginManifestSchema = z
         experimental_mcpServers: z.array(McpServerContributionSchema).default([]),
         forgeProviders: z.array(ForgeProviderContributionSchema).default([]),
         fileDecorationProviders: z.array(FileDecorationContributionSchema).default([]),
+        settings: z.array(SettingContributionSchema).default([]),
       })
       .default({
         panels: [],
@@ -155,6 +172,7 @@ export const PluginManifestSchema = z
         experimental_mcpServers: [],
         forgeProviders: [],
         fileDecorationProviders: [],
+        settings: [],
       }),
   })
   .strict();
@@ -167,5 +185,6 @@ export type {
   ViewContribution,
   McpServerContribution,
   PluginPermission,
+  SettingContribution,
 };
 export type { ForgeProviderContribution, FileDecorationContribution };

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -18,6 +18,13 @@ import type {
 
 const SAFE_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
 
+/**
+ * Setting keys must start with a letter. Stricter than `SAFE_ID_PATTERN` to
+ * exclude leading-underscore names like `__proto__` that would otherwise be
+ * valid identifiers but interact badly with plain-object settings storage.
+ */
+const SETTING_KEY_PATTERN = /^[a-zA-Z][a-zA-Z0-9._-]*$/;
+
 export const SCOPED_PLUGIN_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*\.[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 export const PanelContributionSchema = z.object({
@@ -121,7 +128,7 @@ export const FileDecorationContributionSchema = z
  */
 export const SettingContributionSchema = z
   .object({
-    key: z.string().min(1).max(128).regex(SAFE_ID_PATTERN),
+    key: z.string().min(1).max(128).regex(SETTING_KEY_PATTERN),
     type: z.enum(["string", "number", "boolean", "object", "array"]),
     description: z.string().optional(),
     default: z.any().optional(),

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -15,6 +15,8 @@ import type {
   PluginActionContribution,
   PluginActionDescriptor,
   BuiltInPluginPermission,
+  SettingContribution,
+  SettingsScope,
 } from "../../shared/types/plugin.js";
 import type { WorktreeSnapshot } from "../../shared/types/workspace-host.js";
 import { toPluginWorktreeSnapshot } from "../../shared/utils/pluginWorktreeSnapshot.js";
@@ -52,6 +54,8 @@ import { CHANNELS } from "../ipc/channels.js";
 import type { LoadedPluginInfo } from "../../shared/types/plugin.js";
 import type { PluginToolbarButtonId } from "../../shared/types/toolbar.js";
 import { store } from "../store.js";
+import { projectStore } from "./ProjectStore.js";
+import { resilientAtomicWriteFile } from "../utils/fs.js";
 
 /** Plugin action IDs must be `{pluginId}.{actionId}`. Built-in IDs use colons, so the formats cannot collide. */
 const PLUGIN_ACTION_ID_RE = /^[a-z0-9][a-z0-9-]*\.[a-z0-9][a-zA-Z0-9._-]*$/;
@@ -159,6 +163,22 @@ export class PluginService {
    * {@link getPluginLoadError} for Settings diagnostics and IPC introspection.
    */
   private pluginLoadErrors = new Map<string, PluginLoadErrorRecord>();
+  /**
+   * Per-plugin map of declared setting keys (from `contributes.settings`),
+   * built at `loadPlugin()` time. `host.settings.set()` rejects keys absent
+   * here. Cleared in `unloadPlugin()`.
+   */
+  private pluginSettingKeys = new Map<string, Map<string, SettingContribution>>();
+  /**
+   * In-process `host.settings.onDidChange` listeners, keyed
+   * pluginId → settingKey → scope → callbacks. A plain Set per leaf (not an
+   * EventEmitter) avoids the 10-listener MaxListeners warning. Disposers also
+   * register into `pluginEventCleanups` so unload tears them down.
+   */
+  private settingsListeners = new Map<
+    string,
+    Map<string, Map<SettingsScope, Set<(value: unknown) => void>>>
+  >();
   private workspaceClient: WorkspaceClient | null = null;
   /**
    * Event subscriptions registered during plugin `activate()` when the
@@ -511,6 +531,14 @@ export class PluginService {
       registerFileDecorationProviders(manifest.name, manifest.contributes.fileDecorationProviders);
     }
 
+    if (manifest.contributes.settings.length > 0) {
+      const keyMap = new Map<string, SettingContribution>();
+      for (const setting of manifest.contributes.settings) {
+        keyMap.set(setting.key, setting);
+      }
+      this.pluginSettingKeys.set(manifest.name, keyMap);
+    }
+
     // Insert the plugin into the registry BEFORE importing its main module so
     // synchronous host-API calls made during module evaluation (e.g., a plugin
     // that calls host.registerAction/registerHandler at import time) see the
@@ -558,6 +586,121 @@ export class PluginService {
     const host: PluginHostApi = {
       get pluginId() {
         return pluginId;
+      },
+      // NOT revoke-guarded: settings are read/written and subscribed across the
+      // plugin's whole lifetime, including from post-activation callbacks. The
+      // liveness guard is plugin membership — once unloaded, get() returns
+      // undefined and set() throws.
+      settings: {
+        get: async <T>(
+          key: string,
+          options?: { scope?: SettingsScope }
+        ): Promise<T | undefined> => {
+          if (!this.plugins.has(pluginId)) return undefined;
+          if (typeof key !== "string" || key.length === 0) {
+            throw new Error(`Plugin "${pluginId}" settings.get: key must be a non-empty string`);
+          }
+          const scope: SettingsScope = options?.scope === "project" ? "project" : "user";
+          const filePath = this.getSettingsFilePath(pluginId, scope);
+          if (!filePath) return undefined; // project scope with no active project
+          const data = await this.readSettingsFile(filePath);
+          return (key in data ? data[key] : undefined) as T | undefined;
+        },
+        set: async <T>(
+          key: string,
+          value: T,
+          options?: { scope?: SettingsScope }
+        ): Promise<void> => {
+          if (!this.plugins.has(pluginId)) {
+            throw new Error(`Plugin "${pluginId}" settings.set: plugin is not loaded`);
+          }
+          if (typeof key !== "string" || key.length === 0) {
+            throw new Error(`Plugin "${pluginId}" settings.set: key must be a non-empty string`);
+          }
+          if (value === undefined) {
+            throw new Error(
+              `Plugin "${pluginId}" settings.set: value for key "${key}" must not be undefined`
+            );
+          }
+          const declared = this.pluginSettingKeys.get(pluginId);
+          if (!declared || !declared.has(key)) {
+            throw new Error(
+              `Plugin "${pluginId}" settings.set: key "${key}" is not declared in contributes.settings`
+            );
+          }
+          const scope: SettingsScope = options?.scope === "project" ? "project" : "user";
+          const filePath = this.getSettingsFilePath(pluginId, scope);
+          if (!filePath) {
+            throw new Error(
+              `Plugin "${pluginId}" settings.set: cannot write project-scoped key "${key}" — no active project`
+            );
+          }
+          const data = await this.readSettingsFile(filePath);
+          data[key] = value;
+          await this.writeSettingsFile(filePath, data);
+          this.emitSettingsChange(pluginId, scope, key, value);
+        },
+        onDidChange: <T>(
+          key: string,
+          callback: (value: T | undefined) => void,
+          options?: { scope?: SettingsScope }
+        ): (() => void) => {
+          if (typeof key !== "string" || key.length === 0) {
+            throw new Error(
+              `Plugin "${pluginId}" settings.onDidChange: key must be a non-empty string`
+            );
+          }
+          if (typeof callback !== "function") {
+            throw new Error(
+              `Plugin "${pluginId}" settings.onDidChange: callback must be a function`
+            );
+          }
+          const scope: SettingsScope = options?.scope === "project" ? "project" : "user";
+          const typedCallback = callback as (value: unknown) => void;
+
+          let byPlugin = this.settingsListeners.get(pluginId);
+          if (!byPlugin) {
+            byPlugin = new Map();
+            this.settingsListeners.set(pluginId, byPlugin);
+          }
+          let byKey = byPlugin.get(key);
+          if (!byKey) {
+            byKey = new Map();
+            byPlugin.set(key, byKey);
+          }
+          let byScope = byKey.get(scope);
+          if (!byScope) {
+            byScope = new Set();
+            byKey.set(scope, byScope);
+          }
+          byScope.add(typedCallback);
+
+          let disposed = false;
+          const dispose = (): void => {
+            if (disposed) return;
+            disposed = true;
+            const pluginMap = this.settingsListeners.get(pluginId);
+            const keyMap = pluginMap?.get(key);
+            const scopeSet = keyMap?.get(scope);
+            scopeSet?.delete(typedCallback);
+            if (scopeSet && scopeSet.size === 0) keyMap?.delete(scope);
+            if (keyMap && keyMap.size === 0) pluginMap?.delete(key);
+            if (pluginMap && pluginMap.size === 0) this.settingsListeners.delete(pluginId);
+            const list = this.pluginEventCleanups.get(pluginId);
+            if (!list) return;
+            const idx = list.indexOf(dispose);
+            if (idx >= 0) list.splice(idx, 1);
+            if (list.length === 0) this.pluginEventCleanups.delete(pluginId);
+          };
+
+          let list = this.pluginEventCleanups.get(pluginId);
+          if (!list) {
+            list = [];
+            this.pluginEventCleanups.set(pluginId, list);
+          }
+          list.push(dispose);
+          return dispose;
+        },
       },
       registerHandler: (channel, handler) => {
         if (revoked) {
@@ -808,6 +951,83 @@ export class PluginService {
     };
   }
 
+  /**
+   * Resolve the settings file path for a plugin and scope. Returns `undefined`
+   * for project scope when no project is active (callers translate that into a
+   * `get` returning `undefined` / a `set` rejection). The pluginId is already
+   * validated by `SCOPED_PLUGIN_NAME_PATTERN` (alphanumeric + dot + hyphen),
+   * so it is filesystem-safe as a filename without further sanitization.
+   */
+  private getSettingsFilePath(pluginId: string, scope: SettingsScope): string | undefined {
+    if (scope === "project") {
+      const projectPath = projectStore.getCurrentProject()?.path;
+      if (!projectPath) return undefined;
+      return path.join(projectPath, ".daintree", "plugin-settings", `${pluginId}.json`);
+    }
+    return path.join(os.homedir(), ".daintree", "plugin-settings", `${pluginId}.json`);
+  }
+
+  /**
+   * Read a plugin's settings file as a flat object. Returns `{}` when the file
+   * does not exist yet. Throws a descriptive error when the file exists but is
+   * not parseable JSON or is not a JSON object — corruption should surface to
+   * the plugin rather than be silently swallowed.
+   */
+  private async readSettingsFile(filePath: string): Promise<Record<string, unknown>> {
+    let raw: string;
+    try {
+      raw = await fs.readFile(filePath, "utf-8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return {};
+      throw err;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      throw new Error(
+        `Failed to parse plugin settings file at ${filePath}: ${(err as Error).message}`
+      );
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error(`Plugin settings file at ${filePath} is not a JSON object`);
+    }
+    return parsed as Record<string, unknown>;
+  }
+
+  /**
+   * Atomically write a plugin's settings object with `0o600` perms (POSIX).
+   * `resilientAtomicWriteFile` applies the mode to the temp file before rename
+   * and skips it on Windows.
+   */
+  private async writeSettingsFile(filePath: string, data: Record<string, unknown>): Promise<void> {
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await resilientAtomicWriteFile(filePath, JSON.stringify(data, null, 2), "utf-8", {
+      mode: 0o600,
+    });
+  }
+
+  /** Fire in-process onDidChange listeners for a plugin's key+scope after a write. */
+  private emitSettingsChange(
+    pluginId: string,
+    scope: SettingsScope,
+    key: string,
+    value: unknown
+  ): void {
+    const listeners = this.settingsListeners.get(pluginId)?.get(key)?.get(scope);
+    if (!listeners || listeners.size === 0) return;
+    for (const cb of [...listeners]) {
+      try {
+        cb(value);
+      } catch (err) {
+        console.error(
+          `[PluginService] settings.onDidChange callback for "${pluginId}" key "${key}" threw:`,
+          err
+        );
+      }
+    }
+  }
+
   private async fetchAllWorktreeSnapshots(): Promise<WorktreeSnapshot[]> {
     const client = this.workspaceClient;
     if (!client) return [];
@@ -1024,6 +1244,13 @@ export class PluginService {
     );
     runUnloadStep(pluginId, "unregisterFileDecorationProviderImpls", () =>
       unregisterFileDecorationProviderImpls(pluginId)
+    );
+    // onDidChange disposers in pluginEventCleanups already fired above; the
+    // explicit deletes drop the declared-key table and any leftover listener
+    // maps (belt-and-suspenders for entries not torn down through a disposer).
+    runUnloadStep(pluginId, "clearSettingKeys", () => this.pluginSettingKeys.delete(pluginId));
+    runUnloadStep(pluginId, "clearSettingsListeners", () =>
+      this.settingsListeners.delete(pluginId)
     );
 
     this.plugins.delete(pluginId);

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -179,6 +179,13 @@ export class PluginService {
     string,
     Map<string, Map<SettingsScope, Set<(value: unknown) => void>>>
   >();
+  /**
+   * Per-file write chains serializing `host.settings.set()` read-modify-write
+   * cycles. Without this, two concurrent `set()` calls on different keys of
+   * the same file both read the same snapshot and the last atomic rename wins,
+   * silently dropping the other key. Keyed by settings file path.
+   */
+  private settingsWriteChains = new Map<string, Promise<void>>();
   private workspaceClient: WorkspaceClient | null = null;
   /**
    * Event subscriptions registered during plugin `activate()` when the
@@ -600,11 +607,13 @@ export class PluginService {
           if (typeof key !== "string" || key.length === 0) {
             throw new Error(`Plugin "${pluginId}" settings.get: key must be a non-empty string`);
           }
-          const scope: SettingsScope = options?.scope === "project" ? "project" : "user";
+          const scope = this.resolveSettingsScope(pluginId, options?.scope);
           const filePath = this.getSettingsFilePath(pluginId, scope);
           if (!filePath) return undefined; // project scope with no active project
           const data = await this.readSettingsFile(filePath);
-          return (key in data ? data[key] : undefined) as T | undefined;
+          return (Object.prototype.hasOwnProperty.call(data, key) ? data[key] : undefined) as
+            | T
+            | undefined;
         },
         set: async <T>(
           key: string,
@@ -622,22 +631,29 @@ export class PluginService {
               `Plugin "${pluginId}" settings.set: value for key "${key}" must not be undefined`
             );
           }
+          if (typeof value === "function" || typeof value === "symbol") {
+            throw new Error(
+              `Plugin "${pluginId}" settings.set: value for key "${key}" must be JSON-serializable`
+            );
+          }
           const declared = this.pluginSettingKeys.get(pluginId);
           if (!declared || !declared.has(key)) {
             throw new Error(
               `Plugin "${pluginId}" settings.set: key "${key}" is not declared in contributes.settings`
             );
           }
-          const scope: SettingsScope = options?.scope === "project" ? "project" : "user";
+          const scope = this.resolveSettingsScope(pluginId, options?.scope);
           const filePath = this.getSettingsFilePath(pluginId, scope);
           if (!filePath) {
             throw new Error(
               `Plugin "${pluginId}" settings.set: cannot write project-scoped key "${key}" — no active project`
             );
           }
-          const data = await this.readSettingsFile(filePath);
-          data[key] = value;
-          await this.writeSettingsFile(filePath, data);
+          await this.enqueueSettingsWrite(filePath, async () => {
+            const data = await this.readSettingsFile(filePath);
+            data[key] = value;
+            await this.writeSettingsFile(filePath, data);
+          });
           this.emitSettingsChange(pluginId, scope, key, value);
         },
         onDidChange: <T>(
@@ -655,7 +671,12 @@ export class PluginService {
               `Plugin "${pluginId}" settings.onDidChange: callback must be a function`
             );
           }
-          const scope: SettingsScope = options?.scope === "project" ? "project" : "user";
+          // Guard against a post-unload subscription (e.g. from a lingering
+          // timer holding the host reference). flushPluginEventCleanups has
+          // already run, so a new entry would never be torn down — return an
+          // inert disposer and register nothing.
+          if (!this.plugins.has(pluginId)) return () => {};
+          const scope = this.resolveSettingsScope(pluginId, options?.scope);
           const typedCallback = callback as (value: unknown) => void;
 
           let byPlugin = this.settingsListeners.get(pluginId);
@@ -985,9 +1006,7 @@ export class PluginService {
     try {
       parsed = JSON.parse(raw);
     } catch (err) {
-      throw new Error(
-        `Failed to parse plugin settings file at ${filePath}: ${(err as Error).message}`
-      );
+      throw new Error(`Failed to parse plugin settings file at ${filePath}`, { cause: err });
     }
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
       throw new Error(`Plugin settings file at ${filePath} is not a JSON object`);
@@ -1005,6 +1024,42 @@ export class PluginService {
     await resilientAtomicWriteFile(filePath, JSON.stringify(data, null, 2), "utf-8", {
       mode: 0o600,
     });
+  }
+
+  /**
+   * Normalize and validate a caller-supplied scope. TypeScript guards
+   * in-process callers, but plugin code is JS at runtime — an unrecognized
+   * scope must fail loudly rather than silently coerce to `"user"`.
+   */
+  private resolveSettingsScope(pluginId: string, scope: unknown): SettingsScope {
+    if (scope === undefined || scope === "user") return "user";
+    if (scope === "project") return "project";
+    throw new Error(
+      `Plugin "${pluginId}" settings: invalid scope "${String(scope)}" — must be "user" or "project"`
+    );
+  }
+
+  /**
+   * Serialize a read-modify-write op for a settings file against any other
+   * in-flight write to the same path. A failed write does not poison the
+   * chain — subsequent writes still run. The chain entry self-prunes when it
+   * is the last link, so the map doesn't grow unbounded.
+   */
+  private enqueueSettingsWrite(filePath: string, op: () => Promise<void>): Promise<void> {
+    const tail = this.settingsWriteChains.get(filePath) ?? Promise.resolve();
+    const next = tail.then(op, op);
+    const tracked: Promise<void> = next
+      .then(
+        () => undefined,
+        () => undefined
+      )
+      .finally(() => {
+        if (this.settingsWriteChains.get(filePath) === tracked) {
+          this.settingsWriteChains.delete(filePath);
+        }
+      });
+    this.settingsWriteChains.set(filePath, tracked);
+    return next;
   }
 
   /** Fire in-process onDidChange listeners for a plugin's key+scope after a write. */

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -54,7 +54,7 @@ import { CHANNELS } from "../ipc/channels.js";
 import type { LoadedPluginInfo } from "../../shared/types/plugin.js";
 import type { PluginToolbarButtonId } from "../../shared/types/toolbar.js";
 import { store } from "../store.js";
-import { projectStore } from "./ProjectStore.js";
+import type { projectStore as ProjectStoreSingleton } from "./ProjectStore.js";
 import { resilientAtomicWriteFile } from "../utils/fs.js";
 
 /** Plugin action IDs must be `{pluginId}.{actionId}`. Built-in IDs use colons, so the formats cannot collide. */
@@ -608,7 +608,7 @@ export class PluginService {
             throw new Error(`Plugin "${pluginId}" settings.get: key must be a non-empty string`);
           }
           const scope = this.resolveSettingsScope(pluginId, options?.scope);
-          const filePath = this.getSettingsFilePath(pluginId, scope);
+          const filePath = await this.getSettingsFilePath(pluginId, scope);
           if (!filePath) return undefined; // project scope with no active project
           const data = await this.readSettingsFile(filePath);
           return (Object.prototype.hasOwnProperty.call(data, key) ? data[key] : undefined) as
@@ -643,7 +643,7 @@ export class PluginService {
             );
           }
           const scope = this.resolveSettingsScope(pluginId, options?.scope);
-          const filePath = this.getSettingsFilePath(pluginId, scope);
+          const filePath = await this.getSettingsFilePath(pluginId, scope);
           if (!filePath) {
             throw new Error(
               `Plugin "${pluginId}" settings.set: cannot write project-scoped key "${key}" — no active project`
@@ -973,14 +973,34 @@ export class PluginService {
   }
 
   /**
+   * Lazily resolve the `projectStore` singleton. Imported dynamically rather
+   * than statically so merely importing `PluginService` does not evaluate
+   * `ProjectStore` (whose constructor calls `app.getPath`) — that side effect
+   * broke unrelated test files whose `electron` mock omits `app`. Only the
+   * project-scope settings path actually needs it.
+   */
+  private projectStoreRef: typeof ProjectStoreSingleton | null = null;
+  private async getProjectStore(): Promise<typeof ProjectStoreSingleton> {
+    if (!this.projectStoreRef) {
+      const mod = await import("./ProjectStore.js");
+      this.projectStoreRef = mod.projectStore;
+    }
+    return this.projectStoreRef;
+  }
+
+  /**
    * Resolve the settings file path for a plugin and scope. Returns `undefined`
    * for project scope when no project is active (callers translate that into a
    * `get` returning `undefined` / a `set` rejection). The pluginId is already
    * validated by `SCOPED_PLUGIN_NAME_PATTERN` (alphanumeric + dot + hyphen),
    * so it is filesystem-safe as a filename without further sanitization.
    */
-  private getSettingsFilePath(pluginId: string, scope: SettingsScope): string | undefined {
+  private async getSettingsFilePath(
+    pluginId: string,
+    scope: SettingsScope
+  ): Promise<string | undefined> {
     if (scope === "project") {
+      const projectStore = await this.getProjectStore();
       const projectPath = projectStore.getCurrentProject()?.path;
       if (!projectPath) return undefined;
       return path.join(projectPath, ".daintree", "plugin-settings", `${pluginId}.json`);

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -44,6 +44,9 @@ vi.mock("../../store.js", () => ({
     set: (key: string, value: unknown) => storeState.set(key, value),
   },
 }));
+vi.mock("../ProjectStore.js", () => ({
+  projectStore: { getCurrentProject: vi.fn(() => null) },
+}));
 
 import { PluginService } from "../PluginService.js";
 import type { PluginIpcContext } from "../../../shared/types/plugin.js";

--- a/electron/services/__tests__/PluginService.settings.test.ts
+++ b/electron/services/__tests__/PluginService.settings.test.ts
@@ -1,0 +1,326 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+
+const appMock = vi.hoisted(() => ({
+  getVersion: vi.fn(() => "0.0.0"),
+}));
+const broadcastToRendererMock = vi.hoisted(() => vi.fn());
+const storeMock = vi.hoisted(() => {
+  const state = new Map<string, unknown>();
+  return {
+    get: vi.fn((key: string) => state.get(key)),
+    set: vi.fn((key: string, value: unknown) => state.set(key, value)),
+    _state: state,
+  };
+});
+const getCurrentProjectMock = vi.hoisted(() => vi.fn<() => { path: string } | null>(() => null));
+
+vi.mock("electron", () => ({
+  app: appMock,
+}));
+vi.mock("../../ipc/utils.js", () => ({
+  broadcastToRenderer: broadcastToRendererMock,
+}));
+vi.mock("../../store.js", () => ({
+  store: storeMock,
+}));
+vi.mock("../../../shared/config/panelKindRegistry.js", () => ({
+  registerPanelKind: vi.fn(),
+  unregisterPluginPanelKinds: vi.fn(),
+  onPanelKindRegistered: vi.fn(() => () => {}),
+  onPanelKindUnregistered: vi.fn(() => () => {}),
+  getPluginPanelKinds: vi.fn(() => []),
+}));
+vi.mock("../../../shared/config/toolbarButtonRegistry.js", () => ({
+  registerToolbarButton: vi.fn(),
+  unregisterPluginToolbarButtons: vi.fn(),
+  getAllPluginToolbarButtonConfigs: vi.fn(() => []),
+}));
+vi.mock("../pluginMenuRegistry.js", () => ({
+  registerPluginMenuItem: vi.fn(),
+  unregisterPluginMenuItems: vi.fn(),
+}));
+vi.mock("../forgeProviderRegistry.js", () => ({
+  registerForgeProviders: vi.fn(),
+  unregisterForgeProviders: vi.fn(),
+  registerForgeProviderImpl: vi.fn(),
+  unregisterForgeProviderImpl: vi.fn(),
+  unregisterForgeProviderImpls: vi.fn(),
+  getForgeProviderImpl: vi.fn(),
+  clearForgeProviderImplRegistry: vi.fn(),
+}));
+vi.mock("../ProjectStore.js", () => ({
+  projectStore: { getCurrentProject: getCurrentProjectMock },
+}));
+
+import { PluginService } from "../PluginService.js";
+import { PluginManifestSchema } from "../../schemas/plugin.js";
+
+type SettingsScope = "user" | "project";
+interface SettingsHost {
+  pluginId: string;
+  settings: {
+    get: <T>(key: string, options?: { scope?: SettingsScope }) => Promise<T | undefined>;
+    set: <T>(key: string, value: T, options?: { scope?: SettingsScope }) => Promise<void>;
+    onDidChange: <T>(
+      key: string,
+      callback: (value: T | undefined) => void,
+      options?: { scope?: SettingsScope }
+    ) => () => void;
+  };
+}
+type CreateHostShape = (id: string) => { host: SettingsHost; revoke: () => void };
+
+const PLUGIN_ID = "acme.settings-host";
+
+function settingsManifest(keys: Array<Record<string, unknown>>): Record<string, unknown> {
+  return {
+    name: PLUGIN_ID,
+    version: "1.0.0",
+    contributes: { settings: keys },
+  };
+}
+
+function writePlugin(dirName: string, manifest: Record<string, unknown>): Promise<void> {
+  const dir = path.join(pluginsDir, dirName);
+  return fs
+    .mkdir(dir, { recursive: true })
+    .then(() => fs.writeFile(path.join(dir, "plugin.json"), JSON.stringify(manifest)));
+}
+
+async function makeHost(
+  keys: Array<Record<string, unknown>> = [{ key: "apiKey", type: "string" }]
+): Promise<{ service: PluginService; host: SettingsHost }> {
+  await writePlugin("settings-host", settingsManifest(keys));
+  const service = new PluginService(pluginsDir);
+  await service.initialize();
+  const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(PLUGIN_ID);
+  return { service, host };
+}
+
+let tmpDir: string;
+let pluginsDir: string;
+let homeDir: string;
+let projectDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-plugin-settings-"));
+  pluginsDir = path.join(tmpDir, "plugins");
+  homeDir = path.join(tmpDir, "home");
+  projectDir = path.join(tmpDir, "project");
+  await fs.mkdir(pluginsDir, { recursive: true });
+  await fs.mkdir(homeDir, { recursive: true });
+  await fs.mkdir(projectDir, { recursive: true });
+  vi.clearAllMocks();
+  storeMock._state.clear();
+  getCurrentProjectMock.mockReturnValue(null);
+  vi.spyOn(os, "homedir").mockReturnValue(homeDir);
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("PluginManifestSchema — contributes.settings", () => {
+  it("accepts a settings contribution array", () => {
+    const result = PluginManifestSchema.safeParse({
+      name: PLUGIN_ID,
+      version: "1.0.0",
+      contributes: {
+        settings: [{ key: "apiKey", type: "string", description: "API key", secret: true }],
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.contributes.settings).toEqual([
+        { key: "apiKey", type: "string", description: "API key", secret: true },
+      ]);
+    }
+  });
+
+  it("defaults settings to an empty array when omitted", () => {
+    const result = PluginManifestSchema.safeParse({ name: PLUGIN_ID, version: "1.0.0" });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.contributes.settings).toEqual([]);
+  });
+
+  it("rejects an unknown field on a setting", () => {
+    const result = PluginManifestSchema.safeParse({
+      name: PLUGIN_ID,
+      version: "1.0.0",
+      contributes: { settings: [{ key: "apiKey", type: "string", bogus: true }] },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an invalid setting type", () => {
+    const result = PluginManifestSchema.safeParse({
+      name: PLUGIN_ID,
+      version: "1.0.0",
+      contributes: { settings: [{ key: "apiKey", type: "date" }] },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("host.settings — user scope", () => {
+  it("set then get round-trips a value", async () => {
+    const { host } = await makeHost();
+    await host.settings.set("apiKey", "abc123");
+    expect(await host.settings.get<string>("apiKey")).toBe("abc123");
+  });
+
+  it("get returns undefined for an unset key", async () => {
+    const { host } = await makeHost([
+      { key: "apiKey", type: "string" },
+      { key: "other", type: "string" },
+    ]);
+    expect(await host.settings.get<string>("other")).toBeUndefined();
+  });
+
+  it("persists to ~/.daintree/plugin-settings/{pluginId}.json", async () => {
+    const { host } = await makeHost();
+    await host.settings.set("apiKey", "v");
+    const filePath = path.join(homeDir, ".daintree", "plugin-settings", `${PLUGIN_ID}.json`);
+    const raw = await fs.readFile(filePath, "utf-8");
+    expect(JSON.parse(raw)).toEqual({ apiKey: "v" });
+  });
+
+  it.runIf(process.platform !== "win32")("writes the file with 0o600 perms", async () => {
+    const { host } = await makeHost();
+    await host.settings.set("apiKey", "v");
+    const filePath = path.join(homeDir, ".daintree", "plugin-settings", `${PLUGIN_ID}.json`);
+    const stat = await fs.stat(filePath);
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it("round-trips object and boolean values", async () => {
+    const { host } = await makeHost([
+      { key: "config", type: "object" },
+      { key: "enabled", type: "boolean" },
+    ]);
+    await host.settings.set("config", { a: 1, nested: { b: true } });
+    await host.settings.set("enabled", false);
+    expect(await host.settings.get("config")).toEqual({ a: 1, nested: { b: true } });
+    expect(await host.settings.get<boolean>("enabled")).toBe(false);
+  });
+
+  it("rejects a key not declared in contributes.settings", async () => {
+    const { host } = await makeHost();
+    await expect(host.settings.set("undeclared", "x")).rejects.toThrow(
+      /not declared in contributes\.settings/
+    );
+  });
+
+  it("rejects an undefined value", async () => {
+    const { host } = await makeHost();
+    await expect(host.settings.set("apiKey", undefined as unknown as string)).rejects.toThrow(
+      /must not be undefined/
+    );
+  });
+
+  it("throws when the settings file contains corrupt JSON", async () => {
+    const { host } = await makeHost();
+    const filePath = path.join(homeDir, ".daintree", "plugin-settings", `${PLUGIN_ID}.json`);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "{ not json");
+    await expect(host.settings.get("apiKey")).rejects.toThrow(/Failed to parse/);
+  });
+});
+
+describe("host.settings — project scope", () => {
+  it("get returns undefined when no project is active", async () => {
+    const { host } = await makeHost();
+    getCurrentProjectMock.mockReturnValue(null);
+    expect(await host.settings.get("apiKey", { scope: "project" })).toBeUndefined();
+  });
+
+  it("set rejects when no project is active", async () => {
+    const { host } = await makeHost();
+    getCurrentProjectMock.mockReturnValue(null);
+    await expect(host.settings.set("apiKey", "v", { scope: "project" })).rejects.toThrow(
+      /no active project/
+    );
+  });
+
+  it("set then get round-trips within the active project dir", async () => {
+    const { host } = await makeHost();
+    getCurrentProjectMock.mockReturnValue({ path: projectDir });
+    await host.settings.set("apiKey", "proj-value", { scope: "project" });
+    expect(await host.settings.get<string>("apiKey", { scope: "project" })).toBe("proj-value");
+    const filePath = path.join(projectDir, ".daintree", "plugin-settings", `${PLUGIN_ID}.json`);
+    expect(JSON.parse(await fs.readFile(filePath, "utf-8"))).toEqual({ apiKey: "proj-value" });
+  });
+
+  it("keeps user and project scopes independent", async () => {
+    const { host } = await makeHost();
+    getCurrentProjectMock.mockReturnValue({ path: projectDir });
+    await host.settings.set("apiKey", "user-val", { scope: "user" });
+    await host.settings.set("apiKey", "proj-val", { scope: "project" });
+    expect(await host.settings.get<string>("apiKey", { scope: "user" })).toBe("user-val");
+    expect(await host.settings.get<string>("apiKey", { scope: "project" })).toBe("proj-val");
+  });
+});
+
+describe("host.settings.onDidChange", () => {
+  it("fires the callback after set with the new value", async () => {
+    const { host } = await makeHost();
+    const cb = vi.fn();
+    host.settings.onDidChange<string>("apiKey", cb);
+    await host.settings.set("apiKey", "new");
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith("new");
+  });
+
+  it("fires all listeners registered on the same key", async () => {
+    const { host } = await makeHost();
+    const cb1 = vi.fn();
+    const cb2 = vi.fn();
+    host.settings.onDidChange("apiKey", cb1);
+    host.settings.onDidChange("apiKey", cb2);
+    await host.settings.set("apiKey", "v");
+    expect(cb1).toHaveBeenCalledWith("v");
+    expect(cb2).toHaveBeenCalledWith("v");
+  });
+
+  it("disposer stops further callbacks and is idempotent", async () => {
+    const { host } = await makeHost();
+    const cb = vi.fn();
+    const dispose = host.settings.onDidChange("apiKey", cb);
+    dispose();
+    dispose();
+    await host.settings.set("apiKey", "v");
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("does not fire a user-scope listener on a project-scope write", async () => {
+    const { host } = await makeHost();
+    getCurrentProjectMock.mockReturnValue({ path: projectDir });
+    const cb = vi.fn();
+    host.settings.onDidChange("apiKey", cb, { scope: "user" });
+    await host.settings.set("apiKey", "v", { scope: "project" });
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("auto-disposes listeners when the plugin is unloaded", async () => {
+    const { service, host } = await makeHost();
+    const cb = vi.fn();
+    host.settings.onDidChange("apiKey", cb);
+    service.unloadPlugin(PLUGIN_ID);
+    const listeners = (service as unknown as { settingsListeners: Map<string, unknown> })
+      .settingsListeners;
+    expect(listeners.has(PLUGIN_ID)).toBe(false);
+  });
+});
+
+describe("host.settings — unloaded plugin", () => {
+  it("get returns undefined and set throws after unload", async () => {
+    const { service, host } = await makeHost();
+    service.unloadPlugin(PLUGIN_ID);
+    expect(await host.settings.get("apiKey")).toBeUndefined();
+    await expect(host.settings.set("apiKey", "v")).rejects.toThrow(/plugin is not loaded/);
+  });
+});

--- a/electron/services/__tests__/PluginService.settings.test.ts
+++ b/electron/services/__tests__/PluginService.settings.test.ts
@@ -222,6 +222,54 @@ describe("host.settings — user scope", () => {
     );
   });
 
+  it("rejects a non-JSON-serializable function value", async () => {
+    const { host } = await makeHost();
+    await expect(host.settings.set("apiKey", (() => "x") as unknown as string)).rejects.toThrow(
+      /must be JSON-serializable/
+    );
+  });
+
+  it("rejects an invalid scope value", async () => {
+    const { host } = await makeHost();
+    await expect(
+      host.settings.set("apiKey", "v", { scope: "workspace" as "user" })
+    ).rejects.toThrow(/invalid scope/);
+  });
+
+  it("returns undefined for an inherited prototype key on an empty file", async () => {
+    const { host } = await makeHost([{ key: "toStringX", type: "string" }]);
+    // "constructor" lives on Object.prototype but is never an own key of {}
+    expect(await host.settings.get("constructor")).toBeUndefined();
+  });
+
+  it("preserves all keys under concurrent writes to the same file", async () => {
+    const { host } = await makeHost([
+      { key: "a", type: "number" },
+      { key: "b", type: "number" },
+      { key: "c", type: "number" },
+    ]);
+    await Promise.all([
+      host.settings.set("a", 1),
+      host.settings.set("b", 2),
+      host.settings.set("c", 3),
+    ]);
+    expect(await host.settings.get<number>("a")).toBe(1);
+    expect(await host.settings.get<number>("b")).toBe(2);
+    expect(await host.settings.get<number>("c")).toBe(3);
+  });
+
+  it("persists values across PluginService instances", async () => {
+    const { host } = await makeHost();
+    await host.settings.set("apiKey", "durable");
+    // A fresh service over the same plugins + home dirs must read the value.
+    const service2 = new PluginService(pluginsDir);
+    await service2.initialize();
+    const { host: host2 } = (service2 as unknown as { createHost: CreateHostShape }).createHost(
+      PLUGIN_ID
+    );
+    expect(await host2.settings.get<string>("apiKey")).toBe("durable");
+  });
+
   it("throws when the settings file contains corrupt JSON", async () => {
     const { host } = await makeHost();
     const filePath = path.join(homeDir, ".daintree", "plugin-settings", `${PLUGIN_ID}.json`);
@@ -310,6 +358,17 @@ describe("host.settings.onDidChange", () => {
     const cb = vi.fn();
     host.settings.onDidChange("apiKey", cb);
     service.unloadPlugin(PLUGIN_ID);
+    const listeners = (service as unknown as { settingsListeners: Map<string, unknown> })
+      .settingsListeners;
+    expect(listeners.has(PLUGIN_ID)).toBe(false);
+  });
+
+  it("registers nothing when onDidChange is called after unload", async () => {
+    const { service, host } = await makeHost();
+    service.unloadPlugin(PLUGIN_ID);
+    const dispose = host.settings.onDidChange("apiKey", vi.fn());
+    expect(typeof dispose).toBe("function");
+    expect(() => dispose()).not.toThrow();
     const listeners = (service as unknown as { settingsListeners: Map<string, unknown> })
       .settingsListeners;
     expect(listeners.has(PLUGIN_ID)).toBe(false);

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -63,6 +63,9 @@ vi.mock("../fileDecorationRegistry.js", () => ({
   unregisterFileDecorationProviderImpl: vi.fn(),
   scopeMatchesPattern: vi.fn((s: string, p: string) => s === p),
 }));
+vi.mock("../ProjectStore.js", () => ({
+  projectStore: { getCurrentProject: vi.fn(() => null) },
+}));
 
 import { PluginService } from "../PluginService.js";
 import { PluginManifestSchema } from "../../schemas/plugin.js";

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -87,6 +87,27 @@ export interface McpServerContribution {
   env?: Record<string, string>;
 }
 
+export type SettingType = "string" | "number" | "boolean" | "object" | "array";
+
+/**
+ * Declares a single setting key a plugin may persist via `host.settings`.
+ * `set()` rejects keys not declared here; `get()` / `onDidChange()` accept
+ * any key (a plugin may read or subscribe before the first write).
+ */
+export interface SettingContribution {
+  key: string;
+  type: SettingType;
+  description?: string;
+  default?: unknown;
+  /**
+   * Advisory marker for sensitive values. Storage is unchanged — every
+   * setting is persisted as plaintext JSON with `0o600` perms — this flag
+   * only lets the UI surface a warning. The host never treats secrets
+   * specially at the storage layer (no keychain; see issue #9167).
+   */
+  secret?: boolean;
+}
+
 export interface PluginManifest {
   name: string;
   version: string;
@@ -105,6 +126,7 @@ export interface PluginManifest {
     experimental_mcpServers: McpServerContribution[];
     forgeProviders: ForgeProviderContribution[];
     fileDecorationProviders: FileDecorationContribution[];
+    settings: SettingContribution[];
   };
 }
 
@@ -189,8 +211,56 @@ export interface PluginWorktreeSnapshot {
   readonly createdAt?: number;
 }
 
+export type SettingsScope = "user" | "project";
+
+export interface SettingsAccessOptions {
+  /**
+   * Where the setting lives. `"user"` (default) persists to
+   * `~/.daintree/plugin-settings/{pluginId}.json`; `"project"` persists to
+   * `<projectRoot>/.daintree/plugin-settings/{pluginId}.json` for the
+   * currently-active project. Project-scoped reads return `undefined` and
+   * writes reject when no project is active.
+   */
+  scope?: SettingsScope;
+}
+
+/**
+ * Per-plugin persistent settings. Values are stored as plaintext JSON, one
+ * file per plugin per scope, written with `0o600` permissions on POSIX. No
+ * OS keychain is used (see issue #9167).
+ */
+export interface SettingsApi {
+  /** Read a setting. Returns `undefined` for unset keys and for project scope with no active project. */
+  get<T>(key: string, options?: SettingsAccessOptions): Promise<T | undefined>;
+  /**
+   * Write a setting. The key must be declared in `contributes.settings` or
+   * the call rejects. `value` must not be `undefined` (JSON cannot round-trip
+   * it; deletion is out of scope). Fires `onDidChange` listeners for the same
+   * key and scope in-process after the write lands.
+   */
+  set<T>(key: string, value: T, options?: SettingsAccessOptions): Promise<void>;
+  /**
+   * Subscribe to in-process writes for `key` at the given scope (default
+   * `"user"`). Fires only on writes made through this app instance — external
+   * edits to the JSON file do not trigger the callback. Returns a disposer;
+   * calling it more than once is a no-op. All subscriptions are automatically
+   * disposed when the plugin is unloaded.
+   */
+  onDidChange<T>(
+    key: string,
+    callback: (value: T | undefined) => void,
+    options?: SettingsAccessOptions
+  ): () => void;
+}
+
 export interface PluginHostApi {
   readonly pluginId: string;
+  /**
+   * Per-plugin persistent settings (plaintext JSON, `0o600` on POSIX). Not
+   * revoke-guarded — usable for the plugin's whole lifetime, including from
+   * post-activation callbacks.
+   */
+  readonly settings: SettingsApi;
   registerHandler(channel: string, handler: PluginIpcHandler): void;
   broadcastToRenderer(channel: string, payload: unknown): void;
   /**


### PR DESCRIPTION
## Summary

- `host.settings` was declared on `PluginHostApi` but never implemented — this PR wires it up
- Plugins can now persist per-plugin settings as plaintext JSON, scoped to either the user or the active project, with no OS keychain
- Atomic writes, per-file write serialization, and key validation against `contributes.settings` are all in place

Resolves #9279

## Changes

**Types and schema**
- Added `SettingsApi` (`get<T>`, `set<T>`, `onDidChange`) and `SettingContribution` to `shared/types/plugin.ts`; wired `settings: SettingsApi` onto `PluginHostApi` and `settings[]` onto `PluginManifest.contributes`
- Added `SettingContributionSchema` to the manifest Zod schema (keys must start with a letter; `type` is advisory)

**Implementation (`PluginService.createHost`)**
- Plaintext JSON, one file per plugin per scope:
  - User: `~/.daintree/plugin-settings/{pluginId}.json`
  - Project: `<projectRoot>/.daintree/plugin-settings/{pluginId}.json`
- Atomic writes via `resilientAtomicWriteFile` with `0o600` perms (POSIX; skipped on Windows)
- Concurrent `set()` calls serialized per file to prevent silent key loss
- `set()` validates the key against `contributes.settings` and rejects `undefined` or non-JSON-serializable values
- Project scope returns `undefined` (`get`) or throws (`set`) when no project is active
- `onDidChange` fires in-process only; listeners auto-disposed on plugin unload via `pluginEventCleanups`

**Docs**
- Updated `docs/plugins/host-api.md` and `contribution-points.md`: removed the keychain reference and `_Planned_` markers, documented plaintext + `0o600` storage and the advisory-only `secret` flag

**Security note:** settings are plaintext on disk (`0o600`). The `secret` flag is advisory only — no encryption. This matches the #9167 no-keychain decision and is documented prominently for plugin authors.

## Testing

Added `PluginService.settings.test.ts` (28 tests) covering round-trip, scopes, key validation, concurrency, prototype-key safety, restart persistence, and listener lifecycle. Full `npm run check` passes (typecheck + lint + format); existing plugin tests green.