### PR TITLE
feat(diagnostics): prebuilt redactions, time window, GitHub handoff

### DIFF
--- a/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
@@ -98,14 +98,23 @@ vi.mock("electron", () => ({
 }));
 
 const chmodMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+const readFileMock = vi.hoisted(() => vi.fn(() => Promise.resolve("log line")));
+const statMock = vi.hoisted(() => vi.fn(() => Promise.resolve({ mtimeMs: Date.now() })));
+const existsSyncMock = vi.hoisted(() => vi.fn(() => false));
 
 vi.mock("node:fs", () => ({
   promises: {
-    readFile: vi.fn(() => Promise.resolve("")),
+    readFile: readFileMock,
     chmod: chmodMock,
+    stat: statMock,
   },
   createWriteStream: createWriteStreamMock,
-  existsSync: vi.fn(() => false),
+  existsSync: existsSyncMock,
+}));
+
+vi.mock("../../../utils/logger.js", () => ({
+  getLogFilePath: () => "/logs/daintree.log",
+  getLogDirectory: () => "/logs",
 }));
 
 vi.mock("archiver", () => ({
@@ -165,6 +174,11 @@ describe("registerDiagnosticsHandlers", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // clearAllMocks resets call data but not implementations, so restore the
+    // defaults each test to keep the rotated-log tests isolated.
+    existsSyncMock.mockReturnValue(false);
+    statMock.mockResolvedValue({ mtimeMs: Date.now() });
+    readFileMock.mockResolvedValue("log line");
   });
 
   it("registers all expected IPC handlers", () => {
@@ -258,6 +272,111 @@ describe("registerDiagnosticsHandlers", () => {
 
       expect(result.uptimeSeconds).toBeGreaterThanOrEqual(0);
       expect(result.eventLoopP99Ms).toBe(12);
+    });
+  });
+
+  describe("handleCollectDiagnosticsForReview", () => {
+    it("includes a positive appLaunchTimestamp in the review payload", async () => {
+      registerDiagnosticsHandlers(deps);
+      const handler = getHandlerFn("system:collect-diagnostics-for-review");
+      const result = (await handler()) as {
+        appLaunchTimestamp: number;
+        sectionKeys: string[];
+      };
+
+      expect(typeof result.appLaunchTimestamp).toBe("number");
+      expect(result.appLaunchTimestamp).toBeGreaterThan(0);
+      expect(result.appLaunchTimestamp).toBeLessThanOrEqual(Date.now());
+      expect(result.sectionKeys).toEqual(["metadata"]);
+    });
+  });
+
+  describe("save-bundle time window", () => {
+    const readPaths = () => readFileMock.mock.calls.map((c: unknown[]) => c[0] as string);
+
+    it("skips rotated logs whose mtime predates the window, keeps recent ones", async () => {
+      existsSyncMock.mockImplementation(
+        (p: string) =>
+          p === "/logs/daintree.log" || p === "/logs/daintree.log.1" || p === "/logs/daintree.log.2"
+      );
+      // Window cutoff = 5000ms. .1 is older (skip), .2 is newer (keep).
+      statMock.mockImplementation((p: string) =>
+        Promise.resolve({ mtimeMs: p === "/logs/daintree.log.1" ? 4000 : 6000 })
+      );
+      dialogMock.showSaveDialog.mockResolvedValueOnce({
+        filePath: "/tmp/diagnostics.zip",
+        canceled: false,
+      });
+
+      registerDiagnosticsHandlers(deps);
+      const handler = getHandlerFn("system:save-diagnostics-bundle");
+      await handler(
+        {},
+        {
+          payload: { metadata: {} },
+          enabledSections: { metadata: true, logs: true },
+          replacements: [],
+          timeWindowStartMs: 5000,
+        }
+      );
+
+      const paths = readPaths();
+      expect(paths).toContain("/logs/daintree.log");
+      expect(paths).toContain("/logs/daintree.log.2");
+      expect(paths).not.toContain("/logs/daintree.log.1");
+    });
+
+    it("includes all rotated logs and never stats them when the window is full history", async () => {
+      existsSyncMock.mockImplementation(
+        (p: string) =>
+          p === "/logs/daintree.log" || p === "/logs/daintree.log.1" || p === "/logs/daintree.log.2"
+      );
+      dialogMock.showSaveDialog.mockResolvedValueOnce({
+        filePath: "/tmp/diagnostics.zip",
+        canceled: false,
+      });
+
+      registerDiagnosticsHandlers(deps);
+      const handler = getHandlerFn("system:save-diagnostics-bundle");
+      await handler(
+        {},
+        {
+          payload: { metadata: {} },
+          enabledSections: { metadata: true, logs: true },
+          replacements: [],
+          timeWindowStartMs: null,
+        }
+      );
+
+      const paths = readPaths();
+      expect(paths).toContain("/logs/daintree.log.1");
+      expect(paths).toContain("/logs/daintree.log.2");
+      expect(statMock).not.toHaveBeenCalled();
+    });
+
+    it("includes a rotated log when its stat fails rather than dropping it", async () => {
+      existsSyncMock.mockImplementation(
+        (p: string) => p === "/logs/daintree.log" || p === "/logs/daintree.log.1"
+      );
+      statMock.mockRejectedValue(new Error("stat failed"));
+      dialogMock.showSaveDialog.mockResolvedValueOnce({
+        filePath: "/tmp/diagnostics.zip",
+        canceled: false,
+      });
+
+      registerDiagnosticsHandlers(deps);
+      const handler = getHandlerFn("system:save-diagnostics-bundle");
+      await handler(
+        {},
+        {
+          payload: { metadata: {} },
+          enabledSections: { metadata: true, logs: true },
+          replacements: [],
+          timeWindowStartMs: 5000,
+        }
+      );
+
+      expect(readPaths()).toContain("/logs/daintree.log.1");
     });
   });
 

--- a/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
@@ -97,10 +97,18 @@ vi.mock("electron", () => ({
   },
 }));
 
-const chmodMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
-const readFileMock = vi.hoisted(() => vi.fn(() => Promise.resolve("log line")));
-const statMock = vi.hoisted(() => vi.fn(() => Promise.resolve({ mtimeMs: Date.now() })));
-const existsSyncMock = vi.hoisted(() => vi.fn(() => false));
+const chmodMock = vi.hoisted(() =>
+  vi.fn<(path: string, mode: number) => Promise<void>>(() => Promise.resolve())
+);
+const readFileMock = vi.hoisted(() =>
+  vi.fn<(path: string) => Promise<string>>(() => Promise.resolve("log line"))
+);
+const statMock = vi.hoisted(() =>
+  vi.fn<(path: string) => Promise<{ mtimeMs: number }>>(() =>
+    Promise.resolve({ mtimeMs: Date.now() })
+  )
+);
+const existsSyncMock = vi.hoisted(() => vi.fn<(path: string) => boolean>(() => false));
 
 vi.mock("node:fs", () => ({
   promises: {
@@ -296,12 +304,13 @@ describe("registerDiagnosticsHandlers", () => {
 
     it("skips rotated logs whose mtime predates the window, keeps recent ones", async () => {
       existsSyncMock.mockImplementation(
-        (p: string) =>
+        (p: string): boolean =>
           p === "/logs/daintree.log" || p === "/logs/daintree.log.1" || p === "/logs/daintree.log.2"
       );
       // Window cutoff = 5000ms. .1 is older (skip), .2 is newer (keep).
-      statMock.mockImplementation((p: string) =>
-        Promise.resolve({ mtimeMs: p === "/logs/daintree.log.1" ? 4000 : 6000 })
+      statMock.mockImplementation(
+        (p: string): Promise<{ mtimeMs: number }> =>
+          Promise.resolve({ mtimeMs: p === "/logs/daintree.log.1" ? 4000 : 6000 })
       );
       dialogMock.showSaveDialog.mockResolvedValueOnce({
         filePath: "/tmp/diagnostics.zip",
@@ -328,7 +337,7 @@ describe("registerDiagnosticsHandlers", () => {
 
     it("includes all rotated logs and never stats them when the window is full history", async () => {
       existsSyncMock.mockImplementation(
-        (p: string) =>
+        (p: string): boolean =>
           p === "/logs/daintree.log" || p === "/logs/daintree.log.1" || p === "/logs/daintree.log.2"
       );
       dialogMock.showSaveDialog.mockResolvedValueOnce({
@@ -356,7 +365,7 @@ describe("registerDiagnosticsHandlers", () => {
 
     it("includes a rotated log when its stat fails rather than dropping it", async () => {
       existsSyncMock.mockImplementation(
-        (p: string) => p === "/logs/daintree.log" || p === "/logs/daintree.log.1"
+        (p: string): boolean => p === "/logs/daintree.log" || p === "/logs/daintree.log.1"
       );
       statMock.mockRejectedValue(new Error("stat failed"));
       dialogMock.showSaveDialog.mockResolvedValueOnce({

--- a/electron/ipc/handlers/diagnostics.ts
+++ b/electron/ipc/handlers/diagnostics.ts
@@ -33,6 +33,7 @@ import { getLogFilePath, getLogDirectory } from "../../utils/logger.js";
 import { safeStringify } from "../../utils/safeStringify.js";
 import {
   filterSections,
+  filterLogEntriesByTime,
   applyReplacements,
   type ReplacementRule,
 } from "../../../shared/utils/diagnosticsTransform.js";
@@ -40,11 +41,19 @@ import { typedHandle, typedHandleWithContext } from "../utils.js";
 
 let eventLoopHistogram: IntervalHistogram | null = null;
 
+// Approximate epoch the app process started. Captured at module evaluation
+// (the diagnostics handler is eagerly imported during startup) rather than
+// from `Date.now() - process.uptime() * 1000` at call time, which drifts
+// because `process.uptime()` pauses during OS sleep while `Date.now()` does
+// not. Backs the "Since application launch" time-window option.
+const APP_LAUNCH_TIMESTAMP = Date.now();
+
 async function writeBundleZip(
   zipPath: string,
   jsonContent: string,
   includeLogs: boolean,
-  replacements: ReplacementRule[]
+  replacements: ReplacementRule[],
+  timeWindowStartMs: number | null
 ): Promise<void> {
   const logDir = getLogDirectory();
   const logFile = getLogFilePath();
@@ -52,6 +61,7 @@ async function writeBundleZip(
   const logEntries: Array<{ name: string; content: string }> = [];
 
   if (includeLogs) {
+    // The active log is always current, so it's never time-filtered here.
     if (existsSync(logFile)) {
       const raw = await fs.readFile(logFile, "utf-8");
       logEntries.push({ name: "daintree.log", content: applyReplacements(raw, replacements) });
@@ -59,13 +69,25 @@ async function writeBundleZip(
 
     for (let i = 1; i <= 5; i++) {
       const rotated = path.join(logDir, `daintree.log.${i}`);
-      if (existsSync(rotated)) {
-        const raw = await fs.readFile(rotated, "utf-8");
-        logEntries.push({
-          name: `daintree.log.${i}`,
-          content: applyReplacements(raw, replacements),
-        });
+      if (!existsSync(rotated)) continue;
+
+      if (timeWindowStartMs !== null) {
+        try {
+          const stat = await fs.stat(rotated);
+          // Skip rotated files last written before the window. `mtime`
+          // over-includes a freshly-rotated file holding mostly old lines —
+          // the accepted failure mode (over-include rather than drop).
+          if (stat.mtimeMs < timeWindowStartMs) continue;
+        } catch {
+          // stat failed — include rather than silently drop relevant lines.
+        }
       }
+
+      const raw = await fs.readFile(rotated, "utf-8");
+      logEntries.push({
+        name: `daintree.log.${i}`,
+        content: applyReplacements(raw, replacements),
+      });
     }
   }
 
@@ -252,7 +274,7 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
     const { collectDiagnosticsWithKeys } = await getDiagnosticsCollector();
     const { payload, sectionKeys } = await collectDiagnosticsWithKeys(deps);
     const previewJson = safeStringify(payload, 2);
-    return { payload, sectionKeys, previewJson };
+    return { payload, sectionKeys, previewJson, appLaunchTimestamp: APP_LAUNCH_TIMESTAMP };
   };
   handlers.push(
     typedHandle(CHANNELS.SYSTEM_COLLECT_DIAGNOSTICS_FOR_REVIEW, handleCollectDiagnosticsForReview)
@@ -261,7 +283,11 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
   const handleSaveDiagnosticsBundle = async (
     savePayload: DiagnosticsBundleSavePayload
   ): Promise<boolean> => {
-    const filtered = filterSections(savePayload.payload, savePayload.enabledSections);
+    const timeWindowStartMs = savePayload.timeWindowStartMs ?? null;
+    const filtered = filterLogEntriesByTime(
+      filterSections(savePayload.payload, savePayload.enabledSections),
+      timeWindowStartMs
+    );
     let json = safeStringify(filtered, 2);
     json = applyReplacements(json, savePayload.replacements as ReplacementRule[]);
 
@@ -284,7 +310,8 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
       filePath,
       json,
       includeLogs,
-      savePayload.replacements as ReplacementRule[]
+      savePayload.replacements as ReplacementRule[],
+      timeWindowStartMs
     );
     shell.showItemInFolder(filePath);
     return true;

--- a/shared/types/ipc/system.ts
+++ b/shared/types/ipc/system.ts
@@ -245,6 +245,12 @@ export interface DiagnosticsReviewPayload {
   sectionKeys: string[];
   /** Safe-stringified JSON preview (already redacted). */
   previewJson: string;
+  /**
+   * Approximate epoch (ms) the app process started, captured in the main
+   * process. Backs the "Since application launch" time-window option so the
+   * renderer can compute an absolute cutoff without a separate IPC round-trip.
+   */
+  appLaunchTimestamp: number;
 }
 
 /** User selections sent to the save-bundle IPC. */
@@ -254,7 +260,13 @@ export interface DiagnosticsBundleSavePayload {
   /** Sections the user chose to include. */
   enabledSections: Record<string, boolean>;
   /** Find-and-replace redaction rules. */
-  replacements: Array<{ find: string; replace: string }>;
+  replacements: Array<{ kind?: "literal" | "regex"; find: string; replace: string }>;
+  /**
+   * Absolute epoch (ms) cutoff for log inclusion. Entries and rotated log
+   * files older than this are excluded from the bundle. `null`/omitted means
+   * full history (no time bound).
+   */
+  timeWindowStartMs?: number | null;
 }
 
 /** Payload for starting an agent install via setup wizard */

--- a/shared/utils/__tests__/diagnosticsTransform.test.ts
+++ b/shared/utils/__tests__/diagnosticsTransform.test.ts
@@ -73,6 +73,15 @@ describe("PREBUILT_REDACTIONS", () => {
     expect(apply("ip", "at 12:34:56 today")).toBe("at 12:34:56 today");
   });
 
+  it("does not mangle C++/TS scope-resolution symbols as IPv6", () => {
+    expect(apply("ip", "frame std::vector<int> here")).toBe("frame std::vector<int> here");
+    expect(apply("ip", "in namespace::type::method")).toBe("in namespace::type::method");
+  });
+
+  it("does not redact a quad embedded in a longer dotted run", () => {
+    expect(apply("ip", "version 1.2.3.4.5 build")).toBe("version 1.2.3.4.5 build");
+  });
+
   it("strips POSIX absolute file paths", () => {
     expect(apply("filepath", "open /Users/greg/secret/file.log please")).toBe(
       "open [REDACTED] please"

--- a/shared/utils/__tests__/diagnosticsTransform.test.ts
+++ b/shared/utils/__tests__/diagnosticsTransform.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyReplacements,
+  filterLogEntriesByTime,
+  filterSections,
+  PREBUILT_REDACTIONS,
+  type ReplacementRule,
+} from "../diagnosticsTransform.js";
+
+describe("applyReplacements", () => {
+  it("applies a literal rule by default (no kind)", () => {
+    const rules: ReplacementRule[] = [{ find: "secret", replace: "[X]" }];
+    expect(applyReplacements("a secret and secret", rules)).toBe("a [X] and [X]");
+  });
+
+  it("treats kind:'literal' the same as the default", () => {
+    const rules: ReplacementRule[] = [{ kind: "literal", find: "a.b", replace: "X" }];
+    // Literal: the "." is not a wildcard, so "axb" is untouched.
+    expect(applyReplacements("a.b axb", rules)).toBe("X axb");
+  });
+
+  it("applies a regex rule globally", () => {
+    const rules: ReplacementRule[] = [{ kind: "regex", find: "\\d+", replace: "#" }];
+    expect(applyReplacements("a1 b22 c333", rules)).toBe("a# b# c#");
+  });
+
+  it("silently skips an uncompilable regex pattern without throwing", () => {
+    const rules: ReplacementRule[] = [
+      { kind: "regex", find: "(", replace: "X" },
+      { kind: "regex", find: "b", replace: "B" },
+    ];
+    // Bad pattern skipped; the valid one still applies.
+    expect(applyReplacements("a b c", rules)).toBe("a B c");
+  });
+
+  it("skips rules with an empty find", () => {
+    const rules: ReplacementRule[] = [{ find: "", replace: "X" }];
+    expect(applyReplacements("unchanged", rules)).toBe("unchanged");
+  });
+
+  it("applies rules in order (earlier rules see the original, later see prior output)", () => {
+    const rules: ReplacementRule[] = [
+      { kind: "regex", find: "foo", replace: "bar" },
+      { find: "bar", replace: "baz" },
+    ];
+    expect(applyReplacements("foo", rules)).toBe("baz");
+  });
+});
+
+describe("PREBUILT_REDACTIONS", () => {
+  const apply = (id: string, input: string): string => {
+    const preset = PREBUILT_REDACTIONS.find((p) => p.id === id);
+    if (!preset) throw new Error(`no preset ${id}`);
+    return applyReplacements(input, preset.rules);
+  };
+
+  it("strips email addresses", () => {
+    expect(apply("email", "contact greg@example.com now")).toBe("contact [REDACTED] now");
+  });
+
+  it("strips IPv4 addresses", () => {
+    expect(apply("ip", "host 192.168.1.42 down")).toBe("host [REDACTED] down");
+  });
+
+  it("strips full and compressed IPv6 addresses", () => {
+    expect(apply("ip", "addr 2001:0db8:85a3:0000:0000:8a2e:0370:7334 ok")).toBe(
+      "addr [REDACTED] ok"
+    );
+    expect(apply("ip", "loopback ::1 here")).toBe("loopback [REDACTED] here");
+  });
+
+  it("does not mangle HH:MM:SS timestamps as IPv6", () => {
+    expect(apply("ip", "at 12:34:56 today")).toBe("at 12:34:56 today");
+  });
+
+  it("strips POSIX absolute file paths", () => {
+    expect(apply("filepath", "open /Users/greg/secret/file.log please")).toBe(
+      "open [REDACTED] please"
+    );
+  });
+
+  it("strips Windows drive-letter paths", () => {
+    expect(apply("filepath", "open C:\\Users\\greg\\file.log please")).toBe(
+      "open [REDACTED] please"
+    );
+  });
+
+  it("every prebuilt rule compiles as a valid global regex", () => {
+    for (const preset of PREBUILT_REDACTIONS) {
+      for (const rule of preset.rules) {
+        expect(rule.kind).toBe("regex");
+        expect(() => new RegExp(rule.find, "g")).not.toThrow();
+      }
+    }
+  });
+});
+
+describe("filterSections", () => {
+  it("removes sections explicitly disabled, keeps the rest", () => {
+    const payload = { a: 1, b: 2, c: 3 };
+    expect(filterSections(payload, { a: true, b: false })).toEqual({ a: 1, c: 3 });
+  });
+});
+
+describe("filterLogEntriesByTime", () => {
+  const payload = () => ({
+    logs: {
+      totalEntries: 3,
+      recentEntries: [
+        { id: "1", timestamp: 100, message: "old" },
+        { id: "2", timestamp: 200, message: "mid" },
+        { id: "3", timestamp: 300, message: "new" },
+      ],
+    },
+  });
+
+  it("is a no-op when startMs is null", () => {
+    const p = payload();
+    expect(filterLogEntriesByTime(p, null)).toBe(p);
+  });
+
+  it("drops entries older than the cutoff", () => {
+    const result = filterLogEntriesByTime(payload(), 200) as {
+      logs: { recentEntries: Array<{ id: string }> };
+    };
+    expect(result.logs.recentEntries.map((e) => e.id)).toEqual(["2", "3"]);
+  });
+
+  it("does not mutate the input payload", () => {
+    const p = payload();
+    filterLogEntriesByTime(p, 300);
+    expect(p.logs.recentEntries).toHaveLength(3);
+  });
+
+  it("keeps entries lacking a numeric timestamp rather than dropping them", () => {
+    const p = { logs: { recentEntries: [{ id: "x" }, { id: "y", timestamp: 50 }] } };
+    const result = filterLogEntriesByTime(p, 100) as {
+      logs: { recentEntries: Array<{ id: string }> };
+    };
+    expect(result.logs.recentEntries.map((e) => e.id)).toEqual(["x"]);
+  });
+
+  it("tolerates a missing or non-array logs section", () => {
+    expect(filterLogEntriesByTime({}, 100)).toEqual({});
+    expect(filterLogEntriesByTime({ logs: { error: "failed" } }, 100)).toEqual({
+      logs: { error: "failed" },
+    });
+  });
+});

--- a/shared/utils/__tests__/githubIssueUrl.test.ts
+++ b/shared/utils/__tests__/githubIssueUrl.test.ts
@@ -54,6 +54,16 @@ describe("buildDiagnosticsIssueUrl", () => {
     const encoded = encodeURIComponent(body(buildDiagnosticsIssueUrl(meta))).length;
     expect(encoded).toBeLessThanOrEqual(URL_BODY_BUDGET);
   });
+
+  it("caps the body even when metadata fields are pathologically long", () => {
+    const url = buildDiagnosticsIssueUrl({
+      appVersion: "x".repeat(2000),
+      electronVersion: "y".repeat(2000),
+      nodeVersion: "z".repeat(2000),
+      osVersion: "w".repeat(2000),
+    });
+    expect(encodeURIComponent(body(url)).length).toBeLessThanOrEqual(URL_BODY_BUDGET);
+  });
 });
 
 describe("capForBudget", () => {

--- a/shared/utils/__tests__/githubIssueUrl.test.ts
+++ b/shared/utils/__tests__/githubIssueUrl.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildDiagnosticsIssueUrl,
+  capForBudget,
+  makeUrl,
+  REPO_ISSUE_URL,
+  truncateStackMiddle,
+  TITLE_ENCODED_BUDGET,
+  URL_BODY_BUDGET,
+} from "../githubIssueUrl.js";
+
+function body(url: string): string {
+  return new URL(url).searchParams.get("body") ?? "";
+}
+
+function title(url: string): string {
+  return new URL(url).searchParams.get("title") ?? "";
+}
+
+describe("buildDiagnosticsIssueUrl", () => {
+  const meta = {
+    appVersion: "1.2.3",
+    electronVersion: "41.0.0",
+    nodeVersion: "22.0.0",
+    platform: "darwin",
+    osVersion: "Darwin 25.5.0",
+  };
+
+  it("targets the repo issue form", () => {
+    expect(buildDiagnosticsIssueUrl(meta).startsWith(REPO_ISSUE_URL)).toBe(true);
+  });
+
+  it("includes the environment summary", () => {
+    const b = body(buildDiagnosticsIssueUrl(meta));
+    expect(b).toContain("1.2.3");
+    expect(b).toContain("41.0.0");
+    expect(b).toContain("22.0.0");
+    expect(b).toContain("darwin");
+    expect(b).toContain("Darwin 25.5.0");
+  });
+
+  it("includes the repro skeleton and the ZIP attachment note", () => {
+    const b = body(buildDiagnosticsIssueUrl(meta));
+    expect(b).toContain("Steps to reproduce");
+    expect(b).toContain("drag the saved ZIP into this issue");
+  });
+
+  it("falls back to an unknown marker when no metadata is given", () => {
+    const b = body(buildDiagnosticsIssueUrl({}));
+    expect(b).toContain("_(unknown)_");
+  });
+
+  it("stays within the encoded URL body budget", () => {
+    const encoded = encodeURIComponent(body(buildDiagnosticsIssueUrl(meta))).length;
+    expect(encoded).toBeLessThanOrEqual(URL_BODY_BUDGET);
+  });
+});
+
+describe("capForBudget", () => {
+  it("returns short values unchanged", () => {
+    expect(capForBudget("hello", 100)).toBe("hello");
+  });
+
+  it("truncates with an ellipsis and fits the budget", () => {
+    const result = capForBudget("a".repeat(500), 100);
+    expect(result.endsWith("…")).toBe(true);
+    expect(encodeURIComponent(result).length).toBeLessThanOrEqual(100);
+  });
+
+  it("does not slice into a multi-byte surrogate pair", () => {
+    const result = capForBudget("😀".repeat(100), 20);
+    // Each "😀" encodes to 12 bytes via encodeURIComponent; the result must
+    // still be a valid string (no lone surrogate) and fit the budget.
+    expect(encodeURIComponent(result).length).toBeLessThanOrEqual(20);
+    expect([...result].every((c) => c === "😀" || c === "…")).toBe(true);
+  });
+});
+
+describe("makeUrl", () => {
+  it("caps an over-long title to the title budget", () => {
+    const url = makeUrl("T".repeat(1000), "body");
+    expect(encodeURIComponent(title(url)).length).toBeLessThanOrEqual(TITLE_ENCODED_BUDGET);
+  });
+});
+
+describe("truncateStackMiddle", () => {
+  it("leaves a short stack untouched", () => {
+    const stack = "line1\nline2\nline3";
+    expect(truncateStackMiddle(stack)).toBe(stack);
+  });
+
+  it("middle-truncates a long stack with a visible placeholder", () => {
+    const stack = Array.from({ length: 40 }, (_, i) => `frame ${i}`).join("\n");
+    const result = truncateStackMiddle(stack);
+    expect(result).toContain("middle frames truncated");
+    expect(result.split("\n").length).toBeLessThan(40);
+    // Head and tail frames are preserved.
+    expect(result).toContain("frame 0");
+    expect(result).toContain("frame 39");
+  });
+});

--- a/shared/utils/buildCrashReportUrl.ts
+++ b/shared/utils/buildCrashReportUrl.ts
@@ -1,23 +1,6 @@
 import type { ActionBreadcrumb, CrashLogEntry } from "../types/ipc/crashRecovery.js";
 import { scrubReportText } from "./reportScrubbers.js";
-
-const REPO_ISSUE_URL = "https://github.com/daintreehq/daintree/issues/new";
-
-// GitHub's Nginx fronts the issue form at an 8 KiB URL hard cap. Reserve ~1 KiB
-// for base URL + title + percent-encoding fudge, leaving ~7 KB for the encoded
-// body. Mirrors URL_BODY_BUDGET in src/components/ErrorBoundary/buildReportIssueUrl.ts
-// (duplicated here to avoid a shared → src reverse dependency).
-const URL_BODY_BUDGET = 7000;
-const TITLE_ENCODED_BUDGET = 200;
-
-// When the stack must be middle-truncated we keep the top frames (where the
-// throw originates) and the tail (where it bubbled up). 15+5 fits a typical
-// crash stack while leaving the truncation visible.
-const STACK_HEAD_LINES = 15;
-const STACK_TAIL_LINES = 5;
-
-const STACK_MIDDLE_PLACEHOLDER =
-  "  ... [middle frames truncated — see clipboard for full stack] ...";
+import { URL_BODY_BUDGET, capForBudget, makeUrl, truncateStackMiddle } from "./githubIssueUrl.js";
 
 export interface CrashReportResult {
   url: string;
@@ -186,29 +169,6 @@ function formatCrashBody(
   return scrubReportText(lines.join("\n"));
 }
 
-function truncateStackMiddle(stack: string): string {
-  const lines = stack.split("\n");
-  if (lines.length <= STACK_HEAD_LINES + STACK_TAIL_LINES) return stack;
-  const head = lines.slice(0, STACK_HEAD_LINES);
-  const tail = lines.slice(-STACK_TAIL_LINES);
-  return [...head, STACK_MIDDLE_PLACEHOLDER, ...tail].join("\n");
-}
-
-function capForBudget(value: string, budget: number): string {
-  if (encodeURIComponent(value).length <= budget) return value;
-  const ellipsis = "…";
-  const ellipsisLen = encodeURIComponent(ellipsis).length;
-  const chars = Array.from(value);
-  while (chars.length > 0) {
-    const trimmed = chars.join("");
-    if (encodeURIComponent(trimmed).length + ellipsisLen <= budget) {
-      return trimmed + ellipsis;
-    }
-    chars.pop();
-  }
-  return ellipsis;
-}
-
 function buildStubBody(entry: CrashLogEntry): string {
   const message = entry.errorMessage || "Daintree closed unexpectedly";
   return scrubReportText(
@@ -217,10 +177,6 @@ function buildStubBody(entry: CrashLogEntry): string {
       `**Daintree ${entry.appVersion}** on ${entry.platform} ${entry.arch}\n` +
       `**Error:** ${capForBudget(message, 1000)}\n`
   );
-}
-
-function makeUrl(title: string, body: string): string {
-  return `${REPO_ISSUE_URL}?title=${encodeURIComponent(capForBudget(title, TITLE_ENCODED_BUDGET))}&body=${encodeURIComponent(body)}`;
 }
 
 function makeCrashTitle(entry: CrashLogEntry): string {

--- a/shared/utils/diagnosticsTransform.ts
+++ b/shared/utils/diagnosticsTransform.ts
@@ -5,6 +5,11 @@
  */
 
 export interface ReplacementRule {
+  /**
+   * Match mode. `"literal"` (the back-compat default when omitted) does a plain
+   * substring replace; `"regex"` compiles `find` as a global `RegExp`.
+   */
+  kind?: "literal" | "regex";
   find: string;
   replace: string;
 }
@@ -26,15 +31,48 @@ export function filterSections(
 /** Apply find-and-replace redactions to a JSON string. */
 export function applyReplacements(json: string, rules: ReplacementRule[]): string {
   let out = json;
-  for (const { find, replace } of rules) {
-    if (!find) continue;
+  for (const rule of rules) {
+    if (!rule.find) continue;
     try {
-      out = out.split(find).join(replace);
+      if (rule.kind === "regex") {
+        out = out.replace(new RegExp(rule.find, "g"), rule.replace);
+      } else {
+        out = out.split(rule.find).join(rule.replace);
+      }
     } catch {
-      // Skip invalid replacements
+      // Skip invalid replacements (e.g. an uncompilable regex pattern), the
+      // same way an empty `find` is skipped above.
     }
   }
   return out;
+}
+
+/**
+ * Drop `logs.recentEntries` older than `startMs` (ms epoch). Returns a new
+ * payload (input is not mutated) so the renderer preview and the main-process
+ * save apply identical filtering. `null` is a no-op (full history). Entries
+ * that lack a numeric `timestamp` are kept rather than silently dropped.
+ */
+export function filterLogEntriesByTime(
+  payload: Record<string, unknown>,
+  startMs: number | null
+): Record<string, unknown> {
+  if (startMs === null) return payload;
+  const logs = payload.logs;
+  if (!logs || typeof logs !== "object") return payload;
+  const entries = (logs as { recentEntries?: unknown }).recentEntries;
+  if (!Array.isArray(entries)) return payload;
+  const kept = entries.filter((e) => {
+    if (
+      e &&
+      typeof e === "object" &&
+      typeof (e as { timestamp?: unknown }).timestamp === "number"
+    ) {
+      return (e as { timestamp: number }).timestamp >= startMs;
+    }
+    return true;
+  });
+  return { ...payload, logs: { ...(logs as Record<string, unknown>), recentEntries: kept } };
 }
 
 /** Section metadata for the review dialog. */
@@ -42,6 +80,64 @@ export interface DiagnosticSectionMeta {
   key: string;
   label: string;
 }
+
+/** Identifies a prebuilt one-click redaction toggle in the review dialog. */
+export type PrebuiltRedactionId = "email" | "ip" | "filepath";
+
+/** A prebuilt redaction toggle: a label plus the regex rules it contributes. */
+export interface PrebuiltRedaction {
+  id: PrebuiltRedactionId;
+  label: string;
+  /** Regex rules prepended (in order) to the user's rules when the toggle is on. */
+  rules: ReplacementRule[];
+}
+
+const REDACTED = "[REDACTED]";
+
+const regexRule = (pattern: RegExp): ReplacementRule => ({
+  kind: "regex",
+  find: pattern.source,
+  replace: REDACTED,
+});
+
+/**
+ * Canonical one-click redaction patterns surfaced above the find/replace rows.
+ * Patterns are bounded (no nested unbounded quantifiers over overlapping
+ * classes) so they stay ReDoS-safe. These are best-effort heuristics over free
+ * text and may over- or under-match; they only run when the user opts in. There
+ * is deliberately no token/credential toggle — `secretScrubber` already scrubs
+ * vendor secret sigils on every string before the review dialog renders.
+ */
+export const PREBUILT_REDACTIONS: PrebuiltRedaction[] = [
+  {
+    id: "email",
+    label: "Strip email addresses",
+    rules: [regexRule(/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/)],
+  },
+  {
+    id: "ip",
+    label: "Strip IP addresses (v4/v6)",
+    rules: [
+      regexRule(
+        /(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/
+      ),
+      // Full-form IPv6 requires 4+ groups so `HH:MM:SS` timestamps don't match.
+      regexRule(/(?:[0-9A-Fa-f]{1,4}:){3,7}[0-9A-Fa-f]{1,4}/),
+      // Compressed `::` form (e.g. `fe80::1`, `::1`).
+      regexRule(/(?:[0-9A-Fa-f]{1,4})?::(?:[0-9A-Fa-f]{1,4}:?){0,7}/),
+    ],
+  },
+  {
+    id: "filepath",
+    label: "Strip absolute file paths",
+    rules: [
+      // POSIX absolute path with 2+ segments (avoids mangling every lone `/`).
+      regexRule(/\/(?:[^\s/"\\]+\/)+[^\s/"\\]+/),
+      // Windows drive-letter path.
+      regexRule(/[A-Za-z]:\\(?:[^\\/\s"]+\\)*[^\\/\s"]*/),
+    ],
+  },
+];
 
 /** Human-readable labels for the twelve diagnostic sections. */
 export const SECTION_LABELS: Record<string, string> = {

--- a/shared/utils/diagnosticsTransform.ts
+++ b/shared/utils/diagnosticsTransform.ts
@@ -118,13 +118,19 @@ export const PREBUILT_REDACTIONS: PrebuiltRedaction[] = [
     id: "ip",
     label: "Strip IP addresses (v4/v6)",
     rules: [
+      // `(?<![\w.])`/`(?![\w.])` keep the quad from matching inside a longer
+      // dotted run (e.g. `1.2.3.4.5`); a standalone 4-part version is still
+      // IP-shaped and gets redacted — an accepted opt-in limitation.
       regexRule(
-        /(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/
+        /(?<![\w.])(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(?![\w.])/
       ),
       // Full-form IPv6 requires 4+ groups so `HH:MM:SS` timestamps don't match.
-      regexRule(/(?:[0-9A-Fa-f]{1,4}:){3,7}[0-9A-Fa-f]{1,4}/),
-      // Compressed `::` form (e.g. `fe80::1`, `::1`).
-      regexRule(/(?:[0-9A-Fa-f]{1,4})?::(?:[0-9A-Fa-f]{1,4}:?){0,7}/),
+      // The leading `(?<!\w)` stops a match from starting mid-identifier.
+      regexRule(/(?<!\w)(?:[0-9A-Fa-f]{1,4}:){3,7}[0-9A-Fa-f]{1,4}/),
+      // Compressed `::` form (e.g. `fe80::1`, `::1`). The `(?<!\w)` guard stops
+      // the trailing hex char of an identifier from anchoring the match, so
+      // source symbols like `std::vector` are left intact.
+      regexRule(/(?<!\w)(?:[0-9A-Fa-f]{1,4})?::(?:[0-9A-Fa-f]{1,4}:?){0,7}/),
     ],
   },
   {

--- a/shared/utils/githubIssueUrl.ts
+++ b/shared/utils/githubIssueUrl.ts
@@ -70,9 +70,10 @@ export interface DiagnosticsIssueMetadata {
 
 /**
  * Build the GitHub issue URL paired with a saved diagnostics bundle. The body
- * is a short, static template (env summary + repro skeleton + ZIP note), so no
- * staged truncation is needed — but it still routes through `makeUrl` and the
- * shared title budget so a malformed version string can't blow the URL cap.
+ * is a short, static template (env summary + repro skeleton + ZIP note). The
+ * env values come from controlled system APIs so they're short in practice,
+ * but the body is still capped to the shared budget so a pathological version
+ * string can't blow the URL cap, and the title routes through `makeUrl`.
  */
 export function buildDiagnosticsIssueUrl(metadata: DiagnosticsIssueMetadata): string {
   const envParts: string[] = [];
@@ -91,5 +92,5 @@ export function buildDiagnosticsIssueUrl(metadata: DiagnosticsIssueMetadata): st
     `---\n\n` +
     `Diagnostics bundle attached separately — drag the saved ZIP into this issue.\n`;
 
-  return makeUrl("Diagnostics report", body);
+  return makeUrl("Diagnostics report", capForBudget(body, URL_BODY_BUDGET));
 }

--- a/shared/utils/githubIssueUrl.ts
+++ b/shared/utils/githubIssueUrl.ts
@@ -1,0 +1,95 @@
+/**
+ * Shared GitHub `issues/new` URL primitives. GitHub's Nginx fronts the issue
+ * form at an ~8 KiB URL hard cap; the body budget below also stays under the
+ * Windows `shell.openExternal` ~2,048-char ceiling. Extracted so the error
+ * boundary, crash reporter, and diagnostics bundle share one budget and one
+ * truncation ladder instead of duplicating the constants.
+ */
+
+export const REPO_ISSUE_URL = "https://github.com/daintreehq/daintree/issues/new";
+
+/**
+ * Encoded-body budget. Reserve ~1 KiB for base URL + title + percent-encoding
+ * fudge, leaving ~7 KB for the encoded body. Measured against
+ * `encodeURIComponent` because newlines and backticks inflate 1→3 bytes.
+ */
+export const URL_BODY_BUDGET = 7000;
+
+/** Encoded-title budget, capped separately so a long title can't blow the cap. */
+export const TITLE_ENCODED_BUDGET = 200;
+
+// When a stack must be middle-truncated we keep the top frames (where the throw
+// originates) and the tail (where it bubbled up). 15+5 fits a typical stack
+// while leaving the truncation visible.
+const STACK_HEAD_LINES = 15;
+const STACK_TAIL_LINES = 5;
+
+export const STACK_MIDDLE_PLACEHOLDER =
+  "  ... [middle frames truncated — see clipboard for full stack] ...";
+
+export function truncateStackMiddle(stack: string): string {
+  const lines = stack.split("\n");
+  if (lines.length <= STACK_HEAD_LINES + STACK_TAIL_LINES) return stack;
+  const head = lines.slice(0, STACK_HEAD_LINES);
+  const tail = lines.slice(-STACK_TAIL_LINES);
+  return [...head, STACK_MIDDLE_PLACEHOLDER, ...tail].join("\n");
+}
+
+/**
+ * Trim `value` until its `encodeURIComponent` length fits `budget`, leaving
+ * room for a trailing ellipsis. Walks by character to avoid slicing into a
+ * multi-byte surrogate pair.
+ */
+export function capForBudget(value: string, budget: number): string {
+  if (encodeURIComponent(value).length <= budget) return value;
+  const ellipsis = "…";
+  const ellipsisLen = encodeURIComponent(ellipsis).length;
+  const chars = Array.from(value);
+  while (chars.length > 0) {
+    const trimmed = chars.join("");
+    if (encodeURIComponent(trimmed).length + ellipsisLen <= budget) {
+      return trimmed + ellipsis;
+    }
+    chars.pop();
+  }
+  return ellipsis;
+}
+
+export function makeUrl(title: string, body: string): string {
+  return `${REPO_ISSUE_URL}?title=${encodeURIComponent(capForBudget(title, TITLE_ENCODED_BUDGET))}&body=${encodeURIComponent(body)}`;
+}
+
+/** Environment fields rendered into the diagnostics issue body summary. */
+export interface DiagnosticsIssueMetadata {
+  appVersion?: string;
+  electronVersion?: string;
+  nodeVersion?: string;
+  platform?: string;
+  osVersion?: string;
+}
+
+/**
+ * Build the GitHub issue URL paired with a saved diagnostics bundle. The body
+ * is a short, static template (env summary + repro skeleton + ZIP note), so no
+ * staged truncation is needed — but it still routes through `makeUrl` and the
+ * shared title budget so a malformed version string can't blow the URL cap.
+ */
+export function buildDiagnosticsIssueUrl(metadata: DiagnosticsIssueMetadata): string {
+  const envParts: string[] = [];
+  if (metadata.appVersion) envParts.push(`- **Daintree:** ${metadata.appVersion}`);
+  const osLine = [metadata.platform, metadata.osVersion].filter(Boolean).join(" ");
+  if (osLine) envParts.push(`- **OS:** ${osLine}`);
+  if (metadata.electronVersion) envParts.push(`- **Electron:** ${metadata.electronVersion}`);
+  if (metadata.nodeVersion) envParts.push(`- **Node:** ${metadata.nodeVersion}`);
+  const envSummary = envParts.length > 0 ? envParts.join("\n") : "- _(unknown)_";
+
+  const body =
+    `## Environment\n\n${envSummary}\n\n` +
+    `## Steps to reproduce\n\n1. \n2. \n3. \n\n` +
+    `## Expected behavior\n\n\n` +
+    `## Actual behavior\n\n\n` +
+    `---\n\n` +
+    `Diagnostics bundle attached separately — drag the saved ZIP into this issue.\n`;
+
+  return makeUrl("Diagnostics report", body);
+}

--- a/src/components/ErrorBoundary/buildReportIssueUrl.ts
+++ b/src/components/ErrorBoundary/buildReportIssueUrl.ts
@@ -1,27 +1,17 @@
+import {
+  URL_BODY_BUDGET,
+  capForBudget,
+  makeUrl,
+  truncateStackMiddle,
+} from "@shared/utils/githubIssueUrl";
 import { scrubReportText } from "@shared/utils/reportScrubbers";
 
-const REPO_ISSUE_URL = "https://github.com/daintreehq/daintree/issues/new";
-
-// GitHub's Nginx fronts the issue form at an 8 KiB URL hard cap. Reserve
-// ~1 KiB for base URL + title + percent-encoding fudge, leaving ~7 KB for
-// the encoded body. Measured against `encodeURIComponent` because newlines
-// and backticks inflate 1→3 bytes.
-export const URL_BODY_BUDGET = 7000;
-
-// Cap the encoded title separately so a multi-kilobyte error message can't
-// blow the URL hard cap from the title side, even when the body fits.
-const TITLE_ENCODED_BUDGET = 200;
-
-// When the stack must be middle-truncated we keep the top frames (where the
-// throw originates) and the tail (where it bubbled up through React). 15+5
-// fits a typical render-error stack while leaving the truncation visible.
-const STACK_HEAD_LINES = 15;
-const STACK_TAIL_LINES = 5;
+// Re-exported so existing importers (and tests) keep a stable surface; the
+// canonical definition now lives in the shared helper.
+export { URL_BODY_BUDGET };
 
 const COMPONENT_STACK_PLACEHOLDER =
   "<!-- component stack omitted — exceeded URL budget; full report copied to clipboard -->";
-const STACK_MIDDLE_PLACEHOLDER =
-  "  ... [middle frames truncated — see clipboard for full stack] ...";
 
 export interface ReportIssueInput {
   incidentId: string | null;
@@ -59,31 +49,9 @@ function formatBody(params: {
   );
 }
 
-function truncateStackMiddle(stack: string): string {
-  const lines = stack.split("\n");
-  if (lines.length <= STACK_HEAD_LINES + STACK_TAIL_LINES) return stack;
-  const head = lines.slice(0, STACK_HEAD_LINES);
-  const tail = lines.slice(-STACK_TAIL_LINES);
-  return [...head, STACK_MIDDLE_PLACEHOLDER, ...tail].join("\n");
-}
-
-function capMessageForStub(message: string): string {
-  // The stub body fits inside the URL, so we cap the message line just like
-  // the title — a multi-kilobyte message would otherwise blow the budget.
-  const STUB_MESSAGE_BUDGET = 1000;
-  if (encodeURIComponent(message).length <= STUB_MESSAGE_BUDGET) return message;
-  const ellipsis = "…";
-  const ellipsisLen = encodeURIComponent(ellipsis).length;
-  const chars = Array.from(message);
-  while (chars.length > 0) {
-    const trimmed = chars.join("");
-    if (encodeURIComponent(trimmed).length + ellipsisLen <= STUB_MESSAGE_BUDGET) {
-      return trimmed + ellipsis;
-    }
-    chars.pop();
-  }
-  return ellipsis;
-}
+// The stub body fits inside the URL, so the message line is capped just like
+// the title — a multi-kilobyte message would otherwise blow the budget.
+const STUB_MESSAGE_BUDGET = 1000;
 
 function buildStubBody(params: {
   componentName: string | undefined;
@@ -91,7 +59,7 @@ function buildStubBody(params: {
   message: string;
 }): string {
   const { componentName, incidentId, message } = params;
-  const cappedMessage = capMessageForStub(message || "Unknown error");
+  const cappedMessage = capForBudget(message || "Unknown error", STUB_MESSAGE_BUDGET);
   return (
     `## Error Report\n\n` +
     `The full error details were copied to your clipboard — please paste them below.\n\n` +
@@ -99,28 +67,6 @@ function buildStubBody(params: {
     `**Incident ID:** ${incidentId ?? "unknown"}\n` +
     `**Message:** ${cappedMessage}\n`
   );
-}
-
-function capTitle(title: string): string {
-  if (encodeURIComponent(title).length <= TITLE_ENCODED_BUDGET) return title;
-  // Trim character-by-character until the encoded form fits, leaving room
-  // for the ellipsis. Walking by character avoids slicing into a multi-byte
-  // surrogate pair.
-  const ellipsis = "…";
-  const ellipsisLen = encodeURIComponent(ellipsis).length;
-  const chars = Array.from(title);
-  while (chars.length > 0) {
-    const trimmed = chars.join("");
-    if (encodeURIComponent(trimmed).length + ellipsisLen <= TITLE_ENCODED_BUDGET) {
-      return trimmed + ellipsis;
-    }
-    chars.pop();
-  }
-  return ellipsis;
-}
-
-function makeUrl(title: string, body: string): string {
-  return `${REPO_ISSUE_URL}?title=${encodeURIComponent(capTitle(title))}&body=${encodeURIComponent(body)}`;
 }
 
 /**

--- a/src/components/Settings/DiagnosticsReviewDialog.tsx
+++ b/src/components/Settings/DiagnosticsReviewDialog.tsx
@@ -2,22 +2,54 @@ import { useState, useEffect, useMemo } from "react";
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { Button } from "@/components/ui/button";
-import { CheckIcon, Download, Eye, Replace } from "lucide-react";
+import { CheckIcon, Clock, Download, Eye, Replace, ShieldOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   SECTION_LABELS,
+  PREBUILT_REDACTIONS,
   filterSections,
+  filterLogEntriesByTime,
   applyReplacements,
   type ReplacementRule,
+  type PrebuiltRedactionId,
 } from "@shared/utils/diagnosticsTransform";
 import type { DiagnosticsReviewPayload } from "@shared/types/ipc/system";
 import { safeStringify } from "@/lib/safeStringify";
+
+type TimeWindowId = "5m" | "30m" | "launch" | "full";
+
+const TIME_WINDOW_OPTIONS: { id: TimeWindowId; label: string }[] = [
+  { id: "5m", label: "Last 5 minutes" },
+  { id: "30m", label: "Last 30 minutes" },
+  { id: "launch", label: "Since application launch" },
+  { id: "full", label: "Full log history" },
+];
+
+const DEFAULT_TIME_WINDOW: TimeWindowId = "30m";
+
+/** Resolve a time-window option to an absolute ms cutoff (`null` = full history). */
+function computeTimeWindowStart(id: TimeWindowId, appLaunchTimestamp: number): number | null {
+  switch (id) {
+    case "5m":
+      return Date.now() - 5 * 60 * 1000;
+    case "30m":
+      return Date.now() - 30 * 60 * 1000;
+    case "launch":
+      return appLaunchTimestamp;
+    case "full":
+      return null;
+  }
+}
 
 interface DiagnosticsReviewDialogProps {
   isOpen: boolean;
   onClose: () => void;
   reviewPayload: DiagnosticsReviewPayload | null;
-  onSave: (enabledSections: Record<string, boolean>, replacements: ReplacementRule[]) => void;
+  onSave: (
+    enabledSections: Record<string, boolean>,
+    replacements: ReplacementRule[],
+    timeWindowStartMs: number | null
+  ) => void;
   isSaving: boolean;
 }
 
@@ -32,6 +64,8 @@ export function DiagnosticsReviewDialog({
   const [replacements, setReplacements] = useState<ReplacementRule[]>([
     { find: "", replace: "[REDACTED]" },
   ]);
+  const [prebuiltIds, setPrebuiltIds] = useState<Set<PrebuiltRedactionId>>(new Set());
+  const [timeWindow, setTimeWindow] = useState<TimeWindowId>(DEFAULT_TIME_WINDOW);
   const [showPreview, setShowPreview] = useState(false);
 
   useEffect(() => {
@@ -42,23 +76,45 @@ export function DiagnosticsReviewDialog({
       }
       setEnabledSections(initial);
       setReplacements([{ find: "", replace: "[REDACTED]" }]);
+      setPrebuiltIds(new Set());
+      setTimeWindow(DEFAULT_TIME_WINDOW);
       setShowPreview(false);
     }
   }, [isOpen, reviewPayload]);
 
+  // Active prebuilt toggles contribute regex rules, prepended before the user's
+  // literal rules so canonical patterns run first.
+  const effectiveReplacements = useMemo<ReplacementRule[]>(() => {
+    const prebuilt = PREBUILT_REDACTIONS.filter((p) => prebuiltIds.has(p.id)).flatMap(
+      (p) => p.rules
+    );
+    return [...prebuilt, ...replacements.filter((r) => r.find)];
+  }, [prebuiltIds, replacements]);
+
   const previewJson = useMemo(() => {
     if (!reviewPayload) return "";
-    const filtered = filterSections(reviewPayload.payload, enabledSections);
-    let json = safeStringify(filtered, 2);
-    json = applyReplacements(
-      json,
-      replacements.filter((r) => r.find)
+    const startMs = computeTimeWindowStart(timeWindow, reviewPayload.appLaunchTimestamp);
+    const filtered = filterLogEntriesByTime(
+      filterSections(reviewPayload.payload, enabledSections),
+      startMs
     );
-    return json;
-  }, [reviewPayload, enabledSections, replacements]);
+    return applyReplacements(safeStringify(filtered, 2), effectiveReplacements);
+  }, [reviewPayload, enabledSections, effectiveReplacements, timeWindow]);
 
   const toggleSection = (key: string) => {
     setEnabledSections((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const togglePrebuilt = (id: PrebuiltRedactionId) => {
+    setPrebuiltIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
   };
 
   const addReplacement = () => {
@@ -74,10 +130,9 @@ export function DiagnosticsReviewDialog({
   };
 
   const handleSave = () => {
-    onSave(
-      enabledSections,
-      replacements.filter((r) => r.find)
-    );
+    if (!reviewPayload) return;
+    const startMs = computeTimeWindowStart(timeWindow, reviewPayload.appLaunchTimestamp);
+    onSave(enabledSections, effectiveReplacements, startMs);
   };
 
   const allEnabled = reviewPayload
@@ -139,6 +194,64 @@ export function DiagnosticsReviewDialog({
                   </CheckboxPrimitive.Indicator>
                 </CheckboxPrimitive.Root>
                 {SECTION_LABELS[key] ?? key}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <h4 className="text-sm font-medium text-daintree-text flex items-center gap-1.5 mb-2">
+            <Clock className="w-3.5 h-3.5" />
+            Log time window
+          </h4>
+          <select
+            value={timeWindow}
+            onChange={(e) => setTimeWindow(e.target.value as TimeWindowId)}
+            aria-label="Log time window"
+            className={cn(
+              "h-8 text-xs w-full px-2 rounded border border-daintree-border bg-daintree-bg",
+              "text-daintree-text focus:outline-hidden focus:border-daintree-accent"
+            )}
+          >
+            {TIME_WINDOW_OPTIONS.map((opt) => (
+              <option key={opt.id} value={opt.id}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <h4 className="text-sm font-medium text-daintree-text flex items-center gap-1.5 mb-2">
+            <ShieldOff className="w-3.5 h-3.5" />
+            Prebuilt redactions
+          </h4>
+          <div className="grid grid-cols-1 gap-1.5">
+            {PREBUILT_REDACTIONS.map((preset) => (
+              <label
+                key={preset.id}
+                className={cn(
+                  "flex items-center gap-2 px-2.5 py-1.5 rounded border text-xs cursor-pointer transition-colors",
+                  prebuiltIds.has(preset.id)
+                    ? "border-daintree-border bg-daintree-bg/50 text-daintree-text"
+                    : "border-daintree-border/40 bg-transparent text-daintree-text/60"
+                )}
+              >
+                <CheckboxPrimitive.Root
+                  checked={prebuiltIds.has(preset.id)}
+                  onCheckedChange={() => togglePrebuilt(preset.id)}
+                  className={cn(
+                    "flex shrink-0 w-3.5 h-3.5 rounded border transition-colors",
+                    "bg-daintree-bg border-border-strong",
+                    "data-[state=checked]:bg-daintree-text data-[state=checked]:border-daintree-text",
+                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+                  )}
+                >
+                  <CheckboxPrimitive.Indicator className="flex items-center justify-center text-text-inverse">
+                    <CheckIcon className="w-2.5 h-2.5" />
+                  </CheckboxPrimitive.Indicator>
+                </CheckboxPrimitive.Root>
+                {preset.label}
               </label>
             ))}
           </div>

--- a/src/components/Settings/DiagnosticsReviewDialog.tsx
+++ b/src/components/Settings/DiagnosticsReviewDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { Button } from "@/components/ui/button";
@@ -27,13 +27,21 @@ const TIME_WINDOW_OPTIONS: { id: TimeWindowId; label: string }[] = [
 
 const DEFAULT_TIME_WINDOW: TimeWindowId = "30m";
 
-/** Resolve a time-window option to an absolute ms cutoff (`null` = full history). */
-function computeTimeWindowStart(id: TimeWindowId, appLaunchTimestamp: number): number | null {
+/**
+ * Resolve a time-window option to an absolute ms cutoff (`null` = full history).
+ * `now` is captured once when the dialog opens so the preview and the saved
+ * bundle share an identical cutoff even if the user reviews for a while.
+ */
+function computeTimeWindowStart(
+  id: TimeWindowId,
+  appLaunchTimestamp: number,
+  now: number
+): number | null {
   switch (id) {
     case "5m":
-      return Date.now() - 5 * 60 * 1000;
+      return now - 5 * 60 * 1000;
     case "30m":
-      return Date.now() - 30 * 60 * 1000;
+      return now - 30 * 60 * 1000;
     case "launch":
       return appLaunchTimestamp;
     case "full":
@@ -67,9 +75,13 @@ export function DiagnosticsReviewDialog({
   const [prebuiltIds, setPrebuiltIds] = useState<Set<PrebuiltRedactionId>>(new Set());
   const [timeWindow, setTimeWindow] = useState<TimeWindowId>(DEFAULT_TIME_WINDOW);
   const [showPreview, setShowPreview] = useState(false);
+  // Reference "now" captured at open so the relative windows resolve to a
+  // stable cutoff shared by the preview and the save call.
+  const openedAtRef = useRef(Date.now());
 
   useEffect(() => {
     if (isOpen && reviewPayload) {
+      openedAtRef.current = Date.now();
       const initial: Record<string, boolean> = {};
       for (const key of reviewPayload.sectionKeys) {
         initial[key] = true;
@@ -93,7 +105,11 @@ export function DiagnosticsReviewDialog({
 
   const previewJson = useMemo(() => {
     if (!reviewPayload) return "";
-    const startMs = computeTimeWindowStart(timeWindow, reviewPayload.appLaunchTimestamp);
+    const startMs = computeTimeWindowStart(
+      timeWindow,
+      reviewPayload.appLaunchTimestamp,
+      openedAtRef.current
+    );
     const filtered = filterLogEntriesByTime(
       filterSections(reviewPayload.payload, enabledSections),
       startMs
@@ -131,7 +147,11 @@ export function DiagnosticsReviewDialog({
 
   const handleSave = () => {
     if (!reviewPayload) return;
-    const startMs = computeTimeWindowStart(timeWindow, reviewPayload.appLaunchTimestamp);
+    const startMs = computeTimeWindowStart(
+      timeWindow,
+      reviewPayload.appLaunchTimestamp,
+      openedAtRef.current
+    );
     onSave(enabledSections, effectiveReplacements, startMs);
   };
 

--- a/src/components/Settings/DiagnosticsReviewDialog.tsx
+++ b/src/components/Settings/DiagnosticsReviewDialog.tsx
@@ -27,6 +27,10 @@ const TIME_WINDOW_OPTIONS: { id: TimeWindowId; label: string }[] = [
 
 const DEFAULT_TIME_WINDOW: TimeWindowId = "30m";
 
+function isTimeWindowId(value: string): value is TimeWindowId {
+  return TIME_WINDOW_OPTIONS.some((o) => o.id === value);
+}
+
 /**
  * Resolve a time-window option to an absolute ms cutoff (`null` = full history).
  * `now` is captured once when the dialog opens so the preview and the saved
@@ -219,7 +223,9 @@ export function DiagnosticsReviewDialog({
           </h4>
           <select
             value={timeWindow}
-            onChange={(e) => setTimeWindow(e.target.value as TimeWindowId)}
+            onChange={(e) => {
+              if (isTimeWindowId(e.target.value)) setTimeWindow(e.target.value);
+            }}
             aria-label="Log time window"
             className={cn(
               "h-8 text-xs w-full px-2 rounded border border-daintree-border bg-daintree-bg",

--- a/src/components/Settings/DiagnosticsReviewDialog.tsx
+++ b/src/components/Settings/DiagnosticsReviewDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useState, useEffect, useMemo } from "react";
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { Button } from "@/components/ui/button";
@@ -76,12 +76,13 @@ export function DiagnosticsReviewDialog({
   const [timeWindow, setTimeWindow] = useState<TimeWindowId>(DEFAULT_TIME_WINDOW);
   const [showPreview, setShowPreview] = useState(false);
   // Reference "now" captured at open so the relative windows resolve to a
-  // stable cutoff shared by the preview and the save call.
-  const openedAtRef = useRef(Date.now());
+  // stable cutoff shared by the preview and the save call. Held as state (not a
+  // ref) so the render-time reads below don't trip the React Compiler.
+  const [openedAt, setOpenedAt] = useState(() => Date.now());
 
   useEffect(() => {
     if (isOpen && reviewPayload) {
-      openedAtRef.current = Date.now();
+      setOpenedAt(Date.now());
       const initial: Record<string, boolean> = {};
       for (const key of reviewPayload.sectionKeys) {
         initial[key] = true;
@@ -105,17 +106,13 @@ export function DiagnosticsReviewDialog({
 
   const previewJson = useMemo(() => {
     if (!reviewPayload) return "";
-    const startMs = computeTimeWindowStart(
-      timeWindow,
-      reviewPayload.appLaunchTimestamp,
-      openedAtRef.current
-    );
+    const startMs = computeTimeWindowStart(timeWindow, reviewPayload.appLaunchTimestamp, openedAt);
     const filtered = filterLogEntriesByTime(
       filterSections(reviewPayload.payload, enabledSections),
       startMs
     );
     return applyReplacements(safeStringify(filtered, 2), effectiveReplacements);
-  }, [reviewPayload, enabledSections, effectiveReplacements, timeWindow]);
+  }, [reviewPayload, enabledSections, effectiveReplacements, timeWindow, openedAt]);
 
   const toggleSection = (key: string) => {
     setEnabledSections((prev) => ({ ...prev, [key]: !prev[key] }));
@@ -147,11 +144,7 @@ export function DiagnosticsReviewDialog({
 
   const handleSave = () => {
     if (!reviewPayload) return;
-    const startMs = computeTimeWindowStart(
-      timeWindow,
-      reviewPayload.appLaunchTimestamp,
-      openedAtRef.current
-    );
+    const startMs = computeTimeWindowStart(timeWindow, reviewPayload.appLaunchTimestamp, openedAt);
     onSave(enabledSections, effectiveReplacements, startMs);
   };
 

--- a/src/components/Settings/TroubleshootingTab.tsx
+++ b/src/components/Settings/TroubleshootingTab.tsx
@@ -18,7 +18,12 @@ import { appClient, systemClient, logsClient } from "@/clients";
 import type { AppState, SystemHealthCheckResult } from "@shared/types";
 import type { DiagnosticsReviewPayload } from "@shared/types/ipc/system";
 import type { ReplacementRule } from "@shared/utils/diagnosticsTransform";
+import {
+  buildDiagnosticsIssueUrl,
+  type DiagnosticsIssueMetadata,
+} from "@shared/utils/githubIssueUrl";
 import { actionService } from "@/services/ActionService";
+import { notify } from "@/lib/notify";
 import { logError, logWarn } from "@/utils/logger";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { SettingsSection } from "./SettingsSection";
@@ -92,6 +97,25 @@ function SystemHealthSection() {
   );
 }
 
+/** Pull the GitHub-issue env summary fields out of the untyped review payload. */
+function extractIssueMetadata(payload: Record<string, unknown>): DiagnosticsIssueMetadata {
+  const str = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined);
+  const section = (key: string): Record<string, unknown> | undefined => {
+    const value = payload[key];
+    return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
+  };
+  const metadata = section("metadata");
+  const runtime = section("runtime");
+  const os = section("os");
+  return {
+    appVersion: str(metadata?.appVersion),
+    electronVersion: str(metadata?.electronVersion),
+    nodeVersion: str(metadata?.nodeVersion),
+    platform: str(runtime?.platform) ?? str(os?.platform),
+    osVersion: str(os?.version) ?? str(os?.release),
+  };
+}
+
 function DownloadDiagnosticsSection() {
   const [isCollecting, setIsCollecting] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
@@ -115,7 +139,8 @@ function DownloadDiagnosticsSection() {
 
   const handleSave = async (
     enabledSections: Record<string, boolean>,
-    replacements: ReplacementRule[]
+    replacements: ReplacementRule[],
+    timeWindowStartMs: number | null
   ) => {
     setIsSaving(true);
     try {
@@ -124,8 +149,25 @@ function DownloadDiagnosticsSection() {
         payload,
         enabledSections,
         replacements,
+        timeWindowStartMs,
       });
       if (saved) {
+        const issueUrl = buildDiagnosticsIssueUrl(extractIssueMetadata(payload));
+        notify({
+          type: "success",
+          title: "Diagnostics saved",
+          message: "Open a GitHub issue and drag the saved ZIP into it.",
+          context: { eventKind: "settings" },
+          action: {
+            label: "Continue to GitHub issue",
+            variant: "primary",
+            onClick: () => {
+              safeFireAndForget(systemClient.openExternal(issueUrl), {
+                context: "Opening GitHub issue from diagnostics save",
+              });
+            },
+          },
+        });
         setReviewOpen(false);
       }
     } catch (err) {

--- a/src/components/Settings/TroubleshootingTab.tsx
+++ b/src/components/Settings/TroubleshootingTab.tsx
@@ -100,9 +100,11 @@ function SystemHealthSection() {
 /** Pull the GitHub-issue env summary fields out of the untyped review payload. */
 function extractIssueMetadata(payload: Record<string, unknown>): DiagnosticsIssueMetadata {
   const str = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined);
+  const isRecord = (v: unknown): v is Record<string, unknown> =>
+    typeof v === "object" && v !== null;
   const section = (key: string): Record<string, unknown> | undefined => {
     const value = payload[key];
-    return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
+    return isRecord(value) ? value : undefined;
   };
   const metadata = section("metadata");
   const runtime = section("runtime");
@@ -157,6 +159,9 @@ function DownloadDiagnosticsSection() {
           type: "success",
           title: "Diagnostics saved",
           message: "Open a GitHub issue and drag the saved ZIP into it.",
+          // The saved ZIP is already revealed in the OS file manager, so this
+          // is a one-shot action prompt — no durable inbox row needed.
+          transient: true,
           context: { eventKind: "settings" },
           action: {
             label: "Continue to GitHub issue",


### PR DESCRIPTION
## Summary

- Adds prebuilt redaction toggles (email addresses, IPv4/v6, absolute file paths) to the diagnostics review dialog — these prepend ReDoS-bounded regex rules ahead of the user's own literal rules
- Adds a log time-window `<select>` (last 5 min / last 30 min / since launch / full history) threaded as an absolute `timeWindowStartMs` cutoff through the bundle-save path; rotated `.log.N` files older than the cutoff are skipped by mtime
- Adds a "Continue to GitHub issue" success flow: after saving a bundle, a toast links to a prefilled issue with an env summary, repro skeleton, and ZIP-attachment note

URL-budget helpers (`capForBudget`, `makeUrl`, `truncateStackMiddle`) extracted into `shared/utils/githubIssueUrl.ts` and deduplicated from `buildReportIssueUrl.ts` and `buildCrashReportUrl.ts`.

Closes #9141

## Changes

- `shared/utils/githubIssueUrl.ts` — new shared URL-budget primitives + `buildDiagnosticsIssueUrl`
- `shared/utils/diagnosticsTransform.ts` — prebuilt redaction rules; `ReplacementRule.kind` discriminant (`"literal"` back-compat default, `"regex"` for compiled rules)
- `shared/types/ipc/system.ts` — `timeWindowStartMs` on `DiagnosticsBundleSavePayload`; `appLaunchTimestamp` on `DiagnosticsReviewPayload`
- `electron/ipc/handlers/diagnostics.ts` — mtime-based log rotation skip; exposes `appLaunchTimestamp`
- `src/components/Settings/DiagnosticsReviewDialog.tsx` — redaction toggles, time-window selector, post-save GitHub handoff
- `src/components/Settings/TroubleshootingTab.tsx` — wires `appLaunchTimestamp` through to the dialog

## Testing

New test files: `shared/utils/__tests__/diagnosticsTransform.test.ts`, `shared/utils/__tests__/githubIssueUrl.test.ts`. Expanded `electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts` (time-window mtime filtering, `appLaunchTimestamp`). 84 targeted tests pass; `npm run check` clean.