### PR TITLE
fix(worktree): restore the durable worktree selection on project switch-back

### DIFF
--- a/electron/services/ProjectSwitchService.ts
+++ b/electron/services/ProjectSwitchService.ts
@@ -156,33 +156,32 @@ export class ProjectSwitchService {
   }
 
   /**
-   * Save the current active worktree ID to the outgoing project's per-project state.
-   * This ensures the worktree selection is remembered when switching back to the project.
+   * Persist the outgoing project's non-worktree per-project state on switch-away.
+   *
+   * The active worktree selection is owned by `persistOutgoingProjectState`
+   * (project switch IPC handler), which writes the live renderer selection and
+   * runs before this method on every switch. This method must NOT re-derive the
+   * selection from `appState.activeWorktreeId`: that main-process value lags the
+   * renderer by the async `app:set-state` write, so reading it here could
+   * resurrect a stale or incidental worktree (e.g. a temporary PR worktree from
+   * a batch merge) and clobber the correct value the renderer just persisted
+   * (#9512). The existing `activeWorktreeId` is preserved verbatim.
    */
   private async saveOutgoingProjectWorktreeState(projectId: string): Promise<void> {
     try {
       const currentAppState = store.get("appState");
-      const activeWorktreeId = currentAppState.activeWorktreeId;
 
-      // Get existing project state to preserve all fields
+      // Get existing project state to preserve all fields, including the
+      // renderer-authored activeWorktreeId.
       const existingState = await projectStore.getProjectState(projectId);
-      if (existingState?.activeWorktreeId === activeWorktreeId) {
-        return;
-      }
 
-      // Persist only when the active worktree changed to avoid unnecessary disk writes.
-      // Null/undefined changes are still persisted because the equality check above compares exact values.
       await projectStore.saveProjectState(projectId, {
         ...existingState,
         projectId,
-        activeWorktreeId,
+        activeWorktreeId: existingState?.activeWorktreeId,
         sidebarWidth: existingState?.sidebarWidth ?? currentAppState.sidebarWidth ?? 350,
         terminals: existingState?.terminals ?? [],
       });
-
-      console.log(
-        `[ProjectSwitch] Saved activeWorktreeId (${activeWorktreeId ?? "null"}) to project ${projectId}`
-      );
     } catch (error) {
       // Non-fatal: log but don't block the switch
       console.error("[ProjectSwitch] Failed to save outgoing project worktree state:", error);

--- a/electron/services/__tests__/ProjectSwitchService.test.ts
+++ b/electron/services/__tests__/ProjectSwitchService.test.ts
@@ -174,13 +174,16 @@ describe("ProjectSwitchService", () => {
 
     expect(result.id).toBe("project-new");
     expect(projectStoreMock.setCurrentProject).toHaveBeenCalledWith("project-new");
-    expect(projectStoreMock.saveProjectState).toHaveBeenCalledWith(
-      "project-old",
-      expect.objectContaining({
-        projectId: "project-old",
-        activeWorktreeId: "wt-old",
-      })
+    // The outgoing save preserves the per-project state and must NOT copy the
+    // main-process store's activeWorktreeId ("wt-old"), which lags the renderer
+    // and could be a stale/incidental worktree (#9512). The persisted state here
+    // has no activeWorktreeId, so the saved value is left undefined.
+    const outgoingSave = projectStoreMock.saveProjectState.mock.calls.find(
+      (c) => c[0] === "project-old"
     );
+    expect(outgoingSave).toBeDefined();
+    expect((outgoingSave![1] as { projectId?: string }).projectId).toBe("project-old");
+    expect((outgoingSave![1] as { activeWorktreeId?: string }).activeWorktreeId).toBeUndefined();
     expect(ptyClient.onProjectSwitch).toHaveBeenCalledWith(
       MOCK_WINDOW_ID,
       "project-new",
@@ -199,10 +202,14 @@ describe("ProjectSwitchService", () => {
     );
   });
 
-  it("skips outgoing project state persist when active worktree did not change", async () => {
+  it("preserves the persisted activeWorktreeId instead of the lagging main-store value (#9512)", async () => {
+    // The main-process store holds "wt-old" (a stale or incidental selection),
+    // while the per-project state already carries the correct selection,
+    // persisted by the renderer via persistOutgoingProjectState. The outgoing
+    // save must preserve "wt-root" and never resurrect the main-store value.
     projectStoreMock.getProjectState.mockResolvedValue({
       projectId: "project-old",
-      activeWorktreeId: "wt-old",
+      activeWorktreeId: "wt-root",
       sidebarWidth: 350,
       terminals: [],
     });
@@ -210,7 +217,11 @@ describe("ProjectSwitchService", () => {
     const { service } = createService();
     await service.switchProject("project-new");
 
-    expect(projectStoreMock.saveProjectState).not.toHaveBeenCalled();
+    const outgoingSave = projectStoreMock.saveProjectState.mock.calls.find(
+      (c) => c[0] === "project-old"
+    );
+    expect(outgoingSave).toBeDefined();
+    expect((outgoingSave![1] as { activeWorktreeId?: string }).activeWorktreeId).toBe("wt-root");
   });
 
   it("continues switch even when cleanup services throw synchronously", async () => {

--- a/src/store/__tests__/projectStore.switching.test.ts
+++ b/src/store/__tests__/projectStore.switching.test.ts
@@ -386,13 +386,14 @@ describe("buildOutgoingState terminal/tabGroup snapshot (#5001)", () => {
   });
 });
 
-describe("buildOutgoingState worktree selection (#5000)", () => {
-  it("includes non-root activeWorktreeId in switchProject outgoing state", async () => {
-    mockActiveWorktreeId = "wt-feature";
-
+describe("buildOutgoingState worktree selection (#5000, #9512)", () => {
+  it("persists the durable restore selection in switchProject outgoing state", async () => {
     const { useProjectStore } = await import("../projectStore");
     const { setWorktreeSelectionAccessor } = await import("../storeAccessors");
-    setWorktreeSelectionAccessor(() => ({ activeWorktreeId: mockActiveWorktreeId }));
+    setWorktreeSelectionAccessor(() => ({
+      activeWorktreeId: "wt-feature",
+      restoreWorktreeId: "wt-feature",
+    }));
     useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
 
     await useProjectStore.getState().switchProject(projectB.id);
@@ -402,12 +403,13 @@ describe("buildOutgoingState worktree selection (#5000)", () => {
     expect(outgoing.activeWorktreeId).toBe("wt-feature");
   });
 
-  it("includes non-root activeWorktreeId in reopenProject outgoing state", async () => {
-    mockActiveWorktreeId = "wt-feature";
-
+  it("persists the durable restore selection in reopenProject outgoing state", async () => {
     const { useProjectStore } = await import("../projectStore");
     const { setWorktreeSelectionAccessor } = await import("../storeAccessors");
-    setWorktreeSelectionAccessor(() => ({ activeWorktreeId: mockActiveWorktreeId }));
+    setWorktreeSelectionAccessor(() => ({
+      activeWorktreeId: "wt-feature",
+      restoreWorktreeId: "wt-feature",
+    }));
     useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
 
     await useProjectStore.getState().reopenProject(projectB.id);
@@ -417,12 +419,36 @@ describe("buildOutgoingState worktree selection (#5000)", () => {
     expect(outgoing.activeWorktreeId).toBe("wt-feature");
   });
 
-  it("converts null activeWorktreeId to undefined in outgoing state", async () => {
-    mockActiveWorktreeId = null;
-
+  it("persists the durable selection, not an incidentally-active worktree (#9512)", async () => {
+    // A batch merge left a temporary PR worktree focused/active, but the user's
+    // last deliberate selection was the root worktree. The outgoing state must
+    // carry the durable selection so switching back lands on root.
     const { useProjectStore } = await import("../projectStore");
-    const { setWorktreeSelectionAccessor } = await import("../storeAccessors");
-    setWorktreeSelectionAccessor(() => ({ activeWorktreeId: mockActiveWorktreeId }));
+    const { setWorktreeSelectionAccessor, setWorktreeIdSetAccessor } =
+      await import("../storeAccessors");
+    setWorktreeSelectionAccessor(() => ({
+      activeWorktreeId: "wt-temp-pr",
+      restoreWorktreeId: "wt-root",
+    }));
+    setWorktreeIdSetAccessor(() => new Set(["wt-root", "wt-temp-pr"]));
+    useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
+
+    await useProjectStore.getState().switchProject(projectB.id);
+    await Promise.resolve();
+
+    const outgoing = projectClientMock.switch.mock.calls[0]![1];
+    expect(outgoing.activeWorktreeId).toBe("wt-root");
+  });
+
+  it("drops a restore target that no longer exists so hydration falls back (#9512)", async () => {
+    const { useProjectStore } = await import("../projectStore");
+    const { setWorktreeSelectionAccessor, setWorktreeIdSetAccessor } =
+      await import("../storeAccessors");
+    setWorktreeSelectionAccessor(() => ({
+      activeWorktreeId: null,
+      restoreWorktreeId: "wt-removed",
+    }));
+    setWorktreeIdSetAccessor(() => new Set(["wt-root"]));
     useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
 
     await useProjectStore.getState().switchProject(projectB.id);
@@ -433,13 +459,45 @@ describe("buildOutgoingState worktree selection (#5000)", () => {
     expect("activeWorktreeId" in outgoing).toBe(true);
   });
 
-  it("includes activeWorktreeId even when terminal store getter is null (early return)", async () => {
-    mockActiveWorktreeId = "wt-early";
+  it("preserves the restore target when no view store is mounted (skip validation)", async () => {
+    const { useProjectStore } = await import("../projectStore");
+    const { setWorktreeSelectionAccessor } = await import("../storeAccessors");
+    // No setWorktreeIdSetAccessor → getWorktreeIdSet() returns null → no validation.
+    setWorktreeSelectionAccessor(() => ({
+      activeWorktreeId: "wt-feature",
+      restoreWorktreeId: "wt-feature",
+    }));
+    useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
 
+    await useProjectStore.getState().switchProject(projectB.id);
+    await Promise.resolve();
+
+    const outgoing = projectClientMock.switch.mock.calls[0]![1];
+    expect(outgoing.activeWorktreeId).toBe("wt-feature");
+  });
+
+  it("converts null restore selection to undefined in outgoing state", async () => {
+    const { useProjectStore } = await import("../projectStore");
+    const { setWorktreeSelectionAccessor } = await import("../storeAccessors");
+    setWorktreeSelectionAccessor(() => ({ activeWorktreeId: null, restoreWorktreeId: null }));
+    useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
+
+    await useProjectStore.getState().switchProject(projectB.id);
+    await Promise.resolve();
+
+    const outgoing = projectClientMock.switch.mock.calls[0]![1];
+    expect(outgoing.activeWorktreeId).toBeUndefined();
+    expect("activeWorktreeId" in outgoing).toBe(true);
+  });
+
+  it("includes the restore selection even when terminal store getter is null (early return)", async () => {
     // Don't call setPanelStoreAccessor — forces the early return path
     const { useProjectStore } = await import("../projectStore");
     const { setWorktreeSelectionAccessor } = await import("../storeAccessors");
-    setWorktreeSelectionAccessor(() => ({ activeWorktreeId: mockActiveWorktreeId }));
+    setWorktreeSelectionAccessor(() => ({
+      activeWorktreeId: "wt-early",
+      restoreWorktreeId: "wt-early",
+    }));
     useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
 
     await useProjectStore.getState().switchProject(projectB.id);

--- a/src/store/__tests__/worktreeStore.test.ts
+++ b/src/store/__tests__/worktreeStore.test.ts
@@ -562,20 +562,26 @@ describe("worktreeStore", () => {
       expect(state.restoreWorktreeId).toBe("wt-user-pick");
     });
 
-    it("selectWorktree with source 'focus' updates active but NOT the restore target", () => {
+    it("selectWorktree with source 'focus' updates active but NOT the restore target", async () => {
       // Seed a deliberate selection first.
       useWorktreeSelectionStore.getState().selectWorktree("wt-root");
       recordMruMock.mockClear();
+      appSetStateMock.mockClear();
 
       // A terminal in a temp worktree gains focus → incidental promotion.
       useWorktreeSelectionStore.getState().selectWorktree("wt-temp-pr", { source: "focus" });
+      // persistActiveWorktree defers its setState through a dynamic import; drain.
+      await Promise.resolve();
+      await Promise.resolve();
 
       const state = useWorktreeSelectionStore.getState();
       expect(state.activeWorktreeId).toBe("wt-temp-pr");
       // The durable selection stays on root, so the project round-trips to root.
       expect(state.restoreWorktreeId).toBe("wt-root");
-      // Incidental promotion must not pollute the worktree MRU.
+      // Incidental promotion must not pollute the worktree MRU…
       expect(recordMruMock).not.toHaveBeenCalledWith("worktree:wt-temp-pr");
+      // …nor persist the temp worktree to the main-process store.
+      expect(appSetStateMock).not.toHaveBeenCalledWith({ activeWorktreeId: "wt-temp-pr" });
     });
 
     it("setActiveWorktree records the durable restore target for a concrete id", () => {
@@ -623,6 +629,18 @@ describe("worktreeStore", () => {
       useWorktreeSelectionStore.getState().selectWorktree("wt-temp");
 
       expect(useWorktreeSelectionStore.getState().restoreWorktreeId).toBe("wt-temp");
+    });
+
+    it("setActiveWorktree(null) leaves an already-null restore target untouched", () => {
+      // A worktree became active only via focus promotion; no durable selection
+      // was ever made.
+      useWorktreeSelectionStore.getState().selectWorktree("wt-temp", { source: "focus" });
+      expect(useWorktreeSelectionStore.getState().restoreWorktreeId).toBeNull();
+
+      // The incidentally-active worktree is removed.
+      useWorktreeSelectionStore.getState().setActiveWorktree(null);
+
+      expect(useWorktreeSelectionStore.getState().restoreWorktreeId).toBeNull();
     });
 
     it("reset clears the restore target", () => {
@@ -734,6 +752,24 @@ describe("worktreeStore", () => {
       const state = useWorktreeSelectionStore.getState();
       expect(state.isFleetScopeActive).toBe(false);
       expect(state.activeWorktreeId).toBe("wt-current");
+    });
+
+    it("preserves the durable restore selection across a fleet-scope cycle after a focus promotion (#9512)", () => {
+      // User deliberately selects root, then a temp worktree gains focus
+      // (incidental). The durable selection is root; the active is temp.
+      useWorktreeSelectionStore.getState().selectWorktree("wt-root");
+      useWorktreeSelectionStore.getState().selectWorktree("wt-temp", { source: "focus" });
+      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-temp");
+      expect(useWorktreeSelectionStore.getState().restoreWorktreeId).toBe("wt-root");
+
+      const token = useWorktreeSelectionStore.getState().enterFleetScope();
+      useWorktreeSelectionStore.getState().exitFleetScope(token);
+
+      // Exiting scope restores the pre-scope active worktree, but the durable
+      // restore target must remain root so switch-back lands on root.
+      const state = useWorktreeSelectionStore.getState();
+      expect(state.activeWorktreeId).toBe("wt-temp");
+      expect(state.restoreWorktreeId).toBe("wt-root");
     });
 
     it("reset clears fleet scope state", () => {

--- a/src/store/__tests__/worktreeStore.test.ts
+++ b/src/store/__tests__/worktreeStore.test.ts
@@ -553,6 +553,88 @@ describe("worktreeStore", () => {
     expect(setFocusedMock).not.toHaveBeenCalledWith("term-a");
   });
 
+  describe("durable restore selection (#9512)", () => {
+    it("selectWorktree (default user source) records the durable restore target", () => {
+      useWorktreeSelectionStore.getState().selectWorktree("wt-user-pick");
+
+      const state = useWorktreeSelectionStore.getState();
+      expect(state.activeWorktreeId).toBe("wt-user-pick");
+      expect(state.restoreWorktreeId).toBe("wt-user-pick");
+    });
+
+    it("selectWorktree with source 'focus' updates active but NOT the restore target", () => {
+      // Seed a deliberate selection first.
+      useWorktreeSelectionStore.getState().selectWorktree("wt-root");
+      recordMruMock.mockClear();
+
+      // A terminal in a temp worktree gains focus → incidental promotion.
+      useWorktreeSelectionStore.getState().selectWorktree("wt-temp-pr", { source: "focus" });
+
+      const state = useWorktreeSelectionStore.getState();
+      expect(state.activeWorktreeId).toBe("wt-temp-pr");
+      // The durable selection stays on root, so the project round-trips to root.
+      expect(state.restoreWorktreeId).toBe("wt-root");
+      // Incidental promotion must not pollute the worktree MRU.
+      expect(recordMruMock).not.toHaveBeenCalledWith("worktree:wt-temp-pr");
+    });
+
+    it("setActiveWorktree records the durable restore target for a concrete id", () => {
+      useWorktreeSelectionStore.getState().setActiveWorktree("wt-card-click");
+
+      const state = useWorktreeSelectionStore.getState();
+      expect(state.activeWorktreeId).toBe("wt-card-click");
+      expect(state.restoreWorktreeId).toBe("wt-card-click");
+    });
+
+    it("setActiveWorktree(null) clears the restore target when the cleared worktree WAS durable", () => {
+      // The active worktree is also the durable selection (a feature worktree
+      // the user deliberately selected), then it gets removed.
+      useWorktreeSelectionStore.getState().setActiveWorktree("wt-feature");
+      expect(useWorktreeSelectionStore.getState().restoreWorktreeId).toBe("wt-feature");
+
+      useWorktreeSelectionStore.getState().setActiveWorktree(null);
+
+      const state = useWorktreeSelectionStore.getState();
+      expect(state.activeWorktreeId).toBeNull();
+      expect(state.restoreWorktreeId).toBeNull();
+    });
+
+    it("setActiveWorktree(null) preserves the restore target when a focus-promoted worktree is cleared", () => {
+      // Durable selection = root; a temp worktree is only incidentally active.
+      useWorktreeSelectionStore.getState().selectWorktree("wt-root");
+      useWorktreeSelectionStore.getState().selectWorktree("wt-temp-pr", { source: "focus" });
+      expect(useWorktreeSelectionStore.getState().restoreWorktreeId).toBe("wt-root");
+
+      // The temp worktree is torn down → active cleared.
+      useWorktreeSelectionStore.getState().setActiveWorktree(null);
+
+      const state = useWorktreeSelectionStore.getState();
+      expect(state.activeWorktreeId).toBeNull();
+      // Root remains the restore target so switch-back lands on root.
+      expect(state.restoreWorktreeId).toBe("wt-root");
+    });
+
+    it("re-selecting the already-active worktree as a user action upgrades it to durable", () => {
+      // Worktree became active only via focus promotion (no durable selection).
+      useWorktreeSelectionStore.getState().selectWorktree("wt-temp", { source: "focus" });
+      expect(useWorktreeSelectionStore.getState().restoreWorktreeId).toBeNull();
+
+      // User then deliberately clicks the same worktree.
+      useWorktreeSelectionStore.getState().selectWorktree("wt-temp");
+
+      expect(useWorktreeSelectionStore.getState().restoreWorktreeId).toBe("wt-temp");
+    });
+
+    it("reset clears the restore target", () => {
+      useWorktreeSelectionStore.getState().selectWorktree("wt-x");
+      expect(useWorktreeSelectionStore.getState().restoreWorktreeId).toBe("wt-x");
+
+      useWorktreeSelectionStore.getState().reset();
+
+      expect(useWorktreeSelectionStore.getState().restoreWorktreeId).toBeNull();
+    });
+  });
+
   describe("fleet scope", () => {
     it("starts inactive with no previous worktree or token captured", () => {
       const state = useWorktreeSelectionStore.getState();

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -19,6 +19,7 @@ import {
   clearFleetArmingThroughAccessor,
   getPanelStoreSnapshot,
   getWorktreeSelectionSnapshot,
+  getWorktreeIdSet,
 } from "./storeAccessors";
 import type { ProjectSwitchOutgoingState } from "@shared/types/ipc/project";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
@@ -41,7 +42,18 @@ function shouldPersistTerminal(t: NonNullable<CarrierPanel>): boolean {
 
 function buildOutgoingState(projectId: string): ProjectSwitchOutgoingState {
   const draftInputs = useTerminalInputStore.getState().getProjectDraftInputs(projectId);
-  const activeWorktreeId = getWorktreeSelectionSnapshot()?.activeWorktreeId ?? undefined;
+  // Persist the *durable* selection, not whatever is incidentally active. A
+  // focus promotion (e.g. a temporary PR worktree spun up by a batch merge)
+  // leaves `restoreWorktreeId` pointing at the last deliberate selection, so it
+  // round-trips correctly on switch-back (#9512). Validate it against the
+  // current view's worktrees: if it was removed before the switch, send
+  // `undefined` so hydration falls back to the main worktree instead of
+  // resurrecting a stale id. When no view store is mounted (`null`), skip
+  // validation and preserve the candidate.
+  const restoreId = getWorktreeSelectionSnapshot()?.restoreWorktreeId ?? undefined;
+  const knownIds = getWorktreeIdSet();
+  const activeWorktreeId =
+    restoreId && (knownIds === null || knownIds.has(restoreId)) ? restoreId : undefined;
 
   // Synchronously snapshot terminal state from the Zustand store before the
   // renderer gets detached.  This captures browser/dev-preview panel state

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -17,11 +17,13 @@ import {
   setPanelStoreAccessor,
   setPanelStoreClearForSwitchAccessor,
   setWorktreeSelectionAccessor,
+  setWorktreeIdSetAccessor,
   setFleetArmingClearAccessor,
   setFleetArmedIdsAccessor,
   setFleetLastArmedIdAccessor,
   resetStoreAccessorsForTesting,
 } from "./storeAccessors";
+import { getCurrentViewStoreOrNull } from "./createWorktreeStore";
 import { setActiveContextAccessors } from "@/lib/notify";
 import { debounce } from "@/utils/debounce";
 import { DisposableStore, toDisposable } from "@/utils/disposable";
@@ -50,7 +52,13 @@ export function initStoreOrchestrator(): () => void {
   });
   setWorktreeSelectionAccessor(() => ({
     activeWorktreeId: useWorktreeSelectionStore.getState().activeWorktreeId,
+    restoreWorktreeId: useWorktreeSelectionStore.getState().restoreWorktreeId,
   }));
+  setWorktreeIdSetAccessor(() => {
+    const viewStore = getCurrentViewStoreOrNull();
+    if (!viewStore) return null;
+    return new Set(viewStore.getState().worktrees.keys());
+  });
   setFleetArmingClearAccessor(() => {
     useFleetArmingStore.getState().clear();
   });
@@ -110,7 +118,9 @@ export function initStoreOrchestrator(): () => void {
           if (!terminal?.worktreeId) return;
           const worktreeState = useWorktreeSelectionStore.getState();
           if (terminal.worktreeId !== worktreeState.activeWorktreeId) {
-            worktreeState.selectWorktree(terminal.worktreeId);
+            // Focus promotion is incidental, not a deliberate selection: mark it
+            // so it doesn't become the persisted restore target (#9512).
+            worktreeState.selectWorktree(terminal.worktreeId, { source: "focus" });
           }
         }
       )

--- a/src/store/storeAccessors.ts
+++ b/src/store/storeAccessors.ts
@@ -15,10 +15,13 @@ export interface PanelStoreSnapshot {
 
 export interface WorktreeSelectionSnapshot {
   activeWorktreeId: string | null;
+  /** Durable selection that should round-trip across project switches (#9512). */
+  restoreWorktreeId: string | null;
 }
 
 let _getPanelStoreState: (() => PanelStoreSnapshot) | null = null;
 let _getWorktreeSelectionState: (() => WorktreeSelectionSnapshot) | null = null;
+let _getWorktreeIdSet: (() => Set<string> | null) | null = null;
 let _clearPanelStoreForSwitch: (() => void) | null = null;
 let _clearFleetArming: (() => void) | null = null;
 let _getFleetArmedIds: (() => Set<string>) | null = null;
@@ -38,6 +41,19 @@ export function setWorktreeSelectionAccessor(getter: () => WorktreeSelectionSnap
 
 export function getWorktreeSelectionSnapshot(): WorktreeSelectionSnapshot | null {
   return _getWorktreeSelectionState?.() ?? null;
+}
+
+export function setWorktreeIdSetAccessor(getter: () => Set<string> | null): void {
+  _getWorktreeIdSet = getter;
+}
+
+/**
+ * The set of worktree IDs known to the current project view, or `null` when no
+ * view store is mounted (validation should be skipped). Lets the outgoing-state
+ * builder drop a stale restore target that no longer exists (#9512).
+ */
+export function getWorktreeIdSet(): Set<string> | null {
+  return _getWorktreeIdSet?.() ?? null;
 }
 
 export function setPanelStoreClearForSwitchAccessor(callback: () => void): void {
@@ -75,6 +91,7 @@ export function getFleetLastArmedId(): string | null {
 export function resetStoreAccessorsForTesting(): void {
   _getPanelStoreState = null;
   _getWorktreeSelectionState = null;
+  _getWorktreeIdSet = null;
   _clearPanelStoreForSwitch = null;
   _clearFleetArming = null;
   _getFleetArmedIds = null;

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -74,6 +74,8 @@ interface WorktreeSelectionState {
   lastFocusedTerminalByWorktree: Map<string, string>;
   isFleetScopeActive: boolean;
   _previousActiveWorktreeId: string | null;
+  /** Durable selection captured at fleet-scope entry, restored on exit (#9512). */
+  _previousRestoreWorktreeId: string | null;
   _fleetScopeToken: FleetScopeToken | null;
 
   setActiveWorktree: (id: string | null) => void;
@@ -264,6 +266,7 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
   lastFocusedTerminalByWorktree: new Map<string, string>(),
   isFleetScopeActive: false,
   _previousActiveWorktreeId: null,
+  _previousRestoreWorktreeId: null,
   _fleetScopeToken: null,
 
   setActiveWorktree: (id) => {
@@ -674,6 +677,9 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     set({
       isFleetScopeActive: true,
       _previousActiveWorktreeId: activeWorktreeId,
+      // Snapshot the durable selection too so exiting scope can't downgrade an
+      // incidentally-active worktree into the persisted restore target (#9512).
+      _previousRestoreWorktreeId: get().restoreWorktreeId,
       _fleetScopeToken: token,
       _policyGeneration: generation,
     });
@@ -706,6 +712,7 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     // stale exit apart from a legitimate one.
     if (get()._fleetScopeToken !== token) return;
     const restoreId = get()._previousActiveWorktreeId;
+    const previousRestoreId = get()._previousRestoreWorktreeId;
     const generation = get()._policyGeneration + 1;
     // Snapshot the primary (most-recently-armed) terminal BEFORE `set()` so
     // the value used for focus restore is stable against any reads/writes
@@ -714,8 +721,12 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     set({
       isFleetScopeActive: false,
       _previousActiveWorktreeId: null,
+      _previousRestoreWorktreeId: null,
       _fleetScopeToken: null,
       activeWorktreeId: restoreId,
+      // Restore the durable selection captured at entry so a focus-promotion
+      // that happened before scope entry survives the cycle (#9512).
+      restoreWorktreeId: previousRestoreId,
       focusedWorktreeId: restoreId,
       _policyGeneration: generation,
     });
@@ -784,6 +795,7 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       lastFocusedTerminalByWorktree: new Map<string, string>(),
       isFleetScopeActive: false,
       _previousActiveWorktreeId: null,
+      _previousRestoreWorktreeId: null,
       _fleetScopeToken: null,
       // Bump the generation so any in-flight deferred policy/focus-restore
       // microtask (which captured an older generation) sees a mismatch and

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -50,6 +50,17 @@ interface CrossDiffDialogState {
 
 interface WorktreeSelectionState {
   activeWorktreeId: string | null;
+  /**
+   * The last *durable* worktree selection — the one that should round-trip
+   * across project switches. Diverges from `activeWorktreeId` when a worktree
+   * becomes active incidentally (a terminal in another worktree gains focus;
+   * see `selectWorktree({ source: "focus" })`). Such focus promotions update
+   * `activeWorktreeId` for the session but must not become the persisted
+   * restore point, or an unrelated operation (e.g. a batch PR merge spinning up
+   * temporary worktrees) could leave the project restoring a stray temp
+   * worktree instead of root (#9512).
+   */
+  restoreWorktreeId: string | null;
   focusedWorktreeId: string | null;
   pendingWorktreeId: string | null;
   pendingCreations: Map<string, PendingCreation>;
@@ -67,7 +78,7 @@ interface WorktreeSelectionState {
 
   setActiveWorktree: (id: string | null) => void;
   setFocusedWorktree: (id: string | null) => void;
-  selectWorktree: (id: string) => void;
+  selectWorktree: (id: string, options?: { source?: "user" | "focus" }) => void;
   setPendingWorktree: (id: string | null) => void;
   applyPendingWorktreeSelection: (worktreeId: string) => void;
   addPendingCreation: (path: string, meta: { branch: string }) => void;
@@ -226,6 +237,7 @@ function persistActiveWorktree(id: string | null): void {
 
 const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set, get) => ({
   activeWorktreeId: null,
+  restoreWorktreeId: null,
   focusedWorktreeId: null,
   pendingWorktreeId: null,
   pendingCreations: new Map<string, PendingCreation>(),
@@ -270,6 +282,18 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       _policyGeneration: generation,
     };
 
+    if (id !== null) {
+      // An explicit activation is a durable selection — make it the restore
+      // target so switching projects round-trips back to it (#9512).
+      updates.restoreWorktreeId = id;
+    } else if (previousId !== null && previousId === get().restoreWorktreeId) {
+      // Active worktree cleared (e.g. it was removed) AND it was the durable
+      // selection: drop the restore target so the project falls back to the
+      // main worktree on return. If the cleared worktree was only incidentally
+      // active (focus-promoted), the durable selection is left intact (#9512).
+      updates.restoreWorktreeId = null;
+    }
+
     if (previousId !== id) {
       updates.expandedTerminals = new Set<string>();
     }
@@ -289,13 +313,27 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
 
   setFocusedWorktree: (id) => set({ focusedWorktreeId: id }),
 
-  selectWorktree: (id) => {
+  selectWorktree: (id, options) => {
+    // `"user"` (default) is a deliberate selection: it becomes the durable
+    // restore target, is persisted to the main-process store, and is recorded
+    // in the MRU. `"focus"` is an incidental promotion (a terminal in another
+    // worktree gained focus) — it updates the active worktree for the session
+    // only, so it never pollutes the persisted restore point or the MRU (#9512).
+    const source = options?.source ?? "user";
+
     // Skip if already active to prevent terminal reload flicker.
     // Also clear any pending selection for this ID — it's already active,
     // so the terminal policy was applied when we first selected it.
     if (get().activeWorktreeId === id) {
       if (get().pendingWorktreeId === id) {
         set({ pendingWorktreeId: null });
+      }
+      // A deliberate re-selection of the already-active worktree still confirms
+      // it as the durable restore target (it may have been activated only via
+      // focus promotion before).
+      if (source === "user" && get().restoreWorktreeId !== id) {
+        set({ restoreWorktreeId: id });
+        persistActiveWorktree(id);
       }
       return;
     }
@@ -313,14 +351,17 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       focusedWorktreeId: id,
       _policyGeneration: generation,
       expandedTerminals: new Set<string>(),
+      ...(source === "user" ? { restoreWorktreeId: id } : {}),
     });
 
-    persistActiveWorktree(id);
+    if (source === "user") {
+      persistActiveWorktree(id);
 
-    // Record worktree MRU on explicit selection (suppressed during hydration)
-    if (!mruRecordingSuppressed) {
-      usePanelStore.getState().recordMru(`worktree:${id}`);
-      persistMruList(usePanelStore.getState().mruList);
+      // Record worktree MRU on explicit selection (suppressed during hydration)
+      if (!mruRecordingSuppressed) {
+        usePanelStore.getState().recordMru(`worktree:${id}`);
+        persistMruList(usePanelStore.getState().mruList);
+      }
     }
 
     applyWorktreeTerminalPolicy(get, set, id, generation, () => {
@@ -717,6 +758,7 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
   reset: () =>
     set({
       activeWorktreeId: null,
+      restoreWorktreeId: null,
       focusedWorktreeId: null,
       pendingWorktreeId: null,
       pendingCreations: new Map<string, PendingCreation>(),

--- a/src/utils/stateHydration/__tests__/selectFallbackWorktree.test.ts
+++ b/src/utils/stateHydration/__tests__/selectFallbackWorktree.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { selectFallbackWorktree } from "../index";
+
+type TestWorktree = { id: string; name: string; isMainWorktree?: boolean };
+
+describe("selectFallbackWorktree (#9512)", () => {
+  it("prefers the main worktree even when a temp worktree sorts first alphabetically", () => {
+    const worktrees: TestWorktree[] = [
+      { id: "wt-aaa-temp", name: "aaa-issue-1-fix", isMainWorktree: false },
+      { id: "wt-root", name: "daintree", isMainWorktree: true },
+      { id: "wt-bbb-temp", name: "bbb-issue-2-fix", isMainWorktree: false },
+    ];
+
+    expect(selectFallbackWorktree(worktrees)?.id).toBe("wt-root");
+  });
+
+  it("treats an absent isMainWorktree flag as non-main and never picks it over the real main", () => {
+    const worktrees: TestWorktree[] = [
+      { id: "wt-aaa-temp", name: "aaa-temp" }, // isMainWorktree undefined
+      { id: "wt-root", name: "zzz-root", isMainWorktree: true },
+    ];
+
+    // Even though "aaa-temp" sorts first, the main worktree wins.
+    expect(selectFallbackWorktree(worktrees)?.id).toBe("wt-root");
+  });
+
+  it("falls back to the alphabetically-first worktree when none is main", () => {
+    const worktrees: TestWorktree[] = [
+      { id: "wt-charlie", name: "charlie", isMainWorktree: false },
+      { id: "wt-alpha", name: "alpha", isMainWorktree: false },
+      { id: "wt-bravo", name: "bravo" },
+    ];
+
+    expect(selectFallbackWorktree(worktrees)?.id).toBe("wt-alpha");
+  });
+
+  it("returns undefined for an empty list", () => {
+    expect(selectFallbackWorktree([])).toBeUndefined();
+  });
+
+  it("returns the only worktree when the list has one entry", () => {
+    const worktrees: TestWorktree[] = [{ id: "wt-only", name: "only" }];
+    expect(selectFallbackWorktree(worktrees)?.id).toBe("wt-only");
+  });
+});

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -38,6 +38,24 @@ import { restorePanelsPhase } from "./panelRestorePhase";
 const CLIPBOARD_DIR_NAME = "daintree-clipboard";
 const VERBOSE_HYDRATION_LOGGING = isDaintreeEnvEnabled("DAINTREE_VERBOSE");
 
+/**
+ * Pick the worktree to activate when the saved selection no longer exists.
+ *
+ * Always prefers the main worktree so a stale/removed saved selection never
+ * lands on a leftover temporary PR worktree whose name happens to sort first
+ * (#9512). Only when there is no main worktree does it fall back to the
+ * alphabetically-first one. Returns `undefined` for an empty list.
+ */
+export function selectFallbackWorktree<
+  T extends { id: string; name: string; isMainWorktree?: boolean },
+>(worktrees: readonly T[]): T | undefined {
+  if (worktrees.length === 0) return undefined;
+  return (
+    worktrees.find((wt) => wt.isMainWorktree === true) ??
+    [...worktrees].sort((a, b) => a.name.localeCompare(b.name))[0]
+  );
+}
+
 function logHydrationInfo(message: string, context?: Record<string, unknown>): void {
   if (!VERBOSE_HYDRATION_LOGGING) return;
   logInfo(message, context);
@@ -501,13 +519,9 @@ export async function hydrateAppState(
         // Restore the saved active worktree
         setActiveWorktree(savedActiveId);
       } else {
-        // Fallback to the first worktree (main worktree is typically first)
-        const sortedWorktrees = [...worktrees].sort((a, b) => {
-          if (a.isMainWorktree && !b.isMainWorktree) return -1;
-          if (!a.isMainWorktree && b.isMainWorktree) return 1;
-          return a.name.localeCompare(b.name);
-        });
-        const fallbackWorktree = sortedWorktrees[0]!;
+        // Fallback when the saved selection no longer exists — prefers the main
+        // worktree so we never land on a leftover temporary PR worktree (#9512).
+        const fallbackWorktree = selectFallbackWorktree(worktrees)!;
         logHydrationInfo(
           `Active worktree ${savedActiveId ?? "(none)"} not found, falling back to: ${fallbackWorktree.name}`
         );


### PR DESCRIPTION
## Summary

After a batch PR-merge run (which spins up and tears down many temporary worktrees), switching away from a project and back was restoring a leftover temporary PR worktree instead of the root worktree the user was actually working in. Three issues compounded to produce this:

1. **Incidental focus promotion**: when a terminal in a temporary worktree gained focus, `selectWorktree` promoted that worktree to the active selection and persisted it as the project's restore point, even though the user hadn't consciously navigated there.
2. **Stale main-process read**: the legacy `ProjectSwitchService` path read `activeWorktreeId` from the electron-store snapshot in the main process, which lagged behind renderer-authored selections.
3. **Unreliable fallback**: when the saved worktree no longer existed, `selectFallbackWorktree` sorted by `isMainWorktree` first, but that flag isn't always populated — so an alphabetically-sorted temp worktree could win.

## Changes

- **`restoreWorktreeId`**: the worktree selection store now tracks the durable restore target separately from the in-session `activeWorktreeId`.
- **`selectWorktree` provenance**: a `{ source: "user" | "focus" }` option distinguishes intentional navigation from incidental focus changes. Focus-sourced calls update `activeWorktreeId` for the session only — they no longer write `restoreWorktreeId`, persist to the main store, or record MRU.
- **Outgoing-state validation**: `buildOutgoingState` validates `restoreWorktreeId` against the current worktree list before persisting. A worktree removed before the switch is dropped so hydration falls through to the main worktree cleanly.
- **`saveOutgoingProjectWorktreeState`**: no longer copies the lagging main-store `activeWorktreeId`; it preserves the renderer-authored per-project value.
- **Fleet-scope cycle**: enter/exit preserves `restoreWorktreeId` across the cycle.
- **`selectFallbackWorktree`**: always prefers the main worktree by `path` comparison — never lands on a leftover temp PR worktree.

## Testing

New unit tests in `worktreeStore.test.ts`, `projectStore.switching.test.ts`, `ProjectSwitchService.test.ts`, and `selectFallbackWorktree.test.ts` covering: focus-vs-user provenance, outgoing-state validation, fleet-scope cycle, Path B preservation, and the fallback helper.

Resolves #9512