### PR TITLE
feat(plugins): allow plugin: scheme in renderer CSP

### DIFF
--- a/shared/config/__tests__/csp.test.ts
+++ b/shared/config/__tests__/csp.test.ts
@@ -32,19 +32,21 @@ describe("Daintree app CSP", () => {
   describe("scriptSrcHashes option", () => {
     it("appends a single hash to script-src in production", () => {
       const csp = getDaintreeAppProdCSP({ scriptSrcHashes: ["'sha256-abc123'"] });
-      expect(csp).toContain("script-src 'self' 'wasm-unsafe-eval' 'sha256-abc123'");
+      expect(csp).toContain("script-src 'self' 'wasm-unsafe-eval' plugin: 'sha256-abc123'");
     });
 
     it("appends multiple hashes space-separated in production", () => {
       const csp = getDaintreeAppProdCSP({
         scriptSrcHashes: ["'sha256-aaa'", "'sha256-bbb'"],
       });
-      expect(csp).toContain("script-src 'self' 'wasm-unsafe-eval' 'sha256-aaa' 'sha256-bbb'");
+      expect(csp).toContain(
+        "script-src 'self' 'wasm-unsafe-eval' plugin: 'sha256-aaa' 'sha256-bbb'"
+      );
     });
 
     it("omits the hash list when scriptSrcHashes is empty", () => {
       const csp = getDaintreeAppProdCSP({ scriptSrcHashes: [] });
-      expect(csp).toContain("script-src 'self' 'wasm-unsafe-eval';");
+      expect(csp).toContain("script-src 'self' 'wasm-unsafe-eval' plugin:;");
       expect(csp).not.toMatch(/'sha256-/);
     });
 
@@ -61,6 +63,40 @@ describe("Daintree app CSP", () => {
     it("threads scriptSrcHashes through getDaintreeAppCSP to the prod variant", () => {
       const csp = getDaintreeAppCSP(false, { scriptSrcHashes: ["'sha256-xyz'"] });
       expect(csp).toContain("'sha256-xyz'");
+    });
+  });
+
+  describe("plugin: scheme allowance", () => {
+    // `React.lazy(() => import("plugin://..."))` in
+    // `src/components/Panel/PluginViewHost.tsx` is governed by `script-src`;
+    // `connect-src` covers any `fetch("plugin://...")` plugin authors layer on
+    // top. Both must include `plugin:` for non-PTY plugin panels to render in
+    // production. Past lesson #3757 forbids `bypassCSP: true` — this narrow
+    // directive expansion is the load-bearing alternative.
+    it("allows plugin: in script-src in production for dynamic plugin imports", () => {
+      const csp = getDaintreeAppProdCSP();
+      const scriptSrcMatch = csp.match(/script-src ([^;]*);/);
+      expect(scriptSrcMatch).not.toBeNull();
+      expect(scriptSrcMatch?.[1]).toContain("plugin:");
+    });
+
+    it("allows plugin: in connect-src in production for plugin-served fetches", () => {
+      const csp = getDaintreeAppProdCSP();
+      const connectSrcMatch = csp.match(/connect-src ([^;]*);/);
+      expect(connectSrcMatch).not.toBeNull();
+      expect(connectSrcMatch?.[1]).toContain("plugin:");
+    });
+
+    it("allows plugin: in script-src in development", () => {
+      const csp = getDaintreeAppDevCSP();
+      const scriptSrcMatch = csp.match(/script-src ([^;]*);/);
+      expect(scriptSrcMatch?.[1]).toContain("plugin:");
+    });
+
+    it("allows plugin: in connect-src in development", () => {
+      const csp = getDaintreeAppDevCSP();
+      const connectSrcMatch = csp.match(/connect-src ([^;]*);/);
+      expect(connectSrcMatch?.[1]).toContain("plugin:");
     });
   });
 });

--- a/shared/config/csp.ts
+++ b/shared/config/csp.ts
@@ -3,6 +3,18 @@ import { getDevServerOrigins, getDevServerWebSocketOrigins } from "./devServer.j
 // Custom protocol scheme the renderer fetches/loads from.
 const FILE_SCHEMES = "daintree-file:";
 
+// Plugin-served renderer modules. `plugin:` is a hardened first-party scheme
+// (`standard: true, secure: true`, no `bypassCSP`) — see
+// `electron/main.ts:120-130` — that resolves to the plugin's installed-on-disk
+// root via the handler in `electron/setup/protocols.ts`. Non-PTY plugin panel
+// views are lazy-loaded via `React.lazy(() => import("plugin://..."))` (see
+// `src/components/Panel/PluginViewHost.tsx`), so `plugin:` must appear in
+// `script-src` for the dynamic module load to clear CSP in production. Per
+// past lesson #3757, the alternative — `bypassCSP: true` — is the nuclear
+// option and is explicitly rejected; this narrow directive expansion is the
+// minimum surface to make the feature work without weakening defense-in-depth.
+const PLUGIN_SCHEME = "plugin:";
+
 // Localhost origins allowed for embedded <webview> guests in BrowserPane and
 // DevPreviewPane. Without these in frame-src the host page cannot mount its
 // webview elements at all.
@@ -71,9 +83,12 @@ function buildScriptSrc(base: string, scriptSrcHashes?: readonly string[]): stri
 export function getDaintreeAppProdCSP(options?: DaintreeCspOptions): string {
   return [
     "default-src 'self'",
-    buildScriptSrc("script-src 'self' 'wasm-unsafe-eval'", options?.scriptSrcHashes),
+    buildScriptSrc(
+      `script-src 'self' 'wasm-unsafe-eval' ${PLUGIN_SCHEME}`,
+      options?.scriptSrcHashes
+    ),
     "style-src 'self' 'unsafe-inline'",
-    `connect-src 'self' ${FILE_SCHEMES}`,
+    `connect-src 'self' ${FILE_SCHEMES} ${PLUGIN_SCHEME}`,
     `img-src 'self' ${GITHUB_AVATARS} ${GRAVATAR} ${FILE_SCHEMES} data: blob:`,
     "font-src 'self' data:",
     "media-src 'self'",
@@ -105,9 +120,9 @@ export function getDaintreeAppDevCSP(): string {
 
   return [
     `default-src 'self' ${origins} ${wsOrigins}`,
-    `script-src 'self' ${origins} 'unsafe-inline' 'unsafe-eval'`,
+    `script-src 'self' ${origins} 'unsafe-inline' 'unsafe-eval' ${PLUGIN_SCHEME}`,
     `style-src 'self' ${origins} 'unsafe-inline'`,
-    `connect-src 'self' ${origins} ${wsOrigins} ${FILE_SCHEMES}`,
+    `connect-src 'self' ${origins} ${wsOrigins} ${FILE_SCHEMES} ${PLUGIN_SCHEME}`,
     `img-src 'self' ${origins} ${GITHUB_AVATARS} ${GRAVATAR} ${FILE_SCHEMES} data: blob:`,
     `font-src 'self' ${origins} data:`,
     "media-src 'self'",


### PR DESCRIPTION
Reduced from the original renderer-host PR (#9287) to **only** its still-needed contribution: allowing the `plugin:` scheme in the renderer Content-Security-Policy (`script-src` / `connect-src`, prod + dev).

The renderer-host implementation itself is superseded by #9501 (the canonical inline renderer host), whose lazy `plugin://` import requires this CSP allowance to load. The duplicate host files, `panelKindRegistry`/`plugin.ts`/`usePluginPanelKinds` changes, and eslint-baseline bump have been stripped; the diff is now `shared/config/csp.ts` + its test only. No `unsafe-*` or wildcard added to production CSP.