### PR TITLE
Add weekly stale-quarantine auto-issue cron

### DIFF
--- a/.github/workflows/stale-quarantine.yml
+++ b/.github/workflows/stale-quarantine.yml
@@ -1,0 +1,95 @@
+name: Stale Quarantine
+
+on:
+  schedule:
+    # https://crontab.guru/#0_9_*_*_1 — every Monday 09:00 UTC
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Open or update stale-quarantine issues
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const path = require("node:path");
+            const { pathToFileURL } = require("node:url");
+            const { readFile } = require("node:fs/promises");
+
+            const lib = await import(
+              pathToFileURL(path.resolve("scripts/stale-quarantine-lib.mjs")).href
+            );
+            const { collectStaleQuarantines, buildIssueTitle, buildIssueBody } = lib;
+
+            const label = "test-quarantine";
+            const workspace = process.cwd();
+
+            const globber = await glob.create("e2e/**/*.spec.ts");
+            const absPaths = await globber.glob();
+
+            const files = [];
+            for (const absPath of absPaths) {
+              const source = await readFile(absPath, "utf8");
+              // Repo-relative POSIX path so issue titles stay stable across runners.
+              const specPath = path.relative(workspace, absPath).split(path.sep).join("/");
+              files.push({ path: specPath, source });
+            }
+
+            const stale = collectStaleQuarantines(files, new Date());
+            if (stale.length === 0) {
+              core.info("No stale quarantined tests found.");
+              return;
+            }
+
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            // One open issue per spec. Fetch all open test-quarantine issues once
+            // and match by title. per_page 100 is sufficient at current scale —
+            // switch to github.paginate() if quarantined specs ever exceed 100.
+            const { data: openIssues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: label,
+              state: "open",
+              per_page: 100,
+            });
+            const byTitle = new Map(openIssues.map((issue) => [issue.title, issue]));
+
+            for (const { path: specPath, stale: entries } of stale) {
+              const title = buildIssueTitle(specPath);
+              const body = buildIssueBody(specPath, entries, runUrl);
+              const existing = byTitle.get(title);
+
+              if (existing) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: existing.number,
+                  body,
+                });
+                core.info(`Commented on #${existing.number} for ${specPath}`);
+              } else {
+                const { data: created } = await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title,
+                  body,
+                  labels: [label],
+                });
+                core.info(`Created #${created.number} for ${specPath}`);
+              }
+            }

--- a/scripts/stale-quarantine-lib.mjs
+++ b/scripts/stale-quarantine-lib.mjs
@@ -10,13 +10,12 @@ export const STALE_THRESHOLD_DAYS = 30;
 
 const MS_PER_DAY = 86_400_000;
 
-// Remove block comments and line comments so commented-out annotations are
-// ignored. The line-comment pass keeps a non-`:` lookahead so `://` inside a URL
-// in a description is never mistaken for a comment.
+// Remove block comments and fully-commented lines so commented-out annotations
+// are ignored. Line comments are only stripped when `//` is the first
+// non-whitespace on the line — a trailing or in-string `//` (including `://` in
+// a URL) is left untouched, so description literals are never corrupted.
 function stripComments(source) {
-  return source
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .replace(/(^|[^:])\/\/[^\n]*/gm, "$1");
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^[ \t]*\/\/[^\n]*$/gm, "");
 }
 
 // Matches `type: "quarantine"` immediately followed by `description: "<value>"`.
@@ -39,19 +38,40 @@ export function extractQuarantineAnnotations(source) {
   return annotations;
 }
 
+// Parses a strict YYYY-MM-DD date to epoch ms, or null if it is malformed or a
+// calendar overflow (e.g. 2026-02-31, which Date would silently roll to March).
+function parseQuarantineDate(dateStr) {
+  if (!dateStr || !/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return null;
+  const ms = Date.parse(`${dateStr}T00:00:00.000Z`);
+  if (Number.isNaN(ms)) return null;
+  // The round-tripped date must equal the input — rejects overflowed days.
+  if (new Date(ms).toISOString().slice(0, 10) !== dateStr) return null;
+  return ms;
+}
+
 // Whole-day age of a YYYY-MM-DD date relative to `now`. Returns Infinity for an
-// unparseable date so callers treat it as stale rather than silently skipping it.
+// unparseable date so callers treat it as stale rather than silently skipping
+// it; a future date yields a negative age.
 export function daysSince(dateStr, now = new Date()) {
-  const then = Date.parse(`${dateStr}T00:00:00Z`);
-  if (Number.isNaN(then)) return Infinity;
-  return Math.floor((now.getTime() - then) / MS_PER_DAY);
+  const ms = parseQuarantineDate(dateStr);
+  if (ms === null) return Infinity;
+  return Math.floor((now.getTime() - ms) / MS_PER_DAY);
 }
 
 export function isStale(dateStr, now = new Date(), threshold = STALE_THRESHOLD_DAYS) {
   // A missing or malformed date is surfaced, not hidden: an undated quarantine
   // is exactly the kind of rot this cron exists to catch.
   if (!dateStr) return true;
-  return daysSince(dateStr, now) > threshold;
+  const age = daysSince(dateStr, now);
+  // Past the threshold is stale; a future date (negative age) is almost
+  // certainly a typo, so surface it too.
+  return age < 0 || age > threshold;
+}
+
+// Whole-day age, or null when the date is missing or unparseable.
+function ageInDays(dateStr, now) {
+  const days = daysSince(dateStr, now);
+  return Number.isFinite(days) ? days : null;
 }
 
 // Groups stale annotations by spec. `files` is `{ path, source }[]` so the pure
@@ -64,7 +84,7 @@ export function collectStaleQuarantines(files, now = new Date(), threshold = STA
       .map((annotation) => ({
         date: annotation.date,
         description: annotation.description,
-        ageDays: annotation.date ? daysSince(annotation.date, now) : null,
+        ageDays: ageInDays(annotation.date, now),
       }));
     if (stale.length > 0) {
       results.push({ path, stale });
@@ -77,6 +97,12 @@ export function buildIssueTitle(specPath) {
   return `Stale quarantined test in ${specPath}`;
 }
 
+function formatAge(ageDays) {
+  if (ageDays === null) return "no parseable date";
+  if (ageDays < 0) return "dated in the future";
+  return `${ageDays} days old`;
+}
+
 export function buildIssueBody(specPath, staleEntries, runUrl) {
   const lines = [
     `\`${specPath}\` has quarantined annotations older than ${STALE_THRESHOLD_DAYS} days.`,
@@ -86,10 +112,9 @@ export function buildIssueBody(specPath, staleEntries, runUrl) {
   ];
 
   for (const entry of staleEntries) {
-    const age =
-      entry.ageDays === null ? "no parseable date" : `${entry.ageDays} days old`;
-    const date = entry.date ?? "undated";
-    lines.push(`- **${date}** (${age}) — ${entry.description}`);
+    lines.push(
+      `- **${entry.date ?? "undated"}** (${formatAge(entry.ageDays)}) — ${entry.description}`
+    );
   }
 
   if (runUrl) {

--- a/scripts/stale-quarantine-lib.mjs
+++ b/scripts/stale-quarantine-lib.mjs
@@ -22,8 +22,7 @@ function stripComments(source) {
 // `[\s\S]*?` between the two keys tolerates the newline that wraps a long
 // description onto its own line; the backreferences allow single or double
 // quotes. The leading date is parsed separately from the captured description.
-const ANNOTATION_RE =
-  /type:\s*(['"])quarantine\1\s*,\s*description:\s*(['"])([\s\S]*?)\2/g;
+const ANNOTATION_RE = /type:\s*(['"])quarantine\1\s*,\s*description:\s*(['"])([\s\S]*?)\2/g;
 
 const DATE_RE = /^(\d{4}-\d{2}-\d{2})\b/;
 
@@ -107,7 +106,7 @@ export function buildIssueBody(specPath, staleEntries, runUrl) {
   const lines = [
     `\`${specPath}\` has quarantined annotations older than ${STALE_THRESHOLD_DAYS} days.`,
     "",
-    "Fix the spec and remove its `type: \"quarantine\"` annotation, or formally retire the test.",
+    'Fix the spec and remove its `type: "quarantine"` annotation, or formally retire the test.',
     "",
   ];
 

--- a/scripts/stale-quarantine-lib.mjs
+++ b/scripts/stale-quarantine-lib.mjs
@@ -1,0 +1,104 @@
+// Pure helpers for the weekly stale-quarantine cron
+// (.github/workflows/stale-quarantine.yml). Scans Playwright spec sources for
+// `type: "quarantine"` annotations, parses the leading YYYY-MM-DD date from each
+// description, and flags any older than the staleness threshold.
+//
+// No import-time side effects — safe for Vitest and for dynamic import from
+// actions/github-script.
+
+export const STALE_THRESHOLD_DAYS = 30;
+
+const MS_PER_DAY = 86_400_000;
+
+// Remove block comments and line comments so commented-out annotations are
+// ignored. The line-comment pass keeps a non-`:` lookahead so `://` inside a URL
+// in a description is never mistaken for a comment.
+function stripComments(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/[^\n]*/gm, "$1");
+}
+
+// Matches `type: "quarantine"` immediately followed by `description: "<value>"`.
+// `[\s\S]*?` between the two keys tolerates the newline that wraps a long
+// description onto its own line; the backreferences allow single or double
+// quotes. The leading date is parsed separately from the captured description.
+const ANNOTATION_RE =
+  /type:\s*(['"])quarantine\1\s*,\s*description:\s*(['"])([\s\S]*?)\2/g;
+
+const DATE_RE = /^(\d{4}-\d{2}-\d{2})\b/;
+
+export function extractQuarantineAnnotations(source) {
+  const cleaned = stripComments(source);
+  const annotations = [];
+  for (const match of cleaned.matchAll(ANNOTATION_RE)) {
+    const description = match[3].trim();
+    const dateMatch = description.match(DATE_RE);
+    annotations.push({ description, date: dateMatch ? dateMatch[1] : null });
+  }
+  return annotations;
+}
+
+// Whole-day age of a YYYY-MM-DD date relative to `now`. Returns Infinity for an
+// unparseable date so callers treat it as stale rather than silently skipping it.
+export function daysSince(dateStr, now = new Date()) {
+  const then = Date.parse(`${dateStr}T00:00:00Z`);
+  if (Number.isNaN(then)) return Infinity;
+  return Math.floor((now.getTime() - then) / MS_PER_DAY);
+}
+
+export function isStale(dateStr, now = new Date(), threshold = STALE_THRESHOLD_DAYS) {
+  // A missing or malformed date is surfaced, not hidden: an undated quarantine
+  // is exactly the kind of rot this cron exists to catch.
+  if (!dateStr) return true;
+  return daysSince(dateStr, now) > threshold;
+}
+
+// Groups stale annotations by spec. `files` is `{ path, source }[]` so the pure
+// grouping logic is testable without touching the filesystem.
+export function collectStaleQuarantines(files, now = new Date(), threshold = STALE_THRESHOLD_DAYS) {
+  const results = [];
+  for (const { path, source } of files) {
+    const stale = extractQuarantineAnnotations(source)
+      .filter((annotation) => isStale(annotation.date, now, threshold))
+      .map((annotation) => ({
+        date: annotation.date,
+        description: annotation.description,
+        ageDays: annotation.date ? daysSince(annotation.date, now) : null,
+      }));
+    if (stale.length > 0) {
+      results.push({ path, stale });
+    }
+  }
+  return results;
+}
+
+export function buildIssueTitle(specPath) {
+  return `Stale quarantined test in ${specPath}`;
+}
+
+export function buildIssueBody(specPath, staleEntries, runUrl) {
+  const lines = [
+    `\`${specPath}\` has quarantined annotations older than ${STALE_THRESHOLD_DAYS} days.`,
+    "",
+    "Fix the spec and remove its `type: \"quarantine\"` annotation, or formally retire the test.",
+    "",
+  ];
+
+  for (const entry of staleEntries) {
+    const age =
+      entry.ageDays === null ? "no parseable date" : `${entry.ageDays} days old`;
+    const date = entry.date ?? "undated";
+    lines.push(`- **${date}** (${age}) — ${entry.description}`);
+  }
+
+  if (runUrl) {
+    lines.push("", `**Run:** ${runUrl}`);
+  }
+
+  // Inert dedup marker — the workflow currently matches by title, but this keeps
+  // a future marker-based migration mechanical.
+  lines.push("", `<!-- stale-quarantine-spec:${specPath} -->`);
+
+  return lines.join("\n");
+}

--- a/scripts/stale-quarantine-lib.test.mjs
+++ b/scripts/stale-quarantine-lib.test.mjs
@@ -76,6 +76,24 @@ describe("extractQuarantineAnnotations", () => {
     );
   });
 
+  it("does not corrupt a description containing a bare //", () => {
+    const source = `
+      test.info().annotations.push({
+        type: "quarantine",
+        description: "2026-05-27 flaky // only on CI runners",
+      });
+    `;
+    const result = extractQuarantineAnnotations(source);
+    expect(result).toEqual([
+      { date: "2026-05-27", description: "2026-05-27 flaky // only on CI runners" },
+    ]);
+  });
+
+  it("skips annotations with keys in reverse order (type must precede description)", () => {
+    const source = `annotations.push({ description: "2026-05-27 reversed", type: "quarantine" });`;
+    expect(extractQuarantineAnnotations(source)).toEqual([]);
+  });
+
   it("returns an empty array when there are no annotations", () => {
     expect(extractQuarantineAnnotations("const x = 1;")).toEqual([]);
   });
@@ -130,6 +148,15 @@ describe("isStale", () => {
     expect(isStale("yesterday", now)).toBe(true);
   });
 
+  it("treats a calendar-overflow date as stale", () => {
+    // 2026-02-31 would silently roll to March 3 — reject it instead.
+    expect(isStale("2026-02-31", now)).toBe(true);
+  });
+
+  it("treats a future date as stale (likely a typo)", () => {
+    expect(isStale("3026-01-01", now)).toBe(true);
+  });
+
   it("respects a custom threshold", () => {
     expect(isStale("2026-06-20", now, 5)).toBe(true);
     expect(isStale("2026-06-20", now, 10)).toBe(false);
@@ -162,6 +189,28 @@ describe("collectStaleQuarantines", () => {
     ];
     const result = collectStaleQuarantines(files, now);
     expect(result[0].stale[0]).toMatchObject({ date: null, ageDays: null });
+  });
+
+  it("returns every stale annotation from a single spec", () => {
+    const source = `
+      annotations.push({ type: "quarantine", description: "2026-01-01 first" });
+      annotations.push({ type: "quarantine", description: "2026-02-01 second" });
+      annotations.push({ type: "quarantine", description: "2026-03-01 third" });
+    `;
+    const result = collectStaleQuarantines([{ path: "e2e/e.spec.ts", source }], now);
+    expect(result).toHaveLength(1);
+    expect(result[0].stale).toHaveLength(3);
+  });
+
+  it("reports a calendar-overflow date as stale with a null ageDays", () => {
+    const files = [
+      {
+        path: "e2e/f.spec.ts",
+        source: `annotations.push({ type: "quarantine", description: "2026-02-31 impossible" });`,
+      },
+    ];
+    const result = collectStaleQuarantines(files, now);
+    expect(result[0].stale[0]).toMatchObject({ date: "2026-02-31", ageDays: null });
   });
 
   it("returns an empty array when nothing is stale", () => {
@@ -208,6 +257,13 @@ describe("buildIssueBody", () => {
     ]);
     expect(body).toContain("undated");
     expect(body).toContain("no parseable date");
+  });
+
+  it("labels a future-dated entry", () => {
+    const body = buildIssueBody("e2e/x.spec.ts", [
+      { date: "3026-01-01", ageDays: -365, description: "3026-01-01 future typo" },
+    ]);
+    expect(body).toContain("dated in the future");
   });
 });
 

--- a/scripts/stale-quarantine-lib.test.mjs
+++ b/scripts/stale-quarantine-lib.test.mjs
@@ -71,9 +71,7 @@ describe("extractQuarantineAnnotations", () => {
       });
     `;
     const result = extractQuarantineAnnotations(source);
-    expect(result[0].description).toBe(
-      "2026-05-27 see https://example.com/issue for context"
-    );
+    expect(result[0].description).toBe("2026-05-27 see https://example.com/issue for context");
   });
 
   it("does not corrupt a description containing a bare //", () => {
@@ -227,9 +225,7 @@ describe("collectStaleQuarantines", () => {
 describe("buildIssueTitle", () => {
   it("is sentence case with no terminal period and carries the spec path", () => {
     const title = buildIssueTitle("e2e/full/panels/core-browser-panel.spec.ts");
-    expect(title).toBe(
-      "Stale quarantined test in e2e/full/panels/core-browser-panel.spec.ts"
-    );
+    expect(title).toBe("Stale quarantined test in e2e/full/panels/core-browser-panel.spec.ts");
     expect(title.endsWith(".")).toBe(false);
   });
 });

--- a/scripts/stale-quarantine-lib.test.mjs
+++ b/scripts/stale-quarantine-lib.test.mjs
@@ -1,0 +1,216 @@
+import { describe, it, expect } from "vitest";
+import {
+  STALE_THRESHOLD_DAYS,
+  extractQuarantineAnnotations,
+  daysSince,
+  isStale,
+  collectStaleQuarantines,
+  buildIssueTitle,
+  buildIssueBody,
+} from "./stale-quarantine-lib.mjs";
+
+// Real-world annotation shapes copied from the migrated spec files.
+const INLINE_ANNOTATION = `
+  test.beforeAll(() => {
+    test.info().annotations.push({
+      type: "quarantine",
+      description: "2026-05-27 webview instability causes Electron crash in E2E sequence",
+    });
+  });
+`;
+
+const WRAPPED_DESCRIPTION = `
+  // rest of the full suite green on this Mac; tracked separately.
+  test.info().annotations.push({
+    type: "quarantine",
+    description:
+      "2026-05-27 Full test quarantined: dev-preview: OAuth redirect blocked",
+  });
+`;
+
+describe("extractQuarantineAnnotations", () => {
+  it("parses a single inline annotation", () => {
+    const result = extractQuarantineAnnotations(INLINE_ANNOTATION);
+    expect(result).toEqual([
+      {
+        date: "2026-05-27",
+        description: "2026-05-27 webview instability causes Electron crash in E2E sequence",
+      },
+    ]);
+  });
+
+  it("parses a description that wraps onto its own line", () => {
+    const result = extractQuarantineAnnotations(WRAPPED_DESCRIPTION);
+    expect(result).toHaveLength(1);
+    expect(result[0].date).toBe("2026-05-27");
+    expect(result[0].description).toContain("OAuth redirect blocked");
+  });
+
+  it("parses multiple annotations in one source", () => {
+    const source = INLINE_ANNOTATION + WRAPPED_DESCRIPTION;
+    const result = extractQuarantineAnnotations(source);
+    expect(result).toHaveLength(2);
+  });
+
+  it("ignores commented-out annotations", () => {
+    const source = `
+      // test.info().annotations.push({
+      //   type: "quarantine",
+      //   description: "2026-01-01 disabled long ago",
+      // });
+      /* test.info().annotations.push({ type: "quarantine", description: "2026-01-02 block" }); */
+    `;
+    expect(extractQuarantineAnnotations(source)).toEqual([]);
+  });
+
+  it("does not corrupt a description containing a URL", () => {
+    const source = `
+      test.info().annotations.push({
+        type: "quarantine",
+        description: "2026-05-27 see https://example.com/issue for context",
+      });
+    `;
+    const result = extractQuarantineAnnotations(source);
+    expect(result[0].description).toBe(
+      "2026-05-27 see https://example.com/issue for context"
+    );
+  });
+
+  it("returns an empty array when there are no annotations", () => {
+    expect(extractQuarantineAnnotations("const x = 1;")).toEqual([]);
+  });
+
+  it("records a null date when the description has no leading date", () => {
+    const source = `
+      test.info().annotations.push({
+        type: "quarantine",
+        description: "no date prefix here",
+      });
+    `;
+    expect(extractQuarantineAnnotations(source)).toEqual([
+      { date: null, description: "no date prefix here" },
+    ]);
+  });
+
+  it("handles single-quoted annotations", () => {
+    const source = `annotations.push({ type: 'quarantine', description: '2026-05-27 single quotes' });`;
+    const result = extractQuarantineAnnotations(source);
+    expect(result[0].date).toBe("2026-05-27");
+  });
+});
+
+describe("daysSince", () => {
+  it("counts whole days between dates in UTC", () => {
+    expect(daysSince("2026-05-27", new Date("2026-06-27T00:00:00.000Z"))).toBe(31);
+  });
+
+  it("returns Infinity for an unparseable date", () => {
+    expect(daysSince("not-a-date", new Date())).toBe(Infinity);
+  });
+});
+
+describe("isStale", () => {
+  const now = new Date("2026-06-27T00:00:00.000Z");
+
+  it("is not stale at exactly the threshold", () => {
+    // 2026-05-28 -> 2026-06-27 is exactly 30 days.
+    expect(isStale("2026-05-28", now)).toBe(false);
+  });
+
+  it("is stale one day past the threshold", () => {
+    // 2026-05-27 -> 2026-06-27 is 31 days.
+    expect(isStale("2026-05-27", now)).toBe(true);
+  });
+
+  it("treats a null date as stale", () => {
+    expect(isStale(null, now)).toBe(true);
+  });
+
+  it("treats a malformed date as stale", () => {
+    expect(isStale("yesterday", now)).toBe(true);
+  });
+
+  it("respects a custom threshold", () => {
+    expect(isStale("2026-06-20", now, 5)).toBe(true);
+    expect(isStale("2026-06-20", now, 10)).toBe(false);
+  });
+});
+
+describe("collectStaleQuarantines", () => {
+  const now = new Date("2026-07-01T00:00:00.000Z");
+
+  it("groups stale annotations by spec and skips fresh ones", () => {
+    const files = [
+      { path: "e2e/a.spec.ts", source: INLINE_ANNOTATION },
+      {
+        path: "e2e/b.spec.ts",
+        source: `annotations.push({ type: "quarantine", description: "${todayIso(now)} fresh" });`,
+      },
+    ];
+    const result = collectStaleQuarantines(files, now);
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe("e2e/a.spec.ts");
+    expect(result[0].stale[0].ageDays).toBe(35);
+  });
+
+  it("includes a null ageDays for undated stale annotations", () => {
+    const files = [
+      {
+        path: "e2e/c.spec.ts",
+        source: `annotations.push({ type: "quarantine", description: "undated reason" });`,
+      },
+    ];
+    const result = collectStaleQuarantines(files, now);
+    expect(result[0].stale[0]).toMatchObject({ date: null, ageDays: null });
+  });
+
+  it("returns an empty array when nothing is stale", () => {
+    const files = [
+      {
+        path: "e2e/d.spec.ts",
+        source: `annotations.push({ type: "quarantine", description: "${todayIso(now)} fresh" });`,
+      },
+    ];
+    expect(collectStaleQuarantines(files, now)).toEqual([]);
+  });
+});
+
+describe("buildIssueTitle", () => {
+  it("is sentence case with no terminal period and carries the spec path", () => {
+    const title = buildIssueTitle("e2e/full/panels/core-browser-panel.spec.ts");
+    expect(title).toBe(
+      "Stale quarantined test in e2e/full/panels/core-browser-panel.spec.ts"
+    );
+    expect(title.endsWith(".")).toBe(false);
+  });
+});
+
+describe("buildIssueBody", () => {
+  it("lists each stale entry and includes the run link and dedup marker", () => {
+    const body = buildIssueBody(
+      "e2e/full/panels/core-browser-panel.spec.ts",
+      [{ date: "2026-05-27", ageDays: 35, description: "2026-05-27 webview crash" }],
+      "https://github.com/daintreehq/daintree/actions/runs/123"
+    );
+    expect(body).toContain("e2e/full/panels/core-browser-panel.spec.ts");
+    expect(body).toContain(String(STALE_THRESHOLD_DAYS));
+    expect(body).toContain("35 days old");
+    expect(body).toContain("webview crash");
+    expect(body).toContain("**Run:** https://github.com/daintreehq/daintree/actions/runs/123");
+    expect(body).toContain(
+      "<!-- stale-quarantine-spec:e2e/full/panels/core-browser-panel.spec.ts -->"
+    );
+  });
+
+  it("renders undated entries without crashing", () => {
+    const body = buildIssueBody("e2e/x.spec.ts", [
+      { date: null, ageDays: null, description: "undated reason" },
+    ]);
+    expect(body).toContain("undated");
+    expect(body).toContain("no parseable date");
+  });
+});
+
+function todayIso(now) {
+  return now.toISOString().slice(0, 10);
+}


### PR DESCRIPTION
## Summary

- Adds a weekly Monday cron (`.github/workflows/stale-quarantine.yml`) that scans Playwright E2E specs for `type: "quarantine"` annotations, parses the leading `YYYY-MM-DD` date, and opens or comments on a per-spec tracking issue for any annotation older than 30 days — mirroring the nightly-failure `listForRepo` + `createComment`-or-`create` dedup shape (`nightly.yml` lines 611-647), scoped per spec.
- Parsing and staleness logic lives in a pure, unit-tested lib (`scripts/stale-quarantine-lib.mjs`, 28 Vitest tests in `scripts/stale-quarantine-lib.test.mjs`); the workflow dynamically imports it from `github-script` so the parsing is testable in isolation.
- Uses the `test-quarantine` label (created out-of-band on the repo; the workflow intentionally does not bootstrap labels). Issue titles are sentence case with no terminal period. Does not apply `human-review`.

## Notes

The 4 current quarantine annotations are all dated 2026-05-27, so the cron is wired correctly but stays quiet until they age past 30 days.

Hardening beyond the core issue: URL/`//`-safe comment stripping (so a `://` or bare `//` inside a description isn't truncated), rejection of calendar-overflow dates (e.g. `2026-02-31`), and future-dated annotations are surfaced as stale rather than silently passing.

## Test plan

- [x] `npx vitest run scripts/stale-quarantine-lib.test.mjs` (28 passing)
- [x] `npm run check` (typecheck, lint-ratchet, format) green
- [ ] First scheduled run (or manual `workflow_dispatch`) confirms issue creation against the `test-quarantine` label

Closes #9121.