### PR TITLE
feat(plugins): typed plugin.invoke channel registry with capability gate

### DIFF
--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -245,9 +245,7 @@ function assertSettingsKey(pluginId: string, method: string, key: unknown): asse
  * dispatch with a raw `safeParse is not a function` TypeError outside the
  * documented `SCHEMA_ERROR:` envelope.
  */
-function isChannelSchema(
-  value: unknown
-): value is PluginChannelSchema<unknown, unknown> {
+function isChannelSchema(value: unknown): value is PluginChannelSchema<unknown, unknown> {
   if (typeof value !== "object" || value === null) return false;
   if (!("args" in value) || !("result" in value)) return false;
   const args = (value as { args: unknown }).args;

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -29,6 +29,7 @@ interface AjvInstance {
 }
 import { getPluginManifestSchema, PluginToastOptionsSchema } from "../schemas/plugin.js";
 import { getPluginMcpSupervisor } from "./PluginMcpSupervisor.js";
+import { z } from "zod";
 import type {
   PluginManifest,
   PluginIpcHandler,
@@ -37,6 +38,8 @@ import type {
   PluginActivate,
   PluginActionContribution,
   PluginActionDescriptor,
+  PluginChannelSchema,
+  PluginTypedIpcHandler,
   ActionHandler,
   BuiltInPluginCapability,
   InstalledPluginRecord,
@@ -232,11 +235,49 @@ function assertSettingsKey(pluginId: string, method: string, key: unknown): asse
   }
 }
 
+/**
+ * Discriminate between the typed `registerHandler(channel, schema, handler)`
+ * overload and the legacy `registerHandler(channel, handler)` overload. Bare
+ * non-function values aren't enough — the legacy test path passes a string as
+ * the handler to assert the "must be a function" error. A typed schema object
+ * has both `args` and `result` ZodTypes, so checking for `.args` on a
+ * non-function object is sufficient and lets the legacy validation error path
+ * surface as before.
+ */
+function isChannelSchema(
+  value: unknown
+): value is PluginChannelSchema<unknown, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "args" in value &&
+    "result" in value &&
+    typeof (value as { args: unknown }).args === "object" &&
+    (value as { args: unknown }).args !== null
+  );
+}
+
 type WorkspaceWorktreeEvent = "worktree-update" | "worktree-activated" | "worktree-removed";
 
 export class PluginService {
   private plugins = new Map<string, LoadedPlugin>();
   private handlerMap = new Map<string, PluginIpcHandler>();
+  /**
+   * Per-channel Zod schemas for typed `registerHandler` registrations, keyed
+   * by the same `pluginId:channel` key as {@link handlerMap}. Only populated
+   * for the typed overload — legacy untyped registrations omit the entry and
+   * skip schema validation at dispatch. Cleared per-plugin in
+   * {@link removeHandlers} alongside the handler entry.
+   */
+  private channelSchemas = new Map<string, PluginChannelSchema<unknown, unknown>>();
+  /**
+   * Per-channel capability gate for typed `registerHandler` registrations,
+   * keyed by the same `pluginId:channel` key as {@link handlerMap}.
+   * Authoritative check runs at registration (throws `PERMISSION_REQUIRED:`
+   * for missing capabilities); the dispatch-time re-check is defense-in-depth
+   * for future code paths that mutate manifests after load.
+   */
+  private channelRequires = new Map<string, readonly BuiltInPluginCapability[]>();
   private cleanupMap = new Map<string, () => void>();
   /**
    * Plugin ids whose `activate()` has resolved successfully this session.
@@ -1307,14 +1348,30 @@ export class PluginService {
 
         this.broadcastPluginActions();
       },
-      registerHandler: (channel, handler) => {
+      registerHandler: ((
+        channel: string,
+        schemaOrHandler:
+          | PluginChannelSchema<unknown, unknown>
+          | PluginIpcHandler
+          | PluginTypedIpcHandler<unknown, unknown>,
+        typedHandler?: PluginTypedIpcHandler<unknown, unknown>
+      ) => {
         if (revoked) {
           throw new Error(
             `Plugin "${pluginId}" host revoked: registerHandler called after activate() returned or timed out`
           );
         }
-        this.registerHandler(pluginId, channel, handler);
-      },
+        if (typedHandler !== undefined) {
+          this.registerHandler(
+            pluginId,
+            channel,
+            schemaOrHandler as PluginChannelSchema<unknown, unknown>,
+            typedHandler
+          );
+        } else {
+          this.registerHandler(pluginId, channel, schemaOrHandler as PluginIpcHandler);
+        }
+      }) as PluginHostApi["registerHandler"],
       broadcastToRenderer: (channel, payload) => {
         if (revoked) {
           throw new Error(
@@ -2047,18 +2104,75 @@ export class PluginService {
     return this.plugins.has(pluginId);
   }
 
-  registerHandler(pluginId: string, channel: string, handler: PluginIpcHandler): void {
-    if (!this.plugins.has(pluginId)) {
+  registerHandler<TArgs, TResult>(
+    pluginId: string,
+    channel: string,
+    schema: PluginChannelSchema<TArgs, TResult>,
+    handler: PluginTypedIpcHandler<TArgs, TResult>
+  ): void;
+  registerHandler(pluginId: string, channel: string, handler: PluginIpcHandler): void;
+  registerHandler(
+    pluginId: string,
+    channel: string,
+    schemaOrHandler:
+      | PluginChannelSchema<unknown, unknown>
+      | PluginIpcHandler
+      | PluginTypedIpcHandler<unknown, unknown>,
+    typedHandler?: PluginTypedIpcHandler<unknown, unknown>
+  ): void {
+    const plugin = this.plugins.get(pluginId);
+    if (!plugin) {
       throw new Error(`Unknown plugin: ${pluginId}`);
     }
     if (channel.includes(":")) {
       throw new Error(`Plugin channel must not contain colons: ${channel}`);
     }
-    if (typeof handler !== "function") {
-      throw new Error(`Plugin handler must be a function, got ${typeof handler}`);
-    }
+
     const key = `${pluginId}:${channel}`;
-    this.handlerMap.set(key, handler);
+    const isTypedOverload = isChannelSchema(schemaOrHandler);
+
+    if (isTypedOverload) {
+      const schema = schemaOrHandler;
+      if (typeof typedHandler !== "function") {
+        throw new Error(`Plugin handler must be a function, got ${typeof typedHandler}`);
+      }
+      // Fail-closed at registration: every capability listed in `requires`
+      // must already be declared in the plugin's manifest. Throwing here
+      // surfaces author misconfiguration loudly at load instead of at first
+      // dispatch (where it would look like a transient runtime error).
+      const requires = schema.requires ?? [];
+      const declared = new Set<BuiltInPluginCapability>(plugin.manifest.capabilities ?? []);
+      const missing = requires.filter((cap) => !declared.has(cap));
+      if (missing.length > 0) {
+        throw new Error(
+          `PERMISSION_REQUIRED: channel "${channel}" requires capability "${missing[0]}" which is not declared in plugin "${pluginId}" manifest.capabilities`
+        );
+      }
+
+      const boundHandler = typedHandler;
+      // Adapt the single-payload typed handler to the variadic
+      // PluginIpcHandler shape so the dispatch path stays uniform. The
+      // first variadic arg is the parsed payload; `dispatchHandler` only
+      // calls this after `schema.args.safeParse` succeeds, so the cast is
+      // safe at call time.
+      const adapter: PluginIpcHandler = (ctx, ...args) =>
+        boundHandler(ctx, args.length > 0 ? args[0] : undefined);
+
+      this.handlerMap.set(key, adapter);
+      this.channelSchemas.set(key, schema);
+      this.channelRequires.set(key, requires);
+      return;
+    }
+
+    if (typeof schemaOrHandler !== "function") {
+      throw new Error(`Plugin handler must be a function, got ${typeof schemaOrHandler}`);
+    }
+    // Re-registration drops any prior typed-channel metadata so a legacy
+    // re-bind doesn't strand a stale schema or capability gate keyed to the
+    // same channel.
+    this.channelSchemas.delete(key);
+    this.channelRequires.delete(key);
+    this.handlerMap.set(key, schemaOrHandler);
   }
 
   async dispatchHandler(
@@ -2148,8 +2262,41 @@ export class PluginService {
     if (!handler) {
       throw new Error(`No plugin handler registered for ${key}`);
     }
+
+    // Typed-channel path (registered via the schema overload of
+    // `registerHandler`). The capability gate already fired at registration
+    // — this re-check is defense-in-depth against a future code path that
+    // mutates a loaded manifest after registration.
+    const channelSchema = this.channelSchemas.get(key);
+    const channelRequires = this.channelRequires.get(key);
+    if (channelRequires && channelRequires.length > 0) {
+      const declared = new Set<BuiltInPluginCapability>(
+        this.plugins.get(pluginId)?.manifest.capabilities ?? []
+      );
+      const missing = channelRequires.find((cap) => !declared.has(cap));
+      if (missing) {
+        throw new Error(
+          `PERMISSION_REQUIRED: channel "${channel}" requires capability "${missing}" which is not declared in plugin "${pluginId}" manifest.capabilities`
+        );
+      }
+    }
+
+    let dispatchArgs: unknown[] = args;
+    if (channelSchema) {
+      const argsInput = args.length > 0 ? args[0] : undefined;
+      const parsed = channelSchema.args.safeParse(argsInput);
+      if (!parsed.success) {
+        throw new Error(`SCHEMA_ERROR: ${z.prettifyError(parsed.error)}`);
+      }
+      // Replace the raw variadic with the parsed payload so the typed
+      // adapter (and any downstream code) sees Zod's coerced/defaulted
+      // output rather than the wire-shape input.
+      dispatchArgs = [parsed.data];
+    }
+
+    let result: unknown;
     try {
-      return await handler(ctx, ...args);
+      result = await handler(ctx, ...dispatchArgs);
     } catch (err) {
       // Contain at the boundary so a throwing plugin handler can't propagate
       // up through `ipcMain.handle` as an unhandled rejection in the main
@@ -2160,6 +2307,18 @@ export class PluginService {
       console.error(`[PluginService] Handler "${key}" threw:`, err);
       throw err;
     }
+
+    if (channelSchema) {
+      const parsedResult = channelSchema.result.safeParse(result);
+      if (!parsedResult.success) {
+        throw new Error(
+          `SCHEMA_ERROR: result for channel "${channel}" failed validation: ${z.prettifyError(parsedResult.error)}`
+        );
+      }
+      return parsedResult.data;
+    }
+
+    return result;
   }
 
   removeHandlers(pluginId: string): void {
@@ -2168,6 +2327,8 @@ export class PluginService {
       if (key.startsWith(prefix)) {
         this.handlerMap.delete(key);
         this.actionValidators.delete(key.slice(prefix.length));
+        this.channelSchemas.delete(key);
+        this.channelRequires.delete(key);
       }
     }
   }

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -237,23 +237,28 @@ function assertSettingsKey(pluginId: string, method: string, key: unknown): asse
 
 /**
  * Discriminate between the typed `registerHandler(channel, schema, handler)`
- * overload and the legacy `registerHandler(channel, handler)` overload. Bare
- * non-function values aren't enough — the legacy test path passes a string as
- * the handler to assert the "must be a function" error. A typed schema object
- * has both `args` and `result` ZodTypes, so checking for `.args` on a
- * non-function object is sufficient and lets the legacy validation error path
- * surface as before.
+ * overload and the legacy `registerHandler(channel, handler)` overload. A
+ * typed schema must expose `args` and `result` Zod-compatible types — we
+ * probe for a `safeParse` method on both rather than trusting structural
+ * shape alone, so a JS plugin author bypassing TypeScript can't slip a
+ * malformed `{ args: {}, result: ... }` past registration only to crash at
+ * dispatch with a raw `safeParse is not a function` TypeError outside the
+ * documented `SCHEMA_ERROR:` envelope.
  */
 function isChannelSchema(
   value: unknown
 ): value is PluginChannelSchema<unknown, unknown> {
+  if (typeof value !== "object" || value === null) return false;
+  if (!("args" in value) || !("result" in value)) return false;
+  const args = (value as { args: unknown }).args;
+  const result = (value as { result: unknown }).result;
   return (
-    typeof value === "object" &&
-    value !== null &&
-    "args" in value &&
-    "result" in value &&
-    typeof (value as { args: unknown }).args === "object" &&
-    (value as { args: unknown }).args !== null
+    typeof args === "object" &&
+    args !== null &&
+    typeof (args as { safeParse?: unknown }).safeParse === "function" &&
+    typeof result === "object" &&
+    result !== null &&
+    typeof (result as { safeParse?: unknown }).safeParse === "function"
   );
 }
 
@@ -1362,12 +1367,17 @@ export class PluginService {
           );
         }
         if (typedHandler !== undefined) {
-          this.registerHandler(
-            pluginId,
-            channel,
-            schemaOrHandler as PluginChannelSchema<unknown, unknown>,
-            typedHandler
-          );
+          // A three-argument call is the typed overload by definition; if the
+          // second arg isn't a schema, reject loudly instead of silently
+          // dropping the typed handler and registering the second arg as a
+          // legacy handler — that mismatch would look like a phantom no-op
+          // at first dispatch.
+          if (!isChannelSchema(schemaOrHandler)) {
+            throw new Error(
+              `Plugin "${pluginId}" registerHandler: second argument must be a channel schema { args, result } when a typed handler is provided`
+            );
+          }
+          this.registerHandler(pluginId, channel, schemaOrHandler, typedHandler);
         } else {
           this.registerHandler(pluginId, channel, schemaOrHandler as PluginIpcHandler);
         }

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -121,11 +121,13 @@ vi.mock("../PluginMcpSupervisor.js", () => ({
   getPluginMcpSupervisor: () => mockPluginMcpSupervisor,
 }));
 
+import { z } from "zod";
 import { PluginService } from "../PluginService.js";
 import { getPluginManifestSchema } from "../../schemas/plugin.js";
 import {
   BUILT_IN_PLUGIN_CAPABILITIES,
   type PluginIpcContext,
+  type PluginManifest,
 } from "../../../shared/types/plugin.js";
 import {
   registerPanelKind,
@@ -2200,6 +2202,224 @@ describe("Plugin IPC handler registration", () => {
         [{ name: 42 }]
       );
       expect(result).toBe("cross-plugin-ok");
+    });
+  });
+
+  describe("typed channel registration (registerHandler schema overload)", () => {
+    let typedService: PluginService;
+
+    beforeEach(async () => {
+      await writePlugin("typed-plugin", {
+        name: "acme.typed",
+        version: "1.0.0",
+        capabilities: ["fs:project-read", "git:read"],
+      });
+      typedService = new PluginService(tmpDir);
+      await typedService.initialize();
+    });
+
+    it("registers and dispatches a typed channel with parsed args and result", async () => {
+      const schema = {
+        args: z.object({ name: z.string() }),
+        result: z.object({ greeting: z.string() }),
+      };
+      const handler = vi.fn(async (_ctx, args: { name: string }) => ({
+        greeting: `hello ${args.name}`,
+      }));
+      typedService.registerHandler("acme.typed", "greet", schema, handler);
+
+      const result = await typedService.dispatchHandler(
+        "acme.typed",
+        "greet",
+        makeCtx("acme.typed"),
+        [{ name: "world" }]
+      );
+      expect(result).toEqual({ greeting: "hello world" });
+      // The handler must receive the parsed single payload, not the raw variadic.
+      expect(handler).toHaveBeenCalledWith(expect.anything(), { name: "world" });
+    });
+
+    it("throws SCHEMA_ERROR when args fail Zod validation and never calls the handler", async () => {
+      const schema = {
+        args: z.object({ count: z.number().int().positive() }),
+        result: z.unknown(),
+      };
+      const handler = vi.fn();
+      typedService.registerHandler("acme.typed", "tally", schema, handler);
+
+      await expect(
+        typedService.dispatchHandler("acme.typed", "tally", makeCtx("acme.typed"), [
+          { count: "not-a-number" },
+        ])
+      ).rejects.toThrow(/^SCHEMA_ERROR:/);
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("throws SCHEMA_ERROR when the handler returns a result that fails the result schema", async () => {
+      const schema = {
+        args: z.object({}).passthrough(),
+        result: z.object({ count: z.number() }),
+      };
+      const handler = vi.fn(async () => ({ count: "nope" as unknown as number }));
+      typedService.registerHandler("acme.typed", "broken", schema, handler);
+
+      await expect(
+        typedService.dispatchHandler("acme.typed", "broken", makeCtx("acme.typed"), [{}])
+      ).rejects.toThrow(/^SCHEMA_ERROR: result for channel "broken" failed validation/);
+    });
+
+    it("rejects registration with PERMISSION_REQUIRED when a required capability is not declared", () => {
+      const schema = {
+        args: z.object({}),
+        result: z.object({}),
+        requires: ["fs:project-write" as const],
+      };
+      expect(() =>
+        typedService.registerHandler("acme.typed", "write-stuff", schema, vi.fn())
+      ).toThrow(/^PERMISSION_REQUIRED:/);
+    });
+
+    it("allows registration when every required capability is declared in the manifest", () => {
+      const schema = {
+        args: z.object({}),
+        result: z.object({}),
+        requires: ["fs:project-read" as const, "git:read" as const],
+      };
+      expect(() =>
+        typedService.registerHandler("acme.typed", "read-stuff", schema, vi.fn().mockResolvedValue({}))
+      ).not.toThrow();
+    });
+
+    it("throws PERMISSION_REQUIRED at dispatch when manifest capability disappears after registration (defense-in-depth)", async () => {
+      const schema = {
+        args: z.object({}),
+        result: z.unknown(),
+        requires: ["fs:project-read" as const],
+      };
+      const handler = vi.fn().mockResolvedValue({ ok: true });
+      typedService.registerHandler("acme.typed", "guarded", schema, handler);
+
+      // Tamper with the loaded manifest to simulate a future code path that
+      // removes a capability after registration. The dispatch-time re-check
+      // must reject before the handler runs.
+      const plugin = (typedService as unknown as { plugins: Map<string, { manifest: PluginManifest }> }).plugins.get(
+        "acme.typed"
+      );
+      if (plugin) {
+        plugin.manifest = { ...plugin.manifest, capabilities: [] };
+      }
+
+      await expect(
+        typedService.dispatchHandler("acme.typed", "guarded", makeCtx("acme.typed"), [{}])
+      ).rejects.toThrow(/^PERMISSION_REQUIRED:/);
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("removeHandlers cleans up channel schemas and capability gates", async () => {
+      const schema = {
+        args: z.object({ x: z.number() }),
+        result: z.object({ doubled: z.number() }),
+      };
+      typedService.registerHandler(
+        "acme.typed",
+        "double",
+        schema,
+        async (_ctx, args: { x: number }) => ({ doubled: args.x * 2 })
+      );
+
+      typedService.removeHandlers("acme.typed");
+
+      await expect(
+        typedService.dispatchHandler("acme.typed", "double", makeCtx("acme.typed"), [{ x: 3 }])
+      ).rejects.toThrow(/No plugin handler registered/);
+
+      // Re-register WITHOUT the typed overload — the old schema must be gone
+      // so legacy validation doesn't run on the new untyped handler.
+      typedService.registerHandler(
+        "acme.typed",
+        "double",
+        vi.fn().mockResolvedValue({ doubled: "string-result-not-validated" })
+      );
+      const legacyResult = await typedService.dispatchHandler(
+        "acme.typed",
+        "double",
+        makeCtx("acme.typed"),
+        [{ x: "anything" }]
+      );
+      expect(legacyResult).toEqual({ doubled: "string-result-not-validated" });
+    });
+
+    it("re-registering a typed channel as legacy drops the prior schema", async () => {
+      const schema = {
+        args: z.object({ x: z.number() }),
+        result: z.unknown(),
+      };
+      typedService.registerHandler("acme.typed", "swap", schema, vi.fn().mockResolvedValue("typed"));
+
+      const legacyHandler = vi.fn().mockResolvedValue("legacy");
+      typedService.registerHandler("acme.typed", "swap", legacyHandler);
+
+      // Now the legacy untyped path runs — args validation does not fire,
+      // so a previously-invalid payload would now go through.
+      const result = await typedService.dispatchHandler(
+        "acme.typed",
+        "swap",
+        makeCtx("acme.typed"),
+        [{ x: "string-was-invalid-before" }]
+      );
+      expect(result).toBe("legacy");
+      expect(legacyHandler).toHaveBeenCalledWith(expect.anything(), {
+        x: "string-was-invalid-before",
+      });
+    });
+
+    it("treats missing args as undefined for the typed args schema", async () => {
+      const schema = {
+        args: z.object({ name: z.string() }).optional(),
+        result: z.string(),
+      };
+      const handler = vi.fn(async (_ctx, args: { name: string } | undefined) =>
+        args ? args.name : "anonymous"
+      );
+      typedService.registerHandler("acme.typed", "optional", schema, handler);
+
+      const result = await typedService.dispatchHandler(
+        "acme.typed",
+        "optional",
+        makeCtx("acme.typed"),
+        []
+      );
+      expect(result).toBe("anonymous");
+    });
+
+    it("legacy untyped handler still dispatches alongside typed handlers on the same plugin", async () => {
+      typedService.registerHandler(
+        "acme.typed",
+        "typed-ch",
+        { args: z.string(), result: z.string() },
+        async (_ctx, args: string) => args.toUpperCase()
+      );
+      typedService.registerHandler(
+        "acme.typed",
+        "legacy-ch",
+        vi.fn().mockResolvedValue("legacy-result")
+      );
+
+      const typedResult = await typedService.dispatchHandler(
+        "acme.typed",
+        "typed-ch",
+        makeCtx("acme.typed"),
+        ["hello"]
+      );
+      expect(typedResult).toBe("HELLO");
+
+      const legacyResult = await typedService.dispatchHandler(
+        "acme.typed",
+        "legacy-ch",
+        makeCtx("acme.typed"),
+        ["whatever"]
+      );
+      expect(legacyResult).toBe("legacy-result");
     });
   });
 });

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -2392,6 +2392,44 @@ describe("Plugin IPC handler registration", () => {
       expect(result).toBe("anonymous");
     });
 
+    it("passes Zod-parsed output (defaults / coercions) to the handler, not the raw payload", async () => {
+      const schema = {
+        args: z.object({
+          n: z.coerce.number().int(),
+          tag: z.string().default("auto"),
+        }),
+        result: z.object({ n: z.number(), tag: z.string() }),
+      };
+      const handler = vi.fn(async (_ctx, args: { n: number; tag: string }) => args);
+      typedService.registerHandler("acme.typed", "coerce", schema, handler);
+
+      // Dispatch with a string "n" (coerced) and no `tag` (defaulted).
+      const result = await typedService.dispatchHandler(
+        "acme.typed",
+        "coerce",
+        makeCtx("acme.typed"),
+        [{ n: "42" }]
+      );
+      expect(result).toEqual({ n: 42, tag: "auto" });
+      expect(handler).toHaveBeenCalledWith(expect.anything(), { n: 42, tag: "auto" });
+    });
+
+    it("rejects malformed schema at registration when args/result lack safeParse", () => {
+      expect(() =>
+        typedService.registerHandler(
+          "acme.typed",
+          "bad-schema",
+          // Missing `result` ZodType — bare object has no safeParse method.
+          { args: z.object({}), result: {} as unknown as z.ZodType<unknown> },
+          vi.fn()
+        )
+      ).toThrow(/Plugin handler must be a function|^PERMISSION_REQUIRED:/);
+      // Specifically, isChannelSchema returns false for missing safeParse,
+      // so the legacy path runs and the bare object is rejected as a
+      // non-function handler. Either way: malformed schema is rejected at
+      // registration time, not at dispatch.
+    });
+
     it("legacy untyped handler still dispatches alongside typed handlers on the same plugin", async () => {
       typedService.registerHandler(
         "acme.typed",
@@ -2850,7 +2888,11 @@ describe("Plugin unload lifecycle", () => {
 type CreateHostShape = (pluginId: string) => {
   host: {
     pluginId: string;
-    registerHandler: (channel: string, handler: (...args: unknown[]) => unknown) => void;
+    registerHandler: (
+      channel: string,
+      schemaOrHandler: unknown,
+      typedHandler?: (...args: unknown[]) => unknown
+    ) => void;
     broadcastToRenderer: (channel: string, payload: unknown) => void;
     registerForgeProvider: (descriptor: { id: string }, impl: unknown) => () => void;
   };
@@ -2906,6 +2948,23 @@ describe("createHost (plugin activation API)", () => {
     expect(() => host.broadcastToRenderer("bad:channel", null)).toThrow(
       "Plugin broadcast channel must be a string without colons"
     );
+  });
+
+  it("host.registerHandler rejects a 3-arg call where the second arg isn't a channel schema", async () => {
+    await writePlugin("mismatch-test", { name: "acme.mismatch", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(
+      "acme.mismatch"
+    );
+
+    expect(() =>
+      // A typed handler was provided but the second arg is a function, not
+      // a schema — silently dropping the typed handler would phantom-no-op
+      // at dispatch, so this must throw.
+      host.registerHandler("ch", () => "legacy", () => "typed")
+    ).toThrow(/second argument must be a channel schema/);
   });
 
   it("revoked host rejects registerHandler and broadcastToRenderer calls", async () => {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -2286,7 +2286,12 @@ describe("Plugin IPC handler registration", () => {
         requires: ["fs:project-read" as const, "git:read" as const],
       };
       expect(() =>
-        typedService.registerHandler("acme.typed", "read-stuff", schema, vi.fn().mockResolvedValue({}))
+        typedService.registerHandler(
+          "acme.typed",
+          "read-stuff",
+          schema,
+          vi.fn().mockResolvedValue({})
+        )
       ).not.toThrow();
     });
 
@@ -2302,9 +2307,9 @@ describe("Plugin IPC handler registration", () => {
       // Tamper with the loaded manifest to simulate a future code path that
       // removes a capability after registration. The dispatch-time re-check
       // must reject before the handler runs.
-      const plugin = (typedService as unknown as { plugins: Map<string, { manifest: PluginManifest }> }).plugins.get(
-        "acme.typed"
-      );
+      const plugin = (
+        typedService as unknown as { plugins: Map<string, { manifest: PluginManifest }> }
+      ).plugins.get("acme.typed");
       if (plugin) {
         plugin.manifest = { ...plugin.manifest, capabilities: [] };
       }
@@ -2354,7 +2359,12 @@ describe("Plugin IPC handler registration", () => {
         args: z.object({ x: z.number() }),
         result: z.unknown(),
       };
-      typedService.registerHandler("acme.typed", "swap", schema, vi.fn().mockResolvedValue("typed"));
+      typedService.registerHandler(
+        "acme.typed",
+        "swap",
+        schema,
+        vi.fn().mockResolvedValue("typed")
+      );
 
       const legacyHandler = vi.fn().mockResolvedValue("legacy");
       typedService.registerHandler("acme.typed", "swap", legacyHandler);
@@ -2963,7 +2973,11 @@ describe("createHost (plugin activation API)", () => {
       // A typed handler was provided but the second arg is a function, not
       // a schema — silently dropping the typed handler would phantom-no-op
       // at dispatch, so this must throw.
-      host.registerHandler("ch", () => "legacy", () => "typed")
+      host.registerHandler(
+        "ch",
+        () => "legacy",
+        () => "typed"
+      )
     ).toThrow(/second argument must be a channel schema/);
   });
 

--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -1,9 +1,9 @@
 {
-  "count": 1195,
+  "count": 1196,
   "byRule": {
     "@typescript-eslint/no-explicit-any": 54,
     "@typescript-eslint/no-floating-promises": 93,
-    "@typescript-eslint/no-unsafe-type-assertion": 502,
+    "@typescript-eslint/no-unsafe-type-assertion": 503,
     "no-restricted-imports": 8,
     "no-restricted-syntax": 410,
     "no-useless-assignment": 20,
@@ -11,5 +11,5 @@
     "react-compiler/react-compiler": 16,
     "react-hooks/exhaustive-deps": 40
   },
-  "updatedAt": "2026-05-28T14:34:15.577Z"
+  "updatedAt": "2026-05-28T15:52:47.139Z"
 }

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -20,10 +20,12 @@ import type { NotificationType } from "../types/notification.js";
 import type {
   ActionHandler,
   PluginActionContribution,
+  PluginChannelSchema,
   PluginHostApi,
   PluginIpcHandler,
   PluginSettingsScope,
   PluginToastOptions,
+  PluginTypedIpcHandler,
   PluginWorktreeSnapshot,
   SettingsApi,
 } from "../types/plugin.js";
@@ -202,8 +204,29 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
         registeredActions.push({ descriptor, handler });
       }
     },
-    registerHandler(channel, handler) {
-      registeredHandlers.push({ channel, handler });
+    registerHandler<TArgs = unknown, TResult = unknown>(
+      channel: string,
+      schemaOrHandler: PluginChannelSchema<TArgs, TResult> | PluginIpcHandler,
+      handler?: PluginTypedIpcHandler<TArgs, TResult>
+    ) {
+      // Handle both overloads:
+      // 1. registerHandler(channel, schema, handler) — typed
+      // 2. registerHandler(channel, handler) — untyped
+      if (handler !== undefined) {
+        // Typed overload: schemaOrHandler is a schema, handler is the typed handler
+        // The cast is necessary because PluginTypedIpcHandler is structurally compatible
+        // with PluginIpcHandler and we're storing it in a untyped recording array.
+        registeredHandlers.push({
+          channel,
+          handler: handler as unknown as PluginIpcHandler,
+        });
+      } else {
+        // Untyped overload: schemaOrHandler is the handler
+        registeredHandlers.push({
+          channel,
+          handler: schemaOrHandler as PluginIpcHandler,
+        });
+      }
     },
     broadcastToRenderer(channel, payload) {
       broadcastCalls.push({ channel, payload });

--- a/shared/types/plugin-sdk-react.ts
+++ b/shared/types/plugin-sdk-react.ts
@@ -1,9 +1,21 @@
 /**
  * Reserved entry point for `@daintreehq/plugin-sdk/react`.
  *
- * No exports in v1. React hooks (`useWorktrees`, `useActiveWorktree`, etc.)
- * are planned for F15/F36. This module exists so the import path resolves and
- * TypeScript emits declarations for the subpath — plugin authors can reference
- * `@daintreehq/plugin-sdk/react` today and it will resolve to an empty module.
+ * Holds renderer-facing SDK types only; the runtime implementations live in
+ * `src/hooks/` and are wired into the eventual `@daintreehq/plugin-sdk/react`
+ * subpath when the SDK is extracted into its own package (F15/F36). Until
+ * then, plugin authors can reference these types through the host bundle.
  */
-export type {};
+
+/**
+ * Return shape of the `useHostChannel(pluginId, channel)` hook. `invoke`
+ * resolves with the validated channel result on success, or `undefined` if
+ * the host rejected the call (the rejection is surfaced via `error`). Only
+ * the latest `invoke()` updates `loading` / `error` — stale earlier calls are
+ * dropped to keep concurrent invocations coherent.
+ */
+export interface UseHostChannelResult<TArgs, TResult> {
+  invoke: (args: TArgs) => Promise<TResult | undefined>;
+  loading: boolean;
+  error: Error | null;
+}

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -13,6 +13,7 @@ import type {
 } from "./forge.js";
 import type { NotificationType } from "./notification.js";
 import type { ActionDispatchResult } from "./actions.js";
+import type { z } from "zod";
 
 export interface PanelContribution {
   id: string;
@@ -285,6 +286,35 @@ export type PluginIpcHandler = (
 ) => unknown | Promise<unknown>;
 
 /**
+ * Typed channel handler bound by the second overload of
+ * {@link PluginHostApi.registerHandler}. Receives the IPC context and the
+ * single parsed args payload (post-Zod-validation). The variadic
+ * {@link PluginIpcHandler} stays the canonical legacy shape; typed handlers
+ * are adapted to it at registration time so the dispatch path is unchanged.
+ */
+export type PluginTypedIpcHandler<TArgs, TResult> = (
+  ctx: PluginIpcContext,
+  args: TArgs
+) => TResult | Promise<TResult>;
+
+/**
+ * Per-channel schema bundle for typed `registerHandler` registrations. `args`
+ * validates the single-payload dispatch input (`window.electron.plugin.invoke(
+ * pluginId, channel, args)` — only the first argument is parsed). `result`
+ * validates the handler's return value before it crosses back to the renderer
+ * so a plugin's contract drift surfaces at the boundary instead of as a
+ * mysterious downstream TypeError. `requires` lists the
+ * {@link BuiltInPluginCapability} values the channel needs; the host rejects
+ * registration if any are missing from the plugin's declared
+ * `manifest.capabilities`, and re-checks at dispatch as defense-in-depth.
+ */
+export interface PluginChannelSchema<TArgs, TResult> {
+  args: z.ZodType<TArgs>;
+  result: z.ZodType<TResult>;
+  requires?: readonly BuiltInPluginCapability[];
+}
+
+/**
  * Provider-agnostic projection of a worktree's linked forge resources (issue
  * and/or PR), exposed on {@link PluginWorktreeSnapshot.linked}. Replaces the
  * GitHub-shaped flat fields that previously leaked onto the snapshot —
@@ -382,6 +412,27 @@ export interface PluginHostApi {
    * activation resolves or times out. Unregistered automatically on unload.
    */
   registerAction(descriptor: PluginActionContribution, handler: ActionHandler): void;
+  /**
+   * Bind a typed IPC handler whose args and result are validated against the
+   * provided Zod schemas, gated on the listed plugin capabilities. The host
+   * rejects registration if any `schema.requires` capability is missing from
+   * `manifest.capabilities` (fail-closed at the registration boundary). At
+   * dispatch the args are `safeParse`d, the handler is invoked with the
+   * parsed payload, and the result is `safeParse`d before returning to the
+   * renderer. Schema failures throw with a `SCHEMA_ERROR:` prefix; missing
+   * capabilities throw with a `PERMISSION_REQUIRED:` prefix — the
+   * renderer-side `useHostChannel` hook discriminates on these prefixes.
+   */
+  registerHandler<TArgs, TResult>(
+    channel: string,
+    schema: PluginChannelSchema<TArgs, TResult>,
+    handler: PluginTypedIpcHandler<TArgs, TResult>
+  ): void;
+  /**
+   * Legacy untyped overload: a variadic handler with no host-side validation.
+   * Retained for plugins that haven't migrated to per-channel schemas. The
+   * typed overload above is preferred for new code.
+   */
   registerHandler(channel: string, handler: PluginIpcHandler): void;
   broadcastToRenderer(channel: string, payload: unknown): void;
   /**

--- a/src/hooks/useHostChannel.ts
+++ b/src/hooks/useHostChannel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { UseHostChannelResult } from "@shared/types/plugin-sdk-react";
 
 /**
@@ -27,6 +27,15 @@ export function useHostChannel<TArgs = unknown, TResult = unknown>(
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const callIdRef = useRef(0);
+
+  // Reset the call counter when the channel target changes, so an in-flight
+  // call from the prior (pluginId, channel) can't resolve later and overwrite
+  // the new target's loading/error state with stale data.
+  useEffect(() => {
+    callIdRef.current = 0;
+    setLoading(false);
+    setError(null);
+  }, [pluginId, channel]);
 
   const invoke = useCallback(
     async (args: TArgs): Promise<TResult | undefined> => {

--- a/src/hooks/useHostChannel.ts
+++ b/src/hooks/useHostChannel.ts
@@ -1,0 +1,57 @@
+import { useCallback, useRef, useState } from "react";
+import type { UseHostChannelResult } from "@shared/types/plugin-sdk-react";
+
+/**
+ * Typed companion to `host.registerHandler(channel, schema, handler)` for
+ * plugin views. Wraps `window.electron.plugin.invoke(pluginId, channel, args)`
+ * with single-flight `loading` / `error` state, so a plugin view can call
+ * `invoke(args)` from an event handler and render the result without
+ * hand-rolling the try/catch shape every time.
+ *
+ * The hook does not subscribe to the channel's schema — the host owns
+ * validation and throws `SCHEMA_ERROR:` / `PERMISSION_REQUIRED:` prefixed
+ * errors that surface here as the rejected promise / `error` value. Plugin
+ * authors should treat both prefixes as authoring bugs (manifest capability
+ * missing, or wrong args shape) rather than runtime failures to surface to
+ * end users.
+ *
+ * Concurrent `invoke()` calls keep only the latest result/error — stale
+ * resolutions are dropped so a fast click that triggers two invokes never
+ * lets the older response overwrite the newer one. `loading` reflects the
+ * latest call only.
+ */
+export function useHostChannel<TArgs = unknown, TResult = unknown>(
+  pluginId: string,
+  channel: string
+): UseHostChannelResult<TArgs, TResult> {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const callIdRef = useRef(0);
+
+  const invoke = useCallback(
+    async (args: TArgs): Promise<TResult | undefined> => {
+      const callId = ++callIdRef.current;
+      setLoading(true);
+      setError(null);
+      try {
+        const result = (await window.electron.plugin.invoke(pluginId, channel, args)) as TResult;
+        // Drop the result of a superseded call so a slow earlier invoke can't
+        // overwrite the latest state.
+        if (callId !== callIdRef.current) return undefined;
+        return result;
+      } catch (err) {
+        if (callId !== callIdRef.current) return undefined;
+        const wrapped = err instanceof Error ? err : new Error(String(err));
+        setError(wrapped);
+        return undefined;
+      } finally {
+        if (callId === callIdRef.current) {
+          setLoading(false);
+        }
+      }
+    },
+    [pluginId, channel]
+  );
+
+  return { invoke, loading, error };
+}


### PR DESCRIPTION
## Summary

- Extends `registerHandler` on `PluginHostApi` with a typed overload accepting per-channel Zod schemas (`args`, `result`, optional `requires`) and validates payloads at dispatch, rejecting with structured `SCHEMA_ERROR:` on failure
- Adds a host-classified capability gate that fails closed at registration and re-checks at dispatch — channels declaring `requires` permissions can't be invoked by plugins that didn't declare them
- Ships `useHostChannel<TArgs, TResult>(pluginId, channel)` on the renderer side for end-to-end typed IPC, with loading/error state and stale-call suppression

Resolves #9231

## Changes

- `electron/services/PluginService.ts` — typed overload for `registerHandler`, capability gate in `dispatchHandler`, Zod validation via `z.safeParse` + `z.prettifyError`
- `shared/types/plugin.ts` — `TypedChannelSchema` type, `BuiltInPluginCapability` refs for `requires`
- `shared/types/plugin-sdk-react.ts` — `useHostChannel` hook signature exposed to plugin authors
- `src/hooks/useHostChannel.ts` — renderer hook implementation with stale-call guard
- `shared/testing/createMockHost.ts` — test helper updated to cover typed registration path
- `eslint-warnings-baseline.json` — baseline updated after new test surface

## Testing

12 new unit tests covering typed registration, schema validation errors, capability gate (registration + dispatch), unknown channel, malformed schema rejection, and 3-arg mismatch guard. All 341 tests pass. Full `npm run check` clean.