### PR TITLE
feat(plugins): audit plugin:invoke failures and decoration timeouts

### DIFF
--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -270,10 +270,57 @@ describe("registerPluginHandlers", () => {
     });
     expect(typeof record.errorMessage).toBe("string");
     expect(record.errorMessage).toContain("No plugin handler registered");
-    // Hash is computed from a redacted args summary, so it must be a non-empty
-    // hex string (64-char sha256) even when args are present.
     expect(record.argsHash).toMatch(/^[0-9a-f]{64}$/);
     expect(typeof record.durationMs).toBe("number");
+  });
+
+  it("PLUGIN_INVOKE audit hash discriminates by arg content (#9240)", async () => {
+    // The whole point of the hash on `ipc-invoke` records is forensic
+    // grouping: distinct args MUST produce distinct hashes, otherwise the
+    // hash is just a constant marker and adds no value over the recordType.
+    // A summary-based hash collapses arrays to a constant and would fail
+    // this assertion — `stableArgsSha256` is the right primitive.
+    mockDispatchHandler.mockRejectedValue(new Error("boom"));
+
+    registerPluginHandlers();
+    const invokeHandler = mockIpcMainHandle.mock.calls.find(
+      (c: unknown[]) => c[0] === "plugin:invoke"
+    )![1] as (...args: unknown[]) => unknown;
+
+    const trustedEvent = {
+      senderFrame: { url: "app://daintree/" },
+      sender: { id: 1 },
+    };
+    await expect(invokeHandler(trustedEvent, "p", "ch", "arg-A")).rejects.toThrow();
+    await expect(invokeHandler(trustedEvent, "p", "ch", "arg-B")).rejects.toThrow();
+    await expect(invokeHandler(trustedEvent, "p", "ch", "arg-A")).rejects.toThrow();
+    expect(mockAuditAppend).toHaveBeenCalledTimes(3);
+    const hashes = mockAuditAppend.mock.calls.map((c) => c[0].argsHash as string);
+    // Same args → same hash; different args → different hash.
+    expect(hashes[0]).toBe(hashes[2]);
+    expect(hashes[0]).not.toBe(hashes[1]);
+  });
+
+  it("PLUGIN_INVOKE caps the audited URL on untrusted-sender rejection (#9240)", async () => {
+    registerPluginHandlers();
+    const invokeHandler = mockIpcMainHandle.mock.calls.find(
+      (c: unknown[]) => c[0] === "plugin:invoke"
+    )![1] as (...args: unknown[]) => unknown;
+
+    // A long attacker-controlled URL must not pollute the persistent audit
+    // log with arbitrary content; cap it before it enters errorMessage.
+    const longUrl = `https://evil.test/${"x".repeat(2000)}`;
+    const untrustedEvent = { senderFrame: { url: longUrl }, sender: { id: 1 } };
+    await expect(invokeHandler(untrustedEvent, "p", "ch")).rejects.toThrow(
+      "plugin:invoke rejected: untrusted sender"
+    );
+    expect(mockAuditAppend).toHaveBeenCalledTimes(1);
+    const record = mockAuditAppend.mock.calls[0][0];
+    expect(record.result).toBe("restricted");
+    // 200 chars URL cap + the "untrusted sender (url=...)" wrapping is small,
+    // so the whole errorMessage should stay well under ~300 chars.
+    expect(record.errorMessage.length).toBeLessThan(300);
+    expect(record.errorMessage).toContain("https://evil.test/");
   });
 
   it("PLUGIN_INVOKE handler still rethrows when audit append throws", async () => {
@@ -919,6 +966,51 @@ describe("PLUGIN_FILE_DECORATIONS_GET handler", () => {
     const handler = getHandler();
     await handler({}, "worktree-diff:/r", ["a.ts"]);
     expect(mockAuditAppend).not.toHaveBeenCalled();
+  });
+
+  it("audited durationMs reflects per-provider settle time, not slowest-provider wall-clock (#9240)", async () => {
+    // A provider that rejects immediately and another that hangs until the
+    // timeout must produce audit records with *different* durationMs values,
+    // proving the time is captured at each provider's settle moment rather
+    // than after `Promise.allSettled` returns.
+    vi.useFakeTimers();
+    try {
+      mockGetFileDecorationImpls.mockReturnValue([
+        {
+          pluginId: "p.fast-fail",
+          contributionId: "deco",
+          impl: {
+            provideDecorations: vi.fn().mockRejectedValue(new Error("immediate reject")),
+          },
+        },
+        {
+          pluginId: "p.hang",
+          contributionId: "deco",
+          impl: { provideDecorations: vi.fn().mockReturnValue(new Promise(() => {})) },
+        },
+      ]);
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const handler = getHandler();
+      const promise = handler({}, "s:1", ["a.ts"]) as Promise<unknown>;
+      await vi.advanceTimersByTimeAsync(3000);
+      await promise;
+      expect(mockAuditAppend).toHaveBeenCalledTimes(2);
+      const recordsByPlugin = new Map<string, { durationMs: number }>();
+      for (const call of mockAuditAppend.mock.calls) {
+        recordsByPlugin.set(call[0].pluginId, call[0]);
+      }
+      const fast = recordsByPlugin.get("p.fast-fail")!;
+      const slow = recordsByPlugin.get("p.hang")!;
+      // The rejecting provider settles immediately (microtask after the
+      // race is constructed); the hanging one settles when the 3000ms
+      // timer fires. Allow some slack for the test scheduler.
+      expect(fast.durationMs).toBeLessThan(slow.durationMs);
+      expect(fast.durationMs).toBeLessThan(100);
+      expect(slow.durationMs).toBeGreaterThanOrEqual(3000);
+      warn.mockRestore();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("omits paths whose merged decoration has no fields", async () => {

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -52,6 +52,11 @@ vi.mock("../../../services/fileDecorationRegistry.js", () => ({
   getFileDecorationImpls: (...args: unknown[]) => mockGetFileDecorationImpls(...args),
 }));
 
+const mockAuditAppend = vi.fn();
+vi.mock("../../../services/PluginActionAuditService.js", () => ({
+  getPluginActionAuditService: () => ({ append: mockAuditAppend }),
+}));
+
 const mockIpcMainHandle = vi.fn();
 const mockIpcMainRemoveHandler = vi.fn();
 vi.mock("electron", () => ({
@@ -197,6 +202,9 @@ describe("registerPluginHandlers", () => {
       ["arg1", "arg2"]
     );
     expect(result).toEqual({ data: "hello" });
+    // Successful invokes are intentionally not audited — they would be
+    // high-frequency and overwhelm the ring buffer (#9240).
+    expect(mockAuditAppend).not.toHaveBeenCalled();
   });
 
   it("PLUGIN_INVOKE handler builds ctx with webContentsId from event.sender.id", async () => {
@@ -238,6 +246,57 @@ describe("registerPluginHandlers", () => {
     );
   });
 
+  it("PLUGIN_INVOKE handler audits dispatch failures (#9240)", async () => {
+    mockDispatchHandler.mockRejectedValue(new Error("No plugin handler registered for x:y"));
+
+    registerPluginHandlers();
+    const invokeHandler = mockIpcMainHandle.mock.calls.find(
+      (c: unknown[]) => c[0] === "plugin:invoke"
+    )![1] as (...args: unknown[]) => unknown;
+
+    const trustedEvent = {
+      senderFrame: { url: "app://daintree/" },
+      sender: { id: 1 },
+    };
+    await expect(invokeHandler(trustedEvent, "x", "y", "arg1")).rejects.toThrow();
+    expect(mockAuditAppend).toHaveBeenCalledTimes(1);
+    const record = mockAuditAppend.mock.calls[0][0];
+    expect(record).toMatchObject({
+      pluginId: "x",
+      actionId: "y",
+      recordType: "ipc-invoke",
+      channel: "plugin:invoke",
+      result: "error",
+    });
+    expect(typeof record.errorMessage).toBe("string");
+    expect(record.errorMessage).toContain("No plugin handler registered");
+    // Hash is computed from a redacted args summary, so it must be a non-empty
+    // hex string (64-char sha256) even when args are present.
+    expect(record.argsHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(typeof record.durationMs).toBe("number");
+  });
+
+  it("PLUGIN_INVOKE handler still rethrows when audit append throws", async () => {
+    mockDispatchHandler.mockRejectedValue(new Error("dispatch failed"));
+    mockAuditAppend.mockImplementationOnce(() => {
+      throw new Error("audit broken");
+    });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    registerPluginHandlers();
+    const invokeHandler = mockIpcMainHandle.mock.calls.find(
+      (c: unknown[]) => c[0] === "plugin:invoke"
+    )![1] as (...args: unknown[]) => unknown;
+
+    const trustedEvent = {
+      senderFrame: { url: "app://daintree/" },
+      sender: { id: 1 },
+    };
+    // The original dispatch error must surface — never the audit error.
+    await expect(invokeHandler(trustedEvent, "x", "y")).rejects.toThrow("dispatch failed");
+    errSpy.mockRestore();
+  });
+
   it("PLUGIN_INVOKE handler rejects untrusted senders and does not dispatch", async () => {
     registerPluginHandlers();
     const invokeHandler = mockIpcMainHandle.mock.calls.find(
@@ -252,6 +311,22 @@ describe("registerPluginHandlers", () => {
       invokeHandler(untrustedEvent, "acme.my-plugin", "get-data", "arg1")
     ).rejects.toThrow("plugin:invoke rejected: untrusted sender");
     expect(mockDispatchHandler).not.toHaveBeenCalled();
+    // Untrusted-sender rejection still writes an audit row (#9240 / #8442
+    // audit-even-when-silenced) so a forensic record of the attempted invoke
+    // survives even though the dispatch never ran.
+    expect(mockAuditAppend).toHaveBeenCalledTimes(1);
+    const record = mockAuditAppend.mock.calls[0][0];
+    expect(record).toMatchObject({
+      pluginId: "acme.my-plugin",
+      actionId: "get-data",
+      recordType: "ipc-invoke",
+      channel: "plugin:invoke",
+      result: "restricted",
+      // Args are attacker-controlled and unvalidated — no hash.
+      argsHash: "",
+    });
+    expect(record.errorMessage).toContain("untrusted sender");
+    expect(record.errorMessage).toContain("https://evil.com");
   });
 
   it("PLUGIN_INVOKE handler rejects when senderFrame is missing and does not dispatch", async () => {
@@ -265,6 +340,14 @@ describe("registerPluginHandlers", () => {
       "plugin:invoke rejected: untrusted sender"
     );
     expect(mockDispatchHandler).not.toHaveBeenCalled();
+    // Missing-frame is also recorded as a restricted invoke.
+    expect(mockAuditAppend).toHaveBeenCalledTimes(1);
+    expect(mockAuditAppend.mock.calls[0][0]).toMatchObject({
+      recordType: "ipc-invoke",
+      result: "restricted",
+      pluginId: "acme.my-plugin",
+      actionId: "get-data",
+    });
   });
 
   it("PLUGIN_INVOKE handler rejects invalid args before dispatchHandler runs", async () => {
@@ -741,8 +824,101 @@ describe("PLUGIN_FILE_DECORATIONS_GET handler", () => {
         },
       },
     ]);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const handler = getHandler();
     expect(await handler({}, "s:1", ["a.ts"])).toEqual({ "a.ts": { badge: "3" } });
+    warn.mockRestore();
+  });
+
+  it("audits a rejecting provider (#9240)", async () => {
+    mockGetFileDecorationImpls.mockReturnValue([
+      {
+        pluginId: "p.bad",
+        contributionId: "deco",
+        impl: { provideDecorations: vi.fn().mockRejectedValue(new Error("boom")) },
+      },
+      {
+        pluginId: "p.good",
+        contributionId: "deco",
+        impl: {
+          provideDecorations: vi.fn().mockResolvedValue({ "a.ts": { badge: "3" } }),
+        },
+      },
+    ]);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const handler = getHandler();
+    await handler({}, "worktree-diff:/r", ["a.ts"]);
+    // Healthy provider is not audited; only the rejecting one is.
+    expect(mockAuditAppend).toHaveBeenCalledTimes(1);
+    const record = mockAuditAppend.mock.calls[0][0];
+    expect(record).toMatchObject({
+      pluginId: "p.bad",
+      actionId: "deco",
+      recordType: "decoration-failure",
+      result: "error",
+      failureMode: "rejected",
+      scope: "worktree-diff:/r",
+      contributionId: "deco",
+      argsHash: "",
+    });
+    expect(record.errorMessage).toContain("boom");
+    expect(typeof record.durationMs).toBe("number");
+    warn.mockRestore();
+  });
+
+  it("audits a provider that times out (#9240)", async () => {
+    vi.useFakeTimers();
+    try {
+      mockGetFileDecorationImpls.mockReturnValue([
+        {
+          pluginId: "p.hang",
+          contributionId: "deco",
+          impl: { provideDecorations: vi.fn().mockReturnValue(new Promise(() => {})) },
+        },
+        {
+          pluginId: "p.good",
+          contributionId: "deco",
+          impl: {
+            provideDecorations: vi.fn().mockResolvedValue({ "a.ts": { badge: "4" } }),
+          },
+        },
+      ]);
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const handler = getHandler();
+      const promise = handler({}, "worktree-diff:/r", ["a.ts"]) as Promise<unknown>;
+      await vi.advanceTimersByTimeAsync(3000);
+      await promise;
+      expect(mockAuditAppend).toHaveBeenCalledTimes(1);
+      const record = mockAuditAppend.mock.calls[0][0];
+      expect(record).toMatchObject({
+        pluginId: "p.hang",
+        actionId: "deco",
+        recordType: "decoration-failure",
+        result: "error",
+        failureMode: "timeout",
+        scope: "worktree-diff:/r",
+        contributionId: "deco",
+      });
+      expect(record.errorMessage).toMatch(/timed out after 3000ms/);
+      warn.mockRestore();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not audit successful decoration settles (#9240)", async () => {
+    mockGetFileDecorationImpls.mockReturnValue([
+      {
+        pluginId: "p.good",
+        contributionId: "deco",
+        impl: {
+          provideDecorations: vi.fn().mockResolvedValue({ "a.ts": { badge: "1" } }),
+        },
+      },
+    ]);
+    const handler = getHandler();
+    await handler({}, "worktree-diff:/r", ["a.ts"]);
+    expect(mockAuditAppend).not.toHaveBeenCalled();
   });
 
   it("omits paths whose merged decoration has no fields", async () => {

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -14,10 +14,8 @@ import {
 } from "../../../shared/types/ipc/pluginAudit.js";
 import { PLUGIN_METHOD_CHANNELS } from "./plugin.preload.js";
 import { pluginService } from "../../services/PluginService.js";
-import { summarizeMcpArgs } from "../../../shared/utils/mcpArgsSummary.js";
 import { scrubSecrets } from "../../../shared/utils/secretScrubber.js";
-import { sanitizePath } from "../../utils/pathScrubber.js";
-import { sha256Hex } from "../../utils/pluginMcpHash.js";
+import { stableArgsSha256 } from "../../utils/pluginMcpHash.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import {
   getPluginToolbarButtonIds,
@@ -170,8 +168,13 @@ function safeAppend(input: Parameters<PluginActionAuditService["append"]>[0]): v
   }
 }
 
-/** Pipeline applied to serialized arg summaries before they become the hash input. */
-const scrubArgSummary = (s: string): string => scrubSecrets(sanitizePath(s));
+/**
+ * Cap on attacker-controlled URL strings before they're embedded into an
+ * audit `errorMessage`. The origin and path prefix are forensically useful;
+ * the rest is log pollution and a vector for stuffing secret-like values
+ * into the persistent ring buffer.
+ */
+const UNTRUSTED_URL_MAX_CHARS = 200;
 
 /**
  * A non-empty string is "present" for merge purposes. Empty string counts as
@@ -213,10 +216,13 @@ async function handleFileDecorationsGet(
   if (impls.length === 0) return {};
 
   const merged: Record<string, FileDecoration> = {};
-  // Per-provider start timestamps so audit records carry true elapsed time on
-  // rejection/timeout, not a synthetic constant. Captured at the moment the
-  // race is constructed — matches the lifetime of the provider's promise.
+  // Per-provider start/end timestamps so audit records carry the true elapsed
+  // time of *each* provider, not the wall-clock of the slowest one. `ends[i]`
+  // is captured inside the race chain at the moment that provider settles,
+  // before `Promise.allSettled` returns — measuring `Date.now()` in the
+  // post-allSettled loop would assign every provider the same wall-clock.
   const starts: number[] = new Array(impls.length);
+  const ends: number[] = new Array(impls.length);
   const results = await Promise.allSettled(
     impls.map(({ impl }, i) => {
       starts[i] = Date.now();
@@ -225,14 +231,23 @@ async function handleFileDecorationsGet(
         new Promise<typeof DECORATION_TIMEOUT>((resolve) =>
           setTimeout(() => resolve(DECORATION_TIMEOUT), DECORATION_PROVIDER_TIMEOUT_MS)
         ),
-      ]);
+      ]).then(
+        (v) => {
+          ends[i] = Date.now();
+          return v;
+        },
+        (err: unknown) => {
+          ends[i] = Date.now();
+          throw err;
+        }
+      );
     })
   );
 
   for (let i = 0; i < results.length; i++) {
     const r = results[i];
     const { pluginId, contributionId } = impls[i];
-    const durationMs = Date.now() - starts[i];
+    const durationMs = ends[i] - starts[i];
     if (r.status === "rejected") {
       console.warn(
         `[Plugin] fileDecorationProvider "${pluginId}.${contributionId}" failed for scope "${scope}":`,
@@ -395,14 +410,19 @@ export function registerPluginHandlers(): () => void {
         // Trust check rejected — args are attacker-controlled and unvalidated,
         // so we record the rejection without hashing the payload (#8442:
         // audit-even-when-silenced; the security-relevant signal is "an
-        // untrusted frame attempted to invoke this plugin").
+        // untrusted frame attempted to invoke this plugin"). Cap the URL
+        // before it lands in the persistent log so a hostile frame can't
+        // stuff arbitrary content into the audit by sending a giant URL.
+        const safeUrl = senderUrl
+          ? scrubSecrets(senderUrl.slice(0, UNTRUSTED_URL_MAX_CHARS))
+          : "unknown";
         safeAppend({
           pluginId,
           actionId: channel,
           recordType: "ipc-invoke",
           channel: CHANNELS.PLUGIN_INVOKE,
           result: "restricted",
-          errorMessage: `untrusted sender (url=${senderUrl ?? "unknown"})`,
+          errorMessage: `untrusted sender (url=${safeUrl})`,
           argsHash: "",
           durationMs: Date.now() - start,
         });
@@ -417,11 +437,14 @@ export function registerPluginHandlers(): () => void {
       try {
         return await pluginService.dispatchHandler(pluginId, channel, ctx, args);
       } catch (err) {
-        // Hash the redacted summary so two structurally identical failed
-        // invokes group together in the viewer without persisting raw args.
+        // `stableArgsSha256` content-discriminates without persisting any
+        // arg bytes — two structurally identical failed invokes hash the
+        // same, but distinct args produce distinct hashes. (A summary-based
+        // hash via `summarizeMcpArgs` collapses arrays to a constant, which
+        // would defeat forensic grouping.)
         let argsHash = "";
         try {
-          argsHash = sha256Hex(summarizeMcpArgs(args, scrubArgSummary));
+          argsHash = stableArgsSha256(args);
         } catch {
           // Hashing is best-effort — a serialization throw here must not
           // mask the original handler error.

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -2,7 +2,10 @@ import { ipcMain, dialog } from "electron";
 import { writeFile } from "node:fs/promises";
 import { CHANNELS } from "../channels.js";
 import { defineIpcNamespace, op } from "../define.js";
-import { getPluginActionAuditService } from "../../services/PluginActionAuditService.js";
+import {
+  getPluginActionAuditService,
+  type PluginActionAuditService,
+} from "../../services/PluginActionAuditService.js";
 import {
   PLUGIN_AUDIT_MAX_RECORDS,
   PLUGIN_AUDIT_MIN_RECORDS,
@@ -11,6 +14,11 @@ import {
 } from "../../../shared/types/ipc/pluginAudit.js";
 import { PLUGIN_METHOD_CHANNELS } from "./plugin.preload.js";
 import { pluginService } from "../../services/PluginService.js";
+import { summarizeMcpArgs } from "../../../shared/utils/mcpArgsSummary.js";
+import { scrubSecrets } from "../../../shared/utils/secretScrubber.js";
+import { sanitizePath } from "../../utils/pathScrubber.js";
+import { sha256Hex } from "../../utils/pluginMcpHash.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import {
   getPluginToolbarButtonIds,
   getToolbarButtonConfig,
@@ -148,6 +156,24 @@ const DECORATION_PROVIDER_TIMEOUT_MS = 3000;
 const DECORATION_TIMEOUT = Symbol("decoration-timeout");
 
 /**
+ * Append an audit record without ever surfacing an audit failure to the
+ * caller. Mirrors `forgeAuditService.safeAppend` — a throw from `append()`
+ * (corrupt store, disk error) must never swallow the handler's return value
+ * or replace the original error. Audit is strictly a side channel; the
+ * `#8442` doctrine is that the record is best-effort, not load-bearing.
+ */
+function safeAppend(input: Parameters<PluginActionAuditService["append"]>[0]): void {
+  try {
+    getPluginActionAuditService().append(input);
+  } catch (err) {
+    console.error("[PluginAudit] Failed to append audit record:", err);
+  }
+}
+
+/** Pipeline applied to serialized arg summaries before they become the hash input. */
+const scrubArgSummary = (s: string): string => scrubSecrets(sanitizePath(s));
+
+/**
  * A non-empty string is "present" for merge purposes. Empty string counts as
  * absent so it can't block a later provider from supplying a real value.
  */
@@ -187,31 +213,61 @@ async function handleFileDecorationsGet(
   if (impls.length === 0) return {};
 
   const merged: Record<string, FileDecoration> = {};
+  // Per-provider start timestamps so audit records carry true elapsed time on
+  // rejection/timeout, not a synthetic constant. Captured at the moment the
+  // race is constructed — matches the lifetime of the provider's promise.
+  const starts: number[] = new Array(impls.length);
   const results = await Promise.allSettled(
-    impls.map(({ impl }) =>
-      Promise.race([
+    impls.map(({ impl }, i) => {
+      starts[i] = Date.now();
+      return Promise.race([
         impl.provideDecorations(scope, cleanPaths),
         new Promise<typeof DECORATION_TIMEOUT>((resolve) =>
           setTimeout(() => resolve(DECORATION_TIMEOUT), DECORATION_PROVIDER_TIMEOUT_MS)
         ),
-      ])
-    )
+      ]);
+    })
   );
 
   for (let i = 0; i < results.length; i++) {
     const r = results[i];
     const { pluginId, contributionId } = impls[i];
+    const durationMs = Date.now() - starts[i];
     if (r.status === "rejected") {
       console.warn(
         `[Plugin] fileDecorationProvider "${pluginId}.${contributionId}" failed for scope "${scope}":`,
         r.reason
       );
+      safeAppend({
+        pluginId,
+        actionId: contributionId,
+        recordType: "decoration-failure",
+        result: "error",
+        failureMode: "rejected",
+        scope,
+        contributionId,
+        errorMessage: formatErrorMessage(r.reason, "decoration provider rejected"),
+        argsHash: "",
+        durationMs,
+      });
       continue;
     }
     if (r.value === DECORATION_TIMEOUT) {
       console.warn(
         `[Plugin] fileDecorationProvider "${pluginId}.${contributionId}" timed out after ${DECORATION_PROVIDER_TIMEOUT_MS}ms for scope "${scope}"`
       );
+      safeAppend({
+        pluginId,
+        actionId: contributionId,
+        recordType: "decoration-failure",
+        result: "error",
+        failureMode: "timeout",
+        scope,
+        contributionId,
+        errorMessage: `timed out after ${DECORATION_PROVIDER_TIMEOUT_MS}ms`,
+        argsHash: "",
+        durationMs,
+      });
       continue;
     }
     if (!r.value || typeof r.value !== "object") continue;
@@ -333,8 +389,23 @@ export function registerPluginHandlers(): () => void {
   ipcMain.handle(
     CHANNELS.PLUGIN_INVOKE,
     async (event, pluginId: string, channel: string, ...args: unknown[]) => {
+      const start = Date.now();
       const senderUrl = event.senderFrame?.url;
       if (!senderUrl || !isTrustedRendererUrl(senderUrl)) {
+        // Trust check rejected — args are attacker-controlled and unvalidated,
+        // so we record the rejection without hashing the payload (#8442:
+        // audit-even-when-silenced; the security-relevant signal is "an
+        // untrusted frame attempted to invoke this plugin").
+        safeAppend({
+          pluginId,
+          actionId: channel,
+          recordType: "ipc-invoke",
+          channel: CHANNELS.PLUGIN_INVOKE,
+          result: "restricted",
+          errorMessage: `untrusted sender (url=${senderUrl ?? "unknown"})`,
+          argsHash: "",
+          durationMs: Date.now() - start,
+        });
         throw new Error(`plugin:invoke rejected: untrusted sender (url=${senderUrl ?? "unknown"})`);
       }
       const ctx: PluginIpcContext = {
@@ -343,7 +414,30 @@ export function registerPluginHandlers(): () => void {
         webContentsId: event.sender.id,
         pluginId,
       };
-      return await pluginService.dispatchHandler(pluginId, channel, ctx, args);
+      try {
+        return await pluginService.dispatchHandler(pluginId, channel, ctx, args);
+      } catch (err) {
+        // Hash the redacted summary so two structurally identical failed
+        // invokes group together in the viewer without persisting raw args.
+        let argsHash = "";
+        try {
+          argsHash = sha256Hex(summarizeMcpArgs(args, scrubArgSummary));
+        } catch {
+          // Hashing is best-effort — a serialization throw here must not
+          // mask the original handler error.
+        }
+        safeAppend({
+          pluginId,
+          actionId: channel,
+          recordType: "ipc-invoke",
+          channel: CHANNELS.PLUGIN_INVOKE,
+          result: "error",
+          errorMessage: formatErrorMessage(err, "plugin:invoke dispatch failed"),
+          argsHash,
+          durationMs: Date.now() - start,
+        });
+        throw err;
+      }
     }
   );
   cleanups.push(() => ipcMain.removeHandler(CHANNELS.PLUGIN_INVOKE));

--- a/electron/services/PluginActionAuditService.ts
+++ b/electron/services/PluginActionAuditService.ts
@@ -1,7 +1,9 @@
 // eager-import-allow: wires the plugin-audit ring buffer to the synchronous electron-store slice at boot (global service, mirrors ActionBreadcrumbService)
 import { randomUUID } from "node:crypto";
 import type {
+  DecorationFailureMode,
   PluginActionAuditRecord,
+  PluginActionAuditRecordType,
   PluginActionAuditResult,
   PluginAuditConfig,
 } from "../../shared/types/ipc/pluginAudit.js";
@@ -74,6 +76,7 @@ export class PluginActionAuditService {
         this.append({
           pluginId: payload.pluginId,
           actionId: payload.actionId,
+          recordType: "action-dispatch",
           source: payload.source as ActionSource,
           danger: payload.danger as ActionDanger,
           argsHash: typeof payload.argsHash === "string" ? payload.argsHash : "",
@@ -126,13 +129,26 @@ export class PluginActionAuditService {
   append(input: {
     pluginId: string;
     actionId: string;
-    source: ActionSource;
-    danger: ActionDanger;
+    recordType?: PluginActionAuditRecordType;
+    /** Only meaningful when `recordType === "action-dispatch"`. */
+    source?: ActionSource;
+    /** Only meaningful when `recordType === "action-dispatch"`. */
+    danger?: ActionDanger;
     argsHash: string;
     argsPlaintext?: string;
     durationMs: number;
     result: PluginActionAuditResult;
     turnId?: string;
+    /** IPC channel name — `ipc-invoke` records only. */
+    channel?: string;
+    /** Failure mode — `decoration-failure` records only. */
+    failureMode?: DecorationFailureMode;
+    /** Decoration scope — `decoration-failure` records only. */
+    scope?: string;
+    /** Decoration contribution id — `decoration-failure` records only. */
+    contributionId?: string;
+    /** Human-readable failure message — `error` records. */
+    errorMessage?: string;
   }): void {
     if (this.readConfig().auditEnabled === false) return;
     this.hydrate();
@@ -142,15 +158,21 @@ export class PluginActionAuditService {
       ts: Date.now(),
       pluginId: input.pluginId,
       actionId: input.actionId,
-      source: input.source,
-      danger: input.danger,
       argsHash: input.argsHash,
       durationMs: Math.max(0, Math.round(input.durationMs)),
       result: input.result,
       schemaVersion: PLUGIN_AUDIT_SCHEMA_VERSION,
     };
+    if (input.recordType !== undefined) record.recordType = input.recordType;
+    if (input.source !== undefined) record.source = input.source;
+    if (input.danger !== undefined) record.danger = input.danger;
     if (input.argsPlaintext !== undefined) record.argsPlaintext = input.argsPlaintext;
     if (input.turnId !== undefined) record.turnId = input.turnId;
+    if (input.channel !== undefined) record.channel = input.channel;
+    if (input.failureMode !== undefined) record.failureMode = input.failureMode;
+    if (input.scope !== undefined) record.scope = input.scope;
+    if (input.contributionId !== undefined) record.contributionId = input.contributionId;
+    if (input.errorMessage !== undefined) record.errorMessage = input.errorMessage;
 
     this.enqueueAndTrim(record);
   }

--- a/electron/services/__tests__/PluginActionAuditService.test.ts
+++ b/electron/services/__tests__/PluginActionAuditService.test.ts
@@ -282,6 +282,130 @@ describe("PluginActionAuditService", () => {
     expect(JSON.parse(lines[1]!).actionId).toBe("b");
   });
 
+  describe("non-action-dispatch record types", () => {
+    it("appends an ipc-invoke error record without source/danger", () => {
+      service.append({
+        pluginId: "acme.plugin",
+        actionId: "do-thing",
+        recordType: "ipc-invoke",
+        channel: "plugin:invoke",
+        argsHash: "a".repeat(64),
+        durationMs: 7,
+        result: "error",
+        errorMessage: "boom",
+      });
+      const records = service.getRecords();
+      expect(records).toHaveLength(1);
+      expect(records[0]).toMatchObject({
+        pluginId: "acme.plugin",
+        actionId: "do-thing",
+        recordType: "ipc-invoke",
+        channel: "plugin:invoke",
+        result: "error",
+        errorMessage: "boom",
+        durationMs: 7,
+      });
+      // No source/danger on non-action records.
+      expect(records[0]!.source).toBeUndefined();
+      expect(records[0]!.danger).toBeUndefined();
+    });
+
+    it("appends an ipc-invoke restricted record with empty argsHash", () => {
+      service.append({
+        pluginId: "acme.plugin",
+        actionId: "do-thing",
+        recordType: "ipc-invoke",
+        channel: "plugin:invoke",
+        argsHash: "",
+        durationMs: 0,
+        result: "restricted",
+        errorMessage: "untrusted sender (url=https://evil.com/)",
+      });
+      const r = service.getRecords()[0]!;
+      expect(r.recordType).toBe("ipc-invoke");
+      expect(r.result).toBe("restricted");
+      expect(r.argsHash).toBe("");
+      expect(r.errorMessage).toBe("untrusted sender (url=https://evil.com/)");
+    });
+
+    it("appends a decoration-failure timeout record", () => {
+      service.append({
+        pluginId: "p.slow",
+        actionId: "deco",
+        recordType: "decoration-failure",
+        result: "error",
+        failureMode: "timeout",
+        scope: "worktree-diff:/r",
+        contributionId: "deco",
+        errorMessage: "timed out after 3000ms",
+        argsHash: "",
+        durationMs: 3000,
+      });
+      const r = service.getRecords()[0]!;
+      expect(r).toMatchObject({
+        recordType: "decoration-failure",
+        failureMode: "timeout",
+        scope: "worktree-diff:/r",
+        contributionId: "deco",
+        errorMessage: "timed out after 3000ms",
+        result: "error",
+        durationMs: 3000,
+      });
+    });
+
+    it("appends a decoration-failure rejected record", () => {
+      service.append({
+        pluginId: "p.broken",
+        actionId: "deco",
+        recordType: "decoration-failure",
+        result: "error",
+        failureMode: "rejected",
+        scope: "worktree-diff:/r",
+        contributionId: "deco",
+        errorMessage: "provider rejected: boom",
+        argsHash: "",
+        durationMs: 5,
+      });
+      const r = service.getRecords()[0]!;
+      expect(r.failureMode).toBe("rejected");
+      expect(r.errorMessage).toBe("provider rejected: boom");
+    });
+
+    it("preserves chronological order across mixed record types", () => {
+      service.append({
+        pluginId: "p",
+        actionId: "a",
+        source: "user",
+        danger: "safe",
+        argsHash: "",
+        durationMs: 1,
+        result: "success",
+      });
+      service.append({
+        pluginId: "p",
+        actionId: "b",
+        recordType: "ipc-invoke",
+        channel: "plugin:invoke",
+        argsHash: "",
+        durationMs: 2,
+        result: "error",
+      });
+      service.append({
+        pluginId: "p",
+        actionId: "c",
+        recordType: "decoration-failure",
+        failureMode: "timeout",
+        scope: "s",
+        contributionId: "c",
+        argsHash: "",
+        durationMs: 3,
+        result: "error",
+      });
+      // Newest-first.
+      expect(service.getRecords().map((r) => r.actionId)).toEqual(["c", "b", "a"]);
+    });
+  });
+
   describe("bus integration", () => {
     it("records only plugin-contributed dispatches", () => {
       service.initialize({ isPlaintextEnabled: () => false });

--- a/electron/services/__tests__/PluginActionAuditService.test.ts
+++ b/electron/services/__tests__/PluginActionAuditService.test.ts
@@ -371,6 +371,31 @@ describe("PluginActionAuditService", () => {
       expect(r.errorMessage).toBe("provider rejected: boom");
     });
 
+    it("auditEnabled:false suppresses ipc-invoke and decoration-failure records too", () => {
+      store.saveConfig({ auditEnabled: false });
+      service.append({
+        pluginId: "p",
+        actionId: "ch",
+        recordType: "ipc-invoke",
+        channel: "plugin:invoke",
+        argsHash: "",
+        durationMs: 1,
+        result: "error",
+      });
+      service.append({
+        pluginId: "p",
+        actionId: "c",
+        recordType: "decoration-failure",
+        failureMode: "timeout",
+        scope: "s",
+        contributionId: "c",
+        argsHash: "",
+        durationMs: 3000,
+        result: "error",
+      });
+      expect(service.getRecords()).toEqual([]);
+    });
+
     it("preserves chronological order across mixed record types", () => {
       service.append({
         pluginId: "p",

--- a/shared/types/ipc/pluginAudit.ts
+++ b/shared/types/ipc/pluginAudit.ts
@@ -1,66 +1,134 @@
 import type { ActionSource, ActionDanger } from "../actions.js";
 
 /**
- * Outcome classification for a single plugin-contributed action dispatch.
+ * Outcome classification for a single audit record.
  *
  * - `success`: the action's `run()` resolved without throwing.
- * - `error`: the action's `run()` threw or rejected.
+ * - `error`: the action's `run()` threw, the IPC dispatch rejected, or a
+ *   file-decoration provider rejected/timed out.
  * - `disabled`: dispatch was rejected because the action's `isEnabled`
  *   predicate returned false.
- * - `restricted`: dispatch was rejected because the action is
- *   `danger: "restricted"`, or (once #9231 lands) a required capability
- *   grant was denied.
- *
- * Today only `success` is emitted — the renderer's `action:dispatched`
- * event fires post-success. The other variants are reserved so the record
- * shape is forward-compatible with failure/denial recording (a follow-up
- * partially gated on the #9231 capability gate).
+ * - `restricted`: dispatch or IPC invoke was rejected (e.g. untrusted sender
+ *   on `plugin:invoke`, action carries `danger: "restricted"`, or — once
+ *   #9231 lands — a required capability grant was denied).
  */
 export type PluginActionAuditResult = "success" | "error" | "disabled" | "restricted";
 
 /**
- * Persisted audit record for a single plugin-action dispatch. Written to a
- * ring buffer in the main process whenever an action contributed by a plugin
- * (`ActionDefinition.pluginId` set) is dispatched through `ActionService`.
+ * What kind of plugin activity this record describes. Absent values default
+ * to `"action-dispatch"` so records written before this field existed keep
+ * rendering as action dispatches.
  *
- * Privacy by default: `argsHash` is the SHA-256 hex digest of the dispatch
- * args, computed in the renderer before the record crosses IPC. Raw args are
- * never persisted unless the developer explicitly opts in via
- * `developerMode.pluginAuditPlaintext`, in which case a redacted plaintext
- * summary is stored in `argsPlaintext`.
+ * - `action-dispatch`: a plugin-contributed action dispatched through
+ *   `ActionService` (the original record type).
+ * - `ipc-invoke`: a raw `plugin:invoke` IPC call from the renderer. Only
+ *   failure outcomes (`error` / `restricted`) are recorded — successful
+ *   invokes are high-frequency and would dominate the ring buffer.
+ * - `decoration-failure`: a file-decoration provider rejected or exceeded
+ *   the per-provider timeout. Successful settles are never audited.
+ */
+export type PluginActionAuditRecordType = "action-dispatch" | "ipc-invoke" | "decoration-failure";
+
+/** How a decoration-failure record failed. */
+export type DecorationFailureMode = "timeout" | "rejected";
+
+/**
+ * Persisted audit record for a single plugin activity event. Written to a
+ * ring buffer in the main process for three event types:
+ *
+ *   1. Plugin-contributed action dispatch through `ActionService`
+ *      (`recordType === "action-dispatch"` — the original / default type).
+ *   2. Raw `plugin:invoke` IPC failure or trust-check rejection
+ *      (`recordType === "ipc-invoke"`).
+ *   3. File-decoration provider rejection or timeout
+ *      (`recordType === "decoration-failure"`).
+ *
+ * Privacy by default: `argsHash` is the SHA-256 hex digest of the redacted
+ * args summary. Raw args are never persisted unless the developer explicitly
+ * opts in via `developerMode.pluginAuditPlaintext`, in which case a redacted
+ * plaintext summary is stored in `argsPlaintext`.
+ *
+ * `source` and `danger` only apply to action-dispatch records and are
+ * absent on `ipc-invoke` and `decoration-failure` records.
  */
 export interface PluginActionAuditRecord {
   /** Stable record id (UUID). */
   id: string;
-  /** Wall-clock epoch millis the dispatch was recorded. */
+  /** Wall-clock epoch millis the event was recorded. */
   ts: number;
   /** Contributing plugin id (`ActionDefinition.pluginId`). */
   pluginId: string;
-  /** Dispatched action id — a plugin-registered open-union `ActionId`. */
-  actionId: string;
-  /** Dispatch source (user, keybinding, menu, agent, context-menu). */
-  source: ActionSource;
-  /** Danger classification of the action at dispatch time. */
-  danger: ActionDanger;
   /**
-   * SHA-256 hex digest of the JSON-serialized (redacted) dispatch args.
-   * Empty string when the dispatch carried no args or hashing failed.
+   * For `action-dispatch`: the plugin-registered open-union `ActionId`.
+   * For `ipc-invoke`: the IPC channel string passed to `plugin:invoke`.
+   * For `decoration-failure`: the contribution id of the failing provider.
+   */
+  actionId: string;
+  /**
+   * What kind of plugin activity this record describes. Absent on records
+   * written before this field existed; the viewer should treat absence as
+   * `"action-dispatch"`.
+   */
+  recordType?: PluginActionAuditRecordType;
+  /**
+   * Dispatch source — only present on `action-dispatch` records.
+   * (user, keybinding, menu, agent, context-menu).
+   */
+  source?: ActionSource;
+  /**
+   * Danger classification at dispatch time — only present on
+   * `action-dispatch` records.
+   */
+  danger?: ActionDanger;
+  /**
+   * SHA-256 hex digest of the JSON-serialized (redacted) args summary.
+   * Empty string when the event carried no args, hashing failed, or the
+   * args were never validated (e.g. untrusted-sender rejection).
    */
   argsHash: string;
   /**
-   * Redacted plaintext JSON of the dispatch args. Present only when
+   * Redacted plaintext JSON of the args. Present only when
    * `developerMode.pluginAuditPlaintext` was enabled at record-write time.
    */
   argsPlaintext?: string;
-  /** Wall-clock duration of the `run()` call in milliseconds. */
+  /** Wall-clock duration of the call in milliseconds. */
   durationMs: number;
-  /** Dispatch outcome classification. */
+  /** Event outcome classification. */
   result: PluginActionAuditResult;
   /**
-   * Stable correlation id for the assistant turn this dispatch belongs to.
+   * Stable correlation id for the assistant turn this event belongs to.
    * Reserved — absent until a renderer-facing turn-id push mechanism exists.
    */
   turnId?: string;
+  /**
+   * IPC channel name — only present on `ipc-invoke` records. Lets the
+   * viewer distinguish the channel string (e.g. `plugin:invoke`) from the
+   * caller-supplied channel argument stored in `actionId`.
+   */
+  channel?: string;
+  /**
+   * For `decoration-failure` records: the failure mode. `timeout` means
+   * the provider exceeded `DECORATION_PROVIDER_TIMEOUT_MS`; `rejected`
+   * means the provider's promise rejected.
+   */
+  failureMode?: DecorationFailureMode;
+  /**
+   * For `decoration-failure` records: the decoration scope string the
+   * provider was queried for (e.g. `"worktree-diff:/r"`).
+   */
+  scope?: string;
+  /**
+   * For `decoration-failure` records: the registered contribution id of
+   * the failing provider, mirrored from `actionId` for clarity in the
+   * viewer when multiple plugins contribute to the same scope.
+   */
+  contributionId?: string;
+  /**
+   * Human-readable failure message for `error` records. Mirrors the
+   * `errorMessage` field on `ForgeAuditRecord`. Empty string on
+   * `restricted` records where there's no underlying exception.
+   */
+  errorMessage?: string;
   /** Schema version for forward-compat. New records carry the current version. */
   schemaVersion: number;
 }


### PR DESCRIPTION
## Summary

- Extends `PluginActionAuditRecord` with optional fields for `recordType` (`"action-dispatch"` | `"ipc-invoke"` | `"decoration-failure"`), `channel`, `failureMode`, `scope`, `contributionId`, and `errorMessage`; `source` and `danger` are now optional since they don't apply to IPC and decoration records
- The `PLUGIN_INVOKE` handler now records trust-check rejections (`result: "restricted"`, URL capped at 200 chars and secret-scrubbed) and dispatch errors (`result: "error"`, args hashed via `stableArgsSha256` for content discrimination) — successful invokes are never audited since they're high-frequency
- `handleFileDecorationsGet` records rejection (`failureMode: "rejected"`) and timeout (`failureMode: "timeout"`) with `durationMs` captured inside the `Promise.race` chain for per-provider precision; a `safeAppend` wrapper ensures audit-store throws never mask handler errors

Resolves #9240

## Changes

- `shared/types/ipc/pluginAudit.ts` — new `PluginActionAuditRecordType`, `DecorationFailureMode` types; extended record interface with optional fields
- `electron/services/PluginActionAuditService.ts` — `append()` accepts the new optional fields and threads each through with conditional assignment
- `electron/ipc/handlers/plugin.ts` — audit on `PLUGIN_INVOKE` trust rejection and dispatch error; audit on decoration rejection and timeout with per-provider timing
- `electron/services/__tests__/PluginActionAuditService.test.ts` — 4 new service unit tests
- `electron/ipc/handlers/__tests__/plugin.handlers.test.ts` — 7 new handler tests

## Testing

11 new tests covering all new record types, content-discriminating hash behaviour, URL capping at 200 chars, per-provider `durationMs` precision, and `auditEnabled`-suppression of the new record types. All 73 tests in the affected test files pass.