### PR TITLE
feat(plugins): wire contributes.contextMenus with when evaluation

### DIFF
--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -42,6 +42,11 @@ vi.mock("../../../services/pluginMenuRegistry.js", () => ({
   getPluginMenuItems: (...args: unknown[]) => mockGetPluginMenuItems(...args),
 }));
 
+const mockGetPluginContextMenuItems = vi.fn();
+vi.mock("../../../services/pluginContextMenuRegistry.js", () => ({
+  getPluginContextMenuItems: (...args: unknown[]) => mockGetPluginContextMenuItems(...args),
+}));
+
 const mockGetRegisteredForgeProviders = vi.fn();
 vi.mock("../../../services/forgeProviderRegistry.js", () => ({
   getRegisteredForgeProviders: (...args: unknown[]) => mockGetRegisteredForgeProviders(...args),
@@ -74,6 +79,7 @@ beforeEach(() => {
   mockGetPluginToolbarButtonIds.mockReturnValue([]);
   mockGetToolbarButtonConfig.mockReturnValue(undefined);
   mockGetPluginMenuItems.mockReturnValue([]);
+  mockGetPluginContextMenuItems.mockReturnValue([]);
   mockListPluginActions.mockReturnValue([]);
   mockGetRegisteredForgeProviders.mockReturnValue([]);
   mockGetFileDecorationImpls.mockReturnValue([]);
@@ -760,6 +766,25 @@ describe("pull handlers wait for PluginService init (#9285)", () => {
     releaseGate();
     await inFlight;
     expect(resolved).toBe(true);
+  });
+
+  it("PLUGIN_CONTEXT_MENU_ITEMS reads the registry only after waitForInit() resolves", async () => {
+    const { pluginService } = await import("../../../services/PluginService.js");
+    const waitForInit = vi.mocked(pluginService.waitForInit);
+    let releaseGate: () => void = () => {};
+    waitForInit.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        releaseGate = resolve;
+      })
+    );
+    const handler = getHandler("plugin:context-menu-items");
+    const inFlight = handler({}) as Promise<unknown>;
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockGetPluginContextMenuItems).not.toHaveBeenCalled();
+    releaseGate();
+    await inFlight;
+    expect(mockGetPluginContextMenuItems).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -786,6 +786,19 @@ describe("pull handlers wait for PluginService init (#9285)", () => {
     await inFlight;
     expect(mockGetPluginContextMenuItems).toHaveBeenCalledTimes(1);
   });
+
+  it("PLUGIN_CONTEXT_MENU_ITEMS resolves to the registry's items after init", async () => {
+    const items = [
+      {
+        pluginId: "acme.my-plugin",
+        item: { label: "Do Thing", actionId: "x.y", location: "worktree" },
+      },
+    ];
+    mockGetPluginContextMenuItems.mockReturnValue(items);
+    const handler = getHandler("plugin:context-menu-items");
+    const result = await (handler({}) as Promise<unknown>);
+    expect(result).toEqual(items);
+  });
 });
 
 describe("PLUGIN_FORGE_PROVIDERS_GET handler", () => {

--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -60,6 +60,7 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
   "plugin:toolbar-buttons-changed": "external",
   "plugin:menu-items-changed": "external",
   "plugin:keybindings-changed": "external",
+  "plugin:context-menu-items-changed": "external",
   "plugin:decorations-changed": "external",
   "plugin:provenance-changed": "external",
   "terminal:exit": "external",

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -78,6 +78,10 @@ async function handleKeybindings() {
 }
 
 async function handleContextMenuItems() {
+  // Same init-race guard as `handleMenuItems` — block until startup activation
+  // settles so the renderer's mount-time pull can't observe an empty registry
+  // before plugins finish registering (#9285).
+  await pluginService.waitForInit();
   return getPluginContextMenuItems();
 }
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -138,6 +138,7 @@ import type {
   PluginActionDescriptor,
   MenuItemContribution,
   PluginKeybindingDescriptor,
+  ContextMenuContribution,
 } from "../shared/types/plugin.js";
 import type { PanelKindConfig } from "../shared/config/panelKindRegistry.js";
 import type { ToolbarButtonConfig } from "../shared/config/toolbarButtonRegistry.js";
@@ -2490,6 +2491,12 @@ const api: ElectronAPI = {
     onKeybindingsChanged: (
       callback: (payload: { keybindings: PluginKeybindingDescriptor[]; complete: boolean }) => void
     ) => _eventBusOn("plugin:keybindings-changed", callback),
+    onContextMenuItemsChanged: (
+      callback: (payload: {
+        items: Array<{ pluginId: string; item: ContextMenuContribution }>;
+        complete: boolean;
+      }) => void
+    ) => _eventBusOn("plugin:context-menu-items-changed", callback),
     onDecorationsChanged: (callback: (payload: { scope: string; paths?: string[] }) => void) =>
       _eventBusOn("plugin:decorations-changed", callback),
   },

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -78,6 +78,7 @@ import {
 import {
   registerPluginContextMenuItem,
   unregisterPluginContextMenuItems,
+  getPluginContextMenuItems,
 } from "./pluginContextMenuRegistry.js";
 import {
   trackPluginExpression,
@@ -559,6 +560,14 @@ export class PluginService {
   private menuItemsBroadcastComplete = false;
   private keybindingsBroadcastPending = false;
   private keybindingsBroadcastComplete = false;
+  /**
+   * Same coalescing rationale as {@link menuItemsBroadcastPending}. Context-menu
+   * items are mutated only from `loadPlugin()` / `unloadPlugin()`, so the two
+   * call sites invoke {@link scheduleContextMenuItemsBroadcast} directly.
+   */
+  private contextMenuItemsBroadcastPending = false;
+  /** Mirrors {@link menuItemsBroadcastComplete} for context-menu items. */
+  private contextMenuItemsBroadcastComplete = false;
   private disposed = false;
   private readonly disposeRegistrySubscriptions: () => void;
   /**
@@ -1066,6 +1075,9 @@ export class PluginService {
     for (const ctxMenu of manifest.contributes.contextMenus) {
       trackPluginExpression(manifest.name, ctxMenu.when);
       registerPluginContextMenuItem(manifest.name, ctxMenu);
+    }
+    if (manifest.contributes.contextMenus.length > 0) {
+      this.scheduleContextMenuItemsBroadcast(false);
     }
 
     if (manifest.contributes.experimental_mcpServers.length > 0) {
@@ -2572,6 +2584,9 @@ export class PluginService {
     runUnloadStep(pluginId, "unregisterPluginContextMenuItems", () =>
       unregisterPluginContextMenuItems(pluginId)
     );
+    runUnloadStep(pluginId, "scheduleContextMenuItemsBroadcast", () =>
+      this.scheduleContextMenuItemsBroadcast(true)
+    );
     runUnloadStep(pluginId, "unregisterWhenClausePlugin", () =>
       unregisterWhenClausePlugin(pluginId)
     );
@@ -3073,6 +3088,31 @@ export class PluginService {
   }
 
   /**
+   * Same shape as {@link scheduleMenuItemsBroadcast}; see that method for the
+   * coalescing and `complete`-OR-accumulation rationale.
+   */
+  private scheduleContextMenuItemsBroadcast(complete: boolean): void {
+    if (this.disposed) return;
+    if (complete) this.contextMenuItemsBroadcastComplete = true;
+    if (this.contextMenuItemsBroadcastPending) return;
+    this.contextMenuItemsBroadcastPending = true;
+    queueMicrotask(() => {
+      this.contextMenuItemsBroadcastPending = false;
+      const drained = this.contextMenuItemsBroadcastComplete;
+      this.contextMenuItemsBroadcastComplete = false;
+      if (this.disposed) return;
+      this.broadcastPluginContextMenuItems(drained);
+    });
+  }
+
+  private broadcastPluginContextMenuItems(complete: boolean): void {
+    broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
+      name: "plugin:context-menu-items-changed",
+      payload: { items: getPluginContextMenuItems(), complete },
+    });
+  }
+
+  /**
    * Replay the current actions / panel-kinds / toolbar-button snapshots to a
    * single target webContents. Used by the cold-start view-ready hook so a
    * freshly-restored WebContentsView (post-LRU eviction or first cold load on
@@ -3110,6 +3150,10 @@ export class PluginService {
       {
         name: "plugin:keybindings-changed",
         payload: { keybindings: getPluginKeybindings(), complete: true },
+      },
+      {
+        name: "plugin:context-menu-items-changed",
+        payload: { items: getPluginContextMenuItems(), complete: false },
       },
     ];
     for (const event of events) {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -4631,6 +4631,44 @@ describe("Plugin menu items broadcast", () => {
   });
 });
 
+describe("Plugin context-menu items broadcast", () => {
+  it("coalesces load + unload in the same tick into a single broadcast with complete=true", async () => {
+    const service = new PluginService();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).scheduleContextMenuItemsBroadcast(false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).scheduleContextMenuItemsBroadcast(true);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const broadcasts = broadcastToRendererMock.mock.calls.filter(
+      (call) => (call[1] as { name?: unknown })?.name === "plugin:context-menu-items-changed"
+    );
+    expect(broadcasts).toHaveLength(1);
+    expect((broadcasts[0]?.[1] as { payload: { complete: boolean } }).payload.complete).toBe(true);
+
+    service.dispose();
+  });
+
+  it("dispose() drops a context-menu items broadcast scheduled before disposal", async () => {
+    const service = new PluginService();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).scheduleContextMenuItemsBroadcast(true);
+    service.dispose();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const broadcasts = broadcastToRendererMock.mock.calls.filter(
+      (call) => (call[1] as { name?: unknown })?.name === "plugin:context-menu-items-changed"
+    );
+    expect(broadcasts).toHaveLength(0);
+  });
+});
+
 describe("capabilities declaration logging", () => {
   let logSpy: ReturnType<typeof vi.spyOn>;
   let errorSpy: ReturnType<typeof vi.spyOn>;
@@ -6831,7 +6869,7 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
     await expect(waiter).resolves.toBeUndefined();
   });
 
-  it("pushSnapshotTo() sends actions, panel kinds, toolbar buttons, and menu items to the target webContents", async () => {
+  it("pushSnapshotTo() sends actions, panel kinds, toolbar buttons, menu items, and context-menu items to the target webContents", async () => {
     const service = new PluginService(tmpDir);
     await service.activateStartupFinishedPlugins();
     const send = vi.fn();
@@ -6839,7 +6877,7 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
 
     await service.pushSnapshotTo(wc);
 
-    expect(send).toHaveBeenCalledTimes(5);
+    expect(send).toHaveBeenCalledTimes(6);
     // Every replay goes through the EVENTS_PUSH channel — the same channel the
     // renderer hooks' persistent push listeners consume, so no renderer-side
     // changes are needed for the cold-restore path.
@@ -6852,6 +6890,7 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
     expect(names).toContain("plugin:toolbar-buttons-changed");
     expect(names).toContain("plugin:menu-items-changed");
     expect(names).toContain("plugin:keybindings-changed");
+    expect(names).toContain("plugin:context-menu-items-changed");
     // The keybindings replay is a full authoritative snapshot — the renderer
     // hook full-replaces its plugin bindings on every push, so `complete: true`
     // is consistent with that replace-all semantics.
@@ -6861,9 +6900,9 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
     expect((keybindingsCall?.[1] as { payload: { complete: boolean } }).payload.complete).toBe(
       true
     );
-    // Toolbar and menu-item replays must use `complete: false` so the renderer
-    // does not run a stale-prune sweep — replay is a load-style snapshot, not
-    // an unload-driven authoritative sweep.
+    // Toolbar, menu-item, and context-menu-item replays must use `complete: false`
+    // so the renderer does not run a stale-prune sweep — replay is a load-style
+    // snapshot, not an unload-driven authoritative sweep.
     const toolbarCall = send.mock.calls.find(
       (c) => (c[1] as { name?: string })?.name === "plugin:toolbar-buttons-changed"
     );
@@ -6872,6 +6911,12 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
       (c) => (c[1] as { name?: string })?.name === "plugin:menu-items-changed"
     );
     expect((menuItemsCall?.[1] as { payload: { complete: boolean } }).payload.complete).toBe(false);
+    const contextMenuItemsCall = send.mock.calls.find(
+      (c) => (c[1] as { name?: string })?.name === "plugin:context-menu-items-changed"
+    );
+    expect((contextMenuItemsCall?.[1] as { payload: { complete: boolean } }).payload.complete).toBe(
+      false
+    );
   });
 
   it("pushSnapshotTo() keeps sending remaining channels when one send() throws (TOCTOU)", async () => {
@@ -6890,12 +6935,13 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
 
     await service.pushSnapshotTo(wc);
 
-    expect(send).toHaveBeenCalledTimes(5);
+    expect(send).toHaveBeenCalledTimes(6);
     const names = send.mock.calls.map((c) => (c[1] as { name?: string })?.name);
     expect(names).toContain("plugin:panel-kinds-changed");
     expect(names).toContain("plugin:toolbar-buttons-changed");
     expect(names).toContain("plugin:menu-items-changed");
     expect(names).toContain("plugin:keybindings-changed");
+    expect(names).toContain("plugin:context-menu-items-changed");
   });
 
   it("pushSnapshotTo() skips a destroyed webContents", async () => {
@@ -6923,7 +6969,7 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
 
     await service.activateStartupFinishedPlugins();
     await inFlight;
-    expect(send).toHaveBeenCalledTimes(5);
+    expect(send).toHaveBeenCalledTimes(6);
   });
 
   it("pushSnapshotTo() does not send after dispose()", async () => {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1525,6 +1525,16 @@ export interface ElectronAPI extends GeneratedElectronAPI {
         complete: boolean;
       }) => void
     ): () => void;
+    /** Subscribe to plugin context-menu item registry changes. Returns a cleanup. */
+    onContextMenuItemsChanged(
+      callback: (payload: {
+        items: Array<{
+          pluginId: string;
+          item: import("../plugin.js").ContextMenuContribution;
+        }>;
+        complete: boolean;
+      }) => void
+    ): () => void;
   };
   crashRecovery: {
     getPending(): Promise<import("./crashRecovery.js").PendingCrash | null>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1900,6 +1900,13 @@ export interface IpcEventMap {
     complete: boolean;
   };
 
+  // Plugin context-menu item registry events (main → renderer). Same `complete`
+  // flag semantics as menu items.
+  "plugin:context-menu-items-changed": {
+    items: Array<{ pluginId: string; item: import("../plugin.js").ContextMenuContribution }>;
+    complete: boolean;
+  };
+
   // Plugin file-decoration invalidation (main → renderer). Carries only the
   // changed scope (optionally narrowed to `paths`) — never decoration data.
   // The renderer re-pulls fresh decorations via `plugin:file-decorations-get`.
@@ -1991,6 +1998,8 @@ export type IpcEventBusMap = Pick<
   | "plugin:menu-items-changed"
   // Plugin keybinding registry (global broadcast)
   | "plugin:keybindings-changed"
+  // Plugin context-menu item registry (global broadcast)
+  | "plugin:context-menu-items-changed"
   // Plugin file-decoration invalidation (global broadcast)
   | "plugin:decorations-changed"
   // Plugin provenance record changed (global broadcast)

--- a/src/components/Plugin/PluginContextMenuSection.tsx
+++ b/src/components/Plugin/PluginContextMenuSection.tsx
@@ -1,0 +1,28 @@
+import { ContextMenuItem, ContextMenuSeparator } from "@/components/ui/context-menu";
+import { useMenuActionSource } from "@/components/ui/menu-source";
+import { actionService } from "@/services/ActionService";
+import type { PluginContextMenuItemEntry } from "@/hooks/usePluginContextMenuItems";
+
+/**
+ * Renders plugin-contributed context-menu items as a trailing section, preceded
+ * by a separator. Must be rendered inside a `ContextMenuContent` so
+ * `useMenuActionSource()` resolves to `"context-menu"`. Renders nothing when
+ * there are no items, so a zero-plugin menu produces no DOM diff.
+ */
+export function PluginContextMenuSection({ items }: { items: PluginContextMenuItemEntry[] }) {
+  const source = useMenuActionSource();
+  if (items.length === 0) return null;
+  return (
+    <>
+      <ContextMenuSeparator />
+      {items.map((entry) => (
+        <ContextMenuItem
+          key={`${entry.pluginId}:${entry.item.actionId}`}
+          onSelect={() => void actionService.dispatch(entry.item.actionId, undefined, { source })}
+        >
+          {entry.item.label}
+        </ContextMenuItem>
+      ))}
+    </>
+  );
+}

--- a/src/components/Plugin/__tests__/PluginContextMenuSection.test.tsx
+++ b/src/components/Plugin/__tests__/PluginContextMenuSection.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginContextMenuItemEntry } from "@/hooks/usePluginContextMenuItems";
+
+const dispatchMock = vi.fn();
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: (...args: unknown[]) => dispatchMock(...args) },
+}));
+
+// The real Radix context-menu primitives require an open portal to render
+// items; stub them with plain elements so the section's own logic (separator
+// gating, key, onSelect → dispatch) is what's under test.
+vi.mock("@/components/ui/context-menu", () => ({
+  ContextMenuItem: ({
+    children,
+    onSelect,
+  }: {
+    children: React.ReactNode;
+    onSelect: () => void;
+  }) => (
+    <button type="button" onClick={onSelect}>
+      {children}
+    </button>
+  ),
+  ContextMenuSeparator: () => <hr data-testid="separator" />,
+}));
+
+import { PluginContextMenuSection } from "../PluginContextMenuSection";
+import { MenuActionSourceContext } from "@/components/ui/menu-source";
+
+function entry(pluginId: string, label: string, actionId: string): PluginContextMenuItemEntry {
+  return { pluginId, item: { pluginId, label, actionId, location: "worktree" } as never };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PluginContextMenuSection", () => {
+  it("renders nothing when there are no items", () => {
+    const { container } = render(<PluginContextMenuSection items={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a leading separator and one item per entry", () => {
+    render(
+      <PluginContextMenuSection
+        items={[entry("acme", "Do A", "acme.a"), entry("acme", "Do B", "acme.b")]}
+      />
+    );
+    expect(screen.getByTestId("separator")).toBeTruthy();
+    expect(screen.getByText("Do A")).toBeTruthy();
+    expect(screen.getByText("Do B")).toBeTruthy();
+  });
+
+  it("dispatches the item's actionId with the source from context", () => {
+    render(
+      <MenuActionSourceContext.Provider value="context-menu">
+        <PluginContextMenuSection items={[entry("acme", "Do A", "acme.a")]} />
+      </MenuActionSourceContext.Provider>
+    );
+    fireEvent.click(screen.getByText("Do A"));
+    expect(dispatchMock).toHaveBeenCalledWith("acme.a", undefined, { source: "context-menu" });
+  });
+
+  it("falls back to source 'user' outside a context-menu provider", () => {
+    render(<PluginContextMenuSection items={[entry("acme", "Do A", "acme.a")]} />);
+    fireEvent.click(screen.getByText("Do A"));
+    expect(dispatchMock).toHaveBeenCalledWith("acme.a", undefined, { source: "user" });
+  });
+});

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -13,6 +13,8 @@ import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { isBrowserPanel, isDevPreviewPanel, isPtyPanel, isReviewPanel } from "@shared/types/panel";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { useIsHibernated } from "@/hooks/useIsHibernated";
+import { usePluginContextMenuItems } from "@/hooks/usePluginContextMenuItems";
+import type { WhenClauseContext } from "@shared/utils/whenClause";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { closeAndAnnounce } from "@/lib/accessibility";
 import { terminalHasRunningAgentSession } from "@/utils/destructiveSessionConfirm";
@@ -108,6 +110,12 @@ export function TerminalContextMenu({
   // `multiSelectGestures`.
   const fleetEligible = isFleetArmEligible(terminal);
   const sourceRef = useRef<MenuActionSourceValue>("user");
+
+  const pluginMenuContext = useMemo<WhenClauseContext>(
+    () => ({ panelId: terminalId, panelKind: terminal?.kind }),
+    [terminalId, terminal?.kind]
+  );
+  const pluginItems = usePluginContextMenuItems("terminal", pluginMenuContext);
 
   const [hasSelection, setHasSelection] = useState(false);
   const [hoveredUrl, setHoveredUrl] = useState<string | null>(null);
@@ -888,6 +896,23 @@ export function TerminalContextMenu({
             <OctagonX className={ICON_CLASS} aria-hidden="true" />
             Kill Terminal
           </ContextMenuItem>
+          {pluginItems.length > 0 && (
+            <>
+              <ContextMenuSeparator />
+              {pluginItems.map((entry) => (
+                <ContextMenuItem
+                  key={`${entry.pluginId}:${entry.item.actionId}`}
+                  onSelect={() =>
+                    void actionService.dispatch(entry.item.actionId, undefined, {
+                      source: sourceRef.current,
+                    })
+                  }
+                >
+                  {entry.item.label}
+                </ContextMenuItem>
+              ))}
+            </>
+          )}
         </ContextMenuContent>
       </ContextMenu>
     </>

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -14,6 +14,7 @@ import { isBrowserPanel, isDevPreviewPanel, isPtyPanel, isReviewPanel } from "@s
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { useIsHibernated } from "@/hooks/useIsHibernated";
 import { usePluginContextMenuItems } from "@/hooks/usePluginContextMenuItems";
+import { PluginContextMenuSection } from "@/components/Plugin/PluginContextMenuSection";
 import type { WhenClauseContext } from "@shared/utils/whenClause";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { closeAndAnnounce } from "@/lib/accessibility";
@@ -896,23 +897,7 @@ export function TerminalContextMenu({
             <OctagonX className={ICON_CLASS} aria-hidden="true" />
             Kill Terminal
           </ContextMenuItem>
-          {pluginItems.length > 0 && (
-            <>
-              <ContextMenuSeparator />
-              {pluginItems.map((entry) => (
-                <ContextMenuItem
-                  key={`${entry.pluginId}:${entry.item.actionId}`}
-                  onSelect={() =>
-                    void actionService.dispatch(entry.item.actionId, undefined, {
-                      source: sourceRef.current,
-                    })
-                  }
-                >
-                  {entry.item.label}
-                </ContextMenuItem>
-              ))}
-            </>
-          )}
+          <PluginContextMenuSection items={pluginItems} />
         </ContextMenuContent>
       </ContextMenu>
     </>

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -48,8 +48,16 @@ import { useInputReceiptKey } from "./WorktreeCard/hooks/useInputReceiptKey";
 import { useWorktreeActions } from "./WorktreeCard/hooks/useWorktreeActions";
 import { copyContextWithFeedback } from "@/hooks/useWorktreeActions";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
-import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import { CONTEXT_COMPONENTS, WorktreeMenuItems } from "./WorktreeMenuItems";
+import { usePluginContextMenuItems } from "@/hooks/usePluginContextMenuItems";
+import type { WhenClauseContext } from "@shared/utils/whenClause";
 import { isAgentFleetActionEligible, isFleetArmEligible } from "@/store/fleetArmingStore";
 import { useWorktreeStatus } from "./WorktreeCard/hooks/useWorktreeStatus";
 import { useWorktreeDevServerSession } from "@/hooks/app/useWorktreeDevServerSession";
@@ -213,6 +221,12 @@ export function WorktreeCard({
   } = useWorktreeTerminals(worktree.id);
 
   const devServerSession = useWorktreeDevServerSession(worktree.id);
+
+  const pluginMenuContext = useMemo<WhenClauseContext>(
+    () => ({ worktreeId: worktree.id }),
+    [worktree.id]
+  );
+  const pluginItems = usePluginContextMenuItems("worktree", pluginMenuContext);
 
   // Border accent flash — fires once when the dominant *execution* state for
   // this card meaningfully changes. `directing` is excluded because it's
@@ -1132,6 +1146,23 @@ export function WorktreeCard({
           onStopDevServer={handleStopDevServer}
           onRestartDevServer={handleRestartDevServer}
         />
+        {pluginItems.length > 0 && (
+          <>
+            <ContextMenuSeparator />
+            {pluginItems.map((entry) => (
+              <ContextMenuItem
+                key={`${entry.pluginId}:${entry.item.actionId}`}
+                onSelect={() =>
+                  void actionService.dispatch(entry.item.actionId, undefined, {
+                    source: "context-menu",
+                  })
+                }
+              >
+                {entry.item.label}
+              </ContextMenuItem>
+            ))}
+          </>
+        )}
       </ContextMenuContent>
     </ContextMenu>
   );

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -48,15 +48,10 @@ import { useInputReceiptKey } from "./WorktreeCard/hooks/useInputReceiptKey";
 import { useWorktreeActions } from "./WorktreeCard/hooks/useWorktreeActions";
 import { copyContextWithFeedback } from "@/hooks/useWorktreeActions";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuSeparator,
-  ContextMenuTrigger,
-} from "@/components/ui/context-menu";
+import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
 import { CONTEXT_COMPONENTS, WorktreeMenuItems } from "./WorktreeMenuItems";
 import { usePluginContextMenuItems } from "@/hooks/usePluginContextMenuItems";
+import { PluginContextMenuSection } from "@/components/Plugin/PluginContextMenuSection";
 import type { WhenClauseContext } from "@shared/utils/whenClause";
 import { isAgentFleetActionEligible, isFleetArmEligible } from "@/store/fleetArmingStore";
 import { useWorktreeStatus } from "./WorktreeCard/hooks/useWorktreeStatus";
@@ -1146,23 +1141,7 @@ export function WorktreeCard({
           onStopDevServer={handleStopDevServer}
           onRestartDevServer={handleRestartDevServer}
         />
-        {pluginItems.length > 0 && (
-          <>
-            <ContextMenuSeparator />
-            {pluginItems.map((entry) => (
-              <ContextMenuItem
-                key={`${entry.pluginId}:${entry.item.actionId}`}
-                onSelect={() =>
-                  void actionService.dispatch(entry.item.actionId, undefined, {
-                    source: "context-menu",
-                  })
-                }
-              >
-                {entry.item.label}
-              </ContextMenuItem>
-            ))}
-          </>
-        )}
+        <PluginContextMenuSection items={pluginItems} />
       </ContextMenuContent>
     </ContextMenu>
   );

--- a/src/hooks/__tests__/usePluginContextMenuItems.test.ts
+++ b/src/hooks/__tests__/usePluginContextMenuItems.test.ts
@@ -1,0 +1,219 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import type { ContextMenuContribution, ContextMenuLocation } from "@shared/types/plugin";
+import type { WhenClauseContext } from "@shared/utils/whenClause";
+
+const { contextMenuItemsMock, onContextMenuItemsChangedMock } = vi.hoisted(() => ({
+  contextMenuItemsMock: vi.fn(),
+  onContextMenuItemsChangedMock: vi.fn(),
+}));
+
+function entry(
+  pluginId: string,
+  label: string,
+  location: ContextMenuLocation,
+  extras: Partial<ContextMenuContribution> = {}
+): { pluginId: string; item: ContextMenuContribution } {
+  return {
+    pluginId,
+    item: {
+      label,
+      actionId: `${pluginId}.${label}`,
+      location,
+      ...extras,
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (globalThis as unknown as { window: unknown }).window = Object.assign(globalThis.window ?? {}, {
+    electron: {
+      plugin: {
+        contextMenuItems: contextMenuItemsMock,
+        onContextMenuItemsChanged: onContextMenuItemsChangedMock,
+      },
+    },
+  });
+  vi.resetModules();
+  contextMenuItemsMock.mockResolvedValue([]);
+  onContextMenuItemsChangedMock.mockReturnValue(() => {});
+});
+
+describe("usePluginContextMenuItems", () => {
+  it("exposes plugin items matching the requested location from the mount-time pull", async () => {
+    contextMenuItemsMock.mockResolvedValue([
+      entry("acme", "Foo", "terminal"),
+      entry("acme", "Bar", "worktree"),
+    ]);
+    const { usePluginContextMenuItems } = await import("../usePluginContextMenuItems");
+
+    const { result } = renderHook(() => usePluginContextMenuItems("terminal"));
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1);
+    });
+    expect(result.current[0]?.item.label).toBe("Foo");
+  });
+
+  it("updates entries when a push arrives", async () => {
+    let emit:
+      | ((p: {
+          items: Array<{ pluginId: string; item: ContextMenuContribution }>;
+          complete: boolean;
+        }) => void)
+      | null = null;
+    onContextMenuItemsChangedMock.mockImplementation(
+      (
+        cb: (p: {
+          items: Array<{ pluginId: string; item: ContextMenuContribution }>;
+          complete: boolean;
+        }) => void
+      ) => {
+        emit = cb;
+        return () => {};
+      }
+    );
+    const { usePluginContextMenuItems } = await import("../usePluginContextMenuItems");
+    const { result } = renderHook(() => usePluginContextMenuItems("worktree"));
+
+    await waitFor(() => expect(emit).not.toBeNull());
+    act(() => {
+      emit!({ items: [entry("acme", "WorktreeItem", "worktree")], complete: false });
+    });
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]?.item.label).toBe("WorktreeItem");
+  });
+
+  it("filters out items whose location does not match", async () => {
+    let emit:
+      | ((p: {
+          items: Array<{ pluginId: string; item: ContextMenuContribution }>;
+          complete: boolean;
+        }) => void)
+      | null = null;
+    onContextMenuItemsChangedMock.mockImplementation(
+      (
+        cb: (p: {
+          items: Array<{ pluginId: string; item: ContextMenuContribution }>;
+          complete: boolean;
+        }) => void
+      ) => {
+        emit = cb;
+        return () => {};
+      }
+    );
+    const { usePluginContextMenuItems } = await import("../usePluginContextMenuItems");
+    const { result } = renderHook(() => usePluginContextMenuItems("terminal"));
+
+    await waitFor(() => expect(emit).not.toBeNull());
+    act(() => {
+      emit!({
+        items: [
+          entry("acme", "Term", "terminal"),
+          entry("acme", "WorktreeOnly", "worktree"),
+          entry("acme", "FileOnly", "file"),
+        ],
+        complete: true,
+      });
+    });
+
+    expect(result.current.map((e) => e.item.label)).toEqual(["Term"]);
+  });
+
+  it("drops the mount-time pull if a push has already resolved (pushReceived guard)", async () => {
+    let resolvePull:
+      | ((v: Array<{ pluginId: string; item: ContextMenuContribution }>) => void)
+      | null = null;
+    contextMenuItemsMock.mockImplementation(
+      () =>
+        new Promise<Array<{ pluginId: string; item: ContextMenuContribution }>>((res) => {
+          resolvePull = res;
+        })
+    );
+    let emit:
+      | ((p: {
+          items: Array<{ pluginId: string; item: ContextMenuContribution }>;
+          complete: boolean;
+        }) => void)
+      | null = null;
+    onContextMenuItemsChangedMock.mockImplementation(
+      (
+        cb: (p: {
+          items: Array<{ pluginId: string; item: ContextMenuContribution }>;
+          complete: boolean;
+        }) => void
+      ) => {
+        emit = cb;
+        return () => {};
+      }
+    );
+    const { usePluginContextMenuItems } = await import("../usePluginContextMenuItems");
+    const { result } = renderHook(() => usePluginContextMenuItems("terminal"));
+
+    await waitFor(() => expect(emit).not.toBeNull());
+    act(() => {
+      emit!({ items: [entry("acme", "PushWins", "terminal")], complete: true });
+    });
+    act(() => {
+      resolvePull!([]);
+    });
+    await waitFor(() => {
+      expect(result.current.map((e) => e.item.label)).toEqual(["PushWins"]);
+    });
+  });
+
+  it("includes items without a when clause", async () => {
+    contextMenuItemsMock.mockResolvedValue([entry("acme", "Always", "terminal")]);
+    const { usePluginContextMenuItems } = await import("../usePluginContextMenuItems");
+    const { result } = renderHook(() => usePluginContextMenuItems("terminal"));
+
+    await waitFor(() => expect(result.current).toHaveLength(1));
+  });
+
+  it("filters when clauses around a positive control (truthy keeps, falsy/unset/malformed drop)", async () => {
+    contextMenuItemsMock.mockResolvedValue([
+      entry("acme", "Visible", "terminal", { when: "true" }),
+      entry("acme", "Hidden", "terminal", { when: "false" }),
+      entry("acme", "Unset", "terminal", { when: "missingContextKey" }),
+      entry("acme", "Malformed", "terminal", { when: "&& bad" }),
+    ]);
+    const { usePluginContextMenuItems } = await import("../usePluginContextMenuItems");
+    const { result } = renderHook(() => usePluginContextMenuItems("terminal"));
+
+    await waitFor(() => {
+      expect(result.current.map((e) => e.item.label)).toEqual(["Visible"]);
+    });
+  });
+
+  it("evaluates when clauses against the supplied context (keeps on match, drops on mismatch)", async () => {
+    contextMenuItemsMock.mockResolvedValue([
+      entry("acme", "ForFoo", "worktree", { when: "worktreeId == 'foo'" }),
+    ]);
+    const { usePluginContextMenuItems } = await import("../usePluginContextMenuItems");
+
+    const matchCtx: WhenClauseContext = { worktreeId: "foo" };
+    const { result: matched } = renderHook(() => usePluginContextMenuItems("worktree", matchCtx));
+    await waitFor(() => {
+      expect(matched.current.map((e) => e.item.label)).toEqual(["ForFoo"]);
+    });
+
+    const missCtx: WhenClauseContext = { worktreeId: "bar" };
+    const { result: missed } = renderHook(() => usePluginContextMenuItems("worktree", missCtx));
+    await waitFor(() => {
+      expect(missed.current).toHaveLength(0);
+    });
+  });
+
+  it("cleans up the push subscription on unmount", async () => {
+    const cleanupMock = vi.fn();
+    onContextMenuItemsChangedMock.mockReturnValue(cleanupMock);
+    const { usePluginContextMenuItems } = await import("../usePluginContextMenuItems");
+    const { unmount } = renderHook(() => usePluginContextMenuItems("terminal"));
+
+    unmount();
+    expect(cleanupMock).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/usePluginContextMenuItems.test.ts
+++ b/src/hooks/__tests__/usePluginContextMenuItems.test.ts
@@ -207,6 +207,25 @@ describe("usePluginContextMenuItems", () => {
     });
   });
 
+  it("re-evaluates when clauses when ctx changes without a new push", async () => {
+    contextMenuItemsMock.mockResolvedValue([
+      entry("acme", "ForB", "worktree", { when: "worktreeId == 'b'" }),
+    ]);
+    const { usePluginContextMenuItems } = await import("../usePluginContextMenuItems");
+
+    const { result, rerender } = renderHook(
+      ({ ctx }: { ctx: WhenClauseContext }) => usePluginContextMenuItems("worktree", ctx),
+      { initialProps: { ctx: { worktreeId: "a" } as WhenClauseContext } }
+    );
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(0);
+    });
+
+    rerender({ ctx: { worktreeId: "b" } });
+    expect(result.current.map((e) => e.item.label)).toEqual(["ForB"]);
+  });
+
   it("cleans up the push subscription on unmount", async () => {
     const cleanupMock = vi.fn();
     onContextMenuItemsChangedMock.mockReturnValue(cleanupMock);

--- a/src/hooks/usePluginContextMenuItems.ts
+++ b/src/hooks/usePluginContextMenuItems.ts
@@ -1,0 +1,81 @@
+import { useState, useEffect, useMemo } from "react";
+import type { ContextMenuContribution, ContextMenuLocation } from "@shared/types/plugin";
+import type { WhenClauseContext } from "@shared/utils/whenClause";
+import { parse, evaluate } from "@shared/utils/whenClause";
+import { logWarn } from "@/utils/logger";
+
+export interface PluginContextMenuItemEntry {
+  pluginId: string;
+  item: ContextMenuContribution;
+}
+
+const EMPTY_CONTEXT: WhenClauseContext = {};
+
+/**
+ * Pull plugin-contributed context-menu items on mount and keep them in sync
+ * with main's authoritative set via push. Same pull-on-mount + push-authoritative
+ * shape as `usePluginMenuItems` — see that hook for the `pushReceived` race
+ * rationale.
+ *
+ * Unlike `usePluginMenuItems`, callers pass a `ctx` map captured at menu-open
+ * time (e.g. `{ worktreeId }`, `{ panelId, panelKind }`) so `when` clauses that
+ * reference the surface's context keys evaluate correctly. An item that
+ * references unset keys evaluates to `false` and is hidden — fail-closed. Parse
+ * errors are also fail-closed.
+ *
+ * The `complete` flag on the broadcast is received but has no side effect here
+ * (no renderer-local persisted state to sweep); it is plumbed for symmetry with
+ * the broadcast contract.
+ */
+export function usePluginContextMenuItems(
+  location: ContextMenuLocation,
+  ctx?: WhenClauseContext
+): PluginContextMenuItemEntry[] {
+  const [entries, setEntries] = useState<PluginContextMenuItemEntry[]>([]);
+
+  useEffect(() => {
+    let disposed = false;
+    let pushReceived = false;
+
+    const electron = typeof window !== "undefined" ? window.electron : undefined;
+    if (!electron?.plugin) return;
+
+    void electron.plugin
+      .contextMenuItems()
+      .then((items) => {
+        if (disposed) return;
+        if (pushReceived) return;
+        setEntries(items);
+      })
+      .catch((err: unknown) => {
+        logWarn("[PluginContextMenuItems] Failed to fetch initial plugin context menu items", {
+          error: err,
+        });
+      });
+
+    const cleanup = electron.plugin.onContextMenuItemsChanged((payload) => {
+      if (disposed) return;
+      pushReceived = true;
+      setEntries(payload.items);
+    });
+
+    return () => {
+      disposed = true;
+      cleanup();
+    };
+  }, []);
+
+  return useMemo(() => {
+    const context = ctx ?? EMPTY_CONTEXT;
+    return entries.filter((entry) => {
+      if (entry.item.location !== location) return false;
+      const whenExpr = entry.item.when;
+      if (!whenExpr) return true;
+      try {
+        return evaluate(parse(whenExpr), context);
+      } catch {
+        return false;
+      }
+    });
+  }, [entries, location, ctx]);
+}


### PR DESCRIPTION
## Summary

- Wires `contributes.contextMenus` end-to-end: the registry and activation hooks already existed; this adds the broadcast infrastructure, renderer subscription hook, and injection into the terminal and worktree context menus.
- `PluginService` gets `scheduleContextMenuItemsBroadcast` / `broadcastPluginContextMenuItems` called on load, unload, and cold-start replay so LRU-restored views don't miss contributions.
- `usePluginContextMenuItems(location, ctx?)` evaluates `when` clauses at menu-open time (fail-closed on missing keys or parse errors) and cleans up its IPC listener on unmount.

Resolves #9300

## Changes

- **`PluginService`** — two new broadcast methods; wired at `loadPlugin`, `unloadPlugin`, and `pushSnapshotTo` (cold-start replay).
- **IPC** — `plugin:context-menu-items-changed` added to `IpcEventMap` / `IpcEventBusMap`; push binding + api type in `preload.cts`; `waitForInit()` guard added to `handleContextMenuItems` (was returning an empty list on fast renderer mounts).
- **`usePluginContextMenuItems`** — mirrors `usePluginMenuItems`; ctx-aware `when`-clause evaluation; IPC listener cleaned up on unmount.
- **Injection** — terminal context menu (`ctx { panelId, panelKind }`) and worktree card menu (`ctx { worktreeId }`) via a shared `PluginContextMenuSection` that derives the dispatch source from `useMenuActionSource()`. Zero DOM change when no plugins are loaded.
- **v1 scope** — panel and file locations are plumbing-only (hook supports them, no injection site yet).

## Testing

- `PluginService`: broadcast coalescing and `pushSnapshotTo` replay.
- `plugin.handlers`: `waitForInit` gate and return value.
- `usePluginContextMenuItems`: filtering, `when`-clause evaluation, ctx handling.
- `PluginContextMenuSection`: render, dispatch, source derivation.