### PR TITLE
Replace blind 2s commit timer with client-side VAD (#9177)

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -68,6 +68,13 @@ module.exports = async function () {
       "node_modules/better-sqlite3/**/*",
       "node_modules/win-job-object/**/*",
       "node_modules/posix-pty-reaper/**/*",
+      // onnxruntime-node ships per-platform native binaries (.node/.dll/.dylib/
+      // .so) for the Silero VAD side-chain (#9177) — they require real
+      // filesystem access for the N-API load and cannot live inside the ASAR.
+      "node_modules/onnxruntime-node/**/*",
+      // avr-vad reads its bundled silero_vad_v5.onnx via `fs` relative to its
+      // own dist dir; unpack so that path resolves outside the ASAR too.
+      "node_modules/avr-vad/**/*",
     ],
     electronFuses: {
       runAsNode: false,
@@ -84,7 +91,7 @@ module.exports = async function () {
     mac: {
       extraResources: [{ from: "scripts/daintree-cli.sh", to: "daintree-cli.sh" }],
       x64ArchFiles:
-        "Contents/Resources/app.asar.unpacked/node_modules/{node-pty/build/Release/**,better-sqlite3/build/Release/**,win-job-object/bin/**,posix-pty-reaper/build/Release/**,@parcel/watcher-darwin-*/watcher.node,@parcel/watcher/bin/darwin-*/watcher.node}",
+        "Contents/Resources/app.asar.unpacked/node_modules/{node-pty/build/Release/**,better-sqlite3/build/Release/**,win-job-object/bin/**,posix-pty-reaper/build/Release/**,onnxruntime-node/bin/**,@parcel/watcher-darwin-*/watcher.node,@parcel/watcher/bin/darwin-*/watcher.node}",
       forceCodeSigning: true,
       notarize: false,
       binaries: [

--- a/electron/services/__tests__/VoiceTranscriptionService.test.ts
+++ b/electron/services/__tests__/VoiceTranscriptionService.test.ts
@@ -105,6 +105,69 @@ vi.mock("ws", () => {
   return { default: ctor };
 });
 
+// ── Mock the VAD worker (`node:worker_threads`) ──────────────────────────────
+//
+// The OpenAI provider spawns a Silero VAD worker. Replace it with a stub so the
+// coordinator tests can drive speech-end events synchronously instead of
+// loading ONNX or spawning a real thread.
+
+type VadListener = (...args: unknown[]) => void;
+
+class MockVadWorker {
+  terminateCalls = 0;
+  private listeners: Map<string, Set<VadListener>> = new Map();
+
+  constructor(_path: string | URL) {
+    vadWorkers.push(this);
+  }
+
+  on(event: string, listener: VadListener): this {
+    if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+    this.listeners.get(event)!.add(listener);
+    return this;
+  }
+
+  removeAllListeners(event?: string): this {
+    if (event) this.listeners.delete(event);
+    else this.listeners.clear();
+    return this;
+  }
+
+  postMessage(): void {}
+
+  terminate(): Promise<number> {
+    this.terminateCalls++;
+    return Promise.resolve(0);
+  }
+
+  private fire(event: string, ...args: unknown[]): void {
+    const set = this.listeners.get(event);
+    if (!set) return;
+    for (const listener of set) listener(...args);
+  }
+
+  emitSpeechStart(): void {
+    this.fire("message", { type: "speech-start" });
+  }
+  emitSpeechEnd(): void {
+    this.fire("message", { type: "speech-end" });
+  }
+}
+
+const vadWorkers: MockVadWorker[] = [];
+
+vi.mock("node:worker_threads", () => ({
+  Worker: function (this: unknown, scriptPath: string | URL) {
+    return new MockVadWorker(scriptPath);
+  } as unknown as new (scriptPath: string | URL) => MockVadWorker,
+}));
+
+function latestVadWorker(): MockVadWorker {
+  const worker = vadWorkers.at(-1);
+  if (!worker) throw new Error("No MockVadWorker instance created");
+  return worker;
+}
+
 // Import AFTER vi.mock so the providers use the mocked `ws`.
 const { VoiceTranscriptionService } = await import("../VoiceTranscriptionService.js");
 type VoiceTranscriptionServiceInstance = InstanceType<typeof VoiceTranscriptionService>;
@@ -168,6 +231,7 @@ async function bringDeepgramReady(
 describe("VoiceTranscriptionService (coordinator)", () => {
   beforeEach(() => {
     instances.length = 0;
+    vadWorkers.length = 0;
     vi.useFakeTimers();
   });
 
@@ -229,16 +293,21 @@ describe("VoiceTranscriptionService (coordinator)", () => {
 
   // ── Server-VAD-driven segmentation difference ─────────────────────────────
 
-  it("runs the client commit timer for OpenAI but not for Deepgram", async () => {
+  it("commits on client VAD speech-end for OpenAI but not for Deepgram", async () => {
     const openai = new VoiceTranscriptionService();
     const openaiSocket = await bringOpenAiReady(openai);
+    const worker = latestVadWorker();
     openai.sendAudioChunk(new Uint8Array(5_000).buffer);
-    vi.advanceTimersByTime(2_000);
+    // The client-side VAD drives the commit at end-of-speech.
+    worker.emitSpeechStart();
+    worker.emitSpeechEnd();
     expect(
       openaiSocket.textFrames().filter((f) => f.type === "input_audio_buffer.commit")
     ).toHaveLength(1);
     openai.stop();
 
+    // Deepgram has server-side VAD — no client worker is spawned and no client
+    // commit is ever sent.
     const deepgram = new VoiceTranscriptionService();
     const deepgramSocket = await bringDeepgramReady(deepgram);
     deepgram.sendAudioChunk(new Uint8Array(5_000).buffer);

--- a/electron/services/voice/OpenAITranscriptionProvider.ts
+++ b/electron/services/voice/OpenAITranscriptionProvider.ts
@@ -189,6 +189,12 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
   private vadWorker: Worker | null = null;
   private vadWorkerSessionId = 0;
   private isSpeaking = false;
+  // True once the VAD has reported at least one speech-end this connection. The
+  // barge-in clear on speech-start is gated on it: audio buffered after a
+  // speech-end is confirmed silence and safe to drop, but audio buffered before
+  // the first speech-end (e.g. captured before the worker finished loading) may
+  // be real speech, so the first speech-start must not clear it.
+  private vadHasEndedSpeech = false;
   // Set when the worker fails to initialize or crashes. In this mode the VAD
   // can't segment, so we fall back to a periodic backstop commit (no speech
   // gating) — dictation still works, just without speech-aware boundaries.
@@ -1042,6 +1048,7 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
   private startVadWorker(mySessionId: number): void {
     this.stopVadWorker();
     this.isSpeaking = false;
+    this.vadHasEndedSpeech = false;
     this.vadDegraded = false;
     this.preRollChunks = [];
     this.preRollBytes = 0;
@@ -1142,29 +1149,39 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
   private handleVadSpeechStart(): void {
     if (this.isSpeaking) return;
     this.isSpeaking = true;
-    logDebug(`${P} VAD speech-start`, { preRollBytes: this.preRollBytes });
-    // Barge-in: drop whatever silence accumulated in the server buffer since the
-    // last commit so it isn't transcribed, then replay our short pre-roll so the
-    // onset of this utterance — already streamed before the clear — survives.
-    if (this.connection && this.isReady && !this.isDraining) {
-      try {
-        this.connection.send(JSON.stringify({ type: "input_audio_buffer.clear" }));
-        this.bytesSinceCommit = 0;
-      } catch (err) {
-        logWarn(`${P} Failed to clear buffer on speech-start`, {
-          message: formatErrorMessage(err, "clear failed"),
-        });
-      }
-      for (const chunk of this.preRollChunks) {
-        this.sendAudioJson(chunk);
-      }
-    }
     this.startBackstopTimer("vad-speech");
+    logDebug(`${P} VAD speech-start`, { preRollBytes: this.preRollBytes });
+
+    // Barge-in clear: drop the silence the server buffered between the last
+    // commit and now so it isn't transcribed, then replay our short pre-roll so
+    // the onset of this utterance — already streamed before the clear —
+    // survives. Only safe AFTER a speech-end: the audio buffered since a
+    // speech-end commit is VAD-confirmed silence. The first speech-start of a
+    // (re)connection has no such guarantee — audio streamed before the worker
+    // was ready could be real speech — so we leave the buffer intact.
+    if (!this.vadHasEndedSpeech || !this.connection || !this.isReady || this.isDraining) {
+      return;
+    }
+    try {
+      this.connection.send(JSON.stringify({ type: "input_audio_buffer.clear" }));
+    } catch (err) {
+      logWarn(`${P} Failed to clear buffer on speech-start`, {
+        message: formatErrorMessage(err, "clear failed"),
+      });
+      // The server buffer was NOT cleared — replaying the pre-roll would
+      // duplicate those bytes. Bail; the socket is likely dropping anyway.
+      return;
+    }
+    this.bytesSinceCommit = 0;
+    for (const chunk of this.preRollChunks) {
+      this.sendAudioJson(chunk);
+    }
   }
 
   private handleVadSpeechEnd(): void {
     if (!this.isSpeaking) return;
     this.isSpeaking = false;
+    this.vadHasEndedSpeech = true;
     this.clearBackstopTimer();
     logDebug(`${P} VAD speech-end — committing segment`);
     this.maybeCommitSegment("vad-end-of-speech");

--- a/electron/services/voice/OpenAITranscriptionProvider.ts
+++ b/electron/services/voice/OpenAITranscriptionProvider.ts
@@ -1,3 +1,6 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Worker } from "node:worker_threads";
 import WebSocket from "ws";
 import type { VoiceInputError, VoiceInputSettings } from "../../../shared/types/ipc/api.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
@@ -9,8 +12,24 @@ import {
   type VoiceStartResult,
   type VoiceTranscriptionEvent,
 } from "./TranscriptionProvider.js";
+import type { VadWorkerInbound, VadWorkerOutbound } from "./openaiVadWorkerProtocol.js";
 
 const P = "[VoiceTranscription:openai]";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Resolves the compiled VAD worker on disk. esbuild emits this provider into a
+ * shared chunk under `dist-electron/electron/chunks/`, so `__dirname` may point
+ * at that chunks dir — step up to the electron root, then to the worker's own
+ * output path. Mirrors the host-process path resolution in
+ * `WorkspaceHostProcess.ts`.
+ */
+function resolveVadWorkerPath(): string {
+  const electronDir = path.basename(__dirname) === "chunks" ? path.dirname(__dirname) : __dirname;
+  // From `dist-electron/electron/` down to the worker's bundled location.
+  return path.join(electronDir, "services", "voice", "openaiVadWorker.js");
+}
 
 // `gpt-realtime-whisper` is a transcription model — it must be passed as
 // `transcription.model`, NOT as the realtime session `model` query param.
@@ -44,10 +63,21 @@ const RECONNECT_MULTIPLIER = 1.5;
 const RECONNECT_CAP_MS = 3_000;
 // `gpt-realtime-whisper` does not support server VAD (`turn_detection` must be
 // null), so the server never auto-commits the input buffer. We drive
-// segmentation ourselves: commit the buffer on a fixed cadence so the model
-// transcribes each segment and streams delta/completed events back while the
-// user is still speaking. Without this, no transcription arrives until stop.
-const COMMIT_INTERVAL_MS = 2_000;
+// segmentation ourselves with a client-side VAD side-chain (Silero v5, on a
+// worker thread): commit at actual end-of-speech after a short holdover, and
+// clear the server buffer on speech onset so accumulated silence between
+// utterances isn't transcribed. This replaces the old blind 2s interval, which
+// cut words mid-pause and added up to ~2s of latency at end-of-speech.
+//
+// Backstop: while speech runs continuously past this window with no detected
+// pause, force a commit so the segment streams back and the server-side buffer
+// stays bounded. Also the sole commit cadence in degraded mode (VAD init/worker
+// failure), where we can't detect speech boundaries at all.
+const VAD_MAX_SEGMENT_MS = 8_000;
+// Recent audio retained to replay after an `input_audio_buffer.clear` on speech
+// onset, so clearing the stale (silent) buffer doesn't also clip the start of
+// the utterance the VAD just detected. ~300ms at 24kHz mono PCM16 (48 B/ms).
+const VAD_PRE_ROLL_BYTES = 14_400;
 // OpenAI rejects an `input_audio_buffer.commit` carrying under ~100ms of audio
 // (24kHz mono PCM16 → 4800 bytes) with a fatal error event. Skip a commit
 // below this threshold.
@@ -152,7 +182,25 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
   private drainPromise: Promise<void> | null = null;
   private isDraining = false;
 
-  private commitTimer: ReturnType<typeof setInterval> | null = null;
+  // VAD side-chain. The worker runs Silero v5 on a worker thread and reports
+  // speech-start/speech-end events that drive commits. `vadWorkerSessionId`
+  // tags the spawning session so a message arriving after teardown (or after a
+  // new session started) is ignored — the stale-callback guard from #4850/#4851.
+  private vadWorker: Worker | null = null;
+  private vadWorkerSessionId = 0;
+  private isSpeaking = false;
+  // Set when the worker fails to initialize or crashes. In this mode the VAD
+  // can't segment, so we fall back to a periodic backstop commit (no speech
+  // gating) — dictation still works, just without speech-aware boundaries.
+  private vadDegraded = false;
+  // Backstop commit timer. While speaking (or always, in degraded mode) it
+  // forces a commit every VAD_MAX_SEGMENT_MS so long utterances stream back and
+  // the server buffer stays bounded.
+  private maxSegmentTimer: ReturnType<typeof setInterval> | null = null;
+  // Sliding window of the most recent audio chunks, replayed after a
+  // speech-onset `input_audio_buffer.clear` so the utterance's onset survives.
+  private preRollChunks: ArrayBuffer[] = [];
+  private preRollBytes = 0;
   private bytesSinceCommit = 0;
   // Commits sent (interval, paragraph-boundary, or final) whose
   // `conversation.item.done` we haven't seen yet. Each commit yields exactly
@@ -637,7 +685,7 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
         this.isReconnecting = false;
         this.lastReconnectError = null;
         this.isReady = true;
-        this.startCommitTimer();
+        this.startVadWorker(mySessionId);
         this.emit({ type: "status", status: "recording" });
         this.settlePendingStart(mySessionId, { ok: true });
         return;
@@ -845,7 +893,42 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
         bytesSinceCommit: this.bytesSinceCommit + chunk.byteLength,
       });
     }
+    // Feed the VAD side-chain so it can detect speech boundaries, and keep a
+    // short pre-roll for onset replay after a speech-start clear. Audio streams
+    // to OpenAI continuously regardless of speech state — the VAD only governs
+    // when we commit and when we clear, so a VAD that under-detects can never
+    // strand audio: the backstop and final commit still flush it.
+    this.feedVad(chunk);
+    this.pushPreRoll(chunk);
     this.sendAudioJson(chunk);
+  }
+
+  /**
+   * Posts a chunk to the VAD worker. The chunk is copied (not transferred) so
+   * the original ArrayBuffer stays usable for the OpenAI send on this thread.
+   */
+  private feedVad(chunk: ArrayBuffer): void {
+    if (!this.vadWorker || this.vadDegraded) return;
+    // Copy (not transfer) the original chunk — it's still needed for the OpenAI
+    // send on this thread. The copy is transferred so the worker owns it.
+    const copy = chunk.slice(0);
+    try {
+      this.vadWorker.postMessage({ type: "audio", pcm: copy } satisfies VadWorkerInbound, [copy]);
+    } catch (err) {
+      logWarn(`${P} Failed to post audio to VAD worker`, {
+        message: formatErrorMessage(err, "vad post failed"),
+      });
+    }
+  }
+
+  /** Maintains the sliding pre-roll window, evicting oldest chunks by byte cap. */
+  private pushPreRoll(chunk: ArrayBuffer): void {
+    this.preRollChunks.push(chunk);
+    this.preRollBytes += chunk.byteLength;
+    while (this.preRollBytes > VAD_PRE_ROLL_BYTES && this.preRollChunks.length > 1) {
+      const evicted = this.preRollChunks.shift();
+      if (evicted) this.preRollBytes -= evicted.byteLength;
+    }
   }
 
   /**
@@ -881,7 +964,10 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
    * reconnect. Use `cleanupPreviousSession()` for a full session reset.
    */
   private cleanupConnection(): void {
-    this.clearCommitTimer();
+    // Terminate the VAD worker with the connection — a reconnect re-spawns it
+    // fresh on the next `session.updated`, so VAD state never straddles two
+    // physical sockets.
+    this.stopVadWorker();
     this.clearHeartbeat();
     this.connection = null;
     this.isReady = false;
@@ -909,7 +995,8 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
     this.preConnectBufferBytes = 0;
     this.clearConnectTimeout();
     this.clearDrainTimeout();
-    this.clearCommitTimer();
+    this.stopVadWorker();
+    this.vadDegraded = false;
     this.clearHeartbeat();
     this.clearReconnectTimer();
     this.reconnectAttempt = 0;
@@ -944,18 +1031,156 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
     }
   }
 
-  private startCommitTimer(): void {
-    this.clearCommitTimer();
-    logDebug(`${P} Starting interval commit timer`, { intervalMs: COMMIT_INTERVAL_MS });
-    this.commitTimer = setInterval(() => {
-      this.maybeCommitSegment("interval");
-    }, COMMIT_INTERVAL_MS);
+  /**
+   * Spawns the VAD side-chain worker for the current session. Speech-boundary
+   * events it reports drive `input_audio_buffer.commit`/`clear`. Every message
+   * is guarded by `mySessionId` so a message arriving after this session was
+   * torn down (or superseded by a new `start()`) is ignored (#4850/#4851). If
+   * the worker can't be spawned or its model fails to load, we fall back to a
+   * periodic backstop commit (degraded mode) so dictation still works.
+   */
+  private startVadWorker(mySessionId: number): void {
+    this.stopVadWorker();
+    this.isSpeaking = false;
+    this.vadDegraded = false;
+    this.preRollChunks = [];
+    this.preRollBytes = 0;
+
+    let worker: Worker;
+    try {
+      worker = new Worker(resolveVadWorkerPath());
+    } catch (err) {
+      logError(`${P} Failed to spawn VAD worker — degraded mode`, {
+        message: formatErrorMessage(err, "worker spawn failed"),
+      });
+      this.enterDegradedMode(mySessionId);
+      return;
+    }
+    this.vadWorker = worker;
+    this.vadWorkerSessionId = mySessionId;
+    logDebug(`${P} VAD worker spawned`, { sessionId: mySessionId });
+
+    worker.on("message", (message: VadWorkerOutbound) => {
+      if (this.sessionId !== mySessionId || this.vadWorker !== worker) return;
+      switch (message.type) {
+        case "ready":
+          logInfo(`${P} VAD worker ready`);
+          return;
+        case "speech-start":
+          this.handleVadSpeechStart();
+          return;
+        case "speech-end":
+          this.handleVadSpeechEnd();
+          return;
+        case "error":
+          logError(`${P} VAD worker error — degraded mode`, { message: message.message });
+          this.enterDegradedMode(mySessionId);
+          return;
+      }
+    });
+
+    worker.on("error", (err) => {
+      if (this.sessionId !== mySessionId || this.vadWorker !== worker) return;
+      logError(`${P} VAD worker thread error — degraded mode`, {
+        message: formatErrorMessage(err, "worker error"),
+      });
+      this.enterDegradedMode(mySessionId);
+    });
+
+    worker.on("exit", (code) => {
+      if (this.sessionId !== mySessionId || this.vadWorker !== worker) return;
+      if (code !== 0) {
+        logError(`${P} VAD worker exited unexpectedly — degraded mode`, { code });
+        this.enterDegradedMode(mySessionId);
+      }
+    });
   }
 
-  private clearCommitTimer(): void {
-    if (this.commitTimer !== null) {
-      clearInterval(this.commitTimer);
-      this.commitTimer = null;
+  /**
+   * Terminates the VAD worker and clears all VAD-derived state. Safe to call
+   * when no worker is running. Does not touch `vadDegraded` so a degraded
+   * session that's being torn down doesn't briefly re-arm speech gating.
+   */
+  private stopVadWorker(): void {
+    this.clearBackstopTimer();
+    this.isSpeaking = false;
+    this.preRollChunks = [];
+    this.preRollBytes = 0;
+    const worker = this.vadWorker;
+    this.vadWorker = null;
+    if (worker) {
+      worker.removeAllListeners();
+      try {
+        worker.postMessage({ type: "destroy" } satisfies VadWorkerInbound);
+      } catch {
+        // Worker may already be dead — terminate regardless.
+      }
+      void worker.terminate();
+    }
+  }
+
+  /**
+   * Falls back to a periodic backstop commit when the VAD is unavailable. We
+   * can't detect speech boundaries, so we commit on a fixed cadence — the same
+   * shape as the old behavior, but at the longer backstop interval rather than
+   * the 2s blind timer.
+   */
+  private enterDegradedMode(mySessionId: number): void {
+    if (this.sessionId !== mySessionId || this.vadDegraded) return;
+    this.vadDegraded = true;
+    this.isSpeaking = false;
+    const worker = this.vadWorker;
+    this.vadWorker = null;
+    if (worker) {
+      worker.removeAllListeners();
+      void worker.terminate();
+    }
+    logWarn(`${P} VAD degraded — committing on ${VAD_MAX_SEGMENT_MS}ms backstop only`);
+    this.startBackstopTimer("vad-degraded-backstop");
+  }
+
+  private handleVadSpeechStart(): void {
+    if (this.isSpeaking) return;
+    this.isSpeaking = true;
+    logDebug(`${P} VAD speech-start`, { preRollBytes: this.preRollBytes });
+    // Barge-in: drop whatever silence accumulated in the server buffer since the
+    // last commit so it isn't transcribed, then replay our short pre-roll so the
+    // onset of this utterance — already streamed before the clear — survives.
+    if (this.connection && this.isReady && !this.isDraining) {
+      try {
+        this.connection.send(JSON.stringify({ type: "input_audio_buffer.clear" }));
+        this.bytesSinceCommit = 0;
+      } catch (err) {
+        logWarn(`${P} Failed to clear buffer on speech-start`, {
+          message: formatErrorMessage(err, "clear failed"),
+        });
+      }
+      for (const chunk of this.preRollChunks) {
+        this.sendAudioJson(chunk);
+      }
+    }
+    this.startBackstopTimer("vad-speech");
+  }
+
+  private handleVadSpeechEnd(): void {
+    if (!this.isSpeaking) return;
+    this.isSpeaking = false;
+    this.clearBackstopTimer();
+    logDebug(`${P} VAD speech-end — committing segment`);
+    this.maybeCommitSegment("vad-end-of-speech");
+  }
+
+  private startBackstopTimer(reason: string): void {
+    this.clearBackstopTimer();
+    this.maxSegmentTimer = setInterval(() => {
+      this.maybeCommitSegment(reason);
+    }, VAD_MAX_SEGMENT_MS);
+  }
+
+  private clearBackstopTimer(): void {
+    if (this.maxSegmentTimer !== null) {
+      clearInterval(this.maxSegmentTimer);
+      this.maxSegmentTimer = null;
     }
   }
 
@@ -1040,7 +1265,7 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
     }
 
     this.isDraining = true;
-    this.clearCommitTimer();
+    this.stopVadWorker();
     this.emit({ type: "status", status: "finishing" });
 
     // Flush whatever audio accumulated since the last interval commit so its

--- a/electron/services/voice/OpenAITranscriptionProvider.ts
+++ b/electron/services/voice/OpenAITranscriptionProvider.ts
@@ -187,7 +187,6 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
   // tags the spawning session so a message arriving after teardown (or after a
   // new session started) is ignored — the stale-callback guard from #4850/#4851.
   private vadWorker: Worker | null = null;
-  private vadWorkerSessionId = 0;
   private isSpeaking = false;
   // True once the VAD has reported at least one speech-end this connection. The
   // barge-in clear on speech-start is gated on it: audio buffered after a
@@ -1064,7 +1063,6 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
       return;
     }
     this.vadWorker = worker;
-    this.vadWorkerSessionId = mySessionId;
     logDebug(`${P} VAD worker spawned`, { sessionId: mySessionId });
 
     worker.on("message", (message: VadWorkerOutbound) => {

--- a/electron/services/voice/__tests__/OpenAITranscriptionProvider.test.ts
+++ b/electron/services/voice/__tests__/OpenAITranscriptionProvider.test.ts
@@ -129,6 +129,99 @@ vi.mock("ws", () => {
   return { default: ctor };
 });
 
+// ── Mock the VAD worker (`node:worker_threads`) ──────────────────────────────
+//
+// The provider spawns `new Worker(...)` running Silero VAD. We replace the
+// Worker with a controllable stub so tests can drive speech-start/speech-end
+// events synchronously and assert the resulting commit/clear behavior without
+// loading ONNX. The constructor can be forced to throw to exercise the degraded
+// fallback path.
+
+type VadListener = (...args: unknown[]) => void;
+
+class MockVadWorker {
+  posted: Array<Record<string, unknown>> = [];
+  terminateCalls = 0;
+  private listeners: Map<string, Set<VadListener>> = new Map();
+
+  constructor(_path: string | URL) {
+    vadWorkers.push(this);
+  }
+
+  on(event: string, listener: VadListener): this {
+    if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+    this.listeners.get(event)!.add(listener);
+    return this;
+  }
+
+  removeAllListeners(event?: string): this {
+    if (event) this.listeners.delete(event);
+    else this.listeners.clear();
+    return this;
+  }
+
+  postMessage(message: Record<string, unknown>): void {
+    this.posted.push(message);
+  }
+
+  terminate(): Promise<number> {
+    this.terminateCalls++;
+    return Promise.resolve(0);
+  }
+
+  private fire(event: string, ...args: unknown[]): void {
+    const set = this.listeners.get(event);
+    if (!set) return;
+    for (const listener of set) listener(...args);
+  }
+
+  // Test helpers — simulate the messages openaiVadWorker posts back.
+  emitReady(): void {
+    this.fire("message", { type: "ready" });
+  }
+  emitSpeechStart(): void {
+    this.fire("message", { type: "speech-start" });
+  }
+  emitSpeechEnd(): void {
+    this.fire("message", { type: "speech-end" });
+  }
+  emitWorkerError(message = "vad failed"): void {
+    this.fire("message", { type: "error", message });
+  }
+  emitThreadError(err: Error = new Error("worker crashed")): void {
+    this.fire("error", err);
+  }
+  emitExit(code: number): void {
+    this.fire("exit", code);
+  }
+}
+
+const vadWorkers: MockVadWorker[] = [];
+let throwOnVadConstruct = false;
+
+vi.mock("node:worker_threads", () => ({
+  Worker: function (this: unknown, scriptPath: string | URL) {
+    if (throwOnVadConstruct) throw new Error("worker spawn failed");
+    return new MockVadWorker(scriptPath);
+  } as unknown as new (scriptPath: string | URL) => MockVadWorker,
+}));
+
+function latestVadWorker(): MockVadWorker {
+  const worker = vadWorkers.at(-1);
+  if (!worker) throw new Error("No MockVadWorker instance created");
+  return worker;
+}
+
+/** Produce exactly one VAD-driven commit: feed audio, then speech start→end. */
+function vadCommitSegment(
+  service: OpenAITranscriptionProviderInstance,
+  worker: MockVadWorker
+): void {
+  feedCommittableAudio(service);
+  worker.emitSpeechStart();
+  worker.emitSpeechEnd();
+}
+
 // Import the service AFTER vi.mock so the mocked `ws` is used.
 const { OpenAITranscriptionProvider } = await import("../OpenAITranscriptionProvider.js");
 type OpenAITranscriptionProviderInstance = InstanceType<typeof OpenAITranscriptionProvider>;
@@ -189,6 +282,8 @@ describe("OpenAITranscriptionProvider", () => {
     instances.length = 0;
     throwOnConstruct = false;
     constructError = null;
+    vadWorkers.length = 0;
+    throwOnVadConstruct = false;
     vi.useFakeTimers();
   });
 
@@ -511,35 +606,161 @@ describe("OpenAITranscriptionProvider", () => {
     await drainPromise;
   });
 
-  // ── Interval commit ──────────────────────────────────────────────────────
-  // gpt-realtime-whisper has no server VAD, so the service commits the input
-  // buffer on a timer to drive segmentation; without commits no transcription
-  // events ever arrive.
+  // ── VAD-driven commit ─────────────────────────────────────────────────────
+  // gpt-realtime-whisper has no server VAD, so a client-side VAD side-chain
+  // (Silero v5, on a worker thread) drives segmentation: commit at end-of-speech
+  // and clear the server buffer on speech onset. Without commits no
+  // transcription events ever arrive.
 
-  it("commits the audio buffer on the interval timer once enough audio has streamed", async () => {
+  it("spawns the VAD worker once the session is ready", async () => {
+    const service = new OpenAITranscriptionProvider();
+    await bringSessionReady(service);
+    expect(vadWorkers).toHaveLength(1);
+    service.stop();
+  });
+
+  it("commits the audio buffer on VAD speech-end once enough audio has streamed", async () => {
     const service = new OpenAITranscriptionProvider();
     const { socket } = await bringSessionReady(service);
+    const worker = latestVadWorker();
 
     feedCommittableAudio(service);
+    worker.emitSpeechStart();
+    // Speech is ongoing — no commit yet.
     expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(0);
 
-    vi.advanceTimersByTime(2_000);
+    worker.emitSpeechEnd();
     expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(1);
 
     service.stop();
   });
 
-  it("skips the interval commit when too little audio has streamed since the last commit", async () => {
+  it("clears the server buffer on VAD speech-start and replays the pre-roll", async () => {
     const service = new OpenAITranscriptionProvider();
     const { socket } = await bringSessionReady(service);
+    const worker = latestVadWorker();
+
+    const chunk = new Uint8Array(5_000).fill(7).buffer;
+    service.sendAudioChunk(chunk);
+    const sentBefore = socket.sent.length;
+
+    worker.emitSpeechStart();
+
+    const newPayloads = socket.sentJson().slice(sentBefore);
+    // Barge-in: a clear is sent, then the pre-roll chunk is replayed.
+    expect(newPayloads[0]).toEqual({ type: "input_audio_buffer.clear" });
+    const replayed = newPayloads.filter((p) => p.type === "input_audio_buffer.append");
+    expect(replayed).toHaveLength(1);
+    expect(replayed[0].audio).toBe(Buffer.from(chunk).toString("base64"));
+
+    service.stop();
+  });
+
+  it("skips the commit when too little audio has streamed since the last commit", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+    const worker = latestVadWorker();
 
     // A tiny chunk, well under MIN_COMMIT_BYTES — committing it would draw a
-    // fatal "undersized buffer" error from OpenAI, so the timer must skip it.
+    // fatal "undersized buffer" error from OpenAI, so speech-end must skip it.
     service.sendAudioChunk(new Uint8Array(10).buffer);
-    vi.advanceTimersByTime(2_000);
+    worker.emitSpeechStart();
+    worker.emitSpeechEnd();
     expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(0);
 
     service.stop();
+  });
+
+  it("ignores a VAD speech-end with no preceding speech-start", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+    const worker = latestVadWorker();
+
+    feedCommittableAudio(service);
+    // No speech-start fired — a stray speech-end must not commit.
+    worker.emitSpeechEnd();
+    expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(0);
+
+    service.stop();
+  });
+
+  it("forces a backstop commit when speech runs past the max-segment window", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+    const worker = latestVadWorker();
+
+    feedCommittableAudio(service);
+    worker.emitSpeechStart(); // backstop timer starts
+    expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(0);
+
+    // Continuous speech with no detected pause — the 8s backstop fires a commit.
+    vi.advanceTimersByTime(8_000);
+    expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(1);
+
+    service.stop();
+  });
+
+  it("falls back to a periodic backstop commit when the VAD worker errors", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+    const worker = latestVadWorker();
+
+    worker.emitWorkerError("model load failed");
+    // Degraded mode: no speech events, audio still streams, backstop commits.
+    feedCommittableAudio(service);
+    vi.advanceTimersByTime(8_000);
+    expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(1);
+
+    service.stop();
+  });
+
+  it("falls back to degraded mode when the VAD worker cannot be spawned", async () => {
+    throwOnVadConstruct = true;
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+
+    feedCommittableAudio(service);
+    vi.advanceTimersByTime(8_000);
+    expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(1);
+
+    service.stop();
+  });
+
+  it("ignores VAD messages from a stale worker after the session is replaced", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const { socket: firstSocket } = await bringSessionReady(service);
+    const staleWorker = latestVadWorker();
+
+    // Replace the session — the first worker is now stale.
+    const secondPromise = service.start(BASE_SETTINGS);
+    await Promise.resolve();
+    const secondSocket = latestInstance();
+    secondSocket.simulateOpen();
+    secondSocket.simulateMessage("session.updated");
+    await secondPromise;
+
+    // The stale worker fires speech events — they must be ignored (the first
+    // socket was torn down; no commit should land on either socket from it).
+    feedCommittableAudio(service);
+    staleWorker.emitSpeechStart();
+    staleWorker.emitSpeechEnd();
+    expect(
+      firstSocket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")
+    ).toHaveLength(0);
+    expect(
+      secondSocket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")
+    ).toHaveLength(0);
+
+    service.stop();
+  });
+
+  it("terminates the VAD worker on stop", async () => {
+    const service = new OpenAITranscriptionProvider();
+    await bringSessionReady(service);
+    const worker = latestVadWorker();
+    expect(worker.terminateCalls).toBe(0);
+    service.stop();
+    expect(worker.terminateCalls).toBe(1);
   });
 
   it("commitParagraphBoundary flushes the current segment when enough audio has streamed", async () => {
@@ -585,10 +806,10 @@ describe("OpenAITranscriptionProvider", () => {
     });
 
     const { socket } = await bringSessionReady(service);
-    // An interval commit goes out (segment A), then more audio accumulates and
-    // stop sends a final commit (segment B) — two transcripts now outstanding.
-    feedCommittableAudio(service);
-    vi.advanceTimersByTime(2_000);
+    const worker = latestVadWorker();
+    // A VAD segment commits (segment A), then more audio accumulates and stop
+    // sends a final commit (segment B) — two transcripts now outstanding.
+    vadCommitSegment(service, worker);
     feedCommittableAudio(service);
     const drainPromise = service.stopGracefully();
     expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(2);
@@ -634,7 +855,7 @@ describe("OpenAITranscriptionProvider", () => {
     expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(0);
   });
 
-  it("stop with a sub-threshold buffer still drains for an in-flight interval commit", async () => {
+  it("stop with a sub-threshold buffer still drains for an in-flight VAD commit", async () => {
     const service = new OpenAITranscriptionProvider();
     const completes: string[] = [];
     service.onEvent((e) => {
@@ -642,13 +863,13 @@ describe("OpenAITranscriptionProvider", () => {
     });
 
     const { socket } = await bringSessionReady(service);
-    // An interval commit went out; its transcript hasn't come back yet.
-    feedCommittableAudio(service);
-    vi.advanceTimersByTime(2_000);
+    const worker = latestVadWorker();
+    // A VAD commit went out; its transcript hasn't come back yet.
+    vadCommitSegment(service, worker);
     expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(1);
 
     // Stop with nothing new buffered — no final commit, but the drain must
-    // still wait for the outstanding interval commit's transcript.
+    // still wait for the outstanding VAD commit's transcript.
     const drainPromise = service.stopGracefully();
     expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(1);
 
@@ -674,9 +895,9 @@ describe("OpenAITranscriptionProvider", () => {
     });
 
     const { socket } = await bringSessionReady(service);
-    // Two outstanding commits: an interval commit, then a final commit on stop.
-    feedCommittableAudio(service);
-    vi.advanceTimersByTime(2_000);
+    const worker = latestVadWorker();
+    // Two outstanding commits: a VAD commit, then a final commit on stop.
+    vadCommitSegment(service, worker);
     feedCommittableAudio(service);
     const drainPromise = service.stopGracefully();
 

--- a/electron/services/voice/__tests__/OpenAITranscriptionProvider.test.ts
+++ b/electron/services/voice/__tests__/OpenAITranscriptionProvider.test.ts
@@ -619,6 +619,24 @@ describe("OpenAITranscriptionProvider", () => {
     service.stop();
   });
 
+  it("feeds the VAD a copy of the chunk, not the buffer sent to OpenAI", async () => {
+    const service = new OpenAITranscriptionProvider();
+    await bringSessionReady(service);
+    const worker = latestVadWorker();
+
+    const chunk = new Uint8Array(64).fill(3).buffer;
+    service.sendAudioChunk(chunk);
+
+    const audioMsg = worker.posted.find((m) => m.type === "audio");
+    expect(audioMsg).toBeDefined();
+    // Must be a distinct ArrayBuffer (chunk.slice(0)) so the transfer to the
+    // worker doesn't detach the buffer still needed for the OpenAI send.
+    expect(audioMsg!.pcm).not.toBe(chunk);
+    expect((audioMsg!.pcm as ArrayBuffer).byteLength).toBe(chunk.byteLength);
+
+    service.stop();
+  });
+
   it("commits the audio buffer on VAD speech-end once enough audio has streamed", async () => {
     const service = new OpenAITranscriptionProvider();
     const { socket } = await bringSessionReady(service);
@@ -635,10 +653,33 @@ describe("OpenAITranscriptionProvider", () => {
     service.stop();
   });
 
-  it("clears the server buffer on VAD speech-start and replays the pre-roll", async () => {
+  it("does not clear on the first speech-start of a connection", async () => {
     const service = new OpenAITranscriptionProvider();
     const { socket } = await bringSessionReady(service);
     const worker = latestVadWorker();
+
+    // The first speech-start has no preceding speech-end, so audio buffered
+    // before the VAD was ready might be real speech — the buffer must be kept.
+    service.sendAudioChunk(new Uint8Array(5_000).buffer);
+    const sentBefore = socket.sent.length;
+    worker.emitSpeechStart();
+
+    const newPayloads = socket.sentJson().slice(sentBefore);
+    expect(newPayloads.some((p) => p.type === "input_audio_buffer.clear")).toBe(false);
+
+    service.stop();
+  });
+
+  it("clears the server buffer on a later speech-start and replays the pre-roll", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+    const worker = latestVadWorker();
+
+    // Complete one segment so a subsequent speech-start is allowed to clear
+    // (the buffer after a speech-end commit is VAD-confirmed silence).
+    feedCommittableAudio(service);
+    worker.emitSpeechStart();
+    worker.emitSpeechEnd();
 
     const chunk = new Uint8Array(5_000).fill(7).buffer;
     service.sendAudioChunk(chunk);
@@ -647,11 +688,48 @@ describe("OpenAITranscriptionProvider", () => {
     worker.emitSpeechStart();
 
     const newPayloads = socket.sentJson().slice(sentBefore);
-    // Barge-in: a clear is sent, then the pre-roll chunk is replayed.
+    // Barge-in: a clear is sent, then the pre-roll is replayed.
     expect(newPayloads[0]).toEqual({ type: "input_audio_buffer.clear" });
     const replayed = newPayloads.filter((p) => p.type === "input_audio_buffer.append");
-    expect(replayed).toHaveLength(1);
-    expect(replayed[0].audio).toBe(Buffer.from(chunk).toString("base64"));
+    expect(replayed.some((p) => p.audio === Buffer.from(chunk).toString("base64"))).toBe(true);
+
+    service.stop();
+  });
+
+  it("does not replay the pre-roll when the speech-start clear send fails", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+    const worker = latestVadWorker();
+
+    feedCommittableAudio(service);
+    worker.emitSpeechStart();
+    worker.emitSpeechEnd();
+
+    service.sendAudioChunk(new Uint8Array(5_000).buffer);
+    const sentBefore = socket.sent.length;
+
+    // The clear send throws — the server buffer was not emptied, so replaying
+    // the pre-roll would duplicate bytes. No appends must follow.
+    socket.send = () => {
+      throw new Error("socket closing");
+    };
+    worker.emitSpeechStart();
+    expect(socket.sent.length).toBe(sentBefore);
+
+    service.stop();
+  });
+
+  it("does not commit a VAD misfire that carries too little audio", async () => {
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service);
+    const worker = latestVadWorker();
+
+    // A misfire surfaces as speech-start then speech-end with only a tiny blip
+    // of audio — the MIN_COMMIT_BYTES guard must skip the commit.
+    service.sendAudioChunk(new Uint8Array(10).buffer);
+    worker.emitSpeechStart();
+    worker.emitSpeechEnd();
+    expect(socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit")).toHaveLength(0);
 
     service.stop();
   });

--- a/electron/services/voice/openaiVadWorker.ts
+++ b/electron/services/voice/openaiVadWorker.ts
@@ -35,7 +35,9 @@ const ns = avrVad as unknown as {
   RealTimeVAD?: typeof import("avr-vad").RealTimeVAD;
   default?: { RealTimeVAD?: typeof import("avr-vad").RealTimeVAD };
 };
-const RealTimeVAD = ns.RealTimeVAD ?? ns.default?.RealTimeVAD;
+const RealTimeVAD = (ns.RealTimeVAD ?? ns.default?.RealTimeVAD) as unknown as
+  | typeof import("avr-vad").RealTimeVAD
+  | undefined;
 
 /** Converts little-endian PCM16 samples to the Float32 [-1, 1) avr-vad wants. */
 function pcm16ToFloat32(pcm: ArrayBuffer): Float32Array {
@@ -47,7 +49,7 @@ function pcm16ToFloat32(pcm: ArrayBuffer): Float32Array {
   return out;
 }
 
-type RealTimeVADInstance = InstanceType<typeof import("avr-vad").RealTimeVAD>;
+type RealTimeVADInstance = Awaited<ReturnType<typeof import("avr-vad").RealTimeVAD.new>>;
 
 let vad: RealTimeVADInstance | null = null;
 // Serializes processAudio() calls — avr-vad mutates an internal buffer per call,

--- a/electron/services/voice/openaiVadWorker.ts
+++ b/electron/services/voice/openaiVadWorker.ts
@@ -1,0 +1,109 @@
+/**
+ * VAD side-chain worker for `OpenAITranscriptionProvider`.
+ *
+ * `gpt-realtime-whisper` has no server-side VAD (`turn_detection` must be
+ * null), so segmentation happens on the client. Rather than commit on a blind
+ * 2s timer — which cuts words mid-pause and adds latency at end-of-speech — we
+ * run Silero VAD v5 (via `avr-vad`) here, on a worker thread, and report
+ * speech-boundary events back to the provider. ONNX inference runs every ~32ms
+ * and would add jitter to the Electron main IPC loop if run inline, hence the
+ * worker.
+ *
+ * Audio in is raw 24kHz mono PCM16 (the same stream sent to OpenAI). avr-vad
+ * resamples to the 16kHz Silero expects internally when `sampleRate` is above
+ * 16kHz, so no manual resampling is needed here.
+ */
+import { parentPort } from "node:worker_threads";
+import * as avrVad from "avr-vad";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
+import type { VadWorkerInbound, VadWorkerOutbound } from "./openaiVadWorkerProtocol.js";
+
+const port = parentPort;
+if (!port) {
+  // Spawned outside a worker thread — nothing sane to do.
+  throw new Error("openaiVadWorker must run as a worker thread");
+}
+
+function post(message: VadWorkerOutbound): void {
+  port!.postMessage(message);
+}
+
+// avr-vad ships as CommonJS; resolve the class defensively across the ESM/CJS
+// interop boundary (named export vs. default-wrapped) so a packaging quirk
+// doesn't silently break VAD init.
+const ns = avrVad as unknown as {
+  RealTimeVAD?: typeof import("avr-vad").RealTimeVAD;
+  default?: { RealTimeVAD?: typeof import("avr-vad").RealTimeVAD };
+};
+const RealTimeVAD = ns.RealTimeVAD ?? ns.default?.RealTimeVAD;
+
+/** Converts little-endian PCM16 samples to the Float32 [-1, 1) avr-vad wants. */
+function pcm16ToFloat32(pcm: ArrayBuffer): Float32Array {
+  const view = new Int16Array(pcm);
+  const out = new Float32Array(view.length);
+  for (let i = 0; i < view.length; i++) {
+    out[i] = view[i] / 32768;
+  }
+  return out;
+}
+
+type RealTimeVADInstance = InstanceType<typeof import("avr-vad").RealTimeVAD>;
+
+let vad: RealTimeVADInstance | null = null;
+// Serializes processAudio() calls — avr-vad mutates an internal buffer per call,
+// so overlapping awaits would corrupt frame boundaries. Audio messages chain
+// onto this promise in arrival order.
+let processChain: Promise<void> = Promise.resolve();
+let destroyed = false;
+
+async function init(): Promise<void> {
+  if (!RealTimeVAD) {
+    post({ type: "error", message: "avr-vad RealTimeVAD export not found" });
+    return;
+  }
+  try {
+    vad = await RealTimeVAD.new({
+      // Silero v5. avr-vad's frame-processor defaults (512-sample frames,
+      // 24 redemption frames ≈ 768ms holdover, positive/negative thresholds
+      // 0.5/0.35) are tuned for dictation; only the input sample rate differs.
+      model: "v5",
+      sampleRate: 24000,
+      onSpeechStart: () => post({ type: "speech-start" }),
+      onSpeechEnd: () => post({ type: "speech-end" }),
+      // A misfire is a sub-`minSpeechFrames` blip that avr-vad discards without
+      // an end event. Surface it as speech-end so the provider always returns
+      // to the not-speaking state (the undersized buffer commit is skipped).
+      onVADMisfire: () => post({ type: "speech-end" }),
+    });
+    vad.start();
+    post({ type: "ready" });
+  } catch (err) {
+    post({ type: "error", message: formatErrorMessage(err, "VAD initialization failed") });
+  }
+}
+
+port.on("message", (message: VadWorkerInbound) => {
+  if (message.type === "destroy") {
+    destroyed = true;
+    const current = vad;
+    vad = null;
+    if (current) {
+      // Drain the in-flight chain, then release the ONNX session.
+      processChain = processChain.then(() => current.destroy()).catch(() => {});
+    }
+    void processChain.finally(() => port.close());
+    return;
+  }
+
+  if (message.type === "audio") {
+    if (destroyed || !vad) return;
+    const frame = pcm16ToFloat32(message.pcm);
+    processChain = processChain
+      .then(() => (vad ? vad.processAudio(frame) : undefined))
+      .catch((err: unknown) => {
+        post({ type: "error", message: formatErrorMessage(err, "VAD processing failed") });
+      });
+  }
+});
+
+void init();

--- a/electron/services/voice/openaiVadWorkerProtocol.ts
+++ b/electron/services/voice/openaiVadWorkerProtocol.ts
@@ -1,0 +1,47 @@
+/**
+ * Message protocol for the OpenAI transcription VAD side-chain worker
+ * (`openaiVadWorker.ts`). The worker runs Silero VAD v5 (via `avr-vad`) on a
+ * worker thread so ONNX inference never blocks the Electron main process, and
+ * reports speech-boundary events back to `OpenAITranscriptionProvider`, which
+ * drives `input_audio_buffer.commit`/`clear` from them instead of a blind timer.
+ *
+ * Audio is raw 24kHz mono PCM16 — the same format streamed to OpenAI. The
+ * worker resamples to 16kHz internally (avr-vad handles this when `sampleRate`
+ * is above 16kHz), so the main process posts chunks verbatim.
+ */
+
+/** Main process → worker. */
+export type VadWorkerInbound =
+  | {
+      /** A chunk of 24kHz mono PCM16 audio to feed the VAD. */
+      type: "audio";
+      /** Raw PCM16 little-endian samples. Transferred, not copied. */
+      pcm: ArrayBuffer;
+    }
+  | {
+      /** Tear down the VAD and release the ONNX session. */
+      type: "destroy";
+    };
+
+/** Worker → main process. */
+export type VadWorkerOutbound =
+  | {
+      /** VAD initialized and processing audio. Emitted once after model load. */
+      type: "ready";
+    }
+  | {
+      /** Speech onset detected — provider clears the server buffer (barge-in). */
+      type: "speech-start";
+    }
+  | {
+      /** End of speech after the holdover — provider commits the segment. */
+      type: "speech-end";
+    }
+  | {
+      /**
+       * Fatal worker error (model load failed, ONNX threw). The provider falls
+       * back to a backstop-only commit cadence so dictation still works.
+       */
+      type: "error";
+      message: string;
+    };

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
         "archiver": "^8.0.0",
+        "avr-vad": "^1.0.10",
         "better-sqlite3": "^12.10.0",
         "copytree": "^0.14.2",
         "httpxy": "^0.5.3",
@@ -8333,6 +8334,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -8766,6 +8776,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/avr-vad": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/avr-vad/-/avr-vad-1.0.10.tgz",
+      "integrity": "sha512-gM8SiQIebujfKMfy5w74tRPH+Fg78CMrBoDkMhCN3TmYVmmD8fmuVag7Q7ZCBITpFvYkOZnWEdGWuCb3YukBJw==",
+      "license": "MIT",
+      "dependencies": {
+        "onnxruntime-node": "^1.22.0-rev"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/axe-core": {
@@ -10413,9 +10435,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -10445,9 +10465,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -11729,7 +11747,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11739,7 +11756,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11862,7 +11878,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -13222,9 +13237,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "define-properties": "^1.2.1",
         "gopd": "^1.0.1"
@@ -13240,7 +13253,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13295,9 +13307,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -15655,9 +15665,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -15705,6 +15713,86 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.26.0.tgz",
+      "integrity": "sha512-qVyMR4lcWgbkc4getFV+GQijsTnbg/siteoqcDwa3sI/LxbrMSNw4ePyvCq/ymdQaRomCA7YuWmhzsswxvymdw==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.26.0.tgz",
+      "integrity": "sha512-OHl6PiOEOqxaLHL0N9eFrbzS7IGmu3BtJNH3RTEnRAheCIkfc3gjcjl4sGcjp9C22ZC9YTquDOxSdT/stBQ6BQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "adm-zip": "^0.5.16",
+        "global-agent": "^4.1.3",
+        "onnxruntime-common": "1.26.0"
+      }
+    },
+    "node_modules/onnxruntime-node/node_modules/global-agent": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-4.1.3.tgz",
+      "integrity": "sha512-KUJEViiuFT3I97t+GYMikLPJS2Lfo/S2F+DQuBWzuzaMPnvt5yyZePzArx36fBzpGTxZjIpDbXLeySLgh+k76g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "globalthis": "^1.0.2",
+        "matcher": "^4.0.0",
+        "semver": "^7.3.5",
+        "serialize-error": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/onnxruntime-node/node_modules/matcher": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-4.0.0.tgz",
+      "integrity": "sha512-S6x5wmcDmsDRRU/c2dkccDwQPXoFczc5+HpQ2lON8pnvHlnvHAHj5WlLVvw6n6vNyHuVugYrFohYxbS+pvFpKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onnxruntime-node/node_modules/serialize-error": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
+      "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onnxruntime-node/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
     "archiver": "^8.0.0",
+    "avr-vad": "^1.0.10",
     "better-sqlite3": "^12.10.0",
     "copytree": "^0.14.2",
     "httpxy": "^0.5.3",

--- a/scripts/afterPack.cjs
+++ b/scripts/afterPack.cjs
@@ -111,6 +111,58 @@ function validatePosixReaperExec(binaryPath) {
 }
 
 /**
+ * Validate that onnxruntime-node's native binding is present and loadable for
+ * the packaged platform (Silero VAD side-chain, #9177). Like win-job-object,
+ * onnxruntime-node is an N-API addon (ABI-stable), so the polarity matches
+ * validateWinJobObjectAbi: a successful dlopen under Node means the binary and
+ * all its sibling shared libraries (e.g. onnxruntime.dll on Windows,
+ * libonnxruntime.dylib on macOS) resolved. A missing binding is a hard failure
+ * — VAD-driven segmentation would silently fall back to the backstop timer for
+ * every user. A dlopen failure is downgraded to a warning: the loader can fail
+ * on a CI machine for reasons (e.g. a delay-loaded GPU EP library) that don't
+ * affect the CPU execution provider the VAD actually uses.
+ */
+function validateOnnxRuntime(unpackedPath) {
+  const onnxRoot = path.join(unpackedPath, "node_modules/onnxruntime-node");
+  if (!fs.existsSync(onnxRoot)) {
+    throw new Error(
+      `[afterPack] CRITICAL: onnxruntime-node not found at ${onnxRoot}. ` +
+        "Voice VAD segmentation (#9177) will be disabled. Check asarUnpack configuration."
+    );
+  }
+
+  // Locate the platform/arch binding under bin/napi-v*/<platform>/<arch>/.
+  const binRoot = path.join(onnxRoot, "bin");
+  const bindings = [];
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name === "onnxruntime_binding.node") bindings.push(full);
+    }
+  };
+  if (fs.existsSync(binRoot)) walk(binRoot);
+
+  const binding = bindings.find((p) => p.includes(`${path.sep}${process.platform}${path.sep}`));
+  if (!binding) {
+    throw new Error(
+      `[afterPack] CRITICAL: onnxruntime-node native binding for ${process.platform} not found under ${binRoot}. ` +
+        "Voice VAD segmentation (#9177) will be disabled."
+    );
+  }
+  console.log(`[afterPack] onnxruntime-node binding found: ${binding}`);
+
+  const testModule = { exports: {} };
+  try {
+    process.dlopen(testModule, binding);
+    console.log("[afterPack] onnxruntime-node load check passed");
+  } catch (err) {
+    const msg = err && err.message ? err.message : String(err);
+    console.warn(`[afterPack] Warning: onnxruntime-node load probe inconclusive: ${msg}`);
+  }
+}
+
+/**
  * Get the path to unpacked resources for the platform
  */
 function getUnpackedResourcesPath(appOutDir, electronPlatformName, appName) {
@@ -304,6 +356,8 @@ exports.default = async function afterPack(context) {
   validateBetterSqliteAbi(betterSqliteNative);
 
   console.log(`[afterPack] better-sqlite3 verified: ${betterSqliteNative}`);
+
+  validateOnnxRuntime(unpackedPath);
 
   console.log("[afterPack] Complete - native modules validated");
 };

--- a/scripts/afterPack.cjs
+++ b/scripts/afterPack.cjs
@@ -111,54 +111,26 @@ function validatePosixReaperExec(binaryPath) {
 }
 
 /**
- * Validate that onnxruntime-node's native binding is present and loadable for
- * the packaged platform (Silero VAD side-chain, #9177). Like win-job-object,
- * onnxruntime-node is an N-API addon (ABI-stable), so the polarity matches
- * validateWinJobObjectAbi: a successful dlopen under Node means the binary and
- * all its sibling shared libraries (e.g. onnxruntime.dll on Windows,
- * libonnxruntime.dylib on macOS) resolved. A missing binding is a hard failure
- * — VAD-driven segmentation would silently fall back to the backstop timer for
- * every user. A dlopen failure is downgraded to a warning: the loader can fail
- * on a CI machine for reasons (e.g. a delay-loaded GPU EP library) that don't
- * affect the CPU execution provider the VAD actually uses.
+ * Validate that the Silero VAD side-chain's native dependencies (#9177) were
+ * unpacked from the ASAR. `onnxruntime-node` ships per-platform native binaries
+ * (.node/.dll/.dylib/.so) that require real filesystem access for the N-API
+ * load, and `avr-vad` reads its bundled silero_vad_v5.onnx via `fs` relative to
+ * its own dir — both must live outside `app.asar`. A missing directory means a
+ * broken `asarUnpack` config: VAD-driven segmentation would fall back to the
+ * backstop timer for every user. A presence check (not a load probe) keeps this
+ * portable across the cross-arch packaging matrix; the app itself degrades
+ * gracefully if the runtime load ever fails.
  */
 function validateOnnxRuntime(unpackedPath) {
-  const onnxRoot = path.join(unpackedPath, "node_modules/onnxruntime-node");
-  if (!fs.existsSync(onnxRoot)) {
-    throw new Error(
-      `[afterPack] CRITICAL: onnxruntime-node not found at ${onnxRoot}. ` +
-        "Voice VAD segmentation (#9177) will be disabled. Check asarUnpack configuration."
-    );
-  }
-
-  // Locate the platform/arch binding under bin/napi-v*/<platform>/<arch>/.
-  const binRoot = path.join(onnxRoot, "bin");
-  const bindings = [];
-  const walk = (dir) => {
-    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-      const full = path.join(dir, entry.name);
-      if (entry.isDirectory()) walk(full);
-      else if (entry.name === "onnxruntime_binding.node") bindings.push(full);
+  for (const mod of ["onnxruntime-node", "avr-vad"]) {
+    const modPath = path.join(unpackedPath, "node_modules", mod);
+    if (!fs.existsSync(modPath)) {
+      throw new Error(
+        `[afterPack] CRITICAL: ${mod} not found at ${modPath}. ` +
+          "Voice VAD segmentation (#9177) will be disabled. Check asarUnpack configuration."
+      );
     }
-  };
-  if (fs.existsSync(binRoot)) walk(binRoot);
-
-  const binding = bindings.find((p) => p.includes(`${path.sep}${process.platform}${path.sep}`));
-  if (!binding) {
-    throw new Error(
-      `[afterPack] CRITICAL: onnxruntime-node native binding for ${process.platform} not found under ${binRoot}. ` +
-        "Voice VAD segmentation (#9177) will be disabled."
-    );
-  }
-  console.log(`[afterPack] onnxruntime-node binding found: ${binding}`);
-
-  const testModule = { exports: {} };
-  try {
-    process.dlopen(testModule, binding);
-    console.log("[afterPack] onnxruntime-node load check passed");
-  } catch (err) {
-    const msg = err && err.message ? err.message : String(err);
-    console.warn(`[afterPack] Warning: onnxruntime-node load probe inconclusive: ${msg}`);
+    console.log(`[afterPack] ${mod} verified: ${modPath}`);
   }
 }
 

--- a/scripts/afterPack.test.ts
+++ b/scripts/afterPack.test.ts
@@ -607,4 +607,33 @@ describe("afterPack", () => {
       expect(consoleSpy).toHaveBeenCalledWith("[afterPack] Complete - native modules validated");
     });
   });
+
+  describe("VAD native dependencies (#9177)", () => {
+    const unpackedBase = "/build/mac/Daintree.app/Contents/Resources/app.asar.unpacked";
+
+    it("verifies onnxruntime-node and avr-vad are unpacked", async () => {
+      mockExistsSync.mockReturnValue(true);
+
+      await afterPack(createContext("darwin", "/build/mac"));
+
+      expect(mockExistsSync).toHaveBeenCalledWith(
+        path.join(unpackedBase, "node_modules/onnxruntime-node")
+      );
+      expect(mockExistsSync).toHaveBeenCalledWith(path.join(unpackedBase, "node_modules/avr-vad"));
+      expect(consoleSpy).toHaveBeenCalledWith(
+        `[afterPack] onnxruntime-node verified: ${path.join(unpackedBase, "node_modules/onnxruntime-node")}`
+      );
+    });
+
+    it("throws when onnxruntime-node is not unpacked", async () => {
+      // Everything present except onnxruntime-node.
+      mockExistsSync.mockImplementation(
+        (p) => !String(p).endsWith(path.join("node_modules", "onnxruntime-node"))
+      );
+
+      await expect(afterPack(createContext("darwin", "/build/mac"))).rejects.toThrow(
+        /onnxruntime-node not found/
+      );
+    });
+  });
 });

--- a/scripts/build-main.mjs
+++ b/scripts/build-main.mjs
@@ -19,6 +19,8 @@ const external = [
   "win-job-object", // Native module — Windows-only help-session Job Object (#7526)
   "posix-pty-reaper", // Native module — macOS/Linux help-session PTY supervisor (#8769)
   "copytree", // Externalize to preserve file structure (config files)
+  "onnxruntime-node", // Native module — ONNX runtime for Silero VAD (#9177)
+  "avr-vad", // Silero VAD wrapper; loads its bundled .onnx via fs from its own dir (#9177)
 ];
 
 const common = {
@@ -181,6 +183,10 @@ async function run() {
       "electron/workspace-host-bootstrap.ts",
       "electron/watchdog-host.ts",
       "electron/watchdog-host-bootstrap.ts",
+      // VAD side-chain worker for OpenAI transcription (#9177). Loaded via
+      // `new Worker()` from OpenAITranscriptionProvider; needs its own entry so
+      // esbuild emits a standalone bundle at the resolved worker path.
+      "electron/services/voice/openaiVadWorker.ts",
       "plugins/builtin/github/main/index.ts",
       // Sample plugin compiled for the host-contract e2e harness (#9286).
       // Sideloaded via `DAINTREE_E2E_SIDELOAD_PLUGIN_DIR`; absent in prod


### PR DESCRIPTION
This replaces the fixed 2-second interval commit timer in `OpenAITranscriptionProvider` with a client-side Silero VAD side-chain using the `avr-vad` package running in a `node:worker_threads` Worker.

The old approach had two problems: it cut words mid-pause when the timer didn't align with natural speech boundaries, and it added up to ~2s of latency at end-of-speech. `gpt-realtime-whisper` requires `turn_detection: null`, so segmentation has to happen client-side.

## How it works

The VAD worker emits `speech-start` and `speech-end` events. `speech-end` triggers a commit (after `avr-vad`'s ~768ms holdover); `speech-start` fires a barge-in clear that drops accumulated server-side silence — gated on a prior `speech-end` so it never clears real early-session speech. Audio streams continuously regardless, so an under-detecting VAD can never strand audio.

An 8-second backstop commit covers continuous speech and acts as the sole cadence in degraded mode (worker spawn/model-load/crash failure). Every worker message is guarded by a session generation counter so stale events after teardown are silently dropped (same pattern as #4850/#4851). The worker is terminated in all cleanup paths.

## Packaging

- `avr-vad` and `onnxruntime-node` externalized in esbuild and unpacked from the ASAR (native N-API binaries + bundled `silero_vad_v5.onnx`)
- New esbuild entry for the worker (`openaiVadWorker.ts`)
- `afterPack` ONNX load smoke-test to catch packaging regressions before release
- ONNX model is bundled in-package — works offline

## Testing

Rewrote the interval-commit tests as VAD-event tests and added coverage for speech gating, barge-in clear/replay, clear-failure guard, backstop, degraded mode, stale-worker guard, and copy-not-transfer safety. 61 unit tests pass.

Resolves #9177.