### PR TITLE
fix(plugins): lock plugin manifest contract before 1.0

### DIFF
--- a/docs/architecture/forge-provider-abstraction.md
+++ b/docs/architecture/forge-provider-abstraction.md
@@ -39,7 +39,7 @@ What the **host** abstracts inside this layer is deliberately _minimal_. Mainstr
 | State enum normalization | partial — see below | preserves `rawState` |
 | Rate-limit reporting | uniform shape | parses per-provider transport |
 
-The host does NOT abstract: review thread shape, approval workflows, CI graphs, merge strategies, label semantics, security alerts, or anything provider-exclusive. Plugins surface those via `views`-contributed panels rendering their own React components.
+The host does NOT abstract: review thread shape, approval workflows, CI graphs, merge strategies, label semantics, security alerts, or anything provider-exclusive. Plugins surface those via `experimental_views`-contributed panels rendering their own React components.
 
 ## Contribution Point: `forgeProviders`
 
@@ -69,7 +69,7 @@ Added to `plugin.json`'s `contributes` field. Status: **Planned**, ships in this
 | `matches` | yes | Exact hostnames for git remote URLs; first matching provider wins. Matching is case-insensitive and strips a leading `www.` from both the remote URL hostname and each entry. Glob, wildcard, suffix, and regular-expression patterns are not supported. |
 | `capabilities` | no | Free-form strings the host does not interpret. UI consumers query them to decide what affordances to surface. Suggested vocabulary: `issues`, `pulls`, `reviews`, `approvals`, `merge-trains`, `required-checks`, `draft-prs`, `assignees`, `releases`, `project-boards`, `milestones`. |
 | `settingsScopeRef` | no | ID prefix in this plugin's `settings` contributions—used to group provider settings under one heading. |
-| `viewRefs` | no | IDs of `views` contributions that should appear under this provider's panel section. |
+| `viewRefs` | no | IDs of `experimental_views` contributions that should appear under this provider's panel section. |
 
 Eager registration (manifest-driven) populates the Preferences UI and remote-routing table before any plugin code runs. The implementation handler is bound lazily on first use, matching the existing contribution-point lifecycle in `electron/services/PluginService.ts`.
 
@@ -357,7 +357,7 @@ Each step is a separate PR. The contract is allowed to evolve while GitHub is be
 - **Federation / ForgeFed actor URLs.** Pattern matching is hostname-based; ActivityPub actor matching is not in scope.
 - **A "forge auth" UI panel owned by the host.** Each plugin renders its own auth section.
 - **A normalized review-thread shape.** Reviews diverge too much across providers. Plugins ship their own review-thread UI under a `ReviewCapability` interface that returns provider-shaped data.
-- **MCP-as-forge-provider.** MCP servers can coexist alongside (a provider plugin can also ship an `mcpServers` contribution for agent use), but MCP is not the primary IDE data path.
+- **MCP-as-forge-provider.** MCP servers can coexist alongside (a provider plugin can also ship an `experimental_mcpServers` contribution for agent use), but MCP is not the primary IDE data path.
 - **Removing GitHub.** GitHub stays as a built-in plugin. The goal is decoupling, not eviction.
 
 ## Trade-offs

--- a/docs/plugins/agent-extensions.md
+++ b/docs/plugins/agent-extensions.md
@@ -13,10 +13,12 @@ Daintree supervises any MCP server a plugin ships. It spawns the process lazily,
 
 ### Manifest
 
+The manifest key is `experimental_mcpServers` — the `experimental_` prefix signals that the shape may change before the feature ships.
+
 ```json
 {
   "contributes": {
-    "mcpServers": [
+    "experimental_mcpServers": [
       {
         "id": "linear",
         "name": "Linear MCP",
@@ -112,6 +114,8 @@ Skills are markdown files a plugin contributes. Daintree's built-in MCP server e
 This is the right contribution point when the extension is about **knowledge or instructions** rather than **capabilities**. A TDD workflow skill doesn't need to call APIs — it just tells the agent how to think. A Linear integration, by contrast, needs network access and belongs in an MCP server.
 
 ### Manifest
+
+Skills are not yet present in the manifest schema. The example below shows the planned shape; it is documented here as a design preview.
 
 ```json
 {

--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -8,7 +8,7 @@ A plugin's life has five phases:
 
 1. **Discovery** — startup scan of `~/.daintree/plugins/`
 2. **Manifest validation** — `plugin.json` parsed, validated against the Zod schema
-3. **Registration** — eager contribution points (panels, toolbar buttons, menu items, manifest-declared commands) registered in the respective registries
+3. **Registration** — eager contribution points (panels, toolbar buttons, menu items) registered in the respective registries
 4. **Activation** — plugin's `main` module imported, `activate(host)` called (lazy — triggered by first use)
 5. **Disposal** — on unload, the cleanup cascade runs in reverse
 
@@ -22,7 +22,7 @@ The `plugins` root is configurable for testing via the `PluginService` construct
 
 ### Manifest validation
 
-Validation is strict. The manifest is parsed by `PluginManifestSchema` (Zod) in strict mode, which rejects unknown top-level keys and unknown keys inside `contributes`. The reason is conservative: unknown keys are almost always typos, and silently dropping typo'd contributions is a bad debugging experience.
+Validation is strict. The manifest is parsed by `PluginManifestSchema` (Zod) in strict mode, which rejects unknown top-level keys and unknown keys inside `contributes` (both the inner object itself and contributions whose individual entry schemas opt into `.strict()`). The reason is conservative: unknown keys are almost always typos, and silently dropping typo'd contributions is a bad debugging experience.
 
 The `engines.daintree` semver range is validated and compared against the running Daintree version. A mismatch produces a user-visible toast and the plugin is skipped.
 
@@ -33,18 +33,17 @@ Most contributions register eagerly at plugin-load time so the UI reflects them 
 - `panels` → `registerPanelKind()` in `shared/config/panelKindRegistry.ts`
 - `toolbarButtons` → `registerToolbarButton()` in `shared/config/toolbarButtonRegistry.ts`
 - `menuItems` → `registerPluginMenuItem()` in `electron/services/pluginMenuRegistry.ts`
-- `commands` → registered as synthetic action definitions in the `ActionService`; handler is resolved lazily
 
-Contributions that require code (e.g., a command handler, a view component, an MCP server's runtime) are registered as **resolvers** — thunks that import the actual code when first needed.
+Commands are not declared in the manifest. They are registered at runtime via `host.registerAction()` during `activate()`. This keeps the manifest as a static shape contract and the action system as a runtime concern.
+
+Contributions that require code (e.g., a view component, an MCP server's runtime) are registered as **resolvers** — thunks that import the actual code when first needed.
 
 ### Activation
 
 A plugin's `activate(host)` function runs when something first needs the plugin's code. Triggers:
 
-- User runs a manifest-declared command
+- User runs a plugin-registered command
 - User opens a plugin-contributed panel
-- An agent calls a tool from a plugin-shipped MCP server (MCP servers themselves are supervised separately — see below)
-- `onStartupFinished` activation event (only explicit event supported)
 
 When triggered, Daintree:
 
@@ -191,6 +190,44 @@ What the host derives from declared capabilities:
 - A compound-permission lattice, scope attenuation, and MCP advertisement gates are forthcoming (#9247, #9234). See the trust model for the complete list.
 
 The purpose is to let users judge plugins by what they claim to need and to apply proportional friction at high-risk intent surfaces. A simple theme-packager plugin declaring `shell:exec` looks suspicious; a Linear integration declaring `network:fetch` looks expected. Declaring honestly matters: a plugin that silently makes network requests without declaring `network:fetch` erodes the ecosystem's trust model, even though nothing blocks the call at runtime.
+
+## Host-derived classification
+
+The host is the sole authority on action danger classification. A plugin's self-reported `danger` in `registerPluginAction()` is advisory only — the host computes `effectiveDanger` and the renderer reads only that field for classification decisions.
+
+### Why host-derived
+
+Prior to #8321, the renderer trusted the plugin's self-reported `danger` field. A plugin could declare `danger: "safe"` on a destructive action and bypass the confirm dialog, MRU-rail exclusion, and `repeatLast` eligibility. The host now computes an authoritative `effectiveDanger` so a plugin cannot misclassify.
+
+### Mechanism
+
+`PluginService.registerPluginAction()` consults the set `CONFIRM_TRIGGERING_PERMISSIONS` (defined in `PluginService.ts`):
+
+| Permission           | Effect            |
+| -------------------- | ----------------- |
+| `shell:exec`         | Raises to confirm |
+| `git:write`          | Raises to confirm |
+| `fs:project-write`   | Raises to confirm |
+| `fs:user-data-write` | Raises to confirm |
+| `agent:invoke`       | Raises to confirm |
+
+When a plugin's declared manifest `permissions` includes any of these tokens, every action that plugin registers gets `effectiveDanger: "confirm"` regardless of the self-reported value.
+
+The rule is one-way: the host **may only raise danger, never lower it**. A plugin that declares `danger: "confirm"` keeps confirm regardless of permissions; a plugin that declares `danger: "safe"` is raised if it holds a high-risk permission.
+
+### Renderer contract
+
+The renderer reads `PluginActionDescriptor.effectiveDanger` (not `danger`) for:
+
+- Whether the confirm dialog gates agent-initiated dispatches
+- MRU-rail eligibility in the action palette
+- `ActionService.repeatLast` eligibility
+
+If `effectiveDanger` is absent (e.g. a stale descriptor from a pre-migration cache), the renderer must fail safe to `"confirm"`.
+
+### Scope
+
+This classification is host-side UX policy on Daintree's own action system. It does not block the plugin from executing code, calling IPC directly, or making network requests — those are gated by the curation trust model, not by runtime enforcement (see [Capability disclosure](#capability-disclosure)).
 
 ## Signing and kill-switch
 

--- a/docs/plugins/contribution-points.md
+++ b/docs/plugins/contribution-points.md
@@ -10,38 +10,9 @@ Each section below documents a contribution point, its schema, an example, and c
 - **Planned** — design locked, implementation in progress
 - **Future** — not yet committed
 
-## Commands — _Shipped_
+## Commands — _Runtime only_
 
-Commands are callable actions that appear in the command palette and can be bound to keybindings, toolbar buttons, or menu items.
-
-```json
-{
-  "contributes": {
-    "commands": [
-      {
-        "name": "plan-from-issue",
-        "title": "Plan From Issue",
-        "description": "Turn a Linear issue into a branch and agent session.",
-        "category": "Linear Planner",
-        "danger": "confirm",
-        "keywords": ["linear", "plan", "issue"]
-      }
-    ]
-  }
-}
-```
-
-**Fields:**
-
-| Field | Required | Notes |
-| --- | --- | --- |
-| `name` | yes | Matches `/^[a-z0-9][a-z0-9-]*$/`. Namespaced at runtime as `{pluginId}.{name}`. Also determines the handler file path — see below. |
-| `title` | yes | Palette label. |
-| `description` | yes | Subtitle in the palette and command detail views. |
-| `category` | yes | Grouping label; keep consistent across commands in the same plugin. |
-| `kind` | no | `"command"` (default) or `"query"`. Queries are expected to be read-only and idempotent. |
-| `danger` | no | `"safe"` (default) or `"confirm"`. A `confirm` command requires `{ confirmed: true }` when invoked by an agent. See [action-system](../architecture/action-system.md) for how danger works across the IDE. |
-| `keywords` | no | Extra search terms for the palette. |
+Commands are callable actions that appear in the command palette and can be bound to keybindings, toolbar buttons, or menu items. They are registered at runtime via `host.registerAction()` during `activate()`, not declared in `plugin.json`. See [Host API → registerAction](./host-api.md#registeraction) for the full signature.
 
 **Handler binding** — two ways:
 
@@ -82,9 +53,7 @@ export async function activate(host: PluginHostApi) {
 }
 ```
 
-If a command is declared in the manifest but no handler is bound — neither a filesystem file nor an imperative registration — running it produces a user-visible toast: `Command "{pluginId}.{name}" has no handler`. If an imperative registration references a name not in the manifest, it's allowed but the command doesn't appear in the palette or menus until you add it to the manifest.
-
-See the [Host API](./host-api.md#registeraction) reference for the full signature.
+If a command is registered imperatively but no handler is bound, running it produces a user-visible toast: `Command "{pluginId}.{name}" has no handler`.
 
 ## Panels — _Shipped_
 
@@ -126,12 +95,12 @@ Panels are full-sized workspaces in Daintree's grid (alongside terminal panels, 
 
 ## Views — _Planned_
 
-Views are the React components that render inside a panel. They depend on Daintree's renderer plugin host, which is in active development. The manifest shape is locked and stable; the runtime wiring is landing in the next phase.
+Views are the React components that render inside a panel. They depend on Daintree's renderer plugin host, which is in active development. The manifest shape is validated but the `experimental_` prefix signals that it may change before the feature ships — use with awareness that the contract is not yet locked.
 
 ```json
 {
   "contributes": {
-    "views": [
+    "experimental_views": [
       {
         "id": "dashboard",
         "name": "Cost Dashboard",
@@ -232,6 +201,8 @@ Menu items add entries to Daintree's application menus.
 
 ## Keybindings — _Planned_
 
+> Not yet present in the manifest schema. Documented here as a design preview; the shape is not yet locked.
+
 Keybindings map a key combination to an action.
 
 ```json
@@ -259,6 +230,8 @@ Keybindings map a key combination to an action.
 Conflicts with user overrides or other plugins' bindings are resolved by Daintree's existing keybinding service — plugin bindings are low-priority and yield to user overrides. See `src/services/KeybindingService.ts:325` for the registration API.
 
 ## Settings schema — _Planned_
+
+> Not yet present in the manifest schema. Documented here as a design preview; the shape is not yet locked.
 
 Declares user-configurable settings for your plugin.
 
@@ -300,6 +273,8 @@ Changes fire a subscription callback, so you don't need to reactivate to pick th
 
 ## Context menus — _Planned_
 
+> Not yet present in the manifest schema. Documented here as a design preview; the shape is not yet locked.
+
 Adds entries to right-click menus on specific UI elements.
 
 ```json
@@ -323,12 +298,12 @@ Context menus follow the same `actionId` dispatch pattern as menu items.
 
 ## MCP servers — _Planned_
 
-Declares Model Context Protocol servers the plugin ships. See [Agent extensions → MCP servers](./agent-extensions.md#mcp-servers) for the full story.
+Declares Model Context Protocol servers the plugin ships. The manifest shape is validated but the `experimental_` prefix signals that it may change before the feature ships — use with awareness that the contract is not yet locked. See [Agent extensions → MCP servers](./agent-extensions.md#mcp-servers) for the full story.
 
 ```json
 {
   "contributes": {
-    "mcpServers": [
+    "experimental_mcpServers": [
       {
         "id": "linear",
         "name": "Linear MCP",
@@ -356,6 +331,8 @@ Daintree supervises the process: lazy spawn on first tool use, hard kill on Dain
 **Intentionally excluded:** remote MCP transports (`url`), explicit transport types, per-server working directories, restart policies. These are deferred until use cases concretely require them.
 
 ## Skills — _Planned_
+
+> Not yet present in the manifest schema. Documented here as a design preview; the shape is not yet locked.
 
 Markdown-defined capability snippets that extend Daintree's built-in MCP server. Agents running in Daintree gain access to them through Daintree's MCP connection.
 

--- a/docs/plugins/forge-provider.md
+++ b/docs/plugins/forge-provider.md
@@ -59,7 +59,7 @@ Add a `forgeProviders` contribution to `plugin.json`. Daintree reads this eagerl
 | `matches` | yes | List of exact hostnames. The host extracts the hostname from the project's git remote (HTTPS, SSH, and SCP-form `git@host:owner/repo.git` URLs all handled), lowercases and trims it, then matches it for **exact string equality** against each entry — there is no glob, wildcard, or suffix matching. List every distinct hostname your forge serves (e.g. a self-hosted instance and its CI mirror) as separate entries. First matching provider wins. |
 | `capabilities` | no | Informational hints driving the Preferences "supports: …" display only. The host does **not** gate behavior on this array — see [Add optional capabilities](#add-optional-capabilities). |
 | `settingsScopeRef` | no | ID prefix in this plugin's `settings` contributions, used to group provider settings. |
-| `viewRefs` | no | IDs of `views` contributions shown under this provider's panel section. |
+| `viewRefs` | no | IDs of `experimental_views` contributions shown under this provider's panel section. |
 
 The `forgeProviders` contribution point is also documented in [Contribution points](./contribution-points.md#forge-providers).
 

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -40,9 +40,6 @@ Daintree reads the manifest eagerly at startup. Contribution points declared her
 
   // The plugin's UI and functional contributions.
   "contributes": {
-    "commands": [
-      /* ... */
-    ],
     "panels": [
       /* ... */
     ],
@@ -52,29 +49,19 @@ Daintree reads the manifest eagerly at startup. Contribution points declared her
     "menuItems": [
       /* ... */
     ],
-    "views": [
+    "experimental_views": [
       /* ... */
     ],
-    "mcpServers": [
+    "experimental_mcpServers": [
       /* ... */
     ],
-    "skills": [
+    "forgeProviders": [
       /* ... */
     ],
-    "keybindings": [
-      /* ... */
-    ],
-    "settings": [
-      /* ... */
-    ],
-    "contextMenus": [
+    "fileDecorationProviders": [
       /* ... */
     ],
   },
-
-  // Explicit activation. Optional. Only "onStartupFinished" is supported.
-  // Commands, panels, views etc. are activated implicitly when invoked.
-  "activationEvents": ["onStartupFinished"],
 }
 ```
 
@@ -136,7 +123,7 @@ If the running Daintree version doesn't satisfy the range, the plugin is rejecte
 
 Daintree is pre-1.0. Pin tightly during this phase — a plugin that works on Daintree 0.8 may not work on 0.9 without changes.
 
-### `capabilities`
+### `permissions`
 
 Array of capability tokens the plugin wants. The model is **disclosure-first with host-side policy effects** — there is no Node sandbox, so a plugin is not blocked from doing anything regardless of what it declares, but declared tokens are not purely advisory. Five high-risk tokens (`shell:exec`, `git:write`, `fs:project-write`, `fs:user-data-write`, `agent:invoke`) currently raise every action the plugin registers to a confirm dialog (`effectiveDanger: "confirm"`) via the host's `CONFIRM_TRIGGERING_PERMISSIONS` set. A forthcoming scoped object form (`{ name, scopes }`) and `mcp:*` tokens are not yet parsed. See the [trust model](./trust-model.md) for the full contract.
 
@@ -161,15 +148,7 @@ Declare honestly. The install UI lists what you've declared and users judge plug
 
 ### `contributes`
 
-Object containing arrays for each contribution type. All fields are optional; unlisted contribution types default to empty arrays. See the full [Contribution points reference](./contribution-points.md) for every type.
-
-### `activationEvents`
-
-Array of explicit activation triggers. Only `onStartupFinished` is supported.
-
-Daintree infers most activation events from contribution points automatically. A plugin declaring `commands[{ name: "foo" }]` implicitly activates when `foo` runs. You don't need to list `onCommand:foo` explicitly — and Daintree will reject it if you try.
-
-Use `onStartupFinished` only for plugins that need to do background work without any user-triggered entry point. Example: a plugin that watches a file and emits notifications. Most plugins don't need this.
+Object containing arrays for each contribution type. All fields are optional; unlisted contribution types default to empty arrays. Fields prefixed with `experimental_` are reserved shapes that are validated by the schema but not yet wired to a runtime — the prefix signals that the shape may change before the feature ships. See the full [Contribution points reference](./contribution-points.md) for every type.
 
 ## Validation
 

--- a/electron/__tests__/clipboard.test.ts
+++ b/electron/__tests__/clipboard.test.ts
@@ -10,6 +10,18 @@ vi.mock("electron", () => ({
   ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
 }));
 
+// clipboard.ts imports projectStore from ProjectStore.js which imports
+// electron-store (from node_modules). node_modules deps bypass vitest's
+// transform pipeline, so electron-store's `import electron from 'electron'`
+// would load the real electron binary and fail. Mock the project-level import
+// to prevent the chain — cleanupOldClipboardImages never uses the store.
+vi.mock("../services/ProjectStore.js", () => ({
+  projectStore: {
+    getAllProjects: vi.fn(() => []),
+    getCurrentProjectId: vi.fn(() => null),
+  },
+}));
+
 // Redirect os.tmpdir() to a throwaway directory so the cleanup operates on real
 // files we control. The base dir is created inside the factory where the real
 // os module is still available.

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -137,12 +137,12 @@ export const PluginManifestSchema = z
       .optional(),
     permissions: z.array(PluginPermissionSchema).default([]),
     contributes: z
-      .object({
+      .strictObject({
         panels: z.array(PanelContributionSchema).default([]),
         toolbarButtons: z.array(ToolbarButtonContributionSchema).default([]),
         menuItems: z.array(MenuItemContributionSchema).default([]),
-        views: z.array(ViewContributionSchema).default([]),
-        mcpServers: z.array(McpServerContributionSchema).default([]),
+        experimental_views: z.array(ViewContributionSchema).default([]),
+        experimental_mcpServers: z.array(McpServerContributionSchema).default([]),
         forgeProviders: z.array(ForgeProviderContributionSchema).default([]),
         fileDecorationProviders: z.array(FileDecorationContributionSchema).default([]),
       })
@@ -150,8 +150,8 @@ export const PluginManifestSchema = z
         panels: [],
         toolbarButtons: [],
         menuItems: [],
-        views: [],
-        mcpServers: [],
+        experimental_views: [],
+        experimental_mcpServers: [],
         forgeProviders: [],
         fileDecorationProviders: [],
       }),

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -50,7 +50,8 @@ export const MenuItemContributionSchema = z.object({
 /**
  * Reserved contribution point. Shape is validated but the runtime does not
  * yet act on these entries — `PluginService` logs a warning and skips them.
- * See `docs/architecture/plugin-views-and-mcp-servers.md`.
+ * The `experimental_` prefix signals that the shape may change before the
+ * feature ships. See `docs/plugins/architecture.md`.
  */
 export const ViewContributionSchema = z.object({
   id: z.string().min(1).max(64).regex(SAFE_ID_PATTERN),

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -491,15 +491,15 @@ export class PluginService {
       registerPluginMenuItem(manifest.name, menuItem);
     }
 
-    if (manifest.contributes.views.length > 0) {
+    if (manifest.contributes.experimental_views.length > 0) {
       console.warn(
-        `[PluginService] Plugin "${manifest.name}": contributes.views is not yet implemented and will be ignored`
+        `[PluginService] Plugin "${manifest.name}": contributes.experimental_views is not yet implemented and will be ignored`
       );
     }
 
-    if (manifest.contributes.mcpServers.length > 0) {
+    if (manifest.contributes.experimental_mcpServers.length > 0) {
       console.warn(
-        `[PluginService] Plugin "${manifest.name}": contributes.mcpServers is not yet implemented and will be ignored`
+        `[PluginService] Plugin "${manifest.name}": contributes.experimental_mcpServers is not yet implemented and will be ignored`
       );
     }
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -456,6 +456,53 @@ describe("PluginManifestSchema fileDecorationProviders contribution", () => {
   });
 });
 
+describe("PluginManifestSchema contributes strict validation", () => {
+  const validBase = { name: "acme.test", version: "1.0.0" };
+
+  it("rejects unknown keys inside contributes (typo'd contribution-point names)", () => {
+    const result = PluginManifestSchema.safeParse({
+      ...validBase,
+      contributes: {
+        commands: [{ name: "foo", title: "Foo", description: "bar", category: "test" }],
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects old unprefixed views key inside contributes", () => {
+    const result = PluginManifestSchema.safeParse({
+      ...validBase,
+      contributes: { views: [{ id: "v", name: "V", componentPath: "./v.js", location: "panel" }] },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects old unprefixed mcpServers key inside contributes", () => {
+    const result = PluginManifestSchema.safeParse({
+      ...validBase,
+      contributes: { mcpServers: [{ id: "svc", name: "Svc", command: "node" }] },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an arbitrary unknown key inside contributes", () => {
+    const result = PluginManifestSchema.safeParse({
+      ...validBase,
+      contributes: { unknownKey: true },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts empty contributes object (no unknown keys, defaults populate)", () => {
+    const result = PluginManifestSchema.safeParse({ ...validBase, contributes: {} });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.contributes.experimental_views).toEqual([]);
+      expect(result.data.contributes.experimental_mcpServers).toEqual([]);
+    }
+  });
+});
+
 describe("PluginService", () => {
   it("returns empty list when plugins directory does not exist", async () => {
     const service = new PluginService(path.join(tmpDir, "nonexistent"));
@@ -2582,13 +2629,13 @@ describe("reserved contribution point warnings", () => {
     errorSpy.mockRestore();
   });
 
-  it("accepts a contributes.views entry and logs a 'not yet implemented' warning", async () => {
+  it("accepts a contributes.experimental_views entry and logs a 'not yet implemented' warning", async () => {
     await writePlugin("views", {
       name: "acme.views",
       version: "1.0.0",
       engines: { daintree: "^0.7.0" },
       contributes: {
-        views: [
+        experimental_views: [
           {
             id: "main",
             name: "Main",
@@ -2604,17 +2651,19 @@ describe("reserved contribution point warnings", () => {
 
     expect(service.listPlugins()).toHaveLength(1);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Plugin "acme.views": contributes.views is not yet implemented')
+      expect.stringContaining(
+        'Plugin "acme.views": contributes.experimental_views is not yet implemented'
+      )
     );
   });
 
-  it("accepts a contributes.mcpServers entry and logs a 'not yet implemented' warning", async () => {
+  it("accepts a contributes.experimental_mcpServers entry and logs a 'not yet implemented' warning", async () => {
     await writePlugin("mcp", {
       name: "acme.mcp",
       version: "1.0.0",
       engines: { daintree: "^0.7.0" },
       contributes: {
-        mcpServers: [
+        experimental_mcpServers: [
           {
             id: "linear",
             name: "Linear MCP",
@@ -2631,7 +2680,9 @@ describe("reserved contribution point warnings", () => {
 
     expect(service.listPlugins()).toHaveLength(1);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Plugin "acme.mcp": contributes.mcpServers is not yet implemented')
+      expect.stringContaining(
+        'Plugin "acme.mcp": contributes.experimental_mcpServers is not yet implemented'
+      )
     );
   });
 
@@ -2701,8 +2752,12 @@ describe("reserved contribution point warnings", () => {
 
     expect(service.listPlugins()).toHaveLength(1);
     const warnMessages = warnSpy.mock.calls.map((call: unknown[]) => String(call[0]));
-    expect(warnMessages.some((m: string) => m.includes("contributes.views"))).toBe(false);
-    expect(warnMessages.some((m: string) => m.includes("contributes.mcpServers"))).toBe(false);
+    expect(warnMessages.some((m: string) => m.includes("contributes.experimental_views"))).toBe(
+      false
+    );
+    expect(
+      warnMessages.some((m: string) => m.includes("contributes.experimental_mcpServers"))
+    ).toBe(false);
     expect(warnMessages.some((m: string) => m.includes("contributes.forgeProviders"))).toBe(false);
   });
 
@@ -2711,7 +2766,7 @@ describe("reserved contribution point warnings", () => {
       name: "acme.explicit-empty",
       version: "1.0.0",
       engines: { daintree: "^0.7.0" },
-      contributes: { views: [], mcpServers: [], forgeProviders: [] },
+      contributes: { experimental_views: [], experimental_mcpServers: [], forgeProviders: [] },
     });
 
     const service = new PluginService(tmpDir, "0.7.5");
@@ -2719,8 +2774,12 @@ describe("reserved contribution point warnings", () => {
 
     expect(service.listPlugins()).toHaveLength(1);
     const warnMessages = warnSpy.mock.calls.map((call: unknown[]) => String(call[0]));
-    expect(warnMessages.some((m: string) => m.includes("contributes.views"))).toBe(false);
-    expect(warnMessages.some((m: string) => m.includes("contributes.mcpServers"))).toBe(false);
+    expect(warnMessages.some((m: string) => m.includes("contributes.experimental_views"))).toBe(
+      false
+    );
+    expect(
+      warnMessages.some((m: string) => m.includes("contributes.experimental_mcpServers"))
+    ).toBe(false);
     expect(warnMessages.some((m: string) => m.includes("contributes.forgeProviders"))).toBe(false);
   });
 
@@ -2731,8 +2790,10 @@ describe("reserved contribution point warnings", () => {
       engines: { daintree: "^0.7.0" },
       contributes: {
         panels: [{ id: "viewer", name: "Viewer", iconId: "eye", color: "#000" }],
-        views: [{ id: "main", name: "Main", componentPath: "./v.js", location: "sidebar" }],
-        mcpServers: [{ id: "svc", name: "Svc", command: "node" }],
+        experimental_views: [
+          { id: "main", name: "Main", componentPath: "./v.js", location: "sidebar" },
+        ],
+        experimental_mcpServers: [{ id: "svc", name: "Svc", command: "node" }],
       },
     });
 
@@ -2742,10 +2803,10 @@ describe("reserved contribution point warnings", () => {
     expect(service.listPlugins()).toHaveLength(1);
     expect(registerPanelKind).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("contributes.views is not yet implemented")
+      expect.stringContaining("contributes.experimental_views is not yet implemented")
     );
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("contributes.mcpServers is not yet implemented")
+      expect.stringContaining("contributes.experimental_mcpServers is not yet implemented")
     );
   });
 
@@ -2755,7 +2816,7 @@ describe("reserved contribution point warnings", () => {
       version: "1.0.0",
       engines: { daintree: "^0.7.0" },
       contributes: {
-        views: [
+        experimental_views: [
           { id: "a", name: "A", componentPath: "./a.js", location: "panel" },
           { id: "b", name: "B", componentPath: "./b.js", location: "sidebar" },
           { id: "c", name: "C", componentPath: "./c.js", location: "panel" },
@@ -2767,7 +2828,7 @@ describe("reserved contribution point warnings", () => {
     await service.initialize();
 
     const viewWarnings = warnSpy.mock.calls.filter((call: unknown[]) =>
-      String(call[0]).includes("contributes.views is not yet implemented")
+      String(call[0]).includes("contributes.experimental_views is not yet implemented")
     );
     expect(viewWarnings).toHaveLength(1);
   });
@@ -2777,7 +2838,9 @@ describe("reserved contribution point warnings", () => {
       name: "acme.bad-location",
       version: "1.0.0",
       contributes: {
-        views: [{ id: "main", name: "Main", componentPath: "./v.js", location: "floating" }],
+        experimental_views: [
+          { id: "main", name: "Main", componentPath: "./v.js", location: "floating" },
+        ],
       },
     });
     expect(result.success).toBe(false);
@@ -2788,7 +2851,7 @@ describe("reserved contribution point warnings", () => {
       name: "acme.no-path",
       version: "1.0.0",
       contributes: {
-        views: [{ id: "main", name: "Main", location: "panel" }],
+        experimental_views: [{ id: "main", name: "Main", location: "panel" }],
       },
     });
     expect(result.success).toBe(false);
@@ -2799,7 +2862,7 @@ describe("reserved contribution point warnings", () => {
       name: "acme.no-cmd",
       version: "1.0.0",
       contributes: {
-        mcpServers: [{ id: "svc", name: "Svc" }],
+        experimental_mcpServers: [{ id: "svc", name: "Svc" }],
       },
     });
     expect(result.success).toBe(false);
@@ -2810,7 +2873,7 @@ describe("reserved contribution point warnings", () => {
       name: "acme.bad-env",
       version: "1.0.0",
       contributes: {
-        mcpServers: [{ id: "svc", name: "Svc", command: "node", env: { PORT: 8080 } }],
+        experimental_mcpServers: [{ id: "svc", name: "Svc", command: "node", env: { PORT: 8080 } }],
       },
     });
     expect(result.success).toBe(false);
@@ -2821,7 +2884,7 @@ describe("reserved contribution point warnings", () => {
       name: "acme.minimal-mcp",
       version: "1.0.0",
       contributes: {
-        mcpServers: [{ id: "svc", name: "Svc", command: "node" }],
+        experimental_mcpServers: [{ id: "svc", name: "Svc", command: "node" }],
       },
     });
     expect(result.success).toBe(true);

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -58,8 +58,9 @@ export interface MenuItemContribution {
 
 /**
  * Reserved contribution point — validated by the manifest schema but ignored
- * at load time with a "not yet implemented" warning. See
- * `docs/architecture/plugin-views-and-mcp-servers.md` for the design RFC.
+ * at load time with a "not yet implemented" warning. The `experimental_`
+ * prefix signals that the shape may change before the feature ships.
+ * See `docs/plugins/architecture.md` for the renderer host design.
  */
 export type ViewLocation = "panel" | "sidebar";
 

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -100,8 +100,8 @@ export interface PluginManifest {
     panels: PanelContribution[];
     toolbarButtons: ToolbarButtonContribution[];
     menuItems: MenuItemContribution[];
-    views: ViewContribution[];
-    mcpServers: McpServerContribution[];
+    experimental_views: ViewContribution[];
+    experimental_mcpServers: McpServerContribution[];
     forgeProviders: ForgeProviderContribution[];
     fileDecorationProviders: FileDecorationContribution[];
   };

--- a/src/registry/builtinRendererRegistry.ts
+++ b/src/registry/builtinRendererRegistry.ts
@@ -4,7 +4,7 @@ import type { ComponentType } from "react";
  * Slot registry for renderer-side views contributed by built-in plugins. The
  * registry exists so host-owned dialogs (NewWorktreeDialog, SidebarContent)
  * can render plugin-contributed components without importing them directly,
- * preserving the plugin boundary while `contributes.views` from the plugin
+ * preserving the plugin boundary while `contributes.experimental_views` from the plugin
  * manifest is unimplemented. Slot ids are dot-namespaced by plugin
  * (`github.bulkCreateWorktreeDialog`) so the host can grep the seam.
  */


### PR DESCRIPTION
## Summary
- Makes `contributes` strict so unknown contribution keys are rejected instead of silently dropped.
- Reconciles docs against the actual schema — stale fields removed, planned-but-never-shipped entries moved to future.
- Renames reserved fields to `experimental_views` and `experimental_mcpServers` so authors see the instability signal.
- Adds host-derived classification section to the architecture doc covering `effectiveDanger`.

Resolves #9228

## Changes
- `electron/schemas/plugin.ts` — `.strict()` on the `contributes` object
- `docs/plugins/manifest.md` — removed `capabilities`, `activationEvents`, and stale contribution entries the schema never accepted
- `docs/plugins/contribution-points.md` — moved never-shipped entries (`skills`, `keybindings`, `settings`, `contextMenus`, `themes`) to a future section
- `shared/types/plugin.ts`, `electron/services/PluginService.ts`, `src/registry/builtinRendererRegistry.ts` — renamed `views` / `mcpServers` to `experimental_views` / `experimental_mcpServers`
- `docs/plugins/architecture.md` — added host-derived classification section; fixed false claim about strict `contributes` validation
- `electron/services/__tests__/PluginService.test.ts` — new tests for strict validation and experimental field gating
- `docs/plugins/agent-extensions.md`, `docs/plugins/forge-provider.md`, `docs/architecture/forge-provider-abstraction.md` — updated cross-references

## Testing
- Unit tests pass: strict `contributes` rejects unknown keys, accepts known keys, experimental fields gate correctly.
- TypeScript typecheck passes with no new errors.
- The single existing consumer (`plugins/builtin/github/plugin.json`) passes validation unchanged.