### PR TITLE
feat(plugins): uninstall with dispose cascade + secret-preservation prompt

### DIFF
--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -268,6 +268,19 @@ describe("registerPluginHandlers", () => {
     expect(mockUninstallPlugin).not.toHaveBeenCalled();
   });
 
+  it("PLUGIN_UNINSTALL rejects a path-traversal id without touching the service", async () => {
+    const handler = getHandler("plugin:uninstall");
+    await expect(handler({}, "../../../etc")).rejects.toThrow(/scoped plugin name/);
+    await expect(handler({}, "no-dot")).rejects.toThrow(/scoped plugin name/);
+    expect(mockUninstallPlugin).not.toHaveBeenCalled();
+  });
+
+  it("PLUGIN_UNINSTALL rejects a non-boolean deleteSettings", async () => {
+    const handler = getHandler("plugin:uninstall");
+    await expect(handler({}, "acme.my-plugin", "true")).rejects.toThrow(/must be a boolean/);
+    expect(mockUninstallPlugin).not.toHaveBeenCalled();
+  });
+
   it("PLUGIN_CHECK_FOR_UPDATE returns not-implemented", async () => {
     const handler = getHandler("plugin:check-for-update");
     const result = await handler({}, "acme.my-plugin");

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -253,7 +253,13 @@ describe("registerPluginHandlers", () => {
   it("PLUGIN_UNINSTALL delegates to pluginService.uninstallPlugin", async () => {
     const handler = getHandler("plugin:uninstall");
     await handler({}, "acme.my-plugin");
-    expect(mockUninstallPlugin).toHaveBeenCalledWith("acme.my-plugin");
+    expect(mockUninstallPlugin).toHaveBeenCalledWith("acme.my-plugin", undefined);
+  });
+
+  it("PLUGIN_UNINSTALL forwards the deleteSettings flag", async () => {
+    const handler = getHandler("plugin:uninstall");
+    await handler({}, "acme.my-plugin", true);
+    expect(mockUninstallPlugin).toHaveBeenCalledWith("acme.my-plugin", true);
   });
 
   it("PLUGIN_UNINSTALL throws on an empty id without unloading anything", async () => {

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -122,11 +122,11 @@ async function handleInstallFromUrl(url: string): Promise<PluginInstallResult> {
   return { status: "not-implemented" };
 }
 
-async function handleUninstall(pluginId: string): Promise<void> {
+async function handleUninstall(pluginId: string, deleteSettings?: boolean): Promise<void> {
   if (typeof pluginId !== "string" || pluginId.trim().length === 0) {
     throw new Error("uninstall: pluginId must be a non-empty string");
   }
-  pluginService.uninstallPlugin(pluginId);
+  await pluginService.uninstallPlugin(pluginId, deleteSettings);
 }
 
 async function handleCheckForUpdate(pluginId: string): Promise<PluginCheckUpdateResult> {

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -15,6 +15,7 @@ import {
 import type { PluginDiagnosticsSnapshot } from "../../../shared/types/ipc/pluginDiagnostics.js";
 import { PLUGIN_METHOD_CHANNELS } from "./plugin.preload.js";
 import { pluginService } from "../../services/PluginService.js";
+import { SCOPED_PLUGIN_NAME_PATTERN } from "../../schemas/plugin.js";
 import { scrubSecrets } from "../../../shared/utils/secretScrubber.js";
 import { stableArgsSha256 } from "../../utils/pluginMcpHash.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
@@ -125,6 +126,16 @@ async function handleInstallFromUrl(url: string): Promise<PluginInstallResult> {
 async function handleUninstall(pluginId: string, deleteSettings?: boolean): Promise<void> {
   if (typeof pluginId !== "string" || pluginId.trim().length === 0) {
     throw new Error("uninstall: pluginId must be a non-empty string");
+  }
+  // Validate against the scoped-name format before the service touches the
+  // filesystem — uninstall feeds pluginId straight into `fs.rm(<root>/<id>)`,
+  // so a compromised renderer passing `"../.."` must be rejected at the trust
+  // boundary, not just defended in depth in the service.
+  if (!SCOPED_PLUGIN_NAME_PATTERN.test(pluginId)) {
+    throw new Error("uninstall: pluginId must be a scoped plugin name (publisher.name)");
+  }
+  if (deleteSettings !== undefined && typeof deleteSettings !== "boolean") {
+    throw new Error("uninstall: deleteSettings must be a boolean");
   }
   await pluginService.uninstallPlugin(pluginId, deleteSettings);
 }

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -41,7 +41,11 @@ interface ProperLockfile {
   lock(file: string, opts?: LockOptions): Promise<() => Promise<void>>;
 }
 const properLockfile: ProperLockfile = req("proper-lockfile");
-import { getPluginManifestSchema, PluginToastOptionsSchema } from "../schemas/plugin.js";
+import {
+  getPluginManifestSchema,
+  PluginToastOptionsSchema,
+  SCOPED_PLUGIN_NAME_PATTERN,
+} from "../schemas/plugin.js";
 import { extractPluginArchive, computeArchiveHash } from "./PluginArchive.js";
 import { resilientRename } from "../utils/fs.js";
 import { getPluginMcpSupervisor } from "./PluginMcpSupervisor.js";
@@ -3341,6 +3345,15 @@ export class PluginService {
     if (typeof pluginId !== "string" || pluginId.trim().length === 0) {
       throw new Error("uninstallPlugin: pluginId must be a non-empty string");
     }
+    // Defense-in-depth (the IPC handler validates too): pluginId is joined onto
+    // pluginsRoot for `fs.rm`, so reject anything that isn't a scoped plugin
+    // name before touching the filesystem — blocks `..` traversal and separators.
+    if (!SCOPED_PLUGIN_NAME_PATTERN.test(pluginId)) {
+      throw new Error("uninstallPlugin: pluginId must be a scoped plugin name (publisher.name)");
+    }
+    // Coerce so a non-TypeScript caller can't pass a truthy non-boolean and
+    // silently wipe secrets the user meant to keep.
+    const wipeSettings = deleteSettings === true;
 
     // Capture the record (running or skipped-at-launch) before unload clears it
     // so we know whether the on-disk dir is ours to delete — built-ins live in
@@ -3402,17 +3415,23 @@ export class PluginService {
       }
 
       // Optionally delete user-scope stored settings/secrets. `force` is a safe
-      // no-op when the file doesn't exist. The in-memory store was already
-      // dropped by `unloadPlugin`'s clearPluginSettingsState step.
-      if (deleteSettings) {
+      // no-op when the file doesn't exist; the retry options mirror the plugin
+      // dir deletion so a still-closing settings writer on Windows doesn't strand
+      // the uninstall. The in-memory store was already dropped by
+      // `unloadPlugin`'s clearPluginSettingsState step.
+      if (wipeSettings) {
         const settingsFile = path.join(this.settingsRoot(), `${pluginId}.json`);
-        await fs.rm(settingsFile, { force: true });
+        await fs.rm(settingsFile, { force: true, maxRetries: 5, retryDelay: 100 });
       }
 
       // Bookkeeping runs only after the filesystem deletion succeeds — if `fs.rm`
       // throws, the record stays so the row remains and the user can retry,
       // rather than seeing a "gone" plugin whose files are still on disk.
       this.disabledPlugins.delete(pluginId);
+      // Release the launch-time name reservation (set when a disabled plugin is
+      // skipped at startup) so a same-session reinstall isn't rejected as a
+      // duplicate name.
+      this.reservedNames.delete(pluginId);
       // Clear it from the persisted `plugins.disabled` intent list so a disabled
       // plugin can't resurrect itself on the next launch's disabled-dir re-scan.
       this.setEnabled(pluginId, true);

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -3378,7 +3378,9 @@ export class PluginService {
         },
       });
     } catch (err) {
-      throw new Error(`Couldn't acquire the plugin install lock: ${(err as Error).message}`);
+      throw new Error(`Couldn't acquire the plugin install lock: ${(err as Error).message}`, {
+        cause: err,
+      });
     }
 
     try {

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -3320,39 +3320,113 @@ export class PluginService {
   }
 
   /**
-   * Remove a non-builtin plugin from the running session and drop its
-   * provenance record. Composes the existing {@link unloadPlugin} (which tears
-   * down all of the plugin's contributions and broadcasts the registry
-   * changes) with deletion of the persisted `plugins.installed` record, then
-   * fires a `plugin:provenance-changed` broadcast so every project view's
-   * Settings tab re-pulls the list.
+   * Remove a non-builtin plugin from the running session, delete its on-disk
+   * install, and drop its provenance record. Composes the existing
+   * {@link unloadPlugin} (which tears down all of the plugin's contributions and
+   * broadcasts the registry changes) with deletion of the plugin directory,
+   * optional deletion of its user-scope settings/secrets, and removal of the
+   * persisted `plugins.installed` record, then fires a
+   * `plugin:provenance-changed` broadcast so every project view's Settings tab
+   * re-pulls the list.
    *
-   * This is the F26-precursor: it unloads and forgets the plugin but does NOT
-   * delete the on-disk archive or its stored settings/secrets — that
-   * filesystem cleanup (and the secret-preservation prompt) is owned by F26.
-   * Built-ins have no installed record and cannot be uninstalled; calling this
-   * for one is a no-op beyond the unload.
+   * Holds the same `install.lock` {@link installPlugin} uses, so an install and
+   * an uninstall of the same plugin can't race on the directory. A throwing
+   * disposer never blocks the on-disk deletion — a broken plugin must still be
+   * uninstallable. `deleteSettings` defaults to `false` so stored secrets
+   * survive a reinstall; project-scope settings (per-repo `.daintree/`, tracked
+   * git artifacts) are never touched. Built-ins are app-bundled with no
+   * installed record — their directory is never deleted.
    */
-  uninstallPlugin(pluginId: string): void {
+  async uninstallPlugin(pluginId: string, deleteSettings = false): Promise<void> {
     if (typeof pluginId !== "string" || pluginId.trim().length === 0) {
       throw new Error("uninstallPlugin: pluginId must be a non-empty string");
     }
-    // A plugin is either running (`this.plugins`) or skipped-at-launch because
-    // it was disabled (`this.disabledPlugins`). `unloadPlugin` only touches the
-    // running set, so a disabled plugin must also be dropped from the skipped
-    // map — otherwise `listPlugins()` keeps returning it and the row survives a
-    // "successful" uninstall.
-    this.unloadPlugin(pluginId);
-    this.disabledPlugins.delete(pluginId);
-    // Clear it from the persisted `plugins.disabled` intent list so a disabled
-    // plugin can't resurrect itself on the next launch's disabled-dir re-scan.
-    this.setEnabled(pluginId, true);
-    const records = this.getInstalledRecords();
-    if (pluginId in records) {
-      delete records[pluginId];
-      this.writeInstalledRecords(records);
+
+    // Capture the record (running or skipped-at-launch) before unload clears it
+    // so we know whether the on-disk dir is ours to delete — built-ins live in
+    // the app bundle and must survive.
+    const record = this.plugins.get(pluginId) ?? this.disabledPlugins.get(pluginId);
+    const isBuiltin = record?.isBuiltin ?? false;
+
+    await fs.mkdir(this.pluginsRoot, { recursive: true });
+
+    const lockPath = path.join(this.pluginsRoot, "install.lock");
+    // Definitely assigned below or the catch throws, so `finally` can release
+    // unconditionally without a null guard.
+    let release: () => Promise<void>;
+    try {
+      release = await properLockfile.lock(lockPath, {
+        stale: 20_000,
+        update: 10_000,
+        realpath: false,
+        retries: { retries: 5, minTimeout: 100, maxTimeout: 1_000 },
+        onCompromised: (err) => {
+          console.error("[PluginService] install.lock compromised during uninstall:", err);
+        },
+      });
+    } catch (err) {
+      throw new Error(`Couldn't acquire the plugin install lock: ${(err as Error).message}`);
     }
-    this.broadcastProvenanceChanged();
+
+    try {
+      // A plugin is either running (`this.plugins`) or skipped-at-launch because
+      // it was disabled (`this.disabledPlugins`). `unloadPlugin` only touches the
+      // running set, so a disabled plugin must also be dropped from the skipped
+      // map below. The disposer cascade already swallows per-step errors, but
+      // guard the whole call too: a broken plugin must still be uninstallable.
+      try {
+        this.unloadPlugin(pluginId);
+      } catch (err) {
+        console.error(`[PluginService] unloadPlugin during uninstall of "${pluginId}" threw:`, err);
+      }
+
+      // `unloadPlugin` fires the MCP shutdown fire-and-forget; await it
+      // explicitly here so subprocess handles are released before `fs.rm`
+      // (idempotent — re-shutting-down an already-stopped server is a no-op).
+      // The await covers the signal path only; the Windows tree-kill grace
+      // window is ridden out by the `fs.rm` retry options below.
+      try {
+        await getPluginMcpSupervisor().shutdown({ pluginId });
+      } catch (err) {
+        console.error(`[PluginService] MCP shutdown during uninstall of "${pluginId}" threw:`, err);
+      }
+
+      // Delete the on-disk install. The dir is deterministic — `installPlugin`
+      // always materializes to `<pluginsRoot>/<pluginId>` — so this also reaps
+      // an orphaned record whose plugin failed to load. `force` makes a missing
+      // dir a no-op; the retry options ride out Windows EBUSY/EPERM from handles
+      // still closing during the shutdown grace window. Skip built-ins.
+      if (!isBuiltin) {
+        const pluginDir = path.join(this.pluginsRoot, pluginId);
+        await fs.rm(pluginDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      }
+
+      // Optionally delete user-scope stored settings/secrets. `force` is a safe
+      // no-op when the file doesn't exist. The in-memory store was already
+      // dropped by `unloadPlugin`'s clearPluginSettingsState step.
+      if (deleteSettings) {
+        const settingsFile = path.join(this.settingsRoot(), `${pluginId}.json`);
+        await fs.rm(settingsFile, { force: true });
+      }
+
+      // Bookkeeping runs only after the filesystem deletion succeeds — if `fs.rm`
+      // throws, the record stays so the row remains and the user can retry,
+      // rather than seeing a "gone" plugin whose files are still on disk.
+      this.disabledPlugins.delete(pluginId);
+      // Clear it from the persisted `plugins.disabled` intent list so a disabled
+      // plugin can't resurrect itself on the next launch's disabled-dir re-scan.
+      this.setEnabled(pluginId, true);
+      const records = this.getInstalledRecords();
+      if (pluginId in records) {
+        delete records[pluginId];
+        this.writeInstalledRecords(records);
+      }
+      this.broadcastProvenanceChanged();
+    } finally {
+      await release().catch((err) =>
+        console.warn("[PluginService] Failed to release install.lock after uninstall:", err)
+      );
+    }
   }
 
   private broadcastProvenanceChanged(): void {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -1801,15 +1801,16 @@ describe("PluginService built-in plugin loading", () => {
   });
 
   describe("uninstallPlugin", () => {
-    it("removes a running plugin from listPlugins and broadcasts provenance-changed", async () => {
+    it("removes a running plugin from listPlugins, deletes its dir, and broadcasts provenance-changed", async () => {
       await writePlugin("acme.live", { name: "acme.live", version: "1.0.0" });
       const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
       await service.initialize();
       expect(service.listPlugins()).toHaveLength(1);
 
-      service.uninstallPlugin("acme.live");
+      await service.uninstallPlugin("acme.live");
 
       expect(service.listPlugins()).toEqual([]);
+      await expect(fs.access(path.join(tmpDir, "acme.live"))).rejects.toThrow();
       expect(broadcastToRendererMock).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ name: "plugin:provenance-changed" })
@@ -1827,30 +1828,70 @@ describe("PluginService built-in plugin loading", () => {
       expect(service.listPlugins()).toHaveLength(1);
       expect(service.listPlugins()[0]).toMatchObject({ disabled: true });
 
-      service.uninstallPlugin("acme.off");
+      await service.uninstallPlugin("acme.off");
 
       expect(service.listPlugins()).toEqual([]);
+      await expect(fs.access(path.join(tmpDir, "acme.off"))).rejects.toThrow();
       const stored = storeMock._state.get("plugins") as { disabled?: string[] };
       expect(stored.disabled ?? []).not.toContain("acme.off");
     });
 
-    it("deletes the installed provenance record", () => {
+    it("deletes the installed provenance record", async () => {
       storeMock._state.set("plugins", {
         disabled: [],
         installed: { "acme.gone": { source: "sideload", installedAt: 1 } },
       });
       const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
 
-      service.uninstallPlugin("acme.gone");
+      await service.uninstallPlugin("acme.gone");
 
       const stored = storeMock._state.get("plugins") as { installed?: Record<string, unknown> };
       expect(stored.installed ?? {}).not.toHaveProperty("acme.gone");
     });
 
-    it("throws on an empty or whitespace-only plugin id", () => {
+    it("preserves the user-scope settings file by default", async () => {
+      const pluginsRoot = path.join(tmpDir, "plugins");
+      await fs.mkdir(path.join(pluginsRoot, "acme.keep"), { recursive: true });
+      await fs.writeFile(
+        path.join(pluginsRoot, "acme.keep", "plugin.json"),
+        JSON.stringify({ name: "acme.keep", version: "1.0.0" })
+      );
+      const settingsFile = path.join(tmpDir, "plugin-settings", "acme.keep.json");
+      await fs.mkdir(path.dirname(settingsFile), { recursive: true });
+      await fs.writeFile(settingsFile, JSON.stringify({ token: "secret" }));
+      const service = new PluginService(pluginsRoot, "0.0.0", { builtinPluginsRoot: builtinDir });
+      await service.initialize();
+
+      await service.uninstallPlugin("acme.keep");
+
+      await expect(fs.access(path.join(pluginsRoot, "acme.keep"))).rejects.toThrow();
+      // Secrets survive a plain uninstall.
+      await expect(fs.access(settingsFile)).resolves.toBeUndefined();
+    });
+
+    it("deletes the user-scope settings file when deleteSettings is true", async () => {
+      const pluginsRoot = path.join(tmpDir, "plugins");
+      await fs.mkdir(path.join(pluginsRoot, "acme.wipe"), { recursive: true });
+      await fs.writeFile(
+        path.join(pluginsRoot, "acme.wipe", "plugin.json"),
+        JSON.stringify({ name: "acme.wipe", version: "1.0.0" })
+      );
+      const settingsFile = path.join(tmpDir, "plugin-settings", "acme.wipe.json");
+      await fs.mkdir(path.dirname(settingsFile), { recursive: true });
+      await fs.writeFile(settingsFile, JSON.stringify({ token: "secret" }));
+      const service = new PluginService(pluginsRoot, "0.0.0", { builtinPluginsRoot: builtinDir });
+      await service.initialize();
+
+      await service.uninstallPlugin("acme.wipe", true);
+
+      await expect(fs.access(path.join(pluginsRoot, "acme.wipe"))).rejects.toThrow();
+      await expect(fs.access(settingsFile)).rejects.toThrow();
+    });
+
+    it("rejects on an empty or whitespace-only plugin id", async () => {
       const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
-      expect(() => service.uninstallPlugin("")).toThrow(/non-empty string/);
-      expect(() => service.uninstallPlugin("   ")).toThrow(/non-empty string/);
+      await expect(service.uninstallPlugin("")).rejects.toThrow(/non-empty string/);
+      await expect(service.uninstallPlugin("   ")).rejects.toThrow(/non-empty string/);
     });
   });
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -1888,6 +1888,28 @@ describe("PluginService built-in plugin loading", () => {
       await expect(fs.access(settingsFile)).rejects.toThrow();
     });
 
+    it("clears the launch-time name reservation so a same-session reinstall isn't blocked", async () => {
+      // Regression: a disabled-at-launch plugin reserves its name; uninstall
+      // must release it or loadPlugin rejects the reinstall as a duplicate.
+      storeMock._state.set("plugins", { disabled: ["acme.reserve"] });
+      await writePlugin("acme.reserve", { name: "acme.reserve", version: "1.0.0" });
+      const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
+      await service.initialize();
+      const reserved = () =>
+        (service as unknown as { reservedNames: Set<string> }).reservedNames.has("acme.reserve");
+      expect(reserved()).toBe(true);
+
+      await service.uninstallPlugin("acme.reserve");
+
+      expect(reserved()).toBe(false);
+    });
+
+    it("rejects a path-traversal or non-scoped plugin id before touching the filesystem", async () => {
+      const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
+      await expect(service.uninstallPlugin("../../../etc")).rejects.toThrow(/scoped plugin name/);
+      await expect(service.uninstallPlugin("no-dot")).rejects.toThrow(/scoped plugin name/);
+    });
+
     it("rejects on an empty or whitespace-only plugin id", async () => {
       const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
       await expect(service.uninstallPlugin("")).rejects.toThrow(/non-empty string/);

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -704,7 +704,7 @@ export interface GeneratedIpcInvokeMap {
     result: import("../../config/toolbarButtonRegistry.js").ToolbarButtonConfig[];
   };
   "plugin:uninstall": {
-    args: [pluginId: string];
+    args: [pluginId: string, deleteSettings?: boolean | undefined];
     result: void;
   };
   "plugin:validate-action-ids": {

--- a/src/components/Settings/PluginsTab.tsx
+++ b/src/components/Settings/PluginsTab.tsx
@@ -151,13 +151,13 @@ function PluginRow({ plugin, toggling, onToggle, onUninstall }: PluginRowProps) 
                   variant="ghost"
                   size="icon-sm"
                   onClick={onUninstall}
-                  aria-label={`Delete ${label}`}
+                  aria-label={`Uninstall ${label}`}
                   className="text-daintree-text/50 hover:text-status-error"
                 >
                   <Trash2 />
                 </Button>
               </TooltipTrigger>
-              <TooltipContent side="bottom">Delete plugin</TooltipContent>
+              <TooltipContent side="bottom">Uninstall plugin</TooltipContent>
             </Tooltip>
           )}
 
@@ -216,7 +216,21 @@ export function PluginsTab() {
   const [pending, setPending] = useState<Set<string>>(new Set());
   const [refreshKey, setRefreshKey] = useState(0);
   const [pendingUninstall, setPendingUninstall] = useState<LoadedPluginInfo | null>(null);
+  // Defaults off so stored secrets survive a reinstall — the user opts in to
+  // wiping them. Reset whenever a new uninstall is armed so a prior tick can't
+  // carry over to the next plugin.
+  const [deleteSettings, setDeleteSettings] = useState(false);
   const [isUninstalling, setIsUninstalling] = useState(false);
+
+  const armUninstall = (plugin: LoadedPluginInfo) => {
+    setDeleteSettings(false);
+    setPendingUninstall(plugin);
+  };
+
+  const closeUninstall = () => {
+    setPendingUninstall(null);
+    setDeleteSettings(false);
+  };
   const [showUrlDialog, setShowUrlDialog] = useState(false);
   const [urlInput, setUrlInput] = useState("");
   const [isInstalling, setIsInstalling] = useState(false);
@@ -357,8 +371,8 @@ export function PluginsTab() {
     setIsUninstalling(true);
     try {
       setError(null);
-      await window.electron.plugin.uninstall(id);
-      setPendingUninstall(null);
+      await window.electron.plugin.uninstall(id, deleteSettings);
+      closeUninstall();
       // Re-pull the authoritative list rather than splicing the closure (#5087).
       setRefreshKey((k) => k + 1);
     } catch (err) {
@@ -429,7 +443,7 @@ export function PluginsTab() {
               plugin={plugin}
               toggling={pending.has(plugin.manifest.name)}
               onToggle={() => void handleToggle(plugin)}
-              onUninstall={() => setPendingUninstall(plugin)}
+              onUninstall={() => armUninstall(plugin)}
             />
           ))}
         </div>
@@ -444,15 +458,26 @@ export function PluginsTab() {
 
       <ConfirmDialog
         isOpen={pendingUninstall !== null}
-        onClose={isUninstalling ? undefined : () => setPendingUninstall(null)}
-        title={pendingUninstall ? `Delete '${pluginLabel(pendingUninstall)}'?` : ""}
-        description="Removes the plugin and unloads its panels, commands, and integrations. Its stored settings stay on disk until cleared separately."
-        confirmLabel="Delete plugin"
+        onClose={isUninstalling ? undefined : closeUninstall}
+        title={pendingUninstall ? `Uninstall '${pluginLabel(pendingUninstall)}'?` : ""}
+        description="Removes the plugin and deletes its files, unloading its panels, commands, and integrations. Stored settings and secrets are kept unless you check the box below."
+        confirmLabel="Uninstall plugin"
         cancelLabel="Keep plugin"
         onConfirm={() => void confirmUninstall()}
         isConfirmLoading={isUninstalling}
         variant="destructive"
-      />
+      >
+        <label className="flex items-center gap-2 text-xs text-daintree-text/70 select-none cursor-pointer">
+          <input
+            type="checkbox"
+            checked={deleteSettings}
+            onChange={(e) => setDeleteSettings(e.target.checked)}
+            disabled={isUninstalling}
+            className="size-3.5 rounded-sm border border-daintree-border bg-daintree-bg accent-daintree-text/70"
+          />
+          Also delete stored settings and secrets
+        </label>
+      </ConfirmDialog>
 
       <AppDialog
         isOpen={showUrlDialog}

--- a/src/components/Settings/__tests__/PluginsTab.test.tsx
+++ b/src/components/Settings/__tests__/PluginsTab.test.tsx
@@ -228,23 +228,43 @@ describe("PluginsTab", () => {
     ]);
     renderTab();
     await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
-    expect(screen.queryByRole("button", { name: "Delete Acme Demo" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Uninstall Acme Demo" })).toBeNull();
     expect(screen.getByText("Built-in")).toBeTruthy();
   });
 
-  it("opens a confirm dialog and uninstalls, then re-fetches the list", async () => {
+  it("opens a confirm dialog and uninstalls (settings preserved by default), then re-fetches the list", async () => {
     const listMock = window.electron.plugin.list as ReturnType<typeof vi.fn>;
     listMock.mockResolvedValueOnce([makePlugin()]).mockResolvedValueOnce([]);
     renderTab();
     await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
 
-    fireEvent.click(screen.getByRole("button", { name: "Delete Acme Demo" }));
-    await waitFor(() => expect(screen.getByText("Delete 'Acme Demo'?")).toBeTruthy());
+    fireEvent.click(screen.getByRole("button", { name: "Uninstall Acme Demo" }));
+    await waitFor(() => expect(screen.getByText("Uninstall 'Acme Demo'?")).toBeTruthy());
 
-    fireEvent.click(screen.getByRole("button", { name: "Delete plugin" }));
-    await waitFor(() => expect(window.electron.plugin.uninstall).toHaveBeenCalledWith("acme.demo"));
+    fireEvent.click(screen.getByRole("button", { name: "Uninstall plugin" }));
+    await waitFor(() =>
+      expect(window.electron.plugin.uninstall).toHaveBeenCalledWith("acme.demo", false)
+    );
     await waitFor(() => expect(screen.getByText("No plugins installed")).toBeTruthy());
     expect(listMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("passes deleteSettings=true when the secrets checkbox is checked", async () => {
+    const listMock = window.electron.plugin.list as ReturnType<typeof vi.fn>;
+    listMock.mockResolvedValueOnce([makePlugin()]).mockResolvedValueOnce([]);
+    renderTab();
+    await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: "Uninstall Acme Demo" }));
+    await waitFor(() => expect(screen.getByText("Uninstall 'Acme Demo'?")).toBeTruthy());
+
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Also delete stored settings and secrets" })
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Uninstall plugin" }));
+    await waitFor(() =>
+      expect(window.electron.plugin.uninstall).toHaveBeenCalledWith("acme.demo", true)
+    );
   });
 
   it("disables the check-for-update button", async () => {

--- a/src/components/Settings/__tests__/PluginsTab.test.tsx
+++ b/src/components/Settings/__tests__/PluginsTab.test.tsx
@@ -267,6 +267,28 @@ describe("PluginsTab", () => {
     );
   });
 
+  it("resets the secrets checkbox after cancelling and re-arming uninstall", async () => {
+    (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([makePlugin()]);
+    renderTab();
+    await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
+
+    // Arm, tick the box, then cancel.
+    fireEvent.click(screen.getByRole("button", { name: "Uninstall Acme Demo" }));
+    await waitFor(() => expect(screen.getByText("Uninstall 'Acme Demo'?")).toBeTruthy());
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Also delete stored settings and secrets" })
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Keep plugin" }));
+
+    // Re-arm and confirm without touching the box — the prior tick must not leak.
+    fireEvent.click(screen.getByRole("button", { name: "Uninstall Acme Demo" }));
+    await waitFor(() => expect(screen.getByText("Uninstall 'Acme Demo'?")).toBeTruthy());
+    fireEvent.click(screen.getByRole("button", { name: "Uninstall plugin" }));
+    await waitFor(() =>
+      expect(window.electron.plugin.uninstall).toHaveBeenCalledWith("acme.demo", false)
+    );
+  });
+
   it("disables the check-for-update button", async () => {
     (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([makePlugin()]);
     renderTab();


### PR DESCRIPTION
## Summary

- The existing `uninstallPlugin` stub unloaded the plugin and dropped the record, but never deleted files. This wires the full dispose cascade.
- Adds an optional "Also delete stored settings and secrets" checkbox to the uninstall `ConfirmDialog` (unchecked by default — secrets survive reinstall).
- Security: validates `pluginId` against `SCOPED_PLUGIN_NAME_PATTERN` at the IPC trust boundary and again in the service before `fs.rm` to block path traversal.

Resolves #9298

## Changes

**Uninstall flow**

`uninstallPlugin` is now async. It acquires the same `install.lock` that `installPlugin` holds (prevents install/uninstall races), runs the LIFO disposer cascade (`unloadPlugin`), awaits MCP subprocess shutdown, then deletes the plugin directory via `fs.rm` with Windows retry options (`maxRetries: 5, retryDelay: 100`). A throwing disposer never blocks deletion — a broken plugin stays uninstallable. Bookkeeping (record + disabled + reservation cleanup, provenance broadcast) runs only after `fs.rm` succeeds, so a failed deletion leaves the row for retry rather than producing a phantom-removed plugin.

**Optional secret deletion**

The uninstall `ConfirmDialog` gains a checkbox to also delete stored settings. Only the user-scope settings file (`~/.daintree/plugin-settings/<pluginId>.json`) is removed; project-scope per-repo `.daintree/` settings (tracked git artifacts) are left untouched. `deleteSettings` is threaded through the `plugin:uninstall` IPC call and `handleUninstall`.

**Name reservation**

Cleared on uninstall so a same-session reinstall of a previously-disabled plugin isn't rejected as a duplicate name.

**Microcopy**

`ConfirmDialog` title `Uninstall '<name>'?`, button `Uninstall plugin`, row tooltip/aria `Uninstall`. D1 confirm tier — no typed-name target needed.

## Testing

Extended `PluginService.test.ts` (dir deletion, settings preserved-by-default vs deleted-when-true, name-reservation release, id validation, async rejects), `plugin.handlers.test.ts` (`deleteSettings` forwarding, path-traversal + non-boolean rejection), and `PluginsTab.test.tsx` (uninstall microcopy, `deleteSettings` false/true, checkbox reset on re-arm). `npm run check` and targeted vitest suites all green.