### PR TITLE
fix(macos): remove obsolete hardened-runtime entitlement on Electron 41

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -209,6 +209,26 @@ jobs:
             spctl --assess --type execute --verbose --ignore-cache --no-cache "$app" || true
           done
 
+      - name: Verify macOS TeamIdentifier audit
+        if: inputs.skip_notarization != true
+        shell: bash
+        env:
+          EXPECTED_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$EXPECTED_TEAM_ID" ]]; then
+            echo "::error::APPLE_TEAM_ID secret is empty — cannot verify TeamIdentifier"
+            exit 1
+          fi
+          apps=(
+            "release/mac-arm64/Daintree.app"
+            "release/mac/Daintree.app"
+            "release/mac-universal/Daintree.app"
+          )
+          for app in "${apps[@]}"; do
+            scripts/ci/verify-team-identifier.sh "$app" "$EXPECTED_TEAM_ID"
+          done
+
       - name: Validate update metadata (macOS)
         shell: bash
         run: |

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -210,7 +210,6 @@ jobs:
           done
 
       - name: Verify macOS TeamIdentifier audit
-        if: inputs.skip_notarization != true
         shell: bash
         env:
           EXPECTED_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -2,13 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <!-- V8 JIT compilation in Electron -->
+    <!-- V8 JIT compilation in Electron 41. allow-unsigned-executable-memory
+         was dropped in Electron 12 (PR #26331) and is not needed here. -->
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
-    <!-- Required for loading native modules like node-pty -->
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <true/>
-    <!-- Loading Electron framework libraries -->
+    <!-- Loading native .node modules at runtime (pty.node, better_sqlite3.node).
+         Retained until CI TeamIdentifier audit (scripts/ci/verify-team-identifier.sh)
+         confirms every Mach-O in the bundle shares the expected Team ID. -->
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -159,9 +159,8 @@ Artifacts are uploaded to Cloudflare R2 via AWS CLI:
 
 The hardened runtime entitlements are in `build/entitlements.mac.plist`:
 
-- `com.apple.security.cs.allow-jit` — required for Electron with hardened runtime
-- `com.apple.security.cs.allow-unsigned-executable-memory` — may not be needed for Electron 40+, review when re-enabling notarization
-- `com.apple.security.cs.disable-library-validation` — allows loading node-pty native module
+- `com.apple.security.cs.allow-jit` — required for V8 JIT in Electron 41 (no longer requires `allow-unsigned-executable-memory`, dropped in Electron 12)
+- `com.apple.security.cs.disable-library-validation` — allows loading native .node modules at runtime (pty.node, better_sqlite3.node). Retained until the CI TeamIdentifier audit (`scripts/ci/verify-team-identifier.sh`) confirms every Mach-O in the bundle shares the expected Team ID
 
 ## Local Development Builds
 

--- a/scripts/ci/verify-team-identifier.sh
+++ b/scripts/ci/verify-team-identifier.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Verify every Mach-O binary in a macOS .app bundle shares the expected Team ID.
+# Used as a CI gate on release builds to canary the eventual removal of the
+# com.apple.security.cs.disable-library-validation entitlement.
+set -euo pipefail
+
+APP_BUNDLE="${1:?Usage: $0 <app_bundle_path> <expected_team_id>}"
+EXPECTED_TEAM_ID="${2:?Usage: $0 <app_bundle_path> <expected_team_id>}"
+
+if [[ ! -d "$APP_BUNDLE" ]]; then
+  echo "::error::App bundle directory does not exist: $APP_BUNDLE"
+  exit 1
+fi
+
+if [[ "$APP_BUNDLE" != *.app ]]; then
+  echo "::error::Path does not end in .app: $APP_BUNDLE"
+  exit 1
+fi
+
+if [[ -z "$EXPECTED_TEAM_ID" || ! "$EXPECTED_TEAM_ID" =~ ^[A-Za-z0-9]{10}$ ]]; then
+  echo "::error::Expected Team ID must be a 10-character alphanumeric string, got: '$EXPECTED_TEAM_ID'"
+  exit 1
+fi
+
+echo "Verifying all Mach-O binaries in '$APP_BUNDLE' share Team ID: $EXPECTED_TEAM_ID"
+
+macho_count=0
+failed=0
+
+while IFS= read -r -d '' file; do
+  if ! file -b "$file" | grep -q "Mach-O"; then
+    continue
+  fi
+
+  macho_count=$((macho_count + 1))
+  info=$(codesign -dv "$file" 2>&1) || true
+
+  if echo "$info" | grep -q "code object is not signed at all"; then
+    echo "::error::FAIL: Unsigned binary: $file"
+    failed=$((failed + 1))
+    continue
+  fi
+
+  team_id=$(echo "$info" | grep '^TeamIdentifier=' | cut -d'=' -f2)
+
+  if [[ "$team_id" == "$EXPECTED_TEAM_ID" ]]; then
+    echo "  PASS: $file"
+  elif [[ -z "$team_id" ]]; then
+    echo "::error::FAIL: No TeamIdentifier in signature: $file"
+    failed=$((failed + 1))
+  else
+    echo "::error::FAIL: Mismatched Team ID on $file (got '$team_id', expected '$EXPECTED_TEAM_ID')"
+    failed=$((failed + 1))
+  fi
+done < <(find "$APP_BUNDLE" -type f -print0)
+
+if [[ $macho_count -eq 0 ]]; then
+  echo "::error::FAIL: No Mach-O binaries found in $APP_BUNDLE — bundle is structurally broken"
+  exit 1
+fi
+
+echo "--------------------------------------------------------"
+echo "Mach-O binaries scanned: $macho_count"
+
+if [[ $failed -ne 0 ]]; then
+  echo "::error::Verification FAILED: $failed binary(s) have missing or mismatched Team ID"
+  exit 1
+fi
+
+echo "Verification SUCCESS: All $macho_count Mach-O binaries match Team ID '$EXPECTED_TEAM_ID'"

--- a/scripts/ci/verify-team-identifier.sh
+++ b/scripts/ci/verify-team-identifier.sh
@@ -7,6 +7,8 @@ set -euo pipefail
 APP_BUNDLE="${1:?Usage: $0 <app_bundle_path> <expected_team_id>}"
 EXPECTED_TEAM_ID="${2:?Usage: $0 <app_bundle_path> <expected_team_id>}"
 
+APP_BUNDLE="${APP_BUNDLE%/}"
+
 if [[ ! -d "$APP_BUNDLE" ]]; then
   echo "::error::App bundle directory does not exist: $APP_BUNDLE"
   exit 1


### PR DESCRIPTION
## Summary

Removes `allow-unsigned-executable-memory` from the hardened runtime entitlements. That entitlement was dropped way back in Electron 12 and hasn't been needed since. While I was in there, I added a CI audit gate that scans every Mach-O binary in the .app bundle to verify they all share the expected Team ID. That gate is the prerequisite for eventually dropping `disable-library-validation` entirely.

Resolves #9258

## Changes

- `build/entitlements.mac.plist` -- removed the obsolete entitlement; updated remaining comments to document the gating conditions for future cleanup
- `scripts/ci/verify-team-identifier.sh` -- new CI script that verifies every Mach-O's Team ID against the expected value
- `.github/workflows/release-macos.yml` -- wired the audit into the release workflow as a gate for arm64, x64, and universal builds
- `docs/release.md` -- updated entitlement docs to match the current state

## Testing

- Shell script validated locally against a signed .app bundle
- CI step gated on the `APPLE_TEAM_ID` secret; fails fast if it's missing