### PR TITLE
feat(plugins): implement host.dispatch(actionId, args)

### DIFF
--- a/electron/ipc/__tests__/channelDrift.test.ts
+++ b/electron/ipc/__tests__/channelDrift.test.ts
@@ -58,6 +58,10 @@ const DEAD_CHANNEL_ALLOWLIST = new Set<string>([
   "app-agent:dispatch-action-response",
   "mcp:dispatch-action-response",
   "mcp:get-manifest-response",
+  // fire-and-forget — renderer→main `ipcRenderer.send` reply for the plugin
+  // host.dispatch bridge (PluginService.ts). Paired with the request event
+  // `plugin:dispatch-action-request` declared in IpcEventMap.
+  "plugin:dispatch-action-response",
 
   // fire-and-forget — main→renderer broadcast for in-app demo command
   // forwarding (`sendCommandAndAwait` in handlers/demo.ts). The renderer

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -792,6 +792,10 @@ export const CHANNELS = {
   PLUGIN_SET_AUDIT_ENABLED: "plugin:set-audit-enabled",
   PLUGIN_SET_AUDIT_MAX_RECORDS: "plugin:set-audit-max-records",
   PLUGIN_EXPORT_AUDIT_LOG: "plugin:export-audit-log",
+  /** Bridge: main process (host.dispatch) requests an action dispatch from the renderer. */
+  PLUGIN_DISPATCH_ACTION_REQUEST: "plugin:dispatch-action-request",
+  /** Bridge: renderer returns the action dispatch result to the main process. */
+  PLUGIN_DISPATCH_ACTION_RESPONSE: "plugin:dispatch-action-response",
 
   // Config reload channels
   APP_RELOAD_CONFIG: "app:reload-config",

--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -129,7 +129,8 @@ function normalizeActionDispatchedPayload(
     source !== "keybinding" &&
     source !== "menu" &&
     source !== "agent" &&
-    source !== "context-menu"
+    source !== "context-menu" &&
+    source !== "plugin"
   ) {
     return null;
   }
@@ -183,16 +184,22 @@ function normalizeActionDispatchedPayload(
 
   // Plugin-action audit fields. Both are renderer-controlled strings crossing
   // a trust boundary, so cap/shape them: `pluginId` to a sane length and
-  // `argsHash` to a strict 64-char lowercase-hex SHA-256 digest.
+  // `argsHash` to a strict 64-char lowercase-hex SHA-256 digest. Only carried
+  // for plugin-sourced dispatches (#9280) so the audit log records which
+  // plugin invoked a built-in action; ignored otherwise.
   const pluginIdRaw = payload.pluginId;
   const pluginId =
-    typeof pluginIdRaw === "string" && pluginIdRaw.trim().length > 0 && pluginIdRaw.length <= 100
+    source === "plugin" &&
+    typeof pluginIdRaw === "string" &&
+    pluginIdRaw.trim().length > 0 &&
+    pluginIdRaw.length <= 100
       ? pluginIdRaw
       : undefined;
 
   const argsHashRaw = payload.argsHash;
   const argsHash =
     typeof argsHashRaw === "string" && /^[0-9a-f]{64}$/.test(argsHashRaw) ? argsHashRaw : undefined;
+
 
   return {
     actionId,

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2385,6 +2385,37 @@ const api: ElectronAPI = {
     },
   },
 
+  // Main→renderer bridge for plugin host.dispatch (#9280). The renderer
+  // executes the action via ActionService as the "plugin" source and replies
+  // with the dispatch result. Distinct channels from mcpBridge keep the plugin
+  // and MCP security boundaries traceable.
+  pluginDispatchBridge: {
+    onDispatchActionRequest: (
+      callback: (payload: {
+        requestId: string;
+        pluginId: string;
+        actionId: string;
+        args?: unknown;
+      }) => void
+    ) => {
+      const handler = (
+        _event: Electron.IpcRendererEvent,
+        payload: {
+          requestId: string;
+          pluginId: string;
+          actionId: string;
+          args?: unknown;
+        }
+      ) => callback(payload);
+      ipcRenderer.on(CHANNELS.PLUGIN_DISPATCH_ACTION_REQUEST, handler);
+      return () => ipcRenderer.removeListener(CHANNELS.PLUGIN_DISPATCH_ACTION_REQUEST, handler);
+    },
+
+    sendDispatchActionResponse: (payload: { requestId: string; result: unknown }) => {
+      ipcRenderer.send(CHANNELS.PLUGIN_DISPATCH_ACTION_RESPONSE, payload);
+    },
+  },
+
   plugin: {
     ...buildPluginPreloadBindings(_unwrappingInvoke),
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -159,6 +159,8 @@ type WorkspaceWorktreeEvent = "worktree-update" | "worktree-activated" | "worktr
 
 /** Pending `host.dispatch` round-trip, keyed by requestId in {@link PluginService.pendingDispatches}. */
 interface PendingPluginDispatch {
+  /** Originating plugin, so unloadPlugin() can settle just its slice of pending dispatches. */
+  pluginId: string;
   resolve: (result: ActionDispatchResult) => void;
   timer: ReturnType<typeof setTimeout>;
   webContentsId: number;
@@ -972,6 +974,7 @@ export class PluginService {
       };
 
       this.pendingDispatches.set(requestId, {
+        pluginId,
         resolve,
         timer,
         webContentsId,
@@ -1023,7 +1026,13 @@ export class PluginService {
     clearTimeout(pending.timer);
     pending.destroyedCleanup();
     this.pendingDispatches.delete(requestId);
-    pending.resolve(result as ActionDispatchResult);
+    // Defensive: a malformed reply (valid requestId, missing result) must not
+    // resolve the plugin's promise with undefined — surface it as an error.
+    pending.resolve(
+      result != null
+        ? (result as ActionDispatchResult)
+        : { ok: false, error: { code: "EXECUTION_ERROR", message: "Missing dispatch result" } }
+    );
   }
 
   private async fetchAllWorktreeSnapshots(): Promise<WorktreeSnapshot[]> {
@@ -1243,6 +1252,21 @@ export class PluginService {
     runUnloadStep(pluginId, "unregisterFileDecorationProviderImpls", () =>
       unregisterFileDecorationProviderImpls(pluginId)
     );
+
+    // Settle any in-flight host.dispatch for this plugin before removing it from
+    // the map, so an awaited dispatch resolves PLUGIN_UNLOADED now rather than
+    // succeeding after the plugin's cleanup has run (or waiting out the 30s
+    // timeout). Mirrors dispose()'s blanket settlement, scoped to one plugin.
+    for (const [requestId, pending] of this.pendingDispatches) {
+      if (pending.pluginId !== pluginId) continue;
+      clearTimeout(pending.timer);
+      pending.destroyedCleanup();
+      this.pendingDispatches.delete(requestId);
+      pending.resolve({
+        ok: false,
+        error: { code: "PLUGIN_UNLOADED", message: `Plugin "${pluginId}" was unloaded` },
+      });
+    }
 
     this.plugins.delete(pluginId);
     this.pluginLoadErrors.delete(pluginId);

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -3,7 +3,8 @@ import fs from "fs/promises";
 import path from "path";
 import os from "os";
 import { pathToFileURL } from "url";
-import { app } from "electron";
+import { randomUUID } from "node:crypto";
+import { app, ipcMain } from "electron";
 import * as semver from "semver";
 import { PluginManifestSchema } from "../schemas/plugin.js";
 import type {
@@ -16,7 +17,9 @@ import type {
   PluginActionDescriptor,
   BuiltInPluginPermission,
 } from "../../shared/types/plugin.js";
+import type { ActionDispatchResult } from "../../shared/types/actions.js";
 import type { WorktreeSnapshot } from "../../shared/types/workspace-host.js";
+import { getProjectViewManager, getWindowRegistry } from "../window/windowRef.js";
 import { toPluginWorktreeSnapshot } from "../../shared/utils/pluginWorktreeSnapshot.js";
 import type { WorkspaceClient } from "./WorkspaceClient.js";
 import {
@@ -145,7 +148,22 @@ function runUnloadStep(pluginId: string, step: string, fn: () => void): void {
   }
 }
 
+/**
+ * Upper bound on a single `host.dispatch` round-trip to the renderer. Mirrors
+ * the MCP bridge's dispatch timeout — a renderer that never answers (mid-reload,
+ * wedged) must not leave the plugin's promise pending forever.
+ */
+const PLUGIN_DISPATCH_TIMEOUT_MS = 30_000;
+
 type WorkspaceWorktreeEvent = "worktree-update" | "worktree-activated" | "worktree-removed";
+
+/** Pending `host.dispatch` round-trip, keyed by requestId in {@link PluginService.pendingDispatches}. */
+interface PendingPluginDispatch {
+  resolve: (result: ActionDispatchResult) => void;
+  timer: ReturnType<typeof setTimeout>;
+  webContentsId: number;
+  destroyedCleanup: () => void;
+}
 
 export class PluginService {
   private plugins = new Map<string, LoadedPlugin>();
@@ -217,6 +235,17 @@ export class PluginService {
   private disposed = false;
   private readonly disposeRegistrySubscriptions: () => void;
 
+  /**
+   * In-flight `host.dispatch` round-trips keyed by requestId. Keying by
+   * requestId (not pluginId) is required so concurrent dispatches — from one
+   * plugin or several — never collide on a shared callback slot (#1557).
+   */
+  private pendingDispatches = new Map<string, PendingPluginDispatch>();
+  private readonly dispatchResponseHandler: (
+    event: Electron.IpcMainEvent,
+    payload: unknown
+  ) => void;
+
   constructor(
     pluginsRoot?: string,
     appVersion?: string,
@@ -232,6 +261,12 @@ export class PluginService {
       offRegister();
       offUnregister();
     };
+
+    // The dispatch-response listener must be live before any plugin activates,
+    // since host.dispatch can fire from a timer set up during activate(). Bound
+    // once here and torn down in dispose() so test instances don't leak it.
+    this.dispatchResponseHandler = (event, payload) => this.handleDispatchResponse(event, payload);
+    ipcMain.on(CHANNELS.PLUGIN_DISPATCH_ACTION_RESPONSE, this.dispatchResponseHandler);
   }
 
   /**
@@ -244,6 +279,18 @@ export class PluginService {
   dispose(): void {
     this.disposed = true;
     this.disposeRegistrySubscriptions();
+    ipcMain.removeListener(CHANNELS.PLUGIN_DISPATCH_ACTION_RESPONSE, this.dispatchResponseHandler);
+    // Settle any in-flight dispatch so a test (or shutdown) doesn't leave a
+    // plugin promise pending forever.
+    for (const [, pending] of this.pendingDispatches) {
+      clearTimeout(pending.timer);
+      pending.destroyedCleanup();
+      pending.resolve({
+        ok: false,
+        error: { code: "PLUGIN_UNLOADED", message: "Plugin service disposed" },
+      });
+    }
+    this.pendingDispatches.clear();
   }
 
   /**
@@ -801,6 +848,32 @@ export class PluginService {
           payload: { scope, ...(narrowed && narrowed.length > 0 ? { paths: narrowed } : {}) },
         });
       },
+      // NOT revoke-guarded — same rationale as invalidateFileDecorations: a
+      // plugin orchestrates the app from its own timers and subscription
+      // callbacks, which fire long after activate() resolves. The liveness
+      // guard is plugin membership; once unloaded this resolves to
+      // PLUGIN_UNLOADED rather than throwing into the plugin's closure.
+      dispatch: (actionId, args) => {
+        if (!this.plugins.has(pluginId)) {
+          return Promise.resolve({
+            ok: false,
+            error: {
+              code: "PLUGIN_UNLOADED",
+              message: `Plugin "${pluginId}" is no longer loaded`,
+            },
+          } satisfies ActionDispatchResult);
+        }
+        if (typeof actionId !== "string" || actionId.length === 0) {
+          return Promise.resolve({
+            ok: false,
+            error: {
+              code: "VALIDATION_ERROR",
+              message: `Plugin "${pluginId}" dispatch: actionId must be a non-empty string`,
+            },
+          } satisfies ActionDispatchResult);
+        }
+        return this.sendPluginDispatchRequest(pluginId, actionId, args);
+      },
     };
     return {
       host,
@@ -808,6 +881,149 @@ export class PluginService {
         revoked = true;
       },
     };
+  }
+
+  /**
+   * Resolve the renderer WebContents that should execute a plugin-sourced
+   * dispatch. Plugins have no per-window ownership, so this targets the active
+   * project view of the first live window — never a broadcast, which would race
+   * multiple renderers into duplicate executions and duplicate responses.
+   * Mirrors the MCP renderer bridge's `getActiveProjectWebContents`.
+   */
+  private resolveActiveWebContents(): Electron.WebContents {
+    const registry = getWindowRegistry();
+    if (registry) {
+      for (const ctx of registry.all()) {
+        if (ctx.browserWindow.isDestroyed()) continue;
+        const webContents = ctx.services.projectViewManager?.getActiveView()?.webContents;
+        if (webContents && !webContents.isDestroyed()) {
+          return webContents;
+        }
+      }
+    }
+
+    const fallback = getProjectViewManager()?.getActiveView()?.webContents;
+    if (fallback && !fallback.isDestroyed()) {
+      return fallback;
+    }
+
+    throw new Error("Plugin dispatch renderer bridge unavailable");
+  }
+
+  /**
+   * Main→renderer dispatch round-trip for `host.dispatch`. Sends the action to
+   * a single live renderer, validates the response sender, and times out after
+   * {@link PLUGIN_DISPATCH_TIMEOUT_MS}. Resolves (never rejects) with an
+   * {@link ActionDispatchResult} envelope so the plugin always gets a typed
+   * outcome rather than a thrown error to catch.
+   */
+  private sendPluginDispatchRequest(
+    pluginId: string,
+    actionId: string,
+    args: unknown
+  ): Promise<ActionDispatchResult> {
+    return new Promise((resolve) => {
+      let webContents: Electron.WebContents;
+      try {
+        webContents = this.resolveActiveWebContents();
+      } catch (err) {
+        resolve({
+          ok: false,
+          error: {
+            code: "EXECUTION_ERROR",
+            message:
+              err instanceof Error ? err.message : "Plugin dispatch renderer bridge unavailable",
+          },
+        });
+        return;
+      }
+
+      const requestId = randomUUID();
+      const webContentsId = webContents.id;
+
+      const timer = setTimeout(() => {
+        const pending = this.pendingDispatches.get(requestId);
+        if (!pending) return;
+        pending.destroyedCleanup();
+        this.pendingDispatches.delete(requestId);
+        resolve({
+          ok: false,
+          error: { code: "EXECUTION_ERROR", message: `Action dispatch timed out: ${actionId}` },
+        });
+      }, PLUGIN_DISPATCH_TIMEOUT_MS);
+
+      const onDestroyed = () => {
+        const pending = this.pendingDispatches.get(requestId);
+        if (!pending) return;
+        clearTimeout(pending.timer);
+        this.pendingDispatches.delete(requestId);
+        resolve({
+          ok: false,
+          error: { code: "EXECUTION_ERROR", message: "Plugin dispatch renderer destroyed" },
+        });
+      };
+      webContents.once("destroyed", onDestroyed);
+      const destroyedCleanup = () => {
+        try {
+          webContents.removeListener("destroyed", onDestroyed);
+        } catch {
+          // best-effort; webContents may already be gone
+        }
+      };
+
+      this.pendingDispatches.set(requestId, {
+        resolve,
+        timer,
+        webContentsId,
+        destroyedCleanup,
+      });
+
+      try {
+        webContents.send(CHANNELS.PLUGIN_DISPATCH_ACTION_REQUEST, {
+          requestId,
+          pluginId,
+          actionId,
+          args,
+        });
+      } catch (err) {
+        clearTimeout(timer);
+        destroyedCleanup();
+        this.pendingDispatches.delete(requestId);
+        resolve({
+          ok: false,
+          error: {
+            code: "EXECUTION_ERROR",
+            message: err instanceof Error ? err.message : `Failed to dispatch action: ${actionId}`,
+          },
+        });
+      }
+    });
+  }
+
+  /**
+   * Handles the renderer's reply to a `host.dispatch` request. Validates the
+   * sender against the WebContents the request was sent to so a stale or
+   * cross-window renderer can't resolve a pending dispatch it doesn't own.
+   */
+  private handleDispatchResponse(event: Electron.IpcMainEvent, payload: unknown): void {
+    if (!payload || typeof payload !== "object") return;
+    const { requestId, result } = payload as {
+      requestId?: unknown;
+      result?: unknown;
+    };
+    if (typeof requestId !== "string") return;
+    const pending = this.pendingDispatches.get(requestId);
+    if (!pending) return;
+    if (event.sender.id !== pending.webContentsId) {
+      console.warn(
+        `[PluginService] Ignoring dispatch response from unexpected sender ${event.sender.id} (expected ${pending.webContentsId}, requestId=${requestId})`
+      );
+      return;
+    }
+    clearTimeout(pending.timer);
+    pending.destroyedCleanup();
+    this.pendingDispatches.delete(requestId);
+    pending.resolve(result as ActionDispatchResult);
   }
 
   private async fetchAllWorktreeSnapshots(): Promise<WorktreeSnapshot[]> {

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -21,6 +21,7 @@ import type { ActionDispatchResult } from "../../shared/types/actions.js";
 import type { WorktreeSnapshot } from "../../shared/types/workspace-host.js";
 import { getProjectViewManager, getWindowRegistry } from "../window/windowRef.js";
 import { toPluginWorktreeSnapshot } from "../../shared/utils/pluginWorktreeSnapshot.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import type { WorkspaceClient } from "./WorkspaceClient.js";
 import {
   registerPanelKind,
@@ -933,8 +934,7 @@ export class PluginService {
           ok: false,
           error: {
             code: "EXECUTION_ERROR",
-            message:
-              err instanceof Error ? err.message : "Plugin dispatch renderer bridge unavailable",
+            message: formatErrorMessage(err, "Plugin dispatch renderer bridge unavailable"),
           },
         });
         return;
@@ -996,7 +996,7 @@ export class PluginService {
           ok: false,
           error: {
             code: "EXECUTION_ERROR",
-            message: err instanceof Error ? err.message : `Failed to dispatch action: ${actionId}`,
+            message: formatErrorMessage(err, `Failed to dispatch action: ${actionId}`),
           },
         });
       }

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -34,6 +34,7 @@ import { randomUUID } from "crypto";
 const storeState = new Map<string, unknown>();
 vi.mock("electron", () => ({
   app: { getVersion: vi.fn(() => "0.0.0") },
+  ipcMain: { on: vi.fn(), removeListener: vi.fn() },
 }));
 vi.mock("../../ipc/utils.js", () => ({
   broadcastToRenderer: vi.fn(),

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -8,6 +8,10 @@ import type { PanelKindConfig } from "../../../shared/config/panelKindRegistry.j
 const appMock = vi.hoisted(() => ({
   getVersion: vi.fn(() => "0.0.0"),
 }));
+const ipcMainMock = vi.hoisted(() => ({
+  on: vi.fn(),
+  removeListener: vi.fn(),
+}));
 const broadcastToRendererMock = vi.hoisted(() => vi.fn());
 const storeMock = vi.hoisted(() => {
   const state = new Map<string, unknown>();
@@ -20,6 +24,7 @@ const storeMock = vi.hoisted(() => {
 
 vi.mock("electron", () => ({
   app: appMock,
+  ipcMain: ipcMainMock,
 }));
 vi.mock("../../ipc/utils.js", () => ({
   broadcastToRenderer: broadcastToRendererMock,
@@ -1620,6 +1625,10 @@ type CreateHostShape = (pluginId: string) => {
     registerHandler: (channel: string, handler: (...args: unknown[]) => unknown) => void;
     broadcastToRenderer: (channel: string, payload: unknown) => void;
     registerForgeProvider: (descriptor: { id: string }, impl: unknown) => () => void;
+    dispatch: (
+      actionId: string,
+      args?: unknown
+    ) => Promise<import("../../../shared/types/actions.js").ActionDispatchResult>;
   };
   revoke: () => void;
 };
@@ -1693,6 +1702,60 @@ describe("createHost (plugin activation API)", () => {
     expect(() => host.registerForgeProvider({ id: "github" }, {})).toThrow(
       /host revoked: registerForgeProvider/
     );
+  });
+});
+
+describe("createHost — host.dispatch (#9280)", () => {
+  it("resolves PLUGIN_UNLOADED when the plugin is not loaded", async () => {
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    // createHost for a pluginId never added to the plugins map — mirrors the
+    // post-unload state where a stale timer still holds the host closure.
+    const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(
+      "acme.ghost"
+    );
+
+    const result = await host.dispatch("terminal.new");
+    expect(result).toEqual({
+      ok: false,
+      error: { code: "PLUGIN_UNLOADED", message: expect.stringContaining("acme.ghost") },
+    });
+  });
+
+  it("stays callable after revoke (not revoke-guarded) but fails closed without a renderer", async () => {
+    await writePlugin("dispatch-live", { name: "acme.dispatch-live", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host, revoke } = (service as unknown as { createHost: CreateHostShape }).createHost(
+      "acme.dispatch-live"
+    );
+    revoke();
+
+    // Plugin is still loaded, so revoke does not gate dispatch; with no active
+    // renderer WebContents in this test the bridge fails closed.
+    const result = await host.dispatch("terminal.new");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("EXECUTION_ERROR");
+    }
+  });
+
+  it("rejects a non-string actionId with VALIDATION_ERROR", async () => {
+    await writePlugin("dispatch-validate", { name: "acme.dispatch-validate", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(
+      "acme.dispatch-validate"
+    );
+
+    const result = await host.dispatch("");
+    expect(result).toEqual({
+      ok: false,
+      error: { code: "VALIDATION_ERROR", message: expect.stringContaining("actionId") },
+    });
   });
 });
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -12,6 +12,9 @@ const ipcMainMock = vi.hoisted(() => ({
   on: vi.fn(),
   removeListener: vi.fn(),
 }));
+const windowRefMock = vi.hoisted(() => ({
+  activeWebContents: null as { id: number; send: ReturnType<typeof vi.fn> } | null,
+}));
 const broadcastToRendererMock = vi.hoisted(() => vi.fn());
 const storeMock = vi.hoisted(() => {
   const state = new Map<string, unknown>();
@@ -31,6 +34,15 @@ vi.mock("../../ipc/utils.js", () => ({
 }));
 vi.mock("../../store.js", () => ({
   store: storeMock,
+}));
+vi.mock("../../window/windowRef.js", () => ({
+  // No registry — force the getProjectViewManager() fallback path, which the
+  // dispatch tests drive via windowRefMock.activeWebContents.
+  getWindowRegistry: () => null,
+  getProjectViewManager: () =>
+    windowRefMock.activeWebContents
+      ? { getActiveView: () => ({ webContents: windowRefMock.activeWebContents }) }
+      : null,
 }));
 vi.mock("../../../shared/config/panelKindRegistry.js", () => ({
   registerPanelKind: vi.fn(),
@@ -1755,6 +1767,145 @@ describe("createHost — host.dispatch (#9280)", () => {
     expect(result).toEqual({
       ok: false,
       error: { code: "VALIDATION_ERROR", message: expect.stringContaining("actionId") },
+    });
+  });
+});
+
+describe("host.dispatch — renderer bridge round-trip (#9280)", () => {
+  interface FakeWebContents {
+    id: number;
+    send: ReturnType<typeof vi.fn>;
+    once: ReturnType<typeof vi.fn>;
+    removeListener: ReturnType<typeof vi.fn>;
+    isDestroyed: () => boolean;
+  }
+
+  function makeFakeWebContents(id: number): FakeWebContents {
+    return {
+      id,
+      send: vi.fn(),
+      once: vi.fn(),
+      removeListener: vi.fn(),
+      isDestroyed: () => false,
+    };
+  }
+
+  /**
+   * Build a service whose constructor-registered response handler is captured,
+   * with a fake active WebContents the dispatch bridge will target. Returns the
+   * host, the captured response handler, and the fake WebContents.
+   */
+  async function setupDispatchService(
+    pluginId: string,
+    webContentsId = 42
+  ): Promise<{
+    service: PluginService;
+    host: ReturnType<CreateHostShape>["host"];
+    wc: FakeWebContents;
+    respond: (event: { sender: { id: number } }, payload: unknown) => void;
+  }> {
+    await writePlugin(pluginId.replace(/\W/g, "-"), { name: pluginId, version: "1.0.0" });
+    const wc = makeFakeWebContents(webContentsId);
+    windowRefMock.activeWebContents = wc as unknown as {
+      id: number;
+      send: ReturnType<typeof vi.fn>;
+    };
+
+    ipcMainMock.on.mockClear();
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const respond = ipcMainMock.on.mock.calls[0]![1] as (
+      event: { sender: { id: number } },
+      payload: unknown
+    ) => void;
+
+    const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(pluginId);
+    return { service, host, wc, respond };
+  }
+
+  afterEach(() => {
+    windowRefMock.activeWebContents = null;
+  });
+
+  it("sends the request to the active WebContents and resolves the renderer's result", async () => {
+    const { host, wc, respond } = await setupDispatchService("acme.rt");
+
+    const pending = host.dispatch("terminal.new", { foo: 1 });
+    expect(wc.send).toHaveBeenCalledTimes(1);
+    const [, payload] = wc.send.mock.calls[0]! as [string, { requestId: string; pluginId: string }];
+    expect(payload.pluginId).toBe("acme.rt");
+
+    respond(
+      { sender: { id: wc.id } },
+      { requestId: payload.requestId, result: { ok: true, result: 7 } }
+    );
+    await expect(pending).resolves.toEqual({ ok: true, result: 7 });
+  });
+
+  it("ignores a response from an unexpected sender (cross-window guard)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { host, wc, respond } = await setupDispatchService("acme.sender");
+
+    const pending = host.dispatch("terminal.new");
+    const [, payload] = wc.send.mock.calls[0]! as [string, { requestId: string }];
+
+    // Wrong sender id — must not resolve the pending promise.
+    respond({ sender: { id: wc.id + 1 } }, { requestId: payload.requestId, result: { ok: true } });
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    expect(warnSpy).toHaveBeenCalled();
+
+    // Correct sender still settles it.
+    respond({ sender: { id: wc.id } }, { requestId: payload.requestId, result: { ok: true } });
+    await expect(pending).resolves.toEqual({ ok: true });
+    warnSpy.mockRestore();
+  });
+
+  it("resolves concurrent out-of-order dispatches to their own results", async () => {
+    const { host, wc, respond } = await setupDispatchService("acme.concurrent");
+
+    const p1 = host.dispatch("a.one");
+    const p2 = host.dispatch("a.two");
+    const id1 = (wc.send.mock.calls[0]![1] as { requestId: string }).requestId;
+    const id2 = (wc.send.mock.calls[1]![1] as { requestId: string }).requestId;
+
+    // Reply in reverse order.
+    respond({ sender: { id: wc.id } }, { requestId: id2, result: { ok: true, result: "two" } });
+    respond({ sender: { id: wc.id } }, { requestId: id1, result: { ok: true, result: "one" } });
+
+    await expect(p1).resolves.toEqual({ ok: true, result: "one" });
+    await expect(p2).resolves.toEqual({ ok: true, result: "two" });
+  });
+
+  it("surfaces EXECUTION_ERROR when the response omits a result", async () => {
+    const { host, wc, respond } = await setupDispatchService("acme.noresult");
+
+    const pending = host.dispatch("terminal.new");
+    const { requestId } = wc.send.mock.calls[0]![1] as { requestId: string };
+
+    respond({ sender: { id: wc.id } }, { requestId });
+    await expect(pending).resolves.toEqual({
+      ok: false,
+      error: { code: "EXECUTION_ERROR", message: "Missing dispatch result" },
+    });
+  });
+
+  it("settles an in-flight dispatch with PLUGIN_UNLOADED when the plugin unloads", async () => {
+    const { service, host } = await setupDispatchService("acme.unload-pending");
+
+    const pending = host.dispatch("terminal.new");
+    (service as unknown as { unloadPlugin: (id: string) => void }).unloadPlugin(
+      "acme.unload-pending"
+    );
+
+    await expect(pending).resolves.toEqual({
+      ok: false,
+      error: { code: "PLUGIN_UNLOADED", message: expect.stringContaining("acme.unload-pending") },
     });
   });
 });

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -638,7 +638,7 @@ export type DaintreeEventMap = {
      * redacted but not allowlisted.
      */
     safeArgs?: Record<string, unknown>;
-    source: "user" | "keybinding" | "menu" | "agent" | "context-menu";
+    source: "user" | "keybinding" | "menu" | "agent" | "context-menu" | "plugin";
     context: {
       projectId?: string;
       activeWorktreeId?: string;
@@ -652,9 +652,10 @@ export type DaintreeEventMap = {
     confirmed?: boolean;
     /**
      * Contributing plugin id when this action was registered by a plugin
-     * (`ActionDefinition.pluginId`). Absent for built-in actions. Drives the
-     * plugin-action audit log — the main-side `PluginActionAuditService`
-     * appends a record only when this is present.
+     * (`ActionDefinition.pluginId`) or when `source === "plugin"` (host.dispatch
+     * from #9280). Absent for built-in actions invoked by user/keybinding/menu/
+     * agent/context-menu. Drives the plugin-action audit log — the main-side
+     * `PluginActionAuditService` appends a record only when this is present.
      */
     pluginId?: string;
     /**

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -2,7 +2,7 @@ import type { BuiltInKeyAction } from "./keymap.js";
 import type { BuiltInRuntimeActionId } from "../config/actionIds.js";
 import type { z } from "zod";
 
-export type ActionSource = "user" | "keybinding" | "menu" | "agent" | "context-menu";
+export type ActionSource = "user" | "keybinding" | "menu" | "agent" | "context-menu" | "plugin";
 
 export type ActionKind = "command" | "query";
 
@@ -210,7 +210,8 @@ export type ActionErrorCode =
   | "USER_REJECTED"
   | "CONFIRMATION_TIMEOUT"
   | "ELICITATION_FAILED"
-  | "BINDING_STALE";
+  | "BINDING_STALE"
+  | "PLUGIN_UNLOADED";
 
 export interface ActionError {
   code: ActionErrorCode;
@@ -230,6 +231,12 @@ export interface ActionDispatchOptions {
    * Used by agent dispatch to bind context at dispatch time and prevent confused-deputy attacks.
    */
   contextOverride?: ActionContext;
+  /**
+   * Originating plugin ID for `source: "plugin"` dispatches. Threaded through to
+   * the `action:dispatched` audit event so a plugin-sourced invocation of a
+   * built-in action records which plugin initiated it (#9232).
+   */
+  pluginId?: string;
 }
 
 export interface ActionDispatchPayload {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1426,6 +1426,27 @@ export interface ElectronAPI extends GeneratedElectronAPI {
       confirmationDecision?: import("./mcpServer.js").McpConfirmationDecision;
     }): void;
   };
+  /**
+   * Main→renderer bridge for plugin `host.dispatch` (#9280). The renderer
+   * executes the requested action via ActionService as the `"plugin"` source
+   * and replies with the dispatch result.
+   */
+  pluginDispatchBridge: {
+    /** Listen for plugin-sourced action dispatch requests from the main process. */
+    onDispatchActionRequest(
+      callback: (payload: {
+        requestId: string;
+        pluginId: string;
+        actionId: string;
+        args?: unknown;
+      }) => void
+    ): () => void;
+    /** Send the action dispatch result back to the main process. */
+    sendDispatchActionResponse(payload: {
+      requestId: string;
+      result: import("../actions.js").ActionDispatchResult;
+    }): void;
+  };
   // list / toolbarButtons / menuItems / validateActionIds / get|register|
   // unregisterAction / getPanelKinds / getForgeProviders / getDecorations
   // come from GeneratedElectronAPI; invoke + on are variadic plugin RPC

--- a/shared/types/ipc/crashRecovery.ts
+++ b/shared/types/ipc/crashRecovery.ts
@@ -1,6 +1,12 @@
 import type { ActionDanger } from "../actions.js";
 
-export type ActionBreadcrumbSource = "user" | "keybinding" | "menu" | "agent" | "context-menu";
+export type ActionBreadcrumbSource =
+  | "user"
+  | "keybinding"
+  | "menu"
+  | "agent"
+  | "context-menu"
+  | "plugin";
 
 export interface ActionBreadcrumb {
   id: string;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1612,6 +1612,21 @@ export interface IpcEventMap {
   };
 
   /**
+   * Plugin `host.dispatch` action request (#9280). Main-process PluginService
+   * emits this on the active project WebContents and awaits a renderer
+   * `ipcRenderer.send` reply on `CHANNELS.PLUGIN_DISPATCH_ACTION_RESPONSE`,
+   * correlated by `requestId`. `pluginId` is the originating plugin, threaded
+   * through to the `action:dispatched` audit. The response channel is a
+   * renderer→main fire-and-forget send tracked in `DEAD_CHANNEL_ALLOWLIST`.
+   */
+  "plugin:dispatch-action-request": {
+    requestId: string;
+    pluginId: string;
+    actionId: string;
+    args?: unknown;
+  };
+
+  /**
    * Targeted push: a help-session tool call was denied because its tier
    * doesn't permit the tool. Sent to the pinned WebContents so the renderer
    * can surface an inline approval banner. Tier is `string` (not `McpTier`)

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -1,3 +1,4 @@
+import type { ActionDispatchResult } from "./actions.js";
 import type {
   FileDecorationContribution,
   FileDecorationProviderDescriptor,
@@ -268,6 +269,24 @@ export interface PluginHostApi {
    * unloaded.
    */
   invalidateFileDecorations(scope: string, paths?: string[]): void;
+  /**
+   * Dispatch an action by ID through the renderer-side `ActionService`, as the
+   * `"plugin"` source. Works for both the plugin's own registered actions and
+   * built-in actions, enabling plugins to orchestrate the app from their own
+   * timers and subscription callbacks. The originating `pluginId` is recorded
+   * on the `action:dispatched` audit event.
+   *
+   * Like {@link invalidateFileDecorations} this is NOT revoke-guarded — it must
+   * remain callable for the plugin's whole lifetime, long after `activate()`
+   * resolves. Once the plugin is unloaded it resolves to
+   * `{ ok: false, error: { code: "PLUGIN_UNLOADED" } }`.
+   *
+   * Args are validated by `ActionService` against the action's `argsSchema`;
+   * `danger: "restricted"` actions are rejected with `RESTRICTED`, and
+   * `danger: "confirm"` actions require an explicit confirmation the plugin
+   * dispatch path does not supply, so they resolve to `CONFIRMATION_REQUIRED`.
+   */
+  dispatch(actionId: string, args?: unknown): Promise<ActionDispatchResult>;
 }
 
 export type PluginActivate = (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ import { useQuickCreatePalette } from "./hooks/useQuickCreatePalette";
 import { useDoubleShift } from "./hooks/useDoubleShift";
 import { useProjectMruSwitcher } from "./hooks/useProjectMruSwitcher";
 import { useMcpBridge } from "./hooks/useMcpBridge";
+import { usePluginDispatchBridge } from "./hooks/usePluginDispatchBridge";
 import { useFileDropGuard } from "./hooks/useFileDropGuard";
 import { useSoundPlaybackListener } from "./hooks/useSoundPlaybackListener";
 import { useHeldShortcutReveal } from "./hooks/useHeldShortcutReveal";
@@ -383,6 +384,7 @@ function AppInner() {
   useMainProcessToastListener();
 
   useMcpBridge();
+  usePluginDispatchBridge();
   useSoundPlaybackListener();
   const { homeDir } = useHomeDir();
 

--- a/src/hooks/__tests__/usePluginDispatchBridge.test.tsx
+++ b/src/hooks/__tests__/usePluginDispatchBridge.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ActionDispatchResult } from "@shared/types/actions";
+
+const mocks = vi.hoisted(() => ({
+  dispatch: vi.fn(),
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch: mocks.dispatch,
+  },
+}));
+
+import { usePluginDispatchBridge } from "../usePluginDispatchBridge";
+
+describe("usePluginDispatchBridge", () => {
+  let dispatchHandler:
+    | ((payload: {
+        requestId: string;
+        pluginId: string;
+        actionId: string;
+        args?: unknown;
+      }) => void | Promise<void>)
+    | undefined;
+  let cleanup: ReturnType<typeof vi.fn>;
+  let sendDispatchActionResponse: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dispatchHandler = undefined;
+    cleanup = vi.fn();
+    sendDispatchActionResponse = vi.fn();
+
+    Object.defineProperty(window, "electron", {
+      configurable: true,
+      writable: true,
+      value: {
+        pluginDispatchBridge: {
+          onDispatchActionRequest: (
+            callback: (payload: {
+              requestId: string;
+              pluginId: string;
+              actionId: string;
+              args?: unknown;
+            }) => void | Promise<void>
+          ) => {
+            dispatchHandler = callback;
+            return cleanup;
+          },
+          sendDispatchActionResponse,
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    // @ts-expect-error reset test global
+    delete window.electron;
+  });
+
+  it("dispatches as the plugin source threading pluginId, and replies with the result", async () => {
+    const result: ActionDispatchResult = { ok: true, result: { done: true } };
+    mocks.dispatch.mockResolvedValue(result);
+
+    renderHook(() => usePluginDispatchBridge());
+
+    await dispatchHandler?.({
+      requestId: "req-1",
+      pluginId: "acme.tools",
+      actionId: "terminal.new",
+      args: { foo: "bar" },
+    });
+
+    expect(mocks.dispatch).toHaveBeenCalledWith(
+      "terminal.new",
+      { foo: "bar" },
+      { source: "plugin", pluginId: "acme.tools" }
+    );
+    expect(sendDispatchActionResponse).toHaveBeenCalledWith({ requestId: "req-1", result });
+  });
+
+  it("forwards a structured error result without throwing across the boundary", async () => {
+    const errorResult: ActionDispatchResult = {
+      ok: false,
+      error: { code: "RESTRICTED", message: "nope" },
+    };
+    mocks.dispatch.mockResolvedValue(errorResult);
+
+    renderHook(() => usePluginDispatchBridge());
+
+    await dispatchHandler?.({
+      requestId: "req-2",
+      pluginId: "acme.tools",
+      actionId: "system.restart",
+    });
+
+    expect(sendDispatchActionResponse).toHaveBeenCalledWith({
+      requestId: "req-2",
+      result: errorResult,
+    });
+  });
+
+  it("converts a thrown dispatch into an EXECUTION_ERROR result", async () => {
+    mocks.dispatch.mockRejectedValue(new Error("kaboom"));
+
+    renderHook(() => usePluginDispatchBridge());
+
+    await dispatchHandler?.({
+      requestId: "req-3",
+      pluginId: "acme.tools",
+      actionId: "terminal.new",
+    });
+
+    expect(sendDispatchActionResponse).toHaveBeenCalledWith({
+      requestId: "req-3",
+      result: {
+        ok: false,
+        error: { code: "EXECUTION_ERROR", message: expect.stringContaining("kaboom") },
+      },
+    });
+  });
+
+  it("does not reply after unmount", async () => {
+    let resolveDispatch: (value: ActionDispatchResult) => void = () => {};
+    mocks.dispatch.mockReturnValue(
+      new Promise<ActionDispatchResult>((resolve) => {
+        resolveDispatch = resolve;
+      })
+    );
+
+    const { unmount } = renderHook(() => usePluginDispatchBridge());
+
+    const pending = dispatchHandler?.({
+      requestId: "req-4",
+      pluginId: "acme.tools",
+      actionId: "terminal.new",
+    });
+
+    unmount();
+    resolveDispatch({ ok: true, result: null });
+    await pending;
+
+    expect(sendDispatchActionResponse).not.toHaveBeenCalled();
+    expect(cleanup).toHaveBeenCalled();
+  });
+
+  it("is a no-op when the bridge is unavailable", () => {
+    Object.defineProperty(window, "electron", {
+      configurable: true,
+      writable: true,
+      value: {},
+    });
+    expect(() => renderHook(() => usePluginDispatchBridge())).not.toThrow();
+  });
+});

--- a/src/hooks/usePluginDispatchBridge.ts
+++ b/src/hooks/usePluginDispatchBridge.ts
@@ -1,0 +1,57 @@
+import { useEffect } from "react";
+import { actionService } from "@/services/ActionService";
+import type { ActionId } from "@shared/types/actions";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
+
+/**
+ * Sets up the renderer-side bridge for plugin `host.dispatch` (#9280).
+ *
+ * Listens for dispatch requests forwarded from the main-process PluginService
+ * and executes them via `actionService.dispatch` as the `"plugin"` source,
+ * threading the originating `pluginId` through for the `action:dispatched`
+ * audit (#9232). Always replies with the dispatch result — never throws back
+ * across the boundary — so the plugin's awaited promise always settles with a
+ * typed {@link import("@shared/types/actions").ActionDispatchResult} envelope.
+ *
+ * Unlike {@link import("./useMcpBridge").useMcpBridge} there is no confirmation
+ * modal: plugins are first-party (curated-only), so `danger: "confirm"` actions
+ * resolve to `CONFIRMATION_REQUIRED` from ActionService and `danger:"restricted"`
+ * to `RESTRICTED`. The plugin caller decides what to do with that result.
+ */
+export function usePluginDispatchBridge(): void {
+  useEffect(() => {
+    if (!window.electron?.pluginDispatchBridge) return;
+
+    let disposed = false;
+
+    const cleanup = window.electron.pluginDispatchBridge.onDispatchActionRequest(
+      async ({ requestId, pluginId, actionId, args }) => {
+        try {
+          const result = await actionService.dispatch(actionId as ActionId, args, {
+            source: "plugin",
+            pluginId,
+          });
+          if (disposed) return;
+          window.electron.pluginDispatchBridge.sendDispatchActionResponse({ requestId, result });
+        } catch (err) {
+          if (disposed) return;
+          window.electron.pluginDispatchBridge.sendDispatchActionResponse({
+            requestId,
+            result: {
+              ok: false,
+              error: {
+                code: "EXECUTION_ERROR",
+                message: formatErrorMessage(err, "Plugin action dispatch failed"),
+              },
+            },
+          });
+        }
+      }
+    );
+
+    return () => {
+      disposed = true;
+      cleanup();
+    };
+  }, []);
+}

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -349,12 +349,19 @@ export class ActionService {
       return { ok: false, error };
     }
 
-    // Enforce confirmation for destructive actions from agent sources
-    // Agents must explicitly confirm before executing dangerous operations
-    if (definition.danger === "confirm" && source === "agent" && !options?.confirmed) {
+    // Enforce confirmation for destructive actions from non-interactive sources
+    // (agents, plugins). These have no originating UI dialog, so they must
+    // explicitly confirm before executing dangerous operations. The plugin
+    // dispatch path does not supply `confirmed`, so danger:"confirm" actions
+    // resolve to CONFIRMATION_REQUIRED — a plugin cannot silently bypass consent.
+    if (
+      definition.danger === "confirm" &&
+      (source === "agent" || source === "plugin") &&
+      !options?.confirmed
+    ) {
       const error: ActionError = {
         code: "CONFIRMATION_REQUIRED",
-        message: `Action "${actionId}" requires explicit confirmation from agent sources. Set { confirmed: true } to proceed.`,
+        message: `Action "${actionId}" requires explicit confirmation from ${source} sources. Set { confirmed: true } to proceed.`,
       };
       return { ok: false, error };
     }
@@ -392,7 +399,7 @@ export class ActionService {
         danger: definition.danger,
         safeArgs: this.extractSafeBreadcrumbArgs(args, definition),
         confirmed: options?.confirmed,
-        pluginId: definition.pluginId,
+        pluginId: options?.pluginId ?? definition.pluginId,
       });
       this.emitShortcutHint(actionId, source);
       return { ok: true, result: result as Result };

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -1234,6 +1234,65 @@ describe("ActionService", () => {
         restore();
       }
     });
+
+    it("gates a confirm action dispatched from the plugin source without confirmed (#9280)", async () => {
+      const emit = vi.fn().mockResolvedValue(undefined);
+      const restore = installEmit(emit);
+      try {
+        const run = vi.fn().mockResolvedValue(undefined);
+        service.register({
+          id: "worktree.delete" as ActionId,
+          title: "T",
+          description:
+            "Test action with a short title for verifying title/description field propagation in manifest entries.",
+          category: "worktree",
+          kind: "command",
+          danger: "confirm",
+          scope: "renderer",
+          run,
+        });
+        const result = await service.dispatch("worktree.delete" as ActionId, undefined, {
+          source: "plugin",
+          pluginId: "acme.tools",
+        });
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error.code).toBe("CONFIRMATION_REQUIRED");
+        await Promise.resolve();
+        expect(run).not.toHaveBeenCalled();
+        expect(emit).not.toHaveBeenCalled();
+      } finally {
+        restore();
+      }
+    });
+
+    it("threads pluginId into the action:dispatched payload for plugin-sourced dispatch (#9280)", async () => {
+      const emit = vi.fn().mockResolvedValue(undefined);
+      const restore = installEmit(emit);
+      try {
+        service.register({
+          id: "actions.list" as ActionId,
+          title: "T",
+          description:
+            "Test action with a short title for verifying title/description field propagation in manifest entries.",
+          category: "preferences",
+          kind: "command",
+          danger: "safe",
+          scope: "renderer",
+          run: vi.fn().mockResolvedValue(undefined),
+        });
+        await service.dispatch("actions.list" as ActionId, undefined, {
+          source: "plugin",
+          pluginId: "acme.tools",
+        });
+        await Promise.resolve();
+        expect(emit).toHaveBeenCalledTimes(1);
+        const payload = emit.mock.calls[0]![1] as Record<string, unknown>;
+        expect(payload.source).toBe("plugin");
+        expect(payload.pluginId).toBe("acme.tools");
+      } finally {
+        restore();
+      }
+    });
   });
 
   describe("lastAction tracking", () => {

--- a/src/store/__tests__/persistenceBoundaryHardening.test.ts
+++ b/src/store/__tests__/persistenceBoundaryHardening.test.ts
@@ -591,6 +591,13 @@ describe("persistence boundary hardening", () => {
   });
 
   it("notifies exactly once when a permanent structural fallback occurs", async () => {
+    // Drain pending `void import("@/lib/notify").then(...)` chains from prior
+    // tests' notifyPermanentFallbackOnce dispatches. notify is dispatched via
+    // dynamic import to break a module cycle, and those import resolutions can
+    // straddle test boundaries — once our doMock below activates, any pending
+    // resolution binds to our spy and inflates the count above 1.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
     const notifySpy = vi.fn();
     vi.doMock("@/lib/notify", () => ({ notify: notifySpy }));
     installLocalStorage(
@@ -606,11 +613,16 @@ describe("persistence boundary hardening", () => {
       const { createSafeJSONStorage } = await import("../persistence/safeStorage");
       const storage = createSafeJSONStorage<{ value: number }>();
 
+      // Final drain + reset right before the writes that matter. Any
+      // stragglers from cross-file imports (Zustand persist initialisations in
+      // other suites etc.) get accounted for here and zeroed out, so the
+      // count we assert reflects only THIS test's setItem-triggered notify.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      notifySpy.mockClear();
+
       storage.setItem("notify-key-1", { state: { value: 1 }, version: 1 });
       storage.setItem("notify-key-2", { state: { value: 2 }, version: 1 });
 
-      // notify is dispatched via a dynamic import to break a module cycle;
-      // wait for the microtask queue + import resolution to drain.
       await vi.waitFor(() => expect(notifySpy).toHaveBeenCalledTimes(1));
     } finally {
       vi.doUnmock("@/lib/notify");


### PR DESCRIPTION
## Summary

- Adds `host.dispatch(actionId, args?)` to `PluginHostApi` so plugins running in the main process can invoke actions via the renderer `ActionService`
- Implements a main→renderer IPC bridge in `PluginService` — requestId-keyed pending map, sender validation, 30s timeout, settled on renderer destroy or plugin unload
- Adds `"plugin"` as a new `ActionSource`; `danger: "restricted"` actions return `RESTRICTED`, `danger: "confirm"` actions return `CONFIRMATION_REQUIRED` (no confirm modal in the plugin path)

Resolves #9280

## Changes

- `PluginHostApi.dispatch()` — not revoke-guarded; liveness guard is plugin membership, not the activation window; resolves `PLUGIN_UNLOADED` once the plugin is unloaded
- `PluginService.sendPluginDispatchRequest()` / `handleDispatchResponse()` — mirrors the MCP renderer bridge; targets the active project `WebContents`, never broadcasts; per-plugin unload settlement in `unloadPlugin()`
- `usePluginDispatchBridge` renderer hook — wires `plugin:dispatch-action-request` to `ActionService.dispatch()` with `source: "plugin"` and `pluginId` threaded into the audit record
- `ActionService` plugin confirm gate — rejects `danger: "confirm"` with `CONFIRMATION_REQUIRED` on the plugin path; `pluginId` flows through `ActionDispatchOptions` to the `action:dispatched` audit event
- New IPC channels `plugin:dispatch-action-request` / `plugin:dispatch-action-response`; `PLUGIN_UNLOADED` added to `ActionErrorCode`

## Testing

- `usePluginDispatchBridge` hook unit tests — round-trip, error forwarding, cleanup
- `PluginService` tests — liveness guard, validation, round-trip, sender guard, concurrent dispatches, unload settlement
- `ActionService` tests — plugin confirm gate, `pluginId` in audit record
- `npm run check` clean on the rebased branch