### PR TITLE
feat(plugins): install-from-URL with bounded fetch

### DIFF
--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -294,7 +294,8 @@ describe("registerPluginHandlers", () => {
       ok: opts.ok ?? true,
       status: opts.status ?? 200,
       headers: { get: (name: string) => headerMap.get(name.toLowerCase()) ?? null },
-      body: opts.body ?? streamFromChunks([new Uint8Array([1, 2, 3])]),
+      // Honor an explicit `body: null`; only default when the key is absent.
+      body: "body" in opts ? opts.body : streamFromChunks([new Uint8Array([1, 2, 3])]),
     };
   }
 
@@ -331,6 +332,74 @@ describe("registerPluginHandlers", () => {
     const handler = getHandler("plugin:install-from-url");
     const result = await handler({}, "https://example.com/p.dntr");
     expect(result).toEqual({ status: "installed", pluginId: "acme.my-plugin" });
+  });
+
+  it("PLUGIN_INSTALL_FROM_URL accepts application/zip with a charset parameter", async () => {
+    mockNetFetch.mockResolvedValue(
+      mockResponse({ headers: { "content-type": "application/zip; charset=utf-8" } })
+    );
+    const handler = getHandler("plugin:install-from-url");
+    const result = await handler({}, "https://example.com/download");
+    expect(result).toEqual({ status: "installed", pluginId: "acme.my-plugin" });
+  });
+
+  it("PLUGIN_INSTALL_FROM_URL rejects a near-miss MIME like application/zipper", async () => {
+    mockNetFetch.mockResolvedValue(
+      mockResponse({ headers: { "content-type": "application/zipper" } })
+    );
+    const handler = getHandler("plugin:install-from-url");
+    const result = (await handler({}, "https://example.com/download")) as {
+      status: string;
+      errors: Array<{ code: string }>;
+    };
+    expect(result.status).toBe("failed");
+    expect(result.errors[0]!.code).toBe("content_type_rejected");
+    expect(mockInstallPlugin).not.toHaveBeenCalled();
+  });
+
+  it("PLUGIN_INSTALL_FROM_URL returns fetch_failed when the response has no body", async () => {
+    mockNetFetch.mockResolvedValue(
+      mockResponse({ headers: { "content-type": "application/zip" }, body: null })
+    );
+    const handler = getHandler("plugin:install-from-url");
+    const result = (await handler({}, "https://example.com/p.dntr")) as {
+      status: string;
+      errors: Array<{ code: string }>;
+    };
+    expect(result.status).toBe("failed");
+    expect(result.errors[0]!.code).toBe("fetch_failed");
+    expect(mockInstallPlugin).not.toHaveBeenCalled();
+  });
+
+  it("PLUGIN_INSTALL_FROM_URL accepts a stream of exactly the 30 MB cap", async () => {
+    const atCap = new Uint8Array(30 * 1024 * 1024);
+    mockNetFetch.mockResolvedValue(
+      mockResponse({
+        headers: { "content-type": "application/zip" },
+        body: streamFromChunks([atCap]),
+      })
+    );
+    const handler = getHandler("plugin:install-from-url");
+    const result = await handler({}, "https://example.com/p.dntr");
+    expect(result).toEqual({ status: "installed", pluginId: "acme.my-plugin" });
+  });
+
+  it("PLUGIN_INSTALL_FROM_URL aborts a stream one byte over the cap", async () => {
+    const overCap = new Uint8Array(30 * 1024 * 1024 + 1);
+    mockNetFetch.mockResolvedValue(
+      mockResponse({
+        headers: { "content-type": "application/zip" },
+        body: streamFromChunks([overCap]),
+      })
+    );
+    const handler = getHandler("plugin:install-from-url");
+    const result = (await handler({}, "https://example.com/p.dntr")) as {
+      status: string;
+      errors: Array<{ code: string }>;
+    };
+    expect(result.status).toBe("failed");
+    expect(result.errors[0]!.code).toBe("size_exceeded");
+    expect(mockInstallPlugin).not.toHaveBeenCalled();
   });
 
   it("PLUGIN_INSTALL_FROM_URL rejects an unknown MIME with no .dntr suffix", async () => {

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -7,6 +7,7 @@ const mockListPlugins = vi.fn();
 const mockSetEnabled = vi.fn();
 const mockUninstallPlugin = vi.fn();
 const mockCheckForUpdate = vi.fn();
+const mockInstallPlugin = vi.fn();
 const mockListPluginActions = vi.fn();
 const mockRegisterPluginAction = vi.fn();
 const mockUnregisterPluginAction = vi.fn();
@@ -17,6 +18,7 @@ vi.mock("../../../services/PluginService.js", () => ({
     setEnabled: (...args: unknown[]) => mockSetEnabled(...args),
     uninstallPlugin: (...args: unknown[]) => mockUninstallPlugin(...args),
     checkForUpdate: (...args: unknown[]) => mockCheckForUpdate(...args),
+    installPlugin: (...args: unknown[]) => mockInstallPlugin(...args),
     dispatchHandler: (...args: unknown[]) => mockDispatchHandler(...args),
     registerHandler: (...args: unknown[]) => mockRegisterHandler(...args),
     removeHandlers: (...args: unknown[]) => mockRemoveHandlers(...args),
@@ -70,6 +72,7 @@ const mockIpcMainHandle = vi.fn();
 const mockIpcMainRemoveHandler = vi.fn();
 const mockShowOpenDialog = vi.fn();
 const mockGetFocusedWindow = vi.fn();
+const mockNetFetch = vi.fn();
 vi.mock("electron", () => ({
   ipcMain: {
     handle: (...args: unknown[]) => mockIpcMainHandle(...args),
@@ -80,6 +83,9 @@ vi.mock("electron", () => ({
   },
   BrowserWindow: {
     getFocusedWindow: (...args: unknown[]) => mockGetFocusedWindow(...args),
+  },
+  net: {
+    fetch: (...args: unknown[]) => mockNetFetch(...args),
   },
 }));
 
@@ -97,6 +103,8 @@ beforeEach(() => {
   mockGetFileDecorationImpls.mockReturnValue([]);
   mockGetFocusedWindow.mockReturnValue(null);
   mockShowOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] });
+  mockInstallPlugin.mockResolvedValue({ status: "installed", pluginId: "acme.my-plugin" });
+  mockNetFetch.mockReset();
   _resetIpcGuardForTesting();
   markIpcSecurityReady();
 });
@@ -262,10 +270,174 @@ describe("registerPluginHandlers", () => {
     expect(result).toEqual({ status: "invalid-url" });
   });
 
-  it("PLUGIN_INSTALL_FROM_URL returns not-implemented for a valid URL", async () => {
+  // --- Install-from-URL bounded fetch (F24) ---
+
+  function streamFromChunks(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of chunks) controller.enqueue(chunk);
+        controller.close();
+      },
+    });
+  }
+
+  function mockResponse(opts: {
+    ok?: boolean;
+    status?: number;
+    headers?: Record<string, string>;
+    body?: ReadableStream<Uint8Array> | null;
+  }) {
+    const headerMap = new Map<string, string>(
+      Object.entries(opts.headers ?? {}).map(([k, v]) => [k.toLowerCase(), v])
+    );
+    return {
+      ok: opts.ok ?? true,
+      status: opts.status ?? 200,
+      headers: { get: (name: string) => headerMap.get(name.toLowerCase()) ?? null },
+      body: opts.body ?? streamFromChunks([new Uint8Array([1, 2, 3])]),
+    };
+  }
+
+  function abortError(name: "AbortError" | "TimeoutError" = "AbortError"): DOMException {
+    return new DOMException("The operation was aborted", name);
+  }
+
+  it("PLUGIN_INSTALL_FROM_URL installs a zip archive and passes url provenance", async () => {
+    mockNetFetch.mockResolvedValue(
+      mockResponse({ headers: { "content-type": "application/zip" } })
+    );
     const handler = getHandler("plugin:install-from-url");
     const result = await handler({}, "https://example.com/p.dntr");
-    expect(result).toEqual({ status: "not-implemented" });
+    expect(result).toEqual({ status: "installed", pluginId: "acme.my-plugin" });
+    expect(mockInstallPlugin).toHaveBeenCalledTimes(1);
+    const [archivePath, opts] = mockInstallPlugin.mock.calls[0] as [string, unknown];
+    expect(archivePath).toMatch(/daintree-plugin-.*\.dntr$/);
+    expect(opts).toEqual({ source: "url", originalUrl: "https://example.com/p.dntr" });
+  });
+
+  it("PLUGIN_INSTALL_FROM_URL accepts application/x-dntr content type", async () => {
+    mockNetFetch.mockResolvedValue(
+      mockResponse({ headers: { "content-type": "application/x-dntr" } })
+    );
+    const handler = getHandler("plugin:install-from-url");
+    const result = await handler({}, "https://example.com/download");
+    expect(result).toEqual({ status: "installed", pluginId: "acme.my-plugin" });
+  });
+
+  it("PLUGIN_INSTALL_FROM_URL accepts an unknown MIME when the URL ends in .dntr", async () => {
+    mockNetFetch.mockResolvedValue(
+      mockResponse({ headers: { "content-type": "application/octet-stream" } })
+    );
+    const handler = getHandler("plugin:install-from-url");
+    const result = await handler({}, "https://example.com/p.dntr");
+    expect(result).toEqual({ status: "installed", pluginId: "acme.my-plugin" });
+  });
+
+  it("PLUGIN_INSTALL_FROM_URL rejects an unknown MIME with no .dntr suffix", async () => {
+    mockNetFetch.mockResolvedValue(
+      mockResponse({ headers: { "content-type": "text/html" } })
+    );
+    const handler = getHandler("plugin:install-from-url");
+    const result = await handler({}, "https://example.com/oops");
+    expect(result).toEqual({
+      status: "failed",
+      errors: [{ code: "content_type_rejected", message: expect.any(String) }],
+    });
+    expect(mockInstallPlugin).not.toHaveBeenCalled();
+  });
+
+  it("PLUGIN_INSTALL_FROM_URL returns fetch_failed on a non-2xx response", async () => {
+    mockNetFetch.mockResolvedValue(mockResponse({ ok: false, status: 404 }));
+    const handler = getHandler("plugin:install-from-url");
+    const result = (await handler({}, "https://example.com/p.dntr")) as {
+      status: string;
+      errors: Array<{ code: string }>;
+    };
+    expect(result.status).toBe("failed");
+    expect(result.errors[0]!.code).toBe("fetch_failed");
+    expect(mockInstallPlugin).not.toHaveBeenCalled();
+  });
+
+  it("PLUGIN_INSTALL_FROM_URL returns fetch_failed on a network error", async () => {
+    mockNetFetch.mockRejectedValue(new Error("ENOTFOUND"));
+    const handler = getHandler("plugin:install-from-url");
+    const result = (await handler({}, "https://example.com/p.dntr")) as {
+      status: string;
+      errors: Array<{ code: string }>;
+    };
+    expect(result.status).toBe("failed");
+    expect(result.errors[0]!.code).toBe("fetch_failed");
+  });
+
+  it("PLUGIN_INSTALL_FROM_URL returns fetch_timeout when the request aborts", async () => {
+    mockNetFetch.mockRejectedValue(abortError("AbortError"));
+    const handler = getHandler("plugin:install-from-url");
+    const result = (await handler({}, "https://example.com/p.dntr")) as {
+      status: string;
+      errors: Array<{ code: string }>;
+    };
+    expect(result.status).toBe("failed");
+    expect(result.errors[0]!.code).toBe("fetch_timeout");
+  });
+
+  it("PLUGIN_INSTALL_FROM_URL rejects when Content-Length exceeds the cap", async () => {
+    mockNetFetch.mockResolvedValue(
+      mockResponse({
+        headers: {
+          "content-type": "application/zip",
+          "content-length": String(31 * 1024 * 1024),
+        },
+      })
+    );
+    const handler = getHandler("plugin:install-from-url");
+    const result = (await handler({}, "https://example.com/p.dntr")) as {
+      status: string;
+      errors: Array<{ code: string }>;
+    };
+    expect(result.status).toBe("failed");
+    expect(result.errors[0]!.code).toBe("size_exceeded");
+    expect(mockInstallPlugin).not.toHaveBeenCalled();
+  });
+
+  it("PLUGIN_INSTALL_FROM_URL aborts mid-stream when bytes exceed the cap", async () => {
+    const oversized = new Uint8Array(31 * 1024 * 1024);
+    mockNetFetch.mockResolvedValue(
+      mockResponse({
+        headers: { "content-type": "application/zip" },
+        body: streamFromChunks([oversized]),
+      })
+    );
+    const handler = getHandler("plugin:install-from-url");
+    const result = (await handler({}, "https://example.com/p.dntr")) as {
+      status: string;
+      errors: Array<{ code: string }>;
+    };
+    expect(result.status).toBe("failed");
+    expect(result.errors[0]!.code).toBe("size_exceeded");
+    expect(mockInstallPlugin).not.toHaveBeenCalled();
+  });
+
+  it("PLUGIN_INSTALL_FROM_URL rejects a non-http(s) scheme as invalid-url", async () => {
+    const handler = getHandler("plugin:install-from-url");
+    const result = await handler({}, "file:///etc/passwd");
+    expect(result).toEqual({ status: "invalid-url" });
+    expect(mockNetFetch).not.toHaveBeenCalled();
+  });
+
+  it("PLUGIN_INSTALL_FROM_URL propagates an installPlugin failure", async () => {
+    mockNetFetch.mockResolvedValue(
+      mockResponse({ headers: { "content-type": "application/zip" } })
+    );
+    mockInstallPlugin.mockResolvedValue({
+      status: "failed",
+      errors: [{ code: "manifest_invalid", message: "bad manifest" }],
+    });
+    const handler = getHandler("plugin:install-from-url");
+    const result = await handler({}, "https://example.com/p.dntr");
+    expect(result).toEqual({
+      status: "failed",
+      errors: [{ code: "manifest_invalid", message: "bad manifest" }],
+    });
   });
 
   it("PLUGIN_UNINSTALL delegates to pluginService.uninstallPlugin", async () => {

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -403,9 +403,7 @@ describe("registerPluginHandlers", () => {
   });
 
   it("PLUGIN_INSTALL_FROM_URL rejects an unknown MIME with no .dntr suffix", async () => {
-    mockNetFetch.mockResolvedValue(
-      mockResponse({ headers: { "content-type": "text/html" } })
-    );
+    mockNetFetch.mockResolvedValue(mockResponse({ headers: { "content-type": "text/html" } }));
     const handler = getHandler("plugin:install-from-url");
     const result = await handler({}, "https://example.com/oops");
     expect(result).toEqual({

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -187,31 +187,40 @@ async function handleInstallFromUrl(url: string): Promise<PluginInstallResult> {
       return failed("fetch_failed", "Couldn't download the plugin from that URL.");
     }
 
+    // Drop the open connection on any early return so the socket isn't held
+    // until GC; the body is never consumed on these paths.
+    const abandon = async (result: PluginInstallResult): Promise<PluginInstallResult> => {
+      await response.body?.cancel().catch(() => {});
+      return result;
+    };
+
     if (!response.ok) {
-      return failed("fetch_failed", `The server returned HTTP ${response.status}.`);
+      return abandon(failed("fetch_failed", `The server returned HTTP ${response.status}.`));
     }
 
     const contentLength = response.headers.get("content-length");
     if (contentLength) {
       const declared = Number.parseInt(contentLength, 10);
       if (Number.isFinite(declared) && declared > PLUGIN_DOWNLOAD_MAX_BYTES) {
-        return failed("size_exceeded", "The plugin file is larger than the 30 MB limit.");
+        return abandon(
+          failed("size_exceeded", "The plugin file is larger than the 30 MB limit.")
+        );
       }
     }
 
-    // Accept canonical zip, the optional x-dntr type, or any 2xx whose URL path
-    // ends in `.dntr` (case-insensitive for pasted URLs). response.url is
-    // unreliable in Electron, so the `.dntr` suffix is checked on the original
-    // user URL.
-    const contentType = (response.headers.get("content-type") ?? "").toLowerCase();
-    const mimeOk =
-      contentType.startsWith("application/zip") ||
-      contentType.startsWith("application/x-dntr");
+    // Accept canonical zip (with or without a `; charset=…` parameter), the
+    // optional x-dntr type, or any 2xx whose URL path ends in `.dntr`
+    // (case-insensitive for pasted URLs). An exact/`;`-prefixed match avoids
+    // `application/zipper` slipping through. response.url is unreliable in
+    // Electron, so the `.dntr` suffix is checked on the original user URL.
+    const contentType = (response.headers.get("content-type") ?? "").toLowerCase().trim();
+    const mimeMatches = (type: string) =>
+      contentType === type || contentType.startsWith(`${type};`);
+    const mimeOk = mimeMatches("application/zip") || mimeMatches("application/x-dntr");
     const suffixOk = parsed.pathname.toLowerCase().endsWith(".dntr");
     if (!mimeOk && !suffixOk) {
-      return failed(
-        "content_type_rejected",
-        "That URL didn't return a plugin archive (.dntr)."
+      return abandon(
+        failed("content_type_rejected", "That URL didn't return a plugin archive (.dntr).")
       );
     }
 

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -202,9 +202,7 @@ async function handleInstallFromUrl(url: string): Promise<PluginInstallResult> {
     if (contentLength) {
       const declared = Number.parseInt(contentLength, 10);
       if (Number.isFinite(declared) && declared > PLUGIN_DOWNLOAD_MAX_BYTES) {
-        return abandon(
-          failed("size_exceeded", "The plugin file is larger than the 30 MB limit.")
-        );
+        return abandon(failed("size_exceeded", "The plugin file is larger than the 30 MB limit."));
       }
     }
 

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -1,5 +1,11 @@
-import { ipcMain, dialog, BrowserWindow } from "electron";
-import { writeFile } from "node:fs/promises";
+import { ipcMain, dialog, BrowserWindow, net } from "electron";
+import { writeFile, rm } from "node:fs/promises";
+import { createWriteStream } from "node:fs";
+import { Readable, Transform } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
 import { CHANNELS } from "../channels.js";
 import { defineIpcNamespace, op } from "../define.js";
 import {
@@ -44,6 +50,7 @@ import type {
   PluginActionContribution,
   PluginActionDescriptor,
   PluginInstallOptions,
+  PluginInstallError,
   PluginInstallResult,
   PluginCheckUpdateResult,
   PluginSettingsScope,
@@ -105,24 +112,150 @@ async function handleInstallFromFile(ctx: IpcContext): Promise<PluginInstallResu
   return { status: "not-implemented" };
 }
 
+// Bounded download limits for install-from-URL (F24). Mirrors the spec in
+// docs/plugins/distribution.md: a 30 MB hard cap aborted mid-stream, a 10s
+// deadline, and a MIME/suffix allowlist so a stray HTML error page never
+// reaches the installer.
+const PLUGIN_DOWNLOAD_MAX_BYTES = 30 * 1024 * 1024;
+const PLUGIN_DOWNLOAD_TIMEOUT_MS = 10_000;
+
+function isAbortLikeError(err: unknown): boolean {
+  // AbortSignal.timeout() rejects as "AbortError" (not "TimeoutError") under
+  // Chromium 146, and the size-cap controller.abort() also surfaces as
+  // "AbortError" — so both names are treated as abort-like and disambiguated
+  // by the caller's `sizeAborted` flag. These rejections are DOMExceptions,
+  // which are NOT `Error` instances in Node, so duck-type the `name`.
+  if (typeof err !== "object" || err === null) return false;
+  const name = (err as { name?: unknown }).name;
+  return name === "AbortError" || name === "TimeoutError";
+}
+
+/**
+ * Download a `.dntr` archive from a user-supplied URL into a temp file under
+ * bounded conditions, then hand the path to the atomic installer (F24).
+ *
+ * Guards, in order: well-formed URL + http/https scheme, a 10s deadline, a
+ * MIME/`.dntr`-suffix allowlist, a `Content-Length` pre-check, and a mid-stream
+ * 30 MB byte cap that aborts the in-flight request. All failures resolve as
+ * structured `{ status: "failed", errors }` data so the dialog can render a
+ * tailored message; the handler-owned temp file is always removed in `finally`
+ * (PluginService extracts into its own temp dir and doesn't take ownership of
+ * the download artifact).
+ */
 async function handleInstallFromUrl(url: string): Promise<PluginInstallResult> {
   if (typeof url !== "string" || url.trim().length === 0) {
     return { status: "invalid-url" };
   }
-  // Cheap well-formedness + scheme gate so obvious garbage ("not a url",
-  // "javascript:…") surfaces the invalid-url state immediately. The bounded
-  // download path (size / MIME / timeout / redirect) is F24's job.
+  const trimmed = url.trim();
   let parsed: URL;
   try {
-    parsed = new URL(url.trim());
+    parsed = new URL(trimmed);
   } catch {
     return { status: "invalid-url" };
   }
   if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
     return { status: "invalid-url" };
   }
-  // F24 will validate and route the URL through the bounded install flow here.
-  return { status: "not-implemented" };
+
+  const failed = (code: PluginInstallError["code"], message: string): PluginInstallResult => ({
+    status: "failed",
+    errors: [{ code, message }],
+  });
+
+  const tempPath = path.join(os.tmpdir(), `daintree-plugin-${crypto.randomUUID()}.dntr`);
+  // `redirect: "manual"` rejects immediately in Electron's net.fetch and can't
+  // count hops, so we rely on Chromium's built-in follow (capped at 20, well
+  // above the spec's 5). The size controller and the timeout signal both feed
+  // a single AbortSignal.any().
+  const sizeController = new AbortController();
+  let sizeAborted = false;
+  let wroteTempFile = false;
+
+  try {
+    const signal = AbortSignal.any([
+      sizeController.signal,
+      AbortSignal.timeout(PLUGIN_DOWNLOAD_TIMEOUT_MS),
+    ]);
+
+    let response: Response;
+    try {
+      response = await net.fetch(trimmed, { signal });
+    } catch (err) {
+      if (isAbortLikeError(err)) {
+        return failed("fetch_timeout", "The download timed out before it finished.");
+      }
+      return failed("fetch_failed", "Couldn't download the plugin from that URL.");
+    }
+
+    if (!response.ok) {
+      return failed("fetch_failed", `The server returned HTTP ${response.status}.`);
+    }
+
+    const contentLength = response.headers.get("content-length");
+    if (contentLength) {
+      const declared = Number.parseInt(contentLength, 10);
+      if (Number.isFinite(declared) && declared > PLUGIN_DOWNLOAD_MAX_BYTES) {
+        return failed("size_exceeded", "The plugin file is larger than the 30 MB limit.");
+      }
+    }
+
+    // Accept canonical zip, the optional x-dntr type, or any 2xx whose URL path
+    // ends in `.dntr` (case-insensitive for pasted URLs). response.url is
+    // unreliable in Electron, so the `.dntr` suffix is checked on the original
+    // user URL.
+    const contentType = (response.headers.get("content-type") ?? "").toLowerCase();
+    const mimeOk =
+      contentType.startsWith("application/zip") ||
+      contentType.startsWith("application/x-dntr");
+    const suffixOk = parsed.pathname.toLowerCase().endsWith(".dntr");
+    if (!mimeOk && !suffixOk) {
+      return failed(
+        "content_type_rejected",
+        "That URL didn't return a plugin archive (.dntr)."
+      );
+    }
+
+    if (!response.body) {
+      return failed("fetch_failed", "The server returned an empty response.");
+    }
+
+    let bytesRead = 0;
+    const counter = new Transform({
+      transform(chunk: Buffer, _enc, cb) {
+        bytesRead += chunk.length;
+        if (bytesRead > PLUGIN_DOWNLOAD_MAX_BYTES) {
+          sizeAborted = true;
+          sizeController.abort();
+          cb(new Error("size_exceeded"));
+          return;
+        }
+        cb(null, chunk);
+      },
+    });
+
+    wroteTempFile = true;
+    try {
+      await pipeline(
+        Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]),
+        counter,
+        createWriteStream(tempPath)
+      );
+    } catch (err) {
+      if (sizeAborted) {
+        return failed("size_exceeded", "The plugin file is larger than the 30 MB limit.");
+      }
+      if (isAbortLikeError(err)) {
+        return failed("fetch_timeout", "The download timed out before it finished.");
+      }
+      return failed("fetch_failed", "Couldn't download the plugin from that URL.");
+    }
+
+    return pluginService.installPlugin(tempPath, { source: "url", originalUrl: trimmed });
+  } finally {
+    if (wroteTempFile) {
+      await rm(tempPath, { force: true }).catch(() => {});
+    }
+  }
 }
 
 async function handleUninstall(pluginId: string, deleteSettings?: boolean): Promise<void> {

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -409,6 +409,13 @@ export interface InstalledPluginRecord {
  * - `swap_failed` — atomic rename failed but the prior state was restored
  * - `swap_unrecoverable` — rename failed AND rollback failed; on-disk state is inconsistent
  * - `load_failed` — swap committed but the new plugin failed to load
+ *
+ * Install-from-URL bounded-fetch failures (F24), produced before the archive
+ * reaches `PluginService.installPlugin`:
+ * - `fetch_failed` — non-2xx HTTP status or a network/transport error
+ * - `fetch_timeout` — the download exceeded the 10s deadline
+ * - `size_exceeded` — declared `Content-Length` or the streamed bytes exceeded 30 MB
+ * - `content_type_rejected` — response wasn't a plugin archive (bad MIME and the URL doesn't end in `.dntr`)
  */
 export type PluginInstallErrorCode =
   | "lock_failed"
@@ -420,7 +427,11 @@ export type PluginInstallErrorCode =
   | "unload_failed"
   | "swap_failed"
   | "swap_unrecoverable"
-  | "load_failed";
+  | "load_failed"
+  | "fetch_failed"
+  | "fetch_timeout"
+  | "size_exceeded"
+  | "content_type_rejected";
 
 /**
  * Structured install validation error. `path` is the JSON pointer segments

--- a/src/components/Settings/PluginsTab.tsx
+++ b/src/components/Settings/PluginsTab.tsx
@@ -437,8 +437,16 @@ export function PluginsTab() {
     try {
       const result = await window.electron.plugin.installFromUrl(url);
       handleInstallResult(result);
-      // Keep the dialog open on an invalid URL so the user can correct it.
-      if (result.status !== "invalid-url") {
+      // Keep the dialog open for URL-correctable failures so the user can edit
+      // in place: a malformed URL, a download error (404 / DNS), or a response
+      // that wasn't a plugin archive. Size/timeout failures and successful
+      // installs close it.
+      const correctable =
+        result.status === "invalid-url" ||
+        (result.status === "failed" &&
+          (result.errors[0]?.code === "fetch_failed" ||
+            result.errors[0]?.code === "content_type_rejected"));
+      if (!correctable) {
         setShowUrlDialog(false);
         setUrlInput("");
       }

--- a/src/components/Settings/PluginsTab.tsx
+++ b/src/components/Settings/PluginsTab.tsx
@@ -13,7 +13,11 @@ import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { formatRelativeTime } from "@/lib/formatRelativeTime";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { logError } from "@/utils/logger";
-import type { LoadedPluginInfo, PluginInstallSource } from "@shared/types/plugin";
+import type {
+  LoadedPluginInfo,
+  PluginInstallError,
+  PluginInstallSource,
+} from "@shared/types/plugin";
 
 /** Enabled plugins first, then alphabetically by display name. */
 function sortPlugins(list: readonly LoadedPluginInfo[]): LoadedPluginInfo[] {
@@ -38,6 +42,26 @@ const UP_TO_DATE_NOTIFICATION_DURATION_MS = 4000;
 
 function pluginLabel(plugin: LoadedPluginInfo): string {
   return plugin.manifest.displayName ?? plugin.manifest.name;
+}
+
+/**
+ * Map a structured install failure to user-facing copy. The bounded-fetch codes
+ * (F24) get tailored guidance; everything else falls back to the error's own
+ * message so manifest/engine failures still read clearly.
+ */
+function installErrorMessage(error: PluginInstallError | undefined): string {
+  switch (error?.code) {
+    case "fetch_timeout":
+      return "The download timed out. Check your connection and try again.";
+    case "size_exceeded":
+      return "That plugin is larger than the 30 MB limit.";
+    case "content_type_rejected":
+      return "That URL didn't return a plugin archive (.dntr). Check the URL and try again.";
+    case "fetch_failed":
+      return "Couldn't download the plugin. Check the URL and try again.";
+    default:
+      return error?.message ?? "Installation failed. Check the file and try again.";
+  }
 }
 
 interface PluginRowProps {
@@ -281,6 +305,7 @@ export function PluginsTab() {
     >;
   } | null>(null);
   const [isReinstalling, setIsReinstalling] = useState(false);
+  const [pendingHttpUrl, setPendingHttpUrl] = useState<string | null>(null);
 
   useSettingsTabValidation("plugins", Boolean(error));
 
@@ -385,6 +410,11 @@ export function PluginsTab() {
       case "invalid-url":
         setError("That doesn't look like a valid URL. Check it and try again.");
         return;
+      case "failed": {
+        setNotice(null);
+        setError(installErrorMessage(result.errors[0]));
+        return;
+      }
     }
   };
 
@@ -402,9 +432,7 @@ export function PluginsTab() {
     }
   };
 
-  const handleInstallFromUrl = async () => {
-    const url = urlInput.trim();
-    if (!url || isInstalling) return;
+  const performInstallFromUrl = async (url: string) => {
     setIsInstalling(true);
     try {
       const result = await window.electron.plugin.installFromUrl(url);
@@ -420,6 +448,43 @@ export function PluginsTab() {
     } finally {
       setIsInstalling(false);
     }
+  };
+
+  const handleInstallFromUrl = async () => {
+    const url = urlInput.trim();
+    if (!url || isInstalling) return;
+    // Tier D2: a plaintext HTTP download is unauthenticated and unencrypted, so
+    // gate it behind an explicit confirm before the request leaves the app. The
+    // IPC handler still accepts http:// — this is the renderer's risk surface.
+    let protocol: string;
+    try {
+      protocol = new URL(url).protocol;
+    } catch {
+      // Let the handler return invalid-url so the messaging stays consistent.
+      await performInstallFromUrl(url);
+      return;
+    }
+    if (protocol === "http:") {
+      // Stack avoidance: close the URL input and surface the confirm on its
+      // own. Cancelling reopens the input with the URL intact so the user can
+      // switch to https; confirming proceeds with the install.
+      setShowUrlDialog(false);
+      setPendingHttpUrl(url);
+      return;
+    }
+    await performInstallFromUrl(url);
+  };
+
+  const confirmHttpInstall = async () => {
+    if (!pendingHttpUrl) return;
+    const url = pendingHttpUrl;
+    setPendingHttpUrl(null);
+    await performInstallFromUrl(url);
+  };
+
+  const cancelHttpInstall = () => {
+    setPendingHttpUrl(null);
+    setShowUrlDialog(true);
   };
 
   const confirmUninstall = async () => {
@@ -643,6 +708,18 @@ export function PluginsTab() {
           </div>
         )}
       </ConfirmDialog>
+
+      <ConfirmDialog
+        isOpen={pendingHttpUrl !== null}
+        onClose={isInstalling ? undefined : cancelHttpInstall}
+        title="Install over HTTP?"
+        description="This URL doesn't use HTTPS, so the download isn't encrypted or authenticated in transit. Only continue if you trust the source."
+        confirmLabel="Install over HTTP"
+        cancelLabel="Cancel"
+        onConfirm={() => void confirmHttpInstall()}
+        isConfirmLoading={isInstalling}
+        variant="destructive"
+      />
 
       <AppDialog
         isOpen={showUrlDialog}

--- a/src/components/Settings/__tests__/PluginsTab.test.tsx
+++ b/src/components/Settings/__tests__/PluginsTab.test.tsx
@@ -462,6 +462,13 @@ describe("PluginsTab", () => {
     fireEvent.click(confirm.getByRole("button", { name: "Cancel" }));
     await waitFor(() => expect(screen.queryByText("Install over HTTP?")).toBeNull());
     expect(window.electron.plugin.installFromUrl).not.toHaveBeenCalled();
+    // Cancelling reopens the URL dialog with the typed URL intact so the user
+    // can switch to https.
+    await waitFor(() =>
+      expect((screen.getByLabelText("Plugin URL") as HTMLInputElement).value).toBe(
+        "http://example.com/p.dntr"
+      )
+    );
   });
 
   it("confirming the http warning routes the URL through installFromUrl", async () => {

--- a/src/components/Settings/__tests__/PluginsTab.test.tsx
+++ b/src/components/Settings/__tests__/PluginsTab.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { PluginsTab } from "../PluginsTab";
 import { SettingsValidationProvider } from "../SettingsValidationRegistry";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -426,6 +426,102 @@ describe("PluginsTab", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Install from file" }));
     await waitFor(() => expect(screen.getByText(/isn't available yet/)).toBeTruthy());
+  });
+
+  it("gates an http:// URL behind a confirm dialog before calling installFromUrl", async () => {
+    renderTab();
+    await waitFor(() => expect(screen.getByText("No plugins installed")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: "Install from URL" }));
+    await waitFor(() => expect(screen.getByLabelText("Plugin URL")).toBeTruthy());
+    fireEvent.change(screen.getByLabelText("Plugin URL"), {
+      target: { value: "http://example.com/p.dntr" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Install" }));
+
+    // The confirm gate appears and the IPC call has NOT fired yet.
+    await waitFor(() => expect(screen.getByText("Install over HTTP?")).toBeTruthy());
+    expect(window.electron.plugin.installFromUrl).not.toHaveBeenCalled();
+  });
+
+  it("cancelling the http confirm does not call installFromUrl", async () => {
+    renderTab();
+    await waitFor(() => expect(screen.getByText("No plugins installed")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: "Install from URL" }));
+    await waitFor(() => expect(screen.getByLabelText("Plugin URL")).toBeTruthy());
+    fireEvent.change(screen.getByLabelText("Plugin URL"), {
+      target: { value: "http://example.com/p.dntr" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Install" }));
+    await waitFor(() => expect(screen.getByText("Install over HTTP?")).toBeTruthy());
+
+    // The destructive confirm renders as an alertdialog — scope to it so the
+    // URL dialog's own "Cancel" (animating out) doesn't collide.
+    const confirm = within(screen.getByRole("alertdialog"));
+    fireEvent.click(confirm.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => expect(screen.queryByText("Install over HTTP?")).toBeNull());
+    expect(window.electron.plugin.installFromUrl).not.toHaveBeenCalled();
+  });
+
+  it("confirming the http warning routes the URL through installFromUrl", async () => {
+    (window.electron.plugin.installFromUrl as ReturnType<typeof vi.fn>).mockResolvedValue({
+      status: "installed",
+      pluginId: "acme.demo",
+    });
+    renderTab();
+    await waitFor(() => expect(screen.getByText("No plugins installed")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: "Install from URL" }));
+    await waitFor(() => expect(screen.getByLabelText("Plugin URL")).toBeTruthy());
+    fireEvent.change(screen.getByLabelText("Plugin URL"), {
+      target: { value: "http://example.com/p.dntr" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Install" }));
+    await waitFor(() => expect(screen.getByText("Install over HTTP?")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: "Install over HTTP" }));
+    await waitFor(() =>
+      expect(window.electron.plugin.installFromUrl).toHaveBeenCalledWith(
+        "http://example.com/p.dntr"
+      )
+    );
+  });
+
+  it("shows a tailored error when a URL install fails with size_exceeded", async () => {
+    (window.electron.plugin.installFromUrl as ReturnType<typeof vi.fn>).mockResolvedValue({
+      status: "failed",
+      errors: [{ code: "size_exceeded", message: "too big" }],
+    });
+    renderTab();
+    await waitFor(() => expect(screen.getByText("No plugins installed")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: "Install from URL" }));
+    await waitFor(() => expect(screen.getByLabelText("Plugin URL")).toBeTruthy());
+    fireEvent.change(screen.getByLabelText("Plugin URL"), {
+      target: { value: "https://example.com/p.dntr" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Install" }));
+
+    await waitFor(() => expect(screen.getByText(/larger than the 30 MB limit/)).toBeTruthy());
+  });
+
+  it("shows a tailored error when a URL install times out", async () => {
+    (window.electron.plugin.installFromUrl as ReturnType<typeof vi.fn>).mockResolvedValue({
+      status: "failed",
+      errors: [{ code: "fetch_timeout", message: "slow" }],
+    });
+    renderTab();
+    await waitFor(() => expect(screen.getByText("No plugins installed")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: "Install from URL" }));
+    await waitFor(() => expect(screen.getByLabelText("Plugin URL")).toBeTruthy());
+    fireEvent.change(screen.getByLabelText("Plugin URL"), {
+      target: { value: "https://example.com/p.dntr" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Install" }));
+
+    await waitFor(() => expect(screen.getByText(/download timed out/)).toBeTruthy());
   });
 
   it("re-fetches the list when a provenance-changed event fires", async () => {


### PR DESCRIPTION
## Summary

- Implements the bounded HTTP fetch for plugin install-from-URL — the handler was a not-implemented stub before this.
- `handleInstallFromUrl` now downloads `.dntr` archives via Electron `net.fetch` with a 10s timeout (`AbortSignal.timeout`), a 30 MB hard cap enforced via `Content-Length` pre-check and a mid-stream byte-counter `Transform` that aborts the in-flight request, and a content-type allowlist (`application/zip` / `application/x-dntr`, charset params tolerated) with a `.dntr` URL suffix fallback.
- Streams to an `os.tmpdir()` temp file (cleaned up in `finally`) and hands off to `PluginService.installPlugin` with `source: "url"` and `originalUrl` provenance.
- Adds four fetch-specific `PluginInstallErrorCode` values (`fetch_failed`, `fetch_timeout`, `size_exceeded`, `content_type_rejected`) folded into the existing failed result arm.
- Renderer gates `http://` installs behind a Tier-D2 confirm dialog, maps error codes to tailored copy, and keeps the URL dialog open on URL-correctable failures.

Resolves #9296

## Changes

- `electron/ipc/handlers/plugin.ts` — full `handleInstallFromUrl` implementation replacing the stub
- `shared/types/plugin.ts` — four new `PluginInstallErrorCode` values
- `src/components/Settings/PluginsTab.tsx` — HTTP confirm dialog + per-code error copy + dialog-open-on-failure logic
- `electron/ipc/handlers/__tests__/plugin.handlers.test.ts` — 77 handler tests (fetch success, MIME variants, size cap, mid-stream abort, timeout, scheme rejection, installPlugin passthrough)
- `src/components/Settings/__tests__/PluginsTab.test.tsx` — 24 renderer tests

Known `net.fetch` redirect limitations are documented inline: Chromium caps at 20 redirects (spec recommends 5); `redirect: "manual"` rejects immediately so Chromium's built-in follow is used; `response.url` is unreliable in Electron so the input URL is preserved as `originalUrl`.

## Testing

- 77 handler tests + 24 `PluginsTab` tests pass
- Full `npm run check` pipeline green (typecheck, lint, format, build)