### PR TITLE
feat(plugins): wire manifest commands to lazy handlers and standardize {pluginId}.{actionId} namespace

### DIFF
--- a/docs/plugins/contribution-points.md
+++ b/docs/plugins/contribution-points.md
@@ -196,7 +196,7 @@ Toolbar buttons dispatch an existing action from the main toolbar.
 
 | Field | Required | Notes |
 | --- | --- | --- |
-| `id` | yes | Namespaced at runtime as `plugin.{pluginId}.{id}`. |
+| `id` | yes | Namespaced at runtime as `{pluginId}.{id}`. |
 | `label` | yes | Hover tooltip. |
 | `iconId` | yes | Registered icon ID. |
 | `actionId` | yes | Fully-qualified action ID, including plugin namespace. Built-in actions (e.g. `terminal.new`) also work. |

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -4,6 +4,7 @@ import { BUILT_IN_PLUGIN_PERMISSIONS } from "../../shared/types/plugin.js";
 import type {
   PluginManifest,
   PanelContribution,
+  CommandContribution,
   ToolbarButtonContribution,
   MenuItemContribution,
   ViewContribution,
@@ -28,6 +29,20 @@ export const PanelContributionSchema = z.object({
   canRestart: z.boolean().default(false),
   canConvert: z.boolean().default(false),
   showInPalette: z.boolean().default(true),
+});
+
+const COMMAND_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
+export const CommandContributionSchema = z.object({
+  name: z.string().min(1).max(64).regex(COMMAND_NAME_PATTERN, {
+    error: "Command name must match /^[a-z0-9][a-z0-9-]*$/",
+  }),
+  title: z.string().min(1),
+  description: z.string().min(1),
+  category: z.string().min(1),
+  kind: z.enum(["command", "query"]).default("command"),
+  danger: z.enum(["safe", "confirm"]).default("safe"),
+  keywords: z.array(z.string().min(1)).optional(),
 });
 
 export const ToolbarButtonContributionSchema = z.object({
@@ -139,6 +154,7 @@ export const PluginManifestSchema = z
     contributes: z
       .object({
         panels: z.array(PanelContributionSchema).default([]),
+        commands: z.array(CommandContributionSchema).default([]),
         toolbarButtons: z.array(ToolbarButtonContributionSchema).default([]),
         menuItems: z.array(MenuItemContributionSchema).default([]),
         views: z.array(ViewContributionSchema).default([]),
@@ -148,6 +164,7 @@ export const PluginManifestSchema = z
       })
       .default({
         panels: [],
+        commands: [],
         toolbarButtons: [],
         menuItems: [],
         views: [],
@@ -161,6 +178,7 @@ export const PluginManifestSchema = z
 export type {
   PluginManifest,
   PanelContribution,
+  CommandContribution,
   ToolbarButtonContribution,
   MenuItemContribution,
   ViewContribution,

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -16,6 +16,8 @@ import type {
   PluginActionDescriptor,
   BuiltInPluginPermission,
 } from "../../shared/types/plugin.js";
+import { pluginActionId } from "../../shared/types/plugin.js";
+import { BUILT_IN_ACTION_IDS } from "../../shared/config/actionIds.js";
 import type { WorktreeSnapshot } from "../../shared/types/workspace-host.js";
 import { toPluginWorktreeSnapshot } from "../../shared/utils/pluginWorktreeSnapshot.js";
 import type { WorkspaceClient } from "./WorkspaceClient.js";
@@ -55,6 +57,22 @@ import { store } from "../store.js";
 
 /** Plugin action IDs must be `{pluginId}.{actionId}`. Built-in IDs use colons, so the formats cannot collide. */
 const PLUGIN_ACTION_ID_RE = /^[a-z0-9][a-z0-9-]*\.[a-z0-9][a-zA-Z0-9._-]*$/;
+
+/** Filesystem-convention handler extensions, probed in precedence order. */
+const COMMAND_HANDLER_EXTENSIONS = [".ts", ".tsx", ".js", ".mjs"] as const;
+
+/**
+ * Lazily-built lookup of built-in action ids for command-collision rejection.
+ * `BUILT_IN_ACTION_IDS` is a static array; the Set is memoised on first use so
+ * each `loadPlugin()` does an O(1) membership check instead of a linear scan.
+ */
+let builtInActionIdSet: Set<string> | null = null;
+function getBuiltInActionIdSet(): Set<string> {
+  if (!builtInActionIdSet) {
+    builtInActionIdSet = new Set<string>(BUILT_IN_ACTION_IDS);
+  }
+  return builtInActionIdSet;
+}
 
 const PLUGIN_ACTION_KINDS = new Set(["command", "query"]);
 const PLUGIN_ACTION_DANGERS = new Set(["safe", "confirm"]);
@@ -151,6 +169,20 @@ export class PluginService {
   private cleanupMap = new Map<string, () => void>();
   private pluginActions = new Map<string, PluginActionDescriptor>();
   private pluginActionOwners = new Map<string, Set<string>>();
+  /**
+   * Resolved handler file path for each manifest command, keyed by action id
+   * (`{pluginId}.{name}`). Populated at load time by probing
+   * `src/{name}.{ext}`; absent entries mean no handler file was found (the
+   * command dispatches to a "no handler" error). The `import()` itself is
+   * deferred to first dispatch to keep activation within budget.
+   */
+  private commandHandlerPaths = new Map<string, string>();
+  /**
+   * Memoised default export for each manifest command, keyed by action id.
+   * Filled on first dispatch so subsequent calls skip the module loader
+   * entirely. Cleared per-plugin on unload.
+   */
+  private commandHandlerFns = new Map<string, PluginIpcHandler>();
   private pluginEventCleanups = new Map<string, Array<() => void>>();
   /**
    * Most recent activation error per plugin id. Populated by the catch in
@@ -473,7 +505,7 @@ export class PluginService {
     }
 
     for (const btn of manifest.contributes.toolbarButtons) {
-      const buttonId = `plugin.${manifest.name}.${btn.id}` as PluginToolbarButtonId;
+      const buttonId = pluginActionId(manifest.name, btn.id) as PluginToolbarButtonId;
       registerToolbarButton({
         id: buttonId,
         label: btn.label,
@@ -518,6 +550,12 @@ export class PluginService {
     // inside the plugin's own init, and registerHandler/registerPluginAction
     // throw "Unknown plugin" even for a correctly loaded plugin.
     this.plugins.set(manifest.name, plugin);
+
+    // Wire manifest commands before importing main so the filesystem-convention
+    // handlers are dispatchable even if `activate()` later throws. Each command
+    // resolves to an action id `{pluginId}.{name}` and binds a lazy handler that
+    // imports `src/{name}.{ext}` on first dispatch.
+    await this.registerManifestCommands(manifest, pluginDir);
 
     if (plugin.resolvedMain) {
       try {
@@ -914,6 +952,117 @@ export class PluginService {
     return resolved;
   }
 
+  /**
+   * Register every `contributes.commands` entry as a synthetic plugin action.
+   * For each command: reject ids that collide with a built-in action, probe the
+   * `src/{name}.{ext}` handler file (storing the resolved path for lazy import),
+   * register the descriptor via {@link registerPluginAction}, and bind a lazy
+   * dispatch handler into `handlerMap` so `plugin:invoke` routes to it. Commands
+   * with no handler file are still registered (visible in the palette) but throw
+   * a "no handler" error when dispatched — never at load time.
+   */
+  private async registerManifestCommands(
+    manifest: PluginManifest,
+    pluginDir: string
+  ): Promise<void> {
+    const builtins = getBuiltInActionIdSet();
+    for (const cmd of manifest.contributes.commands) {
+      const actionId = pluginActionId(manifest.name, cmd.name);
+      if (builtins.has(actionId)) {
+        console.error(
+          `[PluginService] Plugin "${manifest.name}" command "${cmd.name}" resolves to action id "${actionId}", which collides with a built-in action — skipping`
+        );
+        continue;
+      }
+
+      const resolvedPath = await this.resolveCommandHandlerPath(pluginDir, cmd.name);
+      if (resolvedPath) {
+        this.commandHandlerPaths.set(actionId, resolvedPath);
+      }
+
+      try {
+        this.registerPluginAction(manifest.name, {
+          id: actionId,
+          title: cmd.title,
+          description: cmd.description,
+          category: cmd.category,
+          kind: cmd.kind,
+          danger: cmd.danger,
+          keywords: cmd.keywords,
+        });
+      } catch (err) {
+        console.error(
+          `[PluginService] Failed to register manifest command "${actionId}" for "${manifest.name}":`,
+          err
+        );
+        this.commandHandlerPaths.delete(actionId);
+        continue;
+      }
+
+      // The renderer dispatches the action by its full id, so the handler is
+      // keyed `{pluginId}:{actionId}` to match `dispatchHandler`'s lookup.
+      this.handlerMap.set(`${manifest.name}:${actionId}`, this.makeCommandHandler(actionId));
+    }
+  }
+
+  /**
+   * Probe `src/{name}.{ext}` for the command handler file, returning the first
+   * existing path in {@link COMMAND_HANDLER_EXTENSIONS} precedence order, or
+   * `null` if none exist (or the path escapes the plugin directory). The
+   * `access` check runs at load time; only the `import()` is deferred.
+   */
+  private async resolveCommandHandlerPath(pluginDir: string, name: string): Promise<string | null> {
+    for (const ext of COMMAND_HANDLER_EXTENSIONS) {
+      const candidate = this.resolveEntryPath(pluginDir, path.join("src", `${name}${ext}`));
+      if (!candidate) continue;
+      try {
+        await fs.access(candidate);
+        return candidate;
+      } catch {
+        // Not present at this extension — try the next.
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Build the lazy dispatch handler for a manifest command. On first call it
+   * imports the resolved handler module and caches its default export; later
+   * calls reuse the cached function. A command with no resolved handler file
+   * throws the documented "no handler" error so the renderer surfaces a toast.
+   */
+  private makeCommandHandler(actionId: string): PluginIpcHandler {
+    return async (ctx, ...args) => {
+      let fn = this.commandHandlerFns.get(actionId);
+      if (!fn) {
+        const resolvedPath = this.commandHandlerPaths.get(actionId);
+        if (!resolvedPath) {
+          throw new Error(`Command "${actionId}" has no handler`);
+        }
+        const mod = (await import(pathToFileURL(resolvedPath).href)) as { default?: unknown };
+        if (typeof mod.default !== "function") {
+          throw new Error(
+            `Command "${actionId}" handler module "${resolvedPath}" has no default export function`
+          );
+        }
+        fn = mod.default as PluginIpcHandler;
+        this.commandHandlerFns.set(actionId, fn);
+      }
+      return await fn(ctx, ...args);
+    };
+  }
+
+  /** Drop cached command handler paths/functions for an unloaded plugin. */
+  private removeCommandHandlers(pluginId: string): void {
+    const prefix = `${pluginId}.`;
+    for (const key of [...this.commandHandlerPaths.keys()]) {
+      if (key.startsWith(prefix)) this.commandHandlerPaths.delete(key);
+    }
+    for (const key of [...this.commandHandlerFns.keys()]) {
+      if (key.startsWith(prefix)) this.commandHandlerFns.delete(key);
+    }
+  }
+
   hasPlugin(pluginId: string): boolean {
     return this.plugins.has(pluginId);
   }
@@ -1002,6 +1151,7 @@ export class PluginService {
     // impl steps are split so a throw in the descriptor unregister doesn't
     // strand the impl unregister and vice versa.
     runUnloadStep(pluginId, "removeHandlers", () => this.removeHandlers(pluginId));
+    runUnloadStep(pluginId, "removeCommandHandlers", () => this.removeCommandHandlers(pluginId));
     runUnloadStep(pluginId, "unregisterPluginActions", () =>
       this.unregisterPluginActions(pluginId)
     );

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -976,9 +976,6 @@ export class PluginService {
       }
 
       const resolvedPath = await this.resolveCommandHandlerPath(pluginDir, cmd.name);
-      if (resolvedPath) {
-        this.commandHandlerPaths.set(actionId, resolvedPath);
-      }
 
       try {
         this.registerPluginAction(manifest.name, {
@@ -991,14 +988,21 @@ export class PluginService {
           keywords: cmd.keywords,
         });
       } catch (err) {
+        // A duplicate `name` (or otherwise-invalid contribution) throws here.
+        // Skip without touching the maps so a prior command that resolved to
+        // the same id keeps its handler path and dispatch entry intact.
         console.error(
           `[PluginService] Failed to register manifest command "${actionId}" for "${manifest.name}":`,
           err
         );
-        this.commandHandlerPaths.delete(actionId);
         continue;
       }
 
+      // Record the handler path and dispatch entry only after registration
+      // succeeds, so a failed registration can't corrupt an existing command.
+      if (resolvedPath) {
+        this.commandHandlerPaths.set(actionId, resolvedPath);
+      }
       // The renderer dispatches the action by its full id, so the handler is
       // keyed `{pluginId}:{actionId}` to match `dispatchHandler`'s lookup.
       this.handlerMap.set(`${manifest.name}:${actionId}`, this.makeCommandHandler(actionId));

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -17,7 +17,6 @@ import type {
   BuiltInPluginPermission,
 } from "../../shared/types/plugin.js";
 import { pluginActionId } from "../../shared/types/plugin.js";
-import { BUILT_IN_ACTION_IDS } from "../../shared/config/actionIds.js";
 import type { WorktreeSnapshot } from "../../shared/types/workspace-host.js";
 import { toPluginWorktreeSnapshot } from "../../shared/utils/pluginWorktreeSnapshot.js";
 import type { WorkspaceClient } from "./WorkspaceClient.js";
@@ -63,15 +62,18 @@ const COMMAND_HANDLER_EXTENSIONS = [".ts", ".tsx", ".js", ".mjs"] as const;
 
 /**
  * Lazily-built lookup of built-in action ids for command-collision rejection.
- * `BUILT_IN_ACTION_IDS` is a static array; the Set is memoised on first use so
- * each `loadPlugin()` does an O(1) membership check instead of a linear scan.
+ * `actionIds.js` is imported dynamically — and only the first time a plugin
+ * with manifest commands loads — so it stays off the boot-critical eager
+ * import graph. The Set (memoised via its promise) gives O(1) membership.
  */
-let builtInActionIdSet: Set<string> | null = null;
-function getBuiltInActionIdSet(): Set<string> {
-  if (!builtInActionIdSet) {
-    builtInActionIdSet = new Set<string>(BUILT_IN_ACTION_IDS);
+let builtInActionIdSetPromise: Promise<Set<string>> | null = null;
+function getBuiltInActionIdSet(): Promise<Set<string>> {
+  if (!builtInActionIdSetPromise) {
+    builtInActionIdSetPromise = import("../../shared/config/actionIds.js").then(
+      (m) => new Set<string>(m.BUILT_IN_ACTION_IDS)
+    );
   }
-  return builtInActionIdSet;
+  return builtInActionIdSetPromise;
 }
 
 const PLUGIN_ACTION_KINDS = new Set(["command", "query"]);
@@ -965,7 +967,8 @@ export class PluginService {
     manifest: PluginManifest,
     pluginDir: string
   ): Promise<void> {
-    const builtins = getBuiltInActionIdSet();
+    if (manifest.contributes.commands.length === 0) return;
+    const builtins = await getBuiltInActionIdSet();
     for (const cmd of manifest.contributes.commands) {
       const actionId = pluginActionId(manifest.name, cmd.name);
       if (builtins.has(actionId)) {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -312,6 +312,41 @@ describe("PluginManifestSchema forgeProviders contribution", () => {
     }
   });
 
+  it("defaults contributes.commands to [] when contributes is absent", () => {
+    const result = PluginManifestSchema.safeParse(validBase);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.contributes.commands).toEqual([]);
+    }
+  });
+
+  it("applies kind/danger defaults to a command and accepts required-only fields", () => {
+    const result = PluginManifestSchema.safeParse({
+      ...validBase,
+      contributes: {
+        commands: [{ name: "do-thing", title: "Do", description: "d", category: "c" }],
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.contributes.commands[0]).toMatchObject({
+        name: "do-thing",
+        kind: "command",
+        danger: "safe",
+      });
+    }
+  });
+
+  it("rejects a command name that violates the slug pattern", () => {
+    const result = PluginManifestSchema.safeParse({
+      ...validBase,
+      contributes: {
+        commands: [{ name: "Do_Thing", title: "Do", description: "d", category: "c" }],
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
   it("defaults contributes.forgeProviders to [] when contributes is an empty object", () => {
     const result = PluginManifestSchema.safeParse({ ...validBase, contributes: {} });
     expect(result.success).toBe(true);
@@ -722,7 +757,7 @@ describe("PluginService", () => {
 
     expect(registerToolbarButton).toHaveBeenCalledWith(
       expect.objectContaining({
-        id: "plugin.acme.toolbar-test.my-btn",
+        id: "acme.toolbar-test.my-btn",
         label: "My Button",
         iconId: "puzzle",
         actionId: "acme.toolbar-test.doThing",
@@ -753,7 +788,7 @@ describe("PluginService", () => {
 
     expect(registerToolbarButton).toHaveBeenCalledWith(
       expect.objectContaining({
-        id: "plugin.acme.default-priority.btn",
+        id: "acme.default-priority.btn",
         priority: 3,
       })
     );
@@ -1763,6 +1798,195 @@ describe("createHost — registerForgeProvider", () => {
     // path during unloadPlugin — independent from the bulk unregisterForgeProviderImpls
     // belt-and-suspenders call.
     expect(unregisterForgeProviderImpl).toHaveBeenCalledWith("acme.forge-flush", "github", impl);
+  });
+});
+
+describe("Manifest commands", () => {
+  it("registers a manifest command as a plugin action descriptor", async () => {
+    await writePlugin("cmd-desc", {
+      name: "acme.cmd-desc",
+      version: "1.0.0",
+      contributes: {
+        commands: [
+          {
+            name: "do-thing",
+            title: "Do Thing",
+            description: "Does a thing",
+            category: "Demo",
+            danger: "confirm",
+            keywords: ["demo"],
+          },
+        ],
+      },
+    });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const action = service.listPluginActions().find((a) => a.id === "acme.cmd-desc.do-thing");
+    expect(action).toMatchObject({
+      pluginId: "acme.cmd-desc",
+      id: "acme.cmd-desc.do-thing",
+      title: "Do Thing",
+      description: "Does a thing",
+      category: "Demo",
+      kind: "command",
+      danger: "confirm",
+      effectiveDanger: "confirm",
+    });
+    expect(action?.keywords).toEqual(["demo"]);
+  });
+
+  it("defaults command kind and danger when omitted", async () => {
+    await writePlugin("cmd-defaults", {
+      name: "acme.cmd-defaults",
+      version: "1.0.0",
+      contributes: {
+        commands: [{ name: "run", title: "Run", description: "Runs", category: "Demo" }],
+      },
+    });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const action = service.listPluginActions().find((a) => a.id === "acme.cmd-defaults.run");
+    expect(action).toMatchObject({ kind: "command", danger: "safe", effectiveDanger: "safe" });
+  });
+
+  it("lazily imports and dispatches a filesystem-convention handler", async () => {
+    await writePlugin("cmd-fs", {
+      name: "acme.cmd-fs",
+      version: "1.0.0",
+      contributes: {
+        commands: [{ name: "run", title: "Run", description: "Runs", category: "Demo" }],
+      },
+    });
+    const srcDir = path.join(tmpDir, "cmd-fs", "src");
+    await fs.mkdir(srcDir, { recursive: true });
+    await fs.writeFile(
+      path.join(srcDir, "run.mjs"),
+      "export default (ctx, args) => ({ ok: true, ctxPlugin: ctx.pluginId, args });\n"
+    );
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const ctx = makeCtx("acme.cmd-fs");
+    const result = await service.dispatchHandler("acme.cmd-fs", "acme.cmd-fs.run", ctx, [{ n: 1 }]);
+    expect(result).toEqual({ ok: true, ctxPlugin: "acme.cmd-fs", args: { n: 1 } });
+
+    // Second dispatch reuses the cached default export and still resolves.
+    const result2 = await service.dispatchHandler("acme.cmd-fs", "acme.cmd-fs.run", ctx, [
+      { n: 2 },
+    ]);
+    expect(result2).toMatchObject({ ok: true, args: { n: 2 } });
+  });
+
+  it("prefers the earlier extension when multiple handler files exist", async () => {
+    await writePlugin("cmd-precedence", {
+      name: "acme.cmd-precedence",
+      version: "1.0.0",
+      contributes: {
+        commands: [{ name: "run", title: "Run", description: "Runs", category: "Demo" }],
+      },
+    });
+    const srcDir = path.join(tmpDir, "cmd-precedence", "src");
+    await fs.mkdir(srcDir, { recursive: true });
+    // `.js` precedes `.mjs`; only the `.js` handler should be imported.
+    await fs.writeFile(path.join(srcDir, "run.js"), "export default () => 'from-js';\n");
+    await fs.writeFile(path.join(srcDir, "run.mjs"), "export default () => 'from-mjs';\n");
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const result = await service.dispatchHandler(
+      "acme.cmd-precedence",
+      "acme.cmd-precedence.run",
+      makeCtx("acme.cmd-precedence"),
+      []
+    );
+    expect(result).toBe("from-js");
+  });
+
+  it("throws 'no handler' on dispatch when a command has no handler file", async () => {
+    await writePlugin("cmd-nohandler", {
+      name: "acme.cmd-nohandler",
+      version: "1.0.0",
+      contributes: {
+        commands: [{ name: "ghost", title: "Ghost", description: "No file", category: "Demo" }],
+      },
+    });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    // The command is still registered (visible in the palette).
+    expect(service.listPluginActions().some((a) => a.id === "acme.cmd-nohandler.ghost")).toBe(true);
+
+    await expect(
+      service.dispatchHandler(
+        "acme.cmd-nohandler",
+        "acme.cmd-nohandler.ghost",
+        makeCtx("acme.cmd-nohandler"),
+        []
+      )
+    ).rejects.toThrow(/Command "acme\.cmd-nohandler\.ghost" has no handler/);
+  });
+
+  it("skips a command whose id collides with a built-in action", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    // "worktree.overview" + "open" resolves to the built-in "worktree.overview.open".
+    await writePlugin("cmd-collide", {
+      name: "worktree.overview",
+      version: "1.0.0",
+      contributes: {
+        commands: [{ name: "open", title: "Open", description: "Collides", category: "Demo" }],
+      },
+    });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    expect(service.listPluginActions().some((a) => a.id === "worktree.overview.open")).toBe(false);
+    await expect(
+      service.dispatchHandler(
+        "worktree.overview",
+        "worktree.overview.open",
+        makeCtx("worktree.overview"),
+        []
+      )
+    ).rejects.toThrow(/No plugin handler registered/);
+    errorSpy.mockRestore();
+  });
+
+  it("clears command handlers on unload", async () => {
+    await writePlugin("cmd-unload", {
+      name: "acme.cmd-unload",
+      version: "1.0.0",
+      contributes: {
+        commands: [{ name: "run", title: "Run", description: "Runs", category: "Demo" }],
+      },
+    });
+    const srcDir = path.join(tmpDir, "cmd-unload", "src");
+    await fs.mkdir(srcDir, { recursive: true });
+    await fs.writeFile(path.join(srcDir, "run.mjs"), "export default () => 'ok';\n");
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+    expect(
+      await service.dispatchHandler(
+        "acme.cmd-unload",
+        "acme.cmd-unload.run",
+        makeCtx("acme.cmd-unload"),
+        []
+      )
+    ).toBe("ok");
+
+    service.unloadPlugin("acme.cmd-unload");
+    await expect(
+      service.dispatchHandler(
+        "acme.cmd-unload",
+        "acme.cmd-unload.run",
+        makeCtx("acme.cmd-unload"),
+        []
+      )
+    ).rejects.toThrow(/No plugin handler registered/);
   });
 });
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -1955,6 +1955,97 @@ describe("Manifest commands", () => {
     errorSpy.mockRestore();
   });
 
+  it("keeps the first command intact when a later command has a duplicate name", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await writePlugin("cmd-dupe", {
+      name: "acme.cmd-dupe",
+      version: "1.0.0",
+      contributes: {
+        commands: [
+          { name: "run", title: "First", description: "First", category: "Demo" },
+          { name: "run", title: "Second", description: "Second", category: "Demo" },
+        ],
+      },
+    });
+    const srcDir = path.join(tmpDir, "cmd-dupe", "src");
+    await fs.mkdir(srcDir, { recursive: true });
+    await fs.writeFile(path.join(srcDir, "run.mjs"), "export default () => 'first';\n");
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const matches = service.listPluginActions().filter((a) => a.id === "acme.cmd-dupe.run");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.title).toBe("First");
+
+    // The surviving command's handler path is not corrupted by the rejected
+    // duplicate registration.
+    expect(
+      await service.dispatchHandler(
+        "acme.cmd-dupe",
+        "acme.cmd-dupe.run",
+        makeCtx("acme.cmd-dupe"),
+        []
+      )
+    ).toBe("first");
+    errorSpy.mockRestore();
+  });
+
+  it("throws when the handler module has no default export function", async () => {
+    await writePlugin("cmd-nodefault", {
+      name: "acme.cmd-nodefault",
+      version: "1.0.0",
+      contributes: {
+        commands: [{ name: "run", title: "Run", description: "Runs", category: "Demo" }],
+      },
+    });
+    const srcDir = path.join(tmpDir, "cmd-nodefault", "src");
+    await fs.mkdir(srcDir, { recursive: true });
+    await fs.writeFile(path.join(srcDir, "run.mjs"), "export const handler = () => 'nope';\n");
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    await expect(
+      service.dispatchHandler(
+        "acme.cmd-nodefault",
+        "acme.cmd-nodefault.run",
+        makeCtx("acme.cmd-nodefault"),
+        []
+      )
+    ).rejects.toThrow(/has no default export function/);
+  });
+
+  it("propagates a handler runtime error as a rejection", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await writePlugin("cmd-throws", {
+      name: "acme.cmd-throws",
+      version: "1.0.0",
+      contributes: {
+        commands: [{ name: "run", title: "Run", description: "Runs", category: "Demo" }],
+      },
+    });
+    const srcDir = path.join(tmpDir, "cmd-throws", "src");
+    await fs.mkdir(srcDir, { recursive: true });
+    await fs.writeFile(
+      path.join(srcDir, "run.mjs"),
+      "export default () => { throw new Error('handler boom'); };\n"
+    );
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    await expect(
+      service.dispatchHandler(
+        "acme.cmd-throws",
+        "acme.cmd-throws.run",
+        makeCtx("acme.cmd-throws"),
+        []
+      )
+    ).rejects.toThrow(/handler boom/);
+    errorSpy.mockRestore();
+  });
+
   it("clears command handlers on unload", async () => {
     await writePlugin("cmd-unload", {
       name: "acme.cmd-unload",

--- a/shared/config/__tests__/toolbarButtonRegistry.test.ts
+++ b/shared/config/__tests__/toolbarButtonRegistry.test.ts
@@ -25,15 +25,15 @@ const makeConfig = (id: string, overrides?: Partial<ToolbarButtonConfig>): Toolb
 
 describe("toolbarButtonRegistry", () => {
   it("registers a button and retrieves it by ID", () => {
-    const config = makeConfig("plugin.acme.test-plugin.viewer");
+    const config = makeConfig("acme.test-plugin.viewer");
     registerToolbarButton(config);
 
-    expect(getToolbarButtonConfig("plugin.acme.test-plugin.viewer")).toEqual(config);
-    expect(getPluginToolbarButtonIds()).toEqual(["plugin.acme.test-plugin.viewer"]);
+    expect(getToolbarButtonConfig("acme.test-plugin.viewer")).toEqual(config);
+    expect(getPluginToolbarButtonIds()).toEqual(["acme.test-plugin.viewer"]);
   });
 
   it("returns undefined for unregistered IDs", () => {
-    expect(getToolbarButtonConfig("plugin.unknown.button")).toBeUndefined();
+    expect(getToolbarButtonConfig("acme.unknown.button")).toBeUndefined();
   });
 
   it("returns empty array when no buttons registered", () => {
@@ -42,24 +42,24 @@ describe("toolbarButtonRegistry", () => {
 
   it("warns and overwrites on duplicate registration", () => {
     const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const first = makeConfig("plugin.acme.test-plugin.btn", { label: "First" });
-    const second = makeConfig("plugin.acme.test-plugin.btn", { label: "Second" });
+    const first = makeConfig("acme.test-plugin.btn", { label: "First" });
+    const second = makeConfig("acme.test-plugin.btn", { label: "Second" });
 
     registerToolbarButton(first);
     registerToolbarButton(second);
 
     expect(spy).toHaveBeenCalledWith(
-      'Toolbar button "plugin.acme.test-plugin.btn" already registered, overwriting'
+      'Toolbar button "acme.test-plugin.btn" already registered, overwriting'
     );
-    expect(getToolbarButtonConfig("plugin.acme.test-plugin.btn")?.label).toBe("Second");
+    expect(getToolbarButtonConfig("acme.test-plugin.btn")?.label).toBe("Second");
     expect(getPluginToolbarButtonIds()).toHaveLength(1);
 
     spy.mockRestore();
   });
 
   it("isRegisteredPluginButton returns true for registered plugin buttons", () => {
-    registerToolbarButton(makeConfig("plugin.acme.my-plugin.action"));
-    expect(isRegisteredPluginButton("plugin.acme.my-plugin.action")).toBe(true);
+    registerToolbarButton(makeConfig("acme.my-plugin.action"));
+    expect(isRegisteredPluginButton("acme.my-plugin.action")).toBe(true);
   });
 
   it("isRegisteredPluginButton returns false for built-in IDs", () => {
@@ -68,12 +68,12 @@ describe("toolbarButtonRegistry", () => {
   });
 
   it("isRegisteredPluginButton returns false for unregistered plugin IDs", () => {
-    expect(isRegisteredPluginButton("plugin.unknown.button")).toBe(false);
+    expect(isRegisteredPluginButton("acme.unknown.button")).toBe(false);
   });
 
   it("clearToolbarButtonRegistry removes all entries", () => {
-    registerToolbarButton(makeConfig("plugin.a.btn"));
-    registerToolbarButton(makeConfig("plugin.b.btn"));
+    registerToolbarButton(makeConfig("acme.a.btn"));
+    registerToolbarButton(makeConfig("acme.b.btn"));
     expect(getPluginToolbarButtonIds()).toHaveLength(2);
 
     clearToolbarButtonRegistry();
@@ -83,45 +83,45 @@ describe("toolbarButtonRegistry", () => {
 
 describe("unregisterPluginToolbarButtons", () => {
   it("removes only buttons owned by the target plugin", () => {
-    registerToolbarButton(makeConfig("plugin.owner-a.one", { pluginId: "owner-a" }));
-    registerToolbarButton(makeConfig("plugin.owner-a.two", { pluginId: "owner-a" }));
-    registerToolbarButton(makeConfig("plugin.owner-b.three", { pluginId: "owner-b" }));
+    registerToolbarButton(makeConfig("owner-a.one", { pluginId: "owner-a" }));
+    registerToolbarButton(makeConfig("owner-a.two", { pluginId: "owner-a" }));
+    registerToolbarButton(makeConfig("owner-b.three", { pluginId: "owner-b" }));
 
     unregisterPluginToolbarButtons("owner-a");
 
     const remaining = getPluginToolbarButtonIds();
-    expect(remaining).toEqual(["plugin.owner-b.three"]);
-    expect(getToolbarButtonConfig("plugin.owner-a.one")).toBeUndefined();
-    expect(getToolbarButtonConfig("plugin.owner-a.two")).toBeUndefined();
-    expect(getToolbarButtonConfig("plugin.owner-b.three")?.pluginId).toBe("owner-b");
+    expect(remaining).toEqual(["owner-b.three"]);
+    expect(getToolbarButtonConfig("owner-a.one")).toBeUndefined();
+    expect(getToolbarButtonConfig("owner-a.two")).toBeUndefined();
+    expect(getToolbarButtonConfig("owner-b.three")?.pluginId).toBe("owner-b");
   });
 
   it("is a no-op when unregistering an unknown pluginId", () => {
-    registerToolbarButton(makeConfig("plugin.owner-a.btn", { pluginId: "owner-a" }));
+    registerToolbarButton(makeConfig("owner-a.btn", { pluginId: "owner-a" }));
     expect(() => unregisterPluginToolbarButtons("never-loaded")).not.toThrow();
     expect(getPluginToolbarButtonIds()).toHaveLength(1);
   });
 
   it("is a no-op for empty or non-string pluginId (defensive input guard)", () => {
-    registerToolbarButton(makeConfig("plugin.owner-a.btn", { pluginId: "owner-a" }));
+    registerToolbarButton(makeConfig("owner-a.btn", { pluginId: "owner-a" }));
     expect(() => unregisterPluginToolbarButtons("")).not.toThrow();
     expect(() => unregisterPluginToolbarButtons(undefined as unknown as string)).not.toThrow();
     expect(getPluginToolbarButtonIds()).toHaveLength(1);
   });
 
   it("is a no-op when unregistering the same plugin twice", () => {
-    registerToolbarButton(makeConfig("plugin.owner-a.btn", { pluginId: "owner-a" }));
+    registerToolbarButton(makeConfig("owner-a.btn", { pluginId: "owner-a" }));
     unregisterPluginToolbarButtons("owner-a");
     expect(() => unregisterPluginToolbarButtons("owner-a")).not.toThrow();
     expect(getPluginToolbarButtonIds()).toHaveLength(0);
   });
 
   it("supports register → unregister → re-register round-trip", () => {
-    registerToolbarButton(makeConfig("plugin.owner-a.btn", { pluginId: "owner-a", label: "V1" }));
+    registerToolbarButton(makeConfig("owner-a.btn", { pluginId: "owner-a", label: "V1" }));
     unregisterPluginToolbarButtons("owner-a");
     expect(getPluginToolbarButtonIds()).toHaveLength(0);
 
-    registerToolbarButton(makeConfig("plugin.owner-a.btn", { pluginId: "owner-a", label: "V2" }));
-    expect(getToolbarButtonConfig("plugin.owner-a.btn")?.label).toBe("V2");
+    registerToolbarButton(makeConfig("owner-a.btn", { pluginId: "owner-a", label: "V2" }));
+    expect(getToolbarButtonConfig("owner-a.btn")?.label).toBe("V2");
   });
 });

--- a/shared/config/toolbarButtonRegistry.ts
+++ b/shared/config/toolbarButtonRegistry.ts
@@ -31,7 +31,10 @@ export function getAllPluginToolbarButtonConfigs(): ToolbarButtonConfig[] {
 }
 
 export function isRegisteredPluginButton(id: string): boolean {
-  return id.startsWith("plugin.") && id in TOOLBAR_BUTTON_REGISTRY;
+  // Every entry in the registry is a plugin-contributed button by definition,
+  // so registry membership is the sole discriminator now that button ids no
+  // longer carry a `plugin.` prefix.
+  return id in TOOLBAR_BUTTON_REGISTRY;
 }
 
 export function unregisterPluginToolbarButtons(pluginId: string): void {

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -28,6 +28,35 @@ export interface ToolbarButtonContribution {
   priority?: 1 | 2 | 3 | 4 | 5;
 }
 
+/**
+ * A `contributes.commands` entry. Each command is registered at load time as a
+ * synthetic plugin action with id `{pluginId}.{name}` (see {@link pluginActionId}).
+ * `name` doubles as the filesystem-convention handler stem: the host probes
+ * `src/{name}.{ts,tsx,js,mjs}` and lazily imports the module's default export on
+ * first dispatch. A command with no matching handler file (and no imperative
+ * registration) still appears in the palette but surfaces a "no handler" error
+ * when dispatched.
+ */
+export interface CommandContribution {
+  name: string;
+  title: string;
+  description: string;
+  category: string;
+  kind: "command" | "query";
+  danger: "safe" | "confirm";
+  keywords?: string[];
+}
+
+/**
+ * Canonical namespacing for plugin-contributed identifiers. Both action ids and
+ * toolbar button ids resolve to `{pluginId}.{name}` — keeping the construction
+ * in one helper prevents the prefix drift that previously left toolbar buttons
+ * on a divergent `plugin.{pluginId}.{id}` form.
+ */
+export function pluginActionId(pluginId: string, name: string): string {
+  return `${pluginId}.${name}`;
+}
+
 export type MenuItemLocation = "terminal" | "file" | "view" | "help";
 
 export const BUILT_IN_PLUGIN_PERMISSIONS = [
@@ -98,6 +127,7 @@ export interface PluginManifest {
   permissions?: PluginPermission[];
   contributes: {
     panels: PanelContribution[];
+    commands: CommandContribution[];
     toolbarButtons: ToolbarButtonContribution[];
     menuItems: MenuItemContribution[];
     views: ViewContribution[];

--- a/shared/types/toolbar.ts
+++ b/shared/types/toolbar.ts
@@ -1,7 +1,7 @@
 import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "../config/agentIds.js";
 
-/** Identifier for plugin-contributed toolbar buttons (namespaced as plugin.name.buttonId) */
-export type PluginToolbarButtonId = `plugin.${string}`;
+/** Identifier for plugin-contributed toolbar buttons (namespaced as `{pluginId}.{buttonId}`) */
+export type PluginToolbarButtonId = `${string}.${string}`;
 
 /** Identifier for any toolbar button (built-in or plugin-contributed) */
 export type AnyToolbarButtonId = ToolbarButtonId | PluginToolbarButtonId;

--- a/src/hooks/usePluginToolbarButtons.ts
+++ b/src/hooks/usePluginToolbarButtons.ts
@@ -17,7 +17,7 @@ export interface PluginToolbarButtonState {
  * once a push arrives, a later-resolving mount-time pull is dropped to avoid
  * rolling back state (mirrors `usePluginPanelKinds`).
  *
- * Stale `plugin.` entries in the `toolbarPreferencesStore` `pinnedButtons`
+ * Stale plugin-button entries in the `toolbarPreferencesStore` `pinnedButtons`
  * map (renderer-local persisted state, no main-process access) are pruned
  * here off the lifecycle snapshot — but ONLY off an authoritative one. The
  * pull and load-time pushes are partial/growing (plugins load concurrently
@@ -74,7 +74,7 @@ export function usePluginToolbarButtons(): PluginToolbarButtonState {
   }, []);
 
   const buttonIds = Array.from(configs.keys()) as PluginToolbarButtonId[];
-  const isRegistered = (id: string) => id.startsWith("plugin.") && configs.has(id);
+  const isRegistered = (id: string) => configs.has(id);
 
   return { buttonIds, configs, isRegistered };
 }

--- a/src/hooks/usePluginToolbarButtons.ts
+++ b/src/hooks/usePluginToolbarButtons.ts
@@ -73,6 +73,7 @@ export function usePluginToolbarButtons(): PluginToolbarButtonState {
     };
   }, []);
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- configs keys are always namespaced plugin button IDs from sync()
   const buttonIds = Array.from(configs.keys()) as PluginToolbarButtonId[];
   const isRegistered = (id: string) => configs.has(id);
 

--- a/src/store/__tests__/toolbarPreferencesStore.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.test.ts
@@ -281,6 +281,32 @@ describe("toolbarPreferencesStore", () => {
       });
     });
 
+    it("v9 strips stale plugin.-prefixed pinned keys while preserving new-format ones", async () => {
+      setStoredState(
+        {
+          layout: {
+            leftButtons: ["terminal", "browser"],
+            rightButtons: ["copy-tree", "settings"],
+            pinnedButtons: {
+              "plugin.acme.old-btn": false,
+              "acme.linear.viewer": false,
+              "copy-tree": false,
+            },
+          },
+          launcher: { alwaysShowDevServer: false },
+        },
+        8
+      );
+
+      const store = await loadStore();
+      const { pinnedButtons } = store.getState().layout;
+      // Old `plugin.`-prefixed key is dropped by the v9 migration.
+      expect(pinnedButtons["plugin.acme.old-btn" as keyof typeof pinnedButtons]).toBeUndefined();
+      // New `{pluginId}.{id}` plugin key and built-in keys survive untouched.
+      expect(pinnedButtons["acme.linear.viewer" as keyof typeof pinnedButtons]).toBe(false);
+      expect(pinnedButtons["copy-tree"]).toBe(false);
+    });
+
     it("merges new default buttons without re-inserting hidden ones", async () => {
       setStoredState(
         {

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -85,13 +85,15 @@ interface ToolbarPreferencesState extends ToolbarPreferences {
   ) => void;
   toggleButtonVisibility: (buttonId: AnyToolbarButtonId, side: "left" | "right") => void;
   /**
-   * Prune `pinnedButtons` entries for plugin buttons (`plugin.` prefix) that
-   * are no longer in the loaded plugin set. `pinnedButtons` is renderer-local
-   * persisted state with no main-process access, so an uninstalled plugin's
-   * stale hide entry can only be swept here, driven by the plugin lifecycle
-   * snapshot in `usePluginToolbarButtons`. Built-in (non-`plugin.`) keys are
-   * never touched. No-ops (returns state unchanged) when nothing is stale so
-   * the per-snapshot call doesn't churn the persist layer.
+   * Prune `pinnedButtons` entries for plugin buttons that are no longer in the
+   * loaded plugin set. Plugin button ids are namespaced `{pluginId}.{id}` and
+   * therefore always contain a dot; built-in toolbar button ids never do, so a
+   * dot is the discriminator. `pinnedButtons` is renderer-local persisted state
+   * with no main-process access, so an uninstalled plugin's stale hide entry
+   * can only be swept here, driven by the plugin lifecycle snapshot in
+   * `usePluginToolbarButtons`. Built-in (dot-free) keys are never touched.
+   * No-ops (returns state unchanged) when nothing is stale so the per-snapshot
+   * call doesn't churn the persist layer.
    */
   sweepStalePluginPinnedButtons: (validIds: string[]) => void;
   setAlwaysShowDevServer: (value: boolean) => void;
@@ -155,7 +157,7 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
         set((state) => {
           const validSet = new Set(validIds);
           const staleKeys = Object.keys(state.layout.pinnedButtons).filter(
-            (key) => key.startsWith("plugin.") && !validSet.has(key)
+            (key) => key.includes(".") && !validSet.has(key)
           );
           if (staleKeys.length === 0) return state;
           const pinned: ToolbarPinnedState = { ...state.layout.pinnedButtons };
@@ -182,7 +184,7 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
     }),
     {
       name: "daintree-toolbar-preferences",
-      version: 8,
+      version: 9,
       storage: createSafeJSONStorage(),
       migrate: (persisted, version) => {
         const state = persisted as Record<string, unknown>;
@@ -293,6 +295,18 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
             // valid v8 shape so `merge()` doesn't fall back to overwriting the
             // freshly-built `pinnedButtons` with the default empty map.
             state.layout = { pinnedButtons: {} } as unknown as Record<string, unknown>;
+          }
+        }
+        if (version < 9) {
+          // Plugin toolbar button ids dropped the redundant `plugin.` prefix,
+          // standardizing on `{pluginId}.{id}` (#9281). Strip stale
+          // `plugin.`-prefixed `pinnedButtons` keys so they don't linger as
+          // orphaned hide entries that never match a registered button.
+          const layout = state.layout as { pinnedButtons?: Record<string, unknown> } | undefined;
+          if (layout?.pinnedButtons) {
+            for (const key of Object.keys(layout.pinnedButtons)) {
+              if (key.startsWith("plugin.")) delete layout.pinnedButtons[key];
+            }
           }
         }
         return state as unknown as ToolbarPreferencesState;


### PR DESCRIPTION
Closes #9281.

Implements two coordinated pieces of plugin infrastructure.

## 1. Manifest command binder (lazy handlers)

Adds `contributes.commands` to the plugin manifest schema (`CommandContribution`: `name`/`title`/`description`/`category` required; `kind` defaults to `"command"`, `danger` to `"safe"`). At load, each command:

- registers a synthetic `{pluginId}.{name}` action through the existing `registerPluginAction` path, and
- probes `src/{name}.{ts,tsx,js,mjs}` (first match wins) for a handler file.

The handler module is imported **lazily — only on first dispatch** — and its default export is memoized, keeping plugin activation within the 5s budget. Commands with no handler file still appear in the palette but throw `Command "{id}" has no handler` when dispatched (never at load). A command id that collides with a built-in action id is rejected at load and skipped.

## 2. Namespace standardization

Toolbar buttons were registered under a divergent `plugin.{pluginId}.{id}` prefix while everything else used the canonical `{pluginId}.{actionId}`. Reconciled in one atomic change:

- new `pluginActionId(pluginId, name)` helper in `shared/types/plugin.ts` (single source of truth for the namespace);
- `PluginToolbarButtonId` relaxed from `` `plugin.${string}` `` to `` `${string}.${string}` ``;
- registry guard (`isRegisteredPluginButton`) and renderer prefix check (`usePluginToolbarButtons`) simplified to registry/membership lookups;
- persisted `pinnedButtons` sweep switched to a dot discriminator (built-in toolbar/agent ids are all dot-free);
- v9 toolbar-prefs migration strips stale `plugin.*` pinned keys.

## Notes

- Dependency issues #9277 (imperative `host.registerAction`), #9271 (provenance `loadError`), #9272 (namespace reservation) are still open; this PR reuses existing infrastructure (`registerPluginAction`, `BUILT_IN_ACTION_IDS`, `console.error` for collisions) and does not block on them.
- The imperative `host.registerAction` escape hatch documented in `contribution-points.md` is #9277 scope; the filesystem-convention binder shipped here is the primary path.

## Tests

- **Manifest commands**: descriptor registration, kind/danger defaults, lazy fs dispatch + caching, extension precedence, no-handler / no-default-export / handler-throws errors, built-in collision skip, duplicate-name survival, unload cleanup.
- **Schema**: `commands` default `[]`, kind/danger defaults, name-pattern rejection.
- **Store**: v9 migration preserves new-format pins while stripping `plugin.*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)