### PR TITLE
feat(plugins): wire manifest commands to lazy src/<name>.ts handlers; canonicalize toolbar namespace

### DIFF
--- a/docs/plugins/contribution-points.md
+++ b/docs/plugins/contribution-points.md
@@ -10,23 +10,48 @@ Each section below documents a contribution point, its schema, an example, and c
 - **Planned** — design locked, implementation in progress
 - **Future** — not yet committed
 
-## Commands — _Runtime only_
+## Commands — _Shipped_
 
-Commands are callable actions that appear in the command palette and can be bound to keybindings, toolbar buttons, or menu items. They are registered at runtime via `host.registerAction()` during `activate()`, not declared in `plugin.json`. See [Host API → registerAction](./host-api.md#registeraction) for the full signature.
+Commands are callable actions that appear in the command palette and can be bound to keybindings, toolbar buttons, or menu items. Declare them in `plugin.json` so the command shows up in the palette before your plugin activates, or register them at runtime via `host.registerAction()` for dynamic cases. See [Host API → registerAction](./host-api.md#registeraction) for the full signature.
 
-**Handler binding** — two ways:
+```json
+{
+  "contributes": {
+    "commands": [
+      {
+        "id": "plan-from-issue",
+        "title": "Plan From Issue",
+        "description": "Turn a Linear issue into a branch and agent session.",
+        "category": "Linear Planner",
+        "kind": "command",
+        "danger": "confirm"
+      }
+    ]
+  }
+}
+```
 
-_Filesystem convention (simple case):_ a command named `plan-from-issue` looks for `src/plan-from-issue.ts` (or `.tsx`). Its default export is the handler.
+**Fields:**
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `id` | yes | Bare command id. Daintree namespaces it as `{pluginId}.{id}` at runtime — matching every other contribution surface. |
+| `title` | yes | Palette entry label. |
+| `description` | yes | One-line summary surfaced in the palette description. |
+| `category` | yes | Grouping label in the palette. Free-form; mirror your plugin's display name. |
+| `kind` | yes | `"command"` or `"query"`. |
+| `danger` | yes | `"safe"` or `"confirm"`. `"restricted"` is rejected — plugins cannot self-register restricted actions. The host raises `"safe"` to `"confirm"` automatically when the plugin holds a high-risk capability. |
+| `keywords` | no | Extra search terms for the palette. |
+| `inputSchema` | no | JSON schema validated against the dispatched `args` payload. |
+
+**Handler binding — two ways:**
+
+_Filesystem convention (manifest-declared, lazy import):_ a command with id `plan-from-issue` looks for `src/plan-from-issue.{ts,tsx,js,mjs}` (probed in that order) under your plugin directory. Its default export is the handler. The module is **not** imported until the command is first dispatched — twenty manifest commands cost zero activation time.
 
 ```ts
 // src/plan-from-issue.ts
-import type { CommandContext } from "@daintreehq/plugin-sdk";
-
-export default async function planFromIssue(ctx: CommandContext) {
-  // ctx.args — validated args if the command declares argsSchema
-  // ctx.dispatch — call other actions
-  // ctx.host — full host API
-  await ctx.showToast({ title: "Planning…" });
+export default async function planFromIssue(args: { issue: number }) {
+  // handler body
 }
 ```
 
@@ -53,7 +78,9 @@ export async function activate(host: PluginHostApi) {
 }
 ```
 
-If a command is registered imperatively but no handler is bound, running it produces a user-visible toast: `Command "{pluginId}.{name}" has no handler`.
+If a manifest-declared command has no matching `src/{id}.{ext}` file and no imperative `registerAction` override, running it produces a user-visible toast: `Command "{pluginId}.{id}" has no handler`. The manifest entry alone is enough to make the command appear in the palette so authors can wire it up incrementally.
+
+**Collision rule:** a command whose resolved `{pluginId}.{id}` matches a built-in Daintree action id is rejected at load with a provenance `loadError` — the command does not register. Pick a different id.
 
 ## Panels — _Shipped_
 
@@ -165,7 +192,7 @@ Toolbar buttons dispatch an existing action from the main toolbar.
 
 | Field | Required | Notes |
 | --- | --- | --- |
-| `id` | yes | Namespaced at runtime as `plugin.{pluginId}.{id}`. |
+| `id` | yes | Namespaced at runtime as `{pluginId}.{id}` — matches the convention used by every other contribution surface. |
 | `label` | yes | Hover tooltip. |
 | `iconId` | yes | Registered icon ID. |
 | `actionId` | yes | Fully-qualified action ID, including plugin namespace. Built-in actions (e.g. `terminal.new`) also work. |

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -62,6 +62,28 @@ export const ContextMenuContributionSchema = z.object({
 });
 
 /**
+ * `contributes.commands` manifest entry. The bare command `id` is namespaced
+ * by `PluginService` at load time as `{pluginId}.{id}` so the descriptor key
+ * matches the {@link PluginActionDescriptor.id} format used by the imperative
+ * `host.registerAction` path. `danger: "restricted"` is rejected — plugins
+ * may only contribute `"safe"` or `"confirm"` commands. Strict so an
+ * unrecognised field surfaces as a manifest error instead of silently dropping
+ * (e.g. a typo on `keywords` would otherwise vanish on a permissive schema).
+ */
+export const CommandContributionSchema = z
+  .object({
+    id: z.string().min(1).max(64).regex(SAFE_ID_PATTERN),
+    title: z.string().min(1),
+    description: z.string(),
+    category: z.string().min(1),
+    kind: z.enum(["command", "query"]),
+    danger: z.enum(["safe", "confirm"]),
+    keywords: z.array(z.string().min(1)).optional(),
+    inputSchema: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict();
+
+/**
  * Reserved contribution point. Shape is validated but the runtime does not
  * yet act on these entries — `PluginService` logs a warning and skips them.
  * The `experimental_` prefix signals that the shape may change before the
@@ -176,6 +198,7 @@ export function getPluginManifestSchema(isBuiltin: boolean) {
           menuItems: z.array(MenuItemContributionSchema).default([]),
           keybindings: z.array(KeybindingContributionSchema).default([]),
           contextMenus: z.array(ContextMenuContributionSchema).default([]),
+          commands: z.array(CommandContributionSchema).default([]),
           experimental_views: z.array(ViewContributionSchema).default([]),
           experimental_mcpServers: z.array(McpServerContributionSchema).default([]),
           forgeProviders: z.array(ForgeProviderContributionSchema).default([]),
@@ -187,6 +210,7 @@ export function getPluginManifestSchema(isBuiltin: boolean) {
           menuItems: [],
           keybindings: [],
           contextMenus: [],
+          commands: [],
           experimental_views: [],
           experimental_mcpServers: [],
           forgeProviders: [],

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -288,6 +288,15 @@ export class PluginService {
    * Cleared per-plugin in {@link unregisterPluginActions}.
    */
   private manifestCommandIds = new Set<string>();
+  /**
+   * Plugin ids whose provenance record carries a load-time `loadError` that
+   * is independent of the plugin's `main` activation outcome — e.g. a
+   * manifest command id colliding with a built-in action id (#9281). When
+   * `_doActivate()` finishes successfully it normally clears `loadError` to
+   * `null`; entries here are exempted from that clear so the diagnostic
+   * survives. Cleared on unload alongside the rest of the per-plugin state.
+   */
+  private pluginsWithLoadTimeErrors = new Set<string>();
   private ajv: AjvInstance | null = null;
   private pluginEventCleanups = new Map<string, Array<() => void>>();
   /**
@@ -911,6 +920,10 @@ export class PluginService {
           this.upsertInstalledRecord(pluginId, {
             loadError: { message, at: Date.now() },
           });
+          // Mark so a later `_doActivate()` success doesn't clear this
+          // load-time diagnostic. Collisions are manifest-level facts that
+          // don't go away when `main` activates cleanly.
+          this.pluginsWithLoadTimeErrors.add(pluginId);
         }
         continue;
       }
@@ -928,6 +941,7 @@ export class PluginService {
         );
         if (!isBuiltin) {
           this.upsertInstalledRecord(pluginId, { loadError });
+          this.pluginsWithLoadTimeErrors.add(pluginId);
         }
         continue;
       }
@@ -1070,8 +1084,11 @@ export class PluginService {
       }
       // Successful activation (or a main with no activate fn) clears any
       // diagnostic record left over from a prior failed attempt — persisted
-      // to the provenance record so it survives a host restart.
-      if (!plugin.isBuiltin) {
+      // to the provenance record so it survives a host restart. Plugins with
+      // a load-time error that is independent of `main` activation (e.g. a
+      // manifest command id collision, #9281) are exempted: their diagnostic
+      // is a manifest-level fact that doesn't go away when `main` activates.
+      if (!plugin.isBuiltin && !this.pluginsWithLoadTimeErrors.has(pluginId)) {
         this.upsertInstalledRecord(pluginId, { loadError: null });
       }
     } catch (err) {
@@ -2221,6 +2238,10 @@ export class PluginService {
     runUnloadStep(pluginId, "clearPluginSettingsState", () =>
       this.clearPluginSettingsState(pluginId)
     );
+
+    // Drop the load-time-error marker (#9281) so a reload with a fixed
+    // manifest can successfully clear `loadError` on next activation.
+    this.pluginsWithLoadTimeErrors.delete(pluginId);
 
     this.plugins.delete(pluginId);
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -95,12 +95,33 @@ import type { ActionDispatchResult } from "../../shared/types/actions.js";
 import type { LoadedPluginInfo } from "../../shared/types/plugin.js";
 import type { PluginToolbarButtonId } from "../../shared/types/toolbar.js";
 import { store } from "../store.js";
+import { BUILT_IN_ACTION_IDS } from "../../shared/config/actionIds.js";
 
 /** Plugin action IDs must be `{pluginId}.{actionId}`. Built-in IDs use colons, so the formats cannot collide. */
 const PLUGIN_ACTION_ID_RE = /^[a-z0-9][a-z0-9-]*\.[a-z0-9][a-zA-Z0-9._-]*$/;
 
 const PLUGIN_ACTION_KINDS = new Set(["command", "query"]);
 const PLUGIN_ACTION_DANGERS = new Set(["safe", "confirm"]);
+
+/**
+ * Built-in action ids materialised as a Set for O(1) collision lookup at
+ * load time. Manifest commands whose namespaced `{pluginId}.{cmd.id}` shadows
+ * a built-in id are rejected via the provenance `loadError` instead of being
+ * silently registered — the renderer would otherwise see two definitions for
+ * the same id and resolve in registration order, leaking command behavior to
+ * whichever side won the race.
+ */
+const BUILT_IN_ACTION_ID_SET: ReadonlySet<string> = new Set<string>(BUILT_IN_ACTION_IDS);
+
+/**
+ * Filesystem-convention extensions probed for a manifest-declared command's
+ * handler module, in precedence order. `.ts`/`.tsx` resolve in Electron 41
+ * (Node 24's type-stripping covers `.ts`; `.tsx` needs the plugin author to
+ * pre-compile or it'll fail at first dispatch) so a dev-mode plugin can ship
+ * source directly. The probe is async file-access only — no module evaluation
+ * happens until dispatch time.
+ */
+const COMMAND_HANDLER_EXTENSIONS = [".ts", ".tsx", ".js", ".mjs"] as const;
 
 /**
  * Capabilities whose presence in a plugin's manifest forces every action that
@@ -244,6 +265,29 @@ export class PluginService {
    * invokes them directly when a `plugin:invoke` lands on the action id.
    */
   private pluginActionHandlers = new Map<string, ActionHandler>();
+  /**
+   * Resolved on-disk paths for manifest-declared command handler modules,
+   * keyed by namespaced action id (`{pluginId}.{cmd.id}`). Populated at
+   * `loadPlugin()` time by probing `src/{cmd.id}.{ts,tsx,js,mjs}` — the
+   * module is NOT imported until first dispatch in {@link dispatchHandler}.
+   * Absence (no entry for a registered descriptor) means the file was not
+   * found at load time and dispatch will surface the documented
+   * `Command "{id}" has no handler` error. Entries are cleared on unload
+   * via {@link unregisterPluginActions} alongside the matching descriptor.
+   */
+  private commandModulePaths = new Map<string, string>();
+  /**
+   * Set of namespaced action ids whose descriptor was registered from
+   * `manifest.contributes.commands`. Distinguishes a manifest-declared
+   * command (whose handler is the lazy `src/{cmd.id}.{ext}` import) from
+   * an imperative `host.registerAction` descriptor (which always pairs
+   * with a closure in {@link pluginActionHandlers}). Drives the
+   * "Command \"{id}\" has no handler" toast text in {@link dispatchHandler}
+   * — without this set, a manifest command with a missing handler file
+   * would fall through to the generic "No plugin handler registered" path.
+   * Cleared per-plugin in {@link unregisterPluginActions}.
+   */
+  private manifestCommandIds = new Set<string>();
   private ajv: AjvInstance | null = null;
   private pluginEventCleanups = new Map<string, Array<() => void>>();
   /**
@@ -757,7 +801,11 @@ export class PluginService {
     }
 
     for (const btn of manifest.contributes.toolbarButtons) {
-      const buttonId = `plugin.${manifest.name}.${btn.id}` as PluginToolbarButtonId;
+      // Canonical `{pluginId}.{id}` form (#9281) — matches `registerPluginAction`
+      // and `panelKindRegistry`. The legacy `plugin.{pluginId}.{id}` form lived
+      // here alone and is migrated renderer-side by `toolbarPreferencesStore`'s
+      // v9 migration so existing user pins survive the rename.
+      const buttonId = `${manifest.name}.${btn.id}` as PluginToolbarButtonId;
       registerToolbarButton({
         id: buttonId,
         label: btn.label,
@@ -817,12 +865,159 @@ export class PluginService {
     // Plugins without a `main` entry contribute no executable code — the
     // provenance record reflects a clean load immediately. Plugins with a
     // `main` entry defer the `loadError: null` write to `_doActivate()` so
-    // the record only clears once activation actually succeeds.
+    // the record only clears once activation actually succeeds. This must
+    // happen BEFORE manifest command registration: a colliding command
+    // writes its own `loadError` via `registerManifestCommands` (#9281), and
+    // clearing it back to `null` here would silently lose the diagnostic.
     if (!plugin.resolvedMain && !opts.isBuiltin) {
       this.upsertInstalledRecord(manifest.name, { loadError: null });
     }
 
+    // Manifest-declared commands (#9281): register descriptors at load time so
+    // the command appears in the action palette before activation; probe the
+    // filesystem-convention handler path but defer the actual `import()` to
+    // first dispatch (the 5s activation budget can't pay N import costs up
+    // front). Probes happen after `plugins.set()` so
+    // `validateAndBuildActionDescriptor` sees the plugin as loaded.
+    if (manifest.contributes.commands.length > 0) {
+      await this.registerManifestCommands(manifest.name, plugin, opts.isBuiltin);
+    }
+
     return plugin;
+  }
+
+  /**
+   * Register each manifest-declared command's descriptor and probe its
+   * filesystem-convention handler path. Handler modules are NOT imported here —
+   * the dynamic `import()` is deferred to {@link dispatchHandler} so plugins
+   * with many commands don't pay the eval cost during the 5s activation
+   * budget. Collisions with built-in action ids surface via the provenance
+   * `loadError` field for non-builtins, or a console warning for builtins
+   * (which have no installed-record slot).
+   */
+  private async registerManifestCommands(
+    pluginId: string,
+    plugin: LoadedPlugin,
+    isBuiltin: boolean
+  ): Promise<void> {
+    let owners = this.pluginActionOwners.get(pluginId);
+    let registered = false;
+    for (const cmd of plugin.manifest.contributes.commands) {
+      const namespacedId = `${pluginId}.${cmd.id}`;
+      if (BUILT_IN_ACTION_ID_SET.has(namespacedId)) {
+        const message = `Plugin "${pluginId}" command id "${namespacedId}" collides with a built-in action id`;
+        console.error(`[PluginService] ${message}`);
+        if (!isBuiltin) {
+          this.upsertInstalledRecord(pluginId, {
+            loadError: { message, at: Date.now() },
+          });
+        }
+        continue;
+      }
+      let descriptor: PluginActionDescriptor;
+      try {
+        descriptor = this.validateAndBuildActionDescriptor(pluginId, {
+          ...cmd,
+          id: namespacedId,
+        });
+      } catch (err) {
+        const loadError = toPluginLoadError(err);
+        console.error(
+          `[PluginService] Failed to validate manifest command "${namespacedId}":`,
+          err
+        );
+        if (!isBuiltin) {
+          this.upsertInstalledRecord(pluginId, { loadError });
+        }
+        continue;
+      }
+      // Replace semantics mirror `host.registerAction` — a manifest-declared
+      // command silently overrides an earlier registration of the same id
+      // from a prior session's host.registerAction call (the handler map gets
+      // cleared on reload anyway).
+      this.pluginActions.set(descriptor.id, descriptor);
+      this.manifestCommandIds.add(descriptor.id);
+      if (!owners) {
+        owners = new Set();
+        this.pluginActionOwners.set(pluginId, owners);
+      }
+      owners.add(descriptor.id);
+      registered = true;
+
+      const resolvedPath = await this.resolveCommandHandlerPath(plugin.dir, cmd.id);
+      if (resolvedPath) {
+        this.commandModulePaths.set(descriptor.id, resolvedPath);
+      }
+      // Missing handler file: descriptor is still registered so the command
+      // appears in the palette; dispatch surfaces the documented
+      // `Command "{id}" has no handler` toast.
+    }
+    if (registered) {
+      this.broadcastPluginActions();
+    }
+  }
+
+  /**
+   * Probe `{pluginDir}/src/{cmdId}.{ts,tsx,js,mjs}` in precedence order,
+   * returning the first existing path or `null` when none match. The result
+   * is cached in {@link commandModulePaths} so the probe runs once per
+   * command per load — dispatch reads the cached path directly. Path
+   * traversal is guarded by {@link resolveEntryPath}: a `cmd.id` that
+   * escapes the plugin dir (e.g. `../../etc/passwd`) is rejected even if it
+   * somehow passed the manifest `SAFE_ID_PATTERN` (`.` is allowed in the
+   * pattern, so a defence-in-depth check is warranted).
+   */
+  private async resolveCommandHandlerPath(
+    pluginDir: string,
+    cmdId: string
+  ): Promise<string | null> {
+    for (const ext of COMMAND_HANDLER_EXTENSIONS) {
+      const candidate = this.resolveEntryPath(pluginDir, path.join("src", `${cmdId}${ext}`));
+      if (!candidate) continue;
+      try {
+        await fs.access(candidate);
+        return candidate;
+      } catch {
+        // File doesn't exist or is unreadable — try the next extension. No
+        // ENOENT vs EACCES distinction because the missing-file case is the
+        // dominant one and a permissions issue surfaces at dispatch import.
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Lazily resolve a manifest-declared command's handler module from
+   * {@link commandModulePaths}, import it via `runImport`, and cache the
+   * default export in {@link pluginActionHandlers}. Concurrent dispatches
+   * race on the cache: the first to set wins; subsequent setters drop the
+   * (identical) handler to avoid clobbering an in-flight set. ESM's
+   * URL-keyed module cache makes the duplicate import effectively free, so
+   * a full in-flight promise map adds no value here.
+   */
+  private async loadManifestCommandHandler(channel: string): Promise<ActionHandler> {
+    const cached = this.pluginActionHandlers.get(channel);
+    if (cached) return cached;
+    const resolvedPath = this.commandModulePaths.get(channel);
+    if (!resolvedPath) {
+      throw new Error(`Command "${channel}" has no handler`);
+    }
+    const descriptor = this.pluginActions.get(channel);
+    const pluginId = descriptor?.pluginId ?? channel;
+    const mod = (await this.runImport(pluginId, resolvedPath)) as { default?: unknown };
+    if (typeof mod.default !== "function") {
+      throw new Error(
+        `Command "${channel}" handler module "${resolvedPath}" has no callable default export`
+      );
+    }
+    const handler = mod.default as ActionHandler;
+    // Race guard: a concurrent dispatch may have already cached the same
+    // handler. Keep the existing entry so the older closure is canonical and
+    // any per-call state inside it isn't shadowed by a sibling import.
+    const existing = this.pluginActionHandlers.get(channel);
+    if (existing) return existing;
+    this.pluginActionHandlers.set(channel, handler);
+    return handler;
   }
 
   /**
@@ -1853,9 +2048,25 @@ export class PluginService {
     // namespaced action id and take precedence over a channel-keyed IPC
     // handler. Only honour one the dispatching plugin owns — the namespace
     // already guarantees this, and the guard mirrors the input-schema check.
-    const actionHandler =
+    let actionHandler =
       descriptor?.pluginId === pluginId ? this.pluginActionHandlers.get(channel) : undefined;
     const handler = this.handlerMap.get(key);
+    // Manifest-declared command (#9281): descriptor registered at load time,
+    // handler module deferred until first dispatch. Lazy-load now, then fall
+    // through to the existing action-handler dispatch path. A missing handler
+    // file throws the documented `Command "{id}" has no handler` toast; a
+    // bad default export throws a separate diagnostic — both surface via the
+    // renderer's `usePluginActions` rejection wrapper. Imperative-only
+    // descriptors (from `host.registerAction` without a manifest entry)
+    // already have a handler in `pluginActionHandlers`, so they short-circuit
+    // on the first check above and never enter this branch.
+    if (
+      !actionHandler &&
+      descriptor?.pluginId === pluginId &&
+      this.manifestCommandIds.has(channel)
+    ) {
+      actionHandler = await this.loadManifestCommandHandler(channel);
+    }
     if (!actionHandler && !handler) {
       throw new Error(`No plugin handler registered for ${key}`);
     }
@@ -2278,6 +2489,8 @@ export class PluginService {
     this.pluginActions.delete(actionId);
     this.actionValidators.delete(actionId);
     this.pluginActionHandlers.delete(actionId);
+    this.manifestCommandIds.delete(actionId);
+    this.commandModulePaths.delete(actionId);
     const owners = this.pluginActionOwners.get(pluginId);
     if (owners) {
       owners.delete(actionId);
@@ -2296,6 +2509,8 @@ export class PluginService {
       this.pluginActions.delete(id);
       this.actionValidators.delete(id);
       this.pluginActionHandlers.delete(id);
+      this.manifestCommandIds.delete(id);
+      this.commandModulePaths.delete(id);
     }
     this.pluginActionOwners.delete(pluginId);
 

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -294,10 +294,8 @@ describe("PluginService integration — panel contributions", () => {
     expect(getPanelKindConfig("acme.real-plugin.viewer")?.extensionId).toBe("acme.real-plugin");
     expect(getPanelKindConfig("alias-dir.viewer")).toBeUndefined();
 
-    expect(getToolbarButtonConfig("plugin.acme.real-plugin.btn")?.pluginId).toBe(
-      "acme.real-plugin"
-    );
-    expect(getToolbarButtonConfig("plugin.alias-dir.btn")).toBeUndefined();
+    expect(getToolbarButtonConfig("acme.real-plugin.btn")?.pluginId).toBe("acme.real-plugin");
+    expect(getToolbarButtonConfig("alias-dir.btn")).toBeUndefined();
 
     const items = getPluginMenuItems();
     expect(items).toHaveLength(1);
@@ -326,10 +324,10 @@ describe("PluginService integration — toolbar button contributions", () => {
     const service = new PluginService(tmpDir, "0.0.0");
     await service.initialize();
 
-    const config = getToolbarButtonConfig("plugin.acme.toolbar-plugin.my-btn");
+    const config = getToolbarButtonConfig("acme.toolbar-plugin.my-btn");
     expect(config).toBeDefined();
     expect(config).toMatchObject({
-      id: "plugin.acme.toolbar-plugin.my-btn",
+      id: "acme.toolbar-plugin.my-btn",
       label: "My Button",
       iconId: "puzzle",
       actionId: "toolbar-plugin.doThing",
@@ -357,7 +355,7 @@ describe("PluginService integration — toolbar button contributions", () => {
     const service = new PluginService(tmpDir, "0.0.0");
     await service.initialize();
 
-    expect(getToolbarButtonConfig("plugin.acme.default-prio.btn")?.priority).toBe(3);
+    expect(getToolbarButtonConfig("acme.default-prio.btn")?.priority).toBe(3);
   });
 });
 
@@ -749,7 +747,7 @@ describe("PluginService integration — main entry execution", () => {
         expect.anything()
       );
       expect(getPanelKindConfig("acme.bad-main.p")).toBeDefined();
-      expect(getToolbarButtonConfig("plugin.acme.bad-main.b")).toBeDefined();
+      expect(getToolbarButtonConfig("acme.bad-main.b")).toBeDefined();
       expect(getPluginMenuItems()).toHaveLength(1);
     } finally {
       errorSpy.mockRestore();
@@ -1109,7 +1107,7 @@ describe("PluginService integration — full contribution fan-out", () => {
     await service.initialize();
 
     expect(getPanelKindConfig("acme.all-in-one.v")?.extensionId).toBe("acme.all-in-one");
-    expect(getToolbarButtonConfig("plugin.acme.all-in-one.b")?.priority).toBe(2);
+    expect(getToolbarButtonConfig("acme.all-in-one.b")?.priority).toBe(2);
     expect(getPluginMenuItems()).toEqual([
       {
         pluginId: "acme.all-in-one",
@@ -1251,7 +1249,7 @@ describe("PluginService integration — built-in plugin loading", () => {
 
     expect(readMarker(markerKey)).toBeUndefined();
     expect(getPanelKindConfig("acme.disabled-user.p")).toBeUndefined();
-    expect(getToolbarButtonConfig("plugin.acme.disabled-user.b")).toBeUndefined();
+    expect(getToolbarButtonConfig("acme.disabled-user.b")).toBeUndefined();
     const listed = service.listPlugins();
     expect(listed).toHaveLength(1);
     expect(listed[0]).toMatchObject({ disabled: true, isBuiltin: false });

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -1305,6 +1305,64 @@ describe("PluginService manifest command contributions (#9281)", () => {
       })
     );
   });
+
+  it("preserves a collision loadError across a successful main activation", async () => {
+    // A plugin with both `main` AND a colliding manifest command writes a
+    // loadError at load time; `_doActivate()` success previously cleared it
+    // unconditionally, erasing the diagnostic. The collision is a manifest-
+    // level fact that doesn't go away when `main` activates cleanly.
+    const { BUILT_IN_ACTION_IDS } = await import("../../../shared/config/actionIds.js");
+    const pluginNamePattern = /^[a-z0-9]+(?:-[a-z0-9]+)*\.[a-z0-9]+(?:-[a-z0-9]+)*$/;
+    const threeSegment = BUILT_IN_ACTION_IDS.find((id) => {
+      const parts = id.split(".");
+      if (parts.length < 3) return false;
+      return pluginNamePattern.test(`${parts[0]}.${parts[1]}`);
+    });
+    if (!threeSegment) return;
+    const parts = threeSegment.split(".");
+    const pluginName = `${parts[0]}.${parts[1]}`;
+    const cmdId = parts.slice(2).join(".");
+
+    const pluginDir = path.join(tmpDir, pluginName);
+    await fs.mkdir(pluginDir, { recursive: true });
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: pluginName,
+        version: "1.0.0",
+        main: "main.js",
+        contributes: {
+          commands: [
+            {
+              id: cmdId,
+              title: "Bad",
+              description: "",
+              category: "X",
+              kind: "command",
+              danger: "safe",
+            },
+          ],
+        },
+      })
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "main.js"),
+      `export async function activate() { /* no-op */ }`
+    );
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+      await service.activatePlugin(pluginName);
+
+      const installed = (storeMock._state.get("plugins") as { installed?: Record<string, unknown> })
+        ?.installed as Record<string, { loadError?: { message: string } | null }> | undefined;
+      expect(installed?.[pluginName]?.loadError?.message).toContain("collides with a built-in");
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 });
 
 describe("PluginService built-in plugin loading", () => {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -1175,12 +1175,7 @@ describe("PluginService manifest command contributions (#9281)", () => {
     await service.initialize();
 
     await expect(
-      service.dispatchHandler(
-        "acme.cmd-nodef",
-        "acme.cmd-nodef.broken",
-        ctx("acme.cmd-nodef"),
-        []
-      )
+      service.dispatchHandler("acme.cmd-nodef", "acme.cmd-nodef.broken", ctx("acme.cmd-nodef"), [])
     ).rejects.toThrow(/no callable default export/);
   });
 
@@ -1289,9 +1284,7 @@ describe("PluginService manifest command contributions (#9281)", () => {
       name: "acme.ns-check",
       version: "1.0.0",
       contributes: {
-        toolbarButtons: [
-          { id: "btn", label: "Btn", iconId: "i", actionId: "acme.ns-check.act" },
-        ],
+        toolbarButtons: [{ id: "btn", label: "Btn", iconId: "i", actionId: "acme.ns-check.act" }],
       },
     });
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -579,10 +579,12 @@ describe("PluginManifestSchema contributes strict validation", () => {
   const validBase = { name: "acme.test", version: "1.0.0" };
 
   it("rejects unknown keys inside contributes (typo'd contribution-point names)", () => {
+    // `commandz` is a deliberate typo of `commands` (#9281) — strict-mode
+    // rejection of unknown keys catches plugin-author typos.
     const result = getPluginManifestSchema(false).safeParse({
       ...validBase,
       contributes: {
-        commands: [{ name: "foo", title: "Foo", description: "bar", category: "test" }],
+        commandz: [{ id: "foo", title: "Foo", description: "bar", category: "test" }],
       },
     });
     expect(result.success).toBe(false);
@@ -938,7 +940,7 @@ describe("PluginService", () => {
 
     expect(registerToolbarButton).toHaveBeenCalledWith(
       expect.objectContaining({
-        id: "plugin.acme.toolbar-test.my-btn",
+        id: "acme.toolbar-test.my-btn",
         label: "My Button",
         iconId: "puzzle",
         actionId: "acme.toolbar-test.doThing",
@@ -969,7 +971,7 @@ describe("PluginService", () => {
 
     expect(registerToolbarButton).toHaveBeenCalledWith(
       expect.objectContaining({
-        id: "plugin.acme.default-priority.btn",
+        id: "acme.default-priority.btn",
         priority: 3,
       })
     );
@@ -1011,6 +1013,297 @@ describe("PluginService", () => {
 
     expect(registerToolbarButton).not.toHaveBeenCalled();
     expect(registerPluginMenuItem).not.toHaveBeenCalled();
+  });
+});
+
+describe("PluginService manifest command contributions (#9281)", () => {
+  async function writePluginWithSrc(
+    name: string,
+    manifest: Record<string, unknown>,
+    files: Record<string, string> = {}
+  ): Promise<void> {
+    const dir = path.join(tmpDir, name);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, "plugin.json"), JSON.stringify(manifest));
+    if (Object.keys(files).length > 0) {
+      await fs.mkdir(path.join(dir, "src"), { recursive: true });
+      for (const [filename, content] of Object.entries(files)) {
+        await fs.writeFile(path.join(dir, "src", filename), content);
+      }
+    }
+  }
+
+  function ctx(pluginId: string): PluginIpcContext {
+    return makeCtx(pluginId);
+  }
+
+  it("registers a manifest command descriptor at load time without importing the handler", async () => {
+    await writePluginWithSrc(
+      "cmd-lazy",
+      {
+        name: "acme.cmd-lazy",
+        version: "1.0.0",
+        contributes: {
+          commands: [
+            {
+              id: "do-thing",
+              title: "Do Thing",
+              description: "Run the thing",
+              category: "Test",
+              kind: "command",
+              danger: "safe",
+            },
+          ],
+        },
+      },
+      {
+        "do-thing.ts": `export default () => "loaded"`,
+      }
+    );
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const actions = service.listPluginActions();
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({
+      pluginId: "acme.cmd-lazy",
+      id: "acme.cmd-lazy.do-thing",
+      title: "Do Thing",
+      category: "Test",
+      kind: "command",
+      danger: "safe",
+      effectiveDanger: "safe",
+    });
+  });
+
+  it("lazily imports and invokes the handler on first dispatch", async () => {
+    await writePluginWithSrc(
+      "cmd-dispatch",
+      {
+        name: "acme.cmd-dispatch",
+        version: "1.0.0",
+        contributes: {
+          commands: [
+            {
+              id: "plan",
+              title: "Plan",
+              description: "",
+              category: "Planning",
+              kind: "command",
+              danger: "safe",
+            },
+          ],
+        },
+      },
+      {
+        "plan.ts": `export default async (args) => ({ ok: true, args })`,
+      }
+    );
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const result = await service.dispatchHandler(
+      "acme.cmd-dispatch",
+      "acme.cmd-dispatch.plan",
+      ctx("acme.cmd-dispatch"),
+      [{ issue: 42 }]
+    );
+    expect(result).toEqual({ ok: true, args: { issue: 42 } });
+  });
+
+  it("throws the documented toast error when the handler file is missing", async () => {
+    await writePluginWithSrc("cmd-missing", {
+      name: "acme.cmd-missing",
+      version: "1.0.0",
+      contributes: {
+        commands: [
+          {
+            id: "ghost",
+            title: "Ghost",
+            description: "",
+            category: "Test",
+            kind: "command",
+            danger: "safe",
+          },
+        ],
+      },
+    });
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    // Descriptor is still registered (palette visibility) even with no file.
+    expect(service.listPluginActions()).toHaveLength(1);
+
+    await expect(
+      service.dispatchHandler(
+        "acme.cmd-missing",
+        "acme.cmd-missing.ghost",
+        ctx("acme.cmd-missing"),
+        []
+      )
+    ).rejects.toThrow('Command "acme.cmd-missing.ghost" has no handler');
+  });
+
+  it("throws when the handler module has no callable default export", async () => {
+    await writePluginWithSrc(
+      "cmd-nodef",
+      {
+        name: "acme.cmd-nodef",
+        version: "1.0.0",
+        contributes: {
+          commands: [
+            {
+              id: "broken",
+              title: "Broken",
+              description: "",
+              category: "Test",
+              kind: "command",
+              danger: "safe",
+            },
+          ],
+        },
+      },
+      {
+        "broken.ts": `export const named = 1`,
+      }
+    );
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    await expect(
+      service.dispatchHandler(
+        "acme.cmd-nodef",
+        "acme.cmd-nodef.broken",
+        ctx("acme.cmd-nodef"),
+        []
+      )
+    ).rejects.toThrow(/no callable default export/);
+  });
+
+  it("probes extensions in order .ts → .tsx → .js → .mjs", async () => {
+    // When both .ts and .js exist, .ts wins.
+    await writePluginWithSrc(
+      "cmd-order",
+      {
+        name: "acme.cmd-order",
+        version: "1.0.0",
+        contributes: {
+          commands: [
+            {
+              id: "pick",
+              title: "Pick",
+              description: "",
+              category: "Test",
+              kind: "command",
+              danger: "safe",
+            },
+          ],
+        },
+      },
+      {
+        "pick.ts": `export default () => "ts-wins"`,
+        "pick.js": `export default () => "js-loses"`,
+      }
+    );
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const result = await service.dispatchHandler(
+      "acme.cmd-order",
+      "acme.cmd-order.pick",
+      ctx("acme.cmd-order"),
+      []
+    );
+    expect(result).toBe("ts-wins");
+  });
+
+  it("surfaces a loadError when a manifest command collides with a built-in id", async () => {
+    // Construct a plugin whose namespaced command id WILL collide. The
+    // manifest schema requires `publisher.name` form (`/^[a-z0-9]+(?:-[a-z0-9]+)*\.[a-z0-9]+(?:-[a-z0-9]+)*$/`),
+    // so we filter built-ins to ones whose first two dotted segments would
+    // satisfy that pattern — three-segment, all-lowercase, no camelCase or
+    // special chars.
+    const { BUILT_IN_ACTION_IDS } = await import("../../../shared/config/actionIds.js");
+    const pluginNamePattern = /^[a-z0-9]+(?:-[a-z0-9]+)*\.[a-z0-9]+(?:-[a-z0-9]+)*$/;
+    const threeSegment = BUILT_IN_ACTION_IDS.find((id) => {
+      const parts = id.split(".");
+      if (parts.length < 3) return false;
+      return pluginNamePattern.test(`${parts[0]}.${parts[1]}`);
+    });
+    if (!threeSegment) {
+      // No suitable target — the collision path is structurally unreachable
+      // from a well-formed plugin manifest, so the load-time guard is
+      // defence-in-depth against a future built-in id whose shape would
+      // overlap. The test still validates the descriptor-registration path
+      // doesn't accidentally allow such an id.
+      return;
+    }
+    const parts = threeSegment.split(".");
+    const pluginName = `${parts[0]}.${parts[1]}`;
+    const cmdId = parts.slice(2).join(".");
+
+    await writePluginWithSrc(pluginName, {
+      name: pluginName,
+      version: "1.0.0",
+      contributes: {
+        commands: [
+          {
+            id: cmdId,
+            title: "Collides",
+            description: "",
+            category: "X",
+            kind: "command",
+            danger: "safe",
+          },
+        ],
+      },
+    });
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+
+      const namespacedId = `${pluginName}.${cmdId}`;
+      // No descriptor for the colliding id.
+      expect(service.listPluginActions().some((a) => a.id === namespacedId)).toBe(false);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`command id "${namespacedId}" collides with a built-in action id`)
+      );
+      // Provenance loadError set on the installed record.
+      const installed = (storeMock._state.get("plugins") as { installed?: Record<string, unknown> })
+        ?.installed as Record<string, { loadError?: { message: string } }> | undefined;
+      expect(installed?.[pluginName]?.loadError?.message).toContain("collides with a built-in");
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("registers the toolbar button under the canonical {pluginId}.{btnId} namespace", async () => {
+    await writePlugin("ns-check", {
+      name: "acme.ns-check",
+      version: "1.0.0",
+      contributes: {
+        toolbarButtons: [
+          { id: "btn", label: "Btn", iconId: "i", actionId: "acme.ns-check.act" },
+        ],
+      },
+    });
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    expect(registerToolbarButton).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "acme.ns-check.btn",
+        pluginId: "acme.ns-check",
+      })
+    );
   });
 });
 

--- a/shared/config/__tests__/toolbarButtonRegistry.test.ts
+++ b/shared/config/__tests__/toolbarButtonRegistry.test.ts
@@ -25,11 +25,11 @@ const makeConfig = (id: string, overrides?: Partial<ToolbarButtonConfig>): Toolb
 
 describe("toolbarButtonRegistry", () => {
   it("registers a button and retrieves it by ID", () => {
-    const config = makeConfig("plugin.acme.test-plugin.viewer");
+    const config = makeConfig("acme.test-plugin.viewer");
     registerToolbarButton(config);
 
-    expect(getToolbarButtonConfig("plugin.acme.test-plugin.viewer")).toEqual(config);
-    expect(getPluginToolbarButtonIds()).toEqual(["plugin.acme.test-plugin.viewer"]);
+    expect(getToolbarButtonConfig("acme.test-plugin.viewer")).toEqual(config);
+    expect(getPluginToolbarButtonIds()).toEqual(["acme.test-plugin.viewer"]);
   });
 
   it("returns undefined for unregistered IDs", () => {
@@ -42,24 +42,24 @@ describe("toolbarButtonRegistry", () => {
 
   it("warns and overwrites on duplicate registration", () => {
     const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const first = makeConfig("plugin.acme.test-plugin.btn", { label: "First" });
-    const second = makeConfig("plugin.acme.test-plugin.btn", { label: "Second" });
+    const first = makeConfig("acme.test-plugin.btn", { label: "First" });
+    const second = makeConfig("acme.test-plugin.btn", { label: "Second" });
 
     registerToolbarButton(first);
     registerToolbarButton(second);
 
     expect(spy).toHaveBeenCalledWith(
-      'Toolbar button "plugin.acme.test-plugin.btn" already registered, overwriting'
+      'Toolbar button "acme.test-plugin.btn" already registered, overwriting'
     );
-    expect(getToolbarButtonConfig("plugin.acme.test-plugin.btn")?.label).toBe("Second");
+    expect(getToolbarButtonConfig("acme.test-plugin.btn")?.label).toBe("Second");
     expect(getPluginToolbarButtonIds()).toHaveLength(1);
 
     spy.mockRestore();
   });
 
   it("isRegisteredPluginButton returns true for registered plugin buttons", () => {
-    registerToolbarButton(makeConfig("plugin.acme.my-plugin.action"));
-    expect(isRegisteredPluginButton("plugin.acme.my-plugin.action")).toBe(true);
+    registerToolbarButton(makeConfig("acme.my-plugin.action"));
+    expect(isRegisteredPluginButton("acme.my-plugin.action")).toBe(true);
   });
 
   it("isRegisteredPluginButton returns false for built-in IDs", () => {
@@ -72,8 +72,8 @@ describe("toolbarButtonRegistry", () => {
   });
 
   it("clearToolbarButtonRegistry removes all entries", () => {
-    registerToolbarButton(makeConfig("plugin.a.btn"));
-    registerToolbarButton(makeConfig("plugin.b.btn"));
+    registerToolbarButton(makeConfig("a.btn"));
+    registerToolbarButton(makeConfig("b.btn"));
     expect(getPluginToolbarButtonIds()).toHaveLength(2);
 
     clearToolbarButtonRegistry();
@@ -83,45 +83,45 @@ describe("toolbarButtonRegistry", () => {
 
 describe("unregisterPluginToolbarButtons", () => {
   it("removes only buttons owned by the target plugin", () => {
-    registerToolbarButton(makeConfig("plugin.owner-a.one", { pluginId: "owner-a" }));
-    registerToolbarButton(makeConfig("plugin.owner-a.two", { pluginId: "owner-a" }));
-    registerToolbarButton(makeConfig("plugin.owner-b.three", { pluginId: "owner-b" }));
+    registerToolbarButton(makeConfig("owner-a.one", { pluginId: "owner-a" }));
+    registerToolbarButton(makeConfig("owner-a.two", { pluginId: "owner-a" }));
+    registerToolbarButton(makeConfig("owner-b.three", { pluginId: "owner-b" }));
 
     unregisterPluginToolbarButtons("owner-a");
 
     const remaining = getPluginToolbarButtonIds();
-    expect(remaining).toEqual(["plugin.owner-b.three"]);
-    expect(getToolbarButtonConfig("plugin.owner-a.one")).toBeUndefined();
-    expect(getToolbarButtonConfig("plugin.owner-a.two")).toBeUndefined();
-    expect(getToolbarButtonConfig("plugin.owner-b.three")?.pluginId).toBe("owner-b");
+    expect(remaining).toEqual(["owner-b.three"]);
+    expect(getToolbarButtonConfig("owner-a.one")).toBeUndefined();
+    expect(getToolbarButtonConfig("owner-a.two")).toBeUndefined();
+    expect(getToolbarButtonConfig("owner-b.three")?.pluginId).toBe("owner-b");
   });
 
   it("is a no-op when unregistering an unknown pluginId", () => {
-    registerToolbarButton(makeConfig("plugin.owner-a.btn", { pluginId: "owner-a" }));
+    registerToolbarButton(makeConfig("owner-a.btn", { pluginId: "owner-a" }));
     expect(() => unregisterPluginToolbarButtons("never-loaded")).not.toThrow();
     expect(getPluginToolbarButtonIds()).toHaveLength(1);
   });
 
   it("is a no-op for empty or non-string pluginId (defensive input guard)", () => {
-    registerToolbarButton(makeConfig("plugin.owner-a.btn", { pluginId: "owner-a" }));
+    registerToolbarButton(makeConfig("owner-a.btn", { pluginId: "owner-a" }));
     expect(() => unregisterPluginToolbarButtons("")).not.toThrow();
     expect(() => unregisterPluginToolbarButtons(undefined as unknown as string)).not.toThrow();
     expect(getPluginToolbarButtonIds()).toHaveLength(1);
   });
 
   it("is a no-op when unregistering the same plugin twice", () => {
-    registerToolbarButton(makeConfig("plugin.owner-a.btn", { pluginId: "owner-a" }));
+    registerToolbarButton(makeConfig("owner-a.btn", { pluginId: "owner-a" }));
     unregisterPluginToolbarButtons("owner-a");
     expect(() => unregisterPluginToolbarButtons("owner-a")).not.toThrow();
     expect(getPluginToolbarButtonIds()).toHaveLength(0);
   });
 
   it("supports register → unregister → re-register round-trip", () => {
-    registerToolbarButton(makeConfig("plugin.owner-a.btn", { pluginId: "owner-a", label: "V1" }));
+    registerToolbarButton(makeConfig("owner-a.btn", { pluginId: "owner-a", label: "V1" }));
     unregisterPluginToolbarButtons("owner-a");
     expect(getPluginToolbarButtonIds()).toHaveLength(0);
 
-    registerToolbarButton(makeConfig("plugin.owner-a.btn", { pluginId: "owner-a", label: "V2" }));
-    expect(getToolbarButtonConfig("plugin.owner-a.btn")?.label).toBe("V2");
+    registerToolbarButton(makeConfig("owner-a.btn", { pluginId: "owner-a", label: "V2" }));
+    expect(getToolbarButtonConfig("owner-a.btn")?.label).toBe("V2");
   });
 });

--- a/shared/config/toolbarButtonRegistry.ts
+++ b/shared/config/toolbarButtonRegistry.ts
@@ -31,7 +31,10 @@ export function getAllPluginToolbarButtonConfigs(): ToolbarButtonConfig[] {
 }
 
 export function isRegisteredPluginButton(id: string): boolean {
-  return id.startsWith("plugin.") && id in TOOLBAR_BUTTON_REGISTRY;
+  // Plugin button ids use the canonical `{pluginId}.{btn}` namespace (#9281),
+  // so registry membership alone is the discriminator — built-in ids never
+  // appear in this registry. The pre-#9281 `plugin.` prefix check is gone.
+  return id in TOOLBAR_BUTTON_REGISTRY;
 }
 
 export function unregisterPluginToolbarButtons(pluginId: string): void {

--- a/shared/types/__tests__/plugin-sdk.test.ts
+++ b/shared/types/__tests__/plugin-sdk.test.ts
@@ -125,6 +125,7 @@ describe("plugin-sdk boundary", () => {
           panels: [],
           toolbarButtons: [],
           menuItems: [],
+          commands: [],
           experimental_views: [],
           experimental_mcpServers: [],
           keybindings: [],

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -124,6 +124,14 @@ export interface PluginManifest {
     menuItems: MenuItemContribution[];
     keybindings: KeybindingContribution[];
     contextMenus: ContextMenuContribution[];
+    /**
+     * Manifest-declared commands. Each entry registers a {@link PluginActionDescriptor}
+     * at load time (so the command appears in the palette before the plugin
+     * activates) and is lazily bound to `src/{id}.{ts,tsx,js,mjs}` on first
+     * dispatch. `id` is the bare command id — the host namespaces it as
+     * `{pluginId}.{id}` to match the {@link PluginActionDescriptor.id} convention.
+     */
+    commands: PluginActionContribution[];
     experimental_views: ViewContribution[];
     experimental_mcpServers: McpServerContribution[];
     forgeProviders: ForgeProviderContribution[];

--- a/shared/types/toolbar.ts
+++ b/shared/types/toolbar.ts
@@ -1,7 +1,18 @@
 import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "../config/agentIds.js";
 
-/** Identifier for plugin-contributed toolbar buttons (namespaced as plugin.name.buttonId) */
-export type PluginToolbarButtonId = `plugin.${string}`;
+/**
+ * Identifier for plugin-contributed toolbar buttons. Canonical namespace is
+ * `{pluginId}.{buttonId}` (matches `PluginActionDescriptor.id`). The legacy
+ * `plugin.{pluginId}.{buttonId}` form was retired in #9281; persisted user
+ * pin preferences carrying the old prefix are renamed by the
+ * `toolbarPreferencesStore` v9 migration.
+ *
+ * The template literal `${string}.${string}` keeps the dotted-namespace
+ * shape in the type system without re-introducing a hard-coded prefix —
+ * the renderer distinguishes plugin from built-in buttons by membership in
+ * the broadcast `configs` map, not by string parsing.
+ */
+export type PluginToolbarButtonId = `${string}.${string}`;
 
 /** Identifier for any toolbar button (built-in or plugin-contributed) */
 export type AnyToolbarButtonId = ToolbarButtonId | PluginToolbarButtonId;

--- a/src/components/Settings/__tests__/PluginsTab.test.tsx
+++ b/src/components/Settings/__tests__/PluginsTab.test.tsx
@@ -24,6 +24,7 @@ function makePlugin(overrides: Partial<LoadedPluginInfo> = {}): LoadedPluginInfo
         panels: [],
         toolbarButtons: [],
         menuItems: [],
+        commands: [],
         experimental_views: [],
         experimental_mcpServers: [],
         keybindings: [],

--- a/src/hooks/__tests__/usePluginToolbarButtons.test.ts
+++ b/src/hooks/__tests__/usePluginToolbarButtons.test.ts
@@ -43,13 +43,13 @@ beforeEach(() => {
 
 describe("usePluginToolbarButtons", () => {
   it("exposes plugin buttons from the mount-time pull without sweeping", async () => {
-    toolbarButtonsMock.mockResolvedValue([pluginButton("plugin.acme.foo")]);
+    toolbarButtonsMock.mockResolvedValue([pluginButton("acme.foo.btn")]);
     const { usePluginToolbarButtons } = await import("../usePluginToolbarButtons");
 
     const { result } = renderHook(() => usePluginToolbarButtons());
 
     await waitFor(() => {
-      expect(result.current.buttonIds).toContain("plugin.acme.foo");
+      expect(result.current.buttonIds).toContain("acme.foo.btn");
     });
     // Pull is partial under deferred init — must never prune persisted prefs.
     expect(sweepMock).not.toHaveBeenCalled();
@@ -67,7 +67,7 @@ describe("usePluginToolbarButtons", () => {
     renderHook(() => usePluginToolbarButtons());
 
     await waitFor(() => expect(emit).not.toBeNull());
-    emit!({ buttons: [pluginButton("plugin.acme.foo")], complete: false });
+    emit!({ buttons: [pluginButton("acme.foo.btn")], complete: false });
 
     expect(sweepMock).not.toHaveBeenCalled();
   });
@@ -84,8 +84,8 @@ describe("usePluginToolbarButtons", () => {
     renderHook(() => usePluginToolbarButtons());
 
     await waitFor(() => expect(emit).not.toBeNull());
-    emit!({ buttons: [pluginButton("plugin.acme.foo")], complete: true });
+    emit!({ buttons: [pluginButton("acme.foo.btn")], complete: true });
 
-    expect(sweepMock).toHaveBeenCalledWith(["plugin.acme.foo"]);
+    expect(sweepMock).toHaveBeenCalledWith(["acme.foo.btn"]);
   });
 });

--- a/src/hooks/usePluginToolbarButtons.ts
+++ b/src/hooks/usePluginToolbarButtons.ts
@@ -17,13 +17,17 @@ export interface PluginToolbarButtonState {
  * once a push arrives, a later-resolving mount-time pull is dropped to avoid
  * rolling back state (mirrors `usePluginPanelKinds`).
  *
- * Stale `plugin.` entries in the `toolbarPreferencesStore` `pinnedButtons`
- * map (renderer-local persisted state, no main-process access) are pruned
- * here off the lifecycle snapshot — but ONLY off an authoritative one. The
- * pull and load-time pushes are partial/growing (plugins load concurrently
- * and `initialize()` is deferred), so sweeping against them would wipe a
+ * Stale plugin entries in the `toolbarPreferencesStore` `pinnedButtons` map
+ * (renderer-local persisted state, no main-process access) are pruned here
+ * off the lifecycle snapshot — but ONLY off an authoritative one. The pull
+ * and load-time pushes are partial/growing (plugins load concurrently and
+ * `initialize()` is deferred), so sweeping against them would wipe a
  * not-yet-loaded plugin's hide preference. Only a `complete` push (a plugin
  * unload — i.e. uninstall, the exact case the sweep exists for) is swept.
+ *
+ * #9281 retired the `plugin.{pluginId}.{btn}` prefix in favour of canonical
+ * `{pluginId}.{btn}`. Stale entries from the old form are renamed by the v9
+ * persistence migration so user pin preferences survive the rename.
  */
 export function usePluginToolbarButtons(): PluginToolbarButtonState {
   const [configs, setConfigs] = useState<Map<string, ToolbarButtonConfig>>(new Map());
@@ -74,7 +78,10 @@ export function usePluginToolbarButtons(): PluginToolbarButtonState {
   }, []);
 
   const buttonIds = Array.from(configs.keys()) as PluginToolbarButtonId[];
-  const isRegistered = (id: string) => id.startsWith("plugin.") && configs.has(id);
+  // The broadcast `configs` map only contains plugin buttons received from
+  // main, so set membership alone is the registered-plugin-button predicate —
+  // no prefix string check needed (#9281).
+  const isRegistered = (id: string) => configs.has(id);
 
   return { buttonIds, configs, isRegistered };
 }

--- a/src/store/__tests__/toolbarPreferencesStore.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.test.ts
@@ -902,6 +902,34 @@ describe("toolbarPreferencesStore", () => {
           terminal: false,
         });
       });
+
+      it("renames `plugin.{pluginId}.{btn}` entries in leftButtons/rightButtons", async () => {
+        // Users who drag-and-dropped plugin toolbar buttons into a fixed
+        // slot had the old-form id stored in the position arrays. Without
+        // renaming, those become dangling references after the namespace
+        // change.
+        storageMock.setItem(
+          STORAGE_KEY,
+          JSON.stringify({
+            state: {
+              layout: {
+                leftButtons: ["terminal", "plugin.acme.foo.btn", "browser"],
+                rightButtons: ["plugin.daintreehq.tool.opener", "settings"],
+                pinnedButtons: {},
+              },
+              launcher: { alwaysShowDevServer: false },
+            },
+            version: 8,
+          })
+        );
+
+        const store = await loadStore();
+        const { leftButtons, rightButtons } = store.getState().layout;
+        expect(leftButtons).toContain("acme.foo.btn");
+        expect(leftButtons).not.toContain("plugin.acme.foo.btn");
+        expect(rightButtons).toContain("daintreehq.tool.opener");
+        expect(rightButtons).not.toContain("plugin.daintreehq.tool.opener");
+      });
     });
   });
 });

--- a/src/store/__tests__/toolbarPreferencesStore.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.test.ts
@@ -145,36 +145,36 @@ describe("toolbarPreferencesStore", () => {
       store.getState().setDefaultSelection("terminal");
       const before = store.getState().launcher.defaultSelection;
 
-      store.getState().toggleButtonVisibility("plugin.acme.foo" as AnyToolbarButtonId, "right");
+      store.getState().toggleButtonVisibility("acme.foo.btn" as AnyToolbarButtonId, "right");
 
       expect(store.getState().launcher.defaultSelection).toBe(before);
-      expect(store.getState().layout.pinnedButtons["plugin.acme.foo"]).toBe(false);
+      expect(store.getState().layout.pinnedButtons["acme.foo.btn"]).toBe(false);
     });
   });
 
   describe("sweepStalePluginPinnedButtons", () => {
     it("removes plugin entries absent from the valid id set", async () => {
       const store = await loadStore();
-      store.getState().toggleButtonVisibility("plugin.acme.old" as AnyToolbarButtonId, "right");
-      store.getState().toggleButtonVisibility("plugin.acme.active" as AnyToolbarButtonId, "right");
+      store.getState().toggleButtonVisibility("acme.foo.old" as AnyToolbarButtonId, "right");
+      store.getState().toggleButtonVisibility("acme.foo.active" as AnyToolbarButtonId, "right");
 
-      store.getState().sweepStalePluginPinnedButtons(["plugin.acme.active"]);
+      store.getState().sweepStalePluginPinnedButtons(["acme.foo.active"]);
 
       const { pinnedButtons } = store.getState().layout;
-      expect(pinnedButtons["plugin.acme.old"]).toBeUndefined();
-      expect(pinnedButtons["plugin.acme.active"]).toBe(false);
+      expect(pinnedButtons["acme.foo.old"]).toBeUndefined();
+      expect(pinnedButtons["acme.foo.active"]).toBe(false);
     });
 
     it("never touches built-in (non-plugin) keys", async () => {
       const store = await loadStore();
       store.getState().toggleButtonVisibility("copy-tree", "right");
-      store.getState().toggleButtonVisibility("plugin.acme.gone" as AnyToolbarButtonId, "right");
+      store.getState().toggleButtonVisibility("acme.foo.gone" as AnyToolbarButtonId, "right");
 
       store.getState().sweepStalePluginPinnedButtons([]);
 
       const { pinnedButtons } = store.getState().layout;
       expect(pinnedButtons["copy-tree"]).toBe(false);
-      expect(pinnedButtons["plugin.acme.gone"]).toBeUndefined();
+      expect(pinnedButtons["acme.foo.gone"]).toBeUndefined();
     });
 
     it("is a no-op (preserves layout reference) when nothing is stale", async () => {
@@ -847,6 +847,60 @@ describe("toolbarPreferencesStore", () => {
 
         const store = await loadStore();
         expect(store.getState().layout.pinnedButtons).toEqual({ "copy-tree": false });
+      });
+    });
+
+    describe("v8→v9 plugin toolbar id rename (#9281)", () => {
+      it("renames `plugin.{pluginId}.{btn}` pinned keys to canonical `{pluginId}.{btn}`", async () => {
+        storageMock.setItem(
+          STORAGE_KEY,
+          JSON.stringify({
+            state: {
+              layout: {
+                leftButtons: ["terminal"],
+                rightButtons: ["settings"],
+                pinnedButtons: {
+                  "plugin.acme.foo.btn": false,
+                  "plugin.daintreehq.tool.opener": false,
+                  "copy-tree": false,
+                },
+              },
+              launcher: { alwaysShowDevServer: false },
+            },
+            version: 8,
+          })
+        );
+
+        const store = await loadStore();
+        const { pinnedButtons } = store.getState().layout;
+        expect(pinnedButtons["acme.foo.btn"]).toBe(false);
+        expect(pinnedButtons["daintreehq.tool.opener"]).toBe(false);
+        expect(pinnedButtons["copy-tree"]).toBe(false);
+        expect(pinnedButtons["plugin.acme.foo.btn"]).toBeUndefined();
+        expect(pinnedButtons["plugin.daintreehq.tool.opener"]).toBeUndefined();
+      });
+
+      it("is a no-op when there are no `plugin.` prefixed keys", async () => {
+        storageMock.setItem(
+          STORAGE_KEY,
+          JSON.stringify({
+            state: {
+              layout: {
+                leftButtons: ["terminal"],
+                rightButtons: ["settings"],
+                pinnedButtons: { "copy-tree": false, terminal: false },
+              },
+              launcher: { alwaysShowDevServer: false },
+            },
+            version: 8,
+          })
+        );
+
+        const store = await loadStore();
+        expect(store.getState().layout.pinnedButtons).toEqual({
+          "copy-tree": false,
+          terminal: false,
+        });
       });
     });
   });

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -300,21 +300,35 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
         }
         if (version < 9) {
           // Plugin toolbar buttons migrated from `plugin.{pluginId}.{btn}` to
-          // canonical `{pluginId}.{btn}` (#9281). Rename persisted pin keys so
-          // user hide preferences survive the rename — otherwise next-launch
-          // sweep would drop them silently since they no longer match any
-          // registered button id. Built-in keys (no `plugin.` prefix) are
-          // untouched.
+          // canonical `{pluginId}.{btn}` (#9281). Rename persisted pin keys
+          // AND the position arrays (`leftButtons`/`rightButtons`, populated
+          // by `moveButton` when a user drags a plugin button into a fixed
+          // slot) so user state survives the rename. Without the array
+          // rename, those entries would become dangling references that
+          // match no registered button config — producing phantom slots.
+          // Built-in ids never start with `plugin.`, so non-prefixed keys
+          // pass through unchanged.
+          const stripPluginPrefix = (id: string): string =>
+            id.startsWith("plugin.") ? id.slice("plugin.".length) : id;
           const layout = state.layout as
-            | { pinnedButtons?: Record<string, boolean> }
+            | {
+                pinnedButtons?: Record<string, boolean>;
+                leftButtons?: string[];
+                rightButtons?: string[];
+              }
             | undefined;
           if (layout?.pinnedButtons) {
             const renamed: Record<string, boolean> = {};
             for (const [key, value] of Object.entries(layout.pinnedButtons)) {
-              const target = key.startsWith("plugin.") ? key.slice("plugin.".length) : key;
-              renamed[target] = value;
+              renamed[stripPluginPrefix(key)] = value;
             }
             layout.pinnedButtons = renamed;
+          }
+          if (Array.isArray(layout?.leftButtons)) {
+            layout.leftButtons = layout.leftButtons.map(stripPluginPrefix);
+          }
+          if (Array.isArray(layout?.rightButtons)) {
+            layout.rightButtons = layout.rightButtons.map(stripPluginPrefix);
           }
         }
         return state as unknown as ToolbarPreferencesState;

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -85,13 +85,16 @@ interface ToolbarPreferencesState extends ToolbarPreferences {
   ) => void;
   toggleButtonVisibility: (buttonId: AnyToolbarButtonId, side: "left" | "right") => void;
   /**
-   * Prune `pinnedButtons` entries for plugin buttons (`plugin.` prefix) that
-   * are no longer in the loaded plugin set. `pinnedButtons` is renderer-local
-   * persisted state with no main-process access, so an uninstalled plugin's
-   * stale hide entry can only be swept here, driven by the plugin lifecycle
-   * snapshot in `usePluginToolbarButtons`. Built-in (non-`plugin.`) keys are
-   * never touched. No-ops (returns state unchanged) when nothing is stale so
-   * the per-snapshot call doesn't churn the persist layer.
+   * Prune `pinnedButtons` entries for plugin buttons that are no longer in
+   * the loaded plugin set. `pinnedButtons` is renderer-local persisted state
+   * with no main-process access, so an uninstalled plugin's stale hide entry
+   * can only be swept here, driven by the plugin lifecycle snapshot in
+   * `usePluginToolbarButtons`. Plugin buttons use the `{pluginId}.{btnId}`
+   * canonical namespace (#9281) — built-in button IDs (`sidebar-toggle`,
+   * `notification-center`, agent IDs like `claude`, etc.) contain only
+   * hyphens or single tokens, never dots, so `key.includes(".")` cleanly
+   * separates the two. No-ops (returns state unchanged) when nothing is
+   * stale so the per-snapshot call doesn't churn the persist layer.
    */
   sweepStalePluginPinnedButtons: (validIds: string[]) => void;
   setAlwaysShowDevServer: (value: boolean) => void;
@@ -155,7 +158,7 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
         set((state) => {
           const validSet = new Set(validIds);
           const staleKeys = Object.keys(state.layout.pinnedButtons).filter(
-            (key) => key.startsWith("plugin.") && !validSet.has(key)
+            (key) => key.includes(".") && !validSet.has(key)
           );
           if (staleKeys.length === 0) return state;
           const pinned: ToolbarPinnedState = { ...state.layout.pinnedButtons };
@@ -182,7 +185,7 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
     }),
     {
       name: "daintree-toolbar-preferences",
-      version: 8,
+      version: 9,
       storage: createSafeJSONStorage(),
       migrate: (persisted, version) => {
         const state = persisted as Record<string, unknown>;
@@ -293,6 +296,25 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
             // valid v8 shape so `merge()` doesn't fall back to overwriting the
             // freshly-built `pinnedButtons` with the default empty map.
             state.layout = { pinnedButtons: {} } as unknown as Record<string, unknown>;
+          }
+        }
+        if (version < 9) {
+          // Plugin toolbar buttons migrated from `plugin.{pluginId}.{btn}` to
+          // canonical `{pluginId}.{btn}` (#9281). Rename persisted pin keys so
+          // user hide preferences survive the rename — otherwise next-launch
+          // sweep would drop them silently since they no longer match any
+          // registered button id. Built-in keys (no `plugin.` prefix) are
+          // untouched.
+          const layout = state.layout as
+            | { pinnedButtons?: Record<string, boolean> }
+            | undefined;
+          if (layout?.pinnedButtons) {
+            const renamed: Record<string, boolean> = {};
+            for (const [key, value] of Object.entries(layout.pinnedButtons)) {
+              const target = key.startsWith("plugin.") ? key.slice("plugin.".length) : key;
+              renamed[target] = value;
+            }
+            layout.pinnedButtons = renamed;
           }
         }
         return state as unknown as ToolbarPreferencesState;


### PR DESCRIPTION
## Summary

- Wires `contributes.commands` in plugin manifests to lazy-loaded handlers via a filesystem convention: `src/{name}.ts` (or `.tsx`, `.js`, `.mjs`), imported on first dispatch so commands don't consume the 5s activation budget
- Rejects manifest command ids that collide with built-in action ids at load time; shows the documented `Command "{id}" has no handler` toast when the handler file or default export is missing
- Reconciles the toolbar button namespace from `plugin.{pluginId}.{id}` to the canonical `{pluginId}.{id}` form used everywhere else — atomic migration across `PluginService`, `PluginToolbarButtonId`, the renderer `isRegistered` guard, a new `isRegisteredPluginButton` helper, and a v9 `toolbarPreferencesStore` migration covering `pinnedButtons` and `leftButtons`/`rightButtons` position arrays

Resolves #9281

## Changes

- `electron/schemas/plugin.ts` — adds `contributes.commands` to the manifest schema
- `electron/services/PluginService.ts` — registers command descriptors at load time; lazy `import()` binds the handler on first dispatch; `loadError` survives a successful `main` activation; toolbar buttons registered under canonical `{pluginId}.{id}`
- `shared/types/plugin.ts` / `shared/types/toolbar.ts` — `pluginActionId()` namespacing helper; updated `PluginToolbarButtonId` type
- `shared/config/toolbarButtonRegistry.ts` — `isRegisteredPluginButton` predicate updated for canonical prefix
- `src/hooks/usePluginToolbarButtons.ts` — renderer `isRegistered` guard migrated from `plugin.` prefix to canonical form
- `src/store/toolbarPreferencesStore.ts` — v9 migration renames persisted `plugin.X.Y` entries to `X.Y` in all position arrays
- New tests: manifest command load/dispatch/collision/extension precedence, v8→v9 store migration, canonical toolbar id format
- `docs/plugins/contribution-points.md` — marks Commands as Shipped; documents the lazy convention and collision rule

## Testing

Unit tests cover the happy path (load + dispatch), missing handler file, missing default export, id collision with a built-in, extension precedence (`.ts` wins over `.tsx`/`.js`/`.mjs`), `loadError` persistence across activation, and the v8→v9 store migration for both pinned and position arrays.