### PR TITLE
fix(ci): tighten macOS post-build validation

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -185,7 +185,6 @@ jobs:
           npx electron-builder --config electron-builder.config.cjs --publish "$PUBLISH_FLAG" -c.buildDependenciesFromSource=true $EXTRA_ARGS
 
       - name: Verify macOS hardened runtime flag
-        if: inputs.skip_notarization != true
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -184,7 +184,25 @@ jobs:
           fi
           npx electron-builder --config electron-builder.config.cjs --publish "$PUBLISH_FLAG" -c.buildDependenciesFromSource=true $EXTRA_ARGS
 
-      - name: Verify macOS notarization staple
+      - name: Verify macOS hardened runtime flag
+        if: inputs.skip_notarization != true
+        shell: bash
+        run: |
+          set -euo pipefail
+          apps=(
+            "release/mac-arm64/Daintree.app"
+            "release/mac/Daintree.app"
+            "release/mac-universal/Daintree.app"
+          )
+          for app in "${apps[@]}"; do
+            if [[ ! -d "$app" ]]; then
+              echo "::error::Missing expected macOS app bundle: $app"
+              exit 1
+            fi
+            scripts/ci/verify-hardened-runtime.sh "$app"
+          done
+
+      - name: Verify macOS notarization and Gatekeeper
         if: inputs.skip_notarization != true
         shell: bash
         run: |
@@ -201,12 +219,14 @@ jobs:
               echo "::error::Missing expected macOS app bundle: $app"
               exit 1
             fi
-            echo "--- codesign: $app"
+            echo "--- codesign verify: $app"
             codesign --verify --deep --strict --verbose=4 "$app"
+            echo "--- codesign check-notarization (online): $app"
+            codesign -vvvv -R="notarized" --check-notarization "$app"
             echo "--- stapler validate: $app"
             xcrun stapler validate "$app"
-            echo "--- spctl (diagnostic only): $app"
-            spctl --assess --type execute --verbose --ignore-cache --no-cache "$app" || true
+            echo "--- spctl assess: $app"
+            spctl --assess --type execute --verbose --ignore-cache --no-cache "$app"
           done
 
       - name: Verify macOS TeamIdentifier audit

--- a/scripts/ci/verify-hardened-runtime.sh
+++ b/scripts/ci/verify-hardened-runtime.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Verify every Mach-O binary in a macOS .app bundle is signed with the
+# hardened runtime flag. Addresses the gap where `codesign --verify --deep`
+# only checks the main executable — embedded helpers, frameworks, and XPC
+# services that ship without `--options runtime` pass every standard check
+# and only surface on user machines.
+set -euo pipefail
+
+APP_BUNDLE="${1:?Usage: $0 <app_bundle_path>}"
+
+APP_BUNDLE="${APP_BUNDLE%/}"
+
+if [[ ! -d "$APP_BUNDLE" ]]; then
+  echo "::error::App bundle directory does not exist: $APP_BUNDLE"
+  exit 1
+fi
+
+if [[ "$APP_BUNDLE" != *.app ]]; then
+  echo "::error::Path does not end in .app: $APP_BUNDLE"
+  exit 1
+fi
+
+echo "Verifying hardened runtime flag on all Mach-O binaries in '$APP_BUNDLE'"
+
+macho_count=0
+failed=0
+
+while IFS= read -r -d '' file; do
+  if ! file -b "$file" | grep -q "Mach-O"; then
+    continue
+  fi
+
+  macho_count=$((macho_count + 1))
+  info=$(codesign -dvvv "$file" 2>&1) || true
+
+  if echo "$info" | grep -q "code object is not signed at all"; then
+    echo "::error::FAIL: Unsigned binary: $file"
+    failed=$((failed + 1))
+    continue
+  fi
+
+  if echo "$info" | grep -q "CodeDirectory.*flags=.*runtime"; then
+    echo "  PASS: $file"
+  else
+    echo "::error::FAIL: Hardened runtime flag missing: $file"
+    failed=$((failed + 1))
+  fi
+done < <(find "$APP_BUNDLE" -type f -print0)
+
+if [[ $macho_count -eq 0 ]]; then
+  echo "::error::FAIL: No Mach-O binaries found in $APP_BUNDLE — bundle is structurally broken"
+  exit 1
+fi
+
+echo "--------------------------------------------------------"
+echo "Mach-O binaries scanned: $macho_count"
+
+if [[ $failed -ne 0 ]]; then
+  echo "::error::Verification FAILED: $failed binary(s) missing hardened runtime flag"
+  exit 1
+fi
+
+echo "Verification SUCCESS: All $macho_count Mach-O binaries have hardened runtime enabled"


### PR DESCRIPTION
## Summary
- Walks all Mach-O binaries in each `.app` bundle to assert the hardened runtime flag is present on every embedded binary, closing the gap where `codesign --verify --deep` only checks the main executable
- Adds `codesign --check-notarization` for online ticket lookup and promotes `spctl --assess` from diagnostic-only to a hard gate

## Changes
- **New**: `scripts/ci/verify-hardened-runtime.sh` — iterates every Mach-O binary in a bundle and verifies the `runtime` flag in the `CodeDirectory`
- **Modified**: `.github/workflows/release-macos.yml` — new hardened runtime verification step (always runs, even when notarization is skipped), online notarization check, `spctl` as a hard gate

## Test plan
- [x] bash syntax check (`bash -n`) — clean
- [x] ShellCheck — no issues
- [x] YAML parse — clean
- [ ] CI: the validation block runs on every release; confirm the new steps pass on the next `v*` tag or workflow_dispatch

Closes #9257

🤖 Generated with [Claude Code](https://claude.com/claude-code)