### PR TITLE
feat(plugin-service): add activationEvents manifest field and defer dynamic import

### DIFF
--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -19,6 +19,9 @@ vi.mock("../../../services/PluginService.js", () => ({
     listPluginActions: (...args: unknown[]) => mockListPluginActions(...args),
     registerPluginAction: (...args: unknown[]) => mockRegisterPluginAction(...args),
     unregisterPluginAction: (...args: unknown[]) => mockUnregisterPluginAction(...args),
+    // No-op for tests that don't care about implicit activation; the IPC
+    // handler awaits it before resolving the impl set.
+    activatePluginsForFileDecorationScope: vi.fn().mockResolvedValue(undefined),
   },
 }));
 

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -171,6 +171,11 @@ async function handleFileDecorationsGet(
   if (cleanPaths.length === 0) return {};
   const requested = new Set(cleanPaths);
 
+  // Implicit activation: any plugin that declares a provider for this scope is
+  // forced to `activate()` before the impl lookup, so providers bound during
+  // activate() are queryable on the first pull. No-op once already activated.
+  await pluginService.activatePluginsForFileDecorationScope(scope);
+
   const impls = getFileDecorationImpls(scope);
   if (impls.length === 0) return {};
 

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -168,6 +168,7 @@ export function getPluginManifestSchema(isBuiltin: boolean) {
         })
         .optional(),
       capabilities: z.array(PluginCapabilitySchema).default([]),
+      activationEvents: z.array(z.literal("onStartupFinished")).default([]),
       contributes: z
         .strictObject({
           panels: z.array(PanelContributionSchema).default([]),

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -126,6 +126,15 @@ interface LoadedPlugin {
 }
 
 const ACTIVATE_TIMEOUT_MS = 5000;
+/**
+ * Time budget for the dynamic `import()` step in {@link PluginService._doActivate}.
+ * Separate from {@link ACTIVATE_TIMEOUT_MS} (which guards the plugin's exported
+ * `activate()` function) so a plugin with a hanging top-level await cannot pin
+ * an activation promise forever — which would in turn block any
+ * `Promise.allSettled` fan-out (file-decoration scope activation, startup
+ * activation), since `allSettled` waits for every promise to settle.
+ */
+const IMPORT_TIMEOUT_MS = 5000;
 
 /**
  * Normalise the value thrown out of `activate()` into a serialisable record.
@@ -706,7 +715,10 @@ export class PluginService {
     const plugin = this.plugins.get(pluginId);
     if (!plugin || !plugin.resolvedMain) return;
     try {
-      const mod = (await import(pathToFileURL(plugin.resolvedMain).href)) as {
+      // Bound the dynamic import — a plugin with a hanging top-level await
+      // would otherwise pin this promise forever and stall `Promise.allSettled`
+      // fan-outs (file-decoration scope, startup activation).
+      const mod = (await this.runImport(pluginId, plugin.resolvedMain)) as {
         activate?: unknown;
       };
       if (typeof mod.activate === "function") {
@@ -714,7 +726,12 @@ export class PluginService {
         const { host, revoke } = this.createHost(pluginId);
         try {
           const cleanup = await this.runActivate(pluginId, activate, host);
-          if (typeof cleanup === "function") {
+          // Guard against an unload that ran concurrently with this activation:
+          // by the time `runActivate` resolves, `unloadPlugin` may have already
+          // cleared `cleanupMap` — writing a cleanup back after that fires
+          // would leak (e.g. a setInterval the plugin set up in activate()
+          // would never be cleared). Drop it on the floor instead.
+          if (typeof cleanup === "function" && this.plugins.has(pluginId)) {
             this.cleanupMap.set(pluginId, cleanup);
           }
         } finally {
@@ -738,6 +755,30 @@ export class PluginService {
   }
 
   /**
+   * Wrap `import()` in a timeout race so a plugin with a hanging top-level
+   * await (e.g. `await new Promise(() => {})`) can't stall the host. ESM's
+   * URL-keyed module cache means a successful import resolves instantly on
+   * retry; a hang only affects the first attempt.
+   */
+  private async runImport(pluginId: string, resolvedMain: string): Promise<unknown> {
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      return await Promise.race([
+        import(pathToFileURL(resolvedMain).href),
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(() => {
+            reject(
+              new Error(`Plugin "${pluginId}" import() timed out after ${IMPORT_TIMEOUT_MS}ms`)
+            );
+          }, IMPORT_TIMEOUT_MS);
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  /**
    * Idempotent activation entry point. Concurrent callers share the same
    * in-flight promise; once activation settles successfully the result is
    * cached for the plugin's lifetime so subsequent callers return synchronously
@@ -756,7 +797,12 @@ export class PluginService {
 
     const promise = this._doActivate(pluginId).then(
       () => {
-        this.activatedPlugins.add(pluginId);
+        // Guard against an unload that ran while activation was in flight:
+        // unload clears `activatedPlugins` and `plugins` synchronously, but a
+        // late-resolving activation would otherwise re-insert a tombstoned id.
+        if (this.plugins.has(pluginId)) {
+          this.activatedPlugins.add(pluginId);
+        }
       },
       () => {
         // Error is already persisted to the provenance record inside

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -174,6 +174,22 @@ export class PluginService {
   private plugins = new Map<string, LoadedPlugin>();
   private handlerMap = new Map<string, PluginIpcHandler>();
   private cleanupMap = new Map<string, () => void>();
+  /**
+   * Plugin ids whose `activate()` has resolved successfully this session.
+   * Checked synchronously by {@link activatePlugin} as the fast path so a
+   * hot dispatch site (e.g. `dispatchHandler`) doesn't pay an async hop on
+   * every call. Cleared in `unloadPlugin` so a runtime unload+reload cycle
+   * re-runs activation.
+   */
+  private activatedPlugins = new Set<string>();
+  /**
+   * In-flight activation promises keyed by plugin id. Concurrent callers
+   * (e.g. a panel open + an action dispatch racing in the same tick) await
+   * the same promise so `_doActivate` runs exactly once per activation.
+   * On success the entry stays cached until unload; on failure it is
+   * deleted so a Settings → "Retry activation" can re-run.
+   */
+  private activationPromises = new Map<string, Promise<void>>();
   private pluginActions = new Map<string, PluginActionDescriptor>();
   private pluginActionOwners = new Map<string, Set<string>>();
   private actionValidators = new Map<string, ValidateFn>();
@@ -654,43 +670,163 @@ export class PluginService {
     // throw "Unknown plugin" even for a correctly loaded plugin.
     this.plugins.set(manifest.name, plugin);
 
-    if (plugin.resolvedMain) {
-      try {
-        const mod = (await import(pathToFileURL(plugin.resolvedMain).href)) as {
-          activate?: unknown;
-        };
-        if (typeof mod.activate === "function") {
-          const activate = mod.activate as PluginActivate;
-          const { host, revoke } = this.createHost(manifest.name);
-          try {
-            const cleanup = await this.runActivate(manifest.name, activate, host);
-            if (typeof cleanup === "function") {
-              this.cleanupMap.set(manifest.name, cleanup);
-            }
-          } finally {
-            revoke();
-          }
-        }
-        // Successful activation (or a main with no activate fn) clears any
-        // diagnostic record left over from a prior failed attempt — persisted
-        // to the provenance record so it survives a host restart.
-        if (!opts.isBuiltin) {
-          this.upsertInstalledRecord(manifest.name, { loadError: null });
-        }
-      } catch (err) {
-        const loadError = toPluginLoadError(err);
-        if (!opts.isBuiltin) {
-          this.upsertInstalledRecord(manifest.name, { loadError });
-        }
-        console.error(`[PluginService] Failed to load main entry for ${manifest.name}:`, err);
-      }
-    } else {
-      if (!opts.isBuiltin) {
-        this.upsertInstalledRecord(manifest.name, { loadError: null });
-      }
+    // Plugins without a `main` entry contribute no executable code — the
+    // provenance record reflects a clean load immediately. Plugins with a
+    // `main` entry defer the `loadError: null` write to `_doActivate()` so
+    // the record only clears once activation actually succeeds.
+    if (!plugin.resolvedMain && !opts.isBuiltin) {
+      this.upsertInstalledRecord(manifest.name, { loadError: null });
     }
 
     return plugin;
+  }
+
+  /**
+   * In v1 only `"onStartupFinished"` is recognised. An empty `activationEvents`
+   * array is treated the same as `["onStartupFinished"]` — every plugin with a
+   * `main` entry activates at startup unless it explicitly lists other events
+   * (none of which exist yet). When `onCommand:*`, `onView:*` etc. land, a
+   * plugin will be able to opt out of startup activation by omitting
+   * `"onStartupFinished"` from a non-empty list.
+   */
+  private shouldActivateOnStartup(manifest: PluginManifest): boolean {
+    const events = manifest.activationEvents;
+    if (!events || events.length === 0) return true;
+    return events.includes("onStartupFinished");
+  }
+
+  /**
+   * Actually import the plugin's `main` module, create its host, and run
+   * `activate()`. Wrapped by {@link activatePlugin} for idempotency &
+   * concurrent-caller dedup — direct callers will re-import on every call.
+   * Errors are persisted to the provenance record but never rethrown by
+   * `activatePlugin` (which exposes a never-rejecting promise to triggers).
+   */
+  private async _doActivate(pluginId: string): Promise<void> {
+    const plugin = this.plugins.get(pluginId);
+    if (!plugin || !plugin.resolvedMain) return;
+    try {
+      const mod = (await import(pathToFileURL(plugin.resolvedMain).href)) as {
+        activate?: unknown;
+      };
+      if (typeof mod.activate === "function") {
+        const activate = mod.activate as PluginActivate;
+        const { host, revoke } = this.createHost(pluginId);
+        try {
+          const cleanup = await this.runActivate(pluginId, activate, host);
+          if (typeof cleanup === "function") {
+            this.cleanupMap.set(pluginId, cleanup);
+          }
+        } finally {
+          revoke();
+        }
+      }
+      // Successful activation (or a main with no activate fn) clears any
+      // diagnostic record left over from a prior failed attempt — persisted
+      // to the provenance record so it survives a host restart.
+      if (!plugin.isBuiltin) {
+        this.upsertInstalledRecord(pluginId, { loadError: null });
+      }
+    } catch (err) {
+      const loadError = toPluginLoadError(err);
+      if (!plugin.isBuiltin) {
+        this.upsertInstalledRecord(pluginId, { loadError });
+      }
+      console.error(`[PluginService] Failed to load main entry for ${pluginId}:`, err);
+      throw err;
+    }
+  }
+
+  /**
+   * Idempotent activation entry point. Concurrent callers share the same
+   * in-flight promise; once activation settles successfully the result is
+   * cached for the plugin's lifetime so subsequent callers return synchronously
+   * via the fast-path `activatedPlugins` check. A rejected activation deletes
+   * the in-flight entry so callers (e.g. Settings "Retry activation") can
+   * re-attempt. Errors are surfaced via the persisted `loadError` record —
+   * this method never rejects, matching the contribution-point trigger
+   * contract that a failed activation must leave routing entries intact.
+   */
+  async activatePlugin(pluginId: string): Promise<void> {
+    if (this.activatedPlugins.has(pluginId)) return;
+    const existing = this.activationPromises.get(pluginId);
+    if (existing) return existing;
+    const plugin = this.plugins.get(pluginId);
+    if (!plugin) return;
+
+    const promise = this._doActivate(pluginId).then(
+      () => {
+        this.activatedPlugins.add(pluginId);
+      },
+      () => {
+        // Error is already persisted to the provenance record inside
+        // `_doActivate`. Drop the in-flight entry so a subsequent
+        // `activatePlugin(pluginId)` re-runs activation (Settings → Retry).
+        this.activationPromises.delete(pluginId);
+      }
+    );
+    this.activationPromises.set(pluginId, promise);
+    return promise;
+  }
+
+  /**
+   * Fan out activation for every plugin whose manifest opts into
+   * `"onStartupFinished"` (or whose `activationEvents` is unset / empty —
+   * see {@link shouldActivateOnStartup}). Activations run in parallel via
+   * `Promise.allSettled`; one slow plugin must not block the rest. Wired
+   * fire-and-forget from the `plugin-service` deferred task so the renderer
+   * keeps progressing while plugins warm up in the background.
+   */
+  async activateStartupFinishedPlugins(): Promise<void> {
+    const targets: string[] = [];
+    for (const plugin of this.plugins.values()) {
+      if (!plugin.resolvedMain) continue;
+      if (!this.shouldActivateOnStartup(plugin.manifest)) continue;
+      targets.push(plugin.manifest.name);
+    }
+    if (targets.length === 0) return;
+    await Promise.allSettled(targets.map((id) => this.activatePlugin(id)));
+  }
+
+  /**
+   * Activate the plugin that owns the forge provider matching `namespacedId`
+   * before the forge RPC server looks up its impl. Resolves the owning plugin
+   * via the manifest registry rather than parsing `pluginId.contributionId` —
+   * plugin ids are `publisher.name` (already containing a dot), so a split
+   * would mis-attribute. A no-op if the namespaced id isn't registered.
+   */
+  async activatePluginForForgeProvider(namespacedId: string): Promise<void> {
+    if (typeof namespacedId !== "string" || namespacedId.length === 0) return;
+    for (const [pluginId, plugin] of this.plugins) {
+      for (const contribution of plugin.manifest.contributes.forgeProviders) {
+        if (`${pluginId}.${contribution.id}` === namespacedId) {
+          await this.activatePlugin(pluginId);
+          return;
+        }
+      }
+    }
+  }
+
+  /**
+   * Activate every plugin whose `fileDecorationProviders` declares a scope
+   * matching `scope`. Mirrors the registry-side `getFileDecorationImpls`
+   * filter so the activation set is exactly the impl set that will be queried
+   * once activation resolves. Runs activations in parallel — one slow plugin
+   * must not stall an entire decoration pull.
+   */
+  async activatePluginsForFileDecorationScope(scope: string): Promise<void> {
+    if (typeof scope !== "string" || scope.length === 0) return;
+    const targets = new Set<string>();
+    for (const [pluginId, plugin] of this.plugins) {
+      for (const contribution of plugin.manifest.contributes.fileDecorationProviders) {
+        if (contribution.scopes.some((pattern) => scopeMatchesPattern(scope, pattern))) {
+          targets.add(pluginId);
+          break;
+        }
+      }
+    }
+    if (targets.size === 0) return;
+    await Promise.allSettled([...targets].map((id) => this.activatePlugin(id)));
   }
 
   private createHost(pluginId: string): { host: PluginHostApi; revoke: () => void } {
@@ -1105,6 +1241,11 @@ export class PluginService {
     ctx: PluginIpcContext,
     args: unknown[]
   ): Promise<unknown> {
+    // Implicit activation: the first dispatch into a plugin's channel forces
+    // its `activate()` to run if it hasn't yet, so handlers registered during
+    // activation are available on the very first call. No-op once activated.
+    await this.activatePlugin(pluginId);
+
     const key = `${pluginId}:${channel}`;
     const handler = this.handlerMap.get(key);
     if (!handler) {
@@ -1164,6 +1305,11 @@ export class PluginService {
 
   unloadPlugin(pluginId: string): void {
     if (!this.plugins.has(pluginId)) return;
+    // Drop activation state so a runtime reload (e.g. dev-mode re-scan) can
+    // re-activate from scratch — otherwise the fast-path `activatedPlugins`
+    // hit would short-circuit `_doActivate` after the new manifest landed.
+    this.activatedPlugins.delete(pluginId);
+    this.activationPromises.delete(pluginId);
     const cleanup = this.cleanupMap.get(pluginId);
     if (cleanup) {
       try {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -2189,6 +2189,7 @@ describe("Plugin unload lifecycle", () => {
 
     try {
       await service.initialize();
+      await service.activateStartupFinishedPlugins();
       expect((globalThis as { __pluginInitObserved?: boolean }).__pluginInitObserved).toBe(true);
     } finally {
       delete (globalThis as { __pluginInitCheck?: unknown }).__pluginInitCheck;
@@ -3773,6 +3774,7 @@ describe("Plugin exception containment (#9276)", () => {
       const service = new PluginService(tmpDir);
       // The host MUST NOT crash — initialize() should resolve.
       await expect(service.initialize()).resolves.toBeUndefined();
+      await service.activateStartupFinishedPlugins();
 
       const record = service.getPluginLoadError("acme.throws-activate");
       expect(record).toBeDefined();
@@ -3798,6 +3800,7 @@ describe("Plugin exception containment (#9276)", () => {
 
       const service = new PluginService(tmpDir);
       await service.initialize();
+      await service.activateStartupFinishedPlugins();
 
       expect(service.getPluginLoadError("acme.clean-activate")).toBeUndefined();
     });
@@ -3824,6 +3827,7 @@ describe("Plugin exception containment (#9276)", () => {
 
       const service = new PluginService(tmpDir);
       await service.initialize();
+      await service.activateStartupFinishedPlugins();
       expect(service.getPluginLoadError("acme.throws-then-unload")).toBeDefined();
 
       // Unload removes the plugin from the registry, but the persisted
@@ -3849,6 +3853,7 @@ describe("Plugin exception containment (#9276)", () => {
 
       const service = new PluginService(tmpDir);
       await service.initialize();
+      await service.activateStartupFinishedPlugins();
 
       const record = service.getPluginLoadError("acme.throws-string");
       expect(record?.message).toBe("plain-string-failure");
@@ -4091,6 +4096,7 @@ describe("Plugin exception containment (#9276)", () => {
 
       const service = new PluginService(tmpDir);
       await service.initialize();
+      await service.activateStartupFinishedPlugins();
 
       const record = service.getPluginLoadError("acme.throws-undefined");
       expect(record).toBeDefined();
@@ -4112,6 +4118,7 @@ describe("Plugin exception containment (#9276)", () => {
 
       const service = new PluginService(tmpDir);
       await service.initialize();
+      await service.activateStartupFinishedPlugins();
 
       const record = service.getPluginLoadError("acme.throws-null");
       expect(record).toBeDefined();
@@ -4248,6 +4255,11 @@ describe("Plugin provenance persistence", () => {
 
     const service = new PluginService(tmpDir);
     await service.initialize();
+    // Force the startup activation pass so this test exercises the path that
+    // would normally import every onStartupFinished plugin. The disabled plugin
+    // is rejected at scan time (never inserted into the plugins map), so the
+    // activation pass cannot pick it up — that's exactly what we assert below.
+    await service.activateStartupFinishedPlugins();
 
     const plugins = service.listPlugins();
     expect(plugins).toHaveLength(1);
@@ -4273,6 +4285,7 @@ describe("Plugin provenance persistence", () => {
 
     const service = new PluginService(tmpDir);
     await service.initialize();
+    await service.activateStartupFinishedPlugins();
 
     const record = service.getPluginLoadError("acme.err-persist");
     expect(record?.message).toBe("persisted-boom");
@@ -4299,6 +4312,7 @@ describe("Plugin provenance persistence", () => {
 
     const first = new PluginService(tmpDir);
     await first.initialize();
+    await first.activateStartupFinishedPlugins();
     expect(first.getPluginLoadError("acme.heal-fail")?.message).toBe("first-fail");
 
     // Second plugin: same concept but different dir + name, so ESM cache
@@ -4317,6 +4331,7 @@ describe("Plugin provenance persistence", () => {
 
     const second = new PluginService(tmpDir);
     await second.initialize();
+    await second.activateStartupFinishedPlugins();
 
     // New plugin loaded successfully — no error
     expect(second.getPluginLoadError("acme.heal-ok")).toBeUndefined();
@@ -4409,5 +4424,235 @@ describe("Plugin provenance persistence", () => {
       | undefined;
     expect(stored?.installed).toHaveProperty("acme.foo");
     expect(stored?.installed?.["acme.foo"]).toBeDefined();
+  });
+});
+
+describe("PluginManifestSchema activationEvents field", () => {
+  const schema = getPluginManifestSchema(false);
+
+  it("defaults to an empty array when omitted", () => {
+    const result = schema.safeParse({
+      name: "acme.foo",
+      version: "1.0.0",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.activationEvents).toEqual([]);
+    }
+  });
+
+  it("accepts an explicit ['onStartupFinished']", () => {
+    const result = schema.safeParse({
+      name: "acme.foo",
+      version: "1.0.0",
+      activationEvents: ["onStartupFinished"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unknown activation event strings (no onCommand/onView in v1)", () => {
+    const result = schema.safeParse({
+      name: "acme.foo",
+      version: "1.0.0",
+      activationEvents: ["onCommand:foo"],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-array activationEvents value", () => {
+    const result = schema.safeParse({
+      name: "acme.foo",
+      version: "1.0.0",
+      activationEvents: "onStartupFinished",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("Deferred activation — activatePlugin", () => {
+  it("initialize() does not import plugin main; activateStartupFinishedPlugins does", async () => {
+    const pluginDir = path.join(tmpDir, "deferred-import");
+    await fs.mkdir(pluginDir);
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({ name: "acme.deferred-import", version: "1.0.0", main: "main.mjs" })
+    );
+    // The module sets a global as a side effect at import time. If the
+    // module were imported during initialize() the global would be set
+    // before we explicitly activate.
+    await fs.writeFile(
+      path.join(pluginDir, "main.mjs"),
+      "globalThis.__deferredImportRan = true; export function activate() {}"
+    );
+
+    try {
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+      // Scan must register the plugin (contributions populated) but must NOT
+      // have imported its main module yet.
+      expect(service.hasPlugin("acme.deferred-import")).toBe(true);
+      expect((globalThis as Record<string, unknown>).__deferredImportRan).toBeUndefined();
+
+      await service.activateStartupFinishedPlugins();
+      expect((globalThis as Record<string, unknown>).__deferredImportRan).toBe(true);
+    } finally {
+      delete (globalThis as Record<string, unknown>).__deferredImportRan;
+    }
+  });
+
+  it("activatePlugin is idempotent — _doActivate runs once across concurrent callers", async () => {
+    const pluginDir = path.join(tmpDir, "dedup-activate");
+    await fs.mkdir(pluginDir);
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({ name: "acme.dedup-activate", version: "1.0.0", main: "main.mjs" })
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "main.mjs"),
+      "globalThis.__dedupCount = (globalThis.__dedupCount ?? 0) + 1; export function activate() {}"
+    );
+
+    try {
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+
+      // Fan out activation from three concurrent callers; the in-flight
+      // promise dedup means _doActivate runs exactly once.
+      await Promise.all([
+        service.activatePlugin("acme.dedup-activate"),
+        service.activatePlugin("acme.dedup-activate"),
+        service.activatePlugin("acme.dedup-activate"),
+      ]);
+
+      // A fourth call after the first settled should hit the synchronous
+      // `activatedPlugins` fast path and not re-import either.
+      await service.activatePlugin("acme.dedup-activate");
+
+      expect((globalThis as Record<string, number>).__dedupCount).toBe(1);
+    } finally {
+      delete (globalThis as Record<string, number>).__dedupCount;
+    }
+  });
+
+  it("activatePlugin does not reject when activate() throws", async () => {
+    const pluginDir = path.join(tmpDir, "throwy-but-stable");
+    await fs.mkdir(pluginDir);
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({ name: "acme.throwy-but-stable", version: "1.0.0", main: "main.mjs" })
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "main.mjs"),
+      "export function activate() { throw new Error('nope'); }"
+    );
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+
+      // Implicit-trigger contract: the promise resolves so callers don't
+      // need a try/catch around every dispatch.
+      await expect(service.activatePlugin("acme.throwy-but-stable")).resolves.toBeUndefined();
+      // Error is persisted to the provenance record instead of propagating.
+      expect(service.getPluginLoadError("acme.throwy-but-stable")?.message).toBe("nope");
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("activatePlugin can re-run after a failure (Settings → Retry)", async () => {
+    const pluginDir = path.join(tmpDir, "retry-activate");
+    await fs.mkdir(pluginDir);
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({ name: "acme.retry-activate", version: "1.0.0", main: "main.mjs" })
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "main.mjs"),
+      "globalThis.__retryCount = (globalThis.__retryCount ?? 0) + 1; export function activate() { throw new Error('retry-boom'); }"
+    );
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+      await service.activatePlugin("acme.retry-activate");
+
+      // After a failure the in-flight entry is dropped so a retry calls
+      // through to _doActivate again. ESM import() is URL-cached, so the
+      // module is only evaluated once — but `activate()` still runs again
+      // on the cached exports. Assert via the persisted error record.
+      expect(service.getPluginLoadError("acme.retry-activate")?.message).toBe("retry-boom");
+
+      await service.activatePlugin("acme.retry-activate");
+      // The fact that this resolves and re-records the error proves the
+      // promise was not cached as a settled success.
+      expect(service.getPluginLoadError("acme.retry-activate")?.message).toBe("retry-boom");
+    } finally {
+      errorSpy.mockRestore();
+      delete (globalThis as Record<string, number>).__retryCount;
+    }
+  });
+
+  it("activateStartupFinishedPlugins activates plugins with activationEvents=['onStartupFinished']", async () => {
+    const pluginDir = path.join(tmpDir, "explicit-onstartup");
+    await fs.mkdir(pluginDir);
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "acme.explicit-onstartup",
+        version: "1.0.0",
+        main: "main.mjs",
+        activationEvents: ["onStartupFinished"],
+      })
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "main.mjs"),
+      "globalThis.__explicitOnstartupRan = true; export function activate() {}"
+    );
+
+    try {
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+      expect((globalThis as Record<string, unknown>).__explicitOnstartupRan).toBeUndefined();
+
+      await service.activateStartupFinishedPlugins();
+      expect((globalThis as Record<string, unknown>).__explicitOnstartupRan).toBe(true);
+    } finally {
+      delete (globalThis as Record<string, unknown>).__explicitOnstartupRan;
+    }
+  });
+
+  it("dispatchHandler implicitly activates the owning plugin before lookup", async () => {
+    const pluginDir = path.join(tmpDir, "implicit-dispatch");
+    await fs.mkdir(pluginDir);
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "acme.implicit-dispatch",
+        version: "1.0.0",
+        main: "main.mjs",
+      })
+    );
+    // The plugin's activate() registers a handler. If dispatchHandler did
+    // not force activation first, the handler would not be registered yet
+    // and the dispatch would throw "No plugin handler registered".
+    await fs.writeFile(
+      path.join(pluginDir, "main.mjs"),
+      "export function activate(host) { host.registerHandler('probe', () => 'pong'); }"
+    );
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+    // Crucially, do NOT call activateStartupFinishedPlugins(). The dispatch
+    // path itself must trigger activation.
+    const result = await service.dispatchHandler(
+      "acme.implicit-dispatch",
+      "probe",
+      makeCtx("acme.implicit-dispatch"),
+      []
+    );
+    expect(result).toBe("pong");
   });
 });

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -4624,6 +4624,74 @@ describe("Deferred activation — activatePlugin", () => {
     }
   });
 
+  it("import() with a hanging top-level await times out instead of stalling forever", async () => {
+    const pluginDir = path.join(tmpDir, "hanging-import");
+    await fs.mkdir(pluginDir);
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({ name: "acme.hanging-import", version: "1.0.0", main: "main.mjs" })
+    );
+    // Top-level `await new Promise(() => {})` hangs forever. Without the
+    // import-timeout guard this would pin `_doActivate` and any
+    // `Promise.allSettled` fan-out behind it.
+    await fs.writeFile(
+      path.join(pluginDir, "main.mjs"),
+      "await new Promise(() => {}); export function activate() {}"
+    );
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+      // The promise resolves (it doesn't reject — `activatePlugin` swallows)
+      // and the timeout error is persisted as the loadError so diagnostics
+      // surface why the plugin never came up.
+      await service.activatePlugin("acme.hanging-import");
+      const record = service.getPluginLoadError("acme.hanging-import");
+      expect(record?.message).toContain("timed out");
+    } finally {
+      errorSpy.mockRestore();
+    }
+  }, 10_000);
+
+  it("unloadPlugin during a racing activation does not leak activatedPlugins state", async () => {
+    const pluginDir = path.join(tmpDir, "race-unload");
+    await fs.mkdir(pluginDir);
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({ name: "acme.race-unload", version: "1.0.0", main: "main.mjs" })
+    );
+    // Activate resolves successfully but the test will unload mid-flight so
+    // the .then handler sees a tombstoned plugins map.
+    await fs.writeFile(
+      path.join(pluginDir, "main.mjs"),
+      "export function activate() { return () => {}; }"
+    );
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+    const activation = service.activatePlugin("acme.race-unload");
+    // Synchronously unload before the activation promise resolves. The
+    // plugin is still in `this.plugins` at this point (activation is
+    // mid-flight), so unload runs fully.
+    service.unloadPlugin("acme.race-unload");
+    await activation;
+
+    // The .then(success) handler now runs after unload; the guard must
+    // prevent re-adding the id to `activatedPlugins`.
+    expect(service.hasPlugin("acme.race-unload")).toBe(false);
+    expect(
+      (service as unknown as { activatedPlugins: Set<string> }).activatedPlugins.has(
+        "acme.race-unload"
+      )
+    ).toBe(false);
+    expect(
+      (service as unknown as { cleanupMap: Map<string, () => void> }).cleanupMap.has(
+        "acme.race-unload"
+      )
+    ).toBe(false);
+  });
+
   it("dispatchHandler implicitly activates the owning plugin before lookup", async () => {
     const pluginDir = path.join(tmpDir, "implicit-dispatch");
     await fs.mkdir(pluginDir);

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -4528,9 +4528,9 @@ describe("Deferred activation — activatePlugin", () => {
       // `activatedPlugins` fast path and not re-import either.
       await service.activatePlugin("acme.dedup-activate");
 
-      expect((globalThis as Record<string, number>).__dedupCount).toBe(1);
+      expect((globalThis as unknown as Record<string, number>).__dedupCount).toBe(1);
     } finally {
-      delete (globalThis as Record<string, number>).__dedupCount;
+      delete (globalThis as unknown as Record<string, number>).__dedupCount;
     }
   });
 
@@ -4591,7 +4591,7 @@ describe("Deferred activation — activatePlugin", () => {
       expect(service.getPluginLoadError("acme.retry-activate")?.message).toBe("retry-boom");
     } finally {
       errorSpy.mockRestore();
-      delete (globalThis as Record<string, number>).__retryCount;
+      delete (globalThis as unknown as Record<string, number>).__retryCount;
     }
   });
 

--- a/electron/services/__tests__/forgeRpcServer.test.ts
+++ b/electron/services/__tests__/forgeRpcServer.test.ts
@@ -1,4 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// forgeRpcServer now imports the PluginService singleton to gate impl lookups
+// behind implicit activation. The singleton constructor calls `app.getVersion()`
+// which is undefined in this test's electron stub — mock the module surface
+// before importing forgeRpcServer so the constructor never runs.
+vi.mock("../PluginService.js", () => ({
+  pluginService: {
+    activatePluginForForgeProvider: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 import { _resetForgeRpcInFlightForTests, dispatchForgeRpc } from "../forgeRpcServer.js";
 import {
   clearForgeProviderImplRegistry,

--- a/electron/services/forgeRpcServer.ts
+++ b/electron/services/forgeRpcServer.ts
@@ -15,6 +15,7 @@ import type {
 import { makeForgeProviderId } from "../../shared/utils/forgeProviderIds.js";
 import { getForgeProviderImpl } from "./forgeProviderRegistry.js";
 import { resolveForgeProvider } from "./forgeProviderResolver.js";
+import { pluginService } from "./PluginService.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 // Deterministic stringify so two windows calling the same method with the same
@@ -179,6 +180,10 @@ async function invoke(req: ForgeRpcRequest): Promise<unknown> {
   if (!req.namespacedId) {
     throw new Error(`Forge RPC ${req.method} requires a namespacedId`);
   }
+  // Implicit activation: force the owning plugin's `activate()` to run before
+  // we try to resolve its impl, so a plugin that only binds during activate()
+  // is reachable on first use without a startup activation gate.
+  await pluginService.activatePluginForForgeProvider(req.namespacedId);
   const impl = getForgeProviderImpl(req.namespacedId);
   if (!impl) {
     throw new Error(`Forge provider "${req.namespacedId}" not registered`);
@@ -210,7 +215,7 @@ async function invoke(req: ForgeRpcRequest): Promise<unknown> {
   }
 }
 
-function invokeResolveProvider(args: unknown[]): ForgeResolveProviderResult | null {
+async function invokeResolveProvider(args: unknown[]): Promise<ForgeResolveProviderResult | null> {
   const [opts] = args as [
     {
       remoteUrl: string | null;
@@ -227,6 +232,8 @@ function invokeResolveProvider(args: unknown[]): ForgeResolveProviderResult | nu
 
   const { pluginId, contribution } = resolved.entry;
   const namespacedId = makeForgeProviderId(pluginId, contribution.id);
+  // Implicit activation before impl lookup — see `invoke` above for rationale.
+  await pluginService.activatePluginForForgeProvider(namespacedId);
   const impl = getForgeProviderImpl(namespacedId);
   if (!impl) return null;
   if (!opts.remoteUrl) return null;

--- a/electron/services/forgeRpcServer.ts
+++ b/electron/services/forgeRpcServer.ts
@@ -15,8 +15,22 @@ import type {
 import { makeForgeProviderId } from "../../shared/utils/forgeProviderIds.js";
 import { getForgeProviderImpl } from "./forgeProviderRegistry.js";
 import { resolveForgeProvider } from "./forgeProviderResolver.js";
-import { pluginService } from "./PluginService.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+
+// PluginService is loaded lazily so importing this file (e.g. from
+// `WorkspaceHostProcess` in tests that mock electron's `app` without
+// `getVersion()`) doesn't trigger the PluginService singleton constructor
+// at module-load time. The first forge RPC dispatch performs the import.
+type PluginServiceShape = {
+  activatePluginForForgeProvider(namespacedId: string): Promise<void>;
+};
+let pluginServicePromise: Promise<PluginServiceShape> | null = null;
+function getPluginService(): Promise<PluginServiceShape> {
+  if (!pluginServicePromise) {
+    pluginServicePromise = import("./PluginService.js").then((mod) => mod.pluginService);
+  }
+  return pluginServicePromise;
+}
 
 // Deterministic stringify so two windows calling the same method with the same
 // arg shape coalesce regardless of property order. Mirrors the bridge-side
@@ -183,6 +197,7 @@ async function invoke(req: ForgeRpcRequest): Promise<unknown> {
   // Implicit activation: force the owning plugin's `activate()` to run before
   // we try to resolve its impl, so a plugin that only binds during activate()
   // is reachable on first use without a startup activation gate.
+  const pluginService = await getPluginService();
   await pluginService.activatePluginForForgeProvider(req.namespacedId);
   const impl = getForgeProviderImpl(req.namespacedId);
   if (!impl) {
@@ -233,6 +248,7 @@ async function invokeResolveProvider(args: unknown[]): Promise<ForgeResolveProvi
   const { pluginId, contribution } = resolved.entry;
   const namespacedId = makeForgeProviderId(pluginId, contribution.id);
   // Implicit activation before impl lookup — see `invoke` above for rationale.
+  const pluginService = await getPluginService();
   await pluginService.activatePluginForForgeProvider(namespacedId);
   const impl = getForgeProviderImpl(namespacedId);
   if (!impl) return null;

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -302,6 +302,10 @@ export async function initGlobalServices(
       } catch (err) {
         console.error("[MAIN] PluginService initialization failed:", err);
       }
+      // Fire-and-forget — activations fan out in parallel and report errors
+      // via the per-plugin `loadError` provenance record. Awaiting here would
+      // delay subsequent deferred tasks behind the slowest plugin's activate().
+      void pluginService.activateStartupFinishedPlugins();
     },
   });
 

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -116,6 +116,7 @@ export interface PluginManifest {
     daintree?: string;
   };
   capabilities?: PluginCapability[];
+  activationEvents?: "onStartupFinished"[];
   contributes: {
     panels: PanelContribution[];
     toolbarButtons: ToolbarButtonContribution[];


### PR DESCRIPTION
## Summary

Previously every plugin's `main` module was eagerly imported at startup regardless of whether the plugin was ever used. As the curated plugin set grows, that's a cold-start cost that scales linearly for free.

This PR adds `activationEvents` to the manifest schema and splits loading into two phases: scan-time (manifest validation, contribution-point registration) and activation-time (the `import()` + `activate()` call). The two phases were previously fused inside `loadPlugin`.

Resolves #9270

## Changes

- Add `activationEvents: z.array(z.literal("onStartupFinished")).default([])` to `PluginManifestSchema` (`electron/schemas/plugin.ts`). Any other value is rejected loudly at parse time so plugin authors don't write `onCommand:foo` expecting it to work.
- Mirror on the `PluginManifest` type (`shared/types/plugin.ts`).
- Refactor `loadPlugin` to keep manifest validation and contribution-point registration at scan time; extract the `import()` + `activate()` call into a new `activatePlugin(pluginId)` method.
- `activatePlugin` is idempotent: a second concurrent caller queues behind the first promise; subsequent calls after activation return immediately.
- Plugins with `onStartupFinished` activate at end-of-startup, after the renderer signals ready.
- Implicit activation hooks cover panel instantiation, menu item invocation, and `{pluginId}.{actionId}` action dispatch — the first trigger pays the import cost, subsequent calls are direct.
- Forge provider and file-decoration provider lookups gate on activation transparently so the first post-startup query never misses.
- Activation failures mark the plugin record with `loadError` but leave its declared contribution points routable for a retry; the existing "Retry activation" path in the Settings tab works without restart.

## Testing

Unit tests in `electron/services/__tests__/PluginService.test.ts` cover:
- Scan-time registration without activation
- `onStartupFinished` activation at end-of-startup
- Idempotent `activatePlugin` (concurrent callers queue, no double-invoke)
- Import timeout: hanging imports resolve with a `loadError` after the timeout elapses
- Unload race: calling `activatePlugin` on an unloaded plugin returns early cleanly
- Activation failure: `loadError` is set, contribution points remain registered