### PR TITLE
feat(plugins): land PluginMcpSupervisor — spawn stdio MCP subprocesses from plugin manifests

### DIFF
--- a/electron/ipc/__tests__/handlers.registry.test.ts
+++ b/electron/ipc/__tests__/handlers.registry.test.ts
@@ -73,6 +73,7 @@ const registerMocks = vi.hoisted(() => ({
   registerRecoveryHandlers: vi.fn(),
   registerSafeModeHandlers: vi.fn(),
   registerPluginHandlers: vi.fn(),
+  registerPluginMcpHandlers: vi.fn(),
   registerPerfHandlers: vi.fn(),
   registerConnectivityHandlers: vi.fn(),
   registerScratchHandlers: vi.fn(),
@@ -240,6 +241,9 @@ vi.mock("../handlers/safeMode.js", () => ({
 }));
 vi.mock("../handlers/plugin.js", () => ({
   registerPluginHandlers: registerMocks.registerPluginHandlers,
+}));
+vi.mock("../handlers/pluginMcp.js", () => ({
+  registerPluginMcpHandlers: registerMocks.registerPluginMcpHandlers,
 }));
 vi.mock("../handlers/perf.js", () => ({
   registerPerfHandlers: registerMocks.registerPerfHandlers,

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -811,6 +811,13 @@ export const CHANNELS = {
   /** Bridge: renderer returns the plugin-sourced action dispatch result to the main process. */
   PLUGIN_DISPATCH_ACTION_RESPONSE: "plugin:dispatch-action-response",
 
+  // Plugin MCP supervisor channels (#9233) — stdio MCP servers contributed by
+  // plugin manifests, supervised in the main process via execa. Distinct from
+  // `mcp-server:*`, which covers the in-process inbound MCP server.
+  PLUGIN_MCP_LIST: "plugin-mcp:list",
+  PLUGIN_MCP_GET_STDERR: "plugin-mcp:get-stderr",
+  PLUGIN_MCP_RESTART: "plugin-mcp:restart",
+
   // Config reload channels
   APP_RELOAD_CONFIG: "app:reload-config",
   APP_CONFIG_RELOADED: "app:config-reloaded",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -61,6 +61,7 @@ import { registerRecoveryHandlers } from "./handlers/recovery.js";
 import { registerSafeModeHandlers } from "./handlers/safeMode.js";
 import { registerWatchdogHandlers } from "./handlers/watchdog.js";
 import { registerPluginHandlers } from "./handlers/plugin.js";
+import { registerPluginMcpHandlers } from "./handlers/pluginMcp.js";
 import { registerConnectivityHandlers } from "./handlers/connectivity.js";
 import { registerScratchHandlers } from "./handlers/scratch/index.js";
 import { events } from "../services/events.js";
@@ -167,6 +168,7 @@ export function registerIpcHandlers(deps: HandlerDependencies): () => void {
     register(() => registerSafeModeHandlers());
     register(() => registerWatchdogHandlers(deps));
     register(() => registerPluginHandlers());
+    register(() => registerPluginMcpHandlers());
     register(() => registerPerfHandlers());
     register(() => registerConnectivityHandlers());
     register(() => registerScratchHandlers(deps));

--- a/electron/ipc/handlers/pluginMcp.preload.ts
+++ b/electron/ipc/handlers/pluginMcp.preload.ts
@@ -1,0 +1,26 @@
+import type { IpcInvokeMap } from "../../types/index.js";
+
+export const PLUGIN_MCP_METHOD_CHANNELS = {
+  list: "plugin-mcp:list",
+  getStderr: "plugin-mcp:get-stderr",
+  restart: "plugin-mcp:restart",
+} as const satisfies Record<string, keyof IpcInvokeMap>;
+
+type Methods = typeof PLUGIN_MCP_METHOD_CHANNELS;
+
+export type PluginMcpPreloadBindings = {
+  [M in keyof Methods]: (
+    ...args: IpcInvokeMap[Methods[M]]["args"]
+  ) => Promise<IpcInvokeMap[Methods[M]]["result"]>;
+};
+
+type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
+
+export function buildPluginMcpPreloadBindings(invoke: Invoker): PluginMcpPreloadBindings {
+  const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const method of Object.keys(PLUGIN_MCP_METHOD_CHANNELS) as Array<keyof Methods>) {
+    const channel = PLUGIN_MCP_METHOD_CHANNELS[method];
+    out[method as string] = (...args) => invoke(channel, ...args);
+  }
+  return out as unknown as PluginMcpPreloadBindings;
+}

--- a/electron/ipc/handlers/pluginMcp.ts
+++ b/electron/ipc/handlers/pluginMcp.ts
@@ -23,12 +23,19 @@ async function handleGetStderr(key: PluginMcpServerKey): Promise<PluginMcpStderr
  * decoupled from `PluginService`.
  */
 async function handleRestart(key: PluginMcpServerKey): Promise<void> {
-  const contribution = pluginService.findMcpServerContribution(key.pluginId, key.serverId);
-  if (!contribution) return;
+  const lookup = pluginService.findMcpServerContribution(key.pluginId, key.serverId);
+  if (!lookup) {
+    // A renderer race with plugin unload can land here. Throw so the caller
+    // sees the failure rather than treating it as a silent no-op restart.
+    throw new Error(
+      `Cannot restart "${key.pluginId}/${key.serverId}": plugin or server is not registered`
+    );
+  }
   await getPluginMcpSupervisor().restart({
     pluginId: key.pluginId,
+    pluginDir: lookup.pluginDir,
     serverId: key.serverId,
-    contribution,
+    contribution: lookup.contribution,
     resolveSettings: (settingId) => pluginService.resolveSettingTemplate(key.pluginId, settingId),
   });
 }

--- a/electron/ipc/handlers/pluginMcp.ts
+++ b/electron/ipc/handlers/pluginMcp.ts
@@ -1,0 +1,47 @@
+import { defineIpcNamespace, op } from "../define.js";
+import { PLUGIN_MCP_METHOD_CHANNELS } from "./pluginMcp.preload.js";
+import { getPluginMcpSupervisor } from "../../services/PluginMcpSupervisor.js";
+import { pluginService } from "../../services/PluginService.js";
+import type {
+  PluginMcpServerInfo,
+  PluginMcpServerKey,
+  PluginMcpStderrResult,
+} from "../../../shared/types/ipc/pluginMcp.js";
+
+async function handleList(): Promise<PluginMcpServerInfo[]> {
+  return getPluginMcpSupervisor().list();
+}
+
+async function handleGetStderr(key: PluginMcpServerKey): Promise<PluginMcpStderrResult> {
+  return getPluginMcpSupervisor().getStderr(key.pluginId, key.serverId);
+}
+
+/**
+ * Re-spawn a specific supervised server, e.g. after the user rotates a secret
+ * the manifest substitutes in via `${settings:*}`. Resolution of the new
+ * settings value happens here at the handler boundary so the supervisor stays
+ * decoupled from `PluginService`.
+ */
+async function handleRestart(key: PluginMcpServerKey): Promise<void> {
+  const contribution = pluginService.findMcpServerContribution(key.pluginId, key.serverId);
+  if (!contribution) return;
+  await getPluginMcpSupervisor().restart({
+    pluginId: key.pluginId,
+    serverId: key.serverId,
+    contribution,
+    resolveSettings: (settingId) => pluginService.resolveSettingTemplate(key.pluginId, settingId),
+  });
+}
+
+export const pluginMcpNamespace = defineIpcNamespace({
+  name: "pluginMcp",
+  ops: {
+    list: op(PLUGIN_MCP_METHOD_CHANNELS.list, handleList),
+    getStderr: op(PLUGIN_MCP_METHOD_CHANNELS.getStderr, handleGetStderr),
+    restart: op(PLUGIN_MCP_METHOD_CHANNELS.restart, handleRestart),
+  },
+});
+
+export function registerPluginMcpHandlers(): () => void {
+  return pluginMcpNamespace.register();
+}

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -228,6 +228,12 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
           import("../services/HelpSessionService.js")
             .then(({ helpSessionService }) => helpSessionService.revokeAll())
             .catch(() => {}),
+          // Tear down every supervised plugin MCP subprocess (#9233). Same
+          // lazy-import guard — if no plugin ever activated an MCP server, the
+          // supervisor module never loaded and there is nothing to stop.
+          import("../services/PluginMcpSupervisor.js")
+            .then(({ getPluginMcpSupervisor }) => getPluginMcpSupervisor().shutdownAll())
+            .catch(() => {}),
           new Promise<void>((resolve) => {
             // Global singletons that previously tore down on last-window-close
             // (electron/window/windowServices.ts) live here now so they cover

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -37,6 +37,7 @@ import { buildCommandsPreloadBindings } from "./ipc/handlers/commands.preload.js
 import { buildPortalPreloadBindings } from "./ipc/handlers/portal.preload.js";
 import { buildDevPreviewPreloadBindings } from "./ipc/handlers/devPreview.preload.js";
 import { buildPluginPreloadBindings } from "./ipc/handlers/plugin.preload.js";
+import { buildPluginMcpPreloadBindings } from "./ipc/handlers/pluginMcp.preload.js";
 import { buildScratchPreloadBindings } from "./ipc/handlers/scratch/preload.js";
 import { buildMcpServerPreloadBindings } from "./ipc/handlers/mcpServer.preload.js";
 import { buildGeminiPreloadBindings } from "./ipc/handlers/gemini.preload.js";
@@ -2474,6 +2475,8 @@ const api: ElectronAPI = {
     onDecorationsChanged: (callback: (payload: { scope: string; paths?: string[] }) => void) =>
       _eventBusOn("plugin:decorations-changed", callback),
   },
+
+  pluginMcp: buildPluginMcpPreloadBindings(_unwrappingInvoke),
 
   crashRecovery: {
     getPending: () => _unwrappingInvoke(CHANNELS.CRASH_RECOVERY_GET_PENDING),

--- a/electron/schemas/__tests__/mcpServerContribution.test.ts
+++ b/electron/schemas/__tests__/mcpServerContribution.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { McpServerContributionSchema } from "../plugin.js";
+
+describe("McpServerContributionSchema (issue #9233)", () => {
+  it("accepts a minimal stdio contribution", () => {
+    const result = McpServerContributionSchema.safeParse({
+      id: "linear",
+      name: "Linear",
+      command: "npx",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts args and env", () => {
+    const result = McpServerContributionSchema.safeParse({
+      id: "linear",
+      name: "Linear",
+      command: "npx",
+      args: ["-y", "@linear/mcp"],
+      env: { LINEAR_TOKEN: "abc" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a contribution declaring a url field (HTTP/SSE transport)", () => {
+    const result = McpServerContributionSchema.safeParse({
+      id: "linear",
+      name: "Linear",
+      command: "npx",
+      url: "https://mcp.example.com",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects any unknown top-level field", () => {
+    const result = McpServerContributionSchema.safeParse({
+      id: "linear",
+      name: "Linear",
+      command: "npx",
+      transport: "stdio",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing required fields", () => {
+    expect(McpServerContributionSchema.safeParse({ name: "Linear", command: "npx" }).success).toBe(
+      false
+    );
+    expect(McpServerContributionSchema.safeParse({ id: "linear", command: "npx" }).success).toBe(
+      false
+    );
+    expect(McpServerContributionSchema.safeParse({ id: "linear", name: "Linear" }).success).toBe(
+      false
+    );
+  });
+
+  it("rejects ids with disallowed characters", () => {
+    const result = McpServerContributionSchema.safeParse({
+      id: "linear server",
+      name: "Linear",
+      command: "npx",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -99,17 +99,23 @@ export const ViewContributionSchema = z.object({
 });
 
 /**
- * Reserved contribution point. Shape mirrors the Claude Desktop / Cursor
- * MCP server config (stdio transport only). `url` is intentionally absent —
- * remote MCP servers are a separate future concern.
+ * Stdio-only MCP server contribution. Shape mirrors the Claude Desktop /
+ * Cursor MCP server config. `url` is absent by design — HTTP/SSE transport
+ * is rejected at the schema boundary. The MCP Authorization spec carves
+ * stdio out of OAuth, and the official SDKs' HTTP transports have a
+ * documented history of DNS-rebinding flaws (CVE-2025-66414,
+ * CVE-2025-66416, CVE-2026-34742). Strict so unknown fields from plugin
+ * authors are rejected loudly rather than silently dropped.
  */
-export const McpServerContributionSchema = z.object({
-  id: z.string().min(1).max(64).regex(SAFE_ID_PATTERN),
-  name: z.string().min(1),
-  command: z.string().min(1),
-  args: z.array(z.string()).optional(),
-  env: z.record(z.string(), z.string()).optional(),
-});
+export const McpServerContributionSchema = z
+  .object({
+    id: z.string().min(1).max(64).regex(SAFE_ID_PATTERN),
+    name: z.string().min(1),
+    command: z.string().min(1),
+    args: z.array(z.string()).optional(),
+    env: z.record(z.string(), z.string()).optional(),
+  })
+  .strict();
 
 /**
  * Reserved contribution point. Shape is validated but the runtime does not

--- a/electron/services/PluginMcpSupervisor.ts
+++ b/electron/services/PluginMcpSupervisor.ts
@@ -251,15 +251,19 @@ export class PluginMcpSupervisor {
     try {
       handle = await this.spawner(resolved);
     } catch (err) {
-      if (state.status !== "stopped") {
+      if (state.status === "spawning") {
         state.status = "crashed";
         state.lastError = formatErrorMessage(err, "MCP supervisor error");
       }
       return;
     }
-    // Same guard after the spawn-await: if a shutdown raced in, kill the
-    // freshly-spawned child immediately rather than registering it as state.
-    if (state.status === "stopped") {
+    // Same guard after the spawn-await: if a shutdown raced in (status flipped
+    // to "stopped" while we were awaiting spawn), kill the freshly-spawned
+    // child immediately rather than registering it as live state. TS narrows
+    // away "stopped" here because the captured-state type tracker can't see
+    // the mutation from a concurrent shutdownOne — the runtime check is real,
+    // the typeof cast just bypasses the dead-code narrowing.
+    if ((state.status as PluginMcpServerStatus) === "stopped") {
       try {
         handle.subprocess.kill();
       } catch {

--- a/electron/services/PluginMcpSupervisor.ts
+++ b/electron/services/PluginMcpSupervisor.ts
@@ -5,6 +5,7 @@ import {
   type PluginMcpServerStatus,
   type PluginMcpStderrResult,
 } from "../../shared/types/ipc/pluginMcp.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { McpServerContributionSchema } from "../schemas/plugin.js";
 
 type McpServerContribution = z.infer<typeof McpServerContributionSchema>;
@@ -48,6 +49,14 @@ export interface ResolvedMcpServerConfig {
   command: string;
   args: string[];
   env: Record<string, string>;
+  /**
+   * Working directory for the child process. The supervisor anchors this to
+   * the plugin's on-disk directory so a manifest like
+   * `command: "node", args: ["./dist/server.js"]` resolves against the plugin
+   * regardless of the Electron process's own cwd. Plugins cannot override
+   * this — it's set by the host, not the manifest.
+   */
+  cwd: string | undefined;
 }
 
 /**
@@ -148,14 +157,15 @@ export class PluginMcpSupervisor {
    */
   async start(input: {
     pluginId: string;
+    pluginDir?: string;
     contributions: McpServerContribution[];
     resolveSettings: (template: string) => Promise<string>;
   }): Promise<void> {
-    const { pluginId, contributions, resolveSettings } = input;
+    const { pluginId, pluginDir, contributions, resolveSettings } = input;
     if (contributions.length === 0) return;
     await Promise.all(
       contributions.map((contribution) =>
-        this.startOne(pluginId, contribution, resolveSettings).catch((err) => {
+        this.startOne(pluginId, pluginDir, contribution, resolveSettings).catch((err) => {
           // startOne records the failure into state.lastError; the catch here
           // exists so a thrown spawn (e.g. unresolved settings template) can't
           // reject the outer Promise.all and abort plugin activation.
@@ -170,6 +180,7 @@ export class PluginMcpSupervisor {
 
   private async startOne(
     pluginId: string,
+    pluginDir: string | undefined,
     contribution: McpServerContribution,
     resolveSettings: (template: string) => Promise<string>
   ): Promise<void> {
@@ -192,12 +203,23 @@ export class PluginMcpSupervisor {
       readyPromise: null,
       stdoutBuffer: "",
     };
-    // Reset transient fields for a restart of a previously-stopped/crashed entry.
+    // Reset transient fields for a restart of a previously-stopped/crashed
+    // entry. A "crashed" entry may still hold a live subprocess (e.g. the
+    // handshake timed out but the server is still running), so kill it
+    // before nulling the reference — otherwise the orphan process leaks.
     if (existing) {
+      if (existing.subprocess) {
+        try {
+          existing.subprocess.kill();
+        } catch {
+          // already-exited or detached — fall through
+        }
+      }
       state.contribution = contribution;
       state.status = "spawning";
       state.lastError = null;
       state.subprocess = null;
+      state.pid = null;
       state.nextRequestId = 1;
       state.pendingCalls.clear();
       state.stdoutBuffer = "";
@@ -209,19 +231,41 @@ export class PluginMcpSupervisor {
 
     let resolved: ResolvedMcpServerConfig;
     try {
-      resolved = await resolveContribution(contribution, resolveSettings);
+      resolved = await resolveContribution(contribution, pluginDir, resolveSettings);
     } catch (err) {
-      state.status = "crashed";
-      state.lastError = err instanceof Error ? err.message : String(err);
+      // A concurrent shutdown may have flipped state.status to "stopped"
+      // while we were resolving — don't claim crashed in that case.
+      if (state.status !== "stopped") {
+        state.status = "crashed";
+        state.lastError = formatErrorMessage(err, "MCP supervisor error");
+      }
       return;
     }
+
+    // If a shutdown landed during resolveContribution, abandon the spawn
+    // entirely so we don't strand a fresh subprocess outside the supervisor's
+    // teardown bookkeeping.
+    if (state.status === "stopped") return;
 
     let handle: SpawnHandle;
     try {
       handle = await this.spawner(resolved);
     } catch (err) {
-      state.status = "crashed";
-      state.lastError = err instanceof Error ? err.message : String(err);
+      if (state.status !== "stopped") {
+        state.status = "crashed";
+        state.lastError = formatErrorMessage(err, "MCP supervisor error");
+      }
+      return;
+    }
+    // Same guard after the spawn-await: if a shutdown raced in, kill the
+    // freshly-spawned child immediately rather than registering it as state.
+    if (state.status === "stopped") {
+      try {
+        handle.subprocess.kill();
+      } catch {
+        // best-effort
+      }
+      handle.exit.catch(() => {});
       return;
     }
     const subprocess = handle.subprocess;
@@ -233,6 +277,12 @@ export class PluginMcpSupervisor {
     // processes (and increasingly the main process under strict modes) treat
     // as fatal. See #4372.
     handle.exit.catch(() => {});
+
+    // Swallow async 'error' events on stdin (e.g. EPIPE after the child
+    // crashed). The pending-call rejection paths handle the logical error;
+    // letting the stream's own error event surface unhandled would crash
+    // the utility process under Electron 37+'s strict rejection mode.
+    subprocess.stdin?.on("error", () => {});
 
     this.attachStderrReader(state);
     this.attachStdoutReader(state);
@@ -297,8 +347,13 @@ export class PluginMcpSupervisor {
       state.status = "ready";
       state.lastError = null;
     } catch (err) {
-      state.status = "crashed";
-      state.lastError = err instanceof Error ? err.message : String(err);
+      // A shutdown that lands mid-handshake already set status to "stopped"
+      // and rejected the pending init call. Don't clobber that with "crashed"
+      // — the UI distinction between user-cancelled and crashed matters.
+      if (state.status !== "stopped") {
+        state.status = "crashed";
+        state.lastError = formatErrorMessage(err, "MCP supervisor error");
+      }
       throw err;
     }
   }
@@ -458,12 +513,23 @@ export class PluginMcpSupervisor {
         timer,
       });
     });
-    writeFrame(stdin, {
-      jsonrpc: "2.0" as const,
-      id: requestId,
-      method: "tools/call",
-      params: { name: input.tool, arguments: input.args ?? {} },
-    });
+    try {
+      writeFrame(stdin, {
+        jsonrpc: "2.0" as const,
+        id: requestId,
+        method: "tools/call",
+        params: { name: input.tool, arguments: input.args ?? {} },
+      });
+    } catch (err) {
+      // stdin may have ended between the status check and the write — e.g.
+      // the child crashed in the same tick. Reject the pending call now
+      // rather than waiting 30s for the tool-call timeout.
+      const pending = state.pendingCalls.get(requestId);
+      if (pending) {
+        state.pendingCalls.delete(requestId);
+        pending.reject(plainError("WRITE_FAILED", formatErrorMessage(err, "stdin write failed")));
+      }
+    }
     return promise;
   }
 
@@ -530,12 +596,13 @@ export class PluginMcpSupervisor {
    */
   async restart(input: {
     pluginId: string;
+    pluginDir?: string;
     serverId: string;
     contribution: McpServerContribution;
     resolveSettings: (template: string) => Promise<string>;
   }): Promise<void> {
     await this.shutdownOne(stateKey(input.pluginId, input.serverId));
-    await this.startOne(input.pluginId, input.contribution, input.resolveSettings);
+    await this.startOne(input.pluginId, input.pluginDir, input.contribution, input.resolveSettings);
   }
 
   /** Snapshot every supervised server for the `plugin-mcp:list` IPC. */
@@ -581,6 +648,7 @@ const SETTINGS_TEMPLATE_RE = /\$\{settings:([a-zA-Z0-9._-]+)\}/g;
  */
 async function resolveContribution(
   contribution: McpServerContribution,
+  cwd: string | undefined,
   resolve: (template: string) => Promise<string>
 ): Promise<ResolvedMcpServerConfig> {
   const command = await substitute(contribution.command, resolve);
@@ -589,7 +657,7 @@ async function resolveContribution(
   for (const [key, value] of Object.entries(contribution.env ?? {})) {
     env[key] = await substitute(value, resolve);
   }
-  return { contribution, command, args, env };
+  return { contribution, command, args, env, cwd };
 }
 
 async function substitute(
@@ -597,17 +665,37 @@ async function substitute(
   resolve: (template: string) => Promise<string>
 ): Promise<string> {
   if (!input.includes("${settings:")) return input;
+  // Resolve each unique placeholder once, then do a single global pass per
+  // key. `replace()` would only consume the first occurrence per call, and
+  // if an earlier resolved value happened to itself contain a `${settings:*}`
+  // literal the placeholder substitution would become order-dependent.
   const matches = [...input.matchAll(SETTINGS_TEMPLATE_RE)];
-  let out = input;
+  const unique = new Map<string, string>();
   for (const match of matches) {
-    const value = await resolve(match[1]!);
-    out = out.replace(match[0], value);
+    const key = match[1]!;
+    if (!unique.has(key)) unique.set(key, await resolve(key));
+  }
+  let out = input;
+  for (const [key, value] of unique) {
+    out = out.replaceAll(`\${settings:${key}}`, value);
   }
   return out;
 }
 
 function writeFrame(stdin: NodeJS.WritableStream, payload: unknown): void {
-  // MCP stdio framing is NDJSON — one JSON-RPC 2.0 message per `\n`.
+  // MCP stdio framing is NDJSON — one JSON-RPC 2.0 message per `\n`. Reject
+  // synchronously if the stream has ended so the caller can surface a
+  // structured error instead of waiting for the async 'error' emission.
+  // The `writable` / `writableEnded` properties are defined on every Node
+  // writable stream; the runtime cast keeps the helper signature minimal.
+  const writable = stdin as NodeJS.WritableStream & {
+    writable?: boolean;
+    writableEnded?: boolean;
+    destroyed?: boolean;
+  };
+  if (writable.writableEnded || writable.destroyed || writable.writable === false) {
+    throw new Error("subprocess stdin is closed");
+  }
   stdin.write(`${JSON.stringify(payload)}\n`);
 }
 
@@ -624,6 +712,7 @@ function plainError(code: string, message: string): Error & { code: string } {
 const defaultSpawner: SubprocessSpawner = async (config) => {
   const { execa } = await import("execa");
   const subprocess = execa(config.command, config.args, {
+    cwd: config.cwd,
     env: { ...process.env, ...config.env },
     stdio: ["pipe", "pipe", "pipe"],
     cleanup: true,

--- a/electron/services/PluginMcpSupervisor.ts
+++ b/electron/services/PluginMcpSupervisor.ts
@@ -1,0 +1,669 @@
+import { z } from "zod";
+import {
+  PLUGIN_MCP_STDERR_RING_LINES,
+  type PluginMcpServerInfo,
+  type PluginMcpServerStatus,
+  type PluginMcpStderrResult,
+} from "../../shared/types/ipc/pluginMcp.js";
+import { McpServerContributionSchema } from "../schemas/plugin.js";
+
+type McpServerContribution = z.infer<typeof McpServerContributionSchema>;
+
+/**
+ * Minimal surface of an `execa` subprocess that the supervisor actually
+ * exercises. Declared as an interface so unit tests can hand in a fake duplex
+ * without pulling in execa's full module surface or relying on
+ * `child_process.spawn`. Mirrors the shape of `ExecaSubprocess` at runtime.
+ *
+ * NOTE: this interface intentionally does NOT inherit from `Promise` /
+ * `PromiseLike`. Execa's real subprocess IS a promise (it resolves when the
+ * child exits), but `await this.spawner(...)` would silently follow that
+ * promise all the way to exit if the interface were thenable. Instead the
+ * spawner returns a {@link SpawnHandle} wrapper that exposes the subprocess
+ * plus a separate `exit` promise.
+ */
+interface SupervisedSubprocess {
+  pid: number | undefined;
+  stdin: NodeJS.WritableStream | null;
+  stdout: NodeJS.ReadableStream | null;
+  stderr: NodeJS.ReadableStream | null;
+  kill(): boolean;
+}
+
+/**
+ * Result returned by the spawner. The `subprocess` field is the live handle
+ * the supervisor reads from / writes to; the `exit` promise resolves (or
+ * rejects) when the child process terminates. The wrapper is non-thenable so
+ * that `await spawner(...)` cannot accidentally wait for child-process exit.
+ */
+export interface SpawnHandle {
+  subprocess: SupervisedSubprocess;
+  exit: Promise<unknown>;
+}
+
+export interface ResolvedMcpServerConfig {
+  /** Raw manifest entry, kept for `name` and identity. */
+  contribution: McpServerContribution;
+  /** `command`/`args`/`env` after `${settings:*}` substitution at spawn time. */
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+}
+
+/**
+ * Spawn shim. Injected so unit tests can substitute a controllable duplex.
+ * Production wiring uses `execa` with `cleanup: true`, `windowsHide: true`,
+ * `detached: false` and `stdio: ["pipe", "pipe", "pipe"]`.
+ */
+export type SubprocessSpawner = (
+  config: ResolvedMcpServerConfig
+) => SpawnHandle | Promise<SpawnHandle>;
+
+/**
+ * Process-tree teardown shim. On Windows we shell out to
+ * `taskkill /T /F /PID <pid>` because Windows does not cascade kills and the
+ * supervisor's direct child is often a shell (`npx`, `uvx`, `.bat`) whose
+ * actual MCP server is a grandchild. Injected so tests can assert the
+ * platform-specific tree-kill is invoked without actually shelling out.
+ *
+ * On POSIX a plain `SIGKILL` is sufficient — `execa` runs children with
+ * `detached: false` so the kernel reparents stranded grandchildren to PID 1
+ * only if the immediate child itself was a shell wrapper. The CVE-cited
+ * failure mode is Windows-specific; POSIX-side cleanup is best-effort.
+ */
+export type ProcessTreeKiller = (pid: number) => void | Promise<void>;
+
+interface PendingCall {
+  resolve: (value: unknown) => void;
+  reject: (reason: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+interface SupervisedServerState {
+  pluginId: string;
+  serverId: string;
+  contribution: McpServerContribution;
+  status: PluginMcpServerStatus;
+  pid: number | null;
+  lastError: string | null;
+  stderrRing: string[];
+  /** Total stderr lines emitted since last spawn — may exceed the ring cap. */
+  stderrTotal: number;
+  subprocess: SupervisedSubprocess | null;
+  nextRequestId: number;
+  pendingCalls: Map<number, PendingCall>;
+  /** Resolves when the handshake completes (or rejects on failure). */
+  readyPromise: Promise<void> | null;
+  /** Stdout NDJSON parse buffer carryover across stream chunks. */
+  stdoutBuffer: string;
+}
+
+const HANDSHAKE_TIMEOUT_MS = 15_000;
+const SHUTDOWN_GRACE_MS = 3_000;
+const TOOL_CALL_TIMEOUT_MS = 30_000;
+
+const MCP_PROTOCOL_VERSION = "2025-06-18";
+const CLIENT_INFO = { name: "daintree-plugin-supervisor", version: "1" } as const;
+
+/**
+ * Manages stdio-only MCP subprocesses contributed by plugin manifests.
+ *
+ * One singleton lives in the main process for the lifetime of the app — the
+ * supervisor is not its own `UtilityProcess` (each MCP server is already an
+ * OS subprocess; nesting them inside a utility-process host would add cost
+ * without benefit, see #4748). Plugin activation calls
+ * {@link PluginMcpSupervisor.start} with the resolved manifest entries; plugin
+ * deactivation (and app shutdown) call {@link shutdown}/{@link shutdownAll}.
+ *
+ * Lifecycle invariants:
+ *  - `tools/call` before the handshake completes fails fast with `NOT_READY`
+ *    rather than queueing (mirrors the in-process MCP server's readiness
+ *    contract — see `readinessProbe.ts`).
+ *  - stderr is drained continuously into a bounded per-server ring buffer
+ *    ({@link PLUGIN_MCP_STDERR_RING_LINES}) and never injected into agent
+ *    context. Surfacing it as token-budget input would burn tokens and open a
+ *    prompt-injection vector from third-party binaries.
+ *  - Pre-resolved settings substitutions reach the supervisor; it never reads
+ *    the settings vault directly. Secret rotation triggers a restart via
+ *    `PluginService`.
+ */
+export class PluginMcpSupervisor {
+  private readonly states = new Map<string, SupervisedServerState>();
+  private readonly spawner: SubprocessSpawner;
+  private readonly killTree: ProcessTreeKiller;
+
+  constructor(options?: { spawner?: SubprocessSpawner; killTree?: ProcessTreeKiller }) {
+    this.spawner = options?.spawner ?? defaultSpawner;
+    this.killTree = options?.killTree ?? defaultProcessTreeKiller;
+  }
+
+  /**
+   * Eagerly spawn every server contributed by `pluginId`. Resolves once every
+   * server has either reached `ready` or transitioned to `crashed` — never
+   * rejects, so a single failing server can't strand plugin activation.
+   *
+   * Idempotent per `(pluginId, serverId)`: a subsequent call against an
+   * already-running server is a no-op. Use {@link restart} to replace a
+   * running server (e.g. after secret rotation).
+   */
+  async start(input: {
+    pluginId: string;
+    contributions: McpServerContribution[];
+    resolveSettings: (template: string) => Promise<string>;
+  }): Promise<void> {
+    const { pluginId, contributions, resolveSettings } = input;
+    if (contributions.length === 0) return;
+    await Promise.all(
+      contributions.map((contribution) =>
+        this.startOne(pluginId, contribution, resolveSettings).catch((err) => {
+          // startOne records the failure into state.lastError; the catch here
+          // exists so a thrown spawn (e.g. unresolved settings template) can't
+          // reject the outer Promise.all and abort plugin activation.
+          console.warn(
+            `[PluginMcpSupervisor] Failed to start "${pluginId}/${contribution.id}":`,
+            err
+          );
+        })
+      )
+    );
+  }
+
+  private async startOne(
+    pluginId: string,
+    contribution: McpServerContribution,
+    resolveSettings: (template: string) => Promise<string>
+  ): Promise<void> {
+    const key = stateKey(pluginId, contribution.id);
+    const existing = this.states.get(key);
+    if (existing && (existing.status === "spawning" || existing.status === "ready")) return;
+
+    const state: SupervisedServerState = existing ?? {
+      pluginId,
+      serverId: contribution.id,
+      contribution,
+      status: "spawning",
+      pid: null,
+      lastError: null,
+      stderrRing: [],
+      stderrTotal: 0,
+      subprocess: null,
+      nextRequestId: 1,
+      pendingCalls: new Map(),
+      readyPromise: null,
+      stdoutBuffer: "",
+    };
+    // Reset transient fields for a restart of a previously-stopped/crashed entry.
+    if (existing) {
+      state.contribution = contribution;
+      state.status = "spawning";
+      state.lastError = null;
+      state.subprocess = null;
+      state.nextRequestId = 1;
+      state.pendingCalls.clear();
+      state.stdoutBuffer = "";
+      // Restart marker so the log viewer can tell pre-restart and post-restart
+      // output apart inside the bounded ring without a separate UI mode.
+      this.appendStderrLine(state, `--- restarted at ${new Date().toISOString()} ---`);
+    }
+    this.states.set(key, state);
+
+    let resolved: ResolvedMcpServerConfig;
+    try {
+      resolved = await resolveContribution(contribution, resolveSettings);
+    } catch (err) {
+      state.status = "crashed";
+      state.lastError = err instanceof Error ? err.message : String(err);
+      return;
+    }
+
+    let handle: SpawnHandle;
+    try {
+      handle = await this.spawner(resolved);
+    } catch (err) {
+      state.status = "crashed";
+      state.lastError = err instanceof Error ? err.message : String(err);
+      return;
+    }
+    const subprocess = handle.subprocess;
+    state.subprocess = subprocess;
+    state.pid = subprocess.pid ?? null;
+    // Execa's subprocess promise rejects with the kill error when the child
+    // exits non-zero or is killed. Without a `.catch` attached at spawn time
+    // it surfaces as an unhandled rejection, which Electron 37+ utility
+    // processes (and increasingly the main process under strict modes) treat
+    // as fatal. See #4372.
+    handle.exit.catch(() => {});
+
+    this.attachStderrReader(state);
+    this.attachStdoutReader(state);
+
+    const handshakePromise = this.runHandshake(state);
+    state.readyPromise = handshakePromise;
+    try {
+      await handshakePromise;
+    } catch {
+      // runHandshake records the failure into state.lastError already.
+    }
+  }
+
+  private async runHandshake(state: SupervisedServerState): Promise<void> {
+    const stdin = state.subprocess?.stdin;
+    if (!stdin) {
+      const err = new Error("subprocess has no stdin stream");
+      state.status = "crashed";
+      state.lastError = err.message;
+      throw err;
+    }
+
+    const initId = state.nextRequestId++;
+    const initialize = {
+      jsonrpc: "2.0" as const,
+      id: initId,
+      method: "initialize",
+      params: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: CLIENT_INFO,
+      },
+    };
+
+    const responsePromise = new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        state.pendingCalls.delete(initId);
+        reject(new Error(`MCP server "${state.contribution.name}" handshake timed out`));
+      }, HANDSHAKE_TIMEOUT_MS);
+      state.pendingCalls.set(initId, {
+        resolve: (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        reject: (reason) => {
+          clearTimeout(timer);
+          reject(reason);
+        },
+        timer,
+      });
+    });
+
+    try {
+      writeFrame(stdin, initialize);
+      await responsePromise;
+      // notifications/initialized has no id; the server does not respond.
+      writeFrame(stdin, {
+        jsonrpc: "2.0" as const,
+        method: "notifications/initialized",
+        params: {},
+      });
+      state.status = "ready";
+      state.lastError = null;
+    } catch (err) {
+      state.status = "crashed";
+      state.lastError = err instanceof Error ? err.message : String(err);
+      throw err;
+    }
+  }
+
+  private attachStdoutReader(state: SupervisedServerState): void {
+    const subprocess = state.subprocess;
+    const stream = subprocess?.stdout;
+    if (!subprocess || !stream) return;
+    stream.setEncoding("utf-8");
+    stream.on("data", (chunk: string) => {
+      // Ignore data from a stale subprocess after a restart. Without the
+      // identity check, the old stream's tail-end emit would parse into the
+      // new handshake's request-id space and resolve the wrong pending call.
+      if (state.subprocess !== subprocess) return;
+      state.stdoutBuffer += chunk;
+      // MCP stdio framing is newline-delimited JSON (NDJSON), not Content-Length
+      // framed like LSP. Each `\n` terminates one JSON-RPC 2.0 message.
+      for (;;) {
+        const newlineIdx = state.stdoutBuffer.indexOf("\n");
+        if (newlineIdx < 0) break;
+        const line = state.stdoutBuffer.slice(0, newlineIdx).trim();
+        state.stdoutBuffer = state.stdoutBuffer.slice(newlineIdx + 1);
+        if (line.length === 0) continue;
+        this.dispatchStdoutMessage(state, line);
+      }
+    });
+    stream.on("close", () => {
+      // The close listener for a killed-and-replaced subprocess can fire
+      // after the new spawn has installed a fresh handshake pending call.
+      // Bind by identity so a stale close doesn't reject the new call.
+      if (state.subprocess !== subprocess) return;
+      this.handleSubprocessExit(state);
+    });
+  }
+
+  private dispatchStdoutMessage(state: SupervisedServerState, raw: string): void {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      // Server emitted non-JSON on stdout. The spec forbids this, but a
+      // misbehaving server shouldn't crash the supervisor; record it for the
+      // log viewer alongside stderr.
+      this.appendStderrLine(state, `[stdout-non-json] ${raw}`);
+      return;
+    }
+    if (!parsed || typeof parsed !== "object") return;
+    const message = parsed as { id?: unknown; result?: unknown; error?: unknown };
+    if (typeof message.id === "number") {
+      const pending = state.pendingCalls.get(message.id);
+      if (!pending) return;
+      state.pendingCalls.delete(message.id);
+      if (message.error !== undefined) {
+        const errObj = message.error as { message?: unknown; code?: unknown };
+        const msg =
+          typeof errObj.message === "string"
+            ? errObj.message
+            : `MCP error code ${String(errObj.code)}`;
+        pending.reject(new Error(msg));
+      } else {
+        pending.resolve(message.result);
+      }
+    }
+    // Notifications (no id) are ignored — we don't subscribe to any.
+  }
+
+  private attachStderrReader(state: SupervisedServerState): void {
+    const subprocess = state.subprocess;
+    const stream = subprocess?.stderr;
+    if (!subprocess || !stream) return;
+    stream.setEncoding("utf-8");
+    let carry = "";
+    stream.on("data", (chunk: string) => {
+      if (state.subprocess !== subprocess) return;
+      carry += chunk;
+      for (;;) {
+        const newlineIdx = carry.indexOf("\n");
+        if (newlineIdx < 0) break;
+        const line = carry.slice(0, newlineIdx);
+        carry = carry.slice(newlineIdx + 1);
+        this.appendStderrLine(state, line);
+      }
+    });
+    stream.on("close", () => {
+      if (state.subprocess !== subprocess) return;
+      if (carry.length > 0) this.appendStderrLine(state, carry);
+    });
+  }
+
+  private appendStderrLine(state: SupervisedServerState, line: string): void {
+    state.stderrRing.push(line);
+    state.stderrTotal++;
+    if (state.stderrRing.length > PLUGIN_MCP_STDERR_RING_LINES) {
+      state.stderrRing.splice(0, state.stderrRing.length - PLUGIN_MCP_STDERR_RING_LINES);
+    }
+  }
+
+  private handleSubprocessExit(state: SupervisedServerState): void {
+    if (state.status === "stopped") return;
+    if (state.status === "spawning" || state.status === "ready") {
+      state.status = "crashed";
+      if (!state.lastError) state.lastError = "MCP server exited unexpectedly";
+    }
+    state.pid = null;
+    state.subprocess = null;
+    for (const [id, pending] of state.pendingCalls) {
+      state.pendingCalls.delete(id);
+      pending.reject(new Error(state.lastError ?? "MCP server exited"));
+    }
+  }
+
+  /**
+   * Dispatch a `tools/call` against a supervised server. Rejects with a
+   * `NOT_READY` error if the handshake hasn't completed — the supervisor does
+   * not queue pre-ready calls because there is no upper bound on how long a
+   * misbehaving server might take to settle, and callers prefer fast failure
+   * over indefinite waiting.
+   */
+  async callTool(input: {
+    pluginId: string;
+    serverId: string;
+    tool: string;
+    args?: Record<string, unknown>;
+  }): Promise<unknown> {
+    const state = this.states.get(stateKey(input.pluginId, input.serverId));
+    if (!state) {
+      throw plainError(
+        "NOT_FOUND",
+        `MCP server "${input.pluginId}/${input.serverId}" is not registered`
+      );
+    }
+    if (state.status !== "ready") {
+      throw plainError(
+        "NOT_READY",
+        `MCP server "${input.pluginId}/${input.serverId}" is ${state.status}, not ready`
+      );
+    }
+    const stdin = state.subprocess?.stdin;
+    if (!stdin) {
+      throw plainError("NOT_READY", "subprocess has no stdin stream");
+    }
+    const requestId = state.nextRequestId++;
+    const promise = new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        state.pendingCalls.delete(requestId);
+        reject(plainError("TIMEOUT", `tools/call "${input.tool}" timed out`));
+      }, TOOL_CALL_TIMEOUT_MS);
+      state.pendingCalls.set(requestId, {
+        resolve: (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        reject: (reason) => {
+          clearTimeout(timer);
+          reject(reason);
+        },
+        timer,
+      });
+    });
+    writeFrame(stdin, {
+      jsonrpc: "2.0" as const,
+      id: requestId,
+      method: "tools/call",
+      params: { name: input.tool, arguments: input.args ?? {} },
+    });
+    return promise;
+  }
+
+  /**
+   * Tear down every supervised server owned by `pluginId`. SIGTERM the
+   * subprocess, wait briefly, then escalate to a process-tree kill on
+   * Windows. Resolves once every owned subprocess has been signalled — does
+   * not wait synchronously for the exit because Electron's app shutdown timer
+   * already bounds the overall shutdown window.
+   */
+  async shutdown(input: { pluginId: string }): Promise<void> {
+    const ownedKeys = [...this.states.keys()].filter((k) => k.startsWith(`${input.pluginId} `));
+    await Promise.all(ownedKeys.map((key) => this.shutdownOne(key)));
+  }
+
+  private async shutdownOne(key: string): Promise<void> {
+    const state = this.states.get(key);
+    if (!state) return;
+    state.status = "stopped";
+    const subprocess = state.subprocess;
+    if (!subprocess) return;
+    const pid = state.pid;
+
+    // Reject in-flight pending calls before we kill the process so callers
+    // don't sit on a 30s tool-call timeout while teardown races.
+    for (const [id, pending] of state.pendingCalls) {
+      state.pendingCalls.delete(id);
+      pending.reject(plainError("STOPPED", "MCP server shutting down"));
+    }
+
+    // Call .kill() with NO arguments. Passing an explicit signal disables
+    // execa's `forceKillAfterDelay` escalation in v9.
+    try {
+      subprocess.kill();
+    } catch {
+      // already-exited or detached — fall through to tree-kill on Windows.
+    }
+
+    if (pid !== null && process.platform === "win32") {
+      // Even with execa cleanup:true, a hard SIGKILL from outside (parent
+      // crash, watchdog) leaves grandchildren stranded on Windows. Always
+      // shell out after the grace window.
+      setTimeout(() => {
+        Promise.resolve(this.killTree(pid)).catch(() => {});
+      }, SHUTDOWN_GRACE_MS);
+    }
+
+    state.subprocess = null;
+    state.pid = null;
+  }
+
+  /** Tear down every server owned by every plugin. App-shutdown entry point. */
+  async shutdownAll(): Promise<void> {
+    const pluginIds = new Set<string>();
+    for (const state of this.states.values()) pluginIds.add(state.pluginId);
+    await Promise.all([...pluginIds].map((pluginId) => this.shutdown({ pluginId })));
+  }
+
+  /**
+   * Force a restart of a single server. Used by `PluginService` when a
+   * settings entry referenced by the manifest changes — the new value is
+   * folded into the env at spawn time, so the existing subprocess has to
+   * exit and respawn for the change to take effect.
+   */
+  async restart(input: {
+    pluginId: string;
+    serverId: string;
+    contribution: McpServerContribution;
+    resolveSettings: (template: string) => Promise<string>;
+  }): Promise<void> {
+    await this.shutdownOne(stateKey(input.pluginId, input.serverId));
+    await this.startOne(input.pluginId, input.contribution, input.resolveSettings);
+  }
+
+  /** Snapshot every supervised server for the `plugin-mcp:list` IPC. */
+  list(): PluginMcpServerInfo[] {
+    return [...this.states.values()].map((state) => this.toInfo(state));
+  }
+
+  /** Per-server stderr fetch for the `plugin-mcp:get-stderr` IPC. */
+  getStderr(pluginId: string, serverId: string): PluginMcpStderrResult {
+    const state = this.states.get(stateKey(pluginId, serverId));
+    if (!state) {
+      return { pluginId, serverId, lines: [], totalLines: 0 };
+    }
+    return {
+      pluginId,
+      serverId,
+      lines: [...state.stderrRing],
+      totalLines: state.stderrTotal,
+    };
+  }
+
+  private toInfo(state: SupervisedServerState): PluginMcpServerInfo {
+    return {
+      pluginId: state.pluginId,
+      serverId: state.serverId,
+      name: state.contribution.name,
+      status: state.status,
+      pid: state.pid,
+      lastError: state.lastError,
+      stderrLineCount: state.stderrRing.length,
+    };
+  }
+}
+
+const SETTINGS_TEMPLATE_RE = /\$\{settings:([a-zA-Z0-9._-]+)\}/g;
+
+/**
+ * One-shot `${settings:settingId}` substitution applied to `command`, each
+ * `args` entry, and each `env` value. The supervisor is handed a resolver
+ * closure by `PluginService` rather than reading the settings vault directly
+ * — the supervisor never knows about the vault's storage layout, and secrets
+ * stay scoped to the plugin host that owns them.
+ */
+async function resolveContribution(
+  contribution: McpServerContribution,
+  resolve: (template: string) => Promise<string>
+): Promise<ResolvedMcpServerConfig> {
+  const command = await substitute(contribution.command, resolve);
+  const args = await Promise.all((contribution.args ?? []).map((arg) => substitute(arg, resolve)));
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(contribution.env ?? {})) {
+    env[key] = await substitute(value, resolve);
+  }
+  return { contribution, command, args, env };
+}
+
+async function substitute(
+  input: string,
+  resolve: (template: string) => Promise<string>
+): Promise<string> {
+  if (!input.includes("${settings:")) return input;
+  const matches = [...input.matchAll(SETTINGS_TEMPLATE_RE)];
+  let out = input;
+  for (const match of matches) {
+    const value = await resolve(match[1]!);
+    out = out.replace(match[0], value);
+  }
+  return out;
+}
+
+function writeFrame(stdin: NodeJS.WritableStream, payload: unknown): void {
+  // MCP stdio framing is NDJSON — one JSON-RPC 2.0 message per `\n`.
+  stdin.write(`${JSON.stringify(payload)}\n`);
+}
+
+function stateKey(pluginId: string, serverId: string): string {
+  return `${pluginId} ${serverId}`;
+}
+
+function plainError(code: string, message: string): Error & { code: string } {
+  const err = new Error(message) as Error & { code: string };
+  err.code = code;
+  return err;
+}
+
+const defaultSpawner: SubprocessSpawner = async (config) => {
+  const { execa } = await import("execa");
+  const subprocess = execa(config.command, config.args, {
+    env: { ...process.env, ...config.env },
+    stdio: ["pipe", "pipe", "pipe"],
+    cleanup: true,
+    windowsHide: true,
+    detached: false,
+    forceKillAfterDelay: SHUTDOWN_GRACE_MS,
+    reject: false,
+  });
+  return {
+    subprocess: subprocess as unknown as SupervisedSubprocess,
+    // execa subprocesses are also Promises that resolve / reject with the
+    // child's exit result. Expose that separately so the supervisor can
+    // attach a `.catch` for unhandled-rejection safety without follow-await
+    // semantics polluting the spawn path.
+    exit: subprocess as unknown as Promise<unknown>,
+  };
+};
+
+const defaultProcessTreeKiller: ProcessTreeKiller = async (pid) => {
+  if (process.platform !== "win32") return;
+  const { execa } = await import("execa");
+  try {
+    await execa("taskkill", ["/T", "/F", "/PID", String(pid)], { reject: false });
+  } catch {
+    // best-effort — the process may have already exited cleanly
+  }
+};
+
+/**
+ * Singleton accessor. Lifecycle wiring (`PluginService` activation,
+ * `unloadPlugin`, `electron/lifecycle/shutdown.ts`) imports this rather than
+ * threading the instance through DI — one supervisor per app session.
+ */
+let singleton: PluginMcpSupervisor | null = null;
+export function getPluginMcpSupervisor(): PluginMcpSupervisor {
+  if (singleton === null) singleton = new PluginMcpSupervisor();
+  return singleton;
+}
+
+/** Test-only: replace the singleton with one wired to controllable shims. */
+export function __setPluginMcpSupervisorForTests(instance: PluginMcpSupervisor | null): void {
+  singleton = instance;
+}

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -28,6 +28,7 @@ interface AjvInstance {
   compile(schema: Record<string, unknown>): ValidateFn;
 }
 import { getPluginManifestSchema, PluginToastOptionsSchema } from "../schemas/plugin.js";
+import { getPluginMcpSupervisor } from "./PluginMcpSupervisor.js";
 import type {
   PluginManifest,
   PluginIpcHandler,
@@ -850,9 +851,20 @@ export class PluginService {
     }
 
     if (manifest.contributes.experimental_mcpServers.length > 0) {
-      console.warn(
-        `[PluginService] Plugin "${manifest.name}": contributes.experimental_mcpServers is not yet implemented and will be ignored`
-      );
+      const contributions = manifest.contributes.experimental_mcpServers;
+      const pluginId = manifest.name;
+      // Eager spawn at activation time so readiness is observable before any
+      // tools/call dispatch. Errors are absorbed inside start() — a single
+      // failing MCP server can't strand plugin activation.
+      void getPluginMcpSupervisor()
+        .start({
+          pluginId,
+          contributions,
+          resolveSettings: (settingId) => this.resolveSettingTemplate(pluginId, settingId),
+        })
+        .catch((err) => {
+          console.warn(`[PluginService] Plugin "${pluginId}": MCP supervisor start failed:`, err);
+        });
     }
 
     if (manifest.contributes.forgeProviders.length > 0) {
@@ -2239,6 +2251,16 @@ export class PluginService {
       this.clearPluginSettingsState(pluginId)
     );
 
+    // Tear down any MCP servers contributed by this plugin (#9233). Best-effort
+    // — a failing teardown is logged but cannot block the unload chain.
+    runUnloadStep(pluginId, "shutdownMcpServers", () => {
+      void getPluginMcpSupervisor()
+        .shutdown({ pluginId })
+        .catch((err) => {
+          console.warn(`[PluginService] MCP supervisor shutdown for "${pluginId}" threw:`, err);
+        });
+    });
+
     // Drop the load-time-error marker (#9281) so a reload with a fixed
     // manifest can successfully clear `loadError` on next activation.
     this.pluginsWithLoadTimeErrors.delete(pluginId);
@@ -2272,6 +2294,45 @@ export class PluginService {
       } catch (err) {
         console.error(`[PluginService] Event cleanup for "${pluginId}" threw during unload:`, err);
       }
+    }
+  }
+
+  /**
+   * Look up a single `contributes.experimental_mcpServers` entry by id. Used by
+   * the `plugin-mcp:restart` IPC handler to feed the supervisor a fresh
+   * contribution (with re-resolved `${settings:*}` substitutions) on each
+   * restart.
+   */
+  findMcpServerContribution(
+    pluginId: string,
+    serverId: string
+  ): PluginManifest["contributes"]["experimental_mcpServers"][number] | undefined {
+    const plugin = this.plugins.get(pluginId);
+    if (!plugin) return undefined;
+    return plugin.manifest.contributes.experimental_mcpServers.find((c) => c.id === serverId);
+  }
+
+  /**
+   * Resolve a `${settings:<id>}` template by reading the named user-scope
+   * setting and stringifying the value. Booleans and numbers become their
+   * JSON representation; objects/arrays become JSON-encoded strings. An
+   * undefined or missing setting resolves to the empty string so the
+   * substituted command remains a valid argv entry rather than a literal
+   * `"undefined"`.
+   */
+  async resolveSettingTemplate(pluginId: string, settingId: string): Promise<string> {
+    const filePath = this.resolveSettingsFilePath(pluginId, "user");
+    if (!filePath) return "";
+    const value = await this.getOrCreateSettingsStore(pluginId, "user", filePath).get<unknown>(
+      settingId
+    );
+    if (value === undefined || value === null) return "";
+    if (typeof value === "string") return value;
+    if (typeof value === "number" || typeof value === "boolean") return String(value);
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return "";
     }
   }
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -859,6 +859,7 @@ export class PluginService {
       void getPluginMcpSupervisor()
         .start({
           pluginId,
+          pluginDir,
           contributions,
           resolveSettings: (settingId) => this.resolveSettingTemplate(pluginId, settingId),
         })
@@ -2298,18 +2299,28 @@ export class PluginService {
   }
 
   /**
-   * Look up a single `contributes.experimental_mcpServers` entry by id. Used by
-   * the `plugin-mcp:restart` IPC handler to feed the supervisor a fresh
+   * Look up a single `contributes.experimental_mcpServers` entry by id along
+   * with the plugin's resolved on-disk directory. Used by the
+   * `plugin-mcp:restart` IPC handler to feed the supervisor a fresh
    * contribution (with re-resolved `${settings:*}` substitutions) on each
-   * restart.
+   * restart, plus the cwd the child process should anchor against.
    */
   findMcpServerContribution(
     pluginId: string,
     serverId: string
-  ): PluginManifest["contributes"]["experimental_mcpServers"][number] | undefined {
+  ):
+    | {
+        contribution: PluginManifest["contributes"]["experimental_mcpServers"][number];
+        pluginDir: string;
+      }
+    | undefined {
     const plugin = this.plugins.get(pluginId);
     if (!plugin) return undefined;
-    return plugin.manifest.contributes.experimental_mcpServers.find((c) => c.id === serverId);
+    const contribution = plugin.manifest.contributes.experimental_mcpServers.find(
+      (c) => c.id === serverId
+    );
+    if (!contribution) return undefined;
+    return { contribution, pluginDir: plugin.dir };
   }
 
   /**

--- a/electron/services/__tests__/PluginMcpSupervisor.test.ts
+++ b/electron/services/__tests__/PluginMcpSupervisor.test.ts
@@ -447,4 +447,153 @@ describe("PluginMcpSupervisor (issue #9233)", () => {
     expect(info?.status).toBe("crashed");
     expect(info?.lastError).toContain("vault unavailable");
   });
+
+  it("leaves status as 'stopped' when shutdown lands mid-handshake", async () => {
+    const fake = makeFakeSubprocess();
+    const supervisor = new PluginMcpSupervisor({
+      spawner: () => fake.handle,
+      killTree: () => {},
+    });
+    const startPromise = supervisor.start({
+      pluginId: "acme.demo",
+      contributions: [{ id: "linear", name: "Linear", command: "node" }],
+      resolveSettings: async () => "",
+    });
+    // Wait for the initialize frame to be on the wire, then shutdown before
+    // the server has a chance to answer.
+    await fake.waitForStdinCount(1);
+    await supervisor.shutdown({ pluginId: "acme.demo" });
+    await startPromise;
+
+    const [info] = supervisor.list();
+    expect(info?.status).toBe("stopped");
+    // No "crashed" leak on lastError either.
+    expect(info?.lastError).toBeNull();
+  });
+
+  it("kills the previous subprocess when start() is called against a crashed entry", async () => {
+    // Models the real leak: the handshake times out but the child process is
+    // still alive (its streams are open). The state transitions to "crashed"
+    // with state.subprocess still set. A subsequent start() must kill that
+    // lingering subprocess before adopting the new one.
+    vi.useFakeTimers();
+    try {
+      const fakes = [makeFakeSubprocess({ pid: 11 }), makeFakeSubprocess({ pid: 22 })];
+      let nth = 0;
+      const supervisor = new PluginMcpSupervisor({
+        spawner: () => fakes[nth++]!.handle,
+        killTree: () => {},
+      });
+      const contribution = { id: "linear", name: "Linear", command: "node" };
+      const start1 = supervisor.start({
+        pluginId: "acme.demo",
+        contributions: [contribution],
+        resolveSettings: async () => "",
+      });
+      // Let the spawn + handshake-write microtasks settle, then advance past
+      // the 15s handshake timeout so runHandshake's catch flips to "crashed"
+      // while the (fake) subprocess is still live.
+      await vi.advanceTimersByTimeAsync(20_000);
+      await start1;
+      expect(supervisor.list()[0]?.status).toBe("crashed");
+      expect(fakes[0]!.killed).toBe(false);
+
+      vi.useRealTimers();
+      const start2 = supervisor.start({
+        pluginId: "acme.demo",
+        contributions: [contribution],
+        resolveSettings: async () => "",
+      });
+      await fakes[1]!.waitForStdinCount(1);
+      fakes[1]!.answerInitialize();
+      await start2;
+
+      expect(fakes[0]!.killed).toBe(true);
+      expect(supervisor.list()[0]?.status).toBe("ready");
+      expect(supervisor.list()[0]?.pid).toBe(22);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("substitutes duplicate ${settings:*} occurrences across command/args/env", async () => {
+    const fake = makeFakeSubprocess();
+    const seen: Array<{ command: string; args: string[]; env: Record<string, string> }> = [];
+    const supervisor = new PluginMcpSupervisor({
+      spawner: (config) => {
+        seen.push({ command: config.command, args: config.args, env: config.env });
+        return fake.handle;
+      },
+      killTree: () => {},
+    });
+    const startPromise = supervisor.start({
+      pluginId: "acme.demo",
+      contributions: [
+        {
+          id: "dup",
+          name: "Dup",
+          command: "${settings:bin}",
+          args: ["${settings:bin}", "--token=${settings:tok}", "--also=${settings:tok}"],
+          env: { ONE: "${settings:tok}", TWO: "${settings:tok}" },
+        },
+      ],
+      resolveSettings: async (settingId) => (settingId === "tok" ? "abc" : "/bin/node"),
+    });
+    await fake.waitForStdinCount(1);
+    fake.answerInitialize();
+    await startPromise;
+
+    expect(seen[0]!.command).toBe("/bin/node");
+    expect(seen[0]!.args).toEqual(["/bin/node", "--token=abc", "--also=abc"]);
+    expect(seen[0]!.env).toEqual({ ONE: "abc", TWO: "abc" });
+  });
+
+  it("forwards pluginDir as the spawner cwd", async () => {
+    const fake = makeFakeSubprocess();
+    let seenCwd: string | undefined;
+    const supervisor = new PluginMcpSupervisor({
+      spawner: (config) => {
+        seenCwd = config.cwd;
+        return fake.handle;
+      },
+      killTree: () => {},
+    });
+    const startPromise = supervisor.start({
+      pluginId: "acme.demo",
+      pluginDir: "/plugins/acme.demo",
+      contributions: [{ id: "linear", name: "Linear", command: "./dist/server.js" }],
+      resolveSettings: async () => "",
+    });
+    await fake.waitForStdinCount(1);
+    fake.answerInitialize();
+    await startPromise;
+
+    expect(seenCwd).toBe("/plugins/acme.demo");
+  });
+
+  it("rejects an in-flight callTool with WRITE_FAILED when stdin is closed", async () => {
+    const fake = makeFakeSubprocess();
+    const supervisor = new PluginMcpSupervisor({
+      spawner: () => fake.handle,
+      killTree: () => {},
+    });
+    const startPromise = supervisor.start({
+      pluginId: "acme.demo",
+      contributions: [{ id: "linear", name: "Linear", command: "node" }],
+      resolveSettings: async () => "",
+    });
+    await fake.waitForStdinCount(1);
+    fake.answerInitialize();
+    await startPromise;
+
+    // Close stdin so the next write throws synchronously.
+    fake.subprocess.stdin.end();
+    const callPromise = supervisor.callTool({
+      pluginId: "acme.demo",
+      serverId: "linear",
+      tool: "linear.getIssue",
+    });
+    callPromise.catch(() => {});
+    await expect(callPromise).rejects.toMatchObject({ code: "WRITE_FAILED" });
+  });
 });

--- a/electron/services/__tests__/PluginMcpSupervisor.test.ts
+++ b/electron/services/__tests__/PluginMcpSupervisor.test.ts
@@ -1,0 +1,450 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PassThrough } from "node:stream";
+import { PluginMcpSupervisor } from "../PluginMcpSupervisor.js";
+import { PLUGIN_MCP_STDERR_RING_LINES } from "../../../shared/types/ipc/pluginMcp.js";
+
+async function flushMicrotasks(): Promise<void> {
+  await new Promise((r) => setImmediate(r));
+}
+
+/**
+ * Fake stdio MCP server. The supervisor talks to it via writable stdin and
+ * readable stdout/stderr just like a real execa subprocess; tests drive
+ * server-side behavior by writing into the stdout passthrough.
+ */
+function makeFakeSubprocess(opts?: { pid?: number }) {
+  const stdin = new PassThrough();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  let killed = false;
+
+  const stdinLines: string[] = [];
+  let stdinBuffer = "";
+  let stdinResolvers: Array<() => void> = [];
+  stdin.on("data", (chunk: Buffer) => {
+    stdinBuffer += chunk.toString("utf-8");
+    for (;;) {
+      const i = stdinBuffer.indexOf("\n");
+      if (i < 0) break;
+      stdinLines.push(stdinBuffer.slice(0, i));
+      stdinBuffer = stdinBuffer.slice(i + 1);
+    }
+    const resolvers = stdinResolvers;
+    stdinResolvers = [];
+    for (const r of resolvers) r();
+  });
+
+  let exitResolve!: () => void;
+  const exitPromise = new Promise<void>((resolve) => {
+    exitResolve = resolve;
+  });
+
+  const subprocess = {
+    pid: opts?.pid ?? 12345,
+    stdin,
+    stdout,
+    stderr,
+    kill() {
+      if (killed) return true;
+      killed = true;
+      stdout.end();
+      stderr.end();
+      exitResolve();
+      return true;
+    },
+  };
+  const handle = { subprocess, exit: exitPromise as Promise<unknown> };
+
+  async function waitForStdinCount(target: number): Promise<void> {
+    while (stdinLines.length < target) {
+      await new Promise<void>((r) => {
+        stdinResolvers.push(r);
+      });
+    }
+  }
+
+  function answerInitialize(): void {
+    stdout.write(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { protocolVersion: "2025-06-18", capabilities: {}, serverInfo: {} },
+      }) + "\n"
+    );
+  }
+
+  function answerLastCall(value: unknown): void {
+    const last = stdinLines.at(-1);
+    if (!last) return;
+    const parsed = JSON.parse(last) as { id?: number };
+    if (typeof parsed.id !== "number") return;
+    stdout.write(JSON.stringify({ jsonrpc: "2.0", id: parsed.id, result: value }) + "\n");
+  }
+
+  function answerLastCallWithError(message: string): void {
+    const last = stdinLines.at(-1);
+    if (!last) return;
+    const parsed = JSON.parse(last) as { id?: number };
+    if (typeof parsed.id !== "number") return;
+    stdout.write(
+      JSON.stringify({ jsonrpc: "2.0", id: parsed.id, error: { code: -32000, message } }) + "\n"
+    );
+  }
+
+  function readStdinLines(): string[] {
+    return [...stdinLines];
+  }
+
+  return {
+    subprocess,
+    handle,
+    waitForStdinCount,
+    answerInitialize,
+    answerLastCall,
+    answerLastCallWithError,
+    readStdinLines,
+    emitStderr(line: string) {
+      stderr.write(line);
+    },
+    closeStdout() {
+      stdout.end();
+    },
+    get killed() {
+      return killed;
+    },
+  };
+}
+
+describe("PluginMcpSupervisor (issue #9233)", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("completes the initialize/initialized handshake and reaches ready", async () => {
+    const fake = makeFakeSubprocess();
+    const supervisor = new PluginMcpSupervisor({
+      spawner: () => fake.handle,
+      killTree: () => {},
+    });
+    const startPromise = supervisor.start({
+      pluginId: "acme.demo",
+      contributions: [{ id: "linear", name: "Linear", command: "node" }],
+      resolveSettings: async () => "",
+    });
+    await fake.waitForStdinCount(1);
+    fake.answerInitialize();
+    await startPromise;
+
+    const lines = fake.readStdinLines();
+    expect(lines).toHaveLength(2);
+    const initialize = JSON.parse(lines[0]!) as Record<string, unknown>;
+    const notification = JSON.parse(lines[1]!) as Record<string, unknown>;
+    expect(initialize.method).toBe("initialize");
+    expect(initialize.id).toBe(1);
+    expect(notification.method).toBe("notifications/initialized");
+    expect(notification).not.toHaveProperty("id");
+
+    const [info] = supervisor.list();
+    expect(info?.status).toBe("ready");
+    expect(info?.lastError).toBeNull();
+    expect(info?.pid).toBe(12345);
+  });
+
+  it("rejects tools/call before the server reaches ready with NOT_READY", async () => {
+    const fake = makeFakeSubprocess();
+    const supervisor = new PluginMcpSupervisor({
+      spawner: () => fake.handle,
+      killTree: () => {},
+    });
+    void supervisor.start({
+      pluginId: "acme.demo",
+      contributions: [{ id: "linear", name: "Linear", command: "node" }],
+      resolveSettings: async () => "",
+    });
+    // Wait until handshake is at least in flight (initialize on stdin) — at
+    // which point the server is "spawning", not "ready".
+    await fake.waitForStdinCount(1);
+
+    await expect(
+      supervisor.callTool({
+        pluginId: "acme.demo",
+        serverId: "linear",
+        tool: "linear.getIssue",
+      })
+    ).rejects.toMatchObject({ code: "NOT_READY" });
+  });
+
+  it("routes tools/call results back to the caller", async () => {
+    const fake = makeFakeSubprocess();
+    const supervisor = new PluginMcpSupervisor({
+      spawner: () => fake.handle,
+      killTree: () => {},
+    });
+    const startPromise = supervisor.start({
+      pluginId: "acme.demo",
+      contributions: [{ id: "linear", name: "Linear", command: "node" }],
+      resolveSettings: async () => "",
+    });
+    await fake.waitForStdinCount(1);
+    fake.answerInitialize();
+    await startPromise;
+
+    const callPromise = supervisor.callTool({
+      pluginId: "acme.demo",
+      serverId: "linear",
+      tool: "linear.getIssue",
+      args: { id: "ENG-1" },
+    });
+    // initialize + notifications/initialized + tools/call = 3 lines.
+    await fake.waitForStdinCount(3);
+    fake.answerLastCall({ title: "An issue" });
+    await expect(callPromise).resolves.toEqual({ title: "An issue" });
+  });
+
+  it("propagates server-reported tool errors as a rejected callTool", async () => {
+    const fake = makeFakeSubprocess();
+    const supervisor = new PluginMcpSupervisor({
+      spawner: () => fake.handle,
+      killTree: () => {},
+    });
+    const startPromise = supervisor.start({
+      pluginId: "acme.demo",
+      contributions: [{ id: "linear", name: "Linear", command: "node" }],
+      resolveSettings: async () => "",
+    });
+    await fake.waitForStdinCount(1);
+    fake.answerInitialize();
+    await startPromise;
+
+    const callPromise = supervisor.callTool({
+      pluginId: "acme.demo",
+      serverId: "linear",
+      tool: "linear.getIssue",
+    });
+    await fake.waitForStdinCount(3);
+    fake.answerLastCallWithError("issue not found");
+    await expect(callPromise).rejects.toThrow("issue not found");
+  });
+
+  it("caps stderr at PLUGIN_MCP_STDERR_RING_LINES and tracks totalLines", async () => {
+    const fake = makeFakeSubprocess();
+    const supervisor = new PluginMcpSupervisor({
+      spawner: () => fake.handle,
+      killTree: () => {},
+    });
+    const startPromise = supervisor.start({
+      pluginId: "acme.demo",
+      contributions: [{ id: "linear", name: "Linear", command: "node" }],
+      resolveSettings: async () => "",
+    });
+    await fake.waitForStdinCount(1);
+    fake.answerInitialize();
+    await startPromise;
+
+    const overflow = PLUGIN_MCP_STDERR_RING_LINES + 50;
+    for (let i = 0; i < overflow; i++) fake.emitStderr(`line ${i}\n`);
+    await flushMicrotasks();
+
+    const stderr = supervisor.getStderr("acme.demo", "linear");
+    expect(stderr.lines).toHaveLength(PLUGIN_MCP_STDERR_RING_LINES);
+    expect(stderr.lines[0]).toBe(`line ${overflow - PLUGIN_MCP_STDERR_RING_LINES}`);
+    expect(stderr.totalLines).toBe(overflow);
+  });
+
+  it("substitutes ${settings:*} into command/args/env at spawn time", async () => {
+    const fake = makeFakeSubprocess();
+    const seen: Array<{ command: string; args: string[]; env: Record<string, string> }> = [];
+    const supervisor = new PluginMcpSupervisor({
+      spawner: (config) => {
+        seen.push({ command: config.command, args: config.args, env: config.env });
+        return fake.handle;
+      },
+      killTree: () => {},
+    });
+    const resolver = async (settingId: string) =>
+      settingId === "linearToken" ? "lin_abc" : "/usr/bin/node";
+    const startPromise = supervisor.start({
+      pluginId: "acme.demo",
+      contributions: [
+        {
+          id: "linear",
+          name: "Linear",
+          command: "${settings:nodeBin}",
+          args: ["-y", "@linear/mcp", "--token=${settings:linearToken}"],
+          env: { LINEAR_TOKEN: "${settings:linearToken}" },
+        },
+      ],
+      resolveSettings: resolver,
+    });
+    await fake.waitForStdinCount(1);
+    fake.answerInitialize();
+    await startPromise;
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.command).toBe("/usr/bin/node");
+    expect(seen[0]!.args).toEqual(["-y", "@linear/mcp", "--token=lin_abc"]);
+    expect(seen[0]!.env).toEqual({ LINEAR_TOKEN: "lin_abc" });
+  });
+
+  it("transitions to crashed and rejects pending calls when the subprocess exits unexpectedly", async () => {
+    const fake = makeFakeSubprocess();
+    const supervisor = new PluginMcpSupervisor({
+      spawner: () => fake.handle,
+      killTree: () => {},
+    });
+    const startPromise = supervisor.start({
+      pluginId: "acme.demo",
+      contributions: [{ id: "linear", name: "Linear", command: "node" }],
+      resolveSettings: async () => "",
+    });
+    await fake.waitForStdinCount(1);
+    fake.answerInitialize();
+    await startPromise;
+
+    const callPromise = supervisor.callTool({
+      pluginId: "acme.demo",
+      serverId: "linear",
+      tool: "linear.getIssue",
+    });
+    // Pre-attach a no-op catch so Node doesn't fire PromiseRejectionHandledWarning
+    // when the test's `rejects.toThrow()` assertion settles asynchronously after
+    // the close handler has already rejected the call.
+    callPromise.catch(() => {});
+    await fake.waitForStdinCount(3);
+    fake.closeStdout();
+    await flushMicrotasks();
+
+    await expect(callPromise).rejects.toThrow();
+    const [info] = supervisor.list();
+    expect(info?.status).toBe("crashed");
+    expect(info?.pid).toBeNull();
+  });
+
+  it("invokes the Windows tree-killer on shutdown", async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+
+    try {
+      const fake = makeFakeSubprocess({ pid: 9876 });
+      const killTree = vi.fn();
+      const supervisor = new PluginMcpSupervisor({
+        spawner: () => fake.handle,
+        killTree,
+      });
+      const startPromise = supervisor.start({
+        pluginId: "acme.demo",
+        contributions: [{ id: "linear", name: "Linear", command: "node" }],
+        resolveSettings: async () => "",
+      });
+      await fake.waitForStdinCount(1);
+      fake.answerInitialize();
+      await startPromise;
+
+      vi.useFakeTimers();
+      const shutdownPromise = supervisor.shutdown({ pluginId: "acme.demo" });
+      await shutdownPromise;
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(killTree).toHaveBeenCalledWith(9876);
+
+      const [info] = supervisor.list();
+      expect(info?.status).toBe("stopped");
+    } finally {
+      vi.useRealTimers();
+      if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
+    }
+  });
+
+  it("does not invoke the tree-killer on POSIX", async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+
+    try {
+      const fake = makeFakeSubprocess({ pid: 4242 });
+      const killTree = vi.fn();
+      const supervisor = new PluginMcpSupervisor({
+        spawner: () => fake.handle,
+        killTree,
+      });
+      const startPromise = supervisor.start({
+        pluginId: "acme.demo",
+        contributions: [{ id: "linear", name: "Linear", command: "node" }],
+        resolveSettings: async () => "",
+      });
+      await fake.waitForStdinCount(1);
+      fake.answerInitialize();
+      await startPromise;
+
+      vi.useFakeTimers();
+      await supervisor.shutdown({ pluginId: "acme.demo" });
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(killTree).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+      if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
+    }
+  });
+
+  it("restart re-spawns and appends a restart marker to the stderr ring", async () => {
+    const fakes = [makeFakeSubprocess({ pid: 1 }), makeFakeSubprocess({ pid: 2 })];
+    let nth = 0;
+    const supervisor = new PluginMcpSupervisor({
+      spawner: () => fakes[nth++]!.handle,
+      killTree: () => {},
+    });
+    const contribution = { id: "linear", name: "Linear", command: "node" };
+    const start = supervisor.start({
+      pluginId: "acme.demo",
+      contributions: [contribution],
+      resolveSettings: async () => "",
+    });
+    await fakes[0]!.waitForStdinCount(1);
+    fakes[0]!.answerInitialize();
+    await start;
+    fakes[0]!.emitStderr("pre-restart line\n");
+    await flushMicrotasks();
+
+    const restartPromise = supervisor.restart({
+      pluginId: "acme.demo",
+      serverId: "linear",
+      contribution,
+      resolveSettings: async () => "",
+    });
+    await fakes[1]!.waitForStdinCount(1);
+    fakes[1]!.answerInitialize();
+    await restartPromise;
+
+    const stderr = supervisor.getStderr("acme.demo", "linear");
+    expect(stderr.lines).toContain("pre-restart line");
+    expect(stderr.lines.some((l) => l.startsWith("--- restarted at "))).toBe(true);
+    const [info] = supervisor.list();
+    expect(info?.status).toBe("ready");
+    expect(info?.pid).toBe(2);
+  });
+
+  it("rejects ${settings:*} substitution failures without crashing activation", async () => {
+    const supervisor = new PluginMcpSupervisor({
+      spawner: () => makeFakeSubprocess().handle,
+      killTree: () => {},
+    });
+    await supervisor.start({
+      pluginId: "acme.demo",
+      contributions: [
+        {
+          id: "broken",
+          name: "Broken",
+          command: "${settings:notFound}",
+          args: ["-y"],
+        },
+      ],
+      resolveSettings: async () => {
+        throw new Error("vault unavailable");
+      },
+    });
+    const [info] = supervisor.list();
+    expect(info?.status).toBe("crashed");
+    expect(info?.lastError).toContain("vault unavailable");
+  });
+});

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -105,6 +105,22 @@ vi.mock("../fileDecorationRegistry.js", () => ({
   scopeMatchesPattern: vi.fn((s: string, p: string) => s === p),
 }));
 
+// Mocked so MCP-server activation tests don't try to spawn real subprocesses
+// or exercise the execa dynamic-import. The supervisor's wiring is verified
+// here; PluginMcpSupervisor's own lifecycle is covered by its dedicated test.
+const mockPluginMcpSupervisor = {
+  start: vi.fn(async () => undefined) as ReturnType<typeof vi.fn>,
+  shutdown: vi.fn(async () => undefined) as ReturnType<typeof vi.fn>,
+  shutdownAll: vi.fn(async () => undefined) as ReturnType<typeof vi.fn>,
+  callTool: vi.fn(),
+  restart: vi.fn(),
+  list: vi.fn(() => []),
+  getStderr: vi.fn(() => ({ pluginId: "", serverId: "", lines: [], totalLines: 0 })),
+};
+vi.mock("../PluginMcpSupervisor.js", () => ({
+  getPluginMcpSupervisor: () => mockPluginMcpSupervisor,
+}));
+
 import { PluginService } from "../PluginService.js";
 import { getPluginManifestSchema } from "../../schemas/plugin.js";
 import {
@@ -4492,7 +4508,8 @@ describe("reserved contribution point warnings", () => {
     );
   });
 
-  it("accepts a contributes.experimental_mcpServers entry and logs a 'not yet implemented' warning", async () => {
+  it("forwards a contributes.experimental_mcpServers entry to the PluginMcpSupervisor (#9233)", async () => {
+    mockPluginMcpSupervisor.start.mockClear();
     await writePlugin("mcp", {
       name: "acme.mcp",
       version: "1.0.0",
@@ -4514,11 +4531,21 @@ describe("reserved contribution point warnings", () => {
     await service.initialize();
 
     expect(service.listPlugins()).toHaveLength(1);
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'Plugin "acme.mcp": contributes.experimental_mcpServers is not yet implemented'
-      )
-    );
+    expect(mockPluginMcpSupervisor.start).toHaveBeenCalledTimes(1);
+    const call = mockPluginMcpSupervisor.start.mock.calls[0]?.[0] as {
+      pluginId: string;
+      contributions: Array<{ id: string; name: string; command: string }>;
+    };
+    expect(call.pluginId).toBe("acme.mcp");
+    expect(call.contributions).toEqual([
+      {
+        id: "linear",
+        name: "Linear MCP",
+        command: "node",
+        args: ["./server.js"],
+        env: { LINEAR_API_KEY: "secret" },
+      },
+    ]);
   });
 
   it("registers a contributes.forgeProviders entry with the forge provider registry", async () => {
@@ -4619,6 +4646,7 @@ describe("reserved contribution point warnings", () => {
   });
 
   it("still processes other contributions when reserved points are present", async () => {
+    mockPluginMcpSupervisor.start.mockClear();
     await writePlugin("mixed", {
       name: "acme.mixed",
       version: "1.0.0",
@@ -4640,9 +4668,8 @@ describe("reserved contribution point warnings", () => {
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("contributes.experimental_views is not yet implemented")
     );
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("contributes.experimental_mcpServers is not yet implemented")
-    );
+    // experimental_mcpServers now reaches the supervisor instead of warning (#9233).
+    expect(mockPluginMcpSupervisor.start).toHaveBeenCalledTimes(1);
   });
 
   it("warns once per category regardless of entry count", async () => {

--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -1,15 +1,15 @@
 {
-  "count": 1197,
+  "count": 1195,
   "byRule": {
     "@typescript-eslint/no-explicit-any": 54,
     "@typescript-eslint/no-floating-promises": 93,
-    "@typescript-eslint/no-unsafe-type-assertion": 501,
+    "@typescript-eslint/no-unsafe-type-assertion": 502,
     "no-restricted-imports": 8,
-    "no-restricted-syntax": 412,
+    "no-restricted-syntax": 410,
     "no-useless-assignment": 20,
     "preserve-caught-error": 52,
     "react-compiler/react-compiler": 16,
     "react-hooks/exhaustive-deps": 40
   },
-  "updatedAt": "2026-05-28T12:06:07.907Z"
+  "updatedAt": "2026-05-28T14:34:15.577Z"
 }

--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -1,15 +1,15 @@
 {
-  "count": 1195,
+  "count": 1197,
   "byRule": {
     "@typescript-eslint/no-explicit-any": 54,
     "@typescript-eslint/no-floating-promises": 93,
-    "@typescript-eslint/no-unsafe-type-assertion": 502,
+    "@typescript-eslint/no-unsafe-type-assertion": 501,
     "no-restricted-imports": 8,
-    "no-restricted-syntax": 410,
+    "no-restricted-syntax": 412,
     "no-useless-assignment": 20,
     "preserve-caught-error": 52,
     "react-compiler/react-compiler": 16,
     "react-hooks/exhaustive-deps": 40
   },
-  "updatedAt": "2026-05-28T08:14:13.441Z"
+  "updatedAt": "2026-05-28T12:06:07.907Z"
 }

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -376,6 +376,17 @@ export interface GeneratedElectronAPI {
       ...args: IpcInvokeMap["plugin:validate-action-ids"]["args"]
     ): Promise<IpcInvokeMap["plugin:validate-action-ids"]["result"]>;
   };
+  pluginMcp: {
+    getStderr(
+      ...args: IpcInvokeMap["plugin-mcp:get-stderr"]["args"]
+    ): Promise<IpcInvokeMap["plugin-mcp:get-stderr"]["result"]>;
+    list(
+      ...args: IpcInvokeMap["plugin-mcp:list"]["args"]
+    ): Promise<IpcInvokeMap["plugin-mcp:list"]["result"]>;
+    restart(
+      ...args: IpcInvokeMap["plugin-mcp:restart"]["args"]
+    ): Promise<IpcInvokeMap["plugin-mcp:restart"]["result"]>;
+  };
   portal: {
     closeTab(
       ...args: IpcInvokeMap["portal:close-tab"]["args"]

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -555,6 +555,18 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: boolean | undefined;
   };
+  "plugin-mcp:get-stderr": {
+    args: [key: import("./pluginMcp.js").PluginMcpServerKey];
+    result: import("./pluginMcp.js").PluginMcpStderrResult;
+  };
+  "plugin-mcp:list": {
+    args: [];
+    result: import("./pluginMcp.js").PluginMcpServerInfo[];
+  };
+  "plugin-mcp:restart": {
+    args: [key: import("./pluginMcp.js").PluginMcpServerKey];
+    result: void;
+  };
   "plugin:actions-get": {
     args: [];
     result: import("../plugin.js").PluginActionDescriptor[];

--- a/shared/types/ipc/pluginMcp.ts
+++ b/shared/types/ipc/pluginMcp.ts
@@ -1,0 +1,58 @@
+/**
+ * Lifecycle state for a single plugin-contributed MCP server tracked by
+ * `PluginMcpSupervisor`. Distinct from the in-process MCP server's
+ * {@link McpRuntimeState} (`disabled|starting|ready|failed`) — this supervises
+ * outbound stdio subprocesses launched from plugin manifests, not the inbound
+ * server that exposes Daintree actions to assistants.
+ *
+ * - `spawning`: subprocess started; `initialize` request sent or in flight.
+ *   `tools/call` against a spawning server fails fast with `NOT_READY`.
+ * - `ready`: handshake complete (server responded to `initialize`, client sent
+ *   `notifications/initialized`). `tools/call` is accepted.
+ * - `crashed`: subprocess exited unexpectedly before `shutdown()` was called,
+ *   or the handshake failed. `lastError` carries the diagnostic.
+ * - `stopped`: `shutdown()` was called and the subprocess exited cleanly.
+ */
+export type PluginMcpServerStatus = "spawning" | "ready" | "crashed" | "stopped";
+
+/**
+ * Compact, JSON-safe snapshot of one supervised MCP server. Returned by the
+ * `plugin-mcp:list` IPC and used by Settings → MCP. Carries no live handles or
+ * subprocess references — those stay inside the supervisor.
+ */
+export interface PluginMcpServerInfo {
+  pluginId: string;
+  serverId: string;
+  name: string;
+  status: PluginMcpServerStatus;
+  /** OS pid of the direct child subprocess. Absent when not currently running. */
+  pid: number | null;
+  /** Most recent error message, if any. Cleared on a successful (re)start. */
+  lastError: string | null;
+  /** Number of stderr lines currently buffered for this server. */
+  stderrLineCount: number;
+}
+
+/**
+ * Result of a `plugin-mcp:get-stderr` IPC. Bounded by the supervisor's
+ * per-server ring cap so a misbehaving server can't pin unbounded memory.
+ */
+export interface PluginMcpStderrResult {
+  pluginId: string;
+  serverId: string;
+  lines: string[];
+  /** Total lines emitted by the server since spawn; may exceed `lines.length`. */
+  totalLines: number;
+}
+
+/**
+ * Identifier passed to per-server IPC calls (`get-stderr`, `restart`). The
+ * pair uniquely identifies one supervised subprocess.
+ */
+export interface PluginMcpServerKey {
+  pluginId: string;
+  serverId: string;
+}
+
+/** Per-server ring cap — capped lines retained for the `Settings → MCP` log view. */
+export const PLUGIN_MCP_STDERR_RING_LINES = 500;


### PR DESCRIPTION
## Summary

- Adds `PluginMcpSupervisor`, a new main-process service that spawns stdio MCP subprocesses from plugin manifests and manages their full lifecycle — connection, graceful shutdown, and per-plugin connection-state tracking.
- Extends `PluginService` to integrate the supervisor, adds new IPC channels so the renderer can query plugin MCP status, and updates the plugin Zod schema to support MCP server configuration.

Resolves #9233

## Changes

- `electron/services/PluginMcpSupervisor.ts` — new service; subprocess lifecycle, MCP connection management, shutdown sequencing, connection-state map
- `electron/services/PluginService.ts` — supervisor integration; starts/stops alongside plugin load/unload
- `electron/ipc/handlers/pluginMcp.ts` + `pluginMcp.preload.ts` — new IPC channels for renderer MCP status queries
- `electron/ipc/channels.ts`, `electron/preload.cts` — channel constants and preload wiring
- `electron/lifecycle/shutdown.ts` — supervisor included in shutdown sequence
- `electron/schemas/plugin.ts` — Zod schema extended with `mcpServers` config block
- `shared/types/ipc/pluginMcp.ts`, `generated-api.ts`, `generated.ts` — IPC types
- `eslint-warnings-baseline.json` — baseline updated for new files

## Testing

334 tests pass across `PluginMcpSupervisor.test.ts`, `PluginService.test.ts`, and `mcpServerContribution.test.ts`, covering subprocess spawn/teardown, connection-state transitions, shutdown races, and schema validation. Typecheck, lint, format, and build all green.