### PR TITLE
fix(recipes): bound MCP recipe.run blast radius and validate in-repo recipes

### DIFF
--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 1277,
-  "moduleCount": 1277,
+  "count": 1278,
+  "moduleCount": 1278,
   "allowlist": [
     "electron/ipc/errorHandlers.ts",
     "electron/ipc/handlers/agentCapabilities.ts",
@@ -1068,22 +1068,22 @@
     },
     {
       "file": "electron/services/PluginService.ts",
-      "line": 381,
+      "line": 440,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/PluginService.ts",
-      "line": 392,
+      "line": 451,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/PluginService.ts",
-      "line": 409,
+      "line": 468,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/PluginService.ts",
-      "line": 1536,
+      "line": 1848,
       "pattern": "sync-store-get"
     },
     {

--- a/electron/services/ProjectIdentityFiles.ts
+++ b/electron/services/ProjectIdentityFiles.ts
@@ -13,7 +13,10 @@ import { resilientAtomicWriteFile } from "../utils/fs.js";
 import { UTF8_BOM } from "./projectStorePaths.js";
 import { safeRecipeFilename } from "../utils/recipeFilename.js";
 import { TerminalRecipeSchema } from "../schemas/ipc.js";
-import { sanitizeRecipeTerminals } from "../../shared/utils/recipeSanitizer.js";
+import {
+  sanitizeRecipeTerminals,
+  MAX_TERMINALS_PER_RECIPE,
+} from "../../shared/utils/recipeSanitizer.js";
 
 /**
  * Builds the exact UTF-8 byte string that `writeInRepoRecipe` lands on disk
@@ -380,14 +383,35 @@ export class ProjectIdentityFiles {
         // Content-validate every terminal at this trust boundary — dropping any
         // with a bad type or control-char-laden command/args/env — so an
         // in-repo recipe can't smuggle injected fields into the spawn path.
-        const sanitizedTerminals = sanitizeRecipeTerminals(result.data.terminals);
+        let sanitizedTerminals = sanitizeRecipeTerminals(result.data.terminals);
         if (sanitizedTerminals.length === 0) {
           console.warn(
             `[ProjectIdentityFiles] Skipping recipe with no valid terminals: ${entry.name}`
           );
           continue;
         }
-        const recipe: TerminalRecipe = { ...result.data, terminals: sanitizedTerminals };
+        if (sanitizedTerminals.length > MAX_TERMINALS_PER_RECIPE) {
+          console.warn(
+            `[ProjectIdentityFiles] Capping recipe ${entry.name} at ${MAX_TERMINALS_PER_RECIPE} terminals (had ${sanitizedTerminals.length})`
+          );
+          sanitizedTerminals = sanitizedTerminals.slice(0, MAX_TERMINALS_PER_RECIPE);
+        }
+        // Build the recipe with explicit known fields only — never spread the
+        // schema's passthrough output, or unknown top-level keys from a crafted
+        // recipe would round-trip into the store and back to disk.
+        const data = result.data;
+        const recipe: TerminalRecipe = {
+          id: data.id,
+          name: data.name,
+          projectId: data.projectId,
+          worktreeId: data.worktreeId,
+          terminals: sanitizedTerminals,
+          createdAt: data.createdAt,
+          showInEmptyState: data.showInEmptyState,
+          lastUsedAt: data.lastUsedAt,
+          usageHistory: data.usageHistory,
+          autoAssign: data.autoAssign,
+        };
         recipes.push(recipe);
         hashes.set(recipe.id, hashRecipePayload(content));
       } catch (error) {

--- a/electron/services/ProjectIdentityFiles.ts
+++ b/electron/services/ProjectIdentityFiles.ts
@@ -13,6 +13,7 @@ import { resilientAtomicWriteFile } from "../utils/fs.js";
 import { UTF8_BOM } from "./projectStorePaths.js";
 import { safeRecipeFilename } from "../utils/recipeFilename.js";
 import { TerminalRecipeSchema } from "../schemas/ipc.js";
+import { sanitizeRecipeTerminals } from "../../shared/utils/recipeSanitizer.js";
 
 /**
  * Builds the exact UTF-8 byte string that `writeInRepoRecipe` lands on disk
@@ -375,8 +376,20 @@ export class ProjectIdentityFiles {
           continue;
         }
         seenIds.add(result.data.id);
-        recipes.push(result.data);
-        hashes.set(result.data.id, hashRecipePayload(content));
+        // The schema only validates shape (and passes unknown fields through).
+        // Content-validate every terminal at this trust boundary — dropping any
+        // with a bad type or control-char-laden command/args/env — so an
+        // in-repo recipe can't smuggle injected fields into the spawn path.
+        const sanitizedTerminals = sanitizeRecipeTerminals(result.data.terminals);
+        if (sanitizedTerminals.length === 0) {
+          console.warn(
+            `[ProjectIdentityFiles] Skipping recipe with no valid terminals: ${entry.name}`
+          );
+          continue;
+        }
+        const recipe: TerminalRecipe = { ...result.data, terminals: sanitizedTerminals };
+        recipes.push(recipe);
+        hashes.set(recipe.id, hashRecipePayload(content));
       } catch (error) {
         console.warn(`[ProjectIdentityFiles] Skipping malformed recipe file: ${entry.name}`, error);
       }

--- a/electron/services/ProjectIdentityFiles.ts
+++ b/electron/services/ProjectIdentityFiles.ts
@@ -411,6 +411,7 @@ export class ProjectIdentityFiles {
           lastUsedAt: data.lastUsedAt,
           usageHistory: data.usageHistory,
           autoAssign: data.autoAssign,
+          scope: data.scope,
         };
         recipes.push(recipe);
         hashes.set(recipe.id, hashRecipePayload(content));

--- a/electron/services/__tests__/writeInRepoFiles.test.ts
+++ b/electron/services/__tests__/writeInRepoFiles.test.ts
@@ -793,6 +793,131 @@ describe("readInRepoRecipes", () => {
     expect(recipes).toHaveLength(1);
     expect(recipes[0]!.id).toBe("r2");
   });
+
+  it("drops a terminal with a non-allowlisted type but keeps valid terminals in the recipe", async () => {
+    const recipesDir = path.join(tmpDir, DAINTREE_RECIPES_DIR);
+    await fs.mkdir(recipesDir, { recursive: true });
+    await fs.writeFile(
+      path.join(recipesDir, "mixed.json"),
+      JSON.stringify({
+        id: "r1",
+        name: "Mixed",
+        terminals: [
+          { type: "terminal", command: "npm test" },
+          { type: "totally-made-up-agent", command: "rm -rf /" },
+        ],
+        createdAt: 100,
+      }),
+      "utf-8"
+    );
+    const recipes = await identityFiles.readInRepoRecipes(tmpDir);
+    expect(recipes).toHaveLength(1);
+    expect(recipes[0]!.terminals).toHaveLength(1);
+    expect(recipes[0]!.terminals[0]!.type).toBe("terminal");
+  });
+
+  it("drops a terminal with control characters in command but keeps the recipe", async () => {
+    const recipesDir = path.join(tmpDir, DAINTREE_RECIPES_DIR);
+    await fs.mkdir(recipesDir, { recursive: true });
+    await fs.writeFile(
+      path.join(recipesDir, "injected.json"),
+      JSON.stringify({
+        id: "r1",
+        name: "Injected",
+        terminals: [
+          { type: "terminal", command: "echo hi\nrm -rf /" },
+          { type: "terminal", command: "echo safe" },
+        ],
+        createdAt: 100,
+      }),
+      "utf-8"
+    );
+    const recipes = await identityFiles.readInRepoRecipes(tmpDir);
+    expect(recipes).toHaveLength(1);
+    expect(recipes[0]!.terminals).toHaveLength(1);
+    expect(recipes[0]!.terminals[0]!.command).toBe("echo safe");
+  });
+
+  it("drops a terminal with control characters in env values", async () => {
+    const recipesDir = path.join(tmpDir, DAINTREE_RECIPES_DIR);
+    await fs.mkdir(recipesDir, { recursive: true });
+    await fs.writeFile(
+      path.join(recipesDir, "env-injected.json"),
+      JSON.stringify({
+        id: "r1",
+        name: "Env Injected",
+        terminals: [
+          { type: "terminal", command: "ok", env: { FOO: "bar\ninjected" } },
+          { type: "terminal", command: "ok", env: { FOO: "bar" } },
+        ],
+        createdAt: 100,
+      }),
+      "utf-8"
+    );
+    const recipes = await identityFiles.readInRepoRecipes(tmpDir);
+    expect(recipes).toHaveLength(1);
+    expect(recipes[0]!.terminals).toHaveLength(1);
+    expect(recipes[0]!.terminals[0]!.env).toEqual({ FOO: "bar" });
+  });
+
+  it("omits a recipe entirely when every terminal fails content validation", async () => {
+    const recipesDir = path.join(tmpDir, DAINTREE_RECIPES_DIR);
+    await fs.mkdir(recipesDir, { recursive: true });
+    await fs.writeFile(
+      path.join(recipesDir, "all-bad.json"),
+      JSON.stringify({
+        id: "r1",
+        name: "All Bad",
+        terminals: [
+          { type: "fake-agent", command: "evil" },
+          { type: "terminal", command: "echo\x00boom" },
+        ],
+        createdAt: 100,
+      }),
+      "utf-8"
+    );
+    const recipes = await identityFiles.readInRepoRecipes(tmpDir);
+    expect(recipes).toHaveLength(0);
+  });
+
+  it("strips unknown passthrough fields from in-repo terminals", async () => {
+    const recipesDir = path.join(tmpDir, DAINTREE_RECIPES_DIR);
+    await fs.mkdir(recipesDir, { recursive: true });
+    await fs.writeFile(
+      path.join(recipesDir, "passthrough.json"),
+      JSON.stringify({
+        id: "r1",
+        name: "Passthrough",
+        terminals: [{ type: "terminal", command: "npm test", shell: true, poisoned: "x" }],
+        createdAt: 100,
+      }),
+      "utf-8"
+    );
+    const recipes = await identityFiles.readInRepoRecipes(tmpDir);
+    expect(recipes).toHaveLength(1);
+    const terminal = recipes[0]!.terminals[0]! as Record<string, unknown>;
+    expect(terminal.shell).toBeUndefined();
+    expect(terminal.poisoned).toBeUndefined();
+    expect(terminal.command).toBe("npm test");
+  });
+
+  it("keeps an initialPrompt that contains newlines", async () => {
+    const recipesDir = path.join(tmpDir, DAINTREE_RECIPES_DIR);
+    await fs.mkdir(recipesDir, { recursive: true });
+    await fs.writeFile(
+      path.join(recipesDir, "prompt.json"),
+      JSON.stringify({
+        id: "r1",
+        name: "Prompt",
+        terminals: [{ type: "claude", initialPrompt: "do this\r\nthen that" }],
+        createdAt: 100,
+      }),
+      "utf-8"
+    );
+    const recipes = await identityFiles.readInRepoRecipes(tmpDir);
+    expect(recipes).toHaveLength(1);
+    expect(recipes[0]!.terminals[0]!.initialPrompt).toBe("do this\nthen that");
+  });
 });
 
 describe("deleteInRepoRecipe", () => {

--- a/electron/services/__tests__/writeInRepoFiles.test.ts
+++ b/electron/services/__tests__/writeInRepoFiles.test.ts
@@ -895,7 +895,7 @@ describe("readInRepoRecipes", () => {
     );
     const recipes = await identityFiles.readInRepoRecipes(tmpDir);
     expect(recipes).toHaveLength(1);
-    const terminal = recipes[0]!.terminals[0]! as Record<string, unknown>;
+    const terminal = recipes[0]!.terminals[0]! as unknown as Record<string, unknown>;
     expect(terminal.shell).toBeUndefined();
     expect(terminal.poisoned).toBeUndefined();
     expect(terminal.command).toBe("npm test");

--- a/electron/services/__tests__/writeInRepoFiles.test.ts
+++ b/electron/services/__tests__/writeInRepoFiles.test.ts
@@ -901,6 +901,27 @@ describe("readInRepoRecipes", () => {
     expect(terminal.command).toBe("npm test");
   });
 
+  it("caps an in-repo recipe at MAX_TERMINALS_PER_RECIPE valid terminals", async () => {
+    const recipesDir = path.join(tmpDir, DAINTREE_RECIPES_DIR);
+    await fs.mkdir(recipesDir, { recursive: true });
+    await fs.writeFile(
+      path.join(recipesDir, "huge.json"),
+      JSON.stringify({
+        id: "r1",
+        name: "Huge",
+        terminals: Array.from({ length: 25 }, (_, i) => ({
+          type: "terminal",
+          command: `echo ${i}`,
+        })),
+        createdAt: 100,
+      }),
+      "utf-8"
+    );
+    const recipes = await identityFiles.readInRepoRecipes(tmpDir);
+    expect(recipes).toHaveLength(1);
+    expect(recipes[0]!.terminals).toHaveLength(10);
+  });
+
   it("keeps an initialPrompt that contains newlines", async () => {
     const recipesDir = path.join(tmpDir, DAINTREE_RECIPES_DIR);
     await fs.mkdir(recipesDir, { recursive: true });

--- a/shared/utils/__tests__/recipeSanitizer.test.ts
+++ b/shared/utils/__tests__/recipeSanitizer.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeRecipeTerminals } from "../recipeSanitizer.js";
+
+describe("sanitizeRecipeTerminals", () => {
+  it("returns empty array for non-array input", () => {
+    expect(sanitizeRecipeTerminals(undefined)).toEqual([]);
+    expect(sanitizeRecipeTerminals(null)).toEqual([]);
+    expect(sanitizeRecipeTerminals("nope")).toEqual([]);
+    expect(sanitizeRecipeTerminals({})).toEqual([]);
+  });
+
+  it("keeps valid terminals and trims empty commands", () => {
+    const result = sanitizeRecipeTerminals([
+      { type: "terminal", title: "Shell", command: "  npm test  " },
+      { type: "dev-preview", title: "Dev", devCommand: "  npm run dev  " },
+      { type: "codex", title: "Agent", initialPrompt: "hello\r\n", args: "  --fast  " },
+    ]);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toMatchObject({ type: "terminal", command: "npm test" });
+    expect(result[1]).toMatchObject({ type: "dev-preview", devCommand: "npm run dev" });
+    expect(result[2]).toMatchObject({ type: "codex", initialPrompt: "hello", args: "--fast" });
+  });
+
+  it("drops terminals with a type outside the allowlist", () => {
+    const result = sanitizeRecipeTerminals([
+      { type: "terminal", command: "ok" },
+      { type: "rm-rf-everything", command: "evil" },
+      { type: "", command: "blank" },
+      { command: "no-type" },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.type).toBe("terminal");
+  });
+
+  it("drops terminals with control characters in command", () => {
+    const result = sanitizeRecipeTerminals([
+      { type: "terminal", command: "echo hi\nrm -rf /" },
+      { type: "terminal", command: "echo\x00boom" },
+      { type: "terminal", command: "echo safe" },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.command).toBe("echo safe");
+  });
+
+  it("drops terminals with control characters in args or devCommand", () => {
+    const result = sanitizeRecipeTerminals([
+      { type: "claude", args: "--model\x00evil" },
+      { type: "dev-preview", devCommand: "npm run\ndev" },
+      { type: "claude", args: "--model sonnet" },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.args).toBe("--model sonnet");
+  });
+
+  it("allows newlines in initialPrompt but rejects other control chars", () => {
+    const result = sanitizeRecipeTerminals([
+      { type: "claude", initialPrompt: "line one\r\nline two" },
+      { type: "claude", initialPrompt: "bad\x07bell" },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.initialPrompt).toBe("line one\nline two");
+  });
+
+  it("drops terminals whose env has non-string values", () => {
+    const result = sanitizeRecipeTerminals([
+      { type: "terminal", command: "ok", env: { FOO: 123 } },
+      { type: "terminal", command: "ok", env: { FOO: "bar" } },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.env).toEqual({ FOO: "bar" });
+  });
+
+  it("drops terminals whose env has control characters in keys or values", () => {
+    const result = sanitizeRecipeTerminals([
+      { type: "terminal", command: "ok", env: { GOOD: "value\ninjected" } },
+      { type: "terminal", command: "ok", env: { "BAD\nKEY": "value" } },
+      { type: "terminal", command: "ok", env: { GOOD: "value" } },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.env).toEqual({ GOOD: "value" });
+  });
+
+  it("strips unknown fields — only known keys survive", () => {
+    const result = sanitizeRecipeTerminals([
+      {
+        type: "terminal",
+        command: "ok",
+        shell: true,
+        __proto__hack: "x",
+        agentModelId: "leak",
+        agentLaunchFlags: ["--leak"],
+      },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(Object.keys(result[0]!).sort()).toEqual([
+      "args",
+      "command",
+      "devCommand",
+      "env",
+      "exitBehavior",
+      "initialPrompt",
+      "title",
+      "type",
+    ]);
+    expect((result[0] as Record<string, unknown>).shell).toBeUndefined();
+    expect((result[0] as Record<string, unknown>).agentModelId).toBeUndefined();
+  });
+
+  it("drops terminals with an unknown non-empty exitBehavior but keeps known ones", () => {
+    const result = sanitizeRecipeTerminals([
+      { type: "terminal", command: "ok", exitBehavior: "keep" },
+      { type: "terminal", command: "ok", exitBehavior: "restart" },
+      { type: "terminal", command: "ok", exitBehavior: "" },
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result[0]?.exitBehavior).toBe("keep");
+    expect(result[1]?.exitBehavior).toBeUndefined();
+  });
+
+  it("returns empty array when every terminal is invalid", () => {
+    const result = sanitizeRecipeTerminals([
+      { type: "bogus" },
+      { type: "terminal", command: "bad\ncmd" },
+    ]);
+    expect(result).toEqual([]);
+  });
+});

--- a/shared/utils/__tests__/recipeSanitizer.test.ts
+++ b/shared/utils/__tests__/recipeSanitizer.test.ts
@@ -103,8 +103,8 @@ describe("sanitizeRecipeTerminals", () => {
       "title",
       "type",
     ]);
-    expect((result[0] as Record<string, unknown>).shell).toBeUndefined();
-    expect((result[0] as Record<string, unknown>).agentModelId).toBeUndefined();
+    expect((result[0] as unknown as Record<string, unknown>).shell).toBeUndefined();
+    expect((result[0] as unknown as Record<string, unknown>).agentModelId).toBeUndefined();
   });
 
   it("drops terminals with an unknown non-empty exitBehavior but keeps known ones", () => {

--- a/shared/utils/recipeSanitizer.ts
+++ b/shared/utils/recipeSanitizer.ts
@@ -1,0 +1,136 @@
+/**
+ * Content-validation for recipe terminals at trust boundaries.
+ *
+ * Both the user-import path (`recipeStore.importRecipe`) and the in-repo load
+ * path (`ProjectIdentityFiles.readInRepoRecipesWithHashes`) feed terminal
+ * definitions into the spawn path, where `command`/`args`/`devCommand`/`env`
+ * are forwarded verbatim to node-pty. A `type` outside the known set, or a
+ * control character in any of those fields, can inject shell commands or
+ * manipulate the terminal — so every terminal is validated here before it can
+ * reach `addPanel`. Invalid terminals are dropped individually; the caller
+ * decides what to do with a recipe left with zero valid terminals.
+ */
+import { BUILT_IN_AGENT_IDS } from "../config/agentIds.js";
+import type { RecipeTerminal, RecipeTerminalType } from "../types/project.js";
+
+/**
+ * Control characters forbidden in command-like fields (`command`, `args`,
+ * `devCommand`, and `env` keys/values). Rejects CR, LF, and all C0 control
+ * chars — any of which could break out of an argument or drive the terminal
+ * when forwarded to the shell.
+ */
+// eslint-disable-next-line no-control-regex
+export const RECIPE_CONTROL_CHARS = /[\r\n\x00-\x1F]/;
+
+/**
+ * Looser set for `initialPrompt`: newlines are legitimate inside a prompt, so
+ * `\r`/`\n` are allowed while the remaining C0 chars and DEL are rejected.
+ */
+// eslint-disable-next-line no-control-regex
+export const RECIPE_PROMPT_CONTROL_CHARS = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/;
+
+const ALLOWED_RECIPE_TYPES: ReadonlySet<string> = new Set<string>([
+  "terminal",
+  "dev-preview",
+  ...BUILT_IN_AGENT_IDS,
+]);
+
+// "restart" is QuickRun-only and never a valid recipe exit behavior (the recipe
+// editor normalizes it away), so it is intentionally excluded here.
+const ALLOWED_EXIT_BEHAVIORS: ReadonlySet<string> = new Set<string>(["keep", "trash", "remove"]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Validates a single raw terminal and maps it to a clean {@link RecipeTerminal}
+ * with only known fields, or returns `null` if it fails any content check.
+ */
+function sanitizeRecipeTerminal(raw: unknown): RecipeTerminal | null {
+  if (!isPlainObject(raw)) return null;
+
+  const type = raw.type;
+  if (typeof type !== "string" || !ALLOWED_RECIPE_TYPES.has(type)) return null;
+
+  if (raw.command !== undefined) {
+    if (typeof raw.command !== "string") return null;
+    if (RECIPE_CONTROL_CHARS.test(raw.command)) return null;
+  }
+  if (raw.initialPrompt !== undefined) {
+    if (typeof raw.initialPrompt !== "string") return null;
+    if (RECIPE_PROMPT_CONTROL_CHARS.test(raw.initialPrompt)) return null;
+  }
+  if (raw.args !== undefined) {
+    if (typeof raw.args !== "string") return null;
+    if (RECIPE_CONTROL_CHARS.test(raw.args)) return null;
+  }
+  if (raw.devCommand !== undefined) {
+    if (typeof raw.devCommand !== "string") return null;
+    if (RECIPE_CONTROL_CHARS.test(raw.devCommand)) return null;
+  }
+
+  let env: Record<string, string> | undefined;
+  if (raw.env !== undefined) {
+    if (!isPlainObject(raw.env)) return null;
+    const cleaned: Record<string, string> = {};
+    for (const [key, value] of Object.entries(raw.env)) {
+      if (typeof value !== "string") return null;
+      if (RECIPE_CONTROL_CHARS.test(key) || RECIPE_CONTROL_CHARS.test(value)) return null;
+      cleaned[key] = value;
+    }
+    env = cleaned;
+  }
+
+  if (
+    raw.exitBehavior !== undefined &&
+    typeof raw.exitBehavior === "string" &&
+    raw.exitBehavior !== "" &&
+    !ALLOWED_EXIT_BEHAVIORS.has(raw.exitBehavior)
+  ) {
+    return null;
+  }
+
+  const recipeType = type as RecipeTerminalType;
+  const isAgent = recipeType !== "terminal" && recipeType !== "dev-preview";
+
+  return {
+    type: recipeType,
+    title: typeof raw.title === "string" ? raw.title : undefined,
+    command:
+      recipeType === "terminal" && typeof raw.command === "string"
+        ? raw.command.trim() || undefined
+        : undefined,
+    env,
+    initialPrompt:
+      isAgent && typeof raw.initialPrompt === "string"
+        ? raw.initialPrompt.replace(/\r\n/g, "\n").trimEnd()
+        : undefined,
+    devCommand:
+      recipeType === "dev-preview" && typeof raw.devCommand === "string"
+        ? raw.devCommand.trim() || undefined
+        : undefined,
+    args:
+      isAgent && typeof raw.args === "string" ? raw.args.trim() || undefined : undefined,
+    exitBehavior:
+      typeof raw.exitBehavior === "string" && ALLOWED_EXIT_BEHAVIORS.has(raw.exitBehavior)
+        ? (raw.exitBehavior as "keep" | "trash" | "remove")
+        : undefined,
+  };
+}
+
+/**
+ * Content-validates an array of raw recipe terminals, returning only the valid
+ * ones mapped to clean {@link RecipeTerminal} objects (known fields only — no
+ * passthrough). Invalid terminals are dropped silently; the caller is
+ * responsible for handling a now-empty result.
+ */
+export function sanitizeRecipeTerminals(terminals: unknown): RecipeTerminal[] {
+  if (!Array.isArray(terminals)) return [];
+  const result: RecipeTerminal[] = [];
+  for (const raw of terminals) {
+    const sanitized = sanitizeRecipeTerminal(raw);
+    if (sanitized) result.push(sanitized);
+  }
+  return result;
+}

--- a/shared/utils/recipeSanitizer.ts
+++ b/shared/utils/recipeSanitizer.ts
@@ -117,8 +117,7 @@ function sanitizeRecipeTerminal(raw: unknown): RecipeTerminal | null {
       recipeType === "dev-preview" && typeof raw.devCommand === "string"
         ? raw.devCommand.trim() || undefined
         : undefined,
-    args:
-      isAgent && typeof raw.args === "string" ? raw.args.trim() || undefined : undefined,
+    args: isAgent && typeof raw.args === "string" ? raw.args.trim() || undefined : undefined,
     exitBehavior:
       typeof raw.exitBehavior === "string" && ALLOWED_EXIT_BEHAVIORS.has(raw.exitBehavior)
         ? (raw.exitBehavior as "keep" | "trash" | "remove")

--- a/shared/utils/recipeSanitizer.ts
+++ b/shared/utils/recipeSanitizer.ts
@@ -14,6 +14,13 @@ import { BUILT_IN_AGENT_IDS } from "../config/agentIds.js";
 import type { RecipeTerminal, RecipeTerminalType } from "../types/project.js";
 
 /**
+ * Maximum number of terminals a single recipe may spawn. Enforced at every
+ * recipe trust boundary (user import and in-repo load) so no recipe can open an
+ * unbounded burst of panels.
+ */
+export const MAX_TERMINALS_PER_RECIPE = 10;
+
+/**
  * Control characters forbidden in command-like fields (`command`, `args`,
  * `devCommand`, and `env` keys/values). Rejects CR, LF, and all C0 control
  * chars — any of which could break out of an argument or drive the terminal

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -3266,8 +3266,8 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
   },
   {
     "category": "recipes",
-    "danger": "safe",
-    "dangerRationale": undefined,
+    "danger": "confirm",
+    "dangerRationale": "Spawns the recipe's terminals, each running shell commands or launching agents. Agent-initiated runs are confirmation-gated so a single dispatch can't open many terminals unprompted.",
     "description": "Run a terminal recipe",
     "examples": undefined,
     "id": "recipe.run",

--- a/src/services/actions/__tests__/actionDefinitions.quality.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.quality.test.ts
@@ -334,6 +334,7 @@ const EXPECTED_CONFIRM_DANGER: ReadonlyArray<ActionId> = [
   "keybinding.resetAll",
   "project.remove",
   "recipe.delete",
+  "recipe.run",
   "devPreview.restartAndClearCache",
   "devPreview.reinstallAndRestart",
 ];

--- a/src/services/actions/definitions/__tests__/recipeActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/recipeActions.adversarial.test.ts
@@ -114,12 +114,39 @@ describe("recipeActions adversarial", () => {
       { activeWorktreeId: "wt-ctx", projectPath: "/repo" }
     );
 
-    expect(runRecipe).toHaveBeenCalledWith("r1", "/repo/arg", "wt-arg", {
-      issueNumber: 1,
-      prNumber: undefined,
-      worktreePath: "/repo/arg",
-      branchName: "feat/a",
-    });
+    expect(runRecipe).toHaveBeenCalledWith(
+      "r1",
+      "/repo/arg",
+      "wt-arg",
+      {
+        issueNumber: 1,
+        prNumber: undefined,
+        worktreePath: "/repo/arg",
+        branchName: "feat/a",
+      },
+      { spawnedBy: undefined, focusPolicy: undefined, dispatchSource: undefined }
+    );
+  });
+
+  it("recipe.run threads ctx.dispatchSource into the run options", async () => {
+    const runRecipe = vi.fn().mockResolvedValue(undefined);
+    setRecipeState({ runRecipe });
+    setWorktreeMap(new Map([["wt-1", { path: "/repo/wt", branch: "feat/x" }]]));
+
+    const run = setupActions();
+    await run(
+      "recipe.run",
+      { recipeId: "r1", worktreeId: "wt-1" },
+      { dispatchSource: "agent", projectPath: "/repo" }
+    );
+
+    expect(runRecipe).toHaveBeenCalledWith(
+      "r1",
+      "/repo/wt",
+      "wt-1",
+      expect.any(Object),
+      expect.objectContaining({ dispatchSource: "agent" })
+    );
   });
 
   it("recipe.run falls back to ctx.projectPath when the target worktree is missing from the view store", async () => {
@@ -134,12 +161,18 @@ describe("recipeActions adversarial", () => {
       { activeWorktreeId: "wt-missing", projectPath: "/repo/main" }
     );
 
-    expect(runRecipe).toHaveBeenCalledWith("r1", "/repo/main", "wt-missing", {
-      issueNumber: undefined,
-      prNumber: undefined,
-      worktreePath: "/repo/main",
-      branchName: undefined,
-    });
+    expect(runRecipe).toHaveBeenCalledWith(
+      "r1",
+      "/repo/main",
+      "wt-missing",
+      {
+        issueNumber: undefined,
+        prNumber: undefined,
+        worktreePath: "/repo/main",
+        branchName: undefined,
+      },
+      { spawnedBy: undefined, focusPolicy: undefined, dispatchSource: undefined }
+    );
   });
 
   it("recipe.run throws when no path source exists", async () => {

--- a/src/services/actions/definitions/recipeActions.ts
+++ b/src/services/actions/definitions/recipeActions.ts
@@ -56,8 +56,11 @@ export function registerRecipeActions(actions: ActionRegistry, _callbacks: Actio
       description: "Run a terminal recipe",
       category: "recipes",
       kind: "command",
-      danger: "safe",
+      danger: "confirm",
       scope: "renderer",
+      dangerRationale:
+        "Spawns the recipe's terminals, each running shell commands or launching agents. " +
+        "Agent-initiated runs are confirmation-gated so a single dispatch can't open many terminals unprompted.",
       argsSchema: z.object({
         recipeId: z.string(),
         worktreeId: z.string().optional(),
@@ -81,12 +84,17 @@ export function registerRecipeActions(actions: ActionRegistry, _callbacks: Actio
           worktreePath,
           branchName: worktree?.branch,
         };
-        if (spawnedBy !== undefined || focusPolicy !== undefined) {
+        if (
+          spawnedBy !== undefined ||
+          focusPolicy !== undefined ||
+          ctx.dispatchSource !== undefined
+        ) {
           await useRecipeStore
             .getState()
             .runRecipe(recipeId, worktreePath, targetWorktreeId, recipeContext, {
               spawnedBy,
               focusPolicy,
+              dispatchSource: ctx.dispatchSource,
             });
         } else {
           await useRecipeStore

--- a/src/services/actions/definitions/recipeActions.ts
+++ b/src/services/actions/definitions/recipeActions.ts
@@ -84,23 +84,16 @@ export function registerRecipeActions(actions: ActionRegistry, _callbacks: Actio
           worktreePath,
           branchName: worktree?.branch,
         };
-        if (
-          spawnedBy !== undefined ||
-          focusPolicy !== undefined ||
-          ctx.dispatchSource !== undefined
-        ) {
-          await useRecipeStore
-            .getState()
-            .runRecipe(recipeId, worktreePath, targetWorktreeId, recipeContext, {
-              spawnedBy,
-              focusPolicy,
-              dispatchSource: ctx.dispatchSource,
-            });
-        } else {
-          await useRecipeStore
-            .getState()
-            .runRecipe(recipeId, worktreePath, targetWorktreeId, recipeContext);
-        }
+        // Always forward dispatchSource so runRecipeWithResults can apply the
+        // agent-source terminal cap. ActionService sets ctx.dispatchSource on
+        // every dispatch, so this is the live path for all real invocations.
+        await useRecipeStore
+          .getState()
+          .runRecipe(recipeId, worktreePath, targetWorktreeId, recipeContext, {
+            spawnedBy,
+            focusPolicy,
+            dispatchSource: ctx.dispatchSource,
+          });
       },
     })
   );

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -816,6 +816,88 @@ describe("recipeStore", () => {
         usePanelLimitStore.setState({ hardLimit: previousHardLimit, warningsDisabled: false });
       }
     });
+
+    it("caps an agent-dispatched run at MAX_AGENT_RECIPE_TERMINALS and never prompts", async () => {
+      const requestConfirmationSpy = vi.fn().mockResolvedValue(true);
+      const previousRequestConfirmation = usePanelLimitStore.getState().requestConfirmation;
+      usePanelLimitStore.setState({ requestConfirmation: requestConfirmationSpy });
+      try {
+        let callIndex = 0;
+        addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
+
+        useRecipeStore.setState({
+          recipes: [
+            {
+              id: "recipe-1",
+              name: "Ten Terminals",
+              projectId: "project-1",
+              terminals: Array.from({ length: 10 }, (_, i) => ({
+                type: "terminal" as const,
+                title: `Shell ${i}`,
+                command: "echo",
+                env: {},
+              })),
+              createdAt: Date.now(),
+            },
+          ],
+          isLoading: false,
+          currentProjectId: "project-1",
+        });
+
+        const results = await useRecipeStore
+          .getState()
+          .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1", undefined, {
+            dispatchSource: "agent",
+          });
+
+        expect(addTerminalMock).toHaveBeenCalledTimes(3);
+        expect(results.spawned).toHaveLength(3);
+        expect(results.failed).toHaveLength(7);
+        expect(results.failed.map((f) => f.index)).toEqual([3, 4, 5, 6, 7, 8, 9]);
+        expect(results.failed.every((f) => f.error === "Agent recipe terminal cap reached")).toBe(
+          true
+        );
+        // Cap runs before preflightSpawnBatchLimit, so the projected count never
+        // crosses the confirm threshold — a headless agent dispatch can't hang.
+        expect(requestConfirmationSpy).not.toHaveBeenCalled();
+      } finally {
+        usePanelLimitStore.setState({ requestConfirmation: previousRequestConfirmation });
+      }
+    });
+
+    it("does not cap a user-dispatched run", async () => {
+      let callIndex = 0;
+      addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
+
+      useRecipeStore.setState({
+        recipes: [
+          {
+            id: "recipe-1",
+            name: "Ten Terminals",
+            projectId: "project-1",
+            terminals: Array.from({ length: 10 }, (_, i) => ({
+              type: "terminal" as const,
+              title: `Shell ${i}`,
+              command: "echo",
+              env: {},
+            })),
+            createdAt: Date.now(),
+          },
+        ],
+        isLoading: false,
+        currentProjectId: "project-1",
+      });
+
+      const results = await useRecipeStore
+        .getState()
+        .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1", undefined, {
+          dispatchSource: "user",
+        });
+
+      expect(addTerminalMock).toHaveBeenCalledTimes(10);
+      expect(results.spawned).toHaveLength(10);
+      expect(results.failed).toHaveLength(0);
+    });
   });
 
   it("keeps importing valid terminals even when others are invalid", async () => {
@@ -904,6 +986,22 @@ describe("recipeStore", () => {
 
     const recipe = useRecipeStore.getState().recipes[0];
     expect(recipe?.terminals[0]?.args).toBeUndefined();
+  });
+
+  it("filters out terminals with control characters in env values on import", async () => {
+    const input = JSON.stringify({
+      name: "Env Injected",
+      terminals: [
+        { type: "terminal", command: "ok", env: { FOO: "bar\ninjected" } },
+        { type: "terminal", command: "ok", env: { FOO: "bar" } },
+      ],
+    });
+
+    await useRecipeStore.getState().importRecipe("project-1", input);
+
+    const recipe = useRecipeStore.getState().recipes[0];
+    expect(recipe?.terminals).toHaveLength(1);
+    expect(recipe?.terminals[0]?.env).toEqual({ FOO: "bar" });
   });
 
   it("sanitizes args on update — keeps for agent, drops for non-agent", async () => {

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -865,6 +865,40 @@ describe("recipeStore", () => {
       }
     });
 
+    it("spawns all terminals for an agent run at exactly the cap", async () => {
+      let callIndex = 0;
+      addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
+
+      useRecipeStore.setState({
+        recipes: [
+          {
+            id: "recipe-1",
+            name: "Three Terminals",
+            projectId: "project-1",
+            terminals: Array.from({ length: 3 }, (_, i) => ({
+              type: "terminal" as const,
+              title: `Shell ${i}`,
+              command: "echo",
+              env: {},
+            })),
+            createdAt: Date.now(),
+          },
+        ],
+        isLoading: false,
+        currentProjectId: "project-1",
+      });
+
+      const results = await useRecipeStore
+        .getState()
+        .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1", undefined, {
+          dispatchSource: "agent",
+        });
+
+      expect(addTerminalMock).toHaveBeenCalledTimes(3);
+      expect(results.spawned).toHaveLength(3);
+      expect(results.failed).toHaveLength(0);
+    });
+
     it("does not cap a user-dispatched run", async () => {
       let callIndex = 0;
       addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -14,7 +14,7 @@ import { projectClient, agentSettingsClient, systemClient, globalRecipesClient }
 import { getAgentConfig } from "@/config/agents";
 import { generateAgentCommand } from "@shared/types";
 import { replaceRecipeVariables, type RecipeContext } from "@/utils/recipeVariables";
-import { sanitizeRecipeTerminals } from "@shared/utils/recipeSanitizer";
+import { sanitizeRecipeTerminals, MAX_TERMINALS_PER_RECIPE } from "@shared/utils/recipeSanitizer";
 import type { ActionSource } from "@shared/types/actions";
 import type { TerminalSpawnSource, AddPanelFocusPolicy } from "@shared/types/panel";
 import { isInRepoRecipeId, safeRecipeFilename } from "@shared/utils/recipeFilename";
@@ -185,7 +185,10 @@ interface RecipeState {
   reset: () => void;
 }
 
-export const MAX_TERMINALS_PER_RECIPE = 10;
+// Re-exported from the shared module so existing renderer imports
+// (`import { MAX_TERMINALS_PER_RECIPE } from "@/store/recipeStore"`) keep working
+// while the in-repo load path (Electron main) shares the same constant.
+export { MAX_TERMINALS_PER_RECIPE };
 
 /**
  * Per-run terminal cap for agent-dispatched recipe runs. A single MCP-approved

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -14,7 +14,8 @@ import { projectClient, agentSettingsClient, systemClient, globalRecipesClient }
 import { getAgentConfig } from "@/config/agents";
 import { generateAgentCommand } from "@shared/types";
 import { replaceRecipeVariables, type RecipeContext } from "@/utils/recipeVariables";
-import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
+import { sanitizeRecipeTerminals } from "@shared/utils/recipeSanitizer";
+import type { ActionSource } from "@shared/types/actions";
 import type { TerminalSpawnSource, AddPanelFocusPolicy } from "@shared/types/panel";
 import { isInRepoRecipeId, safeRecipeFilename } from "@shared/utils/recipeFilename";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -42,6 +43,13 @@ export interface RecipeRunOptions {
   spawnedBy?: TerminalSpawnSource;
   focusPolicy?: AddPanelFocusPolicy;
   terminalIndices?: number[];
+  /**
+   * The action dispatch source that triggered this run. When `"agent"`, a
+   * lower per-run terminal cap ({@link MAX_AGENT_RECIPE_TERMINALS}) is applied
+   * to bound the blast radius of MCP-driven recipe runs. Forwarded from
+   * `recipe.run`'s `ActionContext.dispatchSource`.
+   */
+  dispatchSource?: ActionSource;
 }
 
 function isAgentRecipeType(type: RecipeTerminalType): boolean {
@@ -178,6 +186,14 @@ interface RecipeState {
 }
 
 export const MAX_TERMINALS_PER_RECIPE = 10;
+
+/**
+ * Per-run terminal cap for agent-dispatched recipe runs. A single MCP-approved
+ * `recipe.run` shouldn't authorize a full {@link MAX_TERMINALS_PER_RECIPE}-wide
+ * spawn — an agent context needs at most a handful of panels. Bounds the blast
+ * radius without blocking legitimate agent use.
+ */
+export const MAX_AGENT_RECIPE_TERMINALS = 3;
 
 let loadRecipesRequestId = 0;
 
@@ -674,6 +690,21 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
       }
     }
 
+    // Defense-in-depth blast-radius cap for agent-dispatched runs. recipe.run's
+    // danger:"confirm" gate already requires user approval for agent sources,
+    // but one approval shouldn't authorize a full 10-terminal recipe. Apply the
+    // cap BEFORE preflightSpawnBatchLimit so a capped agent run can never reach
+    // the confirmation-dialog path (which would hang a headless MCP dispatch).
+    if (
+      options?.dispatchSource === "agent" &&
+      validIndices.length > MAX_AGENT_RECIPE_TERMINALS
+    ) {
+      const dropped = validIndices.splice(MAX_AGENT_RECIPE_TERMINALS);
+      for (const index of dropped) {
+        results.failed.push({ index, error: "Agent recipe terminal cap reached" });
+      }
+    }
+
     // Pre-fetch agent settings once for all agent terminals
     let agentSettings: Awaited<ReturnType<typeof agentSettingsClient.get>> | null = null;
     let clipboardDirectory: string | undefined;
@@ -865,82 +896,11 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
       throw new Error(`Recipe cannot exceed ${MAX_TERMINALS_PER_RECIPE} terminals`);
     }
 
-    const ALLOWED_TYPES = ["terminal", ...BUILT_IN_AGENT_IDS, "dev-preview"];
-    const ALLOWED_EXIT_BEHAVIORS = ["keep", "trash", "remove"];
-    const sanitizedTerminals = recipe.terminals
-      .filter((terminal) => {
-        if (!ALLOWED_TYPES.includes(terminal.type)) return false;
-        if (terminal.command !== undefined) {
-          if (typeof terminal.command !== "string") return false;
-          // eslint-disable-next-line no-control-regex
-          if (/[\r\n\x00-\x1F]/.test(terminal.command)) return false;
-        }
-        if (terminal.initialPrompt !== undefined) {
-          if (typeof terminal.initialPrompt !== "string") return false;
-          // Allow newlines (\r\n) but reject other control chars
-          // eslint-disable-next-line no-control-regex
-          if (/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/.test(terminal.initialPrompt)) return false;
-        }
-        if (terminal.args !== undefined) {
-          if (typeof terminal.args !== "string") return false;
-          // eslint-disable-next-line no-control-regex
-          if (/[\r\n\x00-\x1F]/.test(terminal.args)) return false;
-        }
-        if (terminal.devCommand !== undefined) {
-          if (typeof terminal.devCommand !== "string") return false;
-          // eslint-disable-next-line no-control-regex
-          if (/[\r\n\x00-\x1F]/.test(terminal.devCommand)) return false;
-        }
-        if (terminal.env !== undefined) {
-          if (
-            typeof terminal.env !== "object" ||
-            terminal.env === null ||
-            Array.isArray(terminal.env)
-          )
-            return false;
-          for (const value of Object.values(terminal.env)) {
-            if (typeof value !== "string") return false;
-          }
-        }
-        // Validate exitBehavior if present (allow undefined/empty string from UI)
-        if (terminal.exitBehavior !== undefined && typeof terminal.exitBehavior === "string") {
-          const behavior = terminal.exitBehavior as string;
-          // Empty string from UI means "use default" - allow it
-          if (behavior !== "" && !ALLOWED_EXIT_BEHAVIORS.includes(behavior)) {
-            return false;
-          }
-        }
-        return true;
-      })
-      .map((terminal) => ({
-        type: terminal.type,
-        title: typeof terminal.title === "string" ? terminal.title : undefined,
-        command:
-          terminal.type === "terminal" && typeof terminal.command === "string"
-            ? terminal.command.trim() || undefined
-            : undefined,
-        env: terminal.env,
-        initialPrompt:
-          terminal.type !== "terminal" &&
-          terminal.type !== "dev-preview" &&
-          typeof terminal.initialPrompt === "string"
-            ? terminal.initialPrompt.replace(/\r\n/g, "\n").trimEnd()
-            : undefined,
-        devCommand:
-          terminal.type === "dev-preview" && typeof terminal.devCommand === "string"
-            ? terminal.devCommand.trim() || undefined
-            : undefined,
-        args:
-          terminal.type !== "terminal" &&
-          terminal.type !== "dev-preview" &&
-          typeof terminal.args === "string"
-            ? terminal.args.trim() || undefined
-            : undefined,
-        exitBehavior:
-          terminal.exitBehavior && ALLOWED_EXIT_BEHAVIORS.includes(terminal.exitBehavior as string)
-            ? (terminal.exitBehavior as "keep" | "trash" | "remove")
-            : undefined,
-      }));
+    // Content-validate at the import trust boundary. Shared with the in-repo
+    // load path (ProjectIdentityFiles.readInRepoRecipesWithHashes) so both
+    // entry points apply the same type allowlist, control-char filtering, and
+    // explicit field mapping before a terminal can reach the spawn path.
+    const sanitizedTerminals = sanitizeRecipeTerminals(recipe.terminals);
 
     if (sanitizedTerminals.length === 0) {
       throw new Error("No valid terminals found in recipe");

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -698,10 +698,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
     // but one approval shouldn't authorize a full 10-terminal recipe. Apply the
     // cap BEFORE preflightSpawnBatchLimit so a capped agent run can never reach
     // the confirmation-dialog path (which would hang a headless MCP dispatch).
-    if (
-      options?.dispatchSource === "agent" &&
-      validIndices.length > MAX_AGENT_RECIPE_TERMINALS
-    ) {
+    if (options?.dispatchSource === "agent" && validIndices.length > MAX_AGENT_RECIPE_TERMINALS) {
       const dropped = validIndices.splice(MAX_AGENT_RECIPE_TERMINALS);
       for (const index of dropped) {
         results.failed.push({ index, error: "Agent recipe terminal cap reached" });


### PR DESCRIPTION
Closes #9160.

Two security gaps closed.

## Gap 1 — in-repo recipes bypassed content validation

The user-import path applies a full content check: type allowlist, control-char filtering, terminal count cap. In-repo recipes (`.daintree/recipes/*.json`) skipped all of it — they were schema-validated by `TerminalRecipeSchema` but that only checks shape, not content.

Added `shared/utils/recipeSanitizer.ts` (`sanitizeRecipeTerminals`) — a shared helper used at both boundaries. It enforces a type allowlist (`terminal`, `dev-preview`, `BUILT_IN_AGENT_IDS`), strips control characters from `command`, `args`, `devCommand`, `initialPrompt`, and env keys/values, applies an exit-behavior allowlist, and uses explicit field mapping (no passthrough — unknown fields are stripped). Applied at the in-repo load boundary in `ProjectIdentityFiles.readInRepoRecipesWithHashes`: invalid terminals are dropped individually, a recipe with zero valid terminals is skipped entirely, and the per-recipe terminal count is capped at `MAX_TERMINALS_PER_RECIPE` for parity with import. `importRecipe` now uses the same helper, which also adds env-value control-char filtering it previously lacked.

## Gap 2 — `recipe.run` discarded `dispatchSource`, no cap or confirm gate

`recipe.run` dispatched from an MCP agent dropped `ctx.dispatchSource`, so the existing agent-source confirmation gate in `ActionService` never fired. With a 15-minute grant that's up to ~4500 terminals.

`recipe.run` is now `danger:"confirm"` so `ActionService`'s gate fires for agent-sourced calls (user/menu/keybinding sources are unchanged). `dispatchSource` is threaded through `recipeActions` → `runRecipe` → `runRecipeWithResults`. Agent-sourced runs are capped at `MAX_AGENT_RECIPE_TERMINALS` (3) applied *before* `preflightSpawnBatchLimit`, so a capped agent run never reaches the confirmation dialog (which would hang a headless dispatch).

## Testing

- `shared/utils/__tests__/recipeSanitizer.test.ts` — new sanitizer unit tests
- `electron/services/__tests__/writeInRepoFiles.test.ts` — in-repo content-validation and count-cap tests
- `src/store/__tests__/recipeStore.test.ts` — agent-cap, boundary, and env-import tests
- `src/services/actions/__tests__/recipeActions.adversarial.test.ts` — `recipe.run` added to `EXPECTED_CONFIRM_DANGER`, `dispatchSource` threading test