### PR TITLE
feat(theme): add THEME_EXTENSION_REGISTRY and extend governance tests

### DIFF
--- a/shared/theme/__tests__/builtInThemes.test.ts
+++ b/shared/theme/__tests__/builtInThemes.test.ts
@@ -315,6 +315,26 @@ describe("built-in themes", () => {
       `var(--key) consumers not registered in EXTENSION_KEYS: ${directionB.join(", ")}`
     ).toHaveLength(0);
   });
+
+  it("never ships a dock-shadow extension that overrides the fix with a weak alpha (#8156)", () => {
+    // applyAppThemeToRoot sets extensions["dock-shadow"] as an inline style,
+    // which beats the corrected src/index.css base value. Any theme that opts
+    // back in must use the alpha-pinned relative-color form so it stays visible
+    // on light themes — never a raw low-alpha rgba() like the original bug.
+    for (const source of BUILT_IN_THEME_SOURCES) {
+      const dockShadow = source.extensions?.["dock-shadow"];
+      if (dockShadow === undefined) continue;
+      const pinned = dockShadow.match(/rgb\(from var\(--theme-shadow-color\) r g b \/ ([0-9.]+)\)/);
+      expect(
+        pinned,
+        `${source.id} dock-shadow "${dockShadow}" must use the alpha-pinned relative-color form`
+      ).toBeTruthy();
+      expect(
+        Number(pinned![1]),
+        `${source.id} dock-shadow alpha ${pinned![1]} below 0.25 visibility threshold`
+      ).toBeGreaterThanOrEqual(0.25);
+    }
+  });
 });
 
 const SEMANTIC_TOKEN_NAMES = new Set<string>(APP_THEME_TOKEN_KEYS);

--- a/shared/theme/__tests__/builtInThemes.test.ts
+++ b/shared/theme/__tests__/builtInThemes.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { BUILT_IN_THEME_SOURCES } from "../builtInThemes/index.js";
 import { getThemeContrastWarnings } from "../contrast.js";
 import { EXTENSION_KEY_REGISTRY, isExtensionKeyRequired } from "../extensionRegistry.js";
+import { THEME_EXTENSION_REGISTRY } from "../extensions.js";
 import { auditSurfaceRamp, auditAccentProminence, auditCrossThemeAccents } from "../oklch.js";
 import { BUILT_IN_APP_SCHEMES } from "../themes.js";
 import { APP_THEME_TOKEN_KEYS, EXTENSION_KEYS } from "../types.js";
@@ -334,6 +335,29 @@ describe("built-in themes", () => {
         `${source.id} dock-shadow alpha ${pinned![1]} below 0.25 visibility threshold`
       ).toBeGreaterThanOrEqual(0.25);
     }
+  });
+
+  it("pins the required extension key classification", () => {
+    // Second gate over the registry-driven parity test above: flipping a key's
+    // `required` flag silently removes its parity/perceptibility protection, so the
+    // required set is asserted by name here. Update intentionally, never to silence.
+    const required = Object.entries(THEME_EXTENSION_REGISTRY)
+      .filter(([, meta]) => meta.required)
+      .map(([key]) => key)
+      .sort();
+    expect(required).toEqual(
+      [
+        "pulse-missed-bg",
+        "pulse-ring-offset",
+        "sidebar-active-bg",
+        "sidebar-hover-bg",
+        "toolbar-control-armed-shadow",
+      ].sort()
+    );
+    expect(
+      (THEME_EXTENSION_REGISTRY["toolbar-control-armed-shadow"] as { darkOnly?: boolean }).darkOnly,
+      "toolbar-control-armed-shadow must stay darkOnly (light themes inherit the CSS fallback)"
+    ).toBe(true);
   });
 });
 

--- a/shared/theme/builtInThemeSources.ts
+++ b/shared/theme/builtInThemeSources.ts
@@ -8,6 +8,8 @@ export interface BuiltInThemeSource {
   builtin: true;
   palette: ThemePalette;
   tokens?: Partial<AppColorSchemeTokens>;
+  // Built-in themes are closed to the registry: a misspelled or unregistered
+  // extension key fails at compile time.
   extensions?: Partial<Record<ExtensionKey, string>>;
   location?: string;
   heroImage?: string;

--- a/shared/theme/extensions.ts
+++ b/shared/theme/extensions.ts
@@ -1,0 +1,99 @@
+/**
+ * Canonical registry for the theme extensions tier.
+ *
+ * Extension keys are component-scoped CSS hooks (applied as bare `--{key}` custom
+ * properties, never the `--theme-{key}` semantic namespace) that a theme may set to
+ * override a value the component stylesheet would otherwise fall back to. Unlike the
+ * semantic tier (`APP_THEME_TOKEN_KEYS`), which every theme must define in full, most
+ * extension keys are optional cosmetic overrides — but a few have a fallback that is
+ * invisible or wrong, so every applicable built-in theme must define them.
+ *
+ * `required: true` marks the keys whose CSS fallback is not safe to inherit:
+ *   - sidebar-hover-bg / sidebar-active-bg — white-tinted fallback is invisible on light themes
+ *   - pulse-missed-bg — must be a red-tinted wash to read as "missed"
+ *   - pulse-ring-offset — must match the card background or the focus ring tears
+ *   - toolbar-control-armed-shadow — black-tinted fallback is invisible on dark surfaces
+ *     (darkOnly: required on dark themes, must be ABSENT on light themes or it inverts the ring)
+ */
+interface ThemeExtensionMeta {
+  /** Fallback is invisible/wrong, so every applicable built-in theme must define it. */
+  required: boolean;
+  /** Required on dark themes only; light themes must NOT define it (inverts the contrast). */
+  darkOnly?: boolean;
+}
+
+export const THEME_EXTENSION_REGISTRY = {
+  // Sidebar
+  "sidebar-hover-bg": { required: true },
+  "sidebar-active-bg": { required: true },
+  "sidebar-action-hover-bg": { required: false },
+  "worktree-section-hover-bg": { required: false },
+
+  // Toolbar
+  "toolbar-agent-hover-bg": { required: false },
+  "toolbar-control-armed-shadow": { required: true, darkOnly: true },
+  "toolbar-control-hover-bg": { required: false },
+  "toolbar-control-hover-fg": { required: false },
+  "toolbar-control-hover-shadow": { required: false },
+  "toolbar-divider": { required: false },
+  "toolbar-pill-radius": { required: false },
+  "toolbar-project-bg": { required: false },
+  "toolbar-project-border": { required: false },
+  "toolbar-project-chip-bg": { required: false },
+  "toolbar-project-chip-border": { required: false },
+  "toolbar-project-meta-fg": { required: false },
+  "toolbar-project-shadow": { required: false },
+  "toolbar-shadow": { required: false },
+  "toolbar-stats-bg": { required: false },
+  "toolbar-stats-border": { required: false },
+  "toolbar-stats-divider": { required: false },
+  "toolbar-stats-hover-bg": { required: false },
+  "toolbar-stats-shadow": { required: false },
+
+  // Settings
+  "settings-card-bg": { required: false },
+  "settings-dialog-bg": { required: false },
+  "settings-kbd-bg": { required: false },
+  "settings-kbd-border": { required: false },
+  "settings-list-item-bg": { required: false },
+  "settings-nav-active-bg": { required: false },
+  "settings-nav-active-shadow": { required: false },
+  "settings-nav-hover-bg": { required: false },
+  "settings-search-bg": { required: false },
+  "settings-search-muted": { required: false },
+  "settings-sidebar-bg": { required: false },
+  "dialog-header-bg": { required: false },
+
+  // Pulse
+  "pulse-before-bg": { required: false },
+  "pulse-card-bg": { required: false },
+  "pulse-card-header-bg": { required: false },
+  "pulse-card-shadow": { required: false },
+  "pulse-control-hover-bg": { required: false },
+  "pulse-empty-bg": { required: false },
+  "pulse-heat-color": { required: false },
+  "pulse-heat-high-opacity": { required: false },
+  "pulse-heat-low-opacity": { required: false },
+  "pulse-heat-medium-opacity": { required: false },
+  "pulse-missed-bg": { required: true },
+  "pulse-range-bg": { required: false },
+  "pulse-ring-offset": { required: true },
+  "pulse-skeleton-gradient": { required: false },
+
+  // Dock / panel
+  "dock-bg": { required: false },
+  "dock-border": { required: false },
+  "dock-shadow": { required: false },
+  "panel-grid-bg": { required: false },
+} as const satisfies Record<string, ThemeExtensionMeta>;
+
+export type ThemeExtensionKey = keyof typeof THEME_EXTENSION_REGISTRY;
+
+/** Keys whose CSS fallback is unsafe to inherit (see `required` above). */
+export type RequiredThemeExtensionKey = {
+  [K in ThemeExtensionKey]: (typeof THEME_EXTENSION_REGISTRY)[K]["required"] extends true
+    ? K
+    : never;
+}[ThemeExtensionKey];
+
+export const THEME_EXTENSION_KEYS = Object.keys(THEME_EXTENSION_REGISTRY) as ThemeExtensionKey[];

--- a/shared/theme/extensions.ts
+++ b/shared/theme/extensions.ts
@@ -89,9 +89,16 @@ export const THEME_EXTENSION_REGISTRY = {
 
 export type ThemeExtensionKey = keyof typeof THEME_EXTENSION_REGISTRY;
 
-/** Keys whose CSS fallback is unsafe to inherit (see `required` above). */
+/**
+ * Keys every built-in theme must define unconditionally. Excludes `darkOnly` keys,
+ * which are required on dark themes but must be absent on light themes — their
+ * requirement is conditional, so they don't belong in an "always present" type.
+ */
 export type RequiredThemeExtensionKey = {
-  [K in ThemeExtensionKey]: (typeof THEME_EXTENSION_REGISTRY)[K]["required"] extends true
+  [K in ThemeExtensionKey]: (typeof THEME_EXTENSION_REGISTRY)[K] extends {
+    required: true;
+    darkOnly?: false | undefined;
+  }
     ? K
     : never;
 }[ThemeExtensionKey];

--- a/shared/theme/index.ts
+++ b/shared/theme/index.ts
@@ -2,6 +2,7 @@ export * from "./colorValidator.js";
 export * from "./contrast.js";
 export * from "./oklch.js";
 export * from "./entityColors.js";
+export * from "./extensions.js";
 export * from "./palette.js";
 export * from "./semantic.js";
 export * from "./terminal.js";

--- a/shared/theme/types.ts
+++ b/shared/theme/types.ts
@@ -307,7 +307,9 @@ export interface AppColorScheme {
   builtin: boolean;
   tokens: AppColorSchemeTokens;
   palette?: ThemePalette;
-  extensions?: Partial<Record<ExtensionKey, string>>;
+  // Open union: registry keys get autocomplete, but user-imported themes may carry
+  // arbitrary extension keys, so unknown string keys stay assignable.
+  extensions?: Partial<Record<ExtensionKey | (string & {}), string>>;
   location?: string;
   heroImage?: string;
 }

--- a/src/config/__tests__/colorSystem.contract.test.ts
+++ b/src/config/__tests__/colorSystem.contract.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { APP_THEME_TOKEN_KEYS, PANEL_KIND_BRAND_COLORS } from "@shared/theme";
+import {
+  APP_THEME_TOKEN_KEYS,
+  PANEL_KIND_BRAND_COLORS,
+  THEME_EXTENSION_KEYS,
+  THEME_EXTENSION_REGISTRY,
+} from "@shared/theme";
 
 const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(TEST_DIR, "../../..");
@@ -29,6 +34,49 @@ const NON_COLOR_THEME_TOKENS = new Set([
   "panel-state-edge-radius",
   "focus-ring-offset",
   "chrome-noise-texture",
+]);
+
+const THEME_COMPONENT_CSS_FILES = [
+  "src/styles/components/toolbar.css",
+  "src/styles/components/sidebar.css",
+  "src/styles/components/settings.css",
+  "src/styles/components/pulse.css",
+  "src/styles/components/panels.css",
+].map((rel) => path.join(REPO_ROOT, rel));
+
+// Vars consumed via var(--x, …) in the theme component stylesheets that are NOT
+// theme-extension hooks: derived surface/shadow aliases, semantic-token aliases,
+// pip/badge colors set on the element by component logic, and design tokens
+// (radius/timing). They are excluded from extension-drift detection so a derived
+// alias doesn't masquerade as an unregistered extension key. Keep this list in
+// sync only when a genuinely new non-extension var is consumed in these files.
+const NON_EXTENSION_COMPONENT_VARS = new Set([
+  // Chrome / dialog / floating-surface aliases derived from semantic tokens
+  "chrome-bg",
+  "chrome-noise",
+  "chrome-noise-texture",
+  "chrome-shadow",
+  "dialog-bg",
+  "dialog-shadow",
+  "floating-surface-bg",
+  "floating-surface-shadow",
+  "sidebar-ring",
+  "toolbar-bg",
+  "toolbar-noise",
+  "toolbar-control-active-bg",
+  "toolbar-control-armed-bg",
+  "settings-meta-fg",
+  "settings-meta-size",
+  "settings-section-header-bg",
+  "settings-section-header-bg-solid",
+  "toolbar-project-chip-size",
+  // Pip / badge colors set on the element by component logic, not theme overrides
+  "overflow-badge-color",
+  "problems-dot-color",
+  // Design tokens (radius / timing), not color overrides
+  "radius-lg",
+  "duration-150",
+  "ease-out-expo",
 ]);
 
 function collectSourceFiles(dir: string): string[] {
@@ -195,5 +243,50 @@ describe("color system contract", () => {
 
   it("sets color-scheme: normal on webview elements to prevent dark-mode inheritance", () => {
     expect(indexCss).toMatch(/webview\s*\{[^}]*color-scheme:\s*normal/s);
+  });
+});
+
+describe("theme extension contract", () => {
+  const consumedInComponentCss = new Set<string>();
+  for (const file of THEME_COMPONENT_CSS_FILES) {
+    const css = fs.readFileSync(file, "utf8");
+    for (const match of css.matchAll(/var\(\s*--([a-z0-9-]+)/g)) {
+      consumedInComponentCss.add(match[1]!);
+    }
+  }
+
+  const consumedAnywhere = new Set<string>();
+  for (const filePath of collectSourceFiles(SRC_ROOT)) {
+    const source = fs.readFileSync(filePath, "utf8");
+    for (const match of source.matchAll(/var\(\s*--([a-z0-9-]+)/g)) {
+      consumedAnywhere.add(match[1]!);
+    }
+  }
+
+  it("registers every extension hook consumed in theme component stylesheets", () => {
+    // Reverse drift: a new var(--foo, …) hook added to a theme stylesheet must be
+    // registered (or explicitly classified as a non-extension alias above), so the
+    // canonical key set stays exhaustive.
+    const unregistered = Array.from(consumedInComponentCss).filter(
+      (name) =>
+        !name.startsWith("theme-") &&
+        !name.startsWith("color-") &&
+        !NON_EXTENSION_COMPONENT_VARS.has(name) &&
+        !(name in THEME_EXTENSION_REGISTRY)
+    );
+    expect(
+      unregistered,
+      `extension hooks consumed in component CSS but missing from THEME_EXTENSION_REGISTRY: ${unregistered.join(", ")}`
+    ).toEqual([]);
+  });
+
+  it("consumes every registered extension key somewhere in renderer source", () => {
+    // Forward drift: a registry key that nothing consumes is dead governance — drop it
+    // from the registry (and any theme that defines it) instead of carrying it.
+    const unused = THEME_EXTENSION_KEYS.filter((key) => !consumedAnywhere.has(key));
+    expect(
+      unused,
+      `registered extension keys that are no longer consumed in source: ${unused.join(", ")}`
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `shared/theme/extensions.ts` with `THEME_EXTENSION_REGISTRY` (53 keys, `required`/`darkOnly` metadata), deriving `ThemeExtensionKey` and `THEME_EXTENSION_KEYS` — a simpler parallel to `extensionRegistry.ts` scoped to the keys consumed in component stylesheets
- Widens `AppColorScheme.extensions` to an open union (`ExtensionKey | (string & {})`) so user-imported themes can carry arbitrary keys while built-in theme sources stay closed to the registry
- Extends the test suite with three targeted additions: a `dock-shadow` regression guard (#8156), a pin test asserting the required-key set by name (catches silent `required:true → false` flips), and component-CSS drift detection in `colorSystem.contract.test.ts` scoped to the 5 theme stylesheet files

No runtime behaviour change — pure type, registry, and test layer additions on top of the governance work from #9435.

## Changes

- `shared/theme/extensions.ts` — `THEME_EXTENSION_REGISTRY`, `ThemeExtensionKey`, `RequiredThemeExtensionKey`, `THEME_EXTENSION_KEYS`
- `shared/theme/index.ts` — barrel-exports the new module
- `shared/theme/types.ts` — open union on `AppColorScheme.extensions`
- `shared/theme/__tests__/builtInThemes.test.ts` — dock-shadow guard + required-set pin
- `src/config/__tests__/colorSystem.contract.test.ts` — component-CSS drift detection

## Testing

- `npx tsc --noEmit` — clean (pre-existing `culori` type gap in `paletteDistinguishability.test.ts` unrelated)
- `npx vitest run shared/theme/__tests__/builtInThemes.test.ts src/config/__tests__/colorSystem.contract.test.ts` — 63 tests pass