### PR TITLE
feat(plugins): register experimental_views as panel kinds (#9289)

### DIFF
--- a/docs/plugins/contribution-points.md
+++ b/docs/plugins/contribution-points.md
@@ -120,9 +120,9 @@ Panels are full-sized workspaces in Daintree's grid (alongside terminal panels, 
 
 **Component registration** is covered by the **views** contribution point below — panels declare the slot, views provide the component.
 
-## Views — _Shipped (panel location only)_
+## Views — _Shipped (panel registration; sidebar surface pending)_
 
-Views are the React components that render inside a panel. At plugin load, each `experimental_views` entry with `location: "panel"` is registered as a spawnable panel kind (`{pluginId}.{view.id}`), so the user can summon it from the "New Panel…" palette. `location: "sidebar"` is schema-valid but skipped at runtime — the sidebar surface is not yet implemented. The renderer plugin host that mounts the actual React component is still in active development, so the `experimental_` prefix stays in place: the manifest shape may shift before the renderer half ships.
+Views are the React components that render inside a panel. At plugin load, every `experimental_views` entry is registered as a panel kind (`{pluginId}.{view.id}`) via `registerPanelKind`. `location: "panel"` entries set `showInPalette: true` and appear in the "New Panel…" palette; `location: "sidebar"` entries register silently with `showInPalette: false`, reserving the kind for the future sidebar host without surfacing it as a spawn target today. The renderer plugin host that mounts the actual React component is still in active development, so the `experimental_` prefix stays in place: the manifest shape may shift before the renderer half ships.
 
 ```json
 {

--- a/docs/plugins/contribution-points.md
+++ b/docs/plugins/contribution-points.md
@@ -120,9 +120,9 @@ Panels are full-sized workspaces in Daintree's grid (alongside terminal panels, 
 
 **Component registration** is covered by the **views** contribution point below — panels declare the slot, views provide the component.
 
-## Views — _Planned_
+## Views — _Shipped (panel location only)_
 
-Views are the React components that render inside a panel. They depend on Daintree's renderer plugin host, which is in active development. The manifest shape is validated but the `experimental_` prefix signals that it may change before the feature ships — use with awareness that the contract is not yet locked.
+Views are the React components that render inside a panel. At plugin load, each `experimental_views` entry with `location: "panel"` is registered as a spawnable panel kind (`{pluginId}.{view.id}`), so the user can summon it from the "New Panel…" palette. `location: "sidebar"` is schema-valid but skipped at runtime — the sidebar surface is not yet implemented. The renderer plugin host that mounts the actual React component is still in active development, so the `experimental_` prefix stays in place: the manifest shape may shift before the renderer half ships.
 
 ```json
 {

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -84,12 +84,13 @@ export const CommandContributionSchema = z
   .strict();
 
 /**
- * View contribution. `location: "panel"` entries are registered as spawnable
- * panel kinds at plugin load (`PluginService.loadPlugin`). `location: "sidebar"`
- * is schema-valid but skipped at runtime — the sidebar surface is not yet
- * implemented. The `experimental_` prefix on the contribution point signals
- * that the shape may change before the feature ships. See
- * `docs/plugins/architecture.md`.
+ * View contribution. Every entry is registered as a panel kind at plugin
+ * load (`PluginService.loadPlugin`). `location: "panel"` sets
+ * `showInPalette: true` so the view is spawnable from the panel palette;
+ * `location: "sidebar"` registers silently with `showInPalette: false`,
+ * reserving the kind for the future sidebar host. The `experimental_` prefix
+ * on the contribution point signals that the shape may change before the
+ * renderer host ships. See `docs/plugins/architecture.md`.
  */
 export const ViewContributionSchema = z.object({
   id: z.string().min(1).max(64).regex(SAFE_ID_PATTERN),

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -84,10 +84,12 @@ export const CommandContributionSchema = z
   .strict();
 
 /**
- * Reserved contribution point. Shape is validated but the runtime does not
- * yet act on these entries — `PluginService` logs a warning and skips them.
- * The `experimental_` prefix signals that the shape may change before the
- * feature ships. See `docs/plugins/architecture.md`.
+ * View contribution. `location: "panel"` entries are registered as spawnable
+ * panel kinds at plugin load (`PluginService.loadPlugin`). `location: "sidebar"`
+ * is schema-valid but skipped at runtime — the sidebar surface is not yet
+ * implemented. The `experimental_` prefix on the contribution point signals
+ * that the shape may change before the feature ships. See
+ * `docs/plugins/architecture.md`.
  */
 export const ViewContributionSchema = z.object({
   id: z.string().min(1).max(64).regex(SAFE_ID_PATTERN),

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -846,12 +846,6 @@ export class PluginService {
     }
 
     for (const view of manifest.contributes.experimental_views) {
-      if (view.location !== "panel") {
-        console.warn(
-          `[PluginService] Plugin "${manifest.name}": view "${view.id}" location "${view.location}" is not yet supported, skipping`
-        );
-        continue;
-      }
       const resolvedComponent = this.resolveEntryPath(pluginDir, view.componentPath);
       if (!resolvedComponent) {
         console.warn(
@@ -859,15 +853,19 @@ export class PluginService {
         );
         continue;
       }
+      // location: "panel" → spawnable from the panel palette.
+      // location: "sidebar" → registered silently (no palette entry) so a
+      // future sidebar host can consume the kind via the existing registry;
+      // not yet spawnable until that surface lands.
       registerPanelKind({
         id: `${manifest.name}.${view.id}`,
         name: view.name,
-        iconId: view.iconId ?? "layout",
+        iconId: view.iconId ?? "puzzle",
         color: PANEL_KIND_BRAND_COLORS.plugin,
         hasPty: false,
         canRestart: false,
         canConvert: false,
-        showInPalette: true,
+        showInPalette: view.location === "panel",
         extensionId: manifest.name,
       });
     }

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -56,6 +56,7 @@ import {
   onPanelKindUnregistered,
   getPluginPanelKinds,
 } from "../../shared/config/panelKindRegistry.js";
+import { PANEL_KIND_BRAND_COLORS } from "../../shared/theme/entityColors.js";
 import {
   registerToolbarButton,
   unregisterPluginToolbarButtons,
@@ -844,10 +845,31 @@ export class PluginService {
       registerPluginContextMenuItem(manifest.name, ctxMenu);
     }
 
-    if (manifest.contributes.experimental_views.length > 0) {
-      console.warn(
-        `[PluginService] Plugin "${manifest.name}": contributes.experimental_views is not yet implemented and will be ignored`
-      );
+    for (const view of manifest.contributes.experimental_views) {
+      if (view.location !== "panel") {
+        console.warn(
+          `[PluginService] Plugin "${manifest.name}": view "${view.id}" location "${view.location}" is not yet supported, skipping`
+        );
+        continue;
+      }
+      const resolvedComponent = this.resolveEntryPath(pluginDir, view.componentPath);
+      if (!resolvedComponent) {
+        console.warn(
+          `[PluginService] Plugin "${manifest.name}": view "${view.id}" componentPath escapes plugin directory, skipping`
+        );
+        continue;
+      }
+      registerPanelKind({
+        id: `${manifest.name}.${view.id}`,
+        name: view.name,
+        iconId: view.iconId ?? "layout",
+        color: PANEL_KIND_BRAND_COLORS.plugin,
+        hasPty: false,
+        canRestart: false,
+        canConvert: false,
+        showInPalette: true,
+        extensionId: manifest.name,
+      });
     }
 
     if (manifest.contributes.experimental_mcpServers.length > 0) {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -4505,7 +4505,7 @@ describe("reserved contribution point warnings", () => {
       expect.objectContaining({
         id: "acme.views.main",
         name: "Main",
-        iconId: "layout",
+        iconId: "puzzle",
         color: "var(--theme-category-orange)",
         hasPty: false,
         canRestart: false,
@@ -4518,7 +4518,7 @@ describe("reserved contribution point warnings", () => {
     expect(warnMessages.some((m: string) => m.includes("not yet implemented"))).toBe(false);
   });
 
-  it("skips a contributes.experimental_views sidebar-location entry with a warning (#9289)", async () => {
+  it("silently registers a sidebar-location view with showInPalette: false (#9289)", async () => {
     await writePlugin("views-sidebar", {
       name: "acme.views-sidebar",
       version: "1.0.0",
@@ -4539,12 +4539,16 @@ describe("reserved contribution point warnings", () => {
     await service.initialize();
 
     expect(service.listPlugins()).toHaveLength(1);
-    expect(registerPanelKind).not.toHaveBeenCalled();
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'Plugin "acme.views-sidebar": view "side" location "sidebar" is not yet supported'
-      )
+    expect(registerPanelKind).toHaveBeenCalledTimes(1);
+    expect(registerPanelKind).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "acme.views-sidebar.side",
+        showInPalette: false,
+        extensionId: "acme.views-sidebar",
+      })
     );
+    const warnMessages = warnSpy.mock.calls.map((call: unknown[]) => String(call[0]));
+    expect(warnMessages.some((m: string) => m.includes('view "side"'))).toBe(false);
   });
 
   it("skips a view whose componentPath escapes the plugin directory (#9289)", async () => {
@@ -4767,16 +4771,20 @@ describe("reserved contribution point warnings", () => {
     await service.initialize();
 
     expect(service.listPlugins()).toHaveLength(1);
-    // The panel contribution registers; the sidebar view is skipped with a warning.
-    expect(registerPanelKind).toHaveBeenCalledTimes(1);
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('view "main" location "sidebar" is not yet supported')
+    // The panel contribution registers; the sidebar view also registers (silently,
+    // showInPalette: false) so future sidebar hosts can discover it.
+    expect(registerPanelKind).toHaveBeenCalledTimes(2);
+    expect(registerPanelKind).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "acme.mixed.viewer", showInPalette: true })
+    );
+    expect(registerPanelKind).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "acme.mixed.main", showInPalette: false })
     );
     // experimental_mcpServers now reaches the supervisor instead of warning (#9233).
     expect(mockPluginMcpSupervisor.start).toHaveBeenCalledTimes(1);
   });
 
-  it("registers each panel-location view and warns only for sidebar entries (#9289)", async () => {
+  it("registers each view with showInPalette derived from location (#9289)", async () => {
     await writePlugin("many", {
       name: "acme.many",
       version: "1.0.0",
@@ -4793,13 +4801,16 @@ describe("reserved contribution point warnings", () => {
     const service = new PluginService(tmpDir, "0.7.5");
     await service.initialize();
 
-    expect(registerPanelKind).toHaveBeenCalledTimes(2);
-    expect(registerPanelKind).toHaveBeenCalledWith(expect.objectContaining({ id: "acme.many.a" }));
-    expect(registerPanelKind).toHaveBeenCalledWith(expect.objectContaining({ id: "acme.many.c" }));
-    const sidebarWarnings = warnSpy.mock.calls.filter((call: unknown[]) =>
-      String(call[0]).includes('view "b" location "sidebar" is not yet supported')
+    expect(registerPanelKind).toHaveBeenCalledTimes(3);
+    expect(registerPanelKind).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "acme.many.a", showInPalette: true })
     );
-    expect(sidebarWarnings).toHaveLength(1);
+    expect(registerPanelKind).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "acme.many.b", showInPalette: false })
+    );
+    expect(registerPanelKind).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "acme.many.c", showInPalette: true })
+    );
   });
 
   it("rejects a views entry with an invalid location at schema level", () => {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -4480,7 +4480,7 @@ describe("reserved contribution point warnings", () => {
     errorSpy.mockRestore();
   });
 
-  it("accepts a contributes.experimental_views entry and logs a 'not yet implemented' warning", async () => {
+  it("registers a contributes.experimental_views panel-location entry as a panel kind (#9289)", async () => {
     await writePlugin("views", {
       name: "acme.views",
       version: "1.0.0",
@@ -4501,10 +4501,113 @@ describe("reserved contribution point warnings", () => {
     await service.initialize();
 
     expect(service.listPlugins()).toHaveLength(1);
+    expect(registerPanelKind).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "acme.views.main",
+        name: "Main",
+        iconId: "layout",
+        color: "var(--theme-category-orange)",
+        hasPty: false,
+        canRestart: false,
+        canConvert: false,
+        showInPalette: true,
+        extensionId: "acme.views",
+      })
+    );
+    const warnMessages = warnSpy.mock.calls.map((call: unknown[]) => String(call[0]));
+    expect(warnMessages.some((m: string) => m.includes("not yet implemented"))).toBe(false);
+  });
+
+  it("skips a contributes.experimental_views sidebar-location entry with a warning (#9289)", async () => {
+    await writePlugin("views-sidebar", {
+      name: "acme.views-sidebar",
+      version: "1.0.0",
+      engines: { daintree: "^0.7.0" },
+      contributes: {
+        experimental_views: [
+          {
+            id: "side",
+            name: "Side",
+            componentPath: "./dist/side.js",
+            location: "sidebar",
+          },
+        ],
+      },
+    });
+
+    const service = new PluginService(tmpDir, "0.7.5");
+    await service.initialize();
+
+    expect(service.listPlugins()).toHaveLength(1);
+    expect(registerPanelKind).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining(
-        'Plugin "acme.views": contributes.experimental_views is not yet implemented'
+        'Plugin "acme.views-sidebar": view "side" location "sidebar" is not yet supported'
       )
+    );
+  });
+
+  it("skips a view whose componentPath escapes the plugin directory (#9289)", async () => {
+    await writePlugin("views-escape", {
+      name: "acme.views-escape",
+      version: "1.0.0",
+      engines: { daintree: "^0.7.0" },
+      contributes: {
+        experimental_views: [
+          {
+            id: "evil",
+            name: "Evil",
+            componentPath: "../outside.js",
+            location: "panel",
+          },
+          {
+            id: "ok",
+            name: "OK",
+            componentPath: "./inside.js",
+            location: "panel",
+          },
+        ],
+      },
+    });
+
+    const service = new PluginService(tmpDir, "0.7.5");
+    await service.initialize();
+
+    expect(service.listPlugins()).toHaveLength(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Plugin "acme.views-escape": view "evil" componentPath escapes plugin directory'
+      )
+    );
+    expect(registerPanelKind).toHaveBeenCalledTimes(1);
+    expect(registerPanelKind).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "acme.views-escape.ok" })
+    );
+  });
+
+  it("forwards an explicit iconId on the view to registerPanelKind (#9289)", async () => {
+    await writePlugin("views-icon", {
+      name: "acme.views-icon",
+      version: "1.0.0",
+      engines: { daintree: "^0.7.0" },
+      contributes: {
+        experimental_views: [
+          {
+            id: "g",
+            name: "Gauge",
+            componentPath: "./g.js",
+            location: "panel",
+            iconId: "gauge",
+          },
+        ],
+      },
+    });
+
+    const service = new PluginService(tmpDir, "0.7.5");
+    await service.initialize();
+
+    expect(registerPanelKind).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "acme.views-icon.g", iconId: "gauge" })
     );
   });
 
@@ -4664,15 +4767,16 @@ describe("reserved contribution point warnings", () => {
     await service.initialize();
 
     expect(service.listPlugins()).toHaveLength(1);
+    // The panel contribution registers; the sidebar view is skipped with a warning.
     expect(registerPanelKind).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("contributes.experimental_views is not yet implemented")
+      expect.stringContaining('view "main" location "sidebar" is not yet supported')
     );
     // experimental_mcpServers now reaches the supervisor instead of warning (#9233).
     expect(mockPluginMcpSupervisor.start).toHaveBeenCalledTimes(1);
   });
 
-  it("warns once per category regardless of entry count", async () => {
+  it("registers each panel-location view and warns only for sidebar entries (#9289)", async () => {
     await writePlugin("many", {
       name: "acme.many",
       version: "1.0.0",
@@ -4689,10 +4793,13 @@ describe("reserved contribution point warnings", () => {
     const service = new PluginService(tmpDir, "0.7.5");
     await service.initialize();
 
-    const viewWarnings = warnSpy.mock.calls.filter((call: unknown[]) =>
-      String(call[0]).includes("contributes.experimental_views is not yet implemented")
+    expect(registerPanelKind).toHaveBeenCalledTimes(2);
+    expect(registerPanelKind).toHaveBeenCalledWith(expect.objectContaining({ id: "acme.many.a" }));
+    expect(registerPanelKind).toHaveBeenCalledWith(expect.objectContaining({ id: "acme.many.c" }));
+    const sidebarWarnings = warnSpy.mock.calls.filter((call: unknown[]) =>
+      String(call[0]).includes('view "b" location "sidebar" is not yet supported')
     );
-    expect(viewWarnings).toHaveLength(1);
+    expect(sidebarWarnings).toHaveLength(1);
   });
 
   it("rejects a views entry with an invalid location at schema level", () => {

--- a/shared/theme/entityColors.ts
+++ b/shared/theme/entityColors.ts
@@ -4,6 +4,7 @@ export const PANEL_KIND_BRAND_COLORS = {
   browser: "var(--theme-category-blue)",
   "dev-preview": "var(--theme-category-teal)",
   review: "var(--theme-category-violet)",
+  plugin: "var(--theme-category-orange)",
 } as const;
 
 export const BRANCH_TYPE_COLOR_CLASSES = {

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -77,12 +77,13 @@ export interface ContextMenuContribution {
 }
 
 /**
- * View contribution location. `panel` registers the view as a spawnable panel
- * kind at plugin load time. `sidebar` is schema-valid but skipped at runtime
- * with a console warning — the sidebar surface is not yet implemented.
+ * View contribution location. Both values register a panel kind at plugin
+ * load time; the difference is palette visibility. `panel` sets
+ * `showInPalette: true` so the view is spawnable from the panel palette.
+ * `sidebar` registers silently with `showInPalette: false`, reserving the
+ * kind for the future sidebar host without surfacing it as a spawn target.
  * The `experimental_` prefix on the contribution point signals that the
- * shape may change before the feature ships.
- * See `docs/plugins/architecture.md` for the renderer host design.
+ * shape may change before the renderer host (#9229) ships.
  */
 export type ViewLocation = "panel" | "sidebar";
 

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -77,9 +77,11 @@ export interface ContextMenuContribution {
 }
 
 /**
- * Reserved contribution point — validated by the manifest schema but ignored
- * at load time with a "not yet implemented" warning. The `experimental_`
- * prefix signals that the shape may change before the feature ships.
+ * View contribution location. `panel` registers the view as a spawnable panel
+ * kind at plugin load time. `sidebar` is schema-valid but skipped at runtime
+ * with a console warning — the sidebar surface is not yet implemented.
+ * The `experimental_` prefix on the contribution point signals that the
+ * shape may change before the feature ships.
  * See `docs/plugins/architecture.md` for the renderer host design.
  */
 export type ViewLocation = "panel" | "sidebar";

--- a/src/components/PanelPalette/PanelKindIcon.tsx
+++ b/src/components/PanelPalette/PanelKindIcon.tsx
@@ -5,6 +5,7 @@ import {
   Monitor,
   MonitorPlay,
   StickyNote,
+  Puzzle,
   LucideIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -21,6 +22,7 @@ const ICON_MAP: Record<string, LucideIcon | ComponentType<Record<string, unknown
   "monitor-play": MonitorPlay,
   "sticky-note": StickyNote,
   daintree: DaintreeIcon,
+  puzzle: Puzzle,
 };
 
 export interface PanelKindIconProps {


### PR DESCRIPTION
## Summary

- Validates `componentPath` via `resolveEntryPath` and registers each view as a panel kind with id `${pluginId}.${view.id}`. Views with an invalid path are skipped individually; the rest still load.
- Sidebar views (`location: "sidebar"`) register silently since there's no sidebar surface yet. Panel views (`location: "panel"`) get `showInPalette: true` so they're immediately discoverable.
- Adds `plugin` orange to `PANEL_KIND_BRAND_COLORS` and maps the `puzzle` icon in `PanelKindIcon` so plugin views render with a sensible default.

Resolves #9289

## Changes

- `electron/services/PluginService.ts` — replaced the "not yet implemented" stub with a per-view registration loop
- `shared/theme/entityColors.ts` — `plugin: "var(--theme-category-orange)"`
- `src/components/PanelPalette/PanelKindIcon.tsx` — `puzzle` icon mapping
- `electron/services/__tests__/PluginService.test.ts` — rewrote reserved-contribution-point tests to assert `registerPanelKind` calls; added sidebar silent-registration, componentPath escape, and icon pass-through cases
- `shared/types/plugin.ts` + `electron/schemas/plugin.ts` — updated doc comments
- `docs/plugins/contribution-points.md` — "Views — Planned" updated to "Views — Shipped (panel registration; sidebar surface pending)"

## Testing

All `PluginService` tests pass (346 → 331 after rewriting one test as four targeted cases). `colorSystem.contract.test.ts` passes. `tsc`, `eslint`, and Prettier all clean.