### PR TITLE
fix(a11y): close before announce to fix VoiceOver in aria-modal dialogs

### DIFF
--- a/src/components/Browser/WebviewDialog.tsx
+++ b/src/components/Browser/WebviewDialog.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useId } from "react";
+import { AccessibilityAnnouncer } from "@/components/Accessibility/AccessibilityAnnouncer";
 
 const TABBABLE_SELECTOR =
   'a[href], area[href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), audio[controls], video[controls], [contenteditable]:not([contenteditable="false"]), [tabindex]:not([tabindex^="-"])';
@@ -160,6 +161,10 @@ export function WebviewDialog({ dialog, onRespond }: WebviewDialogProps) {
             OK
           </button>
         </div>
+
+        {/* Co-located so store-dispatched announcements reach VoiceOver while
+            this aria-modal subtree holds focus (Chromium 354736464). */}
+        <AccessibilityAnnouncer />
       </div>
     </div>
   );

--- a/src/components/Browser/__tests__/WebviewDialog.test.tsx
+++ b/src/components/Browser/__tests__/WebviewDialog.test.tsx
@@ -117,4 +117,19 @@ describe("WebviewDialog accessibility", () => {
     const labelEl = container.querySelector(`[id="${describedBy}"]`);
     expect(labelEl?.textContent).toBe("Enter a value");
   });
+
+  // VoiceOver drops live-region updates from outside the focused aria-modal
+  // subtree (Chromium 354736464), so a co-located announcer is required here.
+  it("co-locates non-focusable live regions inside the aria-modal panel", () => {
+    const { container } = render(<WebviewDialog dialog={baseAlert} onRespond={vi.fn()} />);
+    const panel = container.querySelector('[aria-modal="true"]');
+    expect(panel).not.toBeNull();
+    expect(panel!.querySelector('[aria-live="polite"]')).not.toBeNull();
+    expect(panel!.querySelector('[aria-live="assertive"]')).not.toBeNull();
+
+    for (const region of panel!.querySelectorAll("[aria-live]")) {
+      const tabindex = region.getAttribute("tabindex");
+      expect(tabindex === null || Number(tabindex) < 0).toBe(true);
+    }
+  });
 });

--- a/src/components/Layout/BackgroundContainer.tsx
+++ b/src/components/Layout/BackgroundContainer.tsx
@@ -8,7 +8,7 @@ import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { cn } from "@/lib/utils";
 import { usePanelStore } from "@/store";
 import type { PtyPanelData } from "@shared/types/panel";
-import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+import { closeAndAnnounce } from "@/lib/accessibility";
 import type { TrashedTerminalGroupMetadata } from "@/store/slices";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useBackgroundedTerminals } from "@/hooks/useTerminalSelectors";
@@ -222,13 +222,10 @@ export function BackgroundContainer({ compact = false }: BackgroundContainerProp
     if (killConfirmId) {
       const target = terminals.find((t) => t.id === killConfirmId);
       removePanel(killConfirmId);
-      // Close the confirm dialog first so the announce reaches AT after focus
-      // returns to the main tree (VoiceOver suppresses live-region updates
-      // from outside the active modal subtree).
-      setKillConfirmId(null);
-      useAnnouncerStore
-        .getState()
-        .announce(target?.title ? `${target.title} killed` : "Terminal killed");
+      closeAndAnnounce(
+        () => setKillConfirmId(null),
+        target?.title ? `${target.title} killed` : "Terminal killed"
+      );
       return;
     }
     setKillConfirmId(null);

--- a/src/components/Layout/WaitingContainer.tsx
+++ b/src/components/Layout/WaitingContainer.tsx
@@ -8,7 +8,7 @@ import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { cn } from "@/lib/utils";
 import { usePanelStore } from "@/store";
 import type { PtyPanelData } from "@shared/types/panel";
-import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+import { closeAndAnnounce } from "@/lib/accessibility";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useWaitingTerminals } from "@/hooks/useTerminalSelectors";
 import { useWorktrees } from "@/hooks/useWorktrees";
@@ -144,13 +144,10 @@ export function WaitingContainer({ compact = false }: WaitingContainerProps) {
     if (killConfirmId) {
       const target = terminals.find((t) => t.id === killConfirmId);
       removePanel(killConfirmId);
-      // Close the confirm dialog first so the announce reaches AT after focus
-      // returns to the main tree (VoiceOver suppresses live-region updates
-      // from outside the active modal subtree).
-      setKillConfirmId(null);
-      useAnnouncerStore
-        .getState()
-        .announce(target?.title ? `${target.title} killed` : "Terminal killed");
+      closeAndAnnounce(
+        () => setKillConfirmId(null),
+        target?.title ? `${target.title} killed` : "Terminal killed"
+      );
       return;
     }
     setKillConfirmId(null);

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -13,7 +13,7 @@ import { isBrowserPanel, isDevPreviewPanel, isPtyPanel, isReviewPanel } from "@s
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { useIsHibernated } from "@/hooks/useIsHibernated";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
-import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+import { closeAndAnnounce } from "@/lib/accessibility";
 import { terminalHasRunningAgentSession } from "@/utils/destructiveSessionConfirm";
 import {
   ArrowDownFromLine,
@@ -383,11 +383,7 @@ export function TerminalContextMenu({
       { terminalId, confirmed: true },
       { source: sourceRef.current }
     );
-    // Close the dialog first so the announce fires after focus returns to the
-    // main tree — VoiceOver suppresses live-region updates from outside the
-    // current modal subtree while focus is trapped.
-    setDestructiveConfirm(null);
-    useAnnouncerStore.getState().announce(announcement);
+    closeAndAnnounce(() => setDestructiveConfirm(null), announcement);
   }, [destructiveConfirm, terminalId]);
 
   const closeDestructiveConfirm = useCallback(() => {

--- a/src/components/Terminal/TerminalDestructiveActionConfirmDialog.tsx
+++ b/src/components/Terminal/TerminalDestructiveActionConfirmDialog.tsx
@@ -1,7 +1,7 @@
 import { type ReactElement, useCallback } from "react";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { actionService } from "@/services/ActionService";
-import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+import { closeAndAnnounce } from "@/lib/accessibility";
 import {
   useTerminalPendingDestructiveActionStore,
   type TerminalPendingDestructiveActionSnapshot,
@@ -154,12 +154,10 @@ export function TerminalDestructiveActionConfirmDialog(): ReactElement | null {
         break;
       }
     }
-    // Close the dialog first so the announce fires after focus returns to
-    // the main tree — VoiceOver suppresses live-region updates from outside
-    // the current modal subtree while focus is trapped.
-    clear();
     if (announcement) {
-      useAnnouncerStore.getState().announce(announcement);
+      closeAndAnnounce(clear, announcement);
+    } else {
+      clear();
     }
   }, [pending, clear]);
 

--- a/src/components/ThemeBrowser/ThemeBrowser.tsx
+++ b/src/components/ThemeBrowser/ThemeBrowser.tsx
@@ -14,6 +14,7 @@ import {
   resolveAppTheme,
 } from "@shared/theme";
 import { PaletteStrip } from "@/components/ui/PaletteStrip";
+import { AccessibilityAnnouncer } from "@/components/Accessibility/AccessibilityAnnouncer";
 import type { AppColorScheme, AppThemeValidationWarning } from "@shared/types/appTheme";
 import { useEscapeStack } from "@/hooks/useEscapeStack";
 import { useOverlayClaim, useImageError } from "@/hooks";
@@ -580,6 +581,10 @@ export function ThemeBrowser() {
       <div aria-live="polite" aria-atomic="true" className="sr-only">
         {previewAnnouncement}
       </div>
+
+      {/* Co-located so store-dispatched announcements reach VoiceOver while
+          this aria-modal subtree holds focus (Chromium 354736464). */}
+      <AccessibilityAnnouncer />
     </div>
   );
 }

--- a/src/components/ThemeBrowser/__tests__/ThemeBrowser.test.tsx
+++ b/src/components/ThemeBrowser/__tests__/ThemeBrowser.test.tsx
@@ -65,6 +65,25 @@ describe("ThemeBrowser", () => {
     useUIStore.setState({ overlayStack: [] });
   });
 
+  // VoiceOver drops live-region updates from outside the focused aria-modal
+  // subtree (Chromium 354736464), so a co-located announcer is required here.
+  it("co-locates non-focusable announcer live regions inside the aria-modal subtree", () => {
+    const { container } = render(<Harness />);
+    const modal = container.querySelector('[aria-modal="true"]');
+    expect(modal).not.toBeNull();
+
+    // AccessibilityAnnouncer contributes the only assertive region; the
+    // existing preview region is polite-only.
+    expect(modal!.querySelectorAll('[aria-live="assertive"]').length).toBe(1);
+    // Preview region (polite) + AccessibilityAnnouncer's polite region.
+    expect(modal!.querySelectorAll('[aria-live="polite"]').length).toBe(2);
+
+    for (const region of modal!.querySelectorAll("[aria-live]")) {
+      const tabindex = region.getAttribute("tabindex");
+      expect(tabindex === null || Number(tabindex) < 0).toBe(true);
+    }
+  });
+
   it("clicking a theme row sets previewSchemeId instantly (no debounce)", () => {
     const target = otherDarkScheme();
     render(<Harness />);

--- a/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
@@ -5,7 +5,7 @@ import { actionService } from "@/services/ActionService";
 import { useMenuActionSource } from "@/components/ui/menu-source";
 import { useRecipeStore } from "@/store/recipeStore";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
-import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+import { closeAndAnnounce } from "@/lib/accessibility";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 
 export type ConfirmDialogState =
@@ -245,10 +245,7 @@ export function useWorktreeActions({
           { worktreeId: worktree.id, confirmed: true },
           { source: "user" }
         );
-        // Close before announce — see VoiceOver modal-scoping note in
-        // TerminalContextMenu.handleDestructiveConfirm.
-        setConfirmDialog({ isOpen: false });
-        useAnnouncerStore.getState().announce("Trashed all sessions");
+        closeAndAnnounce(() => setConfirmDialog({ isOpen: false }), "Trashed all sessions");
       },
     });
   }, [worktree.id, worktree.issueTitle, worktree.branch]);
@@ -268,10 +265,7 @@ export function useWorktreeActions({
           { worktreeId: worktree.id },
           { source: "user" }
         );
-        // Close before announce — see VoiceOver modal-scoping note in
-        // TerminalContextMenu.handleDestructiveConfirm.
-        setConfirmDialog({ isOpen: false });
-        useAnnouncerStore.getState().announce("Terminated all sessions");
+        closeAndAnnounce(() => setConfirmDialog({ isOpen: false }), "Terminated all sessions");
       },
     });
   }, [worktree.id, worktree.issueTitle, worktree.branch]);

--- a/src/lib/__tests__/accessibility.test.ts
+++ b/src/lib/__tests__/accessibility.test.ts
@@ -70,4 +70,19 @@ describe("closeAndAnnounce", () => {
     closeAndAnnounce(() => {}, "Trashed all sessions");
     expect(useAnnouncerStore.getState().polite?.msg).toBe("Trashed all sessions");
   });
+
+  it("closes before mutating the store on the DOM fallback path too", () => {
+    delete (document as DocumentWithAriaNotify).ariaNotify;
+    let storeWasEmptyAtCloseTime = false;
+    const closeFn = vi.fn(() => {
+      storeWasEmptyAtCloseTime = useAnnouncerStore.getState().polite === null;
+    });
+
+    closeAndAnnounce(closeFn, "Terminal killed");
+
+    // The store must still be empty at the moment closeFn ran — the
+    // announcement is only written after the modal closes.
+    expect(storeWasEmptyAtCloseTime).toBe(true);
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Terminal killed");
+  });
 });

--- a/src/lib/__tests__/accessibility.test.ts
+++ b/src/lib/__tests__/accessibility.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { closeAndAnnounce } from "../accessibility";
+import {
+  useAnnouncerStore,
+  _resetAnnouncerDeliveryForTests,
+} from "@/store/accessibilityAnnouncerStore";
+
+interface DocumentWithAriaNotify extends Document {
+  ariaNotify?: (message: string, options?: { priority?: "normal" | "high" }) => void;
+}
+
+describe("closeAndAnnounce", () => {
+  let ariaNotifyMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    useAnnouncerStore.setState({ polite: null, assertive: null, nextId: 1 });
+    _resetAnnouncerDeliveryForTests();
+    ariaNotifyMock = vi.fn();
+    (document as DocumentWithAriaNotify).ariaNotify =
+      ariaNotifyMock as unknown as DocumentWithAriaNotify["ariaNotify"];
+  });
+
+  afterEach(() => {
+    delete (document as DocumentWithAriaNotify).ariaNotify;
+  });
+
+  it("closes before announcing so focus returns to the main tree first", () => {
+    const calls: string[] = [];
+    const closeFn = vi.fn(() => calls.push("close"));
+    ariaNotifyMock.mockImplementation(() => calls.push("announce"));
+
+    closeAndAnnounce(closeFn, "Terminal killed");
+
+    expect(closeFn).toHaveBeenCalledTimes(1);
+    expect(ariaNotifyMock).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(["close", "announce"]);
+  });
+
+  it("forwards a polite priority as ariaNotify 'normal'", () => {
+    closeAndAnnounce(() => {}, "Saved", "polite");
+    expect(ariaNotifyMock).toHaveBeenCalledWith("Saved", { priority: "normal" });
+  });
+
+  it("forwards an assertive priority as ariaNotify 'high'", () => {
+    closeAndAnnounce(() => {}, "Failure", "assertive");
+    expect(ariaNotifyMock).toHaveBeenCalledWith("Failure", { priority: "high" });
+  });
+
+  it("defaults to polite ('normal') when priority is omitted", () => {
+    closeAndAnnounce(() => {}, "Closed");
+    expect(ariaNotifyMock).toHaveBeenCalledWith("Closed", { priority: "normal" });
+  });
+
+  it("forwards an empty message unchanged", () => {
+    closeAndAnnounce(() => {}, "");
+    expect(ariaNotifyMock).toHaveBeenCalledWith("", { priority: "normal" });
+  });
+
+  it("does not announce when closeFn throws", () => {
+    const boom = vi.fn(() => {
+      throw new Error("close failed");
+    });
+    expect(() => closeAndAnnounce(boom, "Should not fire")).toThrow("close failed");
+    expect(ariaNotifyMock).not.toHaveBeenCalled();
+  });
+
+  it("routes through the store DOM fallback when ariaNotify is unavailable", () => {
+    delete (document as DocumentWithAriaNotify).ariaNotify;
+    closeAndAnnounce(() => {}, "Trashed all sessions");
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Trashed all sessions");
+  });
+});

--- a/src/lib/accessibility.ts
+++ b/src/lib/accessibility.ts
@@ -1,3 +1,5 @@
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+
 export const TABBABLE_SELECTOR =
   'a[href], area[href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), audio[controls], video[controls], [contenteditable]:not([contenteditable="false"]), [tabindex]:not([tabindex^="-"])';
 
@@ -31,4 +33,25 @@ export function getVisibleTabbableElements(root: ParentNode): HTMLElement[] {
   return Array.from(root.querySelectorAll<HTMLElement>(TABBABLE_SELECTOR)).filter(
     isVisibleTabbableElement
   );
+}
+
+/**
+ * Close a modal/dialog/popover, then announce a result to assistive tech.
+ *
+ * macOS VoiceOver drops `aria-live` updates that originate outside the focused
+ * `aria-modal="true"` subtree (Chromium 354736464), so announcing before the
+ * modal closes silently loses the message. Closing first hands focus back to
+ * the main tree before the announcement fires. Delivery routes through the
+ * announcer store, which prefers `document.ariaNotify` (bypassing the subtree
+ * filter) and falls back to a live-region mutation — never call `ariaNotify`
+ * directly. If `closeFn` throws, the announcement is skipped so a failed close
+ * can't produce a misleading success message.
+ */
+export function closeAndAnnounce(
+  closeFn: () => void,
+  message: string,
+  priority?: "polite" | "assertive"
+): void {
+  closeFn();
+  useAnnouncerStore.getState().announce(message, priority);
 }


### PR DESCRIPTION
## Summary

- Adds `closeAndAnnounce(closeFn, message, priority?)` to `src/lib/accessibility.ts` — closes the modal before announcing, working around Chromium bug 354736464 where VoiceOver silently drops `aria-live` updates made from outside a focused `aria-modal` subtree.
- Refactors five inline close-then-announce sites (`WaitingContainer`, `BackgroundContainer`, `TerminalDestructiveActionConfirmDialog`, `TerminalContextMenu`, `useWorktreeActions`) onto the helper.
- Co-locates `<AccessibilityAnnouncer />` inside the `ThemeBrowser` and `WebviewDialog` `aria-modal` subtrees as a DOM-fallback safety net — both had `aria-modal` but no co-located announcer.

Resolves #9196

## Changes

- `src/lib/accessibility.ts` — new `closeAndAnnounce` helper; routes through the announcer store (`document.ariaNotify` primary, `sr-only` live-region fallback).
- Five call sites refactored to use the helper instead of inline close-then-announce sequences.
- `ThemeBrowser.tsx` and `WebviewDialog.tsx` — `<AccessibilityAnnouncer />` added inside the modal subtree.
- `src/lib/__tests__/accessibility.test.ts` — new test file covering close-before-announce ordering on both delivery paths, priority forwarding, empty message guard, and throw-skips-announce.
- `ThemeBrowser.test.tsx` and `WebviewDialog.test.tsx` — structural assertions for co-located non-focusable polite and assertive live regions inside `[aria-modal=true]`.

## Testing

- 149 targeted tests pass.
- `npm run check` clean (lint ratchet dropped by 2).
- Toaster left unchanged — its announce calls are outside any `aria-modal` subtree and `document.ariaNotify` already bypasses the filter.