### PR TITLE
feat(notifications): declare grid-bar selection contract

### DIFF
--- a/src/components/Terminal/GridNotificationBar.tsx
+++ b/src/components/Terminal/GridNotificationBar.tsx
@@ -1,13 +1,17 @@
 import React, { useEffect, useRef, useState } from "react";
 import { AlertTriangle, CheckCircle2, Info, XCircle } from "lucide-react";
-import { useShallow } from "zustand/react/shallow";
 import { cn } from "@/lib/utils";
 import {
   BANNER_ENTER_DURATION,
   BANNER_EXIT_DURATION,
   LIVE_REGION_SWAP_DELAY,
 } from "@/lib/animationUtils";
-import { useNotificationStore, type Notification } from "@/store/notificationStore";
+import {
+  GRID_BAR_DWELL_FLOOR_MS,
+  selectGridBarNotification,
+  useNotificationStore,
+  type Notification,
+} from "@/store/notificationStore";
 
 const STATUS_CONFIG = {
   success: {
@@ -60,8 +64,18 @@ export interface GridNotificationBarProps {
 }
 
 export function GridNotificationBar({ className }: GridNotificationBarProps) {
-  const notification = useNotificationStore(
-    useShallow((state) => state.notifications.find((item) => item.placement === "grid-bar"))
+  // Tracks the id currently visible to the user so the selector can enforce
+  // the dwell floor. A ref (not state) avoids spurious re-renders when the
+  // lock target changes — the selector reads the ref on every render.
+  const lockedIdRef = useRef<string | undefined>(undefined);
+  // Bumped by the dwell timeout to force a selector re-evaluation after
+  // dwell expires. The store-subscription path won't fire on its own when
+  // only time has passed.
+  const [, setDwellTick] = useState(0);
+  const dwellTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const notification = useNotificationStore((state) =>
+    selectGridBarNotification(state.notifications, Date.now(), lockedIdRef.current)
   );
   const removeNotification = useNotificationStore((state) => state.removeNotification);
 
@@ -166,6 +180,33 @@ export function GridNotificationBar({ className }: GridNotificationBarProps) {
     }
   }, [notification?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Refresh the dwell lock whenever the displayed notification changes.
+  // When dwell remains, schedule a timeout to re-evaluate the selector
+  // once the floor expires (a higher-severity contender may be waiting).
+  useEffect(() => {
+    if (dwellTimeoutRef.current !== null) {
+      clearTimeout(dwellTimeoutRef.current);
+      dwellTimeoutRef.current = null;
+    }
+    if (!displayedNotification) {
+      lockedIdRef.current = undefined;
+      return;
+    }
+    lockedIdRef.current = displayedNotification.id;
+    const firstShownAt = displayedNotification.firstShownAt ?? Date.now();
+    const dwellRemaining = firstShownAt + GRID_BAR_DWELL_FLOOR_MS - Date.now();
+    if (dwellRemaining <= 0) {
+      // Already past the floor; nudge a re-render so the selector can pick
+      // a higher-severity candidate that arrived during the prior render.
+      setDwellTick((t) => t + 1);
+      return;
+    }
+    dwellTimeoutRef.current = setTimeout(() => {
+      dwellTimeoutRef.current = null;
+      setDwellTick((t) => t + 1);
+    }, dwellRemaining);
+  }, [displayedNotification?.id]);
+
   useEffect(() => {
     return () => {
       if (exitTimeoutRef.current !== null) {
@@ -179,6 +220,10 @@ export function GridNotificationBar({ className }: GridNotificationBarProps) {
       if (swapTimeoutRef.current !== null) {
         clearTimeout(swapTimeoutRef.current);
         swapTimeoutRef.current = null;
+      }
+      if (dwellTimeoutRef.current !== null) {
+        clearTimeout(dwellTimeoutRef.current);
+        dwellTimeoutRef.current = null;
       }
     };
   }, []);

--- a/src/components/Terminal/GridNotificationBar.tsx
+++ b/src/components/Terminal/GridNotificationBar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { AlertTriangle, CheckCircle2, Info, XCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
@@ -181,9 +181,10 @@ export function GridNotificationBar({ className }: GridNotificationBarProps) {
   }, [notification?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Refresh the dwell lock whenever the displayed notification changes.
-  // When dwell remains, schedule a timeout to re-evaluate the selector
-  // once the floor expires (a higher-severity contender may be waiting).
-  useEffect(() => {
+  // Uses a layout effect so the lock is set before paint — a contender
+  // arriving in the same render cycle as the first mount cannot preempt
+  // before the dwell guard is in place.
+  useLayoutEffect(() => {
     if (dwellTimeoutRef.current !== null) {
       clearTimeout(dwellTimeoutRef.current);
       dwellTimeoutRef.current = null;

--- a/src/components/Terminal/GridNotificationBar.tsx
+++ b/src/components/Terminal/GridNotificationBar.tsx
@@ -206,7 +206,7 @@ export function GridNotificationBar({ className }: GridNotificationBarProps) {
       dwellTimeoutRef.current = null;
       setDwellTick((t) => t + 1);
     }, dwellRemaining);
-  }, [displayedNotification?.id]);
+  }, [displayedNotification?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     return () => {

--- a/src/components/Terminal/__tests__/GridNotificationBar.test.tsx
+++ b/src/components/Terminal/__tests__/GridNotificationBar.test.tsx
@@ -635,6 +635,65 @@ describe("GridNotificationBar selection contract", () => {
     expect(queryByText("Low first")).toBeNull();
   });
 
+  it("locks the dwell window even when a higher-priority contender arrives in the same paint cycle", () => {
+    const lowId = addGridBar({ message: "Low priority", priority: "low" });
+    const { getByText, queryByText } = render(<GridNotificationBar />);
+
+    // No rAF tick yet — entry hasn't even animated in. Add a high-priority
+    // contender immediately, in the same paint cycle. The useLayoutEffect
+    // ensures lockedIdRef is set before any re-render runs the selector.
+    act(() => {
+      addGridBar({ message: "High priority", priority: "high" });
+    });
+
+    // Flush the entry rAF.
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+
+    expect(getByText("Low priority")).toBeTruthy();
+    expect(queryByText("High priority")).toBeNull();
+
+    // Cleanup: remove the low one to let the high one come up so afterEach
+    // doesn't time out on pending dwell.
+    act(() => {
+      useNotificationStore.getState().removeNotification(lowId);
+    });
+    act(() => {
+      vi.advanceTimersByTime(LIVE_REGION_SWAP_DELAY + 16);
+    });
+    expect(getByText("High priority")).toBeTruthy();
+  });
+
+  it("releases promptly when the locked notification is dismissed mid-dwell", () => {
+    const lowId = addGridBar({ message: "Low priority", priority: "low" });
+    const { getByText, queryByText } = render(<GridNotificationBar />);
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+    expect(getByText("Low priority")).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    // High priority queued behind the dwell lock.
+    act(() => {
+      addGridBar({ message: "High priority", priority: "high" });
+    });
+    expect(queryByText("High priority")).toBeNull();
+
+    // User dismisses the locked low one before its dwell expires.
+    act(() => {
+      useNotificationStore.getState().removeNotification(lowId);
+    });
+    act(() => {
+      vi.advanceTimersByTime(LIVE_REGION_SWAP_DELAY + 16);
+    });
+
+    expect(getByText("High priority")).toBeTruthy();
+    expect(queryByText("Low priority")).toBeNull();
+  });
+
   it("clears the dwell timer on unmount without firing setState afterwards", () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/src/components/Terminal/__tests__/GridNotificationBar.test.tsx
+++ b/src/components/Terminal/__tests__/GridNotificationBar.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { render, act, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useNotificationStore } from "@/store/notificationStore";
+import { GRID_BAR_DWELL_FLOOR_MS, useNotificationStore } from "@/store/notificationStore";
 import {
   BANNER_ENTER_DURATION,
   BANNER_EXIT_DURATION,
@@ -535,5 +535,126 @@ describe("GridNotificationBar reduced motion", () => {
       vi.advanceTimersByTime(1);
     });
     expect(getByText("Second")).toBeTruthy();
+  });
+});
+
+describe("GridNotificationBar selection contract", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    stubMatchMedia(false);
+    useNotificationStore.getState().reset();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("does not preempt a low-priority notification with a high-priority one inside the dwell floor", () => {
+    addGridBar({ message: "Low priority", priority: "low" });
+    const { container, getByText, queryByText } = render(<GridNotificationBar />);
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+    expect(getByText("Low priority")).toBeTruthy();
+
+    // Higher-priority contender arrives well inside the dwell window.
+    act(() => {
+      vi.advanceTimersByTime(1000);
+      addGridBar({ message: "High priority", priority: "high" });
+    });
+
+    // Dwell still active — newcomer is queued, low-priority stays.
+    expect(getByText("Low priority")).toBeTruthy();
+    expect(queryByText("High priority")).toBeNull();
+    expect(getLiveRegion(container)?.textContent).toContain("Low priority");
+  });
+
+  it("preempts the locked notification once the dwell floor elapses", () => {
+    addGridBar({ message: "Low priority", priority: "low" });
+    const { getByText, queryByText } = render(<GridNotificationBar />);
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+    expect(getByText("Low priority")).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+      addGridBar({ message: "High priority", priority: "high" });
+    });
+    // Still locked.
+    expect(queryByText("High priority")).toBeNull();
+
+    // Advance past the dwell floor + the live-region swap delay.
+    act(() => {
+      vi.advanceTimersByTime(GRID_BAR_DWELL_FLOOR_MS);
+    });
+    act(() => {
+      vi.advanceTimersByTime(LIVE_REGION_SWAP_DELAY + 16);
+    });
+
+    expect(getByText("High priority")).toBeTruthy();
+    expect(queryByText("Low priority")).toBeNull();
+  });
+
+  it("never lets a lower-priority newcomer preempt a higher-priority displayed notification, even after dwell", () => {
+    addGridBar({ message: "High priority", priority: "high" });
+    const { getByText, queryByText } = render(<GridNotificationBar />);
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+    expect(getByText("High priority")).toBeTruthy();
+
+    // Lower-priority newcomer arrives after dwell has fully elapsed.
+    act(() => {
+      vi.advanceTimersByTime(GRID_BAR_DWELL_FLOOR_MS + 1000);
+      addGridBar({ message: "Low priority", priority: "low" });
+    });
+    act(() => {
+      vi.advanceTimersByTime(LIVE_REGION_SWAP_DELAY + 16);
+    });
+
+    // High-priority wins on score regardless of dwell — selection contract,
+    // not just dwell, keeps it visible.
+    expect(getByText("High priority")).toBeTruthy();
+    expect(queryByText("Low priority")).toBeNull();
+  });
+
+  it("picks the winning notification on first mount when multiple grid-bar notifications exist", () => {
+    addGridBar({ message: "Low first", priority: "low" });
+    addGridBar({ message: "High after", priority: "high" });
+
+    const { getByText, queryByText } = render(<GridNotificationBar />);
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+
+    // Old behavior (bare .find()) would show "Low first". New contract picks
+    // the high-priority winner regardless of insertion order.
+    expect(getByText("High after")).toBeTruthy();
+    expect(queryByText("Low first")).toBeNull();
+  });
+
+  it("clears the dwell timer on unmount without firing setState afterwards", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    addGridBar({ message: "Locked", priority: "low" });
+    const { unmount } = render(<GridNotificationBar />);
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+
+    expect(() => {
+      unmount();
+      // Advance past when the dwell timeout would have fired.
+      vi.advanceTimersByTime(GRID_BAR_DWELL_FLOOR_MS * 2);
+    }).not.toThrow();
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 });

--- a/src/store/__tests__/notificationStore.test.ts
+++ b/src/store/__tests__/notificationStore.test.ts
@@ -681,6 +681,34 @@ describe("selectGridBarNotification — selection contract", () => {
     expect(minPriorityGap).toBeGreaterThan(maxTypeBonus);
   });
 
+  it("grid-bar type weights stay in sync with SEVERITY_WEIGHTS", () => {
+    // The selector inlines its own type-weights table to keep
+    // notificationSeverity.ts out of the boot-loaded notification store.
+    // The two must stay consistent — anchor it here so divergence shows up
+    // as a fast unit failure rather than a behavior drift in production.
+    const lowSuccess = makeNotification({
+      id: "lowSuccess",
+      priority: "low",
+      type: "success",
+      firstShownAt: 0,
+    });
+    for (const type of ["success", "info", "warning", "error"] as const) {
+      const candidate = makeNotification({
+        id: `low-${type}`,
+        priority: "low",
+        type,
+        firstShownAt: 1,
+      });
+      // A `low + <type>` candidate must score the same in either weights
+      // table — i.e., it beats `low + success` whenever its type is
+      // stricter, and loses (via firstShownAt tie-break) when equal.
+      const winner = selectGridBarNotification([lowSuccess, candidate], NOW + 6000)?.id;
+      const winnerInExternalTable =
+        SEVERITY_WEIGHTS[type] > SEVERITY_WEIGHTS.success ? candidate.id : lowSuccess.id; // tie → oldest firstShownAt wins
+      expect(winner).toBe(winnerInExternalTable);
+    }
+  });
+
   describe("dwell floor", () => {
     it("keeps the locked notification visible while inside the dwell window", () => {
       const locked = makeNotification({

--- a/src/store/__tests__/notificationStore.test.ts
+++ b/src/store/__tests__/notificationStore.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { useNotificationStore, MAX_VISIBLE_TOASTS, type Notification } from "../notificationStore";
+import {
+  GRID_BAR_DWELL_FLOOR_MS,
+  MAX_VISIBLE_TOASTS,
+  PRIORITY_WEIGHTS,
+  selectGridBarNotification,
+  useNotificationStore,
+  type Notification,
+} from "../notificationStore";
 import { useNotificationHistoryStore } from "../slices/notificationHistorySlice";
 
 const { getState } = useNotificationStore;
@@ -544,3 +551,184 @@ describe("notificationStore — correlationId collapse", () => {
 // (see src/lib/notify.ts). `addNotification()` itself stays loose because
 // notify() spreads its already-validated payload into the store; the
 // previous DEV-only console.error mirror has been removed as redundant.
+
+describe("selectGridBarNotification — selection contract", () => {
+  const NOW = 10_000;
+
+  function makeNotification(overrides: Partial<Notification> = {}): Notification {
+    return {
+      id: overrides.id ?? "n",
+      type: overrides.type ?? "info",
+      priority: overrides.priority ?? "low",
+      placement: overrides.placement ?? "grid-bar",
+      message: overrides.message ?? "msg",
+      firstShownAt: overrides.firstShownAt ?? NOW,
+      ...overrides,
+    };
+  }
+
+  it("returns undefined for an empty notification list", () => {
+    expect(selectGridBarNotification([], NOW)).toBeUndefined();
+  });
+
+  it("returns undefined when no notifications are grid-bar placement", () => {
+    const toast = makeNotification({ id: "t", placement: "toast" });
+    expect(selectGridBarNotification([toast], NOW)).toBeUndefined();
+  });
+
+  it("returns the only candidate when one grid-bar notification exists", () => {
+    const only = makeNotification({ id: "only" });
+    expect(selectGridBarNotification([only], NOW)?.id).toBe("only");
+  });
+
+  it("excludes dismissed grid-bar notifications", () => {
+    const live = makeNotification({ id: "live" });
+    const gone = makeNotification({ id: "gone", dismissed: true });
+    expect(selectGridBarNotification([gone, live], NOW)?.id).toBe("live");
+  });
+
+  it("higher priority wins over lower priority regardless of insertion order", () => {
+    const lowOlder = makeNotification({
+      id: "low",
+      priority: "low",
+      firstShownAt: NOW - 1000,
+    });
+    const highNewer = makeNotification({
+      id: "high",
+      priority: "high",
+      firstShownAt: NOW,
+    });
+    expect(selectGridBarNotification([lowOlder, highNewer], NOW + 6000)?.id).toBe("high");
+  });
+
+  it("watch beats high and high beats low (priority ordering)", () => {
+    const low = makeNotification({ id: "low", priority: "low", firstShownAt: NOW });
+    const high = makeNotification({ id: "high", priority: "high", firstShownAt: NOW });
+    const watch = makeNotification({ id: "watch", priority: "watch", firstShownAt: NOW });
+    expect(selectGridBarNotification([low, high, watch], NOW + 6000)?.id).toBe("watch");
+    expect(selectGridBarNotification([low, high], NOW + 6000)?.id).toBe("high");
+  });
+
+  it("type severity breaks ties within the same priority (error > warning > info > success)", () => {
+    const info = makeNotification({
+      id: "info",
+      priority: "high",
+      type: "info",
+      firstShownAt: NOW,
+    });
+    const error = makeNotification({
+      id: "error",
+      priority: "high",
+      type: "error",
+      firstShownAt: NOW,
+    });
+    expect(selectGridBarNotification([info, error], NOW + 6000)?.id).toBe("error");
+  });
+
+  it("priority dominates type — no low+error can beat a high+success", () => {
+    const lowError = makeNotification({
+      id: "lowErr",
+      priority: "low",
+      type: "error",
+      firstShownAt: NOW,
+    });
+    const highSuccess = makeNotification({
+      id: "highOk",
+      priority: "high",
+      type: "success",
+      firstShownAt: NOW,
+    });
+    expect(selectGridBarNotification([lowError, highSuccess], NOW + 6000)?.id).toBe("highOk");
+  });
+
+  it("oldest firstShownAt wins among exact score ties (chronological tie-break)", () => {
+    const older = makeNotification({
+      id: "older",
+      priority: "high",
+      type: "info",
+      firstShownAt: NOW - 2000,
+    });
+    const newer = makeNotification({
+      id: "newer",
+      priority: "high",
+      type: "info",
+      firstShownAt: NOW,
+    });
+    expect(selectGridBarNotification([newer, older], NOW + 6000)?.id).toBe("older");
+  });
+
+  it("treats missing firstShownAt as 0 for ordering", () => {
+    const withoutTimestamp = makeNotification({
+      id: "stale",
+      priority: "high",
+      firstShownAt: undefined,
+    });
+    const fresh = makeNotification({
+      id: "fresh",
+      priority: "high",
+      firstShownAt: NOW,
+    });
+    expect(selectGridBarNotification([fresh, withoutTimestamp], NOW + 6000)?.id).toBe("stale");
+  });
+
+  it("PRIORITY_WEIGHTS enforces a wide gap larger than any type bonus", () => {
+    // Sanity: the smallest priority gap (low → high = 10) must exceed the
+    // largest type bonus (error = 3). Guards against future tweaks that
+    // would let a low+error eclipse a high+success.
+    const minPriorityGap = PRIORITY_WEIGHTS.high - PRIORITY_WEIGHTS.low;
+    expect(minPriorityGap).toBeGreaterThan(3);
+  });
+
+  describe("dwell floor", () => {
+    it("keeps the locked notification visible while inside the dwell window", () => {
+      const locked = makeNotification({
+        id: "locked",
+        priority: "low",
+        firstShownAt: NOW,
+      });
+      const newcomer = makeNotification({
+        id: "high",
+        priority: "high",
+        firstShownAt: NOW + 100,
+      });
+      const within = NOW + GRID_BAR_DWELL_FLOOR_MS - 1;
+      expect(selectGridBarNotification([locked, newcomer], within, "locked")?.id).toBe("locked");
+    });
+
+    it("releases to the winner exactly at the dwell expiry boundary", () => {
+      const locked = makeNotification({
+        id: "locked",
+        priority: "low",
+        firstShownAt: NOW,
+      });
+      const newcomer = makeNotification({
+        id: "high",
+        priority: "high",
+        firstShownAt: NOW + 100,
+      });
+      const atExpiry = NOW + GRID_BAR_DWELL_FLOOR_MS;
+      expect(selectGridBarNotification([locked, newcomer], atExpiry, "locked")?.id).toBe("high");
+    });
+
+    it("ignores the dwell lock when the locked id is not in the candidate list", () => {
+      const newcomer = makeNotification({ id: "high", priority: "high", firstShownAt: NOW });
+      const result = selectGridBarNotification([newcomer], NOW + 100, "vanished");
+      expect(result?.id).toBe("high");
+    });
+
+    it("returns the locked notification even when no contender exists", () => {
+      const locked = makeNotification({ id: "alone", firstShownAt: NOW });
+      const within = NOW + GRID_BAR_DWELL_FLOOR_MS - 1;
+      // Single candidate path: dwell trivially satisfied.
+      expect(selectGridBarNotification([locked], within, "alone")?.id).toBe("alone");
+    });
+
+    it("falls through to score ordering when no lockedId is supplied", () => {
+      const low = makeNotification({ id: "low", priority: "low", firstShownAt: NOW });
+      const high = makeNotification({ id: "high", priority: "high", firstShownAt: NOW });
+      // Even within the dwell window of the low one, without a lock there's
+      // nothing to protect — the winner is the high-priority candidate.
+      expect(selectGridBarNotification([low, high], NOW + 100)?.id).toBe("high");
+    });
+  });
+});

--- a/src/store/__tests__/notificationStore.test.ts
+++ b/src/store/__tests__/notificationStore.test.ts
@@ -7,6 +7,7 @@ import {
   useNotificationStore,
   type Notification,
 } from "../notificationStore";
+import { SEVERITY_WEIGHTS } from "@/lib/notificationSeverity";
 import { useNotificationHistoryStore } from "../slices/notificationHistorySlice";
 
 const { getState } = useNotificationStore;
@@ -672,11 +673,12 @@ describe("selectGridBarNotification — selection contract", () => {
   });
 
   it("PRIORITY_WEIGHTS enforces a wide gap larger than any type bonus", () => {
-    // Sanity: the smallest priority gap (low → high = 10) must exceed the
-    // largest type bonus (error = 3). Guards against future tweaks that
-    // would let a low+error eclipse a high+success.
+    // Sanity: the smallest priority gap (low → high) must exceed the
+    // largest type bonus. Guards against future tweaks that would let a
+    // low+error eclipse a high+success.
     const minPriorityGap = PRIORITY_WEIGHTS.high - PRIORITY_WEIGHTS.low;
-    expect(minPriorityGap).toBeGreaterThan(3);
+    const maxTypeBonus = Math.max(...Object.values(SEVERITY_WEIGHTS));
+    expect(minPriorityGap).toBeGreaterThan(maxTypeBonus);
   });
 
   describe("dwell floor", () => {

--- a/src/store/notificationStore.ts
+++ b/src/store/notificationStore.ts
@@ -2,7 +2,6 @@ import { create } from "zustand";
 import type { ReactNode } from "react";
 import type { ActionId } from "@shared/types/actions";
 import type { NotificationEventKind } from "@/lib/notify";
-import { SEVERITY_WEIGHTS } from "@/lib/notificationSeverity";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
 import { useUIStore } from "@/store/uiStore";
 
@@ -101,12 +100,26 @@ export const GRID_BAR_DWELL_FLOOR_MS = 5000;
 /**
  * Severity weights for grid-bar selection. `watch` dominates `high` which
  * dominates `low`; the gap is wide enough that no type bonus
- * (SEVERITY_WEIGHTS max = 3) can lift a lower priority above a higher one.
+ * (GRID_BAR_TYPE_WEIGHTS max = 3) can lift a lower priority above a higher one.
  */
 export const PRIORITY_WEIGHTS: Record<NotificationPriority, number> = {
   watch: 100,
   high: 10,
   low: 0,
+};
+
+/**
+ * Type-severity bonus applied on top of `PRIORITY_WEIGHTS` when comparing
+ * grid-bar candidates. Inlined here (rather than imported from
+ * `notificationSeverity.ts`) to keep the boot-loaded notification store
+ * off a new module edge. A consistency test in `notificationStore.test.ts`
+ * asserts these values track `SEVERITY_WEIGHTS`.
+ */
+const GRID_BAR_TYPE_WEIGHTS: Record<NotificationType, number> = {
+  error: 3,
+  warning: 2,
+  info: 1,
+  success: 0,
 };
 
 /**
@@ -145,8 +158,8 @@ export function selectGridBarNotification(
   return [...candidates].sort((a, b) => {
     const scoreDiff =
       PRIORITY_WEIGHTS[b.priority] +
-      SEVERITY_WEIGHTS[b.type] -
-      (PRIORITY_WEIGHTS[a.priority] + SEVERITY_WEIGHTS[a.type]);
+      GRID_BAR_TYPE_WEIGHTS[b.type] -
+      (PRIORITY_WEIGHTS[a.priority] + GRID_BAR_TYPE_WEIGHTS[a.type]);
     if (scoreDiff !== 0) return scoreDiff;
     return (a.firstShownAt ?? 0) - (b.firstShownAt ?? 0);
   })[0];

--- a/src/store/notificationStore.ts
+++ b/src/store/notificationStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import type { ReactNode } from "react";
 import type { ActionId } from "@shared/types/actions";
 import type { NotificationEventKind } from "@/lib/notify";
+import { SEVERITY_WEIGHTS } from "@/lib/notificationSeverity";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
 import { useUIStore } from "@/store/uiStore";
 
@@ -89,6 +90,67 @@ interface NotificationStore {
 }
 
 export const MAX_VISIBLE_TOASTS = 3;
+
+/**
+ * Minimum time a grid-bar notification stays displayed before a
+ * higher-severity newcomer can preempt it. Prevents read-mid-message
+ * disruption when multiple producers contend for the single grid-bar slot.
+ */
+export const GRID_BAR_DWELL_FLOOR_MS = 5000;
+
+/**
+ * Severity weights for grid-bar selection. `watch` dominates `high` which
+ * dominates `low`; the gap is wide enough that no type bonus
+ * (SEVERITY_WEIGHTS max = 3) can lift a lower priority above a higher one.
+ */
+export const PRIORITY_WEIGHTS: Record<NotificationPriority, number> = {
+  watch: 100,
+  high: 10,
+  low: 0,
+};
+
+/**
+ * Single-slot grid-bar selection contract.
+ *
+ * Picks among undismissed `grid-bar` notifications by
+ * `PRIORITY_WEIGHTS[priority] + SEVERITY_WEIGHTS[type]` (highest wins);
+ * ties resolve to the oldest `firstShownAt` (chronological).
+ *
+ * A `lockedId` is the id of the notification currently visible to the
+ * user. While that notification is still within `GRID_BAR_DWELL_FLOOR_MS`
+ * of its `firstShownAt`, it is returned unchanged — a higher-severity
+ * newcomer cannot preempt it mid-read. Once the dwell expires, the
+ * regular score/age ordering applies.
+ *
+ * Pure: callers pass `nowMs` (typically `Date.now()` at render time) so
+ * the selector itself stays time-independent and unit-testable.
+ */
+export function selectGridBarNotification(
+  notifications: Notification[],
+  nowMs: number,
+  lockedId?: string
+): Notification | undefined {
+  const candidates = notifications.filter((n) => n.placement === "grid-bar" && !n.dismissed);
+  if (candidates.length === 0) return undefined;
+  if (candidates.length === 1) return candidates[0];
+
+  if (lockedId !== undefined) {
+    const locked = candidates.find((n) => n.id === lockedId);
+    if (locked !== undefined) {
+      const dwellExpires = (locked.firstShownAt ?? 0) + GRID_BAR_DWELL_FLOOR_MS;
+      if (nowMs < dwellExpires) return locked;
+    }
+  }
+
+  return [...candidates].sort((a, b) => {
+    const scoreDiff =
+      PRIORITY_WEIGHTS[b.priority] +
+      SEVERITY_WEIGHTS[b.type] -
+      (PRIORITY_WEIGHTS[a.priority] + SEVERITY_WEIGHTS[a.type]);
+    if (scoreDiff !== 0) return scoreDiff;
+    return (a.firstShownAt ?? 0) - (b.firstShownAt ?? 0);
+  })[0];
+}
 
 /**
  * Compare two notification messages for the purpose of contentKey bumping.


### PR DESCRIPTION
## Summary

- The old `find()` call in `GridNotificationBar` had no defined ordering — when multiple notifications competed for the single slot the winner was arbitrary, based on array position
- Introduces a pure `selectGridBarNotification` function with a formal contract: severity-weighted scoring (`PRIORITY_WEIGHTS + SEVERITY_WEIGHTS`, wide gap so priority always dominates), oldest-`firstShownAt` tie-break, and a 5-second dwell floor to prevent the pre-paint race that caused flicker when a higher-priority notification arrived mid-render
- Dwell floor is implemented with `lockedIdRef` + `useLayoutEffect` in `GridNotificationBar` so the lock is committed before the first paint, not after it

Resolves #9193

## Changes

- `src/store/notificationStore.ts` — `GRID_BAR_DWELL_FLOOR_MS`, `PRIORITY_WEIGHTS`, `SEVERITY_WEIGHTS`, and the exported `selectGridBarNotification` pure function
- `src/components/Terminal/GridNotificationBar.tsx` — replaced bare `find()` with the new selector; added `lockedIdRef` dwell timer via `useLayoutEffect`
- `src/store/__tests__/notificationStore.test.ts` — unit tests for the selector contract (priority dominance, severity tie-break, `firstShownAt` tie-break, dwell floor, dismiss handling)
- `src/components/Terminal/__tests__/GridNotificationBar.test.tsx` — component tests for dwell preemption, pre-paint race coverage, and mid-dwell dismiss

## Testing

77 tests pass (53 store + 24 component existing + new selector and dwell-preemption coverage). Selector tests exercise every branching path in the contract; component tests cover the `useLayoutEffect` timing and the race where a higher-priority notification arrives while the dwell lock is active.