### PR TITLE
feat(build): bound macOS notarization wait with recovery path

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -155,6 +155,13 @@ jobs:
         env:
           APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY }}
 
+      - name: Download notarization state
+        uses: actions/download-artifact@v7
+        with:
+          name: macos-notarization-state
+          path: release/
+        continue-on-error: true
+
       - name: Build (macOS)
         shell: bash
         env:
@@ -164,6 +171,7 @@ jobs:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          DAINTREE_SKIP_NOTARIZATION: ${{ inputs.skip_notarization && 'true' || '' }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           DEBUG: electron-builder,electron-notarize*,electron-osx-sign*
           npm_config_build_from_source: "true"
@@ -177,12 +185,7 @@ jobs:
             echo "::warning::Dry run — skipping publish to electron-builder targets"
             PUBLISH_FLAG="never"
           fi
-          EXTRA_ARGS=""
-          if [ "${{ inputs.skip_notarization }}" = "true" ]; then
-            echo "::warning::Skipping macOS notarization (manually disabled)"
-            EXTRA_ARGS="-c.mac.notarize=false"
-          fi
-          npx electron-builder --config electron-builder.config.cjs --publish "$PUBLISH_FLAG" -c.buildDependenciesFromSource=true $EXTRA_ARGS
+          npx electron-builder --config electron-builder.config.cjs --publish "$PUBLISH_FLAG" -c.buildDependenciesFromSource=true
 
       - name: Verify macOS notarization staple
         if: inputs.skip_notarization != true
@@ -227,6 +230,15 @@ jobs:
           for app in "${apps[@]}"; do
             scripts/ci/verify-team-identifier.sh "$app" "$EXPECTED_TEAM_ID"
           done
+
+      - name: Upload notarization state
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-notarization-state
+          path: release/.notarization-state.json
+          retention-days: 1
+          if-no-files-found: ignore
 
       - name: Validate update metadata (macOS)
         shell: bash

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -75,12 +75,13 @@ module.exports = async function () {
       grantFileProtocolExtraPrivileges: false,
     },
     afterPack: "./scripts/afterPack.cjs",
+    afterSign: "./scripts/notarize-macos.cjs",
     mac: {
       extraResources: [{ from: "scripts/daintree-cli.sh", to: "daintree-cli.sh" }],
       x64ArchFiles:
         "Contents/Resources/app.asar.unpacked/node_modules/{node-pty/build/Release/**,better-sqlite3/build/Release/**,win-job-object/bin/**,posix-pty-reaper/build/Release/**,@parcel/watcher-darwin-*/watcher.node,@parcel/watcher/bin/darwin-*/watcher.node}",
       forceCodeSigning: true,
-      notarize: true,
+      notarize: false,
       binaries: [
         "Contents/Resources/app.asar.unpacked/node_modules/node-pty/build/Release/spawn-helper",
         "Contents/Resources/app.asar.unpacked/node_modules/posix-pty-reaper/build/Release/daintree_pty_supervisor",

--- a/scripts/notarize-macos.cjs
+++ b/scripts/notarize-macos.cjs
@@ -1,0 +1,172 @@
+const path = require("path");
+const fs = require("fs");
+const { execFileSync } = require("child_process");
+
+const NOTARIZATION_STATE_FILE = ".notarization-state.json";
+const WAIT_TIMEOUT_SECONDS = 1800;
+
+function readState(outDir) {
+  const statePath = path.join(outDir, NOTARIZATION_STATE_FILE);
+  try {
+    return JSON.parse(fs.readFileSync(statePath, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+function writeState(outDir, state) {
+  const statePath = path.join(outDir, NOTARIZATION_STATE_FILE);
+  const tmpPath = statePath + ".tmp";
+  fs.writeFileSync(tmpPath, JSON.stringify(state, null, 2));
+  fs.renameSync(tmpPath, statePath);
+}
+
+function runNotaryTool(args, options) {
+  const fullArgs = [...args, "--output-format", "json"];
+  const keyPath = process.env.APPLE_API_KEY;
+  const keyId = process.env.APPLE_API_KEY_ID;
+  const issuer = process.env.APPLE_API_ISSUER;
+  if (keyPath) fullArgs.push("--key", keyPath);
+  if (keyId) fullArgs.push("--key-id", keyId);
+  if (issuer) fullArgs.push("--issuer", issuer);
+  return execFileSync("xcrun", fullArgs, { encoding: "utf-8", ...options });
+}
+
+exports.default = async function afterSign(context) {
+  if (process.platform !== "darwin") return;
+
+  if (process.env.DAINTREE_SKIP_NOTARIZATION === "true") {
+    console.log("[notarize-macos] Skipping notarization (DAINTREE_SKIP_NOTARIZATION=true)");
+    return;
+  }
+
+  const { appOutDir, outDir, packager, arch } = context;
+  const appName = packager.appInfo.productFilename;
+  const appPath = path.join(appOutDir, `${appName}.app`);
+
+  if (!fs.existsSync(appPath)) {
+    throw new Error(`[notarize-macos] App bundle not found: ${appPath}`);
+  }
+
+  const keyPath = process.env.APPLE_API_KEY;
+  const keyId = process.env.APPLE_API_KEY_ID;
+  const issuer = process.env.APPLE_API_ISSUER;
+
+  if (!keyPath || !keyId || !issuer) {
+    console.warn("[notarize-macos] Apple API credentials not set — skipping notarization");
+    return;
+  }
+
+  const state = readState(outDir) || {};
+  const archKey = String(arch);
+
+  if (state[archKey]?.submissionId && state[archKey]?.status === "submitted") {
+    await reattachAndWait(state, archKey, appPath, appName, outDir);
+  } else {
+    await submitAndWait(state, archKey, appPath, appName, outDir);
+  }
+};
+
+async function reattachAndWait(state, archKey, appPath, appName, outDir) {
+  const { submissionId } = state[archKey];
+  console.log(`[notarize-macos] Reattaching to submission ${submissionId} (arch ${archKey})`);
+
+  try {
+    const output = runNotaryTool(
+      ["notarytool", "wait", submissionId, "--timeout", String(WAIT_TIMEOUT_SECONDS)],
+      {
+        timeout: WAIT_TIMEOUT_SECONDS * 1000 + 60000,
+      }
+    );
+    const result = JSON.parse(output);
+    if (result.status !== "Accepted") {
+      throw new Error(
+        `[notarize-macos] Notarization not accepted for ${submissionId}: status=${result.status}`
+      );
+    }
+    state[archKey] = { submissionId, status: "accepted", timestamp: new Date().toISOString() };
+    writeState(outDir, state);
+  } catch (err) {
+    if (err.status === 124) {
+      console.log(
+        `[notarize-macos] Wait timed out for ${submissionId} — submission continues server-side`
+      );
+      throw new Error(
+        `[notarize-macos] Notarization wait timed out (${WAIT_TIMEOUT_SECONDS}s). ` +
+          `Submission ID: ${submissionId}. Re-run the workflow to reattach and staple.`
+      );
+    }
+    throw err;
+  }
+
+  await stapleApp(appPath, appName, archKey);
+  state[archKey] = { ...state[archKey], status: "stapled", timestamp: new Date().toISOString() };
+  writeState(outDir, state);
+}
+
+async function submitAndWait(state, archKey, appPath, appName, outDir) {
+  console.log(`[notarize-macos] Submitting ${appPath} for notarization (arch ${archKey})`);
+
+  let submitResult;
+  try {
+    const output = runNotaryTool(["notarytool", "submit", appPath], { timeout: 120000 });
+    submitResult = JSON.parse(output);
+  } catch (err) {
+    throw new Error(`[notarize-macos] Submission failed: ${err.stderr || err.message}`);
+  }
+
+  const submissionId = submitResult.id;
+  if (!submissionId) {
+    throw new Error(
+      `[notarize-macos] No submission ID in response: ${JSON.stringify(submitResult)}`
+    );
+  }
+
+  console.log(`[notarize-macos] Submitted: ${submissionId}`);
+
+  state[archKey] = { submissionId, status: "submitted", timestamp: new Date().toISOString() };
+  writeState(outDir, state);
+
+  try {
+    const waitOutput = runNotaryTool(
+      ["notarytool", "wait", submissionId, "--timeout", String(WAIT_TIMEOUT_SECONDS)],
+      { timeout: WAIT_TIMEOUT_SECONDS * 1000 + 60000 }
+    );
+    const waitResult = JSON.parse(waitOutput);
+    if (waitResult.status !== "Accepted") {
+      throw new Error(
+        `[notarize-macos] Notarization not accepted for ${submissionId}: status=${waitResult.status}`
+      );
+    }
+  } catch (err) {
+    if (err.status === 124) {
+      console.log(
+        `[notarize-macos] Wait timed out for ${submissionId} — submission continues server-side`
+      );
+      throw new Error(
+        `[notarize-macos] Notarization wait timed out (${WAIT_TIMEOUT_SECONDS}s). ` +
+          `Submission ID: ${submissionId}. Re-run the workflow to reattach and staple.`
+      );
+    }
+    throw err;
+  }
+
+  state[archKey] = { submissionId, status: "accepted", timestamp: new Date().toISOString() };
+  writeState(outDir, state);
+
+  await stapleApp(appPath, appName, archKey);
+  state[archKey] = { ...state[archKey], status: "stapled", timestamp: new Date().toISOString() };
+  writeState(outDir, state);
+}
+
+async function stapleApp(appPath, appName, archKey) {
+  console.log(`[notarize-macos] Stapling ${appPath}`);
+  try {
+    execFileSync("xcrun", ["stapler", "staple", appPath], { encoding: "utf-8", timeout: 120000 });
+  } catch (err) {
+    throw new Error(
+      `[notarize-macos] Stapling failed for ${appPath}: ${err.stderr || err.message}`
+    );
+  }
+  console.log(`[notarize-macos] Complete — ${appName} notarized and stapled (arch ${archKey})`);
+}

--- a/scripts/notarize-macos.cjs
+++ b/scripts/notarize-macos.cjs
@@ -1,5 +1,6 @@
 const path = require("path");
 const fs = require("fs");
+const os = require("os");
 const { execFileSync } = require("child_process");
 
 const NOTARIZATION_STATE_FILE = ".notarization-state.json";
@@ -7,9 +8,11 @@ const WAIT_TIMEOUT_SECONDS = 1800;
 
 function readState(outDir) {
   const statePath = path.join(outDir, NOTARIZATION_STATE_FILE);
+  if (!fs.existsSync(statePath)) return null;
   try {
     return JSON.parse(fs.readFileSync(statePath, "utf-8"));
   } catch {
+    console.warn("[notarize-macos] Could not parse notarization state file — starting fresh");
     return null;
   }
 }
@@ -30,6 +33,17 @@ function runNotaryTool(args, options) {
   if (keyId) fullArgs.push("--key-id", keyId);
   if (issuer) fullArgs.push("--issuer", issuer);
   return execFileSync("xcrun", fullArgs, { encoding: "utf-8", ...options });
+}
+
+function zipApp(appPath) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-notarize-"));
+  const zipName = path.basename(appPath, ".app") + ".zip";
+  const zipPath = path.join(tmpDir, zipName);
+  execFileSync("ditto", ["-c", "-k", "--sequesterRsrc", "--keepParent", appPath, zipPath], {
+    encoding: "utf-8",
+    timeout: 300000,
+  });
+  return { zipPath, tmpDir };
 }
 
 exports.default = async function afterSign(context) {
@@ -60,7 +74,11 @@ exports.default = async function afterSign(context) {
   const state = readState(outDir) || {};
   const archKey = String(arch);
 
-  if (state[archKey]?.submissionId && state[archKey]?.status === "submitted") {
+  if (state[archKey]?.submissionId && state[archKey]?.status === "accepted") {
+    await stapleApp(appPath, appName, archKey);
+    state[archKey] = { ...state[archKey], status: "stapled", timestamp: new Date().toISOString() };
+    writeState(outDir, state);
+  } else if (state[archKey]?.submissionId && state[archKey]?.status === "submitted") {
     await reattachAndWait(state, archKey, appPath, appName, outDir);
   } else {
     await submitAndWait(state, archKey, appPath, appName, outDir);
@@ -74,9 +92,7 @@ async function reattachAndWait(state, archKey, appPath, appName, outDir) {
   try {
     const output = runNotaryTool(
       ["notarytool", "wait", submissionId, "--timeout", String(WAIT_TIMEOUT_SECONDS)],
-      {
-        timeout: WAIT_TIMEOUT_SECONDS * 1000 + 60000,
-      }
+      { timeout: WAIT_TIMEOUT_SECONDS * 1000 + 60000 }
     );
     const result = JSON.parse(output);
     if (result.status !== "Accepted") {
@@ -105,14 +121,32 @@ async function reattachAndWait(state, archKey, appPath, appName, outDir) {
 }
 
 async function submitAndWait(state, archKey, appPath, appName, outDir) {
-  console.log(`[notarize-macos] Submitting ${appPath} for notarization (arch ${archKey})`);
+  console.log(`[notarize-macos] Zipping ${appPath} for submission`);
+
+  let zipPath;
+  let tmpDir;
+  try {
+    const zip = zipApp(appPath);
+    zipPath = zip.zipPath;
+    tmpDir = zip.tmpDir;
+  } catch (err) {
+    throw new Error(`[notarize-macos] Failed to zip app bundle: ${err.stderr || err.message}`);
+  }
+
+  console.log(`[notarize-macos] Submitting ${zipPath} for notarization (arch ${archKey})`);
 
   let submitResult;
   try {
-    const output = runNotaryTool(["notarytool", "submit", appPath], { timeout: 120000 });
+    const output = runNotaryTool(["notarytool", "submit", zipPath], { timeout: 120000 });
     submitResult = JSON.parse(output);
   } catch (err) {
     throw new Error(`[notarize-macos] Submission failed: ${err.stderr || err.message}`);
+  } finally {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup
+    }
   }
 
   const submissionId = submitResult.id;

--- a/scripts/notarize-macos.test.ts
+++ b/scripts/notarize-macos.test.ts
@@ -7,6 +7,8 @@ const mockExistsSync = vi.fn();
 const mockReadFileSync = vi.fn();
 const mockWriteFileSync = vi.fn();
 const mockRenameSync = vi.fn();
+const mockMkdtempSync = vi.fn();
+const mockRmSync = vi.fn();
 const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -38,7 +40,13 @@ function mockFs() {
     readFileSync: mockReadFileSync,
     writeFileSync: mockWriteFileSync,
     renameSync: mockRenameSync,
+    mkdtempSync: mockMkdtempSync,
+    rmSync: mockRmSync,
   };
+}
+
+function mockOs() {
+  return { tmpdir: () => "/tmp" };
 }
 
 function setAppleCredentials() {
@@ -63,11 +71,13 @@ describe("notarize-macos", () => {
     delete process.env.DAINTREE_SKIP_NOTARIZATION;
     setAppleCredentials();
     setPlatform("darwin");
+    mockMkdtempSync.mockReturnValue("/tmp/daintree-notarize-xxxx");
 
     const originalRequire = Module.prototype.require;
 
     Module.prototype.require = function (id: string) {
       if (id === "fs") return mockFs();
+      if (id === "os") return mockOs();
       if (id === "child_process") return { execFileSync: mockExecFileSync };
       return originalRequire.apply(this, [id]);
     };
@@ -92,9 +102,6 @@ describe("notarize-macos", () => {
     mockExistsSync.mockReturnValue(true);
     await afterSign(createContext());
     expect(mockExecFileSync).not.toHaveBeenCalled();
-    expect(consoleLogSpy).toHaveBeenCalledWith(
-      "[notarize-macos] Skipping notarization (DAINTREE_SKIP_NOTARIZATION=true)"
-    );
   });
 
   it("should skip when credentials are missing", async () => {
@@ -102,9 +109,6 @@ describe("notarize-macos", () => {
     mockExistsSync.mockReturnValue(true);
     await afterSign(createContext());
     expect(mockExecFileSync).not.toHaveBeenCalled();
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
-      "[notarize-macos] Apple API credentials not set — skipping notarization"
-    );
   });
 
   it("should throw when .app bundle is missing", async () => {
@@ -120,52 +124,88 @@ describe("notarize-macos", () => {
       });
     });
 
-    it("should submit, wait, and staple", async () => {
+    it("should zip, submit, wait, and staple", async () => {
       mockExecFileSync
+        .mockReturnValueOnce("") // ditto zip
         .mockReturnValueOnce(JSON.stringify({ id: "sub-123", status: "In Progress" }))
         .mockReturnValueOnce(JSON.stringify({ id: "sub-123", status: "Accepted" }))
         .mockReturnValueOnce("stapled");
 
       await afterSign(createContext());
 
-      expect(mockExecFileSync).toHaveBeenCalledTimes(3);
+      expect(mockExecFileSync).toHaveBeenCalledTimes(4);
 
-      const submitCall = mockExecFileSync.mock.calls[0];
+      // ditto zip
+      const dittoCall = mockExecFileSync.mock.calls[0];
+      expect(dittoCall[0]).toBe("ditto");
+      expect(dittoCall[1]).toContain("-c");
+      expect(dittoCall[1]).toContain("-k");
+
+      // submit
+      const submitCall = mockExecFileSync.mock.calls[1];
       expect(submitCall[0]).toBe("xcrun");
-      expect(submitCall[1]).toContain("notarytool");
       expect(submitCall[1]).toContain("submit");
 
-      const waitCall = mockExecFileSync.mock.calls[1];
+      // wait
+      const waitCall = mockExecFileSync.mock.calls[2];
       expect(waitCall[1]).toContain("wait");
       expect(waitCall[1]).toContain("sub-123");
       expect(waitCall[1]).toContain("--timeout");
 
-      const stapleCall = mockExecFileSync.mock.calls[2];
+      // staple
+      const stapleCall = mockExecFileSync.mock.calls[3];
       expect(stapleCall[1]).toContain("stapler");
       expect(stapleCall[1]).toContain("staple");
 
-      expect(mockWriteFileSync).toHaveBeenCalled();
-      expect(mockRenameSync).toHaveBeenCalled();
+      // Cleanup
+      expect(mockRmSync).toHaveBeenCalledWith("/tmp/daintree-notarize-xxxx", {
+        recursive: true,
+        force: true,
+      });
+    });
+
+    it("should submit the zip, not the .app", async () => {
+      mockExecFileSync
+        .mockReturnValueOnce("") // ditto
+        .mockReturnValueOnce(JSON.stringify({ id: "sub-zip", status: "In Progress" }))
+        .mockReturnValueOnce(JSON.stringify({ id: "sub-zip", status: "Accepted" }))
+        .mockReturnValueOnce("stapled");
+
+      await afterSign(createContext());
+
+      const submitArgs = mockExecFileSync.mock.calls[1][1];
+      const submitPath = submitArgs[submitArgs.indexOf("submit") + 1];
+      expect(submitPath).toContain(".zip");
+      expect(submitPath).not.toContain(".app");
     });
 
     it("should persist state immediately after submit, before wait", async () => {
       mockExecFileSync
+        .mockReturnValueOnce("") // ditto
         .mockReturnValueOnce(JSON.stringify({ id: "sub-456", status: "In Progress" }))
         .mockReturnValueOnce(JSON.stringify({ id: "sub-456", status: "Accepted" }))
         .mockReturnValueOnce("stapled");
 
       await afterSign(createContext());
 
-      const tmpCallIndex = mockWriteFileSync.mock.calls.findIndex((c: any[]) =>
-        c[0].endsWith(".tmp")
-      );
-      expect(tmpCallIndex).toBeGreaterThan(-1);
+      // Find the submission state persist (after submit, before wait)
+      const tmpWrites = mockWriteFileSync.mock.calls.filter((c: any[]) => c[0].endsWith(".tmp"));
+      const statuses = tmpWrites.map((c: any[]) => JSON.parse(c[1])["3"].status);
+      expect(statuses).toContain("submitted");
+    });
 
-      const firstWrite = JSON.parse(mockWriteFileSync.mock.calls[tmpCallIndex][1]);
-      expect(firstWrite["3"].status).toBe("submitted");
+    it("should throw when ditto zip fails", async () => {
+      const err = new Error("zip error");
+      (err as any).stderr = "No space left on device";
+      mockExecFileSync.mockImplementationOnce(() => {
+        throw err;
+      });
+
+      await expect(afterSign(createContext())).rejects.toThrow(/Failed to zip app bundle/);
     });
 
     it("should throw when submit fails", async () => {
+      mockExecFileSync.mockReturnValueOnce(""); // ditto
       const err = new Error("submit error");
       (err as any).stderr = "Network error";
       mockExecFileSync.mockImplementationOnce(() => {
@@ -175,22 +215,38 @@ describe("notarize-macos", () => {
       await expect(afterSign(createContext())).rejects.toThrow(/Submission failed/);
     });
 
+    it("should cleanup temp dir even when submit fails", async () => {
+      mockExecFileSync.mockReturnValueOnce(""); // ditto
+      const err = new Error("submit error");
+      (err as any).stderr = "Network error";
+      mockExecFileSync.mockImplementationOnce(() => {
+        throw err;
+      });
+
+      await expect(afterSign(createContext())).rejects.toThrow();
+      expect(mockRmSync).toHaveBeenCalled();
+    });
+
     it("should throw when submit returns non-JSON", async () => {
-      mockExecFileSync.mockReturnValueOnce("not json {{{");
+      mockExecFileSync
+        .mockReturnValueOnce("") // ditto
+        .mockReturnValueOnce("not json {{{");
 
       await expect(afterSign(createContext())).rejects.toThrow(/Submission failed/);
     });
 
     it("should throw when submit returns no id", async () => {
-      mockExecFileSync.mockReturnValueOnce(JSON.stringify({ status: "error" }));
+      mockExecFileSync
+        .mockReturnValueOnce("") // ditto
+        .mockReturnValueOnce(JSON.stringify({ status: "error" }));
 
       await expect(afterSign(createContext())).rejects.toThrow(/No submission ID/);
     });
 
     it("should throw when wait times out (exit 124)", async () => {
-      mockExecFileSync.mockReturnValueOnce(
-        JSON.stringify({ id: "sub-789", status: "In Progress" })
-      );
+      mockExecFileSync
+        .mockReturnValueOnce("") // ditto
+        .mockReturnValueOnce(JSON.stringify({ id: "sub-789", status: "In Progress" }));
 
       const err = new Error("timed out");
       (err as any).status = 124;
@@ -211,6 +267,7 @@ describe("notarize-macos", () => {
 
     it("should throw when notarization is rejected", async () => {
       mockExecFileSync
+        .mockReturnValueOnce("") // ditto
         .mockReturnValueOnce(JSON.stringify({ id: "sub-000", status: "In Progress" }))
         .mockReturnValueOnce(JSON.stringify({ id: "sub-000", status: "Invalid" }));
 
@@ -219,6 +276,7 @@ describe("notarize-macos", () => {
 
     it("should throw when staple fails", async () => {
       mockExecFileSync
+        .mockReturnValueOnce("") // ditto
         .mockReturnValueOnce(JSON.stringify({ id: "sub-111", status: "In Progress" }))
         .mockReturnValueOnce(JSON.stringify({ id: "sub-111", status: "Accepted" }));
 
@@ -229,15 +287,20 @@ describe("notarize-macos", () => {
       });
 
       await expect(afterSign(createContext())).rejects.toThrow(/Stapling failed/);
+
+      // State should be left as "accepted" so recovery can staple-only
+      const tmpWrites = mockWriteFileSync.mock.calls.filter((c: any[]) => c[0].endsWith(".tmp"));
+      const lastWrite = JSON.parse(tmpWrites[tmpWrites.length - 1][1]);
+      expect(lastWrite["3"].status).toBe("accepted");
     });
   });
 
-  describe("reattach from prior state", () => {
+  describe("reattach from submitted state", () => {
     beforeEach(() => {
       mockExistsSync.mockReturnValue(true);
     });
 
-    it("should reattach instead of resubmitting", async () => {
+    it("should reattach via wait instead of resubmitting", async () => {
       mockReadFileSync.mockReturnValue(
         JSON.stringify({
           "3": { submissionId: "sub-existing", status: "submitted", timestamp: "2026-01-01" },
@@ -253,6 +316,8 @@ describe("notarize-macos", () => {
       expect(mockExecFileSync.mock.calls[0][1]).toContain("wait");
       expect(mockExecFileSync.mock.calls[0][1]).toContain("sub-existing");
       expect(mockExecFileSync.mock.calls[1][1]).toContain("staple");
+      expect(mockExecFileSync.mock.calls.flat().join(" ")).not.toContain("submit");
+      expect(mockExecFileSync.mock.calls.flat().join(" ")).not.toContain("ditto");
     });
 
     it("should throw on reattach timeout with submission ID", async () => {
@@ -272,18 +337,68 @@ describe("notarize-macos", () => {
         /Notarization wait timed out.*sub-existing/
       );
     });
+  });
 
-    it("should throw when reattached wait returns not accepted", async () => {
+  describe("staple-only from accepted state", () => {
+    beforeEach(() => {
+      mockExistsSync.mockReturnValue(true);
+    });
+
+    it("should staple directly without submit or wait", async () => {
       mockReadFileSync.mockReturnValue(
         JSON.stringify({
-          "3": { submissionId: "sub-existing", status: "submitted", timestamp: "2026-01-01" },
+          "3": { submissionId: "sub-accepted", status: "accepted", timestamp: "2026-01-01" },
         })
       );
-      mockExecFileSync.mockReturnValueOnce(
-        JSON.stringify({ id: "sub-existing", status: "Invalid" })
+      mockExecFileSync.mockReturnValueOnce("stapled");
+
+      await afterSign(createContext());
+
+      expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+      const stapleCall = mockExecFileSync.mock.calls[0];
+      expect(stapleCall[1]).toContain("stapler");
+      expect(stapleCall[1]).toContain("staple");
+    });
+
+    it("should throw when staple fails in recovery", async () => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          "3": { submissionId: "sub-accepted", status: "accepted", timestamp: "2026-01-01" },
+        })
       );
 
-      await expect(afterSign(createContext())).rejects.toThrow(/Notarization not accepted/);
+      const err = new Error("staple error");
+      (err as any).stderr = "staple failed";
+      mockExecFileSync.mockImplementationOnce(() => {
+        throw err;
+      });
+
+      await expect(afterSign(createContext())).rejects.toThrow(/Stapling failed/);
+
+      // State should remain "accepted" for retry
+      const tmpWrites = mockWriteFileSync.mock.calls.filter((c: any[]) => c[0].endsWith(".tmp"));
+      expect(tmpWrites.length).toBe(0);
+    });
+  });
+
+  describe("corrupted state file", () => {
+    it("should warn and start fresh when state is unparseable", async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue("{{{ not json");
+
+      mockExecFileSync
+        .mockReturnValueOnce("") // ditto
+        .mockReturnValueOnce(JSON.stringify({ id: "sub-fresh", status: "In Progress" }))
+        .mockReturnValueOnce(JSON.stringify({ id: "sub-fresh", status: "Accepted" }))
+        .mockReturnValueOnce("stapled");
+
+      await afterSign(createContext());
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[notarize-macos] Could not parse notarization state file — starting fresh"
+      );
+      // Should do a fresh submit (ditto + submit + wait + staple)
+      expect(mockExecFileSync.mock.calls[1][1]).toContain("submit");
     });
   });
 
@@ -294,6 +409,7 @@ describe("notarize-macos", () => {
         throw new Error("ENOENT");
       });
       mockExecFileSync
+        .mockReturnValueOnce("") // ditto
         .mockReturnValueOnce(JSON.stringify({ id: "sub-x64", status: "In Progress" }))
         .mockReturnValueOnce(JSON.stringify({ id: "sub-x64", status: "Accepted" }))
         .mockReturnValueOnce("stapled");
@@ -313,14 +429,15 @@ describe("notarize-macos", () => {
         })
       );
       mockExecFileSync
+        .mockReturnValueOnce("") // ditto
         .mockReturnValueOnce(JSON.stringify({ id: "sub-arm64", status: "In Progress" }))
         .mockReturnValueOnce(JSON.stringify({ id: "sub-arm64", status: "Accepted" }))
         .mockReturnValueOnce("stapled");
 
       await afterSign(createContext({ arch: 3 }));
 
-      // First call should be submit (not wait), because arch 3 != 1
-      expect(mockExecFileSync.mock.calls[0][1]).toContain("submit");
+      // Should submit (not wait), because arch 3 !== 1
+      expect(mockExecFileSync.mock.calls[1][1]).toContain("submit");
     });
   });
 
@@ -334,13 +451,14 @@ describe("notarize-macos", () => {
 
     it("should pass Apple API credentials to notarytool", async () => {
       mockExecFileSync
+        .mockReturnValueOnce("") // ditto
         .mockReturnValueOnce(JSON.stringify({ id: "sub-cred", status: "In Progress" }))
         .mockReturnValueOnce(JSON.stringify({ id: "sub-cred", status: "Accepted" }))
         .mockReturnValueOnce("stapled");
 
       await afterSign(createContext());
 
-      const submitArgs = mockExecFileSync.mock.calls[0][1];
+      const submitArgs = mockExecFileSync.mock.calls[1][1];
       expect(submitArgs).toContain("--key");
       expect(submitArgs).toContain("/tmp/key.p8");
       expect(submitArgs).toContain("--key-id");

--- a/scripts/notarize-macos.test.ts
+++ b/scripts/notarize-macos.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import path from "path";
+import Module from "module";
+
+const mockExecFileSync = vi.fn();
+const mockExistsSync = vi.fn();
+const mockReadFileSync = vi.fn();
+const mockWriteFileSync = vi.fn();
+const mockRenameSync = vi.fn();
+const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+const originalPlatform = process.platform;
+
+afterAll(() => {
+  consoleLogSpy.mockRestore();
+  consoleWarnSpy.mockRestore();
+  Object.defineProperty(process, "platform", { value: originalPlatform });
+});
+
+function setPlatform(platform: string) {
+  Object.defineProperty(process, "platform", { value: platform });
+}
+
+function createContext(overrides: Record<string, any> = {}) {
+  return {
+    appOutDir: "/build/mac-arm64",
+    outDir: "/build/release",
+    packager: { appInfo: { productFilename: "Daintree" } },
+    arch: 3,
+    ...overrides,
+  };
+}
+
+function mockFs() {
+  return {
+    existsSync: mockExistsSync,
+    readFileSync: mockReadFileSync,
+    writeFileSync: mockWriteFileSync,
+    renameSync: mockRenameSync,
+  };
+}
+
+function setAppleCredentials() {
+  process.env.APPLE_API_KEY = "/tmp/key.p8";
+  process.env.APPLE_API_KEY_ID = "ABC123";
+  process.env.APPLE_API_ISSUER = "abc-123-456";
+}
+
+function clearAppleCredentials() {
+  delete process.env.APPLE_API_KEY;
+  delete process.env.APPLE_API_KEY_ID;
+  delete process.env.APPLE_API_ISSUER;
+}
+
+describe("notarize-macos", () => {
+  let afterSign: (context: any) => Promise<void>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleLogSpy.mockImplementation(() => {});
+    consoleWarnSpy.mockImplementation(() => {});
+    delete process.env.DAINTREE_SKIP_NOTARIZATION;
+    setAppleCredentials();
+    setPlatform("darwin");
+
+    const originalRequire = Module.prototype.require;
+
+    Module.prototype.require = function (id: string) {
+      if (id === "fs") return mockFs();
+      if (id === "child_process") return { execFileSync: mockExecFileSync };
+      return originalRequire.apply(this, [id]);
+    };
+
+    try {
+      delete require.cache[require.resolve("./notarize-macos.cjs")];
+      const module = require("./notarize-macos.cjs");
+      afterSign = module.default;
+    } finally {
+      Module.prototype.require = originalRequire;
+    }
+  });
+
+  it("should return early on non-macOS", async () => {
+    setPlatform("linux");
+    await afterSign(createContext());
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it("should return early when DAINTREE_SKIP_NOTARIZATION is set", async () => {
+    process.env.DAINTREE_SKIP_NOTARIZATION = "true";
+    mockExistsSync.mockReturnValue(true);
+    await afterSign(createContext());
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      "[notarize-macos] Skipping notarization (DAINTREE_SKIP_NOTARIZATION=true)"
+    );
+  });
+
+  it("should skip when credentials are missing", async () => {
+    clearAppleCredentials();
+    mockExistsSync.mockReturnValue(true);
+    await afterSign(createContext());
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      "[notarize-macos] Apple API credentials not set — skipping notarization"
+    );
+  });
+
+  it("should throw when .app bundle is missing", async () => {
+    mockExistsSync.mockReturnValue(false);
+    await expect(afterSign(createContext())).rejects.toThrow(/App bundle not found/);
+  });
+
+  describe("fresh submission", () => {
+    beforeEach(() => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockImplementation(() => {
+        throw new Error("ENOENT");
+      });
+    });
+
+    it("should submit, wait, and staple", async () => {
+      mockExecFileSync
+        .mockReturnValueOnce(JSON.stringify({ id: "sub-123", status: "In Progress" }))
+        .mockReturnValueOnce(JSON.stringify({ id: "sub-123", status: "Accepted" }))
+        .mockReturnValueOnce("stapled");
+
+      await afterSign(createContext());
+
+      expect(mockExecFileSync).toHaveBeenCalledTimes(3);
+
+      const submitCall = mockExecFileSync.mock.calls[0];
+      expect(submitCall[0]).toBe("xcrun");
+      expect(submitCall[1]).toContain("notarytool");
+      expect(submitCall[1]).toContain("submit");
+
+      const waitCall = mockExecFileSync.mock.calls[1];
+      expect(waitCall[1]).toContain("wait");
+      expect(waitCall[1]).toContain("sub-123");
+      expect(waitCall[1]).toContain("--timeout");
+
+      const stapleCall = mockExecFileSync.mock.calls[2];
+      expect(stapleCall[1]).toContain("stapler");
+      expect(stapleCall[1]).toContain("staple");
+
+      expect(mockWriteFileSync).toHaveBeenCalled();
+      expect(mockRenameSync).toHaveBeenCalled();
+    });
+
+    it("should persist state immediately after submit, before wait", async () => {
+      mockExecFileSync
+        .mockReturnValueOnce(JSON.stringify({ id: "sub-456", status: "In Progress" }))
+        .mockReturnValueOnce(JSON.stringify({ id: "sub-456", status: "Accepted" }))
+        .mockReturnValueOnce("stapled");
+
+      await afterSign(createContext());
+
+      const tmpCallIndex = mockWriteFileSync.mock.calls.findIndex((c: any[]) =>
+        c[0].endsWith(".tmp")
+      );
+      expect(tmpCallIndex).toBeGreaterThan(-1);
+
+      const firstWrite = JSON.parse(mockWriteFileSync.mock.calls[tmpCallIndex][1]);
+      expect(firstWrite["3"].status).toBe("submitted");
+    });
+
+    it("should throw when submit fails", async () => {
+      const err = new Error("submit error");
+      (err as any).stderr = "Network error";
+      mockExecFileSync.mockImplementationOnce(() => {
+        throw err;
+      });
+
+      await expect(afterSign(createContext())).rejects.toThrow(/Submission failed/);
+    });
+
+    it("should throw when submit returns non-JSON", async () => {
+      mockExecFileSync.mockReturnValueOnce("not json {{{");
+
+      await expect(afterSign(createContext())).rejects.toThrow(/Submission failed/);
+    });
+
+    it("should throw when submit returns no id", async () => {
+      mockExecFileSync.mockReturnValueOnce(JSON.stringify({ status: "error" }));
+
+      await expect(afterSign(createContext())).rejects.toThrow(/No submission ID/);
+    });
+
+    it("should throw when wait times out (exit 124)", async () => {
+      mockExecFileSync.mockReturnValueOnce(
+        JSON.stringify({ id: "sub-789", status: "In Progress" })
+      );
+
+      const err = new Error("timed out");
+      (err as any).status = 124;
+      mockExecFileSync.mockImplementationOnce(() => {
+        throw err;
+      });
+
+      await expect(afterSign(createContext())).rejects.toThrow(
+        /Notarization wait timed out.*sub-789/
+      );
+
+      // State was persisted with submission ID before the wait
+      const tmpWrites = mockWriteFileSync.mock.calls.filter((c: any[]) => c[0].endsWith(".tmp"));
+      const lastWrite = JSON.parse(tmpWrites[tmpWrites.length - 1][1]);
+      expect(lastWrite["3"].submissionId).toBe("sub-789");
+      expect(lastWrite["3"].status).toBe("submitted");
+    });
+
+    it("should throw when notarization is rejected", async () => {
+      mockExecFileSync
+        .mockReturnValueOnce(JSON.stringify({ id: "sub-000", status: "In Progress" }))
+        .mockReturnValueOnce(JSON.stringify({ id: "sub-000", status: "Invalid" }));
+
+      await expect(afterSign(createContext())).rejects.toThrow(/Notarization not accepted/);
+    });
+
+    it("should throw when staple fails", async () => {
+      mockExecFileSync
+        .mockReturnValueOnce(JSON.stringify({ id: "sub-111", status: "In Progress" }))
+        .mockReturnValueOnce(JSON.stringify({ id: "sub-111", status: "Accepted" }));
+
+      const err = new Error("staple error");
+      (err as any).stderr = "staple failed";
+      mockExecFileSync.mockImplementationOnce(() => {
+        throw err;
+      });
+
+      await expect(afterSign(createContext())).rejects.toThrow(/Stapling failed/);
+    });
+  });
+
+  describe("reattach from prior state", () => {
+    beforeEach(() => {
+      mockExistsSync.mockReturnValue(true);
+    });
+
+    it("should reattach instead of resubmitting", async () => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          "3": { submissionId: "sub-existing", status: "submitted", timestamp: "2026-01-01" },
+        })
+      );
+      mockExecFileSync
+        .mockReturnValueOnce(JSON.stringify({ id: "sub-existing", status: "Accepted" }))
+        .mockReturnValueOnce("stapled");
+
+      await afterSign(createContext());
+
+      expect(mockExecFileSync).toHaveBeenCalledTimes(2);
+      expect(mockExecFileSync.mock.calls[0][1]).toContain("wait");
+      expect(mockExecFileSync.mock.calls[0][1]).toContain("sub-existing");
+      expect(mockExecFileSync.mock.calls[1][1]).toContain("staple");
+    });
+
+    it("should throw on reattach timeout with submission ID", async () => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          "3": { submissionId: "sub-existing", status: "submitted", timestamp: "2026-01-01" },
+        })
+      );
+
+      const err = new Error("timed out");
+      (err as any).status = 124;
+      mockExecFileSync.mockImplementationOnce(() => {
+        throw err;
+      });
+
+      await expect(afterSign(createContext())).rejects.toThrow(
+        /Notarization wait timed out.*sub-existing/
+      );
+    });
+
+    it("should throw when reattached wait returns not accepted", async () => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          "3": { submissionId: "sub-existing", status: "submitted", timestamp: "2026-01-01" },
+        })
+      );
+      mockExecFileSync.mockReturnValueOnce(
+        JSON.stringify({ id: "sub-existing", status: "Invalid" })
+      );
+
+      await expect(afterSign(createContext())).rejects.toThrow(/Notarization not accepted/);
+    });
+  });
+
+  describe("arch isolation", () => {
+    it("should use context.arch as state key", async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockImplementation(() => {
+        throw new Error("ENOENT");
+      });
+      mockExecFileSync
+        .mockReturnValueOnce(JSON.stringify({ id: "sub-x64", status: "In Progress" }))
+        .mockReturnValueOnce(JSON.stringify({ id: "sub-x64", status: "Accepted" }))
+        .mockReturnValueOnce("stapled");
+
+      await afterSign(createContext({ arch: 1 }));
+
+      const tmpWrites = mockWriteFileSync.mock.calls.filter((c: any[]) => c[0].endsWith(".tmp"));
+      const stateWrite = JSON.parse(tmpWrites[0][1]);
+      expect(stateWrite["1"]).toBeDefined();
+      expect(stateWrite["1"].submissionId).toBe("sub-x64");
+    });
+
+    it("should not reattach when state has different arch", async () => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          "1": { submissionId: "sub-x64", status: "submitted", timestamp: "2026-01-01" },
+        })
+      );
+      mockExecFileSync
+        .mockReturnValueOnce(JSON.stringify({ id: "sub-arm64", status: "In Progress" }))
+        .mockReturnValueOnce(JSON.stringify({ id: "sub-arm64", status: "Accepted" }))
+        .mockReturnValueOnce("stapled");
+
+      await afterSign(createContext({ arch: 3 }));
+
+      // First call should be submit (not wait), because arch 3 != 1
+      expect(mockExecFileSync.mock.calls[0][1]).toContain("submit");
+    });
+  });
+
+  describe("credential injection", () => {
+    beforeEach(() => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockImplementation(() => {
+        throw new Error("ENOENT");
+      });
+    });
+
+    it("should pass Apple API credentials to notarytool", async () => {
+      mockExecFileSync
+        .mockReturnValueOnce(JSON.stringify({ id: "sub-cred", status: "In Progress" }))
+        .mockReturnValueOnce(JSON.stringify({ id: "sub-cred", status: "Accepted" }))
+        .mockReturnValueOnce("stapled");
+
+      await afterSign(createContext());
+
+      const submitArgs = mockExecFileSync.mock.calls[0][1];
+      expect(submitArgs).toContain("--key");
+      expect(submitArgs).toContain("/tmp/key.p8");
+      expect(submitArgs).toContain("--key-id");
+      expect(submitArgs).toContain("ABC123");
+      expect(submitArgs).toContain("--issuer");
+      expect(submitArgs).toContain("abc-123-456");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Apple's notarization servers can take a long time to respond, and our only backstop was the 90-minute job-level timeout in the release workflow. When that clock ran out the whole release attempt was dead -- re-tag and retry.

This adds a 30-minute client-side timeout on `xcrun notarytool submit --wait` and a recovery path that picks up the submission ID from a persisted state file. If notarization is still in progress when our timeout fires, the next release run resumes from the saved submission ID instead of starting over.

## Changes

- Added `scripts/notarize-macos.cjs` -- custom notarization script that wraps `xcrun notarytool` with `--timeout 1800`, persists submission state to `.notarization-state.json`, and supports a staple-only recovery mode when the submission already completed server-side
- Added `scripts/notarize-macos.test.ts` -- 470 lines of tests covering the state machine, timeout handling, and recovery paths
- Wired the custom script into `electron-builder.config.cjs` via `MAC_NOTARIZE_SCRIPT` env var
- Updated `.github/workflows/release-macos.yml` to pass the script path and handle the staple-only recovery case

Resolves #9255

## Testing

Unit tests cover the notarization state machine, submission ID persistence, timeout expiry, and staple-only recovery. The workflow change is a passthrough -- notarization still runs through `electron-builder`, just with the custom script wrapping the notarytool calls.