### PR TITLE
feat(plugins): host contract test harness — createMockHost + Playwright e2e

### DIFF
--- a/e2e/full/platform/core-plugin-host-contract.spec.ts
+++ b/e2e/full/platform/core-plugin-host-contract.spec.ts
@@ -1,0 +1,107 @@
+import path from "path";
+import { test, expect } from "@playwright/test";
+import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
+import { createFixtureRepo } from "../../helpers/fixtures";
+import { openAndOnboardProject } from "../../helpers/project";
+import { SEL } from "../../helpers/selectors";
+import { T_SHORT, T_MEDIUM, T_LONG } from "../../helpers/timeouts";
+
+const mod = process.platform === "darwin" ? "Meta" : "Control";
+const ROOT = path.resolve(import.meta.dirname, "../../..");
+const SAMPLE_PLUGINS_DIR = path.join(ROOT, "dist-electron/plugins/sample");
+
+/**
+ * Plugin host-contract harness (#9286). Sideloads the `hello-daintree` sample
+ * plugin through `DAINTREE_E2E_SIDELOAD_PLUGIN_DIR` (the env-var-stripped
+ * production binary ignores this), then exercises three host-API surfaces
+ * end-to-end:
+ *
+ *   1. `host.showToast` during `activate()` → durable inbox entry
+ *   2. `host.registerAction` → action visible in the action palette
+ *   3. dispatch from the palette → handler's `host.showToast` → second inbox entry
+ *
+ * Inbox-based assertions are chosen over live toast assertions because the
+ * inbox is durable: `notify()` writes to history regardless of toast
+ * suppression / dismiss timing, so the spec is not racing the toast queue.
+ */
+
+test.describe.serial("Core: Plugin host-contract harness", () => {
+  let ctx: AppContext;
+  let fixtureCleanup: (() => void) | undefined;
+
+  test.beforeAll(async () => {
+    ctx = await launchApp({
+      env: { DAINTREE_E2E_SIDELOAD_PLUGIN_DIR: SAMPLE_PLUGINS_DIR },
+    });
+    const { dir, cleanup } = createFixtureRepo({ name: "plugin-host-contract" });
+    fixtureCleanup = cleanup;
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, dir, "Plugin Host Contract");
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
+  });
+
+  test("activation toast lands in the notification inbox", async () => {
+    const { window } = ctx;
+    const bell = window.locator(SEL.notifications.bellButton);
+    await expect(bell).toBeVisible({ timeout: T_LONG });
+    await bell.click();
+    await expect(bell).toHaveAttribute("aria-expanded", "true", { timeout: T_SHORT });
+
+    // Plugin activation toasts are prefixed with `{pluginId}: ...` by the host
+    // (see PluginService.showToast). Look for the prefixed form so we also
+    // verify the provenance namespacing.
+    await expect(
+      window.locator("text=daintree.hello: Hello Daintree plugin activated").first()
+    ).toBeVisible({ timeout: T_LONG });
+
+    await window.keyboard.press("Escape");
+    await expect(bell).toHaveAttribute("aria-expanded", "false", { timeout: T_SHORT });
+  });
+
+  test("registerAction surfaces the action in the action palette", async () => {
+    const { window } = ctx;
+    await window.keyboard.press(`${mod}+Shift+P`);
+    const dialog = window.locator(SEL.actionPalette.dialog);
+    await expect(dialog).toBeVisible({ timeout: T_MEDIUM });
+
+    const searchInput = window.locator(SEL.actionPalette.searchInput);
+    await searchInput.fill("Hello: Greet");
+
+    const greetOption = window
+      .locator(SEL.actionPalette.options)
+      .filter({ hasText: "Hello: Greet" });
+    await expect(greetOption.first()).toBeVisible({ timeout: T_MEDIUM });
+
+    await window.keyboard.press("Escape");
+    await expect(dialog).not.toBeVisible({ timeout: T_SHORT });
+  });
+
+  test("dispatching the action through the palette fires showToast end-to-end", async () => {
+    const { window } = ctx;
+    await window.keyboard.press(`${mod}+Shift+P`);
+    const dialog = window.locator(SEL.actionPalette.dialog);
+    await expect(dialog).toBeVisible({ timeout: T_MEDIUM });
+
+    const searchInput = window.locator(SEL.actionPalette.searchInput);
+    await searchInput.fill("Hello: Greet");
+    const greetOption = window
+      .locator(SEL.actionPalette.options)
+      .filter({ hasText: "Hello: Greet" });
+    await expect(greetOption.first()).toBeVisible({ timeout: T_MEDIUM });
+    await greetOption.first().click();
+    await expect(dialog).not.toBeVisible({ timeout: T_MEDIUM });
+
+    // The handler calls host.showToast — same provenance prefix applies.
+    const bell = window.locator(SEL.notifications.bellButton);
+    await bell.click();
+    await expect(bell).toHaveAttribute("aria-expanded", "true", { timeout: T_SHORT });
+    await expect(
+      window.locator("text=daintree.hello: Hello from the greet action").first()
+    ).toBeVisible({ timeout: T_LONG });
+
+    await window.keyboard.press("Escape");
+  });
+});

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -48,6 +48,11 @@ module.exports = async function () {
       "!node_modules/node-pty/bin",
       "!node_modules/node-pty/prebuilds",
       "!node_modules/ffmpeg-static/**/*",
+      // Sample plugins are an e2e harness fixture (#9286) — sideloaded only
+      // when `DAINTREE_E2E_SIDELOAD_PLUGIN_DIR` is set, which is constant-
+      // folded to "" in production builds. Excluding the dir keeps shipped
+      // binaries from carrying dead test fixtures.
+      "!dist-electron/plugins/sample/**",
     ],
     extraResources: [
       { from: "help", to: "help" },

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -2310,4 +2310,10 @@ export class PluginService {
   }
 }
 
-export const pluginService = new PluginService();
+// E2E backdoor: the host-contract harness (#9286) points the user-plugin root
+// at the compiled sample plugin under `dist-electron/plugins/sample`. The
+// constant-folded define in `scripts/build-main.mjs` rewrites this to `""` in
+// production builds, so the OR-fallback keeps the normal `~/.daintree/plugins`
+// path in any non-test shipped binary.
+const e2eSideloadDir = process.env.DAINTREE_E2E_SIDELOAD_PLUGIN_DIR || undefined;
+export const pluginService = new PluginService(e2eSideloadDir);

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -305,6 +305,15 @@ export class PluginService {
    * on `app.isPackaged` / `process.resourcesPath`.
    */
   private builtinPluginsRoot: string | undefined;
+
+  /**
+   * E2E-only backdoor: an additional directory scanned after the regular
+   * built-in + user scans, with `isBuiltin: true` so plugins claiming the
+   * reserved `daintree.*` namespace (e.g. the `hello-daintree` sample) can
+   * load. Never set in production — the env-var read in the singleton is
+   * constant-folded to `""` via `scripts/build-main.mjs` defines.
+   */
+  private sideloadPluginsRoot: string | undefined;
   private appVersion: string;
   /**
    * Coalesces multiple registry events fired in the same tick (e.g., when a
@@ -346,11 +355,12 @@ export class PluginService {
   constructor(
     pluginsRoot?: string,
     appVersion?: string,
-    options?: { builtinPluginsRoot?: string }
+    options?: { builtinPluginsRoot?: string; sideloadPluginsRoot?: string }
   ) {
     this.pluginsRoot = pluginsRoot ?? path.join(os.homedir(), ".daintree", "plugins");
     this.appVersion = appVersion ?? app.getVersion();
     this.builtinPluginsRoot = options?.builtinPluginsRoot;
+    this.sideloadPluginsRoot = options?.sideloadPluginsRoot;
 
     const offRegister = onPanelKindRegistered(() => this.schedulePanelKindsBroadcast());
     const offUnregister = onPanelKindUnregistered(() => this.schedulePanelKindsBroadcast());
@@ -415,8 +425,16 @@ export class PluginService {
         ? await this.loadFromDir(builtinDir, { isBuiltin: true })
         : 0;
       const userLoaded = await this.loadFromDir(this.pluginsRoot, { isBuiltin: false });
+      // E2E sideload — loaded with isBuiltin:true so manifest.name values in
+      // the reserved `daintree.*` namespace pass the schema's namespace guard.
+      // Runs after the regular scans so sideloaded plugins lose to a real
+      // builtin with the same name (the duplicate guard in loadPlugin keeps
+      // the already-registered builtin).
+      const sideloadLoaded = this.sideloadPluginsRoot
+        ? await this.loadFromDir(this.sideloadPluginsRoot, { isBuiltin: true })
+        : 0;
       console.log(
-        `[PluginService] Loaded ${builtinLoaded} built-in plugin(s) from ${builtinDir ?? "<unresolved>"} and ${userLoaded} user plugin(s) from ${this.pluginsRoot}`
+        `[PluginService] Loaded ${builtinLoaded} built-in plugin(s) from ${builtinDir ?? "<unresolved>"}, ${userLoaded} user plugin(s) from ${this.pluginsRoot}, and ${sideloadLoaded} sideloaded plugin(s) from ${this.sideloadPluginsRoot ?? "<none>"}`
       );
     } finally {
       // Idempotency must hold even when a scan throws (e.g. EACCES on the
@@ -2310,10 +2328,13 @@ export class PluginService {
   }
 }
 
-// E2E backdoor: the host-contract harness (#9286) points the user-plugin root
-// at the compiled sample plugin under `dist-electron/plugins/sample`. The
-// constant-folded define in `scripts/build-main.mjs` rewrites this to `""` in
-// production builds, so the OR-fallback keeps the normal `~/.daintree/plugins`
-// path in any non-test shipped binary.
+// E2E backdoor: the host-contract harness (#9286) sideloads the compiled
+// sample plugin from `dist-electron/plugins/sample` via a dedicated scan that
+// loads with `isBuiltin: true`, which is the only way a plugin claiming the
+// reserved `daintree.*` namespace can pass the manifest schema. The
+// constant-folded define in `scripts/build-main.mjs` rewrites this read to
+// `""` in production builds, so no shipped binary ever sideloads anything.
 const e2eSideloadDir = process.env.DAINTREE_E2E_SIDELOAD_PLUGIN_DIR || undefined;
-export const pluginService = new PluginService(e2eSideloadDir);
+export const pluginService = new PluginService(undefined, undefined, {
+  sideloadPluginsRoot: e2eSideloadDir,
+});

--- a/plugins/sample/hello-daintree/__tests__/activate.test.ts
+++ b/plugins/sample/hello-daintree/__tests__/activate.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { activate } from "../main/index.js";
+import { createMockHost } from "../../../../shared/testing/createMockHost.js";
+import type { PluginIpcContext } from "../../../../shared/types/plugin.js";
+
+function makeCtx(overrides: Partial<PluginIpcContext> = {}): PluginIpcContext {
+  return {
+    projectId: null,
+    worktreeId: null,
+    webContentsId: 0,
+    pluginId: "daintree.hello",
+    ...overrides,
+  };
+}
+
+describe("hello-daintree activate (against createMockHost)", () => {
+  it("registers ping handler that echoes plugin + worktree ids", async () => {
+    const host = createMockHost({ pluginId: "daintree.hello" });
+    await activate(host);
+    const ping = host.registeredHandlers.find((h) => h.channel === "ping");
+    expect(ping).toBeDefined();
+    const result = await ping!.handler(makeCtx({ worktreeId: "wt-7" }));
+    expect(result).toEqual({ pluginId: "daintree.hello", worktreeId: "wt-7" });
+  });
+
+  it("registers the greet action and dispatches it through to a toast", async () => {
+    const host = createMockHost({ pluginId: "daintree.hello" });
+    await activate(host);
+    expect(host.registeredActions).toHaveLength(1);
+    expect(host.registeredActions[0]?.descriptor.id).toBe("greet");
+    const result = await host.dispatch("daintree.hello.greet");
+    expect(result).toEqual({ ok: true, result: { greeted: true } });
+    const greetToast = host.shownToasts.find((t) => t.message.includes("greet action"));
+    expect(greetToast).toBeDefined();
+  });
+
+  it("fires an activation toast and persists a default greeting", async () => {
+    const host = createMockHost({ pluginId: "daintree.hello" });
+    await activate(host);
+    // Activation toast was scheduled with `void` — wait for the microtask queue
+    // to flush so the recording array catches it deterministically.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(host.shownToasts.some((t) => t.message === "Hello Daintree plugin activated")).toBe(
+      true
+    );
+    expect(await host.settings.get<string>("greeting")).toBe("world");
+  });
+
+  it("registers a file-decoration provider on `hello`", async () => {
+    const host = createMockHost({ pluginId: "daintree.hello" });
+    await activate(host);
+    expect(host.registeredFileDecorationProviders).toHaveLength(1);
+    expect(host.registeredFileDecorationProviders[0]?.descriptor.id).toBe("hello");
+    const impl = host.registeredFileDecorationProviders[0]!.impl;
+    const result = await impl.provideDecorations("hello:active", ["/a", "/b"]);
+    expect(result).toEqual({
+      "/a": { badge: "H", tooltip: "Hello Daintree" },
+      "/b": { badge: "H", tooltip: "Hello Daintree" },
+    });
+  });
+
+  it("invalidates decorations when the active worktree changes", async () => {
+    const host = createMockHost({ pluginId: "daintree.hello" });
+    await activate(host);
+    host.simulateActiveWorktreeChange(null);
+    expect(host.invalidationCalls).toContainEqual({ scope: "hello:active", paths: undefined });
+  });
+
+  it("disposer unregisters subscriptions and providers", async () => {
+    const host = createMockHost({ pluginId: "daintree.hello" });
+    const dispose = await activate(host);
+    expect(host.registeredFileDecorationProviders).toHaveLength(1);
+    dispose();
+    expect(host.registeredFileDecorationProviders).toHaveLength(0);
+    // After disposal, worktree changes no longer trigger invalidation.
+    const before = host.invalidationCalls.length;
+    host.simulateActiveWorktreeChange(null);
+    expect(host.invalidationCalls.length).toBe(before);
+  });
+});

--- a/plugins/sample/hello-daintree/main/index.ts
+++ b/plugins/sample/hello-daintree/main/index.ts
@@ -2,21 +2,60 @@ import type { FileDecoration } from "../../../../shared/types/forge.js";
 import type { PluginHostApi, PluginIpcContext } from "../../../../shared/types/plugin.js";
 
 /**
- * Hello Daintree — the minimal reference plugin. It wires up exactly the host
- * APIs and contribution points that exist today, and grows by one contribution
- * point per PR as the plugin host expands (issue #9275). Every line maps to a
- * single capability so an author can read it in one sitting.
+ * Hello Daintree — the minimal reference plugin AND the host-contract test
+ * fixture (#9286). It wires up every host API surface a plugin can call so the
+ * Playwright headless host can assert each one produces the right UI side
+ * effect, and so a single read of this file maps 1:1 to the SDK contract.
  *
- * Declared in plugin.json: one toolbar button and one menu item, both pointing
- * at the `daintree.hello.ping` action, plus one file-decoration provider scoped
- * to `hello:*`.
+ * Declared in plugin.json: one toolbar button + one menu item pointing at the
+ * `daintree.hello.ping` action, plus a `hello:*` file-decoration provider.
  */
-export function activate(host: PluginHostApi): () => void {
-  // An IPC handler the renderer reaches over `plugin:daintree.hello:ping`.
+export async function activate(host: PluginHostApi): Promise<() => void> {
+  // IPC handler the renderer reaches over `plugin:daintree.hello:ping`.
   host.registerHandler("ping", (ctx: PluginIpcContext) => ({
     pluginId: host.pluginId,
     worktreeId: ctx.worktreeId,
   }));
+
+  // Imperatively-registered action. The host namespaces this to
+  // `daintree.hello.greet`; dispatching it surfaces a toast so the E2E spec
+  // can assert the full register → dispatch → showToast loop.
+  host.registerAction(
+    {
+      id: "greet",
+      title: "Hello: Greet",
+      description: "Say hello from the Hello Daintree sample plugin.",
+      category: "Hello Daintree",
+      kind: "command",
+      danger: "safe",
+    },
+    async () => {
+      await host.showToast({
+        message: "Hello from the greet action",
+        type: "success",
+        durationMs: 30_000,
+      });
+      return { greeted: true };
+    }
+  );
+
+  // Settings round-trip — read the persisted greeting, default to "world",
+  // write it back so onDidChange fires for any subscriber, and expose the
+  // live value through an IPC handler so the E2E spec can read it back.
+  let greeting = (await safeGet(host, "greeting")) ?? "world";
+  void host.settings.set("greeting", greeting).catch(() => {});
+  const disposeGreetingSub = host.settings.onDidChange<string>("greeting", (next) => {
+    greeting = next ?? "world";
+  });
+  host.registerHandler("getGreeting", () => greeting);
+
+  // Activation-time toast — observable in the notification inbox so the E2E
+  // spec gets a durable signal without racing the toast dismiss timer.
+  void host.showToast({
+    message: "Hello Daintree plugin activated",
+    type: "info",
+    durationMs: 30_000,
+  });
 
   // Badge every requested path with an "H" — the simplest honest decoration.
   const disposeDecorations = host.registerFileDecorationProvider(
@@ -40,5 +79,14 @@ export function activate(host: PluginHostApi): () => void {
   return () => {
     disposeDecorations();
     disposeWorktree();
+    disposeGreetingSub();
   };
+}
+
+async function safeGet(host: PluginHostApi, key: string): Promise<string | undefined> {
+  try {
+    return await host.settings.get<string>(key);
+  } catch {
+    return undefined;
+  }
 }

--- a/scripts/build-main.mjs
+++ b/scripts/build-main.mjs
@@ -45,6 +45,11 @@ const common = {
           "process.env.DAINTREE_E2E_FAULT_MODE": JSON.stringify(""),
           "process.env.DAINTREE_E2E_MODE": JSON.stringify(""),
           "process.env.DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS": JSON.stringify(""),
+          // The plugin host-contract harness (#9286) reads this to point
+          // PluginService at the compiled sample plugin during e2e. A
+          // non-empty value in prod would silently redirect the user-plugin
+          // root, so it MUST be stripped alongside the other E2E flags.
+          "process.env.DAINTREE_E2E_SIDELOAD_PLUGIN_DIR": JSON.stringify(""),
         }
       : {}),
   },
@@ -110,6 +115,27 @@ function copyBuiltInPluginManifests() {
   }
 }
 
+/**
+ * Mirror `plugin.json` manifests for `plugins/sample/*` alongside their
+ * compiled main entries. Sample plugins are not loaded at runtime by default —
+ * the host-contract e2e harness (#9286) sideloads them via
+ * `DAINTREE_E2E_SIDELOAD_PLUGIN_DIR` pointing at `dist-electron/plugins/sample`.
+ */
+function copySamplePluginManifests() {
+  const pluginsRoot = path.join(root, "plugins/sample");
+  if (!fs.existsSync(pluginsRoot)) return;
+  const entries = fs.readdirSync(pluginsRoot, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const manifestSrc = path.join(pluginsRoot, entry.name, "plugin.json");
+    if (!fs.existsSync(manifestSrc)) continue;
+    const manifestDest = path.join(root, "dist-electron/plugins/sample", entry.name, "plugin.json");
+    fs.mkdirSync(path.dirname(manifestDest), { recursive: true });
+    fs.copyFileSync(manifestSrc, manifestDest);
+    console.log(`[Build] Copied sample plugin manifest: ${entry.name}`);
+  }
+}
+
 function createReadyMarkerPlugin() {
   return {
     name: "build-ready-marker",
@@ -156,6 +182,10 @@ async function run() {
       "electron/watchdog-host.ts",
       "electron/watchdog-host-bootstrap.ts",
       "plugins/builtin/github/main/index.ts",
+      // Sample plugin compiled for the host-contract e2e harness (#9286).
+      // Sideloaded via `DAINTREE_E2E_SIDELOAD_PLUGIN_DIR`; absent in prod
+      // because no `pluginsRoot` defaults to this directory.
+      "plugins/sample/hello-daintree/main/index.ts",
     ],
     outdir: "dist-electron",
     outbase: ".",
@@ -186,11 +216,13 @@ async function run() {
       await Promise.all([ctxEsm.watch(), ctxCjs.watch()]);
       copyBuiltInWorkflows();
       copyBuiltInPluginManifests();
+      copySamplePluginManifests();
       console.log("[Build] Watching for changes...");
     } else {
       await Promise.all([build(esmConfig), build(cjsConfig)]);
       copyBuiltInWorkflows();
       copyBuiltInPluginManifests();
+      copySamplePluginManifests();
       writeBuildReadyMarker();
       console.log("[Build] Complete.");
     }

--- a/shared/testing/__tests__/createMockHost.test.ts
+++ b/shared/testing/__tests__/createMockHost.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMockHost } from "../createMockHost.js";
+import type { PluginActionContribution, PluginWorktreeSnapshot } from "../../types/plugin.js";
+
+const sampleSnapshot: PluginWorktreeSnapshot = {
+  id: "wt-1",
+  worktreeId: "wt-1",
+  path: "/tmp/repo",
+  name: "main",
+  isCurrent: true,
+  linked: null,
+};
+
+const sampleAction: PluginActionContribution = {
+  id: "greet",
+  title: "Greet",
+  description: "Say hello",
+  category: "Hello",
+  kind: "command",
+  danger: "safe",
+};
+
+describe("createMockHost", () => {
+  it("exposes the plugin id passed in options", () => {
+    const host = createMockHost({ pluginId: "daintree.hello" });
+    expect(host.pluginId).toBe("daintree.hello");
+  });
+
+  it("defaults pluginId when none is provided", () => {
+    const host = createMockHost();
+    expect(host.pluginId).toBe("test.mock");
+  });
+
+  it("records registerAction calls", () => {
+    const host = createMockHost();
+    const handler = vi.fn();
+    host.registerAction(sampleAction, handler);
+    expect(host.registeredActions).toHaveLength(1);
+    expect(host.registeredActions[0]?.descriptor).toEqual(sampleAction);
+    expect(host.registeredActions[0]?.handler).toBe(handler);
+  });
+
+  it("records registerHandler calls", () => {
+    const host = createMockHost();
+    const handler = vi.fn();
+    host.registerHandler("ping", handler);
+    expect(host.registeredHandlers).toHaveLength(1);
+    expect(host.registeredHandlers[0]).toEqual({ channel: "ping", handler });
+  });
+
+  it("records broadcastToRenderer calls", () => {
+    const host = createMockHost();
+    host.broadcastToRenderer("evt", { foo: 1 });
+    expect(host.broadcastCalls).toEqual([{ channel: "evt", payload: { foo: 1 } }]);
+  });
+
+  it("records showToast calls and rejects empty messages", async () => {
+    const host = createMockHost();
+    await host.showToast({ message: "hi", type: "info", durationMs: 100 });
+    expect(host.shownToasts).toEqual([{ message: "hi", type: "info", durationMs: 100 }]);
+    await expect(host.showToast({ message: "" })).rejects.toThrow(/non-empty/);
+  });
+
+  it("records invalidateFileDecorations calls", () => {
+    const host = createMockHost();
+    host.invalidateFileDecorations("hello:*");
+    host.invalidateFileDecorations("hello:active", ["/a", "/b"]);
+    expect(host.invalidationCalls).toEqual([
+      { scope: "hello:*", paths: undefined },
+      { scope: "hello:active", paths: ["/a", "/b"] },
+    ]);
+  });
+
+  it("returns initial worktree snapshots", async () => {
+    const host = createMockHost({
+      activeWorktree: sampleSnapshot,
+      worktrees: [sampleSnapshot],
+    });
+    expect(await host.getActiveWorktree()).toEqual(sampleSnapshot);
+    expect(await host.getWorktrees()).toEqual([sampleSnapshot]);
+  });
+
+  it("delivers active-worktree updates and supports idempotent disposal", () => {
+    const host = createMockHost();
+    const cb = vi.fn();
+    const dispose = host.onDidChangeActiveWorktree(cb);
+    host.simulateActiveWorktreeChange(sampleSnapshot);
+    host.simulateActiveWorktreeChange(null);
+    expect(cb).toHaveBeenCalledTimes(2);
+    dispose();
+    dispose(); // no-op
+    host.simulateActiveWorktreeChange(sampleSnapshot);
+    expect(cb).toHaveBeenCalledTimes(2);
+  });
+
+  it("delivers worktree-set updates", () => {
+    const host = createMockHost();
+    const cb = vi.fn();
+    host.onDidChangeWorktrees(cb);
+    host.simulateWorktreesChange([sampleSnapshot]);
+    expect(cb).toHaveBeenCalledWith([sampleSnapshot]);
+  });
+
+  it("registers forge providers and unregisters via disposer", () => {
+    const host = createMockHost();
+    const impl = { parseRemote: vi.fn() } as unknown as Parameters<
+      typeof host.registerForgeProvider
+    >[1];
+    const dispose = host.registerForgeProvider({ id: "ghe" }, impl);
+    expect(host.registeredForgeProviders).toHaveLength(1);
+    dispose();
+    expect(host.registeredForgeProviders).toHaveLength(0);
+  });
+
+  it("registers file-decoration providers and unregisters via disposer", () => {
+    const host = createMockHost();
+    const impl = { provideDecorations: vi.fn(async () => ({})) };
+    const dispose = host.registerFileDecorationProvider({ id: "hello" }, impl);
+    expect(host.registeredFileDecorationProviders).toHaveLength(1);
+    dispose();
+    expect(host.registeredFileDecorationProviders).toHaveLength(0);
+  });
+
+  describe("settings", () => {
+    it("round-trips values within the default user scope", async () => {
+      const host = createMockHost();
+      await host.settings.set("greeting", "world");
+      expect(await host.settings.get<string>("greeting")).toBe("world");
+    });
+
+    it("isolates user and project scopes", async () => {
+      const host = createMockHost({
+        settings: { user: { mode: "alpha" }, project: { mode: "beta" } },
+      });
+      expect(await host.settings.get("mode", "user")).toBe("alpha");
+      expect(await host.settings.get("mode", "project")).toBe("beta");
+    });
+
+    it("rejects undefined writes", async () => {
+      const host = createMockHost();
+      await expect(host.settings.set("k", undefined)).rejects.toThrow(/undefined/);
+    });
+
+    it("fires onDidChange only on value changes and respects disposal", async () => {
+      const host = createMockHost();
+      const cb = vi.fn();
+      const dispose = host.settings.onDidChange<string>("k", cb);
+      await host.settings.set("k", "v1");
+      await host.settings.set("k", "v1"); // unchanged → no fire
+      await host.settings.set("k", "v2");
+      expect(cb).toHaveBeenCalledTimes(2);
+      expect(cb).toHaveBeenNthCalledWith(1, "v1");
+      expect(cb).toHaveBeenNthCalledWith(2, "v2");
+      dispose();
+      await host.settings.set("k", "v3");
+      expect(cb).toHaveBeenCalledTimes(2);
+    });
+
+    it("scopes onDidChange subscriptions independently per scope", async () => {
+      const host = createMockHost();
+      const user = vi.fn();
+      const project = vi.fn();
+      host.settings.onDidChange("k", user, "user");
+      host.settings.onDidChange("k", project, "project");
+      await host.settings.set("k", "uv", "user");
+      await host.settings.set("k", "pv", "project");
+      expect(user).toHaveBeenCalledWith("uv");
+      expect(user).not.toHaveBeenCalledWith("pv");
+      expect(project).toHaveBeenCalledWith("pv");
+    });
+  });
+
+  describe("dispatch", () => {
+    it("routes through registered action handler and records the call", async () => {
+      const host = createMockHost({ pluginId: "daintree.hello" });
+      host.registerAction(sampleAction, async (args) => ({ echoed: args }));
+      const result = await host.dispatch("daintree.hello.greet", { name: "ada" });
+      expect(host.dispatchedActions).toEqual([
+        { actionId: "daintree.hello.greet", args: { name: "ada" } },
+      ]);
+      expect(result).toEqual({ ok: true, result: { echoed: { name: "ada" } } });
+    });
+
+    it("returns NOT_FOUND for unregistered actions", async () => {
+      const host = createMockHost();
+      const result = await host.dispatch("unknown");
+      expect(result).toEqual({
+        ok: false,
+        error: { code: "NOT_FOUND", message: "Action not found: unknown" },
+      });
+    });
+
+    it("returns EXECUTION_ERROR when the handler throws", async () => {
+      const host = createMockHost();
+      host.registerAction(sampleAction, async () => {
+        throw new Error("boom");
+      });
+      const result = await host.dispatch("greet");
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("EXECUTION_ERROR");
+        expect(result.error.message).toBe("boom");
+      }
+    });
+
+    it("honors setDispatchResult overrides", async () => {
+      const host = createMockHost();
+      host.setDispatchResult("daintree.hello.greet", {
+        ok: false,
+        error: { code: "RESTRICTED", message: "nope" },
+      });
+      const result = await host.dispatch("daintree.hello.greet");
+      expect(result).toEqual({
+        ok: false,
+        error: { code: "RESTRICTED", message: "nope" },
+      });
+    });
+
+    it("uses a custom dispatch resolver when provided", async () => {
+      const dispatch = vi.fn(async () => ({ ok: true as const, result: 42 }));
+      const host = createMockHost({ dispatch });
+      const result = await host.dispatch("anything", { x: 1 });
+      expect(dispatch).toHaveBeenCalledWith("anything", { x: 1 });
+      expect(result).toEqual({ ok: true, result: 42 });
+    });
+  });
+});

--- a/shared/testing/__tests__/createMockHost.test.ts
+++ b/shared/testing/__tests__/createMockHost.test.ts
@@ -40,6 +40,19 @@ describe("createMockHost", () => {
     expect(host.registeredActions[0]?.handler).toBe(handler);
   });
 
+  it("registerAction replaces a prior registration with the same id", async () => {
+    const host = createMockHost({ pluginId: "daintree.hello" });
+    const h1 = vi.fn(async () => "v1");
+    const h2 = vi.fn(async () => "v2");
+    host.registerAction(sampleAction, h1);
+    host.registerAction(sampleAction, h2);
+    expect(host.registeredActions).toHaveLength(1);
+    expect(host.registeredActions[0]?.handler).toBe(h2);
+    const result = await host.dispatch("daintree.hello.greet");
+    expect(result).toEqual({ ok: true, result: "v2" });
+    expect(h1).not.toHaveBeenCalled();
+  });
+
   it("records registerHandler calls", () => {
     const host = createMockHost();
     const handler = vi.fn();
@@ -190,12 +203,21 @@ describe("createMockHost", () => {
       });
     });
 
+    it("requires the plugin-id prefix when the host has one bound", async () => {
+      const host = createMockHost({ pluginId: "daintree.hello" });
+      host.registerAction(sampleAction, async () => "ok");
+      // Real host receives the fully-namespaced id; an unprefixed local id is
+      // not a valid built-in action and must not silently resolve.
+      const result = await host.dispatch("greet");
+      expect(result.ok).toBe(false);
+    });
+
     it("returns EXECUTION_ERROR when the handler throws", async () => {
       const host = createMockHost();
       host.registerAction(sampleAction, async () => {
         throw new Error("boom");
       });
-      const result = await host.dispatch("greet");
+      const result = await host.dispatch("test.mock.greet");
       expect(result.ok).toBe(false);
       if (!result.ok) {
         expect(result.error.code).toBe("EXECUTION_ERROR");

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -191,7 +191,16 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
   const host: PluginHostApi & MockHostState = {
     pluginId,
     registerAction(descriptor, handler) {
-      registeredActions.push({ descriptor, handler });
+      // Mirror PluginService.registerAction: re-registering the same id
+      // replaces the prior descriptor + handler. Without this, the recording
+      // array would diverge from production semantics and any plugin test
+      // that re-registers an action would silently dispatch the stale handler.
+      const existing = registeredActions.findIndex((r) => r.descriptor.id === descriptor.id);
+      if (existing >= 0) {
+        registeredActions[existing] = { descriptor, handler };
+      } else {
+        registeredActions.push({ descriptor, handler });
+      }
     },
     registerHandler(channel, handler) {
       registeredHandlers.push({ channel, handler });
@@ -263,10 +272,13 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
       const override = dispatchOverrides.get(actionId);
       if (override) return override;
       if (options.dispatch) return options.dispatch(actionId, args);
-      const localId = actionId.startsWith(`${pluginId}.`)
-        ? actionId.slice(pluginId.length + 1)
-        : actionId;
-      const reg = registeredActions.find((r) => r.descriptor.id === localId);
+      // Match the real host's contract: dispatch ids are always fully
+      // namespaced as `{pluginId}.{descriptor.id}`. Looking up by the full
+      // form means a plugin calling `host.dispatch("greet")` against a
+      // registered action also id'd `"greet"` returns NOT_FOUND in the mock
+      // exactly as it would in production where ActionService never sees an
+      // unprefixed id.
+      const reg = registeredActions.find((r) => actionId === `${pluginId}.${r.descriptor.id}`);
       if (!reg) {
         return {
           ok: false,

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -1,0 +1,314 @@
+/**
+ * In-memory `PluginHostApi` implementation for unit tests. Records every host
+ * call into a recording array so a plugin's `activate()` can be exercised
+ * without booting Electron, the renderer, or the real contribution registries.
+ *
+ * Why the intersection return type — `PluginHostApi & MockHostState` makes the
+ * recording arrays and `simulate*` helpers visible to callers while still
+ * giving TypeScript a compile error the moment `PluginHostApi` gains a new
+ * method this mock doesn't implement.
+ */
+
+import type { ActionDispatchResult } from "../types/actions.js";
+import type {
+  FileDecorationProviderDescriptor,
+  FileDecorationProviderImpl,
+  ForgeProviderDescriptor,
+  ForgeProviderImpl,
+} from "../types/forge.js";
+import type { NotificationType } from "../types/notification.js";
+import type {
+  ActionHandler,
+  PluginActionContribution,
+  PluginHostApi,
+  PluginIpcHandler,
+  PluginSettingsScope,
+  PluginToastOptions,
+  PluginWorktreeSnapshot,
+  SettingsApi,
+} from "../types/plugin.js";
+
+export interface RegisteredActionRecord {
+  descriptor: PluginActionContribution;
+  handler: ActionHandler;
+}
+
+export interface RegisteredHandlerRecord {
+  channel: string;
+  handler: PluginIpcHandler;
+}
+
+export interface BroadcastRecord {
+  channel: string;
+  payload: unknown;
+}
+
+export interface ShownToastRecord {
+  message: string;
+  type: NotificationType | undefined;
+  durationMs: number | undefined;
+}
+
+export interface DispatchedActionRecord {
+  actionId: string;
+  args: unknown;
+}
+
+export interface RegisteredForgeProviderRecord {
+  descriptor: ForgeProviderDescriptor;
+  impl: ForgeProviderImpl;
+}
+
+export interface RegisteredFileDecorationProviderRecord {
+  descriptor: FileDecorationProviderDescriptor;
+  impl: FileDecorationProviderImpl;
+}
+
+export interface InvalidationRecord {
+  scope: string;
+  paths: string[] | undefined;
+}
+
+export interface MockHostState {
+  readonly registeredActions: ReadonlyArray<RegisteredActionRecord>;
+  readonly registeredHandlers: ReadonlyArray<RegisteredHandlerRecord>;
+  readonly broadcastCalls: ReadonlyArray<BroadcastRecord>;
+  readonly shownToasts: ReadonlyArray<ShownToastRecord>;
+  readonly dispatchedActions: ReadonlyArray<DispatchedActionRecord>;
+  readonly registeredForgeProviders: ReadonlyArray<RegisteredForgeProviderRecord>;
+  readonly registeredFileDecorationProviders: ReadonlyArray<RegisteredFileDecorationProviderRecord>;
+  readonly invalidationCalls: ReadonlyArray<InvalidationRecord>;
+
+  /**
+   * Replace the active worktree and notify every `onDidChangeActiveWorktree`
+   * subscriber. Helpers are top-level on the {@link MockHostState} side of the
+   * intersection so they cannot drift into the production `PluginHostApi`.
+   */
+  simulateActiveWorktreeChange(snapshot: PluginWorktreeSnapshot | null): void;
+  simulateWorktreesChange(snapshots: PluginWorktreeSnapshot[]): void;
+
+  /**
+   * Pre-seed a deterministic `dispatch()` result for one action id. Overrides
+   * the default in-memory routing (which resolves the registered handler).
+   */
+  setDispatchResult(actionId: string, result: ActionDispatchResult): void;
+}
+
+export interface CreateMockHostOptions {
+  pluginId?: string;
+  activeWorktree?: PluginWorktreeSnapshot | null;
+  worktrees?: PluginWorktreeSnapshot[];
+  settings?: {
+    user?: Record<string, unknown>;
+    project?: Record<string, unknown>;
+  };
+  /**
+   * Custom resolver for `host.dispatch`. The default routes the call to a
+   * matching `registerAction` handler, returning `NOT_FOUND` otherwise — which
+   * mirrors `ActionService.dispatch` closely enough for activation-time tests.
+   */
+  dispatch?: (actionId: string, args?: unknown) => Promise<ActionDispatchResult>;
+}
+
+export function createMockHost(options: CreateMockHostOptions = {}): PluginHostApi & MockHostState {
+  const pluginId = options.pluginId ?? "test.mock";
+  let activeWorktree: PluginWorktreeSnapshot | null = options.activeWorktree ?? null;
+  let worktrees: PluginWorktreeSnapshot[] = options.worktrees ?? [];
+
+  const registeredActions: RegisteredActionRecord[] = [];
+  const registeredHandlers: RegisteredHandlerRecord[] = [];
+  const broadcastCalls: BroadcastRecord[] = [];
+  const shownToasts: ShownToastRecord[] = [];
+  const dispatchedActions: DispatchedActionRecord[] = [];
+  const registeredForgeProviders: RegisteredForgeProviderRecord[] = [];
+  const registeredFileDecorationProviders: RegisteredFileDecorationProviderRecord[] = [];
+  const invalidationCalls: InvalidationRecord[] = [];
+
+  const activeWorktreeSubs = new Set<(snapshot: PluginWorktreeSnapshot | null) => void>();
+  const worktreesSubs = new Set<(snapshots: PluginWorktreeSnapshot[]) => void>();
+
+  const settingsStore: Record<PluginSettingsScope, Map<string, unknown>> = {
+    user: new Map(Object.entries(options.settings?.user ?? {})),
+    project: new Map(Object.entries(options.settings?.project ?? {})),
+  };
+
+  const settingsSubs: Record<PluginSettingsScope, Map<string, Set<(value: unknown) => void>>> = {
+    user: new Map(),
+    project: new Map(),
+  };
+
+  const dispatchOverrides = new Map<string, ActionDispatchResult>();
+
+  const settings: SettingsApi = {
+    async get<T = unknown>(
+      key: string,
+      scope: PluginSettingsScope = "user"
+    ): Promise<T | undefined> {
+      return settingsStore[scope].get(key) as T | undefined;
+    },
+    async set<T = unknown>(
+      key: string,
+      value: T,
+      scope: PluginSettingsScope = "user"
+    ): Promise<void> {
+      if (value === undefined) {
+        throw new Error("settings.set: value cannot be undefined");
+      }
+      const prev = settingsStore[scope].get(key);
+      settingsStore[scope].set(key, value);
+      if (!Object.is(prev, value)) {
+        const subs = settingsSubs[scope].get(key);
+        if (subs) {
+          for (const cb of subs) cb(value as unknown);
+        }
+      }
+    },
+    onDidChange<T = unknown>(
+      key: string,
+      callback: (value: T | undefined) => void,
+      scope: PluginSettingsScope = "user"
+    ): () => void {
+      let subs = settingsSubs[scope].get(key);
+      if (!subs) {
+        subs = new Set();
+        settingsSubs[scope].set(key, subs);
+      }
+      const cb = callback as (value: unknown) => void;
+      subs.add(cb);
+      let disposed = false;
+      return () => {
+        if (disposed) return;
+        disposed = true;
+        const set = settingsSubs[scope].get(key);
+        if (set) {
+          set.delete(cb);
+          if (set.size === 0) settingsSubs[scope].delete(key);
+        }
+      };
+    },
+  };
+
+  const host: PluginHostApi & MockHostState = {
+    pluginId,
+    registerAction(descriptor, handler) {
+      registeredActions.push({ descriptor, handler });
+    },
+    registerHandler(channel, handler) {
+      registeredHandlers.push({ channel, handler });
+    },
+    broadcastToRenderer(channel, payload) {
+      broadcastCalls.push({ channel, payload });
+    },
+    async getActiveWorktree() {
+      return activeWorktree;
+    },
+    async getWorktrees() {
+      return worktrees;
+    },
+    onDidChangeActiveWorktree(callback) {
+      activeWorktreeSubs.add(callback);
+      let disposed = false;
+      return () => {
+        if (disposed) return;
+        disposed = true;
+        activeWorktreeSubs.delete(callback);
+      };
+    },
+    onDidChangeWorktrees(callback) {
+      worktreesSubs.add(callback);
+      let disposed = false;
+      return () => {
+        if (disposed) return;
+        disposed = true;
+        worktreesSubs.delete(callback);
+      };
+    },
+    registerForgeProvider(descriptor, impl) {
+      const record: RegisteredForgeProviderRecord = { descriptor, impl };
+      registeredForgeProviders.push(record);
+      let disposed = false;
+      return () => {
+        if (disposed) return;
+        disposed = true;
+        const i = registeredForgeProviders.indexOf(record);
+        if (i >= 0) registeredForgeProviders.splice(i, 1);
+      };
+    },
+    registerFileDecorationProvider(descriptor, impl) {
+      const record: RegisteredFileDecorationProviderRecord = { descriptor, impl };
+      registeredFileDecorationProviders.push(record);
+      let disposed = false;
+      return () => {
+        if (disposed) return;
+        disposed = true;
+        const i = registeredFileDecorationProviders.indexOf(record);
+        if (i >= 0) registeredFileDecorationProviders.splice(i, 1);
+      };
+    },
+    invalidateFileDecorations(scope, paths) {
+      invalidationCalls.push({ scope, paths });
+    },
+    async showToast(opts: PluginToastOptions) {
+      if (!opts.message) {
+        throw new Error("showToast: message must be a non-empty string");
+      }
+      shownToasts.push({
+        message: opts.message,
+        type: opts.type,
+        durationMs: opts.durationMs,
+      });
+    },
+    async dispatch(actionId, args) {
+      dispatchedActions.push({ actionId, args });
+      const override = dispatchOverrides.get(actionId);
+      if (override) return override;
+      if (options.dispatch) return options.dispatch(actionId, args);
+      const localId = actionId.startsWith(`${pluginId}.`)
+        ? actionId.slice(pluginId.length + 1)
+        : actionId;
+      const reg = registeredActions.find((r) => r.descriptor.id === localId);
+      if (!reg) {
+        return {
+          ok: false,
+          error: { code: "NOT_FOUND", message: `Action not found: ${actionId}` },
+        };
+      }
+      try {
+        const result = await reg.handler(args);
+        return { ok: true, result };
+      } catch (err) {
+        return {
+          ok: false,
+          error: {
+            code: "EXECUTION_ERROR",
+            message: err instanceof Error ? err.message : String(err),
+          },
+        };
+      }
+    },
+    settings,
+
+    registeredActions,
+    registeredHandlers,
+    broadcastCalls,
+    shownToasts,
+    dispatchedActions,
+    registeredForgeProviders,
+    registeredFileDecorationProviders,
+    invalidationCalls,
+
+    simulateActiveWorktreeChange(snapshot) {
+      activeWorktree = snapshot;
+      for (const cb of activeWorktreeSubs) cb(snapshot);
+    },
+    simulateWorktreesChange(snapshots) {
+      worktrees = snapshots;
+      for (const cb of worktreesSubs) cb(snapshots);
+    },
+    setDispatchResult(actionId, result) {
+      dispatchOverrides.set(actionId, result);
+    },
+  };
+
+  return host;
+}


### PR DESCRIPTION
## Summary

- Adds `createMockHost` in `shared/testing/` — a full `PluginHostApi` implementation backed by in-memory state, typed against the interface so any missing method is a compile error, not a runtime gap
- Adds a Playwright spec in `e2e/full/platform/core-plugin-host-contract.spec.ts` that boots the real app with the sample plugin and asserts observable host effects (palette entries, toast DOM, settings round-trip, panel view render)
- Sideloads the `hello-daintree` sample plugin as a builtin in `PluginService` so it's always present for the e2e test without a user-facing install step

The two layers catch different drift: the mock catches handler-shape regressions cheaply with no Electron boot; Playwright catches the case where the mock was updated but the real implementation wasn't.

Resolves #9286

## Changes

- `shared/testing/createMockHost.ts` — mock fixture implementing full `PluginHostApi`; records `registerAction` calls into `dispatchedActions`, `showToast` into `shownToasts`, `settings.get/set` against a plain object, worktree subscriptions replayed from a fixture array
- `shared/testing/__tests__/createMockHost.test.ts` — unit tests covering every mock surface
- `e2e/full/platform/core-plugin-host-contract.spec.ts` — Playwright spec asserting each host API produces the right UI side effect
- `electron/services/PluginService.ts` — sideloads `hello-daintree` as a builtin
- `plugins/sample/hello-daintree/main/index.ts` — extends sample plugin to exercise all asserted host surfaces
- `electron-builder.config.cjs` — includes the sample plugin in the packaged app
- `scripts/build-main.mjs` — builds the sample plugin as part of the main process build

## Testing

- `shared/testing/__tests__/createMockHost.test.ts` — full mock surface coverage, runs in vitest
- `e2e/full/platform/core-plugin-host-contract.spec.ts` — Playwright contract spec in the `full-platform` bucket, runs on every PR