### PR TITLE
fix(infra): supply monotonic BUILD_NUMBER for AppX manifest versions

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -152,6 +152,12 @@ jobs:
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           DEBUG: electron-builder,electron-notarize*,electron-osx-sign*
+          # Distinguishes pre-release AppX versions — parseInt() in electron-builder's
+          # getVersionInWeirdWindowsForm discards semver suffixes, so 0.14.1-rc.1 and
+          # 0.14.1 would both map to 0.14.1.0 in the manifest. BUILD_NUMBER fills the
+          # 4th slot so every build gets a unique A.B.C.D for Store update detection.
+          # github.run_number is per-workflow monotonic (~weekly releases → fits uint16).
+          BUILD_NUMBER: ${{ github.run_number }}
         run: |
           npm run build
           # Hard security gate (#9148) — fail before packaging if any E2E

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -126,6 +126,7 @@ module.exports = async function () {
       applicationId: "Daintree",
       displayName: "Daintree",
       languages: ["en-US"],
+      setBuildNumber: true,
     },
     // NSIS (non-Store) Windows installer. Produces a single combined x64+arm64
     // `.exe`; the installer selects the right payload at runtime. Auto-update


### PR DESCRIPTION
## Summary
- `electron-builder` strips semver pre-release tags when generating AppX manifests -- `parseInt` discards suffixes, so `0.14.1-rc.1` maps to the same manifest version as `0.14.1`.
- This means the Microsoft Store can't distinguish RC or beta builds from stable builds within the same minor version. Only the most recently submitted package for a given `A.B.C` triplet wins.
- The fix enables `appx.setBuildNumber` and routes `github.run_number` into the fourth version slot so every build gets a unique `A.B.C.D`.

Resolves #9252

## Changes
- `electron-builder.config.cjs` -- set `appx.setBuildNumber: true`
- `.github/workflows/release-windows.yml` -- pass `BUILD_NUMBER: ${{ github.run_number }}`

## Testing
- Confirmed `setBuildNumber` is a recognized electron-builder 26.x option
- `github.run_number` is per-workflow monotonic, which is sufficient for the ~weekly release cadence