### PR TITLE
fix(plugin): sync plugin lifecycle to LRU-evicted views on revival

### DIFF
--- a/e2e/full/resilience/plugin-lifecycle-lru-eviction.spec.ts
+++ b/e2e/full/resilience/plugin-lifecycle-lru-eviction.spec.ts
@@ -1,0 +1,256 @@
+import { test, expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
+import { createFixtureRepos } from "../../helpers/fixtures";
+import { openAndOnboardProject } from "../../helpers/project";
+import { addAndSwitchToProject, selectExistingProjectAndRefresh } from "../../helpers/workflows";
+
+// Plugin lifecycle sync must survive LRU project-view eviction (#9285): a view
+// evicted (destroyed) while a plugin is installed/uninstalled must reflect the
+// current plugin contribution set once it cold-starts — its mount-time pull is
+// the only reconciliation path, since the broadcast fired into a dead view.
+
+const PROJECT_A = "project-A";
+const PROJECT_B = "project-B";
+const PROJECT_C = "project-C";
+
+// cache=2 over three projects evicts exactly one LRU view per switch — the same
+// determinism the core eviction spec relies on.
+const CACHE_LIMIT = 2;
+
+const PLUGIN_ID = "e2e.lifecycle";
+const ACTION_ID = "e2e.lifecycle.ping";
+const ACTION_CONTRIBUTION = {
+  id: ACTION_ID,
+  title: "Lifecycle ping",
+  description: "E2E lifecycle-sync probe action",
+  category: "plugin",
+  kind: "command",
+  danger: "safe",
+} as const;
+
+let ctx: AppContext;
+let fixtureCleanups: Array<() => void> = [];
+let pluginRoot = "";
+let pluginDir = "";
+let projectIdA = "";
+let projectIdC = "";
+
+async function configurePvm(app: AppContext["app"], limit: number): Promise<void> {
+  await app.evaluate((_electron, n) => {
+    const g = globalThis as Record<string, unknown>;
+    const getPvm = g.__daintreeGetPvm as (() => unknown) | undefined;
+    const pvm = getPvm?.() as
+      | {
+          setCachedViewLimit: (n: number) => void;
+          setLowMemoryFreeThresholdMb?: (mb: number | null) => void;
+        }
+      | null
+      | undefined;
+    pvm?.setLowMemoryFreeThresholdMb?.(null);
+    pvm?.setCachedViewLimit(n);
+  }, limit);
+}
+
+async function readPvmState(app: AppContext["app"]): Promise<{
+  projectIds: string[];
+  activeProjectId: string | null;
+  viewCount: number;
+}> {
+  return app.evaluate(() => {
+    const g = globalThis as Record<string, unknown>;
+    const getPvm = g.__daintreeGetPvm as (() => unknown) | undefined;
+    const pvm = getPvm?.() as
+      | {
+          getAllViews: () => Array<{ projectId: string }>;
+          getActiveProjectId: () => string | null;
+        }
+      | null
+      | undefined;
+    if (!pvm) return { projectIds: [], activeProjectId: null, viewCount: -1 };
+    const views = pvm.getAllViews();
+    return {
+      projectIds: views.map((v) => v.projectId),
+      activeProjectId: pvm.getActiveProjectId(),
+      viewCount: views.length,
+    };
+  });
+}
+
+async function requireActiveProjectId(app: AppContext["app"], label: string): Promise<string> {
+  const state = await readPvmState(app);
+  if (!state.activeProjectId) {
+    throw new Error(`[plugin-lru] expected active project id after opening ${label}`);
+  }
+  return state.activeProjectId;
+}
+
+async function evictProjectA(app: AppContext["app"]): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const state = await readPvmState(app);
+        return (
+          state.activeProjectId === projectIdC &&
+          !state.projectIds.includes(projectIdA) &&
+          state.viewCount >= 1 &&
+          state.viewCount <= CACHE_LIMIT
+        );
+      },
+      { timeout: 15_000, intervals: [200, 400, 800, 1600] }
+    )
+    .toBe(true);
+}
+
+async function loadFixturePlugin(app: AppContext["app"]): Promise<number> {
+  return app.evaluate(async (_electron, dir) => {
+    const g = globalThis as Record<string, unknown>;
+    const load = g.__daintreeE2ELoadPlugin as ((d: string) => Promise<number>) | undefined;
+    return load ? load(dir) : -1;
+  }, pluginRoot);
+}
+
+async function unloadFixturePlugin(app: AppContext["app"]): Promise<void> {
+  await app.evaluate(async (_electron, id) => {
+    const g = globalThis as Record<string, unknown>;
+    const unload = g.__daintreeE2EUnloadPlugin as ((i: string) => Promise<void>) | undefined;
+    if (unload) await unload(id);
+  }, PLUGIN_ID);
+}
+
+async function registerFixtureAction(window: Page): Promise<void> {
+  await window.evaluate(
+    async ({ pluginId, action }) => {
+      const api = (
+        window as unknown as {
+          electron?: {
+            plugin?: { registerAction: (id: string, c: unknown) => Promise<void> };
+          };
+        }
+      ).electron?.plugin;
+      if (api) await api.registerAction(pluginId, action);
+    },
+    { pluginId: PLUGIN_ID, action: ACTION_CONTRIBUTION }
+  );
+}
+
+async function hasFixtureAction(window: Page): Promise<boolean> {
+  return window.evaluate((id) => {
+    const fn = (window as unknown as { __daintreeHasAction?: (a: string) => boolean })
+      .__daintreeHasAction;
+    return fn ? fn(id) : false;
+  }, ACTION_ID);
+}
+
+test.describe.serial("Full: plugin lifecycle sync survives LRU project-view eviction", () => {
+  test.beforeAll(async () => {
+    test.setTimeout(300_000);
+    const fixtures = createFixtureRepos(3);
+    fixtureCleanups = fixtures.map((f) => f.cleanup);
+    const [repoA, repoB, repoC] = fixtures.map((f) => f.dir);
+
+    // Fixture plugin: a manifest-only plugin (no main entry). The action is
+    // registered at runtime via the plugin:actions-register IPC, matching how
+    // a plugin contributes actions today.
+    pluginRoot = mkdtempSync(join(tmpdir(), "daintree-e2e-plugin-"));
+    pluginDir = join(pluginRoot, "lifecycle");
+    mkdirSync(pluginDir, { recursive: true });
+    writeFileSync(
+      join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: PLUGIN_ID,
+        displayName: "Lifecycle E2E",
+        version: "1.0.0",
+        engines: { daintree: "*" },
+      })
+    );
+
+    ctx = await launchApp();
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, repoA, PROJECT_A);
+    projectIdA = await requireActiveProjectId(ctx.app, PROJECT_A);
+
+    await configurePvm(ctx.app, CACHE_LIMIT);
+
+    ctx.window = await addAndSwitchToProject(ctx.app, ctx.window, repoB, PROJECT_B);
+    ctx.window = await addAndSwitchToProject(ctx.app, ctx.window, repoC, PROJECT_C);
+    projectIdC = await requireActiveProjectId(ctx.app, PROJECT_C);
+
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_A);
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) {
+      await unloadFixturePlugin(ctx.app).catch(() => undefined);
+      await configurePvm(ctx.app, 5).catch(() => undefined);
+      await closeApp(ctx.app);
+    }
+    for (const cleanup of fixtureCleanups) cleanup();
+    if (pluginRoot) rmSync(pluginRoot, { recursive: true, force: true });
+  });
+
+  test("a plugin action installed while a view is active survives that view's eviction", async () => {
+    test.slow();
+
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_A);
+
+    // Install: load the plugin in main, then register its action (broadcasts to
+    // every live view, including the active A).
+    expect(await loadFixturePlugin(ctx.app)).toBe(1);
+    await registerFixtureAction(ctx.window);
+    await expect.poll(() => hasFixtureAction(ctx.window), { timeout: 10_000 }).toBe(true);
+
+    // A→B→C with cache=2 evicts A's WebContentsView.
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_B);
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_C);
+    await evictProjectA(ctx.app);
+
+    // Cold-start A: its mount-time pull must return the full action set (the
+    // gate on PluginService init makes this race-free), so the action is back.
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_A);
+    await expect.poll(() => hasFixtureAction(ctx.window), { timeout: 10_000 }).toBe(true);
+  });
+
+  test("a plugin uninstalled while a view is evicted is gone after the view revives", async () => {
+    test.slow();
+
+    // Precondition: plugin loaded with its action present on A (carried from the
+    // previous test; re-assert so this test is self-describing).
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_A);
+    await expect.poll(() => hasFixtureAction(ctx.window), { timeout: 10_000 }).toBe(true);
+
+    // Evict A, then uninstall the plugin while A's view is destroyed — the
+    // removal broadcast fires into the live views only, never reaching A.
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_B);
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_C);
+    await evictProjectA(ctx.app);
+    await unloadFixturePlugin(ctx.app);
+
+    // Revived A must reconcile to the current (empty) set off its pull — the
+    // stale action must not linger.
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_A);
+    await expect.poll(() => hasFixtureAction(ctx.window), { timeout: 10_000 }).toBe(false);
+  });
+
+  test("a plugin installed while a view is evicted appears after the view revives", async () => {
+    test.slow();
+
+    // Precondition: plugin not loaded (uninstalled in the previous test).
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_A);
+    await expect.poll(() => hasFixtureAction(ctx.window), { timeout: 10_000 }).toBe(false);
+
+    // Evict A, then install the plugin + register its action while A is dead.
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_B);
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_C);
+    await evictProjectA(ctx.app);
+    expect(await loadFixturePlugin(ctx.app)).toBe(1);
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_C);
+    await registerFixtureAction(ctx.window);
+
+    // Revived A picks up the install off its mount-time pull.
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_A);
+    await expect.poll(() => hasFixtureAction(ctx.window), { timeout: 10_000 }).toBe(true);
+  });
+});

--- a/e2e/full/resilience/plugin-lifecycle-lru-eviction.spec.ts
+++ b/e2e/full/resilience/plugin-lifecycle-lru-eviction.spec.ts
@@ -165,6 +165,12 @@ test.describe.serial("Full: plugin lifecycle sync survives LRU project-view evic
         displayName: "Lifecycle E2E",
         version: "1.0.0",
         engines: { daintree: "*" },
+        // A toolbar button contribution so load/unload also drive the gated
+        // toolbar-buttons pull + stale-prune sweep path on a revived view, not
+        // just the actions path.
+        contributes: {
+          toolbarButtons: [{ id: "ping", label: "Ping", iconId: "puzzle", actionId: ACTION_ID }],
+        },
       })
     );
 

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -8,6 +8,7 @@ const mockListPluginActions = vi.fn();
 const mockRegisterPluginAction = vi.fn();
 const mockUnregisterPluginAction = vi.fn();
 const mockWaitForInitialized = vi.fn();
+let mockIsInitialized = true;
 
 vi.mock("../../../services/PluginService.js", () => ({
   pluginService: {
@@ -20,7 +21,7 @@ vi.mock("../../../services/PluginService.js", () => ({
     unregisterPluginAction: (...args: unknown[]) => mockUnregisterPluginAction(...args),
     waitForInitialized: (...args: unknown[]) => mockWaitForInitialized(...args),
     get isInitialized() {
-      return true;
+      return mockIsInitialized;
     },
   },
 }));
@@ -68,6 +69,7 @@ beforeEach(() => {
   mockGetRegisteredForgeProviders.mockReturnValue([]);
   mockGetFileDecorationImpls.mockReturnValue([]);
   mockWaitForInitialized.mockResolvedValue(undefined);
+  mockIsInitialized = true;
   _resetIpcGuardForTesting();
   markIpcSecurityReady();
 });
@@ -544,6 +546,12 @@ describe("PLUGIN_TOOLBAR_BUTTONS handler", () => {
     expect(await handler({})).toEqual({ buttons: [], complete: true });
   });
 
+  it("reports complete:false when the scan has not settled", async () => {
+    mockIsInitialized = false;
+    const handler = getHandler();
+    expect(await handler({})).toEqual({ buttons: [], complete: false });
+  });
+
   it("filters out ids with no config", async () => {
     mockGetPluginToolbarButtonIds.mockReturnValue(["plugin.acme.foo", "plugin.orphan"]);
     const config = {
@@ -570,10 +578,18 @@ describe("PLUGIN_ACTIONS_GET / PANEL_KINDS_GET init gating", () => {
     ) => unknown;
   }
 
-  it("PLUGIN_ACTIONS_GET awaits waitForInitialized before listing actions", async () => {
+  it("PLUGIN_ACTIONS_GET does not read the registry until waitForInitialized resolves", async () => {
+    let resolveInit: (() => void) | undefined;
+    mockWaitForInitialized.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveInit = resolve;
+      })
+    );
     const handler = getHandler("plugin:actions-get");
-    await handler({});
-    expect(mockWaitForInitialized).toHaveBeenCalledTimes(1);
+    const pending = handler({}) as Promise<unknown>;
+    expect(mockListPluginActions).not.toHaveBeenCalled();
+    resolveInit!();
+    await pending;
     expect(mockListPluginActions).toHaveBeenCalled();
   });
 

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -7,6 +7,7 @@ const mockListPlugins = vi.fn();
 const mockListPluginActions = vi.fn();
 const mockRegisterPluginAction = vi.fn();
 const mockUnregisterPluginAction = vi.fn();
+const mockWaitForInitialized = vi.fn();
 
 vi.mock("../../../services/PluginService.js", () => ({
   pluginService: {
@@ -17,6 +18,10 @@ vi.mock("../../../services/PluginService.js", () => ({
     listPluginActions: (...args: unknown[]) => mockListPluginActions(...args),
     registerPluginAction: (...args: unknown[]) => mockRegisterPluginAction(...args),
     unregisterPluginAction: (...args: unknown[]) => mockUnregisterPluginAction(...args),
+    waitForInitialized: (...args: unknown[]) => mockWaitForInitialized(...args),
+    get isInitialized() {
+      return true;
+    },
   },
 }));
 
@@ -62,6 +67,7 @@ beforeEach(() => {
   mockListPluginActions.mockReturnValue([]);
   mockGetRegisteredForgeProviders.mockReturnValue([]);
   mockGetFileDecorationImpls.mockReturnValue([]);
+  mockWaitForInitialized.mockResolvedValue(undefined);
   _resetIpcGuardForTesting();
   markIpcSecurityReady();
 });
@@ -494,6 +500,87 @@ describe("PLUGIN_ACTIONS_GET / REGISTER / UNREGISTER handlers", () => {
       "acme.my-plugin",
       "acme.my-plugin.doThing"
     );
+  });
+});
+
+describe("PLUGIN_TOOLBAR_BUTTONS handler", () => {
+  function getHandler() {
+    registerPluginHandlers();
+    return mockIpcMainHandle.mock.calls.find(
+      (c: unknown[]) => c[0] === "plugin:toolbar-buttons"
+    )![1] as (...args: unknown[]) => unknown;
+  }
+
+  it("awaits pluginService.waitForInitialized before reading the registry", async () => {
+    let resolveInit: (() => void) | undefined;
+    mockWaitForInitialized.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveInit = resolve;
+      })
+    );
+    const config = {
+      id: "plugin.acme.foo",
+      label: "Foo",
+      iconId: "i",
+      actionId: "acme.do",
+      priority: 3,
+      pluginId: "acme",
+    };
+    mockGetPluginToolbarButtonIds.mockReturnValue(["plugin.acme.foo"]);
+    mockGetToolbarButtonConfig.mockReturnValue(config);
+
+    const handler = getHandler();
+    const pending = handler({}) as Promise<{ buttons: unknown[]; complete: boolean }>;
+    // Registry must not be read until init settles.
+    expect(mockGetPluginToolbarButtonIds).not.toHaveBeenCalled();
+    resolveInit!();
+    const result = await pending;
+    expect(mockGetPluginToolbarButtonIds).toHaveBeenCalled();
+    expect(result).toEqual({ buttons: [config], complete: true });
+  });
+
+  it("returns { buttons: [], complete: true } when no plugin buttons are registered", async () => {
+    const handler = getHandler();
+    expect(await handler({})).toEqual({ buttons: [], complete: true });
+  });
+
+  it("filters out ids with no config", async () => {
+    mockGetPluginToolbarButtonIds.mockReturnValue(["plugin.acme.foo", "plugin.orphan"]);
+    const config = {
+      id: "plugin.acme.foo",
+      label: "Foo",
+      iconId: "i",
+      actionId: "acme.do",
+      priority: 3,
+      pluginId: "acme",
+    };
+    mockGetToolbarButtonConfig.mockImplementation((id: string) =>
+      id === "plugin.acme.foo" ? config : undefined
+    );
+    const handler = getHandler();
+    expect(await handler({})).toEqual({ buttons: [config], complete: true });
+  });
+});
+
+describe("PLUGIN_ACTIONS_GET / PANEL_KINDS_GET init gating", () => {
+  function getHandler(channel: string) {
+    registerPluginHandlers();
+    return mockIpcMainHandle.mock.calls.find((c: unknown[]) => c[0] === channel)![1] as (
+      ...args: unknown[]
+    ) => unknown;
+  }
+
+  it("PLUGIN_ACTIONS_GET awaits waitForInitialized before listing actions", async () => {
+    const handler = getHandler("plugin:actions-get");
+    await handler({});
+    expect(mockWaitForInitialized).toHaveBeenCalledTimes(1);
+    expect(mockListPluginActions).toHaveBeenCalled();
+  });
+
+  it("PLUGIN_PANEL_KINDS_GET awaits waitForInitialized before reading kinds", async () => {
+    const handler = getHandler("plugin:panel-kinds-get");
+    await handler({});
+    expect(mockWaitForInitialized).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -33,10 +33,20 @@ async function handleList(): Promise<LoadedPluginInfo[]> {
   return pluginService.listPlugins();
 }
 
-async function handleToolbarButtons(): Promise<ToolbarButtonConfig[]> {
-  return getPluginToolbarButtonIds()
+async function handleToolbarButtons(): Promise<{
+  buttons: ToolbarButtonConfig[];
+  complete: boolean;
+}> {
+  // Block a cold-started view's mount-time pull until the plugin scan settles,
+  // so it gets the full set instead of an empty registry mid-init (#9285).
+  await pluginService.waitForInitialized();
+  const buttons = getPluginToolbarButtonIds()
     .map((id) => getToolbarButtonConfig(id))
     .filter((c): c is ToolbarButtonConfig => c !== undefined);
+  // Once init has settled the registry is authoritative, so the renderer may
+  // sweep stale `plugin.*` pins against this snapshot — the case (uninstall
+  // while the view was evicted) the pull-side sweep exists for.
+  return { buttons, complete: pluginService.isInitialized };
 }
 
 async function handleMenuItems() {
@@ -84,6 +94,9 @@ async function handleValidateActionIds(actionIds: string[]): Promise<void> {
 // gives it direct access to event.senderFrame — the typed path here does
 // not and doesn't need it.
 async function handleActionsGet(): Promise<PluginActionDescriptor[]> {
+  // See handleToolbarButtons: gate the cold-start pull on the plugin scan so a
+  // revived view doesn't register an empty action set (#9285).
+  await pluginService.waitForInitialized();
   return pluginService.listPluginActions();
 }
 
@@ -99,6 +112,9 @@ async function handleActionsUnregister(pluginId: string, actionId: string): Prom
 }
 
 async function handlePanelKindsGet(): Promise<PanelKindConfig[]> {
+  // See handleToolbarButtons: gate the cold-start pull on the plugin scan so a
+  // revived view's panel-kind registry isn't seeded empty (#9285).
+  await pluginService.waitForInitialized();
   return getPluginPanelKinds();
 }
 

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -45,7 +45,10 @@ async function handleToolbarButtons(): Promise<{
     .filter((c): c is ToolbarButtonConfig => c !== undefined);
   // Once init has settled the registry is authoritative, so the renderer may
   // sweep stale `plugin.*` pins against this snapshot — the case (uninstall
-  // while the view was evicted) the pull-side sweep exists for.
+  // while the view was evicted) the pull-side sweep exists for. `isInitialized`
+  // is true even if the scan threw (the finally in runInitialize still flips
+  // it); a plugin that failed to load has no buttons here, so sweeping its
+  // orphaned pins is the correct outcome rather than a data-loss bug.
   return { buttons, complete: pluginService.isInitialized };
 }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -336,6 +336,21 @@ if (!gotTheLock) {
       (globalThis as Record<string, unknown>).__daintreeGetPvm = getProjectViewManager;
       (globalThis as Record<string, unknown>).__daintreeWriteHeapSnapshot = (filePath: string) =>
         nodeV8.writeHeapSnapshot(filePath);
+      // Plugin install/uninstall harness for the lifecycle-sync spec (#9285).
+      // Loads/unloads a fixture plugin directory at runtime so a spec can
+      // verify contribution sync survives LRU eviction without a production
+      // runtime-install IPC path. Gated on E2E mode only.
+      (globalThis as Record<string, unknown>).__daintreeE2ELoadPlugin = async (dir: string) => {
+        const { pluginService } = await import("./services/PluginService.js");
+        await pluginService.waitForInitialized();
+        return pluginService.loadPluginDir(dir);
+      };
+      (globalThis as Record<string, unknown>).__daintreeE2EUnloadPlugin = async (
+        pluginId: string
+      ) => {
+        const { pluginService } = await import("./services/PluginService.js");
+        pluginService.unloadPlugin(pluginId);
+      };
     }
 
     // Clean up ProjectViewManager when the window's cleanup runs.

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -174,6 +174,15 @@ export class PluginService {
   }> = [];
   private initialized = false;
   /**
+   * In-flight {@link initialize} run, shared by every concurrent caller so the
+   * plugin scan runs exactly once. Stays non-null after the first call (it
+   * resolves once init settles); the `initialized` early-return short-circuits
+   * later callers before they ever reach it. {@link waitForInitialized} reads
+   * this to block a cold-started renderer's pull until the scan completes
+   * instead of handing back an empty registry mid-init (#9285).
+   */
+  private initializePromise: Promise<void> | null = null;
+  /**
    * Plugin ids that are owned by a built-in plugin but currently disabled in
    * Preferences. Held alongside `this.plugins` so the user-dir scan cannot
    * register a third-party plugin under a trusted first-party namespace just
@@ -264,7 +273,16 @@ export class PluginService {
 
   async initialize(): Promise<void> {
     if (this.initialized) return;
+    // Coalesce concurrent callers (the deferred boot task and any IPC handler
+    // that hit waitForInitialized() first) onto a single scan — without this
+    // both would re-run loadFromDir and the contribution registries would log
+    // "already registered, overwriting" warnings.
+    if (this.initializePromise) return this.initializePromise;
+    this.initializePromise = this.runInitialize();
+    return this.initializePromise;
+  }
 
+  private async runInitialize(): Promise<void> {
     // Built-ins load first so user plugins with a colliding manifest.name are
     // rejected by the duplicate guard in loadPlugin() — built-in wins.
     const builtinDir = this.builtinPluginsRoot ?? this.getBuiltinDir();
@@ -280,8 +298,39 @@ export class PluginService {
       // Idempotency must hold even when a scan throws (e.g. EACCES on the
       // user dir): a retry would re-run the built-in scan and trigger
       // "already registered, overwriting" warnings from the contribution
-      // registries.
+      // registries. Set inside `finally` so a partial scan still flips the
+      // flag — a revived view should get whatever actually registered, not
+      // hang forever waiting on a failed init (see waitForInitialized).
       this.initialized = true;
+    }
+  }
+
+  /**
+   * Whether the one-time plugin scan has settled (successfully or not). Used by
+   * the toolbar-buttons IPC handler to mark a pulled snapshot as authoritative:
+   * once init is done the registry holds the complete set, so the renderer may
+   * safely sweep stale `plugin.*` pins against it.
+   */
+  get isInitialized(): boolean {
+    return this.initialized;
+  }
+
+  /**
+   * Resolve once the plugin scan has settled. A cold-started (LRU-revived)
+   * renderer mounts its plugin hooks and pulls before the deferred init task
+   * has run; awaiting this in the pull handlers makes that pull return the
+   * real snapshot instead of an empty registry that a missed broadcast would
+   * never correct (#9285). Kicks off `initialize()` if nothing has yet, then
+   * swallows any scan rejection — init sets `initialized` in its `finally`, so
+   * a failed scan still unblocks callers with whatever registered, matching the
+   * containment in the deferred boot task.
+   */
+  async waitForInitialized(): Promise<void> {
+    if (this.initialized) return;
+    try {
+      await this.initialize();
+    } catch (err) {
+      console.warn("[PluginService] waitForInitialized: initialize() rejected:", err);
     }
   }
 
@@ -1057,6 +1106,17 @@ export class PluginService {
         console.error(`[PluginService] Event cleanup for "${pluginId}" threw during unload:`, err);
       }
     }
+  }
+
+  /**
+   * Load every plugin in `dir` as a user (non-built-in) plugin at runtime,
+   * outside the one-time boot scan. Returns the count loaded. Intended for the
+   * E2E install/uninstall harness (paired with {@link unloadPlugin}) so a spec
+   * can exercise lifecycle sync across LRU-evicted views without shipping a
+   * production runtime-install IPC path. Not wired to any user-facing surface.
+   */
+  async loadPluginDir(dir: string): Promise<number> {
+    return this.loadFromDir(dir, { isBuiltin: false });
   }
 
   listPlugins(): LoadedPluginInfo[] {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -763,6 +763,23 @@ describe("PluginService", () => {
     expect(service.listPlugins()).toHaveLength(1);
   });
 
+  it("waitForInitialized resolves (and marks initialized) when the scan throws", async () => {
+    const service = new PluginService(tmpDir);
+    const eacces = Object.assign(new Error("permission denied"), { code: "EACCES" });
+    const readdirSpy = vi.spyOn(fs, "readdir").mockRejectedValueOnce(eacces);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // A non-ENOENT scan failure must not leave callers hanging — the finally in
+    // runInitialize flips initialized, and waitForInitialized swallows the
+    // rejection so a revived view unblocks with whatever registered.
+    await expect(service.waitForInitialized()).resolves.toBeUndefined();
+    expect(service.isInitialized).toBe(true);
+    expect(service.listPlugins()).toEqual([]);
+
+    readdirSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
   it("coalesces concurrent initialize/waitForInitialized onto one scan", async () => {
     await writePlugin("coalesce", { name: "acme.coalesce", version: "1.0.0" });
     const service = new PluginService(tmpDir);

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -747,6 +747,54 @@ describe("PluginService", () => {
     expect(service.listPlugins()).toHaveLength(1);
   });
 
+  it("isInitialized reflects scan completion", async () => {
+    await writePlugin("init-flag", { name: "acme.init-flag", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    expect(service.isInitialized).toBe(false);
+    await service.initialize();
+    expect(service.isInitialized).toBe(true);
+  });
+
+  it("waitForInitialized resolves after the scan and exposes the loaded set", async () => {
+    await writePlugin("wait-test", { name: "acme.wait-test", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.waitForInitialized();
+    expect(service.isInitialized).toBe(true);
+    expect(service.listPlugins()).toHaveLength(1);
+  });
+
+  it("coalesces concurrent initialize/waitForInitialized onto one scan", async () => {
+    await writePlugin("coalesce", { name: "acme.coalesce", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    // Fire several entry points on the same tick — all must share one scan.
+    await Promise.all([
+      service.initialize(),
+      service.waitForInitialized(),
+      service.initialize(),
+      service.waitForInitialized(),
+    ]);
+    expect(service.listPlugins()).toHaveLength(1);
+  });
+
+  it("loadPluginDir loads plugins from a directory at runtime", async () => {
+    const service = new PluginService(path.join(tmpDir, "nonexistent"));
+    await service.initialize();
+    expect(service.listPlugins()).toHaveLength(0);
+
+    const runtimeDir = path.join(tmpDir, "runtime");
+    await fs.mkdir(runtimeDir, { recursive: true });
+    const pluginDir = path.join(runtimeDir, "late");
+    await fs.mkdir(pluginDir, { recursive: true });
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({ name: "acme.late", version: "1.0.0" })
+    );
+
+    const loaded = await service.loadPluginDir(runtimeDir);
+    expect(loaded).toBe(1);
+    expect(service.listPlugins().map((p) => p.manifest.name)).toContain("acme.late");
+  });
+
   it("registers toolbar buttons from plugin manifest", async () => {
     await writePlugin("toolbar-test", {
       name: "acme.toolbar-test",

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -282,9 +282,13 @@ export async function initGlobalServices(
     },
   });
 
-  // Plugin service — IPC handlers are registered eagerly in windowServices.ts
-  // and return empty lists from internal Maps until initialize() populates them.
-  // Plugin contributions broadcast on registration, so late init is renderer-safe.
+  // Plugin service — IPC handlers are registered eagerly in windowServices.ts.
+  // The pull handlers (getActions / toolbarButtons / getPanelKinds) now await
+  // pluginService.waitForInitialized() before reading their registries, so a
+  // cold-started (LRU-revived) view's mount-time pull blocks on this scan
+  // instead of seeing an empty Map and relying on a broadcast it may have
+  // already missed (#9285). This deferred run and that await coalesce onto the
+  // same one-time scan via initializePromise.
   registerDeferredTask({
     name: "plugin-service",
     run: async () => {

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -573,7 +573,10 @@ export interface GeneratedIpcInvokeMap {
   };
   "plugin:toolbar-buttons": {
     args: [];
-    result: import("../../config/toolbarButtonRegistry.js").ToolbarButtonConfig[];
+    result: {
+      buttons: import("../../config/toolbarButtonRegistry.js").ToolbarButtonConfig[];
+      complete: boolean;
+    };
   };
   "plugin:validate-action-ids": {
     args: [actionIds: string[]];

--- a/src/hooks/__tests__/usePluginToolbarButtons.test.ts
+++ b/src/hooks/__tests__/usePluginToolbarButtons.test.ts
@@ -94,6 +94,34 @@ describe("usePluginToolbarButtons", () => {
     expect(sweepMock).not.toHaveBeenCalled();
   });
 
+  it("a partial push before the pull resolves does not suppress the authoritative pull sweep", async () => {
+    // Regression for #9285: a load-time partial push must not flip pushReceived
+    // and drop the gated complete pull — the pull is the only snapshot that
+    // sweeps stale pins when a view revives after an uninstall it missed.
+    let resolvePull: (v: { buttons: ToolbarButtonConfig[]; complete: boolean }) => void = () => {};
+    toolbarButtonsMock.mockReturnValue(
+      new Promise<{ buttons: ToolbarButtonConfig[]; complete: boolean }>((r) => {
+        resolvePull = r;
+      })
+    );
+    let emit: ((p: { buttons: ToolbarButtonConfig[]; complete: boolean }) => void) | null = null;
+    onToolbarButtonsChangedMock.mockImplementation(
+      (cb: (p: { buttons: ToolbarButtonConfig[]; complete: boolean }) => void) => {
+        emit = cb;
+        return () => {};
+      }
+    );
+    const { usePluginToolbarButtons } = await import("../usePluginToolbarButtons");
+    renderHook(() => usePluginToolbarButtons());
+
+    await waitFor(() => expect(emit).not.toBeNull());
+    emit!({ buttons: [pluginButton("plugin.acme.foo")], complete: false });
+    expect(sweepMock).not.toHaveBeenCalled();
+
+    resolvePull({ buttons: [pluginButton("plugin.acme.foo")], complete: true });
+    await waitFor(() => expect(sweepMock).toHaveBeenCalledWith(["plugin.acme.foo"]));
+  });
+
   it("sweeps stale pinned buttons on an authoritative (complete=true) push", async () => {
     // Non-authoritative pull so the only complete-snapshot sweep under test is
     // the push below.

--- a/src/hooks/__tests__/usePluginToolbarButtons.test.ts
+++ b/src/hooks/__tests__/usePluginToolbarButtons.test.ts
@@ -37,13 +37,16 @@ beforeEach(() => {
     },
   });
   vi.resetModules();
-  toolbarButtonsMock.mockResolvedValue([]);
+  toolbarButtonsMock.mockResolvedValue({ buttons: [], complete: true });
   onToolbarButtonsChangedMock.mockReturnValue(() => {});
 });
 
 describe("usePluginToolbarButtons", () => {
-  it("exposes plugin buttons from the mount-time pull without sweeping", async () => {
-    toolbarButtonsMock.mockResolvedValue([pluginButton("plugin.acme.foo")]);
+  it("exposes plugin buttons from the mount-time pull and sweeps on a complete snapshot", async () => {
+    toolbarButtonsMock.mockResolvedValue({
+      buttons: [pluginButton("plugin.acme.foo")],
+      complete: true,
+    });
     const { usePluginToolbarButtons } = await import("../usePluginToolbarButtons");
 
     const { result } = renderHook(() => usePluginToolbarButtons());
@@ -51,11 +54,30 @@ describe("usePluginToolbarButtons", () => {
     await waitFor(() => {
       expect(result.current.buttonIds).toContain("plugin.acme.foo");
     });
-    // Pull is partial under deferred init — must never prune persisted prefs.
+    // The handler awaits initialize(), so a complete pull is authoritative and
+    // sweeps a plugin uninstalled while this view was evicted (#9285).
+    expect(sweepMock).toHaveBeenCalledWith(["plugin.acme.foo"]);
+  });
+
+  it("does not sweep on a partial (complete=false) pull", async () => {
+    toolbarButtonsMock.mockResolvedValue({
+      buttons: [pluginButton("plugin.acme.foo")],
+      complete: false,
+    });
+    const { usePluginToolbarButtons } = await import("../usePluginToolbarButtons");
+
+    const { result } = renderHook(() => usePluginToolbarButtons());
+
+    await waitFor(() => {
+      expect(result.current.buttonIds).toContain("plugin.acme.foo");
+    });
     expect(sweepMock).not.toHaveBeenCalled();
   });
 
   it("does not sweep on a partial (complete=false) load push", async () => {
+    // Keep the mount-time pull non-authoritative so this test isolates the
+    // push path (the default pull mock is complete=true and would sweep).
+    toolbarButtonsMock.mockResolvedValue({ buttons: [], complete: false });
     let emit: ((p: { buttons: ToolbarButtonConfig[]; complete: boolean }) => void) | null = null;
     onToolbarButtonsChangedMock.mockImplementation(
       (cb: (p: { buttons: ToolbarButtonConfig[]; complete: boolean }) => void) => {
@@ -73,6 +95,9 @@ describe("usePluginToolbarButtons", () => {
   });
 
   it("sweeps stale pinned buttons on an authoritative (complete=true) push", async () => {
+    // Non-authoritative pull so the only complete-snapshot sweep under test is
+    // the push below.
+    toolbarButtonsMock.mockResolvedValue({ buttons: [], complete: false });
     let emit: ((p: { buttons: ToolbarButtonConfig[]; complete: boolean }) => void) | null = null;
     onToolbarButtonsChangedMock.mockImplementation(
       (cb: (p: { buttons: ToolbarButtonConfig[]; complete: boolean }) => void) => {

--- a/src/hooks/usePluginToolbarButtons.ts
+++ b/src/hooks/usePluginToolbarButtons.ts
@@ -19,11 +19,15 @@ export interface PluginToolbarButtonState {
  *
  * Stale `plugin.` entries in the `toolbarPreferencesStore` `pinnedButtons`
  * map (renderer-local persisted state, no main-process access) are pruned
- * here off the lifecycle snapshot — but ONLY off an authoritative one. The
- * pull and load-time pushes are partial/growing (plugins load concurrently
- * and `initialize()` is deferred), so sweeping against them would wipe a
- * not-yet-loaded plugin's hide preference. Only a `complete` push (a plugin
- * unload — i.e. uninstall, the exact case the sweep exists for) is swept.
+ * here off the lifecycle snapshot — but ONLY off an authoritative one. A
+ * load-time push is partial/growing (plugins load concurrently), so sweeping
+ * against it would wipe a not-yet-loaded plugin's hide preference. The pull
+ * and the unload push both carry a `complete` flag: the pull handler awaits
+ * the deferred `initialize()` before returning, so its snapshot is complete
+ * (this is what lets an LRU-revived view sweep a plugin uninstalled while it
+ * was evicted — #9285); an unload push is complete because the registry
+ * reflects the full post-uninstall set at broadcast time. Only complete
+ * snapshots are swept.
  */
 export function usePluginToolbarButtons(): PluginToolbarButtonState {
   const [configs, setConfigs] = useState<Map<string, ToolbarButtonConfig>>(new Map());
@@ -49,12 +53,13 @@ export function usePluginToolbarButtons(): PluginToolbarButtonState {
 
     void electron.plugin
       .toolbarButtons()
-      .then((buttons) => {
+      .then(({ buttons, complete }) => {
         if (disposed) return;
         if (pushReceived) return;
-        // Pull is a display-only safety net: deferred `initialize()` means it
-        // can resolve before all plugins have registered, so never sweep here.
-        sync(buttons, false);
+        // The handler awaits `initialize()` before returning, so `complete`
+        // is true once the scan has settled — a revived view then sweeps any
+        // plugin uninstalled while it was evicted (#9285).
+        sync(buttons, complete);
       })
       .catch((err: unknown) => {
         logWarn("[PluginToolbarButtons] Failed to fetch initial plugin toolbar buttons", {

--- a/src/hooks/usePluginToolbarButtons.ts
+++ b/src/hooks/usePluginToolbarButtons.ts
@@ -68,7 +68,12 @@ export function usePluginToolbarButtons(): PluginToolbarButtonState {
       });
 
     const cleanup = electron.plugin.onToolbarButtonsChanged((payload) => {
-      pushReceived = true;
+      // Only an authoritative (complete) push suppresses the mount-time pull.
+      // A partial load-time push (complete=false) must NOT set the flag: the
+      // gated pull resolves with the full set and is the only snapshot that
+      // sweeps stale pins on a revived view (#9285) — dropping it because a
+      // partial push arrived first would lose that reconciliation.
+      if (payload.complete) pushReceived = true;
       sync(payload.buttons, payload.complete);
     });
 

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -640,6 +640,10 @@ if (typeof window !== "undefined" && window.__DAINTREE_E2E_MODE__ === true) {
     args?: unknown,
     options?: { source?: string; confirmed?: boolean }
   ) => actionService.dispatch(actionId as ActionId, args, options as ActionDispatchOptions);
+  // Per-view registry probe for the plugin lifecycle-sync spec (#9285): a
+  // revived view must reflect installs/uninstalls that happened while it was
+  // LRU-evicted.
+  window.__daintreeHasAction = (actionId: string) => actionService.has(actionId as ActionId);
 }
 
 export function getActionContext(): ActionContext {

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -34,6 +34,12 @@ declare global {
       args?: unknown,
       options?: { source?: string; confirmed?: boolean }
     ) => unknown;
+    /**
+     * Per-view query of the renderer ActionService registry. Lets the plugin
+     * lifecycle-sync spec (#9285) assert that a revived view has (or no longer
+     * has) a plugin-registered action. E2E-gated like __daintreeDispatchAction.
+     */
+    __daintreeHasAction?: (actionId: string) => boolean;
   }
 }
 


### PR DESCRIPTION
## Summary

- Plugin lifecycle events (installs, uninstalls, toolbar changes, panel kinds) broadcast to live/cached `WebContentsView`s but not to evicted ones. A cold-revived view's mount-time pull ran before `PluginService` finished scanning, seeding an empty registry; uninstalls that happened while the view was evicted were never swept.
- Gates the three pull handlers (`plugin:actions-get`, `plugin:toolbar-buttons`, `plugin:panel-kinds-get`) on a new `waitForInitialized()` so a revived view's pull returns the full registry rather than whatever partial state happens to be loaded at mount time.
- Fixes a secondary race: `handleToolbarButtons` now returns `{ buttons, complete: isInitialized }`. The renderer sweeps stale `plugin.*` pinned-button prefs only on a complete snapshot, preventing a partial load-time push from suppressing the later authoritative pull.

Resolves #9285

## Changes

- `PluginService`: `initializePromise` coalescing (concurrent callers share one scan), `isInitialized` getter, `waitForInitialized()` (swallows scan rejection so callers always unblock).
- `electron/ipc/handlers/plugin.ts`: all three pull handlers await `waitForInitialized()` before responding.
- `src/hooks/usePluginToolbarButtons.ts`: reads the new `complete` flag; skips stale-pin sweep when `complete` is false.
- `shared/types/ipc/generated.ts`: regenerated for the new toolbar-buttons result shape.
- `electron/main.ts` + `electron/window/globalServicesInit.ts`: E2E escape hatches (`__daintreeE2ELoadPlugin`, `__daintreeE2EUnloadPlugin`, `__daintreeHasAction`) — all gated behind `DAINTREE_E2E_MODE`.

## Testing

- 257 unit tests pass (`plugin.handlers`, `usePluginToolbarButtons`, `usePluginActions`, `PluginService`).
- New `full-resilience` E2E spec (`plugin-lifecycle-lru-eviction.spec.ts`) covers a fixture plugin (action + toolbar button contributions) across a three-view LRU eviction matrix: install before eviction, uninstall while evicted, revive and verify clean state.
- Typecheck, lint, format, and build all pass.