### PR TITLE
feat(notifications): add per-thread snooze and Linear-parity keybindings to the inbox

### DIFF
--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -1,9 +1,9 @@
 {
-  "count": 1195,
+  "count": 1197,
   "byRule": {
     "@typescript-eslint/no-explicit-any": 54,
     "@typescript-eslint/no-floating-promises": 93,
-    "@typescript-eslint/no-unsafe-type-assertion": 500,
+    "@typescript-eslint/no-unsafe-type-assertion": 502,
     "no-restricted-imports": 8,
     "no-restricted-syntax": 412,
     "no-useless-assignment": 20,
@@ -11,5 +11,5 @@
     "react-compiler/react-compiler": 16,
     "react-hooks/exhaustive-deps": 40
   },
-  "updatedAt": "2026-05-27T13:24:59.623Z"
+  "updatedAt": "2026-05-27T16:27:03.271Z"
 }

--- a/shared/utils/__tests__/snoozeTimestamps.test.ts
+++ b/shared/utils/__tests__/snoozeTimestamps.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { resolveSnoozeDuration, SNOOZE_LABEL } from "../snoozeTimestamps.js";
+
+describe("resolveSnoozeDuration", () => {
+  it("'1h' adds one hour", () => {
+    const now = new Date(2026, 4, 27, 14, 30, 0, 0);
+    const target = new Date(resolveSnoozeDuration("1h", now));
+    expect(target.getHours()).toBe(15);
+    expect(target.getMinutes()).toBe(30);
+    expect(target.getDate()).toBe(27);
+  });
+
+  it("'4h' adds four hours", () => {
+    const now = new Date(2026, 4, 27, 10, 0, 0, 0);
+    const target = new Date(resolveSnoozeDuration("4h", now));
+    expect(target.getHours()).toBe(14);
+    expect(target.getDate()).toBe(27);
+  });
+
+  it("'4h' rolls into the next day when invoked late in the evening", () => {
+    const now = new Date(2026, 4, 27, 22, 0, 0, 0);
+    const target = new Date(resolveSnoozeDuration("4h", now));
+    expect(target.getHours()).toBe(2);
+    expect(target.getDate()).toBe(28);
+  });
+
+  it("'tomorrow-8am' resolves to tomorrow at 8am local", () => {
+    const now = new Date(2026, 4, 27, 14, 30, 45, 123); // Wed 14:30:45
+    const target = new Date(resolveSnoozeDuration("tomorrow-8am", now));
+    expect(target.getDate()).toBe(28);
+    expect(target.getHours()).toBe(8);
+    expect(target.getMinutes()).toBe(0);
+    expect(target.getSeconds()).toBe(0);
+    expect(target.getMilliseconds()).toBe(0);
+  });
+
+  it("'tomorrow-8am' resolves to tomorrow even when invoked before 8am today", () => {
+    const now = new Date(2026, 4, 27, 6, 0, 0, 0); // Wed 06:00
+    const target = new Date(resolveSnoozeDuration("tomorrow-8am", now));
+    expect(target.getDate()).toBe(28);
+    expect(target.getHours()).toBe(8);
+  });
+
+  it("'tomorrow-8am' rolls across month boundary", () => {
+    const now = new Date(2026, 4, 31, 23, 0, 0, 0); // May 31, 23:00
+    const target = new Date(resolveSnoozeDuration("tomorrow-8am", now));
+    expect(target.getMonth()).toBe(5); // June
+    expect(target.getDate()).toBe(1);
+    expect(target.getHours()).toBe(8);
+  });
+
+  it("'next-monday-8am' resolves to next Monday 8am when invoked on a Wednesday", () => {
+    const now = new Date(2026, 4, 27, 10, 0, 0, 0); // Wed 2026-05-27
+    const target = new Date(resolveSnoozeDuration("next-monday-8am", now));
+    expect(target.getDay()).toBe(1); // Monday
+    expect(target.getDate()).toBe(1); // June 1
+    expect(target.getMonth()).toBe(5);
+    expect(target.getHours()).toBe(8);
+  });
+
+  it("'next-monday-8am' rolls a full week when invoked on a Monday", () => {
+    const now = new Date(2026, 5, 1, 10, 0, 0, 0); // Mon 2026-06-01
+    const target = new Date(resolveSnoozeDuration("next-monday-8am", now));
+    expect(target.getDay()).toBe(1);
+    expect(target.getDate()).toBe(8); // June 8 — full week out, never the same day
+  });
+
+  it("'next-monday-8am' resolves to the following Monday when invoked on Sunday", () => {
+    const now = new Date(2026, 4, 31, 14, 0, 0, 0); // Sun 2026-05-31
+    const target = new Date(resolveSnoozeDuration("next-monday-8am", now));
+    expect(target.getDay()).toBe(1);
+    expect(target.getDate()).toBe(1); // June 1 — tomorrow
+  });
+
+  it("returns a strictly future timestamp for every option", () => {
+    const now = new Date(2026, 4, 27, 14, 30, 0, 0);
+    for (const option of ["1h", "4h", "tomorrow-8am", "next-monday-8am"] as const) {
+      expect(resolveSnoozeDuration(option, now)).toBeGreaterThan(now.getTime());
+    }
+  });
+});
+
+describe("SNOOZE_LABEL", () => {
+  it("covers every option in the ladder", () => {
+    for (const option of ["1h", "4h", "tomorrow-8am", "next-monday-8am"] as const) {
+      expect(SNOOZE_LABEL[option]).toBeTruthy();
+    }
+  });
+});

--- a/shared/utils/snoozeTimestamps.ts
+++ b/shared/utils/snoozeTimestamps.ts
@@ -1,0 +1,61 @@
+/**
+ * Snooze duration ladder shown in the per-thread snooze picker. The four
+ * options cover IDE-appropriate defer windows: same-session short defers
+ * ("1h", "4h"), cross-day ("tomorrow-8am"), and full-week ("next-monday-8am").
+ * Mirrors the Linear inbox model — 30-minute slots are intentionally omitted
+ * because dev work happens in deep-work blocks where sub-hour defers are too
+ * granular to be useful.
+ */
+export type SnoozeDurationOption = "1h" | "4h" | "tomorrow-8am" | "next-monday-8am";
+
+export const SNOOZE_DURATION_OPTIONS: readonly SnoozeDurationOption[] = [
+  "1h",
+  "4h",
+  "tomorrow-8am",
+  "next-monday-8am",
+] as const;
+
+export const SNOOZE_LABEL: Record<SnoozeDurationOption, string> = {
+  "1h": "For 1 hour",
+  "4h": "For 4 hours",
+  "tomorrow-8am": "Until tomorrow",
+  "next-monday-8am": "Until next week",
+};
+
+const HOUR_MS = 60 * 60 * 1000;
+const MORNING_HOUR = 8;
+
+/**
+ * Resolves a snooze duration option to an absolute epoch-ms timestamp. Uses
+ * local `Date` arithmetic (matches `nextOccurrenceTimestamp` in `quietHours.ts`)
+ * so DST transitions land on the user-facing wall-clock hour rather than a
+ * UTC offset. The `now` parameter is injectable for tests.
+ */
+export function resolveSnoozeDuration(
+  option: SnoozeDurationOption,
+  now: Date = new Date()
+): number {
+  switch (option) {
+    case "1h":
+      return now.getTime() + HOUR_MS;
+    case "4h":
+      return now.getTime() + 4 * HOUR_MS;
+    case "tomorrow-8am": {
+      const target = new Date(now);
+      target.setDate(target.getDate() + 1);
+      target.setHours(MORNING_HOUR, 0, 0, 0);
+      return target.getTime();
+    }
+    case "next-monday-8am": {
+      const target = new Date(now);
+      // getDay(): 0 = Sunday, 1 = Monday, …, 6 = Saturday. The picker labels
+      // this slot "Until next week", so the resolved timestamp is always
+      // strictly more than 24 hours out even when invoked on a Monday — the
+      // user is deferring to next Monday, not today.
+      const daysUntilNextMonday = (1 - target.getDay() + 7) % 7 || 7;
+      target.setDate(target.getDate() + daysUntilNextMonday);
+      target.setHours(MORNING_HOUR, 0, 0, 0);
+      return target.getTime();
+    }
+  }
+}

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -1,11 +1,23 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Archive, ArrowDown, Bell, CheckCheck, Ellipsis, Layers, Moon, Trash2 } from "lucide-react";
+import {
+  Archive,
+  ArrowDown,
+  Bell,
+  CheckCheck,
+  Clock,
+  Ellipsis,
+  Layers,
+  Moon,
+  Trash2,
+} from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 import {
   useNotificationHistoryStore,
   type NotificationHistoryEntry,
 } from "@/store/slices/notificationHistorySlice";
 import { NotificationCenterEntry } from "./NotificationCenterEntry";
+import { useSnoozeExpiryTimer } from "./useSnoozeExpiryTimer";
+import { resolveSnoozeDuration, type SnoozeDurationOption } from "@shared/utils/snoozeTimestamps";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { cn } from "@/lib/utils";
 import {
@@ -151,6 +163,7 @@ function partitionByContext(groups: ThreadGroup[]): ContextSection[] {
 export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
   const entries = useNotificationHistoryStore((s) => s.entries);
   const unreadCount = useNotificationHistoryStore((s) => s.unreadCount);
+  const snoozedThreads = useNotificationHistoryStore((s) => s.snoozedThreads);
   const clearAll = useNotificationHistoryStore((s) => s.clearAll);
   const markIdsRead = useNotificationHistoryStore((s) => s.markIdsRead);
   const markUnseenAsToast = useNotificationHistoryStore((s) => s.markUnseenAsToast);
@@ -158,6 +171,11 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
   const dismissByCorrelationId = useNotificationHistoryStore((s) => s.dismissByCorrelationId);
   const archiveEntry = useNotificationHistoryStore((s) => s.archiveEntry);
   const archiveByCorrelationId = useNotificationHistoryStore((s) => s.archiveByCorrelationId);
+  const snoozeThread = useNotificationHistoryStore((s) => s.snoozeThread);
+  const clearSnooze = useNotificationHistoryStore((s) => s.clearSnooze);
+  const clearExpiredSnoozes = useNotificationHistoryStore((s) => s.clearExpiredSnoozes);
+
+  useSnoozeExpiryTimer(snoozedThreads, clearExpiredSnoozes);
 
   const {
     notificationsEnabled,
@@ -192,7 +210,8 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
   const lastClosedAt = useUIStore((s) => s.lastNotificationCenterClosedAt);
   const resetLastClosedAt = useUIStore((s) => s.resetNotificationCenterLastClosedAt);
 
-  const [filter, setFilter] = useState<"all" | "unread" | "archived">("all");
+  const [filter, setFilter] = useState<"all" | "unread" | "archived" | "snoozed">("all");
+  const [snoozePendingIndex, setSnoozePendingIndex] = useState<number | null>(null);
   const [frozenUnreadIds, setFrozenUnreadIds] = useState<Set<string> | null>(null);
   const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(null);
   const [dividerEl, setDividerEl] = useState<HTMLDivElement | null>(null);
@@ -283,30 +302,57 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
   }, [showJumpPill]);
 
   const filteredEntries = useMemo(() => {
+    // Recompute "is snoozed?" per entry against the current snooze map.
+    // Inlining the check keeps callers from threading `now` everywhere — for
+    // the inbox-render path a single timestamp captured per render is fine
+    // (the expiry timer will re-render when a snooze actually expires).
+    const now = Date.now();
+    const isSnoozed = (e: NotificationHistoryEntry): boolean => {
+      if (!e.correlationId) return false;
+      const until = snoozedThreads[e.correlationId];
+      return typeof until === "number" && until > now;
+    };
+    if (filter === "snoozed") {
+      // Snoozed tab shows only actively-snoozed (non-archived) entries.
+      // Archived entries that happen to belong to a still-snoozed
+      // correlationId stay in Archived, not here — Snoozed is the "deferred
+      // commitment" surface, Archived is the "done" surface.
+      return entries.filter((e) => e.archivedAt === null && isSnoozed(e));
+    }
     if (filter === "archived") {
       return entries.filter((e) => e.archivedAt !== null);
     }
     if (filter === "all") {
       // Archived entries belong to the Archived tab only — they're done.
-      return entries.filter((e) => e.archivedAt === null);
+      // Snoozed threads are intentionally hidden until they un-snooze.
+      return entries.filter((e) => e.archivedAt === null && !isSnoozed(e));
     }
     if (frozenUnreadIds) {
       return entries.filter(
-        (e) => e.archivedAt === null && (!e.seenAsToast || frozenUnreadIds.has(e.id))
+        (e) =>
+          e.archivedAt === null && !isSnoozed(e) && (!e.seenAsToast || frozenUnreadIds.has(e.id))
       );
     }
-    return entries.filter((e) => e.archivedAt === null && !e.seenAsToast);
-  }, [entries, filter, frozenUnreadIds]);
+    return entries.filter((e) => e.archivedAt === null && !e.seenAsToast && !isSnoozed(e));
+  }, [entries, filter, frozenUnreadIds, snoozedThreads]);
 
   const { needsAttentionGroups, chronoSections, dividerGroupId } = useMemo(() => {
+    const now = Date.now();
+    const isSnoozedGroup = (g: ThreadGroup): boolean => {
+      if (!g.correlationId) return false;
+      const until = snoozedThreads[g.correlationId];
+      return typeof until === "number" && until > now;
+    };
     // Pinned reflects the global unread severe-threads set so it stays the
-    // same in All and Unread filter views. Hidden in Archived — pinned is for
-    // active items only. Chrono respects the active filter.
+    // same in All and Unread filter views. Hidden in Archived and Snoozed —
+    // pinned is for active, attention-required items only. Snoozed threads
+    // are an explicit defer so they must drop out of the pinned rail.
     const pinned =
-      filter === "archived"
+      filter === "archived" || filter === "snoozed"
         ? []
         : groupByCorrelationId(entries.filter((e) => e.archivedAt === null))
             .filter((g) => {
+              if (isSnoozedGroup(g)) return false;
               if (!isUnreadGroup(g)) return false;
               const sev = getWorstSeverity(g.entries);
               return sev === "error" || sev === "warning";
@@ -326,7 +372,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
       : [{ key: "all", groups: chronoGroups }];
 
     let divider: string | null = null;
-    if (lastClosedAt > 0 && filter !== "archived") {
+    if (lastClosedAt > 0 && filter !== "archived" && filter !== "snoozed") {
       for (const g of chronoGroups) {
         if (g.latestTimestamp > lastClosedAt) {
           divider = g.correlationId ?? g.entries[0]?.id ?? null;
@@ -340,7 +386,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
       chronoSections: sections,
       dividerGroupId: divider,
     };
-  }, [entries, filteredEntries, groupByContext, lastClosedAt, filter]);
+  }, [entries, filteredEntries, groupByContext, lastClosedAt, filter, snoozedThreads]);
 
   const totalChronoGroups = chronoSections.reduce((sum, s) => sum + s.groups.length, 0);
 
@@ -470,6 +516,45 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
     [archiveByCorrelationId, archiveEntry]
   );
 
+  // Build a fast index of unread entry IDs grouped by row, so the `u` toggle
+  // can flip read/unread for the focused row in one store call. Without this
+  // memo each keystroke would walk every entry looking for matches.
+  const flatRowEntryIds = useMemo(() => {
+    const map = new Map<string, string[]>();
+    for (const group of groupByCorrelationId(entries)) {
+      const key = group.correlationId ?? group.entries[0]!.id;
+      map.set(
+        key,
+        group.entries.filter((e) => !e.archivedAt).map((e) => e.id)
+      );
+    }
+    return map;
+  }, [entries]);
+
+  const toggleReadForRow = useCallback(
+    (row: FlatRow) => {
+      const ids = flatRowEntryIds.get(row.key) ?? [row.entryId];
+      const live = useNotificationHistoryStore.getState().entries;
+      const liveById = new Map(live.map((e) => [e.id, e] as const));
+      const unreadIds = ids.filter((id) => {
+        const e = liveById.get(id);
+        return e !== undefined && !e.seenAsToast;
+      });
+      if (unreadIds.length > 0) {
+        markIdsRead(unreadIds);
+      } else {
+        // Whole row already read — flip the head entry back to unread so the
+        // dot reappears. Skip when the head entry no longer exists (a
+        // dismissal or prune raced the keystroke).
+        const head = liveById.get(row.entryId);
+        if (head && head.seenAsToast && !head.archivedAt) {
+          markUnseenAsToast(row.entryId, { silent: true });
+        }
+      }
+    },
+    [flatRowEntryIds, markIdsRead, markUnseenAsToast]
+  );
+
   const moveFocusTo = useCallback((index: number) => {
     const target = rowRefs.current.get(index);
     if (target) {
@@ -530,6 +615,29 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
           }
           return;
         }
+        case "u": {
+          // Linear-parity toggle: flip the focused row between read and
+          // unread. Lowercase only — uppercase `U` is reserved for a future
+          // bulk action and would conflict with Shift-modified navigation.
+          if (e.shiftKey || e.metaKey || e.ctrlKey || e.altKey) return;
+          e.preventDefault();
+          const row = flatRows[activeIndex];
+          if (!row) return;
+          toggleReadForRow(row);
+          return;
+        }
+        case "h": {
+          // Linear-parity snooze: open the snooze sub-menu on the focused
+          // row. Lowercase only and only for correlated rows (snooze is a
+          // thread-level concept). The dropdown-open guard at the top of
+          // this handler keeps subsequent j/k from double-navigating.
+          if (e.shiftKey || e.metaKey || e.ctrlKey || e.altKey) return;
+          const row = flatRows[activeIndex];
+          if (!row || !row.correlationId) return;
+          e.preventDefault();
+          setSnoozePendingIndex(activeIndex);
+          return;
+        }
         case "Enter": {
           const row = flatRows[activeIndex];
           if (!row || !row.primaryAction) return;
@@ -541,8 +649,35 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
           return;
       }
     },
-    [rowCount, flatRows, moveFocusTo, dismissEntry, archiveRow, dispatchPrimaryAction, filter]
+    [
+      rowCount,
+      flatRows,
+      moveFocusTo,
+      dismissEntry,
+      archiveRow,
+      dispatchPrimaryAction,
+      filter,
+      toggleReadForRow,
+    ]
   );
+
+  const handleSnoozeForRow = useCallback(
+    (row: FlatRow, option: SnoozeDurationOption) => {
+      if (!row.correlationId) return;
+      snoozeThread(row.correlationId, resolveSnoozeDuration(option));
+    },
+    [snoozeThread]
+  );
+
+  const handleUnsnoozeForRow = useCallback(
+    (row: FlatRow) => {
+      if (!row.correlationId) return;
+      clearSnooze(row.correlationId);
+    },
+    [clearSnooze]
+  );
+
+  const consumeSnoozePending = useCallback(() => setSnoozePendingIndex(null), []);
 
   const handleMarkAllRead = () => {
     // Archived entries are already done; they must never appear in the
@@ -619,6 +754,22 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
   })();
 
   const showGroupToggle = entries.length > 0;
+  // Hide the Snoozed tab when nothing is snoozed — it would otherwise be a
+  // dead chip that always opens to an empty state, training users to ignore
+  // it. Snap focus back to "all" if the active snooze just expired while the
+  // tab was open so the user isn't stranded on a vanished tab.
+  const hasSnoozedThreads = useMemo(() => {
+    const now = Date.now();
+    for (const value of Object.values(snoozedThreads)) {
+      if (typeof value === "number" && value > now) return true;
+    }
+    return false;
+  }, [snoozedThreads]);
+  useEffect(() => {
+    if (filter === "snoozed" && !hasSnoozedThreads) {
+      setFilter("all");
+    }
+  }, [filter, hasSnoozedThreads]);
 
   return (
     <div className="w-[360px] max-h-[420px] flex flex-col">
@@ -672,6 +823,24 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
               >
                 Archived
               </button>
+              {hasSnoozedThreads && (
+                <button
+                  type="button"
+                  aria-pressed={filter === "snoozed"}
+                  onClick={() => {
+                    setFilter("snoozed");
+                    setFrozenUnreadIds(null);
+                  }}
+                  className={cn(
+                    "inline-flex items-center px-2 py-0.5 text-[11px] rounded-full transition-colors",
+                    filter === "snoozed"
+                      ? "bg-filter-selected-bg-strong text-daintree-text font-medium"
+                      : "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.04]"
+                  )}
+                >
+                  Snoozed
+                </button>
+              )}
             </>
           )}
         </div>
@@ -789,7 +958,15 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
           className="h-full overflow-y-auto"
         >
           {totalChronoGroups === 0 && needsAttentionGroups.length === 0 ? (
-            filter === "archived" && entries.length > 0 ? (
+            filter === "snoozed" && entries.length > 0 ? (
+              <EmptyState
+                variant="user-cleared"
+                scale="canvas"
+                title="Nothing snoozed"
+                icon={<Clock />}
+                className="py-10"
+              />
+            ) : filter === "archived" && entries.length > 0 ? (
               <EmptyState
                 variant="user-cleared"
                 scale="canvas"
@@ -855,6 +1032,12 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
                   onDropdownOpenChange={handleDropdownOpenChange}
                   onDismiss={dismissEntry}
                   onDismissThread={dismissByCorrelationId}
+                  snoozePendingIndex={snoozePendingIndex}
+                  snoozedThreads={snoozedThreads}
+                  snoozeRenderTime={now}
+                  onConsumeSnoozePending={consumeSnoozePending}
+                  onSnoozeRow={handleSnoozeForRow}
+                  onUnsnoozeRow={handleUnsnoozeForRow}
                 />
               )}
               {chronoSections.map((section, sectionIdx) => (
@@ -876,6 +1059,12 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
                   onDismiss={dismissEntry}
                   onDismissThread={dismissByCorrelationId}
                   onMarkIdsRead={markIdsReadWithUndo}
+                  snoozePendingIndex={snoozePendingIndex}
+                  snoozedThreads={snoozedThreads}
+                  snoozeRenderTime={now}
+                  onConsumeSnoozePending={consumeSnoozePending}
+                  onSnoozeRow={handleSnoozeForRow}
+                  onUnsnoozeRow={handleUnsnoozeForRow}
                 />
               ))}
             </>
@@ -935,10 +1124,22 @@ function NeedsAttentionSection({
   onDropdownOpenChange,
   onDismiss,
   onDismissThread,
+  snoozePendingIndex,
+  snoozedThreads,
+  snoozeRenderTime,
+  onConsumeSnoozePending,
+  onSnoozeRow,
+  onUnsnoozeRow,
 }: {
   groups: ThreadGroup[];
   onDismiss: (id: string) => void;
   onDismissThread: (correlationId: string) => void;
+  snoozePendingIndex: number | null;
+  snoozedThreads: Record<string, number>;
+  snoozeRenderTime: number;
+  onConsumeSnoozePending: () => void;
+  onSnoozeRow: (row: FlatRow, option: SnoozeDurationOption) => void;
+  onUnsnoozeRow: (row: FlatRow) => void;
 } & RovingSectionProps) {
   return (
     <div data-testid="needs-attention-section" className="border-b border-divider">
@@ -946,15 +1147,33 @@ function NeedsAttentionSection({
         Needs attention
       </div>
       <div role="group" aria-label="Needs attention" className="divide-y divide-tint/[0.04]">
-        {groups.map((group, idx) =>
-          renderGroup(group, onDismiss, onDismissThread, {
-            flatIndex: indexOffset + idx,
-            focusedIndex,
-            setRowRef,
-            onRowFocus,
-            onDropdownOpenChange,
-          })
-        )}
+        {groups.map((group, idx) => {
+          const flatIndex = indexOffset + idx;
+          return renderGroup(
+            group,
+            onDismiss,
+            onDismissThread,
+            {
+              flatIndex,
+              focusedIndex,
+              setRowRef,
+              onRowFocus,
+              onDropdownOpenChange,
+            },
+            buildSnoozeProps(
+              group,
+              flatIndex,
+              snoozePendingIndex,
+              snoozedThreads,
+              snoozeRenderTime,
+              {
+                onConsumeSnoozePending,
+                onSnooze: onSnoozeRow,
+                onUnsnooze: onUnsnoozeRow,
+              }
+            )
+          );
+        })}
       </div>
     </div>
   );
@@ -974,6 +1193,12 @@ function ChronoSection({
   onDismiss,
   onDismissThread,
   onMarkIdsRead,
+  snoozePendingIndex,
+  snoozedThreads,
+  snoozeRenderTime,
+  onConsumeSnoozePending,
+  onSnoozeRow,
+  onUnsnoozeRow,
 }: {
   section: ContextSection;
   groupByContext: boolean;
@@ -983,6 +1208,12 @@ function ChronoSection({
   onDismiss: (id: string) => void;
   onDismissThread: (correlationId: string) => void;
   onMarkIdsRead: (ids: string[], options: { resetLastClosed: boolean }) => void;
+  snoozePendingIndex: number | null;
+  snoozedThreads: Record<string, number>;
+  snoozeRenderTime: number;
+  onConsumeSnoozePending: () => void;
+  onSnoozeRow: (row: FlatRow, option: SnoozeDurationOption) => void;
+  onUnsnoozeRow: (row: FlatRow) => void;
 } & RovingSectionProps) {
   const sectionUnreadIds = section.groups.flatMap((g) =>
     g.entries.filter((e) => !e.seenAsToast).map((e) => e.id)
@@ -1006,6 +1237,7 @@ function ChronoSection({
         {section.groups.map((group, idx) => {
           const groupKey = group.correlationId ?? group.entries[0]!.id;
           const isDivider = dividerGroupId !== null && groupKey === dividerGroupId;
+          const flatIndex = indexOffset + idx;
           return (
             <div key={groupKey}>
               {isDivider && (
@@ -1015,13 +1247,30 @@ function ChronoSection({
                   onMarkRead={() => onMarkIdsRead(newSinceUnreadIds, { resetLastClosed: true })}
                 />
               )}
-              {renderGroup(group, onDismiss, onDismissThread, {
-                flatIndex: indexOffset + idx,
-                focusedIndex,
-                setRowRef,
-                onRowFocus,
-                onDropdownOpenChange,
-              })}
+              {renderGroup(
+                group,
+                onDismiss,
+                onDismissThread,
+                {
+                  flatIndex,
+                  focusedIndex,
+                  setRowRef,
+                  onRowFocus,
+                  onDropdownOpenChange,
+                },
+                buildSnoozeProps(
+                  group,
+                  flatIndex,
+                  snoozePendingIndex,
+                  snoozedThreads,
+                  snoozeRenderTime,
+                  {
+                    onConsumeSnoozePending,
+                    onSnooze: onSnoozeRow,
+                    onUnsnooze: onUnsnoozeRow,
+                  }
+                )
+              )}
             </div>
           );
         })}
@@ -1038,11 +1287,21 @@ interface RowRovingProps {
   onDropdownOpenChange: (open: boolean) => void;
 }
 
+interface SnoozeRowProps {
+  isSnoozePending: boolean;
+  isSnoozed: boolean;
+  snoozedUntil: number | undefined;
+  onConsumeSnoozePending: () => void;
+  onSnooze: (option: SnoozeDurationOption) => void;
+  onUnsnooze: () => void;
+}
+
 function renderGroup(
   group: ThreadGroup,
   onDismiss: (id: string) => void,
   onDismissThread: (correlationId: string) => void,
-  roving: RowRovingProps
+  roving: RowRovingProps,
+  snooze: SnoozeRowProps
 ) {
   const isFocused = roving.flatIndex === roving.focusedIndex;
   const tabIndex = isFocused ? 0 : -1;
@@ -1059,6 +1318,12 @@ function renderGroup(
         tabIndex={tabIndex}
         onRowFocus={handleFocus}
         onDropdownOpenChange={roving.onDropdownOpenChange}
+        isSnoozePending={snooze.isSnoozePending}
+        isSnoozed={snooze.isSnoozed}
+        snoozedUntil={snooze.snoozedUntil}
+        onConsumeSnoozePending={snooze.onConsumeSnoozePending}
+        onSnooze={snooze.onSnooze}
+        onUnsnooze={snooze.onUnsnooze}
       />
     );
   }
@@ -1074,8 +1339,40 @@ function renderGroup(
       role="listitem"
       onFocus={handleFocus}
       onDropdownOpenChange={roving.onDropdownOpenChange}
+      isSnoozePending={snooze.isSnoozePending}
+      isSnoozed={snooze.isSnoozed}
+      snoozedUntil={snooze.snoozedUntil}
+      onConsumeSnoozePending={snooze.onConsumeSnoozePending}
+      onSnooze={snooze.onSnooze}
+      onUnsnooze={snooze.onUnsnooze}
     />
   );
+}
+
+function buildSnoozeProps(
+  group: ThreadGroup,
+  flatIndex: number,
+  snoozePendingIndex: number | null,
+  snoozedThreads: Record<string, number>,
+  now: number,
+  handlers: {
+    onConsumeSnoozePending: () => void;
+    onSnooze: (row: FlatRow, option: SnoozeDurationOption) => void;
+    onUnsnooze: (row: FlatRow) => void;
+  }
+): SnoozeRowProps {
+  const row = buildFlatRow(group);
+  const snoozedUntil = group.correlationId ? snoozedThreads[group.correlationId] : undefined;
+  const isSnoozed =
+    typeof snoozedUntil === "number" && Number.isFinite(snoozedUntil) && snoozedUntil > now;
+  return {
+    isSnoozePending: snoozePendingIndex === flatIndex && !!group.correlationId,
+    isSnoozed,
+    snoozedUntil: isSnoozed ? snoozedUntil : undefined,
+    onConsumeSnoozePending: handlers.onConsumeSnoozePending,
+    onSnooze: (option) => handlers.onSnooze(row, option),
+    onUnsnooze: () => handlers.onUnsnooze(row),
+  };
 }
 
 function ContextSectionHeader({
@@ -1157,6 +1454,12 @@ function NotificationThread({
   tabIndex,
   onRowFocus,
   onDropdownOpenChange,
+  isSnoozePending,
+  isSnoozed,
+  snoozedUntil,
+  onConsumeSnoozePending,
+  onSnooze,
+  onUnsnooze,
 }: {
   group: ThreadGroup;
   onDismiss: () => void;
@@ -1164,6 +1467,12 @@ function NotificationThread({
   tabIndex?: number;
   onRowFocus?: () => void;
   onDropdownOpenChange?: (open: boolean) => void;
+  isSnoozePending?: boolean;
+  isSnoozed?: boolean;
+  snoozedUntil?: number;
+  onConsumeSnoozePending?: () => void;
+  onSnooze?: (option: SnoozeDurationOption) => void;
+  onUnsnooze?: () => void;
 }) {
   const latest = group.entries[0];
   const isNew = group.entries.some((e) => !e.seenAsToast);
@@ -1201,6 +1510,12 @@ function NotificationThread({
         isNew={isNew}
         onDismiss={onDismiss}
         onDropdownOpenChange={onDropdownOpenChange}
+        isSnoozePending={isSnoozePending}
+        isSnoozed={isSnoozed}
+        snoozedUntil={snoozedUntil}
+        onConsumeSnoozePending={onConsumeSnoozePending}
+        onSnooze={onSnooze}
+        onUnsnooze={onUnsnooze}
       />
     </div>
   );

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -681,8 +681,21 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
 
   const handleMarkAllRead = () => {
     // Archived entries are already done; they must never appear in the
-    // mark-all-read undo set or the "Marked N as read" count.
-    const ids = entries.filter((e) => !e.seenAsToast && !e.archivedAt).map((e) => e.id);
+    // mark-all-read undo set or the "Marked N as read" count. Snoozed
+    // threads are explicit deferrals — silently marking them read would
+    // override the user's choice and the resurfaced row would have no
+    // unread dot when its snooze expires.
+    const now = Date.now();
+    const ids = entries
+      .filter((e) => {
+        if (e.seenAsToast || e.archivedAt) return false;
+        if (e.correlationId && snoozedThreads[e.correlationId] !== undefined) {
+          const until = snoozedThreads[e.correlationId];
+          if (typeof until === "number" && until > now) return false;
+        }
+        return true;
+      })
+      .map((e) => e.id);
     if (filter === "unread") {
       setFrozenUnreadIds(new Set(ids));
     }

--- a/src/components/Notifications/NotificationCenterEntry.tsx
+++ b/src/components/Notifications/NotificationCenterEntry.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type Ref } from "react";
-import { CheckCircle2, XCircle, Info, AlertTriangle, MoreHorizontal, X } from "lucide-react";
+import { CheckCircle2, XCircle, Info, AlertTriangle, Clock, MoreHorizontal, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { NotificationHistoryEntry } from "@/store/slices/notificationHistorySlice";
 import { actionService } from "@/services/ActionService";
@@ -15,8 +15,28 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  SNOOZE_DURATION_OPTIONS,
+  SNOOZE_LABEL,
+  type SnoozeDurationOption,
+} from "@shared/utils/snoozeTimestamps";
+
+const snoozedUntilFormatter = new Intl.DateTimeFormat(undefined, {
+  weekday: "short",
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+function formatSnoozedUntil(snoozedUntil: number): string {
+  const target = new Date(snoozedUntil);
+  return snoozedUntilFormatter.format(target);
+}
 
 const TYPE_CONFIG = {
   success: { icon: CheckCircle2, className: "text-status-success" },
@@ -84,6 +104,18 @@ interface NotificationCenterEntryProps {
   role?: string;
   onFocus?: () => void;
   onDropdownOpenChange?: (open: boolean) => void;
+  /**
+   * When true, the parent (NotificationCenter) is requesting that the snooze
+   * picker open programmatically for this row — set by the `h` keybinding.
+   * The row consumes the request via `onConsumeSnoozePending` after opening
+   * so the same flag doesn't reopen the menu on subsequent renders.
+   */
+  isSnoozePending?: boolean;
+  isSnoozed?: boolean;
+  snoozedUntil?: number;
+  onConsumeSnoozePending?: () => void;
+  onSnooze?: (option: SnoozeDurationOption) => void;
+  onUnsnooze?: () => void;
 }
 
 export function NotificationCenterEntry({
@@ -97,6 +129,12 @@ export function NotificationCenterEntry({
   role,
   onFocus,
   onDropdownOpenChange,
+  isSnoozePending = false,
+  isSnoozed = false,
+  snoozedUntil,
+  onConsumeSnoozePending,
+  onSnooze,
+  onUnsnooze,
 }: NotificationCenterEntryProps) {
   const config = TYPE_CONFIG[displayType ?? entry.type];
   const Icon = config.icon;
@@ -234,54 +272,26 @@ export function NotificationCenterEntry({
             </span>
           );
         })()}
-        {(entry.context?.projectId || entry.context?.eventKind) &&
-          (() => {
-            const eventKind = entry.context?.eventKind;
-            return (
-              <DropdownMenu onOpenChange={onDropdownOpenChange}>
-                <DropdownMenuTrigger asChild>
-                  <button
-                    type="button"
-                    aria-label="Notification options"
-                    onClick={(e) => e.stopPropagation()}
-                    className="opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100 focus:opacity-100 data-[state=open]:opacity-100 h-4 w-4 flex items-center justify-center rounded text-daintree-text/40 hover:text-daintree-text/70 transition-opacity"
-                  >
-                    <MoreHorizontal className="h-3 w-3" />
-                  </button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" sideOffset={4}>
-                  {isNotificationEventKind(eventKind) && (
-                    <DropdownMenuItem
-                      onSelect={() => {
-                        const projectId = entry.context?.projectId;
-                        if (!isNotificationEventKind(eventKind)) return;
-                        void actionService.dispatch("project.silenceNotificationKind", {
-                          kind: eventKind,
-                          projectId,
-                        });
-                      }}
-                    >
-                      Silence {EVENT_KIND_LABEL[eventKind]}
-                      {entry.context?.projectId && eventKind !== "uiFeedback"
-                        ? " from this project"
-                        : ""}
-                    </DropdownMenuItem>
-                  )}
-                  {entry.context?.projectId && (
-                    <DropdownMenuItem
-                      onSelect={() => {
-                        const projectId = entry.context?.projectId;
-                        if (!projectId) return;
-                        void actionService.dispatch("project.muteNotifications", { projectId });
-                      }}
-                    >
-                      Mute project notifications
-                    </DropdownMenuItem>
-                  )}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            );
-          })()}
+        <RowOptionsMenu
+          entry={entry}
+          onDropdownOpenChange={onDropdownOpenChange}
+          isSnoozePending={isSnoozePending}
+          isSnoozed={isSnoozed}
+          snoozedUntil={snoozedUntil}
+          onConsumeSnoozePending={onConsumeSnoozePending}
+          onSnooze={onSnooze}
+          onUnsnooze={onUnsnooze}
+        />
+        {isSnoozed && snoozedUntil !== undefined && (
+          <span
+            data-testid="notification-snoozed-indicator"
+            title={`Snoozed until ${formatSnoozedUntil(snoozedUntil)}`}
+            aria-label={`Snoozed until ${formatSnoozedUntil(snoozedUntil)}`}
+            className="inline-flex h-4 w-4 items-center justify-center text-daintree-text/40"
+          >
+            <Clock className="h-3 w-3" aria-hidden="true" />
+          </span>
+        )}
         {onDismiss && (
           <button
             type="button"
@@ -297,5 +307,129 @@ export function NotificationCenterEntry({
         )}
       </div>
     </div>
+  );
+}
+
+interface RowOptionsMenuProps {
+  entry: NotificationHistoryEntry;
+  onDropdownOpenChange?: (open: boolean) => void;
+  isSnoozePending: boolean;
+  isSnoozed: boolean;
+  snoozedUntil: number | undefined;
+  onConsumeSnoozePending?: () => void;
+  onSnooze?: (option: SnoozeDurationOption) => void;
+  onUnsnooze?: () => void;
+}
+
+function RowOptionsMenu({
+  entry,
+  onDropdownOpenChange,
+  isSnoozePending,
+  isSnoozed,
+  snoozedUntil,
+  onConsumeSnoozePending,
+  onSnooze,
+  onUnsnooze,
+}: RowOptionsMenuProps) {
+  const eventKind = entry.context?.eventKind;
+  const hasContextActions = isNotificationEventKind(eventKind) || !!entry.context?.projectId;
+  const supportsSnooze = !!entry.correlationId && !!onSnooze;
+  const hasActions = hasContextActions || supportsSnooze;
+  const [open, setOpen] = useState(false);
+
+  // Programmatic open from the parent's `h` keybinding. Open exactly once
+  // per pending request and consume the flag in the same effect so the menu
+  // doesn't re-open on subsequent renders.
+  useEffect(() => {
+    if (!isSnoozePending) return;
+    if (!supportsSnooze) {
+      onConsumeSnoozePending?.();
+      return;
+    }
+    setOpen(true);
+    onConsumeSnoozePending?.();
+  }, [isSnoozePending, supportsSnooze, onConsumeSnoozePending]);
+
+  if (!hasActions) return null;
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    onDropdownOpenChange?.(next);
+  };
+
+  return (
+    <DropdownMenu open={open} onOpenChange={handleOpenChange}>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label="Notification options"
+          onClick={(e) => e.stopPropagation()}
+          className="opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100 focus:opacity-100 data-[state=open]:opacity-100 h-4 w-4 flex items-center justify-center rounded text-daintree-text/40 hover:text-daintree-text/70 transition-opacity"
+        >
+          <MoreHorizontal className="h-3 w-3" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" sideOffset={4}>
+        {supportsSnooze &&
+          (isSnoozed ? (
+            <DropdownMenuItem
+              onSelect={() => {
+                onUnsnooze?.();
+              }}
+            >
+              <Clock className="mr-2 h-3 w-3" aria-hidden="true" />
+              {snoozedUntil !== undefined
+                ? `Snoozed until ${formatSnoozedUntil(snoozedUntil)} · Unsnooze`
+                : "Unsnooze"}
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>
+                <Clock className="mr-2 h-3 w-3" aria-hidden="true" />
+                Snooze
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                {SNOOZE_DURATION_OPTIONS.map((option) => (
+                  <DropdownMenuItem
+                    key={option}
+                    onSelect={() => {
+                      onSnooze?.(option);
+                    }}
+                  >
+                    {SNOOZE_LABEL[option]}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          ))}
+        {supportsSnooze && hasContextActions && <DropdownMenuSeparator />}
+        {isNotificationEventKind(eventKind) && (
+          <DropdownMenuItem
+            onSelect={() => {
+              const projectId = entry.context?.projectId;
+              if (!isNotificationEventKind(eventKind)) return;
+              void actionService.dispatch("project.silenceNotificationKind", {
+                kind: eventKind,
+                projectId,
+              });
+            }}
+          >
+            Silence {EVENT_KIND_LABEL[eventKind]}
+            {entry.context?.projectId && eventKind !== "uiFeedback" ? " from this project" : ""}
+          </DropdownMenuItem>
+        )}
+        {entry.context?.projectId && (
+          <DropdownMenuItem
+            onSelect={() => {
+              const projectId = entry.context?.projectId;
+              if (!projectId) return;
+              void actionService.dispatch("project.muteNotifications", { projectId });
+            }}
+          >
+            Mute project notifications
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/src/components/Notifications/useSnoozeExpiryTimer.ts
+++ b/src/components/Notifications/useSnoozeExpiryTimer.ts
@@ -1,0 +1,43 @@
+import { useEffect } from "react";
+
+/**
+ * Schedules a single `setTimeout` for the nearest snooze expiry. When it
+ * fires, calls `clearExpiredSnoozes(now)` so the store drops every expired
+ * key in one write and any rows it was hiding reappear in the All/Unread
+ * tabs. Re-arms whenever `snoozedThreads` changes (new snooze added, one
+ * cleared early). Skips entirely when nothing is snoozed.
+ *
+ * Cleanup returns `clearTimeout` so React 19 StrictMode's double-mount in
+ * dev does not leave a dangling timer that double-fires.
+ */
+export function useSnoozeExpiryTimer(
+  snoozedThreads: Record<string, number>,
+  clearExpiredSnoozes: (now: number) => void
+): void {
+  useEffect(() => {
+    let nextExpiry = Infinity;
+    for (const value of Object.values(snoozedThreads)) {
+      if (typeof value === "number" && Number.isFinite(value) && value < nextExpiry) {
+        nextExpiry = value;
+      }
+    }
+    if (!Number.isFinite(nextExpiry)) return;
+    const now = Date.now();
+    if (nextExpiry <= now) {
+      // Past-due expiry on mount — flush immediately rather than schedule a
+      // 0ms timer. setTimeout(0) would still defer past this render cycle.
+      clearExpiredSnoozes(now);
+      return;
+    }
+    const delay = nextExpiry - now;
+    let disposed = false;
+    const id = setTimeout(() => {
+      if (disposed) return;
+      clearExpiredSnoozes(Date.now());
+    }, delay);
+    return () => {
+      disposed = true;
+      clearTimeout(id);
+    };
+  }, [snoozedThreads, clearExpiredSnoozes]);
+}

--- a/src/components/Notifications/useSnoozeExpiryTimer.ts
+++ b/src/components/Notifications/useSnoozeExpiryTimer.ts
@@ -1,11 +1,20 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+
+// Browsers clamp `setTimeout` to a signed 32-bit max (~24.8 days). A snooze
+// scheduled past this would fire the timer early, the no-op sweep returns,
+// and no further timer is scheduled — the snooze would never visibly
+// expire. Capping at this max and re-arming on each fire lets the timer
+// chain across the boundary while still cooperating with React 19
+// StrictMode cleanup.
+const MAX_TIMEOUT_MS = 2_147_483_647;
 
 /**
  * Schedules a single `setTimeout` for the nearest snooze expiry. When it
  * fires, calls `clearExpiredSnoozes(now)` so the store drops every expired
  * key in one write and any rows it was hiding reappear in the All/Unread
  * tabs. Re-arms whenever `snoozedThreads` changes (new snooze added, one
- * cleared early). Skips entirely when nothing is snoozed.
+ * cleared early) and after each clamped fire for snoozes scheduled past
+ * the browser timer cap. Skips entirely when nothing is snoozed.
  *
  * Cleanup returns `clearTimeout` so React 19 StrictMode's double-mount in
  * dev does not leave a dangling timer that double-fires.
@@ -14,6 +23,10 @@ export function useSnoozeExpiryTimer(
   snoozedThreads: Record<string, number>,
   clearExpiredSnoozes: (now: number) => void
 ): void {
+  // Counter that increments after each clamped fire to re-trigger the
+  // effect — `snoozedThreads` is unchanged when the sweep was a no-op, so
+  // we need an explicit re-arm trigger.
+  const [armTick, setArmTick] = useState(0);
   useEffect(() => {
     let nextExpiry = Infinity;
     for (const value of Object.values(snoozedThreads)) {
@@ -29,15 +42,22 @@ export function useSnoozeExpiryTimer(
       clearExpiredSnoozes(now);
       return;
     }
-    const delay = nextExpiry - now;
+    const delay = Math.min(nextExpiry - now, MAX_TIMEOUT_MS);
     let disposed = false;
     const id = setTimeout(() => {
       if (disposed) return;
       clearExpiredSnoozes(Date.now());
+      // The sweep may have been a no-op when `delay` was clamped below the
+      // real expiry — bump the arm tick so the effect re-runs and schedules
+      // the next chunk of the wait.
+      setArmTick((n) => n + 1);
     }, delay);
     return () => {
       disposed = true;
       clearTimeout(id);
     };
-  }, [snoozedThreads, clearExpiredSnoozes]);
+    // armTick is read inside setArmTick (functional update), so React's
+    // exhaustive-deps lint flags it as a dependency — including it gives
+    // the re-arm behavior we want.
+  }, [snoozedThreads, clearExpiredSnoozes, armTick]);
 }

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -2920,6 +2920,78 @@ describe("notify() — thread re-promotion (#9008)", () => {
     // to the summary row) rather than bypassing the rate limiter.
     expect(useNotificationStore.getState().notifications.length).toBe(toastsBefore);
   });
+
+  describe("snooze auto-resurface (#9200)", () => {
+    it("clears the snooze when a thread escalates", () => {
+      seedThread([seedEntry({ type: "info", correlationId: "build" })]);
+      useNotificationHistoryStore.setState({
+        snoozedThreads: { build: Date.now() + 60_000 },
+      });
+      notify({
+        type: "warning",
+        correlationId: "build",
+        message: "Build degraded",
+        priority: "low",
+      });
+      expect(useNotificationHistoryStore.getState().snoozedThreads["build"]).toBeUndefined();
+    });
+
+    it("keeps the snooze when a same-severity update lands on a snoozed thread", () => {
+      seedThread([seedEntry({ type: "info", correlationId: "build" })]);
+      const until = Date.now() + 60_000;
+      useNotificationHistoryStore.setState({ snoozedThreads: { build: until } });
+      notify({
+        type: "info",
+        correlationId: "build",
+        message: "Still building",
+        priority: "low",
+      });
+      expect(useNotificationHistoryStore.getState().snoozedThreads["build"]).toBe(until);
+    });
+
+    it("clears the snooze on an urgent payload regardless of severity", () => {
+      seedThread([seedEntry({ type: "info", correlationId: "build" })]);
+      useNotificationHistoryStore.setState({
+        snoozedThreads: { build: Date.now() + 60_000 },
+      });
+      notify({
+        type: "info",
+        correlationId: "build",
+        message: "Urgent ping",
+        priority: "low",
+        urgent: true,
+      });
+      expect(useNotificationHistoryStore.getState().snoozedThreads["build"]).toBeUndefined();
+    });
+
+    it("leaves snoozes on other correlationIds untouched", () => {
+      seedThread([seedEntry({ type: "info", correlationId: "build" })]);
+      const otherUntil = Date.now() + 60_000;
+      useNotificationHistoryStore.setState({
+        snoozedThreads: {
+          build: Date.now() + 60_000,
+          unrelated: otherUntil,
+        },
+      });
+      notify({
+        type: "warning",
+        correlationId: "build",
+        message: "Escalated",
+        priority: "low",
+      });
+      const after = useNotificationHistoryStore.getState().snoozedThreads;
+      expect(after["build"]).toBeUndefined();
+      expect(after["unrelated"]).toBe(otherUntil);
+    });
+
+    it("does nothing when the incoming notify has no correlationId", () => {
+      useNotificationHistoryStore.setState({
+        snoozedThreads: { build: Date.now() + 60_000 },
+      });
+      notify({ type: "error", message: "Lone error", priority: "low" });
+      expect(useNotificationHistoryStore.getState().snoozedThreads["build"]).toBeDefined();
+    });
+  });
 });
 
 describe("EVENT_POLICY manifest routing", () => {

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -2991,6 +2991,35 @@ describe("notify() — thread re-promotion (#9008)", () => {
       notify({ type: "error", message: "Lone error", priority: "low" });
       expect(useNotificationHistoryStore.getState().snoozedThreads["build"]).toBeDefined();
     });
+
+    it("grid-bar path clears the snooze when the same predicate would re-promote", () => {
+      seedThread([seedEntry({ type: "info", correlationId: "build" })]);
+      useNotificationHistoryStore.setState({
+        snoozedThreads: { build: Date.now() + 60_000 },
+      });
+      notify({
+        type: "warning",
+        correlationId: "build",
+        message: "Inline status escalation",
+        priority: "low",
+        placement: "grid-bar",
+      });
+      expect(useNotificationHistoryStore.getState().snoozedThreads["build"]).toBeUndefined();
+    });
+
+    it("grid-bar path keeps the snooze on a routine same-severity update", () => {
+      seedThread([seedEntry({ type: "info", correlationId: "build" })]);
+      const until = Date.now() + 60_000;
+      useNotificationHistoryStore.setState({ snoozedThreads: { build: until } });
+      notify({
+        type: "info",
+        correlationId: "build",
+        message: "Inline status routine update",
+        priority: "low",
+        placement: "grid-bar",
+      });
+      expect(useNotificationHistoryStore.getState().snoozedThreads["build"]).toBe(until);
+    });
   });
 });
 

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -877,6 +877,21 @@ export function notify(payload: NotifyPayload): string {
   const isQuiet = !payload.urgent && (Date.now() < _quietUntil || isScheduledQuietHours());
 
   if (placement === "grid-bar") {
+    // Auto-resurface: grid-bar bypasses the toast gate but still mutates
+    // history. Mirror the post-gate `clearSnooze` from the main path so an
+    // escalating/un-snoozing grid-bar entry on a snoozed thread doesn't
+    // land hidden behind a stale snooze. Same predicate as the main path so
+    // routine same-severity grid-bar updates keep the snooze intact.
+    if (correlationId && !payload.transient) {
+      const wouldRePromote = shouldReToast(
+        type,
+        getEntriesByCorrelationId(correlationId),
+        payload.urgent
+      );
+      if (wouldRePromote) {
+        useNotificationHistoryStore.getState().clearSnooze(correlationId);
+      }
+    }
     const entryId =
       historyMessage && !payload.transient
         ? useNotificationHistoryStore.getState().addEntry({

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -921,6 +921,17 @@ export function notify(payload: NotifyPayload): string {
       : false;
   const effectiveShouldToast = shouldToast || shouldToastThread;
 
+  // Auto-resurface: a snoozed thread that re-toasts (escalated severity,
+  // urgent, or full un-snooze) must clear its snooze before `addEntry`
+  // lands the new history row. Running this before the write keeps the
+  // store atomically consistent — observers never see an unread badge that
+  // counts the new entry while still hiding its thread behind the snooze
+  // filter. Routine same-severity updates do not pass `shouldReToast` and
+  // therefore stay snoozed, preserving the user's defer choice.
+  if (effectiveShouldToast && correlationId) {
+    useNotificationHistoryStore.getState().clearSnooze(correlationId);
+  }
+
   // Per-source rate-limit gate. Only consumes a token (and routes to the
   // overflow summary inbox row) when the notification would actually toast
   // in the current state — blurred/quiet/disabled paths already deliver

--- a/src/store/__tests__/notificationHistoryStore.test.ts
+++ b/src/store/__tests__/notificationHistoryStore.test.ts
@@ -1344,6 +1344,51 @@ describe("notificationHistorySlice", () => {
       expect(getState().snoozedThreads["thread-1"]).toBeUndefined();
     });
 
+    it("dismissEntry clears the snooze when the dismissed entry was the last active one for that correlationId", () => {
+      addEntry({ correlationId: "solo", message: "only entry" });
+      const id = getState().entries[0]!.id;
+      getState().snoozeThread("solo", Date.now() + 60_000);
+      getState().dismissEntry(id);
+      expect(getState().snoozedThreads["solo"]).toBeUndefined();
+    });
+
+    it("dismissEntry keeps the snooze when other active entries share the correlationId", () => {
+      addEntry({ correlationId: "shared", message: "first" });
+      addEntry({ correlationId: "shared", message: "second" });
+      const until = Date.now() + 60_000;
+      getState().snoozeThread("shared", until);
+      const firstId = getState().entries[1]!.id;
+      getState().dismissEntry(firstId);
+      expect(getState().snoozedThreads["shared"]).toBe(until);
+    });
+
+    it("archiveEntry clears the snooze when archiving the last active entry for that correlationId", () => {
+      addEntry({ correlationId: "solo-arch", message: "only entry" });
+      const id = getState().entries[0]!.id;
+      getState().snoozeThread("solo-arch", Date.now() + 60_000);
+      getState().archiveEntry(id);
+      expect(getState().snoozedThreads["solo-arch"]).toBeUndefined();
+    });
+
+    it("archiveEntry keeps the snooze when other active entries share the correlationId", () => {
+      addEntry({ correlationId: "shared-arch", message: "first" });
+      addEntry({ correlationId: "shared-arch", message: "second" });
+      const until = Date.now() + 60_000;
+      getState().snoozeThread("shared-arch", until);
+      const firstId = getState().entries[1]!.id;
+      getState().archiveEntry(firstId);
+      expect(getState().snoozedThreads["shared-arch"]).toBe(until);
+    });
+
+    it("dismissEntry on an uncorrelated entry does not touch the snooze map", () => {
+      addEntry({ message: "uncorrelated" });
+      const id = getState().entries[0]!.id;
+      const until = Date.now() + 60_000;
+      getState().snoozeThread("other", until);
+      getState().dismissEntry(id);
+      expect(getState().snoozedThreads["other"]).toBe(until);
+    });
+
     it("clearAll empties snoozedThreads", () => {
       getState().snoozeThread("thread-1", Date.now() + 60_000);
       getState().clearAll();

--- a/src/store/__tests__/notificationHistoryStore.test.ts
+++ b/src/store/__tests__/notificationHistoryStore.test.ts
@@ -4,6 +4,7 @@ import {
   getEntriesByCorrelationId,
   pruneNotificationEntries,
   sanitizePersistedEntry,
+  sanitizeSnoozedThreads,
   READ_RETENTION_MS,
   ARCHIVED_RETENTION_MS,
   type NotificationHistoryEntry,
@@ -53,6 +54,7 @@ describe("notificationHistorySlice", () => {
       entries: [],
       unreadCount: 0,
       evictedToInboxCount: 0,
+      snoozedThreads: {},
     });
   });
 
@@ -1258,6 +1260,128 @@ describe("notificationHistorySlice", () => {
       });
       expect(result!.actions![0]!.actionArgs).toEqual({ panelId: "p1" });
       expect(result!.actions![0]!.variant).toBe("secondary");
+    });
+  });
+
+  describe("snoozedThreads", () => {
+    it("defaults to an empty map", () => {
+      expect(getState().snoozedThreads).toEqual({});
+    });
+
+    it("snoozeThread adds and overwrites the expiry for a correlationId", () => {
+      const until = Date.now() + 60_000;
+      getState().snoozeThread("thread-1", until);
+      expect(getState().snoozedThreads["thread-1"]).toBe(until);
+      const later = until + 60_000;
+      getState().snoozeThread("thread-1", later);
+      expect(getState().snoozedThreads["thread-1"]).toBe(later);
+    });
+
+    it("snoozeThread ignores empty correlationId and non-finite timestamps", () => {
+      getState().snoozeThread("", Date.now() + 1000);
+      getState().snoozeThread("thread-x", Number.NaN);
+      getState().snoozeThread("thread-y", Number.POSITIVE_INFINITY);
+      expect(getState().snoozedThreads).toEqual({});
+    });
+
+    it("clearSnooze removes the entry", () => {
+      getState().snoozeThread("thread-1", Date.now() + 60_000);
+      getState().clearSnooze("thread-1");
+      expect(getState().snoozedThreads["thread-1"]).toBeUndefined();
+    });
+
+    it("clearSnooze is a no-op when nothing is snoozed", () => {
+      const before = getState();
+      getState().clearSnooze("missing");
+      expect(getState()).toBe(before);
+    });
+
+    it("clearExpiredSnoozes drops only past entries", () => {
+      const now = Date.now();
+      getState().snoozeThread("future", now + 60_000);
+      getState().snoozeThread("past", now + 50);
+      getState().clearExpiredSnoozes(now + 1000);
+      expect(getState().snoozedThreads).toEqual({ future: now + 60_000 });
+    });
+
+    it("clearExpiredSnoozes is a no-op when nothing has expired", () => {
+      getState().snoozeThread("future", Date.now() + 60_000);
+      const before = getState();
+      getState().clearExpiredSnoozes(Date.now());
+      expect(getState()).toBe(before);
+    });
+
+    it("unreadCount excludes snoozed correlationIds", () => {
+      addEntry({ correlationId: "panel-1", message: "first" });
+      addEntry({ correlationId: "panel-1", message: "second" });
+      addEntry({ correlationId: "panel-2", message: "other" });
+      addEntry({ message: "uncorrelated" });
+      expect(getState().unreadCount).toBe(4);
+
+      getState().snoozeThread("panel-1", Date.now() + 60_000);
+      expect(getState().unreadCount).toBe(2);
+
+      getState().clearSnooze("panel-1");
+      expect(getState().unreadCount).toBe(4);
+    });
+
+    it("unreadCount excludes a snoozed thread when a new entry lands on it", () => {
+      getState().snoozeThread("panel-1", Date.now() + 60_000);
+      addEntry({ correlationId: "panel-1", message: "new entry" });
+      expect(getState().unreadCount).toBe(0);
+    });
+
+    it("dismissByCorrelationId clears the corresponding snooze", () => {
+      getState().snoozeThread("thread-1", Date.now() + 60_000);
+      getState().dismissByCorrelationId("thread-1");
+      expect(getState().snoozedThreads["thread-1"]).toBeUndefined();
+    });
+
+    it("archiveByCorrelationId clears the corresponding snooze", () => {
+      addEntry({ correlationId: "thread-1", message: "stuck" });
+      getState().snoozeThread("thread-1", Date.now() + 60_000);
+      getState().archiveByCorrelationId("thread-1");
+      expect(getState().snoozedThreads["thread-1"]).toBeUndefined();
+    });
+
+    it("clearAll empties snoozedThreads", () => {
+      getState().snoozeThread("thread-1", Date.now() + 60_000);
+      getState().clearAll();
+      expect(getState().snoozedThreads).toEqual({});
+    });
+  });
+
+  describe("sanitizeSnoozedThreads", () => {
+    it("returns empty map for non-object input", () => {
+      expect(sanitizeSnoozedThreads(null)).toEqual({});
+      expect(sanitizeSnoozedThreads(undefined)).toEqual({});
+      expect(sanitizeSnoozedThreads("nope")).toEqual({});
+      expect(sanitizeSnoozedThreads(42)).toEqual({});
+    });
+
+    it("drops keys with blank ids or non-numeric values", () => {
+      const result = sanitizeSnoozedThreads(
+        {
+          "": Date.now() + 60_000,
+          "thread-1": "not-a-number",
+          "thread-2": Number.NaN,
+          "thread-3": Number.POSITIVE_INFINITY,
+        },
+        Date.now()
+      );
+      expect(result).toEqual({});
+    });
+
+    it("drops keys whose snooze already expired", () => {
+      const now = Date.now();
+      const result = sanitizeSnoozedThreads(
+        {
+          past: now - 1,
+          future: now + 60_000,
+        },
+        now
+      );
+      expect(result).toEqual({ future: now + 60_000 });
     });
   });
 });

--- a/src/store/slices/notificationHistorySlice.ts
+++ b/src/store/slices/notificationHistorySlice.ts
@@ -72,10 +72,36 @@ export const READ_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 export const ARCHIVED_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 
 export const NOTIFICATION_HISTORY_STORAGE_KEY = "daintree-notification-history";
-const NOTIFICATION_HISTORY_PERSIST_VERSION = 1;
+const NOTIFICATION_HISTORY_PERSIST_VERSION = 2;
 
-function computeUnreadCount(entries: NotificationHistoryEntry[]): number {
-  return entries.filter((e) => !e.seenAsToast && e.countable !== false && !e.archivedAt).length;
+/**
+ * Returns true when `correlationId` is currently snoozed by the user.
+ * Treats expired snoozes as not-snoozed — callers don't need to manually
+ * sweep before reading. A missing `correlationId` is always not-snoozed
+ * because snooze is a thread-level affordance.
+ */
+function isSnoozedAt(
+  snoozedThreads: Record<string, number>,
+  correlationId: string | undefined,
+  now: number
+): boolean {
+  if (!correlationId) return false;
+  const until = snoozedThreads[correlationId];
+  return typeof until === "number" && until > now;
+}
+
+function computeUnreadCount(
+  entries: NotificationHistoryEntry[],
+  snoozedThreads: Record<string, number>,
+  now: number = Date.now()
+): number {
+  return entries.filter((e) => {
+    if (e.seenAsToast) return false;
+    if (e.countable === false) return false;
+    if (e.archivedAt) return false;
+    if (isSnoozedAt(snoozedThreads, e.correlationId, now)) return false;
+    return true;
+  }).length;
 }
 
 /**
@@ -183,8 +209,35 @@ export function sanitizePersistedEntry(raw: unknown): NotificationHistoryEntry |
   };
 }
 
+/**
+ * Defensively coerce the persisted `snoozedThreads` blob into a clean map.
+ * Strips non-object input, blank keys, non-finite values, and entries whose
+ * snooze has already expired (no point hydrating a snooze that fires
+ * immediately and then forces a re-render to clear itself).
+ */
+export function sanitizeSnoozedThreads(
+  raw: unknown,
+  now: number = Date.now()
+): Record<string, number> {
+  if (!raw || typeof raw !== "object") return {};
+  const out: Record<string, number> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof key !== "string" || key.length === 0) continue;
+    if (typeof value !== "number" || !Number.isFinite(value)) continue;
+    if (value <= now) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
 interface PersistedNotificationHistoryShape {
   entries: NotificationHistoryEntry[];
+  /**
+   * Map of `correlationId` → expiry epoch-ms timestamp. Snoozed threads are
+   * hidden from the All/Unread/Archived tabs, surface only in the Snoozed
+   * tab, and are excluded from the unread badge count.
+   */
+  snoozedThreads?: Record<string, number>;
 }
 
 interface NotificationHistoryState {
@@ -196,6 +249,15 @@ interface NotificationHistoryState {
    * and the toolbar bell arrival animation. Reset by `resetEvictedCount`.
    */
   evictedToInboxCount: number;
+  /**
+   * Per-thread snooze map: `correlationId` → expiry epoch-ms. While a thread
+   * is snoozed, its entries are hidden from All/Unread/Archived, do not count
+   * toward `unreadCount`, and only surface in the Snoozed tab. The snooze
+   * clears automatically (a) when the timestamp passes (via
+   * `clearExpiredSnoozes`) or (b) when a `notify()` call with a matching
+   * `correlationId` triggers `shouldReToast` (the thread escalated).
+   */
+  snoozedThreads: Record<string, number>;
   addEntry: (entry: AddEntryInput) => string;
   /**
    * Replaces the `message` text on an existing entry without bumping
@@ -245,6 +307,23 @@ interface NotificationHistoryState {
    * doesn't fire on every tick.
    */
   pruneExpiredEntries: (now?: number) => void;
+  /**
+   * Snooze a thread until `snoozedUntil` (epoch ms). Overwrites any prior
+   * snooze for the same `correlationId`. Recomputes `unreadCount` so the
+   * badge updates atomically with the visibility change.
+   */
+  snoozeThread: (correlationId: string, snoozedUntil: number) => void;
+  /**
+   * Remove `correlationId` from the snooze map. No-op when the thread is not
+   * snoozed.
+   */
+  clearSnooze: (correlationId: string) => void;
+  /**
+   * Drop every snooze whose expiry has passed. Called on a `setTimeout`
+   * registered by `useSnoozeExpiryTimer`. No-op when nothing has expired so
+   * the persist write doesn't fire on every tick.
+   */
+  clearExpiredSnoozes: (now?: number) => void;
 }
 
 export const useNotificationHistoryStore = create<NotificationHistoryState>()(
@@ -253,6 +332,7 @@ export const useNotificationHistoryStore = create<NotificationHistoryState>()(
       entries: [],
       unreadCount: 0,
       evictedToInboxCount: 0,
+      snoozedThreads: {},
       addEntry: (entry) => {
         const { supersedes, ...rest } = entry;
         const seenAsToast = rest.seenAsToast ?? false;
@@ -290,7 +370,10 @@ export const useNotificationHistoryStore = create<NotificationHistoryState>()(
 
           const candidate = [newEntry, ...sourceEntries];
           const updated = pruneNotificationEntries(candidate, now);
-          return { entries: updated, unreadCount: computeUnreadCount(updated) };
+          return {
+            entries: updated,
+            unreadCount: computeUnreadCount(updated, state.snoozedThreads, now),
+          };
         });
         return newEntry.id;
       },
@@ -316,7 +399,7 @@ export const useNotificationHistoryStore = create<NotificationHistoryState>()(
           );
           return {
             entries,
-            unreadCount: computeUnreadCount(entries),
+            unreadCount: computeUnreadCount(entries, state.snoozedThreads),
             evictedToInboxCount: options?.silent
               ? state.evictedToInboxCount
               : state.evictedToInboxCount + 1,
@@ -327,15 +410,21 @@ export const useNotificationHistoryStore = create<NotificationHistoryState>()(
           const entries = state.entries.filter((e) => e.id !== id);
           return {
             entries,
-            unreadCount: computeUnreadCount(entries),
+            unreadCount: computeUnreadCount(entries, state.snoozedThreads),
           };
         }),
       dismissByCorrelationId: (correlationId) =>
         set((state) => {
           const entries = state.entries.filter((e) => e.correlationId !== correlationId);
+          // Clearing the thread also clears its snooze — a dismissed thread
+          // shouldn't reappear in the Snoozed tab as a ghost row with no
+          // entries.
+          const snoozedThreads = { ...state.snoozedThreads };
+          delete snoozedThreads[correlationId];
           return {
             entries,
-            unreadCount: computeUnreadCount(entries),
+            snoozedThreads,
+            unreadCount: computeUnreadCount(entries, snoozedThreads),
           };
         }),
       archiveEntry: (id) =>
@@ -348,7 +437,7 @@ export const useNotificationHistoryStore = create<NotificationHistoryState>()(
           );
           return {
             entries,
-            unreadCount: computeUnreadCount(entries),
+            unreadCount: computeUnreadCount(entries, state.snoozedThreads, now),
           };
         }),
       archiveByCorrelationId: (correlationId) =>
@@ -363,12 +452,23 @@ export const useNotificationHistoryStore = create<NotificationHistoryState>()(
             return e;
           });
           if (!mutated) return state;
+          // Archiving the whole thread also clears its snooze — the user has
+          // resolved it, so it shouldn't surface again at the snooze expiry.
+          const snoozedThreads = state.snoozedThreads[correlationId]
+            ? (() => {
+                const next = { ...state.snoozedThreads };
+                delete next[correlationId];
+                return next;
+              })()
+            : state.snoozedThreads;
           return {
             entries,
-            unreadCount: computeUnreadCount(entries),
+            snoozedThreads,
+            unreadCount: computeUnreadCount(entries, snoozedThreads, now),
           };
         }),
-      clearAll: () => set({ entries: [], unreadCount: 0, evictedToInboxCount: 0 }),
+      clearAll: () =>
+        set({ entries: [], unreadCount: 0, evictedToInboxCount: 0, snoozedThreads: {} }),
       markAllRead: () =>
         set((state) => ({
           unreadCount: 0,
@@ -389,7 +489,7 @@ export const useNotificationHistoryStore = create<NotificationHistoryState>()(
           if (!mutated) return state;
           return {
             entries,
-            unreadCount: computeUnreadCount(entries),
+            unreadCount: computeUnreadCount(entries, state.snoozedThreads),
           };
         }),
       markSummarized: (ids) =>
@@ -407,25 +507,95 @@ export const useNotificationHistoryStore = create<NotificationHistoryState>()(
         set((state) => {
           const filtered = pruneNotificationEntries(state.entries, now);
           if (filtered.length === state.entries.length) return state;
-          return { entries: filtered, unreadCount: computeUnreadCount(filtered) };
+          return {
+            entries: filtered,
+            unreadCount: computeUnreadCount(filtered, state.snoozedThreads, now),
+          };
+        }),
+      snoozeThread: (correlationId, snoozedUntil) => {
+        if (!correlationId || !Number.isFinite(snoozedUntil)) return;
+        set((state) => {
+          if (state.snoozedThreads[correlationId] === snoozedUntil) return state;
+          const snoozedThreads = { ...state.snoozedThreads, [correlationId]: snoozedUntil };
+          return {
+            snoozedThreads,
+            unreadCount: computeUnreadCount(state.entries, snoozedThreads),
+          };
+        });
+      },
+      clearSnooze: (correlationId) => {
+        if (!correlationId) return;
+        set((state) => {
+          if (state.snoozedThreads[correlationId] === undefined) return state;
+          const snoozedThreads = { ...state.snoozedThreads };
+          delete snoozedThreads[correlationId];
+          return {
+            snoozedThreads,
+            unreadCount: computeUnreadCount(state.entries, snoozedThreads),
+          };
+        });
+      },
+      clearExpiredSnoozes: (now = Date.now()) =>
+        set((state) => {
+          let mutated = false;
+          const next: Record<string, number> = {};
+          for (const [key, value] of Object.entries(state.snoozedThreads)) {
+            if (value > now) {
+              next[key] = value;
+            } else {
+              mutated = true;
+            }
+          }
+          if (!mutated) return state;
+          return {
+            snoozedThreads: next,
+            unreadCount: computeUnreadCount(state.entries, next, now),
+          };
         }),
     }),
     {
       name: NOTIFICATION_HISTORY_STORAGE_KEY,
       version: NOTIFICATION_HISTORY_PERSIST_VERSION,
-      storage: createDebouncedSafeJSONStorage<PersistedNotificationHistoryShape>(300),
-      // Only persist entries — unreadCount is recomputed on hydration, and
-      // evictedToInboxCount is a session-only discoverability counter that
-      // resets to 0 on every fresh load.
-      partialize: (state): PersistedNotificationHistoryShape => ({ entries: state.entries }),
+      // Storage is `unknown` instead of `PersistedNotificationHistoryShape`
+      // because `migrate` can return a pre-v2 blob shape; the persist
+      // middleware then funnels that through `merge`, which does its own
+      // defensive coercion.
+      storage: createDebouncedSafeJSONStorage<unknown>(300),
+      // Only persist entries + snoozedThreads — unreadCount is recomputed on
+      // hydration, and evictedToInboxCount is a session-only discoverability
+      // counter that resets to 0 on every fresh load.
+      partialize: (state): PersistedNotificationHistoryShape => ({
+        entries: state.entries,
+        snoozedThreads: state.snoozedThreads,
+      }),
+      // v1 → v2 adds `snoozedThreads` (per-thread snooze map, #9200). The
+      // entries shape is unchanged, so v1 blobs are otherwise valid; default
+      // the new field to an empty map and let `merge` finish the work.
+      migrate: (persistedState, version) => {
+        if (version < 2) {
+          const prev =
+            persistedState && typeof persistedState === "object"
+              ? (persistedState as Record<string, unknown>)
+              : {};
+          return { ...prev, snoozedThreads: {} };
+        }
+        return persistedState;
+      },
       merge: (persisted, current) => {
         const p = persisted as Partial<PersistedNotificationHistoryShape> | undefined;
         const rawEntries = Array.isArray(p?.entries) ? p.entries : [];
         const sanitized = rawEntries
           .map(sanitizePersistedEntry)
           .filter((e): e is NotificationHistoryEntry => e !== null);
-        const pruned = pruneNotificationEntries(sanitized, Date.now());
-        return { ...current, entries: pruned, unreadCount: computeUnreadCount(pruned) };
+        const now = Date.now();
+        const pruned = pruneNotificationEntries(sanitized, now);
+        const snoozedThreads = sanitizeSnoozedThreads(p?.snoozedThreads, now);
+        return {
+          ...current,
+          entries: pruned,
+          snoozedThreads,
+          unreadCount: computeUnreadCount(pruned, snoozedThreads, now),
+        };
       },
     }
   )

--- a/src/store/slices/notificationHistorySlice.ts
+++ b/src/store/slices/notificationHistorySlice.ts
@@ -90,6 +90,30 @@ function isSnoozedAt(
   return typeof until === "number" && until > now;
 }
 
+/**
+ * Returns a new snooze map with `correlationId` removed when no active
+ * (non-archived) entries remain for that thread, leaving the input map
+ * untouched in every other case. Called after dismiss/archive on a single
+ * entry that carried a correlationId — without this sweep the snooze map
+ * would keep keys with nothing behind them and the Snoozed tab would
+ * surface an empty ghost row.
+ */
+function clearSnoozeIfThreadGone(
+  snoozedThreads: Record<string, number>,
+  remainingEntries: NotificationHistoryEntry[],
+  correlationId: string | undefined
+): Record<string, number> {
+  if (!correlationId) return snoozedThreads;
+  if (snoozedThreads[correlationId] === undefined) return snoozedThreads;
+  const stillActive = remainingEntries.some(
+    (e) => e.correlationId === correlationId && e.archivedAt === null
+  );
+  if (stillActive) return snoozedThreads;
+  const next = { ...snoozedThreads };
+  delete next[correlationId];
+  return next;
+}
+
 function computeUnreadCount(
   entries: NotificationHistoryEntry[],
   snoozedThreads: Record<string, number>,
@@ -407,10 +431,21 @@ export const useNotificationHistoryStore = create<NotificationHistoryState>()(
         }),
       dismissEntry: (id) =>
         set((state) => {
+          const removed = state.entries.find((e) => e.id === id);
           const entries = state.entries.filter((e) => e.id !== id);
+          // If dismissing this entry leaves no other entries with the same
+          // correlationId, drop the snooze too — otherwise the snoozed-thread
+          // map keeps a key with nothing behind it ("ghost snooze") and the
+          // Snoozed tab stays visible as an empty chip.
+          const snoozedThreads = clearSnoozeIfThreadGone(
+            state.snoozedThreads,
+            entries,
+            removed?.correlationId
+          );
           return {
             entries,
-            unreadCount: computeUnreadCount(entries, state.snoozedThreads),
+            snoozedThreads,
+            unreadCount: computeUnreadCount(entries, snoozedThreads),
           };
         }),
       dismissByCorrelationId: (correlationId) =>
@@ -435,9 +470,18 @@ export const useNotificationHistoryStore = create<NotificationHistoryState>()(
           const entries = state.entries.map((e) =>
             e.id === id ? { ...e, archivedAt: now, seenAsToast: true } : e
           );
+          // If archiving this entry leaves no remaining active entries for
+          // its correlationId, clear the snooze so the Snoozed tab doesn't
+          // keep an empty ghost row.
+          const snoozedThreads = clearSnoozeIfThreadGone(
+            state.snoozedThreads,
+            entries,
+            entry.correlationId
+          );
           return {
             entries,
-            unreadCount: computeUnreadCount(entries, state.snoozedThreads, now),
+            snoozedThreads,
+            unreadCount: computeUnreadCount(entries, snoozedThreads, now),
           };
         }),
       archiveByCorrelationId: (correlationId) =>


### PR DESCRIPTION
## Summary

- Adds per-thread snooze to the notification inbox: each entry gets a `DropdownMenu.Sub` snooze picker with four durations (1h, 4h, Tomorrow 8am, Next Monday 8am), and snoozed threads vanish from All/Unread until the timer fires
- Brings the inbox closer to Linear-parity with two new keybindings: `u` to toggle read/unread, `h` to open the snooze picker on the focused row
- New Snoozed tab that only appears when at least one thread is snoozed; snoozed threads are excluded from the unread badge and from Mark all read

Resolves #9200

## Changes

- `notificationHistorySlice` — adds `snoozedThreads: Record<string, number>` map and a persist migration from v1 to v2 via `sanitizeSnoozedThreads` (strips expired and orphaned entries on load, safe for round-trips where the thread map arrives out of order)
- `useSnoozeExpiryTimer` — single-`setTimeout` hook that targets the earliest expiry and clears the snooze when it fires mid-session; cleans up on unmount and reschedules when the map changes
- Auto-resurface: when `shouldReToast` fires on an escalation or urgent entry, the snooze is cleared before `addEntry` lands so the thread comes back immediately
- `NotificationCenter` — new `snoozedThreads` derived state wired into the tab bar, unread badge, and the filtered thread lists
- `NotificationCenterEntry` — snooze picker sub-menu, keybinding handlers for `u` and `h`, and snooze affordance in the row action area
- `snoozeTimestamps.ts` — shared utility for computing the four target timestamps
- Unit tests for the store slice (`notificationHistoryStore.test.ts`), `notify.ts`, and `snoozeTimestamps.test.ts`

## Testing

- Snooze a thread → it disappears from All and Unread, appears in the Snoozed tab, badge drops
- Let the snooze expire in-session → thread reappears in All automatically
- Post a new error/urgent entry to a snoozed thread → it resurfaces immediately without waiting for expiry
- Press `u` on a focused row → read state toggles
- Press `h` on a focused row → snooze picker opens
- Reload the app with an active snooze → thread is still absent until expiry, expired snoozes are cleaned on load