### PR TITLE
feat(plugins): plugin diagnostics export — host.logger + report-issue payload

### DIFF
--- a/electron/ipc/__tests__/leafPreloadNamespaces.test.ts
+++ b/electron/ipc/__tests__/leafPreloadNamespaces.test.ts
@@ -148,6 +148,9 @@ describe("leaf preload namespace bindings", () => {
       expect(PLUGIN_METHOD_CHANNELS.setAuditEnabled).toBe(CHANNELS.PLUGIN_SET_AUDIT_ENABLED);
       expect(PLUGIN_METHOD_CHANNELS.setAuditMaxRecords).toBe(CHANNELS.PLUGIN_SET_AUDIT_MAX_RECORDS);
       expect(PLUGIN_METHOD_CHANNELS.exportAuditLog).toBe(CHANNELS.PLUGIN_EXPORT_AUDIT_LOG);
+      expect(PLUGIN_METHOD_CHANNELS.getDiagnosticsSnapshot).toBe(
+        CHANNELS.PLUGIN_GET_DIAGNOSTICS_SNAPSHOT
+      );
     });
 
     it("scratch matches", () => {

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -819,6 +819,7 @@ export const CHANNELS = {
   PLUGIN_SET_AUDIT_ENABLED: "plugin:set-audit-enabled",
   PLUGIN_SET_AUDIT_MAX_RECORDS: "plugin:set-audit-max-records",
   PLUGIN_EXPORT_AUDIT_LOG: "plugin:export-audit-log",
+  PLUGIN_GET_DIAGNOSTICS_SNAPSHOT: "plugin:get-diagnostics-snapshot",
   /** Bridge: main process dispatches a plugin-sourced action request to the renderer. */
   PLUGIN_DISPATCH_ACTION_REQUEST: "plugin:dispatch-action-request",
   /** Bridge: renderer returns the plugin-sourced action dispatch result to the main process. */

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -136,6 +136,10 @@ describe("registerPluginHandlers", () => {
       expect.any(Function)
     );
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:export-audit-log", expect.any(Function));
+    expect(mockIpcMainHandle).toHaveBeenCalledWith(
+      "plugin:get-diagnostics-snapshot",
+      expect.any(Function)
+    );
   });
 
   it("throws before registering any handler when invoked before enforceIpcSenderValidation", () => {

--- a/electron/ipc/handlers/plugin.preload.ts
+++ b/electron/ipc/handlers/plugin.preload.ts
@@ -26,6 +26,7 @@ export const PLUGIN_METHOD_CHANNELS = {
   setAuditEnabled: "plugin:set-audit-enabled",
   setAuditMaxRecords: "plugin:set-audit-max-records",
   exportAuditLog: "plugin:export-audit-log",
+  getDiagnosticsSnapshot: "plugin:get-diagnostics-snapshot",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof PLUGIN_METHOD_CHANNELS;

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -12,6 +12,7 @@ import {
   type PluginActionAuditRecord,
   type PluginAuditConfig,
 } from "../../../shared/types/ipc/pluginAudit.js";
+import type { PluginDiagnosticsSnapshot } from "../../../shared/types/ipc/pluginDiagnostics.js";
 import { PLUGIN_METHOD_CHANNELS } from "./plugin.preload.js";
 import { pluginService } from "../../services/PluginService.js";
 import { scrubSecrets } from "../../../shared/utils/secretScrubber.js";
@@ -399,6 +400,16 @@ async function handleExportAuditLog(records: PluginActionAuditRecord[]): Promise
   return true;
 }
 
+// ── Plugin diagnostics snapshot ───────────────────────────────────────────
+
+async function handleGetDiagnosticsSnapshot(): Promise<PluginDiagnosticsSnapshot> {
+  // Block until startup activation settles so the snapshot is post-activation
+  // (mirrors handleToolbarButtons) — otherwise a fast renderer could read an
+  // empty plugin set before any activate() runs.
+  await pluginService.waitForInit();
+  return pluginService.getDiagnosticsSnapshot();
+}
+
 export const pluginNamespace = defineIpcNamespace({
   name: "plugin",
   ops: {
@@ -422,6 +433,10 @@ export const pluginNamespace = defineIpcNamespace({
     setAuditEnabled: op(PLUGIN_METHOD_CHANNELS.setAuditEnabled, handleSetAuditEnabled),
     setAuditMaxRecords: op(PLUGIN_METHOD_CHANNELS.setAuditMaxRecords, handleSetAuditMaxRecords),
     exportAuditLog: op(PLUGIN_METHOD_CHANNELS.exportAuditLog, handleExportAuditLog),
+    getDiagnosticsSnapshot: op(
+      PLUGIN_METHOD_CHANNELS.getDiagnosticsSnapshot,
+      handleGetDiagnosticsSnapshot
+    ),
   },
 });
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -329,6 +329,27 @@ const PLUGIN_LOG_LINE_MAX_CHARS = 2048;
 /** Max audit records included per plugin in a diagnostics snapshot. */
 const PLUGIN_DIAGNOSTICS_AUDIT_PER_PLUGIN = 50;
 
+/**
+ * Serialize an arbitrary logger payload without ever throwing. Tries
+ * `JSON.stringify`, falls back to `String()`, and absorbs a throwing
+ * `toString` so `host.logger.*` keeps its no-throw contract for adversarial
+ * `fields`. Returns the empty string only when serialization yields nothing
+ * useful.
+ */
+function safeStringify(value: unknown): string {
+  try {
+    const json = JSON.stringify(value);
+    if (typeof json === "string") return json;
+  } catch {
+    // fall through to String()
+  }
+  try {
+    return String(value);
+  } catch {
+    return "[unserializable]";
+  }
+}
+
 function runUnloadStep(pluginId: string, step: string, fn: () => void): void {
   try {
     fn();
@@ -1512,33 +1533,39 @@ export class PluginService {
 
   /**
    * Append one line to a plugin's diagnostic ring buffer and mirror it to the
-   * host console. No-ops once the plugin is unloaded (membership is the
-   * liveness gate, same as the other non-revoke-guarded host methods).
-   * `fields`, when present, is JSON-serialized and folded into the message; an
-   * unserializable payload falls back to `String(fields)` rather than throwing
-   * — a logger call must never propagate an error back into plugin code.
+   * host console. `boundPlugin` is the {@link LoadedPlugin} the calling host
+   * was created for; the write no-ops unless it is still the live instance for
+   * `pluginId`. This is stricter than a `this.plugins.has(pluginId)` check: it
+   * also rejects a stale host left over from a previous activation after a
+   * same-id reload (dev-mode rescan), so the old session's timers can't
+   * pollute the new buffer.
+   *
+   * `fields`, when present, is JSON-serialized and folded into the message;
+   * serialization is fully defensive (a circular ref or a throwing `toString`
+   * never escapes). The rendered line is truncated codepoint-aware so a
+   * multi-byte glyph is never split into a lone surrogate — a lone surrogate
+   * would make `encodeURIComponent` throw downstream in `buildReportIssueUrl`.
+   * A logger call must never propagate an error back into plugin code.
    */
   private recordPluginLog(
+    boundPlugin: LoadedPlugin,
     pluginId: string,
     level: PluginDiagnosticsLogLine["level"],
     message: string,
     fields?: Record<string, unknown>
   ): void {
-    if (!this.plugins.has(pluginId)) return;
+    if (this.plugins.get(pluginId) !== boundPlugin) return;
 
-    const text = typeof message === "string" ? message : String(message);
-    let rendered = text;
+    let rendered = typeof message === "string" ? message : safeStringify(message);
     if (fields !== undefined) {
-      let serialized: string;
-      try {
-        serialized = JSON.stringify(fields);
-      } catch {
-        serialized = String(fields);
-      }
-      rendered = serialized ? `${text} ${serialized}` : text;
+      const serialized = safeStringify(fields);
+      rendered = serialized ? `${rendered} ${serialized}` : rendered;
     }
-    if (rendered.length > PLUGIN_LOG_LINE_MAX_CHARS) {
-      rendered = `${rendered.slice(0, PLUGIN_LOG_LINE_MAX_CHARS - 1)}…`;
+    // Codepoint-aware cap: spreading splits at codepoint (not UTF-16 code-unit)
+    // boundaries, so the slice can never bisect a surrogate pair.
+    const codepoints = Array.from(rendered);
+    if (codepoints.length > PLUGIN_LOG_LINE_MAX_CHARS) {
+      rendered = `${codepoints.slice(0, PLUGIN_LOG_LINE_MAX_CHARS - 1).join("")}…`;
     }
 
     let buffer = this.logBuffers.get(pluginId);
@@ -1604,6 +1631,10 @@ export class PluginService {
 
   private createHost(pluginId: string): { host: PluginHostApi; revoke: () => void } {
     let revoked = false;
+    // The LoadedPlugin this host is bound to. recordPluginLog compares against
+    // the live instance so a stale host (post-unload, or after a same-id
+    // reload) can't write into the current session's log buffer.
+    const boundPlugin = this.plugins.get(pluginId);
     const host: PluginHostApi = {
       get pluginId() {
         return pluginId;
@@ -1975,9 +2006,15 @@ export class PluginService {
       // membership (enforced inside recordPluginLog) — writes silently no-op
       // once the plugin unloads. Synchronous void return; never throws.
       logger: {
-        info: (message, fields) => this.recordPluginLog(pluginId, "info", message, fields),
-        warn: (message, fields) => this.recordPluginLog(pluginId, "warn", message, fields),
-        error: (message, fields) => this.recordPluginLog(pluginId, "error", message, fields),
+        info: (message, fields) => {
+          if (boundPlugin) this.recordPluginLog(boundPlugin, pluginId, "info", message, fields);
+        },
+        warn: (message, fields) => {
+          if (boundPlugin) this.recordPluginLog(boundPlugin, pluginId, "warn", message, fields);
+        },
+        error: (message, fields) => {
+          if (boundPlugin) this.recordPluginLog(boundPlugin, pluginId, "error", message, fields);
+        },
       },
       // NOT revoke-guarded: plugins read/write settings throughout their
       // lifetime (IPC handlers, timers), long after activate() resolves. The

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -125,6 +125,12 @@ import { getWindowRegistry, getProjectViewManager } from "../window/windowRef.js
 import type { ActionDispatchResult } from "../../shared/types/actions.js";
 import type { LoadedPluginInfo } from "../../shared/types/plugin.js";
 import type { PluginToolbarButtonId } from "../../shared/types/toolbar.js";
+import { getPluginActionAuditService } from "./PluginActionAuditService.js";
+import type {
+  PluginDiagnosticsAuditRecord,
+  PluginDiagnosticsLogLine,
+  PluginDiagnosticsSnapshot,
+} from "../../shared/types/ipc/pluginDiagnostics.js";
 import { store } from "../store.js";
 import { BUILT_IN_ACTION_IDS } from "../../shared/config/actionIds.js";
 
@@ -316,6 +322,13 @@ function toPluginLoadError(err: unknown): PluginLoadError {
  * thrown disposer would strand later steps and leak registrations that fail
  * the next load with a duplicate-id error.
  */
+/** Max retained log lines per plugin in the in-memory diagnostics ring buffer. */
+const PLUGIN_LOG_BUFFER_MAX = 500;
+/** Max bytes for a single rendered log line; longer lines are truncated with an ellipsis. */
+const PLUGIN_LOG_LINE_MAX_CHARS = 2048;
+/** Max audit records included per plugin in a diagnostics snapshot. */
+const PLUGIN_DIAGNOSTICS_AUDIT_PER_PLUGIN = 50;
+
 function runUnloadStep(pluginId: string, step: string, fn: () => void): void {
   try {
     fn();
@@ -399,6 +412,15 @@ type WorkspaceWorktreeEvent = "worktree-update" | "worktree-activated" | "worktr
 
 export class PluginService {
   private plugins = new Map<string, LoadedPlugin>();
+  /**
+   * Per-plugin diagnostic log ring buffer, keyed by `pluginId` (= manifest
+   * name). Written by `host.logger.*`, capped at {@link PLUGIN_LOG_BUFFER_MAX}
+   * lines (FIFO eviction), and cleared in {@link unloadPlugin} so a reload of
+   * the same plugin starts clean. Lines are stored raw — secret/path scrubbing
+   * happens only at the report-export boundary, never here (mirrors the
+   * action-breadcrumb ring's raw-capture convention).
+   */
+  private logBuffers = new Map<string, PluginDiagnosticsLogLine[]>();
   private handlerMap = new Map<string, PluginIpcHandler>();
   /**
    * Per-channel Zod schemas for typed `registerHandler` registrations, keyed
@@ -1488,6 +1510,98 @@ export class PluginService {
     await Promise.allSettled([...targets].map((id) => this.activatePlugin(id)));
   }
 
+  /**
+   * Append one line to a plugin's diagnostic ring buffer and mirror it to the
+   * host console. No-ops once the plugin is unloaded (membership is the
+   * liveness gate, same as the other non-revoke-guarded host methods).
+   * `fields`, when present, is JSON-serialized and folded into the message; an
+   * unserializable payload falls back to `String(fields)` rather than throwing
+   * — a logger call must never propagate an error back into plugin code.
+   */
+  private recordPluginLog(
+    pluginId: string,
+    level: PluginDiagnosticsLogLine["level"],
+    message: string,
+    fields?: Record<string, unknown>
+  ): void {
+    if (!this.plugins.has(pluginId)) return;
+
+    const text = typeof message === "string" ? message : String(message);
+    let rendered = text;
+    if (fields !== undefined) {
+      let serialized: string;
+      try {
+        serialized = JSON.stringify(fields);
+      } catch {
+        serialized = String(fields);
+      }
+      rendered = serialized ? `${text} ${serialized}` : text;
+    }
+    if (rendered.length > PLUGIN_LOG_LINE_MAX_CHARS) {
+      rendered = `${rendered.slice(0, PLUGIN_LOG_LINE_MAX_CHARS - 1)}…`;
+    }
+
+    let buffer = this.logBuffers.get(pluginId);
+    if (!buffer) {
+      buffer = [];
+      this.logBuffers.set(pluginId, buffer);
+    }
+    buffer.push({ ts: Date.now(), level, message: rendered });
+    if (buffer.length > PLUGIN_LOG_BUFFER_MAX) {
+      buffer.splice(0, buffer.length - PLUGIN_LOG_BUFFER_MAX);
+    }
+
+    console[level](`[plugin:${pluginId}] ${rendered}`);
+  }
+
+  /**
+   * Atomic, post-activation diagnostics snapshot of every loaded plugin:
+   * provenance, the per-plugin log ring buffer, and the last
+   * {@link PLUGIN_DIAGNOSTICS_AUDIT_PER_PLUGIN} audit records. Consumed by the
+   * error-report builder. `originalUrl` is intentionally omitted (it can embed
+   * install-time credentials); `argsHash`/`argsPlaintext` are dropped from
+   * audit records. Returns `{ plugins: [] }` when nothing is loaded so the
+   * report can omit the section entirely.
+   */
+  getDiagnosticsSnapshot(): PluginDiagnosticsSnapshot {
+    // getRecords() is global and newest-first; bucket per plugin in one pass,
+    // capping each bucket — no per-plugin sort needed.
+    const auditByPlugin = new Map<string, PluginDiagnosticsAuditRecord[]>();
+    for (const record of getPluginActionAuditService().getRecords()) {
+      let list = auditByPlugin.get(record.pluginId);
+      if (!list) {
+        list = [];
+        auditByPlugin.set(record.pluginId, list);
+      }
+      if (list.length >= PLUGIN_DIAGNOSTICS_AUDIT_PER_PLUGIN) continue;
+      const { argsHash: _argsHash, argsPlaintext: _argsPlaintext, ...rest } = record;
+      list.push(rest);
+    }
+
+    const plugins = this.listPlugins()
+      .filter((info) => this.plugins.has(info.manifest.name))
+      .map((info) => {
+        const pluginId = info.manifest.name;
+        const buffer = this.logBuffers.get(pluginId);
+        return {
+          pluginId,
+          displayName: info.manifest.displayName ?? info.manifest.name,
+          version: info.manifest.version,
+          source: info.source,
+          installedAt: info.installedAt,
+          isBuiltin: info.isBuiltin,
+          devMode: info.devMode,
+          disabled: info.disabled,
+          archiveHash: info.archiveHash,
+          loadError: info.loadError,
+          logLines: buffer ? buffer.map((line) => ({ ...line })) : [],
+          auditRecords: auditByPlugin.get(pluginId) ?? [],
+        };
+      });
+
+    return { plugins };
+  }
+
   private createHost(pluginId: string): { host: PluginHostApi; revoke: () => void } {
     let revoked = false;
     const host: PluginHostApi = {
@@ -1855,6 +1969,15 @@ export class PluginService {
           };
         }
         return this.sendDispatchToRenderer(actionId, args);
+      },
+      // NOT revoke-guarded for the same reason as showToast/dispatch: plugins
+      // log from post-activation callbacks and timers. Liveness is plugin
+      // membership (enforced inside recordPluginLog) — writes silently no-op
+      // once the plugin unloads. Synchronous void return; never throws.
+      logger: {
+        info: (message, fields) => this.recordPluginLog(pluginId, "info", message, fields),
+        warn: (message, fields) => this.recordPluginLog(pluginId, "warn", message, fields),
+        error: (message, fields) => this.recordPluginLog(pluginId, "error", message, fields),
       },
       // NOT revoke-guarded: plugins read/write settings throughout their
       // lifetime (IPC handlers, timers), long after activate() resolves. The
@@ -2975,6 +3098,10 @@ export class PluginService {
     // Drop the load-time-error marker (#9281) so a reload with a fixed
     // manifest can successfully clear `loadError` on next activation.
     this.pluginsWithLoadTimeErrors.delete(pluginId);
+
+    // Drop the diagnostic log ring buffer so a reload of the same plugin
+    // doesn't carry forward log lines from the previous session.
+    this.logBuffers.delete(pluginId);
 
     this.plugins.delete(pluginId);
 

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -33,7 +33,11 @@ import { randomUUID } from "crypto";
 
 const storeState = new Map<string, unknown>();
 vi.mock("electron", () => ({
-  app: { getVersion: vi.fn(() => "0.0.0") },
+  // getPath is needed because importing PluginService transitively constructs
+  // the eager ProjectStore singleton (which reads app.getPath("userData")).
+  // The path is never written to disk in these tests — ProjectStore only does
+  // I/O in initialize(), which they don't call.
+  app: { getVersion: vi.fn(() => "0.0.0"), getPath: vi.fn(() => "/tmp/daintree-plugin-int") },
 }));
 vi.mock("../../ipc/utils.js", () => ({
   broadcastToRenderer: vi.fn(),
@@ -1311,5 +1315,110 @@ describe("PluginService integration — built-in plugin loading", () => {
     } finally {
       errorSpy.mockRestore();
     }
+  });
+});
+
+describe("PluginService integration — diagnostic logger", () => {
+  async function loadWithLoggerActivate(
+    pluginName: string,
+    hostKey: string,
+    activateBody: string
+  ): Promise<PluginService> {
+    globalMarkers.add(hostKey);
+    const pluginDir = await writePlugin(pluginName, { name: pluginName, version: "1.2.3" });
+    const mainFile = `logger-${randomUUID()}.mjs`;
+    await fs.writeFile(
+      path.join(pluginDir, mainFile),
+      `export function activate(host) {\n  globalThis[${JSON.stringify(hostKey)}] = host;\n  ${activateBody}\n}\n`
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: pluginName,
+        version: "1.2.3",
+        displayName: "Logger Plugin",
+        main: mainFile,
+      })
+    );
+    const service = new PluginService(tmpDir, "0.0.0");
+    await service.initialize();
+    // Activation is deferred — the logger is wired inside activate(), so it
+    // only fires once the startup fan-out runs (mirrors the line-918 pattern).
+    await service.activateStartupFinishedPlugins();
+    return service;
+  }
+
+  it("captures logger lines (level, message, folded fields) in the snapshot", async () => {
+    const service = await loadWithLoggerActivate(
+      "acme.logger",
+      "__loggerHost1",
+      `host.logger.info("hello");
+       host.logger.warn("careful", { code: 42 });
+       host.logger.error("boom");`
+    );
+
+    const entry = service
+      .getDiagnosticsSnapshot()
+      .plugins.find((p) => p.pluginId === "acme.logger");
+    expect(entry).toBeDefined();
+    expect(entry?.displayName).toBe("Logger Plugin");
+    expect(entry?.version).toBe("1.2.3");
+    expect(entry?.logLines.map((l) => ({ level: l.level, message: l.message }))).toEqual([
+      { level: "info", message: "hello" },
+      { level: "warn", message: 'careful {"code":42}' },
+      { level: "error", message: "boom" },
+    ]);
+    expect(entry?.logLines.every((l) => typeof l.ts === "number")).toBe(true);
+  });
+
+  it("evicts oldest lines beyond the 500-entry cap (FIFO)", async () => {
+    const service = await loadWithLoggerActivate(
+      "acme.logger-cap",
+      "__loggerHost2",
+      `for (let i = 0; i < 600; i++) host.logger.info("line-" + i);`
+    );
+
+    const entry = service
+      .getDiagnosticsSnapshot()
+      .plugins.find((p) => p.pluginId === "acme.logger-cap");
+    expect(entry?.logLines).toHaveLength(500);
+    // Oldest 100 evicted: buffer holds line-100 .. line-599.
+    expect(entry?.logLines[0]?.message).toBe("line-100");
+    expect(entry?.logLines.at(-1)?.message).toBe("line-599");
+  });
+
+  it("truncates a single line longer than the per-line byte cap with an ellipsis", async () => {
+    const service = await loadWithLoggerActivate(
+      "acme.logger-long",
+      "__loggerHost3",
+      `host.logger.info("x".repeat(5000));`
+    );
+
+    const entry = service
+      .getDiagnosticsSnapshot()
+      .plugins.find((p) => p.pluginId === "acme.logger-long");
+    const line = entry?.logLines[0]?.message ?? "";
+    expect(line).toHaveLength(2048);
+    expect(line.endsWith("…")).toBe(true);
+  });
+
+  it("logger writes are a silent no-op after the plugin unloads", async () => {
+    const service = await loadWithLoggerActivate(
+      "acme.logger-unload",
+      "__loggerHost4",
+      `host.logger.info("before-unload");`
+    );
+    const host = (globalThis as Record<string, unknown>).__loggerHost4 as {
+      logger: { info: (m: string) => void };
+    };
+
+    service.unloadPlugin("acme.logger-unload");
+    // The post-unload call must not throw and must not resurrect the buffer.
+    expect(() => host.logger.info("after-unload")).not.toThrow();
+
+    const entry = service
+      .getDiagnosticsSnapshot()
+      .plugins.find((p) => p.pluginId === "acme.logger-unload");
+    expect(entry).toBeUndefined();
   });
 });

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -1402,6 +1402,37 @@ describe("PluginService integration — diagnostic logger", () => {
     expect(line.endsWith("…")).toBe(true);
   });
 
+  it("truncates multi-byte glyph lines without producing a lone surrogate", async () => {
+    const service = await loadWithLoggerActivate(
+      "acme.logger-emoji",
+      "__loggerHost5",
+      `host.logger.info("😀".repeat(3000));`
+    );
+
+    const entry = service
+      .getDiagnosticsSnapshot()
+      .plugins.find((p) => p.pluginId === "acme.logger-emoji");
+    const line = entry?.logLines[0]?.message ?? "";
+    // A lone surrogate would make encodeURIComponent throw downstream.
+    expect(() => encodeURIComponent(line)).not.toThrow();
+    expect(line.endsWith("…")).toBe(true);
+  });
+
+  it("keeps per-plugin log buffers isolated", async () => {
+    await loadWithLoggerActivate("acme.logger-a", "__loggerHost6a", `host.logger.info("from-a");`);
+    const service = await loadWithLoggerActivate(
+      "acme.logger-b",
+      "__loggerHost6b",
+      `host.logger.info("from-b");`
+    );
+
+    const snapshot = service.getDiagnosticsSnapshot();
+    const a = snapshot.plugins.find((p) => p.pluginId === "acme.logger-a");
+    const b = snapshot.plugins.find((p) => p.pluginId === "acme.logger-b");
+    expect(a?.logLines.map((l) => l.message)).toEqual(["from-a"]);
+    expect(b?.logLines.map((l) => l.message)).toEqual(["from-b"]);
+  });
+
   it("logger writes are a silent no-op after the plugin unloads", async () => {
     const service = await loadWithLoggerActivate(
       "acme.logger-unload",

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -322,6 +322,11 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
       }
     },
     settings,
+    logger: {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    },
 
     registeredActions,
     registeredHandlers,

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -362,6 +362,9 @@ export interface GeneratedElectronAPI {
     getDecorations(
       ...args: IpcInvokeMap["plugin:file-decorations-get"]["args"]
     ): Promise<IpcInvokeMap["plugin:file-decorations-get"]["result"]>;
+    getDiagnosticsSnapshot(
+      ...args: IpcInvokeMap["plugin:get-diagnostics-snapshot"]["args"]
+    ): Promise<IpcInvokeMap["plugin:get-diagnostics-snapshot"]["result"]>;
     getForgeProviders(
       ...args: IpcInvokeMap["plugin:forge-providers-get"]["args"]
     ): Promise<IpcInvokeMap["plugin:forge-providers-get"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -651,6 +651,10 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: import("./pluginAudit.js").PluginActionAuditRecord[];
   };
+  "plugin:get-diagnostics-snapshot": {
+    args: [];
+    result: import("./pluginDiagnostics.js").PluginDiagnosticsSnapshot;
+  };
   "plugin:install": {
     args: [archivePath: string, opts?: import("../plugin.js").PluginInstallOptions | undefined];
     result: import("../plugin.js").PluginInstallResult;

--- a/shared/types/ipc/pluginDiagnostics.ts
+++ b/shared/types/ipc/pluginDiagnostics.ts
@@ -1,0 +1,60 @@
+import type { PluginActionAuditRecord } from "./pluginAudit.js";
+import type { PluginInstallSource, PluginLoadError } from "../plugin.js";
+
+/**
+ * A single line from a plugin's in-memory log ring buffer, captured via
+ * `host.logger.{info,warn,error}`. `message` already folds in any structured
+ * `fields` passed to the logger and is capped at the per-line byte budget.
+ * Stored raw in the main-process buffer; secret/path scrubbing is applied only
+ * at the report-export boundary (`buildReportIssueUrl`), never on this struct.
+ */
+export interface PluginDiagnosticsLogLine {
+  /** Wall-clock epoch millis the line was logged. */
+  ts: number;
+  level: "info" | "warn" | "error";
+  /** Rendered log text (message + serialized fields), capped per line. */
+  message: string;
+}
+
+/**
+ * A plugin-action audit record projected for diagnostics export. Drops the
+ * privacy-sensitive `argsHash` and `argsPlaintext` fields — neither carries
+ * meaning for a maintainer reading a bug report, and `argsPlaintext` could
+ * surface redacted-but-still-sensitive payloads outside the audit viewer.
+ */
+export type PluginDiagnosticsAuditRecord = Omit<
+  PluginActionAuditRecord,
+  "argsHash" | "argsPlaintext"
+>;
+
+/**
+ * Per-plugin diagnostics entry. Provenance fields mirror `LoadedPluginInfo`,
+ * minus `originalUrl` — that field is documented "Never logged to console"
+ * because an install URL can embed auth tokens in its query string, so it is
+ * omitted at the type level (omission, not nulling, prevents accidental
+ * serialization).
+ */
+export interface PluginDiagnosticsPluginEntry {
+  pluginId: string;
+  displayName: string;
+  version: string;
+  source: PluginInstallSource;
+  installedAt: number;
+  isBuiltin: boolean;
+  devMode: boolean;
+  disabled: boolean;
+  archiveHash: string | null;
+  loadError: PluginLoadError | null;
+  logLines: PluginDiagnosticsLogLine[];
+  auditRecords: PluginDiagnosticsAuditRecord[];
+}
+
+/**
+ * Atomic snapshot of all loaded plugins' diagnostics, gathered in one pass via
+ * `plugin:get-diagnostics-snapshot`. Consumed by the error-report builder to
+ * append a plugin-diagnostics section. `plugins` is empty when no plugins are
+ * loaded, in which case the report omits the section entirely.
+ */
+export interface PluginDiagnosticsSnapshot {
+  plugins: PluginDiagnosticsPluginEntry[];
+}

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -679,6 +679,32 @@ export interface PluginHostApi {
    * `chmod 0o600` on POSIX — no OS keychain (#9167). See {@link SettingsApi}.
    */
   readonly settings: SettingsApi;
+  /**
+   * Structured diagnostic logger backed by a bounded per-plugin ring buffer in
+   * the main process. Lines are forwarded to the host console (prefixed
+   * `[plugin:{pluginId}]`) and retained for the most recent ~500 entries so
+   * they can be folded into an error report on demand. See {@link PluginLogger}.
+   *
+   * Like {@link invalidateFileDecorations}, {@link showToast}, and
+   * {@link dispatch} this is NOT revoke-guarded: plugins log from
+   * post-activation callbacks and timers. Writes become a silent no-op once the
+   * plugin is unloaded.
+   */
+  readonly logger: PluginLogger;
+}
+
+/**
+ * Synchronous, fire-and-forget diagnostic logger handed to a plugin via
+ * {@link PluginHostApi.logger}. Each call appends one line to the plugin's
+ * ring buffer and mirrors it to the host console. `fields` is an optional
+ * structured payload serialized alongside the message; an unserializable
+ * payload is coerced to a string rather than thrown. Calls return `void` — the
+ * write is enqueued internally and never rejects.
+ */
+export interface PluginLogger {
+  info(message: string, fields?: Record<string, unknown>): void;
+  warn(message: string, fields?: Record<string, unknown>): void;
+  error(message: string, fields?: Record<string, unknown>): void;
 }
 
 export type PluginActivate = (

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -8,6 +8,7 @@ import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { buildReportIssueUrl } from "./buildReportIssueUrl";
 import { notify } from "@/lib/notify";
 import type { ReportIssueEnrichment } from "../../../shared/types/ipc/system";
+import type { PluginDiagnosticsSnapshot } from "../../../shared/types/ipc/pluginDiagnostics";
 
 const ENRICHMENT_TIMEOUT_MS = 2000;
 
@@ -18,6 +19,19 @@ async function fetchReportEnrichment(): Promise<ReportIssueEnrichment | null> {
   if (!getter) return null;
   try {
     return await Promise.race<ReportIssueEnrichment | null>([
+      getter(),
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), ENRICHMENT_TIMEOUT_MS)),
+    ]);
+  } catch {
+    return null;
+  }
+}
+
+async function fetchPluginDiagnostics(): Promise<PluginDiagnosticsSnapshot | null> {
+  const getter = window.electron?.plugin?.getDiagnosticsSnapshot;
+  if (!getter) return null;
+  try {
+    return await Promise.race<PluginDiagnosticsSnapshot | null>([
       getter(),
       new Promise<null>((resolve) => setTimeout(() => resolve(null), ENRICHMENT_TIMEOUT_MS)),
     ]);
@@ -181,7 +195,10 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
       if (!error) return;
 
-      const enrichment = await fetchReportEnrichment();
+      const [enrichment, pluginDiagnostics] = await Promise.all([
+        fetchReportEnrichment(),
+        fetchPluginDiagnostics(),
+      ]);
 
       const { url, fullBody, usedClipboardFallback } = buildReportIssueUrl({
         incidentId,
@@ -192,6 +209,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
         context,
         systemInfo: enrichment?.systemInfo,
         recentActions: enrichment?.recentActions,
+        pluginDiagnostics,
       });
 
       if (usedClipboardFallback) {

--- a/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
@@ -327,9 +327,12 @@ describe("ErrorBoundary", () => {
     );
 
     fireEvent.click(screen.getByText("Report issue"));
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+
+    await waitFor(() =>
+      expect(
+        vi.mocked(actionService.dispatch).mock.calls.find(([id]) => id === "system.openExternal")
+      ).toBeDefined()
+    );
 
     expect(electron.system.getReportEnrichment).toHaveBeenCalledTimes(1);
     const dispatchCall = vi
@@ -360,9 +363,12 @@ describe("ErrorBoundary", () => {
     );
 
     fireEvent.click(screen.getByText("Report issue"));
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+
+    await waitFor(() =>
+      expect(
+        vi.mocked(actionService.dispatch).mock.calls.find(([id]) => id === "system.openExternal")
+      ).toBeDefined()
+    );
 
     const dispatchCall = vi
       .mocked(actionService.dispatch)
@@ -601,9 +607,7 @@ describe("ErrorBoundary", () => {
     );
 
     fireEvent.click(screen.getByText("Report issue")); // first click — hangs
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(actionService.dispatch).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(actionService.dispatch).toHaveBeenCalledTimes(1));
 
     // User gives up and recovers the pane while the first report is still in flight.
     shouldThrow = false;

--- a/src/components/ErrorBoundary/__tests__/buildReportIssueUrl.test.ts
+++ b/src/components/ErrorBoundary/__tests__/buildReportIssueUrl.test.ts
@@ -8,6 +8,7 @@ import {
   type ReportIssueInput,
 } from "../buildReportIssueUrl";
 import type { ActionBreadcrumb } from "../../../../shared/types/ipc/crashRecovery";
+import type { PluginDiagnosticsSnapshot } from "../../../../shared/types/ipc/pluginDiagnostics";
 
 function getEncodedBodyLength(url: string): number {
   const bodyParam = new URL(url).searchParams.get("body") ?? "";
@@ -433,5 +434,104 @@ describe("buildNotificationReportUrl", () => {
       makeNotificationInput({ notificationType: undefined })
     );
     expect(result.fullBody).not.toContain("**Type:**");
+  });
+});
+
+describe("buildReportIssueUrl — plugin diagnostics", () => {
+  function makePluginEntry(
+    overrides: Partial<PluginDiagnosticsSnapshot["plugins"][number]> = {}
+  ): PluginDiagnosticsSnapshot["plugins"][number] {
+    return {
+      pluginId: "acme.demo",
+      displayName: "Demo Plugin",
+      version: "2.0.0",
+      source: "sideload",
+      installedAt: 1700000000000,
+      isBuiltin: false,
+      devMode: false,
+      disabled: false,
+      archiveHash: "abc123",
+      loadError: null,
+      logLines: [{ ts: 1700000001000, level: "info", message: "started" }],
+      auditRecords: [],
+      ...overrides,
+    };
+  }
+
+  it("renders a plugin diagnostics section when plugins are loaded", () => {
+    const result = buildReportIssueUrl(
+      makeInput({ pluginDiagnostics: { plugins: [makePluginEntry()] } })
+    );
+    expect(result.fullBody).toContain("Plugin diagnostics (1)");
+    expect(result.fullBody).toContain("### Demo Plugin v2.0.0");
+    expect(result.fullBody).toContain("- id: acme.demo");
+    expect(result.fullBody).toContain("[info] started");
+  });
+
+  it("omits the section entirely when no plugins are loaded", () => {
+    const empty = buildReportIssueUrl(makeInput({ pluginDiagnostics: { plugins: [] } }));
+    expect(empty.fullBody).not.toContain("Plugin diagnostics");
+
+    const nullish = buildReportIssueUrl(makeInput({ pluginDiagnostics: null }));
+    expect(nullish.fullBody).not.toContain("Plugin diagnostics");
+  });
+
+  it("scrubs secrets and user paths in log lines", () => {
+    const result = buildReportIssueUrl(
+      makeInput({
+        pluginDiagnostics: {
+          plugins: [
+            makePluginEntry({
+              logLines: [
+                { ts: 1700000001000, level: "error", message: "read /Users/alice/secret.txt" },
+              ],
+            }),
+          ],
+        },
+      })
+    );
+    expect(result.fullBody).toContain("/Users/USER/secret.txt");
+    expect(result.fullBody).not.toContain("/Users/alice/");
+  });
+
+  it("drops the diagnostics section but keeps system info when the URL budget is tight", () => {
+    const bigLogLines = Array.from({ length: 500 }, (_, i) => ({
+      ts: 1700000001000 + i,
+      level: "info" as const,
+      message: `log line number ${i} with some padding to inflate the encoded size`,
+    }));
+    const result = buildReportIssueUrl(
+      makeInput({
+        systemInfo: "os: macOS\napp: 1.0.0",
+        pluginDiagnostics: { plugins: [makePluginEntry({ logLines: bigLogLines })] },
+      })
+    );
+
+    // The huge section forces clipboard fallback or in-URL drop; either way the
+    // URL stays within budget and the full payload retains the diagnostics.
+    expect(getEncodedBodyLength(result.url)).toBeLessThanOrEqual(URL_BODY_BUDGET);
+    expect(result.fullBody).toContain("Plugin diagnostics (1)");
+    const urlBody = decodeURIComponent(new URL(result.url).searchParams.get("body") ?? "");
+    expect(urlBody).not.toContain("log line number 250");
+  });
+
+  it("adds a plugin-count line to the clipboard-fallback stub body", () => {
+    // Long individual lines survive middle-truncation, forcing the stub path
+    // (mirrors the existing clipboard-fallback fixture).
+    const longLine = "x".repeat(1200);
+    const stack = Array.from({ length: 25 }, () => longLine).join("\n");
+    const componentStack = Array.from({ length: 10 }, () => longLine).join("\n");
+    const result = buildReportIssueUrl(
+      makeInput({
+        stack,
+        componentStack,
+        pluginDiagnostics: {
+          plugins: [makePluginEntry(), makePluginEntry({ pluginId: "acme.two" })],
+        },
+      })
+    );
+    expect(result.usedClipboardFallback).toBe(true);
+    const urlBody = decodeURIComponent(new URL(result.url).searchParams.get("body") ?? "");
+    expect(urlBody).toContain("2 plugins loaded");
   });
 });

--- a/src/components/ErrorBoundary/__tests__/buildReportIssueUrl.test.ts
+++ b/src/components/ErrorBoundary/__tests__/buildReportIssueUrl.test.ts
@@ -507,12 +507,33 @@ describe("buildReportIssueUrl — plugin diagnostics", () => {
       })
     );
 
-    // The huge section forces clipboard fallback or in-URL drop; either way the
-    // URL stays within budget and the full payload retains the diagnostics.
+    // The diagnostics section is dropped (rung 4) but system info is kept —
+    // the ladder must NOT fall through to the stub. Asserting systemInfo is
+    // present guards against a regression that drops too much.
     expect(getEncodedBodyLength(result.url)).toBeLessThanOrEqual(URL_BODY_BUDGET);
+    expect(result.usedClipboardFallback).toBe(false);
     expect(result.fullBody).toContain("Plugin diagnostics (1)");
     const urlBody = decodeURIComponent(new URL(result.url).searchParams.get("body") ?? "");
     expect(urlBody).not.toContain("log line number 250");
+    expect(urlBody).toContain("<summary>System info</summary>");
+  });
+
+  it("does not throw on log lines containing multi-byte glyphs", () => {
+    // A lone surrogate (from a naive code-unit slice upstream) would make
+    // encodeURIComponent throw; assert a well-formed multi-byte line is safe.
+    const result = buildReportIssueUrl(
+      makeInput({
+        pluginDiagnostics: {
+          plugins: [
+            makePluginEntry({
+              logLines: [{ ts: 1700000001000, level: "info", message: "😀".repeat(50) }],
+            }),
+          ],
+        },
+      })
+    );
+    expect(() => new URL(result.url)).not.toThrow();
+    expect(result.fullBody).toContain("😀");
   });
 
   it("adds a plugin-count line to the clipboard-fallback stub body", () => {

--- a/src/components/ErrorBoundary/buildReportIssueUrl.ts
+++ b/src/components/ErrorBoundary/buildReportIssueUrl.ts
@@ -7,6 +7,11 @@ import {
 import { scrubReportText } from "@shared/utils/reportScrubbers";
 
 import type { ActionBreadcrumb } from "../../../shared/types/ipc/crashRecovery";
+import type {
+  PluginDiagnosticsAuditRecord,
+  PluginDiagnosticsLogLine,
+  PluginDiagnosticsSnapshot,
+} from "../../../shared/types/ipc/pluginDiagnostics";
 
 // Re-exported so existing importers (and tests) keep a stable surface; the
 // canonical definition now lives in the shared helper.
@@ -43,6 +48,8 @@ export interface ReportIssueInput {
   systemInfo?: string;
   /** Recent action breadcrumbs (oldest first). */
   recentActions?: ActionBreadcrumb[];
+  /** Loaded-plugin diagnostics (logger ring buffer + audit tail + provenance). */
+  pluginDiagnostics?: PluginDiagnosticsSnapshot | null;
   /** Override the "now" reference for relative timestamps (test-only). */
   now?: number;
 }
@@ -110,6 +117,67 @@ function formatRecentActionsSection(actions: ActionBreadcrumb[] | undefined, now
   );
 }
 
+function formatPluginAuditLine(record: PluginDiagnosticsAuditRecord): string {
+  const ts = new Date(record.ts).toISOString();
+  const kind = record.recordType ?? "action-dispatch";
+  const parts = [ts, kind, record.actionId, record.result, `${record.durationMs}ms`];
+  if (record.errorMessage) parts.push(`— ${record.errorMessage}`);
+  return parts.join(" ");
+}
+
+function formatPluginLogLine(line: PluginDiagnosticsLogLine): string {
+  return `${new Date(line.ts).toISOString()} [${line.level}] ${line.message}`;
+}
+
+function formatPluginEntry(plugin: PluginDiagnosticsSnapshot["plugins"][number]): string {
+  const tags = [
+    plugin.isBuiltin ? "builtin" : null,
+    plugin.devMode ? "dev" : null,
+    plugin.disabled ? "disabled" : null,
+  ].filter(Boolean);
+  const tagSuffix = tags.length > 0 ? ` (${tags.join(", ")})` : "";
+  const installed = plugin.installedAt ? new Date(plugin.installedAt).toISOString() : "n/a";
+
+  const meta = [
+    `### ${plugin.displayName} v${plugin.version}${tagSuffix}`,
+    `- id: ${plugin.pluginId}`,
+    `- source: ${plugin.source}`,
+    `- installed: ${installed}`,
+    `- archiveHash: ${plugin.archiveHash ?? "n/a"}`,
+    `- loadError: ${plugin.loadError ? plugin.loadError.message : "none"}`,
+  ].join("\n");
+
+  const auditBlock =
+    plugin.auditRecords.length > 0
+      ? `\n\naudit (${plugin.auditRecords.length}):\n\`\`\`\n` +
+        `${plugin.auditRecords.map(formatPluginAuditLine).join("\n")}\n\`\`\``
+      : "";
+
+  const logBlock =
+    plugin.logLines.length > 0
+      ? `\n\nlogs (${plugin.logLines.length}):\n\`\`\`\n` +
+        `${plugin.logLines.map(formatPluginLogLine).join("\n")}\n\`\`\``
+      : "";
+
+  return meta + auditBlock + logBlock;
+}
+
+function formatPluginDiagnosticsSection(
+  snapshot: PluginDiagnosticsSnapshot | null | undefined
+): string {
+  if (!snapshot || snapshot.plugins.length === 0) return "";
+  const body = snapshot.plugins.map(formatPluginEntry).join("\n\n");
+  // Scrub the whole block once — log lines and loadError messages can carry
+  // user paths or secret sigils. scrubReportText only rewrites those, never
+  // the surrounding Markdown structure.
+  const scrubbed = scrubReportText(body);
+  return (
+    `\n\n<details>\n<summary>Plugin diagnostics (${snapshot.plugins.length})</summary>\n\n` +
+    `${scrubbed}\n\n` +
+    `</details>`
+  );
+}
+
 function formatBody(params: {
   componentName: string | undefined;
   incidentId: string | null;
@@ -119,6 +187,7 @@ function formatBody(params: {
   componentStack: string;
   systemInfo?: string;
   recentActions?: ActionBreadcrumb[];
+  pluginDiagnostics?: PluginDiagnosticsSnapshot | null;
   now: number;
 }): string {
   const {
@@ -130,6 +199,7 @@ function formatBody(params: {
     componentStack,
     systemInfo,
     recentActions,
+    pluginDiagnostics,
     now,
   } = params;
   return (
@@ -142,7 +212,8 @@ function formatBody(params: {
     `**Stack Trace:**\n\`\`\`\n${stack || "No stack trace"}\n\`\`\`\n\n` +
     `**Component Stack:**\n\`\`\`\n${componentStack || "No component stack"}\n\`\`\`` +
     formatSystemInfoSection(systemInfo) +
-    formatRecentActionsSection(recentActions, now)
+    formatRecentActionsSection(recentActions, now) +
+    formatPluginDiagnosticsSection(pluginDiagnostics)
   );
 }
 
@@ -196,15 +267,21 @@ function buildStubBody(params: {
   componentName: string | undefined;
   incidentId: string | null;
   message: string;
+  pluginCount: number;
 }): string {
-  const { componentName, incidentId, message } = params;
+  const { componentName, incidentId, message, pluginCount } = params;
   const cappedMessage = capForBudget(message || "Unknown error", STUB_MESSAGE_BUDGET);
+  const pluginLine =
+    pluginCount > 0
+      ? `\n_${pluginCount} plugin${pluginCount === 1 ? "" : "s"} loaded — full diagnostics in the clipboard payload._\n`
+      : "";
   return (
     `## Error Report\n\n` +
     `The full error details were copied to your clipboard — please paste them below.\n\n` +
     `**Component:** ${componentName || "Unknown"}\n` +
     `**Incident ID:** ${incidentId ?? "unknown"}\n` +
-    `**Message:** ${cappedMessage}\n`
+    `**Message:** ${cappedMessage}\n` +
+    pluginLine
   );
 }
 
@@ -229,9 +306,10 @@ function buildNotificationStubBody(params: { incidentId: string | null; message:
  *   1. Full body + enrichment sections fit → use it
  *   2. Drop componentStack, keep enrichment
  *   3. Middle-truncate stack, keep enrichment
- *   4. Drop recentActions section, keep systemInfo
- *   5. Drop systemInfo too
- *   6. Stub body + clipboard fallback
+ *   4. Drop plugin diagnostics (the largest section), keep systemInfo + actions
+ *   5. Drop recentActions section, keep systemInfo
+ *   6. Drop systemInfo too
+ *   7. Stub body + clipboard fallback
  */
 export function buildReportIssueUrl(input: ReportIssueInput): ReportIssueResult {
   // Redact user paths/secrets before the stack enters either the URL body or
@@ -255,6 +333,7 @@ export function buildReportIssueUrl(input: ReportIssueInput): ReportIssueResult 
     componentStack,
     systemInfo: input.systemInfo,
     recentActions: input.recentActions,
+    pluginDiagnostics: input.pluginDiagnostics,
   });
 
   if (encodeURIComponent(fullBody).length <= URL_BODY_BUDGET) {
@@ -267,6 +346,7 @@ export function buildReportIssueUrl(input: ReportIssueInput): ReportIssueResult 
     componentStack: COMPONENT_STACK_PLACEHOLDER,
     systemInfo: input.systemInfo,
     recentActions: input.recentActions,
+    pluginDiagnostics: input.pluginDiagnostics,
   });
 
   if (encodeURIComponent(withoutComponentStack).length <= URL_BODY_BUDGET) {
@@ -284,6 +364,7 @@ export function buildReportIssueUrl(input: ReportIssueInput): ReportIssueResult 
     componentStack: COMPONENT_STACK_PLACEHOLDER,
     systemInfo: input.systemInfo,
     recentActions: input.recentActions,
+    pluginDiagnostics: input.pluginDiagnostics,
   });
 
   if (encodeURIComponent(withTruncatedStack).length <= URL_BODY_BUDGET) {
@@ -294,7 +375,27 @@ export function buildReportIssueUrl(input: ReportIssueInput): ReportIssueResult 
     };
   }
 
-  // Drop recent actions first — the system info is more compact and more
+  // Drop plugin diagnostics next — it's the largest enrichment section (a
+  // 500-line log buffer per plugin), and the full payload is preserved on the
+  // clipboard regardless. systemInfo + recent actions stay in the URL.
+  const withoutPluginDiagnostics = formatBody({
+    ...base,
+    stack: truncatedStack,
+    componentStack: COMPONENT_STACK_PLACEHOLDER,
+    systemInfo: input.systemInfo,
+    recentActions: input.recentActions,
+    pluginDiagnostics: undefined,
+  });
+
+  if (encodeURIComponent(withoutPluginDiagnostics).length <= URL_BODY_BUDGET) {
+    return {
+      url: makeUrl(title, withoutPluginDiagnostics),
+      fullBody,
+      usedClipboardFallback: false,
+    };
+  }
+
+  // Drop recent actions next — the system info is more compact and more
   // useful for triage than a long action log when budget is tight.
   const withoutActions = formatBody({
     ...base,
@@ -302,6 +403,7 @@ export function buildReportIssueUrl(input: ReportIssueInput): ReportIssueResult 
     componentStack: COMPONENT_STACK_PLACEHOLDER,
     systemInfo: input.systemInfo,
     recentActions: undefined,
+    pluginDiagnostics: undefined,
   });
 
   if (encodeURIComponent(withoutActions).length <= URL_BODY_BUDGET) {
@@ -332,6 +434,7 @@ export function buildReportIssueUrl(input: ReportIssueInput): ReportIssueResult 
     componentName: input.componentName,
     incidentId: input.incidentId,
     message: input.message,
+    pluginCount: input.pluginDiagnostics?.plugins.length ?? 0,
   });
 
   return { url: makeUrl(title, stubBody), fullBody, usedClipboardFallback: true };


### PR DESCRIPTION
## Summary

- Adds `host.logger` (`info`/`warn`/`error`) to each plugin instance, backed by a per-plugin ring buffer (500 lines, FIFO eviction, 2048-codepoint/line cap, console-forwarded with `[plugin:id]` prefix)
- Adds a `plugin:get-diagnostics-snapshot` IPC endpoint returning an atomic snapshot: per-plugin provenance, last 50 audit records per plugin, and the log buffer (`originalUrl` omitted as a credential-leak guard)
- Wires the snapshot into `buildReportIssueUrl` (new `plugin-diagnostics` section, scrubbed at export, dropped first in the URL truncation ladder) and into `ErrorBoundary` crash enrichment (2s timeout, null fallback)

Resolves #9291

## Changes

- `PluginService` — ring buffer management: FIFO eviction, surrogate-safe line cap, no-op after unload, buffer cleared on plugin unload; bound to the activating plugin instance so stale/reloaded hosts can't pollute the live buffer; intentionally not revoke-guarded so post-activation callbacks are captured
- `electron/ipc/handlers/plugin.ts` + `channels.ts` + generated types — new `plugin:get-diagnostics-snapshot` channel
- `shared/types/ipc/pluginDiagnostics.ts` + `shared/types/plugin.ts` — snapshot shape types
- `buildReportIssueUrl.ts` — plugin-diagnostics section with `scrubReportText` pass; truncation ladder drops plugin diagnostics first
- `ErrorBoundary.tsx` — fetches snapshot alongside crash enrichment, 2s timeout, null fallback
- `shared/testing/createMockHost.ts` — `logger` added to mock plugin host

## Testing

Tests cover: ring-buffer eviction, line cap, surrogate safety, per-plugin isolation, no-op after unload, snapshot shape, report formatting, scrubbing, and truncation-ladder ordering. All targeted tests and `npm run check` (typecheck/lint/format/IPC codegen) pass.