### PR TITLE
feat(plugins): manual update check + settings-preserving reinstall

### DIFF
--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -6,6 +6,7 @@ const mockRemoveHandlers = vi.fn();
 const mockListPlugins = vi.fn();
 const mockSetEnabled = vi.fn();
 const mockUninstallPlugin = vi.fn();
+const mockCheckForUpdate = vi.fn();
 const mockListPluginActions = vi.fn();
 const mockRegisterPluginAction = vi.fn();
 const mockUnregisterPluginAction = vi.fn();
@@ -15,6 +16,7 @@ vi.mock("../../../services/PluginService.js", () => ({
     listPlugins: (...args: unknown[]) => mockListPlugins(...args),
     setEnabled: (...args: unknown[]) => mockSetEnabled(...args),
     uninstallPlugin: (...args: unknown[]) => mockUninstallPlugin(...args),
+    checkForUpdate: (...args: unknown[]) => mockCheckForUpdate(...args),
     dispatchHandler: (...args: unknown[]) => mockDispatchHandler(...args),
     registerHandler: (...args: unknown[]) => mockRegisterHandler(...args),
     removeHandlers: (...args: unknown[]) => mockRemoveHandlers(...args),
@@ -281,10 +283,29 @@ describe("registerPluginHandlers", () => {
     expect(mockUninstallPlugin).not.toHaveBeenCalled();
   });
 
-  it("PLUGIN_CHECK_FOR_UPDATE returns not-implemented", async () => {
+  it("PLUGIN_CHECK_FOR_UPDATE delegates to pluginService.checkForUpdate and returns the result", async () => {
+    mockCheckForUpdate.mockResolvedValue({
+      status: "available",
+      name: "acme.my-plugin",
+      version: "2.0.0",
+      capabilities: ["network:fetch"],
+    });
     const handler = getHandler("plugin:check-for-update");
     const result = await handler({}, "acme.my-plugin");
-    expect(result).toEqual({ status: "not-implemented" });
+    expect(mockCheckForUpdate).toHaveBeenCalledWith("acme.my-plugin");
+    expect(result).toEqual({
+      status: "available",
+      name: "acme.my-plugin",
+      version: "2.0.0",
+      capabilities: ["network:fetch"],
+    });
+  });
+
+  it("PLUGIN_CHECK_FOR_UPDATE returns invalid-id for an empty id without delegating", async () => {
+    const handler = getHandler("plugin:check-for-update");
+    const result = await handler({}, "");
+    expect(result).toEqual({ status: "invalid-id" });
+    expect(mockCheckForUpdate).not.toHaveBeenCalled();
   });
 
   it("PLUGIN_INVOKE handler delegates to pluginService.dispatchHandler for trusted senders", async () => {

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -144,8 +144,9 @@ async function handleCheckForUpdate(pluginId: string): Promise<PluginCheckUpdate
   if (typeof pluginId !== "string" || pluginId.trim().length === 0) {
     return { status: "invalid-id" };
   }
-  // F25 owns the manual update check (reinstall preserving settings).
-  return { status: "not-implemented" };
+  // The service owns the bounded download + hash compare and returns a
+  // structured result for every domain outcome (#9297).
+  return pluginService.checkForUpdate(pluginId);
 }
 
 async function handleToolbarButtons(): Promise<ToolbarButtonConfig[]> {

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -3077,6 +3077,13 @@ export class PluginService {
       return { status: "invalid-id" };
     }
     const url = record.originalUrl;
+    // Without a baseline hash (corrupt record, or a dir-load that never hashed)
+    // there's nothing to compare against — a string never equals `null`, so the
+    // diff would always read as "available". Fail loudly instead of misleading.
+    if (!record.archiveHash) {
+      return { status: "fetch-failed", message: "No baseline archive hash to compare against" };
+    }
+    const baselineHash = record.archiveHash;
 
     // `net` requires a full Electron runtime; lazy-import it so the service
     // module stays importable in unit tests that don't fetch.
@@ -3094,6 +3101,7 @@ export class PluginService {
         return { status: "fetch-failed", message: `Couldn't reach ${url}: ${(err as Error).message}` };
       }
       if (!response.ok) {
+        await response.body?.cancel().catch(() => {});
         return { status: "fetch-failed", message: `Server responded with HTTP ${response.status}` };
       }
 
@@ -3101,6 +3109,7 @@ export class PluginService {
       const contentType = (response.headers.get("content-type") ?? "").split(";")[0].trim().toLowerCase();
       const ALLOWED_CONTENT_TYPES = ["application/octet-stream", "application/zip", "application/x-zip"];
       if (contentType && !ALLOWED_CONTENT_TYPES.includes(contentType)) {
+        await response.body?.cancel().catch(() => {});
         return { status: "fetch-failed", message: `Unexpected content type "${contentType}"` };
       }
 
@@ -3111,25 +3120,38 @@ export class PluginService {
       if (!body) {
         return { status: "fetch-failed", message: "Response had no body" };
       }
-      const handle = await fs.open(tmpArchive, "w");
+      // A read/write fault mid-stream must come back as a structured
+      // `fetch-failed`, not a thrown rejection — the "never throws for domain
+      // outcomes" contract (#3769). A `null` sentinel signals the oversize abort
+      // so the early-return stays out of the catch.
+      let oversized = false;
       try {
-        const reader = body.getReader();
-        let bytes = 0;
-        for (;;) {
-          const { done, value } = await reader.read();
-          if (done || !value) break;
-          bytes += value.byteLength;
-          if (bytes > MAX_DNTR_BYTES) {
-            await reader.cancel().catch(() => {});
-            return {
-              status: "fetch-failed",
-              message: `Archive exceeds the ${MAX_DNTR_BYTES}-byte size limit`,
-            };
+        const handle = await fs.open(tmpArchive, "w");
+        try {
+          const reader = body.getReader();
+          let bytes = 0;
+          for (;;) {
+            const { done, value } = await reader.read();
+            if (done || !value) break;
+            bytes += value.byteLength;
+            if (bytes > MAX_DNTR_BYTES) {
+              await reader.cancel().catch(() => {});
+              oversized = true;
+              break;
+            }
+            await handle.write(value);
           }
-          await handle.write(value);
+        } finally {
+          await handle.close();
         }
-      } finally {
-        await handle.close();
+      } catch (err) {
+        return { status: "fetch-failed", message: `Couldn't download the archive: ${(err as Error).message}` };
+      }
+      if (oversized) {
+        return {
+          status: "fetch-failed",
+          message: `Archive exceeds the ${MAX_DNTR_BYTES}-byte size limit`,
+        };
       }
 
       let downloadedHash: string;
@@ -3138,7 +3160,7 @@ export class PluginService {
       } catch (err) {
         return { status: "fetch-failed", message: `Couldn't hash the archive: ${(err as Error).message}` };
       }
-      if (downloadedHash === record.archiveHash) {
+      if (downloadedHash === baselineHash) {
         return { status: "up-to-date" };
       }
 
@@ -3151,6 +3173,16 @@ export class PluginService {
         return {
           status: "fetch-failed",
           message: `Downloaded archive isn't a valid plugin: ${(err as Error).message}`,
+        };
+      }
+      // The URL must still serve the SAME plugin — a redirected or swapped URL
+      // could serve a different archive, and a later reinstall would replace
+      // this plugin's directory with a stranger's. Reject the mismatch rather
+      // than presenting a foreign plugin as an "update".
+      if (manifest.name !== pluginId) {
+        return {
+          status: "fetch-failed",
+          message: `Downloaded archive is for a different plugin ("${manifest.name}")`,
         };
       }
       return {

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -46,7 +46,12 @@ import {
   PluginToastOptionsSchema,
   SCOPED_PLUGIN_NAME_PATTERN,
 } from "../schemas/plugin.js";
-import { extractPluginArchive, computeArchiveHash } from "./PluginArchive.js";
+import {
+  extractPluginArchive,
+  computeArchiveHash,
+  readArchiveManifest,
+  MAX_DNTR_BYTES,
+} from "./PluginArchive.js";
 import { resilientRename } from "../utils/fs.js";
 import { getPluginMcpSupervisor } from "./PluginMcpSupervisor.js";
 import { z } from "zod";
@@ -69,6 +74,7 @@ import type {
   PluginInstallErrorCode,
   PluginInstallResult,
   PluginInstallOptions,
+  PluginCheckUpdateResult,
   PluginSettingsScope,
   ViewContribution,
 } from "../../shared/types/plugin.js";
@@ -292,6 +298,9 @@ interface PendingPluginDispatch {
  * activation), since `allSettled` waits for every promise to settle.
  */
 const IMPORT_TIMEOUT_MS = 5000;
+
+/** Timeout for the manual update-check download (#9297). */
+const FETCH_TIMEOUT_MS = 30_000;
 
 /**
  * Normalise the value thrown out of `activate()` into a serialisable record.
@@ -2905,13 +2914,20 @@ export class PluginService {
       // cleanup doesn't delete the freshly installed plugin.
       tmpDir = null;
 
-      // 5. Persist provenance and load the new plugin.
+      // 5. Persist provenance and load the new plugin. On an upgrade over an
+      // existing install (the swap path) preserve the original `installedAt`
+      // and record `updatedAt` instead — `upsertInstalledRecord` spreads over
+      // the prior record, so omitting `installedAt` from the patch keeps it.
+      // Clear any prior update signal: the user just reinstalled, so whatever
+      // `updateAvailable` flagged is now resolved (#9297).
       this.upsertInstalledRecord(pluginId, {
         source: opts?.source ?? "sideload",
-        installedAt: Date.now(),
         originalUrl: opts?.originalUrl ?? null,
         archiveHash: hash,
         loadError: null,
+        ...(existing
+          ? { updatedAt: Date.now(), updateAvailable: null }
+          : { installedAt: Date.now() }),
       });
 
       // A plugin disabled in Preferences installs to disk but is intentionally
@@ -3035,6 +3051,122 @@ export class PluginService {
       });
     }
     return null;
+  }
+
+  /**
+   * Manual update check (#9297). Re-fetches the plugin's `originalUrl`, hashes
+   * the downloaded archive, and compares it against the installed `archiveHash`.
+   * Purely informational — it never installs. The user's follow-up is a manual
+   * reinstall (via `installFromUrl`), which preserves settings and `installedAt`.
+   *
+   * Domain failures (no record, no URL, network/content-type/size faults, a
+   * malformed archive) are returned as data — never thrown — so the structured
+   * result survives the structured-clone IPC boundary (#3769). The download is
+   * lock-free: it writes to a private temp dir and reads the hash/manifest, so
+   * it doesn't contend with the install lock.
+   */
+  async checkForUpdate(pluginId: string): Promise<PluginCheckUpdateResult> {
+    if (typeof pluginId !== "string" || pluginId.trim().length === 0) {
+      return { status: "invalid-id" };
+    }
+    const record = this.getInstalledRecord(pluginId);
+    // No record, or a sideload/builtin with no original URL — the UI gates the
+    // button on `originalUrl !== null`, so the no-URL case is unreachable in
+    // practice; treat it as `invalid-id` defensively.
+    if (!record || !record.originalUrl) {
+      return { status: "invalid-id" };
+    }
+    const url = record.originalUrl;
+
+    // `net` requires a full Electron runtime; lazy-import it so the service
+    // module stays importable in unit tests that don't fetch.
+    const { net } = await import("electron");
+
+    let tmpRoot: string | null = null;
+    try {
+      tmpRoot = await fs.mkdtemp(path.join(this.pluginsRoot, ".update-check-"));
+      const tmpArchive = path.join(tmpRoot, "plugin.dntr");
+
+      let response: Awaited<ReturnType<typeof net.fetch>>;
+      try {
+        response = await net.fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+      } catch (err) {
+        return { status: "fetch-failed", message: `Couldn't reach ${url}: ${(err as Error).message}` };
+      }
+      if (!response.ok) {
+        return { status: "fetch-failed", message: `Server responded with HTTP ${response.status}` };
+      }
+
+      // Content-type guard — match the install flow's accepted archive types.
+      const contentType = (response.headers.get("content-type") ?? "").split(";")[0].trim().toLowerCase();
+      const ALLOWED_CONTENT_TYPES = ["application/octet-stream", "application/zip", "application/x-zip"];
+      if (contentType && !ALLOWED_CONTENT_TYPES.includes(contentType)) {
+        return { status: "fetch-failed", message: `Unexpected content type "${contentType}"` };
+      }
+
+      // Stream to disk with a running byte counter so an oversized body is
+      // aborted before the whole 30 MB is written (defense in depth ahead of
+      // `computeArchiveHash`'s stat-based cap).
+      const body = response.body;
+      if (!body) {
+        return { status: "fetch-failed", message: "Response had no body" };
+      }
+      const handle = await fs.open(tmpArchive, "w");
+      try {
+        const reader = body.getReader();
+        let bytes = 0;
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done || !value) break;
+          bytes += value.byteLength;
+          if (bytes > MAX_DNTR_BYTES) {
+            await reader.cancel().catch(() => {});
+            return {
+              status: "fetch-failed",
+              message: `Archive exceeds the ${MAX_DNTR_BYTES}-byte size limit`,
+            };
+          }
+          await handle.write(value);
+        }
+      } finally {
+        await handle.close();
+      }
+
+      let downloadedHash: string;
+      try {
+        downloadedHash = await computeArchiveHash(tmpArchive);
+      } catch (err) {
+        return { status: "fetch-failed", message: `Couldn't hash the archive: ${(err as Error).message}` };
+      }
+      if (downloadedHash === record.archiveHash) {
+        return { status: "up-to-date" };
+      }
+
+      // Hashes differ — surface the new manifest's preview so the confirm dialog
+      // can show what the reinstall would bring in.
+      let manifest: PluginManifest;
+      try {
+        manifest = await readArchiveManifest(tmpArchive);
+      } catch (err) {
+        return {
+          status: "fetch-failed",
+          message: `Downloaded archive isn't a valid plugin: ${(err as Error).message}`,
+        };
+      }
+      return {
+        status: "available",
+        name: manifest.name,
+        version: manifest.version,
+        displayName: manifest.displayName,
+        capabilities: manifest.capabilities ?? [],
+      };
+    } finally {
+      if (tmpRoot) {
+        await fs.rm(tmpRoot, { recursive: true, force: true }).catch((err) => {
+          console.warn(`[PluginService] Failed to clean up update-check temp dir ${tmpRoot}:`, err);
+        });
+      }
+    }
   }
 
   unloadPlugin(pluginId: string): void {
@@ -3268,6 +3400,7 @@ export class PluginService {
         isBuiltin: false,
         source: record?.source ?? "sideload",
         installedAt: record?.installedAt ?? 0,
+        updatedAt: record?.updatedAt,
         archiveHash: record?.archiveHash ?? null,
         originalUrl: record?.originalUrl ?? null,
         loadError: record?.loadError ?? null,

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -3098,7 +3098,10 @@ export class PluginService {
       try {
         response = await net.fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
       } catch (err) {
-        return { status: "fetch-failed", message: `Couldn't reach ${url}: ${(err as Error).message}` };
+        return {
+          status: "fetch-failed",
+          message: `Couldn't reach ${url}: ${(err as Error).message}`,
+        };
       }
       if (!response.ok) {
         await response.body?.cancel().catch(() => {});
@@ -3106,8 +3109,15 @@ export class PluginService {
       }
 
       // Content-type guard — match the install flow's accepted archive types.
-      const contentType = (response.headers.get("content-type") ?? "").split(";")[0].trim().toLowerCase();
-      const ALLOWED_CONTENT_TYPES = ["application/octet-stream", "application/zip", "application/x-zip"];
+      const contentType = (response.headers.get("content-type") ?? "")
+        .split(";")[0]
+        .trim()
+        .toLowerCase();
+      const ALLOWED_CONTENT_TYPES = [
+        "application/octet-stream",
+        "application/zip",
+        "application/x-zip",
+      ];
       if (contentType && !ALLOWED_CONTENT_TYPES.includes(contentType)) {
         await response.body?.cancel().catch(() => {});
         return { status: "fetch-failed", message: `Unexpected content type "${contentType}"` };
@@ -3145,7 +3155,10 @@ export class PluginService {
           await handle.close();
         }
       } catch (err) {
-        return { status: "fetch-failed", message: `Couldn't download the archive: ${(err as Error).message}` };
+        return {
+          status: "fetch-failed",
+          message: `Couldn't download the archive: ${(err as Error).message}`,
+        };
       }
       if (oversized) {
         return {
@@ -3158,7 +3171,10 @@ export class PluginService {
       try {
         downloadedHash = await computeArchiveHash(tmpArchive);
       } catch (err) {
-        return { status: "fetch-failed", message: `Couldn't hash the archive: ${(err as Error).message}` };
+        return {
+          status: "fetch-failed",
+          message: `Couldn't hash the archive: ${(err as Error).message}`,
+        };
       }
       if (downloadedHash === baselineHash) {
         return { status: "up-to-date" };

--- a/electron/services/__tests__/PluginService.checkForUpdate.test.ts
+++ b/electron/services/__tests__/PluginService.checkForUpdate.test.ts
@@ -151,8 +151,9 @@ async function installUrlPlugin(
   const archive = await makeArchive(manifest);
   const res = await service.installPlugin(archive, { source: "url", originalUrl: url });
   expect(res.status).toBe("installed");
-  const installed = (storeState.get("plugins") as { installed: Record<string, { archiveHash: string }> })
-    .installed[manifest.name];
+  const installed = (
+    storeState.get("plugins") as { installed: Record<string, { archiveHash: string }> }
+  ).installed[manifest.name];
   return installed.archiveHash;
 }
 
@@ -209,7 +210,9 @@ describe("checkForUpdate — guards", () => {
     const service = new PluginService(pluginsRoot, "0.0.0");
     await installUrlPlugin(service, { name: "acme.nohash", version: "1.0.0" });
     // Corrupt the record so archiveHash is null.
-    const plugins = storeState.get("plugins") as { installed: Record<string, { archiveHash: unknown }> };
+    const plugins = storeState.get("plugins") as {
+      installed: Record<string, { archiveHash: unknown }>;
+    };
     plugins.installed["acme.nohash"].archiveHash = null;
     storeState.set("plugins", plugins);
 

--- a/electron/services/__tests__/PluginService.checkForUpdate.test.ts
+++ b/electron/services/__tests__/PluginService.checkForUpdate.test.ts
@@ -134,6 +134,9 @@ function fakeResponse(
             : Promise.resolve({ done: true, value: undefined }),
         cancel,
       }),
+      // Real ReadableStream exposes cancel() on the stream itself (used by the
+      // early-return cleanup paths before any reader is acquired).
+      cancel: () => Promise.resolve(),
     },
     _cancel: cancel,
   };
@@ -198,6 +201,21 @@ describe("checkForUpdate — guards", () => {
     await service.installPlugin(archive); // sideload — no originalUrl
     const result = await service.checkForUpdate("acme.sideload");
     expect(result).toEqual({ status: "invalid-id" });
+    expect(netMock.fetch).not.toHaveBeenCalled();
+    service.dispose();
+  });
+
+  it("returns fetch-failed (no fetch) when the record has no baseline hash", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+    await installUrlPlugin(service, { name: "acme.nohash", version: "1.0.0" });
+    // Corrupt the record so archiveHash is null.
+    const plugins = storeState.get("plugins") as { installed: Record<string, { archiveHash: unknown }> };
+    plugins.installed["acme.nohash"].archiveHash = null;
+    storeState.set("plugins", plugins);
+
+    const result = await service.checkForUpdate("acme.nohash");
+
+    expect(result.status).toBe("fetch-failed");
     expect(netMock.fetch).not.toHaveBeenCalled();
     service.dispose();
   });
@@ -309,6 +327,48 @@ describe("checkForUpdate — fetch failures", () => {
     expect(result.status).toBe("fetch-failed");
     if (result.status === "fetch-failed") expect(result.message).toContain("size limit");
     expect(response._cancel).toHaveBeenCalled();
+    expect(await leftoverTempDirs()).toHaveLength(0);
+    service.dispose();
+  });
+
+  it("returns fetch-failed when the archive is for a different plugin", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+    await installUrlPlugin(service, { name: "acme.victim", version: "1.0.0" });
+    // A redirected/swapped URL now serves a completely different plugin.
+    const bytes = await readArchiveBytes({ name: "evil.other", version: "9.9.9" });
+    netMock.fetch.mockResolvedValueOnce(fakeResponse([new Uint8Array(bytes)]));
+
+    const result = await service.checkForUpdate("acme.victim");
+
+    expect(result.status).toBe("fetch-failed");
+    if (result.status === "fetch-failed") expect(result.message).toContain("evil.other");
+    expect(await leftoverTempDirs()).toHaveLength(0);
+    service.dispose();
+  });
+
+  it("returns fetch-failed (not a thrown rejection) when the body read fails mid-stream", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+    await installUrlPlugin(service, { name: "acme.streamerr", version: "1.0.0" });
+    let read = 0;
+    netMock.fetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: { get: () => "application/octet-stream" },
+      body: {
+        getReader: () => ({
+          read: () =>
+            read++ === 0
+              ? Promise.resolve({ done: false, value: new Uint8Array([1, 2, 3]) })
+              : Promise.reject(new Error("stream aborted")),
+          cancel: () => Promise.resolve(),
+        }),
+      },
+    });
+
+    const result = await service.checkForUpdate("acme.streamerr");
+
+    expect(result.status).toBe("fetch-failed");
+    if (result.status === "fetch-failed") expect(result.message).toContain("stream aborted");
     expect(await leftoverTempDirs()).toHaveLength(0);
     service.dispose();
   });

--- a/electron/services/__tests__/PluginService.checkForUpdate.test.ts
+++ b/electron/services/__tests__/PluginService.checkForUpdate.test.ts
@@ -1,0 +1,331 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+
+/**
+ * Unit test for the manual update check (#9297).
+ *
+ * `PluginService.checkForUpdate` re-fetches the plugin's `originalUrl`, streams
+ * the archive to a temp file (capped at `MAX_DNTR_BYTES`), hashes it, and
+ * compares against the installed `archiveHash`. It returns a structured result
+ * for every domain outcome and never throws. `net.fetch` is the only mocked
+ * collaborator; the real pack/hash/manifest-read logic runs unmocked.
+ *
+ * Mocks mirror `PluginService.install.test.ts`, plus `net` on the electron mock
+ * (the service lazy-imports it via `await import("electron")`).
+ */
+
+const appMock = vi.hoisted(() => ({
+  getVersion: vi.fn(() => "0.0.0"),
+  getPath: vi.fn(() => "/tmp/daintree-update-test-userdata"),
+}));
+const netMock = vi.hoisted(() => ({ fetch: vi.fn() }));
+const storeMock = vi.hoisted(() => {
+  const state = new Map<string, unknown>();
+  return {
+    get: vi.fn((key: string) => state.get(key)),
+    set: vi.fn((key: string, value: unknown) => state.set(key, value)),
+    _state: state,
+  };
+});
+
+vi.mock("electron", () => ({
+  app: appMock,
+  net: netMock,
+  ipcMain: { on: vi.fn(), removeListener: vi.fn() },
+}));
+vi.mock("../../window/windowRef.js", () => ({
+  getWindowRegistry: vi.fn(() => null),
+  getProjectViewManager: vi.fn(() => null),
+  setWindowRegistry: vi.fn(),
+  setMainWindow: vi.fn(),
+  getMainWindow: vi.fn(() => null),
+  setProjectViewManager: vi.fn(),
+}));
+vi.mock("../../ipc/utils.js", () => ({ broadcastToRenderer: vi.fn() }));
+vi.mock("../../store.js", () => ({ store: storeMock }));
+vi.mock("../ProjectStore.js", () => ({ projectStore: { getCurrentProject: vi.fn(() => null) } }));
+vi.mock("../../../shared/config/panelKindRegistry.js", () => ({
+  registerPanelKind: vi.fn(),
+  unregisterPluginPanelKinds: vi.fn(),
+  onPanelKindRegistered: vi.fn(() => () => {}),
+  onPanelKindUnregistered: vi.fn(() => () => {}),
+  getPluginPanelKinds: vi.fn(() => []),
+}));
+vi.mock("../../../shared/config/toolbarButtonRegistry.js", () => ({
+  registerToolbarButton: vi.fn(),
+  unregisterPluginToolbarButtons: vi.fn(),
+  getAllPluginToolbarButtonConfigs: vi.fn(() => []),
+}));
+vi.mock("../pluginMenuRegistry.js", () => ({
+  registerPluginMenuItem: vi.fn(),
+  unregisterPluginMenuItems: vi.fn(),
+  getPluginMenuItems: vi.fn(() => []),
+}));
+vi.mock("../forgeProviderRegistry.js", () => ({
+  registerForgeProviders: vi.fn(),
+  unregisterForgeProviders: vi.fn(),
+  registerForgeProviderImpl: vi.fn(),
+  unregisterForgeProviderImpl: vi.fn(),
+  unregisterForgeProviderImpls: vi.fn(),
+  getForgeProviderImpl: vi.fn(),
+  clearForgeProviderImplRegistry: vi.fn(),
+}));
+vi.mock("../fileDecorationRegistry.js", () => ({
+  registerFileDecorationProviders: vi.fn(),
+  registerFileDecorationProviderImpl: vi.fn(),
+  unregisterFileDecorationProviders: vi.fn(),
+  unregisterFileDecorationProviderImpls: vi.fn(),
+  unregisterFileDecorationProviderImpl: vi.fn(),
+  scopeMatchesPattern: vi.fn((s: string, p: string) => s === p),
+}));
+vi.mock("../PluginMcpSupervisor.js", () => ({
+  getPluginMcpSupervisor: () => ({
+    start: vi.fn(async () => undefined),
+    shutdown: vi.fn(async () => undefined),
+    shutdownAll: vi.fn(async () => undefined),
+    callTool: vi.fn(),
+    restart: vi.fn(),
+    list: vi.fn(() => []),
+    getStderr: vi.fn(() => ({ pluginId: "", serverId: "", lines: [], totalLines: 0 })),
+  }),
+}));
+
+import { PluginService } from "../PluginService.js";
+import { packPluginArchive, MAX_DNTR_BYTES } from "../PluginArchive.js";
+
+const storeState = storeMock._state;
+
+let tmpDir: string;
+let pluginsRoot: string;
+
+interface ManifestShape {
+  name: string;
+  version: string;
+  [key: string]: unknown;
+}
+
+async function makeArchive(manifest: ManifestShape): Promise<string> {
+  const src = await fs.mkdtemp(path.join(tmpDir, "src-"));
+  await fs.writeFile(path.join(src, "plugin.json"), JSON.stringify(manifest));
+  const out = path.join(tmpDir, `${manifest.name}-${manifest.version}.dntr`);
+  await packPluginArchive(src, out);
+  return out;
+}
+
+/** Minimal `Response`-like object that streams `chunks` from `body.getReader()`. */
+function fakeResponse(
+  chunks: Uint8Array[],
+  opts: { ok?: boolean; status?: number; contentType?: string | null } = {}
+) {
+  const { ok = true, status = 200, contentType = "application/octet-stream" } = opts;
+  let i = 0;
+  const cancel = vi.fn(() => Promise.resolve());
+  return {
+    ok,
+    status,
+    headers: { get: (k: string) => (k.toLowerCase() === "content-type" ? contentType : null) },
+    body: {
+      getReader: () => ({
+        read: () =>
+          i < chunks.length
+            ? Promise.resolve({ done: false, value: chunks[i++] })
+            : Promise.resolve({ done: true, value: undefined }),
+        cancel,
+      }),
+    },
+    _cancel: cancel,
+  };
+}
+
+/** Install a URL-sourced plugin and return its recorded archive hash. */
+async function installUrlPlugin(
+  service: PluginService,
+  manifest: ManifestShape,
+  url = "https://example.com/plugin.dntr"
+): Promise<string> {
+  const archive = await makeArchive(manifest);
+  const res = await service.installPlugin(archive, { source: "url", originalUrl: url });
+  expect(res.status).toBe("installed");
+  const installed = (storeState.get("plugins") as { installed: Record<string, { archiveHash: string }> })
+    .installed[manifest.name];
+  return installed.archiveHash;
+}
+
+async function readArchiveBytes(manifest: ManifestShape): Promise<Buffer> {
+  const archive = await makeArchive(manifest);
+  return fs.readFile(archive);
+}
+
+async function leftoverTempDirs(): Promise<string[]> {
+  const entries = await fs.readdir(pluginsRoot);
+  return entries.filter((e) => e.startsWith(".update-check-"));
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-update-test-"));
+  pluginsRoot = path.join(tmpDir, "plugins");
+});
+
+afterEach(async () => {
+  try {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  } finally {
+    storeState.clear();
+    vi.clearAllMocks();
+  }
+});
+
+describe("checkForUpdate — guards", () => {
+  it("returns invalid-id for an unknown plugin and never fetches", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+    const result = await service.checkForUpdate("acme.nope");
+    expect(result).toEqual({ status: "invalid-id" });
+    expect(netMock.fetch).not.toHaveBeenCalled();
+    service.dispose();
+  });
+
+  it("returns invalid-id for an empty pluginId", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+    expect(await service.checkForUpdate("")).toEqual({ status: "invalid-id" });
+    service.dispose();
+  });
+
+  it("returns invalid-id for a plugin without an originalUrl", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+    const archive = await makeArchive({ name: "acme.sideload", version: "1.0.0" });
+    await service.installPlugin(archive); // sideload — no originalUrl
+    const result = await service.checkForUpdate("acme.sideload");
+    expect(result).toEqual({ status: "invalid-id" });
+    expect(netMock.fetch).not.toHaveBeenCalled();
+    service.dispose();
+  });
+});
+
+describe("checkForUpdate — hash comparison", () => {
+  it("returns up-to-date when the re-fetched archive hashes identically", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+    const manifest = { name: "acme.same", version: "1.0.0" };
+    await installUrlPlugin(service, manifest);
+    const bytes = await readArchiveBytes(manifest);
+    netMock.fetch.mockResolvedValueOnce(fakeResponse([new Uint8Array(bytes)]));
+
+    const result = await service.checkForUpdate("acme.same");
+
+    expect(result).toEqual({ status: "up-to-date" });
+    expect(await leftoverTempDirs()).toHaveLength(0);
+    service.dispose();
+  });
+
+  it("returns available with the new manifest preview when hashes differ", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+    await installUrlPlugin(service, { name: "acme.diff", version: "1.0.0" });
+    const newManifest = {
+      name: "acme.diff",
+      version: "2.0.0",
+      displayName: "Acme Diff Pro",
+      capabilities: ["network:fetch", "git:read"],
+    };
+    const bytes = await readArchiveBytes(newManifest);
+    netMock.fetch.mockResolvedValueOnce(fakeResponse([new Uint8Array(bytes)]));
+
+    const result = await service.checkForUpdate("acme.diff");
+
+    expect(result).toEqual({
+      status: "available",
+      name: "acme.diff",
+      version: "2.0.0",
+      displayName: "Acme Diff Pro",
+      capabilities: ["network:fetch", "git:read"],
+    });
+    expect(await leftoverTempDirs()).toHaveLength(0);
+    service.dispose();
+  });
+
+  it("defaults capabilities to an empty array when the new manifest declares none", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+    await installUrlPlugin(service, { name: "acme.nocaps", version: "1.0.0" });
+    const bytes = await readArchiveBytes({ name: "acme.nocaps", version: "2.0.0" });
+    netMock.fetch.mockResolvedValueOnce(fakeResponse([new Uint8Array(bytes)]));
+
+    const result = await service.checkForUpdate("acme.nocaps");
+
+    expect(result).toMatchObject({ status: "available", version: "2.0.0", capabilities: [] });
+    service.dispose();
+  });
+});
+
+describe("checkForUpdate — fetch failures", () => {
+  it("returns fetch-failed when the network request rejects", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+    await installUrlPlugin(service, { name: "acme.neterr", version: "1.0.0" });
+    netMock.fetch.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    const result = await service.checkForUpdate("acme.neterr");
+
+    expect(result.status).toBe("fetch-failed");
+    if (result.status === "fetch-failed") expect(result.message).toContain("ECONNREFUSED");
+    expect(await leftoverTempDirs()).toHaveLength(0);
+    service.dispose();
+  });
+
+  it("returns fetch-failed on a non-2xx response", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+    await installUrlPlugin(service, { name: "acme.404", version: "1.0.0" });
+    netMock.fetch.mockResolvedValueOnce(fakeResponse([], { ok: false, status: 404 }));
+
+    const result = await service.checkForUpdate("acme.404");
+
+    expect(result.status).toBe("fetch-failed");
+    if (result.status === "fetch-failed") expect(result.message).toContain("404");
+    service.dispose();
+  });
+
+  it("returns fetch-failed for an unexpected content type", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+    await installUrlPlugin(service, { name: "acme.html", version: "1.0.0" });
+    netMock.fetch.mockResolvedValueOnce(
+      fakeResponse([new Uint8Array([1, 2, 3])], { contentType: "text/html" })
+    );
+
+    const result = await service.checkForUpdate("acme.html");
+
+    expect(result.status).toBe("fetch-failed");
+    if (result.status === "fetch-failed") expect(result.message).toContain("text/html");
+    service.dispose();
+  });
+
+  it("aborts and returns fetch-failed when the body exceeds the size cap", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+    await installUrlPlugin(service, { name: "acme.huge", version: "1.0.0" });
+    // First chunk fills the cap exactly (written, not yet over); the 1-byte
+    // second chunk pushes it over, triggering the abort.
+    const response = fakeResponse([new Uint8Array(MAX_DNTR_BYTES), new Uint8Array([0])]);
+    netMock.fetch.mockResolvedValueOnce(response);
+
+    const result = await service.checkForUpdate("acme.huge");
+
+    expect(result.status).toBe("fetch-failed");
+    if (result.status === "fetch-failed") expect(result.message).toContain("size limit");
+    expect(response._cancel).toHaveBeenCalled();
+    expect(await leftoverTempDirs()).toHaveLength(0);
+    service.dispose();
+  });
+
+  it("returns fetch-failed when the downloaded bytes aren't a valid archive", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+    await installUrlPlugin(service, { name: "acme.garbage", version: "1.0.0" });
+    // Hashes differ from the installed archive, so it proceeds to manifest read,
+    // which fails on non-zip bytes.
+    netMock.fetch.mockResolvedValueOnce(
+      fakeResponse([new Uint8Array(Buffer.from("not a zip archive"))])
+    );
+
+    const result = await service.checkForUpdate("acme.garbage");
+
+    expect(result.status).toBe("fetch-failed");
+    expect(await leftoverTempDirs()).toHaveLength(0);
+    service.dispose();
+  });
+});

--- a/electron/services/__tests__/PluginService.install.test.ts
+++ b/electron/services/__tests__/PluginService.install.test.ts
@@ -323,6 +323,55 @@ describe("installPlugin — upgrade swap", () => {
     service.dispose();
   });
 
+  it("preserves installedAt and records updatedAt on an upgrade", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+
+    const v1 = await makeArchive({ name: "acme.stamp", version: "1.0.0" });
+    expect((await service.installPlugin(v1)).status).toBe("installed");
+    const firstInfo = service.listPlugins().find((p) => p.manifest.name === "acme.stamp");
+    expect(firstInfo).toBeDefined();
+    const originalInstalledAt = firstInfo!.installedAt;
+    expect(originalInstalledAt).toBeGreaterThan(0);
+    // First install records no upgrade timestamp.
+    expect(firstInfo!.updatedAt).toBeUndefined();
+
+    const before = Date.now();
+    const v2 = await makeArchive({ name: "acme.stamp", version: "2.0.0" });
+    expect((await service.installPlugin(v2)).status).toBe("installed");
+
+    const secondInfo = service.listPlugins().find((p) => p.manifest.name === "acme.stamp");
+    expect(secondInfo).toBeDefined();
+    // installedAt is preserved from the first install; updatedAt is newly set.
+    expect(secondInfo!.installedAt).toBe(originalInstalledAt);
+    expect(secondInfo!.updatedAt).toBeGreaterThanOrEqual(before);
+
+    service.dispose();
+  });
+
+  it("clears a prior updateAvailable flag on a successful upgrade", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+
+    const v1 = await makeArchive({ name: "acme.clearflag", version: "1.0.0" });
+    expect((await service.installPlugin(v1)).status).toBe("installed");
+
+    // Simulate an update-check having flagged an available update.
+    const records = storeMock.get("plugins") as { installed?: Record<string, unknown> } | undefined;
+    const installed = (records?.installed ?? {}) as Record<string, Record<string, unknown>>;
+    installed["acme.clearflag"] = {
+      ...installed["acme.clearflag"],
+      updateAvailable: { version: "2.0.0", channel: "manual" },
+    };
+    storeMock.set("plugins", { ...records, installed });
+
+    const v2 = await makeArchive({ name: "acme.clearflag", version: "2.0.0" });
+    expect((await service.installPlugin(v2)).status).toBe("installed");
+
+    const info = service.listPlugins().find((p) => p.manifest.name === "acme.clearflag");
+    expect(info?.updateAvailable).toBeNull();
+
+    service.dispose();
+  });
+
   it("restores the old plugin's runtime state when the swap rolls back", async () => {
     const service = new PluginService(pluginsRoot, "0.0.0");
 

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -291,16 +291,37 @@ export interface SettingsApi {
 export type PluginInstallSource = "builtin" | "sideload" | "url" | "catalog";
 
 /**
- * Outcome of a manual update check (`plugin:check-for-update`). Update support
- * (manual reinstall preserving settings — never auto) is owned by F25 and
- * hasn't landed, so the handler resolves `{ status: "not-implemented" }` and
- * the UI keeps the per-row button disabled.
+ * Discriminant for {@link PluginCheckUpdateResult}. A manual update check
+ * (`plugin:check-for-update`) re-fetches the plugin's `originalUrl`, hashes the
+ * archive, and compares it against the installed `archiveHash` — the check is
+ * purely informational and never installs. Manual reinstall (preserving
+ * settings, never auto) is the user's follow-up action.
+ *
+ * - `up-to-date` — the re-fetched archive hashes identically to the installed one
+ * - `available` — the hashes differ; the result carries the new manifest preview
+ * - `invalid-id` — no installed record, or the record has no `originalUrl`
+ *   (sideload/builtin); the UI gate makes the no-URL case unreachable in practice
+ * - `fetch-failed` — network error, non-2xx response, bad content-type, or an
+ *   archive that exceeds the size cap / fails to parse; carries a `message`
  */
-export type PluginUpdateCheckStatus = "available" | "up-to-date" | "invalid-id" | "not-implemented";
+export type PluginUpdateCheckStatus = "available" | "up-to-date" | "invalid-id" | "fetch-failed";
 
-export interface PluginCheckUpdateResult {
-  status: PluginUpdateCheckStatus;
-}
+/**
+ * Outcome of a manual update check. Returned as plain data (never thrown) so the
+ * structured result survives Electron's structured-clone IPC boundary (#3769) —
+ * domain failures (`fetch-failed`) come back as data, not as a rejected promise.
+ */
+export type PluginCheckUpdateResult =
+  | { status: "up-to-date" }
+  | {
+      status: "available";
+      name: string;
+      version: string;
+      displayName?: string;
+      capabilities: PluginCapability[];
+    }
+  | { status: "invalid-id" }
+  | { status: "fetch-failed"; message: string };
 
 export interface PluginLoadError {
   message: string;
@@ -321,6 +342,13 @@ export interface PluginUpdateAvailable {
 export interface InstalledPluginRecord {
   source: PluginInstallSource;
   installedAt: number;
+  /**
+   * When the plugin was last reinstalled over an existing install (the #9292
+   * swap path). Absent on first install — `installedAt` alone marks an untouched
+   * install. Preserved separately from `installedAt` so a manual update keeps
+   * the original install date while recording the upgrade.
+   */
+  updatedAt?: number;
   archiveHash: string | null;
   originalUrl: string | null;
   disabled: boolean;
@@ -413,6 +441,11 @@ export interface LoadedPluginInfo {
   source: PluginInstallSource;
   /** When the plugin was first installed (record created). `0` for builtins. */
   installedAt: number;
+  /**
+   * When the plugin was last reinstalled over an existing install. `undefined`
+   * for builtins and for plugins that have never been upgraded.
+   */
+  updatedAt?: number;
   /** SHA-256 of the `.dntr` archive at install time. `null` for builtins and dev-mode dir loads. */
   archiveHash: string | null;
   /** Original install URL. `null` for builtins and sideloads. Never logged to console. */

--- a/src/components/Settings/PluginsTab.tsx
+++ b/src/components/Settings/PluginsTab.tsx
@@ -315,6 +315,9 @@ export function PluginsTab() {
   useEffect(() => {
     return window.electron.plugin.onProvenanceChanged(() => {
       setRefreshKey((k) => k + 1);
+      // A plugin may have been uninstalled in another window — close any open
+      // reinstall confirm so it can't fire `installFromUrl` on a stale record.
+      setPendingUpdate(null);
     });
   }, []);
 

--- a/src/components/Settings/PluginsTab.tsx
+++ b/src/components/Settings/PluginsTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Plug, AlertCircle, FilePlus, Link2, Trash2, RefreshCw, Info } from "lucide-react";
 import { SettingsSwitch } from "@/components/Settings/SettingsSwitch";
 import { Button } from "@/components/ui/button";
@@ -40,8 +40,11 @@ function pluginLabel(plugin: LoadedPluginInfo): string {
 interface PluginRowProps {
   plugin: LoadedPluginInfo;
   toggling: boolean;
+  checkingUpdate: boolean;
+  upToDate: boolean;
   onToggle: () => void;
   onUninstall: () => void;
+  onCheckForUpdate: () => void;
 }
 
 /**
@@ -52,17 +55,27 @@ interface PluginRowProps {
  * Row expansion (capabilities, contributed actions, load-error stack trace) is
  * left as a follow-up slot per the issue.
  */
-function PluginRow({ plugin, toggling, onToggle, onUninstall }: PluginRowProps) {
+function PluginRow({
+  plugin,
+  toggling,
+  checkingUpdate,
+  upToDate,
+  onToggle,
+  onUninstall,
+  onCheckForUpdate,
+}: PluginRowProps) {
   const label = pluginLabel(plugin);
   const enabled = plugin.disabled !== true;
   const restartRequired = plugin.pendingRestart === true;
   const sourceLabel = SOURCE_BADGE_LABELS[plugin.source] ?? plugin.source;
-  // File-installed plugins have no upstream, so check-for-update has nothing to
-  // hit; URL-installed ones do, but the update flow (F25) hasn't landed yet —
-  // either way the button stays disabled with an explanatory tooltip.
+  // URL-installed plugins have an upstream to re-fetch and compare against;
+  // file-installed plugins and built-ins don't, so the button stays disabled
+  // with an explanatory tooltip.
   const canCheckUpdate = plugin.originalUrl !== null;
   const updateTooltip = canCheckUpdate
-    ? "Checking for updates isn't available yet"
+    ? checkingUpdate
+      ? "Checking for a new version…"
+      : "Check for a new version"
     : plugin.isBuiltin
       ? "Built-in plugins update with Daintree"
       : "No update URL — reinstall from a file to update";
@@ -102,7 +115,14 @@ function PluginRow({ plugin, toggling, onToggle, onUninstall }: PluginRowProps) 
             )}
             {!plugin.isBuiltin && plugin.installedAt > 0 && (
               <div className="text-[11px] text-daintree-text/40 mt-1">
-                Installed {formatRelativeTime(plugin.installedAt)}
+                {plugin.updatedAt
+                  ? `Updated ${formatRelativeTime(plugin.updatedAt)}`
+                  : `Installed ${formatRelativeTime(plugin.installedAt)}`}
+              </div>
+            )}
+            {upToDate && (
+              <div className="text-[11px] text-daintree-text/50 mt-1" role="status">
+                Already up to date
               </div>
             )}
           </div>
@@ -115,10 +135,11 @@ function PluginRow({ plugin, toggling, onToggle, onUninstall }: PluginRowProps) 
                 <Button
                   variant="ghost"
                   size="icon-sm"
-                  disabled
+                  onClick={onCheckForUpdate}
+                  disabled={checkingUpdate}
                   aria-label={`Check ${label} for updates`}
                 >
-                  <RefreshCw />
+                  <RefreshCw className={checkingUpdate ? "animate-spin" : undefined} />
                 </Button>
               </TooltipTrigger>
               <TooltipContent side="bottom">{updateTooltip}</TooltipContent>
@@ -202,10 +223,13 @@ function RowSkeleton() {
  * or URL, enable/disable (#9284), uninstall, provenance, and a check-for-update
  * affordance. Section chrome (header + install buttons) paints before the
  * bridge call resolves; the installed list shows `animate-pulse-delayed` row
- * skeletons during the initial pull. The install flows are thin callers — the
- * atomic extract/validate/swap install (F21/F23/F24) and update check (F25)
- * land separately, so those operations currently surface a "not available yet"
- * notice. Uninstall is fully wired (Tier D1 `ConfirmDialog`).
+ * skeletons during the initial pull. The install-from-file/URL flows are thin
+ * callers — the atomic extract/validate/swap install (F21/F23/F24) lands
+ * separately, so those operations currently surface a "not available yet"
+ * notice. The manual update check (#9297) is fully wired: it re-fetches the
+ * plugin's URL, compares archive hashes, and either shows "Already up to date"
+ * or opens a confirm dialog to reinstall. Uninstall is fully wired (Tier D1
+ * `ConfirmDialog`).
  */
 export function PluginsTab() {
   const [plugins, setPlugins] = useState<LoadedPluginInfo[]>([]);
@@ -234,8 +258,31 @@ export function PluginsTab() {
   const [showUrlDialog, setShowUrlDialog] = useState(false);
   const [urlInput, setUrlInput] = useState("");
   const [isInstalling, setIsInstalling] = useState(false);
+  // Update-check state. `checkingUpdate` drives the per-row spinner; the ref is
+  // the synchronous reentrancy guard (state batches, leaving a double-click
+  // window — #4703). `upToDateId` shows the transient "Already up to date" note;
+  // `pendingUpdate` holds the fetched manifest preview for the confirm dialog.
+  const [checkingUpdate, setCheckingUpdate] = useState<Set<string>>(new Set());
+  const checkingUpdateRef = useRef<Set<string>>(new Set());
+  const [upToDateId, setUpToDateId] = useState<string | null>(null);
+  const upToDateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [pendingUpdate, setPendingUpdate] = useState<{
+    plugin: LoadedPluginInfo;
+    result: Extract<
+      Awaited<ReturnType<typeof window.electron.plugin.checkForUpdate>>,
+      { status: "available" }
+    >;
+  } | null>(null);
+  const [isReinstalling, setIsReinstalling] = useState(false);
 
   useSettingsTabValidation("plugins", Boolean(error));
+
+  // Clear the "Already up to date" auto-dismiss timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (upToDateTimerRef.current) clearTimeout(upToDateTimerRef.current);
+    };
+  }, []);
 
   // Single data-loading effect, keyed on `refreshKey`. Mutations re-pull by
   // bumping the counter rather than splitting into a second effect that shares
@@ -383,6 +430,70 @@ export function PluginsTab() {
     }
   };
 
+  const handleCheckForUpdate = async (plugin: LoadedPluginInfo) => {
+    const id = plugin.manifest.name;
+    // Synchronous reentrancy guard — a rapid double-click would otherwise fire
+    // two downloads before the first render flips the spinner (#4703).
+    if (checkingUpdateRef.current.has(id)) return;
+    checkingUpdateRef.current.add(id);
+    setCheckingUpdate((prev) => new Set(prev).add(id));
+    // A fresh check supersedes any lingering "up to date" note for this plugin.
+    if (upToDateId === id) setUpToDateId(null);
+    try {
+      setError(null);
+      const result = await window.electron.plugin.checkForUpdate(id);
+      switch (result.status) {
+        case "up-to-date":
+          if (upToDateTimerRef.current) clearTimeout(upToDateTimerRef.current);
+          setUpToDateId(id);
+          upToDateTimerRef.current = setTimeout(() => setUpToDateId(null), 4000);
+          break;
+        case "available":
+          setPendingUpdate({ plugin, result });
+          break;
+        case "fetch-failed":
+          setError(`Couldn't check for an update: ${result.message}`);
+          break;
+        case "invalid-id":
+          // The button is gated on `originalUrl !== null`, so this is a bug, not
+          // a user-facing state — log it without a toast.
+          logError("Update check returned invalid-id", new Error(id));
+          break;
+      }
+    } catch (err) {
+      setError(formatErrorMessage(err, "Failed to check for update"));
+      logError("Failed to check plugin for update", err);
+    } finally {
+      checkingUpdateRef.current.delete(id);
+      setCheckingUpdate((prev) => {
+        const copy = new Set(prev);
+        copy.delete(id);
+        return copy;
+      });
+    }
+  };
+
+  const confirmReinstall = async () => {
+    if (!pendingUpdate) return;
+    const url = pendingUpdate.plugin.originalUrl;
+    if (!url) {
+      setPendingUpdate(null);
+      return;
+    }
+    setIsReinstalling(true);
+    try {
+      setError(null);
+      const result = await window.electron.plugin.installFromUrl(url);
+      setPendingUpdate(null);
+      handleInstallResult(result);
+    } catch (err) {
+      setError(formatErrorMessage(err, "Failed to reinstall plugin"));
+      logError("Failed to reinstall plugin from URL", err);
+    } finally {
+      setIsReinstalling(false);
+    }
+  };
+
   return (
     <div className="space-y-6">
       <div className="flex items-start justify-between gap-4">
@@ -442,8 +553,11 @@ export function PluginsTab() {
               key={plugin.manifest.name}
               plugin={plugin}
               toggling={pending.has(plugin.manifest.name)}
+              checkingUpdate={checkingUpdate.has(plugin.manifest.name)}
+              upToDate={upToDateId === plugin.manifest.name}
               onToggle={() => void handleToggle(plugin)}
               onUninstall={() => armUninstall(plugin)}
+              onCheckForUpdate={() => void handleCheckForUpdate(plugin)}
             />
           ))}
         </div>
@@ -477,6 +591,41 @@ export function PluginsTab() {
           />
           Also delete stored settings and secrets
         </label>
+      </ConfirmDialog>
+
+      <ConfirmDialog
+        isOpen={pendingUpdate !== null}
+        onClose={isReinstalling ? undefined : () => setPendingUpdate(null)}
+        title={pendingUpdate ? `Update '${pluginLabel(pendingUpdate.plugin)}'?` : ""}
+        description="Downloads the latest archive and reinstalls over the current version. Your settings are kept."
+        confirmLabel="Reinstall plugin"
+        cancelLabel="Cancel"
+        onConfirm={() => void confirmReinstall()}
+        isConfirmLoading={isReinstalling}
+      >
+        {pendingUpdate && (
+          <div className="mt-3 space-y-1.5 text-xs text-daintree-text/70">
+            <div>
+              <span className="text-daintree-text/50">New version</span>{" "}
+              <span className="font-medium text-daintree-text">v{pendingUpdate.result.version}</span>
+              {pendingUpdate.result.displayName &&
+                pendingUpdate.result.displayName !== pluginLabel(pendingUpdate.plugin) && (
+                  <span className="text-daintree-text/50">
+                    {" "}
+                    · now named {pendingUpdate.result.displayName}
+                  </span>
+                )}
+            </div>
+            {pendingUpdate.result.capabilities.length > 0 && (
+              <div>
+                <span className="text-daintree-text/50">Capabilities</span>{" "}
+                <span className="text-daintree-text">
+                  {pendingUpdate.result.capabilities.join(", ")}
+                </span>
+              </div>
+            )}
+          </div>
+        )}
       </ConfirmDialog>
 
       <AppDialog

--- a/src/components/Settings/PluginsTab.tsx
+++ b/src/components/Settings/PluginsTab.tsx
@@ -33,6 +33,8 @@ const SOURCE_BADGE_LABELS: Record<PluginInstallSource, string> = {
   catalog: "Catalog",
 };
 
+const UP_TO_DATE_NOTIFICATION_DURATION_MS = 4000;
+
 function pluginLabel(plugin: LoadedPluginInfo): string {
   return plugin.manifest.displayName ?? plugin.manifest.name;
 }
@@ -449,7 +451,10 @@ export function PluginsTab() {
         case "up-to-date":
           if (upToDateTimerRef.current) clearTimeout(upToDateTimerRef.current);
           setUpToDateId(id);
-          upToDateTimerRef.current = setTimeout(() => setUpToDateId(null), 4000);
+          upToDateTimerRef.current = setTimeout(
+            () => setUpToDateId(null),
+            UP_TO_DATE_NOTIFICATION_DURATION_MS
+          );
           break;
         case "available":
           setPendingUpdate({ plugin, result });
@@ -605,12 +610,15 @@ export function PluginsTab() {
         cancelLabel="Cancel"
         onConfirm={() => void confirmReinstall()}
         isConfirmLoading={isReinstalling}
+        variant="default"
       >
         {pendingUpdate && (
           <div className="mt-3 space-y-1.5 text-xs text-daintree-text/70">
             <div>
               <span className="text-daintree-text/50">New version</span>{" "}
-              <span className="font-medium text-daintree-text">v{pendingUpdate.result.version}</span>
+              <span className="font-medium text-daintree-text">
+                v{pendingUpdate.result.version}
+              </span>
               {pendingUpdate.result.displayName &&
                 pendingUpdate.result.displayName !== pluginLabel(pendingUpdate.plugin) && (
                   <span className="text-daintree-text/50">

--- a/src/components/Settings/__tests__/PluginsTab.test.tsx
+++ b/src/components/Settings/__tests__/PluginsTab.test.tsx
@@ -323,7 +323,9 @@ describe("PluginsTab", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Check Acme Demo for updates" }));
 
-    await waitFor(() => expect(window.electron.plugin.checkForUpdate).toHaveBeenCalledWith("acme.demo"));
+    await waitFor(() =>
+      expect(window.electron.plugin.checkForUpdate).toHaveBeenCalledWith("acme.demo")
+    );
     await waitFor(() => expect(screen.getByText("Already up to date")).toBeTruthy());
   });
 

--- a/src/components/Settings/__tests__/PluginsTab.test.tsx
+++ b/src/components/Settings/__tests__/PluginsTab.test.tsx
@@ -352,6 +352,22 @@ describe("PluginsTab", () => {
     );
   });
 
+  it("guards against double-clicks while a check is in flight", async () => {
+    (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([urlPlugin()]);
+    // Never-resolving check keeps the in-flight guard active across both clicks.
+    (window.electron.plugin.checkForUpdate as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise(() => {})
+    );
+    renderTab();
+    await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
+
+    const btn = screen.getByRole("button", { name: "Check Acme Demo for updates" });
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+
+    expect(window.electron.plugin.checkForUpdate).toHaveBeenCalledTimes(1);
+  });
+
   it("shows an error when the update check fails to fetch", async () => {
     (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([urlPlugin()]);
     (window.electron.plugin.checkForUpdate as ReturnType<typeof vi.fn>).mockResolvedValue({

--- a/src/components/Settings/__tests__/PluginsTab.test.tsx
+++ b/src/components/Settings/__tests__/PluginsTab.test.tsx
@@ -68,7 +68,7 @@ beforeEach(() => {
       installFromFile: vi.fn().mockResolvedValue({ status: "not-implemented" }),
       installFromUrl: vi.fn().mockResolvedValue({ status: "not-implemented" }),
       uninstall: vi.fn().mockResolvedValue(undefined),
-      checkForUpdate: vi.fn().mockResolvedValue({ status: "not-implemented" }),
+      checkForUpdate: vi.fn().mockResolvedValue({ status: "up-to-date" }),
       onProvenanceChanged: vi.fn().mockReturnValue(() => {}),
     },
   } as unknown as typeof window.electron;
@@ -289,12 +289,81 @@ describe("PluginsTab", () => {
     );
   });
 
-  it("disables the check-for-update button", async () => {
+  it("disables the check-for-update button for a file-installed plugin", async () => {
     (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([makePlugin()]);
     renderTab();
     await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
     const checkBtn = screen.getByRole("button", { name: "Check Acme Demo for updates" });
     expect(checkBtn.hasAttribute("disabled")).toBe(true);
+  });
+
+  const urlPlugin = (overrides: Partial<LoadedPluginInfo> = {}) =>
+    makePlugin({
+      source: "url",
+      originalUrl: "https://example.com/p.dntr",
+      archiveHash: "abc123",
+      ...overrides,
+    });
+
+  it("enables the check-for-update button for a URL-installed plugin", async () => {
+    (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([urlPlugin()]);
+    renderTab();
+    await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
+    const checkBtn = screen.getByRole("button", { name: "Check Acme Demo for updates" });
+    expect(checkBtn.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("shows 'Already up to date' when the check finds a matching hash", async () => {
+    (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([urlPlugin()]);
+    (window.electron.plugin.checkForUpdate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      status: "up-to-date",
+    });
+    renderTab();
+    await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: "Check Acme Demo for updates" }));
+
+    await waitFor(() => expect(window.electron.plugin.checkForUpdate).toHaveBeenCalledWith("acme.demo"));
+    await waitFor(() => expect(screen.getByText("Already up to date")).toBeTruthy());
+  });
+
+  it("opens a confirm dialog with the new version and reinstalls on confirm", async () => {
+    (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([urlPlugin()]);
+    (window.electron.plugin.checkForUpdate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      status: "available",
+      name: "acme.demo",
+      version: "2.0.0",
+      capabilities: ["network:fetch"],
+    });
+    renderTab();
+    await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: "Check Acme Demo for updates" }));
+
+    await waitFor(() => expect(screen.getByText("Update 'Acme Demo'?")).toBeTruthy());
+    expect(screen.getByText("v2.0.0")).toBeTruthy();
+    expect(screen.getByText("network:fetch")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Reinstall plugin" }));
+    await waitFor(() =>
+      expect(window.electron.plugin.installFromUrl).toHaveBeenCalledWith(
+        "https://example.com/p.dntr"
+      )
+    );
+  });
+
+  it("shows an error when the update check fails to fetch", async () => {
+    (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([urlPlugin()]);
+    (window.electron.plugin.checkForUpdate as ReturnType<typeof vi.fn>).mockResolvedValue({
+      status: "fetch-failed",
+      message: "HTTP 500",
+    });
+    renderTab();
+    await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: "Check Acme Demo for updates" }));
+
+    await waitFor(() => expect(screen.getByText(/HTTP 500/)).toBeTruthy());
   });
 
   it("opens the URL dialog and routes the URL through installFromUrl", async () => {


### PR DESCRIPTION
Two pieces of the plugin update flow landed here.

**Reinstall preserves metadata.** When installing over an existing plugin (the swap path from #9292), `installedAt` is kept from the original record, a new `updatedAt` is written, and any prior `updateAvailable` flag is cleared. Settings files were already untouched by the swap — this just fills in the missing timestamp bookkeeping.

**Check for update is wired.** The button in Settings > Plugins was previously stubbed. `PluginService.checkForUpdate` is a new lock-free method that re-fetches the plugin's `originalUrl` with `AbortSignal.timeout(30_000)`, a content-type guard, and a 30 MB streamed size cap. It hashes the archive and compares against the installed `archiveHash` — returning either up-to-date or a preview with the new name, version, and capabilities. A mismatched manifest name (different plugin) and records with no baseline hash are rejected with structured results rather than throws.

The UI enables the button for URL-installed plugins only. Up-to-date returns a transient "Already up to date" note; a detected update opens a Tier-D1 confirm dialog showing the new version and capabilities, then reinstalls via `installFromUrl`.

`PluginCheckUpdateResult` is now a discriminated union. `updatedAt` is added to `InstalledPluginRecord` and `LoadedPluginInfo`.

Resolves #9297

## Changes

- `PluginService.checkForUpdate` — lock-free re-fetch, hash comparison, structured result union
- `PluginService.install` — preserve `installedAt`, write `updatedAt`, clear `updateAvailable` on swap
- `PluginsTab` — enable check button for URL plugins, transient up-to-date note, Tier-D1 confirm dialog
- `shared/types/plugin.ts` — `PluginCheckUpdateResult` discriminated union, `updatedAt` field
- 116 tests across `PluginService.install`, `PluginService.checkForUpdate`, `plugin.handlers`, and `PluginsTab`

## Testing

Full unit coverage added. Note: the install-from-URL path (F24) hasn't landed yet, so confirming the reinstall dialog surfaces the existing "not available yet" notice — the check and preview flow is the deliverable here.