### PR TITLE
fix(github): gate PR revalidation behind a REST ETag probe to protect GraphQL quota

### DIFF
--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -1014,6 +1014,21 @@ class PullRequestService {
       return;
     }
 
+    // Per-project poll lease (#9055): only the elected window revalidates per
+    // cycle; siblings receive the resulting sys:pr:detected / sys:pr:cleared
+    // updates through main → renderer fan-out, exactly as checkForPRs relies on.
+    // Gating here is also what makes the open-PR-list ETag baseline single-owner:
+    // the cache is a main-process singleton keyed by owner/repo, so if every
+    // window committed it against its own tracked subset, one window's clean diff
+    // could advance the baseline past a change another window hasn't consumed and
+    // mask it behind a later 304. One revalidating window removes that race (and
+    // the redundant cross-window conditional GETs). Fails open on IPC timeout.
+    const leaseAcquired = await getForgeBridge().acquirePollLease();
+    if (!leaseAcquired) {
+      logDebug("Skipping PR revalidation — sibling window holds poll lease");
+      return;
+    }
+
     // Collect resolved worktrees that need revalidation, plus a per-PR snapshot
     // (state + REST change markers) for the cheap open-PR-list probe below.
     const lookupBranchByWorktreeId = new Map<string, string | undefined>();
@@ -1098,6 +1113,24 @@ class PullRequestService {
                 )
               )
             );
+
+      // Stale-in-flight guard: if `setForgeSettings`/`refresh()` swapped the
+      // provider while the probe or the GraphQL re-fetch was in flight, the
+      // results (and the snapshots we'd seed) belong to the OLD provider.
+      // Abandon the cycle quietly — the next poll picks up the new provider's
+      // PRs. Mirrors the same guard in checkForPRs.
+      if (
+        this.providerNamespacedId !== providerId ||
+        this.repoRef?.host !== repo.host ||
+        this.repoRef?.owner !== repo.owner ||
+        this.repoRef?.repo !== repo.repo
+      ) {
+        logDebug("Discarding stale PR revalidation results — provider changed mid-cycle", {
+          fromProviderId: providerId,
+          toProviderId: this.providerNamespacedId,
+        });
+        return;
+      }
 
       const enrichedPRNumbers = new Set<number>();
 

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -6,7 +6,13 @@ import { generateProjectId } from "./projectStorePaths.js";
 import { createHardenedGit } from "../utils/hardenedGit.js";
 import { getForgeBridge } from "../workspace-host/forgeBridge.js";
 import { BatchLoader } from "../workspace-host/batchLoader.js";
-import type { RepoRef, PR as ForgePR, RateLimitInfo, CIStatus } from "../../shared/types/forge.js";
+import type {
+  RepoRef,
+  PR as ForgePR,
+  PRSnapshot,
+  RateLimitInfo,
+  CIStatus,
+} from "../../shared/types/forge.js";
 
 // Focus-aware polling cadence: faster when any Daintree window is focused so
 // users see PR transitions promptly, slower when fully blurred to conserve the
@@ -93,6 +99,12 @@ interface InternalLinkedPR {
   _ciStatus?: import("../../shared/types/forge.js").CIStatus;
   providerId: string;
   stagnantPollCount: number;
+  // REST change-detection markers for the open-PR-list revalidation probe.
+  // Only the REST probe populates these (the GraphQL PR shape carries neither
+  // head.sha nor a raw ISO updated_at), so they stay undefined until the first
+  // probe-driven revalidation cycle seeds them.
+  headSha?: string;
+  updatedAt?: string;
 }
 
 export interface PRDetectionResult {
@@ -1002,15 +1014,26 @@ class PullRequestService {
       return;
     }
 
-    // Collect resolved worktrees that need revalidation
+    // Collect resolved worktrees that need revalidation, plus a per-PR snapshot
+    // (state + REST change markers) for the cheap open-PR-list probe below.
     const lookupBranchByWorktreeId = new Map<string, string | undefined>();
     const uniquePRNumbers = new Set<number>();
+    const trackedByNumber = new Map<number, PRSnapshot>();
     for (const worktreeId of this.resolvedWorktrees) {
       const context = this.candidates.get(worktreeId);
       const detectedPR = this.detectedPRs.get(worktreeId);
       if (context && detectedPR) {
         lookupBranchByWorktreeId.set(worktreeId, context.branchName);
         uniquePRNumbers.add(detectedPR.number);
+        if (!trackedByNumber.has(detectedPR.number)) {
+          trackedByNumber.set(detectedPR.number, {
+            number: detectedPR.number,
+            headSha: detectedPR.headSha ?? null,
+            updatedAt: detectedPR.updatedAt ?? null,
+            state: detectedPR.state,
+            title: detectedPR.title,
+          });
+        }
       }
     }
 
@@ -1020,29 +1043,61 @@ class PullRequestService {
     const prByNumberLoader = this.prByNumberLoader;
     if (!prByNumberLoader) return;
 
+    // Cheap conditional probe of the repo's open-PR list. When the provider
+    // supports it, an authenticated 304 (or a clean diff) means none of the
+    // tracked PRs changed, so the per-PR GraphQL re-fetch fan-out is skipped
+    // entirely — the dominant steady-state quota cost this issue addresses. A
+    // `fallback` result or an absent capability re-fetches every tracked PR,
+    // preserving the pre-probe behavior. CI polling for in-flight PRs still runs
+    // below regardless, since a CI re-run doesn't bump the PR's updated_at.
+    let numbersToRefetch: number[];
+    const changedSnapshotByNumber = new Map<number, PRSnapshot>();
     try {
-      // Revalidate each known PR by number through the provider-scoped loader,
-      // coalescing the fan-out into one `findPRsByNumbers` batch when supported.
-      // The loader resolves null for a confirmed-missing PR but rejects on a
-      // transient error, which we map to `error: true` and skip so a flaky API
-      // call doesn't clear valid PR state.
-      const prNumbers = [...uniquePRNumbers];
-      const results = await Promise.all(
-        prNumbers.map((prNumber) =>
-          prByNumberLoader.load(prNumber).then(
-            (pr): { prNumber: number; pr: ForgePR | null; error: boolean } => ({
-              prNumber,
-              pr,
-              error: false,
-            }),
-            (): { prNumber: number; pr: ForgePR | null; error: boolean } => ({
-              prNumber,
-              pr: null,
-              error: true,
-            })
-          )
-        )
-      );
+      const probe = await bridge.probeOpenPRList(providerId, repo, [...trackedByNumber.values()]);
+      if (probe && probe.kind === "unchanged") {
+        numbersToRefetch = [];
+      } else if (probe && probe.kind === "changed") {
+        for (const snap of probe.changed) {
+          if (uniquePRNumbers.has(snap.number)) {
+            changedSnapshotByNumber.set(snap.number, snap);
+          }
+        }
+        numbersToRefetch = [...changedSnapshotByNumber.keys()];
+      } else {
+        // `fallback`, or a `null` result (capability absent) — re-fetch all.
+        numbersToRefetch = [...uniquePRNumbers];
+      }
+    } catch {
+      // A probe RPC failure must not stall revalidation — fall back to a full
+      // re-fetch, exactly as if the provider had no probe capability.
+      numbersToRefetch = [...uniquePRNumbers];
+    }
+
+    try {
+      // Revalidate the PRs the probe flagged (or all, on fallback) by number
+      // through the provider-scoped loader, coalescing the fan-out into one
+      // `findPRsByNumbers` batch when supported. The loader resolves null for a
+      // confirmed-missing PR but rejects on a transient error, which we map to
+      // `error: true` and skip so a flaky API call doesn't clear valid PR state.
+      const results =
+        numbersToRefetch.length === 0
+          ? []
+          : await Promise.all(
+              numbersToRefetch.map((prNumber) =>
+                prByNumberLoader.load(prNumber).then(
+                  (pr): { prNumber: number; pr: ForgePR | null; error: boolean } => ({
+                    prNumber,
+                    pr,
+                    error: false,
+                  }),
+                  (): { prNumber: number; pr: ForgePR | null; error: boolean } => ({
+                    prNumber,
+                    pr: null,
+                    error: true,
+                  })
+                )
+              )
+            );
 
       const enrichedPRNumbers = new Set<number>();
 
@@ -1107,6 +1162,18 @@ class PullRequestService {
             });
           }
 
+          // Advance the change-detection snapshot from the probe's fresh REST
+          // data so the next probe tick resolves to a zero-cost 304. Only the
+          // REST probe carries head.sha / raw updated_at (the GraphQL PR shape
+          // does not), so seeding from anywhere else is impossible. This runs on
+          // the success path only — a transient error skips it above, leaving
+          // the stale snapshot so the next probe re-flags the PR (self-healing).
+          const snap = changedSnapshotByNumber.get(prNumber);
+          if (snap) {
+            detectedPR.headSha = snap.headSha ?? undefined;
+            detectedPR.updatedAt = snap.updatedAt ?? undefined;
+          }
+
           // Revalidate CI status once per unique PR number. Multiple
           // worktrees on the same branch share the same detectedPR object
           // reference — deduplicating avoids double-counting stagnant polls
@@ -1115,6 +1182,18 @@ class PullRequestService {
             enrichedPRNumbers.add(prNumber);
             this.enrichPRWithCIStatus(detectedPR, repo);
           }
+        }
+      }
+
+      // CI status can change without the PR's metadata changing — a re-run does
+      // not bump updated_at, so the probe reports those PRs unchanged. Keep
+      // polling CI for any in-flight PR not already enriched above, so green/red
+      // transitions still surface promptly even on an otherwise-quiet tick.
+      for (const detectedPR of this.detectedPRs.values()) {
+        if (enrichedPRNumbers.has(detectedPR.number)) continue;
+        if (detectedPR.ciStatus === "PENDING" || detectedPR.ciStatus === "EXPECTED") {
+          enrichedPRNumbers.add(detectedPR.number);
+          this.enrichPRWithCIStatus(detectedPR, repo);
         }
       }
 

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -969,6 +969,75 @@ describe("PullRequestService", () => {
     pullRequestService.destroy();
   });
 
+  it("seeds headSha/updatedAt from a changed probe so the next tick's snapshot is in sync", async () => {
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+
+    const batchSpy = vi.fn(async (_repo: RepoRef, branches: string[]) => {
+      const map = new Map<string, ForgePR | null>();
+      for (const branch of branches) {
+        map.set(branch, makeMockForgePR({ number: 1, headRef: branch }));
+      }
+      return map;
+    });
+    const mockImpl = mockForgeProviderResolved(undefined, batchSpy);
+
+    const findPRsByNumbers = vi.fn(async (_repo: RepoRef, prNumbers: number[]) => {
+      const map = new Map<number, ForgePR | null>();
+      for (const n of prNumbers) map.set(n, makeMockForgePR({ number: n }));
+      return map;
+    });
+    const probeCalls: PRSnapshot[][] = [];
+    const probeOpenPRList = vi.fn(async (_repo: RepoRef, tracked: PRSnapshot[]) => {
+      probeCalls.push(tracked);
+      if (probeCalls.length === 1) {
+        return {
+          kind: "changed" as const,
+          changed: [
+            {
+              number: 1,
+              headSha: "sha2",
+              updatedAt: "2024-02-02T00:00:00Z",
+              state: "open" as const,
+              title: "Add new feature",
+            },
+          ],
+        };
+      }
+      return { kind: "unchanged" as const };
+    });
+    mockImpl.batchLookups = { findPRsByNumbers, probeOpenPRList };
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+    );
+
+    await pullRequestService.refresh();
+
+    const revalidate = (
+      pullRequestService as unknown as { revalidateResolvedPRs: () => Promise<void> }
+    ).revalidateResolvedPRs.bind(pullRequestService);
+
+    await revalidate();
+    await revalidate();
+
+    // First probe saw the un-seeded (null) markers; after consuming the changed
+    // probe, the second probe's tracked snapshot carries the seeded REST markers.
+    expect(probeCalls).toHaveLength(2);
+    expect(probeCalls[0][0]).toMatchObject({ number: 1, headSha: null, updatedAt: null });
+    expect(probeCalls[1][0]).toMatchObject({
+      number: 1,
+      headSha: "sha2",
+      updatedAt: "2024-02-02T00:00:00Z",
+    });
+
+    pullRequestService.destroy();
+  });
+
   it("keeps polling CI for in-flight PRs even when probeOpenPRList reports unchanged", async () => {
     vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
 

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -6,6 +6,7 @@ import type {
   ForgeProviderImpl,
   RepoRef,
   PR as ForgePR,
+  PRSnapshot,
   CIStatus,
 } from "../../../shared/types/forge.js";
 import type { ForgeResolveProviderResult } from "../../../shared/types/workspace-host.js";
@@ -88,6 +89,10 @@ function makeMockBridge(impl: ForgeProviderImpl) {
     getCIStatuses: vi.fn(async (_id: string, repo: RepoRef, prNumbers: number[]) => {
       if (!impl.batchLookups?.getCIStatuses) return null;
       return impl.batchLookups.getCIStatuses(repo, prNumbers);
+    }),
+    probeOpenPRList: vi.fn(async (_id: string, repo: RepoRef, tracked: PRSnapshot[]) => {
+      if (!impl.batchLookups?.probeOpenPRList) return null;
+      return impl.batchLookups.probeOpenPRList(repo, tracked);
     }),
     getRateLimit: vi.fn(async (_id: string) => impl.getRateLimit?.() ?? null),
     clearPullRequestCaches: vi.fn(async (_id: string) => {
@@ -848,6 +853,173 @@ describe("PullRequestService", () => {
       expect.arrayContaining([1, 2])
     );
     expect(mockImpl.getPR).not.toHaveBeenCalled();
+
+    pullRequestService.destroy();
+  });
+
+  it("skips the findPRsByNumbers revalidation batch when probeOpenPRList reports unchanged", async () => {
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+
+    const batchSpy = vi.fn(async (_repo: RepoRef, branches: string[]) => {
+      const map = new Map<string, ForgePR | null>();
+      for (const branch of branches) {
+        map.set(
+          branch,
+          makeMockForgePR({ number: branch === "feature/a" ? 1 : 2, headRef: branch })
+        );
+      }
+      return map;
+    });
+    const mockImpl = mockForgeProviderResolved(undefined, batchSpy);
+
+    const findPRsByNumbers = vi.fn(async (_repo: RepoRef, prNumbers: number[]) => {
+      const map = new Map<number, ForgePR | null>();
+      for (const n of prNumbers) map.set(n, makeMockForgePR({ number: n }));
+      return map;
+    });
+    const probeOpenPRList = vi.fn(async () => ({ kind: "unchanged" as const }));
+    mockImpl.batchLookups = { findPRsByNumbers, probeOpenPRList };
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+    );
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-2", branch: "feature/b" })
+    );
+
+    await pullRequestService.refresh();
+    findPRsByNumbers.mockClear();
+    probeOpenPRList.mockClear();
+
+    await (
+      pullRequestService as unknown as { revalidateResolvedPRs: () => Promise<void> }
+    ).revalidateResolvedPRs();
+
+    // A 304-equivalent probe means nothing changed — the GraphQL re-fetch is skipped.
+    expect(probeOpenPRList).toHaveBeenCalledTimes(1);
+    expect(findPRsByNumbers).not.toHaveBeenCalled();
+
+    pullRequestService.destroy();
+  });
+
+  it("re-fetches only the changed PR when probeOpenPRList reports a subset changed", async () => {
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+
+    const batchSpy = vi.fn(async (_repo: RepoRef, branches: string[]) => {
+      const map = new Map<string, ForgePR | null>();
+      for (const branch of branches) {
+        map.set(
+          branch,
+          makeMockForgePR({ number: branch === "feature/a" ? 1 : 2, headRef: branch })
+        );
+      }
+      return map;
+    });
+    const mockImpl = mockForgeProviderResolved(undefined, batchSpy);
+
+    const findPRsByNumbers = vi.fn(async (_repo: RepoRef, prNumbers: number[]) => {
+      const map = new Map<number, ForgePR | null>();
+      for (const n of prNumbers) map.set(n, makeMockForgePR({ number: n }));
+      return map;
+    });
+    const probeOpenPRList = vi.fn(async () => ({
+      kind: "changed" as const,
+      changed: [
+        {
+          number: 1,
+          headSha: "sha2",
+          updatedAt: "2024-02-02T00:00:00Z",
+          state: "open" as const,
+          title: "Add new feature",
+        },
+      ],
+    }));
+    mockImpl.batchLookups = { findPRsByNumbers, probeOpenPRList };
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+    );
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-2", branch: "feature/b" })
+    );
+
+    await pullRequestService.refresh();
+    findPRsByNumbers.mockClear();
+
+    await (
+      pullRequestService as unknown as { revalidateResolvedPRs: () => Promise<void> }
+    ).revalidateResolvedPRs();
+
+    // Only PR #1 changed — PR #2 is not re-fetched.
+    expect(findPRsByNumbers).toHaveBeenCalledTimes(1);
+    expect(findPRsByNumbers).toHaveBeenCalledWith(expect.anything(), [1]);
+
+    pullRequestService.destroy();
+  });
+
+  it("keeps polling CI for in-flight PRs even when probeOpenPRList reports unchanged", async () => {
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+
+    const batchSpy = vi.fn(async (_repo: RepoRef, branches: string[]) => {
+      const map = new Map<string, ForgePR | null>();
+      for (const branch of branches)
+        map.set(branch, makeMockForgePR({ number: 1, headRef: branch }));
+      return map;
+    });
+    const mockImpl = mockForgeProviderResolved(undefined, batchSpy);
+
+    const getCIStatuses = vi.fn(async (_repo: RepoRef, prNumbers: number[]) => {
+      const map = new Map<number, CIStatus | null>();
+      for (const n of prNumbers) {
+        map.set(n, { state: "pending", total: 1, passed: 0, failed: 0, pending: 1, rawData: null });
+      }
+      return map;
+    });
+    const findPRsByNumbers = vi.fn(async (_repo: RepoRef, prNumbers: number[]) => {
+      const map = new Map<number, ForgePR | null>();
+      for (const n of prNumbers) map.set(n, makeMockForgePR({ number: n }));
+      return map;
+    });
+    const probeOpenPRList = vi.fn(async () => ({ kind: "unchanged" as const }));
+    mockImpl.batchLookups = { findPRsByNumbers, getCIStatuses, probeOpenPRList };
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+    );
+
+    await pullRequestService.refresh();
+    await flushLoaders();
+
+    getCIStatuses.mockClear();
+    findPRsByNumbers.mockClear();
+
+    await (
+      pullRequestService as unknown as { revalidateResolvedPRs: () => Promise<void> }
+    ).revalidateResolvedPRs();
+    await flushLoaders();
+
+    // PR metadata re-fetch is skipped (probe unchanged) but CI keeps polling,
+    // since a CI re-run doesn't bump the PR's updated_at.
+    expect(findPRsByNumbers).not.toHaveBeenCalled();
+    expect(getCIStatuses).toHaveBeenCalledTimes(1);
+    expect(getCIStatuses).toHaveBeenCalledWith(expect.anything(), [1]);
 
     pullRequestService.destroy();
   });

--- a/electron/services/forgeRpcServer.ts
+++ b/electron/services/forgeRpcServer.ts
@@ -9,6 +9,8 @@ import type {
   ForgeProviderImpl,
   Issue,
   PR,
+  PRListProbeResult,
+  PRSnapshot,
   RateLimitInfo,
   RepoRef,
 } from "../../shared/types/forge.js";
@@ -199,6 +201,8 @@ async function invoke(req: ForgeRpcRequest): Promise<unknown> {
       return invokeGetCIStatus(impl, req.args);
     case "getCIStatuses":
       return invokeGetCIStatuses(impl, req.args);
+    case "probeOpenPRList":
+      return invokeProbeOpenPRList(impl, req.args);
     case "getRateLimit":
       return invokeGetRateLimit(impl);
     case "clearPullRequestCaches":
@@ -282,6 +286,15 @@ async function invokeGetCIStatuses(
   const [repo, prNumbers] = args as [RepoRef, number[]];
   if (!impl.batchLookups?.getCIStatuses) return null;
   return impl.batchLookups.getCIStatuses(repo, prNumbers);
+}
+
+async function invokeProbeOpenPRList(
+  impl: ForgeProviderImpl,
+  args: unknown[]
+): Promise<PRListProbeResult | null> {
+  const [repo, tracked] = args as [RepoRef, PRSnapshot[]];
+  if (!impl.batchLookups?.probeOpenPRList) return null;
+  return impl.batchLookups.probeOpenPRList(repo, tracked);
 }
 
 async function invokeGetRateLimit(impl: ForgeProviderImpl): Promise<RateLimitInfo | null> {

--- a/electron/workspace-host/forgeBridge.ts
+++ b/electron/workspace-host/forgeBridge.ts
@@ -4,7 +4,15 @@ import type {
   ForgeRpcMethod,
   ForgeResolveProviderResult,
 } from "../../shared/types/workspace-host.js";
-import type { CIStatus, Issue, PR, RateLimitInfo, RepoRef } from "../../shared/types/forge.js";
+import type {
+  CIStatus,
+  Issue,
+  PR,
+  PRListProbeResult,
+  PRSnapshot,
+  RateLimitInfo,
+  RepoRef,
+} from "../../shared/types/forge.js";
 
 // Deterministic stringify so identical arg shapes coalesce regardless of
 // property order.
@@ -129,6 +137,20 @@ export class ForgeBridge {
       repo,
       prNumbers,
     ]);
+  }
+
+  /**
+   * Optional cheap conditional probe of the repo's open-PR list. Returns `null`
+   * when the provider does not implement `batchLookups.probeOpenPRList`; the
+   * caller then revalidates every tracked PR as if no probe existed. See
+   * {@link PRListProbeResult}.
+   */
+  probeOpenPRList(
+    namespacedId: string,
+    repo: RepoRef,
+    tracked: PRSnapshot[]
+  ): Promise<PRListProbeResult | null> {
+    return this.invoke<PRListProbeResult | null>("probeOpenPRList", namespacedId, [repo, tracked]);
   }
 
   /**

--- a/plugins/builtin/github/main/GitHubCaches.ts
+++ b/plugins/builtin/github/main/GitHubCaches.ts
@@ -96,6 +96,22 @@ export const repoPRListETagCache = new Cache<string, string>({
 });
 
 /**
+ * Repo-level ETag for `GET /repos/{owner}/{repo}/pulls?state=open&per_page=100`,
+ * keyed `${owner}/${repo}`. The steady-state PR revalidation probe
+ * (`probeOpenPRList` in `GitHubPRDiscovery.ts`) sends it as `If-None-Match`; an
+ * authenticated `304` means no open PR on page 1 changed, so the GraphQL
+ * revalidation fan-out is skipped at zero rate-limit cost. Distinct from
+ * {@link repoPRListETagCache} (which probes `per_page=1&state=all` for the
+ * detection path) — the URL, and therefore the ETag, differs, so sharing one
+ * cache would cross-contaminate the two probes' baselines. 1-hour TTL matches
+ * the other ETag caches.
+ */
+export const openPRListETagCache = new Cache<string, string>({
+  maxSize: ETAG_CACHE_MAX_SIZE,
+  defaultTTL: ETAG_CACHE_TTL,
+});
+
+/**
  * ETag for the repo's REST `/events` feed, keyed by `owner/repo`. The activity
  * probe sends it back as `If-None-Match`; an authenticated `304 Not Modified`
  * costs zero rate-limit quota, which is the whole point of polling here instead
@@ -214,6 +230,7 @@ export function clearGitHubCaches(): void {
   prETagCache.clear();
   branchListETagCache.clear();
   repoPRListETagCache.clear();
+  openPRListETagCache.clear();
   reviewThreadsCache.clear();
   prRequiredStatusCache.clear();
   forgeQueryCache.clear();
@@ -258,6 +275,7 @@ export function clearPRCaches(): void {
   prETagCache.clear();
   branchListETagCache.clear();
   repoPRListETagCache.clear();
+  openPRListETagCache.clear();
   reviewThreadsCache.clear();
   prRequiredStatusCache.clear();
   // PR queries (GET_PR, LIST_PRS, PR CI status, batch-branch) all flow through

--- a/plugins/builtin/github/main/GitHubPRDiscovery.ts
+++ b/plugins/builtin/github/main/GitHubPRDiscovery.ts
@@ -8,11 +8,13 @@ import {
   prETagCache,
   branchListETagCache,
   repoPRListETagCache,
+  openPRListETagCache,
   truncateBody,
   getETagCacheVersion,
   writePRTooltip,
 } from "./GitHubCaches.js";
 import type { GitHubPRCIStatus, PRTooltipData } from "../../../../shared/types/github.js";
+import type { PRListProbeResult, PRSnapshot } from "../../../../shared/types/forge.js";
 import type { PRCheckCandidate, PRCheckResult, BatchPRCheckResult, LinkedPR } from "./types.js";
 
 interface BatchPRTooltipFields {
@@ -293,6 +295,163 @@ export async function probeRepoPRListChange(
   } catch {
     return "unknown";
   }
+}
+
+interface OpenPRListItem {
+  number?: number;
+  state?: string;
+  title?: string;
+  updated_at?: string;
+  head?: { sha?: string } | null;
+}
+
+/**
+ * Steady-state revalidation probe: one conditional `GET .../pulls?state=open`
+ * against the open-PR list. Diffs the result against the caller's `tracked`
+ * snapshots and returns only the PRs that changed, so an idle repo skips the
+ * GraphQL revalidation fan-out entirely (the old per-PR tick cost ~3 GraphQL
+ * points each; this costs zero on a `304`).
+ *
+ * ETag commit discipline (the key correctness rule, mirrors `fetchActivityProbe`
+ * in `GitHubStats.ts`): the new ETag is committed ONLY when no tracked PR
+ * changed — i.e. the caller's view is already in sync with the probe. While any
+ * tracked PR still differs the old ETag is left in place, so the next tick
+ * re-fetches (`200`) and re-diffs instead of masking the unconsumed change
+ * behind a `304`. Once the caller has processed the change and passes matching
+ * snapshots, the diff comes back clean and the ETag advances — 304s resume from
+ * then on. This gates the commit on caller-sync without a second round-trip.
+ *
+ * Returns `fallback` on any inconclusive outcome (rate-limit block, network or
+ * parse error, missing ETag, concurrent cache clear) so the caller runs its
+ * full revalidation. Uses the REST `core` bucket;
+ * `daintreeSkipRateLimitPreflight` bypasses the wrapper's unscoped (graphql)
+ * gate since the `core` check below is the correct one.
+ *
+ * Per-page limitation: the ETag covers only page 1 (`per_page=100`). For a repo
+ * with >100 open PRs a tracked PR on page 2 reads as "absent" and is reported
+ * changed every tick — wasting a GraphQL re-fetch but never masking a change.
+ * Daintree tracks few PRs per worktree, so this is a rare, bounded cost.
+ */
+export async function probeOpenPRList(
+  owner: string,
+  repo: string,
+  token: string,
+  tracked: PRSnapshot[]
+): Promise<PRListProbeResult> {
+  const block = gitHubRateLimitService.shouldBlockRequest("core");
+  if (block.blocked) return { kind: "fallback" };
+
+  const cacheKey = `${owner}/${repo}`;
+  const cachedETag = openPRListETagCache.get(cacheKey);
+  const versionAtStart = getETagCacheVersion();
+  const url = `https://api.github.com/repos/${owner}/${repo}/pulls?state=open&per_page=100`;
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (cachedETag) {
+    headers["If-None-Match"] = cachedETag;
+  }
+
+  let response: Response;
+  try {
+    response = await rateLimitAwareFetch(url, {
+      headers,
+      signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
+      daintreeSkipRateLimitPreflight: true,
+    });
+  } catch {
+    return { kind: "fallback" };
+  }
+
+  // A concurrent cache clear (token change / manual refresh) invalidated the
+  // ETag baseline this request was built on — fall back rather than acting on a
+  // `304` against a now-cleared ETag, or committing a stale-baseline `200`.
+  if (getETagCacheVersion() !== versionAtStart) {
+    return { kind: "fallback" };
+  }
+
+  if (response.status === 304) {
+    return { kind: "unchanged" };
+  }
+  if (response.status !== 200) {
+    return { kind: "fallback" };
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    return { kind: "fallback" };
+  }
+  if (!Array.isArray(body)) {
+    return { kind: "fallback" };
+  }
+
+  const restByNumber = new Map<number, OpenPRListItem>();
+  for (const item of body as OpenPRListItem[]) {
+    if (item && typeof item.number === "number") {
+      restByNumber.set(item.number, item);
+    }
+  }
+
+  const changed: PRSnapshot[] = [];
+  for (const t of tracked) {
+    const rest = restByNumber.get(t.number);
+    if (t.state === "open" || t.state === null) {
+      // Expected in the open list. Absent → it left the open set (merged /
+      // closed / deleted), so the caller must re-fetch to learn the new state.
+      // Present with a different head SHA or update time → changed.
+      if (!rest) {
+        changed.push({
+          number: t.number,
+          headSha: null,
+          updatedAt: null,
+          state: null,
+          title: null,
+        });
+      } else {
+        const headSha = rest.head?.sha ?? null;
+        const updatedAt = rest.updated_at ?? null;
+        if (headSha !== t.headSha || updatedAt !== t.updatedAt) {
+          changed.push({
+            number: t.number,
+            headSha,
+            updatedAt,
+            state: "open",
+            title: rest.title ?? null,
+          });
+        }
+      }
+    } else if (rest) {
+      // Known merged/closed → expected absent. Present again means reopened.
+      changed.push({
+        number: t.number,
+        headSha: rest.head?.sha ?? null,
+        updatedAt: rest.updated_at ?? null,
+        state: "open",
+        title: rest.title ?? null,
+      });
+    }
+  }
+
+  if (changed.length === 0) {
+    // Caller is in sync with the probe — advance the ETag baseline so future
+    // unchanged ticks resolve as a zero-cost `304`. A `200` with no ETag can't
+    // establish a baseline, so drop any stale entry and re-probe next tick.
+    const etag = response.headers.get("etag");
+    if (etag) {
+      openPRListETagCache.set(cacheKey, etag);
+    } else {
+      openPRListETagCache.invalidate(cacheKey);
+    }
+    return { kind: "unchanged" };
+  }
+
+  // Tracked PRs still differ — deliberately do NOT advance the ETag; the next
+  // tick re-fetches and re-diffs until the caller has consumed the change.
+  return { kind: "changed", changed };
 }
 
 async function probePRChange(

--- a/plugins/builtin/github/main/__tests__/GitHubPRDiscovery.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubPRDiscovery.test.ts
@@ -1,9 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
-import { probeRepoPRListChange, batchCheckLinkedPRs } from "../GitHubPRDiscovery.js";
-import { repoPRListETagCache, clearPRCaches } from "../GitHubCaches.js";
+import {
+  probeRepoPRListChange,
+  probeOpenPRList,
+  batchCheckLinkedPRs,
+} from "../GitHubPRDiscovery.js";
+import { repoPRListETagCache, openPRListETagCache, clearPRCaches } from "../GitHubCaches.js";
 import { GitHubAuth, _resetGithubFetchSemaphoreForTests } from "../GitHubAuth.js";
 import { gitHubRateLimitService } from "../GitHubRateLimitService.js";
 import { getRepoContext } from "../GitHubRepoContext.js";
+import type { PRSnapshot } from "../../../../../shared/types/forge.js";
 
 vi.mock("../GitHubRepoContext.js", async () => {
   const actual =
@@ -154,6 +159,233 @@ describe("probeRepoPRListChange", () => {
     setFetch(() => Promise.reject(new Error("ECONNREFUSED")));
 
     expect(await probeRepoPRListChange("o", "r", "ghp_token")).toBe("unknown");
+  });
+});
+
+describe("probeOpenPRList", () => {
+  beforeEach(() => {
+    openPRListETagCache.clear();
+    gitHubRateLimitService._resetForTests();
+    _resetGithubFetchSemaphoreForTests();
+  });
+
+  afterEach(() => {
+    gitHubRateLimitService._resetForTests();
+  });
+
+  function openPRBody(
+    items: Array<{ number: number; sha?: string; updatedAt?: string; title?: string }>
+  ): string {
+    return JSON.stringify(
+      items.map((i) => ({
+        number: i.number,
+        state: "open",
+        title: i.title ?? "PR",
+        updated_at: i.updatedAt ?? "2024-01-01T00:00:00Z",
+        head: { sha: i.sha ?? "sha1" },
+      }))
+    );
+  }
+
+  const tracked = (number: number, overrides: Partial<PRSnapshot> = {}): PRSnapshot => ({
+    number,
+    headSha: "sha1",
+    updatedAt: "2024-01-01T00:00:00Z",
+    state: "open",
+    title: "PR",
+    ...overrides,
+  });
+
+  it("hits the open-PR list with the fixed query and sends If-None-Match when an ETag is cached", async () => {
+    openPRListETagCache.set("o/r", 'W/"cached"');
+    const mock = setFetch(() => new Response(null, { status: 304, headers: RATE_LIMIT_HEADERS }));
+
+    const result = await probeOpenPRList("o", "r", "ghp_token", [tracked(1)]);
+
+    expect(result).toEqual({ kind: "unchanged" });
+    const [url, init] = mock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.github.com/repos/o/r/pulls?state=open&per_page=100");
+    expect((init.headers as Record<string, string>)["If-None-Match"]).toBe('W/"cached"');
+    // A 304 leaves the existing baseline in place.
+    expect(openPRListETagCache.get("o/r")).toBe('W/"cached"');
+  });
+
+  it("commits the ETag and reports unchanged when no tracked PR differs", async () => {
+    openPRListETagCache.set("o/r", 'W/"old"');
+    setFetch(
+      () =>
+        new Response(openPRBody([{ number: 1, sha: "sha1", updatedAt: "2024-01-01T00:00:00Z" }]), {
+          status: 200,
+          headers: { ...RATE_LIMIT_HEADERS, etag: 'W/"new"' },
+        })
+    );
+
+    const result = await probeOpenPRList("o", "r", "ghp_token", [tracked(1)]);
+
+    expect(result).toEqual({ kind: "unchanged" });
+    // Caller is in sync → baseline advances so the next tick can 304.
+    expect(openPRListETagCache.get("o/r")).toBe('W/"new"');
+  });
+
+  it("reports the changed PR and does NOT commit the ETag while the change is unconsumed", async () => {
+    openPRListETagCache.set("o/r", 'W/"old"');
+    setFetch(
+      () =>
+        new Response(openPRBody([{ number: 1, sha: "sha2", updatedAt: "2024-02-02T00:00:00Z" }]), {
+          status: 200,
+          headers: { ...RATE_LIMIT_HEADERS, etag: 'W/"new"' },
+        })
+    );
+
+    const result = await probeOpenPRList("o", "r", "ghp_token", [tracked(1)]);
+
+    expect(result).toEqual({
+      kind: "changed",
+      changed: [
+        {
+          number: 1,
+          headSha: "sha2",
+          updatedAt: "2024-02-02T00:00:00Z",
+          state: "open",
+          title: "PR",
+        },
+      ],
+    });
+    // ETag stays on the old baseline so the next tick re-fetches and re-diffs.
+    expect(openPRListETagCache.get("o/r")).toBe('W/"old"');
+  });
+
+  it("flags an open tracked PR that left the open list as changed with null markers", async () => {
+    setFetch(
+      () =>
+        new Response(openPRBody([{ number: 9 }]), {
+          status: 200,
+          headers: { ...RATE_LIMIT_HEADERS, etag: 'W/"x"' },
+        })
+    );
+
+    const result = await probeOpenPRList("o", "r", "ghp_token", [tracked(1)]);
+
+    expect(result).toEqual({
+      kind: "changed",
+      changed: [{ number: 1, headSha: null, updatedAt: null, state: null, title: null }],
+    });
+  });
+
+  it("does not flag a known-merged tracked PR that is absent from the open list", async () => {
+    setFetch(
+      () =>
+        new Response(openPRBody([{ number: 9 }]), {
+          status: 200,
+          headers: { ...RATE_LIMIT_HEADERS, etag: 'W/"x"' },
+        })
+    );
+
+    const result = await probeOpenPRList("o", "r", "ghp_token", [tracked(1, { state: "merged" })]);
+
+    expect(result).toEqual({ kind: "unchanged" });
+    expect(openPRListETagCache.get("o/r")).toBe('W/"x"');
+  });
+
+  it("flags a known-merged tracked PR that reappears in the open list (reopened)", async () => {
+    setFetch(
+      () =>
+        new Response(openPRBody([{ number: 1, sha: "sha3", updatedAt: "2024-03-03T00:00:00Z" }]), {
+          status: 200,
+          headers: { ...RATE_LIMIT_HEADERS, etag: 'W/"x"' },
+        })
+    );
+
+    const result = await probeOpenPRList("o", "r", "ghp_token", [tracked(1, { state: "closed" })]);
+
+    expect(result).toEqual({
+      kind: "changed",
+      changed: [
+        {
+          number: 1,
+          headSha: "sha3",
+          updatedAt: "2024-03-03T00:00:00Z",
+          state: "open",
+          title: "PR",
+        },
+      ],
+    });
+  });
+
+  it("falls back when the core rate-limit bucket is blocking", async () => {
+    gitHubRateLimitService.update(
+      {
+        get: (name: string) =>
+          ({
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": String(Math.floor(Date.now() / 1000) + 3600),
+            "x-ratelimit-resource": "core",
+          })[name.toLowerCase()] ?? null,
+      } as unknown as Headers,
+      200
+    );
+    const mock = setFetch(() => new Response(openPRBody([{ number: 1 }]), { status: 200 }));
+
+    const result = await probeOpenPRList("o", "r", "ghp_token", [tracked(1)]);
+
+    expect(result).toEqual({ kind: "fallback" });
+    expect(mock).not.toHaveBeenCalled();
+  });
+
+  it("falls back on a non-200/304 status", async () => {
+    setFetch(() => new Response("nope", { status: 500, headers: RATE_LIMIT_HEADERS }));
+
+    const result = await probeOpenPRList("o", "r", "ghp_token", [tracked(1)]);
+
+    expect(result).toEqual({ kind: "fallback" });
+  });
+
+  it("falls back when the 200 body is not an array", async () => {
+    setFetch(
+      () =>
+        new Response('{"message":"oops"}', {
+          status: 200,
+          headers: { ...RATE_LIMIT_HEADERS, etag: 'W/"x"' },
+        })
+    );
+
+    const result = await probeOpenPRList("o", "r", "ghp_token", [tracked(1)]);
+
+    expect(result).toEqual({ kind: "fallback" });
+  });
+
+  it("falls back (writing nothing) when the ETag cache version changes mid-flight", async () => {
+    openPRListETagCache.set("o/r", 'W/"old"');
+    let resolveFetch: ((response: Response) => void) | null = null;
+    setFetch(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+
+    const probe = probeOpenPRList("o", "r", "ghp_token", [tracked(1, { headSha: "sha1" })]);
+    await vi.waitFor(() => expect(resolveFetch).not.toBeNull());
+
+    clearPRCaches();
+
+    resolveFetch!(
+      new Response(openPRBody([{ number: 1, sha: "sha9" }]), {
+        status: 200,
+        headers: { ...RATE_LIMIT_HEADERS, etag: 'W/"new"' },
+      })
+    );
+
+    expect(await probe).toEqual({ kind: "fallback" });
+    expect(openPRListETagCache.get("o/r")).toBeUndefined();
+  });
+
+  it("falls back when the fetch rejects", async () => {
+    setFetch(() => Promise.reject(new Error("ECONNREFUSED")));
+
+    expect(await probeOpenPRList("o", "r", "ghp_token", [tracked(1)])).toEqual({
+      kind: "fallback",
+    });
   });
 });
 

--- a/plugins/builtin/github/main/__tests__/GitHubPRDiscovery.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubPRDiscovery.test.ts
@@ -387,6 +387,61 @@ describe("probeOpenPRList", () => {
       kind: "fallback",
     });
   });
+
+  it("reports changed on the cold-start (null-marker) snapshot every detection goes through", async () => {
+    setFetch(
+      () =>
+        new Response(openPRBody([{ number: 1, sha: "sha1", updatedAt: "2024-01-01T00:00:00Z" }]), {
+          status: 200,
+          headers: { ...RATE_LIMIT_HEADERS, etag: 'W/"x"' },
+        })
+    );
+
+    // A freshly-detected PR has null head.sha/updated_at markers — they can
+    // never match a real REST field, so the first revalidation must re-fetch.
+    const result = await probeOpenPRList("o", "r", "ghp_token", [
+      tracked(1, { headSha: null, updatedAt: null }),
+    ]);
+
+    expect(result.kind).toBe("changed");
+    // The ETag is NOT committed while the caller is out of sync.
+    expect(openPRListETagCache.get("o/r")).toBeUndefined();
+  });
+
+  it("self-heals across cycles: changed (no commit) → synced (commit) → 304", async () => {
+    openPRListETagCache.set("o/r", 'W/"E0"');
+    // Header-aware mock: a request already holding the post-change ETag gets a
+    // 304; otherwise a 200 reporting PR #1 at the new sha + the new ETag.
+    setFetch((...args: unknown[]) => {
+      const init = args[1] as RequestInit | undefined;
+      const inm = (init?.headers as Record<string, string> | undefined)?.["If-None-Match"];
+      if (inm === 'W/"E1"') {
+        return new Response(null, { status: 304, headers: RATE_LIMIT_HEADERS });
+      }
+      return new Response(
+        openPRBody([{ number: 1, sha: "sha2", updatedAt: "2024-02-02T00:00:00Z" }]),
+        { status: 200, headers: { ...RATE_LIMIT_HEADERS, etag: 'W/"E1"' } }
+      );
+    });
+
+    // Cycle 1: caller still on the old sha → changed, old ETag preserved.
+    const c1 = await probeOpenPRList("o", "r", "ghp_token", [tracked(1, { headSha: "sha1" })]);
+    expect(c1.kind).toBe("changed");
+    expect(openPRListETagCache.get("o/r")).toBe('W/"E0"');
+
+    // Cycle 2: caller consumed the change (sha2) → clean diff commits the ETag.
+    const c2 = await probeOpenPRList("o", "r", "ghp_token", [
+      tracked(1, { headSha: "sha2", updatedAt: "2024-02-02T00:00:00Z" }),
+    ]);
+    expect(c2).toEqual({ kind: "unchanged" });
+    expect(openPRListETagCache.get("o/r")).toBe('W/"E1"');
+
+    // Cycle 3: the committed ETag now drives a zero-cost 304.
+    const c3 = await probeOpenPRList("o", "r", "ghp_token", [
+      tracked(1, { headSha: "sha2", updatedAt: "2024-02-02T00:00:00Z" }),
+    ]);
+    expect(c3).toEqual({ kind: "unchanged" });
+  });
 });
 
 describe("batchCheckLinkedPRs repo-level probe gate", () => {

--- a/plugins/builtin/github/main/forgeProvider.ts
+++ b/plugins/builtin/github/main/forgeProvider.ts
@@ -14,6 +14,8 @@ import type {
   NormalizedReviewDecision,
   PR,
   Page,
+  PRListProbeResult,
+  PRSnapshot,
   PushErrorClassification,
   RateLimitInfo,
   RepoMetadata,
@@ -45,6 +47,7 @@ import {
   repoEventsETagCache,
 } from "./GitHubCaches.js";
 import { parseGitHubError } from "./GitHubErrors.js";
+import { probeOpenPRList } from "./GitHubPRDiscovery.js";
 import { deriveRequiredCIStatus } from "./prRequiredCIStatus.js";
 import { MAX_REVIEW_THREAD_PAGES } from "./GitHubCaches.js";
 import type { RollupContextNode } from "./prRequiredCIStatus.js";
@@ -905,6 +908,17 @@ async function getCIStatusImpl(repo: RepoRef, prNumber: number): Promise<CIStatu
   });
 }
 
+async function probeOpenPRListImpl(
+  repo: RepoRef,
+  tracked: PRSnapshot[]
+): Promise<PRListProbeResult> {
+  const token = GitHubAuth.getToken();
+  // No token → the conditional GET can't be made; let the caller revalidate
+  // through its normal (also token-gated) path rather than claim "unchanged".
+  if (!token) return { kind: "fallback" };
+  return probeOpenPRList(repo.owner, repo.repo, token, tracked);
+}
+
 async function getRepoMetadataImpl(repo: RepoRef): Promise<RepoMetadata> {
   const response = await runQuery(
     REPO_METADATA_QUERY,
@@ -1065,6 +1079,7 @@ export const githubForgeProvider: ForgeProviderImpl = {
   batchLookups: {
     findPRsByNumbers: findPRsByNumbersImpl,
     getCIStatuses: getCIStatusesImpl,
+    probeOpenPRList: probeOpenPRListImpl,
   },
   getRepoMetadata: getRepoMetadataImpl,
 

--- a/shared/types/forge.ts
+++ b/shared/types/forge.ts
@@ -366,6 +366,43 @@ export interface MilestoneCapability {
 }
 
 /**
+ * Lightweight snapshot of a PR's change-detection fields, exchanged with
+ * {@link BatchLookupCapability.probeOpenPRList}. The caller passes its current
+ * view of each tracked PR; the provider diffs it against a cheap probe and
+ * returns only the PRs that changed. `headSha`/`updatedAt` are the change
+ * markers a REST provider reads straight from its pulls-list response;
+ * `state` lets the provider interpret a PR's *absence* from the open-PR list
+ * correctly — a known-merged/closed PR is expected to be absent (not a change),
+ * whereas an open PR's absence means it left the open set. A `null` field means
+ * "unknown" (a not-yet-seeded caller snapshot, or — in a returned `changed`
+ * entry — that the probe had no fresh data and the caller must re-fetch through
+ * the authoritative path to learn the new value).
+ */
+export interface PRSnapshot {
+  number: number;
+  headSha: string | null;
+  updatedAt: string | null;
+  state: NormalizedPRState | null;
+  title: string | null;
+}
+
+/**
+ * Result of {@link BatchLookupCapability.probeOpenPRList}.
+ *   - `unchanged` — no tracked PR changed; the caller skips its expensive
+ *     per-PR revalidation entirely (the probe cost ~zero quota on a 304).
+ *   - `changed` — `changed` lists the tracked PRs that changed; the caller
+ *     re-fetches only those through the authoritative path. A snapshot with
+ *     all-`null` change fields means "changed, but the probe has no fresh data"
+ *     (e.g. the PR left the open set) — re-fetch to learn its new state.
+ *   - `fallback` — the probe was inconclusive (auth/network/rate-limit/cold
+ *     cache); the caller must run its full revalidation as if no probe existed.
+ */
+export type PRListProbeResult =
+  | { kind: "unchanged" }
+  | { kind: "changed"; changed: PRSnapshot[] }
+  | { kind: "fallback" };
+
+/**
  * Optional multi-key batch lookups. The host's host-side `BatchLoader`
  * coalesces same-tick `getCIStatus`/`getPR` fan-out into one of these calls
  * when the provider implements them, collapsing N round-trips into ceil(N/100)
@@ -380,6 +417,15 @@ export interface MilestoneCapability {
 export interface BatchLookupCapability {
   getCIStatuses?(repo: RepoRef, prNumbers: number[]): Promise<Map<number, CIStatus | null>>;
   findPRsByNumbers?(repo: RepoRef, prNumbers: number[]): Promise<Map<number, PR | null>>;
+  /**
+   * Optional cheap conditional probe of the repo's open-PR list. Given the
+   * caller's current {@link PRSnapshot}s of the PRs it tracks, return only
+   * those that changed (or `unchanged`/`fallback`). Lets a steady-state
+   * revalidation poll skip the expensive per-PR GraphQL fan-out when nothing
+   * changed — an authenticated conditional `304` costs zero quota. Providers
+   * that can't probe cheaply omit it; the caller then re-fetches every PR.
+   */
+  probeOpenPRList?(repo: RepoRef, tracked: PRSnapshot[]): Promise<PRListProbeResult>;
 }
 
 /**

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -478,6 +478,7 @@ export type ForgeRpcMethod =
   | "getIssue"
   | "getCIStatus"
   | "getCIStatuses"
+  | "probeOpenPRList"
   | "getRateLimit"
   | "clearPullRequestCaches";
 


### PR DESCRIPTION
## Summary

- Replaces the steady-state PR revalidation GraphQL tick (`revalidateResolvedPRs`) with a cheap REST conditional GET against `GET /repos/{owner}/{repo}/pulls?state=open&per_page=100`. A 304 response costs zero quota points and short-circuits the GraphQL fan-out entirely; a 200 diffs `head.sha`/`updated_at` against the caller's snapshots and re-fetches only the changed PRs through the existing GraphQL path.
- At 25 open PRs polling every 30s, the old path burned ~9000 GraphQL points/hour per instance — well over the 5000/hour budget. This drops steady-state cost by ~25× on an unchanged repo.
- Adds a `probeOpenPRList` capability on `BatchLookupCapability` with an ETag cache (`openPRListETagCache`) that is cleared on manual refresh. The ETag baseline is single-owner (per-project poll lease) and committed only after the caller's tracked PRs are confirmed in sync. CI polling for PENDING/EXPECTED PRs continues even on a 304, since a CI re-run doesn't bump `updated_at`.

Resolves #9366

## Changes

- `shared/types/forge.ts` — `probeOpenPRList` method added to `BatchLookupCapability`; new `OpenPRListProbeResult` type with `changed`/`unchanged` variants
- `plugins/builtin/github/main/GitHubPRDiscovery.ts` — REST probe implementation with ETag conditional GET, diff logic, and `openPRListETagCache`
- `electron/services/PullRequestService.ts` — `revalidateResolvedPRs` switches to the probe path; falling back to full GraphQL fetch only when the probe reports changes
- `electron/services/forgeRpcServer.ts` + `electron/workspace-host/forgeBridge.ts` — `probeOpenPRList` wired through RPC and bridge layers
- `shared/types/workspace-host.ts` — bridge type updated
- Tests updated in `PullRequestService.test.ts` and `GitHubPRDiscovery.test.ts` to cover probe hit, probe miss (changed subset), and CI-polling exception

## Testing

Unit tests cover the three probe paths: 304 (unchanged — GraphQL skipped), 200 with changes (partial re-fetch), and the CI-polling exception for PENDING PRs on an otherwise-unchanged list. The ETag cache invalidation on manual refresh is tested directly. All existing `PullRequestService` and `GitHubPRDiscovery` tests continue to pass.