### PR TITLE
feat(portal): viewport-aware width restore and richer resize separator

### DIFF
--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -427,6 +427,7 @@ export {
   PORTAL_MIN_WIDTH,
   PORTAL_MAX_WIDTH,
   PORTAL_DEFAULT_WIDTH,
+  PORTAL_MIN_EDITOR_WIDTH,
 } from "./portal.js";
 
 // Voice types - canonical phase model for voice session and transcript lifecycle

--- a/shared/types/portal.ts
+++ b/shared/types/portal.ts
@@ -118,3 +118,7 @@ export const DEFAULT_PORTAL_TABS: PortalTab[] = [];
 export const PORTAL_MIN_WIDTH = 320;
 export const PORTAL_MAX_WIDTH = 1200;
 export const PORTAL_DEFAULT_WIDTH = 480;
+// Minimum editor canvas width preserved when restoring a persisted portal
+// width on launch. If the saved width would shrink the editor below this on
+// the current viewport, the portal falls back to a viewport-safe size.
+export const PORTAL_MIN_EDITOR_WIDTH = 400;

--- a/src/components/Portal/PortalDock.tsx
+++ b/src/components/Portal/PortalDock.tsx
@@ -381,7 +381,7 @@ export function PortalDock() {
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       const step = e.shiftKey ? RESIZE_STEP_COARSE : RESIZE_STEP_FINE;
-      let nextWidth: number | null = null;
+      let nextWidth: number;
       switch (e.key) {
         case "ArrowLeft":
           nextWidth = width + step;

--- a/src/components/Portal/PortalDock.tsx
+++ b/src/components/Portal/PortalDock.tsx
@@ -8,7 +8,12 @@ import { PortalLaunchpad } from "./PortalLaunchpad";
 import { DevServerDashboard } from "./DevServerDashboard";
 import { PortalTabSkeleton } from "./PortalTabSkeleton";
 import { useSkeletonGate, useSkeletonFloor } from "@/hooks/useDeferredLoading";
-import { PORTAL_MIN_WIDTH, PORTAL_MAX_WIDTH } from "@shared/types";
+import {
+  PORTAL_MIN_WIDTH,
+  PORTAL_MAX_WIDTH,
+  PORTAL_DEFAULT_WIDTH,
+  PORTAL_MIN_EDITOR_WIDTH,
+} from "@shared/types";
 import { getAIAgentInfo } from "@/lib/aiAgentDetection";
 import { useKeybindingScope } from "@/hooks/useKeybinding";
 import { useMacroFocusStore } from "@/store/macroFocusStore";
@@ -320,10 +325,16 @@ export function PortalDock() {
     }
   }, []);
 
-  const RESIZE_STEP = 10;
+  const RESIZE_STEP_FINE = 10;
+  const RESIZE_STEP_COARSE = 50;
 
   const handleResizeStart = useCallback(
     (e: React.MouseEvent) => {
+      // Skip the second mousedown of a double-click. The browser fires
+      // mousedown twice before dblclick, so a propagation/preventDefault
+      // tweak inside the dblclick handler is too late — the drag has
+      // already started. See lesson #4997.
+      if (e.detail > 1) return;
       e.preventDefault();
       setIsResizing(true);
       const startX = e.clientX;
@@ -352,20 +363,60 @@ export function PortalDock() {
     [width, setWidth]
   );
 
+  const handleResizeDoubleClick = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    void actionService.dispatch("portal.resetWidth", undefined, { source: "user" });
+  }, []);
+
+  // Right-anchored dock: ArrowLeft widens, ArrowRight narrows. Home/End and
+  // Shift+Arrow follow the WAI-ARIA APG window-splitter pattern (Home/End)
+  // plus the common IDE convention of a coarse step under Shift.
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === "ArrowLeft") {
-        e.preventDefault();
-        const newWidth = Math.min(width + RESIZE_STEP, PORTAL_MAX_WIDTH);
-        setWidth(newWidth);
-      } else if (e.key === "ArrowRight") {
-        e.preventDefault();
-        const newWidth = Math.max(width - RESIZE_STEP, PORTAL_MIN_WIDTH);
-        setWidth(newWidth);
+      const step = e.shiftKey ? RESIZE_STEP_COARSE : RESIZE_STEP_FINE;
+      let nextWidth: number | null = null;
+      switch (e.key) {
+        case "ArrowLeft":
+          nextWidth = width + step;
+          break;
+        case "ArrowRight":
+          nextWidth = width - step;
+          break;
+        case "Home":
+          nextWidth = PORTAL_MIN_WIDTH;
+          break;
+        case "End":
+          nextWidth = PORTAL_MAX_WIDTH;
+          break;
+        default:
+          return;
       }
+      e.preventDefault();
+      setWidth(Math.min(Math.max(nextWidth, PORTAL_MIN_WIDTH), PORTAL_MAX_WIDTH));
     },
     [width, setWidth]
   );
+
+  // One-time viewport clamp on mount. The zustand persist `merge` callback
+  // can't safely read window.innerWidth — Electron's BrowserWindow boots with
+  // `show: false`, so innerWidth is 0 during synchronous hydration and every
+  // restore would fall back to the default. Running after layout in a mount
+  // effect avoids that. Only writes when the persisted width would crowd the
+  // editor below PORTAL_MIN_EDITOR_WIDTH on the current viewport.
+  const didClampRestoredWidthRef = useRef(false);
+  useEffect(() => {
+    if (didClampRestoredWidthRef.current) return;
+    didClampRestoredWidthRef.current = true;
+    const vw = window.innerWidth;
+    if (vw <= 0) return;
+    const safeMax = Math.max(
+      PORTAL_MIN_WIDTH,
+      Math.min(PORTAL_MAX_WIDTH, vw - PORTAL_MIN_EDITOR_WIDTH)
+    );
+    const currentWidth = usePortalStore.getState().width;
+    if (currentWidth <= safeMax) return;
+    setWidth(Math.min(PORTAL_DEFAULT_WIDTH, safeMax));
+  }, [setWidth]);
 
   useEffect(() => {
     return () => {
@@ -430,6 +481,7 @@ export function PortalDock() {
               isResizing && "bg-overlay-medium"
             )}
             onMouseDown={handleResizeStart}
+            onDoubleClick={handleResizeDoubleClick}
             onKeyDown={handleKeyDown}
           >
             <div

--- a/src/components/Portal/PortalDock.tsx
+++ b/src/components/Portal/PortalDock.tsx
@@ -328,6 +328,12 @@ export function PortalDock() {
   const RESIZE_STEP_FINE = 10;
   const RESIZE_STEP_COARSE = 50;
 
+  // Holds the cleanup for an active drag so the unmount effect can drop the
+  // document listeners if the dock tears down mid-drag. Without this the
+  // listeners outlive the component (the closure keeps writing through
+  // setWidth, which still mutates the surviving Zustand store).
+  const dragCleanupRef = useRef<(() => void) | null>(null);
+
   const handleResizeStart = useCallback(
     (e: React.MouseEvent) => {
       // Skip the second mousedown of a double-click. The browser fires
@@ -347,18 +353,19 @@ export function PortalDock() {
       };
 
       const handleMouseUp = () => {
+        cleanup();
+      };
+
+      const cleanup = () => {
         setIsResizing(false);
         document.removeEventListener("mousemove", handleMouseMove);
         document.removeEventListener("mouseup", handleMouseUp);
+        dragCleanupRef.current = null;
       };
 
       document.addEventListener("mousemove", handleMouseMove);
       document.addEventListener("mouseup", handleMouseUp);
-
-      return () => {
-        document.removeEventListener("mousemove", handleMouseMove);
-        document.removeEventListener("mouseup", handleMouseUp);
-      };
+      dragCleanupRef.current = cleanup;
     },
     [width, setWidth]
   );
@@ -406,9 +413,11 @@ export function PortalDock() {
   const didClampRestoredWidthRef = useRef(false);
   useEffect(() => {
     if (didClampRestoredWidthRef.current) return;
-    didClampRestoredWidthRef.current = true;
     const vw = window.innerWidth;
+    // vw can legitimately be 0 during early hydration — bail without
+    // tripping the ref so the next mount attempt can still clamp.
     if (vw <= 0) return;
+    didClampRestoredWidthRef.current = true;
     const safeMax = Math.max(
       PORTAL_MIN_WIDTH,
       Math.min(PORTAL_MAX_WIDTH, vw - PORTAL_MIN_EDITOR_WIDTH)
@@ -421,6 +430,7 @@ export function PortalDock() {
   useEffect(() => {
     return () => {
       setIsResizing(false);
+      dragCleanupRef.current?.();
     };
   }, []);
 

--- a/src/components/Portal/__tests__/PortalDock.separator.test.tsx
+++ b/src/components/Portal/__tests__/PortalDock.separator.test.tsx
@@ -110,6 +110,26 @@ describe("PortalDock — resize separator", () => {
       expect(usePortalStore.getState().width).toBe(1100);
     });
 
+    it("still clamps on a second mount after an innerWidth=0 first mount", () => {
+      setViewportWidth(0);
+      act(() => {
+        usePortalStore.setState({ width: 1100 });
+      });
+
+      const view = render(<PortalDock />);
+      expect(usePortalStore.getState().width).toBe(1100);
+      view.unmount();
+
+      // Window is now visible — the next PortalDock mount should clamp.
+      setViewportWidth(1366);
+      act(() => {
+        usePortalStore.setState({ width: 1100 });
+      });
+      render(<PortalDock />);
+
+      expect(usePortalStore.getState().width).toBe(PORTAL_DEFAULT_WIDTH);
+    });
+
     it("falls back to safeMax when the viewport is too small to fit the default width", () => {
       setViewportWidth(700);
       act(() => {
@@ -168,6 +188,25 @@ describe("PortalDock — resize separator", () => {
 
       // Dock is right-anchored: dragging left widens (delta = startX - clientX).
       expect(usePortalStore.getState().width).toBe(900);
+    });
+
+    it("drops document listeners if the dock unmounts mid-drag", () => {
+      act(() => {
+        usePortalStore.setState({ width: 800 });
+      });
+
+      const view = render(<PortalDock />);
+      fireEvent.mouseDown(getSeparator(), { clientX: 1000, detail: 1 });
+      // Confirm the drag is wired before unmount.
+      fireEvent.mouseMove(document, { clientX: 950 });
+      expect(usePortalStore.getState().width).toBe(850);
+
+      view.unmount();
+
+      // After unmount the listeners must be gone — further mousemoves on
+      // the document must not mutate the surviving store.
+      fireEvent.mouseMove(document, { clientX: 700 });
+      expect(usePortalStore.getState().width).toBe(850);
     });
   });
 

--- a/src/components/Portal/__tests__/PortalDock.separator.test.tsx
+++ b/src/components/Portal/__tests__/PortalDock.separator.test.tsx
@@ -1,0 +1,246 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import {
+  PORTAL_DEFAULT_WIDTH,
+  PORTAL_MAX_WIDTH,
+  PORTAL_MIN_EDITOR_WIDTH,
+  PORTAL_MIN_WIDTH,
+} from "@shared/types";
+
+const dispatchMock = vi.fn().mockResolvedValue({ ok: true });
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch: (...args: unknown[]) => dispatchMock(...args),
+  },
+}));
+
+// Heavy children pull in their own toolbars, links, and IPC plumbing. Stubs
+// keep this test focused on the separator behavior.
+vi.mock("../PortalToolbar", () => ({
+  PortalToolbar: () => null,
+}));
+vi.mock("../PortalLaunchpad", () => ({
+  PortalLaunchpad: () => null,
+}));
+vi.mock("../PortalTabSkeleton", () => ({
+  PortalTabSkeleton: () => null,
+}));
+
+import { PortalDock } from "../PortalDock";
+import { usePortalStore } from "@/store";
+
+function setViewportWidth(value: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+function getSeparator(): HTMLElement {
+  const el = document.querySelector('[role="separator"]');
+  if (!el) throw new Error("Resize separator not found");
+  return el as HTMLElement;
+}
+
+describe("PortalDock — resize separator", () => {
+  beforeEach(() => {
+    dispatchMock.mockReset();
+    dispatchMock.mockResolvedValue({ ok: true });
+
+    Object.defineProperty(window, "electron", {
+      configurable: true,
+      writable: true,
+      value: {
+        portal: {
+          onNavEvent: vi.fn(() => vi.fn()),
+          onNewTabMenuAction: vi.fn(() => vi.fn()),
+          onFocus: vi.fn(() => vi.fn()),
+          onBlur: vi.fn(() => vi.fn()),
+          resize: vi.fn(),
+        },
+      },
+    });
+
+    usePortalStore.getState().reset();
+    setViewportWidth(2000);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("viewport-aware width restore", () => {
+    it("clamps a persisted width that would crowd the editor below the safe threshold", () => {
+      setViewportWidth(1366);
+      act(() => {
+        usePortalStore.setState({ width: 1100 });
+      });
+
+      render(<PortalDock />);
+
+      // safeMax = min(1200, 1366-400) = 966; persisted 1100 > 966 → snap to
+      // min(default, safeMax) = min(480, 966) = 480.
+      expect(usePortalStore.getState().width).toBe(PORTAL_DEFAULT_WIDTH);
+    });
+
+    it("leaves an in-range persisted width untouched on mount", () => {
+      setViewportWidth(1366);
+      act(() => {
+        usePortalStore.setState({ width: 900 });
+      });
+
+      render(<PortalDock />);
+
+      // safeMax = 966; persisted 900 ≤ 966 → no write.
+      expect(usePortalStore.getState().width).toBe(900);
+    });
+
+    it("does not write when window.innerWidth is 0 (Electron pre-show race)", () => {
+      setViewportWidth(0);
+      act(() => {
+        usePortalStore.setState({ width: 1100 });
+      });
+
+      render(<PortalDock />);
+
+      expect(usePortalStore.getState().width).toBe(1100);
+    });
+
+    it("falls back to safeMax when the viewport is too small to fit the default width", () => {
+      setViewportWidth(700);
+      act(() => {
+        usePortalStore.setState({ width: 900 });
+      });
+
+      render(<PortalDock />);
+
+      // safeMax = max(PORTAL_MIN_WIDTH, min(1200, 700-400)) = max(320, 300) =
+      // 320; min(default, safeMax) = min(480, 320) = 320.
+      expect(usePortalStore.getState().width).toBe(PORTAL_MIN_WIDTH);
+    });
+  });
+
+  describe("double-click reset", () => {
+    it("dispatches portal.resetWidth on double-click", () => {
+      act(() => {
+        usePortalStore.setState({ width: 800 });
+      });
+
+      render(<PortalDock />);
+      fireEvent.doubleClick(getSeparator());
+
+      expect(dispatchMock).toHaveBeenCalledWith("portal.resetWidth", undefined, {
+        source: "user",
+      });
+    });
+
+    it("does not start a drag for the second mousedown of a double-click", () => {
+      act(() => {
+        usePortalStore.setState({ width: 800 });
+      });
+
+      render(<PortalDock />);
+      const separator = getSeparator();
+
+      // Second mousedown of a dblclick carries detail=2. If the guard fires,
+      // the document-level mousemove that follows must not move the width.
+      fireEvent.mouseDown(separator, { clientX: 1000, detail: 2 });
+      fireEvent.mouseMove(document, { clientX: 800 });
+
+      expect(usePortalStore.getState().width).toBe(800);
+    });
+
+    it("still starts a drag for a normal single mousedown (detail=1)", () => {
+      act(() => {
+        usePortalStore.setState({ width: 800 });
+      });
+
+      render(<PortalDock />);
+      const separator = getSeparator();
+
+      fireEvent.mouseDown(separator, { clientX: 1000, detail: 1 });
+      fireEvent.mouseMove(document, { clientX: 900 });
+      fireEvent.mouseUp(document);
+
+      // Dock is right-anchored: dragging left widens (delta = startX - clientX).
+      expect(usePortalStore.getState().width).toBe(900);
+    });
+  });
+
+  describe("keyboard handler", () => {
+    beforeEach(() => {
+      act(() => {
+        usePortalStore.setState({ width: 800 });
+      });
+    });
+
+    it("ArrowLeft widens by 10 (right-anchored dock)", () => {
+      render(<PortalDock />);
+      fireEvent.keyDown(getSeparator(), { key: "ArrowLeft" });
+      expect(usePortalStore.getState().width).toBe(810);
+    });
+
+    it("ArrowRight narrows by 10", () => {
+      render(<PortalDock />);
+      fireEvent.keyDown(getSeparator(), { key: "ArrowRight" });
+      expect(usePortalStore.getState().width).toBe(790);
+    });
+
+    it("Shift+ArrowLeft widens by the coarse step", () => {
+      render(<PortalDock />);
+      fireEvent.keyDown(getSeparator(), { key: "ArrowLeft", shiftKey: true });
+      expect(usePortalStore.getState().width).toBe(850);
+    });
+
+    it("Shift+ArrowRight narrows by the coarse step", () => {
+      render(<PortalDock />);
+      fireEvent.keyDown(getSeparator(), { key: "ArrowRight", shiftKey: true });
+      expect(usePortalStore.getState().width).toBe(750);
+    });
+
+    it("Home snaps to PORTAL_MIN_WIDTH", () => {
+      render(<PortalDock />);
+      fireEvent.keyDown(getSeparator(), { key: "Home" });
+      expect(usePortalStore.getState().width).toBe(PORTAL_MIN_WIDTH);
+    });
+
+    it("End snaps to PORTAL_MAX_WIDTH", () => {
+      render(<PortalDock />);
+      fireEvent.keyDown(getSeparator(), { key: "End" });
+      expect(usePortalStore.getState().width).toBe(PORTAL_MAX_WIDTH);
+    });
+
+    it("clamps a coarse-step widen to PORTAL_MAX_WIDTH", () => {
+      act(() => {
+        usePortalStore.setState({ width: PORTAL_MAX_WIDTH - 10 });
+      });
+      render(<PortalDock />);
+      fireEvent.keyDown(getSeparator(), { key: "ArrowLeft", shiftKey: true });
+      expect(usePortalStore.getState().width).toBe(PORTAL_MAX_WIDTH);
+    });
+
+    it("clamps a coarse-step narrow to PORTAL_MIN_WIDTH", () => {
+      act(() => {
+        usePortalStore.setState({ width: PORTAL_MIN_WIDTH + 10 });
+      });
+      render(<PortalDock />);
+      fireEvent.keyDown(getSeparator(), { key: "ArrowRight", shiftKey: true });
+      expect(usePortalStore.getState().width).toBe(PORTAL_MIN_WIDTH);
+    });
+
+    it("ignores unrelated keys (e.g. Enter)", () => {
+      render(<PortalDock />);
+      fireEvent.keyDown(getSeparator(), { key: "Enter" });
+      expect(usePortalStore.getState().width).toBe(800);
+    });
+  });
+
+  it("exports a sensible PORTAL_MIN_EDITOR_WIDTH constant", () => {
+    // Sanity guard: the clamp math assumes a non-trivial editor reserve.
+    expect(PORTAL_MIN_EDITOR_WIDTH).toBeGreaterThanOrEqual(320);
+  });
+});


### PR DESCRIPTION
## Summary

- Viewport-aware width restore on launch: if the persisted width would crowd the editor below `PORTAL_MIN_EDITOR_WIDTH` (400px) on the current viewport, a mount-time clamp snaps it to a safe default. Runs in `PortalDock` rather than the zustand persist `merge` callback because Electron's `BrowserWindow.show: false` startup leaves `window.innerWidth = 0` during synchronous hydration.
- Double-click reset on the resize separator resets the portal to its default width. Matches VS Code / Obsidian / Chrome DevTools convention. Guarded against the dblclick's second `mousedown` via `e.detail > 1` in `handleResizeStart` (lesson from #4997 — no `setTimeout` arbitration).
- Extended keyboard support on the separator: `Home` (snap to min), `End` (snap to max), and `Shift+Arrow` (50px coarse step) alongside the existing Arrow fine step (10px). Follows the WAI-ARIA APG window-splitter pattern.

Also fixes a real drag-listener leak (document `mousemove`/`mouseup` listeners survived component unmount) and makes the clamp ref retry-safe for the early-hydration `innerWidth = 0` race.

Resolves #9208

## Changes

- `shared/types/portal.ts` — added `PORTAL_MIN_EDITOR_WIDTH = 400`
- `shared/types/index.ts` — re-exported the new constant
- `src/components/Portal/PortalDock.tsx` — viewport clamp on mount, double-click reset, extended keyboard handler, unmount cleanup, retry-safe clamp ref
- `src/components/Portal/__tests__/PortalDock.separator.test.tsx` (new) — 14 tests covering all three features plus regression coverage for the review fixes

## Testing

- [ ] Set portal width above 1000px, quit and relaunch on a narrow display — verify it snaps to the default
- [ ] Double-click the resize separator — verify width resets to 480
- [ ] Focus the separator (Tab in from a neighboring element) — verify `Arrow`, `Home`, `End`, and `Shift+Arrow` behave as documented
- [ ] Start a drag and close the portal mid-drag — verify no further width changes leak after unmount