### PR TITLE
feat(plugins): add host.dispatch(actionId, args) to the plugin host API

### DIFF
--- a/electron/ipc/__tests__/channelDrift.test.ts
+++ b/electron/ipc/__tests__/channelDrift.test.ts
@@ -58,6 +58,7 @@ const DEAD_CHANNEL_ALLOWLIST = new Set<string>([
   "app-agent:dispatch-action-response",
   "mcp:dispatch-action-response",
   "mcp:get-manifest-response",
+  "plugin:dispatch-action-response",
 
   // fire-and-forget — main→renderer broadcast for in-app demo command
   // forwarding (`sendCommandAndAwait` in handlers/demo.ts). The renderer

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -805,6 +805,10 @@ export const CHANNELS = {
   PLUGIN_SET_AUDIT_ENABLED: "plugin:set-audit-enabled",
   PLUGIN_SET_AUDIT_MAX_RECORDS: "plugin:set-audit-max-records",
   PLUGIN_EXPORT_AUDIT_LOG: "plugin:export-audit-log",
+  /** Bridge: main process dispatches a plugin-sourced action request to the renderer. */
+  PLUGIN_DISPATCH_ACTION_REQUEST: "plugin:dispatch-action-request",
+  /** Bridge: renderer returns the plugin-sourced action dispatch result to the main process. */
+  PLUGIN_DISPATCH_ACTION_RESPONSE: "plugin:dispatch-action-response",
 
   // Config reload channels
   APP_RELOAD_CONFIG: "app:reload-config",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -19,7 +19,7 @@ import type {
   McpGrantLifecyclePayload,
   McpBearerIdentity,
 } from "../shared/types/ipc/mcpServer.js";
-import type { ActionContext } from "../shared/types/actions.js";
+import type { ActionContext, ActionDispatchResult } from "../shared/types/actions.js";
 import type { PushProgressEvent } from "../shared/types/ipc/gitPush.js";
 import { CHANNELS } from "./ipc/channels.js";
 import {
@@ -2421,6 +2421,23 @@ const api: ElectronAPI = {
       confirmationDecision?: "approved" | "rejected" | "timeout";
     }) => {
       ipcRenderer.send(CHANNELS.MCP_SERVER_DISPATCH_ACTION_RESPONSE, payload);
+    },
+  },
+
+  pluginBridge: {
+    onDispatchActionRequest: (
+      callback: (payload: { requestId: string; actionId: string; args?: unknown }) => void
+    ) => {
+      const handler = (
+        _event: Electron.IpcRendererEvent,
+        payload: { requestId: string; actionId: string; args?: unknown }
+      ) => callback(payload);
+      ipcRenderer.on(CHANNELS.PLUGIN_DISPATCH_ACTION_REQUEST, handler);
+      return () => ipcRenderer.removeListener(CHANNELS.PLUGIN_DISPATCH_ACTION_REQUEST, handler);
+    },
+
+    sendDispatchActionResponse: (payload: { requestId: string; result: ActionDispatchResult }) => {
+      ipcRenderer.send(CHANNELS.PLUGIN_DISPATCH_ACTION_RESPONSE, payload);
     },
   },
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -1291,6 +1291,16 @@ export class PluginService {
    */
   private sendDispatchToRenderer(actionId: string, args: unknown): Promise<ActionDispatchResult> {
     return new Promise((resolve) => {
+      if (this.disposed) {
+        resolve({
+          ok: false,
+          error: {
+            code: "EXECUTION_ERROR",
+            message: "PluginService is disposed",
+          },
+        });
+        return;
+      }
       const webContents = this.resolveActiveWebContents();
       if (!webContents) {
         resolve({

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -3,7 +3,8 @@ import fs from "fs/promises";
 import path from "path";
 import os from "os";
 import { pathToFileURL } from "url";
-import { app } from "electron";
+import { app, ipcMain } from "electron";
+import { randomUUID } from "node:crypto";
 import * as semver from "semver";
 // Aliased to avoid colliding with Vite's auto-injected ESM shim
 // (`import { createRequire } from 'module'; const require = createRequire(import.meta.url);`),
@@ -85,6 +86,8 @@ import {
 } from "./fileDecorationRegistry.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
 import { CHANNELS } from "../ipc/channels.js";
+import { getWindowRegistry, getProjectViewManager } from "../window/windowRef.js";
+import type { ActionDispatchResult } from "../../shared/types/actions.js";
 import type { LoadedPluginInfo } from "../../shared/types/plugin.js";
 import type { PluginToolbarButtonId } from "../../shared/types/toolbar.js";
 import { store } from "../store.js";
@@ -126,6 +129,26 @@ interface LoadedPlugin {
 }
 
 const ACTIVATE_TIMEOUT_MS = 5000;
+/**
+ * Time budget for a `host.dispatch()` main→renderer round-trip. Matches the MCP
+ * dispatch timeout (`MCP_DISPATCH_TIMEOUT_MS`); without it a destroyed or
+ * unresponsive renderer would leak entries in `pendingPluginDispatches` forever.
+ * On timeout the pending request resolves with an `EXECUTION_ERROR` result.
+ */
+const PLUGIN_DISPATCH_TIMEOUT_MS = 30_000;
+
+/**
+ * A `host.dispatch()` request awaiting its renderer response. Unlike the MCP
+ * bridge's `PendingRequest`, the promise always resolves with an
+ * {@link ActionDispatchResult} (never rejects) — `host.dispatch` returns the
+ * `{ ok: false }` envelope on failure rather than throwing.
+ */
+interface PendingPluginDispatch {
+  resolve: (result: ActionDispatchResult) => void;
+  timer: ReturnType<typeof setTimeout>;
+  webContentsId: number;
+  destroyedCleanup?: () => void;
+}
 /**
  * Time budget for the dynamic `import()` step in {@link PluginService._doActivate}.
  * Separate from {@link ACTIVATE_TIMEOUT_MS} (which guards the plugin's exported
@@ -270,6 +293,18 @@ export class PluginService {
   private toolbarButtonsBroadcastComplete = false;
   private disposed = false;
   private readonly disposeRegistrySubscriptions: () => void;
+  /**
+   * In-flight `host.dispatch()` round-trips keyed by `requestId`. Each entry is
+   * resolved by the {@link CHANNELS.PLUGIN_DISPATCH_ACTION_RESPONSE} listener,
+   * the timeout, the renderer's `destroyed` event, or {@link dispose}.
+   */
+  private pendingPluginDispatches = new Map<string, PendingPluginDispatch>();
+  /**
+   * Removes the lazily-registered `ipcMain` response listener for plugin
+   * dispatch. `null` until the first `host.dispatch()` registers it; cleared in
+   * {@link dispose}.
+   */
+  private pluginDispatchListenerCleanup: (() => void) | null = null;
 
   constructor(
     pluginsRoot?: string,
@@ -298,6 +333,20 @@ export class PluginService {
   dispose(): void {
     this.disposed = true;
     this.disposeRegistrySubscriptions();
+    this.pluginDispatchListenerCleanup?.();
+    this.pluginDispatchListenerCleanup = null;
+    for (const pending of this.pendingPluginDispatches.values()) {
+      clearTimeout(pending.timer);
+      pending.destroyedCleanup?.();
+      pending.resolve({
+        ok: false,
+        error: {
+          code: "EXECUTION_ERROR",
+          message: "PluginService disposed before plugin action dispatch resolved",
+        },
+      });
+    }
+    this.pendingPluginDispatches.clear();
   }
 
   /**
@@ -1148,6 +1197,25 @@ export class PluginService {
           rateLimitKey: `plugin:${pluginId}:${parsed.data.type}`,
         });
       },
+      // NOT revoke-guarded for the same reason as invalidateFileDecorations and
+      // showToast: plugins dispatch actions from post-activation callbacks and
+      // timers. Liveness is plugin membership — once the plugin unloads this
+      // returns PLUGIN_UNLOADED without attempting a round-trip. Args are
+      // validated by ActionService against the action's argsSchema, and
+      // danger:"restricted"/"confirm" are rejected there with the "plugin"
+      // source, so the host does not re-check them.
+      dispatch: async (actionId, args) => {
+        if (!this.plugins.has(pluginId)) {
+          return {
+            ok: false,
+            error: {
+              code: "PLUGIN_UNLOADED",
+              message: `Plugin "${pluginId}" is no longer loaded`,
+            },
+          };
+        }
+        return this.sendDispatchToRenderer(actionId, args);
+      },
     };
     return {
       host,
@@ -1155,6 +1223,148 @@ export class PluginService {
         revoked = true;
       },
     };
+  }
+
+  /**
+   * Resolve the active project's renderer WebContents, mirroring the MCP
+   * renderer bridge's resolution order: walk every live window's active
+   * project view first, then fall back to the global `ProjectViewManager`.
+   * Returns `null` (rather than throwing) when no renderer is available so
+   * `sendDispatchToRenderer` can return an error result.
+   */
+  private resolveActiveWebContents(): Electron.WebContents | null {
+    const registry = getWindowRegistry();
+    if (registry) {
+      for (const ctx of registry.all()) {
+        if (ctx.browserWindow.isDestroyed()) continue;
+        const webContents = ctx.services.projectViewManager?.getActiveView()?.webContents;
+        if (webContents && !webContents.isDestroyed()) {
+          return webContents;
+        }
+      }
+    }
+    const fallback = getProjectViewManager()?.getActiveView()?.webContents;
+    if (fallback && !fallback.isDestroyed()) {
+      return fallback;
+    }
+    return null;
+  }
+
+  /**
+   * Lazily register the single `ipcMain` listener that resolves plugin dispatch
+   * responses. Registered on first `host.dispatch()` and torn down in
+   * {@link dispose}. The handler validates `event.sender.id` against the
+   * pending request's `webContentsId` so a renderer in another window cannot
+   * resolve a dispatch initiated for a different window (#4641).
+   */
+  private ensurePluginDispatchListener(): void {
+    if (this.pluginDispatchListenerCleanup) return;
+    const handler = (
+      event: Electron.IpcMainEvent,
+      payload: { requestId: string; result: ActionDispatchResult }
+    ) => {
+      if (!payload || typeof payload.requestId !== "string") return;
+      const pending = this.pendingPluginDispatches.get(payload.requestId);
+      if (!pending) return;
+      if (event.sender.id !== pending.webContentsId) {
+        console.warn(
+          `[PluginService] Ignoring dispatch response from unexpected sender ${event.sender.id} (expected ${pending.webContentsId}, requestId=${payload.requestId})`
+        );
+        return;
+      }
+      clearTimeout(pending.timer);
+      pending.destroyedCleanup?.();
+      this.pendingPluginDispatches.delete(payload.requestId);
+      pending.resolve(payload.result);
+    };
+    ipcMain.on(CHANNELS.PLUGIN_DISPATCH_ACTION_RESPONSE, handler);
+    this.pluginDispatchListenerCleanup = () => {
+      ipcMain.removeListener(CHANNELS.PLUGIN_DISPATCH_ACTION_RESPONSE, handler);
+    };
+  }
+
+  /**
+   * Send a plugin-sourced action dispatch to the active renderer and await its
+   * response. Always resolves with an {@link ActionDispatchResult} — failures
+   * (no renderer, timeout, destroyed view, send error) come back as
+   * `EXECUTION_ERROR` rather than a rejected promise.
+   */
+  private sendDispatchToRenderer(actionId: string, args: unknown): Promise<ActionDispatchResult> {
+    return new Promise((resolve) => {
+      const webContents = this.resolveActiveWebContents();
+      if (!webContents) {
+        resolve({
+          ok: false,
+          error: {
+            code: "EXECUTION_ERROR",
+            message: "No active renderer available to dispatch plugin action",
+          },
+        });
+        return;
+      }
+
+      this.ensurePluginDispatchListener();
+
+      const requestId = randomUUID();
+      const webContentsId = webContents.id;
+      const timer = setTimeout(() => {
+        const pending = this.pendingPluginDispatches.get(requestId);
+        if (!pending) return;
+        pending.destroyedCleanup?.();
+        this.pendingPluginDispatches.delete(requestId);
+        resolve({
+          ok: false,
+          error: {
+            code: "EXECUTION_ERROR",
+            message: `Plugin action dispatch timed out: ${actionId}`,
+          },
+        });
+      }, PLUGIN_DISPATCH_TIMEOUT_MS);
+
+      const onDestroyed = () => {
+        const pending = this.pendingPluginDispatches.get(requestId);
+        if (!pending) return;
+        clearTimeout(pending.timer);
+        this.pendingPluginDispatches.delete(requestId);
+        resolve({
+          ok: false,
+          error: {
+            code: "EXECUTION_ERROR",
+            message: "Renderer destroyed before plugin action dispatch resolved",
+          },
+        });
+      };
+      webContents.once("destroyed", onDestroyed);
+      const destroyedCleanup = () => {
+        try {
+          webContents.removeListener("destroyed", onDestroyed);
+        } catch {
+          // best-effort; webContents may already be gone
+        }
+      };
+
+      this.pendingPluginDispatches.set(requestId, {
+        resolve,
+        timer,
+        webContentsId,
+        destroyedCleanup,
+      });
+
+      try {
+        webContents.send(CHANNELS.PLUGIN_DISPATCH_ACTION_REQUEST, { requestId, actionId, args });
+      } catch {
+        clearTimeout(timer);
+        destroyedCleanup();
+        this.pendingPluginDispatches.delete(requestId);
+        resolve({
+          ok: false,
+          error: {
+            code: "EXECUTION_ERROR",
+            message: `Failed to dispatch plugin action: ${actionId}`,
+          },
+        });
+      }
+    });
   }
 
   private async fetchAllWorktreeSnapshots(): Promise<WorktreeSnapshot[]> {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -9,6 +9,31 @@ import type { PanelKindConfig } from "../../../shared/config/panelKindRegistry.j
 const appMock = vi.hoisted(() => ({
   getVersion: vi.fn(() => "0.0.0"),
 }));
+const ipcMainMock = vi.hoisted(() => {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+  return {
+    on: vi.fn((channel: string, handler: (...args: unknown[]) => void) => {
+      let set = listeners.get(channel);
+      if (!set) {
+        set = new Set();
+        listeners.set(channel, set);
+      }
+      set.add(handler);
+    }),
+    removeListener: vi.fn((channel: string, handler: (...args: unknown[]) => void) => {
+      listeners.get(channel)?.delete(handler);
+    }),
+    _emit: (channel: string, event: unknown, payload: unknown) => {
+      for (const handler of [...(listeners.get(channel) ?? [])]) handler(event, payload);
+    },
+    _listenerCount: (channel: string) => listeners.get(channel)?.size ?? 0,
+    _reset: () => listeners.clear(),
+  };
+});
+const windowRefMock = vi.hoisted(() => ({
+  getWindowRegistry: vi.fn(() => null),
+  getProjectViewManager: vi.fn(() => null),
+}));
 const broadcastToRendererMock = vi.hoisted(() => vi.fn());
 const storeMock = vi.hoisted(() => {
   const state = new Map<string, unknown>();
@@ -21,6 +46,15 @@ const storeMock = vi.hoisted(() => {
 
 vi.mock("electron", () => ({
   app: appMock,
+  ipcMain: ipcMainMock,
+}));
+vi.mock("../../window/windowRef.js", () => ({
+  getWindowRegistry: windowRefMock.getWindowRegistry,
+  getProjectViewManager: windowRefMock.getProjectViewManager,
+  setWindowRegistry: vi.fn(),
+  setMainWindow: vi.fn(),
+  getMainWindow: vi.fn(() => null),
+  setProjectViewManager: vi.fn(),
 }));
 vi.mock("../../ipc/utils.js", () => ({
   broadcastToRenderer: broadcastToRendererMock,
@@ -2507,6 +2541,220 @@ describe("createHost — showToast", () => {
       (call: unknown[]) => call[0] === CHANNELS.NOTIFICATION_SHOW_TOAST
     );
     expect(toastBroadcasts).toHaveLength(0);
+  });
+});
+
+type DispatchHostShape = (pluginId: string) => {
+  host: {
+    dispatch: (
+      actionId: string,
+      args?: unknown
+    ) => Promise<import("../../../shared/types/actions.js").ActionDispatchResult>;
+  };
+  revoke: () => void;
+};
+
+interface FakeWebContents {
+  id: number;
+  isDestroyed: () => boolean;
+  once: ReturnType<typeof vi.fn>;
+  removeListener: ReturnType<typeof vi.fn>;
+  send: ReturnType<typeof vi.fn>;
+  _triggerDestroyed: () => void;
+}
+
+function makeFakeWebContents(id: number): FakeWebContents {
+  const destroyedHandlers = new Set<() => void>();
+  return {
+    id,
+    isDestroyed: () => false,
+    once: vi.fn((event: string, cb: () => void) => {
+      if (event === "destroyed") destroyedHandlers.add(cb);
+    }),
+    removeListener: vi.fn((event: string, cb: () => void) => {
+      if (event === "destroyed") destroyedHandlers.delete(cb);
+    }),
+    send: vi.fn(),
+    _triggerDestroyed: () => {
+      for (const cb of [...destroyedHandlers]) cb();
+    },
+  };
+}
+
+/** Set the active renderer the plugin dispatch bridge will target, or `null`. */
+function setActiveWebContents(wc: FakeWebContents | null): void {
+  windowRefMock.getWindowRegistry.mockReturnValue(null);
+  windowRefMock.getProjectViewManager.mockReturnValue(
+    wc ? ({ getActiveView: () => ({ webContents: wc }) } as never) : null
+  );
+}
+
+/** Read the request payload from the most recent dispatch `webContents.send`. */
+function lastDispatchRequest(wc: FakeWebContents): {
+  requestId: string;
+  actionId: string;
+  args?: unknown;
+} {
+  const call = [...wc.send.mock.calls]
+    .reverse()
+    .find((c) => c[0] === CHANNELS.PLUGIN_DISPATCH_ACTION_REQUEST);
+  if (!call) throw new Error("no PLUGIN_DISPATCH_ACTION_REQUEST send recorded");
+  return call[1] as { requestId: string; actionId: string; args?: unknown };
+}
+
+describe("createHost — dispatch", () => {
+  beforeEach(() => {
+    ipcMainMock._reset();
+    setActiveWebContents(null);
+  });
+
+  it("returns PLUGIN_UNLOADED without a round-trip once the plugin is unloaded", async () => {
+    const wc = makeFakeWebContents(7);
+    setActiveWebContents(wc);
+    await writePlugin("dispatch-unload", { name: "acme.dispatch-unload", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: DispatchHostShape }).createHost(
+      "acme.dispatch-unload"
+    );
+
+    service.unloadPlugin("acme.dispatch-unload");
+    const result = await host.dispatch("terminal.new", { x: 1 });
+
+    expect(result).toEqual({
+      ok: false,
+      error: { code: "PLUGIN_UNLOADED", message: expect.stringContaining("no longer loaded") },
+    });
+    expect(wc.send).not.toHaveBeenCalled();
+  });
+
+  it("returns EXECUTION_ERROR when no renderer is available", async () => {
+    setActiveWebContents(null);
+    await writePlugin("dispatch-norender", { name: "acme.dispatch-norender", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: DispatchHostShape }).createHost(
+      "acme.dispatch-norender"
+    );
+
+    const result = await host.dispatch("app.openSettings");
+    expect(result).toEqual({
+      ok: false,
+      error: { code: "EXECUTION_ERROR", message: expect.stringContaining("No active renderer") },
+    });
+  });
+
+  it("sends the request and resolves with the renderer's matching response", async () => {
+    const wc = makeFakeWebContents(11);
+    setActiveWebContents(wc);
+    await writePlugin("dispatch-ok", { name: "acme.dispatch-ok", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: DispatchHostShape }).createHost(
+      "acme.dispatch-ok"
+    );
+
+    const pending = host.dispatch("acme.dispatch-ok.doThing", { count: 3 });
+
+    const req = lastDispatchRequest(wc);
+    expect(req.actionId).toBe("acme.dispatch-ok.doThing");
+    expect(req.args).toEqual({ count: 3 });
+    expect(typeof req.requestId).toBe("string");
+
+    ipcMainMock._emit(
+      CHANNELS.PLUGIN_DISPATCH_ACTION_RESPONSE,
+      { sender: { id: 11 } },
+      { requestId: req.requestId, result: { ok: true, result: 42 } }
+    );
+
+    await expect(pending).resolves.toEqual({ ok: true, result: 42 });
+  });
+
+  it("ignores a response from an unexpected sender id (cross-window guard)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const wc = makeFakeWebContents(11);
+    setActiveWebContents(wc);
+    await writePlugin("dispatch-guard", { name: "acme.dispatch-guard", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: DispatchHostShape }).createHost(
+      "acme.dispatch-guard"
+    );
+
+    const pending = host.dispatch("acme.dispatch-guard.go");
+    const req = lastDispatchRequest(wc);
+
+    // Ignore any warnings emitted during plugin load/init; only count the guard.
+    warnSpy.mockClear();
+
+    // Wrong sender — must be ignored and warned about.
+    ipcMainMock._emit(
+      CHANNELS.PLUGIN_DISPATCH_ACTION_RESPONSE,
+      { sender: { id: 999 } },
+      { requestId: req.requestId, result: { ok: true, result: "spoofed" } }
+    );
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("unexpected sender"));
+
+    // Correct sender — resolves with the real result.
+    ipcMainMock._emit(
+      CHANNELS.PLUGIN_DISPATCH_ACTION_RESPONSE,
+      { sender: { id: 11 } },
+      { requestId: req.requestId, result: { ok: true, result: "real" } }
+    );
+
+    await expect(pending).resolves.toEqual({ ok: true, result: "real" });
+    warnSpy.mockRestore();
+  });
+
+  it("dispose() drains pending dispatches and removes the response listener", async () => {
+    const wc = makeFakeWebContents(11);
+    setActiveWebContents(wc);
+    await writePlugin("dispatch-dispose", { name: "acme.dispatch-dispose", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: DispatchHostShape }).createHost(
+      "acme.dispatch-dispose"
+    );
+
+    const pending = host.dispatch("acme.dispatch-dispose.go");
+    expect(ipcMainMock._listenerCount(CHANNELS.PLUGIN_DISPATCH_ACTION_RESPONSE)).toBe(1);
+
+    service.dispose();
+
+    await expect(pending).resolves.toEqual({
+      ok: false,
+      error: { code: "EXECUTION_ERROR", message: expect.stringContaining("disposed") },
+    });
+    expect(ipcMainMock.removeListener).toHaveBeenCalledWith(
+      CHANNELS.PLUGIN_DISPATCH_ACTION_RESPONSE,
+      expect.any(Function)
+    );
+  });
+
+  it("resolves with EXECUTION_ERROR when the target renderer is destroyed mid-dispatch", async () => {
+    const wc = makeFakeWebContents(11);
+    setActiveWebContents(wc);
+    await writePlugin("dispatch-destroyed", { name: "acme.dispatch-destroyed", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: DispatchHostShape }).createHost(
+      "acme.dispatch-destroyed"
+    );
+
+    const pending = host.dispatch("acme.dispatch-destroyed.go");
+    wc._triggerDestroyed();
+
+    await expect(pending).resolves.toEqual({
+      ok: false,
+      error: { code: "EXECUTION_ERROR", message: expect.stringContaining("destroyed") },
+    });
   });
 });
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -2756,6 +2756,71 @@ describe("createHost — dispatch", () => {
       error: { code: "EXECUTION_ERROR", message: expect.stringContaining("destroyed") },
     });
   });
+
+  it("after dispose() returns EXECUTION_ERROR without re-registering a listener", async () => {
+    const wc = makeFakeWebContents(11);
+    setActiveWebContents(wc);
+    await writePlugin("dispatch-after-dispose", {
+      name: "acme.dispatch-after-dispose",
+      version: "1.0.0",
+    });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: DispatchHostShape }).createHost(
+      "acme.dispatch-after-dispose"
+    );
+
+    // The plugin stays in the map (dispose doesn't unload), so the host's own
+    // PLUGIN_UNLOADED guard wouldn't catch this — the disposed guard must.
+    service.dispose();
+    const result = await host.dispatch("acme.dispatch-after-dispose.go");
+
+    expect(result).toEqual({
+      ok: false,
+      error: { code: "EXECUTION_ERROR", message: expect.stringContaining("disposed") },
+    });
+    expect(ipcMainMock._listenerCount(CHANNELS.PLUGIN_DISPATCH_ACTION_RESPONSE)).toBe(0);
+    expect(wc.send).not.toHaveBeenCalled();
+  });
+
+  it("times out a dispatch that never receives a response and ignores a late reply", async () => {
+    const wc = makeFakeWebContents(11);
+    setActiveWebContents(wc);
+    await writePlugin("dispatch-timeout", { name: "acme.dispatch-timeout", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: DispatchHostShape }).createHost(
+      "acme.dispatch-timeout"
+    );
+
+    // Switch to fake timers only after plugin load/init (which uses real I/O).
+    vi.useFakeTimers();
+    try {
+      const pending = host.dispatch("acme.dispatch-timeout.go");
+      const req = lastDispatchRequest(wc);
+
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      await expect(pending).resolves.toEqual({
+        ok: false,
+        error: { code: "EXECUTION_ERROR", message: expect.stringContaining("timed out") },
+      });
+
+      // A late response for a timed-out request is silently dropped (no throw,
+      // no double-resolve) because the pending entry was already deleted.
+      expect(() =>
+        ipcMainMock._emit(
+          CHANNELS.PLUGIN_DISPATCH_ACTION_RESPONSE,
+          { sender: { id: 11 } },
+          { requestId: req.requestId, result: { ok: true, result: "late" } }
+        )
+      ).not.toThrow();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("createHost — registerForgeProvider", () => {

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -2,7 +2,7 @@ import type { BuiltInKeyAction } from "./keymap.js";
 import type { BuiltInRuntimeActionId } from "../config/actionIds.js";
 import type { z } from "zod";
 
-export type ActionSource = "user" | "keybinding" | "menu" | "agent" | "context-menu";
+export type ActionSource = "user" | "keybinding" | "menu" | "agent" | "context-menu" | "plugin";
 
 export type ActionKind = "command" | "query";
 
@@ -210,7 +210,8 @@ export type ActionErrorCode =
   | "USER_REJECTED"
   | "CONFIRMATION_TIMEOUT"
   | "ELICITATION_FAILED"
-  | "BINDING_STALE";
+  | "BINDING_STALE"
+  | "PLUGIN_UNLOADED";
 
 export interface ActionError {
   code: ActionErrorCode;

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1454,6 +1454,22 @@ export interface ElectronAPI extends GeneratedElectronAPI {
       confirmationDecision?: import("./mcpServer.js").McpConfirmationDecision;
     }): void;
   };
+  pluginBridge: {
+    /**
+     * Listen for plugin-sourced action dispatch requests from the main process.
+     * Unlike {@link mcpBridge.onDispatchActionRequest} there is no `confirmed`,
+     * `context`, or `callerInfo`: plugins cannot bypass confirm-gating and don't
+     * override the action context.
+     */
+    onDispatchActionRequest(
+      callback: (payload: { requestId: string; actionId: string; args?: unknown }) => void
+    ): () => void;
+    /** Send the plugin action dispatch result back to the main process. */
+    sendDispatchActionResponse(payload: {
+      requestId: string;
+      result: import("../actions.js").ActionDispatchResult;
+    }): void;
+  };
   // list / toolbarButtons / menuItems / validateActionIds / get|register|
   // unregisterAction / getPanelKinds / getForgeProviders / getDecorations
   // come from GeneratedElectronAPI; invoke + on are variadic plugin RPC

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1635,6 +1635,21 @@ export interface IpcEventMap {
   };
 
   /**
+   * Plugin-sourced action dispatch request. Main process emits this on the
+   * active project WebContents and awaits a renderer `ipcRenderer.send` reply
+   * on `CHANNELS.PLUGIN_DISPATCH_ACTION_RESPONSE`, correlated by `requestId`.
+   * Unlike `mcp:dispatch-action-request` there is no `confirmed` or `context`:
+   * plugins cannot bypass confirm-gating and don't override the action context.
+   * The response channel is a renderer→main fire-and-forget send tracked in
+   * `DEAD_CHANNEL_ALLOWLIST` in channelDrift.test.ts.
+   */
+  "plugin:dispatch-action-request": {
+    requestId: string;
+    actionId: string;
+    args: unknown;
+  };
+
+  /**
    * Targeted push: a help-session tool call was denied because its tier
    * doesn't permit the tool. Sent to the pinned WebContents so the renderer
    * can surface an inline approval banner. Tier is `string` (not `McpTier`)

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -12,6 +12,7 @@ import type {
   ResourceRef,
 } from "./forge.js";
 import type { NotificationType } from "./notification.js";
+import type { ActionDispatchResult } from "./actions.js";
 
 export interface PanelContribution {
   id: string;
@@ -365,6 +366,25 @@ export interface PluginHostApi {
    * unknown `type`) reject so authoring mistakes surface loudly.
    */
   showToast(options: PluginToastOptions): Promise<void>;
+  /**
+   * Dispatch an action by id through the app's `ActionService` with a `"plugin"`
+   * source. Plugins use this to invoke their own registered actions, actions
+   * contributed by other plugins, or any built-in action — always through the
+   * audited, validated dispatch path rather than bypassing it.
+   *
+   * Args are validated against the action's `argsSchema` by `ActionService`;
+   * the host does not re-validate. Actions classified `danger: "restricted"`
+   * are rejected with `RESTRICTED`, and `danger: "confirm"` actions return
+   * `CONFIRMATION_REQUIRED` (plugins cannot bypass confirm-gating — there is no
+   * `confirmed` flag).
+   *
+   * Like {@link invalidateFileDecorations} and {@link showToast} this is NOT
+   * revoke-guarded: plugins call it from post-activation subscription callbacks
+   * and timers. Once the plugin is unloaded it returns
+   * `{ ok: false, error: { code: "PLUGIN_UNLOADED" } }` without attempting a
+   * dispatch.
+   */
+  dispatch(actionId: string, args?: unknown): Promise<ActionDispatchResult>;
 }
 
 export type PluginActivate = (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ import { useQuickCreatePalette } from "./hooks/useQuickCreatePalette";
 import { useDoubleShift } from "./hooks/useDoubleShift";
 import { useProjectMruSwitcher } from "./hooks/useProjectMruSwitcher";
 import { useMcpBridge } from "./hooks/useMcpBridge";
+import { usePluginBridge } from "./hooks/usePluginBridge";
 import { useFileDropGuard } from "./hooks/useFileDropGuard";
 import { useSoundPlaybackListener } from "./hooks/useSoundPlaybackListener";
 import { notifyViewPainted, removeStartupSkeleton } from "./utils/removeStartupSkeleton";
@@ -400,6 +401,7 @@ function AppInner() {
   useMainProcessToastListener();
 
   useMcpBridge();
+  usePluginBridge();
   useSoundPlaybackListener();
   const { homeDir } = useHomeDir();
 

--- a/src/hooks/usePluginBridge.ts
+++ b/src/hooks/usePluginBridge.ts
@@ -1,0 +1,56 @@
+import { useEffect } from "react";
+import { actionService } from "@/services/ActionService";
+import type { ActionId } from "@shared/types/actions";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
+
+/**
+ * Sets up the renderer-side plugin dispatch bridge.
+ *
+ * Listens for plugin-sourced action dispatch requests from the main process (a
+ * plugin calling `host.dispatch()`), routes them through `actionService.dispatch`
+ * with `source: "plugin"`, and returns the structured result. Unlike the MCP
+ * bridge there is no confirmation intercept: plugins cannot bypass confirm-gating,
+ * so `danger:"confirm"` actions return `CONFIRMATION_REQUIRED` and
+ * `danger:"restricted"` returns `RESTRICTED` directly from ActionService.
+ *
+ * The success response send sits inside the try block so a non-serializable
+ * action result (a DataCloneError on `ipcRenderer.send`) is caught and replaced
+ * with a serializable `EXECUTION_ERROR` envelope rather than stranding the
+ * main-side pending request until its timeout.
+ */
+export function usePluginBridge(): void {
+  useEffect(() => {
+    if (!window.electron?.pluginBridge) return;
+
+    let disposed = false;
+
+    const cleanup = window.electron.pluginBridge.onDispatchActionRequest(
+      async ({ requestId, actionId, args }) => {
+        try {
+          const result = await actionService.dispatch(actionId as ActionId, args, {
+            source: "plugin",
+          });
+          if (disposed) return;
+          window.electron.pluginBridge.sendDispatchActionResponse({ requestId, result });
+        } catch (err) {
+          if (disposed) return;
+          window.electron.pluginBridge.sendDispatchActionResponse({
+            requestId,
+            result: {
+              ok: false,
+              error: {
+                code: "EXECUTION_ERROR",
+                message: formatErrorMessage(err, "Plugin action dispatch failed"),
+              },
+            },
+          });
+        }
+      }
+    );
+
+    return () => {
+      disposed = true;
+      cleanup();
+    };
+  }, []);
+}

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -350,13 +350,13 @@ export class ActionService {
     }
 
     // Enforce confirmation for destructive actions from agent and plugin
-    // sources. Agents must explicitly confirm via { confirmed: true }; plugins
-    // have no confirm bypass at all (host.dispatch carries no `confirmed`), so
-    // danger:"confirm" actions always return CONFIRMATION_REQUIRED for them.
+    // sources. Agents may explicitly confirm via { confirmed: true }; plugins
+    // have NO confirm bypass — the `confirmed` flag is ignored for plugin
+    // sources, so danger:"confirm" actions always return CONFIRMATION_REQUIRED
+    // for them even if a caller spoofs `confirmed: true` on a "plugin" dispatch.
     if (
       definition.danger === "confirm" &&
-      (source === "agent" || source === "plugin") &&
-      !options?.confirmed
+      (source === "plugin" || (source === "agent" && !options?.confirmed))
     ) {
       const error: ActionError = {
         code: "CONFIRMATION_REQUIRED",

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -349,12 +349,18 @@ export class ActionService {
       return { ok: false, error };
     }
 
-    // Enforce confirmation for destructive actions from agent sources
-    // Agents must explicitly confirm before executing dangerous operations
-    if (definition.danger === "confirm" && source === "agent" && !options?.confirmed) {
+    // Enforce confirmation for destructive actions from agent and plugin
+    // sources. Agents must explicitly confirm via { confirmed: true }; plugins
+    // have no confirm bypass at all (host.dispatch carries no `confirmed`), so
+    // danger:"confirm" actions always return CONFIRMATION_REQUIRED for them.
+    if (
+      definition.danger === "confirm" &&
+      (source === "agent" || source === "plugin") &&
+      !options?.confirmed
+    ) {
       const error: ActionError = {
         code: "CONFIRMATION_REQUIRED",
-        message: `Action "${actionId}" requires explicit confirmation from agent sources. Set { confirmed: true } to proceed.`,
+        message: `Action "${actionId}" requires explicit confirmation from ${source} sources.`,
       };
       return { ok: false, error };
     }

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -304,11 +304,19 @@ describe("ActionService", () => {
         run: mockRun,
       });
 
-      // Even passing confirmed:true must not let a plugin bypass the gate; the
-      // host API never sets it, but assert defense-in-depth here anyway.
       const result = await service.dispatch("actions.list", undefined, { source: "plugin" });
       expect(result.ok).toBe(false);
       if (!result.ok) expect(result.error.code).toBe("CONFIRMATION_REQUIRED");
+      expect(mockRun).not.toHaveBeenCalled();
+
+      // Defense-in-depth: the host API never sets `confirmed`, but even a caller
+      // spoofing confirmed:true on a "plugin" dispatch must NOT bypass the gate.
+      const spoofed = await service.dispatch("actions.list", undefined, {
+        source: "plugin",
+        confirmed: true,
+      });
+      expect(spoofed.ok).toBe(false);
+      if (!spoofed.ok) expect(spoofed.error.code).toBe("CONFIRMATION_REQUIRED");
       expect(mockRun).not.toHaveBeenCalled();
     });
 

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -271,6 +271,67 @@ describe("ActionService", () => {
       expect(mockRun).toHaveBeenCalled();
     });
 
+    it("executes a safe action dispatched from a plugin source", async () => {
+      const mockRun = vi.fn().mockResolvedValue("ok");
+      service.register({
+        id: "actions.list" as ActionId,
+        title: "Test Action",
+        description:
+          "A test action for validating ActionService dispatch, registration, and manifest entry generation.",
+        category: "test",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        run: mockRun,
+      });
+
+      const result = await service.dispatch("actions.list", undefined, { source: "plugin" });
+      expect(result.ok).toBe(true);
+      expect(mockRun).toHaveBeenCalled();
+    });
+
+    it("returns CONFIRMATION_REQUIRED for a confirm action from a plugin source (no confirmed bypass)", async () => {
+      const mockRun = vi.fn().mockResolvedValue(undefined);
+      service.register({
+        id: "actions.list" as ActionId,
+        title: "Test Action",
+        description:
+          "A test action for validating ActionService dispatch, registration, and manifest entry generation.",
+        category: "test",
+        kind: "command",
+        danger: "confirm",
+        scope: "renderer",
+        run: mockRun,
+      });
+
+      // Even passing confirmed:true must not let a plugin bypass the gate; the
+      // host API never sets it, but assert defense-in-depth here anyway.
+      const result = await service.dispatch("actions.list", undefined, { source: "plugin" });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.code).toBe("CONFIRMATION_REQUIRED");
+      expect(mockRun).not.toHaveBeenCalled();
+    });
+
+    it("returns RESTRICTED for a restricted action from a plugin source", async () => {
+      const mockRun = vi.fn().mockResolvedValue(undefined);
+      service.register({
+        id: "actions.list" as ActionId,
+        title: "Test Action",
+        description:
+          "A test action for validating ActionService dispatch, registration, and manifest entry generation.",
+        category: "test",
+        kind: "command",
+        danger: "restricted",
+        scope: "renderer",
+        run: mockRun,
+      });
+
+      const result = await service.dispatch("actions.list", undefined, { source: "plugin" });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.code).toBe("RESTRICTED");
+      expect(mockRun).not.toHaveBeenCalled();
+    });
+
     it("should validate arguments with Zod schema", async () => {
       const nameSchema = z.object({ name: z.string() });
       const action: ActionDefinition<typeof nameSchema, void> = {
@@ -1289,6 +1350,17 @@ describe("ActionService", () => {
       expect(service.getLastAction()?.actionId).toBe("test.user");
 
       await service.dispatch("test.agent" as ActionId, undefined, { source: "agent" });
+      expect(service.getLastAction()?.actionId).toBe("test.user");
+    });
+
+    it("does not capture plugin-source dispatches", async () => {
+      service.register(makeAction("test.user"));
+      service.register(makeAction("test.plugin"));
+
+      await service.dispatch("test.user" as ActionId, undefined, { source: "user" });
+      expect(service.getLastAction()?.actionId).toBe("test.user");
+
+      await service.dispatch("test.plugin" as ActionId, undefined, { source: "plugin" });
       expect(service.getLastAction()?.actionId).toBe("test.user");
     });
 


### PR DESCRIPTION
## Summary

- Adds `host.dispatch(actionId, args)` to the plugin host API so plugins can invoke actions through the audited `ActionService` dispatch path rather than bypassing it.
- New `"plugin"` `ActionSource` (distinct from `"agent"` for audit and MRU purposes) and `PLUGIN_UNLOADED` error code. `host.dispatch` is not revoke-guarded — it returns `PLUGIN_UNLOADED` once the plugin unloads, so post-activation callbacks and timers can call it safely.
- Confirm-gating is strict: plugin sources always return `CONFIRMATION_REQUIRED` (no confirmed bypass, even if spoofed), `danger:"restricted"` actions are rejected, and `"plugin"` is excluded from `REPEATABLE_SOURCES` so nothing leaks into MRU or `repeatLast`.

**Depends on #9277** (`host.registerAction`), which is still open. `host.dispatch` is fully functional standalone today — plugins can dispatch built-ins and other plugins' actions. The "dispatch your own registered action" story completes when #9277 merges; both should ship together.

Resolves #9280

## Changes

- `shared/types/actions.ts` — `"plugin"` added to `ActionSource`; `PLUGIN_UNLOADED` added to `ActionErrorCode`.
- `shared/types/ipc/` — new `plugin:dispatch-action-request` / `plugin:dispatch-action-response` channels in `channels.ts`, `maps.ts`, and `api.ts`.
- `shared/types/plugin.ts` — `dispatch(actionId, args?)` added to `PluginHostApi`.
- `electron/services/PluginService.ts` — cross-process round-trip via the new IPC channels, modeled on the MCP renderer bridge: per-request `webContentsId` sender guard, 30 s timeout, destroyed-renderer cleanup, `dispose()` drain. The promise always resolves an `ActionDispatchResult`, never rejects.
- `src/hooks/usePluginBridge.ts` — new renderer hook that routes to `actionService.dispatch({ source: "plugin" })`; catches non-serializable results and returns `EXECUTION_ERROR`.
- `src/App.tsx` — mounts `usePluginBridge`.
- `src/services/ActionService.ts` — enforces plugin confirm-gate and `REPEATABLE_SOURCES` exclusion.

## Testing

- `npx vitest run` on `PluginService`, `ActionService`, and `channelDrift` — 388 tests pass.
- `npm run check` — all 9 checks pass (typecheck, IPC/channel drift guards, lint ratchet, format).