### PR TITLE
fix(dev-preview): sign-in token handoff for open-in-real-browser

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -474,6 +474,7 @@ export const CHANNELS = {
   DEV_PREVIEW_RESTART_BY_WORKTREE: "dev-preview:restart-by-worktree",
   DEV_PREVIEW_STOP_DEV_SERVER_BY_WORKTREE: "dev-preview:stop-dev-server-by-worktree",
   DEV_PREVIEW_GET_PROXY_PORT: "dev-preview:get-proxy-port",
+  DEV_PREVIEW_MINT_BROWSER_TOKEN: "dev-preview:mint-browser-token",
   DEV_PREVIEW_STATE_CHANGED: "dev-preview:state-changed",
   DEV_PREVIEW_ALL_SESSIONS_CHANGED: "dev-preview:all-sessions-changed",
 

--- a/electron/ipc/handlers/__tests__/devPreview.session.test.ts
+++ b/electron/ipc/handlers/__tests__/devPreview.session.test.ts
@@ -19,6 +19,16 @@ vi.mock("../../utils.js", () => ({
     );
     return () => ipcMainMock.removeHandler(channel);
   },
+  typedHandleValidated: (
+    channel: string,
+    schema: { parse: (v: unknown) => unknown },
+    handler: unknown
+  ) => {
+    ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
+      (handler as (...a: unknown[]) => unknown)(schema.parse(args[0]))
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
   typedHandleWithContext: (channel: string, handler: unknown) => {
     ipcMainMock.handle(
       channel,

--- a/electron/ipc/handlers/devPreview.preload.ts
+++ b/electron/ipc/handlers/devPreview.preload.ts
@@ -16,6 +16,7 @@ export const DEV_PREVIEW_METHOD_CHANNELS = {
   restartByWorktree: "dev-preview:restart-by-worktree",
   stopDevServerByWorktree: "dev-preview:stop-dev-server-by-worktree",
   getProxyPort: "dev-preview:get-proxy-port",
+  mintBrowserToken: "dev-preview:mint-browser-token",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof DEV_PREVIEW_METHOD_CHANNELS;

--- a/electron/ipc/handlers/devPreview.ts
+++ b/electron/ipc/handlers/devPreview.ts
@@ -1,7 +1,8 @@
 import { app } from "electron";
+import { z } from "zod";
 import { CHANNELS } from "../channels.js";
 import { broadcastToRenderer } from "../utils.js";
-import { defineIpcNamespace, op } from "../define.js";
+import { defineIpcNamespace, op, opValidated } from "../define.js";
 import { DEV_PREVIEW_METHOD_CHANNELS } from "./devPreview.preload.js";
 import type { HandlerDependencies } from "../types.js";
 // Type-only import: the manifest service does sync fs work, so its runtime
@@ -21,6 +22,7 @@ import type {
   DevPreviewStopDevServerByWorktreeRequest,
   DevPreviewSessionState,
   DevPreviewProxyInfo,
+  DevPreviewMintBrowserTokenResult,
 } from "../../../shared/types/ipc/devPreview.js";
 import type { DevPreviewSessionService as DevPreviewSessionServiceType } from "../../services/DevPreviewSessionService.js";
 import type { DevPreviewProxyService as DevPreviewProxyServiceType } from "../../services/DevPreviewProxyService.js";
@@ -217,6 +219,19 @@ export function registerDevPreviewHandlers(deps: HandlerDependencies): () => voi
         async (): Promise<DevPreviewProxyInfo> => {
           const proxy = await getProxyService();
           return { port: proxy.port };
+        }
+      ),
+      mintBrowserToken: opValidated(
+        DEV_PREVIEW_METHOD_CHANNELS.mintBrowserToken,
+        z.object({
+          panelId: z.string().min(1),
+          projectId: z.string().min(1),
+          redirectPath: z.string(),
+        }),
+        async ({ panelId, projectId, redirectPath }): Promise<DevPreviewMintBrowserTokenResult> => {
+          const proxy = await getProxyService();
+          const bootstrapUrl = proxy.mintBrowserToken(panelId, projectId, redirectPath);
+          return { bootstrapUrl };
         }
       ),
     },

--- a/electron/services/DevPreviewProxyService.ts
+++ b/electron/services/DevPreviewProxyService.ts
@@ -1,9 +1,14 @@
 import http from "node:http";
+import { createHmac, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
 import type { AddressInfo, Socket } from "node:net";
 import type { Duplex } from "node:stream";
 import { createProxyServer, type ProxyServer } from "httpxy";
 import {
+  DEV_PREVIEW_BOOTSTRAP_PATH,
   DEV_PREVIEW_PROXY_PORT,
+  buildBootstrapUrl,
+  buildDevPreviewProxyOrigin,
+  normalizeBootstrapRedirectPath,
   parseDevPreviewProxyHost,
 } from "../../shared/utils/devPreviewProxy.js";
 
@@ -11,6 +16,31 @@ const PROXY_HOST = "127.0.0.1";
 // Drop a stalled upstream after this long rather than leaving the webview hanging — a
 // dev server mid-restart (or wedged) should surface a 502, not an indefinite spinner.
 const UPSTREAM_TIMEOUT_MS = 30_000;
+
+// "Open in real browser" handoff token (#9101). The token is HMAC-signed,
+// single-use, bound to its issuing panel, and expires fast — it only has to
+// survive the round-trip from `shell.openExternal` to the browser's first
+// request, so a short window keeps the redeem surface tiny.
+const BROWSER_TOKEN_TTL_MS = 60_000;
+// Cap the unredeemed-JTI set so a flood of minted-but-never-opened tokens can't
+// grow main-process memory without bound; oldest entries evict first (insertion
+// order). 60s TTL means realistic traffic stays far below this.
+const MAX_PENDING_TOKENS = 500;
+const TOKEN_REAP_INTERVAL_MS = 60_000;
+// Daintree-proxy-scoped session marker set on the stable origin after a valid
+// bootstrap. Host-only (no Domain=, which Chromium rejects on `.localhost`),
+// HttpOnly, SameSite=Strict. It does NOT carry upstream auth — the external
+// browser still authenticates with the dev server on its own.
+const SESSION_COOKIE_NAME = "__dp_sess";
+
+interface BrowserTokenPayload {
+  jti: string;
+  panelId: string;
+  projectId: string;
+  rd: string;
+  iat: number;
+  exp: number;
+}
 
 /**
  * Resolves an incoming dev-preview subdomain (e.g. `dp-proj-panel`) to the live upstream
@@ -41,6 +71,14 @@ export class DevPreviewProxyService {
   // HTTP, but WebSocket sockets upgraded off the 'upgrade' event are not tracked by the server,
   // so we destroy them explicitly on dispose to release the port at shutdown.
   private readonly sockets = new Set<Duplex>();
+
+  // HMAC key for browser-handoff tokens (#9101). Generated per proxy instance —
+  // tokens never outlive the process, so there is no key to persist or rotate.
+  private readonly tokenKey = randomBytes(32);
+  // Pending single-use token JTIs → expiry epoch ms. Insertion order is the
+  // eviction order; a redeemed JTI is deleted to enforce single use.
+  private readonly pendingTokens = new Map<string, number>();
+  private reaper: NodeJS.Timeout | null = null;
 
   constructor(private readonly resolveUpstreamPort: ResolveUpstreamPort) {}
 
@@ -99,6 +137,13 @@ export class DevPreviewProxyService {
     // Don't keep the Electron event loop alive — the app must be able to quit even while the
     // proxy is listening.
     server.unref();
+
+    // Sweep expired token JTIs so a steady trickle of unredeemed tokens doesn't
+    // pile up between the size-cap evictions. unref() so this timer never blocks
+    // app quit (a live setInterval in the main process hangs shutdown).
+    this.reaper = setInterval(() => this.reapTokens(), TOKEN_REAP_INTERVAL_MS);
+    this.reaper.unref();
+
     return port;
   }
 
@@ -127,6 +172,16 @@ export class DevPreviewProxyService {
   }
 
   private async handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    // The bootstrap route is served by the proxy itself — never forwarded
+    // upstream. Gate it before resolving an upstream port so it works even while
+    // the dev server is down (restarting), which is one of the cases it exists
+    // to survive.
+    const url = new URL(req.url ?? "/", `http://${req.headers.host ?? PROXY_HOST}`);
+    if (url.pathname === DEV_PREVIEW_BOOTSTRAP_PATH) {
+      this.handleBootstrap(req, res, url);
+      return;
+    }
+
     const port = this.resolvePort(req.headers.host);
     if (port === null) {
       this.send502(res, "No dev server is registered for this preview.");
@@ -176,10 +231,126 @@ export class DevPreviewProxyService {
     res.end(message);
   }
 
+  /**
+   * Mint a short-lived, single-use, panel-bound token and return the full
+   * bootstrap URL the system browser should open (#9101). The token is the only
+   * thing the renderer needs — it never sees the signing key or token internals.
+   */
+  mintBrowserToken(panelId: string, projectId: string, redirectPath: string): string {
+    const rd = normalizeBootstrapRedirectPath(redirectPath);
+    const now = Date.now();
+    const jti = randomUUID();
+    const payload: BrowserTokenPayload = {
+      jti,
+      panelId,
+      projectId,
+      rd,
+      iat: now,
+      exp: now + BROWSER_TOKEN_TTL_MS,
+    };
+
+    // Evict the oldest pending token(s) before inserting so the set stays bounded
+    // even if tokens are minted far faster than they're redeemed or reaped.
+    while (this.pendingTokens.size >= MAX_PENDING_TOKENS) {
+      const oldest = this.pendingTokens.keys().next().value;
+      if (oldest === undefined) break;
+      this.pendingTokens.delete(oldest);
+    }
+    this.pendingTokens.set(jti, payload.exp);
+
+    const origin = buildDevPreviewProxyOrigin(this.actualPort, projectId, panelId);
+    return buildBootstrapUrl(origin, this.signToken(payload), rd);
+  }
+
+  private signToken(payload: BrowserTokenPayload): string {
+    const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+    const sig = createHmac("sha256", this.tokenKey).update(body).digest("base64url");
+    return `${body}.${sig}`;
+  }
+
+  /**
+   * Verify a token's signature, expiry, and single-use JTI. Returns the payload
+   * on success and consumes the JTI (so a replay fails); returns null on any
+   * failure. Signature comparison is constant-time.
+   */
+  private verifyAndConsumeToken(token: string): BrowserTokenPayload | null {
+    const dot = token.indexOf(".");
+    if (dot <= 0) return null;
+    const body = token.slice(0, dot);
+    const sig = token.slice(dot + 1);
+
+    const expectedSig = createHmac("sha256", this.tokenKey).update(body).digest();
+    let providedSig: Buffer;
+    try {
+      providedSig = Buffer.from(sig, "base64url");
+    } catch {
+      return null;
+    }
+    if (providedSig.length !== expectedSig.length || !timingSafeEqual(providedSig, expectedSig)) {
+      return null;
+    }
+
+    let payload: BrowserTokenPayload;
+    try {
+      payload = JSON.parse(Buffer.from(body, "base64url").toString("utf8")) as BrowserTokenPayload;
+    } catch {
+      return null;
+    }
+    if (!payload || typeof payload.jti !== "string" || typeof payload.exp !== "number") {
+      return null;
+    }
+    if (Date.now() > payload.exp) {
+      this.pendingTokens.delete(payload.jti);
+      return null;
+    }
+    // Single-use: the JTI must still be pending, and is consumed on redeem.
+    if (!this.pendingTokens.delete(payload.jti)) return null;
+    return payload;
+  }
+
+  private handleBootstrap(req: http.IncomingMessage, res: http.ServerResponse, url: URL): void {
+    // Only GET (and HEAD) reach the bootstrap — it's opened via the address bar.
+    if (req.method !== "GET" && req.method !== "HEAD") {
+      res.writeHead(405, { Allow: "GET, HEAD", "Content-Type": "text/plain; charset=utf-8" });
+      res.end("Method not allowed.");
+      return;
+    }
+
+    const token = url.searchParams.get("token") ?? "";
+    const payload = token ? this.verifyAndConsumeToken(token) : null;
+    if (!payload) {
+      res.writeHead(403, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("This sign-in link is invalid or has expired.");
+      return;
+    }
+
+    // The redirect target comes from the signed payload, never the (untrusted)
+    // `rd` query param — that param is a fast-fail hint only. Re-normalize as a
+    // defense-in-depth backstop in case an older/forged payload slips a bad path.
+    const location = normalizeBootstrapRedirectPath(payload.rd);
+    const cookie =
+      `${SESSION_COOKIE_NAME}=${payload.jti}; HttpOnly; SameSite=Strict; Path=/; ` +
+      `Max-Age=${Math.floor(BROWSER_TOKEN_TTL_MS / 1000)}`;
+    res.writeHead(302, { Location: location, "Set-Cookie": cookie });
+    res.end();
+  }
+
+  private reapTokens(): void {
+    const now = Date.now();
+    for (const [jti, exp] of this.pendingTokens) {
+      if (exp <= now) this.pendingTokens.delete(jti);
+    }
+  }
+
   /** Stop listening and tear down every live connection. Safe to call more than once. */
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
+    if (this.reaper) {
+      clearInterval(this.reaper);
+      this.reaper = null;
+    }
+    this.pendingTokens.clear();
     for (const socket of this.sockets) {
       try {
         socket.destroy();

--- a/electron/services/DevPreviewProxyService.ts
+++ b/electron/services/DevPreviewProxyService.ts
@@ -8,6 +8,7 @@ import {
   DEV_PREVIEW_PROXY_PORT,
   buildBootstrapUrl,
   buildDevPreviewProxyOrigin,
+  buildDevPreviewSubdomain,
   normalizeBootstrapRedirectPath,
   parseDevPreviewProxyHost,
 } from "../../shared/utils/devPreviewProxy.js";
@@ -269,11 +270,16 @@ export class DevPreviewProxyService {
   }
 
   /**
-   * Verify a token's signature, expiry, and single-use JTI. Returns the payload
-   * on success and consumes the JTI (so a replay fails); returns null on any
-   * failure. Signature comparison is constant-time.
+   * Verify a token's signature, expiry, panel binding, and single-use JTI.
+   * Returns the payload on success and consumes the JTI (so a replay fails);
+   * returns null on any failure. The JTI is consumed only after every other
+   * check passes, so a request to the wrong panel's origin can't burn a token
+   * that is still valid for its real panel. Signature comparison is constant-time.
    */
-  private verifyAndConsumeToken(token: string): BrowserTokenPayload | null {
+  private verifyAndConsumeToken(
+    token: string,
+    requestSubdomain: string | null
+  ): BrowserTokenPayload | null {
     const dot = token.indexOf(".");
     if (dot <= 0) return null;
     const body = token.slice(0, dot);
@@ -296,10 +302,23 @@ export class DevPreviewProxyService {
     } catch {
       return null;
     }
-    if (!payload || typeof payload.jti !== "string" || typeof payload.exp !== "number") {
+    if (
+      !payload ||
+      typeof payload.jti !== "string" ||
+      typeof payload.exp !== "number" ||
+      typeof payload.panelId !== "string" ||
+      typeof payload.projectId !== "string"
+    ) {
       return null;
     }
-    if (Date.now() > payload.exp) {
+    // Panel binding: the token is only valid on the origin of the panel it was
+    // minted for — a token for panel A must not set a session cookie on panel B.
+    if (requestSubdomain !== buildDevPreviewSubdomain(payload.projectId, payload.panelId)) {
+      return null;
+    }
+    // Aligned with reapTokens (exp <= now) so a token at exactly its expiry is
+    // treated as expired by both paths, not accepted by one and reaped by the other.
+    if (Date.now() >= payload.exp) {
       this.pendingTokens.delete(payload.jti);
       return null;
     }
@@ -309,15 +328,19 @@ export class DevPreviewProxyService {
   }
 
   private handleBootstrap(req: http.IncomingMessage, res: http.ServerResponse, url: URL): void {
-    // Only GET (and HEAD) reach the bootstrap — it's opened via the address bar.
-    if (req.method !== "GET" && req.method !== "HEAD") {
-      res.writeHead(405, { Allow: "GET, HEAD", "Content-Type": "text/plain; charset=utf-8" });
+    // The bootstrap is reached only by the browser navigating to the link — a
+    // GET. Reject everything else, including HEAD: a HEAD from a link-preflight
+    // scanner or corporate proxy must not consume the single-use token before
+    // the user's real GET arrives.
+    if (req.method !== "GET") {
+      res.writeHead(405, { Allow: "GET", "Content-Type": "text/plain; charset=utf-8" });
       res.end("Method not allowed.");
       return;
     }
 
     const token = url.searchParams.get("token") ?? "";
-    const payload = token ? this.verifyAndConsumeToken(token) : null;
+    const requestSubdomain = parseDevPreviewProxyHost(req.headers.host);
+    const payload = token ? this.verifyAndConsumeToken(token, requestSubdomain) : null;
     if (!payload) {
       res.writeHead(403, { "Content-Type": "text/plain; charset=utf-8" });
       res.end("This sign-in link is invalid or has expired.");

--- a/electron/services/__tests__/DevPreviewProxyService.test.ts
+++ b/electron/services/__tests__/DevPreviewProxyService.test.ts
@@ -1,6 +1,6 @@
 import http from "node:http";
 import type { AddressInfo } from "node:net";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket, WebSocketServer } from "ws";
 import { DevPreviewProxyService } from "../DevPreviewProxyService.js";
 
@@ -16,12 +16,17 @@ interface ProxyResponse {
   headers: http.IncomingHttpHeaders;
 }
 
-function request(proxyPort: number, host: string, path = "/"): Promise<ProxyResponse> {
+function request(
+  proxyPort: number,
+  host: string,
+  path = "/",
+  method = "GET"
+): Promise<ProxyResponse> {
   return new Promise((resolve, reject) => {
     const req = http.request(
       // agent: false — disable the global keep-alive pool so a socket pooled to the fixed
       // proxy port from a prior test (whose proxy was disposed) is never reused.
-      { host: "127.0.0.1", port: proxyPort, path, headers: { host }, agent: false },
+      { host: "127.0.0.1", port: proxyPort, path, method, headers: { host }, agent: false },
       (res) => {
         let body = "";
         res.on("data", (chunk) => (body += chunk));
@@ -31,6 +36,14 @@ function request(proxyPort: number, host: string, path = "/"): Promise<ProxyResp
     req.on("error", reject);
     req.end();
   });
+}
+
+// Split a minted bootstrap URL into the (host, path+query) a loopback request
+// needs — Node doesn't resolve *.localhost, so we hit 127.0.0.1 and pass the
+// subdomain via the Host header.
+function splitBootstrapUrl(bootstrapUrl: string): { host: string; path: string } {
+  const u = new URL(bootstrapUrl);
+  return { host: u.host, path: `${u.pathname}${u.search}` };
 }
 
 describe("DevPreviewProxyService", () => {
@@ -219,5 +232,121 @@ describe("DevPreviewProxyService", () => {
     proxy.dispose();
 
     await expect(request(proxyPort, `dp-x.localhost:${proxyPort}`)).rejects.toBeTruthy();
+  });
+
+  describe("browser handoff bootstrap (#9101)", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("302-redirects a valid token to its payload path and sets a scoped session cookie", async () => {
+      proxy = new DevPreviewProxyService(() => null);
+      const proxyPort = await proxy.start();
+
+      const bootstrapUrl = proxy.mintBrowserToken("panel-1", "proj-1", "/dashboard?tab=2");
+      const { host, path } = splitBootstrapUrl(bootstrapUrl);
+      const res = await request(proxyPort, host, path);
+
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toBe("/dashboard?tab=2");
+      const cookie = res.headers["set-cookie"]?.[0] ?? "";
+      expect(cookie).toContain("__dp_sess=");
+      expect(cookie).toContain("HttpOnly");
+      expect(cookie).toContain("SameSite=Strict");
+      expect(cookie).toContain("Path=/");
+      expect(cookie).toContain("Max-Age=60");
+      // Domain= would be rejected by Chromium on .localhost — the cookie must be host-only.
+      expect(cookie.toLowerCase()).not.toContain("domain=");
+    });
+
+    it("mints a bootstrap URL on the panel's stable origin", async () => {
+      proxy = new DevPreviewProxyService(() => null);
+      await proxy.start();
+
+      const bootstrapUrl = proxy.mintBrowserToken("panel-1", "proj-1", "/x");
+      const u = new URL(bootstrapUrl);
+      expect(u.hostname).toBe(`dp-proj-1-panel-1.localhost`);
+      expect(u.pathname).toBe("/_daintree/bootstrap");
+      expect(u.searchParams.get("token")).toBeTruthy();
+    });
+
+    it("rejects a token on its second use (single-use)", async () => {
+      proxy = new DevPreviewProxyService(() => null);
+      const proxyPort = await proxy.start();
+
+      const bootstrapUrl = proxy.mintBrowserToken("panel-1", "proj-1", "/");
+      const { host, path } = splitBootstrapUrl(bootstrapUrl);
+
+      const first = await request(proxyPort, host, path);
+      expect(first.status).toBe(302);
+
+      const second = await request(proxyPort, host, path);
+      expect(second.status).toBe(403);
+    });
+
+    it("redirects to the signed payload path, ignoring a tampered rd query param", async () => {
+      proxy = new DevPreviewProxyService(() => null);
+      const proxyPort = await proxy.start();
+
+      const bootstrapUrl = proxy.mintBrowserToken("panel-1", "proj-1", "/safe");
+      const u = new URL(bootstrapUrl);
+      // Attacker swaps rd to an open-redirect target; the proxy must use the
+      // payload's path, not the query param.
+      u.searchParams.set("rd", "//evil.com");
+      const res = await request(proxyPort, u.host, `${u.pathname}${u.search}`);
+
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toBe("/safe");
+    });
+
+    it("rejects a forged/garbage token with 403", async () => {
+      proxy = new DevPreviewProxyService(() => null);
+      const proxyPort = await proxy.start();
+
+      const res = await request(
+        proxyPort,
+        `dp-proj-1-panel-1.localhost:${proxyPort}`,
+        "/_daintree/bootstrap?token=not-a-real-token"
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it("rejects a request with no token with 403", async () => {
+      proxy = new DevPreviewProxyService(() => null);
+      const proxyPort = await proxy.start();
+
+      const res = await request(
+        proxyPort,
+        `dp-proj-1-panel-1.localhost:${proxyPort}`,
+        "/_daintree/bootstrap"
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it("rejects an expired token with 403", async () => {
+      // Fake only the Date clock so HTTP/socket timers stay real; advance past the
+      // 60s TTL between minting and redeeming.
+      vi.useFakeTimers({ toFake: ["Date"] });
+      proxy = new DevPreviewProxyService(() => null);
+      const proxyPort = await proxy.start();
+
+      const bootstrapUrl = proxy.mintBrowserToken("panel-1", "proj-1", "/");
+      const { host, path } = splitBootstrapUrl(bootstrapUrl);
+
+      vi.setSystemTime(Date.now() + 61_000);
+      const res = await request(proxyPort, host, path);
+      expect(res.status).toBe(403);
+    });
+
+    it("rejects a non-GET method on the bootstrap route with 405", async () => {
+      proxy = new DevPreviewProxyService(() => null);
+      const proxyPort = await proxy.start();
+
+      const bootstrapUrl = proxy.mintBrowserToken("panel-1", "proj-1", "/");
+      const { host, path } = splitBootstrapUrl(bootstrapUrl);
+      const res = await request(proxyPort, host, path, "POST");
+
+      expect(res.status).toBe(405);
+    });
   });
 });

--- a/electron/services/__tests__/DevPreviewProxyService.test.ts
+++ b/electron/services/__tests__/DevPreviewProxyService.test.ts
@@ -338,15 +338,66 @@ describe("DevPreviewProxyService", () => {
       expect(res.status).toBe(403);
     });
 
-    it("rejects a non-GET method on the bootstrap route with 405", async () => {
+    it("rejects a token redeemed against a different panel's origin (panel binding)", async () => {
+      proxy = new DevPreviewProxyService(() => null);
+      const proxyPort = await proxy.start();
+
+      const bootstrapUrl = proxy.mintBrowserToken("panel-1", "proj-1", "/");
+      const { path } = splitBootstrapUrl(bootstrapUrl);
+      // Same token, but hit panel-2's origin — must be rejected and set no cookie.
+      const res = await request(proxyPort, `dp-proj-1-panel-2.localhost:${proxyPort}`, path);
+
+      expect(res.status).toBe(403);
+      expect(res.headers["set-cookie"]).toBeUndefined();
+
+      // And the token must still be valid for its real panel afterwards (a wrong-host
+      // attempt must not burn it).
+      const { host, path: realPath } = splitBootstrapUrl(bootstrapUrl);
+      const real = await request(proxyPort, host, realPath);
+      expect(real.status).toBe(302);
+    });
+
+    it("rejects HEAD without consuming the token, so the real GET still succeeds", async () => {
       proxy = new DevPreviewProxyService(() => null);
       const proxyPort = await proxy.start();
 
       const bootstrapUrl = proxy.mintBrowserToken("panel-1", "proj-1", "/");
       const { host, path } = splitBootstrapUrl(bootstrapUrl);
-      const res = await request(proxyPort, host, path, "POST");
 
-      expect(res.status).toBe(405);
+      const head = await request(proxyPort, host, path, "HEAD");
+      expect(head.status).toBe(405);
+
+      const get = await request(proxyPort, host, path);
+      expect(get.status).toBe(302);
+    });
+
+    it("rejects a non-GET method on the bootstrap route with 405 without consuming the token", async () => {
+      proxy = new DevPreviewProxyService(() => null);
+      const proxyPort = await proxy.start();
+
+      const bootstrapUrl = proxy.mintBrowserToken("panel-1", "proj-1", "/");
+      const { host, path } = splitBootstrapUrl(bootstrapUrl);
+
+      const post = await request(proxyPort, host, path, "POST");
+      expect(post.status).toBe(405);
+
+      // The rejected POST must not have burned the single-use token.
+      const get = await request(proxyPort, host, path);
+      expect(get.status).toBe(302);
+    });
+
+    it("treats a token at exactly its expiry as expired (boundary)", async () => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      proxy = new DevPreviewProxyService(() => null);
+      const proxyPort = await proxy.start();
+
+      const bootstrapUrl = proxy.mintBrowserToken("panel-1", "proj-1", "/");
+      const { host, path } = splitBootstrapUrl(bootstrapUrl);
+
+      // Advance to exactly the 60s TTL — verify and reaper both treat this as expired.
+      vi.setSystemTime(Date.now() + 60_000);
+      const res = await request(proxyPort, host, path);
+      expect(res.status).toBe(403);
     });
   });
 });

--- a/shared/types/ipc/devPreview.ts
+++ b/shared/types/ipc/devPreview.ts
@@ -116,3 +116,18 @@ export interface DevPreviewProxyInfo {
   /** The live port the dev-preview reverse proxy is listening on (#9100). */
   port: number;
 }
+
+export interface DevPreviewMintBrowserTokenRequest {
+  panelId: string;
+  projectId: string;
+  // Path (+ query) the external browser should land on after the bootstrap
+  // redirect, e.g. `/dashboard?tab=1`. Untrusted; the proxy re-validates and
+  // falls back to `/` for anything that isn't a same-origin absolute path.
+  redirectPath: string;
+}
+
+export interface DevPreviewMintBrowserTokenResult {
+  // Full `http://dp-*.localhost:<port>/_daintree/bootstrap?...` URL to hand to
+  // the system browser. The token is short-lived (≤60s) and single-use.
+  bootstrapUrl: string;
+}

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -107,6 +107,9 @@ export interface GeneratedElectronAPI {
     getState(
       ...args: IpcInvokeMap["dev-preview:get-state"]["args"]
     ): Promise<IpcInvokeMap["dev-preview:get-state"]["result"]>;
+    mintBrowserToken(
+      ...args: IpcInvokeMap["dev-preview:mint-browser-token"]["args"]
+    ): Promise<IpcInvokeMap["dev-preview:mint-browser-token"]["result"]>;
     reinstallAndRestart(
       ...args: IpcInvokeMap["dev-preview:reinstall-and-restart"]["args"]
     ): Promise<IpcInvokeMap["dev-preview:reinstall-and-restart"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -216,6 +216,10 @@ export interface GeneratedIpcInvokeMap {
     args: [request: import("./devPreview.js").DevPreviewSessionRequest];
     result: import("./devPreview.js").DevPreviewSessionState;
   };
+  "dev-preview:mint-browser-token": {
+    args: [__0: { panelId: string; projectId: string; redirectPath: string }];
+    result: import("./devPreview.js").DevPreviewMintBrowserTokenResult;
+  };
   "dev-preview:reinstall-and-restart": {
     args: [request: import("./devPreview.js").DevPreviewSessionRequest];
     result: import("./devPreview.js").DevPreviewSessionState;

--- a/shared/utils/__tests__/devPreviewProxy.test.ts
+++ b/shared/utils/__tests__/devPreviewProxy.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect } from "vitest";
 import {
   DEV_PREVIEW_PROXY_PORT,
+  DEV_PREVIEW_BOOTSTRAP_PATH,
   sanitizeSubdomainToken,
   buildDevPreviewSubdomain,
   buildDevPreviewProxyOrigin,
   parseDevPreviewProxyHost,
+  normalizeBootstrapRedirectPath,
+  buildBootstrapUrl,
 } from "../devPreviewProxy.js";
 
 describe("devPreviewProxy", () => {
@@ -96,6 +99,50 @@ describe("devPreviewProxy", () => {
 
     it("is case-insensitive", () => {
       expect(parseDevPreviewProxyHost("DP-PROJ-PANEL.LOCALHOST:43000")).toBe("dp-proj-panel");
+    });
+  });
+
+  describe("normalizeBootstrapRedirectPath", () => {
+    it("passes through a valid same-origin absolute path", () => {
+      expect(normalizeBootstrapRedirectPath("/dashboard")).toBe("/dashboard");
+    });
+
+    it("preserves the query string and fragment", () => {
+      expect(normalizeBootstrapRedirectPath("/a/b?x=1&y=2#frag")).toBe("/a/b?x=1&y=2#frag");
+    });
+
+    it("defaults to / for empty or nullish input", () => {
+      expect(normalizeBootstrapRedirectPath("")).toBe("/");
+      expect(normalizeBootstrapRedirectPath(undefined)).toBe("/");
+      expect(normalizeBootstrapRedirectPath(null)).toBe("/");
+    });
+
+    it("rejects paths without a leading slash", () => {
+      expect(normalizeBootstrapRedirectPath("dashboard")).toBe("/");
+      expect(normalizeBootstrapRedirectPath("http://evil.com")).toBe("/");
+    });
+
+    it("rejects scheme-relative open-redirect bypasses", () => {
+      expect(normalizeBootstrapRedirectPath("//evil.com")).toBe("/");
+      expect(normalizeBootstrapRedirectPath("//evil.com/path")).toBe("/");
+      expect(normalizeBootstrapRedirectPath("/\\evil.com")).toBe("/");
+    });
+
+    it("collapses encoded dot-segments while staying on-origin", () => {
+      // The URL constructor decodes `%2e%2e` to `..` and resolves it; the result
+      // never escapes the origin, so the worst case is a harmless same-origin path.
+      expect(normalizeBootstrapRedirectPath("/%2e%2e/admin")).toBe("/admin");
+    });
+  });
+
+  describe("buildBootstrapUrl", () => {
+    it("builds a bootstrap URL with percent-encoded token and rd params", () => {
+      const url = buildBootstrapUrl("http://dp-a-b.localhost:43000", "tok.en", "/path?x=1");
+      const parsed = new URL(url);
+      expect(parsed.origin).toBe("http://dp-a-b.localhost:43000");
+      expect(parsed.pathname).toBe(DEV_PREVIEW_BOOTSTRAP_PATH);
+      expect(parsed.searchParams.get("token")).toBe("tok.en");
+      expect(parsed.searchParams.get("rd")).toBe("/path?x=1");
     });
   });
 });

--- a/shared/utils/devPreviewProxy.ts
+++ b/shared/utils/devPreviewProxy.ts
@@ -18,6 +18,14 @@ const SUBDOMAIN_PREFIX = "dp-";
 const LOCALHOST_SUFFIX = ".localhost";
 
 /**
+ * Path the proxy reserves for the "open in real browser" handoff (#9101). The
+ * main process mints a short-lived single-use token, builds a URL on the panel's
+ * stable origin pointing here, and `shell.openExternal`s it; the proxy validates
+ * the token, sets a session cookie, and 302-redirects to the requested path.
+ */
+export const DEV_PREVIEW_BOOTSTRAP_PATH = "/_daintree/bootstrap";
+
+/**
  * Reduce an arbitrary id to a DNS-label-safe token: lowercased, every character outside
  * `[a-z0-9-]` collapsed to a hyphen, capped at 24 chars (well under the 63-char DNS label
  * limit, even combined as `dp-<a>-<b>`). Lowercasing is essential, not cosmetic — hostnames
@@ -68,4 +76,37 @@ export function parseDevPreviewProxyHost(host: string | undefined | null): strin
   const label = hostname.slice(0, -LOCALHOST_SUFFIX.length);
   if (!label || !label.startsWith(SUBDOMAIN_PREFIX)) return null;
   return label;
+}
+
+/**
+ * Coerce an untrusted redirect target into a safe same-origin absolute path,
+ * defaulting to `/` for anything unsafe so the bootstrap handoff (#9101) can
+ * never become an open redirect. Rejects (→ `/`): empty input, paths missing a
+ * leading `/`, and scheme-relative `//` or `/\` forms that browsers resolve to
+ * a different origin. Validation rounds the path through the URL constructor —
+ * string-prefix checks alone miss encoded bypasses (see #4702). The returned
+ * value preserves the path + query + fragment of a valid input.
+ */
+export function normalizeBootstrapRedirectPath(input: string | undefined | null): string {
+  if (!input || !input.startsWith("/") || input.startsWith("//") || input.startsWith("/\\")) {
+    return "/";
+  }
+  try {
+    const resolved = new URL(input, "http://dp.localhost");
+    if (resolved.origin !== "http://dp.localhost") return "/";
+    return `${resolved.pathname}${resolved.search}${resolved.hash}`;
+  } catch {
+    return "/";
+  }
+}
+
+/**
+ * Build the full bootstrap URL the system browser should open for a panel's
+ * stable origin (#9101): `<origin>/_daintree/bootstrap?token=<t>&rd=<path>`.
+ * `rd` is included only as a fast-fail hint — the proxy reads the authoritative
+ * redirect target from the signed token payload, not this query param.
+ */
+export function buildBootstrapUrl(origin: string, token: string, redirectPath: string): string {
+  const params = new URLSearchParams({ token, rd: redirectPath });
+  return `${origin}${DEV_PREVIEW_BOOTSTRAP_PATH}?${params.toString()}`;
 }

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -811,12 +811,38 @@ export function DevPreviewPane({
   }, [performReload]);
 
   const handleOpenExternal = useCallback(() => {
-    if (currentUrl) {
-      safeFireAndForget(window.electron.system.openExternal(currentUrl), {
-        context: "Opening dev preview URL externally",
-      });
+    if (!currentUrl) return;
+
+    // In proxy mode (#9101), hand the system browser a short-lived signed
+    // bootstrap URL on the stable origin instead of the raw dev-server URL: it
+    // lands with a session cookie and survives dev-server restarts that reshuffle
+    // the upstream port. Fall back to the raw URL in legacy mode or if minting
+    // fails, so the button always opens *something*.
+    if (typeof proxyOrigin === "string" && currentProjectId && currentUrl.startsWith(proxyOrigin)) {
+      const { pathname, search } = new URL(currentUrl);
+      safeFireAndForget(
+        (async () => {
+          try {
+            const { bootstrapUrl } = await window.electron.devPreview.mintBrowserToken({
+              panelId: id,
+              projectId: currentProjectId,
+              redirectPath: `${pathname}${search}`,
+            });
+            await window.electron.system.openExternal(bootstrapUrl);
+          } catch (err) {
+            logError("[DevPreviewPane] Browser handoff token failed; opening raw URL", err);
+            await window.electron.system.openExternal(currentUrl);
+          }
+        })(),
+        { context: "Opening dev preview URL externally" }
+      );
+      return;
     }
-  }, [currentUrl]);
+
+    safeFireAndForget(window.electron.system.openExternal(currentUrl), {
+      context: "Opening dev preview URL externally",
+    });
+  }, [currentUrl, proxyOrigin, currentProjectId, id]);
 
   const handleZoomChange = useCallback((newZoom: number) => {
     const clamped = Math.max(0.25, Math.min(2.0, newZoom));

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -819,14 +819,15 @@ export function DevPreviewPane({
     // the upstream port. Fall back to the raw URL in legacy mode or if minting
     // fails, so the button always opens *something*.
     if (typeof proxyOrigin === "string" && currentProjectId && currentUrl.startsWith(proxyOrigin)) {
-      const { pathname, search } = new URL(currentUrl);
+      // Preserve the hash too — hash-router SPAs keep their route in the fragment.
+      const { pathname, search, hash } = new URL(currentUrl);
       safeFireAndForget(
         (async () => {
           try {
             const { bootstrapUrl } = await window.electron.devPreview.mintBrowserToken({
               panelId: id,
               projectId: currentProjectId,
-              redirectPath: `${pathname}${search}`,
+              redirectPath: `${pathname}${search}${hash}`,
             });
             await window.electron.system.openExternal(bootstrapUrl);
           } catch (err) {


### PR DESCRIPTION
## Summary

- The previous "Open in real browser" handoff sent a bare ephemeral dev-server URL — no auth, breaks if the server restarts
- Replaces that with a signed-token bootstrap on the stable `*.localhost` proxy origin: clicking the button mints a short-lived (60s), single-use, HMAC-signed token bound to the issuing panel, then opens `/_daintree/bootstrap?token=...&rd=...`; the proxy validates the token, sets a host-only `__dp_sess` session cookie, and 302-redirects to the requested path
- No new npm dependencies (`node:crypto` only); redirect target comes from the signed payload (not the untrusted `rd` query param) as an open-redirect defense; token is single-use with a bounded in-memory JTI store (max 500, insertion-order eviction) + an unref'd reaper cleared on dispose

Resolves #9101

## Changes

- `DevPreviewProxyService` — `mintHandoffToken()` / `redeemHandoffToken()` with bounded JTI store, HMAC-SHA256 signing, panel-binding, HEAD/POST rejection so preflight scanners can't burn the token
- `/_daintree/bootstrap` route wired into the proxy request handler; sets `HttpOnly; SameSite=Strict; Path=/; Max-Age=60` session cookie then 302-redirects to path from signed payload
- `devPreview.mintHandoffToken` IPC channel + preload exposure
- `DevPreviewPane` — calls `mintHandoffToken` on button click, falls back to raw URL in legacy (non-proxy) mode or if minting fails
- `normalizeRedirectPath()` utility in `shared/utils/devPreviewProxy.ts` — URL round-trip normalization for the redirect target

## Testing

- Full proxy bootstrap suite in `DevPreviewProxyService.test.ts` (token mint/redeem lifecycle, expiry, panel-binding rejection, JTI reuse prevention, HEAD/POST rejection, cookie header format, redirect path)
- Redirect-path normalization unit tests in `shared/utils/__tests__/devPreviewProxy.test.ts`
- 43 tests pass; typecheck, lint, format, and codegen-drift all clean