### PR TITLE
feat(plugins): render contributes.settings as a generated form

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -824,6 +824,10 @@ export const CHANNELS = {
   PLUGIN_SET_AUDIT_MAX_RECORDS: "plugin:set-audit-max-records",
   PLUGIN_EXPORT_AUDIT_LOG: "plugin:export-audit-log",
   PLUGIN_GET_DIAGNOSTICS_SNAPSHOT: "plugin:get-diagnostics-snapshot",
+  PLUGIN_SETTINGS_GET_VALUES: "plugin:settings-get-values",
+  PLUGIN_SETTINGS_SET_VALUE: "plugin:settings-set-value",
+  PLUGIN_SETTINGS_DELETE_VALUE: "plugin:settings-delete-value",
+  PLUGIN_SETTINGS_REVEAL_SECRET: "plugin:settings-reveal-secret",
   /** Bridge: main process dispatches a plugin-sourced action request to the renderer. */
   PLUGIN_DISPATCH_ACTION_REQUEST: "plugin:dispatch-action-request",
   /** Bridge: renderer returns the plugin-sourced action dispatch result to the main process. */

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -104,7 +104,7 @@ beforeEach(() => {
 describe("registerPluginHandlers", () => {
   it("registers handlers for all plugin channels", () => {
     registerPluginHandlers();
-    expect(mockIpcMainHandle).toHaveBeenCalledTimes(26);
+    expect(mockIpcMainHandle).toHaveBeenCalledTimes(30);
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:list", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:install", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:set-enabled", expect.any(Function));
@@ -159,6 +159,22 @@ describe("registerPluginHandlers", () => {
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:export-audit-log", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith(
       "plugin:get-diagnostics-snapshot",
+      expect.any(Function)
+    );
+    expect(mockIpcMainHandle).toHaveBeenCalledWith(
+      "plugin:settings-get-values",
+      expect.any(Function)
+    );
+    expect(mockIpcMainHandle).toHaveBeenCalledWith(
+      "plugin:settings-set-value",
+      expect.any(Function)
+    );
+    expect(mockIpcMainHandle).toHaveBeenCalledWith(
+      "plugin:settings-delete-value",
+      expect.any(Function)
+    );
+    expect(mockIpcMainHandle).toHaveBeenCalledWith(
+      "plugin:settings-reveal-secret",
       expect.any(Function)
     );
   });

--- a/electron/ipc/handlers/plugin.preload.ts
+++ b/electron/ipc/handlers/plugin.preload.ts
@@ -31,6 +31,10 @@ export const PLUGIN_METHOD_CHANNELS = {
   setAuditMaxRecords: "plugin:set-audit-max-records",
   exportAuditLog: "plugin:export-audit-log",
   getDiagnosticsSnapshot: "plugin:get-diagnostics-snapshot",
+  getSettingValues: "plugin:settings-get-values",
+  setSettingValue: "plugin:settings-set-value",
+  deleteSettingValue: "plugin:settings-delete-value",
+  revealSecretSetting: "plugin:settings-reveal-secret",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof PLUGIN_METHOD_CHANNELS;

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -46,6 +46,8 @@ import type {
   PluginInstallOptions,
   PluginInstallResult,
   PluginCheckUpdateResult,
+  PluginSettingsScope,
+  PluginSettingsUiValues,
 } from "../../../shared/types/plugin.js";
 import type { IpcContext } from "../types.js";
 import type { ToolbarButtonConfig } from "../../../shared/config/toolbarButtonRegistry.js";
@@ -483,6 +485,44 @@ async function handleGetDiagnosticsSnapshot(): Promise<PluginDiagnosticsSnapshot
   return pluginService.getDiagnosticsSnapshot();
 }
 
+// ── Plugin settings UI bridge (#9301) ─────────────────────────────────────
+
+async function handleSettingsGetValues(
+  pluginId: string,
+  scope: PluginSettingsScope,
+  projectId: string | null
+): Promise<PluginSettingsUiValues> {
+  return pluginService.getSettingValuesForUi(pluginId, scope, projectId);
+}
+
+async function handleSettingsSetValue(
+  pluginId: string,
+  key: string,
+  value: unknown,
+  scope: PluginSettingsScope,
+  projectId: string | null
+): Promise<void> {
+  await pluginService.setSettingValueFromUi(pluginId, key, value, scope, projectId);
+}
+
+async function handleSettingsDeleteValue(
+  pluginId: string,
+  key: string,
+  scope: PluginSettingsScope,
+  projectId: string | null
+): Promise<void> {
+  await pluginService.deleteSettingValueFromUi(pluginId, key, scope, projectId);
+}
+
+async function handleSettingsRevealSecret(
+  pluginId: string,
+  key: string,
+  scope: PluginSettingsScope,
+  projectId: string | null
+): Promise<string | null> {
+  return pluginService.revealSecretSettingForUi(pluginId, key, scope, projectId);
+}
+
 export const pluginNamespace = defineIpcNamespace({
   name: "plugin",
   ops: {
@@ -516,6 +556,10 @@ export const pluginNamespace = defineIpcNamespace({
       PLUGIN_METHOD_CHANNELS.getDiagnosticsSnapshot,
       handleGetDiagnosticsSnapshot
     ),
+    getSettingValues: op(PLUGIN_METHOD_CHANNELS.getSettingValues, handleSettingsGetValues),
+    setSettingValue: op(PLUGIN_METHOD_CHANNELS.setSettingValue, handleSettingsSetValue),
+    deleteSettingValue: op(PLUGIN_METHOD_CHANNELS.deleteSettingValue, handleSettingsDeleteValue),
+    revealSecretSetting: op(PLUGIN_METHOD_CHANNELS.revealSecretSetting, handleSettingsRevealSecret),
   },
 });
 

--- a/electron/schemas/__tests__/settingsContribution.test.ts
+++ b/electron/schemas/__tests__/settingsContribution.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { getPluginManifestSchema } from "../plugin.js";
+
+type SettingInput = Record<string, unknown>;
+
+function parseSettings(settings: SettingInput[], isBuiltin = false) {
+  return getPluginManifestSchema(isBuiltin).safeParse({
+    name: "acme.settings-test",
+    version: "1.0.0",
+    contributes: { settings },
+  });
+}
+
+function settingsOf(result: ReturnType<typeof parseSettings>) {
+  if (!result.success) throw new Error("expected manifest to parse");
+  return result.data.contributes.settings ?? [];
+}
+
+describe("contributes.settings schema (#9301)", () => {
+  it("accepts all six field types", () => {
+    const result = parseSettings([
+      { id: "name", type: "string" },
+      { id: "count", type: "number" },
+      { id: "enabled", type: "boolean" },
+      { id: "mode", type: "enum", options: ["a", "b"] },
+      { id: "config", type: "json" },
+      { id: "token", type: "secret" },
+    ]);
+    expect(result.success).toBe(true);
+    expect(settingsOf(result)).toHaveLength(6);
+  });
+
+  it("defaults scope to user when omitted", () => {
+    const result = parseSettings([{ id: "name", type: "string" }]);
+    expect(result.success).toBe(true);
+    expect(settingsOf(result)[0].scope).toBe("user");
+  });
+
+  it("preserves an explicit project scope", () => {
+    const result = parseSettings([{ id: "name", type: "string", scope: "project" }]);
+    expect(settingsOf(result)[0].scope).toBe("project");
+  });
+
+  it("treats an omitted type as valid (renders as text)", () => {
+    const result = parseSettings([{ id: "name" }]);
+    expect(result.success).toBe(true);
+    expect(settingsOf(result)[0].type).toBeUndefined();
+  });
+
+  it("coerces the legacy secret:true flag to type:secret", () => {
+    const result = parseSettings([{ id: "token", secret: true }]);
+    expect(result.success).toBe(true);
+    expect(settingsOf(result)[0].type).toBe("secret");
+  });
+
+  it("rejects an enum without options", () => {
+    const result = parseSettings([{ id: "mode", type: "enum" }]);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an enum with an empty options array", () => {
+    const result = parseSettings([{ id: "mode", type: "enum", options: [] }]);
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts number min/max bounds", () => {
+    const result = parseSettings([{ id: "count", type: "number", min: 0, max: 10 }]);
+    expect(result.success).toBe(true);
+    const def = settingsOf(result)[0];
+    expect(def.min).toBe(0);
+    expect(def.max).toBe(10);
+  });
+
+  it("rejects a number whose min exceeds max", () => {
+    const result = parseSettings([{ id: "count", type: "number", min: 10, max: 0 }]);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an unknown field key (strict)", () => {
+    const result = parseSettings([{ id: "name", type: "string", bogus: true }]);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a setting with no id", () => {
+    const result = parseSettings([{ type: "string" }]);
+    expect(result.success).toBe(false);
+  });
+
+  it("defaults contributes.settings to an empty array when absent", () => {
+    const result = getPluginManifestSchema(false).safeParse({
+      name: "acme.no-settings",
+      version: "1.0.0",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.contributes.settings).toEqual([]);
+  });
+});

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -361,6 +361,52 @@ export const PluginToastOptionsSchema = z
   })
   .strict();
 
+/**
+ * One `contributes.settings` field declaration (#9301). `type` is optional
+ * (renders as a text field when omitted); the legacy `secret: true` flag is
+ * normalized to `type: "secret"` by the transform so downstream consumers only
+ * switch on `type`. A plain object (not `discriminatedUnion`) is used because
+ * `type` is optional on the string/number/boolean branch. Strict so a misspelled
+ * field key surfaces as a manifest error rather than silently dropping.
+ */
+export const SettingDefinitionSchema = z
+  .object({
+    id: z.string().min(1),
+    type: z.enum(["string", "number", "boolean", "enum", "json", "secret"]).optional(),
+    label: z.string().min(1).optional(),
+    description: z.string().min(1).optional(),
+    default: z.unknown().optional(),
+    scope: z.enum(["user", "project"]).default("user"),
+    options: z.array(z.string().min(1)).min(1).optional(),
+    min: z.number().optional(),
+    max: z.number().optional(),
+    secret: z.boolean().optional(),
+  })
+  .strict()
+  .superRefine((val, ctx) => {
+    const effectiveType = val.secret === true ? "secret" : (val.type ?? "string");
+    if (effectiveType === "enum" && (!val.options || val.options.length === 0)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Settings of type "enum" require a non-empty options array',
+        path: ["options"],
+      });
+    }
+    if (val.min !== undefined && val.max !== undefined && val.min > val.max) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Setting min cannot be greater than max",
+        path: ["min"],
+      });
+    }
+  })
+  .transform((val) => {
+    if (val.secret === true && val.type !== "secret") {
+      return { ...val, type: "secret" as const };
+    }
+    return val;
+  });
+
 export function getPluginManifestSchema(isBuiltin: boolean) {
   return z
     .strictObject({
@@ -398,6 +444,7 @@ export function getPluginManifestSchema(isBuiltin: boolean) {
           experimental_mcpServers: z.array(McpServerContributionSchema).default([]),
           forgeProviders: z.array(ForgeProviderContributionSchema).default([]),
           fileDecorationProviders: z.array(FileDecorationContributionSchema).default([]),
+          settings: z.array(SettingDefinitionSchema).default([]),
         })
         .default({
           panels: [],
@@ -410,6 +457,7 @@ export function getPluginManifestSchema(isBuiltin: boolean) {
           experimental_mcpServers: [],
           forgeProviders: [],
           fileDecorationProviders: [],
+          settings: [],
         }),
     })
     .superRefine((manifest, ctx) => {

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -78,6 +78,7 @@ import type {
   PluginSettingsScope,
   PluginSettingsUiValues,
   ViewContribution,
+  SettingDefinition,
 } from "../../shared/types/plugin.js";
 import { PluginSettingsStore } from "./PluginSettingsStore.js";
 import { projectStore } from "./ProjectStore.js";
@@ -3943,55 +3944,94 @@ export class PluginService {
     });
   }
 
+  // ============================================================
+  // Settings UI bridge (#9301)
+  //
+  // Renderer-facing read/write/reveal/clear for the generated settings form.
+  // These reuse the same per-(plugin, scope) store and subscriber path as the
+  // plugin-facing `host.settings` API, so a write from the form fires the
+  // owning plugin's `onDidChange` without it reactivating. Project scope is
+  // resolved from an explicit `projectId` (not the main-process "current
+  // project") so a settings form in one window can't read or write another
+  // window's active-project values.
+  // ============================================================
+
+  private uiSettingDefinitions(pluginId: string): SettingDefinition[] {
+    return this.plugins.get(pluginId)?.manifest.contributes.settings ?? [];
+  }
+
   /**
-   * Fetch all non-secret setting values and the list of secret keys for a
-   * plugin + scope. Used by the plugin settings UI to populate form fields.
-   * Secrets are not returned — only their key names (so the UI can render
-   * masked fields) and a "reveal" affordance.
+   * A setting is secret when it declares the canonical `type: "secret"` OR the
+   * legacy `secret: true` flag. Both must be checked — the manifest schema keeps
+   * the boolean when coercing `secret: true` to `type: "secret"`, but a manifest
+   * authored directly as `{ type: "secret" }` carries no boolean, so a
+   * `secret`-only check would leak its value into {@link getSettingValuesForUi}.
+   */
+  private isSecretSetting(def: SettingDefinition): boolean {
+    return def.type === "secret" || def.secret === true;
+  }
+
+  /**
+   * Resolve the settings file path for a UI call. User scope is fixed; project
+   * scope resolves the explicit `projectId` (returns `null` for an
+   * unknown/absent id, which callers treat as "no project active").
+   *
+   * Invariant: the renderer passes its own `currentProject.id`, the same id
+   * space `projectStore.getProjectById` is keyed on. This is what makes
+   * per-window project scoping correct — a form in one window resolves *its*
+   * project, not the main process's globally-"current" project, which may
+   * belong to a different window.
+   */
+  private resolveUiSettingsFilePath(
+    pluginId: string,
+    scope: PluginSettingsScope,
+    projectId: string | null
+  ): string | null {
+    if (scope === "project") {
+      if (!projectId) return null;
+      const root = projectStore.getProjectById(projectId)?.path;
+      if (!root) return null;
+      return path.join(root, ".daintree", "plugin-settings", `${pluginId}.json`);
+    }
+    return path.join(this.settingsRoot(), `${pluginId}.json`);
+  }
+
+  /**
+   * Read stored values for one plugin + scope, for the settings form. Secret
+   * settings are never returned by value — their ids appear in `secretsSet` when
+   * a value is stored. Only settings whose declared scope matches `scope` are
+   * included, so a stray key in the wrong file can't surface under the other
+   * scope.
    */
   async getSettingValuesForUi(
     pluginId: string,
     scope: PluginSettingsScope,
-    _projectId: string | null
+    projectId: string | null
   ): Promise<PluginSettingsUiValues> {
-    const filePath = this.resolveSettingsFilePath(pluginId, scope);
-    if (!filePath) {
-      return { values: {}, secretsSet: [] };
-    }
-
-    const store = this.getOrCreateSettingsStore(pluginId, scope, filePath);
-    const manifest = this.plugins.get(pluginId)?.manifest;
-    const settings = manifest?.contributes.settings ?? [];
-
     const values: Record<string, unknown> = {};
     const secretsSet: string[] = [];
-
-    for (const setting of settings) {
-      const value = await store.get<unknown>(setting.id);
-      if (value !== undefined) {
-        if (setting.secret) {
-          secretsSet.push(setting.id);
-        } else {
-          values[setting.id] = value;
-        }
-      }
-    }
-
+    const filePath = this.resolveUiSettingsFilePath(pluginId, scope, projectId);
+    if (!filePath) return { values, secretsSet };
+    const store = this.getOrCreateSettingsStore(pluginId, scope, filePath);
+    const defs = this.uiSettingDefinitions(pluginId).filter((d) => (d.scope ?? "user") === scope);
+    await Promise.all(
+      defs.map(async (def) => {
+        const stored = await store.get<unknown>(def.id);
+        if (stored === undefined) return;
+        if (this.isSecretSetting(def)) secretsSet.push(def.id);
+        else values[def.id] = stored;
+      })
+    );
     return { values, secretsSet };
   }
 
-  /**
-   * Persist a single setting value. The UI calls this when the user changes
-   * a form field. Values are JSON-serialized; secret settings are handled
-   * identically to non-secret ones at storage time (the secret classification
-   * is metadata, not an encryption marker).
-   */
+  /** Persist a value from the settings form, firing the plugin's `onDidChange`. */
   async setSettingValueFromUi(
     pluginId: string,
     key: string,
     value: unknown,
     scope: PluginSettingsScope,
-    _projectId: string | null
+    projectId: string | null
   ): Promise<void> {
     assertSettingsKey(pluginId, "set", key);
     if (value === undefined) {
@@ -4000,7 +4040,7 @@ export class PluginService {
       );
     }
     this.assertSettingDeclared(pluginId, key);
-    const filePath = this.resolveSettingsFilePath(pluginId, scope);
+    const filePath = this.resolveUiSettingsFilePath(pluginId, scope, projectId);
     if (!filePath) {
       throw new Error(
         `Plugin "${pluginId}" settings: no active project — "project" scope has no target`
@@ -4012,42 +4052,44 @@ export class PluginService {
   }
 
   /**
-   * Delete a setting value. The UI calls this when the user clears a form
-   * field (for optional settings).
+   * Clear a stored value (the form's "reset to default" — resetting removes the
+   * stored override rather than writing the declared default). Fires
+   * `onDidChange` with `undefined` so the plugin falls back to its default.
    */
   async deleteSettingValueFromUi(
     pluginId: string,
     key: string,
     scope: PluginSettingsScope,
-    _projectId: string | null
+    projectId: string | null
   ): Promise<void> {
     assertSettingsKey(pluginId, "delete", key);
-    const filePath = this.resolveSettingsFilePath(pluginId, scope);
-    if (!filePath) {
-      throw new Error(
-        `Plugin "${pluginId}" settings: no active project — "project" scope has no target`
-      );
-    }
+    this.assertSettingDeclared(pluginId, key);
+    const filePath = this.resolveUiSettingsFilePath(pluginId, scope, projectId);
+    if (!filePath) return;
     const store = this.getOrCreateSettingsStore(pluginId, scope, filePath);
     const changed = await store.delete(key);
     if (changed) this.notifySettingsSubscribers(pluginId, scope, key, undefined);
   }
 
   /**
-   * Decrypt/reveal a secret setting value. Secrets are stored as plaintext
-   * (there's no encryption), so revealing just means returning the stored
-   * value. Returns `null` if the setting is not set. The UI uses this when
-   * the user clicks "reveal" on a masked field.
+   * Fetch a single secret value for in-place reveal. Returns `null` when unset.
+   * Non-string secrets are JSON-stringified so the form can display them.
+   *
+   * Only a declared `secret`-typed setting may be revealed — this is the secret
+   * counterpart to the masking in {@link getSettingValuesForUi}. The guard stops
+   * the channel being used as a generic read-any-key bypass that would let a
+   * caller pull non-secret (or undeclared) values one at a time.
    */
   async revealSecretSettingForUi(
     pluginId: string,
     key: string,
     scope: PluginSettingsScope,
-    _projectId: string | null
+    projectId: string | null
   ): Promise<string | null> {
     assertSettingsKey(pluginId, "get", key);
-    this.assertSettingDeclared(pluginId, key);
-    const filePath = this.resolveSettingsFilePath(pluginId, scope);
+    const def = this.uiSettingDefinitions(pluginId).find((s) => s.id === key);
+    if (!def || !this.isSecretSetting(def)) return null;
+    const filePath = this.resolveUiSettingsFilePath(pluginId, scope, projectId);
     if (!filePath) return null;
     const value = await this.getOrCreateSettingsStore(pluginId, scope, filePath).get<unknown>(key);
     if (value === undefined || value === null) return null;

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -76,6 +76,7 @@ import type {
   PluginInstallOptions,
   PluginCheckUpdateResult,
   PluginSettingsScope,
+  PluginSettingsUiValues,
   ViewContribution,
 } from "../../shared/types/plugin.js";
 import { PluginSettingsStore } from "./PluginSettingsStore.js";
@@ -3940,6 +3941,118 @@ export class PluginService {
       name: "plugin:context-menu-items-changed",
       payload: { items: getPluginContextMenuItems(), complete },
     });
+  }
+
+  /**
+   * Fetch all non-secret setting values and the list of secret keys for a
+   * plugin + scope. Used by the plugin settings UI to populate form fields.
+   * Secrets are not returned — only their key names (so the UI can render
+   * masked fields) and a "reveal" affordance.
+   */
+  async getSettingValuesForUi(
+    pluginId: string,
+    scope: PluginSettingsScope,
+    _projectId: string | null
+  ): Promise<PluginSettingsUiValues> {
+    const filePath = this.resolveSettingsFilePath(pluginId, scope);
+    if (!filePath) {
+      return { values: {}, secretsSet: [] };
+    }
+
+    const store = this.getOrCreateSettingsStore(pluginId, scope, filePath);
+    const manifest = this.plugins.get(pluginId)?.manifest;
+    const settings = manifest?.contributes.settings ?? [];
+
+    const values: Record<string, unknown> = {};
+    const secretsSet: string[] = [];
+
+    for (const setting of settings) {
+      const value = await store.get<unknown>(setting.id);
+      if (value !== undefined) {
+        if (setting.secret) {
+          secretsSet.push(setting.id);
+        } else {
+          values[setting.id] = value;
+        }
+      }
+    }
+
+    return { values, secretsSet };
+  }
+
+  /**
+   * Persist a single setting value. The UI calls this when the user changes
+   * a form field. Values are JSON-serialized; secret settings are handled
+   * identically to non-secret ones at storage time (the secret classification
+   * is metadata, not an encryption marker).
+   */
+  async setSettingValueFromUi(
+    pluginId: string,
+    key: string,
+    value: unknown,
+    scope: PluginSettingsScope,
+    _projectId: string | null
+  ): Promise<void> {
+    assertSettingsKey(pluginId, "set", key);
+    if (value === undefined) {
+      throw new Error(
+        `Plugin "${pluginId}" settings: value for "${key}" is undefined — settings cannot store undefined`
+      );
+    }
+    this.assertSettingDeclared(pluginId, key);
+    const filePath = this.resolveSettingsFilePath(pluginId, scope);
+    if (!filePath) {
+      throw new Error(
+        `Plugin "${pluginId}" settings: no active project — "project" scope has no target`
+      );
+    }
+    const store = this.getOrCreateSettingsStore(pluginId, scope, filePath);
+    const changed = await store.set(key, value);
+    if (changed) this.notifySettingsSubscribers(pluginId, scope, key, value);
+  }
+
+  /**
+   * Delete a setting value. The UI calls this when the user clears a form
+   * field (for optional settings).
+   */
+  async deleteSettingValueFromUi(
+    pluginId: string,
+    key: string,
+    scope: PluginSettingsScope,
+    _projectId: string | null
+  ): Promise<void> {
+    assertSettingsKey(pluginId, "delete", key);
+    const filePath = this.resolveSettingsFilePath(pluginId, scope);
+    if (!filePath) {
+      throw new Error(
+        `Plugin "${pluginId}" settings: no active project — "project" scope has no target`
+      );
+    }
+    const store = this.getOrCreateSettingsStore(pluginId, scope, filePath);
+    const changed = await store.delete(key);
+    if (changed) this.notifySettingsSubscribers(pluginId, scope, key, undefined);
+  }
+
+  /**
+   * Decrypt/reveal a secret setting value. Secrets are stored as plaintext
+   * (there's no encryption), so revealing just means returning the stored
+   * value. Returns `null` if the setting is not set. The UI uses this when
+   * the user clicks "reveal" on a masked field.
+   */
+  async revealSecretSettingForUi(
+    pluginId: string,
+    key: string,
+    scope: PluginSettingsScope,
+    _projectId: string | null
+  ): Promise<string | null> {
+    assertSettingsKey(pluginId, "get", key);
+    this.assertSettingDeclared(pluginId, key);
+    const filePath = this.resolveSettingsFilePath(pluginId, scope);
+    if (!filePath) return null;
+    const value = await this.getOrCreateSettingsStore(pluginId, scope, filePath).get<unknown>(key);
+    if (value === undefined || value === null) return null;
+    if (typeof value === "string") return value;
+    return JSON.stringify(value);
   }
 
   /**

--- a/electron/services/PluginSettingsStore.ts
+++ b/electron/services/PluginSettingsStore.ts
@@ -67,6 +67,36 @@ export class PluginSettingsStore {
     return true;
   }
 
+  /**
+   * Remove `key`. Resolves to `true` when a stored value was actually deleted
+   * (so the caller can fire change subscribers with `undefined`), `false` when
+   * the key was already absent. On write failure the optimistic in-memory delete
+   * is rolled back and the error rethrown. Serialized through the same write
+   * chain as {@link set} so a concurrent set/delete can't interleave.
+   */
+  async delete(key: string): Promise<boolean> {
+    const result = this.writeChain.then(() => this.doDelete(key));
+    this.writeChain = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
+  }
+
+  private async doDelete(key: string): Promise<boolean> {
+    const cache = await this.load();
+    if (!cache.has(key)) return false;
+    const prev = cache.get(key);
+    cache.delete(key);
+    try {
+      await this.persist(cache);
+    } catch (err) {
+      cache.set(key, prev);
+      throw err;
+    }
+    return true;
+  }
+
   private async load(): Promise<Map<string, unknown>> {
     if (this.cache) return this.cache;
     if (!this.loadPromise) {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -37,6 +37,7 @@ const windowRefMock = vi.hoisted(() => ({
 const broadcastToRendererMock = vi.hoisted(() => vi.fn());
 const projectStoreMock = vi.hoisted(() => ({
   getCurrentProject: vi.fn((): { path: string } | null => null),
+  getProjectById: vi.fn((_id: string): { path: string } | null => null),
 }));
 const storeMock = vi.hoisted(() => {
   const state = new Map<string, unknown>();

--- a/electron/services/__tests__/PluginSettingsStore.test.ts
+++ b/electron/services/__tests__/PluginSettingsStore.test.ts
@@ -141,4 +141,54 @@ describe("PluginSettingsStore", () => {
     const raw = await fs.readFile(filePath, "utf-8");
     expect(JSON.parse(raw)).toEqual({ a: 1, b: 2, c: 3, d: 4 });
   });
+
+  describe("delete", () => {
+    it("removes a stored key and reports the change", async () => {
+      const { store, filePath } = storeAt("acme.plugin.json");
+      await store.set("token", "sk-test");
+      expect(await store.delete("token")).toBe(true);
+      expect(await store.get("token")).toBeUndefined();
+      const raw = await fs.readFile(filePath, "utf-8");
+      expect(JSON.parse(raw)).toEqual({});
+    });
+
+    it("returns false when deleting an absent key", async () => {
+      const { store } = storeAt("acme.plugin.json");
+      expect(await store.delete("missing")).toBe(false);
+    });
+
+    it("leaves sibling keys intact", async () => {
+      const { store } = storeAt("acme.plugin.json");
+      await store.set("a", 1);
+      await store.set("b", 2);
+      expect(await store.delete("a")).toBe(true);
+      expect(await store.get("a")).toBeUndefined();
+      expect(await store.get<number>("b")).toBe(2);
+    });
+
+    it("persists the deletion across instances", async () => {
+      const { store, filePath } = storeAt("acme.plugin.json");
+      await store.set("token", "sk-test");
+      await store.delete("token");
+      const reopened = new PluginSettingsStore(filePath);
+      expect(await reopened.get("token")).toBeUndefined();
+    });
+
+    const rollbackDeleteIt =
+      process.platform === "win32" || process.getuid?.() === 0 ? it.skip : it;
+    rollbackDeleteIt("rolls back the in-memory delete when the write fails", async () => {
+      const dir = path.join(tmpDir, "ro-del");
+      await fs.mkdir(dir, { recursive: true });
+      const store = new PluginSettingsStore(path.join(dir, "acme.plugin.json"));
+      await store.set("token", "value");
+      await fs.chmod(dir, 0o555);
+      try {
+        await expect(store.delete("token")).rejects.toBeTruthy();
+        // The optimistic in-memory delete must not survive a failed persist.
+        expect(await store.get<string>("token")).toBe("value");
+      } finally {
+        await fs.chmod(dir, 0o755);
+      }
+    });
+  });
 });

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -350,6 +350,9 @@ export interface GeneratedElectronAPI {
     contextMenuItems(
       ...args: IpcInvokeMap["plugin:context-menu-items"]["args"]
     ): Promise<IpcInvokeMap["plugin:context-menu-items"]["result"]>;
+    deleteSettingValue(
+      ...args: IpcInvokeMap["plugin:settings-delete-value"]["args"]
+    ): Promise<IpcInvokeMap["plugin:settings-delete-value"]["result"]>;
     exportAuditLog(
       ...args: IpcInvokeMap["plugin:export-audit-log"]["args"]
     ): Promise<IpcInvokeMap["plugin:export-audit-log"]["result"]>;
@@ -374,6 +377,9 @@ export interface GeneratedElectronAPI {
     getPanelKinds(
       ...args: IpcInvokeMap["plugin:panel-kinds-get"]["args"]
     ): Promise<IpcInvokeMap["plugin:panel-kinds-get"]["result"]>;
+    getSettingValues(
+      ...args: IpcInvokeMap["plugin:settings-get-values"]["args"]
+    ): Promise<IpcInvokeMap["plugin:settings-get-values"]["result"]>;
     install(
       ...args: IpcInvokeMap["plugin:install"]["args"]
     ): Promise<IpcInvokeMap["plugin:install"]["result"]>;
@@ -395,6 +401,9 @@ export interface GeneratedElectronAPI {
     registerAction(
       ...args: IpcInvokeMap["plugin:actions-register"]["args"]
     ): Promise<IpcInvokeMap["plugin:actions-register"]["result"]>;
+    revealSecretSetting(
+      ...args: IpcInvokeMap["plugin:settings-reveal-secret"]["args"]
+    ): Promise<IpcInvokeMap["plugin:settings-reveal-secret"]["result"]>;
     setAuditEnabled(
       ...args: IpcInvokeMap["plugin:set-audit-enabled"]["args"]
     ): Promise<IpcInvokeMap["plugin:set-audit-enabled"]["result"]>;
@@ -404,6 +413,9 @@ export interface GeneratedElectronAPI {
     setEnabled(
       ...args: IpcInvokeMap["plugin:set-enabled"]["args"]
     ): Promise<IpcInvokeMap["plugin:set-enabled"]["result"]>;
+    setSettingValue(
+      ...args: IpcInvokeMap["plugin:settings-set-value"]["args"]
+    ): Promise<IpcInvokeMap["plugin:settings-set-value"]["result"]>;
     toolbarButtons(
       ...args: IpcInvokeMap["plugin:toolbar-buttons"]["args"]
     ): Promise<IpcInvokeMap["plugin:toolbar-buttons"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -699,6 +699,42 @@ export interface GeneratedIpcInvokeMap {
     args: [pluginId: string, enabled: boolean];
     result: void;
   };
+  "plugin:settings-delete-value": {
+    args: [
+      pluginId: string,
+      key: string,
+      scope: import("../plugin.js").PluginSettingsScope,
+      projectId: string | null,
+    ];
+    result: void;
+  };
+  "plugin:settings-get-values": {
+    args: [
+      pluginId: string,
+      scope: import("../plugin.js").PluginSettingsScope,
+      projectId: string | null,
+    ];
+    result: import("../plugin.js").PluginSettingsUiValues;
+  };
+  "plugin:settings-reveal-secret": {
+    args: [
+      pluginId: string,
+      key: string,
+      scope: import("../plugin.js").PluginSettingsScope,
+      projectId: string | null,
+    ];
+    result: string | null;
+  };
+  "plugin:settings-set-value": {
+    args: [
+      pluginId: string,
+      key: string,
+      value: unknown,
+      scope: import("../plugin.js").PluginSettingsScope,
+      projectId: string | null,
+    ];
+    result: void;
+  };
   "plugin:toolbar-buttons": {
     args: [];
     result: import("../../config/toolbarButtonRegistry.js").ToolbarButtonConfig[];

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -228,26 +228,62 @@ export interface PluginManifest {
 }
 
 /**
- * Declaration for a single plugin setting. Reserved for `contributes.settings`
- * (F29), which owns the canonical schema (types, defaults, UI metadata). The
- * shape here is intentionally permissive — only `id` is load-bearing today, used
- * by {@link SettingsApi.set} key validation.
+ * Field control kind for a {@link SettingDefinition}. Drives which input the
+ * generated settings form renders (#9301):
+ * - `string` → single-line text input (default when `type` is omitted)
+ * - `number` → numeric input, optionally range-bounded by `min`/`max`
+ * - `boolean` → toggle switch
+ * - `enum` → select, choices from `options`
+ * - `json` → multi-line textarea, validated as JSON on blur
+ * - `secret` → password input, never rendered with its stored value until the
+ *   user explicitly reveals it
+ */
+export type SettingFieldType = "string" | "number" | "boolean" | "enum" | "json" | "secret";
+
+/**
+ * Declaration for a single plugin setting under `contributes.settings` (#9301).
+ * Rendered as a generated form field in Preferences → Plugins and persisted via
+ * {@link SettingsApi}. `id` is the storage key; `type` selects the control. The
+ * manifest schema coerces the legacy `secret: true` flag to `type: "secret"`, so
+ * consumers only need to switch on `type`.
  */
 export interface SettingDefinition {
   id: string;
-  type?: "string" | "number" | "boolean" | "object";
+  type?: SettingFieldType;
   label?: string;
   description?: string;
   default?: unknown;
+  /** Where the value is stored. Defaults to `"user"`. */
+  scope?: PluginSettingsScope;
+  /** Allowed values for `type: "enum"`. Ignored for other types. */
+  options?: string[];
+  /** Inclusive lower bound for `type: "number"`. */
+  min?: number;
+  /** Inclusive upper bound for `type: "number"`. */
+  max?: number;
   /**
-   * UI-only hint (F19): the Settings tab renders a "stored in plaintext"
-   * warning for the field. Does NOT change storage mechanics — values are
-   * always plaintext JSON regardless of this flag (#9167).
+   * Legacy plaintext-secret hint (F19). The manifest schema normalizes
+   * `secret: true` to `type: "secret"`; new manifests should use the type.
+   * Storage is always plaintext JSON regardless of this flag (#9167).
    */
   secret?: boolean;
 }
 
 export type PluginSettingsScope = "user" | "project";
+
+/**
+ * Snapshot of one plugin's stored setting values for a single scope, returned to
+ * the settings UI (#9301). Secret values are deliberately never included —
+ * `secretsSet` only reports *which* secret keys have a stored value so the form
+ * can show a "saved" affordance without exposing the secret. Revealing a secret
+ * requires a separate, explicit `revealSecretSetting` call.
+ */
+export interface PluginSettingsUiValues {
+  /** Stored non-secret values keyed by setting id. A missing key means unset. */
+  values: Record<string, unknown>;
+  /** Ids of secret-typed settings that currently have a stored value. */
+  secretsSet: string[];
+}
 
 /**
  * Persistent, plugin-scoped key/value settings exposed on

--- a/src/components/Settings/PluginSettingsForm.tsx
+++ b/src/components/Settings/PluginSettingsForm.tsx
@@ -1,0 +1,502 @@
+import { useCallback, useEffect, useState } from "react";
+import { Eye, EyeOff, RotateCcw } from "lucide-react";
+import { SettingsSwitch } from "@/components/Settings/SettingsSwitch";
+import { Button } from "@/components/ui/button";
+import { useProjectStore } from "@/store/projectStore";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { logError } from "@/utils/logger";
+import type {
+  LoadedPluginInfo,
+  PluginSettingsScope,
+  SettingDefinition,
+  SettingFieldType,
+} from "@shared/types/plugin";
+
+const SCOPE_BADGE_LABEL: Record<PluginSettingsScope, string> = {
+  user: "User",
+  project: "Project",
+};
+
+const INPUT_CLASS =
+  "w-full px-2.5 py-1.5 text-sm rounded-[var(--radius-md)] bg-daintree-bg border border-daintree-border text-daintree-text placeholder:text-daintree-text/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed";
+
+function settingScope(def: SettingDefinition): PluginSettingsScope {
+  return def.scope ?? "user";
+}
+
+function effectiveType(def: SettingDefinition): SettingFieldType {
+  if (def.secret === true) return "secret";
+  return def.type ?? "string";
+}
+
+function fieldLabel(def: SettingDefinition): string {
+  return def.label ?? def.id;
+}
+
+/** Stringify a stored/default value for a text, number, or JSON input. */
+function toDraft(value: unknown, type: SettingFieldType): string {
+  if (value === undefined || value === null) return "";
+  if (type === "json") {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return "";
+    }
+  }
+  return String(value);
+}
+
+interface SettingFieldProps {
+  def: SettingDefinition;
+  pluginId: string;
+  projectId: string | null;
+  /** Stored non-secret value for this field's scope, or undefined when unset. */
+  storedValue: unknown;
+  /** Whether a secret value is currently stored (secret fields only). */
+  secretIsSet: boolean;
+  /** Whether this field's scope values have finished loading. */
+  loaded: boolean;
+}
+
+/**
+ * One generated field. Owns its own draft/validation/reveal state. Project-scoped
+ * fields are remounted by the parent on project switch (keyed on projectId), so
+ * the draft re-initializes from the new project's stored value.
+ */
+function SettingField({
+  def,
+  pluginId,
+  projectId,
+  storedValue,
+  secretIsSet,
+  loaded,
+}: SettingFieldProps) {
+  const type = effectiveType(def);
+  const scope = settingScope(def);
+  const isSecret = type === "secret";
+  const scopeReady = scope === "user" || projectId !== null;
+
+  // Draft for text / number / json / enum inputs (string-backed).
+  const [draft, setDraft] = useState("");
+  // Last value committed to storage, to skip no-op writes on blur.
+  const [committed, setCommitted] = useState("");
+  const [boolValue, setBoolValue] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  // Secret-specific state.
+  const [hasStored, setHasStored] = useState(secretIsSet);
+  const [revealed, setRevealed] = useState(false);
+
+  // Initialize from stored value (falling back to the declared default) once the
+  // scope's values resolve. Runs once per (re)mount when `loaded` flips true.
+  useEffect(() => {
+    if (!loaded) return;
+    if (isSecret) {
+      setHasStored(secretIsSet);
+      setRevealed(false);
+      setDraft("");
+      return;
+    }
+    if (type === "boolean") {
+      const initial = storedValue ?? def.default;
+      setBoolValue(initial === true);
+      return;
+    }
+    const initial = toDraft(storedValue ?? def.default, type);
+    setDraft(initial);
+    setCommitted(initial);
+    setError(null);
+  }, [loaded, storedValue, secretIsSet, isSecret, type, def.default]);
+
+  // Returns whether the write succeeded so callers can advance their committed
+  // state; never throws (the error is surfaced inline) so blur handlers can fire
+  // it without an unhandled rejection.
+  const writeValue = useCallback(
+    async (value: unknown): Promise<boolean> => {
+      setSaving(true);
+      try {
+        await window.electron.plugin.setSettingValue(pluginId, def.id, value, scope, projectId);
+        setError(null);
+        return true;
+      } catch (err) {
+        setError(formatErrorMessage(err, "Couldn't save setting"));
+        logError(`Failed to save plugin setting ${pluginId}.${def.id}`, err);
+        return false;
+      } finally {
+        setSaving(false);
+      }
+    },
+    [pluginId, def.id, scope, projectId]
+  );
+
+  const handleReset = useCallback(async () => {
+    setSaving(true);
+    try {
+      await window.electron.plugin.deleteSettingValue(pluginId, def.id, scope, projectId);
+      setError(null);
+      if (isSecret) {
+        setHasStored(false);
+        setRevealed(false);
+        setDraft("");
+      } else if (type === "boolean") {
+        setBoolValue(def.default === true);
+      } else {
+        const reset = toDraft(def.default, type);
+        setDraft(reset);
+        setCommitted(reset);
+      }
+    } catch (err) {
+      setError(formatErrorMessage(err, "Couldn't reset setting"));
+      logError(`Failed to reset plugin setting ${pluginId}.${def.id}`, err);
+    } finally {
+      setSaving(false);
+    }
+  }, [pluginId, def.id, def.default, scope, projectId, isSecret, type]);
+
+  const controlsDisabled = !loaded || !scopeReady || saving;
+  const fieldId = `plugin-setting-${pluginId}-${def.id}`;
+  const describedBy = error ? `${fieldId}-error` : def.description ? `${fieldId}-desc` : undefined;
+
+  const commitText = async () => {
+    if (draft === committed) return;
+    if (type === "number") {
+      const trimmed = draft.trim();
+      if (trimmed === "") {
+        // Empty clears the field back to default — drop the stored override.
+        await handleReset();
+        return;
+      }
+      const num = Number(trimmed);
+      if (!Number.isFinite(num)) {
+        setError("Enter a valid number");
+        return;
+      }
+      if (def.min !== undefined && num < def.min) {
+        setError(`Must be at least ${def.min}`);
+        return;
+      }
+      if (def.max !== undefined && num > def.max) {
+        setError(`Must be at most ${def.max}`);
+        return;
+      }
+      if (await writeValue(num)) setCommitted(draft);
+      return;
+    }
+    if (type === "json") {
+      const trimmed = draft.trim();
+      if (trimmed === "") {
+        await handleReset();
+        return;
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        setError("Enter valid JSON");
+        return;
+      }
+      if (await writeValue(parsed)) setCommitted(draft);
+      return;
+    }
+    // string
+    if (await writeValue(draft)) setCommitted(draft);
+  };
+
+  const handleReveal = async () => {
+    try {
+      const value = await window.electron.plugin.revealSecretSetting(
+        pluginId,
+        def.id,
+        scope,
+        projectId
+      );
+      setDraft(value ?? "");
+      setRevealed(true);
+      setError(null);
+    } catch (err) {
+      setError(formatErrorMessage(err, "Couldn't reveal secret"));
+      logError(`Failed to reveal plugin secret ${pluginId}.${def.id}`, err);
+    }
+  };
+
+  const commitSecret = async () => {
+    // Re-mask on blur regardless; only persist when something was typed.
+    const value = draft;
+    setRevealed(false);
+    setDraft("");
+    if (value === "") return;
+    if (await writeValue(value)) setHasStored(true);
+  };
+
+  const renderControl = () => {
+    if (type === "boolean") {
+      return (
+        <SettingsSwitch
+          id={fieldId}
+          checked={boolValue}
+          disabled={controlsDisabled}
+          aria-describedby={describedBy}
+          aria-label={fieldLabel(def)}
+          onCheckedChange={(next) => {
+            setBoolValue(next);
+            void writeValue(next);
+          }}
+        />
+      );
+    }
+    if (type === "enum") {
+      const options = def.options ?? [];
+      return (
+        <select
+          id={fieldId}
+          value={draft}
+          disabled={controlsDisabled}
+          aria-describedby={describedBy}
+          className={INPUT_CLASS}
+          onChange={(e) => {
+            const next = e.target.value;
+            setDraft(next);
+            setCommitted(next);
+            void writeValue(next);
+          }}
+        >
+          {/* Empty placeholder so an unset enum doesn't silently adopt the first option. */}
+          {draft === "" && <option value="">Select…</option>}
+          {options.map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </select>
+      );
+    }
+    if (type === "json") {
+      return (
+        <textarea
+          id={fieldId}
+          value={draft}
+          disabled={controlsDisabled}
+          aria-describedby={describedBy}
+          rows={4}
+          spellCheck={false}
+          className={`${INPUT_CLASS} font-mono text-xs resize-y`}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={() => void commitText()}
+        />
+      );
+    }
+    if (type === "secret") {
+      return (
+        <div className="flex items-center gap-1.5">
+          <input
+            id={fieldId}
+            type={revealed ? "text" : "password"}
+            value={draft}
+            disabled={controlsDisabled}
+            aria-describedby={describedBy}
+            placeholder={hasStored ? "••••••••" : "Not set"}
+            autoComplete="off"
+            className={INPUT_CLASS}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={() => void commitSecret()}
+          />
+          {hasStored && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              disabled={controlsDisabled}
+              aria-label={revealed ? `Hide ${fieldLabel(def)}` : `Reveal ${fieldLabel(def)}`}
+              // Toggle reveal without firing the input's blur-commit.
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => {
+                if (revealed) {
+                  setRevealed(false);
+                  setDraft("");
+                } else {
+                  void handleReveal();
+                }
+              }}
+            >
+              {revealed ? <EyeOff /> : <Eye />}
+            </Button>
+          )}
+        </div>
+      );
+    }
+    // string
+    return (
+      <input
+        id={fieldId}
+        type="text"
+        value={draft}
+        disabled={controlsDisabled}
+        aria-describedby={describedBy}
+        className={INPUT_CLASS}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => void commitText()}
+      />
+    );
+  };
+
+  const canReset =
+    (isSecret ? hasStored : storedValue !== undefined) && loaded && scopeReady && !saving;
+
+  return (
+    <div className="grid grid-cols-[minmax(0,1fr)] gap-1.5">
+      <div className="flex items-center justify-between gap-2">
+        <label htmlFor={fieldId} className="text-xs font-medium text-daintree-text">
+          {fieldLabel(def)}
+        </label>
+        <div className="flex items-center gap-1.5 shrink-0">
+          <span className="text-[10px] uppercase tracking-wide text-daintree-text/40">
+            {SCOPE_BADGE_LABEL[scope]}
+          </span>
+          {canReset && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label={`Reset ${fieldLabel(def)} to default`}
+              className="text-daintree-text/40 hover:text-daintree-text/70"
+              onClick={() => void handleReset()}
+            >
+              <RotateCcw />
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* boolean lays the switch beside the description; others stack. */}
+      {type === "boolean" ? (
+        <div className="flex items-center justify-between gap-3">
+          {def.description ? (
+            <p id={`${fieldId}-desc`} className="text-[11px] text-daintree-text/50">
+              {def.description}
+            </p>
+          ) : (
+            <span />
+          )}
+          {renderControl()}
+        </div>
+      ) : (
+        <>
+          {renderControl()}
+          {def.description && (
+            <p id={`${fieldId}-desc`} className="text-[11px] text-daintree-text/50">
+              {def.description}
+            </p>
+          )}
+        </>
+      )}
+
+      {!scopeReady && (
+        <p className="text-[11px] text-daintree-text/40">Open a project to edit this setting.</p>
+      )}
+      {error && (
+        <p id={`${fieldId}-error`} className="text-[11px] text-status-danger">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+interface PluginSettingsFormProps {
+  plugin: LoadedPluginInfo;
+}
+
+/**
+ * Generated settings form for one plugin's `contributes.settings` (#9301). Field
+ * chrome (labels, controls, scope badges) renders synchronously from the already
+ * loaded manifest; stored values hydrate asynchronously per scope. User-scoped
+ * values load once; project-scoped values reload whenever the active project
+ * changes (the fields are remounted so their drafts re-initialize).
+ */
+export function PluginSettingsForm({ plugin }: PluginSettingsFormProps) {
+  const pluginId = plugin.manifest.name;
+  const settings = plugin.manifest.contributes.settings ?? [];
+  const projectId = useProjectStore((s) => s.currentProject?.id ?? null);
+
+  const hasUserScope = settings.some((s) => settingScope(s) === "user");
+  const hasProjectScope = settings.some((s) => settingScope(s) === "project");
+
+  const [userValues, setUserValues] = useState<Record<string, unknown> | null>(null);
+  const [userSecrets, setUserSecrets] = useState<Set<string>>(new Set());
+  const [projectValues, setProjectValues] = useState<Record<string, unknown> | null>(null);
+  const [projectSecrets, setProjectSecrets] = useState<Set<string>>(new Set());
+
+  // User-scoped values: load once per plugin.
+  useEffect(() => {
+    if (!hasUserScope) return;
+    let cancelled = false;
+    window.electron.plugin
+      .getSettingValues(pluginId, "user", null)
+      .then((res) => {
+        if (cancelled) return;
+        setUserValues(res.values);
+        setUserSecrets(new Set(res.secretsSet));
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setUserValues({});
+        logError(`Failed to load user plugin settings for ${pluginId}`, err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [pluginId, hasUserScope]);
+
+  // Project-scoped values: reload on project switch (#9301 re-render requirement).
+  useEffect(() => {
+    if (!hasProjectScope) return;
+    if (projectId === null) {
+      setProjectValues({});
+      setProjectSecrets(new Set());
+      return;
+    }
+    let cancelled = false;
+    setProjectValues(null);
+    window.electron.plugin
+      .getSettingValues(pluginId, "project", projectId)
+      .then((res) => {
+        if (cancelled) return;
+        setProjectValues(res.values);
+        setProjectSecrets(new Set(res.secretsSet));
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setProjectValues({});
+        logError(`Failed to load project plugin settings for ${pluginId}`, err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [pluginId, hasProjectScope, projectId]);
+
+  if (settings.length === 0) return null;
+
+  return (
+    <div className="mt-4 pt-4 border-t border-daintree-border space-y-4">
+      <h4 className="text-xs font-medium text-daintree-text/70">Settings</h4>
+      {settings.map((def) => {
+        const scope = settingScope(def);
+        const loaded = scope === "user" ? userValues !== null : projectValues !== null;
+        const values = scope === "user" ? userValues : projectValues;
+        const secrets = scope === "user" ? userSecrets : projectSecrets;
+        return (
+          <SettingField
+            // Remount project-scoped fields on project switch so drafts reset.
+            key={scope === "project" ? `${def.id}:${projectId ?? "none"}` : def.id}
+            def={def}
+            pluginId={pluginId}
+            projectId={projectId}
+            storedValue={values?.[def.id]}
+            secretIsSet={secrets.has(def.id)}
+            loaded={loaded}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/Settings/PluginSettingsForm.tsx
+++ b/src/components/Settings/PluginSettingsForm.tsx
@@ -220,12 +220,20 @@ function SettingField({
   };
 
   const commitSecret = async () => {
-    // Re-mask on blur regardless; only persist when something was typed.
     const value = draft;
-    setRevealed(false);
-    setDraft("");
-    if (value === "") return;
-    if (await writeValue(value)) setHasStored(true);
+    if (value === "") {
+      setRevealed(false);
+      setDraft("");
+      return;
+    }
+    // Persist first; only re-mask (and drop the value from the DOM) once the
+    // write succeeds, so a failed save leaves the typed value recoverable next
+    // to the inline error instead of silently discarding it.
+    if (await writeValue(value)) {
+      setHasStored(true);
+      setRevealed(false);
+      setDraft("");
+    }
   };
 
   const renderControl = () => {

--- a/src/components/Settings/PluginsTab.tsx
+++ b/src/components/Settings/PluginsTab.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Plug, AlertCircle, FilePlus, Link2, Trash2, RefreshCw, Info } from "lucide-react";
 import { SettingsSwitch } from "@/components/Settings/SettingsSwitch";
+import { PluginSettingsForm } from "@/components/Settings/PluginSettingsForm";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { AppDialog } from "@/components/ui/AppDialog";
@@ -200,6 +201,10 @@ function PluginRow({
             Failed to load: {plugin.loadError.message}
           </p>
         </div>
+      )}
+
+      {enabled && (plugin.manifest.contributes.settings?.length ?? 0) > 0 && (
+        <PluginSettingsForm plugin={plugin} />
       )}
     </div>
   );

--- a/src/components/Settings/__tests__/PluginSettingsForm.test.tsx
+++ b/src/components/Settings/__tests__/PluginSettingsForm.test.tsx
@@ -1,0 +1,218 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { PluginSettingsForm } from "../PluginSettingsForm";
+import type { LoadedPluginInfo, SettingDefinition } from "@shared/types/plugin";
+
+let currentProjectId: string | null = null;
+
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: (selector: (s: { currentProject: { id: string } | null }) => unknown) =>
+    selector({ currentProject: currentProjectId ? { id: currentProjectId } : null }),
+}));
+
+const pluginApi = {
+  getSettingValues: vi.fn(),
+  setSettingValue: vi.fn().mockResolvedValue(undefined),
+  deleteSettingValue: vi.fn().mockResolvedValue(undefined),
+  revealSecretSetting: vi.fn(),
+};
+
+function makePlugin(settings: SettingDefinition[]): LoadedPluginInfo {
+  return {
+    manifest: {
+      name: "acme.test",
+      version: "1.0.0",
+      contributes: {
+        panels: [],
+        toolbarButtons: [],
+        menuItems: [],
+        keybindings: [],
+        contextMenus: [],
+        commands: [],
+        experimental_views: [],
+        experimental_mcpServers: [],
+        forgeProviders: [],
+        fileDecorationProviders: [],
+        settings,
+      },
+    },
+    dir: "/tmp/acme.test",
+    loadedAt: 0,
+    isBuiltin: false,
+    source: "sideload",
+    installedAt: 0,
+    archiveHash: null,
+    originalUrl: null,
+    loadError: null,
+    disabled: false,
+    updateAvailable: null,
+    devMode: false,
+  } as unknown as LoadedPluginInfo;
+}
+
+beforeEach(() => {
+  currentProjectId = null;
+  vi.clearAllMocks();
+  pluginApi.setSettingValue.mockResolvedValue(undefined);
+  pluginApi.deleteSettingValue.mockResolvedValue(undefined);
+  pluginApi.getSettingValues.mockResolvedValue({ values: {}, secretsSet: [] });
+  (window as unknown as { electron: unknown }).electron = { plugin: pluginApi };
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PluginSettingsForm", () => {
+  it("renders field chrome immediately, before values resolve", () => {
+    let resolve!: (v: { values: Record<string, unknown>; secretsSet: string[] }) => void;
+    pluginApi.getSettingValues.mockReturnValue(
+      new Promise((r) => {
+        resolve = r;
+      })
+    );
+    render(
+      <PluginSettingsForm
+        plugin={makePlugin([{ id: "apiKey", type: "string", label: "API key" }])}
+      />
+    );
+    // Label + control paint synchronously from the manifest; the input is
+    // disabled until the bridge call resolves.
+    const input = screen.getByLabelText("API key") as HTMLInputElement;
+    expect(input).toBeTruthy();
+    expect(input.disabled).toBe(true);
+    resolve({ values: {}, secretsSet: [] });
+  });
+
+  it("populates a stored string value and writes it on blur", async () => {
+    pluginApi.getSettingValues.mockResolvedValue({ values: { apiKey: "stored" }, secretsSet: [] });
+    render(
+      <PluginSettingsForm
+        plugin={makePlugin([{ id: "apiKey", type: "string", label: "API key" }])}
+      />
+    );
+
+    const input = (await screen.findByLabelText("API key")) as HTMLInputElement;
+    await waitFor(() => expect(input.value).toBe("stored"));
+
+    fireEvent.change(input, { target: { value: "changed" } });
+    fireEvent.blur(input);
+
+    await waitFor(() =>
+      expect(pluginApi.setSettingValue).toHaveBeenCalledWith(
+        "acme.test",
+        "apiKey",
+        "changed",
+        "user",
+        null
+      )
+    );
+  });
+
+  it("shows the declared default when no value is stored", async () => {
+    render(
+      <PluginSettingsForm
+        plugin={makePlugin([{ id: "host", type: "string", label: "Host", default: "localhost" }])}
+      />
+    );
+    const input = (await screen.findByLabelText("Host")) as HTMLInputElement;
+    await waitFor(() => expect(input.value).toBe("localhost"));
+  });
+
+  it("writes a boolean on toggle", async () => {
+    render(
+      <PluginSettingsForm plugin={makePlugin([{ id: "flag", type: "boolean", label: "Flag" }])} />
+    );
+    const toggle = (await screen.findByRole("switch", { name: "Flag" })) as HTMLButtonElement;
+    await waitFor(() => expect(toggle.disabled).toBe(false));
+    fireEvent.click(toggle);
+    await waitFor(() =>
+      expect(pluginApi.setSettingValue).toHaveBeenCalledWith(
+        "acme.test",
+        "flag",
+        true,
+        "user",
+        null
+      )
+    );
+  });
+
+  it("writes an enum on change", async () => {
+    render(
+      <PluginSettingsForm
+        plugin={makePlugin([{ id: "mode", type: "enum", label: "Mode", options: ["a", "b"] }])}
+      />
+    );
+    const select = (await screen.findByLabelText("Mode")) as HTMLSelectElement;
+    await waitFor(() => expect(select.disabled).toBe(false));
+    fireEvent.change(select, { target: { value: "b" } });
+    await waitFor(() =>
+      expect(pluginApi.setSettingValue).toHaveBeenCalledWith("acme.test", "mode", "b", "user", null)
+    );
+  });
+
+  it("surfaces an inline error for invalid JSON and does not write", async () => {
+    render(
+      <PluginSettingsForm plugin={makePlugin([{ id: "cfg", type: "json", label: "Config" }])} />
+    );
+    const textarea = (await screen.findByLabelText("Config")) as HTMLTextAreaElement;
+    await waitFor(() => expect(textarea.disabled).toBe(false));
+    fireEvent.change(textarea, { target: { value: "{ not json" } });
+    fireEvent.blur(textarea);
+    expect(await screen.findByText("Enter valid JSON")).toBeTruthy();
+    expect(pluginApi.setSettingValue).not.toHaveBeenCalled();
+  });
+
+  it("never shows a secret value until revealed, then re-masks on blur", async () => {
+    pluginApi.getSettingValues.mockResolvedValue({ values: {}, secretsSet: ["token"] });
+    pluginApi.revealSecretSetting.mockResolvedValue("sekret");
+    render(
+      <PluginSettingsForm plugin={makePlugin([{ id: "token", type: "secret", label: "Token" }])} />
+    );
+
+    const input = (await screen.findByLabelText("Token")) as HTMLInputElement;
+    await waitFor(() => expect(input.disabled).toBe(false));
+    // Bulk load never carried the secret value.
+    expect(input.value).toBe("");
+    expect(input.type).toBe("password");
+
+    fireEvent.click(screen.getByRole("button", { name: "Reveal Token" }));
+    await waitFor(() => expect(input.value).toBe("sekret"));
+    expect(input.type).toBe("text");
+
+    fireEvent.blur(input);
+    await waitFor(() =>
+      expect(pluginApi.setSettingValue).toHaveBeenCalledWith(
+        "acme.test",
+        "token",
+        "sekret",
+        "user",
+        null
+      )
+    );
+    // Re-masked: value cleared from the DOM.
+    await waitFor(() => expect(input.value).toBe(""));
+  });
+
+  it("renders a scope badge per field", async () => {
+    render(
+      <PluginSettingsForm
+        plugin={makePlugin([{ id: "p", type: "string", label: "P", scope: "project" }])}
+      />
+    );
+    expect(await screen.findByText("Project")).toBeTruthy();
+  });
+
+  it("disables project-scoped fields when no project is active", async () => {
+    currentProjectId = null;
+    render(
+      <PluginSettingsForm
+        plugin={makePlugin([{ id: "p", type: "string", label: "P", scope: "project" }])}
+      />
+    );
+    const input = (await screen.findByLabelText("P")) as HTMLInputElement;
+    expect(input.disabled).toBe(true);
+    expect(screen.getByText("Open a project to edit this setting.")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Closes #9301.

Renders a plugin's `contributes.settings` declarations as a generated form under Preferences → Plugins, so plugin authors can collect API tokens and config without shipping a custom panel. Persists through the existing `host.settings` storage (#9279) and fires `onDidChange` to the owning plugin.

## What changed

- **Schema/types** — `SettingDefinition` now models all six field types (`string`, `number`, `boolean`, `enum`, `json`, `secret`) plus `scope`, `options`, `min`/`max`. The manifest Zod schema validates them (enum requires options, min ≤ max) and coerces the legacy `secret: true` flag to `type: "secret"`. Added `contributes.settings` to the schema (defaulting to `[]`).
- **IPC** — four renderer-facing channels (`plugin:settings-get-values`, `-set-value`, `-delete-value`, `-reveal-secret`) wired through the existing `plugin.preload` → `IpcInvokeMap` → `defineIpcNamespace` pipeline; `generated-api.ts` regenerated via codegen.
- **Service** — `PluginService` gains UI-facing read/write/delete/reveal methods that reuse the same per-(plugin, scope) store and `notifySettingsSubscribers` path as the plugin API. Secrets are never returned in the bulk read (only their ids in `secretsSet`); reveal is restricted to declared secret-typed keys. Project scope resolves an explicit `projectId` via `getProjectById` for per-window correctness. Added `PluginSettingsStore.delete` for reset-to-default.
- **UI** — `PluginSettingsForm` renders field chrome synchronously from the manifest and hydrates values async per scope (no full-area spinner). Per-type controls: text/number/JSON write on blur with inline validation; boolean/enum write on change; secrets stay masked until an explicit reveal and re-mask on blur. Scope badges, reset-to-default, and project-switch re-fetch (project-scoped fields remount on project change). Mounted per-plugin in `PluginsTab`.

## Testing

- Schema: all six types, scope default, legacy `secret:true` coercion, enum/min-max validation, strict unknown-key rejection.
- Store: `delete` cases (removal, no-op, sibling-intact, persistence, rollback).
- Service: secret redaction (canonical `type:secret`), explicit-projectId routing vs active project, scope filtering, reveal guard (non-secret/undeclared → null), delete, undeclared-key rejection.
- Component: chrome-immediate render, blur/change writes, inline JSON error, secret reveal/mask cycle, scope badge, project-disabled state.
- Full `npm run check` green (typecheck, IPC codegen drift, lint:ratchet, format).