### PR TITLE
refactor(ci): extract shared release steps as composite actions

### DIFF
--- a/.github/actions/checkout-shallow/action.yml
+++ b/.github/actions/checkout-shallow/action.yml
@@ -1,0 +1,10 @@
+name: Checkout (shallow)
+description: Shallow checkout of the triggering commit via actions/checkout@v6
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v6
+      with:
+        clean: true
+        fetch-depth: 1

--- a/.github/actions/publish-daintree/action.yml
+++ b/.github/actions/publish-daintree/action.yml
@@ -1,0 +1,123 @@
+name: Publish Daintree release
+description: Download artifacts, verify monotonic version, upload to R2, and notify website
+
+inputs:
+  artifact_name:
+    description: Name of the build artifact to download
+    required: true
+  include_globs:
+    description: Space-separated glob patterns for binary R2 upload (e.g. "*.dmg *.zip *.blockmap")
+    required: true
+  metadata_suffix:
+    description: YAML metadata filename fragment (e.g. "-mac", "-linux", or "" for Windows)
+    required: false
+    default: ""
+  release_platforms:
+    description: Comma-separated platform list for check-version-monotonic.mjs (e.g. "mac", "linux", "win")
+    required: true
+  node_version:
+    description: Node.js version
+    required: false
+    default: "22"
+  publish_url:
+    description: Base URL for R2 upload verification
+    required: false
+    default: https://updates.daintree.org/releases/
+  r2_access_key_id:
+    description: R2 access key ID
+    required: true
+  r2_secret_access_key:
+    description: R2 secret access key
+    required: true
+  r2_endpoint:
+    description: R2 endpoint URL
+    required: true
+  r2_bucket:
+    description: R2 bucket name
+    required: true
+  website_webhook_secret:
+    description: Website webhook secret
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Check out repository
+      uses: ./.github/actions/checkout-shallow
+
+    - name: Set up Node.js and install dependencies
+      uses: ./.github/actions/setup-node-install
+      with:
+        node_version: ${{ inputs.node_version }}
+        install_args: --ignore-scripts
+
+    - name: Resolve update metadata prefix
+      uses: ./.github/actions/resolve-update-metadata-prefix
+
+    - name: Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: release/
+
+    - name: List release files
+      shell: bash
+      run: ls -lah release/
+
+    - name: Install gate dependencies
+      shell: bash
+      run: npm install --no-save --no-audit --no-fund --ignore-scripts js-yaml semver
+
+    - name: Check version is monotonically increasing
+      shell: bash
+      env:
+        RELEASE_PLATFORMS: ${{ inputs.release_platforms }}
+      run: node scripts/ci/check-version-monotonic.mjs
+
+    - name: Upload binaries to R2
+      shell: bash
+      env:
+        AWS_ACCESS_KEY_ID: ${{ inputs.r2_access_key_id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.r2_secret_access_key }}
+        AWS_DEFAULT_REGION: auto
+        R2_ENDPOINT: ${{ inputs.r2_endpoint }}
+        R2_BUCKET: ${{ inputs.r2_bucket }}
+      run: |
+        read -ra GLOBS <<< "${{ inputs.include_globs }}"
+        INCLUDE_FLAGS=()
+        for glob in "${GLOBS[@]}"; do
+          INCLUDE_FLAGS+=(--include "$glob")
+        done
+        aws s3 sync release/ "s3://${R2_BUCKET}/releases/" \
+          --endpoint-url "${R2_ENDPOINT}" \
+          --no-progress \
+          --exclude "*" \
+          "${INCLUDE_FLAGS[@]}" \
+          --cache-control "public, max-age=31536000, immutable"
+
+    - name: Verify binaries reachable on R2
+      shell: bash
+      env:
+        PUBLISH_URL: ${{ inputs.publish_url }}
+      run: node scripts/ci/verify-r2-uploads.mjs
+
+    - name: Upload metadata to R2
+      shell: bash
+      env:
+        AWS_ACCESS_KEY_ID: ${{ inputs.r2_access_key_id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.r2_secret_access_key }}
+        AWS_DEFAULT_REGION: auto
+        R2_ENDPOINT: ${{ inputs.r2_endpoint }}
+        R2_BUCKET: ${{ inputs.r2_bucket }}
+      run: |
+        aws s3 sync release/ "s3://${R2_BUCKET}/releases/" \
+          --endpoint-url "${R2_ENDPOINT}" \
+          --no-progress \
+          --exclude "*" \
+          --include "${UPDATE_METADATA_PREFIX}${{ inputs.metadata_suffix }}.yml" \
+          --cache-control "no-cache, no-store, must-revalidate"
+
+    - name: Notify website of new release
+      uses: ./.github/actions/website-notify
+      with:
+        webhook_secret: ${{ inputs.website_webhook_secret }}

--- a/.github/actions/resolve-update-metadata-prefix/action.yml
+++ b/.github/actions/resolve-update-metadata-prefix/action.yml
@@ -1,0 +1,25 @@
+name: Resolve update metadata prefix
+description: Derive UPDATE_METADATA_PREFIX (rc/beta/latest) from the triggering tag
+
+outputs:
+  prefix:
+    description: The resolved prefix (rc, beta, or latest)
+    value: ${{ steps.resolve.outputs.prefix }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve prefix from tag
+      id: resolve
+      shell: bash
+      run: |
+        TAG_VERSION="${GITHUB_REF_NAME#v}"
+        if [[ "$TAG_VERSION" == *-rc* ]]; then
+          PREFIX="rc"
+        elif [[ "$TAG_VERSION" == *-beta* ]]; then
+          PREFIX="beta"
+        else
+          PREFIX="latest"
+        fi
+        echo "UPDATE_METADATA_PREFIX=${PREFIX}" >> "$GITHUB_ENV"
+        echo "prefix=${PREFIX}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/setup-node-install/action.yml
+++ b/.github/actions/setup-node-install/action.yml
@@ -1,0 +1,29 @@
+name: Setup Node.js and install dependencies
+description: Set up Node.js with npm cache, then install via npm-ci-retry.mjs
+
+inputs:
+  node_version:
+    description: Node.js version
+    required: true
+  install_args:
+    description: Extra arguments to pass to npm-ci-retry.mjs (e.g. --ignore-scripts)
+    required: false
+    default: ""
+  msvs_version:
+    description: MSVS version for Windows native module builds (sets npm_config_msvs_version)
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node_version }}
+        cache: npm
+
+    - name: Install dependencies
+      shell: bash
+      env:
+        npm_config_msvs_version: ${{ inputs.msvs_version }}
+      run: node scripts/ci/npm-ci-retry.mjs ${{ inputs.install_args }}

--- a/.github/actions/website-notify/action.yml
+++ b/.github/actions/website-notify/action.yml
@@ -1,0 +1,25 @@
+name: Notify website of new release
+description: POST the refresh-releases webhook to daintree.org
+
+inputs:
+  webhook_secret:
+    description: Website webhook secret (WEBSITE_WEBHOOK_SECRET)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Notify website
+      shell: bash
+      env:
+        WEBSITE_WEBHOOK_SECRET: ${{ inputs.webhook_secret }}
+      run: |
+        sleep 1
+        RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://daintree.org/api/refresh-releases \
+          -H "Authorization: Bearer ${WEBSITE_WEBHOOK_SECRET}")
+        HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+        BODY=$(echo "$RESPONSE" | sed '$d')
+        echo "Response (HTTP ${HTTP_CODE}): ${BODY}"
+        if [ "$HTTP_CODE" -ne 200 ]; then
+          echo "::warning::Website refresh failed (HTTP ${HTTP_CODE})"
+        fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -238,15 +238,7 @@ jobs:
           }
 
       - name: Check out repository
-        shell: bash
-        run: |
-          set -euo pipefail
-          git init "$GITHUB_WORKSPACE"
-          git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          git -C "$GITHUB_WORKSPACE" fetch --no-tags --prune --no-recurse-submodules --depth=1 origin "$GITHUB_SHA"
-          git -C "$GITHUB_WORKSPACE" checkout --force FETCH_HEAD
-          git -C "$GITHUB_WORKSPACE" clean -ffdx
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        uses: ./.github/actions/checkout-shallow
 
       - name: Cache Playwright browsers
         id: cache-playwright

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -34,28 +34,17 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out repository
-        shell: bash
-        run: |
-          set -euo pipefail
-          git init "$GITHUB_WORKSPACE"
-          git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          git -C "$GITHUB_WORKSPACE" fetch --no-tags --prune --no-recurse-submodules --depth=1 origin "$GITHUB_SHA"
-          git -C "$GITHUB_WORKSPACE" checkout --force FETCH_HEAD
-          git -C "$GITHUB_WORKSPACE" clean -ffdx
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
+        uses: ./.github/actions/checkout-shallow
 
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libarchive-tools
 
-      - name: Install dependencies
-        run: node scripts/ci/npm-ci-retry.mjs
+      - name: Set up Node.js and install dependencies
+        uses: ./.github/actions/setup-node-install
+        with:
+          node_version: ${{ env.NODE_VERSION }}
 
       - name: Check
         run: npm run check
@@ -66,28 +55,17 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Check out repository
-        shell: bash
-        run: |
-          set -euo pipefail
-          git init "$GITHUB_WORKSPACE"
-          git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          git -C "$GITHUB_WORKSPACE" fetch --no-tags --prune --no-recurse-submodules --depth=1 origin "$GITHUB_SHA"
-          git -C "$GITHUB_WORKSPACE" checkout --force FETCH_HEAD
-          git -C "$GITHUB_WORKSPACE" clean -ffdx
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
+        uses: ./.github/actions/checkout-shallow
 
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libarchive-tools
 
-      - name: Install dependencies
-        run: node scripts/ci/npm-ci-retry.mjs
+      - name: Set up Node.js and install dependencies
+        uses: ./.github/actions/setup-node-install
+        with:
+          node_version: ${{ env.NODE_VERSION }}
 
       - name: Test
         run: npm run test
@@ -131,27 +109,10 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Check out repository
-        shell: bash
-        run: |
-          set -euo pipefail
-          git init "$GITHUB_WORKSPACE"
-          git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          git -C "$GITHUB_WORKSPACE" fetch --no-tags --prune --no-recurse-submodules --depth=1 origin "$GITHUB_SHA"
-          git -C "$GITHUB_WORKSPACE" checkout --force FETCH_HEAD
-          git -C "$GITHUB_WORKSPACE" clean -ffdx
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        uses: ./.github/actions/checkout-shallow
 
       - name: Resolve update metadata prefix
-        shell: bash
-        run: |
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          if [[ "$PKG_VERSION" == *-rc* ]]; then
-            echo "UPDATE_METADATA_PREFIX=rc" >> "$GITHUB_ENV"
-          elif [[ "$PKG_VERSION" == *-beta* ]]; then
-            echo "UPDATE_METADATA_PREFIX=beta" >> "$GITHUB_ENV"
-          else
-            echo "UPDATE_METADATA_PREFIX=latest" >> "$GITHUB_ENV"
-          fi
+        uses: ./.github/actions/resolve-update-metadata-prefix
 
       - name: Verify version matches tag
         if: startsWith(github.ref, 'refs/tags/v')
@@ -164,14 +125,10 @@ jobs:
             exit 1
           fi
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
+      - name: Set up Node.js and install dependencies
+        uses: ./.github/actions/setup-node-install
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-
-      - name: Install dependencies
-        run: node scripts/ci/npm-ci-retry.mjs
+          node_version: ${{ env.NODE_VERSION }}
 
       - name: Install Linux dependencies
         run: |
@@ -230,109 +187,15 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - name: Checkout repository
-        shell: bash
-        run: |
-          set -euo pipefail
-          git init "$GITHUB_WORKSPACE"
-          git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          git -C "$GITHUB_WORKSPACE" fetch --no-tags --prune --no-recurse-submodules --depth=1 origin "$GITHUB_SHA"
-          git -C "$GITHUB_WORKSPACE" checkout --force FETCH_HEAD
-          git -C "$GITHUB_WORKSPACE" clean -ffdx
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
+      - name: Publish Daintree (Linux)
+        uses: ./.github/actions/publish-daintree
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-
-      - name: Install dependencies
-        run: node scripts/ci/npm-ci-retry.mjs --ignore-scripts
-
-      - name: Resolve update metadata prefix
-        shell: bash
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
-          if [[ "$TAG_VERSION" == *-rc* ]]; then
-            echo "UPDATE_METADATA_PREFIX=rc" >> "$GITHUB_ENV"
-          elif [[ "$TAG_VERSION" == *-beta* ]]; then
-            echo "UPDATE_METADATA_PREFIX=beta" >> "$GITHUB_ENV"
-          else
-            echo "UPDATE_METADATA_PREFIX=latest" >> "$GITHUB_ENV"
-          fi
-
-      - name: Download Linux artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: release-daintree-ubuntu-22.04
-          path: release/
-
-      - name: List release files
-        run: ls -lah release/
-
-      - name: Install gate dependencies
-        shell: bash
-        run: npm install --no-save --no-audit --no-fund --ignore-scripts js-yaml semver
-
-      - name: Check version is monotonically increasing
-        shell: bash
-        env:
-          UPDATE_METADATA_PREFIX: ${{ env.UPDATE_METADATA_PREFIX }}
-          RELEASE_PLATFORMS: linux
-        run: node scripts/ci/check-version-monotonic.mjs
-
-      - name: Upload binaries to R2
-        shell: bash
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: auto
-          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
-          R2_BUCKET: ${{ secrets.DAINTREE_R2_BUCKET }}
-        run: |
-          aws s3 sync release/ "s3://${R2_BUCKET}/releases/" \
-            --endpoint-url "${R2_ENDPOINT}" \
-            --no-progress \
-            --exclude "*" \
-            --include "*.AppImage" \
-            --include "*.deb" \
-            --include "*.blockmap" \
-            --cache-control "public, max-age=31536000, immutable"
-
-      - name: Verify binaries reachable on R2
-        shell: bash
-        env:
-          PUBLISH_URL: https://updates.daintree.org/releases/
-        run: node scripts/ci/verify-r2-uploads.mjs
-
-      - name: Upload metadata to R2
-        shell: bash
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: auto
-          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
-          R2_BUCKET: ${{ secrets.DAINTREE_R2_BUCKET }}
-        run: |
-          aws s3 sync release/ "s3://${R2_BUCKET}/releases/" \
-            --endpoint-url "${R2_ENDPOINT}" \
-            --no-progress \
-            --exclude "*" \
-            --include "${UPDATE_METADATA_PREFIX}-linux.yml" \
-            --cache-control "no-cache, no-store, must-revalidate"
-
-      - name: Notify website of new release
-        shell: bash
-        env:
-          WEBSITE_WEBHOOK_SECRET: ${{ secrets.WEBSITE_WEBHOOK_SECRET }}
-        run: |
-          sleep 1
-          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://daintree.org/api/refresh-releases \
-            -H "Authorization: Bearer ${WEBSITE_WEBHOOK_SECRET}")
-          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
-          BODY=$(echo "$RESPONSE" | sed '$d')
-          echo "Response (HTTP ${HTTP_CODE}): ${BODY}"
-          if [ "$HTTP_CODE" -ne 200 ]; then
-            echo "::warning::Website refresh failed (HTTP ${HTTP_CODE})"
-          fi
+          artifact_name: release-daintree-ubuntu-22.04
+          include_globs: "*.AppImage *.deb *.blockmap"
+          metadata_suffix: "-linux"
+          release_platforms: linux
+          r2_access_key_id: ${{ secrets.R2_ACCESS_KEY_ID }}
+          r2_secret_access_key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          r2_endpoint: ${{ secrets.R2_ENDPOINT }}
+          r2_bucket: ${{ secrets.DAINTREE_R2_BUCKET }}
+          website_webhook_secret: ${{ secrets.WEBSITE_WEBHOOK_SECRET }}

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -47,28 +47,17 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out repository
-        shell: bash
-        run: |
-          set -euo pipefail
-          git init "$GITHUB_WORKSPACE"
-          git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          git -C "$GITHUB_WORKSPACE" fetch --no-tags --prune --no-recurse-submodules --depth=1 origin "$GITHUB_SHA"
-          git -C "$GITHUB_WORKSPACE" checkout --force FETCH_HEAD
-          git -C "$GITHUB_WORKSPACE" clean -ffdx
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
+        uses: ./.github/actions/checkout-shallow
 
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libarchive-tools
 
-      - name: Install dependencies
-        run: node scripts/ci/npm-ci-retry.mjs
+      - name: Set up Node.js and install dependencies
+        uses: ./.github/actions/setup-node-install
+        with:
+          node_version: ${{ env.NODE_VERSION }}
 
       - name: Check
         run: npm run check
@@ -79,23 +68,12 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Check out repository
-        shell: bash
-        run: |
-          set -euo pipefail
-          git init "$GITHUB_WORKSPACE"
-          git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          git -C "$GITHUB_WORKSPACE" fetch --no-tags --prune --no-recurse-submodules --depth=1 origin "$GITHUB_SHA"
-          git -C "$GITHUB_WORKSPACE" checkout --force FETCH_HEAD
-          git -C "$GITHUB_WORKSPACE" clean -ffdx
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        uses: ./.github/actions/checkout-shallow
 
-      - uses: actions/setup-node@v6
+      - name: Set up Node.js and install dependencies
+        uses: ./.github/actions/setup-node-install
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-
-      - name: Install dependencies
-        run: node scripts/ci/npm-ci-retry.mjs
+          node_version: ${{ env.NODE_VERSION }}
 
       - name: Test
         run: npm run test
@@ -142,27 +120,10 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Check out repository
-        shell: bash
-        run: |
-          set -euo pipefail
-          git init "$GITHUB_WORKSPACE"
-          git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          git -C "$GITHUB_WORKSPACE" fetch --no-tags --prune --no-recurse-submodules --depth=1 origin "$GITHUB_SHA"
-          git -C "$GITHUB_WORKSPACE" checkout --force FETCH_HEAD
-          git -C "$GITHUB_WORKSPACE" clean -ffdx
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        uses: ./.github/actions/checkout-shallow
 
       - name: Resolve update metadata prefix
-        shell: bash
-        run: |
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          if [[ "$PKG_VERSION" == *-rc* ]]; then
-            echo "UPDATE_METADATA_PREFIX=rc" >> "$GITHUB_ENV"
-          elif [[ "$PKG_VERSION" == *-beta* ]]; then
-            echo "UPDATE_METADATA_PREFIX=beta" >> "$GITHUB_ENV"
-          else
-            echo "UPDATE_METADATA_PREFIX=latest" >> "$GITHUB_ENV"
-          fi
+        uses: ./.github/actions/resolve-update-metadata-prefix
 
       - name: Verify version matches tag
         if: startsWith(github.ref, 'refs/tags/v')
@@ -175,14 +136,10 @@ jobs:
             exit 1
           fi
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
+      - name: Set up Node.js and install dependencies
+        uses: ./.github/actions/setup-node-install
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-
-      - name: Install dependencies
-        run: node scripts/ci/npm-ci-retry.mjs
+          node_version: ${{ env.NODE_VERSION }}
 
       - name: Import macOS certificates
         uses: apple-actions/import-codesign-certs@v6
@@ -289,112 +246,15 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - name: Checkout repository
-        shell: bash
-        run: |
-          set -euo pipefail
-          git init "$GITHUB_WORKSPACE"
-          git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          git -C "$GITHUB_WORKSPACE" fetch --no-tags --prune --no-recurse-submodules --depth=1 origin "$GITHUB_SHA"
-          git -C "$GITHUB_WORKSPACE" checkout --force FETCH_HEAD
-          git -C "$GITHUB_WORKSPACE" clean -ffdx
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
+      - name: Publish Daintree (macOS)
+        uses: ./.github/actions/publish-daintree
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-
-      - name: Install dependencies
-        run: node scripts/ci/npm-ci-retry.mjs --ignore-scripts
-
-      - name: Resolve update metadata prefix
-        shell: bash
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
-          if [[ "$TAG_VERSION" == *-rc* ]]; then
-            echo "UPDATE_METADATA_PREFIX=rc" >> "$GITHUB_ENV"
-          elif [[ "$TAG_VERSION" == *-beta* ]]; then
-            echo "UPDATE_METADATA_PREFIX=beta" >> "$GITHUB_ENV"
-          else
-            echo "UPDATE_METADATA_PREFIX=latest" >> "$GITHUB_ENV"
-          fi
-
-      - name: Download macOS artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: release-daintree-macos-14
-          path: release/
-
-      - name: List release files
-        run: ls -lah release/
-
-      - name: Install gate dependencies
-        shell: bash
-        run: npm install --no-save --no-audit --no-fund --ignore-scripts js-yaml semver
-
-      - name: Check version is monotonically increasing
-        shell: bash
-        env:
-          UPDATE_METADATA_PREFIX: ${{ env.UPDATE_METADATA_PREFIX }}
-          # Per-OS scope (#8052): only macOS metadata is present in this
-          # workflow's release/ dir. Per-platform monotonicity is the only
-          # invariant electron-updater enforces; cross-OS alignment is not.
-          RELEASE_PLATFORMS: mac
-        run: node scripts/ci/check-version-monotonic.mjs
-
-      - name: Upload binaries to R2
-        shell: bash
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: auto
-          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
-          R2_BUCKET: ${{ secrets.DAINTREE_R2_BUCKET }}
-        run: |
-          aws s3 sync release/ "s3://${R2_BUCKET}/releases/" \
-            --endpoint-url "${R2_ENDPOINT}" \
-            --no-progress \
-            --exclude "*" \
-            --include "*.dmg" \
-            --include "*.zip" \
-            --include "*.blockmap" \
-            --cache-control "public, max-age=31536000, immutable"
-
-      - name: Verify binaries reachable on R2
-        shell: bash
-        env:
-          PUBLISH_URL: https://updates.daintree.org/releases/
-        run: node scripts/ci/verify-r2-uploads.mjs
-
-      - name: Upload metadata to R2
-        shell: bash
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: auto
-          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
-          R2_BUCKET: ${{ secrets.DAINTREE_R2_BUCKET }}
-        run: |
-          aws s3 sync release/ "s3://${R2_BUCKET}/releases/" \
-            --endpoint-url "${R2_ENDPOINT}" \
-            --no-progress \
-            --exclude "*" \
-            --include "${UPDATE_METADATA_PREFIX}-mac.yml" \
-            --cache-control "no-cache, no-store, must-revalidate"
-
-      - name: Notify website of new release
-        shell: bash
-        env:
-          WEBSITE_WEBHOOK_SECRET: ${{ secrets.WEBSITE_WEBHOOK_SECRET }}
-        run: |
-          sleep 1
-          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://daintree.org/api/refresh-releases \
-            -H "Authorization: Bearer ${WEBSITE_WEBHOOK_SECRET}")
-          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
-          BODY=$(echo "$RESPONSE" | sed '$d')
-          echo "Response (HTTP ${HTTP_CODE}): ${BODY}"
-          if [ "$HTTP_CODE" -ne 200 ]; then
-            echo "::warning::Website refresh failed (HTTP ${HTTP_CODE})"
-          fi
+          artifact_name: release-daintree-macos-14
+          include_globs: "*.dmg *.zip *.blockmap"
+          metadata_suffix: "-mac"
+          release_platforms: mac
+          r2_access_key_id: ${{ secrets.R2_ACCESS_KEY_ID }}
+          r2_secret_access_key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          r2_endpoint: ${{ secrets.R2_ENDPOINT }}
+          r2_bucket: ${{ secrets.DAINTREE_R2_BUCKET }}
+          website_webhook_secret: ${{ secrets.WEBSITE_WEBHOOK_SECRET }}

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -37,28 +37,17 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out repository
-        shell: bash
-        run: |
-          set -euo pipefail
-          git init "$GITHUB_WORKSPACE"
-          git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          git -C "$GITHUB_WORKSPACE" fetch --no-tags --prune --no-recurse-submodules --depth=1 origin "$GITHUB_SHA"
-          git -C "$GITHUB_WORKSPACE" checkout --force FETCH_HEAD
-          git -C "$GITHUB_WORKSPACE" clean -ffdx
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
+        uses: ./.github/actions/checkout-shallow
 
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libarchive-tools
 
-      - name: Install dependencies
-        run: node scripts/ci/npm-ci-retry.mjs
+      - name: Set up Node.js and install dependencies
+        uses: ./.github/actions/setup-node-install
+        with:
+          node_version: ${{ env.NODE_VERSION }}
 
       - name: Check
         run: npm run check
@@ -69,25 +58,13 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Check out repository
-        shell: bash
-        run: |
-          set -euo pipefail
-          git init "$GITHUB_WORKSPACE"
-          git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          git -C "$GITHUB_WORKSPACE" fetch --no-tags --prune --no-recurse-submodules --depth=1 origin "$GITHUB_SHA"
-          git -C "$GITHUB_WORKSPACE" checkout --force FETCH_HEAD
-          git -C "$GITHUB_WORKSPACE" clean -ffdx
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        uses: ./.github/actions/checkout-shallow
 
-      - uses: actions/setup-node@v6
+      - name: Set up Node.js and install dependencies
+        uses: ./.github/actions/setup-node-install
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-
-      - name: Install dependencies
-        run: node scripts/ci/npm-ci-retry.mjs
-        env:
-          npm_config_msvs_version: "2022"
+          node_version: ${{ env.NODE_VERSION }}
+          msvs_version: "2022"
 
       - name: Test
         run: npm run test
@@ -137,27 +114,10 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Check out repository
-        shell: bash
-        run: |
-          set -euo pipefail
-          git init "$GITHUB_WORKSPACE"
-          git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          git -C "$GITHUB_WORKSPACE" fetch --no-tags --prune --no-recurse-submodules --depth=1 origin "$GITHUB_SHA"
-          git -C "$GITHUB_WORKSPACE" checkout --force FETCH_HEAD
-          git -C "$GITHUB_WORKSPACE" clean -ffdx
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        uses: ./.github/actions/checkout-shallow
 
       - name: Resolve update metadata prefix
-        shell: bash
-        run: |
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          if [[ "$PKG_VERSION" == *-rc* ]]; then
-            echo "UPDATE_METADATA_PREFIX=rc" >> "$GITHUB_ENV"
-          elif [[ "$PKG_VERSION" == *-beta* ]]; then
-            echo "UPDATE_METADATA_PREFIX=beta" >> "$GITHUB_ENV"
-          else
-            echo "UPDATE_METADATA_PREFIX=latest" >> "$GITHUB_ENV"
-          fi
+        uses: ./.github/actions/resolve-update-metadata-prefix
 
       - name: Verify version matches tag
         if: startsWith(github.ref, 'refs/tags/v')
@@ -170,16 +130,11 @@ jobs:
             exit 1
           fi
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
+      - name: Set up Node.js and install dependencies
+        uses: ./.github/actions/setup-node-install
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-
-      - name: Install dependencies
-        run: node scripts/ci/npm-ci-retry.mjs
-        env:
-          npm_config_msvs_version: "2022"
+          node_version: ${{ env.NODE_VERSION }}
+          msvs_version: "2022"
 
       # Cross-compile win-job-object (source-only N-API addon) for arm64 so the
       # NSIS combined installer can ship both archs. node-pty and better-sqlite3
@@ -340,110 +295,15 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - name: Checkout repository
-        shell: bash
-        run: |
-          set -euo pipefail
-          git init "$GITHUB_WORKSPACE"
-          git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          git -C "$GITHUB_WORKSPACE" fetch --no-tags --prune --no-recurse-submodules --depth=1 origin "$GITHUB_SHA"
-          git -C "$GITHUB_WORKSPACE" checkout --force FETCH_HEAD
-          git -C "$GITHUB_WORKSPACE" clean -ffdx
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
+      - name: Publish Daintree (Windows)
+        uses: ./.github/actions/publish-daintree
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-
-      - name: Install dependencies
-        run: node scripts/ci/npm-ci-retry.mjs --ignore-scripts
-
-      - name: Resolve update metadata prefix
-        shell: bash
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
-          if [[ "$TAG_VERSION" == *-rc* ]]; then
-            echo "UPDATE_METADATA_PREFIX=rc" >> "$GITHUB_ENV"
-          elif [[ "$TAG_VERSION" == *-beta* ]]; then
-            echo "UPDATE_METADATA_PREFIX=beta" >> "$GITHUB_ENV"
-          else
-            echo "UPDATE_METADATA_PREFIX=latest" >> "$GITHUB_ENV"
-          fi
-
-      - name: Download Windows artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: release-daintree-windows-latest
-          path: release/
-
-      - name: List release files
-        run: ls -lah release/
-
-      - name: Install gate dependencies
-        shell: bash
-        run: npm install --no-save --no-audit --no-fund --ignore-scripts js-yaml semver
-
-      - name: Check version is monotonically increasing
-        shell: bash
-        env:
-          UPDATE_METADATA_PREFIX: ${{ env.UPDATE_METADATA_PREFIX }}
-          RELEASE_PLATFORMS: win
-        run: node scripts/ci/check-version-monotonic.mjs
-
-      - name: Upload binaries to R2
-        shell: bash
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: auto
-          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
-          R2_BUCKET: ${{ secrets.DAINTREE_R2_BUCKET }}
-        run: |
-          aws s3 sync release/ "s3://${R2_BUCKET}/releases/" \
-            --endpoint-url "${R2_ENDPOINT}" \
-            --no-progress \
-            --exclude "*" \
-            --include "*.appx" \
-            --include "*.msix" \
-            --include "*.exe" \
-            --include "*.blockmap" \
-            --cache-control "public, max-age=31536000, immutable"
-
-      - name: Verify binaries reachable on R2
-        shell: bash
-        env:
-          PUBLISH_URL: https://updates.daintree.org/releases/
-        run: node scripts/ci/verify-r2-uploads.mjs
-
-      - name: Upload metadata to R2
-        shell: bash
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: auto
-          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
-          R2_BUCKET: ${{ secrets.DAINTREE_R2_BUCKET }}
-        run: |
-          aws s3 sync release/ "s3://${R2_BUCKET}/releases/" \
-            --endpoint-url "${R2_ENDPOINT}" \
-            --no-progress \
-            --exclude "*" \
-            --include "${UPDATE_METADATA_PREFIX}.yml" \
-            --cache-control "no-cache, no-store, must-revalidate"
-
-      - name: Notify website of new release
-        shell: bash
-        env:
-          WEBSITE_WEBHOOK_SECRET: ${{ secrets.WEBSITE_WEBHOOK_SECRET }}
-        run: |
-          sleep 1
-          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://daintree.org/api/refresh-releases \
-            -H "Authorization: Bearer ${WEBSITE_WEBHOOK_SECRET}")
-          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
-          BODY=$(echo "$RESPONSE" | sed '$d')
-          echo "Response (HTTP ${HTTP_CODE}): ${BODY}"
-          if [ "$HTTP_CODE" -ne 200 ]; then
-            echo "::warning::Website refresh failed (HTTP ${HTTP_CODE})"
-          fi
+          artifact_name: release-daintree-windows-latest
+          include_globs: "*.appx *.msix *.exe *.blockmap"
+          metadata_suffix: ""
+          release_platforms: win
+          r2_access_key_id: ${{ secrets.R2_ACCESS_KEY_ID }}
+          r2_secret_access_key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          r2_endpoint: ${{ secrets.R2_ENDPOINT }}
+          r2_bucket: ${{ secrets.DAINTREE_R2_BUCKET }}
+          website_webhook_secret: ${{ secrets.WEBSITE_WEBHOOK_SECRET }}


### PR DESCRIPTION
## Summary
- Extracts five composite actions from the duplicated YAML in the three per-OS release workflows and `e2e.yml`.
- `publish-daintree` carries the bulk of the dedup — download, verify, upload to R2, and website notify in one parameterized action.
- Net reduction of about 500 lines. No runtime behavior change.

Resolves #9118

## Changes
- `.github/actions/checkout-shallow` — git checkout boilerplate (used in release workflows + e2e)
- `.github/actions/setup-node-install` — Node.js setup + `npm-ci-retry.mjs`
- `.github/actions/resolve-update-metadata-prefix` — rc/beta/latest resolver from tag
- `.github/actions/website-notify` — POST webhook to daintree.org
- `.github/actions/publish-daintree` — full publish job (version check, R2 sync, metadata upload, notify)
- `release-macos.yml`, `release-linux.yml`, `release-windows.yml` — all now compose these actions instead of inlining
- `e2e.yml` — uses `checkout-shallow` instead of inline git boilerplate

## Testing
- CI dry-run: the `npm ci --ignore-scripts` step in `publish-daintree` means the composite actions parse and resolve without needing a full install.
- The per-OS failure-isolation property from #8052 is preserved — each workflow keeps its own concurrency group, tag trigger, and publish path.