### PR TITLE
feat(plugins): compound-capability lattice with manifest scopes

### DIFF
--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import * as semver from "semver";
 import { z } from "zod";
 import { BUILT_IN_PLUGIN_CAPABILITIES } from "../../shared/types/plugin.js";
@@ -158,6 +159,162 @@ export const FileDecorationContributionSchema = z
 export const PluginCapabilitySchema = z.enum(BUILT_IN_PLUGIN_CAPABILITIES);
 
 /**
+ * Hostnames that resolve to private/loopback/link-local space and must not
+ * appear in a plugin's `scopes.network.allowedUrls`. Literal-string matches
+ * only — DNS rebinding (a public hostname that resolves to RFC1918 at
+ * request time) is out of scope for manifest-level validation. See #9247.
+ */
+const PRIVATE_LOOPBACK_HOSTNAME_LITERALS = new Set(["localhost", "ip6-localhost", "ip6-loopback"]);
+/** IPv4 loopback (127.0.0.0/8). */
+const IPV4_LOOPBACK_REGEX = /^127\./;
+/** IPv4 link-local (169.254.0.0/16). Catches the AWS metadata endpoint. */
+const IPV4_LINK_LOCAL_REGEX = /^169\.254\./;
+/** IPv4 RFC1918 10.0.0.0/8. */
+const IPV4_RFC1918_TEN_REGEX = /^10\./;
+/** IPv4 RFC1918 192.168.0.0/16. */
+const IPV4_RFC1918_192_REGEX = /^192\.168\./;
+/** IPv4 RFC1918 172.16.0.0/12 (172.16.* through 172.31.*). */
+const IPV4_RFC1918_172_REGEX = /^172\.(1[6-9]|2\d|3[0-1])\./;
+/** IPv6 literal loopback (::1) — `new URL()` returns hostname stripped of brackets. */
+const IPV6_LOOPBACK_REGEX = /^\[?::1\]?$/;
+
+function isPrivateOrLoopbackHostname(hostname: string): boolean {
+  const lower = hostname.toLowerCase();
+  if (PRIVATE_LOOPBACK_HOSTNAME_LITERALS.has(lower)) return true;
+  if (IPV4_LOOPBACK_REGEX.test(lower)) return true;
+  if (IPV4_LINK_LOCAL_REGEX.test(lower)) return true;
+  if (IPV4_RFC1918_TEN_REGEX.test(lower)) return true;
+  if (IPV4_RFC1918_192_REGEX.test(lower)) return true;
+  if (IPV4_RFC1918_172_REGEX.test(lower)) return true;
+  if (IPV6_LOOPBACK_REGEX.test(lower)) return true;
+  return false;
+}
+
+/**
+ * Per-entry validator for `scopes.network.allowedUrls`. Each entry must:
+ *
+ * - Parse as a `https:` URL (no `http:`, `file:`, custom schemes).
+ * - Contain no `*` substring (wildcards are rejected so a tightly-bound
+ *   declaration cannot smuggle a permissive value past the manifest gate).
+ * - Carry no embedded credentials (no `https://user:pass@host`).
+ * - Target a multi-label hostname (at least one `.` after parse). Single-label
+ *   intranet hosts are rejected to keep allowlists auditable from the manifest.
+ * - Not target a private/loopback/link-local address (SSRF mitigation).
+ */
+const PluginAllowedUrlSchema = z.string().superRefine((value, ctx) => {
+  if (value.includes("*")) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Wildcard characters are not allowed in scopes.network.allowedUrls: "${value}"`,
+      params: { errorCode: "scope_wildcard_rejected" },
+    });
+    return;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `scopes.network.allowedUrls entry is not a valid URL: "${value}"`,
+      params: { errorCode: "scope_url_invalid" },
+    });
+    return;
+  }
+  if (parsed.protocol !== "https:") {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `scopes.network.allowedUrls entries must use https:// — got "${parsed.protocol}" in "${value}"`,
+      params: { errorCode: "scope_url_not_https" },
+    });
+    return;
+  }
+  if (parsed.username !== "" || parsed.password !== "") {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `scopes.network.allowedUrls entries must not embed credentials: "${value}"`,
+      params: { errorCode: "scope_url_has_credentials" },
+    });
+    return;
+  }
+  const hostname = parsed.hostname;
+  if (isPrivateOrLoopbackHostname(hostname)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `scopes.network.allowedUrls entry targets a private or loopback address: "${value}"`,
+      params: { errorCode: "scope_url_private_target" },
+    });
+    return;
+  }
+  if (hostname === "" || !hostname.includes(".")) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `scopes.network.allowedUrls hostnames must be multi-label (got "${hostname}" in "${value}")`,
+      params: { errorCode: "scope_url_hostname_unqualified" },
+    });
+    return;
+  }
+});
+
+/**
+ * Per-entry validator for `scopes.fs.allowedPaths`. Each entry must be a
+ * literal absolute path with no `..` segment and no `*` glob — the schema
+ * boundary is the load-bearing gate (#4593, #4702), so substring `..` checks
+ * are insufficient (segment-by-segment rejection).
+ */
+const PluginAllowedPathSchema = z.string().superRefine((value, ctx) => {
+  if (value.includes("*")) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Wildcard characters are not allowed in scopes.fs.allowedPaths: "${value}"`,
+      params: { errorCode: "scope_wildcard_rejected" },
+    });
+    return;
+  }
+  if (!path.isAbsolute(value)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `scopes.fs.allowedPaths entries must be absolute paths: "${value}"`,
+      params: { errorCode: "scope_path_relative" },
+    });
+    return;
+  }
+  const segments = value.split(/[\\/]/);
+  if (segments.some((seg) => seg === "..")) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `scopes.fs.allowedPaths entries must not contain ".." segments: "${value}"`,
+      params: { errorCode: "scope_path_traversal" },
+    });
+    return;
+  }
+});
+
+export const PluginNetworkScopeSchema = z
+  .object({
+    allowedUrls: z.array(PluginAllowedUrlSchema).min(1),
+  })
+  .strict();
+
+export const PluginFsScopeSchema = z
+  .object({
+    allowedPaths: z.array(PluginAllowedPathSchema).min(1),
+  })
+  .strict();
+
+/**
+ * Top-level `scopes` field on `PluginManifest`. Strict so a misspelled scope
+ * bucket (e.g. `networking` instead of `network`) surfaces as a manifest error
+ * rather than silently failing to attenuate the compound-capability lattice.
+ */
+export const PluginManifestScopesSchema = z
+  .object({
+    network: PluginNetworkScopeSchema.optional(),
+    fs: PluginFsScopeSchema.optional(),
+  })
+  .strict();
+
+/**
  * Validates the options passed to `host.showToast`. Both the main-process path
  * (plugin `activate` code) and any future renderer path (SDK React hooks over
  * IPC) converge on this schema. `priority` and `action` are intentionally
@@ -196,6 +353,7 @@ export function getPluginManifestSchema(isBuiltin: boolean) {
         })
         .optional(),
       capabilities: z.array(PluginCapabilitySchema).default([]),
+      scopes: PluginManifestScopesSchema.optional(),
       activationEvents: z.array(z.literal("onStartupFinished")).default([]),
       contributes: z
         .strictObject({

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -164,7 +164,16 @@ export const PluginCapabilitySchema = z.enum(BUILT_IN_PLUGIN_CAPABILITIES);
  * only — DNS rebinding (a public hostname that resolves to RFC1918 at
  * request time) is out of scope for manifest-level validation. See #9247.
  */
-const PRIVATE_LOOPBACK_HOSTNAME_LITERALS = new Set(["localhost", "ip6-localhost", "ip6-loopback"]);
+// "0.0.0.0" is a Linux/Unix synonym for "any local interface" and routes to
+// loopback on many platforms — it must be rejected alongside "localhost".
+// Trailing-FQDN-dot variants (e.g. "localhost.") are normalized away before
+// the literal check (see `normalizeHostname` below) so we only list bare forms.
+const PRIVATE_LOOPBACK_HOSTNAME_LITERALS = new Set([
+  "localhost",
+  "ip6-localhost",
+  "ip6-loopback",
+  "0.0.0.0",
+]);
 /** IPv4 loopback (127.0.0.0/8). */
 const IPV4_LOOPBACK_REGEX = /^127\./;
 /** IPv4 link-local (169.254.0.0/16). Catches the AWS metadata endpoint. */
@@ -175,18 +184,29 @@ const IPV4_RFC1918_TEN_REGEX = /^10\./;
 const IPV4_RFC1918_192_REGEX = /^192\.168\./;
 /** IPv4 RFC1918 172.16.0.0/12 (172.16.* through 172.31.*). */
 const IPV4_RFC1918_172_REGEX = /^172\.(1[6-9]|2\d|3[0-1])\./;
-/** IPv6 literal loopback (::1) — `new URL()` returns hostname stripped of brackets. */
+/**
+ * IPv6 literal loopback (::1). `new URL("https://[::1]").hostname` is `"[::1]"`
+ * — WHATWG retains the brackets — so the regex matches both the bracketed
+ * form (as returned by `new URL`) and a bare `::1` for completeness.
+ */
 const IPV6_LOOPBACK_REGEX = /^\[?::1\]?$/;
 
+function normalizeHostname(hostname: string): string {
+  // WHATWG URL parsing preserves trailing FQDN dots (RFC 1034 §3.1): the host
+  // "localhost." is structurally identical to "localhost" but would skip a
+  // literal-set check. Strip the trailing dot before any classification.
+  return hostname.replace(/\.$/, "").toLowerCase();
+}
+
 function isPrivateOrLoopbackHostname(hostname: string): boolean {
-  const lower = hostname.toLowerCase();
-  if (PRIVATE_LOOPBACK_HOSTNAME_LITERALS.has(lower)) return true;
-  if (IPV4_LOOPBACK_REGEX.test(lower)) return true;
-  if (IPV4_LINK_LOCAL_REGEX.test(lower)) return true;
-  if (IPV4_RFC1918_TEN_REGEX.test(lower)) return true;
-  if (IPV4_RFC1918_192_REGEX.test(lower)) return true;
-  if (IPV4_RFC1918_172_REGEX.test(lower)) return true;
-  if (IPV6_LOOPBACK_REGEX.test(lower)) return true;
+  const normalized = normalizeHostname(hostname);
+  if (PRIVATE_LOOPBACK_HOSTNAME_LITERALS.has(normalized)) return true;
+  if (IPV4_LOOPBACK_REGEX.test(normalized)) return true;
+  if (IPV4_LINK_LOCAL_REGEX.test(normalized)) return true;
+  if (IPV4_RFC1918_TEN_REGEX.test(normalized)) return true;
+  if (IPV4_RFC1918_192_REGEX.test(normalized)) return true;
+  if (IPV4_RFC1918_172_REGEX.test(normalized)) return true;
+  if (IPV6_LOOPBACK_REGEX.test(normalized)) return true;
   return false;
 }
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -144,6 +144,74 @@ const CONFIRM_TRIGGERING_CAPABILITIES: ReadonlySet<BuiltInPluginCapability> = ne
   "agent:invoke",
 ]);
 
+/**
+ * Compound-capability lattice (#9247). The flat
+ * {@link CONFIRM_TRIGGERING_CAPABILITIES} set only catches single capabilities
+ * that are themselves irreversible. It misses the two compound threat classes:
+ *
+ * 1. **Exfiltration** — a sensitive read paired with an unconstrained network
+ *    or shell sink. Neither side alone is destructive (read-only or merely
+ *    capable of network I/O), but together they form a data-exfiltration path.
+ * 2. **Remote-controlled mutation** — `network:fetch` paired with a local
+ *    write or shell sink. Both sides may already elevate individually
+ *    (`fs:*-write`, `git:write`, `shell:exec` are flat-elevated), but the
+ *    compound rule documents the intent and is belt-and-suspenders if the
+ *    flat set ever drifts.
+ *
+ * A plugin can attenuate the elevation by declaring tight scopes on the sink
+ * — currently only `scopes.network.allowedUrls` is consulted, since
+ * `shell:exec` is categorically high-risk and fs writes already elevate
+ * individually. Wildcard rejection is enforced at the schema boundary so the
+ * runtime only needs to check non-empty presence; see
+ * `electron/schemas/plugin.ts`.
+ */
+const SENSITIVE_READ_CAPABILITIES: ReadonlySet<BuiltInPluginCapability> = new Set([
+  "agent:read",
+  "git:read",
+  "fs:project-read",
+  "fs:user-data-read",
+]);
+const REMOTE_MUTATION_SINK_CAPABILITIES: ReadonlySet<BuiltInPluginCapability> = new Set([
+  "fs:project-write",
+  "fs:user-data-write",
+  "git:write",
+  "shell:exec",
+]);
+
+function manifestHasTightNetworkScope(manifest: PluginManifest | undefined): boolean {
+  const urls = manifest?.scopes?.network?.allowedUrls;
+  return Array.isArray(urls) && urls.length > 0;
+}
+
+function manifestTriggersCompoundElevation(
+  manifest: PluginManifest | undefined,
+  declaredCapabilities: readonly BuiltInPluginCapability[]
+): boolean {
+  if (declaredCapabilities.length < 2) return false;
+  const capSet = new Set<BuiltInPluginCapability>(declaredCapabilities);
+  const hasSensitiveRead = [...SENSITIVE_READ_CAPABILITIES].some((c) => capSet.has(c));
+  const hasNetworkFetch = capSet.has("network:fetch");
+  const hasShellExec = capSet.has("shell:exec");
+  const networkScoped = manifestHasTightNetworkScope(manifest);
+
+  // Exfiltration class: sensitive read + unconstrained sink.
+  if (hasSensitiveRead) {
+    if (hasShellExec) return true;
+    if (hasNetworkFetch && !networkScoped) return true;
+  }
+
+  // Remote-controlled mutation class: network:fetch (the remote control
+  // channel) + any local write or shell sink. A tightly-scoped network:fetch
+  // can't be remote-controlled, so the scope attenuates this class too.
+  if (hasNetworkFetch && !networkScoped) {
+    for (const sink of REMOTE_MUTATION_SINK_CAPABILITIES) {
+      if (capSet.has(sink)) return true;
+    }
+  }
+
+  return false;
+}
+
 interface LoadedPlugin {
   manifest: PluginManifest;
   dir: string;
@@ -2523,14 +2591,17 @@ export class PluginService {
 
     // Host-authoritative danger: the plugin's self-reported `danger` is
     // advisory. Raise it to "confirm" (never lower) when the plugin holds a
-    // high-risk capability, so a plugin can't declare "safe" on a destructive
-    // action to slip past the renderer's confirm/MRU/repeatLast gates.
-    const manifestCapabilities = this.plugins.get(pluginId)?.manifest.capabilities ?? [];
+    // high-risk capability or a compound-capability pair (#9247), so a plugin
+    // can't declare "safe" on a destructive action to slip past the renderer's
+    // confirm/MRU/repeatLast gates.
+    const manifest = this.plugins.get(pluginId)?.manifest;
+    const manifestCapabilities = manifest?.capabilities ?? [];
     const hasHighRiskCapability = manifestCapabilities.some((p) =>
       CONFIRM_TRIGGERING_CAPABILITIES.has(p)
     );
+    const hasCompoundElevation = manifestTriggersCompoundElevation(manifest, manifestCapabilities);
     const effectiveDanger: "safe" | "confirm" =
-      danger === "confirm" || hasHighRiskCapability ? "confirm" : "safe";
+      danger === "confirm" || hasHighRiskCapability || hasCompoundElevation ? "confirm" : "safe";
 
     return {
       pluginId,

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -436,6 +436,152 @@ describe("PluginManifestSchema capabilities field", () => {
   });
 });
 
+describe("PluginManifestSchema scopes field", () => {
+  const validBase = { name: "acme.scope-test", version: "1.0.0" };
+
+  it("accepts manifest with no scopes field", () => {
+    const result = getPluginManifestSchema(false).safeParse(validBase);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.scopes).toBeUndefined();
+    }
+  });
+
+  it("accepts empty scopes object (both buckets optional)", () => {
+    const result = getPluginManifestSchema(false).safeParse({ ...validBase, scopes: {} });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a valid network scope with one https URL", () => {
+    const result = getPluginManifestSchema(false).safeParse({
+      ...validBase,
+      scopes: { network: { allowedUrls: ["https://api.example.com/v2"] } },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.scopes?.network?.allowedUrls).toEqual(["https://api.example.com/v2"]);
+    }
+  });
+
+  it.each([
+    ["http://api.example.com", "scope_url_not_https"],
+    ["ftp://api.example.com", "scope_url_not_https"],
+    ["file:///etc/passwd", "scope_url_not_https"],
+    ["https://localhost", "scope_url_private_target"],
+    ["https://intranet", "scope_url_hostname_unqualified"],
+    ["https://127.0.0.1", "scope_url_private_target"],
+    ["https://[::1]", "scope_url_private_target"],
+    ["https://169.254.169.254", "scope_url_private_target"],
+    ["https://10.0.0.1", "scope_url_private_target"],
+    ["https://192.168.1.1", "scope_url_private_target"],
+    ["https://172.16.0.1", "scope_url_private_target"],
+    ["https://172.31.255.255", "scope_url_private_target"],
+    ["https://user:pass@example.com", "scope_url_has_credentials"],
+    ["https://example.com/*", "scope_wildcard_rejected"],
+    ["https://*.example.com", "scope_wildcard_rejected"],
+    ["not-a-url", "scope_url_invalid"],
+  ])("rejects network.allowedUrls entry %j with errorCode %s", (url, errorCode) => {
+    const result = getPluginManifestSchema(false).safeParse({
+      ...validBase,
+      scopes: { network: { allowedUrls: [url] } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const matching = result.error.issues.find(
+        (i) =>
+          i.code === "custom" &&
+          (i as unknown as { params?: { errorCode?: string } }).params?.errorCode === errorCode
+      );
+      expect(matching).toBeDefined();
+    }
+  });
+
+  it("rejects empty allowedUrls array (min 1 required)", () => {
+    const result = getPluginManifestSchema(false).safeParse({
+      ...validBase,
+      scopes: { network: { allowedUrls: [] } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown key inside scopes (strict)", () => {
+    const result = getPluginManifestSchema(false).safeParse({
+      ...validBase,
+      scopes: { networking: { allowedUrls: ["https://api.example.com"] } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.code === "unrecognized_keys")).toBe(true);
+    }
+  });
+
+  it("rejects unknown key inside scopes.network (strict)", () => {
+    const result = getPluginManifestSchema(false).safeParse({
+      ...validBase,
+      scopes: {
+        network: {
+          allowedUrls: ["https://api.example.com"],
+          deniedUrls: ["https://evil.com"],
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.code === "unrecognized_keys")).toBe(true);
+    }
+  });
+
+  it("accepts a valid fs scope with an absolute path", () => {
+    const result = getPluginManifestSchema(false).safeParse({
+      ...validBase,
+      scopes: { fs: { allowedPaths: ["/home/user/projects"] } },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.scopes?.fs?.allowedPaths).toEqual(["/home/user/projects"]);
+    }
+  });
+
+  it.each([
+    ["relative/path", "scope_path_relative"],
+    ["./relative", "scope_path_relative"],
+    ["../escape", "scope_path_relative"],
+    ["/home/user/../etc", "scope_path_traversal"],
+    ["/home/user/**", "scope_wildcard_rejected"],
+    ["/home/*/projects", "scope_wildcard_rejected"],
+  ])("rejects fs.allowedPaths entry %j with errorCode %s", (entryPath, errorCode) => {
+    const result = getPluginManifestSchema(false).safeParse({
+      ...validBase,
+      scopes: { fs: { allowedPaths: [entryPath] } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const matching = result.error.issues.find(
+        (i) =>
+          i.code === "custom" &&
+          (i as unknown as { params?: { errorCode?: string } }).params?.errorCode === errorCode
+      );
+      expect(matching).toBeDefined();
+    }
+  });
+
+  it("rejects empty allowedPaths array (min 1 required)", () => {
+    const result = getPluginManifestSchema(false).safeParse({
+      ...validBase,
+      scopes: { fs: { allowedPaths: [] } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects scalar (non-array) allowedUrls value", () => {
+    const result = getPluginManifestSchema(false).safeParse({
+      ...validBase,
+      scopes: { network: { allowedUrls: "https://api.example.com" } },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
 describe("PluginManifestSchema forgeProviders contribution", () => {
   const validBase = { name: "acme.forge", version: "1.0.0" };
 
@@ -3496,11 +3642,164 @@ describe("Plugin action registry", () => {
     }
   );
 
-  it("does not raise effectiveDanger for read-only / reversible capabilities", async () => {
+  it.each([
+    ["agent:read", "network:fetch"],
+    ["git:read", "network:fetch"],
+    ["fs:project-read", "network:fetch"],
+    ["fs:user-data-read", "network:fetch"],
+  ])(
+    "raises effectiveDanger to 'confirm' for compound exfiltration pair %s + %s (no scope)",
+    async (source, sink) => {
+      const safeName = `${source}-${sink}`.replace(/[^a-z]/g, "-");
+      const name = `acme.compound-${safeName}`;
+      await writePlugin(`compound-${safeName}`, {
+        name,
+        version: "1.0.0",
+        capabilities: [source, sink],
+      });
+      const svc = new PluginService(tmpDir);
+      await svc.initialize();
+
+      svc.registerPluginAction(name, {
+        ...validContribution(),
+        id: `${name}.doThing`,
+        danger: "safe" as const,
+      });
+
+      const action = svc.listPluginActions().find((a) => a.id === `${name}.doThing`);
+      expect(action?.danger).toBe("safe");
+      expect(action?.effectiveDanger).toBe("confirm");
+    }
+  );
+
+  it("does NOT raise effectiveDanger for compound exfiltration pair when network:fetch has a tight scope", async () => {
+    await writePlugin("scoped-network", {
+      name: "acme.scoped-network",
+      version: "1.0.0",
+      capabilities: ["agent:read", "network:fetch"],
+      scopes: { network: { allowedUrls: ["https://api.example.com/v2"] } },
+    });
+    const svc = new PluginService(tmpDir);
+    await svc.initialize();
+
+    svc.registerPluginAction("acme.scoped-network", {
+      ...validContribution(),
+      id: "acme.scoped-network.doThing",
+      danger: "safe" as const,
+    });
+
+    const action = svc.listPluginActions().find((a) => a.id === "acme.scoped-network.doThing");
+    expect(action?.effectiveDanger).toBe("safe");
+  });
+
+  it("raises effectiveDanger for sensitive-read + shell:exec even with network scope (shell is never attenuated)", async () => {
+    await writePlugin("read-shell", {
+      name: "acme.read-shell",
+      version: "1.0.0",
+      capabilities: ["fs:project-read", "shell:exec"],
+      scopes: { network: { allowedUrls: ["https://api.example.com"] } },
+    });
+    const svc = new PluginService(tmpDir);
+    await svc.initialize();
+
+    svc.registerPluginAction("acme.read-shell", {
+      ...validContribution(),
+      id: "acme.read-shell.doThing",
+      danger: "safe" as const,
+    });
+
+    // shell:exec is flat-elevated regardless — but the test asserts the compound
+    // path also fires because the network scope must not attenuate shell sinks.
+    const action = svc.listPluginActions().find((a) => a.id === "acme.read-shell.doThing");
+    expect(action?.effectiveDanger).toBe("confirm");
+  });
+
+  it("raises effectiveDanger for remote-mutation pair network:fetch + git:write (no scope)", async () => {
+    await writePlugin("net-write", {
+      name: "acme.net-write",
+      version: "1.0.0",
+      capabilities: ["network:fetch", "git:write"],
+    });
+    const svc = new PluginService(tmpDir);
+    await svc.initialize();
+
+    svc.registerPluginAction("acme.net-write", {
+      ...validContribution(),
+      id: "acme.net-write.doThing",
+      danger: "safe" as const,
+    });
+
+    // git:write already elevates flat — compound path is redundant but correct.
+    expect(
+      svc.listPluginActions().find((a) => a.id === "acme.net-write.doThing")?.effectiveDanger
+    ).toBe("confirm");
+  });
+
+  it("does not compound-elevate a plugin holding only a sensitive read (no sink)", async () => {
+    await writePlugin("read-only", {
+      name: "acme.read-only",
+      version: "1.0.0",
+      capabilities: ["agent:read", "git:read"],
+    });
+    const svc = new PluginService(tmpDir);
+    await svc.initialize();
+
+    svc.registerPluginAction("acme.read-only", {
+      ...validContribution(),
+      id: "acme.read-only.doThing",
+      danger: "safe" as const,
+    });
+
+    expect(
+      svc.listPluginActions().find((a) => a.id === "acme.read-only.doThing")?.effectiveDanger
+    ).toBe("safe");
+  });
+
+  it("does not compound-elevate a plugin holding only network:fetch (no source/sink pair)", async () => {
+    await writePlugin("net-only", {
+      name: "acme.net-only",
+      version: "1.0.0",
+      capabilities: ["network:fetch"],
+    });
+    const svc = new PluginService(tmpDir);
+    await svc.initialize();
+
+    svc.registerPluginAction("acme.net-only", {
+      ...validContribution(),
+      id: "acme.net-only.doThing",
+      danger: "safe" as const,
+    });
+
+    expect(
+      svc.listPluginActions().find((a) => a.id === "acme.net-only.doThing")?.effectiveDanger
+    ).toBe("safe");
+  });
+
+  it("compound elevation is order-independent in the capabilities array", async () => {
+    await writePlugin("order", {
+      name: "acme.order",
+      version: "1.0.0",
+      capabilities: ["network:fetch", "agent:read"],
+    });
+    const svc = new PluginService(tmpDir);
+    await svc.initialize();
+
+    svc.registerPluginAction("acme.order", {
+      ...validContribution(),
+      id: "acme.order.doThing",
+      danger: "safe" as const,
+    });
+
+    expect(
+      svc.listPluginActions().find((a) => a.id === "acme.order.doThing")?.effectiveDanger
+    ).toBe("confirm");
+  });
+
+  it("does not raise effectiveDanger for read-only / reversible capabilities (no compound pair)", async () => {
     await writePlugin("readonly", {
       name: "acme.readonly",
       version: "1.0.0",
-      capabilities: ["fs:project-read", "network:fetch", "clipboard:write", "git:read"],
+      capabilities: ["fs:project-read", "clipboard:write", "git:read"],
     });
     const svc = new PluginService(tmpDir);
     await svc.initialize();

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -476,6 +476,10 @@ describe("PluginManifestSchema scopes field", () => {
     ["https://192.168.1.1", "scope_url_private_target"],
     ["https://172.16.0.1", "scope_url_private_target"],
     ["https://172.31.255.255", "scope_url_private_target"],
+    ["https://0", "scope_url_private_target"],
+    ["https://0.0.0.0", "scope_url_private_target"],
+    ["https://localhost.", "scope_url_private_target"],
+    ["https://LOCALHOST", "scope_url_private_target"],
     ["https://user:pass@example.com", "scope_url_has_credentials"],
     ["https://example.com/*", "scope_wildcard_rejected"],
     ["https://*.example.com", "scope_wildcard_rejected"],
@@ -3672,24 +3676,55 @@ describe("Plugin action registry", () => {
     }
   );
 
-  it("does NOT raise effectiveDanger for compound exfiltration pair when network:fetch has a tight scope", async () => {
-    await writePlugin("scoped-network", {
-      name: "acme.scoped-network",
+  it.each(["agent:read", "git:read", "fs:project-read", "fs:user-data-read"])(
+    "tight network scope attenuates compound elevation for sensitive-read source %s + network:fetch",
+    async (source) => {
+      const safe = source.replace(/[^a-z]/g, "-");
+      const name = `acme.attenuated-${safe}`;
+      await writePlugin(`attenuated-${safe}`, {
+        name,
+        version: "1.0.0",
+        capabilities: [source, "network:fetch"],
+        scopes: { network: { allowedUrls: ["https://api.example.com/v2"] } },
+      });
+      const svc = new PluginService(tmpDir);
+      await svc.initialize();
+
+      svc.registerPluginAction(name, {
+        ...validContribution(),
+        id: `${name}.doThing`,
+        danger: "safe" as const,
+      });
+
+      expect(svc.listPluginActions().find((a) => a.id === `${name}.doThing`)?.effectiveDanger).toBe(
+        "safe"
+      );
+    }
+  );
+
+  it("scoped network:fetch does NOT suppress flat elevation from fs:project-write", async () => {
+    // The compound attenuation only short-circuits the compound elevation path
+    // — flat-elevated capabilities in CONFIRM_TRIGGERING_CAPABILITIES must
+    // still raise effectiveDanger regardless of any scope.
+    await writePlugin("scoped-with-write", {
+      name: "acme.scoped-with-write",
       version: "1.0.0",
-      capabilities: ["agent:read", "network:fetch"],
-      scopes: { network: { allowedUrls: ["https://api.example.com/v2"] } },
+      capabilities: ["network:fetch", "fs:project-write"],
+      scopes: { network: { allowedUrls: ["https://api.example.com"] } },
     });
     const svc = new PluginService(tmpDir);
     await svc.initialize();
 
-    svc.registerPluginAction("acme.scoped-network", {
+    svc.registerPluginAction("acme.scoped-with-write", {
       ...validContribution(),
-      id: "acme.scoped-network.doThing",
+      id: "acme.scoped-with-write.doThing",
       danger: "safe" as const,
     });
 
-    const action = svc.listPluginActions().find((a) => a.id === "acme.scoped-network.doThing");
-    expect(action?.effectiveDanger).toBe("safe");
+    expect(
+      svc.listPluginActions().find((a) => a.id === "acme.scoped-with-write.doThing")
+        ?.effectiveDanger
+    ).toBe("confirm");
   });
 
   it("raises effectiveDanger for sensitive-read + shell:exec even with network scope (shell is never attenuated)", async () => {

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -107,6 +107,46 @@ export interface McpServerContribution {
   env?: Record<string, string>;
 }
 
+/**
+ * Per-capability scope binding that attenuates the compound-capability lattice
+ * elevation in `PluginService.validateAndBuildActionDescriptor`. The lattice
+ * elevates `effectiveDanger` to `"confirm"` when a plugin pairs a sensitive
+ * source (sensitive reads, or `network:fetch` as a remote control channel)
+ * with a sink (`network:fetch`, local writes, `shell:exec`). Tightly-bound
+ * sinks skip elevation — a plugin that proves its `network:fetch` only talks
+ * to one explicit HTTPS API is not a generic exfiltration channel.
+ *
+ * Wildcards (`*`, `**`) are rejected at schema parse time so a tightly-bound
+ * declaration cannot smuggle a permissive value past the manifest gate.
+ * SSRF targets (loopback, link-local, RFC1918) and embedded credentials are
+ * also rejected at parse time. See `electron/schemas/plugin.ts` for the
+ * canonical validation rules.
+ */
+export interface PluginNetworkScope {
+  /**
+   * Allowlist of HTTPS URLs the plugin's `network:fetch` capability may talk
+   * to. Each entry must parse as a `https:` URL with a multi-segment hostname,
+   * no embedded credentials, no wildcards, and no private/loopback target.
+   */
+  allowedUrls: string[];
+}
+
+export interface PluginFsScope {
+  /**
+   * Allowlist of absolute filesystem paths the plugin's `fs:*` capabilities
+   * may touch. Each entry must be an absolute path containing no `..` segment
+   * and no `*`/`**` glob (literal-path allowlist only). Reserved for future
+   * compound rules that attenuate fs sinks; the current lattice only consults
+   * `scopes.network` for compound elevation.
+   */
+  allowedPaths: string[];
+}
+
+export interface PluginManifestScopes {
+  network?: PluginNetworkScope;
+  fs?: PluginFsScope;
+}
+
 export interface PluginManifest {
   name: string;
   version: string;
@@ -117,6 +157,13 @@ export interface PluginManifest {
     daintree?: string;
   };
   capabilities?: PluginCapability[];
+  /**
+   * Per-capability scope bindings that attenuate the compound-capability
+   * lattice. See {@link PluginManifestScopes}. Absent on most plugins —
+   * the lattice still elevates compound pairs without scopes, so this field
+   * is opt-in only for plugins that need to skip elevation.
+   */
+  scopes?: PluginManifestScopes;
   activationEvents?: "onStartupFinished"[];
   contributes: {
     panels: PanelContribution[];


### PR DESCRIPTION
## Summary

The flat `CONFIRM_TRIGGERING_CAPABILITIES` set only catches single-capability risks. Two compound threat classes slipped through:

- **Exfiltration** -- any sensitive read (`agent:read`, `git:read`, `fs:project-read`, `fs:user-data-read`) paired with an unconstrained network sink (`network:fetch`) or `shell:exec`
- **Remote-controlled mutation** -- `network:fetch` paired with any local write (`fs:project-write`, `fs:user-data-write`, `git:write`) or `shell:exec`

Both now raise `effectiveDanger` to `"confirm"` via a new lattice in `validateAndBuildActionDescriptor`. The host may only raise, never lower, so existing flat elevations are unaffected.

To give well-behaved plugins a way out, the manifest gains an optional `scopes` field. A non-empty `scopes.network.allowedUrls` with a valid https-only allowlist marks `network:fetch` as tightly-scoped, skipping compound elevation for that plugin. `shell:exec` is never attenuated -- categorically too risky. `scopes.fs.allowedPaths` is validated and stored but not yet consulted by the lattice (reserved for future fs-sink attenuation).

Resolves #9247

## Changes

- `shared/types/plugin.ts` -- `PluginNetworkScope`, `PluginFsScope`, `PluginManifestScopes` interfaces; optional `scopes` on `PluginManifest`
- `electron/schemas/plugin.ts` -- `PluginAllowedUrlSchema` (https-only, rejects wildcards, SSRF targets, single-label hosts, trailing-dot variants, `0.0.0.0`), `PluginAllowedPathSchema` (absolute, no `..` segments), `PluginNetworkScopeSchema`, `PluginFsScopeSchema`, `PluginManifestScopesSchema`; wired into the strict manifest object
- `electron/services/PluginService.ts` -- `SENSITIVE_READ_CAPABILITIES`, `REMOTE_MUTATION_SINK_CAPABILITIES`, `manifestHasTightNetworkScope()`, `manifestTriggersCompoundElevation()`; extended `effectiveDanger` block
- `electron/services/__tests__/PluginService.test.ts` -- URL/path validation matrices, SSRF bypass matrix (`0.0.0.0`, trailing-dot, case-insensitive), 9 compound-lattice cases (all 4 exfiltration source pairs, full attenuation matrix, remote-mutation pair, order independence, source-only/sink-only negatives)

## Testing

- `npx vitest run electron/services/__tests__/PluginService.test.ts` -- 377 pass
- `npx vitest run src/components/__tests__/PluginConfirmDialog.test.tsx` -- 13 pass
- `npm run typecheck` -- clean
- `npm run check` -- clean; lint ratchet baseline unchanged at 1195