### PR TITLE
feat(settings): add forge audit log viewer and improve plugin viewer

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -785,6 +785,16 @@ export const CHANNELS = {
   FORGE_GET_REPO_METADATA: "forge:get-repo-metadata",
   FORGE_CLASSIFY_PUSH_ERROR: "forge:classify-push-error",
 
+  // Forge audit log channels — separate prefix from `forge:*` so the codegen
+  // produces a dedicated `forgeAudit` namespace in the renderer rather than
+  // appending into the hand-written `forge` namespace.
+  FORGE_AUDIT_GET_RECORDS: "forge-audit:get-records",
+  FORGE_AUDIT_GET_CONFIG: "forge-audit:get-config",
+  FORGE_AUDIT_GET_STATS: "forge-audit:get-stats",
+  FORGE_AUDIT_CLEAR_LOG: "forge-audit:clear-log",
+  FORGE_AUDIT_EXPORT_LOG: "forge-audit:export-log",
+  FORGE_AUDIT_SET_ENABLED: "forge-audit:set-enabled",
+
   // Plugin channels
   PLUGIN_LIST: "plugin:list",
   PLUGIN_SET_ENABLED: "plugin:set-enabled",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -47,6 +47,7 @@ import { registerShortcutHintsHandlers } from "./handlers/shortcutHints.js";
 import { registerForgeHandlers } from "./handlers/forge.js";
 import { registerForgeDataHandlers } from "./handlers/forgeData.js";
 import { registerForgeSettingsHandlers } from "./handlers/forgeSettings.js";
+import { registerForgeAuditHandlers } from "./handlers/forgeAudit.js";
 import { registerVoiceInputHandlers } from "./handlers/voiceInput.js";
 import { registerMcpServerHandlers } from "./handlers/mcpServer.js";
 import { registerHelpAssistantHandlers } from "./handlers/helpAssistant.js";
@@ -155,6 +156,7 @@ export function registerIpcHandlers(deps: HandlerDependencies): () => void {
     register(() => registerForgeSettingsHandlers());
     register(() => registerForgeHandlers());
     register(() => registerForgeDataHandlers());
+    register(() => registerForgeAuditHandlers());
     register(() => registerVoiceInputHandlers(deps));
     register(() => registerMcpServerHandlers());
     register(() => registerHelpAssistantHandlers());

--- a/electron/ipc/handlers/__tests__/forgeAudit.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeAudit.handlers.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ForgeAuditRecord, ForgeAuditStats } from "../../../../shared/types/ipc/forge.js";
+
+const ipcHandlers = vi.hoisted(() => new Map<string, unknown>());
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn((channel: string, fn: unknown) => ipcHandlers.set(channel, fn)),
+  removeHandler: vi.fn((channel: string) => ipcHandlers.delete(channel)),
+}));
+
+const showSaveDialogMock = vi.hoisted(() => vi.fn());
+vi.mock("electron", () => ({
+  ipcMain: ipcMainMock,
+  dialog: { showSaveDialog: showSaveDialogMock },
+}));
+
+const writeFileMock = vi.hoisted(() => vi.fn());
+vi.mock("node:fs/promises", () => ({ writeFile: writeFileMock }));
+
+const auditServiceMock = vi.hoisted(() => ({
+  getRecords: vi.fn<() => ForgeAuditRecord[]>(() => []),
+  getAuditConfig: vi.fn<() => { enabled: boolean; maxRecords: number }>(() => ({
+    enabled: true,
+    maxRecords: 500,
+  })),
+  getAuditStats: vi.fn<() => ForgeAuditStats>(() => ({
+    anomalySignals: [],
+    anomalySuppressed: true,
+    anomalyRecordFloor: 10,
+  })),
+  clear: vi.fn(),
+  setEnabled: vi.fn<(enabled: boolean) => { enabled: boolean; maxRecords: number }>(() => ({
+    enabled: false,
+    maxRecords: 500,
+  })),
+}));
+
+vi.mock("../../../services/forge/forgeAuditService.js", () => ({
+  forgeAuditService: auditServiceMock,
+}));
+
+import { registerForgeAuditHandlers } from "../forgeAudit.js";
+
+type Handler = (event: Electron.IpcMainInvokeEvent, ...args: unknown[]) => Promise<unknown>;
+
+function getHandler(channel: string): Handler {
+  const fn = ipcHandlers.get(channel);
+  if (!fn) throw new Error(`handler not registered: ${channel}`);
+  return fn as Handler;
+}
+
+function fakeEvent(): Electron.IpcMainInvokeEvent {
+  return { sender: {} as Electron.WebContents } as Electron.IpcMainInvokeEvent;
+}
+
+describe("registerForgeAuditHandlers", () => {
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    ipcHandlers.clear();
+    vi.clearAllMocks();
+    auditServiceMock.getRecords.mockReturnValue([]);
+    auditServiceMock.getAuditConfig.mockReturnValue({ enabled: true, maxRecords: 500 });
+    auditServiceMock.getAuditStats.mockReturnValue({
+      anomalySignals: [],
+      anomalySuppressed: true,
+      anomalyRecordFloor: 10,
+    });
+    auditServiceMock.setEnabled.mockReturnValue({ enabled: false, maxRecords: 500 });
+    cleanup = registerForgeAuditHandlers();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("registers all six forge audit channels", () => {
+    expect(ipcMainMock.handle).toHaveBeenCalledTimes(6);
+    expect(ipcHandlers.has("forge-audit:get-records")).toBe(true);
+    expect(ipcHandlers.has("forge-audit:get-config")).toBe(true);
+    expect(ipcHandlers.has("forge-audit:get-stats")).toBe(true);
+    expect(ipcHandlers.has("forge-audit:clear-log")).toBe(true);
+    expect(ipcHandlers.has("forge-audit:set-enabled")).toBe(true);
+    expect(ipcHandlers.has("forge-audit:export-log")).toBe(true);
+  });
+
+  it("get-audit-records delegates to service.getRecords", async () => {
+    const sample: ForgeAuditRecord[] = [
+      {
+        id: "1",
+        timestamp: 1,
+        providerId: "builtin.github",
+        methodName: "listIssues",
+        result: "success",
+        durationMs: 10,
+        schemaVersion: 1,
+        severity: "info",
+      },
+    ];
+    auditServiceMock.getRecords.mockReturnValue(sample);
+    await expect(getHandler("forge-audit:get-records")(fakeEvent())).resolves.toEqual(sample);
+    expect(auditServiceMock.getRecords).toHaveBeenCalledTimes(1);
+  });
+
+  it("get-audit-config delegates to service.getAuditConfig", async () => {
+    auditServiceMock.getAuditConfig.mockReturnValue({ enabled: false, maxRecords: 1000 });
+    await expect(getHandler("forge-audit:get-config")(fakeEvent())).resolves.toEqual({
+      enabled: false,
+      maxRecords: 1000,
+    });
+  });
+
+  it("get-audit-stats delegates to service.getAuditStats", async () => {
+    const stats: ForgeAuditStats = {
+      anomalySignals: [
+        {
+          id: "first-seen:builtin.github:listIssues",
+          kind: "first-seen-method",
+          providerId: "builtin.github",
+          methodName: "listIssues",
+          severity: "danger",
+          timestamp: 1,
+          recordIds: ["1"],
+        },
+      ],
+      anomalySuppressed: false,
+      anomalyRecordFloor: 10,
+    };
+    auditServiceMock.getAuditStats.mockReturnValue(stats);
+    await expect(getHandler("forge-audit:get-stats")(fakeEvent())).resolves.toEqual(stats);
+  });
+
+  it("clear-audit-log delegates to service.clear", async () => {
+    await getHandler("forge-audit:clear-log")(fakeEvent());
+    expect(auditServiceMock.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("set-audit-enabled forwards boolean and returns config", async () => {
+    auditServiceMock.setEnabled.mockReturnValue({ enabled: false, maxRecords: 500 });
+    await expect(getHandler("forge-audit:set-enabled")(fakeEvent(), false)).resolves.toEqual({
+      enabled: false,
+      maxRecords: 500,
+    });
+    expect(auditServiceMock.setEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it("set-audit-enabled rejects non-boolean input", async () => {
+    await expect(getHandler("forge-audit:set-enabled")(fakeEvent(), "true")).rejects.toThrow(
+      "enabled must be a boolean"
+    );
+    expect(auditServiceMock.setEnabled).not.toHaveBeenCalled();
+  });
+
+  it("export-audit-log writes NDJSON when dialog confirms", async () => {
+    showSaveDialogMock.mockResolvedValue({
+      canceled: false,
+      filePath: "/tmp/forge-audit.ndjson",
+    });
+    const records: ForgeAuditRecord[] = [
+      {
+        id: "a",
+        timestamp: 1,
+        providerId: "builtin.github",
+        methodName: "listIssues",
+        result: "success",
+        durationMs: 5,
+        schemaVersion: 1,
+        severity: "info",
+      },
+      {
+        id: "b",
+        timestamp: 2,
+        providerId: "builtin.github",
+        methodName: "getIssue",
+        result: "error",
+        durationMs: 12,
+        schemaVersion: 1,
+        severity: "error",
+        errorMessage: "404",
+      },
+    ];
+    await expect(getHandler("forge-audit:export-log")(fakeEvent(), records)).resolves.toBe(true);
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+    const [path, content] = writeFileMock.mock.calls[0]!;
+    expect(path).toBe("/tmp/forge-audit.ndjson");
+    expect(content).toBe(JSON.stringify(records[0]) + "\n" + JSON.stringify(records[1]) + "\n");
+  });
+
+  it("export-audit-log returns false when dialog is canceled", async () => {
+    showSaveDialogMock.mockResolvedValue({ canceled: true, filePath: undefined });
+    await expect(getHandler("forge-audit:export-log")(fakeEvent(), [])).resolves.toBe(false);
+    expect(writeFileMock).not.toHaveBeenCalled();
+  });
+
+  it("export-audit-log rejects non-array input", async () => {
+    await expect(getHandler("forge-audit:export-log")(fakeEvent(), "not an array")).rejects.toThrow(
+      "records must be an array"
+    );
+  });
+});

--- a/electron/ipc/handlers/__tests__/forgeAudit.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeAudit.handlers.test.ts
@@ -11,6 +11,10 @@ const showSaveDialogMock = vi.hoisted(() => vi.fn());
 vi.mock("electron", () => ({
   ipcMain: ipcMainMock,
   dialog: { showSaveDialog: showSaveDialogMock },
+  // Stubbed to satisfy `webContentsRegistry.getWindowForWebContents`'s typeof
+  // check; the fake event below has no real WebContents, so this just returns
+  // null and `ctx.senderWindow` resolves to null in tests.
+  BrowserWindow: { fromWebContents: () => null },
 }));
 
 const writeFileMock = vi.hoisted(() => vi.fn());
@@ -143,6 +147,15 @@ describe("registerForgeAuditHandlers", () => {
     expect(auditServiceMock.setEnabled).toHaveBeenCalledWith(false);
   });
 
+  it("set-audit-enabled forwards true and returns enabled config", async () => {
+    auditServiceMock.setEnabled.mockReturnValue({ enabled: true, maxRecords: 500 });
+    await expect(getHandler("forge-audit:set-enabled")(fakeEvent(), true)).resolves.toEqual({
+      enabled: true,
+      maxRecords: 500,
+    });
+    expect(auditServiceMock.setEnabled).toHaveBeenCalledWith(true);
+  });
+
   it("set-audit-enabled rejects non-boolean input", async () => {
     await expect(getHandler("forge-audit:set-enabled")(fakeEvent(), "true")).rejects.toThrow(
       "enabled must be a boolean"
@@ -182,13 +195,35 @@ describe("registerForgeAuditHandlers", () => {
     expect(writeFileMock).toHaveBeenCalledTimes(1);
     const [path, content] = writeFileMock.mock.calls[0]!;
     expect(path).toBe("/tmp/forge-audit.ndjson");
-    expect(content).toBe(JSON.stringify(records[0]) + "\n" + JSON.stringify(records[1]) + "\n");
+    expect(typeof content).toBe("string");
+    const lines = (content as string).trim().split("\n");
+    expect(lines).toHaveLength(2);
+    const round0 = JSON.parse(lines[0]!);
+    const round1 = JSON.parse(lines[1]!);
+    expect(round0.id).toBe("a");
+    expect(round1.id).toBe("b");
+    expect(round1.errorMessage).toBe("404");
   });
 
   it("export-audit-log returns false when dialog is canceled", async () => {
     showSaveDialogMock.mockResolvedValue({ canceled: true, filePath: undefined });
     await expect(getHandler("forge-audit:export-log")(fakeEvent(), [])).resolves.toBe(false);
     expect(writeFileMock).not.toHaveBeenCalled();
+  });
+
+  it("export-audit-log returns false when dialog confirms but no path is chosen", async () => {
+    showSaveDialogMock.mockResolvedValue({ canceled: false, filePath: undefined });
+    await expect(getHandler("forge-audit:export-log")(fakeEvent(), [])).resolves.toBe(false);
+    expect(writeFileMock).not.toHaveBeenCalled();
+  });
+
+  it("export-audit-log propagates writeFile rejections", async () => {
+    showSaveDialogMock.mockResolvedValue({
+      canceled: false,
+      filePath: "/tmp/forge-audit.ndjson",
+    });
+    writeFileMock.mockRejectedValue(new Error("EACCES"));
+    await expect(getHandler("forge-audit:export-log")(fakeEvent(), [])).rejects.toThrow("EACCES");
   });
 
   it("export-audit-log rejects non-array input", async () => {

--- a/electron/ipc/handlers/forgeAudit.preload.ts
+++ b/electron/ipc/handlers/forgeAudit.preload.ts
@@ -1,0 +1,29 @@
+import type { IpcInvokeMap } from "../../types/index.js";
+
+export const FORGE_AUDIT_METHOD_CHANNELS = {
+  getRecords: "forge-audit:get-records",
+  getConfig: "forge-audit:get-config",
+  getStats: "forge-audit:get-stats",
+  clearLog: "forge-audit:clear-log",
+  exportLog: "forge-audit:export-log",
+  setEnabled: "forge-audit:set-enabled",
+} as const satisfies Record<string, keyof IpcInvokeMap>;
+
+type Methods = typeof FORGE_AUDIT_METHOD_CHANNELS;
+
+export type ForgeAuditPreloadBindings = {
+  [M in keyof Methods]: (
+    ...args: IpcInvokeMap[Methods[M]]["args"]
+  ) => Promise<IpcInvokeMap[Methods[M]]["result"]>;
+};
+
+type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
+
+export function buildForgeAuditPreloadBindings(invoke: Invoker): ForgeAuditPreloadBindings {
+  const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const method of Object.keys(FORGE_AUDIT_METHOD_CHANNELS) as Array<keyof Methods>) {
+    const channel = FORGE_AUDIT_METHOD_CHANNELS[method];
+    out[method as string] = (...args) => invoke(channel, ...args);
+  }
+  return out as unknown as ForgeAuditPreloadBindings;
+}

--- a/electron/ipc/handlers/forgeAudit.ts
+++ b/electron/ipc/handlers/forgeAudit.ts
@@ -1,0 +1,58 @@
+import { dialog } from "electron";
+import { writeFile } from "node:fs/promises";
+import { defineIpcNamespace, op } from "../define.js";
+import { FORGE_AUDIT_METHOD_CHANNELS } from "./forgeAudit.preload.js";
+import { forgeAuditService } from "../../services/forge/forgeAuditService.js";
+import type { ForgeAuditRecord, ForgeAuditStats } from "../../../shared/types/ipc/forge.js";
+
+export const forgeAuditNamespace = defineIpcNamespace({
+  name: "forgeAudit",
+  ops: {
+    getRecords: op(
+      FORGE_AUDIT_METHOD_CHANNELS.getRecords,
+      async (): Promise<ForgeAuditRecord[]> => forgeAuditService.getRecords()
+    ),
+    getConfig: op(
+      FORGE_AUDIT_METHOD_CHANNELS.getConfig,
+      async (): Promise<{ enabled: boolean; maxRecords: number }> =>
+        forgeAuditService.getAuditConfig()
+    ),
+    getStats: op(
+      FORGE_AUDIT_METHOD_CHANNELS.getStats,
+      async (): Promise<ForgeAuditStats> => forgeAuditService.getAuditStats()
+    ),
+    clearLog: op(FORGE_AUDIT_METHOD_CHANNELS.clearLog, async (): Promise<void> => {
+      forgeAuditService.clear();
+    }),
+    setEnabled: op(
+      FORGE_AUDIT_METHOD_CHANNELS.setEnabled,
+      async (enabled: boolean): Promise<{ enabled: boolean; maxRecords: number }> => {
+        if (typeof enabled !== "boolean") throw new Error("enabled must be a boolean");
+        return forgeAuditService.setEnabled(enabled);
+      }
+    ),
+    exportLog: op(
+      FORGE_AUDIT_METHOD_CHANNELS.exportLog,
+      async (records: ForgeAuditRecord[]): Promise<boolean> => {
+        if (!Array.isArray(records)) throw new Error("records must be an array");
+        const ndjson = records.map((r) => JSON.stringify(r)).join("\n") + "\n";
+        const now = Date.now();
+        const defaultFilename = `forge-audit-log-${new Date(now)
+          .toISOString()
+          .replace(/[:.]/g, "-")}.ndjson`;
+        const { filePath, canceled } = await dialog.showSaveDialog({
+          title: "Export forge audit log",
+          defaultPath: defaultFilename,
+          filters: [{ name: "NDJSON Files", extensions: ["ndjson"] }],
+        });
+        if (canceled || !filePath) return false;
+        await writeFile(filePath, ndjson, "utf-8");
+        return true;
+      }
+    ),
+  },
+});
+
+export function registerForgeAuditHandlers(): () => void {
+  return forgeAuditNamespace.register();
+}

--- a/electron/ipc/handlers/forgeAudit.ts
+++ b/electron/ipc/handlers/forgeAudit.ts
@@ -3,6 +3,8 @@ import { writeFile } from "node:fs/promises";
 import { defineIpcNamespace, op } from "../define.js";
 import { FORGE_AUDIT_METHOD_CHANNELS } from "./forgeAudit.preload.js";
 import { forgeAuditService } from "../../services/forge/forgeAuditService.js";
+import { sanitizePath } from "../../utils/pathScrubber.js";
+import { scrubSecrets } from "../../../shared/utils/secretScrubber.js";
 import type { ForgeAuditRecord, ForgeAuditStats } from "../../../shared/types/ipc/forge.js";
 
 export const forgeAuditNamespace = defineIpcNamespace({
@@ -33,22 +35,38 @@ export const forgeAuditNamespace = defineIpcNamespace({
     ),
     exportLog: op(
       FORGE_AUDIT_METHOD_CHANNELS.exportLog,
-      async (records: ForgeAuditRecord[]): Promise<boolean> => {
+      async (ctx, records: ForgeAuditRecord[]): Promise<boolean> => {
         if (!Array.isArray(records)) throw new Error("records must be an array");
-        const ndjson = records.map((r) => JSON.stringify(r)).join("\n") + "\n";
+        // Defense-in-depth scrub on the NDJSON before it hits disk: provider
+        // error messages can carry partial tokens (e.g. "401 invalid_token ghp_…")
+        // even though argsSummary is already redacted at write time.
+        const ndjsonLines = records.map((rawRecord) => {
+          const record = rawRecord as unknown as Record<string, unknown>;
+          const cleaned: Record<string, unknown> = {};
+          for (const [key, value] of Object.entries(record)) {
+            cleaned[key] = typeof value === "string" ? sanitizePath(value) : value;
+          }
+          return scrubSecrets(JSON.stringify(cleaned));
+        });
+        const ndjson = ndjsonLines.join("\n") + "\n";
         const now = Date.now();
         const defaultFilename = `forge-audit-log-${new Date(now)
           .toISOString()
           .replace(/[:.]/g, "-")}.ndjson`;
-        const { filePath, canceled } = await dialog.showSaveDialog({
+        const dialogOptions: Electron.SaveDialogOptions = {
           title: "Export forge audit log",
           defaultPath: defaultFilename,
           filters: [{ name: "NDJSON Files", extensions: ["ndjson"] }],
-        });
+        };
+        const win = ctx.senderWindow ?? undefined;
+        const { filePath, canceled } = win
+          ? await dialog.showSaveDialog(win, dialogOptions)
+          : await dialog.showSaveDialog(dialogOptions);
         if (canceled || !filePath) return false;
         await writeFile(filePath, ndjson, "utf-8");
         return true;
-      }
+      },
+      { withContext: true }
     ),
   },
 });

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -40,6 +40,7 @@ import { buildPluginPreloadBindings } from "./ipc/handlers/plugin.preload.js";
 import { buildPluginMcpPreloadBindings } from "./ipc/handlers/pluginMcp.preload.js";
 import { buildScratchPreloadBindings } from "./ipc/handlers/scratch/preload.js";
 import { buildMcpServerPreloadBindings } from "./ipc/handlers/mcpServer.preload.js";
+import { buildForgeAuditPreloadBindings } from "./ipc/handlers/forgeAudit.preload.js";
 import { buildGeminiPreloadBindings } from "./ipc/handlers/gemini.preload.js";
 import { buildMilestonesPreloadBindings } from "./ipc/handlers/milestones.preload.js";
 import { buildOnboardingPreloadBindings } from "./ipc/handlers/onboarding.preload.js";
@@ -2316,6 +2317,8 @@ const api: ElectronAPI = {
     classifyPushError: (payload: { cwd: string; stderr: string }) =>
       _unwrappingInvoke(CHANNELS.FORGE_CLASSIFY_PUSH_ERROR, payload),
   },
+
+  forgeAudit: buildForgeAuditPreloadBindings(_unwrappingInvoke),
 
   // Voice Input API
   voiceInput: {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1362,6 +1362,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
       stderr: string;
     }): Promise<{ providerId: string; classification: PushErrorClassification | null } | null>;
   };
+  // forgeAudit comes from GeneratedElectronAPI
   voiceInput: {
     getSettings(): Promise<VoiceInputSettings>;
     setSettings(settings: Partial<VoiceInputSettings>): Promise<void>;

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -143,6 +143,26 @@ export interface GeneratedElectronAPI {
       ...args: IpcInvokeMap["event-inspector:get-filtered"]["args"]
     ): Promise<IpcInvokeMap["event-inspector:get-filtered"]["result"]>;
   };
+  forgeAudit: {
+    clearLog(
+      ...args: IpcInvokeMap["forge-audit:clear-log"]["args"]
+    ): Promise<IpcInvokeMap["forge-audit:clear-log"]["result"]>;
+    exportLog(
+      ...args: IpcInvokeMap["forge-audit:export-log"]["args"]
+    ): Promise<IpcInvokeMap["forge-audit:export-log"]["result"]>;
+    getConfig(
+      ...args: IpcInvokeMap["forge-audit:get-config"]["args"]
+    ): Promise<IpcInvokeMap["forge-audit:get-config"]["result"]>;
+    getRecords(
+      ...args: IpcInvokeMap["forge-audit:get-records"]["args"]
+    ): Promise<IpcInvokeMap["forge-audit:get-records"]["result"]>;
+    getStats(
+      ...args: IpcInvokeMap["forge-audit:get-stats"]["args"]
+    ): Promise<IpcInvokeMap["forge-audit:get-stats"]["result"]>;
+    setEnabled(
+      ...args: IpcInvokeMap["forge-audit:set-enabled"]["args"]
+    ): Promise<IpcInvokeMap["forge-audit:set-enabled"]["result"]>;
+  };
   gemini: {
     enableAlternateBuffer(
       ...args: IpcInvokeMap["gemini:enable-alternate-buffer"]["args"]

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -275,6 +275,30 @@ export interface GeneratedIpcInvokeMap {
     args: [filters: import("./events.js").EventFilterOptions];
     result: import("./events.js").EventRecord[];
   };
+  "forge-audit:clear-log": {
+    args: [];
+    result: void;
+  };
+  "forge-audit:export-log": {
+    args: [records: import("./forge.js").ForgeAuditRecord[]];
+    result: boolean;
+  };
+  "forge-audit:get-config": {
+    args: [];
+    result: { enabled: boolean; maxRecords: number };
+  };
+  "forge-audit:get-records": {
+    args: [];
+    result: import("./forge.js").ForgeAuditRecord[];
+  };
+  "forge-audit:get-stats": {
+    args: [];
+    result: import("./forge.js").ForgeAuditStats;
+  };
+  "forge-audit:set-enabled": {
+    args: [enabled: boolean];
+    result: { enabled: boolean; maxRecords: number };
+  };
   "forge:unassign-issue": {
     args: [payload: { cwd: string; issueNumber: number; username: string }];
     result: void;

--- a/src/components/Settings/CodeForgeSettingsTab.tsx
+++ b/src/components/Settings/CodeForgeSettingsTab.tsx
@@ -7,11 +7,14 @@ import {
   type ComponentType,
   type ReactNode,
 } from "react";
-import { GitBranch, Key, Check, AlertCircle } from "lucide-react";
+import { GitBranch, Key, Check, AlertCircle, ScrollText } from "lucide-react";
 import { GitHubIcon } from "@/components/icons/brands";
 import type { ForgeProviderContribution, ForgeProviderEntry } from "@shared/types";
+import type { ForgeAuditRecord, ForgeAuditStats } from "@shared/types/ipc/forge";
+import { FORGE_AUDIT_DEFAULT_MAX_RECORDS } from "@shared/types/ipc/forge";
 import { makeForgeProviderId } from "@shared/utils/forgeProviderIds";
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import {
   ForgeProviderSelectorDropdown,
   type ForgeProviderOption,
@@ -19,8 +22,12 @@ import {
 import { GitHubSettingsTab } from "./GitHubSettingsTab";
 import { ForgeIntegrationsTab } from "./ForgeIntegrationsTab";
 import { SettingsLoadErrorBanner } from "./SettingsLoadErrorBanner";
+import { SettingsSection } from "./SettingsSection";
+import { SettingsSwitchCard } from "./SettingsSwitchCard";
+import { ForgeAuditLogViewer } from "./ForgeAuditLogViewer";
 import { useSettingsTabValidation } from "./SettingsValidationRegistry";
 import { useTabLoad } from "@/hooks";
+import { appClient } from "@/clients";
 import { logError } from "@/utils/logger";
 
 type ForgeIcon = ComponentType<{ className?: string; size?: number; "aria-hidden"?: boolean }>;
@@ -32,6 +39,7 @@ function getForgeIcon(id: string): ForgeIcon {
 const GENERAL_ID = "general";
 const GITHUB_ID = "github";
 const CREDENTIAL_RESULT_DISPLAY_MS = 5000;
+const COPY_FEEDBACK_MS = 2000;
 
 interface CodeForgeSettingsTabProps {
   activeSubtab: string | null;
@@ -56,6 +64,129 @@ export function CodeForgeSettingsTab({ activeSubtab, onSubtabChange }: CodeForge
     errorMessage: "Couldn't load forge providers",
     timeoutMessage: "Forge providers took too long to load.",
   });
+
+  const [auditRecords, setAuditRecords] = useState<ForgeAuditRecord[]>([]);
+  const [auditEnabled, setAuditEnabled] = useState(true);
+  const [auditMaxRecords, setAuditMaxRecords] = useState(FORGE_AUDIT_DEFAULT_MAX_RECORDS);
+  const [auditStats, setAuditStats] = useState<ForgeAuditStats | null>(null);
+  const [auditLoading, setAuditLoading] = useState(true);
+  const [auditCopied, setAuditCopied] = useState(false);
+  const [auditExported, setAuditExported] = useState(false);
+  const [showAuditClearConfirm, setShowAuditClearConfirm] = useState(false);
+  const [developerMode, setDeveloperMode] = useState(false);
+  const auditCopyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const auditExportTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const refreshAuditRecords = useCallback(async (): Promise<void> => {
+    try {
+      const [recordsResult, statsResult] = await Promise.allSettled([
+        window.electron.forgeAudit.getRecords(),
+        window.electron.forgeAudit.getStats(),
+      ]);
+      if (recordsResult.status === "fulfilled") setAuditRecords(recordsResult.value);
+      else logError("Failed to load forge audit log", recordsResult.reason);
+      if (statsResult.status === "fulfilled") setAuditStats(statsResult.value);
+      else logError("Failed to load forge audit stats", statsResult.reason);
+    } catch (err) {
+      logError("Failed to load forge audit log", err);
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.allSettled([
+      window.electron.forgeAudit.getConfig(),
+      window.electron.forgeAudit.getRecords(),
+      window.electron.forgeAudit.getStats(),
+      appClient.getState(),
+    ])
+      .then(([cfgResult, recordsResult, statsResult, stateResult]) => {
+        if (cancelled) return;
+        if (cfgResult.status === "fulfilled") {
+          setAuditEnabled(cfgResult.value.enabled);
+          setAuditMaxRecords(cfgResult.value.maxRecords);
+        } else {
+          logError("Failed to load forge audit config", cfgResult.reason);
+        }
+        if (recordsResult.status === "fulfilled") {
+          setAuditRecords(recordsResult.value);
+        } else {
+          logError("Failed to load forge audit log", recordsResult.reason);
+        }
+        if (statsResult.status === "fulfilled") {
+          setAuditStats(statsResult.value);
+        } else {
+          logError("Failed to load forge audit stats", statsResult.reason);
+        }
+        if (stateResult.status === "fulfilled" && stateResult.value?.developerMode) {
+          setDeveloperMode(stateResult.value.developerMode.enabled === true);
+        }
+        setAuditLoading(false);
+      })
+      .catch((err) => {
+        logError("Failed to load forge audit settings", err);
+        if (!cancelled) setAuditLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (auditCopyTimeoutRef.current) clearTimeout(auditCopyTimeoutRef.current);
+      if (auditExportTimeoutRef.current) clearTimeout(auditExportTimeoutRef.current);
+    };
+  }, []);
+
+  const handleAuditEnabledToggle = useCallback(async () => {
+    try {
+      const next = !auditEnabled;
+      const cfg = await window.electron.forgeAudit.setEnabled(next);
+      setAuditEnabled(cfg.enabled);
+      setAuditMaxRecords(cfg.maxRecords);
+    } catch (err) {
+      logError("Failed to toggle forge audit log", err);
+    }
+  }, [auditEnabled]);
+
+  const handleAuditCopy = useCallback(async (toCopy: ForgeAuditRecord[]) => {
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(toCopy, null, 2));
+      setAuditCopied(true);
+      if (auditCopyTimeoutRef.current) clearTimeout(auditCopyTimeoutRef.current);
+      auditCopyTimeoutRef.current = setTimeout(() => setAuditCopied(false), COPY_FEEDBACK_MS);
+    } catch (err) {
+      logError("Failed to copy forge audit log", err);
+    }
+  }, []);
+
+  const handleAuditExport = useCallback(async (toExport: ForgeAuditRecord[]) => {
+    try {
+      const saved = await window.electron.forgeAudit.exportLog(toExport);
+      if (saved) {
+        setAuditExported(true);
+        if (auditExportTimeoutRef.current) clearTimeout(auditExportTimeoutRef.current);
+        auditExportTimeoutRef.current = setTimeout(() => setAuditExported(false), COPY_FEEDBACK_MS);
+      }
+    } catch (err) {
+      logError("Failed to export forge audit log", err);
+    }
+  }, []);
+
+  const handleAuditClear = useCallback(async () => {
+    try {
+      await window.electron.forgeAudit.clearLog();
+      setAuditRecords([]);
+      setAuditStats((prev) =>
+        prev ? { ...prev, anomalySignals: [], anomalySuppressed: true } : prev
+      );
+    } catch (err) {
+      logError("Failed to clear forge audit log", err);
+    } finally {
+      setShowAuditClearConfirm(false);
+    }
+  }, []);
 
   const providerOptions = useMemo<ForgeProviderOption[]>(
     () =>
@@ -99,7 +230,41 @@ export function CodeForgeSettingsTab({ activeSubtab, onSubtabChange }: CodeForge
           onSubtabChange={onSubtabChange}
         />
 
-        {isGeneral && <ForgeIntegrationsTab />}
+        {isGeneral && (
+          <>
+            <ForgeIntegrationsTab />
+            <SettingsSection
+              icon={ScrollText}
+              title="Forge audit log"
+              description="Records every forge provider call — list / get / assign / validateToken — with redacted argument summaries. Use it to triage slow providers, failure clusters, and unexpected anomalies surfaced by the audit health snapshot."
+            >
+              <div className="flex flex-col gap-4">
+                <SettingsSwitchCard
+                  id="forge-audit-enable"
+                  title="Record forge provider calls"
+                  subtitle="Append a record each time a forge provider method is invoked"
+                  isEnabled={auditEnabled}
+                  onChange={() => void handleAuditEnabledToggle()}
+                  ariaLabel="Toggle forge audit log"
+                />
+                <ForgeAuditLogViewer
+                  records={auditRecords}
+                  loading={auditLoading}
+                  maxRecords={auditMaxRecords}
+                  anomalySignals={auditStats?.anomalySignals}
+                  anomalySuppressed={auditStats?.anomalySuppressed ?? true}
+                  onRefresh={refreshAuditRecords}
+                  onCopy={handleAuditCopy}
+                  onExport={handleAuditExport}
+                  onClear={() => setShowAuditClearConfirm(true)}
+                  copyFlashActive={auditCopied}
+                  exportFlashActive={auditExported}
+                  developerMode={developerMode}
+                />
+              </div>
+            </SettingsSection>
+          </>
+        )}
 
         {isGitHub && (
           <ForgeProviderCard name="GitHub" Icon={GitHubIcon}>
@@ -123,6 +288,16 @@ export function CodeForgeSettingsTab({ activeSubtab, onSubtabChange }: CodeForge
           </ForgeProviderCard>
         )}
       </div>
+
+      <ConfirmDialog
+        isOpen={showAuditClearConfirm}
+        variant="destructive"
+        onConfirm={() => void handleAuditClear()}
+        onClose={() => setShowAuditClearConfirm(false)}
+        title="Clear forge audit log?"
+        description="This permanently deletes all recorded forge provider calls on this machine. New calls will still be recorded."
+        confirmLabel="Clear log"
+      />
     </div>
   );
 }

--- a/src/components/Settings/ForgeAuditLogViewer.tsx
+++ b/src/components/Settings/ForgeAuditLogViewer.tsx
@@ -1,25 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
-import { Check, Copy, Download, Eye, RefreshCw } from "lucide-react";
+import { Check, Clock, Copy, Download, Eye, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
-import type { PluginActionAuditRecord, PluginActionAuditResult } from "@shared/types";
+import type { ForgeAnomalyKind, ForgeAuditRecord, ForgeAuditResult } from "@shared/types/ipc/forge";
 
-type ResultFilter = "all" | PluginActionAuditResult;
-
-const RESULT_LABEL: Record<PluginActionAuditResult, string> = {
-  success: "Success",
-  error: "Error",
-  disabled: "Disabled",
-  restricted: "Restricted",
-};
-
-const RESULT_DOT_CLASS: Record<PluginActionAuditResult, string> = {
-  success: "bg-status-success",
-  error: "bg-status-danger",
-  disabled: "bg-status-warning",
-  restricted: "bg-status-danger",
-};
+type ResultFilter = "all" | ForgeAuditResult;
 
 type TimeRange = "5m" | "1h" | "24h" | "all";
 
@@ -30,6 +16,25 @@ const TIME_RANGE_MS: Record<Exclude<TimeRange, "all">, number> = {
 };
 
 const RELATIVE_TIMESTAMP_REFRESH_MS = 30_000;
+
+const RESULT_LABEL: Record<ForgeAuditResult, string> = {
+  success: "Success",
+  "not-found": "Not found",
+  error: "Error",
+};
+
+const RESULT_DOT_CLASS: Record<ForgeAuditResult, string> = {
+  success: "bg-status-success",
+  "not-found": "bg-status-info",
+  error: "bg-status-danger",
+};
+
+const ANOMALY_KIND_LABEL: Record<ForgeAnomalyKind, string> = {
+  "latency-drift": "latency drift",
+  "first-seen-method": "first-seen method",
+  "failure-cluster": "failure cluster",
+  "p95-z-score": "p95 outlier",
+};
 
 function formatRelativeTimestamp(ts: number, now: number): string {
   const diffMs = now - ts;
@@ -43,28 +48,33 @@ function formatRelativeTimestamp(ts: number, now: number): string {
   return `${Math.floor(hr / 24)}d ago`;
 }
 
-interface PluginActionAuditLogViewerProps {
-  records: PluginActionAuditRecord[];
+interface ForgeAuditLogViewerProps {
+  records: ForgeAuditRecord[];
   loading: boolean;
   maxRecords: number;
+  anomalySignals?: import("@shared/types/ipc/forge").ForgeAnomalySignal[];
+  anomalySuppressed?: boolean;
   onRefresh: () => Promise<void> | void;
-  onCopy: (records: PluginActionAuditRecord[]) => Promise<void> | void;
-  onExport: (records: PluginActionAuditRecord[]) => Promise<void> | void;
+  onCopy: (records: ForgeAuditRecord[]) => Promise<void> | void;
+  onExport: (records: ForgeAuditRecord[]) => Promise<void> | void;
   onClear: () => void;
   copyFlashActive?: boolean;
   exportFlashActive?: boolean;
   /**
-   * When true, successful dispatches are included in the default view. Off by
-   * default so the rare error/restricted rows aren't drowned out by a flood of
-   * `success` records. Opt-in via the developer-mode toggle on the parent tab.
+   * When true, successful calls are included in the default view. Off by
+   * default so rare error and not-found rows aren't drowned out by the
+   * high-volume `success` flow. Opt-in via the developer-mode toggle on the
+   * parent tab.
    */
   developerMode?: boolean;
 }
 
-export function PluginActionAuditLogViewer({
+export function ForgeAuditLogViewer({
   records,
   loading,
   maxRecords,
+  anomalySignals = [],
+  anomalySuppressed = true,
   onRefresh,
   onCopy,
   onExport,
@@ -72,12 +82,13 @@ export function PluginActionAuditLogViewer({
   copyFlashActive,
   exportFlashActive,
   developerMode = false,
-}: PluginActionAuditLogViewerProps) {
-  const [pluginFilter, setPluginFilter] = useState("");
+}: ForgeAuditLogViewerProps) {
+  const [methodFilter, setMethodFilter] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
   const [resultFilter, setResultFilter] = useState<ResultFilter>("all");
   const [timeRange, setTimeRange] = useState<TimeRange>("all");
   const [showSuccessful, setShowSuccessful] = useState(false);
+  const [ignoreLastHour, setIgnoreLastHour] = useState(false);
   const [nowTick, setNowTick] = useState(Date.now());
 
   useEffect(() => {
@@ -85,39 +96,62 @@ export function PluginActionAuditLogViewer({
     return () => clearInterval(id);
   }, []);
 
-  // Whether the rendered list will visibly hide successful records. The toggle
-  // is the user's expressed intent, but `resultFilter === "success"` means the
-  // user explicitly asked for that bucket — don't filter them back out.
+  // The toggle is the user's expressed intent, but `resultFilter === "success"`
+  // means the user explicitly asked for that bucket — don't filter them back out.
   const suppressSuccess = !showSuccessful && resultFilter !== "success";
 
   const filteredRecords = useMemo(() => {
-    const needle = pluginFilter.trim().toLowerCase();
+    const needle = methodFilter.trim().toLowerCase();
     const search = searchQuery.trim().toLowerCase();
     const cutoffMs = timeRange !== "all" ? nowTick - TIME_RANGE_MS[timeRange] : undefined;
     return records.filter((record) => {
-      if (cutoffMs !== undefined && record.ts < cutoffMs) return false;
+      if (cutoffMs !== undefined && record.timestamp < cutoffMs) return false;
       if (suppressSuccess && record.result === "success") return false;
       if (resultFilter !== "all" && record.result !== resultFilter) return false;
       if (
         needle.length > 0 &&
-        !record.pluginId.toLowerCase().includes(needle) &&
-        !record.actionId.toLowerCase().includes(needle)
+        !record.methodName.toLowerCase().includes(needle) &&
+        !record.providerId.toLowerCase().includes(needle)
       ) {
         return false;
       }
       if (search.length > 0) {
-        const args = record.argsPlaintext ?? "";
-        const hash = record.argsHash ?? "";
-        if (!args.toLowerCase().includes(search) && !hash.toLowerCase().includes(search)) {
+        const args = record.argsSummary ?? "";
+        const err = record.errorMessage ?? "";
+        if (!args.toLowerCase().includes(search) && !err.toLowerCase().includes(search)) {
           return false;
         }
       }
       return true;
     });
-  }, [records, pluginFilter, searchQuery, resultFilter, suppressSuccess, timeRange, nowTick]);
+  }, [records, methodFilter, searchQuery, resultFilter, suppressSuccess, timeRange, nowTick]);
+
+  const oneHourAgo = nowTick - 3_600_000;
+  const visibleSignals = useMemo(() => {
+    if (anomalySuppressed) return [];
+    return ignoreLastHour
+      ? anomalySignals.filter((s) => s.timestamp <= oneHourAgo)
+      : anomalySignals;
+  }, [anomalySignals, anomalySuppressed, ignoreLastHour, oneHourAgo]);
+
+  const signalRecordIds = useMemo(() => {
+    const set = new Set<string>();
+    for (const sig of visibleSignals) {
+      for (const id of sig.recordIds) set.add(id);
+    }
+    return set;
+  }, [visibleSignals]);
+
+  const anomalyCountsByKind = useMemo(() => {
+    const counts = new Map<ForgeAnomalyKind, number>();
+    for (const sig of visibleSignals) {
+      counts.set(sig.kind, (counts.get(sig.kind) ?? 0) + 1);
+    }
+    return counts;
+  }, [visibleSignals]);
 
   const isFiltering =
-    pluginFilter.trim().length > 0 ||
+    methodFilter.trim().length > 0 ||
     searchQuery.trim().length > 0 ||
     resultFilter !== "all" ||
     timeRange !== "all" ||
@@ -129,10 +163,10 @@ export function PluginActionAuditLogViewer({
       <div className="flex flex-wrap items-center gap-2">
         <input
           type="text"
-          value={pluginFilter}
-          onChange={(e) => setPluginFilter(e.target.value)}
-          placeholder="Filter by plugin or action ID"
-          aria-label="Filter audit by plugin or action ID"
+          value={methodFilter}
+          onChange={(e) => setMethodFilter(e.target.value)}
+          placeholder="Filter by method or provider"
+          aria-label="Filter audit by method or provider"
           className="flex-1 min-w-[180px] bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-daintree-text/40 font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
         />
         <input
@@ -150,9 +184,8 @@ export function PluginActionAuditLogViewer({
             if (
               value === "all" ||
               value === "success" ||
-              value === "error" ||
-              value === "disabled" ||
-              value === "restricted"
+              value === "not-found" ||
+              value === "error"
             ) {
               setResultFilter(value);
             }
@@ -162,9 +195,8 @@ export function PluginActionAuditLogViewer({
         >
           <option value="all">All results</option>
           <option value="success">Success</option>
+          <option value="not-found">Not found</option>
           <option value="error">Error</option>
-          <option value="disabled">Disabled</option>
-          <option value="restricted">Restricted</option>
         </select>
         <select
           value={timeRange}
@@ -195,10 +227,38 @@ export function PluginActionAuditLogViewer({
             aria-pressed={showSuccessful}
           >
             <Eye className="w-3.5 h-3.5" />
-            Show successful dispatches
+            Show successful calls
+          </button>
+        )}
+        {!anomalySuppressed && anomalySignals.length > 0 && (
+          <button
+            type="button"
+            onClick={() => setIgnoreLastHour((v) => !v)}
+            className={cn(
+              "flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded-[var(--radius-md)] border transition-colors",
+              ignoreLastHour
+                ? "border-status-warning/20 text-status-warning bg-status-warning/10"
+                : "border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft"
+            )}
+            aria-pressed={ignoreLastHour}
+          >
+            <Clock className="w-3.5 h-3.5" />
+            Ignore last hour
           </button>
         )}
       </div>
+
+      {!anomalySuppressed && visibleSignals.length > 0 && (
+        <div className="flex items-start gap-2 p-2.5 rounded-[var(--radius-md)] bg-status-danger/10 border border-status-danger/20">
+          <span className="text-xs text-status-danger">
+            {visibleSignals.length} anomaly signal{visibleSignals.length !== 1 ? "s" : ""}
+            {anomalyCountsByKind.size > 0 &&
+              ` (${Array.from(anomalyCountsByKind.entries())
+                .map(([kind, count]) => `${count} ${ANOMALY_KIND_LABEL[kind]}`)
+                .join(", ")})`}
+          </span>
+        </div>
+      )}
 
       <div className="max-h-64 overflow-y-auto rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg">
         {loading ? (
@@ -209,20 +269,16 @@ export function PluginActionAuditLogViewer({
           </Skeleton>
         ) : filteredRecords.length === 0 ? (
           records.length === 0 ? (
-            <EmptyState
-              variant="zero-data"
-              scale="sidebar"
-              title="No plugin actions recorded yet"
-            />
+            <EmptyState variant="zero-data" scale="sidebar" title="No forge calls recorded yet" />
           ) : suppressSuccess &&
-            pluginFilter.trim().length === 0 &&
+            methodFilter.trim().length === 0 &&
             searchQuery.trim().length === 0 &&
             resultFilter === "all" &&
             timeRange === "all" ? (
             <EmptyState
               variant="user-cleared"
               scale="sidebar"
-              title="No errors or restricted dispatches"
+              title="No errors or not-found results"
             />
           ) : (
             <EmptyState
@@ -235,38 +291,47 @@ export function PluginActionAuditLogViewer({
           <ul className="divide-y divide-daintree-border">
             {filteredRecords.map((record) => (
               <li key={record.id} className="grid grid-cols-[auto_1fr_auto] gap-2 p-2 text-xs">
-                <span
-                  className={cn(
-                    "mt-1 h-2 w-2 rounded-full shrink-0",
-                    RESULT_DOT_CLASS[record.result]
+                <div className="flex items-start gap-1 mt-1">
+                  <span
+                    className={cn("h-2 w-2 rounded-full shrink-0", RESULT_DOT_CLASS[record.result])}
+                    aria-label={RESULT_LABEL[record.result]}
+                    title={RESULT_LABEL[record.result]}
+                  />
+                  {signalRecordIds.has(record.id) && (
+                    <span
+                      className="h-2 w-2 rounded-sm rotate-45 shrink-0 bg-status-danger"
+                      title="Anomaly"
+                    />
                   )}
-                  aria-label={RESULT_LABEL[record.result]}
-                  title={RESULT_LABEL[record.result]}
-                />
+                </div>
                 <div className="min-w-0">
                   <div className="flex items-center gap-2">
                     <span className="font-mono text-daintree-text/90 truncate">
-                      {record.actionId}
+                      {record.methodName}
                     </span>
-                    <span className="text-[10px] uppercase tracking-wide text-daintree-text/50">
-                      {record.source}
-                    </span>
+                    {(record.repoOwner || record.repoName) && (
+                      <span className="font-mono text-[10px] text-daintree-text/50 truncate">
+                        {record.repoOwner ? `${record.repoOwner}/` : ""}
+                        {record.repoName ?? ""}
+                      </span>
+                    )}
                   </div>
                   <div className="mt-0.5 font-mono text-daintree-text/50 truncate">
-                    {record.pluginId}
+                    {record.providerId}
                   </div>
-                  {record.argsPlaintext ? (
+                  {record.argsSummary && record.argsSummary !== "{}" && (
                     <div className="mt-0.5 font-mono text-daintree-text/40 truncate">
-                      {record.argsPlaintext}
+                      {record.argsSummary}
                     </div>
-                  ) : record.argsHash ? (
-                    <div className="mt-0.5 font-mono text-daintree-text/40 truncate">
-                      sha256:{record.argsHash.slice(0, 16)}…
+                  )}
+                  {record.errorMessage && (
+                    <div className="mt-0.5 text-[10px] text-status-danger/80 truncate">
+                      {record.errorMessage}
                     </div>
-                  ) : null}
+                  )}
                 </div>
                 <div className="text-right text-daintree-text/40 whitespace-nowrap">
-                  <div>{formatRelativeTimestamp(record.ts, nowTick)}</div>
+                  <div>{formatRelativeTimestamp(record.timestamp, nowTick)}</div>
                   <div>{record.durationMs}ms</div>
                 </div>
               </li>

--- a/src/components/Settings/PluginActionsSettingsTab.tsx
+++ b/src/components/Settings/PluginActionsSettingsTab.tsx
@@ -4,6 +4,7 @@ import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { SettingsSection } from "@/components/Settings/SettingsSection";
 import { SettingsSwitchCard } from "@/components/Settings/SettingsSwitchCard";
 import { PluginActionAuditLogViewer } from "@/components/Settings/PluginActionAuditLogViewer";
+import { appClient } from "@/clients";
 import { logError } from "@/utils/logger";
 import { type PluginActionAuditRecord, PLUGIN_AUDIT_DEFAULT_MAX_RECORDS } from "@shared/types";
 
@@ -13,6 +14,7 @@ export function PluginActionsSettingsTab() {
   const [records, setRecords] = useState<PluginActionAuditRecord[]>([]);
   const [auditEnabled, setAuditEnabled] = useState(true);
   const [maxRecords, setMaxRecords] = useState(PLUGIN_AUDIT_DEFAULT_MAX_RECORDS);
+  const [developerMode, setDeveloperMode] = useState(false);
   const [loading, setLoading] = useState(true);
   const [copiedFlash, setCopiedFlash] = useState(false);
   const [exportedFlash, setExportedFlash] = useState(false);
@@ -35,8 +37,9 @@ export function PluginActionsSettingsTab() {
     Promise.allSettled([
       window.electron.plugin.getAuditConfig(),
       window.electron.plugin.getAuditRecords(),
+      appClient.getState(),
     ])
-      .then(([cfgResult, recordsResult]) => {
+      .then(([cfgResult, recordsResult, stateResult]) => {
         if (cancelled) return;
         if (cfgResult.status === "fulfilled") {
           setAuditEnabled(cfgResult.value.enabled);
@@ -48,6 +51,9 @@ export function PluginActionsSettingsTab() {
           setRecords(recordsResult.value);
         } else {
           logError("Failed to load plugin audit log", recordsResult.reason);
+        }
+        if (stateResult.status === "fulfilled" && stateResult.value?.developerMode) {
+          setDeveloperMode(stateResult.value.developerMode.enabled === true);
         }
         setLoading(false);
       })
@@ -139,6 +145,7 @@ export function PluginActionsSettingsTab() {
             onClear={() => setShowClearConfirm(true)}
             copyFlashActive={copiedFlash}
             exportFlashActive={exportedFlash}
+            developerMode={developerMode}
           />
         </div>
       </SettingsSection>

--- a/src/components/Settings/__tests__/CodeForgeSettingsTab.credentials.test.tsx
+++ b/src/components/Settings/__tests__/CodeForgeSettingsTab.credentials.test.tsx
@@ -60,6 +60,21 @@ function installForgeMocks(opts: ForgeMockOptions) {
       getCredentialStatus,
       clearCredential,
     },
+    forgeAudit: {
+      getRecords: vi.fn(async () => []),
+      getConfig: vi.fn(async () => ({ enabled: true, maxRecords: 500 })),
+      getStats: vi.fn(async () => ({
+        anomalySignals: [],
+        anomalySuppressed: true,
+        anomalyRecordFloor: 10,
+      })),
+      clearLog: vi.fn(async () => {}),
+      exportLog: vi.fn(async () => false),
+      setEnabled: vi.fn(async () => ({ enabled: true, maxRecords: 500 })),
+    },
+    app: {
+      getState: vi.fn(async () => ({ developerMode: { enabled: false } })),
+    },
   } as unknown as typeof window.electron;
   return { setCredential, getCredentialStatus, clearCredential };
 }


### PR DESCRIPTION
## Summary

- Adds a `ForgeAuditLogViewer` component embedded in the CodeForge settings tab (General view) with method/provider filter, args search, result filter, time-range picker (5m/1h/24h/all), anomaly signal banner with ignore-last-hour toggle, per-row anomaly markers, and a copy/export/clear toolbar.
- Wires a new `forgeAudit` IPC namespace via `defineIpcNamespace` with six ops: `getRecords`, `getConfig`, `getStats`, `clearLog`, `exportLog`, `setEnabled`. Export writes secret-scrubbed NDJSON via `showSaveDialog`, attached to the parent window.
- Enhances `PluginActionAuditLogViewer` with time-range filtering, args search, and a developer-mode-gated toggle to show successful dispatches. Both viewers default to hiding success rows so errors and anomalies surface immediately.

Resolves #9241

## Changes

- `electron/ipc/handlers/forgeAudit.ts` — 6-op IPC handler; `exportLog` scrubs secrets, attaches save dialog to calling `BrowserWindow`
- `electron/ipc/handlers/forgeAudit.preload.ts` — preload bindings for the `forgeAudit` namespace
- `electron/ipc/handlers.ts`, `electron/preload.cts` — register handler and expose namespace
- `shared/types/ipc/api.ts`, `generated-api.ts`, `generated.ts` — generated type additions for `forgeAudit`
- `src/components/Settings/ForgeAuditLogViewer.tsx` — new viewer component (410 lines)
- `src/components/Settings/CodeForgeSettingsTab.tsx` — embed viewer with enable toggle and clear-with-confirm
- `src/components/Settings/PluginActionAuditLogViewer.tsx` — time range, args search, successful-dispatches toggle
- `src/components/Settings/PluginActionsSettingsTab.tsx` — minor wiring update

## Testing

13 unit tests in `electron/ipc/handlers/__tests__/forgeAudit.handlers.test.ts` covering handler registration, delegation to `forgeAuditLog`, argument validation, NDJSON export format, dialog cancel path (no file chosen), and `writeFile` rejection handling.