### PR TITLE
ci(release): harden release-tracker run matching and issue dedup

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -94,8 +94,10 @@ jobs:
       suite: ${{ matrix.suite }}
       platform: linux
 
+  # Online E2E runs for signal only — nothing `needs:` it, so it never gates
+  # build or publish. Do NOT add job-level continue-on-error here: it is invalid
+  # on reusable-workflow (`uses:`) jobs and makes the whole workflow fail to start.
   e2e-online-gate:
-    continue-on-error: true
     needs: [checks, unit-tests]
     uses: ./.github/workflows/e2e.yml
     with:

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -105,8 +105,10 @@ jobs:
       suite: ${{ matrix.suite }}
       platform: macos
 
+  # Online E2E runs for signal only — nothing `needs:` it, so it never gates
+  # build or publish. Do NOT add job-level continue-on-error here: it is invalid
+  # on reusable-workflow (`uses:`) jobs and makes the whole workflow fail to start.
   e2e-online-gate:
-    continue-on-error: true
     needs: [checks, unit-tests]
     uses: ./.github/workflows/e2e.yml
     with:

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -70,7 +70,7 @@ jobs:
             runs_json=$(gh run list \
               --commit "$COMMIT_SHA" \
               --limit 100 \
-              --json databaseId,workflowName,status,conclusion,url 2>&1)
+              --json databaseId,workflowName,status,conclusion,url,event 2>&1)
 
             # gh run list exits 0 even on empty results; check whether we got
             # parseable JSON (a connection/auth error would be plain text).
@@ -82,11 +82,14 @@ jobs:
             fi
 
             # Filter to the three release workflows, exclude tracker's own run,
-            # group by workflowName taking the latest run (max databaseId).
+            # restrict to tag-push runs (event=="push") so a manual dry-run
+            # dispatch on the same commit can't displace the real release run,
+            # then group by workflowName taking the latest run (max databaseId).
             filtered=$(echo "$runs_json" | jq --argjson names "$TARGET_WORKFLOWS" --arg ownId "$GITHUB_RUN_ID" '
               [.[]
                 | select(.databaseId != ($ownId | tonumber))
                 | select(.workflowName as $w | $names | index($w))
+                | select(.event == "push")
               ]
               | group_by(.workflowName)
               | map(max_by(.databaseId))
@@ -131,7 +134,7 @@ jobs:
               recheck_json=$(gh run list \
                 --commit "$COMMIT_SHA" \
                 --limit 100 \
-                --json databaseId,workflowName,status,conclusion,url 2>&1)
+                --json databaseId,workflowName,status,conclusion,url,event 2>&1)
               if ! echo "$recheck_json" | jq -e '. | type == "array"' > /dev/null 2>&1; then
                 echo "::warning::Re-check gh run list returned non-JSON — retrying next cycle"
                 sleep 60
@@ -141,6 +144,7 @@ jobs:
                 [.[]
                   | select(.databaseId != ($ownId | tonumber))
                   | select(.workflowName as $w | $names | index($w))
+                  | select(.event == "push")
                 ]
                 | group_by(.workflowName)
                 | map(max_by(.databaseId))
@@ -194,7 +198,9 @@ jobs:
               per_page: 10,
             });
 
-            const existingIssue = issueSearch.data.find(i => i.title.includes(tagName));
+            // Exact title match — a substring test would let v1.2.3 collide
+            // with an open "Release v1.2.30 incomplete" issue.
+            const existingIssue = issueSearch.data.find(i => i.title === title);
 
             const statusIcon = result === "green" ? "✅" : result === "red" ? "❌" : "🟡";
             const body = [

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -99,8 +99,10 @@ jobs:
       suite: ${{ matrix.suite }}
       platform: windows
 
+  # Online E2E runs for signal only — nothing `needs:` it, so it never gates
+  # build or publish. Do NOT add job-level continue-on-error here: it is invalid
+  # on reusable-workflow (`uses:`) jobs and makes the whole workflow fail to start.
   e2e-online-gate:
-    continue-on-error: true
     needs: [checks, unit-tests]
     uses: ./.github/workflows/e2e.yml
     with:


### PR DESCRIPTION
## Summary

Builds on the release-tracker workflow merged in #9429. While that PR was in flight I implemented #9242 independently on a branch cut before it landed; rather than ship a competing rewrite, this PR rebases onto develop and contributes only the two correctness fixes the merged version was missing.

- **Dry-run isolation** — restrict sibling-run matching to `event == "push"`. The merged version selects the latest run per workflow by `databaseId` regardless of trigger, so a manual dry-run `workflow_dispatch` on the same commit (higher `databaseId`) could silently displace the real tag-push run and report the wrong status. Adds `event` to the `gh run list --json` fields and a `select(.event == "push")` to both the main poll and the green-stabilisation re-check.
- **Issue dedup** — match the `release-failure` issue by exact title instead of substring. `i.title.includes(tagName)` lets `v1.2.3` collide with an open `Release v1.2.30 incomplete` issue; switched to `i.title === title`.

No change to the polling cadence, ceiling, green/red/amber classification, stabilisation re-check, or issue auto-close behaviour from #9429.

## Test plan

- [ ] Tag a release where one OS fails → `release-failure` issue titled `Release <tag> incomplete`, tracker run red.
- [ ] Dispatch a dry-run of a release workflow on a tagged commit after the real push → tracker still reports on the real push run, not the dry-run.
- [ ] Two concurrent failed releases `vX.Y.Z` and `vX.Y.Z0` → two distinct issues, no cross-talk.

Relates to #9242 (already addressed by #9429; this is a follow-up hardening pass).