### PR TITLE
feat(plugins): drag-and-drop .dntr install in settings tab

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -802,6 +802,7 @@ export const CHANNELS = {
   PLUGIN_INSTALL: "plugin:install",
   PLUGIN_SET_ENABLED: "plugin:set-enabled",
   PLUGIN_INSTALL_FROM_FILE: "plugin:install-from-file",
+  PLUGIN_INSTALL_FROM_PATH: "plugin:install-from-path",
   PLUGIN_INSTALL_FROM_URL: "plugin:install-from-url",
   PLUGIN_UNINSTALL: "plugin:uninstall",
   PLUGIN_CHECK_FOR_UPDATE: "plugin:check-for-update",

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -1,13 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const mockDispatchHandler = vi.fn();
 const mockRegisterHandler = vi.fn();
 const mockRemoveHandlers = vi.fn();
 const mockListPlugins = vi.fn();
 const mockSetEnabled = vi.fn();
+const mockInstallPlugin = vi.fn();
 const mockUninstallPlugin = vi.fn();
 const mockCheckForUpdate = vi.fn();
-const mockInstallPlugin = vi.fn();
 const mockListPluginActions = vi.fn();
 const mockRegisterPluginAction = vi.fn();
 const mockUnregisterPluginAction = vi.fn();
@@ -16,9 +19,9 @@ vi.mock("../../../services/PluginService.js", () => ({
   pluginService: {
     listPlugins: (...args: unknown[]) => mockListPlugins(...args),
     setEnabled: (...args: unknown[]) => mockSetEnabled(...args),
+    installPlugin: (...args: unknown[]) => mockInstallPlugin(...args),
     uninstallPlugin: (...args: unknown[]) => mockUninstallPlugin(...args),
     checkForUpdate: (...args: unknown[]) => mockCheckForUpdate(...args),
-    installPlugin: (...args: unknown[]) => mockInstallPlugin(...args),
     dispatchHandler: (...args: unknown[]) => mockDispatchHandler(...args),
     registerHandler: (...args: unknown[]) => mockRegisterHandler(...args),
     removeHandlers: (...args: unknown[]) => mockRemoveHandlers(...args),
@@ -112,12 +115,16 @@ beforeEach(() => {
 describe("registerPluginHandlers", () => {
   it("registers handlers for all plugin channels", () => {
     registerPluginHandlers();
-    expect(mockIpcMainHandle).toHaveBeenCalledTimes(30);
+    expect(mockIpcMainHandle).toHaveBeenCalledTimes(31);
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:list", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:install", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:set-enabled", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith(
       "plugin:install-from-file",
+      expect.any(Function)
+    );
+    expect(mockIpcMainHandle).toHaveBeenCalledWith(
+      "plugin:install-from-path",
       expect.any(Function)
     );
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:install-from-url", expect.any(Function));
@@ -199,6 +206,7 @@ describe("registerPluginHandlers", () => {
     const cleanup = registerPluginHandlers();
     cleanup();
     expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:list");
+    expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:install-from-path");
     expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:invoke");
     expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:toolbar-buttons");
     expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:menu-items");
@@ -505,6 +513,82 @@ describe("registerPluginHandlers", () => {
       status: "failed",
       errors: [{ code: "manifest_invalid", message: "bad manifest" }],
     });
+  });
+
+  it("PLUGIN_INSTALL_FROM_PATH rejects an empty path without touching the installer", async () => {
+    const handler = getHandler("plugin:install-from-path");
+    const result = await handler({}, "");
+    expect(result).toEqual({
+      status: "failed",
+      errors: [{ code: "archive_invalid", message: expect.any(String) }],
+    });
+    expect(mockInstallPlugin).not.toHaveBeenCalled();
+  });
+
+  it("PLUGIN_INSTALL_FROM_PATH rejects a relative path", async () => {
+    const handler = getHandler("plugin:install-from-path");
+    const result = await handler({}, "relative/plugin.dntr");
+    expect(result).toMatchObject({ status: "failed" });
+    expect(mockInstallPlugin).not.toHaveBeenCalled();
+  });
+
+  it("PLUGIN_INSTALL_FROM_PATH rejects a non-.dntr extension", async () => {
+    const handler = getHandler("plugin:install-from-path");
+    const result = await handler({}, "/tmp/not-a-plugin.txt");
+    expect(result).toEqual({
+      status: "failed",
+      errors: [{ code: "archive_invalid", message: "Only .dntr files can be installed" }],
+    });
+    expect(mockInstallPlugin).not.toHaveBeenCalled();
+  });
+
+  it("PLUGIN_INSTALL_FROM_PATH fails when the file can't be read", async () => {
+    const handler = getHandler("plugin:install-from-path");
+    const result = await handler({}, "/tmp/does-not-exist-9295.dntr");
+    expect(result).toMatchObject({ status: "failed" });
+    expect(mockInstallPlugin).not.toHaveBeenCalled();
+  });
+
+  it("PLUGIN_INSTALL_FROM_PATH rejects a file without the ZIP magic bytes", async () => {
+    const file = join(tmpdir(), `plugin-bad-magic-${process.pid}.dntr`);
+    await writeFile(file, Buffer.from("not a zip"));
+    try {
+      const handler = getHandler("plugin:install-from-path");
+      const result = await handler({}, file);
+      expect(result).toMatchObject({ status: "failed" });
+      expect(mockInstallPlugin).not.toHaveBeenCalled();
+    } finally {
+      await rm(file, { force: true });
+    }
+  });
+
+  it("PLUGIN_INSTALL_FROM_PATH delegates to installPlugin for a valid .dntr archive", async () => {
+    const file = join(tmpdir(), `plugin-good-magic-${process.pid}.dntr`);
+    // ZIP local-file-header signature + filler so the 4-byte read succeeds.
+    await writeFile(file, Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00, 0x00]));
+    mockInstallPlugin.mockResolvedValue({ status: "installed", pluginId: "acme.dropped" });
+    try {
+      const handler = getHandler("plugin:install-from-path");
+      const result = await handler({}, file);
+      expect(mockInstallPlugin).toHaveBeenCalledWith(file);
+      expect(result).toEqual({ status: "installed", pluginId: "acme.dropped" });
+    } finally {
+      await rm(file, { force: true });
+    }
+  });
+
+  it("PLUGIN_INSTALL_FROM_PATH accepts an uppercase .DNTR extension", async () => {
+    const file = join(tmpdir(), `plugin-upper-${process.pid}.DNTR`);
+    await writeFile(file, Buffer.from([0x50, 0x4b, 0x03, 0x04]));
+    mockInstallPlugin.mockResolvedValue({ status: "installed", pluginId: "acme.upper" });
+    try {
+      const handler = getHandler("plugin:install-from-path");
+      const result = await handler({}, file);
+      expect(mockInstallPlugin).toHaveBeenCalledWith(file);
+      expect(result).toEqual({ status: "installed", pluginId: "acme.upper" });
+    } finally {
+      await rm(file, { force: true });
+    }
   });
 
   it("PLUGIN_UNINSTALL delegates to pluginService.uninstallPlugin", async () => {

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -528,7 +528,7 @@ describe("registerPluginHandlers", () => {
   it("PLUGIN_INSTALL_FROM_PATH rejects a relative path", async () => {
     const handler = getHandler("plugin:install-from-path");
     const result = await handler({}, "relative/plugin.dntr");
-    expect(result).toMatchObject({ status: "failed" });
+    expect(result).toMatchObject({ status: "failed", errors: [{ code: "archive_invalid" }] });
     expect(mockInstallPlugin).not.toHaveBeenCalled();
   });
 
@@ -545,7 +545,7 @@ describe("registerPluginHandlers", () => {
   it("PLUGIN_INSTALL_FROM_PATH fails when the file can't be read", async () => {
     const handler = getHandler("plugin:install-from-path");
     const result = await handler({}, "/tmp/does-not-exist-9295.dntr");
-    expect(result).toMatchObject({ status: "failed" });
+    expect(result).toMatchObject({ status: "failed", errors: [{ code: "archive_invalid" }] });
     expect(mockInstallPlugin).not.toHaveBeenCalled();
   });
 
@@ -555,7 +555,7 @@ describe("registerPluginHandlers", () => {
     try {
       const handler = getHandler("plugin:install-from-path");
       const result = await handler({}, file);
-      expect(result).toMatchObject({ status: "failed" });
+      expect(result).toMatchObject({ status: "failed", errors: [{ code: "archive_invalid" }] });
       expect(mockInstallPlugin).not.toHaveBeenCalled();
     } finally {
       await rm(file, { force: true });

--- a/electron/ipc/handlers/plugin.preload.ts
+++ b/electron/ipc/handlers/plugin.preload.ts
@@ -10,6 +10,7 @@ export const PLUGIN_METHOD_CHANNELS = {
   install: "plugin:install",
   setEnabled: "plugin:set-enabled",
   installFromFile: "plugin:install-from-file",
+  installFromPath: "plugin:install-from-path",
   installFromUrl: "plugin:install-from-url",
   uninstall: "plugin:uninstall",
   checkForUpdate: "plugin:check-for-update",

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -1,10 +1,10 @@
 import { ipcMain, dialog, BrowserWindow, net } from "electron";
-import { writeFile, rm } from "node:fs/promises";
+import { open, writeFile, rm } from "node:fs/promises";
 import { createWriteStream } from "node:fs";
 import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import os from "node:os";
-import path from "node:path";
+import path, { extname, isAbsolute } from "node:path";
 import crypto from "node:crypto";
 import { CHANNELS } from "../channels.js";
 import { defineIpcNamespace, op } from "../define.js";
@@ -128,6 +128,57 @@ function isAbortLikeError(err: unknown): boolean {
   if (typeof err !== "object" || err === null) return false;
   const name = (err as { name?: unknown }).name;
   return name === "AbortError" || name === "TimeoutError";
+}
+
+// Local-file-header signature that prefixes every ZIP (and therefore every
+// `.dntr`) archive. Cheap structural gate before the path reaches #9292's
+// atomic install flow.
+const ZIP_MAGIC = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
+
+/**
+ * Install a plugin from a path produced by a drag-and-drop onto the Plugin
+ * settings tab (#9295). The renderer resolves the native path via the
+ * plugin-scoped `getDroppedFilePath` bridge and hands it here; main owns every
+ * trust gate because the renderer can't be trusted to validate before #9292
+ * runs: the path must be a non-empty absolute `.dntr`, and its first four bytes
+ * must be the ZIP magic. Only the header is read — never the whole archive —
+ * so a hostile multi-GB file can't be slurped into memory. All failures come
+ * back as structured `{ status: "failed" }` data (never thrown) so the tab can
+ * render an inline message.
+ */
+async function handleInstallFromPath(path: string): Promise<PluginInstallResult> {
+  const fail = (message: string): PluginInstallResult => ({
+    status: "failed",
+    errors: [{ code: "archive_invalid", message }],
+  });
+  if (typeof path !== "string" || path.length === 0) {
+    return fail("Couldn't resolve the dropped file's path");
+  }
+  // Segment-aware guards, never a `..` substring match (#4702): require an
+  // absolute path and a `.dntr` extension before touching the filesystem.
+  if (!isAbsolute(path)) {
+    return fail("Install path must be an absolute filesystem path");
+  }
+  if (extname(path).toLowerCase() !== ".dntr") {
+    return fail("Only .dntr files can be installed");
+  }
+  let header: Buffer;
+  try {
+    const fh = await open(path, "r");
+    try {
+      const buf = Buffer.alloc(4);
+      const { bytesRead } = await fh.read(buf, 0, 4, 0);
+      header = buf.subarray(0, bytesRead);
+    } finally {
+      await fh.close();
+    }
+  } catch {
+    return fail("Couldn't read the dropped file");
+  }
+  if (header.length < 4 || !header.equals(ZIP_MAGIC)) {
+    return fail("That file isn't a valid .dntr plugin archive");
+  }
+  return pluginService.installPlugin(path);
 }
 
 /**
@@ -672,6 +723,7 @@ export const pluginNamespace = defineIpcNamespace({
     installFromFile: op(PLUGIN_METHOD_CHANNELS.installFromFile, handleInstallFromFile, {
       withContext: true,
     }),
+    installFromPath: op(PLUGIN_METHOD_CHANNELS.installFromPath, handleInstallFromPath),
     installFromUrl: op(PLUGIN_METHOD_CHANNELS.installFromUrl, handleInstallFromUrl),
     uninstall: op(PLUGIN_METHOD_CHANNELS.uninstall, handleUninstall),
     checkForUpdate: op(PLUGIN_METHOD_CHANNELS.checkForUpdate, handleCheckForUpdate),

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2461,6 +2461,14 @@ const api: ElectronAPI = {
   plugin: {
     ...buildPluginPreloadBindings(_unwrappingInvoke),
 
+    // Plugin-scoped bridge to the native filesystem path of a dropped File.
+    // `webUtils.getPathForFile` must run in the preload (Electron 32 removed
+    // `File.path`). Confined to the plugin namespace — deliberately NOT a
+    // global `window.electron` method — so arbitrary native-path recovery
+    // stays bounded to the plugin install surface (#9295). Returns `""` for
+    // synthetic/non-disk File objects; the renderer treats empty as an error.
+    getDroppedFilePath: (file: File): string => webUtils.getPathForFile(file),
+
     // plugin:invoke uses raw ipcMain.handle with variadic args — its signature
     // can't be expressed through IpcInvokeMap, so it stays inline.
     invoke: (pluginId: string, channel: string, ...args: unknown[]) =>

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1481,6 +1481,14 @@ export interface ElectronAPI extends GeneratedElectronAPI {
   // helpers that aren't expressible through IpcInvokeMap, and the on*
   // entries are renderer-only subscriptions.
   plugin: GeneratedElectronAPI["plugin"] & {
+    /**
+     * Resolve the absolute native filesystem path of a dropped File via
+     * `webUtils.getPathForFile`. Plugin-scoped (never exposed globally) so
+     * native-path recovery stays confined to the plugin install surface
+     * (#9295). Returns `""` for synthetic/non-disk File objects (clipboard
+     * paste, virtual files) — treat empty as a structured error.
+     */
+    getDroppedFilePath(file: File): string;
     invoke(pluginId: string, channel: string, ...args: unknown[]): Promise<unknown>;
     on(pluginId: string, channel: string, callback: (payload: unknown) => void): () => void;
     /** Subscribe to plugin-action registry changes. Returns a cleanup. */

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -386,6 +386,9 @@ export interface GeneratedElectronAPI {
     installFromFile(
       ...args: IpcInvokeMap["plugin:install-from-file"]["args"]
     ): Promise<IpcInvokeMap["plugin:install-from-file"]["result"]>;
+    installFromPath(
+      ...args: IpcInvokeMap["plugin:install-from-path"]["args"]
+    ): Promise<IpcInvokeMap["plugin:install-from-path"]["result"]>;
     installFromUrl(
       ...args: IpcInvokeMap["plugin:install-from-url"]["args"]
     ): Promise<IpcInvokeMap["plugin:install-from-url"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -667,6 +667,10 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: import("../plugin.js").PluginInstallResult;
   };
+  "plugin:install-from-path": {
+    args: [path: string];
+    result: import("../plugin.js").PluginInstallResult;
+  };
   "plugin:install-from-url": {
     args: [url: string];
     result: import("../plugin.js").PluginInstallResult;

--- a/src/components/Settings/PluginsTab.tsx
+++ b/src/components/Settings/PluginsTab.tsx
@@ -1,5 +1,14 @@
 import { useEffect, useRef, useState } from "react";
-import { Plug, AlertCircle, FilePlus, Link2, Trash2, RefreshCw, Info } from "lucide-react";
+import {
+  Plug,
+  AlertCircle,
+  FilePlus,
+  Link2,
+  Trash2,
+  RefreshCw,
+  Info,
+  Download,
+} from "lucide-react";
 import { SettingsSwitch } from "@/components/Settings/SettingsSwitch";
 import { PluginSettingsForm } from "@/components/Settings/PluginSettingsForm";
 import { Button } from "@/components/ui/button";
@@ -306,6 +315,11 @@ export function PluginsTab() {
   } | null>(null);
   const [isReinstalling, setIsReinstalling] = useState(false);
   const [pendingHttpUrl, setPendingHttpUrl] = useState<string | null>(null);
+  // Integer depth counter so the overlay survives child enter/leave churn
+  // without flicker (same pattern as the terminal drop zone). The boolean is
+  // derived from it for the overlay render.
+  const dragDepthRef = useRef(0);
+  const [isDragOverFiles, setIsDragOverFiles] = useState(false);
 
   useSettingsTabValidation("plugins", Boolean(error));
 
@@ -495,6 +509,75 @@ export function PluginsTab() {
     setShowUrlDialog(true);
   };
 
+  // Install one or more dropped `.dntr` files sequentially through #9292's
+  // install lock — one dialog per file, no batch UX (#9295). Non-`.dntr` drops
+  // surface a quiet inline notice; an empty path (synthetic File object that
+  // `getDroppedFilePath` can't resolve) is a structured error, not a missing
+  // file.
+  const installDroppedFiles = async (files: File[]) => {
+    const dntrFiles = files.filter((f) => f.name.toLowerCase().endsWith(".dntr"));
+    if (dntrFiles.length === 0) {
+      setError(null);
+      setNotice("Only .dntr files can be installed.");
+      return;
+    }
+    if (isInstalling) return;
+    setNotice(null);
+    setIsInstalling(true);
+    try {
+      for (const file of dntrFiles) {
+        const path = window.electron.plugin.getDroppedFilePath(file);
+        if (!path) {
+          setNotice(null);
+          setError("Couldn't read that file's location — try Install from file instead.");
+          continue;
+        }
+        const result = await window.electron.plugin.installFromPath(path);
+        handleInstallResult(result);
+      }
+    } catch (err) {
+      setError(formatErrorMessage(err, "Failed to install plugin"));
+      logError("Failed to install plugin from drop", err);
+    } finally {
+      setIsInstalling(false);
+    }
+  };
+
+  const handleDragEnter = (e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes("Files")) return;
+    e.preventDefault();
+    e.stopPropagation();
+    dragDepthRef.current++;
+    if (dragDepthRef.current === 1) setIsDragOverFiles(true);
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes("Files")) return;
+    e.preventDefault();
+    e.stopPropagation();
+    e.dataTransfer.dropEffect = "copy";
+  };
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes("Files")) return;
+    e.stopPropagation();
+    dragDepthRef.current--;
+    if (dragDepthRef.current <= 0) {
+      dragDepthRef.current = 0;
+      setIsDragOverFiles(false);
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes("Files")) return;
+    e.preventDefault();
+    e.stopPropagation();
+    dragDepthRef.current = 0;
+    setIsDragOverFiles(false);
+    const files = Array.from(e.dataTransfer.files);
+    if (files.length > 0) void installDroppedFiles(files);
+  };
+
   const confirmUninstall = async () => {
     if (!pendingUninstall) return;
     const id = pendingUninstall.manifest.name;
@@ -581,7 +664,19 @@ export function PluginsTab() {
   };
 
   return (
-    <div className="space-y-6">
+    <div
+      className="relative space-y-6"
+      onDragEnter={handleDragEnter}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      {isDragOverFiles && (
+        <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 rounded-[var(--radius-lg)] bg-daintree-bg/80 ring-2 ring-daintree-accent pointer-events-none">
+          <Download className="w-6 h-6 text-daintree-accent" aria-hidden="true" />
+          <p className="text-sm font-medium text-daintree-text">Drop a .dntr file to install</p>
+        </div>
+      )}
       <div className="flex items-start justify-between gap-4">
         <div>
           <h3 className="text-sm font-medium text-daintree-text">Installed plugins</h3>

--- a/src/components/Settings/PluginsTab.tsx
+++ b/src/components/Settings/PluginsTab.tsx
@@ -320,6 +320,10 @@ export function PluginsTab() {
   // derived from it for the overlay render.
   const dragDepthRef = useRef(0);
   const [isDragOverFiles, setIsDragOverFiles] = useState(false);
+  // Synchronous mutex for the drop install loop. The `isInstalling` state lags
+  // a render, so two drops dispatched before React flushes could both read a
+  // stale `false`; the ref flips immediately and serializes them.
+  const installingRef = useRef(false);
 
   useSettingsTabValidation("plugins", Boolean(error));
 
@@ -521,26 +525,38 @@ export function PluginsTab() {
       setNotice("Only .dntr files can be installed.");
       return;
     }
-    if (isInstalling) return;
+    if (installingRef.current) return;
+    installingRef.current = true;
     setNotice(null);
+    setError(null);
     setIsInstalling(true);
+    // Collect per-file failures so a later file's success can't silently clear
+    // an earlier file's error (the loop installs one file at a time).
+    const failures: string[] = [];
     try {
       for (const file of dntrFiles) {
         const path = window.electron.plugin.getDroppedFilePath(file);
         if (!path) {
-          setNotice(null);
-          setError("Couldn't read that file's location — try Install from file instead.");
+          failures.push(`${file.name} — couldn't read its location, try Install from file`);
           continue;
         }
-        const result = await window.electron.plugin.installFromPath(path);
-        handleInstallResult(result);
+        try {
+          const result = await window.electron.plugin.installFromPath(path);
+          if (result.status === "failed") {
+            failures.push(`${file.name} — ${result.errors[0]?.message ?? "install failed"}`);
+          } else {
+            handleInstallResult(result);
+          }
+        } catch (err) {
+          failures.push(`${file.name} — ${formatErrorMessage(err, "install failed")}`);
+          logError("Failed to install plugin from drop", err);
+        }
       }
-    } catch (err) {
-      setError(formatErrorMessage(err, "Failed to install plugin"));
-      logError("Failed to install plugin from drop", err);
     } finally {
+      installingRef.current = false;
       setIsInstalling(false);
     }
+    if (failures.length > 0) setError(failures.join("; "));
   };
 
   const handleDragEnter = (e: React.DragEvent) => {

--- a/src/components/Settings/PluginsTab.tsx
+++ b/src/components/Settings/PluginsTab.tsx
@@ -688,8 +688,8 @@ export function PluginsTab() {
       onDrop={handleDrop}
     >
       {isDragOverFiles && (
-        <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 rounded-[var(--radius-lg)] bg-daintree-bg/80 ring-2 ring-daintree-accent pointer-events-none">
-          <Download className="w-6 h-6 text-daintree-accent" aria-hidden="true" />
+        <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 rounded-[var(--radius-lg)] bg-daintree-bg/80 border-2 border-dashed border-daintree-border pointer-events-none">
+          <Download className="w-6 h-6 text-daintree-text/60" aria-hidden="true" />
           <p className="text-sm font-medium text-daintree-text">Drop a .dntr file to install</p>
         </div>
       )}


### PR DESCRIPTION
## Summary

- Wires drag-and-drop `.dntr` plugin installation into the Plugin Settings tab (#9295, under epic #5651). The whole tab is a drop target so there's no precise zone to aim for.
- Dropped files resolve their native path through a new `plugin.getDroppedFilePath` preload bridge wrapping `webUtils.getPathForFile` (Electron 32 removed `File.path`), then route through a new `plugin:install-from-path` IPC handler that validates the path and ZIP magic bytes (`PK\x03\x04`, first 4 bytes only) before handing off to the existing #9292 installer.
- Non-`.dntr` drops get a quiet inline "Only .dntr files can be installed." notice — no toast. Multi-file drops install sequentially through #9292's lock; per-file failures are collected so a later success can't mask an earlier one.

Resolves #9295

## Changes

- `electron/preload.cts` — new `plugin.getDroppedFilePath(file)` bridge, deliberately scoped to the plugin namespace rather than exposed globally, keeping native-path recovery bounded to the install surface
- `electron/ipc/channels.ts` + `electron/ipc/handlers/plugin.ts` — new `plugin:install-from-path` handler with path validation (non-empty, absolute, `.dntr` extension) and magic-byte check
- `electron/ipc/handlers/plugin.preload.ts` — registers the new channel
- `shared/types/ipc/api.ts` + generated types — `installFromPath` added to the plugin namespace
- `src/components/Settings/PluginsTab.tsx` — drop zone overlay, `dragDepthRef` integer-depth counter (avoids child enter/leave flicker), `installDroppedFiles` sequential loop, handlers for `dragenter`/`dragover`/`dragleave`/`drop`

## Testing

7 new `plugin:install-from-path` handler tests in `plugin.handlers.test.ts` using real temp files: empty path, relative path, wrong extension, unreadable file, bad magic bytes, valid `.dntr`, and case-insensitive `.DNTR`. Channel drift guard passes (27 handlers, was 26). `npm run check` clean.