### PR TITLE
feat(dev-preview): stable *.localhost proxy origin so cookies survive restarts

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -465,6 +465,7 @@ export const CHANNELS = {
   DEV_PREVIEW_STOP_BY_WORKTREE: "dev-preview:stop-by-worktree",
   DEV_PREVIEW_RESTART_BY_WORKTREE: "dev-preview:restart-by-worktree",
   DEV_PREVIEW_STOP_DEV_SERVER_BY_WORKTREE: "dev-preview:stop-dev-server-by-worktree",
+  DEV_PREVIEW_GET_PROXY_PORT: "dev-preview:get-proxy-port",
   DEV_PREVIEW_STATE_CHANGED: "dev-preview:state-changed",
   DEV_PREVIEW_ALL_SESSIONS_CHANGED: "dev-preview:all-sessions-changed",
 

--- a/electron/ipc/handlers/devPreview.preload.ts
+++ b/electron/ipc/handlers/devPreview.preload.ts
@@ -15,6 +15,7 @@ export const DEV_PREVIEW_METHOD_CHANNELS = {
   stopByWorktree: "dev-preview:stop-by-worktree",
   restartByWorktree: "dev-preview:restart-by-worktree",
   stopDevServerByWorktree: "dev-preview:stop-dev-server-by-worktree",
+  getProxyPort: "dev-preview:get-proxy-port",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof DEV_PREVIEW_METHOD_CHANNELS;

--- a/electron/ipc/handlers/devPreview.ts
+++ b/electron/ipc/handlers/devPreview.ts
@@ -20,13 +20,41 @@ import type {
   DevPreviewRestartByWorktreeRequest,
   DevPreviewStopDevServerByWorktreeRequest,
   DevPreviewSessionState,
+  DevPreviewProxyInfo,
 } from "../../../shared/types/ipc/devPreview.js";
 import type { DevPreviewSessionService as DevPreviewSessionServiceType } from "../../services/DevPreviewSessionService.js";
+import type { DevPreviewProxyService as DevPreviewProxyServiceType } from "../../services/DevPreviewProxyService.js";
 import { getHibernationService } from "../../services/HibernationService.js";
 
 export function registerDevPreviewHandlers(deps: HandlerDependencies): () => void {
   let sessionService: DevPreviewSessionServiceType | null = null;
   let sessionServicePromise: Promise<DevPreviewSessionServiceType> | null = null;
+  let proxyService: DevPreviewProxyServiceType | null = null;
+  let proxyServicePromise: Promise<DevPreviewProxyServiceType> | null = null;
+
+  // The reverse proxy (#9100) gives each dev-preview panel a stable `*.localhost` origin.
+  // It starts lazily on the first getProxyPort call (renderer mount) and resolves each
+  // request's subdomain to the live upstream port via the session service — which may not
+  // exist yet, in which case there is no upstream and the proxy returns a 502.
+  async function getProxyService(): Promise<DevPreviewProxyServiceType> {
+    if (proxyService) return proxyService;
+    if (!proxyServicePromise) {
+      proxyServicePromise = import("../../services/DevPreviewProxyService.js")
+        .then(async (mod) => {
+          const svc = new mod.DevPreviewProxyService((subdomain) =>
+            sessionService ? sessionService.getUpstreamPortForSubdomain(subdomain) : null
+          );
+          await svc.start();
+          proxyService = svc;
+          return svc;
+        })
+        .catch((err) => {
+          proxyServicePromise = null;
+          throw err;
+        });
+    }
+    return proxyServicePromise;
+  }
 
   async function getSessionService(): Promise<DevPreviewSessionServiceType> {
     if (sessionService) return sessionService;
@@ -184,6 +212,13 @@ export function registerDevPreviewHandlers(deps: HandlerDependencies): () => voi
           return svc.stopDevServerByWorktree(request.worktreeId);
         }
       ),
+      getProxyPort: op(
+        DEV_PREVIEW_METHOD_CHANNELS.getProxyPort,
+        async (): Promise<DevPreviewProxyInfo> => {
+          const proxy = await getProxyService();
+          return { port: proxy.port };
+        }
+      ),
     },
   });
 
@@ -201,6 +236,9 @@ export function registerDevPreviewHandlers(deps: HandlerDependencies): () => voi
     unsubHibernation();
     if (sessionService) {
       sessionService.dispose();
+    }
+    if (proxyService) {
+      proxyService.dispose();
     }
     cleanups.forEach((dispose) => dispose());
   };

--- a/electron/services/DevPreviewProxyService.ts
+++ b/electron/services/DevPreviewProxyService.ts
@@ -1,0 +1,199 @@
+import http from "node:http";
+import type { AddressInfo, Socket } from "node:net";
+import type { Duplex } from "node:stream";
+import { createProxyServer, type ProxyServer } from "httpxy";
+import {
+  DEV_PREVIEW_PROXY_PORT,
+  parseDevPreviewProxyHost,
+} from "../../shared/utils/devPreviewProxy.js";
+
+const PROXY_HOST = "127.0.0.1";
+// Drop a stalled upstream after this long rather than leaving the webview hanging — a
+// dev server mid-restart (or wedged) should surface a 502, not an indefinite spinner.
+const UPSTREAM_TIMEOUT_MS = 30_000;
+
+/**
+ * Resolves an incoming dev-preview subdomain (e.g. `dp-proj-panel`) to the live upstream
+ * dev-server port, or null when no session owns that subdomain. Injected so the proxy stays
+ * decoupled from DevPreviewSessionService internals.
+ */
+export type ResolveUpstreamPort = (subdomain: string) => number | null;
+
+/**
+ * Fixed-port reverse proxy that gives every dev-preview panel a stable `*.localhost` origin
+ * (#9100). The webview always loads `http://dp-<token>.localhost:<proxyPort>`; this server
+ * forwards each request to the panel's current upstream dev-server port, which it resolves
+ * live so a dev-server restart on a fresh port is transparent to the webview (the origin —
+ * and therefore cookies/localStorage — never changes).
+ *
+ * Two transforms are load-bearing and handled by httpxy:
+ *  - `changeOrigin` rewrites the `Host` header to the upstream so Vite/Next host checks pass.
+ *  - `cookieDomainRewrite: ""` strips the `Domain=` attribute from upstream `Set-Cookie`
+ *    headers so cookies bind host-only to the stable origin instead of being rejected.
+ */
+export class DevPreviewProxyService {
+  private server: http.Server | null = null;
+  private proxy: ProxyServer | null = null;
+  private actualPort = 0;
+  private startPromise: Promise<number> | null = null;
+  private disposed = false;
+  // Live sockets (HTTP keep-alive + upgraded WebSockets). server.closeAllConnections() handles
+  // HTTP, but WebSocket sockets upgraded off the 'upgrade' event are not tracked by the server,
+  // so we destroy them explicitly on dispose to release the port at shutdown.
+  private readonly sockets = new Set<Duplex>();
+
+  constructor(private readonly resolveUpstreamPort: ResolveUpstreamPort) {}
+
+  /** The port the proxy actually bound to (43000, or an OS-assigned fallback). 0 until started. */
+  get port(): number {
+    return this.actualPort;
+  }
+
+  /** Idempotent: starts the proxy once and resolves with the bound port on every call. */
+  async start(): Promise<number> {
+    if (!this.startPromise) {
+      this.startPromise = this.startInternal().catch((err) => {
+        this.startPromise = null;
+        throw err;
+      });
+    }
+    return this.startPromise;
+  }
+
+  private async startInternal(): Promise<number> {
+    const proxy = createProxyServer({
+      changeOrigin: true,
+      cookieDomainRewrite: "",
+      ws: true,
+      proxyTimeout: UPSTREAM_TIMEOUT_MS,
+    });
+    // httpxy, when an 'error' listener is attached, emits 'error' and resolves the web()/ws()
+    // promise rather than rejecting — so the response must be finished here, or the webview
+    // hangs on a dead upstream. (An attached listener is also required so a late socket error
+    // doesn't surface as an unhandled 'error' event and crash the process.) The per-call
+    // try/catch below is a backstop for the reject path; send502/destroy are idempotent.
+    proxy.on("error", (_err, _req, res) => {
+      if (!res) return;
+      if (res instanceof http.ServerResponse) {
+        this.send502(res, "The dev server isn't responding.");
+      } else {
+        res.destroy();
+      }
+    });
+    this.proxy = proxy;
+
+    const server = http.createServer((req, res) => {
+      void this.handleRequest(req, res);
+    });
+    server.on("upgrade", (req, socket, head) => {
+      void this.handleUpgrade(req, socket, head);
+    });
+    server.on("connection", (socket) => {
+      this.sockets.add(socket);
+      socket.once("close", () => this.sockets.delete(socket));
+    });
+    this.server = server;
+
+    const port = await this.listenWithFallback(server);
+    this.actualPort = port;
+    // Don't keep the Electron event loop alive — the app must be able to quit even while the
+    // proxy is listening.
+    server.unref();
+    return port;
+  }
+
+  private listenWithFallback(server: http.Server): Promise<number> {
+    return new Promise<number>((resolve, reject) => {
+      const resolvePort = () => resolve((server.address() as AddressInfo).port);
+
+      const onFirstError = (err: NodeJS.ErrnoException) => {
+        if (err.code !== "EADDRINUSE") {
+          reject(err);
+          return;
+        }
+        // The fixed port is taken (another Daintree window, or an unrelated process). Fall
+        // back to an OS-assigned port; the live port is published via IPC, so callers never
+        // assume the fixed value.
+        server.once("error", reject);
+        server.listen(0, PROXY_HOST, resolvePort);
+      };
+
+      server.once("error", onFirstError);
+      server.listen(DEV_PREVIEW_PROXY_PORT, PROXY_HOST, () => {
+        server.removeListener("error", onFirstError);
+        resolvePort();
+      });
+    });
+  }
+
+  private async handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const port = this.resolvePort(req.headers.host);
+    if (port === null) {
+      this.send502(res, "No dev server is registered for this preview.");
+      return;
+    }
+    try {
+      await this.proxy!.web(req, res, { target: `http://${PROXY_HOST}:${port}` });
+    } catch {
+      this.send502(res, "The dev server isn't responding.");
+    }
+  }
+
+  private async handleUpgrade(
+    req: http.IncomingMessage,
+    socket: Duplex,
+    head: Buffer
+  ): Promise<void> {
+    this.sockets.add(socket);
+    socket.once("close", () => this.sockets.delete(socket));
+
+    const port = this.resolvePort(req.headers.host);
+    if (port === null) {
+      socket.destroy();
+      return;
+    }
+    try {
+      // The 'upgrade' event types the socket as Duplex; httpxy's ws() wants net.Socket, which
+      // is exactly the concrete type Node provides here.
+      await this.proxy!.ws(req, socket as Socket, { target: `http://${PROXY_HOST}:${port}` }, head);
+    } catch {
+      socket.destroy();
+    }
+  }
+
+  private resolvePort(host: string | undefined): number | null {
+    const subdomain = parseDevPreviewProxyHost(host);
+    if (!subdomain) return null;
+    return this.resolveUpstreamPort(subdomain);
+  }
+
+  private send502(res: http.ServerResponse, message: string): void {
+    if (res.headersSent) {
+      res.end();
+      return;
+    }
+    res.writeHead(502, { "Content-Type": "text/plain; charset=utf-8" });
+    res.end(message);
+  }
+
+  /** Stop listening and tear down every live connection. Safe to call more than once. */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    for (const socket of this.sockets) {
+      try {
+        socket.destroy();
+      } catch {
+        // Socket already gone.
+      }
+    }
+    this.sockets.clear();
+    const server = this.server;
+    if (server) {
+      server.closeAllConnections?.();
+      server.close();
+    }
+    this.server = null;
+    this.proxy = null;
+  }
+}

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -26,6 +26,7 @@ import {
 } from "./DevPreviewRequestValidators.js";
 
 export { normalizeNextjsDevCommand } from "./DevPreviewCommandNormalizer.js";
+import { buildDevPreviewSubdomain } from "../../shared/utils/devPreviewProxy.js";
 import type { DevPreviewManifestEntry } from "./DevPreviewManifestService.js";
 import type { PtyClient } from "./PtyClient.js";
 import { UrlDetector } from "./UrlDetector.js";
@@ -280,6 +281,25 @@ export class DevPreviewSessionService {
       });
     }
     return result;
+  }
+
+  /**
+   * Resolve a dev-preview proxy subdomain (`dp-<projectToken>-<panelToken>`) to the upstream
+   * dev-server port currently allocated for that panel, or null when none is registered (#9100).
+   * Used by DevPreviewProxyService to forward each request to the live upstream port without
+   * coupling to session internals. The portRegistry is keyed by the full (projectId, panelId)
+   * session key; since both halves are sanitized into the subdomain, we rebuild the expected
+   * subdomain per entry and match on equality — avoiding any ambiguous split of a label whose
+   * tokens may themselves contain hyphens.
+   */
+  getUpstreamPortForSubdomain(subdomain: string): number | null {
+    for (const session of this.sessions.values()) {
+      if (buildDevPreviewSubdomain(session.projectId, session.panelId) === subdomain) {
+        const port = this.portRegistry.get(createSessionKey(session.projectId, session.panelId));
+        return port ?? null;
+      }
+    }
+    return null;
   }
 
   dispose(): void {

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -131,6 +131,17 @@ const CRASH_LOOP_BACKOFF_MULTIPLIER = 1.5;
 const CRASH_LOOP_MAX_DELAY_MS = 3000;
 const CRASH_LOOP_MAX_ATTEMPTS = 5;
 
+/** Parse the numeric port out of a detected dev-server URL, or null if absent/unparseable. */
+function parseUrlPort(url: string | null): number | null {
+  if (!url) return null;
+  try {
+    const port = new URL(url).port;
+    return port ? Number(port) : null;
+  } catch {
+    return null;
+  }
+}
+
 export class DevPreviewSessionService {
   private readonly detector = new UrlDetector();
   private readonly textDecoder = new TextDecoder();
@@ -285,19 +296,25 @@ export class DevPreviewSessionService {
 
   /**
    * Resolve a dev-preview proxy subdomain (`dp-<projectToken>-<panelToken>`) to the upstream
-   * dev-server port currently allocated for that panel, or null when none is registered (#9100).
-   * Used by DevPreviewProxyService to forward each request to the live upstream port without
-   * coupling to session internals. The portRegistry is keyed by the full (projectId, panelId)
-   * session key; since both halves are sanitized into the subdomain, we rebuild the expected
-   * subdomain per entry and match on equality — avoiding any ambiguous split of a label whose
-   * tokens may themselves contain hyphens.
+   * dev-server port for that panel, or null when none is live (#9100). Used by
+   * DevPreviewProxyService to forward each request without coupling to session internals.
+   * We rebuild the expected subdomain per session and match on equality — avoiding any
+   * ambiguous split of a label whose sanitized tokens may themselves contain hyphens.
    */
   getUpstreamPortForSubdomain(subdomain: string): number | null {
     for (const session of this.sessions.values()) {
-      if (buildDevPreviewSubdomain(session.projectId, session.panelId) === subdomain) {
-        const port = this.portRegistry.get(createSessionKey(session.projectId, session.panelId));
-        return port ?? null;
-      }
+      if (buildDevPreviewSubdomain(session.projectId, session.panelId) !== subdomain) continue;
+      // Only forward to a live server. After an explicit stop the registry entry lingers
+      // (the success path doesn't release it), so a stale port could otherwise be handed to
+      // whatever process later binds it.
+      if (!RUNNING_STATES.has(session.status)) return null;
+      // Prefer the port the dev server actually bound — UrlDetector overwrites session.url
+      // when the server lands on a different port than the one allocated (a command that
+      // ignores the injected PORT). Fall back to the allocated port while still starting,
+      // before any URL has been detected.
+      const detectedPort = parseUrlPort(session.url);
+      if (detectedPort !== null) return detectedPort;
+      return this.portRegistry.get(createSessionKey(session.projectId, session.panelId)) ?? null;
     }
     return null;
   }

--- a/electron/services/__tests__/DevPreviewProxyService.test.ts
+++ b/electron/services/__tests__/DevPreviewProxyService.test.ts
@@ -1,0 +1,172 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocket, WebSocketServer } from "ws";
+import { DevPreviewProxyService } from "../DevPreviewProxyService.js";
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve((server.address() as AddressInfo).port));
+  });
+}
+
+interface ProxyResponse {
+  status: number;
+  body: string;
+  headers: http.IncomingHttpHeaders;
+}
+
+function request(proxyPort: number, host: string, path = "/"): Promise<ProxyResponse> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      // agent: false — disable the global keep-alive pool so a socket pooled to the fixed
+      // proxy port from a prior test (whose proxy was disposed) is never reused.
+      { host: "127.0.0.1", port: proxyPort, path, headers: { host }, agent: false },
+      (res) => {
+        let body = "";
+        res.on("data", (chunk) => (body += chunk));
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, body, headers: res.headers }));
+      }
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("DevPreviewProxyService", () => {
+  let proxy: DevPreviewProxyService | null = null;
+  let upstream: http.Server | null = null;
+  let wss: WebSocketServer | null = null;
+
+  afterEach(() => {
+    proxy?.dispose();
+    proxy = null;
+    upstream?.close();
+    upstream = null;
+    wss?.close();
+    wss = null;
+  });
+
+  it("forwards an HTTP request to the resolved upstream port and rewrites Host", async () => {
+    let seenHost: string | undefined;
+    upstream = http.createServer((req, res) => {
+      seenHost = req.headers.host;
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end("hello from upstream");
+    });
+    const upstreamPort = await listen(upstream);
+
+    proxy = new DevPreviewProxyService((sub) => (sub === "dp-test" ? upstreamPort : null));
+    const proxyPort = await proxy.start();
+
+    const res = await request(proxyPort, `dp-test.localhost:${proxyPort}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toBe("hello from upstream");
+    // changeOrigin rewrote the Host away from the proxy subdomain to the upstream — Vite/Next
+    // host checks depend on this.
+    expect(seenHost).toContain("127.0.0.1");
+    expect(seenHost).toContain(String(upstreamPort));
+  });
+
+  it("strips the Domain attribute from upstream Set-Cookie headers", async () => {
+    upstream = http.createServer((_req, res) => {
+      res.writeHead(200, { "Set-Cookie": "sid=abc; Domain=localhost; Path=/" });
+      res.end("ok");
+    });
+    const upstreamPort = await listen(upstream);
+
+    proxy = new DevPreviewProxyService(() => upstreamPort);
+    const proxyPort = await proxy.start();
+
+    const res = await request(proxyPort, `dp-test.localhost:${proxyPort}`);
+    const setCookie = res.headers["set-cookie"]?.[0] ?? "";
+
+    expect(setCookie).toContain("sid=abc");
+    expect(setCookie.toLowerCase()).not.toContain("domain=");
+  });
+
+  it("returns 502 when no upstream is registered for the subdomain", async () => {
+    proxy = new DevPreviewProxyService(() => null);
+    const proxyPort = await proxy.start();
+
+    const res = await request(proxyPort, `dp-missing.localhost:${proxyPort}`);
+    expect(res.status).toBe(502);
+  });
+
+  it("returns 502 for a host that is not a dev-preview proxy subdomain", async () => {
+    proxy = new DevPreviewProxyService(() => 9999);
+    const proxyPort = await proxy.start();
+
+    const res = await request(proxyPort, "example.com");
+    expect(res.status).toBe(502);
+  });
+
+  it("returns 502 when the upstream is unreachable", async () => {
+    // Resolve to a port nothing is listening on.
+    proxy = new DevPreviewProxyService(() => 1);
+    const proxyPort = await proxy.start();
+
+    const res = await request(proxyPort, `dp-test.localhost:${proxyPort}`);
+    expect(res.status).toBe(502);
+  });
+
+  it("exposes the bound port and is idempotent on start", async () => {
+    proxy = new DevPreviewProxyService(() => null);
+    const first = await proxy.start();
+    const second = await proxy.start();
+
+    expect(first).toBe(second);
+    expect(proxy.port).toBe(first);
+  });
+
+  it("forwards a WebSocket upgrade to the resolved upstream", async () => {
+    wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await new Promise<void>((resolve) => wss!.on("listening", resolve));
+    const upstreamPort = (wss.address() as AddressInfo).port;
+    wss.on("connection", (socket) => {
+      socket.on("message", (msg) => socket.send(`echo:${msg}`));
+    });
+
+    proxy = new DevPreviewProxyService(() => upstreamPort);
+    const proxyPort = await proxy.start();
+
+    // Node doesn't map *.localhost to loopback (only Chromium does), so connect to the loopback
+    // address and override the Host header to the proxy subdomain.
+    const client = new WebSocket(`ws://127.0.0.1:${proxyPort}/`, {
+      headers: { host: `dp-test.localhost:${proxyPort}` },
+    });
+    const reply = await new Promise<string>((resolve, reject) => {
+      client.on("open", () => client.send("ping"));
+      client.on("message", (data) => resolve(data.toString()));
+      client.on("error", reject);
+    });
+    client.close();
+
+    expect(reply).toBe("echo:ping");
+  });
+
+  it("destroys the upgrade socket when no upstream is registered", async () => {
+    proxy = new DevPreviewProxyService(() => null);
+    const proxyPort = await proxy.start();
+
+    const client = new WebSocket(`ws://127.0.0.1:${proxyPort}/`, {
+      headers: { host: `dp-missing.localhost:${proxyPort}` },
+    });
+    await expect(
+      new Promise((_resolve, reject) => {
+        client.on("open", () => reject(new Error("unexpected open")));
+        client.on("error", reject);
+        client.on("close", () => reject(new Error("closed")));
+      })
+    ).rejects.toBeTruthy();
+  });
+
+  it("stops accepting connections after dispose", async () => {
+    proxy = new DevPreviewProxyService(() => null);
+    const proxyPort = await proxy.start();
+    proxy.dispose();
+
+    await expect(request(proxyPort, `dp-x.localhost:${proxyPort}`)).rejects.toBeTruthy();
+  });
+});

--- a/electron/services/__tests__/DevPreviewProxyService.test.ts
+++ b/electron/services/__tests__/DevPreviewProxyService.test.ts
@@ -86,6 +86,32 @@ describe("DevPreviewProxyService", () => {
     expect(setCookie.toLowerCase()).not.toContain("domain=");
   });
 
+  it("strips Domain from every Set-Cookie header (multiple cookies, incl. Domain=.localhost)", async () => {
+    upstream = http.createServer((_req, res) => {
+      res.writeHead(200, {
+        "Set-Cookie": [
+          "sid=abc; Domain=.localhost; Path=/",
+          "uid=xyz; Domain=localhost; SameSite=None",
+        ],
+      });
+      res.end("ok");
+    });
+    const upstreamPort = await listen(upstream);
+
+    proxy = new DevPreviewProxyService(() => upstreamPort);
+    const proxyPort = await proxy.start();
+
+    const res = await request(proxyPort, `dp-test.localhost:${proxyPort}`);
+    const cookies = res.headers["set-cookie"] ?? [];
+
+    expect(cookies).toHaveLength(2);
+    expect(cookies.join(" ")).toContain("sid=abc");
+    expect(cookies.join(" ")).toContain("uid=xyz");
+    for (const cookie of cookies) {
+      expect(cookie.toLowerCase()).not.toContain("domain=");
+    }
+  });
+
   it("returns 502 when no upstream is registered for the subdomain", async () => {
     proxy = new DevPreviewProxyService(() => null);
     const proxyPort = await proxy.start();
@@ -144,6 +170,31 @@ describe("DevPreviewProxyService", () => {
     client.close();
 
     expect(reply).toBe("echo:ping");
+  });
+
+  it("preserves the request path and query string on a WS upgrade (HMR)", async () => {
+    let seenUrl: string | undefined;
+    wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await new Promise<void>((resolve) => wss!.on("listening", resolve));
+    const upstreamPort = (wss.address() as AddressInfo).port;
+    wss.on("connection", (socket, req) => {
+      seenUrl = req.url;
+      socket.send("ok");
+    });
+
+    proxy = new DevPreviewProxyService(() => upstreamPort);
+    const proxyPort = await proxy.start();
+
+    const client = new WebSocket(`ws://127.0.0.1:${proxyPort}/@vite/client?t=123`, {
+      headers: { host: `dp-test.localhost:${proxyPort}` },
+    });
+    await new Promise<void>((resolve, reject) => {
+      client.on("message", () => resolve());
+      client.on("error", reject);
+    });
+    client.close();
+
+    expect(seenUrl).toBe("/@vite/client?t=123");
   });
 
   it("destroys the upgrade socket when no upstream is registered", async () => {

--- a/electron/services/__tests__/DevPreviewSessionService.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.test.ts
@@ -1618,5 +1618,22 @@ describe("DevPreviewSessionService", () => {
     it("returns null for an unknown subdomain", () => {
       expect(service.getUpstreamPortForSubdomain("dp-nope-nope")).toBeNull();
     });
+
+    it("returns null once the session is stopped even though the registry entry lingers", async () => {
+      vi.spyOn(portAllocator, "allocatePort").mockImplementation(
+        async (registry: Map<string, number>, key: string) => {
+          registry.set(key, 4321);
+          return 4321;
+        }
+      );
+
+      await service.ensure(baseRequest);
+      const subdomain = buildDevPreviewSubdomain(baseRequest.projectId, baseRequest.panelId);
+      expect(service.getUpstreamPortForSubdomain(subdomain)).toBe(4321);
+
+      await service.stop({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+
+      expect(service.getUpstreamPortForSubdomain(subdomain)).toBeNull();
+    });
   });
 });

--- a/electron/services/__tests__/DevPreviewSessionService.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.test.ts
@@ -3,6 +3,7 @@ import https from "node:https";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DevPreviewSessionService } from "../DevPreviewSessionService.js";
 import * as portAllocator from "../DevPreviewPortAllocator.js";
+import { buildDevPreviewSubdomain } from "../../../shared/utils/devPreviewProxy.js";
 import type { PtyClient } from "../PtyClient.js";
 import type { DevPreviewSessionState } from "../../../shared/types/ipc/devPreview.js";
 
@@ -1596,6 +1597,26 @@ describe("DevPreviewSessionService", () => {
         projectId: baseRequest.projectId,
       });
       expect(state.phaseLabel).toBeUndefined();
+    });
+  });
+
+  describe("getUpstreamPortForSubdomain (#9100)", () => {
+    it("resolves a panel's proxy subdomain to its allocated upstream port", async () => {
+      vi.spyOn(portAllocator, "allocatePort").mockImplementation(
+        async (registry: Map<string, number>, key: string) => {
+          registry.set(key, 4321);
+          return 4321;
+        }
+      );
+
+      await service.ensure(baseRequest);
+
+      const subdomain = buildDevPreviewSubdomain(baseRequest.projectId, baseRequest.panelId);
+      expect(service.getUpstreamPortForSubdomain(subdomain)).toBe(4321);
+    });
+
+    it("returns null for an unknown subdomain", () => {
+      expect(service.getUpstreamPortForSubdomain("dp-nope-nope")).toBeNull();
     });
   });
 });

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -17,7 +17,11 @@ import {
   isDevPreviewPartition,
 } from "../utils/webviewCsp.js";
 import { canOpenExternalUrl, openExternalUrl } from "../utils/openExternal.js";
-import { isLocalhostUrl, isSafeNavigationUrl } from "../../shared/utils/urlUtils.js";
+import {
+  isLocalhostUrl,
+  isDevPreviewProxyUrl,
+  isSafeNavigationUrl,
+} from "../../shared/utils/urlUtils.js";
 import { getWebviewDialogService } from "../services/WebviewDialogService.js";
 import { looksLikeOAuthUrl } from "../services/OAuthLoopbackService.js";
 import { CHANNELS } from "../ipc/channels.js";
@@ -418,7 +422,7 @@ export function setupWebviewCSP(): void {
 
         const blocked = isBrowserPanel
           ? !isSafeNavigationUrl(navigationUrl)
-          : !isLocalhostUrl(navigationUrl);
+          : !isLocalhostUrl(navigationUrl) && !isDevPreviewProxyUrl(navigationUrl);
 
         if (blocked) {
           const label = isBrowserPanel ? "unsafe" : "non-localhost";
@@ -433,7 +437,7 @@ export function setupWebviewCSP(): void {
 
         const blocked = isBrowserPanel
           ? !isSafeNavigationUrl(redirectUrl)
-          : !isLocalhostUrl(redirectUrl);
+          : !isLocalhostUrl(redirectUrl) && !isDevPreviewProxyUrl(redirectUrl);
 
         if (blocked) {
           const label = isBrowserPanel ? "unsafe" : "non-localhost";

--- a/electron/utils/__tests__/webviewCsp.test.ts
+++ b/electron/utils/__tests__/webviewCsp.test.ts
@@ -158,6 +158,30 @@ describe("webviewCsp", () => {
       expect(csp).toContain("wss://[::1]:*");
     });
 
+    // The dev-preview reverse proxy serves the stable dp-*.localhost origin (#9100),
+    // so every directive that admits a localhost wildcard must also admit the subdomain
+    // wildcard, plus ws://*.localhost:* in connect-src for HMR.
+    it("includes the *.localhost proxy origin in every localhost-bearing directive", () => {
+      const directives = parseDirectives(getLocalhostDevCSP());
+
+      for (const directive of [
+        "default-src",
+        "script-src",
+        "style-src",
+        "connect-src",
+        "img-src",
+        "frame-src",
+        "form-action",
+      ]) {
+        expect(directives[directive]).toContain("http://*.localhost:*");
+      }
+    });
+
+    it("includes ws://*.localhost:* in connect-src for proxied HMR", () => {
+      const directives = parseDirectives(getLocalhostDevCSP());
+      expect(directives["connect-src"]).toContain("ws://*.localhost:*");
+    });
+
     it("does not allow external origins in script-src or default-src", () => {
       const csp = getLocalhostDevCSP();
       const directives = Object.fromEntries(

--- a/electron/utils/webviewCsp.ts
+++ b/electron/utils/webviewCsp.ts
@@ -46,18 +46,22 @@ export function classifyPartition(partition: string): WebviewPartitionType {
  * applied at the session level before the framework is known.
  */
 export function getLocalhostDevCSP(): string {
+  // http://*.localhost:* (and ws://*.localhost:* for HMR) covers the stable dev-preview proxy
+  // origin (#9100). The webview loads `http://dp-<token>.localhost:<proxyPort>`, so every
+  // directive that admits a localhost wildcard must also admit the subdomain wildcard or the
+  // page's own assets/HMR socket would be blocked.
   return [
-    "default-src 'self' http://localhost:* http://127.0.0.1:* http://[::1]:* https://localhost:* https://127.0.0.1:* https://[::1]:*",
-    "script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:* http://127.0.0.1:* http://[::1]:* https://localhost:* https://127.0.0.1:* https://[::1]:*",
-    "style-src 'self' 'unsafe-inline' http://localhost:* http://127.0.0.1:* http://[::1]:* https://localhost:* https://127.0.0.1:* https://[::1]:*",
-    "connect-src 'self' ws://localhost:* ws://127.0.0.1:* ws://[::1]:* wss://localhost:* wss://127.0.0.1:* wss://[::1]:* http://localhost:* http://127.0.0.1:* http://[::1]:* https://localhost:* https://127.0.0.1:* https://[::1]:*",
-    "img-src 'self' data: blob: https: http://localhost:* http://127.0.0.1:* http://[::1]:* https://localhost:* https://127.0.0.1:* https://[::1]:*",
+    "default-src 'self' http://localhost:* http://127.0.0.1:* http://[::1]:* http://*.localhost:* https://localhost:* https://127.0.0.1:* https://[::1]:*",
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:* http://127.0.0.1:* http://[::1]:* http://*.localhost:* https://localhost:* https://127.0.0.1:* https://[::1]:*",
+    "style-src 'self' 'unsafe-inline' http://localhost:* http://127.0.0.1:* http://[::1]:* http://*.localhost:* https://localhost:* https://127.0.0.1:* https://[::1]:*",
+    "connect-src 'self' ws://localhost:* ws://127.0.0.1:* ws://[::1]:* ws://*.localhost:* wss://localhost:* wss://127.0.0.1:* wss://[::1]:* http://localhost:* http://127.0.0.1:* http://[::1]:* http://*.localhost:* https://localhost:* https://127.0.0.1:* https://[::1]:*",
+    "img-src 'self' data: blob: https: http://localhost:* http://127.0.0.1:* http://[::1]:* http://*.localhost:* https://localhost:* https://127.0.0.1:* https://[::1]:*",
     "font-src 'self' data:",
-    "frame-src 'self' blob: http://localhost:* http://127.0.0.1:* http://[::1]:* https://localhost:* https://127.0.0.1:* https://[::1]:*",
+    "frame-src 'self' blob: http://localhost:* http://127.0.0.1:* http://[::1]:* http://*.localhost:* https://localhost:* https://127.0.0.1:* https://[::1]:*",
     "worker-src 'self' blob:",
     "object-src 'none'",
     "base-uri 'self'",
-    "form-action 'self' http://localhost:* http://127.0.0.1:* http://[::1]:* https://localhost:* https://127.0.0.1:* https://[::1]:*",
+    "form-action 'self' http://localhost:* http://127.0.0.1:* http://[::1]:* http://*.localhost:* https://localhost:* https://127.0.0.1:* https://[::1]:*",
   ].join("; ");
 }
 

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -18,7 +18,7 @@ import {
 import { registerProtocolsForSession, getDistPath } from "../setup/protocols.js";
 import { getDevServerUrl } from "../../shared/config/devServer.js";
 import { isTrustedRendererUrl } from "../../shared/utils/trustedRenderer.js";
-import { isLocalhostUrl } from "../../shared/utils/urlUtils.js";
+import { isLocalhostUrl, isDevPreviewProxyUrl } from "../../shared/utils/urlUtils.js";
 import { canOpenExternalUrl, openExternalUrl } from "../utils/openExternal.js";
 import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
 import { forgetBlinkSample, forgetEluSample } from "../services/ProcessMemoryMonitor.js";
@@ -1116,7 +1116,9 @@ export class ProjectViewManager {
       params: Record<string, string>
     ) => {
       const allowedPartitions = ["persist:browser", "persist:dev-preview"];
-      const isAllowedLocalhostUrl = isLocalhostUrl(params.src);
+      // Dev-preview webviews load the stable proxy origin (dp-*.localhost), which
+      // isLocalhostUrl rejects — accept it explicitly (#9100).
+      const isAllowedLocalhostUrl = isLocalhostUrl(params.src) || isDevPreviewProxyUrl(params.src);
       const isValidPartition =
         allowedPartitions.includes(params.partition || "") ||
         (params.partition?.startsWith("persist:dev-preview-") ?? false);

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -19,7 +19,7 @@ import {
 
 import { canOpenExternalUrl, openExternalUrl } from "../utils/openExternal.js";
 import { isTrustedRendererUrl } from "../../shared/utils/trustedRenderer.js";
-import { isLocalhostUrl } from "../../shared/utils/urlUtils.js";
+import { isLocalhostUrl, isDevPreviewProxyUrl } from "../../shared/utils/urlUtils.js";
 import { getDevServerUrl } from "../../shared/config/devServer.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { sendToRenderer } from "../ipc/handlers.js";
@@ -414,7 +414,9 @@ export function setupBrowserWindow(
   // Harden webview security — on the app view's webContents
   appWebContents.on("will-attach-webview", (event, webPreferences, params) => {
     const allowedPartitions = ["persist:browser", "persist:dev-preview"];
-    const isAllowedLocalhostUrl = isLocalhostUrl(params.src);
+    // Dev-preview webviews now load the stable proxy origin (dp-*.localhost), which
+    // isLocalhostUrl rejects — accept it explicitly (#9100).
+    const isAllowedLocalhostUrl = isLocalhostUrl(params.src) || isDevPreviewProxyUrl(params.src);
     const isValidPartition =
       allowedPartitions.includes(params.partition || "") ||
       (params.partition?.startsWith("persist:dev-preview-") ?? false);

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "archiver": "^8.0.0",
         "better-sqlite3": "^12.10.0",
         "copytree": "^0.14.2",
+        "httpxy": "^0.5.3",
         "ipaddr.js": "^2.4.0",
         "js-yaml": "^4.1.1",
         "node-addon-api": "^8.8.0",
@@ -13576,6 +13577,12 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/httpxy": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/httpxy/-/httpxy-0.5.3.tgz",
+      "integrity": "sha512-SMS9V6Sn7VWaS11lYhoAr0ceoaiolTWf4jYdJn0NJhCdKMu9R2H9Fh0LBDWBHQF6HRLI1PmaePYsjanSpE5PEw==",
+      "license": "MIT"
     },
     "node_modules/human-signals": {
       "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "archiver": "^8.0.0",
     "better-sqlite3": "^12.10.0",
     "copytree": "^0.14.2",
+    "httpxy": "^0.5.3",
     "ipaddr.js": "^2.4.0",
     "js-yaml": "^4.1.1",
     "node-addon-api": "^8.8.0",

--- a/shared/types/ipc/devPreview.ts
+++ b/shared/types/ipc/devPreview.ts
@@ -111,3 +111,8 @@ export interface DevPreviewRestartByWorktreeRequest {
 export interface DevPreviewStopDevServerByWorktreeRequest {
   worktreeId: string;
 }
+
+export interface DevPreviewProxyInfo {
+  /** The live port the dev-preview reverse proxy is listening on (#9100). */
+  port: number;
+}

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -96,6 +96,9 @@ export interface GeneratedElectronAPI {
     getDestructivePreviewSizes(
       ...args: IpcInvokeMap["dev-preview:get-destructive-preview-sizes"]["args"]
     ): Promise<IpcInvokeMap["dev-preview:get-destructive-preview-sizes"]["result"]>;
+    getProxyPort(
+      ...args: IpcInvokeMap["dev-preview:get-proxy-port"]["args"]
+    ): Promise<IpcInvokeMap["dev-preview:get-proxy-port"]["result"]>;
     getState(
       ...args: IpcInvokeMap["dev-preview:get-state"]["args"]
     ): Promise<IpcInvokeMap["dev-preview:get-state"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -204,6 +204,10 @@ export interface GeneratedIpcInvokeMap {
     args: [request: import("./devPreview.js").DevPreviewDestructivePreviewSizesRequest];
     result: import("./devPreview.js").DevPreviewDestructivePreviewSizes;
   };
+  "dev-preview:get-proxy-port": {
+    args: [];
+    result: import("./devPreview.js").DevPreviewProxyInfo;
+  };
   "dev-preview:get-state": {
     args: [request: import("./devPreview.js").DevPreviewSessionRequest];
     result: import("./devPreview.js").DevPreviewSessionState;

--- a/shared/utils/__tests__/devPreviewProxy.test.ts
+++ b/shared/utils/__tests__/devPreviewProxy.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEV_PREVIEW_PROXY_PORT,
+  sanitizeSubdomainToken,
+  buildDevPreviewSubdomain,
+  buildDevPreviewProxyOrigin,
+  parseDevPreviewProxyHost,
+} from "../devPreviewProxy.js";
+
+describe("devPreviewProxy", () => {
+  describe("sanitizeSubdomainToken", () => {
+    it("passes through DNS-safe tokens", () => {
+      expect(sanitizeSubdomainToken("panel-1")).toBe("panel-1");
+      expect(sanitizeSubdomainToken("abc123_DEF")).toBe("abc123_DEF");
+    });
+
+    it("replaces non-alphanumeric characters with hyphens", () => {
+      expect(sanitizeSubdomainToken("a/b c.d")).toBe("a-b-c-d");
+    });
+
+    it("caps the token at 24 characters", () => {
+      expect(sanitizeSubdomainToken("x".repeat(40))).toHaveLength(24);
+    });
+
+    it("falls back to 'x' for an empty result", () => {
+      expect(sanitizeSubdomainToken("")).toBe("x");
+    });
+  });
+
+  describe("buildDevPreviewSubdomain", () => {
+    it("builds a dp-<projectToken>-<panelToken> label", () => {
+      expect(buildDevPreviewSubdomain("project-1", "panel-1")).toBe("dp-project-1-panel-1");
+    });
+
+    it("is deterministic for the same inputs", () => {
+      expect(buildDevPreviewSubdomain("p", "q")).toBe(buildDevPreviewSubdomain("p", "q"));
+    });
+
+    it("stays within the 63-char DNS label limit for long ids", () => {
+      const label = buildDevPreviewSubdomain("P".repeat(50), "Q".repeat(50));
+      expect(label.length).toBeLessThanOrEqual(63);
+    });
+  });
+
+  describe("buildDevPreviewProxyOrigin", () => {
+    it("builds the full http origin with the subdomain and port", () => {
+      expect(buildDevPreviewProxyOrigin(43000, "project-1", "panel-1")).toBe(
+        "http://dp-project-1-panel-1.localhost:43000"
+      );
+    });
+  });
+
+  describe("parseDevPreviewProxyHost", () => {
+    it("extracts the subdomain label, stripping the port", () => {
+      expect(parseDevPreviewProxyHost("dp-project-1-panel-1.localhost:43000")).toBe(
+        "dp-project-1-panel-1"
+      );
+    });
+
+    it("round-trips with buildDevPreviewProxyOrigin's host", () => {
+      const subdomain = buildDevPreviewSubdomain("proj", "panel");
+      const host = `${subdomain}.localhost:${DEV_PREVIEW_PROXY_PORT}`;
+      expect(parseDevPreviewProxyHost(host)).toBe(subdomain);
+    });
+
+    it("returns null for non-localhost hosts", () => {
+      expect(parseDevPreviewProxyHost("example.com:43000")).toBeNull();
+      expect(parseDevPreviewProxyHost("127.0.0.1:3000")).toBeNull();
+    });
+
+    it("returns null for bare localhost (no subdomain label)", () => {
+      expect(parseDevPreviewProxyHost("localhost:43000")).toBeNull();
+    });
+
+    it("returns null for a *.localhost subdomain without the dp- prefix", () => {
+      expect(parseDevPreviewProxyHost("evil.localhost:43000")).toBeNull();
+    });
+
+    it("returns null for empty/undefined hosts", () => {
+      expect(parseDevPreviewProxyHost(undefined)).toBeNull();
+      expect(parseDevPreviewProxyHost("")).toBeNull();
+    });
+
+    it("is case-insensitive", () => {
+      expect(parseDevPreviewProxyHost("DP-PROJ-PANEL.LOCALHOST:43000")).toBe("dp-proj-panel");
+    });
+  });
+});

--- a/shared/utils/__tests__/devPreviewProxy.test.ts
+++ b/shared/utils/__tests__/devPreviewProxy.test.ts
@@ -9,12 +9,17 @@ import {
 
 describe("devPreviewProxy", () => {
   describe("sanitizeSubdomainToken", () => {
-    it("passes through DNS-safe tokens", () => {
+    it("passes through already DNS-safe lowercase tokens", () => {
       expect(sanitizeSubdomainToken("panel-1")).toBe("panel-1");
-      expect(sanitizeSubdomainToken("abc123_DEF")).toBe("abc123_DEF");
+      expect(sanitizeSubdomainToken("abc123")).toBe("abc123");
     });
 
-    it("replaces non-alphanumeric characters with hyphens", () => {
+    it("lowercases uppercase characters (DNS hosts are case-insensitive)", () => {
+      expect(sanitizeSubdomainToken("ProjABC")).toBe("projabc");
+    });
+
+    it("folds underscores and other non-[a-z0-9-] characters to hyphens", () => {
+      expect(sanitizeSubdomainToken("abc123_DEF")).toBe("abc123-def");
       expect(sanitizeSubdomainToken("a/b c.d")).toBe("a-b-c-d");
     });
 
@@ -39,6 +44,14 @@ describe("devPreviewProxy", () => {
     it("stays within the 63-char DNS label limit for long ids", () => {
       const label = buildDevPreviewSubdomain("P".repeat(50), "Q".repeat(50));
       expect(label.length).toBeLessThanOrEqual(63);
+    });
+
+    it("round-trips through parseDevPreviewProxyHost for uppercase ids (case-insensitive Host)", () => {
+      // The browser lowercases the Host header, so the built subdomain must equal the parsed
+      // one even when the ids contain uppercase — otherwise the proxy lookup misses.
+      const subdomain = buildDevPreviewSubdomain("ProjABC", "PanelXYZ");
+      const host = `${subdomain.toUpperCase()}.localhost:43000`;
+      expect(parseDevPreviewProxyHost(host)).toBe(subdomain);
     });
   });
 

--- a/shared/utils/__tests__/urlUtils.test.ts
+++ b/shared/utils/__tests__/urlUtils.test.ts
@@ -3,6 +3,7 @@ import {
   extractLocalhostUrls,
   normalizeBrowserUrl,
   isLocalhostUrl,
+  isDevPreviewProxyUrl,
   isSafeNavigationUrl,
   stripAnsiAndOscCodes,
   isImplicitlyAllowedHost,
@@ -435,6 +436,32 @@ describe("urlUtils", () => {
 
     it("returns true for https IPv6 [::1] URL", () => {
       expect(isLocalhostUrl("https://[::1]:3000")).toBe(true);
+    });
+  });
+
+  describe("isDevPreviewProxyUrl", () => {
+    it("returns true for an http *.localhost subdomain", () => {
+      expect(isDevPreviewProxyUrl("http://dp-proj-panel.localhost:43000/")).toBe(true);
+      expect(isDevPreviewProxyUrl("http://dp-proj-panel.localhost:43000/some/route?q=1")).toBe(
+        true
+      );
+    });
+
+    it("returns false for bare localhost (that's isLocalhostUrl's job)", () => {
+      expect(isDevPreviewProxyUrl("http://localhost:43000/")).toBe(false);
+    });
+
+    it("returns false for https *.localhost (proxy serves plain http only)", () => {
+      expect(isDevPreviewProxyUrl("https://dp-proj-panel.localhost:43000/")).toBe(false);
+    });
+
+    it("does not match a public host that merely embeds 'localhost'", () => {
+      expect(isDevPreviewProxyUrl("http://evil.localhost.example.com:43000/")).toBe(false);
+    });
+
+    it("returns false for remote URLs and invalid input", () => {
+      expect(isDevPreviewProxyUrl("http://example.com")).toBe(false);
+      expect(isDevPreviewProxyUrl("not a url")).toBe(false);
     });
   });
 

--- a/shared/utils/devPreviewProxy.ts
+++ b/shared/utils/devPreviewProxy.ts
@@ -18,12 +18,20 @@ const SUBDOMAIN_PREFIX = "dp-";
 const LOCALHOST_SUFFIX = ".localhost";
 
 /**
- * Reduce an arbitrary id to a DNS-label-safe token. Mirrors the `sanitizeToken` used for
- * terminal ids: non-alphanumeric runs collapse to hyphens and the result is capped at 24
- * chars (well under the 63-char DNS label limit, even combined as `dp-<a>-<b>`).
+ * Reduce an arbitrary id to a DNS-label-safe token: lowercased, every character outside
+ * `[a-z0-9-]` collapsed to a hyphen, capped at 24 chars (well under the 63-char DNS label
+ * limit, even combined as `dp-<a>-<b>`). Lowercasing is essential, not cosmetic — hostnames
+ * are case-insensitive, so the browser sends the `Host` header lowercased; building the
+ * subdomain in any other case would make the proxy's subdomain→port lookup miss. Underscores
+ * are folded too since they aren't valid in RFC 1123 DNS labels.
  */
 export function sanitizeSubdomainToken(input: string): string {
-  return input.replace(/[^a-zA-Z0-9_-]/g, "-").slice(0, 24) || "x";
+  return (
+    input
+      .toLowerCase()
+      .replace(/[^a-z0-9-]/g, "-")
+      .slice(0, 24) || "x"
+  );
 }
 
 /**

--- a/shared/utils/devPreviewProxy.ts
+++ b/shared/utils/devPreviewProxy.ts
@@ -1,0 +1,63 @@
+// Stable-origin reverse proxy for dev-preview panels (#9100).
+//
+// Every dev-preview panel loads a fixed `dp-<projectToken>-<panelToken>.localhost:<proxyPort>`
+// origin instead of the dev server's ephemeral `localhost:<random-port>`. Chromium maps any
+// `*.localhost` host to loopback as a Secure Context (no OS DNS, no TLS), so cookies,
+// localStorage, and sessionStorage now survive dev-server restarts that reshuffle the upstream
+// port. These helpers are the single source of truth for the subdomain shape, shared by the
+// main-process proxy/session services and the renderer that builds the webview URL.
+
+/**
+ * Default fixed port for the dev-preview reverse proxy. The proxy falls back to an
+ * OS-assigned port if this is already bound, so always resolve the live port via the
+ * `devPreview.getProxyPort` IPC rather than assuming this constant.
+ */
+export const DEV_PREVIEW_PROXY_PORT = 43000;
+
+const SUBDOMAIN_PREFIX = "dp-";
+const LOCALHOST_SUFFIX = ".localhost";
+
+/**
+ * Reduce an arbitrary id to a DNS-label-safe token. Mirrors the `sanitizeToken` used for
+ * terminal ids: non-alphanumeric runs collapse to hyphens and the result is capped at 24
+ * chars (well under the 63-char DNS label limit, even combined as `dp-<a>-<b>`).
+ */
+export function sanitizeSubdomainToken(input: string): string {
+  return input.replace(/[^a-zA-Z0-9_-]/g, "-").slice(0, 24) || "x";
+}
+
+/**
+ * Build the stable subdomain label for a dev-preview panel: `dp-<projectToken>-<panelToken>`.
+ * Deterministic per (projectId, panelId), so the same panel always resolves to the same origin.
+ */
+export function buildDevPreviewSubdomain(projectId: string, panelId: string): string {
+  return `${SUBDOMAIN_PREFIX}${sanitizeSubdomainToken(projectId)}-${sanitizeSubdomainToken(panelId)}`;
+}
+
+/**
+ * Build the full stable origin a dev-preview webview should load, e.g.
+ * `http://dp-myproj-panel1.localhost:43000`. Plain HTTP — `*.localhost` is a Secure Context.
+ */
+export function buildDevPreviewProxyOrigin(
+  proxyPort: number,
+  projectId: string,
+  panelId: string
+): string {
+  return `http://${buildDevPreviewSubdomain(projectId, panelId)}.localhost:${proxyPort}`;
+}
+
+/**
+ * Extract the dev-preview subdomain label from an incoming `Host` header (e.g.
+ * `dp-myproj-panel1.localhost:43000` -> `dp-myproj-panel1`). Returns null for any host that is
+ * not a `dp-*.localhost` subdomain, so the proxy can reject unrelated requests with a 502.
+ */
+export function parseDevPreviewProxyHost(host: string | undefined | null): string | null {
+  if (!host) return null;
+  // Strip the optional `:port`. Bracketed IPv6 hosts ([::1]) never match the suffix below,
+  // so the naive split is safe for the only hosts the proxy actually serves.
+  const hostname = host.split(":")[0]?.trim().toLowerCase() ?? "";
+  if (!hostname.endsWith(LOCALHOST_SUFFIX)) return null;
+  const label = hostname.slice(0, -LOCALHOST_SUFFIX.length);
+  if (!label || !label.startsWith(SUBDOMAIN_PREFIX)) return null;
+  return label;
+}

--- a/shared/utils/urlUtils.ts
+++ b/shared/utils/urlUtils.ts
@@ -129,6 +129,25 @@ export function isLocalhostUrl(url: string): boolean {
   }
 }
 
+/**
+ * True for the stable dev-preview proxy origin: an `http://*.localhost` subdomain (#9100).
+ * Chromium maps every `*.localhost` host to loopback as a Secure Context, so these never reach
+ * the public network — but `isLocalhostUrl` (exact loopback only) rejects them, so the
+ * dev-preview webview guards must accept this shape separately. Kept HTTP-only on purpose:
+ * the proxy serves plain HTTP, and widening to HTTPS would admit a subdomain we never bind.
+ * Bare `localhost` is intentionally excluded here (that is `isLocalhostUrl`'s job).
+ */
+export function isDevPreviewProxyUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:") return false;
+    const hostname = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+    return hostname.endsWith(".localhost") && hostname.length > ".localhost".length;
+  } catch {
+    return false;
+  }
+}
+
 export function isSafeNavigationUrl(url: string): boolean {
   try {
     const protocol = new URL(url.trim()).protocol;

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -312,8 +312,14 @@ export function DevPreviewPane({
   const [proxyPort, setProxyPort] = useState<number | null | undefined>(undefined);
   useEffect(() => {
     let cancelled = false;
-    window.electron.devPreview
-      .getProxyPort()
+    // Tolerate a bridge that predates the proxy IPC (older preload, partial test mock): degrade
+    // to null = legacy direct-localhost mode rather than crashing or hanging in the loading gate.
+    const getProxyPort = window.electron?.devPreview?.getProxyPort;
+    if (typeof getProxyPort !== "function") {
+      setProxyPort(null);
+      return;
+    }
+    getProxyPort()
       .then(({ port }) => {
         if (!cancelled) setProxyPort(port);
       })

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -426,6 +426,17 @@ export function DevPreviewPane({
   const isUnconfigured =
     Boolean(currentProjectId) && !isSettingsLoading && projectSettings !== null && !devCommand;
 
+  // Hold the webview (show the loading state) while the dev server is running but the pane
+  // hasn't settled onto the stable proxy origin yet (#9100). Covers two cases: the proxy port
+  // is still being fetched (proxyOrigin === undefined), and an upgraded session whose persisted
+  // history is a raw localhost URL that the navigation effect is about to migrate. Without this
+  // the webview would briefly load the unstable origin. Legacy mode (proxyOrigin === null) opts
+  // out entirely.
+  const isProxyUrlPending =
+    status === "running" &&
+    (proxyOrigin === undefined ||
+      (typeof proxyOrigin === "string" && !!currentUrl && !currentUrl.startsWith(proxyOrigin)));
+
   const { isEvicted, evictingRef } = useWebviewEviction(id, location);
 
   const [isRecoveringFromEviction, setIsRecoveringFromEviction] = useState(false);
@@ -1400,7 +1411,7 @@ export function DevPreviewPane({
               {viewportFit && fitScale < 1 && ` · ${Math.round(fitScale * 100)}%`}
             </div>
           )}
-          {isRestarting || status === "starting" || status === "installing" ? (
+          {isRestarting || status === "starting" || status === "installing" || isProxyUrlPending ? (
             <DevPreviewLoadingState
               variant="full"
               isLoading={true}

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -74,6 +74,7 @@ import { useDevPreviewLoadLifecycle, type SessionStorageEntry } from "./useDevPr
 
 import { BlockedNavBanner, blockedNavReducer } from "./BlockedNavBanner";
 import { looksLikeOAuthUrl } from "@shared/utils/urlUtils";
+import { buildDevPreviewProxyOrigin } from "@shared/utils/devPreviewProxy";
 
 async function captureWebviewSessionStorage(
   webviewElement: Electron.WebviewTag | null
@@ -303,6 +304,31 @@ export function DevPreviewPane({
     const panelToken = sanitizePartitionToken(id);
     return `persist:dev-preview-${projectToken}-${worktreeToken}-${panelToken}`;
   }, [currentProjectId, worktreeId, id]);
+
+  // Resolve the dev-preview reverse proxy port once, then derive the stable origin this
+  // panel's webview loads (#9100). `undefined` = still fetching (hold navigation until it
+  // settles so we don't flash the unstable direct-localhost origin); `null` = proxy
+  // unavailable, fall back to the legacy direct-localhost behavior.
+  const [proxyPort, setProxyPort] = useState<number | null | undefined>(undefined);
+  useEffect(() => {
+    let cancelled = false;
+    window.electron.devPreview
+      .getProxyPort()
+      .then(({ port }) => {
+        if (!cancelled) setProxyPort(port);
+      })
+      .catch(() => {
+        if (!cancelled) setProxyPort(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  const proxyOrigin = useMemo<string | null | undefined>(() => {
+    if (proxyPort === undefined) return undefined;
+    if (proxyPort === null || !currentProjectId) return null;
+    return buildDevPreviewProxyOrigin(proxyPort, currentProjectId, id);
+  }, [proxyPort, currentProjectId, id]);
 
   const [forceKillBannerDismissed, setForceKillBannerDismissed] = useState(false);
 
@@ -627,12 +653,15 @@ export function DevPreviewPane({
 
   useEffect(() => {
     if (isUnconfigured) return;
-    const nextUrl = url ? computeDevServerUrl(url, currentUrl) : false;
+    // Hold navigation until the proxy port resolution settles, otherwise the pane would
+    // briefly adopt the unstable direct-localhost origin before the proxy origin is known (#9100).
+    if (proxyOrigin === undefined) return;
+    const nextUrl = url ? computeDevServerUrl(url, currentUrl, proxyOrigin) : false;
     if (nextUrl !== false) {
       setHistory((prev) => pushBrowserHistory(prev, nextUrl));
       lastSetUrlRef.current = nextUrl;
     }
-  }, [url, currentUrl, isUnconfigured]);
+  }, [url, currentUrl, isUnconfigured, proxyOrigin]);
 
   useEffect(() => {
     if (isUnconfigured) return;

--- a/src/components/DevPreview/__tests__/urlSync.test.ts
+++ b/src/components/DevPreview/__tests__/urlSync.test.ts
@@ -68,4 +68,42 @@ describe("computeDevServerUrl", () => {
   it("falls forward to the detected URL when the detected URL cannot be parsed", () => {
     expect(computeDevServerUrl("not-a-url", "http://localhost:3000/dashboard")).toBe("not-a-url");
   });
+
+  describe("proxy mode (#9100)", () => {
+    const PROXY = "http://dp-proj-panel.localhost:43000";
+
+    it("returns false when there is no detected URL even with a proxy origin", () => {
+      expect(computeDevServerUrl("", "", PROXY)).toBe(false);
+    });
+
+    it("navigates onto the proxy origin root on first detection", () => {
+      expect(computeDevServerUrl("http://localhost:3000/", "", PROXY)).toBe(`${PROXY}/`);
+    });
+
+    it("returns false once the pane is already on the proxy origin (stable restart)", () => {
+      // Dev server restarted on a new upstream port; the proxy follows it transparently,
+      // so the webview must NOT re-navigate.
+      expect(computeDevServerUrl("http://localhost:3001/", `${PROXY}/dashboard`, PROXY)).toBe(
+        false
+      );
+    });
+
+    it("ignores the upstream port entirely — same proxy origin regardless of detected port", () => {
+      expect(computeDevServerUrl("http://localhost:9999/", `${PROXY}/`, PROXY)).toBe(false);
+    });
+
+    it("migrates off a stale direct-localhost URL onto the proxy origin, preserving the route", () => {
+      expect(
+        computeDevServerUrl("http://localhost:3000/", "http://localhost:3000/settings?tab=x", PROXY)
+      ).toBe(`${PROXY}/settings?tab=x`);
+    });
+
+    it("honors a non-root base path the dev server advertises when first adopting the proxy", () => {
+      expect(computeDevServerUrl("http://localhost:5174/app/", "", PROXY)).toBe(`${PROXY}/app/`);
+    });
+
+    it("returns false when the proxy origin string cannot be parsed", () => {
+      expect(computeDevServerUrl("http://localhost:3000/", "", "not-a-url")).toBe(false);
+    });
+  });
 });

--- a/src/components/DevPreview/urlSync.ts
+++ b/src/components/DevPreview/urlSync.ts
@@ -35,7 +35,7 @@ export function computeDevServerUrl(
     } catch {
       return false;
     }
-    let current: URL | null = null;
+    let current: URL | null;
     try {
       current = currentUrl ? new URL(currentUrl) : null;
     } catch {
@@ -48,7 +48,7 @@ export function computeDevServerUrl(
     // First navigation onto the proxy origin (or migrating off a stale localhost
     // URL). Choose the route: honor a non-root path the dev server advertises
     // (Vite `base`), else preserve the pane's current route, else land on root.
-    let detected: URL | null = null;
+    let detected: URL | null;
     try {
       detected = new URL(detectedUrl);
     } catch {

--- a/src/components/DevPreview/urlSync.ts
+++ b/src/components/DevPreview/urlSync.ts
@@ -5,17 +5,68 @@
  * Returns `false` when no adoption is needed (no detected URL, or the detected
  * URL is the same origin the pane is already on — a port-stable restart).
  *
- * When the dev server restarts on a different origin (typically a port shift,
- * e.g. 3000 → 3001), the detected URL is the bare server root. Navigating to it
- * directly would drop the route the user was on. To preserve it, the current
- * URL's pathname/search/hash are grafted onto the detected origin.
+ * **Proxy mode (#9100):** when `proxyOrigin` is supplied, the webview always sits
+ * on the stable `dp-*.localhost` proxy origin and never moves off it. A dev-server
+ * restart only shifts the upstream port — which the proxy resolves live — so once
+ * the pane is on the proxy origin there is nothing to navigate (returns `false`).
+ * The only navigation is the first one onto the proxy origin (and any migration
+ * off a stale direct-localhost URL), where the route is taken from the detected
+ * URL's non-root path, else the pane's current route, else `/`.
  *
- * If the detected URL itself carries a non-root path (e.g. a Vite `base`
- * config advertising `http://localhost:5174/app/`), that path is intentional
- * and is navigated to as-is — grafting only applies to a bare server root.
+ * **Legacy mode (no proxy):** when the dev server restarts on a different origin
+ * (typically a port shift, e.g. 3000 → 3001), the detected URL is the bare server
+ * root. Navigating to it directly would drop the route the user was on; to preserve
+ * it, the current URL's pathname/search/hash are grafted onto the detected origin.
+ * If the detected URL itself carries a non-root path (e.g. a Vite `base` config
+ * advertising `http://localhost:5174/app/`), that path is intentional and is
+ * navigated to as-is — grafting only applies to a bare server root.
  */
-export function computeDevServerUrl(detectedUrl: string, currentUrl: string): string | false {
+export function computeDevServerUrl(
+  detectedUrl: string,
+  currentUrl: string,
+  proxyOrigin?: string | null
+): string | false {
   if (!detectedUrl) return false;
+
+  if (proxyOrigin) {
+    let proxy: URL;
+    try {
+      proxy = new URL(proxyOrigin);
+    } catch {
+      return false;
+    }
+    let current: URL | null = null;
+    try {
+      current = currentUrl ? new URL(currentUrl) : null;
+    } catch {
+      current = null;
+    }
+    // Already on the stable proxy origin — a restart only moved the upstream port,
+    // which the proxy follows transparently. Nothing to navigate.
+    if (current && current.origin === proxy.origin) return false;
+
+    // First navigation onto the proxy origin (or migrating off a stale localhost
+    // URL). Choose the route: honor a non-root path the dev server advertises
+    // (Vite `base`), else preserve the pane's current route, else land on root.
+    let detected: URL | null = null;
+    try {
+      detected = new URL(detectedUrl);
+    } catch {
+      detected = null;
+    }
+    const target = new URL(proxy.toString());
+    if (detected && detected.pathname !== "/") {
+      target.pathname = detected.pathname;
+      target.search = detected.search;
+      target.hash = detected.hash;
+    } else if (current) {
+      target.pathname = current.pathname;
+      target.search = current.search;
+      target.hash = current.hash;
+    }
+    return target.toString();
+  }
+
   if (!currentUrl) return detectedUrl;
   if (detectedUrl === currentUrl) return false;
 


### PR DESCRIPTION
Adds a stable reverse proxy layer to dev-preview panels so that cookies, `localStorage`, and `sessionStorage` survive dev-server restarts.

## The problem

Dev-preview webviews were loading the dev server directly — `http://localhost:<random-port>`. Ports are reallocated from 3000–9999 on every restart, so the origin changed on each cycle and the browser discarded all storage for that origin.

## How it works

A fixed-port (43000) in-process Node HTTP reverse proxy (`DevPreviewProxyService`, backed by `httpxy`). Each panel loads a stable subdomain origin — `http://dp-<projectToken>-<panelToken>.localhost:43000` — and the proxy forwards to the live upstream dev-server port. `*.localhost` is a Secure Context in Chromium on plain HTTP (no TLS/mkcert needed), so `document.cookie`, `localStorage`, and `sessionStorage` all work and persist across restarts.

Key details:

- `changeOrigin` rewrites `Host` so Vite/Next host-check middleware passes through cleanly
- `cookieDomainRewrite: ""` strips `Domain` from `Set-Cookie` headers so cookies bind host-only to the stable origin
- Clean 502 when there's no upstream or the upstream is unreachable
- WebSocket upgrades forwarded for HMR
- Proxy binds `127.0.0.1`; `EADDRINUSE` falls back to an OS-assigned port; `server.unref()` so it doesn't hold the process open; sockets torn down on `dispose()`
- `getProxyPort` IPC op starts the proxy lazily on first call
- `DevPreviewSessionService.getUpstreamPortForSubdomain` resolves subdomain → live port (gated on running state; prefers the detected bind port)
- Security guards (`will-attach-webview` in `createWindow` + `ProjectViewManager`, `will-navigate`/`will-redirect` in `protocols`) and `getLocalhostDevCSP` accept `http://*.localhost:*` (and `ws://*.localhost:*` for HMR) via the new `isDevPreviewProxyUrl` helper
- Renderer loads the stable origin and no longer re-navigates on upstream port shifts

## Migration note

Webview partitions are unchanged, but the storage origin changes from `http://localhost:<port>` to `http://dp-<token>.localhost:43000`. On first launch after upgrade, any dev-preview cookies/`localStorage` stored at the old (already-ephemeral) origin start fresh — this is the fix, not a regression.

## Testing

253 unit tests pass. New coverage: `DevPreviewProxyService.test.ts` (HTTP forward + `Host` rewrite, single + multi/`.localhost` `Set-Cookie` domain strip, 502 on no-upstream/non-subdomain/unreachable, idempotent start, WS upgrade echo + path/query preservation, dispose), `devPreviewProxy` helpers including case-insensitive round-trip, `isDevPreviewProxyUrl`, CSP `*.localhost`, `urlSync` proxy mode, `SessionService.getUpstreamPortForSubdomain` including stopped → null. Full `npm run check` and `npm run lint` pass.

Closes #9100. Unblocks #9101 and #9102. (#9090 — port pinning — was closed in favour of this approach.)