### PR TITLE
feat(voice): pluggable transcription providers + Deepgram backend

### DIFF
--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 1273,
-  "moduleCount": 1273,
+  "count": 1275,
+  "moduleCount": 1275,
   "allowlist": [
     "electron/ipc/errorHandlers.ts",
     "electron/ipc/handlers/agentCapabilities.ts",

--- a/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
+++ b/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
@@ -458,8 +458,10 @@ describe("getVoiceSettings migration", () => {
       vi.mocked(store.set).mock.calls[0] as unknown as [string, Record<string, unknown>]
     )[1];
     expect(persisted).not.toHaveProperty("correctionApiKey");
-    expect(persisted).not.toHaveProperty("deepgramApiKey");
     expect(persisted).not.toHaveProperty("apiKey");
+    // deepgramApiKey and transcriptionProvider are now first-class fields.
+    expect(persisted).toHaveProperty("deepgramApiKey", "");
+    expect(persisted).toHaveProperty("transcriptionProvider", "openai");
   });
 
   it("migrates first-generation apiKey (sk-*) into openaiApiKey", async () => {
@@ -475,7 +477,7 @@ describe("getVoiceSettings migration", () => {
     expect(vi.mocked(store.set)).toHaveBeenCalledOnce();
   });
 
-  it("drops deepgramApiKey without carrying it into openaiApiKey", async () => {
+  it("preserves a stored deepgramApiKey as a first-class field", async () => {
     const { store } = await import("../../../store.js");
     vi.mocked(store.get).mockReturnValueOnce({
       enabled: true,
@@ -484,13 +486,41 @@ describe("getVoiceSettings migration", () => {
 
     const settings = getVoiceSettings();
 
+    // deepgramApiKey now flows through; it does not bleed into openaiApiKey and
+    // is no longer dropped on read.
+    expect(settings.deepgramApiKey).toBe("dg-xxx");
     expect(settings.openaiApiKey).toBe("");
-    // Cleanup is still persisted so the dropped key disappears from disk.
+    // No legacy keys and a valid (defaulted) provider — nothing to persist.
+    expect(vi.mocked(store.set)).not.toHaveBeenCalled();
+  });
+
+  it("defaults an unrecognized transcriptionProvider to openai and persists it", async () => {
+    const { store } = await import("../../../store.js");
+    vi.mocked(store.get).mockReturnValueOnce({
+      enabled: true,
+      openaiApiKey: "sk-present",
+      transcriptionProvider: "bogus-provider",
+    });
+
+    const settings = getVoiceSettings();
+
+    expect(settings.transcriptionProvider).toBe("openai");
     expect(vi.mocked(store.set)).toHaveBeenCalledOnce();
-    const persisted = (
-      vi.mocked(store.set).mock.calls[0] as unknown as [string, Record<string, unknown>]
-    )[1];
-    expect(persisted).not.toHaveProperty("deepgramApiKey");
+  });
+
+  it("keeps a stored deepgram provider choice without resetting it", async () => {
+    const { store } = await import("../../../store.js");
+    vi.mocked(store.get).mockReturnValueOnce({
+      enabled: true,
+      deepgramApiKey: "dg-xxx",
+      transcriptionProvider: "deepgram",
+    });
+
+    const settings = getVoiceSettings();
+
+    expect(settings.transcriptionProvider).toBe("deepgram");
+    // A valid stored provider with no legacy keys triggers no write.
+    expect(vi.mocked(store.set)).not.toHaveBeenCalled();
   });
 
   it("does not overwrite an existing openaiApiKey when legacy fields are present", async () => {

--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -7,7 +7,10 @@ import { projectStore } from "../../services/ProjectStore.js";
 import { VoiceTranscriptionService } from "../../services/VoiceTranscriptionService.js";
 import { VoiceCorrectionService } from "../../services/VoiceCorrectionService.js";
 import type { HandlerDependencies, IpcContext } from "../types.js";
-import type { VoiceInputSettings } from "../../../shared/types/ipc/api.js";
+import type {
+  VoiceInputSettings,
+  VoiceTranscriptionProvider,
+} from "../../../shared/types/ipc/api.js";
 import { logDebug } from "../../utils/logger.js";
 import { buildOpenAIHeaders } from "../../../shared/utils/openaiHeaders.js";
 import { applyDictationCommands } from "../../services/voiceDictationCommands.js";
@@ -27,11 +30,15 @@ let correctionService: VoiceCorrectionService | null = null;
 let sessionController: AbortController | null = null;
 let sessionProjectInfo: { name?: string; path?: string } = {};
 
+const VALID_TRANSCRIPTION_PROVIDERS: VoiceTranscriptionProvider[] = ["openai", "deepgram"];
+
 const VOICE_INPUT_DEFAULTS: VoiceInputSettings = {
   enabled: false,
   openaiApiKey: "",
+  deepgramApiKey: "",
   language: "en",
   customDictionary: [],
+  transcriptionProvider: "openai",
   transcriptionModel: "gpt-realtime-whisper",
   correctionEnabled: false,
   correctionModel: "gpt-5-mini",
@@ -48,17 +55,17 @@ export function getVoiceSettings(): VoiceInputSettings {
   const stored = store.get("voiceInput") as
     | (Partial<VoiceInputSettings> & {
         apiKey?: string;
-        deepgramApiKey?: string;
         correctionApiKey?: string;
       })
     | undefined;
 
-  // Pluck legacy fields so they don't leak into the merged object via spread.
-  const { apiKey, deepgramApiKey, correctionApiKey, ...rest } = stored ?? {};
+  // Pluck truly-legacy key fields so they don't leak into the merged object via
+  // spread. `deepgramApiKey` is now a first-class field, so it flows through
+  // `rest` instead of being dropped.
+  const { apiKey, correctionApiKey, ...rest } = stored ?? {};
   const merged: VoiceInputSettings = { ...VOICE_INPUT_DEFAULTS, ...rest };
 
-  // Migrate prior OpenAI keys into the unified field. The Deepgram key is
-  // dropped — it belonged to a different provider.
+  // Migrate prior OpenAI keys into the unified field.
   if (!merged.openaiApiKey) {
     if (correctionApiKey?.startsWith("sk-")) {
       merged.openaiApiKey = correctionApiKey;
@@ -67,25 +74,42 @@ export function getVoiceSettings(): VoiceInputSettings {
     }
   }
 
-  // Migrate legacy Deepgram model values ('nova-3' / 'nova-2') to the unified OpenAI model.
+  // Default the provider to "openai" only when it's missing or unrecognized
+  // (e.g. settings written before the provider field existed). Crucially this
+  // does NOT reset a valid, user-chosen provider on every read — the prior
+  // migration's habit of force-resetting fields each launch is the #9175 bug.
+  const providerNeedsDefault = !VALID_TRANSCRIPTION_PROVIDERS.includes(
+    merged.transcriptionProvider
+  );
+  if (providerNeedsDefault) merged.transcriptionProvider = "openai";
+
+  // Normalize a stale/invalid transcription model to the only supported value.
+  // The model union is single-valued, so this is a one-shot cleanup of legacy
+  // Deepgram model strings ('nova-3' / 'nova-2'), not a user-choice revert —
+  // the provider, not the model, is what selects the backend now.
   const staleModel = merged.transcriptionModel !== "gpt-realtime-whisper";
   if (staleModel) merged.transcriptionModel = "gpt-realtime-whisper";
 
-  // Persist the cleaned object on first read after upgrade so the legacy
-  // fields disappear from disk. `store.set` with a full object replaces.
+  // Persist the cleaned object on first read after upgrade so the legacy key
+  // fields disappear from disk and any defaulted/normalized values are written
+  // through. `store.set` with a full object replaces.
   if (
     apiKey !== undefined ||
-    deepgramApiKey !== undefined ||
     correctionApiKey !== undefined ||
+    providerNeedsDefault ||
     staleModel
   ) {
     store.set("voiceInput", merged);
   }
 
-  // Env-var override takes absolute precedence over stored key.
-  const envKey = process.env.WHISPER_API_KEY?.trim();
-  if (envKey) {
-    merged.openaiApiKey = envKey;
+  // Env-var overrides take absolute precedence over stored keys.
+  const envOpenAiKey = process.env.WHISPER_API_KEY?.trim();
+  if (envOpenAiKey) {
+    merged.openaiApiKey = envOpenAiKey;
+  }
+  const envDeepgramKey = process.env.DEEPGRAM_API_KEY?.trim();
+  if (envDeepgramKey) {
+    merged.deepgramApiKey = envDeepgramKey;
   }
 
   return merged;

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2319,8 +2319,10 @@ const api: ElectronAPI = {
       patch: Partial<{
         enabled: boolean;
         openaiApiKey: string;
+        deepgramApiKey: string;
         language: string;
         customDictionary: string[];
+        transcriptionProvider: "openai" | "deepgram";
         transcriptionModel: "gpt-realtime-whisper";
         correctionEnabled: boolean;
         correctionModel: "gpt-5-nano" | "gpt-5-mini";

--- a/electron/services/VoiceTranscriptionService.ts
+++ b/electron/services/VoiceTranscriptionService.ts
@@ -1,1020 +1,108 @@
-import WebSocket from "ws";
-import type { VoiceInputSettings, VoiceInputStatus } from "../../shared/types/ipc/api.js";
-import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
-import { buildOpenAIHeaders } from "../../shared/utils/openaiHeaders.js";
-import { logDebug, logInfo, logWarn, logError } from "../utils/logger.js";
+import type { VoiceInputSettings } from "../../shared/types/ipc/api.js";
+import { logInfo } from "../utils/logger.js";
+import { DeepgramTranscriptionProvider } from "./voice/DeepgramTranscriptionProvider.js";
+import { OpenAITranscriptionProvider } from "./voice/OpenAITranscriptionProvider.js";
+import type {
+  TranscriptionProvider,
+  VoiceStartResult,
+  VoiceTranscriptionEvent,
+} from "./voice/TranscriptionProvider.js";
+
+// Re-export the provider-shared types so existing importers (and tests) keep a
+// single entry point even though the definitions now live alongside the
+// provider interface.
+export type {
+  CorrectionWord,
+  SegmentConfidence,
+  VoiceStartResult,
+  VoiceTranscriptionEvent,
+} from "./voice/TranscriptionProvider.js";
 
 const P = "[VoiceTranscription]";
 
-// `gpt-realtime-whisper` is a transcription model — it must be passed as
-// `transcription.model`, NOT as the realtime session `model` query param.
-// The session connects via `?intent=transcription` instead.
-const OPENAI_REALTIME_URL =
-  process.env.DAINTREE_REALTIME_WS_URL ?? "wss://api.openai.com/v1/realtime?intent=transcription";
-const OPENAI_TRANSCRIPTION_MODEL = "gpt-realtime-whisper";
-const CONNECT_TIMEOUT_MS = 10_000;
-// Backstop for the drain: if a committed segment's `conversation.item.done`
-// never arrives (server error, dropped frame), force-close after this long
-// rather than hanging the stop.
-const DRAIN_TIMEOUT_MS = 3_000;
-const PRE_CONNECT_BUFFER_MAX = 100;
-// Hard byte ceiling for buffered-but-not-yet-sent audio (pre-connect and during
-// a reconnect window). 24kHz mono PCM16 ≈ 48KB/s, so ~150KB ≈ 3s — the point
-// past which voice context is lost anyway. Caps memory if chunks are large.
-const PRE_CONNECT_BUFFER_MAX_BYTES = 150_000;
-// Client-side ping/pong heartbeat. The OpenAI Realtime server sends its own
-// pings (auto-ponged by `ws`), but a half-open TCP connection on our side —
-// server alive, our socket silently dead — is only detectable by us pinging
-// and watching for the pong. On a missed pong we `terminate()` (no closing
-// handshake on a dead socket) which fires `close` and drives the reconnect.
-const HEARTBEAT_INTERVAL_MS = 20_000;
-// Automatic reconnect on an unexpected mid-session drop. Exponential backoff
-// with full jitter: delay = random() * min(CAP, INITIAL * MULTIPLIER^attempt).
-// Gentle multiplier so the first few retries are near-instant; after
-// RECONNECT_MAX_ATTEMPTS we give up and surface a fatal error.
-const RECONNECT_MAX_ATTEMPTS = 5;
-const RECONNECT_INITIAL_MS = 150;
-const RECONNECT_MULTIPLIER = 1.5;
-const RECONNECT_CAP_MS = 3_000;
-// `gpt-realtime-whisper` does not support server VAD (`turn_detection` must be
-// null), so the server never auto-commits the input buffer. We drive
-// segmentation ourselves: commit the buffer on a fixed cadence so the model
-// transcribes each segment and streams delta/completed events back while the
-// user is still speaking. Without this, no transcription arrives until stop.
-const COMMIT_INTERVAL_MS = 2_000;
-// OpenAI rejects an `input_audio_buffer.commit` carrying under ~100ms of audio
-// (24kHz mono PCM16 → 4800 bytes) with a fatal error event. Skip a commit
-// below this threshold.
-const MIN_COMMIT_BYTES = 4_800;
-
-export interface CorrectionWord {
-  word: string;
-  confidence: number;
-  start?: number;
-  end?: number;
-}
-
-export interface SegmentConfidence {
-  minConfidence: number;
-  wordCount: number;
-  uncertainWords: string[];
-  words: CorrectionWord[];
-}
-
-export type VoiceTranscriptionEvent =
-  | { type: "delta"; text: string }
-  | { type: "complete"; text: string; confidence?: SegmentConfidence }
-  | { type: "paragraph_boundary" }
-  | { type: "error"; message: string }
-  | { type: "status"; status: VoiceInputStatus };
-
-type VoiceStartResult = { ok: true } | { ok: false; error: string };
-
-// We use the `ws` package rather than Node 22's global `WebSocket`. The
-// WHATWG spec exposes only `(url, protocols?)` — its constructor silently
-// discards any third options argument, so custom upgrade headers cannot be
-// sent. The `ws` package accepts a 2-arg `(url, options)` form with full
-// header support, which is also what the openai SDK uses internally.
-
-const STUB_CONFIDENCE: SegmentConfidence = {
-  minConfidence: 1.0,
-  wordCount: 0,
-  uncertainWords: [],
-  words: [],
-};
-
+/**
+ * Orchestrates voice transcription across pluggable backends. Selects a
+ * `TranscriptionProvider` from `settings.transcriptionProvider`, forwards its
+ * events to subscribers, and tears the previous provider down on every new
+ * session so a provider switch (or a plain restart) can't leak listeners or a
+ * live socket (lesson #4754).
+ *
+ * The provider owns its own protocol, connection lifecycle, timers, and — for
+ * backends without server-side VAD — its segmentation cadence. This layer holds
+ * no transcription logic of its own; it is purely selection + event forwarding.
+ */
 export class VoiceTranscriptionService {
-  private connection: WebSocket | null = null;
-  private sessionId = 0;
-  private connectTimeout: ReturnType<typeof setTimeout> | null = null;
+  private provider: TranscriptionProvider | null = null;
+  private providerUnsub: (() => void) | null = null;
   private listeners: Set<(event: VoiceTranscriptionEvent) => void> = new Set();
-  private pendingStart: { sessionId: number; resolve: (result: VoiceStartResult) => void } | null =
-    null;
-
-  private preConnectBuffer: ArrayBuffer[] = [];
-  private preConnectBufferBytes = 0;
-  private isReady = false;
-
-  // Heartbeat (half-open detection) for the current connection. `isAlive` is
-  // set on every pong and on open; the interval terminates the socket if a full
-  // cycle elapses with no pong.
-  private heartbeatInterval: ReturnType<typeof setInterval> | null = null;
-  private isAlive = false;
-
-  // Reconnect state. `reconnectAttempt` and `isReconnecting` survive across
-  // individual connection teardowns (cleanupConnection) and are only reset by
-  // cleanupPreviousSession (a full session reset) or a successful reconnect.
-  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-  private reconnectAttempt = 0;
-  private isReconnecting = false;
-  // Set on graceful/fatal teardown so the trailing `close` event isn't mistaken
-  // for an unexpected drop and doesn't trigger a reconnect.
-  private isExpectedClose = false;
-
-  private drainResolve: (() => void) | null = null;
-  private drainTimeout: ReturnType<typeof setTimeout> | null = null;
-  private drainPromise: Promise<void> | null = null;
-  private isDraining = false;
-
-  private commitTimer: ReturnType<typeof setInterval> | null = null;
-  private bytesSinceCommit = 0;
-  // Commits sent (interval, paragraph-boundary, or final) whose
-  // `conversation.item.done` we haven't seen yet. Each commit yields exactly
-  // one completion, so the drain is finished precisely when this hits zero —
-  // no timing heuristic needed.
-  private pendingCommits = 0;
-  // Item ids already counted toward `pendingCommits` — guards against a
-  // completion being counted twice (e.g. a `.completed` and a `.done` for the
-  // same item).
-  private completedItemIds = new Set<string>();
-
-  /** Cumulative delta text since the last complete event — used for incremental diffs. */
-  private liveText = "";
-
-  private audioChunkCount = 0;
-  private staleChunkWarned = false;
-  private preConnectBufferOverflowWarned = false;
 
   onEvent(listener: (event: VoiceTranscriptionEvent) => void): () => void {
     this.listeners.add(listener);
     return () => this.listeners.delete(listener);
   }
 
-  /**
-   * Flushes the current audio segment at a user-driven paragraph boundary
-   * (Enter pressed mid-utterance). With no server VAD, committing here closes
-   * the in-progress segment so its transcript finalizes promptly and the next
-   * `completed` event reflects only speech after the boundary. Also clears the
-   * live-delta state since the renderer has already captured the displayed text.
-   */
-  commitParagraphBoundary(): void {
-    this.maybeCommitSegment("paragraph-boundary");
-    this.liveText = "";
-  }
-
   private emit(event: VoiceTranscriptionEvent): void {
-    if (event.type === "status") {
-      logInfo(`${P} status → ${event.status}`);
-    } else if (event.type === "error") {
-      logWarn(`${P} emitting error event`, { message: event.message });
-    }
     for (const listener of this.listeners) {
       listener(event);
     }
   }
 
-  private clearConnectTimeout(): void {
-    if (this.connectTimeout !== null) {
-      clearTimeout(this.connectTimeout);
-      this.connectTimeout = null;
+  private createProvider(settings: VoiceInputSettings): TranscriptionProvider {
+    switch (settings.transcriptionProvider) {
+      case "deepgram":
+        return new DeepgramTranscriptionProvider();
+      case "openai":
+      default:
+        return new OpenAITranscriptionProvider();
     }
   }
 
-  private settlePendingStart(sessionId: number, result: VoiceStartResult): void {
-    if (this.pendingStart?.sessionId !== sessionId) return;
-    const { resolve } = this.pendingStart;
-    this.pendingStart = null;
-    resolve(result);
+  private disposeProvider(): void {
+    if (this.providerUnsub) {
+      this.providerUnsub();
+      this.providerUnsub = null;
+    }
+    if (this.provider) {
+      this.provider.destroy();
+      this.provider = null;
+    }
   }
 
   async start(settings: VoiceInputSettings): Promise<VoiceStartResult> {
-    if (!settings.openaiApiKey) {
-      logWarn(`${P} No OpenAI API key configured`);
-      return { ok: false, error: "OpenAI API key not configured" };
-    }
-
-    const mySessionId = this.sessionId + 1;
-    logInfo(`${P} Starting session ${mySessionId}`, {
-      language: settings.language,
-      hasDictionary: settings.customDictionary.length > 0,
+    // Tear down any previous provider (and its subscription) before swapping in
+    // a new one — covers both a provider switch and a plain restart.
+    this.disposeProvider();
+    const provider = this.createProvider(settings);
+    this.provider = provider;
+    logInfo(`${P} Using provider`, {
+      provider: settings.transcriptionProvider,
+      hasServerVAD: provider.hasServerVAD,
     });
-    this.cleanupPreviousSession();
-    this.sessionId = mySessionId;
-    this.isReady = false;
-    this.preConnectBuffer = [];
-    this.preConnectBufferBytes = 0;
-    this.reconnectAttempt = 0;
-    this.isReconnecting = false;
-    this.isExpectedClose = false;
-    this.liveText = "";
-
-    this.emit({ type: "status", status: "connecting" });
-
-    return new Promise((resolve) => {
-      this.pendingStart = { sessionId: mySessionId, resolve };
-      this.connect(mySessionId, settings);
-    });
-  }
-
-  /**
-   * Opens the WebSocket and wires every event handler for one connection
-   * attempt. Shared by `start()` (initial connect, with a pending start promise
-   * to settle) and `reconnectOnce()` (mid-session reconnect, no pending start).
-   * The reconnect path is distinguished purely by `this.isReconnecting`, so a
-   * construct/timeout failure reschedules instead of surfacing a fatal error.
-   */
-  private connect(mySessionId: number, settings: VoiceInputSettings): void {
-    let connection: WebSocket;
-    try {
-      connection = new WebSocket(OPENAI_REALTIME_URL, {
-        headers: buildOpenAIHeaders(
-          settings.openaiApiKey,
-          settings.organizationId,
-          settings.projectId
-        ),
-      });
-    } catch (err) {
-      const message = formatErrorMessage(err, "Failed to open WebSocket");
-      logError(`${P} ${message}`);
-      if (this.isReconnecting) {
-        this.scheduleReconnect(mySessionId, settings);
-      } else {
-        this.emit({ type: "error", message });
-        this.emit({ type: "status", status: "error" });
-        this.settlePendingStart(mySessionId, { ok: false, error: message });
-      }
-      return;
-    }
-
-    this.connection = connection;
-    logInfo(`${P} Opening OpenAI realtime WebSocket`, {
-      url: OPENAI_REALTIME_URL,
-      model: OPENAI_TRANSCRIPTION_MODEL,
-      language: settings.language || "en",
-      customDictionaryTerms: settings.customDictionary.length,
-      reconnectAttempt: this.isReconnecting ? this.reconnectAttempt : 0,
-    });
-
-    this.connectTimeout = setTimeout(() => {
-      this.connectTimeout = null;
-      if (this.sessionId !== mySessionId) return;
-      logError(`${P} Connection timed out (${CONNECT_TIMEOUT_MS}ms)`);
-      if (this.isReconnecting) {
-        // Force the dead socket closed; the `close` handler schedules the next
-        // reconnect attempt (or gives up once attempts are exhausted).
-        try {
-          connection.terminate();
-        } catch {
-          // Ignore terminate errors
-        }
-        return;
-      }
-      // Expected teardown — the trailing `close` from connection.close() must
-      // not override the "error" status below with "idle".
-      this.isExpectedClose = true;
-      try {
-        connection.close();
-      } catch {
-        // Ignore close errors
-      }
-      this.cleanupConnection();
-      this.emit({ type: "error", message: "Connection timed out" });
-      this.emit({ type: "status", status: "error" });
-      this.settlePendingStart(mySessionId, { ok: false, error: "Connection timed out" });
-    }, CONNECT_TIMEOUT_MS);
-
-    connection.on("pong", () => {
-      if (this.sessionId !== mySessionId || this.connection !== connection) return;
-      this.isAlive = true;
-    });
-
-    // Open handler — same logic for initial connect and reconnect.
-    connection.on("open", () => {
-      if (this.sessionId !== mySessionId) {
-        logWarn(`${P} Session expired during connect, closing`);
-        try {
-          connection.close();
-        } catch {
-          // Ignore close errors
-        }
-        return;
-      }
-      this.startHeartbeat(connection, mySessionId);
-      logInfo(`${P} WebSocket opened, sending session.update`);
-      // TODO: pass `transcription.prompt` from settings once #7832 lands.
-      // `turn_detection` MUST be explicitly `null` for `gpt-realtime-whisper`
-      // (VAD is not supported for this model). It is not enough to omit it:
-      // when absent the server applies a default VAD that this model can't
-      // use, and then silently produces no transcription — it still acks
-      // `input_audio_buffer.committed` but emits no `conversation.item.added`
-      // / `conversation.item.done`. With it set to `null`, each manual commit
-      // yields a transcribed item. (An explicit non-null `turn_detection`
-      // block, by contrast, is hard-rejected with an error event.)
-      const sessionUpdate = {
-        type: "session.update",
-        session: {
-          type: "transcription",
-          audio: {
-            input: {
-              format: { type: "audio/pcm", rate: 24000 },
-              transcription: {
-                model: OPENAI_TRANSCRIPTION_MODEL,
-                language: settings.language || "en",
-              },
-              turn_detection: null,
-            },
-          },
-        },
-      };
-      // Log the exact payload — the session config (especially the explicit
-      // `turn_detection: null`) is the most common cause of "commits acked
-      // but no transcription items" regressions.
-      logInfo(`${P} → session.update`, { session: sessionUpdate.session });
-      try {
-        connection.send(JSON.stringify(sessionUpdate));
-      } catch (err) {
-        const message = formatErrorMessage(err, "Failed to send session.update");
-        logError(`${P} ${message}`);
-        this.handleFatalError(mySessionId, message);
-      }
-    });
-
-    connection.on("message", (data) => {
-      if (this.sessionId !== mySessionId || this.connection !== connection) return;
-      const raw =
-        typeof data === "string"
-          ? data
-          : Buffer.isBuffer(data)
-            ? data.toString("utf8")
-            : Array.isArray(data)
-              ? Buffer.concat(data).toString("utf8")
-              : Buffer.from(data as ArrayBuffer).toString("utf8");
-
-      let parsed: Record<string, unknown>;
-      try {
-        parsed = JSON.parse(raw) as Record<string, unknown>;
-      } catch {
-        logWarn(`${P} Ignoring non-JSON message`, { raw: raw.slice(0, 200) });
-        return;
-      }
-
-      const type = typeof parsed.type === "string" ? parsed.type : "";
-      this.handleServerEvent(mySessionId, type, parsed);
-    });
-
-    connection.on("error", (err) => {
-      this.clearConnectTimeout();
-      if (this.sessionId !== mySessionId || this.connection !== connection) return;
-      const message = formatErrorMessage(err, "WebSocket error");
-      logError(`${P} WebSocket error`, { message });
-      // A transport error on a ready (or reconnecting) session is recoverable —
-      // `ws` always fires `close` right after `error`, and the close handler
-      // owns the reconnect decision, so just log here. A pre-ready error
-      // (auth/DNS/refused on the very first connect) is fatal: tear down now.
-      if (!this.isReady && !this.isReconnecting) {
-        this.handleFatalError(mySessionId, message);
-      }
-    });
-
-    connection.on("close", (code, reason) => {
-      this.clearConnectTimeout();
-      this.clearHeartbeat();
-      // Ignore the close of a socket that's already been superseded or torn down
-      // out-of-band (reconnect swap, or handleFatalError which terminates after
-      // nulling this.connection) — that path has already emitted its status.
-      if (this.sessionId !== mySessionId || this.connection !== connection) return;
-      const wasReady = this.isReady;
-      logInfo(`${P} WebSocket closed`, {
-        code,
-        reason: Buffer.isBuffer(reason) ? reason.toString("utf8") : String(reason ?? ""),
-        wasReady,
-        wasReconnecting: this.isReconnecting,
-        wasExpected: this.isExpectedClose,
-        wasDraining: this.isDraining,
-        audioChunksStreamed: this.audioChunkCount,
-      });
-      this.cleanupConnection();
-      if (this.isDraining) {
-        this.settleDrain("connection-closed");
-        return;
-      }
-      // An unexpected drop of a ready session (or a failed reconnect attempt
-      // while still mid-reconnect) is recoverable — schedule a retry instead of
-      // ending the session. Graceful stops and fatal errors set isExpectedClose.
-      if (!this.isExpectedClose && (wasReady || this.isReconnecting)) {
-        this.scheduleReconnect(mySessionId, settings);
-        return;
-      }
-      this.settlePendingStart(mySessionId, { ok: false, error: "Connection closed" });
-      // A deliberate teardown (fatal error / connect timeout) already emitted its
-      // terminal status ("error"); don't override it with "idle" here. Only an
-      // unexpected close of a never-ready connection should fall through to idle.
-      if (!this.isExpectedClose) {
-        this.emit({ type: "status", status: "idle" });
-      }
-    });
-  }
-
-  /**
-   * Starts the ping/pong heartbeat for one connection. `isAlive` is set true on
-   * open and on every pong; each interval tick terminates the socket if no pong
-   * arrived since the last ping, then sends a fresh ping. The session-id /
-   * socket-identity guard stops a stale interval from terminating a newer
-   * connection (lesson #4850).
-   */
-  private startHeartbeat(connection: WebSocket, mySessionId: number): void {
-    this.clearHeartbeat();
-    this.isAlive = true;
-    this.heartbeatInterval = setInterval(() => {
-      if (this.sessionId !== mySessionId || this.connection !== connection) {
-        this.clearHeartbeat();
-        return;
-      }
-      if (!this.isAlive) {
-        logWarn(`${P} Heartbeat: no pong, terminating half-open connection`);
-        try {
-          connection.terminate();
-        } catch {
-          // Ignore terminate errors — the close handler drives reconnect.
-        }
-        return;
-      }
-      this.isAlive = false;
-      try {
-        connection.ping();
-      } catch (err) {
-        logWarn(`${P} Heartbeat ping failed`, { message: formatErrorMessage(err, "ping failed") });
-      }
-    }, HEARTBEAT_INTERVAL_MS);
-  }
-
-  private clearHeartbeat(): void {
-    if (this.heartbeatInterval !== null) {
-      clearInterval(this.heartbeatInterval);
-      this.heartbeatInterval = null;
-    }
-  }
-
-  private clearReconnectTimer(): void {
-    if (this.reconnectTimer !== null) {
-      clearTimeout(this.reconnectTimer);
-      this.reconnectTimer = null;
-    }
-  }
-
-  /**
-   * Schedules the next reconnect attempt with exponential backoff + full jitter.
-   * Gives up (fatal error) once RECONNECT_MAX_ATTEMPTS is reached. The timer
-   * callback re-checks the session id so a `stop()`/new `start()` between
-   * scheduling and firing cancels it (lessons #4850/#4851).
-   */
-  private scheduleReconnect(mySessionId: number, settings: VoiceInputSettings): void {
-    if (this.sessionId !== mySessionId) return;
-    if (this.reconnectAttempt >= RECONNECT_MAX_ATTEMPTS) {
-      logError(`${P} Reconnect failed after ${RECONNECT_MAX_ATTEMPTS} attempts — giving up`);
-      this.isReconnecting = false;
-      this.handleFatalError(mySessionId, "Connection lost — reconnect failed");
-      return;
-    }
-
-    this.isReconnecting = true;
-    const ceiling = Math.min(
-      RECONNECT_CAP_MS,
-      RECONNECT_INITIAL_MS * RECONNECT_MULTIPLIER ** this.reconnectAttempt
-    );
-    const delay = Math.random() * ceiling;
-    this.reconnectAttempt++;
-    logInfo(`${P} Scheduling reconnect`, {
-      attempt: this.reconnectAttempt,
-      maxAttempts: RECONNECT_MAX_ATTEMPTS,
-      delayMs: Math.round(delay),
-    });
-    this.emit({ type: "status", status: "reconnecting" });
-
-    this.clearReconnectTimer();
-    this.reconnectTimer = setTimeout(() => {
-      this.reconnectTimer = null;
-      if (this.sessionId !== mySessionId) return;
-      this.reconnectOnce(mySessionId, settings);
-    }, delay);
-  }
-
-  /**
-   * Tears down the dead connection (without touching the session id, reconnect
-   * counter, or buffered audio) and opens a fresh one. Audio captured during
-   * the reconnect window stays in `preConnectBuffer` and is flushed once the new
-   * connection reaches `session.updated`.
-   */
-  private reconnectOnce(mySessionId: number, settings: VoiceInputSettings): void {
-    if (this.sessionId !== mySessionId) return;
-    logInfo(`${P} Reconnecting`, { attempt: this.reconnectAttempt });
-    this.cleanupConnection();
-    this.connect(mySessionId, settings);
-  }
-
-  private handleFatalError(mySessionId: number, message: string): void {
-    logError(`${P} Fatal error — tearing down session`, { message });
-    // Mark the close as expected so the trailing `close` event (after the
-    // socket tears down) isn't treated as a recoverable drop.
-    this.isExpectedClose = true;
-    this.isReconnecting = false;
-    this.clearReconnectTimer();
-    // Close the physical socket — a server-sent fatal `error` event leaves the
-    // connection open otherwise. Captured before cleanupConnection() nulls it.
-    const conn = this.connection;
-    this.cleanupConnection();
-    if (conn) {
-      try {
-        conn.terminate();
-      } catch {
-        // Ignore terminate errors
-      }
-    }
-    this.emit({ type: "error", message });
-    this.emit({ type: "status", status: "error" });
-    this.settlePendingStart(mySessionId, { ok: false, error: message });
-    this.settleDrain("fatal-error");
-  }
-
-  private handleServerEvent(
-    mySessionId: number,
-    type: string,
-    payload: Record<string, unknown>
-  ): void {
-    switch (type) {
-      case "session.created":
-        logInfo(`${P} ← session.created`, { session: payload.session });
-        return;
-
-      case "session.updated":
-        this.clearConnectTimeout();
-        // Log the session config the server actually applied — this is ground
-        // truth for whether `turn_detection`, model, and format took effect.
-        logInfo(`${P} ← session.updated — session ready`, { session: payload.session });
-        if (this.preConnectBuffer.length > 0 && this.connection) {
-          logInfo(`${P} Flushing ${this.preConnectBuffer.length} buffered audio chunks`);
-          // Detach the buffer before flushing so its state stays consistent even
-          // if a send throws partway through the loop.
-          const buffered = this.preConnectBuffer;
-          this.preConnectBuffer = [];
-          this.preConnectBufferBytes = 0;
-          for (const chunk of buffered) {
-            this.sendAudioJson(chunk);
-          }
-        }
-        // A successful (re)connection clears the reconnect state so a later drop
-        // gets a fresh full backoff budget.
-        this.reconnectAttempt = 0;
-        this.isReconnecting = false;
-        this.isReady = true;
-        this.startCommitTimer();
-        this.emit({ type: "status", status: "recording" });
-        this.settlePendingStart(mySessionId, { ok: true });
-        return;
-
-      case "input_audio_buffer.committed":
-        // Server ack that our commit landed. A transcription item
-        // (`conversation.item.added` then `.done`) should follow within ~1s; if
-        // it never does, the session config or the commit cadence is wrong.
-        logDebug(`${P} ← input_audio_buffer.committed`, {
-          itemId: typeof payload.item_id === "string" ? payload.item_id : undefined,
-        });
-        return;
-
-      case "input_audio_buffer.speech_started":
-      case "input_audio_buffer.speech_stopped":
-        // VAD signals — not expected for gpt-realtime-whisper (no turn
-        // detection), but log them if they appear; their presence would mean
-        // the server applied a VAD default we didn't ask for.
-        logInfo(`${P} ← ${type}`, { payload });
-        return;
-
-      case "conversation.item.input_audio_transcription.delta": {
-        const delta = typeof payload.delta === "string" ? payload.delta : "";
-        // Length only — dictated text is user content, kept out of logs.
-        logDebug(`${P} ← transcription.delta`, { length: delta.length });
-        if (!delta) return;
-        this.emit({ type: "delta", text: delta });
-        this.liveText += delta;
-        return;
-      }
-
-      case "conversation.item.input_audio_transcription.completed": {
-        // Side-channel transcription event used by conversation-style sessions.
-        // The `?intent=transcription` endpoint reports completions via
-        // `conversation.item.done` instead (handled below) — this case stays so
-        // a session that does emit it still works.
-        const transcript = typeof payload.transcript === "string" ? payload.transcript : "";
-        const itemId = typeof payload.item_id === "string" ? payload.item_id : undefined;
-        logInfo(`${P} ← transcription.completed`, { itemId, length: transcript.length });
-        this.handleTranscriptComplete(transcript, itemId);
-        return;
-      }
-
-      case "conversation.item.added": {
-        // The `?intent=transcription` endpoint creates the item shell here on
-        // commit; the transcript arrives with `conversation.item.done`.
-        const item = payload.item as
-          | { id?: string; content?: Array<{ type?: string; transcript?: string }> }
-          | undefined;
-        logDebug(`${P} ← conversation.item.added`, {
-          itemId: item?.id,
-          contentTypes: item?.content?.map((part) => part.type),
-        });
-        return;
-      }
-
-      case "conversation.item.done": {
-        // The `?intent=transcription` endpoint reports each committed segment's
-        // final transcript via `conversation.item.done`, not via
-        // `...input_audio_transcription.completed`. The text lives on the
-        // item's `input_audio` content part.
-        const item = payload.item as
-          | { id?: string; content?: Array<{ type?: string; transcript?: string }> }
-          | undefined;
-        const audioPart = item?.content?.find((part) => part.type === "input_audio");
-        const transcript = audioPart?.transcript ?? "";
-        // Length only — dictated text is user content, kept out of logs.
-        logInfo(`${P} ← conversation.item.done`, {
-          itemId: item?.id,
-          hasInputAudioPart: !!audioPart,
-          length: transcript.length,
-        });
-        if (!audioPart) {
-          // Not a transcription segment — don't count it against an
-          // outstanding commit, or a stray `done` could settle the drain early.
-          logWarn(`${P} conversation.item.done carried no input_audio content part — not counted`, {
-            contentTypes: item?.content?.map((part) => part.type),
-          });
-          return;
-        }
-        this.handleTranscriptComplete(transcript, item?.id);
-        return;
-      }
-
-      case "error": {
-        const errorPayload = payload.error as
-          | { message?: string; type?: string; code?: string; param?: string }
-          | undefined;
-        const message = errorPayload?.message ?? "OpenAI realtime error";
-        logError(`${P} ← server error event`, {
-          message,
-          type: errorPayload?.type,
-          code: errorPayload?.code,
-          param: errorPayload?.param,
-        });
-        this.handleFatalError(mySessionId, message);
-        return;
-      }
-
-      default:
-        // Log the full payload (truncated) so an unrecognised event shape is
-        // never invisible — this is how the conversation.item.done schema
-        // mismatch was originally caught.
-        logDebug(`${P} ← unhandled server event`, {
-          type,
-          payload: JSON.stringify(payload).slice(0, 600),
-        });
-    }
-  }
-
-  /**
-   * Handles one committed segment's transcript: emits it to the renderer and
-   * decrements the outstanding-commit counter. While draining, settles the
-   * drain the moment every committed segment has reported back. Shared by the
-   * `...input_audio_transcription.completed` and `conversation.item.done`
-   * paths since both report a committed segment.
-   *
-   * `itemId` is deduped: a completion already counted (e.g. a `.completed` and
-   * a `.done` for the same item, or a repeated frame) is ignored entirely, so
-   * it can't drop `pendingCommits` below the number genuinely in flight and
-   * settle the drain before the final transcript lands.
-   */
-  private handleTranscriptComplete(rawTranscript: string, itemId?: string): void {
-    if (itemId && this.completedItemIds.has(itemId)) {
-      logDebug(`${P} Duplicate completion for item ${itemId} — ignoring`);
-      return;
-    }
-    if (itemId) {
-      this.completedItemIds.add(itemId);
-    }
-
-    const transcript = rawTranscript.trim();
-    this.liveText = "";
-    if (this.pendingCommits > 0) {
-      this.pendingCommits--;
-    }
-    if (transcript) {
-      logDebug(`${P} Emitting complete transcript to renderer`, { length: transcript.length });
-      this.emit({ type: "complete", text: transcript, confidence: { ...STUB_CONFIDENCE } });
-    } else {
-      logDebug(`${P} Completion had an empty transcript — nothing emitted`);
-    }
-    // Each commit yields exactly one completion. Once every committed segment
-    // has reported back the drain is genuinely finished — no grace timer, no
-    // guessing whether a late final-commit transcript is still in flight.
-    if (this.isDraining && this.pendingCommits === 0) {
-      logDebug(`${P} All committed segments transcribed — settling drain`);
-      this.settleDrain("all-segments-transcribed");
-    }
-  }
-
-  private sendAudioJson(chunk: ArrayBuffer): void {
-    if (!this.connection) return;
-    const audio = Buffer.from(chunk).toString("base64");
-    try {
-      this.connection.send(JSON.stringify({ type: "input_audio_buffer.append", audio }));
-    } catch (err) {
-      // A send can throw if the socket transitioned to CLOSING mid-flush. Don't
-      // let it escape the buffer-flush loop (which would leave the buffer in a
-      // partially-cleared state) — the trailing `close` event drives reconnect.
-      logWarn(`${P} Failed to send audio chunk`, {
-        message: formatErrorMessage(err, "send failed"),
-      });
-      return;
-    }
-    this.bytesSinceCommit += chunk.byteLength;
+    // Subscribe before start() so the synchronous "connecting" status emitted
+    // during start() is forwarded to listeners.
+    this.providerUnsub = provider.onEvent((event) => this.emit(event));
+    return provider.start(settings);
   }
 
   sendAudioChunk(chunk: ArrayBuffer): void {
-    if (this.isDraining) return;
-
-    if (!this.isReady || !this.connection) {
-      // Buffer while connecting (initial) or reconnecting (mid-session drop) so
-      // audio captured during the gap is flushed once the session is ready.
-      if (this.connection || this.pendingStart || this.isReconnecting) {
-        this.bufferPreConnectChunk(chunk);
-      } else if (!this.staleChunkWarned) {
-        this.staleChunkWarned = true;
-        logWarn(`${P} sendAudioChunk called but no active session`);
-      }
-      return;
-    }
-    this.audioChunkCount++;
-    if (this.audioChunkCount <= 3 || this.audioChunkCount % 100 === 0) {
-      logDebug(`${P} Sending audio chunk #${this.audioChunkCount}`, {
-        bytes: chunk.byteLength,
-        bytesSinceCommit: this.bytesSinceCommit + chunk.byteLength,
-      });
-    }
-    this.sendAudioJson(chunk);
+    this.provider?.sendAudioChunk(chunk);
   }
 
-  /**
-   * Appends a chunk to the pre-connect / reconnect buffer, enforcing both a
-   * chunk-count cap and a byte cap. Oldest-wins: once either ceiling is hit the
-   * chunk is dropped (warned once) — a voice gap past ~3s is unrecoverable
-   * anyway, so there's no value in retaining unbounded audio.
-   */
-  private bufferPreConnectChunk(chunk: ArrayBuffer): void {
-    if (
-      this.preConnectBuffer.length >= PRE_CONNECT_BUFFER_MAX ||
-      this.preConnectBufferBytes + chunk.byteLength > PRE_CONNECT_BUFFER_MAX_BYTES
-    ) {
-      if (!this.preConnectBufferOverflowWarned) {
-        this.preConnectBufferOverflowWarned = true;
-        logWarn(`${P} Pre-connect buffer full, dropping audio`, {
-          chunks: this.preConnectBuffer.length,
-          bytes: this.preConnectBufferBytes,
-          maxChunks: PRE_CONNECT_BUFFER_MAX,
-          maxBytes: PRE_CONNECT_BUFFER_MAX_BYTES,
-        });
-      }
-      return;
-    }
-    this.preConnectBuffer.push(chunk);
-    this.preConnectBufferBytes += chunk.byteLength;
-  }
-
-  /**
-   * Tears down per-connection state without ending the session. Deliberately
-   * does NOT touch `sessionId`, `reconnectAttempt`, `isReconnecting`,
-   * `isExpectedClose`, or the pre-connect buffer — those survive across a
-   * reconnect. Use `cleanupPreviousSession()` for a full session reset.
-   */
-  private cleanupConnection(): void {
-    this.clearCommitTimer();
-    this.clearHeartbeat();
-    this.connection = null;
-    this.isReady = false;
-    this.isAlive = false;
-    this.bytesSinceCommit = 0;
-    this.pendingCommits = 0;
-    this.completedItemIds.clear();
-  }
-
-  private cleanupPreviousSession(): void {
-    logDebug(`${P} Cleaning up previous session`, {
-      sessionId: this.sessionId,
-      hasConnection: !!this.connection,
-    });
-    const pendingSessionId = this.pendingStart?.sessionId;
-    this.sessionId++;
-    this.audioChunkCount = 0;
-    this.staleChunkWarned = false;
-    this.preConnectBufferOverflowWarned = false;
-    this.isReady = false;
-    this.bytesSinceCommit = 0;
-    this.pendingCommits = 0;
-    this.completedItemIds.clear();
-    this.preConnectBuffer = [];
-    this.preConnectBufferBytes = 0;
-    this.clearConnectTimeout();
-    this.clearDrainTimeout();
-    this.clearCommitTimer();
-    this.clearHeartbeat();
-    this.clearReconnectTimer();
-    this.reconnectAttempt = 0;
-    this.isReconnecting = false;
-    this.isExpectedClose = false;
-    this.isAlive = false;
-    this.isDraining = false;
-    this.liveText = "";
-    if (this.drainResolve) {
-      this.drainResolve();
-      this.drainResolve = null;
-    }
-    this.drainPromise = null;
-    if (pendingSessionId !== undefined) {
-      this.settlePendingStart(pendingSessionId, { ok: false, error: "Voice session stopped" });
-    }
-    if (this.connection) {
-      try {
-        this.connection.close();
-      } catch {
-        // Ignore close errors
-      }
-      this.connection = null;
-    }
-  }
-
-  private clearDrainTimeout(): void {
-    if (this.drainTimeout !== null) {
-      clearTimeout(this.drainTimeout);
-      this.drainTimeout = null;
-    }
-  }
-
-  private startCommitTimer(): void {
-    this.clearCommitTimer();
-    logDebug(`${P} Starting interval commit timer`, { intervalMs: COMMIT_INTERVAL_MS });
-    this.commitTimer = setInterval(() => {
-      this.maybeCommitSegment("interval");
-    }, COMMIT_INTERVAL_MS);
-  }
-
-  private clearCommitTimer(): void {
-    if (this.commitTimer !== null) {
-      clearInterval(this.commitTimer);
-      this.commitTimer = null;
-    }
-  }
-
-  /**
-   * Sends `input_audio_buffer.commit` to close the current segment so the model
-   * transcribes it and streams back delta/completed events. No-ops when there's
-   * no live connection, the session isn't ready, we're already draining, or too
-   * little audio has accumulated since the last commit (OpenAI rejects an
-   * undersized buffer with a fatal error event).
-   */
-  private maybeCommitSegment(reason: string): void {
-    if (!this.connection || !this.isReady || this.isDraining) {
-      logDebug(`${P} Commit skipped — session not in a committable state`, {
-        reason,
-        hasConnection: !!this.connection,
-        isReady: this.isReady,
-        isDraining: this.isDraining,
-      });
-      return;
-    }
-    if (this.bytesSinceCommit < MIN_COMMIT_BYTES) {
-      logDebug(`${P} Commit skipped — buffer below threshold`, {
-        reason,
-        bytesSinceCommit: this.bytesSinceCommit,
-        thresholdBytes: MIN_COMMIT_BYTES,
-      });
-      return;
-    }
-    try {
-      this.connection.send(JSON.stringify({ type: "input_audio_buffer.commit" }));
-      this.pendingCommits++;
-      logDebug(`${P} → input_audio_buffer.commit`, {
-        reason,
-        bytes: this.bytesSinceCommit,
-        chunksStreamed: this.audioChunkCount,
-        pendingCommits: this.pendingCommits,
-      });
-      this.bytesSinceCommit = 0;
-    } catch (err) {
-      logWarn(`${P} Failed to commit audio segment`, {
-        reason,
-        message: formatErrorMessage(err, "commit failed"),
-      });
-    }
-  }
-
-  private settleDrain(reason: string): void {
-    this.clearDrainTimeout();
-    this.isDraining = false;
-    this.drainPromise = null;
-    if (this.drainResolve) {
-      logInfo(`${P} Drain completed`, { reason });
-      const resolve = this.drainResolve;
-      this.drainResolve = null;
-      resolve();
-    } else {
-      logDebug(`${P} settleDrain called with no pending drain`, { reason });
-    }
+  commitParagraphBoundary(): void {
+    this.provider?.commitParagraphBoundary();
   }
 
   async stopGracefully(): Promise<void> {
-    logInfo(`${P} stopGracefully() called`, {
-      sessionId: this.sessionId,
-      hasConnection: !!this.connection,
-    });
-
-    if (this.drainPromise) {
-      logDebug(`${P} Already draining, joining existing promise`);
-      return this.drainPromise;
-    }
-
-    // A graceful stop is an expected close — cancel any pending reconnect and
-    // stop the close handler from retrying.
-    this.isExpectedClose = true;
-    this.isReconnecting = false;
-    this.clearReconnectTimer();
-
-    if (!this.connection || !this.isReady) {
-      this.cleanupPreviousSession();
-      this.emit({ type: "status", status: "idle" });
-      return;
-    }
-
-    this.isDraining = true;
-    this.clearCommitTimer();
-    this.emit({ type: "status", status: "finishing" });
-
-    // Flush whatever audio accumulated since the last interval commit so its
-    // transcript is included. If too little remains, OpenAI would reject the
-    // commit as undersized — skip it; an interval commit's transcript may still
-    // be in flight, and `pendingCommits` already accounts for it.
-    if (this.bytesSinceCommit >= MIN_COMMIT_BYTES) {
-      try {
-        this.connection.send(JSON.stringify({ type: "input_audio_buffer.commit" }));
-        this.pendingCommits++;
-        logInfo(`${P} → input_audio_buffer.commit (final)`, {
-          bytes: this.bytesSinceCommit,
-          chunksStreamed: this.audioChunkCount,
-          pendingCommits: this.pendingCommits,
-        });
-        this.bytesSinceCommit = 0;
-      } catch {
-        logWarn(`${P} Failed to send final commit, closing immediately`);
-        this.cleanupPreviousSession();
-        this.emit({ type: "status", status: "idle" });
-        return;
-      }
-    } else {
-      logInfo(`${P} Stop with sub-threshold buffer — no final commit`, {
-        bytesSinceCommit: this.bytesSinceCommit,
-        thresholdBytes: MIN_COMMIT_BYTES,
-      });
-    }
-
-    const sessionIdBeforeDrain = this.sessionId;
-
-    // Drain only while there are committed segments still awaiting their
-    // `conversation.item.done`. If none are outstanding, the session is already
-    // fully transcribed — close immediately rather than waiting on a timer.
-    if (this.pendingCommits > 0) {
-      logInfo(`${P} Draining — awaiting ${this.pendingCommits} transcription(s)`);
-      this.drainPromise = new Promise<void>((resolve) => {
-        this.drainResolve = resolve;
-        this.drainTimeout = setTimeout(() => {
-          logWarn(`${P} Drain timed out after ${DRAIN_TIMEOUT_MS}ms, force closing`, {
-            pendingCommits: this.pendingCommits,
-          });
-          this.settleDrain("timeout");
-        }, DRAIN_TIMEOUT_MS);
-      });
-      await this.drainPromise;
-    } else {
-      logInfo(`${P} Nothing to drain — no outstanding transcriptions`);
-      this.isDraining = false;
-    }
-
-    // If start() was called during drain it already ran cleanupPreviousSession()
-    // and incremented sessionId — don't tear down the new session.
-    if (this.sessionId === sessionIdBeforeDrain) {
-      this.cleanupPreviousSession();
-      this.emit({ type: "status", status: "idle" });
-    }
+    if (!this.provider) return;
+    await this.provider.stopGracefully();
   }
 
   stop(): void {
-    logInfo(`${P} stop() called`, { sessionId: this.sessionId, hasConnection: !!this.connection });
-    // Suppress any reconnect: this is a deliberate stop. The sessionId bump in
-    // cleanupPreviousSession is the primary guard; the flag documents intent and
-    // covers the brief window before the bump takes effect.
-    this.isExpectedClose = true;
-    this.isReconnecting = false;
-    this.clearReconnectTimer();
-    this.cleanupPreviousSession();
-    this.emit({ type: "status", status: "idle" });
+    this.provider?.stop();
   }
 
   destroy(): void {
-    this.stop();
+    this.disposeProvider();
     this.listeners.clear();
   }
 }

--- a/electron/services/__tests__/VoiceTranscriptionService.integration.test.ts
+++ b/electron/services/__tests__/VoiceTranscriptionService.integration.test.ts
@@ -26,8 +26,10 @@ describe("VoiceTranscriptionService integration", () => {
       const result = await service.start({
         enabled: true,
         openaiApiKey: OPENAI_API_KEY,
+        deepgramApiKey: "",
         language: "en",
         customDictionary: [],
+        transcriptionProvider: "openai",
         transcriptionModel: "gpt-realtime-whisper",
         correctionEnabled: false,
         correctionModel: "gpt-5-mini",

--- a/electron/services/__tests__/VoiceTranscriptionService.test.ts
+++ b/electron/services/__tests__/VoiceTranscriptionService.test.ts
@@ -3,10 +3,10 @@ import type { VoiceInputSettings } from "../../../shared/types/ipc/api.js";
 
 // ── Mock the `ws` package ────────────────────────────────────────────────────
 //
-// The service imports `WebSocket from "ws"` (the npm package, not the WHATWG
-// global) because Node's global WebSocket constructor silently drops the
-// custom-headers option needed for OpenAI auth. We mock the entire module so
-// the constructor returns a controllable EventEmitter-style stub.
+// The coordinator delegates to a concrete provider (OpenAI or Deepgram), each
+// of which imports `WebSocket from "ws"`. We mock the module once so both
+// providers receive the same controllable stub. The stub records string control
+// frames and binary audio frames so the test can tell the two transports apart.
 
 interface MockOptions {
   headers: Record<string, string>;
@@ -23,11 +23,9 @@ class MockWebSocket {
   url: string;
   options: MockOptions;
   readyState: number = MockWebSocket.CONNECTING;
-  sent: string[] = [];
+  sent: Array<string | Buffer> = [];
   closeCalls = 0;
-  closeCode?: number;
   terminateCalls = 0;
-  pingCalls = 0;
 
   private listeners: Map<string, Set<WsListener>> = new Map();
 
@@ -60,33 +58,23 @@ class MockWebSocket {
     for (const listener of set) listener(...args);
   }
 
-  send(payload: string): void {
+  send(payload: string | Buffer): void {
     this.sent.push(payload);
   }
 
   close(code?: number): void {
     this.closeCalls++;
-    this.closeCode = code;
+    void code;
     this.readyState = MockWebSocket.CLOSED;
   }
 
-  // `ws.terminate()` destroys the socket without a closing handshake. The real
-  // package fires a `close` event afterward; mirror that so the service's
-  // close-driven reconnect path is exercised.
   terminate(): void {
     this.terminateCalls++;
     this.readyState = MockWebSocket.CLOSED;
     this.fire("close", 1006, undefined);
   }
 
-  ping(): void {
-    this.pingCalls++;
-  }
-
-  // Test helpers
-  simulatePong(): void {
-    this.fire("pong");
-  }
+  ping(): void {}
 
   simulateOpen(): void {
     this.readyState = MockWebSocket.OPEN;
@@ -97,48 +85,38 @@ class MockWebSocket {
     this.fire("message", Buffer.from(JSON.stringify({ type, ...payload })));
   }
 
-  simulateRawMessage(data: string | Buffer): void {
-    this.fire("message", data);
+  textFrames(): Array<Record<string, unknown>> {
+    return this.sent
+      .filter((s): s is string => typeof s === "string")
+      .map((s) => JSON.parse(s) as Record<string, unknown>);
   }
 
-  simulateError(err: Error = new Error("WebSocket error")): void {
-    this.fire("error", err);
-  }
-
-  simulateClose(code?: number, reason?: Buffer | string): void {
-    this.readyState = MockWebSocket.CLOSED;
-    this.fire("close", code, reason);
-  }
-
-  sentJson(): Array<Record<string, unknown>> {
-    return this.sent.map((s) => JSON.parse(s) as Record<string, unknown>);
+  binaryFrames(): Buffer[] {
+    return this.sent.filter((s): s is Buffer => Buffer.isBuffer(s));
   }
 }
 
 const instances: MockWebSocket[] = [];
-let throwOnConstruct = false;
-let constructError: Error | null = null;
 
 vi.mock("ws", () => {
   const ctor = function (this: unknown, url: string, options: MockOptions) {
-    if (throwOnConstruct) {
-      throw constructError ?? new Error("WebSocket construction failed");
-    }
     return new MockWebSocket(url, options);
   } as unknown as new (url: string, options: MockOptions) => MockWebSocket;
   return { default: ctor };
 });
 
-// Import the service AFTER vi.mock so the mocked `ws` is used.
+// Import AFTER vi.mock so the providers use the mocked `ws`.
 const { VoiceTranscriptionService } = await import("../VoiceTranscriptionService.js");
 type VoiceTranscriptionServiceInstance = InstanceType<typeof VoiceTranscriptionService>;
 type VoiceTranscriptionEvent = import("../VoiceTranscriptionService.js").VoiceTranscriptionEvent;
 
-const BASE_SETTINGS: VoiceInputSettings = {
+const OPENAI_SETTINGS: VoiceInputSettings = {
   enabled: true,
   openaiApiKey: "sk-test",
+  deepgramApiKey: "",
   language: "en",
   customDictionary: [],
+  transcriptionProvider: "openai",
   transcriptionModel: "gpt-realtime-whisper",
   correctionEnabled: false,
   correctionModel: "gpt-5-mini",
@@ -150,42 +128,45 @@ const BASE_SETTINGS: VoiceInputSettings = {
   projectId: "",
 };
 
+const DEEPGRAM_SETTINGS: VoiceInputSettings = {
+  ...OPENAI_SETTINGS,
+  openaiApiKey: "",
+  deepgramApiKey: "dg-test",
+  transcriptionProvider: "deepgram",
+};
+
 function latestInstance(): MockWebSocket {
   const instance = instances.at(-1);
   if (!instance) throw new Error("No MockWebSocket instance created");
   return instance;
 }
 
-/** Advance the service through connect → ready. Returns the active mock socket. */
-async function bringSessionReady(
-  service: VoiceTranscriptionServiceInstance,
-  settings: VoiceInputSettings = BASE_SETTINGS
-): Promise<{ socket: MockWebSocket; result: { ok: true } | { ok: false; error: string } }> {
-  const startPromise = service.start(settings);
-  // start() runs synchronously through to assigning pendingStart; allow the
-  // microtask queue to settle so the constructor + onopen wiring is in place.
+async function bringOpenAiReady(
+  service: VoiceTranscriptionServiceInstance
+): Promise<MockWebSocket> {
+  const startPromise = service.start(OPENAI_SETTINGS);
   await Promise.resolve();
   const socket = latestInstance();
   socket.simulateOpen();
   socket.simulateMessage("session.updated");
-  const result = await startPromise;
-  return { socket, result };
+  await startPromise;
+  return socket;
 }
 
-/**
- * Feed enough uncommitted audio that the next `input_audio_buffer.commit` clears
- * the MIN_COMMIT_BYTES floor — otherwise the service skips the commit to avoid
- * OpenAI's "undersized buffer" error.
- */
-function feedCommittableAudio(service: VoiceTranscriptionServiceInstance): void {
-  service.sendAudioChunk(new Uint8Array(5_000).buffer);
+async function bringDeepgramReady(
+  service: VoiceTranscriptionServiceInstance
+): Promise<MockWebSocket> {
+  const startPromise = service.start(DEEPGRAM_SETTINGS);
+  await Promise.resolve();
+  const socket = latestInstance();
+  socket.simulateOpen();
+  await startPromise;
+  return socket;
 }
 
-describe("VoiceTranscriptionService", () => {
+describe("VoiceTranscriptionService (coordinator)", () => {
   beforeEach(() => {
     instances.length = 0;
-    throwOnConstruct = false;
-    constructError = null;
     vi.useFakeTimers();
   });
 
@@ -194,975 +175,162 @@ describe("VoiceTranscriptionService", () => {
     vi.restoreAllMocks();
   });
 
-  // ── Startup / readiness ──────────────────────────────────────────────────
+  // ── Provider selection ──────────────────────────────────────────────────
 
-  it("fails to start when no OpenAI API key is configured", async () => {
+  it("routes to the OpenAI provider for transcriptionProvider 'openai'", async () => {
     const service = new VoiceTranscriptionService();
-    const result = await service.start({ ...BASE_SETTINGS, openaiApiKey: "" });
-    expect(result).toEqual({ ok: false, error: "OpenAI API key not configured" });
-    expect(instances).toHaveLength(0);
-  });
-
-  it("constructs the WebSocket with the realtime URL and auth headers", async () => {
-    const service = new VoiceTranscriptionService();
-    void service.start({ ...BASE_SETTINGS, openaiApiKey: "sk-abc" });
+    void service.start(OPENAI_SETTINGS);
     await Promise.resolve();
     const socket = latestInstance();
     expect(socket.url).toBe("wss://api.openai.com/v1/realtime?intent=transcription");
-    expect(socket.options.headers.Authorization).toBe("Bearer sk-abc");
+    expect(socket.options.headers.Authorization).toBe("Bearer sk-test");
     service.stop();
   });
 
-  it("sends session.update on WebSocket open and stays not-ready until session.updated", async () => {
+  it("routes to the Deepgram provider for transcriptionProvider 'deepgram'", async () => {
+    const service = new VoiceTranscriptionService();
+    void service.start(DEEPGRAM_SETTINGS);
+    await Promise.resolve();
+    const socket = latestInstance();
+    expect(new URL(socket.url).host).toBe("api.deepgram.com");
+    expect(socket.options.headers.Authorization).toBe("Token dg-test");
+    service.stop();
+  });
+
+  // ── Event forwarding ──────────────────────────────────────────────────────
+
+  it("forwards provider status events to subscribers", async () => {
     const service = new VoiceTranscriptionService();
     const statuses: string[] = [];
     service.onEvent((e) => {
       if (e.type === "status") statuses.push(e.status);
     });
-
-    const startPromise = service.start(BASE_SETTINGS);
-    expect(statuses).toEqual(["connecting"]);
-    await Promise.resolve();
-    const socket = latestInstance();
-    socket.simulateOpen();
-
-    expect(socket.sent).toHaveLength(1);
-    const sessionUpdate = JSON.parse(socket.sent[0]) as {
-      type: string;
-      session: { type: string; audio: { input: Record<string, unknown> } };
-    };
-    expect(sessionUpdate.type).toBe("session.update");
-    expect(sessionUpdate.session.type).toBe("transcription");
-    expect(sessionUpdate.session.audio.input).toMatchObject({
-      format: { type: "audio/pcm", rate: 24000 },
-      transcription: { model: "gpt-realtime-whisper", language: "en" },
-    });
-    // `turn_detection` must be EXPLICITLY null for gpt-realtime-whisper — see
-    // the session.update comment in VoiceTranscriptionService. Omitting it
-    // makes the server silently emit no transcription items.
-    expect(sessionUpdate.session.audio.input.turn_detection).toBeNull();
-
-    // Still not ready — start() must wait for session.updated
-    expect(statuses).toEqual(["connecting"]);
-
-    socket.simulateMessage("session.updated");
-    await expect(startPromise).resolves.toEqual({ ok: true });
+    await bringOpenAiReady(service);
     expect(statuses).toEqual(["connecting", "recording"]);
-  });
-
-  it("uses the configured language in session.update", async () => {
-    const service = new VoiceTranscriptionService();
-    void service.start({ ...BASE_SETTINGS, language: "es" });
-    await Promise.resolve();
-    const socket = latestInstance();
-    socket.simulateOpen();
-    const payload = JSON.parse(socket.sent[0]) as {
-      session: { audio: { input: { transcription: { language: string } } } };
-    };
-    expect(payload.session.audio.input.transcription.language).toBe("es");
     service.stop();
   });
 
-  it("settles a pending start when the session is stopped before session.updated", async () => {
-    const service = new VoiceTranscriptionService();
-    const startPromise = service.start(BASE_SETTINGS);
-    await Promise.resolve();
-    latestInstance().simulateOpen();
-    // No session.updated yet — stop before ready.
-    service.stop();
-    await expect(startPromise).resolves.toEqual({
-      ok: false,
-      error: "Voice session stopped",
-    });
-  });
-
-  it("does not emit idle when start() replaces a previous session", async () => {
-    const service = new VoiceTranscriptionService();
-    await bringSessionReady(service);
-
-    const events: VoiceTranscriptionEvent[] = [];
-    service.onEvent((e) => events.push(e));
-
-    const secondPromise = service.start(BASE_SETTINGS);
-    const idleBeforeConnect = events.filter((e) => e.type === "status" && e.status === "idle");
-    expect(idleBeforeConnect).toHaveLength(0);
-
-    await Promise.resolve();
-    const socket = latestInstance();
-    socket.simulateOpen();
-    socket.simulateMessage("session.updated");
-    await secondPromise;
-  });
-
-  it("times out and closes the socket if session.updated does not arrive within 10s", async () => {
-    const service = new VoiceTranscriptionService();
-    const errors: string[] = [];
-    service.onEvent((e) => {
-      if (e.type === "error") errors.push(e.message);
-    });
-
-    const startPromise = service.start(BASE_SETTINGS);
-    await Promise.resolve();
-    const socket = latestInstance();
-    socket.simulateOpen();
-    // Never simulate session.updated.
-
-    vi.advanceTimersByTime(10_000);
-
-    await expect(startPromise).resolves.toEqual({ ok: false, error: "Connection timed out" });
-    expect(errors).toContain("Connection timed out");
-    expect(socket.closeCalls).toBe(1);
-  });
-
-  // ── Delta / complete events ──────────────────────────────────────────────
-
-  it("emits delta for incremental transcription deltas", async () => {
-    const service = new VoiceTranscriptionService();
-    const deltas: string[] = [];
-    service.onEvent((e) => {
-      if (e.type === "delta") deltas.push(e.text);
-    });
-
-    const { socket } = await bringSessionReady(service);
-    socket.simulateMessage("conversation.item.input_audio_transcription.delta", {
-      delta: "Hello",
-    });
-    socket.simulateMessage("conversation.item.input_audio_transcription.delta", {
-      delta: " world",
-    });
-
-    expect(deltas).toEqual(["Hello", " world"]);
-  });
-
-  it("ignores empty deltas", async () => {
-    const service = new VoiceTranscriptionService();
-    const deltas: string[] = [];
-    service.onEvent((e) => {
-      if (e.type === "delta") deltas.push(e.text);
-    });
-
-    const { socket } = await bringSessionReady(service);
-    socket.simulateMessage("conversation.item.input_audio_transcription.delta", { delta: "" });
-    socket.simulateMessage("conversation.item.input_audio_transcription.delta", {});
-
-    expect(deltas).toEqual([]);
-  });
-
-  it("emits complete with stub confidence on transcription.completed", async () => {
+  it("forwards delta and complete events from the active provider", async () => {
     const service = new VoiceTranscriptionService();
     const events: VoiceTranscriptionEvent[] = [];
     service.onEvent((e) => events.push(e));
 
-    const { socket } = await bringSessionReady(service);
+    const socket = await bringOpenAiReady(service);
+    socket.simulateMessage("conversation.item.input_audio_transcription.delta", { delta: "Hi" });
     socket.simulateMessage("conversation.item.input_audio_transcription.completed", {
-      transcript: "Hello world",
+      transcript: "Hi there",
     });
 
-    const complete = events.find((e) => e.type === "complete");
-    expect(complete).toEqual({
-      type: "complete",
-      text: "Hello world",
-      confidence: { minConfidence: 1.0, wordCount: 0, uncertainWords: [], words: [] },
-    });
-  });
-
-  it("does not emit complete when transcript is empty or whitespace-only", async () => {
-    const service = new VoiceTranscriptionService();
-    const completes: string[] = [];
-    service.onEvent((e) => {
-      if (e.type === "complete") completes.push(e.text);
-    });
-
-    const { socket } = await bringSessionReady(service);
-    socket.simulateMessage("conversation.item.input_audio_transcription.completed", {
-      transcript: "",
-    });
-    socket.simulateMessage("conversation.item.input_audio_transcription.completed", {
-      transcript: "   ",
-    });
-    socket.simulateMessage("conversation.item.input_audio_transcription.completed", {});
-
-    expect(completes).toEqual([]);
-  });
-
-  it("emits complete from a conversation.item.done event (intent=transcription endpoint)", async () => {
-    const service = new VoiceTranscriptionService();
-    const events: VoiceTranscriptionEvent[] = [];
-    service.onEvent((e) => events.push(e));
-
-    const { socket } = await bringSessionReady(service);
-    // The `?intent=transcription` endpoint reports each committed segment via
-    // conversation.item.done; the transcript lives on the input_audio part.
-    socket.simulateMessage("conversation.item.added", {
-      item: { content: [{ type: "input_audio" }] },
-    });
-    socket.simulateMessage("conversation.item.done", {
-      item: {
-        content: [{ type: "input_audio", transcript: "hello from done" }],
-      },
-    });
-
-    const complete = events.find((e) => e.type === "complete");
-    expect(complete).toEqual({
-      type: "complete",
-      text: "hello from done",
-      confidence: { minConfidence: 1.0, wordCount: 0, uncertainWords: [], words: [] },
-    });
-  });
-
-  it("ignores a conversation.item.done with no input_audio transcript", async () => {
-    const service = new VoiceTranscriptionService();
-    const completes: string[] = [];
-    service.onEvent((e) => {
-      if (e.type === "complete") completes.push(e.text);
-    });
-
-    const { socket } = await bringSessionReady(service);
-    socket.simulateMessage("conversation.item.done", { item: { content: [] } });
-    socket.simulateMessage("conversation.item.done", {
-      item: { content: [{ type: "input_audio", transcript: "   " }] },
-    });
-    socket.simulateMessage("conversation.item.done", {});
-
-    expect(completes).toEqual([]);
-  });
-
-  // ── Audio chunk handling ─────────────────────────────────────────────────
-
-  it("sends audio chunks as base64 input_audio_buffer.append after session.updated", async () => {
-    const service = new VoiceTranscriptionService();
-    const { socket } = await bringSessionReady(service);
-
-    const chunk = new Uint8Array([1, 2, 3, 4]).buffer;
-    const sentBeforeAudio = socket.sent.length;
-    service.sendAudioChunk(chunk);
-    expect(socket.sent.length).toBe(sentBeforeAudio + 1);
-    const payload = JSON.parse(socket.sent.at(-1)!) as { type: string; audio: string };
-    expect(payload.type).toBe("input_audio_buffer.append");
-    expect(payload.audio).toBe(Buffer.from(chunk).toString("base64"));
-  });
-
-  it("buffers pre-connect audio chunks and flushes them after session.updated", async () => {
-    const service = new VoiceTranscriptionService();
-    const startPromise = service.start(BASE_SETTINGS);
-    await Promise.resolve();
-    const socket = latestInstance();
-
-    // Queue chunks before the WS open / session.updated round-trip.
-    service.sendAudioChunk(new Uint8Array([1]).buffer);
-    service.sendAudioChunk(new Uint8Array([2]).buffer);
-
-    expect(socket.sent).toHaveLength(0);
-
-    socket.simulateOpen();
-    // session.update sent on open, no audio yet
-    expect(socket.sent).toHaveLength(1);
-
-    socket.simulateMessage("session.updated");
-    await startPromise;
-
-    const audioPayloads = socket
-      .sentJson()
-      .filter((p) => p.type === "input_audio_buffer.append")
-      .map((p) => p.audio as string);
-    expect(audioPayloads).toEqual([
-      Buffer.from(new Uint8Array([1])).toString("base64"),
-      Buffer.from(new Uint8Array([2])).toString("base64"),
-    ]);
-  });
-
-  it("caps the pre-connect buffer at 100 chunks and warns once on overflow", async () => {
-    const service = new VoiceTranscriptionService();
-    void service.start(BASE_SETTINGS);
-    await Promise.resolve();
-
-    // Push 105 chunks before session.updated — last 5 should be dropped.
-    for (let i = 0; i < 105; i++) {
-      service.sendAudioChunk(new Uint8Array([i % 256]).buffer);
-    }
-    const socket = latestInstance();
-    socket.simulateOpen();
-    socket.simulateMessage("session.updated");
-
-    const audioCount = socket
-      .sentJson()
-      .filter((p) => p.type === "input_audio_buffer.append").length;
-    expect(audioCount).toBe(100);
+    expect(events.some((e) => e.type === "delta" && e.text === "Hi")).toBe(true);
+    expect(events.some((e) => e.type === "complete" && e.text === "Hi there")).toBe(true);
     service.stop();
   });
 
-  it("drops audio chunks while draining", async () => {
-    const service = new VoiceTranscriptionService();
-    const { socket } = await bringSessionReady(service);
+  // ── Server-VAD-driven segmentation difference ─────────────────────────────
 
-    // Feed enough audio that stop sends a real final commit and genuinely drains.
-    feedCommittableAudio(service);
-    const drainPromise = service.stopGracefully();
-    const sentAtStartOfDrain = socket.sent.length;
-    service.sendAudioChunk(new Uint8Array([99]).buffer);
-    expect(socket.sent.length).toBe(sentAtStartOfDrain);
-
-    socket.simulateMessage("conversation.item.done", {
-      item: { content: [{ type: "input_audio", transcript: "done" }] },
-    });
-    await drainPromise;
-  });
-
-  // ── Interval commit ──────────────────────────────────────────────────────
-  // gpt-realtime-whisper has no server VAD, so the service commits the input
-  // buffer on a timer to drive segmentation; without commits no transcription
-  // events ever arrive.
-
-  it("commits the audio buffer on the interval timer once enough audio has streamed", async () => {
-    const service = new VoiceTranscriptionService();
-    const { socket } = await bringSessionReady(service);
-
-    feedCommittableAudio(service);
-    expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(0);
-
+  it("runs the client commit timer for OpenAI but not for Deepgram", async () => {
+    const openai = new VoiceTranscriptionService();
+    const openaiSocket = await bringOpenAiReady(openai);
+    openai.sendAudioChunk(new Uint8Array(5_000).buffer);
     vi.advanceTimersByTime(2_000);
-    expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(1);
+    expect(
+      openaiSocket.textFrames().filter((f) => f.type === "input_audio_buffer.commit")
+    ).toHaveLength(1);
+    openai.stop();
 
-    service.stop();
-  });
-
-  it("skips the interval commit when too little audio has streamed since the last commit", async () => {
-    const service = new VoiceTranscriptionService();
-    const { socket } = await bringSessionReady(service);
-
-    // A tiny chunk, well under MIN_COMMIT_BYTES — committing it would draw a
-    // fatal "undersized buffer" error from OpenAI, so the timer must skip it.
-    service.sendAudioChunk(new Uint8Array(10).buffer);
-    vi.advanceTimersByTime(2_000);
-    expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(0);
-
-    service.stop();
-  });
-
-  it("commitParagraphBoundary flushes the current segment when enough audio has streamed", async () => {
-    const service = new VoiceTranscriptionService();
-    const { socket } = await bringSessionReady(service);
-
-    feedCommittableAudio(service);
-    service.commitParagraphBoundary();
-    expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(1);
-
-    service.stop();
-  });
-
-  // ── Graceful stop / drain ────────────────────────────────────────────────
-
-  it("sends input_audio_buffer.commit on stopGracefully and waits for completed", async () => {
-    const service = new VoiceTranscriptionService();
-    const statuses: string[] = [];
-    service.onEvent((e) => {
-      if (e.type === "status") statuses.push(e.status);
-    });
-
-    const { socket } = await bringSessionReady(service);
-    feedCommittableAudio(service);
-    const drainPromise = service.stopGracefully();
-    expect(statuses).toContain("finishing");
-
-    const commitPayloads = socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit");
-    expect(commitPayloads).toHaveLength(1);
-
-    socket.simulateMessage("conversation.item.done", {
-      item: { content: [{ type: "input_audio", transcript: "final" }] },
-    });
-    await drainPromise;
-    expect(statuses.at(-1)).toBe("idle");
-  });
-
-  it("drain waits for every outstanding commit's transcript, not just the first", async () => {
-    const service = new VoiceTranscriptionService();
-    const completes: string[] = [];
-    service.onEvent((e) => {
-      if (e.type === "complete") completes.push(e.text);
-    });
-
-    const { socket } = await bringSessionReady(service);
-    // An interval commit goes out (segment A), then more audio accumulates and
-    // stop sends a final commit (segment B) — two transcripts now outstanding.
-    feedCommittableAudio(service);
-    vi.advanceTimersByTime(2_000);
-    feedCommittableAudio(service);
-    const drainPromise = service.stopGracefully();
-    expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(2);
-
-    let settled = false;
-    void drainPromise.then(() => {
-      settled = true;
-    });
-
-    // Segment A completes first — drain must NOT settle, B is still in flight.
-    socket.simulateMessage("conversation.item.done", {
-      item: { content: [{ type: "input_audio", transcript: "first half" }] },
-    });
-    await Promise.resolve();
-    expect(settled).toBe(false);
-
-    // Segment B completes — every outstanding commit has now reported back.
-    socket.simulateMessage("conversation.item.done", {
-      item: { content: [{ type: "input_audio", transcript: "second half" }] },
-    });
-    await drainPromise;
-    expect(completes).toEqual(["first half", "second half"]);
-  });
-
-  it("drain resolves after the timeout if no completion arrives", async () => {
-    const service = new VoiceTranscriptionService();
-    await bringSessionReady(service);
-    feedCommittableAudio(service);
-
-    const drainPromise = service.stopGracefully();
-    vi.advanceTimersByTime(3_000);
-    await expect(drainPromise).resolves.toBeUndefined();
-  });
-
-  it("stop with a sub-threshold buffer and nothing outstanding resolves immediately", async () => {
-    const service = new VoiceTranscriptionService();
-    const { socket } = await bringSessionReady(service);
-
-    // No audio since the last commit and no commits in flight — nothing to
-    // transcribe, so stop closes without sending a commit or arming a timer.
-    const drainPromise = service.stopGracefully();
-    await expect(drainPromise).resolves.toBeUndefined();
-    expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(0);
-  });
-
-  it("stop with a sub-threshold buffer still drains for an in-flight interval commit", async () => {
-    const service = new VoiceTranscriptionService();
-    const completes: string[] = [];
-    service.onEvent((e) => {
-      if (e.type === "complete") completes.push(e.text);
-    });
-
-    const { socket } = await bringSessionReady(service);
-    // An interval commit went out; its transcript hasn't come back yet.
-    feedCommittableAudio(service);
-    vi.advanceTimersByTime(2_000);
-    expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(1);
-
-    // Stop with nothing new buffered — no final commit, but the drain must
-    // still wait for the outstanding interval commit's transcript.
-    const drainPromise = service.stopGracefully();
-    expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(1);
-
-    let settled = false;
-    void drainPromise.then(() => {
-      settled = true;
-    });
-    await Promise.resolve();
-    expect(settled).toBe(false);
-
-    socket.simulateMessage("conversation.item.done", {
-      item: { content: [{ type: "input_audio", transcript: "tail" }] },
-    });
-    await drainPromise;
-    expect(completes).toEqual(["tail"]);
-  });
-
-  it("ignores a duplicate conversation.item.done for the same item during drain", async () => {
-    const service = new VoiceTranscriptionService();
-    const completes: string[] = [];
-    service.onEvent((e) => {
-      if (e.type === "complete") completes.push(e.text);
-    });
-
-    const { socket } = await bringSessionReady(service);
-    // Two outstanding commits: an interval commit, then a final commit on stop.
-    feedCommittableAudio(service);
-    vi.advanceTimersByTime(2_000);
-    feedCommittableAudio(service);
-    const drainPromise = service.stopGracefully();
-
-    let settled = false;
-    void drainPromise.then(() => {
-      settled = true;
-    });
-
-    // Segment A completes, then a DUPLICATE of A arrives — the duplicate must
-    // not be counted again (which would settle the drain while B is still in
-    // flight) and must not re-emit A's transcript.
-    const itemADone = {
-      item: { id: "item-A", content: [{ type: "input_audio", transcript: "alpha" }] },
-    };
-    socket.simulateMessage("conversation.item.done", itemADone);
-    socket.simulateMessage("conversation.item.done", itemADone);
-    await Promise.resolve();
-    expect(settled).toBe(false);
-    expect(completes).toEqual(["alpha"]);
-
-    // Segment B completes — now every outstanding commit has reported back.
-    socket.simulateMessage("conversation.item.done", {
-      item: { id: "item-B", content: [{ type: "input_audio", transcript: "beta" }] },
-    });
-    await drainPromise;
-    expect(completes).toEqual(["alpha", "beta"]);
-  });
-
-  it("does not let a conversation.item.done without an input_audio part settle the drain", async () => {
-    const service = new VoiceTranscriptionService();
-    const { socket } = await bringSessionReady(service);
-
-    feedCommittableAudio(service);
-    const drainPromise = service.stopGracefully(); // one outstanding commit
-
-    let settled = false;
-    void drainPromise.then(() => {
-      settled = true;
-    });
-
-    // A `done` with no input_audio content part — not a transcription segment,
-    // so it must not be counted against the outstanding commit.
-    socket.simulateMessage("conversation.item.done", {
-      item: { id: "item-noaudio", content: [{ type: "text" }] },
-    });
-    await Promise.resolve();
-    expect(settled).toBe(false);
-
-    socket.simulateMessage("conversation.item.done", {
-      item: { id: "item-real", content: [{ type: "input_audio", transcript: "real" }] },
-    });
-    await drainPromise;
-  });
-
-  it("repeated stopGracefully calls share a single in-flight drain", async () => {
-    const service = new VoiceTranscriptionService();
-    const { socket } = await bringSessionReady(service);
-    feedCommittableAudio(service);
-
-    const first = service.stopGracefully();
-    const second = service.stopGracefully();
-
-    // Only one commit is sent, even though stop was called twice.
-    const commits = socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit");
-    expect(commits).toHaveLength(1);
-
-    socket.simulateMessage("conversation.item.done", {
-      item: { content: [{ type: "input_audio", transcript: "ok" }] },
-    });
-    await Promise.all([first, second]);
-  });
-
-  it("stopGracefully without an open connection goes straight to idle", async () => {
-    const service = new VoiceTranscriptionService();
-    const statuses: string[] = [];
-    service.onEvent((e) => {
-      if (e.type === "status") statuses.push(e.status);
-    });
-
-    await service.stopGracefully();
-    expect(statuses).toEqual(["idle"]);
-  });
-
-  it("start() during an in-flight drain resolves the old drain and reaches recording", async () => {
-    const service = new VoiceTranscriptionService();
-    const statuses: string[] = [];
-    service.onEvent((e) => {
-      if (e.type === "status") statuses.push(e.status);
-    });
-
-    const { socket: firstSocket } = await bringSessionReady(service);
-    feedCommittableAudio(service);
-    const drainPromise = service.stopGracefully();
-    // Don't simulate completion — drain is still in flight when start() runs.
-
-    const secondStart = service.start(BASE_SETTINGS);
-    await Promise.resolve();
-    const secondSocket = latestInstance();
-    secondSocket.simulateOpen();
-    secondSocket.simulateMessage("session.updated");
-    await secondStart;
-
-    // The first drain resolves once cleanupPreviousSession fires from start().
-    await drainPromise;
-
-    // Old commit was sent, new commit was NOT (new session has no drain).
-    const commitsOnFirst = firstSocket
-      .sentJson()
-      .filter((p) => p.type === "input_audio_buffer.commit").length;
-    const commitsOnSecond = secondSocket
-      .sentJson()
-      .filter((p) => p.type === "input_audio_buffer.commit").length;
-    expect(commitsOnFirst).toBe(1);
-    expect(commitsOnSecond).toBe(0);
-    expect(statuses.at(-1)).toBe("recording");
-  });
-
-  // ── Error handling ───────────────────────────────────────────────────────
-
-  it("emits error and error status when the WebSocket reports an error", async () => {
-    const service = new VoiceTranscriptionService();
-    const events: VoiceTranscriptionEvent[] = [];
-    service.onEvent((e) => events.push(e));
-
-    const startPromise = service.start(BASE_SETTINGS);
-    await Promise.resolve();
-    const socket = latestInstance();
-    socket.simulateOpen();
-    socket.simulateError(new Error("network down"));
-
-    await expect(startPromise).resolves.toEqual({ ok: false, error: "network down" });
-    expect(events.some((e) => e.type === "error" && /network down/.test(e.message))).toBe(true);
-    expect(events.some((e) => e.type === "status" && e.status === "error")).toBe(true);
-  });
-
-  it("propagates server-side error events", async () => {
-    const service = new VoiceTranscriptionService();
-    const errors: string[] = [];
-    service.onEvent((e) => {
-      if (e.type === "error") errors.push(e.message);
-    });
-
-    const { socket } = await bringSessionReady(service);
-    socket.simulateMessage("error", {
-      error: { message: "invalid_session_config", type: "invalid_request_error" },
-    });
-
-    expect(errors).toContain("invalid_session_config");
-  });
-
-  it("parses string message data as well as Buffer", async () => {
-    const service = new VoiceTranscriptionService();
-    const completes: string[] = [];
-    service.onEvent((e) => {
-      if (e.type === "complete") completes.push(e.text);
-    });
-
-    const { socket } = await bringSessionReady(service);
-    // `ws` can deliver messages as strings when the server sends a text frame.
-    socket.simulateRawMessage(
-      JSON.stringify({
-        type: "conversation.item.input_audio_transcription.completed",
-        transcript: "from string",
-      })
+    const deepgram = new VoiceTranscriptionService();
+    const deepgramSocket = await bringDeepgramReady(deepgram);
+    deepgram.sendAudioChunk(new Uint8Array(5_000).buffer);
+    vi.advanceTimersByTime(2_500);
+    expect(deepgramSocket.textFrames().some((f) => f.type === "input_audio_buffer.commit")).toBe(
+      false
     );
-    expect(completes).toEqual(["from string"]);
+    deepgram.stop();
   });
 
-  it("ignores malformed JSON messages without throwing", async () => {
+  // ── Audio transport delegation ─────────────────────────────────────────────
+
+  it("delegates audio as base64 JSON for OpenAI and raw binary for Deepgram", async () => {
+    const openai = new VoiceTranscriptionService();
+    const openaiSocket = await bringOpenAiReady(openai);
+    const chunk = new Uint8Array([1, 2, 3]).buffer;
+    openai.sendAudioChunk(chunk);
+    const append = openaiSocket.textFrames().find((f) => f.type === "input_audio_buffer.append");
+    expect(append?.audio).toBe(Buffer.from(chunk).toString("base64"));
+    expect(openaiSocket.binaryFrames()).toHaveLength(0);
+    openai.stop();
+
+    const deepgram = new VoiceTranscriptionService();
+    const deepgramSocket = await bringDeepgramReady(deepgram);
+    deepgram.sendAudioChunk(chunk);
+    expect(deepgramSocket.binaryFrames()).toHaveLength(1);
+    expect(deepgramSocket.binaryFrames()[0].equals(Buffer.from(chunk))).toBe(true);
+    deepgram.stop();
+  });
+
+  // ── Provider switch teardown ───────────────────────────────────────────────
+
+  it("tears down the previous provider and stops forwarding its events on switch", async () => {
     const service = new VoiceTranscriptionService();
     const events: VoiceTranscriptionEvent[] = [];
     service.onEvent((e) => events.push(e));
 
-    const { socket } = await bringSessionReady(service);
-    expect(() => socket.simulateRawMessage("not json {")).not.toThrow();
+    const openaiSocket = await bringOpenAiReady(service);
 
-    // Service still functional afterward
-    socket.simulateMessage("conversation.item.input_audio_transcription.completed", {
-      transcript: "ok",
-    });
-    expect(events.some((e) => e.type === "complete")).toBe(true);
-  });
+    // Switch to Deepgram — the previous OpenAI socket must be closed.
+    const deepgramSocket = await bringDeepgramReady(service);
+    expect(deepgramSocket).not.toBe(openaiSocket);
+    expect(openaiSocket.closeCalls).toBeGreaterThanOrEqual(1);
 
-  it("fails start when WebSocket construction throws", async () => {
-    throwOnConstruct = true;
-    constructError = new Error("ECONNREFUSED");
-    const service = new VoiceTranscriptionService();
-    const result = await service.start(BASE_SETTINGS);
-    expect(result).toEqual({ ok: false, error: "ECONNREFUSED" });
-  });
-
-  // ── Reentrancy / stale-session guard ─────────────────────────────────────
-
-  it("ignores transcript events from a stale session", async () => {
-    const service = new VoiceTranscriptionService();
-    const completes: string[] = [];
-    service.onEvent((e) => {
-      if (e.type === "complete") completes.push(e.text);
-    });
-
-    const { socket: firstSocket } = await bringSessionReady(service);
-    // Start a second session; the first socket is now stale.
-    const secondPromise = service.start(BASE_SETTINGS);
-    await Promise.resolve();
-    const secondSocket = latestInstance();
-    secondSocket.simulateOpen();
-    secondSocket.simulateMessage("session.updated");
-    await secondPromise;
-
-    firstSocket.simulateMessage("conversation.item.input_audio_transcription.completed", {
+    const completesBefore = events.filter((e) => e.type === "complete").length;
+    // A late event from the torn-down OpenAI socket must not be forwarded.
+    openaiSocket.simulateMessage("conversation.item.input_audio_transcription.completed", {
       transcript: "ghost",
     });
+    expect(events.filter((e) => e.type === "complete").length).toBe(completesBefore);
 
-    expect(completes).toEqual([]);
-  });
-
-  // ── commitParagraphBoundary ──────────────────────────────────────────────
-
-  it("commitParagraphBoundary resets state and does not touch the WebSocket", async () => {
-    const service = new VoiceTranscriptionService();
-    const { socket } = await bringSessionReady(service);
-    const sentBefore = socket.sent.length;
-
-    socket.simulateMessage("conversation.item.input_audio_transcription.delta", {
-      delta: "Hello",
+    // The new Deepgram provider's events are forwarded.
+    deepgramSocket.simulateMessage("Results", {
+      is_final: true,
+      channel: { alternatives: [{ transcript: "live" }] },
     });
-    service.commitParagraphBoundary();
-
-    expect(socket.sent.length).toBe(sentBefore);
-    expect(socket.closeCalls).toBe(0);
+    expect(events.some((e) => e.type === "complete" && e.text === "live")).toBe(true);
+    service.stop();
   });
 
-  // ── destroy ─────────────────────────────────────────────────────────────
+  // ── Lifecycle delegation ───────────────────────────────────────────────────
 
-  it("destroy closes the socket and clears listeners", async () => {
+  it("delegates commitParagraphBoundary to the active provider", async () => {
+    const service = new VoiceTranscriptionService();
+    const socket = await bringDeepgramReady(service);
+    service.commitParagraphBoundary();
+    expect(socket.textFrames().filter((f) => f.type === "Finalize")).toHaveLength(1);
+    service.stop();
+  });
+
+  it("stopGracefully is a no-op before any session is started", async () => {
+    const service = new VoiceTranscriptionService();
+    const events: VoiceTranscriptionEvent[] = [];
+    service.onEvent((e) => events.push(e));
+    await expect(service.stopGracefully()).resolves.toBeUndefined();
+    expect(events).toEqual([]);
+  });
+
+  it("destroy disposes the active provider and clears listeners", async () => {
     const service = new VoiceTranscriptionService();
     const events: VoiceTranscriptionEvent[] = [];
     service.onEvent((e) => events.push(e));
 
-    const { socket } = await bringSessionReady(service);
+    const socket = await bringOpenAiReady(service);
     service.destroy();
     expect(socket.closeCalls).toBe(1);
 
-    // Listeners cleared: subsequent emits should not reach the recorded array.
     const lengthAtDestroy = events.length;
-    // Spawn a brand-new session — the listener from before destroy should be gone.
-    const { socket: socket2 } = await bringSessionReady(service);
+    // Listener cleared — a brand-new session's events must not reach the array.
+    const socket2 = await bringOpenAiReady(service);
     socket2.simulateMessage("conversation.item.input_audio_transcription.completed", {
       transcript: "after destroy",
     });
     expect(events.length).toBe(lengthAtDestroy);
-  });
-
-  // ── Heartbeat (half-open detection) ──────────────────────────────────────
-
-  it("pings on the heartbeat interval once the connection is open", async () => {
-    const service = new VoiceTranscriptionService();
-    const { socket } = await bringSessionReady(service);
-
-    expect(socket.pingCalls).toBe(0);
-    vi.advanceTimersByTime(20_000);
-    expect(socket.pingCalls).toBe(1);
-
-    service.stop();
-  });
-
-  it("terminates the socket when a heartbeat ping goes unanswered", async () => {
-    const service = new VoiceTranscriptionService();
-    const { socket } = await bringSessionReady(service);
-
-    // First tick: ping sent, awaiting pong.
-    vi.advanceTimersByTime(20_000);
-    expect(socket.pingCalls).toBe(1);
-    expect(socket.terminateCalls).toBe(0);
-
-    // Second tick: no pong arrived → terminate (not graceful close).
-    vi.advanceTimersByTime(20_000);
-    expect(socket.terminateCalls).toBe(1);
-    expect(socket.closeCalls).toBe(0);
-
-    service.stop();
-  });
-
-  it("a pong keeps the connection alive across heartbeat ticks", async () => {
-    const service = new VoiceTranscriptionService();
-    const { socket } = await bringSessionReady(service);
-
-    vi.advanceTimersByTime(20_000);
-    expect(socket.pingCalls).toBe(1);
-    socket.simulatePong();
-
-    vi.advanceTimersByTime(20_000);
-    expect(socket.pingCalls).toBe(2);
-    expect(socket.terminateCalls).toBe(0);
-
-    service.stop();
-  });
-
-  it("a stale connection's heartbeat does not terminate a newer socket", async () => {
-    const service = new VoiceTranscriptionService();
-    const { socket: firstSocket } = await bringSessionReady(service);
-
-    // Replace the session — the first socket and its heartbeat are now stale.
-    const secondPromise = service.start(BASE_SETTINGS);
-    await Promise.resolve();
-    const secondSocket = latestInstance();
-    secondSocket.simulateOpen();
-    secondSocket.simulateMessage("session.updated");
-    await secondPromise;
-
-    // The first socket's heartbeat was torn down when the session was replaced;
-    // it must never terminate (its sessionId/socket-identity guard would also
-    // catch it). The second socket stays alive as long as it pongs.
-    vi.advanceTimersByTime(20_000);
-    secondSocket.simulatePong();
-    vi.advanceTimersByTime(20_000);
-    expect(firstSocket.terminateCalls).toBe(0);
-    expect(secondSocket.terminateCalls).toBe(0);
-
-    service.stop();
-  });
-
-  // ── Reconnection ─────────────────────────────────────────────────────────
-
-  it("reconnects after an unexpected drop and returns to recording", async () => {
-    vi.spyOn(Math, "random").mockReturnValue(0.5);
-    const service = new VoiceTranscriptionService();
-    const { socket } = await bringSessionReady(service);
-
-    const statuses: string[] = [];
-    service.onEvent((e) => {
-      if (e.type === "status") statuses.push(e.status);
-    });
-
-    socket.simulateClose(1006, Buffer.from("abnormal"));
-    expect(statuses).toContain("reconnecting");
-
-    // Backoff timer fires → a fresh socket is opened.
-    vi.advanceTimersByTime(3_000);
-    const socket2 = latestInstance();
-    expect(socket2).not.toBe(socket);
-
-    socket2.simulateOpen();
-    socket2.simulateMessage("session.updated");
-    expect(statuses.at(-1)).toBe("recording");
-
-    service.stop();
-  });
-
-  it("buffers audio captured during the reconnect window and flushes it after reconnect", async () => {
-    vi.spyOn(Math, "random").mockReturnValue(0.5);
-    const service = new VoiceTranscriptionService();
-    const { socket } = await bringSessionReady(service);
-
-    socket.simulateClose(1006);
-
-    // Audio keeps flowing while we're reconnecting — it must be buffered, not
-    // dropped (connection is null and there's no pending start at this point).
-    const chunk = new Uint8Array([7, 7, 7, 7]).buffer;
-    service.sendAudioChunk(chunk);
-
-    vi.advanceTimersByTime(3_000);
-    const socket2 = latestInstance();
-    socket2.simulateOpen();
-    socket2.simulateMessage("session.updated");
-
-    const audio = socket2
-      .sentJson()
-      .filter((p) => p.type === "input_audio_buffer.append")
-      .map((p) => p.audio as string);
-    expect(audio).toEqual([Buffer.from(chunk).toString("base64")]);
-
-    service.stop();
-  });
-
-  it("gives up and emits error after exhausting reconnect attempts", async () => {
-    vi.spyOn(Math, "random").mockReturnValue(0.5);
-    const service = new VoiceTranscriptionService();
-    const { socket } = await bringSessionReady(service);
-
-    const statuses: string[] = [];
-    const errors: string[] = [];
-    service.onEvent((e) => {
-      if (e.type === "status") statuses.push(e.status);
-      if (e.type === "error") errors.push(e.message);
-    });
-
-    // Initial drop schedules attempt 1.
-    socket.simulateClose(1006);
-
-    // Each cycle: fire the backoff timer (opens a socket), then drop it again
-    // before it can reach session.updated. After RECONNECT_MAX_ATTEMPTS the
-    // service gives up.
-    for (let i = 0; i < 5; i++) {
-      vi.advanceTimersByTime(3_000);
-      latestInstance().simulateClose(1006);
-    }
-
-    expect(statuses).toContain("reconnecting");
-    expect(statuses).toContain("error");
-    expect(errors.some((m) => /reconnect failed/i.test(m))).toBe(true);
-  });
-
-  it("a graceful stop during the reconnect window cancels the pending retry", async () => {
-    vi.spyOn(Math, "random").mockReturnValue(0.5);
-    const service = new VoiceTranscriptionService();
-    const { socket } = await bringSessionReady(service);
-
-    socket.simulateClose(1006);
-    const instancesBeforeStop = instances.length;
-
-    service.stop();
-
-    // The backoff timer was cleared by stop() — advancing time opens no socket.
-    vi.advanceTimersByTime(3_000);
-    expect(instances.length).toBe(instancesBeforeStop);
-  });
-
-  it("does not reconnect after a server-side fatal error and ends in error, not idle", async () => {
-    const service = new VoiceTranscriptionService();
-    const { socket } = await bringSessionReady(service);
-    const statuses: string[] = [];
-    service.onEvent((e) => {
-      if (e.type === "status") statuses.push(e.status);
-    });
-    const instancesBefore = instances.length;
-
-    // A server error is fatal: the socket is terminated, the trailing close must
-    // not trigger a reconnect, and the final status stays "error" (not "idle").
-    socket.simulateMessage("error", {
-      error: { message: "invalid_session_config", type: "invalid_request_error" },
-    });
-    expect(socket.terminateCalls).toBe(1);
-
-    // The terminate() above already fired a close; an extra server close is a
-    // no-op for status. Simulate it to be sure idle never leaks through.
-    socket.simulateClose(1011);
-
-    vi.advanceTimersByTime(3_000);
-    expect(instances.length).toBe(instancesBefore);
-    expect(statuses).toContain("error");
-    expect(statuses).not.toContain("idle");
-  });
-
-  it("enforces the pre-connect buffer byte cap independently of the chunk cap", async () => {
-    const service = new VoiceTranscriptionService();
-    void service.start(BASE_SETTINGS);
-    await Promise.resolve();
-
-    // Five 40KB chunks = 200KB, over the 150KB ceiling but well under the
-    // 100-chunk cap — only the first chunks that fit under 150KB are kept.
-    for (let i = 0; i < 5; i++) {
-      service.sendAudioChunk(new Uint8Array(40_000).buffer);
-    }
-    const socket = latestInstance();
-    socket.simulateOpen();
-    socket.simulateMessage("session.updated");
-
-    const audioCount = socket
-      .sentJson()
-      .filter((p) => p.type === "input_audio_buffer.append").length;
-    // 3 × 40KB = 120KB fits; a 4th would push to 160KB > 150KB, so it's dropped.
-    expect(audioCount).toBe(3);
-    service.stop();
-  });
-
-  it("retries and gives up when the reconnect socket constructor keeps throwing", async () => {
-    vi.spyOn(Math, "random").mockReturnValue(0.5);
-    const service = new VoiceTranscriptionService();
-    const { socket } = await bringSessionReady(service);
-
-    const statuses: string[] = [];
-    service.onEvent((e) => {
-      if (e.type === "status") statuses.push(e.status);
-    });
-
-    // Every reconnect attempt's WebSocket construction fails.
-    throwOnConstruct = true;
-    constructError = new Error("ECONNREFUSED");
-    const instancesBefore = instances.length;
-
-    socket.simulateClose(1006);
-    // Drive all backoff cycles — each fires the timer, connect() throws, and
-    // reschedules until attempts are exhausted.
-    for (let i = 0; i < 6; i++) {
-      vi.advanceTimersByTime(3_000);
-    }
-
-    expect(instances.length).toBe(instancesBefore);
-    expect(statuses).toContain("error");
   });
 });

--- a/electron/services/voice/DeepgramTranscriptionProvider.ts
+++ b/electron/services/voice/DeepgramTranscriptionProvider.ts
@@ -1,0 +1,561 @@
+import WebSocket from "ws";
+import type { VoiceInputSettings } from "../../../shared/types/ipc/api.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
+import { logDebug, logInfo, logWarn, logError } from "../../utils/logger.js";
+import {
+  STUB_CONFIDENCE,
+  type TranscriptionProvider,
+  type VoiceStartResult,
+  type VoiceTranscriptionEvent,
+} from "./TranscriptionProvider.js";
+
+const P = "[VoiceTranscription:deepgram]";
+
+const DEEPGRAM_BASE_URL =
+  process.env.DAINTREE_DEEPGRAM_WS_URL ?? "wss://api.deepgram.com/v1/listen";
+const DEEPGRAM_MODEL = "nova-3";
+const CONNECT_TIMEOUT_MS = 10_000;
+// Backstop for the graceful drain: after `CloseStream` the server flushes its
+// remaining transcripts and closes. If it never closes (network hiccup), force
+// the stop through after this long rather than hanging.
+const DRAIN_TIMEOUT_MS = 3_000;
+// Deepgram drops an idle connection after ~10s of no audio with a NET-0001
+// error. A periodic KeepAlive text frame resets that timer; well under 10s
+// gives margin even if a tick is delayed.
+const KEEPALIVE_INTERVAL_MS = 5_000;
+const PRE_CONNECT_BUFFER_MAX = 100;
+// 24kHz mono PCM16 ≈ 48KB/s, so ~150KB ≈ 3s of audio — past which voice
+// context is lost anyway. Matches the OpenAI provider's ceiling.
+const PRE_CONNECT_BUFFER_MAX_BYTES = 150_000;
+
+// Like the OpenAI provider we use the `ws` package rather than Node's global
+// WebSocket so the `Authorization` upgrade header can be sent. Deepgram differs
+// from OpenAI in two ways: audio is streamed as raw binary frames (not base64
+// JSON), and turn detection is server-side (`endpointing`), so there is no
+// client-side commit timer — finalized segments arrive on their own.
+
+/** Build the Deepgram streaming URL. `linear16` @ 24kHz matches the renderer's
+ * AudioContext capture rate, so no resampling is needed. `endpointing=300`
+ * turns on server-side VAD: a 300ms pause finalizes the current segment. */
+function buildUrl(settings: VoiceInputSettings): string {
+  const params = new URLSearchParams({
+    model: DEEPGRAM_MODEL,
+    encoding: "linear16",
+    sample_rate: "24000",
+    endpointing: "300",
+  });
+  if (settings.language) {
+    params.set("language", settings.language);
+  }
+  return `${DEEPGRAM_BASE_URL}?${params.toString()}`;
+}
+
+export class DeepgramTranscriptionProvider implements TranscriptionProvider {
+  readonly hasServerVAD = true;
+
+  private connection: WebSocket | null = null;
+  private sessionId = 0;
+  private connectTimeout: ReturnType<typeof setTimeout> | null = null;
+  private listeners: Set<(event: VoiceTranscriptionEvent) => void> = new Set();
+  private pendingStart: { sessionId: number; resolve: (result: VoiceStartResult) => void } | null =
+    null;
+
+  private preConnectBuffer: ArrayBuffer[] = [];
+  private preConnectBufferBytes = 0;
+  private isReady = false;
+
+  private keepAliveTimer: ReturnType<typeof setInterval> | null = null;
+
+  // Set on graceful/fatal teardown so the trailing `close` event isn't treated
+  // as an unexpected drop.
+  private isExpectedClose = false;
+
+  private drainResolve: (() => void) | null = null;
+  private drainTimeout: ReturnType<typeof setTimeout> | null = null;
+  private drainPromise: Promise<void> | null = null;
+  private isDraining = false;
+
+  private audioChunkCount = 0;
+  private staleChunkWarned = false;
+  private preConnectBufferOverflowWarned = false;
+
+  onEvent(listener: (event: VoiceTranscriptionEvent) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  /**
+   * With server-side VAD the backend segments utterances on its own, so a
+   * user-driven boundary just asks Deepgram to finalize whatever it has
+   * buffered now via a `Finalize` control frame; the resulting final Results
+   * event flows through as a `complete`.
+   */
+  commitParagraphBoundary(): void {
+    if (!this.connection || !this.isReady || this.isDraining) return;
+    try {
+      this.connection.send(JSON.stringify({ type: "Finalize" }));
+      logDebug(`${P} → Finalize (paragraph boundary)`);
+    } catch (err) {
+      logWarn(`${P} Failed to send Finalize`, { message: formatErrorMessage(err, "send failed") });
+    }
+  }
+
+  private emit(event: VoiceTranscriptionEvent): void {
+    if (event.type === "status") {
+      logInfo(`${P} status → ${event.status}`);
+    } else if (event.type === "error") {
+      logWarn(`${P} emitting error event`, { message: event.message });
+    }
+    for (const listener of this.listeners) {
+      listener(event);
+    }
+  }
+
+  private clearConnectTimeout(): void {
+    if (this.connectTimeout !== null) {
+      clearTimeout(this.connectTimeout);
+      this.connectTimeout = null;
+    }
+  }
+
+  private settlePendingStart(sessionId: number, result: VoiceStartResult): void {
+    if (this.pendingStart?.sessionId !== sessionId) return;
+    const { resolve } = this.pendingStart;
+    this.pendingStart = null;
+    resolve(result);
+  }
+
+  async start(settings: VoiceInputSettings): Promise<VoiceStartResult> {
+    if (!settings.deepgramApiKey) {
+      logWarn(`${P} No Deepgram API key configured`);
+      return { ok: false, error: "Deepgram API key not configured" };
+    }
+
+    const mySessionId = this.sessionId + 1;
+    logInfo(`${P} Starting session ${mySessionId}`, { language: settings.language });
+    this.cleanupPreviousSession();
+    this.sessionId = mySessionId;
+    this.isReady = false;
+    this.preConnectBuffer = [];
+    this.preConnectBufferBytes = 0;
+    this.isExpectedClose = false;
+
+    this.emit({ type: "status", status: "connecting" });
+
+    return new Promise((resolve) => {
+      this.pendingStart = { sessionId: mySessionId, resolve };
+      this.connect(mySessionId, settings);
+    });
+  }
+
+  private connect(mySessionId: number, settings: VoiceInputSettings): void {
+    const url = buildUrl(settings);
+    let connection: WebSocket;
+    try {
+      connection = new WebSocket(url, {
+        headers: {
+          Authorization: `Token ${settings.deepgramApiKey}`,
+        },
+      });
+    } catch (err) {
+      const message = formatErrorMessage(err, "Failed to open WebSocket");
+      logError(`${P} ${message}`);
+      this.emit({ type: "error", message });
+      this.emit({ type: "status", status: "error" });
+      this.settlePendingStart(mySessionId, { ok: false, error: message });
+      return;
+    }
+
+    this.connection = connection;
+    logInfo(`${P} Opening Deepgram WebSocket`, { url, language: settings.language || "en" });
+
+    this.connectTimeout = setTimeout(() => {
+      this.connectTimeout = null;
+      if (this.sessionId !== mySessionId) return;
+      logError(`${P} Connection timed out (${CONNECT_TIMEOUT_MS}ms)`);
+      this.isExpectedClose = true;
+      try {
+        connection.close();
+      } catch {
+        // Ignore close errors
+      }
+      this.cleanupConnection();
+      this.emit({ type: "error", message: "Connection timed out" });
+      this.emit({ type: "status", status: "error" });
+      this.settlePendingStart(mySessionId, { ok: false, error: "Connection timed out" });
+    }, CONNECT_TIMEOUT_MS);
+
+    connection.on("open", () => {
+      if (this.sessionId !== mySessionId) {
+        logWarn(`${P} Session expired during connect, closing`);
+        try {
+          connection.close();
+        } catch {
+          // Ignore close errors
+        }
+        return;
+      }
+      // Deepgram is ready to receive audio the moment the socket opens — the
+      // model config lives in the URL query string, so there's no session
+      // handshake to await (unlike OpenAI's `session.update`).
+      this.clearConnectTimeout();
+      logInfo(`${P} WebSocket opened — session ready`);
+      if (this.preConnectBuffer.length > 0) {
+        logInfo(`${P} Flushing ${this.preConnectBuffer.length} buffered audio chunks`);
+        const buffered = this.preConnectBuffer;
+        this.preConnectBuffer = [];
+        this.preConnectBufferBytes = 0;
+        for (const chunk of buffered) {
+          this.sendAudioBinary(chunk);
+        }
+      }
+      this.isReady = true;
+      this.startKeepAlive(connection, mySessionId);
+      this.emit({ type: "status", status: "recording" });
+      this.settlePendingStart(mySessionId, { ok: true });
+    });
+
+    connection.on("message", (data) => {
+      if (this.sessionId !== mySessionId || this.connection !== connection) return;
+      const raw =
+        typeof data === "string"
+          ? data
+          : Buffer.isBuffer(data)
+            ? data.toString("utf8")
+            : Array.isArray(data)
+              ? Buffer.concat(data).toString("utf8")
+              : Buffer.from(data as ArrayBuffer).toString("utf8");
+
+      let parsed: Record<string, unknown>;
+      try {
+        parsed = JSON.parse(raw) as Record<string, unknown>;
+      } catch {
+        logWarn(`${P} Ignoring non-JSON message`, { raw: raw.slice(0, 200) });
+        return;
+      }
+
+      const type = typeof parsed.type === "string" ? parsed.type : "";
+      this.handleServerEvent(mySessionId, type, parsed);
+    });
+
+    connection.on("error", (err) => {
+      this.clearConnectTimeout();
+      if (this.sessionId !== mySessionId || this.connection !== connection) return;
+      const message = formatErrorMessage(err, "WebSocket error");
+      logError(`${P} WebSocket error`, { message });
+      // `ws` fires `close` right after `error`; a pre-ready transport error
+      // (auth/DNS/refused) is fatal, otherwise let the close handler decide.
+      if (!this.isReady) {
+        this.handleFatalError(mySessionId, message);
+      }
+    });
+
+    connection.on("close", (code, reason) => {
+      this.clearConnectTimeout();
+      this.clearKeepAlive();
+      if (this.sessionId !== mySessionId || this.connection !== connection) return;
+      const wasReady = this.isReady;
+      logInfo(`${P} WebSocket closed`, {
+        code,
+        reason: Buffer.isBuffer(reason) ? reason.toString("utf8") : String(reason ?? ""),
+        wasReady,
+        wasExpected: this.isExpectedClose,
+        wasDraining: this.isDraining,
+        audioChunksStreamed: this.audioChunkCount,
+      });
+      this.cleanupConnection();
+      if (this.isDraining) {
+        this.settleDrain("connection-closed");
+        return;
+      }
+      this.settlePendingStart(mySessionId, { ok: false, error: "Connection closed" });
+      if (this.isExpectedClose) return;
+      // No reconnect for Deepgram (first-cut provider). An unexpected drop of a
+      // ready session is surfaced as an error; a never-ready drop falls through
+      // to idle (matches the OpenAI provider's terminal semantics).
+      if (wasReady) {
+        this.emit({ type: "error", message: "Connection lost" });
+        this.emit({ type: "status", status: "error" });
+      } else {
+        this.emit({ type: "status", status: "idle" });
+      }
+    });
+  }
+
+  private startKeepAlive(connection: WebSocket, mySessionId: number): void {
+    this.clearKeepAlive();
+    this.keepAliveTimer = setInterval(() => {
+      if (this.sessionId !== mySessionId || this.connection !== connection) {
+        this.clearKeepAlive();
+        return;
+      }
+      try {
+        connection.send(JSON.stringify({ type: "KeepAlive" }));
+        logDebug(`${P} → KeepAlive`);
+      } catch (err) {
+        logWarn(`${P} KeepAlive send failed`, {
+          message: formatErrorMessage(err, "send failed"),
+        });
+      }
+    }, KEEPALIVE_INTERVAL_MS);
+  }
+
+  private clearKeepAlive(): void {
+    if (this.keepAliveTimer !== null) {
+      clearInterval(this.keepAliveTimer);
+      this.keepAliveTimer = null;
+    }
+  }
+
+  private handleFatalError(mySessionId: number, message: string): void {
+    logError(`${P} Fatal error — tearing down session`, { message });
+    this.isExpectedClose = true;
+    const conn = this.connection;
+    this.cleanupConnection();
+    if (conn) {
+      try {
+        conn.terminate();
+      } catch {
+        // Ignore terminate errors
+      }
+    }
+    this.emit({ type: "error", message });
+    this.emit({ type: "status", status: "error" });
+    this.settlePendingStart(mySessionId, { ok: false, error: message });
+    this.settleDrain("fatal-error");
+  }
+
+  private handleServerEvent(
+    _mySessionId: number,
+    type: string,
+    payload: Record<string, unknown>
+  ): void {
+    switch (type) {
+      case "Results": {
+        const channel = payload.channel as
+          | { alternatives?: Array<{ transcript?: string }> }
+          | undefined;
+        const transcript = channel?.alternatives?.[0]?.transcript ?? "";
+        const isFinal = payload.is_final === true;
+        const speechFinal = payload.speech_final === true;
+        // Interim hypotheses (is_final === false) are revised in place; emitting
+        // them as append-style deltas would corrupt the renderer's live buffer.
+        // Only finalized segments are emitted — they arrive within ~300ms of an
+        // endpoint and won't change. A speech_final result is always is_final,
+        // so this branch covers both.
+        logDebug(`${P} ← Results`, { length: transcript.length, isFinal, speechFinal });
+        if (!isFinal) return;
+        const trimmed = transcript.trim();
+        if (trimmed) {
+          this.emit({ type: "complete", text: trimmed, confidence: { ...STUB_CONFIDENCE } });
+        }
+        return;
+      }
+
+      case "UtteranceEnd":
+      case "SpeechStarted":
+      case "Metadata":
+        // VAD / metadata signals. Segmentation is already handled via is_final
+        // Results, so these are informational only.
+        logDebug(`${P} ← ${type}`);
+        return;
+
+      case "Error": {
+        const message =
+          (typeof payload.description === "string" && payload.description) ||
+          (typeof payload.message === "string" && payload.message) ||
+          "Deepgram error";
+        logError(`${P} ← server error event`, { message });
+        this.handleFatalError(_mySessionId, message);
+        return;
+      }
+
+      default:
+        logDebug(`${P} ← unhandled server event`, {
+          type,
+          payload: JSON.stringify(payload).slice(0, 600),
+        });
+    }
+  }
+
+  private sendAudioBinary(chunk: ArrayBuffer): void {
+    if (!this.connection) return;
+    try {
+      // Deepgram expects raw PCM16 as binary WebSocket frames — NOT base64 JSON.
+      this.connection.send(Buffer.from(chunk));
+    } catch (err) {
+      logWarn(`${P} Failed to send audio chunk`, {
+        message: formatErrorMessage(err, "send failed"),
+      });
+    }
+  }
+
+  sendAudioChunk(chunk: ArrayBuffer): void {
+    if (this.isDraining) return;
+
+    if (!this.isReady || !this.connection) {
+      if (this.connection || this.pendingStart) {
+        this.bufferPreConnectChunk(chunk);
+      } else if (!this.staleChunkWarned) {
+        this.staleChunkWarned = true;
+        logWarn(`${P} sendAudioChunk called but no active session`);
+      }
+      return;
+    }
+    this.audioChunkCount++;
+    if (this.audioChunkCount <= 3 || this.audioChunkCount % 100 === 0) {
+      logDebug(`${P} Sending audio chunk #${this.audioChunkCount}`, { bytes: chunk.byteLength });
+    }
+    this.sendAudioBinary(chunk);
+  }
+
+  private bufferPreConnectChunk(chunk: ArrayBuffer): void {
+    if (
+      this.preConnectBuffer.length >= PRE_CONNECT_BUFFER_MAX ||
+      this.preConnectBufferBytes + chunk.byteLength > PRE_CONNECT_BUFFER_MAX_BYTES
+    ) {
+      if (!this.preConnectBufferOverflowWarned) {
+        this.preConnectBufferOverflowWarned = true;
+        logWarn(`${P} Pre-connect buffer full, dropping audio`, {
+          chunks: this.preConnectBuffer.length,
+          bytes: this.preConnectBufferBytes,
+          maxChunks: PRE_CONNECT_BUFFER_MAX,
+          maxBytes: PRE_CONNECT_BUFFER_MAX_BYTES,
+        });
+      }
+      return;
+    }
+    this.preConnectBuffer.push(chunk);
+    this.preConnectBufferBytes += chunk.byteLength;
+  }
+
+  private cleanupConnection(): void {
+    this.clearKeepAlive();
+    this.connection = null;
+    this.isReady = false;
+  }
+
+  private cleanupPreviousSession(): void {
+    logDebug(`${P} Cleaning up previous session`, {
+      sessionId: this.sessionId,
+      hasConnection: !!this.connection,
+    });
+    const pendingSessionId = this.pendingStart?.sessionId;
+    this.sessionId++;
+    this.audioChunkCount = 0;
+    this.staleChunkWarned = false;
+    this.preConnectBufferOverflowWarned = false;
+    this.isReady = false;
+    this.preConnectBuffer = [];
+    this.preConnectBufferBytes = 0;
+    this.clearConnectTimeout();
+    this.clearDrainTimeout();
+    this.clearKeepAlive();
+    this.isExpectedClose = false;
+    this.isDraining = false;
+    if (this.drainResolve) {
+      this.drainResolve();
+      this.drainResolve = null;
+    }
+    this.drainPromise = null;
+    if (pendingSessionId !== undefined) {
+      this.settlePendingStart(pendingSessionId, { ok: false, error: "Voice session stopped" });
+    }
+    if (this.connection) {
+      try {
+        this.connection.close();
+      } catch {
+        // Ignore close errors
+      }
+      this.connection = null;
+    }
+  }
+
+  private clearDrainTimeout(): void {
+    if (this.drainTimeout !== null) {
+      clearTimeout(this.drainTimeout);
+      this.drainTimeout = null;
+    }
+  }
+
+  private settleDrain(reason: string): void {
+    this.clearDrainTimeout();
+    this.isDraining = false;
+    this.drainPromise = null;
+    if (this.drainResolve) {
+      logInfo(`${P} Drain completed`, { reason });
+      const resolve = this.drainResolve;
+      this.drainResolve = null;
+      resolve();
+    } else {
+      logDebug(`${P} settleDrain called with no pending drain`, { reason });
+    }
+  }
+
+  async stopGracefully(): Promise<void> {
+    logInfo(`${P} stopGracefully() called`, {
+      sessionId: this.sessionId,
+      hasConnection: !!this.connection,
+    });
+
+    if (this.drainPromise) {
+      logDebug(`${P} Already draining, joining existing promise`);
+      return this.drainPromise;
+    }
+
+    this.isExpectedClose = true;
+
+    if (!this.connection || !this.isReady) {
+      this.cleanupPreviousSession();
+      this.emit({ type: "status", status: "idle" });
+      return;
+    }
+
+    this.isDraining = true;
+    this.clearKeepAlive();
+    this.emit({ type: "status", status: "finishing" });
+
+    // CloseStream tells Deepgram we're done sending audio. The server flushes
+    // any remaining transcripts (delivered as final Results, emitted above) and
+    // then closes the socket, which settles the drain via the close handler.
+    try {
+      this.connection.send(JSON.stringify({ type: "CloseStream" }));
+      logInfo(`${P} → CloseStream`);
+    } catch {
+      logWarn(`${P} Failed to send CloseStream, closing immediately`);
+      this.cleanupPreviousSession();
+      this.emit({ type: "status", status: "idle" });
+      return;
+    }
+
+    const sessionIdBeforeDrain = this.sessionId;
+
+    this.drainPromise = new Promise<void>((resolve) => {
+      this.drainResolve = resolve;
+      this.drainTimeout = setTimeout(() => {
+        logWarn(`${P} Drain timed out after ${DRAIN_TIMEOUT_MS}ms, force closing`);
+        this.settleDrain("timeout");
+      }, DRAIN_TIMEOUT_MS);
+    });
+    await this.drainPromise;
+
+    // If start() was called during drain it already ran cleanupPreviousSession()
+    // and incremented sessionId — don't tear down the new session.
+    if (this.sessionId === sessionIdBeforeDrain) {
+      this.cleanupPreviousSession();
+      this.emit({ type: "status", status: "idle" });
+    }
+  }
+
+  stop(): void {
+    logInfo(`${P} stop() called`, { sessionId: this.sessionId, hasConnection: !!this.connection });
+    this.isExpectedClose = true;
+    this.cleanupPreviousSession();
+    this.emit({ type: "status", status: "idle" });
+  }
+
+  destroy(): void {
+    this.stop();
+    this.listeners.clear();
+  }
+}

--- a/electron/services/voice/OpenAITranscriptionProvider.ts
+++ b/electron/services/voice/OpenAITranscriptionProvider.ts
@@ -1,0 +1,998 @@
+import WebSocket from "ws";
+import type { VoiceInputSettings } from "../../../shared/types/ipc/api.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
+import { buildOpenAIHeaders } from "../../../shared/utils/openaiHeaders.js";
+import { logDebug, logInfo, logWarn, logError } from "../../utils/logger.js";
+import {
+  STUB_CONFIDENCE,
+  type TranscriptionProvider,
+  type VoiceStartResult,
+  type VoiceTranscriptionEvent,
+} from "./TranscriptionProvider.js";
+
+const P = "[VoiceTranscription:openai]";
+
+// `gpt-realtime-whisper` is a transcription model — it must be passed as
+// `transcription.model`, NOT as the realtime session `model` query param.
+// The session connects via `?intent=transcription` instead.
+const OPENAI_REALTIME_URL =
+  process.env.DAINTREE_REALTIME_WS_URL ?? "wss://api.openai.com/v1/realtime?intent=transcription";
+const OPENAI_TRANSCRIPTION_MODEL = "gpt-realtime-whisper";
+const CONNECT_TIMEOUT_MS = 10_000;
+// Backstop for the drain: if a committed segment's `conversation.item.done`
+// never arrives (server error, dropped frame), force-close after this long
+// rather than hanging the stop.
+const DRAIN_TIMEOUT_MS = 3_000;
+const PRE_CONNECT_BUFFER_MAX = 100;
+// Hard byte ceiling for buffered-but-not-yet-sent audio (pre-connect and during
+// a reconnect window). 24kHz mono PCM16 ≈ 48KB/s, so ~150KB ≈ 3s — the point
+// past which voice context is lost anyway. Caps memory if chunks are large.
+const PRE_CONNECT_BUFFER_MAX_BYTES = 150_000;
+// Client-side ping/pong heartbeat. The OpenAI Realtime server sends its own
+// pings (auto-ponged by `ws`), but a half-open TCP connection on our side —
+// server alive, our socket silently dead — is only detectable by us pinging
+// and watching for the pong. On a missed pong we `terminate()` (no closing
+// handshake on a dead socket) which fires `close` and drives the reconnect.
+const HEARTBEAT_INTERVAL_MS = 20_000;
+// Automatic reconnect on an unexpected mid-session drop. Exponential backoff
+// with full jitter: delay = random() * min(CAP, INITIAL * MULTIPLIER^attempt).
+// Gentle multiplier so the first few retries are near-instant; after
+// RECONNECT_MAX_ATTEMPTS we give up and surface a fatal error.
+const RECONNECT_MAX_ATTEMPTS = 5;
+const RECONNECT_INITIAL_MS = 150;
+const RECONNECT_MULTIPLIER = 1.5;
+const RECONNECT_CAP_MS = 3_000;
+// `gpt-realtime-whisper` does not support server VAD (`turn_detection` must be
+// null), so the server never auto-commits the input buffer. We drive
+// segmentation ourselves: commit the buffer on a fixed cadence so the model
+// transcribes each segment and streams delta/completed events back while the
+// user is still speaking. Without this, no transcription arrives until stop.
+const COMMIT_INTERVAL_MS = 2_000;
+// OpenAI rejects an `input_audio_buffer.commit` carrying under ~100ms of audio
+// (24kHz mono PCM16 → 4800 bytes) with a fatal error event. Skip a commit
+// below this threshold.
+const MIN_COMMIT_BYTES = 4_800;
+
+// We use the `ws` package rather than Node 22's global `WebSocket`. The
+// WHATWG spec exposes only `(url, protocols?)` — its constructor silently
+// discards any third options argument, so custom upgrade headers cannot be
+// sent. The `ws` package accepts a 2-arg `(url, options)` form with full
+// header support, which is also what the openai SDK uses internally.
+
+export class OpenAITranscriptionProvider implements TranscriptionProvider {
+  readonly hasServerVAD = false;
+
+  private connection: WebSocket | null = null;
+  private sessionId = 0;
+  private connectTimeout: ReturnType<typeof setTimeout> | null = null;
+  private listeners: Set<(event: VoiceTranscriptionEvent) => void> = new Set();
+  private pendingStart: { sessionId: number; resolve: (result: VoiceStartResult) => void } | null =
+    null;
+
+  private preConnectBuffer: ArrayBuffer[] = [];
+  private preConnectBufferBytes = 0;
+  private isReady = false;
+
+  // Heartbeat (half-open detection) for the current connection. `isAlive` is
+  // set on every pong and on open; the interval terminates the socket if a full
+  // cycle elapses with no pong.
+  private heartbeatInterval: ReturnType<typeof setInterval> | null = null;
+  private isAlive = false;
+
+  // Reconnect state. `reconnectAttempt` and `isReconnecting` survive across
+  // individual connection teardowns (cleanupConnection) and are only reset by
+  // cleanupPreviousSession (a full session reset) or a successful reconnect.
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectAttempt = 0;
+  private isReconnecting = false;
+  // Set on graceful/fatal teardown so the trailing `close` event isn't mistaken
+  // for an unexpected drop and doesn't trigger a reconnect.
+  private isExpectedClose = false;
+
+  private drainResolve: (() => void) | null = null;
+  private drainTimeout: ReturnType<typeof setTimeout> | null = null;
+  private drainPromise: Promise<void> | null = null;
+  private isDraining = false;
+
+  private commitTimer: ReturnType<typeof setInterval> | null = null;
+  private bytesSinceCommit = 0;
+  // Commits sent (interval, paragraph-boundary, or final) whose
+  // `conversation.item.done` we haven't seen yet. Each commit yields exactly
+  // one completion, so the drain is finished precisely when this hits zero —
+  // no timing heuristic needed.
+  private pendingCommits = 0;
+  // Item ids already counted toward `pendingCommits` — guards against a
+  // completion being counted twice (e.g. a `.completed` and a `.done` for the
+  // same item).
+  private completedItemIds = new Set<string>();
+
+  /** Cumulative delta text since the last complete event — used for incremental diffs. */
+  private liveText = "";
+
+  private audioChunkCount = 0;
+  private staleChunkWarned = false;
+  private preConnectBufferOverflowWarned = false;
+
+  onEvent(listener: (event: VoiceTranscriptionEvent) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  /**
+   * Flushes the current audio segment at a user-driven paragraph boundary
+   * (Enter pressed mid-utterance). With no server VAD, committing here closes
+   * the in-progress segment so its transcript finalizes promptly and the next
+   * `completed` event reflects only speech after the boundary. Also clears the
+   * live-delta state since the renderer has already captured the displayed text.
+   */
+  commitParagraphBoundary(): void {
+    this.maybeCommitSegment("paragraph-boundary");
+    this.liveText = "";
+  }
+
+  private emit(event: VoiceTranscriptionEvent): void {
+    if (event.type === "status") {
+      logInfo(`${P} status → ${event.status}`);
+    } else if (event.type === "error") {
+      logWarn(`${P} emitting error event`, { message: event.message });
+    }
+    for (const listener of this.listeners) {
+      listener(event);
+    }
+  }
+
+  private clearConnectTimeout(): void {
+    if (this.connectTimeout !== null) {
+      clearTimeout(this.connectTimeout);
+      this.connectTimeout = null;
+    }
+  }
+
+  private settlePendingStart(sessionId: number, result: VoiceStartResult): void {
+    if (this.pendingStart?.sessionId !== sessionId) return;
+    const { resolve } = this.pendingStart;
+    this.pendingStart = null;
+    resolve(result);
+  }
+
+  async start(settings: VoiceInputSettings): Promise<VoiceStartResult> {
+    if (!settings.openaiApiKey) {
+      logWarn(`${P} No OpenAI API key configured`);
+      return { ok: false, error: "OpenAI API key not configured" };
+    }
+
+    const mySessionId = this.sessionId + 1;
+    logInfo(`${P} Starting session ${mySessionId}`, {
+      language: settings.language,
+      hasDictionary: settings.customDictionary.length > 0,
+    });
+    this.cleanupPreviousSession();
+    this.sessionId = mySessionId;
+    this.isReady = false;
+    this.preConnectBuffer = [];
+    this.preConnectBufferBytes = 0;
+    this.reconnectAttempt = 0;
+    this.isReconnecting = false;
+    this.isExpectedClose = false;
+    this.liveText = "";
+
+    this.emit({ type: "status", status: "connecting" });
+
+    return new Promise((resolve) => {
+      this.pendingStart = { sessionId: mySessionId, resolve };
+      this.connect(mySessionId, settings);
+    });
+  }
+
+  /**
+   * Opens the WebSocket and wires every event handler for one connection
+   * attempt. Shared by `start()` (initial connect, with a pending start promise
+   * to settle) and `reconnectOnce()` (mid-session reconnect, no pending start).
+   * The reconnect path is distinguished purely by `this.isReconnecting`, so a
+   * construct/timeout failure reschedules instead of surfacing a fatal error.
+   */
+  private connect(mySessionId: number, settings: VoiceInputSettings): void {
+    let connection: WebSocket;
+    try {
+      connection = new WebSocket(OPENAI_REALTIME_URL, {
+        headers: buildOpenAIHeaders(
+          settings.openaiApiKey,
+          settings.organizationId,
+          settings.projectId
+        ),
+      });
+    } catch (err) {
+      const message = formatErrorMessage(err, "Failed to open WebSocket");
+      logError(`${P} ${message}`);
+      if (this.isReconnecting) {
+        this.scheduleReconnect(mySessionId, settings);
+      } else {
+        this.emit({ type: "error", message });
+        this.emit({ type: "status", status: "error" });
+        this.settlePendingStart(mySessionId, { ok: false, error: message });
+      }
+      return;
+    }
+
+    this.connection = connection;
+    logInfo(`${P} Opening OpenAI realtime WebSocket`, {
+      url: OPENAI_REALTIME_URL,
+      model: OPENAI_TRANSCRIPTION_MODEL,
+      language: settings.language || "en",
+      customDictionaryTerms: settings.customDictionary.length,
+      reconnectAttempt: this.isReconnecting ? this.reconnectAttempt : 0,
+    });
+
+    this.connectTimeout = setTimeout(() => {
+      this.connectTimeout = null;
+      if (this.sessionId !== mySessionId) return;
+      logError(`${P} Connection timed out (${CONNECT_TIMEOUT_MS}ms)`);
+      if (this.isReconnecting) {
+        // Force the dead socket closed; the `close` handler schedules the next
+        // reconnect attempt (or gives up once attempts are exhausted).
+        try {
+          connection.terminate();
+        } catch {
+          // Ignore terminate errors
+        }
+        return;
+      }
+      // Expected teardown — the trailing `close` from connection.close() must
+      // not override the "error" status below with "idle".
+      this.isExpectedClose = true;
+      try {
+        connection.close();
+      } catch {
+        // Ignore close errors
+      }
+      this.cleanupConnection();
+      this.emit({ type: "error", message: "Connection timed out" });
+      this.emit({ type: "status", status: "error" });
+      this.settlePendingStart(mySessionId, { ok: false, error: "Connection timed out" });
+    }, CONNECT_TIMEOUT_MS);
+
+    connection.on("pong", () => {
+      if (this.sessionId !== mySessionId || this.connection !== connection) return;
+      this.isAlive = true;
+    });
+
+    // Open handler — same logic for initial connect and reconnect.
+    connection.on("open", () => {
+      if (this.sessionId !== mySessionId) {
+        logWarn(`${P} Session expired during connect, closing`);
+        try {
+          connection.close();
+        } catch {
+          // Ignore close errors
+        }
+        return;
+      }
+      this.startHeartbeat(connection, mySessionId);
+      logInfo(`${P} WebSocket opened, sending session.update`);
+      // TODO: pass `transcription.prompt` from settings once #7832 lands.
+      // `turn_detection` MUST be explicitly `null` for `gpt-realtime-whisper`
+      // (VAD is not supported for this model). It is not enough to omit it:
+      // when absent the server applies a default VAD that this model can't
+      // use, and then silently produces no transcription — it still acks
+      // `input_audio_buffer.committed` but emits no `conversation.item.added`
+      // / `conversation.item.done`. With it set to `null`, each manual commit
+      // yields a transcribed item. (An explicit non-null `turn_detection`
+      // block, by contrast, is hard-rejected with an error event.)
+      const sessionUpdate = {
+        type: "session.update",
+        session: {
+          type: "transcription",
+          audio: {
+            input: {
+              format: { type: "audio/pcm", rate: 24000 },
+              transcription: {
+                model: OPENAI_TRANSCRIPTION_MODEL,
+                language: settings.language || "en",
+              },
+              turn_detection: null,
+            },
+          },
+        },
+      };
+      // Log the exact payload — the session config (especially the explicit
+      // `turn_detection: null`) is the most common cause of "commits acked
+      // but no transcription items" regressions.
+      logInfo(`${P} → session.update`, { session: sessionUpdate.session });
+      try {
+        connection.send(JSON.stringify(sessionUpdate));
+      } catch (err) {
+        const message = formatErrorMessage(err, "Failed to send session.update");
+        logError(`${P} ${message}`);
+        this.handleFatalError(mySessionId, message);
+      }
+    });
+
+    connection.on("message", (data) => {
+      if (this.sessionId !== mySessionId || this.connection !== connection) return;
+      const raw =
+        typeof data === "string"
+          ? data
+          : Buffer.isBuffer(data)
+            ? data.toString("utf8")
+            : Array.isArray(data)
+              ? Buffer.concat(data).toString("utf8")
+              : Buffer.from(data as ArrayBuffer).toString("utf8");
+
+      let parsed: Record<string, unknown>;
+      try {
+        parsed = JSON.parse(raw) as Record<string, unknown>;
+      } catch {
+        logWarn(`${P} Ignoring non-JSON message`, { raw: raw.slice(0, 200) });
+        return;
+      }
+
+      const type = typeof parsed.type === "string" ? parsed.type : "";
+      this.handleServerEvent(mySessionId, type, parsed);
+    });
+
+    connection.on("error", (err) => {
+      this.clearConnectTimeout();
+      if (this.sessionId !== mySessionId || this.connection !== connection) return;
+      const message = formatErrorMessage(err, "WebSocket error");
+      logError(`${P} WebSocket error`, { message });
+      // A transport error on a ready (or reconnecting) session is recoverable —
+      // `ws` always fires `close` right after `error`, and the close handler
+      // owns the reconnect decision, so just log here. A pre-ready error
+      // (auth/DNS/refused on the very first connect) is fatal: tear down now.
+      if (!this.isReady && !this.isReconnecting) {
+        this.handleFatalError(mySessionId, message);
+      }
+    });
+
+    connection.on("close", (code, reason) => {
+      this.clearConnectTimeout();
+      this.clearHeartbeat();
+      // Ignore the close of a socket that's already been superseded or torn down
+      // out-of-band (reconnect swap, or handleFatalError which terminates after
+      // nulling this.connection) — that path has already emitted its status.
+      if (this.sessionId !== mySessionId || this.connection !== connection) return;
+      const wasReady = this.isReady;
+      logInfo(`${P} WebSocket closed`, {
+        code,
+        reason: Buffer.isBuffer(reason) ? reason.toString("utf8") : String(reason ?? ""),
+        wasReady,
+        wasReconnecting: this.isReconnecting,
+        wasExpected: this.isExpectedClose,
+        wasDraining: this.isDraining,
+        audioChunksStreamed: this.audioChunkCount,
+      });
+      this.cleanupConnection();
+      if (this.isDraining) {
+        this.settleDrain("connection-closed");
+        return;
+      }
+      // An unexpected drop of a ready session (or a failed reconnect attempt
+      // while still mid-reconnect) is recoverable — schedule a retry instead of
+      // ending the session. Graceful stops and fatal errors set isExpectedClose.
+      if (!this.isExpectedClose && (wasReady || this.isReconnecting)) {
+        this.scheduleReconnect(mySessionId, settings);
+        return;
+      }
+      this.settlePendingStart(mySessionId, { ok: false, error: "Connection closed" });
+      // A deliberate teardown (fatal error / connect timeout) already emitted its
+      // terminal status ("error"); don't override it with "idle" here. Only an
+      // unexpected close of a never-ready connection should fall through to idle.
+      if (!this.isExpectedClose) {
+        this.emit({ type: "status", status: "idle" });
+      }
+    });
+  }
+
+  /**
+   * Starts the ping/pong heartbeat for one connection. `isAlive` is set true on
+   * open and on every pong; each interval tick terminates the socket if no pong
+   * arrived since the last ping, then sends a fresh ping. The session-id /
+   * socket-identity guard stops a stale interval from terminating a newer
+   * connection (lesson #4850).
+   */
+  private startHeartbeat(connection: WebSocket, mySessionId: number): void {
+    this.clearHeartbeat();
+    this.isAlive = true;
+    this.heartbeatInterval = setInterval(() => {
+      if (this.sessionId !== mySessionId || this.connection !== connection) {
+        this.clearHeartbeat();
+        return;
+      }
+      if (!this.isAlive) {
+        logWarn(`${P} Heartbeat: no pong, terminating half-open connection`);
+        try {
+          connection.terminate();
+        } catch {
+          // Ignore terminate errors — the close handler drives reconnect.
+        }
+        return;
+      }
+      this.isAlive = false;
+      try {
+        connection.ping();
+      } catch (err) {
+        logWarn(`${P} Heartbeat ping failed`, { message: formatErrorMessage(err, "ping failed") });
+      }
+    }, HEARTBEAT_INTERVAL_MS);
+  }
+
+  private clearHeartbeat(): void {
+    if (this.heartbeatInterval !== null) {
+      clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = null;
+    }
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  /**
+   * Schedules the next reconnect attempt with exponential backoff + full jitter.
+   * Gives up (fatal error) once RECONNECT_MAX_ATTEMPTS is reached. The timer
+   * callback re-checks the session id so a `stop()`/new `start()` between
+   * scheduling and firing cancels it (lessons #4850/#4851).
+   */
+  private scheduleReconnect(mySessionId: number, settings: VoiceInputSettings): void {
+    if (this.sessionId !== mySessionId) return;
+    if (this.reconnectAttempt >= RECONNECT_MAX_ATTEMPTS) {
+      logError(`${P} Reconnect failed after ${RECONNECT_MAX_ATTEMPTS} attempts — giving up`);
+      this.isReconnecting = false;
+      this.handleFatalError(mySessionId, "Connection lost — reconnect failed");
+      return;
+    }
+
+    this.isReconnecting = true;
+    const ceiling = Math.min(
+      RECONNECT_CAP_MS,
+      RECONNECT_INITIAL_MS * RECONNECT_MULTIPLIER ** this.reconnectAttempt
+    );
+    const delay = Math.random() * ceiling;
+    this.reconnectAttempt++;
+    logInfo(`${P} Scheduling reconnect`, {
+      attempt: this.reconnectAttempt,
+      maxAttempts: RECONNECT_MAX_ATTEMPTS,
+      delayMs: Math.round(delay),
+    });
+    this.emit({ type: "status", status: "reconnecting" });
+
+    this.clearReconnectTimer();
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (this.sessionId !== mySessionId) return;
+      this.reconnectOnce(mySessionId, settings);
+    }, delay);
+  }
+
+  /**
+   * Tears down the dead connection (without touching the session id, reconnect
+   * counter, or buffered audio) and opens a fresh one. Audio captured during
+   * the reconnect window stays in `preConnectBuffer` and is flushed once the new
+   * connection reaches `session.updated`.
+   */
+  private reconnectOnce(mySessionId: number, settings: VoiceInputSettings): void {
+    if (this.sessionId !== mySessionId) return;
+    logInfo(`${P} Reconnecting`, { attempt: this.reconnectAttempt });
+    this.cleanupConnection();
+    this.connect(mySessionId, settings);
+  }
+
+  private handleFatalError(mySessionId: number, message: string): void {
+    logError(`${P} Fatal error — tearing down session`, { message });
+    // Mark the close as expected so the trailing `close` event (after the
+    // socket tears down) isn't treated as a recoverable drop.
+    this.isExpectedClose = true;
+    this.isReconnecting = false;
+    this.clearReconnectTimer();
+    // Close the physical socket — a server-sent fatal `error` event leaves the
+    // connection open otherwise. Captured before cleanupConnection() nulls it.
+    const conn = this.connection;
+    this.cleanupConnection();
+    if (conn) {
+      try {
+        conn.terminate();
+      } catch {
+        // Ignore terminate errors
+      }
+    }
+    this.emit({ type: "error", message });
+    this.emit({ type: "status", status: "error" });
+    this.settlePendingStart(mySessionId, { ok: false, error: message });
+    this.settleDrain("fatal-error");
+  }
+
+  private handleServerEvent(
+    mySessionId: number,
+    type: string,
+    payload: Record<string, unknown>
+  ): void {
+    switch (type) {
+      case "session.created":
+        logInfo(`${P} ← session.created`, { session: payload.session });
+        return;
+
+      case "session.updated":
+        this.clearConnectTimeout();
+        // Log the session config the server actually applied — this is ground
+        // truth for whether `turn_detection`, model, and format took effect.
+        logInfo(`${P} ← session.updated — session ready`, { session: payload.session });
+        if (this.preConnectBuffer.length > 0 && this.connection) {
+          logInfo(`${P} Flushing ${this.preConnectBuffer.length} buffered audio chunks`);
+          // Detach the buffer before flushing so its state stays consistent even
+          // if a send throws partway through the loop.
+          const buffered = this.preConnectBuffer;
+          this.preConnectBuffer = [];
+          this.preConnectBufferBytes = 0;
+          for (const chunk of buffered) {
+            this.sendAudioJson(chunk);
+          }
+        }
+        // A successful (re)connection clears the reconnect state so a later drop
+        // gets a fresh full backoff budget.
+        this.reconnectAttempt = 0;
+        this.isReconnecting = false;
+        this.isReady = true;
+        this.startCommitTimer();
+        this.emit({ type: "status", status: "recording" });
+        this.settlePendingStart(mySessionId, { ok: true });
+        return;
+
+      case "input_audio_buffer.committed":
+        // Server ack that our commit landed. A transcription item
+        // (`conversation.item.added` then `.done`) should follow within ~1s; if
+        // it never does, the session config or the commit cadence is wrong.
+        logDebug(`${P} ← input_audio_buffer.committed`, {
+          itemId: typeof payload.item_id === "string" ? payload.item_id : undefined,
+        });
+        return;
+
+      case "input_audio_buffer.speech_started":
+      case "input_audio_buffer.speech_stopped":
+        // VAD signals — not expected for gpt-realtime-whisper (no turn
+        // detection), but log them if they appear; their presence would mean
+        // the server applied a VAD default we didn't ask for.
+        logInfo(`${P} ← ${type}`, { payload });
+        return;
+
+      case "conversation.item.input_audio_transcription.delta": {
+        const delta = typeof payload.delta === "string" ? payload.delta : "";
+        // Length only — dictated text is user content, kept out of logs.
+        logDebug(`${P} ← transcription.delta`, { length: delta.length });
+        if (!delta) return;
+        this.emit({ type: "delta", text: delta });
+        this.liveText += delta;
+        return;
+      }
+
+      case "conversation.item.input_audio_transcription.completed": {
+        // Side-channel transcription event used by conversation-style sessions.
+        // The `?intent=transcription` endpoint reports completions via
+        // `conversation.item.done` instead (handled below) — this case stays so
+        // a session that does emit it still works.
+        const transcript = typeof payload.transcript === "string" ? payload.transcript : "";
+        const itemId = typeof payload.item_id === "string" ? payload.item_id : undefined;
+        logInfo(`${P} ← transcription.completed`, { itemId, length: transcript.length });
+        this.handleTranscriptComplete(transcript, itemId);
+        return;
+      }
+
+      case "conversation.item.added": {
+        // The `?intent=transcription` endpoint creates the item shell here on
+        // commit; the transcript arrives with `conversation.item.done`.
+        const item = payload.item as
+          | { id?: string; content?: Array<{ type?: string; transcript?: string }> }
+          | undefined;
+        logDebug(`${P} ← conversation.item.added`, {
+          itemId: item?.id,
+          contentTypes: item?.content?.map((part) => part.type),
+        });
+        return;
+      }
+
+      case "conversation.item.done": {
+        // The `?intent=transcription` endpoint reports each committed segment's
+        // final transcript via `conversation.item.done`, not via
+        // `...input_audio_transcription.completed`. The text lives on the
+        // item's `input_audio` content part.
+        const item = payload.item as
+          | { id?: string; content?: Array<{ type?: string; transcript?: string }> }
+          | undefined;
+        const audioPart = item?.content?.find((part) => part.type === "input_audio");
+        const transcript = audioPart?.transcript ?? "";
+        // Length only — dictated text is user content, kept out of logs.
+        logInfo(`${P} ← conversation.item.done`, {
+          itemId: item?.id,
+          hasInputAudioPart: !!audioPart,
+          length: transcript.length,
+        });
+        if (!audioPart) {
+          // Not a transcription segment — don't count it against an
+          // outstanding commit, or a stray `done` could settle the drain early.
+          logWarn(`${P} conversation.item.done carried no input_audio content part — not counted`, {
+            contentTypes: item?.content?.map((part) => part.type),
+          });
+          return;
+        }
+        this.handleTranscriptComplete(transcript, item?.id);
+        return;
+      }
+
+      case "error": {
+        const errorPayload = payload.error as
+          | { message?: string; type?: string; code?: string; param?: string }
+          | undefined;
+        const message = errorPayload?.message ?? "OpenAI realtime error";
+        logError(`${P} ← server error event`, {
+          message,
+          type: errorPayload?.type,
+          code: errorPayload?.code,
+          param: errorPayload?.param,
+        });
+        this.handleFatalError(mySessionId, message);
+        return;
+      }
+
+      default:
+        // Log the full payload (truncated) so an unrecognised event shape is
+        // never invisible — this is how the conversation.item.done schema
+        // mismatch was originally caught.
+        logDebug(`${P} ← unhandled server event`, {
+          type,
+          payload: JSON.stringify(payload).slice(0, 600),
+        });
+    }
+  }
+
+  /**
+   * Handles one committed segment's transcript: emits it to the renderer and
+   * decrements the outstanding-commit counter. While draining, settles the
+   * drain the moment every committed segment has reported back. Shared by the
+   * `...input_audio_transcription.completed` and `conversation.item.done`
+   * paths since both report a committed segment.
+   *
+   * `itemId` is deduped: a completion already counted (e.g. a `.completed` and
+   * a `.done` for the same item, or a repeated frame) is ignored entirely, so
+   * it can't drop `pendingCommits` below the number genuinely in flight and
+   * settle the drain before the final transcript lands.
+   */
+  private handleTranscriptComplete(rawTranscript: string, itemId?: string): void {
+    if (itemId && this.completedItemIds.has(itemId)) {
+      logDebug(`${P} Duplicate completion for item ${itemId} — ignoring`);
+      return;
+    }
+    if (itemId) {
+      this.completedItemIds.add(itemId);
+    }
+
+    const transcript = rawTranscript.trim();
+    this.liveText = "";
+    if (this.pendingCommits > 0) {
+      this.pendingCommits--;
+    }
+    if (transcript) {
+      logDebug(`${P} Emitting complete transcript to renderer`, { length: transcript.length });
+      this.emit({ type: "complete", text: transcript, confidence: { ...STUB_CONFIDENCE } });
+    } else {
+      logDebug(`${P} Completion had an empty transcript — nothing emitted`);
+    }
+    // Each commit yields exactly one completion. Once every committed segment
+    // has reported back the drain is genuinely finished — no grace timer, no
+    // guessing whether a late final-commit transcript is still in flight.
+    if (this.isDraining && this.pendingCommits === 0) {
+      logDebug(`${P} All committed segments transcribed — settling drain`);
+      this.settleDrain("all-segments-transcribed");
+    }
+  }
+
+  private sendAudioJson(chunk: ArrayBuffer): void {
+    if (!this.connection) return;
+    const audio = Buffer.from(chunk).toString("base64");
+    try {
+      this.connection.send(JSON.stringify({ type: "input_audio_buffer.append", audio }));
+    } catch (err) {
+      // A send can throw if the socket transitioned to CLOSING mid-flush. Don't
+      // let it escape the buffer-flush loop (which would leave the buffer in a
+      // partially-cleared state) — the trailing `close` event drives reconnect.
+      logWarn(`${P} Failed to send audio chunk`, {
+        message: formatErrorMessage(err, "send failed"),
+      });
+      return;
+    }
+    this.bytesSinceCommit += chunk.byteLength;
+  }
+
+  sendAudioChunk(chunk: ArrayBuffer): void {
+    if (this.isDraining) return;
+
+    if (!this.isReady || !this.connection) {
+      // Buffer while connecting (initial) or reconnecting (mid-session drop) so
+      // audio captured during the gap is flushed once the session is ready.
+      if (this.connection || this.pendingStart || this.isReconnecting) {
+        this.bufferPreConnectChunk(chunk);
+      } else if (!this.staleChunkWarned) {
+        this.staleChunkWarned = true;
+        logWarn(`${P} sendAudioChunk called but no active session`);
+      }
+      return;
+    }
+    this.audioChunkCount++;
+    if (this.audioChunkCount <= 3 || this.audioChunkCount % 100 === 0) {
+      logDebug(`${P} Sending audio chunk #${this.audioChunkCount}`, {
+        bytes: chunk.byteLength,
+        bytesSinceCommit: this.bytesSinceCommit + chunk.byteLength,
+      });
+    }
+    this.sendAudioJson(chunk);
+  }
+
+  /**
+   * Appends a chunk to the pre-connect / reconnect buffer, enforcing both a
+   * chunk-count cap and a byte cap. Oldest-wins: once either ceiling is hit the
+   * chunk is dropped (warned once) — a voice gap past ~3s is unrecoverable
+   * anyway, so there's no value in retaining unbounded audio.
+   */
+  private bufferPreConnectChunk(chunk: ArrayBuffer): void {
+    if (
+      this.preConnectBuffer.length >= PRE_CONNECT_BUFFER_MAX ||
+      this.preConnectBufferBytes + chunk.byteLength > PRE_CONNECT_BUFFER_MAX_BYTES
+    ) {
+      if (!this.preConnectBufferOverflowWarned) {
+        this.preConnectBufferOverflowWarned = true;
+        logWarn(`${P} Pre-connect buffer full, dropping audio`, {
+          chunks: this.preConnectBuffer.length,
+          bytes: this.preConnectBufferBytes,
+          maxChunks: PRE_CONNECT_BUFFER_MAX,
+          maxBytes: PRE_CONNECT_BUFFER_MAX_BYTES,
+        });
+      }
+      return;
+    }
+    this.preConnectBuffer.push(chunk);
+    this.preConnectBufferBytes += chunk.byteLength;
+  }
+
+  /**
+   * Tears down per-connection state without ending the session. Deliberately
+   * does NOT touch `sessionId`, `reconnectAttempt`, `isReconnecting`,
+   * `isExpectedClose`, or the pre-connect buffer — those survive across a
+   * reconnect. Use `cleanupPreviousSession()` for a full session reset.
+   */
+  private cleanupConnection(): void {
+    this.clearCommitTimer();
+    this.clearHeartbeat();
+    this.connection = null;
+    this.isReady = false;
+    this.isAlive = false;
+    this.bytesSinceCommit = 0;
+    this.pendingCommits = 0;
+    this.completedItemIds.clear();
+  }
+
+  private cleanupPreviousSession(): void {
+    logDebug(`${P} Cleaning up previous session`, {
+      sessionId: this.sessionId,
+      hasConnection: !!this.connection,
+    });
+    const pendingSessionId = this.pendingStart?.sessionId;
+    this.sessionId++;
+    this.audioChunkCount = 0;
+    this.staleChunkWarned = false;
+    this.preConnectBufferOverflowWarned = false;
+    this.isReady = false;
+    this.bytesSinceCommit = 0;
+    this.pendingCommits = 0;
+    this.completedItemIds.clear();
+    this.preConnectBuffer = [];
+    this.preConnectBufferBytes = 0;
+    this.clearConnectTimeout();
+    this.clearDrainTimeout();
+    this.clearCommitTimer();
+    this.clearHeartbeat();
+    this.clearReconnectTimer();
+    this.reconnectAttempt = 0;
+    this.isReconnecting = false;
+    this.isExpectedClose = false;
+    this.isAlive = false;
+    this.isDraining = false;
+    this.liveText = "";
+    if (this.drainResolve) {
+      this.drainResolve();
+      this.drainResolve = null;
+    }
+    this.drainPromise = null;
+    if (pendingSessionId !== undefined) {
+      this.settlePendingStart(pendingSessionId, { ok: false, error: "Voice session stopped" });
+    }
+    if (this.connection) {
+      try {
+        this.connection.close();
+      } catch {
+        // Ignore close errors
+      }
+      this.connection = null;
+    }
+  }
+
+  private clearDrainTimeout(): void {
+    if (this.drainTimeout !== null) {
+      clearTimeout(this.drainTimeout);
+      this.drainTimeout = null;
+    }
+  }
+
+  private startCommitTimer(): void {
+    this.clearCommitTimer();
+    logDebug(`${P} Starting interval commit timer`, { intervalMs: COMMIT_INTERVAL_MS });
+    this.commitTimer = setInterval(() => {
+      this.maybeCommitSegment("interval");
+    }, COMMIT_INTERVAL_MS);
+  }
+
+  private clearCommitTimer(): void {
+    if (this.commitTimer !== null) {
+      clearInterval(this.commitTimer);
+      this.commitTimer = null;
+    }
+  }
+
+  /**
+   * Sends `input_audio_buffer.commit` to close the current segment so the model
+   * transcribes it and streams back delta/completed events. No-ops when there's
+   * no live connection, the session isn't ready, we're already draining, or too
+   * little audio has accumulated since the last commit (OpenAI rejects an
+   * undersized buffer with a fatal error event).
+   */
+  private maybeCommitSegment(reason: string): void {
+    if (!this.connection || !this.isReady || this.isDraining) {
+      logDebug(`${P} Commit skipped — session not in a committable state`, {
+        reason,
+        hasConnection: !!this.connection,
+        isReady: this.isReady,
+        isDraining: this.isDraining,
+      });
+      return;
+    }
+    if (this.bytesSinceCommit < MIN_COMMIT_BYTES) {
+      logDebug(`${P} Commit skipped — buffer below threshold`, {
+        reason,
+        bytesSinceCommit: this.bytesSinceCommit,
+        thresholdBytes: MIN_COMMIT_BYTES,
+      });
+      return;
+    }
+    try {
+      this.connection.send(JSON.stringify({ type: "input_audio_buffer.commit" }));
+      this.pendingCommits++;
+      logDebug(`${P} → input_audio_buffer.commit`, {
+        reason,
+        bytes: this.bytesSinceCommit,
+        chunksStreamed: this.audioChunkCount,
+        pendingCommits: this.pendingCommits,
+      });
+      this.bytesSinceCommit = 0;
+    } catch (err) {
+      logWarn(`${P} Failed to commit audio segment`, {
+        reason,
+        message: formatErrorMessage(err, "commit failed"),
+      });
+    }
+  }
+
+  private settleDrain(reason: string): void {
+    this.clearDrainTimeout();
+    this.isDraining = false;
+    this.drainPromise = null;
+    if (this.drainResolve) {
+      logInfo(`${P} Drain completed`, { reason });
+      const resolve = this.drainResolve;
+      this.drainResolve = null;
+      resolve();
+    } else {
+      logDebug(`${P} settleDrain called with no pending drain`, { reason });
+    }
+  }
+
+  async stopGracefully(): Promise<void> {
+    logInfo(`${P} stopGracefully() called`, {
+      sessionId: this.sessionId,
+      hasConnection: !!this.connection,
+    });
+
+    if (this.drainPromise) {
+      logDebug(`${P} Already draining, joining existing promise`);
+      return this.drainPromise;
+    }
+
+    // A graceful stop is an expected close — cancel any pending reconnect and
+    // stop the close handler from retrying.
+    this.isExpectedClose = true;
+    this.isReconnecting = false;
+    this.clearReconnectTimer();
+
+    if (!this.connection || !this.isReady) {
+      this.cleanupPreviousSession();
+      this.emit({ type: "status", status: "idle" });
+      return;
+    }
+
+    this.isDraining = true;
+    this.clearCommitTimer();
+    this.emit({ type: "status", status: "finishing" });
+
+    // Flush whatever audio accumulated since the last interval commit so its
+    // transcript is included. If too little remains, OpenAI would reject the
+    // commit as undersized — skip it; an interval commit's transcript may still
+    // be in flight, and `pendingCommits` already accounts for it.
+    if (this.bytesSinceCommit >= MIN_COMMIT_BYTES) {
+      try {
+        this.connection.send(JSON.stringify({ type: "input_audio_buffer.commit" }));
+        this.pendingCommits++;
+        logInfo(`${P} → input_audio_buffer.commit (final)`, {
+          bytes: this.bytesSinceCommit,
+          chunksStreamed: this.audioChunkCount,
+          pendingCommits: this.pendingCommits,
+        });
+        this.bytesSinceCommit = 0;
+      } catch {
+        logWarn(`${P} Failed to send final commit, closing immediately`);
+        this.cleanupPreviousSession();
+        this.emit({ type: "status", status: "idle" });
+        return;
+      }
+    } else {
+      logInfo(`${P} Stop with sub-threshold buffer — no final commit`, {
+        bytesSinceCommit: this.bytesSinceCommit,
+        thresholdBytes: MIN_COMMIT_BYTES,
+      });
+    }
+
+    const sessionIdBeforeDrain = this.sessionId;
+
+    // Drain only while there are committed segments still awaiting their
+    // `conversation.item.done`. If none are outstanding, the session is already
+    // fully transcribed — close immediately rather than waiting on a timer.
+    if (this.pendingCommits > 0) {
+      logInfo(`${P} Draining — awaiting ${this.pendingCommits} transcription(s)`);
+      this.drainPromise = new Promise<void>((resolve) => {
+        this.drainResolve = resolve;
+        this.drainTimeout = setTimeout(() => {
+          logWarn(`${P} Drain timed out after ${DRAIN_TIMEOUT_MS}ms, force closing`, {
+            pendingCommits: this.pendingCommits,
+          });
+          this.settleDrain("timeout");
+        }, DRAIN_TIMEOUT_MS);
+      });
+      await this.drainPromise;
+    } else {
+      logInfo(`${P} Nothing to drain — no outstanding transcriptions`);
+      this.isDraining = false;
+    }
+
+    // If start() was called during drain it already ran cleanupPreviousSession()
+    // and incremented sessionId — don't tear down the new session.
+    if (this.sessionId === sessionIdBeforeDrain) {
+      this.cleanupPreviousSession();
+      this.emit({ type: "status", status: "idle" });
+    }
+  }
+
+  stop(): void {
+    logInfo(`${P} stop() called`, { sessionId: this.sessionId, hasConnection: !!this.connection });
+    // Suppress any reconnect: this is a deliberate stop. The sessionId bump in
+    // cleanupPreviousSession is the primary guard; the flag documents intent and
+    // covers the brief window before the bump takes effect.
+    this.isExpectedClose = true;
+    this.isReconnecting = false;
+    this.clearReconnectTimer();
+    this.cleanupPreviousSession();
+    this.emit({ type: "status", status: "idle" });
+  }
+
+  destroy(): void {
+    this.stop();
+    this.listeners.clear();
+  }
+}

--- a/electron/services/voice/TranscriptionProvider.ts
+++ b/electron/services/voice/TranscriptionProvider.ts
@@ -1,0 +1,65 @@
+import type { VoiceInputSettings, VoiceInputStatus } from "../../../shared/types/ipc/api.js";
+
+export interface CorrectionWord {
+  word: string;
+  confidence: number;
+  start?: number;
+  end?: number;
+}
+
+export interface SegmentConfidence {
+  minConfidence: number;
+  wordCount: number;
+  uncertainWords: string[];
+  words: CorrectionWord[];
+}
+
+export type VoiceTranscriptionEvent =
+  | { type: "delta"; text: string }
+  | { type: "complete"; text: string; confidence?: SegmentConfidence }
+  | { type: "paragraph_boundary" }
+  | { type: "error"; message: string }
+  | { type: "status"; status: VoiceInputStatus };
+
+export type VoiceStartResult = { ok: true } | { ok: false; error: string };
+
+// Providers emit a neutral, fully-confident stub: the real word-level
+// confidence/correction pass lives in VoiceCorrectionService, not the
+// transcription stream. Both providers reuse this so the renderer's confidence
+// shape stays consistent regardless of backend.
+export const STUB_CONFIDENCE: SegmentConfidence = {
+  minConfidence: 1.0,
+  wordCount: 0,
+  uncertainWords: [],
+  words: [],
+};
+
+/**
+ * One concrete transcription backend (OpenAI Realtime, Deepgram, …). The
+ * orchestrator (`VoiceTranscriptionService`) talks only to this interface and
+ * never to a provider's protocol details. A provider owns its own WebSocket
+ * connection, authentication, audio encoding, server-event parsing, and any
+ * timers (commit cadence, keep-alive, heartbeat) its protocol requires.
+ */
+export interface TranscriptionProvider {
+  /**
+   * Whether the backend performs server-side voice-activity detection / turn
+   * detection. When `false` the provider must drive utterance segmentation
+   * itself (e.g. OpenAI's fixed commit cadence, since `gpt-realtime-whisper`
+   * does not support server VAD). When `true` the backend emits finalized
+   * segments on its own, so no client-side commit timer exists.
+   */
+  readonly hasServerVAD: boolean;
+  start(settings: VoiceInputSettings): Promise<VoiceStartResult>;
+  sendAudioChunk(chunk: ArrayBuffer): void;
+  /**
+   * Flush the current audio segment at a user-driven paragraph boundary (Enter
+   * pressed mid-utterance). A no-op for server-VAD providers, which segment on
+   * their own.
+   */
+  commitParagraphBoundary(): void;
+  stopGracefully(): Promise<void>;
+  stop(): void;
+  destroy(): void;
+  onEvent(listener: (event: VoiceTranscriptionEvent) => void): () => void;
+}

--- a/electron/services/voice/__tests__/DeepgramTranscriptionProvider.test.ts
+++ b/electron/services/voice/__tests__/DeepgramTranscriptionProvider.test.ts
@@ -299,6 +299,25 @@ describe("DeepgramTranscriptionProvider", () => {
     provider.stop();
   });
 
+  it("enforces the pre-connect byte cap independently of chunk count", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const startPromise = provider.start(BASE_SETTINGS);
+    await Promise.resolve();
+    const socket = latestInstance();
+
+    // Five 40KB chunks = 200KB, over the 150KB ceiling. Only the chunks that
+    // fit under 150KB are retained.
+    for (let i = 0; i < 5; i++) {
+      provider.sendAudioChunk(new Uint8Array(40_000).buffer);
+    }
+    socket.simulateOpen();
+    await startPromise;
+
+    // 3 × 40KB = 120KB fits; a 4th would push to 160KB > 150KB, so it's dropped.
+    expect(socket.binaryFrames()).toHaveLength(3);
+    provider.stop();
+  });
+
   it("drops audio chunks while draining", async () => {
     const provider = new DeepgramTranscriptionProvider();
     const { socket } = await bringSessionReady(provider);
@@ -374,6 +393,33 @@ describe("DeepgramTranscriptionProvider", () => {
     expect(() => socket.simulateRawMessage("not json {")).not.toThrow();
     socket.simulateMessage(resultsMessage("still works", { is_final: true }));
     expect(completes).toEqual(["still works"]);
+    provider.stop();
+  });
+
+  it("handles malformed Results payloads without throwing or emitting", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const completes: string[] = [];
+    provider.onEvent((e) => {
+      if (e.type === "complete") completes.push(e.text);
+    });
+
+    const { socket } = await bringSessionReady(provider);
+    // No channel field.
+    expect(() => socket.simulateMessage({ type: "Results", is_final: true })).not.toThrow();
+    // Empty alternatives array.
+    expect(() =>
+      socket.simulateMessage({ type: "Results", is_final: true, channel: { alternatives: [] } })
+    ).not.toThrow();
+    // is_final as a string, not a strict boolean — treated as interim, not emitted.
+    expect(() =>
+      socket.simulateMessage({
+        type: "Results",
+        is_final: "true",
+        channel: { alternatives: [{ transcript: "stringy" }] },
+      })
+    ).not.toThrow();
+
+    expect(completes).toEqual([]);
     provider.stop();
   });
 

--- a/electron/services/voice/__tests__/DeepgramTranscriptionProvider.test.ts
+++ b/electron/services/voice/__tests__/DeepgramTranscriptionProvider.test.ts
@@ -1,0 +1,564 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { VoiceInputSettings } from "../../../../shared/types/ipc/api.js";
+
+// ── Mock the `ws` package ────────────────────────────────────────────────────
+//
+// Like the OpenAI provider, the Deepgram provider imports `WebSocket from "ws"`
+// so it can send the `Authorization` upgrade header. The mock captures both
+// string control frames (KeepAlive / CloseStream / Finalize) and binary audio
+// frames (raw PCM16 Buffers) so the test can assert the transport differences.
+
+interface MockOptions {
+  headers: Record<string, string>;
+}
+
+type WsListener = (...args: unknown[]) => void;
+
+class MockWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  url: string;
+  options: MockOptions;
+  readyState: number = MockWebSocket.CONNECTING;
+  sent: Array<string | Buffer> = [];
+  closeCalls = 0;
+  closeCode?: number;
+  terminateCalls = 0;
+
+  private listeners: Map<string, Set<WsListener>> = new Map();
+
+  constructor(url: string, options: MockOptions) {
+    this.url = url;
+    this.options = options;
+    instances.push(this);
+  }
+
+  on(event: string, listener: WsListener): this {
+    if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+    this.listeners.get(event)!.add(listener);
+    return this;
+  }
+
+  off(event: string, listener: WsListener): this {
+    this.listeners.get(event)?.delete(listener);
+    return this;
+  }
+
+  removeAllListeners(event?: string): this {
+    if (event) this.listeners.delete(event);
+    else this.listeners.clear();
+    return this;
+  }
+
+  private fire(event: string, ...args: unknown[]): void {
+    const set = this.listeners.get(event);
+    if (!set) return;
+    for (const listener of set) listener(...args);
+  }
+
+  send(payload: string | Buffer): void {
+    this.sent.push(payload);
+  }
+
+  close(code?: number): void {
+    this.closeCalls++;
+    this.closeCode = code;
+    this.readyState = MockWebSocket.CLOSED;
+  }
+
+  terminate(): void {
+    this.terminateCalls++;
+    this.readyState = MockWebSocket.CLOSED;
+    this.fire("close", 1006, undefined);
+  }
+
+  // Test helpers
+  simulateOpen(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.fire("open");
+  }
+
+  simulateMessage(payload: Record<string, unknown>): void {
+    this.fire("message", Buffer.from(JSON.stringify(payload)));
+  }
+
+  simulateRawMessage(data: string | Buffer): void {
+    this.fire("message", data);
+  }
+
+  simulateError(err: Error = new Error("WebSocket error")): void {
+    this.fire("error", err);
+  }
+
+  simulateClose(code?: number, reason?: Buffer | string): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.fire("close", code, reason);
+  }
+
+  /** Control (text) frames the provider sent, parsed as JSON. */
+  textFrames(): Array<Record<string, unknown>> {
+    return this.sent
+      .filter((s): s is string => typeof s === "string")
+      .map((s) => JSON.parse(s) as Record<string, unknown>);
+  }
+
+  /** Raw binary audio frames the provider sent. */
+  binaryFrames(): Buffer[] {
+    return this.sent.filter((s): s is Buffer => Buffer.isBuffer(s));
+  }
+}
+
+const instances: MockWebSocket[] = [];
+let throwOnConstruct = false;
+let constructError: Error | null = null;
+
+vi.mock("ws", () => {
+  const ctor = function (this: unknown, url: string, options: MockOptions) {
+    if (throwOnConstruct) {
+      throw constructError ?? new Error("WebSocket construction failed");
+    }
+    return new MockWebSocket(url, options);
+  } as unknown as new (url: string, options: MockOptions) => MockWebSocket;
+  return { default: ctor };
+});
+
+// Import AFTER vi.mock so the mocked `ws` is used.
+const { DeepgramTranscriptionProvider } = await import("../DeepgramTranscriptionProvider.js");
+type DeepgramTranscriptionProviderInstance = InstanceType<typeof DeepgramTranscriptionProvider>;
+type VoiceTranscriptionEvent = import("../TranscriptionProvider.js").VoiceTranscriptionEvent;
+
+const BASE_SETTINGS: VoiceInputSettings = {
+  enabled: true,
+  openaiApiKey: "",
+  deepgramApiKey: "dg-test",
+  language: "en",
+  customDictionary: [],
+  transcriptionProvider: "deepgram",
+  transcriptionModel: "gpt-realtime-whisper",
+  correctionEnabled: false,
+  correctionModel: "gpt-5-mini",
+  correctionCustomInstructions: "",
+  paragraphingStrategy: "spoken-command",
+  resolveFileLinks: true,
+  deviceId: "",
+};
+
+function latestInstance(): MockWebSocket {
+  const instance = instances.at(-1);
+  if (!instance) throw new Error("No MockWebSocket instance created");
+  return instance;
+}
+
+async function bringSessionReady(
+  provider: DeepgramTranscriptionProviderInstance,
+  settings: VoiceInputSettings = BASE_SETTINGS
+): Promise<{ socket: MockWebSocket; result: { ok: true } | { ok: false; error: string } }> {
+  const startPromise = provider.start(settings);
+  await Promise.resolve();
+  const socket = latestInstance();
+  socket.simulateOpen();
+  const result = await startPromise;
+  return { socket, result };
+}
+
+function resultsMessage(transcript: string, flags: { is_final: boolean; speech_final?: boolean }) {
+  return {
+    type: "Results",
+    is_final: flags.is_final,
+    speech_final: flags.speech_final ?? false,
+    channel: { alternatives: [{ transcript }] },
+  };
+}
+
+describe("DeepgramTranscriptionProvider", () => {
+  beforeEach(() => {
+    instances.length = 0;
+    throwOnConstruct = false;
+    constructError = null;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // ── Capability ──────────────────────────────────────────────────────────
+
+  it("declares server-side VAD", () => {
+    const provider = new DeepgramTranscriptionProvider();
+    expect(provider.hasServerVAD).toBe(true);
+  });
+
+  // ── Startup ────────────────────────────────────────────────────────────
+
+  it("fails to start when no Deepgram API key is configured", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const result = await provider.start({ ...BASE_SETTINGS, deepgramApiKey: "" });
+    expect(result).toEqual({ ok: false, error: "Deepgram API key not configured" });
+    expect(instances).toHaveLength(0);
+  });
+
+  it("constructs the WebSocket with the Deepgram streaming URL and Token auth", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    void provider.start({ ...BASE_SETTINGS, deepgramApiKey: "dg-abc", language: "en" });
+    await Promise.resolve();
+    const socket = latestInstance();
+
+    const url = new URL(socket.url);
+    expect(url.origin + url.pathname).toBe("wss://api.deepgram.com/v1/listen");
+    expect(url.searchParams.get("model")).toBe("nova-3");
+    expect(url.searchParams.get("encoding")).toBe("linear16");
+    expect(url.searchParams.get("sample_rate")).toBe("24000");
+    expect(url.searchParams.get("endpointing")).toBe("300");
+    expect(url.searchParams.get("language")).toBe("en");
+    expect(socket.options.headers.Authorization).toBe("Token dg-abc");
+    provider.stop();
+  });
+
+  it("becomes ready and emits recording on WebSocket open", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const statuses: string[] = [];
+    provider.onEvent((e) => {
+      if (e.type === "status") statuses.push(e.status);
+    });
+
+    const startPromise = provider.start(BASE_SETTINGS);
+    expect(statuses).toEqual(["connecting"]);
+    await Promise.resolve();
+    latestInstance().simulateOpen();
+
+    await expect(startPromise).resolves.toEqual({ ok: true });
+    expect(statuses).toEqual(["connecting", "recording"]);
+    provider.stop();
+  });
+
+  it("times out and closes the socket if open does not arrive within 10s", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const errors: string[] = [];
+    provider.onEvent((e) => {
+      if (e.type === "error") errors.push(e.message);
+    });
+
+    const startPromise = provider.start(BASE_SETTINGS);
+    await Promise.resolve();
+    const socket = latestInstance();
+    // Never open.
+    vi.advanceTimersByTime(10_000);
+
+    await expect(startPromise).resolves.toEqual({ ok: false, error: "Connection timed out" });
+    expect(errors).toContain("Connection timed out");
+    expect(socket.closeCalls).toBe(1);
+  });
+
+  it("fails start when WebSocket construction throws", async () => {
+    throwOnConstruct = true;
+    constructError = new Error("ECONNREFUSED");
+    const provider = new DeepgramTranscriptionProvider();
+    const result = await provider.start(BASE_SETTINGS);
+    expect(result).toEqual({ ok: false, error: "ECONNREFUSED" });
+  });
+
+  // ── Audio transport ──────────────────────────────────────────────────────
+
+  it("sends audio chunks as raw binary frames, not base64 JSON", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const { socket } = await bringSessionReady(provider);
+
+    const chunk = new Uint8Array([1, 2, 3, 4]).buffer;
+    provider.sendAudioChunk(chunk);
+
+    const binary = socket.binaryFrames();
+    expect(binary).toHaveLength(1);
+    expect(binary[0].equals(Buffer.from(chunk))).toBe(true);
+    // No JSON audio envelope like OpenAI's input_audio_buffer.append.
+    expect(socket.textFrames().some((f) => f.type === "input_audio_buffer.append")).toBe(false);
+    provider.stop();
+  });
+
+  it("buffers pre-connect audio and flushes it as binary after open", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const startPromise = provider.start(BASE_SETTINGS);
+    await Promise.resolve();
+    const socket = latestInstance();
+
+    provider.sendAudioChunk(new Uint8Array([1]).buffer);
+    provider.sendAudioChunk(new Uint8Array([2]).buffer);
+    expect(socket.binaryFrames()).toHaveLength(0);
+
+    socket.simulateOpen();
+    await startPromise;
+
+    const binary = socket.binaryFrames();
+    expect(binary).toHaveLength(2);
+    expect(binary[0].equals(Buffer.from(new Uint8Array([1])))).toBe(true);
+    expect(binary[1].equals(Buffer.from(new Uint8Array([2])))).toBe(true);
+    provider.stop();
+  });
+
+  it("drops audio chunks while draining", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const { socket } = await bringSessionReady(provider);
+
+    const drainPromise = provider.stopGracefully();
+    const binaryAtDrain = socket.binaryFrames().length;
+    provider.sendAudioChunk(new Uint8Array([9]).buffer);
+    expect(socket.binaryFrames().length).toBe(binaryAtDrain);
+
+    socket.simulateClose(1000);
+    await drainPromise;
+  });
+
+  // ── Results → complete ─────────────────────────────────────────────────
+
+  it("emits complete only for finalized (is_final) results", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const completes: string[] = [];
+    provider.onEvent((e) => {
+      if (e.type === "complete") completes.push(e.text);
+    });
+
+    const { socket } = await bringSessionReady(provider);
+    // Interim hypothesis — must NOT be emitted (would corrupt the live buffer).
+    socket.simulateMessage(resultsMessage("hello wor", { is_final: false }));
+    expect(completes).toEqual([]);
+
+    // Finalized segment — emitted.
+    socket.simulateMessage(resultsMessage("hello world", { is_final: true }));
+    expect(completes).toEqual(["hello world"]);
+    provider.stop();
+  });
+
+  it("emits complete on a speech_final result", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const events: VoiceTranscriptionEvent[] = [];
+    provider.onEvent((e) => events.push(e));
+
+    const { socket } = await bringSessionReady(provider);
+    socket.simulateMessage(resultsMessage("done speaking", { is_final: true, speech_final: true }));
+
+    const complete = events.find((e) => e.type === "complete");
+    expect(complete).toEqual({
+      type: "complete",
+      text: "done speaking",
+      confidence: { minConfidence: 1.0, wordCount: 0, uncertainWords: [], words: [] },
+    });
+    provider.stop();
+  });
+
+  it("does not emit complete for an empty or whitespace-only final transcript", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const completes: string[] = [];
+    provider.onEvent((e) => {
+      if (e.type === "complete") completes.push(e.text);
+    });
+
+    const { socket } = await bringSessionReady(provider);
+    socket.simulateMessage(resultsMessage("", { is_final: true }));
+    socket.simulateMessage(resultsMessage("   ", { is_final: true }));
+    expect(completes).toEqual([]);
+    provider.stop();
+  });
+
+  it("ignores non-JSON messages without throwing", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const completes: string[] = [];
+    provider.onEvent((e) => {
+      if (e.type === "complete") completes.push(e.text);
+    });
+
+    const { socket } = await bringSessionReady(provider);
+    expect(() => socket.simulateRawMessage("not json {")).not.toThrow();
+    socket.simulateMessage(resultsMessage("still works", { is_final: true }));
+    expect(completes).toEqual(["still works"]);
+    provider.stop();
+  });
+
+  // ── No client commit timer (server VAD) ──────────────────────────────────
+
+  it("never runs a client-side commit timer", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const { socket } = await bringSessionReady(provider);
+
+    provider.sendAudioChunk(new Uint8Array(5_000).buffer);
+    // Advancing well past the OpenAI 2s commit cadence must not emit any commit.
+    vi.advanceTimersByTime(2_500);
+    expect(socket.textFrames().some((f) => f.type === "input_audio_buffer.commit")).toBe(false);
+    provider.stop();
+  });
+
+  // ── KeepAlive ────────────────────────────────────────────────────────────
+
+  it("sends a KeepAlive control frame on the keep-alive interval", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const { socket } = await bringSessionReady(provider);
+
+    expect(socket.textFrames().filter((f) => f.type === "KeepAlive")).toHaveLength(0);
+    vi.advanceTimersByTime(5_000);
+    expect(socket.textFrames().filter((f) => f.type === "KeepAlive")).toHaveLength(1);
+    vi.advanceTimersByTime(5_000);
+    expect(socket.textFrames().filter((f) => f.type === "KeepAlive")).toHaveLength(2);
+    provider.stop();
+  });
+
+  it("stops sending KeepAlive after stop()", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const { socket } = await bringSessionReady(provider);
+
+    provider.stop();
+    const keepAlivesBefore = socket.textFrames().filter((f) => f.type === "KeepAlive").length;
+    vi.advanceTimersByTime(15_000);
+    expect(socket.textFrames().filter((f) => f.type === "KeepAlive").length).toBe(keepAlivesBefore);
+  });
+
+  // ── Paragraph boundary ─────────────────────────────────────────────────
+
+  it("sends a Finalize control frame on commitParagraphBoundary", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const { socket } = await bringSessionReady(provider);
+
+    provider.commitParagraphBoundary();
+    expect(socket.textFrames().filter((f) => f.type === "Finalize")).toHaveLength(1);
+    provider.stop();
+  });
+
+  // ── Graceful stop / drain ────────────────────────────────────────────────
+
+  it("sends CloseStream on stopGracefully and drains until the socket closes", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const statuses: string[] = [];
+    const completes: string[] = [];
+    provider.onEvent((e) => {
+      if (e.type === "status") statuses.push(e.status);
+      if (e.type === "complete") completes.push(e.text);
+    });
+
+    const { socket } = await bringSessionReady(provider);
+    const drainPromise = provider.stopGracefully();
+    expect(statuses).toContain("finishing");
+    expect(socket.textFrames().filter((f) => f.type === "CloseStream")).toHaveLength(1);
+
+    // The server flushes a final result, then closes.
+    socket.simulateMessage(resultsMessage("flushed tail", { is_final: true }));
+    socket.simulateClose(1000);
+    await drainPromise;
+
+    expect(completes).toEqual(["flushed tail"]);
+    expect(statuses.at(-1)).toBe("idle");
+  });
+
+  it("drain resolves after the timeout if the socket never closes", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    await bringSessionReady(provider);
+
+    const drainPromise = provider.stopGracefully();
+    vi.advanceTimersByTime(3_000);
+    await expect(drainPromise).resolves.toBeUndefined();
+  });
+
+  it("stopGracefully without an open connection goes straight to idle", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const statuses: string[] = [];
+    provider.onEvent((e) => {
+      if (e.type === "status") statuses.push(e.status);
+    });
+
+    await provider.stopGracefully();
+    expect(statuses).toEqual(["idle"]);
+  });
+
+  it("repeated stopGracefully calls share a single in-flight drain", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const { socket } = await bringSessionReady(provider);
+
+    const first = provider.stopGracefully();
+    const second = provider.stopGracefully();
+    expect(socket.textFrames().filter((f) => f.type === "CloseStream")).toHaveLength(1);
+
+    socket.simulateClose(1000);
+    await Promise.all([first, second]);
+  });
+
+  // ── Error handling ─────────────────────────────────────────────────────
+
+  it("surfaces a server-side Error event as a fatal error", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const events: VoiceTranscriptionEvent[] = [];
+    provider.onEvent((e) => events.push(e));
+
+    const { socket } = await bringSessionReady(provider);
+    socket.simulateMessage({ type: "Error", description: "invalid api key" });
+
+    expect(events.some((e) => e.type === "error" && /invalid api key/.test(e.message))).toBe(true);
+    expect(events.some((e) => e.type === "status" && e.status === "error")).toBe(true);
+  });
+
+  it("emits error and error status when the WebSocket reports a pre-ready error", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const events: VoiceTranscriptionEvent[] = [];
+    provider.onEvent((e) => events.push(e));
+
+    const startPromise = provider.start(BASE_SETTINGS);
+    await Promise.resolve();
+    latestInstance().simulateError(new Error("dns failure"));
+
+    await expect(startPromise).resolves.toEqual({ ok: false, error: "dns failure" });
+    expect(events.some((e) => e.type === "error" && /dns failure/.test(e.message))).toBe(true);
+    expect(events.some((e) => e.type === "status" && e.status === "error")).toBe(true);
+  });
+
+  it("surfaces an unexpected drop of a ready session as an error", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const statuses: string[] = [];
+    provider.onEvent((e) => {
+      if (e.type === "status") statuses.push(e.status);
+    });
+
+    const { socket } = await bringSessionReady(provider);
+    socket.simulateClose(1006, Buffer.from("abnormal"));
+
+    expect(statuses).toContain("error");
+    expect(statuses).not.toContain("idle");
+  });
+
+  // ── Stale-session guard ──────────────────────────────────────────────────
+
+  it("ignores results from a stale session", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const completes: string[] = [];
+    provider.onEvent((e) => {
+      if (e.type === "complete") completes.push(e.text);
+    });
+
+    const { socket: firstSocket } = await bringSessionReady(provider);
+    // Replace the session; the first socket is now stale.
+    const second = provider.start(BASE_SETTINGS);
+    await Promise.resolve();
+    latestInstance().simulateOpen();
+    await second;
+
+    firstSocket.simulateMessage(resultsMessage("ghost", { is_final: true }));
+    expect(completes).toEqual([]);
+    provider.stop();
+  });
+
+  // ── destroy ──────────────────────────────────────────────────────────────
+
+  it("destroy closes the socket and clears listeners", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const events: VoiceTranscriptionEvent[] = [];
+    provider.onEvent((e) => events.push(e));
+
+    const { socket } = await bringSessionReady(provider);
+    provider.destroy();
+    expect(socket.closeCalls).toBe(1);
+
+    const lengthAtDestroy = events.length;
+    const { socket: socket2 } = await bringSessionReady(provider);
+    socket2.simulateMessage(resultsMessage("after destroy", { is_final: true }));
+    expect(events.length).toBe(lengthAtDestroy);
+  });
+});

--- a/electron/services/voice/__tests__/OpenAITranscriptionProvider.test.ts
+++ b/electron/services/voice/__tests__/OpenAITranscriptionProvider.test.ts
@@ -1,0 +1,1168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { VoiceInputSettings } from "../../../../shared/types/ipc/api.js";
+
+// ── Mock the `ws` package ────────────────────────────────────────────────────
+//
+// The service imports `WebSocket from "ws"` (the npm package, not the WHATWG
+// global) because Node's global WebSocket constructor silently drops the
+// custom-headers option needed for OpenAI auth. We mock the entire module so
+// the constructor returns a controllable EventEmitter-style stub.
+
+interface MockOptions {
+  headers: Record<string, string>;
+}
+
+type WsListener = (...args: unknown[]) => void;
+
+class MockWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  url: string;
+  options: MockOptions;
+  readyState: number = MockWebSocket.CONNECTING;
+  sent: string[] = [];
+  closeCalls = 0;
+  closeCode?: number;
+  terminateCalls = 0;
+  pingCalls = 0;
+
+  private listeners: Map<string, Set<WsListener>> = new Map();
+
+  constructor(url: string, options: MockOptions) {
+    this.url = url;
+    this.options = options;
+    instances.push(this);
+  }
+
+  on(event: string, listener: WsListener): this {
+    if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+    this.listeners.get(event)!.add(listener);
+    return this;
+  }
+
+  off(event: string, listener: WsListener): this {
+    this.listeners.get(event)?.delete(listener);
+    return this;
+  }
+
+  removeAllListeners(event?: string): this {
+    if (event) this.listeners.delete(event);
+    else this.listeners.clear();
+    return this;
+  }
+
+  private fire(event: string, ...args: unknown[]): void {
+    const set = this.listeners.get(event);
+    if (!set) return;
+    for (const listener of set) listener(...args);
+  }
+
+  send(payload: string): void {
+    this.sent.push(payload);
+  }
+
+  close(code?: number): void {
+    this.closeCalls++;
+    this.closeCode = code;
+    this.readyState = MockWebSocket.CLOSED;
+  }
+
+  // `ws.terminate()` destroys the socket without a closing handshake. The real
+  // package fires a `close` event afterward; mirror that so the service's
+  // close-driven reconnect path is exercised.
+  terminate(): void {
+    this.terminateCalls++;
+    this.readyState = MockWebSocket.CLOSED;
+    this.fire("close", 1006, undefined);
+  }
+
+  ping(): void {
+    this.pingCalls++;
+  }
+
+  // Test helpers
+  simulatePong(): void {
+    this.fire("pong");
+  }
+
+  simulateOpen(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.fire("open");
+  }
+
+  simulateMessage(type: string, payload: Record<string, unknown> = {}): void {
+    this.fire("message", Buffer.from(JSON.stringify({ type, ...payload })));
+  }
+
+  simulateRawMessage(data: string | Buffer): void {
+    this.fire("message", data);
+  }
+
+  simulateError(err: Error = new Error("WebSocket error")): void {
+    this.fire("error", err);
+  }
+
+  simulateClose(code?: number, reason?: Buffer | string): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.fire("close", code, reason);
+  }
+
+  sentJson(): Array<Record<string, unknown>> {
+    return this.sent.map((s) => JSON.parse(s) as Record<string, unknown>);
+  }
+}
+
+const instances: MockWebSocket[] = [];
+let throwOnConstruct = false;
+let constructError: Error | null = null;
+
+vi.mock("ws", () => {
+  const ctor = function (this: unknown, url: string, options: MockOptions) {
+    if (throwOnConstruct) {
+      throw constructError ?? new Error("WebSocket construction failed");
+    }
+    return new MockWebSocket(url, options);
+  } as unknown as new (url: string, options: MockOptions) => MockWebSocket;
+  return { default: ctor };
+});
+
+// Import the service AFTER vi.mock so the mocked `ws` is used.
+const { OpenAITranscriptionProvider } = await import("../OpenAITranscriptionProvider.js");
+type OpenAITranscriptionProviderInstance = InstanceType<typeof OpenAITranscriptionProvider>;
+type VoiceTranscriptionEvent = import("../TranscriptionProvider.js").VoiceTranscriptionEvent;
+
+const BASE_SETTINGS: VoiceInputSettings = {
+  enabled: true,
+  openaiApiKey: "sk-test",
+  deepgramApiKey: "",
+  language: "en",
+  customDictionary: [],
+  transcriptionProvider: "openai",
+  transcriptionModel: "gpt-realtime-whisper",
+  correctionEnabled: false,
+  correctionModel: "gpt-5-mini",
+  correctionCustomInstructions: "",
+  paragraphingStrategy: "spoken-command",
+  resolveFileLinks: true,
+  deviceId: "",
+};
+
+function latestInstance(): MockWebSocket {
+  const instance = instances.at(-1);
+  if (!instance) throw new Error("No MockWebSocket instance created");
+  return instance;
+}
+
+/** Advance the service through connect → ready. Returns the active mock socket. */
+async function bringSessionReady(
+  service: OpenAITranscriptionProviderInstance,
+  settings: VoiceInputSettings = BASE_SETTINGS
+): Promise<{ socket: MockWebSocket; result: { ok: true } | { ok: false; error: string } }> {
+  const startPromise = service.start(settings);
+  // start() runs synchronously through to assigning pendingStart; allow the
+  // microtask queue to settle so the constructor + onopen wiring is in place.
+  await Promise.resolve();
+  const socket = latestInstance();
+  socket.simulateOpen();
+  socket.simulateMessage("session.updated");
+  const result = await startPromise;
+  return { socket, result };
+}
+
+/**
+ * Feed enough uncommitted audio that the next `input_audio_buffer.commit` clears
+ * the MIN_COMMIT_BYTES floor — otherwise the service skips the commit to avoid
+ * OpenAI's "undersized buffer" error.
+ */
+function feedCommittableAudio(service: OpenAITranscriptionProviderInstance): void {
+  service.sendAudioChunk(new Uint8Array(5_000).buffer);
+}
+
+describe("OpenAITranscriptionProvider", () => {
+  beforeEach(() => {
+    instances.length = 0;
+    throwOnConstruct = false;
+    constructError = null;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // ── Startup / readiness ──────────────────────────────────────────────────
+
+  it("fails to start when no OpenAI API key is configured", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const result = await service.start({ ...BASE_SETTINGS, openaiApiKey: "" });
+    expect(result).toEqual({ ok: false, error: "OpenAI API key not configured" });
+    expect(instances).toHaveLength(0);
+  });
+
+  it("constructs the WebSocket with the realtime URL and auth headers", async () => {
+    const service = new OpenAITranscriptionProvider();
+    void service.start({ ...BASE_SETTINGS, openaiApiKey: "sk-abc" });
+    await Promise.resolve();
+    const socket = latestInstance();
+    expect(socket.url).toBe("wss://api.openai.com/v1/realtime?intent=transcription");
+    expect(socket.options.headers.Authorization).toBe("Bearer sk-abc");
+    service.stop();
+  });
+
+  it("sends session.update on WebSocket open and stays not-ready until session.updated", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const statuses: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "status") statuses.push(e.status);
+    });
+
+    const startPromise = service.start(BASE_SETTINGS);
+    expect(statuses).toEqual(["connecting"]);
+    await Promise.resolve();
+    const socket = latestInstance();
+    socket.simulateOpen();
+
+    expect(socket.sent).toHaveLength(1);
+    const sessionUpdate = JSON.parse(socket.sent[0]) as {
+      type: string;
+      session: { type: string; audio: { input: Record<string, unknown> } };
+    };
+    expect(sessionUpdate.type).toBe("session.update");
+    expect(sessionUpdate.session.type).toBe("transcription");
+    expect(sessionUpdate.session.audio.input).toMatchObject({
+      format: { type: "audio/pcm", rate: 24000 },
+      transcription: { model: "gpt-realtime-whisper", language: "en" },
+    });
+    // `turn_detection` must be EXPLICITLY null for gpt-realtime-whisper — see
+    // the session.update comment in OpenAITranscriptionProvider. Omitting it
+    // makes the server silently emit no transcription items.
+    expect(sessionUpdate.session.audio.input.turn_detection).toBeNull();
+
+    // Still not ready — start() must wait for session.updated
+    expect(statuses).toEqual(["connecting"]);
+
+    socket.simulateMessage("session.updated");
+    await expect(startPromise).resolves.toEqual({ ok: true });
+    expect(statuses).toEqual(["connecting", "recording"]);
+  });
+
+  it("uses the configured language in session.update", async () => {
+    const service = new OpenAITranscriptionProvider();
+    void service.start({ ...BASE_SETTINGS, language: "es" });
+    await Promise.resolve();
+    const socket = latestInstance();
+    socket.simulateOpen();
+    const payload = JSON.parse(socket.sent[0]) as {
+      session: { audio: { input: { transcription: { language: string } } } };
+    };
+    expect(payload.session.audio.input.transcription.language).toBe("es");
+    service.stop();
+  });
+
+  it("settles a pending start when the session is stopped before session.updated", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const startPromise = service.start(BASE_SETTINGS);
+    await Promise.resolve();
+    latestInstance().simulateOpen();
+    // No session.updated yet — stop before ready.
+    service.stop();
+    await expect(startPromise).resolves.toEqual({
+      ok: false,
+      error: "Voice session stopped",
+    });
+  });
+
+  it("does not emit idle when start() replaces a previous session", async () => {
+    const service = new OpenAITranscriptionProvider();
+    await bringSessionReady(service);
+
+    const events: VoiceTranscriptionEvent[] = [];
+    service.onEvent((e) => events.push(e));
+
+    const secondPromise = service.start(BASE_SETTINGS);
+    const idleBeforeConnect = events.filter((e) => e.type === "status" && e.status === "idle");
+    expect(idleBeforeConnect).toHaveLength(0);
+
+    await Promise.resolve();
+    const socket = latestInstance();
+    socket.simulateOpen();
+    socket.simulateMessage("session.updated");
+    await secondPromise;
+  });
+
+  it("times out and closes the socket if session.updated does not arrive within 10s", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const errors: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "error") errors.push(e.message);
+    });
+
+    const startPromise = service.start(BASE_SETTINGS);
+    await Promise.resolve();
+    const socket = latestInstance();
+    socket.simulateOpen();
+    // Never simulate session.updated.
+
+    vi.advanceTimersByTime(10_000);
+
+    await expect(startPromise).resolves.toEqual({ ok: false, error: "Connection timed out" });
+    expect(errors).toContain("Connection timed out");
+    expect(socket.closeCalls).toBe(1);
+  });
+
+  // ── Delta / complete events ──────────────────────────────────────────────
+
+  it("emits delta for incremental transcription deltas", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const deltas: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "delta") deltas.push(e.text);
+    });
+
+    const { socket } = await bringSessionReady(service);
+    socket.simulateMessage("conversation.item.input_audio_transcription.delta", {
+      delta: "Hello",
+    });
+    socket.simulateMessage("conversation.item.input_audio_transcription.delta", {
+      delta: " world",
+    });
+
+    expect(deltas).toEqual(["Hello", " world"]);
+  });
+
+  it("ignores empty deltas", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const deltas: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "delta") deltas.push(e.text);
+    });
+
+    const { socket } = await bringSessionReady(service);
+    socket.simulateMessage("conversation.item.input_audio_transcription.delta", { delta: "" });
+    socket.simulateMessage("conversation.item.input_audio_transcription.delta", {});
+
+    expect(deltas).toEqual([]);
+  });
+
+  it("emits complete with stub confidence on transcription.completed", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const events: VoiceTranscriptionEvent[] = [];
+    service.onEvent((e) => events.push(e));
+
+    const { socket } = await bringSessionReady(service);
+    socket.simulateMessage("conversation.item.input_audio_transcription.completed", {
+      transcript: "Hello world",
+    });
+
+    const complete = events.find((e) => e.type === "complete");
+    expect(complete).toEqual({
+      type: "complete",
+      text: "Hello world",
+      confidence: { minConfidence: 1.0, wordCount: 0, uncertainWords: [], words: [] },
+    });
+  });
+
+  it("does not emit complete when transcript is empty or whitespace-only", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const completes: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "complete") completes.push(e.text);
+    });
+
+    const { socket } = await bringSessionReady(service);
+    socket.simulateMessage("conversation.item.input_audio_transcription.completed", {
+      transcript: "",
+    });
+    socket.simulateMessage("conversation.item.input_audio_transcription.completed", {
+      transcript: "   ",
+    });
+    socket.simulateMessage("conversation.item.input_audio_transcription.completed", {});
+
+    expect(completes).toEqual([]);
+  });
+
+  it("emits complete from a conversation.item.done event (intent=transcription endpoint)", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const events: VoiceTranscriptionEvent[] = [];
+    service.onEvent((e) => events.push(e));
+
+    const { socket } = await bringSessionReady(service);
+    // The `?intent=transcription` endpoint reports each committed segment via
+    // conversation.item.done; the transcript lives on the input_audio part.
+    socket.simulateMessage("conversation.item.added", {
+      item: { content: [{ type: "input_audio" }] },
+    });
+    socket.simulateMessage("conversation.item.done", {
+      item: {
+        content: [{ type: "input_audio", transcript: "hello from done" }],
+      },
+    });
+
+    const complete = events.find((e) => e.type === "complete");
+    expect(complete).toEqual({
+      type: "complete",
+      text: "hello from done",
+      confidence: { minConfidence: 1.0, wordCount: 0, uncertainWords: [], words: [] },
+    });
+  });
+
+  it("ignores a conversation.item.done with no input_audio transcript", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const completes: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "complete") completes.push(e.text);
+    });
+
+    const { socket } = await bringSessionReady(service);
+    socket.simulateMessage("conversation.item.done", { item: { content: [] } });
+    socket.simulateMessage("conversation.item.done", {
+      item: { content: [{ type: "input_audio", transcript: "   " }] },
+    });
+    socket.simulateMessage("conversation.item.done", {});
+
+    expect(completes).toEqual([]);
+  });
+
+  // ── Audio chunk handling ─────────────────────────────────────────────────
+
+  it("sends audio chunks as base64 input_audio_buffer.append after session.updated", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+
+    const chunk = new Uint8Array([1, 2, 3, 4]).buffer;
+    const sentBeforeAudio = socket.sent.length;
+    service.sendAudioChunk(chunk);
+    expect(socket.sent.length).toBe(sentBeforeAudio + 1);
+    const payload = JSON.parse(socket.sent.at(-1)!) as { type: string; audio: string };
+    expect(payload.type).toBe("input_audio_buffer.append");
+    expect(payload.audio).toBe(Buffer.from(chunk).toString("base64"));
+  });
+
+  it("buffers pre-connect audio chunks and flushes them after session.updated", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const startPromise = service.start(BASE_SETTINGS);
+    await Promise.resolve();
+    const socket = latestInstance();
+
+    // Queue chunks before the WS open / session.updated round-trip.
+    service.sendAudioChunk(new Uint8Array([1]).buffer);
+    service.sendAudioChunk(new Uint8Array([2]).buffer);
+
+    expect(socket.sent).toHaveLength(0);
+
+    socket.simulateOpen();
+    // session.update sent on open, no audio yet
+    expect(socket.sent).toHaveLength(1);
+
+    socket.simulateMessage("session.updated");
+    await startPromise;
+
+    const audioPayloads = socket
+      .sentJson()
+      .filter((p) => p.type === "input_audio_buffer.append")
+      .map((p) => p.audio as string);
+    expect(audioPayloads).toEqual([
+      Buffer.from(new Uint8Array([1])).toString("base64"),
+      Buffer.from(new Uint8Array([2])).toString("base64"),
+    ]);
+  });
+
+  it("caps the pre-connect buffer at 100 chunks and warns once on overflow", async () => {
+    const service = new OpenAITranscriptionProvider();
+    void service.start(BASE_SETTINGS);
+    await Promise.resolve();
+
+    // Push 105 chunks before session.updated — last 5 should be dropped.
+    for (let i = 0; i < 105; i++) {
+      service.sendAudioChunk(new Uint8Array([i % 256]).buffer);
+    }
+    const socket = latestInstance();
+    socket.simulateOpen();
+    socket.simulateMessage("session.updated");
+
+    const audioCount = socket
+      .sentJson()
+      .filter((p) => p.type === "input_audio_buffer.append").length;
+    expect(audioCount).toBe(100);
+    service.stop();
+  });
+
+  it("drops audio chunks while draining", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+
+    // Feed enough audio that stop sends a real final commit and genuinely drains.
+    feedCommittableAudio(service);
+    const drainPromise = service.stopGracefully();
+    const sentAtStartOfDrain = socket.sent.length;
+    service.sendAudioChunk(new Uint8Array([99]).buffer);
+    expect(socket.sent.length).toBe(sentAtStartOfDrain);
+
+    socket.simulateMessage("conversation.item.done", {
+      item: { content: [{ type: "input_audio", transcript: "done" }] },
+    });
+    await drainPromise;
+  });
+
+  // ── Interval commit ──────────────────────────────────────────────────────
+  // gpt-realtime-whisper has no server VAD, so the service commits the input
+  // buffer on a timer to drive segmentation; without commits no transcription
+  // events ever arrive.
+
+  it("commits the audio buffer on the interval timer once enough audio has streamed", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+
+    feedCommittableAudio(service);
+    expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(0);
+
+    vi.advanceTimersByTime(2_000);
+    expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(1);
+
+    service.stop();
+  });
+
+  it("skips the interval commit when too little audio has streamed since the last commit", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+
+    // A tiny chunk, well under MIN_COMMIT_BYTES — committing it would draw a
+    // fatal "undersized buffer" error from OpenAI, so the timer must skip it.
+    service.sendAudioChunk(new Uint8Array(10).buffer);
+    vi.advanceTimersByTime(2_000);
+    expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(0);
+
+    service.stop();
+  });
+
+  it("commitParagraphBoundary flushes the current segment when enough audio has streamed", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+
+    feedCommittableAudio(service);
+    service.commitParagraphBoundary();
+    expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(1);
+
+    service.stop();
+  });
+
+  // ── Graceful stop / drain ────────────────────────────────────────────────
+
+  it("sends input_audio_buffer.commit on stopGracefully and waits for completed", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const statuses: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "status") statuses.push(e.status);
+    });
+
+    const { socket } = await bringSessionReady(service);
+    feedCommittableAudio(service);
+    const drainPromise = service.stopGracefully();
+    expect(statuses).toContain("finishing");
+
+    const commitPayloads = socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit");
+    expect(commitPayloads).toHaveLength(1);
+
+    socket.simulateMessage("conversation.item.done", {
+      item: { content: [{ type: "input_audio", transcript: "final" }] },
+    });
+    await drainPromise;
+    expect(statuses.at(-1)).toBe("idle");
+  });
+
+  it("drain waits for every outstanding commit's transcript, not just the first", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const completes: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "complete") completes.push(e.text);
+    });
+
+    const { socket } = await bringSessionReady(service);
+    // An interval commit goes out (segment A), then more audio accumulates and
+    // stop sends a final commit (segment B) — two transcripts now outstanding.
+    feedCommittableAudio(service);
+    vi.advanceTimersByTime(2_000);
+    feedCommittableAudio(service);
+    const drainPromise = service.stopGracefully();
+    expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(2);
+
+    let settled = false;
+    void drainPromise.then(() => {
+      settled = true;
+    });
+
+    // Segment A completes first — drain must NOT settle, B is still in flight.
+    socket.simulateMessage("conversation.item.done", {
+      item: { content: [{ type: "input_audio", transcript: "first half" }] },
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    // Segment B completes — every outstanding commit has now reported back.
+    socket.simulateMessage("conversation.item.done", {
+      item: { content: [{ type: "input_audio", transcript: "second half" }] },
+    });
+    await drainPromise;
+    expect(completes).toEqual(["first half", "second half"]);
+  });
+
+  it("drain resolves after the timeout if no completion arrives", async () => {
+    const service = new OpenAITranscriptionProvider();
+    await bringSessionReady(service);
+    feedCommittableAudio(service);
+
+    const drainPromise = service.stopGracefully();
+    vi.advanceTimersByTime(3_000);
+    await expect(drainPromise).resolves.toBeUndefined();
+  });
+
+  it("stop with a sub-threshold buffer and nothing outstanding resolves immediately", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+
+    // No audio since the last commit and no commits in flight — nothing to
+    // transcribe, so stop closes without sending a commit or arming a timer.
+    const drainPromise = service.stopGracefully();
+    await expect(drainPromise).resolves.toBeUndefined();
+    expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(0);
+  });
+
+  it("stop with a sub-threshold buffer still drains for an in-flight interval commit", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const completes: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "complete") completes.push(e.text);
+    });
+
+    const { socket } = await bringSessionReady(service);
+    // An interval commit went out; its transcript hasn't come back yet.
+    feedCommittableAudio(service);
+    vi.advanceTimersByTime(2_000);
+    expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(1);
+
+    // Stop with nothing new buffered — no final commit, but the drain must
+    // still wait for the outstanding interval commit's transcript.
+    const drainPromise = service.stopGracefully();
+    expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(1);
+
+    let settled = false;
+    void drainPromise.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    socket.simulateMessage("conversation.item.done", {
+      item: { content: [{ type: "input_audio", transcript: "tail" }] },
+    });
+    await drainPromise;
+    expect(completes).toEqual(["tail"]);
+  });
+
+  it("ignores a duplicate conversation.item.done for the same item during drain", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const completes: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "complete") completes.push(e.text);
+    });
+
+    const { socket } = await bringSessionReady(service);
+    // Two outstanding commits: an interval commit, then a final commit on stop.
+    feedCommittableAudio(service);
+    vi.advanceTimersByTime(2_000);
+    feedCommittableAudio(service);
+    const drainPromise = service.stopGracefully();
+
+    let settled = false;
+    void drainPromise.then(() => {
+      settled = true;
+    });
+
+    // Segment A completes, then a DUPLICATE of A arrives — the duplicate must
+    // not be counted again (which would settle the drain while B is still in
+    // flight) and must not re-emit A's transcript.
+    const itemADone = {
+      item: { id: "item-A", content: [{ type: "input_audio", transcript: "alpha" }] },
+    };
+    socket.simulateMessage("conversation.item.done", itemADone);
+    socket.simulateMessage("conversation.item.done", itemADone);
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    expect(completes).toEqual(["alpha"]);
+
+    // Segment B completes — now every outstanding commit has reported back.
+    socket.simulateMessage("conversation.item.done", {
+      item: { id: "item-B", content: [{ type: "input_audio", transcript: "beta" }] },
+    });
+    await drainPromise;
+    expect(completes).toEqual(["alpha", "beta"]);
+  });
+
+  it("does not let a conversation.item.done without an input_audio part settle the drain", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+
+    feedCommittableAudio(service);
+    const drainPromise = service.stopGracefully(); // one outstanding commit
+
+    let settled = false;
+    void drainPromise.then(() => {
+      settled = true;
+    });
+
+    // A `done` with no input_audio content part — not a transcription segment,
+    // so it must not be counted against the outstanding commit.
+    socket.simulateMessage("conversation.item.done", {
+      item: { id: "item-noaudio", content: [{ type: "text" }] },
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    socket.simulateMessage("conversation.item.done", {
+      item: { id: "item-real", content: [{ type: "input_audio", transcript: "real" }] },
+    });
+    await drainPromise;
+  });
+
+  it("repeated stopGracefully calls share a single in-flight drain", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+    feedCommittableAudio(service);
+
+    const first = service.stopGracefully();
+    const second = service.stopGracefully();
+
+    // Only one commit is sent, even though stop was called twice.
+    const commits = socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit");
+    expect(commits).toHaveLength(1);
+
+    socket.simulateMessage("conversation.item.done", {
+      item: { content: [{ type: "input_audio", transcript: "ok" }] },
+    });
+    await Promise.all([first, second]);
+  });
+
+  it("stopGracefully without an open connection goes straight to idle", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const statuses: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "status") statuses.push(e.status);
+    });
+
+    await service.stopGracefully();
+    expect(statuses).toEqual(["idle"]);
+  });
+
+  it("start() during an in-flight drain resolves the old drain and reaches recording", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const statuses: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "status") statuses.push(e.status);
+    });
+
+    const { socket: firstSocket } = await bringSessionReady(service);
+    feedCommittableAudio(service);
+    const drainPromise = service.stopGracefully();
+    // Don't simulate completion — drain is still in flight when start() runs.
+
+    const secondStart = service.start(BASE_SETTINGS);
+    await Promise.resolve();
+    const secondSocket = latestInstance();
+    secondSocket.simulateOpen();
+    secondSocket.simulateMessage("session.updated");
+    await secondStart;
+
+    // The first drain resolves once cleanupPreviousSession fires from start().
+    await drainPromise;
+
+    // Old commit was sent, new commit was NOT (new session has no drain).
+    const commitsOnFirst = firstSocket
+      .sentJson()
+      .filter((p) => p.type === "input_audio_buffer.commit").length;
+    const commitsOnSecond = secondSocket
+      .sentJson()
+      .filter((p) => p.type === "input_audio_buffer.commit").length;
+    expect(commitsOnFirst).toBe(1);
+    expect(commitsOnSecond).toBe(0);
+    expect(statuses.at(-1)).toBe("recording");
+  });
+
+  // ── Error handling ───────────────────────────────────────────────────────
+
+  it("emits error and error status when the WebSocket reports an error", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const events: VoiceTranscriptionEvent[] = [];
+    service.onEvent((e) => events.push(e));
+
+    const startPromise = service.start(BASE_SETTINGS);
+    await Promise.resolve();
+    const socket = latestInstance();
+    socket.simulateOpen();
+    socket.simulateError(new Error("network down"));
+
+    await expect(startPromise).resolves.toEqual({ ok: false, error: "network down" });
+    expect(events.some((e) => e.type === "error" && /network down/.test(e.message))).toBe(true);
+    expect(events.some((e) => e.type === "status" && e.status === "error")).toBe(true);
+  });
+
+  it("propagates server-side error events", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const errors: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "error") errors.push(e.message);
+    });
+
+    const { socket } = await bringSessionReady(service);
+    socket.simulateMessage("error", {
+      error: { message: "invalid_session_config", type: "invalid_request_error" },
+    });
+
+    expect(errors).toContain("invalid_session_config");
+  });
+
+  it("parses string message data as well as Buffer", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const completes: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "complete") completes.push(e.text);
+    });
+
+    const { socket } = await bringSessionReady(service);
+    // `ws` can deliver messages as strings when the server sends a text frame.
+    socket.simulateRawMessage(
+      JSON.stringify({
+        type: "conversation.item.input_audio_transcription.completed",
+        transcript: "from string",
+      })
+    );
+    expect(completes).toEqual(["from string"]);
+  });
+
+  it("ignores malformed JSON messages without throwing", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const events: VoiceTranscriptionEvent[] = [];
+    service.onEvent((e) => events.push(e));
+
+    const { socket } = await bringSessionReady(service);
+    expect(() => socket.simulateRawMessage("not json {")).not.toThrow();
+
+    // Service still functional afterward
+    socket.simulateMessage("conversation.item.input_audio_transcription.completed", {
+      transcript: "ok",
+    });
+    expect(events.some((e) => e.type === "complete")).toBe(true);
+  });
+
+  it("fails start when WebSocket construction throws", async () => {
+    throwOnConstruct = true;
+    constructError = new Error("ECONNREFUSED");
+    const service = new OpenAITranscriptionProvider();
+    const result = await service.start(BASE_SETTINGS);
+    expect(result).toEqual({ ok: false, error: "ECONNREFUSED" });
+  });
+
+  // ── Reentrancy / stale-session guard ─────────────────────────────────────
+
+  it("ignores transcript events from a stale session", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const completes: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "complete") completes.push(e.text);
+    });
+
+    const { socket: firstSocket } = await bringSessionReady(service);
+    // Start a second session; the first socket is now stale.
+    const secondPromise = service.start(BASE_SETTINGS);
+    await Promise.resolve();
+    const secondSocket = latestInstance();
+    secondSocket.simulateOpen();
+    secondSocket.simulateMessage("session.updated");
+    await secondPromise;
+
+    firstSocket.simulateMessage("conversation.item.input_audio_transcription.completed", {
+      transcript: "ghost",
+    });
+
+    expect(completes).toEqual([]);
+  });
+
+  // ── commitParagraphBoundary ──────────────────────────────────────────────
+
+  it("commitParagraphBoundary resets state and does not touch the WebSocket", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+    const sentBefore = socket.sent.length;
+
+    socket.simulateMessage("conversation.item.input_audio_transcription.delta", {
+      delta: "Hello",
+    });
+    service.commitParagraphBoundary();
+
+    expect(socket.sent.length).toBe(sentBefore);
+    expect(socket.closeCalls).toBe(0);
+  });
+
+  // ── destroy ─────────────────────────────────────────────────────────────
+
+  it("destroy closes the socket and clears listeners", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const events: VoiceTranscriptionEvent[] = [];
+    service.onEvent((e) => events.push(e));
+
+    const { socket } = await bringSessionReady(service);
+    service.destroy();
+    expect(socket.closeCalls).toBe(1);
+
+    // Listeners cleared: subsequent emits should not reach the recorded array.
+    const lengthAtDestroy = events.length;
+    // Spawn a brand-new session — the listener from before destroy should be gone.
+    const { socket: socket2 } = await bringSessionReady(service);
+    socket2.simulateMessage("conversation.item.input_audio_transcription.completed", {
+      transcript: "after destroy",
+    });
+    expect(events.length).toBe(lengthAtDestroy);
+  });
+
+  // ── Heartbeat (half-open detection) ──────────────────────────────────────
+
+  it("pings on the heartbeat interval once the connection is open", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+
+    expect(socket.pingCalls).toBe(0);
+    vi.advanceTimersByTime(20_000);
+    expect(socket.pingCalls).toBe(1);
+
+    service.stop();
+  });
+
+  it("terminates the socket when a heartbeat ping goes unanswered", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+
+    // First tick: ping sent, awaiting pong.
+    vi.advanceTimersByTime(20_000);
+    expect(socket.pingCalls).toBe(1);
+    expect(socket.terminateCalls).toBe(0);
+
+    // Second tick: no pong arrived → terminate (not graceful close).
+    vi.advanceTimersByTime(20_000);
+    expect(socket.terminateCalls).toBe(1);
+    expect(socket.closeCalls).toBe(0);
+
+    service.stop();
+  });
+
+  it("a pong keeps the connection alive across heartbeat ticks", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+
+    vi.advanceTimersByTime(20_000);
+    expect(socket.pingCalls).toBe(1);
+    socket.simulatePong();
+
+    vi.advanceTimersByTime(20_000);
+    expect(socket.pingCalls).toBe(2);
+    expect(socket.terminateCalls).toBe(0);
+
+    service.stop();
+  });
+
+  it("a stale connection's heartbeat does not terminate a newer socket", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const { socket: firstSocket } = await bringSessionReady(service);
+
+    // Replace the session — the first socket and its heartbeat are now stale.
+    const secondPromise = service.start(BASE_SETTINGS);
+    await Promise.resolve();
+    const secondSocket = latestInstance();
+    secondSocket.simulateOpen();
+    secondSocket.simulateMessage("session.updated");
+    await secondPromise;
+
+    // The first socket's heartbeat was torn down when the session was replaced;
+    // it must never terminate (its sessionId/socket-identity guard would also
+    // catch it). The second socket stays alive as long as it pongs.
+    vi.advanceTimersByTime(20_000);
+    secondSocket.simulatePong();
+    vi.advanceTimersByTime(20_000);
+    expect(firstSocket.terminateCalls).toBe(0);
+    expect(secondSocket.terminateCalls).toBe(0);
+
+    service.stop();
+  });
+
+  // ── Reconnection ─────────────────────────────────────────────────────────
+
+  it("reconnects after an unexpected drop and returns to recording", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+
+    const statuses: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "status") statuses.push(e.status);
+    });
+
+    socket.simulateClose(1006, Buffer.from("abnormal"));
+    expect(statuses).toContain("reconnecting");
+
+    // Backoff timer fires → a fresh socket is opened.
+    vi.advanceTimersByTime(3_000);
+    const socket2 = latestInstance();
+    expect(socket2).not.toBe(socket);
+
+    socket2.simulateOpen();
+    socket2.simulateMessage("session.updated");
+    expect(statuses.at(-1)).toBe("recording");
+
+    service.stop();
+  });
+
+  it("buffers audio captured during the reconnect window and flushes it after reconnect", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+
+    socket.simulateClose(1006);
+
+    // Audio keeps flowing while we're reconnecting — it must be buffered, not
+    // dropped (connection is null and there's no pending start at this point).
+    const chunk = new Uint8Array([7, 7, 7, 7]).buffer;
+    service.sendAudioChunk(chunk);
+
+    vi.advanceTimersByTime(3_000);
+    const socket2 = latestInstance();
+    socket2.simulateOpen();
+    socket2.simulateMessage("session.updated");
+
+    const audio = socket2
+      .sentJson()
+      .filter((p) => p.type === "input_audio_buffer.append")
+      .map((p) => p.audio as string);
+    expect(audio).toEqual([Buffer.from(chunk).toString("base64")]);
+
+    service.stop();
+  });
+
+  it("gives up and emits error after exhausting reconnect attempts", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+
+    const statuses: string[] = [];
+    const errors: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "status") statuses.push(e.status);
+      if (e.type === "error") errors.push(e.message);
+    });
+
+    // Initial drop schedules attempt 1.
+    socket.simulateClose(1006);
+
+    // Each cycle: fire the backoff timer (opens a socket), then drop it again
+    // before it can reach session.updated. After RECONNECT_MAX_ATTEMPTS the
+    // service gives up.
+    for (let i = 0; i < 5; i++) {
+      vi.advanceTimersByTime(3_000);
+      latestInstance().simulateClose(1006);
+    }
+
+    expect(statuses).toContain("reconnecting");
+    expect(statuses).toContain("error");
+    expect(errors.some((m) => /reconnect failed/i.test(m))).toBe(true);
+  });
+
+  it("a graceful stop during the reconnect window cancels the pending retry", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+
+    socket.simulateClose(1006);
+    const instancesBeforeStop = instances.length;
+
+    service.stop();
+
+    // The backoff timer was cleared by stop() — advancing time opens no socket.
+    vi.advanceTimersByTime(3_000);
+    expect(instances.length).toBe(instancesBeforeStop);
+  });
+
+  it("does not reconnect after a server-side fatal error and ends in error, not idle", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+    const statuses: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "status") statuses.push(e.status);
+    });
+    const instancesBefore = instances.length;
+
+    // A server error is fatal: the socket is terminated, the trailing close must
+    // not trigger a reconnect, and the final status stays "error" (not "idle").
+    socket.simulateMessage("error", {
+      error: { message: "invalid_session_config", type: "invalid_request_error" },
+    });
+    expect(socket.terminateCalls).toBe(1);
+
+    // The terminate() above already fired a close; an extra server close is a
+    // no-op for status. Simulate it to be sure idle never leaks through.
+    socket.simulateClose(1011);
+
+    vi.advanceTimersByTime(3_000);
+    expect(instances.length).toBe(instancesBefore);
+    expect(statuses).toContain("error");
+    expect(statuses).not.toContain("idle");
+  });
+
+  it("enforces the pre-connect buffer byte cap independently of the chunk cap", async () => {
+    const service = new OpenAITranscriptionProvider();
+    void service.start(BASE_SETTINGS);
+    await Promise.resolve();
+
+    // Five 40KB chunks = 200KB, over the 150KB ceiling but well under the
+    // 100-chunk cap — only the first chunks that fit under 150KB are kept.
+    for (let i = 0; i < 5; i++) {
+      service.sendAudioChunk(new Uint8Array(40_000).buffer);
+    }
+    const socket = latestInstance();
+    socket.simulateOpen();
+    socket.simulateMessage("session.updated");
+
+    const audioCount = socket
+      .sentJson()
+      .filter((p) => p.type === "input_audio_buffer.append").length;
+    // 3 × 40KB = 120KB fits; a 4th would push to 160KB > 150KB, so it's dropped.
+    expect(audioCount).toBe(3);
+    service.stop();
+  });
+
+  it("retries and gives up when the reconnect socket constructor keeps throwing", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+
+    const statuses: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "status") statuses.push(e.status);
+    });
+
+    // Every reconnect attempt's WebSocket construction fails.
+    throwOnConstruct = true;
+    constructError = new Error("ECONNREFUSED");
+    const instancesBefore = instances.length;
+
+    socket.simulateClose(1006);
+    // Drive all backoff cycles — each fires the timer, connect() throws, and
+    // reschedules until attempts are exhausted.
+    for (let i = 0; i < 6; i++) {
+      vi.advanceTimersByTime(3_000);
+    }
+
+    expect(instances.length).toBe(instancesBefore);
+    expect(statuses).toContain("error");
+  });
+});

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -195,8 +195,10 @@ export interface StoreSchema {
   voiceInput: {
     enabled: boolean;
     openaiApiKey: string;
+    deepgramApiKey: string;
     language: string;
     customDictionary: string[];
+    transcriptionProvider: string;
     transcriptionModel: string;
     correctionEnabled: boolean;
     correctionModel: string;
@@ -450,8 +452,10 @@ const storeOptions = {
     voiceInput: {
       enabled: false,
       openaiApiKey: "",
+      deepgramApiKey: "",
       language: "en",
       customDictionary: [],
+      transcriptionProvider: "openai",
       transcriptionModel: "gpt-realtime-whisper",
       correctionEnabled: false,
       correctionModel: "gpt-5-mini",

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -246,6 +246,7 @@ export type {
   VoiceInputSettings,
   VoiceInputStatus,
   VoiceTranscriptionModel,
+  VoiceTranscriptionProvider,
   VoiceCorrectionModel,
   VoiceParagraphingStrategy,
   HelpAssistantSettings,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1555,6 +1555,17 @@ export type MicPermissionStatus =
 
 export type VoiceTranscriptionModel = "gpt-realtime-whisper";
 
+/**
+ * Transcription backend. Each provider owns its own WebSocket protocol, audio
+ * framing, and turn-detection behavior:
+ *
+ * - "openai": OpenAI Realtime (`gpt-realtime-whisper`). No server VAD, so the
+ *   provider drives segmentation with a client-side commit cadence.
+ * - "deepgram": Deepgram Nova-3 streaming. Native server-side VAD / endpointing,
+ *   so no client commit timer is needed.
+ */
+export type VoiceTranscriptionProvider = "openai" | "deepgram";
+
 export type VoiceCorrectionModel = "gpt-5-nano" | "gpt-5-mini";
 
 /**
@@ -1573,8 +1584,12 @@ export type VoiceParagraphingStrategy = "spoken-command" | "manual";
 export interface VoiceInputSettings {
   enabled: boolean;
   openaiApiKey: string;
+  /** API key for the Deepgram transcription provider. Empty string when unset. */
+  deepgramApiKey: string;
   language: string;
   customDictionary: string[];
+  /** Which transcription backend to use. Defaults to "openai". */
+  transcriptionProvider: VoiceTranscriptionProvider;
   transcriptionModel: VoiceTranscriptionModel;
   correctionEnabled: boolean;
   correctionModel: VoiceCorrectionModel;

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -36,6 +36,7 @@ import type {
   MicPermissionStatus,
   VoiceCorrectionModel,
   VoiceParagraphingStrategy,
+  VoiceTranscriptionProvider,
 } from "@shared/types";
 
 const LANGUAGES = [
@@ -68,11 +69,30 @@ const CORRECTION_MODELS: {
   },
 ];
 
+const TRANSCRIPTION_PROVIDERS: {
+  value: VoiceTranscriptionProvider;
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: "openai",
+    label: "OpenAI",
+    description: "Realtime Whisper · spoken-command formatting",
+  },
+  {
+    value: "deepgram",
+    label: "Deepgram",
+    description: "Nova-3 · server-side turn detection",
+  },
+];
+
 const DEFAULT_SETTINGS: VoiceInputSettings = {
   enabled: false,
   openaiApiKey: "",
+  deepgramApiKey: "",
   language: "en",
   customDictionary: [],
+  transcriptionProvider: "openai",
   transcriptionModel: "gpt-realtime-whisper",
   correctionEnabled: false,
   correctionModel: "gpt-5-mini",
@@ -181,7 +201,7 @@ export function VoiceInputSettingsTab() {
       <SettingsSection
         icon={Mic}
         title="Speech-to-text"
-        description="Real-time transcription. Requires an OpenAI API key and microphone access."
+        description="Real-time transcription. Requires a provider API key and microphone access."
         id="voice-speech-to-text"
       >
         <SettingsSwitchCard
@@ -204,14 +224,28 @@ export function VoiceInputSettingsTab() {
               onRefresh={handleRefreshMicPermission}
             />
 
+            <SettingsSelect
+              label="Transcription provider"
+              description="The backend that turns your speech into text"
+              value={settings.transcriptionProvider}
+              onValueChange={(v) =>
+                update({ transcriptionProvider: v as VoiceTranscriptionProvider })
+              }
+              options={TRANSCRIPTION_PROVIDERS.map(({ value, label, description }) => ({
+                value,
+                label,
+                description,
+              }))}
+            />
+
             <div
               role="note"
               className="rounded-[var(--radius-md)] border border-daintree-border/60 bg-daintree-bg/40 p-3"
             >
               <p className="text-xs text-daintree-text/60 select-text">
-                Microphone audio is streamed over an encrypted connection to OpenAI for
-                transcription using your API key. Audio is not used for model training. OpenAI may
-                retain audio in abuse-monitoring logs for up to 30 days.
+                {settings.transcriptionProvider === "deepgram"
+                  ? "Microphone audio is streamed over an encrypted connection to Deepgram for transcription using your API key. Deepgram does not retain streaming audio or transcripts by default."
+                  : "Microphone audio is streamed over an encrypted connection to OpenAI for transcription using your API key. Audio is not used for model training. OpenAI may retain audio in abuse-monitoring logs for up to 30 days."}
               </p>
             </div>
 
@@ -241,28 +275,50 @@ export function VoiceInputSettingsTab() {
               </button>
             </div>
 
-            <ApiKeyRow
-              label="OpenAI API Key"
-              value={settings.openaiApiKey}
-              placeholder="sk-..."
-              onSave={(key) => update({ openaiApiKey: key })}
-              onValidate={(key) => window.electron?.voiceInput?.validateApiKey(key)}
-              helpUrl="https://platform.openai.com/api-keys"
-              helpLabel="Get API key"
-            />
+            {settings.transcriptionProvider === "deepgram" ? (
+              <>
+                <ApiKeyRow
+                  label="Deepgram API Key"
+                  value={settings.deepgramApiKey}
+                  placeholder="Deepgram API key"
+                  onSave={(key) => update({ deepgramApiKey: key })}
+                  helpUrl="https://console.deepgram.com/"
+                  helpLabel="Get API key"
+                />
 
-            {(!settings.openaiApiKey || !settings.openaiApiKey.startsWith("sk-proj-")) && (
-              <p className="text-xs text-daintree-text/50">
-                Use a Project API key (starts with <code className="font-mono">sk-proj-</code>) for
-                the best security
-              </p>
-            )}
+                {settings.deepgramApiKey && (
+                  <p className="text-xs text-daintree-text/50 mt-1">
+                    Your API key is stored locally in plain text. Set usage limits on your Deepgram
+                    account to cap exposure.
+                  </p>
+                )}
+              </>
+            ) : (
+              <>
+                <ApiKeyRow
+                  label="OpenAI API Key"
+                  value={settings.openaiApiKey}
+                  placeholder="sk-..."
+                  onSave={(key) => update({ openaiApiKey: key })}
+                  onValidate={(key) => window.electron?.voiceInput?.validateApiKey(key)}
+                  helpUrl="https://platform.openai.com/api-keys"
+                  helpLabel="Get API key"
+                />
 
-            {settings.openaiApiKey && (
-              <p className="text-xs text-daintree-text/50 mt-1">
-                Your API key is stored locally in plain text. Set billing limits on your OpenAI
-                account to cap exposure.
-              </p>
+                {(!settings.openaiApiKey || !settings.openaiApiKey.startsWith("sk-proj-")) && (
+                  <p className="text-xs text-daintree-text/50">
+                    Use a Project API key (starts with <code className="font-mono">sk-proj-</code>)
+                    for the best security
+                  </p>
+                )}
+
+                {settings.openaiApiKey && (
+                  <p className="text-xs text-daintree-text/50 mt-1">
+                    Your API key is stored locally in plain text. Set billing limits on your OpenAI
+                    account to cap exposure.
+                  </p>
+                )}
+              </>
             )}
 
             {settings.openaiApiKey && <AdvancedSection settings={settings} update={update} />}
@@ -363,7 +419,11 @@ interface ApiKeyRowProps {
   value: string;
   placeholder: string;
   onSave: (key: string) => void;
-  onValidate: (key: string) => Promise<{ valid: boolean; error?: string } | undefined> | undefined;
+  /**
+   * Remote key validation. When omitted (e.g. providers without a validation
+   * endpoint), the key is saved without a remote check.
+   */
+  onValidate?: (key: string) => Promise<{ valid: boolean; error?: string } | undefined> | undefined;
   helpUrl: string;
   helpLabel: string;
 }
@@ -394,6 +454,13 @@ function ApiKeyRow({
   const handleSave = async () => {
     const key = keyInput.trim();
     if (!key) return;
+    // Providers without a validation endpoint save the key directly.
+    if (!onValidate) {
+      onSave(key);
+      setKeyInput("");
+      setValidation("valid");
+      return;
+    }
     setValidation("testing");
     setValidationError(null);
     try {

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -228,9 +228,11 @@ export function VoiceInputSettingsTab() {
               label="Transcription provider"
               description="The backend that turns your speech into text"
               value={settings.transcriptionProvider}
-              onValueChange={(v) =>
-                update({ transcriptionProvider: v as VoiceTranscriptionProvider })
-              }
+              onValueChange={(v) => {
+                // Narrow the select's string value to the union via a guard
+                // rather than an unsafe assertion.
+                if (v === "openai" || v === "deepgram") update({ transcriptionProvider: v });
+              }}
               options={TRANSCRIPTION_PROVIDERS.map(({ value, label, description }) => ({
                 value,
                 label,

--- a/src/services/VoiceRecordingService.ts
+++ b/src/services/VoiceRecordingService.ts
@@ -290,11 +290,18 @@ class VoiceRecordingService {
 
   async refreshConfiguration(): Promise<boolean> {
     const settings = await window.electron.voiceInput.getSettings();
-    const isConfigured = settings.enabled && !!settings.openaiApiKey;
+    // "Configured" means the selected provider has its own API key — Deepgram
+    // uses deepgramApiKey, every other provider uses openaiApiKey.
+    const hasProviderKey =
+      settings.transcriptionProvider === "deepgram"
+        ? !!settings.deepgramApiKey
+        : !!settings.openaiApiKey;
+    const isConfigured = settings.enabled && hasProviderKey;
     this.selectedDeviceId = settings.deviceId ?? "";
     logDebug(`${LOG_PREFIX} refreshConfiguration`, {
       enabled: settings.enabled,
-      hasApiKey: !!settings.openaiApiKey,
+      provider: settings.transcriptionProvider,
+      hasProviderKey,
       isConfigured,
       correctionEnabled: settings.correctionEnabled,
     });

--- a/src/services/__tests__/VoiceRecordingService.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.test.ts
@@ -856,3 +856,61 @@ describe("VoiceRecordingService — interim delta handling (#9172)", () => {
     voiceModule.__state.panelBuffers = {};
   });
 });
+
+describe("VoiceRecordingService — provider configuration gating", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    suspendCallbacks.length = 0;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("treats a Deepgram-only user (no OpenAI key) as configured", async () => {
+    const electron = buildElectronStub();
+    electron.voiceInput.getSettings.mockResolvedValue({
+      enabled: true,
+      openaiApiKey: "",
+      deepgramApiKey: "dg-test",
+      transcriptionProvider: "deepgram",
+      correctionEnabled: false,
+    });
+    setupGlobals(electron);
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    await expect(voiceRecordingService.refreshConfiguration()).resolves.toBe(true);
+  });
+
+  it("treats a Deepgram user without a Deepgram key as not configured", async () => {
+    const electron = buildElectronStub();
+    electron.voiceInput.getSettings.mockResolvedValue({
+      enabled: true,
+      // An OpenAI key must NOT satisfy the Deepgram provider.
+      openaiApiKey: "sk-key",
+      deepgramApiKey: "",
+      transcriptionProvider: "deepgram",
+      correctionEnabled: false,
+    });
+    setupGlobals(electron);
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    await expect(voiceRecordingService.refreshConfiguration()).resolves.toBe(false);
+  });
+
+  it("treats an OpenAI user with an OpenAI key as configured", async () => {
+    const electron = buildElectronStub();
+    electron.voiceInput.getSettings.mockResolvedValue({
+      enabled: true,
+      openaiApiKey: "sk-key",
+      deepgramApiKey: "",
+      transcriptionProvider: "openai",
+      correctionEnabled: false,
+    });
+    setupGlobals(electron);
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    await expect(voiceRecordingService.refreshConfiguration()).resolves.toBe(true);
+  });
+});


### PR DESCRIPTION
`VoiceTranscriptionService` was a monolith with OpenAI baked in — no way to swap providers, and the settings migration was silently resetting the chosen provider on every read. This PR fixes that.

## What changed

Extracted a `TranscriptionProvider` interface and made `VoiceTranscriptionService` a thin coordinator: it reads `settings.transcriptionProvider`, instantiates the right backend, forwards events, and tears down the previous provider on each new session.

Two backends ship:

- **`OpenAITranscriptionProvider`** — existing behavior preserved; client-side VAD, 2s commit cadence, `hasServerVAD: false`.
- **`DeepgramTranscriptionProvider`** — Nova-3 model, server-side VAD/endpointing, raw binary frames at 24kHz linear16, `KeepAlive` + `CloseStream` drain, `hasServerVAD: true` (no commit timer needed).

Settings changes:

- Added `transcriptionProvider` and `deepgramApiKey` to `VoiceInputSettings` (shared type, store schema/defaults, preload bridge).
- Provider selector + Deepgram key field in the voice settings tab; `DEEPGRAM_API_KEY` env override also works.
- Fixed the migration so it no longer resets the provider on every read — unknown values default to `"openai"`, Deepgram key is preserved.
- `VoiceRecordingService.isConfigured` is now provider-aware, so a Deepgram-only user (no OpenAI key) can dictate.

## Technical notes

- Deepgram emits `complete` only on finalized (`is_final`) results — interim hypotheses are revised in place and would corrupt the renderer's append buffer; finals arrive within ~300ms of an endpoint.
- 24kHz linear16 matches the renderer's existing `AudioContext` capture rate, so no resampling is needed.
- Auto-reconnect is not implemented in this first cut — an unexpected drop surfaces as an error. OpenAI's reconnect/heartbeat logic is unchanged.

## Test plan

- [ ] `npm run check` passes (typecheck + lint + format)
- [ ] Unit suites pass: `OpenAITranscriptionProvider`, `DeepgramTranscriptionProvider`, coordinator, `voiceInput` migration, `VoiceRecordingService` provider-gating
- [ ] Manual: select Deepgram in settings, enter a key, dictate into a terminal — transcripts appear and stop drains cleanly
- [ ] Manual: OpenAI path unchanged

Closes #9175.