### PR TITLE
feat(theme): govern extension tier with typed registry

### DIFF
--- a/shared/theme/__tests__/builtInThemes.test.ts
+++ b/shared/theme/__tests__/builtInThemes.test.ts
@@ -1,9 +1,12 @@
+import { readdirSync, readFileSync, statSync, type Dirent } from "node:fs";
+import { join, relative } from "node:path";
 import { describe, expect, it } from "vitest";
 import { BUILT_IN_THEME_SOURCES } from "../builtInThemes/index.js";
 import { getThemeContrastWarnings } from "../contrast.js";
+import { EXTENSION_KEY_REGISTRY, isExtensionKeyRequired } from "../extensionRegistry.js";
 import { auditSurfaceRamp, auditAccentProminence, auditCrossThemeAccents } from "../oklch.js";
 import { BUILT_IN_APP_SCHEMES } from "../themes.js";
-import { APP_THEME_TOKEN_KEYS } from "../types.js";
+import { APP_THEME_TOKEN_KEYS, EXTENSION_KEYS } from "../types.js";
 
 describe("built-in themes", () => {
   it("every source compiles to a valid AppColorScheme", () => {
@@ -141,71 +144,111 @@ describe("built-in themes", () => {
     }
   });
 
-  it("every source defines perceptible sidebar hover and active extension tokens", () => {
-    // Both extensions must exist (daintree previously omitted sidebar-hover-bg, leaving the
-    // sidebar WorktreeCard with an invisible 1.5% fallback). Hover must be at or above the
-    // overlay-subtle baseline (3% dark / 2.5% light) and active must be one step stronger
-    // so the selected row is distinguishable from the hovered row. Polarity must also match
-    // the theme type — a light theme using white tint or a dark theme using black would
-    // render invisibly even at the right alpha.
-    const minHoverAlpha = { dark: 0.03, light: 0.025 } as const;
-    const minActiveAlpha = { dark: 0.05, light: 0.04 } as const;
-    const expectedTint = {
-      dark: /rgba\(\s*255\s*,\s*255\s*,\s*255/,
-      light: /rgba\(\s*0\s*,\s*0\s*,\s*0/,
-    } as const;
-    const parseAlpha = (value: string): number => {
-      const match = value.match(/rgba?\([^)]*?,\s*([0-9.]+)\s*\)/);
-      return match ? Number(match[1]) : NaN;
-    };
-    for (const source of BUILT_IN_THEME_SOURCES) {
-      const hover = source.extensions?.["sidebar-hover-bg"];
-      const active = source.extensions?.["sidebar-active-bg"];
-      expect(hover, `${source.id} missing sidebar-hover-bg extension`).toBeTruthy();
-      expect(active, `${source.id} missing sidebar-active-bg extension`).toBeTruthy();
-      const polarity = source.type;
-      expect(
-        parseAlpha(hover!),
-        `${source.id} sidebar-hover-bg ${hover} below ${minHoverAlpha[polarity]} threshold`
-      ).toBeGreaterThanOrEqual(minHoverAlpha[polarity]);
-      expect(
-        parseAlpha(active!),
-        `${source.id} sidebar-active-bg ${active} below ${minActiveAlpha[polarity]} threshold`
-      ).toBeGreaterThanOrEqual(minActiveAlpha[polarity]);
-      expect(
-        parseAlpha(active!),
-        `${source.id} sidebar-active-bg ${active} should be stronger than sidebar-hover-bg ${hover}`
-      ).toBeGreaterThan(parseAlpha(hover!));
-      expect(
-        hover,
-        `${source.id} sidebar-hover-bg ${hover} polarity does not match theme type ${polarity}`
-      ).toMatch(expectedTint[polarity]);
-      expect(
-        active,
-        `${source.id} sidebar-active-bg ${active} polarity does not match theme type ${polarity}`
-      ).toMatch(expectedTint[polarity]);
-    }
+  it("EXTENSION_KEY_REGISTRY covers every canonical extension key", () => {
+    // Drift guard between EXTENSION_KEYS and EXTENSION_KEY_REGISTRY: any new
+    // key must be added to both, and any removed key must be dropped from both.
+    const registryKeys = Object.keys(EXTENSION_KEY_REGISTRY).sort();
+    const canonicalKeys = [...EXTENSION_KEYS].sort();
+    expect(registryKeys).toEqual(canonicalKeys);
   });
 
-  it("never ships a dock-shadow extension that overrides the fix with a weak alpha (#8156)", () => {
-    // applyAppThemeToRoot sets extensions["dock-shadow"] as an inline style,
-    // which beats the corrected src/index.css base value. Any theme that opts
-    // back in must use the alpha-pinned relative-color form so it stays visible
-    // on light themes — never a raw low-alpha rgba() like the original bug.
-    for (const source of BUILT_IN_THEME_SOURCES) {
-      const dockShadow = source.extensions?.["dock-shadow"];
-      if (dockShadow === undefined) continue;
-      const pinned = dockShadow.match(/rgb\(from var\(--theme-shadow-color\) r g b \/ ([0-9.]+)\)/);
-      expect(
-        pinned,
-        `${source.id} dock-shadow "${dockShadow}" must use the alpha-pinned relative-color form`
-      ).toBeTruthy();
-      expect(
-        Number(pinned![1]),
-        `${source.id} dock-shadow alpha ${pinned![1]} below 0.25 visibility threshold`
-      ).toBeGreaterThanOrEqual(0.25);
+  it.each(BUILT_IN_THEME_SOURCES.map((s) => [s.id, s] as const))(
+    "theme %s satisfies extension-tier governance",
+    (_id, source) => {
+      const polarity = source.type;
+      const extensions = source.extensions ?? {};
+      const failures: string[] = [];
+
+      for (const key of EXTENSION_KEYS) {
+        const meta = EXTENSION_KEY_REGISTRY[key];
+        const value = extensions[key];
+        const required = isExtensionKeyRequired(key, polarity);
+
+        if (required && value === undefined) {
+          failures.push(`${source.id} (${polarity}) missing required extension: ${key}`);
+          continue;
+        }
+
+        if (!required && meta.forbidWhenNotRequired && value !== undefined) {
+          failures.push(
+            `${source.id} (${polarity}) must not set ${key}; the CSS fallback is correct ` +
+              `for this polarity and an override here inverts the bug it patches.`
+          );
+          continue;
+        }
+
+        if (value === undefined) continue;
+
+        const tint = meta.perceptibility?.expectedTint?.[polarity];
+        if (tint && !tint.test(value)) {
+          failures.push(
+            `${source.id} ${key} value "${value}" does not match expected ${polarity} tint`
+          );
+        }
+
+        const minAlpha = meta.perceptibility?.minAlpha?.[polarity];
+        if (minAlpha !== undefined) {
+          const alpha = parseAlpha(value);
+          if (Number.isNaN(alpha) || alpha < minAlpha) {
+            failures.push(
+              `${source.id} ${key} alpha ${alpha} below ${minAlpha} threshold (value="${value}")`
+            );
+          }
+        }
+
+        const maxAlpha = meta.perceptibility?.maxAlpha?.[polarity];
+        if (maxAlpha !== undefined) {
+          const alpha = parseAlpha(value);
+          if (!Number.isNaN(alpha) && alpha > maxAlpha) {
+            failures.push(
+              `${source.id} ${key} alpha ${alpha} above ${maxAlpha} ceiling (value="${value}")`
+            );
+          }
+        }
+
+        if (meta.formatGuard && !meta.formatGuard.test(value)) {
+          failures.push(`${source.id} ${key} value "${value}" does not match required format`);
+        }
+
+        if (meta.formatGuard && meta.minFormatAlpha !== undefined) {
+          const m = value.match(meta.formatGuard);
+          const alpha = m?.[1] !== undefined ? Number(m[1]) : NaN;
+          if (Number.isNaN(alpha) || alpha < meta.minFormatAlpha || alpha > 1) {
+            failures.push(
+              `${source.id} ${key} format alpha ${alpha} outside [${meta.minFormatAlpha}, 1] (value="${value}")`
+            );
+          }
+        }
+      }
+
+      // Cross-key invariant: sidebar-active-bg must be stronger than sidebar-hover-bg
+      // so the selected row is distinguishable from the hovered row.
+      const hover = extensions["sidebar-hover-bg"];
+      const active = extensions["sidebar-active-bg"];
+      if (hover !== undefined && active !== undefined) {
+        const hoverAlpha = parseAlpha(hover);
+        const activeAlpha = parseAlpha(active);
+        if (!(activeAlpha > hoverAlpha)) {
+          failures.push(
+            `${source.id} sidebar-active-bg (alpha ${activeAlpha}) must be stronger than ` +
+              `sidebar-hover-bg (alpha ${hoverAlpha}); values "${active}" vs "${hover}"`
+          );
+        }
+      }
+
+      // Extra-key regression: no built-in source ships an unregistered extension
+      // key. TypeScript enforces this at compile time, but a runtime check
+      // catches `as unknown as` casts and ad-hoc fixture mutations.
+      const extraKeys = Object.keys(extensions).filter(
+        (k) => !(EXTENSION_KEYS as readonly string[]).includes(k)
+      );
+      if (extraKeys.length > 0) {
+        failures.push(`${source.id} ships unregistered extension keys: ${extraKeys.join(", ")}`);
+      }
+
+      expect(failures, failures.join("\n")).toHaveLength(0);
     }
-  });
+  );
 
   it("surface elevation ramp passes OKLCH audit", () => {
     for (const source of BUILT_IN_THEME_SOURCES) {
@@ -241,43 +284,217 @@ describe("built-in themes", () => {
     expect(result.failures, `cross-theme failures:\n${result.failures.join("\n")}`).toHaveLength(0);
   });
 
-  it("dark themes override toolbar-control-armed-shadow with a white-tinted hairline; light themes inherit the black-tinted CSS fallback", () => {
-    // Dark themes must provide a white-tinted hairline override — the CSS fallback
-    // is black-tinted (rgba(0,0,0,0.18)) so on dark surfaces it would render
-    // invisibly. Light themes must NOT define this extension; a copy-paste from a
-    // dark theme would put a white ring on a light toolbar, which inverts the
-    // original #8175 bug.
-    const parseAlpha = (value: string): number => {
-      const match = value.match(/rgba?\([^)]*?,\s*([0-9.]+)\s*\)/);
-      return match ? Number(match[1]) : NaN;
-    };
-    for (const source of BUILT_IN_THEME_SOURCES) {
-      const armed = source.extensions?.["toolbar-control-armed-shadow"];
-      if (source.type === "dark") {
-        expect(
-          armed,
-          `${source.id} (dark) missing toolbar-control-armed-shadow override`
-        ).toBeTruthy();
-        expect(
-          armed,
-          `${source.id} toolbar-control-armed-shadow must use the hairline geometry`
-        ).toMatch(/inset\s+0\s+0\s+0\s+1px/);
-        expect(
-          armed,
-          `${source.id} toolbar-control-armed-shadow must be white-tinted on a dark theme`
-        ).toMatch(/rgba\(\s*255\s*,\s*255\s*,\s*255/);
-        const alpha = parseAlpha(armed!);
-        expect(
-          alpha,
-          `${source.id} toolbar-control-armed-shadow alpha ${alpha} outside [0.08, 0.25]`
-        ).toBeGreaterThanOrEqual(0.08);
-        expect(alpha).toBeLessThanOrEqual(0.25);
-      } else {
-        expect(
-          armed,
-          `${source.id} (light) must not override toolbar-control-armed-shadow; it should inherit the black-tinted CSS fallback`
-        ).toBeUndefined();
-      }
-    }
+  it("EXTENSION_KEYS is in sync with the CSS/TSX surface (drift detection)", () => {
+    // Two-direction drift check:
+    //   A: every registered extension key must have at least one var(--key)
+    //      consumer in the renderer.
+    //   B: every var(--key) consumed in the renderer that is not a known
+    //      system/local/Tailwind/Radix variable must be a registered
+    //      extension key.
+    // This is the contract that makes EXTENSION_KEYS the single source of
+    // truth for the extension tier.
+    const repoRoot = findRepoRoot();
+    const { consumed, declared } = scanRendererVars(repoRoot);
+    const registered = new Set<string>(EXTENSION_KEYS);
+
+    const directionA = [...registered].filter((k) => !consumed.has(k));
+    expect(
+      directionA,
+      `Extension keys with no var(--key) consumer in src/: ${directionA.join(", ")}`
+    ).toHaveLength(0);
+
+    // A var consumed via var(--name) is only an extension-tier candidate if
+    // it is NOT declared somewhere in the renderer (statically in CSS as
+    // `--name:` or dynamically in a TSX inline style). Locally-declared vars
+    // are component-scope cascade intermediates, not theme extension hooks.
+    const directionB = [...consumed].filter(
+      (v) => !registered.has(v) && !declared.has(v) && !isNonExtensionVar(v)
+    );
+    expect(
+      directionB,
+      `var(--key) consumers not registered in EXTENSION_KEYS: ${directionB.join(", ")}`
+    ).toHaveLength(0);
   });
 });
+
+const SEMANTIC_TOKEN_NAMES = new Set<string>(APP_THEME_TOKEN_KEYS);
+
+// CSS variables that are not extension keys and therefore must be excluded
+// from the drift scan. This list is intentionally explicit (not prefix-only)
+// so that future additions are surfaced for review rather than silently
+// shadowed by a too-broad prefix match.
+const NON_EXTENSION_VAR_PREFIXES = ["theme-", "color-", "radix-", "tw-", "_"];
+const NON_EXTENSION_VAR_NAMES = new Set<string>([
+  // Tailwind v4 / shadcn static aliases declared once in src/index.css :root
+  "background",
+  "foreground",
+  "card",
+  "card-foreground",
+  "popover",
+  "popover-foreground",
+  "primary",
+  "primary-foreground",
+  "secondary",
+  "secondary-foreground",
+  "muted",
+  "muted-foreground",
+  "accent",
+  "accent-foreground",
+  "destructive",
+  "destructive-foreground",
+  "border",
+  "input",
+  "ring",
+  "radius",
+  "radius-sm",
+  "radius-md",
+  "radius-lg",
+  "radius-xl",
+  "chart-1",
+  "chart-2",
+  "chart-3",
+  "chart-4",
+  "chart-5",
+  "sidebar",
+  "sidebar-foreground",
+  "sidebar-primary",
+  "sidebar-primary-foreground",
+  "sidebar-accent",
+  "sidebar-accent-foreground",
+  "sidebar-border",
+  "sidebar-ring",
+  "font-sans",
+  "font-mono",
+  "font-serif",
+]);
+
+function isNonExtensionVar(name: string): boolean {
+  if (SEMANTIC_TOKEN_NAMES.has(name)) return true;
+  if (NON_EXTENSION_VAR_NAMES.has(name)) return true;
+  for (const prefix of NON_EXTENSION_VAR_PREFIXES) {
+    if (name.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+function findRepoRoot(): string {
+  // Vitest runs with cwd = project root (vitest.config.ts at repo root).
+  // Sanity-check by verifying src/ exists; fall back to a walk-up if not.
+  const cwd = process.cwd();
+  try {
+    if (statSync(join(cwd, "src")).isDirectory()) return cwd;
+  } catch {
+    // fall through
+  }
+  let current = new URL(".", import.meta.url).pathname;
+  for (let i = 0; i < 6; i++) {
+    try {
+      if (statSync(join(current, "src")).isDirectory()) return current;
+    } catch {
+      // continue walking up
+    }
+    current = join(current, "..");
+  }
+  throw new Error("Could not locate repo root (no src/ found from cwd or test file)");
+}
+
+function scanRendererVars(repoRoot: string): {
+  consumed: Set<string>;
+  declared: Set<string>;
+} {
+  // `declared` is intentionally repo-wide rather than per-file: a var declared
+  // anywhere in src/ is treated as locally-managed and excluded from drift
+  // Direction B everywhere. This is safe because extension keys are only ever
+  // *consumed* via var(--key, fallback); they never have a bare `--key:`
+  // declaration in component CSS (themes set them dynamically via
+  // applyAppThemeToRoot.setProperty). If that invariant changes — e.g. a
+  // theme starts emitting extension vars into a static :root block — this
+  // scanner would silently miss the new drift surface.
+  const consumed = new Set<string>();
+  const declared = new Set<string>();
+  const targets: string[] = [];
+  walk(join(repoRoot, "src"), targets, (path) => {
+    if (path.endsWith(".css")) return true;
+    if (path.endsWith(".tsx") || path.endsWith(".ts")) {
+      // Skip test files — they can declare arbitrary vars in fixtures.
+      if (path.includes(`${"__tests__"}`)) return false;
+      if (path.endsWith(".test.ts") || path.endsWith(".test.tsx")) return false;
+      if (path.endsWith(".spec.ts") || path.endsWith(".spec.tsx")) return false;
+      return true;
+    }
+    return false;
+  });
+
+  const varPattern = /var\(--([a-zA-Z_][a-zA-Z0-9_-]*)/g;
+  // Static CSS declaration: `--name: ...` at start of a line (any indent).
+  const cssDeclPattern = /(?:^|[;{}\s])--([a-zA-Z_][a-zA-Z0-9_-]*)\s*:/g;
+  // TSX inline-style key: `"--name"` / `'--name'` (covers both bracketed
+  // computed keys and plain string keys in style objects).
+  const tsxDeclPattern = /["'`]--([a-zA-Z_][a-zA-Z0-9_-]*)["'`]/g;
+  // setProperty calls: `setProperty("--name", ...)` and variants.
+  const setPropPattern = /setProperty\(\s*["'`]--([a-zA-Z_][a-zA-Z0-9_-]*)["'`]/g;
+
+  for (const file of targets) {
+    let contents: string;
+    try {
+      contents = readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+    // Collapse multi-line var(...) so the regex catches names split across
+    // lines (e.g. var(\n  --settings-section-header-bg,\n  ...))
+    const collapsed = contents.replace(/var\(\s*\n\s+/g, "var(").replace(/var\(\s+/g, "var(");
+
+    for (const match of collapsed.matchAll(varPattern)) {
+      const name = match[1];
+      if (name) consumed.add(name);
+    }
+    if (file.endsWith(".css")) {
+      for (const match of contents.matchAll(cssDeclPattern)) {
+        const name = match[1];
+        if (name) declared.add(name);
+      }
+    } else {
+      for (const match of contents.matchAll(tsxDeclPattern)) {
+        const name = match[1];
+        if (name) declared.add(name);
+      }
+      for (const match of contents.matchAll(setPropPattern)) {
+        const name = match[1];
+        if (name) declared.add(name);
+      }
+    }
+  }
+  // Self-sanity: if the scanner finds zero vars at all, something is wrong
+  // with the walk — fail loudly rather than reporting false-pass drift.
+  if (consumed.size === 0) {
+    throw new Error(
+      `Drift scanner found zero var(--key) consumers under ${relative(repoRoot, join(repoRoot, "src"))}/`
+    );
+  }
+  return { consumed, declared };
+}
+
+function walk(dir: string, out: string[], accept: (path: string) => boolean): void {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true, encoding: "utf8" }) as Dirent[];
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "dist" || entry.name === "build")
+        continue;
+      walk(path, out, accept);
+      continue;
+    }
+    if (entry.isFile() && accept(path)) out.push(path);
+  }
+}
+
+function parseAlpha(value: string): number {
+  const match = value.match(/rgba?\([^)]*?,\s*([0-9.]+)\s*\)/);
+  return match ? Number(match[1]) : NaN;
+}

--- a/shared/theme/builtInThemeSources.ts
+++ b/shared/theme/builtInThemeSources.ts
@@ -1,5 +1,5 @@
 import type { ThemePalette } from "./palette.js";
-import type { AppColorSchemeTokens } from "./types.js";
+import type { AppColorSchemeTokens, ExtensionKey } from "./types.js";
 
 export interface BuiltInThemeSource {
   id: string;
@@ -8,7 +8,7 @@ export interface BuiltInThemeSource {
   builtin: true;
   palette: ThemePalette;
   tokens?: Partial<AppColorSchemeTokens>;
-  extensions?: Record<string, string>;
+  extensions?: Partial<Record<ExtensionKey, string>>;
   location?: string;
   heroImage?: string;
 }

--- a/shared/theme/extensionRegistry.ts
+++ b/shared/theme/extensionRegistry.ts
@@ -1,0 +1,182 @@
+import { EXTENSION_KEYS, type ExtensionKey } from "./types.js";
+
+type ColorMode = "dark" | "light";
+
+/**
+ * Per-extension-key governance metadata. The parity loop in
+ * shared/theme/__tests__/builtInThemes.test.ts iterates EXTENSION_KEYS and
+ * applies these rules:
+ *
+ * - `required` true / false / fn(mode) controls whether every theme of a given
+ *   polarity must provide a value. The fn form encodes polarity-conditional
+ *   requirements (e.g. dark-only).
+ * - `forbidWhenNotRequired` asserts the inverse for the polarity where
+ *   `required(mode)` is false — used when a copy-paste from the opposite
+ *   polarity would render incorrectly (e.g. a white-tinted hairline on a
+ *   light toolbar inverts the original bug).
+ * - `perceptibility` validates a present value matches the polarity-tint
+ *   regex and clears a minimum alpha threshold per polarity.
+ * - `formatGuard` validates the literal CSS form of the value when present,
+ *   used for keys whose value must use a specific syntax (e.g. the
+ *   `rgb(from var(--theme-shadow-color) r g b / X)` form so the shadow
+ *   stays visible on light themes).
+ */
+export interface ExtensionKeyMetadata {
+  required: boolean | ((mode: ColorMode) => boolean);
+  forbidWhenNotRequired?: boolean;
+  perceptibility?: {
+    minAlpha?: Partial<Record<ColorMode, number>>;
+    maxAlpha?: Partial<Record<ColorMode, number>>;
+    expectedTint?: Partial<Record<ColorMode, RegExp>>;
+  };
+  formatGuard?: RegExp;
+  minFormatAlpha?: number;
+}
+
+const OPTIONAL: ExtensionKeyMetadata = { required: false };
+
+const SIDEBAR_HOVER: ExtensionKeyMetadata = {
+  required: true,
+  perceptibility: {
+    minAlpha: { dark: 0.03, light: 0.025 },
+    expectedTint: {
+      dark: /rgba\(\s*255\s*,\s*255\s*,\s*255/,
+      light: /rgba\(\s*0\s*,\s*0\s*,\s*0/,
+    },
+  },
+};
+
+const SIDEBAR_ACTIVE: ExtensionKeyMetadata = {
+  required: true,
+  perceptibility: {
+    minAlpha: { dark: 0.05, light: 0.04 },
+    expectedTint: {
+      dark: /rgba\(\s*255\s*,\s*255\s*,\s*255/,
+      light: /rgba\(\s*0\s*,\s*0\s*,\s*0/,
+    },
+  },
+};
+
+const TOOLBAR_ARMED: ExtensionKeyMetadata = {
+  required: (mode) => mode === "dark",
+  forbidWhenNotRequired: true,
+  perceptibility: {
+    minAlpha: { dark: 0.08 },
+    maxAlpha: { dark: 0.25 },
+    expectedTint: { dark: /rgba\(\s*255\s*,\s*255\s*,\s*255/ },
+  },
+  formatGuard: /inset\s+0\s+0\s+0\s+1px/,
+};
+
+const DOCK_SHADOW: ExtensionKeyMetadata = {
+  required: false,
+  formatGuard: /rgb\(from var\(--theme-shadow-color\) r g b \/ ([0-9.]+)\)/,
+  minFormatAlpha: 0.25,
+};
+
+export const EXTENSION_KEY_REGISTRY = {
+  // Chrome material
+  "chrome-bg": OPTIONAL,
+  "chrome-noise": OPTIONAL,
+  "chrome-shadow": OPTIONAL,
+
+  // Dialog + floating surface
+  "dialog-bg": OPTIONAL,
+  "dialog-header-bg": OPTIONAL,
+  "dialog-shadow": OPTIONAL,
+  "floating-surface-bg": OPTIONAL,
+  "floating-surface-shadow": OPTIONAL,
+
+  // Dock
+  "dock-bg": OPTIONAL,
+  "dock-border": OPTIONAL,
+  "dock-shadow": DOCK_SHADOW,
+
+  // Panel grid
+  "panel-grid-bg": OPTIONAL,
+  "terminal-grid-bg": OPTIONAL,
+
+  // Pulse
+  "pulse-before-bg": OPTIONAL,
+  "pulse-card-bg": OPTIONAL,
+  "pulse-card-header-bg": OPTIONAL,
+  "pulse-card-shadow": OPTIONAL,
+  "pulse-control-hover-bg": OPTIONAL,
+  "pulse-empty-bg": OPTIONAL,
+  "pulse-heat-color": OPTIONAL,
+  "pulse-heat-high-opacity": OPTIONAL,
+  "pulse-heat-low-opacity": OPTIONAL,
+  "pulse-heat-medium-opacity": OPTIONAL,
+  "pulse-missed-bg": OPTIONAL,
+  "pulse-range-bg": OPTIONAL,
+  "pulse-ring-offset": OPTIONAL,
+  "pulse-skeleton-gradient": OPTIONAL,
+
+  // Settings
+  "settings-card-bg": OPTIONAL,
+  "settings-dialog-bg": OPTIONAL,
+  "settings-kbd-bg": OPTIONAL,
+  "settings-kbd-border": OPTIONAL,
+  "settings-list-item-bg": OPTIONAL,
+  "settings-meta-fg": OPTIONAL,
+  "settings-meta-size": OPTIONAL,
+  "settings-nav-active-bg": OPTIONAL,
+  "settings-nav-active-shadow": OPTIONAL,
+  "settings-nav-hover-bg": OPTIONAL,
+  "settings-search-bg": OPTIONAL,
+  "settings-search-muted": OPTIONAL,
+  "settings-section-header-bg": OPTIONAL,
+  "settings-section-header-bg-solid": OPTIONAL,
+  "settings-sidebar-bg": OPTIONAL,
+
+  // Sidebar — required keys whose CSS fallback (white-tint) is invisible on
+  // light themes. See #8175 lineage.
+  "sidebar-action-hover-bg": OPTIONAL,
+  "sidebar-active-bg": SIDEBAR_ACTIVE,
+  "sidebar-hover-bg": SIDEBAR_HOVER,
+
+  // Toolbar — toolbar-control-armed-shadow is polarity-conditional. Dark
+  // themes must override the CSS fallback (which is black-tinted, invisible
+  // on dark surfaces); light themes must inherit the fallback or they put
+  // a white ring on a light toolbar (the original #8175 inversion).
+  "toolbar-agent-hover-bg": OPTIONAL,
+  "toolbar-bg": OPTIONAL,
+  "toolbar-control-active-bg": OPTIONAL,
+  "toolbar-control-armed-bg": OPTIONAL,
+  "toolbar-control-armed-shadow": TOOLBAR_ARMED,
+  "toolbar-control-hover-bg": OPTIONAL,
+  "toolbar-control-hover-fg": OPTIONAL,
+  "toolbar-control-hover-shadow": OPTIONAL,
+  "toolbar-divider": OPTIONAL,
+  "toolbar-noise": OPTIONAL,
+  "toolbar-pill-radius": OPTIONAL,
+  "toolbar-shadow": OPTIONAL,
+
+  // Toolbar project pill
+  "toolbar-project-bg": OPTIONAL,
+  "toolbar-project-border": OPTIONAL,
+  "toolbar-project-chip-bg": OPTIONAL,
+  "toolbar-project-chip-border": OPTIONAL,
+  "toolbar-project-chip-size": OPTIONAL,
+  "toolbar-project-meta-fg": OPTIONAL,
+  "toolbar-project-shadow": OPTIONAL,
+
+  // Toolbar stats pill
+  "toolbar-stats-bg": OPTIONAL,
+  "toolbar-stats-border": OPTIONAL,
+  "toolbar-stats-divider": OPTIONAL,
+  "toolbar-stats-hover-bg": OPTIONAL,
+  "toolbar-stats-shadow": OPTIONAL,
+
+  // Worktree section
+  "worktree-section-hover-bg": OPTIONAL,
+} as const satisfies Record<ExtensionKey, ExtensionKeyMetadata>;
+
+export function isExtensionKeyRequired(key: ExtensionKey, mode: ColorMode): boolean {
+  const meta = EXTENSION_KEY_REGISTRY[key];
+  return typeof meta.required === "function" ? meta.required(mode) : meta.required;
+}
+
+// Re-export for callers that want both the canonical list and the registry
+// from a single module.
+export { EXTENSION_KEYS };

--- a/shared/theme/types.ts
+++ b/shared/theme/types.ts
@@ -198,6 +198,108 @@ export type AppThemeTokenKey = (typeof APP_THEME_TOKEN_KEYS)[number];
 
 export type AppColorSchemeTokens = Record<AppThemeTokenKey, string>;
 
+// Extension tier: optional per-theme overrides for component-scoped CSS custom
+// properties that are not part of the semantic-token contract. Each key is
+// applied as a bare CSS variable (e.g. "sidebar-hover-bg" -> --sidebar-hover-bg)
+// and must have a fallback at the consumer site. Governance is in
+// shared/theme/extensionRegistry.ts; the parity + drift tests are in
+// shared/theme/__tests__/builtInThemes.test.ts.
+export const EXTENSION_KEYS = [
+  // Chrome material (translucent inner-panel surface)
+  "chrome-bg",
+  "chrome-noise",
+  "chrome-shadow",
+
+  // Dialog + floating surface
+  "dialog-bg",
+  "dialog-header-bg",
+  "dialog-shadow",
+  "floating-surface-bg",
+  "floating-surface-shadow",
+
+  // Dock (docked terminal/agent dock pill)
+  "dock-bg",
+  "dock-border",
+  "dock-shadow",
+
+  // Panel grid background
+  "panel-grid-bg",
+  "terminal-grid-bg",
+
+  // Pulse (work-pulse heatmap)
+  "pulse-before-bg",
+  "pulse-card-bg",
+  "pulse-card-header-bg",
+  "pulse-card-shadow",
+  "pulse-control-hover-bg",
+  "pulse-empty-bg",
+  "pulse-heat-color",
+  "pulse-heat-high-opacity",
+  "pulse-heat-low-opacity",
+  "pulse-heat-medium-opacity",
+  "pulse-missed-bg",
+  "pulse-range-bg",
+  "pulse-ring-offset",
+  "pulse-skeleton-gradient",
+
+  // Settings tab
+  "settings-card-bg",
+  "settings-dialog-bg",
+  "settings-kbd-bg",
+  "settings-kbd-border",
+  "settings-list-item-bg",
+  "settings-meta-fg",
+  "settings-meta-size",
+  "settings-nav-active-bg",
+  "settings-nav-active-shadow",
+  "settings-nav-hover-bg",
+  "settings-search-bg",
+  "settings-search-muted",
+  "settings-section-header-bg",
+  "settings-section-header-bg-solid",
+  "settings-sidebar-bg",
+
+  // Sidebar interaction
+  "sidebar-action-hover-bg",
+  "sidebar-active-bg",
+  "sidebar-hover-bg",
+
+  // Toolbar
+  "toolbar-agent-hover-bg",
+  "toolbar-bg",
+  "toolbar-control-active-bg",
+  "toolbar-control-armed-bg",
+  "toolbar-control-armed-shadow",
+  "toolbar-control-hover-bg",
+  "toolbar-control-hover-fg",
+  "toolbar-control-hover-shadow",
+  "toolbar-divider",
+  "toolbar-noise",
+  "toolbar-pill-radius",
+  "toolbar-shadow",
+
+  // Toolbar project pill
+  "toolbar-project-bg",
+  "toolbar-project-border",
+  "toolbar-project-chip-bg",
+  "toolbar-project-chip-border",
+  "toolbar-project-chip-size",
+  "toolbar-project-meta-fg",
+  "toolbar-project-shadow",
+
+  // Toolbar stats pill
+  "toolbar-stats-bg",
+  "toolbar-stats-border",
+  "toolbar-stats-divider",
+  "toolbar-stats-hover-bg",
+  "toolbar-stats-shadow",
+
+  // Worktree section
+  "worktree-section-hover-bg",
+] as const;
+
+export type ExtensionKey = (typeof EXTENSION_KEYS)[number];
+
 export interface AppColorScheme {
   id: string;
   name: string;
@@ -205,7 +307,7 @@ export interface AppColorScheme {
   builtin: boolean;
   tokens: AppColorSchemeTokens;
   palette?: ThemePalette;
-  extensions?: Record<string, string>;
+  extensions?: Partial<Record<ExtensionKey, string>>;
   location?: string;
   heroImage?: string;
 }


### PR DESCRIPTION
## Summary

- Adds `EXTENSION_KEYS` (70 keys) and `ExtensionKey` type to `shared/theme/types.ts`, tightening `AppColorScheme.extensions` from `Record<string, string>` to `Partial<Record<ExtensionKey, string>>`.
- New `shared/theme/extensionRegistry.ts` with per-key governance metadata: required/forbidden rules, perceptibility constraints (min alpha, expected tint), and format guards (e.g. relative-color syntax, alpha bounds).
- Replaced three hand-written extension perceptibility tests in `shared/theme/__tests__/builtInThemes.test.ts` with a registry-driven loop covering all built-in themes x all extension keys, plus a bidirectional drift detection pass that scans `src/**/*.{css,ts,tsx}` for undeclared consumers or declared-but-unused vars.

## Why

The extension tier was a free-form `string → string` map with no compile-time shape enforcement and only a handful of manually-maintained perceptibility tests. This brings it up to the same standard as the semantic tier: the type system rejects unknown keys at compile time, the registry codifies the contract for each key, and the test suite enforces that contract across every built-in theme automatically.

No changes to runtime emission — `shared/theme/themes.ts` still applies extensions as bare `--{key}` CSS vars.

Closes #9222

## Test plan

- [ ] `npm run check` passes (typecheck, lint, format)
- [ ] 41 theme tests pass (`npx vitest run shared/theme`)
- [ ] Introducing a typo in an extension key in any built-in theme source produces a TypeScript error
- [ ] Removing `EXTENSION_KEYS` coverage for an existing `var(--key)` consumer trips the drift detection test
- [ ] Adding a new key to `EXTENSION_KEYS` without a registry entry causes the registry completeness assertion to fail