### PR TITLE
feat(diagnostics): surface export dialog from crash-adjacent error UIs

### DIFF
--- a/shared/config/actionIds.ts
+++ b/shared/config/actionIds.ts
@@ -252,6 +252,9 @@ export const BUILT_IN_ACTION_IDS = [
   "logs.clearLevelOverrides",
   "logs.getRegistry",
 
+  // -- diagnosticsActions --
+  "diagnostics.openReview",
+
   // -- errorActions --
   "errors.clearAll",
   "errors.openLogs",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -253,6 +253,13 @@ const LazyPanelLimitConfirmDialog = lazy(() =>
   preloadPanelLimitConfirmDialog().then((m) => ({ default: m.PanelLimitConfirmDialog }))
 );
 
+function preloadDiagnosticsReviewDialogHost() {
+  return import("./components/Settings/DiagnosticsReviewDialogHost");
+}
+const LazyDiagnosticsReviewDialogHost = lazy(() =>
+  preloadDiagnosticsReviewDialogHost().then((m) => ({ default: m.DiagnosticsReviewDialogHost }))
+);
+
 function preloadGitPushConfirmDialog() {
   return import("./components/Git/GitPushConfirmDialog");
 }
@@ -1289,6 +1296,18 @@ function AppInner() {
               >
                 <Suspense fallback={null}>
                   <LazyPanelLimitConfirmDialog />
+                </Suspense>
+              </ErrorBoundary>
+            )}
+
+            {isStateLoaded && (
+              <ErrorBoundary
+                variant="component"
+                componentName="DiagnosticsReviewDialogHost"
+                resetKeys={[Number(isStateLoaded)]}
+              >
+                <Suspense fallback={null}>
+                  <LazyDiagnosticsReviewDialogHost />
                 </Suspense>
               </ErrorBoundary>
             )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -684,6 +684,13 @@ function AppInner() {
             onUpdateConfig={updateCrashConfig}
           />
         </Suspense>
+        {/* Diagnostics host stays reachable while the crash dialog is blocking
+            the app — without this, the inline "Send diagnostics" action in
+            CrashRecoveryDialog (recovery-failed banner) has nothing to render
+            the dialog into. */}
+        <Suspense fallback={null}>
+          <LazyDiagnosticsReviewDialogHost />
+        </Suspense>
       </div>
     );
   }

--- a/src/components/Recovery/CrashRecoveryDialog.tsx
+++ b/src/components/Recovery/CrashRecoveryDialog.tsx
@@ -4,6 +4,7 @@ import {
   ChevronDown,
   ChevronRight,
   Copy,
+  Download,
   ExternalLink,
   FileText,
   SquareTerminal,
@@ -78,6 +79,7 @@ export function CrashRecoveryDialog({
     () => new Set(panels.filter((p) => !(shouldDeselectSuspects && p.isSuspect)).map((p) => p.id))
   );
   const [resolving, setResolving] = useState(false);
+  const [recoveryError, setRecoveryError] = useState<string | null>(null);
   const [detailsOpen, setDetailsOpen] = useState(false);
   const [showReportPreview, setShowReportPreview] = useState(false);
   const [reportError, setReportError] = useState<string | null>(null);
@@ -114,33 +116,29 @@ export function CrashRecoveryDialog({
     async (action: CrashRecoveryAction) => {
       if (resolving) return;
       setResolving(true);
+      setRecoveryError(null);
       try {
         await onResolve(action);
       } catch (err) {
-        notify({
-          type: "error",
-          title: "Recovery failed",
-          message: formatErrorMessage(err, "Couldn't complete recovery action"),
-          duration: 6000,
-          action: {
-            label: "Send diagnostics",
-            actionId: "diagnostics.openReview",
-            actionArgs: { scope: { source: "recovery.crashRecoveryFailed" } },
-            onClick: () => {
-              void actionService.dispatch(
-                "diagnostics.openReview",
-                { scope: { source: "recovery.crashRecoveryFailed" } },
-                { source: "user" }
-              );
-            },
-          },
-        });
+        // notify() is dead in the crash-pending branch (Toaster isn't mounted
+        // yet — the main app tree only renders after the user resolves the
+        // dialog). Surface the failure inline alongside the recovery buttons
+        // so the diagnostics action is reachable in the failure path.
+        setRecoveryError(formatErrorMessage(err, "Couldn't complete recovery action"));
       } finally {
         setResolving(false);
       }
     },
     [resolving, onResolve]
   );
+
+  const handleSendDiagnostics = useCallback(() => {
+    void actionService.dispatch(
+      "diagnostics.openReview",
+      { scope: { source: "recovery.crashRecoveryFailed" } },
+      { source: "user" }
+    );
+  }, []);
 
   const handleRestoreSelected = useCallback(() => {
     handleResolve({ kind: "restore", panelIds: [...selectedIds] });
@@ -374,6 +372,26 @@ export function CrashRecoveryDialog({
                   </div>
                 </div>
               </button>
+            </div>
+          )}
+
+          {recoveryError && (
+            <div className="rounded-md overflow-hidden" data-testid="recovery-error">
+              <InlineStatusBanner
+                severity="error"
+                icon={AlertTriangle}
+                title="Recovery failed"
+                description={recoveryError}
+                animated={false}
+                action={{
+                  id: "send-diagnostics",
+                  label: "Send diagnostics",
+                  icon: Download,
+                  onClick: handleSendDiagnostics,
+                }}
+                onClose={() => setRecoveryError(null)}
+                closeAriaLabel="Dismiss recovery error"
+              />
             </div>
           )}
 

--- a/src/components/Recovery/CrashRecoveryDialog.tsx
+++ b/src/components/Recovery/CrashRecoveryDialog.tsx
@@ -25,6 +25,7 @@ import {
 } from "./recoveryCopy";
 import { logError } from "@/utils/logger";
 import { notify } from "@/lib/notify";
+import { actionService } from "@/services/ActionService";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { scrubReportText } from "@shared/utils/reportScrubbers";
 import {
@@ -116,12 +117,23 @@ export function CrashRecoveryDialog({
       try {
         await onResolve(action);
       } catch (err) {
-        // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
         notify({
           type: "error",
           title: "Recovery failed",
           message: formatErrorMessage(err, "Couldn't complete recovery action"),
           duration: 6000,
+          action: {
+            label: "Send diagnostics",
+            actionId: "diagnostics.openReview",
+            actionArgs: { scope: { source: "recovery.crashRecoveryFailed" } },
+            onClick: () => {
+              void actionService.dispatch(
+                "diagnostics.openReview",
+                { scope: { source: "recovery.crashRecoveryFailed" } },
+                { source: "user" }
+              );
+            },
+          },
         });
       } finally {
         setResolving(false);

--- a/src/components/Recovery/HostCrashBanner.tsx
+++ b/src/components/Recovery/HostCrashBanner.tsx
@@ -23,6 +23,7 @@ export function HostCrashBanner() {
   const backendStatus = usePanelStore((s) => s.backendStatus);
   const lastCrashType = usePanelStore((s) => s.lastCrashType);
   const isCollectingDiagnostics = useDiagnosticsReviewStore((s) => s.isCollecting);
+  const diagnosticsError = useDiagnosticsReviewStore((s) => s.downloadError);
   const [isRestarting, setIsRestarting] = useState(false);
   const recoveringShown = useDohertyGate(backendStatus === "recovering");
 
@@ -104,6 +105,17 @@ export function HostCrashBanner() {
       role="alert"
       animated={false}
       trailingSlot={sendDiagnosticsButton}
+      descriptionExtras={
+        diagnosticsError ? (
+          <p
+            className="text-xs mt-1.5 break-words"
+            style={{ color: "color-mix(in oklab, var(--color-status-error) 80%, transparent)" }}
+            data-testid="host-crash-banner-diagnostics-error"
+          >
+            Diagnostics collection failed: {diagnosticsError}
+          </p>
+        ) : null
+      }
       action={{
         id: "restart",
         label: isRestarting ? "Restarting…" : "Restart service",

--- a/src/components/Recovery/HostCrashBanner.tsx
+++ b/src/components/Recovery/HostCrashBanner.tsx
@@ -1,7 +1,8 @@
 import { useState, type CSSProperties } from "react";
-import { AlertTriangle, Loader2 } from "lucide-react";
+import { AlertTriangle, Download, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { usePanelStore } from "@/store/panelStore";
+import { useDiagnosticsReviewStore } from "@/store/diagnosticsReviewStore";
 import { actionService } from "@/services/ActionService";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { logError } from "@/utils/logger";
@@ -21,6 +22,7 @@ function SpinnerIcon({ className, style }: { className?: string; style?: CSSProp
 export function HostCrashBanner() {
   const backendStatus = usePanelStore((s) => s.backendStatus);
   const lastCrashType = usePanelStore((s) => s.lastCrashType);
+  const isCollectingDiagnostics = useDiagnosticsReviewStore((s) => s.isCollecting);
   const [isRestarting, setIsRestarting] = useState(false);
   const recoveringShown = useDohertyGate(backendStatus === "recovering");
 
@@ -56,6 +58,43 @@ export function HostCrashBanner() {
     }
   };
 
+  const handleSendDiagnostics = () => {
+    void actionService.dispatch(
+      "diagnostics.openReview",
+      {
+        scope: {
+          source: "recovery.hostCrashBanner",
+          // 5-minute window scope hint — surfaced for downstream filtering once
+          // the collection IPC supports it; today it's metadata only.
+          timeWindowMs: 5 * 60 * 1000,
+        },
+      },
+      { source: "user" }
+    );
+  };
+
+  // `trailingSlot` is the documented escape hatch for surfacing a secondary
+  // affordance on an error banner without breaking the single-action rule
+  // (see InlineStatusBanner.tsx). Keeping "Restart service" as the primary
+  // `action` preserves the dangerFilled emphasis.
+  const sendDiagnosticsButton = (
+    <button
+      type="button"
+      onClick={handleSendDiagnostics}
+      disabled={isCollectingDiagnostics}
+      aria-label="Send diagnostics"
+      className={cn(
+        "flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded transition-colors",
+        "text-daintree-text/70 hover:text-daintree-text hover:bg-daintree-border/50",
+        "outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent",
+        isCollectingDiagnostics && "cursor-not-allowed opacity-60 hover:bg-transparent"
+      )}
+    >
+      <Download className="w-3 h-3" aria-hidden="true" />
+      {isCollectingDiagnostics ? "Collecting…" : "Send diagnostics"}
+    </button>
+  );
+
   return (
     <InlineStatusBanner
       icon={AlertTriangle}
@@ -64,6 +103,7 @@ export function HostCrashBanner() {
       severity="error"
       role="alert"
       animated={false}
+      trailingSlot={sendDiagnosticsButton}
       action={{
         id: "restart",
         label: isRestarting ? "Restarting…" : "Restart service",

--- a/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
+++ b/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
@@ -89,18 +89,39 @@ vi.mock("@/components/Terminal/InlineStatusBanner", () => ({
     title,
     description,
     severity,
+    action,
   }: {
     title: ReactNode;
     description?: ReactNode;
     severity?: string;
+    action?: { id: string; label: string; onClick: () => void };
   }) => (
     <div data-testid="inline-status-banner" data-severity={severity ?? "error"}>
       <span data-testid="inline-status-banner-title">{title}</span>
       {description ? (
         <span data-testid="inline-status-banner-description">{description}</span>
       ) : null}
+      {action ? (
+        <button
+          type="button"
+          data-testid={`inline-status-banner-action-${action.id}`}
+          onClick={action.onClick}
+        >
+          {action.label}
+        </button>
+      ) : null}
     </div>
   ),
+}));
+
+const actionServiceDispatchMock = vi.fn<
+  (actionId: string, args?: unknown, opts?: unknown) => Promise<{ ok: true; result: undefined }>
+>(async () => ({ ok: true, result: undefined }));
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch: (actionId: string, args?: unknown, opts?: unknown) =>
+      actionServiceDispatchMock(actionId, args, opts),
+  },
 }));
 
 const mockPanels = [
@@ -184,6 +205,7 @@ function setup(overrides?: {
 
 beforeEach(() => {
   notifyMock.mockReset();
+  actionServiceDispatchMock.mockClear();
   Object.defineProperty(window, "electron", {
     configurable: true,
     writable: true,
@@ -940,6 +962,66 @@ describe("CrashRecoveryDialog", () => {
       const rows = within(list).getAllByTestId(/^action-row-/);
       expect(rows[0]!.getAttribute("data-testid")).toBe("action-row-act-2");
       expect(rows[1]!.getAttribute("data-testid")).toBe("action-row-act-1");
+    });
+  });
+
+  describe("recovery-failed inline banner", () => {
+    it("does not render the banner during the happy path", () => {
+      setup();
+      expect(screen.queryByTestId("recovery-error")).toBeNull();
+    });
+
+    it("shows an inline error with Send diagnostics when onResolve rejects", async () => {
+      const failingResolve = vi.fn(async () => {
+        throw new Error("backup unreadable");
+      });
+      setup({ onResolve: failingResolve });
+
+      // Select-all is already selected by default for non-suspect panels; click
+      // "Restore selected" to fire onResolve.
+      fireEvent.click(screen.getByTestId("restore-selected-button"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("recovery-error")).toBeTruthy();
+      });
+      const banner = within(screen.getByTestId("recovery-error")).getByTestId(
+        "inline-status-banner"
+      );
+      expect(banner.getAttribute("data-severity")).toBe("error");
+      const desc = within(screen.getByTestId("recovery-error")).getByTestId(
+        "inline-status-banner-description"
+      );
+      expect(desc.textContent).toContain("backup unreadable");
+
+      // notify() is NOT called for the recovery-failed path — the inline banner
+      // replaces it because the Toaster isn't mounted while the crash dialog
+      // is blocking the app.
+      expect(notifyMock).not.toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Recovery failed" })
+      );
+    });
+
+    it("Send diagnostics button dispatches the diagnostics.openReview action", async () => {
+      const failingResolve = vi.fn(async () => {
+        throw new Error("boom");
+      });
+      setup({ onResolve: failingResolve });
+      fireEvent.click(screen.getByTestId("restore-selected-button"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("recovery-error")).toBeTruthy();
+      });
+      fireEvent.click(
+        within(screen.getByTestId("recovery-error")).getByTestId(
+          "inline-status-banner-action-send-diagnostics"
+        )
+      );
+
+      expect(actionServiceDispatchMock).toHaveBeenCalledWith(
+        "diagnostics.openReview",
+        { scope: { source: "recovery.crashRecoveryFailed" } },
+        { source: "user" }
+      );
     });
   });
 });

--- a/src/components/Settings/DiagnosticsReviewDialog.tsx
+++ b/src/components/Settings/DiagnosticsReviewDialog.tsx
@@ -15,6 +15,7 @@ import {
 } from "@shared/utils/diagnosticsTransform";
 import type { DiagnosticsReviewPayload } from "@shared/types/ipc/system";
 import { safeStringify } from "@/lib/safeStringify";
+import type { DiagnosticsReviewScope } from "@/store/diagnosticsReviewStore";
 
 type TimeWindowId = "5m" | "30m" | "launch" | "full";
 
@@ -63,6 +64,12 @@ interface DiagnosticsReviewDialogProps {
     timeWindowStartMs: number | null
   ) => void;
   isSaving: boolean;
+  /**
+   * Optional scope hint. When `sections` is provided, only those keys start
+   * enabled; sections not listed start unchecked. The user can still toggle
+   * any section manually before saving.
+   */
+  initialScope?: DiagnosticsReviewScope | null;
 }
 
 export function DiagnosticsReviewDialog({
@@ -71,6 +78,7 @@ export function DiagnosticsReviewDialog({
   reviewPayload,
   onSave,
   isSaving,
+  initialScope,
 }: DiagnosticsReviewDialogProps) {
   const [enabledSections, setEnabledSections] = useState<Record<string, boolean>>({});
   const [replacements, setReplacements] = useState<ReplacementRule[]>([
@@ -87,9 +95,17 @@ export function DiagnosticsReviewDialog({
   useEffect(() => {
     if (isOpen && reviewPayload) {
       setOpenedAt(Date.now());
+      const scopedSections = initialScope?.sections;
       const initial: Record<string, boolean> = {};
-      for (const key of reviewPayload.sectionKeys) {
-        initial[key] = true;
+      if (scopedSections && scopedSections.length > 0) {
+        const allow = new Set(scopedSections);
+        for (const key of reviewPayload.sectionKeys) {
+          initial[key] = allow.has(key);
+        }
+      } else {
+        for (const key of reviewPayload.sectionKeys) {
+          initial[key] = true;
+        }
       }
       setEnabledSections(initial);
       setReplacements([{ find: "", replace: "[REDACTED]" }]);
@@ -97,7 +113,7 @@ export function DiagnosticsReviewDialog({
       setTimeWindow(DEFAULT_TIME_WINDOW);
       setShowPreview(false);
     }
-  }, [isOpen, reviewPayload]);
+  }, [isOpen, reviewPayload, initialScope]);
 
   // Active prebuilt toggles contribute regex rules, prepended before the user's
   // literal rules so canonical patterns run first.

--- a/src/components/Settings/DiagnosticsReviewDialog.tsx
+++ b/src/components/Settings/DiagnosticsReviewDialog.tsx
@@ -97,7 +97,11 @@ export function DiagnosticsReviewDialog({
       setOpenedAt(Date.now());
       const scopedSections = initialScope?.sections;
       const initial: Record<string, boolean> = {};
-      if (scopedSections && scopedSections.length > 0) {
+      // Distinguish "no scope" (sectionKeys undefined → all enabled) from
+      // "explicit empty scope" (sectionKeys === [] → none enabled). The
+      // latter would otherwise fall back to all-enabled, ignoring an
+      // intentional clear from the caller.
+      if (scopedSections !== undefined) {
         const allow = new Set(scopedSections);
         for (const key of reviewPayload.sectionKeys) {
           initial[key] = allow.has(key);

--- a/src/components/Settings/DiagnosticsReviewDialogHost.tsx
+++ b/src/components/Settings/DiagnosticsReviewDialogHost.tsx
@@ -1,0 +1,37 @@
+import { useShallow } from "zustand/react/shallow";
+import { useDiagnosticsReviewStore } from "@/store/diagnosticsReviewStore";
+import { DiagnosticsReviewDialog } from "./DiagnosticsReviewDialog";
+
+/**
+ * App-level host for the diagnostics review dialog. Reads dialog state from
+ * the store so any caller (Settings, HostCrashBanner, error toasts) can drive
+ * the same dialog by dispatching `diagnostics.openReview` — the dialog lives
+ * outside the Settings subtree and stays mounted regardless of where the
+ * request came from.
+ */
+export function DiagnosticsReviewDialogHost() {
+  const { isOpen, reviewPayload, isSaving, scope, closeReview, saveReview } =
+    useDiagnosticsReviewStore(
+      useShallow((s) => ({
+        isOpen: s.isOpen,
+        reviewPayload: s.reviewPayload,
+        isSaving: s.isSaving,
+        scope: s.scope,
+        closeReview: s.closeReview,
+        saveReview: s.saveReview,
+      }))
+    );
+
+  return (
+    <DiagnosticsReviewDialog
+      isOpen={isOpen}
+      onClose={closeReview}
+      reviewPayload={reviewPayload}
+      onSave={(enabledSections, replacements, timeWindowStartMs) => {
+        void saveReview(enabledSections, replacements, timeWindowStartMs);
+      }}
+      isSaving={isSaving}
+      initialScope={scope}
+    />
+  );
+}

--- a/src/components/Settings/TroubleshootingTab.tsx
+++ b/src/components/Settings/TroubleshootingTab.tsx
@@ -16,19 +16,12 @@ import {
 import { cn } from "@/lib/utils";
 import { appClient, systemClient, logsClient } from "@/clients";
 import type { AppState, SystemHealthCheckResult } from "@shared/types";
-import type { DiagnosticsReviewPayload } from "@shared/types/ipc/system";
-import type { ReplacementRule } from "@shared/utils/diagnosticsTransform";
-import {
-  buildDiagnosticsIssueUrl,
-  type DiagnosticsIssueMetadata,
-} from "@shared/utils/githubIssueUrl";
 import { actionService } from "@/services/ActionService";
-import { notify } from "@/lib/notify";
+import { useDiagnosticsReviewStore } from "@/store/diagnosticsReviewStore";
 import { logError, logWarn } from "@/utils/logger";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { SettingsSection } from "./SettingsSection";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
-import { DiagnosticsReviewDialog } from "./DiagnosticsReviewDialog";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 function SystemHealthSection() {
@@ -97,89 +90,16 @@ function SystemHealthSection() {
   );
 }
 
-/** Pull the GitHub-issue env summary fields out of the untyped review payload. */
-function extractIssueMetadata(payload: Record<string, unknown>): DiagnosticsIssueMetadata {
-  const str = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined);
-  const isRecord = (v: unknown): v is Record<string, unknown> =>
-    typeof v === "object" && v !== null;
-  const section = (key: string): Record<string, unknown> | undefined => {
-    const value = payload[key];
-    return isRecord(value) ? value : undefined;
-  };
-  const metadata = section("metadata");
-  const runtime = section("runtime");
-  const os = section("os");
-  return {
-    appVersion: str(metadata?.appVersion),
-    electronVersion: str(metadata?.electronVersion),
-    nodeVersion: str(metadata?.nodeVersion),
-    platform: str(runtime?.platform) ?? str(os?.platform),
-    osVersion: str(os?.version) ?? str(os?.release),
-  };
-}
-
 function DownloadDiagnosticsSection() {
-  const [isCollecting, setIsCollecting] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
-  const [reviewOpen, setReviewOpen] = useState(false);
-  const [reviewPayload, setReviewPayload] = useState<DiagnosticsReviewPayload | null>(null);
-  const [downloadError, setDownloadError] = useState<string | null>(null);
+  const isCollecting = useDiagnosticsReviewStore((s) => s.isCollecting);
+  const downloadError = useDiagnosticsReviewStore((s) => s.downloadError);
 
-  const handleOpenReview = async () => {
-    setIsCollecting(true);
-    setDownloadError(null);
-    try {
-      const payload = await systemClient.collectDiagnosticsForReview();
-      setReviewPayload(payload);
-      setReviewOpen(true);
-    } catch (err) {
-      setDownloadError(formatErrorMessage(err, "Failed to collect diagnostics"));
-    } finally {
-      setIsCollecting(false);
-    }
-  };
-
-  const handleSave = async (
-    enabledSections: Record<string, boolean>,
-    replacements: ReplacementRule[],
-    timeWindowStartMs: number | null
-  ) => {
-    setIsSaving(true);
-    try {
-      const payload = reviewPayload?.payload ?? {};
-      const saved = await systemClient.saveDiagnosticsBundle({
-        payload,
-        enabledSections,
-        replacements,
-        timeWindowStartMs,
-      });
-      if (saved) {
-        const issueUrl = buildDiagnosticsIssueUrl(extractIssueMetadata(payload));
-        notify({
-          type: "success",
-          title: "Diagnostics saved",
-          message: "Open a GitHub issue and drag the saved ZIP into it.",
-          // The saved ZIP is already revealed in the OS file manager, so this
-          // is a one-shot action prompt — no durable inbox row needed.
-          transient: true,
-          context: { eventKind: "settings" },
-          action: {
-            label: "Continue to GitHub issue",
-            variant: "primary",
-            onClick: () => {
-              safeFireAndForget(systemClient.openExternal(issueUrl), {
-                context: "Opening GitHub issue from diagnostics save",
-              });
-            },
-          },
-        });
-        setReviewOpen(false);
-      }
-    } catch (err) {
-      setDownloadError(formatErrorMessage(err, "Failed to save diagnostics bundle"));
-    } finally {
-      setIsSaving(false);
-    }
+  const handleOpenReview = () => {
+    void actionService.dispatch(
+      "diagnostics.openReview",
+      { scope: { source: "settings.troubleshooting" } },
+      { source: "user" }
+    );
   };
 
   return (
@@ -191,7 +111,7 @@ function DownloadDiagnosticsSection() {
       <Button
         variant="outline"
         size="sm"
-        onClick={() => void handleOpenReview()}
+        onClick={handleOpenReview}
         disabled={isCollecting}
         className="text-daintree-text border-daintree-border hover:bg-daintree-border hover:text-daintree-text mb-3"
       >
@@ -199,13 +119,6 @@ function DownloadDiagnosticsSection() {
         {isCollecting ? "Collecting..." : "Download Diagnostics"}
       </Button>
       {downloadError && <p className="text-xs text-status-error mb-3">{downloadError}</p>}
-      <DiagnosticsReviewDialog
-        isOpen={reviewOpen}
-        onClose={() => setReviewOpen(false)}
-        reviewPayload={reviewPayload}
-        onSave={handleSave}
-        isSaving={isSaving}
-      />
     </SettingsSection>
   );
 }

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -963,6 +963,18 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "title": "Open Dev Preview",
   },
   {
+    "category": "diagnostics",
+    "danger": "safe",
+    "dangerRationale": undefined,
+    "description": "Collect a diagnostics snapshot and open the review dialog for export. Optional scope hint (timeWindowMs, sections) pre-selects which sections to include.",
+    "examples": undefined,
+    "id": "diagnostics.openReview",
+    "keywords": undefined,
+    "kind": "command",
+    "requiresArgs": false,
+    "title": "Send diagnostics",
+  },
+  {
     "category": "agent",
     "danger": "safe",
     "dangerRationale": undefined,

--- a/src/services/actions/actionDefinitions.ts
+++ b/src/services/actions/actionDefinitions.ts
@@ -6,6 +6,7 @@ import { registerAppActions } from "./definitions/appActions";
 import { registerBrowserActions } from "./definitions/browserActions";
 import { registerDevPreviewActions } from "./definitions/devPreviewActions";
 import { registerDevServerActions } from "./definitions/devServerActions";
+import { registerDiagnosticsActions } from "./definitions/diagnosticsActions";
 import { registerEnvActions } from "./definitions/envActions";
 import { registerGithubActions } from "./definitions/githubActions";
 import { registerGitActions } from "./definitions/gitActions";
@@ -68,6 +69,7 @@ export function createActionDefinitions(
   registerIntrospectionActions(actions, callbacks);
   registerDevServerActions(actions, callbacks);
   registerDevPreviewActions(actions, callbacks);
+  registerDiagnosticsActions(actions, callbacks);
   registerWorkflowActions(actions, callbacks);
   registerFileActions(actions, callbacks);
   registerVoiceActions(actions);

--- a/src/services/actions/definitions/diagnosticsActions.ts
+++ b/src/services/actions/definitions/diagnosticsActions.ts
@@ -8,6 +8,8 @@ const scopeSchema = z.object({
   sections: z.array(z.string()).optional(),
 });
 
+const argsSchema = z.object({ scope: scopeSchema.optional() }).optional();
+
 export function registerDiagnosticsActions(
   actions: ActionRegistry,
   _callbacks: ActionCallbacks
@@ -21,10 +23,13 @@ export function registerDiagnosticsActions(
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ scope: scopeSchema.optional() }).optional(),
+    argsSchema,
     run: async (args: unknown) => {
-      const parsed = (args as { scope?: z.infer<typeof scopeSchema> } | undefined) ?? {};
-      await useDiagnosticsReviewStore.getState().openReview(parsed.scope);
+      // Parse rather than cast so the lint ratchet doesn't grow the
+      // `no-unsafe-type-assertion` baseline; the dispatcher already validates
+      // via argsSchema, so this is effectively a typed re-derive.
+      const parsed = argsSchema.parse(args);
+      await useDiagnosticsReviewStore.getState().openReview(parsed?.scope);
     },
   }));
 }

--- a/src/services/actions/definitions/diagnosticsActions.ts
+++ b/src/services/actions/definitions/diagnosticsActions.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
+import { useDiagnosticsReviewStore } from "@/store/diagnosticsReviewStore";
+
+const scopeSchema = z.object({
+  timeWindowMs: z.number().int().positive().optional(),
+  source: z.string().optional(),
+  sections: z.array(z.string()).optional(),
+});
+
+export function registerDiagnosticsActions(
+  actions: ActionRegistry,
+  _callbacks: ActionCallbacks
+): void {
+  actions.set("diagnostics.openReview", () => ({
+    id: "diagnostics.openReview",
+    title: "Send diagnostics",
+    description:
+      "Collect a diagnostics snapshot and open the review dialog for export. Optional scope hint (timeWindowMs, sections) pre-selects which sections to include.",
+    category: "diagnostics",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: z.object({ scope: scopeSchema.optional() }).optional(),
+    run: async (args: unknown) => {
+      const parsed = (args as { scope?: z.infer<typeof scopeSchema> } | undefined) ?? {};
+      await useDiagnosticsReviewStore.getState().openReview(parsed.scope);
+    },
+  }));
+}

--- a/src/store/__tests__/diagnosticsReviewStore.test.ts
+++ b/src/store/__tests__/diagnosticsReviewStore.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { collectMock, saveMock } = vi.hoisted(() => ({
+  collectMock: vi.fn(),
+  saveMock: vi.fn(),
+}));
+
+vi.mock("@/clients", () => ({
+  systemClient: {
+    collectDiagnosticsForReview: collectMock,
+    saveDiagnosticsBundle: saveMock,
+    openExternal: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@/lib/notify", () => ({
+  notify: vi.fn(),
+}));
+
+vi.mock("@/utils/safeFireAndForget", () => ({
+  safeFireAndForget: vi.fn(),
+}));
+
+import { useDiagnosticsReviewStore } from "../diagnosticsReviewStore";
+
+const samplePayload = {
+  payload: { app: { version: "1.0" }, env: { node: "20" } },
+  sectionKeys: ["app", "env"],
+  previewJson: '{"app":{"version":"1.0"},"env":{"node":"20"}}',
+};
+
+function resetStore() {
+  useDiagnosticsReviewStore.setState({
+    isOpen: false,
+    isCollecting: false,
+    isSaving: false,
+    reviewPayload: null,
+    scope: null,
+    downloadError: null,
+  });
+}
+
+describe("diagnosticsReviewStore", () => {
+  beforeEach(() => {
+    collectMock.mockReset();
+    saveMock.mockReset();
+    resetStore();
+  });
+
+  it("starts closed with no payload or error", () => {
+    const state = useDiagnosticsReviewStore.getState();
+    expect(state.isOpen).toBe(false);
+    expect(state.isCollecting).toBe(false);
+    expect(state.isSaving).toBe(false);
+    expect(state.reviewPayload).toBeNull();
+    expect(state.downloadError).toBeNull();
+  });
+
+  it("openReview collects then atomically sets isOpen + reviewPayload + clears collecting", async () => {
+    collectMock.mockResolvedValueOnce(samplePayload);
+
+    const seenStates: Array<{
+      isCollecting: boolean;
+      isOpen: boolean;
+      payload: unknown;
+    }> = [];
+    const unsub = useDiagnosticsReviewStore.subscribe((s) =>
+      seenStates.push({
+        isCollecting: s.isCollecting,
+        isOpen: s.isOpen,
+        payload: s.reviewPayload,
+      })
+    );
+
+    await useDiagnosticsReviewStore.getState().openReview();
+    unsub();
+
+    expect(collectMock).toHaveBeenCalledTimes(1);
+
+    // The mid-flight state has isCollecting=true with the dialog still closed.
+    expect(seenStates[0]).toEqual({ isCollecting: true, isOpen: false, payload: null });
+
+    // Final state: dialog open, payload populated, collecting cleared — all in
+    // a single transition so the dialog's useEffect never observes an
+    // intermediate (isOpen=true, payload=null) frame.
+    const final = useDiagnosticsReviewStore.getState();
+    expect(final.isOpen).toBe(true);
+    expect(final.isCollecting).toBe(false);
+    expect(final.reviewPayload).toEqual(samplePayload);
+    expect(final.downloadError).toBeNull();
+  });
+
+  it("openReview captures the scope hint", async () => {
+    collectMock.mockResolvedValueOnce(samplePayload);
+    await useDiagnosticsReviewStore.getState().openReview({
+      source: "recovery.hostCrashBanner",
+      timeWindowMs: 300_000,
+      sections: ["app"],
+    });
+
+    const state = useDiagnosticsReviewStore.getState();
+    expect(state.scope).toEqual({
+      source: "recovery.hostCrashBanner",
+      timeWindowMs: 300_000,
+      sections: ["app"],
+    });
+  });
+
+  it("openReview reports collection failures via downloadError without opening", async () => {
+    collectMock.mockRejectedValueOnce(new Error("boom"));
+    await useDiagnosticsReviewStore.getState().openReview();
+
+    const state = useDiagnosticsReviewStore.getState();
+    expect(state.isOpen).toBe(false);
+    expect(state.isCollecting).toBe(false);
+    expect(state.reviewPayload).toBeNull();
+    expect(state.downloadError).toContain("boom");
+  });
+
+  it("ignores concurrent openReview calls while collecting", async () => {
+    type Resolver = (value: typeof samplePayload) => void;
+    let resolveCollect: Resolver = () => {};
+    collectMock.mockImplementationOnce(
+      () =>
+        new Promise<typeof samplePayload>((resolve) => {
+          resolveCollect = resolve;
+        })
+    );
+
+    const first = useDiagnosticsReviewStore.getState().openReview();
+    // Second call should short-circuit because isCollecting is already true.
+    await useDiagnosticsReviewStore.getState().openReview();
+    expect(collectMock).toHaveBeenCalledTimes(1);
+
+    resolveCollect(samplePayload);
+    await first;
+  });
+
+  it("closeReview clears isOpen and the scope hint", async () => {
+    collectMock.mockResolvedValueOnce(samplePayload);
+    await useDiagnosticsReviewStore.getState().openReview({ source: "settings" });
+    expect(useDiagnosticsReviewStore.getState().isOpen).toBe(true);
+
+    useDiagnosticsReviewStore.getState().closeReview();
+    const state = useDiagnosticsReviewStore.getState();
+    expect(state.isOpen).toBe(false);
+    expect(state.scope).toBeNull();
+    // The collected payload is intentionally retained so a re-open from the
+    // same surface doesn't need to re-IPC. closeReview only flips the visible
+    // state.
+    expect(state.reviewPayload).toEqual(samplePayload);
+  });
+
+  it("saveReview hits IPC and closes the dialog when the user picks a file", async () => {
+    collectMock.mockResolvedValueOnce(samplePayload);
+    saveMock.mockResolvedValueOnce(true);
+    await useDiagnosticsReviewStore.getState().openReview();
+
+    await useDiagnosticsReviewStore
+      .getState()
+      .saveReview({ app: true, env: false }, [{ find: "secret", replace: "[REDACTED]" }]);
+
+    expect(saveMock).toHaveBeenCalledWith({
+      payload: samplePayload.payload,
+      enabledSections: { app: true, env: false },
+      replacements: [{ find: "secret", replace: "[REDACTED]" }],
+      timeWindowStartMs: undefined,
+    });
+    const state = useDiagnosticsReviewStore.getState();
+    expect(state.isOpen).toBe(false);
+    expect(state.isSaving).toBe(false);
+  });
+
+  it("saveReview keeps the dialog open when the user cancels the save dialog", async () => {
+    collectMock.mockResolvedValueOnce(samplePayload);
+    saveMock.mockResolvedValueOnce(false);
+    await useDiagnosticsReviewStore.getState().openReview();
+
+    await useDiagnosticsReviewStore.getState().saveReview({ app: true }, []);
+    const state = useDiagnosticsReviewStore.getState();
+    expect(state.isOpen).toBe(true);
+    expect(state.isSaving).toBe(false);
+  });
+
+  it("saveReview surfaces IPC failures via downloadError", async () => {
+    collectMock.mockResolvedValueOnce(samplePayload);
+    saveMock.mockRejectedValueOnce(new Error("disk full"));
+    await useDiagnosticsReviewStore.getState().openReview();
+
+    await useDiagnosticsReviewStore.getState().saveReview({ app: true }, []);
+    const state = useDiagnosticsReviewStore.getState();
+    expect(state.isSaving).toBe(false);
+    expect(state.downloadError).toContain("disk full");
+  });
+
+  it("saveReview no-ops if there is no payload yet", async () => {
+    await useDiagnosticsReviewStore.getState().saveReview({}, []);
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  it("clearError resets the error string", () => {
+    useDiagnosticsReviewStore.setState({ downloadError: "boom" });
+    useDiagnosticsReviewStore.getState().clearError();
+    expect(useDiagnosticsReviewStore.getState().downloadError).toBeNull();
+  });
+});

--- a/src/store/__tests__/diagnosticsReviewStore.test.ts
+++ b/src/store/__tests__/diagnosticsReviewStore.test.ts
@@ -171,6 +171,40 @@ describe("diagnosticsReviewStore", () => {
     expect(state.isSaving).toBe(false);
   });
 
+  it("saveReview clears stale downloadError on success", async () => {
+    collectMock.mockResolvedValueOnce(samplePayload);
+    saveMock.mockResolvedValueOnce(true);
+    await useDiagnosticsReviewStore.getState().openReview();
+    // Seed a stale error from a prior attempt.
+    useDiagnosticsReviewStore.setState({ downloadError: "previous attempt failed" });
+
+    await useDiagnosticsReviewStore.getState().saveReview({ app: true }, []);
+    expect(useDiagnosticsReviewStore.getState().downloadError).toBeNull();
+  });
+
+  it("openReview short-circuits while a save is in flight", async () => {
+    collectMock.mockResolvedValueOnce(samplePayload);
+    await useDiagnosticsReviewStore.getState().openReview();
+
+    // Park the save in-flight and try to open a second review.
+    type Resolver = (value: boolean) => void;
+    let resolveSave: Resolver = () => {};
+    saveMock.mockImplementationOnce(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveSave = resolve;
+        })
+    );
+
+    const savePromise = useDiagnosticsReviewStore.getState().saveReview({ app: true }, []);
+    await useDiagnosticsReviewStore.getState().openReview();
+    // collectMock would have been called twice if the guard missed.
+    expect(collectMock).toHaveBeenCalledTimes(1);
+
+    resolveSave(true);
+    await savePromise;
+  });
+
   it("saveReview keeps the dialog open when the user cancels the save dialog", async () => {
     collectMock.mockResolvedValueOnce(samplePayload);
     saveMock.mockResolvedValueOnce(false);

--- a/src/store/diagnosticsReviewStore.ts
+++ b/src/store/diagnosticsReviewStore.ts
@@ -67,7 +67,11 @@ export const useDiagnosticsReviewStore = create<DiagnosticsReviewState>((set, ge
   downloadError: null,
 
   openReview: async (scope) => {
-    if (get().isCollecting) return;
+    // Block while a prior open is in flight OR while a save is still resolving
+    // — otherwise a second open swaps `reviewPayload` underneath the in-flight
+    // save and the save's success callback would then close the freshly opened
+    // dialog.
+    if (get().isCollecting || get().isSaving) return;
     set({ isCollecting: true, downloadError: null });
     try {
       const payload = await systemClient.collectDiagnosticsForReview();
@@ -121,7 +125,7 @@ export const useDiagnosticsReviewStore = create<DiagnosticsReviewState>((set, ge
             },
           },
         });
-        set({ isSaving: false, isOpen: false, scope: null });
+        set({ isSaving: false, isOpen: false, scope: null, downloadError: null });
       } else {
         set({ isSaving: false });
       }

--- a/src/store/diagnosticsReviewStore.ts
+++ b/src/store/diagnosticsReviewStore.ts
@@ -1,0 +1,137 @@
+import { create } from "zustand";
+import type { DiagnosticsReviewPayload } from "@shared/types/ipc/system";
+import type { ReplacementRule } from "@shared/utils/diagnosticsTransform";
+import { systemClient } from "@/clients";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
+import {
+  buildDiagnosticsIssueUrl,
+  type DiagnosticsIssueMetadata,
+} from "@shared/utils/githubIssueUrl";
+import { notify } from "@/lib/notify";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
+
+export interface DiagnosticsReviewScope {
+  /** Time window hint (ms) — currently UI metadata; no backend filtering yet. */
+  timeWindowMs?: number;
+  /** Surface that requested the export, for correlation in future telemetry. */
+  source?: string;
+  /** Pre-selected section keys. Sections not listed start unchecked. */
+  sections?: string[];
+}
+
+interface DiagnosticsReviewState {
+  isOpen: boolean;
+  isCollecting: boolean;
+  isSaving: boolean;
+  reviewPayload: DiagnosticsReviewPayload | null;
+  scope: DiagnosticsReviewScope | null;
+  downloadError: string | null;
+
+  openReview: (scope?: DiagnosticsReviewScope) => Promise<void>;
+  closeReview: () => void;
+  saveReview: (
+    enabledSections: Record<string, boolean>,
+    replacements: ReplacementRule[],
+    timeWindowStartMs?: number | null
+  ) => Promise<void>;
+  clearError: () => void;
+}
+
+/** Pull the GitHub-issue env summary fields out of the untyped review payload. */
+function extractIssueMetadata(payload: Record<string, unknown>): DiagnosticsIssueMetadata {
+  const str = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined);
+  const isRecord = (v: unknown): v is Record<string, unknown> =>
+    typeof v === "object" && v !== null;
+  const section = (key: string): Record<string, unknown> | undefined => {
+    const value = payload[key];
+    return isRecord(value) ? value : undefined;
+  };
+  const metadata = section("metadata");
+  const runtime = section("runtime");
+  const os = section("os");
+  return {
+    appVersion: str(metadata?.appVersion),
+    electronVersion: str(metadata?.electronVersion),
+    nodeVersion: str(metadata?.nodeVersion),
+    platform: str(runtime?.platform) ?? str(os?.platform),
+    osVersion: str(os?.version) ?? str(os?.release),
+  };
+}
+
+export const useDiagnosticsReviewStore = create<DiagnosticsReviewState>((set, get) => ({
+  isOpen: false,
+  isCollecting: false,
+  isSaving: false,
+  reviewPayload: null,
+  scope: null,
+  downloadError: null,
+
+  openReview: async (scope) => {
+    if (get().isCollecting) return;
+    set({ isCollecting: true, downloadError: null });
+    try {
+      const payload = await systemClient.collectDiagnosticsForReview();
+      set({
+        isOpen: true,
+        reviewPayload: payload,
+        scope: scope ?? null,
+        isCollecting: false,
+      });
+    } catch (err) {
+      set({
+        isCollecting: false,
+        downloadError: formatErrorMessage(err, "Failed to collect diagnostics"),
+      });
+    }
+  },
+
+  closeReview: () => {
+    set({ isOpen: false, scope: null });
+  },
+
+  saveReview: async (enabledSections, replacements, timeWindowStartMs) => {
+    const { reviewPayload } = get();
+    if (!reviewPayload || get().isSaving) return;
+    set({ isSaving: true });
+    try {
+      const payload = reviewPayload.payload;
+      const saved = await systemClient.saveDiagnosticsBundle({
+        payload,
+        enabledSections,
+        replacements,
+        timeWindowStartMs,
+      });
+      if (saved) {
+        const issueUrl = buildDiagnosticsIssueUrl(extractIssueMetadata(payload));
+        notify({
+          type: "success",
+          title: "Diagnostics saved",
+          message: "Open a GitHub issue and drag the saved ZIP into it.",
+          // The saved ZIP is already revealed in the OS file manager, so this
+          // is a one-shot action prompt — no durable inbox row needed.
+          transient: true,
+          context: { eventKind: "settings" },
+          action: {
+            label: "Continue to GitHub issue",
+            variant: "primary",
+            onClick: () => {
+              safeFireAndForget(systemClient.openExternal(issueUrl), {
+                context: "Opening GitHub issue from diagnostics save",
+              });
+            },
+          },
+        });
+        set({ isSaving: false, isOpen: false, scope: null });
+      } else {
+        set({ isSaving: false });
+      }
+    } catch (err) {
+      set({
+        isSaving: false,
+        downloadError: formatErrorMessage(err, "Failed to save diagnostics bundle"),
+      });
+    }
+  },
+
+  clearError: () => set({ downloadError: null }),
+}));

--- a/src/store/listeners/panel/lifecycle.ts
+++ b/src/store/listeners/panel/lifecycle.ts
@@ -159,6 +159,7 @@ export async function handleFallbackTriggered(data: {
         message: `Could not switch to "${nextPreset.name}": ${result.error ?? "unknown error"}`,
         duration: 12000,
         supersedeKey: fallbackSupersedeKey,
+        context: { eventKind: "agent", panelId: terminalId },
         action: {
           label: "Send diagnostics",
           actionId: "diagnostics.openReview",

--- a/src/store/listeners/panel/lifecycle.ts
+++ b/src/store/listeners/panel/lifecycle.ts
@@ -152,7 +152,6 @@ export async function handleFallbackTriggered(data: {
         supersedeKey: fallbackSupersedeKey,
       });
     } else {
-      // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
       notify({
         type: "error",
         priority: "high",
@@ -160,6 +159,18 @@ export async function handleFallbackTriggered(data: {
         message: `Could not switch to "${nextPreset.name}": ${result.error ?? "unknown error"}`,
         duration: 12000,
         supersedeKey: fallbackSupersedeKey,
+        action: {
+          label: "Send diagnostics",
+          actionId: "diagnostics.openReview",
+          actionArgs: { scope: { source: "terminal.fallbackActivationFailed" } },
+          onClick: () => {
+            void actionService.dispatch(
+              "diagnostics.openReview",
+              { scope: { source: "terminal.fallbackActivationFailed" } },
+              { source: "user" }
+            );
+          },
+        },
       });
     }
   } finally {


### PR DESCRIPTION
## Summary

- The diagnostics review/export dialog was only reachable from Settings > Troubleshooting. Users hitting a real crash couldn't get to it without navigating away from the error surface.
- New `diagnosticsReviewStore` singleton lifts dialog state out of `TroubleshootingTab` and makes it dispatchable from anywhere via a new `diagnostics.openReview` action with an optional `scope` parameter.
- `DiagnosticsReviewDialogHost` is now mounted lazily at the `App` level so the dialog is reachable even while the crash recovery dialog is blocking.

Resolves #9139

## Changes

- **`diagnosticsReviewStore`** (`src/store/diagnosticsReviewStore.ts`) — singleton Zustand store managing open/close/save lifecycle with atomic state transitions. Prevents stale-payload races and captures collection errors inline.
- **`diagnostics.openReview` action** (`src/services/actions/definitions/diagnosticsActions.ts`) — calls into the store; accepts optional `{ source, timeWindowMs, sections }` scope so each call site can narrow what gets collected.
- **`DiagnosticsReviewDialogHost`** (`src/components/Settings/DiagnosticsReviewDialogHost.tsx`) — lazy host mounted in both the main and crash-pending branches of `App.tsx`.
- **`HostCrashBanner`** — secondary "Send diagnostics" button via `InlineStatusBanner.trailingSlot`; also surfaces collection failures inline rather than via `notify()`.
- **`CrashRecoveryDialog`** — recovery-failed path switches from a dead `notify()` call (Toaster isn't mounted) to an `InlineStatusBanner` with a "Send diagnostics" action.
- **`lifecycle.ts`** — "Fallback activation failed" toast gets a "Send diagnostics" action.
- **`TroubleshootingTab`** — simplified to dispatch the action instead of owning local dialog state.

## Testing

- New `src/store/__tests__/diagnosticsReviewStore.test.ts` — 13 tests covering open/close/save lifecycle, atomic state transitions, scope retention, error capture, `isCollecting`/`isSaving` guards, and stale-error clearing on save success.
- New tests in `src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx` — recovery-failed inline banner appears on `onResolve` rejection; "Send diagnostics" dispatches the right scope.
- `ErrorBoundary` GitHub-URL flow untouched (out of scope per issue).