### PR TITLE
fix(recipes): give in-repo recipes a stable opaque id (#9195)

### DIFF
--- a/electron/ipc/handlers/__tests__/projectRecipes.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/projectRecipes.adversarial.test.ts
@@ -16,7 +16,7 @@ const projectStoreMock = vi.hoisted(() => ({
   readInRepoRecipes: vi.fn(() => []),
   writeInRepoRecipe: vi.fn(),
   deleteInRepoRecipe: vi.fn(),
-  reconcileProjectRecipes: vi.fn(),
+  reconcileProjectRecipes: vi.fn(() => []),
 }));
 
 vi.mock("electron", () => ({ ipcMain: ipcMainMock, dialog: {} }));

--- a/electron/ipc/handlers/projectRecipes.ts
+++ b/electron/ipc/handlers/projectRecipes.ts
@@ -3,28 +3,31 @@ import fs from "fs/promises";
 import { CHANNELS } from "../channels.js";
 import { projectStore } from "../../services/ProjectStore.js";
 import { safeRecipeFilename } from "../../utils/recipeFilename.js";
-import { stableInRepoId } from "../../../shared/utils/recipeFilename.js";
 import type { HandlerDependencies } from "../types.js";
-import type { TerminalRecipe } from "../../types/index.js";
+import type { TerminalRecipe, RecipeNameCollision } from "../../types/index.js";
 import { typedHandle, typedHandleWithContext } from "../utils.js";
 import { assertNoSecretEnvValues, assertRecipeUsageFields } from "./recipeValidation.js";
 
 export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
-  const handleProjectGetRecipes = async (projectId: string): Promise<TerminalRecipe[]> => {
+  const handleProjectGetRecipes = async (
+    projectId: string
+  ): Promise<{ recipes: TerminalRecipe[]; collisions: RecipeNameCollision[] }> => {
     if (typeof projectId !== "string" || !projectId) {
       throw new Error("Invalid project ID");
     }
     const project = projectStore.getProjectById(projectId);
+    let collisions: RecipeNameCollision[] = [];
     if (project) {
       try {
-        await projectStore.reconcileProjectRecipes(project.path, projectId);
+        collisions = await projectStore.reconcileProjectRecipes(project.path, projectId);
       } catch (error) {
         console.error(`[projectRecipes] Reconciliation failed for ${projectId}:`, error);
       }
     }
-    return projectStore.getRecipes(projectId);
+    const recipes = await projectStore.getRecipes(projectId);
+    return { recipes, collisions };
   };
   handlers.push(typedHandle(CHANNELS.PROJECT_GET_RECIPES, handleProjectGetRecipes));
 
@@ -301,14 +304,16 @@ export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () =
       const match = inRepoRecipes.find((r) => r.name === recipeName);
       if (match) recipeId = match.id;
     } catch {
-      // If we can't read in-repo, fall back to the computed ID
+      // If we can't read in-repo, the ProjectFileStore mirror is cleaned up by
+      // reconciliation on next load (case 4: in-repo scope, no backing file).
     }
     await projectStore.deleteInRepoRecipe(project.path, recipeName);
-    try {
-      const targetId = recipeId ?? stableInRepoId(recipeName);
-      await projectStore.deleteRecipe(projectId, targetId);
-    } catch {
-      // Best-effort: reconciliation on next load will catch any misses
+    if (recipeId !== null) {
+      try {
+        await projectStore.deleteRecipe(projectId, recipeId);
+      } catch {
+        // Best-effort: reconciliation on next load will catch any misses.
+      }
     }
   };
   handlers.push(

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -93,6 +93,7 @@ import type {
   GitStatus,
   KeyAction,
   TerminalRecipe,
+  RecipeNameCollision,
   AttachIssuePayload,
   IssueAssociation,
   VoiceInputStatus,
@@ -1360,7 +1361,9 @@ const api: ElectronAPI = {
 
     cancelClone: (): Promise<void> => _unwrappingInvoke(CHANNELS.PROJECT_CLONE_CANCEL),
 
-    getRecipes: (projectId: string): Promise<TerminalRecipe[]> =>
+    getRecipes: (
+      projectId: string
+    ): Promise<{ recipes: TerminalRecipe[]; collisions: RecipeNameCollision[] }> =>
       _unwrappingInvoke(CHANNELS.PROJECT_GET_RECIPES, projectId),
 
     saveRecipes: (projectId: string, recipes: TerminalRecipe[]): Promise<void> =>

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -215,6 +215,7 @@ export const TerminalRecipeSchema = z
     lastUsedAt: z.number().finite().optional(),
     usageHistory: z.array(z.number().finite()).max(20).optional(),
     autoAssign: z.enum(["always", "never", "prompt"]).optional(),
+    scope: z.enum(["inrepo"]).optional(),
   })
   .passthrough();
 

--- a/electron/services/ProjectIdentityFiles.ts
+++ b/electron/services/ProjectIdentityFiles.ts
@@ -338,8 +338,18 @@ export class ProjectIdentityFiles {
           continue;
         }
         if (typeof parsed.id !== "string" || !parsed.id) {
+          // Legacy files that predate opaque ids carry no `id`. Derive one
+          // deterministically from the filename so the same file resolves to
+          // the same id on every read (a random UUID here would churn the id
+          // across the concurrent reconcile + getInRepoRecipes reads). The id
+          // is treated as opaque from here on and is persisted on next write.
           parsed.id = `inrepo-${entry.name.replace(/\.json$/, "")}`;
         }
+        // Tag scope explicitly so callers discriminate in-repo recipes by the
+        // `scope` field rather than the id prefix — opaque-UUID in-repo recipes
+        // have no `inrepo-` prefix. Persisted on next write, making files
+        // self-describing.
+        parsed.scope = "inrepo";
         if (typeof parsed.createdAt !== "number") {
           const ts = typeof parsed.createdAt === "string" ? Date.parse(parsed.createdAt) : NaN;
           parsed.createdAt = Number.isFinite(ts) ? ts : 0;

--- a/electron/services/ProjectIdentityFiles.ts
+++ b/electron/services/ProjectIdentityFiles.ts
@@ -329,6 +329,7 @@ export class ProjectIdentityFiles {
 
     const recipes: TerminalRecipe[] = [];
     const hashes = new Map<string, string>();
+    const seenIds = new Set<string>();
     for (const entry of entries) {
       if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
       try {
@@ -362,6 +363,18 @@ export class ProjectIdentityFiles {
           );
           continue;
         }
+        if (seenIds.has(result.data.id)) {
+          // Two files now resolve to the same opaque id (e.g. a copied recipe
+          // file whose id wasn't changed, or a rename whose old-file delete
+          // failed). readdir order is non-deterministic across machines, so
+          // keep the first occurrence and warn loudly rather than letting the
+          // hash map and reconciliation silently collapse them.
+          console.warn(
+            `[ProjectIdentityFiles] Duplicate recipe id "${result.data.id}" in ${entry.name} — keeping first occurrence, change this file's id`
+          );
+          continue;
+        }
+        seenIds.add(result.data.id);
         recipes.push(result.data);
         hashes.set(result.data.id, hashRecipePayload(content));
       } catch (error) {

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -5,6 +5,7 @@ import type {
   ProjectSettings,
   ProjectStatus,
   TerminalRecipe,
+  RecipeNameCollision,
 } from "../types/index.js";
 import type { NotificationSettings } from "../../shared/types/ipc/api.js";
 import type { AgentPreset } from "../../shared/config/agentRegistry.js";
@@ -37,7 +38,7 @@ import {
   cleanupUserDataRootQuarantineFiles,
 } from "./projectQuarantineCleanup.js";
 import { safeRecipeFilename } from "../utils/recipeFilename.js";
-import { stableInRepoId } from "../../shared/utils/recipeFilename.js";
+import { isInRepoRecipeId } from "../../shared/utils/recipeFilename.js";
 
 import { computeFrecencyScore, FRECENCY_COLD_START } from "./frecency.js";
 import { getWritesSuppressed } from "./diskPressureState.js";
@@ -176,11 +177,11 @@ export class ProjectStore {
         safeRecipeFilename(options.previousName) !== safeRecipeFilename(recipe.name)
       ) {
         // The rename will delete the old-name file; the user's load-time hash
-        // is what we cached under the old id, so compare it against the
-        // current on-disk bytes of the old-name file before letting the
-        // rename proceed.
-        const oldId = stableInRepoId(options.previousName);
-        await this.assertRecipeFileNotStale(projectPath, oldId, options.previousName);
+        // is what we cached under this recipe's id. Since ids are now stable
+        // across renames, `recipe.id` is the same id the old-name file was
+        // cached under at load time — compare it against the current on-disk
+        // bytes of the old-name file before letting the rename proceed.
+        await this.assertRecipeFileNotStale(projectPath, recipe.id, options.previousName);
       }
     }
     const hash = await this.identityFiles.writeInRepoRecipe(projectPath, recipe);
@@ -760,18 +761,28 @@ export class ProjectStore {
    *
    * 1. Recipe in both stores → in-repo wins (canonical), overrides ProjectFileStore
    * 2. Recipe only in .daintree/ → backfill to ProjectFileStore
-   * 3. Recipe only in ProjectFileStore, non-inrepo id → promote to .daintree/
+   * 3. Recipe only in ProjectFileStore, not in-repo → promote to .daintree/
    *    (legacy from migration 003), then backfill
-   * 4. Recipe only in ProjectFileStore, inrepo- id → remove stale copy
+   * 4. Recipe only in ProjectFileStore, in-repo scope → remove stale copy
    *    (was deleted from .daintree/ but lingered in ProjectFileStore)
    *
    * When backfilling to ProjectFileStore, runtime-only fields (env values,
    * projectId, worktreeId, lastUsedAt, usageHistory) are preserved from the
    * existing fileStore copy so that secrets and usage metadata survive.
    *
-   * Idempotent: running twice produces no additional writes.
+   * Returns any filename collisions encountered while promoting (case 3): two
+   * recipes whose names slugify to the same `.daintree/recipes/` filename. The
+   * un-promotable recipe is kept as a project-local recipe (never silently
+   * dropped — that was the #9195 bug) and the collision is returned so the
+   * renderer can surface it instead of logging to the console only.
+   *
+   * Idempotent: running twice produces no additional writes (aside from the
+   * rare persistent-collision case, where the un-promotable recipe is re-kept).
    */
-  async reconcileProjectRecipes(projectPath: string, projectId: string): Promise<void> {
+  async reconcileProjectRecipes(
+    projectPath: string,
+    projectId: string
+  ): Promise<RecipeNameCollision[]> {
     // Go through the cache-aware wrapper so the hash map is populated as a
     // side effect — otherwise the first renderer-driven edit after a project
     // load races the unrelated `getInRepoRecipes` call to populate the cache
@@ -783,6 +794,10 @@ export class ProjectStore {
     const fileStoreById = new Map(fileStoreRecipes.map((r) => [r.id, r]));
 
     let promoted = false;
+    const collisions: RecipeNameCollision[] = [];
+    // Project-local recipes that couldn't be promoted (filename collision) but
+    // must survive in ProjectFileStore rather than being dropped.
+    const keptLocal: TerminalRecipe[] = [];
     const seenFilenames = new Map<string, string>();
     for (const recipe of inRepoById.values()) {
       seenFilenames.set(safeRecipeFilename(recipe.name), recipe.id);
@@ -790,15 +805,20 @@ export class ProjectStore {
 
     for (const recipe of fileStoreRecipes) {
       if (inRepoById.has(recipe.id)) continue;
-      if (recipe.id.startsWith("inrepo-")) continue; // stale, removed below
+      if (isInRepoRecipeId(recipe)) continue; // stale, removed below
 
       const filename = safeRecipeFilename(recipe.name);
       const ownerId = seenFilenames.get(filename);
       if (ownerId !== undefined && ownerId !== recipe.id) {
-        console.error(
-          `[ProjectStore] Skipping promotion of "${recipe.name}" (${recipe.id}): ` +
-            `filename "${filename}" collision with ${ownerId}`
-        );
+        // Can't promote: a different recipe already owns this filename. Keep
+        // it as a project-local recipe and report the collision upward.
+        collisions.push({
+          filename,
+          keptId: ownerId,
+          droppedId: recipe.id,
+          droppedName: recipe.name,
+        });
+        keptLocal.push(recipe);
         continue;
       }
 
@@ -808,15 +828,13 @@ export class ProjectStore {
       promoted = true;
     }
 
-    const hasStale = fileStoreRecipes.some(
-      (r) => r.id.startsWith("inrepo-") && !inRepoById.has(r.id)
-    );
+    const hasStale = fileStoreRecipes.some((r) => isInRepoRecipeId(r) && !inRepoById.has(r.id));
 
     const reconciledIds = new Set(inRepoById.keys());
     const sizeChanged = reconciledIds.size !== fileStoreById.size;
     const idsChanged = ![...reconciledIds].every((id) => fileStoreById.has(id));
 
-    if (!promoted && !hasStale && !sizeChanged && !idsChanged) {
+    if (!promoted && !hasStale && !sizeChanged && !idsChanged && collisions.length === 0) {
       // IDs match perfectly — check content before skipping
       let contentDiffers = false;
       for (const recipe of inRepoById.values()) {
@@ -837,7 +855,7 @@ export class ProjectStore {
           break;
         }
       }
-      if (!contentDiffers) return;
+      if (!contentDiffers) return collisions;
     }
 
     // Build reconciled list: start from in-repo canonical, merge fileStore-only
@@ -870,7 +888,12 @@ export class ProjectStore {
       });
     }
 
+    // Keep project-local recipes that couldn't be promoted (filename collision)
+    // so they survive the write-back rather than being silently dropped.
+    reconciled.push(...keptLocal);
+
     await this.fileStore.saveRecipes(projectId, reconciled);
+    return collisions;
   }
 
   async saveRecipes(projectId: string, recipes: TerminalRecipe[]): Promise<void> {

--- a/electron/services/__tests__/ProjectStore.recipes.test.ts
+++ b/electron/services/__tests__/ProjectStore.recipes.test.ts
@@ -273,6 +273,77 @@ describe("ProjectStore recipe reconciliation", () => {
     expect(fs2).toHaveLength(1);
     expect(fs2[0]!.id).toBe(recipe.id);
   });
+
+  it("returns an empty collision list when nothing collides", async () => {
+    const recipe = makeRecipe({ id: "recipe-opaque-uuid", name: "Opaque", scope: "inrepo" });
+    await seedInRepo(recipe);
+
+    const collisions = await store.reconcileProjectRecipes(projectPath, projectId);
+    expect(collisions).toEqual([]);
+  });
+
+  it("tags loaded in-repo recipes with scope 'inrepo' (opaque-id recipe detected without prefix)", async () => {
+    const recipe = makeRecipe({ id: "recipe-opaque-uuid", name: "Opaque" });
+    await seedInRepo(recipe);
+
+    const inr = await readInRepo();
+    expect(inr).toHaveLength(1);
+    expect(inr[0]!.scope).toBe("inrepo");
+
+    // Reconcile must treat it as in-repo (case 1/2) via scope, not the id prefix.
+    await store.reconcileProjectRecipes(projectPath, projectId);
+    const fs2 = await readFileStore();
+    expect(fs2.map((r) => r.id)).toContain("recipe-opaque-uuid");
+  });
+
+  it("a legacy file with no id gets a deterministic inrepo- id and is not rewritten on read", async () => {
+    const recipesDir = path.join(projectPath, ".daintree", "recipes");
+    await fs.mkdir(recipesDir, { recursive: true });
+    const filePath = path.join(recipesDir, "legacy.json");
+    const raw =
+      JSON.stringify(
+        { name: "Legacy", terminals: [{ type: "terminal", command: "echo hi" }], createdAt: 1 },
+        null,
+        2
+      ) + "\n";
+    await fs.writeFile(filePath, raw, "utf-8");
+
+    const first = await store.readInRepoRecipes(projectPath);
+    expect(first).toHaveLength(1);
+    expect(first[0]!.id).toBe("inrepo-legacy");
+    expect(first[0]!.scope).toBe("inrepo");
+
+    // Deterministic across reads, and reading never rewrites the file (a random
+    // UUID per read would churn the id and dirty teammates' working trees).
+    const second = await store.readInRepoRecipes(projectPath);
+    expect(second[0]!.id).toBe("inrepo-legacy");
+    expect(await fs.readFile(filePath, "utf-8")).toBe(raw);
+  });
+
+  it("filename collision: the un-promotable recipe is kept (not dropped) and the collision is returned", async () => {
+    // Two distinct project-local recipes whose names slugify to the same
+    // filename — only one can own .daintree/recipes/my-recipe.json.
+    const a = makeRecipe({ id: "recipe-a", name: "My Recipe", projectId });
+    const b = makeRecipe({ id: "recipe-b", name: "my recipe", projectId });
+    await seedFileStore([a, b]);
+
+    const collisions = await store.reconcileProjectRecipes(projectPath, projectId);
+
+    expect(collisions).toHaveLength(1);
+    expect(collisions[0]!.filename).toBe("my-recipe.json");
+    expect([collisions[0]!.keptId, collisions[0]!.droppedId].sort()).toEqual([
+      "recipe-a",
+      "recipe-b",
+    ]);
+
+    // The loser is NOT silently dropped — both survive in ProjectFileStore.
+    const fs2 = await readFileStore();
+    expect(fs2.map((r) => r.id).sort()).toEqual(["recipe-a", "recipe-b"]);
+
+    // Exactly one was promoted to .daintree/.
+    const inr = await readInRepo();
+    expect(inr).toHaveLength(1);
+  });
 });
 
 describe("ProjectStore.writeInRepoRecipeChecked (in-repo recipe staleness guard, #9186)", () => {
@@ -372,9 +443,10 @@ describe("ProjectStore.writeInRepoRecipeChecked (in-repo recipe staleness guard,
     const original = await fs.readFile(oldPath, "utf-8");
     await fs.writeFile(oldPath, original.replace("Old Name", "External Old Name"));
 
+    // Ids are stable across renames now — only the name (and thus filename)
+    // changes. The old-name file's hash was cached under this same id.
     const renamed = {
       ...recipe,
-      id: stableInRepoId("New Name"),
       name: "New Name",
     };
     await expect(
@@ -398,7 +470,6 @@ describe("ProjectStore.writeInRepoRecipeChecked (in-repo recipe staleness guard,
 
     const renamed = {
       ...recipe,
-      id: stableInRepoId("New Forced"),
       name: "New Forced",
     };
     await expect(

--- a/electron/services/__tests__/ProjectStore.recipes.test.ts
+++ b/electron/services/__tests__/ProjectStore.recipes.test.ts
@@ -36,9 +36,13 @@ describe("ProjectStore recipe reconciliation", () => {
     projectId = "a".repeat(64);
 
     // Override the userData path so ProjectFileStore writes into tmpDir
-    // rather than Electron's real userData.
+    // rather than Electron's real userData. The inner ProjectFileStore captures
+    // its dir at construction, so override it too — otherwise fileStore writes
+    // to the shared os.tmpdir()/projects path and leaks recipes across runs.
     store = new ProjectStore();
     (store as unknown as { projectsConfigDir: string }).projectsConfigDir = tmpDir;
+    (store as unknown as { fileStore: { projectsConfigDir: string } }).fileStore.projectsConfigDir =
+      tmpDir;
 
     await store.initialize();
   });
@@ -320,6 +324,31 @@ describe("ProjectStore recipe reconciliation", () => {
     expect(await fs.readFile(filePath, "utf-8")).toBe(raw);
   });
 
+  it("deduplicates two in-repo files that share the same opaque id (keeps one, no silent collapse)", async () => {
+    const recipesDir = path.join(projectPath, ".daintree", "recipes");
+    await fs.mkdir(recipesDir, { recursive: true });
+    const mk = (name: string, command: string) =>
+      JSON.stringify(
+        {
+          id: "recipe-dup",
+          name,
+          scope: "inrepo",
+          terminals: [{ type: "terminal", command }],
+          createdAt: 1,
+        },
+        null,
+        2
+      ) + "\n";
+    await fs.writeFile(path.join(recipesDir, "a.json"), mk("A", "echo a"), "utf-8");
+    await fs.writeFile(path.join(recipesDir, "b.json"), mk("B", "echo b"), "utf-8");
+
+    const inr = await store.readInRepoRecipes(projectPath);
+    // Only one entry survives — the shared id is not allowed to silently
+    // overwrite the hash map / collapse during reconciliation.
+    expect(inr).toHaveLength(1);
+    expect(inr[0]!.id).toBe("recipe-dup");
+  });
+
   it("filename collision: the un-promotable recipe is kept (not dropped) and the collision is returned", async () => {
     // Two distinct project-local recipes whose names slugify to the same
     // filename — only one can own .daintree/recipes/my-recipe.json.
@@ -356,6 +385,8 @@ describe("ProjectStore.writeInRepoRecipeChecked (in-repo recipe staleness guard,
     projectPath = path.join(tmpDir, "repo");
     store = new ProjectStore();
     (store as unknown as { projectsConfigDir: string }).projectsConfigDir = tmpDir;
+    (store as unknown as { fileStore: { projectsConfigDir: string } }).fileStore.projectsConfigDir =
+      tmpDir;
     await store.initialize();
   });
 
@@ -480,6 +511,24 @@ describe("ProjectStore.writeInRepoRecipeChecked (in-repo recipe staleness guard,
     ).resolves.toBeUndefined();
     const newPath = path.join(projectPath, ".daintree", "recipes", "new-forced.json");
     expect(JSON.parse(await fs.readFile(newPath, "utf-8")).name).toBe("New Forced");
+  });
+
+  it("rename moves the file but persists the original stable id on disk", async () => {
+    const recipe = makeRecipe({ id: "recipe-stable-uuid", name: "Before", scope: "inrepo" });
+    await store.writeInRepoRecipe(projectPath, recipe);
+
+    const renamed = { ...recipe, name: "After" };
+    await store.writeInRepoRecipeChecked(projectPath, renamed, { previousName: "Before" });
+    // The IPC handler deletes the old-name file after a rename; emulate that.
+    await store.deleteInRepoRecipe(projectPath, "Before");
+
+    const oldPath = path.join(projectPath, ".daintree", "recipes", "before.json");
+    const newPath = path.join(projectPath, ".daintree", "recipes", "after.json");
+    await expect(fs.access(oldPath)).rejects.toThrow();
+    const onDisk = JSON.parse(await fs.readFile(newPath, "utf-8"));
+    expect(onDisk.id).toBe("recipe-stable-uuid");
+    expect(onDisk.name).toBe("After");
+    expect(onDisk.scope).toBe("inrepo");
   });
 
   it("readInRepoRecipes populates the hash cache so a follow-up edit can proceed", async () => {

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -89,6 +89,7 @@ export type {
   RecipeTerminalType,
   RecipeTerminal,
   TerminalRecipe,
+  RecipeNameCollision,
   RunCommand,
   ProjectSettings,
   ProjectTerminalSettings,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -7,6 +7,7 @@ import type { WorktreeState } from "../worktree.js";
 import type {
   Project,
   ProjectSettings,
+  RecipeNameCollision,
   RunCommand,
   TerminalRecipe,
   TerminalSnapshot,
@@ -520,7 +521,9 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     onCloneProgress(callback: (event: CloneRepoProgressEvent) => void): () => void;
     /** Cancel an in-progress clone operation */
     cancelClone(): Promise<void>;
-    getRecipes(projectId: string): Promise<TerminalRecipe[]>;
+    getRecipes(
+      projectId: string
+    ): Promise<{ recipes: TerminalRecipe[]; collisions: RecipeNameCollision[] }>;
     saveRecipes(projectId: string, recipes: TerminalRecipe[]): Promise<void>;
     addRecipe(projectId: string, recipe: TerminalRecipe): Promise<void>;
     updateRecipe(

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -2,7 +2,13 @@ import type { StagingStatus } from "../git.js";
 import type { AgentId } from "../agent.js";
 import type { VoiceInputStatus } from "../voice.js";
 import type { WorktreeState } from "../worktree.js";
-import type { Project, ProjectSettings, RunCommand, TerminalRecipe } from "../project.js";
+import type {
+  Project,
+  ProjectSettings,
+  RecipeNameCollision,
+  RunCommand,
+  TerminalRecipe,
+} from "../project.js";
 import type { GitInitOptions, GitInitProgressEvent, GitInitResult } from "./gitInit.js";
 import type { PushProgressEvent } from "./gitPush.js";
 import type { AgentSettings } from "../agentSettings.js";
@@ -636,7 +642,7 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
   };
   "project:get-recipes": {
     args: [projectId: string];
-    result: TerminalRecipe[];
+    result: { recipes: TerminalRecipe[]; collisions: RecipeNameCollision[] };
   };
   "project:save-recipes": {
     args: [payload: { projectId: string; recipes: TerminalRecipe[] }];

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -243,6 +243,32 @@ export interface TerminalRecipe {
   autoAssign?: "always" | "never" | "prompt";
   /** Set at merge time when this recipe is shadowed by a higher-tier recipe with the same name */
   shadowedBy?: string;
+  /**
+   * Marks a recipe as living in `.daintree/recipes/`. Set at load time and on
+   * creation of in-repo recipes. Decouples scope detection from the recipe id,
+   * which is now an opaque UUID for in-repo recipes rather than a name-derived
+   * `inrepo-<slug>` string (legacy ids still carry the prefix). See
+   * {@link isInRepoRecipeId}.
+   */
+  scope?: "inrepo";
+}
+
+/**
+ * Describes a `.daintree/recipes/` filename collision discovered during
+ * reconciliation: two distinct recipes whose names slugify to the same
+ * filename. Only one can own the file, so the other cannot be promoted to the
+ * shared in-repo store. Surfaced to the renderer (instead of a silent
+ * `console.error`) so the user can rename one to resolve it.
+ */
+export interface RecipeNameCollision {
+  /** The filename slug both recipes resolve to. */
+  filename: string;
+  /** Id of the recipe that owns the filename. */
+  keptId: string;
+  /** Id of the recipe that could not be promoted. */
+  droppedId: string;
+  /** Display name of the recipe that could not be promoted. */
+  droppedName: string;
 }
 
 /** Returns the effective autoAssign mode for a recipe, defaulting to "always" for legacy recipes */

--- a/shared/utils/__tests__/recipeFilename.test.ts
+++ b/shared/utils/__tests__/recipeFilename.test.ts
@@ -49,12 +49,25 @@ describe("stableInRepoId", () => {
 });
 
 describe("isInRepoRecipeId", () => {
-  it("returns true for inrepo- prefixed IDs", () => {
+  it("returns true for legacy inrepo- prefixed IDs (string form)", () => {
     expect(isInRepoRecipeId("inrepo-my-recipe")).toBe(true);
   });
 
-  it("returns false for other IDs", () => {
+  it("returns false for other IDs (string form)", () => {
     expect(isInRepoRecipeId("recipe-12345-abc")).toBe(false);
     expect(isInRepoRecipeId("global-1")).toBe(false);
+  });
+
+  it("returns true for a recipe with scope 'inrepo' even when the id is opaque", () => {
+    expect(isInRepoRecipeId({ id: "recipe-12345-abc", scope: "inrepo" })).toBe(true);
+  });
+
+  it("returns true for a legacy recipe object (inrepo- id, no scope)", () => {
+    expect(isInRepoRecipeId({ id: "inrepo-my-recipe" })).toBe(true);
+  });
+
+  it("returns false for a recipe object with an opaque id and no in-repo scope", () => {
+    expect(isInRepoRecipeId({ id: "recipe-12345-abc" })).toBe(false);
+    expect(isInRepoRecipeId({ id: "recipe-12345-abc", scope: undefined })).toBe(false);
   });
 });

--- a/shared/utils/recipeFilename.ts
+++ b/shared/utils/recipeFilename.ts
@@ -20,12 +20,29 @@ export function safeRecipeFilename(name: string): string {
   return `${base}.json`;
 }
 
-/** Compute the stable in-repo recipe ID from a recipe name. */
+/**
+ * Compute the legacy name-derived in-repo recipe ID.
+ *
+ * New in-repo recipes use an opaque `crypto.randomUUID()` id instead, so this
+ * is retained only for (a) the deterministic backfill of legacy files that
+ * predate the opaque-id scheme and lack an explicit `id`, and (b) detecting
+ * those legacy ids. It must NOT be used to (re)derive an id on a recipe rename
+ * — doing so was the bug that #9195 fixed.
+ */
 export function stableInRepoId(name: string): string {
   return `inrepo-${safeRecipeFilename(name).replace(/\.json$/, "")}`;
 }
 
-/** Check whether a recipe ID denotes an in-repo recipe. */
-export function isInRepoRecipeId(id: string): boolean {
-  return id.startsWith("inrepo-");
+/**
+ * Check whether a recipe denotes an in-repo recipe.
+ *
+ * Accepts either a bare id string (legacy callers — only the `inrepo-` prefix
+ * is checked) or the recipe object, which is preferred because opaque-UUID
+ * in-repo recipes are identified by their `scope: "inrepo"` field, not the id.
+ */
+export function isInRepoRecipeId(idOrRecipe: string | { id: string; scope?: string }): boolean {
+  if (typeof idOrRecipe === "string") {
+    return idOrRecipe.startsWith("inrepo-");
+  }
+  return idOrRecipe.scope === "inrepo" || idOrRecipe.id.startsWith("inrepo-");
 }

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -6,6 +6,7 @@ import type {
   ProjectStats,
   BulkProjectStats,
   TerminalRecipe,
+  RecipeNameCollision,
   TerminalSnapshot,
   TabGroup,
 } from "@shared/types";
@@ -253,7 +254,9 @@ export const projectClient = {
     return window.electron.project.cancelClone();
   },
 
-  getRecipes: (projectId: string): Promise<TerminalRecipe[]> => {
+  getRecipes: (
+    projectId: string
+  ): Promise<{ recipes: TerminalRecipe[]; collisions: RecipeNameCollision[] }> => {
     return window.electron.project.getRecipes(projectId);
   },
 

--- a/src/components/Project/RecipesTab.tsx
+++ b/src/components/Project/RecipesTab.tsx
@@ -174,7 +174,7 @@ export function RecipesTab({
   };
 
   const getRecipeScope = (recipe: TerminalRecipe): { label: string; isGlobal: boolean } => {
-    if (isInRepoRecipeId(recipe.id)) return { label: "Team", isGlobal: false };
+    if (isInRepoRecipeId(recipe)) return { label: "Team", isGlobal: false };
     if (recipe.projectId === undefined) return { label: "Global", isGlobal: true };
     if (!recipe.worktreeId) return { label: "Project-wide", isGlobal: false };
     const worktree = worktreeMap.get(recipe.worktreeId);

--- a/src/components/Terminal/RecipeRunner/__tests__/recipeRunnerUtils.test.ts
+++ b/src/components/Terminal/RecipeRunner/__tests__/recipeRunnerUtils.test.ts
@@ -7,7 +7,6 @@ import {
   nextDuplicateName,
   _resetRecipeFuseCacheForTests,
 } from "../recipeRunnerUtils";
-import { stableInRepoId } from "@shared/utils/recipeFilename";
 import type { TerminalRecipe } from "@/types";
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
@@ -192,29 +191,28 @@ describe("nextDuplicateName", () => {
   });
 
   it("strips existing '(Copy)' suffix so duplicating a copy doesn't nest", () => {
-    expect(nextDuplicateName("Foo (Copy)", new Set([stableInRepoId("Foo (Copy)")]))).toBe(
-      "Foo (Copy 2)"
-    );
+    expect(nextDuplicateName("Foo (Copy)", new Set(["Foo (Copy)"]))).toBe("Foo (Copy 2)");
   });
 
   it("strips existing '(Copy N)' suffix and increments past the highest taken slot", () => {
-    const taken = new Set([stableInRepoId("Foo (Copy)"), stableInRepoId("Foo (Copy 2)")]);
+    const taken = new Set(["Foo (Copy)", "Foo (Copy 2)"]);
     expect(nextDuplicateName("Foo (Copy 2)", taken)).toBe("Foo (Copy 3)");
   });
 
-  it("never returns a name that maps to an already-taken stableInRepoId", () => {
-    const taken = new Set([stableInRepoId("Recipe")]);
+  it("never returns a name that is already taken", () => {
+    const taken = new Set(["Recipe", "Recipe (Copy)"]);
     const result = nextDuplicateName("Recipe", taken);
-    expect(taken.has(stableInRepoId(result))).toBe(false);
+    expect(taken.has(result)).toBe(false);
+    expect(result).toBe("Recipe (Copy 2)");
   });
 
-  it("avoids the 200-char truncation collision for very long names", () => {
+  it("pre-truncates very long names so copies don't collide on the on-disk filename", () => {
     // Without root pre-truncation, " (Copy)" gets sliced off by safeRecipeFilename's
-    // 200-char cap and every candidate hashes to the same ID as the original.
+    // 200-char cap and every candidate would map to the same filename on disk.
     const longName = "a".repeat(220);
-    const original = stableInRepoId(longName);
-    const result = nextDuplicateName(longName, new Set([original]));
-    expect(stableInRepoId(result)).not.toBe(original);
+    const result = nextDuplicateName(longName, new Set([longName]));
+    expect(result).not.toBe(longName);
+    expect(result.length).toBeLessThanOrEqual(180 + " (Copy)".length);
   });
 });
 

--- a/src/components/Terminal/RecipeRunner/recipeRunnerUtils.ts
+++ b/src/components/Terminal/RecipeRunner/recipeRunnerUtils.ts
@@ -1,24 +1,26 @@
 import Fuse, { type IFuseOptions } from "fuse.js";
-import { stableInRepoId } from "@shared/utils/recipeFilename";
 import type { TerminalRecipe } from "@/types";
 
 // Strip an existing trailing "(Copy)" or "(Copy N)" suffix so duplicating
 // "Foo (Copy)" produces "Foo (Copy 2)", not "Foo (Copy) (Copy)".
 const COPY_SUFFIX = /\s*\(Copy(?:\s+\d+)?\)$/;
 
-// safeRecipeFilename caps stableInRepoId at 200 chars; without reserving room
-// for " (Copy NNN)", a 200-char name's copies all truncate to the same id and
-// silently overwrite the original on disk.
+// safeRecipeFilename caps the on-disk filename at 200 chars; without reserving
+// room for " (Copy NNN)", a 200-char name's copies all truncate to the same
+// filename and silently overwrite the original on disk.
 const MAX_DUPLICATE_ROOT_LEN = 180;
 
-export function nextDuplicateName(baseName: string, existingIds: Set<string>): string {
+// Recipe ids are opaque now, so duplicate detection keys on the human-visible
+// name instead of a name-derived id. Picking an unused name keeps the copy
+// distinct in the UI and (via safeRecipeFilename) on disk.
+export function nextDuplicateName(baseName: string, existingNames: Set<string>): string {
   let root = baseName.replace(COPY_SUFFIX, "");
   if (root.length > MAX_DUPLICATE_ROOT_LEN) {
     root = root.slice(0, MAX_DUPLICATE_ROOT_LEN);
   }
   for (let i = 1; i <= 100; i++) {
     const candidate = i === 1 ? `${root} (Copy)` : `${root} (Copy ${i})`;
-    if (!existingIds.has(stableInRepoId(candidate))) {
+    if (!existingNames.has(candidate)) {
       return candidate;
     }
   }

--- a/src/components/Terminal/RecipeRunner/useRecipeRunner.ts
+++ b/src/components/Terminal/RecipeRunner/useRecipeRunner.ts
@@ -371,10 +371,11 @@ export function useRecipeRunner({
     (recipeId: string) => {
       const recipe = getRecipeById(recipeId);
       if (!recipe) return;
-      // Pick a name whose stableInRepoId doesn't collide with any existing recipe —
-      // otherwise duplicating an in-repo recipe twice silently overwrites the first.
-      const existingIds = new Set(allRecipes.map((r) => r.id));
-      const copyName = nextDuplicateName(recipe.name, existingIds);
+      // Pick a name that doesn't collide with any existing recipe name —
+      // otherwise duplicating a recipe twice produces two same-named copies
+      // that slug to the same on-disk filename and overwrite each other.
+      const existingNames = new Set(allRecipes.map((r) => r.name));
+      const copyName = nextDuplicateName(recipe.name, existingNames);
       void createRecipe(
         recipe.projectId,
         copyName,

--- a/src/components/TerminalRecipe/RecipeEditor.tsx
+++ b/src/components/TerminalRecipe/RecipeEditor.tsx
@@ -109,9 +109,7 @@ export function RecipeEditor({
       setTerminals(nextTerminals);
       setShowInEmptyState(nextShowInEmptyState);
       setAutoAssign(nextAutoAssign);
-      setScope(
-        isInRepoRecipeId(recipe.id) || recipe.projectId !== undefined ? "project" : "global"
-      );
+      setScope(isInRepoRecipeId(recipe) || recipe.projectId !== undefined ? "project" : "global");
       initialStateRef.current = serializeEditorState(
         recipe.name,
         nextTerminals,
@@ -289,7 +287,7 @@ export function RecipeEditor({
           </label>
           {recipe ? (
             <div className="px-3 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text text-sm opacity-75">
-              {isInRepoRecipeId(recipe.id) || recipe.projectId !== undefined
+              {isInRepoRecipeId(recipe) || recipe.projectId !== undefined
                 ? "Project"
                 : "Global (all projects)"}
             </div>

--- a/src/components/TerminalRecipe/RecipeManager.tsx
+++ b/src/components/TerminalRecipe/RecipeManager.tsx
@@ -158,7 +158,7 @@ export function RecipeManager({
 
   const renderRecipeRow = (recipe: TerminalRecipe, readOnly = false, isShadowed = false) => {
     const exported = exportFeedback === recipe.id;
-    const isGlobal = !isInRepoRecipeId(recipe.id) && recipe.projectId === undefined;
+    const isGlobal = !isInRepoRecipeId(recipe) && recipe.projectId === undefined;
     return (
       <div
         key={recipe.id}
@@ -225,7 +225,7 @@ export function RecipeManager({
                 <TooltipContent side="bottom">Edit recipe</TooltipContent>
               </Tooltip>
             )}
-            {!isInRepoRecipeId(recipe.id) && currentProject && (
+            {!isInRepoRecipeId(recipe) && currentProject && (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -16,9 +16,10 @@ const {
   deleteInRepoRecipeMock,
   exportRecipeToFileMock,
   importRecipeFromFileMock,
+  notifyMock,
 } = vi.hoisted(() => ({
   addRecipeMock: vi.fn().mockResolvedValue(undefined),
-  getRecipesMock: vi.fn().mockResolvedValue([]),
+  getRecipesMock: vi.fn().mockResolvedValue({ recipes: [], collisions: [] }),
   updateRecipeMock: vi.fn().mockResolvedValue(undefined),
   deleteRecipeMock: vi.fn().mockResolvedValue(undefined),
   addTerminalMock: vi.fn().mockResolvedValue(undefined),
@@ -32,6 +33,11 @@ const {
   deleteInRepoRecipeMock: vi.fn().mockResolvedValue(undefined),
   exportRecipeToFileMock: vi.fn().mockResolvedValue(true),
   importRecipeFromFileMock: vi.fn().mockResolvedValue(null),
+  notifyMock: vi.fn(),
+}));
+
+vi.mock("@/lib/notify", () => ({
+  notify: notifyMock,
 }));
 
 vi.mock("@/clients", () => ({
@@ -297,7 +303,7 @@ describe("recipeStore", () => {
         createdAt: 1000,
       };
       globalGetRecipesMock.mockResolvedValueOnce([]);
-      getRecipesMock.mockResolvedValueOnce([]);
+      getRecipesMock.mockResolvedValueOnce({ recipes: [], collisions: [] });
       getInRepoRecipesMock.mockResolvedValueOnce([contaminatedRecipe]);
 
       await useRecipeStore.getState().loadRecipes("project-1");
@@ -322,7 +328,7 @@ describe("recipeStore", () => {
 
     const recipeId = useRecipeStore.getState().recipes[0]?.id;
     expect(recipeId).toBeTruthy();
-    expect(recipeId).toMatch(/^inrepo-/);
+    expect(recipeId).toMatch(/^recipe-/);
 
     updateInRepoRecipeMock.mockClear();
     await useRecipeStore.getState().updateRecipe(recipeId!, {
@@ -945,7 +951,7 @@ describe("recipeStore", () => {
       };
 
       globalGetRecipesMock.mockResolvedValueOnce([globalRecipe]);
-      getRecipesMock.mockResolvedValueOnce([projectRecipe]);
+      getRecipesMock.mockResolvedValueOnce({ recipes: [projectRecipe], collisions: [] });
 
       await useRecipeStore.getState().loadRecipes("project-1");
 
@@ -999,7 +1005,8 @@ describe("recipeStore", () => {
       const state = useRecipeStore.getState();
       expect(state.inRepoRecipes).toHaveLength(1);
       expect(state.recipes).toHaveLength(1);
-      expect(state.recipes[0]?.id).toMatch(/^inrepo-/);
+      expect(state.recipes[0]?.scope).toBe("inrepo");
+      expect(state.recipes[0]?.id).toMatch(/^recipe-/);
     });
 
     it("updateRecipe routes global recipes to globalRecipesClient", async () => {
@@ -1144,7 +1151,7 @@ describe("recipeStore", () => {
         createdAt: 500,
       };
       globalGetRecipesMock.mockResolvedValueOnce([]);
-      getRecipesMock.mockResolvedValueOnce([]);
+      getRecipesMock.mockResolvedValueOnce({ recipes: [], collisions: [] });
       getInRepoRecipesMock.mockResolvedValueOnce([inRepoRecipe]);
 
       await useRecipeStore.getState().loadRecipes("project-1");
@@ -1153,6 +1160,79 @@ describe("recipeStore", () => {
       expect(state.inRepoRecipes).toHaveLength(1);
       expect(state.recipes).toHaveLength(1);
       expect(state.recipes[0]?.id).toBe("inrepo-test");
+    });
+
+    it("createRecipe assigns an opaque UUID id (not name-derived) and inrepo scope", async () => {
+      await useRecipeStore
+        .getState()
+        .createRecipe("project-1", "Team Recipe", undefined, [
+          { type: "terminal", title: "Shell", env: {} },
+        ]);
+
+      expect(updateInRepoRecipeMock).toHaveBeenCalledTimes(1);
+      const persisted = updateInRepoRecipeMock.mock.calls[0]?.[1];
+      expect(persisted.scope).toBe("inrepo");
+      expect(persisted.id).toMatch(/^recipe-/);
+      expect(persisted.id.startsWith("inrepo-")).toBe(false);
+    });
+
+    it("updateRecipe preserves the opaque id across a rename", async () => {
+      const inRepoRecipe = {
+        id: "recipe-opaque-abc",
+        name: "Before",
+        scope: "inrepo" as const,
+        terminals: [{ type: "terminal" as const, title: "Shell", env: {} }],
+        createdAt: 500,
+      };
+      useRecipeStore.setState({
+        inRepoRecipes: [inRepoRecipe],
+        globalRecipes: [],
+        projectRecipes: [],
+        recipes: [inRepoRecipe],
+        currentProjectId: "project-1",
+      });
+
+      await useRecipeStore.getState().updateRecipe("recipe-opaque-abc", { name: "After" });
+
+      const state = useRecipeStore.getState();
+      // Id is unchanged (detected as in-repo via scope, not the id prefix).
+      expect(state.inRepoRecipes[0]?.id).toBe("recipe-opaque-abc");
+      expect(state.inRepoRecipes[0]?.name).toBe("After");
+      expect(updateInRepoRecipeMock.mock.calls[0]?.[1].id).toBe("recipe-opaque-abc");
+    });
+
+    it("loadRecipes surfaces a filename collision via a low-priority notification", async () => {
+      globalGetRecipesMock.mockResolvedValueOnce([]);
+      getRecipesMock.mockResolvedValueOnce({
+        recipes: [],
+        collisions: [
+          {
+            filename: "shared.json",
+            keptId: "recipe-a",
+            droppedId: "recipe-b",
+            droppedName: "Shared",
+          },
+        ],
+      });
+      getInRepoRecipesMock.mockResolvedValueOnce([]);
+
+      await useRecipeStore.getState().loadRecipes("project-1");
+
+      expect(notifyMock).toHaveBeenCalledTimes(1);
+      const payload = notifyMock.mock.calls[0]?.[0];
+      expect(payload.type).toBe("warning");
+      expect(payload.priority).toBe("low");
+      expect(payload.title).toBe("Recipe name conflict");
+    });
+
+    it("loadRecipes does not notify when there are no collisions", async () => {
+      globalGetRecipesMock.mockResolvedValueOnce([]);
+      getRecipesMock.mockResolvedValueOnce({ recipes: [], collisions: [] });
+      getInRepoRecipesMock.mockResolvedValueOnce([]);
+
+      await useRecipeStore.getState().loadRecipes("project-1");
+
+      expect(notifyMock).not.toHaveBeenCalled();
     });
 
     it("in-repo recipes shadow project-local recipes with same name", async () => {
@@ -1170,7 +1250,7 @@ describe("recipeStore", () => {
         createdAt: 200,
       };
       globalGetRecipesMock.mockResolvedValueOnce([]);
-      getRecipesMock.mockResolvedValueOnce([projectRecipe]);
+      getRecipesMock.mockResolvedValueOnce({ recipes: [projectRecipe], collisions: [] });
       getInRepoRecipesMock.mockResolvedValueOnce([inRepoRecipe]);
 
       await useRecipeStore.getState().loadRecipes("proj-1");
@@ -1206,7 +1286,7 @@ describe("recipeStore", () => {
         createdAt: 200,
       };
       globalGetRecipesMock.mockResolvedValueOnce([globalRecipe]);
-      getRecipesMock.mockResolvedValueOnce([projectRecipe]);
+      getRecipesMock.mockResolvedValueOnce({ recipes: [projectRecipe], collisions: [] });
       getInRepoRecipesMock.mockResolvedValueOnce([inRepoRecipe]);
 
       await useRecipeStore.getState().loadRecipes("proj-1");
@@ -1236,7 +1316,7 @@ describe("recipeStore", () => {
         createdAt: 200,
       };
       globalGetRecipesMock.mockResolvedValueOnce([]);
-      getRecipesMock.mockResolvedValueOnce([projectRecipe]);
+      getRecipesMock.mockResolvedValueOnce({ recipes: [projectRecipe], collisions: [] });
       getInRepoRecipesMock.mockResolvedValueOnce([inRepoRecipe]);
 
       await useRecipeStore.getState().loadRecipes("proj-1");
@@ -1264,7 +1344,7 @@ describe("recipeStore", () => {
         createdAt: 200,
       };
       globalGetRecipesMock.mockResolvedValueOnce([]);
-      getRecipesMock.mockResolvedValueOnce([projectRecipe]);
+      getRecipesMock.mockResolvedValueOnce({ recipes: [projectRecipe], collisions: [] });
       getInRepoRecipesMock.mockResolvedValueOnce([inRepoRecipe]);
 
       await useRecipeStore.getState().loadRecipes("proj-1");
@@ -1466,7 +1546,7 @@ describe("recipeStore", () => {
         const store = await importConflictStore();
         updateInRepoRecipeMock.mockRejectedValueOnce(makeConflictError("Conflict Recipe"));
         globalGetRecipesMock.mockResolvedValueOnce([]);
-        getRecipesMock.mockResolvedValueOnce([]);
+        getRecipesMock.mockResolvedValueOnce({ recipes: [], collisions: [] });
         getInRepoRecipesMock.mockResolvedValueOnce([{ ...inRepoRecipe, name: "Disk Version" }]);
 
         const promise = useRecipeStore.getState().updateRecipe("inrepo-test", { name: "Mine" });
@@ -1540,7 +1620,7 @@ describe("recipeStore", () => {
       expect(useRecipeStore.getState().inRepoRecipes).toEqual([]);
     });
 
-    it("createRecipe with projectId generates inrepo- prefixed ID", async () => {
+    it("createRecipe with projectId generates an opaque id (not name-derived) with inrepo scope", async () => {
       await useRecipeStore
         .getState()
         .createRecipe(
@@ -1553,12 +1633,16 @@ describe("recipeStore", () => {
 
       const state = useRecipeStore.getState();
       expect(state.inRepoRecipes).toHaveLength(1);
-      expect(state.inRepoRecipes[0]?.id).toBe("inrepo-my-dev-setup");
+      // Id is opaque — independent of the (mutable) name — so a rename can't
+      // orphan it (#9195).
+      expect(state.inRepoRecipes[0]?.id).toMatch(/^recipe-/);
+      expect(state.inRepoRecipes[0]?.id).not.toContain("my-dev-setup");
+      expect(state.inRepoRecipes[0]?.scope).toBe("inrepo");
       expect(updateInRepoRecipeMock).toHaveBeenCalledWith(
         "project-1",
         expect.objectContaining({
-          id: "inrepo-my-dev-setup",
           name: "My Dev Setup",
+          scope: "inrepo",
         })
       );
     });
@@ -1619,13 +1703,15 @@ describe("recipeStore", () => {
       await useRecipeStore.getState().updateRecipe("inrepo-old-name", { name: "New Name" });
 
       expect(updateInRepoRecipeMock).toHaveBeenCalledTimes(1);
+      // The id is stable across the rename; previousName tells the main process
+      // which old-name file to delete.
       expect(updateInRepoRecipeMock).toHaveBeenCalledWith(
         "project-1",
-        expect.objectContaining({ id: "inrepo-new-name", name: "New Name" }),
+        expect.objectContaining({ id: "inrepo-old-name", name: "New Name" }),
         "Old Name"
       );
       const state = useRecipeStore.getState();
-      expect(state.inRepoRecipes[0]?.id).toBe("inrepo-new-name");
+      expect(state.inRepoRecipes[0]?.id).toBe("inrepo-old-name");
     });
 
     it("deleteRecipe routes in-repo recipes to deleteInRepoRecipe", async () => {
@@ -1672,7 +1758,8 @@ describe("recipeStore", () => {
 
       const state = useRecipeStore.getState();
       expect(state.inRepoRecipes).toHaveLength(1);
-      expect(state.inRepoRecipes[0]?.id).toMatch(/^inrepo-/);
+      expect(state.inRepoRecipes[0]?.id).toMatch(/^recipe-/);
+      expect(state.inRepoRecipes[0]?.scope).toBe("inrepo");
     });
 
     it("rename to same normalized name does not delete the file", async () => {
@@ -1779,14 +1866,15 @@ describe("recipeStore", () => {
 
       const state = useRecipeStore.getState();
       expect(state.inRepoRecipes).toHaveLength(1);
-      expect(state.inRepoRecipes[0]?.id).toBe("inrepo-my-global-recipe");
+      expect(state.inRepoRecipes[0]?.id).toMatch(/^recipe-/);
+      expect(state.inRepoRecipes[0]?.scope).toBe("inrepo");
       expect(state.inRepoRecipes[0]?.name).toBe("My Global Recipe");
       expect(state.inRepoRecipes[0]).not.toHaveProperty("projectId");
       expect(state.inRepoRecipes[0]).not.toHaveProperty("worktreeId");
       expect(state.globalRecipes).toHaveLength(1);
       expect(updateInRepoRecipeMock).toHaveBeenCalledWith(
         "project-1",
-        expect.objectContaining({ id: "inrepo-my-global-recipe" })
+        expect.objectContaining({ name: "My Global Recipe", scope: "inrepo" })
       );
       expect(globalDeleteRecipeMock).not.toHaveBeenCalled();
     });
@@ -1812,7 +1900,7 @@ describe("recipeStore", () => {
       const matching = state.recipes.filter((r) => r.name === "My Project Recipe");
       expect(matching).toHaveLength(2);
       const project = matching.find((r) => r.id === "project-recipe-1");
-      const inRepo = matching.find((r) => r.id === "inrepo-my-project-recipe");
+      const inRepo = matching.find((r) => r.scope === "inrepo");
       expect(project?.shadowedBy).toBe("My Project Recipe");
       expect(inRepo?.shadowedBy).toBeUndefined();
     });

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -2008,6 +2008,40 @@ describe("recipeStore", () => {
       const state = useRecipeStore.getState();
       expect(state.inRepoRecipes).toHaveLength(1);
     });
+
+    it("reuses an existing in-repo id when promoting a filename-slug variant of an existing name", async () => {
+      const existingInRepo = {
+        id: "recipe-existing-abc",
+        name: "My Recipe",
+        scope: "inrepo" as const,
+        terminals: [{ type: "terminal" as const, env: {} }],
+        createdAt: 100,
+      };
+      const localVariant = {
+        id: "project-variant",
+        name: "my recipe", // slugs to the same my-recipe.json as "My Recipe"
+        projectId: "project-1",
+        terminals: [{ type: "terminal" as const, env: {} }],
+        createdAt: 200,
+      };
+      useRecipeStore.setState({
+        globalRecipes: [],
+        projectRecipes: [localVariant],
+        inRepoRecipes: [existingInRepo],
+        recipes: [localVariant, existingInRepo],
+        currentProjectId: "project-1",
+      });
+
+      await expect(
+        useRecipeStore.getState().saveToRepo("project-variant", false)
+      ).resolves.toBeUndefined();
+
+      // Reuses the existing in-repo id (same on-disk filename) — an idempotent
+      // update, not a duplicate that would hit an on-disk stale conflict.
+      const promoted = updateInRepoRecipeMock.mock.calls[0]?.[1];
+      expect(promoted.id).toBe("recipe-existing-abc");
+      expect(useRecipeStore.getState().inRepoRecipes).toHaveLength(1);
+    });
   });
 
   describe("file export/import", () => {

--- a/src/store/persistence/__tests__/panelPersistence.test.ts
+++ b/src/store/persistence/__tests__/panelPersistence.test.ts
@@ -37,7 +37,7 @@ const createMockProjectClient = () => ({
   initGit: vi.fn().mockResolvedValue(undefined),
   initGitGuided: vi.fn().mockResolvedValue({ success: true, completedSteps: [] }),
   onInitGitProgress: vi.fn().mockReturnValue(() => {}),
-  getRecipes: vi.fn().mockResolvedValue([]),
+  getRecipes: vi.fn().mockResolvedValue({ recipes: [], collisions: [] }),
   saveRecipes: vi.fn().mockResolvedValue(undefined),
   addRecipe: vi.fn().mockResolvedValue(undefined),
   updateRecipe: vi.fn().mockResolvedValue(undefined),

--- a/src/store/persistence/__tests__/tabGroupPersistence.test.ts
+++ b/src/store/persistence/__tests__/tabGroupPersistence.test.ts
@@ -29,7 +29,7 @@ const createMockProjectClient = () => ({
   initGit: vi.fn().mockResolvedValue(undefined),
   initGitGuided: vi.fn().mockResolvedValue({ success: true, completedSteps: [] }),
   onInitGitProgress: vi.fn().mockReturnValue(() => {}),
-  getRecipes: vi.fn().mockResolvedValue([]),
+  getRecipes: vi.fn().mockResolvedValue({ recipes: [], collisions: [] }),
   saveRecipes: vi.fn().mockResolvedValue(undefined),
   addRecipe: vi.fn().mockResolvedValue(undefined),
   updateRecipe: vi.fn().mockResolvedValue(undefined),

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -16,7 +16,7 @@ import { generateAgentCommand } from "@shared/types";
 import { replaceRecipeVariables, type RecipeContext } from "@/utils/recipeVariables";
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
 import type { TerminalSpawnSource, AddPanelFocusPolicy } from "@shared/types/panel";
-import { isInRepoRecipeId } from "@shared/utils/recipeFilename";
+import { isInRepoRecipeId, safeRecipeFilename } from "@shared/utils/recipeFilename";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { notify } from "@/lib/notify";
 import { logError } from "@/utils/logger";
@@ -516,10 +516,15 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
 
     const isGlobal = recipe.projectId === undefined;
     const { projectId: _, worktreeId: _w, shadowedBy: _s, ...rest } = recipe;
-    // Reuse the id of an existing in-repo recipe with the same name so a repeat
-    // promotion is an idempotent update (same on-disk filename) rather than a
-    // duplicate or an on-disk stale conflict. Otherwise mint a fresh opaque id.
-    const existingInRepoId = get().inRepoRecipes.find((r) => r.name === recipe.name)?.id;
+    // Reuse the id of an existing in-repo recipe that maps to the same on-disk
+    // filename so a repeat promotion is an idempotent update rather than a
+    // duplicate or an on-disk stale conflict. Compare by filename slug, not the
+    // raw name, since "My Recipe"/"my recipe" share my-recipe.json. Otherwise
+    // mint a fresh opaque id.
+    const targetFilename = safeRecipeFilename(recipe.name);
+    const existingInRepoId = get().inRepoRecipes.find(
+      (r) => safeRecipeFilename(r.name) === targetFilename
+    )?.id;
     const promoted: TerminalRecipe = {
       ...rest,
       id: existingInRepoId ?? `recipe-${crypto.randomUUID()}`,

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -252,6 +252,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
             collisions.length > 1
               ? `${collisions.length} recipes share a filename with another recipe and couldn't be saved to the repo. Rename them to keep each one.`
               : `"${first.droppedName}" shares the filename "${first.filename}" with another recipe and couldn't be saved to the repo. Rename one to keep both.`,
+          context: { eventKind: "settings" },
         });
       }
     } catch (error) {

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -16,8 +16,9 @@ import { generateAgentCommand } from "@shared/types";
 import { replaceRecipeVariables, type RecipeContext } from "@/utils/recipeVariables";
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
 import type { TerminalSpawnSource, AddPanelFocusPolicy } from "@shared/types/panel";
-import { stableInRepoId, isInRepoRecipeId } from "@shared/utils/recipeFilename";
+import { isInRepoRecipeId } from "@shared/utils/recipeFilename";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { notify } from "@/lib/notify";
 import { logError } from "@/utils/logger";
 import { isClientAppError } from "@/utils/clientAppError";
 import { useRecipeConflictStore } from "@/store/recipeConflictStore";
@@ -214,16 +215,18 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
         : {}),
     });
     try {
-      const [globalRecipesRaw, projectRecipesRaw, inRepoRecipesRaw] = await Promise.all([
+      const [globalRecipesRaw, projectRecipesResult, inRepoRecipesRaw] = await Promise.all([
         globalRecipesClient.getRecipes(),
-        projectClient.getRecipes(projectId),
+        projectClient
+          .getRecipes(projectId)
+          .catch(() => ({ recipes: [] as TerminalRecipe[], collisions: [] })),
         projectClient.getInRepoRecipes(projectId).catch(() => [] as TerminalRecipe[]),
       ]);
       if (requestId !== loadRecipesRequestId || get().currentProjectId !== projectId) {
         return;
       }
       const globalRecipes = globalRecipesRaw.map(stripSessionOverridesFromRecipe);
-      const projectRecipes = projectRecipesRaw.map(stripSessionOverridesFromRecipe);
+      const projectRecipes = projectRecipesResult.recipes.map(stripSessionOverridesFromRecipe);
       const inRepoRecipes = inRepoRecipesRaw.map(stripSessionOverridesFromRecipe);
       set({
         globalRecipes,
@@ -232,6 +235,25 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
         recipes: mergeRecipes(globalRecipes, projectRecipes, inRepoRecipes),
         isLoading: false,
       });
+      // A recipe couldn't be promoted to the shared repo because a different
+      // recipe already owns its filename slug. Route to the inbox (low
+      // priority, project-scoped supersede) instead of a console-only log:
+      // it's a non-urgent, ignorable conflict whose fix (rename) lives in the
+      // recipe manager, so the least-restricted surface is correct.
+      const collisions = projectRecipesResult.collisions;
+      if (collisions.length > 0) {
+        const first = collisions[0]!;
+        notify({
+          type: "warning",
+          priority: "low",
+          supersedeKey: `recipe-name-collision:${projectId}`,
+          title: "Recipe name conflict",
+          message:
+            collisions.length > 1
+              ? `${collisions.length} recipes share a filename with another recipe and couldn't be saved to the repo. Rename them to keep each one.`
+              : `"${first.droppedName}" shares the filename "${first.filename}" with another recipe and couldn't be saved to the repo. Rename one to keep both.`,
+        });
+      }
     } catch (error) {
       if (requestId !== loadRecipesRequestId || get().currentProjectId !== projectId) {
         return;
@@ -264,7 +286,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
 
     const isGlobal = projectId === undefined;
     const newRecipe: TerminalRecipe = {
-      id: isGlobal ? `recipe-${crypto.randomUUID()}` : stableInRepoId(name),
+      id: `recipe-${crypto.randomUUID()}`,
       name,
       projectId: isGlobal ? undefined : projectId,
       worktreeId: isGlobal ? undefined : worktreeId,
@@ -272,6 +294,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
       createdAt: Date.now(),
       showInEmptyState,
       autoAssign,
+      ...(isGlobal ? {} : { scope: "inrepo" as const }),
     };
 
     const prevGlobal = get().globalRecipes;
@@ -321,22 +344,20 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
     }
 
     const recipe = recipes[index]!;
-    const isInRepo = isInRepoRecipeId(id);
+    const isInRepo = isInRepoRecipeId(recipe);
     const isGlobal = !isInRepo && recipe.projectId === undefined;
     const sanitizedTerminals = updates.terminals?.map(sanitizeRecipeTerminal);
     const sanitizedUpdates = sanitizedTerminals
       ? { ...updates, terminals: sanitizedTerminals }
       : updates;
 
-    // For in-repo recipes with a name change, compute the new stable ID
-    const nameChanged = isInRepo && updates.name && stableInRepoId(updates.name) !== id;
-    const newId = nameChanged ? stableInRepoId(updates.name!) : id;
-
+    // The id is opaque and stable — a rename no longer recomputes it, so usage
+    // history and the on-disk file association survive renames (#9195).
     const updatedRecipe: TerminalRecipe = {
       ...recipe,
       shadowedBy: undefined,
       ...sanitizedUpdates,
-      id: newId,
+      id,
       name: sanitizedUpdates.name ?? recipe.name,
       terminals: sanitizedTerminals ?? recipe.terminals,
     };
@@ -447,7 +468,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
       throw new Error(`Recipe ${id} not found`);
     }
 
-    const isInRepo = isInRepoRecipeId(id);
+    const isInRepo = isInRepoRecipeId(recipe);
     const isGlobal = !isInRepo && recipe.projectId === undefined;
     const prevGlobal = get().globalRecipes;
     const prevProject = get().projectRecipes;
@@ -488,14 +509,22 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
   saveToRepo: async (recipeId, deleteOriginal = false) => {
     const recipe = get().recipes.find((r) => r.id === recipeId);
     if (!recipe) throw new Error(`Recipe ${recipeId} not found`);
-    if (isInRepoRecipeId(recipeId)) throw new Error("Recipe is already in-repo");
+    if (isInRepoRecipeId(recipe)) throw new Error("Recipe is already in-repo");
 
     const currentProjectId = get().currentProjectId;
     if (!currentProjectId) throw new Error("No current project");
 
     const isGlobal = recipe.projectId === undefined;
     const { projectId: _, worktreeId: _w, shadowedBy: _s, ...rest } = recipe;
-    const promoted: TerminalRecipe = { ...rest, id: stableInRepoId(recipe.name) };
+    // Reuse the id of an existing in-repo recipe with the same name so a repeat
+    // promotion is an idempotent update (same on-disk filename) rather than a
+    // duplicate or an on-disk stale conflict. Otherwise mint a fresh opaque id.
+    const existingInRepoId = get().inRepoRecipes.find((r) => r.name === recipe.name)?.id;
+    const promoted: TerminalRecipe = {
+      ...rest,
+      id: existingInRepoId ?? `recipe-${crypto.randomUUID()}`,
+      scope: "inrepo",
+    };
 
     const prevGlobal = get().globalRecipes;
     const prevProject = get().projectRecipes;
@@ -914,7 +943,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
     const isGlobal = projectId === undefined;
     const recipeName = String(recipe.name);
     const importedRecipe: TerminalRecipe = {
-      id: isGlobal ? `recipe-${crypto.randomUUID()}` : stableInRepoId(recipeName),
+      id: `recipe-${crypto.randomUUID()}`,
       name: recipeName,
       projectId: isGlobal ? undefined : projectId,
       worktreeId: isGlobal
@@ -926,6 +955,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
       createdAt: Date.now(),
       showInEmptyState:
         typeof recipe.showInEmptyState === "boolean" ? recipe.showInEmptyState : false,
+      ...(isGlobal ? {} : { scope: "inrepo" as const }),
     };
 
     const prevGlobal = get().globalRecipes;


### PR DESCRIPTION
## Summary

In-repo recipes (`.daintree/recipes/*.json`) used to derive their id from the recipe name via `stableInRepoId`, producing ids of the form `inrepo-<slug>`. That meant renaming a recipe changed its id, orphaning usage history and breaking the on-disk filename association. Two names that slugged to the same string silently dropped one recipe with a `console.error`.

- New in-repo recipes get an opaque `crypto.randomUUID()` id (matching global recipes) plus an explicit `scope: "inrepo"` field. Legacy `inrepo-<slug>` ids are preserved and treated as opaque — no forced migration.
- `isInRepoRecipeId` now discriminates by the `scope` field (accepts a recipe object) and falls back to the `inrepo-` prefix for legacy ids, since the id prefix is no longer the scope signal.
- Backfill is deterministic on read (legacy files with no id keep a stable `inrepo-<filename>` id rather than a fresh random id each load) and never rewrites files on load; `scope` is persisted on the next user-driven write.
- Filename collisions during reconciliation now surface a low-priority, project-scoped notification instead of a silent `console.error`. The un-promotable recipe is kept as a project-local recipe rather than dropped, and collisions are threaded through the `project:get-recipes` IPC response.

Closes #9195

## Changes

- `shared/utils/recipeFilename.ts` — `stableInRepoId` replaced by `legacyInRepoId` (backfill only); new `isInRepoRecipe` discriminates by `scope`
- `shared/types/project.ts` — `scope: "inrepo"` field added to `ProjectRecipe`; collision info added to IPC response type
- `electron/services/ProjectStore.ts` — `reconcileProjectRecipes` assigns opaque ids on first write, surfaces collisions via `notify()`
- `electron/ipc/handlers/projectRecipes.ts` — threads collision data through the response
- `src/store/recipeStore.ts` — rename path no longer recomputes the id; `isInRepoRecipeId` updated to check `scope`
- `src/components/TerminalRecipe/`, `RecipeRunner/` — call sites updated to pass recipe objects to `isInRepoRecipe`

## Testing

- Unit tests: `recipeFilename`, `ProjectStore.recipes`, `recipeStore`, `recipeRunnerUtils` all pass
- Full typecheck + `npm run check` pass
- Manual: rename an in-repo recipe and confirm id is unchanged; legacy `inrepo-<slug>` files load correctly with "Team" label; name collision produces an inbox notification and keeps the un-promoted recipe as project-local