### PR TITLE
feat(ci): post-upload CDN edge verification for release metadata

### DIFF
--- a/.github/actions/publish-daintree/action.yml
+++ b/.github/actions/publish-daintree/action.yml
@@ -117,6 +117,13 @@ runs:
           --include "${UPDATE_METADATA_PREFIX}${{ inputs.metadata_suffix }}.yml" \
           --cache-control "no-cache, no-store, must-revalidate"
 
+    - name: Verify update metadata at CDN edge
+      shell: bash
+      env:
+        PUBLISH_URL: ${{ inputs.publish_url }}
+        METADATA_SUFFIX: ${{ inputs.metadata_suffix }}
+      run: node scripts/ci/verify-r2-metadata.mjs
+
     - name: Notify website of new release
       uses: ./.github/actions/website-notify
       with:

--- a/scripts/ci/verify-r2-metadata.mjs
+++ b/scripts/ci/verify-r2-metadata.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+// Verifies that the update metadata YAML just uploaded to R2 is reachable at
+// the public CDN edge URL and its content matches the local copy. Without this
+// post-upload gate, a Cloudflare CDN edge node could serve a cached 404 for
+// the metadata YAML even after the R2 PUT succeeds — see #9122.
+//
+// GETs the public metadata URL with exponential-backoff retry (5s / 10s / 20s),
+// parses the remote YAML, and compares version, path, sha512, and files[]
+// entries against the local copy. A mismatch or persistent 404 fails the
+// publish so the release is not advertised to clients until the CDN is
+// consistent.
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { setTimeout as defaultSleep } from "node:timers/promises";
+import { load } from "js-yaml";
+import { buildPublishedUrl } from "./verify-r2-uploads.mjs";
+
+const VALID_SUFFIXES = new Set(["-mac", "-linux", ""]);
+
+export function metadataFilename(prefix, suffix) {
+  return `${prefix}${suffix}.yml`;
+}
+
+export function validateMetadataSuffix(suffix) {
+  if (!VALID_SUFFIXES.has(suffix)) {
+    const list = [...VALID_SUFFIXES].map((s) => (s === "" ? '""' : `"${s}"`)).join(", ");
+    return {
+      ok: false,
+      error: `Invalid METADATA_SUFFIX "${suffix}". Expected one of: ${list}.`,
+    };
+  }
+  return { ok: true };
+}
+
+export function loadLocalMetadata(releaseDir, filename) {
+  const filePath = path.join(releaseDir, filename);
+  let raw;
+  try {
+    raw = readFileSync(filePath, "utf8");
+  } catch (err) {
+    throw new Error(`failed to read local metadata ${filePath}: ${err?.message ?? err}`);
+  }
+  let parsed;
+  try {
+    parsed = load(raw);
+  } catch (err) {
+    throw new Error(`failed to parse local metadata ${filePath}: ${err?.message ?? err}`);
+  }
+  if (parsed === null || typeof parsed !== "object") {
+    throw new Error(`${filePath}: expected a YAML mapping`);
+  }
+  if (typeof parsed.version !== "string") {
+    throw new Error(`${filePath}: missing or non-string 'version' field`);
+  }
+  if (typeof parsed.path !== "string") {
+    throw new Error(`${filePath}: missing or non-string 'path' field`);
+  }
+  if (typeof parsed.sha512 !== "string") {
+    throw new Error(`${filePath}: missing or non-string 'sha512' field`);
+  }
+  if (!Array.isArray(parsed.files) || parsed.files.length === 0) {
+    throw new Error(`${filePath}: 'files' is missing or empty`);
+  }
+  return parsed;
+}
+
+export async function fetchRemoteMetadata(url, fetchImpl = fetch) {
+  let response;
+  try {
+    response = await fetchImpl(url);
+  } catch (err) {
+    throw new Error(`network error fetching ${url}: ${err?.message ?? err}`);
+  }
+  if (response.status !== 200) {
+    throw new Error(`expected HTTP 200 for ${url}, got ${response.status}`);
+  }
+  let body;
+  try {
+    body = await response.text();
+  } catch (err) {
+    throw new Error(`failed to read body from ${url}: ${err?.message ?? err}`);
+  }
+  let parsed;
+  try {
+    parsed = load(body);
+  } catch (err) {
+    throw new Error(`failed to parse YAML from ${url}: ${err?.message ?? err}`);
+  }
+  if (parsed === null || typeof parsed !== "object") {
+    throw new Error(`${url}: expected a YAML mapping`);
+  }
+  return parsed;
+}
+
+export function compareMetadata(local, remote) {
+  if (local.version !== remote.version) {
+    return `version mismatch: local=${local.version}, remote=${remote.version}`;
+  }
+  if (local.path !== remote.path) {
+    return `path mismatch: local=${local.path}, remote=${remote.path}`;
+  }
+  if (local.sha512 !== remote.sha512) {
+    return `sha512 mismatch for primary artifact (path=${local.path})`;
+  }
+  if (!Array.isArray(remote.files)) {
+    return `remote files[] is not an array`;
+  }
+  if (local.files.length !== remote.files.length) {
+    return `files[] length mismatch: local=${local.files.length}, remote=${remote.files.length}`;
+  }
+  for (let i = 0; i < local.files.length; i++) {
+    const localFile = local.files[i];
+    const remoteFile = remote.files[i];
+    if (localFile.url !== remoteFile.url) {
+      return `files[${i}].url mismatch: local=${localFile.url}, remote=${remoteFile.url}`;
+    }
+    if (localFile.sha512 !== remoteFile.sha512) {
+      return `files[${i}].sha512 mismatch for ${localFile.url}`;
+    }
+  }
+  if (local.releaseDate !== remote.releaseDate) {
+    console.warn(
+      `[verify-metadata] releaseDate differs (info only): local=${local.releaseDate}, remote=${remote.releaseDate}`
+    );
+  }
+  return null;
+}
+
+export async function verifyMetadataOnce(filename, publishUrl, releaseDir, fetchImpl = fetch) {
+  let local;
+  try {
+    local = loadLocalMetadata(releaseDir, filename);
+  } catch (err) {
+    return { ok: false, error: err.message };
+  }
+  const url = buildPublishedUrl(publishUrl, filename);
+  let remote;
+  try {
+    remote = await fetchRemoteMetadata(url, fetchImpl);
+  } catch (err) {
+    return { ok: false, error: err.message };
+  }
+  const cmpErr = compareMetadata(local, remote);
+  if (cmpErr) {
+    return { ok: false, error: `content mismatch for ${url}: ${cmpErr}` };
+  }
+  return { ok: true };
+}
+
+export async function verifyMetadataWithRetries({
+  filename,
+  publishUrl,
+  releaseDir,
+  fetch: fetchFn = fetch,
+  sleep: sleepFn = defaultSleep,
+  maxAttempts = 3,
+  baseDelayMs = 5000,
+  log = console.log,
+}) {
+  let lastError = null;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const result = await verifyMetadataOnce(filename, publishUrl, releaseDir, fetchFn);
+    if (result.ok) {
+      log(
+        `[verify-metadata] ${buildPublishedUrl(publishUrl, filename)} verified (attempt ${attempt})`
+      );
+      return null;
+    }
+    lastError = result.error;
+    if (attempt < maxAttempts) {
+      const delay = baseDelayMs * Math.pow(2, attempt - 1);
+      log(
+        `[verify-metadata] attempt ${attempt}/${maxAttempts} failed: ${result.error} — retrying in ${delay}ms`
+      );
+      await sleepFn(delay);
+    }
+  }
+  return lastError;
+}
+
+async function main() {
+  const publishUrl = process.env.PUBLISH_URL;
+  const releaseDir = process.env.RELEASE_DIR ?? "release";
+  const prefix = process.env.UPDATE_METADATA_PREFIX;
+  const suffix = process.env.METADATA_SUFFIX ?? "";
+
+  if (!publishUrl) {
+    console.error("::error::PUBLISH_URL env var is required");
+    process.exit(1);
+  }
+  if (!prefix) {
+    console.error("::error::UPDATE_METADATA_PREFIX env var is required");
+    process.exit(1);
+  }
+
+  const suffixCheck = validateMetadataSuffix(suffix);
+  if (!suffixCheck.ok) {
+    console.error(`::error::${suffixCheck.error}`);
+    process.exit(1);
+  }
+
+  const filename = metadataFilename(prefix, suffix);
+
+  console.log(`[verify-metadata] checking ${buildPublishedUrl(publishUrl, filename)}`);
+
+  const error = await verifyMetadataWithRetries({
+    filename,
+    publishUrl,
+    releaseDir,
+  });
+
+  if (error) {
+    console.error(`::error file=${filename}::${error}`);
+    console.error(`[verify-metadata] metadata verification failed after retries`);
+    process.exit(1);
+  }
+
+  console.log(`[verify-metadata] metadata verified reachable and correct`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/scripts/ci/verify-r2-metadata.mjs
+++ b/scripts/ci/verify-r2-metadata.mjs
@@ -18,6 +18,7 @@ import { load } from "js-yaml";
 import { buildPublishedUrl } from "./verify-r2-uploads.mjs";
 
 const VALID_SUFFIXES = new Set(["-mac", "-linux", ""]);
+const FETCH_TIMEOUT_MS = 15_000;
 
 export function metadataFilename(prefix, suffix) {
   return `${prefix}${suffix}.yml`;
@@ -66,32 +67,45 @@ export function loadLocalMetadata(releaseDir, filename) {
   return parsed;
 }
 
-export async function fetchRemoteMetadata(url, fetchImpl = fetch) {
-  let response;
+export async function fetchRemoteMetadata(url, fetchImpl = fetch, timeoutMs = FETCH_TIMEOUT_MS) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    response = await fetchImpl(url);
-  } catch (err) {
-    throw new Error(`network error fetching ${url}: ${err?.message ?? err}`);
+    let response;
+    try {
+      response = await fetchImpl(url, { signal: controller.signal });
+    } catch (err) {
+      const cause = err instanceof Error ? err.message : String(err);
+      const error = new Error(`network error fetching ${url}: ${cause}`);
+      error.transient = true;
+      throw error;
+    }
+    if (response.status !== 200) {
+      const error = new Error(`expected HTTP 200 for ${url}, got ${response.status}`);
+      error.transient = true;
+      throw error;
+    }
+    let body;
+    try {
+      body = await response.text();
+    } catch (err) {
+      const cause = err instanceof Error ? err.message : String(err);
+      throw new Error(`failed to read body from ${url}: ${cause}`);
+    }
+    let parsed;
+    try {
+      parsed = load(body);
+    } catch (err) {
+      const cause = err instanceof Error ? err.message : String(err);
+      throw new Error(`failed to parse YAML from ${url}: ${cause}`);
+    }
+    if (parsed === null || typeof parsed !== "object") {
+      throw new Error(`${url}: expected a YAML mapping`);
+    }
+    return parsed;
+  } finally {
+    clearTimeout(timer);
   }
-  if (response.status !== 200) {
-    throw new Error(`expected HTTP 200 for ${url}, got ${response.status}`);
-  }
-  let body;
-  try {
-    body = await response.text();
-  } catch (err) {
-    throw new Error(`failed to read body from ${url}: ${err?.message ?? err}`);
-  }
-  let parsed;
-  try {
-    parsed = load(body);
-  } catch (err) {
-    throw new Error(`failed to parse YAML from ${url}: ${err?.message ?? err}`);
-  }
-  if (parsed === null || typeof parsed !== "object") {
-    throw new Error(`${url}: expected a YAML mapping`);
-  }
-  return parsed;
 }
 
 export function compareMetadata(local, remote) {
@@ -113,6 +127,9 @@ export function compareMetadata(local, remote) {
   for (let i = 0; i < local.files.length; i++) {
     const localFile = local.files[i];
     const remoteFile = remote.files[i];
+    if (remoteFile === null || typeof remoteFile !== "object") {
+      return `files[${i}]: remote entry is not an object`;
+    }
     if (localFile.url !== remoteFile.url) {
       return `files[${i}].url mismatch: local=${localFile.url}, remote=${remoteFile.url}`;
     }
@@ -120,9 +137,13 @@ export function compareMetadata(local, remote) {
       return `files[${i}].sha512 mismatch for ${localFile.url}`;
     }
   }
-  if (local.releaseDate !== remote.releaseDate) {
+  const localDate =
+    typeof local.releaseDate === "string" ? local.releaseDate : String(local.releaseDate);
+  const remoteDate =
+    typeof remote.releaseDate === "string" ? remote.releaseDate : String(remote.releaseDate);
+  if (localDate !== remoteDate) {
     console.warn(
-      `[verify-metadata] releaseDate differs (info only): local=${local.releaseDate}, remote=${remote.releaseDate}`
+      `[verify-metadata] releaseDate differs (info only): local=${localDate}, remote=${remoteDate}`
     );
   }
   return null;
@@ -133,18 +154,18 @@ export async function verifyMetadataOnce(filename, publishUrl, releaseDir, fetch
   try {
     local = loadLocalMetadata(releaseDir, filename);
   } catch (err) {
-    return { ok: false, error: err.message };
+    return { ok: false, error: err.message, transient: false };
   }
   const url = buildPublishedUrl(publishUrl, filename);
   let remote;
   try {
     remote = await fetchRemoteMetadata(url, fetchImpl);
   } catch (err) {
-    return { ok: false, error: err.message };
+    return { ok: false, error: err.message, transient: err.transient === true };
   }
   const cmpErr = compareMetadata(local, remote);
   if (cmpErr) {
-    return { ok: false, error: `content mismatch for ${url}: ${cmpErr}` };
+    return { ok: false, error: `content mismatch for ${url}: ${cmpErr}`, transient: false };
   }
   return { ok: true };
 }
@@ -159,6 +180,9 @@ export async function verifyMetadataWithRetries({
   baseDelayMs = 5000,
   log = console.log,
 }) {
+  if (!Number.isFinite(maxAttempts) || maxAttempts < 1) {
+    return `maxAttempts must be >= 1, got ${maxAttempts}`;
+  }
   let lastError = null;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     const result = await verifyMetadataOnce(filename, publishUrl, releaseDir, fetchFn);
@@ -169,13 +193,17 @@ export async function verifyMetadataWithRetries({
       return null;
     }
     lastError = result.error;
-    if (attempt < maxAttempts) {
-      const delay = baseDelayMs * Math.pow(2, attempt - 1);
-      log(
-        `[verify-metadata] attempt ${attempt}/${maxAttempts} failed: ${result.error} — retrying in ${delay}ms`
-      );
-      await sleepFn(delay);
+    if (!result.transient || attempt >= maxAttempts) {
+      if (!result.transient) {
+        log(`[verify-metadata] permanent error, not retrying: ${result.error}`);
+      }
+      break;
     }
+    const delay = baseDelayMs * Math.pow(2, attempt - 1);
+    log(
+      `[verify-metadata] attempt ${attempt}/${maxAttempts} failed: ${result.error} — retrying in ${delay}ms`
+    );
+    await sleepFn(delay);
   }
   return lastError;
 }

--- a/scripts/ci/verify-r2-metadata.test.mjs
+++ b/scripts/ci/verify-r2-metadata.test.mjs
@@ -1,0 +1,444 @@
+import { describe, it, expect, vi } from "vitest";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+import {
+  metadataFilename,
+  validateMetadataSuffix,
+  loadLocalMetadata,
+  fetchRemoteMetadata,
+  compareMetadata,
+  verifyMetadataOnce,
+  verifyMetadataWithRetries,
+} from "./verify-r2-metadata.mjs";
+
+function makeResponse({ status = 200, body = "version: 1.0.0\n" }) {
+  return {
+    status,
+    text: () => Promise.resolve(body),
+  };
+}
+
+describe("metadataFilename", () => {
+  it("constructs Mac filename", () => {
+    expect(metadataFilename("latest", "-mac")).toBe("latest-mac.yml");
+  });
+
+  it("constructs Linux filename", () => {
+    expect(metadataFilename("rc", "-linux")).toBe("rc-linux.yml");
+  });
+
+  it("constructs Windows filename (empty suffix)", () => {
+    expect(metadataFilename("beta", "")).toBe("beta.yml");
+  });
+});
+
+describe("validateMetadataSuffix", () => {
+  it("accepts -mac", () => {
+    expect(validateMetadataSuffix("-mac").ok).toBe(true);
+  });
+
+  it("accepts -linux", () => {
+    expect(validateMetadataSuffix("-linux").ok).toBe(true);
+  });
+
+  it("accepts empty string (Windows)", () => {
+    expect(validateMetadataSuffix("").ok).toBe(true);
+  });
+
+  it("rejects unknown suffix", () => {
+    const result = validateMetadataSuffix("-win");
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("-win");
+  });
+
+  it("rejects bare platform without dash", () => {
+    const result = validateMetadataSuffix("mac");
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("loadLocalMetadata", () => {
+  it("reads and parses a valid metadata YAML file", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "verify-r2-metadata-test-"));
+    try {
+      const yml = path.join(dir, "latest-mac.yml");
+      const content =
+        "version: 1.0.0\nfiles:\n  - url: mac.zip\n    sha512: aaa\n    size: 100\npath: mac.zip\nsha512: aaa\nreleaseDate: 2024-01-01\n";
+      await writeFile(yml, content);
+      const result = loadLocalMetadata(dir, "latest-mac.yml");
+      expect(result.version).toBe("1.0.0");
+      expect(result.path).toBe("mac.zip");
+      expect(result.sha512).toBe("aaa");
+      expect(result.files).toHaveLength(1);
+      expect(result.files[0].url).toBe("mac.zip");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws when file does not exist", () => {
+    expect(() => loadLocalMetadata("/nonexistent", "latest-mac.yml")).toThrow(
+      /failed to read local metadata/
+    );
+  });
+
+  it("throws on malformed YAML", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "verify-r2-metadata-test-"));
+    try {
+      const yml = path.join(dir, "latest-mac.yml");
+      await writeFile(yml, "version: 1.0.0\nfiles:\n  - url: foo\n    size: [unclosed\n");
+      expect(() => loadLocalMetadata(dir, "latest-mac.yml")).toThrow(/failed to parse/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws when version field is missing", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "verify-r2-metadata-test-"));
+    try {
+      const yml = path.join(dir, "latest-mac.yml");
+      await writeFile(yml, "files: []\npath: x\nsha512: aaa\n");
+      expect(() => loadLocalMetadata(dir, "latest-mac.yml")).toThrow(/version/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws when files[] is empty", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "verify-r2-metadata-test-"));
+    try {
+      const yml = path.join(dir, "latest-mac.yml");
+      await writeFile(yml, "version: 1.0.0\nfiles: []\npath: x\nsha512: aaa\n");
+      expect(() => loadLocalMetadata(dir, "latest-mac.yml")).toThrow(/files.*empty/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("fetchRemoteMetadata", () => {
+  it("returns parsed YAML on 200", async () => {
+    const body =
+      "version: 1.0.0\nfiles:\n  - url: mac.zip\n    sha512: aaa\n    size: 100\npath: mac.zip\nsha512: aaa\nreleaseDate: 2024-01-01\n";
+    const fetchFn = vi.fn().mockResolvedValue(makeResponse({ status: 200, body }));
+    const result = await fetchRemoteMetadata(
+      "https://updates.daintree.org/releases/latest-mac.yml",
+      fetchFn
+    );
+    expect(result.version).toBe("1.0.0");
+    expect(result.files).toHaveLength(1);
+  });
+
+  it("throws on 404", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(makeResponse({ status: 404 }));
+    await expect(
+      fetchRemoteMetadata("https://updates.daintree.org/releases/latest-mac.yml", fetchFn)
+    ).rejects.toThrow(/HTTP 200.*got 404/);
+  });
+
+  it("throws on 500", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(makeResponse({ status: 500 }));
+    await expect(
+      fetchRemoteMetadata("https://updates.daintree.org/releases/latest-mac.yml", fetchFn)
+    ).rejects.toThrow(/500/);
+  });
+
+  it("throws on malformed YAML in body", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(makeResponse({ status: 200, body: "\tbad: tab indentation is illegal" }));
+    await expect(
+      fetchRemoteMetadata("https://updates.daintree.org/releases/latest-mac.yml", fetchFn)
+    ).rejects.toThrow(/failed to parse YAML/);
+  });
+
+  it("throws on network error", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error("DNS lookup failed"));
+    await expect(
+      fetchRemoteMetadata("https://updates.daintree.org/releases/latest-mac.yml", fetchFn)
+    ).rejects.toThrow(/network error/);
+  });
+});
+
+describe("compareMetadata", () => {
+  const baseLocal = {
+    version: "1.0.0",
+    path: "mac.zip",
+    sha512: "aaa",
+    files: [
+      { url: "mac.zip", sha512: "aaa", size: 100 },
+      { url: "mac-arm64.zip", sha512: "bbb", size: 200 },
+    ],
+    releaseDate: "2024-01-01T00:00:00.000Z",
+  };
+
+  it("returns null on full match", () => {
+    const remote = structuredClone(baseLocal);
+    expect(compareMetadata(baseLocal, remote)).toBeNull();
+  });
+
+  it("returns null on match with different releaseDate (warn only)", () => {
+    const remote = structuredClone(baseLocal);
+    remote.releaseDate = "2025-01-01T00:00:00.000Z";
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(compareMetadata(baseLocal, remote)).toBeNull();
+      expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining("releaseDate differs"));
+    } finally {
+      consoleWarn.mockRestore();
+    }
+  });
+
+  it("detects version mismatch", () => {
+    const remote = structuredClone(baseLocal);
+    remote.version = "2.0.0";
+    expect(compareMetadata(baseLocal, remote)).toContain("version mismatch");
+  });
+
+  it("detects path mismatch", () => {
+    const remote = structuredClone(baseLocal);
+    remote.path = "other.zip";
+    expect(compareMetadata(baseLocal, remote)).toContain("path mismatch");
+  });
+
+  it("detects sha512 mismatch", () => {
+    const remote = structuredClone(baseLocal);
+    remote.sha512 = "xxx";
+    expect(compareMetadata(baseLocal, remote)).toContain("sha512 mismatch");
+  });
+
+  it("detects files[] length mismatch", () => {
+    const remote = structuredClone(baseLocal);
+    remote.files = [remote.files[0]];
+    expect(compareMetadata(baseLocal, remote)).toContain("files[] length mismatch");
+  });
+
+  it("detects remote files[] not an array", () => {
+    const remote = { ...baseLocal, files: "not-an-array" };
+    expect(compareMetadata(baseLocal, remote)).toContain("not an array");
+  });
+
+  it("detects per-file url mismatch", () => {
+    const remote = structuredClone(baseLocal);
+    remote.files[1].url = "wrong.zip";
+    expect(compareMetadata(baseLocal, remote)).toContain("files[1].url mismatch");
+  });
+
+  it("detects per-file sha512 mismatch", () => {
+    const remote = structuredClone(baseLocal);
+    remote.files[0].sha512 = "wrong-hash";
+    expect(compareMetadata(baseLocal, remote)).toContain("files[0].sha512 mismatch");
+  });
+});
+
+describe("verifyMetadataOnce", () => {
+  const publishUrl = "https://updates.daintree.org/releases/";
+
+  it("returns ok when local and remote match", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "verify-r2-metadata-test-"));
+    try {
+      const content =
+        "version: 1.0.0\nfiles:\n  - url: mac.zip\n    sha512: aaa\n    size: 100\npath: mac.zip\nsha512: aaa\nreleaseDate: 2024-01-01\n";
+      await writeFile(path.join(dir, "latest-mac.yml"), content);
+      const fetchFn = vi.fn().mockResolvedValue(makeResponse({ status: 200, body: content }));
+
+      const result = await verifyMetadataOnce("latest-mac.yml", publishUrl, dir, fetchFn);
+      expect(result.ok).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns error when local file is missing", async () => {
+    const result = await verifyMetadataOnce("latest-mac.yml", publishUrl, "/nonexistent", vi.fn());
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("failed to read local metadata");
+  });
+
+  it("returns error when remote returns 404", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "verify-r2-metadata-test-"));
+    try {
+      const content =
+        "version: 1.0.0\nfiles:\n  - url: mac.zip\n    sha512: aaa\n    size: 100\npath: mac.zip\nsha512: aaa\nreleaseDate: 2024-01-01\n";
+      await writeFile(path.join(dir, "latest-mac.yml"), content);
+      const fetchFn = vi.fn().mockResolvedValue(makeResponse({ status: 404 }));
+
+      const result = await verifyMetadataOnce("latest-mac.yml", publishUrl, dir, fetchFn);
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("404");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns error on content mismatch", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "verify-r2-metadata-test-"));
+    try {
+      const localContent =
+        "version: 1.0.0\nfiles:\n  - url: mac.zip\n    sha512: aaa\n    size: 100\npath: mac.zip\nsha512: aaa\nreleaseDate: 2024-01-01\n";
+      const remoteContent =
+        "version: 2.0.0\nfiles:\n  - url: mac.zip\n    sha512: aaa\n    size: 100\npath: mac.zip\nsha512: aaa\nreleaseDate: 2024-01-01\n";
+      await writeFile(path.join(dir, "latest-mac.yml"), localContent);
+      const fetchFn = vi.fn().mockResolvedValue(makeResponse({ status: 200, body: remoteContent }));
+
+      const result = await verifyMetadataOnce("latest-mac.yml", publishUrl, dir, fetchFn);
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("version mismatch");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("verifyMetadataWithRetries", () => {
+  const publishUrl = "https://updates.daintree.org/releases/";
+
+  it("returns null on first-attempt success without sleeping", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "verify-r2-metadata-test-"));
+    try {
+      const content =
+        "version: 1.0.0\nfiles:\n  - url: mac.zip\n    sha512: aaa\n    size: 100\npath: mac.zip\nsha512: aaa\nreleaseDate: 2024-01-01\n";
+      await writeFile(path.join(dir, "latest-mac.yml"), content);
+      const fetchFn = vi.fn().mockResolvedValue(makeResponse({ status: 200, body: content }));
+      const sleepFn = vi.fn().mockResolvedValue(undefined);
+      const log = vi.fn();
+
+      const error = await verifyMetadataWithRetries({
+        filename: "latest-mac.yml",
+        publishUrl,
+        releaseDir: dir,
+        fetch: fetchFn,
+        sleep: sleepFn,
+        log,
+      });
+
+      expect(error).toBeNull();
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+      expect(sleepFn).not.toHaveBeenCalled();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("retries on 404 and succeeds on third attempt", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "verify-r2-metadata-test-"));
+    try {
+      const content =
+        "version: 1.0.0\nfiles:\n  - url: mac.zip\n    sha512: aaa\n    size: 100\npath: mac.zip\nsha512: aaa\nreleaseDate: 2024-01-01\n";
+      await writeFile(path.join(dir, "latest-mac.yml"), content);
+      const fetchFn = vi
+        .fn()
+        .mockResolvedValueOnce(makeResponse({ status: 404 }))
+        .mockResolvedValueOnce(makeResponse({ status: 404 }))
+        .mockResolvedValueOnce(makeResponse({ status: 200, body: content }));
+      const sleepFn = vi.fn().mockResolvedValue(undefined);
+      const log = vi.fn();
+
+      const error = await verifyMetadataWithRetries({
+        filename: "latest-mac.yml",
+        publishUrl,
+        releaseDir: dir,
+        fetch: fetchFn,
+        sleep: sleepFn,
+        log,
+      });
+
+      expect(error).toBeNull();
+      expect(fetchFn).toHaveBeenCalledTimes(3);
+      expect(sleepFn).toHaveBeenCalledTimes(2);
+      expect(sleepFn).toHaveBeenNthCalledWith(1, 5000);
+      expect(sleepFn).toHaveBeenNthCalledWith(2, 10000);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns last error after all retries exhausted", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "verify-r2-metadata-test-"));
+    try {
+      const content =
+        "version: 1.0.0\nfiles:\n  - url: mac.zip\n    sha512: aaa\n    size: 100\npath: mac.zip\nsha512: aaa\nreleaseDate: 2024-01-01\n";
+      await writeFile(path.join(dir, "latest-mac.yml"), content);
+      const fetchFn = vi.fn().mockResolvedValue(makeResponse({ status: 404 }));
+      const sleepFn = vi.fn().mockResolvedValue(undefined);
+      const log = vi.fn();
+
+      const error = await verifyMetadataWithRetries({
+        filename: "latest-mac.yml",
+        publishUrl,
+        releaseDir: dir,
+        fetch: fetchFn,
+        sleep: sleepFn,
+        log,
+      });
+
+      expect(error).toContain("404");
+      expect(fetchFn).toHaveBeenCalledTimes(3);
+      expect(sleepFn).toHaveBeenCalledTimes(2);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("retries on network errors", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "verify-r2-metadata-test-"));
+    try {
+      const content =
+        "version: 1.0.0\nfiles:\n  - url: mac.zip\n    sha512: aaa\n    size: 100\npath: mac.zip\nsha512: aaa\nreleaseDate: 2024-01-01\n";
+      await writeFile(path.join(dir, "latest-mac.yml"), content);
+      const fetchFn = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("ECONNRESET"))
+        .mockResolvedValueOnce(makeResponse({ status: 200, body: content }));
+      const sleepFn = vi.fn().mockResolvedValue(undefined);
+      const log = vi.fn();
+
+      const error = await verifyMetadataWithRetries({
+        filename: "latest-mac.yml",
+        publishUrl,
+        releaseDir: dir,
+        fetch: fetchFn,
+        sleep: sleepFn,
+        log,
+      });
+
+      expect(error).toBeNull();
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("respects custom maxAttempts and baseDelayMs", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "verify-r2-metadata-test-"));
+    try {
+      const content =
+        "version: 1.0.0\nfiles:\n  - url: mac.zip\n    sha512: aaa\n    size: 100\npath: mac.zip\nsha512: aaa\nreleaseDate: 2024-01-01\n";
+      await writeFile(path.join(dir, "latest-mac.yml"), content);
+      const fetchFn = vi.fn().mockResolvedValue(makeResponse({ status: 404 }));
+      const sleepFn = vi.fn().mockResolvedValue(undefined);
+      const log = vi.fn();
+
+      await verifyMetadataWithRetries({
+        filename: "latest-mac.yml",
+        publishUrl,
+        releaseDir: dir,
+        fetch: fetchFn,
+        sleep: sleepFn,
+        maxAttempts: 4,
+        baseDelayMs: 100,
+        log,
+      });
+
+      expect(fetchFn).toHaveBeenCalledTimes(4);
+      expect(sleepFn).toHaveBeenCalledTimes(3);
+      expect(sleepFn).toHaveBeenNthCalledWith(1, 100);
+      expect(sleepFn).toHaveBeenNthCalledWith(2, 200);
+      expect(sleepFn).toHaveBeenNthCalledWith(3, 400);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/ci/verify-r2-metadata.test.mjs
+++ b/scripts/ci/verify-r2-metadata.test.mjs
@@ -160,6 +160,27 @@ describe("fetchRemoteMetadata", () => {
       fetchRemoteMetadata("https://updates.daintree.org/releases/latest-mac.yml", fetchFn)
     ).rejects.toThrow(/network error/);
   });
+
+  it("throws on body read failure", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      status: 200,
+      text: () => Promise.reject(new Error("stream closed")),
+    });
+    await expect(
+      fetchRemoteMetadata("https://updates.daintree.org/releases/latest-mac.yml", fetchFn)
+    ).rejects.toThrow(/failed to read body/);
+  });
+
+  it("passes AbortController signal to fetch", async () => {
+    const body =
+      "version: 1.0.0\nfiles:\n  - url: mac.zip\n    sha512: aaa\n    size: 100\npath: mac.zip\nsha512: aaa\n";
+    const fetchFn = vi.fn().mockResolvedValue(makeResponse({ status: 200, body }));
+    await fetchRemoteMetadata("https://updates.daintree.org/releases/latest-mac.yml", fetchFn);
+    expect(fetchFn).toHaveBeenCalledWith(
+      "https://updates.daintree.org/releases/latest-mac.yml",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
 });
 
 describe("compareMetadata", () => {
@@ -230,6 +251,35 @@ describe("compareMetadata", () => {
     const remote = structuredClone(baseLocal);
     remote.files[0].sha512 = "wrong-hash";
     expect(compareMetadata(baseLocal, remote)).toContain("files[0].sha512 mismatch");
+  });
+
+  it("handles null remote file entry", () => {
+    const remote = structuredClone(baseLocal);
+    remote.files[1] = null;
+    expect(compareMetadata(baseLocal, remote)).toContain("files[1]: remote entry is not an object");
+  });
+
+  it("handles non-object remote file entry", () => {
+    const remote = structuredClone(baseLocal);
+    remote.files[0] = "not-an-object";
+    expect(compareMetadata(baseLocal, remote)).toContain("files[0]: remote entry is not an object");
+  });
+
+  it("handles Date objects in releaseDate (js-yaml timestamp schema)", () => {
+    const local = { ...baseLocal, releaseDate: new Date("2024-01-01T00:00:00.000Z") };
+    const remote = { ...baseLocal, releaseDate: new Date("2024-01-01T00:00:00.000Z") };
+    expect(compareMetadata(local, remote)).toBeNull();
+  });
+
+  it("handles mixed Date/string releaseDate comparison", () => {
+    const local = { ...baseLocal, releaseDate: new Date("2024-01-01T00:00:00.000Z") };
+    const remote = { ...baseLocal, releaseDate: "2024-01-01T00:00:00.000Z" };
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(compareMetadata(local, remote)).toBeNull();
+    } finally {
+      consoleWarn.mockRestore();
+    }
   });
 });
 
@@ -437,6 +487,82 @@ describe("verifyMetadataWithRetries", () => {
       expect(sleepFn).toHaveBeenNthCalledWith(1, 100);
       expect(sleepFn).toHaveBeenNthCalledWith(2, 200);
       expect(sleepFn).toHaveBeenNthCalledWith(3, 400);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns error when maxAttempts is 0", async () => {
+    const error = await verifyMetadataWithRetries({
+      filename: "latest-mac.yml",
+      publishUrl: "https://x.example/r/",
+      releaseDir: "/nonexistent",
+      fetch: vi.fn(),
+      sleep: vi.fn(),
+      maxAttempts: 0,
+      log: vi.fn(),
+    });
+    expect(error).toContain("maxAttempts must be >= 1");
+  });
+
+  it("returns error when maxAttempts is negative", async () => {
+    const error = await verifyMetadataWithRetries({
+      filename: "latest-mac.yml",
+      publishUrl: "https://x.example/r/",
+      releaseDir: "/nonexistent",
+      fetch: vi.fn(),
+      sleep: vi.fn(),
+      maxAttempts: -1,
+      log: vi.fn(),
+    });
+    expect(error).toContain("maxAttempts must be >= 1");
+  });
+
+  it("does not retry permanent (local file) errors", async () => {
+    const fetchFn = vi.fn();
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    const log = vi.fn();
+
+    const error = await verifyMetadataWithRetries({
+      filename: "latest-mac.yml",
+      publishUrl: "https://x.example/r/",
+      releaseDir: "/nonexistent",
+      fetch: fetchFn,
+      sleep: sleepFn,
+      log,
+    });
+
+    expect(error).toBeTruthy();
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(sleepFn).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("permanent error"));
+  });
+
+  it("does not retry content mismatch errors", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "verify-r2-metadata-test-"));
+    try {
+      const localContent =
+        "version: 1.0.0\nfiles:\n  - url: mac.zip\n    sha512: aaa\n    size: 100\npath: mac.zip\nsha512: aaa\nreleaseDate: 2024-01-01\n";
+      const remoteContent =
+        "version: 2.0.0\nfiles:\n  - url: mac.zip\n    sha512: aaa\n    size: 100\npath: mac.zip\nsha512: aaa\nreleaseDate: 2024-01-01\n";
+      await writeFile(path.join(dir, "latest-mac.yml"), localContent);
+      const fetchFn = vi.fn().mockResolvedValue(makeResponse({ status: 200, body: remoteContent }));
+      const sleepFn = vi.fn().mockResolvedValue(undefined);
+      const log = vi.fn();
+
+      const error = await verifyMetadataWithRetries({
+        filename: "latest-mac.yml",
+        publishUrl: "https://x.example/r/",
+        releaseDir: dir,
+        fetch: fetchFn,
+        sleep: sleepFn,
+        log,
+      });
+
+      expect(error).toContain("version mismatch");
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+      expect(sleepFn).not.toHaveBeenCalled();
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("permanent error"));
     } finally {
       await rm(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Adds a post-upload CDN edge verification step that fetches the release metadata YAML from the public CDN after upload, retrying over a short polling window with staleness detection and stalled-connection abort. Wired into all three per-OS release workflows between binary upload and website-notify.

This guards against Cloudflare CDN cache skew stranding the `electron-updater` pointer -- the failure mode from #7573, where the CDN edge serves a stale pointer and blocks updates with `allowDowngrade: false`.

Resolves #9122.

## Changes

- `scripts/ci/verify-r2-metadata.mjs` -- new post-upload verifier that polls the public CDN for the just-written YAML, detects staleness, aborts on stalled connections, and fails hard if the edge never catches up
- `scripts/ci/verify-r2-metadata.test.mjs` -- 46 vitest unit tests covering normal flow, staleness detection, stalled fetch abort, timeout, and edge cases
- `.github/actions/publish-daintree/action.yml` -- wires the verifier between the YAML upload step and the website-notify step

## Testing

46/46 vitest tests pass. Manual verification of the polling and abort paths against local mock endpoints.