### PR TITLE
fix(ci): demote online E2E from per-OS release gate

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -103,7 +103,7 @@ jobs:
     secrets: inherit
 
   build-daintree:
-    needs: [checks, unit-tests, e2e-core-gate, e2e-full-gate, e2e-online-gate]
+    needs: [checks, unit-tests, e2e-core-gate, e2e-full-gate]
     name: Build Daintree (Linux)
     runs-on: ubuntu-22.04
     timeout-minutes: 90

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -95,6 +95,7 @@ jobs:
       platform: linux
 
   e2e-online-gate:
+    continue-on-error: true
     needs: [checks, unit-tests]
     uses: ./.github/workflows/e2e.yml
     with:

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -106,6 +106,7 @@ jobs:
       platform: macos
 
   e2e-online-gate:
+    continue-on-error: true
     needs: [checks, unit-tests]
     uses: ./.github/workflows/e2e.yml
     with:

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -114,7 +114,7 @@ jobs:
     secrets: inherit
 
   build-daintree:
-    needs: [checks, unit-tests, e2e-core-gate, e2e-full-gate, e2e-online-gate]
+    needs: [checks, unit-tests, e2e-core-gate, e2e-full-gate]
     name: Build Daintree (macOS)
     runs-on: macos-14
     timeout-minutes: 90

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -108,7 +108,7 @@ jobs:
     secrets: inherit
 
   build-daintree:
-    needs: [checks, unit-tests, e2e-core-gate, e2e-full-gate, e2e-online-gate]
+    needs: [checks, unit-tests, e2e-core-gate, e2e-full-gate]
     name: Build Daintree (Windows)
     runs-on: windows-latest
     timeout-minutes: 90

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -100,6 +100,7 @@ jobs:
       platform: windows
 
   e2e-online-gate:
+    continue-on-error: true
     needs: [checks, unit-tests]
     uses: ./.github/workflows/e2e.yml
     with:

--- a/e2e/helpers/claudeAuth.ts
+++ b/e2e/helpers/claudeAuth.ts
@@ -15,6 +15,7 @@ export async function configureClaudeAuthEnv(page: Page): Promise<void> {
     await window.electron.globalEnv.set({
       ...currentGlobalEnv,
       ANTHROPIC_API_KEY: anthropicApiKey,
+      ANTHROPIC_MODEL: "claude-haiku-4-5-20251001",
       // CLAUDE_CODE_SIMPLE=1 is the env-var equivalent of `claude --bare`:
       // it skips marketplace OAuth, plugin sync, auto-memory, CLAUDE.md
       // discovery, and keychain reads. Anthropic auth becomes strictly
@@ -31,6 +32,7 @@ export async function configureClaudeAuthEnv(page: Page): Promise<void> {
       globalEnv: {
         ...currentEnv,
         ANTHROPIC_API_KEY: anthropicApiKey,
+        ANTHROPIC_MODEL: "claude-haiku-4-5-20251001",
         CLAUDE_CODE_SIMPLE: "1",
       },
     });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -84,7 +84,7 @@ export default defineConfig({
       name: "online",
       testDir: "./e2e/online",
       timeout: onlineTimeout,
-      retries: isCI ? 2 : 0,
+      retries: isCI ? 1 : 0,
     },
     {
       name: "nightly",


### PR DESCRIPTION
## Summary

The online E2E suite currently gates releases on all three OSes. Anthropic API flake blocks publishes the same way a real regression would, and the retries burn API credits in the process. This demotes the suite to observation-only so we can collect data without it holding up releases.

Resolves #9127.

## Changes

- **Added `continue-on-error: true`** to the `e2e-online-gate` step in `release-linux.yml`, `release-macos.yml`, and `release-windows.yml`. The tests still run and report, but failures won't block publish.
- **Reduced Playwright retries from 2 to 1** for the `online` project in `playwright.config.ts`. Fewer retries during systemic outages saves credits without meaningfully reducing signal.
- **Switched the CI test model to a cheaper Haiku variant** by setting `ANTHROPIC_MODEL` in `e2e/helpers/claudeAuth.ts`. The `full/presets` suite already proves the CLI honors this env var.

## Plan

Run this for a release cycle or two and capture how often `online` would have blocked publish. That data determines whether the next investment is cassette replay (the CLI honors `ANTHROPIC_BASE_URL`, so it's feasible) or a post-publish canary — both deferred follow-ups.