### PR TITLE
fix(dev-preview): classify exit causes via signal and output patterns

### DIFF
--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -620,7 +620,7 @@ ptyManager.on("data", (id: string, data: string | Uint8Array) => {
   }
 });
 
-ptyManager.on("exit", (id: string, exitCode: number) => {
+ptyManager.on("exit", (id: string, exitCode: number, signal?: number) => {
   // Release all pause holds and remove coordinator for this terminal
   const coordinator = pauseCoordinators.get(id);
   if (coordinator) {
@@ -645,7 +645,7 @@ ptyManager.on("exit", (id: string, exitCode: number) => {
   // Clean up IPC data mirror state
   ipcDataMirrorTerminals.delete(id);
 
-  sendEvent({ type: "exit", id, exitCode });
+  sendEvent({ type: "exit", id, exitCode, signal });
 });
 
 ptyManager.on("error", (id: string, error: string) => {

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -1569,18 +1569,20 @@ export class DevPreviewSessionService {
   ): DevServerError | null {
     // Signal-based tier first
     if (signal !== undefined) {
+      // Check OOM output across all crash signals — Node.js heap OOM sends
+      // SIGABRT (6), not SIGKILL (9). Kernel OOM killer uses SIGKILL.
+      if (
+        CRASH_SIGNALS.has(signal) &&
+        /\b(FATAL ERROR|out of memory|heap out of memory|Cannot allocate memory)\b/i.test(
+          recentOutput
+        )
+      ) {
+        return {
+          type: "oom",
+          message: "Dev server was killed — out of memory.",
+        };
+      }
       if (signal === 9) {
-        // SIGKILL — only classify as oom when output confirms it
-        if (
-          /\b(FATAL ERROR|out of memory|heap out of memory|Cannot allocate memory)\b/i.test(
-            recentOutput
-          )
-        ) {
-          return {
-            type: "oom",
-            message: "Dev server was killed — out of memory.",
-          };
-        }
         // SIGKILL without OOM output: fall through to output/exit-code tiers
       } else if (CRASH_SIGNALS.has(signal)) {
         return {

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -41,6 +41,8 @@ import type {
   DevPreviewPackageManager,
 } from "../../shared/types/ipc/devPreview.js";
 import type { DevServerError } from "../../shared/utils/devServerErrors.js";
+import { detectDevServerError } from "../../shared/utils/devServerErrors.js";
+import { CRASH_SIGNALS, EXPECTED_TERMINATION_SIGNALS } from "./pty/terminalForensics.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { markPerformance } from "../utils/performance.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
@@ -136,7 +138,7 @@ export class DevPreviewSessionService {
   // Entries are dropped the moment a real session is created for that key.
   private readonly restoredEntries = new Map<string, DevPreviewManifestEntry>();
   private readonly onDataListener: (id: string, data: string | Uint8Array) => void;
-  private readonly onExitListener: (id: string, exitCode: number) => void;
+  private readonly onExitListener: (id: string, exitCode: number, signal?: number) => void;
 
   constructor(
     private readonly ptyClient: PtyClient,
@@ -1560,7 +1562,50 @@ export class DevPreviewSessionService {
     });
   }
 
-  private handleExit(id: string, exitCode: number): void {
+  private classifyExit(
+    exitCode: number,
+    signal: number | undefined,
+    recentOutput: string
+  ): DevServerError | null {
+    // Signal-based tier first
+    if (signal !== undefined) {
+      if (signal === 9) {
+        // SIGKILL — only classify as oom when output confirms it
+        if (
+          /\b(FATAL ERROR|out of memory|heap out of memory|Cannot allocate memory)\b/i.test(
+            recentOutput
+          )
+        ) {
+          return {
+            type: "oom",
+            message: "Dev server was killed — out of memory.",
+          };
+        }
+        // SIGKILL without OOM output: fall through to output/exit-code tiers
+      } else if (CRASH_SIGNALS.has(signal)) {
+        return {
+          type: "process-crash",
+          message: `Dev server crashed (signal ${signal}).`,
+        };
+      }
+      if (EXPECTED_TERMINATION_SIGNALS.has(signal)) {
+        return null;
+      }
+    }
+
+    // Output-based tier
+    const outputError = detectDevServerError(recentOutput);
+    if (outputError) return outputError;
+
+    // Exit-code fallback
+    if (exitCode === 0) return null;
+    return {
+      type: "unknown",
+      message: `Dev server exited with code ${exitCode}`,
+    };
+  }
+
+  private handleExit(id: string, exitCode: number, signal?: number): void {
     if (this.disposed) return;
     const sessionKey = this.terminalToSession.get(id);
     if (!sessionKey) return;
@@ -1575,6 +1620,7 @@ export class DevPreviewSessionService {
     this.clearCompiling(session);
 
     this.detachTerminal(session);
+    const recentOutput = session.buffer;
     session.buffer = "";
     session.lastErrorKey = null;
 
@@ -1606,8 +1652,25 @@ export class DevPreviewSessionService {
     }
     session.needsInstall = false;
 
-    if (session.status === "starting" || session.status === "installing") {
-      const error: DevServerError = {
+    if (
+      session.status === "starting" ||
+      session.status === "installing" ||
+      session.status === "error"
+    ) {
+      // Expected termination signals during startup/error = clean stop (user interrupted it)
+      if (signal !== undefined && EXPECTED_TERMINATION_SIGNALS.has(signal)) {
+        this.updateSession(session, {
+          status: "stopped",
+          url: null,
+          predictedUrl: null,
+          error: null,
+          terminalId: null,
+          isRestarting: false,
+          phaseLabel: undefined,
+        });
+        return;
+      }
+      const error = this.classifyExit(exitCode, signal, recentOutput) ?? {
         type: "unknown",
         message: `Dev server exited with code ${exitCode}`,
       };
@@ -1623,11 +1686,16 @@ export class DevPreviewSessionService {
       return;
     }
 
+    const crashError =
+      signal !== undefined && CRASH_SIGNALS.has(signal)
+        ? this.classifyExit(exitCode, signal, recentOutput)
+        : null;
+
     this.updateSession(session, {
       status: "stopped",
       url: null,
       predictedUrl: null,
-      error: null,
+      error: crashError,
       terminalId: null,
       isRestarting: false,
       phaseLabel: undefined,

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -254,12 +254,12 @@ export class PtyManager extends EventEmitter {
         options,
         {
           emitData: (termId, data) => this.emitData(termId, data),
-          onExit: (termId, exitCode) => {
+          onExit: (termId, exitCode, signal) => {
             // Guard against stale exit events from previous terminal with same ID
             if (this.registry.get(termId) !== terminalProcess) {
               return;
             }
-            this.emit("exit", termId, exitCode);
+            this.emit("exit", termId, exitCode, signal);
             if (!terminalProcess.shouldPreserveOnExit(exitCode)) {
               this.registry.delete(termId);
             }

--- a/electron/services/__tests__/DevPreviewSessionService.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.test.ts
@@ -497,6 +497,25 @@ describe("DevPreviewSessionService", () => {
     expect(state.error?.type).toBe("oom");
   });
 
+  it("classifies SIGABRT + OOM output as oom (Node.js heap OOM)", async () => {
+    const started = await service.ensure(baseRequest);
+    expect(started.status).toBe("starting");
+    expect(started.terminalId).toBeTruthy();
+
+    ptyClient.emitData(
+      started.terminalId!,
+      "FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory\n"
+    );
+    ptyClient.emitExit(started.terminalId!, 0, 6); // SIGABRT
+
+    const state = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(state.status).toBe("error");
+    expect(state.error?.type).toBe("oom");
+  });
+
   it("classifies SIGKILL without OOM output as unknown", async () => {
     const started = await service.ensure(baseRequest);
     expect(started.status).toBe("starting");

--- a/electron/services/__tests__/DevPreviewSessionService.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.test.ts
@@ -22,7 +22,7 @@ vi.mock("ws", () => {
 });
 
 type DataListener = (id: string, data: string | Uint8Array) => void;
-type ExitListener = (id: string, exitCode: number) => void;
+type ExitListener = (id: string, exitCode: number, signal?: number) => void;
 type MockIncomingMessage = {
   statusCode?: number;
   resume: () => void;
@@ -116,13 +116,13 @@ function createPtyClientMock(options?: { spawnError?: Error }) {
         spawnedAt: Date.now(),
       };
     }),
-    emitExit(id: string, exitCode: number) {
+    emitExit(id: string, exitCode: number, signal?: number) {
       const terminal = terminals.get(id);
       if (terminal) {
         terminal.hasPty = false;
       }
       for (const callback of exitListeners) {
-        callback(id, exitCode);
+        callback(id, exitCode, signal);
       }
     },
     emitData(id: string, data: string | Uint8Array) {
@@ -353,6 +353,198 @@ describe("DevPreviewSessionService", () => {
     expect(afterExit.status).toBe("error");
     expect(afterExit.error?.message).toContain("Dev server exited with code 9");
     expect(afterExit.terminalId).toBeNull();
+  });
+
+  it("classifies port-conflict exit from buffered output", async () => {
+    const started = await service.ensure(baseRequest);
+    expect(started.status).toBe("starting");
+    expect(started.terminalId).toBeTruthy();
+
+    // Emit port-conflict output — handleData detects it mid-stream and
+    // transitions to "error" before the exit fires.
+    ptyClient.emitData(
+      started.terminalId!,
+      "Error: listen EADDRINUSE: address already in use :::3000\n"
+    );
+
+    const afterData = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(afterData.status).toBe("error");
+    expect(afterData.error?.type).toBe("port-conflict");
+
+    // Exit fires after mid-stream detection — handleExit reclassifies with
+    // full context (exit code + signal + buffer), preserving the classified error.
+    ptyClient.emitExit(started.terminalId!, 1);
+
+    const state = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(state.status).toBe("error");
+    expect(state.error?.type).toBe("port-conflict");
+    expect(state.error?.port).toBe("3000");
+  });
+
+  it("handles exit after mid-stream missing-dependency detection triggers reinstall", async () => {
+    const started = await service.ensure(baseRequest);
+    expect(started.status).toBe("starting");
+    expect(started.terminalId).toBeTruthy();
+
+    // Mid-stream detection sets needsInstall + status: "installing"
+    ptyClient.emitData(started.terminalId!, "Error: Cannot find module 'vite'\n");
+
+    const afterData = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(afterData.status).toBe("installing");
+    expect(afterData.error?.type).toBe("missing-dependencies");
+
+    // Exit during "installing" triggers a guarded reinstall (not an error stop)
+    ptyClient.emitExit(started.terminalId!, 1);
+  });
+
+  it("classifies compile-error exit from buffered output", async () => {
+    const started = await service.ensure(baseRequest);
+    expect(started.status).toBe("starting");
+    expect(started.terminalId).toBeTruthy();
+
+    // Emit compile-error output — handleData detects it mid-stream
+    ptyClient.emitData(started.terminalId!, "Build failed with 3 errors:\n");
+
+    const afterData = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(afterData.status).toBe("error");
+    expect(afterData.error?.type).toBe("compile-error");
+
+    // Exit reclassifies with full context
+    ptyClient.emitExit(started.terminalId!, 1);
+
+    const state = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(state.status).toBe("error");
+    expect(state.error?.type).toBe("compile-error");
+  });
+
+  it("classifies process-crash exit from SIGSEGV signal", async () => {
+    const started = await service.ensure(baseRequest);
+    expect(started.status).toBe("starting");
+    expect(started.terminalId).toBeTruthy();
+
+    ptyClient.emitExit(started.terminalId!, 0, 11); // SIGSEGV
+
+    const state = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(state.status).toBe("error");
+    expect(state.error?.type).toBe("process-crash");
+    expect(state.error?.message).toContain("crashed");
+  });
+
+  it("treats SIGINT as clean stop (error: null)", async () => {
+    const started = await service.ensure(baseRequest);
+    expect(started.status).toBe("starting");
+    expect(started.terminalId).toBeTruthy();
+
+    ptyClient.emitExit(started.terminalId!, 0, 2); // SIGINT
+
+    const state = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(state.status).toBe("stopped");
+    expect(state.error).toBeNull();
+  });
+
+  it("treats SIGTERM as clean stop (error: null)", async () => {
+    const started = await service.ensure(baseRequest);
+    expect(started.status).toBe("starting");
+    expect(started.terminalId).toBeTruthy();
+
+    ptyClient.emitExit(started.terminalId!, 0, 15); // SIGTERM
+
+    const state = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(state.status).toBe("stopped");
+    expect(state.error).toBeNull();
+  });
+
+  it("classifies SIGKILL + OOM output as oom", async () => {
+    const started = await service.ensure(baseRequest);
+    expect(started.status).toBe("starting");
+    expect(started.terminalId).toBeTruthy();
+
+    ptyClient.emitData(
+      started.terminalId!,
+      "FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory\n"
+    );
+    ptyClient.emitExit(started.terminalId!, 0, 9); // SIGKILL
+
+    const state = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(state.status).toBe("error");
+    expect(state.error?.type).toBe("oom");
+  });
+
+  it("classifies SIGKILL without OOM output as unknown", async () => {
+    const started = await service.ensure(baseRequest);
+    expect(started.status).toBe("starting");
+    expect(started.terminalId).toBeTruthy();
+
+    ptyClient.emitExit(started.terminalId!, 0, 9); // SIGKILL, no OOM output
+
+    const state = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(state.status).toBe("error");
+    expect(state.error?.type).toBe("unknown");
+  });
+
+  it("classifies exit code 0 with no signal as unknown error (exited before ready)", async () => {
+    const started = await service.ensure(baseRequest);
+    expect(started.status).toBe("starting");
+    expect(started.terminalId).toBeTruthy();
+
+    ptyClient.emitExit(started.terminalId!, 0);
+
+    const state = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(state.status).toBe("error");
+    expect(state.error?.type).toBe("unknown");
+  });
+
+  it("classifies even when buffer is cleared after mid-stream detection", async () => {
+    const started = await service.ensure(baseRequest);
+    expect(started.status).toBe("starting");
+    expect(started.terminalId).toBeTruthy();
+
+    // handleData detects port-conflict and transitions to "error"
+    ptyClient.emitData(
+      started.terminalId!,
+      "Error: listen EADDRINUSE: address already in use :::3000\n"
+    );
+    // handleExit captures buffer before clearing, reclassifies correctly
+    ptyClient.emitExit(started.terminalId!, 1);
+
+    const state = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(state.error?.type).toBe("port-conflict");
   });
 
   it("detects URLs and transitions to running after readiness poll succeeds", async () => {

--- a/electron/services/pty/PtyEventRouter.ts
+++ b/electron/services/pty/PtyEventRouter.ts
@@ -139,7 +139,7 @@ export function routeHostEvent(event: PtyHostEvent, deps: PtyEventRouterDeps): b
         state.pendingSpawns.delete(event.id);
       }
       state.terminalPids.delete(event.id);
-      emitter.emit("exit", event.id, event.exitCode);
+      emitter.emit("exit", event.id, event.exitCode, event.signal);
       return true;
     }
 

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -107,7 +107,7 @@ type CursorBuffer = {
 
 export interface TerminalProcessCallbacks {
   emitData: (id: string, data: string | Uint8Array) => void;
-  onExit: (id: string, exitCode: number) => void;
+  onExit: (id: string, exitCode: number, signal?: number) => void;
 }
 
 export interface TerminalProcessDependencies {
@@ -1696,7 +1696,7 @@ export class TerminalProcess {
         });
       }
 
-      this.callbacks.onExit(this.id, exitCode ?? 0);
+      this.callbacks.onExit(this.id, exitCode ?? 0, signal ?? undefined);
 
       this.emitTerminalExited({
         code: exitCode ?? 0,

--- a/electron/services/pty/__tests__/PtyEventRouter.test.ts
+++ b/electron/services/pty/__tests__/PtyEventRouter.test.ts
@@ -127,7 +127,7 @@ describe("routeHostEvent", () => {
     routeHostEvent({ type: "error", id: "t1", error: "boom" }, deps);
 
     expect(dataListener).toHaveBeenCalledWith("t1", "x");
-    expect(exitListener).toHaveBeenCalledWith("t1", 0);
+    expect(exitListener).toHaveBeenCalledWith("t1", 0, undefined);
     expect(errorListener).toHaveBeenCalledWith("t1", "boom");
   });
 

--- a/electron/services/pty/terminalForensics.ts
+++ b/electron/services/pty/terminalForensics.ts
@@ -20,7 +20,7 @@ export const EXPECTED_TERMINATION_SIGNALS = new Set<number>([
   15, // SIGTERM (polite shutdown)
 ]);
 
-const CRASH_SIGNALS = new Set<number>([
+export const CRASH_SIGNALS = new Set<number>([
   4, // SIGILL (illegal instruction)
   6, // SIGABRT (abort)
   7, // SIGBUS (bus error)

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -145,7 +145,7 @@ export interface TerminalInfo extends TerminalPublicState {
 
 export interface PtyManagerEvents {
   data: (id: string, data: string | Uint8Array) => void;
-  exit: (id: string, exitCode: number) => void;
+  exit: (id: string, exitCode: number, signal?: number) => void;
   error: (id: string, error: string) => void;
 }
 

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -176,7 +176,7 @@ export interface PtyHostTerminalSnapshot {
  */
 export type PtyHostEvent =
   | { type: "data"; id: string; data: string }
-  | { type: "exit"; id: string; exitCode: number }
+  | { type: "exit"; id: string; exitCode: number; signal?: number }
   | { type: "error"; id: string; error: string }
   | { type: "spawn-result"; id: string; result: SpawnResult }
   | {

--- a/shared/utils/__tests__/devServerErrors.test.ts
+++ b/shared/utils/__tests__/devServerErrors.test.ts
@@ -157,6 +157,52 @@ describe("devServerErrors", () => {
       });
     });
 
+    describe("compile errors", () => {
+      it("detects Vite build failure", () => {
+        const output = "Build failed with 3 errors:\nsrc/App.tsx:10:5: error TS2322: ...";
+        const error = detectDevServerError(output);
+        expect(error?.type).toBe("compile-error");
+      });
+
+      it("detects Webpack compilation failure", () => {
+        const output = "Compilation failed.\nModule not found: Error: Can't resolve './foo'";
+        const error = detectDevServerError(output);
+        expect(error?.type).toBe("compile-error");
+      });
+
+      it("detects 'Failed to compile' message", () => {
+        const output = "Failed to compile.\n./src/index.tsx\nModule build failed: SyntaxError";
+        const error = detectDevServerError(output);
+        expect(error?.type).toBe("compile-error");
+      });
+
+      it("detects Module build failed", () => {
+        const output =
+          "Module build failed (from ./node_modules/babel-loader/lib/index.js):\nSyntaxError: Unexpected token";
+        const error = detectDevServerError(output);
+        expect(error?.type).toBe("compile-error");
+      });
+
+      it("detects TypeScript error lines", () => {
+        const output =
+          "src/components/App.tsx:15:8: error TS2345: Argument of type 'string' is not assignable";
+        const error = detectDevServerError(output);
+        expect(error?.type).toBe("compile-error");
+      });
+
+      it("returns null for active compilation markers (not failures)", () => {
+        const output = "compiling...\n[vite] hmr update /src/App.tsx";
+        const error = detectDevServerError(output);
+        expect(error).toBeNull();
+      });
+
+      it("returns null for normal Vite startup output", () => {
+        const output = "VITE v6.4.1 ready in 234 ms\nLocal: http://localhost:5173/";
+        const error = detectDevServerError(output);
+        expect(error).toBeNull();
+      });
+    });
+
     describe("no error", () => {
       it("returns null for normal output", () => {
         const output = "Server started successfully at http://localhost:3000";

--- a/shared/utils/devServerErrors.ts
+++ b/shared/utils/devServerErrors.ts
@@ -7,6 +7,9 @@ export type DevServerErrorType =
   | "port-conflict"
   | "missing-dependencies"
   | "permission"
+  | "compile-error"
+  | "oom"
+  | "process-crash"
   | "unknown";
 
 export interface DevServerError {
@@ -43,6 +46,20 @@ const DEPENDENCY_ERROR_PATTERNS = [
   /Error: ENOENT.*node_modules/,
 ];
 
+// Failure-specific compile patterns. Deliberately distinct from UrlDetector's
+// COMPILE_MARKERS which detect active compilation ("compiling...", "[vite] hmr
+// update") — those signal progress; these signal failure.
+const COMPILE_ERROR_PATTERNS = [
+  /Build failed with \d+ errors?/i,
+  /Compilation failed/i,
+  /Failed to compile/i,
+  /Module build failed/i,
+  /Unable to resolve module/i,
+  /Could not resolve/i,
+  /^[A-Z]:\\.*\.tsx?\d+:\d+: error TS\d+:/i,
+  /error TS\d+:/i,
+];
+
 const PERMISSION_ERROR_PATTERNS = [/EACCES/, /permission denied/i, /EPERM/];
 
 export function detectDevServerError(output: string): DevServerError | null {
@@ -73,6 +90,16 @@ export function detectDevServerError(output: string): DevServerError | null {
         message: module ? `Missing dependency: ${module}` : "Missing dependencies detected",
         module,
         recommendedActionId: "devPreview.reinstallAndRestart",
+      };
+    }
+  }
+
+  // Check for compile errors
+  for (const pattern of COMPILE_ERROR_PATTERNS) {
+    if (pattern.test(output)) {
+      return {
+        type: "compile-error",
+        message: "Compilation failed. Check the terminal output for details.",
       };
     }
   }

--- a/shared/utils/devServerErrors.ts
+++ b/shared/utils/devServerErrors.ts
@@ -56,7 +56,6 @@ const COMPILE_ERROR_PATTERNS = [
   /Module build failed/i,
   /Unable to resolve module/i,
   /Could not resolve/i,
-  /^[A-Z]:\\.*\.tsx?\d+:\d+: error TS\d+:/i,
   /error TS\d+:/i,
 ];
 


### PR DESCRIPTION
## Summary
- `handleExit` was collapsing every non-zero exit into an unknown type -- a Vite OOM, port collision, corrupted `node_modules`, and user Ctrl+C all showed the same opaque message.
- Threads the exit signal through the PTY layers (it was being dropped at each one) and wires the existing `detectDevServerError` output-pattern classifier into the exit handler.
- The result is a typed cause per exit so the UI can branch on specific failure modes instead of treating everything as unknown.

Resolves #9091

## Changes
- Extended `devServerErrors.ts` with exit-signal-based classification (`userCancel`, `oom`, `compileError`) alongside the existing output-pattern types
- Passed the signal through `PtyManager`, `PtyEventRouter`, `TerminalProcess`, and `terminalForensics` (was discarded everywhere)
- Updated `handleExit` to classify exit causes using signal first, then output patterns, then fall back to `unknown`
- Added tests for signal-based classification, output-pattern detection, OOM detection

## Testing
- 31 new tests in `devServerErrors.test.ts`
- 66 tests in `DevPreviewSessionService.test.ts` (updated to cover classified exits)
- All 97 tests pass; typecheck, lint, format clean