### PR TITLE
feat(plugins): atomic plugin install with temp-extract, validate, swap, rollback (#9292)

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -799,6 +799,7 @@ export const CHANNELS = {
 
   // Plugin channels
   PLUGIN_LIST: "plugin:list",
+  PLUGIN_INSTALL: "plugin:install",
   PLUGIN_SET_ENABLED: "plugin:set-enabled",
   PLUGIN_INVOKE: "plugin:invoke",
   PLUGIN_TOOLBAR_BUTTONS: "plugin:toolbar-buttons",

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -90,8 +90,9 @@ beforeEach(() => {
 describe("registerPluginHandlers", () => {
   it("registers handlers for all plugin channels", () => {
     registerPluginHandlers();
-    expect(mockIpcMainHandle).toHaveBeenCalledTimes(20);
+    expect(mockIpcMainHandle).toHaveBeenCalledTimes(21);
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:list", expect.any(Function));
+    expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:install", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:set-enabled", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:invoke", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:toolbar-buttons", expect.any(Function));

--- a/electron/ipc/handlers/plugin.preload.ts
+++ b/electron/ipc/handlers/plugin.preload.ts
@@ -7,6 +7,7 @@ import type { IpcInvokeMap } from "../../types/index.js";
 // (allowlisted in `ipcHandleCoverage.test.ts`).
 export const PLUGIN_METHOD_CHANNELS = {
   list: "plugin:list",
+  install: "plugin:install",
   setEnabled: "plugin:set-enabled",
   toolbarButtons: "plugin:toolbar-buttons",
   menuItems: "plugin:menu-items",

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -41,6 +41,8 @@ import type {
   PluginIpcContext,
   PluginActionContribution,
   PluginActionDescriptor,
+  PluginInstallOptions,
+  PluginInstallResult,
 } from "../../../shared/types/plugin.js";
 import type { ToolbarButtonConfig } from "../../../shared/config/toolbarButtonRegistry.js";
 import { assertIpcSecurityReady } from "../ipcGuard.js";
@@ -51,6 +53,26 @@ async function handleList(): Promise<LoadedPluginInfo[]> {
 
 async function handleSetEnabled(pluginId: string, enabled: boolean): Promise<void> {
   pluginService.setEnabled(pluginId, enabled);
+}
+
+/**
+ * Install a plugin from a `.dntr` archive (or pre-extracted directory) path.
+ * Structured validation failures come back as `{ status: "failed", errors }`
+ * data — never thrown — so the install dialog can render per-field messages
+ * intact across the IPC boundary (#3769). Only unexpected infrastructure
+ * faults (a lock subsystem crash) propagate as a thrown Error.
+ */
+async function handleInstall(
+  archivePath: string,
+  opts?: PluginInstallOptions
+): Promise<PluginInstallResult> {
+  if (typeof archivePath !== "string" || archivePath.length === 0) {
+    return {
+      status: "failed",
+      errors: [{ code: "archive_invalid", message: "Install path must be a non-empty string" }],
+    };
+  }
+  return pluginService.installPlugin(archivePath, opts);
 }
 
 async function handleToolbarButtons(): Promise<ToolbarButtonConfig[]> {
@@ -381,6 +403,7 @@ export const pluginNamespace = defineIpcNamespace({
   name: "plugin",
   ops: {
     list: op(PLUGIN_METHOD_CHANNELS.list, handleList),
+    install: op(PLUGIN_METHOD_CHANNELS.install, handleInstall),
     setEnabled: op(PLUGIN_METHOD_CHANNELS.setEnabled, handleSetEnabled),
     toolbarButtons: op(PLUGIN_METHOD_CHANNELS.toolbarButtons, handleToolbarButtons),
     menuItems: op(PLUGIN_METHOD_CHANNELS.menuItems, handleMenuItems),

--- a/electron/services/PluginArchive.ts
+++ b/electron/services/PluginArchive.ts
@@ -270,6 +270,11 @@ export async function extractPluginArchive(archivePath: string, destDir: string)
 
   return new Promise<void>((resolve, reject) => {
     let settled = false;
+    // Running total of declared uncompressed bytes. yauzl validates each
+    // entry's decompressed length against its `uncompressedSize` header by
+    // default, so this is a trustworthy bound — it guards against a zip-bomb
+    // whose compressed form fits under MAX_DNTR_BYTES but expands to many GB.
+    let totalUncompressed = 0;
     const fail = (err: Error) => {
       if (settled) return;
       settled = true;
@@ -292,6 +297,11 @@ export async function extractPluginArchive(archivePath: string, destDir: string)
       const pathErr = isValidEntryName(name);
       if (pathErr) {
         return fail(new Error(`Invalid entry path "${name}": ${pathErr}`));
+      }
+
+      totalUncompressed += entry.uncompressedSize;
+      if (totalUncompressed > MAX_DNTR_BYTES) {
+        return fail(new Error(`Uncompressed archive size exceeds ${MAX_DNTR_BYTES} byte limit`));
       }
 
       const resolved = path.resolve(root, name);

--- a/electron/services/PluginArchive.ts
+++ b/electron/services/PluginArchive.ts
@@ -250,6 +250,88 @@ export async function readArchiveManifest(archivePath: string): Promise<PluginMa
 }
 
 /**
+ * Extract every entry of a `.dntr` archive into `destDir`. The caller owns
+ * `destDir` (created beforehand) and is responsible for cleanup on failure.
+ *
+ * Each entry is guarded against path traversal: the resolved on-disk path must
+ * stay within `destDir`. Backslashes, leading slashes, and drive letters are
+ * rejected via {@link isValidEntryName} before resolution. Directory entries
+ * (trailing `/`) only create the directory; file entries stream to disk and
+ * the next entry is read only after the write stream closes (`lazyEntries`).
+ */
+export async function extractPluginArchive(archivePath: string, destDir: string): Promise<void> {
+  const stat = await fs.stat(archivePath);
+  if (stat.size > MAX_DNTR_BYTES) {
+    throw new Error(`Archive size ${stat.size} exceeds ${MAX_DNTR_BYTES} byte limit`);
+  }
+
+  const root = path.resolve(destDir);
+  const zipfile = await openZip(archivePath);
+
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const fail = (err: Error) => {
+      if (settled) return;
+      settled = true;
+      zipfile.close();
+      reject(err);
+    };
+
+    zipfile.on("entry", (entry: yauzl.Entry) => {
+      const name = normalizePath(entry.fileName);
+
+      // Reject any raw name that isn't already POSIX-normalized — backslashes,
+      // leading slashes, and drive letters are always invalid in a `.dntr`.
+      if (entry.fileName !== name) {
+        return fail(
+          new Error(
+            `Invalid entry path "${entry.fileName}": path must use forward slashes, no leading / or drive letters`
+          )
+        );
+      }
+      const pathErr = isValidEntryName(name);
+      if (pathErr) {
+        return fail(new Error(`Invalid entry path "${name}": ${pathErr}`));
+      }
+
+      const resolved = path.resolve(root, name);
+      if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+        return fail(new Error(`Entry "${name}" escapes the extraction directory`));
+      }
+
+      // Directory entry — create and advance.
+      if (name.endsWith("/")) {
+        fs.mkdir(resolved, { recursive: true }).then(() => zipfile.readEntry(), fail);
+        return;
+      }
+
+      fs.mkdir(path.dirname(resolved), { recursive: true }).then(() => {
+        zipfile.openReadStream(entry, (err, stream) => {
+          if (err) return fail(err);
+          const out = createWriteStream(resolved, { mode: 0o644 });
+          stream.on("error", fail);
+          out.on("error", fail);
+          out.on("finish", () => zipfile.readEntry());
+          stream.pipe(out);
+        });
+      }, fail);
+    });
+
+    zipfile.on("end", () => {
+      if (!settled) {
+        settled = true;
+        zipfile.close();
+        resolve();
+      }
+    });
+
+    zipfile.on("error", (err) => fail(err));
+
+    zipfile.readEntry();
+  });
+}
+
+/**
  * Verify a `.dntr` archive against the format spec.
  * Checks: max size, first entry is plugin.json, path validity,
  * exclusion patterns, manifest schema.

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -2576,6 +2576,13 @@ export class PluginService {
 
     const lockPath = path.join(this.pluginsRoot, "install.lock");
     let release: (() => Promise<void>) | null = null;
+    // Set if proper-lockfile reports the lock was compromised mid-hold (mtime
+    // drift, external deletion). When that happens a second instance could
+    // reclaim the lock, so we abort before the irreversible swap step rather
+    // than risk two installs racing on the same directory. Re-throwing inside
+    // `onCompromised` is unsafe — it fires from a timer and would surface as an
+    // uncaught exception — so we flag and check at the commit point instead.
+    let lockCompromised = false;
     try {
       release = await properLockfile.lock(lockPath, {
         // Sub-30s stale TTL with mid-hold refresh every 10s. A crashed prior
@@ -2588,6 +2595,7 @@ export class PluginService {
         realpath: false,
         retries: { retries: 5, minTimeout: 100, maxTimeout: 1_000 },
         onCompromised: (err) => {
+          lockCompromised = true;
           console.error("[PluginService] install.lock compromised during install:", err);
         },
       });
@@ -2686,6 +2694,13 @@ export class PluginService {
         existing = false;
       }
 
+      // Abort before the irreversible swap if the lock was compromised — a
+      // second instance may now hold it and racing the rename would corrupt
+      // the directory. Nothing has been written to the final location yet.
+      if (lockCompromised) {
+        return fail("lock_failed", "Install lock was compromised mid-install; aborted before swap");
+      }
+
       if (existing) {
         try {
           this.unloadPlugin(pluginId);
@@ -2698,7 +2713,28 @@ export class PluginService {
       }
 
       const swapError = await this._swapPluginDir(tmpDir, finalDir, existing);
-      if (swapError) return { status: "failed", errors: [swapError] };
+      if (swapError) {
+        // On a recoverable upgrade failure the old directory was restored on
+        // disk, but `unloadPlugin` already tore down its runtime state. Re-load
+        // it so the previous version stays live this session (rollback must
+        // restore runtime state too, not just disk). `swap_unrecoverable` means
+        // the directory may be missing — don't attempt a reload there.
+        if (existing && swapError.code === "swap_failed") {
+          try {
+            const restored = await this.loadPlugin(this.pluginsRoot, pluginId, {
+              isBuiltin: false,
+              disabled: this.getDisabledIds(),
+            });
+            if (restored) await this.activatePlugin(pluginId);
+          } catch (reloadErr) {
+            console.error(
+              `[PluginService] Failed to restore "${pluginId}" runtime state after swap rollback:`,
+              reloadErr
+            );
+          }
+        }
+        return { status: "failed", errors: [swapError] };
+      }
       // The temp dir was renamed into place — drop the handle so the `finally`
       // cleanup doesn't delete the freshly installed plugin.
       tmpDir = null;
@@ -2712,10 +2748,34 @@ export class PluginService {
         loadError: null,
       });
 
-      const loaded = await this.loadPlugin(this.pluginsRoot, pluginId, {
-        isBuiltin: false,
-        disabled: this.getDisabledIds(),
-      });
+      // A plugin disabled in Preferences installs to disk but is intentionally
+      // not loaded this session (`loadPlugin` would return null for it). The
+      // files and provenance are committed, so this is a successful install.
+      if (this.getDisabledIds().has(pluginId)) {
+        return { status: "installed", pluginId };
+      }
+
+      let loaded: LoadedPlugin | null;
+      try {
+        loaded = await this.loadPlugin(this.pluginsRoot, pluginId, {
+          isBuiltin: false,
+          disabled: this.getDisabledIds(),
+        });
+      } catch (err) {
+        // A manifest field that passes the schema but throws downstream (e.g. a
+        // malformed `when` expression rejected by the when-clause parser) must
+        // surface as a structured result, not an unhandled rejection. The swap
+        // committed and provenance is persisted; leave the directory in place.
+        return {
+          status: "failed",
+          errors: [
+            {
+              code: "load_failed",
+              message: `Plugin "${pluginId}" installed but failed to load: ${(err as Error).message}. Retry from Settings.`,
+            },
+          ],
+        };
+      }
       if (!loaded) {
         // The swap committed and provenance is persisted, so the directory is
         // intact and consistent — the user can retry activation or reinstall

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -2575,7 +2575,6 @@ export class PluginService {
     await fs.mkdir(this.pluginsRoot, { recursive: true });
 
     const lockPath = path.join(this.pluginsRoot, "install.lock");
-    let release: (() => Promise<void>) | null = null;
     // Set if proper-lockfile reports the lock was compromised mid-hold (mtime
     // drift, external deletion). When that happens a second instance could
     // reclaim the lock, so we abort before the irreversible swap step rather
@@ -2583,6 +2582,9 @@ export class PluginService {
     // `onCompromised` is unsafe — it fires from a timer and would surface as an
     // uncaught exception — so we flag and check at the commit point instead.
     let lockCompromised = false;
+    // Definitely assigned below or the catch returns, so the `finally` can
+    // release unconditionally without a null guard.
+    let release: () => Promise<void>;
     try {
       release = await properLockfile.lock(lockPath, {
         // Sub-30s stale TTL with mid-hold refresh every 10s. A crashed prior
@@ -2802,11 +2804,9 @@ export class PluginService {
           console.warn(`[PluginService] Failed to clean up install temp dir ${tmpDir}:`, err);
         });
       }
-      if (release) {
-        await release().catch((err) => {
-          console.warn("[PluginService] Failed to release install lock:", err);
-        });
-      }
+      await release().catch((err) => {
+        console.warn("[PluginService] Failed to release install lock:", err);
+      });
     }
   }
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -27,7 +27,23 @@ interface ValidateFn {
 interface AjvInstance {
   compile(schema: Record<string, unknown>): ValidateFn;
 }
+
+// proper-lockfile is CJS-only and ships no bundled types. Require it via the
+// same createRequire interop as ajv and declare the narrow surface we use.
+interface LockOptions {
+  stale?: number;
+  update?: number;
+  realpath?: boolean;
+  retries?: number | { retries: number; minTimeout?: number; maxTimeout?: number };
+  onCompromised?: (err: Error) => void;
+}
+interface ProperLockfile {
+  lock(file: string, opts?: LockOptions): Promise<() => Promise<void>>;
+}
+const properLockfile: ProperLockfile = req("proper-lockfile");
 import { getPluginManifestSchema, PluginToastOptionsSchema } from "../schemas/plugin.js";
+import { extractPluginArchive, computeArchiveHash } from "./PluginArchive.js";
+import { resilientRename } from "../utils/fs.js";
 import { getPluginMcpSupervisor } from "./PluginMcpSupervisor.js";
 import { z } from "zod";
 import type {
@@ -45,6 +61,10 @@ import type {
   InstalledPluginRecord,
   PluginLoadError,
   PluginInstallSource,
+  PluginInstallError,
+  PluginInstallErrorCode,
+  PluginInstallResult,
+  PluginInstallOptions,
   PluginSettingsScope,
   ViewContribution,
 } from "../../shared/types/plugin.js";
@@ -817,7 +837,11 @@ export class PluginService {
       throw err;
     }
 
-    const pluginDirs = entries.filter((e) => e.isDirectory());
+    // Skip dot-prefixed dirs: plugin ids are `publisher.name` and a publisher
+    // segment can never start with a dot, so `.install-tmp-*` staging dirs and
+    // `.old-*` parked dirs left by the installer (e.g. after a crash mid-swap)
+    // are never mistaken for installable plugins.
+    const pluginDirs = entries.filter((e) => e.isDirectory() && !e.name.startsWith("."));
     // Disabled state applies to built-in and user plugins alike (#9284).
     const disabled = this.getDisabledIds();
     const results = await Promise.allSettled(
@@ -2513,6 +2537,280 @@ export class PluginService {
         this.channelRequires.delete(key);
       }
     }
+  }
+
+  /**
+   * Atomically install a plugin from a `.dntr` archive path or a pre-extracted
+   * directory. This is the ONLY path that mutates {@link pluginsRoot} — direct
+   * IPC writes to the plugins directory are a review blocker (#9292).
+   *
+   * The flow, with rollback on every failure branch:
+   * 1. Acquire the cross-process `install.lock` (sub-30s stale TTL so a crashed
+   *    prior install can't hold it forever). A second instance blocks, not races.
+   * 2. Extract / copy the source into a sibling `.install-tmp-*` dir — same
+   *    filesystem as the final location so the eventual rename is atomic.
+   * 3. Validate `plugin.json` with the strict Zod schema (unknown keys, reserved
+   *    `daintree.*` namespace, publisher/name agreement) and the engine range.
+   * 4. Compute the `.dntr` SHA-256 for the `archiveHash` provenance field.
+   * 5. If the id already exists: `unloadPlugin` (disposer cascade), then swap via
+   *    rename — park old aside → move new in → restore old on failure. Per-plugin
+   *    settings/secrets live under a separate `plugin-settings/` root, so the
+   *    directory swap never touches them; no preserve/restore step is needed.
+   * 6. On any failure the temp dir is removed, the lock released, and a structured
+   *    error returned. The on-disk plugin directory is never left half-written.
+   *
+   * Structured validation errors are RETURNED as `{ status: "failed", errors }`
+   * data, never thrown, so they survive the IPC structured-clone boundary
+   * intact (#3769) for the F22/F23/F24 install dialogs.
+   */
+  async installPlugin(
+    archivePath: string,
+    opts?: PluginInstallOptions
+  ): Promise<PluginInstallResult> {
+    const fail = (code: PluginInstallErrorCode, message: string): PluginInstallResult => ({
+      status: "failed",
+      errors: [{ code, message }],
+    });
+
+    await fs.mkdir(this.pluginsRoot, { recursive: true });
+
+    const lockPath = path.join(this.pluginsRoot, "install.lock");
+    let release: (() => Promise<void>) | null = null;
+    try {
+      release = await properLockfile.lock(lockPath, {
+        // Sub-30s stale TTL with mid-hold refresh every 10s. A crashed prior
+        // install's lock is reclaimed after 20s instead of being held forever.
+        stale: 20_000,
+        update: 10_000,
+        // The lock target need not pre-exist — proper-lockfile creates
+        // `install.lock.lock` adjacent. `realpath: false` skips the existence
+        // probe that would otherwise reject before the lock dir is made.
+        realpath: false,
+        retries: { retries: 5, minTimeout: 100, maxTimeout: 1_000 },
+        onCompromised: (err) => {
+          console.error("[PluginService] install.lock compromised during install:", err);
+        },
+      });
+    } catch (err) {
+      return fail(
+        "lock_failed",
+        `Couldn't acquire the plugin install lock: ${(err as Error).message}`
+      );
+    }
+
+    let tmpDir: string | null = null;
+    try {
+      tmpDir = await fs.mkdtemp(path.join(this.pluginsRoot, ".install-tmp-"));
+
+      // 1. Materialize the plugin into the temp dir.
+      let sourceIsDir: boolean;
+      try {
+        sourceIsDir = (await fs.stat(archivePath)).isDirectory();
+      } catch (err) {
+        return fail("archive_invalid", `Install source not found: ${(err as Error).message}`);
+      }
+
+      let hash: string | null = null;
+      if (sourceIsDir) {
+        try {
+          await fs.cp(archivePath, tmpDir, { recursive: true });
+        } catch (err) {
+          return fail(
+            "archive_invalid",
+            `Failed to copy plugin directory: ${(err as Error).message}`
+          );
+        }
+      } else {
+        try {
+          await extractPluginArchive(archivePath, tmpDir);
+        } catch (err) {
+          return fail("archive_invalid", `Failed to extract archive: ${(err as Error).message}`);
+        }
+        try {
+          hash = await computeArchiveHash(archivePath);
+        } catch (err) {
+          return fail("hash_failed", `Failed to compute archive hash: ${(err as Error).message}`);
+        }
+      }
+
+      // 2. Read + strictly validate the manifest.
+      let rawManifest: string;
+      try {
+        rawManifest = await fs.readFile(path.join(tmpDir, "plugin.json"), "utf-8");
+      } catch {
+        return fail("manifest_invalid", "plugin.json not found at the archive root");
+      }
+      let json: unknown;
+      try {
+        json = JSON.parse(rawManifest);
+      } catch {
+        return fail("manifest_invalid", "plugin.json is not valid JSON");
+      }
+      const parsed = getPluginManifestSchema(false).safeParse(json);
+      if (!parsed.success) {
+        const errors: PluginInstallError[] = parsed.error.issues.map((issue) => {
+          const isNamespace =
+            issue.code === "custom" &&
+            (issue as unknown as { params?: { errorCode?: string } }).params?.errorCode ===
+              "namespace_reserved";
+          return {
+            code: isNamespace ? "namespace_unauthorized" : "manifest_invalid",
+            path: issue.path.map(String),
+            message: issue.message,
+          };
+        });
+        return { status: "failed", errors };
+      }
+      const manifest = parsed.data;
+
+      // 3. Engine compatibility.
+      const requiredRange = manifest.engines?.daintree;
+      if (
+        requiredRange &&
+        !semver.satisfies(this.appVersion, requiredRange, { includePrerelease: true })
+      ) {
+        return fail(
+          "engine_incompatible",
+          `Plugin requires Daintree ${requiredRange} but the running version is ${this.appVersion}`
+        );
+      }
+
+      // 4. Atomic swap into the final location.
+      const pluginId = manifest.name;
+      const finalDir = path.join(this.pluginsRoot, pluginId);
+      let existing = false;
+      try {
+        await fs.access(finalDir);
+        existing = true;
+      } catch {
+        existing = false;
+      }
+
+      if (existing) {
+        try {
+          this.unloadPlugin(pluginId);
+        } catch (err) {
+          return fail(
+            "unload_failed",
+            `Failed to unload the existing "${pluginId}" before upgrade: ${(err as Error).message}`
+          );
+        }
+      }
+
+      const swapError = await this._swapPluginDir(tmpDir, finalDir, existing);
+      if (swapError) return { status: "failed", errors: [swapError] };
+      // The temp dir was renamed into place — drop the handle so the `finally`
+      // cleanup doesn't delete the freshly installed plugin.
+      tmpDir = null;
+
+      // 5. Persist provenance and load the new plugin.
+      this.upsertInstalledRecord(pluginId, {
+        source: opts?.source ?? "sideload",
+        installedAt: Date.now(),
+        originalUrl: opts?.originalUrl ?? null,
+        archiveHash: hash,
+        loadError: null,
+      });
+
+      const loaded = await this.loadPlugin(this.pluginsRoot, pluginId, {
+        isBuiltin: false,
+        disabled: this.getDisabledIds(),
+      });
+      if (!loaded) {
+        // The swap committed and provenance is persisted, so the directory is
+        // intact and consistent — the user can retry activation or reinstall
+        // without re-downloading. We deliberately leave the directory in place.
+        return {
+          status: "failed",
+          errors: [
+            {
+              code: "load_failed",
+              message: `Plugin "${pluginId}" installed but failed to load. Retry from Settings.`,
+            },
+          ],
+        };
+      }
+
+      // setPluginArchiveHash requires the plugin to be loaded; call it after.
+      if (hash) this.setPluginArchiveHash(pluginId, hash);
+      await this.activatePlugin(pluginId);
+
+      return { status: "installed", pluginId };
+    } finally {
+      if (tmpDir) {
+        await fs.rm(tmpDir, { recursive: true, force: true }).catch((err) => {
+          console.warn(`[PluginService] Failed to clean up install temp dir ${tmpDir}:`, err);
+        });
+      }
+      if (release) {
+        await release().catch((err) => {
+          console.warn("[PluginService] Failed to release install lock:", err);
+        });
+      }
+    }
+  }
+
+  /**
+   * Atomic directory swap for {@link installPlugin}. Returns `null` on success
+   * or a structured {@link PluginInstallError} on failure. When `existing` is
+   * true the current `finalDir` is parked aside first and restored if the new
+   * directory can't be moved in.
+   *
+   * `swap_unrecoverable` is reserved for the case where BOTH the move-in AND
+   * the restore fail — the plugin directory may be missing and the message
+   * says so explicitly rather than swallowing the inconsistency.
+   */
+  private async _swapPluginDir(
+    tmpDir: string,
+    finalDir: string,
+    existing: boolean
+  ): Promise<PluginInstallError | null> {
+    const parked = existing ? `${finalDir}.old-${randomUUID()}` : null;
+
+    if (parked) {
+      try {
+        await resilientRename(finalDir, parked);
+      } catch (err) {
+        return {
+          code: "swap_failed",
+          message: `Couldn't move the existing plugin aside: ${(err as Error).message}`,
+        };
+      }
+    }
+
+    try {
+      await resilientRename(tmpDir, finalDir);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      const detail =
+        code === "EXDEV"
+          ? `cross-device rename not supported — the staging dir is on a different filesystem than ${finalDir}`
+          : (err as Error).message;
+      if (parked) {
+        try {
+          await resilientRename(parked, finalDir);
+        } catch (restoreErr) {
+          return {
+            code: "swap_unrecoverable",
+            message: `Install failed (${detail}) and the previous plugin couldn't be restored (${(restoreErr as Error).message}). The directory at ${finalDir} may be missing — reinstall to recover.`,
+          };
+        }
+      }
+      return {
+        code: "swap_failed",
+        message: `Couldn't move the new plugin into place: ${detail}`,
+      };
+    }
+
+    // New dir is in place — remove the parked old copy best-effort. A failure
+    // here only leaks a `.old-*` dir (skipped by the load scan), never the
+    // installed plugin.
+    if (parked) {
+      await fs.rm(parked, { recursive: true, force: true }).catch((err) => {
+        console.warn(`[PluginService] Failed to remove parked old plugin dir ${parked}:`, err);
+      });
+    }
+    return null;
   }
 
   unloadPlugin(pluginId: string): void {

--- a/electron/services/__tests__/PluginArchive.extract.test.ts
+++ b/electron/services/__tests__/PluginArchive.extract.test.ts
@@ -32,32 +32,53 @@ async function createFixture(baseDir: string, files: Record<string, string>): Pr
 // before writing). This is the only way to forge a genuine zip-slip archive to
 // exercise extractPluginArchive's traversal guards — the bundled writer would
 // never emit one.
-function buildRawZip(entries: Array<{ name: string; content: string }>): Buffer {
+// Each entry is either STORE (`content` string) or a real DEFLATE entry
+// (`deflateOf` raw buffer) so a genuine, internally-consistent zip-bomb can be
+// built — large uncompressedSize, tiny compressed payload, valid CRC — that
+// yauzl accepts and only the installer's own size guard rejects.
+type RawEntry = { name: string; content: string } | { name: string; deflateOf: Buffer };
+
+function buildRawZip(entries: RawEntry[]): Buffer {
   const chunks: Buffer[] = [];
   const central: Buffer[] = [];
   let offset = 0;
   for (const e of entries) {
-    const data = Buffer.from(e.content);
     const nameBuf = Buffer.from(e.name, "utf-8");
-    const crc = zlib.crc32(data) >>> 0;
+    let method: number;
+    let stored: Buffer;
+    let uncompressedSize: number;
+    let crc: number;
+    if ("deflateOf" in e) {
+      method = 8;
+      stored = zlib.deflateRawSync(e.deflateOf);
+      uncompressedSize = e.deflateOf.length;
+      crc = zlib.crc32(e.deflateOf) >>> 0;
+    } else {
+      method = 0;
+      stored = Buffer.from(e.content);
+      uncompressedSize = stored.length;
+      crc = zlib.crc32(stored) >>> 0;
+    }
     const lfh = Buffer.alloc(30);
     lfh.writeUInt32LE(0x04034b50, 0);
     lfh.writeUInt16LE(20, 4);
+    lfh.writeUInt16LE(method, 8);
     lfh.writeUInt32LE(crc, 14);
-    lfh.writeUInt32LE(data.length, 18);
-    lfh.writeUInt32LE(data.length, 22);
+    lfh.writeUInt32LE(stored.length, 18);
+    lfh.writeUInt32LE(uncompressedSize, 22);
     lfh.writeUInt16LE(nameBuf.length, 26);
     const localOffset = offset;
-    chunks.push(lfh, nameBuf, data);
-    offset += lfh.length + nameBuf.length + data.length;
+    chunks.push(lfh, nameBuf, stored);
+    offset += lfh.length + nameBuf.length + stored.length;
 
     const cdh = Buffer.alloc(46);
     cdh.writeUInt32LE(0x02014b50, 0);
     cdh.writeUInt16LE(20, 4);
     cdh.writeUInt16LE(20, 6);
+    cdh.writeUInt16LE(method, 10);
     cdh.writeUInt32LE(crc, 16);
-    cdh.writeUInt32LE(data.length, 20);
-    cdh.writeUInt32LE(data.length, 24);
+    cdh.writeUInt32LE(stored.length, 20);
+    cdh.writeUInt32LE(uncompressedSize, 24);
     cdh.writeUInt16LE(nameBuf.length, 28);
     cdh.writeUInt32LE(localOffset, 42);
     central.push(Buffer.concat([cdh, nameBuf]));
@@ -147,6 +168,30 @@ describe("extractPluginArchive", () => {
     await fs.mkdir(dest, { recursive: true });
 
     await expect(extractPluginArchive(archivePath, dest)).rejects.toThrow();
+  });
+
+  it("rejects a zip-bomb whose declared uncompressed size exceeds the limit", async () => {
+    const archivePath = path.join(tmpDir, "bomb.dntr");
+    await fs.writeFile(
+      archivePath,
+      buildRawZip([
+        { name: "plugin.json", content: JSON.stringify(validManifest()) },
+        // 31 MB of zeroes deflates to a few KB — a valid entry yauzl accepts,
+        // whose uncompressedSize trips the installer's cumulative size guard.
+        { name: "huge.bin", deflateOf: Buffer.alloc(31 * 1024 * 1024) },
+      ])
+    );
+    const dest = path.join(tmpDir, "extracted-bomb");
+    await fs.mkdir(dest, { recursive: true });
+
+    await expect(extractPluginArchive(archivePath, dest)).rejects.toThrow(/exceeds/);
+    // Guard trips before the bomb entry is written.
+    expect(
+      await fs
+        .access(path.join(dest, "huge.bin"))
+        .then(() => true)
+        .catch(() => false)
+    ).toBe(false);
   });
 
   it("rejects an oversize archive before extracting", async () => {

--- a/electron/services/__tests__/PluginArchive.extract.test.ts
+++ b/electron/services/__tests__/PluginArchive.extract.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+import zlib from "zlib";
+import { packPluginArchive, extractPluginArchive } from "../PluginArchive.js";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-extract-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+function validManifest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return { name: "acme.test-plugin", version: "1.0.0", ...overrides };
+}
+
+async function createFixture(baseDir: string, files: Record<string, string>): Promise<void> {
+  for (const [filePath, content] of Object.entries(files)) {
+    const full = path.join(baseDir, filePath);
+    await fs.mkdir(path.dirname(full), { recursive: true });
+    await fs.writeFile(full, content);
+  }
+}
+
+// Build a raw STORE (uncompressed) zip with arbitrary entry-name bytes,
+// bypassing the path sanitization `archiver` applies (it strips `..` segments
+// before writing). This is the only way to forge a genuine zip-slip archive to
+// exercise extractPluginArchive's traversal guards — the bundled writer would
+// never emit one.
+function buildRawZip(entries: Array<{ name: string; content: string }>): Buffer {
+  const chunks: Buffer[] = [];
+  const central: Buffer[] = [];
+  let offset = 0;
+  for (const e of entries) {
+    const data = Buffer.from(e.content);
+    const nameBuf = Buffer.from(e.name, "utf-8");
+    const crc = zlib.crc32(data) >>> 0;
+    const lfh = Buffer.alloc(30);
+    lfh.writeUInt32LE(0x04034b50, 0);
+    lfh.writeUInt16LE(20, 4);
+    lfh.writeUInt32LE(crc, 14);
+    lfh.writeUInt32LE(data.length, 18);
+    lfh.writeUInt32LE(data.length, 22);
+    lfh.writeUInt16LE(nameBuf.length, 26);
+    const localOffset = offset;
+    chunks.push(lfh, nameBuf, data);
+    offset += lfh.length + nameBuf.length + data.length;
+
+    const cdh = Buffer.alloc(46);
+    cdh.writeUInt32LE(0x02014b50, 0);
+    cdh.writeUInt16LE(20, 4);
+    cdh.writeUInt16LE(20, 6);
+    cdh.writeUInt32LE(crc, 16);
+    cdh.writeUInt32LE(data.length, 20);
+    cdh.writeUInt32LE(data.length, 24);
+    cdh.writeUInt16LE(nameBuf.length, 28);
+    cdh.writeUInt32LE(localOffset, 42);
+    central.push(Buffer.concat([cdh, nameBuf]));
+  }
+  const centralBuf = Buffer.concat(central);
+  const centralOffset = offset;
+  chunks.push(centralBuf);
+
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(entries.length, 8);
+  eocd.writeUInt16LE(entries.length, 10);
+  eocd.writeUInt32LE(centralBuf.length, 12);
+  eocd.writeUInt32LE(centralOffset, 16);
+  chunks.push(eocd);
+  return Buffer.concat(chunks);
+}
+
+describe("extractPluginArchive", () => {
+  it("extracts every entry faithfully into the destination", async () => {
+    const sourceDir = path.join(tmpDir, "source");
+    await createFixture(sourceDir, {
+      "plugin.json": JSON.stringify(validManifest()),
+      "dist/index.js": "module.exports = { hello: true };",
+      "icons/logo.svg": "<svg></svg>",
+    });
+    const archivePath = path.join(tmpDir, "out.dntr");
+    await packPluginArchive(sourceDir, archivePath);
+
+    const dest = path.join(tmpDir, "extracted");
+    await fs.mkdir(dest, { recursive: true });
+    await extractPluginArchive(archivePath, dest);
+
+    expect(await fs.readFile(path.join(dest, "dist/index.js"), "utf-8")).toBe(
+      "module.exports = { hello: true };"
+    );
+    expect(await fs.readFile(path.join(dest, "icons/logo.svg"), "utf-8")).toBe("<svg></svg>");
+    const manifest = JSON.parse(await fs.readFile(path.join(dest, "plugin.json"), "utf-8"));
+    expect(manifest.name).toBe("acme.test-plugin");
+  });
+
+  it("rejects a path-traversal entry and writes nothing outside the destination", async () => {
+    const archivePath = path.join(tmpDir, "evil.dntr");
+    await fs.writeFile(
+      archivePath,
+      buildRawZip([
+        { name: "plugin.json", content: JSON.stringify(validManifest()) },
+        { name: "../escape.js", content: "pwned" },
+      ])
+    );
+    const dest = path.join(tmpDir, "extracted-evil");
+    await fs.mkdir(dest, { recursive: true });
+
+    await expect(extractPluginArchive(archivePath, dest)).rejects.toThrow();
+    const escaped = await fs
+      .access(path.join(tmpDir, "escape.js"))
+      .then(() => true)
+      .catch(() => false);
+    expect(escaped).toBe(false);
+  });
+
+  it("rejects a backslash entry name", async () => {
+    const archivePath = path.join(tmpDir, "backslash.dntr");
+    await fs.writeFile(
+      archivePath,
+      buildRawZip([
+        { name: "plugin.json", content: JSON.stringify(validManifest()) },
+        { name: "..\\escape.js", content: "pwned" },
+      ])
+    );
+    const dest = path.join(tmpDir, "extracted-bs");
+    await fs.mkdir(dest, { recursive: true });
+
+    await expect(extractPluginArchive(archivePath, dest)).rejects.toThrow();
+  });
+
+  it("rejects an absolute entry name", async () => {
+    const archivePath = path.join(tmpDir, "absolute.dntr");
+    await fs.writeFile(
+      archivePath,
+      buildRawZip([
+        { name: "plugin.json", content: JSON.stringify(validManifest()) },
+        { name: "/etc/passwd", content: "pwned" },
+      ])
+    );
+    const dest = path.join(tmpDir, "extracted-abs");
+    await fs.mkdir(dest, { recursive: true });
+
+    await expect(extractPluginArchive(archivePath, dest)).rejects.toThrow();
+  });
+
+  it("rejects an oversize archive before extracting", async () => {
+    const archivePath = path.join(tmpDir, "huge.dntr");
+    await fs.writeFile(
+      archivePath,
+      buildRawZip([{ name: "plugin.json", content: JSON.stringify(validManifest()) }])
+    );
+    const handle = await fs.open(archivePath, "a");
+    try {
+      await handle.truncate(30 * 1024 * 1024 + 1);
+    } finally {
+      await handle.close();
+    }
+    const dest = path.join(tmpDir, "extracted-huge");
+    await fs.mkdir(dest, { recursive: true });
+
+    await expect(extractPluginArchive(archivePath, dest)).rejects.toThrow(/exceeds/);
+  });
+});

--- a/electron/services/__tests__/PluginService.install.test.ts
+++ b/electron/services/__tests__/PluginService.install.test.ts
@@ -88,9 +88,16 @@ vi.mock("../PluginMcpSupervisor.js", () => ({
     getStderr: vi.fn(() => ({ pluginId: "", serverId: "", lines: [], totalLines: 0 })),
   }),
 }));
+// resilientRename is spied (default = real impl) so the swap-rollback test can
+// force the move-in rename to fail while leaving every other call real.
+vi.mock("../../utils/fs.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../utils/fs.js")>();
+  return { ...actual, resilientRename: vi.fn(actual.resilientRename) };
+});
 
 import { PluginService } from "../PluginService.js";
 import { packPluginArchive } from "../PluginArchive.js";
+import { resilientRename } from "../../utils/fs.js";
 
 const storeState = storeMock._state;
 
@@ -312,6 +319,99 @@ describe("installPlugin — upgrade swap", () => {
     expect(JSON.parse(await fs.readFile(settingsFile, "utf-8"))).toEqual({
       apiKey: "secret-token",
     });
+
+    service.dispose();
+  });
+
+  it("restores the old plugin's runtime state when the swap rolls back", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+
+    const v1 = await makeArchive({ name: "acme.rollback", version: "1.0.0" }, { "v1.txt": "one" });
+    expect((await service.installPlugin(v1)).status).toBe("installed");
+    expect(service.listPlugins().some((p) => p.manifest.name === "acme.rollback")).toBe(true);
+
+    // Fail the move-in rename (2nd call) so the swap rolls back: 1=park-aside,
+    // 2=move-new-in (throws), 3=restore-parked. Real impl for park + restore.
+    const real = (await vi.importActual<typeof import("../../utils/fs.js")>("../../utils/fs.js"))
+      .resilientRename;
+    vi.mocked(resilientRename)
+      .mockImplementationOnce((s, d) => real(s, d))
+      .mockImplementationOnce(() =>
+        Promise.reject(Object.assign(new Error("disk full"), { code: "ENOSPC" }))
+      )
+      .mockImplementationOnce((s, d) => real(s, d));
+
+    const v2 = await makeArchive({ name: "acme.rollback", version: "2.0.0" }, { "v2.txt": "two" });
+    const result = await service.installPlugin(v2);
+
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") expect(result.errors[0].code).toBe("swap_failed");
+    // On-disk rollback: the old version is restored, no parked dir leaks.
+    expect(await exists(path.join(pluginsRoot, "acme.rollback", "v1.txt"))).toBe(true);
+    expect(await exists(path.join(pluginsRoot, "acme.rollback", "v2.txt"))).toBe(false);
+    expect((await fs.readdir(pluginsRoot)).filter((e) => e.includes(".old-"))).toHaveLength(0);
+    // Runtime rollback: the old plugin is loaded again, not left torn down.
+    expect(service.listPlugins().some((p) => p.manifest.name === "acme.rollback")).toBe(true);
+
+    service.dispose();
+  });
+});
+
+describe("installPlugin — load + provenance edge cases", () => {
+  it("returns load_failed (not an unhandled rejection) when a manifest field throws downstream", async () => {
+    // A malformed `when` expression passes the schema (any non-empty string)
+    // but throws in the when-clause parser during loadPlugin.
+    const archive = await makeArchive({
+      name: "acme.bad-when",
+      version: "1.0.0",
+      contributes: {
+        menuItems: [
+          { label: "Run", location: "terminal", actionId: "acme.bad-when.run", when: "foo &&" },
+        ],
+      },
+    });
+    const service = new PluginService(pluginsRoot, "0.0.0");
+
+    const result = await service.installPlugin(archive);
+
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") expect(result.errors[0].code).toBe("load_failed");
+    // The swap committed; the directory is deliberately left in place.
+    expect(await exists(path.join(pluginsRoot, "acme.bad-when", "plugin.json"))).toBe(true);
+
+    service.dispose();
+  });
+
+  it("returns installed (not load_failed) when the plugin id is disabled", async () => {
+    storeState.set("plugins", { disabled: ["acme.disabled-install"] });
+    const archive = await makeArchive({ name: "acme.disabled-install", version: "1.0.0" });
+    const service = new PluginService(pluginsRoot, "0.0.0");
+
+    const result = await service.installPlugin(archive);
+
+    expect(result).toEqual({ status: "installed", pluginId: "acme.disabled-install" });
+    expect(await exists(path.join(pluginsRoot, "acme.disabled-install", "plugin.json"))).toBe(true);
+    const installed = (storeState.get("plugins") as { installed: Record<string, unknown> })
+      .installed["acme.disabled-install"] as { source: string };
+    expect(installed.source).toBe("sideload");
+
+    service.dispose();
+  });
+
+  it("clears archiveHash when an archive install is replaced by a directory install", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+
+    const archive = await makeArchive({ name: "acme.rehash", version: "1.0.0" });
+    await service.installPlugin(archive);
+    const afterArchive = (storeState.get("plugins") as { installed: Record<string, unknown> })
+      .installed["acme.rehash"] as { archiveHash: string | null };
+    expect(afterArchive.archiveHash).toMatch(/^[a-f0-9]{64}$/);
+
+    const dir = await makeSourceDir({ name: "acme.rehash", version: "2.0.0" });
+    await service.installPlugin(dir);
+    const afterDir = (storeState.get("plugins") as { installed: Record<string, unknown> })
+      .installed["acme.rehash"] as { archiveHash: string | null };
+    expect(afterDir.archiveHash).toBeNull();
 
     service.dispose();
   });

--- a/electron/services/__tests__/PluginService.install.test.ts
+++ b/electron/services/__tests__/PluginService.install.test.ts
@@ -1,0 +1,318 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+
+/**
+ * Unit test for the atomic plugin installer (#9292).
+ *
+ * Exercises `PluginService.installPlugin` against real `.dntr` archives (packed
+ * via the real `packPluginArchive`), a real temp plugins root, and the real
+ * file lock — only the module-scope Electron/registry singletons are mocked, so
+ * the actual filesystem extract/validate/swap/rollback logic runs unmocked.
+ * Covers the happy path, every structured-error branch, the upgrade swap,
+ * settings preservation, and that no half-written state is left behind.
+ *
+ * Mocks mirror `PluginService.test.ts`: `electron`, `windowRef`, `store`,
+ * `ProjectStore`, the contribution registries, and `PluginMcpSupervisor` are
+ * all imported at module scope by `PluginService`.
+ */
+
+const appMock = vi.hoisted(() => ({
+  getVersion: vi.fn(() => "0.0.0"),
+  getPath: vi.fn(() => "/tmp/daintree-install-test-userdata"),
+}));
+const storeMock = vi.hoisted(() => {
+  const state = new Map<string, unknown>();
+  return {
+    get: vi.fn((key: string) => state.get(key)),
+    set: vi.fn((key: string, value: unknown) => state.set(key, value)),
+    _state: state,
+  };
+});
+
+vi.mock("electron", () => ({ app: appMock, ipcMain: { on: vi.fn(), removeListener: vi.fn() } }));
+vi.mock("../../window/windowRef.js", () => ({
+  getWindowRegistry: vi.fn(() => null),
+  getProjectViewManager: vi.fn(() => null),
+  setWindowRegistry: vi.fn(),
+  setMainWindow: vi.fn(),
+  getMainWindow: vi.fn(() => null),
+  setProjectViewManager: vi.fn(),
+}));
+vi.mock("../../ipc/utils.js", () => ({ broadcastToRenderer: vi.fn() }));
+vi.mock("../../store.js", () => ({ store: storeMock }));
+vi.mock("../ProjectStore.js", () => ({ projectStore: { getCurrentProject: vi.fn(() => null) } }));
+vi.mock("../../../shared/config/panelKindRegistry.js", () => ({
+  registerPanelKind: vi.fn(),
+  unregisterPluginPanelKinds: vi.fn(),
+  onPanelKindRegistered: vi.fn(() => () => {}),
+  onPanelKindUnregistered: vi.fn(() => () => {}),
+  getPluginPanelKinds: vi.fn(() => []),
+}));
+vi.mock("../../../shared/config/toolbarButtonRegistry.js", () => ({
+  registerToolbarButton: vi.fn(),
+  unregisterPluginToolbarButtons: vi.fn(),
+  getAllPluginToolbarButtonConfigs: vi.fn(() => []),
+}));
+vi.mock("../pluginMenuRegistry.js", () => ({
+  registerPluginMenuItem: vi.fn(),
+  unregisterPluginMenuItems: vi.fn(),
+  getPluginMenuItems: vi.fn(() => []),
+}));
+vi.mock("../forgeProviderRegistry.js", () => ({
+  registerForgeProviders: vi.fn(),
+  unregisterForgeProviders: vi.fn(),
+  registerForgeProviderImpl: vi.fn(),
+  unregisterForgeProviderImpl: vi.fn(),
+  unregisterForgeProviderImpls: vi.fn(),
+  getForgeProviderImpl: vi.fn(),
+  clearForgeProviderImplRegistry: vi.fn(),
+}));
+vi.mock("../fileDecorationRegistry.js", () => ({
+  registerFileDecorationProviders: vi.fn(),
+  registerFileDecorationProviderImpl: vi.fn(),
+  unregisterFileDecorationProviders: vi.fn(),
+  unregisterFileDecorationProviderImpls: vi.fn(),
+  unregisterFileDecorationProviderImpl: vi.fn(),
+  scopeMatchesPattern: vi.fn((s: string, p: string) => s === p),
+}));
+vi.mock("../PluginMcpSupervisor.js", () => ({
+  getPluginMcpSupervisor: () => ({
+    start: vi.fn(async () => undefined),
+    shutdown: vi.fn(async () => undefined),
+    shutdownAll: vi.fn(async () => undefined),
+    callTool: vi.fn(),
+    restart: vi.fn(),
+    list: vi.fn(() => []),
+    getStderr: vi.fn(() => ({ pluginId: "", serverId: "", lines: [], totalLines: 0 })),
+  }),
+}));
+
+import { PluginService } from "../PluginService.js";
+import { packPluginArchive } from "../PluginArchive.js";
+
+const storeState = storeMock._state;
+
+let tmpDir: string;
+let pluginsRoot: string;
+
+interface ManifestShape {
+  name: string;
+  version: string;
+  [key: string]: unknown;
+}
+
+async function makeSourceDir(
+  manifest: ManifestShape,
+  extraFiles: Record<string, string> = {}
+): Promise<string> {
+  const src = await fs.mkdtemp(path.join(tmpDir, "src-"));
+  await fs.writeFile(path.join(src, "plugin.json"), JSON.stringify(manifest));
+  for (const [rel, content] of Object.entries(extraFiles)) {
+    const full = path.join(src, rel);
+    await fs.mkdir(path.dirname(full), { recursive: true });
+    await fs.writeFile(full, content);
+  }
+  return src;
+}
+
+async function makeArchive(
+  manifest: ManifestShape,
+  extraFiles: Record<string, string> = {}
+): Promise<string> {
+  const src = await makeSourceDir(manifest, extraFiles);
+  const out = path.join(tmpDir, `${manifest.name}-${manifest.version}.dntr`);
+  await packPluginArchive(src, out);
+  return out;
+}
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-install-test-"));
+  pluginsRoot = path.join(tmpDir, "plugins");
+});
+
+afterEach(async () => {
+  try {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  } finally {
+    storeState.clear();
+    vi.clearAllMocks();
+  }
+});
+
+describe("installPlugin — happy path", () => {
+  it("installs a valid .dntr archive, records provenance, and lands the directory", async () => {
+    const archive = await makeArchive(
+      { name: "acme.installer-ok", version: "1.0.0", displayName: "OK" },
+      { "dist/index.js": "module.exports = {};" }
+    );
+    const service = new PluginService(pluginsRoot, "0.0.0");
+
+    const result = await service.installPlugin(archive, { source: "catalog" });
+
+    expect(result).toEqual({ status: "installed", pluginId: "acme.installer-ok" });
+    expect(await exists(path.join(pluginsRoot, "acme.installer-ok", "plugin.json"))).toBe(true);
+
+    const installed = (storeState.get("plugins") as { installed: Record<string, unknown> })
+      .installed["acme.installer-ok"] as { source: string; archiveHash: string | null };
+    expect(installed.source).toBe("catalog");
+    expect(installed.archiveHash).toMatch(/^[a-f0-9]{64}$/);
+
+    service.dispose();
+  });
+
+  it("installs from a pre-extracted directory with a null archive hash", async () => {
+    const src = await makeSourceDir({ name: "acme.dir-install", version: "1.0.0" });
+    const service = new PluginService(pluginsRoot, "0.0.0");
+
+    const result = await service.installPlugin(src);
+
+    expect(result).toEqual({ status: "installed", pluginId: "acme.dir-install" });
+    const installed = (storeState.get("plugins") as { installed: Record<string, unknown> })
+      .installed["acme.dir-install"] as { archiveHash: string | null; source: string };
+    expect(installed.archiveHash).toBeNull();
+    expect(installed.source).toBe("sideload");
+
+    service.dispose();
+  });
+
+  it("leaves no temp or parked directories behind after a successful install", async () => {
+    const archive = await makeArchive({ name: "acme.clean", version: "1.0.0" });
+    const service = new PluginService(pluginsRoot, "0.0.0");
+
+    await service.installPlugin(archive);
+
+    const entries = await fs.readdir(pluginsRoot);
+    expect(entries.filter((e) => e.startsWith(".install-tmp-"))).toHaveLength(0);
+    expect(entries.filter((e) => e.includes(".old-"))).toHaveLength(0);
+    expect(entries).toContain("acme.clean");
+
+    service.dispose();
+  });
+});
+
+describe("installPlugin — validation failures (rollback)", () => {
+  it("rejects an unknown top-level manifest key without writing a directory", async () => {
+    const archive = await makeArchive({
+      name: "acme.bad-key",
+      version: "1.0.0",
+      bogusUnknownKey: true,
+    });
+    const service = new PluginService(pluginsRoot, "0.0.0");
+
+    const result = await service.installPlugin(archive);
+
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.errors.some((e) => e.code === "manifest_invalid")).toBe(true);
+    }
+    expect(await exists(path.join(pluginsRoot, "acme.bad-key"))).toBe(false);
+
+    service.dispose();
+  });
+
+  it("rejects a reserved daintree.* namespace with namespace_unauthorized", async () => {
+    const archive = await makeArchive({ name: "daintree.evil", version: "1.0.0" });
+    const service = new PluginService(pluginsRoot, "0.0.0");
+
+    const result = await service.installPlugin(archive);
+
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.errors.some((e) => e.code === "namespace_unauthorized")).toBe(true);
+    }
+    expect(await exists(path.join(pluginsRoot, "daintree.evil"))).toBe(false);
+
+    service.dispose();
+  });
+
+  it("rejects an incompatible engines.daintree range", async () => {
+    const archive = await makeArchive({
+      name: "acme.future",
+      version: "1.0.0",
+      engines: { daintree: ">=99.0.0" },
+    });
+    const service = new PluginService(pluginsRoot, "0.0.0");
+
+    const result = await service.installPlugin(archive);
+
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.errors[0].code).toBe("engine_incompatible");
+    }
+    expect(await exists(path.join(pluginsRoot, "acme.future"))).toBe(false);
+
+    service.dispose();
+  });
+
+  it("returns archive_invalid for a missing source path", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+
+    const result = await service.installPlugin(path.join(tmpDir, "does-not-exist.dntr"));
+
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.errors[0].code).toBe("archive_invalid");
+    }
+
+    service.dispose();
+  });
+});
+
+describe("installPlugin — upgrade swap", () => {
+  it("swaps an existing plugin to the new version and removes the old directory", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+
+    const v1 = await makeArchive({ name: "acme.upgrade", version: "1.0.0" }, { "v1.txt": "one" });
+    const first = await service.installPlugin(v1);
+    expect(first.status).toBe("installed");
+    expect(await exists(path.join(pluginsRoot, "acme.upgrade", "v1.txt"))).toBe(true);
+
+    const v2 = await makeArchive({ name: "acme.upgrade", version: "2.0.0" }, { "v2.txt": "two" });
+    const second = await service.installPlugin(v2);
+    expect(second.status).toBe("installed");
+
+    // New version's file present, old version's file gone — a true swap, not a merge.
+    expect(await exists(path.join(pluginsRoot, "acme.upgrade", "v2.txt"))).toBe(true);
+    expect(await exists(path.join(pluginsRoot, "acme.upgrade", "v1.txt"))).toBe(false);
+
+    const entries = await fs.readdir(pluginsRoot);
+    expect(entries.filter((e) => e.includes(".old-"))).toHaveLength(0);
+
+    service.dispose();
+  });
+
+  it("preserves the plugin's separate settings file across an upgrade", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+
+    const v1 = await makeArchive({ name: "acme.keep-settings", version: "1.0.0" });
+    await service.installPlugin(v1);
+
+    // Settings live under a sibling `plugin-settings/` root, never inside the
+    // plugin dir, so the directory swap must not touch them.
+    const settingsRoot = path.join(tmpDir, "plugin-settings");
+    await fs.mkdir(settingsRoot, { recursive: true });
+    const settingsFile = path.join(settingsRoot, "acme.keep-settings.json");
+    await fs.writeFile(settingsFile, JSON.stringify({ apiKey: "secret-token" }));
+
+    const v2 = await makeArchive({ name: "acme.keep-settings", version: "2.0.0" });
+    await service.installPlugin(v2);
+
+    expect(await exists(settingsFile)).toBe(true);
+    expect(JSON.parse(await fs.readFile(settingsFile, "utf-8"))).toEqual({
+      apiKey: "secret-token",
+    });
+
+    service.dispose();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "node-addon-api": "^8.8.0",
         "node-pty": "1.2.0-beta.12",
         "posix-pty-reaper": "file:electron/native/posix-pty-reaper",
+        "proper-lockfile": "^4.1.2",
         "react-colorful": "^5.6.1",
         "safe-stable-stringify": "^2.5.0",
         "smol-toml": "^1.6.1",
@@ -16705,7 +16706,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -16717,7 +16717,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/property-information": {
@@ -17294,7 +17293,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "node-addon-api": "^8.8.0",
     "node-pty": "1.2.0-beta.12",
     "posix-pty-reaper": "file:electron/native/posix-pty-reaper",
+    "proper-lockfile": "^4.1.2",
     "react-colorful": "^5.6.1",
     "safe-stable-stringify": "^2.5.0",
     "smol-toml": "^1.6.1",

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -368,6 +368,9 @@ export interface GeneratedElectronAPI {
     getPanelKinds(
       ...args: IpcInvokeMap["plugin:panel-kinds-get"]["args"]
     ): Promise<IpcInvokeMap["plugin:panel-kinds-get"]["result"]>;
+    install(
+      ...args: IpcInvokeMap["plugin:install"]["args"]
+    ): Promise<IpcInvokeMap["plugin:install"]["result"]>;
     keybindings(
       ...args: IpcInvokeMap["plugin:keybindings"]["args"]
     ): Promise<IpcInvokeMap["plugin:keybindings"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -651,6 +651,10 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: import("./pluginAudit.js").PluginActionAuditRecord[];
   };
+  "plugin:install": {
+    args: [archivePath: string, opts?: import("../plugin.js").PluginInstallOptions | undefined];
+    result: import("../plugin.js").PluginInstallResult;
+  };
   "plugin:keybindings": {
     args: [];
     result: { pluginId: string; item: import("../plugin.js").KeybindingContribution }[];

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -317,6 +317,65 @@ export interface InstalledPluginRecord {
   loadError: PluginLoadError | null;
 }
 
+/**
+ * Discriminated failure code for {@link PluginInstallResult}. Each value maps
+ * to a distinct failure branch in `PluginService.installPlugin` so the install
+ * dialog (F22a/b/F23/F24) can render a tailored message instead of a raw
+ * stringified error.
+ *
+ * - `lock_failed` — couldn't acquire the cross-process `install.lock`
+ * - `archive_invalid` — `.dntr` extraction failed (bad zip, path traversal, oversize)
+ * - `manifest_invalid` — `plugin.json` failed the strict Zod schema
+ * - `engine_incompatible` — `engines.daintree` range doesn't satisfy the running version
+ * - `namespace_unauthorized` — reserved `daintree.*` name or publisher/name disagreement
+ * - `hash_failed` — couldn't compute the archive SHA-256
+ * - `unload_failed` — the existing plugin's disposer cascade threw
+ * - `swap_failed` — atomic rename failed but the prior state was restored
+ * - `swap_unrecoverable` — rename failed AND rollback failed; on-disk state is inconsistent
+ * - `load_failed` — swap committed but the new plugin failed to load
+ */
+export type PluginInstallErrorCode =
+  | "lock_failed"
+  | "archive_invalid"
+  | "manifest_invalid"
+  | "engine_incompatible"
+  | "namespace_unauthorized"
+  | "hash_failed"
+  | "unload_failed"
+  | "swap_failed"
+  | "swap_unrecoverable"
+  | "load_failed";
+
+/**
+ * Structured install validation error. `path` is the JSON pointer segments
+ * into `plugin.json` for `manifest_invalid` failures (empty for non-manifest
+ * errors) so the dialog can highlight the offending field.
+ */
+export interface PluginInstallError {
+  code: PluginInstallErrorCode;
+  path?: string[];
+  message: string;
+}
+
+/**
+ * Result of {@link PluginService.installPlugin}. Returned as plain data (never
+ * thrown) so structured validation errors survive Electron's structured-clone
+ * IPC boundary intact (#3769). The discriminant is `status` rather than `ok`
+ * because `ok`/`success` keys collide with the IPC success envelope and are
+ * rejected by `ForbidIpcEnvelopeKeys` at the handler boundary.
+ */
+export type PluginInstallResult =
+  | { status: "installed"; pluginId: string }
+  | { status: "failed"; errors: PluginInstallError[] };
+
+/** Optional provenance hints recorded on a successful install. */
+export interface PluginInstallOptions {
+  /** How the install was initiated. Defaults to `"sideload"` when omitted. */
+  source?: PluginInstallSource;
+  /** Original download URL for catalog/url installs. Never logged. */
+  originalUrl?: string | null;
+}
+
 export interface LoadedPluginInfo {
   manifest: PluginManifest;
   dir: string;


### PR DESCRIPTION
## Summary

- Adds `PluginService.installPlugin(archivePath, opts?)` as the single atomic installer entry point -- the only path that writes to `~/.daintree/plugins/`
- Extracts to a sibling `.install-tmp-*` dir on the same filesystem (guaranteeing atomic rename), validates manifest, acquires a cross-process lock, and swaps atomically -- on any failure the filesystem is left in the pre-install state
- Returns a discriminated union (`{status:"installed",pluginId}` | `{status:"failed",errors:PluginInstallError[]}`) and never throws; structured errors on every failure path

Resolves #9292

## Changes

**Core install flow** (`electron/services/PluginService.ts`): ensure plugin root → acquire `install.lock` via `proper-lockfile` (stale 20s / update 10s, `realpath:false`, `onCompromised` aborts before swap) → `mkdtemp` sibling `.install-tmp-*` → extract or `fs.cp` → SHA-256 hash (archive only) → Zod manifest validation (unknown keys + `daintree.*` namespace rejected) → engine semver check → on upgrade: `unloadPlugin` then `_swapPluginDir` (parks old → renames new in → restores old on double-fault, sets `swap_unrecoverable` on second fault) → `upsertInstalledRecord` provenance → `loadPlugin` → `setPluginArchiveHash` → `activatePlugin`. `finally{}` removes temp dir and releases lock.

**Archive extraction** (`electron/services/PluginArchive.ts`): new `extractPluginArchive` with zip-slip guards (backslash, absolute, and `..` paths all rejected), cumulative uncompressed-size guard to block zip-bombs.

**IPC wiring**: new `plugin:install` channel in `electron/ipc/channels.ts`, handler in `electron/ipc/handlers/plugin.ts`, preload binding in `electron/ipc/handlers/plugin.preload.ts`, regenerated `shared/types/ipc/generated.ts` and `shared/types/ipc/generated-api.ts`. `proper-lockfile` promoted from transitive dev dep to production dependency.

**`loadFromDir`** now skips dot-prefixed directories so `.install-tmp-*` and `.old-*` staging dirs are never scanned.

**Plugin settings** live at the separate `~/.daintree/plugin-settings/` root, so the directory swap never touches them -- no preserve/restore needed (covered by test).

**New shared types** (`shared/types/plugin.ts`): `PluginInstallError`, `PluginInstallResult`, `PluginInstallOptions` discriminated union.

## Testing

- `electron/services/__tests__/PluginService.install.test.ts`: happy path, directory source, no temp-dir leak, `manifest_invalid`, `namespace_unauthorized`, `engine_incompatible`, missing source, upgrade swap, settings preservation across swap, swap rollback restores runtime state, `load_failed` on downstream throw, disabled→installed, archive→dir clears hash.
- `electron/services/__tests__/PluginArchive.extract.test.ts`: faithful extraction, path traversal / backslash / absolute path rejection, zip-bomb guard, oversize single-file rejection.

## Notes

Directory-source (developer sideload) installs copy symlinks as-is without containment checks -- low impact, deferred. This implementation unblocks F22a/F22b/F23/F24 (install surfaces) and F25/F26 (update/uninstall, which can reuse the swap + lock primitives). Part of epic #5651.