### PR TITLE
feat(dev-preview): bind Cmd+R to reload the focused dev preview panel

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -365,6 +365,7 @@ export const CHANNELS = {
   WEBVIEW_DIALOG_REQUEST: "webview:dialog-request",
   WEBVIEW_DIALOG_RESPONSE: "webview:dialog-response",
   WEBVIEW_FIND_SHORTCUT: "webview:find-shortcut",
+  WEBVIEW_RELOAD_SHORTCUT: "webview:reload-shortcut",
   WEBVIEW_NAVIGATION_BLOCKED: "webview:navigation-blocked",
   WEBVIEW_UNRESPONSIVE: "webview:unresponsive",
   WEBVIEW_RESPONSIVE: "webview:responsive",

--- a/electron/ipc/handlers/webview.ts
+++ b/electron/ipc/handlers/webview.ts
@@ -669,8 +669,16 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     ) {
       throw new Error("Invalid arguments: webContentsId must be number, panelId must be string");
     }
-    const { webContentsId, panelId } = payload as { webContentsId: number; panelId: string };
-    getWebviewDialogService().registerPanel(webContentsId, panelId);
+    const { webContentsId, panelId, kind } = payload as {
+      webContentsId: number;
+      panelId: string;
+      kind?: unknown;
+    };
+    getWebviewDialogService().registerPanel(
+      webContentsId,
+      panelId,
+      typeof kind === "string" ? kind : undefined
+    );
   };
 
   const handleDialogResponse = async (payload: unknown): Promise<void> => {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1794,6 +1794,8 @@ const api: ElectronAPI = {
     onFindShortcut: (
       callback: (payload: { panelId: string; shortcut: "find" | "next" | "prev" | "close" }) => void
     ): (() => void) => _typedOn(CHANNELS.WEBVIEW_FIND_SHORTCUT, callback),
+    onReloadShortcut: (callback: (payload: { panelId: string }) => void): (() => void) =>
+      _typedOn(CHANNELS.WEBVIEW_RELOAD_SHORTCUT, callback),
     onNavigationBlocked: (
       callback: (payload: { panelId: string; url: string; canOpenExternal: boolean }) => void
     ): (() => void) => _typedOn(CHANNELS.WEBVIEW_NAVIGATION_BLOCKED, callback),

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1778,8 +1778,8 @@ const api: ElectronAPI = {
   webview: {
     setLifecycleState: (webContentsId: number, frozen: boolean): Promise<void> =>
       _unwrappingInvoke(CHANNELS.WEBVIEW_SET_LIFECYCLE_STATE, webContentsId, frozen),
-    registerPanel: (webContentsId: number, panelId: string): Promise<void> =>
-      _unwrappingInvoke(CHANNELS.WEBVIEW_REGISTER_PANEL, { webContentsId, panelId }),
+    registerPanel: (webContentsId: number, panelId: string, kind?: string): Promise<void> =>
+      _unwrappingInvoke(CHANNELS.WEBVIEW_REGISTER_PANEL, { webContentsId, panelId, kind }),
     respondToDialog: (dialogId: string, confirmed: boolean, response?: string): Promise<void> =>
       _unwrappingInvoke(CHANNELS.WEBVIEW_DIALOG_RESPONSE, { dialogId, confirmed, response }),
     onDialogRequest: (

--- a/electron/services/WebviewDialogService.ts
+++ b/electron/services/WebviewDialogService.ts
@@ -12,14 +12,16 @@ type SessionStorageEntry = [string, string];
 
 class WebviewDialogService {
   private panelMap = new Map<number, string>();
+  private kindMap = new Map<number, string>();
   private pendingDialogs = new Map<string, PendingDialog>();
   private pendingOAuthSessionStorage = new Map<string, Promise<SessionStorageEntry[]>>();
   private destroyedListeners = new Set<number>();
 
-  registerPanel(webContentsId: number, panelId: string): void {
+  registerPanel(webContentsId: number, panelId: string, kind?: string): void {
     const wc = webContents.fromId(webContentsId);
     if (!wc || wc.isDestroyed()) {
       this.panelMap.delete(webContentsId);
+      this.kindMap.delete(webContentsId);
       this.destroyedListeners.delete(webContentsId);
       return;
     }
@@ -27,9 +29,17 @@ class WebviewDialogService {
     const previousPanelId = this.panelMap.get(webContentsId);
     if (previousPanelId && previousPanelId !== panelId) {
       this.pendingOAuthSessionStorage.delete(previousPanelId);
+      // Drop a stale kind when the webContents is rebound to a different panel;
+      // the new owner re-supplies it on its own registration.
+      this.kindMap.delete(webContentsId);
     }
 
     this.panelMap.set(webContentsId, panelId);
+    // Registration happens from multiple effects (dialog + console capture);
+    // only some pass a kind. Preserve a previously-set kind when omitted.
+    if (kind !== undefined) {
+      this.kindMap.set(webContentsId, kind);
+    }
 
     if (!this.destroyedListeners.has(webContentsId)) {
       this.destroyedListeners.add(webContentsId);
@@ -40,6 +50,7 @@ class WebviewDialogService {
           this.pendingOAuthSessionStorage.delete(panelId);
         }
         this.panelMap.delete(webContentsId);
+        this.kindMap.delete(webContentsId);
         this.destroyedListeners.delete(webContentsId);
       });
     }
@@ -47,6 +58,10 @@ class WebviewDialogService {
 
   getPanelId(webContentsId: number): string | undefined {
     return this.panelMap.get(webContentsId);
+  }
+
+  getPanelKind(webContentsId: number): string | undefined {
+    return this.kindMap.get(webContentsId);
   }
 
   registerDialog(

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -121,6 +121,7 @@ vi.mock("../../window/windowRef.js", () => ({
 vi.mock("../../ipc/channels.js", () => ({
   CHANNELS: {
     WEBVIEW_FIND_SHORTCUT: "webview:find-shortcut",
+    WEBVIEW_RELOAD_SHORTCUT: "webview:reload-shortcut",
     WEBVIEW_NAVIGATION_BLOCKED: "webview:navigation-blocked",
   },
 }));
@@ -408,6 +409,68 @@ describe("setupWebviewCSP — webview guest navigation restriction", () => {
         panelId: "panel-1",
         shortcut: "find",
       });
+    });
+
+    it("sends reload shortcut (Cmd/Ctrl+R) to the parent window and prevents default (#9497)", () => {
+      const mockSend = vi.fn();
+      mockFromWebContents.mockReturnValue({
+        isDestroyed: () => false,
+        webContents: { send: mockSend },
+      });
+      mockedGetWebviewDialogService.mockReturnValue({
+        registerDialog: vi.fn(),
+        getPanelId: vi.fn(() => "panel-1"),
+      } as unknown as ReturnType<typeof getWebviewDialogService>);
+
+      const contents = createMockWebContents("webview");
+      (contents as unknown as { hostWebContents: unknown }).hostWebContents = { id: 99 };
+      simulateWebContentsCreated(contents);
+
+      const beforeInputHandlers = getEventHandlers(contents, "before-input-event");
+      const mockEvent = { preventDefault: vi.fn() };
+      beforeInputHandlers[0](mockEvent, {
+        type: "keyDown",
+        key: "r",
+        meta: true,
+        control: true,
+        alt: false,
+        shift: false,
+      });
+
+      expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1);
+      expect(mockSend).toHaveBeenCalledWith("webview:reload-shortcut", {
+        panelId: "panel-1",
+      });
+    });
+
+    it("ignores Cmd/Ctrl+Shift+R so it does not shadow other reload variants (#9497)", () => {
+      const mockSend = vi.fn();
+      mockFromWebContents.mockReturnValue({
+        isDestroyed: () => false,
+        webContents: { send: mockSend },
+      });
+      mockedGetWebviewDialogService.mockReturnValue({
+        registerDialog: vi.fn(),
+        getPanelId: vi.fn(() => "panel-1"),
+      } as unknown as ReturnType<typeof getWebviewDialogService>);
+
+      const contents = createMockWebContents("webview");
+      (contents as unknown as { hostWebContents: unknown }).hostWebContents = { id: 99 };
+      simulateWebContentsCreated(contents);
+
+      const beforeInputHandlers = getEventHandlers(contents, "before-input-event");
+      const mockEvent = { preventDefault: vi.fn() };
+      beforeInputHandlers[0](mockEvent, {
+        type: "keyDown",
+        key: "r",
+        meta: true,
+        control: true,
+        alt: false,
+        shift: true,
+      });
+
+      expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+      expect(mockSend).not.toHaveBeenCalledWith("webview:reload-shortcut", expect.anything());
     });
   });
 

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -110,6 +110,7 @@ vi.mock("../../services/WebviewDialogService.js", () => ({
   getWebviewDialogService: vi.fn(() => ({
     registerDialog: vi.fn(),
     getPanelId: vi.fn(() => "panel-browser-1"),
+    getPanelKind: vi.fn(() => "dev-preview"),
     storeOAuthSessionStorage: vi.fn(),
   })),
 }));
@@ -420,6 +421,7 @@ describe("setupWebviewCSP — webview guest navigation restriction", () => {
       mockedGetWebviewDialogService.mockReturnValue({
         registerDialog: vi.fn(),
         getPanelId: vi.fn(() => "panel-1"),
+        getPanelKind: vi.fn(() => "dev-preview"),
       } as unknown as ReturnType<typeof getWebviewDialogService>);
 
       const contents = createMockWebContents("webview");
@@ -443,6 +445,37 @@ describe("setupWebviewCSP — webview guest navigation restriction", () => {
       });
     });
 
+    it("does not swallow Cmd/Ctrl+R for non-dev-preview webviews like browser panels (#9497)", () => {
+      const mockSend = vi.fn();
+      mockFromWebContents.mockReturnValue({
+        isDestroyed: () => false,
+        webContents: { send: mockSend },
+      });
+      mockedGetWebviewDialogService.mockReturnValue({
+        registerDialog: vi.fn(),
+        getPanelId: vi.fn(() => "panel-browser-1"),
+        getPanelKind: vi.fn(() => "browser"),
+      } as unknown as ReturnType<typeof getWebviewDialogService>);
+
+      const contents = createMockWebContents("webview");
+      (contents as unknown as { hostWebContents: unknown }).hostWebContents = { id: 99 };
+      simulateWebContentsCreated(contents);
+
+      const beforeInputHandlers = getEventHandlers(contents, "before-input-event");
+      const mockEvent = { preventDefault: vi.fn() };
+      beforeInputHandlers[0](mockEvent, {
+        type: "keyDown",
+        key: "r",
+        meta: true,
+        control: true,
+        alt: false,
+        shift: false,
+      });
+
+      expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+      expect(mockSend).not.toHaveBeenCalledWith("webview:reload-shortcut", expect.anything());
+    });
+
     it("ignores Cmd/Ctrl+Shift+R so it does not shadow other reload variants (#9497)", () => {
       const mockSend = vi.fn();
       mockFromWebContents.mockReturnValue({
@@ -452,6 +485,7 @@ describe("setupWebviewCSP — webview guest navigation restriction", () => {
       mockedGetWebviewDialogService.mockReturnValue({
         registerDialog: vi.fn(),
         getPanelId: vi.fn(() => "panel-1"),
+        getPanelKind: vi.fn(() => "dev-preview"),
       } as unknown as ReturnType<typeof getWebviewDialogService>);
 
       const contents = createMockWebContents("webview");

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -797,14 +797,21 @@ export function setupWebviewCSP(): void {
 
         if (!shortcut && !isReload) return;
 
-        const panelId = getWebviewDialogService().getPanelId(contents.id);
+        const dialogService = getWebviewDialogService();
+        const panelId = dialogService.getPanelId(contents.id);
         if (!panelId) return;
 
         const findParentWindow = getWindowForWebContents(contents.hostWebContents ?? contents);
 
         if (isReload) {
-          event.preventDefault();
+          // Only dev-preview guests get Cmd/Ctrl+R reload — claiming the key for
+          // other webview kinds (e.g. the browser panel) would swallow it from
+          // the guest page, which has no reload handler of its own here.
+          if (dialogService.getPanelKind(contents.id) !== "dev-preview") return;
+          // preventDefault only when the signal can actually be delivered, so a
+          // window teardown race doesn't eat the key with no reload to show for it.
           if (findParentWindow && !findParentWindow.isDestroyed()) {
+            event.preventDefault();
             getAppWebContents(findParentWindow).send(CHANNELS.WEBVIEW_RELOAD_SHORTCUT, {
               panelId,
             });

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -775,7 +775,10 @@ export function setupWebviewCSP(): void {
       contents.on("unresponsive", notifyUnresponsive);
       contents.on("responsive", notifyResponsive);
 
-      // Intercept find-in-page shortcuts (Cmd/Ctrl+F, Cmd/Ctrl+G, Escape) from webview guests
+      // Intercept find-in-page (Cmd/Ctrl+F, Cmd/Ctrl+G, Escape) and reload
+      // (Cmd/Ctrl+R) shortcuts from webview guests. When the guest has focus
+      // Chromium routes keystrokes directly to it, so the outer renderer's
+      // keydown listener never sees these — they must be caught here.
       contents.on("before-input-event", (event, input) => {
         if (input.type !== "keyDown") return;
         const isMac = process.platform === "darwin";
@@ -790,15 +793,28 @@ export function setupWebviewCSP(): void {
           shortcut = input.shift ? "prev" : "next";
         }
 
-        if (!shortcut) return;
+        const isReload = mod && input.key.toLowerCase() === "r" && !input.alt && !input.shift;
+
+        if (!shortcut && !isReload) return;
 
         const panelId = getWebviewDialogService().getPanelId(contents.id);
         if (!panelId) return;
 
+        const findParentWindow = getWindowForWebContents(contents.hostWebContents ?? contents);
+
+        if (isReload) {
+          event.preventDefault();
+          if (findParentWindow && !findParentWindow.isDestroyed()) {
+            getAppWebContents(findParentWindow).send(CHANNELS.WEBVIEW_RELOAD_SHORTCUT, {
+              panelId,
+            });
+          }
+          return;
+        }
+
         if (shortcut !== "close") {
           event.preventDefault();
         }
-        const findParentWindow = getWindowForWebContents(contents.hostWebContents ?? contents);
         if (findParentWindow && !findParentWindow.isDestroyed()) {
           getAppWebContents(findParentWindow).send(CHANNELS.WEBVIEW_FIND_SHORTCUT, {
             panelId,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -876,7 +876,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     /** Freeze or unfreeze a webview's JS execution via CDP Page.setWebLifecycleState */
     setLifecycleState(webContentsId: number, frozen: boolean): Promise<void>;
     /** Register a webview's webContentsId with its panel ID for dialog routing */
-    registerPanel(webContentsId: number, panelId: string): Promise<void>;
+    registerPanel(webContentsId: number, panelId: string, kind?: string): Promise<void>;
     /** Respond to a JavaScript dialog (alert/confirm/prompt) shown by a webview */
     respondToDialog(dialogId: string, confirmed: boolean, response?: string): Promise<void>;
     /** Subscribe to dialog requests from webview guests */

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -893,6 +893,8 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     onFindShortcut(
       callback: (payload: { panelId: string; shortcut: "find" | "next" | "prev" | "close" }) => void
     ): () => void;
+    /** Subscribe to reload shortcut (Cmd/Ctrl+R) forwarded from focused webview guests */
+    onReloadShortcut(callback: (payload: { panelId: string }) => void): () => void;
     /** Subscribe to blocked cross-origin navigation events from webview guests */
     onNavigationBlocked(
       callback: (payload: { panelId: string; url: string; canOpenExternal: boolean }) => void

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1782,6 +1782,11 @@ export interface IpcEventMap {
     shortcut: "find" | "next" | "prev" | "close";
   };
 
+  // Webview reload shortcut (Cmd/Ctrl+R) forwarded from focused guest
+  "webview:reload-shortcut": {
+    panelId: string;
+  };
+
   // Webview navigation blocked — cross-origin navigation was prevented
   "webview:navigation-blocked": {
     panelId: string;

--- a/shared/types/keymap.ts
+++ b/shared/types/keymap.ts
@@ -169,6 +169,9 @@ export type BuiltInKeyAction =
   | "portal.nextTab"
   | "portal.prevTab"
 
+  // Dev preview actions
+  | "devPreview.reloadPreview"
+
   // Action palette
   | "action.palette"
   | "action.palette.open"
@@ -350,6 +353,7 @@ export const KEY_ACTION_VALUES: ReadonlySet<string> = new Set<string>([
   "portal.closeTab",
   "portal.nextTab",
   "portal.prevTab",
+  "devPreview.reloadPreview",
   "action.palette",
   "action.palette.open",
   "action.repeatLast",

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1269,7 +1269,8 @@ export function DevPreviewPane({
   const { currentDialog, handleDialogRespond } = useWebviewDialog(
     id,
     isEvicted ? null : webviewElement,
-    isWebviewReady && !isEvicted
+    isWebviewReady && !isEvicted,
+    "dev-preview"
   );
 
   // Consolidated emulation effect above handles all preset/rotation/DPR changes.

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -58,6 +58,7 @@ import { useWebviewDialog } from "@/hooks/useWebviewDialog";
 import { WebviewDialog } from "../Browser/WebviewDialog";
 import { FindBar } from "../Browser/FindBar";
 import { useFindInPage } from "@/hooks/useFindInPage";
+import { useKeybindingScope } from "@/hooks/useKeybinding";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import {
   getViewportPreset,
@@ -1281,6 +1282,11 @@ export function DevPreviewPane({
     isFocused
   );
 
+  // Activate the dev-preview keybinding scope while focused so Cmd/Ctrl+R maps
+  // to devPreview.reloadPreview when the panel chrome (toolbar/header) has focus.
+  // The guest-focused case is covered separately by onReloadShortcut below.
+  useKeybindingScope("dev-preview", isFocused);
+
   // Listen for blocked navigation events from main process.
   // 150ms debounce: latest URL wins — repeated blocks within the window
   // replace the pending data rather than stacking.
@@ -1350,6 +1356,17 @@ export function DevPreviewPane({
       setCrashDetails(null);
     }
   }, [currentUrl, crashState]);
+
+  // Listen for the reload shortcut (Cmd/Ctrl+R) forwarded from the focused
+  // webview guest. When the guest has focus, the outer renderer's keybinding
+  // handler never fires, so the main process intercepts the key and forwards it.
+  useEffect(() => {
+    const cleanup = window.electron.webview.onReloadShortcut((payload) => {
+      if (payload.panelId !== id) return;
+      handleHardReload();
+    });
+    return cleanup;
+  }, [id, handleHardReload]);
 
   // Listen for action-driven hard-reload events
   useEffect(() => {

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -390,6 +390,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         registerPanel: vi.fn(() => Promise.resolve()),
         onDialogRequest: vi.fn(() => vi.fn()),
         onFindShortcut: vi.fn(() => vi.fn()),
+        onReloadShortcut: vi.fn(() => vi.fn()),
         onNavigationBlocked: vi.fn(() => vi.fn()),
         onOAuthLoopbackStatus: vi.fn(() => vi.fn()),
         setLifecycleState: vi.fn().mockResolvedValue(undefined),
@@ -433,6 +434,49 @@ describe("DevPreviewPane webview lifecycle regression", () => {
     });
 
     expect(webview.setZoomFactor).toHaveBeenCalledWith(1.4);
+  });
+
+  it("hard-reloads the focused webview guest when onReloadShortcut fires for this panel (#9497)", async () => {
+    let reloadCb: ((payload: { panelId: string }) => void) | undefined;
+    const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
+      .electron;
+    electron.webview.onReloadShortcut = vi.fn((cb: (payload: { panelId: string }) => void) => {
+      reloadCb = cb;
+      return vi.fn();
+    });
+    const reloadIgnoringCache = electron.webview.reloadIgnoringCache as ReturnType<typeof vi.fn>;
+
+    const { container } = render(<DevPreviewPane {...baseProps} />);
+    getWebviewElement(container);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(reloadCb).toBeDefined();
+
+    // A shortcut targeting a different panel must not reload this one
+    act(() => {
+      reloadCb?.({ panelId: "some-other-panel" });
+    });
+    expect(reloadIgnoringCache).not.toHaveBeenCalled();
+
+    // A shortcut targeting this panel triggers a cache-ignoring reload
+    act(() => {
+      reloadCb?.({ panelId: "dev-preview-panel-1" });
+    });
+    expect(reloadIgnoringCache).toHaveBeenCalledWith(42, "dev-preview-panel-1");
+  });
+
+  it("unsubscribes from onReloadShortcut on unmount (#9497)", () => {
+    const unsubscribe = vi.fn();
+    const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
+      .electron;
+    electron.webview.onReloadShortcut = vi.fn(() => unsubscribe);
+
+    const { unmount } = render(<DevPreviewPane {...baseProps} />);
+    expect(electron.webview.onReloadShortcut).toHaveBeenCalled();
+    unmount();
+    expect(unsubscribe).toHaveBeenCalled();
   });
 
   it("binds loading listeners when webview mounts after initial waiting state", async () => {
@@ -824,6 +868,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         registerPanel: vi.fn(() => Promise.resolve()),
         onDialogRequest: vi.fn(() => vi.fn()),
         onFindShortcut: vi.fn(() => vi.fn()),
+        onReloadShortcut: vi.fn(() => vi.fn()),
         onNavigationBlocked: vi.fn(() => vi.fn()),
         onOAuthLoopbackStatus: vi.fn(() => vi.fn()),
         onUnresponsive: vi.fn(() => vi.fn()),
@@ -882,6 +927,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         registerPanel: vi.fn(() => Promise.resolve()),
         onDialogRequest: vi.fn(() => vi.fn()),
         onFindShortcut: vi.fn(() => vi.fn()),
+        onReloadShortcut: vi.fn(() => vi.fn()),
         onNavigationBlocked: vi.fn(() => vi.fn()),
         onOAuthLoopbackStatus: vi.fn(() => vi.fn()),
         onUnresponsive: vi.fn(() => vi.fn()),
@@ -930,6 +976,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         registerPanel: vi.fn(() => Promise.resolve()),
         onDialogRequest: vi.fn(() => vi.fn()),
         onFindShortcut: vi.fn(() => vi.fn()),
+        onReloadShortcut: vi.fn(() => vi.fn()),
         onNavigationBlocked: vi.fn(() => vi.fn()),
         onOAuthLoopbackStatus: vi.fn(() => vi.fn()),
         onUnresponsive: vi.fn(() => vi.fn()),

--- a/src/hooks/useWebviewDialog.ts
+++ b/src/hooks/useWebviewDialog.ts
@@ -7,7 +7,8 @@ import { formatErrorMessage } from "@shared/utils/errorMessage";
 export function useWebviewDialog(
   panelId: string,
   webviewElement: Electron.WebviewTag | null,
-  isWebviewReady: boolean
+  isWebviewReady: boolean,
+  kind?: string
 ) {
   const [dialogQueue, setDialogQueue] = useState<WebviewDialogRequest[]>([]);
 
@@ -16,7 +17,7 @@ export function useWebviewDialog(
     if (!webviewElement || !isWebviewReady) return;
     try {
       const webContentsId = webviewElement.getWebContentsId();
-      window.electron.webview.registerPanel(webContentsId, panelId).catch((err) => {
+      window.electron.webview.registerPanel(webContentsId, panelId, kind).catch((err) => {
         // Registration failed — dialogs will fall back to native. Surface at
         // warn (not error) since native fallback is a working UX, not broken.
         logWarn("Webview dialog registration failed", {
@@ -28,7 +29,7 @@ export function useWebviewDialog(
       // Intentional: getWebContentsId() throws when the webview isn't attached
       // yet — the next ready cycle re-runs this effect.
     }
-  }, [panelId, webviewElement, isWebviewReady]);
+  }, [panelId, webviewElement, isWebviewReady, kind]);
 
   // Subscribe to dialog requests for this panel
   useEffect(() => {

--- a/src/services/defaultKeybindings.ts
+++ b/src/services/defaultKeybindings.ts
@@ -677,6 +677,14 @@ const CORE_KEYBINDINGS: KeybindingConfig[] = [
     category: "Portal",
   },
   {
+    actionId: "devPreview.reloadPreview",
+    combo: "Cmd+R",
+    scope: "dev-preview",
+    priority: 20,
+    description: "Reload dev preview",
+    category: "Dev Preview",
+  },
+  {
     actionId: "nav.toggleSidebar",
     combo: "Cmd+B",
     scope: "global",

--- a/src/services/keybindingUtils.ts
+++ b/src/services/keybindingUtils.ts
@@ -1,7 +1,14 @@
 import type { BuiltInActionId, ActionId } from "@shared/types/actions";
 import { isMac } from "@/lib/platform";
 
-export type KeyScope = "global" | "terminal" | "modal" | "worktreeList" | "portal" | "worktreeGrid";
+export type KeyScope =
+  | "global"
+  | "terminal"
+  | "modal"
+  | "worktreeList"
+  | "portal"
+  | "worktreeGrid"
+  | "dev-preview";
 
 export interface KeybindingConfig {
   actionId: BuiltInActionId;


### PR DESCRIPTION
## Summary

- Binds `Cmd+R` (`Ctrl+R` on Win/Linux) to reload the focused dev preview webview without restarting the dev server.
- Two code paths cover both focus scenarios: a scoped keybinding handles panel chrome focus; a main-process intercept handles when the webview guest itself has DOM focus (Chromium routes those keypresses straight to the OOPIF, so the renderer `keydown` never fires).
- Scoped to dev-preview panels only — browser panels are untouched.

Resolves #9497.

## Changes

**Scoped keybinding (panel chrome focus)**
- New `"dev-preview"` `KeyScope` in `keymap.ts`.
- `devPreview.reloadPreview` registered in `defaultKeybindings.ts` at priority 20.
- `DevPreviewPane` activates the scope via `useKeybindingScope(isFocused)`.

**Main-process intercept (webview guest focus)**
- `before-input-event` listener added in `protocols.ts`; fires `WEBVIEW_RELOAD_SHORTCUT` IPC when `Cmd/Ctrl+R` is detected (Shift variant excluded).
- `DevPreviewPane` subscribes to the channel, hard-reloads on panel match, and unsubscribes on unmount.
- Panel kind tracked in `WebviewDialogService` and threaded through `registerPanel` / `useWebviewDialog` so the intercept is scoped to dev-preview panels only.

## Testing

- `protocols.test.ts` — reload routing, Shift guard, browser-panel passthrough.
- `DevPreviewPane.webview.test.tsx` — reload on match, ignore on non-match, cleanup on unmount.
- Keymap registration verified against existing `KeyScope` precedents.