### PR TITLE
feat(plugins): structured audit log for plugin-action dispatch

### DIFF
--- a/compiler-bailout-baseline.json
+++ b/compiler-bailout-baseline.json
@@ -377,7 +377,7 @@
     "pipelineErrors": []
   },
   "src/components/Diagnostics/DiagnosticsActions.tsx": {
-    "success": 4,
+    "success": 5,
     "skip": 0,
     "error": 0,
     "pipeline": 0,
@@ -408,6 +408,16 @@
   },
   "src/components/Diagnostics/LogsContent.tsx": {
     "success": 2,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Diagnostics/PerfContent.tsx": {
+    "success": 6,
     "skip": 0,
     "error": 0,
     "pipeline": 0,
@@ -2166,6 +2176,26 @@
     "skipReasons": [],
     "pipelineErrors": []
   },
+  "src/components/Settings/PluginActionAuditLogViewer.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Settings/PluginActionsSettingsTab.tsx": {
+    "success": 0,
+    "skip": 0,
+    "error": 1,
+    "pipeline": 0,
+    "hintCount": 1,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
   "src/components/Settings/PortalSettingsTab.tsx": {
     "success": 3,
     "skip": 0,
@@ -2636,6 +2666,16 @@
     "skipReasons": [],
     "pipelineErrors": []
   },
+  "src/components/Terminal/BannerOverflowMenu.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
   "src/components/Terminal/ContentGrid.tsx": {
     "success": 1,
     "skip": 0,
@@ -3008,6 +3048,16 @@
   },
   "src/components/Terminal/TerminalPane.tsx": {
     "success": 3,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Terminal/TerminalPaneSkeleton.tsx": {
+    "success": 1,
     "skip": 0,
     "error": 0,
     "pipeline": 0,
@@ -3403,7 +3453,7 @@
     "pipelineErrors": []
   },
   "src/components/Worktree/CrossWorktreeDiff.tsx": {
-    "success": 1,
+    "success": 2,
     "skip": 0,
     "error": 2,
     "pipeline": 0,
@@ -3745,7 +3795,7 @@
     "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx": {
-    "success": 1,
+    "success": 2,
     "skip": 0,
     "error": 1,
     "pipeline": 0,
@@ -5005,6 +5055,16 @@
     "pipelineErrors": []
   },
   "src/hooks/app/useHomeDir.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/hooks/app/useNotificationHistoryPruning.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,

--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 1258,
-  "moduleCount": 1258,
+  "count": 1260,
+  "moduleCount": 1260,
   "allowlist": [
     "electron/ipc/errorHandlers.ts",
     "electron/ipc/handlers/agentCapabilities.ts",
@@ -49,6 +49,7 @@
     "electron/services/IdleTerminalNotificationService.ts",
     "electron/services/McpServerService.ts",
     "electron/services/PanelSuspectLedgerService.ts",
+    "electron/services/PluginActionAuditService.ts",
     "electron/services/PluginService.ts",
     "electron/services/ProcessMemoryMonitor.ts",
     "electron/services/ProjectEnvSecureStorage.ts",
@@ -1045,6 +1046,16 @@
       "pattern": "sync-sqlite"
     },
     {
+      "file": "electron/services/PluginActionAuditService.ts",
+      "line": 249,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/PluginActionAuditService.ts",
+      "line": 252,
+      "pattern": "sync-store-get"
+    },
+    {
       "file": "electron/services/PluginService.ts",
       "line": 325,
       "pattern": "sync-store-get"
@@ -1381,22 +1392,12 @@
     },
     {
       "file": "electron/store.ts",
-      "line": 502,
+      "line": 518,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 504,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/store.ts",
-      "line": 519,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/store.ts",
-      "line": 534,
+      "line": 520,
       "pattern": "sync-fs"
     },
     {
@@ -1406,32 +1407,42 @@
     },
     {
       "file": "electron/store.ts",
-      "line": 537,
+      "line": 550,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 552,
+      "line": 551,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 554,
+      "line": 553,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 571,
+      "line": 568,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 580,
+      "line": 570,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 581,
+      "line": 587,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/store.ts",
+      "line": 596,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/store.ts",
+      "line": 597,
       "pattern": "sync-fs"
     },
     {
@@ -1646,22 +1657,27 @@
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 86,
+      "line": 87,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 169,
+      "line": 170,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 577,
+      "line": 235,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 723,
+      "line": 585,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/window/globalServicesInit.ts",
+      "line": 731,
       "pattern": "sync-store-get"
     },
     {

--- a/electron/__tests__/clipboard.test.ts
+++ b/electron/__tests__/clipboard.test.ts
@@ -8,6 +8,10 @@ vi.mock("electron", () => ({
   clipboard: { readImage: vi.fn(), writeImage: vi.fn(), writeText: vi.fn(), readText: vi.fn() },
   nativeImage: { createFromBuffer: vi.fn(), createFromPath: vi.fn() },
   ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+  // The clipboard handler transitively imports the projectStore singleton,
+  // whose constructor reads app.getPath("userData"). Include `app` so the
+  // module graph instantiates regardless of suite ordering.
+  app: { getPath: vi.fn(() => "/tmp/clipboard-test-user-data") },
 }));
 
 // clipboard.ts imports projectStore from ProjectStore.js which imports

--- a/electron/ipc/__tests__/leafPreloadNamespaces.test.ts
+++ b/electron/ipc/__tests__/leafPreloadNamespaces.test.ts
@@ -141,6 +141,12 @@ describe("leaf preload namespace bindings", () => {
       expect(PLUGIN_METHOD_CHANNELS.registerAction).toBe(CHANNELS.PLUGIN_ACTIONS_REGISTER);
       expect(PLUGIN_METHOD_CHANNELS.unregisterAction).toBe(CHANNELS.PLUGIN_ACTIONS_UNREGISTER);
       expect(PLUGIN_METHOD_CHANNELS.getPanelKinds).toBe(CHANNELS.PLUGIN_PANEL_KINDS_GET);
+      expect(PLUGIN_METHOD_CHANNELS.getAuditRecords).toBe(CHANNELS.PLUGIN_GET_AUDIT_RECORDS);
+      expect(PLUGIN_METHOD_CHANNELS.getAuditConfig).toBe(CHANNELS.PLUGIN_GET_AUDIT_CONFIG);
+      expect(PLUGIN_METHOD_CHANNELS.clearAuditLog).toBe(CHANNELS.PLUGIN_CLEAR_AUDIT_LOG);
+      expect(PLUGIN_METHOD_CHANNELS.setAuditEnabled).toBe(CHANNELS.PLUGIN_SET_AUDIT_ENABLED);
+      expect(PLUGIN_METHOD_CHANNELS.setAuditMaxRecords).toBe(CHANNELS.PLUGIN_SET_AUDIT_MAX_RECORDS);
+      expect(PLUGIN_METHOD_CHANNELS.exportAuditLog).toBe(CHANNELS.PLUGIN_EXPORT_AUDIT_LOG);
     });
 
     it("scratch matches", () => {

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -786,6 +786,12 @@ export const CHANNELS = {
   PLUGIN_PANEL_KINDS_GET: "plugin:panel-kinds-get",
   PLUGIN_FORGE_PROVIDERS_GET: "plugin:forge-providers-get",
   PLUGIN_FILE_DECORATIONS_GET: "plugin:file-decorations-get",
+  PLUGIN_GET_AUDIT_RECORDS: "plugin:get-audit-records",
+  PLUGIN_GET_AUDIT_CONFIG: "plugin:get-audit-config",
+  PLUGIN_CLEAR_AUDIT_LOG: "plugin:clear-audit-log",
+  PLUGIN_SET_AUDIT_ENABLED: "plugin:set-audit-enabled",
+  PLUGIN_SET_AUDIT_MAX_RECORDS: "plugin:set-audit-max-records",
+  PLUGIN_EXPORT_AUDIT_LOG: "plugin:export-audit-log",
 
   // Config reload channels
   APP_RELOAD_CONFIG: "app:reload-config",

--- a/electron/ipc/handlers/__tests__/events.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/events.handlers.test.ts
@@ -181,6 +181,26 @@ describe("events IPC handler — action:dispatched", () => {
     cleanup();
   });
 
+  it("rejects uppercase or wrong-length argsHash (strict lowercase 64-hex)", () => {
+    const { emit, cleanup } = setup();
+    ipcMainMock._invoke("events:emit", "action:dispatched", {
+      ...base,
+      pluginId: "acme.plugin",
+      argsHash: "A".repeat(64), // uppercase — rejected
+    });
+    ipcMainMock._invoke("events:emit", "action:dispatched", {
+      ...base,
+      pluginId: "acme.plugin",
+      argsHash: "a".repeat(63), // too short — rejected
+    });
+
+    expect((emit.mock.calls[0]![1] as Record<string, unknown>).argsHash).toBeUndefined();
+    expect((emit.mock.calls[1]![1] as Record<string, unknown>).argsHash).toBeUndefined();
+    // pluginId is still forwarded even when argsHash is dropped.
+    expect((emit.mock.calls[0]![1] as Record<string, unknown>).pluginId).toBe("acme.plugin");
+    cleanup();
+  });
+
   it("rejects invalid action payloads (non-string actionId)", () => {
     const { emit, cleanup } = setup();
     ipcMainMock._invoke("events:emit", "action:dispatched", { ...base, actionId: 123 });

--- a/electron/ipc/handlers/__tests__/events.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/events.handlers.test.ts
@@ -152,6 +152,35 @@ describe("events IPC handler — action:dispatched", () => {
     cleanup();
   });
 
+  it("forwards a valid pluginId and 64-char hex argsHash", () => {
+    const { emit, cleanup } = setup();
+    const hash = "a".repeat(64);
+    ipcMainMock._invoke("events:emit", "action:dispatched", {
+      ...base,
+      pluginId: "acme.plugin",
+      argsHash: hash,
+    });
+
+    const normalized = emit.mock.calls[0]![1] as Record<string, unknown>;
+    expect(normalized.pluginId).toBe("acme.plugin");
+    expect(normalized.argsHash).toBe(hash);
+    cleanup();
+  });
+
+  it("drops a malformed argsHash and over-long pluginId", () => {
+    const { emit, cleanup } = setup();
+    ipcMainMock._invoke("events:emit", "action:dispatched", {
+      ...base,
+      pluginId: "x".repeat(200),
+      argsHash: "not-hex",
+    });
+
+    const normalized = emit.mock.calls[0]![1] as Record<string, unknown>;
+    expect(normalized.pluginId).toBeUndefined();
+    expect(normalized.argsHash).toBeUndefined();
+    cleanup();
+  });
+
   it("rejects invalid action payloads (non-string actionId)", () => {
     const { emit, cleanup } = setup();
     ipcMainMock._invoke("events:emit", "action:dispatched", { ...base, actionId: 123 });

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -69,7 +69,7 @@ beforeEach(() => {
 describe("registerPluginHandlers", () => {
   it("registers handlers for all plugin channels", () => {
     registerPluginHandlers();
-    expect(mockIpcMainHandle).toHaveBeenCalledTimes(11);
+    expect(mockIpcMainHandle).toHaveBeenCalledTimes(17);
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:list", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:invoke", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:toolbar-buttons", expect.any(Function));
@@ -93,6 +93,21 @@ describe("registerPluginHandlers", () => {
       "plugin:file-decorations-get",
       expect.any(Function)
     );
+    expect(mockIpcMainHandle).toHaveBeenCalledWith(
+      "plugin:get-audit-records",
+      expect.any(Function)
+    );
+    expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:get-audit-config", expect.any(Function));
+    expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:clear-audit-log", expect.any(Function));
+    expect(mockIpcMainHandle).toHaveBeenCalledWith(
+      "plugin:set-audit-enabled",
+      expect.any(Function)
+    );
+    expect(mockIpcMainHandle).toHaveBeenCalledWith(
+      "plugin:set-audit-max-records",
+      expect.any(Function)
+    );
+    expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:export-audit-log", expect.any(Function));
   });
 
   it("throws before registering any handler when invoked before enforceIpcSenderValidation", () => {

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -518,6 +518,9 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
             showStateDebug: Boolean(devMode.showStateDebug),
             autoOpenDiagnostics: Boolean(devMode.autoOpenDiagnostics),
             focusEventsTab: Boolean(devMode.focusEventsTab),
+            ...(typeof devMode.pluginAuditPlaintext === "boolean"
+              ? { pluginAuditPlaintext: devMode.pluginAuditPlaintext }
+              : {}),
           };
         }
       }

--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -181,6 +181,19 @@ function normalizeActionDispatchedPayload(
   const confirmed: boolean | undefined =
     typeof payload.confirmed === "boolean" ? payload.confirmed : undefined;
 
+  // Plugin-action audit fields. Both are renderer-controlled strings crossing
+  // a trust boundary, so cap/shape them: `pluginId` to a sane length and
+  // `argsHash` to a strict 64-char lowercase-hex SHA-256 digest.
+  const pluginIdRaw = payload.pluginId;
+  const pluginId =
+    typeof pluginIdRaw === "string" && pluginIdRaw.trim().length > 0 && pluginIdRaw.length <= 100
+      ? pluginIdRaw
+      : undefined;
+
+  const argsHashRaw = payload.argsHash;
+  const argsHash =
+    typeof argsHashRaw === "string" && /^[0-9a-f]{64}$/.test(argsHashRaw) ? argsHashRaw : undefined;
+
   return {
     actionId,
     args: safeArgs,
@@ -192,6 +205,8 @@ function normalizeActionDispatchedPayload(
     danger,
     ...(safeBreadcrumbArgs ? { safeArgs: safeBreadcrumbArgs } : {}),
     ...(confirmed !== undefined ? { confirmed } : {}),
+    ...(pluginId !== undefined ? { pluginId } : {}),
+    ...(argsHash !== undefined ? { argsHash } : {}),
   };
 }
 

--- a/electron/ipc/handlers/plugin.preload.ts
+++ b/electron/ipc/handlers/plugin.preload.ts
@@ -16,6 +16,12 @@ export const PLUGIN_METHOD_CHANNELS = {
   getPanelKinds: "plugin:panel-kinds-get",
   getForgeProviders: "plugin:forge-providers-get",
   getDecorations: "plugin:file-decorations-get",
+  getAuditRecords: "plugin:get-audit-records",
+  getAuditConfig: "plugin:get-audit-config",
+  clearAuditLog: "plugin:clear-audit-log",
+  setAuditEnabled: "plugin:set-audit-enabled",
+  setAuditMaxRecords: "plugin:set-audit-max-records",
+  exportAuditLog: "plugin:export-audit-log",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof PLUGIN_METHOD_CHANNELS;

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -253,7 +253,7 @@ async function handleSetAuditMaxRecords(max: number): Promise<PluginAuditConfig>
       `max must be between ${PLUGIN_AUDIT_MIN_RECORDS} and ${PLUGIN_AUDIT_MAX_RECORDS}`
     );
   }
-  return getPluginActionAuditService().setAuditMaxRecords(max);
+  return getPluginActionAuditService().setMaxRecords(max);
 }
 
 async function handleExportAuditLog(records: PluginActionAuditRecord[]): Promise<boolean> {

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -1,6 +1,14 @@
-import { ipcMain } from "electron";
+import { ipcMain, dialog } from "electron";
+import { writeFile } from "node:fs/promises";
 import { CHANNELS } from "../channels.js";
 import { defineIpcNamespace, op } from "../define.js";
+import { getPluginActionAuditService } from "../../services/PluginActionAuditService.js";
+import {
+  PLUGIN_AUDIT_MAX_RECORDS,
+  PLUGIN_AUDIT_MIN_RECORDS,
+  type PluginActionAuditRecord,
+  type PluginAuditConfig,
+} from "../../../shared/types/ipc/pluginAudit.js";
 import { PLUGIN_METHOD_CHANNELS } from "./plugin.preload.js";
 import { pluginService } from "../../services/PluginService.js";
 import {
@@ -217,6 +225,52 @@ async function handleFileDecorationsGet(
   return merged;
 }
 
+// ── Plugin-action audit log ───────────────────────────────────────────────
+
+async function handleGetAuditRecords(): Promise<PluginActionAuditRecord[]> {
+  return getPluginActionAuditService().getRecords();
+}
+
+async function handleGetAuditConfig(): Promise<PluginAuditConfig> {
+  return getPluginActionAuditService().getConfig();
+}
+
+async function handleClearAuditLog(): Promise<void> {
+  getPluginActionAuditService().clear();
+}
+
+async function handleSetAuditEnabled(enabled: boolean): Promise<PluginAuditConfig> {
+  if (typeof enabled !== "boolean") throw new Error("enabled must be a boolean");
+  return getPluginActionAuditService().setEnabled(enabled);
+}
+
+async function handleSetAuditMaxRecords(max: number): Promise<PluginAuditConfig> {
+  if (typeof max !== "number" || !Number.isFinite(max) || !Number.isInteger(max)) {
+    throw new Error("max must be a finite integer");
+  }
+  if (max < PLUGIN_AUDIT_MIN_RECORDS || max > PLUGIN_AUDIT_MAX_RECORDS) {
+    throw new Error(
+      `max must be between ${PLUGIN_AUDIT_MIN_RECORDS} and ${PLUGIN_AUDIT_MAX_RECORDS}`
+    );
+  }
+  return getPluginActionAuditService().setAuditMaxRecords(max);
+}
+
+async function handleExportAuditLog(records: PluginActionAuditRecord[]): Promise<boolean> {
+  if (!Array.isArray(records)) throw new Error("records must be an array");
+  const ndjsonContent = getPluginActionAuditService().exportRecords(records) + "\n";
+  const now = Date.now();
+  const defaultFilename = `plugin-audit-log-${new Date(now).toISOString().replace(/[:.]/g, "-")}.ndjson`;
+  const { filePath, canceled } = await dialog.showSaveDialog({
+    title: "Export plugin audit log",
+    defaultPath: defaultFilename,
+    filters: [{ name: "NDJSON Files", extensions: ["ndjson"] }],
+  });
+  if (canceled || !filePath) return false;
+  await writeFile(filePath, ndjsonContent, "utf-8");
+  return true;
+}
+
 export const pluginNamespace = defineIpcNamespace({
   name: "plugin",
   ops: {
@@ -230,6 +284,12 @@ export const pluginNamespace = defineIpcNamespace({
     getPanelKinds: op(PLUGIN_METHOD_CHANNELS.getPanelKinds, handlePanelKindsGet),
     getForgeProviders: op(PLUGIN_METHOD_CHANNELS.getForgeProviders, handleForgeProvidersGet),
     getDecorations: op(PLUGIN_METHOD_CHANNELS.getDecorations, handleFileDecorationsGet),
+    getAuditRecords: op(PLUGIN_METHOD_CHANNELS.getAuditRecords, handleGetAuditRecords),
+    getAuditConfig: op(PLUGIN_METHOD_CHANNELS.getAuditConfig, handleGetAuditConfig),
+    clearAuditLog: op(PLUGIN_METHOD_CHANNELS.clearAuditLog, handleClearAuditLog),
+    setAuditEnabled: op(PLUGIN_METHOD_CHANNELS.setAuditEnabled, handleSetAuditEnabled),
+    setAuditMaxRecords: op(PLUGIN_METHOD_CHANNELS.setAuditMaxRecords, handleSetAuditMaxRecords),
+    exportAuditLog: op(PLUGIN_METHOD_CHANNELS.exportAuditLog, handleExportAuditLog),
   },
 });
 

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -204,6 +204,12 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
           import("../services/McpServerService.js")
             .then(({ mcpServerService }) => mcpServerService.stop())
             .catch(() => {}),
+          // Flush any debounced plugin-audit records before exit — the flush
+          // timer is unref'd, so the tail of a session would otherwise be lost.
+          // Lazy-import guarded like MCP: skip silently if init never ran.
+          import("../services/PluginActionAuditService.js")
+            .then(({ getPluginActionAuditService }) => getPluginActionAuditService().flushNow())
+            .catch(() => {}),
           // Revoke and remove any in-flight help-session dirs. Same lazy-import
           // guard as MCP — the module only loads if a help session was provisioned.
           import("../services/HelpSessionService.js")

--- a/electron/services/PluginActionAuditService.ts
+++ b/electron/services/PluginActionAuditService.ts
@@ -1,0 +1,255 @@
+import { randomUUID } from "node:crypto";
+import type {
+  PluginActionAuditRecord,
+  PluginActionAuditResult,
+  PluginAuditConfig,
+} from "../../shared/types/ipc/pluginAudit.js";
+import {
+  PLUGIN_AUDIT_DEFAULT_MAX_RECORDS,
+  PLUGIN_AUDIT_MAX_RECORDS,
+  PLUGIN_AUDIT_MIN_RECORDS,
+  PLUGIN_AUDIT_SCHEMA_VERSION,
+} from "../../shared/types/ipc/pluginAudit.js";
+import type { ActionSource, ActionDanger } from "../../shared/types/actions.js";
+import { events } from "./events.js";
+import type { TypedEventBus } from "./events.js";
+
+const FLUSH_DEBOUNCE_MS = 1000;
+const MAX_PLAINTEXT_CHARS = 4096;
+
+/**
+ * Persisted plaintext args may only be stored when the developer opts in.
+ * Serializes the (already redacted) args the renderer forwarded, capped so a
+ * single oversized payload can't bloat the store. Returns undefined when the
+ * args are absent or unserializable.
+ */
+function summarizePlaintext(args: unknown): string | undefined {
+  if (args === undefined || args === null) return undefined;
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(args);
+  } catch {
+    return undefined;
+  }
+  if (typeof serialized !== "string") return undefined;
+  return serialized.length > MAX_PLAINTEXT_CHARS
+    ? `${serialized.slice(0, MAX_PLAINTEXT_CHARS)}…`
+    : serialized;
+}
+
+/**
+ * Main-process ring buffer of plugin-action dispatch audit records. Mirrors
+ * the MCP `AuditService` storage pattern (hydrate / append / trim / debounced
+ * flush) without its anomaly-detection surface — plugin audit is a plain
+ * chronological dispatch trail.
+ *
+ * Records are appended from the `action:dispatched` bus event whenever the
+ * dispatched action carries a `pluginId`. Persistence is wired to the
+ * `plugins` store slice via the `saveConfig`/`readConfig` callbacks so the
+ * service stays decoupled from the concrete store module.
+ */
+export class PluginActionAuditService {
+  private records: PluginActionAuditRecord[] = [];
+  private flushTimer: ReturnType<typeof setTimeout> | null = null;
+  private hydrated = false;
+  private unsubscribe: (() => void) | null = null;
+
+  constructor(
+    private readonly saveConfig: (patch: Record<string, unknown>) => void,
+    private readonly readConfig: () => Record<string, unknown>
+  ) {}
+
+  /**
+   * Subscribe to the action-dispatch bus. Records are appended only for
+   * plugin-contributed actions (`payload.pluginId` set). `isPlaintextEnabled`
+   * gates whether the redacted plaintext args are persisted alongside the hash.
+   */
+  initialize(opts: { isPlaintextEnabled: () => boolean }, bus: TypedEventBus = events): void {
+    if (this.unsubscribe) return;
+    this.unsubscribe = bus.on("action:dispatched", (payload) => {
+      if (typeof payload.pluginId !== "string" || payload.pluginId.length === 0) return;
+      try {
+        this.append({
+          pluginId: payload.pluginId,
+          actionId: payload.actionId,
+          source: payload.source as ActionSource,
+          danger: payload.danger as ActionDanger,
+          argsHash: typeof payload.argsHash === "string" ? payload.argsHash : "",
+          argsPlaintext: opts.isPlaintextEnabled() ? summarizePlaintext(payload.args) : undefined,
+          durationMs: payload.durationMs,
+          result: "success",
+        });
+      } catch (err) {
+        console.warn("[PluginAudit] Failed to append dispatch record:", err);
+      }
+    });
+  }
+
+  dispose(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.flushNow();
+    this.records = [];
+    this.hydrated = false;
+  }
+
+  hydrate(): void {
+    if (this.hydrated) return;
+    const config = this.readConfig();
+    const persisted = Array.isArray(config.auditLog) ? config.auditLog : [];
+    const cap = this.normalizeMaxRecords(config.auditMaxRecords);
+    const safe = persisted.filter(
+      (r: unknown): r is PluginActionAuditRecord =>
+        r !== null && typeof r === "object" && typeof (r as { id?: unknown }).id === "string"
+    );
+    this.records = safe.length > cap ? safe.slice(safe.length - cap) : safe;
+    this.hydrated = true;
+  }
+
+  normalizeMaxRecords(value: unknown): number {
+    const n = typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : NaN;
+    if (!Number.isFinite(n)) return PLUGIN_AUDIT_DEFAULT_MAX_RECORDS;
+    if (n < PLUGIN_AUDIT_MIN_RECORDS) return PLUGIN_AUDIT_MIN_RECORDS;
+    if (n > PLUGIN_AUDIT_MAX_RECORDS) return PLUGIN_AUDIT_MAX_RECORDS;
+    return n;
+  }
+
+  append(input: {
+    pluginId: string;
+    actionId: string;
+    source: ActionSource;
+    danger: ActionDanger;
+    argsHash: string;
+    argsPlaintext?: string;
+    durationMs: number;
+    result: PluginActionAuditResult;
+    turnId?: string;
+  }): void {
+    if (this.readConfig().auditEnabled === false) return;
+    this.hydrate();
+
+    const record: PluginActionAuditRecord = {
+      id: randomUUID(),
+      ts: Date.now(),
+      pluginId: input.pluginId,
+      actionId: input.actionId,
+      source: input.source,
+      danger: input.danger,
+      argsHash: input.argsHash,
+      durationMs: Math.max(0, Math.round(input.durationMs)),
+      result: input.result,
+      schemaVersion: PLUGIN_AUDIT_SCHEMA_VERSION,
+    };
+    if (input.argsPlaintext !== undefined) record.argsPlaintext = input.argsPlaintext;
+    if (input.turnId !== undefined) record.turnId = input.turnId;
+
+    this.enqueueAndTrim(record);
+  }
+
+  private enqueueAndTrim(record: PluginActionAuditRecord): void {
+    this.records.push(record);
+    const cap = this.normalizeMaxRecords(this.readConfig().auditMaxRecords);
+    if (this.records.length > cap) {
+      this.records.splice(0, this.records.length - cap);
+    }
+    this.scheduleFlush();
+  }
+
+  private scheduleFlush(): void {
+    if (this.flushTimer) return;
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = null;
+      this.flush();
+    }, FLUSH_DEBOUNCE_MS);
+    this.flushTimer.unref?.();
+  }
+
+  private flush(): void {
+    if (!this.hydrated) return;
+    try {
+      this.saveConfig({ auditLog: [...this.records] });
+    } catch (err) {
+      console.error("[PluginAudit] Failed to flush audit log:", err);
+    }
+  }
+
+  flushNow(): void {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    this.flush();
+  }
+
+  /** Newest-first view of all persisted records. */
+  getRecords(): PluginActionAuditRecord[] {
+    this.hydrate();
+    return [...this.records].reverse();
+  }
+
+  getConfig(): PluginAuditConfig {
+    const config = this.readConfig();
+    return {
+      enabled: config.auditEnabled !== false,
+      maxRecords: this.normalizeMaxRecords(config.auditMaxRecords),
+    };
+  }
+
+  setEnabled(enabled: boolean): PluginAuditConfig {
+    this.hydrate();
+    this.saveConfig({ auditEnabled: enabled });
+    return this.getConfig();
+  }
+
+  setMaxRecords(max: number): PluginAuditConfig {
+    this.hydrate();
+    const normalized = this.normalizeMaxRecords(max);
+    if (this.records.length > normalized) {
+      this.records.splice(0, this.records.length - normalized);
+    }
+    this.saveConfig({ auditMaxRecords: normalized });
+    this.flushNow();
+    return this.getConfig();
+  }
+
+  clear(): void {
+    this.hydrate();
+    this.records = [];
+    this.flushNow();
+  }
+
+  /** Serialize the given records as newline-delimited JSON for export. */
+  exportRecords(records: PluginActionAuditRecord[]): string {
+    return records.map((r) => JSON.stringify(r)).join("\n");
+  }
+
+  _resetForTest(): void {
+    this.dispose();
+    this.records = [];
+    this.hydrated = false;
+  }
+}
+
+let instance: PluginActionAuditService | null = null;
+
+export function getPluginActionAuditService(): PluginActionAuditService {
+  if (!instance) {
+    // Lazy require to avoid pulling the electron-store module into unit tests
+    // that exercise the class directly with injected callbacks.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { store } = require("../store.js") as typeof import("../store.js");
+    instance = new PluginActionAuditService(
+      (patch) => {
+        const current = (store.get("plugins") ?? {}) as Record<string, unknown>;
+        store.set("plugins", { ...current, ...patch });
+      },
+      () => (store.get("plugins") ?? {}) as Record<string, unknown>
+    );
+  }
+  return instance;
+}
+
+export function _resetPluginActionAuditServiceForTest(): void {
+  instance?._resetForTest();
+  instance = null;
+}

--- a/electron/services/PluginActionAuditService.ts
+++ b/electron/services/PluginActionAuditService.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: wires the plugin-audit ring buffer to the synchronous electron-store slice at boot (global service, mirrors ActionBreadcrumbService)
 import { randomUUID } from "node:crypto";
 import type {
   PluginActionAuditRecord,
@@ -13,6 +14,7 @@ import {
 import type { ActionSource, ActionDanger } from "../../shared/types/actions.js";
 import { events } from "./events.js";
 import type { TypedEventBus } from "./events.js";
+import { store } from "../store.js";
 
 const FLUSH_DEBOUNCE_MS = 1000;
 const MAX_PLAINTEXT_CHARS = 4096;
@@ -241,10 +243,8 @@ let instance: PluginActionAuditService | null = null;
 
 export function getPluginActionAuditService(): PluginActionAuditService {
   if (!instance) {
-    // Lazy require to avoid pulling the electron-store module into unit tests
-    // that exercise the class directly with injected callbacks.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { store } = require("../store.js") as typeof import("../store.js");
+    // `store` is the lazy electron-store Proxy — importing it doesn't initialize
+    // the backing store, and the singleton is only constructed on first use.
     instance = new PluginActionAuditService(
       (patch) => {
         const current = (store.get("plugins") ?? {}) as Record<string, unknown>;

--- a/electron/services/PluginActionAuditService.ts
+++ b/electron/services/PluginActionAuditService.ts
@@ -98,10 +98,17 @@ export class PluginActionAuditService {
     const config = this.readConfig();
     const persisted = Array.isArray(config.auditLog) ? config.auditLog : [];
     const cap = this.normalizeMaxRecords(config.auditMaxRecords);
-    const safe = persisted.filter(
-      (r: unknown): r is PluginActionAuditRecord =>
-        r !== null && typeof r === "object" && typeof (r as { id?: unknown }).id === "string"
-    );
+    const safe = persisted.filter((r: unknown): r is PluginActionAuditRecord => {
+      if (r === null || typeof r !== "object") return false;
+      const rec = r as { id?: unknown; pluginId?: unknown; actionId?: unknown };
+      // Require the fields the viewer reads unguarded (`pluginId.toLowerCase()`,
+      // `actionId.toLowerCase()`) so a manually corrupted store can't crash it.
+      return (
+        typeof rec.id === "string" &&
+        typeof rec.pluginId === "string" &&
+        typeof rec.actionId === "string"
+      );
+    });
     this.records = safe.length > cap ? safe.slice(safe.length - cap) : safe;
     this.hydrated = true;
   }

--- a/electron/services/__tests__/PluginActionAuditService.test.ts
+++ b/electron/services/__tests__/PluginActionAuditService.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { events, type DaintreeEventMap } from "../events.js";
+import { PluginActionAuditService } from "../PluginActionAuditService.js";
+
+/** In-memory stand-in for the `plugins` store slice. */
+function makeConfigStore(initial: Record<string, unknown> = {}) {
+  let config: Record<string, unknown> = { auditEnabled: true, auditMaxRecords: 500, ...initial };
+  return {
+    saveConfig: (patch: Record<string, unknown>) => {
+      config = { ...config, ...patch };
+    },
+    readConfig: () => config,
+    raw: () => config,
+  };
+}
+
+function emitDispatch(overrides: Partial<DaintreeEventMap["action:dispatched"]> = {}): void {
+  events.emit("action:dispatched", {
+    actionId: "plugin.foo.bar",
+    source: "user",
+    context: {},
+    timestamp: Date.now(),
+    category: "plugin",
+    durationMs: 3,
+    danger: "safe",
+    ...overrides,
+  });
+}
+
+describe("PluginActionAuditService", () => {
+  let store: ReturnType<typeof makeConfigStore>;
+  let service: PluginActionAuditService;
+
+  beforeEach(() => {
+    store = makeConfigStore();
+    service = new PluginActionAuditService(store.saveConfig, store.readConfig);
+  });
+
+  afterEach(() => {
+    service.dispose();
+    vi.useRealTimers();
+  });
+
+  it("starts empty", () => {
+    expect(service.getRecords()).toEqual([]);
+  });
+
+  it("appends a record with the expected shape", () => {
+    service.append({
+      pluginId: "acme.plugin",
+      actionId: "acme.do-thing",
+      source: "user",
+      danger: "safe",
+      argsHash: "a".repeat(64),
+      durationMs: 12,
+      result: "success",
+    });
+    const records = service.getRecords();
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      pluginId: "acme.plugin",
+      actionId: "acme.do-thing",
+      source: "user",
+      danger: "safe",
+      argsHash: "a".repeat(64),
+      durationMs: 12,
+      result: "success",
+      schemaVersion: 1,
+    });
+    expect(typeof records[0]!.id).toBe("string");
+    expect(typeof records[0]!.ts).toBe("number");
+  });
+
+  it("does not append when auditEnabled is false", () => {
+    store.saveConfig({ auditEnabled: false });
+    service.append({
+      pluginId: "acme.plugin",
+      actionId: "acme.do-thing",
+      source: "user",
+      danger: "safe",
+      argsHash: "",
+      durationMs: 1,
+      result: "success",
+    });
+    expect(service.getRecords()).toEqual([]);
+  });
+
+  it("trims to the configured max records (oldest evicted)", () => {
+    store.saveConfig({ auditMaxRecords: 50 });
+    for (let i = 0; i < 60; i++) {
+      service.append({
+        pluginId: "acme.plugin",
+        actionId: `acme.action-${i}`,
+        source: "user",
+        danger: "safe",
+        argsHash: "",
+        durationMs: 1,
+        result: "success",
+      });
+    }
+    const records = service.getRecords();
+    expect(records).toHaveLength(50);
+    // Newest-first: the most recent dispatch is first; oldest 10 evicted.
+    expect(records[0]!.actionId).toBe("acme.action-59");
+    expect(records.at(-1)!.actionId).toBe("acme.action-10");
+  });
+
+  it("returns records newest-first", () => {
+    service.append({
+      pluginId: "p",
+      actionId: "first",
+      source: "user",
+      danger: "safe",
+      argsHash: "",
+      durationMs: 1,
+      result: "success",
+    });
+    service.append({
+      pluginId: "p",
+      actionId: "second",
+      source: "user",
+      danger: "safe",
+      argsHash: "",
+      durationMs: 1,
+      result: "success",
+    });
+    const records = service.getRecords();
+    expect(records.map((r) => r.actionId)).toEqual(["second", "first"]);
+  });
+
+  it("clear() empties the ring and persists", () => {
+    service.append({
+      pluginId: "p",
+      actionId: "x",
+      source: "user",
+      danger: "safe",
+      argsHash: "",
+      durationMs: 1,
+      result: "success",
+    });
+    service.clear();
+    expect(service.getRecords()).toEqual([]);
+    expect(store.raw().auditLog).toEqual([]);
+  });
+
+  it("setEnabled / setMaxRecords return and persist config", () => {
+    expect(service.setEnabled(false)).toEqual({ enabled: false, maxRecords: 500 });
+    expect(store.raw().auditEnabled).toBe(false);
+    expect(service.setMaxRecords(100)).toMatchObject({ maxRecords: 100 });
+    expect(store.raw().auditMaxRecords).toBe(100);
+  });
+
+  it("clamps maxRecords to the allowed range", () => {
+    expect(service.setMaxRecords(1).maxRecords).toBe(50);
+    expect(service.setMaxRecords(999_999).maxRecords).toBe(5000);
+  });
+
+  it("hydrates persisted records on first read", () => {
+    const seeded = makeConfigStore({
+      auditLog: [
+        {
+          id: "seed-1",
+          ts: 1,
+          pluginId: "p",
+          actionId: "seeded",
+          source: "user",
+          danger: "safe",
+          argsHash: "",
+          durationMs: 1,
+          result: "success",
+          schemaVersion: 1,
+        },
+      ],
+    });
+    const svc = new PluginActionAuditService(seeded.saveConfig, seeded.readConfig);
+    const records = svc.getRecords();
+    expect(records).toHaveLength(1);
+    expect(records[0]!.actionId).toBe("seeded");
+    svc.dispose();
+  });
+
+  it("exportRecords serializes as NDJSON", () => {
+    const ndjson = service.exportRecords([
+      {
+        id: "1",
+        ts: 1,
+        pluginId: "p",
+        actionId: "a",
+        source: "user",
+        danger: "safe",
+        argsHash: "",
+        durationMs: 1,
+        result: "success",
+        schemaVersion: 1,
+      },
+      {
+        id: "2",
+        ts: 2,
+        pluginId: "p",
+        actionId: "b",
+        source: "user",
+        danger: "safe",
+        argsHash: "",
+        durationMs: 1,
+        result: "success",
+        schemaVersion: 1,
+      },
+    ]);
+    const lines = ndjson.split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]!).actionId).toBe("a");
+    expect(JSON.parse(lines[1]!).actionId).toBe("b");
+  });
+
+  describe("bus integration", () => {
+    it("records only plugin-contributed dispatches", () => {
+      service.initialize({ isPlaintextEnabled: () => false });
+      emitDispatch({ actionId: "builtin.action" }); // no pluginId — ignored
+      emitDispatch({ actionId: "plugin.foo", pluginId: "foo", argsHash: "b".repeat(64) });
+      const records = service.getRecords();
+      expect(records).toHaveLength(1);
+      expect(records[0]).toMatchObject({
+        pluginId: "foo",
+        actionId: "plugin.foo",
+        argsHash: "b".repeat(64),
+        result: "success",
+      });
+    });
+
+    it("persists plaintext args only when the developer opts in", () => {
+      let plaintext = false;
+      service.initialize({ isPlaintextEnabled: () => plaintext });
+
+      emitDispatch({ pluginId: "foo", args: { name: "value" } });
+      expect(service.getRecords()[0]!.argsPlaintext).toBeUndefined();
+
+      plaintext = true;
+      emitDispatch({ pluginId: "foo", actionId: "plugin.foo2", args: { name: "value" } });
+      const newest = service.getRecords()[0]!;
+      expect(newest.actionId).toBe("plugin.foo2");
+      expect(newest.argsPlaintext).toBe(JSON.stringify({ name: "value" }));
+    });
+  });
+});

--- a/electron/services/__tests__/PluginActionAuditService.test.ts
+++ b/electron/services/__tests__/PluginActionAuditService.test.ts
@@ -1,4 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The service module statically imports the electron-store-backed `store` for
+// its singleton factory. These tests exercise the class directly with injected
+// callbacks, so stub `store` to keep the unit test hermetic (no electron).
+vi.mock("../../store.js", () => ({
+  store: { get: vi.fn(() => ({})), set: vi.fn() },
+}));
+
 import { events, type DaintreeEventMap } from "../events.js";
 import { PluginActionAuditService } from "../PluginActionAuditService.js";
 

--- a/electron/services/__tests__/PluginActionAuditService.test.ts
+++ b/electron/services/__tests__/PluginActionAuditService.test.ts
@@ -155,6 +155,68 @@ describe("PluginActionAuditService", () => {
     expect(service.setMaxRecords(999_999).maxRecords).toBe(5000);
   });
 
+  it("flushes to the store after the debounce window (oldest-first)", () => {
+    vi.useFakeTimers();
+    const svc = new PluginActionAuditService(store.saveConfig, store.readConfig);
+    svc.append({
+      pluginId: "p",
+      actionId: "first",
+      source: "user",
+      danger: "safe",
+      argsHash: "",
+      durationMs: 1,
+      result: "success",
+    });
+    svc.append({
+      pluginId: "p",
+      actionId: "second",
+      source: "user",
+      danger: "safe",
+      argsHash: "",
+      durationMs: 1,
+      result: "success",
+    });
+    expect(store.raw().auditLog).toBeUndefined();
+    vi.advanceTimersByTime(1000);
+    const persisted = store.raw().auditLog as Array<{ actionId: string }>;
+    // Stored oldest-first (getRecords reverses for display).
+    expect(persisted.map((r) => r.actionId)).toEqual(["first", "second"]);
+    svc.dispose();
+  });
+
+  it("dispose() flushes pending records synchronously", () => {
+    vi.useFakeTimers();
+    const svc = new PluginActionAuditService(store.saveConfig, store.readConfig);
+    svc.append({
+      pluginId: "p",
+      actionId: "x",
+      source: "user",
+      danger: "safe",
+      argsHash: "",
+      durationMs: 1,
+      result: "success",
+    });
+    expect(store.raw().auditLog).toBeUndefined();
+    svc.dispose(); // flushes without advancing the debounce timer
+    expect((store.raw().auditLog as unknown[]).length).toBe(1);
+  });
+
+  it("hydrate rejects records missing string pluginId/actionId", () => {
+    const seeded = makeConfigStore({
+      auditLog: [
+        { id: "ok", pluginId: "p", actionId: "a", ts: 1, schemaVersion: 1 },
+        { id: "bad-plugin", pluginId: null, actionId: "a" },
+        { id: "no-action", pluginId: "p" },
+        { pluginId: "p", actionId: "a" }, // missing id
+      ],
+    });
+    const svc = new PluginActionAuditService(seeded.saveConfig, seeded.readConfig);
+    const records = svc.getRecords();
+    expect(records).toHaveLength(1);
+    expect(records[0]!.id).toBe("ok");
+    svc.dispose();
+  });
+
   it("hydrates persisted records on first read", () => {
     const seeded = makeConfigStore({
       auditLog: [

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -650,6 +650,19 @@ export type DaintreeEventMap = {
     danger: "safe" | "confirm" | "restricted";
     /** True when an agent explicitly confirmed a danger:"confirm" action. Absent for user-source and safe actions. */
     confirmed?: boolean;
+    /**
+     * Contributing plugin id when this action was registered by a plugin
+     * (`ActionDefinition.pluginId`). Absent for built-in actions. Drives the
+     * plugin-action audit log — the main-side `PluginActionAuditService`
+     * appends a record only when this is present.
+     */
+    pluginId?: string;
+    /**
+     * SHA-256 hex digest of the (redacted) dispatch args, computed in the
+     * renderer. Only set for plugin actions. Persisted in the audit record
+     * so raw args need never cross IPC for fingerprinting.
+     */
+    argsHash?: string;
   };
 
   // Terminal Trash Events

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -14,6 +14,8 @@ import type { IssueAssociation } from "../shared/types/ipc/worktree.js";
 import type { ErrorRecord } from "../shared/types/ipc/errors.js";
 import type { AssistantTurnRecord, McpAuditRecord } from "../shared/types/ipc/mcpServer.js";
 import { MCP_AUDIT_DEFAULT_MAX_RECORDS } from "../shared/types/ipc/mcpServer.js";
+import type { PluginActionAuditRecord } from "../shared/types/ipc/pluginAudit.js";
+import { PLUGIN_AUDIT_DEFAULT_MAX_RECORDS } from "../shared/types/ipc/pluginAudit.js";
 import type { BuiltInAgentId } from "../shared/config/agentIds.js";
 import type { AgentId } from "../shared/types/agent.js";
 import { DEFAULT_AGENT_SETTINGS, DEFAULT_APP_AGENT_CONFIG } from "../shared/types/index.js";
@@ -79,6 +81,12 @@ export interface StoreSchema {
       showStateDebug: boolean;
       autoOpenDiagnostics: boolean;
       focusEventsTab: boolean;
+      /**
+       * Persist raw (redacted) plugin-action args alongside the SHA-256 hash
+       * in the plugin audit log. Off by default — the audit log stores only
+       * the hash for privacy. Opt-in for plugin authors debugging dispatch.
+       */
+      pluginAuditPlaintext?: boolean;
     };
     terminals: Array<{
       id: string;
@@ -306,6 +314,12 @@ export interface StoreSchema {
    */
   plugins: {
     disabledBuiltins: string[];
+    /** Master switch for the plugin-action audit log. Defaults to true. */
+    auditEnabled: boolean;
+    /** Ring-buffer cap for persisted plugin-action audit records. */
+    auditMaxRecords: number;
+    /** Persisted plugin-action audit ring buffer (oldest-first). */
+    auditLog?: PluginActionAuditRecord[];
   };
   /**
    * Global default forge provider id for newly opened projects. `null` (or
@@ -476,6 +490,8 @@ const storeOptions = {
     logLevelOverrides: {},
     plugins: {
       disabledBuiltins: [],
+      auditEnabled: true,
+      auditMaxRecords: PLUGIN_AUDIT_DEFAULT_MAX_RECORDS,
     },
   },
   cwd: process.env.DAINTREE_USER_DATA,

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -16,6 +16,7 @@ import { secureStorage } from "../services/SecureStorage.js";
 import { notificationService } from "../services/NotificationService.js";
 import { preAgentSnapshotService } from "../services/PreAgentSnapshotService.js";
 import { getActionBreadcrumbService } from "../services/ActionBreadcrumbService.js";
+import { getPluginActionAuditService } from "../services/PluginActionAuditService.js";
 import {
   initializeHibernationService,
   getHibernationService,
@@ -226,6 +227,13 @@ export async function initGlobalServices(
   // grace period now starts from the deferred initialize() so the suppression
   // window still covers the actual agent startup interval.
   getActionBreadcrumbService().initialize();
+
+  // Plugin-action audit log: subscribes to action:dispatched and records every
+  // plugin-contributed dispatch. Plaintext args are persisted only when the
+  // developer has opted in via appState.developerMode.pluginAuditPlaintext.
+  getPluginActionAuditService().initialize({
+    isPlaintextEnabled: () => store.get("appState")?.developerMode?.pluginAuditPlaintext === true,
+  });
 
   registerDeferredTask({
     name: "agent-notification-service",

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -353,6 +353,17 @@ export {
   MCP_AUDIT_MAX_RECORDS,
   MCP_AUDIT_DEFAULT_MAX_RECORDS,
 } from "./ipc/mcpServer.js";
+export type {
+  PluginActionAuditRecord,
+  PluginActionAuditResult,
+  PluginAuditConfig,
+} from "./ipc/pluginAudit.js";
+export {
+  PLUGIN_AUDIT_SCHEMA_VERSION,
+  PLUGIN_AUDIT_MIN_RECORDS,
+  PLUGIN_AUDIT_MAX_RECORDS,
+  PLUGIN_AUDIT_DEFAULT_MAX_RECORDS,
+} from "./ipc/pluginAudit.js";
 
 // Event types - event context for correlation
 export type { EventContext } from "./events.js";

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -302,9 +302,21 @@ export interface GeneratedElectronAPI {
     ): Promise<IpcInvokeMap["onboarding:set-step"]["result"]>;
   };
   plugin: {
+    clearAuditLog(
+      ...args: IpcInvokeMap["plugin:clear-audit-log"]["args"]
+    ): Promise<IpcInvokeMap["plugin:clear-audit-log"]["result"]>;
+    exportAuditLog(
+      ...args: IpcInvokeMap["plugin:export-audit-log"]["args"]
+    ): Promise<IpcInvokeMap["plugin:export-audit-log"]["result"]>;
     getActions(
       ...args: IpcInvokeMap["plugin:actions-get"]["args"]
     ): Promise<IpcInvokeMap["plugin:actions-get"]["result"]>;
+    getAuditConfig(
+      ...args: IpcInvokeMap["plugin:get-audit-config"]["args"]
+    ): Promise<IpcInvokeMap["plugin:get-audit-config"]["result"]>;
+    getAuditRecords(
+      ...args: IpcInvokeMap["plugin:get-audit-records"]["args"]
+    ): Promise<IpcInvokeMap["plugin:get-audit-records"]["result"]>;
     getDecorations(
       ...args: IpcInvokeMap["plugin:file-decorations-get"]["args"]
     ): Promise<IpcInvokeMap["plugin:file-decorations-get"]["result"]>;
@@ -323,6 +335,12 @@ export interface GeneratedElectronAPI {
     registerAction(
       ...args: IpcInvokeMap["plugin:actions-register"]["args"]
     ): Promise<IpcInvokeMap["plugin:actions-register"]["result"]>;
+    setAuditEnabled(
+      ...args: IpcInvokeMap["plugin:set-audit-enabled"]["args"]
+    ): Promise<IpcInvokeMap["plugin:set-audit-enabled"]["result"]>;
+    setAuditMaxRecords(
+      ...args: IpcInvokeMap["plugin:set-audit-max-records"]["args"]
+    ): Promise<IpcInvokeMap["plugin:set-audit-max-records"]["result"]>;
     toolbarButtons(
       ...args: IpcInvokeMap["plugin:toolbar-buttons"]["args"]
     ): Promise<IpcInvokeMap["plugin:toolbar-buttons"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -551,6 +551,14 @@ export interface GeneratedIpcInvokeMap {
     args: [pluginId: string, actionId: string];
     result: void;
   };
+  "plugin:clear-audit-log": {
+    args: [];
+    result: void;
+  };
+  "plugin:export-audit-log": {
+    args: [records: import("./pluginAudit.js").PluginActionAuditRecord[]];
+    result: boolean;
+  };
   "plugin:file-decorations-get": {
     args: [scope: string, paths: string[]];
     result: Record<string, import("../forge.js").FileDecoration>;
@@ -558,6 +566,14 @@ export interface GeneratedIpcInvokeMap {
   "plugin:forge-providers-get": {
     args: [];
     result: import("../forge.js").RegisteredForgeProvider[];
+  };
+  "plugin:get-audit-config": {
+    args: [];
+    result: import("./pluginAudit.js").PluginAuditConfig;
+  };
+  "plugin:get-audit-records": {
+    args: [];
+    result: import("./pluginAudit.js").PluginActionAuditRecord[];
   };
   "plugin:list": {
     args: [];
@@ -570,6 +586,14 @@ export interface GeneratedIpcInvokeMap {
   "plugin:panel-kinds-get": {
     args: [];
     result: import("../../config/panelKindRegistry.js").PanelKindConfig[];
+  };
+  "plugin:set-audit-enabled": {
+    args: [enabled: boolean];
+    result: import("./pluginAudit.js").PluginAuditConfig;
+  };
+  "plugin:set-audit-max-records": {
+    args: [max: number];
+    result: import("./pluginAudit.js").PluginAuditConfig;
   };
   "plugin:toolbar-buttons": {
     args: [];

--- a/shared/types/ipc/pluginAudit.ts
+++ b/shared/types/ipc/pluginAudit.ts
@@ -1,0 +1,79 @@
+import type { ActionSource, ActionDanger } from "../actions.js";
+
+/**
+ * Outcome classification for a single plugin-contributed action dispatch.
+ *
+ * - `success`: the action's `run()` resolved without throwing.
+ * - `error`: the action's `run()` threw or rejected.
+ * - `disabled`: dispatch was rejected because the action's `isEnabled`
+ *   predicate returned false.
+ * - `restricted`: dispatch was rejected because the action is
+ *   `danger: "restricted"`, or (once #9231 lands) a required capability
+ *   grant was denied.
+ *
+ * Today only `success` is emitted — the renderer's `action:dispatched`
+ * event fires post-success. The other variants are reserved so the record
+ * shape is forward-compatible with failure/denial recording (a follow-up
+ * partially gated on the #9231 capability gate).
+ */
+export type PluginActionAuditResult = "success" | "error" | "disabled" | "restricted";
+
+/**
+ * Persisted audit record for a single plugin-action dispatch. Written to a
+ * ring buffer in the main process whenever an action contributed by a plugin
+ * (`ActionDefinition.pluginId` set) is dispatched through `ActionService`.
+ *
+ * Privacy by default: `argsHash` is the SHA-256 hex digest of the dispatch
+ * args, computed in the renderer before the record crosses IPC. Raw args are
+ * never persisted unless the developer explicitly opts in via
+ * `developerMode.pluginAuditPlaintext`, in which case a redacted plaintext
+ * summary is stored in `argsPlaintext`.
+ */
+export interface PluginActionAuditRecord {
+  /** Stable record id (UUID). */
+  id: string;
+  /** Wall-clock epoch millis the dispatch was recorded. */
+  ts: number;
+  /** Contributing plugin id (`ActionDefinition.pluginId`). */
+  pluginId: string;
+  /** Dispatched action id — a plugin-registered open-union `ActionId`. */
+  actionId: string;
+  /** Dispatch source (user, keybinding, menu, agent, context-menu). */
+  source: ActionSource;
+  /** Danger classification of the action at dispatch time. */
+  danger: ActionDanger;
+  /**
+   * SHA-256 hex digest of the JSON-serialized (redacted) dispatch args.
+   * Empty string when the dispatch carried no args or hashing failed.
+   */
+  argsHash: string;
+  /**
+   * Redacted plaintext JSON of the dispatch args. Present only when
+   * `developerMode.pluginAuditPlaintext` was enabled at record-write time.
+   */
+  argsPlaintext?: string;
+  /** Wall-clock duration of the `run()` call in milliseconds. */
+  durationMs: number;
+  /** Dispatch outcome classification. */
+  result: PluginActionAuditResult;
+  /**
+   * Stable correlation id for the assistant turn this dispatch belongs to.
+   * Reserved — absent until a renderer-facing turn-id push mechanism exists.
+   */
+  turnId?: string;
+  /** Schema version for forward-compat. New records carry the current version. */
+  schemaVersion: number;
+}
+
+/** Renderer-facing audit configuration snapshot. */
+export interface PluginAuditConfig {
+  enabled: boolean;
+  maxRecords: number;
+}
+
+export const PLUGIN_AUDIT_SCHEMA_VERSION = 1;
+
+/** Minimum, maximum, and default values for the configurable ring-buffer cap. */
+export const PLUGIN_AUDIT_MIN_RECORDS = 50;
+export const PLUGIN_AUDIT_MAX_RECORDS = 5000;
+export const PLUGIN_AUDIT_DEFAULT_MAX_RECORDS = 500;

--- a/src/components/Settings/PluginActionAuditLogViewer.tsx
+++ b/src/components/Settings/PluginActionAuditLogViewer.tsx
@@ -1,0 +1,256 @@
+import { useEffect, useMemo, useState } from "react";
+import { Check, Copy, Download, RefreshCw } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
+import type { PluginActionAuditRecord, PluginActionAuditResult } from "@shared/types";
+
+type ResultFilter = "all" | PluginActionAuditResult;
+
+const RESULT_LABEL: Record<PluginActionAuditResult, string> = {
+  success: "Success",
+  error: "Error",
+  disabled: "Disabled",
+  restricted: "Restricted",
+};
+
+const RESULT_DOT_CLASS: Record<PluginActionAuditResult, string> = {
+  success: "bg-status-success",
+  error: "bg-status-danger",
+  disabled: "bg-status-warning",
+  restricted: "bg-status-danger",
+};
+
+const RELATIVE_TIMESTAMP_REFRESH_MS = 30_000;
+
+function formatRelativeTimestamp(ts: number, now: number): string {
+  const diffMs = now - ts;
+  if (diffMs < 0) return "just now";
+  const sec = Math.floor(diffMs / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  return `${Math.floor(hr / 24)}d ago`;
+}
+
+interface PluginActionAuditLogViewerProps {
+  records: PluginActionAuditRecord[];
+  loading: boolean;
+  maxRecords: number;
+  onRefresh: () => Promise<void> | void;
+  onCopy: (records: PluginActionAuditRecord[]) => Promise<void> | void;
+  onExport: (records: PluginActionAuditRecord[]) => Promise<void> | void;
+  onClear: () => void;
+  copyFlashActive?: boolean;
+  exportFlashActive?: boolean;
+}
+
+export function PluginActionAuditLogViewer({
+  records,
+  loading,
+  maxRecords,
+  onRefresh,
+  onCopy,
+  onExport,
+  onClear,
+  copyFlashActive,
+  exportFlashActive,
+}: PluginActionAuditLogViewerProps) {
+  const [pluginFilter, setPluginFilter] = useState("");
+  const [resultFilter, setResultFilter] = useState<ResultFilter>("all");
+  const [nowTick, setNowTick] = useState(Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => setNowTick(Date.now()), RELATIVE_TIMESTAMP_REFRESH_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  const filteredRecords = useMemo(() => {
+    const needle = pluginFilter.trim().toLowerCase();
+    return records.filter((record) => {
+      if (resultFilter !== "all" && record.result !== resultFilter) return false;
+      if (
+        needle.length > 0 &&
+        !record.pluginId.toLowerCase().includes(needle) &&
+        !record.actionId.toLowerCase().includes(needle)
+      ) {
+        return false;
+      }
+      return true;
+    });
+  }, [records, pluginFilter, resultFilter]);
+
+  const isFiltering = pluginFilter.trim().length > 0 || resultFilter !== "all";
+  const showCopyAll = filteredRecords.length === records.length;
+
+  return (
+    <div className="contents">
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          type="text"
+          value={pluginFilter}
+          onChange={(e) => setPluginFilter(e.target.value)}
+          placeholder="Filter by plugin or action ID"
+          aria-label="Filter audit by plugin or action ID"
+          className="flex-1 min-w-[180px] bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-daintree-text/40 font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+        />
+        <select
+          value={resultFilter}
+          onChange={(e) => {
+            const value = e.target.value;
+            if (
+              value === "all" ||
+              value === "success" ||
+              value === "error" ||
+              value === "disabled" ||
+              value === "restricted"
+            ) {
+              setResultFilter(value);
+            }
+          }}
+          aria-label="Filter audit by result"
+          className="bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+        >
+          <option value="all">All results</option>
+          <option value="success">Success</option>
+          <option value="error">Error</option>
+          <option value="disabled">Disabled</option>
+          <option value="restricted">Restricted</option>
+        </select>
+      </div>
+
+      <div className="max-h-64 overflow-y-auto rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg">
+        {loading ? (
+          <Skeleton label="Loading audit records" className="space-y-2 p-3">
+            <SkeletonBone className="h-5 w-5/6" />
+            <SkeletonBone className="h-5 w-4/6" />
+            <SkeletonBone className="h-5 w-3/4" />
+          </Skeleton>
+        ) : filteredRecords.length === 0 ? (
+          records.length === 0 ? (
+            <EmptyState
+              variant="zero-data"
+              scale="sidebar"
+              title="No plugin actions recorded yet"
+            />
+          ) : (
+            <EmptyState
+              variant="filtered-empty"
+              scale="sidebar"
+              title="No records match the current filters"
+            />
+          )
+        ) : (
+          <ul className="divide-y divide-daintree-border">
+            {filteredRecords.map((record) => (
+              <li key={record.id} className="grid grid-cols-[auto_1fr_auto] gap-2 p-2 text-xs">
+                <span
+                  className={cn(
+                    "mt-1 h-2 w-2 rounded-full shrink-0",
+                    RESULT_DOT_CLASS[record.result]
+                  )}
+                  aria-label={RESULT_LABEL[record.result]}
+                  title={RESULT_LABEL[record.result]}
+                />
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono text-daintree-text/90 truncate">
+                      {record.actionId}
+                    </span>
+                    <span className="text-[10px] uppercase tracking-wide text-daintree-text/50">
+                      {record.source}
+                    </span>
+                  </div>
+                  <div className="mt-0.5 font-mono text-daintree-text/50 truncate">
+                    {record.pluginId}
+                  </div>
+                  {record.argsPlaintext ? (
+                    <div className="mt-0.5 font-mono text-daintree-text/40 truncate">
+                      {record.argsPlaintext}
+                    </div>
+                  ) : record.argsHash ? (
+                    <div className="mt-0.5 font-mono text-daintree-text/40 truncate">
+                      sha256:{record.argsHash.slice(0, 16)}…
+                    </div>
+                  ) : null}
+                </div>
+                <div className="text-right text-daintree-text/40 whitespace-nowrap">
+                  <div>{formatRelativeTimestamp(record.ts, nowTick)}</div>
+                  <div>{record.durationMs}ms</div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => void onRefresh()}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-[var(--radius-md)] border border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft transition-colors"
+          aria-label="Refresh audit log"
+        >
+          <RefreshCw className="w-3.5 h-3.5" />
+          Refresh
+        </button>
+        <button
+          type="button"
+          onClick={() => void onCopy(filteredRecords)}
+          disabled={filteredRecords.length === 0}
+          className={cn(
+            "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-[var(--radius-md)] border transition-colors",
+            filteredRecords.length === 0
+              ? "border-daintree-border text-daintree-text/30 cursor-not-allowed"
+              : copyFlashActive
+                ? "text-status-success border-status-success/30"
+                : "border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft"
+          )}
+        >
+          {copyFlashActive ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
+          {copyFlashActive ? "Copied!" : `Copy ${showCopyAll ? "all" : "filtered"} as JSON`}
+        </button>
+        <button
+          type="button"
+          onClick={() => void onExport(filteredRecords)}
+          disabled={filteredRecords.length === 0}
+          className={cn(
+            "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-[var(--radius-md)] border transition-colors",
+            filteredRecords.length === 0
+              ? "border-daintree-border text-daintree-text/30 cursor-not-allowed"
+              : exportFlashActive
+                ? "text-status-success border-status-success/30"
+                : "border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft"
+          )}
+        >
+          {exportFlashActive ? (
+            <Check className="w-3.5 h-3.5" />
+          ) : (
+            <Download className="w-3.5 h-3.5" />
+          )}
+          {exportFlashActive ? "Exported!" : "Export as NDJSON"}
+        </button>
+        <button
+          type="button"
+          onClick={onClear}
+          disabled={records.length === 0}
+          className={cn(
+            "px-3 py-1.5 text-xs font-medium rounded-[var(--radius-md)] border transition-colors",
+            records.length === 0
+              ? "border-daintree-border text-daintree-text/30 cursor-not-allowed"
+              : "border-daintree-border text-status-danger hover:text-status-danger hover:bg-status-danger/10 hover:border-status-danger/20"
+          )}
+        >
+          Clear log
+        </button>
+        <span className="ml-auto text-xs text-daintree-text/40">
+          {isFiltering
+            ? `${filteredRecords.length} of ${records.length}`
+            : `${records.length} of ${maxRecords}`}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Settings/PluginActionsSettingsTab.tsx
+++ b/src/components/Settings/PluginActionsSettingsTab.tsx
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ScrollText } from "lucide-react";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { SettingsSection } from "@/components/Settings/SettingsSection";
+import { SettingsSwitchCard } from "@/components/Settings/SettingsSwitchCard";
+import { PluginActionAuditLogViewer } from "@/components/Settings/PluginActionAuditLogViewer";
+import { logError } from "@/utils/logger";
+import { type PluginActionAuditRecord, PLUGIN_AUDIT_DEFAULT_MAX_RECORDS } from "@shared/types";
+
+const COPY_FEEDBACK_MS = 2000;
+
+export function PluginActionsSettingsTab() {
+  const [records, setRecords] = useState<PluginActionAuditRecord[]>([]);
+  const [auditEnabled, setAuditEnabled] = useState(true);
+  const [maxRecords, setMaxRecords] = useState(PLUGIN_AUDIT_DEFAULT_MAX_RECORDS);
+  const [loading, setLoading] = useState(true);
+  const [copiedFlash, setCopiedFlash] = useState(false);
+  const [exportedFlash, setExportedFlash] = useState(false);
+  const [showClearConfirm, setShowClearConfirm] = useState(false);
+
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const exportTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const refreshRecords = useCallback(async (): Promise<void> => {
+    try {
+      const next = await window.electron.plugin.getAuditRecords();
+      setRecords(next);
+    } catch (err) {
+      logError("Failed to load plugin audit log", err);
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.allSettled([
+      window.electron.plugin.getAuditConfig(),
+      window.electron.plugin.getAuditRecords(),
+    ])
+      .then(([cfgResult, recordsResult]) => {
+        if (cancelled) return;
+        if (cfgResult.status === "fulfilled") {
+          setAuditEnabled(cfgResult.value.enabled);
+          setMaxRecords(cfgResult.value.maxRecords);
+        } else {
+          logError("Failed to load plugin audit config", cfgResult.reason);
+        }
+        if (recordsResult.status === "fulfilled") {
+          setRecords(recordsResult.value);
+        } else {
+          logError("Failed to load plugin audit log", recordsResult.reason);
+        }
+        setLoading(false);
+      })
+      .catch((err) => {
+        logError("Failed to load plugin audit settings", err);
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      if (exportTimeoutRef.current) clearTimeout(exportTimeoutRef.current);
+    };
+  }, []);
+
+  const handleEnabledToggle = useCallback(async () => {
+    try {
+      const next = !auditEnabled;
+      const cfg = await window.electron.plugin.setAuditEnabled(next);
+      setAuditEnabled(cfg.enabled);
+      setMaxRecords(cfg.maxRecords);
+    } catch (err) {
+      logError("Failed to toggle plugin audit log", err);
+    }
+  }, [auditEnabled]);
+
+  const handleCopy = useCallback(async (toCopy: PluginActionAuditRecord[]) => {
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(toCopy, null, 2));
+      setCopiedFlash(true);
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = setTimeout(() => setCopiedFlash(false), COPY_FEEDBACK_MS);
+    } catch (err) {
+      logError("Failed to copy plugin audit log", err);
+    }
+  }, []);
+
+  const handleExport = useCallback(async (toExport: PluginActionAuditRecord[]) => {
+    try {
+      const saved = await window.electron.plugin.exportAuditLog(toExport);
+      if (saved) {
+        setExportedFlash(true);
+        if (exportTimeoutRef.current) clearTimeout(exportTimeoutRef.current);
+        exportTimeoutRef.current = setTimeout(() => setExportedFlash(false), COPY_FEEDBACK_MS);
+      }
+    } catch (err) {
+      logError("Failed to export plugin audit log", err);
+    }
+  }, []);
+
+  const handleClear = useCallback(async () => {
+    try {
+      await window.electron.plugin.clearAuditLog();
+      setRecords([]);
+    } catch (err) {
+      logError("Failed to clear plugin audit log", err);
+    } finally {
+      setShowClearConfirm(false);
+    }
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <SettingsSection
+        icon={ScrollText}
+        title="Plugin action audit log"
+        description="Records every action dispatched by an installed plugin. Arguments are stored as a SHA-256 hash by default; turn on plaintext args in Developer mode to keep a readable copy."
+      >
+        <div className="flex flex-col gap-4">
+          <SettingsSwitchCard
+            id="plugin-audit-enable"
+            title="Record plugin actions"
+            subtitle="Append a record each time a plugin action is dispatched"
+            isEnabled={auditEnabled}
+            onChange={() => void handleEnabledToggle()}
+            ariaLabel="Toggle plugin action audit log"
+          />
+          <PluginActionAuditLogViewer
+            records={records}
+            loading={loading}
+            maxRecords={maxRecords}
+            onRefresh={refreshRecords}
+            onCopy={handleCopy}
+            onExport={handleExport}
+            onClear={() => setShowClearConfirm(true)}
+            copyFlashActive={copiedFlash}
+            exportFlashActive={exportedFlash}
+          />
+        </div>
+      </SettingsSection>
+
+      <ConfirmDialog
+        isOpen={showClearConfirm}
+        variant="destructive"
+        onConfirm={() => void handleClear()}
+        onClose={() => setShowClearConfirm(false)}
+        title="Clear plugin audit log?"
+        description="This permanently deletes all recorded plugin action dispatches on this machine. New dispatches will still be recorded."
+        confirmLabel="Clear log"
+      />
+    </div>
+  );
+}

--- a/src/components/Settings/__tests__/settingsSearchUtils.test.ts
+++ b/src/components/Settings/__tests__/settingsSearchUtils.test.ts
@@ -356,6 +356,7 @@ describe("SETTINGS_SEARCH_INDEX", () => {
       assistant: "Daintree Assistant",
 
       mcp: "MCP Server",
+      plugins: "Plugins",
       environment: "Environment",
       privacy: "Privacy & Data",
       troubleshooting: "Troubleshooting",
@@ -393,6 +394,7 @@ describe("SETTINGS_SEARCH_INDEX", () => {
       assistant: "Daintree Assistant",
 
       mcp: "MCP Server",
+      plugins: "Plugins",
       environment: "Environment Variables",
       privacy: "Privacy & Data",
       troubleshooting: "Troubleshooting",

--- a/src/components/Settings/__tests__/settingsTabRegistry.test.ts
+++ b/src/components/Settings/__tests__/settingsTabRegistry.test.ts
@@ -19,12 +19,12 @@ const globalEntries = allEntries.filter((e) => e.scope === "global");
 const projectEntries = allEntries.filter((e) => e.scope === "project");
 
 describe("SETTINGS_REGISTRY", () => {
-  it("has 25 entries (17 global + 8 project)", () => {
-    expect(SETTINGS_REGISTRY).toHaveLength(25);
+  it("has 26 entries (18 global + 8 project)", () => {
+    expect(SETTINGS_REGISTRY).toHaveLength(26);
   });
 
-  it("has 17 global entries", () => {
-    expect(globalEntries).toHaveLength(17);
+  it("has 18 global entries", () => {
+    expect(globalEntries).toHaveLength(18);
   });
 
   it("has 8 project entries", () => {
@@ -77,9 +77,9 @@ describe("SETTINGS_REGISTRY", () => {
     expect(eager[0]!.id).toBe("general");
   });
 
-  it("has 24 lazy entries (16 global + 8 project)", () => {
+  it("has 25 lazy entries (17 global + 8 project)", () => {
     const lazy = SETTINGS_REGISTRY.filter((e) => e.importKind === "lazy");
-    expect(lazy).toHaveLength(24);
+    expect(lazy).toHaveLength(25);
   });
 
   it("all global entries belong to known global groups", () => {
@@ -213,10 +213,10 @@ describe("getSettingsNavGroups", () => {
     ]);
   });
 
-  it("all 17 global entries are distributed across global groups", () => {
+  it("all 18 global entries are distributed across global groups", () => {
     const groups = getSettingsNavGroups("global");
     const totalEntries = groups.reduce((sum, g) => sum + g.entries.length, 0);
-    expect(totalEntries).toBe(17);
+    expect(totalEntries).toBe(18);
   });
 
   it("global groups contain only global-scoped entries", () => {
@@ -253,8 +253,8 @@ describe("getSettingsNavGroups", () => {
 });
 
 describe("SettingsTab type coverage", () => {
-  it("union of registry IDs equals 25", () => {
+  it("union of registry IDs equals 26", () => {
     const allIds = new Set(SETTINGS_REGISTRY.map((e) => e.id));
-    expect(allIds.size).toBe(25);
+    expect(allIds.size).toBe(26);
   });
 });

--- a/src/components/Settings/settingsTabRegistry.tsx
+++ b/src/components/Settings/settingsTabRegistry.tsx
@@ -8,6 +8,7 @@ import {
   Mic,
   PanelRight,
   Keyboard,
+  ScrollText,
   SquareTerminal,
   Settings as SettingsIcon,
   Settings2,
@@ -94,6 +95,7 @@ const importToolbarSettingsTab = () => import("./ToolbarSettingsTab");
 const importIntegrationsTab = () => import("./IntegrationsTab");
 const importVoiceInputSettingsTab = () => import("./VoiceInputSettingsTab");
 const importMcpServerSettingsTab = () => import("./McpServerSettingsTab");
+const importPluginActionsSettingsTab = () => import("./PluginActionsSettingsTab");
 const importDaintreeAssistantSettingsTab = () => import("./DaintreeAssistantSettingsTab");
 const importEnvironmentSettingsTab = () => import("./EnvironmentSettingsTab");
 const importPrivacyDataTab = () => import("./PrivacyDataTab");
@@ -146,6 +148,9 @@ const LazyVoiceInputSettingsTab = lazy(() =>
 );
 const LazyMcpServerSettingsTab = lazy(() =>
   importMcpServerSettingsTab().then((m) => ({ default: m.McpServerSettingsTab }))
+);
+const LazyPluginActionsSettingsTab = lazy(() =>
+  importPluginActionsSettingsTab().then((m) => ({ default: m.PluginActionsSettingsTab }))
 );
 const LazyDaintreeAssistantSettingsTab = lazy(() =>
   importDaintreeAssistantSettingsTab().then((m) => ({ default: m.DaintreeAssistantSettingsTab }))
@@ -1340,6 +1345,30 @@ export const SETTINGS_REGISTRY = [
     ],
   } satisfies LazySettingsTabEntry,
 
+  {
+    id: "plugins",
+    scope: "global",
+    group: "Integrations",
+    label: "Plugins",
+    headerTitle: "Plugins",
+    icon: <ScrollText className="w-4 h-4" />,
+    importKind: "lazy",
+    importer: importPluginActionsSettingsTab,
+    LazyComponent: LazyPluginActionsSettingsTab,
+    searchNavDescription: "Audit log of actions dispatched by installed plugins",
+    searchNavKeywords: ["plugins", "audit", "log", "actions", "dispatch", "history", "security"],
+    sections: [
+      {
+        id: "plugin-audit-enable",
+        section: "Plugin action audit log",
+        title: "Record plugin actions",
+        description:
+          "Append a structured audit record each time an installed plugin dispatches an action. Arguments are hashed by default.",
+        keywords: ["plugin", "audit", "log", "record", "actions", "dispatch", "hash", "privacy"],
+      },
+    ],
+  } satisfies LazySettingsTabEntry,
+
   // ═══ Global — Support ═══
   {
     id: "troubleshooting",
@@ -1741,6 +1770,7 @@ export const globalTabIcons: Record<GlobalSettingsTab, ReactNode> = {
   integrations: <Blocks className="w-5 h-5 text-text-secondary" />,
   voice: <Mic className="w-5 h-5 text-text-secondary" />,
   mcp: <McpServerIcon className="w-5 h-5 text-text-secondary" />,
+  plugins: <ScrollText className="w-5 h-5 text-text-secondary" />,
   environment: <KeyRound className="w-5 h-5 text-text-secondary" />,
   privacy: <Shield className="w-5 h-5 text-text-secondary" />,
   troubleshooting: <LifeBuoy className="w-5 h-5 text-text-secondary" />,

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -392,6 +392,7 @@ export class ActionService {
         danger: definition.danger,
         safeArgs: this.extractSafeBreadcrumbArgs(args, definition),
         confirmed: options?.confirmed,
+        pluginId: definition.pluginId,
       });
       this.emitShortcutHint(actionId, source);
       return { ok: true, result: result as Result };
@@ -603,8 +604,14 @@ export class ActionService {
     danger: ActionDanger;
     safeArgs?: Record<string, unknown>;
     confirmed?: boolean;
+    pluginId?: string;
   }): Promise<void> {
     if (!isElectronApiAvailable()) return;
+
+    // Plugin actions feed the plugin-action audit log: compute the SHA-256
+    // digest of the (already redacted) args in the renderer so raw args need
+    // never cross IPC for fingerprinting. Built-in actions skip this entirely.
+    const argsHash = payload.pluginId !== undefined ? await sha256Hex(payload.args) : undefined;
 
     try {
       await window.electron.events.emit("action:dispatched", {
@@ -618,6 +625,8 @@ export class ActionService {
         danger: payload.danger,
         ...(payload.safeArgs ? { safeArgs: payload.safeArgs } : {}),
         ...(payload.confirmed !== undefined ? { confirmed: payload.confirmed } : {}),
+        ...(payload.pluginId !== undefined ? { pluginId: payload.pluginId } : {}),
+        ...(argsHash !== undefined ? { argsHash } : {}),
       });
     } catch (err) {
       logWarn("Failed to emit action:dispatched event", {
@@ -625,6 +634,33 @@ export class ActionService {
         error: err,
       });
     }
+  }
+}
+
+/**
+ * SHA-256 hex digest of the JSON-serialized value, computed via SubtleCrypto.
+ * Returns an empty string when the value is absent, unserializable, or when
+ * the Web Crypto API is unavailable — the audit record stores `""` rather
+ * than failing the dispatch flow.
+ */
+async function sha256Hex(value: unknown): Promise<string> {
+  if (value === undefined || value === null) return "";
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    serialized = "[unserializable]";
+  }
+  if (serialized === undefined) serialized = "[unserializable]";
+  try {
+    const subtle = globalThis.crypto?.subtle;
+    if (!subtle) return "";
+    const buf = await subtle.digest("SHA-256", new TextEncoder().encode(serialized));
+    return Array.from(new Uint8Array(buf))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+  } catch {
+    return "";
   }
 }
 


### PR DESCRIPTION
Mirrors the existing MCP audit system for plugin-dispatched actions. Closes #9232.

## Summary

- Adds `PluginActionAuditRecord` + `PluginActionAuditService` (`electron/services/PluginActionAuditService.ts`): a debounced ring buffer, configurable max records, flushed on shutdown.
- Privacy by default: args stored as a SHA-256 `argsHash`; raw plaintext only persisted when `developerMode.pluginAuditPlaintext` is enabled. The renderer computes the hash before the IPC boundary; the handler validates `pluginId` (≤100 chars) and `argsHash` (strict 64-char lowercase hex).
- 6 new IPC channels via the codegen namespace (`plugin:get-audit-records`, `get-audit-config`, `clear-audit-log`, `set-audit-enabled`, `set-audit-max-records`, `export-audit-log`).
- New "Plugins" settings tab under Integrations with a full audit log viewer: filter by plugin/action, copy as JSON, export as NDJSON, clear with a confirm dialog.

## Changes

- `electron/services/PluginActionAuditService.ts` — ring-buffer service + shutdown flush
- `electron/services/events.ts`, `electron/ipc/handlers/events.ts` — emit `pluginId` + `argsHash` on `action:dispatched`
- `electron/ipc/handlers/plugin.ts` — 6 audit IPC handlers with input validation
- `electron/store.ts` — `auditEnabled` (default `true`) + `maxRecords` in plugins store slice
- `electron/window/globalServicesInit.ts` + `electron/lifecycle/shutdown.ts` — service wiring
- `shared/types/ipc/pluginAudit.ts`, `generated-api.ts`, `generated.ts` — shared types
- `src/services/ActionService.ts` — computes SHA-256 `argsHash`, forwards `pluginId`
- `src/components/Settings/PluginActionsSettingsTab.tsx` + `PluginActionAuditLogViewer.tsx` — settings tab + viewer
- `src/components/Settings/settingsTabRegistry.tsx` — registers the new tab

## Scope note

This first pass records successful dispatches (`action:dispatched` fires post-success). The `result` union reserves `error`/`disabled`/`restricted` variants for a follow-up; full capability grant/denial recording depends on #9231's capability gate.

## Testing

- `PluginActionAuditService` unit tests: ring-buffer eviction, plaintext gating, hydration, flush/dispose, bus integration.
- `events.handlers.test.ts`: verifies `pluginId` + `argsHash` forwarding and hex boundary validation.
- `plugin.handlers.test.ts`: handler registration coverage.
- `leafPreloadNamespaces.test.ts`: new IPC channels in inventory.