### PR TITLE
feat(notifications): add OS-level Do-Not-Disturb awareness (#9188)

### DIFF
--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 1269,
-  "moduleCount": 1269,
+  "count": 1273,
+  "moduleCount": 1273,
   "allowlist": [
     "electron/ipc/errorHandlers.ts",
     "electron/ipc/handlers/agentCapabilities.ts",
@@ -163,12 +163,12 @@
     },
     {
       "file": "electron/ipc/handlers/diagnostics.ts",
-      "line": 55,
+      "line": 65,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/ipc/handlers/diagnostics.ts",
-      "line": 62,
+      "line": 72,
       "pattern": "sync-fs"
     },
     {
@@ -1068,22 +1068,22 @@
     },
     {
       "file": "electron/services/PluginService.ts",
-      "line": 356,
+      "line": 381,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/PluginService.ts",
-      "line": 367,
+      "line": 392,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/PluginService.ts",
-      "line": 384,
+      "line": 409,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/PluginService.ts",
-      "line": 1344,
+      "line": 1536,
       "pattern": "sync-store-get"
     },
     {
@@ -1373,17 +1373,12 @@
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 60,
+      "line": 71,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 61,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/setup/environment.ts",
-      "line": 63,
+      "line": 72,
       "pattern": "sync-fs"
     },
     {
@@ -1393,27 +1388,32 @@
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 86,
+      "line": 85,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 155,
+      "line": 97,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 251,
+      "line": 166,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 329,
+      "line": 262,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 643,
+      "line": 340,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/setup/environment.ts",
+      "line": 654,
       "pattern": "sync-sqlite"
     },
     {
@@ -1683,27 +1683,27 @@
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 87,
+      "line": 88,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 170,
+      "line": 171,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 235,
+      "line": 236,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 585,
+      "line": 597,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 731,
+      "line": 743,
       "pattern": "sync-store-get"
     },
     {

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -386,6 +386,12 @@ export const CHANNELS = {
   SYSTEM_SLEEP_ON_SUSPEND: "system-sleep:on-suspend",
   SYSTEM_SLEEP_ON_WAKE: "system-sleep:on-wake",
 
+  // OS Do-Not-Disturb / Focus state. Read-only push channel for the renderer;
+  // never used to suppress in-app toasts (the OS already silences its native
+  // banners — double-gating would hide signals the user cannot observe).
+  OS_DND_GET_STATE: "os-dnd:get-state",
+  OS_DND_STATE_CHANGED: "os-dnd:state-changed",
+
   KEYBINDING_GET_OVERRIDES: "keybinding:get-overrides",
   KEYBINDING_SET_OVERRIDE: "keybinding:set-override",
   KEYBINDING_REMOVE_OVERRIDE: "keybinding:remove-override",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -19,6 +19,7 @@ import { registerPortalHandlers } from "./handlers/portal.js";
 import { registerHibernationHandlers } from "./handlers/hibernation.js";
 import { registerIdleTerminalHandlers } from "./handlers/idleTerminals.js";
 import { registerSystemSleepHandlers } from "./handlers/systemSleep.js";
+import { registerOsDndHandlers } from "./handlers/osDnd.js";
 import { registerKeybindingHandlers } from "./handlers/keybinding.js";
 import { registerWorktreeConfigHandlers } from "./handlers/worktreeConfig.js";
 import { registerNotificationHandlers } from "./handlers/notifications.js";
@@ -127,6 +128,7 @@ export function registerIpcHandlers(deps: HandlerDependencies): () => void {
     register(() => registerHibernationHandlers(deps));
     register(() => registerIdleTerminalHandlers(deps));
     register(() => registerSystemSleepHandlers(deps));
+    register(() => registerOsDndHandlers(deps));
     register(() => registerKeybindingHandlers(deps));
     register(() => registerWorktreeConfigHandlers(deps));
     register(() => registerNotificationHandlers(deps));

--- a/electron/ipc/handlers/osDnd.preload.ts
+++ b/electron/ipc/handlers/osDnd.preload.ts
@@ -1,0 +1,24 @@
+import type { IpcInvokeMap } from "../../types/index.js";
+
+export const OS_DND_METHOD_CHANNELS = {
+  getState: "os-dnd:get-state",
+} as const satisfies Record<string, keyof IpcInvokeMap>;
+
+type Methods = typeof OS_DND_METHOD_CHANNELS;
+
+export type OsDndPreloadBindings = {
+  [M in keyof Methods]: (
+    ...args: IpcInvokeMap[Methods[M]]["args"]
+  ) => Promise<IpcInvokeMap[Methods[M]]["result"]>;
+};
+
+type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
+
+export function buildOsDndPreloadBindings(invoke: Invoker): OsDndPreloadBindings {
+  const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const method of Object.keys(OS_DND_METHOD_CHANNELS) as Array<keyof Methods>) {
+    const channel = OS_DND_METHOD_CHANNELS[method];
+    out[method as string] = (...args) => invoke(channel, ...args);
+  }
+  return out as unknown as OsDndPreloadBindings;
+}

--- a/electron/ipc/handlers/osDnd.ts
+++ b/electron/ipc/handlers/osDnd.ts
@@ -1,12 +1,16 @@
 import { CHANNELS } from "../channels.js";
 import { broadcastToRenderer } from "../utils.js";
-import { getOsDndService } from "../../services/OsDndService.js";
+import { initializeOsDndService } from "../../services/OsDndService.js";
 import type { HandlerDependencies } from "../types.js";
 import { defineIpcNamespace, op } from "../define.js";
 import { OS_DND_METHOD_CHANNELS } from "./osDnd.preload.js";
 
 export function registerOsDndHandlers(_deps: HandlerDependencies): () => void {
-  const osDndService = getOsDndService();
+  // Initialize eagerly during handler registration so the first renderer
+  // hydrate IPC call always lands on a probed service. The matching deferred
+  // task (electron/window/globalServicesInit.ts) is idempotent and remains in
+  // place for symmetry with sibling services.
+  const osDndService = initializeOsDndService();
 
   const namespace = defineIpcNamespace({
     name: "osDnd",

--- a/electron/ipc/handlers/osDnd.ts
+++ b/electron/ipc/handlers/osDnd.ts
@@ -1,0 +1,31 @@
+import { CHANNELS } from "../channels.js";
+import { broadcastToRenderer } from "../utils.js";
+import { getOsDndService } from "../../services/OsDndService.js";
+import type { HandlerDependencies } from "../types.js";
+import { defineIpcNamespace, op } from "../define.js";
+import { OS_DND_METHOD_CHANNELS } from "./osDnd.preload.js";
+
+export function registerOsDndHandlers(_deps: HandlerDependencies): () => void {
+  const osDndService = getOsDndService();
+
+  const namespace = defineIpcNamespace({
+    name: "osDnd",
+    ops: {
+      getState: op(
+        OS_DND_METHOD_CHANNELS.getState,
+        async (): Promise<boolean | undefined> => osDndService.getState()
+      ),
+    },
+  });
+
+  const cleanups: Array<() => void> = [];
+  cleanups.push(namespace.register());
+
+  cleanups.push(
+    osDndService.onStateChanged((osDndActive) => {
+      broadcastToRenderer(CHANNELS.OS_DND_STATE_CHANGED, { osDndActive });
+    })
+  );
+
+  return () => cleanups.forEach((cleanup) => cleanup());
+}

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -19,6 +19,7 @@ import { getDatabaseMaintenanceService } from "../services/DatabaseMaintenanceSe
 import { getHibernationService } from "../services/HibernationService.js";
 import { getIdleTerminalNotificationService } from "../services/IdleTerminalNotificationService.js";
 import { getSystemSleepService } from "../services/SystemSleepService.js";
+import { getOsDndService } from "../services/OsDndService.js";
 import { gitHubTokenHealthService } from "../services/github/GitHubTokenHealthService.js";
 import {
   agentConnectivityService,
@@ -253,6 +254,11 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
               getSystemSleepService().dispose();
             } catch (err) {
               console.warn("[MAIN] SystemSleepService.dispose failed:", err);
+            }
+            try {
+              getOsDndService().dispose();
+            } catch (err) {
+              console.warn("[MAIN] OsDndService.dispose failed:", err);
             }
 
             try {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -50,6 +50,7 @@ import { buildConnectivityPreloadBindings } from "./ipc/handlers/connectivity.pr
 import { buildHibernationPreloadBindings } from "./ipc/handlers/hibernation.preload.js";
 import { buildIdleTerminalPreloadBindings } from "./ipc/handlers/idleTerminals.preload.js";
 import { buildSystemSleepPreloadBindings } from "./ipc/handlers/systemSleep.preload.js";
+import { buildOsDndPreloadBindings } from "./ipc/handlers/osDnd.preload.js";
 import { buildAgentCapabilitiesPreloadBindings } from "./ipc/handlers/agentCapabilities.preload.js";
 import { buildHelpAssistantPreloadBindings } from "./ipc/handlers/helpAssistant.preload.js";
 import { buildMenuPreloadBindings } from "./ipc/handlers/menu.preload.js";
@@ -1879,6 +1880,15 @@ const api: ElectronAPI = {
 
     onWake: (callback: (sleepDurationMs: number) => void) =>
       _typedOn(CHANNELS.SYSTEM_SLEEP_ON_WAKE, callback),
+  },
+
+  // OS Do-Not-Disturb / Focus state. Read-only signal — never used to gate
+  // in-app toasts (the OS already silences its native banners).
+  osDnd: {
+    ...buildOsDndPreloadBindings(_unwrappingInvoke),
+
+    onStateChanged: (callback: (payload: { osDndActive: boolean | undefined }) => void) =>
+      _typedOn(CHANNELS.OS_DND_STATE_CHANGED, callback),
   },
 
   // Keybinding API

--- a/electron/services/AgentNotificationService.ts
+++ b/electron/services/AgentNotificationService.ts
@@ -5,6 +5,7 @@ import { projectStore } from "./ProjectStore.js";
 import { soundService } from "./SoundService.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { isScheduledQuietNow } from "../../shared/utils/quietHours.js";
+import { getOsDndService } from "./OsDndService.js";
 
 const COMPLETION_DEBOUNCE_MS = 2000;
 const NOTIFICATION_STAGGER_MS = 500;
@@ -541,9 +542,12 @@ class AgentNotificationService {
         this.clearWorkingPulse(terminalId);
         return;
       }
-      // During scheduled quiet hours or an active session mute, skip this tick's
-      // sound but keep the loop alive so pulses resume automatically after.
-      if (isScheduledQuietNow(currentSettings) || this.isSessionMuted()) {
+      // During scheduled quiet hours, an active session mute, or OS-level
+      // Do-Not-Disturb / Focus, skip this tick's sound but keep the loop alive
+      // so pulses resume automatically after. Treat an `undefined` OS state
+      // (unsupported platform / detection failed) as "do not gate".
+      const osDndActive = getOsDndService().getState() === true;
+      if (isScheduledQuietNow(currentSettings) || this.isSessionMuted() || osDndActive) {
         const jitter =
           WORKING_PULSE_MIN_INTERVAL_MS +
           Math.random() * (WORKING_PULSE_MAX_INTERVAL_MS - WORKING_PULSE_MIN_INTERVAL_MS);

--- a/electron/services/OsDndService.ts
+++ b/electron/services/OsDndService.ts
@@ -1,0 +1,180 @@
+import { systemPreferences } from "electron";
+import { execFileSync } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+
+type StateCallback = (osDndActive: boolean | undefined) => void;
+
+/**
+ * OsDndService — surfaces the OS-level Do-Not-Disturb / Focus state to the
+ * renderer.
+ *
+ * @pattern Factory/Accessor Methods (Pattern C)
+ *
+ * macOS (primary supported platform):
+ *   - Initial state probed once via `plutil` reading
+ *     `~/Library/DoNotDisturb/DB/Assertions.json` — a non-empty mode
+ *     identifier means a Focus mode (including classic DND) is active.
+ *   - Live updates via `systemPreferences.subscribeNotification` on the
+ *     private `_NSDoNotDisturbEnabledNotification` /
+ *     `_NSDoNotDisturbDisabledNotification` Darwin notifications. These are
+ *     not in the public macOS SDK but have been the canonical DND/Focus
+ *     transition signals since macOS 12 and remain wired through Focus modes.
+ *
+ * Windows / Linux: state is left `undefined`. Cross-desktop Linux DND
+ * detection has no reliable standard, and Windows Focus Assist has no
+ * Electron-exposed event subscription — failing soft is the correct choice
+ * for both.
+ *
+ * The state is consumed in two places only: the working-pulse audio gate in
+ * `AgentNotificationService` and the read-only toolbar tooltip display. It
+ * must NEVER be used to suppress in-app toasts.
+ */
+class OsDndService {
+  private state: boolean | undefined = undefined;
+  private initialized = false;
+  private subscriptionIds: number[] = [];
+  private listeners = new Set<StateCallback>();
+
+  initialize(): void {
+    if (this.initialized) {
+      return;
+    }
+    this.initialized = true;
+
+    if (process.platform !== "darwin") {
+      // No detection available — leave state undefined.
+      return;
+    }
+
+    this.state = this.probeMacOsInitialState();
+
+    try {
+      const enabledId = systemPreferences.subscribeNotification(
+        "_NSDoNotDisturbEnabledNotification",
+        () => this.applyState(true)
+      );
+      this.subscriptionIds.push(enabledId);
+    } catch (err) {
+      console.warn("[OsDndService] Failed to subscribe to DND-enabled notification:", err);
+    }
+
+    try {
+      const disabledId = systemPreferences.subscribeNotification(
+        "_NSDoNotDisturbDisabledNotification",
+        () => this.applyState(false)
+      );
+      this.subscriptionIds.push(disabledId);
+    } catch (err) {
+      console.warn("[OsDndService] Failed to subscribe to DND-disabled notification:", err);
+    }
+  }
+
+  /**
+   * macOS initial-state probe. The subscription only fires on transitions, so
+   * without this we'd report `undefined` until the user toggled DND. The
+   * `Assertions.json` file lists the active Focus-mode assertions; an empty
+   * read means no mode is active. Anything that throws (file missing, parse
+   * failure, sandbox restriction) collapses to `undefined` — fail-soft.
+   */
+  private probeMacOsInitialState(): boolean | undefined {
+    const assertionsPath = path.join(
+      os.homedir(),
+      "Library",
+      "DoNotDisturb",
+      "DB",
+      "Assertions.json"
+    );
+    try {
+      const out = execFileSync(
+        "/usr/bin/plutil",
+        [
+          "-extract",
+          "data.0.storeAssertionRecords.0.assertionDetailsModeIdentifier",
+          "raw",
+          "-o",
+          "-",
+          assertionsPath,
+        ],
+        { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 1500 }
+      );
+      return out.trim().length > 0;
+    } catch {
+      // Assertions.json may not exist if the user has never enabled DND, or
+      // plutil may exit non-zero when no assertion is set. Either case means
+      // DND is not active — return false, not undefined, so the probe still
+      // produces useful state when the file is simply absent.
+      return false;
+    }
+  }
+
+  private applyState(next: boolean): void {
+    if (this.state === next) return;
+    this.state = next;
+    for (const callback of this.listeners) {
+      try {
+        callback(next);
+      } catch (err) {
+        console.error("[OsDndService] State callback error:", err);
+      }
+    }
+  }
+
+  /**
+   * Current DND state. `undefined` means "unknown" (unsupported platform or
+   * detection failed) — consumers must treat it as "do not gate".
+   */
+  getState(): boolean | undefined {
+    return this.state;
+  }
+
+  /**
+   * Subscribe to DND transitions. Returns an unsubscribe function.
+   */
+  onStateChanged(callback: StateCallback): () => void {
+    this.listeners.add(callback);
+    return () => {
+      this.listeners.delete(callback);
+    };
+  }
+
+  dispose(): void {
+    if (!this.initialized) return;
+    for (const id of this.subscriptionIds) {
+      try {
+        systemPreferences.unsubscribeNotification(id);
+      } catch (err) {
+        console.warn("[OsDndService] Failed to unsubscribe DND notification:", err);
+      }
+    }
+    this.subscriptionIds = [];
+    this.listeners.clear();
+    this.state = undefined;
+    this.initialized = false;
+  }
+}
+
+let osDndService: OsDndService | null = null;
+
+export function getOsDndService(): OsDndService {
+  if (!osDndService) {
+    osDndService = new OsDndService();
+  }
+  return osDndService;
+}
+
+export function initializeOsDndService(): OsDndService {
+  const service = getOsDndService();
+  service.initialize();
+  return service;
+}
+
+/** Test-only: reset the singleton so each test starts clean. */
+export function __resetOsDndServiceForTests(): void {
+  if (osDndService) {
+    osDndService.dispose();
+  }
+  osDndService = null;
+}
+
+export { OsDndService };

--- a/electron/services/__tests__/AgentNotificationService.adversarial.test.ts
+++ b/electron/services/__tests__/AgentNotificationService.adversarial.test.ts
@@ -44,6 +44,10 @@ vi.mock("../SoundService.js", () => ({
   soundService: soundServiceMock,
 }));
 
+vi.mock("../OsDndService.js", () => ({
+  getOsDndService: () => ({ getState: () => undefined }),
+}));
+
 import { events } from "../events.js";
 import { agentNotificationService } from "../AgentNotificationService.js";
 

--- a/electron/services/__tests__/AgentNotificationService.allClear.test.ts
+++ b/electron/services/__tests__/AgentNotificationService.allClear.test.ts
@@ -44,6 +44,10 @@ vi.mock("../SoundService.js", () => ({
   soundService: soundServiceMock,
 }));
 
+vi.mock("../OsDndService.js", () => ({
+  getOsDndService: () => ({ getState: () => undefined }),
+}));
+
 import { events } from "../events.js";
 import { agentNotificationService } from "../AgentNotificationService.js";
 

--- a/electron/services/__tests__/AgentNotificationService.test.ts
+++ b/electron/services/__tests__/AgentNotificationService.test.ts
@@ -957,6 +957,39 @@ describe("AgentNotificationService", () => {
     });
   });
 
+  describe("OS DND hard constraint — never suppresses in-app toasts", () => {
+    // The issue explicitly forbids `osDndActive` from suppressing in-app
+    // notifications. The OS already silences its own native banners; double-
+    // gating would hide signals the user cannot observe.
+
+    it("completion notifications still fire when OS DND is active", () => {
+      mockStore({ completedEnabled: true, soundEnabled: true });
+      osDndServiceMock.getState.mockReturnValue(true);
+
+      events.emit("agent:state-changed", makePayload("completed", "working"));
+      vi.advanceTimersByTime(2001); // past completion debounce + flush
+
+      expect(notificationServiceMock.showWatchNotification).toHaveBeenCalledTimes(1);
+      expect(notificationServiceMock.showWatchNotification).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.any(Object),
+        "notification:watch-navigate",
+        true
+      );
+    });
+
+    it("waiting notifications still fire when OS DND is active", () => {
+      mockStore({ waitingEnabled: true, soundEnabled: true });
+      osDndServiceMock.getState.mockReturnValue(true);
+
+      events.emit("agent:state-changed", makePayload("waiting", "working"));
+      vi.advanceTimersByTime(200); // past the burst window
+
+      expect(notificationServiceMock.showWatchNotification).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("agent:spawned UI feedback sound", () => {
     it("plays agent-spawned sound when uiFeedbackSoundEnabled is true", () => {
       mockStore({ uiFeedbackSoundEnabled: true });

--- a/electron/services/__tests__/AgentNotificationService.test.ts
+++ b/electron/services/__tests__/AgentNotificationService.test.ts
@@ -28,6 +28,10 @@ const soundServiceMock = vi.hoisted(() => ({
   getVariantCount: vi.fn(() => 1),
 }));
 
+const osDndServiceMock = vi.hoisted(() => ({
+  getState: vi.fn<() => boolean | undefined>(() => undefined),
+}));
+
 vi.mock("../../store.js", () => ({
   store: storeMock,
 }));
@@ -42,6 +46,10 @@ vi.mock("../NotificationService.js", () => ({
 
 vi.mock("../SoundService.js", () => ({
   soundService: soundServiceMock,
+}));
+
+vi.mock("../OsDndService.js", () => ({
+  getOsDndService: () => osDndServiceMock,
 }));
 
 import { events } from "../events.js";
@@ -110,6 +118,7 @@ describe("AgentNotificationService", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    osDndServiceMock.getState.mockReturnValue(undefined);
     agentNotificationService.initialize();
     // Register the test terminal as watched so gate passes by default
     agentNotificationService.syncWatchedPanels(["term-1"]);
@@ -909,6 +918,41 @@ describe("AgentNotificationService", () => {
 
       // Should continue existing pulse, not restart
       vi.advanceTimersByTime(10_000);
+      expect(soundServiceMock.playPulse).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips pulse audio while OS DND is active but keeps the loop alive", () => {
+      mockStore({ soundEnabled: true, workingPulseEnabled: true });
+      osDndServiceMock.getState.mockReturnValue(true);
+
+      events.emit("agent:state-changed", makePayload("working", "idle"));
+      vi.advanceTimersByTime(10_000);
+      expect(soundServiceMock.playPulse).not.toHaveBeenCalled();
+
+      // OS DND turns off mid-loop — next tick must fire normally without a
+      // new spawn event, proving the interval timer is still armed.
+      osDndServiceMock.getState.mockReturnValue(false);
+      vi.advanceTimersByTime(10_000);
+      expect(soundServiceMock.playPulse).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not gate the pulse when OS DND state is undefined", () => {
+      mockStore({ soundEnabled: true, workingPulseEnabled: true });
+      osDndServiceMock.getState.mockReturnValue(undefined);
+
+      events.emit("agent:state-changed", makePayload("working", "idle"));
+      vi.advanceTimersByTime(10_000);
+
+      expect(soundServiceMock.playPulse).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not gate the pulse when OS DND is explicitly off", () => {
+      mockStore({ soundEnabled: true, workingPulseEnabled: true });
+      osDndServiceMock.getState.mockReturnValue(false);
+
+      events.emit("agent:state-changed", makePayload("working", "idle"));
+      vi.advanceTimersByTime(10_000);
+
       expect(soundServiceMock.playPulse).toHaveBeenCalledTimes(1);
     });
   });

--- a/electron/services/__tests__/OsDndService.test.ts
+++ b/electron/services/__tests__/OsDndService.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const execFileSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  execFileSync: execFileSyncMock,
+}));
+
+const systemPreferencesMock = vi.hoisted(() => {
+  const handlers = new Map<number, () => void>();
+  let nextId = 1;
+  const subscribeNotification = vi.fn((_name: string, cb: () => void): number => {
+    const id = nextId++;
+    handlers.set(id, cb);
+    return id;
+  });
+  const unsubscribeNotification = vi.fn((id: number): void => {
+    handlers.delete(id);
+  });
+  return {
+    subscribeNotification,
+    unsubscribeNotification,
+    __fireByName(name: string): void {
+      // Each subscribe call records its name on the mock's call list; find
+      // the id by index and invoke its handler.
+      const calls = subscribeNotification.mock.calls;
+      for (let i = 0; i < calls.length; i++) {
+        if (calls[i]?.[0] === name) {
+          const id = i + 1;
+          handlers.get(id)?.();
+        }
+      }
+    },
+    __reset(): void {
+      handlers.clear();
+      nextId = 1;
+      subscribeNotification.mockClear();
+      unsubscribeNotification.mockClear();
+    },
+  };
+});
+
+vi.mock("electron", () => ({
+  systemPreferences: systemPreferencesMock,
+}));
+
+import { __resetOsDndServiceForTests, getOsDndService } from "../OsDndService.js";
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+}
+
+beforeEach(() => {
+  execFileSyncMock.mockReset();
+  systemPreferencesMock.__reset();
+  __resetOsDndServiceForTests();
+});
+
+afterEach(() => {
+  __resetOsDndServiceForTests();
+  setPlatform(originalPlatform);
+});
+
+describe("OsDndService — macOS", () => {
+  beforeEach(() => {
+    setPlatform("darwin");
+  });
+
+  it("initial probe reads Focus mode identifier from Assertions.json (active → true)", () => {
+    execFileSyncMock.mockReturnValueOnce("com.apple.donotdisturb.mode.default\n");
+    const svc = getOsDndService();
+    svc.initialize();
+    expect(svc.getState()).toBe(true);
+  });
+
+  it("initial probe with empty plutil output reports DND off", () => {
+    execFileSyncMock.mockReturnValueOnce("");
+    const svc = getOsDndService();
+    svc.initialize();
+    expect(svc.getState()).toBe(false);
+  });
+
+  it("initial probe failure (file missing / plutil throws) reports DND off (no assertion present)", () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    const svc = getOsDndService();
+    svc.initialize();
+    expect(svc.getState()).toBe(false);
+  });
+
+  it("subscribes to both enabled and disabled Darwin notifications", () => {
+    execFileSyncMock.mockReturnValueOnce("");
+    const svc = getOsDndService();
+    svc.initialize();
+    const names = systemPreferencesMock.subscribeNotification.mock.calls.map((c) => c[0]);
+    expect(names).toContain("_NSDoNotDisturbEnabledNotification");
+    expect(names).toContain("_NSDoNotDisturbDisabledNotification");
+  });
+
+  it("flips state to true on the enabled notification and notifies listeners", () => {
+    execFileSyncMock.mockReturnValueOnce("");
+    const svc = getOsDndService();
+    svc.initialize();
+    expect(svc.getState()).toBe(false);
+
+    const listener = vi.fn();
+    svc.onStateChanged(listener);
+
+    systemPreferencesMock.__fireByName("_NSDoNotDisturbEnabledNotification");
+    expect(svc.getState()).toBe(true);
+    expect(listener).toHaveBeenCalledWith(true);
+  });
+
+  it("flips state to false on the disabled notification", () => {
+    execFileSyncMock.mockReturnValueOnce("com.apple.focus.work\n");
+    const svc = getOsDndService();
+    svc.initialize();
+    expect(svc.getState()).toBe(true);
+
+    const listener = vi.fn();
+    svc.onStateChanged(listener);
+
+    systemPreferencesMock.__fireByName("_NSDoNotDisturbDisabledNotification");
+    expect(svc.getState()).toBe(false);
+    expect(listener).toHaveBeenCalledWith(false);
+  });
+
+  it("does not notify listeners on a no-op transition (already in the target state)", () => {
+    execFileSyncMock.mockReturnValueOnce("");
+    const svc = getOsDndService();
+    svc.initialize();
+
+    const listener = vi.fn();
+    svc.onStateChanged(listener);
+
+    // Service is already at `false`; firing the disabled event must not
+    // re-broadcast.
+    systemPreferencesMock.__fireByName("_NSDoNotDisturbDisabledNotification");
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("initialize is idempotent — repeat calls do not re-subscribe", () => {
+    execFileSyncMock.mockReturnValue("");
+    const svc = getOsDndService();
+    svc.initialize();
+    const firstCount = systemPreferencesMock.subscribeNotification.mock.calls.length;
+    svc.initialize();
+    expect(systemPreferencesMock.subscribeNotification.mock.calls.length).toBe(firstCount);
+  });
+
+  it("dispose unsubscribes every notification and clears state", () => {
+    execFileSyncMock.mockReturnValueOnce("");
+    const svc = getOsDndService();
+    svc.initialize();
+    const subCount = systemPreferencesMock.subscribeNotification.mock.calls.length;
+    svc.dispose();
+    expect(systemPreferencesMock.unsubscribeNotification.mock.calls.length).toBe(subCount);
+    expect(svc.getState()).toBeUndefined();
+  });
+
+  it("dispose is safe to call before or after initialize", () => {
+    const svc = getOsDndService();
+    expect(() => svc.dispose()).not.toThrow();
+    execFileSyncMock.mockReturnValueOnce("");
+    svc.initialize();
+    expect(() => svc.dispose()).not.toThrow();
+    expect(() => svc.dispose()).not.toThrow();
+  });
+
+  it("onStateChanged returns an unsubscribe that detaches the listener", () => {
+    execFileSyncMock.mockReturnValueOnce("");
+    const svc = getOsDndService();
+    svc.initialize();
+
+    const listener = vi.fn();
+    const off = svc.onStateChanged(listener);
+    off();
+
+    systemPreferencesMock.__fireByName("_NSDoNotDisturbEnabledNotification");
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe("OsDndService — non-macOS platforms", () => {
+  it("Linux returns undefined and skips subscribeNotification entirely", () => {
+    setPlatform("linux");
+    const svc = getOsDndService();
+    svc.initialize();
+    expect(svc.getState()).toBeUndefined();
+    expect(systemPreferencesMock.subscribeNotification).not.toHaveBeenCalled();
+  });
+
+  it("Windows returns undefined and skips subscribeNotification entirely", () => {
+    setPlatform("win32");
+    const svc = getOsDndService();
+    svc.initialize();
+    expect(svc.getState()).toBeUndefined();
+    expect(systemPreferencesMock.subscribeNotification).not.toHaveBeenCalled();
+  });
+});

--- a/electron/services/__tests__/OsDndService.test.ts
+++ b/electron/services/__tests__/OsDndService.test.ts
@@ -182,6 +182,21 @@ describe("OsDndService — macOS", () => {
     systemPreferencesMock.__fireByName("_NSDoNotDisturbEnabledNotification");
     expect(listener).not.toHaveBeenCalled();
   });
+
+  it("dispose followed by initialize re-probes and re-subscribes", () => {
+    execFileSyncMock.mockReturnValueOnce("");
+    const svc = getOsDndService();
+    svc.initialize();
+    const firstSubCount = systemPreferencesMock.subscribeNotification.mock.calls.length;
+
+    svc.dispose();
+    expect(svc.getState()).toBeUndefined();
+
+    execFileSyncMock.mockReturnValueOnce("com.apple.focus.work\n");
+    svc.initialize();
+    expect(svc.getState()).toBe(true);
+    expect(systemPreferencesMock.subscribeNotification.mock.calls.length).toBe(firstSubCount * 2);
+  });
 });
 
 describe("OsDndService — non-macOS platforms", () => {

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -27,6 +27,7 @@ import {
   SESSION_EVICTION_MAX_BYTES,
 } from "../services/pty/terminalSessionPersistence.js";
 import { initializeSystemSleepService } from "../services/SystemSleepService.js";
+import { initializeOsDndService } from "../services/OsDndService.js";
 import { getDatabaseMaintenanceService } from "../services/DatabaseMaintenanceService.js";
 import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
 import {
@@ -343,6 +344,13 @@ export async function initGlobalServices(
     name: "system-sleep-service",
     run: () => {
       initializeSystemSleepService();
+    },
+  });
+
+  registerDeferredTask({
+    name: "os-dnd-service",
+    run: () => {
+      initializeOsDndService();
     },
   });
 

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -981,6 +981,21 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     /** Subscribe to wake events with sleep duration */
     onWake(callback: (sleepDurationMs: number) => void): () => void;
   };
+  /**
+   * OS Do-Not-Disturb / Focus state.
+   *
+   * `osDndActive` is `true` when the OS reports DND/Focus active, `false`
+   * when off, and `undefined` on unsupported platforms (Windows/Linux) or
+   * when detection fails — fail-soft semantics. Consumers must treat
+   * `undefined` as "unknown / do not gate". Used by the working-pulse audio
+   * gate and the read-only toolbar tooltip; never for in-app toast
+   * suppression. Invoke method comes from GeneratedElectronAPI;
+   * onStateChanged is a renderer-only subscription.
+   */
+  osDnd: GeneratedElectronAPI["osDnd"] & {
+    /** Subscribe to DND state transitions. Returns an unsubscribe function. */
+    onStateChanged(callback: (payload: { osDndActive: boolean | undefined }) => void): () => void;
+  };
   keybinding: {
     /** Get current keybinding overrides */
     getOverrides(): Promise<Record<KeyAction, string[]>>;

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -304,6 +304,11 @@ export interface GeneratedElectronAPI {
       ...args: IpcInvokeMap["onboarding:set-step"]["args"]
     ): Promise<IpcInvokeMap["onboarding:set-step"]["result"]>;
   };
+  osDnd: {
+    getState(
+      ...args: IpcInvokeMap["os-dnd:get-state"]["args"]
+    ): Promise<IpcInvokeMap["os-dnd:get-state"]["result"]>;
+  };
   plugin: {
     clearAuditLog(
       ...args: IpcInvokeMap["plugin:clear-audit-log"]["args"]

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -543,6 +543,10 @@ export interface GeneratedIpcInvokeMap {
     args: [arg: string | { step: string | null; agentSetupIds?: string[] | undefined } | null];
     result: void;
   };
+  "os-dnd:get-state": {
+    args: [];
+    result: boolean | undefined;
+  };
   "plugin:actions-get": {
     args: [];
     result: import("../plugin.js").PluginActionDescriptor[];

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1686,6 +1686,10 @@ export interface IpcEventMap {
   "system-sleep:on-suspend": void;
   "system-sleep:on-wake": number;
 
+  // OS Do-Not-Disturb / Focus state transitions. Read-only; never used to
+  // suppress in-app toasts.
+  "os-dnd:state-changed": import("./osDnd.js").OsDndState;
+
   // Menu events
   "menu:action": { actionId: string; args?: unknown };
 

--- a/shared/types/ipc/osDnd.ts
+++ b/shared/types/ipc/osDnd.ts
@@ -1,0 +1,17 @@
+/**
+ * Snapshot of the OS-level Do-Not-Disturb (macOS Focus) state.
+ *
+ * `osDndActive` is the read-only signal surfaced from the main process:
+ *   - `true`  — DND/Focus is engaged
+ *   - `false` — DND/Focus is off
+ *   - `undefined` — fail-soft default (unsupported platform or detection
+ *     failed). Treat `undefined` as "unknown / do not gate".
+ *
+ * The signal must NEVER be used to suppress in-app toasts — the OS already
+ * silences its own native banners, and double-gating would hide signals the
+ * user cannot otherwise observe. The only consumers are the working-pulse
+ * audio loop and the read-only toolbar/notification-center display.
+ */
+export interface OsDndState {
+  osDndActive: boolean | undefined;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -505,6 +505,13 @@ function AppInner() {
   }, [crashState.status]);
   useEffect(() => {
     void useNotificationSettingsStore.getState().hydrate();
+    // Subscribe to OS DND transitions before hydrate resolves so a transition
+    // mid-hydration cannot be missed. Push events from main are tolerant of
+    // an `undefined` namespace at preload (renderer harness in tests).
+    const unsubscribe = window.electron?.osDnd?.onStateChanged?.((payload) => {
+      useNotificationSettingsStore.getState().setOsDndActive(payload.osDndActive);
+    });
+    return () => unsubscribe?.();
   }, []);
   useProjectSwitchRehydration();
   useShortcutHints(isStateLoaded);

--- a/src/components/Layout/NotificationCenterToolbarButton.tsx
+++ b/src/components/Layout/NotificationCenterToolbarButton.tsx
@@ -48,6 +48,7 @@ export function NotificationCenterToolbarButton({
     quietHoursStartMin,
     quietHoursEndMin,
     quietHoursWeekdays,
+    osDndActive,
   } = useNotificationSettingsStore(
     useShallow((s) => ({
       enabled: s.enabled,
@@ -56,6 +57,7 @@ export function NotificationCenterToolbarButton({
       quietHoursStartMin: s.quietHoursStartMin,
       quietHoursEndMin: s.quietHoursEndMin,
       quietHoursWeekdays: s.quietHoursWeekdays,
+      osDndActive: s.osDndActive,
     }))
   );
 
@@ -202,6 +204,23 @@ export function NotificationCenterToolbarButton({
     }
   }, [isDndActive, isSessionMuted, notificationsEnabled]);
 
+  // Announce OS DND transitions separately. The OS DND signal is read-only
+  // (it does not gate in-app toasts), but the user benefits from knowing the
+  // bell tooltip just changed. Coerce `undefined` to `false` so an initial
+  // unknown state never narrates a transition.
+  const prevOsDndActiveRef = useRef(osDndActive === true);
+  useEffect(() => {
+    const next = osDndActive === true;
+    const prev = prevOsDndActiveRef.current;
+    prevOsDndActiveRef.current = next;
+    if (!notificationsEnabled) return;
+    if (prev === next) return;
+    // Suppress when in-app DND is already announcing — the in-app signal
+    // takes priority since it changes more user-visible behavior.
+    if (isDndActive) return;
+    setDndAnnouncement(next ? "OS Do Not Disturb active" : "OS Do Not Disturb off");
+  }, [osDndActive, isDndActive, notificationsEnabled]);
+
   if (!notificationsEnabled) return null;
 
   const label = (() => {
@@ -209,6 +228,7 @@ export function NotificationCenterToolbarButton({
       return `Notifications — paused until ${timeFormatter.format(new Date(quietUntil))}`;
     }
     if (isScheduledMuted) return "Notifications — quiet hours active";
+    if (osDndActive === true) return "Notifications — OS Do Not Disturb active";
     if (notificationUnreadCount > 0) return `Notifications — ${notificationUnreadCount} unread`;
     return "Notifications";
   })();

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -45,6 +45,7 @@ import { getWorstSeverity, SEVERITY_WEIGHTS } from "@/lib/notificationSeverity";
 import {
   computeEffectiveNotificationState,
   heroLine,
+  osDndDisplayNote,
   selectKindOffKinds,
   KIND_SHORT_LABEL,
 } from "@/lib/notificationEffectiveState";
@@ -190,6 +191,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
     quietHoursWeekdays,
     groupByContext,
     setGroupByContext,
+    osDndActive,
   } = useNotificationSettingsStore(
     useShallow((s) => ({
       notificationsEnabled: s.enabled,
@@ -204,6 +206,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
       quietHoursWeekdays: s.quietHoursWeekdays,
       groupByContext: s.groupByContext,
       setGroupByContext: s.setGroupByContext,
+      osDndActive: s.osDndActive,
     }))
   );
 
@@ -230,7 +233,11 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
     quietHoursEndMin,
     quietHoursWeekdays,
   });
-  const showMutedPill = isSessionMuted || isScheduledMuted;
+  const isOsDndActive = osDndActive === true;
+  // The OS DND pill is informational only — it surfaces a state the user
+  // chose at the OS level. In-app toasts still fire (the OS already silences
+  // its native banners), but the working-pulse audio is gated in main.
+  const showMutedPill = isSessionMuted || isScheduledMuted || isOsDndActive;
 
   useEffect(() => {
     if (!open) {
@@ -723,21 +730,29 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
     setSessionQuietUntil(0);
   };
 
-  const pillLabel = isSessionMuted
-    ? `Muted until ${timeFormatter.format(new Date(quietUntil))}`
-    : "Quiet hours";
+  const pillLabel = (() => {
+    if (isSessionMuted) return `Muted until ${timeFormatter.format(new Date(quietUntil))}`;
+    if (isScheduledMuted) return "Quiet hours";
+    // OS DND case — the in-app gates are off, so name the source plainly.
+    return osDndDisplayNote(osDndActive) ?? "";
+  })();
   // Effective-state summary: with the gates stacked, fold them into a single
   // line that answers "what will fire right now" plus which kinds are switched
   // off. Memoized over the gate inputs so it's a stable value the rest of the
   // render (and the compiler) can lean on.
   const { summaryHeroLine, offLabel } = useMemo(() => {
+    // `isQuiet` only encodes in-app suppression (session mute + scheduled
+    // quiet) — OS DND must never be folded into `isQuiet` because it would
+    // flip kinds to `quiet-gated`, which the hard constraint forbids.
+    const inAppQuiet = isSessionMuted || isScheduledMuted;
     const states = computeEffectiveNotificationState({
       enabled: notificationsEnabled,
-      isQuiet: showMutedPill,
+      isQuiet: inAppQuiet,
       completedEnabled,
       waitingEnabled,
       workingPulseEnabled,
       uiFeedbackSoundEnabled,
+      osDndActive,
     });
     const offKinds = selectKindOffKinds(states);
     return {
@@ -747,11 +762,13 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
     };
   }, [
     notificationsEnabled,
-    showMutedPill,
+    isSessionMuted,
+    isScheduledMuted,
     completedEnabled,
     waitingEnabled,
     workingPulseEnabled,
     uiFeedbackSoundEnabled,
+    osDndActive,
   ]);
   const morningLabel = `Until ${timeFormatter.format(new Date(nextOccurrenceTimestamp(8 * 60)))}`;
   const mutedEmptyDescription = (() => {
@@ -1000,7 +1017,10 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
                 icon={<Bell />}
                 className="py-10"
               />
-            ) : showMutedPill ? (
+            ) : isSessionMuted || isScheduledMuted ? (
+              // OS DND alone does not trigger the "Notifications paused" copy
+              // — in-app toasts still fire, so naming them "paused" would be
+              // misleading. The pill above still surfaces the OS state.
               <div data-testid="notification-muted-empty-state">
                 <EmptyState
                   variant="zero-data"

--- a/src/lib/__tests__/notificationEffectiveState.test.ts
+++ b/src/lib/__tests__/notificationEffectiveState.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   computeEffectiveNotificationState,
   heroLine,
+  osDndDisplayNote,
   selectInterruptingKinds,
   selectKindOffKinds,
   KIND_SHORT_LABEL,
@@ -140,5 +141,27 @@ describe("heroLine", () => {
   it("states plainly when nothing will interrupt", () => {
     const states = computeEffectiveNotificationState({ ...ALL_ON, enabled: false });
     expect(heroLine(states)).toBe("Nothing will interrupt you right now");
+  });
+});
+
+describe("osDndDisplayNote", () => {
+  it("returns the display string when OS DND is active", () => {
+    expect(osDndDisplayNote(true)).toBe("OS Do Not Disturb is active");
+  });
+
+  it("returns null when OS DND is explicitly off", () => {
+    expect(osDndDisplayNote(false)).toBeNull();
+  });
+
+  it("returns null when the OS DND state is unknown (unsupported platform)", () => {
+    expect(osDndDisplayNote(undefined)).toBeNull();
+  });
+});
+
+describe("EffectiveStateInput — osDndActive does NOT gate classification", () => {
+  it("OS DND active does not flip any kind to quiet-gated (hard constraint: no in-app suppression)", () => {
+    const baseline = computeEffectiveNotificationState(ALL_ON);
+    const withOsDnd = computeEffectiveNotificationState({ ...ALL_ON, osDndActive: true });
+    expect(withOsDnd).toEqual(baseline);
   });
 });

--- a/src/lib/notificationEffectiveState.ts
+++ b/src/lib/notificationEffectiveState.ts
@@ -50,6 +50,13 @@ export interface EffectiveStateInput {
   waitingEnabled: boolean;
   workingPulseEnabled: boolean;
   uiFeedbackSoundEnabled: boolean;
+  /**
+   * OS-level Do-Not-Disturb / Focus state. Read-only display signal — does
+   * NOT participate in `classifyKind` because the OS already silences its own
+   * native banners; double-gating would hide signals the user cannot observe.
+   * `true`/`false`/`undefined` map to "active"/"off"/"unknown" in the summary.
+   */
+  osDndActive?: boolean | undefined;
 }
 
 export interface KindEffectiveState {
@@ -159,4 +166,14 @@ export function heroLine(states: KindEffectiveState[]): string {
   const interrupting = selectInterruptingKinds(states);
   if (interrupting.length === 0) return "Nothing will interrupt you right now";
   return `Will interrupt you: ${joinLabels(interrupting)}`;
+}
+
+/**
+ * Read-only display string describing the OS-level DND state. Returns `null`
+ * when the signal is unknown (unsupported platform / detection failed) or when
+ * DND is explicitly off — in both cases we don't show anything extra in the
+ * summary. The OS already silences its own banners; this is purely informational.
+ */
+export function osDndDisplayNote(osDndActive: boolean | undefined): string | null {
+  return osDndActive === true ? "OS Do Not Disturb is active" : null;
 }

--- a/src/store/__tests__/notificationSettingsStore.test.ts
+++ b/src/store/__tests__/notificationSettingsStore.test.ts
@@ -2,9 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
 
 const getSettings = vi.fn();
+const getOsDndState = vi.fn();
 
 beforeEach(() => {
   getSettings.mockReset();
+  getOsDndState.mockReset();
+  getOsDndState.mockResolvedValue(undefined);
   useNotificationSettingsStore.setState({
     enabled: true,
     hydrated: false,
@@ -12,9 +15,13 @@ beforeEach(() => {
     waitingEnabled: true,
     workingPulseEnabled: false,
     uiFeedbackSoundEnabled: false,
+    osDndActive: undefined,
   });
   (globalThis as { window?: unknown }).window = {
-    electron: { notification: { getSettings } },
+    electron: {
+      notification: { getSettings },
+      osDnd: { getState: getOsDndState },
+    },
   };
 });
 
@@ -78,5 +85,61 @@ describe("notificationSettingsStore hydrate — per-kind toggles", () => {
 
     expect(getSettings).toHaveBeenCalledTimes(1);
     expect(useNotificationSettingsStore.getState().completedEnabled).toBe(false);
+  });
+});
+
+describe("notificationSettingsStore — osDndActive", () => {
+  it("defaults to undefined before hydrate so consumers treat it as unknown", () => {
+    expect(useNotificationSettingsStore.getState().osDndActive).toBeUndefined();
+  });
+
+  it("hydrates osDndActive from the IPC snapshot", async () => {
+    getSettings.mockResolvedValue({ enabled: true });
+    getOsDndState.mockResolvedValue(true);
+
+    await useNotificationSettingsStore.getState().hydrate();
+
+    expect(useNotificationSettingsStore.getState().osDndActive).toBe(true);
+  });
+
+  it("preserves a push update that arrived before hydration resolved", async () => {
+    // Simulate a push event landing first — common when the renderer mounts
+    // mid-DND-transition. Hydration must not clobber the fresh value.
+    let resolveSettings: ((v: { enabled: true }) => void) | undefined;
+    const settingsPromise = new Promise<{ enabled: true }>((r) => {
+      resolveSettings = r;
+    });
+    getSettings.mockReturnValue(settingsPromise);
+    getOsDndState.mockResolvedValue(false);
+
+    const hydratePromise = useNotificationSettingsStore.getState().hydrate();
+
+    // Push lands before either IPC resolves.
+    useNotificationSettingsStore.getState().setOsDndActive(true);
+
+    resolveSettings?.({ enabled: true });
+    await hydratePromise;
+
+    expect(useNotificationSettingsStore.getState().osDndActive).toBe(true);
+  });
+
+  it("setOsDndActive accepts true, false, and undefined", () => {
+    const { setOsDndActive } = useNotificationSettingsStore.getState();
+    setOsDndActive(true);
+    expect(useNotificationSettingsStore.getState().osDndActive).toBe(true);
+    setOsDndActive(false);
+    expect(useNotificationSettingsStore.getState().osDndActive).toBe(false);
+    setOsDndActive(undefined);
+    expect(useNotificationSettingsStore.getState().osDndActive).toBeUndefined();
+  });
+
+  it("treats an IPC failure as a no-op — osDndActive stays at its prior value", async () => {
+    getSettings.mockResolvedValue({ enabled: true });
+    getOsDndState.mockRejectedValue(new Error("ipc down"));
+
+    useNotificationSettingsStore.setState({ osDndActive: true });
+    await useNotificationSettingsStore.getState().hydrate();
+
+    expect(useNotificationSettingsStore.getState().osDndActive).toBe(true);
   });
 });

--- a/src/store/notificationSettingsStore.ts
+++ b/src/store/notificationSettingsStore.ts
@@ -19,6 +19,11 @@ interface NotificationSettingsState {
   // Reactive mirror of session-mute timestamp (epoch ms). Drives toolbar
   // DND indicator. In-memory only — meaningless across restarts.
   quietUntil: number;
+  // OS-level Do-Not-Disturb / Focus state mirrored from the main-process
+  // OsDndService. `undefined` = unknown (unsupported platform / detection
+  // failed); consumers must treat it as "do not gate". Display-only here —
+  // never a toast-suppression gate (the OS already silences native banners).
+  osDndActive: boolean | undefined;
   hydrate(): Promise<void>;
   setEnabled(value: boolean): void;
   setQuietHoursEnabled(value: boolean): void;
@@ -27,6 +32,7 @@ interface NotificationSettingsState {
   setQuietHoursWeekdays(value: number[]): void;
   setGroupByContext(value: boolean): void;
   setQuietUntil(ts: number): void;
+  setOsDndActive(value: boolean | undefined): void;
 }
 
 export const useNotificationSettingsStore = create<NotificationSettingsState>((set, get) => ({
@@ -45,6 +51,7 @@ export const useNotificationSettingsStore = create<NotificationSettingsState>((s
   quietHoursWeekdays: [],
   groupByContext: false,
   quietUntil: 0,
+  osDndActive: undefined,
 
   async hydrate() {
     if (get().hydrated) return;
@@ -67,6 +74,18 @@ export const useNotificationSettingsStore = create<NotificationSettingsState>((s
             : [],
           groupByContext: settings.groupByContext === true,
         });
+      }
+      // Hydrate the OS DND signal alongside notification settings. A push
+      // event may have already arrived (subscription is set up earlier in
+      // App startup); only adopt the IPC snapshot when the live store value
+      // is still its `undefined` default so we don't clobber a fresher push.
+      try {
+        const initialOsDnd = await window.electron?.osDnd?.getState();
+        if (get().osDndActive === undefined) {
+          set({ osDndActive: initialOsDnd });
+        }
+      } catch {
+        // Leave osDndActive at its current value on IPC failure.
       }
     } catch {
       // fall through — always mark hydrated below so retries don't thrash IPC
@@ -130,5 +149,9 @@ export const useNotificationSettingsStore = create<NotificationSettingsState>((s
 
   setQuietUntil(ts: number) {
     set({ quietUntil: Number.isFinite(ts) ? ts : 0 });
+  },
+
+  setOsDndActive(value: boolean | undefined) {
+    set({ osDndActive: value });
   },
 }));


### PR DESCRIPTION
## Summary

- Adds `OsDndService` to the electron services layer — reads macOS Focus/DND state via a one-shot `plutil` probe of `~/Library/DoNotDisturb/DB/Assertions.json`, then stays live via `systemPreferences.subscribeNotification`. Windows/Linux return `undefined` as a fail-soft.
- New IPC channels (`os-dnd:get-state` invoke + `os-dnd:state-changed` push event) hydrate `osDndActive: boolean | undefined` in `notificationSettingsStore` on mount and keep it current.
- `AgentNotificationService` pulse tick now gates on OS DND state alongside the existing quiet-hours and session-mute checks — audio stops during OS DND, resumes automatically when cleared.
- `NotificationCenter` summary pill and toolbar bell tooltip surface OS DND state as read-only; the in-app bell icon and toast routing are untouched.

Hard constraint from the issue is enforced: `osDndActive` is never used to suppress in-app toasts. The OS already silences native banners; double-gating would hide signals the user can't see. Regression tests assert completion/waiting toasts still fire under OS DND.

Resolves #9188

## Changes

- `electron/services/OsDndService.ts` — new Pattern C singleton (mirrors `SystemSleepService`); eager-initialised during IPC handler registration so the first renderer hydrate call always lands on a probed service
- `electron/ipc/handlers/osDnd.ts` + `osDnd.preload.ts` — invoke handler + preload bindings
- `electron/ipc/channels.ts`, `handlers.ts`, `preload.cts`, `electron/lifecycle/shutdown.ts` — wired through the standard IPC pipeline
- `shared/types/ipc/osDnd.ts` + generated maps updated
- `src/store/notificationSettingsStore.ts` — `osDndActive` field, mount hydration, push subscription
- `src/App.tsx` — push subscription setup
- `src/lib/notificationEffectiveState.ts` — `osDndDisplayNote` helper for read-only UI note
- `src/components/Layout/NotificationCenterToolbarButton.tsx` + `src/components/Notifications/NotificationCenter.tsx` — display OS DND state
- `electron/services/AgentNotificationService.ts` — pulse tick gate
- Tests: `OsDndService.test.ts` (218 lines), `AgentNotificationService.test.ts` extended, `notificationSettingsStore.test.ts` extended, `notificationEffectiveState.test.ts` added

## Testing

- 301 targeted tests pass across the new service, store, and notification path
- Full verify pipeline clean: typecheck, IPC drift check, lint ratchet, format, build
- Adversarial tests assert pulse still skips under OS DND and that toasts are never suppressed by `osDndActive`