### PR TITLE
ci(release): add packaged-artifact smoke gate to per-OS release workflows

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -180,9 +180,81 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+  # Packaged-artifact smoke (#9246) — launches the freshly-built AppImage in
+  # --smoke-test mode and validates every stability marker including the
+  # node-pty, better-sqlite3, and posix-pty-reaper native module checks. Gates
+  # publish so a regression in the packaged tree (e.g. an asar.unpacked native
+  # missing for the build's arch) fails the release instead of shipping.
+  smoke-packaged:
+    needs: [build-daintree]
+    name: Smoke (packaged AppImage)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: ./.github/actions/checkout-shallow
+
+      - name: Set up Node.js and install dependencies
+        uses: ./.github/actions/setup-node-install
+        with:
+          node_version: ${{ env.NODE_VERSION }}
+
+      - name: Install runtime dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            xvfb \
+            libgbm1 \
+            libgtk-3-0 \
+            libnss3 \
+            libasound2 \
+            libxss1 \
+            libxtst6 \
+            libatk1.0-0 \
+            libdrm2
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: release-daintree-ubuntu-22.04
+          path: ${{ runner.temp }}/release-artifact
+
+      - name: Extract AppImage
+        id: extract
+        shell: bash
+        run: |
+          set -euo pipefail
+          APPIMAGE=$(find "$RUNNER_TEMP/release-artifact" -maxdepth 2 -name '*.AppImage' | head -n 1)
+          if [ -z "$APPIMAGE" ]; then
+            echo "::error::No .AppImage found in downloaded artifact"
+            find "$RUNNER_TEMP/release-artifact" -maxdepth 3 -type f | head -50
+            exit 1
+          fi
+          echo "Found AppImage: $APPIMAGE"
+          chmod +x "$APPIMAGE"
+          mkdir -p "$RUNNER_TEMP/appimage-work"
+          cd "$RUNNER_TEMP/appimage-work"
+          # --appimage-extract avoids FUSE, which is unavailable on GitHub
+          # Actions hosted runners. Produces ./squashfs-root with an AppRun
+          # entry point that sets LD_LIBRARY_PATH and APPDIR before exec'ing
+          # the real binary.
+          "$APPIMAGE" --appimage-extract
+          BIN="$RUNNER_TEMP/appimage-work/squashfs-root/AppRun"
+          if [ ! -x "$BIN" ]; then
+            echo "::error::Extracted AppRun missing or not executable at $BIN"
+            ls -la "$RUNNER_TEMP/appimage-work/squashfs-root" || true
+            exit 1
+          fi
+          echo "packaged_binary=$BIN" >> "$GITHUB_OUTPUT"
+
+      - name: Run packaged smoke
+        env:
+          PACKAGED_BINARY: ${{ steps.extract.outputs.packaged_binary }}
+        run: xvfb-run --auto-servernum node scripts/run-packaged-smoke.mjs
+
   publish-daintree:
     if: startsWith(github.ref, 'refs/tags/v') && inputs.dry_run != true
-    needs: [build-daintree]
+    needs: [build-daintree, smoke-packaged]
     runs-on: ubuntu-22.04
     timeout-minutes: 15
 

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -258,9 +258,83 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+  # Packaged-artifact smoke (#9246) — mounts the freshly-built DMG, copies the
+  # .app out, removes the quarantine xattr (required even for notarized apps
+  # on a headless CI runner that can't dismiss a Gatekeeper prompt), and runs
+  # the binary in --smoke-test mode. Validates node-pty, better-sqlite3, and
+  # posix-pty-reaper markers from the asar.unpacked tree. Gates publish.
+  smoke-packaged:
+    needs: [build-daintree]
+    name: Smoke (packaged .app)
+    runs-on: macos-14
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: ./.github/actions/checkout-shallow
+
+      - name: Set up Node.js and install dependencies
+        uses: ./.github/actions/setup-node-install
+        with:
+          node_version: ${{ env.NODE_VERSION }}
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: release-daintree-macos-14
+          path: ${{ runner.temp }}/release-artifact
+
+      - name: Mount DMG and install app
+        id: extract
+        shell: bash
+        run: |
+          set -euo pipefail
+          # macos-14 runners are arm64 — prefer the native-arch DMG; fall back
+          # to universal, then to anything *.dmg the artifact contains.
+          DMG=$(find "$RUNNER_TEMP/release-artifact" -maxdepth 2 -name '*-arm64.dmg' | head -n 1)
+          if [ -z "$DMG" ]; then
+            DMG=$(find "$RUNNER_TEMP/release-artifact" -maxdepth 2 -name '*-universal.dmg' | head -n 1)
+          fi
+          if [ -z "$DMG" ]; then
+            DMG=$(find "$RUNNER_TEMP/release-artifact" -maxdepth 2 -name '*.dmg' | head -n 1)
+          fi
+          if [ -z "$DMG" ]; then
+            echo "::error::No .dmg found in downloaded artifact"
+            find "$RUNNER_TEMP/release-artifact" -maxdepth 3 -type f | head -50
+            exit 1
+          fi
+          echo "Selected DMG: $DMG"
+          MOUNT="$RUNNER_TEMP/dmg-mount"
+          mkdir -p "$MOUNT"
+          hdiutil attach -nobrowse -readonly -mountpoint "$MOUNT" "$DMG"
+          APP_SRC=$(find "$MOUNT" -maxdepth 2 -name '*.app' | head -n 1)
+          if [ -z "$APP_SRC" ]; then
+            echo "::error::No .app bundle found inside DMG"
+            ls -la "$MOUNT" || true
+            hdiutil detach "$MOUNT" || true
+            exit 1
+          fi
+          APP_DST="$RUNNER_TEMP/Daintree.app"
+          cp -R "$APP_SRC" "$APP_DST"
+          hdiutil detach "$MOUNT"
+          # Headless CI can't dismiss a Gatekeeper prompt; clearing quarantine
+          # is required even when the app is notarized.
+          xattr -rd com.apple.quarantine "$APP_DST" || true
+          BIN="$APP_DST/Contents/MacOS/Daintree"
+          if [ ! -x "$BIN" ]; then
+            echo "::error::Expected executable missing at $BIN"
+            ls -la "$APP_DST/Contents/MacOS" || true
+            exit 1
+          fi
+          echo "packaged_binary=$BIN" >> "$GITHUB_OUTPUT"
+
+      - name: Run packaged smoke
+        env:
+          PACKAGED_BINARY: ${{ steps.extract.outputs.packaged_binary }}
+        run: node scripts/run-packaged-smoke.mjs
+
   publish-daintree:
     if: startsWith(github.ref, 'refs/tags/v') && inputs.dry_run != true
-    needs: [build-daintree]
+    needs: [build-daintree, smoke-packaged]
     runs-on: ubuntu-22.04
     timeout-minutes: 15
 

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -306,16 +306,18 @@ jobs:
           MOUNT="$RUNNER_TEMP/dmg-mount"
           mkdir -p "$MOUNT"
           hdiutil attach -nobrowse -readonly -mountpoint "$MOUNT" "$DMG"
+          # Ensure the mount is detached even if cp -R fails partway through;
+          # without the trap a failed copy strands the device and the next
+          # release run on a reusable runner would collide on the mountpoint.
+          trap 'hdiutil detach "$MOUNT" 2>/dev/null || true' EXIT
           APP_SRC=$(find "$MOUNT" -maxdepth 2 -name '*.app' | head -n 1)
           if [ -z "$APP_SRC" ]; then
             echo "::error::No .app bundle found inside DMG"
             ls -la "$MOUNT" || true
-            hdiutil detach "$MOUNT" || true
             exit 1
           fi
           APP_DST="$RUNNER_TEMP/Daintree.app"
           cp -R "$APP_SRC" "$APP_DST"
-          hdiutil detach "$MOUNT"
           # Headless CI can't dismiss a Gatekeeper prompt; clearing quarantine
           # is required even when the app is notarized.
           xattr -rd com.apple.quarantine "$APP_DST" || true

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -298,9 +298,92 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+  # Packaged-artifact smoke (#9246) — runs the freshly-built NSIS installer
+  # silently, locates the installed Daintree.exe via the per-user uninstall
+  # registry entry (with a fixed-path fallback), and launches it in
+  # --smoke-test mode. Validates the four native modules including
+  # win-job-object (asar.unpacked native that doesn't ship a prebuilt and so
+  # is uniquely at risk if cross-compile for arm64 fails silently). Gates
+  # publish.
+  smoke-packaged:
+    needs: [build-daintree]
+    name: Smoke (packaged NSIS)
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: ./.github/actions/checkout-shallow
+
+      - name: Set up Node.js and install dependencies
+        uses: ./.github/actions/setup-node-install
+        with:
+          node_version: ${{ env.NODE_VERSION }}
+          msvs_version: "2022"
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: release-daintree-windows-latest
+          path: ${{ runner.temp }}/release-artifact
+
+      - name: Install NSIS package
+        id: extract
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $installer = Get-ChildItem -Path "$env:RUNNER_TEMP\release-artifact" -Recurse -Filter '*.exe' |
+            Select-Object -First 1
+          if (-not $installer) {
+            Write-Host "::error::No NSIS .exe found in downloaded artifact"
+            Get-ChildItem -Path "$env:RUNNER_TEMP\release-artifact" -Recurse | Select-Object -First 30 | ForEach-Object { Write-Host $_.FullName }
+            exit 1
+          }
+          Write-Host "Selected installer: $($installer.FullName)"
+          # /S — silent NSIS install. perMachine=false in electron-builder
+          # config means the installer lands under %LOCALAPPDATA%\Programs.
+          $proc = Start-Process -FilePath $installer.FullName -ArgumentList '/S' -PassThru -Wait
+          if ($proc.ExitCode -ne 0) {
+            Write-Host "::error::Silent NSIS install failed with exit code $($proc.ExitCode)"
+            exit $proc.ExitCode
+          }
+          # Locate the install via the per-user uninstall registry entry; fall
+          # back to the default path electron-builder uses when the user
+          # doesn't change it.
+          $entry = Get-ChildItem 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall' -ErrorAction SilentlyContinue |
+            ForEach-Object { Get-ItemProperty $_.PSPath -ErrorAction SilentlyContinue } |
+            Where-Object { $_.DisplayName -eq 'Daintree' } |
+            Select-Object -First 1
+          $installDir = $null
+          if ($entry -and $entry.InstallLocation) {
+            $installDir = $entry.InstallLocation
+          }
+          if (-not $installDir -or -not (Test-Path $installDir)) {
+            $fallback = Join-Path $env:LOCALAPPDATA 'Programs\Daintree'
+            if (Test-Path $fallback) {
+              $installDir = $fallback
+            }
+          }
+          if (-not $installDir) {
+            Write-Host "::error::Could not locate Daintree install directory after silent NSIS install"
+            exit 1
+          }
+          $bin = Join-Path $installDir 'Daintree.exe'
+          if (-not (Test-Path $bin)) {
+            Write-Host "::error::Expected Daintree.exe missing at $bin"
+            Get-ChildItem $installDir -Recurse -Depth 2 -ErrorAction SilentlyContinue | ForEach-Object { Write-Host $_.FullName }
+            exit 1
+          }
+          Write-Host "Resolved packaged binary: $bin"
+          "packaged_binary=$bin" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Run packaged smoke
+        env:
+          PACKAGED_BINARY: ${{ steps.extract.outputs.packaged_binary }}
+        run: node scripts/run-packaged-smoke.mjs
+
   publish-daintree:
     if: startsWith(github.ref, 'refs/tags/v') && inputs.dry_run != true
-    needs: [build-daintree]
+    needs: [build-daintree, smoke-packaged]
     runs-on: ubuntu-22.04
     timeout-minutes: 15
 

--- a/electron/native/posix-pty-reaper/index.d.ts
+++ b/electron/native/posix-pty-reaper/index.d.ts
@@ -1,0 +1,2 @@
+export function getSupervisorPath(): string | null;
+export function isAvailable(): boolean;

--- a/electron/native/win-job-object/index.d.ts
+++ b/electron/native/win-job-object/index.d.ts
@@ -1,0 +1,3 @@
+export function assignProcessToHelpJob(pid: number): boolean;
+export function isAvailable(): boolean;
+export function getLoadError(): unknown;

--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -649,6 +649,57 @@ if (isSmokeTest) {
     console.error("[SMOKE] FAILED — better-sqlite3 native module:", (err as Error).message);
     app.exit(1);
   }
+
+  // Verify win-job-object on Windows: the .node binding loaded AND the
+  // critical assignProcessToHelpJob() call path works. Adding the current
+  // process to a Job Object is safe on CI runners — they're ordinary Windows
+  // processes — and proves the kernel object can be created and assigned.
+  if (process.platform === "win32") {
+    try {
+      const mod = (await import("win-job-object")) as {
+        isAvailable: () => boolean;
+        assignProcessToHelpJob: (pid: number) => boolean;
+        getLoadError?: () => unknown;
+      };
+      if (!mod.isAvailable()) {
+        const loadErr = mod.getLoadError?.();
+        throw new Error(
+          `win-job-object binding not loaded${loadErr ? `: ${String(loadErr)}` : ""}`
+        );
+      }
+      if (!mod.assignProcessToHelpJob(process.pid)) {
+        throw new Error("assignProcessToHelpJob returned false");
+      }
+      console.error("[SMOKE] CHECK: win-job-object native module — OK");
+    } catch (err) {
+      console.error("[SMOKE] FAILED — win-job-object native module:", (err as Error).message);
+      app.exit(1);
+    }
+  }
+
+  // Verify posix-pty-reaper on macOS / Linux: isAvailable() resolves the
+  // supervisor path and confirms the compiled binary is present and
+  // executable (uses fs.accessSync with X_OK internally).
+  if (process.platform === "darwin" || process.platform === "linux") {
+    try {
+      const mod = (await import("posix-pty-reaper")) as {
+        getSupervisorPath: () => string | null;
+        isAvailable: () => boolean;
+      };
+      if (!mod.isAvailable()) {
+        const supervisorPath = mod.getSupervisorPath();
+        throw new Error(
+          `supervisor binary missing or not executable${
+            supervisorPath ? ` at ${supervisorPath}` : ""
+          }`
+        );
+      }
+      console.error("[SMOKE] CHECK: posix-pty-reaper native module — OK");
+    } catch (err) {
+      console.error("[SMOKE] FAILED — posix-pty-reaper native module:", (err as Error).message);
+      app.exit(1);
+    }
+  }
 }
 
 app.enableSandbox();

--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -650,10 +650,15 @@ if (isSmokeTest) {
     app.exit(1);
   }
 
-  // Verify win-job-object on Windows: the .node binding loaded AND the
-  // critical assignProcessToHelpJob() call path works. Adding the current
-  // process to a Job Object is safe on CI runners — they're ordinary Windows
-  // processes — and proves the kernel object can be created and assigned.
+  // Verify win-job-object on Windows: the .node binding loaded. The
+  // assignProcessToHelpJob(process.pid) call path is exercised too, but its
+  // false return is non-fatal — production code (HelpSessionJobService)
+  // treats it as a warning + graceful degradation, and the native source
+  // explicitly notes ERROR_ACCESS_DENIED in CI/MDM environments where the
+  // runner already wraps the process in a non-nesting-compatible job.
+  // We promote the binding-load check to a hard requirement and demote
+  // assign failure to a one-line note so the smoke isn't more strict than
+  // the running app.
   if (process.platform === "win32") {
     try {
       const mod = (await import("win-job-object")) as {
@@ -667,10 +672,14 @@ if (isSmokeTest) {
           `win-job-object binding not loaded${loadErr ? `: ${String(loadErr)}` : ""}`
         );
       }
-      if (!mod.assignProcessToHelpJob(process.pid)) {
-        throw new Error("assignProcessToHelpJob returned false");
+      const assigned = mod.assignProcessToHelpJob(process.pid);
+      if (assigned) {
+        console.error("[SMOKE] CHECK: win-job-object native module — OK");
+      } else {
+        console.error(
+          "[SMOKE] CHECK: win-job-object native module — OK (binding loaded; assign degraded — CI/MDM may already hold a non-nesting job)"
+        );
       }
-      console.error("[SMOKE] CHECK: win-job-object native module — OK");
     } catch (err) {
       console.error("[SMOKE] FAILED — win-job-object native module:", (err as Error).message);
       app.exit(1);

--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -661,11 +661,7 @@ if (isSmokeTest) {
   // the running app.
   if (process.platform === "win32") {
     try {
-      const mod = (await import("win-job-object")) as {
-        isAvailable: () => boolean;
-        assignProcessToHelpJob: (pid: number) => boolean;
-        getLoadError?: () => unknown;
-      };
+      const mod = await import("win-job-object");
       if (!mod.isAvailable()) {
         const loadErr = mod.getLoadError?.();
         throw new Error(
@@ -691,10 +687,7 @@ if (isSmokeTest) {
   // executable (uses fs.accessSync with X_OK internally).
   if (process.platform === "darwin" || process.platform === "linux") {
     try {
-      const mod = (await import("posix-pty-reaper")) as {
-        getSupervisorPath: () => string | null;
-        isAvailable: () => boolean;
-      };
+      const mod = await import("posix-pty-reaper");
       if (!mod.isAvailable()) {
         const supervisorPath = mod.getSupervisorPath();
         throw new Error(

--- a/scripts/run-packaged-smoke.mjs
+++ b/scripts/run-packaged-smoke.mjs
@@ -1,0 +1,226 @@
+/**
+ * Packaged-artifact smoke runner — gates per-OS release publish (#9246).
+ *
+ * Launches the already-installed/extracted Daintree binary in --smoke-test
+ * mode and validates that the same stability markers emitted by
+ * electron/setup/environment.ts and electron/services/smokeTest.ts are
+ * present. Unlike scripts/run-smoke.mjs (which uses require('electron') to
+ * launch the dev binary against the build output in dist/), this runner
+ * takes the path to the actually-shipped binary via the PACKAGED_BINARY env
+ * var so it exercises the asar payload, asar.unpacked native modules, and
+ * codesigning that real users see.
+ *
+ * Expected markers cover the four native modules: node-pty,
+ * better-sqlite3, win-job-object (Windows only), and posix-pty-reaper
+ * (macOS / Linux only).
+ */
+
+import { spawn } from "child_process";
+import { mkdtemp, rm } from "fs/promises";
+import os from "os";
+import path from "path";
+import url from "url";
+
+const BASE_REQUIRED_MARKERS = [
+  "[SMOKE] CHECK: node-pty native module",
+  "[SMOKE] CHECK: better-sqlite3 native module",
+  "[SMOKE] CHECK: Renderer did-finish-load",
+  "[SMOKE] CHECK: Renderer + IPC bridge",
+  "[SMOKE] CHECK: Terminal stress rounds",
+  "[SMOKE] CHECK: Project persistence stress",
+  "[SMOKE] Stability soak complete",
+];
+
+export function buildRequiredMarkers(platform) {
+  const markers = [...BASE_REQUIRED_MARKERS];
+  if (platform === "win32") {
+    markers.push("[SMOKE] CHECK: win-job-object native module");
+  } else if (platform === "darwin" || platform === "linux") {
+    markers.push("[SMOKE] CHECK: posix-pty-reaper native module");
+  }
+  return markers;
+}
+
+export function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function runPackagedSmokeOnce({ binaryPath, runIndex, runCount, timeoutMs, extraArgs }) {
+  return new Promise((resolve, reject) => {
+    mkdtemp(path.join(os.tmpdir(), "daintree-packaged-smoke-"))
+      .then((userDataDir) => {
+        const args = [
+          "--smoke-test",
+          "--disable-gpu",
+          "--disable-software-rasterizer",
+          "--noerrdialogs",
+          `--user-data-dir=${userDataDir}`,
+          ...extraArgs,
+        ];
+        if (process.platform === "linux") {
+          args.push("--no-sandbox");
+        }
+
+        console.log(`[PACKAGED-SMOKE] Run ${runIndex}/${runCount}: launching ${binaryPath}`);
+
+        const env = {
+          ...process.env,
+          NODE_ENV: "production",
+        };
+        delete env.ELECTRON_RUN_AS_NODE;
+        delete env.ATOM_SHELL_INTERNAL_RUN_AS_NODE;
+
+        const child = spawn(binaryPath, args, {
+          env,
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+
+        let timedOut = false;
+        let output = "";
+        let hardKillTimer;
+
+        const cleanup = async () => {
+          clearTimeout(timeoutTimer);
+          if (hardKillTimer) clearTimeout(hardKillTimer);
+          await rm(userDataDir, { recursive: true, force: true });
+        };
+
+        const timeoutTimer = setTimeout(() => {
+          timedOut = true;
+          console.error(
+            `[PACKAGED-SMOKE] Run ${runIndex}/${runCount}: timed out after ${timeoutMs}ms`
+          );
+          child.kill();
+          hardKillTimer = setTimeout(() => child.kill("SIGKILL"), 5_000);
+        }, timeoutMs);
+        timeoutTimer.unref();
+
+        child.stdout?.on("data", (chunk) => {
+          const text = chunk.toString();
+          output += text;
+          process.stdout.write(text);
+        });
+
+        child.stderr?.on("data", (chunk) => {
+          const text = chunk.toString();
+          output += text;
+          process.stderr.write(text);
+        });
+
+        child.on("error", async (error) => {
+          await cleanup();
+          reject(error);
+        });
+
+        child.on("close", async (code, signal) => {
+          await cleanup();
+          resolve({ code, signal, output, timedOut });
+        });
+      })
+      .catch(reject);
+  });
+}
+
+export function validateSmokeOutput(runIndex, runCount, result, requiredMarkers) {
+  const { code, signal, output, timedOut } = result;
+  if (timedOut) {
+    throw new Error(`Packaged smoke run ${runIndex}/${runCount} timed out`);
+  }
+  if (code !== 0) {
+    throw new Error(
+      `Packaged smoke run ${runIndex}/${runCount} failed with code ${code} (signal ${signal})`
+    );
+  }
+  if (output.includes("[SMOKE] FAILED")) {
+    throw new Error(`Packaged smoke run ${runIndex}/${runCount} reported a smoke failure`);
+  }
+  for (const marker of requiredMarkers) {
+    if (!output.includes(marker)) {
+      throw new Error(
+        `Packaged smoke run ${runIndex}/${runCount} missing expected marker: ${marker}`
+      );
+    }
+  }
+}
+
+async function main() {
+  const binaryPath = process.env.PACKAGED_BINARY?.trim();
+  if (!binaryPath) {
+    throw new Error("PACKAGED_BINARY env var is required");
+  }
+  // We deliberately do NOT fs.statSync here — on the CI Linux runner the
+  // AppRun entry point is a symlink/launcher resolved by AppImage tooling,
+  // and the spawn() failure path already produces a clear error if the
+  // path is wrong. Validating presence inline would force per-platform
+  // resolve logic into this script that's better expressed in the
+  // workflow's discovery step.
+
+  const runCount = parsePositiveInt(process.env.SMOKE_RUNS, 1);
+  const retries = Number.parseInt(process.env.SMOKE_RETRIES ?? "", 10);
+  const retriesPerRun = Number.isFinite(retries) && retries >= 0 ? retries : 0;
+  const timeoutMs = parsePositiveInt(process.env.SMOKE_TIMEOUT_MS, 240_000);
+  const extraArgs = (process.env.SMOKE_EXTRA_ARGS ?? "")
+    .split(/\s+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  const requiredMarkers = buildRequiredMarkers(process.platform);
+
+  for (let i = 1; i <= runCount; i++) {
+    const maxAttempts = retriesPerRun + 1;
+    let lastError;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        const result = await runPackagedSmokeOnce({
+          binaryPath,
+          runIndex: i,
+          runCount,
+          timeoutMs,
+          extraArgs,
+        });
+        validateSmokeOutput(i, runCount, result, requiredMarkers);
+        if (attempt > 1) {
+          console.log(
+            `[PACKAGED-SMOKE] Run ${i}/${runCount}: PASS (on attempt ${attempt}/${maxAttempts})`
+          );
+        } else {
+          console.log(`[PACKAGED-SMOKE] Run ${i}/${runCount}: PASS`);
+        }
+        lastError = undefined;
+        break;
+      } catch (error) {
+        lastError = error;
+        const message = error instanceof Error ? error.message : String(error);
+        if (attempt < maxAttempts) {
+          console.warn(
+            `[PACKAGED-SMOKE] Run ${i}/${runCount}: attempt ${attempt}/${maxAttempts} failed — retrying. Cause: ${message}`
+          );
+        } else {
+          console.error(
+            `[PACKAGED-SMOKE] Run ${i}/${runCount}: exhausted ${maxAttempts} attempt(s). Last cause: ${message}`
+          );
+        }
+      }
+    }
+    if (lastError) {
+      throw lastError;
+    }
+  }
+
+  console.log(
+    `[PACKAGED-SMOKE] All ${runCount} packaged smoke run(s) passed (up to ${retriesPerRun} retry/retries per run)`
+  );
+}
+
+const invokedDirectly =
+  process.argv[1] && import.meta.url === url.pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main().catch((error) => {
+    console.error(
+      "[PACKAGED-SMOKE] FAILED:",
+      error instanceof Error ? error.message : String(error)
+    );
+    process.exit(1);
+  });
+}

--- a/scripts/run-packaged-smoke.mjs
+++ b/scripts/run-packaged-smoke.mjs
@@ -83,7 +83,20 @@ function runPackagedSmokeOnce({ binaryPath, runIndex, runCount, timeoutMs, extra
         const cleanup = async () => {
           clearTimeout(timeoutTimer);
           if (hardKillTimer) clearTimeout(hardKillTimer);
-          await rm(userDataDir, { recursive: true, force: true });
+          // Swallow rm failures (Windows file locks held by a slow-exit
+          // child are the common case). Letting cleanup() throw would
+          // leave the outer Promise unresolved and hang the job until the
+          // workflow-level timeout fires — the temp dir is in $TMPDIR
+          // and the runner is ephemeral, so a stale dir is harmless.
+          try {
+            await rm(userDataDir, { recursive: true, force: true });
+          } catch (rmErr) {
+            console.warn(
+              `[PACKAGED-SMOKE] Cleanup: failed to remove ${userDataDir}: ${
+                rmErr instanceof Error ? rmErr.message : String(rmErr)
+              }`
+            );
+          }
         };
 
         const timeoutTimer = setTimeout(() => {

--- a/scripts/run-packaged-smoke.test.mjs
+++ b/scripts/run-packaged-smoke.test.mjs
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildRequiredMarkers,
+  parsePositiveInt,
+  validateSmokeOutput,
+} from "./run-packaged-smoke.mjs";
+
+const SHARED_MARKERS = [
+  "[SMOKE] CHECK: node-pty native module",
+  "[SMOKE] CHECK: better-sqlite3 native module",
+  "[SMOKE] CHECK: Renderer did-finish-load",
+  "[SMOKE] CHECK: Renderer + IPC bridge",
+  "[SMOKE] CHECK: Terminal stress rounds",
+  "[SMOKE] CHECK: Project persistence stress",
+  "[SMOKE] Stability soak complete",
+];
+
+function fullOutputFor(platform) {
+  return buildRequiredMarkers(platform).join("\n") + "\n";
+}
+
+describe("buildRequiredMarkers", () => {
+  it.each(["win32", "darwin", "linux"])("includes every shared marker on %s", (platform) => {
+    const markers = buildRequiredMarkers(platform);
+    for (const shared of SHARED_MARKERS) {
+      expect(markers).toContain(shared);
+    }
+  });
+
+  it("adds win-job-object on Windows and omits posix-pty-reaper", () => {
+    const markers = buildRequiredMarkers("win32");
+    expect(markers).toContain("[SMOKE] CHECK: win-job-object native module");
+    expect(markers).not.toContain("[SMOKE] CHECK: posix-pty-reaper native module");
+  });
+
+  it.each(["darwin", "linux"])(
+    "adds posix-pty-reaper on %s and omits win-job-object",
+    (platform) => {
+      const markers = buildRequiredMarkers(platform);
+      expect(markers).toContain("[SMOKE] CHECK: posix-pty-reaper native module");
+      expect(markers).not.toContain("[SMOKE] CHECK: win-job-object native module");
+    }
+  );
+
+  it("emits no platform-specific reaper marker for unknown platforms", () => {
+    const markers = buildRequiredMarkers("aix");
+    expect(markers).not.toContain("[SMOKE] CHECK: win-job-object native module");
+    expect(markers).not.toContain("[SMOKE] CHECK: posix-pty-reaper native module");
+  });
+});
+
+describe("parsePositiveInt", () => {
+  it("returns parsed value when positive integer", () => {
+    expect(parsePositiveInt("5", 1)).toBe(5);
+  });
+
+  it("returns fallback for non-numeric strings", () => {
+    expect(parsePositiveInt("abc", 7)).toBe(7);
+  });
+
+  it("returns fallback for negative numbers", () => {
+    expect(parsePositiveInt("-3", 4)).toBe(4);
+  });
+
+  it("returns fallback for zero", () => {
+    expect(parsePositiveInt("0", 9)).toBe(9);
+  });
+
+  it("returns fallback for undefined input", () => {
+    expect(parsePositiveInt(undefined, 42)).toBe(42);
+  });
+});
+
+describe("validateSmokeOutput", () => {
+  it("passes when every required marker is present and exit code is 0", () => {
+    const markers = buildRequiredMarkers("linux");
+    const result = {
+      code: 0,
+      signal: null,
+      output: fullOutputFor("linux"),
+      timedOut: false,
+    };
+    expect(() => validateSmokeOutput(1, 1, result, markers)).not.toThrow();
+  });
+
+  it("throws when the run timed out", () => {
+    expect(() =>
+      validateSmokeOutput(
+        2,
+        3,
+        { code: null, signal: null, output: "", timedOut: true },
+        SHARED_MARKERS
+      )
+    ).toThrow(/timed out/);
+  });
+
+  it("throws on non-zero exit code", () => {
+    expect(() =>
+      validateSmokeOutput(
+        1,
+        1,
+        { code: 1, signal: null, output: fullOutputFor("linux"), timedOut: false },
+        buildRequiredMarkers("linux")
+      )
+    ).toThrow(/failed with code 1/);
+  });
+
+  it("throws when output contains [SMOKE] FAILED", () => {
+    const output = fullOutputFor("linux") + "[SMOKE] FAILED — something broke\n";
+    expect(() =>
+      validateSmokeOutput(
+        1,
+        1,
+        { code: 0, signal: null, output, timedOut: false },
+        buildRequiredMarkers("linux")
+      )
+    ).toThrow(/reported a smoke failure/);
+  });
+
+  it("throws when a required marker is missing", () => {
+    const markers = buildRequiredMarkers("linux");
+    const output = markers
+      .filter((m) => m !== "[SMOKE] CHECK: posix-pty-reaper native module")
+      .join("\n");
+    expect(() =>
+      validateSmokeOutput(1, 1, { code: 0, signal: null, output, timedOut: false }, markers)
+    ).toThrow(/missing expected marker.*posix-pty-reaper/);
+  });
+});

--- a/scripts/run-smoke.mjs
+++ b/scripts/run-smoke.mjs
@@ -33,6 +33,7 @@ const BUILD_ARTIFACTS = [
 
 const REQUIRED_MARKERS = [
   "[SMOKE] CHECK: node-pty native module",
+  "[SMOKE] CHECK: better-sqlite3 native module",
   "[SMOKE] CHECK: Renderer did-finish-load",
   "[SMOKE] CHECK: Renderer + IPC bridge",
   "[SMOKE] CHECK: Terminal stress rounds",


### PR DESCRIPTION
## Summary

- Adds a `smoke-packaged` job to `release-linux.yml`, `release-macos.yml`, and `release-windows.yml` that runs the freshly-built installer, launches the installed binary with `--smoke-test`, and validates required output markers before `publish-daintree` is allowed to proceed
- Adds `scripts/run-packaged-smoke.mjs` with full platform-conditional marker logic, plus 17 unit tests in `scripts/run-packaged-smoke.test.mjs` covering `buildRequiredMarkers`, `parsePositiveInt`, and `validateSmokeOutput` pass/fail paths
- Extends `electron/setup/environment.ts` to validate `win-job-object` (Windows; assign-pid demoted to warning to match CI/MDM environments) and `posix-pty-reaper` (macOS/Linux) alongside the existing `node-pty` and `better-sqlite3` checks

Resolves #9246

## Changes

- `release-linux.yml` -- `--appimage-extract` then `xvfb-run AppRun --smoke-test`
- `release-macos.yml` -- `hdiutil attach` DMG (arm64-first), `cp .app`, `xattr -rd com.apple.quarantine`, `trap` detach on EXIT
- `release-windows.yml` -- silent NSIS `/S` install, locate path via `HKCU` uninstall registry with `%LOCALAPPDATA%` fallback
- `scripts/run-packaged-smoke.mjs` -- new launcher script; `PACKAGED_BINARY` env selects the binary, platform-conditional `REQUIRED_MARKERS` gate the result
- `scripts/run-packaged-smoke.test.mjs` -- 17 vitest unit tests, all passing
- `electron/setup/environment.ts` -- validates all four native bindings in `--smoke-test` mode
- `scripts/run-smoke.mjs` -- fixes a missed `better-sqlite3` marker that was emitted but never validated
- `electron/native/win-job-object/index.d.ts`, `electron/native/posix-pty-reaper/index.d.ts` -- adds type declarations for the two in-tree native modules

## Testing

- 17 unit tests pass (`npm run test -- scripts/run-packaged-smoke.test.mjs`)
- `npm run check` clean (typecheck + lint + format, 0 errors)
- Smoke logic validated against the existing dev-mode `--smoke-test` path in `environment.ts`
- Per-OS install/extract steps mirror patterns from existing CI jobs and have been reviewed against platform tooling docs (`hdiutil`, NSIS, AppImage spec)