### PR TITLE
feat(e2e): add launch telemetry to attribute CI failure modes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -460,6 +460,10 @@ jobs:
         shell: bash
         env:
           ELECTRON_ENABLE_LOGGING: "1"
+          DEBUG: "pw:protocol,pw:browser"
+          DEBUG_COLORS: "0"
+          E2E_LAUNCH_TELEMETRY: "1"
+          E2E_LAUNCH_TELEMETRY_FILE: ${{ runner.temp }}/e2e-launch-telemetry-${{ matrix.shard }}.jsonl
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENCODE_E2E_ENABLED: ${{ inputs.suite == 'online' && '1' || '' }}
           FAIL_ON_FLAKY_TESTS: ${{ (inputs.suite == 'core' || inputs.suite == 'online') && 'true' || 'false' }}
@@ -469,6 +473,9 @@ jobs:
           while true; do
             sleep 60
             echo "[e2e] heartbeat $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+            if [ -f "$E2E_LAUNCH_TELEMETRY_FILE" ]; then
+              tail -n 3 "$E2E_LAUNCH_TELEMETRY_FILE" 2>/dev/null | sed 's/^/[e2e] launch-telemetry /'
+            fi
           done &
           heartbeat_pid=$!
           trap 'kill "$heartbeat_pid" 2>/dev/null || true' EXIT

--- a/e2e/helpers/__tests__/launchTelemetry.test.ts
+++ b/e2e/helpers/__tests__/launchTelemetry.test.ts
@@ -1,0 +1,557 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import {
+  install,
+  beginAttempt,
+  observeStderrLine,
+  observeMainProcessExit,
+  observeRendererCrash,
+  classify,
+  writeSummary,
+  dispose,
+} from "../launchTelemetry";
+
+const PW_PROTOCOL_SEND =
+  '  pw:protocol SEND ► {"id":1,"method":"Browser.getVersion","params":{}} +0ms\n';
+const PW_PROTOCOL_RECV = '  pw:protocol ◀ RECV {"id":1,"result":{"userAgent":"test"}} +5ms\n';
+const PW_PROTOCOL_SEND_NO_ID =
+  '  pw:protocol SEND ► {"method":"Target.setDiscoverTargets","params":{"discover":true}} +1ms\n';
+
+function writeDebugLines(...lines: string[]) {
+  for (const line of lines) {
+    process.stderr.write(line);
+  }
+}
+
+function mockStderr(): { mock: ReturnType<typeof vi.fn>; restore: () => void } {
+  const real = process.stderr.write;
+  const mock = vi.fn((..._args: unknown[]) => true);
+  process.stderr.write = mock as unknown as typeof process.stderr.write;
+  return {
+    mock,
+    restore: () => {
+      process.stderr.write = real;
+    },
+  };
+}
+
+beforeEach(() => {
+  dispose();
+});
+
+afterEach(() => {
+  dispose();
+  delete process.env.E2E_LAUNCH_TELEMETRY;
+  delete process.env.E2E_LAUNCH_TELEMETRY_FILE;
+  delete process.env.DEBUG;
+});
+
+// ---------------------------------------------------------------------------
+// Installation
+// ---------------------------------------------------------------------------
+describe("install", () => {
+  it("is a no-op when E2E_LAUNCH_TELEMETRY is not set", () => {
+    delete process.env.E2E_LAUNCH_TELEMETRY;
+    process.env.DEBUG = "pw:protocol";
+    const original = process.stderr.write;
+    install();
+    expect(process.stderr.write).toBe(original);
+  });
+
+  it("is a no-op when DEBUG does not include pw:protocol or pw:browser", () => {
+    process.env.E2E_LAUNCH_TELEMETRY = "1";
+    process.env.DEBUG = "other:debug";
+    const original = process.stderr.write;
+    install();
+    expect(process.stderr.write).toBe(original);
+  });
+
+  it("patches stderr.write when both env vars are set", () => {
+    process.env.E2E_LAUNCH_TELEMETRY = "1";
+    process.env.DEBUG = "pw:protocol,pw:browser";
+    const original = process.stderr.write;
+    install();
+    expect(process.stderr.write).not.toBe(original);
+  });
+
+  it("does not double-wrap stderr", () => {
+    process.env.E2E_LAUNCH_TELEMETRY = "1";
+    process.env.DEBUG = "pw:protocol";
+    install();
+    const first = process.stderr.write;
+    install();
+    expect(process.stderr.write).toBe(first);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Protocol interception
+// ---------------------------------------------------------------------------
+describe("protocol interception", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+  it("consumes pw:protocol SEND lines", () => {
+    process.env.E2E_LAUNCH_TELEMETRY = "1";
+    process.env.DEBUG = "pw:protocol";
+    install();
+    beginAttempt(1, 3);
+    writeDebugLines(PW_PROTOCOL_SEND);
+
+    // Not enough elapsed time for CDP-silent classification
+    expect(classify()).toBe("unknown");
+  });
+
+  it("does not flag CDP-silent when receives arrive", () => {
+    process.env.E2E_LAUNCH_TELEMETRY = "1";
+    process.env.DEBUG = "pw:protocol";
+    install();
+    beginAttempt(1, 3);
+    writeDebugLines(PW_PROTOCOL_SEND, PW_PROTOCOL_RECV);
+
+    vi.advanceTimersByTime(3000);
+    expect(classify()).not.toBe("cdp-handshake-silent");
+  });
+
+  it("swallows pw:protocol lines so they don't reach real stderr", () => {
+    const { mock, restore } = mockStderr();
+
+    try {
+      process.env.E2E_LAUNCH_TELEMETRY = "1";
+      process.env.DEBUG = "pw:protocol";
+      dispose(); // reset after mockStderr replacement
+      install();
+      beginAttempt(1, 3);
+
+      process.stderr.write("normal line\n");
+      process.stderr.write(PW_PROTOCOL_SEND);
+
+      const normalCalls = mock.mock.calls.filter(
+        (c) => typeof c[0] === "string" && (c[0] as string).includes("normal line")
+      );
+      const protocolCalls = mock.mock.calls.filter(
+        (c) => typeof c[0] === "string" && (c[0] as string).includes("pw:protocol")
+      );
+      expect(normalCalls.length).toBeGreaterThanOrEqual(1);
+      expect(protocolCalls.length).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it("tolerates malformed JSON in debug lines", () => {
+    process.env.E2E_LAUNCH_TELEMETRY = "1";
+    process.env.DEBUG = "pw:protocol";
+    install();
+    beginAttempt(1, 3);
+
+    expect(() => {
+      process.stderr.write("  pw:protocol SEND ► {not valid json} +0ms\n");
+    }).not.toThrow();
+  });
+
+  it("tolerates debug lines without JSON payload", () => {
+    process.env.E2E_LAUNCH_TELEMETRY = "1";
+    process.env.DEBUG = "pw:protocol";
+    install();
+    beginAttempt(1, 3);
+
+    expect(() => {
+      process.stderr.write("  pw:protocol some message without json\n");
+    }).not.toThrow();
+  });
+
+  it("tracks method names from sent commands in summary", () => {
+    const { mock, restore } = mockStderr();
+
+    try {
+      process.env.E2E_LAUNCH_TELEMETRY = "1";
+      process.env.DEBUG = "pw:protocol";
+      dispose();
+      install();
+      beginAttempt(1, 3);
+      writeDebugLines(PW_PROTOCOL_SEND);
+
+      vi.advanceTimersByTime(3000);
+      writeSummary();
+
+      const summaryCall = mock.mock.calls.find(
+        (c) => typeof c[0] === "string" && (c[0] as string).includes("e2e_launch_telemetry")
+      );
+      expect(summaryCall).toBeDefined();
+      expect(summaryCall![0]).toContain("Browser.getVersion");
+    } finally {
+      restore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Crashpad detection
+// ---------------------------------------------------------------------------
+describe("crashpad detection", () => {
+  beforeEach(() => {
+    process.env.E2E_LAUNCH_TELEMETRY = "1";
+    process.env.DEBUG = "pw:protocol";
+  });
+
+  it("detects FATAL kr == KERN_SUCCESS signature", () => {
+    beginAttempt(1, 3);
+    observeStderrLine("FATAL kr == KERN_SUCCESS in exception_handler_server.cc");
+    expect(classify()).toBe("crashpad-stderr");
+  });
+
+  it("detects generic crashpad signature", () => {
+    beginAttempt(1, 3);
+    observeStderrLine("[crashpad] handler startup failed");
+    expect(classify()).toBe("crashpad-stderr");
+  });
+
+  it("detects Breakpad signature", () => {
+    beginAttempt(1, 3);
+    observeStderrLine("Breakpad exception handler started");
+    expect(classify()).toBe("crashpad-stderr");
+  });
+
+  it("does not flag normal stderr as crashpad", () => {
+    beginAttempt(1, 3);
+    observeStderrLine("normal application stderr output");
+    expect(classify()).not.toBe("crashpad-stderr");
+  });
+
+  it("caps stored signature list without throwing", () => {
+    beginAttempt(1, 3);
+
+    const signatures = [
+      "crashpad",
+      "Breakpad",
+      "exception_handler_server",
+      "EXCEPTION_",
+      "handler_start",
+      "Handler was started",
+      "FATAL kr == KERN_SUCCESS",
+    ];
+    for (const sig of signatures) {
+      observeStderrLine(sig);
+    }
+
+    expect(classify()).toBe("crashpad-stderr");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Classification priority
+// ---------------------------------------------------------------------------
+describe("classification priority", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    process.env.E2E_LAUNCH_TELEMETRY = "1";
+    process.env.DEBUG = "pw:protocol";
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("webcontents-crash beats main-process-exit", () => {
+    beginAttempt(1, 3);
+    observeMainProcessExit(1, null);
+    observeRendererCrash();
+    expect(classify()).toBe("webcontents-crash");
+  });
+
+  it("webcontents-crash beats crashpad-stderr", () => {
+    beginAttempt(1, 3);
+    observeStderrLine("FATAL kr == KERN_SUCCESS");
+    observeRendererCrash();
+    expect(classify()).toBe("webcontents-crash");
+  });
+
+  it("main-process-exit beats crashpad-stderr", () => {
+    beginAttempt(1, 3);
+    observeStderrLine("crashpad handler failure");
+    observeMainProcessExit(1, null);
+    expect(classify()).toBe("main-process-exit");
+  });
+
+  it("main-process-exit via signal beats crashpad-stderr", () => {
+    beginAttempt(1, 3);
+    observeStderrLine("crashpad handler failure");
+    observeMainProcessExit(null, "SIGKILL");
+    expect(classify()).toBe("main-process-exit");
+  });
+
+  it("main-process-exit with code 0 falls through to crashpad", () => {
+    beginAttempt(1, 3);
+    observeStderrLine("crashpad handler failure");
+    observeMainProcessExit(0, null);
+    expect(classify()).toBe("crashpad-stderr");
+  });
+
+  it("crashpad-stderr beats cdp-handshake-silent", () => {
+    install();
+    beginAttempt(1, 3);
+    writeDebugLines(PW_PROTOCOL_SEND);
+    observeStderrLine("FATAL kr == KERN_SUCCESS");
+
+    vi.advanceTimersByTime(3000);
+    expect(classify()).toBe("crashpad-stderr");
+  });
+
+  it("returns unknown when no signals are present", () => {
+    beginAttempt(1, 3);
+    expect(classify()).toBe("unknown");
+  });
+
+  it("main-process-exit beats cdp-handshake-silent", () => {
+    install();
+    beginAttempt(1, 3);
+    writeDebugLines(PW_PROTOCOL_SEND);
+    observeMainProcessExit(1, null);
+
+    vi.advanceTimersByTime(3000);
+    expect(classify()).toBe("main-process-exit");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CDP-handshake-silent
+// ---------------------------------------------------------------------------
+describe("cdp-handshake-silent", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    process.env.E2E_LAUNCH_TELEMETRY = "1";
+    process.env.DEBUG = "pw:protocol";
+    install();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("classifies when sends exist but no receives and enough time passes", () => {
+    beginAttempt(1, 3);
+    writeDebugLines(PW_PROTOCOL_SEND);
+    vi.advanceTimersByTime(3000);
+    expect(classify()).toBe("cdp-handshake-silent");
+  });
+
+  it("does not classify when receives arrived", () => {
+    beginAttempt(1, 3);
+    writeDebugLines(PW_PROTOCOL_SEND, PW_PROTOCOL_RECV);
+    vi.advanceTimersByTime(3000);
+    expect(classify()).not.toBe("cdp-handshake-silent");
+  });
+
+  it("does not classify before minimum elapsed time", () => {
+    beginAttempt(1, 3);
+    writeDebugLines(PW_PROTOCOL_SEND);
+    expect(classify()).not.toBe("cdp-handshake-silent");
+  });
+
+  it("does not classify with zero sends", () => {
+    beginAttempt(1, 3);
+    vi.advanceTimersByTime(3000);
+    expect(classify()).toBe("unknown");
+  });
+
+  it("handles send without id gracefully", () => {
+    beginAttempt(1, 3);
+    writeDebugLines(PW_PROTOCOL_SEND_NO_ID);
+    vi.advanceTimersByTime(3000);
+    expect(classify()).toBe("cdp-handshake-silent");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Summary output
+// ---------------------------------------------------------------------------
+describe("writeSummary", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    process.env.E2E_LAUNCH_TELEMETRY = "1";
+    process.env.DEBUG = "pw:protocol";
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("emits a compact line with the expected prefix and fields", () => {
+    beginAttempt(2, 3);
+    observeMainProcessExit(1, null);
+    expect(classify()).toBe("main-process-exit");
+
+    const { mock, restore } = mockStderr();
+
+    try {
+      writeSummary();
+      const telLine = mock.mock.calls
+        .map((c) => String(c[0]))
+        .find((l: string) => l.includes("e2e_launch_telemetry"));
+      expect(telLine).toBeDefined();
+      expect(telLine!).toContain("mode=main-process-exit");
+      expect(telLine!).toContain("attempt=2/3");
+      expect(telLine!).toContain("exitCode=1");
+    } finally {
+      restore();
+    }
+  });
+
+  it("does not leak raw protocol payloads into summary output", () => {
+    install();
+    beginAttempt(1, 3);
+    writeDebugLines(
+      '  pw:protocol SEND ► {"id":1,"method":"Browser.getVersion","params":{"userAgent":"secret-token"}} +0ms\n'
+    );
+    vi.advanceTimersByTime(3000);
+
+    const { mock, restore } = mockStderr();
+
+    try {
+      writeSummary();
+      const telLine = mock.mock.calls
+        .map((c) => String(c[0]))
+        .find((l: string) => l.includes("e2e_launch_telemetry"));
+      expect(telLine).toBeDefined();
+      expect(telLine!).not.toContain("secret-token");
+      expect(telLine!).not.toContain("userAgent");
+      expect(telLine!).not.toContain('"params"');
+    } finally {
+      restore();
+    }
+  });
+
+  it("writes JSONL to E2E_LAUNCH_TELEMETRY_FILE when set", () => {
+    const tmp = os.tmpdir();
+    const file = path.join(tmp, `telemetry-test-${Date.now()}.jsonl`);
+    process.env.E2E_LAUNCH_TELEMETRY_FILE = file;
+
+    beginAttempt(1, 3);
+    observeStderrLine("FATAL kr == KERN_SUCCESS");
+    writeSummary();
+
+    const content = fs.readFileSync(file, "utf-8");
+    expect(content).toContain("crashpad-stderr");
+
+    try {
+      fs.unlinkSync(file);
+    } catch {
+      // best-effort
+    }
+  });
+
+  it("returns the resolved mode", () => {
+    beginAttempt(1, 3);
+    observeRendererCrash();
+    const result = writeSummary();
+    expect(result).toBe("webcontents-crash");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Attempt reset
+// ---------------------------------------------------------------------------
+describe("beginAttempt reset", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    process.env.E2E_LAUNCH_TELEMETRY = "1";
+    process.env.DEBUG = "pw:protocol";
+    install();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resets all per-attempt state between attempts", () => {
+    beginAttempt(1, 3);
+    observeStderrLine("FATAL kr == KERN_SUCCESS");
+    observeMainProcessExit(1, null);
+    expect(classify()).toBe("main-process-exit");
+
+    beginAttempt(2, 3);
+    expect(classify()).toBe("unknown");
+  });
+
+  it("resets protocol counters between attempts", () => {
+    beginAttempt(1, 3);
+    writeDebugLines(PW_PROTOCOL_SEND);
+    vi.advanceTimersByTime(3000);
+    expect(classify()).toBe("cdp-handshake-silent");
+
+    beginAttempt(2, 3);
+    vi.advanceTimersByTime(3000);
+    expect(classify()).toBe("unknown");
+  });
+
+  it("tracks correct attempt numbers in summaries", () => {
+    const { mock, restore } = mockStderr();
+
+    try {
+      beginAttempt(1, 3);
+      observeStderrLine("crashpad error");
+      writeSummary();
+
+      beginAttempt(2, 3);
+      observeStderrLine("crashpad error");
+      writeSummary();
+
+      const lines = mock.mock.calls.map((c) => String(c[0]));
+      const t1 = lines.find(
+        (l: string) => l.includes("attempt=1/3") && l.includes("e2e_launch_telemetry")
+      );
+      const t2 = lines.find(
+        (l: string) => l.includes("attempt=2/3") && l.includes("e2e_launch_telemetry")
+      );
+      expect(t1).toBeDefined();
+      expect(t2).toBeDefined();
+    } finally {
+      restore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dispose / cleanup
+// ---------------------------------------------------------------------------
+describe("dispose", () => {
+  it("restores original stderr.write", () => {
+    const original = process.stderr.write;
+    process.env.E2E_LAUNCH_TELEMETRY = "1";
+    process.env.DEBUG = "pw:protocol";
+    install();
+    expect(process.stderr.write).not.toBe(original);
+    dispose();
+    expect(process.stderr.write).toBe(original);
+  });
+
+  it("resets all state to defaults", () => {
+    process.env.E2E_LAUNCH_TELEMETRY = "1";
+    process.env.DEBUG = "pw:protocol";
+    install();
+    beginAttempt(1, 3);
+    observeStderrLine("FATAL kr == KERN_SUCCESS");
+    observeMainProcessExit(1, "SIGTERM");
+    observeRendererCrash();
+
+    dispose();
+
+    install();
+    beginAttempt(1, 1);
+    expect(classify()).toBe("unknown");
+  });
+
+  it("is idempotent", () => {
+    expect(() => {
+      dispose();
+      dispose();
+    }).not.toThrow();
+  });
+});

--- a/e2e/helpers/launch.ts
+++ b/e2e/helpers/launch.ts
@@ -6,6 +6,15 @@ import { execSync } from "child_process";
 import path from "path";
 import { getDescendantPids } from "./stress";
 import { removePathSync } from "./fixtures";
+import {
+  install as installTelemetry,
+  beginAttempt,
+  observeStderrLine,
+  observeMainProcessExit,
+  observeRendererCrash,
+  writeSummary,
+  dispose as disposeTelemetry,
+} from "./launchTelemetry";
 
 const require = createRequire(import.meta.url);
 const electronPath = require("electron") as unknown as string;
@@ -113,7 +122,10 @@ export async function launchApp(options: LaunchOptions = {}): Promise<AppContext
   const attemptTimeout = (_attempt: number) => (isMacOSLocal ? 50_000 : launchTimeout);
   let lastError: unknown = null;
 
+  installTelemetry();
+
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    beginAttempt(attempt, maxAttempts);
     const userDataDir = options.userDataDir ?? mkdtempSync(path.join(tmpdir(), "daintree-e2e-"));
     const args = [`--user-data-dir=${userDataDir}`, ROOT];
 
@@ -210,9 +222,11 @@ export async function launchApp(options: LaunchOptions = {}): Promise<AppContext
           process.stderr.write(`[E2E_STDOUT] ${chunk.toString()}`);
         });
         proc.stderr?.on("data", (chunk: Buffer) => {
+          observeStderrLine(chunk.toString());
           process.stderr.write(`[E2E_STDERR] ${chunk.toString()}`);
         });
         proc.on("exit", (code: number | null, signal: string | null) => {
+          observeMainProcessExit(code, signal);
           process.stderr.write(`[E2E_EXIT] code=${code} signal=${signal}\n`);
         });
       } catch {
@@ -222,7 +236,10 @@ export async function launchApp(options: LaunchOptions = {}): Promise<AppContext
       // After WebContentsView migration, firstWindow() returns the BW sentinel page.
       // Poll for the real app page loaded in the WebContentsView.
       const window = await pollForAppWindow(app, launchTimeout);
-      window.on("crash", () => console.error("[e2e] Renderer crashed"));
+      window.on("crash", () => {
+        observeRendererCrash();
+        console.error("[e2e] Renderer crashed");
+      });
       window.on("console", (msg) => {
         if (msg.type() === "error") console.error("[e2e:console]", msg.text());
       });
@@ -271,6 +288,7 @@ export async function launchApp(options: LaunchOptions = {}): Promise<AppContext
         }
       }
       if (attempt < maxAttempts) {
+        writeSummary();
         console.warn(`[e2e] Launch attempt ${attempt}/${maxAttempts} failed, retrying...`);
         if (isWindowsCI) cleanupWindowsElectronProcesses();
         if (isMacOSLocal) cleanupMacElectronE2eProcesses();
@@ -281,6 +299,8 @@ export async function launchApp(options: LaunchOptions = {}): Promise<AppContext
     }
   }
 
+  writeSummary();
+  disposeTelemetry();
   throw lastError instanceof Error ? lastError : new Error("Failed to launch Electron app");
 }
 

--- a/e2e/helpers/launch.ts
+++ b/e2e/helpers/launch.ts
@@ -274,6 +274,7 @@ export async function launchApp(options: LaunchOptions = {}): Promise<AppContext
       const readySelector = options.waitForSelector ?? '[aria-label="Toggle Sidebar"]';
       await window.locator(readySelector).waitFor({ state: "visible", timeout: launchTimeout });
 
+      disposeTelemetry();
       return { app, window, userDataDir };
     } catch (error) {
       lastError = error;

--- a/e2e/helpers/launchTelemetry.ts
+++ b/e2e/helpers/launchTelemetry.ts
@@ -102,11 +102,17 @@ function parseProtocolLine(line: string): void {
   if (!isSend && !isRecv) return;
 
   try {
-    // Extract just the JSON portion — the first balanced `{...}` or `[...]`.
-    const jsonMatch = line.match(/[{[].*[}\]]/);
-    if (!jsonMatch) return;
-
-    const payload = JSON.parse(jsonMatch[0]);
+    // Find the JSON payload: locate the first `{` after the directional
+    // marker (►/▸/◀), then slice to end-of-line minus the debug-package
+    // delta suffix (`+Nms`). This avoids false matches on bracketed
+    // prefixes and handles text between the marker and JSON (e.g. "RECV").
+    const markerIdx = Math.max(line.indexOf("►"), line.indexOf("▸"), line.indexOf("◀"));
+    const searchStart = markerIdx >= 0 ? markerIdx + 1 : 0;
+    const openBrace = line.indexOf("{", searchStart);
+    if (openBrace < 0) return;
+    const raw = line.slice(openBrace);
+    const jsonStr = raw.replace(/\s+\+\d+ms\s*$/, "");
+    const payload = JSON.parse(jsonStr);
 
     if (isSend && typeof payload?.method === "string") {
       const id = typeof payload.id === "number" ? payload.id : null;

--- a/e2e/helpers/launchTelemetry.ts
+++ b/e2e/helpers/launchTelemetry.ts
@@ -270,7 +270,8 @@ export function writeSummary(mode?: LaunchFailureMode): string {
     (summary.crashpad.matched ? ` crashpad=${summary.crashpad.signatures[0]}` : "") +
     (summary.rendererCrash.seen ? " rendererCrash=true" : "") +
     (summary.mainExit.code !== null ? ` exitCode=${summary.mainExit.code}` : "") +
-    (summary.mainExit.signal !== null ? ` exitSignal=${summary.mainExit.signal}` : "");
+    (summary.mainExit.signal !== null ? ` exitSignal=${summary.mainExit.signal}` : "") +
+    (malformedCount > 0 ? ` malformed=${malformedCount}` : "");
 
   const telemetryFile = process.env.E2E_LAUNCH_TELEMETRY_FILE;
   if (telemetryFile) {

--- a/e2e/helpers/launchTelemetry.ts
+++ b/e2e/helpers/launchTelemetry.ts
@@ -1,0 +1,301 @@
+import { appendFileSync, mkdirSync } from "fs";
+import path from "path";
+
+export type LaunchFailureMode =
+  | "cdp-handshake-silent"
+  | "crashpad-stderr"
+  | "webcontents-crash"
+  | "main-process-exit"
+  | "unknown";
+
+interface ProtocolSnapshot {
+  sent: number;
+  received: number;
+  pending: number;
+  lastSentMethods: string[];
+  lastReceivedMethods: string[];
+  /** ms since beginAttempt */
+  firstSendMs: number;
+  lastReceiveMs: number;
+}
+
+interface TelemetrySummary {
+  timestamp: string;
+  attempt: number;
+  maxAttempts: number;
+  mode: LaunchFailureMode;
+  elapsedMs: number;
+  protocol: {
+    sent: number;
+    received: number;
+    pending: number;
+    lastSentMethods: string[];
+    lastReceivedMethods: string[];
+  };
+  crashpad: { matched: boolean; signatures: string[] };
+  rendererCrash: { seen: boolean };
+  mainExit: { code: number | null; signal: string | null };
+}
+
+// Signatures indicative of a crashpad / breakpad failure in the Electron main
+// process. These strings appear on stderr before the process exits abnormally.
+const CRASHPAD_SIGNATURES = [
+  "FATAL kr == KERN_SUCCESS",
+  "crashpad",
+  "exception_handler_server",
+  "EXCEPTION_",
+  "Breakpad",
+  "handler_start",
+  "Handler was started",
+];
+
+const MAX_METHOD_HISTORY = 6;
+const MAX_SIGNATURE_LIST = 5;
+const CDP_SILENT_MIN_SENT = 1;
+const CDP_SILENT_MIN_ELAPSED_MS = 2000;
+
+let installed = false;
+let originalStderrWrite: typeof process.stderr.write | null = null;
+let currentAttempt = 0;
+let currentMaxAttempts = 0;
+let attemptStartMs = 0;
+let protocolSent = 0;
+let protocolReceived = 0;
+let pendingIds = new Set<number>();
+let lastSentMethods: string[] = [];
+let lastReceivedMethods: string[] = [];
+let firstSendMs = 0;
+let lastReceiveMs = 0;
+let crashpadMatched = false;
+let crashpadSignatures: string[] = [];
+let rendererCrashSeen = false;
+let mainExitCode: number | null = null;
+let mainExitSignal: string | null = null;
+let malformedCount = 0;
+
+function isEnabled(): boolean {
+  if (process.env.E2E_LAUNCH_TELEMETRY !== "1") return false;
+  const debug = process.env.DEBUG ?? "";
+  return debug.includes("pw:protocol") || debug.includes("pw:browser");
+}
+
+function isPlaywrightDebugLine(line: string): boolean {
+  return line.includes("pw:protocol") || line.includes("pw:browser");
+}
+
+function restoreStderr(): void {
+  if (originalStderrWrite) {
+    process.stderr.write = originalStderrWrite;
+    originalStderrWrite = null;
+  }
+  installed = false;
+}
+
+function parseProtocolLine(line: string): void {
+  // pw:protocol lines look like:
+  //   pw:protocol SEND ► {"id":1,"method":"Browser.getVersion","params":{}} +0ms
+  //   pw:protocol ◀ RECV {"id":1,"result":{...}} +5ms
+  // The JSON payload and delta suffix vary — be tolerant.
+
+  const isSend = /SEND\s*[►▸]/.test(line);
+  const isRecv = /◀\s*RECV|RECV/.test(line);
+  if (!isSend && !isRecv) return;
+
+  try {
+    // Extract just the JSON portion — the first balanced `{...}` or `[...]`.
+    const jsonMatch = line.match(/[{[].*[}\]]/);
+    if (!jsonMatch) return;
+
+    const payload = JSON.parse(jsonMatch[0]);
+
+    if (isSend && typeof payload?.method === "string") {
+      const id = typeof payload.id === "number" ? payload.id : null;
+      protocolSent++;
+      if (id !== null) pendingIds.add(id);
+      if (firstSendMs === 0) firstSendMs = Date.now() - attemptStartMs;
+      lastSentMethods.unshift(payload.method);
+      if (lastSentMethods.length > MAX_METHOD_HISTORY) lastSentMethods.pop();
+    } else if (isRecv) {
+      protocolReceived++;
+      const id = typeof payload?.id === "number" ? payload.id : null;
+      if (id !== null) pendingIds.delete(id);
+      lastReceiveMs = Date.now() - attemptStartMs;
+      if (typeof payload?.method === "string") {
+        lastReceivedMethods.unshift(payload.method);
+        if (lastReceivedMethods.length > MAX_METHOD_HISTORY) lastReceivedMethods.pop();
+      }
+    }
+  } catch {
+    malformedCount++;
+  }
+}
+
+function parseBrowserLine(_line: string): void {
+  // pw:browser lines track lifecycle: <launching>, <launched>, etc.
+  // We don't need to parse these deeply; their presence is tracked via
+  // protocol telemetry. This hook exists for future expansion.
+}
+
+function stderrWrite(chunk: unknown, encodingOrCb?: unknown, cb?: unknown): boolean {
+  const data = typeof chunk === "string" ? chunk : String(chunk);
+  if (isPlaywrightDebugLine(data)) {
+    if (data.includes("pw:protocol")) parseProtocolLine(data);
+    else if (data.includes("pw:browser")) parseBrowserLine(data);
+    // Swallow — don't forward raw Playwright debug to GHA stderr.
+    return true;
+  }
+  return originalStderrWrite!.call(
+    process.stderr,
+    chunk,
+    ...([encodingOrCb, cb].filter(Boolean) as Parameters<typeof process.stderr.write>)
+  ) as boolean;
+}
+
+export function install(): void {
+  if (!isEnabled() || installed) return;
+  originalStderrWrite = process.stderr.write;
+  process.stderr.write = stderrWrite as typeof process.stderr.write;
+  installed = true;
+}
+
+export function beginAttempt(attempt: number, maxAttempts: number): void {
+  currentAttempt = attempt;
+  currentMaxAttempts = maxAttempts;
+  attemptStartMs = Date.now();
+  protocolSent = 0;
+  protocolReceived = 0;
+  pendingIds = new Set();
+  lastSentMethods = [];
+  lastReceivedMethods = [];
+  firstSendMs = 0;
+  lastReceiveMs = 0;
+  crashpadMatched = false;
+  crashpadSignatures = [];
+  rendererCrashSeen = false;
+  mainExitCode = null;
+  mainExitSignal = null;
+  malformedCount = 0;
+}
+
+export function observeStderrLine(line: string): void {
+  if (!isEnabled()) return;
+  for (const sig of CRASHPAD_SIGNATURES) {
+    if (line.includes(sig)) {
+      crashpadMatched = true;
+      crashpadSignatures.unshift(sig);
+      if (crashpadSignatures.length > MAX_SIGNATURE_LIST) crashpadSignatures.pop();
+      break;
+    }
+  }
+}
+
+export function observeMainProcessExit(code: number | null, signal: string | null): void {
+  mainExitCode = code;
+  mainExitSignal = signal;
+}
+
+export function observeRendererCrash(): void {
+  rendererCrashSeen = true;
+}
+
+export function classify(): LaunchFailureMode {
+  if (rendererCrashSeen) return "webcontents-crash";
+  if (mainExitCode !== null && mainExitCode !== 0) return "main-process-exit";
+  if (mainExitSignal !== null) return "main-process-exit";
+  if (crashpadMatched) return "crashpad-stderr";
+  if (
+    protocolSent >= CDP_SILENT_MIN_SENT &&
+    protocolReceived === 0 &&
+    Date.now() - attemptStartMs >= CDP_SILENT_MIN_ELAPSED_MS
+  ) {
+    return "cdp-handshake-silent";
+  }
+  return "unknown";
+}
+
+function snapshot(): ProtocolSnapshot {
+  return {
+    sent: protocolSent,
+    received: protocolReceived,
+    pending: pendingIds.size,
+    lastSentMethods: [...lastSentMethods],
+    lastReceivedMethods: [...lastReceivedMethods],
+    firstSendMs,
+    lastReceiveMs,
+  };
+}
+
+function buildSummary(mode: LaunchFailureMode): TelemetrySummary {
+  const proto = snapshot();
+  return {
+    timestamp: new Date().toISOString(),
+    attempt: currentAttempt,
+    maxAttempts: currentMaxAttempts,
+    mode,
+    elapsedMs: Date.now() - attemptStartMs,
+    protocol: {
+      sent: proto.sent,
+      received: proto.received,
+      pending: proto.pending,
+      lastSentMethods: proto.lastSentMethods,
+      lastReceivedMethods: proto.lastReceivedMethods,
+    },
+    crashpad: { matched: crashpadMatched, signatures: [...crashpadSignatures] },
+    rendererCrash: { seen: rendererCrashSeen },
+    mainExit: { code: mainExitCode, signal: mainExitSignal },
+  };
+}
+
+export function writeSummary(mode?: LaunchFailureMode): string {
+  const resolved = mode ?? classify();
+  const summary = buildSummary(resolved);
+
+  const shortLine =
+    `[e2e_launch_telemetry] attempt=${summary.attempt}/${summary.maxAttempts}` +
+    ` mode=${summary.mode} elapsedMs=${summary.elapsedMs}` +
+    ` sent=${summary.protocol.sent} recv=${summary.protocol.received}` +
+    ` pending=${summary.protocol.pending}` +
+    (summary.protocol.lastSentMethods.length > 0
+      ? ` lastSend=${summary.protocol.lastSentMethods[0]}`
+      : "") +
+    (summary.protocol.lastReceivedMethods.length > 0
+      ? ` lastRecv=${summary.protocol.lastReceivedMethods[0]}`
+      : "") +
+    (summary.crashpad.matched ? ` crashpad=${summary.crashpad.signatures[0]}` : "") +
+    (summary.rendererCrash.seen ? " rendererCrash=true" : "") +
+    (summary.mainExit.code !== null ? ` exitCode=${summary.mainExit.code}` : "") +
+    (summary.mainExit.signal !== null ? ` exitSignal=${summary.mainExit.signal}` : "");
+
+  const telemetryFile = process.env.E2E_LAUNCH_TELEMETRY_FILE;
+  if (telemetryFile) {
+    try {
+      mkdirSync(path.dirname(telemetryFile), { recursive: true });
+      appendFileSync(telemetryFile, JSON.stringify(summary) + "\n", "utf-8");
+    } catch {
+      // Telemetry is best-effort; never fail the launch path.
+    }
+  }
+
+  process.stderr.write(`${shortLine}\n`);
+  return resolved;
+}
+
+export function dispose(): void {
+  restoreStderr();
+  currentAttempt = 0;
+  currentMaxAttempts = 0;
+  attemptStartMs = 0;
+  protocolSent = 0;
+  protocolReceived = 0;
+  pendingIds = new Set();
+  lastSentMethods = [];
+  lastReceivedMethods = [];
+  firstSendMs = 0;
+  lastReceiveMs = 0;
+  crashpadMatched = false;
+  crashpadSignatures = [];
+  rendererCrashSeen = false;
+  mainExitCode = null;
+  mainExitSignal = null;
+  malformedCount = 0;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
       "src/**/*.{test,spec}.{js,ts,jsx,tsx}",
       "shared/**/*.{test,spec}.{js,ts}",
       "scripts/**/*.{test,spec}.{js,ts,mjs}",
-      "e2e/**/*.{test,spec}.{js,ts}",
+      "e2e/helpers/__tests__/*.{test,spec}.{js,ts}",
       "plugins/**/*.{test,spec}.{js,ts,jsx,tsx}",
     ],
     exclude: [

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       "src/**/*.{test,spec}.{js,ts,jsx,tsx}",
       "shared/**/*.{test,spec}.{js,ts}",
       "scripts/**/*.{test,spec}.{js,ts,mjs}",
+      "e2e/**/*.{test,spec}.{js,ts}",
       "plugins/**/*.{test,spec}.{js,ts,jsx,tsx}",
     ],
     exclude: [


### PR DESCRIPTION
## Summary

This adds launch telemetry that classifies E2E launch failures on Windows CI into one of four modes. The intent is to gather attribution data so we can collapse retry layers based on what each one actually mitigates.

Right now the E2E retry stack compounds to ~6 attempts and hides flake telemetry from any reporter plugged into the suite. This is step one: instrument first, then collapse once we have signal.

## Changes

- New `launchTelemetry.ts` helper parses `DEBUG=pw:protocol,pw:browser` output to classify launch failures as CDP-handshake, crashpad stderr, `WebContents.crash`, or main-process exit
- Wired into the in-helper retry loop in `launch.ts` so each attempt logs its failure mode before retrying
- Surfaces malformed protocol frame count in the telemetry summary line for cases where the DEBUG output is garbled
- Unit tests covering all four failure modes, malformed protocol handling, and summary line formatting
- Enabled `DEBUG=pw:protocol,pw:browser` on Windows CI legs in the E2E workflow

Resolves #9115

## Testing

- `launchTelemetry.test.ts` covers classification, malformed frame handling, and summary formatting
- `npm run check` (typecheck + lint + format) clean