### PR TITLE
feat(ci): build Windows arm64 natively on windows-11-arm

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -108,9 +108,9 @@ jobs:
       platform: windows
     secrets: inherit
 
-  build-daintree:
+  build-daintree-x64:
     needs: [checks, unit-tests, e2e-core-gate, e2e-full-gate]
-    name: Build Daintree (Windows)
+    name: Build Daintree (Windows x64)
     runs-on: windows-latest
     timeout-minutes: 90
     steps:
@@ -137,39 +137,18 @@ jobs:
           node_version: ${{ env.NODE_VERSION }}
           msvs_version: "2022"
 
-      # Cross-compile win-job-object (source-only N-API addon) for arm64 so the
-      # NSIS combined installer can ship both archs. node-pty and better-sqlite3
-      # have arm64 prebuilts; electron-builder pulls those via npmRebuild during
-      # packaging. The post-install copy of node-pty's conpty win10-arm64 DLLs
-      # is recovered by `scripts/afterPack.cjs` based on `context.arch`.
-      - name: Cross-compile arm64 native modules (Windows)
-        shell: bash
-        env:
-          npm_config_msvs_version: "2022"
-        run: npm run rebuild:win-arm64
-
-      - name: Build
+      - name: Build (x64)
         shell: bash
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           DEBUG: electron-builder,electron-notarize*,electron-osx-sign*
-          # Distinguishes pre-release AppX versions — parseInt() in electron-builder's
-          # getVersionInWeirdWindowsForm discards semver suffixes, so 0.14.1-rc.1 and
-          # 0.14.1 would both map to 0.14.1.0 in the manifest. BUILD_NUMBER fills the
-          # 4th slot so every build gets a unique A.B.C.D for Store update detection.
-          # github.run_number is per-workflow monotonic (~weekly releases → fits uint16).
           BUILD_NUMBER: ${{ github.run_number }}
         run: |
           npm run build
-          # Hard security gate (#9148) — fail before packaging if any E2E
-          # backdoor survived the production strip.
           npm run check:preload-backdoors
-          # Windows binaries are published via the R2 upload in the publish
-          # job (and the Microsoft Store step below), never by electron-builder
-          # directly — so --publish is always "never" here.
-          npx electron-builder --config electron-builder.config.cjs --publish never
+          npx electron-builder --config electron-builder.config.cjs --win appx nsis --x64 --publish never
 
-      - name: Verify Windows Store package was built
+      - name: Verify Windows Store package was built (x64)
         shell: pwsh
         run: |
           $packages = @(Get-ChildItem -Path 'release\*.appx', 'release\*.msix' -ErrorAction SilentlyContinue)
@@ -180,7 +159,7 @@ jobs:
           }
           Write-Host "Found $($packages.Count) Store package(s) in release/"
 
-      - name: Verify Windows NSIS installer was built
+      - name: Verify Windows NSIS installer was built (x64)
         shell: pwsh
         run: |
           $installers = @(Get-ChildItem -Path 'release\*.exe' -ErrorAction SilentlyContinue)
@@ -271,14 +250,115 @@ jobs:
           }
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ":rocket: Microsoft Store submission published (product $env:STORE_PRODUCT_ID)"
 
-      - name: Validate update metadata (Windows NSIS)
+      - name: Upload build artifacts (x64)
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-daintree-windows-x64
+          path: |
+            release/*.appx
+            release/*.msix
+            release/*.exe
+            release/*.blockmap
+            release/*.yml
+          retention-days: 7
+          if-no-files-found: error
+
+  build-daintree-arm64:
+    needs: [checks, unit-tests, e2e-core-gate, e2e-full-gate]
+    name: Build Daintree (Windows arm64)
+    runs-on: windows-11-arm
+    timeout-minutes: 90
+    steps:
+      - name: Check out repository
+        uses: ./.github/actions/checkout-shallow
+
+      - name: Verify version matches tag
+        if: startsWith(github.ref, 'refs/tags/v')
         shell: bash
         run: |
-          # electron-updater on Windows polls `<channel>.yml` (no platform
-          # suffix) — Provider.js getChannelFilePrefix() returns "" for win32.
-          # This is the canonical filename installed clients fetch, so we
-          # generate (and validate) it here even though electron-builder's
-          # packaging step already wrote a copy.
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Set up Node.js and install dependencies
+        uses: ./.github/actions/setup-node-install
+        with:
+          node_version: ${{ env.NODE_VERSION }}
+          msvs_version: "2022"
+
+      - name: Build (arm64)
+        shell: bash
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          DEBUG: electron-builder,electron-notarize*,electron-osx-sign*
+        run: |
+          npm run build
+          npm run check:preload-backdoors
+          # arm64 builds NSIS only (no AppX/Store target).
+          npx electron-builder --config electron-builder.config.cjs --win nsis --arm64 --publish never
+
+      - name: Verify Windows NSIS installer was built (arm64)
+        shell: pwsh
+        run: |
+          $installers = @(Get-ChildItem -Path 'release\*.exe' -ErrorAction SilentlyContinue)
+          if ($installers.Count -ne 1) {
+            Write-Host "::error::Expected exactly 1 NSIS .exe in release/, found $($installers.Count). Confirm electron-builder.config.cjs lists the nsis target."
+            Get-ChildItem -Path release -ErrorAction SilentlyContinue | ForEach-Object { Write-Host $_.Name }
+            exit 1
+          }
+          Write-Host "Found NSIS installer: $($installers[0].Name) ($([math]::Round($installers[0].Length / 1MB, 1)) MB)"
+
+      - name: Upload build artifacts (arm64)
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-daintree-windows-arm64
+          path: |
+            release/*.exe
+            release/*.blockmap
+            release/*.yml
+          retention-days: 7
+          if-no-files-found: error
+
+  assemble-windows-release:
+    needs: [build-daintree-x64, build-daintree-arm64]
+    name: Assemble Windows release
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: ./.github/actions/checkout-shallow
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libarchive-tools
+
+      - name: Set up Node.js and install dependencies
+        uses: ./.github/actions/setup-node-install
+        with:
+          node_version: ${{ env.NODE_VERSION }}
+
+      - name: Resolve update metadata prefix
+        uses: ./.github/actions/resolve-update-metadata-prefix
+
+      - name: Download x64 artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: release-daintree-windows-x64
+          path: release/
+
+      - name: Download arm64 artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: release-daintree-windows-arm64
+          path: release/
+
+      - name: Generate and validate update metadata
+        shell: bash
+        run: |
           node scripts/ci/generate-update-metadata.mjs windows "release/${UPDATE_METADATA_PREFIX}.yml"
           if [ ! -f "release/${UPDATE_METADATA_PREFIX}.yml" ]; then
             echo "::error::Missing release/${UPDATE_METADATA_PREFIX}.yml - Windows auto-update metadata was not generated"
@@ -286,7 +366,7 @@ jobs:
           fi
           node scripts/ci/validate-update-metadata.mjs "release/${UPDATE_METADATA_PREFIX}.yml"
 
-      - name: Upload build artifacts
+      - name: Upload combined build artifacts
         uses: actions/upload-artifact@v7
         with:
           name: release-daintree-windows-latest
@@ -307,7 +387,7 @@ jobs:
   # is uniquely at risk if cross-compile for arm64 fails silently). Gates
   # publish.
   smoke-packaged:
-    needs: [build-daintree]
+    needs: [assemble-windows-release]
     name: Smoke (packaged NSIS)
     runs-on: windows-latest
     timeout-minutes: 20
@@ -384,7 +464,7 @@ jobs:
 
   publish-daintree:
     if: startsWith(github.ref, 'refs/tags/v') && inputs.dry_run != true
-    needs: [build-daintree, smoke-packaged]
+    needs: [assemble-windows-release, smoke-packaged]
     runs-on: ubuntu-22.04
     timeout-minutes: 15
 

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -112,6 +112,7 @@ module.exports = async function () {
     },
     win: {
       icon: "build/icon.ico",
+      artifactName: "${productName}-${version}-${arch}-setup.${ext}",
       target: [
         { target: "appx", arch: ["x64"] },
         { target: "nsis", arch: ["x64", "arm64"] },
@@ -129,9 +130,9 @@ module.exports = async function () {
       languages: ["en-US"],
       setBuildNumber: true,
     },
-    // NSIS (non-Store) Windows installer. Produces a single combined x64+arm64
-    // `.exe`; the installer selects the right payload at runtime. Auto-update
-    // is delivered via the generic provider URL above — gated in the renderer
+    // NSIS (non-Store) Windows installer. Separate x64 and arm64 installers
+    // built on their respective native runners (#9244). Auto-update is
+    // delivered via the generic provider URL above — gated in the renderer
     // by `process.windowsStore` so MSIX/AppX builds keep using the Store path.
     nsis: {
       oneClick: false,
@@ -143,6 +144,7 @@ module.exports = async function () {
       shortcutName: "Daintree",
       uninstallDisplayName: "Daintree",
       differentialPackage: true,
+      buildUniversalInstaller: false,
     },
     linux: {
       icon: "build/icon.png",

--- a/scripts/ci/generate-update-metadata.mjs
+++ b/scripts/ci/generate-update-metadata.mjs
@@ -89,6 +89,12 @@ function selectArtifacts(platform, fileNames) {
     // through the Store and must be excluded here. electron-updater's
     // Provider.findFile() selects the .exe whose URL contains process.arch,
     // falling back to the first entry — so x64 must be first.
+    const archPattern = /-(x64|arm64)-setup\.exe$/;
+    const extractArch = (fileName) => {
+      const match = fileName.match(archPattern);
+      return match ? match[1] : null;
+    };
+
     const installers = fileNames
       .filter((fileName) => fileName.endsWith(".exe") && !fileName.endsWith(".exe.blockmap"))
       .sort();
@@ -96,7 +102,7 @@ function selectArtifacts(platform, fileNames) {
       throw new Error(`Expected at least 1 Windows NSIS .exe artifact, found 0`);
     }
     for (const installer of installers) {
-      if (!installer.includes("-x64-") && !installer.includes("-arm64-")) {
+      if (!extractArch(installer)) {
         throw new Error(
           `Windows NSIS .exe must include architecture token (-x64- or -arm64-): ${installer}`
         );
@@ -106,14 +112,12 @@ function selectArtifacts(platform, fileNames) {
     // picks x64 (the larger install base).
     const archOrder = { x64: 0, arm64: 1 };
     installers.sort((a, b) => {
-      const aArch = a.includes("-x64-") ? "x64" : "arm64";
-      const bArch = b.includes("-x64-") ? "x64" : "arm64";
-      return archOrder[aArch] - archOrder[bArch];
+      return archOrder[extractArch(a)] - archOrder[extractArch(b)];
     });
     // Fail on duplicate archs
     const seen = new Set();
     for (const installer of installers) {
-      const arch = installer.includes("-x64-") ? "x64" : "arm64";
+      const arch = extractArch(installer);
       if (seen.has(arch)) {
         throw new Error(`Duplicate ${arch} Windows NSIS .exe: ${installer}`);
       }

--- a/scripts/ci/generate-update-metadata.mjs
+++ b/scripts/ci/generate-update-metadata.mjs
@@ -85,13 +85,39 @@ function selectArtifacts(platform, fileNames) {
   }
 
   if (platform === "windows") {
-    // NSIS produces a single combined installer covering all selected archs;
-    // `.appx` artifacts are routed through the Store and must be excluded here.
-    const installers = fileNames.filter((fileName) => fileName.endsWith(".exe")).sort();
-    if (installers.length !== 1) {
-      throw new Error(
-        `Expected exactly 1 Windows NSIS .exe artifact, found ${installers.length}: ${installers.join(", ") || "(none)"}`
-      );
+    // Separate per-arch NSIS installers (#9244). `.appx` artifacts are routed
+    // through the Store and must be excluded here. electron-updater's
+    // Provider.findFile() selects the .exe whose URL contains process.arch,
+    // falling back to the first entry — so x64 must be first.
+    const installers = fileNames
+      .filter((fileName) => fileName.endsWith(".exe") && !fileName.endsWith(".exe.blockmap"))
+      .sort();
+    if (installers.length === 0) {
+      throw new Error(`Expected at least 1 Windows NSIS .exe artifact, found 0`);
+    }
+    for (const installer of installers) {
+      if (!installer.includes("-x64-") && !installer.includes("-arm64-")) {
+        throw new Error(
+          `Windows NSIS .exe must include architecture token (-x64- or -arm64-): ${installer}`
+        );
+      }
+    }
+    // Sort x64 before arm64 so electron-updater's arch-agnostic fallback
+    // picks x64 (the larger install base).
+    const archOrder = { x64: 0, arm64: 1 };
+    installers.sort((a, b) => {
+      const aArch = a.includes("-x64-") ? "x64" : "arm64";
+      const bArch = b.includes("-x64-") ? "x64" : "arm64";
+      return archOrder[aArch] - archOrder[bArch];
+    });
+    // Fail on duplicate archs
+    const seen = new Set();
+    for (const installer of installers) {
+      const arch = installer.includes("-x64-") ? "x64" : "arm64";
+      if (seen.has(arch)) {
+        throw new Error(`Duplicate ${arch} Windows NSIS .exe: ${installer}`);
+      }
+      seen.add(arch);
     }
     return installers;
   }

--- a/scripts/ci/generate-update-metadata.test.mjs
+++ b/scripts/ci/generate-update-metadata.test.mjs
@@ -150,18 +150,16 @@ describe("generate-update-metadata", () => {
     ).rejects.toThrow("Expected exactly 1 Linux AppImage artifact");
   });
 
-  it("writes Windows metadata for the NSIS .exe and ignores .appx artifacts", async () => {
+  it("writes Windows metadata for a single NSIS .exe and ignores .appx artifacts", async () => {
     const dir = await tempDir();
     const releaseDir = path.join(dir, "release");
     await mkdir(releaseDir);
     const packagePath = await writePackageJson(dir, "1.2.3");
-    await writeArtifact(releaseDir, "Daintree-1.2.3-setup.exe", "nsis-installer");
-    await writeArtifact(releaseDir, "Daintree-1.2.3-setup.exe.blockmap", "blockmap");
+    await writeArtifact(releaseDir, "Daintree-1.2.3-x64-setup.exe", "nsis-installer");
+    await writeArtifact(releaseDir, "Daintree-1.2.3-x64-setup.exe.blockmap", "blockmap");
     await writeArtifact(releaseDir, "Daintree-1.2.3.appx", "appx");
 
     // electron-updater on Windows polls `<channel>.yml` (no platform suffix).
-    // Mirror the production filename so this test catches a regression that
-    // accidentally moves Windows metadata into `latest-win.yml` again.
     const metadataPath = path.join(releaseDir, "latest.yml");
     const metadata = await generateUpdateMetadata({
       platform: "windows",
@@ -174,12 +172,52 @@ describe("generate-update-metadata", () => {
     const fromFile = load(await readFile(metadataPath, "utf8"));
     expect(fromFile).toEqual(metadata);
     expect(metadata.version).toBe("1.2.3");
-    expect(metadata.path).toBe("Daintree-1.2.3-setup.exe");
+    expect(metadata.path).toBe("Daintree-1.2.3-x64-setup.exe");
     expect(metadata.files).toHaveLength(1);
     expect(metadata.files[0]).toMatchObject({
-      url: "Daintree-1.2.3-setup.exe",
+      url: "Daintree-1.2.3-x64-setup.exe",
       blockMapSize: 8,
     });
+  });
+
+  it("writes Windows metadata for separate x64 and arm64 NSIS installers", async () => {
+    const dir = await tempDir();
+    const releaseDir = path.join(dir, "release");
+    await mkdir(releaseDir);
+    const packagePath = await writePackageJson(dir, "1.2.3");
+    await writeArtifact(releaseDir, "Daintree-1.2.3-arm64-setup.exe", "arm64");
+    await writeArtifact(releaseDir, "Daintree-1.2.3-arm64-setup.exe.blockmap", "arm64-blockmap");
+    await writeArtifact(releaseDir, "Daintree-1.2.3-x64-setup.exe", "x64");
+    await writeArtifact(releaseDir, "Daintree-1.2.3-x64-setup.exe.blockmap", "x64-blockmap");
+    await writeArtifact(releaseDir, "Daintree-1.2.3.appx", "appx");
+
+    const metadataPath = path.join(releaseDir, "latest.yml");
+    const metadata = await generateUpdateMetadata({
+      platform: "windows",
+      releaseDir,
+      metadataPath,
+      packagePath,
+      releaseDate: "2026-01-02T03:04:05.000Z",
+    });
+
+    const fromFile = load(await readFile(metadataPath, "utf8"));
+    expect(fromFile).toEqual(metadata);
+    expect(metadata.version).toBe("1.2.3");
+    // x64 must be first for electron-updater's arch-agnostic fallback
+    expect(metadata.path).toBe("Daintree-1.2.3-x64-setup.exe");
+    expect(metadata.files).toHaveLength(2);
+    expect(metadata.files[0]).toMatchObject({
+      url: "Daintree-1.2.3-x64-setup.exe",
+      blockMapSize: 12,
+    });
+    expect(metadata.files[1]).toMatchObject({
+      url: "Daintree-1.2.3-arm64-setup.exe",
+      blockMapSize: 14,
+    });
+    expect(metadata.files.map((file) => file.url)).toEqual([
+      "Daintree-1.2.3-x64-setup.exe",
+      "Daintree-1.2.3-arm64-setup.exe",
+    ]);
   });
 
   it("fails when Windows packaging produced no NSIS .exe", async () => {
@@ -196,16 +234,15 @@ describe("generate-update-metadata", () => {
         metadataPath: path.join(releaseDir, "latest.yml"),
         packagePath,
       })
-    ).rejects.toThrow("Expected exactly 1 Windows NSIS .exe artifact, found 0");
+    ).rejects.toThrow("Expected at least 1 Windows NSIS .exe artifact, found 0");
   });
 
-  it("fails when Windows packaging produced more than one NSIS .exe", async () => {
+  it("fails when Windows NSIS .exe filename lacks an architecture token", async () => {
     const dir = await tempDir();
     const releaseDir = path.join(dir, "release");
     await mkdir(releaseDir);
     const packagePath = await writePackageJson(dir);
-    await writeArtifact(releaseDir, "Daintree-1.2.3-x64.exe", "x64");
-    await writeArtifact(releaseDir, "Daintree-1.2.3-arm64.exe", "arm64");
+    await writeArtifact(releaseDir, "Daintree-1.2.3-setup.exe", "no-arch");
 
     await expect(
       generateUpdateMetadata({
@@ -214,6 +251,24 @@ describe("generate-update-metadata", () => {
         metadataPath: path.join(releaseDir, "latest.yml"),
         packagePath,
       })
-    ).rejects.toThrow("Expected exactly 1 Windows NSIS .exe artifact, found 2");
+    ).rejects.toThrow("must include architecture token");
+  });
+
+  it("fails when Windows packaging produced duplicate arch installers", async () => {
+    const dir = await tempDir();
+    const releaseDir = path.join(dir, "release");
+    await mkdir(releaseDir);
+    const packagePath = await writePackageJson(dir);
+    await writeArtifact(releaseDir, "Daintree-1.2.3-x64-setup.exe", "x64-a");
+    await writeArtifact(releaseDir, "Daintree-1.2.3-x64-setup-v2.exe", "x64-b");
+
+    await expect(
+      generateUpdateMetadata({
+        platform: "windows",
+        releaseDir,
+        metadataPath: path.join(releaseDir, "latest.yml"),
+        packagePath,
+      })
+    ).rejects.toThrow("Duplicate x64 Windows NSIS .exe");
   });
 });

--- a/scripts/ci/generate-update-metadata.test.mjs
+++ b/scripts/ci/generate-update-metadata.test.mjs
@@ -260,7 +260,7 @@ describe("generate-update-metadata", () => {
     await mkdir(releaseDir);
     const packagePath = await writePackageJson(dir);
     await writeArtifact(releaseDir, "Daintree-1.2.3-x64-setup.exe", "x64-a");
-    await writeArtifact(releaseDir, "Daintree-1.2.3-x64-setup-v2.exe", "x64-b");
+    await writeArtifact(releaseDir, "Daintree-0.0.0-x64-setup.exe", "x64-b");
 
     await expect(
       generateUpdateMetadata({


### PR DESCRIPTION
## Summary
- Moves the Windows arm64 release build from cross-compiling on x64 runners to native building on `windows-11-arm` runners.
- Eliminates an entire class of native-module failures: `npm_config_arch` not propagating through `node-gyp`, source-only addons linking against the wrong `kernel32.lib`, and `node-pty` ConPTY assets mis-caching on the wrong host.
- `windows-11-arm` runners are free for public repos, so this costs nothing and validates the full native toolchain on real arm64 hardware.

Resolves #9244

## Changes
- Splits the `release-windows` workflow into separate `build-daintree-x64` and `build-daintree-arm64` jobs, plus an `assemble-windows-release` job that combines artifacts.
- Updates `electron-builder.config.cjs` for per-arch artifact naming (`${arch}` in `artifactName`) and separate NSIS installers (`buildUniversalInstaller: false`).
- Updates `scripts/ci/generate-update-metadata.mjs` to handle multiple per-arch Windows installers, with x64 sorted first for `electron-updater`'s arch-agnostic fallback.
- Expands the metadata generator tests for multi-arch installers, duplicate detection, and missing-arch-token validation.
- Keeps the existing `rebuild:win-arm64` script as a fallback for a couple release cycles while the native job soaks.

## Testing
- `generate-update-metadata.test.mjs` updated and passing locally for single-arch, dual-arch, missing-token, and duplicate-arch scenarios.
- CI pipeline on this PR exercises the x64 build path. The arm64 path cannot run on x64 hosts, but the metadata assembly logic is tested on `ubuntu-22.04`.