### PR TITLE
feat(build): extend native-module ABI validation to win-job-object and posix-pty-reaper

### DIFF
--- a/scripts/afterPack.cjs
+++ b/scripts/afterPack.cjs
@@ -2,6 +2,25 @@ const path = require("path");
 const fs = require("fs");
 
 /**
+ * Map electron-builder's Arch enum to the Node-style string used by process.arch.
+ * Enum values: ia32=0, x64=1, armv7l=2, arm64=3, universal=5.
+ */
+function electronBuilderArchToNodeArch(archEnum) {
+  switch (archEnum) {
+    case 0:
+      return "ia32";
+    case 1:
+      return "x64";
+    case 2:
+      return "arm";
+    case 3:
+      return "arm64";
+    default:
+      return null;
+  }
+}
+
+/**
  * Validate that win_job_object.node loads and exports its primary binding.
  *
  * win-job-object is an N-API addon, so its compiled binary has a stable ABI
@@ -197,7 +216,19 @@ exports.default = async function afterPack(context) {
           'Help-session crash-safe reaping (#7526) will be disabled. Run "npm run rebuild" on a Windows runner with VS 2022 Build Tools.'
       );
     }
-    validateWinJobObjectLoadable(winJobObjectBinary);
+    // electron-builder calls afterPack once per target arch (x64 + arm64). The
+    // host CI runner is typically x64, so dlopen-ing the arm64 PE binary throws
+    // "not a valid Win32 application". We can only meaningfully forward-load
+    // the binary when the target arch matches the host. Existence check above
+    // is the only validation for the cross-arch pass.
+    const targetNodeArch = electronBuilderArchToNodeArch(context.arch);
+    if (targetNodeArch === process.arch) {
+      validateWinJobObjectLoadable(winJobObjectBinary);
+    } else {
+      console.log(
+        `[afterPack] win-job-object dlopen probe skipped: target arch ${targetNodeArch} ≠ host arch ${process.arch}`
+      );
+    }
     console.log(`[afterPack] win-job-object verified: ${winJobObjectBinary}`);
   } else {
     // macOS and Linux use pty.node

--- a/scripts/afterPack.cjs
+++ b/scripts/afterPack.cjs
@@ -2,6 +2,39 @@ const path = require("path");
 const fs = require("fs");
 
 /**
+ * Validate that win_job_object.node loads and exports its primary binding.
+ *
+ * win-job-object is an N-API addon, so its compiled binary has a stable ABI
+ * across Node.js and Electron versions — unlike better-sqlite3, the inverse
+ * dlopen trick does not apply (a correctly-built N-API binary always loads
+ * under Node). The probe is a forward load + export-shape check: dlopen the
+ * .node file directly and confirm `assignProcessToHelpJob` is wired up. This
+ * catches the realistic Windows failure modes — missing VCRUNTIME140.dll,
+ * arch mismatch (x64 vs arm64), truncated binary — all of which surface as
+ * thrown errors from `process.dlopen`.
+ */
+function validateWinJobObjectLoadable(nativeBinaryPath) {
+  const testModule = { exports: {} };
+  try {
+    process.dlopen(testModule, nativeBinaryPath);
+  } catch (err) {
+    const msg = err && err.message ? err.message : String(err);
+    throw new Error(
+      `[afterPack] CRITICAL: win-job-object failed to load: ${msg}. ` +
+        "Help-session crash-safe reaping (#7526) will be broken. " +
+        "Check that VCRUNTIME140.dll is present and the binary architecture matches the target (x64 vs arm64)."
+    );
+  }
+  if (typeof testModule.exports.assignProcessToHelpJob !== "function") {
+    throw new Error(
+      `[afterPack] CRITICAL: win-job-object loaded but assignProcessToHelpJob export is missing or not a function. ` +
+        "Help-session crash-safe reaping (#7526) will be broken."
+    );
+  }
+  console.log("[afterPack] win-job-object ABI check passed (N-API forward load OK)");
+}
+
+/**
  * Validate that better_sqlite3.node has Electron ABI, not Node ABI.
  *
  * better-sqlite3 uses the raw V8/NAN C++ API (not N-API), so the binary is
@@ -164,6 +197,7 @@ exports.default = async function afterPack(context) {
           'Help-session crash-safe reaping (#7526) will be disabled. Run "npm run rebuild" on a Windows runner with VS 2022 Build Tools.'
       );
     }
+    validateWinJobObjectLoadable(winJobObjectBinary);
     console.log(`[afterPack] win-job-object verified: ${winJobObjectBinary}`);
   } else {
     // macOS and Linux use pty.node
@@ -187,6 +221,19 @@ exports.default = async function afterPack(context) {
       throw new Error(
         `[afterPack] CRITICAL: posix-pty-reaper supervisor binary not found at ${posixReaperBinary}. ` +
           'Help-session crash-safe reaping (#8769) will be disabled. Run "npm run rebuild".'
+      );
+    }
+    // posix-pty-reaper is a compiled C executable (not a .node addon) with no
+    // safe `--version` probe — its main() enters a blocking read loop on stdin.
+    // Verify the executable bit is set so the supervisor can actually be spawned
+    // at runtime; this mirrors the wrapper's own isAvailable() check.
+    try {
+      fs.accessSync(posixReaperBinary, fs.constants.X_OK);
+    } catch (err) {
+      const msg = err && err.message ? err.message : String(err);
+      throw new Error(
+        `[afterPack] CRITICAL: posix-pty-reaper supervisor exists but is not executable at ${posixReaperBinary}: ${msg}. ` +
+          'Help-session crash-safe reaping (#8769) will be broken. Run "npm run rebuild".'
       );
     }
     console.log(`[afterPack] posix-pty-reaper verified: ${posixReaperBinary}`);

--- a/scripts/afterPack.test.ts
+++ b/scripts/afterPack.test.ts
@@ -18,10 +18,35 @@ afterAll(() => {
   process.dlopen = originalDlopen;
 });
 
-function createContext(platform: string, appOutDir: string, appName = "Daintree") {
+// electron-builder Arch enum: ia32=0, x64=1, armv7l=2, arm64=3, universal=5.
+function nodeArchToEnum(nodeArch: string): number {
+  switch (nodeArch) {
+    case "ia32":
+      return 0;
+    case "x64":
+      return 1;
+    case "arm":
+      return 2;
+    case "arm64":
+      return 3;
+    default:
+      return 1; // fall back to x64 for unknown host archs in CI
+  }
+}
+
+function createContext(
+  platform: string,
+  appOutDir: string,
+  appName = "Daintree",
+  // Default to the current host arch so the win-job-object dlopen probe runs
+  // in tests (it is skipped when target ≠ host). Tests exercising cross-arch
+  // behavior pass an explicit value.
+  arch: number = nodeArchToEnum(process.arch)
+) {
   return {
     appOutDir,
     electronPlatformName: platform,
+    arch,
     packager: { appInfo: { productFilename: appName } },
   };
 }
@@ -518,6 +543,58 @@ describe("afterPack", () => {
       );
     });
 
+    it("should skip dlopen probe when target arch ≠ host arch (cross-arch packaging)", async () => {
+      mockExistsSync.mockReturnValue(true);
+      const dlopenCalls: string[] = [];
+      process.dlopen = ((mod: { exports: Record<string, unknown> }, filename: string) => {
+        dlopenCalls.push(filename);
+        if (filename.includes("win_job_object")) {
+          // Simulate the cross-arch failure mode in case the probe is wrongly invoked.
+          throw new Error("%1 is not a valid Win32 application.");
+        }
+        throw new Error("NODE_MODULE_VERSION mismatch");
+      }) as typeof process.dlopen;
+
+      const originalArch = process.arch;
+      // Lie about host arch — we want to simulate x64 host packaging arm64
+      Object.defineProperty(process, "arch", { value: "x64", configurable: true });
+      try {
+        // arch = 3 → arm64 (electron-builder Arch enum)
+        await afterPack(createContext("win32", "/build/win", "Daintree", 3));
+      } finally {
+        Object.defineProperty(process, "arch", { value: originalArch, configurable: true });
+      }
+
+      // Probe must be skipped — no dlopen call against win_job_object
+      expect(dlopenCalls.some((p) => p.includes("win_job_object"))).toBe(false);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("win-job-object dlopen probe skipped")
+      );
+    });
+
+    it("should run dlopen probe when target arch === host arch (same-arch packaging)", async () => {
+      mockExistsSync.mockReturnValue(true);
+      const dlopenCalls: string[] = [];
+      process.dlopen = ((mod: { exports: Record<string, unknown> }, filename: string) => {
+        dlopenCalls.push(filename);
+        if (filename.includes("win_job_object")) {
+          mod.exports.assignProcessToHelpJob = () => true;
+          return;
+        }
+        throw new Error("NODE_MODULE_VERSION mismatch");
+      }) as typeof process.dlopen;
+
+      const originalArch = process.arch;
+      Object.defineProperty(process, "arch", { value: "arm64", configurable: true });
+      try {
+        await afterPack(createContext("win32", "/build/win", "Daintree", 3));
+      } finally {
+        Object.defineProperty(process, "arch", { value: originalArch, configurable: true });
+      }
+
+      expect(dlopenCalls.some((p) => p.includes("win_job_object"))).toBe(true);
+    });
+
     it("should only run on Windows", async () => {
       mockExistsSync.mockReturnValue(true);
       const dlopenCalls: string[] = [];
@@ -547,7 +624,10 @@ describe("afterPack", () => {
       await afterPack(createContext("linux", "/build/linux"));
 
       expect(mockAccessSync).toHaveBeenCalledWith(
-        expect.stringContaining("daintree_pty_supervisor"),
+        path.join(
+          "/build/linux/resources/app.asar.unpacked",
+          "node_modules/posix-pty-reaper/build/Release/daintree_pty_supervisor"
+        ),
         1 // X_OK from mocked fs.constants
       );
     });

--- a/scripts/afterPack.test.ts
+++ b/scripts/afterPack.test.ts
@@ -6,6 +6,7 @@ const mockExistsSync = vi.fn();
 const mockReaddirSync = vi.fn();
 const mockMkdirSync = vi.fn();
 const mockCopyFileSync = vi.fn();
+const mockAccessSync = vi.fn();
 const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -32,13 +33,26 @@ describe("afterPack", () => {
     vi.clearAllMocks();
     consoleSpy.mockImplementation(() => {});
     warnSpy.mockImplementation(() => {});
+    // Default: both native modules load cleanly.
+    //   - better-sqlite3: dlopen throws NODE_MODULE_VERSION mismatch (correct Electron ABI)
+    //   - win-job-object: dlopen succeeds and populates assignProcessToHelpJob export
+    //   - posix-pty-reaper: accessSync(X_OK) passes
+    // Individual tests override these for specific scenarios.
+    mockAccessSync.mockImplementation(() => {});
 
-    // Default: simulate Electron-ABI binary (correct) — dlopen throws ABI mismatch
-    process.dlopen = (() => {
+    let dlopenCallCount = 0;
+    process.dlopen = ((moduleObj: { exports: Record<string, unknown> }, filename: string) => {
+      dlopenCallCount += 1;
+      if (filename.includes("win_job_object")) {
+        moduleObj.exports.assignProcessToHelpJob = () => true;
+        return;
+      }
       throw new Error(
         "was compiled against a different Node.js version using NODE_MODULE_VERSION 131"
       );
     }) as typeof process.dlopen;
+    // Silence the unused-variable warning while preserving the counter for future debugging.
+    void dlopenCallCount;
 
     const originalRequire = Module.prototype.require;
 
@@ -49,6 +63,8 @@ describe("afterPack", () => {
           readdirSync: mockReaddirSync,
           mkdirSync: mockMkdirSync,
           copyFileSync: mockCopyFileSync,
+          accessSync: mockAccessSync,
+          constants: { X_OK: 1 },
         };
       }
       return originalRequire.apply(this, [id]);
@@ -375,7 +391,11 @@ describe("afterPack", () => {
 
     it("should pass when dlopen throws not a valid Win32 application", async () => {
       mockExistsSync.mockReturnValue(true);
-      process.dlopen = (() => {
+      process.dlopen = ((mod: { exports: Record<string, unknown> }, filename: string) => {
+        if (filename.includes("win_job_object")) {
+          mod.exports.assignProcessToHelpJob = () => true;
+          return;
+        }
         throw new Error("not a valid Win32 application");
       }) as typeof process.dlopen;
 
@@ -399,7 +419,11 @@ describe("afterPack", () => {
 
     it("should warn but continue on inconclusive probe (e.g. missing DLL)", async () => {
       mockExistsSync.mockReturnValue(true);
-      process.dlopen = (() => {
+      process.dlopen = ((mod: { exports: Record<string, unknown> }, filename: string) => {
+        if (filename.includes("win_job_object")) {
+          mod.exports.assignProcessToHelpJob = () => true;
+          return;
+        }
         throw new Error("The specified module could not be found");
       }) as typeof process.dlopen;
 
@@ -411,8 +435,12 @@ describe("afterPack", () => {
     it("should run ABI validation on all platforms", async () => {
       mockExistsSync.mockReturnValue(true);
       const dlopenCalls: string[] = [];
-      process.dlopen = ((_mod: any, path: string) => {
-        dlopenCalls.push(path);
+      process.dlopen = ((mod: { exports: Record<string, unknown> }, filename: string) => {
+        dlopenCalls.push(filename);
+        if (filename.includes("win_job_object")) {
+          mod.exports.assignProcessToHelpJob = () => true;
+          return;
+        }
         throw new Error("NODE_MODULE_VERSION mismatch");
       }) as typeof process.dlopen;
 
@@ -426,9 +454,133 @@ describe("afterPack", () => {
               : `/build/${platform === "win32" ? "win" : "linux"}`
           )
         );
-        expect(dlopenCalls.length).toBe(1);
-        expect(dlopenCalls[0]).toContain("better_sqlite3.node");
+        // better-sqlite3 ABI probe runs on every platform; win-job-object runs on win32 only.
+        const sqliteCalls = dlopenCalls.filter((p) => p.includes("better_sqlite3.node"));
+        expect(sqliteCalls.length).toBe(1);
       }
+    });
+  });
+
+  describe("win-job-object ABI validation", () => {
+    it("should pass when dlopen succeeds and assignProcessToHelpJob is exported", async () => {
+      mockExistsSync.mockReturnValue(true);
+      // beforeEach default already simulates a healthy win-job-object load.
+
+      await afterPack(createContext("win32", "/build/win"));
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "[afterPack] win-job-object ABI check passed (N-API forward load OK)"
+      );
+    });
+
+    it("should throw CRITICAL when dlopen fails (missing VCRUNTIME140.dll)", async () => {
+      mockExistsSync.mockReturnValue(true);
+      process.dlopen = ((_mod: unknown, filename: string) => {
+        if (filename.includes("win_job_object")) {
+          throw new Error(
+            "The specified module could not be found. \\?\\C:\\app\\win_job_object.node"
+          );
+        }
+        throw new Error("NODE_MODULE_VERSION mismatch");
+      }) as typeof process.dlopen;
+
+      await expect(afterPack(createContext("win32", "/build/win"))).rejects.toThrow(
+        /win-job-object failed to load/
+      );
+    });
+
+    it("should throw CRITICAL with arch-mismatch hint", async () => {
+      mockExistsSync.mockReturnValue(true);
+      process.dlopen = ((_mod: unknown, filename: string) => {
+        if (filename.includes("win_job_object")) {
+          throw new Error("%1 is not a valid Win32 application.");
+        }
+        throw new Error("NODE_MODULE_VERSION mismatch");
+      }) as typeof process.dlopen;
+
+      await expect(afterPack(createContext("win32", "/build/win"))).rejects.toThrow(
+        /architecture matches the target/
+      );
+    });
+
+    it("should throw CRITICAL when dlopen succeeds but export is missing", async () => {
+      mockExistsSync.mockReturnValue(true);
+      process.dlopen = ((mod: { exports: Record<string, unknown> }, filename: string) => {
+        if (filename.includes("win_job_object")) {
+          // Loaded but no assignProcessToHelpJob export wired up
+          return;
+        }
+        throw new Error("NODE_MODULE_VERSION mismatch");
+      }) as typeof process.dlopen;
+
+      await expect(afterPack(createContext("win32", "/build/win"))).rejects.toThrow(
+        /assignProcessToHelpJob export is missing/
+      );
+    });
+
+    it("should only run on Windows", async () => {
+      mockExistsSync.mockReturnValue(true);
+      const dlopenCalls: string[] = [];
+      process.dlopen = ((mod: { exports: Record<string, unknown> }, filename: string) => {
+        dlopenCalls.push(filename);
+        if (filename.includes("win_job_object")) {
+          mod.exports.assignProcessToHelpJob = () => true;
+          return;
+        }
+        throw new Error("NODE_MODULE_VERSION mismatch");
+      }) as typeof process.dlopen;
+
+      await afterPack(createContext("linux", "/build/linux"));
+      expect(dlopenCalls.some((p) => p.includes("win_job_object"))).toBe(false);
+
+      dlopenCalls.length = 0;
+      await afterPack(createContext("darwin", "/build/mac"));
+      expect(dlopenCalls.some((p) => p.includes("win_job_object"))).toBe(false);
+    });
+  });
+
+  describe("posix-pty-reaper executable check", () => {
+    it("should pass when accessSync(X_OK) succeeds", async () => {
+      mockExistsSync.mockReturnValue(true);
+      // beforeEach default already returns success from accessSync.
+
+      await afterPack(createContext("linux", "/build/linux"));
+
+      expect(mockAccessSync).toHaveBeenCalledWith(
+        expect.stringContaining("daintree_pty_supervisor"),
+        1 // X_OK from mocked fs.constants
+      );
+    });
+
+    it("should throw CRITICAL when accessSync throws (binary not executable)", async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockAccessSync.mockImplementation(() => {
+        throw Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+      });
+
+      await expect(afterPack(createContext("linux", "/build/linux"))).rejects.toThrow(
+        /posix-pty-reaper supervisor exists but is not executable/
+      );
+    });
+
+    it("should throw CRITICAL on macOS when accessSync fails", async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockAccessSync.mockImplementation(() => {
+        throw new Error("EACCES");
+      });
+
+      await expect(afterPack(createContext("darwin", "/build/mac"))).rejects.toThrow(
+        /posix-pty-reaper supervisor exists but is not executable/
+      );
+    });
+
+    it("should not run on Windows", async () => {
+      mockExistsSync.mockReturnValue(true);
+
+      await afterPack(createContext("win32", "/build/win"));
+
+      // accessSync is only called from the POSIX branch
+      expect(mockAccessSync).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

- `better-sqlite3` had a `dlopen`-based ABI probe in `afterPack.cjs`; `win-job-object` and `posix-pty-reaper` only had existence checks, meaning a missing transitive DLL or non-executable binary would compile, pack, sign, ship, and silently disable help-session crash-safe reaping at first use
- Adds a `dlopen` forward-load probe for `win-job-object` (Windows N-API addon) that checks for the expected `assignProcessToHelpJob` export, and an `fs.accessSync` executable-bit check for `posix-pty-reaper` (POSIX C supervisor binary) — cross-arch packaging skips the `dlopen` probe since x64 hosts can't `dlopen` arm64 PE binaries
- Adds two non-fatal `[SMOKE] WARN` blocks for both modules in `electron/setup/environment.ts` — loss of either is degraded mode, not a startup failure

Resolves #9245

## Changes

- `scripts/afterPack.cjs`: `validateWinJobObjectLoadable()` uses `process.dlopen` to forward-load the N-API addon and confirm the export shape; `electronBuilderArchToNodeArch()` helper gates the probe to same-arch packaging. POSIX branch adds `fs.accessSync(X_OK)` for the `posix-pty-reaper` binary
- `electron/setup/environment.ts`: two `require()`-based non-fatal smoke checks after the existing `better-sqlite3` block
- `scripts/afterPack.test.ts`: 11 new tests covering win-job-object success, missing DLL, arch mismatch, missing export, cross-arch skip, same-arch run, POSIX no-op, and posix-pty-reaper pass/fail on Linux and macOS, plus Windows no-op

## Testing

All 11 new unit tests pass. Existing `afterPack` tests unaffected. The cross-arch skip path is validated with a dedicated test that flips arch away from the host.