### PR TITLE
feat(plugin-mcp): lazy two-tier tool discovery with crash-recovery refetch

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -829,6 +829,13 @@ export const CHANNELS = {
   PLUGIN_MCP_LIST: "plugin-mcp:list",
   PLUGIN_MCP_GET_STDERR: "plugin-mcp:get-stderr",
   PLUGIN_MCP_RESTART: "plugin-mcp:restart",
+  // Lazy two-tier tool discovery (#9235): tier-1 summaries on demand and the
+  // tier-2 full schema for a single selected tool.
+  PLUGIN_MCP_LIST_TOOLS: "plugin-mcp:list-tools",
+  PLUGIN_MCP_GET_FULL_SCHEMA: "plugin-mcp:get-full-schema",
+  // Advanced tuning: the global tool-count cap surfaced as a setting (#9235).
+  PLUGIN_MCP_GET_CONFIG: "plugin-mcp:get-config",
+  PLUGIN_MCP_SET_CONFIG: "plugin-mcp:set-config",
 
   // Config reload channels
   APP_RELOAD_CONFIG: "app:reload-config",

--- a/electron/ipc/handlers/pluginMcp.preload.ts
+++ b/electron/ipc/handlers/pluginMcp.preload.ts
@@ -4,6 +4,10 @@ export const PLUGIN_MCP_METHOD_CHANNELS = {
   list: "plugin-mcp:list",
   getStderr: "plugin-mcp:get-stderr",
   restart: "plugin-mcp:restart",
+  listTools: "plugin-mcp:list-tools",
+  getFullSchema: "plugin-mcp:get-full-schema",
+  getConfig: "plugin-mcp:get-config",
+  setConfig: "plugin-mcp:set-config",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof PLUGIN_MCP_METHOD_CHANNELS;

--- a/electron/ipc/handlers/pluginMcp.ts
+++ b/electron/ipc/handlers/pluginMcp.ts
@@ -2,10 +2,18 @@ import { defineIpcNamespace, op } from "../define.js";
 import { PLUGIN_MCP_METHOD_CHANNELS } from "./pluginMcp.preload.js";
 import { getPluginMcpSupervisor } from "../../services/PluginMcpSupervisor.js";
 import { pluginService } from "../../services/PluginService.js";
-import type {
-  PluginMcpServerInfo,
-  PluginMcpServerKey,
-  PluginMcpStderrResult,
+import { store } from "../../store.js";
+import {
+  PLUGIN_MCP_DEFAULT_MAX_TOOLS_PER_SESSION,
+  PLUGIN_MCP_MAX_MAX_TOOLS_PER_SESSION,
+  PLUGIN_MCP_MIN_MAX_TOOLS_PER_SESSION,
+  type PluginMcpConfig,
+  type PluginMcpGetFullSchemaResult,
+  type PluginMcpListToolsResult,
+  type PluginMcpServerInfo,
+  type PluginMcpServerKey,
+  type PluginMcpStderrResult,
+  type PluginMcpToolKey,
 } from "../../../shared/types/ipc/pluginMcp.js";
 
 async function handleList(): Promise<PluginMcpServerInfo[]> {
@@ -14,6 +22,49 @@ async function handleList(): Promise<PluginMcpServerInfo[]> {
 
 async function handleGetStderr(key: PluginMcpServerKey): Promise<PluginMcpStderrResult> {
   return getPluginMcpSupervisor().getStderr(key.pluginId, key.serverId);
+}
+
+/**
+ * Resolve the plugin's contribution and lazily spawn its MCP server (idempotent
+ * — a no-op if already running), then return tier-1 tool summaries (#9235).
+ * Spawning here, on first enumeration, is the lazy-discovery contract: plugin
+ * activation no longer eagerly starts MCP subprocesses.
+ */
+async function handleListTools(key: PluginMcpServerKey): Promise<PluginMcpListToolsResult> {
+  await ensureServerStarted(key);
+  const cfg = store.get("pluginMcpConfig") as { maxToolsPerSession?: unknown } | undefined;
+  return getPluginMcpSupervisor().listTools(
+    key.pluginId,
+    key.serverId,
+    clampMaxTools(cfg?.maxToolsPerSession)
+  );
+}
+
+/** Tier-2 lookup: the full input schema for a single agent-selected tool (#9235). */
+async function handleGetFullSchema(key: PluginMcpToolKey): Promise<PluginMcpGetFullSchemaResult> {
+  await ensureServerStarted(key);
+  return getPluginMcpSupervisor().getFullSchema(key.pluginId, key.serverId, key.toolName);
+}
+
+/**
+ * Look up the live contribution and (idempotently) start its supervised server.
+ * Resolution happens at the handler boundary — same pattern as
+ * {@link handleRestart} — so the supervisor stays decoupled from `PluginService`
+ * and never holds a stale `resolveSettings` closure across a plugin reload.
+ */
+async function ensureServerStarted(key: PluginMcpServerKey): Promise<void> {
+  const lookup = pluginService.findMcpServerContribution(key.pluginId, key.serverId);
+  if (!lookup) {
+    throw new Error(
+      `Cannot enumerate tools for "${key.pluginId}/${key.serverId}": plugin or server is not registered`
+    );
+  }
+  await getPluginMcpSupervisor().start({
+    pluginId: key.pluginId,
+    pluginDir: lookup.pluginDir,
+    contributions: [lookup.contribution],
+    resolveSettings: (settingId) => pluginService.resolveSettingTemplate(key.pluginId, settingId),
+  });
 }
 
 /**
@@ -40,12 +91,43 @@ async function handleRestart(key: PluginMcpServerKey): Promise<void> {
   });
 }
 
+/**
+ * Read the advanced plugin-MCP config (#9235). Falls back to the default cap if
+ * the persisted value is absent or out of range — the supervisor applies the
+ * same clamp at enumeration time, so this only normalises what the UI shows.
+ */
+async function handleGetConfig(): Promise<PluginMcpConfig> {
+  const cfg = store.get("pluginMcpConfig") as { maxToolsPerSession?: unknown } | undefined;
+  return { maxToolsPerSession: clampMaxTools(cfg?.maxToolsPerSession) };
+}
+
+/** Persist the advanced plugin-MCP config, clamping the cap to a sane range. */
+async function handleSetConfig(config: PluginMcpConfig): Promise<PluginMcpConfig> {
+  const next: PluginMcpConfig = { maxToolsPerSession: clampMaxTools(config.maxToolsPerSession) };
+  store.set("pluginMcpConfig", next);
+  return next;
+}
+
+function clampMaxTools(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return PLUGIN_MCP_DEFAULT_MAX_TOOLS_PER_SESSION;
+  }
+  const floored = Math.floor(value);
+  if (floored < PLUGIN_MCP_MIN_MAX_TOOLS_PER_SESSION) return PLUGIN_MCP_MIN_MAX_TOOLS_PER_SESSION;
+  if (floored > PLUGIN_MCP_MAX_MAX_TOOLS_PER_SESSION) return PLUGIN_MCP_MAX_MAX_TOOLS_PER_SESSION;
+  return floored;
+}
+
 export const pluginMcpNamespace = defineIpcNamespace({
   name: "pluginMcp",
   ops: {
     list: op(PLUGIN_MCP_METHOD_CHANNELS.list, handleList),
     getStderr: op(PLUGIN_MCP_METHOD_CHANNELS.getStderr, handleGetStderr),
     restart: op(PLUGIN_MCP_METHOD_CHANNELS.restart, handleRestart),
+    listTools: op(PLUGIN_MCP_METHOD_CHANNELS.listTools, handleListTools),
+    getFullSchema: op(PLUGIN_MCP_METHOD_CHANNELS.getFullSchema, handleGetFullSchema),
+    getConfig: op(PLUGIN_MCP_METHOD_CHANNELS.getConfig, handleGetConfig),
+    setConfig: op(PLUGIN_MCP_METHOD_CHANNELS.setConfig, handleSetConfig),
   },
 });
 

--- a/electron/services/PluginMcpSupervisor.ts
+++ b/electron/services/PluginMcpSupervisor.ts
@@ -1,9 +1,15 @@
 import { z } from "zod";
 import {
+  PLUGIN_MCP_DEFAULT_MAX_TOOLS_PER_SESSION,
   PLUGIN_MCP_STDERR_RING_LINES,
+  PLUGIN_MCP_TOOL_DESCRIPTION_CAP,
+  type PluginMcpFullTool,
+  type PluginMcpGetFullSchemaResult,
+  type PluginMcpListToolsResult,
   type PluginMcpServerInfo,
   type PluginMcpServerStatus,
   type PluginMcpStderrResult,
+  type PluginMcpToolSummary,
 } from "../../shared/types/ipc/pluginMcp.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { McpServerContributionSchema } from "../schemas/plugin.js";
@@ -105,6 +111,26 @@ interface SupervisedServerState {
   readyPromise: Promise<void> | null;
   /** Stdout NDJSON parse buffer carryover across stream chunks. */
   stdoutBuffer: string;
+  /**
+   * Lazily-fetched `tools/list` result (#9235), full tier-2 entries with input
+   * schemas. `null` means "not yet fetched, or invalidated by a crash/restart
+   * or a `notifications/tools/list_changed`". Never holds stale data across a
+   * subprocess exit — see {@link handleSubprocessExit}.
+   */
+  toolsCache: PluginMcpFullTool[] | null;
+  /**
+   * Singleflight guard for {@link fetchToolsList} — concurrent enumerations
+   * (multiple agent panes hitting `plugin-mcp:list-tools` before the cache
+   * warms) share one in-flight `tools/list` round instead of each spawning a
+   * fresh request. Cleared in `.finally()`. See lessons #4832 / #4441.
+   */
+  toolsListInflight: Promise<PluginMcpFullTool[]> | null;
+  /**
+   * Count of tools this server contributed to the last enumeration AFTER the
+   * global per-session cap was applied. Summed across the other servers to
+   * compute the remaining budget so the ~200 cap spans all servers, not each.
+   */
+  surfacedToolCount: number;
 }
 
 const HANDSHAKE_TIMEOUT_MS = 15_000;
@@ -202,6 +228,9 @@ export class PluginMcpSupervisor {
       pendingCalls: new Map(),
       readyPromise: null,
       stdoutBuffer: "",
+      toolsCache: null,
+      toolsListInflight: null,
+      surfacedToolCount: 0,
     };
     // Reset transient fields for a restart of a previously-stopped/crashed
     // entry. A "crashed" entry may still hold a live subprocess (e.g. the
@@ -223,6 +252,12 @@ export class PluginMcpSupervisor {
       state.nextRequestId = 1;
       state.pendingCalls.clear();
       state.stdoutBuffer = "";
+      // A restart may bring up a server with a different tool surface — discard
+      // the previous tool cache so the next enumeration refetches and re-runs
+      // the TOFU comparison (#9235).
+      state.toolsCache = null;
+      state.toolsListInflight = null;
+      state.surfacedToolCount = 0;
       // Restart marker so the log viewer can tell pre-restart and post-restart
       // output apart inside the bounded ring without a separate UI mode.
       this.appendStderrLine(state, `--- restarted at ${new Date().toISOString()} ---`);
@@ -405,7 +440,12 @@ export class PluginMcpSupervisor {
       return;
     }
     if (!parsed || typeof parsed !== "object") return;
-    const message = parsed as { id?: unknown; result?: unknown; error?: unknown };
+    const message = parsed as {
+      id?: unknown;
+      result?: unknown;
+      error?: unknown;
+      method?: unknown;
+    };
     if (typeof message.id === "number") {
       const pending = state.pendingCalls.get(message.id);
       if (!pending) return;
@@ -420,8 +460,18 @@ export class PluginMcpSupervisor {
       } else {
         pending.resolve(message.result);
       }
+      return;
     }
-    // Notifications (no id) are ignored — we don't subscribe to any.
+    // The server advertised that its tool set changed mid-session. The spec
+    // marks this notification best-effort, so it's only a fast-path refresh —
+    // crash/restart invalidation does NOT depend on it (#9235). Drop the cache
+    // so the next enumeration refetches; leave any in-flight fetch to settle.
+    if (message.method === "notifications/tools/list_changed") {
+      state.toolsCache = null;
+      state.surfacedToolCount = 0;
+      return;
+    }
+    // Other notifications (no id) are ignored — we don't subscribe to any.
   }
 
   private attachStderrReader(state: SupervisedServerState): void {
@@ -463,6 +513,14 @@ export class PluginMcpSupervisor {
     }
     state.pid = null;
     state.subprocess = null;
+    // Invalidate the tool cache on crash so a post-restart enumeration refetches
+    // and the TOFU comparator re-runs against the consent store before any tool
+    // is re-injected (#9235). An in-flight fetch's pending call is rejected by
+    // the loop below; its `.finally()` clears `toolsListInflight` (the identity
+    // guard there tolerates this eager null).
+    state.toolsCache = null;
+    state.toolsListInflight = null;
+    state.surfacedToolCount = 0;
     for (const [id, pending] of state.pendingCalls) {
       state.pendingCalls.delete(id);
       pending.reject(new Error(state.lastError ?? "MCP server exited"));
@@ -495,16 +553,39 @@ export class PluginMcpSupervisor {
         `MCP server "${input.pluginId}/${input.serverId}" is ${state.status}, not ready`
       );
     }
+    return this.sendRequest(
+      state,
+      "tools/call",
+      { name: input.tool, arguments: input.args ?? {} },
+      TOOL_CALL_TIMEOUT_MS,
+      () => plainError("TIMEOUT", `tools/call "${input.tool}" timed out`)
+    );
+  }
+
+  /**
+   * Send a JSON-RPC request frame and resolve with its `result`. Centralises
+   * the request-id allocation, pending-call bookkeeping, timeout wiring, and
+   * the synchronous-write-failure fast-reject shared by {@link callTool} and
+   * {@link fetchToolsList}. Returns a rejected promise (never throws) so call
+   * sites can uniformly `await`.
+   */
+  private sendRequest(
+    state: SupervisedServerState,
+    method: string,
+    params: Record<string, unknown>,
+    timeoutMs: number,
+    makeTimeoutError: () => Error
+  ): Promise<unknown> {
     const stdin = state.subprocess?.stdin;
     if (!stdin) {
-      throw plainError("NOT_READY", "subprocess has no stdin stream");
+      return Promise.reject(plainError("NOT_READY", "subprocess has no stdin stream"));
     }
     const requestId = state.nextRequestId++;
     const promise = new Promise<unknown>((resolve, reject) => {
       const timer = setTimeout(() => {
         state.pendingCalls.delete(requestId);
-        reject(plainError("TIMEOUT", `tools/call "${input.tool}" timed out`));
-      }, TOOL_CALL_TIMEOUT_MS);
+        reject(makeTimeoutError());
+      }, timeoutMs);
       state.pendingCalls.set(requestId, {
         resolve: (value) => {
           clearTimeout(timer);
@@ -518,16 +599,11 @@ export class PluginMcpSupervisor {
       });
     });
     try {
-      writeFrame(stdin, {
-        jsonrpc: "2.0" as const,
-        id: requestId,
-        method: "tools/call",
-        params: { name: input.tool, arguments: input.args ?? {} },
-      });
+      writeFrame(stdin, { jsonrpc: "2.0" as const, id: requestId, method, params });
     } catch (err) {
       // stdin may have ended between the status check and the write — e.g.
       // the child crashed in the same tick. Reject the pending call now
-      // rather than waiting 30s for the tool-call timeout.
+      // rather than waiting for the timeout.
       const pending = state.pendingCalls.get(requestId);
       if (pending) {
         state.pendingCalls.delete(requestId);
@@ -535,6 +611,130 @@ export class PluginMcpSupervisor {
       }
     }
     return promise;
+  }
+
+  /**
+   * Tier-1 enumeration (#9235). Lazily fetches and caches `tools/list`, then
+   * returns name + truncated-description summaries (never input schemas) up to
+   * the global per-session cap aggregated across every supervised server. The
+   * caller (the `plugin-mcp:list-tools` IPC handler) is responsible for having
+   * spawned the server first via {@link start} — `listTools` then awaits the
+   * handshake so a first-call-after-lazy-spawn enumeration resolves correctly.
+   *
+   * `maxToolsPerSession` is supplied by the caller (read from the
+   * `pluginMcpConfig` setting at the IPC boundary) so the supervisor stays free
+   * of any electron-store dependency and unit-testable in isolation.
+   */
+  async listTools(
+    pluginId: string,
+    serverId: string,
+    maxToolsPerSession: number = PLUGIN_MCP_DEFAULT_MAX_TOOLS_PER_SESSION
+  ): Promise<PluginMcpListToolsResult> {
+    const state = this.states.get(stateKey(pluginId, serverId));
+    if (!state) {
+      throw plainError("NOT_FOUND", `MCP server "${pluginId}/${serverId}" is not registered`);
+    }
+    const all = await this.fetchToolsList(state);
+    const maxTools =
+      Number.isFinite(maxToolsPerSession) && maxToolsPerSession > 0
+        ? Math.floor(maxToolsPerSession)
+        : PLUGIN_MCP_DEFAULT_MAX_TOOLS_PER_SESSION;
+    const alreadySurfaced = this.surfacedToolsExcluding(state);
+    const remaining = Math.max(0, maxTools - alreadySurfaced);
+    const capped = all.slice(0, remaining);
+    state.surfacedToolCount = capped.length;
+    return {
+      pluginId,
+      serverId,
+      tools: capped.map(
+        (tool): PluginMcpToolSummary => ({
+          name: tool.name,
+          description: truncateToolDescription(tool.description),
+        })
+      ),
+      truncated: capped.length < all.length,
+      maxToolsPerSession: maxTools,
+    };
+  }
+
+  /**
+   * Tier-2 lookup (#9235). Returns the full cached tool definition (input
+   * schema + annotations) for a single tool the agent has selected, fetching
+   * `tools/list` first if the cache is cold. A discriminated union rather than
+   * a throw so a stale tool name (e.g. requested after a crash refetch dropped
+   * it) surfaces as `{ found: false }`.
+   */
+  async getFullSchema(
+    pluginId: string,
+    serverId: string,
+    toolName: string
+  ): Promise<PluginMcpGetFullSchemaResult> {
+    const state = this.states.get(stateKey(pluginId, serverId));
+    if (!state) {
+      throw plainError("NOT_FOUND", `MCP server "${pluginId}/${serverId}" is not registered`);
+    }
+    const all = await this.fetchToolsList(state);
+    const tool = all.find((t) => t.name === toolName);
+    return tool ? { found: true, tool } : { found: false };
+  }
+
+  /**
+   * Resolve the cached tool list, or fetch it once under a singleflight guard.
+   * On success the result is cached on the state; on failure the cache stays
+   * `null` (so a crashed-mid-fetch server never serves stale data after
+   * restart) and the rejection propagates to every concurrent caller.
+   */
+  private fetchToolsList(state: SupervisedServerState): Promise<PluginMcpFullTool[]> {
+    if (state.toolsCache) return Promise.resolve(state.toolsCache);
+    if (state.toolsListInflight) return state.toolsListInflight;
+    const promise = this.runToolsListFetch(state)
+      .then((tools) => {
+        state.toolsCache = tools;
+        return tools;
+      })
+      .finally(() => {
+        // Identity guard: a crash/restart may have already nulled (or replaced)
+        // the field; only clear the slot this fetch owns.
+        if (state.toolsListInflight === promise) state.toolsListInflight = null;
+      });
+    state.toolsListInflight = promise;
+    return promise;
+  }
+
+  /** Drive the `tools/list` cursor loop to completion, paging until exhausted. */
+  private async runToolsListFetch(state: SupervisedServerState): Promise<PluginMcpFullTool[]> {
+    // Await the handshake so a first-call-after-lazy-spawn enumeration doesn't
+    // race the `initialize` round. A handshake failure rejects here.
+    if (state.readyPromise) await state.readyPromise;
+    if (state.status !== "ready") {
+      throw plainError(
+        "NOT_READY",
+        `MCP server "${state.pluginId}/${state.serverId}" is ${state.status}, not ready`
+      );
+    }
+    const tools: PluginMcpFullTool[] = [];
+    let cursor: string | undefined;
+    for (;;) {
+      const params = cursor === undefined ? {} : { cursor };
+      const result = await this.sendRequest(state, "tools/list", params, TOOL_CALL_TIMEOUT_MS, () =>
+        plainError("TIMEOUT", `tools/list for "${state.pluginId}/${state.serverId}" timed out`)
+      );
+      const page = parseToolsListResult(result);
+      tools.push(...page.tools);
+      if (!page.nextCursor) break;
+      cursor = page.nextCursor;
+    }
+    return tools;
+  }
+
+  /** Tools already surfaced by every OTHER server — the consumed cap budget. */
+  private surfacedToolsExcluding(exclude: SupervisedServerState): number {
+    let total = 0;
+    for (const state of this.states.values()) {
+      if (state === exclude) continue;
+      total += state.surfacedToolCount;
+    }
+    return total;
   }
 
   /**
@@ -705,6 +905,53 @@ function writeFrame(stdin: NodeJS.WritableStream, payload: unknown): void {
 
 function stateKey(pluginId: string, serverId: string): string {
   return `${pluginId} ${serverId}`;
+}
+
+/**
+ * Truncate a tier-1 tool description to {@link PLUGIN_MCP_TOOL_DESCRIPTION_CAP}
+ * code units, appending an ellipsis when clipped. `slice` is UTF-16-unit based
+ * (V8 serialises a dangling surrogate safely), which is sufficient for the
+ * context-budget guard this enforces (#9235).
+ */
+function truncateToolDescription(description: string | undefined): string | undefined {
+  if (description === undefined) return undefined;
+  if (description.length <= PLUGIN_MCP_TOOL_DESCRIPTION_CAP) return description;
+  return `${description.slice(0, PLUGIN_MCP_TOOL_DESCRIPTION_CAP)}…`;
+}
+
+/**
+ * Parse one `tools/list` JSON-RPC result into typed tool entries plus the
+ * optional pagination cursor. Tolerant of a misbehaving server: non-object
+ * results and malformed entries (missing `name`) are skipped rather than
+ * thrown, so a single bad entry can't abort the whole enumeration.
+ */
+function parseToolsListResult(result: unknown): {
+  tools: PluginMcpFullTool[];
+  nextCursor: string | undefined;
+} {
+  if (!result || typeof result !== "object") return { tools: [], nextCursor: undefined };
+  const obj = result as { tools?: unknown; nextCursor?: unknown };
+  const rawTools = Array.isArray(obj.tools) ? obj.tools : [];
+  const tools: PluginMcpFullTool[] = [];
+  for (const entry of rawTools) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as {
+      name?: unknown;
+      description?: unknown;
+      inputSchema?: unknown;
+      annotations?: unknown;
+    };
+    if (typeof e.name !== "string") continue;
+    tools.push({
+      name: e.name,
+      description: typeof e.description === "string" ? e.description : undefined,
+      inputSchema: e.inputSchema ?? {},
+      annotations: e.annotations,
+    });
+  }
+  const nextCursor =
+    typeof obj.nextCursor === "string" && obj.nextCursor.length > 0 ? obj.nextCursor : undefined;
+  return { tools, nextCursor };
 }
 
 function plainError(code: string, message: string): Error & { code: string } {

--- a/electron/services/PluginMcpSupervisor.ts
+++ b/electron/services/PluginMcpSupervisor.ts
@@ -109,6 +109,13 @@ interface SupervisedServerState {
   pendingCalls: Map<number, PendingCall>;
   /** Resolves when the handshake completes (or rejects on failure). */
   readyPromise: Promise<void> | null;
+  /**
+   * Resolves when the in-flight `startOne` run for this server settles (ready
+   * or crashed) — never rejects. Concurrent lazy-spawn callers (two windows
+   * opening the same cold plugin) await this so they don't race the handshake
+   * and see a transient `spawning` status. Cleared once the run settles (#9235).
+   */
+  inflightStart: Promise<void> | null;
   /** Stdout NDJSON parse buffer carryover across stream chunks. */
   stdoutBuffer: string;
   /**
@@ -136,6 +143,13 @@ interface SupervisedServerState {
 const HANDSHAKE_TIMEOUT_MS = 15_000;
 const SHUTDOWN_GRACE_MS = 3_000;
 const TOOL_CALL_TIMEOUT_MS = 30_000;
+/**
+ * Upper bound on `tools/list` cursor pages (#9235). A misbehaving server that
+ * returns the same non-empty `nextCursor` forever would otherwise loop without
+ * end and accumulate tools unbounded — the cap is only applied after the full
+ * fetch. 200 tools/page × 100 pages is far above any legitimate tool surface.
+ */
+export const TOOLS_LIST_MAX_PAGES = 100;
 
 const MCP_PROTOCOL_VERSION = "2025-06-18";
 const CLIENT_INFO = { name: "daintree-plugin-supervisor", version: "1" } as const;
@@ -204,7 +218,13 @@ export class PluginMcpSupervisor {
     );
   }
 
-  private async startOne(
+  /**
+   * Idempotent per `(pluginId, serverId)`. A call against an already-spawning or
+   * ready server returns the in-flight start promise (so concurrent lazy-spawn
+   * callers await readiness rather than proceeding against a transient
+   * `spawning` state — #9235) instead of being a fire-and-forget no-op.
+   */
+  private startOne(
     pluginId: string,
     pluginDir: string | undefined,
     contribution: McpServerContribution,
@@ -212,7 +232,31 @@ export class PluginMcpSupervisor {
   ): Promise<void> {
     const key = stateKey(pluginId, contribution.id);
     const existing = this.states.get(key);
-    if (existing && (existing.status === "spawning" || existing.status === "ready")) return;
+    if (existing && (existing.status === "spawning" || existing.status === "ready")) {
+      return existing.inflightStart ?? Promise.resolve();
+    }
+    // `doStartOne` runs synchronously up to its first `await` — by the time it
+    // returns the promise the state is already in the map, so we can stamp the
+    // in-flight handle onto it for concurrent callers to await.
+    const run = this.doStartOne(pluginId, pluginDir, contribution, resolveSettings);
+    const state = this.states.get(key);
+    if (state) {
+      state.inflightStart = run;
+      void run.finally(() => {
+        if (state.inflightStart === run) state.inflightStart = null;
+      });
+    }
+    return run;
+  }
+
+  private async doStartOne(
+    pluginId: string,
+    pluginDir: string | undefined,
+    contribution: McpServerContribution,
+    resolveSettings: (template: string) => Promise<string>
+  ): Promise<void> {
+    const key = stateKey(pluginId, contribution.id);
+    const existing = this.states.get(key);
 
     const state: SupervisedServerState = existing ?? {
       pluginId,
@@ -227,6 +271,7 @@ export class PluginMcpSupervisor {
       nextRequestId: 1,
       pendingCalls: new Map(),
       readyPromise: null,
+      inflightStart: null,
       stdoutBuffer: "",
       toolsCache: null,
       toolsListInflight: null,
@@ -469,6 +514,10 @@ export class PluginMcpSupervisor {
     if (message.method === "notifications/tools/list_changed") {
       state.toolsCache = null;
       state.surfacedToolCount = 0;
+      // Supersede any in-flight fetch so its resolution can't re-cache the
+      // pre-notification tool list (the `.then` identity guard then no-ops). The
+      // next enumeration starts a fresh fetch.
+      state.toolsListInflight = null;
       return;
     }
     // Other notifications (no id) are ignored — we don't subscribe to any.
@@ -689,12 +738,14 @@ export class PluginMcpSupervisor {
     if (state.toolsListInflight) return state.toolsListInflight;
     const promise = this.runToolsListFetch(state)
       .then((tools) => {
-        state.toolsCache = tools;
+        // Identity guard: a crash/restart or a mid-fetch
+        // `notifications/tools/list_changed` may have invalidated this fetch by
+        // nulling/replacing the in-flight handle. Only cache if we still own it,
+        // so a superseded fetch can't repopulate the cache with stale tools.
+        if (state.toolsListInflight === promise) state.toolsCache = tools;
         return tools;
       })
       .finally(() => {
-        // Identity guard: a crash/restart may have already nulled (or replaced)
-        // the field; only clear the slot this fetch owns.
         if (state.toolsListInflight === promise) state.toolsListInflight = null;
       });
     state.toolsListInflight = promise;
@@ -703,8 +754,13 @@ export class PluginMcpSupervisor {
 
   /** Drive the `tools/list` cursor loop to completion, paging until exhausted. */
   private async runToolsListFetch(state: SupervisedServerState): Promise<PluginMcpFullTool[]> {
-    // Await the handshake so a first-call-after-lazy-spawn enumeration doesn't
-    // race the `initialize` round. A handshake failure rejects here.
+    // Await the in-flight spawn first — there's a window where a concurrent
+    // lazy spawn has registered the state (`status: "spawning"`) but not yet
+    // assigned `readyPromise`. Awaiting `inflightStart` closes that race so a
+    // first-call-after-lazy-spawn enumeration doesn't see a transient status.
+    if (state.inflightStart) await state.inflightStart;
+    // Then await the handshake so the `initialize` round has completed. A
+    // handshake failure rejects here.
     if (state.readyPromise) await state.readyPromise;
     if (state.status !== "ready") {
       throw plainError(
@@ -714,17 +770,22 @@ export class PluginMcpSupervisor {
     }
     const tools: PluginMcpFullTool[] = [];
     let cursor: string | undefined;
-    for (;;) {
+    for (let page = 0; page < TOOLS_LIST_MAX_PAGES; page++) {
       const params = cursor === undefined ? {} : { cursor };
       const result = await this.sendRequest(state, "tools/list", params, TOOL_CALL_TIMEOUT_MS, () =>
         plainError("TIMEOUT", `tools/list for "${state.pluginId}/${state.serverId}" timed out`)
       );
-      const page = parseToolsListResult(result);
-      tools.push(...page.tools);
-      if (!page.nextCursor) break;
-      cursor = page.nextCursor;
+      const parsed = parseToolsListResult(result);
+      tools.push(...parsed.tools);
+      if (!parsed.nextCursor) return tools;
+      cursor = parsed.nextCursor;
     }
-    return tools;
+    // Exhausted the page budget without a terminal page — a server paging
+    // forever. Fail rather than loop unbounded.
+    throw plainError(
+      "TOOLS_LIST_PAGINATION",
+      `tools/list for "${state.pluginId}/${state.serverId}" exceeded ${TOOLS_LIST_MAX_PAGES} pages`
+    );
   }
 
   /** Tools already surfaced by every OTHER server — the consumed cap budget. */
@@ -753,6 +814,12 @@ export class PluginMcpSupervisor {
     const state = this.states.get(key);
     if (!state) return;
     state.status = "stopped";
+    // Drop the tool cache and release this server's slice of the global cap
+    // budget so a stopped/unloaded server doesn't pin tools or budget (#9235).
+    // Done before the `!subprocess` early-return so it always runs.
+    state.toolsCache = null;
+    state.toolsListInflight = null;
+    state.surfacedToolCount = 0;
     const subprocess = state.subprocess;
     if (!subprocess) return;
     const pid = state.pid;

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -1080,23 +1080,11 @@ export class PluginService {
       this.scheduleContextMenuItemsBroadcast(false);
     }
 
-    if (manifest.contributes.experimental_mcpServers.length > 0) {
-      const contributions = manifest.contributes.experimental_mcpServers;
-      const pluginId = manifest.name;
-      // Eager spawn at activation time so readiness is observable before any
-      // tools/call dispatch. Errors are absorbed inside start() — a single
-      // failing MCP server can't strand plugin activation.
-      void getPluginMcpSupervisor()
-        .start({
-          pluginId,
-          pluginDir,
-          contributions,
-          resolveSettings: (settingId) => this.resolveSettingTemplate(pluginId, settingId),
-        })
-        .catch((err) => {
-          console.warn(`[PluginService] Plugin "${pluginId}": MCP supervisor start failed:`, err);
-        });
-    }
+    // Lazy MCP discovery (#9235): plugin activation no longer eagerly spawns
+    // contributed MCP servers. The subprocess starts on the first tool
+    // enumeration (`plugin-mcp:list-tools`), which resolves the contribution
+    // and calls the (idempotent) supervisor `start()` at the IPC boundary. This
+    // keeps idle plugins from holding live subprocesses they never use.
 
     if (manifest.contributes.forgeProviders.length > 0) {
       registerForgeProviders(manifest.name, manifest.contributes.forgeProviders);

--- a/electron/services/__tests__/PluginMcpSupervisor.test.ts
+++ b/electron/services/__tests__/PluginMcpSupervisor.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PassThrough } from "node:stream";
-import { PluginMcpSupervisor } from "../PluginMcpSupervisor.js";
+import { PluginMcpSupervisor, TOOLS_LIST_MAX_PAGES } from "../PluginMcpSupervisor.js";
 import { PLUGIN_MCP_STDERR_RING_LINES } from "../../../shared/types/ipc/pluginMcp.js";
 
 async function flushMicrotasks(): Promise<void> {
@@ -648,6 +648,122 @@ describe("PluginMcpSupervisor lazy tool discovery (issue #9235)", () => {
     fake.answerInitialize();
     await startPromise;
   }
+
+  it("resolves a concurrent first-call enumeration that races the lazy spawn", async () => {
+    // Regression for the readyPromise-null window: enumerate while the server is
+    // still "spawning" (readyPromise not yet assigned). The call must await the
+    // in-flight start rather than fast-failing with NOT_READY.
+    const fake = makeFakeSubprocess();
+    const supervisor = new PluginMcpSupervisor({ spawner: () => fake.handle, killTree: () => {} });
+
+    const startPromise = supervisor.start({
+      pluginId: "acme.demo",
+      contributions: [CONTRIBUTION],
+      resolveSettings: async () => "",
+    });
+    // Enumerate immediately — before the handshake completes.
+    const listPromise = supervisor.listTools("acme.demo", "linear");
+
+    await fake.waitForStdinCount(1);
+    fake.answerInitialize();
+    await startPromise;
+    await fake.waitForStdinCount(3);
+    fake.answerLastCall({ tools: [{ name: "a", inputSchema: {} }] });
+
+    const result = await listPromise;
+    expect(result.tools.map((t) => t.name)).toEqual(["a"]);
+  });
+
+  it("does not repopulate the cache when list_changed arrives mid-fetch", async () => {
+    const fake = makeFakeSubprocess();
+    const supervisor = new PluginMcpSupervisor({ spawner: () => fake.handle, killTree: () => {} });
+    await startReady(supervisor, fake);
+
+    const first = supervisor.listTools("acme.demo", "linear");
+    await fake.waitForStdinCount(3);
+    // Invalidation lands while the tools/list request is still in flight.
+    fake.emitStdout({ jsonrpc: "2.0", method: "notifications/tools/list_changed" });
+    await flushMicrotasks();
+    // The now-superseded request resolves with the OLD data.
+    fake.answerLastCall({ tools: [{ name: "old", inputSchema: {} }] });
+    await first;
+
+    // The cache must NOT hold the old data — the next call refetches.
+    const second = supervisor.listTools("acme.demo", "linear");
+    await fake.waitForStdinCount(4);
+    expect(fake.lastCallMethod()).toBe("tools/list");
+    fake.answerLastCall({ tools: [{ name: "fresh", inputSchema: {} }] });
+    expect((await second).tools.map((t) => t.name)).toEqual(["fresh"]);
+  });
+
+  it("rejects a tools/list that pages past the pagination guard", async () => {
+    const fake = makeFakeSubprocess();
+    const supervisor = new PluginMcpSupervisor({ spawner: () => fake.handle, killTree: () => {} });
+    await startReady(supervisor, fake);
+
+    const listPromise = supervisor.listTools("acme.demo", "linear");
+    listPromise.catch(() => {});
+    // Always hand back the same non-empty cursor so the loop never terminates
+    // on its own — it must bail out at the page guard.
+    for (let i = 0; i < TOOLS_LIST_MAX_PAGES; i++) {
+      await fake.waitForStdinCount(3 + i);
+      fake.answerLastCall({ tools: [{ name: `t${i}`, inputSchema: {} }], nextCursor: "loop" });
+    }
+    await expect(listPromise).rejects.toMatchObject({ code: "TOOLS_LIST_PAGINATION" });
+  });
+
+  it("releases a stopped server's slice of the global cap budget on shutdown", async () => {
+    const fakes = [makeFakeSubprocess({ pid: 1 }), makeFakeSubprocess({ pid: 2 })];
+    let nth = 0;
+    const supervisor = new PluginMcpSupervisor({
+      spawner: () => fakes[nth++]!.handle,
+      killTree: () => {},
+    });
+    const startA = supervisor.start({
+      pluginId: "acme.a",
+      contributions: [{ id: "s", name: "S", command: "node" }],
+      resolveSettings: async () => "",
+    });
+    await fakes[0]!.waitForStdinCount(1);
+    fakes[0]!.answerInitialize();
+    await startA;
+    const startB = supervisor.start({
+      pluginId: "acme.b",
+      contributions: [{ id: "s", name: "S", command: "node" }],
+      resolveSettings: async () => "",
+    });
+    await fakes[1]!.waitForStdinCount(1);
+    fakes[1]!.answerInitialize();
+    await startB;
+
+    // A surfaces 2 of a budget of 3.
+    const aPromise = supervisor.listTools("acme.a", "s", 3);
+    await fakes[0]!.waitForStdinCount(3);
+    fakes[0]!.answerLastCall({
+      tools: [
+        { name: "a1", inputSchema: {} },
+        { name: "a2", inputSchema: {} },
+      ],
+    });
+    await aPromise;
+
+    // Shut A down — its budget slice must be released.
+    await supervisor.shutdown({ pluginId: "acme.a" });
+
+    // B now sees the FULL budget of 3, not the leftover 1.
+    const bPromise = supervisor.listTools("acme.b", "s", 3);
+    await fakes[1]!.waitForStdinCount(3);
+    fakes[1]!.answerLastCall({
+      tools: [
+        { name: "b1", inputSchema: {} },
+        { name: "b2", inputSchema: {} },
+        { name: "b3", inputSchema: {} },
+      ],
+    });
+    const bResult = await bPromise;
+    expect(bResult.tools.map((t) => t.name)).toEqual(["b1", "b2", "b3"]);
+    expect(bResult.truncated).toBe(false);
+  });
 
   it("fetches tools/list on first enumeration and returns tier-1 summaries without schemas", async () => {
     const fake = makeFakeSubprocess();

--- a/electron/services/__tests__/PluginMcpSupervisor.test.ts
+++ b/electron/services/__tests__/PluginMcpSupervisor.test.ts
@@ -901,7 +901,12 @@ describe("PluginMcpSupervisor lazy tool discovery (issue #9235)", () => {
     // Cache was dropped — a fresh tools/list goes out (frame 4).
     await fake.waitForStdinCount(4);
     expect(fake.lastCallMethod()).toBe("tools/list");
-    fake.answerLastCall({ tools: [{ name: "a", inputSchema: {} }, { name: "b", inputSchema: {} }] });
+    fake.answerLastCall({
+      tools: [
+        { name: "a", inputSchema: {} },
+        { name: "b", inputSchema: {} },
+      ],
+    });
     const result = await second;
     expect(result.tools.map((t) => t.name)).toEqual(["a", "b"]);
   });

--- a/electron/services/__tests__/PluginMcpSupervisor.test.ts
+++ b/electron/services/__tests__/PluginMcpSupervisor.test.ts
@@ -95,6 +95,26 @@ function makeFakeSubprocess(opts?: { pid?: number }) {
     return [...stdinLines];
   }
 
+  function lastCallMethod(): string | undefined {
+    const last = stdinLines.at(-1);
+    if (!last) return undefined;
+    try {
+      return (JSON.parse(last) as { method?: string }).method;
+    } catch {
+      return undefined;
+    }
+  }
+
+  function lastCallParams(): Record<string, unknown> | undefined {
+    const last = stdinLines.at(-1);
+    if (!last) return undefined;
+    try {
+      return (JSON.parse(last) as { params?: Record<string, unknown> }).params;
+    } catch {
+      return undefined;
+    }
+  }
+
   return {
     subprocess,
     handle,
@@ -103,8 +123,14 @@ function makeFakeSubprocess(opts?: { pid?: number }) {
     answerLastCall,
     answerLastCallWithError,
     readStdinLines,
+    lastCallMethod,
+    lastCallParams,
     emitStderr(line: string) {
       stderr.write(line);
+    },
+    /** Write a raw JSON-RPC message (e.g. a server notification) onto stdout. */
+    emitStdout(message: unknown) {
+      stdout.write(JSON.stringify(message) + "\n");
     },
     closeStdout() {
       stdout.end();
@@ -595,5 +621,332 @@ describe("PluginMcpSupervisor (issue #9233)", () => {
     });
     callPromise.catch(() => {});
     await expect(callPromise).rejects.toMatchObject({ code: "WRITE_FAILED" });
+  });
+});
+
+describe("PluginMcpSupervisor lazy tool discovery (issue #9235)", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const CONTRIBUTION = { id: "linear", name: "Linear", command: "node" };
+
+  /** Spawn one server and drive it to `ready`. */
+  async function startReady(
+    supervisor: PluginMcpSupervisor,
+    fake: ReturnType<typeof makeFakeSubprocess>
+  ): Promise<void> {
+    const startPromise = supervisor.start({
+      pluginId: "acme.demo",
+      contributions: [CONTRIBUTION],
+      resolveSettings: async () => "",
+    });
+    await fake.waitForStdinCount(1);
+    fake.answerInitialize();
+    await startPromise;
+  }
+
+  it("fetches tools/list on first enumeration and returns tier-1 summaries without schemas", async () => {
+    const fake = makeFakeSubprocess();
+    const supervisor = new PluginMcpSupervisor({ spawner: () => fake.handle, killTree: () => {} });
+    await startReady(supervisor, fake);
+
+    const longDescription = "x".repeat(250);
+    const listPromise = supervisor.listTools("acme.demo", "linear");
+    // initialize + notifications/initialized + tools/list = 3 frames.
+    await fake.waitForStdinCount(3);
+    expect(fake.lastCallMethod()).toBe("tools/list");
+    expect(fake.lastCallParams()).toEqual({});
+    fake.answerLastCall({
+      tools: [
+        { name: "getIssue", description: "Fetch an issue", inputSchema: { type: "object" } },
+        { name: "verbose", description: longDescription, inputSchema: { type: "object" } },
+      ],
+    });
+
+    const result = await listPromise;
+    expect(result.tools).toEqual([
+      { name: "getIssue", description: "Fetch an issue" },
+      { name: "verbose", description: `${"x".repeat(200)}…` },
+    ]);
+    // Tier-1 must not leak the input schema.
+    for (const tool of result.tools) {
+      expect(tool).not.toHaveProperty("inputSchema");
+    }
+    expect(result.truncated).toBe(false);
+    expect(result.maxToolsPerSession).toBe(200);
+  });
+
+  it("follows the tools/list pagination cursor across pages", async () => {
+    const fake = makeFakeSubprocess();
+    const supervisor = new PluginMcpSupervisor({ spawner: () => fake.handle, killTree: () => {} });
+    await startReady(supervisor, fake);
+
+    const listPromise = supervisor.listTools("acme.demo", "linear");
+    await fake.waitForStdinCount(3);
+    expect(fake.lastCallParams()).toEqual({});
+    fake.answerLastCall({ tools: [{ name: "a", inputSchema: {} }], nextCursor: "cursor-2" });
+
+    await fake.waitForStdinCount(4);
+    expect(fake.lastCallMethod()).toBe("tools/list");
+    expect(fake.lastCallParams()).toEqual({ cursor: "cursor-2" });
+    fake.answerLastCall({ tools: [{ name: "b", inputSchema: {} }] });
+
+    const result = await listPromise;
+    expect(result.tools.map((t) => t.name)).toEqual(["a", "b"]);
+    // No third page requested.
+    expect(fake.readStdinLines()).toHaveLength(4);
+  });
+
+  it("serves the cached tool list on the second enumeration without a refetch", async () => {
+    const fake = makeFakeSubprocess();
+    const supervisor = new PluginMcpSupervisor({ spawner: () => fake.handle, killTree: () => {} });
+    await startReady(supervisor, fake);
+
+    const first = supervisor.listTools("acme.demo", "linear");
+    await fake.waitForStdinCount(3);
+    fake.answerLastCall({ tools: [{ name: "a", inputSchema: {} }] });
+    await first;
+
+    const second = await supervisor.listTools("acme.demo", "linear");
+    expect(second.tools.map((t) => t.name)).toEqual(["a"]);
+    // Still only 3 frames: no second tools/list went out.
+    expect(fake.readStdinLines()).toHaveLength(3);
+  });
+
+  it("deduplicates concurrent enumerations into one tools/list round (singleflight)", async () => {
+    const fake = makeFakeSubprocess();
+    const supervisor = new PluginMcpSupervisor({ spawner: () => fake.handle, killTree: () => {} });
+    await startReady(supervisor, fake);
+
+    const p1 = supervisor.listTools("acme.demo", "linear");
+    const p2 = supervisor.listTools("acme.demo", "linear");
+    await fake.waitForStdinCount(3);
+    fake.answerLastCall({ tools: [{ name: "a", inputSchema: {} }] });
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1.tools.map((t) => t.name)).toEqual(["a"]);
+    expect(r2.tools.map((t) => t.name)).toEqual(["a"]);
+    // One tools/list frame only.
+    expect(fake.readStdinLines()).toHaveLength(3);
+  });
+
+  it("returns the full tool definition from getFullSchema, or not-found for an unknown name", async () => {
+    const fake = makeFakeSubprocess();
+    const supervisor = new PluginMcpSupervisor({ spawner: () => fake.handle, killTree: () => {} });
+    await startReady(supervisor, fake);
+
+    const schemaPromise = supervisor.getFullSchema("acme.demo", "linear", "getIssue");
+    await fake.waitForStdinCount(3);
+    fake.answerLastCall({
+      tools: [
+        {
+          name: "getIssue",
+          description: "Fetch an issue",
+          inputSchema: { type: "object", properties: { id: { type: "string" } } },
+          annotations: { readOnly: true },
+        },
+      ],
+    });
+    const hit = await schemaPromise;
+    expect(hit).toEqual({
+      found: true,
+      tool: {
+        name: "getIssue",
+        description: "Fetch an issue",
+        inputSchema: { type: "object", properties: { id: { type: "string" } } },
+        annotations: { readOnly: true },
+      },
+    });
+
+    // Second lookup hits the cache (no new frame) and misses on an unknown name.
+    const miss = await supervisor.getFullSchema("acme.demo", "linear", "nope");
+    expect(miss).toEqual({ found: false });
+    expect(fake.readStdinLines()).toHaveLength(3);
+  });
+
+  it("invalidates the cache on a notifications/tools/list_changed and refetches", async () => {
+    const fake = makeFakeSubprocess();
+    const supervisor = new PluginMcpSupervisor({ spawner: () => fake.handle, killTree: () => {} });
+    await startReady(supervisor, fake);
+
+    const first = supervisor.listTools("acme.demo", "linear");
+    await fake.waitForStdinCount(3);
+    fake.answerLastCall({ tools: [{ name: "a", inputSchema: {} }] });
+    await first;
+
+    fake.emitStdout({ jsonrpc: "2.0", method: "notifications/tools/list_changed" });
+    await flushMicrotasks();
+
+    const second = supervisor.listTools("acme.demo", "linear");
+    // Cache was dropped — a fresh tools/list goes out (frame 4).
+    await fake.waitForStdinCount(4);
+    expect(fake.lastCallMethod()).toBe("tools/list");
+    fake.answerLastCall({ tools: [{ name: "a", inputSchema: {} }, { name: "b", inputSchema: {} }] });
+    const result = await second;
+    expect(result.tools.map((t) => t.name)).toEqual(["a", "b"]);
+  });
+
+  it("ignores unrelated notifications and keeps the cache", async () => {
+    const fake = makeFakeSubprocess();
+    const supervisor = new PluginMcpSupervisor({ spawner: () => fake.handle, killTree: () => {} });
+    await startReady(supervisor, fake);
+
+    const first = supervisor.listTools("acme.demo", "linear");
+    await fake.waitForStdinCount(3);
+    fake.answerLastCall({ tools: [{ name: "a", inputSchema: {} }] });
+    await first;
+
+    fake.emitStdout({ jsonrpc: "2.0", method: "notifications/message", params: { level: "info" } });
+    await flushMicrotasks();
+
+    const second = await supervisor.listTools("acme.demo", "linear");
+    expect(second.tools.map((t) => t.name)).toEqual(["a"]);
+    // Cache survived — no refetch.
+    expect(fake.readStdinLines()).toHaveLength(3);
+  });
+
+  it("invalidates the cache on crash and refetches after restart", async () => {
+    const fakes = [makeFakeSubprocess({ pid: 1 }), makeFakeSubprocess({ pid: 2 })];
+    let nth = 0;
+    const supervisor = new PluginMcpSupervisor({
+      spawner: () => fakes[nth++]!.handle,
+      killTree: () => {},
+    });
+    await startReady(supervisor, fakes[0]!);
+
+    const first = supervisor.listTools("acme.demo", "linear");
+    await fakes[0]!.waitForStdinCount(3);
+    fakes[0]!.answerLastCall({ tools: [{ name: "a", inputSchema: {} }] });
+    await first;
+
+    // Crash the server: cache must be dropped.
+    fakes[0]!.closeStdout();
+    await flushMicrotasks();
+    expect(supervisor.list()[0]?.status).toBe("crashed");
+
+    // Restart and enumerate again — a fresh tools/list must go out on the new
+    // subprocess (the cache did not survive the crash).
+    const restartPromise = supervisor.restart({
+      pluginId: "acme.demo",
+      serverId: "linear",
+      contribution: CONTRIBUTION,
+      resolveSettings: async () => "",
+    });
+    await fakes[1]!.waitForStdinCount(1);
+    fakes[1]!.answerInitialize();
+    await restartPromise;
+
+    const second = supervisor.listTools("acme.demo", "linear");
+    await fakes[1]!.waitForStdinCount(3);
+    expect(fakes[1]!.lastCallMethod()).toBe("tools/list");
+    fakes[1]!.answerLastCall({ tools: [{ name: "b", inputSchema: {} }] });
+    const result = await second;
+    expect(result.tools.map((t) => t.name)).toEqual(["b"]);
+  });
+
+  it("rejects an in-flight enumeration when the server crashes mid-fetch and recovers after restart", async () => {
+    const fakes = [makeFakeSubprocess({ pid: 1 }), makeFakeSubprocess({ pid: 2 })];
+    let nth = 0;
+    const supervisor = new PluginMcpSupervisor({
+      spawner: () => fakes[nth++]!.handle,
+      killTree: () => {},
+    });
+    await startReady(supervisor, fakes[0]!);
+
+    const pending = supervisor.listTools("acme.demo", "linear");
+    pending.catch(() => {});
+    await fakes[0]!.waitForStdinCount(3);
+    // Crash before answering tools/list.
+    fakes[0]!.closeStdout();
+    await flushMicrotasks();
+    await expect(pending).rejects.toThrow();
+
+    // The inflight guard must have cleared so a post-restart enumeration runs.
+    const restartPromise = supervisor.restart({
+      pluginId: "acme.demo",
+      serverId: "linear",
+      contribution: CONTRIBUTION,
+      resolveSettings: async () => "",
+    });
+    await fakes[1]!.waitForStdinCount(1);
+    fakes[1]!.answerInitialize();
+    await restartPromise;
+
+    const recovered = supervisor.listTools("acme.demo", "linear");
+    await fakes[1]!.waitForStdinCount(3);
+    fakes[1]!.answerLastCall({ tools: [{ name: "ok", inputSchema: {} }] });
+    expect((await recovered).tools.map((t) => t.name)).toEqual(["ok"]);
+  });
+
+  it("enforces the global tool cap and reports truncation", async () => {
+    const fake = makeFakeSubprocess();
+    const supervisor = new PluginMcpSupervisor({ spawner: () => fake.handle, killTree: () => {} });
+    await startReady(supervisor, fake);
+
+    const listPromise = supervisor.listTools("acme.demo", "linear", 2);
+    await fake.waitForStdinCount(3);
+    fake.answerLastCall({
+      tools: [
+        { name: "a", inputSchema: {} },
+        { name: "b", inputSchema: {} },
+        { name: "c", inputSchema: {} },
+      ],
+    });
+    const result = await listPromise;
+    expect(result.tools.map((t) => t.name)).toEqual(["a", "b"]);
+    expect(result.truncated).toBe(true);
+    expect(result.maxToolsPerSession).toBe(2);
+  });
+
+  it("spreads the global cap budget across multiple servers", async () => {
+    const fakes = [makeFakeSubprocess({ pid: 1 }), makeFakeSubprocess({ pid: 2 })];
+    let nth = 0;
+    const supervisor = new PluginMcpSupervisor({
+      spawner: () => fakes[nth++]!.handle,
+      killTree: () => {},
+    });
+    const startPromise = supervisor.start({
+      pluginId: "acme.demo",
+      contributions: [
+        { id: "linear", name: "Linear", command: "node" },
+        { id: "github", name: "GitHub", command: "node" },
+      ],
+      resolveSettings: async () => "",
+    });
+    await fakes[0]!.waitForStdinCount(1);
+    fakes[0]!.answerInitialize();
+    await fakes[1]!.waitForStdinCount(1);
+    fakes[1]!.answerInitialize();
+    await startPromise;
+
+    // First server surfaces 2 of its 2 tools (budget 3 → remaining 3).
+    const firstPromise = supervisor.listTools("acme.demo", "linear", 3);
+    await fakes[0]!.waitForStdinCount(3);
+    fakes[0]!.answerLastCall({
+      tools: [
+        { name: "l1", inputSchema: {} },
+        { name: "l2", inputSchema: {} },
+      ],
+    });
+    const first = await firstPromise;
+    expect(first.tools.map((t) => t.name)).toEqual(["l1", "l2"]);
+    expect(first.truncated).toBe(false);
+
+    // Second server only has 1 slot of budget left (3 - 2 already surfaced).
+    const secondPromise = supervisor.listTools("acme.demo", "github", 3);
+    await fakes[1]!.waitForStdinCount(3);
+    fakes[1]!.answerLastCall({
+      tools: [
+        { name: "g1", inputSchema: {} },
+        { name: "g2", inputSchema: {} },
+      ],
+    });
+    const second = await secondPromise;
+    expect(second.tools.map((t) => t.name)).toEqual(["g1"]);
+    expect(second.truncated).toBe(true);
   });
 });

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -5411,7 +5411,7 @@ describe("reserved contribution point warnings", () => {
     );
   });
 
-  it("forwards a contributes.experimental_mcpServers entry to the PluginMcpSupervisor (#9233)", async () => {
+  it("registers a contributes.experimental_mcpServers entry without eagerly spawning it (#9235)", async () => {
     mockPluginMcpSupervisor.start.mockClear();
     await writePlugin("mcp", {
       name: "acme.mcp",
@@ -5434,21 +5434,19 @@ describe("reserved contribution point warnings", () => {
     await service.initialize();
 
     expect(service.listPlugins()).toHaveLength(1);
-    expect(mockPluginMcpSupervisor.start).toHaveBeenCalledTimes(1);
-    const call = mockPluginMcpSupervisor.start.mock.calls[0]?.[0] as {
-      pluginId: string;
-      contributions: Array<{ id: string; name: string; command: string }>;
-    };
-    expect(call.pluginId).toBe("acme.mcp");
-    expect(call.contributions).toEqual([
-      {
-        id: "linear",
-        name: "Linear MCP",
-        command: "node",
-        args: ["./server.js"],
-        env: { LINEAR_API_KEY: "secret" },
-      },
-    ]);
+    // Lazy discovery (#9235): activation must NOT spawn the MCP subprocess —
+    // it starts on the first `plugin-mcp:list-tools` enumeration instead.
+    expect(mockPluginMcpSupervisor.start).not.toHaveBeenCalled();
+    // The contribution is still registered so the IPC boundary can resolve and
+    // lazily start it on demand.
+    const lookup = service.findMcpServerContribution("acme.mcp", "linear");
+    expect(lookup?.contribution).toEqual({
+      id: "linear",
+      name: "Linear MCP",
+      command: "node",
+      args: ["./server.js"],
+      env: { LINEAR_API_KEY: "secret" },
+    });
   });
 
   it("registers a contributes.forgeProviders entry with the forge provider registry", async () => {
@@ -5573,8 +5571,10 @@ describe("reserved contribution point warnings", () => {
         'experimental_views entry "main" has location "sidebar" which is not yet implemented'
       )
     );
-    // experimental_mcpServers now reaches the supervisor instead of warning (#9233).
-    expect(mockPluginMcpSupervisor.start).toHaveBeenCalledTimes(1);
+    // experimental_mcpServers is registered (no warning) but, under lazy
+    // discovery (#9235), is NOT spawned at activation.
+    expect(mockPluginMcpSupervisor.start).not.toHaveBeenCalled();
+    expect(service.findMcpServerContribution("acme.mixed", "svc")).toBeDefined();
   });
 
   it("logs one warning per orphan or unsupported view entry", async () => {

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -20,6 +20,7 @@ import { PLUGIN_AUDIT_DEFAULT_MAX_RECORDS } from "../shared/types/ipc/pluginAudi
 import type { PluginMcpAuditRecord } from "../shared/types/ipc/pluginMcpAudit.js";
 import { PLUGIN_MCP_AUDIT_DEFAULT_MAX_RECORDS } from "../shared/types/ipc/pluginMcpAudit.js";
 import type { PluginMcpConsentRecord } from "../shared/types/pluginMcpConsent.js";
+import { PLUGIN_MCP_DEFAULT_MAX_TOOLS_PER_SESSION } from "../shared/types/ipc/pluginMcp.js";
 import type { ForgeAuditRecord } from "../shared/types/ipc/forge.js";
 import { FORGE_AUDIT_DEFAULT_MAX_RECORDS } from "../shared/types/ipc/forge.js";
 import type { BuiltInAgentId } from "../shared/config/agentIds.js";
@@ -394,6 +395,16 @@ export interface StoreSchema {
     pins?: PluginMcpConsentRecord[];
     revoked?: string[];
   };
+  /**
+   * Advanced plugin-MCP tuning (#9235). `maxToolsPerSession` is the hard cap on
+   * the number of tools surfaced into agent context across ALL supervised
+   * servers per session — lazy tier-1 enumeration clips to this so a chatty
+   * server can't flood the agent's tool budget. Additive key; absence falls
+   * back to {@link PLUGIN_MCP_DEFAULT_MAX_TOOLS_PER_SESSION}.
+   */
+  pluginMcpConfig: {
+    maxToolsPerSession: number;
+  };
 }
 
 const storeOptions = {
@@ -561,6 +572,9 @@ const storeOptions = {
       auditMaxRecords: PLUGIN_MCP_AUDIT_DEFAULT_MAX_RECORDS,
     },
     pluginMcpConsent: {},
+    pluginMcpConfig: {
+      maxToolsPerSession: PLUGIN_MCP_DEFAULT_MAX_TOOLS_PER_SESSION,
+    },
   },
   cwd: process.env.DAINTREE_USER_DATA,
 };

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -400,15 +400,27 @@ export interface GeneratedElectronAPI {
     ): Promise<IpcInvokeMap["plugin:validate-action-ids"]["result"]>;
   };
   pluginMcp: {
+    getConfig(
+      ...args: IpcInvokeMap["plugin-mcp:get-config"]["args"]
+    ): Promise<IpcInvokeMap["plugin-mcp:get-config"]["result"]>;
+    getFullSchema(
+      ...args: IpcInvokeMap["plugin-mcp:get-full-schema"]["args"]
+    ): Promise<IpcInvokeMap["plugin-mcp:get-full-schema"]["result"]>;
     getStderr(
       ...args: IpcInvokeMap["plugin-mcp:get-stderr"]["args"]
     ): Promise<IpcInvokeMap["plugin-mcp:get-stderr"]["result"]>;
     list(
       ...args: IpcInvokeMap["plugin-mcp:list"]["args"]
     ): Promise<IpcInvokeMap["plugin-mcp:list"]["result"]>;
+    listTools(
+      ...args: IpcInvokeMap["plugin-mcp:list-tools"]["args"]
+    ): Promise<IpcInvokeMap["plugin-mcp:list-tools"]["result"]>;
     restart(
       ...args: IpcInvokeMap["plugin-mcp:restart"]["args"]
     ): Promise<IpcInvokeMap["plugin-mcp:restart"]["result"]>;
+    setConfig(
+      ...args: IpcInvokeMap["plugin-mcp:set-config"]["args"]
+    ): Promise<IpcInvokeMap["plugin-mcp:set-config"]["result"]>;
   };
   portal: {
     closeTab(

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -583,6 +583,14 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: boolean | undefined;
   };
+  "plugin-mcp:get-config": {
+    args: [];
+    result: import("./pluginMcp.js").PluginMcpConfig;
+  };
+  "plugin-mcp:get-full-schema": {
+    args: [key: import("./pluginMcp.js").PluginMcpToolKey];
+    result: import("./pluginMcp.js").PluginMcpGetFullSchemaResult;
+  };
   "plugin-mcp:get-stderr": {
     args: [key: import("./pluginMcp.js").PluginMcpServerKey];
     result: import("./pluginMcp.js").PluginMcpStderrResult;
@@ -591,9 +599,17 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: import("./pluginMcp.js").PluginMcpServerInfo[];
   };
+  "plugin-mcp:list-tools": {
+    args: [key: import("./pluginMcp.js").PluginMcpServerKey];
+    result: import("./pluginMcp.js").PluginMcpListToolsResult;
+  };
   "plugin-mcp:restart": {
     args: [key: import("./pluginMcp.js").PluginMcpServerKey];
     result: void;
+  };
+  "plugin-mcp:set-config": {
+    args: [config: import("./pluginMcp.js").PluginMcpConfig];
+    result: import("./pluginMcp.js").PluginMcpConfig;
   };
   "plugin:actions-get": {
     args: [];

--- a/shared/types/ipc/pluginMcp.ts
+++ b/shared/types/ipc/pluginMcp.ts
@@ -54,5 +54,94 @@ export interface PluginMcpServerKey {
   serverId: string;
 }
 
+/**
+ * Identifier passed to `plugin-mcp:get-full-schema` — the server pair plus the
+ * tool name whose full input schema the agent has selected (tier 2).
+ */
+export interface PluginMcpToolKey extends PluginMcpServerKey {
+  toolName: string;
+}
+
+/**
+ * Tier-1 tool summary injected into agent context at session start (#9235):
+ * just the name and a short, truncated description — never the input schema.
+ * The full schema is fetched lazily via `plugin-mcp:get-full-schema` only when
+ * the agent's own discovery query matches a tool.
+ */
+export interface PluginMcpToolSummary {
+  name: string;
+  /** Truncated to {@link PLUGIN_MCP_TOOL_DESCRIPTION_CAP} chars; absent if the server gave none. */
+  description?: string;
+}
+
+/**
+ * Tier-2 full tool definition — the cached `tools/list` entry including the
+ * JSON input schema and annotations. Returned by `plugin-mcp:get-full-schema`.
+ * `inputSchema` is typed `unknown` because no shared JSON-schema type exists
+ * and the supervisor never inspects its shape (consistent with how
+ * `PluginMcpConsentService` types it for TOFU fingerprinting).
+ */
+export interface PluginMcpFullTool {
+  name: string;
+  description?: string;
+  inputSchema: unknown;
+  annotations?: unknown;
+}
+
+/**
+ * Result of `plugin-mcp:list-tools`. Carries the tier-1 summaries plus the cap
+ * that was applied — `truncated` is true when the global per-session cap
+ * ({@link PluginMcpServerKey}-spanning) clipped this server's list.
+ */
+export interface PluginMcpListToolsResult {
+  pluginId: string;
+  serverId: string;
+  tools: PluginMcpToolSummary[];
+  /** True when the global per-session cap clipped the returned list. */
+  truncated: boolean;
+  /** The cap applied (advanced setting `pluginMcpConfig.maxToolsPerSession`). */
+  maxToolsPerSession: number;
+}
+
+/**
+ * Result of `plugin-mcp:get-full-schema`. A discriminated union so callers can
+ * handle the not-found case (e.g. a stale tool name after a crash refetch)
+ * without a thrown error — mirrors `getStderr` returning an empty result for
+ * an unknown server rather than throwing.
+ */
+export type PluginMcpGetFullSchemaResult =
+  | { found: true; tool: PluginMcpFullTool }
+  | { found: false };
+
+/**
+ * Advanced plugin-MCP tuning surfaced via `plugin-mcp:get-config` /
+ * `plugin-mcp:set-config` (#9235). Persisted in the `pluginMcpConfig` store
+ * slice. Kept a distinct object (rather than loose IPC args) so future tuning
+ * knobs can be added without widening the channel signature.
+ */
+export interface PluginMcpConfig {
+  /** Hard cap on tools surfaced across ALL servers per session. */
+  maxToolsPerSession: number;
+}
+
 /** Per-server ring cap — capped lines retained for the `Settings → MCP` log view. */
 export const PLUGIN_MCP_STDERR_RING_LINES = 500;
+
+/** Clamp bounds for the user-configurable tool cap. */
+export const PLUGIN_MCP_MIN_MAX_TOOLS_PER_SESSION = 1;
+export const PLUGIN_MCP_MAX_MAX_TOOLS_PER_SESSION = 10_000;
+
+/**
+ * Tier-1 description cap (#9235). Descriptions longer than this are sliced and
+ * suffixed with an ellipsis before injection so a verbose third-party server
+ * can't blow the agent's context budget at session start.
+ */
+export const PLUGIN_MCP_TOOL_DESCRIPTION_CAP = 200;
+
+/**
+ * Default hard cap on the number of tools surfaced across ALL supervised
+ * servers within a session (#9235). Surfaced as the advanced setting
+ * `pluginMcpConfig.maxToolsPerSession`; this constant is the fallback when the
+ * setting is absent or invalid.
+ */
+export const PLUGIN_MCP_DEFAULT_MAX_TOOLS_PER_SESSION = 200;


### PR DESCRIPTION
Plugin activation no longer eagerly spawns MCP subprocesses. A server starts on the first `plugin-mcp:list-tools` enumeration at the IPC boundary, with results cached per server using singleflight dedup. Cursor pagination over raw NDJSON with a max-pages guard keeps enumeration bounded.

Resolves #9235

## Changes

**Lazy startup and two-tier injection**

`listTools` returns tier-1 summaries (name + ~200-char truncated description, no input schema). `getFullSchema` returns the full cached tool on demand for an agent-selected tool. Nothing spawns until the first enumeration request arrives.

**Hard cap**

200 tools across all servers per session, controlled by the new `pluginMcpConfig.maxToolsPerSession` setting (clamped 1–10000, default 200, exposed via `plugin-mcp:get-config` / `plugin-mcp:set-config` IPC). Budget is shared across servers; truncation is reported via the result's `truncated` flag.

**Crash recovery**

Tool cache is invalidated unconditionally on subprocess exit and on restart — not reliant on `notifications/tools/list_changed` (which is also wired as a best-effort fast-path). TOFU re-comparison happens naturally on the next `callTool` via `PluginMcpConsentService` after refetch. Stopped servers release their cache and cap-budget slice.

**Concurrency**

`inflightStart` tracking closes a `readyPromise`-null race for concurrent first-call enumerations. Identity-guarded cache writes prevent a mid-fetch `list_changed` from repopulating stale tools.

**IPC**

Adds 5 IPC types + 4 IPC ops (`plugin-mcp:list-tools`, `plugin-mcp:get-full-schema`, `plugin-mcp:get-config`, `plugin-mcp:set-config`). Codegen regenerated; drift check clean.

## Testing

17 new/updated unit tests covering the two touched service files. Full test suite passes (431 tests). Typecheck, lint, format, and IPC codegen drift checks all clean.

Depends on #9233 (supervisor lifecycle) and #9234 (TOFU comparator), both merged.

Backend only — no UI surface for `maxToolsPerSession` yet (no plugin-MCP settings panel exists).