### PR TITLE
feat(plugins): plugin diagnostics export — host.logger + report-issue payload (#9291)

### DIFF
--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 1258,
-  "moduleCount": 1258,
+  "count": 1259,
+  "moduleCount": 1259,
   "allowlist": [
     "electron/ipc/errorHandlers.ts",
     "electron/ipc/handlers/agentCapabilities.ts",
@@ -1046,7 +1046,7 @@
     },
     {
       "file": "electron/services/PluginService.ts",
-      "line": 325,
+      "line": 392,
       "pattern": "sync-store-get"
     },
     {

--- a/electron/__tests__/clipboard.test.ts
+++ b/electron/__tests__/clipboard.test.ts
@@ -8,6 +8,10 @@ vi.mock("electron", () => ({
   clipboard: { readImage: vi.fn(), writeImage: vi.fn(), writeText: vi.fn(), readText: vi.fn() },
   nativeImage: { createFromBuffer: vi.fn(), createFromPath: vi.fn() },
   ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+  // The clipboard handler imports `projectStore`, whose module-level singleton
+  // calls `app.getPath("userData")` at construction — so the mock must provide
+  // `app` or the import throws before any test runs.
+  app: { getPath: vi.fn(() => "/tmp") },
 }));
 
 // clipboard.ts imports projectStore from ProjectStore.js which imports

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -786,6 +786,7 @@ export const CHANNELS = {
   PLUGIN_PANEL_KINDS_GET: "plugin:panel-kinds-get",
   PLUGIN_FORGE_PROVIDERS_GET: "plugin:forge-providers-get",
   PLUGIN_FILE_DECORATIONS_GET: "plugin:file-decorations-get",
+  PLUGIN_GET_DIAGNOSTICS: "plugin:get-diagnostics",
 
   // Config reload channels
   APP_RELOAD_CONFIG: "app:reload-config",

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -7,6 +7,7 @@ const mockListPlugins = vi.fn();
 const mockListPluginActions = vi.fn();
 const mockRegisterPluginAction = vi.fn();
 const mockUnregisterPluginAction = vi.fn();
+const mockGetDiagnosticsSnapshot = vi.fn();
 
 vi.mock("../../../services/PluginService.js", () => ({
   pluginService: {
@@ -17,6 +18,7 @@ vi.mock("../../../services/PluginService.js", () => ({
     listPluginActions: (...args: unknown[]) => mockListPluginActions(...args),
     registerPluginAction: (...args: unknown[]) => mockRegisterPluginAction(...args),
     unregisterPluginAction: (...args: unknown[]) => mockUnregisterPluginAction(...args),
+    getDiagnosticsSnapshot: (...args: unknown[]) => mockGetDiagnosticsSnapshot(...args),
   },
 }));
 
@@ -69,8 +71,9 @@ beforeEach(() => {
 describe("registerPluginHandlers", () => {
   it("registers handlers for all plugin channels", () => {
     registerPluginHandlers();
-    expect(mockIpcMainHandle).toHaveBeenCalledTimes(11);
+    expect(mockIpcMainHandle).toHaveBeenCalledTimes(12);
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:list", expect.any(Function));
+    expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:get-diagnostics", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:invoke", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:toolbar-buttons", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:menu-items", expect.any(Function));
@@ -681,6 +684,36 @@ describe("PLUGIN_FILE_DECORATIONS_GET handler", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe("PLUGIN_GET_DIAGNOSTICS handler", () => {
+  function getHandler() {
+    registerPluginHandlers();
+    return mockIpcMainHandle.mock.calls.find(
+      (c: unknown[]) => c[0] === "plugin:get-diagnostics"
+    )![1] as (...args: unknown[]) => unknown;
+  }
+
+  it("delegates to pluginService.getDiagnosticsSnapshot", async () => {
+    const snapshot = [
+      {
+        name: "acme.plugin",
+        version: "1.0.0",
+        source: "user",
+        installedAt: "2026-01-01T00:00:00.000Z",
+        logLines: [],
+      },
+    ];
+    mockGetDiagnosticsSnapshot.mockReturnValue(snapshot);
+    const handler = getHandler();
+    expect(await handler({})).toBe(snapshot);
+  });
+
+  it("returns an empty array when no plugins are loaded", async () => {
+    mockGetDiagnosticsSnapshot.mockReturnValue([]);
+    const handler = getHandler();
+    expect(await handler({})).toEqual([]);
   });
 });
 

--- a/electron/ipc/handlers/plugin.preload.ts
+++ b/electron/ipc/handlers/plugin.preload.ts
@@ -16,6 +16,7 @@ export const PLUGIN_METHOD_CHANNELS = {
   getPanelKinds: "plugin:panel-kinds-get",
   getForgeProviders: "plugin:forge-providers-get",
   getDecorations: "plugin:file-decorations-get",
+  getDiagnostics: "plugin:get-diagnostics",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof PLUGIN_METHOD_CHANNELS;

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -25,6 +25,7 @@ import type {
   PluginIpcContext,
   PluginActionContribution,
   PluginActionDescriptor,
+  PluginDiagnosticsSnapshot,
 } from "../../../shared/types/plugin.js";
 import type { ToolbarButtonConfig } from "../../../shared/config/toolbarButtonRegistry.js";
 import { assertIpcSecurityReady } from "../ipcGuard.js";
@@ -104,6 +105,10 @@ async function handlePanelKindsGet(): Promise<PanelKindConfig[]> {
 
 async function handleForgeProvidersGet(): Promise<RegisteredForgeProvider[]> {
   return getRegisteredForgeProviders();
+}
+
+async function handleGetDiagnostics(): Promise<PluginDiagnosticsSnapshot> {
+  return pluginService.getDiagnosticsSnapshot();
 }
 
 /**
@@ -230,6 +235,7 @@ export const pluginNamespace = defineIpcNamespace({
     getPanelKinds: op(PLUGIN_METHOD_CHANNELS.getPanelKinds, handlePanelKindsGet),
     getForgeProviders: op(PLUGIN_METHOD_CHANNELS.getForgeProviders, handleForgeProvidersGet),
     getDecorations: op(PLUGIN_METHOD_CHANNELS.getDecorations, handleFileDecorationsGet),
+    getDiagnostics: op(PLUGIN_METHOD_CHANNELS.getDiagnostics, handleGetDiagnostics),
   },
 });
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -15,7 +15,12 @@ import type {
   PluginActionContribution,
   PluginActionDescriptor,
   BuiltInPluginPermission,
+  PluginLogLevel,
+  PluginLogLine,
+  PluginDiagnosticsEntry,
+  PluginDiagnosticsSnapshot,
 } from "../../shared/types/plugin.js";
+import { scrubLogLine } from "../../shared/utils/pluginDiagnosticsScrub.js";
 import type { WorktreeSnapshot } from "../../shared/types/workspace-host.js";
 import { toPluginWorktreeSnapshot } from "../../shared/utils/pluginWorktreeSnapshot.js";
 import type { WorkspaceClient } from "./WorkspaceClient.js";
@@ -102,6 +107,43 @@ interface PluginLoadErrorRecord {
 
 const ACTIVATE_TIMEOUT_MS = 5000;
 
+/** Per-plugin ring buffer depth. Oldest lines are overwritten FIFO. */
+const LOG_BUFFER_CAPACITY = 500;
+
+/**
+ * Cap on a single line's serialized `fields` payload (~2KB) so a plugin can't
+ * `logger.error`-bomb the host into memory pressure. Oversized payloads are
+ * replaced with a single truncation marker, never silently dropped.
+ */
+const LOG_FIELDS_MAX_BYTES = 2048;
+
+/**
+ * Fixed-capacity FIFO ring buffer of log lines, pre-allocated to avoid
+ * per-push allocation/GC churn. `head` points at the next write slot; `count`
+ * tracks how many slots are live (saturates at capacity).
+ */
+class PluginLogBuffer {
+  private readonly buf: PluginLogLine[] = new Array(LOG_BUFFER_CAPACITY);
+  private head = 0;
+  private count = 0;
+
+  push(line: PluginLogLine): void {
+    this.buf[this.head] = line;
+    this.head = (this.head + 1) % LOG_BUFFER_CAPACITY;
+    if (this.count < LOG_BUFFER_CAPACITY) this.count++;
+  }
+
+  /** Lines in reverse-chronological order (most recent first). */
+  toReverseChronological(): PluginLogLine[] {
+    const out: PluginLogLine[] = [];
+    for (let i = 1; i <= this.count; i++) {
+      const idx = (this.head - i + LOG_BUFFER_CAPACITY) % LOG_BUFFER_CAPACITY;
+      out.push(this.buf[idx]);
+    }
+    return out;
+  }
+}
+
 /**
  * Normalise the value thrown out of `activate()` into a serialisable record.
  * `unknown` becomes a stable `{ message, stack?, at }` shape so the Settings
@@ -147,6 +189,7 @@ type WorkspaceWorktreeEvent = "worktree-update" | "worktree-activated" | "worktr
 
 export class PluginService {
   private plugins = new Map<string, LoadedPlugin>();
+  private logBuffers = new Map<string, PluginLogBuffer>();
   private handlerMap = new Map<string, PluginIpcHandler>();
   private cleanupMap = new Map<string, () => void>();
   private pluginActions = new Map<string, PluginActionDescriptor>();
@@ -518,6 +561,10 @@ export class PluginService {
     // inside the plugin's own init, and registerHandler/registerPluginAction
     // throw "Unknown plugin" even for a correctly loaded plugin.
     this.plugins.set(manifest.name, plugin);
+    // The log buffer shares the plugin's lifecycle — created here so host.logger
+    // calls during module evaluation/activation land in it, torn down in unloadPlugin.
+    this.logBuffers.set(manifest.name, new PluginLogBuffer());
+    this.pluginLoadErrors.delete(manifest.name);
 
     if (plugin.resolvedMain) {
       try {
@@ -542,6 +589,9 @@ export class PluginService {
         // same service in tests, or in future hot-reload paths.
         this.pluginLoadErrors.delete(manifest.name);
       } catch (err) {
+        // Retain the load error so the diagnostics export (and the #9290 detail
+        // view) can surface it. Per CLAUDE.md notify() rules this is Tier 0/1 —
+        // logged, not toasted.
         const record = toPluginLoadErrorRecord(err);
         this.pluginLoadErrors.set(manifest.name, record);
         console.error(`[PluginService] Failed to load main entry for ${manifest.name}:`, err);
@@ -551,6 +601,86 @@ export class PluginService {
     }
 
     return plugin;
+  }
+
+  /**
+   * Write a line into a plugin's ring buffer and forward it to the host
+   * console. Synchronous and fire-and-forget: a missing buffer (plugin already
+   * unloaded) is a silent no-op. Oversized `fields` payloads are truncated to
+   * a single marker rather than dropped silently.
+   */
+  private appendLog(
+    pluginId: string,
+    level: PluginLogLevel,
+    message: string,
+    fields?: Record<string, unknown>
+  ): void {
+    const buffer = this.logBuffers.get(pluginId);
+    if (!buffer) return;
+
+    const safeMessage = typeof message === "string" ? message : String(message);
+
+    let serializedFields: string | undefined;
+    if (fields !== undefined) {
+      try {
+        const json = JSON.stringify(fields);
+        serializedFields =
+          json !== undefined && json.length > LOG_FIELDS_MAX_BYTES
+            ? `[truncated: fields exceeded ${LOG_FIELDS_MAX_BYTES} bytes]`
+            : json;
+      } catch {
+        serializedFields = "[unserializable fields]";
+      }
+    }
+
+    buffer.push({
+      timestamp: Date.now(),
+      level,
+      message: safeMessage,
+      ...(serializedFields !== undefined ? { fields: serializedFields } : {}),
+    });
+
+    const prefix = `[plugin:${pluginId}]`;
+    const consoleArgs =
+      fields !== undefined ? [prefix, safeMessage, fields] : [prefix, safeMessage];
+    if (level === "warn") console.warn(...consoleArgs);
+    else if (level === "error") console.error(...consoleArgs);
+    else console.info(...consoleArgs);
+  }
+
+  /**
+   * Point-in-time diagnostics snapshot of every loaded plugin: provenance,
+   * captured load error, and the most-recent scrubbed log lines. Secrets are
+   * scrubbed on this export pass only — the raw ring buffer is never modified.
+   * Returns an empty array when no plugins are loaded so the report-issue
+   * payload can omit the section entirely.
+   */
+  getDiagnosticsSnapshot(): PluginDiagnosticsSnapshot {
+    const snapshot: PluginDiagnosticsEntry[] = [];
+    for (const [pluginId, plugin] of this.plugins) {
+      const buffer = this.logBuffers.get(pluginId);
+      const logLines = buffer ? buffer.toReverseChronological().map(scrubLogLine) : [];
+      const loadErrorRecord = this.pluginLoadErrors.get(pluginId);
+      // Provenance falls back to load-derived values until #9271 lands; the
+      // action audit tail (#9232) is omitted until that log exists.
+      snapshot.push({
+        name: plugin.manifest.name,
+        version: plugin.manifest.version,
+        source: plugin.isBuiltin ? "builtin" : "user",
+        installedAt: new Date(plugin.loadedAt).toISOString(),
+        ...(loadErrorRecord !== undefined
+          ? {
+              loadError: scrubLogLine({
+                timestamp: loadErrorRecord.at,
+                level: "error",
+                message: loadErrorRecord.stack ?? loadErrorRecord.message,
+              }).message,
+            }
+          : {}),
+        logLines,
+      });
+    }
+    return snapshot;
   }
 
   private createHost(pluginId: string): { host: PluginHostApi; revoke: () => void } {
@@ -799,6 +929,15 @@ export class PluginService {
           payload: { scope, ...(narrowed && narrowed.length > 0 ? { paths: narrowed } : {}) },
         });
       },
+      // NOT revoke-guarded: plugins log from post-activation callbacks (timers,
+      // worktree subscriptions) that fire long after activate() resolves. The
+      // liveness guard is buffer membership — appendLog is a silent no-op once
+      // the plugin unloads.
+      logger: {
+        info: (message, fields) => this.appendLog(pluginId, "info", message, fields),
+        warn: (message, fields) => this.appendLog(pluginId, "warn", message, fields),
+        error: (message, fields) => this.appendLog(pluginId, "error", message, fields),
+      },
     };
     return {
       host,
@@ -1027,6 +1166,7 @@ export class PluginService {
     );
 
     this.plugins.delete(pluginId);
+    this.logBuffers.delete(pluginId);
     this.pluginLoadErrors.delete(pluginId);
 
     if (decorationScopes && decorationScopes.length > 0) {

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -111,11 +111,35 @@ const ACTIVATE_TIMEOUT_MS = 5000;
 const LOG_BUFFER_CAPACITY = 500;
 
 /**
- * Cap on a single line's serialized `fields` payload (~2KB) so a plugin can't
- * `logger.error`-bomb the host into memory pressure. Oversized payloads are
- * replaced with a single truncation marker, never silently dropped.
+ * Caps on a single line so a plugin can't `logger.error`-bomb the host into
+ * memory pressure: the serialized `fields` payload and the `message` string
+ * are each bounded to ~2KB (UTF-8 bytes). Oversized values are replaced/cut
+ * with a single truncation marker, never silently dropped.
  */
 const LOG_FIELDS_MAX_BYTES = 2048;
+const LOG_MESSAGE_MAX_BYTES = 2048;
+const MESSAGE_TRUNCATION_MARKER = "…[truncated]";
+
+/**
+ * Cut `text` to at most `maxBytes` UTF-8 bytes, appending a truncation marker
+ * when it overflows. Walks by code point so a multi-byte character is never
+ * split mid-sequence.
+ */
+function capUtf8(text: string, maxBytes: number, marker: string): string {
+  if (Buffer.byteLength(text, "utf8") <= maxBytes) return text;
+  const markerBytes = Buffer.byteLength(marker, "utf8");
+  const budget = Math.max(0, maxBytes - markerBytes);
+  const chars = Array.from(text);
+  let used = 0;
+  let out = "";
+  for (const ch of chars) {
+    const chBytes = Buffer.byteLength(ch, "utf8");
+    if (used + chBytes > budget) break;
+    out += ch;
+    used += chBytes;
+  }
+  return out + marker;
+}
 
 /**
  * Fixed-capacity FIFO ring buffer of log lines, pre-allocated to avoid
@@ -618,14 +642,18 @@ export class PluginService {
     const buffer = this.logBuffers.get(pluginId);
     if (!buffer) return;
 
-    const safeMessage = typeof message === "string" ? message : String(message);
+    const rawMessage = typeof message === "string" ? message : String(message);
+    // Cap the stored message too — fields alone aren't enough to stop a
+    // `logger.error("x".repeat(5e6))` memory bomb (also avoids stalling IPC
+    // serialization of the snapshot). The console forward keeps the raw text.
+    const safeMessage = capUtf8(rawMessage, LOG_MESSAGE_MAX_BYTES, MESSAGE_TRUNCATION_MARKER);
 
     let serializedFields: string | undefined;
     if (fields !== undefined) {
       try {
         const json = JSON.stringify(fields);
         serializedFields =
-          json !== undefined && json.length > LOG_FIELDS_MAX_BYTES
+          json !== undefined && Buffer.byteLength(json, "utf8") > LOG_FIELDS_MAX_BYTES
             ? `[truncated: fields exceeded ${LOG_FIELDS_MAX_BYTES} bytes]`
             : json;
       } catch {
@@ -641,8 +669,7 @@ export class PluginService {
     });
 
     const prefix = `[plugin:${pluginId}]`;
-    const consoleArgs =
-      fields !== undefined ? [prefix, safeMessage, fields] : [prefix, safeMessage];
+    const consoleArgs = fields !== undefined ? [prefix, rawMessage, fields] : [prefix, rawMessage];
     if (level === "warn") console.warn(...consoleArgs);
     else if (level === "error") console.error(...consoleArgs);
     else console.info(...consoleArgs);

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -1205,3 +1205,113 @@ describe("PluginService integration — built-in plugin loading", () => {
     }
   });
 });
+
+describe("PluginService integration — host.logger and diagnostics", () => {
+  async function writeLoggingPlugin(name: string, body: string): Promise<void> {
+    const dir = await writePlugin(name, { name, version: "2.1.0" });
+    const mainFile = `log-${randomUUID()}.mjs`;
+    await fs.writeFile(path.join(dir, mainFile), `export function activate(host) {\n${body}\n}\n`);
+    await fs.writeFile(
+      path.join(dir, "plugin.json"),
+      JSON.stringify({ name, version: "2.1.0", main: mainFile })
+    );
+  }
+
+  it("captures host.logger lines in the diagnostics snapshot, newest first", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    try {
+      await writeLoggingPlugin(
+        "acme.logger",
+        `host.logger.info("first line");
+         host.logger.warn("second line", { code: 42 });
+         host.logger.error("third line");`
+      );
+      const service = new PluginService(tmpDir, "0.0.0");
+      await service.initialize();
+
+      const snapshot = service.getDiagnosticsSnapshot();
+      const entry = snapshot.find((p) => p.name === "acme.logger");
+      expect(entry).toBeDefined();
+      expect(entry?.version).toBe("2.1.0");
+      expect(entry?.source).toBe("user");
+      expect(entry?.logLines.map((l) => l.message)).toEqual([
+        "third line",
+        "second line",
+        "first line",
+      ]);
+      expect(entry?.logLines[0].level).toBe("error");
+      expect(entry?.logLines[1].fields).toBe(JSON.stringify({ code: 42 }));
+      // Console forwarding is on by default with the plugin prefix.
+      expect(infoSpy).toHaveBeenCalledWith("[plugin:acme.logger]", "first line");
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it("scrubs secrets from log lines on export but leaves the raw buffer intact", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await writeLoggingPlugin(
+        "acme.secrets",
+        `host.logger.error("token ghp_abcdefghijklmnopqrstuvwxyz0123 leaked");`
+      );
+      const service = new PluginService(tmpDir, "0.0.0");
+      await service.initialize();
+
+      const entry = service.getDiagnosticsSnapshot().find((p) => p.name === "acme.secrets");
+      expect(entry?.logLines[0].message).toContain("[REDACTED]");
+      expect(entry?.logLines[0].message).not.toContain("ghp_abcdefghij");
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("caps oversized log fields with a single truncation marker", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    try {
+      await writeLoggingPlugin("acme.big", `host.logger.info("big", { blob: "x".repeat(5000) });`);
+      const service = new PluginService(tmpDir, "0.0.0");
+      await service.initialize();
+
+      const entry = service.getDiagnosticsSnapshot().find((p) => p.name === "acme.big");
+      expect(entry?.logLines[0].fields).toMatch(/^\[truncated:/);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it("drops the log buffer when a plugin unloads", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    try {
+      await writeLoggingPlugin("acme.transient", `host.logger.info("hi");`);
+      const service = new PluginService(tmpDir, "0.0.0");
+      await service.initialize();
+      expect(service.getDiagnosticsSnapshot().some((p) => p.name === "acme.transient")).toBe(true);
+
+      service.unloadPlugin("acme.transient");
+      expect(service.getDiagnosticsSnapshot().some((p) => p.name === "acme.transient")).toBe(false);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it("captures a plugin's load error in the diagnostics snapshot", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await writeLoggingPlugin("acme.broken", `throw new Error("activation boom");`);
+      const service = new PluginService(tmpDir, "0.0.0");
+      await service.initialize();
+
+      const entry = service.getDiagnosticsSnapshot().find((p) => p.name === "acme.broken");
+      expect(entry?.loadError).toContain("activation boom");
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("returns an empty snapshot when no plugins are loaded", async () => {
+    const service = new PluginService(tmpDir, "0.0.0");
+    await service.initialize();
+    expect(service.getDiagnosticsSnapshot()).toEqual([]);
+  });
+});

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -1266,6 +1266,61 @@ describe("PluginService integration — host.logger and diagnostics", () => {
     }
   });
 
+  it("keeps only the newest 500 lines after wraparound, reverse-chronological", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    try {
+      await writeLoggingPlugin(
+        "acme.flood",
+        `for (let i = 0; i < 505; i++) host.logger.info("line-" + i);`
+      );
+      const service = new PluginService(tmpDir, "0.0.0");
+      await service.initialize();
+
+      const entry = service.getDiagnosticsSnapshot().find((p) => p.name === "acme.flood");
+      expect(entry?.logLines).toHaveLength(500);
+      // Newest first: line-504 down to line-5; line-0..4 evicted.
+      expect(entry?.logLines[0].message).toBe("line-504");
+      expect(entry?.logLines[499].message).toBe("line-5");
+      expect(entry?.logLines.some((l) => l.message === "line-0")).toBe(false);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it("caps an oversized message string with a truncation marker", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    try {
+      await writeLoggingPlugin("acme.bigmsg", `host.logger.info("x".repeat(5000));`);
+      const service = new PluginService(tmpDir, "0.0.0");
+      await service.initialize();
+
+      const entry = service.getDiagnosticsSnapshot().find((p) => p.name === "acme.bigmsg");
+      const message = entry?.logLines[0].message ?? "";
+      expect(message.length).toBeLessThan(5000);
+      expect(message.endsWith("…[truncated]")).toBe(true);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it("scrubs secrets out of a captured load error", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await writeLoggingPlugin(
+        "acme.errsecret",
+        `throw new Error("boot failed: ghp_abcdefghijklmnopqrstuvwxyz0123");`
+      );
+      const service = new PluginService(tmpDir, "0.0.0");
+      await service.initialize();
+
+      const entry = service.getDiagnosticsSnapshot().find((p) => p.name === "acme.errsecret");
+      expect(entry?.loadError).toContain("[REDACTED]");
+      expect(entry?.loadError).not.toContain("ghp_abcdefghij");
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it("caps oversized log fields with a single truncation marker", async () => {
     const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
     try {

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -308,6 +308,9 @@ export interface GeneratedElectronAPI {
     getDecorations(
       ...args: IpcInvokeMap["plugin:file-decorations-get"]["args"]
     ): Promise<IpcInvokeMap["plugin:file-decorations-get"]["result"]>;
+    getDiagnostics(
+      ...args: IpcInvokeMap["plugin:get-diagnostics"]["args"]
+    ): Promise<IpcInvokeMap["plugin:get-diagnostics"]["result"]>;
     getForgeProviders(
       ...args: IpcInvokeMap["plugin:forge-providers-get"]["args"]
     ): Promise<IpcInvokeMap["plugin:forge-providers-get"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -559,6 +559,10 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: import("../forge.js").RegisteredForgeProvider[];
   };
+  "plugin:get-diagnostics": {
+    args: [];
+    result: import("../plugin.js").PluginDiagnosticsSnapshot;
+  };
   "plugin:list": {
     args: [];
     result: import("../plugin.js").LoadedPluginInfo[];

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -260,7 +260,72 @@ export interface PluginHostApi {
    * unloaded.
    */
   invalidateFileDecorations(scope: string, paths?: string[]): void;
+  /**
+   * Per-plugin tagged log channel. Each call writes a line into a fixed-size
+   * FIFO ring buffer (most-recent ~500 lines) owned by the host and forwards
+   * the message to the host console prefixed `[plugin:${pluginId}]`. Writes
+   * are synchronous from the plugin's POV — the call enqueues and returns
+   * immediately, never backpressured. Like {@link invalidateFileDecorations}
+   * this is NOT revoke-guarded: a plugin logs from its own post-activation
+   * callbacks (timers, subscriptions) long after `activate()` resolves. It
+   * becomes a silent no-op once the plugin is unloaded.
+   */
+  readonly logger: PluginLogger;
 }
+
+export type PluginLogLevel = "info" | "warn" | "error";
+
+export interface PluginLogger {
+  info(message: string, fields?: Record<string, unknown>): void;
+  warn(message: string, fields?: Record<string, unknown>): void;
+  error(message: string, fields?: Record<string, unknown>): void;
+}
+
+/**
+ * One line in a plugin's ring buffer. `fields` is the plugin-supplied
+ * structured payload, JSON-stringified at write time and capped to ~2KB; a
+ * line whose serialized fields exceed the cap carries a single truncation
+ * marker instead of silent loss.
+ */
+export interface PluginLogLine {
+  timestamp: number;
+  level: PluginLogLevel;
+  message: string;
+  fields?: string;
+}
+
+/**
+ * Recent plugin-action dispatch, sourced from the audit log (#9232). Omitted
+ * from the diagnostics snapshot until that audit log lands.
+ */
+export interface PluginActionAuditEntry {
+  timestamp: number;
+  actionId: string;
+  effectiveDanger: "safe" | "confirm";
+}
+
+/** One loaded plugin's slice of the diagnostics export payload. */
+export interface PluginDiagnosticsEntry {
+  name: string;
+  version: string;
+  /** "builtin" for app-bundled plugins, "user" otherwise. */
+  source: string;
+  /**
+   * ISO-8601 install/load time. Falls back to the load timestamp until the
+   * provenance fields from #9271 land.
+   */
+  installedAt: string;
+  /** Present once #9271 wires dev-mode provenance; omitted otherwise. */
+  devMode?: boolean;
+  /** Load-time error caught while importing the plugin's main entry, if any. */
+  loadError?: string;
+  /** Most-recent log lines, reverse-chronological, with secrets scrubbed. */
+  logLines: PluginLogLine[];
+  /** Recent plugin-action dispatches (#9232); omitted until that log lands. */
+  actionAuditTail?: PluginActionAuditEntry[];
+}
+
+export type PluginDiagnosticsSnapshot = PluginDiagnosticsEntry[];
 
 export type PluginActivate = (
   host: PluginHostApi

--- a/shared/utils/__tests__/pluginDiagnosticsScrub.test.ts
+++ b/shared/utils/__tests__/pluginDiagnosticsScrub.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { scrubSecrets, scrubLogLine } from "../pluginDiagnosticsScrub.js";
+import type { PluginLogLine } from "../../types/plugin.js";
+
+describe("scrubSecrets", () => {
+  it("redacts GitHub tokens of every prefix", () => {
+    const text =
+      "ghp_abcdefghijklmnopqrstuvwxyz0123 gho_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345 ghs_0123456789abcdefghijABCDE";
+    const out = scrubSecrets(text);
+    expect(out).not.toMatch(/gh[pous]_[A-Za-z0-9]/);
+    expect(out.match(/\[REDACTED\]/g)).toHaveLength(3);
+  });
+
+  it("redacts OpenAI keys including project/service-account prefixes", () => {
+    const out = scrubSecrets(
+      "key=sk-abcdefghijklmnopqrstuvwxyz0123 proj=sk-proj-abcdefghijklmnopqrstuvwxyz"
+    );
+    expect(out).not.toContain("sk-abcdefghij");
+    expect(out).not.toContain("sk-proj-abcdef");
+    expect(out.match(/\[REDACTED\]/g)).toHaveLength(2);
+  });
+
+  it("redacts AWS access key ids", () => {
+    const out = scrubSecrets("aws AKIAIOSFODNN7EXAMPLE and ASIAY34FZKBOKMUTVV7A here");
+    expect(out).not.toContain("AKIAIOSFODNN7EXAMPLE");
+    expect(out).not.toContain("ASIAY34FZKBOKMUTVV7A");
+  });
+
+  it("redacts the credential in an Authorization Bearer header but keeps the scheme", () => {
+    const out = scrubSecrets("Authorization: Bearer abc.def.ghi-jkl_mno");
+    expect(out).toBe("Authorization: Bearer [REDACTED]");
+  });
+
+  it("redacts JWTs", () => {
+    const jwt =
+      "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    const out = scrubSecrets(`token ${jwt} end`);
+    expect(out).toBe("token [REDACTED] end");
+  });
+
+  it("redacts JSON-ish secret values while preserving the key", () => {
+    const out = scrubSecrets('{"api_key":"supersecretvalue","password":"hunter2pass"}');
+    expect(out).toContain('"api_key":"[REDACTED]"');
+    expect(out).toContain('"password":"[REDACTED]"');
+  });
+
+  it("leaves git SHAs, UUIDs, and ordinary text untouched", () => {
+    const text =
+      "commit f7aed9fba432cc82a9 uuid 550e8400-e29b-41d4-a716-446655440000 ran the build";
+    expect(scrubSecrets(text)).toBe(text);
+  });
+
+  it("is idempotent", () => {
+    const once = scrubSecrets("ghp_abcdefghijklmnopqrstuvwxyz0123");
+    expect(scrubSecrets(once)).toBe(once);
+  });
+
+  it("handles empty input", () => {
+    expect(scrubSecrets("")).toBe("");
+  });
+});
+
+describe("scrubLogLine", () => {
+  it("scrubs message and fields without mutating the input", () => {
+    const line: PluginLogLine = {
+      timestamp: 123,
+      level: "error",
+      message: "auth failed with ghp_abcdefghijklmnopqrstuvwxyz0123",
+      fields: '{"token":"sk-abcdefghijklmnopqrstuvwxyz0123"}',
+    };
+    const scrubbed = scrubLogLine(line);
+    expect(scrubbed.message).toContain("[REDACTED]");
+    expect(scrubbed.fields).toContain("[REDACTED]");
+    expect(scrubbed.timestamp).toBe(123);
+    expect(scrubbed.level).toBe("error");
+    // Input untouched.
+    expect(line.message).toContain("ghp_abcdefghijklmnopqrstuvwxyz0123");
+    expect(line.fields).toContain("sk-abcdefghijklmnopqrstuvwxyz0123");
+  });
+
+  it("omits fields when the line has none", () => {
+    const line: PluginLogLine = { timestamp: 1, level: "info", message: "hello" };
+    expect(scrubLogLine(line)).toEqual({ timestamp: 1, level: "info", message: "hello" });
+  });
+});

--- a/shared/utils/__tests__/pluginDiagnosticsScrub.test.ts
+++ b/shared/utils/__tests__/pluginDiagnosticsScrub.test.ts
@@ -5,10 +5,10 @@ import type { PluginLogLine } from "../../types/plugin.js";
 describe("scrubSecrets", () => {
   it("redacts GitHub tokens of every prefix", () => {
     const text =
-      "ghp_abcdefghijklmnopqrstuvwxyz0123 gho_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345 ghs_0123456789abcdefghijABCDE";
+      "ghp_abcdefghijklmnopqrstuvwxyz0123 gho_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345 ghs_0123456789abcdefghijABCDE ghr_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345 ghu_abcdefghijklmnopqrstuvwxyz0123";
     const out = scrubSecrets(text);
-    expect(out).not.toMatch(/gh[pous]_[A-Za-z0-9]/);
-    expect(out.match(/\[REDACTED\]/g)).toHaveLength(3);
+    expect(out).not.toMatch(/gh[pousr]_[A-Za-z0-9]/);
+    expect(out.match(/\[REDACTED\]/g)).toHaveLength(5);
   });
 
   it("redacts OpenAI keys including project/service-account prefixes", () => {

--- a/shared/utils/pluginDiagnosticsScrub.ts
+++ b/shared/utils/pluginDiagnosticsScrub.ts
@@ -1,0 +1,62 @@
+import type { PluginLogLine } from "../types/plugin.js";
+
+const REDACTED = "[REDACTED]";
+
+/**
+ * Secret patterns scrubbed from plugin log lines before they leave the main
+ * process in a diagnostics export. Deliberately shaped (provider-prefix or
+ * key-name anchored) rather than length-based — a generic `[A-Za-z0-9]{32,}`
+ * catch-all would shred git SHAs, UUIDs, and base64 chunks that are safe and
+ * useful to a maintainer. The raw ring buffer is never scrubbed; only the
+ * export pass runs these.
+ */
+const SECRET_PATTERNS: RegExp[] = [
+  // GitHub tokens (personal, oauth, user-to-server, server-to-server, refresh).
+  /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g,
+  // OpenAI keys, including project / service-account prefixes.
+  /\bsk-(?:proj-|svcacct-)?[A-Za-z0-9_-]{20,}\b/g,
+  // AWS access key ids.
+  /\b(?:AKIA|ASIA|AGPA|AIDA|AROA|ANPA|ANVA)[A-Z0-9]{16}\b/g,
+  // JSON Web Tokens (header.payload.signature).
+  /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g,
+];
+
+// Authorization: Bearer <token> — keep the scheme, drop the credential.
+const BEARER_PATTERN = /(authorization\s*[:=]\s*bearer\s+)([A-Za-z0-9._\-+/=]+)/gi;
+
+// "token": "value" / "api_key": "value" etc. in JSON-ish text — keep the key,
+// redact the value. Matches single or double quotes.
+const JSON_SECRET_PATTERN =
+  /(["']?(?:api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret|token|secret|password|passwd|pwd)["']?\s*[:=]\s*["'])([^"']{4,})(["'])/gi;
+
+/**
+ * Replace common secret formats in `text` with `[REDACTED]`. Idempotent and
+ * order-independent across the pattern set.
+ */
+export function scrubSecrets(text: string): string {
+  if (!text) return text;
+  let out = text;
+  out = out.replace(BEARER_PATTERN, (_m, prefix: string) => `${prefix}${REDACTED}`);
+  out = out.replace(
+    JSON_SECRET_PATTERN,
+    (_m, prefix: string, _value: string, suffix: string) => `${prefix}${REDACTED}${suffix}`
+  );
+  for (const pattern of SECRET_PATTERNS) {
+    out = out.replace(pattern, REDACTED);
+  }
+  return out;
+}
+
+/**
+ * Scrub a single ring-buffer line for export — both the message and the
+ * serialized `fields` string pass through {@link scrubSecrets}. Returns a new
+ * object; the input line (the raw buffer entry) is never mutated.
+ */
+export function scrubLogLine(line: PluginLogLine): PluginLogLine {
+  return {
+    timestamp: line.timestamp,
+    level: line.level,
+    message: scrubSecrets(line.message),
+    ...(line.fields !== undefined ? { fields: scrubSecrets(line.fields) } : {}),
+  };
+}

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -6,6 +6,7 @@ import { logError } from "@/utils/logger";
 import { captureRendererException } from "@/utils/rendererSentry";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { buildReportIssueUrl } from "./buildReportIssueUrl";
+import type { PluginDiagnosticsSnapshot } from "../../../shared/types/plugin";
 import { notify } from "@/lib/notify";
 
 interface ErrorBoundaryProps {
@@ -163,6 +164,15 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
       if (!error) return;
 
+      // Best-effort plugin diagnostics — if the bridge is missing or the call
+      // fails, the report still opens without the plugin section.
+      let pluginDiagnostics: PluginDiagnosticsSnapshot | undefined;
+      try {
+        pluginDiagnostics = await window.electron?.plugin?.getDiagnostics();
+      } catch {
+        pluginDiagnostics = undefined;
+      }
+
       const { url, fullBody, usedClipboardFallback } = buildReportIssueUrl({
         incidentId,
         componentName,
@@ -170,6 +180,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
         stack: error.stack ?? "",
         componentStack: errorInfo?.componentStack ?? "",
         context,
+        pluginDiagnostics,
       });
 
       if (usedClipboardFallback) {

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -164,11 +164,20 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
       if (!error) return;
 
-      // Best-effort plugin diagnostics — if the bridge is missing or the call
-      // fails, the report still opens without the plugin section.
+      // Best-effort plugin diagnostics — if the bridge is missing, the call
+      // fails, or it stalls (a plugin spamming huge logs could slow snapshot
+      // serialization), the report still opens without the plugin section.
+      // The race against a 2s timeout guards the `reportInFlight` reset in the
+      // outer finally from being blocked by a never-resolving IPC call.
       let pluginDiagnostics: PluginDiagnosticsSnapshot | undefined;
       try {
-        pluginDiagnostics = await window.electron?.plugin?.getDiagnostics();
+        const fetchDiagnostics = window.electron?.plugin?.getDiagnostics();
+        pluginDiagnostics = fetchDiagnostics
+          ? await Promise.race([
+              fetchDiagnostics,
+              new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 2000)),
+            ])
+          : undefined;
       } catch {
         pluginDiagnostics = undefined;
       }

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -9,6 +9,11 @@ import { buildReportIssueUrl } from "./buildReportIssueUrl";
 import type { PluginDiagnosticsSnapshot } from "../../../shared/types/plugin";
 import { notify } from "@/lib/notify";
 
+// Upper bound on how long the report path waits for the plugin diagnostics
+// snapshot before proceeding without it. Generous for serializing ≤500
+// capped-message lines; guards the Report button from a stalled IPC call.
+const PLUGIN_DIAGNOSTICS_TIMEOUT_MS = 2000;
+
 interface ErrorBoundaryProps {
   children: ReactNode;
   fallback?: React.ComponentType<ErrorFallbackProps>;
@@ -175,7 +180,9 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
         pluginDiagnostics = fetchDiagnostics
           ? await Promise.race([
               fetchDiagnostics,
-              new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 2000)),
+              new Promise<undefined>((resolve) =>
+                setTimeout(() => resolve(undefined), PLUGIN_DIAGNOSTICS_TIMEOUT_MS)
+              ),
             ])
           : undefined;
       } catch {

--- a/src/components/ErrorBoundary/__tests__/buildReportIssueUrl.test.ts
+++ b/src/components/ErrorBoundary/__tests__/buildReportIssueUrl.test.ts
@@ -220,6 +220,24 @@ describe("buildReportIssueUrl", () => {
     expect(new URL(result.url).searchParams.get("body")).toContain("Plugin diagnostics");
   });
 
+  it("does not throw on a non-finite log timestamp from a corrupt payload", () => {
+    const result = buildReportIssueUrl(
+      makeInput({
+        pluginDiagnostics: [
+          {
+            name: "acme.plugin",
+            version: "1.0.0",
+            source: "user",
+            installedAt: "2026-01-01T00:00:00.000Z",
+            logLines: [{ timestamp: NaN, level: "info", message: "test" }],
+          },
+        ],
+      })
+    );
+    expect(() => new URL(result.url)).not.toThrow();
+    expect(result.fullBody).toContain("[unknown] INFO test");
+  });
+
   it("drops the plugin section from the URL when it would blow the budget, but keeps it in fullBody", () => {
     const huge = "z".repeat(20000);
     const result = buildReportIssueUrl(

--- a/src/components/ErrorBoundary/__tests__/buildReportIssueUrl.test.ts
+++ b/src/components/ErrorBoundary/__tests__/buildReportIssueUrl.test.ts
@@ -187,4 +187,60 @@ describe("buildReportIssueUrl", () => {
     expect(title.length).toBeLessThan(longMessage.length);
     expect(title.endsWith("…")).toBe(true);
   });
+
+  it("omits the plugin section when no diagnostics are provided", () => {
+    const result = buildReportIssueUrl(makeInput());
+    expect(result.fullBody).not.toContain("Plugin diagnostics");
+  });
+
+  it("omits the plugin section when the diagnostics array is empty", () => {
+    const result = buildReportIssueUrl(makeInput({ pluginDiagnostics: [] }));
+    expect(result.fullBody).not.toContain("Plugin diagnostics");
+  });
+
+  it("includes a collapsible plugin section when plugins are loaded", () => {
+    const result = buildReportIssueUrl(
+      makeInput({
+        pluginDiagnostics: [
+          {
+            name: "acme.plugin",
+            version: "1.2.3",
+            source: "user",
+            installedAt: "2026-01-01T00:00:00.000Z",
+            logLines: [{ timestamp: 0, level: "error", message: "kaboom" }],
+          },
+        ],
+      })
+    );
+    expect(result.usedClipboardFallback).toBe(false);
+    expect(result.fullBody).toContain("<summary>Plugin diagnostics (1)</summary>");
+    expect(result.fullBody).toContain("acme.plugin@1.2.3 (user)");
+    expect(result.fullBody).toContain("kaboom");
+    expect(getEncodedBodyLength(result.url)).toBeLessThanOrEqual(URL_BODY_BUDGET);
+    expect(new URL(result.url).searchParams.get("body")).toContain("Plugin diagnostics");
+  });
+
+  it("drops the plugin section from the URL when it would blow the budget, but keeps it in fullBody", () => {
+    const huge = "z".repeat(20000);
+    const result = buildReportIssueUrl(
+      makeInput({
+        pluginDiagnostics: [
+          {
+            name: "acme.noisy",
+            version: "1.0.0",
+            source: "user",
+            installedAt: "2026-01-01T00:00:00.000Z",
+            logLines: [{ timestamp: 0, level: "info", message: huge }],
+          },
+        ],
+      })
+    );
+    // Error report itself is small, so no clipboard fallback — but the plugin
+    // section is too big for the URL and is dropped from it.
+    expect(result.usedClipboardFallback).toBe(false);
+    expect(getEncodedBodyLength(result.url)).toBeLessThanOrEqual(URL_BODY_BUDGET);
+    expect(new URL(result.url).searchParams.get("body")).not.toContain("Plugin diagnostics");
+    // The full report (clipboard payload) still carries it.
+    expect(result.fullBody).toContain("Plugin diagnostics");
+  });
 });

--- a/src/components/ErrorBoundary/buildReportIssueUrl.ts
+++ b/src/components/ErrorBoundary/buildReportIssueUrl.ts
@@ -1,3 +1,5 @@
+import type { PluginDiagnosticsSnapshot } from "../../../shared/types/plugin";
+
 const REPO_ISSUE_URL = "https://github.com/daintreehq/daintree/issues/new";
 
 // GitHub's Nginx fronts the issue form at an 8 KiB URL hard cap. Reserve
@@ -28,6 +30,14 @@ export interface ReportIssueInput {
   stack: string;
   componentStack: string;
   context: Record<string, unknown> | undefined;
+  /**
+   * Optional plugin diagnostics snapshot (loaded plugins, provenance, scrubbed
+   * recent log lines). Rendered as a collapsible section appended to the body.
+   * Supplementary context — dropped from the URL first when over budget, but
+   * always present in `fullBody` for the clipboard fallback. Omitted entirely
+   * when no plugins are loaded.
+   */
+  pluginDiagnostics?: PluginDiagnosticsSnapshot;
 }
 
 export interface ReportIssueResult {
@@ -54,6 +64,51 @@ function formatBody(params: {
     `${context ? JSON.stringify(context, null, 2) : "None"}\n\n` +
     `**Stack Trace:**\n\`\`\`\n${stack || "No stack trace"}\n\`\`\`\n\n` +
     `**Component Stack:**\n\`\`\`\n${componentStack || "No component stack"}\n\`\`\``
+  );
+}
+
+/**
+ * Render the plugin diagnostics slice as a collapsible markdown section so it
+ * doesn't dominate a short report. Returns an empty string when no plugins are
+ * loaded — the caller omits the section entirely.
+ */
+function formatPluginDiagnosticsSection(
+  diagnostics: PluginDiagnosticsSnapshot | undefined
+): string {
+  if (!diagnostics || diagnostics.length === 0) return "";
+  const lines: string[] = [];
+  for (const plugin of diagnostics) {
+    lines.push(`#### ${plugin.name}@${plugin.version} (${plugin.source})`);
+    lines.push(`- Installed: ${plugin.installedAt}`);
+    if (plugin.devMode) lines.push(`- Dev mode: yes`);
+    if (plugin.loadError) {
+      lines.push(`- Load error:`);
+      lines.push("```");
+      lines.push(plugin.loadError);
+      lines.push("```");
+    }
+    if (plugin.logLines.length > 0) {
+      lines.push(`- Recent logs (${plugin.logLines.length}, newest first):`);
+      lines.push("```");
+      for (const line of plugin.logLines) {
+        const ts = new Date(line.timestamp).toISOString();
+        const fields = line.fields ? ` ${line.fields}` : "";
+        lines.push(`[${ts}] ${line.level.toUpperCase()} ${line.message}${fields}`);
+      }
+      lines.push("```");
+    }
+    if (plugin.actionAuditTail && plugin.actionAuditTail.length > 0) {
+      lines.push(`- Recent actions:`);
+      for (const entry of plugin.actionAuditTail) {
+        const ts = new Date(entry.timestamp).toISOString();
+        lines.push(`  - ${ts} \`${entry.actionId}\` (${entry.effectiveDanger})`);
+      }
+    }
+    lines.push("");
+  }
+  return (
+    `<details>\n<summary>Plugin diagnostics (${diagnostics.length})</summary>\n\n` +
+    `${lines.join("\n")}\n</details>`
   );
 }
 
@@ -129,7 +184,8 @@ function makeUrl(title: string, body: string): string {
  */
 export function buildReportIssueUrl(input: ReportIssueInput): ReportIssueResult {
   const title = `Component Error: ${input.message || "Unknown"}`;
-  const fullBody = formatBody({
+  const pluginSection = formatPluginDiagnosticsSection(input.pluginDiagnostics);
+  const baseBody = formatBody({
     componentName: input.componentName,
     incidentId: input.incidentId,
     message: input.message,
@@ -137,9 +193,21 @@ export function buildReportIssueUrl(input: ReportIssueInput): ReportIssueResult 
     stack: input.stack,
     componentStack: input.componentStack,
   });
+  // `fullBody` is the complete report (incl. plugin diagnostics) — it's what
+  // the clipboard fallback writes. The URL body may carry less.
+  const fullBody = pluginSection ? `${baseBody}\n\n${pluginSection}` : baseBody;
 
+  // Prefer including plugin diagnostics in the URL when the whole thing fits.
   if (encodeURIComponent(fullBody).length <= URL_BODY_BUDGET) {
     return { url: makeUrl(title, fullBody), fullBody, usedClipboardFallback: false };
+  }
+
+  // Plugin diagnostics are supplementary — drop them from the URL before
+  // touching the error signal, then run the existing truncation waterfall on
+  // the error report alone. (When no plugins are loaded, baseBody === fullBody
+  // and this is the original first check.)
+  if (pluginSection && encodeURIComponent(baseBody).length <= URL_BODY_BUDGET) {
+    return { url: makeUrl(title, baseBody), fullBody, usedClipboardFallback: false };
   }
 
   const withoutComponentStack = formatBody({

--- a/src/components/ErrorBoundary/buildReportIssueUrl.ts
+++ b/src/components/ErrorBoundary/buildReportIssueUrl.ts
@@ -72,6 +72,13 @@ function formatBody(params: {
  * doesn't dominate a short report. Returns an empty string when no plugins are
  * loaded — the caller omits the section entirely.
  */
+// A timestamp crosses the IPC boundary as plain JSON, so a corrupt/hand-built
+// payload could carry NaN or Infinity — `new Date(NaN).toISOString()` throws,
+// which would bubble out of buildReportIssueUrl and silently fail the report.
+function safeIso(timestamp: number): string {
+  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : "unknown";
+}
+
 function formatPluginDiagnosticsSection(
   diagnostics: PluginDiagnosticsSnapshot | undefined
 ): string {
@@ -91,7 +98,7 @@ function formatPluginDiagnosticsSection(
       lines.push(`- Recent logs (${plugin.logLines.length}, newest first):`);
       lines.push("```");
       for (const line of plugin.logLines) {
-        const ts = new Date(line.timestamp).toISOString();
+        const ts = safeIso(line.timestamp);
         const fields = line.fields ? ` ${line.fields}` : "";
         lines.push(`[${ts}] ${line.level.toUpperCase()} ${line.message}${fields}`);
       }
@@ -100,7 +107,7 @@ function formatPluginDiagnosticsSection(
     if (plugin.actionAuditTail && plugin.actionAuditTail.length > 0) {
       lines.push(`- Recent actions:`);
       for (const entry of plugin.actionAuditTail) {
-        const ts = new Date(entry.timestamp).toISOString();
+        const ts = safeIso(entry.timestamp);
         lines.push(`  - ${ts} \`${entry.actionId}\` (${entry.effectiveDanger})`);
       }
     }


### PR DESCRIPTION
## Summary

- Adds `host.logger` (`info`/`warn`/`error`) to the plugin host API, backed by a per-plugin 500-entry FIFO ring buffer in `PluginService`. Not revoke-guarded so log writes during teardown aren't silently dropped. Message and `fields` each capped at ~2KB UTF-8 with a truncation marker; all writes forward to the host console with a `[plugin:id]` prefix.
- Adds `getDiagnosticsSnapshot()` and a new `plugin:get-diagnostics` IPC channel. Secrets are scrubbed on export only (via `shared/utils/pluginDiagnosticsScrub.ts`), not on write, so the in-memory buffer holds the raw lines.
- Extends `buildReportIssueUrl` with an optional collapsible, budget-gated plugin section; `ErrorBoundary` fetches the snapshot best-effort with a 2s timeout so a slow IPC call never blocks the error UI.

`#9271` (provenance) and `#9232` (audit log) are still open — those fields use graceful fallbacks for now.

Resolves #9291

## Changes

- `shared/types/plugin.ts` — `PluginLogLine`, `PluginDiagnosticsEntry`, `PluginDiagnosticsSnapshot` types; `logger` added to `PluginHostApi`
- `shared/utils/pluginDiagnosticsScrub.ts` — shared scrub helper (bearer tokens, `sk-*`, `gh[pousr]_*`, etc.)
- `electron/services/PluginService.ts` — `PluginLogBuffer` ring buffer class; `appendLog`, `getDiagnosticsSnapshot`, `getPluginLoadError` methods
- `electron/ipc/channels.ts` + `electron/ipc/handlers/plugin.ts` + `electron/ipc/handlers/plugin.preload.ts` — `plugin:get-diagnostics` channel
- `shared/types/ipc/generated-api.ts` + `generated.ts` — updated IPC surface
- `src/components/ErrorBoundary/buildReportIssueUrl.ts` — plugin section with `<details>` budget gate
- `src/components/ErrorBoundary/ErrorBoundary.tsx` — best-effort diagnostics fetch with `DIAGNOSTICS_TIMEOUT_MS` constant

## Testing

Unit test coverage added for: scrub patterns (bearer, `sk-*`, `gh[pousr]_*`, nested objects), ring-buffer wraparound at exactly 500 and 501 entries, per-message 2KB cap with truncation marker, load-error scrub path, `buildReportIssueUrl` budget-gating, and NaN-timestamp guard in the scrub helper. `npm run check` and targeted vitest pass.