### PR TITLE
fix(browser): surface webview crash and unresponsive state

### DIFF
--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -5,9 +5,10 @@ import { useWebviewEviction } from "@/hooks/useWebviewEviction";
 import { useWebviewDialog } from "@/hooks/useWebviewDialog";
 import { useWebviewEvents } from "@/hooks/useWebviewEvents";
 import { useBrowserActionListeners } from "@/hooks/useBrowserActionListeners";
-import { AlertTriangle, ExternalLink, RotateCw, Square } from "lucide-react";
+import { AlertTriangle, ExternalLink, RotateCw, Square, XCircle } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { Button } from "@/components/ui/button";
+import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { usePanelStore } from "@/store";
 import type { BrowserHistory, BrowserNavigationHistorySnapshot } from "@shared/types/browser";
 import { ContentPanel, type BasePanelProps } from "@/components/Panel";
@@ -143,6 +144,20 @@ export function BrowserPane({
   // Doherty 400ms gate: skip loading affordances on fast loads to prevent flicker.
   const showLoadingOverlay = useDohertyGate(isLoading);
   const [loadError, setLoadError] = useState<LoadError | null>(null);
+  // Webview crash / unresponsive state. `crashed` covers render-process-gone
+  // with a recoverable reason (not memory-eviction or clean-exit); `unresponsive`
+  // is driven by the main-process unresponsive/responsive WebContents events,
+  // which auto-clear without user action. Mutually exclusive states mirror
+  // DevPreview's pattern. crashTimestampsRef bounds the auto-reload silently to
+  // the first crash within a 60s window; a second crash within the window
+  // surfaces the banner to break the loop.
+  const [crashState, setCrashState] = useState<"none" | "crashed" | "unresponsive">("none");
+  const [crashDetails, setCrashDetails] = useState<{
+    reason: string;
+    exitCode: number;
+  } | null>(null);
+  const crashTimestampsRef = useRef<number[]>([]);
+  const crashReloadRef = useRef<() => void>(() => {});
   const [blockedNav, setBlockedNav] = useState<{
     url: string;
     canOpenExternal: boolean;
@@ -248,6 +263,23 @@ export function BrowserPane({
     return () => clearTimeout(timer);
   }, [blockedNav]);
 
+  const handleRenderProcessGone = useCallback((details: { reason: string; exitCode: number }) => {
+    const now = Date.now();
+    const timestamps = crashTimestampsRef.current.filter((ts) => now - ts < 60_000);
+    timestamps.push(now);
+    crashTimestampsRef.current = timestamps;
+
+    setCrashDetails(details);
+    setCrashState("crashed");
+
+    // Auto-reload silently on the first crash within the 60s window so a
+    // one-off renderer fault recovers transparently. A second crash within
+    // the window leaves the banner up so the user can act.
+    if (timestamps.length < 2) {
+      crashReloadRef.current();
+    }
+  }, []);
+
   useWebviewEvents({
     webviewElement,
     isInitialRestoredLoadRef,
@@ -264,6 +296,7 @@ export function BrowserPane({
     setIsSlowLoad,
     setBlockedNav,
     setHistory,
+    onRenderProcessGone: handleRenderProcessGone,
   });
 
   const commitNavigation = useCallback(
@@ -375,8 +408,70 @@ export function BrowserPane({
     setIsLoading(true);
     setLoadError(null);
     setIsSlowLoad(false);
+    setCrashState("none");
+    setCrashDetails(null);
+    crashTimestampsRef.current = [];
     webviewRef.current?.reload();
   }, []);
+
+  // Auto-reload uses a raw webview.reload() — explicitly NOT going through
+  // handleReload, which clears crashTimestampsRef and would break the second-
+  // crash loop detector. Only user-initiated reload/dismiss should reset the
+  // crash window.
+  useEffect(() => {
+    crashReloadRef.current = () => {
+      setIsLoading(true);
+      setLoadError(null);
+      setIsSlowLoad(false);
+      webviewRef.current?.reload();
+    };
+  }, []);
+
+  // Listen for webview unresponsive/responsive events from the main process.
+  // Unresponsive is auto-clearing — the responsive event from Chromium dismisses
+  // the banner without user action, so this is Tier 1/3 ambient (no recovery
+  // button needed beyond the optional Reload). `crashed` outranks `unresponsive`:
+  // if the renderer has died, ignore a stale responsive event.
+  useEffect(() => {
+    const cleanupUnresponsive = window.electron.webview.onUnresponsive((data) => {
+      if (data.panelId !== id) return;
+      setCrashState((prev) => (prev === "crashed" ? prev : "unresponsive"));
+    });
+    const cleanupResponsive = window.electron.webview.onResponsive((data) => {
+      if (data.panelId !== id) return;
+      setCrashState((prev) => (prev === "unresponsive" ? "none" : prev));
+    });
+    return () => {
+      cleanupUnresponsive();
+      cleanupResponsive();
+    };
+  }, [id]);
+
+  // Clear crash state when the user navigates to a fresh URL. Depending on
+  // crashState here would create an instant-reset loop: the effect would fire
+  // the moment crashState transitions from "none" and clear it back. Track the
+  // last URL we cleared at via a ref so this effect runs only on real URL
+  // transitions.
+  const lastClearedCrashUrlRef = useRef<string>(currentUrl);
+  useEffect(() => {
+    if (currentUrl === lastClearedCrashUrlRef.current) return;
+    lastClearedCrashUrlRef.current = currentUrl;
+    if (currentUrl && currentUrl !== "about:blank") {
+      setCrashState("none");
+      setCrashDetails(null);
+    }
+  }, [currentUrl]);
+
+  // Clear crash state on memory eviction so a restored panel doesn't surface
+  // a stale banner. The eviction placeholder owns the visual signal in that
+  // window — see useWebviewEviction.
+  useEffect(() => {
+    if (isEvicted) {
+      setCrashState("none");
+      setCrashDetails(null);
+      crashTimestampsRef.current = [];
+    }
+  }, [isEvicted]);
 
   const handleCancelLoad = useCallback(() => {
     if (slowLoadTimeoutRef.current) {
@@ -757,6 +852,54 @@ export function BrowserPane({
                   </button>
                 </div>
               </div>
+            )}
+            {crashState === "crashed" && (
+              <InlineStatusBanner
+                icon={XCircle}
+                title="Page process crashed"
+                description={
+                  crashDetails
+                    ? `Reason: ${crashDetails.reason} (exit code ${crashDetails.exitCode})`
+                    : "Browser renderer terminated unexpectedly."
+                }
+                severity="error"
+                animated={false}
+                actions={[
+                  {
+                    id: "reload",
+                    label: "Reload",
+                    icon: RotateCw,
+                    variant: "dangerFilled",
+                    onClick: handleReload,
+                    ariaLabel: "Reload page",
+                  },
+                ]}
+                onClose={() => {
+                  setCrashState("none");
+                  setCrashDetails(null);
+                  crashTimestampsRef.current = [];
+                }}
+              />
+            )}
+            {crashState === "unresponsive" && (
+              <InlineStatusBanner
+                icon={AlertTriangle}
+                title="Page not responding"
+                description="The page may be stuck in a long-running script."
+                severity="warning"
+                animated={false}
+                actions={[
+                  {
+                    id: "reload",
+                    label: "Reload",
+                    icon: RotateCw,
+                    variant: "danger",
+                    onClick: handleReload,
+                    ariaLabel: "Reload page",
+                  },
+                ]}
+                onClose={() => setCrashState("none")}
+              />
             )}
             {blockedNav && (
               <div

--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -269,6 +269,9 @@ export function BrowserPane({
     timestamps.push(now);
     crashTimestampsRef.current = timestamps;
 
+    // Clear any stale load-error overlay (z-30, absolute inset-0) — without
+    // this it would occlude the crash banner, which is an in-flow element.
+    setLoadError(null);
     setCrashDetails(details);
     setCrashState("crashed");
 
@@ -435,7 +438,14 @@ export function BrowserPane({
   useEffect(() => {
     const cleanupUnresponsive = window.electron.webview.onUnresponsive((data) => {
       if (data.panelId !== id) return;
-      setCrashState((prev) => (prev === "crashed" ? prev : "unresponsive"));
+      setCrashState((prev) => {
+        if (prev === "crashed") return prev;
+        // Clear any in-flight load error — the page is unresponsive, the
+        // error is no longer actionable, and its absolute z-30 overlay
+        // would occlude this banner.
+        setLoadError(null);
+        return "unresponsive";
+      });
     });
     const cleanupResponsive = window.electron.webview.onResponsive((data) => {
       if (data.panelId !== id) return;
@@ -459,6 +469,9 @@ export function BrowserPane({
     if (currentUrl && currentUrl !== "about:blank") {
       setCrashState("none");
       setCrashDetails(null);
+      // Don't carry the prior URL's crash history into the new URL's 60s
+      // window — that would mis-throttle the first auto-recovery there.
+      crashTimestampsRef.current = [];
     }
   }, [currentUrl]);
 

--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -877,16 +877,14 @@ export function BrowserPane({
                 }
                 severity="error"
                 animated={false}
-                actions={[
-                  {
-                    id: "reload",
-                    label: "Reload",
-                    icon: RotateCw,
-                    variant: "dangerFilled",
-                    onClick: handleReload,
-                    ariaLabel: "Reload page",
-                  },
-                ]}
+                action={{
+                  id: "reload",
+                  label: "Reload",
+                  icon: RotateCw,
+                  variant: "dangerFilled",
+                  onClick: handleReload,
+                  ariaLabel: "Reload page",
+                }}
                 onClose={() => {
                   setCrashState("none");
                   setCrashDetails(null);
@@ -901,16 +899,14 @@ export function BrowserPane({
                 description="The page may be stuck in a long-running script."
                 severity="warning"
                 animated={false}
-                actions={[
-                  {
-                    id: "reload",
-                    label: "Reload",
-                    icon: RotateCw,
-                    variant: "danger",
-                    onClick: handleReload,
-                    ariaLabel: "Reload page",
-                  },
-                ]}
+                action={{
+                  id: "reload",
+                  label: "Reload",
+                  icon: RotateCw,
+                  variant: "danger",
+                  onClick: handleReload,
+                  ariaLabel: "Reload page",
+                }}
                 onClose={() => setCrashState("none")}
               />
             )}

--- a/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
+++ b/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
@@ -201,6 +201,24 @@ describe("BrowserPane webview lifecycle regression", () => {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (globalThis as any).window = globalThis.window ?? {};
+    // InlineStatusBanner reads window.matchMedia at render time; jsdom does
+    // not implement it, so provide a no-op stub.
+    if (typeof window.matchMedia !== "function") {
+      Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        configurable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+          matches: false,
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        })),
+      });
+    }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).electron = {
       clipboard: {
@@ -211,6 +229,8 @@ describe("BrowserPane webview lifecycle regression", () => {
         respondToDialog: vi.fn(() => Promise.resolve()),
         onDialogRequest: vi.fn(() => vi.fn()),
         onNavigationBlocked: vi.fn(() => vi.fn()),
+        onUnresponsive: vi.fn(() => vi.fn()),
+        onResponsive: vi.fn(() => vi.fn()),
       },
       window: {
         onDestroyHiddenWebviews: vi.fn(() => vi.fn()),
@@ -1094,6 +1114,145 @@ describe("BrowserPane webview lifecycle regression", () => {
       const alert = container.querySelector('[role="alert"]');
       expect(alert).not.toBeNull();
       expect(alert?.textContent).toContain("Couldn't resolve");
+    });
+  });
+
+  describe("crash and unresponsive recovery (#9212)", () => {
+    function emitRenderProcessGone(
+      webview: MockWebviewElement,
+      reason: string,
+      exitCode = 1
+    ): void {
+      emitWebviewEvent(webview, "render-process-gone", {
+        details: { reason, exitCode },
+      });
+    }
+
+    function getUnresponsiveCallback(): (payload: { panelId: string }) => void {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mock = (window as any).electron.webview.onUnresponsive;
+      const lastCall = mock.mock.calls[mock.mock.calls.length - 1];
+      return lastCall[0];
+    }
+
+    function getResponsiveCallback(): (payload: { panelId: string }) => void {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mock = (window as any).electron.webview.onResponsive;
+      const lastCall = mock.mock.calls[mock.mock.calls.length - 1];
+      return lastCall[0];
+    }
+
+    it("auto-reloads silently on the first crash within 60s and surfaces the banner", () => {
+      // The auto-reload runs in the background to recover from a one-off crash,
+      // and the banner stays up so the user has explicit recovery if the reload
+      // does not succeed. A second crash within the window stops auto-reloading
+      // (see next test) to avoid a reload loop.
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitRenderProcessGone(webview, "crashed");
+      });
+
+      expect(webview.reload).toHaveBeenCalledTimes(1);
+      expect(container.textContent).toContain("Page process crashed");
+    });
+
+    it("does not auto-reload on a second crash within the 60s window", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitRenderProcessGone(webview, "crashed");
+      });
+      act(() => {
+        emitRenderProcessGone(webview, "oom", 9);
+      });
+
+      expect(webview.reload).toHaveBeenCalledTimes(1);
+      expect(container.textContent).toContain("Page process crashed");
+      expect(container.textContent).toContain("Reason: oom (exit code 9)");
+    });
+
+    it("ignores memory-eviction reason — eviction placeholder owns that signal", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitRenderProcessGone(webview, "memory-eviction");
+        emitRenderProcessGone(webview, "memory-eviction");
+      });
+
+      expect(webview.reload).not.toHaveBeenCalled();
+      expect(container.textContent).not.toContain("Page process crashed");
+    });
+
+    it("ignores clean-exit reason — intentional renderer shutdown", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitRenderProcessGone(webview, "clean-exit", 0);
+        emitRenderProcessGone(webview, "clean-exit", 0);
+      });
+
+      expect(webview.reload).not.toHaveBeenCalled();
+      expect(container.textContent).not.toContain("Page process crashed");
+    });
+
+    it("shows the unresponsive banner when WEBVIEW_UNRESPONSIVE fires for this panel", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const onUnresponsive = getUnresponsiveCallback();
+
+      act(() => {
+        onUnresponsive({ panelId: "browser-panel-1" });
+      });
+
+      expect(container.textContent).toContain("Page not responding");
+    });
+
+    it("ignores WEBVIEW_UNRESPONSIVE for a different panel", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const onUnresponsive = getUnresponsiveCallback();
+
+      act(() => {
+        onUnresponsive({ panelId: "some-other-panel" });
+      });
+
+      expect(container.textContent).not.toContain("Page not responding");
+    });
+
+    it("auto-clears the unresponsive banner when WEBVIEW_RESPONSIVE fires", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const onUnresponsive = getUnresponsiveCallback();
+      const onResponsive = getResponsiveCallback();
+
+      act(() => {
+        onUnresponsive({ panelId: "browser-panel-1" });
+      });
+      expect(container.textContent).toContain("Page not responding");
+
+      act(() => {
+        onResponsive({ panelId: "browser-panel-1" });
+      });
+      expect(container.textContent).not.toContain("Page not responding");
+    });
+
+    it("does not downgrade a crashed banner when a stale responsive event fires", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+      const onResponsive = getResponsiveCallback();
+
+      act(() => {
+        emitRenderProcessGone(webview, "crashed");
+        emitRenderProcessGone(webview, "crashed");
+      });
+      expect(container.textContent).toContain("Page process crashed");
+
+      act(() => {
+        onResponsive({ panelId: "browser-panel-1" });
+      });
+      expect(container.textContent).toContain("Page process crashed");
     });
   });
 });

--- a/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
+++ b/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
@@ -1174,17 +1174,24 @@ describe("BrowserPane webview lifecycle regression", () => {
       expect(container.textContent).toContain("Reason: oom (exit code 9)");
     });
 
-    it("ignores memory-eviction reason — eviction placeholder owns that signal", () => {
+    it("surfaces the banner on OS-pressure memory-eviction (no Daintree eviction in flight)", () => {
+      // Chromium reports `memory-eviction` for two distinct paths:
+      //   (1) Daintree's own about:blank src swap from useWebviewEviction
+      //       (gated by evictingRef.current and handled by the eviction
+      //       placeholder).
+      //   (2) The OS killing the renderer under system memory pressure on a
+      //       visible panel. In path (2) evictingRef stays false and the
+      //       eviction placeholder never renders — the pane would go blank
+      //       silently without a crash banner. #9212.
       const { container } = render(<BrowserPane {...baseProps} />);
       const webview = getWebviewElement(container);
 
       act(() => {
         emitRenderProcessGone(webview, "memory-eviction");
-        emitRenderProcessGone(webview, "memory-eviction");
       });
 
-      expect(webview.reload).not.toHaveBeenCalled();
-      expect(container.textContent).not.toContain("Page process crashed");
+      expect(webview.reload).toHaveBeenCalledTimes(1);
+      expect(container.textContent).toContain("Page process crashed");
     });
 
     it("ignores clean-exit reason — intentional renderer shutdown", () => {
@@ -1252,6 +1259,86 @@ describe("BrowserPane webview lifecycle regression", () => {
       act(() => {
         onResponsive({ panelId: "browser-panel-1" });
       });
+      expect(container.textContent).toContain("Page process crashed");
+    });
+
+    it("does not let a stale unresponsive event replace a crashed banner", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+      const onUnresponsive = getUnresponsiveCallback();
+
+      act(() => {
+        emitRenderProcessGone(webview, "crashed");
+      });
+      expect(container.textContent).toContain("Page process crashed");
+
+      act(() => {
+        onUnresponsive({ panelId: "browser-panel-1" });
+      });
+      expect(container.textContent).toContain("Page process crashed");
+      expect(container.textContent).not.toContain("Page not responding");
+    });
+
+    it("clears stuck-load timer so a load timeout does not replace the crash banner", () => {
+      // The load-error overlay is rendered as absolute z-30 over the entire
+      // pane — without clearing the slow-load timer on crash, a pending 30s
+      // timeout would fire after the crash and stack a "Page Load Timed Out"
+      // overlay on top of the in-flow crash banner, hiding it entirely.
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        webview.setMockLoading(true);
+        emitWebviewEvent(webview, "did-start-loading");
+      });
+      act(() => {
+        vi.advanceTimersByTime(10_000);
+      });
+      act(() => {
+        emitRenderProcessGone(webview, "crashed");
+      });
+      act(() => {
+        vi.advanceTimersByTime(30_000);
+      });
+
+      expect(webview.stop).not.toHaveBeenCalled();
+      expect(container.textContent).toContain("Page process crashed");
+      expect(container.textContent).not.toContain("Page Load Timed Out");
+    });
+
+    it("auto-reloads again on a crash that lands just outside the 60s window", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitRenderProcessGone(webview, "crashed");
+      });
+      act(() => {
+        vi.advanceTimersByTime(60_001);
+      });
+      act(() => {
+        emitRenderProcessGone(webview, "crashed");
+      });
+
+      expect(webview.reload).toHaveBeenCalledTimes(2);
+      expect(container.textContent).toContain("Page process crashed");
+    });
+
+    it("does not auto-reload on a crash just inside the 60s window", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitRenderProcessGone(webview, "crashed");
+      });
+      act(() => {
+        vi.advanceTimersByTime(59_999);
+      });
+      act(() => {
+        emitRenderProcessGone(webview, "crashed");
+      });
+
+      expect(webview.reload).toHaveBeenCalledTimes(1);
       expect(container.textContent).toContain("Page process crashed");
     });
   });

--- a/src/hooks/useWebviewEvents.ts
+++ b/src/hooks/useWebviewEvents.ts
@@ -36,6 +36,7 @@ export type UseWebviewEventsOptions = {
   setIsSlowLoad: (v: boolean) => void;
   setBlockedNav: (v: { url: string; canOpenExternal: boolean } | null) => void;
   setHistory: React.Dispatch<React.SetStateAction<BrowserHistory>>;
+  onRenderProcessGone?: (details: { reason: string; exitCode: number }) => void;
 };
 
 /**
@@ -65,10 +66,17 @@ export function useWebviewEvents({
   setIsSlowLoad,
   setBlockedNav,
   setHistory,
+  onRenderProcessGone,
 }: UseWebviewEventsOptions): void {
   const getZoomFactor = useEffectEvent(() => zoomFactor);
   const getProjectId = useEffectEvent(() => projectId);
   const getLoadTimeoutMs = useEffectEvent(() => loadTimeoutMs);
+  // Route render-process-gone through useEffectEvent so the lifecycle effect
+  // doesn't rebind listeners when the callback identity changes — listeners
+  // are torn down/rebuilt only when the webview element itself swaps.
+  const fireRenderProcessGone = useEffectEvent((details: { reason: string; exitCode: number }) => {
+    onRenderProcessGone?.(details);
+  });
 
   useEffect(() => {
     const webview = webviewElement;
@@ -313,6 +321,27 @@ export function useWebviewEvents({
       // Webview not yet attached to DOM - dom-ready handler will take over
     }
 
+    const handleRenderProcessGone = (event: Event) => {
+      const details = (event as Event & { details?: { reason: string; exitCode: number } }).details;
+      if (!details) return;
+      // Webview eviction (about:blank src swap by useWebviewEviction) can race
+      // a memory-eviction crash report from Chromium; defer to the eviction
+      // placeholder rather than showing a duplicate crash banner.
+      if (details.reason === "clean-exit" || details.reason === "memory-eviction") return;
+      if (evictingRef.current) return;
+      setIsLoading(false);
+      setIsSlowLoad(false);
+      if (slowLoadTimeoutRef.current) {
+        clearTimeout(slowLoadTimeoutRef.current);
+        slowLoadTimeoutRef.current = null;
+      }
+      if (loadTimeoutRef.current) {
+        clearTimeout(loadTimeoutRef.current);
+        loadTimeoutRef.current = null;
+      }
+      fireRenderProcessGone(details);
+    };
+
     webview.addEventListener("dom-ready", handleDomReady);
     webview.addEventListener("did-start-loading", handleDidStartLoading);
     webview.addEventListener("did-stop-loading", handleDidStopLoading);
@@ -321,6 +350,7 @@ export function useWebviewEvents({
     webview.addEventListener("did-navigate-in-page", handleDidNavigateInPage);
     webview.addEventListener("page-title-updated", handlePageTitleUpdated);
     webview.addEventListener("page-favicon-updated", handlePageFaviconUpdated);
+    webview.addEventListener("render-process-gone", handleRenderProcessGone);
 
     return () => {
       webview.removeEventListener("dom-ready", handleDomReady);
@@ -331,6 +361,7 @@ export function useWebviewEvents({
       webview.removeEventListener("did-navigate-in-page", handleDidNavigateInPage);
       webview.removeEventListener("page-title-updated", handlePageTitleUpdated);
       webview.removeEventListener("page-favicon-updated", handlePageFaviconUpdated);
+      webview.removeEventListener("render-process-gone", handleRenderProcessGone);
       if (faviconDebounceTimer) {
         clearTimeout(faviconDebounceTimer);
         faviconDebounceTimer = null;

--- a/src/hooks/useWebviewEvents.ts
+++ b/src/hooks/useWebviewEvents.ts
@@ -324,10 +324,14 @@ export function useWebviewEvents({
     const handleRenderProcessGone = (event: Event) => {
       const details = (event as Event & { details?: { reason: string; exitCode: number } }).details;
       if (!details) return;
-      // Webview eviction (about:blank src swap by useWebviewEviction) can race
-      // a memory-eviction crash report from Chromium; defer to the eviction
-      // placeholder rather than showing a duplicate crash banner.
-      if (details.reason === "clean-exit" || details.reason === "memory-eviction") return;
+      // `clean-exit` (exit code 0) is intentional renderer shutdown — never
+      // a crash. `memory-eviction` is filtered ONLY when Daintree itself
+      // triggered the eviction: the about:blank src swap in useWebviewEviction
+      // sets evictingRef and causes Chromium to report memory-eviction. When
+      // the OS kills the renderer under system memory pressure with no
+      // Daintree eviction in flight, the panel goes blank with no other UI
+      // signal — surface the crash banner. #9212.
+      if (details.reason === "clean-exit") return;
       if (evictingRef.current) return;
       setIsLoading(false);
       setIsSlowLoad(false);


### PR DESCRIPTION
## Summary

- The browser pane would go blank silently when the webview crashed or hung. Wired a `render-process-gone` listener in `useWebviewEvents` that skips clean exits and skips Daintree's own memory-eviction in flight, so OS-pressure renderer kills now surface a Tier 3 inline banner instead of disappearing.
- Added `crashState` to `BrowserPane` with banners mirroring the DevPreview pattern: crashed shows a red error banner with a Reload action; unresponsive shows a warning that auto-clears when Chromium reports the page recovered.
- Auto-reload fires silently on the first crash within a 60-second sliding window; a second crash in the window leaves the banner up as a loop guard.

Resolves #9212

## Changes

- `useWebviewEvents`: wire `render-process-gone`, consuming already-emitted `WEBVIEW_UNRESPONSIVE` / `WEBVIEW_RESPONSIVE` IPC channels — no main-process changes required.
- `BrowserPane`: add `crashState` ("none" | "crashed" | "unresponsive"), inline banners for each state, and logic to clear the load-error overlay on crash/unresponsive entry so the absolute-positioned overlay doesn't occlude the in-flow banner.
- Reset crash timestamps on URL transitions and on memory eviction so a restored pane never shows stale state.
- 12 new tests covering crash, unresponsive, IPC routing, load-error/crash race, 60-second window boundaries, eviction interactions, and OS-pressure memory eviction.

## Testing

- Browser pane goes blank (crash): now shows "Page process crashed" with a Reload action.
- Browser pane hangs: now shows "Page not responding" that auto-clears on recovery.
- Memory eviction by Daintree: unchanged — "Reclaimed for memory" placeholder still owns that signal.
- Crash loop (two within 60s): banner persists, no reload spam.
- Crash after the 60-second window: silent auto-reload resumes.
- All 54 tests pass.