### PR TITLE
feat(window): paint project identity into cold-start skeleton

### DIFF
--- a/electron/__tests__/clipboard.test.ts
+++ b/electron/__tests__/clipboard.test.ts
@@ -28,6 +28,13 @@ vi.mock("../services/ProjectStore.js", () => ({
     getCurrentProjectId: vi.fn(() => null),
   },
 
+// The clipboard handler imports the projectStore singleton, whose constructor
+// reaches for Electron's `app` at module-eval time. Stub it so this test stays
+// isolated from the real store (the cleanup logic only reads project paths).
+vi.mock("../services/ProjectStore.js", () => ({
+  projectStore: { getAllProjects: () => [] },
+}));
+
 // Redirect os.tmpdir() to a throwaway directory so the cleanup operates on real
 // files we control. The base dir is created inside the factory where the real
 // os module is still available.

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -150,6 +150,17 @@ const initialColorSchemeId = process.argv
   .find((a) => a.startsWith(INITIAL_COLOR_SCHEME_ARG))
   ?.slice(INITIAL_COLOR_SCHEME_ARG.length);
 
+// Destination project id passed from the main process via additionalArguments,
+// replacing the former `?projectId=` query string so the document URL stays
+// static and the V8 bytecode cache is shared across projects (#9162). Read the
+// same way as the color scheme above and exposed as
+// `window.__DAINTREE_INITIAL_PROJECT__` so renderer stores resolve their scope
+// without parsing the URL.
+const INITIAL_PROJECT_ID_ARG = "--daintree-initial-project-id=";
+const initialProjectId = process.argv
+  .find((a) => a.startsWith(INITIAL_PROJECT_ID_ARG))
+  ?.slice(INITIAL_PROJECT_ID_ARG.length);
+
 // Store MessagePort for direct Renderer ↔ Pty Host communication
 // Note: We cannot return MessagePort via contextBridge (it's not cloneable/transferable via that API).
 // Instead, we use window.postMessage to transfer it to the main world.
@@ -2701,5 +2712,14 @@ if (process.env.DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS === "1" && !isPackagedBuild)
 if (initialColorSchemeId) {
   contextBridge.exposeInMainWorld("__DAINTREE_INITIAL_THEME__", {
     colorSchemeId: initialColorSchemeId,
+  });
+}
+
+// Surface the destination project id (seeded via additionalArguments) so the
+// renderer resolves its project scope without a `?projectId=` query string,
+// keeping the document URL static for V8 bytecode cache reuse (#9162).
+if (initialProjectId) {
+  contextBridge.exposeInMainWorld("__DAINTREE_INITIAL_PROJECT__", {
+    id: initialProjectId,
   });
 }

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -28,9 +28,12 @@ import { logInfo, logWarn } from "../utils/logger.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import {
   injectSkeletonCss,
+  injectSkeletonProjectIdentity,
   resolveInitialColorSchemeId,
   INITIAL_COLOR_SCHEME_ARG,
+  INITIAL_PROJECT_ID_ARG,
 } from "./skeletonCss.js";
+import { projectStore } from "../services/ProjectStore.js";
 import { CHANNELS } from "../ipc/channels.js";
 import {
   attachRendererConsoleCapture,
@@ -957,7 +960,7 @@ export class ProjectViewManager {
     }
   }
 
-  private createView(_projectId: string): WebContentsView {
+  private createView(projectId: string): WebContentsView {
     const ses = session.fromPartition("persist:daintree");
 
     // Register app:// and daintree-file:// protocol handlers on this session.
@@ -979,8 +982,14 @@ export class ProjectViewManager {
         v8CacheOptions: "code",
         // Seed the renderer with the persisted theme so project-switch cold
         // starts and LRU-evicted views paint the saved scheme on first frame
-        // instead of a prefers-color-scheme default (#9169).
-        additionalArguments: [`${INITIAL_COLOR_SCHEME_ARG}=${resolveInitialColorSchemeId()}`],
+        // instead of a prefers-color-scheme default (#9169). The project id is
+        // threaded the same way instead of via a `?projectId=` query string so
+        // the document URL stays static and the V8 bytecode cache is shared
+        // across projects (#9162).
+        additionalArguments: [
+          `${INITIAL_COLOR_SCHEME_ARG}=${resolveInitialColorSchemeId()}`,
+          `${INITIAL_PROJECT_ID_ARG}=${projectId}`,
+        ],
       },
     });
   }
@@ -1022,9 +1031,25 @@ export class ProjectViewManager {
       wc.once("preload-error", onPreloadError);
       wc.once("render-process-gone", onProcessGone);
 
-      injectSkeletonCss(wc);
+      // Paint the skeleton on `dom-ready`, NOT before `loadURL`. `insertCSS`
+      // and `executeJavaScript` are scoped to the live document, and the
+      // navigation that `loadURL` kicks off discards anything injected into the
+      // prior (about:blank) context — so injecting here pre-navigation was a
+      // silent no-op. Mirrors the `dom-ready` wiring in createWindow.ts. `once`
+      // is correct because each cold start creates a fresh WebContentsView.
+      // Re-read the project inside the handler rather than closing over a value
+      // captured now, so the freshest name/emoji/color is painted (#9162).
+      wc.once("dom-ready", () => {
+        if (wc.isDestroyed()) return;
+        const project = projectStore.getProjectById(projectId);
+        injectSkeletonCss(wc, project);
+        injectSkeletonProjectIdentity(wc, project);
+      });
 
-      const encodedId = encodeURIComponent(projectId);
+      // The document URL is intentionally static (no `?projectId=`): the id
+      // travels via additionalArguments so the V8 bytecode cache stays shared
+      // across projects instead of fragmenting one entry per project (#9162).
+      //
       // Outer .catch surfaces any rejection from `wc.loadURL` itself; the inner
       // did-fail-load / preload-error / timeout handlers already reject the
       // outer Promise with a descriptive Error. ERR_ABORTED is the dominant
@@ -1039,11 +1064,10 @@ export class ProjectViewManager {
         });
       };
       if (process.env.NODE_ENV === "development") {
-        const devServerUrl = getDevServerUrl();
-        const url = `${devServerUrl}?projectId=${encodedId}`;
+        const url = getDevServerUrl();
         wc.loadURL(url).catch((err) => onLoadURLReject(err, url));
       } else {
-        const url = `app://daintree/index.html?projectId=${encodedId}`;
+        const url = "app://daintree/index.html";
         wc.loadURL(url).catch((err) => onLoadURLReject(err, url));
       }
     });

--- a/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
@@ -127,8 +127,14 @@ vi.mock("../../ipc/errorHandlers.js", () => ({
 
 vi.mock("../skeletonCss.js", () => ({
   injectSkeletonCss: vi.fn(),
+  injectSkeletonProjectIdentity: vi.fn(),
   INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
+  INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
   resolveInitialColorSchemeId: vi.fn(() => "daintree"),
+}));
+
+vi.mock("../../services/ProjectStore.js", () => ({
+  projectStore: { getProjectById: vi.fn(() => null) },
 }));
 
 vi.mock("../../utils/webContentsLifecycle.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -111,8 +111,14 @@ vi.mock("../../ipc/errorHandlers.js", () => ({
 
 vi.mock("../skeletonCss.js", () => ({
   injectSkeletonCss: vi.fn(),
+  injectSkeletonProjectIdentity: vi.fn(),
   INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
+  INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
   resolveInitialColorSchemeId: vi.fn(() => "daintree"),
+}));
+
+vi.mock("../../services/ProjectStore.js", () => ({
+  projectStore: { getProjectById: vi.fn(() => null) },
 }));
 
 vi.mock("../rendererConsoleCapture.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
@@ -133,8 +133,14 @@ vi.mock("../../ipc/errorHandlers.js", () => ({
 
 vi.mock("../skeletonCss.js", () => ({
   injectSkeletonCss: vi.fn(),
+  injectSkeletonProjectIdentity: vi.fn(),
   INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
+  INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
   resolveInitialColorSchemeId: vi.fn(() => "daintree"),
+}));
+
+vi.mock("../../services/ProjectStore.js", () => ({
+  projectStore: { getProjectById: vi.fn(() => null) },
 }));
 
 vi.mock("../rendererConsoleCapture.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.freeze.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.freeze.test.ts
@@ -82,8 +82,14 @@ vi.mock("../../ipc/errorHandlers.js", () => ({
 
 vi.mock("../skeletonCss.js", () => ({
   injectSkeletonCss: vi.fn(),
+  injectSkeletonProjectIdentity: vi.fn(),
   INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
+  INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
   resolveInitialColorSchemeId: vi.fn(() => "daintree"),
+}));
+
+vi.mock("../../services/ProjectStore.js", () => ({
+  projectStore: { getProjectById: vi.fn(() => null) },
 }));
 
 vi.mock("../../utils/webContentsLifecycle.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.gc.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.gc.test.ts
@@ -83,8 +83,14 @@ vi.mock("../../ipc/errorHandlers.js", () => ({
 
 vi.mock("../skeletonCss.js", () => ({
   injectSkeletonCss: vi.fn(),
+  injectSkeletonProjectIdentity: vi.fn(),
   INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
+  INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
   resolveInitialColorSchemeId: vi.fn(() => "daintree"),
+}));
+
+vi.mock("../../services/ProjectStore.js", () => ({
+  projectStore: { getProjectById: vi.fn(() => null) },
 }));
 
 vi.mock("../../utils/webContentsLifecycle.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -133,8 +133,14 @@ vi.mock("../../ipc/errorHandlers.js", () => ({
 
 vi.mock("../skeletonCss.js", () => ({
   injectSkeletonCss: vi.fn(),
+  injectSkeletonProjectIdentity: vi.fn(),
   INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
+  INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
   resolveInitialColorSchemeId: vi.fn(() => "daintree"),
+}));
+
+vi.mock("../../services/ProjectStore.js", () => ({
+  projectStore: { getProjectById: vi.fn(() => null) },
 }));
 
 vi.mock("../rendererConsoleCapture.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -122,8 +122,14 @@ vi.mock("../../ipc/errorHandlers.js", () => ({
 
 vi.mock("../skeletonCss.js", () => ({
   injectSkeletonCss: vi.fn(),
+  injectSkeletonProjectIdentity: vi.fn(),
   INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
+  INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
   resolveInitialColorSchemeId: vi.fn(() => "daintree"),
+}));
+
+vi.mock("../../services/ProjectStore.js", () => ({
+  projectStore: { getProjectById: vi.fn(() => null) },
 }));
 
 vi.mock("../../utils/webContentsLifecycle.js", () => ({

--- a/electron/window/__tests__/skeletonCss.test.ts
+++ b/electron/window/__tests__/skeletonCss.test.ts
@@ -95,8 +95,8 @@ describe("injectSkeletonProjectIdentity (#9162)", () => {
     expect(wc.executeJavaScript).not.toHaveBeenCalled();
   });
 
-  it("the generated script mutates the real skeleton DOM correctly", () => {
-    const { JSDOM } = require("jsdom") as typeof import("jsdom");
+  it("the generated script mutates the real skeleton DOM correctly", async () => {
+    const { JSDOM } = await import("jsdom");
     const dom = new JSDOM(
       `<div id="startup-skeleton"><div class="skeleton-logo-section"><div class="skeleton-title"></div></div></div>`
     );

--- a/electron/window/__tests__/skeletonCss.test.ts
+++ b/electron/window/__tests__/skeletonCss.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const storeMock = vi.hoisted(() => ({
+  get: vi.fn((key: string) => {
+    if (key === "appState") return { sidebarWidth: 350, focusMode: false };
+    if (key === "appTheme") return { colorSchemeId: "daintree" };
+    return undefined;
+  }),
+  set: vi.fn(),
+}));
+
+vi.mock("../../store.js", () => ({ store: storeMock }));
+
+vi.mock("electron", () => ({
+  nativeTheme: { shouldUseDarkColors: true },
+}));
+
+import { injectSkeletonCss, injectSkeletonProjectIdentity } from "../skeletonCss.js";
+
+interface FakeWc {
+  insertCSS: ReturnType<typeof vi.fn>;
+  executeJavaScript: ReturnType<typeof vi.fn>;
+  isDestroyed: ReturnType<typeof vi.fn>;
+}
+
+function makeWc(): FakeWc {
+  return {
+    insertCSS: vi.fn(() => Promise.resolve("")),
+    executeJavaScript: vi.fn(() => Promise.resolve(undefined)),
+    isDestroyed: vi.fn(() => false),
+  };
+}
+
+describe("injectSkeletonCss accent override (#9162)", () => {
+  beforeEach(() => {
+    storeMock.get.mockClear();
+  });
+
+  it("paints the project color as the accent token when a color is set", () => {
+    const wc = makeWc();
+    injectSkeletonCss(wc as never, { color: "#ff0000" });
+    const css = wc.insertCSS.mock.calls[0]?.[0] as string;
+    expect(css).toContain("--theme-accent-primary: #ff0000");
+  });
+
+  it("leaves the theme accent untouched when no project is supplied", () => {
+    const wc = makeWc();
+    injectSkeletonCss(wc as never);
+    const css = wc.insertCSS.mock.calls[0]?.[0] as string;
+    expect(css).toContain("--theme-accent-primary:");
+    expect(css).not.toContain("--theme-accent-primary: #ff0000");
+  });
+
+  it("ignores an invalid color and falls back to the theme accent", () => {
+    const wc = makeWc();
+    injectSkeletonCss(wc as never, { color: "not-a-hex" });
+    const css = wc.insertCSS.mock.calls[0]?.[0] as string;
+    expect(css).toContain("--theme-accent-primary:");
+    expect(css).not.toContain("not-a-hex");
+  });
+});
+
+describe("injectSkeletonProjectIdentity (#9162)", () => {
+  it("paints emoji and name into the title via executeJavaScript", () => {
+    const wc = makeWc();
+    injectSkeletonProjectIdentity(wc as never, { name: "My Project", emoji: "🚀" });
+    expect(wc.executeJavaScript).toHaveBeenCalledTimes(1);
+    const script = wc.executeJavaScript.mock.calls[0]?.[0] as string;
+    expect(script).toContain("skeleton-title--identified");
+    expect(script).toContain("skeleton-logo-section--identified");
+    expect(script).toContain(JSON.stringify("🚀  My Project"));
+  });
+
+  it("uses the name alone when there is no emoji", () => {
+    const wc = makeWc();
+    injectSkeletonProjectIdentity(wc as never, { name: "Solo", emoji: "" });
+    const script = wc.executeJavaScript.mock.calls[0]?.[0] as string;
+    expect(script).toContain(JSON.stringify("Solo"));
+  });
+
+  it("escapes names that contain quotes and backslashes", () => {
+    const wc = makeWc();
+    const hostile = 'a";b\\c</script>';
+    injectSkeletonProjectIdentity(wc as never, { name: hostile, emoji: "" });
+    const script = wc.executeJavaScript.mock.calls[0]?.[0] as string;
+    // The raw payload must be JSON-encoded, never spliced in verbatim.
+    expect(script).toContain(JSON.stringify(hostile));
+    expect(script).not.toContain('"' + hostile + '"');
+  });
+
+  it("does nothing when the project has no resolvable name", () => {
+    const wc = makeWc();
+    injectSkeletonProjectIdentity(wc as never, { name: "   ", emoji: "🚀" });
+    injectSkeletonProjectIdentity(wc as never, null);
+    expect(wc.executeJavaScript).not.toHaveBeenCalled();
+  });
+});

--- a/electron/window/__tests__/skeletonCss.test.ts
+++ b/electron/window/__tests__/skeletonCss.test.ts
@@ -94,4 +94,28 @@ describe("injectSkeletonProjectIdentity (#9162)", () => {
     injectSkeletonProjectIdentity(wc as never, null);
     expect(wc.executeJavaScript).not.toHaveBeenCalled();
   });
+
+  it("the generated script mutates the real skeleton DOM correctly", () => {
+    const { JSDOM } = require("jsdom") as typeof import("jsdom");
+    const dom = new JSDOM(
+      `<div id="startup-skeleton"><div class="skeleton-logo-section"><div class="skeleton-title"></div></div></div>`
+    );
+    const wc = makeWc();
+    // U+2028 (line separator) would break a naive string-spliced script but is
+    // safe through JSON.stringify — execute the real generated script to prove it.
+    const name = "Edge Case";
+    injectSkeletonProjectIdentity(wc as never, { name, emoji: "✨" });
+    const script = wc.executeJavaScript.mock.calls[0]?.[0] as string;
+
+    // Execute the real generated script with jsdom's document in scope (the
+    // script references a free `document`, which we bind as a parameter).
+    const run = new Function("document", script) as (d: unknown) => void;
+    run(dom.window.document);
+
+    const title = dom.window.document.querySelector("#startup-skeleton .skeleton-title");
+    const section = dom.window.document.querySelector("#startup-skeleton .skeleton-logo-section");
+    expect(title?.textContent).toBe(`✨  ${name}`);
+    expect(title?.classList.contains("skeleton-title--identified")).toBe(true);
+    expect(section?.classList.contains("skeleton-logo-section--identified")).toBe(true);
+  });
 });

--- a/electron/window/skeletonCss.ts
+++ b/electron/window/skeletonCss.ts
@@ -9,8 +9,13 @@
  */
 import { nativeTheme, type WebContents } from "electron";
 import { store } from "../store.js";
-import { resolveAppTheme, getAppThemeCssVariables } from "../../shared/theme/index.js";
+import {
+  resolveAppTheme,
+  getAppThemeCssVariables,
+  applyAccentOverrideToScheme,
+} from "../../shared/theme/index.js";
 import type { AppColorScheme } from "../../shared/theme/index.js";
+import type { Project } from "../../shared/types/project.js";
 import {
   appCustomSchemesReadSchema,
   appCustomSchemesWriteSchema,
@@ -25,6 +30,17 @@ import {
  * saved theme instead of a `prefers-color-scheme` default (#9169).
  */
 export const INITIAL_COLOR_SCHEME_ARG = "--daintree-initial-color-scheme-id";
+
+/**
+ * Command-line argument carrying the destination project id from the main
+ * process into each project-switch `WebContentsView`. Replaces the former
+ * `?projectId=` query string on `loadURL` so the document URL stays static
+ * across projects, keeping the V8 bytecode cache (`v8CacheOptions: "code"`)
+ * keyed to a single URL instead of fragmenting one entry per project (#9162).
+ * Read synchronously in preload.cts from `process.argv` and exposed as
+ * `window.__DAINTREE_INITIAL_PROJECT__`.
+ */
+export const INITIAL_PROJECT_ID_ARG = "--daintree-initial-project-id";
 
 /**
  * Resolves the color scheme id to seed the renderer with on cold start.
@@ -50,7 +66,14 @@ export function resolveInitialColorSchemeId(): string {
     : "bondi";
 }
 
-export function injectSkeletonCss(wc: WebContents): void {
+/**
+ * Inject the first-paint skeleton CSS custom properties. When a cold-start
+ * project switch supplies the destination `project`, its accent color (when
+ * set) overrides the theme's native accent tokens so the skeleton paints the
+ * project's brand color before React mounts (#9162). Passing `null`/`undefined`
+ * (the initial-window path) leaves the resolved scheme untouched.
+ */
+export function injectSkeletonCss(wc: WebContents, project?: Pick<Project, "color"> | null): void {
   const appState = store.get("appState");
   const sidebarWidth = appState?.sidebarWidth ?? 350;
   const focusMode = appState?.focusMode ?? false;
@@ -81,7 +104,10 @@ export function injectSkeletonCss(wc: WebContents): void {
     }
   }
   const scheme = resolveAppTheme(colorSchemeId, customSchemes);
-  const themeVars = getAppThemeCssVariables(scheme);
+  // Paint the destination project's accent on cold starts. Safe to call
+  // unconditionally — a missing or invalid color returns the scheme unchanged.
+  const themedScheme = applyAccentOverrideToScheme(scheme, project?.color);
+  const themeVars = getAppThemeCssVariables(themedScheme);
 
   // Build CSS string
   const lines: string[] = [":root {"];
@@ -113,4 +139,30 @@ export function injectSkeletonCss(wc: WebContents): void {
   }
 
   void wc.insertCSS(lines.join("\n"), { cssOrigin: "user" });
+}
+
+/**
+ * Paint the destination project's name and emoji into the cold-start skeleton's
+ * title element via `executeJavaScript` (#9162). CSS alone can't set text
+ * content on `.skeleton-title`, so this mutates the DOM directly. Must run
+ * after `dom-ready` (the element must exist) — the no-op shimmer placeholder
+ * stays for projects with no resolvable name. The injected values are passed
+ * through `JSON.stringify` so emoji and arbitrary names can't break out of the
+ * string literal.
+ */
+export function injectSkeletonProjectIdentity(
+  wc: WebContents,
+  project: Pick<Project, "name" | "emoji"> | null | undefined
+): void {
+  const name = typeof project?.name === "string" ? project.name.trim() : "";
+  if (!name) return;
+  const emoji = typeof project?.emoji === "string" ? project.emoji.trim() : "";
+  const label = emoji ? `${emoji}  ${name}` : name;
+  const labelLiteral = JSON.stringify(label);
+  const script = `(function(){try{var t=document.querySelector('#startup-skeleton .skeleton-title');if(t){t.textContent=${labelLiteral};t.classList.add('skeleton-title--identified');}var s=document.querySelector('#startup-skeleton .skeleton-logo-section');if(s){s.classList.add('skeleton-logo-section--identified');}}catch(e){}})();`;
+  void wc.executeJavaScript(script, true).catch(() => {
+    // Best-effort first-paint enhancement: a destroyed/navigated context is
+    // expected during rapid project switching. Swallow — the generic skeleton
+    // remains a correct fallback.
+  });
 }

--- a/index.html
+++ b/index.html
@@ -925,6 +925,12 @@
           animation: none;
           opacity: 1;
         }
+        /* Show the painted project name immediately — its reveal is motion, not
+           a timing signal, so reduced-motion users must still see it (#9162). */
+        .skeleton-title.skeleton-title--identified {
+          animation: none;
+          opacity: 1;
+        }
         /* Snap the stuck-state in without a fade. Duration 0ms preserves the
            6s safety delay (the timing mechanism) while removing the motion. */
         .skeleton-stuck {

--- a/index.html
+++ b/index.html
@@ -420,6 +420,36 @@
         animation: skeleton-shimmer 1.5s linear infinite;
       }
 
+      /* ── Project identity (painted on cold-start switch — #9162) ──
+         When the main process resolves the destination project it sets the
+         title's text content and adds these classes, collapsing the shimmer
+         placeholder into real "emoji  name" text and tinting the logo with the
+         project's accent color. */
+      .skeleton-title.skeleton-title--identified {
+        width: auto;
+        height: auto;
+        min-height: 28px;
+        overflow: visible;
+        background: none;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 18px;
+        font-weight: 600;
+        line-height: 1.4;
+        color: var(--theme-text-primary, #e4e4e7);
+        opacity: 0;
+        animation: skeleton-reveal 400ms ease-out forwards;
+      }
+      .skeleton-title.skeleton-title--identified::after {
+        content: none;
+        animation: none;
+      }
+      .skeleton-logo-section--identified .skeleton-logo {
+        color: var(--theme-accent-primary, #e4e4e7);
+        opacity: 0.16;
+      }
+
       /* ── Tagline (real text — synced with WelcomeScreen.tsx) ── */
       .skeleton-tagline {
         margin-top: 12px;

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -166,6 +166,13 @@ function cancelProjectReadRequests(): void {
 function getLocationProjectId(): string | null {
   if (typeof window === "undefined") return null;
 
+  // Prefer the id seeded by preload via additionalArguments (#9162). The
+  // `?projectId=` query string fallback covers the initial-window load
+  // (createWindow.ts still passes it) and any test/shell view without the
+  // bootstrap global.
+  const seeded = window.__DAINTREE_INITIAL_PROJECT__?.id;
+  if (seeded) return seeded;
+
   try {
     return new URL(window.location.href).searchParams.get("projectId");
   } catch {

--- a/src/store/worktreeFilterStore.ts
+++ b/src/store/worktreeFilterStore.ts
@@ -171,6 +171,11 @@ const GLOBAL_KEY = "daintree-worktree-filters";
  */
 function resolveProjectIdFromUrl(): string {
   if (typeof window === "undefined") return "default";
+  // Prefer the id seeded by preload via additionalArguments (#9162); preload
+  // runs before this module evaluates, so the global is available. Fall back to
+  // the `?projectId=` query string (initial-window load) and finally "default".
+  const seeded = window.__DAINTREE_INITIAL_PROJECT__?.id;
+  if (seeded && seeded.length > 0) return seeded;
   try {
     const fromUrl = new URLSearchParams(window.location.search).get("projectId");
     return fromUrl && fromUrl.length > 0 ? fromUrl : "default";

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -29,6 +29,8 @@ declare global {
     __DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS__?: boolean;
     /** Persisted color scheme id seeded by preload for first-paint theming (#9169). */
     __DAINTREE_INITIAL_THEME__?: { colorSchemeId: string };
+    /** Destination project id seeded by preload, replacing the `?projectId=` query string (#9162). */
+    __DAINTREE_INITIAL_PROJECT__?: { id: string };
     __daintreeDispatchAction?: (
       actionId: string,
       args?: unknown,


### PR DESCRIPTION
## Summary

- Cold-start project switches showed a generic skeleton with no project identity. This paints the name, emoji, and accent color in before React mounts.
- Fixed a latent no-op: `injectSkeletonCss` was running before `loadURL`, so the navigation discarded it. Moved to `wc.once("dom-ready")`.
- Threaded `projectId` through `additionalArguments` instead of a `?projectId=` URL query string, keeping the document URL static for V8 bytecode cache reuse. Renderer stores read the seeded value with URL fallback.

Resolves #9162

## Changes

- `electron/window/skeletonCss.ts` — extended `injectSkeletonCss` to override accent tokens via `applyAccentOverrideToScheme`; added `injectSkeletonProjectIdentity` to paint `"emoji  name"` into `.skeleton-title` via `executeJavaScript` (JSON-escaped, U+2028-safe) and tint the logo
- `electron/window/ProjectViewManager.ts` — moved injection to `dom-ready`, removed `?projectId=` from `loadURL`, threads `projectId` via `additionalArguments → window.__DAINTREE_INITIAL_PROJECT__`
- `electron/preload.cts` — exposes `__DAINTREE_INITIAL_PROJECT__` to the renderer
- `src/store/projectStore.ts`, `src/store/worktreeFilterStore.ts` — read seeded project id with URL fallback
- `index.html` — reduced-motion handling for the painted skeleton title
- `electron/window/__tests__/skeletonCss.test.ts` — 8 unit tests covering accent override, identity escaping, DOM mutation, and guards

## Testing

Typecheck, lint, and format clean. 8 unit tests added covering accent token override, project identity injection (including U+2028 line separator escaping), DOM mutation, and guard conditions. Warm-cached path and the `createWindow` initial load are unchanged.