### PR TITLE
feat(menus): align grid context menu with dock, group agents by toolbar pin

### DIFF
--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useRef, useCallback, useLayoutEffect } from "react";
 
+import { useShallow } from "zustand/react/shallow";
 import { SortableContext, horizontalListSortingStrategy } from "@dnd-kit/sortable";
 import { useDndContext, useDroppable } from "@dnd-kit/core";
 import { ChevronLeft, ChevronRight } from "lucide-react";
@@ -32,6 +33,8 @@ import { useHorizontalScrollControls } from "@/hooks";
 import { useProjectSettings } from "@/hooks/useProjectSettings";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
+import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
+import { sortAgentsByToolbarPin } from "@/lib/agentMenuOrder";
 import type { ActionSource } from "@shared/types/actions";
 import { actionService } from "@/services/ActionService";
 import {
@@ -84,6 +87,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
   const helpTerminalId = useHelpPanelStore((s) => s.terminalId);
   const agentSettings = useAgentSettingsStore((s) => s.settings);
   const agentAvailability = useCliAvailabilityStore((s) => s.availability);
+  const leftButtons = useToolbarPreferencesStore(useShallow((s) => s.layout.leftButtons));
   const setDockDensity = usePreferencesStore((s) => s.setDockDensity);
   const { settings: projectSettings } = useProjectSettings();
   const hasDevPreview = Boolean(projectSettings?.devServerCommand?.trim());
@@ -128,11 +132,11 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
   const activeWorktree = activeWorktreeId ? worktrees.find((w) => w.id === activeWorktreeId) : null;
   const cwd = activeWorktree?.path ?? currentProject?.path ?? "";
 
-  const launchAgents = useMemo<DockLaunchAgent[]>(() => {
+  const { sorted: launchAgents, pinnedCount } = useMemo(() => {
     const baseIds = getAgentIds();
     const settingsIds = agentSettings?.agents ? Object.keys(agentSettings.agents) : [];
     const extraIds = settingsIds.filter((id) => !baseIds.includes(id)).sort();
-    return [...baseIds, ...extraIds]
+    const agents: DockLaunchAgent[] = [...baseIds, ...extraIds]
       .filter((id) => isAgentInstalled(agentAvailability?.[id]))
       .map((id) => {
         const config = getAgentConfig(id);
@@ -144,7 +148,8 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
           availability: agentAvailability?.[id],
         };
       });
-  }, [agentAvailability, agentSettings]);
+    return sortAgentsByToolbarPin(agents, leftButtons, agentSettings);
+  }, [agentAvailability, agentSettings, leftButtons]);
 
   const recipeContext = activeWorktree
     ? {
@@ -334,6 +339,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
           <div className="shrink-0 flex items-center">
             <DockLaunchButton
               agents={launchAgents}
+              pinnedCount={pinnedCount}
               hasDevPreview={hasDevPreview}
               onLaunchAgent={(agentId) => void handleAddTerminal(agentId, "menu")}
               activeWorktreeId={activeWorktreeId}
@@ -464,6 +470,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
         <DockLaunchMenuItems
           components={CONTEXT_MENU_COMPONENTS}
           agents={launchAgents}
+          pinnedCount={pinnedCount}
           hasDevPreview={hasDevPreview}
           activeWorktreeId={activeWorktreeId}
           cwd={cwd}

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -25,6 +25,7 @@ const DROPDOWN_COMPONENTS: DockLaunchMenuComponents = {
 
 interface DockLaunchButtonProps {
   agents: ReadonlyArray<DockLaunchAgent>;
+  pinnedCount?: number;
   hasDevPreview: boolean;
   onLaunchAgent: (agentId: string) => void;
   activeWorktreeId: string | null;
@@ -34,6 +35,7 @@ interface DockLaunchButtonProps {
 
 export function DockLaunchButton({
   agents,
+  pinnedCount,
   hasDevPreview,
   onLaunchAgent,
   activeWorktreeId,
@@ -102,6 +104,7 @@ export function DockLaunchButton({
         <DockLaunchMenuItems
           components={DROPDOWN_COMPONENTS}
           agents={agents}
+          pinnedCount={pinnedCount}
           hasDevPreview={hasDevPreview}
           activeWorktreeId={activeWorktreeId}
           cwd={cwd}

--- a/src/components/Layout/DockLaunchMenuItems.tsx
+++ b/src/components/Layout/DockLaunchMenuItems.tsx
@@ -32,6 +32,15 @@ interface DockLaunchMenuItemsProps {
   cwd: string;
   recipeContext?: RecipeContext;
   onLaunchAgent: (agentId: string) => void;
+  /**
+   * Number of leading `agents` entries that are pinned to the toolbar (as
+   * produced by `sortAgentsByToolbarPin`). When defined and a strict subset of
+   * `agents`, the list renders as two labelled groups ("Pinned" / "Other")
+   * split by a separator. Otherwise the list renders flat under a single
+   * "Launch agent" label, preserving the original behavior for callers that
+   * don't pass it.
+   */
+  pinnedCount?: number;
   // The surface attribution to attach to the settings dispatch for
   // non-launchable rows. Defaults to "menu"; ContentDock's context-menu
   // path overrides it so telemetry stays consistent with how the user
@@ -47,6 +56,7 @@ export function DockLaunchMenuItems({
   cwd,
   recipeContext,
   onLaunchAgent,
+  pinnedCount,
   settingsSource = "menu",
 }: DockLaunchMenuItemsProps) {
   // Subscribe inside the menu so the listener only runs while open.
@@ -57,49 +67,68 @@ export function DockLaunchMenuItems({
       (r.worktreeId === undefined || r.worktreeId === (activeWorktreeId ?? undefined))
   );
 
+  const renderAgentItem = (agent: DockLaunchAgent) => {
+    const Icon = agent.icon;
+    const isLaunchable = isAgentLaunchable(agent.availability);
+    const blocked = isAgentBlocked(agent.availability);
+    // Mirrors AgentButton.tsx: a non-launchable but installed agent
+    // dims and routes to its settings subtab so the user can resolve
+    // the precondition instead of bouncing off a disabled row.
+    const settingsTooltip = blocked
+      ? `${agent.name} is blocked by endpoint security. Click to configure.`
+      : `${agent.name} needs setup. Click to configure.`;
+    return (
+      <C.Item
+        key={agent.id}
+        className={!isLaunchable ? "opacity-70" : undefined}
+        title={!isLaunchable ? settingsTooltip : undefined}
+        onSelect={() => {
+          if (isLaunchable) {
+            onLaunchAgent(agent.id);
+          } else {
+            void actionService.dispatch(
+              "app.settings.openTab",
+              { tab: "agents", subtab: agent.id },
+              { source: settingsSource }
+            );
+          }
+        }}
+      >
+        {Icon ? (
+          <BrandMark brandColor={agent.brandColor} className="w-3.5 h-3.5 mr-2">
+            <Icon className="w-3.5 h-3.5" brandColor={agent.brandColor} />
+          </BrandMark>
+        ) : (
+          <SquareTerminal className="w-3.5 h-3.5 mr-2" />
+        )}
+        {agent.name}
+      </C.Item>
+    );
+  };
+
+  // Only split into labelled groups when the pinned set is a strict subset —
+  // an all-pinned or all-unpinned list stays a single "Launch agent" group so
+  // a lone "Pinned"/"Other" header never sits over the whole list.
+  const showGroups = pinnedCount !== undefined && pinnedCount > 0 && pinnedCount < agents.length;
+
   return (
     <>
       {agents.length > 0 && (
         <>
-          <C.Label>Launch agent</C.Label>
-          {agents.map((agent) => {
-            const Icon = agent.icon;
-            const isLaunchable = isAgentLaunchable(agent.availability);
-            const blocked = isAgentBlocked(agent.availability);
-            // Mirrors AgentButton.tsx: a non-launchable but installed agent
-            // dims and routes to its settings subtab so the user can resolve
-            // the precondition instead of bouncing off a disabled row.
-            const settingsTooltip = blocked
-              ? `${agent.name} is blocked by endpoint security. Click to configure.`
-              : `${agent.name} needs setup. Click to configure.`;
-            return (
-              <C.Item
-                key={agent.id}
-                className={!isLaunchable ? "opacity-70" : undefined}
-                title={!isLaunchable ? settingsTooltip : undefined}
-                onSelect={() => {
-                  if (isLaunchable) {
-                    onLaunchAgent(agent.id);
-                  } else {
-                    void actionService.dispatch(
-                      "app.settings.openTab",
-                      { tab: "agents", subtab: agent.id },
-                      { source: settingsSource }
-                    );
-                  }
-                }}
-              >
-                {Icon ? (
-                  <BrandMark brandColor={agent.brandColor} className="w-3.5 h-3.5 mr-2">
-                    <Icon className="w-3.5 h-3.5" brandColor={agent.brandColor} />
-                  </BrandMark>
-                ) : (
-                  <SquareTerminal className="w-3.5 h-3.5 mr-2" />
-                )}
-                {agent.name}
-              </C.Item>
-            );
-          })}
+          {showGroups ? (
+            <>
+              <C.Label>Pinned</C.Label>
+              {agents.slice(0, pinnedCount).map(renderAgentItem)}
+              <C.Separator />
+              <C.Label>Other</C.Label>
+              {agents.slice(pinnedCount).map(renderAgentItem)}
+            </>
+          ) : (
+            <>
+              <C.Label>Launch agent</C.Label>
+              {agents.map(renderAgentItem)}
+            </>
+          )}
           <C.Separator />
         </>
       )}

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -133,7 +133,7 @@ describe("DockLaunchButton", () => {
   });
 
   it("splits agents into Pinned/Other groups when pinnedCount is a strict subset", () => {
-    const { getAllByTestId } = render(
+    const { getAllByTestId, container } = render(
       <DockLaunchButton
         agents={AGENTS}
         pinnedCount={1}
@@ -146,6 +146,13 @@ describe("DockLaunchButton", () => {
 
     const labels = getAllByTestId("dock-launcher-label").map((el) => el.textContent);
     expect(labels).toEqual(["Pinned", "Other", "Launch panel"]);
+
+    // Assert document order so a regression that puts both agents under one
+    // group (or swaps them) is caught: Pinned → Claude → Other → Gemini.
+    const text = container.textContent ?? "";
+    expect(text.indexOf("Pinned")).toBeLessThan(text.indexOf("Claude"));
+    expect(text.indexOf("Claude")).toBeLessThan(text.indexOf("Other"));
+    expect(text.indexOf("Other")).toBeLessThan(text.indexOf("Gemini"));
   });
 
   it("keeps a flat Launch agent group when all agents are pinned", () => {

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -132,6 +132,38 @@ describe("DockLaunchButton", () => {
     expect(labels).toEqual(["Launch agent", "Launch panel", "Launch recipe"]);
   });
 
+  it("splits agents into Pinned/Other groups when pinnedCount is a strict subset", () => {
+    const { getAllByTestId } = render(
+      <DockLaunchButton
+        agents={AGENTS}
+        pinnedCount={1}
+        hasDevPreview={false}
+        onLaunchAgent={vi.fn()}
+        activeWorktreeId={null}
+        cwd="/tmp"
+      />
+    );
+
+    const labels = getAllByTestId("dock-launcher-label").map((el) => el.textContent);
+    expect(labels).toEqual(["Pinned", "Other", "Launch panel"]);
+  });
+
+  it("keeps a flat Launch agent group when all agents are pinned", () => {
+    const { getAllByTestId } = render(
+      <DockLaunchButton
+        agents={AGENTS}
+        pinnedCount={AGENTS.length}
+        hasDevPreview={false}
+        onLaunchAgent={vi.fn()}
+        activeWorktreeId={null}
+        cwd="/tmp"
+      />
+    );
+
+    const labels = getAllByTestId("dock-launcher-label").map((el) => el.textContent);
+    expect(labels).toEqual(["Launch agent", "Launch panel"]);
+  });
+
   it("invokes onLaunchAgent for a launchable agent", () => {
     const onLaunchAgent = vi.fn();
     const { getByText } = render(

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -25,7 +25,7 @@ import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
 import { useProjectStore } from "@/store/projectStore";
-import { computeGridCanLaunch, computeGridSelectedAgentIds } from "./contentGridAgentFilter";
+import { computeGridSelectedAgentIds } from "./contentGridAgentFilter";
 import { buildFleetPanels } from "./contentGridFleetPanels";
 import { useDndPlaceholder, useIsDragging, GRID_PLACEHOLDER_ID } from "@/components/DragDrop";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
@@ -53,6 +53,8 @@ import {
   ContextMenuActionItem,
   ContextMenuContent,
   ContextMenuCheckboxItem,
+  ContextMenuItem,
+  ContextMenuLabel,
   ContextMenuSeparator,
   ContextMenuSub,
   ContextMenuSubContent,
@@ -60,7 +62,17 @@ import {
 } from "@/components/ui/context-menu";
 import { MenuActionSourceContext } from "@/components/ui/menu-source";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
-import { getEffectiveAgentIds, getEffectiveAgentConfig } from "@shared/config/agentRegistry";
+import { getEffectiveAgentIds } from "@shared/config/agentRegistry";
+import { getAgentConfig } from "@/config/agents";
+import {
+  DockLaunchMenuItems,
+  type DockLaunchAgent,
+  type DockLaunchMenuComponents,
+} from "@/components/Layout/DockLaunchMenuItems";
+import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
+import { useAgentSettingsStore } from "@/store/agentSettingsStore";
+import { useProjectSettingsStore } from "@/store/projectSettingsStore";
+import { sortAgentsByToolbarPin } from "@/lib/agentMenuOrder";
 import { getMaximizedGroupFocusTarget } from "./contentGridFocus";
 import { setGridLayoutSnapshot } from "./gridLayoutSnapshot";
 import { actionService } from "@/services/ActionService";
@@ -72,6 +84,15 @@ import { actionService } from "@/services/ActionService";
 const EMPTY_PANEL_IDS: string[] = [];
 const EMPTY_TERMINALS: PanelInstance[] = [];
 const EMPTY_TAB_GROUPS: TabGroup[] = [];
+
+// Radix primitives mapped for the shared dock/grid launch menu. Defined per
+// call site (mirrors ContentDock) so the presentational component stays
+// decoupled from the consumer's Radix import space.
+const GRID_CONTEXT_MENU_COMPONENTS: DockLaunchMenuComponents = {
+  Item: ContextMenuItem,
+  Label: ContextMenuLabel,
+  Separator: ContextMenuSeparator,
+};
 
 export function pixelSnapTransform({ x, y }: TransformProperties): string {
   const tx = typeof x === "number" ? x : parseFloat(x ?? "0") || 0;
@@ -132,7 +153,6 @@ export interface ContentGridContext {
   panelIds: string[];
   gridItemCount: number;
   twoPaneTerminals: [PanelInstance, PanelInstance] | null;
-  gridAgentMenuItems: { id: string; name: string; canLaunch: boolean }[];
   gridContextMenuContent: React.ReactNode;
   handleAddTabForPanel: (panel: PanelInstance) => Promise<void>;
   handleGridLaunch: (agentId: string) => void;
@@ -223,6 +243,14 @@ export function useContentGridContext({
   const showProjectPulse = usePreferencesStore((state) => state.showProjectPulse);
   const currentProject = useProjectStore((state) => state.currentProject);
   const isAvailabilityInitialized = useCliAvailabilityStore((s) => s.isInitialized);
+  // `useShallow` is mandatory on the `leftButtons` array slice — a bare
+  // selector returns a new array reference every store tick and would
+  // invalidate this hook's "use memo" block on any unrelated toolbar update.
+  const leftButtons = useToolbarPreferencesStore(useShallow((s) => s.layout.leftButtons));
+  const agentSettings = useAgentSettingsStore((s) => s.settings);
+  const hasDevPreview = useProjectSettingsStore((s) =>
+    Boolean(s.settings?.devServerCommand?.trim())
+  );
 
   const gridSelectedAgentIds = useMemo(
     () =>
@@ -243,6 +271,17 @@ export function useContentGridContext({
       ? activeWorktree.name?.trim() || "Unknown Worktree"
       : activeWorktree.branch?.trim() || activeWorktree.name?.trim() || "Unknown Worktree"
     : null;
+
+  // Mirrors ContentDock so the shared launch menu can run recipes with the
+  // same worktree-scoped variable substitutions from the grid surface.
+  const gridRecipeContext = activeWorktree
+    ? {
+        issueNumber: activeWorktree.issueNumber,
+        prNumber: activeWorktree.linked?.pr?.ref.number,
+        branchName: activeWorktree.branch,
+        worktreePath: activeWorktree.path,
+      }
+    : undefined;
 
   const isInTrash = usePanelStore((state) => state.isInTrash);
 
@@ -632,15 +671,23 @@ export function useContentGridContext({
   );
   const layoutAnimationEnabled = !isProjectSwitching && closingIds.size === 0;
 
-  const gridAgentMenuItems = useMemo(() => {
-    return getEffectiveAgentIds()
+  // Build the same `DockLaunchAgent[]` shape the dock uses so the grid menu
+  // renders identical brand icons, then split/order by toolbar pin state.
+  const { sorted: gridLaunchAgents, pinnedCount: gridAgentPinnedCount } = useMemo(() => {
+    const agents: DockLaunchAgent[] = getEffectiveAgentIds()
       .filter((id) => !gridSelectedAgentIds || gridSelectedAgentIds.has(id))
       .map((id) => {
-        const agentConfig = getEffectiveAgentConfig(id);
-        const canLaunch = computeGridCanLaunch(id, isAvailabilityInitialized, agentAvailability);
-        return { id, name: agentConfig?.name ?? id, canLaunch };
+        const config = getAgentConfig(id);
+        return {
+          id,
+          name: config?.name ?? id,
+          icon: config?.icon,
+          brandColor: config?.color,
+          availability: agentAvailability?.[id],
+        };
       });
-  }, [agentAvailability, gridSelectedAgentIds, isAvailabilityInitialized]);
+    return sortAgentsByToolbarPin(agents, leftButtons, agentSettings);
+  }, [agentAvailability, gridSelectedAgentIds, leftButtons, agentSettings]);
 
   const handleGridLaunch = useCallback(
     (agentId: string) => {
@@ -949,29 +996,17 @@ export function useContentGridContext({
 
   const gridContextMenuContent = (
     <ContextMenuContent>
-      <ContextMenuActionItem
-        actionId="agent.launch"
-        args={{ agentId: "terminal", location: "grid", cwd: defaultCwd || undefined }}
-      >
-        New Terminal
-      </ContextMenuActionItem>
-      <ContextMenuActionItem
-        actionId="agent.launch"
-        args={{ agentId: "browser", location: "grid", cwd: defaultCwd || undefined }}
-      >
-        New Browser
-      </ContextMenuActionItem>
-      {gridAgentMenuItems.length > 0 && <ContextMenuSeparator />}
-      {gridAgentMenuItems.map((agent) => (
-        <ContextMenuActionItem
-          key={agent.id}
-          actionId="agent.launch"
-          args={{ agentId: agent.id, location: "grid", cwd: defaultCwd || undefined }}
-          disabled={!agent.canLaunch}
-        >
-          New {agent.name}
-        </ContextMenuActionItem>
-      ))}
+      <DockLaunchMenuItems
+        components={GRID_CONTEXT_MENU_COMPONENTS}
+        agents={gridLaunchAgents}
+        pinnedCount={gridAgentPinnedCount}
+        hasDevPreview={hasDevPreview}
+        activeWorktreeId={activeWorktreeId}
+        cwd={defaultCwd ?? ""}
+        recipeContext={gridRecipeContext}
+        onLaunchAgent={handleGridLaunch}
+        settingsSource="context-menu"
+      />
       <ContextMenuSeparator />
       <ContextMenuSub>
         <ContextMenuSubTrigger>Grid Layout</ContextMenuSubTrigger>
@@ -1080,7 +1115,6 @@ export function useContentGridContext({
     panelIds,
     gridItemCount,
     twoPaneTerminals,
-    gridAgentMenuItems,
     gridContextMenuContent,
     handleAddTabForPanel,
     handleGridLaunch,

--- a/src/lib/__tests__/agentMenuOrder.test.ts
+++ b/src/lib/__tests__/agentMenuOrder.test.ts
@@ -52,9 +52,27 @@ describe("sortAgentsByToolbarPin", () => {
     expect(pinnedCount).toBe(0);
   });
 
-  it("returns pinnedCount === length when all agents are pinned", () => {
+  it("returns pinnedCount === length and applies leftButtons order when all agents are pinned", () => {
     const agents = [agent("claude", "ready"), agent("gemini", "ready")];
-    const { pinnedCount } = sortAgentsByToolbarPin(agents, ["gemini", "claude"], settings({}));
+    const { sorted, pinnedCount } = sortAgentsByToolbarPin(
+      agents,
+      ["gemini", "claude"],
+      settings({})
+    );
+    // leftButtons reverses the input order — guards against a sort that counts
+    // pinned agents correctly but ignores the toolbar ordering.
+    expect(sorted.map((a) => a.id)).toEqual(["gemini", "claude"]);
+    expect(pinnedCount).toBe(2);
+  });
+
+  it("orders [inLeftButtons, pinned-absent, unpinned] across all three groups", () => {
+    const agents = [
+      agent("gemini", "ready"), // pinned, absent from leftButtons → end of pinned group
+      agent("codex", "missing"), // unpinned
+      agent("claude", "ready"), // pinned, leftButtons index 0
+    ];
+    const { sorted, pinnedCount } = sortAgentsByToolbarPin(agents, ["claude"], settings({}));
+    expect(sorted.map((a) => a.id)).toEqual(["claude", "gemini", "codex"]);
     expect(pinnedCount).toBe(2);
   });
 

--- a/src/lib/__tests__/agentMenuOrder.test.ts
+++ b/src/lib/__tests__/agentMenuOrder.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import type { AgentSettings } from "@shared/types/agentSettings";
+import type { AgentAvailabilityState } from "@shared/types";
+import { sortAgentsByToolbarPin, type PinnableAgent } from "../agentMenuOrder";
+
+function agent(id: string, availability?: AgentAvailabilityState): PinnableAgent {
+  return { id, availability };
+}
+
+function settings(agents: AgentSettings["agents"]): AgentSettings {
+  return { agents };
+}
+
+describe("sortAgentsByToolbarPin", () => {
+  it("orders pinned agents by leftButtons index, unpinned trailing in input order", () => {
+    const agents = [agent("claude", "missing"), agent("gemini", "ready"), agent("codex", "ready")];
+    const { sorted, pinnedCount } = sortAgentsByToolbarPin(
+      agents,
+      ["codex", "gemini"],
+      settings({})
+    );
+    expect(sorted.map((a) => a.id)).toEqual(["codex", "gemini", "claude"]);
+    expect(pinnedCount).toBe(2);
+  });
+
+  it("treats explicit pinned:true as pinned regardless of availability", () => {
+    const agents = [agent("claude", "missing"), agent("gemini", "missing")];
+    const { sorted, pinnedCount } = sortAgentsByToolbarPin(
+      agents,
+      ["claude"],
+      settings({ claude: { pinned: true } })
+    );
+    expect(sorted.map((a) => a.id)).toEqual(["claude", "gemini"]);
+    expect(pinnedCount).toBe(1);
+  });
+
+  it("treats explicit pinned:false as unpinned even when installed", () => {
+    const agents = [agent("claude", "ready"), agent("gemini", "ready")];
+    const { sorted, pinnedCount } = sortAgentsByToolbarPin(
+      agents,
+      ["claude", "gemini"],
+      settings({ claude: { pinned: false } })
+    );
+    expect(sorted.map((a) => a.id)).toEqual(["gemini", "claude"]);
+    expect(pinnedCount).toBe(1);
+  });
+
+  it("returns pinnedCount 0 when no agents are pinned", () => {
+    const agents = [agent("claude", "missing"), agent("gemini", undefined)];
+    const { sorted, pinnedCount } = sortAgentsByToolbarPin(agents, [], settings({}));
+    expect(sorted.map((a) => a.id)).toEqual(["claude", "gemini"]);
+    expect(pinnedCount).toBe(0);
+  });
+
+  it("returns pinnedCount === length when all agents are pinned", () => {
+    const agents = [agent("claude", "ready"), agent("gemini", "ready")];
+    const { pinnedCount } = sortAgentsByToolbarPin(agents, ["gemini", "claude"], settings({}));
+    expect(pinnedCount).toBe(2);
+  });
+
+  it("places a pinned agent absent from leftButtons at the end of the pinned group", () => {
+    const agents = [agent("claude", "ready"), agent("gemini", "ready")];
+    // gemini pinned but not in leftButtons → after claude (index 0), before any unpinned.
+    const { sorted, pinnedCount } = sortAgentsByToolbarPin(agents, ["claude"], settings({}));
+    expect(sorted.map((a) => a.id)).toEqual(["claude", "gemini"]);
+    expect(pinnedCount).toBe(2);
+  });
+
+  it("uses the first index for a duplicated id in leftButtons", () => {
+    const agents = [agent("claude", "ready"), agent("gemini", "ready")];
+    const { sorted } = sortAgentsByToolbarPin(agents, ["gemini", "claude", "gemini"], settings({}));
+    expect(sorted.map((a) => a.id)).toEqual(["gemini", "claude"]);
+  });
+
+  it("treats a missing settings entry as following availability", () => {
+    const agents = [agent("claude", "ready"), agent("gemini", "missing")];
+    const { sorted, pinnedCount } = sortAgentsByToolbarPin(agents, ["claude"], null);
+    expect(sorted.map((a) => a.id)).toEqual(["claude", "gemini"]);
+    expect(pinnedCount).toBe(1);
+  });
+
+  it("treats undefined availability with no pin as unpinned", () => {
+    const agents = [agent("claude", undefined)];
+    const { pinnedCount } = sortAgentsByToolbarPin(agents, [], settings({}));
+    expect(pinnedCount).toBe(0);
+  });
+});

--- a/src/lib/agentMenuOrder.ts
+++ b/src/lib/agentMenuOrder.ts
@@ -1,0 +1,50 @@
+import type { AgentSettings } from "@shared/types/agentSettings";
+import type { AgentAvailabilityState } from "@shared/types";
+import { isAgentToolbarVisible } from "@shared/utils/agentPinned";
+
+/** Minimal shape needed to order an agent against the toolbar pin state. */
+export interface PinnableAgent {
+  id: string;
+  availability?: AgentAvailabilityState;
+}
+
+/**
+ * Splits and orders agents the way both the dock and grid context menus
+ * present them: toolbar-pinned agents first (in toolbar `leftButtons` order),
+ * then the remaining agents in their incoming order.
+ *
+ * "Pinned to toolbar" follows the tri-state resolver `isAgentToolbarVisible`
+ * (explicit pin wins, then live CLI availability) so the menu grouping always
+ * matches what the toolbar actually shows. `leftButtons` supplies the order
+ * only — an agent visible in the toolbar but absent from `leftButtons` (e.g.
+ * explicitly pinned but never dragged into the rail) sorts to the end of the
+ * pinned group via a stable sort.
+ *
+ * Returns the concatenated array plus `pinnedCount` so callers can render a
+ * separator + labels between the two groups without re-deriving the split.
+ */
+export function sortAgentsByToolbarPin<T extends PinnableAgent>(
+  agents: ReadonlyArray<T>,
+  leftButtons: readonly string[],
+  agentSettings: AgentSettings | null | undefined
+): { sorted: T[]; pinnedCount: number } {
+  const order = new Map<string, number>();
+  for (let i = 0; i < leftButtons.length; i++) {
+    const id = leftButtons[i]!;
+    if (!order.has(id)) order.set(id, i);
+  }
+
+  const pinned: T[] = [];
+  const unpinned: T[] = [];
+  for (const agent of agents) {
+    if (isAgentToolbarVisible(agentSettings?.agents?.[agent.id], agent.availability)) {
+      pinned.push(agent);
+    } else {
+      unpinned.push(agent);
+    }
+  }
+
+  pinned.sort((a, b) => (order.get(a.id) ?? Infinity) - (order.get(b.id) ?? Infinity));
+
+  return { sorted: [...pinned, ...unpinned], pinnedCount: pinned.length };
+}


### PR DESCRIPTION
## Summary

- The grid right-click context menu now uses `DockLaunchMenuItems` instead of plain inline rows, so it shows agent brand icons and sectioned grouping to match the dock.
- Both menus now order agents by toolbar pin order: pinned agents appear first (in `leftButtons` order) under a "Pinned" label, then the rest under "Other". When the pinned set isn't a strict subset, the list stays flat.
- The grid menu now also surfaces dev-preview and recipes, matching the dock menu.

Resolves #9513

## Changes

- `src/lib/agentMenuOrder.ts` — new `sortAgentsByToolbarPin` utility
- `src/lib/__tests__/agentMenuOrder.test.ts` — 11 unit tests covering sorting and grouping edge cases
- `src/components/Layout/DockLaunchMenuItems.tsx` — new `pinnedCount` prop drives the Pinned/Other grouped render
- `src/components/Layout/ContentDock.tsx` and `DockLaunchButton.tsx` — sort `launchAgents` via the new utility before passing to `DockLaunchMenuItems`
- `src/components/Terminal/useContentGridContext.tsx` — replaces inline agent rows with `DockLaunchMenuItems`; subscribes to `leftButtons`, `agentSettings`, and `devServerCommand` for full parity with the dock

## Testing

- 25 unit tests pass: 11 in `agentMenuOrder.test.ts` + 14 in `DockLaunchButton.test.tsx`
- `npm run check` clean (typecheck, lint ratchet, format, build all green)