### PR TITLE
feat(plugins): implement main-side host.registerAction(descriptor, handler)

### DIFF
--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -35,6 +35,7 @@ import type {
   PluginActivate,
   PluginActionContribution,
   PluginActionDescriptor,
+  ActionHandler,
   BuiltInPluginCapability,
   InstalledPluginRecord,
   PluginLoadError,
@@ -202,6 +203,15 @@ export class PluginService {
   private pluginActions = new Map<string, PluginActionDescriptor>();
   private pluginActionOwners = new Map<string, Set<string>>();
   private actionValidators = new Map<string, ValidateFn>();
+  /**
+   * Main-side action handler closures keyed by the same namespaced action id
+   * (`{pluginId}.{actionId}`) used by {@link pluginActions}. Populated only via
+   * `host.registerAction` — the renderer-side IPC `registerPluginAction` path
+   * stores metadata only, so a key present here is definitionally a main-side
+   * handler. The closures never cross the IPC boundary; `dispatchHandler`
+   * invokes them directly when a `plugin:invoke` lands on the action id.
+   */
+  private pluginActionHandlers = new Map<string, ActionHandler>();
   private ajv: AjvInstance | null = null;
   private pluginEventCleanups = new Map<string, Array<() => void>>();
   private workspaceClient: WorkspaceClient | null = null;
@@ -881,6 +891,51 @@ export class PluginService {
       get pluginId() {
         return pluginId;
       },
+      registerAction: (descriptor, handler) => {
+        if (revoked) {
+          throw new Error(
+            `Plugin "${pluginId}" host revoked: registerAction called after activate() returned or timed out`
+          );
+        }
+        if (!descriptor || typeof descriptor !== "object") {
+          throw new Error(`Plugin "${pluginId}" registerAction: descriptor must be an object`);
+        }
+        if (typeof handler !== "function") {
+          throw new Error(`Plugin "${pluginId}" registerAction: handler must be a function`);
+        }
+        if (typeof descriptor.id !== "string" || descriptor.id.length === 0) {
+          throw new Error(
+            `Plugin "${pluginId}" registerAction: descriptor.id must be a non-empty string`
+          );
+        }
+        // The host receives an un-prefixed id ("plan-from-issue") and
+        // namespaces it to "{pluginId}.{id}" — the inverse of the renderer IPC
+        // path, which already sends the namespaced id. validateAndBuild* then
+        // checks the prefixed id against the shared format/ownership rules.
+        const namespacedId = `${pluginId}.${descriptor.id}`;
+        const built = this.validateAndBuildActionDescriptor(pluginId, {
+          ...descriptor,
+          id: namespacedId,
+        });
+
+        // Replace semantics (per host-api.md): re-registering the same id
+        // overwrites the prior descriptor + handler. Evict any stale compiled
+        // input schema so the next dispatch recompiles against the new
+        // descriptor. Handlers are cleaned up on unload via
+        // unregisterPluginActions, matching the IPC-registered action path.
+        this.pluginActions.set(namespacedId, built);
+        this.pluginActionHandlers.set(namespacedId, handler);
+        this.actionValidators.delete(namespacedId);
+
+        let owners = this.pluginActionOwners.get(pluginId);
+        if (!owners) {
+          owners = new Set();
+          this.pluginActionOwners.set(pluginId, owners);
+        }
+        owners.add(namespacedId);
+
+        this.broadcastPluginActions();
+      },
       registerHandler: (channel, handler) => {
         if (revoked) {
           throw new Error(
@@ -1293,12 +1348,18 @@ export class PluginService {
     await this.activatePlugin(pluginId);
 
     const key = `${pluginId}:${channel}`;
+    const descriptor = this.pluginActions.get(channel);
+    // Main-side action handlers (host.registerAction) are addressed by the
+    // namespaced action id and take precedence over a channel-keyed IPC
+    // handler. Only honour one the dispatching plugin owns — the namespace
+    // already guarantees this, and the guard mirrors the input-schema check.
+    const actionHandler =
+      descriptor?.pluginId === pluginId ? this.pluginActionHandlers.get(channel) : undefined;
     const handler = this.handlerMap.get(key);
-    if (!handler) {
+    if (!actionHandler && !handler) {
       throw new Error(`No plugin handler registered for ${key}`);
     }
 
-    const descriptor = this.pluginActions.get(channel);
     if (descriptor?.inputSchema && descriptor.pluginId === pluginId) {
       let validator = this.actionValidators.get(channel);
       if (!validator) {
@@ -1325,6 +1386,25 @@ export class PluginService {
       }
     }
 
+    // A main-side action handler receives the args payload only — no IPC ctx,
+    // per the ActionHandler contract. The renderer's synthetic action forwards
+    // a single args object, so pass args[0] (undefined when called with none).
+    if (actionHandler) {
+      try {
+        return await actionHandler(args.length > 0 ? args[0] : undefined);
+      } catch (err) {
+        // Contain at the boundary so a throwing handler can't propagate up
+        // through `ipcMain.handle` as an unhandled rejection. The error still
+        // surfaces to the renderer (rethrown after logging).
+        // TODO(#9232): emit PluginActionAuditRecord to the audit pipeline.
+        console.error(`[PluginService] Action handler "${channel}" threw:`, err);
+        throw err;
+      }
+    }
+
+    if (!handler) {
+      throw new Error(`No plugin handler registered for ${key}`);
+    }
     try {
       return await handler(ctx, ...args);
     } catch (err) {
@@ -1573,11 +1653,17 @@ export class PluginService {
   }
 
   /**
-   * Register a runtime-contributed action for a loaded plugin.
-   * Validates id format, namespace ownership, and rejects "restricted" danger.
-   * Broadcasts the full action list to all renderers so windows stay in sync.
+   * Validate a plugin action contribution and build its host-authoritative
+   * descriptor. Shared by the renderer IPC path ({@link registerPluginAction},
+   * which throws on duplicate) and the main-side `host.registerAction` path
+   * (which replaces on duplicate) — so the duplicate check is deliberately NOT
+   * performed here. The caller must pass the already-namespaced
+   * `contribution.id` (`{pluginId}.{actionId}`).
    */
-  registerPluginAction(pluginId: string, contribution: PluginActionContribution): void {
+  private validateAndBuildActionDescriptor(
+    pluginId: string,
+    contribution: PluginActionContribution
+  ): PluginActionDescriptor {
     if (!this.plugins.has(pluginId)) {
       throw new Error(`Unknown plugin: ${pluginId}`);
     }
@@ -1612,9 +1698,6 @@ export class PluginService {
         `Plugin action "${id}" has invalid danger "${danger}". Plugins may only register "safe" or "confirm" actions.`
       );
     }
-    if (this.pluginActions.has(id)) {
-      throw new Error(`Plugin action "${id}" is already registered`);
-    }
 
     // Host-authoritative danger: the plugin's self-reported `danger` is
     // advisory. Raise it to "confirm" (never lower) when the plugin holds a
@@ -1627,7 +1710,7 @@ export class PluginService {
     const effectiveDanger: "safe" | "confirm" =
       danger === "confirm" || hasHighRiskCapability ? "confirm" : "safe";
 
-    const descriptor: PluginActionDescriptor = {
+    return {
       pluginId,
       id,
       title,
@@ -1642,14 +1725,29 @@ export class PluginService {
           ? { ...contribution.inputSchema }
           : undefined,
     };
+  }
 
-    this.pluginActions.set(id, descriptor);
+  /**
+   * Register a runtime-contributed action for a loaded plugin (renderer IPC
+   * path). Validates id format, namespace ownership, and rejects "restricted"
+   * danger. Throws if the action id is already registered — re-registration
+   * from the renderer is a plugin authoring bug. The main-side
+   * `host.registerAction` path uses replace semantics instead.
+   * Broadcasts the full action list to all renderers so windows stay in sync.
+   */
+  registerPluginAction(pluginId: string, contribution: PluginActionContribution): void {
+    const descriptor = this.validateAndBuildActionDescriptor(pluginId, contribution);
+    if (this.pluginActions.has(descriptor.id)) {
+      throw new Error(`Plugin action "${descriptor.id}" is already registered`);
+    }
+
+    this.pluginActions.set(descriptor.id, descriptor);
     let owners = this.pluginActionOwners.get(pluginId);
     if (!owners) {
       owners = new Set();
       this.pluginActionOwners.set(pluginId, owners);
     }
-    owners.add(id);
+    owners.add(descriptor.id);
 
     this.broadcastPluginActions();
   }
@@ -1661,6 +1759,7 @@ export class PluginService {
 
     this.pluginActions.delete(actionId);
     this.actionValidators.delete(actionId);
+    this.pluginActionHandlers.delete(actionId);
     const owners = this.pluginActionOwners.get(pluginId);
     if (owners) {
       owners.delete(actionId);
@@ -1678,6 +1777,7 @@ export class PluginService {
     for (const id of owners) {
       this.pluginActions.delete(id);
       this.actionValidators.delete(id);
+      this.pluginActionHandlers.delete(id);
     }
     this.pluginActionOwners.delete(pluginId);
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -908,6 +908,16 @@ export class PluginService {
             `Plugin "${pluginId}" registerAction: descriptor.id must be a non-empty string`
           );
         }
+        // The host adds the prefix, so a pre-prefixed id would silently produce
+        // a doubled "{pluginId}.{pluginId}.{id}" that still passes validation.
+        // Reject it up front to enforce the "id must NOT include the plugin
+        // prefix" contract (see host-api.md) instead of registering a malformed
+        // action id.
+        if (descriptor.id.startsWith(`${pluginId}.`)) {
+          throw new Error(
+            `Plugin "${pluginId}" registerAction: descriptor.id "${descriptor.id}" must not include the plugin prefix — Daintree adds it`
+          );
+        }
         // The host receives an un-prefixed id ("plan-from-issue") and
         // namespaces it to "{pluginId}.{id}" — the inverse of the renderer IPC
         // path, which already sends the namespaced id. validateAndBuild* then
@@ -1388,10 +1398,12 @@ export class PluginService {
 
     // A main-side action handler receives the args payload only — no IPC ctx,
     // per the ActionHandler contract. The renderer's synthetic action forwards
-    // a single args object, so pass args[0] (undefined when called with none).
+    // a single args object; default to `{}` when called with none so the
+    // handler sees the same value the input-schema validation accepted above
+    // (which also defaults the empty case to `{}`).
     if (actionHandler) {
       try {
-        return await actionHandler(args.length > 0 ? args[0] : undefined);
+        return await actionHandler(args.length > 0 ? args[0] : {});
       } catch (err) {
         // Contain at the boundary so a throwing handler can't propagate up
         // through `ipcMain.handle` as an unhandled rejection. The error still

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -876,6 +876,70 @@ describe("PluginService integration — activate() lifecycle", () => {
     expect(result.args).toEqual(["hello"]);
   });
 
+  it("registers a main-side action via host.registerAction and dispatches it end-to-end", async () => {
+    const pluginDir = await writePlugin("acme.action-plugin", {
+      name: "acme.action-plugin",
+      version: "1.0.0",
+    });
+    const mainFile = `action-${randomUUID()}.mjs`;
+    await fs.writeFile(
+      path.join(pluginDir, mainFile),
+      `export function activate(host) {
+  host.registerAction(
+    {
+      id: "do-thing",
+      title: "Do thing",
+      description: "Does the thing",
+      category: "Actions",
+      kind: "command",
+      danger: "safe",
+    },
+    async (args) => ({ echoed: args })
+  );
+}
+`
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "acme.action-plugin",
+        version: "1.0.0",
+        main: mainFile,
+      })
+    );
+
+    const service = new PluginService(tmpDir, "0.0.0");
+    await service.initialize();
+    // Activation is deferred: startup plugins activate via this fan-out (the
+    // production trigger is globalServicesInit). registerAction runs inside
+    // activate(), so the action only surfaces once activation has run.
+    await service.activateStartupFinishedPlugins();
+
+    // The action surfaces in the renderer-facing list with the namespaced id.
+    expect(service.listPluginActions().map((a) => a.id)).toContain("acme.action-plugin.do-thing");
+
+    // Dispatch lands on the main-side handler with the args payload only.
+    const result = await service.dispatchHandler(
+      "acme.action-plugin",
+      "acme.action-plugin.do-thing",
+      makeCtx("acme.action-plugin"),
+      [{ issue: 7 }]
+    );
+    expect(result).toEqual({ echoed: { issue: 7 } });
+
+    // Unload tears the handler down — a later dispatch finds nothing.
+    service.unloadPlugin("acme.action-plugin");
+    expect(service.listPluginActions()).toEqual([]);
+    await expect(
+      service.dispatchHandler(
+        "acme.action-plugin",
+        "acme.action-plugin.do-thing",
+        makeCtx("acme.action-plugin"),
+        [{}]
+      )
+    ).rejects.toThrow(/No plugin handler registered/);
+  });
+
   it("invokes activate's returned cleanup before handlers are removed on unload", async () => {
     const markerKey = makeMarkerKey();
     const pluginDir = await writePlugin("acme.cleanup-plugin", {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -2991,7 +2991,7 @@ describe("createHost — registerAction", () => {
     expect(result).toEqual({ done: true });
   });
 
-  it("invokes the handler with undefined when dispatched with no args", async () => {
+  it("invokes the handler with {} when dispatched with no args", async () => {
     const handler = vi.fn().mockReturnValue("ran");
     const { host } = getHost("acme.act-test");
     host.registerAction(descriptor(), handler);
@@ -3002,7 +3002,9 @@ describe("createHost — registerAction", () => {
       makeCtx("acme.act-test"),
       []
     );
-    expect(handler).toHaveBeenCalledWith(undefined);
+    // Defaults to {} (matching the input-schema validation default) rather than
+    // undefined, so a handler can safely destructure the args object.
+    expect(handler).toHaveBeenCalledWith({});
     expect(result).toBe("ran");
   });
 
@@ -3033,6 +3035,35 @@ describe("createHost — registerAction", () => {
     expect(() => host.registerAction(descriptor({ id: "" }), () => undefined)).toThrow(
       /descriptor.id must be a non-empty string/
     );
+  });
+
+  it("rejects an id that already includes the plugin prefix (no double-prefix)", () => {
+    const { host } = getHost("acme.act-test");
+    expect(() =>
+      host.registerAction(descriptor({ id: "acme.act-test.plan-from-issue" }), () => undefined)
+    ).toThrow(/must not include the plugin prefix/);
+    // Nothing was registered under the doubled id.
+    expect(service.listPluginActions()).toHaveLength(0);
+  });
+
+  it("passes {} to the handler when dispatched with no args (matches schema validation)", async () => {
+    const handler = vi.fn().mockReturnValue("ok");
+    const { host } = getHost("acme.act-test");
+    // Schema with only optional fields accepts an empty object.
+    host.registerAction(
+      descriptor({ inputSchema: { type: "object", properties: { flag: { type: "boolean" } } } }),
+      handler
+    );
+
+    const result = await service.dispatchHandler(
+      "acme.act-test",
+      "acme.act-test.plan-from-issue",
+      makeCtx("acme.act-test"),
+      []
+    );
+    // Handler receives the same {} the validator accepted — not undefined.
+    expect(handler).toHaveBeenCalledWith({});
+    expect(result).toBe("ok");
   });
 
   it("rejects restricted danger", () => {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -2914,6 +2914,298 @@ describe("Plugin action registry", () => {
   });
 });
 
+type ActionDescriptorInput = {
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+  kind: "command" | "query";
+  danger: "safe" | "confirm";
+  keywords?: string[];
+  inputSchema?: Record<string, unknown>;
+};
+type ActionHostShape = (pluginId: string) => {
+  host: {
+    registerAction: (
+      descriptor: ActionDescriptorInput,
+      handler: (args: unknown) => unknown
+    ) => void;
+  };
+  revoke: () => void;
+};
+
+describe("createHost — registerAction", () => {
+  let service: PluginService;
+
+  const descriptor = (overrides: Partial<ActionDescriptorInput> = {}): ActionDescriptorInput => ({
+    id: "plan-from-issue",
+    title: "Plan from issue",
+    description: "Turn an issue into a session",
+    category: "Planner",
+    kind: "command",
+    danger: "safe",
+    ...overrides,
+  });
+
+  const getHost = (pluginId: string) =>
+    (service as unknown as { createHost: ActionHostShape }).createHost(pluginId);
+
+  beforeEach(async () => {
+    await writePlugin("act-test", { name: "acme.act-test", version: "1.0.0" });
+    service = new PluginService(tmpDir);
+    await service.initialize();
+    broadcastToRendererMock.mockClear();
+  });
+
+  it("namespaces the un-prefixed id to {pluginId}.{id} and stores the descriptor", () => {
+    const { host } = getHost("acme.act-test");
+    host.registerAction(descriptor(), () => "ok");
+
+    const actions = service.listPluginActions();
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({
+      pluginId: "acme.act-test",
+      id: "acme.act-test.plan-from-issue",
+      title: "Plan from issue",
+    });
+    // Registering a new action broadcasts the refreshed list to renderers.
+    expect(broadcastToRendererMock).toHaveBeenCalledWith(CHANNELS.EVENTS_PUSH, {
+      name: "plugin:actions-changed",
+      payload: { actions },
+    });
+  });
+
+  it("invokes the handler with the args payload only — no IPC ctx", async () => {
+    const handler = vi.fn().mockResolvedValue({ done: true });
+    const { host } = getHost("acme.act-test");
+    host.registerAction(descriptor(), handler);
+
+    const result = await service.dispatchHandler(
+      "acme.act-test",
+      "acme.act-test.plan-from-issue",
+      makeCtx("acme.act-test"),
+      [{ issue: 42 }]
+    );
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({ issue: 42 });
+    expect(result).toEqual({ done: true });
+  });
+
+  it("invokes the handler with undefined when dispatched with no args", async () => {
+    const handler = vi.fn().mockReturnValue("ran");
+    const { host } = getHost("acme.act-test");
+    host.registerAction(descriptor(), handler);
+
+    const result = await service.dispatchHandler(
+      "acme.act-test",
+      "acme.act-test.plan-from-issue",
+      makeCtx("acme.act-test"),
+      []
+    );
+    expect(handler).toHaveBeenCalledWith(undefined);
+    expect(result).toBe("ran");
+  });
+
+  it("rejects calls after the host is revoked", () => {
+    const { host, revoke } = getHost("acme.act-test");
+    revoke();
+    expect(() => host.registerAction(descriptor(), () => undefined)).toThrow(
+      /host revoked: registerAction/
+    );
+  });
+
+  it("rejects a non-object descriptor", () => {
+    const { host } = getHost("acme.act-test");
+    expect(() =>
+      host.registerAction(null as unknown as ActionDescriptorInput, () => undefined)
+    ).toThrow(/descriptor must be an object/);
+  });
+
+  it("rejects a non-function handler", () => {
+    const { host } = getHost("acme.act-test");
+    expect(() =>
+      host.registerAction(descriptor(), "not-a-function" as unknown as () => unknown)
+    ).toThrow(/handler must be a function/);
+  });
+
+  it("rejects an empty descriptor.id", () => {
+    const { host } = getHost("acme.act-test");
+    expect(() => host.registerAction(descriptor({ id: "" }), () => undefined)).toThrow(
+      /descriptor.id must be a non-empty string/
+    );
+  });
+
+  it("rejects restricted danger", () => {
+    const { host } = getHost("acme.act-test");
+    expect(() =>
+      host.registerAction(
+        descriptor({ danger: "restricted" as unknown as "safe" }),
+        () => undefined
+      )
+    ).toThrow(/invalid danger/i);
+  });
+
+  it("raises effectiveDanger to confirm when the manifest grants a high-risk capability", async () => {
+    await writePlugin("act-risky", {
+      name: "acme.act-risky",
+      version: "1.0.0",
+      capabilities: ["shell:exec"],
+    });
+    const svc = new PluginService(tmpDir);
+    await svc.initialize();
+    const { host } = (svc as unknown as { createHost: ActionHostShape }).createHost(
+      "acme.act-risky"
+    );
+
+    host.registerAction(descriptor({ danger: "safe" }), () => undefined);
+
+    const action = svc.listPluginActions().find((a) => a.id === "acme.act-risky.plan-from-issue");
+    expect(action?.danger).toBe("safe");
+    expect(action?.effectiveDanger).toBe("confirm");
+  });
+
+  it("replaces the prior descriptor and handler on re-registration with the same id", async () => {
+    const first = vi.fn().mockReturnValue("first");
+    const second = vi.fn().mockReturnValue("second");
+    const { host } = getHost("acme.act-test");
+
+    host.registerAction(descriptor({ title: "Old title" }), first);
+    host.registerAction(descriptor({ title: "New title" }), second);
+
+    // Exactly one descriptor — replace, not append.
+    const actions = service.listPluginActions();
+    expect(actions).toHaveLength(1);
+    expect(actions[0].title).toBe("New title");
+
+    const result = await service.dispatchHandler(
+      "acme.act-test",
+      "acme.act-test.plan-from-issue",
+      makeCtx("acme.act-test"),
+      [{}]
+    );
+    expect(result).toBe("second");
+    expect(first).not.toHaveBeenCalled();
+  });
+
+  it("lets a host re-registration replace a renderer IPC registration", async () => {
+    // IPC path registers metadata only (no main-side handler).
+    service.registerPluginAction("acme.act-test", {
+      id: "acme.act-test.plan-from-issue",
+      title: "Via IPC",
+      description: "registered through the renderer path",
+      category: "Planner",
+      kind: "command",
+      danger: "safe",
+    });
+
+    const handler = vi.fn().mockReturnValue("from-host");
+    const { host } = getHost("acme.act-test");
+    // Replace semantics: re-registering the same id from the host does not throw.
+    expect(() => host.registerAction(descriptor(), handler)).not.toThrow();
+
+    const result = await service.dispatchHandler(
+      "acme.act-test",
+      "acme.act-test.plan-from-issue",
+      makeCtx("acme.act-test"),
+      [{}]
+    );
+    expect(result).toBe("from-host");
+  });
+
+  it("keeps the renderer IPC path throwing on a duplicate id (asymmetric semantics)", () => {
+    const { host } = getHost("acme.act-test");
+    host.registerAction(descriptor(), () => undefined);
+
+    // The IPC path stays loud on duplicates even after a host registration.
+    expect(() =>
+      service.registerPluginAction("acme.act-test", {
+        id: "acme.act-test.plan-from-issue",
+        title: "Dup",
+        description: "duplicate",
+        category: "Planner",
+        kind: "command",
+        danger: "safe",
+      })
+    ).toThrow(/already registered/);
+  });
+
+  it("validates args against the action's inputSchema", async () => {
+    const handler = vi.fn().mockReturnValue("ok");
+    const { host } = getHost("acme.act-test");
+    host.registerAction(
+      descriptor({
+        inputSchema: {
+          type: "object",
+          properties: { name: { type: "string" } },
+          required: ["name"],
+        },
+      }),
+      handler
+    );
+
+    await expect(
+      service.dispatchHandler(
+        "acme.act-test",
+        "acme.act-test.plan-from-issue",
+        makeCtx("acme.act-test"),
+        [{}]
+      )
+    ).rejects.toThrow(/Invalid arguments/);
+    expect(handler).not.toHaveBeenCalled();
+
+    const result = await service.dispatchHandler(
+      "acme.act-test",
+      "acme.act-test.plan-from-issue",
+      makeCtx("acme.act-test"),
+      [{ name: "issue" }]
+    );
+    expect(result).toBe("ok");
+  });
+
+  it("propagates an async handler rejection through dispatch", async () => {
+    const { host } = getHost("acme.act-test");
+    host.registerAction(descriptor(), async () => {
+      throw new Error("handler boom");
+    });
+
+    await expect(
+      service.dispatchHandler(
+        "acme.act-test",
+        "acme.act-test.plan-from-issue",
+        makeCtx("acme.act-test"),
+        [{}]
+      )
+    ).rejects.toThrow("handler boom");
+  });
+
+  it("removes the handler on unload so dispatch throws afterwards", async () => {
+    const { host } = getHost("acme.act-test");
+    host.registerAction(descriptor(), () => "ok");
+    expect(
+      await service.dispatchHandler(
+        "acme.act-test",
+        "acme.act-test.plan-from-issue",
+        makeCtx("acme.act-test"),
+        [{}]
+      )
+    ).toBe("ok");
+
+    service.unloadPlugin("acme.act-test");
+
+    expect(service.listPluginActions()).toEqual([]);
+    await expect(
+      service.dispatchHandler(
+        "acme.act-test",
+        "acme.act-test.plan-from-issue",
+        makeCtx("acme.act-test"),
+        [{}]
+      )
+    ).rejects.toThrow(
+      "No plugin handler registered for acme.act-test:acme.act-test.plan-from-issue"
+    );
+  });
+});
+
 describe("Plugin panel kind registry broadcast", () => {
   it("dispose() drops a microtask scheduled before disposal", async () => {
     // Capture the listener PluginService passes into onPanelKindRegistered so

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -2,7 +2,7 @@ import type { BuiltInKeyAction } from "./keymap.js";
 import type { BuiltInRuntimeActionId } from "../config/actionIds.js";
 import type { z } from "zod";
 
-export type ActionSource = "user" | "keybinding" | "menu" | "agent" | "context-menu";
+export type ActionSource = "user" | "keybinding" | "menu" | "agent" | "context-menu" | "plugin";
 
 export type ActionKind = "command" | "query";
 

--- a/shared/types/plugin-sdk.ts
+++ b/shared/types/plugin-sdk.ts
@@ -41,7 +41,7 @@ export type { PluginManifest } from "./plugin.js";
 
 // ── Activation contract ─────────────────────────────────────────────
 
-export type { PluginActivate, PluginHostApi } from "./plugin.js";
+export type { PluginActivate, PluginHostApi, ActionHandler } from "./plugin.js";
 
 // ── IPC (registerHandler, broadcastToRenderer) — ships in v1 ────────
 

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -281,8 +281,31 @@ export interface PluginToastOptions {
   durationMs?: number;
 }
 
+/**
+ * Runtime handler bound to a plugin-registered action via
+ * {@link PluginHostApi.registerAction}. Receives the dispatch args payload
+ * (the renderer-side synthetic action forwards a single args object) and
+ * returns the action's result. Unlike {@link PluginIpcHandler} it does NOT
+ * receive an IPC context — action handlers are addressed by action id, not by
+ * a per-invocation channel context. The closure lives only in main and never
+ * crosses the IPC boundary.
+ */
+export type ActionHandler = (args: unknown) => unknown | Promise<unknown>;
+
 export interface PluginHostApi {
   readonly pluginId: string;
+  /**
+   * Imperatively register an action with a main-side handler. The
+   * `descriptor.id` must NOT include the plugin prefix — the host namespaces
+   * it as `{pluginId}.{descriptor.id}` at runtime. `descriptor.danger` accepts
+   * `"safe"` or `"confirm"`; `"restricted"` is rejected. The host raises the
+   * effective danger to `"confirm"` when the plugin holds a high-risk
+   * capability, mirroring {@link PluginActionDescriptor.effectiveDanger}.
+   * Calling with a previously-registered id replaces the prior descriptor and
+   * handler. Must be called during `activate()` — the host is revoked once
+   * activation resolves or times out. Unregistered automatically on unload.
+   */
+  registerAction(descriptor: PluginActionContribution, handler: ActionHandler): void;
   registerHandler(channel: string, handler: PluginIpcHandler): void;
   broadcastToRenderer(channel: string, payload: unknown): void;
   /**


### PR DESCRIPTION
## Summary

Adds `registerAction(descriptor, handler)` to the main-side plugin host (`PluginHostApi`). Plugins can now imperatively register an action with a main-side handler during `activate()`; the handler runs in main and fires when the renderer dispatches the synthetic `ActionDefinition` back over `plugin:invoke`. Previously only manifest-declared / renderer-IPC metadata registration existed, so a plugin calling `host.registerAction` failed at runtime.

Closes #9277.

> Supersedes the earlier #9381, which was closed as out-of-Wave-1 scope. This is an independent implementation rebased onto current `develop` (opened on a fresh branch to avoid force-pushing over #9381's branch).

## Changes

- **`ActionHandler` type** added to `shared/types/plugin.ts` and re-exported from the `@daintreehq/plugin-sdk` boundary (`shared/types/plugin-sdk.ts`). Signature: `(args: unknown) => unknown | Promise<unknown>` — receives the dispatch args payload only, no IPC ctx (unlike `PluginIpcHandler`).
- **`registerAction` on `PluginHostApi`** wired into `createHost()` following the existing revoke-guard pattern. Returns `void`; auto-cleaned on unload.
- Un-prefixed `descriptor.id` is namespaced to `{pluginId}.{id}`; a pre-prefixed id is rejected to avoid a silent doubled id. Re-registration **replaces** the prior descriptor + handler, while the renderer IPC `registerPluginAction` path keeps **throwing** on duplicates. Shared validation extracted into `validateAndBuildActionDescriptor`.
- Handler closures stored in a new `pluginActionHandlers` map (keyed by namespaced id) and invoked by `dispatchHandler` ahead of channel-keyed IPC handlers — only when `descriptor.pluginId` matches the dispatching plugin. Handlers receive `{}` (matching input-schema validation) when dispatched with no args.
- `"restricted"` danger rejected; `effectiveDanger` promotion (high-risk capability → `confirm`) applies identically to the IPC path. Handlers removed on `unregisterPluginAction(s)` / unload.
- `"plugin"` added to the `ActionSource` union (excluded from `REPEATABLE_SOURCES`, mirroring `"agent"`).

## Test plan

- [x] Unit: `PluginService.test.ts` — new `createHost — registerAction` block (namespacing, revoke guard, descriptor/handler/id validation, double-prefix rejection, danger validation + capability promotion, replace semantics, asymmetric IPC dup-throw, input-schema validation, args-only `{}` default, async rejection, unload cleanup). 289 passing.
- [x] Integration: `PluginService.integration.test.ts` — end-to-end `activate() → registerAction → dispatch → unload` via the deferred startup-activation path.
- [x] `npm run check` clean (typecheck, lint ratchet -1, format, IPC codegen, channels).

## Note (separate follow-up)

13 pre-existing integration lifecycle tests in `PluginService.integration.test.ts` are currently broken on `develop`: commit `5b4924e71` (deferred activation) migrated the **unit** tests to call `activateStartupFinishedPlugins()` after `initialize()` but did not update the **integration** tests. Out of scope for this PR; flagging for a follow-up.