### PR TITLE
fix(diagnostics): polish dock tab visuals and pin focus preservation

### DIFF
--- a/e2e/full/panels/core-diagnostics-auto-open.spec.ts
+++ b/e2e/full/panels/core-diagnostics-auto-open.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "@playwright/test";
+import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
+import { SEL } from "../../helpers/selectors";
+import { T_MEDIUM, T_SHORT } from "../../helpers/timeouts";
+
+let ctx: AppContext;
+
+test.describe.serial("Core: Diagnostics Dock — auto-open preserves focus", () => {
+  test.beforeAll(async () => {
+    ctx = await launchApp();
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+  });
+
+  test("auto-promotion to Problems tab does not steal terminal focus", async () => {
+    const { window } = ctx;
+
+    const textarea = window.locator(SEL.terminal.xtermHelperTextarea);
+    await expect(textarea.first()).toBeVisible({ timeout: T_MEDIUM });
+
+    await textarea.first().focus();
+    await expect(textarea.first()).toBeFocused({ timeout: T_SHORT });
+
+    await window.evaluate(() => {
+      window.__DAINTREE_E2E_ADD_ERROR__?.("E2E focus preservation test error");
+    });
+
+    const dock = window.locator(SEL.diagnostics.dock);
+    await expect(dock).toBeVisible({ timeout: T_MEDIUM });
+
+    const problemsTab = window.locator(SEL.diagnostics.tab("problems"));
+    await expect(problemsTab).toHaveAttribute("aria-selected", "true", {
+      timeout: T_SHORT,
+    });
+
+    await expect(textarea.first()).toBeFocused({ timeout: T_SHORT });
+
+    await window.evaluate(() => {
+      window.__DAINTREE_E2E_CLEAR_ERRORS__?.();
+    });
+
+    await window.locator(SEL.diagnostics.closeButton).click();
+    await expect(dock).not.toBeVisible({ timeout: T_SHORT });
+  });
+});

--- a/src/components/Diagnostics/DiagnosticsDock.tsx
+++ b/src/components/Diagnostics/DiagnosticsDock.tsx
@@ -57,10 +57,10 @@ function TabButton({ tab, label, isActive, onClick, badge }: TabButtonProps) {
       {label}
       {badge !== undefined && badge > 0 && (
         <span className="ml-1.5 px-1.5 py-0.5 text-xs tabular-nums bg-status-error/15 text-status-error rounded-full">
-          {badge}
+          {badge > 99 ? "99+" : badge}
         </span>
       )}
-      {isActive && <div className="absolute bottom-0 left-0 right-0 h-px bg-daintree-accent/70" />}
+      {isActive && <div className="absolute bottom-0 left-0 right-0 h-px bg-daintree-text/30" />}
     </button>
   );
 }

--- a/src/components/Diagnostics/__tests__/DiagnosticsDock.test.tsx
+++ b/src/components/Diagnostics/__tests__/DiagnosticsDock.test.tsx
@@ -243,6 +243,48 @@ describe("DiagnosticsDock — separator keyboard resize", () => {
   });
 });
 
+describe("DiagnosticsDock — badge cap", () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  function setErrors(count: number) {
+    useErrorStore.setState({
+      errors: Array.from({ length: count }, (_, i) => ({
+        id: `err-${i}`,
+        type: "unknown" as const,
+        message: `Error ${i}`,
+        retryability: "none" as const,
+        source: "test",
+        timestamp: Date.now(),
+        dismissed: false,
+        fromPreviousSession: false,
+      })),
+    });
+  }
+
+  it("shows exact count when errors <= 99", () => {
+    setErrors(99);
+    const { container } = render(<DiagnosticsDock />);
+    const badge = container.querySelector('[id="diagnostics-problems-tab"] span');
+    expect(badge?.textContent).toBe("99");
+  });
+
+  it("caps at 99+ when errors >= 100", () => {
+    setErrors(100);
+    const { container } = render(<DiagnosticsDock />);
+    const badge = container.querySelector('[id="diagnostics-problems-tab"] span');
+    expect(badge?.textContent).toBe("99+");
+  });
+
+  it("shows no badge when error count is zero", () => {
+    setErrors(0);
+    const { container } = render(<DiagnosticsDock />);
+    const badge = container.querySelector('[id="diagnostics-problems-tab"] span');
+    expect(badge).toBeNull();
+  });
+});
+
 describe("DiagnosticsDock — resize lag suppression", () => {
   beforeEach(() => {
     resetStores();


### PR DESCRIPTION
A few small polish changes to the diagnostics dock tab, plus an e2e spec to make sure we don't accidentally break focus preservation on auto-promotion.

Three changes:

- The active tab underline switches from the accent color to a neutral overlay tone. The jump-to-latest button in the same region owns accent, and the tab indicator shouldn't compete with it.
- The Problems tab count badge caps at `99+` with a stable pill width, so the layout doesn't shift when the count crosses 100.
- A Playwright spec in `e2e/full/panels/` pins the existing auto-promotion behavior -- the dock opens and switches to the Problems tab without stealing DOM focus from the editor or terminal.

Fixes #9138