### PR TITLE
feat(voice): add pre-recording arming state for dictation target confirmation

### DIFF
--- a/shared/types/voice.ts
+++ b/shared/types/voice.ts
@@ -6,9 +6,14 @@
  */
 
 /**
- * The phase of the voice recording session as reported over IPC.
+ * The phase of the voice recording session.
  *
  * - idle: No active session.
+ * - arming: Renderer-only pre-recording state. Fires synchronously on hotkey
+ *   press so the target panel and toolbar can show a visual cue (~<50ms)
+ *   before audio init begins (~200ms). The backend never emits this status
+ *   over IPC; it lives only in the renderer voice store and is overwritten
+ *   by `beginSession()` once `connecting` arrives.
  * - connecting: WebSocket to OpenAI Realtime is being established.
  * - recording: Connected and receiving audio; live transcription in progress.
  * - paused: Session alive (WebSocket open) but audio capture suspended;
@@ -21,6 +26,7 @@
  */
 export type VoiceInputStatus =
   | "idle"
+  | "arming"
   | "connecting"
   | "recording"
   | "paused"
@@ -41,8 +47,11 @@ export type VoiceInputStatus =
 export type VoiceTranscriptPhase = "idle" | "interim" | "utterance_final" | "stable";
 
 /**
- * Returns true when the voice session is in an active phase (i.e. not idle or error).
- * Use this instead of comparing against multiple status strings inline.
+ * Returns true when the voice session is in an active phase (i.e. not idle,
+ * arming, or error). `arming` is excluded deliberately: it is the pre-audio
+ * confirmation window, and including it would cause the toggle guard to treat
+ * a second hotkey press during arming as a stop instead of letting the
+ * in-flight start complete.
  */
 export function isActiveVoiceSession(status: VoiceInputStatus): boolean {
   return (

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -262,7 +262,8 @@ export function Toolbar({
   const hasActiveVoiceRecording = useVoiceRecordingStore(
     (state) =>
       state.activeTarget !== null &&
-      (state.status === "connecting" ||
+      (state.status === "arming" ||
+        state.status === "connecting" ||
         state.status === "recording" ||
         state.status === "paused" ||
         state.status === "finishing")

--- a/src/components/Layout/VoiceRecordingToolbarButton.tsx
+++ b/src/components/Layout/VoiceRecordingToolbarButton.tsx
@@ -59,6 +59,7 @@ export function VoiceRecordingToolbarButton({
   const hover = useShortcutHintHover("voiceInput.toggle");
   const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
 
+  const isArming = status === "arming";
   const isConnecting = status === "connecting";
   const isRecording = status === "recording";
   const isReconnecting = status === "reconnecting";
@@ -66,7 +67,7 @@ export function VoiceRecordingToolbarButton({
   const isPaused = status === "paused";
   const isActive =
     Boolean(activeTarget) &&
-    (isConnecting || isRecording || isReconnecting || isFinishing || isPaused);
+    (isArming || isConnecting || isRecording || isReconnecting || isFinishing || isPaused);
 
   // Doherty gate — under 400ms of "connecting" should never paint the orbit;
   // it would flash before the recording state arrives.
@@ -77,6 +78,13 @@ export function VoiceRecordingToolbarButton({
   // RAF loop spinning on null refs.
   const showOrbit =
     isActive && (isRecording || isReconnecting || isFinishing || isPaused || showConnecting);
+  // Arming paints immediately with no Doherty gate — the visual confirmation
+  // IS the point of the state, and a gate would defeat it. The cue is a
+  // static accent ring instead of the orbit (which only spins once audio
+  // chunks land). Hold the static ring through the pre-Doherty connecting
+  // window so the indicator never blanks out between the arming flash and
+  // the orbit appearing.
+  const showArming = isActive && (isArming || (isConnecting && !showConnecting));
 
   // Mutable bridge: audioLevel updates ~60Hz; we read it inside the RAF tick
   // rather than re-rendering on every change. Pattern lifted from
@@ -194,26 +202,31 @@ export function VoiceRecordingToolbarButton({
     return () => cancelAnimationFrame(rafRef.current);
   }, [showOrbit, isFinishing, isPaused]);
 
-  if (!isActive || !showOrbit) {
+  if (!isActive || (!showOrbit && !showArming)) {
     return <VoiceRecordingPlaceholder />;
   }
 
   const contextLabel = [activeTarget?.projectName, activeTarget?.worktreeLabel]
     .filter(Boolean)
     .join(" / ");
-  const tooltipTitle = isConnecting
-    ? "Preparing dictation..."
-    : isReconnecting
-      ? "Reconnecting..."
-      : isFinishing
-        ? "Finishing transcription..."
-        : isPaused
-          ? contextLabel
-            ? `Paused: ${contextLabel}`
-            : "Dictation paused"
-          : contextLabel
-            ? `Recording: ${contextLabel}`
-            : "Recording in another panel";
+  const targetLabel = activeTarget?.panelTitle ?? contextLabel;
+  const tooltipTitle = isArming
+    ? targetLabel
+      ? `Arming dictation: ${targetLabel}`
+      : "Arming dictation..."
+    : isConnecting
+      ? "Preparing dictation..."
+      : isReconnecting
+        ? "Reconnecting..."
+        : isFinishing
+          ? "Finishing transcription..."
+          : isPaused
+            ? contextLabel
+              ? `Paused: ${contextLabel}`
+              : "Dictation paused"
+            : contextLabel
+              ? `Recording: ${contextLabel}`
+              : "Recording in another panel";
   const tooltipExtra = (() => {
     const parts: Array<string | null> = [];
     if (isRecording || isPaused) parts.push(formatDuration(elapsedSeconds));
@@ -249,64 +262,87 @@ export function VoiceRecordingToolbarButton({
               aria-keyshortcuts={ariaShortcut}
             >
               <Mic className="h-4 w-4" />
-              {/* Orbit overlay — absolute inset on the relative Button. No
-                  contain:strict at this scale: the toolbar button is a flex
-                  child and clipping the orbit would crop the ring. */}
-              <span
-                ref={trackRef}
-                aria-hidden="true"
-                className="absolute inset-1 rounded-full pointer-events-none"
-                style={{
-                  opacity: 0.08,
-                  background: `var(--theme-accent-primary)`,
-                  mask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
-                  WebkitMask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
-                  maskComposite: "exclude",
-                  WebkitMaskComposite: "xor",
-                  padding: `${BASE_THICKNESS}px`,
-                  transition: "opacity 80ms ease-out",
-                }}
-              />
-              <div
-                ref={wrapperRef}
-                aria-hidden="true"
-                className="absolute inset-1 pointer-events-none"
-                style={{ willChange: "transform" }}
-              >
+              {/* Arming ring — static accent border painted during the
+                  pre-audio confirmation window. Replaces the orbit until
+                  audio is hot, so the user sees an immediate confirmation
+                  that the hotkey was registered. */}
+              {showArming && (
                 <span
-                  ref={ringRef}
-                  className="absolute inset-0 rounded-full"
+                  aria-hidden="true"
+                  className="absolute inset-1 rounded-full pointer-events-none"
                   style={{
-                    padding: `${BASE_THICKNESS}px`,
+                    background: `var(--theme-accent-primary)`,
+                    opacity: 0.55,
                     mask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
                     WebkitMask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
                     maskComposite: "exclude",
                     WebkitMaskComposite: "xor",
+                    padding: `${BASE_THICKNESS}px`,
                   }}
                 />
-                <span
-                  ref={dotHaloRef}
-                  className="absolute rounded-full bg-daintree-accent/30"
-                  style={{
-                    width: "6px",
-                    height: "6px",
-                    top: 0,
-                    left: "50%",
-                    transform: "translate(-50%, -35%)",
-                  }}
-                />
-                <span
-                  ref={dotCoreRef}
-                  className="absolute rounded-full bg-daintree-accent"
-                  style={{
-                    width: "3.5px",
-                    height: "3.5px",
-                    top: 0,
-                    left: "50%",
-                    transform: "translate(-50%, -15%)",
-                  }}
-                />
-              </div>
+              )}
+              {/* Orbit overlay — absolute inset on the relative Button. No
+                  contain:strict at this scale: the toolbar button is a flex
+                  child and clipping the orbit would crop the ring. */}
+              {showOrbit && (
+                <>
+                  <span
+                    ref={trackRef}
+                    aria-hidden="true"
+                    className="absolute inset-1 rounded-full pointer-events-none"
+                    style={{
+                      opacity: 0.08,
+                      background: `var(--theme-accent-primary)`,
+                      mask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
+                      WebkitMask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
+                      maskComposite: "exclude",
+                      WebkitMaskComposite: "xor",
+                      padding: `${BASE_THICKNESS}px`,
+                      transition: "opacity 80ms ease-out",
+                    }}
+                  />
+                  <div
+                    ref={wrapperRef}
+                    aria-hidden="true"
+                    className="absolute inset-1 pointer-events-none"
+                    style={{ willChange: "transform" }}
+                  >
+                    <span
+                      ref={ringRef}
+                      className="absolute inset-0 rounded-full"
+                      style={{
+                        padding: `${BASE_THICKNESS}px`,
+                        mask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
+                        WebkitMask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
+                        maskComposite: "exclude",
+                        WebkitMaskComposite: "xor",
+                      }}
+                    />
+                    <span
+                      ref={dotHaloRef}
+                      className="absolute rounded-full bg-daintree-accent/30"
+                      style={{
+                        width: "6px",
+                        height: "6px",
+                        top: 0,
+                        left: "50%",
+                        transform: "translate(-50%, -35%)",
+                      }}
+                    />
+                    <span
+                      ref={dotCoreRef}
+                      className="absolute rounded-full bg-daintree-accent"
+                      style={{
+                        width: "3.5px",
+                        height: "3.5px",
+                        top: 0,
+                        left: "50%",
+                        transform: "translate(-50%, -15%)",
+                      }}
+                    />
+                  </div>
+                </>
+              )}
             </Button>
           </TooltipTrigger>
           <TooltipContent side="bottom" className="text-center">

--- a/src/components/Layout/__tests__/VoiceRecordingToolbarButton.test.ts
+++ b/src/components/Layout/__tests__/VoiceRecordingToolbarButton.test.ts
@@ -46,8 +46,10 @@ describe("VoiceRecordingToolbarButton polish — issue #8176", () => {
 
     it("placeholder is returned via early-return so an inactive slot never paints orbit chrome", () => {
       // The early return must come AFTER hooks (RAF, refs) but BEFORE the
-      // active button JSX, mirroring VoiceInputButton's gating.
-      expect(source).toMatch(/if\s*\(!isActive\s*\|\|\s*!showOrbit\)\s*{/);
+      // active button JSX, mirroring VoiceInputButton's gating. The guard
+      // now also lets the arming state through so its static accent ring
+      // can paint before audio init begins (#9178).
+      expect(source).toMatch(/if\s*\(!isActive\s*\|\|\s*\(!showOrbit\s*&&\s*!showArming\)\)\s*{/);
       expect(source).toMatch(/return\s+<VoiceRecordingPlaceholder/);
     });
 
@@ -135,6 +137,30 @@ describe("VoiceRecordingToolbarButton polish — issue #8176", () => {
     it("uses scoped transition durations — never the broad transition-all", () => {
       // Motion timing rule: never widen scoped transitions to transition-all.
       expect(source).not.toContain("transition-all");
+    });
+  });
+
+  // Issue #9178 — pre-recording arming state.
+  describe("pre-recording arming state (#9178)", () => {
+    it("derives isArming and isActive includes it so the placeholder gives way", () => {
+      expect(source).toMatch(/const\s+isArming\s*=\s*status\s*===\s*"arming"/);
+      expect(source).toMatch(/isActive\s*=[\s\S]*?isArming/);
+    });
+
+    it("shows the arming cue without the Doherty gate — immediate hotkey feedback", () => {
+      // Arming IS the visual confirmation the user expects in <50ms; gating
+      // it behind the 400ms threshold would defeat the feature.
+      expect(source).toMatch(/showArming\s*=\s*isActive\s*&&\s*\(isArming/);
+    });
+
+    it("the tooltip names the target panel during arming so the user can verify before audio opens", () => {
+      expect(source).toMatch(/Arming dictation/);
+    });
+
+    it("the toolbar overflow pin includes arming so the button pops out before audio init", () => {
+      // Arming must survive the overflow filter — otherwise the cue is
+      // invisible whenever the user hides the button.
+      expect(toolbar).toMatch(/state\.status\s*===\s*"arming"/);
     });
   });
 });

--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -121,6 +121,13 @@ export interface ContentPanelProps extends BasePanelProps {
   // and the Moon icon in the header.
   isHibernated?: boolean;
 
+  // True when voice dictation is in its pre-audio arming window targeting
+  // this pane. Drives the panel-state-arming border cue (single load-bearing
+  // signal during the ~200ms before the mic opens and recording chrome takes
+  // over). Outranks waiting/working/hibernated because it is user-initiated
+  // and time-bounded.
+  isVoiceArming?: boolean;
+
   // Tab support
   tabs?: TabInfo[];
   groupId?: string;
@@ -184,6 +191,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
     isSelected = false,
     isFleetFollower = false,
     isHibernated = false,
+    isVoiceArming = false,
     tabs,
     groupId,
     onTabClick,
@@ -457,15 +465,17 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
             "rounded border shadow-[var(--theme-shadow-ambient)] transition-colors duration-300",
           location === "grid" &&
             !isMaximized &&
-            (showSelectedChrome && showGridAttention
-              ? "terminal-selected"
-              : showGridAttention && showGridAgentHighlights && blockedState === "waiting"
-                ? "panel-state-waiting"
-                : showGridAttention && showGridAgentHighlights && isWorkingState
-                  ? "panel-state-working"
-                  : showGridAttention && isHibernated
-                    ? "panel-state-hibernated"
-                    : "border-overlay hover:border-tint/[0.08]"),
+            (showGridAttention && isVoiceArming
+              ? "panel-state-arming"
+              : showSelectedChrome && showGridAttention
+                ? "terminal-selected"
+                : showGridAttention && showGridAgentHighlights && blockedState === "waiting"
+                  ? "panel-state-waiting"
+                  : showGridAttention && showGridAgentHighlights && isWorkingState
+                    ? "panel-state-working"
+                    : showGridAttention && isHibernated
+                      ? "panel-state-hibernated"
+                      : "border-overlay hover:border-tint/[0.08]"),
           location === "grid" && isMaximized && "border-0 rounded-none z-[var(--z-maximized)]",
           worktreeAccentColor && location === "grid" && !isMaximized && "panel-worktree-identity",
           // Voice-dictation lock border overrides ambient state colours so the

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -51,6 +51,7 @@ import {
   useTerminalInputStore,
 } from "@/store";
 import { useFleetArmingStore, isFleetArmEligible } from "@/store/fleetArmingStore";
+import { useVoiceRecordingStore } from "@/store/voiceRecordingStore";
 import { useTerminalLogic } from "@/hooks/useTerminalLogic";
 import { useIsHibernated } from "@/hooks/useIsHibernated";
 import { errorsClient } from "@/clients";
@@ -417,6 +418,12 @@ function TerminalPaneComponent({
   const isBackendRecovering = backendStatus === "recovering";
 
   const isHibernated = useIsHibernated(id);
+
+  // Pre-audio confirmation cue. Subscribes to both fields so a target swap
+  // mid-arming repaints the right pane on the next render.
+  const isVoiceArming = useVoiceRecordingStore(
+    (s) => s.status === "arming" && s.activeTarget?.panelId === id
+  );
 
   const hybridInputEnabled = useTerminalInputStore((state) => state.hybridInputEnabled);
   const preferredTerminalFocusTarget = usePanelStore((state) => state.preferredTerminalFocusTarget);
@@ -1135,6 +1142,7 @@ function TerminalPaneComponent({
       isSelected={isSelected}
       isFleetFollower={isFleetFollower}
       isHibernated={isHibernated}
+      isVoiceArming={isVoiceArming}
       tabs={tabs}
       onTabClick={onTabClick}
       onTabClose={onTabClose}

--- a/src/index.css
+++ b/src/index.css
@@ -1901,6 +1901,18 @@ body,
     0 0 0 1px color-mix(in oklab, var(--color-category-amber) 10%, transparent);
 }
 
+/* Arming state — pre-audio confirmation window (~200ms). User pressed the
+ * dictation hotkey; this border paints synchronously so the target panel is
+ * unambiguous before the mic goes hot. Uses the accent token because the
+ * arming panel is the single load-bearing focus signal in its region for the
+ * brief window before "connecting" → "recording" replaces it. */
+.panel-state-arming {
+  border-color: color-mix(in oklab, var(--theme-accent-primary) 70%, transparent);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in oklab, var(--theme-accent-primary) 18%, transparent),
+    0 0 0 1px color-mix(in oklab, var(--theme-accent-primary) 12%, transparent);
+}
+
 /* Per-worktree color identity — left-edge stripe on grid panels */
 .panel-worktree-identity {
   position: relative;
@@ -2647,7 +2659,8 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
     border-color: GrayText;
   }
 
-  .panel-voice-dictation-locked {
+  .panel-voice-dictation-locked,
+  .panel-state-arming {
     border-color: Highlight;
     outline: 2px solid Highlight;
     outline-offset: -2px;
@@ -2752,7 +2765,8 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
   .panel-state-waiting,
   .panel-state-working,
   .panel-state-hibernated,
-  .panel-voice-dictation-locked {
+  .panel-voice-dictation-locked,
+  .panel-state-arming {
     border-width: 2px;
   }
 

--- a/src/services/VoiceRecordingService.ts
+++ b/src/services/VoiceRecordingService.ts
@@ -299,7 +299,8 @@ class VoiceRecordingService {
 
     this.unsubscribers.push(
       usePanelStore.subscribe((state) => {
-        const activeTarget = useVoiceRecordingStore.getState().activeTarget;
+        const voiceState = useVoiceRecordingStore.getState();
+        const activeTarget = voiceState.activeTarget;
         if (!activeTarget) return;
 
         // If the recording target belongs to a different project than the
@@ -311,6 +312,13 @@ class VoiceRecordingService {
         const panel = found && found.location !== "trash" ? found : undefined;
 
         if (!panel) {
+          // No microphone has opened yet during arming — fall back to
+          // cancelArming() so we don't drive stop() through a non-existent
+          // session.
+          if (voiceState.status === "arming") {
+            this.cancelArming();
+            return;
+          }
           const panelId = activeTarget.panelId;
           void this.stop("Dictation stopped because its panel was closed.", {
             preserveLiveText: true,
@@ -325,6 +333,7 @@ class VoiceRecordingService {
       if (e.key !== "Escape") return;
       const state = useVoiceRecordingStore.getState();
       if (
+        state.status !== "arming" &&
         state.status !== "connecting" &&
         state.status !== "recording" &&
         state.status !== "paused" &&
@@ -333,6 +342,14 @@ class VoiceRecordingService {
         return;
       e.preventDefault();
       e.stopPropagation();
+      // Arming is the pre-audio confirmation window. No session has begun
+      // yet, so route abort through cancelArming() instead of stop() —
+      // stop() would log "no active session" warnings and skip the cleanup
+      // path that resets activeTarget back to null.
+      if (state.status === "arming") {
+        this.cancelArming();
+        return;
+      }
       this.pttActiveKeyCode = null;
       void this.stop("Dictation cancelled.", { preserveLiveText: true });
     };
@@ -436,6 +453,15 @@ class VoiceRecordingService {
       status: state.status,
     });
 
+    // A second press during the pre-audio arming window aborts back to idle.
+    // No microphone has been opened yet, so there is nothing for stop() to
+    // unwind — incrementing startRequestId via cancelArming() is enough to
+    // make the in-flight start() bail at its next staleness check.
+    if (isActiveTarget && state.status === "arming") {
+      this.cancelArming();
+      return;
+    }
+
     if (isActiveTarget && isActive) {
       await this.stop("Dictation stopped.", { preserveLiveText: true });
       return;
@@ -446,7 +472,22 @@ class VoiceRecordingService {
     // targets are a navigation aid, not a session log).
     useVoiceRecordingStore.getState().recordRecentTarget(target);
 
+    // Synchronous pre-audio cue. setArming() resolves under 1ms (Zustand set);
+    // the first await inside start() then carries us to "connecting" within
+    // ~50–200ms, by which point beginSession() has overwritten this state.
+    useVoiceRecordingStore.getState().setArming(target);
     await this.start(target);
+  }
+
+  /**
+   * Abort an in-flight arming window before audio init begins. Bumping
+   * startRequestId invalidates any pending start() so it bails at its next
+   * staleness check; finishSession() returns the store to idle without
+   * touching panel buffers (no transcript exists yet).
+   */
+  private cancelArming(): void {
+    this.startRequestId++;
+    useVoiceRecordingStore.getState().finishSession({ nextStatus: "idle" });
   }
 
   async start(target: VoiceRecordingTarget): Promise<void> {
@@ -585,7 +626,12 @@ class VoiceRecordingService {
       return;
     }
 
-    if (useVoiceRecordingStore.getState().activeTarget) {
+    // Only an actually-started session (connecting/recording/etc.) needs to be
+    // torn down here. The arming state seeds activeTarget synchronously before
+    // start() runs so the UI can paint the cue — treating that as an existing
+    // session would call stop() on a session that never opened a mic.
+    const preStartState = useVoiceRecordingStore.getState();
+    if (preStartState.activeTarget && isActiveVoiceSession(preStartState.status)) {
       logDebug(`${LOG_PREFIX} Stopping existing session before starting new one`);
       await this.stop(undefined, {
         preserveLiveText: true,

--- a/src/services/VoiceRecordingService.ts
+++ b/src/services/VoiceRecordingService.ts
@@ -490,6 +490,17 @@ class VoiceRecordingService {
     useVoiceRecordingStore.getState().finishSession({ nextStatus: "idle" });
   }
 
+  /**
+   * Roll the store off the "arming" status when a `start()` call has set
+   * an error and is about to return. Without this, the store would stay
+   * `{ status: "arming", activeTarget: T }` indefinitely — the toolbar and
+   * panel border would keep showing the pre-recording cue with no mic to
+   * back it up.
+   */
+  private failArming(): void {
+    useVoiceRecordingStore.getState().finishSession({ nextStatus: "error" });
+  }
+
   async start(target: VoiceRecordingTarget): Promise<void> {
     this.initialize();
     const startRequestId = ++this.startRequestId;
@@ -511,14 +522,31 @@ class VoiceRecordingService {
         useVoiceRecordingStore
           .getState()
           .announce("Voice dictation is not configured. Open Voice settings to continue.");
+        this.failArming();
       }
       return;
     }
 
     // Check and request OS-level microphone permission (macOS requires this
     // from the main process before getUserMedia will succeed in the renderer).
+    // The IPC call is wrapped so a rejection (main-process crash, channel
+    // teardown) doesn't leak past start() and leave the store armed forever.
     logDebug(`${LOG_PREFIX} Checking microphone permission`);
-    const micStatus = await window.electron.voiceInput.checkMicPermission();
+    let micStatus: Awaited<ReturnType<typeof window.electron.voiceInput.checkMicPermission>>;
+    try {
+      micStatus = await window.electron.voiceInput.checkMicPermission();
+    } catch (err) {
+      logError(`${LOG_PREFIX} checkMicPermission IPC rejected`, err);
+      if (!this.isStartRequestStale(startRequestId)) {
+        useVoiceRecordingStore.getState().setLastError({
+          severity: "fatal",
+          code: "mic_permission_check_failed",
+          message: "Could not check microphone permission. Try again.",
+        });
+        this.failArming();
+      }
+      return;
+    }
     if (this.isStartRequestStale(startRequestId)) {
       return;
     }
@@ -531,6 +559,7 @@ class VoiceRecordingService {
         .getState()
         .setLastError({ severity: "fatal", code: "mic_permission_denied", message });
       useVoiceRecordingStore.getState().announce(message);
+      this.failArming();
       safeFireAndForget(window.electron.voiceInput.openMicSettings(), {
         context: "Opening OS microphone settings",
       });
@@ -539,7 +568,21 @@ class VoiceRecordingService {
 
     if (micStatus === "not-determined") {
       logDebug(`${LOG_PREFIX} Requesting OS microphone permission`);
-      const granted = await window.electron.voiceInput.requestMicPermission();
+      let granted: boolean;
+      try {
+        granted = await window.electron.voiceInput.requestMicPermission();
+      } catch (err) {
+        logError(`${LOG_PREFIX} requestMicPermission IPC rejected`, err);
+        if (!this.isStartRequestStale(startRequestId)) {
+          useVoiceRecordingStore.getState().setLastError({
+            severity: "fatal",
+            code: "mic_permission_request_failed",
+            message: "Could not request microphone permission. Try again.",
+          });
+          this.failArming();
+        }
+        return;
+      }
       if (this.isStartRequestStale(startRequestId)) {
         return;
       }
@@ -550,6 +593,7 @@ class VoiceRecordingService {
           .getState()
           .setLastError({ severity: "fatal", code: "mic_permission_denied", message });
         useVoiceRecordingStore.getState().announce(message);
+        this.failArming();
         return;
       }
     }
@@ -571,12 +615,17 @@ class VoiceRecordingService {
         name: error instanceof DOMException ? error.name : "unknown",
         message,
       });
-      const micCode =
-        error instanceof DOMException && error.name === "NotAllowedError"
-          ? "mic_permission_denied"
-          : "mic_access_failed";
-      useVoiceRecordingStore.getState().setLastError({ severity: "fatal", code: micCode, message });
-      useVoiceRecordingStore.getState().announce(message);
+      if (!this.isStartRequestStale(startRequestId)) {
+        const micCode =
+          error instanceof DOMException && error.name === "NotAllowedError"
+            ? "mic_permission_denied"
+            : "mic_access_failed";
+        useVoiceRecordingStore
+          .getState()
+          .setLastError({ severity: "fatal", code: micCode, message });
+        useVoiceRecordingStore.getState().announce(message);
+        this.failArming();
+      }
       return;
     }
 
@@ -626,12 +675,13 @@ class VoiceRecordingService {
       return;
     }
 
-    // Only an actually-started session (connecting/recording/etc.) needs to be
-    // torn down here. The arming state seeds activeTarget synchronously before
-    // start() runs so the UI can paint the cue — treating that as an existing
-    // session would call stop() on a session that never opened a mic.
-    const preStartState = useVoiceRecordingStore.getState();
-    if (preStartState.activeTarget && isActiveVoiceSession(preStartState.status)) {
+    // Only an actually-started session (open mic stream) needs to be torn
+    // down here. `this.stream` is the canonical "audio is open" flag and is
+    // independent of store status — using store.activeTarget here would
+    // false-positive during the arming window (we seeded it ourselves) and
+    // status alone would miss a cross-panel switch where the new "arming"
+    // status has already overwritten the prior session's "recording".
+    if (this.stream) {
       logDebug(`${LOG_PREFIX} Stopping existing session before starting new one`);
       await this.stop(undefined, {
         preserveLiveText: true,

--- a/src/services/__tests__/VoiceRecordingService.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.test.ts
@@ -502,6 +502,67 @@ describe("VoiceRecordingService — arming state", () => {
     storeModule.__state.status = "idle";
   });
 
+  it("start() failure path clears arming so the store does not stay armed forever", async () => {
+    // Issue #9178 — every start() early-return after setArming() must roll
+    // the store off "arming", otherwise the toolbar/panel border keeps
+    // showing the pre-recording cue with no mic behind it. This test
+    // simulates the not-configured path.
+    const electronStub = buildElectronStub();
+    electronStub.voiceInput.getSettings.mockResolvedValue({
+      enabled: false,
+      openaiApiKey: "",
+      correctionEnabled: false,
+    });
+    setupGlobals(electronStub);
+
+    const storeModule = (await import("@/store/voiceRecordingStore")) as unknown as {
+      useVoiceRecordingStore: {
+        getState: () => {
+          finishSession: ReturnType<typeof vi.fn>;
+          setError: ReturnType<typeof vi.fn>;
+        };
+      };
+    };
+    const fns = storeModule.useVoiceRecordingStore.getState();
+    const finishSessionMock = fns.finishSession;
+    const setErrorMock = fns.setError;
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+
+    await voiceRecordingService.start({ panelId: "panel-1" });
+
+    expect(setErrorMock).toHaveBeenCalled();
+    // failArming() routes through finishSession with nextStatus:"error"
+    expect(finishSessionMock).toHaveBeenCalledWith({ nextStatus: "error" });
+  });
+
+  it("cross-panel switch while recording tears down the existing session", async () => {
+    // Regression guard. Before the fix, toggle() set arming on the new
+    // target which masked the existing recording status — start()'s
+    // teardown check skipped, leaving the old MediaStream open. The fix
+    // keys teardown on this.stream rather than store status.
+    setupGlobals();
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    const stopSpy = vi
+      .spyOn(voiceRecordingService, "stop")
+      .mockImplementation(async () => undefined);
+
+    // Simulate an open audio session by attaching a stream directly.
+    // We use `as unknown as` to reach a private field for test setup only.
+    const fakeStream = { getTracks: () => [{ stop: vi.fn() }] };
+    (voiceRecordingService as unknown as { stream: unknown }).stream = fakeStream;
+
+    await voiceRecordingService.start({ panelId: "panel-b" });
+
+    // start() must call stop() to tear down the prior session even though
+    // setArming() has by now overwritten store status from "recording" to
+    // "arming". Before the fix this assertion failed.
+    expect(stopSpy).toHaveBeenCalled();
+
+    (voiceRecordingService as unknown as { stream: unknown }).stream = null;
+  });
+
   it("Escape during arming routes through finishSession instead of stop()", async () => {
     const { windowListeners } = setupGlobals();
 

--- a/src/services/__tests__/VoiceRecordingService.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.test.ts
@@ -20,6 +20,7 @@ vi.mock("@/store/voiceRecordingStore", () => {
     setStatus: vi.fn(),
     setConfigured: vi.fn(),
     setCorrectionEnabled: vi.fn(),
+    setArming: vi.fn(),
     beginSession: vi.fn(),
     finishSession: vi.fn(),
     setAudioLevel: vi.fn(),
@@ -426,6 +427,114 @@ describe("isActiveVoiceSession helper", () => {
   it("returns false for terminal phases", () => {
     expect(isActiveVoiceSession("idle")).toBe(false);
     expect(isActiveVoiceSession("error")).toBe(false);
+  });
+
+  it("returns false for arming — it is pre-audio, not an active session", () => {
+    // Arming must be excluded so the toggle guard treats a second hotkey
+    // press during arming as continuing the start, not stopping a session
+    // that hasn't begun.
+    expect(isActiveVoiceSession("arming")).toBe(false);
+  });
+});
+
+describe("VoiceRecordingService — arming state", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    suspendCallbacks.length = 0;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("toggle() calls setArming() with the target before invoking start()", async () => {
+    setupGlobals();
+
+    const storeModule = (await import("@/store/voiceRecordingStore")) as unknown as {
+      useVoiceRecordingStore: {
+        getState: () => { setArming: ReturnType<typeof vi.fn> };
+      };
+    };
+    const setArmingMock = storeModule.useVoiceRecordingStore.getState().setArming;
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    const startSpy = vi
+      .spyOn(voiceRecordingService, "start")
+      .mockImplementation(async () => undefined);
+
+    const target = { panelId: "panel-1", panelTitle: "Terminal" };
+    await voiceRecordingService.toggle(target);
+
+    expect(setArmingMock).toHaveBeenCalledWith(target);
+    expect(startSpy).toHaveBeenCalledWith(target);
+    // Ordering: setArming must run before start() so the synchronous cue
+    // paints before any await yields control.
+    expect(setArmingMock.mock.invocationCallOrder[0]).toBeLessThan(
+      startSpy.mock.invocationCallOrder[0]!
+    );
+  });
+
+  it("toggle() during arming on the same target aborts via finishSession (no stop())", async () => {
+    setupGlobals();
+
+    const storeModule = (await import("@/store/voiceRecordingStore")) as unknown as {
+      useVoiceRecordingStore: {
+        getState: () => { finishSession: ReturnType<typeof vi.fn> };
+      };
+      __state: { activeTarget: { panelId: string } | null; status: string };
+    };
+    storeModule.__state.activeTarget = { panelId: "panel-1" };
+    storeModule.__state.status = "arming";
+    const finishSessionMock = storeModule.useVoiceRecordingStore.getState().finishSession;
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    const stopSpy = vi.spyOn(voiceRecordingService, "stop");
+    const startSpy = vi.spyOn(voiceRecordingService, "start");
+
+    await voiceRecordingService.toggle({ panelId: "panel-1" });
+
+    expect(finishSessionMock).toHaveBeenCalledWith({ nextStatus: "idle" });
+    expect(stopSpy).not.toHaveBeenCalled();
+    expect(startSpy).not.toHaveBeenCalled();
+
+    storeModule.__state.activeTarget = null;
+    storeModule.__state.status = "idle";
+  });
+
+  it("Escape during arming routes through finishSession instead of stop()", async () => {
+    const { windowListeners } = setupGlobals();
+
+    const storeModule = (await import("@/store/voiceRecordingStore")) as unknown as {
+      useVoiceRecordingStore: {
+        getState: () => { finishSession: ReturnType<typeof vi.fn> };
+      };
+      __state: { activeTarget: { panelId: string } | null; status: string };
+    };
+    storeModule.__state.activeTarget = { panelId: "panel-1" };
+    storeModule.__state.status = "arming";
+    const finishSessionMock = storeModule.useVoiceRecordingStore.getState().finishSession;
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    const stopSpy = vi.spyOn(voiceRecordingService, "stop");
+
+    voiceRecordingService.initialize();
+
+    const escapeEvent = {
+      key: "Escape",
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    };
+    const keydownListeners = windowListeners["keydown"] ?? [];
+    for (const listener of keydownListeners) {
+      listener(escapeEvent);
+    }
+
+    expect(finishSessionMock).toHaveBeenCalledWith({ nextStatus: "idle" });
+    expect(stopSpy).not.toHaveBeenCalled();
+
+    storeModule.__state.activeTarget = null;
+    storeModule.__state.status = "idle";
   });
 });
 

--- a/src/store/__tests__/voiceRecordingStore.test.ts
+++ b/src/store/__tests__/voiceRecordingStore.test.ts
@@ -20,6 +20,49 @@ function reset() {
   });
 }
 
+describe("voiceRecordingStore — setArming", () => {
+  beforeEach(reset);
+
+  it("atomically sets status='arming' and activeTarget in a single update", () => {
+    let intermediateStatus: string | null = null;
+    let intermediateTarget: typeof TARGET | null | undefined = undefined;
+    const unsub = useVoiceRecordingStore.subscribe((state) => {
+      // The first subscriber notification reads the new state. If status and
+      // activeTarget were written separately, one snapshot would observe
+      // status=arming with activeTarget=null (or vice versa).
+      if (intermediateStatus === null) {
+        intermediateStatus = state.status;
+        intermediateTarget = state.activeTarget;
+      }
+    });
+    try {
+      useVoiceRecordingStore.getState().setArming(TARGET);
+    } finally {
+      unsub();
+    }
+
+    expect(intermediateStatus).toBe("arming");
+    expect(intermediateTarget).toEqual(TARGET);
+    const final = useVoiceRecordingStore.getState();
+    expect(final.status).toBe("arming");
+    expect(final.activeTarget).toEqual(TARGET);
+  });
+
+  it("clears any prior errorMessage so a fresh arming flow doesn't show stale text", () => {
+    useVoiceRecordingStore.setState({ errorMessage: "Previous failure" });
+    useVoiceRecordingStore.getState().setArming(TARGET);
+    expect(useVoiceRecordingStore.getState().errorMessage).toBeNull();
+  });
+
+  it("transitions cleanly to connecting when beginSession runs after arming", () => {
+    useVoiceRecordingStore.getState().setArming(TARGET);
+    useVoiceRecordingStore.getState().beginSession(TARGET);
+    const state = useVoiceRecordingStore.getState();
+    expect(state.status).toBe("connecting");
+    expect(state.activeTarget).toEqual(TARGET);
+  });
+});
+
 describe("voiceRecordingStore — clearPanelBuffer", () => {
   beforeEach(reset);
 

--- a/src/store/voiceRecordingStore.ts
+++ b/src/store/voiceRecordingStore.ts
@@ -89,6 +89,7 @@ interface VoiceRecordingState {
   setConfigured: (isConfigured: boolean) => void;
   setCorrectionEnabled: (enabled: boolean) => void;
   setAudioLevel: (level: number) => void;
+  setArming: (target: VoiceRecordingTarget) => void;
   beginSession: (target: VoiceRecordingTarget) => void;
   setStatus: (status: VoiceInputStatus) => void;
   setLastError: (error: VoiceInputError | null) => void;
@@ -152,6 +153,16 @@ export const useVoiceRecordingStore = create<VoiceRecordingState>()(
       setLastError: (error) => set({ lastError: error }),
 
       setAudioLevel: (audioLevel) => set({ audioLevel }),
+
+      // Atomic single-set transition into the pre-audio confirmation phase.
+      // Fires synchronously before any await in start() so the target panel
+      // and toolbar can paint the arming cue before microphone init begins.
+      setArming: (target) =>
+        set({
+          activeTarget: target,
+          status: "arming",
+          lastError: null,
+        }),
 
       beginSession: (target) =>
         set((state) => ({


### PR DESCRIPTION
## Summary

- Adds an `arming` status to `VoiceInputStatus` so the store and UI have a distinct pre-recording phase before the mic goes hot
- `VoiceRecordingService` resolves and holds the target panel synchronously on activation, so the user sees exactly where the transcription will land while audio initializes in the background
- `ContentPanel` gains an arming border variant; `VoiceRecordingToolbarButton` shows the target panel label during arming — arming clears on start failure, cross-panel switch, and double-press

Resolves #9178

## Changes

- `shared/types/voice.ts` — adds `"arming"` to `VoiceInputStatus`
- `src/store/voiceRecordingStore.ts` — adds `setArming` action and `isActiveVoiceSession` guard (arming is not an active session)
- `src/services/VoiceRecordingService.ts` — resolves target panel synchronously before mic init; clears arming on `start()` failure and teardown
- `src/components/Panel/ContentPanel.tsx` — new `panel-state-arming` border variant wired to the arming status
- `src/components/Terminal/TerminalPane.tsx` — passes panel identity for arming detection
- `src/components/Layout/VoiceRecordingToolbarButton.tsx` + `Toolbar.tsx` — shows target label in toolbar button during arming
- `src/index.css` — `panel-state-arming` CSS class

The hold-to-speak gesture is tracked separately in #9189.

## Testing

66 unit tests covering: `setArming` atomicity, `isActiveVoiceSession(arming) === false`, toggle ordering, same-target double-press abort, Escape during arming, `start()` failure clears arming, cross-panel switch teardown, and toolbar UI assertions.