### PR TITLE
fix(build): tighten ASAR integrity coverage, add better-sqlite3 to universal build glob

### DIFF
--- a/docs/distribution/asar-integrity.md
+++ b/docs/distribution/asar-integrity.md
@@ -1,0 +1,11 @@
+# ASAR integrity
+
+Electron supports embedded ASAR integrity validation on macOS (since Electron 16) and Windows (since Electron 30). Daintree enables this via the `enableEmbeddedAsarIntegrityValidation` fuse in `electron-builder.config.cjs`.
+
+## Platform coverage
+
+| Platform | ASAR integrity | Notes |
+| --- | --- | --- |
+| macOS | Supported | `enableEmbeddedAsarIntegrityValidation` + `ElectronAsarIntegrity` in `Info.plist` |
+| Windows | Supported | `enableEmbeddedAsarIntegrityValidation` + `ElectronAsarIntegrity` resource |
+| Linux | Not supported | Electron has no ASAR integrity validation on Linux — the platform lacks the required OS-level code-signing infrastructure that macOS and Windows integrity checks chain into. AppImage's outer squashfs hash is the only tamper signal on Linux distributions. This is a known framework limitation, not a bug. |

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -43,6 +43,7 @@ module.exports = async function () {
     files: [
       "dist/**/*",
       "dist-electron/**/*",
+      "electron/services/persistence/migrations/**/*",
       "!demo/**",
       "!node_modules/node-pty/bin",
       "!node_modules/node-pty/prebuilds",
@@ -51,7 +52,6 @@ module.exports = async function () {
     extraResources: [
       { from: "help", to: "help" },
       { from: "electron/resources/sounds", to: "sounds" },
-      { from: "electron/services/persistence/migrations", to: "migrations" },
     ],
     // node-pty and better-sqlite3 contain native .node binaries that need
     // real filesystem access for `require()` — they cannot live inside the
@@ -78,7 +78,7 @@ module.exports = async function () {
     mac: {
       extraResources: [{ from: "scripts/daintree-cli.sh", to: "daintree-cli.sh" }],
       x64ArchFiles:
-        "Contents/Resources/app.asar.unpacked/node_modules/{node-pty/build/Release/**,win-job-object/bin/**,posix-pty-reaper/build/Release/**,@parcel/watcher-darwin-*/watcher.node,@parcel/watcher/bin/darwin-*/watcher.node}",
+        "Contents/Resources/app.asar.unpacked/node_modules/{node-pty/build/Release/**,better-sqlite3/build/Release/**,win-job-object/bin/**,posix-pty-reaper/build/Release/**,@parcel/watcher-darwin-*/watcher.node,@parcel/watcher/bin/darwin-*/watcher.node}",
       forceCodeSigning: true,
       notarize: true,
       binaries: [

--- a/electron/services/persistence/db.ts
+++ b/electron/services/persistence/db.ts
@@ -21,9 +21,7 @@ export function getBackupPath(): string {
 }
 
 export function getMigrationsFolder(): string {
-  return app.isPackaged
-    ? path.join(process.resourcesPath, "migrations")
-    : path.join(app.getAppPath(), "electron/services/persistence/migrations");
+  return path.join(app.getAppPath(), "electron/services/persistence/migrations");
 }
 
 export function getSharedDb(): AppDb {


### PR DESCRIPTION
## Summary
Tightens ASAR integrity coverage by pulling Drizzle migration files inside `app.asar` instead of shipping them as `extraResources`, and adds `better-sqlite3` to the macOS universal-build glob so it won't break the universal binary. Documents the Linux ASAR gap so nobody chases it as a bug.

Resolves #9260.

## Changes
- **Migrations inside `app.asar`** — removed the `extraResources` entry for `electron/services/persistence/migrations`, added it to `files[]`, and collapsed `getMigrationsFolder()` to a single path. Drizzle's migrator reads via `fs.readFileSync`, which ASAR virtualizes transparently, so the move is mechanically safe. This brings the SQL migration files under the integrity fuse on macOS and Windows.
- **`better-sqlite3` in `mac.x64ArchFiles`** — added `better-sqlite3/build/Release/**` to the brace expansion alongside `node-pty`, `win-job-object`, `posix-pty-reaper`, and `@parcel/watcher`. Without it, byte-identical native artifacts from x64 and arm64 single-arch builds trigger a `@electron/universal` error halting the universal build.
- **Linux ASAR gap documented** — added `docs/distribution/asar-integrity.md` explaining that Electron has no ASAR integrity validation on Linux and that AppImage's squashfs hash is the only tamper signal. No code change applies.
- **`asar integrity-digest` descoped** — `@electron/asar` v4.1.0 added the subcommand but v4.2.0 reverted it, and `electron-builder` has no native support. This is tracked upstream.

## Testing
- Typecheck passes on the simplified `getMigrationsFolder()` path
- `sounds/` and `help/` remain in `extraResources` — they were considered and explicitly rejected because OS-spawned processes and recursive `fs.cp`/`fs.readdir` don't work inside ASAR in Electron 41