### PR TITLE
feat(plugins): add settings template resolver for MCP env values

### DIFF
--- a/electron/services/__tests__/settingsTemplateResolver.test.ts
+++ b/electron/services/__tests__/settingsTemplateResolver.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  resolveSettingsTemplates,
+  SettingTemplateError,
+  type PluginSettingsApi,
+} from "../settingsTemplateResolver.js";
+
+function fakeApi(values: Record<string, string | undefined>): PluginSettingsApi {
+  return {
+    get: vi.fn(async (key: string) => values[key]),
+  };
+}
+
+let api: ReturnType<typeof fakeApi>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("resolveSettingsTemplates", () => {
+  describe("substitution", () => {
+    it("substitutes a single ${settings:id} template", async () => {
+      api = fakeApi({ "linear.apiToken": "sk-abc123" });
+      const result = await resolveSettingsTemplates(
+        "Bearer ${settings:linear.apiToken}",
+        "acme.linear",
+        api
+      );
+      expect(result).toBe("Bearer sk-abc123");
+    });
+
+    it("substitutes multiple distinct templates", async () => {
+      api = fakeApi({ apiToken: "sk-abc", orgId: "org-42" });
+      const result = await resolveSettingsTemplates(
+        "${settings:apiToken}:${settings:orgId}",
+        "acme.plugin",
+        api
+      );
+      expect(result).toBe("sk-abc:org-42");
+    });
+
+    it("substitutes templates embedded in literal text", async () => {
+      api = fakeApi({ token: "sk-xyz" });
+      const result = await resolveSettingsTemplates(
+        "KEY=${settings:token}&other=val",
+        "acme.plugin",
+        api
+      );
+      expect(result).toBe("KEY=sk-xyz&other=val");
+    });
+
+    it("supports underscore keys", async () => {
+      api = fakeApi({ api_key: "secret123" });
+      const result = await resolveSettingsTemplates("${settings:api_key}", "acme.plugin", api);
+      expect(result).toBe("secret123");
+    });
+
+    it("supports dot-separated keys", async () => {
+      api = fakeApi({ "linear.apiToken": "sk-dot" });
+      const result = await resolveSettingsTemplates(
+        "${settings:linear.apiToken}",
+        "acme.linear",
+        api
+      );
+      expect(result).toBe("sk-dot");
+    });
+
+    it("deduplicates lookups for repeated keys", async () => {
+      api = fakeApi({ token: "once" });
+      const result = await resolveSettingsTemplates(
+        "${settings:token}-${settings:token}",
+        "acme.plugin",
+        api
+      );
+      expect(result).toBe("once-once");
+      expect(api.get).toHaveBeenCalledTimes(1);
+      expect(api.get).toHaveBeenCalledWith("token");
+    });
+
+    it("returns empty string when get() returns empty string (valid value)", async () => {
+      api = fakeApi({ token: "" });
+      const result = await resolveSettingsTemplates(
+        "prefix-${settings:token}-suffix",
+        "acme.plugin",
+        api
+      );
+      expect(result).toBe("prefix--suffix");
+    });
+
+    it("returns text unchanged when no templates present", async () => {
+      api = fakeApi({});
+      const result = await resolveSettingsTemplates("plain text no templates", "acme.plugin", api);
+      expect(result).toBe("plain text no templates");
+    });
+
+    it("returns empty string for empty text input", async () => {
+      api = fakeApi({});
+      const result = await resolveSettingsTemplates("", "acme.plugin", api);
+      expect(result).toBe("");
+    });
+  });
+
+  describe("near-misses pass through as literal", () => {
+    it("leaves $settings:foo unchanged (missing braces)", async () => {
+      api = fakeApi({});
+      const result = await resolveSettingsTemplates("$settings:foo", "acme.plugin", api);
+      expect(result).toBe("$settings:foo");
+      expect(api.get).not.toHaveBeenCalled();
+    });
+
+    it("leaves ${settings:} unchanged (empty key)", async () => {
+      api = fakeApi({});
+      const result = await resolveSettingsTemplates("${settings:}", "acme.plugin", api);
+      expect(result).toBe("${settings:}");
+      expect(api.get).not.toHaveBeenCalled();
+    });
+
+    it("leaves ${other:foo} unchanged (wrong namespace)", async () => {
+      api = fakeApi({});
+      const result = await resolveSettingsTemplates("${other:foo}", "acme.plugin", api);
+      expect(result).toBe("${other:foo}");
+      expect(api.get).not.toHaveBeenCalled();
+    });
+
+    it("leaves ${settings:1foo} unchanged (starts with digit)", async () => {
+      api = fakeApi({});
+      const result = await resolveSettingsTemplates("${settings:1foo}", "acme.plugin", api);
+      expect(result).toBe("${settings:1foo}");
+      expect(api.get).not.toHaveBeenCalled();
+    });
+
+    it("leaves ${settings:foo-bar} unchanged (hyphen in key)", async () => {
+      api = fakeApi({});
+      const result = await resolveSettingsTemplates("${settings:foo-bar}", "acme.plugin", api);
+      expect(result).toBe("${settings:foo-bar}");
+      expect(api.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("escape", () => {
+    it("leaves backslash-escaped template unchanged", async () => {
+      api = fakeApi({});
+      const result = await resolveSettingsTemplates("\\${settings:foo}", "acme.plugin", api);
+      expect(result).toBe("\\${settings:foo}");
+      expect(api.get).not.toHaveBeenCalled();
+    });
+
+    it("resolves adjacent unescaped template while leaving escaped one", async () => {
+      api = fakeApi({ foo: "bar" });
+      const result = await resolveSettingsTemplates(
+        "\\${settings:foo} ${settings:foo}",
+        "acme.plugin",
+        api
+      );
+      expect(result).toBe("\\${settings:foo} bar");
+    });
+  });
+
+  describe("errors", () => {
+    it("throws SettingTemplateError for unmatched setting", async () => {
+      api = fakeApi({});
+      await expect(
+        resolveSettingsTemplates("${settings:missing}", "acme.plugin", api)
+      ).rejects.toThrow(SettingTemplateError);
+    });
+
+    it("includes the pluginId and token in the error", async () => {
+      api = fakeApi({});
+      let caught: SettingTemplateError | null = null;
+      try {
+        await resolveSettingsTemplates("${settings:missing.key}", "acme.linear", api);
+      } catch (e) {
+        caught = e as SettingTemplateError;
+      }
+      expect(caught).not.toBeNull();
+      expect(caught!.code).toBe("UNMATCHED_SETTING");
+      expect(caught!.pluginId).toBe("acme.linear");
+      expect(caught!.token).toBe("missing.key");
+    });
+
+    it("error message contains the token id, not any resolved value", async () => {
+      api = fakeApi({ known: "secret-value" });
+      await expect(
+        resolveSettingsTemplates("${settings:known}${settings:missing}", "acme.plugin", api)
+      ).rejects.toThrow("missing");
+      // The message must NOT contain the resolved value of "known"
+      try {
+        await resolveSettingsTemplates("${settings:known}${settings:missing}", "acme.plugin", api);
+      } catch (e) {
+        expect((e as Error).message).not.toContain("secret-value");
+      }
+    });
+
+    it("fails the entire call when any one setting is missing (no partial substitution)", async () => {
+      api = fakeApi({ good: "resolved" });
+      await expect(
+        resolveSettingsTemplates("${settings:good}${settings:bad}", "acme.plugin", api)
+      ).rejects.toThrow(SettingTemplateError);
+    });
+
+    it("throws only once even with multiple unmatched tokens (fail-fast on first)", async () => {
+      api = fakeApi({});
+      // Both tokens are unmatched — should throw on the first one
+      await expect(
+        resolveSettingsTemplates("${settings:a}${settings:b}", "acme.plugin", api)
+      ).rejects.toThrow("a");
+    });
+  });
+});

--- a/electron/services/__tests__/settingsTemplateResolver.test.ts
+++ b/electron/services/__tests__/settingsTemplateResolver.test.ts
@@ -7,7 +7,24 @@ import {
 
 function fakeApi(values: Record<string, string | undefined>): PluginSettingsApi {
   return {
-    get: vi.fn(async (key: string) => values[key]),
+    get: vi.fn(async (key: string) => {
+      const v = values[key];
+      if (v === undefined && !(key in values)) {
+        return undefined;
+      }
+      return v;
+    }),
+  };
+}
+
+function throwingApi(errors: Record<string, Error>): PluginSettingsApi {
+  return {
+    get: vi.fn(async (key: string) => {
+      if (key in errors) {
+        throw errors[key];
+      }
+      return undefined;
+    }),
   };
 }
 
@@ -91,6 +108,7 @@ describe("resolveSettingsTemplates", () => {
       api = fakeApi({});
       const result = await resolveSettingsTemplates("plain text no templates", "acme.plugin", api);
       expect(result).toBe("plain text no templates");
+      expect(api.get).not.toHaveBeenCalled();
     });
 
     it("returns empty string for empty text input", async () => {
@@ -135,6 +153,27 @@ describe("resolveSettingsTemplates", () => {
       expect(result).toBe("${settings:foo-bar}");
       expect(api.get).not.toHaveBeenCalled();
     });
+
+    it("leaves ${settings:foo.} unchanged (trailing dot)", async () => {
+      api = fakeApi({});
+      const result = await resolveSettingsTemplates("${settings:foo.}", "acme.plugin", api);
+      expect(result).toBe("${settings:foo.}");
+      expect(api.get).not.toHaveBeenCalled();
+    });
+
+    it("leaves ${settings:.foo} unchanged (leading dot)", async () => {
+      api = fakeApi({});
+      const result = await resolveSettingsTemplates("${settings:.foo}", "acme.plugin", api);
+      expect(result).toBe("${settings:.foo}");
+      expect(api.get).not.toHaveBeenCalled();
+    });
+
+    it("leaves ${settings:foo..bar} unchanged (double dot)", async () => {
+      api = fakeApi({});
+      const result = await resolveSettingsTemplates("${settings:foo..bar}", "acme.plugin", api);
+      expect(result).toBe("${settings:foo..bar}");
+      expect(api.get).not.toHaveBeenCalled();
+    });
   });
 
   describe("escape", () => {
@@ -145,14 +184,16 @@ describe("resolveSettingsTemplates", () => {
       expect(api.get).not.toHaveBeenCalled();
     });
 
-    it("resolves adjacent unescaped template while leaving escaped one", async () => {
-      api = fakeApi({ foo: "bar" });
+    it("resolves adjacent unescaped template while leaving escaped one, distinct keys", async () => {
+      api = fakeApi({ public: "ok" });
       const result = await resolveSettingsTemplates(
-        "\\${settings:foo} ${settings:foo}",
+        "\\${settings:secret} ${settings:public}",
         "acme.plugin",
         api
       );
-      expect(result).toBe("\\${settings:foo} bar");
+      expect(result).toBe("\\${settings:secret} ok");
+      expect(api.get).toHaveBeenCalledTimes(1);
+      expect(api.get).toHaveBeenCalledWith("public");
     });
   });
 
@@ -180,15 +221,27 @@ describe("resolveSettingsTemplates", () => {
 
     it("error message contains the token id, not any resolved value", async () => {
       api = fakeApi({ known: "secret-value" });
-      await expect(
-        resolveSettingsTemplates("${settings:known}${settings:missing}", "acme.plugin", api)
-      ).rejects.toThrow("missing");
-      // The message must NOT contain the resolved value of "known"
       try {
         await resolveSettingsTemplates("${settings:known}${settings:missing}", "acme.plugin", api);
       } catch (e) {
+        expect((e as Error).message).toContain("missing");
         expect((e as Error).message).not.toContain("secret-value");
       }
+    });
+
+    it("has exact error shape for mixed known+missing", async () => {
+      api = fakeApi({ known: "secret" });
+      let caught: SettingTemplateError | null = null;
+      try {
+        await resolveSettingsTemplates("${settings:known}${settings:missing}", "acme.plugin", api);
+      } catch (e) {
+        caught = e as SettingTemplateError;
+      }
+      expect(caught).not.toBeNull();
+      expect(caught!.code).toBe("UNMATCHED_SETTING");
+      expect(caught!.pluginId).toBe("acme.plugin");
+      expect(caught!.token).toBe("missing");
+      expect(caught!.message).toBe('Unmatched setting template "missing" for plugin "acme.plugin"');
     });
 
     it("fails the entire call when any one setting is missing (no partial substitution)", async () => {
@@ -198,12 +251,21 @@ describe("resolveSettingsTemplates", () => {
       ).rejects.toThrow(SettingTemplateError);
     });
 
-    it("throws only once even with multiple unmatched tokens (fail-fast on first)", async () => {
-      api = fakeApi({});
-      // Both tokens are unmatched — should throw on the first one
-      await expect(
-        resolveSettingsTemplates("${settings:a}${settings:b}", "acme.plugin", api)
-      ).rejects.toThrow("a");
+    it("wraps get() rejection in SettingTemplateError, hiding backend details", async () => {
+      const api2 = throwingApi({
+        secretKey: new Error("decrypt failed: sk-live-secret"),
+      });
+      let caught: SettingTemplateError | null = null;
+      try {
+        await resolveSettingsTemplates("${settings:secretKey}", "acme.plugin", api2);
+      } catch (e) {
+        caught = e as SettingTemplateError;
+      }
+      expect(caught).not.toBeNull();
+      expect(caught!.code).toBe("UNMATCHED_SETTING");
+      expect(caught!.token).toBe("secretKey");
+      expect(caught!.message).not.toContain("decrypt");
+      expect(caught!.message).not.toContain("sk-live-secret");
     });
   });
 });

--- a/electron/services/settingsTemplateResolver.ts
+++ b/electron/services/settingsTemplateResolver.ts
@@ -19,7 +19,8 @@ export class SettingTemplateError extends Error {
   }
 }
 
-const SETTINGS_TEMPLATE_RE = /(?<!\\)\$\{settings:([a-zA-Z_][a-zA-Z0-9_.]*)\}/g;
+const SETTINGS_TEMPLATE_RE =
+  /(?<!\\)\$\{settings:([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*)\}/g;
 
 /**
  * Scan `text` for `${settings:<id>}` templates and substitute each with the
@@ -39,19 +40,22 @@ export async function resolveSettingsTemplates(
   if (matches.length === 0) return text;
 
   const uniqueIds = new Map<string, string>();
-  const lookupMap = new Map<string, string>();
 
   for (const match of matches) {
     const settingId = match[1];
     if (!uniqueIds.has(settingId)) {
       uniqueIds.set(settingId, settingId);
-      lookupMap.set(settingId, match[0]);
     }
   }
 
   const results = await Promise.all(
     [...uniqueIds.keys()].map(async (id) => {
-      const value = await settings.get(id);
+      let value: string | undefined;
+      try {
+        value = await settings.get(id);
+      } catch {
+        throw new SettingTemplateError(pluginId, id);
+      }
       if (value === undefined) {
         throw new SettingTemplateError(pluginId, id);
       }

--- a/electron/services/settingsTemplateResolver.ts
+++ b/electron/services/settingsTemplateResolver.ts
@@ -1,0 +1,74 @@
+/**
+ * Minimal settings read surface consumed by the template resolver. #9279 will
+ * replace this with the full `host.settings` API.
+ */
+export interface PluginSettingsApi {
+  get(key: string): Promise<string | undefined>;
+}
+
+export class SettingTemplateError extends Error {
+  public readonly code = "UNMATCHED_SETTING";
+  public readonly pluginId: string;
+  public readonly token: string;
+
+  constructor(pluginId: string, token: string) {
+    super(`Unmatched setting template "${token}" for plugin "${pluginId}"`);
+    this.name = "SettingTemplateError";
+    this.pluginId = pluginId;
+    this.token = token;
+  }
+}
+
+const SETTINGS_TEMPLATE_RE = /(?<!\\)\$\{settings:([a-zA-Z_][a-zA-Z0-9_.]*)\}/g;
+
+/**
+ * Scan `text` for `${settings:<id>}` templates and substitute each with the
+ * value from the plugin-scoped settings API. Throws `SettingTemplateError` if
+ * any referenced setting is not configured — never silently falls back to an
+ * empty string.
+ *
+ * Near-miss syntax (`$settings:foo`, `${settings:}`, `${other:foo}`) passes
+ * through as literal text. Escaped `\${settings:foo}` is left unchanged.
+ */
+export async function resolveSettingsTemplates(
+  text: string,
+  pluginId: string,
+  settings: PluginSettingsApi
+): Promise<string> {
+  const matches = [...text.matchAll(SETTINGS_TEMPLATE_RE)];
+  if (matches.length === 0) return text;
+
+  const uniqueIds = new Map<string, string>();
+  const lookupMap = new Map<string, string>();
+
+  for (const match of matches) {
+    const settingId = match[1];
+    if (!uniqueIds.has(settingId)) {
+      uniqueIds.set(settingId, settingId);
+      lookupMap.set(settingId, match[0]);
+    }
+  }
+
+  const results = await Promise.all(
+    [...uniqueIds.keys()].map(async (id) => {
+      const value = await settings.get(id);
+      if (value === undefined) {
+        throw new SettingTemplateError(pluginId, id);
+      }
+      return { id, value };
+    })
+  );
+
+  const resolved = new Map<string, string>();
+  for (const { id, value } of results) {
+    resolved.set(id, value);
+  }
+
+  return text.replace(SETTINGS_TEMPLATE_RE, (_match, id) => {
+    const value = resolved.get(id);
+    if (value === undefined) {
+      throw new SettingTemplateError(pluginId, id);
+    }
+    return value;
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a `resolveSettingsTemplates()` function that scans text for `${settings:id}` tokens and substitutes them with the plugin's own setting values.
- The resolver is a pure function scoped per-plugin — it throws a typed `SettingTemplateError` on unmatched tokens instead of silently falling back to an empty string.
- No MCP wiring yet; that lives in #9233.

Resolves #9282.

## Changes
- New `electron/services/settingsTemplateResolver.ts` — the resolver, `SettingTemplateError`, and the `PluginSettingsApi` interface it reads through.
- The regex only matches valid identifiers (`[a-zA-Z_][a-zA-Z0-9_]*` dot-separated segments). Near-misses like `$settings:foo`, `${settings:}`, `${other:foo}`, and escaped `\${settings:foo}` pass through as literal text.
- Deduplicates repeated keys into a single `settings.get()` call.

## Testing
- 25 unit tests covering single and multiple substitutions, dot-separated and underscore keys, deduplication, near-miss pass-through, escape handling, unmatched-token errors, rejection wrapping, and the empty-string-as-valid-value edge case.