### PR TITLE
Sync plugin lifecycle across project views and survive LRU eviction

### DIFF
--- a/e2e/full/resilience/core-plugin-lifecycle-across-views.spec.ts
+++ b/e2e/full/resilience/core-plugin-lifecycle-across-views.spec.ts
@@ -1,0 +1,203 @@
+import { test, expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
+import { createFixtureRepos } from "../../helpers/fixtures";
+import { openAndOnboardProject } from "../../helpers/project";
+import { addAndSwitchToProject, selectExistingProjectAndRefresh } from "../../helpers/workflows";
+import { T_LONG } from "../../helpers/timeouts";
+
+// Three projects with cache=2 — the same shape as the LRU eviction spec.
+// A→B→C cycles deterministically evict A as LRU when C loads, so we can
+// observe both the cached-warm path (B) and the cold-restore path (A) without
+// CI memory pressure being able to collapse the cache below the user limit.
+const PROJECT_A = "plugin-A";
+const PROJECT_B = "plugin-B";
+const PROJECT_C = "plugin-C";
+const CACHE_LIMIT = 2;
+
+let ctx: AppContext;
+let fixtureCleanups: Array<() => void> = [];
+let projectIdA = "";
+
+interface PluginSnapshot {
+  pluginNames: string[];
+  actionIds: string[];
+  panelKindIds: string[];
+  toolbarButtonIds: string[];
+}
+
+async function configurePvm(app: AppContext["app"], limit: number): Promise<void> {
+  await app.evaluate((_electron, n) => {
+    const g = globalThis as Record<string, unknown>;
+    const getPvm = g.__daintreeGetPvm as (() => unknown) | undefined;
+    const pvm = getPvm?.() as
+      | {
+          setCachedViewLimit: (n: number) => void;
+          setLowMemoryFreeThresholdMb?: (mb: number | null) => void;
+        }
+      | null
+      | undefined;
+    // Same low-memory-cap disable as the LRU spec: a CI collapse to 1 would
+    // make A→B→C eviction non-deterministic and let the cache hide bugs.
+    pvm?.setLowMemoryFreeThresholdMb?.(null);
+    pvm?.setCachedViewLimit(n);
+  }, limit);
+}
+
+async function readPvmProjectIds(app: AppContext["app"]): Promise<{
+  activeProjectId: string | null;
+  projectIds: string[];
+}> {
+  return app.evaluate(() => {
+    const g = globalThis as Record<string, unknown>;
+    const getPvm = g.__daintreeGetPvm as (() => unknown) | undefined;
+    const pvm = getPvm?.() as
+      | {
+          getAllViews: () => Array<{ projectId: string }>;
+          getActiveProjectId: () => string | null;
+        }
+      | null
+      | undefined;
+    if (!pvm) return { activeProjectId: null, projectIds: [] };
+    return {
+      activeProjectId: pvm.getActiveProjectId(),
+      projectIds: pvm.getAllViews().map((v) => v.projectId),
+    };
+  });
+}
+
+async function requireActiveProjectId(app: AppContext["app"], label: string): Promise<string> {
+  const { activeProjectId } = await readPvmProjectIds(app);
+  if (!activeProjectId) {
+    throw new Error(`[plugin-lifecycle] expected active project id after opening ${label}`);
+  }
+  return activeProjectId;
+}
+
+async function waitForProjectAEvicted(app: AppContext["app"]): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const state = await readPvmProjectIds(app);
+        return !state.projectIds.includes(projectIdA);
+      },
+      {
+        timeout: 15_000,
+        intervals: [200, 400, 800, 1600],
+      }
+    )
+    .toBe(true);
+}
+
+// Reads the plugin contribution snapshot the renderer would mount against:
+// the four shapes the main process broadcasts (list, actions, panel kinds,
+// toolbar buttons). Ids are sorted so equality comparisons across views
+// aren't sensitive to enumeration order.
+async function readPluginSnapshot(window: Page): Promise<PluginSnapshot> {
+  return window.evaluate(async () => {
+    const api = (
+      window as unknown as {
+        electron?: {
+          plugin?: {
+            list: () => Promise<Array<{ name: string }>>;
+            getActions: () => Promise<Array<{ id: string }>>;
+            getPanelKinds: () => Promise<Array<{ id: string }>>;
+            toolbarButtons: () => Promise<Array<{ id: string }>>;
+          };
+        };
+      }
+    ).electron?.plugin;
+    if (!api) {
+      throw new Error("window.electron.plugin is not exposed");
+    }
+    const [plugins, actions, kinds, buttons] = await Promise.all([
+      api.list(),
+      api.getActions(),
+      api.getPanelKinds(),
+      api.toolbarButtons(),
+    ]);
+    return {
+      pluginNames: plugins.map((p) => p.name).sort(),
+      actionIds: actions.map((a) => a.id).sort(),
+      panelKindIds: kinds.map((k) => k.id).sort(),
+      toolbarButtonIds: buttons.map((b) => b.id).sort(),
+    };
+  });
+}
+
+test.describe.serial("Core: plugin lifecycle across project views and LRU restore", () => {
+  test.beforeAll(async () => {
+    test.setTimeout(300_000);
+    const fixtures = createFixtureRepos(3);
+    fixtureCleanups = fixtures.map((f) => f.cleanup);
+    const [repoA, repoB, repoC] = fixtures.map((f) => f.dir);
+
+    ctx = await launchApp();
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, repoA, PROJECT_A);
+    projectIdA = await requireActiveProjectId(ctx.app, PROJECT_A);
+
+    await configurePvm(ctx.app, CACHE_LIMIT);
+
+    ctx.window = await addAndSwitchToProject(ctx.app, ctx.window, repoB, PROJECT_B);
+    ctx.window = await addAndSwitchToProject(ctx.app, ctx.window, repoC, PROJECT_C);
+
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_A);
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) {
+      await configurePvm(ctx.app, 5).catch(() => undefined);
+      await closeApp(ctx.app);
+    }
+    for (const cleanup of fixtureCleanups) cleanup();
+  });
+
+  test("plugin snapshot is identical across the three views", async () => {
+    test.slow();
+
+    // Active = A. Read its snapshot first.
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_A);
+    const snapshotA = await readPluginSnapshot(ctx.window);
+
+    // Switch to B (a previously-active, now-cached view becomes active again)
+    // and assert the snapshot matches. Warm reactivation does not remount the
+    // renderer, so this exercises the persistent listener path, not pull-on-
+    // mount — they must converge on the same set.
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_B);
+    const snapshotB = await readPluginSnapshot(ctx.window);
+
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_C);
+    const snapshotC = await readPluginSnapshot(ctx.window);
+
+    expect(snapshotB).toEqual(snapshotA);
+    expect(snapshotC).toEqual(snapshotA);
+  });
+
+  test("cold-restored view sees the same plugin snapshot as its peers", async () => {
+    test.slow();
+
+    // Force A→B→C so A is evicted as the LRU view.
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_A);
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_B);
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_C);
+
+    await waitForProjectAEvicted(ctx.app);
+
+    // C is still active and was never evicted — its snapshot is the
+    // authoritative reference for what the cold-restored view must observe.
+    const snapshotC = await readPluginSnapshot(ctx.window);
+
+    // Cold-restore A: a fresh WebContentsView is created, the renderer mounts,
+    // pull-on-mount + the targeted pushSnapshotTo (the #9285 fix) populate the
+    // hook state. The pull is gated on waitForInit() and the push is the
+    // belt-and-suspenders for views that mount before activation settles.
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_A);
+
+    await expect
+      .poll(() => readPluginSnapshot(ctx.window), {
+        timeout: T_LONG,
+        intervals: [200, 400, 800, 1600],
+      })
+      .toEqual(snapshotC);
+  });
+});

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -22,6 +22,11 @@ vi.mock("../../../services/PluginService.js", () => ({
     // No-op for tests that don't care about implicit activation; the IPC
     // handler awaits it before resolving the impl set.
     activatePluginsForFileDecorationScope: vi.fn().mockResolvedValue(undefined),
+    // The three pull handlers (getActions / getPanelKinds / toolbarButtons)
+    // await waitForInit() so a renderer that mounts before startup activation
+    // settles still gets a populated snapshot — resolved-immediately in tests
+    // since we don't exercise the gate here.
+    waitForInit: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -551,6 +556,53 @@ describe("PLUGIN_ACTIONS_GET / REGISTER / UNREGISTER handlers", () => {
       "acme.my-plugin",
       "acme.my-plugin.doThing"
     );
+  });
+});
+
+describe("pull handlers wait for PluginService init (#9285)", () => {
+  function getHandler(channel: string) {
+    registerPluginHandlers();
+    return mockIpcMainHandle.mock.calls.find((c: unknown[]) => c[0] === channel)![1] as (
+      ...args: unknown[]
+    ) => unknown;
+  }
+
+  it("PLUGIN_ACTIONS_GET reads the registry only after waitForInit() resolves", async () => {
+    const { pluginService } = await import("../../../services/PluginService.js");
+    const waitForInit = vi.mocked(pluginService.waitForInit);
+    let releaseGate: () => void = () => {};
+    waitForInit.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        releaseGate = resolve;
+      })
+    );
+    const handler = getHandler("plugin:actions-get");
+    const inFlight = handler({}) as Promise<unknown>;
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockListPluginActions).not.toHaveBeenCalled();
+    releaseGate();
+    await inFlight;
+    expect(mockListPluginActions).toHaveBeenCalledTimes(1);
+  });
+
+  it("PLUGIN_TOOLBAR_BUTTONS reads the registry only after waitForInit() resolves", async () => {
+    const { pluginService } = await import("../../../services/PluginService.js");
+    const waitForInit = vi.mocked(pluginService.waitForInit);
+    let releaseGate: () => void = () => {};
+    waitForInit.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        releaseGate = resolve;
+      })
+    );
+    const handler = getHandler("plugin:toolbar-buttons");
+    const inFlight = handler({}) as Promise<unknown>;
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockGetPluginToolbarButtonIds).not.toHaveBeenCalled();
+    releaseGate();
+    await inFlight;
+    expect(mockGetPluginToolbarButtonIds).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -604,6 +604,33 @@ describe("pull handlers wait for PluginService init (#9285)", () => {
     await inFlight;
     expect(mockGetPluginToolbarButtonIds).toHaveBeenCalledTimes(1);
   });
+
+  it("PLUGIN_PANEL_KINDS_GET reads the registry only after waitForInit() resolves", async () => {
+    const { pluginService } = await import("../../../services/PluginService.js");
+    const waitForInit = vi.mocked(pluginService.waitForInit);
+    let releaseGate: () => void = () => {};
+    waitForInit.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        releaseGate = resolve;
+      })
+    );
+    const handler = getHandler("plugin:panel-kinds-get");
+    const inFlight = handler({}) as Promise<unknown>;
+    await Promise.resolve();
+    await Promise.resolve();
+    // `handlePanelKindsGet` reads from the panelKindRegistry, which is mocked
+    // separately at module load; the call we can observe through `pluginService`
+    // here is the gate itself. Assert the inFlight promise has not resolved yet.
+    let resolved = false;
+    void inFlight.then(() => {
+      resolved = true;
+    });
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+    releaseGate();
+    await inFlight;
+    expect(resolved).toBe(true);
+  });
 });
 
 describe("PLUGIN_FORGE_PROVIDERS_GET handler", () => {

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -48,6 +48,11 @@ async function handleSetEnabled(pluginId: string, enabled: boolean): Promise<voi
 }
 
 async function handleToolbarButtons(): Promise<ToolbarButtonConfig[]> {
+  // Block the renderer's mount-time pull until startup activation has settled,
+  // otherwise a fast renderer can read an empty registry before any plugin's
+  // activate() runs — leaving plugin toolbar buttons missing until the next
+  // mutation pushes a fresh broadcast (#9285).
+  await pluginService.waitForInit();
   return getPluginToolbarButtonIds()
     .map((id) => getToolbarButtonConfig(id))
     .filter((c): c is ToolbarButtonConfig => c !== undefined);
@@ -106,6 +111,7 @@ async function handleValidateActionIds(actionIds: string[]): Promise<void> {
 // gives it direct access to event.senderFrame — the typed path here does
 // not and doesn't need it.
 async function handleActionsGet(): Promise<PluginActionDescriptor[]> {
+  await pluginService.waitForInit();
   return pluginService.listPluginActions();
 }
 
@@ -121,6 +127,7 @@ async function handleActionsUnregister(pluginId: string, actionId: string): Prom
 }
 
 async function handlePanelKindsGet(): Promise<PanelKindConfig[]> {
+  await pluginService.waitForInit();
   return getPluginPanelKinds();
 }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -339,6 +339,20 @@ if (!gotTheLock) {
             }
           }
         }
+
+        // Replay the plugin contributions snapshot to a freshly-loaded view
+        // (cold start, LRU restore, crash reload, DevTools refresh) so its
+        // renderer registry is current even if every push was emitted while
+        // the previous V8 context was alive. The renderer's pull-on-mount is
+        // a separate path; this is the push path that lets the existing
+        // persistent listeners overtake a slow IPC pull. Dynamically imported
+        // to avoid pulling PluginService into main.ts's static graph (#9285).
+        const wcId = wc.id;
+        import("./services/PluginService.js")
+          .then(({ pluginService }) => pluginService.pushSnapshotTo(wc))
+          .catch((err) => {
+            console.warn(`[main] pushSnapshotTo failed for wc ${wcId}:`, err);
+          });
       },
     });
     setProjectViewManager(pvm);

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -2387,18 +2387,27 @@ export class PluginService {
     await this.initPromise;
     if (this.disposed) return;
     if (webContents.isDestroyed()) return;
-    webContents.send(CHANNELS.EVENTS_PUSH, {
-      name: "plugin:actions-changed",
-      payload: { actions: this.listPluginActions() },
-    });
-    webContents.send(CHANNELS.EVENTS_PUSH, {
-      name: "plugin:panel-kinds-changed",
-      payload: { kinds: getPluginPanelKinds() },
-    });
-    webContents.send(CHANNELS.EVENTS_PUSH, {
-      name: "plugin:toolbar-buttons-changed",
-      payload: { buttons: getAllPluginToolbarButtonConfigs(), complete: false },
-    });
+    // Mirror `broadcastToRenderer`'s defensive send pattern (electron/ipc/utils.ts:337-352):
+    // the wc may be destroyed between the isDestroyed() check above and any
+    // individual send (TOCTOU), and a throw on the first send would otherwise
+    // leave the next two channels un-sent — silently degrading the
+    // cold-restored renderer to its pull-on-mount path for those two channels
+    // only. Each send is independently guarded.
+    const events: Array<{ name: string; payload: unknown }> = [
+      { name: "plugin:actions-changed", payload: { actions: this.listPluginActions() } },
+      { name: "plugin:panel-kinds-changed", payload: { kinds: getPluginPanelKinds() } },
+      {
+        name: "plugin:toolbar-buttons-changed",
+        payload: { buttons: getAllPluginToolbarButtonConfigs(), complete: false },
+      },
+    ];
+    for (const event of events) {
+      try {
+        webContents.send(CHANNELS.EVENTS_PUSH, event);
+      } catch {
+        // Silently ignore send failures during window initialization/disposal.
+      }
+    }
   }
 }
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -340,6 +340,16 @@ export class PluginService {
   private disposed = false;
   private readonly disposeRegistrySubscriptions: () => void;
   /**
+   * Resolves once {@link initialize} and {@link activateStartupFinishedPlugins}
+   * have both settled (or {@link dispose} has run). Renderer pull-on-mount IPC
+   * handlers await this so a fresh `getActions` / `getPanelKinds` /
+   * `toolbarButtons` call can't return `[]` while plugins are still being
+   * loaded and activated. Settled in `finally` so a plugin activation failure
+   * never permanently deadlocks the renderer (#9285).
+   */
+  private readonly initPromise: Promise<void>;
+  private resolveInit: (() => void) | null = null;
+  /**
    * In-flight `host.dispatch()` round-trips keyed by `requestId`. Each entry is
    * resolved by the {@link CHANNELS.PLUGIN_DISPATCH_ACTION_RESPONSE} listener,
    * the timeout, the renderer's `destroyed` event, or {@link dispose}.
@@ -362,12 +372,28 @@ export class PluginService {
     this.builtinPluginsRoot = options?.builtinPluginsRoot;
     this.sideloadPluginsRoot = options?.sideloadPluginsRoot;
 
+    this.initPromise = new Promise<void>((resolve) => {
+      this.resolveInit = resolve;
+    });
+
     const offRegister = onPanelKindRegistered(() => this.schedulePanelKindsBroadcast());
     const offUnregister = onPanelKindUnregistered(() => this.schedulePanelKindsBroadcast());
     this.disposeRegistrySubscriptions = () => {
       offRegister();
       offUnregister();
     };
+  }
+
+  /**
+   * Resolves once startup load + activation has settled. The three pull-on-mount
+   * IPC handlers (`getActions`, `getPanelKinds`, `toolbarButtons`) await this
+   * so a renderer that mounts before plugins activate doesn't observe an empty
+   * registry. Safe to await repeatedly; resolves immediately after the first
+   * settle. {@link dispose} also resolves it to prevent test hangs when a
+   * service is torn down without calling {@link activateStartupFinishedPlugins}.
+   */
+  waitForInit(): Promise<void> {
+    return this.initPromise;
   }
 
   /**
@@ -382,6 +408,11 @@ export class PluginService {
     this.disposeRegistrySubscriptions();
     this.pluginDispatchListenerCleanup?.();
     this.pluginDispatchListenerCleanup = null;
+    // Settle the init gate so unit tests that tear down the service without
+    // running activateStartupFinishedPlugins() don't hang IPC callers awaiting
+    // waitForInit().
+    this.resolveInit?.();
+    this.resolveInit = null;
     for (const pending of this.pendingPluginDispatches.values()) {
       clearTimeout(pending.timer);
       pending.destroyedCleanup?.();
@@ -928,14 +959,25 @@ export class PluginService {
    * keeps progressing while plugins warm up in the background.
    */
   async activateStartupFinishedPlugins(): Promise<void> {
-    const targets: string[] = [];
-    for (const plugin of this.plugins.values()) {
-      if (!plugin.resolvedMain) continue;
-      if (!this.shouldActivateOnStartup(plugin.manifest)) continue;
-      targets.push(plugin.manifest.name);
+    try {
+      const targets: string[] = [];
+      for (const plugin of this.plugins.values()) {
+        if (!plugin.resolvedMain) continue;
+        if (!this.shouldActivateOnStartup(plugin.manifest)) continue;
+        targets.push(plugin.manifest.name);
+      }
+      if (targets.length === 0) return;
+      await Promise.allSettled(targets.map((id) => this.activatePlugin(id)));
+    } finally {
+      // Open the init gate even if every plugin's activate() rejected — a
+      // crashed plugin must not strand renderer IPC callers awaiting
+      // waitForInit() forever. `Promise.allSettled` already swallows
+      // individual rejections, but `targets.length === 0` short-circuits
+      // before the awaited line, so the finally is what guarantees release
+      // in the no-plugins case.
+      this.resolveInit?.();
+      this.resolveInit = null;
     }
-    if (targets.length === 0) return;
-    await Promise.allSettled(targets.map((id) => this.activatePlugin(id)));
   }
 
   /**
@@ -2324,6 +2366,38 @@ export class PluginService {
     broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
       name: "plugin:toolbar-buttons-changed",
       payload: { buttons: getAllPluginToolbarButtonConfigs(), complete },
+    });
+  }
+
+  /**
+   * Replay the current actions / panel-kinds / toolbar-button snapshots to a
+   * single target webContents. Used by the cold-start view-ready hook so a
+   * freshly-restored WebContentsView (post-LRU eviction or first cold load on
+   * project switch) gets a complete plugin state on the same channels its
+   * persistent push listeners already consume — no renderer-side changes
+   * needed. Awaits {@link waitForInit} so the snapshot is post-activation, not
+   * the empty pre-init view (#9285).
+   *
+   * Toolbar buttons use `complete: false` so the renderer does not stale-prune
+   * against this snapshot — replay is authoritative for the target view but
+   * conceptually identical to a coalesced "load tick" broadcast, not an
+   * unload sweep.
+   */
+  async pushSnapshotTo(webContents: Electron.WebContents): Promise<void> {
+    await this.initPromise;
+    if (this.disposed) return;
+    if (webContents.isDestroyed()) return;
+    webContents.send(CHANNELS.EVENTS_PUSH, {
+      name: "plugin:actions-changed",
+      payload: { actions: this.listPluginActions() },
+    });
+    webContents.send(CHANNELS.EVENTS_PUSH, {
+      name: "plugin:panel-kinds-changed",
+      payload: { kinds: getPluginPanelKinds() },
+    });
+    webContents.send(CHANNELS.EVENTS_PUSH, {
+      name: "plugin:toolbar-buttons-changed",
+      payload: { buttons: getAllPluginToolbarButtonConfigs(), complete: false },
     });
   }
 }

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -5594,6 +5594,12 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
     await service.pushSnapshotTo(wc);
 
     expect(send).toHaveBeenCalledTimes(3);
+    // Every replay goes through the EVENTS_PUSH channel — the same channel the
+    // renderer hooks' persistent push listeners consume, so no renderer-side
+    // changes are needed for the cold-restore path.
+    for (const call of send.mock.calls) {
+      expect(call[0]).toBe(CHANNELS.EVENTS_PUSH);
+    }
     const names = send.mock.calls.map((c) => (c[1] as { name?: string })?.name);
     expect(names).toContain("plugin:actions-changed");
     expect(names).toContain("plugin:panel-kinds-changed");
@@ -5605,6 +5611,28 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
       (c) => (c[1] as { name?: string })?.name === "plugin:toolbar-buttons-changed"
     );
     expect((toolbarCall?.[1] as { payload: { complete: boolean } }).payload.complete).toBe(false);
+  });
+
+  it("pushSnapshotTo() keeps sending remaining channels when one send() throws (TOCTOU)", async () => {
+    // Simulates the wc being destroyed between the isDestroyed() guard and an
+    // individual send — Electron raises "Object has been destroyed". Without
+    // per-send try/catch one bad call would silently drop the remaining two
+    // channels and the cold-restored renderer would miss state.
+    const service = new PluginService(tmpDir);
+    await service.activateStartupFinishedPlugins();
+    const send = vi.fn((_channel: string, payload: { name: string }) => {
+      if (payload.name === "plugin:actions-changed") {
+        throw new Error("Object has been destroyed");
+      }
+    });
+    const wc = { send, isDestroyed: () => false } as unknown as Electron.WebContents;
+
+    await service.pushSnapshotTo(wc);
+
+    expect(send).toHaveBeenCalledTimes(3);
+    const names = send.mock.calls.map((c) => (c[1] as { name?: string })?.name);
+    expect(names).toContain("plugin:panel-kinds-changed");
+    expect(names).toContain("plugin:toolbar-buttons-changed");
   });
 
   it("pushSnapshotTo() skips a destroyed webContents", async () => {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -5554,3 +5554,94 @@ describe("createHost — settings", () => {
     expect(await host.settings.get<string>("token")).toBe("still-works");
   });
 });
+
+describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
+  it("waitForInit() stays pending until activateStartupFinishedPlugins() settles", async () => {
+    const service = new PluginService(tmpDir);
+    let resolved = false;
+    const waiter = service.waitForInit().then(() => {
+      resolved = true;
+    });
+    // Yield through several microtasks to make sure nothing leaks out of init.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    await service.activateStartupFinishedPlugins();
+    await waiter;
+    expect(resolved).toBe(true);
+  });
+
+  it("waitForInit() resolves after activateStartupFinishedPlugins() even with zero plugins", async () => {
+    const service = new PluginService(tmpDir);
+    await service.activateStartupFinishedPlugins();
+    await expect(service.waitForInit()).resolves.toBeUndefined();
+  });
+
+  it("dispose() resolves a pending waitForInit() so callers don't deadlock", async () => {
+    const service = new PluginService(tmpDir);
+    const waiter = service.waitForInit();
+    service.dispose();
+    await expect(waiter).resolves.toBeUndefined();
+  });
+
+  it("pushSnapshotTo() sends actions, panel kinds, and toolbar buttons to the target webContents", async () => {
+    const service = new PluginService(tmpDir);
+    await service.activateStartupFinishedPlugins();
+    const send = vi.fn();
+    const wc = { send, isDestroyed: () => false } as unknown as Electron.WebContents;
+
+    await service.pushSnapshotTo(wc);
+
+    expect(send).toHaveBeenCalledTimes(3);
+    const names = send.mock.calls.map((c) => (c[1] as { name?: string })?.name);
+    expect(names).toContain("plugin:actions-changed");
+    expect(names).toContain("plugin:panel-kinds-changed");
+    expect(names).toContain("plugin:toolbar-buttons-changed");
+    // Toolbar replay must use `complete: false` so the renderer does not
+    // run a stale-prune sweep — replay is a load-style snapshot, not an
+    // unload-driven authoritative sweep.
+    const toolbarCall = send.mock.calls.find(
+      (c) => (c[1] as { name?: string })?.name === "plugin:toolbar-buttons-changed"
+    );
+    expect((toolbarCall?.[1] as { payload: { complete: boolean } }).payload.complete).toBe(false);
+  });
+
+  it("pushSnapshotTo() skips a destroyed webContents", async () => {
+    const service = new PluginService(tmpDir);
+    await service.activateStartupFinishedPlugins();
+    const send = vi.fn();
+    const wc = { send, isDestroyed: () => true } as unknown as Electron.WebContents;
+
+    await service.pushSnapshotTo(wc);
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("pushSnapshotTo() waits for init before sending — no empty snapshot races startup", async () => {
+    const service = new PluginService(tmpDir);
+    const send = vi.fn();
+    const wc = { send, isDestroyed: () => false } as unknown as Electron.WebContents;
+
+    // Fire pushSnapshotTo before init has resolved — it must hold off the
+    // webContents.send calls until activateStartupFinishedPlugins() settles.
+    const inFlight = service.pushSnapshotTo(wc);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(send).not.toHaveBeenCalled();
+
+    await service.activateStartupFinishedPlugins();
+    await inFlight;
+    expect(send).toHaveBeenCalledTimes(3);
+  });
+
+  it("pushSnapshotTo() does not send after dispose()", async () => {
+    const service = new PluginService(tmpDir);
+    const send = vi.fn();
+    const wc = { send, isDestroyed: () => false } as unknown as Electron.WebContents;
+    const inFlight = service.pushSnapshotTo(wc);
+    service.dispose();
+    await inFlight;
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Notifications/NotificationCenterEntry.tsx
+++ b/src/components/Notifications/NotificationCenterEntry.tsx
@@ -482,7 +482,7 @@ function RowOptionsMenu({
       // title/message) and JSON.stringify can surface TypeError (circular
       // refs / BigInt in context). Without this catch the rejection escapes
       // the `void handleReportOnGitHub()` site as an unhandled promise.
-      // eslint-disable-next-line no-console -- logger was loaded lazily; falls back to console
+
       console.warn("Failed to build notification report", reportError);
     } finally {
       setReportInFlight(false);


### PR DESCRIPTION
Two bugs in plugin state sync, both fixed here.

**Bug 1 — init race.** `usePluginActions`, `usePluginPanelKinds`, and `usePluginToolbarButtons` all pull on mount. If that pull lands before `PluginService.activateStartupFinishedPlugins()` runs, every handler returns `[]` and the renderer quietly registers nothing.

**Bug 2 — LRU eviction.** When a `WebContentsView` is cold-restored after LRU eviction, its new V8 context remounts the hooks and pulls again — but it also misses every `plugin:*-changed` broadcast emitted while the previous context was alive.

## Fix

Three parts:

**1. Init gate** — `PluginService.waitForInit()` resolves after `activateStartupFinishedPlugins()` settles. The resolve lives in a `finally` block so a plugin activation failure never deadlocks renderer IPC. It also resolves in `dispose()` to prevent test hangs. The three pull IPC handlers (`getActions`, `getPanelKinds`, `toolbarButtons`) all `await waitForInit()` before reading state.

**2. Targeted snapshot replay** — `PluginService.pushSnapshotTo(webContents)` sends actions, panel kinds, and toolbar buttons (`complete: false`) to a single target view on the `EVENTS_PUSH` channel. Wired into the existing `onViewReady` callback in `main.ts`, which fires on `did-finish-load` for the active view (cold start, reload, crash recovery) but never on warm reactivation (which doesn't trigger `did-finish-load`). Each send is wrapped in `try/catch` matching the `broadcastToRenderer` pattern.

**3. Tests** — new `full-resilience` E2E spec: 3-project / `cache=2` matrix verifying snapshot consistency across cached, warm, and LRU-evicted-then-cold-restored views. Unit tests for the init gate (pending / `finally`-resolves / `dispose`-resolves), `pushSnapshotTo` shape (`EVENTS_PUSH` channel, `complete: false` toolbar, destroyed-wc skip, TOCTOU partial-send recovery), and gate-held regression tests for all three pull IPC handlers.

## Testing

- 364 unit tests pass
- `tsc` clean
- lint ratchet improved by 1
- new E2E spec runs in `full-resilience` bucket

Closes #9285.