### PR TITLE
fix(error-boundary): surface scrubbed stack in production crash fallback

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -194,7 +194,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
         } else {
           notify({
             type: "info",
-            title: "Error details too long",
+            title: "Report not copied",
             message:
               "Couldn't copy the full report. Quote the Error ID shown above when filing the issue.",
             inboxMessage: "Couldn't copy crash report to clipboard.",

--- a/src/components/ErrorBoundary/ErrorFallback.tsx
+++ b/src/components/ErrorBoundary/ErrorFallback.tsx
@@ -4,6 +4,7 @@ import { actionService } from "@/services/ActionService";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { AccessibilityAnnouncer } from "@/components/Accessibility/AccessibilityAnnouncer";
+import { scrubReportText } from "@shared/utils/reportScrubbers";
 import { TriangleAlert } from "lucide-react";
 
 export interface ErrorFallbackProps {
@@ -187,15 +188,25 @@ export function ErrorFallback({
           )}
         </div>
 
-        {import.meta.env.DEV && errorInfo?.componentStack && variant !== "component" && (
+        {(error.stack || errorInfo?.componentStack) && variant !== "component" && (
           <details className="w-full mt-4">
             <summary className="cursor-pointer text-xs text-daintree-text/60 hover:text-daintree-text/80">
               Technical details
             </summary>
+            {/* Production stacks are scrubbed before display so crash reporters
+                never expose user paths or secrets; dev keeps the raw stack. */}
             <pre className="mt-2 p-3 bg-scrim-soft rounded text-xs text-status-error/80 overflow-auto max-h-48 select-text">
-              {error.stack || "No stack trace available"}
-              {"\n\nComponent Stack:\n"}
-              {errorInfo.componentStack}
+              {import.meta.env.DEV
+                ? error.stack || "No stack trace available"
+                : scrubReportText(error.stack || "No stack trace available")}
+              {errorInfo?.componentStack && (
+                <>
+                  {"\n\nComponent Stack:\n"}
+                  {import.meta.env.DEV
+                    ? errorInfo.componentStack
+                    : scrubReportText(errorInfo.componentStack)}
+                </>
+              )}
             </pre>
           </details>
         )}

--- a/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
@@ -326,14 +326,14 @@ describe("ErrorBoundary", () => {
     expect(notify).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "info",
-        title: "Error details too long",
+        title: "Report not copied",
         inboxMessage: expect.any(String),
       })
     );
     // Failure branch must NOT be transient — the user needs the inbox entry.
     expect(notify).not.toHaveBeenCalledWith(
       expect.objectContaining({
-        title: "Error details too long",
+        title: "Report not copied",
         transient: true,
       })
     );
@@ -369,7 +369,7 @@ describe("ErrorBoundary", () => {
     expect(notify).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "info",
-        title: "Error details too long",
+        title: "Report not copied",
       })
     );
   });
@@ -528,7 +528,7 @@ describe("ErrorBoundary", () => {
     expect(notify).not.toHaveBeenCalled();
   });
 
-  it("hides technical details in production mode", () => {
+  it("surfaces technical details in production mode so crashes reach reporters", () => {
     vi.stubEnv("DEV", false);
 
     render(
@@ -537,7 +537,7 @@ describe("ErrorBoundary", () => {
       </ErrorBoundary>
     );
 
-    expect(screen.queryByText("Technical details")).toBeNull();
+    expect(screen.getByText("Technical details")).toBeTruthy();
   });
 
   it("calls onError callback when provided", () => {

--- a/src/components/ErrorBoundary/__tests__/ErrorFallback.test.tsx
+++ b/src/components/ErrorBoundary/__tests__/ErrorFallback.test.tsx
@@ -70,14 +70,77 @@ describe("ErrorFallback", () => {
       expect(copyButton.getAttribute("aria-label")).toBe("Copy error ID");
     });
 
-    it("does not render technical details", () => {
+    it("renders technical details so crash reporters see the stack", () => {
       render(<ErrorFallback {...baseProps} variant="section" />);
-      expect(screen.queryByText("Technical details")).toBeNull();
+      expect(screen.getByText("Technical details")).toBeTruthy();
     });
 
-    it("does not render stack trace", () => {
+    it("renders the stack trace inside the details block", () => {
       render(<ErrorFallback {...baseProps} variant="section" />);
-      expect(screen.queryByText(/at TestComponent/)).toBeNull();
+      expect(screen.getByText(/at TestComponent/)).toBeTruthy();
+    });
+
+    it("keeps the details block collapsed by default (no open attribute)", () => {
+      const { container } = render(<ErrorFallback {...baseProps} variant="section" />);
+      const details = container.querySelector("details");
+      expect(details).toBeTruthy();
+      expect(details?.hasAttribute("open")).toBe(false);
+    });
+
+    it("scrubs user paths from the displayed stack", () => {
+      const error = Object.assign(new Error("boom"), {
+        stack: "Error: boom\n    at fn (/Users/alice/project/src/file.ts:10:5)",
+      });
+      const { container } = render(
+        <ErrorFallback {...baseProps} error={error} variant="section" />
+      );
+      const pre = container.querySelector("pre");
+      expect(pre?.textContent).toContain("/Users/USER/project/src/file.ts");
+      expect(pre?.textContent).not.toContain("/Users/alice/");
+    });
+
+    it("scrubs user paths from the displayed component stack", () => {
+      const error = Object.assign(new Error("boom"), { stack: "Error: boom" });
+      const errorInfo = {
+        componentStack: "\n    at Comp (/home/bob/app/Comp.tsx:3:1)",
+      } as React.ErrorInfo;
+      const { container } = render(
+        <ErrorFallback {...baseProps} error={error} errorInfo={errorInfo} variant="section" />
+      );
+      const pre = container.querySelector("pre");
+      expect(pre?.textContent).toContain("/home/USER/app/Comp.tsx");
+      expect(pre?.textContent).not.toContain("/home/bob/");
+    });
+
+    it("renders details when only error.stack is present (no componentStack)", () => {
+      const error = Object.assign(new Error("boom"), {
+        stack: "Error: boom\n    at solo (file.ts:1:1)",
+      });
+      render(
+        <ErrorFallback
+          error={error}
+          resetError={baseProps.resetError}
+          incidentId={baseProps.incidentId}
+          variant="section"
+        />
+      );
+      expect(screen.getByText("Technical details")).toBeTruthy();
+      expect(screen.getByText(/at solo/)).toBeTruthy();
+    });
+
+    it("does not render details when both stack and componentStack are absent", () => {
+      const error = Object.assign(new Error("boom"), { stack: undefined });
+      const { container } = render(
+        <ErrorFallback
+          error={error}
+          errorInfo={{ componentStack: "" } as React.ErrorInfo}
+          resetError={baseProps.resetError}
+          incidentId={baseProps.incidentId}
+          variant="section"
+        />
+      );
+      expect(screen.queryByText("Technical details")).toBeNull();
+      expect(container.querySelector("details")).toBeNull();
     });
   });
 

--- a/src/components/ErrorBoundary/__tests__/ErrorFallback.test.tsx
+++ b/src/components/ErrorBoundary/__tests__/ErrorFallback.test.tsx
@@ -142,6 +142,38 @@ describe("ErrorFallback", () => {
       expect(screen.queryByText("Technical details")).toBeNull();
       expect(container.querySelector("details")).toBeNull();
     });
+
+    it("renders technical details for the fullscreen variant too", () => {
+      render(<ErrorFallback {...baseProps} variant="fullscreen" />);
+      expect(screen.getByText("Technical details")).toBeTruthy();
+      expect(screen.getByText(/at TestComponent/)).toBeTruthy();
+    });
+
+    it("scrubs the component stack when error.stack is absent", () => {
+      const error = Object.assign(new Error("boom"), { stack: undefined });
+      const errorInfo = {
+        componentStack: "\n    at Comp (/home/bob/app/Comp.tsx:3:1)",
+      } as React.ErrorInfo;
+      const { container } = render(
+        <ErrorFallback {...baseProps} error={error} errorInfo={errorInfo} variant="section" />
+      );
+      const pre = container.querySelector("pre");
+      expect(pre?.textContent).toContain("No stack trace available");
+      expect(pre?.textContent).toContain("/home/USER/app/Comp.tsx");
+      expect(pre?.textContent).not.toContain("/home/bob/");
+    });
+
+    it("scrubs Windows user paths from the displayed stack", () => {
+      const error = Object.assign(new Error("boom"), {
+        stack: "Error: boom\n    at fn (C:\\Users\\alice\\project\\file.ts:10:5)",
+      });
+      const { container } = render(
+        <ErrorFallback {...baseProps} error={error} variant="section" />
+      );
+      const pre = container.querySelector("pre");
+      expect(pre?.textContent).toContain("C:\\Users\\USER\\project\\file.ts");
+      expect(pre?.textContent).not.toContain("C:\\Users\\alice\\");
+    });
   });
 
   describe("development mode", () => {

--- a/src/components/ErrorBoundary/__tests__/buildReportIssueUrl.test.ts
+++ b/src/components/ErrorBoundary/__tests__/buildReportIssueUrl.test.ts
@@ -36,6 +36,27 @@ describe("buildReportIssueUrl", () => {
     expect(getEncodedBodyLength(result.url)).toBeLessThanOrEqual(URL_BODY_BUDGET);
   });
 
+  it("scrubs user paths from the stack in both URL body and clipboard payload", () => {
+    const result = buildReportIssueUrl(
+      makeInput({
+        stack: "Error: boom\n  at fn (/Users/alice/project/file.ts:10)",
+        componentStack: "  in Comp (/home/bob/app/Comp.tsx:3)",
+      })
+    );
+
+    const body = decodeURIComponent(new URL(result.url).searchParams.get("body") ?? "");
+    expect(body).toContain("/Users/USER/project/file.ts");
+    expect(body).not.toContain("/Users/alice/");
+    expect(body).toContain("/home/USER/app/Comp.tsx");
+    expect(body).not.toContain("/home/bob/");
+
+    // The clipboard payload is the same surface (pasted into a public issue).
+    expect(result.fullBody).toContain("/Users/USER/project/file.ts");
+    expect(result.fullBody).not.toContain("/Users/alice/");
+    expect(result.fullBody).toContain("/home/USER/app/Comp.tsx");
+    expect(result.fullBody).not.toContain("/home/bob/");
+  });
+
   it("encodes title and body so URL is safe to navigate", () => {
     const result = buildReportIssueUrl(
       makeInput({ message: "Cannot read property 'foo' of undefined & friends" })

--- a/src/components/ErrorBoundary/buildReportIssueUrl.ts
+++ b/src/components/ErrorBoundary/buildReportIssueUrl.ts
@@ -1,3 +1,5 @@
+import { scrubReportText } from "@shared/utils/reportScrubbers";
+
 const REPO_ISSUE_URL = "https://github.com/daintreehq/daintree/issues/new";
 
 // GitHub's Nginx fronts the issue form at an 8 KiB URL hard cap. Reserve
@@ -128,14 +130,19 @@ function makeUrl(title: string, body: string): string {
  * write `fullBody` to the clipboard and use the short stub URL.
  */
 export function buildReportIssueUrl(input: ReportIssueInput): ReportIssueResult {
+  // Redact user paths/secrets before the stack enters either the URL body or
+  // the clipboard payload — both surfaces end up pasted into a public issue.
+  const stack = scrubReportText(input.stack);
+  const componentStack = scrubReportText(input.componentStack);
+
   const title = `Component Error: ${input.message || "Unknown"}`;
   const fullBody = formatBody({
     componentName: input.componentName,
     incidentId: input.incidentId,
     message: input.message,
     context: input.context,
-    stack: input.stack,
-    componentStack: input.componentStack,
+    stack,
+    componentStack,
   });
 
   if (encodeURIComponent(fullBody).length <= URL_BODY_BUDGET) {
@@ -147,7 +154,7 @@ export function buildReportIssueUrl(input: ReportIssueInput): ReportIssueResult 
     incidentId: input.incidentId,
     message: input.message,
     context: input.context,
-    stack: input.stack,
+    stack,
     componentStack: COMPONENT_STACK_PLACEHOLDER,
   });
 
@@ -159,7 +166,7 @@ export function buildReportIssueUrl(input: ReportIssueInput): ReportIssueResult 
     };
   }
 
-  const truncatedStack = truncateStackMiddle(input.stack);
+  const truncatedStack = truncateStackMiddle(stack);
   const withTruncatedStack = formatBody({
     componentName: input.componentName,
     incidentId: input.incidentId,


### PR DESCRIPTION
## Summary

The `ErrorFallback` "Technical details" `<details>` block was gated behind `import.meta.env.DEV`, so production builds showed only the error message and Error ID — crash reporters and users filing issues never got a stack trace. This surfaces the stack in production with path/secret redaction, kept collapsed by default.

- **`ErrorFallback.tsx`** — removed the `import.meta.env.DEV` gate; the block now renders whenever a stack or component stack exists (non-`component` variants), collapsed by default. In production the stack and component stack pass through `scrubReportText` (`@shared/utils/reportScrubbers`) to redact user paths/secrets; dev keeps the raw stack.
- **`buildReportIssueUrl.ts`** — scrub `stack` + `componentStack` at function entry so both the GitHub issue URL body and the clipboard fallback payload are redacted (same data, same public destination).
- **`ErrorBoundary.tsx`** — overflow toast title `"Error details too long"` → `"Report not copied"` (microcopy: verb-led past tense, no period).

Scrubbing is deliberately scoped to the stack and component stack, not `error.message` or `context` — both are out of the issue's scope and scrubbing `message` risks degrading diagnostic signal.

## Test plan

- [x] `npx vitest run src/components/ErrorBoundary` — 85 tests pass
- [x] `npm run check` — typecheck + lint ratchet (improved by 2) + format all clean
- [x] Production disclosure rendered for `section` and `fullscreen` variants, collapsed by default (no `open` attribute)
- [x] macOS / Linux / Windows user paths scrubbed to `USER` in both the visible stack and the issue URL/clipboard body
- [x] Component-stack-only and both-absent edge cases covered

Closes #9142