### PR TITLE
fix(e2e): capture Electron crash dumps and main-process logs in CI artifacts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -499,6 +499,40 @@ jobs:
           path: test-results/.last-run.json
           key: e2e-last-run-${{ runner.os }}-${{ runner.arch }}-${{ inputs.suite || 'core' }}-s${{ matrix.shard }}of${{ matrix.shardTotal }}-${{ github.run_id }}-${{ github.run_attempt }}
 
+      - name: Collect crash dumps (fallback from platform default paths)
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          FALLBACK_DIR="daintree-e2e-artifacts/fallback-crash-dumps"
+          mkdir -p "$FALLBACK_DIR"
+
+          case "$RUNNER_OS" in
+            macOS)
+              CRASHPAD_DIR="$HOME/Library/Application Support/Daintree/Crashpad"
+              ;;
+            Linux)
+              CRASHPAD_DIR="$HOME/.config/Daintree/Crashpad"
+              ;;
+            Windows)
+              CRASHPAD_DIR="$APPDATA/Daintree/Crashpad"
+              ;;
+            *)
+              echo "[e2e] Unknown OS, skipping fallback crash dump collection"
+              exit 0
+              ;;
+          esac
+
+          for subdir in new pending completed; do
+            if [ -d "$CRASHPAD_DIR/$subdir" ]; then
+              cp -r "$CRASHPAD_DIR/$subdir" "$FALLBACK_DIR/$subdir" 2>/dev/null || true
+            fi
+          done
+
+          # Count what we collected
+          COLLECTED=$(find "$FALLBACK_DIR" -type f 2>/dev/null | wc -l)
+          echo "[e2e] Fallback crash dump collection: $COLLECTED files"
+
       - name: Upload test results
         if: always()
         continue-on-error: true
@@ -508,5 +542,6 @@ jobs:
           path: |
             test-results/
             playwright-report/
+            daintree-e2e-artifacts/
           retention-days: 7
           if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ coverage/
 test-results/
 playwright-report/
 blob-report/
+daintree-e2e-artifacts/
 
 # Temp files
 tmp/

--- a/e2e/helpers/launch.ts
+++ b/e2e/helpers/launch.ts
@@ -1,6 +1,6 @@
 import { _electron as electron, type ElectronApplication, type Page } from "@playwright/test";
 import { createRequire } from "module";
-import { mkdtempSync, unlinkSync, readdirSync } from "fs";
+import { mkdtempSync, mkdirSync, unlinkSync, readdirSync, appendFileSync } from "fs";
 import { tmpdir } from "os";
 import { execSync } from "child_process";
 import path from "path";
@@ -195,6 +195,25 @@ export async function launchApp(options: LaunchOptions = {}): Promise<AppContext
       delete launchEnv.ELECTRON_RUN_AS_NODE;
       delete launchEnv.ATOM_SHELL_INTERNAL_RUN_AS_NODE;
 
+      // Route crash dumps and Chromium logs into workspace-relative paths so
+      // CI artifact upload captures them. Per-launch uniqueness avoids
+      // collisions across parallel Playwright workers and retry attempts.
+      const artifactRoot = path.join(ROOT, "daintree-e2e-artifacts");
+      const launchId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const crashDumpsDir = path.join(artifactRoot, "crash-dumps", launchId);
+      const logsDir = path.join(artifactRoot, "logs");
+      const logFile = path.join(logsDir, `electron-main-${launchId}.log`);
+      mkdirSync(crashDumpsDir, { recursive: true });
+      mkdirSync(logsDir, { recursive: true });
+      launchEnv.DAINTREE_E2E_CRASH_DUMPS_DIR = crashDumpsDir;
+      launchEnv.ELECTRON_ENABLE_LOGGING = "file";
+      launchEnv.ELECTRON_LOG_FILE = logFile;
+      args.push(
+        `--crash-reporter-directory=${crashDumpsDir}`,
+        "--enable-logging=file",
+        `--log-file=${logFile}`
+      );
+
       app = await electron.launch({
         executablePath: electronPath,
         args,
@@ -208,9 +227,19 @@ export async function launchApp(options: LaunchOptions = {}): Promise<AppContext
         const proc = app.process();
         proc.stdout?.on("data", (chunk: Buffer) => {
           process.stderr.write(`[E2E_STDOUT] ${chunk.toString()}`);
+          try {
+            appendFileSync(logFile, `[STDOUT] ${chunk.toString()}`);
+          } catch {
+            /* best-effort file tee */
+          }
         });
         proc.stderr?.on("data", (chunk: Buffer) => {
           process.stderr.write(`[E2E_STDERR] ${chunk.toString()}`);
+          try {
+            appendFileSync(logFile, `[STDERR] ${chunk.toString()}`);
+          } catch {
+            /* best-effort file tee */
+          }
         });
         proc.on("exit", (code: number | null, signal: string | null) => {
           process.stderr.write(`[E2E_EXIT] code=${code} signal=${signal}\n`);

--- a/e2e/helpers/launch.ts
+++ b/e2e/helpers/launch.ts
@@ -198,21 +198,21 @@ export async function launchApp(options: LaunchOptions = {}): Promise<AppContext
       // Route crash dumps and Chromium logs into workspace-relative paths so
       // CI artifact upload captures them. Per-launch uniqueness avoids
       // collisions across parallel Playwright workers and retry attempts.
+      //
+      // crashDumps are redirected via app.setPath("crashDumps") in
+      // electron/setup/environment.ts (reads DAINTREE_E2E_CRASH_DUMPS_DIR).
+      // Chromium logging goes to a file via --enable-logging=file --log-file.
+      // Main-process stdout/stderr is teed to a separate file below.
       const artifactRoot = path.join(ROOT, "daintree-e2e-artifacts");
       const launchId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
       const crashDumpsDir = path.join(artifactRoot, "crash-dumps", launchId);
       const logsDir = path.join(artifactRoot, "logs");
       const logFile = path.join(logsDir, `electron-main-${launchId}.log`);
+      const teeFile = path.join(logsDir, `electron-main-${launchId}-tee.log`);
       mkdirSync(crashDumpsDir, { recursive: true });
       mkdirSync(logsDir, { recursive: true });
       launchEnv.DAINTREE_E2E_CRASH_DUMPS_DIR = crashDumpsDir;
-      launchEnv.ELECTRON_ENABLE_LOGGING = "file";
-      launchEnv.ELECTRON_LOG_FILE = logFile;
-      args.push(
-        `--crash-reporter-directory=${crashDumpsDir}`,
-        "--enable-logging=file",
-        `--log-file=${logFile}`
-      );
+      args.push("--enable-logging=file", `--log-file=${logFile}`);
 
       app = await electron.launch({
         executablePath: electronPath,
@@ -228,7 +228,7 @@ export async function launchApp(options: LaunchOptions = {}): Promise<AppContext
         proc.stdout?.on("data", (chunk: Buffer) => {
           process.stderr.write(`[E2E_STDOUT] ${chunk.toString()}`);
           try {
-            appendFileSync(logFile, `[STDOUT] ${chunk.toString()}`);
+            appendFileSync(teeFile, `[STDOUT] ${chunk.toString()}`);
           } catch {
             /* best-effort file tee */
           }
@@ -236,7 +236,7 @@ export async function launchApp(options: LaunchOptions = {}): Promise<AppContext
         proc.stderr?.on("data", (chunk: Buffer) => {
           process.stderr.write(`[E2E_STDERR] ${chunk.toString()}`);
           try {
-            appendFileSync(logFile, `[STDERR] ${chunk.toString()}`);
+            appendFileSync(teeFile, `[STDERR] ${chunk.toString()}`);
           } catch {
             /* best-effort file tee */
           }

--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -50,6 +50,17 @@ if (!app.isPackaged && !hasExplicitUserDataDir) {
   );
 }
 
+// E2E: redirect crash dumps to workspace-relative path so CI artifact upload
+// captures them. Runs before crashReporter.start() (main.ts:158) because
+// environment.ts is imported synchronously at the top of main.ts.
+if (
+  process.env.DAINTREE_E2E_MODE === "1" &&
+  process.env.DAINTREE_E2E_CRASH_DUMPS_DIR &&
+  path.isAbsolute(process.env.DAINTREE_E2E_CRASH_DUMPS_DIR)
+) {
+  app.setPath("crashDumps", process.env.DAINTREE_E2E_CRASH_DUMPS_DIR);
+}
+
 // Handle --reset-data: wipe userData before Chromium acquires file locks
 // AND before reading any flag files below — otherwise a reset-while-disabled
 // launch would carry the stale GPU flag forward by one cycle.


### PR DESCRIPTION
## Summary

When Electron crashes during an E2E run, the uploaded artifact has `test-results/` and `playwright-report/` but no crash dump or main-process log. Crashpad writes to platform-specific paths outside the workspace, so `upload-artifact` never sees them. This routes everything into a workspace-relative directory that CI already picks up.

## Changes

- Route crash dumps to `daintree-e2e-artifacts/crash-dumps/<launch-id>/` via `app.setPath("crashDumps")`, gated behind `DAINTREE_E2E_MODE` so it never fires in production
- Enable Chromium file logging (`--enable-logging=file --log-file`) per launch
- Tee main-process stdout and stderr to a per-launch `electron-main-<id>-tee.log` for offline debugging
- Add a CI fallback step that copies dumps from platform-default Crashpad paths when the env-var redirect doesn't catch them
- Include `daintree-e2e-artifacts/` in the `upload-artifact` glob and add a `.gitignore` entry for local runs

Resolves #9116