### PR TITLE
fix(voice): render interim dictation as ghost widget to preserve undo history

### DIFF
--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { EditorView } from "@codemirror/view";
-import { EditorSelection } from "@codemirror/state";
+import { EditorSelection, Transaction } from "@codemirror/state";
+import { isolateHistory } from "@codemirror/commands";
 import type { BuiltInAgentId } from "@shared/config/agentIds";
 import type { AgentState } from "@/types";
 import { logError } from "@/utils/logger";
@@ -438,15 +439,19 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
         setValue(draft);
         lastEmittedValueRef.current = draft;
         isApplyingExternalValueRef.current = true;
+        // `isolateHistory.of("before")` keeps the dictation/correction commit
+        // from merging into the user's prior keystroke history group, so a
+        // single Cmd-Z undoes just the dictated text (#9172).
         view.dispatch({
           changes: { from: 0, to: current.length, insert: draft },
           selection: { anchor: draft.length },
+          annotations: [Transaction.userEvent.of("input.dictate"), isolateHistory.of("before")],
           scrollIntoView: true,
         });
       }
     }, [voiceDraftRevision, terminalId, currentProject?.id]);
 
-    useVoiceDecorations({ terminalId, editorViewRef, voiceDraftRevision });
+    useVoiceDecorations({ terminalId, editorViewRef });
 
     const resetEditorDoc = () => {
       applyEditorValue("", {

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -1,7 +1,6 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { EditorView } from "@codemirror/view";
-import { EditorSelection, Transaction } from "@codemirror/state";
-import { isolateHistory } from "@codemirror/commands";
+import { EditorSelection } from "@codemirror/state";
 import type { BuiltInAgentId } from "@shared/config/agentIds";
 import type { AgentState } from "@/types";
 import { logError } from "@/utils/logger";
@@ -439,13 +438,9 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
         setValue(draft);
         lastEmittedValueRef.current = draft;
         isApplyingExternalValueRef.current = true;
-        // `isolateHistory.of("before")` keeps the dictation/correction commit
-        // from merging into the user's prior keystroke history group, so a
-        // single Cmd-Z undoes just the dictated text (#9172).
         view.dispatch({
           changes: { from: 0, to: current.length, insert: draft },
           selection: { anchor: draft.length },
-          annotations: [Transaction.userEvent.of("input.dictate"), isolateHistory.of("before")],
           scrollIntoView: true,
         });
       }

--- a/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
+++ b/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
@@ -27,8 +27,8 @@ import {
   fileDropChipField,
   addFileDropChip,
   createFilePasteHandler,
-  interimMarkField,
-  setInterimRange,
+  interimWidgetField,
+  setInterimText,
   pendingAIField,
   setPendingAIRanges,
   diffChipField,
@@ -876,90 +876,74 @@ describe("createFilePasteHandler", () => {
   });
 });
 
-describe("interimMarkField", () => {
+describe("interimWidgetField", () => {
   function makeView(doc = "") {
     const parent = document.createElement("div");
     return new EditorView({
       parent,
-      state: EditorState.create({ doc, extensions: [interimMarkField] }),
+      state: EditorState.create({ doc, extensions: [interimWidgetField] }),
     });
   }
 
-  it("applies interim mark decoration for the given range", () => {
+  it("stores the interim text in the field when dispatched", () => {
     const view = makeView("hello world");
-    view.dispatch({ effects: setInterimRange.of({ from: 6, to: 11 }) });
+    view.dispatch({ effects: setInterimText.of("draft text") });
 
-    const decos = view.state.field(interimMarkField);
-    const iter = decos.iter();
-    expect(iter.value).not.toBeNull();
-    expect(iter.from).toBe(6);
-    expect(iter.to).toBe(11);
+    expect(view.state.field(interimWidgetField)).toBe("draft text");
     view.destroy();
   });
 
-  it("clears interim mark when null is dispatched", () => {
+  it("renders a ghost widget at the end of the doc when text is present", () => {
     const view = makeView("hello world");
-    view.dispatch({ effects: setInterimRange.of({ from: 0, to: 5 }) });
-    view.dispatch({ effects: setInterimRange.of(null) });
+    view.dispatch({ effects: setInterimText.of("more") });
 
-    const decos = view.state.field(interimMarkField);
-    const iter = decos.iter();
-    expect(iter.value).toBeNull();
+    // Locate the ghost span in the rendered DOM.
+    const ghost = view.contentDOM.querySelector(".cm-voice-interim");
+    expect(ghost).not.toBeNull();
+    expect(ghost?.textContent).toBe("more");
     view.destroy();
   });
 
-  it("does not expand mark past boundary on insert at the end", () => {
-    const view = makeView("hello");
-    view.dispatch({ effects: setInterimRange.of({ from: 0, to: 5 }) });
-    // Insert text at the end of the marked range
-    view.dispatch({ changes: { from: 5, insert: " world" } });
-
-    const decos = view.state.field(interimMarkField);
-    const iter = decos.iter();
-    expect(iter.value).not.toBeNull();
-    // Mark should still end at 5 (mapped through change), not expand to include " world"
-    expect(iter.from).toBe(0);
-    expect(iter.to).toBe(5);
-    view.destroy();
-  });
-
-  it("maps mark range through document changes", () => {
+  it("clears the ghost widget when an empty string is dispatched", () => {
     const view = makeView("hello world");
-    view.dispatch({ effects: setInterimRange.of({ from: 6, to: 11 }) });
-    // Insert "XX" at position 0
-    view.dispatch({ changes: { from: 0, insert: "XX" } });
+    view.dispatch({ effects: setInterimText.of("draft") });
+    expect(view.contentDOM.querySelector(".cm-voice-interim")).not.toBeNull();
 
-    const decos = view.state.field(interimMarkField);
-    const iter = decos.iter();
-    expect(iter.value).not.toBeNull();
-    expect(iter.from).toBe(8); // shifted by 2
-    expect(iter.to).toBe(13);
+    view.dispatch({ effects: setInterimText.of("") });
+    expect(view.contentDOM.querySelector(".cm-voice-interim")).toBeNull();
     view.destroy();
   });
 
-  it("handles simultaneous doc change and clear effect correctly (map-before-effect)", () => {
+  it("does not mutate the document when interim text is set", () => {
     const view = makeView("hello");
-    view.dispatch({ effects: setInterimRange.of({ from: 0, to: 5 }) });
+    const before = view.state.doc.toString();
+    view.dispatch({ effects: setInterimText.of("interim text not in doc") });
 
-    // Single transaction: insert text AND clear the mark
-    view.dispatch({
-      changes: { from: 5, insert: " world" },
-      effects: setInterimRange.of(null),
-    });
-
-    const decos = view.state.field(interimMarkField);
-    const iter = decos.iter();
-    expect(iter.value).toBeNull();
+    expect(view.state.doc.toString()).toBe(before);
+    expect(view.state.doc.length).toBe(5);
     view.destroy();
   });
 
-  it("returns Decoration.none for invalid range (from >= to)", () => {
-    const view = makeView("hello");
-    view.dispatch({ effects: setInterimRange.of({ from: 5, to: 5 }) });
+  it("interim updates do not enter the undo history (no docChanged)", () => {
+    const view = makeView("base");
+    view.dispatch({ effects: setInterimText.of("a") });
+    view.dispatch({ effects: setInterimText.of("ab") });
+    view.dispatch({ effects: setInterimText.of("abc") });
 
-    const decos = view.state.field(interimMarkField);
-    const iter = decos.iter();
-    expect(iter.value).toBeNull();
+    // None of the interim dispatches touched the document, so the doc
+    // is still the original value — and the undo history holds no entries
+    // attributable to these effect-only transactions.
+    expect(view.state.doc.toString()).toBe("base");
+    view.destroy();
+  });
+
+  it("ghost widget is suppressed during IME composition", () => {
+    const view = makeView("hello");
+    // jsdom doesn't expose a composing setter, so stub the property.
+    Object.defineProperty(view, "composing", { value: true, configurable: true });
+    view.dispatch({ effects: setInterimText.of("ime guard") });
+
+    expect(view.contentDOM.querySelector(".cm-voice-interim")).toBeNull();
     view.destroy();
   });
 });
@@ -1089,42 +1073,39 @@ describe("voice decoration phase integration", () => {
       parent,
       state: EditorState.create({
         doc,
-        extensions: [interimMarkField, pendingAIField],
+        extensions: [interimWidgetField, pendingAIField],
       }),
     });
   }
 
-  it("utterance_final phase produces no decorations even when ranges could be set", () => {
+  it("utterance_final phase produces no decorations even when effects could be set", () => {
     const view = makeView("hello world");
     view.dispatch({
-      effects: [setInterimRange.of(null), setPendingAIRanges.of([])],
+      effects: [setInterimText.of(""), setPendingAIRanges.of([])],
     });
 
-    const interimDecos = view.state.field(interimMarkField);
-    const aiDecos = view.state.field(pendingAIField);
-    expect(interimDecos.iter().value).toBeNull();
-    expect(aiDecos.iter().value).toBeNull();
+    expect(view.state.field(interimWidgetField)).toBe("");
+    expect(view.state.field(pendingAIField).iter().value).toBeNull();
+    expect(view.contentDOM.querySelector(".cm-voice-interim")).toBeNull();
     view.destroy();
   });
 
-  it("correctionEnabled=false suppresses both decorations", () => {
+  it("clearing both interim and pending decorations leaves no DOM artifacts", () => {
     const view = makeView("hello world");
     view.dispatch({
-      effects: [
-        setInterimRange.of({ from: 0, to: 5 }),
-        setPendingAIRanges.of([{ from: 6, to: 11 }]),
-      ],
+      effects: [setInterimText.of("draft"), setPendingAIRanges.of([{ from: 6, to: 11 }])],
     });
 
-    expect(view.state.field(interimMarkField).iter().value).not.toBeNull();
+    expect(view.state.field(interimWidgetField)).toBe("draft");
     expect(view.state.field(pendingAIField).iter().value).not.toBeNull();
 
     view.dispatch({
-      effects: [setInterimRange.of(null), setPendingAIRanges.of([])],
+      effects: [setInterimText.of(""), setPendingAIRanges.of([])],
     });
 
-    expect(view.state.field(interimMarkField).iter().value).toBeNull();
+    expect(view.state.field(interimWidgetField)).toBe("");
     expect(view.state.field(pendingAIField).iter().value).toBeNull();
+    expect(view.contentDOM.querySelector(".cm-voice-interim")).toBeNull();
     view.destroy();
   });
 });

--- a/src/components/Terminal/hooks/useEditorFactory.ts
+++ b/src/components/Terminal/hooks/useEditorFactory.ts
@@ -23,7 +23,7 @@ import {
   createTerminalChipTooltip,
   selectionChipField,
   createSelectionChipTooltip,
-  interimMarkField,
+  interimWidgetField,
   pendingAIField,
   createAutoSize,
   createCustomKeymap,
@@ -148,7 +148,7 @@ export function useEditorFactory({
         selectionChipTooltipCompartmentRef.current.of(
           !disabled ? createSelectionChipTooltip() : []
         ),
-        interimMarkField,
+        interimWidgetField,
         pendingAIField,
         EditorView.updateListener.of((update) => contextUpdateRef.current(update)),
         keymapCompartmentRef.current.of(

--- a/src/components/Terminal/hooks/useVoiceDecorations.ts
+++ b/src/components/Terminal/hooks/useVoiceDecorations.ts
@@ -1,25 +1,18 @@
 import { useEffect } from "react";
 import type { EditorView } from "@codemirror/view";
 import { useVoiceRecordingStore } from "@/store";
-import { setInterimRange, setPendingAIRanges } from "../inputEditorExtensions";
+import { setInterimText, setPendingAIRanges } from "../inputEditorExtensions";
 
 interface UseVoiceDecorationsParams {
   terminalId: string;
   editorViewRef: React.RefObject<EditorView | null>;
-  voiceDraftRevision: number;
 }
 
-export function useVoiceDecorations({
-  terminalId,
-  editorViewRef,
-  voiceDraftRevision,
-}: UseVoiceDecorationsParams) {
+export function useVoiceDecorations({ terminalId, editorViewRef }: UseVoiceDecorationsParams) {
   const transcriptPhase = useVoiceRecordingStore(
     (s) => s.panelBuffers[terminalId]?.transcriptPhase ?? "idle"
   );
-  const liveSegmentStart = useVoiceRecordingStore(
-    (s) => s.panelBuffers[terminalId]?.draftLengthAtSegmentStart ?? -1
-  );
+  const liveText = useVoiceRecordingStore((s) => s.panelBuffers[terminalId]?.liveText ?? "");
   const correctionRange = useVoiceRecordingStore(
     (s) => s.panelBuffers[terminalId]?.correctionRange ?? null
   );
@@ -28,14 +21,9 @@ export function useVoiceDecorations({
     const view = editorViewRef.current;
     if (!view) return;
 
-    const docLen = view.state.doc.length;
-    const interimRange =
-      transcriptPhase === "interim" && liveSegmentStart >= 0 && liveSegmentStart < docLen
-        ? { from: liveSegmentStart, to: docLen }
-        : null;
+    const ghostText = transcriptPhase === "interim" && liveText.length > 0 ? liveText : "";
 
-    // The whole-passage AI cleanup pass marks its range with a dotted underline
-    // (`cm-voice-pending-ai`) so the user sees correction is in flight.
+    const docLen = view.state.doc.length;
     const pendingRanges =
       correctionRange &&
       correctionRange.from >= 0 &&
@@ -45,7 +33,7 @@ export function useVoiceDecorations({
         : [];
 
     view.dispatch({
-      effects: [setInterimRange.of(interimRange), setPendingAIRanges.of(pendingRanges)],
+      effects: [setInterimText.of(ghostText), setPendingAIRanges.of(pendingRanges)],
     });
-  }, [transcriptPhase, voiceDraftRevision, liveSegmentStart, correctionRange, editorViewRef]);
+  }, [transcriptPhase, liveText, correctionRange, editorViewRef]);
 }

--- a/src/components/Terminal/hooks/useVoiceWaitSubmit.ts
+++ b/src/components/Terminal/hooks/useVoiceWaitSubmit.ts
@@ -3,6 +3,7 @@ import { EditorView } from "@codemirror/view";
 import type { Compartment } from "@codemirror/state";
 import { useTerminalInputStore } from "@/store/terminalInputStore";
 import { useVoiceRecordingStore } from "@/store";
+import { useProjectStore } from "@/store/projectStore";
 import { voiceRecordingService } from "@/services/VoiceRecordingService";
 
 interface UseVoiceWaitSubmitParams {
@@ -54,6 +55,24 @@ export function useVoiceWaitSubmit({
         }
 
         if (!useTerminalInputStore.getState().isVoiceSubmitting(terminalId)) return;
+
+        // `stop()` bumps voiceDraftRevision after writing the final transcript
+        // to the input store, but HybridInputBar's sync useEffect doesn't fire
+        // until the next React render — which is AFTER this microtask. Sync
+        // the editor here so sendFromEditor reads the final dictated text and
+        // not the pre-stop doc (#9172).
+        const projectId = useProjectStore.getState().currentProject?.id;
+        const draft = useTerminalInputStore.getState().getDraftInput(terminalId, projectId);
+        const finalView = editorViewRef.current;
+        if (finalView) {
+          const current = finalView.state.doc.toString();
+          if (draft !== current) {
+            finalView.dispatch({
+              changes: { from: 0, to: current.length, insert: draft },
+              selection: { anchor: draft.length },
+            });
+          }
+        }
 
         sendFromEditorRef.current();
       } finally {

--- a/src/components/Terminal/inputEditorExtensions/base.ts
+++ b/src/components/Terminal/inputEditorExtensions/base.ts
@@ -1,4 +1,4 @@
-import { EditorView, Decoration, keymap, placeholder } from "@codemirror/view";
+import { EditorView, Decoration, WidgetType, keymap, placeholder } from "@codemirror/view";
 import type { Extension } from "@codemirror/state";
 import { StateField, StateEffect, Prec } from "@codemirror/state";
 import { insertNewline } from "@codemirror/commands";
@@ -214,32 +214,50 @@ export const chipEntranceTheme: Extension = EditorView.baseTheme({
   ),
 });
 
-const interimMark = Decoration.mark({ class: "cm-voice-interim" });
+class InterimGhostWidget extends WidgetType {
+  constructor(readonly text: string) {
+    super();
+  }
+  eq(other: InterimGhostWidget): boolean {
+    return other.text === this.text;
+  }
+  toDOM(): HTMLElement {
+    const span = document.createElement("span");
+    span.className = "cm-voice-interim";
+    span.textContent = this.text;
+    span.style.userSelect = "none";
+    span.style.pointerEvents = "none";
+    return span;
+  }
+  ignoreEvent(): boolean {
+    return true;
+  }
+}
 
-export const setInterimRange = StateEffect.define<{ from: number; to: number } | null>();
+export const setInterimText = StateEffect.define<string>();
 
-export const interimMarkField = StateField.define({
+export const interimWidgetField = StateField.define<string>({
   create() {
-    return Decoration.none;
+    return "";
   },
   update(value, tr) {
-    if (tr.docChanged) {
-      value = value.map(tr.changes);
-    }
     for (const effect of tr.effects) {
-      if (effect.is(setInterimRange)) {
-        const range = effect.value;
-        if (!range) return Decoration.none;
-        const docLen = tr.state.doc.length;
-        if (range.from >= 0 && range.to <= docLen && range.from < range.to) {
-          return Decoration.set([interimMark.range(range.from, range.to)]);
-        }
-        return Decoration.none;
+      if (effect.is(setInterimText)) {
+        return effect.value;
       }
     }
     return value;
   },
-  provide: (f) => EditorView.decorations.from(f),
+  provide: (f) =>
+    EditorView.decorations.from(f, (text) => (view) => {
+      // Suppress the ghost during IME composition so it can't displace the
+      // composition overlay (mirrors the xterm guard added for #4379).
+      if (!text || view.composing) return Decoration.none;
+      const pos = view.state.doc.length;
+      return Decoration.set([
+        Decoration.widget({ widget: new InterimGhostWidget(text), side: 1 }).range(pos),
+      ]);
+    }),
 });
 
 const pendingAIMark = Decoration.mark({ class: "cm-voice-pending-ai" });

--- a/src/components/Terminal/inputEditorExtensions/index.ts
+++ b/src/components/Terminal/inputEditorExtensions/index.ts
@@ -1,8 +1,8 @@
 export {
   buildInputBarTheme,
   chipEntranceTheme,
-  setInterimRange,
-  interimMarkField,
+  setInterimText,
+  interimWidgetField,
   setPendingAIRanges,
   pendingAIField,
   computeAutoSize,

--- a/src/services/VoiceRecordingService.ts
+++ b/src/services/VoiceRecordingService.ts
@@ -105,7 +105,8 @@ class VoiceRecordingService {
         if (panelId) {
           const buffer = voiceState.panelBuffers[panelId];
           const segmentStart = buffer?.insertPoint ?? -1;
-          if (segmentStart >= 0 || text.trim()) {
+          const finalText = text.trim();
+          if (finalText) {
             const inputStore = useTerminalInputStore.getState();
             const draft = inputStore.getDraftInput(panelId, projectId);
             // Slice back to where this segment started and replace with final transcript.
@@ -113,10 +114,9 @@ class VoiceRecordingService {
             // when nothing has been written — the separator still re-fixes spacing.
             const base = segmentStart >= 0 ? draft.slice(0, segmentStart) : draft;
             const { separator, insertStart } = getVoiceInsertMetadata(base);
-            if ((buffer?.activeParagraphStart ?? -1) < 0 && text.trim()) {
+            if ((buffer?.activeParagraphStart ?? -1) < 0) {
               useVoiceRecordingStore.getState().setActiveParagraphStart(panelId, insertStart);
             }
-            const finalText = text.trim();
             inputStore.setDraftInput(panelId, base + separator + finalText, projectId);
             inputStore.bumpVoiceDraftRevision();
           }

--- a/src/services/VoiceRecordingService.ts
+++ b/src/services/VoiceRecordingService.ts
@@ -81,24 +81,16 @@ class VoiceRecordingService {
               .getDraftInput(target.panelId, target.projectId);
             const { insertStart } = getVoiceInsertMetadata(draft);
             useVoiceRecordingStore.getState().setSessionDraftStart(target.panelId, insertStart);
-            // Snapshot where dictated text actually begins, including any separator
-            // inserted between existing draft text and the first dictated token.
-            useVoiceRecordingStore
-              .getState()
-              .setDraftLengthAtSegmentStart(target.panelId, insertStart);
+            // Snapshot where dictated text will begin once the final commit runs,
+            // including any leading separator inserted between existing draft and
+            // the first dictated token. Stable for the lifetime of the utterance.
+            useVoiceRecordingStore.getState().setInsertPoint(target.panelId, insertStart);
             // Track paragraph start for the first utterance in a new paragraph.
             useVoiceRecordingStore.getState().setActiveParagraphStart(target.panelId, insertStart);
-            // First delta of a new utterance — use appendVoiceText for separator logic.
-            useTerminalInputStore
-              .getState()
-              .appendVoiceText(target.panelId, delta, target.projectId);
-          } else {
-            // Subsequent deltas — append raw to keep length in sync with liveText.
-            const store = useTerminalInputStore.getState();
-            const existing = store.getDraftInput(target.panelId, target.projectId);
-            store.setDraftInput(target.panelId, existing + delta, target.projectId);
-            store.bumpVoiceDraftRevision();
           }
+          // Interim deltas accumulate in liveText only — the ghost-widget
+          // decoration renders them outside the doc model so the editor's
+          // history records a single transaction per utterance (#9172).
         }
         useVoiceRecordingStore.getState().appendDelta(delta);
       })
@@ -112,11 +104,13 @@ class VoiceRecordingService {
         const projectId = voiceState.activeTarget?.projectId;
         if (panelId) {
           const buffer = voiceState.panelBuffers[panelId];
-          const segmentStart = buffer?.draftLengthAtSegmentStart ?? -1;
+          const segmentStart = buffer?.insertPoint ?? -1;
           if (segmentStart >= 0 || text.trim()) {
             const inputStore = useTerminalInputStore.getState();
             const draft = inputStore.getDraftInput(panelId, projectId);
             // Slice back to where this segment started and replace with final transcript.
+            // In the new flow the doc carries no interim text, so the slice is a no-op
+            // when nothing has been written — the separator still re-fixes spacing.
             const base = segmentStart >= 0 ? draft.slice(0, segmentStart) : draft;
             const { separator, insertStart } = getVoiceInsertMetadata(base);
             if ((buffer?.activeParagraphStart ?? -1) < 0 && text.trim()) {
@@ -721,17 +715,24 @@ class VoiceRecordingService {
       }
 
       if (hasSession) {
-        // Flush any remaining delta text (liveText) to the draft store before
-        // finishSession clears it — this handles the case where recording stops
-        // mid-utterance with un-committed delta text in the editor.
+        // Flush any remaining interim text (liveText) into the draft as a final
+        // commit before finishSession clears it. In the ghost-widget flow the
+        // doc carries no interim text, so without this flush a mid-utterance
+        // stop would silently drop the partial transcription.
         if (preserveLiveText) {
           const currentTarget = useVoiceRecordingStore.getState().activeTarget;
           if (currentTarget) {
-            const { panelId } = currentTarget;
+            const { panelId, projectId } = currentTarget;
             const buffer = useVoiceRecordingStore.getState().panelBuffers[panelId];
             const remaining = buffer?.liveText?.trim();
+            const segmentStart = buffer?.insertPoint ?? -1;
             if (remaining) {
-              useTerminalInputStore.getState().bumpVoiceDraftRevision();
+              const inputStore = useTerminalInputStore.getState();
+              const draft = inputStore.getDraftInput(panelId, projectId);
+              const base = segmentStart >= 0 ? draft.slice(0, segmentStart) : draft;
+              const { separator } = getVoiceInsertMetadata(base);
+              inputStore.setDraftInput(panelId, base + separator + remaining, projectId);
+              inputStore.bumpVoiceDraftRevision();
             }
           }
         }

--- a/src/services/__tests__/VoiceRecordingService.adversarial.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.adversarial.test.ts
@@ -20,7 +20,7 @@ interface MockPanelBuffer {
   completedSegments: string[];
   projectId?: string;
   sessionDraftStart: number;
-  draftLengthAtSegmentStart: number;
+  insertPoint: number;
   activeParagraphStart: number;
   transcriptPhase: string;
 }
@@ -46,7 +46,7 @@ function createPanelBuffer(overrides: Partial<MockPanelBuffer> = {}): MockPanelB
     liveText: "",
     completedSegments: [],
     sessionDraftStart: -1,
-    draftLengthAtSegmentStart: -1,
+    insertPoint: -1,
     activeParagraphStart: -1,
     transcriptPhase: "idle",
     ...overrides,
@@ -102,7 +102,7 @@ const runtime = vi.hoisted(() => ({
     setElapsedSeconds: vi.fn<(seconds: number) => void>(),
     appendDelta: vi.fn<(delta: string) => void>(),
     completeSegment: vi.fn<(text: string) => void>(),
-    setDraftLengthAtSegmentStart: vi.fn<(panelId: string, length: number) => void>(),
+    setInsertPoint: vi.fn<(panelId: string, length: number) => void>(),
     setSessionDraftStart: vi.fn<(panelId: string, length: number) => void>(),
     setActiveParagraphStart: vi.fn<(panelId: string, length: number) => void>(),
     resetParagraphState: vi.fn<(panelId: string) => void>(),
@@ -111,7 +111,6 @@ const runtime = vi.hoisted(() => ({
   terminalInputFns: {
     getDraftInput: vi.fn<(panelId: string, projectId?: string) => string>(),
     setDraftInput: vi.fn<(panelId: string, value: string, projectId?: string) => void>(),
-    appendVoiceText: vi.fn<(panelId: string, value: string, projectId?: string) => void>(),
     bumpVoiceDraftRevision: vi.fn<() => void>(),
   },
   statusListeners: new Set<VoiceStatusCallback>(),
@@ -214,11 +213,11 @@ function resetRuntime(): void {
   runtime.voiceFns.setElapsedSeconds.mockImplementation(() => undefined);
   runtime.voiceFns.appendDelta.mockImplementation(() => undefined);
   runtime.voiceFns.completeSegment.mockImplementation(() => undefined);
-  runtime.voiceFns.setDraftLengthAtSegmentStart.mockImplementation((panelId, length) => {
+  runtime.voiceFns.setInsertPoint.mockImplementation((panelId, length) => {
     runtime.voiceState.panelBuffers[panelId] = createPanelBuffer(
       runtime.voiceState.panelBuffers[panelId]
     );
-    runtime.voiceState.panelBuffers[panelId].draftLengthAtSegmentStart = length;
+    runtime.voiceState.panelBuffers[panelId].insertPoint = length;
   });
   runtime.voiceFns.setSessionDraftStart.mockImplementation((panelId, length) => {
     runtime.voiceState.panelBuffers[panelId] = createPanelBuffer(
@@ -247,9 +246,6 @@ function resetRuntime(): void {
   );
   runtime.terminalInputFns.setDraftInput.mockImplementation((panelId, value) => {
     runtime.drafts[panelId] = value;
-  });
-  runtime.terminalInputFns.appendVoiceText.mockImplementation((panelId, value) => {
-    runtime.drafts[panelId] = `${runtime.drafts[panelId] ?? ""}${value}`;
   });
   runtime.terminalInputFns.bumpVoiceDraftRevision.mockImplementation(() => undefined);
 

--- a/src/services/__tests__/VoiceRecordingService.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.test.ts
@@ -24,7 +24,9 @@ vi.mock("@/store/voiceRecordingStore", () => {
     setElapsedSeconds: vi.fn(),
     appendDelta: vi.fn(),
     completeSegment: vi.fn(),
-    setDraftLengthAtSegmentStart: vi.fn(),
+    setInsertPoint: vi.fn(),
+    setSessionDraftStart: vi.fn(),
+    setActiveParagraphStart: vi.fn(),
     clearPanelBuffer: vi.fn(),
   };
   const getState = () => ({ ...state, ...fns });
@@ -50,7 +52,6 @@ vi.mock("@/store/terminalInputStore", () => {
   const fns = {
     getDraftInput: vi.fn(() => ""),
     setDraftInput: vi.fn(),
-    appendVoiceText: vi.fn(),
     bumpVoiceDraftRevision: vi.fn(),
   };
   const getState = () => fns;
@@ -705,5 +706,111 @@ describe("VoiceRecordingService — assistant dictation routing (#8887)", () => 
     expect(useVoiceRecordingStore.getState().setError).toHaveBeenCalledWith(
       expect.stringContaining("Start the Daintree Assistant")
     );
+  });
+});
+
+describe("VoiceRecordingService — interim delta handling (#9172)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    suspendCallbacks.length = 0;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("does not write to the draft store or bump the voice revision on interim deltas", async () => {
+    const { electronStub } = setupGlobals();
+    let deltaCallback: ((delta: string) => void) | null = null;
+    // Cast through unknown because the stub's vi.fn is initialised with a
+    // zero-arg shape; the real handler takes a (delta:string)=>void.
+    (
+      electronStub.voiceInput.onTranscriptionDelta as unknown as {
+        mockImplementation: (impl: (cb: (delta: string) => void) => () => void) => void;
+      }
+    ).mockImplementation((cb) => {
+      deltaCallback = cb;
+      return () => {};
+    });
+
+    const { __state } = (await import("@/store/voiceRecordingStore")) as unknown as {
+      __state: { activeTarget: { panelId: string } | null };
+    };
+    __state.activeTarget = { panelId: "panel-1" };
+
+    const { useTerminalInputStore } = await import("@/store/terminalInputStore");
+    const inputStore = useTerminalInputStore.getState();
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    voiceRecordingService.initialize();
+
+    expect(deltaCallback).not.toBeNull();
+    deltaCallback!("hello");
+    deltaCallback!(" world");
+    deltaCallback!(" again");
+
+    // The interim path must not mutate the draft store — that's the entire fix.
+    expect(inputStore.setDraftInput).not.toHaveBeenCalled();
+    expect(inputStore.bumpVoiceDraftRevision).not.toHaveBeenCalled();
+
+    __state.activeTarget = null;
+  });
+
+  it("commits exactly one draft write per onTranscriptionComplete (one undo step)", async () => {
+    const { electronStub } = setupGlobals();
+    let deltaCallback: ((delta: string) => void) | null = null;
+    let completeCallback: ((payload: { text: string }) => void) | null = null;
+    (
+      electronStub.voiceInput.onTranscriptionDelta as unknown as {
+        mockImplementation: (impl: (cb: (delta: string) => void) => () => void) => void;
+      }
+    ).mockImplementation((cb) => {
+      deltaCallback = cb;
+      return () => {};
+    });
+    (
+      electronStub.voiceInput.onTranscriptionComplete as unknown as {
+        mockImplementation: (impl: (cb: (payload: { text: string }) => void) => () => void) => void;
+      }
+    ).mockImplementation((cb) => {
+      completeCallback = cb;
+      return () => {};
+    });
+
+    const voiceModule = (await import("@/store/voiceRecordingStore")) as unknown as {
+      __state: {
+        activeTarget: { panelId: string } | null;
+        panelBuffers: Record<string, { insertPoint: number }>;
+      };
+    };
+    voiceModule.__state.activeTarget = { panelId: "panel-1" };
+
+    const { useTerminalInputStore } = await import("@/store/terminalInputStore");
+    const inputStore = useTerminalInputStore.getState();
+    (inputStore.getDraftInput as ReturnType<typeof vi.fn>).mockReturnValue("existing");
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    voiceRecordingService.initialize();
+
+    // Five interim deltas — none should commit to the draft.
+    deltaCallback!("hel");
+    deltaCallback!("lo");
+    deltaCallback!(" wor");
+    deltaCallback!("ld");
+    deltaCallback!("!");
+
+    // Simulate insertPoint being captured by the first delta. The test stub
+    // for setInsertPoint is a no-op, so seed the buffer manually.
+    voiceModule.__state.panelBuffers["panel-1"] = { insertPoint: 8 };
+
+    // Single completion event — exactly one write, one revision bump.
+    completeCallback!({ text: "hello world!" });
+
+    expect(inputStore.setDraftInput).toHaveBeenCalledTimes(1);
+    expect(inputStore.bumpVoiceDraftRevision).toHaveBeenCalledTimes(1);
+
+    voiceModule.__state.activeTarget = null;
+    voiceModule.__state.panelBuffers = {};
   });
 });

--- a/src/services/__tests__/VoiceRecordingService.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.test.ts
@@ -813,4 +813,46 @@ describe("VoiceRecordingService — interim delta handling (#9172)", () => {
     voiceModule.__state.activeTarget = null;
     voiceModule.__state.panelBuffers = {};
   });
+
+  it("does not write a separator-only draft on a silent (empty) onTranscriptionComplete", async () => {
+    const { electronStub } = setupGlobals();
+    let completeCallback: ((payload: { text: string }) => void) | null = null;
+    (
+      electronStub.voiceInput.onTranscriptionComplete as unknown as {
+        mockImplementation: (impl: (cb: (payload: { text: string }) => void) => () => void) => void;
+      }
+    ).mockImplementation((cb) => {
+      completeCallback = cb;
+      return () => {};
+    });
+
+    const voiceModule = (await import("@/store/voiceRecordingStore")) as unknown as {
+      __state: {
+        activeTarget: { panelId: string } | null;
+        panelBuffers: Record<string, { insertPoint: number }>;
+      };
+    };
+    voiceModule.__state.activeTarget = { panelId: "panel-1" };
+    voiceModule.__state.panelBuffers["panel-1"] = { insertPoint: 5 };
+
+    const { useTerminalInputStore } = await import("@/store/terminalInputStore");
+    const inputStore = useTerminalInputStore.getState();
+    (inputStore.getDraftInput as ReturnType<typeof vi.fn>).mockReturnValue("hello");
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    voiceRecordingService.initialize();
+
+    // Defeat any cross-test fn-instance reuse (Vitest may keep top-level
+    // mock factory closures across re-imports).
+    (inputStore.setDraftInput as ReturnType<typeof vi.fn>).mockClear();
+    (inputStore.bumpVoiceDraftRevision as ReturnType<typeof vi.fn>).mockClear();
+
+    completeCallback!({ text: "   " });
+
+    expect(inputStore.setDraftInput).not.toHaveBeenCalled();
+    expect(inputStore.bumpVoiceDraftRevision).not.toHaveBeenCalled();
+
+    voiceModule.__state.activeTarget = null;
+    voiceModule.__state.panelBuffers = {};
+  });
 });

--- a/src/store/__tests__/voiceRecordingStore.test.ts
+++ b/src/store/__tests__/voiceRecordingStore.test.ts
@@ -104,18 +104,14 @@ describe("voiceRecordingStore — transcript phase transitions", () => {
     expect(buffer?.transcriptPhase).toBe("idle");
   });
 
-  it("resetParagraphState resets draftLengthAtSegmentStart to -1", () => {
+  it("resetParagraphState resets insertPoint to -1", () => {
     useVoiceRecordingStore.getState().beginSession(TARGET);
-    useVoiceRecordingStore.getState().setDraftLengthAtSegmentStart(PANEL_ID, 42);
-    expect(
-      useVoiceRecordingStore.getState().panelBuffers[PANEL_ID]?.draftLengthAtSegmentStart
-    ).toBe(42);
+    useVoiceRecordingStore.getState().setInsertPoint(PANEL_ID, 42);
+    expect(useVoiceRecordingStore.getState().panelBuffers[PANEL_ID]?.insertPoint).toBe(42);
 
     useVoiceRecordingStore.getState().resetParagraphState(PANEL_ID);
 
-    expect(
-      useVoiceRecordingStore.getState().panelBuffers[PANEL_ID]?.draftLengthAtSegmentStart
-    ).toBe(-1);
+    expect(useVoiceRecordingStore.getState().panelBuffers[PANEL_ID]?.insertPoint).toBe(-1);
   });
 
   it("resetParagraphState resets liveText to empty string", () => {
@@ -128,15 +124,13 @@ describe("voiceRecordingStore — transcript phase transitions", () => {
     expect(useVoiceRecordingStore.getState().panelBuffers[PANEL_ID]?.liveText).toBe("");
   });
 
-  it("after resetParagraphState, setDraftLengthAtSegmentStart can set a new anchor", () => {
+  it("after resetParagraphState, setInsertPoint can set a new anchor", () => {
     useVoiceRecordingStore.getState().beginSession(TARGET);
-    useVoiceRecordingStore.getState().setDraftLengthAtSegmentStart(PANEL_ID, 20);
+    useVoiceRecordingStore.getState().setInsertPoint(PANEL_ID, 20);
     useVoiceRecordingStore.getState().resetParagraphState(PANEL_ID);
-    useVoiceRecordingStore.getState().setDraftLengthAtSegmentStart(PANEL_ID, 21);
+    useVoiceRecordingStore.getState().setInsertPoint(PANEL_ID, 21);
 
-    expect(
-      useVoiceRecordingStore.getState().panelBuffers[PANEL_ID]?.draftLengthAtSegmentStart
-    ).toBe(21);
+    expect(useVoiceRecordingStore.getState().panelBuffers[PANEL_ID]?.insertPoint).toBe(21);
   });
 
   it("finishSession resets transcriptPhase to idle regardless of prior phase", () => {

--- a/src/store/terminalInputStore.ts
+++ b/src/store/terminalInputStore.ts
@@ -103,7 +103,6 @@ export interface TerminalInputState {
   setHybridInputAutoFocus: (enabled: boolean) => void;
   getDraftInput: (terminalId: string, projectId?: string) => string;
   setDraftInput: (terminalId: string, value: string, projectId?: string) => void;
-  appendVoiceText: (terminalId: string, text: string, projectId?: string) => void;
   bumpVoiceDraftRevision: () => void;
   clearDraftInput: (terminalId: string, projectId?: string) => void;
   clearAllDraftInputs: () => void;
@@ -199,16 +198,6 @@ export const useTerminalInputStore = create<TerminalInputState>()((set, get) => 
       newDraftInputs.delete(key);
       return { draftInputs: newDraftInputs };
     }),
-  appendVoiceText: (terminalId, text, projectId) =>
-    set((state) => {
-      const key = makeDraftKey(terminalId, projectId);
-      const newDraftInputs = new Map(state.draftInputs);
-      const existing = newDraftInputs.get(key) ?? "";
-      const separator = existing && !existing.endsWith(" ") ? " " : "";
-      newDraftInputs.set(key, existing + separator + text);
-      return { draftInputs: newDraftInputs, voiceDraftRevision: state.voiceDraftRevision + 1 };
-    }),
-
   bumpVoiceDraftRevision: () =>
     set((state) => ({ voiceDraftRevision: state.voiceDraftRevision + 1 })),
 

--- a/src/store/voiceRecordingStore.ts
+++ b/src/store/voiceRecordingStore.ts
@@ -16,8 +16,8 @@ interface VoiceTranscriptBuffer {
   projectId?: string;
   /** Draft length snapshot taken before the first delta of the session. */
   sessionDraftStart: number;
-  /** Draft length snapshot taken before the first delta of a segment. */
-  draftLengthAtSegmentStart: number;
+  /** CodeMirror position where the next utterance's final text will be inserted. */
+  insertPoint: number;
   /** Draft length at the start of the current paragraph (-1 = not set). */
   activeParagraphStart: number;
   /** Explicit transcript lifecycle phase — derived from and updated alongside buffer state. */
@@ -59,7 +59,7 @@ interface VoiceRecordingState {
   setElapsedSeconds: (seconds: number) => void;
   appendDelta: (delta: string) => void;
   setSessionDraftStart: (panelId: string, length: number) => void;
-  setDraftLengthAtSegmentStart: (panelId: string, length: number) => void;
+  setInsertPoint: (panelId: string, length: number) => void;
   completeSegment: (text: string) => void;
   setCorrectionRange: (panelId: string, range: { from: number; to: number } | null) => void;
   setActiveParagraphStart: (panelId: string, length: number) => void;
@@ -80,7 +80,7 @@ function getBuffer(
       liveText: "",
       completedSegments: [],
       sessionDraftStart: -1,
-      draftLengthAtSegmentStart: -1,
+      insertPoint: -1,
       activeParagraphStart: -1,
       transcriptPhase: "idle" as VoiceTranscriptPhase,
       correctionRange: null,
@@ -119,7 +119,7 @@ export const useVoiceRecordingStore = create<VoiceRecordingState>()((set, get) =
           completedSegments: [],
           projectId: target.projectId,
           sessionDraftStart: -1,
-          draftLengthAtSegmentStart: -1,
+          insertPoint: -1,
           activeParagraphStart: -1,
           transcriptPhase: "idle" as VoiceTranscriptPhase,
           correctionRange: null,
@@ -162,14 +162,14 @@ export const useVoiceRecordingStore = create<VoiceRecordingState>()((set, get) =
       };
     }),
 
-  setDraftLengthAtSegmentStart: (panelId, length) =>
+  setInsertPoint: (panelId, length) =>
     set((state) => {
       const buffer = getBuffer(state.panelBuffers, panelId);
-      if (buffer.draftLengthAtSegmentStart >= 0) return state;
+      if (buffer.insertPoint >= 0) return state;
       return {
         panelBuffers: {
           ...state.panelBuffers,
-          [panelId]: { ...buffer, draftLengthAtSegmentStart: length },
+          [panelId]: { ...buffer, insertPoint: length },
         },
       };
     }),
@@ -188,7 +188,7 @@ export const useVoiceRecordingStore = create<VoiceRecordingState>()((set, get) =
             [panelId]: {
               ...buffer,
               liveText: "",
-              draftLengthAtSegmentStart: -1,
+              insertPoint: -1,
               transcriptPhase: "idle" as VoiceTranscriptPhase,
             },
           },
@@ -201,7 +201,7 @@ export const useVoiceRecordingStore = create<VoiceRecordingState>()((set, get) =
           [panelId]: {
             ...buffer,
             liveText: "",
-            draftLengthAtSegmentStart: -1,
+            insertPoint: -1,
             completedSegments: [...buffer.completedSegments, normalized],
             transcriptPhase: "utterance_final" as VoiceTranscriptPhase,
           },
@@ -243,7 +243,7 @@ export const useVoiceRecordingStore = create<VoiceRecordingState>()((set, get) =
             ...buffer,
             liveText: "",
             completedSegments: [],
-            draftLengthAtSegmentStart: -1,
+            insertPoint: -1,
             activeParagraphStart: -1,
             transcriptPhase: "idle" as VoiceTranscriptPhase,
           },


### PR DESCRIPTION
## Summary

- Interim transcription text was being written to the editor document on every delta — 30–50 `doc.replace` transactions per utterance, all landing in undo history and causing visible doc churn.
- Fix renders interim text as a `WidgetDecoration` (DOM node outside the document model) so the document stays untouched during dictation. A single write fires on `onTranscriptionComplete`, one transaction per utterance.
- `useVoiceWaitSubmit` now syncs the draft from the input store back to the editor synchronously after `stop()` resolves, closing a React-render-lag race that could drop the final transcript before `sendFromEditor` runs.

Resolves #9172

## Changes

- `src/components/Terminal/inputEditorExtensions/base.ts` — replaced `interimMarkField`/`setInterimRange` with `InterimGhostWidget` + `interimWidgetField` + `setInterimText`; widget is suppressed when `view.composing === true` (IME guard)
- `src/services/VoiceRecordingService.ts` — stripped interim `setDraftInput`/`appendVoiceText`/`bumpVoiceDraftRevision` from `onTranscriptionDelta`; `onTranscriptionComplete` writes once and skips on empty transcript; `stop()`-time flush performs a real slice-back-and-replace
- `src/components/Terminal/hooks/useVoiceDecorations.ts` — dispatches `setInterimText` + `setPendingAIRanges` in one transaction; `voiceDraftRevision` dependency removed
- `src/components/Terminal/hooks/useVoiceWaitSubmit.ts` — reads draft from input store and dispatches to editor before `sendFromEditor` runs
- `src/store/voiceRecordingStore.ts` — renamed `draftLengthAtSegmentStart` to `insertPoint`
- `src/store/terminalInputStore.ts` — removed unused `appendVoiceText`

## Testing

- 3 new tests in `VoiceRecordingService.test.ts`: no doc mutation on interim deltas, single write per completion, no write on silent utterance
- `inputEditorExtensions.test.tsx` updated: widget DOM presence, no-doc-mutation, IME composition suppression
- `voiceRecordingStore.test.ts` and `VoiceRecordingService.adversarial.test.ts` updated for renames
- 160 unit tests pass; `tsc --noEmit` clean; lint baseline improved by 2 warnings