### PR TITLE
fix(build): isolate native rebuilds so one failure doesn't abort the rest

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "package:linux": "npm run build && electron-builder --linux",
     "package:local": "npm run build && electron-builder --mac --dir -c.mac.identity=null -c.mac.forceCodeSigning=false -c.mac.notarize=false",
     "package:local:dmg": "npm run build && electron-builder --mac dmg -c.mac.identity=null -c.mac.forceCodeSigning=false -c.mac.notarize=false",
-    "rebuild": "electron-rebuild -f -w node-pty,better-sqlite3,win-job-object,posix-pty-reaper && node node_modules/node-pty/scripts/post-install.js",
+    "rebuild": "node scripts/postinstall.cjs",
     "postinstall": "node scripts/postinstall.cjs",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "package:win": "npm run build && electron-builder --win appx nsis",
     "package:win:nsis": "npm run build && electron-builder --win nsis",
     "package:win:appx": "npm run build && electron-builder --win appx",
-    "rebuild:win-arm64": "cross-env npm_config_arch=arm64 electron-rebuild -f -w win-job-object --arch=arm64 && cross-env npm_config_arch=arm64 node node_modules/node-pty/scripts/post-install.js",
+    "rebuild:win-arm64": "cross-env npm_config_arch=arm64 electron-rebuild -f -w win-job-object --arch=arm64; cross-env npm_config_arch=arm64 node node_modules/node-pty/scripts/post-install.js",
     "package:linux": "npm run build && electron-builder --linux",
     "package:local": "npm run build && electron-builder --mac --dir -c.mac.identity=null -c.mac.forceCodeSigning=false -c.mac.notarize=false",
     "package:local:dmg": "npm run build && electron-builder --mac dmg -c.mac.identity=null -c.mac.forceCodeSigning=false -c.mac.notarize=false",

--- a/scripts/postinstall.cjs
+++ b/scripts/postinstall.cjs
@@ -1,14 +1,51 @@
+const path = require("path");
 const { execSync } = require("child_process");
+const { rebuild } = require("@electron/rebuild");
+const { version: electronVersion } = require("electron/package.json");
 
-// `win-job-object` is a Windows-only N-API addon (#7526). Its binding.gyp
-// emits zero sources on macOS / Linux (the target has empty sources list),
-// so node-gyp skips it with a SKIPPED message — the wrapper handles the
-// missing-binary case gracefully.
-//
-// `posix-pty-reaper` is the inverse (#8769): a macOS / Linux executable whose
-// binding.gyp emits `type: none` on Windows, so it's a no-op there and the
-// wrapper reports unavailable.
-execSync("electron-rebuild -f -w node-pty,better-sqlite3,win-job-object,posix-pty-reaper", {
-  stdio: "inherit",
-});
-require("../node_modules/node-pty/scripts/post-install.js");
+const NATIVE_MODULES = ["node-pty", "better-sqlite3", "win-job-object", "posix-pty-reaper"];
+
+const buildPath = path.resolve(__dirname, "..");
+
+async function runPostinstall() {
+  const failures = [];
+
+  for (const mod of NATIVE_MODULES) {
+    try {
+      await rebuild({
+        buildPath,
+        electronVersion,
+        onlyModules: [mod],
+        force: true,
+      });
+    } catch (err) {
+      failures.push({ module: mod, error: err });
+    }
+  }
+
+  // Always run ConPTY asset fetch — it's idempotent, exits 0 on non-Windows,
+  // and must not be skipped just because an unrelated native rebuild failed.
+  // Using execSync (not require()) because the post-install script ends with
+  // process.exit(0), which would override our process.exitCode.
+  try {
+    execSync("node node_modules/node-pty/scripts/post-install.js", {
+      stdio: "inherit",
+    });
+  } catch (err) {
+    failures.push({ module: "node-pty post-install", error: err });
+  }
+
+  if (failures.length > 0) {
+    console.error(`\nRebuild failures (${failures.length}/${NATIVE_MODULES.length + 1}):`);
+    for (const { module: mod, error } of failures) {
+      console.error(`  ${mod}: ${error.message}`);
+    }
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  runPostinstall();
+}
+
+module.exports = { runPostinstall };

--- a/scripts/postinstall.cjs
+++ b/scripts/postinstall.cjs
@@ -30,6 +30,7 @@ async function runPostinstall() {
   try {
     execSync("node node_modules/node-pty/scripts/post-install.js", {
       stdio: "inherit",
+      cwd: buildPath,
     });
   } catch (err) {
     failures.push({ module: "node-pty post-install", error: err });
@@ -38,7 +39,7 @@ async function runPostinstall() {
   if (failures.length > 0) {
     console.error(`\nRebuild failures (${failures.length}/${NATIVE_MODULES.length + 1}):`);
     for (const { module: mod, error } of failures) {
-      console.error(`  ${mod}: ${error.message}`);
+      console.error(`  ${mod}: ${error?.message ?? String(error)}`);
     }
     process.exitCode = 1;
   }

--- a/scripts/postinstall.test.ts
+++ b/scripts/postinstall.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from "vitest";
+import path from "path";
+import Module from "module";
+
+const mockRebuild = vi.fn();
+const mockExecSync = vi.fn();
+
+const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+const originalExitCode = process.exitCode;
+
+afterAll(() => {
+  consoleErrorSpy.mockRestore();
+  consoleLogSpy.mockRestore();
+});
+
+describe("postinstall", () => {
+  let runPostinstall: () => Promise<void>;
+  const originalRequire = Module.prototype.require;
+
+  function setupMocks() {
+    Module.prototype.require = function (id: string) {
+      if (id === "@electron/rebuild") {
+        return { rebuild: mockRebuild };
+      }
+      if (id === "electron/package.json") {
+        return { version: "41.7.1" };
+      }
+      if (id === "child_process") {
+        return {
+          execSync: mockExecSync,
+          exec: vi.fn(),
+          spawn: vi.fn(),
+          spawnSync: vi.fn(),
+        };
+      }
+      return originalRequire.apply(this, [id]);
+    } as typeof Module.prototype.require;
+  }
+
+  function restoreMocks() {
+    Module.prototype.require = originalRequire;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleErrorSpy.mockImplementation(() => {});
+    consoleLogSpy.mockImplementation(() => {});
+    mockRebuild.mockResolvedValue(undefined);
+    mockExecSync.mockReturnValue(undefined);
+    process.exitCode = undefined;
+
+    setupMocks();
+    try {
+      delete require.cache[require.resolve("./postinstall.cjs")];
+      const module = require("./postinstall.cjs");
+      runPostinstall = module.runPostinstall;
+    } finally {
+      restoreMocks();
+    }
+  });
+
+  afterEach(() => {
+    restoreMocks();
+  });
+
+  it("should rebuild all four modules sequentially", async () => {
+    await runPostinstall();
+
+    expect(mockRebuild).toHaveBeenCalledTimes(4);
+    expect(mockRebuild).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        onlyModules: ["node-pty"],
+        force: true,
+      })
+    );
+    expect(mockRebuild).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        onlyModules: ["better-sqlite3"],
+      })
+    );
+    expect(mockRebuild).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        onlyModules: ["win-job-object"],
+      })
+    );
+    expect(mockRebuild).toHaveBeenNthCalledWith(
+      4,
+      expect.objectContaining({
+        onlyModules: ["posix-pty-reaper"],
+      })
+    );
+  });
+
+  it("should pass electronVersion and buildPath to every rebuild call", async () => {
+    await runPostinstall();
+
+    for (let i = 1; i <= 4; i++) {
+      expect(mockRebuild).toHaveBeenNthCalledWith(
+        i,
+        expect.objectContaining({
+          electronVersion: "41.7.1",
+          buildPath: path.resolve(__dirname, ".."),
+          force: true,
+        })
+      );
+    }
+  });
+
+  it("should run node-pty post-install after all rebuilds", async () => {
+    await runPostinstall();
+
+    expect(mockExecSync).toHaveBeenCalledTimes(1);
+    expect(mockExecSync).toHaveBeenCalledWith(
+      "node node_modules/node-pty/scripts/post-install.js",
+      { stdio: "inherit" }
+    );
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("should continue rebuilding when the first module fails", async () => {
+    mockRebuild.mockRejectedValueOnce(new Error("node-pty build failed"));
+
+    await runPostinstall();
+
+    expect(mockRebuild).toHaveBeenCalledTimes(4);
+    expect(mockExecSync).toHaveBeenCalledTimes(1);
+    expect(process.exitCode).toBe(1);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it("should continue rebuilding when a middle module fails", async () => {
+    mockRebuild.mockRejectedValueOnce(new Error("node-pty OK"));
+    mockRebuild.mockRejectedValueOnce(new Error("better-sqlite3 failed"));
+
+    await runPostinstall();
+
+    expect(mockRebuild).toHaveBeenCalledTimes(4);
+    expect(mockExecSync).toHaveBeenCalledTimes(1);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("should continue when the last module fails", async () => {
+    mockRebuild.mockResolvedValueOnce(undefined);
+    mockRebuild.mockResolvedValueOnce(undefined);
+    mockRebuild.mockResolvedValueOnce(undefined);
+    mockRebuild.mockRejectedValueOnce(new Error("posix-pty-reaper failed"));
+
+    await runPostinstall();
+
+    expect(mockRebuild).toHaveBeenCalledTimes(4);
+    expect(mockExecSync).toHaveBeenCalledTimes(1);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("should report all failures when all modules fail", async () => {
+    mockRebuild.mockRejectedValue(new Error("rebuild failed"));
+
+    await runPostinstall();
+
+    expect(mockRebuild).toHaveBeenCalledTimes(4);
+    expect(mockExecSync).toHaveBeenCalledTimes(1);
+    expect(process.exitCode).toBe(1);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it("should still run post-install when all rebuilds fail", async () => {
+    mockRebuild.mockRejectedValue(new Error("all failed"));
+
+    await runPostinstall();
+
+    expect(mockExecSync).toHaveBeenCalledTimes(1);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("should report post-install failure separately", async () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error("ConPTY fetch failed");
+    });
+
+    await runPostinstall();
+
+    expect(mockRebuild).toHaveBeenCalledTimes(4);
+    expect(process.exitCode).toBe(1);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it("should exit 0 when everything succeeds", async () => {
+    await runPostinstall();
+
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("should log failure details with module names", async () => {
+    mockRebuild.mockRejectedValueOnce(new Error("gyp error"));
+    mockRebuild.mockRejectedValueOnce(new Error("link error"));
+
+    await runPostinstall();
+
+    const errorCalls = consoleErrorSpy.mock.calls.flat().join(" ");
+    expect(errorCalls).toMatch(/node-pty/);
+    expect(errorCalls).toMatch(/better-sqlite3/);
+  });
+});

--- a/scripts/postinstall.test.ts
+++ b/scripts/postinstall.test.ts
@@ -13,6 +13,7 @@ const originalExitCode = process.exitCode;
 afterAll(() => {
   consoleErrorSpy.mockRestore();
   consoleLogSpy.mockRestore();
+  process.exitCode = originalExitCode;
 });
 
 describe("postinstall", () => {
@@ -117,7 +118,7 @@ describe("postinstall", () => {
     expect(mockExecSync).toHaveBeenCalledTimes(1);
     expect(mockExecSync).toHaveBeenCalledWith(
       "node node_modules/node-pty/scripts/post-install.js",
-      { stdio: "inherit" }
+      { stdio: "inherit", cwd: expect.any(String) }
     );
     expect(process.exitCode).toBeUndefined();
   });
@@ -134,7 +135,7 @@ describe("postinstall", () => {
   });
 
   it("should continue rebuilding when a middle module fails", async () => {
-    mockRebuild.mockRejectedValueOnce(new Error("node-pty OK"));
+    mockRebuild.mockResolvedValueOnce(undefined);
     mockRebuild.mockRejectedValueOnce(new Error("better-sqlite3 failed"));
 
     await runPostinstall();
@@ -142,6 +143,10 @@ describe("postinstall", () => {
     expect(mockRebuild).toHaveBeenCalledTimes(4);
     expect(mockExecSync).toHaveBeenCalledTimes(1);
     expect(process.exitCode).toBe(1);
+
+    const errorCalls = consoleErrorSpy.mock.calls.flat().join(" ");
+    expect(errorCalls).toMatch(/better-sqlite3/);
+    expect(errorCalls).not.toMatch(/node-pty/);
   });
 
   it("should continue when the last module fails", async () => {
@@ -187,6 +192,10 @@ describe("postinstall", () => {
     expect(mockRebuild).toHaveBeenCalledTimes(4);
     expect(process.exitCode).toBe(1);
     expect(consoleErrorSpy).toHaveBeenCalled();
+
+    const errorCalls = consoleErrorSpy.mock.calls.flat().join(" ");
+    expect(errorCalls).toMatch(/node-pty post-install/);
+    expect(errorCalls).toMatch(/ConPTY fetch failed/);
   });
 
   it("should exit 0 when everything succeeds", async () => {


### PR DESCRIPTION
## Summary
- Switched postinstall from a single `execSync` call that fail-fast aborted to per-module isolated rebuilds using `@electron/rebuild`'s programmatic API
- The ConPTY asset fetch always runs regardless of rebuild failures -- it used to get skipped entirely when any native module flaked
- The `rebuild` npm script now delegates to `postinstall.cjs`, so contributors get the same resilience as a fresh install

Resolves #9253

## Changes
- `scripts/postinstall.cjs`: replaced the 14-line single `execSync` with isolated per-module rebuilds that report all failures without blocking survivors
- `package.json`: pointed `rebuild` at `scripts/postinstall.cjs` and switched `rebuild:win-arm64` from `&&` to `;` so the ConPTY fetch runs even when the win-arm64 rebuild fails
- `scripts/postinstall.test.ts`: 11 unit tests covering sequential rebuilds, partial failures, full failures, and post-install failure isolation

## Testing
- All 11 unit tests pass (`npx vitest run scripts/postinstall.test.ts`)
- Prettier, ESLint, and TypeScript typecheck clean