### PR TITLE
feat(plugins): typed plugin.invoke channel registry with capability gate

### DIFF
--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -5,6 +5,7 @@ import os from "os";
 import { pathToFileURL } from "url";
 import { app } from "electron";
 import * as semver from "semver";
+import type { z } from "zod";
 import { PluginManifestSchema } from "../schemas/plugin.js";
 import type {
   PluginManifest,
@@ -14,6 +15,8 @@ import type {
   PluginActivate,
   PluginActionContribution,
   PluginActionDescriptor,
+  PluginChannelSchema,
+  PluginInvokeResult,
   BuiltInPluginPermission,
 } from "../../shared/types/plugin.js";
 import type { WorktreeSnapshot } from "../../shared/types/workspace-host.js";
@@ -100,6 +103,27 @@ interface PluginLoadErrorRecord {
   at: number;
 }
 
+/**
+ * A registered channel handler plus its optional typed contract. Untyped
+ * registrations leave `argsSchema` undefined and dispatch raw (the legacy
+ * action-dispatch path); typed registrations carry the Zod schemas and the
+ * declared `requires` permissions enforced by the capability gate.
+ */
+interface HandlerEntry {
+  handler: PluginIpcHandler;
+  argsSchema?: z.ZodType;
+  resultSchema?: z.ZodType;
+  requires: BuiltInPluginPermission[];
+}
+
+function isChannelSchema(value: unknown): value is PluginChannelSchema {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { args?: { safeParse?: unknown } }).args?.safeParse === "function"
+  );
+}
+
 const ACTIVATE_TIMEOUT_MS = 5000;
 
 /**
@@ -147,7 +171,7 @@ type WorkspaceWorktreeEvent = "worktree-update" | "worktree-activated" | "worktr
 
 export class PluginService {
   private plugins = new Map<string, LoadedPlugin>();
-  private handlerMap = new Map<string, PluginIpcHandler>();
+  private handlerMap = new Map<string, HandlerEntry>();
   private cleanupMap = new Map<string, () => void>();
   private pluginActions = new Map<string, PluginActionDescriptor>();
   private pluginActionOwners = new Map<string, Set<string>>();
@@ -559,13 +583,17 @@ export class PluginService {
       get pluginId() {
         return pluginId;
       },
-      registerHandler: (channel, handler) => {
+      registerHandler: (
+        channel: string,
+        schemaOrHandler: PluginChannelSchema | PluginIpcHandler,
+        maybeHandler?: PluginIpcHandler
+      ) => {
         if (revoked) {
           throw new Error(
             `Plugin "${pluginId}" host revoked: registerHandler called after activate() returned or timed out`
           );
         }
-        this.registerHandler(pluginId, channel, handler);
+        this.registerHandler(pluginId, channel, schemaOrHandler, maybeHandler);
       },
       broadcastToRenderer: (channel, payload) => {
         if (revoked) {
@@ -918,18 +946,47 @@ export class PluginService {
     return this.plugins.has(pluginId);
   }
 
-  registerHandler(pluginId: string, channel: string, handler: PluginIpcHandler): void {
+  registerHandler(pluginId: string, channel: string, handler: PluginIpcHandler): void;
+  registerHandler(
+    pluginId: string,
+    channel: string,
+    schema: PluginChannelSchema,
+    handler: PluginIpcHandler
+  ): void;
+  registerHandler(
+    pluginId: string,
+    channel: string,
+    schemaOrHandler: PluginChannelSchema | PluginIpcHandler,
+    maybeHandler?: PluginIpcHandler
+  ): void {
     if (!this.plugins.has(pluginId)) {
       throw new Error(`Unknown plugin: ${pluginId}`);
     }
     if (channel.includes(":")) {
       throw new Error(`Plugin channel must not contain colons: ${channel}`);
     }
-    if (typeof handler !== "function") {
-      throw new Error(`Plugin handler must be a function, got ${typeof handler}`);
+
+    let entry: HandlerEntry;
+    if (typeof schemaOrHandler === "function") {
+      // Untyped registration — raw passthrough, no validation or gate.
+      entry = { handler: schemaOrHandler, requires: [] };
+    } else if (isChannelSchema(schemaOrHandler)) {
+      // Typed registration — store schemas + declared permission gate.
+      if (typeof maybeHandler !== "function") {
+        throw new Error(`Plugin handler must be a function, got ${typeof maybeHandler}`);
+      }
+      entry = {
+        handler: maybeHandler,
+        argsSchema: schemaOrHandler.args,
+        resultSchema: schemaOrHandler.result,
+        requires: schemaOrHandler.requires ?? [],
+      };
+    } else {
+      throw new Error(`Plugin handler must be a function, got ${typeof schemaOrHandler}`);
     }
+
     const key = `${pluginId}:${channel}`;
-    this.handlerMap.set(key, handler);
+    this.handlerMap.set(key, entry);
   }
 
   async dispatchHandler(
@@ -939,22 +996,75 @@ export class PluginService {
     args: unknown[]
   ): Promise<unknown> {
     const key = `${pluginId}:${channel}`;
-    const handler = this.handlerMap.get(key);
-    if (!handler) {
+    const entry = this.handlerMap.get(key);
+    if (!entry) {
+      // Untyped action-dispatch callers (e.g. usePluginActions) rely on a
+      // thrown rejection here; typed callers (useHostChannel) catch it and
+      // synthesize a HANDLER_NOT_FOUND envelope.
       throw new Error(`No plugin handler registered for ${key}`);
     }
-    try {
-      return await handler(ctx, ...args);
-    } catch (err) {
-      // Contain at the boundary so a throwing plugin handler can't propagate
-      // up through `ipcMain.handle` as an unhandled rejection in the main
-      // process. The error still surfaces to the renderer (we rethrow after
-      // logging) — the renderer-side wrapping in `usePluginActions` turns
-      // that rejection into a user-facing toast.
-      // TODO(#9232): emit PluginActionAuditRecord to the audit pipeline.
-      console.error(`[PluginService] Handler "${key}" threw:`, err);
-      throw err;
+
+    // Untyped registrations keep the legacy raw passthrough — no envelope.
+    if (!entry.argsSchema) {
+      return await entry.handler(ctx, ...args);
     }
+
+    // Capability gate: deny dispatch (failing closed) when the channel declares
+    // permissions the plugin manifest doesn't grant.
+    const granted = this.plugins.get(pluginId)?.manifest.permissions ?? [];
+    const missing = entry.requires.filter((p) => !granted.includes(p));
+    if (missing.length > 0) {
+      return {
+        ok: false,
+        code: "PERMISSION_REQUIRED",
+        missing,
+      } satisfies PluginInvokeResult<never>;
+    }
+
+    // Single-payload contract: validate args[0] against the args schema.
+    const parsed = entry.argsSchema.safeParse(args[0]);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        code: "VALIDATION_FAILED",
+        issues: parsed.error.issues.map((i) => ({
+          code: i.code,
+          message: i.message,
+          path: i.path.filter((p): p is string | number => typeof p !== "symbol"),
+        })),
+      } satisfies PluginInvokeResult<never>;
+    }
+
+    let result: unknown;
+    try {
+      result = await entry.handler(ctx, parsed.data);
+    } catch (err) {
+      return {
+        ok: false,
+        code: "HANDLER_ERROR",
+        message: err instanceof Error ? err.message : String(err),
+      } satisfies PluginInvokeResult<never>;
+    }
+
+    // Optional result validation — a handler returning an off-contract value is
+    // a plugin bug surfaced to the author, not a thrown crash.
+    if (entry.resultSchema) {
+      const parsedResult = entry.resultSchema.safeParse(result);
+      if (!parsedResult.success) {
+        return {
+          ok: false,
+          code: "VALIDATION_FAILED",
+          issues: parsedResult.error.issues.map((i) => ({
+            code: i.code,
+            message: i.message,
+            path: i.path.filter((p): p is string | number => typeof p !== "symbol"),
+          })),
+        } satisfies PluginInvokeResult<never>;
+      }
+      return { ok: true, data: parsedResult.data } satisfies PluginInvokeResult<unknown>;
+    }
+
+    return { ok: true, data: result } satisfies PluginInvokeResult<unknown>;
   }
 
   removeHandlers(pluginId: string): void {

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -1030,8 +1030,15 @@ export class PluginService {
     }
 
     // Untyped registrations keep the legacy raw passthrough — no envelope.
+    // Exception containment (#9276): log and rethrow the original so the
+    // caller still rejects with the handler's own error.
     if (!entry.argsSchema) {
-      return await entry.handler(ctx, ...args);
+      try {
+        return await entry.handler(ctx, ...args);
+      } catch (err) {
+        console.error(`Handler "${key}" threw:`, err);
+        throw err;
+      }
     }
 
     // Capability gate: deny dispatch (failing closed) when the channel declares
@@ -1067,6 +1074,9 @@ export class PluginService {
     try {
       result = await entry.handler(ctx, parsed.data);
     } catch (err) {
+      // Same exception-containment observability as the untyped path (#9276),
+      // but the typed contract returns the failure rather than rethrowing.
+      console.error(`Handler "${key}" threw:`, err);
       return {
         ok: false,
         code: "HANDLER_ERROR",

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -584,7 +584,7 @@ export class PluginService {
       get pluginId() {
         return pluginId;
       },
-      registerHandler: (
+      registerHandler: ((
         channel: string,
         schemaOrHandler: PluginChannelSchema | PluginIpcHandler,
         maybeHandler?: PluginIpcHandler
@@ -594,8 +594,19 @@ export class PluginService {
             `Plugin "${pluginId}" host revoked: registerHandler called after activate() returned or timed out`
           );
         }
-        this.registerHandler(pluginId, channel, schemaOrHandler, maybeHandler);
-      },
+        if (maybeHandler !== undefined) {
+          // Typed form: registerHandler(channel, schema, handler)
+          this.registerHandler(
+            pluginId,
+            channel,
+            schemaOrHandler as PluginChannelSchema,
+            maybeHandler
+          );
+        } else {
+          // Untyped form: registerHandler(channel, handler)
+          this.registerHandler(pluginId, channel, schemaOrHandler as PluginIpcHandler);
+        }
+      }) as PluginHostApi["registerHandler"],
       broadcastToRenderer: (channel, payload) => {
         if (revoked) {
           throw new Error(
@@ -948,11 +959,14 @@ export class PluginService {
   }
 
   registerHandler(pluginId: string, channel: string, handler: PluginIpcHandler): void;
-  registerHandler(
+  registerHandler<TArgs extends z.ZodType, TResult extends z.ZodType = z.ZodType>(
     pluginId: string,
     channel: string,
-    schema: PluginChannelSchema,
-    handler: PluginIpcHandler
+    schema: PluginChannelSchema<TArgs, TResult>,
+    handler: (
+      ctx: PluginIpcContext,
+      payload: z.output<TArgs>
+    ) => z.input<TResult> | Promise<z.input<TResult>>
   ): void;
   registerHandler(
     pluginId: string,

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -6,6 +6,7 @@ import { pathToFileURL } from "url";
 import { app } from "electron";
 import * as semver from "semver";
 import type { z } from "zod";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { PluginManifestSchema } from "../schemas/plugin.js";
 import type {
   PluginManifest,
@@ -967,13 +968,25 @@ export class PluginService {
     }
 
     let entry: HandlerEntry;
-    if (typeof schemaOrHandler === "function") {
-      // Untyped registration — raw passthrough, no validation or gate.
+    if (maybeHandler === undefined) {
+      // Untyped form: registerHandler(channel, handler) — raw passthrough.
+      if (typeof schemaOrHandler !== "function") {
+        throw new Error(`Plugin handler must be a function, got ${typeof schemaOrHandler}`);
+      }
       entry = { handler: schemaOrHandler, requires: [] };
-    } else if (isChannelSchema(schemaOrHandler)) {
-      // Typed registration — store schemas + declared permission gate.
+    } else {
+      // Typed form: registerHandler(channel, schema, handler) — gate + validate.
       if (typeof maybeHandler !== "function") {
         throw new Error(`Plugin handler must be a function, got ${typeof maybeHandler}`);
+      }
+      if (!isChannelSchema(schemaOrHandler)) {
+        throw new Error(`Plugin channel schema must provide a Zod "args" schema`);
+      }
+      if (
+        schemaOrHandler.result !== undefined &&
+        typeof (schemaOrHandler.result as { safeParse?: unknown }).safeParse !== "function"
+      ) {
+        throw new Error(`Plugin channel "result" must be a Zod schema`);
       }
       entry = {
         handler: maybeHandler,
@@ -981,8 +994,6 @@ export class PluginService {
         resultSchema: schemaOrHandler.result,
         requires: schemaOrHandler.requires ?? [],
       };
-    } else {
-      throw new Error(`Plugin handler must be a function, got ${typeof schemaOrHandler}`);
     }
 
     const key = `${pluginId}:${channel}`;
@@ -1035,6 +1046,9 @@ export class PluginService {
       } satisfies PluginInvokeResult<never>;
     }
 
+    // The handler passed the gate and validation, so an exception here is a
+    // runtime bug inside the plugin — surface it as HANDLER_ERROR rather than
+    // letting it reject (which the renderer would misread as HANDLER_NOT_FOUND).
     let result: unknown;
     try {
       result = await entry.handler(ctx, parsed.data);
@@ -1042,7 +1056,7 @@ export class PluginService {
       return {
         ok: false,
         code: "HANDLER_ERROR",
-        message: err instanceof Error ? err.message : String(err),
+        message: formatErrorMessage(err, "Plugin handler threw"),
       } satisfies PluginInvokeResult<never>;
     }
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import { EventEmitter } from "node:events";
 import fs from "fs/promises";
 import path from "path";
@@ -1154,6 +1155,188 @@ describe("Plugin IPC handler registration", () => {
       []
     );
     expect(result).toBe("sync-result");
+  });
+});
+
+describe("PluginService typed channel registerHandler + capability gate", () => {
+  let service: PluginService;
+
+  beforeEach(async () => {
+    await writePlugin("test-plugin", {
+      name: "acme.test-plugin",
+      version: "1.0.0",
+      permissions: ["network:fetch"],
+    });
+    service = new PluginService(tmpDir);
+    await service.initialize();
+  });
+
+  it("validates the payload and wraps a successful result in an envelope", async () => {
+    const handler = vi.fn((_ctx, payload: { name: string }) => `hi ${payload.name}`);
+    service.registerHandler(
+      "acme.test-plugin",
+      "greet",
+      { args: z.object({ name: z.string() }) },
+      handler
+    );
+
+    const result = await service.dispatchHandler(
+      "acme.test-plugin",
+      "greet",
+      makeCtx("acme.test-plugin"),
+      [{ name: "ada" }]
+    );
+
+    expect(result).toEqual({ ok: true, data: "hi ada" });
+    // Single-payload contract: handler receives the parsed payload, not variadic.
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ pluginId: "acme.test-plugin" }),
+      {
+        name: "ada",
+      }
+    );
+  });
+
+  it("returns VALIDATION_FAILED with serializable issues for a bad payload", async () => {
+    const handler = vi.fn();
+    service.registerHandler(
+      "acme.test-plugin",
+      "greet",
+      { args: z.object({ name: z.string() }) },
+      handler
+    );
+
+    const result = (await service.dispatchHandler(
+      "acme.test-plugin",
+      "greet",
+      makeCtx("acme.test-plugin"),
+      [{ name: 123 }]
+    )) as { ok: false; code: string; issues: Array<{ message: string }> };
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("VALIDATION_FAILED");
+    expect(Array.isArray(result.issues)).toBe(true);
+    expect(result.issues.length).toBeGreaterThan(0);
+    expect(handler).not.toHaveBeenCalled();
+    // Envelope must survive structured clone (no class instances).
+    expect(() => structuredClone(result)).not.toThrow();
+  });
+
+  it("fails closed with PERMISSION_REQUIRED when a required permission is not granted", async () => {
+    const handler = vi.fn();
+    service.registerHandler(
+      "acme.test-plugin",
+      "run",
+      { args: z.object({}), requires: ["shell:exec"] },
+      handler
+    );
+
+    const result = await service.dispatchHandler(
+      "acme.test-plugin",
+      "run",
+      makeCtx("acme.test-plugin"),
+      [{}]
+    );
+
+    expect(result).toEqual({ ok: false, code: "PERMISSION_REQUIRED", missing: ["shell:exec"] });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("allows dispatch when all required permissions are granted by the manifest", async () => {
+    const handler = vi.fn(() => "ok");
+    service.registerHandler(
+      "acme.test-plugin",
+      "fetch-thing",
+      { args: z.object({}), requires: ["network:fetch"] },
+      handler
+    );
+
+    const result = await service.dispatchHandler(
+      "acme.test-plugin",
+      "fetch-thing",
+      makeCtx("acme.test-plugin"),
+      [{}]
+    );
+
+    expect(result).toEqual({ ok: true, data: "ok" });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("checks the permission gate before validating args", async () => {
+    const handler = vi.fn();
+    service.registerHandler(
+      "acme.test-plugin",
+      "run",
+      { args: z.object({ name: z.string() }), requires: ["shell:exec"] },
+      handler
+    );
+
+    const result = (await service.dispatchHandler(
+      "acme.test-plugin",
+      "run",
+      makeCtx("acme.test-plugin"),
+      [{ name: 123 }]
+    )) as { code: string };
+
+    expect(result.code).toBe("PERMISSION_REQUIRED");
+  });
+
+  it("returns VALIDATION_FAILED when the handler result violates the result schema", async () => {
+    const handler = vi.fn(() => ({ wrong: true }));
+    service.registerHandler(
+      "acme.test-plugin",
+      "typed-result",
+      { args: z.object({}), result: z.object({ value: z.number() }) },
+      handler
+    );
+
+    const result = (await service.dispatchHandler(
+      "acme.test-plugin",
+      "typed-result",
+      makeCtx("acme.test-plugin"),
+      [{}]
+    )) as { ok: false; code: string };
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("throws a missing permission with no manifest permissions field", async () => {
+    await writePlugin("bare-plugin", { name: "acme.bare-plugin", version: "1.0.0" });
+    const bare = new PluginService(tmpDir);
+    await bare.initialize();
+    bare.registerHandler(
+      "acme.bare-plugin",
+      "run",
+      { args: z.object({}), requires: ["network:fetch"] },
+      vi.fn()
+    );
+
+    const result = await bare.dispatchHandler(
+      "acme.bare-plugin",
+      "run",
+      makeCtx("acme.bare-plugin"),
+      [{}]
+    );
+
+    expect(result).toEqual({ ok: false, code: "PERMISSION_REQUIRED", missing: ["network:fetch"] });
+  });
+
+  it("still throws for a missing handler (untyped action-dispatch contract preserved)", async () => {
+    await expect(
+      service.dispatchHandler("acme.test-plugin", "nope", makeCtx("acme.test-plugin"), [{}])
+    ).rejects.toThrow("No plugin handler registered for acme.test-plugin:nope");
+  });
+
+  it("rejects a typed registration whose handler is not a function", () => {
+    expect(() =>
+      service.registerHandler(
+        "acme.test-plugin",
+        "bad",
+        { args: z.object({}) },
+        "not-a-fn" as never
+      )
+    ).toThrow("Plugin handler must be a function, got string");
   });
 });
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -1282,7 +1282,9 @@ describe("PluginService typed channel registerHandler + capability gate", () => 
   });
 
   it("returns VALIDATION_FAILED when the handler result violates the result schema", async () => {
-    const handler = vi.fn(() => ({ wrong: true }));
+    // Cast bypasses the result-schema return-type check so we can exercise the
+    // runtime result-validation path with a deliberately off-contract return.
+    const handler = vi.fn(() => ({ wrong: true })) as never;
     service.registerHandler(
       "acme.test-plugin",
       "typed-result",

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -1322,6 +1322,57 @@ describe("PluginService typed channel registerHandler + capability gate", () => 
     expect(result).toEqual({ ok: false, code: "PERMISSION_REQUIRED", missing: ["network:fetch"] });
   });
 
+  it("returns HANDLER_ERROR when the handler throws after passing the gate", async () => {
+    const handler = vi.fn(() => {
+      throw new Error("db down");
+    });
+    service.registerHandler("acme.test-plugin", "boom", { args: z.object({}) }, handler);
+
+    const result = (await service.dispatchHandler(
+      "acme.test-plugin",
+      "boom",
+      makeCtx("acme.test-plugin"),
+      [{}]
+    )) as { ok: false; code: string; message: string };
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("HANDLER_ERROR");
+    expect(result.message).toBe("db down");
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports exactly the missing permissions when grants are partial", async () => {
+    const handler = vi.fn();
+    service.registerHandler(
+      "acme.test-plugin",
+      "multi",
+      { args: z.object({}), requires: ["network:fetch", "shell:exec", "git:write"] },
+      handler
+    );
+
+    const result = (await service.dispatchHandler(
+      "acme.test-plugin",
+      "multi",
+      makeCtx("acme.test-plugin"),
+      [{}]
+    )) as { code: string; missing: string[] };
+
+    expect(result.code).toBe("PERMISSION_REQUIRED");
+    expect(result.missing).toEqual(["shell:exec", "git:write"]);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("rejects a typed registration whose result is not a Zod schema", () => {
+    expect(() =>
+      service.registerHandler(
+        "acme.test-plugin",
+        "bad-result",
+        { args: z.object({}), result: { notZod: true } as never },
+        vi.fn()
+      )
+    ).toThrow('Plugin channel "result" must be a Zod schema');
+  });
+
   it("still throws for a missing handler (untyped action-dispatch contract preserved)", async () => {
     await expect(
       service.dispatchHandler("acme.test-plugin", "nope", makeCtx("acme.test-plugin"), [{}])

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -166,13 +166,17 @@ export interface PluginInvokeIssue {
 /**
  * Structured failure returned by a typed channel. Always returned, never
  * thrown — throwing would strip the structured fields to a bare message across
- * the contextBridge. `HANDLER_NOT_FOUND` is synthesized renderer-side by
- * {@link useHostChannel} when an invoke rejects (the host still throws on a
- * missing handler to preserve the untyped action-dispatch contract).
+ * the contextBridge. `HANDLER_ERROR` carries the message of an exception the
+ * handler threw *after* passing the gate and validation (a runtime bug in the
+ * plugin, distinct from a missing handler). `HANDLER_NOT_FOUND` is synthesized
+ * renderer-side by {@link useHostChannel} when an invoke rejects (the host
+ * still throws on a missing handler to preserve the untyped action-dispatch
+ * contract).
  */
 export type PluginInvokeError =
   | { ok: false; code: "VALIDATION_FAILED"; issues: PluginInvokeIssue[] }
   | { ok: false; code: "PERMISSION_REQUIRED"; missing: BuiltInPluginPermission[] }
+  | { ok: false; code: "HANDLER_ERROR"; message: string }
   | { ok: false; code: "HANDLER_NOT_FOUND"; channel: string };
 
 /** Result envelope a typed channel resolves with: success data or a structured error. */

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -1,3 +1,4 @@
+import type { z } from "zod";
 import type {
   FileDecorationContribution,
   FileDecorationProviderDescriptor,
@@ -134,6 +135,50 @@ export type PluginIpcHandler = (
 ) => unknown | Promise<unknown>;
 
 /**
+ * Typed-channel registration descriptor passed to the schema overload of
+ * {@link PluginHostApi.registerHandler}. The channel takes a single payload
+ * (issue #9230 settled single-payload over variadic), validated host-side by
+ * {@link args} before the handler runs. {@link result} optionally validates the
+ * handler's return. {@link requires} declares the manifest permissions the
+ * channel needs — the host capability gate denies dispatch (failing closed)
+ * when any are absent from the plugin manifest.
+ */
+export interface PluginChannelSchema<
+  TArgs extends z.ZodType = z.ZodType,
+  TResult extends z.ZodType = z.ZodType,
+> {
+  args: TArgs;
+  result?: TResult;
+  requires?: BuiltInPluginPermission[];
+}
+
+/**
+ * Serializable projection of a Zod issue. Real `ZodError` instances lose all
+ * data except `.message` when cloned across the contextBridge, so typed
+ * channels surface validation failures through this plain shape instead.
+ */
+export interface PluginInvokeIssue {
+  code: string;
+  message: string;
+  path: ReadonlyArray<string | number>;
+}
+
+/**
+ * Structured failure returned by a typed channel. Always returned, never
+ * thrown — throwing would strip the structured fields to a bare message across
+ * the contextBridge. `HANDLER_NOT_FOUND` is synthesized renderer-side by
+ * {@link useHostChannel} when an invoke rejects (the host still throws on a
+ * missing handler to preserve the untyped action-dispatch contract).
+ */
+export type PluginInvokeError =
+  | { ok: false; code: "VALIDATION_FAILED"; issues: PluginInvokeIssue[] }
+  | { ok: false; code: "PERMISSION_REQUIRED"; missing: BuiltInPluginPermission[] }
+  | { ok: false; code: "HANDLER_NOT_FOUND"; channel: string };
+
+/** Result envelope a typed channel resolves with: success data or a structured error. */
+export type PluginInvokeResult<T> = { ok: true; data: T } | PluginInvokeError;
+
+/**
  * Provider-agnostic projection of a worktree's linked forge resources (issue
  * and/or PR), exposed on {@link PluginWorktreeSnapshot.linked}. Replaces the
  * GitHub-shaped flat fields that previously leaked onto the snapshot —
@@ -191,7 +236,28 @@ export interface PluginWorktreeSnapshot {
 
 export interface PluginHostApi {
   readonly pluginId: string;
+  /**
+   * Register an untyped IPC handler for `channel`. Args pass through unchanged
+   * and the handler's return value is sent back raw. Prefer the typed overload
+   * for new channels — it gates dispatch on declared permissions and validates
+   * the payload host-side.
+   */
   registerHandler(channel: string, handler: PluginIpcHandler): void;
+  /**
+   * Register a typed IPC handler for `channel`. The host validates the single
+   * payload against `schema.args` and checks `schema.requires` against the
+   * plugin manifest before dispatch, failing closed with a structured
+   * {@link PluginInvokeError}. The handler receives the parsed payload and its
+   * result is wrapped in a {@link PluginInvokeResult} `{ ok: true, data }`.
+   */
+  registerHandler<TArgs extends z.ZodType, TResult extends z.ZodType = z.ZodType>(
+    channel: string,
+    schema: PluginChannelSchema<TArgs, TResult>,
+    handler: (
+      ctx: PluginIpcContext,
+      payload: z.output<TArgs>
+    ) => z.input<TResult> | Promise<z.input<TResult>>
+  ): void;
   broadcastToRenderer(channel: string, payload: unknown): void;
   /**
    * Returns the currently-active worktree (`isCurrent === true`) across all

--- a/src/hooks/__tests__/useHostChannel.test.tsx
+++ b/src/hooks/__tests__/useHostChannel.test.tsx
@@ -102,6 +102,58 @@ describe("useHostChannel", () => {
     expect(result.current.error).toBeNull();
   });
 
+  it("clears stale data when a later call fails", async () => {
+    invokeMock.mockResolvedValueOnce({ ok: true, data: "secret" });
+    const { result } = renderHook(() => useHostChannel("acme.plugin", "run"));
+
+    await act(async () => {
+      result.current.invoke({});
+    });
+    await waitFor(() => expect(result.current.data).toBe("secret"));
+
+    invokeMock.mockResolvedValueOnce({
+      ok: false,
+      code: "PERMISSION_REQUIRED",
+      missing: ["git:write"],
+    });
+    await act(async () => {
+      result.current.invoke({});
+    });
+
+    await waitFor(() => expect(result.current.error?.code).toBe("PERMISSION_REQUIRED"));
+    // Old payload must not linger next to the fresh denial.
+    expect(result.current.data).toBeNull();
+  });
+
+  it("ignores a slower earlier invoke that resolves after a newer one (last-write-wins)", async () => {
+    const deferreds: Array<(v: unknown) => void> = [];
+    invokeMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          deferreds.push(resolve);
+        })
+    );
+    const { result } = renderHook(() => useHostChannel<unknown, string>("acme.plugin", "run"));
+
+    act(() => {
+      result.current.invoke("A");
+    });
+    act(() => {
+      result.current.invoke("B");
+    });
+
+    // Resolve the newer call (B) first, then the older call (A).
+    await act(async () => {
+      deferreds[1]?.({ ok: true, data: "B" });
+    });
+    await act(async () => {
+      deferreds[0]?.({ ok: true, data: "A" });
+    });
+
+    // A is stale — it must not clobber B's result.
+    expect(result.current.data).toBe("B");
+  });
+
   it("treats a raw (non-envelope) resolution as success data for legacy channels", async () => {
     invokeMock.mockResolvedValue("legacy-value");
     const { result } = renderHook(() => useHostChannel("acme.plugin", "legacy"));

--- a/src/hooks/__tests__/useHostChannel.test.tsx
+++ b/src/hooks/__tests__/useHostChannel.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useHostChannel } from "../useHostChannel";
+
+const invokeMock = vi.fn();
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  Object.defineProperty(window, "electron", {
+    configurable: true,
+    value: { plugin: { invoke: invokeMock } },
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useHostChannel", () => {
+  it("populates data from a successful envelope", async () => {
+    invokeMock.mockResolvedValue({ ok: true, data: { greeting: "hi" } });
+    const { result } = renderHook(() =>
+      useHostChannel<{ name: string }, { greeting: string }>("acme.plugin", "greet")
+    );
+
+    await act(async () => {
+      result.current.invoke({ name: "ada" });
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual({ greeting: "hi" }));
+    expect(result.current.error).toBeNull();
+    expect(invokeMock).toHaveBeenCalledWith("acme.plugin", "greet", { name: "ada" });
+  });
+
+  it("populates error from a VALIDATION_FAILED envelope", async () => {
+    invokeMock.mockResolvedValue({
+      ok: false,
+      code: "VALIDATION_FAILED",
+      issues: [{ code: "invalid_type", message: "Expected string", path: ["name"] }],
+    });
+    const { result } = renderHook(() => useHostChannel("acme.plugin", "greet"));
+
+    await act(async () => {
+      result.current.invoke({ name: 123 });
+    });
+
+    await waitFor(() => expect(result.current.error?.code).toBe("VALIDATION_FAILED"));
+    expect(result.current.data).toBeNull();
+  });
+
+  it("populates error from a PERMISSION_REQUIRED envelope", async () => {
+    invokeMock.mockResolvedValue({
+      ok: false,
+      code: "PERMISSION_REQUIRED",
+      missing: ["shell:exec"],
+    });
+    const { result } = renderHook(() => useHostChannel("acme.plugin", "run"));
+
+    await act(async () => {
+      result.current.invoke({});
+    });
+
+    await waitFor(() => expect(result.current.error?.code).toBe("PERMISSION_REQUIRED"));
+  });
+
+  it("synthesizes HANDLER_NOT_FOUND when the invoke rejects", async () => {
+    invokeMock.mockRejectedValue(new Error("No plugin handler registered for acme.plugin:missing"));
+    const { result } = renderHook(() => useHostChannel("acme.plugin", "missing"));
+
+    await act(async () => {
+      result.current.invoke({});
+    });
+
+    await waitFor(() => expect(result.current.error?.code).toBe("HANDLER_NOT_FOUND"));
+    expect(result.current.error).toEqual({
+      ok: false,
+      code: "HANDLER_NOT_FOUND",
+      channel: "missing",
+    });
+  });
+
+  it("clears a prior error on a subsequent successful call", async () => {
+    invokeMock.mockResolvedValueOnce({
+      ok: false,
+      code: "PERMISSION_REQUIRED",
+      missing: ["git:write"],
+    });
+    const { result } = renderHook(() => useHostChannel("acme.plugin", "run"));
+
+    await act(async () => {
+      result.current.invoke({});
+    });
+    await waitFor(() => expect(result.current.error?.code).toBe("PERMISSION_REQUIRED"));
+
+    invokeMock.mockResolvedValueOnce({ ok: true, data: "done" });
+    await act(async () => {
+      result.current.invoke({});
+    });
+
+    await waitFor(() => expect(result.current.data).toBe("done"));
+    expect(result.current.error).toBeNull();
+  });
+
+  it("treats a raw (non-envelope) resolution as success data for legacy channels", async () => {
+    invokeMock.mockResolvedValue("legacy-value");
+    const { result } = renderHook(() => useHostChannel("acme.plugin", "legacy"));
+
+    await act(async () => {
+      result.current.invoke({});
+    });
+
+    await waitFor(() => expect(result.current.data).toBe("legacy-value"));
+  });
+
+  it("does not set state after unmount", async () => {
+    let resolveInvoke: (v: unknown) => void = () => {};
+    invokeMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveInvoke = resolve;
+      })
+    );
+    const { result, unmount } = renderHook(() => useHostChannel("acme.plugin", "greet"));
+
+    act(() => {
+      result.current.invoke({});
+    });
+    unmount();
+
+    await act(async () => {
+      resolveInvoke({ ok: true, data: "late" });
+    });
+    // No setState-on-unmounted warning is the implicit pass; state stayed null.
+    expect(result.current.data).toBeNull();
+  });
+});

--- a/src/hooks/useHostChannel.ts
+++ b/src/hooks/useHostChannel.ts
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import type { PluginInvokeError, PluginInvokeResult } from "@shared/types/plugin";
+
+export interface UseHostChannelResult<TArgs, TResult> {
+  /** Invoke the channel with a single typed payload. */
+  invoke: (payload: TArgs) => void;
+  /** True while an invocation is in flight. */
+  isPending: boolean;
+  /** The last successful result, or `null` before the first success. */
+  data: TResult | null;
+  /** The last structured failure, or `null` when the last call succeeded. */
+  error: PluginInvokeError | null;
+}
+
+function isInvokeResult(value: unknown): value is PluginInvokeResult<unknown> {
+  return typeof value === "object" && value !== null && "ok" in value;
+}
+
+/**
+ * Typed renderer-side client for a plugin's typed host channel. Mirrors the
+ * host-side {@link PluginChannelSchema} contract: `invoke(payload)` sends a
+ * single typed payload and the host validates it, gates it on declared
+ * permissions, and resolves a {@link PluginInvokeResult} envelope. Success
+ * populates `data`; a structured failure (or a rejected invoke, surfaced as
+ * `HANDLER_NOT_FOUND`) populates `error`.
+ *
+ * This is the foundation for the future `@daintreehq/plugin-sdk/react` package
+ * but ships in-tree for now. `TArgs`/`TResult` are author-supplied — the
+ * renderer holds no Zod schema, so validation is host-authoritative.
+ */
+export function useHostChannel<TArgs = unknown, TResult = unknown>(
+  pluginId: string,
+  channel: string
+): UseHostChannelResult<TArgs, TResult> {
+  const [isPending, startTransition] = useTransition();
+  const [data, setData] = useState<TResult | null>(null);
+  const [error, setError] = useState<PluginInvokeError | null>(null);
+
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const invoke = useCallback(
+    (payload: TArgs) => {
+      startTransition(async () => {
+        try {
+          const raw = await window.electron.plugin.invoke(pluginId, channel, payload);
+          if (!isMountedRef.current) return;
+
+          if (isInvokeResult(raw)) {
+            if (raw.ok) {
+              // Host is authoritative — the renderer holds no schema to refine `unknown` to TResult.
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- TResult is author-supplied; validation is host-side
+              setData(raw.data as TResult);
+              setError(null);
+            } else {
+              setError(raw);
+            }
+            return;
+          }
+
+          // An untyped channel resolves a raw value rather than an envelope —
+          // treat it as success data so the hook still works against legacy
+          // (non-schema) registrations.
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- TResult is author-supplied; validation is host-side
+          setData(raw as TResult);
+          setError(null);
+        } catch {
+          // A rejected invoke means the channel never reached its typed
+          // dispatch path (missing handler, untrusted sender, or a handler
+          // that threw). Surface it as the structured HANDLER_NOT_FOUND code.
+          if (!isMountedRef.current) return;
+          setError({ ok: false, code: "HANDLER_NOT_FOUND", channel });
+        }
+      });
+    },
+    [pluginId, channel]
+  );
+
+  return { invoke, isPending, data, error };
+}

--- a/src/hooks/useHostChannel.ts
+++ b/src/hooks/useHostChannel.ts
@@ -44,12 +44,17 @@ export function useHostChannel<TArgs = unknown, TResult = unknown>(
     };
   }, []);
 
+  // Last-write-wins: a slower earlier invoke must not clobber a newer one's
+  // result. Each call captures its id and bails if a later call superseded it.
+  const callIdRef = useRef(0);
+
   const invoke = useCallback(
     (payload: TArgs) => {
+      const callId = ++callIdRef.current;
       startTransition(async () => {
         try {
           const raw = await window.electron.plugin.invoke(pluginId, channel, payload);
-          if (!isMountedRef.current) return;
+          if (!isMountedRef.current || callId !== callIdRef.current) return;
 
           if (isInvokeResult(raw)) {
             if (raw.ok) {
@@ -58,6 +63,9 @@ export function useHostChannel<TArgs = unknown, TResult = unknown>(
               setData(raw.data as TResult);
               setError(null);
             } else {
+              // Clear stale data so a caller can't render an old payload next
+              // to a fresh denial/validation error.
+              setData(null);
               setError(raw);
             }
             return;
@@ -70,10 +78,12 @@ export function useHostChannel<TArgs = unknown, TResult = unknown>(
           setData(raw as TResult);
           setError(null);
         } catch {
-          // A rejected invoke means the channel never reached its typed
-          // dispatch path (missing handler, untrusted sender, or a handler
-          // that threw). Surface it as the structured HANDLER_NOT_FOUND code.
-          if (!isMountedRef.current) return;
+          // A rejected invoke means dispatch never reached the typed handler:
+          // the channel isn't registered (or the sender wasn't trusted). Typed
+          // handlers that throw at runtime are returned as a HANDLER_ERROR
+          // envelope above, so they don't land here.
+          if (!isMountedRef.current || callId !== callIdRef.current) return;
+          setData(null);
           setError({ ok: false, code: "HANDLER_NOT_FOUND", channel });
         }
       });


### PR DESCRIPTION
Closes #9231.

## What

Adds a typed contract and a host-side capability gate to the plugin `plugin:invoke` perimeter, plus a renderer hook for plugin view authors. Disclosure model only — runtime permission-prompt UI and sandboxing are explicitly out of scope.

### 1. Typed `registerHandler` overload (`shared/types/plugin.ts`)
Plugins can now register a channel with a Zod schema instead of a bare function:

```ts
host.registerHandler("greet", { args: z.object({ name: z.string() }), requires: ["network:fetch"] }, (ctx, payload) => `hi ${payload.name}`);
```

`schema` carries `args` (single payload — the variadic-vs-single-payload question from #9230 is settled in favor of single payload), an optional `result` schema, and an optional `requires` permission array. The untyped `(channel, handler)` overload is unchanged.

### 2. Host capability gate (`PluginService.dispatchHandler`)
For typed channels, before dispatch the host:
- **fails closed** with `PERMISSION_REQUIRED` (listing the missing permissions) when the plugin manifest doesn't grant a declared `requires` permission;
- validates the payload against `args`, returning `VALIDATION_FAILED` with a serializable issue projection;
- validates the handler's return against `result` (if given);
- wraps success in `{ ok: true, data }`.

A handler that throws *after* passing the gate returns a structured `HANDLER_ERROR` rather than rejecting. Untyped registrations keep the legacy raw passthrough and the throw-on-missing-handler contract, so existing plugin **action dispatch** (`usePluginActions`) is unchanged — minimal blast radius.

### 3. `useHostChannel` renderer hook (`src/hooks/useHostChannel.ts`)
`useHostChannel<TArgs, TResult>(pluginId, channel)` returns `{ invoke, isPending, data, error }`. Uses `useTransition` + a mounted-ref guard + a last-write-wins call-id guard (so a slow earlier invoke can't clobber a newer result), routes the envelope to `data`/`error`, clears stale data on failure, and synthesizes `HANDLER_NOT_FOUND` on a rejected invoke. Foundation for the future `@daintreehq/plugin-sdk/react` package; ships in-tree for now.

### Envelope
Structured `PluginInvokeResult<T>` / `PluginInvokeError` + serializable `PluginInvokeIssue` projection so validation/permission failures survive the contextBridge (raw `ZodError` instances lose all but `.message` across Structured Clone).

## Tests
- `PluginService`: capability gate (full grant / partial grant / no-permissions-field fail-closed / gate-before-validation), arg + result validation, `HANDLER_ERROR`, missing-handler still throws, bad result-schema rejected at registration.
- `useHostChannel`: success / validation / permission / `HANDLER_NOT_FOUND` / stale-data-cleared / concurrent out-of-order / legacy-raw / unmount guard.
- Typecheck, lint-ratchet (no new warnings), format, and IPC/channel gates all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)