### PR TITLE
feat(ci): signature-keyed dedup for nightly failures

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -59,6 +59,10 @@ on:
         description: "Optional total shard count for a single-shard rerun, e.g. 4. Must be paired with shard."
         type: string
         default: ""
+      json_report:
+        description: "Enable Playwright JSON reporter for machine-readable test results (nightly dedup)."
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       platform:
@@ -81,6 +85,10 @@ on:
         description: "Optional total shard count for a single-shard rerun. Must be paired with shard."
         type: string
         default: ""
+      json_report:
+        description: "Enable Playwright JSON reporter for machine-readable test results (nightly dedup)."
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -434,6 +442,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENCODE_E2E_ENABLED: ${{ inputs.suite == 'online' && '1' || '' }}
           FAIL_ON_FLAKY_TESTS: ${{ (inputs.suite == 'core' || inputs.suite == 'online') && 'true' || 'false' }}
+          PLAYWRIGHT_JSON_REPORT: ${{ inputs.json_report && '1' || '' }}
         run: |
           set -euo pipefail
           npx playwright test ${{ steps.test-cmd.outputs.args }} ${SHARD_ARGS:-} ${LAST_FAILED_ARGS:-}
@@ -445,6 +454,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENCODE_E2E_ENABLED: ${{ inputs.suite == 'online' && '1' || '' }}
           FAIL_ON_FLAKY_TESTS: ${{ (inputs.suite == 'core' || inputs.suite == 'online') && 'true' || 'false' }}
+          PLAYWRIGHT_JSON_REPORT: ${{ inputs.json_report && '1' || '' }}
         run: |
           set -euo pipefail
           xvfb-run --auto-servernum npx playwright test ${{ steps.test-cmd.outputs.args }} ${SHARD_ARGS:-} ${LAST_FAILED_ARGS:-}
@@ -463,6 +473,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENCODE_E2E_ENABLED: ${{ inputs.suite == 'online' && '1' || '' }}
           FAIL_ON_FLAKY_TESTS: ${{ (inputs.suite == 'core' || inputs.suite == 'online') && 'true' || 'false' }}
+          PLAYWRIGHT_JSON_REPORT: ${{ inputs.json_report && '1' || '' }}
         run: |
           set -euo pipefail
 
@@ -474,6 +485,28 @@ jobs:
           trap 'kill "$heartbeat_pid" 2>/dev/null || true' EXIT
 
           npx playwright test ${{ steps.test-cmd.outputs.args }} ${SHARD_ARGS:-} ${LAST_FAILED_ARGS:-}
+
+      # Extract structured failure data for nightly dedup. Only runs when
+      # the Playwright JSON reporter was enabled AND the test run failed.
+      - name: Extract failure signatures
+        if: failure() && inputs.json_report
+        shell: bash
+        run: |
+          if [ -f playwright-results.json ]; then
+            node scripts/ci/extract-failures.mjs playwright-results.json /tmp/failure-report.json
+          else
+            echo "[extract] No playwright-results.json found — skipping"
+            echo '[]' > /tmp/failure-report.json
+          fi
+
+      - name: Upload failure report
+        if: failure() && inputs.json_report
+        uses: actions/upload-artifact@v7
+        with:
+          name: failure-report-${{ inputs.suite || 'core' }}-${{ matrix.name }}-s${{ matrix.shard }}of${{ matrix.shardTotal }}
+          path: /tmp/failure-report.json
+          retention-days: 7
+          if-no-files-found: ignore
 
       # Persist .last-run.json for a potential job-level retry. Runs even on
       # Playwright failure (if: always()) — that's precisely when the retry

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -622,7 +622,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p failure-reports
-          ARTIFACTS=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" \
+          ARTIFACTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" \
             --jq '[.artifacts[] | select(.name | startswith("failure-report-"))] | length')
           echo "Found ${ARTIFACTS} failure-report artifact(s)"
 
@@ -632,7 +632,7 @@ jobs:
             exit 0
           fi
 
-          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" \
+          gh api --paginate "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" \
             --jq '.artifacts[] | select(.name | startswith("failure-report-")) | "\(.id)\t\(.name)"' \
             | while IFS=$'\t' read -r id name; do
               echo "Downloading artifact ${id} (${name})..."
@@ -663,8 +663,8 @@ jobs:
                 if (!fs.existsSync(reportPath)) continue;
 
                 // Parse OS from artifact name: failure-report-{suite}-{osName}-s{shard}of{total}
-                const parts = entry.name.split('-');
-                const osName = parts.slice(3).join('-').replace(/-s\d+of\d+$/, '');
+                const osMatch = entry.name.match(/-(Linux|macOS|Windows)-s\d+of\d+$/);
+                const osName = osMatch ? osMatch[1] : "unknown";
 
                 try {
                   const content = fs.readFileSync(reportPath, 'utf8');

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -424,6 +424,7 @@ jobs:
     with:
       suite: core
       platform: ${{ inputs.platform || 'all' }}
+      json_report: true
 
   # Six domain buckets, each a reusable-workflow call expanded across the OS
   # matrix inside e2e.yml. e2e.yml auto-shards every full-* suite 4 ways
@@ -448,6 +449,7 @@ jobs:
     with:
       suite: ${{ matrix.suite }}
       platform: ${{ inputs.platform || 'non-windows' }}
+      json_report: true
 
   e2e-online:
     needs: [check, test]
@@ -455,6 +457,7 @@ jobs:
     with:
       suite: online
       platform: ${{ inputs.platform || 'all' }}
+      json_report: true
     secrets: inherit
 
   # Memory-leak detection — runs the `nightly` E2E suite. e2e.yml forces
@@ -467,6 +470,7 @@ jobs:
     with:
       suite: nightly
       platform: ${{ inputs.platform || 'non-windows' }}
+      json_report: true
 
   publish:
     if: inputs.platform == '' || inputs.platform == 'all'
@@ -606,42 +610,270 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       issues: write
+      actions: read
 
     steps:
-      - name: Create or update failure issue
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Download failure reports
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p failure-reports
+          ARTIFACTS=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" \
+            --jq '[.artifacts[] | select(.name | startswith("failure-report-"))] | length')
+          echo "Found ${ARTIFACTS} failure-report artifact(s)"
+
+          if [ "$ARTIFACTS" -eq 0 ]; then
+            echo "No failure reports to process"
+            echo '[]' > failure-reports/all-failures.json
+            exit 0
+          fi
+
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" \
+            --jq '.artifacts[] | select(.name | startswith("failure-report-")) | "\(.id)\t\(.name)"' \
+            | while IFS=$'\t' read -r id name; do
+              echo "Downloading artifact ${id} (${name})..."
+              mkdir -p "failure-reports/${name}"
+              gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/${id}/zip" > "failure-reports/${name}.zip"
+              unzip -o "failure-reports/${name}.zip" -d "failure-reports/${name}/"
+            done
+
+      - name: Process failures and manage issues
         uses: actions/github-script@v8
         with:
           script: |
-            const title = `[Nightly] Tests failed on ${new Date().toISOString().split('T')[0]}`;
-            const label = 'nightly-failure';
-            const body = [
-              `The nightly test suite failed.`,
-              ``,
-              `**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              `**Date:** ${new Date().toISOString()}`,
-            ].join('\n');
+            const fs = require('node:fs');
+            const path = require('node:path');
 
-            const { data: issues } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: label,
-              state: 'open',
-              per_page: 1,
-            });
+            const workspace = process.env.GITHUB_WORKSPACE;
+            const mod = await import(path.join(workspace, 'scripts/ci/process-nightly-issues.mjs'));
 
-            if (issues.length > 0) {
+            // Collect all failure reports from downloaded artifacts
+            const reportsDir = path.join(workspace, 'failure-reports');
+            const allFailures = [];
+
+            if (fs.existsSync(reportsDir)) {
+              const entries = fs.readdirSync(reportsDir, { withFileTypes: true });
+              for (const entry of entries) {
+                if (!entry.isDirectory()) continue;
+                const reportPath = path.join(reportsDir, entry.name, 'failure-report.json');
+                if (!fs.existsSync(reportPath)) continue;
+
+                // Parse OS from artifact name: failure-report-{suite}-{osName}-s{shard}of{total}
+                const parts = entry.name.split('-');
+                const osName = parts.slice(3).join('-').replace(/-s\d+of\d+$/, '');
+
+                try {
+                  const content = fs.readFileSync(reportPath, 'utf8');
+                  const reports = JSON.parse(content);
+                  for (const r of reports) {
+                    allFailures.push({ ...r, os: osName });
+                  }
+                } catch (err) {
+                  console.error(`Failed to read ${reportPath}: ${err.message}`);
+                }
+              }
+            }
+
+            console.log(`Collected ${allFailures.length} failure(s) from artifacts`);
+
+            if (allFailures.length === 0) {
+              console.log('No test failures to process');
+              return;
+            }
+
+            const deduped = mod.deduplicateReports(allFailures);
+            const today = new Date().toISOString().split('T')[0];
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const runId = context.runId;
+
+            // Fetch all open nightly-failure issues
+            const openIssues = await github.paginate(
+              github.rest.issues.listForRepo,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: 'nightly-failure',
+                state: 'open',
+                per_page: 100,
+              }
+            );
+
+            console.log(`Fetched ${openIssues.length} open nightly-failure issues`);
+
+            // Parse metadata from each issue
+            const parsedIssues = openIssues.map((issue) => ({
+              number: issue.number,
+              title: issue.title,
+              body: issue.body,
+              labels: issue.labels.map((l) => l.name),
+              metadata: mod.parseMetadata(issue.body),
+            }));
+
+            // Process each unique failure signature
+            let created = 0;
+            let updated = 0;
+
+            for (const report of deduped) {
+              const existing = mod.findIssueBySignature(parsedIssues, report.signature);
+              const metadata = mod.nextMetadata(existing?.metadata ?? null, report, runId, runUrl, today);
+              const title = mod.buildIssueTitle(report);
+              const body = mod.buildIssueBody(report, metadata, runUrl);
+              const labels = mod.labelsForIssue(report);
+              const escalateLabels = mod.labelsForEscalation(metadata);
+
+              if (existing) {
+                const updateLabels = [...new Set([...existing.labels, ...labels, ...escalateLabels])];
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: existing.number,
+                  title,
+                  body,
+                  labels: updateLabels,
+                });
+
+                if (escalateLabels.length > 0 && !existing.labels.includes('human-review')) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: existing.number,
+                    body: mod.buildEscalationComment(),
+                  });
+                }
+
+                updated++;
+              } else {
+                await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title,
+                  body,
+                  labels: [...labels, ...escalateLabels],
+                });
+                created++;
+              }
+            }
+
+            console.log(`Created ${created} new issue(s), updated ${updated} existing issue(s)`);
+
+            // Stale sweep: close issues whose last_seen is >14 days ago
+            let staleClosed = 0;
+            for (const issue of parsedIssues) {
+              if (!issue.metadata) continue;
+              if (issue.labels.includes('human-review')) continue;
+              if (!mod.shouldStaleClose(issue.metadata, today)) continue;
+
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'not_planned',
+              });
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: issues[0].number,
-                body: body,
+                issue_number: issue.number,
+                body: 'Auto-closed: this failure has not been seen in over 14 days. If it recurs, a new issue will be created.',
               });
-            } else {
-              await github.rest.issues.create({
+              staleClosed++;
+            }
+
+            if (staleClosed > 0) {
+              console.log(`Stale-closed ${staleClosed} issue(s)`);
+            }
+
+  notify-success:
+    if: success() && github.event_name == 'schedule'
+    needs:
+      [
+        check,
+        test,
+        build,
+        integration-test,
+        knip,
+        e2e-core,
+        e2e-full,
+        e2e-online,
+        e2e-nightly,
+        publish,
+      ]
+    runs-on: ubuntu-22.04
+    permissions:
+      issues: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Close resolved failure issues
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const path = require('node:path');
+            const mod = await import(path.join(process.env.GITHUB_WORKSPACE, 'scripts/ci/process-nightly-issues.mjs'));
+
+            const today = new Date().toISOString().split('T')[0];
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const openIssues = await github.paginate(
+              github.rest.issues.listForRepo,
+              {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                title,
-                body,
-                labels: [label],
-              });
+                labels: 'nightly-failure',
+                state: 'open',
+                per_page: 100,
+              }
+            );
+
+            console.log(`Found ${openIssues.length} open nightly-failure issues`);
+
+            let recovered = 0;
+            let staleClosed = 0;
+
+            for (const issue of openIssues) {
+              const meta = mod.parseMetadata(issue.body);
+              if (!meta) continue;
+
+              const hasHumanReview = issue.labels.some((l) => l.name === 'human-review');
+              if (hasHumanReview) continue;
+
+              if (mod.shouldCloseOnGreen(meta, today)) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: mod.buildRecoveredComment(runUrl),
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+                recovered++;
+              } else if (mod.shouldStaleClose(meta, today)) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: 'Auto-closed: this failure has not been seen in over 14 days. If it recurs, a new issue will be created.',
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                  state_reason: 'not_planned',
+                });
+                staleClosed++;
+              }
             }
+
+            console.log(`Recovered (green close): ${recovered}, Stale-closed: ${staleClosed}`);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,9 +18,19 @@ const onlineTimeout = isWindowsCI ? 480_000 : 300_000;
 // outputs can be merged into a single unified HTML report. PR CI and local
 // runs keep the default reporters.
 const useBlobReporter = process.env.PLAYWRIGHT_BLOB_REPORT === "1";
-const reporter: ReporterDescription[] | undefined = useBlobReporter
-  ? [["github"], ["blob", { outputDir: "blob-report" }]]
-  : undefined;
+const useJsonReporter = process.env.PLAYWRIGHT_JSON_REPORT === "1";
+const reporter: ReporterDescription[] | undefined =
+  useBlobReporter || useJsonReporter
+    ? [
+        ["github"],
+        ...(useBlobReporter
+          ? [["blob", { outputDir: "blob-report" }] as ReporterDescription[]]
+          : []),
+        ...(useJsonReporter
+          ? [["json", { outputFile: "playwright-results.json" }] as ReporterDescription[]]
+          : []),
+      ]
+    : undefined;
 
 export default defineConfig({
   workers: e2eWorkers,

--- a/scripts/ci/extract-failures.mjs
+++ b/scripts/ci/extract-failures.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+function fail(message) {
+  console.error(`::error::${message}`);
+  process.exit(1);
+}
+
+function walkSuites(suites, parentPath = [], results = []) {
+  for (const suite of suites) {
+    const currentPath = suite.title ? [...parentPath, suite.title] : parentPath;
+    if (suite.suites?.length) walkSuites(suite.suites, currentPath, results);
+    for (const spec of suite.specs ?? []) {
+      const specPath = [...currentPath, spec.title];
+      for (const test of spec.tests ?? []) {
+        for (const result of test.results ?? []) {
+          if (result.status === "passed" || result.status === "skipped") continue;
+          const primaryError = result.errors?.[0];
+          results.push({
+            file: suite.file,
+            titlePath: specPath,
+            projectName: test.projectName,
+            status: result.status,
+            errorMessage: primaryError?.message ?? "Unknown error",
+            errorStack: primaryError?.stack ?? null,
+          });
+        }
+      }
+    }
+  }
+  return results;
+}
+
+const PATH_RE = /\/(?:Users|home|root)\/[\w./-]+/g;
+const TIMESTAMP_RE = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})/g;
+const LINE_COL_RE = /:\d+:\d+/g;
+const MEM_ADDR_RE = /0x[0-9a-fA-F]{8,}/g;
+const UUID_RE = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
+const PORT_RE = /:\d{4,5}\b/g;
+
+export function normalizeError(message) {
+  return message
+    .replace(PATH_RE, "<path>")
+    .replace(TIMESTAMP_RE, "<timestamp>")
+    .replace(LINE_COL_RE, ":<line>:<col>")
+    .replace(MEM_ADDR_RE, "0x<addr>")
+    .replace(UUID_RE, "<uuid>")
+    .replace(PORT_RE, ":<port>")
+    .replace(/\r\n/g, "\n")
+    .trim();
+}
+
+export function computeSignature(file, titlePath, errorMessage) {
+  const normalized = normalizeError(errorMessage);
+  const raw = [file, titlePath.join("::"), normalized].join("::");
+  const hash = createHash("sha256").update(raw).digest("hex");
+  return hash.slice(0, 12);
+}
+
+export function extractFailures(report) {
+  const failures = [];
+  if (!report?.suites) return failures;
+
+  for (const suite of report.suites) {
+    const file = suite.file;
+    const suiteFailures = walkSuites([suite]);
+    for (const f of suiteFailures) {
+      failures.push({
+        ...f,
+        signature: computeSignature(f.file, f.titlePath, f.errorMessage),
+      });
+    }
+  }
+  return failures;
+}
+
+async function main() {
+  const inputPath = process.argv[2];
+  const outputPath = process.argv[3];
+
+  if (!inputPath) {
+    fail("Usage: extract-failures.mjs <playwright-results.json> [output.json]");
+  }
+
+  let raw;
+  try {
+    raw = JSON.parse(await readFile(inputPath, "utf8"));
+  } catch (err) {
+    fail(`Failed to read ${inputPath}: ${err.message}`);
+  }
+
+  const failures = extractFailures(raw);
+
+  if (failures.length === 0) {
+    console.log("[extract-failures] No failures found");
+    if (outputPath) {
+      await readFile(outputPath, "utf8").catch(() => {});
+    }
+    return;
+  }
+
+  const output = failures.map((f) => ({
+    signature: f.signature,
+    file: f.file,
+    titlePath: f.titlePath,
+    projectName: f.projectName,
+    normalizedError: normalizeError(f.errorMessage),
+    rawError: f.errorMessage,
+    status: f.status,
+  }));
+
+  const json = JSON.stringify(output, null, 2);
+
+  if (outputPath) {
+    const { writeFile } = await import("node:fs/promises");
+    await writeFile(outputPath, json, "utf8");
+    console.log(`[extract-failures] Wrote ${output.length} failure(s) to ${outputPath}`);
+  } else {
+    console.log(json);
+  }
+}
+
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  await main();
+}

--- a/scripts/ci/extract-failures.mjs
+++ b/scripts/ci/extract-failures.mjs
@@ -7,10 +7,11 @@ function fail(message) {
   process.exit(1);
 }
 
-function walkSuites(suites, parentPath = [], results = []) {
+function walkSuites(suites, parentPath = [], results = [], parentFile = null) {
   for (const suite of suites) {
+    const file = suite.file || parentFile;
     const currentPath = suite.title ? [...parentPath, suite.title] : parentPath;
-    if (suite.suites?.length) walkSuites(suite.suites, currentPath, results);
+    if (suite.suites?.length) walkSuites(suite.suites, currentPath, results, file);
     for (const spec of suite.specs ?? []) {
       const specPath = [...currentPath, spec.title];
       for (const test of spec.tests ?? []) {
@@ -18,7 +19,7 @@ function walkSuites(suites, parentPath = [], results = []) {
           if (result.status === "passed" || result.status === "skipped") continue;
           const primaryError = result.errors?.[0];
           results.push({
-            file: suite.file,
+            file,
             titlePath: specPath,
             projectName: test.projectName,
             status: result.status,
@@ -32,7 +33,11 @@ function walkSuites(suites, parentPath = [], results = []) {
   return results;
 }
 
-const PATH_RE = /\/(?:Users|home|root)\/[\w./-]+/g;
+const POSIX_PATH_RE = /\/(?:Users|home|root|private\/var)\/[\w./-]+/g;
+const WIN_PATH_RE = /[A-Z]:\\[\w\\/\-.]+|[A-Z]:\\\\[\w\\\\/\-.]+/g;
+const WIN_DRIVE_RE = /[A-Z]:(?=<path>|\/)/g;
+const PATH_RE = new RegExp(`${POSIX_PATH_RE.source}|${WIN_PATH_RE.source}`, "g");
+const BSLASH_RE = /\\/g;
 const TIMESTAMP_RE = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})/g;
 const LINE_COL_RE = /:\d+:\d+/g;
 const MEM_ADDR_RE = /0x[0-9a-fA-F]{8,}/g;
@@ -41,7 +46,9 @@ const PORT_RE = /:\d{4,5}\b/g;
 
 export function normalizeError(message) {
   return message
+    .replace(BSLASH_RE, "/")
     .replace(PATH_RE, "<path>")
+    .replace(WIN_DRIVE_RE, "")
     .replace(TIMESTAMP_RE, "<timestamp>")
     .replace(LINE_COL_RE, ":<line>:<col>")
     .replace(MEM_ADDR_RE, "0x<addr>")
@@ -63,8 +70,7 @@ export function extractFailures(report) {
   if (!report?.suites) return failures;
 
   for (const suite of report.suites) {
-    const file = suite.file;
-    const suiteFailures = walkSuites([suite]);
+    const suiteFailures = walkSuites([suite], [], [], suite.file);
     for (const f of suiteFailures) {
       failures.push({
         ...f,
@@ -95,7 +101,8 @@ async function main() {
   if (failures.length === 0) {
     console.log("[extract-failures] No failures found");
     if (outputPath) {
-      await readFile(outputPath, "utf8").catch(() => {});
+      const { writeFile } = await import("node:fs/promises");
+      await writeFile(outputPath, "[]", "utf8");
     }
     return;
   }

--- a/scripts/ci/extract-failures.test.mjs
+++ b/scripts/ci/extract-failures.test.mjs
@@ -1,0 +1,256 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { computeSignature, extractFailures, normalizeError } from "./extract-failures.mjs";
+
+test("normalizeError strips paths", () => {
+  const input = "Error at /Users/test/project/src/file.ts:42:10";
+  const result = normalizeError(input);
+  assert.ok(!result.includes("/Users/test/project"));
+  assert.ok(result.includes("<path>"));
+});
+
+test("normalizeError strips timestamps", () => {
+  const input = "Failed at 2025-06-15T03:00:00.123Z";
+  const result = normalizeError(input);
+  assert.ok(!result.includes("2025-06-15"));
+  assert.ok(result.includes("<timestamp>"));
+});
+
+test("normalizeError strips line:col", () => {
+  const input = "Error at file.ts:42:10 and also file.ts:100:5";
+  const result = normalizeError(input);
+  assert.ok(!result.includes(":42:10"));
+  assert.ok(!result.includes(":100:5"));
+  assert.ok(result.includes(":<line>:<col>"));
+});
+
+test("normalizeError strips memory addresses", () => {
+  const input = "Segfault at 0x7fff5fbff000 and 0xDEADBEEF1234";
+  const result = normalizeError(input);
+  assert.ok(!result.includes("0x7fff5fbff000"));
+  assert.ok(!result.includes("0xDEADBEEF1234"));
+  assert.ok(result.includes("0x<addr>"));
+});
+
+test("normalizeError strips UUIDs", () => {
+  const input = "Session abc123de-4567-8901-abcd-ef1234567890 not found";
+  const result = normalizeError(input);
+  assert.ok(!result.includes("abc123de-4567-8901-abcd-ef1234567890"));
+  assert.ok(result.includes("<uuid>"));
+});
+
+test("normalizeError strips ports", () => {
+  const input = "Connection refused on localhost:9222";
+  const result = normalizeError(input);
+  assert.ok(!result.includes(":9222"));
+});
+
+test("computeSignature is deterministic", () => {
+  const sig1 = computeSignature("spec.ts", ["suite", "test name"], "Error: things broke");
+  const sig2 = computeSignature("spec.ts", ["suite", "test name"], "Error: things broke");
+  assert.equal(sig1, sig2);
+  assert.equal(sig1.length, 12);
+});
+
+test("computeSignature varies by file", () => {
+  const sig1 = computeSignature("a.spec.ts", ["test"], "error");
+  const sig2 = computeSignature("b.spec.ts", ["test"], "error");
+  assert.notEqual(sig1, sig2);
+});
+
+test("computeSignature varies by title path", () => {
+  const sig1 = computeSignature("x.spec.ts", ["A", "B"], "error");
+  const sig2 = computeSignature("x.spec.ts", ["A", "C"], "error");
+  assert.notEqual(sig1, sig2);
+});
+
+test("computeSignature normalizes error before hashing", () => {
+  const sig1 = computeSignature("spec.ts", ["test"], "Error at /Users/alice/code.ts:10:5");
+  const sig2 = computeSignature("spec.ts", ["test"], "Error at /home/bob/code.ts:20:15");
+  assert.equal(sig1, sig2);
+});
+
+test("extractFailures returns empty for null/undefined", () => {
+  assert.deepEqual(extractFailures(null), []);
+  assert.deepEqual(extractFailures({}), []);
+  assert.deepEqual(extractFailures({ suites: [] }), []);
+});
+
+test("extractFailures extracts failing tests", () => {
+  const report = {
+    suites: [
+      {
+        file: "e2e/core/test.spec.ts",
+        title: "root",
+        specs: [
+          {
+            title: "should work",
+            tests: [
+              {
+                projectName: "core",
+                results: [
+                  {
+                    status: "failed",
+                    errors: [{ message: "AssertionError: expected 1 got 2", stack: "at ..." }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  const failures = extractFailures(report);
+  assert.equal(failures.length, 1);
+  assert.equal(failures[0].file, "e2e/core/test.spec.ts");
+  assert.deepEqual(failures[0].titlePath, ["root", "should work"]);
+  assert.equal(failures[0].projectName, "core");
+  assert.equal(failures[0].status, "failed");
+  assert.ok(failures[0].signature);
+});
+
+test("extractFailures skips passed and skipped tests", () => {
+  const report = {
+    suites: [
+      {
+        file: "spec.ts",
+        title: "root",
+        specs: [
+          {
+            title: "passes",
+            tests: [{ projectName: "core", results: [{ status: "passed", errors: [] }] }],
+          },
+          {
+            title: "skipped",
+            tests: [{ projectName: "core", results: [{ status: "skipped", errors: [] }] }],
+          },
+          {
+            title: "fails",
+            tests: [
+              {
+                projectName: "core",
+                results: [{ status: "failed", errors: [{ message: "boom" }] }],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  const failures = extractFailures(report);
+  assert.equal(failures.length, 1);
+  assert.equal(failures[0].titlePath[1], "fails");
+});
+
+test("extractFailures walks nested suites", () => {
+  const report = {
+    suites: [
+      {
+        file: "spec.ts",
+        title: "root",
+        suites: [
+          {
+            title: "Feature X",
+            specs: [
+              {
+                title: "scenario A",
+                tests: [
+                  {
+                    projectName: "full-terminal",
+                    results: [{ status: "failed", errors: [{ message: "timeout" }] }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  const failures = extractFailures(report);
+  assert.equal(failures.length, 1);
+  assert.deepEqual(failures[0].titlePath, ["root", "Feature X", "scenario A"]);
+});
+
+test("extractFailures handles missing errors gracefully", () => {
+  const report = {
+    suites: [
+      {
+        file: "spec.ts",
+        title: "root",
+        specs: [
+          {
+            title: "fails",
+            tests: [
+              {
+                projectName: "core",
+                results: [{ status: "failed", errors: [] }],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  const failures = extractFailures(report);
+  assert.equal(failures.length, 1);
+  assert.equal(failures[0].errorMessage, "Unknown error");
+});
+
+test("extractFailures handles retries (multiple results per test)", () => {
+  const report = {
+    suites: [
+      {
+        file: "spec.ts",
+        title: "root",
+        specs: [
+          {
+            title: "flaky",
+            tests: [
+              {
+                projectName: "core",
+                results: [
+                  { status: "failed", errors: [{ message: "first fail" }] },
+                  { status: "failed", errors: [{ message: "second fail" }] },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  const failures = extractFailures(report);
+  assert.equal(failures.length, 2);
+});
+
+test("extractFailures handles multi-project reports", () => {
+  const report = {
+    suites: [
+      {
+        file: "spec.ts",
+        title: "root",
+        specs: [
+          {
+            title: "test",
+            tests: [
+              {
+                projectName: "core",
+                results: [{ status: "failed", errors: [{ message: "err" }] }],
+              },
+              {
+                projectName: "full-terminal",
+                results: [{ status: "failed", errors: [{ message: "err" }] }],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  const failures = extractFailures(report);
+  assert.equal(failures.length, 2);
+  assert.equal(failures[0].projectName, "core");
+  assert.equal(failures[1].projectName, "full-terminal");
+});

--- a/scripts/ci/extract-failures.test.mjs
+++ b/scripts/ci/extract-failures.test.mjs
@@ -254,3 +254,61 @@ test("extractFailures handles multi-project reports", () => {
   assert.equal(failures[0].projectName, "core");
   assert.equal(failures[1].projectName, "full-terminal");
 });
+
+test("extractFailures propagates file to nested describe suites", () => {
+  const report = {
+    suites: [
+      {
+        file: "e2e/core/login.spec.ts",
+        title: "root",
+        suites: [
+          {
+            title: "Login page",
+            specs: [
+              {
+                title: "should reject invalid password",
+                tests: [
+                  {
+                    projectName: "core",
+                    results: [{ status: "failed", errors: [{ message: "timeout" }] }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  const failures = extractFailures(report);
+  assert.equal(failures.length, 1);
+  assert.equal(failures[0].file, "e2e/core/login.spec.ts");
+  assert.deepEqual(failures[0].titlePath, ["root", "Login page", "should reject invalid password"]);
+
+  // Same nested structure, different file → different signature
+  const report2 = { suites: [{ ...report.suites[0], file: "e2e/core/signup.spec.ts" }] };
+  const failures2 = extractFailures(report2);
+  assert.equal(failures2.length, 1);
+  assert.equal(failures2[0].file, "e2e/core/signup.spec.ts");
+  assert.notEqual(failures[0].signature, failures2[0].signature);
+});
+
+test("normalizeError normalizes Windows paths", () => {
+  const posixErr = "Error at /Users/runner/work/repo/e2e/test.spec.ts:42";
+  const winErr = "Error at C:\\Users\\runneradmin\\work\\repo\\e2e\\test.spec.ts:42";
+  assert.equal(normalizeError(winErr), normalizeError(posixErr));
+});
+
+test("computeSignature matches across OS path flavors", () => {
+  const sig1 = computeSignature(
+    "e2e/test.spec.ts",
+    ["suite", "test"],
+    "Error at /Users/runner/work/repo/e2e/test.spec.ts:42:10"
+  );
+  const sig2 = computeSignature(
+    "e2e/test.spec.ts",
+    ["suite", "test"],
+    "Error at C:\\Users\\runneradmin\\work\\repo\\e2e\\test.spec.ts:42:10"
+  );
+  assert.equal(sig1, sig2);
+});

--- a/scripts/ci/extract-failures.test.mjs
+++ b/scripts/ci/extract-failures.test.mjs
@@ -1,82 +1,81 @@
-import { strict as assert } from "node:assert";
-import { test } from "node:test";
+import { describe, it, expect } from "vitest";
 import { computeSignature, extractFailures, normalizeError } from "./extract-failures.mjs";
 
-test("normalizeError strips paths", () => {
+it("normalizeError strips paths", () => {
   const input = "Error at /Users/test/project/src/file.ts:42:10";
   const result = normalizeError(input);
-  assert.ok(!result.includes("/Users/test/project"));
-  assert.ok(result.includes("<path>"));
+  expect(result).not.toContain("/Users/test/project");
+  expect(result).toContain("<path>");
 });
 
-test("normalizeError strips timestamps", () => {
+it("normalizeError strips timestamps", () => {
   const input = "Failed at 2025-06-15T03:00:00.123Z";
   const result = normalizeError(input);
-  assert.ok(!result.includes("2025-06-15"));
-  assert.ok(result.includes("<timestamp>"));
+  expect(result).not.toContain("2025-06-15");
+  expect(result).toContain("<timestamp>");
 });
 
-test("normalizeError strips line:col", () => {
+it("normalizeError strips line:col", () => {
   const input = "Error at file.ts:42:10 and also file.ts:100:5";
   const result = normalizeError(input);
-  assert.ok(!result.includes(":42:10"));
-  assert.ok(!result.includes(":100:5"));
-  assert.ok(result.includes(":<line>:<col>"));
+  expect(result).not.toContain(":42:10");
+  expect(result).not.toContain(":100:5");
+  expect(result).toContain(":<line>:<col>");
 });
 
-test("normalizeError strips memory addresses", () => {
+it("normalizeError strips memory addresses", () => {
   const input = "Segfault at 0x7fff5fbff000 and 0xDEADBEEF1234";
   const result = normalizeError(input);
-  assert.ok(!result.includes("0x7fff5fbff000"));
-  assert.ok(!result.includes("0xDEADBEEF1234"));
-  assert.ok(result.includes("0x<addr>"));
+  expect(result).not.toContain("0x7fff5fbff000");
+  expect(result).not.toContain("0xDEADBEEF1234");
+  expect(result).toContain("0x<addr>");
 });
 
-test("normalizeError strips UUIDs", () => {
+it("normalizeError strips UUIDs", () => {
   const input = "Session abc123de-4567-8901-abcd-ef1234567890 not found";
   const result = normalizeError(input);
-  assert.ok(!result.includes("abc123de-4567-8901-abcd-ef1234567890"));
-  assert.ok(result.includes("<uuid>"));
+  expect(result).not.toContain("abc123de-4567-8901-abcd-ef1234567890");
+  expect(result).toContain("<uuid>");
 });
 
-test("normalizeError strips ports", () => {
+it("normalizeError strips ports", () => {
   const input = "Connection refused on localhost:9222";
   const result = normalizeError(input);
-  assert.ok(!result.includes(":9222"));
+  expect(result).not.toContain(":9222");
 });
 
-test("computeSignature is deterministic", () => {
+it("computeSignature is deterministic", () => {
   const sig1 = computeSignature("spec.ts", ["suite", "test name"], "Error: things broke");
   const sig2 = computeSignature("spec.ts", ["suite", "test name"], "Error: things broke");
-  assert.equal(sig1, sig2);
-  assert.equal(sig1.length, 12);
+  expect(sig1).toBe(sig2);
+  expect(sig1.length).toBe(12);
 });
 
-test("computeSignature varies by file", () => {
+it("computeSignature varies by file", () => {
   const sig1 = computeSignature("a.spec.ts", ["test"], "error");
   const sig2 = computeSignature("b.spec.ts", ["test"], "error");
-  assert.notEqual(sig1, sig2);
+  expect(sig1).not.toBe(sig2);
 });
 
-test("computeSignature varies by title path", () => {
+it("computeSignature varies by title path", () => {
   const sig1 = computeSignature("x.spec.ts", ["A", "B"], "error");
   const sig2 = computeSignature("x.spec.ts", ["A", "C"], "error");
-  assert.notEqual(sig1, sig2);
+  expect(sig1).not.toBe(sig2);
 });
 
-test("computeSignature normalizes error before hashing", () => {
+it("computeSignature normalizes error before hashing", () => {
   const sig1 = computeSignature("spec.ts", ["test"], "Error at /Users/alice/code.ts:10:5");
   const sig2 = computeSignature("spec.ts", ["test"], "Error at /home/bob/code.ts:20:15");
-  assert.equal(sig1, sig2);
+  expect(sig1).toBe(sig2);
 });
 
-test("extractFailures returns empty for null/undefined", () => {
-  assert.deepEqual(extractFailures(null), []);
-  assert.deepEqual(extractFailures({}), []);
-  assert.deepEqual(extractFailures({ suites: [] }), []);
+it("extractFailures returns empty for null/undefined", () => {
+  expect(extractFailures(null)).toEqual([]);
+  expect(extractFailures({})).toEqual([]);
+  expect(extractFailures({ suites: [] })).toEqual([]);
 });
 
-test("extractFailures extracts failing tests", () => {
+it("extractFailures extracts failing tests", () => {
   const report = {
     suites: [
       {
@@ -102,15 +101,15 @@ test("extractFailures extracts failing tests", () => {
     ],
   };
   const failures = extractFailures(report);
-  assert.equal(failures.length, 1);
-  assert.equal(failures[0].file, "e2e/core/test.spec.ts");
-  assert.deepEqual(failures[0].titlePath, ["root", "should work"]);
-  assert.equal(failures[0].projectName, "core");
-  assert.equal(failures[0].status, "failed");
-  assert.ok(failures[0].signature);
+  expect(failures.length).toBe(1);
+  expect(failures[0].file).toBe("e2e/core/test.spec.ts");
+  expect(failures[0].titlePath).toEqual(["root", "should work"]);
+  expect(failures[0].projectName).toBe("core");
+  expect(failures[0].status).toBe("failed");
+  expect(failures[0].signature).toBeTruthy();
 });
 
-test("extractFailures skips passed and skipped tests", () => {
+it("extractFailures skips passed and skipped tests", () => {
   const report = {
     suites: [
       {
@@ -139,11 +138,11 @@ test("extractFailures skips passed and skipped tests", () => {
     ],
   };
   const failures = extractFailures(report);
-  assert.equal(failures.length, 1);
-  assert.equal(failures[0].titlePath[1], "fails");
+  expect(failures.length).toBe(1);
+  expect(failures[0].titlePath[1]).toBe("fails");
 });
 
-test("extractFailures walks nested suites", () => {
+it("extractFailures walks nested suites", () => {
   const report = {
     suites: [
       {
@@ -169,11 +168,11 @@ test("extractFailures walks nested suites", () => {
     ],
   };
   const failures = extractFailures(report);
-  assert.equal(failures.length, 1);
-  assert.deepEqual(failures[0].titlePath, ["root", "Feature X", "scenario A"]);
+  expect(failures.length).toBe(1);
+  expect(failures[0].titlePath).toEqual(["root", "Feature X", "scenario A"]);
 });
 
-test("extractFailures handles missing errors gracefully", () => {
+it("extractFailures handles missing errors gracefully", () => {
   const report = {
     suites: [
       {
@@ -194,11 +193,11 @@ test("extractFailures handles missing errors gracefully", () => {
     ],
   };
   const failures = extractFailures(report);
-  assert.equal(failures.length, 1);
-  assert.equal(failures[0].errorMessage, "Unknown error");
+  expect(failures.length).toBe(1);
+  expect(failures[0].errorMessage).toBe("Unknown error");
 });
 
-test("extractFailures handles retries (multiple results per test)", () => {
+it("extractFailures handles retries (multiple results per test)", () => {
   const report = {
     suites: [
       {
@@ -222,10 +221,10 @@ test("extractFailures handles retries (multiple results per test)", () => {
     ],
   };
   const failures = extractFailures(report);
-  assert.equal(failures.length, 2);
+  expect(failures.length).toBe(2);
 });
 
-test("extractFailures handles multi-project reports", () => {
+it("extractFailures handles multi-project reports", () => {
   const report = {
     suites: [
       {
@@ -250,12 +249,12 @@ test("extractFailures handles multi-project reports", () => {
     ],
   };
   const failures = extractFailures(report);
-  assert.equal(failures.length, 2);
-  assert.equal(failures[0].projectName, "core");
-  assert.equal(failures[1].projectName, "full-terminal");
+  expect(failures.length).toBe(2);
+  expect(failures[0].projectName).toBe("core");
+  expect(failures[1].projectName).toBe("full-terminal");
 });
 
-test("extractFailures propagates file to nested describe suites", () => {
+it("extractFailures propagates file to nested describe suites", () => {
   const report = {
     suites: [
       {
@@ -281,25 +280,25 @@ test("extractFailures propagates file to nested describe suites", () => {
     ],
   };
   const failures = extractFailures(report);
-  assert.equal(failures.length, 1);
-  assert.equal(failures[0].file, "e2e/core/login.spec.ts");
-  assert.deepEqual(failures[0].titlePath, ["root", "Login page", "should reject invalid password"]);
+  expect(failures.length).toBe(1);
+  expect(failures[0].file).toBe("e2e/core/login.spec.ts");
+  expect(failures[0].titlePath).toEqual(["root", "Login page", "should reject invalid password"]);
 
   // Same nested structure, different file → different signature
   const report2 = { suites: [{ ...report.suites[0], file: "e2e/core/signup.spec.ts" }] };
   const failures2 = extractFailures(report2);
-  assert.equal(failures2.length, 1);
-  assert.equal(failures2[0].file, "e2e/core/signup.spec.ts");
-  assert.notEqual(failures[0].signature, failures2[0].signature);
+  expect(failures2.length).toBe(1);
+  expect(failures2[0].file).toBe("e2e/core/signup.spec.ts");
+  expect(failures[0].signature).not.toBe(failures2[0].signature);
 });
 
-test("normalizeError normalizes Windows paths", () => {
+it("normalizeError normalizes Windows paths", () => {
   const posixErr = "Error at /Users/runner/work/repo/e2e/test.spec.ts:42";
   const winErr = "Error at C:\\Users\\runneradmin\\work\\repo\\e2e\\test.spec.ts:42";
-  assert.equal(normalizeError(winErr), normalizeError(posixErr));
+  expect(normalizeError(winErr)).toBe(normalizeError(posixErr));
 });
 
-test("computeSignature matches across OS path flavors", () => {
+it("computeSignature matches across OS path flavors", () => {
   const sig1 = computeSignature(
     "e2e/test.spec.ts",
     ["suite", "test"],
@@ -310,5 +309,5 @@ test("computeSignature matches across OS path flavors", () => {
     ["suite", "test"],
     "Error at C:\\Users\\runneradmin\\work\\repo\\e2e\\test.spec.ts:42:10"
   );
-  assert.equal(sig1, sig2);
+  expect(sig1).toBe(sig2);
 });

--- a/scripts/ci/process-nightly-issues.mjs
+++ b/scripts/ci/process-nightly-issues.mjs
@@ -1,0 +1,162 @@
+const METADATA_MARKER = /<!-- METADATA:\s*(\{[\s\S]*?\})\s*-->/;
+const SIGNATURE_LENGTH = 12;
+const ESCALATION_THRESHOLD = 3;
+const STALE_DAYS = 14;
+const BUCKET_LABELS = [
+  "core",
+  "full-terminal",
+  "full-worktree",
+  "full-presets",
+  "full-platform",
+  "full-panels",
+  "full-resilience",
+  "online",
+  "nightly",
+];
+
+export function parseMetadata(body) {
+  if (!body) return null;
+  const match = body.match(METADATA_MARKER);
+  if (!match) return null;
+  try {
+    const parsed = JSON.parse(match[1]);
+    if (typeof parsed?.signature !== "string" || parsed.signature.length !== SIGNATURE_LENGTH) {
+      return null;
+    }
+    return {
+      signature: parsed.signature,
+      consecutive_failures:
+        typeof parsed.consecutive_failures === "number" ? parsed.consecutive_failures : 1,
+      first_seen: parsed.first_seen ?? null,
+      last_seen: parsed.last_seen ?? null,
+      last_seen_run_id:
+        typeof parsed.last_seen_run_id === "number" ? parsed.last_seen_run_id : null,
+      last_green_run_url: parsed.last_green_run_url ?? null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function buildMetadataBlock(metadata) {
+  const json = JSON.stringify(metadata, null, 2);
+  return `<!-- METADATA:\n${json}\n-->`;
+}
+
+export function buildIssueTitle(report) {
+  const context = report.titlePath.slice(1).join(" › ");
+  const display = context.length > 60 ? context.slice(0, 57) + "..." : context;
+  return `[Nightly] ${report.projectName}: ${display}`;
+}
+
+export function buildIssueBody(report, metadata, runUrl) {
+  const titlePathDisplay = report.titlePath.join(" › ");
+  const osLabel = report.os ?? "unknown";
+  const lines = [
+    `**Suite:** ${report.projectName}`,
+    `**Test:** ${titlePathDisplay}`,
+    `**File:** ${report.file}`,
+    `**OS:** ${osLabel}`,
+    ``,
+    `**Run:** ${runUrl}`,
+    ``,
+    "```",
+    report.rawError?.trim() || report.normalizedError,
+    "```",
+    "",
+    `First seen: ${metadata.first_seen ?? "now"} | Consecutive failures: ${metadata.consecutive_failures}`,
+    "",
+    report.rawError
+      ? `<details><summary>Normalized error (for dedup)</summary>\n\n\`\`\`\n${report.normalizedError}\n\`\`\`\n</details>`
+      : "",
+    "",
+    buildMetadataBlock(metadata),
+  ];
+  return lines.join("\n");
+}
+
+export function buildRecoveredComment(runUrl) {
+  return [
+    "This failure did not recur in the latest nightly run. Closing as resolved.",
+    "",
+    `**Run:** ${runUrl}`,
+  ].join("\n");
+}
+
+export function buildEscalationComment() {
+  return "This failure has occurred 3 or more consecutive times. Adding `human-review` label — it needs manual investigation.";
+}
+
+export function nextMetadata(existing, report, runId, runUrl, today) {
+  if (existing && existing.last_seen_run_id === runId) {
+    return existing;
+  }
+
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const yesterdayStr = yesterday.toISOString().split("T")[0];
+
+  const wasConsecutive = existing?.last_seen && existing.last_seen.startsWith(yesterdayStr);
+
+  return {
+    signature: report.signature,
+    consecutive_failures: wasConsecutive ? existing.consecutive_failures + 1 : 1,
+    first_seen: existing?.first_seen ?? today,
+    last_seen: today,
+    last_seen_run_id: runId,
+    last_green_run_url: existing?.last_green_run_url ?? null,
+  };
+}
+
+export function shouldEscalateToHumanReview(metadata) {
+  return metadata.consecutive_failures >= ESCALATION_THRESHOLD;
+}
+
+export function shouldCloseOnGreen(issueMeta, today) {
+  if (!issueMeta?.last_seen) return false;
+  return issueMeta.last_seen < today;
+}
+
+export function shouldStaleClose(issueMeta, today) {
+  if (!issueMeta?.last_seen) return false;
+  const lastSeen = new Date(issueMeta.last_seen);
+  const now = new Date(today);
+  const diffDays = (now - lastSeen) / (1000 * 60 * 60 * 24);
+  return diffDays > STALE_DAYS;
+}
+
+export function findIssueBySignature(parsedIssues, signature) {
+  return parsedIssues.find((i) => i.metadata?.signature === signature);
+}
+
+export function deduplicateReports(reports) {
+  const seen = new Map();
+  const merged = [];
+  for (const report of reports) {
+    const existing = seen.get(report.signature);
+    if (existing) {
+      if (!existing.oses) existing.oses = [existing.os ?? "unknown"];
+      existing.oses.push(report.os ?? "unknown");
+    } else {
+      seen.set(report.signature, { ...report });
+      merged.push(report);
+    }
+  }
+  return merged;
+}
+
+export function bucketLabelForSuite(suite) {
+  return BUCKET_LABELS.includes(suite) ? [suite] : [];
+}
+
+const BASE_LABEL = "nightly-failure";
+const HUMAN_REVIEW_LABEL = "human-review";
+
+export function labelsForIssue(report) {
+  const labels = [BASE_LABEL, ...bucketLabelForSuite(report.projectName)];
+  return labels;
+}
+
+export function labelsForEscalation(metadata) {
+  return shouldEscalateToHumanReview(metadata) ? [HUMAN_REVIEW_LABEL] : [];
+}

--- a/scripts/ci/process-nightly-issues.mjs
+++ b/scripts/ci/process-nightly-issues.mjs
@@ -131,18 +131,15 @@ export function findIssueBySignature(parsedIssues, signature) {
 
 export function deduplicateReports(reports) {
   const seen = new Map();
-  const merged = [];
   for (const report of reports) {
     const existing = seen.get(report.signature);
     if (existing) {
-      if (!existing.oses) existing.oses = [existing.os ?? "unknown"];
-      existing.oses.push(report.os ?? "unknown");
+      existing.oses = [...(existing.oses ?? [existing.os ?? "unknown"]), report.os ?? "unknown"];
     } else {
       seen.set(report.signature, { ...report });
-      merged.push(report);
     }
   }
-  return merged;
+  return [...seen.values()];
 }
 
 export function bucketLabelForSuite(suite) {

--- a/scripts/ci/process-nightly-issues.test.mjs
+++ b/scripts/ci/process-nightly-issues.test.mjs
@@ -1,0 +1,258 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import {
+  buildMetadataBlock,
+  buildIssueBody,
+  buildIssueTitle,
+  buildRecoveredComment,
+  deduplicateReports,
+  findIssueBySignature,
+  labelsForEscalation,
+  labelsForIssue,
+  nextMetadata,
+  parseMetadata,
+  shouldCloseOnGreen,
+  shouldEscalateToHumanReview,
+  shouldStaleClose,
+} from "./process-nightly-issues.mjs";
+
+test("parseMetadata extracts valid metadata", () => {
+  const body = `
+Some content
+<!-- METADATA:
+{
+  "signature": "abcdef123456",
+  "consecutive_failures": 2,
+  "first_seen": "2026-05-20",
+  "last_seen": "2026-05-28",
+  "last_seen_run_id": 12345,
+  "last_green_run_url": null
+}
+-->
+More content
+`;
+  const meta = parseMetadata(body);
+  assert.ok(meta);
+  assert.equal(meta.signature, "abcdef123456");
+  assert.equal(meta.consecutive_failures, 2);
+  assert.equal(meta.first_seen, "2026-05-20");
+  assert.equal(meta.last_seen, "2026-05-28");
+  assert.equal(meta.last_seen_run_id, 12345);
+});
+
+test("parseMetadata returns null for missing marker", () => {
+  assert.equal(parseMetadata("no metadata here"), null);
+  assert.equal(parseMetadata(null), null);
+});
+
+test("parseMetadata returns null for invalid JSON in marker", () => {
+  assert.equal(parseMetadata("<!-- METADATA:\n{invalid}\n-->"), null);
+});
+
+test("parseMetadata returns null for missing signature", () => {
+  assert.equal(parseMetadata('<!-- METADATA:\n{"consecutive_failures": 1}\n-->'), null);
+});
+
+test("parseMetadata returns null for wrong signature length", () => {
+  assert.equal(parseMetadata('<!-- METADATA:\n{"signature": "abc"}\n-->'), null);
+});
+
+test("buildMetadataBlock round-trips through parseMetadata", () => {
+  const original = {
+    signature: "deadbeef1234",
+    consecutive_failures: 3,
+    first_seen: "2026-05-20",
+    last_seen: "2026-05-28",
+    last_seen_run_id: 99999,
+    last_green_run_url: null,
+  };
+  const block = buildMetadataBlock(original);
+  const parsed = parseMetadata(block);
+  assert.deepEqual(parsed, original);
+});
+
+test("buildMetadataBlock produces valid marker", () => {
+  const block = buildMetadataBlock({
+    signature: "abcdef123456",
+    consecutive_failures: 1,
+    first_seen: "2026-05-28",
+    last_seen: "2026-05-28",
+    last_seen_run_id: 1,
+    last_green_run_url: null,
+  });
+  assert.ok(block.startsWith("<!-- METADATA:"));
+  assert.ok(block.endsWith("-->"));
+  assert.ok(block.includes('"abcdef123456"'));
+});
+
+test("buildIssueTitle", () => {
+  const report = {
+    projectName: "full-terminal",
+    titlePath: ["root", "Search", "should find text"],
+  };
+  const title = buildIssueTitle(report);
+  assert.ok(title.includes("[Nightly]"));
+  assert.ok(title.includes("full-terminal"));
+  assert.ok(title.includes("should find text"));
+});
+
+test("buildIssueTitle truncates long titles", () => {
+  const report = {
+    projectName: "core",
+    titlePath: [
+      "root",
+      "A very long test name that exceeds sixty characters and should be truncated",
+    ],
+  };
+  const title = buildIssueTitle(report);
+  assert.ok(title.length <= 80);
+  assert.ok(title.endsWith("..."));
+});
+
+test("buildIssueBody contains key info", () => {
+  const report = {
+    projectName: "core",
+    file: "e2e/core/test.spec.ts",
+    titlePath: ["root", "should work"],
+    rawError: "Expected 1 got 2",
+    normalizedError: "Expected 1 got 2",
+    os: "Linux",
+    signature: "abcdef123456",
+  };
+  const metadata = {
+    signature: "abcdef123456",
+    consecutive_failures: 1,
+    first_seen: "2026-05-28",
+    last_seen: "2026-05-28",
+    last_seen_run_id: 1,
+    last_green_run_url: null,
+  };
+  const body = buildIssueBody(report, metadata, "https://github.com/org/repo/actions/runs/1");
+  assert.ok(body.includes("e2e/core/test.spec.ts"));
+  assert.ok(body.includes("should work"));
+  assert.ok(body.includes("Expected 1 got 2"));
+  assert.ok(body.includes("Linux"));
+  assert.ok(body.includes("METADATA:"));
+});
+
+test("nextMetadata creates new metadata", () => {
+  const report = { signature: "abcdef123456" };
+  const meta = nextMetadata(null, report, 1, "https://run", "2026-05-28");
+  assert.equal(meta.signature, "abcdef123456");
+  assert.equal(meta.consecutive_failures, 1);
+  assert.equal(meta.first_seen, "2026-05-28");
+  assert.equal(meta.last_seen, "2026-05-28");
+  assert.equal(meta.last_seen_run_id, 1);
+});
+
+test("nextMetadata skips increment on same run_id", () => {
+  const existing = {
+    signature: "abcdef123456",
+    consecutive_failures: 2,
+    first_seen: "2026-05-26",
+    last_seen: "2026-05-28",
+    last_seen_run_id: 1,
+    last_green_run_url: null,
+  };
+  const report = { signature: "abcdef123456" };
+  const meta = nextMetadata(existing, report, 1, "https://run", "2026-05-28");
+  assert.equal(meta.consecutive_failures, 2);
+});
+
+test("nextMetadata increments on consecutive day", () => {
+  const existing = {
+    signature: "abcdef123456",
+    consecutive_failures: 2,
+    first_seen: "2026-05-26",
+    last_seen: "2026-05-27",
+    last_seen_run_id: 999,
+    last_green_run_url: null,
+  };
+  const report = { signature: "abcdef123456" };
+  const meta = nextMetadata(existing, report, 1, "https://run", "2026-05-28");
+  assert.equal(meta.consecutive_failures, 3);
+});
+
+test("nextMetadata resets on non-consecutive day", () => {
+  const existing = {
+    signature: "abcdef123456",
+    consecutive_failures: 2,
+    first_seen: "2026-05-20",
+    last_seen: "2026-05-25",
+    last_seen_run_id: 999,
+    last_green_run_url: null,
+  };
+  const report = { signature: "abcdef123456" };
+  const meta = nextMetadata(existing, report, 1, "https://run", "2026-05-28");
+  assert.equal(meta.consecutive_failures, 1);
+});
+
+test("nextMetadata preserves first_seen", () => {
+  const existing = {
+    signature: "abcdef123456",
+    consecutive_failures: 1,
+    first_seen: "2026-05-20",
+    last_seen: "2026-05-27",
+    last_seen_run_id: 999,
+    last_green_run_url: null,
+  };
+  const report = { signature: "abcdef123456" };
+  const meta = nextMetadata(existing, report, 2, "https://run", "2026-05-28");
+  assert.equal(meta.first_seen, "2026-05-20");
+});
+
+test("shouldEscalateToHumanReview at threshold", () => {
+  assert.equal(shouldEscalateToHumanReview({ consecutive_failures: 2 }), false);
+  assert.equal(shouldEscalateToHumanReview({ consecutive_failures: 3 }), true);
+  assert.equal(shouldEscalateToHumanReview({ consecutive_failures: 5 }), true);
+});
+
+test("shouldCloseOnGreen", () => {
+  assert.equal(shouldCloseOnGreen({ last_seen: "2026-05-27" }, "2026-05-28"), true);
+  assert.equal(shouldCloseOnGreen({ last_seen: "2026-05-28" }, "2026-05-28"), false);
+  assert.equal(shouldCloseOnGreen(null, "2026-05-28"), false);
+});
+
+test("shouldStaleClose after 14 days", () => {
+  assert.equal(shouldStaleClose({ last_seen: "2026-05-13" }, "2026-05-28"), true);
+  assert.equal(shouldStaleClose({ last_seen: "2026-05-14" }, "2026-05-28"), false);
+  assert.equal(shouldStaleClose(null, "2026-05-28"), false);
+});
+
+test("findIssueBySignature", () => {
+  const issues = [
+    { number: 1, metadata: { signature: "aaaa11112222" } },
+    { number: 2, metadata: { signature: "bbbb33334444" } },
+    { number: 3, metadata: null },
+  ];
+  const found = findIssueBySignature(issues, "bbbb33334444");
+  assert.equal(found.number, 2);
+  assert.equal(findIssueBySignature(issues, "nope"), undefined);
+});
+
+test("deduplicateReports merges same signature", () => {
+  const reports = [
+    { signature: "abc123", projectName: "core", os: "Linux" },
+    { signature: "abc123", projectName: "core", os: "macOS" },
+    { signature: "def456", projectName: "full-terminal", os: "Linux" },
+  ];
+  const deduped = deduplicateReports(reports);
+  assert.equal(deduped.length, 2);
+});
+
+test("labelsForIssue", () => {
+  const labels = labelsForIssue({ projectName: "full-terminal" });
+  assert.ok(labels.includes("nightly-failure"));
+  assert.ok(labels.includes("full-terminal"));
+});
+
+test("labelsForEscalation", () => {
+  assert.deepEqual(labelsForEscalation({ consecutive_failures: 2 }), []);
+  assert.ok(labelsForEscalation({ consecutive_failures: 3 }).includes("human-review"));
+});
+
+test("buildRecoveredComment", () => {
+  const comment = buildRecoveredComment("https://github.com/org/repo/actions/runs/5");
+  assert.ok(comment.includes("did not recur"));
+  assert.ok(comment.includes("/actions/runs/5"));
+});

--- a/scripts/ci/process-nightly-issues.test.mjs
+++ b/scripts/ci/process-nightly-issues.test.mjs
@@ -230,7 +230,7 @@ test("findIssueBySignature", () => {
   assert.equal(findIssueBySignature(issues, "nope"), undefined);
 });
 
-test("deduplicateReports merges same signature", () => {
+test("deduplicateReports merges same signature with oses array", () => {
   const reports = [
     { signature: "abc123", projectName: "core", os: "Linux" },
     { signature: "abc123", projectName: "core", os: "macOS" },
@@ -238,6 +238,11 @@ test("deduplicateReports merges same signature", () => {
   ];
   const deduped = deduplicateReports(reports);
   assert.equal(deduped.length, 2);
+  const merged = deduped.find((d) => d.signature === "abc123");
+  assert.ok(merged);
+  assert.deepEqual(merged.oses, ["Linux", "macOS"]);
+  // input reports not mutated
+  assert.ok(!("oses" in reports[0]));
 });
 
 test("labelsForIssue", () => {

--- a/scripts/ci/process-nightly-issues.test.mjs
+++ b/scripts/ci/process-nightly-issues.test.mjs
@@ -1,5 +1,4 @@
-import { strict as assert } from "node:assert";
-import { test } from "node:test";
+import { describe, it, expect } from "vitest";
 import {
   buildMetadataBlock,
   buildIssueBody,
@@ -16,7 +15,7 @@ import {
   shouldStaleClose,
 } from "./process-nightly-issues.mjs";
 
-test("parseMetadata extracts valid metadata", () => {
+it("parseMetadata extracts valid metadata", () => {
   const body = `
 Some content
 <!-- METADATA:
@@ -32,32 +31,32 @@ Some content
 More content
 `;
   const meta = parseMetadata(body);
-  assert.ok(meta);
-  assert.equal(meta.signature, "abcdef123456");
-  assert.equal(meta.consecutive_failures, 2);
-  assert.equal(meta.first_seen, "2026-05-20");
-  assert.equal(meta.last_seen, "2026-05-28");
-  assert.equal(meta.last_seen_run_id, 12345);
+  expect(meta).toBeTruthy();
+  expect(meta.signature).toBe("abcdef123456");
+  expect(meta.consecutive_failures).toBe(2);
+  expect(meta.first_seen).toBe("2026-05-20");
+  expect(meta.last_seen).toBe("2026-05-28");
+  expect(meta.last_seen_run_id).toBe(12345);
 });
 
-test("parseMetadata returns null for missing marker", () => {
-  assert.equal(parseMetadata("no metadata here"), null);
-  assert.equal(parseMetadata(null), null);
+it("parseMetadata returns null for missing marker", () => {
+  expect(parseMetadata("no metadata here")).toBe(null);
+  expect(parseMetadata(null)).toBe(null);
 });
 
-test("parseMetadata returns null for invalid JSON in marker", () => {
-  assert.equal(parseMetadata("<!-- METADATA:\n{invalid}\n-->"), null);
+it("parseMetadata returns null for invalid JSON in marker", () => {
+  expect(parseMetadata("<!-- METADATA:\n{invalid}\n-->")).toBe(null);
 });
 
-test("parseMetadata returns null for missing signature", () => {
-  assert.equal(parseMetadata('<!-- METADATA:\n{"consecutive_failures": 1}\n-->'), null);
+it("parseMetadata returns null for missing signature", () => {
+  expect(parseMetadata('<!-- METADATA:\n{"consecutive_failures": 1}\n-->')).toBe(null);
 });
 
-test("parseMetadata returns null for wrong signature length", () => {
-  assert.equal(parseMetadata('<!-- METADATA:\n{"signature": "abc"}\n-->'), null);
+it("parseMetadata returns null for wrong signature length", () => {
+  expect(parseMetadata('<!-- METADATA:\n{"signature": "abc"}\n-->')).toBe(null);
 });
 
-test("buildMetadataBlock round-trips through parseMetadata", () => {
+it("buildMetadataBlock round-trips through parseMetadata", () => {
   const original = {
     signature: "deadbeef1234",
     consecutive_failures: 3,
@@ -68,10 +67,10 @@ test("buildMetadataBlock round-trips through parseMetadata", () => {
   };
   const block = buildMetadataBlock(original);
   const parsed = parseMetadata(block);
-  assert.deepEqual(parsed, original);
+  expect(parsed).toEqual(original);
 });
 
-test("buildMetadataBlock produces valid marker", () => {
+it("buildMetadataBlock produces valid marker", () => {
   const block = buildMetadataBlock({
     signature: "abcdef123456",
     consecutive_failures: 1,
@@ -80,23 +79,23 @@ test("buildMetadataBlock produces valid marker", () => {
     last_seen_run_id: 1,
     last_green_run_url: null,
   });
-  assert.ok(block.startsWith("<!-- METADATA:"));
-  assert.ok(block.endsWith("-->"));
-  assert.ok(block.includes('"abcdef123456"'));
+  expect(block.startsWith("<!-- METADATA:")).toBeTruthy();
+  expect(block.endsWith("-->")).toBeTruthy();
+  expect(block).toContain('"abcdef123456"');
 });
 
-test("buildIssueTitle", () => {
+it("buildIssueTitle", () => {
   const report = {
     projectName: "full-terminal",
     titlePath: ["root", "Search", "should find text"],
   };
   const title = buildIssueTitle(report);
-  assert.ok(title.includes("[Nightly]"));
-  assert.ok(title.includes("full-terminal"));
-  assert.ok(title.includes("should find text"));
+  expect(title).toContain("[Nightly]");
+  expect(title).toContain("full-terminal");
+  expect(title).toContain("should find text");
 });
 
-test("buildIssueTitle truncates long titles", () => {
+it("buildIssueTitle truncates long titles", () => {
   const report = {
     projectName: "core",
     titlePath: [
@@ -105,11 +104,11 @@ test("buildIssueTitle truncates long titles", () => {
     ],
   };
   const title = buildIssueTitle(report);
-  assert.ok(title.length <= 80);
-  assert.ok(title.endsWith("..."));
+  expect(title.length).toBeLessThanOrEqual(80);
+  expect(title.endsWith("...")).toBeTruthy();
 });
 
-test("buildIssueBody contains key info", () => {
+it("buildIssueBody contains key info", () => {
   const report = {
     projectName: "core",
     file: "e2e/core/test.spec.ts",
@@ -128,24 +127,24 @@ test("buildIssueBody contains key info", () => {
     last_green_run_url: null,
   };
   const body = buildIssueBody(report, metadata, "https://github.com/org/repo/actions/runs/1");
-  assert.ok(body.includes("e2e/core/test.spec.ts"));
-  assert.ok(body.includes("should work"));
-  assert.ok(body.includes("Expected 1 got 2"));
-  assert.ok(body.includes("Linux"));
-  assert.ok(body.includes("METADATA:"));
+  expect(body).toContain("e2e/core/test.spec.ts");
+  expect(body).toContain("should work");
+  expect(body).toContain("Expected 1 got 2");
+  expect(body).toContain("Linux");
+  expect(body).toContain("METADATA:");
 });
 
-test("nextMetadata creates new metadata", () => {
+it("nextMetadata creates new metadata", () => {
   const report = { signature: "abcdef123456" };
   const meta = nextMetadata(null, report, 1, "https://run", "2026-05-28");
-  assert.equal(meta.signature, "abcdef123456");
-  assert.equal(meta.consecutive_failures, 1);
-  assert.equal(meta.first_seen, "2026-05-28");
-  assert.equal(meta.last_seen, "2026-05-28");
-  assert.equal(meta.last_seen_run_id, 1);
+  expect(meta.signature).toBe("abcdef123456");
+  expect(meta.consecutive_failures).toBe(1);
+  expect(meta.first_seen).toBe("2026-05-28");
+  expect(meta.last_seen).toBe("2026-05-28");
+  expect(meta.last_seen_run_id).toBe(1);
 });
 
-test("nextMetadata skips increment on same run_id", () => {
+it("nextMetadata skips increment on same run_id", () => {
   const existing = {
     signature: "abcdef123456",
     consecutive_failures: 2,
@@ -156,10 +155,10 @@ test("nextMetadata skips increment on same run_id", () => {
   };
   const report = { signature: "abcdef123456" };
   const meta = nextMetadata(existing, report, 1, "https://run", "2026-05-28");
-  assert.equal(meta.consecutive_failures, 2);
+  expect(meta.consecutive_failures).toBe(2);
 });
 
-test("nextMetadata increments on consecutive day", () => {
+it("nextMetadata increments on consecutive day", () => {
   const existing = {
     signature: "abcdef123456",
     consecutive_failures: 2,
@@ -170,10 +169,10 @@ test("nextMetadata increments on consecutive day", () => {
   };
   const report = { signature: "abcdef123456" };
   const meta = nextMetadata(existing, report, 1, "https://run", "2026-05-28");
-  assert.equal(meta.consecutive_failures, 3);
+  expect(meta.consecutive_failures).toBe(3);
 });
 
-test("nextMetadata resets on non-consecutive day", () => {
+it("nextMetadata resets on non-consecutive day", () => {
   const existing = {
     signature: "abcdef123456",
     consecutive_failures: 2,
@@ -184,10 +183,10 @@ test("nextMetadata resets on non-consecutive day", () => {
   };
   const report = { signature: "abcdef123456" };
   const meta = nextMetadata(existing, report, 1, "https://run", "2026-05-28");
-  assert.equal(meta.consecutive_failures, 1);
+  expect(meta.consecutive_failures).toBe(1);
 });
 
-test("nextMetadata preserves first_seen", () => {
+it("nextMetadata preserves first_seen", () => {
   const existing = {
     signature: "abcdef123456",
     consecutive_failures: 1,
@@ -198,66 +197,66 @@ test("nextMetadata preserves first_seen", () => {
   };
   const report = { signature: "abcdef123456" };
   const meta = nextMetadata(existing, report, 2, "https://run", "2026-05-28");
-  assert.equal(meta.first_seen, "2026-05-20");
+  expect(meta.first_seen).toBe("2026-05-20");
 });
 
-test("shouldEscalateToHumanReview at threshold", () => {
-  assert.equal(shouldEscalateToHumanReview({ consecutive_failures: 2 }), false);
-  assert.equal(shouldEscalateToHumanReview({ consecutive_failures: 3 }), true);
-  assert.equal(shouldEscalateToHumanReview({ consecutive_failures: 5 }), true);
+it("shouldEscalateToHumanReview at threshold", () => {
+  expect(shouldEscalateToHumanReview({ consecutive_failures: 2 })).toBe(false);
+  expect(shouldEscalateToHumanReview({ consecutive_failures: 3 })).toBe(true);
+  expect(shouldEscalateToHumanReview({ consecutive_failures: 5 })).toBe(true);
 });
 
-test("shouldCloseOnGreen", () => {
-  assert.equal(shouldCloseOnGreen({ last_seen: "2026-05-27" }, "2026-05-28"), true);
-  assert.equal(shouldCloseOnGreen({ last_seen: "2026-05-28" }, "2026-05-28"), false);
-  assert.equal(shouldCloseOnGreen(null, "2026-05-28"), false);
+it("shouldCloseOnGreen", () => {
+  expect(shouldCloseOnGreen({ last_seen: "2026-05-27" }, "2026-05-28")).toBe(true);
+  expect(shouldCloseOnGreen({ last_seen: "2026-05-28" }, "2026-05-28")).toBe(false);
+  expect(shouldCloseOnGreen(null, "2026-05-28")).toBe(false);
 });
 
-test("shouldStaleClose after 14 days", () => {
-  assert.equal(shouldStaleClose({ last_seen: "2026-05-13" }, "2026-05-28"), true);
-  assert.equal(shouldStaleClose({ last_seen: "2026-05-14" }, "2026-05-28"), false);
-  assert.equal(shouldStaleClose(null, "2026-05-28"), false);
+it("shouldStaleClose after 14 days", () => {
+  expect(shouldStaleClose({ last_seen: "2026-05-13" }, "2026-05-28")).toBe(true);
+  expect(shouldStaleClose({ last_seen: "2026-05-14" }, "2026-05-28")).toBe(false);
+  expect(shouldStaleClose(null, "2026-05-28")).toBe(false);
 });
 
-test("findIssueBySignature", () => {
+it("findIssueBySignature", () => {
   const issues = [
     { number: 1, metadata: { signature: "aaaa11112222" } },
     { number: 2, metadata: { signature: "bbbb33334444" } },
     { number: 3, metadata: null },
   ];
   const found = findIssueBySignature(issues, "bbbb33334444");
-  assert.equal(found.number, 2);
-  assert.equal(findIssueBySignature(issues, "nope"), undefined);
+  expect(found.number).toBe(2);
+  expect(findIssueBySignature(issues, "nope")).toBeUndefined();
 });
 
-test("deduplicateReports merges same signature with oses array", () => {
+it("deduplicateReports merges same signature with oses array", () => {
   const reports = [
     { signature: "abc123", projectName: "core", os: "Linux" },
     { signature: "abc123", projectName: "core", os: "macOS" },
     { signature: "def456", projectName: "full-terminal", os: "Linux" },
   ];
   const deduped = deduplicateReports(reports);
-  assert.equal(deduped.length, 2);
+  expect(deduped.length).toBe(2);
   const merged = deduped.find((d) => d.signature === "abc123");
-  assert.ok(merged);
-  assert.deepEqual(merged.oses, ["Linux", "macOS"]);
+  expect(merged).toBeTruthy();
+  expect(merged.oses).toEqual(["Linux", "macOS"]);
   // input reports not mutated
-  assert.ok(!("oses" in reports[0]));
+  expect("oses" in reports[0]).toBeFalsy();
 });
 
-test("labelsForIssue", () => {
+it("labelsForIssue", () => {
   const labels = labelsForIssue({ projectName: "full-terminal" });
-  assert.ok(labels.includes("nightly-failure"));
-  assert.ok(labels.includes("full-terminal"));
+  expect(labels).toContain("nightly-failure");
+  expect(labels).toContain("full-terminal");
 });
 
-test("labelsForEscalation", () => {
-  assert.deepEqual(labelsForEscalation({ consecutive_failures: 2 }), []);
-  assert.ok(labelsForEscalation({ consecutive_failures: 3 }).includes("human-review"));
+it("labelsForEscalation", () => {
+  expect(labelsForEscalation({ consecutive_failures: 2 })).toEqual([]);
+  expect(labelsForEscalation({ consecutive_failures: 3 })).toContain("human-review");
 });
 
-test("buildRecoveredComment", () => {
+it("buildRecoveredComment", () => {
   const comment = buildRecoveredComment("https://github.com/org/repo/actions/runs/5");
-  assert.ok(comment.includes("did not recur"));
-  assert.ok(comment.includes("/actions/runs/5"));
+  expect(comment).toContain("did not recur");
+  expect(comment).toContain("/actions/runs/5");
 });


### PR DESCRIPTION
## Summary
The nightly CI workflow had a single rolling `nightly-failure` issue where every failure piled into one comment thread. New regressions were indistinguishable from stale flakes.

This replaces it with signature-keyed dedup. Each unique failure (hash of test file, title path, and normalized assertion message) gets its own issue. A matching step on the success edge auto-closes issues whose signatures didn't recur. Three-time repeat failures get the `human-review` label. A 14-day stale sweep cleans up orphaned signatures from renamed tests.

Resolves #9109

## Changes
- `scripts/ci/extract-failures.mjs` — walks the Playwright JSON report, extracts every non-passing test result, normalizes paths/timestamps/memory addresses, and produces a stable SHA-256 signature per failure
- `scripts/ci/process-nightly-issues.mjs` — parses the hidden `<!-- METADATA: {...} -->` block from issue bodies, matches running signatures against open issues, creates new issues for novel failures, closes resolved ones, and escalates 3x repeaters to `human-review`
- `.github/workflows/nightly.yml` — replaced the single-issue notify job with the extract-then-process pipeline plus a stale sweep job that runs weekly
- `.github/workflows/e2e.yml` — publishes the JSON test report as an artifact so the nightly workflow can consume it
- `playwright.config.ts` — added `full` meta-project so the report walks all six buckets in one pass

## Testing
- Unit tests (`extract-failures.test.mjs`, `process-nightly-issues.test.mjs`) cover signature normalization across POSIX and Windows paths, metadata round-trip parsing, issue title construction, and stale-sweep date math
- Manually verified the JSON report structure from a local full-bucket run against the extractor's expected schema