### PR TITLE
feat(worktree): surface dev-server state on the dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,6 +67,7 @@ import {
   useThemeBrowserSettingsBridge,
   useErrorRetry,
   useActiveWorktreeSync,
+  useWorktreeDevServerStateSync,
 } from "./hooks/app";
 import { useResourceProfile } from "./hooks/useResourceProfile";
 import { AppLayout } from "./components/Layout";
@@ -335,6 +336,7 @@ function AppInner() {
   useUnloadCleanup();
   useResourceProfile();
   useRecipeFocusReload();
+  useWorktreeDevServerStateSync();
 
   useEffect(() => {
     window.__DAINTREE_E2E_ERROR_STORE__ = () =>

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -52,6 +52,7 @@ import { useFleetArmingStore, collectFilterArmEligibleIds } from "@/store/fleetA
 import { useShallow } from "zustand/react/shallow";
 import { systemClient } from "@/clients";
 import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
+import { useWorktreeDevServerStore } from "@/store/worktreeDevServerStore";
 import {
   matchesFilters,
   matchesQuickStateFilter,
@@ -506,6 +507,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     prIssueFilters,
     sessionFilters,
     activityFilters,
+    devServerFilters,
     alwaysShowActive,
     alwaysShowWaiting,
     pinnedWorktrees,
@@ -521,6 +523,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       prIssueFilters: state.prIssueFilters,
       sessionFilters: state.sessionFilters,
       activityFilters: state.activityFilters,
+      devServerFilters: state.devServerFilters,
       alwaysShowActive: state.alwaysShowActive,
       alwaysShowWaiting: state.alwaysShowWaiting,
       pinnedWorktrees: state.pinnedWorktrees,
@@ -528,6 +531,8 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       quickStateFilter: state.quickStateFilter,
     }))
   );
+
+  const devServerSessions = useWorktreeDevServerStore((s) => s.sessionsByWorktreeId);
 
   const isSortDisabledPrevRef = useRef(isGroupedByType || query.trim().length > 0);
   useEffect(() => {
@@ -560,7 +565,8 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     typeFilters.size +
     prIssueFilters.size +
     sessionFilters.size +
-    activityFilters.size;
+    activityFilters.size +
+    devServerFilters.size;
   const collapsedWorktrees = useWorktreeFilterStore((state) => state.collapsedWorktrees);
   const pruneStaleWorktreeIds = useWorktreeFilterStore((state) => state.pruneStaleWorktreeIds);
   const setQuickStateFilter = useWorktreeFilterStore((state) => state.setQuickStateFilter);
@@ -768,14 +774,21 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     const nonMain = deferredWorktrees.filter(
       (w) => w.id !== mainWorktree?.id && w.id !== integrationWorktree?.id
     );
-    return computeChipCounts(nonMain, derivedMetaMap, activeWorktreeId, {
-      query,
-      statusFilters,
-      typeFilters,
-      prIssueFilters,
-      sessionFilters,
-      activityFilters,
-    });
+    return computeChipCounts(
+      nonMain,
+      derivedMetaMap,
+      activeWorktreeId,
+      {
+        query,
+        statusFilters,
+        typeFilters,
+        prIssueFilters,
+        sessionFilters,
+        activityFilters,
+        devServerFilters,
+      },
+      devServerSessions
+    );
   }, [
     deferredWorktrees,
     derivedMetaMap,
@@ -788,6 +801,8 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     prIssueFilters,
     sessionFilters,
     activityFilters,
+    devServerFilters,
+    devServerSessions,
   ]);
 
   const mainWorktreeAggregateCounts = useMemo(() => {
@@ -817,6 +832,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         prIssueFilters,
         sessionFilters,
         activityFilters,
+        devServerFilters,
       };
 
       // Filter non-main worktrees only (exclude main and integration by ID)
@@ -852,7 +868,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
             !hasFacetFiltersActive
           ) {
             withoutQuickStateMatch = true;
-          } else if (matchesFilters(worktree, filters, derived, isActive)) {
+          } else if (matchesFilters(worktree, filters, derived, isActive, devServerSessions)) {
             withoutQuickStateMatch = true;
           }
         }
@@ -881,7 +897,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
           return false;
         }
 
-        return matchesFilters(worktree, filters, derived, isActive);
+        return matchesFilters(worktree, filters, derived, isActive, devServerSessions);
       });
 
       const existingWorktreeIds = new Set(deferredWorktrees.map((w) => w.id));
@@ -917,6 +933,8 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       prIssueFilters,
       sessionFilters,
       activityFilters,
+      devServerFilters,
+      devServerSessions,
       alwaysShowActive,
       alwaysShowWaiting,
       pinnedWorktrees,
@@ -1013,6 +1031,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     prIssueFilters,
     sessionFilters,
     activityFilters,
+    devServerFilters,
   };
 
   const mainMatchesQueryPre = mainWorktree && worktreeMatchesQueryPre(mainWorktree);
@@ -1031,7 +1050,8 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
           hasMergeConflict: false,
           chipState: null,
         },
-        mainWorktree.id === activeWorktreeId
+        mainWorktree.id === activeWorktreeId,
+        devServerSessions
       ));
   const mainVisible = mainMatchesQueryPre && mainMatchesFacetsPre;
 
@@ -1052,7 +1072,8 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
           hasMergeConflict: false,
           chipState: null,
         },
-        integrationWorktree.id === activeWorktreeId
+        integrationWorktree.id === activeWorktreeId,
+        devServerSessions
       ));
   const integrationVisible = integrationMatchesQueryPre && integrationMatchesFacetsPre;
 

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -59,7 +59,7 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
         /alwaysShowWaiting[\s\S]*?derived\.hasWaitingAgent[\s\S]*?!hasActiveQuery/
       );
       expect(source).toMatch(
-        /else if \(matchesFilters\(worktree, filters, derived, isActive\)\) \{\s*withoutQuickStateMatch = true;/
+        /else if \(matchesFilters\(worktree, filters, derived, isActive, devServerSessions\)\) \{\s*withoutQuickStateMatch = true;/
       );
     });
   });
@@ -127,13 +127,13 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       expect(branch).toContain('variant="filtered-empty"');
     });
 
-    it("derives the active facet filter count from the five facet Set sizes — issue #7971", () => {
+    it("derives the active facet filter count from the six facet Set sizes — issues #7971, #9087", () => {
       // The combined-axis title needs the actual number of facet filters
-      // selected. Sum the five facet axes (status, type, github, session,
-      // activity) — the same axes hasFacetFilters() reads. Do not include
-      // query or quickStateFilter, which are named separately in the title.
+      // selected. Sum the six facet axes (status, type, github, session,
+      // activity, dev server) — the same axes hasFacetFilters() reads. Do not
+      // include query or quickStateFilter, which are named separately in the title.
       expect(source).toMatch(
-        /const activeFacetFilterCount =\s*statusFilters\.size \+\s*typeFilters\.size \+\s*prIssueFilters\.size \+\s*sessionFilters\.size \+\s*activityFilters\.size;/
+        /const activeFacetFilterCount =\s*statusFilters\.size \+\s*typeFilters\.size \+\s*prIssueFilters\.size \+\s*sessionFilters\.size \+\s*activityFilters\.size \+\s*devServerFilters\.size;/
       );
     });
 

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -52,6 +52,7 @@ import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/component
 import { CONTEXT_COMPONENTS, WorktreeMenuItems } from "./WorktreeMenuItems";
 import { isAgentFleetActionEligible, isFleetArmEligible } from "@/store/fleetArmingStore";
 import { useWorktreeStatus } from "./WorktreeCard/hooks/useWorktreeStatus";
+import { useWorktreeDevServerSession } from "@/hooks/app/useWorktreeDevServerSession";
 import { computeChipState } from "./utils/computeChipState";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 
@@ -210,6 +211,8 @@ export function WorktreeCard({
     terminals: worktreeTerminals,
     dominantAgentState,
   } = useWorktreeTerminals(worktree.id);
+
+  const devServerSession = useWorktreeDevServerSession(worktree.id);
 
   // Border accent flash — fires once when the dominant *execution* state for
   // this card meaningfully changes. `directing` is excluded because it's
@@ -877,6 +880,7 @@ export function WorktreeCard({
                 resourceLastOutput={worktree.resourceStatus?.lastOutput}
                 resourceEndpoint={worktree.resourceStatus?.endpoint}
                 resourceLastCheckedAt={worktree.resourceStatus?.lastCheckedAt}
+                devServerSession={devServerSession}
                 lastGitStatusCheckedAt={worktree.lastGitStatusCheckedAt}
                 onRevalidateGitStatus={handleRevalidate}
                 onCheckResourceStatus={hasStatusCommand ? handleResourceStatus : undefined}

--- a/src/components/Worktree/WorktreeCard/DevServerIndicator.tsx
+++ b/src/components/Worktree/WorktreeCard/DevServerIndicator.tsx
@@ -1,0 +1,95 @@
+import { useMemo } from "react";
+import { Globe, Loader2, CircleAlert } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useDohertyGate } from "@/hooks/useDeferredLoading";
+import type { DevPreviewSessionState } from "@shared/types/ipc/devPreview";
+
+interface DevServerIndicatorProps {
+  session: DevPreviewSessionState | undefined;
+}
+
+function extractPort(url: string | null | undefined): string | null {
+  if (!url) return null;
+  try {
+    return new URL(url).port || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Secondary per-row dev-server signal in the worktree header's trailing icon
+ * group. Renders nothing for `stopped`/`restored-stopped`/`stopping` (no live
+ * server) — only `starting`/`installing`/`running`/`error` surface, mirroring
+ * `isLiveDevServerStatus`. Deliberately ambient: a bare icon + tooltip, no row
+ * tint, no banner, no accent color — the agent indicator stays the row's anchor.
+ */
+export function DevServerIndicator({ session }: DevServerIndicatorProps) {
+  const status = session?.status;
+  const isStartup = status === "starting" || status === "installing";
+  // Doherty gate: a sub-400ms start should never flash a spinner.
+  const showStartupSpinner = useDohertyGate(isStartup);
+  const port = useMemo(() => extractPort(session?.url), [session?.url]);
+
+  if (!session || !status) return null;
+
+  if (status === "running") {
+    const { url } = session;
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            data-testid="dev-server-indicator"
+            data-dev-server-status="running"
+            aria-label={url ? `Dev server running at ${url}` : "Dev server running"}
+            className="inline-flex items-center gap-1 text-xs text-text-muted shrink-0"
+          >
+            <Globe className="w-3 h-3 shrink-0 text-status-success" aria-hidden="true" />
+            {port && <span className="tabular-nums">:{port}</span>}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top">{url ?? "Dev server running"}</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            data-testid="dev-server-indicator"
+            data-dev-server-status="error"
+            aria-label="Dev server error"
+            className="inline-flex items-center text-status-error shrink-0"
+          >
+            <CircleAlert className="w-3 h-3 shrink-0" aria-hidden="true" />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top">{session.error?.message ?? "Dev server error"}</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  if (isStartup) {
+    if (!showStartupSpinner) return null;
+    const label = status === "installing" ? "Installing dependencies" : "Starting dev server";
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            data-testid="dev-server-indicator"
+            data-dev-server-status={status}
+            aria-label={label}
+            className="inline-flex items-center text-text-muted shrink-0"
+          >
+            <Loader2 className="w-3 h-3 shrink-0 animate-spin" aria-hidden="true" />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top">{label}</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return null;
+}

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -10,8 +10,11 @@ import type { AggregateCounts } from "./MainWorktreeSummaryRows";
 import { IssueBadge } from "./IssueBadge";
 import { PRBadge } from "./PRBadge";
 import { EnvironmentPopover } from "./EnvironmentPopover";
+import { DevServerIndicator } from "./DevServerIndicator";
 import { CollapsedSessionIndicators } from "./CollapsedSessionIndicators";
 import { CollapsedAlarmPill } from "./CollapsedAlarmPill";
+import { isLiveDevServerStatus } from "@/lib/worktreeFilters";
+import type { DevPreviewSessionState } from "@shared/types/ipc/devPreview";
 import { WorktreeActionsToolbar } from "./WorktreeActionsToolbar";
 import { MainWorktreeSecondaryRow } from "./MainWorktreeSecondaryRow";
 import { NonMainSecondaryRow } from "./NonMainSecondaryRow";
@@ -44,6 +47,7 @@ export interface WorktreeHeaderProps {
   resourceLastOutput?: string;
   resourceEndpoint?: string;
   resourceLastCheckedAt?: number;
+  devServerSession?: DevPreviewSessionState;
   lastGitStatusCheckedAt?: number;
   onRevalidateGitStatus?: () => void;
   onCheckResourceStatus?: () => void;
@@ -235,6 +239,7 @@ export function WorktreeHeader({
   resourceLastOutput,
   resourceEndpoint,
   resourceLastCheckedAt,
+  devServerSession,
   lastGitStatusCheckedAt,
   onRevalidateGitStatus,
   onCheckResourceStatus,
@@ -271,6 +276,7 @@ export function WorktreeHeader({
     : !!(worktree.issueNumber && displayTitle);
   const hasPlanFile = Boolean(worktree.hasPlanFile);
   const hasFreshnessPill = !!(lastGitStatusCheckedAt && lastGitStatusCheckedAt > 0);
+  const hasDevServerSignal = !!devServerSession && isLiveDevServerStatus(devServerSession.status);
   const underlineOnHover = variant !== "sidebar" || isActive;
   const hasUpstreamDelta =
     (worktree.aheadCount !== undefined && worktree.aheadCount > 0) ||
@@ -392,6 +398,7 @@ export function WorktreeHeader({
           (worktree.worktreeMode && worktree.worktreeMode !== "local") ||
           resourceStatusLabel ||
           isLifecycleRunning ||
+          hasDevServerSignal ||
           hasFreshnessPill) && (
           <div className="flex items-center gap-2 shrink-0">
             {isPinned && !isMainWorktree && (
@@ -426,6 +433,7 @@ export function WorktreeHeader({
                 className="w-3.5 h-3.5 text-daintree-text/40"
               />
             )}
+            <DevServerIndicator session={devServerSession} />
           </div>
         )}
 

--- a/src/components/Worktree/WorktreeCard/__tests__/DevServerIndicator.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/DevServerIndicator.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, act, cleanup } from "@testing-library/react";
+import { DevServerIndicator } from "../DevServerIndicator";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { DevPreviewSessionState, DevPreviewSessionStatus } from "@shared/types/ipc/devPreview";
+
+function makeSession(
+  status: DevPreviewSessionStatus,
+  overrides: Partial<DevPreviewSessionState> = {}
+): DevPreviewSessionState {
+  return {
+    panelId: "p1",
+    projectId: "proj",
+    worktreeId: "w1",
+    status,
+    url: null,
+    predictedUrl: null,
+    error: null,
+    terminalId: null,
+    isRestarting: false,
+    generation: 0,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+function renderIndicator(session: DevPreviewSessionState | undefined) {
+  return render(
+    <TooltipProvider>
+      <DevServerIndicator session={session} />
+    </TooltipProvider>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("DevServerIndicator", () => {
+  it("renders nothing when there is no session", () => {
+    renderIndicator(undefined);
+    expect(screen.queryByTestId("dev-server-indicator")).toBeNull();
+  });
+
+  it.each<DevPreviewSessionStatus>(["stopped", "restored-stopped", "stopping"])(
+    "renders nothing for %s",
+    (status) => {
+      renderIndicator(makeSession(status));
+      expect(screen.queryByTestId("dev-server-indicator")).toBeNull();
+    }
+  );
+
+  it("renders a running indicator with the port and a URL aria-label", () => {
+    renderIndicator(makeSession("running", { url: "http://localhost:5173" }));
+    const el = screen.getByTestId("dev-server-indicator");
+    expect(el.getAttribute("data-dev-server-status")).toBe("running");
+    expect(el.textContent).toContain(":5173");
+    expect(el.getAttribute("aria-label")).toBe("Dev server running at http://localhost:5173");
+  });
+
+  it("renders a running indicator without port text when the URL has no port", () => {
+    renderIndicator(makeSession("running", { url: "http://localhost" }));
+    const el = screen.getByTestId("dev-server-indicator");
+    expect(el.getAttribute("data-dev-server-status")).toBe("running");
+    expect(el.textContent).not.toContain(":");
+  });
+
+  it("renders an error indicator", () => {
+    renderIndicator(makeSession("error", { error: { type: "unknown", message: "boom" } }));
+    const el = screen.getByTestId("dev-server-indicator");
+    expect(el.getAttribute("data-dev-server-status")).toBe("error");
+    expect(el.getAttribute("aria-label")).toBe("Dev server error");
+  });
+
+  it("defers the starting spinner until the Doherty threshold elapses", () => {
+    vi.useFakeTimers();
+    renderIndicator(makeSession("starting"));
+    // Sub-400ms: nothing shown (no flicker).
+    expect(screen.queryByTestId("dev-server-indicator")).toBeNull();
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    const el = screen.getByTestId("dev-server-indicator");
+    expect(el.getAttribute("data-dev-server-status")).toBe("starting");
+  });
+
+  it("shows the installing spinner after the gate", () => {
+    vi.useFakeTimers();
+    renderIndicator(makeSession("installing"));
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    const el = screen.getByTestId("dev-server-indicator");
+    expect(el.getAttribute("data-dev-server-status")).toBe("installing");
+    expect(el.getAttribute("aria-label")).toBe("Installing dependencies");
+  });
+});

--- a/src/components/Worktree/WorktreeFilterPopover.tsx
+++ b/src/components/Worktree/WorktreeFilterPopover.tsx
@@ -12,6 +12,7 @@ import {
   type PrIssueFilter,
   type SessionFilter,
   type ActivityFilter,
+  type DevServerFilter,
 } from "@/store/worktreeFilterStore";
 import type { ChipCounts } from "@/lib/worktreeFilters";
 
@@ -125,6 +126,13 @@ const ACTIVITY_OPTIONS: { value: ActivityFilter; label: string }[] = [
   { value: "last7d", label: "7d" },
 ];
 
+const DEV_SERVER_OPTIONS: { value: DevServerFilter; label: string }[] = [
+  { value: "hasDevServer", label: "Has server" },
+  { value: "running", label: "Running" },
+  { value: "starting", label: "Starting" },
+  { value: "error", label: "Error" },
+];
+
 const ORDER_OPTIONS: { value: OrderBy; label: string }[] = [
   { value: "created", label: "Date created" },
   { value: "recent", label: "Recently updated" },
@@ -160,6 +168,7 @@ export function WorktreeFilterPopover({
     prIssueFilters,
     sessionFilters,
     activityFilters,
+    devServerFilters,
     setQuery,
     setOrderBy,
     setGroupByType,
@@ -168,6 +177,7 @@ export function WorktreeFilterPopover({
     togglePrIssueFilter,
     toggleSessionFilter,
     toggleActivityFilter,
+    toggleDevServerFilter,
     clearAll,
     getActiveFilterCount,
     hasActiveFilters,
@@ -181,6 +191,7 @@ export function WorktreeFilterPopover({
       prIssueFilters: state.prIssueFilters,
       sessionFilters: state.sessionFilters,
       activityFilters: state.activityFilters,
+      devServerFilters: state.devServerFilters,
       setQuery: state.setQuery,
       setOrderBy: state.setOrderBy,
       setGroupByType: state.setGroupByType,
@@ -189,6 +200,7 @@ export function WorktreeFilterPopover({
       togglePrIssueFilter: state.togglePrIssueFilter,
       toggleSessionFilter: state.toggleSessionFilter,
       toggleActivityFilter: state.toggleActivityFilter,
+      toggleDevServerFilter: state.toggleDevServerFilter,
       clearAll: state.clearAll,
       getActiveFilterCount: state.getActiveFilterCount,
       hasActiveFilters: state.hasActiveFilters,
@@ -418,6 +430,20 @@ export function WorktreeFilterPopover({
                   isActive={activityFilters.has(option.value)}
                   onClick={() => toggleActivityFilter(option.value)}
                   count={chipCounts?.activity[option.value]}
+                />
+              ))}
+            </div>
+          </FilterSection>
+
+          <FilterSection title="Dev server" defaultOpen={devServerFilters.size > 0}>
+            <div className="flex flex-wrap gap-1.5">
+              {DEV_SERVER_OPTIONS.map((option) => (
+                <FilterChip
+                  key={option.value}
+                  label={option.label}
+                  isActive={devServerFilters.has(option.value)}
+                  onClick={() => toggleDevServerFilter(option.value)}
+                  count={chipCounts?.devServer[option.value]}
                 />
               ))}
             </div>

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -15,6 +15,7 @@ import {
 import type { WorktreeState, WorktreeSnapshot } from "@/types";
 import type { UseAgentLauncherReturn } from "@/hooks/useAgentLauncher";
 import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
+import { useWorktreeDevServerStore } from "@/store/worktreeDevServerStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { AccessibilityAnnouncer } from "@/components/Accessibility/AccessibilityAnnouncer";
 import { usePanelStore } from "@/store/panelStore";
@@ -225,6 +226,7 @@ export function WorktreeOverviewModal({
     prIssueFilters,
     sessionFilters,
     activityFilters,
+    devServerFilters,
     alwaysShowActive,
     alwaysShowWaiting,
     pinnedWorktrees,
@@ -240,6 +242,7 @@ export function WorktreeOverviewModal({
       prIssueFilters: state.prIssueFilters,
       sessionFilters: state.sessionFilters,
       activityFilters: state.activityFilters,
+      devServerFilters: state.devServerFilters,
       alwaysShowActive: state.alwaysShowActive,
       alwaysShowWaiting: state.alwaysShowWaiting,
       pinnedWorktrees: state.pinnedWorktrees,
@@ -247,6 +250,7 @@ export function WorktreeOverviewModal({
       quickStateFilter: state.quickStateFilter,
     }))
   );
+  const devServerSessions = useWorktreeDevServerStore((s) => s.sessionsByWorktreeId);
   const clearAllFilters = useWorktreeFilterStore((state) => state.clearAll);
   const hasActiveFilters = useWorktreeFilterStore((state) => state.hasActiveFilters);
   const hasFacetFilters = useWorktreeFilterStore((state) => state.hasFacetFilters);
@@ -325,14 +329,21 @@ export function WorktreeOverviewModal({
 
   const chipCounts = useMemo(() => {
     const candidates = hideMainWorktree ? worktrees.filter((w) => !w.isMainWorktree) : worktrees;
-    return computeChipCounts(candidates, derivedMetaMap, activeWorktreeId, {
-      query,
-      statusFilters,
-      typeFilters,
-      prIssueFilters,
-      sessionFilters,
-      activityFilters,
-    });
+    return computeChipCounts(
+      candidates,
+      derivedMetaMap,
+      activeWorktreeId,
+      {
+        query,
+        statusFilters,
+        typeFilters,
+        prIssueFilters,
+        sessionFilters,
+        activityFilters,
+        devServerFilters,
+      },
+      devServerSessions
+    );
   }, [
     worktrees,
     derivedMetaMap,
@@ -344,6 +355,8 @@ export function WorktreeOverviewModal({
     prIssueFilters,
     sessionFilters,
     activityFilters,
+    devServerFilters,
+    devServerSessions,
   ]);
 
   // Compute aggregate statistics from derivedMetaMap
@@ -388,6 +401,7 @@ export function WorktreeOverviewModal({
       prIssueFilters,
       sessionFilters,
       activityFilters,
+      devServerFilters,
     };
 
     // Filter worktrees
@@ -433,7 +447,7 @@ export function WorktreeOverviewModal({
         return false;
       }
 
-      return matchesFilters(worktree, filters, derived, isActive);
+      return matchesFilters(worktree, filters, derived, isActive, devServerSessions);
     });
 
     // Filter out pinned worktrees that no longer exist
@@ -462,6 +476,8 @@ export function WorktreeOverviewModal({
     prIssueFilters,
     sessionFilters,
     activityFilters,
+    devServerFilters,
+    devServerSessions,
     alwaysShowActive,
     alwaysShowWaiting,
     pinnedWorktrees,

--- a/src/components/Worktree/__tests__/WorktreeSidebarSearchBar.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeSidebarSearchBar.test.tsx
@@ -15,6 +15,7 @@ function resetWorktreeFilterStore() {
     prIssueFilters: new Set(),
     sessionFilters: new Set(),
     activityFilters: new Set(),
+    devServerFilters: new Set(),
     alwaysShowActive: true,
     alwaysShowWaiting: true,
     hideMainWorktree: false,

--- a/src/hooks/app/__tests__/useWorktreeDevServerSession.test.tsx
+++ b/src/hooks/app/__tests__/useWorktreeDevServerSession.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useWorktreeDevServerSession } from "../useWorktreeDevServerSession";
+import { useWorktreeDevServerStore } from "@/store/worktreeDevServerStore";
+import type { DevPreviewSessionState } from "@shared/types/ipc/devPreview";
+
+function makeSession(worktreeId: string): DevPreviewSessionState {
+  return {
+    panelId: "p1",
+    projectId: "proj",
+    worktreeId,
+    status: "running",
+    url: "http://localhost:5173",
+    predictedUrl: null,
+    error: null,
+    terminalId: null,
+    isRestarting: false,
+    generation: 0,
+    updatedAt: 1,
+  };
+}
+
+describe("useWorktreeDevServerSession", () => {
+  let getByWorktree: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    useWorktreeDevServerStore.getState().reset();
+    getByWorktree = vi.fn();
+    // Define on the real window (don't spread it — `document` lives on the
+    // prototype and would be lost, breaking RTL's `waitFor`).
+    Object.defineProperty(window, "electron", {
+      value: { devPreview: { getByWorktree } },
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it("hydrates the store on a cache miss", async () => {
+    getByWorktree.mockResolvedValue(makeSession("w1"));
+    const { result } = renderHook(() => useWorktreeDevServerSession("w1"));
+    await waitFor(() => {
+      expect(result.current?.status).toBe("running");
+    });
+    expect(getByWorktree).toHaveBeenCalledWith({ worktreeId: "w1" });
+  });
+
+  it("does not call getByWorktree when the store already has the entry", () => {
+    useWorktreeDevServerStore.getState().setSession("w1", makeSession("w1"));
+    renderHook(() => useWorktreeDevServerSession("w1"));
+    expect(getByWorktree).not.toHaveBeenCalled();
+  });
+
+  it("does not write a stored session after unmount", async () => {
+    let resolve!: (v: DevPreviewSessionState | null) => void;
+    getByWorktree.mockReturnValue(
+      new Promise<DevPreviewSessionState | null>((r) => {
+        resolve = r;
+      })
+    );
+    const { unmount } = renderHook(() => useWorktreeDevServerSession("w1"));
+    unmount();
+    resolve(makeSession("w1"));
+    await Promise.resolve();
+    expect(useWorktreeDevServerStore.getState().sessionsByWorktreeId.w1).toBeUndefined();
+  });
+
+  it("does not write when getByWorktree resolves null (no session)", async () => {
+    getByWorktree.mockResolvedValue(null);
+    renderHook(() => useWorktreeDevServerSession("w1"));
+    await waitFor(() => {
+      expect(getByWorktree).toHaveBeenCalled();
+    });
+    expect(useWorktreeDevServerStore.getState().sessionsByWorktreeId.w1).toBeUndefined();
+  });
+});

--- a/src/hooks/app/__tests__/useWorktreeDevServerStateSync.test.tsx
+++ b/src/hooks/app/__tests__/useWorktreeDevServerStateSync.test.tsx
@@ -45,7 +45,13 @@ describe("useWorktreeDevServerStateSync", () => {
         devPreview: {
           onStateChanged: (cb: Listener) => {
             listeners.push(cb);
-            return unsubscribe;
+            // Mirror the real IPC contract: the returned cleanup detaches the
+            // handler so no further payloads are delivered.
+            return () => {
+              unsubscribe();
+              const i = listeners.indexOf(cb);
+              if (i >= 0) listeners.splice(i, 1);
+            };
           },
         },
       },
@@ -79,5 +85,13 @@ describe("useWorktreeDevServerStateSync", () => {
     expect(unsubscribe).not.toHaveBeenCalled();
     unmount();
     expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not mutate the store from a broadcast delivered after unmount", () => {
+    const { unmount } = renderHook(() => useWorktreeDevServerStateSync());
+    unmount();
+    // The cleanup detached the handler, so a late broadcast reaches no listener.
+    emit({ state: makeSession("w1", "running") });
+    expect(useWorktreeDevServerStore.getState().sessionsByWorktreeId).toEqual({});
   });
 });

--- a/src/hooks/app/__tests__/useWorktreeDevServerStateSync.test.tsx
+++ b/src/hooks/app/__tests__/useWorktreeDevServerStateSync.test.tsx
@@ -33,11 +33,11 @@ function makeSession(
 
 describe("useWorktreeDevServerStateSync", () => {
   let listeners: Listener[];
-  let unsubscribe: ReturnType<typeof vi.fn>;
+  let unsubscribe: () => void;
 
   beforeEach(() => {
     listeners = [];
-    unsubscribe = vi.fn();
+    unsubscribe = vi.fn() as () => void;
     useWorktreeDevServerStore.getState().reset();
     vi.stubGlobal("window", {
       ...window,
@@ -65,7 +65,7 @@ describe("useWorktreeDevServerStateSync", () => {
   it("writes broadcasts with a worktreeId into the store", () => {
     renderHook(() => useWorktreeDevServerStateSync());
     emit({ state: makeSession("w1", "running") });
-    expect(useWorktreeDevServerStore.getState().sessionsByWorktreeId.w1.status).toBe("running");
+    expect(useWorktreeDevServerStore.getState().sessionsByWorktreeId.w1?.status).toBe("running");
   });
 
   it("skips broadcasts that have no worktreeId", () => {

--- a/src/hooks/app/__tests__/useWorktreeDevServerStateSync.test.tsx
+++ b/src/hooks/app/__tests__/useWorktreeDevServerStateSync.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useWorktreeDevServerStateSync } from "../useWorktreeDevServerStateSync";
+import { useWorktreeDevServerStore } from "@/store/worktreeDevServerStore";
+import type {
+  DevPreviewSessionState,
+  DevPreviewStateChangedPayload,
+  DevPreviewSessionStatus,
+} from "@shared/types/ipc/devPreview";
+
+type Listener = (payload: DevPreviewStateChangedPayload) => void;
+
+function makeSession(
+  worktreeId: string | undefined,
+  status: DevPreviewSessionStatus,
+  updatedAt = 1
+): DevPreviewSessionState {
+  return {
+    panelId: "p1",
+    projectId: "proj",
+    worktreeId,
+    status,
+    url: null,
+    predictedUrl: null,
+    error: null,
+    terminalId: null,
+    isRestarting: false,
+    generation: 0,
+    updatedAt,
+  };
+}
+
+describe("useWorktreeDevServerStateSync", () => {
+  let listeners: Listener[];
+  let unsubscribe: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    listeners = [];
+    unsubscribe = vi.fn();
+    useWorktreeDevServerStore.getState().reset();
+    vi.stubGlobal("window", {
+      ...window,
+      electron: {
+        devPreview: {
+          onStateChanged: (cb: Listener) => {
+            listeners.push(cb);
+            return unsubscribe;
+          },
+        },
+      },
+    });
+  });
+
+  function emit(payload: DevPreviewStateChangedPayload) {
+    for (const l of listeners) l(payload);
+  }
+
+  it("writes broadcasts with a worktreeId into the store", () => {
+    renderHook(() => useWorktreeDevServerStateSync());
+    emit({ state: makeSession("w1", "running") });
+    expect(useWorktreeDevServerStore.getState().sessionsByWorktreeId.w1.status).toBe("running");
+  });
+
+  it("skips broadcasts that have no worktreeId", () => {
+    renderHook(() => useWorktreeDevServerStateSync());
+    emit({ state: makeSession(undefined, "running") });
+    expect(useWorktreeDevServerStore.getState().sessionsByWorktreeId).toEqual({});
+  });
+
+  it("skips broadcasts whose worktreeId is only whitespace", () => {
+    renderHook(() => useWorktreeDevServerStateSync());
+    emit({ state: makeSession("   ", "running") });
+    expect(useWorktreeDevServerStore.getState().sessionsByWorktreeId).toEqual({});
+  });
+
+  it("unsubscribes on unmount", () => {
+    const { unmount } = renderHook(() => useWorktreeDevServerStateSync());
+    expect(unsubscribe).not.toHaveBeenCalled();
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/app/index.ts
+++ b/src/hooks/app/index.ts
@@ -22,3 +22,5 @@ export { useAgentWaitingNudge } from "./useAgentWaitingNudge";
 export { useFocusOnActivateIntent } from "./useFocusOnActivateIntent";
 export { useNotificationHistoryPruning } from "./useNotificationHistoryPruning";
 export { useRecipeFocusReload } from "./useRecipeFocusReload";
+export { useWorktreeDevServerStateSync } from "./useWorktreeDevServerStateSync";
+export { useWorktreeDevServerSession } from "./useWorktreeDevServerSession";

--- a/src/hooks/app/useWorktreeDevServerSession.ts
+++ b/src/hooks/app/useWorktreeDevServerSession.ts
@@ -2,17 +2,18 @@ import { useEffect } from "react";
 import type { DevPreviewSessionState } from "@shared/types/ipc/devPreview";
 import { useWorktreeDevServerStore } from "@/store/worktreeDevServerStore";
 
-// Dedup guard shared across all rows: `getByWorktree` is a cheap in-memory
-// lookup on the main side, but a worktree can mount in the sidebar and the grid
-// simultaneously — without this set both rows would fire the same hydration.
-const inFlightHydrations = new Set<string>();
-
 /**
  * Reactive read of a worktree's latest dev-server session plus one-shot lazy
  * hydration. `DEV_PREVIEW_STATE_CHANGED` only fires on *changes*, so a server
  * that was already running before the dashboard mounted would never reach the
  * store via the broadcast alone — this primes the entry once via
  * `getByWorktree` when the cache has no record for the worktree yet.
+ *
+ * No cross-row dedup guard: the effect runs once per mount, the store-entry
+ * check short-circuits once data exists, and `getByWorktree` is a cheap
+ * in-memory lookup on the main side. The freshness guard in the store makes
+ * concurrent writes idempotent, so a worktree shown in two places (sidebar +
+ * overview modal) at most fires the lookup twice — simpler and race-free.
  */
 export function useWorktreeDevServerSession(
   worktreeId: string
@@ -23,8 +24,6 @@ export function useWorktreeDevServerSession(
     if (useWorktreeDevServerStore.getState().sessionsByWorktreeId[worktreeId] !== undefined) {
       return;
     }
-    if (inFlightHydrations.has(worktreeId)) return;
-    inFlightHydrations.add(worktreeId);
     let disposed = false;
     window.electron.devPreview
       .getByWorktree({ worktreeId })
@@ -32,10 +31,7 @@ export function useWorktreeDevServerSession(
         if (disposed || !result) return;
         useWorktreeDevServerStore.getState().setSession(worktreeId, result);
       })
-      .catch(() => {})
-      .finally(() => {
-        inFlightHydrations.delete(worktreeId);
-      });
+      .catch(() => {});
     return () => {
       disposed = true;
     };

--- a/src/hooks/app/useWorktreeDevServerSession.ts
+++ b/src/hooks/app/useWorktreeDevServerSession.ts
@@ -1,0 +1,45 @@
+import { useEffect } from "react";
+import type { DevPreviewSessionState } from "@shared/types/ipc/devPreview";
+import { useWorktreeDevServerStore } from "@/store/worktreeDevServerStore";
+
+// Dedup guard shared across all rows: `getByWorktree` is a cheap in-memory
+// lookup on the main side, but a worktree can mount in the sidebar and the grid
+// simultaneously — without this set both rows would fire the same hydration.
+const inFlightHydrations = new Set<string>();
+
+/**
+ * Reactive read of a worktree's latest dev-server session plus one-shot lazy
+ * hydration. `DEV_PREVIEW_STATE_CHANGED` only fires on *changes*, so a server
+ * that was already running before the dashboard mounted would never reach the
+ * store via the broadcast alone — this primes the entry once via
+ * `getByWorktree` when the cache has no record for the worktree yet.
+ */
+export function useWorktreeDevServerSession(
+  worktreeId: string
+): DevPreviewSessionState | undefined {
+  const session = useWorktreeDevServerStore((s) => s.sessionsByWorktreeId[worktreeId]);
+
+  useEffect(() => {
+    if (useWorktreeDevServerStore.getState().sessionsByWorktreeId[worktreeId] !== undefined) {
+      return;
+    }
+    if (inFlightHydrations.has(worktreeId)) return;
+    inFlightHydrations.add(worktreeId);
+    let disposed = false;
+    window.electron.devPreview
+      .getByWorktree({ worktreeId })
+      .then((result) => {
+        if (disposed || !result) return;
+        useWorktreeDevServerStore.getState().setSession(worktreeId, result);
+      })
+      .catch(() => {})
+      .finally(() => {
+        inFlightHydrations.delete(worktreeId);
+      });
+    return () => {
+      disposed = true;
+    };
+  }, [worktreeId]);
+
+  return session;
+}

--- a/src/hooks/app/useWorktreeDevServerStateSync.ts
+++ b/src/hooks/app/useWorktreeDevServerStateSync.ts
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+import { useWorktreeDevServerStore } from "@/store/worktreeDevServerStore";
+
+/**
+ * App-level singleton that mirrors every `DEV_PREVIEW_STATE_CHANGED` broadcast
+ * into `worktreeDevServerStore`, keyed by `worktreeId`. Mount once (in `App`).
+ *
+ * Payloads without a `worktreeId` (dev-preview panels opened with no worktree
+ * association) are skipped — the worktree dashboard is worktree-centric and has
+ * no row to attach them to. The subscription lives in `useEffect` with a
+ * returned cleanup so it never leaks across fast-refresh or unmount (#4754).
+ */
+export function useWorktreeDevServerStateSync(): void {
+  useEffect(() => {
+    return window.electron.devPreview.onStateChanged((payload) => {
+      const { state } = payload;
+      const worktreeId = state.worktreeId?.trim();
+      if (!worktreeId) return;
+      useWorktreeDevServerStore.getState().setSession(worktreeId, state);
+    });
+  }, []);
+}

--- a/src/lib/__tests__/worktreeCyclingOrder.test.ts
+++ b/src/lib/__tests__/worktreeCyclingOrder.test.ts
@@ -51,6 +51,7 @@ function resetFilterStore(): void {
     prIssueFilters: new Set(),
     sessionFilters: new Set(),
     activityFilters: new Set(),
+    devServerFilters: new Set(),
     alwaysShowActive: true,
     alwaysShowWaiting: true,
     hideMainWorktree: false,

--- a/src/lib/__tests__/worktreeFilters.test.ts
+++ b/src/lib/__tests__/worktreeFilters.test.ts
@@ -14,6 +14,8 @@ import {
   computeChipCounts,
   emptyChipCounts,
   compareWorktreeNames,
+  matchesDevServerFilter,
+  isLiveDevServerStatus,
   type DerivedWorktreeMeta,
   type FilterState,
 } from "../worktreeFilters";
@@ -24,6 +26,25 @@ import type {
   SessionFilter,
   ActivityFilter,
 } from "@/store/worktreeFilterStore";
+import type { DevPreviewSessionState, DevPreviewSessionStatus } from "@shared/types/ipc/devPreview";
+
+const makeDevSession = (
+  status: DevPreviewSessionStatus,
+  overrides: Partial<DevPreviewSessionState> = {}
+): DevPreviewSessionState => ({
+  panelId: "p1",
+  projectId: "proj",
+  worktreeId: "test-id",
+  status,
+  url: null,
+  predictedUrl: null,
+  error: null,
+  terminalId: null,
+  isRestarting: false,
+  generation: 0,
+  updatedAt: 1,
+  ...overrides,
+});
 
 const createMockWorktree = (overrides: Partial<Worktree> = {}): Worktree => {
   const num = overrides.prNumber;
@@ -68,6 +89,7 @@ const createEmptyFilters = (): FilterState => ({
   prIssueFilters: new Set(),
   sessionFilters: new Set(),
   activityFilters: new Set(),
+  devServerFilters: new Set(),
 });
 
 const createEmptyMeta = (): DerivedWorktreeMeta => ({
@@ -1445,6 +1467,7 @@ describe("computeChipCounts", () => {
       prIssueFilters: new Set(),
       sessionFilters: new Set(),
       activityFilters: new Set(),
+      devServerFilters: new Set(),
     };
     const counts = computeChipCounts(worktrees, new Map(), null, filters);
     // Status chips count against base set excluding status (all 3 worktrees)
@@ -1469,6 +1492,7 @@ describe("computeChipCounts", () => {
       prIssueFilters: new Set(),
       sessionFilters: new Set(),
       activityFilters: new Set(),
+      devServerFilters: new Set(),
     };
     const counts = computeChipCounts(worktrees, new Map(), null, filters);
     // Branch type chips show absolute totals (sibling group excluded from base set)
@@ -1505,6 +1529,7 @@ describe("computeChipCounts", () => {
       prIssueFilters: new Set(),
       sessionFilters: new Set(),
       activityFilters: new Set<ActivityFilter>(["last15m"]),
+      devServerFilters: new Set(),
     };
     const counts = computeChipCounts(worktrees, new Map(), null, filters);
     // Type chips count against base set excluding type filters (activity=last15m → w1 and w2)
@@ -1529,6 +1554,7 @@ describe("computeChipCounts", () => {
       prIssueFilters: new Set(),
       sessionFilters: new Set(),
       activityFilters: new Set(),
+      devServerFilters: new Set(),
     };
     const counts = computeChipCounts(worktrees, new Map(), null, filters);
     // Only w1 and w3 match "login" query — all chips counted against this subset
@@ -1555,6 +1581,7 @@ describe("computeChipCounts", () => {
       prIssueFilters: new Set(),
       sessionFilters: new Set<SessionFilter>(["working"]),
       activityFilters: new Set(),
+      devServerFilters: new Set(),
     };
     const counts = computeChipCounts(worktrees, map, null, filters);
     // Session chips: base set = type=bugfix → only w3
@@ -1579,6 +1606,7 @@ describe("computeChipCounts", () => {
       prIssueFilters: new Set(),
       sessionFilters: new Set(),
       activityFilters: new Set(),
+      devServerFilters: new Set(),
     };
     const counts = computeChipCounts(worktrees, new Map(), null, filters);
     // Type chips ignore their own active filter — show absolute totals
@@ -1599,6 +1627,7 @@ describe("computeChipCounts", () => {
       prIssueFilters: new Set(),
       sessionFilters: new Set(),
       activityFilters: new Set(),
+      devServerFilters: new Set(),
     };
     const counts = computeChipCounts(worktrees, new Map(), null, filters);
     // Only w1 matches the exact-number query — all chips counted against it
@@ -1619,5 +1648,116 @@ describe("computeChipCounts", () => {
     expect(counts.activity.last15m).toBe(1);
     expect(counts.activity.last1h).toBe(1);
     expect(counts.activity.last24h).toBe(1);
+  });
+});
+
+describe("isLiveDevServerStatus", () => {
+  it("treats starting/installing/running/error as live", () => {
+    expect(isLiveDevServerStatus("starting")).toBe(true);
+    expect(isLiveDevServerStatus("installing")).toBe(true);
+    expect(isLiveDevServerStatus("running")).toBe(true);
+    expect(isLiveDevServerStatus("error")).toBe(true);
+  });
+
+  it("treats stopped/restored-stopped/stopping as not live", () => {
+    expect(isLiveDevServerStatus("stopped")).toBe(false);
+    expect(isLiveDevServerStatus("restored-stopped")).toBe(false);
+    expect(isLiveDevServerStatus("stopping")).toBe(false);
+  });
+});
+
+describe("matchesDevServerFilter", () => {
+  it("never matches when there is no session", () => {
+    expect(matchesDevServerFilter("hasDevServer", undefined)).toBe(false);
+    expect(matchesDevServerFilter("running", undefined)).toBe(false);
+    expect(matchesDevServerFilter("starting", undefined)).toBe(false);
+    expect(matchesDevServerFilter("error", undefined)).toBe(false);
+  });
+
+  it("matches 'running' only for running sessions", () => {
+    expect(matchesDevServerFilter("running", makeDevSession("running"))).toBe(true);
+    expect(matchesDevServerFilter("running", makeDevSession("starting"))).toBe(false);
+    expect(matchesDevServerFilter("running", makeDevSession("stopped"))).toBe(false);
+  });
+
+  it("matches 'starting' for both starting and installing", () => {
+    expect(matchesDevServerFilter("starting", makeDevSession("starting"))).toBe(true);
+    expect(matchesDevServerFilter("starting", makeDevSession("installing"))).toBe(true);
+    expect(matchesDevServerFilter("starting", makeDevSession("running"))).toBe(false);
+  });
+
+  it("matches 'error' only for error sessions", () => {
+    expect(matchesDevServerFilter("error", makeDevSession("error"))).toBe(true);
+    expect(matchesDevServerFilter("error", makeDevSession("running"))).toBe(false);
+  });
+
+  it("matches 'hasDevServer' for any live status but not stopped variants", () => {
+    expect(matchesDevServerFilter("hasDevServer", makeDevSession("running"))).toBe(true);
+    expect(matchesDevServerFilter("hasDevServer", makeDevSession("installing"))).toBe(true);
+    expect(matchesDevServerFilter("hasDevServer", makeDevSession("error"))).toBe(true);
+    expect(matchesDevServerFilter("hasDevServer", makeDevSession("stopped"))).toBe(false);
+    expect(matchesDevServerFilter("hasDevServer", makeDevSession("restored-stopped"))).toBe(false);
+  });
+});
+
+describe("matchesFilters — dev-server facet", () => {
+  it("excludes worktrees with no live session when a dev-server filter is active", () => {
+    const worktree = createMockWorktree({ id: "w1" });
+    const filters = createEmptyFilters();
+    filters.devServerFilters.add("running");
+    expect(matchesFilters(worktree, filters, createEmptyMeta(), false, {})).toBe(false);
+  });
+
+  it("includes a worktree whose session matches the active dev-server filter", () => {
+    const worktree = createMockWorktree({ id: "w1" });
+    const filters = createEmptyFilters();
+    filters.devServerFilters.add("running");
+    const sessions = { w1: makeDevSession("running", { worktreeId: "w1" }) };
+    expect(matchesFilters(worktree, filters, createEmptyMeta(), false, sessions)).toBe(true);
+  });
+
+  it("OR-matches within the dev-server category", () => {
+    const worktree = createMockWorktree({ id: "w1" });
+    const filters = createEmptyFilters();
+    filters.devServerFilters.add("running");
+    filters.devServerFilters.add("error");
+    const sessions = { w1: makeDevSession("error", { worktreeId: "w1" }) };
+    expect(matchesFilters(worktree, filters, createEmptyMeta(), false, sessions)).toBe(true);
+  });
+
+  it("treats a missing session map as no match when a dev-server filter is active", () => {
+    const worktree = createMockWorktree({ id: "w1" });
+    const filters = createEmptyFilters();
+    filters.devServerFilters.add("hasDevServer");
+    expect(matchesFilters(worktree, filters, createEmptyMeta(), false)).toBe(false);
+  });
+});
+
+describe("computeChipCounts — dev-server counts", () => {
+  it("counts each dev-server facet from the session map", () => {
+    const worktrees = [
+      createMockWorktree({ id: "w1" }),
+      createMockWorktree({ id: "w2" }),
+      createMockWorktree({ id: "w3" }),
+      createMockWorktree({ id: "w4" }),
+    ];
+    const sessions: Record<string, DevPreviewSessionState> = {
+      w1: makeDevSession("running", { worktreeId: "w1" }),
+      w2: makeDevSession("installing", { worktreeId: "w2" }),
+      w3: makeDevSession("error", { worktreeId: "w3" }),
+      w4: makeDevSession("stopped", { worktreeId: "w4" }),
+    };
+    const counts = computeChipCounts(worktrees, new Map(), null, createEmptyFilters(), sessions);
+    expect(counts.devServer.running).toBe(1);
+    expect(counts.devServer.starting).toBe(1); // installing counts under "starting"
+    expect(counts.devServer.error).toBe(1);
+    expect(counts.devServer.hasDevServer).toBe(3); // running + installing + error, not stopped
+  });
+
+  it("reports zero dev-server counts when no session map is provided", () => {
+    const worktrees = [createMockWorktree({ id: "w1" })];
+    const counts = computeChipCounts(worktrees, new Map(), null, createEmptyFilters());
+    expect(counts.devServer.running).toBe(0);
+    expect(counts.devServer.hasDevServer).toBe(0);
   });
 });

--- a/src/lib/worktreeCyclingOrder.ts
+++ b/src/lib/worktreeCyclingOrder.ts
@@ -3,6 +3,7 @@ import { usePanelStore } from "@/store/panelStore";
 import { isPtyPanel } from "@shared/types/panel";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
+import { useWorktreeDevServerStore } from "@/store/worktreeDevServerStore";
 import { computeChipState } from "@/components/Worktree/utils/computeChipState";
 import type { WorktreeLifecycleStage } from "@/components/Worktree/WorktreeCard/hooks/useWorktreeStatus";
 import {
@@ -125,12 +126,15 @@ export function getVisibleWorktreesForCycling(
     prIssueFilters,
     sessionFilters,
     activityFilters,
+    devServerFilters,
     alwaysShowActive,
     alwaysShowWaiting,
     pinnedWorktrees,
     manualOrder,
     quickStateFilter,
   } = filterState;
+
+  const devServerSessions = useWorktreeDevServerStore.getState().sessionsByWorktreeId;
 
   const viewState = getCurrentViewStore().getState();
   const rawWorktrees = Array.from(viewState.worktrees.values())
@@ -178,6 +182,7 @@ export function getVisibleWorktreesForCycling(
     prIssueFilters,
     sessionFilters,
     activityFilters,
+    devServerFilters,
   };
 
   const hasFacetFiltersActive = filterState.hasFacetFilters();
@@ -213,7 +218,7 @@ export function getVisibleWorktreesForCycling(
     if (quickStateFilter !== "all" && !matchesQuickStateFilter(quickStateFilter, derived)) {
       return false;
     }
-    return matchesFilters(worktree, filters, derived, isActive);
+    return matchesFilters(worktree, filters, derived, isActive, devServerSessions);
   });
 
   const existingIds = new Set(rawWorktrees.map((w) => w.id));
@@ -244,7 +249,13 @@ export function getVisibleWorktreesForCycling(
     };
     if (
       !hasFacetFiltersActive ||
-      matchesFilters(mainWorktree, filters, mainDerived, mainWorktree.id === activeWorktreeId)
+      matchesFilters(
+        mainWorktree,
+        filters,
+        mainDerived,
+        mainWorktree.id === activeWorktreeId,
+        devServerSessions
+      )
     ) {
       topPinned.push(mainWorktree);
     }
@@ -265,7 +276,8 @@ export function getVisibleWorktreesForCycling(
         integrationWorktree,
         filters,
         intDerived,
-        integrationWorktree.id === activeWorktreeId
+        integrationWorktree.id === activeWorktreeId,
+        devServerSessions
       )
     ) {
       topPinned.push(integrationWorktree);

--- a/src/lib/worktreeFilters.ts
+++ b/src/lib/worktreeFilters.ts
@@ -8,8 +8,10 @@ import type {
   PrIssueFilter,
   SessionFilter,
   ActivityFilter,
+  DevServerFilter,
 } from "@/store/worktreeFilterStore";
 import type { ChipState } from "@/components/Worktree/utils/computeChipState";
+import type { DevPreviewSessionState, DevPreviewSessionStatus } from "@shared/types/ipc/devPreview";
 
 export interface DerivedWorktreeMeta {
   terminalCount: number;
@@ -36,6 +38,34 @@ export function matchesQuickStateFilter(
       return meta.chipState === "waiting";
     case "finished":
       return meta.chipState === "complete" || meta.chipState === "cleanup";
+  }
+}
+
+/**
+ * A dev-server status the worktree row surfaces as a live signal. `stopped`,
+ * `restored-stopped`, and the transient `stopping` render nothing, so both the
+ * row indicator and the dev-server facet filter treat them as "no live server".
+ */
+export function isLiveDevServerStatus(status: DevPreviewSessionStatus): boolean {
+  return (
+    status === "running" || status === "starting" || status === "installing" || status === "error"
+  );
+}
+
+export function matchesDevServerFilter(
+  filter: DevServerFilter,
+  session: DevPreviewSessionState | undefined
+): boolean {
+  if (!session) return false;
+  switch (filter) {
+    case "running":
+      return session.status === "running";
+    case "starting":
+      return session.status === "starting" || session.status === "installing";
+    case "error":
+      return session.status === "error";
+    case "hasDevServer":
+      return isLiveDevServerStatus(session.status);
   }
 }
 
@@ -135,13 +165,15 @@ export interface FilterState {
   prIssueFilters: Set<PrIssueFilter>;
   sessionFilters: Set<SessionFilter>;
   activityFilters: Set<ActivityFilter>;
+  devServerFilters: Set<DevServerFilter>;
 }
 
 export function matchesFilters(
   worktree: Worktree | WorktreeState,
   filters: FilterState,
   derived: DerivedWorktreeMeta,
-  isActive: boolean
+  isActive: boolean,
+  sessionsByWorktreeId?: Record<string, DevPreviewSessionState>
 ): boolean {
   // Text search
   if (filters.query.length > 0) {
@@ -217,6 +249,19 @@ export function matchesFilters(
     if (filters.activityFilters.has("last7d") && now - lastActivity < 7 * 24 * 60 * 60 * 1000)
       hasMatch = true;
 
+    if (!hasMatch) return false;
+  }
+
+  // Dev-server filters (OR within category)
+  if (filters.devServerFilters.size > 0) {
+    const session = sessionsByWorktreeId?.[worktree.id];
+    let hasMatch = false;
+    for (const filter of filters.devServerFilters) {
+      if (matchesDevServerFilter(filter, session)) {
+        hasMatch = true;
+        break;
+      }
+    }
     if (!hasMatch) return false;
   }
 
@@ -382,7 +427,8 @@ export function hasAnyFilters(filters: FilterState): boolean {
     filters.typeFilters.size > 0 ||
     filters.prIssueFilters.size > 0 ||
     filters.sessionFilters.size > 0 ||
-    filters.activityFilters.size > 0
+    filters.activityFilters.size > 0 ||
+    filters.devServerFilters.size > 0
   );
 }
 
@@ -435,6 +481,7 @@ export interface ChipCounts {
   prIssue: Record<PrIssueFilter, number>;
   sessions: Record<SessionFilter, number>;
   activity: Record<ActivityFilter, number>;
+  devServer: Record<DevServerFilter, number>;
 }
 
 const STATUS_KEYS: StatusFilter[] = ["active", "dirty", "stale", "idle"];
@@ -458,6 +505,7 @@ const TYPE_KEYS: TypeFilter[] = [
 const PR_ISSUE_KEYS: PrIssueFilter[] = ["hasIssue", "hasPR", "prOpen", "prMerged", "prClosed"];
 const SESSION_KEYS: SessionFilter[] = ["hasTerminals", "working", "waiting", "completed", "exited"];
 const ACTIVITY_KEYS: ActivityFilter[] = ["last15m", "last1h", "last24h", "last7d"];
+const DEV_SERVER_KEYS: DevServerFilter[] = ["running", "starting", "hasDevServer", "error"];
 
 const ACTIVITY_WINDOW_MS: Record<ActivityFilter, number> = {
   last15m: 15 * 60 * 1000,
@@ -479,6 +527,7 @@ export function emptyChipCounts(): ChipCounts {
     prIssue: emptyRecord(PR_ISSUE_KEYS),
     sessions: emptyRecord(SESSION_KEYS),
     activity: emptyRecord(ACTIVITY_KEYS),
+    devServer: emptyRecord(DEV_SERVER_KEYS),
   };
 }
 
@@ -500,7 +549,8 @@ export function computeChipCounts(
   worktrees: readonly (Worktree | WorktreeState)[],
   derivedMetaMap: Map<string, DerivedWorktreeMeta>,
   activeWorktreeId: string | null,
-  filters: FilterState
+  filters: FilterState,
+  sessionsByWorktreeId?: Record<string, DevPreviewSessionState>
 ): ChipCounts {
   const counts = emptyChipCounts();
   const now = Date.now();
@@ -508,7 +558,13 @@ export function computeChipCounts(
   const baseIsActive = (w: (typeof worktrees)[number]) => w.id === activeWorktreeId;
   const getDerived = (id: string) => derivedMetaMap.get(id) ?? DEFAULT_DERIVED_META;
   const matchesGroup = (w: (typeof worktrees)[number], groupKey: keyof FilterState) =>
-    matchesFilters(w, withoutGroup(filters, groupKey), getDerived(w.id), baseIsActive(w));
+    matchesFilters(
+      w,
+      withoutGroup(filters, groupKey),
+      getDerived(w.id),
+      baseIsActive(w),
+      sessionsByWorktreeId
+    );
 
   // Build base set per group — filtered by all OTHER groups + query
   const statusBase = worktrees.filter((w) => matchesGroup(w, "statusFilters"));
@@ -516,6 +572,7 @@ export function computeChipCounts(
   const prIssueBase = worktrees.filter((w) => matchesGroup(w, "prIssueFilters"));
   const sessionsBase = worktrees.filter((w) => matchesGroup(w, "sessionFilters"));
   const activityBase = worktrees.filter((w) => matchesGroup(w, "activityFilters"));
+  const devServerBase = worktrees.filter((w) => matchesGroup(w, "devServerFilters"));
 
   for (const w of statusBase) {
     const statuses = computeStatus(w, baseIsActive(w));
@@ -552,6 +609,14 @@ export function computeChipCounts(
       for (const key of ACTIVITY_KEYS) {
         if (elapsed < ACTIVITY_WINDOW_MS[key]) counts.activity[key]++;
       }
+    }
+  }
+
+  for (const w of devServerBase) {
+    const session = sessionsByWorktreeId?.[w.id];
+    if (!session) continue;
+    for (const key of DEV_SERVER_KEYS) {
+      if (matchesDevServerFilter(key, session)) counts.devServer[key]++;
     }
   }
 

--- a/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
@@ -391,6 +391,7 @@ beforeEach(() => {
     prIssueFilters: new Set(),
     sessionFilters: new Set(),
     activityFilters: new Set(),
+    devServerFilters: new Set(),
     alwaysShowActive: true,
     alwaysShowWaiting: true,
     hideMainWorktree: false,

--- a/src/store/__tests__/worktreeDevServerStore.test.ts
+++ b/src/store/__tests__/worktreeDevServerStore.test.ts
@@ -53,12 +53,13 @@ describe("worktreeDevServerStore", () => {
     expect(after).toBe(before);
   });
 
-  it("rejects an equal-timestamp duplicate write (no reference churn)", () => {
+  it("applies an equal-timestamp write (last-write-wins for same-ms transitions)", () => {
     const store = useWorktreeDevServerStore.getState();
-    store.setSession("w1", makeSession({ worktreeId: "w1", status: "running", updatedAt: 100 }));
-    const before = useWorktreeDevServerStore.getState().sessionsByWorktreeId.w1;
+    store.setSession("w1", makeSession({ worktreeId: "w1", status: "starting", updatedAt: 100 }));
+    // A synchronous spawn failure can flip starting→error within the same ms;
+    // the latter transition must not be dropped.
     store.setSession("w1", makeSession({ worktreeId: "w1", status: "error", updatedAt: 100 }));
-    expect(useWorktreeDevServerStore.getState().sessionsByWorktreeId.w1).toBe(before);
+    expect(useWorktreeDevServerStore.getState().sessionsByWorktreeId.w1.status).toBe("error");
   });
 
   it("removeSession deletes the entry", () => {

--- a/src/store/__tests__/worktreeDevServerStore.test.ts
+++ b/src/store/__tests__/worktreeDevServerStore.test.ts
@@ -37,17 +37,17 @@ describe("worktreeDevServerStore", () => {
     const store = useWorktreeDevServerStore.getState();
     store.setSession("w1", makeSession({ worktreeId: "w1", status: "starting", updatedAt: 100 }));
     store.setSession("w1", makeSession({ worktreeId: "w1", status: "running", updatedAt: 200 }));
-    expect(useWorktreeDevServerStore.getState().sessionsByWorktreeId.w1.status).toBe("running");
+    expect(useWorktreeDevServerStore.getState().sessionsByWorktreeId.w1?.status).toBe("running");
   });
 
   it("rejects a stale write whose updatedAt is older than the stored entry", () => {
     const store = useWorktreeDevServerStore.getState();
     // Live broadcast lands first…
     store.setSession("w1", makeSession({ worktreeId: "w1", status: "running", updatedAt: 200 }));
-    const before = useWorktreeDevServerStore.getState().sessionsByWorktreeId.w1;
+    const before = useWorktreeDevServerStore.getState().sessionsByWorktreeId.w1!;
     // …then a slow getByWorktree hydration resolves with an older snapshot.
     store.setSession("w1", makeSession({ worktreeId: "w1", status: "starting", updatedAt: 100 }));
-    const after = useWorktreeDevServerStore.getState().sessionsByWorktreeId.w1;
+    const after = useWorktreeDevServerStore.getState().sessionsByWorktreeId.w1!;
     expect(after.status).toBe("running");
     // Same object reference — no needless re-render from the dropped write.
     expect(after).toBe(before);
@@ -59,7 +59,7 @@ describe("worktreeDevServerStore", () => {
     // A synchronous spawn failure can flip starting→error within the same ms;
     // the latter transition must not be dropped.
     store.setSession("w1", makeSession({ worktreeId: "w1", status: "error", updatedAt: 100 }));
-    expect(useWorktreeDevServerStore.getState().sessionsByWorktreeId.w1.status).toBe("error");
+    expect(useWorktreeDevServerStore.getState().sessionsByWorktreeId.w1?.status).toBe("error");
   });
 
   it("removeSession deletes the entry", () => {

--- a/src/store/__tests__/worktreeDevServerStore.test.ts
+++ b/src/store/__tests__/worktreeDevServerStore.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useWorktreeDevServerStore } from "../worktreeDevServerStore";
+import type { DevPreviewSessionState, DevPreviewSessionStatus } from "@shared/types/ipc/devPreview";
+
+function makeSession(
+  overrides: Partial<DevPreviewSessionState> & {
+    worktreeId: string;
+    status: DevPreviewSessionStatus;
+    updatedAt: number;
+  }
+): DevPreviewSessionState {
+  return {
+    panelId: `panel-${overrides.worktreeId}`,
+    projectId: "proj-1",
+    url: null,
+    predictedUrl: null,
+    error: null,
+    terminalId: null,
+    isRestarting: false,
+    generation: 0,
+    ...overrides,
+  };
+}
+
+describe("worktreeDevServerStore", () => {
+  beforeEach(() => {
+    useWorktreeDevServerStore.getState().reset();
+  });
+
+  it("stores a session keyed by worktreeId", () => {
+    const session = makeSession({ worktreeId: "w1", status: "running", updatedAt: 100 });
+    useWorktreeDevServerStore.getState().setSession("w1", session);
+    expect(useWorktreeDevServerStore.getState().sessionsByWorktreeId.w1).toEqual(session);
+  });
+
+  it("applies a newer update over an older one", () => {
+    const store = useWorktreeDevServerStore.getState();
+    store.setSession("w1", makeSession({ worktreeId: "w1", status: "starting", updatedAt: 100 }));
+    store.setSession("w1", makeSession({ worktreeId: "w1", status: "running", updatedAt: 200 }));
+    expect(useWorktreeDevServerStore.getState().sessionsByWorktreeId.w1.status).toBe("running");
+  });
+
+  it("rejects a stale write whose updatedAt is older than the stored entry", () => {
+    const store = useWorktreeDevServerStore.getState();
+    // Live broadcast lands first…
+    store.setSession("w1", makeSession({ worktreeId: "w1", status: "running", updatedAt: 200 }));
+    const before = useWorktreeDevServerStore.getState().sessionsByWorktreeId.w1;
+    // …then a slow getByWorktree hydration resolves with an older snapshot.
+    store.setSession("w1", makeSession({ worktreeId: "w1", status: "starting", updatedAt: 100 }));
+    const after = useWorktreeDevServerStore.getState().sessionsByWorktreeId.w1;
+    expect(after.status).toBe("running");
+    // Same object reference — no needless re-render from the dropped write.
+    expect(after).toBe(before);
+  });
+
+  it("rejects an equal-timestamp duplicate write (no reference churn)", () => {
+    const store = useWorktreeDevServerStore.getState();
+    store.setSession("w1", makeSession({ worktreeId: "w1", status: "running", updatedAt: 100 }));
+    const before = useWorktreeDevServerStore.getState().sessionsByWorktreeId.w1;
+    store.setSession("w1", makeSession({ worktreeId: "w1", status: "error", updatedAt: 100 }));
+    expect(useWorktreeDevServerStore.getState().sessionsByWorktreeId.w1).toBe(before);
+  });
+
+  it("removeSession deletes the entry", () => {
+    const store = useWorktreeDevServerStore.getState();
+    store.setSession("w1", makeSession({ worktreeId: "w1", status: "running", updatedAt: 100 }));
+    store.removeSession("w1");
+    expect(useWorktreeDevServerStore.getState().sessionsByWorktreeId.w1).toBeUndefined();
+  });
+
+  it("reset clears all sessions", () => {
+    const store = useWorktreeDevServerStore.getState();
+    store.setSession("w1", makeSession({ worktreeId: "w1", status: "running", updatedAt: 100 }));
+    store.setSession("w2", makeSession({ worktreeId: "w2", status: "error", updatedAt: 100 }));
+    store.reset();
+    expect(useWorktreeDevServerStore.getState().sessionsByWorktreeId).toEqual({});
+  });
+});

--- a/src/store/__tests__/worktreeFilterStore.test.ts
+++ b/src/store/__tests__/worktreeFilterStore.test.ts
@@ -12,6 +12,7 @@ function resetWorktreeFilterStore() {
     prIssueFilters: new Set(),
     sessionFilters: new Set(),
     activityFilters: new Set(),
+    devServerFilters: new Set(),
     alwaysShowActive: true,
     alwaysShowWaiting: true,
     hideMainWorktree: false,
@@ -200,6 +201,12 @@ describe("worktreeFilterStore", () => {
       expect(useWorktreeFilterStore.getState().hasFacetFilters()).toBe(true);
     });
 
+    it("returns true when a devServerFilter is active", () => {
+      useWorktreeFilterStore.getState().clearAll();
+      useWorktreeFilterStore.getState().toggleDevServerFilter("running");
+      expect(useWorktreeFilterStore.getState().hasFacetFilters()).toBe(true);
+    });
+
     it("returns false when only query is active", () => {
       useWorktreeFilterStore.getState().clearAll();
       useWorktreeFilterStore.getState().setQuery("search term");
@@ -233,6 +240,40 @@ describe("worktreeFilterStore", () => {
     useWorktreeFilterStore.getState().clearAll();
 
     expect(useWorktreeFilterStore.getState().quickStateFilter).toBe("all");
+  });
+
+  describe("devServerFilters", () => {
+    it("toggleDevServerFilter adds and removes a value", () => {
+      const store = useWorktreeFilterStore.getState();
+      store.toggleDevServerFilter("running");
+      expect(useWorktreeFilterStore.getState().devServerFilters.has("running")).toBe(true);
+      store.toggleDevServerFilter("running");
+      expect(useWorktreeFilterStore.getState().devServerFilters.has("running")).toBe(false);
+    });
+
+    it("counts devServerFilters in getActiveFilterCount and hasActiveFilters", () => {
+      useWorktreeFilterStore.getState().toggleDevServerFilter("running");
+      useWorktreeFilterStore.getState().toggleDevServerFilter("error");
+      expect(useWorktreeFilterStore.getState().getActiveFilterCount()).toBe(2);
+      expect(useWorktreeFilterStore.getState().hasActiveFilters()).toBe(true);
+    });
+
+    it("resets devServerFilters on clearAll", () => {
+      useWorktreeFilterStore.getState().toggleDevServerFilter("running");
+      useWorktreeFilterStore.getState().clearAll();
+      expect(useWorktreeFilterStore.getState().devServerFilters.size).toBe(0);
+    });
+
+    it("does not persist devServerFilters to localStorage (session-only)", () => {
+      useWorktreeFilterStore.getState().toggleDevServerFilter("running");
+      // The per-project persist key holds only the persisted shape; the
+      // session-only devServerFilters must never appear in it.
+      const persisted = Object.keys(localStorage)
+        .filter((k) => k.startsWith("daintree-worktree-filters"))
+        .map((k) => localStorage.getItem(k) ?? "")
+        .join("\n");
+      expect(persisted).not.toContain("devServerFilters");
+    });
   });
 
   it('clearQuickStateFilter resets only quickStateFilter to "all"', () => {

--- a/src/store/worktreeDevServerStore.ts
+++ b/src/store/worktreeDevServerStore.ts
@@ -1,0 +1,43 @@
+import { create } from "zustand";
+import type { DevPreviewSessionState } from "@shared/types/ipc/devPreview";
+
+/**
+ * Runtime-ephemeral cache of the latest dev-server session per worktree, keyed
+ * by `worktreeId`. Populated by a single app-level `DEV_PREVIEW_STATE_CHANGED`
+ * subscription (`useWorktreeDevServerStateSync`) plus per-row lazy hydration
+ * (`useWorktreeDevServerSession`). Not persisted — dev-server state is process
+ * state that does not survive an app restart.
+ *
+ * Sessions in any status (including `stopped`/`restored-stopped`) are retained
+ * so the `updatedAt` freshness guard can reject stale writes; read sites decide
+ * which statuses are "live" (see `isLiveDevServerStatus` in `worktreeFilters`).
+ */
+interface WorktreeDevServerState {
+  sessionsByWorktreeId: Record<string, DevPreviewSessionState>;
+  setSession: (worktreeId: string, session: DevPreviewSessionState) => void;
+  removeSession: (worktreeId: string) => void;
+  reset: () => void;
+}
+
+export const useWorktreeDevServerStore = create<WorktreeDevServerState>((set) => ({
+  sessionsByWorktreeId: {},
+  setSession: (worktreeId, session) =>
+    set((state) => {
+      const existing = state.sessionsByWorktreeId[worktreeId];
+      // Freshness guard: a lazy `getByWorktree` hydration can resolve after a
+      // newer live broadcast already landed. Drop the stale (or duplicate)
+      // write so the row never regresses to an older snapshot.
+      if (existing && session.updatedAt <= existing.updatedAt) return state;
+      return {
+        sessionsByWorktreeId: { ...state.sessionsByWorktreeId, [worktreeId]: session },
+      };
+    }),
+  removeSession: (worktreeId) =>
+    set((state) => {
+      if (!(worktreeId in state.sessionsByWorktreeId)) return state;
+      const next = { ...state.sessionsByWorktreeId };
+      delete next[worktreeId];
+      return { sessionsByWorktreeId: next };
+    }),
+  reset: () => set({ sessionsByWorktreeId: {} }),
+}));

--- a/src/store/worktreeDevServerStore.ts
+++ b/src/store/worktreeDevServerStore.ts
@@ -25,9 +25,12 @@ export const useWorktreeDevServerStore = create<WorktreeDevServerState>((set) =>
     set((state) => {
       const existing = state.sessionsByWorktreeId[worktreeId];
       // Freshness guard: a lazy `getByWorktree` hydration can resolve after a
-      // newer live broadcast already landed. Drop the stale (or duplicate)
-      // write so the row never regresses to an older snapshot.
-      if (existing && session.updatedAt <= existing.updatedAt) return state;
+      // newer live broadcast already landed. Drop only strictly-older writes so
+      // the row never regresses to a stale snapshot. Equal timestamps apply
+      // (last-write-wins): two distinct transitions emitted in the same
+      // millisecond — e.g. a synchronous spawn failure flipping starting→error —
+      // must not silently lose the latter.
+      if (existing && session.updatedAt < existing.updatedAt) return state;
       return {
         sessionsByWorktreeId: { ...state.sessionsByWorktreeId, [worktreeId]: session },
       };

--- a/src/store/worktreeFilterStore.ts
+++ b/src/store/worktreeFilterStore.ts
@@ -30,6 +30,7 @@ export type TypeFilter =
 export type PrIssueFilter = "hasIssue" | "hasPR" | "prOpen" | "prMerged" | "prClosed";
 export type SessionFilter = "hasTerminals" | "working" | "waiting" | "completed" | "exited";
 export type ActivityFilter = "last15m" | "last1h" | "last24h" | "last7d";
+export type DevServerFilter = "running" | "starting" | "hasDevServer" | "error";
 
 const PR_ISSUE_FILTER_VALUES: ReadonlySet<string> = new Set<PrIssueFilter>([
   "hasIssue",
@@ -51,6 +52,8 @@ interface WorktreeFilterState {
   prIssueFilters: Set<PrIssueFilter>;
   sessionFilters: Set<SessionFilter>;
   activityFilters: Set<ActivityFilter>;
+  /** Transient session-only dev-server facet filter (not persisted). */
+  devServerFilters: Set<DevServerFilter>;
   alwaysShowActive: boolean;
   alwaysShowWaiting: boolean;
   hideMainWorktree: boolean;
@@ -70,6 +73,7 @@ interface WorktreeFilterActions {
   togglePrIssueFilter: (filter: PrIssueFilter) => void;
   toggleSessionFilter: (filter: SessionFilter) => void;
   toggleActivityFilter: (filter: ActivityFilter) => void;
+  toggleDevServerFilter: (filter: DevServerFilter) => void;
   setAlwaysShowActive: (enabled: boolean) => void;
   setAlwaysShowWaiting: (enabled: boolean) => void;
   setHideMainWorktree: (enabled: boolean) => void;
@@ -107,8 +111,11 @@ interface GlobalPrefsState {
 /**
  * Fields that are query-shaped or identity-scoped — they must not leak across
  * projects. These live in the per-project store
- * (`daintree-worktree-filters:{projectId}`). `quickStateFilter` is transient
- * (not persisted) but is also scoped to the current project's in-memory state.
+ * (`daintree-worktree-filters:{projectId}`). `quickStateFilter` and
+ * `devServerFilters` are transient (not persisted) but are also scoped to the
+ * current project's in-memory state. `devServerFilters` is deliberately session
+ * -only: a persisted "running" filter would show an empty worktree list on the
+ * next launch (no servers are running yet) until the user noticed and cleared it.
  */
 interface ProjectScopedState {
   query: string;
@@ -121,6 +128,7 @@ interface ProjectScopedState {
   collapsedWorktrees: string[];
   manualOrder: string[];
   quickStateFilter: QuickStateFilter;
+  devServerFilters: Set<DevServerFilter>;
 }
 
 interface GlobalPersistedShape {
@@ -335,6 +343,7 @@ const _projectStore = create<ProjectScopedState>()(
       collapsedWorktrees: _legacySeed.collapsedWorktrees ?? [],
       manualOrder: _legacySeed.manualOrder ?? [],
       quickStateFilter: "all",
+      devServerFilters: new Set<DevServerFilter>(),
     }),
     {
       name: PROJECT_KEY,
@@ -450,6 +459,14 @@ const _actions: WorktreeFilterActions = {
       return { activityFilters: next };
     });
   },
+  toggleDevServerFilter: (filter) => {
+    _projectStore.setState((state) => {
+      const next = new Set(state.devServerFilters);
+      if (next.has(filter)) next.delete(filter);
+      else next.add(filter);
+      return { devServerFilters: next };
+    });
+  },
   setAlwaysShowActive: (enabled) => {
     _globalPrefsStore.setState({ alwaysShowActive: enabled });
   },
@@ -521,6 +538,7 @@ const _actions: WorktreeFilterActions = {
       sessionFilters: new Set(),
       activityFilters: new Set(),
       quickStateFilter: "all",
+      devServerFilters: new Set(),
     });
     _globalPrefsStore.setState({ hideMainWorktree: false });
   },
@@ -534,6 +552,7 @@ const _actions: WorktreeFilterActions = {
       p.prIssueFilters.size +
       p.sessionFilters.size +
       p.activityFilters.size +
+      p.devServerFilters.size +
       (p.quickStateFilter !== "all" ? 1 : 0)
     );
   },
@@ -547,6 +566,7 @@ const _actions: WorktreeFilterActions = {
       p.prIssueFilters.size > 0 ||
       p.sessionFilters.size > 0 ||
       p.activityFilters.size > 0 ||
+      p.devServerFilters.size > 0 ||
       p.quickStateFilter !== "all"
     );
   },
@@ -557,7 +577,8 @@ const _actions: WorktreeFilterActions = {
       p.typeFilters.size > 0 ||
       p.prIssueFilters.size > 0 ||
       p.sessionFilters.size > 0 ||
-      p.activityFilters.size > 0
+      p.activityFilters.size > 0 ||
+      p.devServerFilters.size > 0
     );
   },
 };
@@ -582,6 +603,7 @@ function _computeMergedState(): WorktreeFilterStore {
     prIssueFilters: p.prIssueFilters,
     sessionFilters: p.sessionFilters,
     activityFilters: p.activityFilters,
+    devServerFilters: p.devServerFilters,
     alwaysShowActive: g.alwaysShowActive,
     alwaysShowWaiting: g.alwaysShowWaiting,
     hideMainWorktree: g.hideMainWorktree,


### PR DESCRIPTION
Surfaces the state of a worktree's dev server on the dashboard. The wiring was already there on the main side (`DEV_PREVIEW_STATE_CHANGED` broadcasting, `devPreview.getByWorktree` IPC) but nothing in the renderer was listening outside the dev-preview pane itself. This closes that gap.

## What changed

**Per-row status indicator** — the `WorktreeHeader` trailing icon group (alongside `EnvironmentPopover`) now shows a `DevServerIndicator`: spinner for `starting`/`installing` (Doherty-gated at 400ms), Globe + port for `running`, error pip for `error`. Ambient secondary signal — no row tint, no banner, no accent color, no toast.

**Dev server filter facet** — `WorktreeFilterPopover` has a new "Dev server" facet with options: Has server / Running / Starting / Error. Session-only, not persisted, so it never greets you with an empty list on the next launch.

**Store + sync** — a new non-persisted `worktreeDevServerStore` (keyed by `worktreeId`) receives `DEV_PREVIEW_STATE_CHANGED` broadcasts via `useWorktreeDevServerStateSync` (mounted at app level). Per-row lazy hydration via `devPreview.getByWorktree` IPC on first render, with a strict `updatedAt <` freshness guard so a slow hydration response can't regress a newer broadcast.

Display-only by design. Interactive actions (restart, stop, output) are tracked in #9098.

`devServerFilters` is threaded through `matchesFilters` / `computeChipCounts` across `SidebarContent`, `WorktreeOverviewModal`, and `worktreeCyclingOrder`; fails safe (excludes) if a caller omits the session map.

## Testing

- Unit: `worktreeDevServerStore` (freshness guard, remove, reset), `useWorktreeDevServerStateSync` (broadcast→store, missing `worktreeId` skip, unmount cleanup), `useWorktreeDevServerSession` (lazy hydrate, cache-hit skip, post-unmount no-write, null result), `worktreeFilters` (`matchesDevServerFilter`, `matchesFilters` dev-server branch, `computeChipCounts` dev-server counts), `worktreeFilterStore` (toggle/clear/count/session-only persistence), `DevServerIndicator` (all states + Doherty gate)
- `npm run check` clean

Closes #9087