### PR TITLE
feat(voice): structured error model with severity-based recovery

### DIFF
--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -399,7 +399,7 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
           rawText: null,
         });
       } else if (voiceEvent.type === "error") {
-        getAppWebContents(win).send(CHANNELS.VOICE_INPUT_ERROR, voiceEvent.message);
+        getAppWebContents(win).send(CHANNELS.VOICE_INPUT_ERROR, voiceEvent.error);
       } else if (voiceEvent.type === "status") {
         getAppWebContents(win).send(CHANNELS.VOICE_INPUT_STATUS, voiceEvent.status);
       }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -97,6 +97,7 @@ import type {
   RecipeNameCollision,
   AttachIssuePayload,
   IssueAssociation,
+  VoiceInputError,
   VoiceInputStatus,
 } from "../shared/types/index.js";
 import type { ColorVisionMode, AppColorScheme } from "../shared/types/appTheme.js";
@@ -2344,7 +2345,8 @@ const api: ElectronAPI = {
     ) => _typedOn(CHANNELS.VOICE_INPUT_TRANSCRIPTION_COMPLETE, callback),
     onParagraphBoundary: (callback: (payload: { rawText: string | null }) => void) =>
       _typedOn(CHANNELS.VOICE_INPUT_PARAGRAPH_BOUNDARY, callback),
-    onError: (callback: (error: string) => void) => _typedOn(CHANNELS.VOICE_INPUT_ERROR, callback),
+    onError: (callback: (error: VoiceInputError) => void) =>
+      _typedOn(CHANNELS.VOICE_INPUT_ERROR, callback),
     onStatus: (callback: (status: VoiceInputStatus) => void) =>
       _typedOn(CHANNELS.VOICE_INPUT_STATUS, callback),
     checkMicPermission: () => _unwrappingInvoke(CHANNELS.VOICE_INPUT_CHECK_MIC_PERMISSION),

--- a/electron/services/__tests__/VoiceTranscriptionService.integration.test.ts
+++ b/electron/services/__tests__/VoiceTranscriptionService.integration.test.ts
@@ -49,7 +49,8 @@ describe("VoiceTranscriptionService integration", () => {
 
       const errors = events.filter((e) => e.type === "error");
       if (errors.length > 0) {
-        throw new Error(`Server returned error: ${(errors[0] as { message: string }).message}`);
+        const errEvent = errors[0] as { type: "error"; error: { message: string } };
+        throw new Error(`Server returned error: ${errEvent.error.message}`);
       }
 
       service.stop();

--- a/electron/services/voice/DeepgramTranscriptionProvider.ts
+++ b/electron/services/voice/DeepgramTranscriptionProvider.ts
@@ -1,5 +1,5 @@
 import WebSocket from "ws";
-import type { VoiceInputSettings } from "../../../shared/types/ipc/api.js";
+import type { VoiceInputError, VoiceInputSettings } from "../../../shared/types/ipc/api.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import { logDebug, logInfo, logWarn, logError } from "../../utils/logger.js";
 import {
@@ -104,7 +104,11 @@ export class DeepgramTranscriptionProvider implements TranscriptionProvider {
     if (event.type === "status") {
       logInfo(`${P} status → ${event.status}`);
     } else if (event.type === "error") {
-      logWarn(`${P} emitting error event`, { message: event.message });
+      logWarn(`${P} emitting error event`, {
+        severity: event.error.severity,
+        code: event.error.code,
+        message: event.error.message,
+      });
     }
     for (const listener of this.listeners) {
       listener(event);
@@ -160,7 +164,10 @@ export class DeepgramTranscriptionProvider implements TranscriptionProvider {
     } catch (err) {
       const message = formatErrorMessage(err, "Failed to open WebSocket");
       logError(`${P} ${message}`);
-      this.emit({ type: "error", message });
+      this.emit({
+        type: "error",
+        error: { severity: "fatal", code: "ws_construct_failed", message },
+      });
       this.emit({ type: "status", status: "error" });
       this.settlePendingStart(mySessionId, { ok: false, error: message });
       return;
@@ -180,7 +187,10 @@ export class DeepgramTranscriptionProvider implements TranscriptionProvider {
         // Ignore close errors
       }
       this.cleanupConnection();
-      this.emit({ type: "error", message: "Connection timed out" });
+      this.emit({
+        type: "error",
+        error: { severity: "fatal", code: "connection_timeout", message: "Connection timed out" },
+      });
       this.emit({ type: "status", status: "error" });
       this.settlePendingStart(mySessionId, { ok: false, error: "Connection timed out" });
     }, CONNECT_TIMEOUT_MS);
@@ -246,7 +256,11 @@ export class DeepgramTranscriptionProvider implements TranscriptionProvider {
       // `ws` fires `close` right after `error`; a pre-ready transport error
       // (auth/DNS/refused) is fatal, otherwise let the close handler decide.
       if (!this.isReady) {
-        this.handleFatalError(mySessionId, message);
+        this.handleFatalError(mySessionId, {
+          severity: "fatal",
+          code: "ws_transport_error",
+          message,
+        });
       }
     });
 
@@ -274,7 +288,10 @@ export class DeepgramTranscriptionProvider implements TranscriptionProvider {
       // ready session is surfaced as an error; a never-ready drop falls through
       // to idle (matches the OpenAI provider's terminal semantics).
       if (wasReady) {
-        this.emit({ type: "error", message: "Connection lost" });
+        this.emit({
+          type: "error",
+          error: { severity: "fatal", code: "ws_close_unexpected", message: "Connection lost" },
+        });
         this.emit({ type: "status", status: "error" });
       } else {
         this.emit({ type: "status", status: "idle" });
@@ -307,8 +324,11 @@ export class DeepgramTranscriptionProvider implements TranscriptionProvider {
     }
   }
 
-  private handleFatalError(mySessionId: number, message: string): void {
-    logError(`${P} Fatal error — tearing down session`, { message });
+  private handleFatalError(mySessionId: number, error: VoiceInputError): void {
+    logError(`${P} Fatal error — tearing down session`, {
+      code: error.code,
+      message: error.message,
+    });
     this.isExpectedClose = true;
     const conn = this.connection;
     this.cleanupConnection();
@@ -319,9 +339,9 @@ export class DeepgramTranscriptionProvider implements TranscriptionProvider {
         // Ignore terminate errors
       }
     }
-    this.emit({ type: "error", message });
+    this.emit({ type: "error", error });
     this.emit({ type: "status", status: "error" });
-    this.settlePendingStart(mySessionId, { ok: false, error: message });
+    this.settlePendingStart(mySessionId, { ok: false, error: error.message });
     this.settleDrain("fatal-error");
   }
 
@@ -366,7 +386,11 @@ export class DeepgramTranscriptionProvider implements TranscriptionProvider {
           (typeof payload.message === "string" && payload.message) ||
           "Deepgram error";
         logError(`${P} ← server error event`, { message });
-        this.handleFatalError(_mySessionId, message);
+        this.handleFatalError(_mySessionId, {
+          severity: "fatal",
+          code: "deepgram_server_error",
+          message,
+        });
         return;
       }
 

--- a/electron/services/voice/OpenAITranscriptionProvider.ts
+++ b/electron/services/voice/OpenAITranscriptionProvider.ts
@@ -1,5 +1,5 @@
 import WebSocket from "ws";
-import type { VoiceInputSettings } from "../../../shared/types/ipc/api.js";
+import type { VoiceInputError, VoiceInputSettings } from "../../../shared/types/ipc/api.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import { buildOpenAIHeaders } from "../../../shared/utils/openaiHeaders.js";
 import { logDebug, logInfo, logWarn, logError } from "../../utils/logger.js";
@@ -53,6 +53,59 @@ const COMMIT_INTERVAL_MS = 2_000;
 // below this threshold.
 const MIN_COMMIT_BYTES = 4_800;
 
+// OpenAI Realtime `error.code` values that are recoverable by reconnecting.
+// All other codes (auth, content policy, schema violations) are fatal — a retry
+// will fail the same way, so the user must intervene.
+const TRANSIENT_OPENAI_CODES = new Set<string>(["rate_limit_exceeded", "server_error"]);
+
+// WebSocket close codes that indicate a recoverable transport drop. The
+// existing close handler already gates reconnect on `!isExpectedClose &&
+// wasReady`; this set is used to classify the error emitted on giving up
+// (and to decide reconnect-vs-fatal for the brand-new failure modes we now
+// surface explicitly).
+const TRANSIENT_CLOSE_CODES = new Set<number>([1006, 1011, 1012, 1013]);
+
+/**
+ * Classifies an OpenAI Realtime `error` event payload into a structured
+ * `VoiceInputError`. Pure function — exported for unit testing. The classifier
+ * is conservative: anything not on the transient allowlist is treated as fatal
+ * so the renderer surfaces a recovery action instead of silently retrying.
+ */
+export function classifyOpenAIError(payload: {
+  message?: string;
+  type?: string;
+  code?: string;
+  param?: string | null;
+}): VoiceInputError {
+  const code = payload.code ?? (payload.type === "server_error" ? "server_error" : "unknown_error");
+  const severity: VoiceInputError["severity"] = TRANSIENT_OPENAI_CODES.has(code)
+    ? "transient"
+    : "fatal";
+  return {
+    severity,
+    code,
+    message: payload.message ?? "OpenAI realtime error",
+    param: payload.param ?? null,
+  };
+}
+
+/**
+ * Classifies a WebSocket close code into a `VoiceInputError` severity. Used to
+ * tag the error emitted when reconnect attempts exhaust, so the renderer can
+ * distinguish "we tried, the network kept dropping" from "the server rejected
+ * us outright".
+ */
+export function classifyCloseCode(code: number, reason?: string): VoiceInputError {
+  const severity: VoiceInputError["severity"] = TRANSIENT_CLOSE_CODES.has(code)
+    ? "transient"
+    : "fatal";
+  return {
+    severity,
+    code: `ws_close_${code}`,
+    message: reason && reason.trim() ? reason : `Connection closed (code ${code})`,
+  };
+}
+
 // We use the `ws` package rather than Node 22's global `WebSocket`. The
 // WHATWG spec exposes only `(url, protocols?)` — its constructor silently
 // discards any third options argument, so custom upgrade headers cannot be
@@ -85,6 +138,11 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private reconnectAttempt = 0;
   private isReconnecting = false;
+  // Last classified transport/server error that drove the current reconnect
+  // cycle. Used when reconnect attempts exhaust so the fatal error surfaced to
+  // the renderer carries the original failure context (e.g. `ws_close_1006`)
+  // instead of a generic "reconnect failed" string.
+  private lastReconnectError: VoiceInputError | null = null;
   // Set on graceful/fatal teardown so the trailing `close` event isn't mistaken
   // for an unexpected drop and doesn't trigger a reconnect.
   private isExpectedClose = false;
@@ -134,11 +192,19 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
     if (event.type === "status") {
       logInfo(`${P} status → ${event.status}`);
     } else if (event.type === "error") {
-      logWarn(`${P} emitting error event`, { message: event.message });
+      logWarn(`${P} emitting error event`, {
+        severity: event.error.severity,
+        code: event.error.code,
+        message: event.error.message,
+      });
     }
     for (const listener of this.listeners) {
       listener(event);
     }
+  }
+
+  private emitError(error: VoiceInputError): void {
+    this.emit({ type: "error", error });
   }
 
   private clearConnectTimeout(): void {
@@ -173,6 +239,7 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
     this.preConnectBufferBytes = 0;
     this.reconnectAttempt = 0;
     this.isReconnecting = false;
+    this.lastReconnectError = null;
     this.isExpectedClose = false;
     this.liveText = "";
 
@@ -207,7 +274,7 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
       if (this.isReconnecting) {
         this.scheduleReconnect(mySessionId, settings);
       } else {
-        this.emit({ type: "error", message });
+        this.emitError({ severity: "fatal", code: "ws_construct_failed", message });
         this.emit({ type: "status", status: "error" });
         this.settlePendingStart(mySessionId, { ok: false, error: message });
       }
@@ -246,7 +313,11 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
         // Ignore close errors
       }
       this.cleanupConnection();
-      this.emit({ type: "error", message: "Connection timed out" });
+      this.emitError({
+        severity: "fatal",
+        code: "connection_timeout",
+        message: "Connection timed out",
+      });
       this.emit({ type: "status", status: "error" });
       this.settlePendingStart(mySessionId, { ok: false, error: "Connection timed out" });
     }, CONNECT_TIMEOUT_MS);
@@ -303,7 +374,11 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
       } catch (err) {
         const message = formatErrorMessage(err, "Failed to send session.update");
         logError(`${P} ${message}`);
-        this.handleFatalError(mySessionId, message);
+        this.handleFatalError(mySessionId, {
+          severity: "fatal",
+          code: "session_update_send_failed",
+          message,
+        });
       }
     });
 
@@ -340,7 +415,11 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
       // owns the reconnect decision, so just log here. A pre-ready error
       // (auth/DNS/refused on the very first connect) is fatal: tear down now.
       if (!this.isReady && !this.isReconnecting) {
-        this.handleFatalError(mySessionId, message);
+        this.handleFatalError(mySessionId, {
+          severity: "fatal",
+          code: "ws_transport_error",
+          message,
+        });
       }
     });
 
@@ -352,9 +431,10 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
       // nulling this.connection) — that path has already emitted its status.
       if (this.sessionId !== mySessionId || this.connection !== connection) return;
       const wasReady = this.isReady;
+      const reasonText = Buffer.isBuffer(reason) ? reason.toString("utf8") : String(reason ?? "");
       logInfo(`${P} WebSocket closed`, {
         code,
-        reason: Buffer.isBuffer(reason) ? reason.toString("utf8") : String(reason ?? ""),
+        reason: reasonText,
         wasReady,
         wasReconnecting: this.isReconnecting,
         wasExpected: this.isExpectedClose,
@@ -369,7 +449,16 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
       // An unexpected drop of a ready session (or a failed reconnect attempt
       // while still mid-reconnect) is recoverable — schedule a retry instead of
       // ending the session. Graceful stops and fatal errors set isExpectedClose.
+      // Don't overwrite a pre-existing `lastReconnectError` (set by the
+      // transient OpenAI server-error path before it terminated the socket) —
+      // that's richer context than the synthetic 1006 from terminate().
       if (!this.isExpectedClose && (wasReady || this.isReconnecting)) {
+        if (!this.lastReconnectError) {
+          this.lastReconnectError = classifyCloseCode(
+            typeof code === "number" ? code : 1006,
+            reasonText
+          );
+        }
         this.scheduleReconnect(mySessionId, settings);
         return;
       }
@@ -441,7 +530,14 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
     if (this.reconnectAttempt >= RECONNECT_MAX_ATTEMPTS) {
       logError(`${P} Reconnect failed after ${RECONNECT_MAX_ATTEMPTS} attempts — giving up`);
       this.isReconnecting = false;
-      this.handleFatalError(mySessionId, "Connection lost — reconnect failed");
+      const last = this.lastReconnectError;
+      this.handleFatalError(mySessionId, {
+        severity: "fatal",
+        code: "reconnect_exhausted",
+        message: last
+          ? `Reconnect failed (${last.code}): ${last.message}`
+          : "Connection lost — reconnect failed",
+      });
       return;
     }
 
@@ -480,12 +576,17 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
     this.connect(mySessionId, settings);
   }
 
-  private handleFatalError(mySessionId: number, message: string): void {
-    logError(`${P} Fatal error — tearing down session`, { message });
+  private handleFatalError(mySessionId: number, error: VoiceInputError): void {
+    logError(`${P} Fatal error — tearing down session`, {
+      code: error.code,
+      message: error.message,
+      severity: error.severity,
+    });
     // Mark the close as expected so the trailing `close` event (after the
     // socket tears down) isn't treated as a recoverable drop.
     this.isExpectedClose = true;
     this.isReconnecting = false;
+    this.lastReconnectError = null;
     this.clearReconnectTimer();
     // Close the physical socket — a server-sent fatal `error` event leaves the
     // connection open otherwise. Captured before cleanupConnection() nulls it.
@@ -498,9 +599,9 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
         // Ignore terminate errors
       }
     }
-    this.emit({ type: "error", message });
+    this.emitError(error);
     this.emit({ type: "status", status: "error" });
-    this.settlePendingStart(mySessionId, { ok: false, error: message });
+    this.settlePendingStart(mySessionId, { ok: false, error: error.message });
     this.settleDrain("fatal-error");
   }
 
@@ -534,6 +635,7 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
         // gets a fresh full backoff budget.
         this.reconnectAttempt = 0;
         this.isReconnecting = false;
+        this.lastReconnectError = null;
         this.isReady = true;
         this.startCommitTimer();
         this.emit({ type: "status", status: "recording" });
@@ -622,16 +724,34 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
 
       case "error": {
         const errorPayload = payload.error as
-          | { message?: string; type?: string; code?: string; param?: string }
+          | { message?: string; type?: string; code?: string; param?: string | null }
           | undefined;
-        const message = errorPayload?.message ?? "OpenAI realtime error";
+        const classified = classifyOpenAIError(errorPayload ?? {});
         logError(`${P} ← server error event`, {
-          message,
-          type: errorPayload?.type,
-          code: errorPayload?.code,
-          param: errorPayload?.param,
+          severity: classified.severity,
+          code: classified.code,
+          message: classified.message,
+          param: classified.param,
+          openaiType: errorPayload?.type,
         });
-        this.handleFatalError(mySessionId, message);
+        // Transient server-side errors (rate_limit_exceeded, server_error) are
+        // recoverable. Emit the classified error first so the renderer can show
+        // "rate-limited, retrying" in the tooltip, then terminate the socket —
+        // its trailing `close` fires the existing close handler, which schedules
+        // a reconnect with the same backoff/jitter machinery used for transport
+        // drops. Calling scheduleReconnect directly here would race the in-flight
+        // close event and risk double-scheduling.
+        if (classified.severity === "transient" && this.connection) {
+          this.lastReconnectError = classified;
+          this.emitError(classified);
+          try {
+            this.connection.terminate();
+          } catch {
+            // Ignore terminate errors — the close handler still drives reconnect.
+          }
+          return;
+        }
+        this.handleFatalError(mySessionId, classified);
         return;
       }
 
@@ -794,6 +914,7 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
     this.clearReconnectTimer();
     this.reconnectAttempt = 0;
     this.isReconnecting = false;
+    this.lastReconnectError = null;
     this.isExpectedClose = false;
     this.isAlive = false;
     this.isDraining = false;

--- a/electron/services/voice/TranscriptionProvider.ts
+++ b/electron/services/voice/TranscriptionProvider.ts
@@ -1,4 +1,8 @@
-import type { VoiceInputSettings, VoiceInputStatus } from "../../../shared/types/ipc/api.js";
+import type {
+  VoiceInputError,
+  VoiceInputSettings,
+  VoiceInputStatus,
+} from "../../../shared/types/ipc/api.js";
 
 export interface CorrectionWord {
   word: string;
@@ -18,7 +22,7 @@ export type VoiceTranscriptionEvent =
   | { type: "delta"; text: string }
   | { type: "complete"; text: string; confidence?: SegmentConfidence }
   | { type: "paragraph_boundary" }
-  | { type: "error"; message: string }
+  | { type: "error"; error: VoiceInputError }
   | { type: "status"; status: VoiceInputStatus };
 
 export type VoiceStartResult = { ok: true } | { ok: false; error: string };

--- a/electron/services/voice/__tests__/DeepgramTranscriptionProvider.test.ts
+++ b/electron/services/voice/__tests__/DeepgramTranscriptionProvider.test.ts
@@ -242,7 +242,7 @@ describe("DeepgramTranscriptionProvider", () => {
     const provider = new DeepgramTranscriptionProvider();
     const errors: string[] = [];
     provider.onEvent((e) => {
-      if (e.type === "error") errors.push(e.message);
+      if (e.type === "error") errors.push(e.error.message);
     });
 
     const startPromise = provider.start(BASE_SETTINGS);
@@ -540,7 +540,9 @@ describe("DeepgramTranscriptionProvider", () => {
     const { socket } = await bringSessionReady(provider);
     socket.simulateMessage({ type: "Error", description: "invalid api key" });
 
-    expect(events.some((e) => e.type === "error" && /invalid api key/.test(e.message))).toBe(true);
+    expect(events.some((e) => e.type === "error" && /invalid api key/.test(e.error.message))).toBe(
+      true
+    );
     expect(events.some((e) => e.type === "status" && e.status === "error")).toBe(true);
   });
 
@@ -554,7 +556,9 @@ describe("DeepgramTranscriptionProvider", () => {
     latestInstance().simulateError(new Error("dns failure"));
 
     await expect(startPromise).resolves.toEqual({ ok: false, error: "dns failure" });
-    expect(events.some((e) => e.type === "error" && /dns failure/.test(e.message))).toBe(true);
+    expect(events.some((e) => e.type === "error" && /dns failure/.test(e.error.message))).toBe(
+      true
+    );
     expect(events.some((e) => e.type === "status" && e.status === "error")).toBe(true);
   });
 

--- a/electron/services/voice/__tests__/OpenAITranscriptionProvider.test.ts
+++ b/electron/services/voice/__tests__/OpenAITranscriptionProvider.test.ts
@@ -300,7 +300,7 @@ describe("OpenAITranscriptionProvider", () => {
     const service = new OpenAITranscriptionProvider();
     const errors: string[] = [];
     service.onEvent((e) => {
-      if (e.type === "error") errors.push(e.message);
+      if (e.type === "error") errors.push(e.error.message);
     });
 
     const startPromise = service.start(BASE_SETTINGS);
@@ -807,7 +807,9 @@ describe("OpenAITranscriptionProvider", () => {
     socket.simulateError(new Error("network down"));
 
     await expect(startPromise).resolves.toEqual({ ok: false, error: "network down" });
-    expect(events.some((e) => e.type === "error" && /network down/.test(e.message))).toBe(true);
+    expect(events.some((e) => e.type === "error" && /network down/.test(e.error.message))).toBe(
+      true
+    );
     expect(events.some((e) => e.type === "status" && e.status === "error")).toBe(true);
   });
 
@@ -815,7 +817,7 @@ describe("OpenAITranscriptionProvider", () => {
     const service = new OpenAITranscriptionProvider();
     const errors: string[] = [];
     service.onEvent((e) => {
-      if (e.type === "error") errors.push(e.message);
+      if (e.type === "error") errors.push(e.error.message);
     });
 
     const { socket } = await bringSessionReady(service);
@@ -1060,7 +1062,7 @@ describe("OpenAITranscriptionProvider", () => {
     const errors: string[] = [];
     service.onEvent((e) => {
       if (e.type === "status") statuses.push(e.status);
-      if (e.type === "error") errors.push(e.message);
+      if (e.type === "error") errors.push(e.error.message);
     });
 
     // Initial drop schedules attempt 1.

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -431,7 +431,7 @@ export {
 } from "./portal.js";
 
 // Voice types - canonical phase model for voice session and transcript lifecycle
-export type { VoiceTranscriptPhase } from "./voice.js";
+export type { VoiceInputError, VoiceInputErrorSeverity, VoiceTranscriptPhase } from "./voice.js";
 export { isActiveVoiceSession } from "./voice.js";
 
 // Workspace Host types - IPC protocol for workspace management

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -16,8 +16,8 @@ import type { ChecklistState, HelpAssistantTier, IpcEventBusMap, IpcInvokeMap } 
 import type { GeneratedElectronAPI } from "./generated-api.js";
 import type { AgentSettings, AgentSettingsEntry } from "../agentSettings.js";
 import type { AgentPreset } from "../../config/agentRegistry.js";
-import type { VoiceInputStatus } from "../voice.js";
-export type { VoiceInputStatus };
+import type { VoiceInputError, VoiceInputStatus } from "../voice.js";
+export type { VoiceInputError, VoiceInputStatus };
 import type {
   AuthValidation,
   ForgeProviderEntry,
@@ -1372,7 +1372,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
       callback: (payload: { text: string; willCorrect: boolean }) => void
     ): () => void;
     onParagraphBoundary(callback: (payload: { rawText: string | null }) => void): () => void;
-    onError(callback: (error: string) => void): () => void;
+    onError(callback: (error: VoiceInputError) => void): () => void;
     onStatus(callback: (status: VoiceInputStatus) => void): () => void;
     checkMicPermission(): Promise<MicPermissionStatus>;
     requestMicPermission(): Promise<boolean>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1,6 +1,6 @@
 import type { StagingStatus } from "../git.js";
 import type { AgentId } from "../agent.js";
-import type { VoiceInputStatus } from "../voice.js";
+import type { VoiceInputError, VoiceInputStatus } from "../voice.js";
 import type { WorktreeState } from "../worktree.js";
 import type {
   Project,
@@ -1817,7 +1817,7 @@ export interface IpcEventMap {
     replacement: string;
     resolved: boolean;
   };
-  "voice-input:error": string;
+  "voice-input:error": VoiceInputError;
   "voice-input:status": VoiceInputStatus;
 
   // Demo mode events (main → renderer command forwarding)

--- a/shared/types/voice.ts
+++ b/shared/types/voice.ts
@@ -53,3 +53,41 @@ export function isActiveVoiceSession(status: VoiceInputStatus): boolean {
     status === "finishing"
   );
 }
+
+/**
+ * Severity classification for a voice-input error. Drives the renderer's
+ * recovery behavior: transient errors keep the session alive while the main
+ * process reconnects; fatal errors tear down the session and surface a toast.
+ *
+ * - transient: a recoverable transport or rate-limit fault — the main process
+ *   is already reconnecting (or will, on the next close). The user sees the
+ *   "reconnecting" status but the session intent is preserved.
+ * - fatal: requires user action (auth/quota/permission/config) or is
+ *   unrecoverable. The session ends.
+ */
+export type VoiceInputErrorSeverity = "transient" | "fatal";
+
+/**
+ * Structured error payload emitted by the voice input pipeline. Plain
+ * serializable shape so it crosses Electron's contextBridge (no class
+ * instances, no Error subclasses).
+ *
+ * `code` is a stable identifier — UI mapping, telemetry, and tests should
+ * branch on `code`, not on `message`. `message` carries the user-facing
+ * fallback string for surfaces that lack a code mapping.
+ */
+export interface VoiceInputError {
+  severity: VoiceInputErrorSeverity;
+  /**
+   * Stable error code. For server-emitted errors this mirrors the OpenAI
+   * Realtime `error.code` (e.g. `"rate_limit_exceeded"`,
+   * `"session_expired"`); for transport errors it's a synthetic code like
+   * `"ws_close_1006"` or `"connection_timeout"`; for renderer-side
+   * pre-connect failures it's a descriptive slug like `"mic_permission_denied"`.
+   */
+  code: string;
+  /** Human-readable fallback message — shown when no `code` mapping exists. */
+  message: string;
+  /** OpenAI error payload `param` field, when present. */
+  param?: string | null;
+}

--- a/src/components/Terminal/VoiceInputButton.tsx
+++ b/src/components/Terminal/VoiceInputButton.tsx
@@ -4,6 +4,29 @@ import { Spinner } from "@/components/ui/Spinner";
 import { cn } from "@/lib/utils";
 import { useVoiceRecordingStore } from "@/store/voiceRecordingStore";
 import { voiceRecordingService } from "@/services/VoiceRecordingService";
+import type { VoiceInputError } from "@shared/types";
+
+/**
+ * Maps a `VoiceInputError` to a concise tooltip string. Transient errors
+ * (rate-limit, transport drop) surface a "reconnecting" nudge rather than an
+ * alarming message — the mic button's orbital animation already signals the
+ * in-progress retry. Fatal errors show the human-readable message fallback.
+ */
+function formatVoiceErrorTooltip(error: VoiceInputError | null): string {
+  if (!error) return "Voice input error";
+  const code = String(error.code);
+  if (error.severity === "transient") {
+    if (code === "rate_limit_exceeded") return "Rate limited — reconnecting";
+    if (code.startsWith("ws_close_")) return "Connection dropped — reconnecting";
+    return "Reconnecting…";
+  }
+  // Fatal — map known codes to actionable user-facing strings.
+  if (code === "rate_limit_exceeded") return "Rate limit exceeded — check your API key quota";
+  if (code === "reconnect_exhausted") return "Connection failed after several retries";
+  if (code === "connection_timeout") return "Connection timed out";
+  if (code.startsWith("ws_close_")) return `Connection closed — check network`;
+  return error.message;
+}
 
 // Flywheel — double-smoothed for S-curve easing
 const IDLE_SPEED = 72; // deg/sec — 1 revolution per 5s
@@ -38,7 +61,7 @@ export function VoiceInputButton({
 }: VoiceInputButtonProps) {
   const status = useVoiceRecordingStore((state) => state.status);
   const isConfigured = useVoiceRecordingStore((state) => state.isConfigured);
-  const errorMessage = useVoiceRecordingStore((state) => state.errorMessage);
+  const lastError = useVoiceRecordingStore((state) => state.lastError);
   const activePanelId = useVoiceRecordingStore((state) => state.activeTarget?.panelId ?? null);
   const audioLevel = useVoiceRecordingStore((state) => state.audioLevel);
 
@@ -295,7 +318,7 @@ export function VoiceInputButton({
           !isConfigured
             ? "Configure voice input"
             : status === "error"
-              ? (errorMessage ?? "Voice input error")
+              ? formatVoiceErrorTooltip(lastError)
               : isFinishing
                 ? "Finishing transcription..."
                 : isPaused

--- a/src/components/Terminal/__tests__/VoiceInputButton.test.tsx
+++ b/src/components/Terminal/__tests__/VoiceInputButton.test.tsx
@@ -31,7 +31,7 @@ describe("VoiceInputButton", () => {
     useVoiceRecordingStore.setState({
       isConfigured: false,
       status: "idle",
-      errorMessage: null,
+      lastError: null,
       activeTarget: null,
       elapsedSeconds: 0,
       panelBuffers: {},

--- a/src/services/VoiceRecordingService.ts
+++ b/src/services/VoiceRecordingService.ts
@@ -4,12 +4,13 @@ import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { isAssistantFocused } from "@/store/macroFocusStore";
 import { useTerminalInputStore } from "@/store/terminalInputStore";
 import { useVoiceRecordingStore, type VoiceRecordingTarget } from "@/store/voiceRecordingStore";
-import { isActiveVoiceSession } from "@shared/types";
+import { isActiveVoiceSession, type VoiceInputError } from "@shared/types";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { VOICE_INPUT_SETTINGS_CHANGED_EVENT } from "@/lib/voiceInputSettingsEvents";
 import { logDebug, logInfo, logWarn, logError } from "@/utils/logger";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
+import { notify } from "@/lib/notify";
 
 const LOG_PREFIX = "[VoiceRecording]";
 
@@ -182,15 +183,38 @@ class VoiceRecordingService {
     );
 
     this.unsubscribers.push(
-      voiceInput.onError((error) => {
+      voiceInput.onError((error: VoiceInputError) => {
         // During graceful stop, the main process suppresses drain errors.
         // If one leaks through, ignore it to avoid prematurely finalizing.
         if (this.isStoppingSession) {
           logWarn(`${LOG_PREFIX} Ignoring error during stop`, { error });
           return;
         }
-        logError(`${LOG_PREFIX} Received error from backend`, { error });
-        useVoiceRecordingStore.getState().setError(error);
+        logError(`${LOG_PREFIX} Received error from backend`, {
+          severity: error.severity,
+          code: error.code,
+          message: error.message,
+        });
+        useVoiceRecordingStore.getState().setLastError(error);
+
+        // Transient errors (rate-limit, transport drop) are recoverable — the
+        // main process is already reconnecting. Store the error for tooltip
+        // context but keep the session alive; the reconnecting status update
+        // arriving on the same channel will update the UI.
+        if (error.severity === "transient") {
+          return;
+        }
+
+        // Fatal error — tear down the session and surface a toast so the user
+        // knows action is needed (check API key, network, etc.).
+        // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
+        notify({
+          type: "error",
+          title: "Dictation stopped",
+          // eslint-disable-next-line no-restricted-syntax -- raw error.message: VoiceInputError is constructed internally with well-formed user copy
+          message: error.message,
+          context: { eventKind: "connectivity" },
+        });
         void this.stop("Dictation stopped because the connection failed.", {
           skipRemoteStop: true,
           nextStatus: "error",
@@ -366,7 +390,11 @@ class VoiceRecordingService {
     if (!isConfigured || this.isStartRequestStale(startRequestId)) {
       logWarn(`${LOG_PREFIX} Not configured, aborting start`);
       if (!this.isStartRequestStale(startRequestId)) {
-        useVoiceRecordingStore.getState().setError("Voice input is not configured.");
+        useVoiceRecordingStore.getState().setLastError({
+          severity: "fatal",
+          code: "renderer_error",
+          message: "Voice input is not configured.",
+        });
         useVoiceRecordingStore
           .getState()
           .announce("Voice dictation is not configured. Open Voice settings to continue.");
@@ -386,7 +414,9 @@ class VoiceRecordingService {
     if (micStatus === "denied" || micStatus === "restricted") {
       const message = "Microphone permission denied. Enable it in System Settings and try again.";
       logError(`${LOG_PREFIX} Microphone permission denied at OS level`, { micStatus });
-      useVoiceRecordingStore.getState().setError(message);
+      useVoiceRecordingStore
+        .getState()
+        .setLastError({ severity: "fatal", code: "mic_permission_denied", message });
       useVoiceRecordingStore.getState().announce(message);
       safeFireAndForget(window.electron.voiceInput.openMicSettings(), {
         context: "Opening OS microphone settings",
@@ -403,7 +433,9 @@ class VoiceRecordingService {
       logDebug(`${LOG_PREFIX} OS microphone permission result`, { granted });
       if (!granted) {
         const message = "Microphone permission denied. Enable it in System Settings and try again.";
-        useVoiceRecordingStore.getState().setError(message);
+        useVoiceRecordingStore
+          .getState()
+          .setLastError({ severity: "fatal", code: "mic_permission_denied", message });
         useVoiceRecordingStore.getState().announce(message);
         return;
       }
@@ -426,7 +458,11 @@ class VoiceRecordingService {
         name: error instanceof DOMException ? error.name : "unknown",
         message,
       });
-      useVoiceRecordingStore.getState().setError(message);
+      const micCode =
+        error instanceof DOMException && error.name === "NotAllowedError"
+          ? "mic_permission_denied"
+          : "mic_access_failed";
+      useVoiceRecordingStore.getState().setLastError({ severity: "fatal", code: micCode, message });
       useVoiceRecordingStore.getState().announce(message);
       return;
     }
@@ -557,7 +593,11 @@ class VoiceRecordingService {
     } catch (err) {
       if (this.generation !== generation || this.isStartRequestStale(startRequestId)) return;
       logError(`${LOG_PREFIX} Failed to load pcm-processor worklet`, err);
-      useVoiceRecordingStore.getState().setError("Failed to load the audio processor.");
+      useVoiceRecordingStore.getState().setLastError({
+        severity: "fatal",
+        code: "renderer_error",
+        message: "Failed to load the audio processor.",
+      });
       await this.stop(undefined, { nextStatus: "error", announce: false });
       useVoiceRecordingStore.getState().announce("Voice dictation failed to initialize.");
       return;
@@ -653,7 +693,9 @@ class VoiceRecordingService {
 
     if (!result.ok) {
       logError(`${LOG_PREFIX} Backend start failed`, { error: result.error });
-      useVoiceRecordingStore.getState().setError(result.error);
+      useVoiceRecordingStore
+        .getState()
+        .setLastError({ severity: "fatal", code: "backend_start_failed", message: result.error });
       await this.cleanupAudioCapture();
       useVoiceRecordingStore.getState().finishSession({ nextStatus: "error" });
       useVoiceRecordingStore.getState().announce("Voice dictation failed to start.");
@@ -884,9 +926,11 @@ class VoiceRecordingService {
     if (isAssistantFocused()) {
       const assistantTarget = this.getAssistantTarget();
       if (!assistantTarget) {
-        useVoiceRecordingStore
-          .getState()
-          .setError("Daintree Assistant is starting — try again in a moment.");
+        useVoiceRecordingStore.getState().setLastError({
+          severity: "fatal",
+          code: "renderer_error",
+          message: "Daintree Assistant is starting — try again in a moment.",
+        });
         useVoiceRecordingStore
           .getState()
           .announce("Daintree Assistant is starting. Try dictation again in a moment.");
@@ -898,7 +942,11 @@ class VoiceRecordingService {
 
     const target = this.getFocusedPanelTarget();
     if (!target) {
-      useVoiceRecordingStore.getState().setError("No focused terminal is available for dictation.");
+      useVoiceRecordingStore.getState().setLastError({
+        severity: "fatal",
+        code: "renderer_error",
+        message: "No focused terminal is available for dictation.",
+      });
       useVoiceRecordingStore
         .getState()
         .announce("Focus a terminal input before starting dictation.");
@@ -928,7 +976,11 @@ class VoiceRecordingService {
     // the user to retry once the session exists.
     const assistantTarget = this.getAssistantTarget();
     if (!assistantTarget) {
-      useVoiceRecordingStore.getState().setError("Start the Daintree Assistant before dictating.");
+      useVoiceRecordingStore.getState().setLastError({
+        severity: "fatal",
+        code: "renderer_error",
+        message: "Start the Daintree Assistant before dictating.",
+      });
       useVoiceRecordingStore.getState().announce("Start the Daintree Assistant before dictating.");
       return;
     }

--- a/src/services/__tests__/VoiceRecordingService.adversarial.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.adversarial.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { VoiceRecordingTarget } from "@/store/voiceRecordingStore";
+import type { VoiceInputError } from "@shared/types";
 
 type VoiceStatusCallback = (status: string) => void;
-type VoiceErrorCallback = (error: string) => void;
+type VoiceErrorCallback = (error: VoiceInputError) => void;
 type VoidCleanup = () => void;
 
 interface MockTrack {
@@ -90,7 +91,7 @@ const runtime = vi.hoisted(() => ({
     isConfigured: false,
   },
   voiceFns: {
-    setError: vi.fn<(message: string | null) => void>(),
+    setLastError: vi.fn<(error: VoiceInputError | null) => void>(),
     announce: vi.fn<(text: string) => void>(),
     setStatus: vi.fn<(status: string) => void>(),
     setConfigured: vi.fn<(configured: boolean) => void>(),
@@ -190,7 +191,7 @@ function resetRuntime(): void {
   runtime.createdWorkletNodes = [];
   Object.values(runtime.voiceInput).forEach((fn) => fn.mockReset());
 
-  runtime.voiceFns.setError.mockImplementation(() => undefined);
+  runtime.voiceFns.setLastError.mockImplementation(() => undefined);
   runtime.voiceFns.announce.mockImplementation(() => undefined);
   runtime.voiceFns.setStatus.mockImplementation((status) => {
     runtime.voiceState.status = status;
@@ -460,7 +461,7 @@ function emitStatus(status: string): void {
   }
 }
 
-function emitError(error: string): void {
+function emitError(error: VoiceInputError): void {
   for (const listener of runtime.errorListeners) {
     listener(error);
   }
@@ -596,14 +597,45 @@ describe("VoiceRecordingService adversarial", () => {
       expect(runtime.voiceFns.setStatus).toHaveBeenCalledWith("finishing");
     });
     emitStatus("idle");
-    emitError("network lost");
+    // A late backend error arriving mid-drain (isStoppingSession === true) must be
+    // suppressed — it would otherwise clobber lastError and prematurely finalize
+    // a session that's already winding down gracefully.
+    emitError({ severity: "fatal", code: "ws_close_1006", message: "network lost" });
     stopDeferred.resolve();
     await stopPromise;
 
     expect(runtime.voiceInput.stop).toHaveBeenCalledTimes(1);
     expect(runtime.voiceFns.finishSession).toHaveBeenCalledTimes(1);
     expect(runtime.voiceFns.announce).toHaveBeenCalledTimes(1);
-    expect(runtime.voiceFns.setError).not.toHaveBeenCalled();
+    // The error is dropped while stopping, so the structured error never reaches
+    // the store — lastError stays whatever it was before the graceful stop.
+    expect(runtime.voiceFns.setLastError).not.toHaveBeenCalled();
+  });
+
+  it("TRANSIENT_ERROR_STORES_STRUCTURED_PAYLOAD_AND_KEEPS_SESSION", async () => {
+    runtime.voiceState.activeTarget = { panelId: "panel-1", panelTitle: "Panel One" };
+    runtime.voiceState.status = "recording";
+    runtime.voiceState.panelBuffers["panel-1"] = createPanelBuffer();
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    voiceRecordingService.initialize();
+
+    const transientError: VoiceInputError = {
+      severity: "transient",
+      code: "rate_limit_exceeded",
+      message: "Rate limited, reconnecting…",
+    };
+    emitError(transientError);
+
+    // The full structured payload — not just a string — is forwarded to the store
+    // so the renderer can branch on code/severity for tooltip and recovery copy.
+    expect(runtime.voiceFns.setLastError).toHaveBeenCalledTimes(1);
+    expect(runtime.voiceFns.setLastError).toHaveBeenCalledWith(transientError);
+    // Transient errors are recoverable: the main process is already reconnecting,
+    // so the session must stay alive (no teardown / no remote stop).
+    expect(runtime.voiceFns.finishSession).not.toHaveBeenCalled();
+    expect(runtime.voiceInput.stop).not.toHaveBeenCalled();
+    expect(runtime.voiceState.activeTarget?.panelId).toBe("panel-1");
   });
 
   it("PAUSE_AUTO_STOPS_AFTER_60S_WHEN_NOT_RESUMED", async () => {

--- a/src/services/__tests__/VoiceRecordingService.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.test.ts
@@ -13,7 +13,7 @@ vi.mock("@/store/voiceRecordingStore", () => {
     isConfigured: false,
   };
   const fns = {
-    setError: vi.fn(),
+    setLastError: vi.fn(),
     announce: vi.fn(),
     setStatus: vi.fn(),
     setConfigured: vi.fn(),
@@ -548,12 +548,12 @@ describe("VoiceRecordingService — assistant dictation routing (#8887)", () => 
     const voice = (await import("@/store/voiceRecordingStore")) as unknown as {
       useVoiceRecordingStore: {
         getState: () => {
-          setError: ReturnType<typeof vi.fn>;
+          setLastError: ReturnType<typeof vi.fn>;
           announce: ReturnType<typeof vi.fn>;
         };
       };
     };
-    voice.useVoiceRecordingStore.getState().setError.mockClear();
+    voice.useVoiceRecordingStore.getState().setLastError.mockClear();
     voice.useVoiceRecordingStore.getState().announce.mockClear();
     return { macro, help, panel };
   }
@@ -596,8 +596,8 @@ describe("VoiceRecordingService — assistant dictation routing (#8887)", () => 
     await voiceRecordingService.toggleFocusedPanel();
 
     expect(toggleSpy).not.toHaveBeenCalled();
-    expect(useVoiceRecordingStore.getState().setError).toHaveBeenCalledWith(
-      expect.stringContaining("starting")
+    expect(useVoiceRecordingStore.getState().setLastError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining("starting") })
     );
   });
 
@@ -635,8 +635,8 @@ describe("VoiceRecordingService — assistant dictation routing (#8887)", () => 
     expect(help.__fns.setOpen).toHaveBeenCalledWith(true);
     expect(help.__fns.requestFocus).toHaveBeenCalled();
     expect(toggleSpy).not.toHaveBeenCalled();
-    expect(useVoiceRecordingStore.getState().setError).toHaveBeenCalledWith(
-      expect.stringContaining("Start the Daintree Assistant")
+    expect(useVoiceRecordingStore.getState().setLastError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining("Start the Daintree Assistant") })
     );
   });
 
@@ -725,8 +725,8 @@ describe("VoiceRecordingService — assistant dictation routing (#8887)", () => 
     await voiceRecordingService.toggleAssistant();
 
     expect(toggleSpy).not.toHaveBeenCalled();
-    expect(useVoiceRecordingStore.getState().setError).toHaveBeenCalledWith(
-      expect.stringContaining("Start the Daintree Assistant")
+    expect(useVoiceRecordingStore.getState().setLastError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining("Start the Daintree Assistant") })
     );
   });
 });

--- a/src/store/__tests__/voiceRecordingStore.test.ts
+++ b/src/store/__tests__/voiceRecordingStore.test.ts
@@ -9,7 +9,7 @@ function reset() {
     isConfigured: false,
     correctionEnabled: false,
     status: "idle",
-    errorMessage: null,
+    lastError: null,
     activeTarget: null,
     elapsedSeconds: 0,
     audioLevel: 0,

--- a/src/store/voiceRecordingStore.ts
+++ b/src/store/voiceRecordingStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { VoiceInputStatus, VoiceTranscriptPhase } from "@shared/types";
+import type { VoiceInputError, VoiceInputStatus, VoiceTranscriptPhase } from "@shared/types";
 
 export interface VoiceRecordingTarget {
   panelId: string;
@@ -44,7 +44,7 @@ interface VoiceRecordingState {
   /** Whether AI correction is enabled for the current session. */
   correctionEnabled: boolean;
   status: VoiceInputStatus;
-  errorMessage: string | null;
+  lastError: VoiceInputError | null;
   activeTarget: VoiceRecordingTarget | null;
   elapsedSeconds: number;
   audioLevel: number;
@@ -55,7 +55,7 @@ interface VoiceRecordingState {
   setAudioLevel: (level: number) => void;
   beginSession: (target: VoiceRecordingTarget) => void;
   setStatus: (status: VoiceInputStatus) => void;
-  setError: (message: string | null) => void;
+  setLastError: (error: VoiceInputError | null) => void;
   setElapsedSeconds: (seconds: number) => void;
   appendDelta: (delta: string) => void;
   setSessionDraftStart: (panelId: string, length: number) => void;
@@ -92,7 +92,7 @@ export const useVoiceRecordingStore = create<VoiceRecordingState>()((set, get) =
   isConfigured: false,
   correctionEnabled: false,
   status: "idle",
-  errorMessage: null,
+  lastError: null,
   activeTarget: null,
   elapsedSeconds: 0,
   audioLevel: 0,
@@ -109,7 +109,7 @@ export const useVoiceRecordingStore = create<VoiceRecordingState>()((set, get) =
     set((state) => ({
       activeTarget: target,
       status: "connecting",
-      errorMessage: null,
+      lastError: null,
       elapsedSeconds: 0,
       panelBuffers: {
         ...state.panelBuffers,
@@ -129,7 +129,7 @@ export const useVoiceRecordingStore = create<VoiceRecordingState>()((set, get) =
 
   setStatus: (status) => set({ status }),
 
-  setError: (message) => set({ errorMessage: message }),
+  setLastError: (error) => set({ lastError: error }),
 
   setElapsedSeconds: (elapsedSeconds) => set({ elapsedSeconds }),
 


### PR DESCRIPTION
## Summary

- Replaces unstructured error strings throughout the voice input stack with `VoiceInputError` — a plain serializable object carrying `severity` (`transient` | `fatal`), a stable `code`, and a `message`
- Transient errors (WebSocket drops, rate limits) keep the session alive while the backend reconnects; fatal errors stop the session and emit a toast routed via `connectivity` event policy
- The `VoiceInputButton` tooltip now uses `formatVoiceErrorTooltip` to map known codes to actionable copy instead of surfacing raw server messages

Resolves #9171

## Changes

- `shared/types/voice.ts` — adds `VoiceInputError` and `VoiceInputErrorSeverity`; exported through `shared/types/index.ts` and `shared/types/ipc/api.ts`
- `electron/services/voice/TranscriptionProvider.ts` — `VoiceTranscriptionEvent` error branch updated from `{ message: string }` to `{ error: VoiceInputError }`
- `electron/services/voice/OpenAITranscriptionProvider.ts` — adds `classifyOpenAIError` and `classifyCloseCode` pure classifier functions; `handleFatalError` now takes a `VoiceInputError`; transient server errors emit the classified error before terminating, and the close handler guards `lastReconnectError` against overwrites by synthetic 1006 codes
- `electron/services/voice/DeepgramTranscriptionProvider.ts` — error emission updated to match the new union shape
- `electron/ipc/handlers/voiceInput.ts` and `electron/preload.cts` — pass the full `VoiceInputError` object over IPC instead of `voiceEvent.message`
- `src/services/VoiceRecordingService.ts` — `onError` branches on severity: transient errors store the classified error for tooltip context and return; fatal errors stop the session and emit a toast; all renderer-side pre-connect error paths use `setLastError` with structured objects
- `src/store/voiceRecordingStore.ts` — `errorMessage: string | null` replaced by `lastError: VoiceInputError | null`
- `src/components/Terminal/VoiceInputButton.tsx` — tooltip reads `lastError` via `formatVoiceErrorTooltip`
- Tests updated throughout; existing suites pass with no new failures

## Testing

- Unit tests: `OpenAITranscriptionProvider`, `DeepgramTranscriptionProvider`, `VoiceTranscriptionService`, `voiceRecordingStore`, `VoiceInputButton`, `VoiceRecordingService` — all passing (103 tests)
- Typecheck clean across renderer and electron tsconfigs
- Lint ratchet updated (net -1 warning)