### PR TITLE
feat(voice): add push-to-talk recording mode

### DIFF
--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 1279,
-  "moduleCount": 1279,
+  "count": 1275,
+  "moduleCount": 1275,
   "allowlist": [
     "electron/ipc/errorHandlers.ts",
     "electron/ipc/handlers/agentCapabilities.ts",
@@ -163,12 +163,12 @@
     },
     {
       "file": "electron/ipc/handlers/diagnostics.ts",
-      "line": 67,
+      "line": 65,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/ipc/handlers/diagnostics.ts",
-      "line": 74,
+      "line": 72,
       "pattern": "sync-fs"
     },
     {
@@ -318,7 +318,7 @@
     },
     {
       "file": "electron/ipc/handlers/voiceInput.ts",
-      "line": 55,
+      "line": 56,
       "pattern": "sync-store-get"
     },
     {
@@ -1068,22 +1068,22 @@
     },
     {
       "file": "electron/services/PluginService.ts",
-      "line": 466,
+      "line": 381,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/PluginService.ts",
-      "line": 477,
+      "line": 392,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/PluginService.ts",
-      "line": 494,
+      "line": 409,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/PluginService.ts",
-      "line": 2063,
+      "line": 1536,
       "pattern": "sync-store-get"
     },
     {
@@ -1123,32 +1123,32 @@
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 98,
+      "line": 97,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 357,
+      "line": 356,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 540,
+      "line": 539,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 547,
+      "line": 546,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 601,
+      "line": 600,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 607,
+      "line": 606,
       "pattern": "sync-fs"
     },
     {
@@ -1418,57 +1418,57 @@
     },
     {
       "file": "electron/store.ts",
-      "line": 555,
+      "line": 551,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 557,
+      "line": 553,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 572,
+      "line": 568,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 587,
+      "line": 583,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 588,
+      "line": 584,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 590,
+      "line": 586,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 605,
+      "line": 601,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 607,
+      "line": 603,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 624,
+      "line": 620,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 633,
+      "line": 629,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 634,
+      "line": 630,
       "pattern": "sync-fs"
     },
     {

--- a/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
+++ b/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
@@ -586,6 +586,47 @@ describe("getVoiceSettings migration", () => {
     }
   });
 
+  it("returns recordingMode='toggle' when the field is missing from the store", async () => {
+    const { store } = await import("../../../store.js");
+    vi.mocked(store.get).mockReturnValueOnce({
+      enabled: true,
+      openaiApiKey: "sk-present",
+      // recordingMode intentionally absent.
+    });
+
+    const settings = getVoiceSettings();
+
+    expect(settings.recordingMode).toBe("toggle");
+  });
+
+  it("preserves recordingMode='push-to-talk' when stored", async () => {
+    const { store } = await import("../../../store.js");
+    vi.mocked(store.get).mockReturnValueOnce({
+      enabled: true,
+      openaiApiKey: "sk-present",
+      recordingMode: "push-to-talk",
+    });
+
+    const settings = getVoiceSettings();
+
+    expect(settings.recordingMode).toBe("push-to-talk");
+  });
+
+  it("normalizes malformed recordingMode values to 'toggle' without writing to disk", async () => {
+    const { store } = await import("../../../store.js");
+    vi.mocked(store.get).mockReturnValueOnce({
+      enabled: true,
+      openaiApiKey: "sk-present",
+      recordingMode: "hold" as unknown,
+    });
+
+    const settings = getVoiceSettings();
+
+    expect(settings.recordingMode).toBe("toggle");
+    // Normalization must not persist back to the store.
+    expect(vi.mocked(store.set)).not.toHaveBeenCalled();
+  });
+
   it("skips env override when WHISPER_API_KEY is empty string", async () => {
     const { store } = await import("../../../store.js");
     vi.mocked(store.get).mockReturnValueOnce({

--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -48,6 +48,7 @@ const VOICE_INPUT_DEFAULTS: VoiceInputSettings = {
   deviceId: "",
   organizationId: "",
   projectId: "",
+  recordingMode: "toggle",
 };
 
 /** Read voiceInput settings with defaults for fields added after initial store creation. */
@@ -89,6 +90,11 @@ export function getVoiceSettings(): VoiceInputSettings {
   // the provider, not the model, is what selects the backend now.
   const staleModel = merged.transcriptionModel !== "gpt-realtime-whisper";
   if (staleModel) merged.transcriptionModel = "gpt-realtime-whisper";
+
+  // Normalize malformed recordingMode values in memory only (no write-back).
+  if (merged.recordingMode !== "toggle" && merged.recordingMode !== "push-to-talk") {
+    merged.recordingMode = "toggle";
+  }
 
   // Persist the cleaned object on first read after upgrade so the legacy key
   // fields disappear from disk and any defaulted/normalized values are written

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2334,6 +2334,7 @@ const api: ElectronAPI = {
         paragraphingStrategy: "spoken-command" | "manual";
         resolveFileLinks: boolean;
         deviceId: string;
+        recordingMode: "toggle" | "push-to-talk";
       }>
     ) => _unwrappingInvoke(CHANNELS.VOICE_INPUT_SET_SETTINGS, patch),
     start: () => _unwrappingInvoke(CHANNELS.VOICE_INPUT_START),

--- a/electron/services/__tests__/VoiceTranscriptionService.integration.test.ts
+++ b/electron/services/__tests__/VoiceTranscriptionService.integration.test.ts
@@ -39,6 +39,7 @@ describe("VoiceTranscriptionService integration", () => {
         deviceId: "",
         organizationId: "",
         projectId: "",
+        recordingMode: "toggle",
       });
 
       expect(result).toEqual({ ok: true });

--- a/electron/services/__tests__/VoiceTranscriptionService.test.ts
+++ b/electron/services/__tests__/VoiceTranscriptionService.test.ts
@@ -126,6 +126,7 @@ const OPENAI_SETTINGS: VoiceInputSettings = {
   deviceId: "",
   organizationId: "",
   projectId: "",
+  recordingMode: "toggle",
 };
 
 const DEEPGRAM_SETTINGS: VoiceInputSettings = {

--- a/electron/services/voice/__tests__/DeepgramTranscriptionProvider.test.ts
+++ b/electron/services/voice/__tests__/DeepgramTranscriptionProvider.test.ts
@@ -146,6 +146,7 @@ const BASE_SETTINGS: VoiceInputSettings = {
   deviceId: "",
   organizationId: "",
   projectId: "",
+  recordingMode: "toggle",
 };
 
 function latestInstance(): MockWebSocket {

--- a/electron/services/voice/__tests__/OpenAITranscriptionProvider.test.ts
+++ b/electron/services/voice/__tests__/OpenAITranscriptionProvider.test.ts
@@ -150,6 +150,7 @@ const BASE_SETTINGS: VoiceInputSettings = {
   deviceId: "",
   organizationId: "",
   projectId: "",
+  recordingMode: "toggle",
 };
 
 function latestInstance(): MockWebSocket {

--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -1,15 +1,15 @@
 {
-  "count": 1196,
+  "count": 1195,
   "byRule": {
     "@typescript-eslint/no-explicit-any": 54,
     "@typescript-eslint/no-floating-promises": 93,
     "@typescript-eslint/no-unsafe-type-assertion": 502,
     "no-restricted-imports": 8,
-    "no-restricted-syntax": 411,
+    "no-restricted-syntax": 410,
     "no-useless-assignment": 20,
     "preserve-caught-error": 52,
     "react-compiler/react-compiler": 16,
     "react-hooks/exhaustive-deps": 40
   },
-  "updatedAt": "2026-05-28T07:59:22.300Z"
+  "updatedAt": "2026-05-28T08:14:13.441Z"
 }

--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -1,15 +1,15 @@
 {
-  "count": 1194,
+  "count": 1196,
   "byRule": {
     "@typescript-eslint/no-explicit-any": 54,
     "@typescript-eslint/no-floating-promises": 93,
-    "@typescript-eslint/no-unsafe-type-assertion": 501,
+    "@typescript-eslint/no-unsafe-type-assertion": 502,
     "no-restricted-imports": 8,
-    "no-restricted-syntax": 410,
+    "no-restricted-syntax": 411,
     "no-useless-assignment": 20,
     "preserve-caught-error": 52,
     "react-compiler/react-compiler": 16,
     "react-hooks/exhaustive-deps": 40
   },
-  "updatedAt": "2026-05-28T08:07:13.631Z"
+  "updatedAt": "2026-05-28T07:59:22.300Z"
 }

--- a/renderer-bundle-size-baseline.json
+++ b/renderer-bundle-size-baseline.json
@@ -11,23 +11,23 @@
     },
     "ActionService": {
       "raw": 10718,
-      "gzip": 4129
+      "gzip": 4128
     },
     "AgentCard": {
       "raw": 12536,
-      "gzip": 4631
+      "gzip": 4634
     },
     "AgentSettings": {
       "raw": 89323,
-      "gzip": 26427
+      "gzip": 26430
     },
     "AgentShortcutCapture": {
       "raw": 1685,
       "gzip": 894
     },
     "App": {
-      "raw": 1345854,
-      "gzip": 378605
+      "raw": 1344703,
+      "gzip": 378364
     },
     "AutomationTab": {
       "raw": 33330,
@@ -35,7 +35,7 @@
     },
     "BrowserPane": {
       "raw": 25540,
-      "gzip": 8906
+      "gzip": 8908
     },
     "CelebrationConfetti": {
       "raw": 3056,
@@ -43,7 +43,7 @@
     },
     "CloneRepoDialog": {
       "raw": 7726,
-      "gzip": 2853
+      "gzip": 2854
     },
     "CodeForgeSettingsTab": {
       "raw": 28229,
@@ -59,7 +59,7 @@
     },
     "CommitList": {
       "raw": 12902,
-      "gzip": 4987
+      "gzip": 4990
     },
     "ContextTab": {
       "raw": 11733,
@@ -67,19 +67,19 @@
     },
     "CrashRecoveryDialog": {
       "raw": 22601,
-      "gzip": 6984
+      "gzip": 6987
     },
     "CreateProjectFolderDialog": {
       "raw": 3588,
-      "gzip": 1520
+      "gzip": 1521
     },
     "CrossWorktreeDiff": {
       "raw": 9890,
-      "gzip": 3652
+      "gzip": 3655
     },
     "DaintreeAssistantSettingsTab": {
       "raw": 24076,
-      "gzip": 7685
+      "gzip": 7689
     },
     "DaintreeIcon": {
       "raw": 1858,
@@ -87,7 +87,7 @@
     },
     "DevPreviewPane": {
       "raw": 84880,
-      "gzip": 25193
+      "gzip": 25199
     },
     "DiagnosticsReviewDialogHost": {
       "raw": 12587,
@@ -95,11 +95,11 @@
     },
     "DiffViewer": {
       "raw": 31779,
-      "gzip": 11829
+      "gzip": 11830
     },
     "EnvironmentSettingsTab": {
       "raw": 6394,
-      "gzip": 2528
+      "gzip": 2530
     },
     "EnvironmentVariablesEditor": {
       "raw": 7365,
@@ -111,11 +111,11 @@
     },
     "GeneralTab": {
       "raw": 20715,
-      "gzip": 5966
+      "gzip": 5967
     },
     "GettingStartedChecklist": {
       "raw": 8304,
-      "gzip": 3519
+      "gzip": 3521
     },
     "GitHubDropdownSkeletons": {
       "raw": 6511,
@@ -131,51 +131,51 @@
     },
     "GitInitDialog": {
       "raw": 6297,
-      "gzip": 2255
+      "gzip": 2257
     },
     "GitPullRebaseConfirmDialog": {
       "raw": 4925,
-      "gzip": 2150
+      "gzip": 2151
     },
     "GitPushConfirmDialog": {
       "raw": 4849,
-      "gzip": 2135
+      "gzip": 2137
     },
     "GlobalBannerCoordinator": {
       "raw": 13054,
-      "gzip": 4978
+      "gzip": 4979
     },
     "HybridInputBar": {
-      "raw": 133162,
-      "gzip": 39747
+      "raw": 132041,
+      "gzip": 39441
     },
     "IntegrationsTab": {
       "raw": 11132,
       "gzip": 3160
     },
     "KeybindingService": {
-      "raw": 41038,
-      "gzip": 9593
+      "raw": 40863,
+      "gzip": 9567
     },
     "KeyboardShortcutsTab": {
       "raw": 8946,
-      "gzip": 3134
+      "gzip": 3137
     },
     "LiveTimeAgo": {
       "raw": 3263,
-      "gzip": 1607
+      "gzip": 1610
     },
     "LogLevelPalette": {
       "raw": 5367,
-      "gzip": 2271
+      "gzip": 2272
     },
     "McpAuditLogViewer": {
       "raw": 18407,
-      "gzip": 5363
+      "gzip": 5364
     },
     "McpConfirmDialog": {
       "raw": 3216,
-      "gzip": 1527
+      "gzip": 1528
     },
     "McpServerIcon": {
       "raw": 1048,
@@ -187,11 +187,11 @@
     },
     "NewTerminalPalette": {
       "raw": 4505,
-      "gzip": 2194
+      "gzip": 2195
     },
     "NewWorktreeDialog": {
       "raw": 49460,
-      "gzip": 14912
+      "gzip": 14919
     },
     "NotificationSettingsTab": {
       "raw": 16255,
@@ -199,7 +199,7 @@
     },
     "OnboardingFlow": {
       "raw": 49963,
-      "gzip": 15624
+      "gzip": 15633
     },
     "PaletteOverflowNotice": {
       "raw": 523,
@@ -215,7 +215,7 @@
     },
     "PanelPalette": {
       "raw": 7811,
-      "gzip": 3723
+      "gzip": 3721
     },
     "PluginActionsSettingsTab": {
       "raw": 11395,
@@ -231,35 +231,35 @@
     },
     "PortalSettingsTab": {
       "raw": 14642,
-      "gzip": 5118
+      "gzip": 5120
     },
     "PrivacyDataTab": {
       "raw": 12586,
-      "gzip": 3820
+      "gzip": 3824
     },
     "ProjectNotificationsTab": {
       "raw": 9914,
-      "gzip": 3582
+      "gzip": 3581
     },
     "ProjectSwitcherPalette": {
       "raw": 111,
-      "gzip": 122
+      "gzip": 119
     },
     "QuickCreatePalette": {
       "raw": 6635,
-      "gzip": 2645
+      "gzip": 2647
     },
     "QuickSwitcher": {
       "raw": 5238,
-      "gzip": 2350
+      "gzip": 2352
     },
     "RecipeConflictDialog": {
       "raw": 2244,
-      "gzip": 1095
+      "gzip": 1096
     },
     "RecipeEditor": {
       "raw": 16862,
-      "gzip": 4481
+      "gzip": 4482
     },
     "RecipesTab": {
       "raw": 12803,
@@ -267,7 +267,7 @@
     },
     "ReviewHubContent": {
       "raw": 128283,
-      "gzip": 35615
+      "gzip": 35617
     },
     "ReviewPane": {
       "raw": 1109,
@@ -279,7 +279,7 @@
     },
     "SendToAgentPalette": {
       "raw": 4113,
-      "gzip": 1838
+      "gzip": 1839
     },
     "SettingsCheckbox": {
       "raw": 3183,
@@ -291,7 +291,7 @@
     },
     "SettingsDialog": {
       "raw": 50805,
-      "gzip": 16668
+      "gzip": 16669
     },
     "SettingsFlushRegistry": {
       "raw": 1314,
@@ -311,11 +311,11 @@
     },
     "SettingsSelect": {
       "raw": 2179,
-      "gzip": 1005
+      "gzip": 1007
     },
     "SettingsShortcutCapture": {
       "raw": 6557,
-      "gzip": 2371
+      "gzip": 2374
     },
     "SettingsSubtabBar": {
       "raw": 1815,
@@ -335,7 +335,7 @@
     },
     "ShortcutReferenceDialog": {
       "raw": 5418,
-      "gzip": 2393
+      "gzip": 2392
     },
     "Spinner": {
       "raw": 580,
@@ -343,23 +343,23 @@
     },
     "TerminalAppearanceTab": {
       "raw": 24615,
-      "gzip": 8164
+      "gzip": 8165
     },
     "TerminalInstanceService": {
       "raw": 224678,
-      "gzip": 59269
+      "gzip": 59270
     },
     "TerminalSettingsTab": {
       "raw": 20075,
-      "gzip": 5724
+      "gzip": 5725
     },
     "ThemePalette": {
       "raw": 5283,
-      "gzip": 2518
+      "gzip": 2520
     },
     "ToolbarSettingsTab": {
       "raw": 13472,
-      "gzip": 4948
+      "gzip": 4949
     },
     "TroubleshootingTab": {
       "raw": 11627,
@@ -367,27 +367,27 @@
     },
     "TruncatedTooltip": {
       "raw": 2667,
-      "gzip": 1354
+      "gzip": 1356
     },
     "VoiceInputSettingsTab": {
-      "raw": 28082,
-      "gzip": 9198
+      "raw": 28775,
+      "gzip": 9393
     },
     "WorktreeOverviewModal": {
       "raw": 33622,
-      "gzip": 11684
+      "gzip": 11688
     },
     "WorktreePalette": {
       "raw": 4008,
-      "gzip": 1833
+      "gzip": 1835
     },
     "WorktreeSettingsTab": {
       "raw": 8188,
-      "gzip": 2364
+      "gzip": 2367
     },
     "WorktreeSidebarSearchBar": {
       "raw": 221135,
-      "gzip": 68110
+      "gzip": 68117
     },
     "accessibilityAnnouncerStore": {
       "raw": 565,
@@ -547,7 +547,7 @@
     },
     "diagnosticsReviewStore": {
       "raw": 1739,
-      "gzip": 849
+      "gzip": 852
     },
     "diff": {
       "raw": 302,
@@ -687,7 +687,7 @@
     },
     "index": {
       "raw": 452902,
-      "gzip": 141932
+      "gzip": 141935
     },
     "java": {
       "raw": 2888,
@@ -819,7 +819,7 @@
     },
     "panelSpawning": {
       "raw": 12562,
-      "gzip": 4800
+      "gzip": 4801
     },
     "pascal": {
       "raw": 2256,
@@ -879,7 +879,7 @@
     },
     "projectStore": {
       "raw": 15030,
-      "gzip": 5007
+      "gzip": 5009
     },
     "properties": {
       "raw": 664,
@@ -923,7 +923,7 @@
     },
     "recipeStore": {
       "raw": 13859,
-      "gzip": 4536
+      "gzip": 4537
     },
     "recoveryCopy": {
       "raw": 1766,
@@ -950,8 +950,8 @@
       "gzip": 1213
     },
     "safeStorage": {
-      "raw": 5328,
-      "gzip": 2038
+      "raw": 5335,
+      "gzip": 2044
     },
     "safeStringify": {
       "raw": 403,
@@ -979,11 +979,11 @@
     },
     "select": {
       "raw": 9624,
-      "gzip": 3392
+      "gzip": 3394
     },
     "settingsTabRegistry": {
       "raw": 70231,
-      "gzip": 18222
+      "gzip": 18227
     },
     "shell": {
       "raw": 2449,
@@ -1019,7 +1019,7 @@
     },
     "storeAccessors": {
       "raw": 7252,
-      "gzip": 2219
+      "gzip": 2220
     },
     "stylus": {
       "raw": 23526,
@@ -1039,7 +1039,7 @@
     },
     "systemWakeStore": {
       "raw": 5371,
-      "gzip": 2419
+      "gzip": 2420
     },
     "tcl": {
       "raw": 2353,
@@ -1063,7 +1063,7 @@
     },
     "terminalInputStore": {
       "raw": 7635,
-      "gzip": 2714
+      "gzip": 2717
     },
     "textile": {
       "raw": 6772,
@@ -1091,7 +1091,7 @@
     },
     "twoPaneSplitStore": {
       "raw": 2148,
-      "gzip": 952
+      "gzip": 953
     },
     "uiStore": {
       "raw": 7357,
@@ -1099,7 +1099,7 @@
     },
     "useAgentDiscoveryOnboarding": {
       "raw": 2768,
-      "gzip": 1044
+      "gzip": 1043
     },
     "useDebounce": {
       "raw": 410,
@@ -1115,15 +1115,15 @@
     },
     "useFindInPage": {
       "raw": 34181,
-      "gzip": 10098
+      "gzip": 10101
     },
     "useMcpReadiness": {
       "raw": 698,
-      "gzip": 448
+      "gzip": 452
     },
     "useResizeObserverRaf": {
-      "raw": 33507,
-      "gzip": 10859
+      "raw": 33264,
+      "gzip": 10747
     },
     "utils": {
       "raw": 218,
@@ -1227,7 +1227,7 @@
     },
     "viewportPresets": {
       "raw": 5176,
-      "gzip": 1933
+      "gzip": 1934
     },
     "webidl": {
       "raw": 2449,
@@ -1252,12 +1252,12 @@
   },
   "totals": {
     "js": {
-      "raw": 7485084,
-      "gzip": 2375449
+      "raw": 7483094,
+      "gzip": 2375099
     },
     "css": {
-      "raw": 299318,
-      "gzip": 38821
+      "raw": 299262,
+      "gzip": 38812
     }
   }
 }

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -249,6 +249,7 @@ export type {
   VoiceTranscriptionProvider,
   VoiceCorrectionModel,
   VoiceParagraphingStrategy,
+  VoiceRecordingMode,
   HelpAssistantSettings,
   HelpAssistantAuditRetention,
   HelpAssistantIdleHibernateMinutes,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1599,6 +1599,19 @@ export type VoiceCorrectionModel = "gpt-5-nano" | "gpt-5-mini";
  */
 export type VoiceParagraphingStrategy = "spoken-command" | "manual";
 
+/**
+ * Recording mode for voice dictation.
+ *
+ * "toggle" (default): Pressing the voice shortcut starts recording; pressing it
+ *   again stops recording. Recording persists until the user explicitly ends it.
+ *
+ * "push-to-talk": Recording is bound to the keyboard shortcut press. Pressing and
+ *   holding the voice shortcut starts recording; releasing the trigger key stops
+ *   recording and drains the transcript into the editor without auto-submitting.
+ *   Escape still cancels. The toolbar button remains toggle-only regardless of mode.
+ */
+export type VoiceRecordingMode = "toggle" | "push-to-talk";
+
 export interface VoiceInputSettings {
   enabled: boolean;
   openaiApiKey: string;
@@ -1622,6 +1635,8 @@ export interface VoiceInputSettings {
   organizationId: string;
   /** OpenAI Project ID for legacy sk- keys. Sent as OpenAI-Project header. */
   projectId: string;
+  /** Controls whether recording is held (push-to-talk) or toggled. Defaults to "toggle". */
+  recordingMode: VoiceRecordingMode;
 }
 
 export type HelpAssistantAuditRetention = 7 | 30 | 0;

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -37,6 +37,7 @@ import type {
   VoiceCorrectionModel,
   VoiceParagraphingStrategy,
   VoiceTranscriptionProvider,
+  VoiceRecordingMode,
 } from "@shared/types";
 
 const LANGUAGES = [
@@ -102,6 +103,7 @@ const DEFAULT_SETTINGS: VoiceInputSettings = {
   deviceId: "",
   organizationId: "",
   projectId: "",
+  recordingMode: "toggle",
 };
 
 type ApiKeyValidation = "idle" | "testing" | "valid" | "invalid";
@@ -336,6 +338,11 @@ export function VoiceInputSettingsTab() {
               value={settings.paragraphingStrategy ?? "spoken-command"}
               language={settings.language}
               onChange={(v) => update({ paragraphingStrategy: v })}
+            />
+
+            <RecordingModeRow
+              value={settings.recordingMode ?? "toggle"}
+              onChange={(v) => update({ recordingMode: v })}
             />
 
             <DictionarySection
@@ -807,6 +814,34 @@ function ParagraphingStrategyRow({
       options={[
         { value: "spoken-command", label: "Spoken commands" },
         { value: "manual", label: "Manual Enter only" },
+      ]}
+    />
+  );
+}
+
+// ── Recording mode row ──
+
+function RecordingModeRow({
+  value,
+  onChange,
+}: {
+  value: VoiceRecordingMode;
+  onChange: (v: VoiceRecordingMode) => void;
+}) {
+  const description =
+    value === "toggle"
+      ? "Press the dictation shortcut to start, press again to stop."
+      : "Hold the dictation shortcut to record. Releasing the key stops recording without submitting.";
+
+  return (
+    <SettingsSelect
+      label="Recording mode"
+      description={description}
+      value={value}
+      onValueChange={(v) => onChange(v as VoiceRecordingMode)}
+      options={[
+        { value: "toggle", label: "Toggle" },
+        { value: "push-to-talk", label: "Push to talk" },
       ]}
     />
   );

--- a/src/components/Settings/__tests__/VoiceInputSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/VoiceInputSettingsTab.test.tsx
@@ -27,7 +27,30 @@ vi.mock("../SettingsSwitchCard", () => ({
 }));
 
 vi.mock("../SettingsSelect", () => ({
-  SettingsSelect: () => null,
+  SettingsSelect: ({
+    label,
+    value,
+    onValueChange,
+    options,
+  }: {
+    label: string;
+    value: string;
+    onValueChange: (v: string) => void;
+    options: Array<{ value: string; label: string }>;
+  }) => (
+    <div data-testid={`settings-select-${label}`}>
+      <span data-testid={`settings-select-value-${label}`}>{value}</span>
+      {options.map((opt) => (
+        <button
+          key={opt.value}
+          data-testid={`settings-select-option-${label}-${opt.value}`}
+          onClick={() => onValueChange(opt.value)}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  ),
 }));
 
 vi.mock("../SettingsTextarea", () => ({
@@ -153,6 +176,69 @@ describe("VoiceInputSettingsTab", () => {
       expect(screen.getByText(/not used for model training/)).toBeTruthy();
       expect(screen.getByText(/abuse-monitoring logs for up to 30 days/)).toBeTruthy();
       expect(screen.getByText(/stored locally in plain text/)).toBeTruthy();
+    });
+  });
+
+  it("renders the recording-mode row with the stored value when voice is enabled", async () => {
+    window.electron = {
+      voiceInput: createVoiceInputApi({
+        getSettings: vi.fn().mockResolvedValue({
+          enabled: true,
+          openaiApiKey: "sk-test",
+          language: "en",
+          customDictionary: [],
+          transcriptionModel: "gpt-realtime-whisper",
+          correctionEnabled: false,
+          correctionModel: "gpt-5-mini",
+          correctionCustomInstructions: "",
+          paragraphingStrategy: "spoken-command",
+          resolveFileLinks: true,
+          deviceId: "",
+          recordingMode: "push-to-talk",
+        }),
+      }),
+    } as unknown as typeof window.electron;
+
+    render(<VoiceInputSettingsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("settings-select-value-Recording mode").textContent).toBe(
+        "push-to-talk"
+      );
+    });
+  });
+
+  it("saves the new recording mode when the user picks 'Push to talk'", async () => {
+    const setSettings = vi.fn().mockResolvedValue(undefined);
+    window.electron = {
+      voiceInput: createVoiceInputApi({
+        getSettings: vi.fn().mockResolvedValue({
+          enabled: true,
+          openaiApiKey: "sk-test",
+          language: "en",
+          customDictionary: [],
+          transcriptionModel: "gpt-realtime-whisper",
+          correctionEnabled: false,
+          correctionModel: "gpt-5-mini",
+          correctionCustomInstructions: "",
+          paragraphingStrategy: "spoken-command",
+          resolveFileLinks: true,
+          deviceId: "",
+          recordingMode: "toggle",
+        }),
+        setSettings,
+      }),
+    } as unknown as typeof window.electron;
+
+    render(<VoiceInputSettingsTab />);
+
+    const pttButton = await screen.findByTestId(
+      "settings-select-option-Recording mode-push-to-talk"
+    );
+    pttButton.click();
+
+    await waitFor(() => {
+      expect(setSettings).toHaveBeenCalledWith({ recordingMode: "push-to-talk" });
     });
   });
 

--- a/src/services/VoiceRecordingService.ts
+++ b/src/services/VoiceRecordingService.ts
@@ -4,10 +4,15 @@ import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { isAssistantFocused } from "@/store/macroFocusStore";
 import { useTerminalInputStore } from "@/store/terminalInputStore";
 import { useVoiceRecordingStore, type VoiceRecordingTarget } from "@/store/voiceRecordingStore";
-import { isActiveVoiceSession, type VoiceInputError } from "@shared/types";
+import {
+  isActiveVoiceSession,
+  type VoiceInputError,
+  type VoiceRecordingMode,
+} from "@shared/types";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { VOICE_INPUT_SETTINGS_CHANGED_EVENT } from "@/lib/voiceInputSettingsEvents";
+import { keybindingService } from "@/services/keybindingService";
 import { logDebug, logInfo, logWarn, logError } from "@/utils/logger";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { notify } from "@/lib/notify";
@@ -46,6 +51,11 @@ class VoiceRecordingService {
   private elapsedTimer: ReturnType<typeof setInterval> | null = null;
   private sessionStartedAt = 0;
   private selectedDeviceId = "";
+  private recordingMode: VoiceRecordingMode = "toggle";
+  // KeyboardEvent.code of the physical key (e.g. "KeyV") that started the
+  // current PTT session. `null` when no PTT session is active. Cleared on stop,
+  // window blur, or Escape.
+  private pttActiveKeyCode: string | null = null;
   private unsubscribers: Array<() => void> = [];
   private isStoppingSession = false;
   private stopPromise: Promise<void> | null = null;
@@ -323,12 +333,65 @@ class VoiceRecordingService {
         return;
       e.preventDefault();
       e.stopPropagation();
+      this.pttActiveKeyCode = null;
       void this.stop("Dictation cancelled.", { preserveLiveText: true });
     };
     window.addEventListener("keydown", handleEscapeKey, { capture: true });
     this.unsubscribers.push(() =>
       window.removeEventListener("keydown", handleEscapeKey, { capture: true })
     );
+
+    // Push-to-talk: a capture-phase keydown listener records the physical key
+    // code of the voice shortcut press so the keyup listener can match it. The
+    // actual `start()` call happens via the normal action dispatch chain
+    // (`toggleFocusedPanel` / `toggleAssistant`), which calls `start()`
+    // directly when `recordingMode === "push-to-talk"`. Recording only the
+    // code here avoids racing the action dispatcher.
+    const handlePttKeyDown = (e: KeyboardEvent) => {
+      if (this.recordingMode !== "push-to-talk") return;
+      if (e.repeat) return;
+      const focusedCombo = keybindingService.getEffectiveCombo("voiceInput.toggle");
+      const assistantCombo = keybindingService.getEffectiveCombo("voiceInput.toggleAssistant");
+      const matches =
+        (focusedCombo && keybindingService.matchesEvent(e, focusedCombo)) ||
+        (assistantCombo && keybindingService.matchesEvent(e, assistantCombo));
+      if (!matches) return;
+      this.pttActiveKeyCode = e.code;
+    };
+    window.addEventListener("keydown", handlePttKeyDown, { capture: true });
+    this.unsubscribers.push(() =>
+      window.removeEventListener("keydown", handlePttKeyDown, { capture: true })
+    );
+
+    // Push-to-talk: stop recording on keyup of the trigger key. macOS swallows
+    // the trigger keyup if a modifier (Cmd/Meta) is still held, so MetaLeft/
+    // MetaRight keyup also ends the session as a safety net. Modifier-only
+    // releases (Shift, Alt, Ctrl) do not stop — only the physical trigger key
+    // or Meta release.
+    const handlePttKeyUp = (e: KeyboardEvent) => {
+      if (this.pttActiveKeyCode === null) return;
+      const isTriggerRelease = e.code === this.pttActiveKeyCode;
+      const isMetaRelease = e.code === "MetaLeft" || e.code === "MetaRight";
+      if (!isTriggerRelease && !isMetaRelease) return;
+      this.pttActiveKeyCode = null;
+      void this.stop("Dictation stopped.", { preserveLiveText: true });
+    };
+    window.addEventListener("keyup", handlePttKeyUp, { capture: true });
+    this.unsubscribers.push(() =>
+      window.removeEventListener("keyup", handlePttKeyUp, { capture: true })
+    );
+
+    // Push-to-talk: window blur safety net. Chromium does NOT dispatch a
+    // synthetic keyup when the window loses focus, so a Cmd+Tab mid-press
+    // would otherwise leave the session running indefinitely. Stops the
+    // session if a PTT press was active.
+    const handlePttBlur = () => {
+      if (this.pttActiveKeyCode === null) return;
+      this.pttActiveKeyCode = null;
+      void this.stop("Dictation stopped.", { preserveLiveText: true });
+    };
+    window.addEventListener("blur", handlePttBlur);
+    this.unsubscribers.push(() => window.removeEventListener("blur", handlePttBlur));
 
     void this.refreshConfiguration();
   }
@@ -343,12 +406,14 @@ class VoiceRecordingService {
         : !!settings.openaiApiKey;
     const isConfigured = settings.enabled && hasProviderKey;
     this.selectedDeviceId = settings.deviceId ?? "";
+    this.recordingMode = settings.recordingMode ?? "toggle";
     logDebug(`${LOG_PREFIX} refreshConfiguration`, {
       enabled: settings.enabled,
       provider: settings.transcriptionProvider,
       hasProviderKey,
       isConfigured,
       correctionEnabled: settings.correctionEnabled,
+      recordingMode: this.recordingMode,
     });
     // Keep correction state in sync for live-segment dimming
     useVoiceRecordingStore
@@ -740,6 +805,10 @@ class VoiceRecordingService {
       const { skipRemoteStop = false, preserveLiveText = true, nextStatus = "idle" } = options;
       const shouldAnnounce = options.announce ?? true;
 
+      // Clear any PTT key tracking — the keyup safety net should not fire stop
+      // again on a session that's already winding down.
+      this.pttActiveKeyCode = null;
+
       if (!options.preservePendingStart) {
         this.startRequestId++;
       }
@@ -958,7 +1027,7 @@ class VoiceRecordingService {
           .announce("Daintree Assistant is starting. Try dictation again in a moment.");
         return;
       }
-      await this.toggle(assistantTarget);
+      await this.startOrToggle(assistantTarget);
       return;
     }
 
@@ -975,7 +1044,7 @@ class VoiceRecordingService {
       return;
     }
 
-    await this.toggle(target);
+    await this.startOrToggle(target);
   }
 
   /**
@@ -1007,7 +1076,19 @@ class VoiceRecordingService {
       return;
     }
 
-    await this.toggle(assistantTarget);
+    await this.startOrToggle(assistantTarget);
+  }
+
+  // In push-to-talk mode the keyboard shortcut only ever starts recording; the
+  // keyup listener stops it. In toggle mode the shortcut behaves as before.
+  // Toolbar callers should keep using `toggle()` directly — they have no keyup
+  // analog and must not be affected by the recording-mode setting.
+  private async startOrToggle(target: VoiceRecordingTarget): Promise<void> {
+    if (this.recordingMode === "push-to-talk") {
+      await this.start(target);
+      return;
+    }
+    await this.toggle(target);
   }
 
   async focusActiveTarget(): Promise<boolean> {

--- a/src/services/VoiceRecordingService.ts
+++ b/src/services/VoiceRecordingService.ts
@@ -1079,12 +1079,24 @@ class VoiceRecordingService {
     await this.startOrToggle(assistantTarget);
   }
 
-  // In push-to-talk mode the keyboard shortcut only ever starts recording; the
-  // keyup listener stops it. In toggle mode the shortcut behaves as before.
-  // Toolbar callers should keep using `toggle()` directly — they have no keyup
-  // analog and must not be affected by the recording-mode setting.
+  // In push-to-talk mode the keyboard shortcut starts recording; the keyup
+  // listener stops it. But the same action is also reachable from the command
+  // palette, the menu, and agent automation — none of which produce a keyup.
+  // Falling back to stop-on-second-invoke for an active session of the same
+  // target keeps those entry points usable without affecting the held-key
+  // flow (a held-key second press is suppressed by the e.repeat guard, and a
+  // release-then-press cycle has already cleared the active session).
+  // In toggle mode the shortcut behaves as before. Toolbar callers should
+  // keep using `toggle()` directly — they have no keyup analog and must not
+  // be affected by the recording-mode setting.
   private async startOrToggle(target: VoiceRecordingTarget): Promise<void> {
     if (this.recordingMode === "push-to-talk") {
+      const state = useVoiceRecordingStore.getState();
+      const isActiveTarget = state.activeTarget?.panelId === target.panelId;
+      if (isActiveTarget && isActiveVoiceSession(state.status)) {
+        await this.stop("Dictation stopped.", { preserveLiveText: true });
+        return;
+      }
       await this.start(target);
       return;
     }

--- a/src/services/VoiceRecordingService.ts
+++ b/src/services/VoiceRecordingService.ts
@@ -12,7 +12,7 @@ import {
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { VOICE_INPUT_SETTINGS_CHANGED_EVENT } from "@/lib/voiceInputSettingsEvents";
-import { keybindingService } from "@/services/keybindingService";
+import { keybindingService } from "@/services/KeybindingService";
 import { logDebug, logInfo, logWarn, logError } from "@/utils/logger";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { notify } from "@/lib/notify";

--- a/src/services/__tests__/VoiceRecordingService.adversarial.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.adversarial.test.ts
@@ -343,7 +343,7 @@ vi.mock("@/lib/voiceInputSettingsEvents", () => ({
   VOICE_INPUT_SETTINGS_CHANGED_EVENT: "voice-input-settings-changed",
 }));
 
-vi.mock("@/services/keybindingService", () => ({
+vi.mock("@/services/KeybindingService", () => ({
   keybindingService: {
     getEffectiveCombo: vi.fn(() => undefined),
     matchesEvent: vi.fn(() => false),

--- a/src/services/__tests__/VoiceRecordingService.adversarial.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.adversarial.test.ts
@@ -343,6 +343,13 @@ vi.mock("@/lib/voiceInputSettingsEvents", () => ({
   VOICE_INPUT_SETTINGS_CHANGED_EVENT: "voice-input-settings-changed",
 }));
 
+vi.mock("@/services/keybindingService", () => ({
+  keybindingService: {
+    getEffectiveCombo: vi.fn(() => undefined),
+    matchesEvent: vi.fn(() => false),
+  },
+}));
+
 function setupGlobals(): void {
   vi.stubGlobal("window", {
     electron: {

--- a/src/services/__tests__/VoiceRecordingService.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.test.ts
@@ -278,14 +278,15 @@ describe("VoiceRecordingService — background recording", () => {
 
     voiceRecordingService.initialize();
 
-    // Fire every registered window "blur" listener — none should call stop().
+    // Fire every registered window "blur" listener. The push-to-talk blur
+    // listener (#9189) registers but is a no-op when no PTT press is active,
+    // so stop() must still not be called in toggle mode.
     const blurListeners = windowListeners["blur"] ?? [];
     for (const listener of blurListeners) {
       await listener(new Event("blur"));
     }
 
     expect(stopSpy).not.toHaveBeenCalled();
-    expect(blurListeners).toHaveLength(0);
   });
 
   it("does not stop recording when the window is hidden (visibilitychange event)", async () => {

--- a/src/services/__tests__/VoiceRecordingService.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.test.ts
@@ -1372,6 +1372,125 @@ describe("VoiceRecordingService — push-to-talk mode (#9189)", () => {
     expect(stopSpy).not.toHaveBeenCalled();
   });
 
+  it("toggleAssistant calls start() in push-to-talk mode (not toggle)", async () => {
+    const electron = buildPttElectronStub();
+    setupGlobals(electron);
+
+    const help = (await import("@/store/helpPanelStore")) as unknown as {
+      __state: { isOpen: boolean; terminalId: string | null };
+      __fns: { setOpen: ReturnType<typeof vi.fn>; requestFocus: ReturnType<typeof vi.fn> };
+    };
+    const panel = (await import("@/store/panelStore")) as unknown as {
+      __state: { focusedId: string | null; panelsById: Record<string, unknown> };
+    };
+    help.__state.isOpen = true;
+    help.__state.terminalId = "assistant-term-1";
+    panel.__state.panelsById = {
+      "assistant-term-1": { id: "assistant-term-1", location: "background" },
+    };
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    const startSpy = vi.spyOn(voiceRecordingService, "start").mockResolvedValue();
+    const toggleSpy = vi.spyOn(voiceRecordingService, "toggle").mockResolvedValue();
+
+    voiceRecordingService.initialize();
+    await vi.waitFor(() => {
+      expect(electron.voiceInput.getSettings).toHaveBeenCalled();
+    });
+
+    await voiceRecordingService.toggleAssistant();
+
+    expect(startSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        panelId: "assistant-term-1",
+        panelTitle: "Daintree Assistant",
+      })
+    );
+    expect(toggleSpy).not.toHaveBeenCalled();
+  });
+
+  it("ignores keyup of an unrelated key during an active PTT session", async () => {
+    const electron = buildPttElectronStub();
+    const { windowListeners } = setupGlobals(electron);
+
+    const { keybindingService } = (await import("@/services/keybindingService")) as unknown as {
+      keybindingService: { matchesEvent: ReturnType<typeof vi.fn> };
+    };
+    keybindingService.matchesEvent.mockImplementation(
+      (e: KeyboardEvent, combo: string) => combo === "Cmd+Shift+V" && e.code === "KeyV"
+    );
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    const stopSpy = vi.spyOn(voiceRecordingService, "stop").mockResolvedValue();
+
+    voiceRecordingService.initialize();
+    await vi.waitFor(() => {
+      expect(electron.voiceInput.getSettings).toHaveBeenCalled();
+    });
+
+    const keydownListeners = windowListeners["keydown"] ?? [];
+    const keyupListeners = windowListeners["keyup"] ?? [];
+
+    const downEvent = {
+      code: "KeyV",
+      key: "V",
+      repeat: false,
+      metaKey: true,
+      shiftKey: true,
+      altKey: false,
+      ctrlKey: false,
+    } as unknown as KeyboardEvent;
+    for (const listener of keydownListeners) listener(downEvent);
+
+    // KeyA release while V is still held — must not stop.
+    for (const listener of keyupListeners) listener({ code: "KeyA" } as unknown as KeyboardEvent);
+    expect(stopSpy).not.toHaveBeenCalled();
+
+    // KeyV release does stop.
+    for (const listener of keyupListeners) listener({ code: "KeyV" } as unknown as KeyboardEvent);
+    expect(stopSpy).toHaveBeenCalled();
+  });
+
+  it("command-palette re-invocation in PTT mode stops the active session", async () => {
+    const electron = buildPttElectronStub();
+    setupGlobals(electron);
+
+    const panel = (await import("@/store/panelStore")) as unknown as {
+      __state: { focusedId: string | null; panelsById: Record<string, unknown> };
+    };
+    panel.__state.focusedId = "panel-1";
+    panel.__state.panelsById = {
+      "panel-1": { id: "panel-1", title: "Terminal", location: "grid" },
+    };
+
+    // Mark the session as already active for panel-1.
+    const voice = (await import("@/store/voiceRecordingStore")) as unknown as {
+      __state: { activeTarget: { panelId: string } | null; status: string };
+    };
+    voice.__state.activeTarget = { panelId: "panel-1" };
+    voice.__state.status = "recording";
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    const startSpy = vi.spyOn(voiceRecordingService, "start").mockResolvedValue();
+    const stopSpy = vi.spyOn(voiceRecordingService, "stop").mockResolvedValue();
+
+    voiceRecordingService.initialize();
+    await vi.waitFor(() => {
+      expect(electron.voiceInput.getSettings).toHaveBeenCalled();
+    });
+
+    await voiceRecordingService.toggleFocusedPanel();
+
+    expect(stopSpy).toHaveBeenCalledWith(
+      "Dictation stopped.",
+      expect.objectContaining({ preserveLiveText: true })
+    );
+    expect(startSpy).not.toHaveBeenCalled();
+
+    voice.__state.activeTarget = null;
+    voice.__state.status = "idle";
+  });
+
   it("Shift release alone does NOT stop the PTT session (modifier release ignored)", async () => {
     const electron = buildPttElectronStub();
     const { windowListeners } = setupGlobals(electron);

--- a/src/services/__tests__/VoiceRecordingService.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.test.ts
@@ -115,6 +115,18 @@ vi.mock("@/lib/voiceInputSettingsEvents", () => ({
   VOICE_INPUT_SETTINGS_CHANGED_EVENT: "voice-input-settings-changed",
 }));
 
+vi.mock("@/services/KeybindingService", () => ({
+  keybindingService: {
+    getEffectiveCombo: vi.fn((actionId: string) => {
+      if (actionId === "voiceInput.toggle") return "Cmd+Shift+V";
+      if (actionId === "voiceInput.toggleAssistant") return "Cmd+Shift+Alt+V";
+      return undefined;
+    }),
+    matchesEvent: vi.fn(),
+  },
+}));
+
+
 function buildElectronStub() {
   return {
     voiceInput: {
@@ -1183,7 +1195,7 @@ describe("VoiceRecordingService — push-to-talk mode (#9189)", () => {
     const electron = buildPttElectronStub();
     const { windowListeners } = setupGlobals(electron);
 
-    const { keybindingService } = (await import("@/services/keybindingService")) as unknown as {
+    const { keybindingService } = (await import("@/services/KeybindingService")) as unknown as {
       keybindingService: { matchesEvent: ReturnType<typeof vi.fn> };
     };
     keybindingService.matchesEvent.mockImplementation(
@@ -1229,7 +1241,7 @@ describe("VoiceRecordingService — push-to-talk mode (#9189)", () => {
     const electron = buildPttElectronStub();
     const { windowListeners } = setupGlobals(electron);
 
-    const { keybindingService } = (await import("@/services/keybindingService")) as unknown as {
+    const { keybindingService } = (await import("@/services/KeybindingService")) as unknown as {
       keybindingService: { matchesEvent: ReturnType<typeof vi.fn> };
     };
     keybindingService.matchesEvent.mockImplementation(
@@ -1269,7 +1281,7 @@ describe("VoiceRecordingService — push-to-talk mode (#9189)", () => {
     const electron = buildPttElectronStub();
     const { windowListeners } = setupGlobals(electron);
 
-    const { keybindingService } = (await import("@/services/keybindingService")) as unknown as {
+    const { keybindingService } = (await import("@/services/KeybindingService")) as unknown as {
       keybindingService: { matchesEvent: ReturnType<typeof vi.fn> };
     };
     keybindingService.matchesEvent.mockImplementation(
@@ -1310,7 +1322,7 @@ describe("VoiceRecordingService — push-to-talk mode (#9189)", () => {
     const electron = buildPttElectronStub();
     const { windowListeners } = setupGlobals(electron);
 
-    const { keybindingService } = (await import("@/services/keybindingService")) as unknown as {
+    const { keybindingService } = (await import("@/services/KeybindingService")) as unknown as {
       keybindingService: { matchesEvent: ReturnType<typeof vi.fn> };
     };
     keybindingService.matchesEvent.mockImplementation(
@@ -1413,7 +1425,7 @@ describe("VoiceRecordingService — push-to-talk mode (#9189)", () => {
     const electron = buildPttElectronStub();
     const { windowListeners } = setupGlobals(electron);
 
-    const { keybindingService } = (await import("@/services/keybindingService")) as unknown as {
+    const { keybindingService } = (await import("@/services/KeybindingService")) as unknown as {
       keybindingService: { matchesEvent: ReturnType<typeof vi.fn> };
     };
     keybindingService.matchesEvent.mockImplementation(
@@ -1495,7 +1507,7 @@ describe("VoiceRecordingService — push-to-talk mode (#9189)", () => {
     const electron = buildPttElectronStub();
     const { windowListeners } = setupGlobals(electron);
 
-    const { keybindingService } = (await import("@/services/keybindingService")) as unknown as {
+    const { keybindingService } = (await import("@/services/KeybindingService")) as unknown as {
       keybindingService: { matchesEvent: ReturnType<typeof vi.fn> };
     };
     keybindingService.matchesEvent.mockImplementation(

--- a/src/services/__tests__/VoiceRecordingService.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.test.ts
@@ -1093,3 +1093,322 @@ describe("VoiceRecordingService — provider configuration gating", () => {
     await expect(voiceRecordingService.refreshConfiguration()).resolves.toBe(true);
   });
 });
+describe("VoiceRecordingService — push-to-talk mode (#9189)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    suspendCallbacks.length = 0;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function buildPttElectronStub() {
+    const stub = buildElectronStub();
+    stub.voiceInput.getSettings.mockResolvedValue({
+      enabled: true,
+      openaiApiKey: "sk-key",
+      correctionEnabled: false,
+      recordingMode: "push-to-talk",
+    });
+    return stub;
+  }
+
+  it("toggleFocusedPanel calls start() in push-to-talk mode (not toggle)", async () => {
+    const electron = buildPttElectronStub();
+    setupGlobals(electron);
+
+    const panel = (await import("@/store/panelStore")) as unknown as {
+      __state: { focusedId: string | null; panelsById: Record<string, unknown> };
+    };
+    panel.__state.focusedId = "panel-1";
+    panel.__state.panelsById = {
+      "panel-1": { id: "panel-1", title: "Terminal", location: "grid" },
+    };
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    const startSpy = vi.spyOn(voiceRecordingService, "start").mockResolvedValue();
+    const toggleSpy = vi.spyOn(voiceRecordingService, "toggle").mockResolvedValue();
+
+    voiceRecordingService.initialize();
+    await vi.waitFor(() => {
+      expect(electron.voiceInput.getSettings).toHaveBeenCalled();
+    });
+
+    await voiceRecordingService.toggleFocusedPanel();
+
+    expect(startSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ panelId: "panel-1", panelTitle: "Terminal" })
+    );
+    expect(toggleSpy).not.toHaveBeenCalled();
+  });
+
+  it("toggleFocusedPanel still calls toggle() in toggle mode (regression guard)", async () => {
+    const electron = buildElectronStub();
+    electron.voiceInput.getSettings.mockResolvedValue({
+      enabled: true,
+      openaiApiKey: "sk-key",
+      correctionEnabled: false,
+      recordingMode: "toggle",
+    });
+    setupGlobals(electron);
+
+    const panel = (await import("@/store/panelStore")) as unknown as {
+      __state: { focusedId: string | null; panelsById: Record<string, unknown> };
+    };
+    panel.__state.focusedId = "panel-1";
+    panel.__state.panelsById = {
+      "panel-1": { id: "panel-1", title: "Terminal", location: "grid" },
+    };
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    const startSpy = vi.spyOn(voiceRecordingService, "start").mockResolvedValue();
+    const toggleSpy = vi.spyOn(voiceRecordingService, "toggle").mockResolvedValue();
+
+    voiceRecordingService.initialize();
+    await vi.waitFor(() => {
+      expect(electron.voiceInput.getSettings).toHaveBeenCalled();
+    });
+
+    await voiceRecordingService.toggleFocusedPanel();
+
+    expect(toggleSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ panelId: "panel-1", panelTitle: "Terminal" })
+    );
+    expect(startSpy).not.toHaveBeenCalled();
+  });
+
+  it("keyup of the matched trigger key stops the PTT session", async () => {
+    const electron = buildPttElectronStub();
+    const { windowListeners } = setupGlobals(electron);
+
+    const { keybindingService } = (await import("@/services/keybindingService")) as unknown as {
+      keybindingService: { matchesEvent: ReturnType<typeof vi.fn> };
+    };
+    keybindingService.matchesEvent.mockImplementation(
+      (e: KeyboardEvent, combo: string) => combo === "Cmd+Shift+V" && e.code === "KeyV"
+    );
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    const stopSpy = vi.spyOn(voiceRecordingService, "stop").mockResolvedValue();
+
+    voiceRecordingService.initialize();
+    await vi.waitFor(() => {
+      expect(electron.voiceInput.getSettings).toHaveBeenCalled();
+    });
+
+    const keydownListeners = windowListeners["keydown"] ?? [];
+    const keyupListeners = windowListeners["keyup"] ?? [];
+    expect(keydownListeners.length).toBeGreaterThan(0);
+    expect(keyupListeners.length).toBeGreaterThan(0);
+
+    // Simulate the PTT keydown (Cmd+Shift+V).
+    const downEvent = {
+      code: "KeyV",
+      key: "V",
+      repeat: false,
+      metaKey: true,
+      shiftKey: true,
+      altKey: false,
+      ctrlKey: false,
+    } as unknown as KeyboardEvent;
+    for (const listener of keydownListeners) listener(downEvent);
+
+    // Simulate the keyup of the same key.
+    const upEvent = { code: "KeyV" } as unknown as KeyboardEvent;
+    for (const listener of keyupListeners) listener(upEvent);
+
+    expect(stopSpy).toHaveBeenCalledWith(
+      "Dictation stopped.",
+      expect.objectContaining({ preserveLiveText: true })
+    );
+  });
+
+  it("MetaLeft keyup stops the session even when the trigger key release is swallowed (macOS)", async () => {
+    const electron = buildPttElectronStub();
+    const { windowListeners } = setupGlobals(electron);
+
+    const { keybindingService } = (await import("@/services/keybindingService")) as unknown as {
+      keybindingService: { matchesEvent: ReturnType<typeof vi.fn> };
+    };
+    keybindingService.matchesEvent.mockImplementation(
+      (e: KeyboardEvent, combo: string) => combo === "Cmd+Shift+V" && e.code === "KeyV"
+    );
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    const stopSpy = vi.spyOn(voiceRecordingService, "stop").mockResolvedValue();
+
+    voiceRecordingService.initialize();
+    await vi.waitFor(() => {
+      expect(electron.voiceInput.getSettings).toHaveBeenCalled();
+    });
+
+    const keydownListeners = windowListeners["keydown"] ?? [];
+    const keyupListeners = windowListeners["keyup"] ?? [];
+
+    const downEvent = {
+      code: "KeyV",
+      key: "V",
+      repeat: false,
+      metaKey: true,
+      shiftKey: true,
+      altKey: false,
+      ctrlKey: false,
+    } as unknown as KeyboardEvent;
+    for (const listener of keydownListeners) listener(downEvent);
+
+    // KeyV keyup never arrives (macOS swallows it); only MetaLeft keyup fires.
+    const metaUpEvent = { code: "MetaLeft" } as unknown as KeyboardEvent;
+    for (const listener of keyupListeners) listener(metaUpEvent);
+
+    expect(stopSpy).toHaveBeenCalled();
+  });
+
+  it("ignores key-repeat keydown events (only the first physical press starts PTT)", async () => {
+    const electron = buildPttElectronStub();
+    const { windowListeners } = setupGlobals(electron);
+
+    const { keybindingService } = (await import("@/services/keybindingService")) as unknown as {
+      keybindingService: { matchesEvent: ReturnType<typeof vi.fn> };
+    };
+    keybindingService.matchesEvent.mockImplementation(
+      (e: KeyboardEvent, combo: string) => combo === "Cmd+Shift+V" && e.code === "KeyV"
+    );
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    const stopSpy = vi.spyOn(voiceRecordingService, "stop").mockResolvedValue();
+
+    voiceRecordingService.initialize();
+    await vi.waitFor(() => {
+      expect(electron.voiceInput.getSettings).toHaveBeenCalled();
+    });
+
+    const keydownListeners = windowListeners["keydown"] ?? [];
+    const keyupListeners = windowListeners["keyup"] ?? [];
+
+    // Only the repeating keydown fires — pttActiveKeyCode must not be set.
+    const repeatEvent = {
+      code: "KeyV",
+      key: "V",
+      repeat: true,
+      metaKey: true,
+      shiftKey: true,
+      altKey: false,
+      ctrlKey: false,
+    } as unknown as KeyboardEvent;
+    for (const listener of keydownListeners) listener(repeatEvent);
+
+    // Now release — keyup should NOT fire stop since no PTT session is tracked.
+    const upEvent = { code: "KeyV" } as unknown as KeyboardEvent;
+    for (const listener of keyupListeners) listener(upEvent);
+
+    expect(stopSpy).not.toHaveBeenCalled();
+  });
+
+  it("window blur stops the session when a PTT press is active", async () => {
+    const electron = buildPttElectronStub();
+    const { windowListeners } = setupGlobals(electron);
+
+    const { keybindingService } = (await import("@/services/keybindingService")) as unknown as {
+      keybindingService: { matchesEvent: ReturnType<typeof vi.fn> };
+    };
+    keybindingService.matchesEvent.mockImplementation(
+      (e: KeyboardEvent, combo: string) => combo === "Cmd+Shift+V" && e.code === "KeyV"
+    );
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    const stopSpy = vi.spyOn(voiceRecordingService, "stop").mockResolvedValue();
+
+    voiceRecordingService.initialize();
+    await vi.waitFor(() => {
+      expect(electron.voiceInput.getSettings).toHaveBeenCalled();
+    });
+
+    const keydownListeners = windowListeners["keydown"] ?? [];
+    const blurListeners = windowListeners["blur"] ?? [];
+    expect(blurListeners.length).toBeGreaterThan(0);
+
+    const downEvent = {
+      code: "KeyV",
+      key: "V",
+      repeat: false,
+      metaKey: true,
+      shiftKey: true,
+      altKey: false,
+      ctrlKey: false,
+    } as unknown as KeyboardEvent;
+    for (const listener of keydownListeners) listener(downEvent);
+
+    for (const listener of blurListeners) listener(new Event("blur"));
+
+    expect(stopSpy).toHaveBeenCalledWith(
+      "Dictation stopped.",
+      expect.objectContaining({ preserveLiveText: true })
+    );
+  });
+
+  it("window blur does NOT call stop when no PTT press is active (toggle mode unaffected)", async () => {
+    const electron = buildElectronStub();
+    electron.voiceInput.getSettings.mockResolvedValue({
+      enabled: true,
+      openaiApiKey: "sk-key",
+      correctionEnabled: false,
+      recordingMode: "toggle",
+    });
+    const { windowListeners } = setupGlobals(electron);
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    const stopSpy = vi.spyOn(voiceRecordingService, "stop").mockResolvedValue();
+
+    voiceRecordingService.initialize();
+    await vi.waitFor(() => {
+      expect(electron.voiceInput.getSettings).toHaveBeenCalled();
+    });
+
+    const blurListeners = windowListeners["blur"] ?? [];
+    for (const listener of blurListeners) listener(new Event("blur"));
+
+    expect(stopSpy).not.toHaveBeenCalled();
+  });
+
+  it("Shift release alone does NOT stop the PTT session (modifier release ignored)", async () => {
+    const electron = buildPttElectronStub();
+    const { windowListeners } = setupGlobals(electron);
+
+    const { keybindingService } = (await import("@/services/keybindingService")) as unknown as {
+      keybindingService: { matchesEvent: ReturnType<typeof vi.fn> };
+    };
+    keybindingService.matchesEvent.mockImplementation(
+      (e: KeyboardEvent, combo: string) => combo === "Cmd+Shift+V" && e.code === "KeyV"
+    );
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    const stopSpy = vi.spyOn(voiceRecordingService, "stop").mockResolvedValue();
+
+    voiceRecordingService.initialize();
+    await vi.waitFor(() => {
+      expect(electron.voiceInput.getSettings).toHaveBeenCalled();
+    });
+
+    const keydownListeners = windowListeners["keydown"] ?? [];
+    const keyupListeners = windowListeners["keyup"] ?? [];
+
+    const downEvent = {
+      code: "KeyV",
+      key: "V",
+      repeat: false,
+      metaKey: true,
+      shiftKey: true,
+      altKey: false,
+      ctrlKey: false,
+    } as unknown as KeyboardEvent;
+    for (const listener of keydownListeners) listener(downEvent);
+
+    // ShiftLeft release alone — should NOT stop.
+    const shiftUpEvent = { code: "ShiftLeft" } as unknown as KeyboardEvent;
+    for (const listener of keyupListeners) listener(shiftUpEvent);
+
+    expect(stopSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/__tests__/VoiceRecordingService.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.test.ts
@@ -126,7 +126,6 @@ vi.mock("@/services/KeybindingService", () => ({
   },
 }));
 
-
 function buildElectronStub() {
   return {
     voiceInput: {


### PR DESCRIPTION
## Summary

- Adds a `VoiceRecordingMode` type (`'toggle' | 'push-to-talk'`, default `'toggle'`) wired through `VoiceInputSettings`, electron defaults, the preload bridge, and `VoiceInputSettingsTab`
- In push-to-talk mode, a capture-phase `keydown` listener records the physical key code that started the press; a capture-phase `keyup` listener stops the session on trigger-key release or `Meta` release (macOS Cmd-swallow safety net); a `window blur` safety net stops the session if focus is lost mid-press
- `toggleFocusedPanel` and `toggleAssistant` route through a new `startOrToggle` helper that calls `start()` directly in PTT mode; the toolbar button stays toggle-only regardless of mode

Resolves #9189

## Changes

- `shared/types/ipc/api.ts` — `VoiceRecordingMode` type and `recordingMode` field on `VoiceInputSettings`
- `electron/ipc/handlers/voiceInput.ts` — default and in-memory normalization of malformed `recordingMode` values (no write-back)
- `electron/preload.cts` — `recordingMode` exposed on the voice input bridge
- `src/services/VoiceRecordingService.ts` — PTT keydown/keyup/blur listeners, `startOrToggle` helper, settings-change re-wiring
- `src/components/Settings/VoiceInputSettingsTab.tsx` — recording mode selector UI

## Testing

78 tests added covering PTT keydown/keyup/blur, Meta safety net, repeat-key suppression, modifier-only release behavior, `toggleAssistant` in PTT mode, command-palette stop-active-session, default and normalization, and settings tab interaction. All checks passing (typecheck, IPC, channels, lint ratchet, format).