### PR TITLE
feat(plugins): wire contributes.keybindings through KeybindingService

### DIFF
--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -59,6 +59,7 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
   "plugin:panel-kinds-changed": "external",
   "plugin:toolbar-buttons-changed": "external",
   "plugin:menu-items-changed": "external",
+  "plugin:keybindings-changed": "external",
   "plugin:decorations-changed": "external",
   "plugin:provenance-changed": "external",
   "terminal:exit": "external",

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -73,6 +73,7 @@ async function handleMenuItems() {
 }
 
 async function handleKeybindings() {
+  await pluginService.waitForInit();
   return getPluginKeybindings();
 }
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -134,7 +134,11 @@ import type {
 type SpawnResultPayload = SpawnResult;
 import type { PortalNewTabMenuAction } from "../shared/types/portal.js";
 import type { ResourceProfilePayload } from "../shared/types/resourceProfile.js";
-import type { PluginActionDescriptor, MenuItemContribution } from "../shared/types/plugin.js";
+import type {
+  PluginActionDescriptor,
+  MenuItemContribution,
+  PluginKeybindingDescriptor,
+} from "../shared/types/plugin.js";
 import type { PanelKindConfig } from "../shared/config/panelKindRegistry.js";
 import type { ToolbarButtonConfig } from "../shared/config/toolbarButtonRegistry.js";
 
@@ -2481,6 +2485,9 @@ const api: ElectronAPI = {
         complete: boolean;
       }) => void
     ) => _eventBusOn("plugin:menu-items-changed", callback),
+    onKeybindingsChanged: (
+      callback: (payload: { keybindings: PluginKeybindingDescriptor[]; complete: boolean }) => void
+    ) => _eventBusOn("plugin:keybindings-changed", callback),
     onDecorationsChanged: (callback: (payload: { scope: string; paths?: string[] }) => void) =>
       _eventBusOn("plugin:decorations-changed", callback),
   },

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -52,6 +52,14 @@ export const MenuItemContributionSchema = z.object({
 export const KeybindingContributionSchema = z.object({
   actionId: z.string().min(1),
   combo: z.string().min(1),
+  // Closed to the renderer's KeyScope union (src/services/keybindingUtils.ts).
+  // An unknown scope would never match the active scope and silently produce an
+  // inert binding, so reject it at the manifest gate instead. Defaults to
+  // "global" in the renderer hook when omitted.
+  scope: z
+    .enum(["global", "terminal", "modal", "worktreeList", "portal", "worktreeGrid"])
+    .optional(),
+  description: z.string().min(1).optional(),
   when: z.string().min(1).optional(),
 });
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -73,6 +73,7 @@ import {
 import {
   registerPluginKeybinding,
   unregisterPluginKeybindings,
+  getPluginKeybindings,
 } from "./pluginKeybindingRegistry.js";
 import {
   registerPluginContextMenuItem,
@@ -556,6 +557,8 @@ export class PluginService {
   private menuItemsBroadcastPending = false;
   /** Mirrors {@link toolbarButtonsBroadcastComplete} for menu items. */
   private menuItemsBroadcastComplete = false;
+  private keybindingsBroadcastPending = false;
+  private keybindingsBroadcastComplete = false;
   private disposed = false;
   private readonly disposeRegistrySubscriptions: () => void;
   /**
@@ -1055,6 +1058,9 @@ export class PluginService {
     for (const keybinding of manifest.contributes.keybindings) {
       trackPluginExpression(manifest.name, keybinding.when);
       registerPluginKeybinding(manifest.name, keybinding);
+    }
+    if (manifest.contributes.keybindings.length > 0) {
+      this.scheduleKeybindingsBroadcast(false);
     }
 
     for (const ctxMenu of manifest.contributes.contextMenus) {
@@ -2560,6 +2566,9 @@ export class PluginService {
     runUnloadStep(pluginId, "unregisterPluginKeybindings", () =>
       unregisterPluginKeybindings(pluginId)
     );
+    runUnloadStep(pluginId, "scheduleKeybindingsBroadcast", () =>
+      this.scheduleKeybindingsBroadcast(true)
+    );
     runUnloadStep(pluginId, "unregisterPluginContextMenuItems", () =>
       unregisterPluginContextMenuItems(pluginId)
     );
@@ -3045,6 +3054,24 @@ export class PluginService {
     });
   }
 
+  private scheduleKeybindingsBroadcast(complete: boolean): void {
+    this.keybindingsBroadcastComplete ||= complete;
+    if (this.keybindingsBroadcastPending) {
+      return;
+    }
+    this.keybindingsBroadcastPending = true;
+    queueMicrotask(() => {
+      const isComplete = this.keybindingsBroadcastComplete;
+      this.keybindingsBroadcastPending = false;
+      this.keybindingsBroadcastComplete = false;
+      if (this.disposed) return;
+      broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
+        name: "plugin:keybindings-changed",
+        payload: { keybindings: getPluginKeybindings(), complete: isComplete },
+      });
+    });
+  }
+
   /**
    * Replay the current actions / panel-kinds / toolbar-button snapshots to a
    * single target webContents. Used by the cold-start view-ready hook so a
@@ -3079,6 +3106,10 @@ export class PluginService {
       {
         name: "plugin:menu-items-changed",
         payload: { items: getPluginMenuItems(), complete: false },
+      },
+      {
+        name: "plugin:keybindings-changed",
+        payload: { keybindings: getPluginKeybindings(), complete: true },
       },
     ];
     for (const event of events) {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -6839,7 +6839,7 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
 
     await service.pushSnapshotTo(wc);
 
-    expect(send).toHaveBeenCalledTimes(4);
+    expect(send).toHaveBeenCalledTimes(5);
     // Every replay goes through the EVENTS_PUSH channel — the same channel the
     // renderer hooks' persistent push listeners consume, so no renderer-side
     // changes are needed for the cold-restore path.
@@ -6851,6 +6851,16 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
     expect(names).toContain("plugin:panel-kinds-changed");
     expect(names).toContain("plugin:toolbar-buttons-changed");
     expect(names).toContain("plugin:menu-items-changed");
+    expect(names).toContain("plugin:keybindings-changed");
+    // The keybindings replay is a full authoritative snapshot — the renderer
+    // hook full-replaces its plugin bindings on every push, so `complete: true`
+    // is consistent with that replace-all semantics.
+    const keybindingsCall = send.mock.calls.find(
+      (c) => (c[1] as { name?: string })?.name === "plugin:keybindings-changed"
+    );
+    expect((keybindingsCall?.[1] as { payload: { complete: boolean } }).payload.complete).toBe(
+      true
+    );
     // Toolbar and menu-item replays must use `complete: false` so the renderer
     // does not run a stale-prune sweep — replay is a load-style snapshot, not
     // an unload-driven authoritative sweep.
@@ -6880,11 +6890,12 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
 
     await service.pushSnapshotTo(wc);
 
-    expect(send).toHaveBeenCalledTimes(4);
+    expect(send).toHaveBeenCalledTimes(5);
     const names = send.mock.calls.map((c) => (c[1] as { name?: string })?.name);
     expect(names).toContain("plugin:panel-kinds-changed");
     expect(names).toContain("plugin:toolbar-buttons-changed");
     expect(names).toContain("plugin:menu-items-changed");
+    expect(names).toContain("plugin:keybindings-changed");
   });
 
   it("pushSnapshotTo() skips a destroyed webContents", async () => {
@@ -6912,7 +6923,7 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
 
     await service.activateStartupFinishedPlugins();
     await inFlight;
-    expect(send).toHaveBeenCalledTimes(4);
+    expect(send).toHaveBeenCalledTimes(5);
   });
 
   it("pushSnapshotTo() does not send after dispose()", async () => {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1516,6 +1516,13 @@ export interface ElectronAPI extends GeneratedElectronAPI {
         complete: boolean;
       }) => void
     ): () => void;
+    /** Subscribe to plugin keybinding registry changes. Returns a cleanup. */
+    onKeybindingsChanged(
+      callback: (payload: {
+        keybindings: import("../plugin.js").PluginKeybindingDescriptor[];
+        complete: boolean;
+      }) => void
+    ): () => void;
   };
   crashRecovery: {
     getPending(): Promise<import("./crashRecovery.js").PendingCrash | null>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1888,6 +1888,13 @@ export interface IpcEventMap {
     complete: boolean;
   };
 
+  // Plugin keybinding registry events (main → renderer). Same `complete` flag
+  // semantics as toolbar buttons and menu items.
+  "plugin:keybindings-changed": {
+    keybindings: import("../plugin.js").PluginKeybindingDescriptor[];
+    complete: boolean;
+  };
+
   // Plugin file-decoration invalidation (main → renderer). Carries only the
   // changed scope (optionally narrowed to `paths`) — never decoration data.
   // The renderer re-pulls fresh decorations via `plugin:file-decorations-get`.
@@ -1977,6 +1984,8 @@ export type IpcEventBusMap = Pick<
   | "plugin:toolbar-buttons-changed"
   // Plugin menu item registry (global broadcast)
   | "plugin:menu-items-changed"
+  // Plugin keybinding registry (global broadcast)
+  | "plugin:keybindings-changed"
   // Plugin file-decoration invalidation (global broadcast)
   | "plugin:decorations-changed"
   // Plugin provenance record changed (global broadcast)

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -67,7 +67,14 @@ export interface MenuItemContribution {
 export interface KeybindingContribution {
   actionId: string;
   combo: string;
+  scope?: string;
+  description?: string;
   when?: string;
+}
+
+export interface PluginKeybindingDescriptor {
+  pluginId: string;
+  item: KeybindingContribution;
 }
 
 export interface ContextMenuContribution {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import { useGitHubRateLimit } from "./hooks/useGitHubRateLimit";
 import { useActionRegistry } from "./hooks/useActionRegistry";
 import { usePluginActions } from "./hooks/usePluginActions";
 import { usePluginPanelKinds } from "./hooks/usePluginPanelKinds";
+import { usePluginKeybindings } from "./hooks/usePluginKeybindings";
 import { useUpdateListener } from "./hooks/useUpdateListener";
 import { useStoreUpdateListener } from "./hooks/useStoreUpdateListener";
 import { useMainProcessToastListener } from "./hooks/useMainProcessToastListener";
@@ -659,6 +660,7 @@ function AppInner() {
 
   usePluginActions();
   usePluginPanelKinds();
+  usePluginKeybindings();
 
   useMenuActions();
 

--- a/src/hooks/__tests__/usePluginKeybindings.test.ts
+++ b/src/hooks/__tests__/usePluginKeybindings.test.ts
@@ -33,7 +33,7 @@ afterEach(() => {
 
 describe("usePluginKeybindings", () => {
   it("registers plugin keybindings pulled on mount", async () => {
-    keybindingsMock.mockResolvedValue([makeEntry("p1", "p1.act", "CmdOrCtrl+k")]);
+    keybindingsMock.mockResolvedValue([makeEntry("p1", "p1.act", "Cmd+Shift+8")]);
 
     const { keybindingService } = await import("@/services/KeybindingService");
     const registerSpy = vi.spyOn(keybindingService, "registerBinding");
@@ -80,7 +80,7 @@ describe("usePluginKeybindings", () => {
     await waitFor(() => expect(emit).not.toBeNull());
     act(() => {
       emit!({
-        keybindings: [makeEntry("p2", "p2.act", "CmdOrCtrl+j")],
+        keybindings: [makeEntry("p2", "p2.act", "Cmd+Shift+9")],
         complete: false,
       });
     });
@@ -128,13 +128,13 @@ describe("usePluginKeybindings", () => {
     await waitFor(() => expect(emit).not.toBeNull());
     act(() => {
       emit!({
-        keybindings: [makeEntry("p2", "p2.act", "CmdOrCtrl+j")],
+        keybindings: [makeEntry("p2", "p2.act", "Cmd+Shift+9")],
         complete: true,
       });
     });
 
     await act(async () => {
-      resolvePull!([makeEntry("p1", "p1.act", "CmdOrCtrl+k")]);
+      resolvePull!([makeEntry("p1", "p1.act", "Cmd+Shift+8")]);
       await Promise.resolve();
     });
 
@@ -143,7 +143,7 @@ describe("usePluginKeybindings", () => {
   });
 
   it("removes plugin bindings on unmount", async () => {
-    keybindingsMock.mockResolvedValue([makeEntry("p1", "p1.act", "CmdOrCtrl+k")]);
+    keybindingsMock.mockResolvedValue([makeEntry("p1", "p1.act", "Cmd+Shift+8")]);
 
     const { keybindingService } = await import("@/services/KeybindingService");
     const registerSpy = vi.spyOn(keybindingService, "registerBinding");
@@ -166,7 +166,7 @@ describe("usePluginKeybindings", () => {
         pluginId: "p1",
         item: {
           actionId: "p1.act",
-          combo: "CmdOrCtrl+k",
+          combo: "Cmd+Shift+8",
           scope: "terminal",
           when: "terminalFocused",
           description: "Do the thing",
@@ -193,7 +193,7 @@ describe("usePluginKeybindings", () => {
   });
 
   it("defaults scope to global when the contribution omits it", async () => {
-    keybindingsMock.mockResolvedValue([makeEntry("p1", "p1.act", "CmdOrCtrl+k")]);
+    keybindingsMock.mockResolvedValue([makeEntry("p1", "p1.act", "Cmd+Shift+8")]);
 
     const { keybindingService } = await import("@/services/KeybindingService");
     const registerSpy = vi.spyOn(keybindingService, "registerBinding");
@@ -235,13 +235,65 @@ describe("usePluginKeybindings", () => {
 
     await waitFor(() => expect(emit).not.toBeNull());
     act(() => {
-      emit!({ keybindings: [makeEntry("p1", "p1.act", "CmdOrCtrl+k")], complete: true });
+      emit!({ keybindings: [makeEntry("p1", "p1.act", "Cmd+Shift+8")], complete: true });
     });
     act(() => {
       emit!({ keybindings: [], complete: true });
     });
 
     expect(removeSpy).toHaveBeenCalledWith("p1");
+  });
+
+  it("registers a binding that resolves a matching keyboard event, removed on empty push", async () => {
+    let emit:
+      | ((payload: {
+          keybindings: Array<{ pluginId: string; item: { actionId: string; combo: string } }>;
+          complete: boolean;
+        }) => void)
+      | null = null;
+    onKeybindingsChangedMock.mockImplementation(
+      (
+        cb: (payload: {
+          keybindings: Array<{ pluginId: string; item: { actionId: string; combo: string } }>;
+          complete: boolean;
+        }) => void
+      ) => {
+        emit = cb;
+        return () => {};
+      }
+    );
+
+    // Pin the platform so metaKey maps to the Cmd modifier deterministically.
+    Object.defineProperty(globalThis.navigator, "platform", {
+      value: "MacIntel",
+      configurable: true,
+    });
+
+    const { keybindingService } = await import("@/services/KeybindingService");
+
+    const { usePluginKeybindings } = await import("../usePluginKeybindings");
+    renderHook(() => usePluginKeybindings());
+
+    await waitFor(() => expect(emit).not.toBeNull());
+    act(() => {
+      emit!({ keybindings: [makeEntry("p1", "p1.act", "Cmd+Shift+8")], complete: true });
+    });
+
+    const event = {
+      key: "8",
+      code: "Digit8",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: true,
+      altKey: false,
+      getModifierState: () => false,
+    } as unknown as KeyboardEvent;
+    expect(keybindingService.findMatchingAction(event)?.actionId).toBe("p1.act");
+
+    act(() => {
+      emit!({ keybindings: [], complete: true });
+    });
+    expect(keybindingService.findMatchingAction(event)).toBeUndefined();
   });
 
   it("unsubscribes from the push channel on unmount", async () => {

--- a/src/hooks/__tests__/usePluginKeybindings.test.ts
+++ b/src/hooks/__tests__/usePluginKeybindings.test.ts
@@ -1,0 +1,257 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { KEYBINDING_PRIORITY } from "@/services/defaultKeybindings";
+
+const { keybindingsMock, onKeybindingsChangedMock } = vi.hoisted(() => ({
+  keybindingsMock: vi.fn(),
+  onKeybindingsChangedMock: vi.fn(),
+}));
+
+function makeEntry(pluginId: string, actionId: string, combo: string) {
+  return { pluginId, item: { actionId, combo } };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (globalThis as unknown as { window: unknown }).window = Object.assign(globalThis.window ?? {}, {
+    electron: {
+      plugin: {
+        keybindings: keybindingsMock,
+        onKeybindingsChanged: onKeybindingsChangedMock,
+      },
+    },
+  });
+  vi.resetModules();
+  keybindingsMock.mockResolvedValue([]);
+  onKeybindingsChangedMock.mockReturnValue(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("usePluginKeybindings", () => {
+  it("registers plugin keybindings pulled on mount", async () => {
+    keybindingsMock.mockResolvedValue([makeEntry("p1", "p1.act", "CmdOrCtrl+k")]);
+
+    const { keybindingService } = await import("@/services/KeybindingService");
+    const registerSpy = vi.spyOn(keybindingService, "registerBinding");
+
+    const { usePluginKeybindings } = await import("../usePluginKeybindings");
+    renderHook(() => usePluginKeybindings());
+
+    await waitFor(() => {
+      expect(registerSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionId: "p1.act",
+          pluginId: "p1",
+          priority: KEYBINDING_PRIORITY.PLUGIN,
+        })
+      );
+    });
+  });
+
+  it("applies push updates authoritatively", async () => {
+    let emit:
+      | ((payload: {
+          keybindings: Array<{ pluginId: string; item: { actionId: string; combo: string } }>;
+          complete: boolean;
+        }) => void)
+      | null = null;
+    onKeybindingsChangedMock.mockImplementation(
+      (
+        cb: (payload: {
+          keybindings: Array<{ pluginId: string; item: { actionId: string; combo: string } }>;
+          complete: boolean;
+        }) => void
+      ) => {
+        emit = cb;
+        return () => {};
+      }
+    );
+
+    const { keybindingService } = await import("@/services/KeybindingService");
+    const registerSpy = vi.spyOn(keybindingService, "registerBinding");
+
+    const { usePluginKeybindings } = await import("../usePluginKeybindings");
+    renderHook(() => usePluginKeybindings());
+
+    await waitFor(() => expect(emit).not.toBeNull());
+    act(() => {
+      emit!({
+        keybindings: [makeEntry("p2", "p2.act", "CmdOrCtrl+j")],
+        complete: false,
+      });
+    });
+
+    expect(registerSpy).toHaveBeenCalledWith(expect.objectContaining({ actionId: "p2.act" }));
+  });
+
+  it("ignores stale pull after push arrives", async () => {
+    let resolvePull:
+      | ((v: Array<{ pluginId: string; item: { actionId: string; combo: string } }>) => void)
+      | null = null;
+    keybindingsMock.mockImplementation(
+      () =>
+        new Promise<Array<{ pluginId: string; item: { actionId: string; combo: string } }>>(
+          (res) => {
+            resolvePull = res;
+          }
+        )
+    );
+
+    let emit:
+      | ((payload: {
+          keybindings: Array<{ pluginId: string; item: { actionId: string; combo: string } }>;
+          complete: boolean;
+        }) => void)
+      | null = null;
+    onKeybindingsChangedMock.mockImplementation(
+      (
+        cb: (payload: {
+          keybindings: Array<{ pluginId: string; item: { actionId: string; combo: string } }>;
+          complete: boolean;
+        }) => void
+      ) => {
+        emit = cb;
+        return () => {};
+      }
+    );
+
+    const { keybindingService } = await import("@/services/KeybindingService");
+    const registerSpy = vi.spyOn(keybindingService, "registerBinding");
+
+    const { usePluginKeybindings } = await import("../usePluginKeybindings");
+    renderHook(() => usePluginKeybindings());
+
+    await waitFor(() => expect(emit).not.toBeNull());
+    act(() => {
+      emit!({
+        keybindings: [makeEntry("p2", "p2.act", "CmdOrCtrl+j")],
+        complete: true,
+      });
+    });
+
+    await act(async () => {
+      resolvePull!([makeEntry("p1", "p1.act", "CmdOrCtrl+k")]);
+      await Promise.resolve();
+    });
+
+    const calls = registerSpy.mock.calls.map((c) => c[0].actionId);
+    expect(calls).not.toContain("p1.act");
+  });
+
+  it("removes plugin bindings on unmount", async () => {
+    keybindingsMock.mockResolvedValue([makeEntry("p1", "p1.act", "CmdOrCtrl+k")]);
+
+    const { keybindingService } = await import("@/services/KeybindingService");
+    const registerSpy = vi.spyOn(keybindingService, "registerBinding");
+    const removeSpy = vi.spyOn(keybindingService, "removePluginBindings");
+
+    const { usePluginKeybindings } = await import("../usePluginKeybindings");
+    const { unmount } = renderHook(() => usePluginKeybindings());
+
+    await waitFor(() => {
+      expect(registerSpy).toHaveBeenCalledWith(expect.objectContaining({ actionId: "p1.act" }));
+    });
+
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith("p1");
+  });
+
+  it("threads scope, when, and description through to registerBinding", async () => {
+    keybindingsMock.mockResolvedValue([
+      {
+        pluginId: "p1",
+        item: {
+          actionId: "p1.act",
+          combo: "CmdOrCtrl+k",
+          scope: "terminal",
+          when: "terminalFocused",
+          description: "Do the thing",
+        },
+      },
+    ]);
+
+    const { keybindingService } = await import("@/services/KeybindingService");
+    const registerSpy = vi.spyOn(keybindingService, "registerBinding");
+
+    const { usePluginKeybindings } = await import("../usePluginKeybindings");
+    renderHook(() => usePluginKeybindings());
+
+    await waitFor(() => {
+      expect(registerSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionId: "p1.act",
+          scope: "terminal",
+          when: "terminalFocused",
+          description: "Do the thing",
+        })
+      );
+    });
+  });
+
+  it("defaults scope to global when the contribution omits it", async () => {
+    keybindingsMock.mockResolvedValue([makeEntry("p1", "p1.act", "CmdOrCtrl+k")]);
+
+    const { keybindingService } = await import("@/services/KeybindingService");
+    const registerSpy = vi.spyOn(keybindingService, "registerBinding");
+
+    const { usePluginKeybindings } = await import("../usePluginKeybindings");
+    renderHook(() => usePluginKeybindings());
+
+    await waitFor(() => {
+      expect(registerSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ actionId: "p1.act", scope: "global" })
+      );
+    });
+  });
+
+  it("removes prior registrations when an authoritative empty push arrives", async () => {
+    let emit:
+      | ((payload: {
+          keybindings: Array<{ pluginId: string; item: { actionId: string; combo: string } }>;
+          complete: boolean;
+        }) => void)
+      | null = null;
+    onKeybindingsChangedMock.mockImplementation(
+      (
+        cb: (payload: {
+          keybindings: Array<{ pluginId: string; item: { actionId: string; combo: string } }>;
+          complete: boolean;
+        }) => void
+      ) => {
+        emit = cb;
+        return () => {};
+      }
+    );
+
+    const { keybindingService } = await import("@/services/KeybindingService");
+    const removeSpy = vi.spyOn(keybindingService, "removePluginBindings");
+
+    const { usePluginKeybindings } = await import("../usePluginKeybindings");
+    renderHook(() => usePluginKeybindings());
+
+    await waitFor(() => expect(emit).not.toBeNull());
+    act(() => {
+      emit!({ keybindings: [makeEntry("p1", "p1.act", "CmdOrCtrl+k")], complete: true });
+    });
+    act(() => {
+      emit!({ keybindings: [], complete: true });
+    });
+
+    expect(removeSpy).toHaveBeenCalledWith("p1");
+  });
+
+  it("unsubscribes from the push channel on unmount", async () => {
+    const unsubscribe = vi.fn();
+    onKeybindingsChangedMock.mockReturnValue(unsubscribe);
+
+    const { usePluginKeybindings } = await import("../usePluginKeybindings");
+    const { unmount } = renderHook(() => usePluginKeybindings());
+
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/usePluginKeybindings.ts
+++ b/src/hooks/usePluginKeybindings.ts
@@ -1,0 +1,81 @@
+import { useEffect } from "react";
+import { keybindingService } from "@/services/KeybindingService";
+import { KEYBINDING_PRIORITY } from "@/services/defaultKeybindings";
+import type { KeyScope } from "@/services/keybindingUtils";
+import type { PluginKeybindingDescriptor } from "@shared/types/plugin";
+
+/**
+ * Registers plugin-contributed keybindings into the KeybindingService.
+ *
+ * Pattern: pull-on-mount + push-authoritative (mirrors usePluginMenuItems).
+ *
+ * - On mount, pulls current plugin keybindings via `plugin.keybindings()`.
+ * - Subscribes to `onKeybindingsChanged` for authoritative push updates.
+ * - The push handler replaces the registered set; the pull only applies if no
+ *   push has arrived yet (avoids clobbering a fresher push with a stale pull).
+ *
+ * Plugin bindings are registered at the PLUGIN priority tier (above built-in
+ * defaults, below elevated built-ins and user overrides) and tagged with their
+ * owning `pluginId` so unload can remove only that plugin's bindings without
+ * disturbing built-in defaults that share an actionId.
+ */
+export function usePluginKeybindings(): void {
+  useEffect(() => {
+    let disposed = false;
+    let pushReceived = false;
+    const registeredPluginIds = new Set<string>();
+
+    const electron = window.electron;
+    if (!electron?.plugin) {
+      return;
+    }
+
+    const apply = (entries: PluginKeybindingDescriptor[]) => {
+      for (const pluginId of registeredPluginIds) {
+        keybindingService.removePluginBindings(pluginId);
+      }
+      registeredPluginIds.clear();
+      for (const { pluginId, item } of entries) {
+        keybindingService.registerBinding({
+          actionId: item.actionId,
+          combo: item.combo,
+          scope: (item.scope as KeyScope | undefined) ?? "global",
+          priority: KEYBINDING_PRIORITY.PLUGIN,
+          when: item.when,
+          description: item.description,
+          pluginId,
+        });
+        registeredPluginIds.add(pluginId);
+      }
+    };
+
+    electron.plugin
+      .keybindings()
+      .then((entries) => {
+        if (disposed || pushReceived) {
+          return;
+        }
+        apply(entries ?? []);
+      })
+      .catch(() => {
+        // Ignore pull errors; push will populate when available.
+      });
+
+    const unsubscribe = electron.plugin.onKeybindingsChanged?.((payload) => {
+      pushReceived = true;
+      if (disposed) {
+        return;
+      }
+      apply(payload?.keybindings ?? []);
+    });
+
+    return () => {
+      disposed = true;
+      unsubscribe?.();
+      for (const pluginId of registeredPluginIds) {
+        keybindingService.removePluginBindings(pluginId);
+      }
+      registeredPluginIds.clear();
+    };
+  }, []);
+}

--- a/src/services/KeybindingService.ts
+++ b/src/services/KeybindingService.ts
@@ -487,8 +487,14 @@ class KeybindingService {
       for (const arr of this.bindings.values()) {
         for (const existing of arr) {
           if (existing.actionId === config.actionId) continue;
-          if (!existing.combo) continue;
-          if (!combosFieldsEqual(existing.combo, config.combo)) continue;
+          // Compare against the EFFECTIVE combo — a user override remaps where a
+          // built-in actually fires, so a plugin binding at the overridden combo
+          // would otherwise slip past this guard and then win at resolution
+          // (PLUGIN priority > DEFAULT). Fall back to the stored combo when no
+          // override exists.
+          const effectiveCombo = this.getEffectiveCombo(existing.actionId) ?? existing.combo;
+          if (!effectiveCombo) continue;
+          if (!combosFieldsEqual(effectiveCombo, config.combo)) continue;
           if (!scopesConflict(existing.scope, config.scope)) continue;
           console.warn(
             `[KeybindingService] Skipping binding for "${config.actionId}" (${config.combo}, scope=${config.scope}) — combo already registered to "${existing.actionId}" (scope=${existing.scope}). Use setOverride() to rebind.`
@@ -499,11 +505,16 @@ class KeybindingService {
     }
     const arr = this.bindings.get(config.actionId);
     if (arr) {
-      // Replace a same-actionId entry with the same combo (self-update), otherwise push.
+      // Replace only on a true self-update: the existing same-combo entry must
+      // share this config's owner (both built-in/user with no pluginId, or the
+      // same pluginId). Replacing a differently-owned entry would let a plugin
+      // clobber a built-in binding for the same action+combo — and destroy it on
+      // unload, since removePluginBindings() filters by pluginId. Push instead so
+      // both coexist; resolution picks by priority and unload only drops the plugin's.
       const existingIdx = arr.findIndex(
         (b) => b.combo?.trim().toLowerCase() === config.combo?.trim().toLowerCase()
       );
-      if (existingIdx !== -1) {
+      if (existingIdx !== -1 && arr[existingIdx]!.pluginId === config.pluginId) {
         arr[existingIdx] = config;
       } else {
         arr.push(config);

--- a/src/services/KeybindingService.ts
+++ b/src/services/KeybindingService.ts
@@ -511,6 +511,28 @@ class KeybindingService {
     } else {
       this.bindings.set(config.actionId, [config]);
     }
+    // Dynamic registrations (plugin load) must flush to subscribers — the
+    // shortcuts reference, settings tab, and hint hovers read from this snapshot.
+    this.notifyListeners();
+  }
+
+  removePluginBindings(pluginId: string): void {
+    let changed = false;
+    for (const [actionId, bindings] of this.bindings.entries()) {
+      const filtered = bindings.filter((b) => b.pluginId !== pluginId);
+      if (filtered.length === bindings.length) {
+        continue;
+      }
+      changed = true;
+      if (filtered.length === 0) {
+        this.bindings.delete(actionId);
+      } else {
+        this.bindings.set(actionId, filtered);
+      }
+    }
+    if (changed) {
+      this.notifyListeners();
+    }
   }
 
   removeBinding(actionId: string): void {

--- a/src/services/__tests__/KeybindingService.test.ts
+++ b/src/services/__tests__/KeybindingService.test.ts
@@ -1818,4 +1818,49 @@ describe("KeybindingService", () => {
       expect(match).toBeUndefined();
     });
   });
+
+  describe("dynamic plugin binding listener notification", () => {
+    it("notifies subscribers when registerBinding adds a binding", () => {
+      const service = new KeybindingService();
+      const listener = vi.fn();
+      service.subscribe(listener);
+
+      service.registerBinding({
+        actionId: "p1.act",
+        combo: "Cmd+Shift+8",
+        scope: "global",
+        priority: 1,
+        pluginId: "p1",
+      });
+
+      expect(listener).toHaveBeenCalled();
+    });
+
+    it("notifies subscribers when removePluginBindings removes a binding", () => {
+      const service = new KeybindingService();
+      service.registerBinding({
+        actionId: "p1.act",
+        combo: "Cmd+Shift+8",
+        scope: "global",
+        priority: 1,
+        pluginId: "p1",
+      });
+
+      const listener = vi.fn();
+      service.subscribe(listener);
+      service.removePluginBindings("p1");
+
+      expect(listener).toHaveBeenCalled();
+    });
+
+    it("does not notify when removePluginBindings matches nothing", () => {
+      const service = new KeybindingService();
+      const listener = vi.fn();
+      service.subscribe(listener);
+
+      service.removePluginBindings("nonexistent");
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/services/__tests__/KeybindingService.test.ts
+++ b/src/services/__tests__/KeybindingService.test.ts
@@ -1862,5 +1862,65 @@ describe("KeybindingService", () => {
 
       expect(listener).not.toHaveBeenCalled();
     });
+
+    it("does not clobber a built-in when a plugin binds the same action and combo", () => {
+      const service = new KeybindingService();
+      const builtIn = service
+        .getAllBindings()
+        .find((b) => b.actionId === "terminal.close" && !b.pluginId);
+      expect(builtIn).toBeDefined();
+
+      // Plugin contributes the same actionId + combo as the built-in.
+      service.registerBinding({
+        actionId: builtIn!.actionId,
+        combo: builtIn!.combo!,
+        scope: builtIn!.scope,
+        priority: 1,
+        pluginId: "p1",
+      });
+
+      service.removePluginBindings("p1");
+
+      // The original built-in must survive the plugin's load/unload cycle.
+      const after = service
+        .getAllBindings()
+        .filter((b) => b.actionId === "terminal.close" && !b.pluginId);
+      expect(after).toHaveLength(1);
+      expect(after[0]!.combo).toBe(builtIn!.combo);
+    });
+
+    it("rejects a plugin binding that collides with a user-overridden combo", async () => {
+      const prevWindow = (globalThis as { window?: unknown }).window;
+      (globalThis as { window?: unknown }).window = {
+        electron: { keybinding: { setOverride: vi.fn().mockResolvedValue(undefined) } },
+      };
+      try {
+        const service = new KeybindingService();
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        // User remaps a built-in to Cmd+Shift+8 (its stored combo is something else).
+        await service.setOverride("nav.quickSwitcher", ["Cmd+Shift+8"]);
+
+        const before = service.getAllBindings().length;
+        service.registerBinding({
+          actionId: "plugin.act",
+          combo: "Cmd+Shift+8",
+          scope: "global",
+          priority: 1,
+          pluginId: "p1",
+        });
+
+        // The plugin binding must be rejected — the effective (overridden) combo is taken.
+        expect(service.getAllBindings().length).toBe(before);
+        expect(warnSpy).toHaveBeenCalled();
+        warnSpy.mockRestore();
+      } finally {
+        if (prevWindow === undefined) {
+          delete (globalThis as { window?: unknown }).window;
+        } else {
+          (globalThis as { window?: unknown }).window = prevWindow;
+        }
+      }
+    });
   });
 });

--- a/src/services/defaultKeybindings.ts
+++ b/src/services/defaultKeybindings.ts
@@ -1131,3 +1131,10 @@ export const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
   ...CORE_KEYBINDINGS,
   ...WINDOWS_KEYBINDINGS,
 ];
+
+export const KEYBINDING_PRIORITY = {
+  DEFAULT: 0,
+  PLUGIN: 1,
+  ELEVATED: 5,
+  OVERRIDE: 10,
+} as const;

--- a/src/services/keybindingUtils.ts
+++ b/src/services/keybindingUtils.ts
@@ -17,6 +17,7 @@ export interface KeybindingConfig {
 export type RegisteredKeybindingConfig = Omit<KeybindingConfig, "actionId"> & {
   actionId: ActionId;
   when?: string;
+  pluginId?: string;
 };
 
 // "conflict": same combo as an existing binding in an overlapping scope.


### PR DESCRIPTION
Wires the `contributes.keybindings` field in plugin manifests end-to-end through to the renderer `KeybindingService`. The field was documented but inert.

Resolves #9299.

## Changes

**PluginService (main)**
- Walks manifest keybindings on plugin load/unload, registering/removing them in `pluginKeybindingRegistry`
- Broadcasts a `plugin:keybindings-changed` IPC event coalesced on a microtask — multiple plugins loading together produce one broadcast
- `pushSnapshotTo` now replays the full keybindings snapshot to newly restored views for cold-start correctness
- Load broadcast is guarded on `length > 0`, matching the toolbar/menu pattern

**Renderer**
- New `usePluginKeybindings` hook (pull-on-mount + push-authoritative, mirrors `usePluginMenuItems`) — mounted in `App.tsx`
- Registers plugin bindings into `KeybindingService` at the `PLUGIN` priority tier, tagged by `pluginId`, and removes them by `pluginId` on unmount/unload
- Supports chord combos, `when` clauses (consumed by the #9273 when-evaluator at resolution time), and `description`
- Scope is closed to the `KeyScope` enum in the manifest schema (`global`/`terminal`/`modal`/`worktreeList`/`portal`/`worktreeGrid`)

**KeybindingService**
- `registerBinding` and `removePluginBindings` now notify subscribers so shortcut-reference, settings tab, and hint UIs update on plugin load/unload

**Hardening**
- A plugin cannot overwrite a built-in binding for the same action+combo — the built-in survives unload
- Conflict detection compares effective (user-override-aware) combos, so a plugin can't register at an overridden combo and win at resolution

## Testing

522 passing. New tests in `usePluginKeybindings.test.ts` (pull, push, stale-pull suppression, unmount cleanup, scope/description threading, default-global, empty-push removal, unsubscribe, e2e resolution), `KeybindingService.test.ts` (listener notification x3, built-in-survival regression, override-conflict), and `PluginService.test.ts` (`pushSnapshotTo` counts 4→5, `keybindings-changed` payload assertions). `npm run check` clean.