### PR TITLE
feat(plugins): wire renderer consumer for plugin menu items

### DIFF
--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -58,6 +58,7 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
   "plugin:actions-changed": "external",
   "plugin:panel-kinds-changed": "external",
   "plugin:toolbar-buttons-changed": "external",
+  "plugin:menu-items-changed": "external",
   "plugin:decorations-changed": "external",
   "plugin:provenance-changed": "external",
   "terminal:exit": "external",

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -59,6 +59,10 @@ async function handleToolbarButtons(): Promise<ToolbarButtonConfig[]> {
 }
 
 async function handleMenuItems() {
+  // Same init-race guard as `handleToolbarButtons` — block until startup
+  // activation settles so the renderer's mount-time pull can't observe an
+  // empty registry before plugins finish registering (#9285).
+  await pluginService.waitForInit();
   return getPluginMenuItems();
 }
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -133,7 +133,7 @@ import type {
 type SpawnResultPayload = SpawnResult;
 import type { PortalNewTabMenuAction } from "../shared/types/portal.js";
 import type { ResourceProfilePayload } from "../shared/types/resourceProfile.js";
-import type { PluginActionDescriptor } from "../shared/types/plugin.js";
+import type { PluginActionDescriptor, MenuItemContribution } from "../shared/types/plugin.js";
 import type { PanelKindConfig } from "../shared/config/panelKindRegistry.js";
 import type { ToolbarButtonConfig } from "../shared/config/toolbarButtonRegistry.js";
 
@@ -2472,6 +2472,12 @@ const api: ElectronAPI = {
     onToolbarButtonsChanged: (
       callback: (payload: { buttons: ToolbarButtonConfig[]; complete: boolean }) => void
     ) => _eventBusOn("plugin:toolbar-buttons-changed", callback),
+    onMenuItemsChanged: (
+      callback: (payload: {
+        items: Array<{ pluginId: string; item: MenuItemContribution }>;
+        complete: boolean;
+      }) => void
+    ) => _eventBusOn("plugin:menu-items-changed", callback),
     onDecorationsChanged: (callback: (payload: { scope: string; paths?: string[] }) => void) =>
       _eventBusOn("plugin:decorations-changed", callback),
   },

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -61,7 +61,11 @@ import {
   unregisterPluginToolbarButtons,
   getAllPluginToolbarButtonConfigs,
 } from "../../shared/config/toolbarButtonRegistry.js";
-import { registerPluginMenuItem, unregisterPluginMenuItems } from "./pluginMenuRegistry.js";
+import {
+  registerPluginMenuItem,
+  unregisterPluginMenuItems,
+  getPluginMenuItems,
+} from "./pluginMenuRegistry.js";
 import {
   registerPluginKeybinding,
   unregisterPluginKeybindings,
@@ -391,6 +395,14 @@ export class PluginService {
    * partial/growing snapshot (concurrent load + deferred init) and must not.
    */
   private toolbarButtonsBroadcastComplete = false;
+  /**
+   * Same coalescing rationale as {@link toolbarButtonsBroadcastPending}. Menu
+   * items are mutated only from `loadPlugin()` / `unloadPlugin()`, so the two
+   * call sites invoke {@link scheduleMenuItemsBroadcast} directly.
+   */
+  private menuItemsBroadcastPending = false;
+  /** Mirrors {@link toolbarButtonsBroadcastComplete} for menu items. */
+  private menuItemsBroadcastComplete = false;
   private disposed = false;
   private readonly disposeRegistrySubscriptions: () => void;
   /**
@@ -832,6 +844,9 @@ export class PluginService {
     for (const menuItem of manifest.contributes.menuItems) {
       trackPluginExpression(manifest.name, menuItem.when);
       registerPluginMenuItem(manifest.name, menuItem);
+    }
+    if (manifest.contributes.menuItems.length > 0) {
+      this.scheduleMenuItemsBroadcast(false);
     }
 
     for (const keybinding of manifest.contributes.keybindings) {
@@ -2217,6 +2232,9 @@ export class PluginService {
       this.unregisterPluginActions(pluginId)
     );
     runUnloadStep(pluginId, "unregisterPluginMenuItems", () => unregisterPluginMenuItems(pluginId));
+    runUnloadStep(pluginId, "scheduleMenuItemsBroadcast", () =>
+      this.scheduleMenuItemsBroadcast(true)
+    );
     runUnloadStep(pluginId, "unregisterPluginKeybindings", () =>
       unregisterPluginKeybindings(pluginId)
     );
@@ -2678,6 +2696,31 @@ export class PluginService {
   }
 
   /**
+   * Same shape as {@link scheduleToolbarButtonsBroadcast}; see that method for
+   * the coalescing and `complete`-OR-accumulation rationale.
+   */
+  private scheduleMenuItemsBroadcast(complete: boolean): void {
+    if (this.disposed) return;
+    if (complete) this.menuItemsBroadcastComplete = true;
+    if (this.menuItemsBroadcastPending) return;
+    this.menuItemsBroadcastPending = true;
+    queueMicrotask(() => {
+      this.menuItemsBroadcastPending = false;
+      const drained = this.menuItemsBroadcastComplete;
+      this.menuItemsBroadcastComplete = false;
+      if (this.disposed) return;
+      this.broadcastPluginMenuItems(drained);
+    });
+  }
+
+  private broadcastPluginMenuItems(complete: boolean): void {
+    broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
+      name: "plugin:menu-items-changed",
+      payload: { items: getPluginMenuItems(), complete },
+    });
+  }
+
+  /**
    * Replay the current actions / panel-kinds / toolbar-button snapshots to a
    * single target webContents. Used by the cold-start view-ready hook so a
    * freshly-restored WebContentsView (post-LRU eviction or first cold load on
@@ -2707,6 +2750,10 @@ export class PluginService {
       {
         name: "plugin:toolbar-buttons-changed",
         payload: { buttons: getAllPluginToolbarButtonConfigs(), complete: false },
+      },
+      {
+        name: "plugin:menu-items-changed",
+        payload: { items: getPluginMenuItems(), complete: false },
       },
     ];
     for (const event of events) {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -83,6 +83,7 @@ vi.mock("../../../shared/config/toolbarButtonRegistry.js", () => ({
 vi.mock("../pluginMenuRegistry.js", () => ({
   registerPluginMenuItem: vi.fn(),
   unregisterPluginMenuItems: vi.fn(),
+  getPluginMenuItems: vi.fn(() => []),
 }));
 vi.mock("../forgeProviderRegistry.js", () => ({
   registerForgeProviders: vi.fn(),
@@ -5956,7 +5957,7 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
     await expect(waiter).resolves.toBeUndefined();
   });
 
-  it("pushSnapshotTo() sends actions, panel kinds, and toolbar buttons to the target webContents", async () => {
+  it("pushSnapshotTo() sends actions, panel kinds, toolbar buttons, and menu items to the target webContents", async () => {
     const service = new PluginService(tmpDir);
     await service.activateStartupFinishedPlugins();
     const send = vi.fn();
@@ -5964,7 +5965,7 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
 
     await service.pushSnapshotTo(wc);
 
-    expect(send).toHaveBeenCalledTimes(3);
+    expect(send).toHaveBeenCalledTimes(4);
     // Every replay goes through the EVENTS_PUSH channel — the same channel the
     // renderer hooks' persistent push listeners consume, so no renderer-side
     // changes are needed for the cold-restore path.
@@ -5975,19 +5976,24 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
     expect(names).toContain("plugin:actions-changed");
     expect(names).toContain("plugin:panel-kinds-changed");
     expect(names).toContain("plugin:toolbar-buttons-changed");
-    // Toolbar replay must use `complete: false` so the renderer does not
-    // run a stale-prune sweep — replay is a load-style snapshot, not an
-    // unload-driven authoritative sweep.
+    expect(names).toContain("plugin:menu-items-changed");
+    // Toolbar and menu-item replays must use `complete: false` so the renderer
+    // does not run a stale-prune sweep — replay is a load-style snapshot, not
+    // an unload-driven authoritative sweep.
     const toolbarCall = send.mock.calls.find(
       (c) => (c[1] as { name?: string })?.name === "plugin:toolbar-buttons-changed"
     );
     expect((toolbarCall?.[1] as { payload: { complete: boolean } }).payload.complete).toBe(false);
+    const menuItemsCall = send.mock.calls.find(
+      (c) => (c[1] as { name?: string })?.name === "plugin:menu-items-changed"
+    );
+    expect((menuItemsCall?.[1] as { payload: { complete: boolean } }).payload.complete).toBe(false);
   });
 
   it("pushSnapshotTo() keeps sending remaining channels when one send() throws (TOCTOU)", async () => {
     // Simulates the wc being destroyed between the isDestroyed() guard and an
     // individual send — Electron raises "Object has been destroyed". Without
-    // per-send try/catch one bad call would silently drop the remaining two
+    // per-send try/catch one bad call would silently drop the remaining
     // channels and the cold-restored renderer would miss state.
     const service = new PluginService(tmpDir);
     await service.activateStartupFinishedPlugins();
@@ -6000,10 +6006,11 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
 
     await service.pushSnapshotTo(wc);
 
-    expect(send).toHaveBeenCalledTimes(3);
+    expect(send).toHaveBeenCalledTimes(4);
     const names = send.mock.calls.map((c) => (c[1] as { name?: string })?.name);
     expect(names).toContain("plugin:panel-kinds-changed");
     expect(names).toContain("plugin:toolbar-buttons-changed");
+    expect(names).toContain("plugin:menu-items-changed");
   });
 
   it("pushSnapshotTo() skips a destroyed webContents", async () => {
@@ -6031,7 +6038,7 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
 
     await service.activateStartupFinishedPlugins();
     await inFlight;
-    expect(send).toHaveBeenCalledTimes(3);
+    expect(send).toHaveBeenCalledTimes(4);
   });
 
   it("pushSnapshotTo() does not send after dispose()", async () => {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -3960,6 +3960,53 @@ describe("Plugin panel kind registry broadcast", () => {
   });
 });
 
+describe("Plugin menu items broadcast", () => {
+  it("coalesces load + unload in the same tick into a single broadcast with complete=true", async () => {
+    // Schedule a non-complete (load) broadcast followed by a complete (unload)
+    // broadcast in the same synchronous tick. The OR-accumulation invariant
+    // means the single coalesced broadcast must carry complete=true so the
+    // renderer treats it as authoritative.
+    const service = new PluginService();
+
+    type S = PluginService & {
+      scheduleMenuItemsBroadcast: (complete: boolean) => void;
+    };
+    (service as S).scheduleMenuItemsBroadcast(false);
+    (service as S).scheduleMenuItemsBroadcast(true);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const menuItemsBroadcasts = broadcastToRendererMock.mock.calls.filter(
+      (call) => (call[1] as { name?: unknown })?.name === "plugin:menu-items-changed"
+    );
+    expect(menuItemsBroadcasts).toHaveLength(1);
+    expect(
+      (menuItemsBroadcasts[0]?.[1] as { payload: { complete: boolean } }).payload.complete
+    ).toBe(true);
+
+    service.dispose();
+  });
+
+  it("dispose() drops a menu items broadcast scheduled before disposal", async () => {
+    const service = new PluginService();
+
+    type S = PluginService & {
+      scheduleMenuItemsBroadcast: (complete: boolean) => void;
+    };
+    (service as S).scheduleMenuItemsBroadcast(true);
+    service.dispose();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const menuItemsBroadcasts = broadcastToRendererMock.mock.calls.filter(
+      (call) => (call[1] as { name?: unknown })?.name === "plugin:menu-items-changed"
+    );
+    expect(menuItemsBroadcasts).toHaveLength(0);
+  });
+});
+
 describe("capabilities declaration logging", () => {
   let logSpy: ReturnType<typeof vi.spyOn>;
   let errorSpy: ReturnType<typeof vi.spyOn>;

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -3968,11 +3968,10 @@ describe("Plugin menu items broadcast", () => {
     // renderer treats it as authoritative.
     const service = new PluginService();
 
-    type S = PluginService & {
-      scheduleMenuItemsBroadcast: (complete: boolean) => void;
-    };
-    (service as S).scheduleMenuItemsBroadcast(false);
-    (service as S).scheduleMenuItemsBroadcast(true);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).scheduleMenuItemsBroadcast(false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).scheduleMenuItemsBroadcast(true);
 
     await Promise.resolve();
     await Promise.resolve();
@@ -3991,10 +3990,8 @@ describe("Plugin menu items broadcast", () => {
   it("dispose() drops a menu items broadcast scheduled before disposal", async () => {
     const service = new PluginService();
 
-    type S = PluginService & {
-      scheduleMenuItemsBroadcast: (complete: boolean) => void;
-    };
-    (service as S).scheduleMenuItemsBroadcast(true);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).scheduleMenuItemsBroadcast(true);
     service.dispose();
 
     await Promise.resolve();

--- a/electron/window/perWindowInit.ts
+++ b/electron/window/perWindowInit.ts
@@ -86,6 +86,29 @@ export async function initPerWindowServices(
     },
   });
 
+  // Native View/Help menus include plugin-contributed menu items via
+  // `getPluginMenuItems()` at build time, but `createApplicationMenu` ran above
+  // before any plugin's `activate()` had finished — so its first menu would
+  // show none of them. Lazy-import `pluginService` to avoid the cyclic edge
+  // (`PluginService` depends on services that may eventually reach window
+  // code), then await init and rebuild once. Dynamic plugin load/unload does
+  // not refresh the native menu — accepted limitation; the in-app renderer
+  // hook is the dynamic surface.
+  registerDeferredTask({
+    name: `plugin-menu-rebuild:${win.id}`,
+    run: async () => {
+      try {
+        const { pluginService } = await import("../services/PluginService.js");
+        await pluginService.waitForInit();
+        if (!win.isDestroyed()) {
+          createApplicationMenu(win, cliService);
+        }
+      } catch (err) {
+        console.error("[MAIN] Plugin menu rebuild failed:", err);
+      }
+    },
+  });
+
   // Arm the drain trigger immediately. All tasks for this window are now
   // registered; any subsequent `await` in setupWindowServices could hang
   // (PTY host, workspace loadProject, plugin init) and must not block the

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1505,6 +1505,16 @@ export interface ElectronAPI extends GeneratedElectronAPI {
         complete: boolean;
       }) => void
     ): () => void;
+    /** Subscribe to plugin menu item registry changes. Returns a cleanup. */
+    onMenuItemsChanged(
+      callback: (payload: {
+        items: Array<{
+          pluginId: string;
+          item: import("../plugin.js").MenuItemContribution;
+        }>;
+        complete: boolean;
+      }) => void
+    ): () => void;
   };
   crashRecovery: {
     getPending(): Promise<import("./crashRecovery.js").PendingCrash | null>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1880,6 +1880,14 @@ export interface IpcEventMap {
     complete: boolean;
   };
 
+  // Plugin menu item registry events (main → renderer). Same `complete` flag
+  // semantics as toolbar buttons: true for an authoritative post-unload
+  // snapshot, false for partial/growing load-time broadcasts.
+  "plugin:menu-items-changed": {
+    items: Array<{ pluginId: string; item: import("../plugin.js").MenuItemContribution }>;
+    complete: boolean;
+  };
+
   // Plugin file-decoration invalidation (main → renderer). Carries only the
   // changed scope (optionally narrowed to `paths`) — never decoration data.
   // The renderer re-pulls fresh decorations via `plugin:file-decorations-get`.
@@ -1967,6 +1975,8 @@ export type IpcEventBusMap = Pick<
   | "plugin:panel-kinds-changed"
   // Plugin toolbar button registry (global broadcast)
   | "plugin:toolbar-buttons-changed"
+  // Plugin menu item registry (global broadcast)
+  | "plugin:menu-items-changed"
   // Plugin file-decoration invalidation (global broadcast)
   | "plugin:decorations-changed"
   // Plugin provenance record changed (global broadcast)

--- a/src/hooks/__tests__/usePluginMenuItems.test.ts
+++ b/src/hooks/__tests__/usePluginMenuItems.test.ts
@@ -182,27 +182,23 @@ describe("usePluginMenuItems", () => {
     await waitFor(() => expect(result.current).toHaveLength(1));
   });
 
-  it("excludes items whose when clause evaluates falsy", async () => {
+  it("filters when clauses around a positive control (truthy keeps, falsy/unset/malformed drop)", async () => {
+    // Positive control alongside the negative cases — without it the assertion
+    // would pass trivially against `useState`'s initial empty array even if
+    // the hook never applied the pull result. The visible item proves the
+    // pull resolved AND `useMemo` ran the filter.
     menuItemsMock.mockResolvedValue([
+      entry("acme", "Visible", "terminal", { when: "true" }),
       entry("acme", "Hidden", "terminal", { when: "false" }),
       entry("acme", "Unset", "terminal", { when: "missingContextKey" }),
+      entry("acme", "Malformed", "terminal", { when: "&& bad" }),
     ]);
     const { usePluginMenuItems } = await import("../usePluginMenuItems");
     const { result } = renderHook(() => usePluginMenuItems("terminal"));
 
-    // Pull resolves to [] of filtered items — wait for any state settling
-    // then assert the filtered set is empty.
-    await waitFor(() => expect(menuItemsMock).toHaveBeenCalled());
-    expect(result.current).toEqual([]);
-  });
-
-  it("excludes items whose when clause fails to parse (fail-closed)", async () => {
-    menuItemsMock.mockResolvedValue([entry("acme", "Malformed", "terminal", { when: "&& bad" })]);
-    const { usePluginMenuItems } = await import("../usePluginMenuItems");
-    const { result } = renderHook(() => usePluginMenuItems("terminal"));
-
-    await waitFor(() => expect(menuItemsMock).toHaveBeenCalled());
-    expect(result.current).toEqual([]);
+    await waitFor(() => {
+      expect(result.current.map((e) => e.item.label)).toEqual(["Visible"]);
+    });
   });
 
   it("cleans up the push subscription on unmount", async () => {

--- a/src/hooks/__tests__/usePluginMenuItems.test.ts
+++ b/src/hooks/__tests__/usePluginMenuItems.test.ts
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import type { MenuItemContribution, MenuItemLocation } from "@shared/types/plugin";
+
+const { menuItemsMock, onMenuItemsChangedMock } = vi.hoisted(() => ({
+  menuItemsMock: vi.fn(),
+  onMenuItemsChangedMock: vi.fn(),
+}));
+
+function entry(
+  pluginId: string,
+  label: string,
+  location: MenuItemLocation,
+  extras: Partial<MenuItemContribution> = {}
+): { pluginId: string; item: MenuItemContribution } {
+  return {
+    pluginId,
+    item: {
+      label,
+      actionId: `${pluginId}.${label}`,
+      location,
+      ...extras,
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (globalThis as unknown as { window: unknown }).window = Object.assign(globalThis.window ?? {}, {
+    electron: {
+      plugin: {
+        menuItems: menuItemsMock,
+        onMenuItemsChanged: onMenuItemsChangedMock,
+      },
+    },
+  });
+  vi.resetModules();
+  menuItemsMock.mockResolvedValue([]);
+  onMenuItemsChangedMock.mockReturnValue(() => {});
+});
+
+describe("usePluginMenuItems", () => {
+  it("exposes plugin menu items matching the requested location from the mount-time pull", async () => {
+    menuItemsMock.mockResolvedValue([
+      entry("acme", "Foo", "terminal"),
+      entry("acme", "Bar", "view"),
+    ]);
+    const { usePluginMenuItems } = await import("../usePluginMenuItems");
+
+    const { result } = renderHook(() => usePluginMenuItems("terminal"));
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1);
+    });
+    expect(result.current[0]?.item.label).toBe("Foo");
+  });
+
+  it("updates entries when a push arrives", async () => {
+    let emit:
+      | ((p: {
+          items: Array<{ pluginId: string; item: MenuItemContribution }>;
+          complete: boolean;
+        }) => void)
+      | null = null;
+    onMenuItemsChangedMock.mockImplementation(
+      (
+        cb: (p: {
+          items: Array<{ pluginId: string; item: MenuItemContribution }>;
+          complete: boolean;
+        }) => void
+      ) => {
+        emit = cb;
+        return () => {};
+      }
+    );
+    const { usePluginMenuItems } = await import("../usePluginMenuItems");
+    const { result } = renderHook(() => usePluginMenuItems("view"));
+
+    await waitFor(() => expect(emit).not.toBeNull());
+    act(() => {
+      emit!({ items: [entry("acme", "ViewItem", "view")], complete: false });
+    });
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]?.item.label).toBe("ViewItem");
+  });
+
+  it("filters out items whose location does not match", async () => {
+    let emit:
+      | ((p: {
+          items: Array<{ pluginId: string; item: MenuItemContribution }>;
+          complete: boolean;
+        }) => void)
+      | null = null;
+    onMenuItemsChangedMock.mockImplementation(
+      (
+        cb: (p: {
+          items: Array<{ pluginId: string; item: MenuItemContribution }>;
+          complete: boolean;
+        }) => void
+      ) => {
+        emit = cb;
+        return () => {};
+      }
+    );
+    const { usePluginMenuItems } = await import("../usePluginMenuItems");
+    const { result } = renderHook(() => usePluginMenuItems("terminal"));
+
+    await waitFor(() => expect(emit).not.toBeNull());
+    act(() => {
+      emit!({
+        items: [
+          entry("acme", "Term", "terminal"),
+          entry("acme", "ViewOnly", "view"),
+          entry("acme", "HelpOnly", "help"),
+        ],
+        complete: true,
+      });
+    });
+
+    expect(result.current.map((e) => e.item.label)).toEqual(["Term"]);
+  });
+
+  it("drops the mount-time pull if a push has already resolved (pushReceived guard)", async () => {
+    let resolvePull: ((v: Array<{ pluginId: string; item: MenuItemContribution }>) => void) | null =
+      null;
+    menuItemsMock.mockImplementation(
+      () =>
+        new Promise<Array<{ pluginId: string; item: MenuItemContribution }>>((res) => {
+          resolvePull = res;
+        })
+    );
+    let emit:
+      | ((p: {
+          items: Array<{ pluginId: string; item: MenuItemContribution }>;
+          complete: boolean;
+        }) => void)
+      | null = null;
+    onMenuItemsChangedMock.mockImplementation(
+      (
+        cb: (p: {
+          items: Array<{ pluginId: string; item: MenuItemContribution }>;
+          complete: boolean;
+        }) => void
+      ) => {
+        emit = cb;
+        return () => {};
+      }
+    );
+    const { usePluginMenuItems } = await import("../usePluginMenuItems");
+    const { result } = renderHook(() => usePluginMenuItems("terminal"));
+
+    await waitFor(() => expect(emit).not.toBeNull());
+    // Push arrives with the canonical state before the pull resolves.
+    act(() => {
+      emit!({ items: [entry("acme", "PushWins", "terminal")], complete: true });
+    });
+    // The late-resolving pull (which would return an empty initial set) must
+    // be dropped — otherwise it would roll the renderer back to []/stale.
+    act(() => {
+      resolvePull!([]);
+    });
+    await waitFor(() => {
+      expect(result.current.map((e) => e.item.label)).toEqual(["PushWins"]);
+    });
+  });
+
+  it("includes items without a when clause", async () => {
+    menuItemsMock.mockResolvedValue([entry("acme", "Always", "terminal")]);
+    const { usePluginMenuItems } = await import("../usePluginMenuItems");
+    const { result } = renderHook(() => usePluginMenuItems("terminal"));
+
+    await waitFor(() => expect(result.current).toHaveLength(1));
+  });
+
+  it("includes items whose when clause evaluates truthy", async () => {
+    menuItemsMock.mockResolvedValue([entry("acme", "Truthy", "terminal", { when: "true" })]);
+    const { usePluginMenuItems } = await import("../usePluginMenuItems");
+    const { result } = renderHook(() => usePluginMenuItems("terminal"));
+
+    await waitFor(() => expect(result.current).toHaveLength(1));
+  });
+
+  it("excludes items whose when clause evaluates falsy", async () => {
+    menuItemsMock.mockResolvedValue([
+      entry("acme", "Hidden", "terminal", { when: "false" }),
+      entry("acme", "Unset", "terminal", { when: "missingContextKey" }),
+    ]);
+    const { usePluginMenuItems } = await import("../usePluginMenuItems");
+    const { result } = renderHook(() => usePluginMenuItems("terminal"));
+
+    // Pull resolves to [] of filtered items — wait for any state settling
+    // then assert the filtered set is empty.
+    await waitFor(() => expect(menuItemsMock).toHaveBeenCalled());
+    expect(result.current).toEqual([]);
+  });
+
+  it("excludes items whose when clause fails to parse (fail-closed)", async () => {
+    menuItemsMock.mockResolvedValue([entry("acme", "Malformed", "terminal", { when: "&& bad" })]);
+    const { usePluginMenuItems } = await import("../usePluginMenuItems");
+    const { result } = renderHook(() => usePluginMenuItems("terminal"));
+
+    await waitFor(() => expect(menuItemsMock).toHaveBeenCalled());
+    expect(result.current).toEqual([]);
+  });
+
+  it("cleans up the push subscription on unmount", async () => {
+    const cleanupMock = vi.fn();
+    onMenuItemsChangedMock.mockReturnValue(cleanupMock);
+    const { usePluginMenuItems } = await import("../usePluginMenuItems");
+    const { unmount } = renderHook(() => usePluginMenuItems("terminal"));
+
+    unmount();
+    expect(cleanupMock).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/usePluginMenuItems.ts
+++ b/src/hooks/usePluginMenuItems.ts
@@ -1,0 +1,71 @@
+import { useState, useEffect, useMemo } from "react";
+import type { MenuItemContribution, MenuItemLocation } from "@shared/types/plugin";
+import { parse, evaluate } from "@shared/utils/whenClause";
+import { logWarn } from "@/utils/logger";
+
+export interface PluginMenuItemEntry {
+  pluginId: string;
+  item: MenuItemContribution;
+}
+
+/**
+ * Pull plugin-contributed menu items on mount and keep them in sync with
+ * main's authoritative set via push. Same pull-on-mount + push-authoritative
+ * shape as `usePluginToolbarButtons` — see that hook for the `pushReceived`
+ * race rationale.
+ *
+ * `when` clauses are evaluated synchronously against an empty context. The
+ * renderer-side reactive `WhenClauseStore` is not yet wired (no producers call
+ * `setWhenContext`), so an item that references unset context keys evaluates
+ * to `false` and is hidden — fail-closed. Parse errors are also fail-closed.
+ *
+ * Unlike toolbar buttons, menu items have no renderer-local persisted state to
+ * sweep, so the `complete` flag on the broadcast is received but has no side
+ * effect here. It is plumbed for symmetry with the broadcast contract.
+ */
+export function usePluginMenuItems(location: MenuItemLocation): PluginMenuItemEntry[] {
+  const [entries, setEntries] = useState<PluginMenuItemEntry[]>([]);
+
+  useEffect(() => {
+    let disposed = false;
+    let pushReceived = false;
+
+    const electron = typeof window !== "undefined" ? window.electron : undefined;
+    if (!electron?.plugin) return;
+
+    void electron.plugin
+      .menuItems()
+      .then((items) => {
+        if (disposed) return;
+        if (pushReceived) return;
+        setEntries(items);
+      })
+      .catch((err: unknown) => {
+        logWarn("[PluginMenuItems] Failed to fetch initial plugin menu items", { error: err });
+      });
+
+    const cleanup = electron.plugin.onMenuItemsChanged((payload) => {
+      if (disposed) return;
+      pushReceived = true;
+      setEntries(payload.items);
+    });
+
+    return () => {
+      disposed = true;
+      cleanup();
+    };
+  }, []);
+
+  return useMemo(() => {
+    return entries.filter((entry) => {
+      if (entry.item.location !== location) return false;
+      const whenExpr = entry.item.when;
+      if (!whenExpr) return true;
+      try {
+        return evaluate(parse(whenExpr), {});
+      } catch {
+        return false;
+      }
+    });
+  }, [entries, location]);
+}


### PR DESCRIPTION
## Summary

- The main process registry and native View/Help menu were already in place, but there was no renderer hook to consume menu items for in-app surfaces, no broadcast event for menu-item changes, and the native menu was built before plugins activated so plugin items never appeared.
- This PR closes the gap end-to-end: event type, preload subscription, `PluginService` broadcasts, renderer hook, IPC init-race fix, cold-restore snapshot, and a per-window deferred native menu rebuild.

Resolves #9288

## Changes

**Event and preload**
- New `plugin:menu-items-changed` event type with allowlist entry, preload subscription, and `ElectronAPI.plugin.onMenuItemsChanged` typing.

**PluginService broadcasts**
- `broadcastPluginMenuItems` and `scheduleMenuItemsBroadcast` added to `PluginService` — microtask coalescing and OR-accumulated `complete` flag, mirroring the toolbar buttons broadcasts exactly.
- Load- and unload-time broadcast triggers.
- Menu items snapshot included in `pushSnapshotTo` for cold-restored `WebContentsViews`.

**IPC handler**
- `handleMenuItems` now awaits `pluginService.waitForInit()`, matching the init-race fix applied to the toolbar handler in #9285.

**Renderer hook**
- New `usePluginMenuItems(location)` hook mirroring `usePluginToolbarButtons`: pull-on-mount, push-authoritative, `pushReceived` guard, per-location filter, synchronous when-clause evaluation via `@shared/utils/whenClause` (fail-closed against `{}`).

**Native menu**
- Per-window deferred task rebuilds the native menu once after `pluginService.waitForInit()` resolves, so plugin View/Help items appear on first paint.

## Out of scope

- No in-app context menu wiring (terminal/file-tree menus don't exist yet; the hook is the plumbing layer).
- When-clause context is evaluated against `{}` — `WhenClauseStore` has no producers yet, so items referencing context keys are hidden (same behaviour as `electron/menu.ts`).
- Dynamic plugin load/unload updates the renderer hook state but does not re-fire the native menu rebuild (rare path; acceptable trade-off).

## Testing

- `usePluginMenuItems` unit tests: location filter, push updates, `pushReceived` guard, when-clause positive/negative, cleanup on unmount — all pass.
- `PluginService` unit tests: extended `pushSnapshotTo` assertions for 4 events including menu items with `complete: false`; coalescing and dispose-cancel tests — all pass.
- `npm run check`: typecheck, IPC channel guards, lint ratchet, format check — all pass.