### PR TITLE
feat(plugins): implement host.settings API (#9279)

### DIFF
--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 1278,
-  "moduleCount": 1278,
+  "count": 1279,
+  "moduleCount": 1279,
   "allowlist": [
     "electron/ipc/errorHandlers.ts",
     "electron/ipc/handlers/agentCapabilities.ts",
@@ -1068,22 +1068,22 @@
     },
     {
       "file": "electron/services/PluginService.ts",
-      "line": 440,
+      "line": 466,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/PluginService.ts",
-      "line": 451,
+      "line": 477,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/PluginService.ts",
-      "line": 468,
+      "line": 494,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/PluginService.ts",
-      "line": 1848,
+      "line": 2063,
       "pattern": "sync-store-get"
     },
     {

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -41,7 +41,10 @@ import type {
   InstalledPluginRecord,
   PluginLoadError,
   PluginInstallSource,
+  PluginSettingsScope,
 } from "../../shared/types/plugin.js";
+import { PluginSettingsStore } from "./PluginSettingsStore.js";
+import { projectStore } from "./ProjectStore.js";
 import type { WorktreeSnapshot } from "../../shared/types/workspace-host.js";
 import { toPluginWorktreeSnapshot } from "../../shared/utils/pluginWorktreeSnapshot.js";
 import type { WorkspaceClient } from "./WorkspaceClient.js";
@@ -201,6 +204,12 @@ function runUnloadStep(pluginId: string, step: string, fn: () => void): void {
   }
 }
 
+function assertSettingsKey(pluginId: string, method: string, key: unknown): asserts key is string {
+  if (typeof key !== "string" || key.length === 0) {
+    throw new Error(`Plugin "${pluginId}" settings.${method}: key must be a non-empty string`);
+  }
+}
+
 type WorkspaceWorktreeEvent = "worktree-update" | "worktree-activated" | "worktree-removed";
 
 export class PluginService {
@@ -237,6 +246,23 @@ export class PluginService {
   private pluginActionHandlers = new Map<string, ActionHandler>();
   private ajv: AjvInstance | null = null;
   private pluginEventCleanups = new Map<string, Array<() => void>>();
+  /**
+   * Persisted-settings stores keyed by `{pluginId} {scope} {filePath}` (plugin
+   * ids never contain spaces — see the manifest name pattern). Keyed on the
+   * resolved path (not just scope) so a project switch — which changes the
+   * `project`-scope path — creates a fresh store without evicting the old
+   * project's cache. Entries for a plugin are dropped on unload.
+   */
+  private settingsStores = new Map<string, PluginSettingsStore>();
+  /**
+   * Active `host.settings.onDidChange` subscriptions per plugin. Held here (not
+   * on the store) so they survive project-root switches and are flushed in one
+   * place on unload. Each disposer is also tracked in {@link pluginEventCleanups}.
+   */
+  private settingsSubscribers = new Map<
+    string,
+    Set<{ key: string; scope: PluginSettingsScope; cb: (value: unknown) => void }>
+  >();
   private workspaceClient: WorkspaceClient | null = null;
   /**
    * Event subscriptions registered during plugin `activate()` when the
@@ -1281,6 +1307,103 @@ export class PluginService {
         }
         return this.sendDispatchToRenderer(actionId, args);
       },
+      // NOT revoke-guarded: plugins read/write settings throughout their
+      // lifetime (IPC handlers, timers), long after activate() resolves. The
+      // store is the source of truth, so a late call is harmless.
+      settings: {
+        get: async <T = unknown>(
+          key: string,
+          scope: PluginSettingsScope = "user"
+        ): Promise<T | undefined> => {
+          assertSettingsKey(pluginId, "get", key);
+          const filePath = this.resolveSettingsFilePath(pluginId, scope);
+          // Project scope with no active project: read resolves to undefined
+          // rather than throwing, matching the "unset key" return.
+          if (!filePath) return undefined;
+          return this.getOrCreateSettingsStore(pluginId, scope, filePath).get<T>(key);
+        },
+        set: async <T = unknown>(
+          key: string,
+          value: T,
+          scope: PluginSettingsScope = "user"
+        ): Promise<void> => {
+          assertSettingsKey(pluginId, "set", key);
+          if (value === undefined) {
+            throw new Error(
+              `Plugin "${pluginId}" settings.set: value for "${key}" is undefined — settings cannot store undefined`
+            );
+          }
+          let serialized: string | undefined;
+          try {
+            serialized = JSON.stringify(value);
+          } catch {
+            serialized = undefined;
+          }
+          if (serialized === undefined) {
+            throw new Error(
+              `Plugin "${pluginId}" settings.set: value for "${key}" is not JSON-serializable`
+            );
+          }
+          this.assertSettingDeclared(pluginId, key);
+          const filePath = this.resolveSettingsFilePath(pluginId, scope);
+          if (!filePath) {
+            throw new Error(
+              `Plugin "${pluginId}" settings.set: no active project — "project" scope has no target`
+            );
+          }
+          const store = this.getOrCreateSettingsStore(pluginId, scope, filePath);
+          const changed = await store.set(key, value);
+          if (changed) this.notifySettingsSubscribers(pluginId, scope, key, value);
+        },
+        onDidChange: <T = unknown>(
+          key: string,
+          callback: (value: T | undefined) => void,
+          scope: PluginSettingsScope = "user"
+        ): (() => void) => {
+          if (revoked) {
+            throw new Error(
+              `Plugin "${pluginId}" host revoked: settings.onDidChange called after activate() returned or timed out`
+            );
+          }
+          assertSettingsKey(pluginId, "onDidChange", key);
+          if (typeof callback !== "function") {
+            throw new Error(
+              `Plugin "${pluginId}" settings.onDidChange: callback must be a function`
+            );
+          }
+          const sub = { key, scope, cb: callback as (value: unknown) => void };
+          let subs = this.settingsSubscribers.get(pluginId);
+          if (!subs) {
+            subs = new Set();
+            this.settingsSubscribers.set(pluginId, subs);
+          }
+          subs.add(sub);
+
+          let disposed = false;
+          const dispose = (): void => {
+            if (disposed) return;
+            disposed = true;
+            const set = this.settingsSubscribers.get(pluginId);
+            if (set) {
+              set.delete(sub);
+              if (set.size === 0) this.settingsSubscribers.delete(pluginId);
+            }
+            const list = this.pluginEventCleanups.get(pluginId);
+            if (!list) return;
+            const idx = list.indexOf(dispose);
+            if (idx >= 0) list.splice(idx, 1);
+            if (list.length === 0) this.pluginEventCleanups.delete(pluginId);
+          };
+
+          let list = this.pluginEventCleanups.get(pluginId);
+          if (!list) {
+            list = [];
+            this.pluginEventCleanups.set(pluginId, list);
+          }
+          list.push(dispose);
+          return dispose;
+        },
+      },
     };
     return {
       host,
@@ -1440,6 +1563,92 @@ export class PluginService {
         });
       }
     });
+  }
+
+  /**
+   * Root directory for user-scope plugin settings: a sibling of the plugins
+   * dir. Production: `~/.daintree/plugin-settings`. Derived from
+   * {@link pluginsRoot} so tests that pass a custom root stay isolated.
+   */
+  private settingsRoot(): string {
+    return path.join(path.dirname(this.pluginsRoot), "plugin-settings");
+  }
+
+  /**
+   * Resolve the JSON file backing a plugin's settings for a scope. User scope is
+   * fixed; project scope resolves the active project at call time and returns
+   * `undefined` when none is active.
+   */
+  private resolveSettingsFilePath(
+    pluginId: string,
+    scope: PluginSettingsScope
+  ): string | undefined {
+    if (scope === "project") {
+      const root = projectStore.getCurrentProject()?.path;
+      if (!root) return undefined;
+      return path.join(root, ".daintree", "plugin-settings", `${pluginId}.json`);
+    }
+    return path.join(this.settingsRoot(), `${pluginId}.json`);
+  }
+
+  private getOrCreateSettingsStore(
+    pluginId: string,
+    scope: PluginSettingsScope,
+    filePath: string
+  ): PluginSettingsStore {
+    const cacheKey = `${pluginId} ${scope} ${filePath}`;
+    let store = this.settingsStores.get(cacheKey);
+    if (!store) {
+      store = new PluginSettingsStore(filePath);
+      this.settingsStores.set(cacheKey, store);
+    }
+    return store;
+  }
+
+  /**
+   * Enforce `contributes.settings` key declarations on `set`. F29 has not landed
+   * yet, so manifests never declare settings today and any key is accepted; once
+   * a plugin declares them, undeclared keys are rejected.
+   */
+  private assertSettingDeclared(pluginId: string, key: string): void {
+    const declared = this.plugins.get(pluginId)?.manifest.contributes.settings;
+    if (!declared || declared.length === 0) return;
+    if (!declared.some((s) => s.id === key)) {
+      throw new Error(
+        `Plugin "${pluginId}" settings.set: key "${key}" is not declared in contributes.settings`
+      );
+    }
+  }
+
+  private notifySettingsSubscribers(
+    pluginId: string,
+    scope: PluginSettingsScope,
+    key: string,
+    value: unknown
+  ): void {
+    const subs = this.settingsSubscribers.get(pluginId);
+    if (!subs) return;
+    // Snapshot so a callback that disposes itself doesn't mutate the live set
+    // mid-iteration.
+    for (const sub of [...subs]) {
+      if (sub.key !== key || sub.scope !== scope) continue;
+      try {
+        sub.cb(value);
+      } catch (err) {
+        console.error(
+          `[PluginService] settings.onDidChange callback for "${pluginId}" key "${key}" failed:`,
+          err
+        );
+      }
+    }
+  }
+
+  private clearPluginSettingsState(pluginId: string): void {
+    this.settingsSubscribers.delete(pluginId);
+    const prefix = `${pluginId} `;
+    for (const cacheKey of [...this.settingsStores.keys()]) {
+      if (cacheKey.startsWith(prefix)) this.settingsStores.delete(cacheKey);
+    }
   }
 
   private async fetchAllWorktreeSnapshots(): Promise<WorktreeSnapshot[]> {
@@ -1733,6 +1942,12 @@ export class PluginService {
     );
     runUnloadStep(pluginId, "unregisterFileDecorationProviderImpls", () =>
       unregisterFileDecorationProviderImpls(pluginId)
+    );
+    // Subscriber disposers already fired in flushPluginEventCleanups() above;
+    // this drops any leftover subscriber-set entry and the in-memory settings
+    // store caches so a reload starts from disk.
+    runUnloadStep(pluginId, "clearPluginSettingsState", () =>
+      this.clearPluginSettingsState(pluginId)
     );
 
     this.plugins.delete(pluginId);

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -247,11 +247,12 @@ export class PluginService {
   private ajv: AjvInstance | null = null;
   private pluginEventCleanups = new Map<string, Array<() => void>>();
   /**
-   * Persisted-settings stores keyed by `{pluginId} {scope} {filePath}` (plugin
-   * ids never contain spaces — see the manifest name pattern). Keyed on the
-   * resolved path (not just scope) so a project switch — which changes the
-   * `project`-scope path — creates a fresh store without evicting the old
-   * project's cache. Entries for a plugin are dropped on unload.
+   * Persisted-settings stores keyed by `{pluginId}\u0000{scope}\u0000{filePath}`.
+   * The NUL (`\u0000`) separator is unambiguous because a valid plugin id can
+   * never contain it (see the manifest name pattern). Keyed on the resolved path
+   * (not just scope) so a project switch — which changes the `project`-scope
+   * path — creates a fresh store without evicting the old project's cache.
+   * Entries for a plugin are dropped on unload.
    */
   private settingsStores = new Map<string, PluginSettingsStore>();
   /**
@@ -1596,7 +1597,7 @@ export class PluginService {
     scope: PluginSettingsScope,
     filePath: string
   ): PluginSettingsStore {
-    const cacheKey = `${pluginId} ${scope} ${filePath}`;
+    const cacheKey = `${pluginId}\u0000${scope}\u0000${filePath}`;
     let store = this.settingsStores.get(cacheKey);
     if (!store) {
       store = new PluginSettingsStore(filePath);
@@ -1645,7 +1646,7 @@ export class PluginService {
 
   private clearPluginSettingsState(pluginId: string): void {
     this.settingsSubscribers.delete(pluginId);
-    const prefix = `${pluginId} `;
+    const prefix = `${pluginId}\u0000`;
     for (const cacheKey of [...this.settingsStores.keys()]) {
       if (cacheKey.startsWith(prefix)) this.settingsStores.delete(cacheKey);
     }

--- a/electron/services/PluginSettingsStore.ts
+++ b/electron/services/PluginSettingsStore.ts
@@ -24,7 +24,9 @@ export class PluginSettingsStore {
 
   async get<T = unknown>(key: string): Promise<T | undefined> {
     const cache = await this.load();
-    return cache.get(key) as T | undefined;
+    // Return a detached copy so a caller mutating the result can't reach into
+    // the in-memory cache and diverge it from disk.
+    return cloneValue(cache.get(key)) as T | undefined;
   }
 
   /**
@@ -47,7 +49,14 @@ export class PluginSettingsStore {
     const cache = await this.load();
     const had = cache.has(key);
     const prev = cache.get(key);
-    cache.set(key, value);
+    // Detect a no-op before touching disk: an idempotent set should neither
+    // write nor fail (e.g. on a read-only directory).
+    if (had && valuesEqual(prev, value)) return false;
+    // Store a detached, JSON-faithful copy so (a) a caller mutating the original
+    // object can't diverge the cache from disk, and (b) the cache reflects what
+    // actually persists (e.g. NaN/Infinity coerce to null under JSON, in memory
+    // and on disk alike).
+    cache.set(key, cloneValue(value));
     try {
       await this.persist(cache);
     } catch (err) {
@@ -55,7 +64,7 @@ export class PluginSettingsStore {
       else cache.delete(key);
       throw err;
     }
-    return !had || !valuesEqual(prev, value);
+    return true;
   }
 
   private async load(): Promise<Map<string, unknown>> {
@@ -63,7 +72,15 @@ export class PluginSettingsStore {
     if (!this.loadPromise) {
       this.loadPromise = this.readFile();
     }
-    this.cache = await this.loadPromise;
+    try {
+      this.cache = await this.loadPromise;
+    } catch (err) {
+      // Don't permanently poison the instance on a transient/corrupt read —
+      // drop the failed promise so a later access (e.g. after the file is
+      // repaired) re-reads from disk.
+      this.loadPromise = null;
+      throw err;
+    }
     return this.cache;
   }
 
@@ -104,4 +121,14 @@ function valuesEqual(a: unknown, b: unknown): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * JSON-faithful clone. Primitives pass through; objects are round-tripped so the
+ * returned value shares no references with the caller's input. Values are always
+ * JSON-serializable here (validated by the host before reaching the store).
+ */
+function cloneValue<T>(value: T): T {
+  if (value === null || typeof value !== "object") return value;
+  return JSON.parse(JSON.stringify(value)) as T;
 }

--- a/electron/services/PluginSettingsStore.ts
+++ b/electron/services/PluginSettingsStore.ts
@@ -1,0 +1,107 @@
+import path from "path";
+import fs from "fs/promises";
+import { resilientAtomicWriteFile } from "../utils/fs.js";
+
+/** chmod applied to settings files on POSIX. Skipped on Windows by the writer. */
+const SETTINGS_FILE_MODE = 0o600;
+
+/**
+ * Plaintext, JSON-backed key/value store for one plugin + scope, identified by
+ * its resolved file path. Loads lazily on first access and caches the decoded
+ * object in memory; writes go through {@link resilientAtomicWriteFile} with
+ * `chmod 0o600` (POSIX only). There is deliberately no OS keychain (#9167).
+ *
+ * Change subscriptions are intentionally NOT owned here — `PluginService` holds
+ * them so they survive project-root switches that change the resolved path.
+ */
+export class PluginSettingsStore {
+  private cache: Map<string, unknown> | null = null;
+  private loadPromise: Promise<Map<string, unknown>> | null = null;
+  /** Serializes writes so concurrent `set` calls can't interleave read-modify-write. */
+  private writeChain: Promise<void> = Promise.resolve();
+
+  constructor(private readonly filePath: string) {}
+
+  async get<T = unknown>(key: string): Promise<T | undefined> {
+    const cache = await this.load();
+    return cache.get(key) as T | undefined;
+  }
+
+  /**
+   * Persist `value` at `key`. Resolves to `true` when the stored value actually
+   * changed (so the caller can fire change subscribers), `false` for a no-op
+   * write. On write failure the optimistic in-memory mutation is rolled back and
+   * the error rethrown.
+   */
+  async set<T = unknown>(key: string, value: T): Promise<boolean> {
+    const result = this.writeChain.then(() => this.doSet(key, value));
+    // Keep the chain alive even when this write rejects, so queued writes run.
+    this.writeChain = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
+  }
+
+  private async doSet<T>(key: string, value: T): Promise<boolean> {
+    const cache = await this.load();
+    const had = cache.has(key);
+    const prev = cache.get(key);
+    cache.set(key, value);
+    try {
+      await this.persist(cache);
+    } catch (err) {
+      if (had) cache.set(key, prev);
+      else cache.delete(key);
+      throw err;
+    }
+    return !had || !valuesEqual(prev, value);
+  }
+
+  private async load(): Promise<Map<string, unknown>> {
+    if (this.cache) return this.cache;
+    if (!this.loadPromise) {
+      this.loadPromise = this.readFile();
+    }
+    this.cache = await this.loadPromise;
+    return this.cache;
+  }
+
+  private async readFile(): Promise<Map<string, unknown>> {
+    let raw: string;
+    try {
+      raw = await fs.readFile(this.filePath, "utf-8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return new Map();
+      throw err;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw new Error(`Plugin settings file is not valid JSON: ${this.filePath}`);
+    }
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error(`Plugin settings file must contain a JSON object: ${this.filePath}`);
+    }
+    return new Map(Object.entries(parsed as Record<string, unknown>));
+  }
+
+  private async persist(cache: Map<string, unknown>): Promise<void> {
+    const obj: Record<string, unknown> = {};
+    for (const [k, v] of cache) obj[k] = v;
+    await fs.mkdir(path.dirname(this.filePath), { recursive: true });
+    await resilientAtomicWriteFile(this.filePath, JSON.stringify(obj, null, 2), "utf-8", {
+      mode: SETTINGS_FILE_MODE,
+    });
+  }
+}
+
+function valuesEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+}

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -35,6 +35,9 @@ const windowRefMock = vi.hoisted(() => ({
   getProjectViewManager: vi.fn(() => null),
 }));
 const broadcastToRendererMock = vi.hoisted(() => vi.fn());
+const projectStoreMock = vi.hoisted(() => ({
+  getCurrentProject: vi.fn((): { path: string } | null => null),
+}));
 const storeMock = vi.hoisted(() => {
   const state = new Map<string, unknown>();
   return {
@@ -61,6 +64,9 @@ vi.mock("../../ipc/utils.js", () => ({
 }));
 vi.mock("../../store.js", () => ({
   store: storeMock,
+}));
+vi.mock("../ProjectStore.js", () => ({
+  projectStore: projectStoreMock,
 }));
 vi.mock("../../../shared/config/panelKindRegistry.js", () => ({
   registerPanelKind: vi.fn(),
@@ -5358,5 +5364,193 @@ describe("Deferred activation — activatePlugin", () => {
       []
     );
     expect(result).toBe("pong");
+  });
+});
+
+type SettingsScope = "user" | "project";
+type SettingsHostShape = (pluginId: string) => {
+  host: {
+    settings: {
+      get: <T = unknown>(key: string, scope?: SettingsScope) => Promise<T | undefined>;
+      set: <T = unknown>(key: string, value: T, scope?: SettingsScope) => Promise<void>;
+      onDidChange: <T = unknown>(
+        key: string,
+        cb: (value: T | undefined) => void,
+        scope?: SettingsScope
+      ) => () => void;
+    };
+  };
+  revoke: () => void;
+};
+
+async function setupSettingsService(
+  pluginId: string
+): Promise<{ service: PluginService; settingsRoot: string }> {
+  const pluginsRoot = path.join(tmpDir, "plugins");
+  const dir = path.join(pluginsRoot, pluginId);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    path.join(dir, "plugin.json"),
+    JSON.stringify({ name: pluginId, version: "1.0.0" })
+  );
+  const service = new PluginService(pluginsRoot);
+  await service.initialize();
+  // User-scope settings live as a sibling of the plugins dir.
+  return { service, settingsRoot: path.join(tmpDir, "plugin-settings") };
+}
+
+function createSettingsHost(service: PluginService, pluginId: string) {
+  return (service as unknown as { createHost: SettingsHostShape }).createHost(pluginId);
+}
+
+describe("createHost — settings", () => {
+  beforeEach(() => {
+    projectStoreMock.getCurrentProject.mockReturnValue(null);
+  });
+
+  it("get returns undefined for an unset key", async () => {
+    const { service } = await setupSettingsService("acme.settings-get");
+    const { host } = createSettingsHost(service, "acme.settings-get");
+    expect(await host.settings.get("token")).toBeUndefined();
+  });
+
+  it("round-trips a value in user scope and persists it as JSON", async () => {
+    const { service, settingsRoot } = await setupSettingsService("acme.settings-rt");
+    const { host } = createSettingsHost(service, "acme.settings-rt");
+    await host.settings.set("token", "sk-test");
+    expect(await host.settings.get<string>("token")).toBe("sk-test");
+    const raw = await fs.readFile(path.join(settingsRoot, "acme.settings-rt.json"), "utf-8");
+    expect(JSON.parse(raw)).toEqual({ token: "sk-test" });
+  });
+
+  const chmodIt = process.platform === "win32" ? it.skip : it;
+  chmodIt("writes the user-scope file with mode 0o600", async () => {
+    const { service, settingsRoot } = await setupSettingsService("acme.settings-mode");
+    const { host } = createSettingsHost(service, "acme.settings-mode");
+    await host.settings.set("token", "secret");
+    const stat = await fs.stat(path.join(settingsRoot, "acme.settings-mode.json"));
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it("project scope get returns undefined when no project is active", async () => {
+    projectStoreMock.getCurrentProject.mockReturnValue(null);
+    const { service } = await setupSettingsService("acme.settings-noproj");
+    const { host } = createSettingsHost(service, "acme.settings-noproj");
+    expect(await host.settings.get("token", "project")).toBeUndefined();
+  });
+
+  it("project scope set throws when no project is active", async () => {
+    projectStoreMock.getCurrentProject.mockReturnValue(null);
+    const { service } = await setupSettingsService("acme.settings-noproj2");
+    const { host } = createSettingsHost(service, "acme.settings-noproj2");
+    await expect(host.settings.set("token", "x", "project")).rejects.toThrow(/no active project/);
+  });
+
+  it("project scope writes under the active project root", async () => {
+    const projectDir = path.join(tmpDir, "proj");
+    projectStoreMock.getCurrentProject.mockReturnValue({ path: projectDir });
+    const { service } = await setupSettingsService("acme.settings-proj");
+    const { host } = createSettingsHost(service, "acme.settings-proj");
+    await host.settings.set("token", "in-project", "project");
+    expect(await host.settings.get<string>("token", "project")).toBe("in-project");
+    const raw = await fs.readFile(
+      path.join(projectDir, ".daintree", "plugin-settings", "acme.settings-proj.json"),
+      "utf-8"
+    );
+    expect(JSON.parse(raw)).toEqual({ token: "in-project" });
+  });
+
+  it("resolves the active project at call time, tracking project switches", async () => {
+    const projA = path.join(tmpDir, "projA");
+    const projB = path.join(tmpDir, "projB");
+    const { service } = await setupSettingsService("acme.settings-switch");
+    const { host } = createSettingsHost(service, "acme.settings-switch");
+
+    projectStoreMock.getCurrentProject.mockReturnValue({ path: projA });
+    await host.settings.set("k", "a-value", "project");
+
+    projectStoreMock.getCurrentProject.mockReturnValue({ path: projB });
+    expect(await host.settings.get("k", "project")).toBeUndefined();
+    await host.settings.set("k", "b-value", "project");
+    expect(await host.settings.get<string>("k", "project")).toBe("b-value");
+
+    projectStoreMock.getCurrentProject.mockReturnValue({ path: projA });
+    expect(await host.settings.get<string>("k", "project")).toBe("a-value");
+  });
+
+  it("set rejects undefined and non-serializable values", async () => {
+    const { service } = await setupSettingsService("acme.settings-bad");
+    const { host } = createSettingsHost(service, "acme.settings-bad");
+    await expect(host.settings.set("k", undefined as unknown as string)).rejects.toThrow(
+      /undefined/
+    );
+    await expect(host.settings.set("k", (() => {}) as unknown as string)).rejects.toThrow(
+      /not JSON-serializable/
+    );
+  });
+
+  it("set rejects an empty key", async () => {
+    const { service } = await setupSettingsService("acme.settings-emptykey");
+    const { host } = createSettingsHost(service, "acme.settings-emptykey");
+    await expect(host.settings.set("", "x")).rejects.toThrow(/non-empty string/);
+  });
+
+  it("onDidChange fires with the new value after a changing set", async () => {
+    const { service } = await setupSettingsService("acme.settings-watch");
+    const { host } = createSettingsHost(service, "acme.settings-watch");
+    const cb = vi.fn();
+    host.settings.onDidChange<string>("token", cb);
+    await host.settings.set("token", "v1");
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith("v1");
+  });
+
+  it("onDidChange does not fire for a no-op write", async () => {
+    const { service } = await setupSettingsService("acme.settings-noop");
+    const { host } = createSettingsHost(service, "acme.settings-noop");
+    const cb = vi.fn();
+    host.settings.onDidChange("token", cb);
+    await host.settings.set("token", "same");
+    await host.settings.set("token", "same");
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("onDidChange only fires for its subscribed scope", async () => {
+    projectStoreMock.getCurrentProject.mockReturnValue({ path: path.join(tmpDir, "proj-scope") });
+    const { service } = await setupSettingsService("acme.settings-scope");
+    const { host } = createSettingsHost(service, "acme.settings-scope");
+    const userCb = vi.fn();
+    host.settings.onDidChange("token", userCb, "user");
+    await host.settings.set("token", "proj-value", "project");
+    expect(userCb).not.toHaveBeenCalled();
+  });
+
+  it("onDidChange disposer stops further callbacks", async () => {
+    const { service } = await setupSettingsService("acme.settings-dispose");
+    const { host } = createSettingsHost(service, "acme.settings-dispose");
+    const cb = vi.fn();
+    const dispose = host.settings.onDidChange("token", cb);
+    dispose();
+    await host.settings.set("token", "v1");
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("unloadPlugin disposes settings subscriptions", async () => {
+    const { service } = await setupSettingsService("acme.settings-unload");
+    const { host } = createSettingsHost(service, "acme.settings-unload");
+    const cb = vi.fn();
+    host.settings.onDidChange("token", cb);
+    service.unloadPlugin("acme.settings-unload");
+    await host.settings.set("token", "after-unload");
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("revoked host rejects settings.onDidChange but still allows get/set", async () => {
+    const { service } = await setupSettingsService("acme.settings-revoke");
+    const { host, revoke } = createSettingsHost(service, "acme.settings-revoke");
+    revoke();
+    expect(() => host.settings.onDidChange("token", () => {})).toThrow(/host revoked/);
+    await expect(host.settings.set("token", "still-works")).resolves.toBeUndefined();
+    expect(await host.settings.get<string>("token")).toBe("still-works");
   });
 });

--- a/electron/services/__tests__/PluginSettingsStore.test.ts
+++ b/electron/services/__tests__/PluginSettingsStore.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+import { PluginSettingsStore } from "../PluginSettingsStore.js";
+
+let tmpDir: string;
+
+function storeAt(...segments: string[]): { store: PluginSettingsStore; filePath: string } {
+  const filePath = path.join(tmpDir, ...segments);
+  return { store: new PluginSettingsStore(filePath), filePath };
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-plugin-settings-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("PluginSettingsStore", () => {
+  it("returns undefined for an unset key when the file does not exist", async () => {
+    const { store } = storeAt("missing", "acme.plugin.json");
+    expect(await store.get("token")).toBeUndefined();
+  });
+
+  it("set creates the directory, persists JSON, and round-trips the value", async () => {
+    const { store, filePath } = storeAt("nested", "dir", "acme.plugin.json");
+    const changed = await store.set("token", "sk-test");
+    expect(changed).toBe(true);
+    expect(await store.get<string>("token")).toBe("sk-test");
+
+    const raw = await fs.readFile(filePath, "utf-8");
+    expect(JSON.parse(raw)).toEqual({ token: "sk-test" });
+  });
+
+  it("persists across store instances pointed at the same file", async () => {
+    const { store, filePath } = storeAt("acme.plugin.json");
+    await store.set("count", 3);
+    await store.set("flag", true);
+
+    const reopened = new PluginSettingsStore(filePath);
+    expect(await reopened.get<number>("count")).toBe(3);
+    expect(await reopened.get<boolean>("flag")).toBe(true);
+  });
+
+  it("stores structured values", async () => {
+    const { store } = storeAt("acme.plugin.json");
+    const value = { nested: { list: [1, 2, 3] }, name: "x" };
+    await store.set("config", value);
+    expect(await store.get("config")).toEqual(value);
+  });
+
+  const chmodIt = process.platform === "win32" ? it.skip : it;
+  chmodIt("writes the file with mode 0o600", async () => {
+    const { store, filePath } = storeAt("acme.plugin.json");
+    await store.set("token", "secret");
+    const stat = await fs.stat(filePath);
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it("set returns false for a no-op write of an equal value", async () => {
+    const { store } = storeAt("acme.plugin.json");
+    expect(await store.set("k", { a: 1 })).toBe(true);
+    expect(await store.set("k", { a: 1 })).toBe(false);
+    expect(await store.set("k", { a: 2 })).toBe(true);
+  });
+
+  it("rejects when the file contains invalid JSON", async () => {
+    const { store, filePath } = storeAt("acme.plugin.json");
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "{ not json", "utf-8");
+    await expect(store.get("token")).rejects.toThrow(/not valid JSON/);
+  });
+
+  it("rejects when the file contains a non-object JSON value", async () => {
+    const { store, filePath } = storeAt("acme.plugin.json");
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, JSON.stringify([1, 2, 3]), "utf-8");
+    await expect(store.get("token")).rejects.toThrow(/must contain a JSON object/);
+  });
+
+  // Skipped where directory mode bits don't gate writes (Windows, or running
+  // as root which bypasses permission checks).
+  const rollbackIt = process.platform === "win32" || process.getuid?.() === 0 ? it.skip : it;
+  rollbackIt("rolls back the in-memory value when the write fails", async () => {
+    const dir = path.join(tmpDir, "ro");
+    await fs.mkdir(dir, { recursive: true });
+    const store = new PluginSettingsStore(path.join(dir, "acme.plugin.json"));
+    // Read+execute only: load() (readFile → ENOENT) still succeeds, but the
+    // atomic write of the temp file into the directory fails with EACCES.
+    await fs.chmod(dir, 0o555);
+    try {
+      await expect(store.set("token", "value")).rejects.toBeTruthy();
+      // The optimistic in-memory mutation must not survive a failed persist.
+      expect(await store.get("token")).toBeUndefined();
+    } finally {
+      // Restore write perms so afterEach can remove the tree.
+      await fs.chmod(dir, 0o755);
+    }
+  });
+
+  it("serializes concurrent writes so all keys are persisted", async () => {
+    const { store, filePath } = storeAt("acme.plugin.json");
+    await Promise.all([store.set("a", 1), store.set("b", 2), store.set("c", 3), store.set("d", 4)]);
+    const raw = await fs.readFile(filePath, "utf-8");
+    expect(JSON.parse(raw)).toEqual({ a: 1, b: 2, c: 3, d: 4 });
+  });
+});

--- a/electron/services/__tests__/PluginSettingsStore.test.ts
+++ b/electron/services/__tests__/PluginSettingsStore.test.ts
@@ -101,6 +101,40 @@ describe("PluginSettingsStore", () => {
     }
   });
 
+  it("recovers on the same instance after a corrupt file is repaired", async () => {
+    const { store, filePath } = storeAt("acme.plugin.json");
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "{ broken", "utf-8");
+    await expect(store.get("token")).rejects.toThrow(/not valid JSON/);
+
+    // External repair — the same store instance must not stay poisoned.
+    await fs.writeFile(filePath, JSON.stringify({ token: "fixed" }), "utf-8");
+    expect(await store.get<string>("token")).toBe("fixed");
+  });
+
+  it("does not diverge from disk when the caller mutates a stored object", async () => {
+    const { store } = storeAt("acme.plugin.json");
+    const value = { a: 1 };
+    await store.set("config", value);
+    value.a = 2;
+    expect(await store.get<{ a: number }>("config")).toEqual({ a: 1 });
+  });
+
+  const idempotentIt = process.platform === "win32" || process.getuid?.() === 0 ? it.skip : it;
+  idempotentIt("treats an equal-value set as a no-op, even when the dir is read-only", async () => {
+    const dir = path.join(tmpDir, "idem");
+    await fs.mkdir(dir, { recursive: true });
+    const store = new PluginSettingsStore(path.join(dir, "acme.plugin.json"));
+    expect(await store.set("token", "v1")).toBe(true);
+    await fs.chmod(dir, 0o555);
+    try {
+      // Equal value: must skip the write and not fail on the read-only dir.
+      expect(await store.set("token", "v1")).toBe(false);
+    } finally {
+      await fs.chmod(dir, 0o755);
+    }
+  });
+
   it("serializes concurrent writes so all keys are persisted", async () => {
     const { store, filePath } = storeAt("acme.plugin.json");
     await Promise.all([store.set("a", 1), store.set("b", 2), store.set("c", 3), store.set("d", 4)]);

--- a/electron/services/settingsTemplateResolver.ts
+++ b/electron/services/settingsTemplateResolver.ts
@@ -1,6 +1,9 @@
 /**
- * Minimal settings read surface consumed by the template resolver. #9279 will
- * replace this with the full `host.settings` API.
+ * Minimal settings read surface consumed by the template resolver. This is a
+ * structural subset of the full `host.settings` `SettingsApi` (shared/types/
+ * plugin.ts, #9279) — a real `SettingsApi` satisfies it, since its `get` widens
+ * to an optional `scope` argument and a generic return. Kept narrow here so the
+ * resolver only depends on the read it actually performs.
  */
 export interface PluginSettingsApi {
   get(key: string): Promise<string | undefined>;

--- a/shared/types/plugin-sdk.ts
+++ b/shared/types/plugin-sdk.ts
@@ -43,6 +43,10 @@ export type { PluginManifest } from "./plugin.js";
 
 export type { PluginActivate, PluginHostApi, ActionHandler } from "./plugin.js";
 
+// ── Settings (host.settings) ────────────────────────────────────────
+
+export type { SettingsApi, PluginSettingsScope, SettingDefinition } from "./plugin.js";
+
 // ── IPC (registerHandler, broadcastToRenderer) — ships in v1 ────────
 
 export type { PluginIpcContext, PluginIpcHandler } from "./plugin.js";

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -128,7 +128,74 @@ export interface PluginManifest {
     experimental_mcpServers: McpServerContribution[];
     forgeProviders: ForgeProviderContribution[];
     fileDecorationProviders: FileDecorationContribution[];
+    /**
+     * Declared plugin settings. Reserved for F29 — absent from parsed manifests
+     * until that schema lands, so `host.settings.set()` accepts any key for now.
+     * When present, `set()` rejects keys not declared here.
+     */
+    settings?: SettingDefinition[];
   };
+}
+
+/**
+ * Declaration for a single plugin setting. Reserved for `contributes.settings`
+ * (F29), which owns the canonical schema (types, defaults, UI metadata). The
+ * shape here is intentionally permissive — only `id` is load-bearing today, used
+ * by {@link SettingsApi.set} key validation.
+ */
+export interface SettingDefinition {
+  id: string;
+  type?: "string" | "number" | "boolean" | "object";
+  label?: string;
+  description?: string;
+  default?: unknown;
+  /**
+   * UI-only hint (F19): the Settings tab renders a "stored in plaintext"
+   * warning for the field. Does NOT change storage mechanics — values are
+   * always plaintext JSON regardless of this flag (#9167).
+   */
+  secret?: boolean;
+}
+
+export type PluginSettingsScope = "user" | "project";
+
+/**
+ * Persistent, plugin-scoped key/value settings exposed on
+ * {@link PluginHostApi.settings}. Values are stored as plaintext JSON at
+ * `~/.daintree/plugin-settings/{pluginId}.json` (user scope) or
+ * `<projectRoot>/.daintree/plugin-settings/{pluginId}.json` (project scope),
+ * with `chmod 0o600` applied on POSIX. There is deliberately no OS-keychain
+ * integration (#9167) — do not store secrets that must survive disk compromise.
+ *
+ * `scope` defaults to `"user"`. Project scope resolves the active project at
+ * call time, so it tracks project switches: `get` returns `undefined` and `set`
+ * throws when no project is active.
+ */
+export interface SettingsApi {
+  /**
+   * Read a setting. Resolves to `undefined` when the key is unset, or (for
+   * `"project"` scope) when no project is active.
+   */
+  get<T = unknown>(key: string, scope?: PluginSettingsScope): Promise<T | undefined>;
+  /**
+   * Persist a setting. Rejects `undefined` and non-JSON-serializable values.
+   * For `"project"` scope with no active project, throws. When the manifest
+   * declares `contributes.settings`, an undeclared key is rejected.
+   */
+  set<T = unknown>(key: string, value: T, scope?: PluginSettingsScope): Promise<void>;
+  /**
+   * Subscribe to in-process writes of `key` in `scope` (default `"user"`). The
+   * callback fires with the new value after each `set` that changes it. Edits
+   * made to the JSON file by other processes do NOT fire until the plugin
+   * reloads. Must be called during `activate()`. Returns a disposer; calling it
+   * more than once is a no-op. All subscriptions are automatically disposed when
+   * the plugin is unloaded.
+   */
+  onDidChange<T = unknown>(
+    key: string,
+    callback: (value: T | undefined) => void,
+    scope?: PluginSettingsScope
+  ): () => void;
 }
 
 export type PluginInstallSource = "builtin" | "sideload" | "url" | "catalog";
@@ -408,6 +475,11 @@ export interface PluginHostApi {
    * dispatch.
    */
   dispatch(actionId: string, args?: unknown): Promise<ActionDispatchResult>;
+  /**
+   * Persistent, plugin-scoped key/value settings. Plaintext JSON storage with
+   * `chmod 0o600` on POSIX — no OS keychain (#9167). See {@link SettingsApi}.
+   */
+  readonly settings: SettingsApi;
 }
 
 export type PluginActivate = (


### PR DESCRIPTION
## Summary

- Adds `host.settings` (`PluginHostApi.settings`) to the plugin host, giving plugins persistent, plugin-scoped key/value storage. Plaintext JSON with `chmod 0o600` on POSIX — no OS keychain, per decision #9167.
- New `SettingsApi`, `PluginSettingsScope`, and `SettingDefinition` types added to `shared/types/plugin.ts` and re-exported from the SDK boundary (`plugin-sdk.ts`).
- New `PluginSettingsStore` (`electron/services/PluginSettingsStore.ts`): JSON-backed, lazy-loading store with an in-memory cache, serialized writes via `resilientAtomicWriteFile(..., { mode: 0o600 })`, optimistic-with-rollback `set` semantics, no-op-write skipping, and JSON-faithful value cloning to keep cache and disk consistent.
- Wired into `PluginService.createHost()` with `get`/`set`/`onDidChange`. User scope persists to `~/.daintree/plugin-settings/{pluginId}.json`; project scope to `<projectRoot>/.daintree/plugin-settings/{pluginId}.json` with the active project resolved at call time. Subscriptions auto-dispose on plugin unload.

Resolves #9279

## API

- `get<T>(key, scope?): Promise<T | undefined>` — scope defaults to `"user"`.
- `set<T>(key, value, scope?): Promise<void>` — rejects `undefined` and non-JSON-serializable values; validates key against `contributes.settings` when declared.
- `onDidChange<T>(key, cb, scope?): () => void` — fires in-process, on value change only; must be called during `activate()`; returns a disposer.

## Design notes / known gaps

- `get`/`set` are not revoke-guarded (used throughout plugin lifetime); `onDidChange` is revoke-guarded (subscribe during `activate`), matching the existing `onDidChangeActiveWorktree` pattern.
- `onDidChange` fires only on in-process writes — external edits to the JSON file don't fire until the plugin reloads (documented).
- Manifest key validation against `contributes.settings` is graceful: F29 hasn't landed yet, so the field is absent from parsed manifests and any key is accepted. The TS type adds `contributes.settings` as reserved/optional; the Zod schema is left for F29 to fill in.
- `secret: true` on a future setting definition is a UI-only hint (F19) and doesn't change storage mechanics.
- Minor known edge: a synchronous `unloadPlugin()` drops the store reference without awaiting an in-flight write; the atomic rename bounds the risk to a very tight unload/reload window. Left as a follow-up.

## Testing

- `PluginSettingsStore` unit tests: round-trip, `0o600` mode, structured values, invalid/non-object JSON rejection, no-op skip, write-failure rollback, corrupt-file recovery, caller-mutation isolation, concurrent-write serialization.
- `PluginService.createHost()` settings tests: user round-trip, `0o600` file, project scope `undefined`/throws when no project active, project writes under root, call-time project resolution across switches, `undefined`/non-serializable/empty-key rejection, `onDidChange` fire/no-op/scope-filtering/dispose, unload disposes subscriptions, revoke guards `onDidChange` but not `get`/`set`.
- `npm run check` passes (typecheck + lint + format).

Depends on #9269 (SDK export boundary); blocks F14, F19, F29, and #9233.