### PR TITLE
feat(plugins): sideload .dntr archives from the Windows + Linux second-instance event

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,0 +1,33 @@
+; Custom NSIS include for the per-user `.dntr` (Daintree plugin archive) file
+; association. electron-builder's built-in `fileAssociations` writes to HKLM and
+; requires `perMachine: true`, which would force UAC elevation on install and on
+; every auto-update. Daintree ships a per-user (HKCU) installer, so the
+; association is registered by hand here under HKCU\Software\Classes instead.
+;
+; Double-clicking a `.dntr` file then launches Daintree with the file path as a
+; bare argv entry, which app's `second-instance` handler validates and sideloads
+; (see electron/lifecycle/appLifecycle.ts).
+
+!macro customInstall
+  ; ProgID describing the plugin-archive document type.
+  WriteRegStr HKCU "Software\Classes\Daintree.Plugin" "" "Daintree Plugin"
+  WriteRegStr HKCU "Software\Classes\Daintree.Plugin\DefaultIcon" "" "$INSTDIR\${APP_EXECUTABLE_FILENAME},0"
+  WriteRegStr HKCU "Software\Classes\Daintree.Plugin\shell\open\command" "" '"$INSTDIR\${APP_EXECUTABLE_FILENAME}" "%1"'
+
+  ; Map the `.dntr` extension to the ProgID.
+  WriteRegStr HKCU "Software\Classes\.dntr" "" "Daintree.Plugin"
+
+  ; Tell the shell the association table changed so Explorer picks it up now.
+  System::Call 'shell32::SHChangeNotify(i 0x08000000, i 0, i 0, i 0)'
+!macroend
+
+!macro customUnInstall
+  DeleteRegKey HKCU "Software\Classes\Daintree.Plugin"
+  ; Only drop the extension mapping if it still points at our ProgID, so a
+  ; different handler that claimed `.dntr` since install is left untouched.
+  ReadRegStr $0 HKCU "Software\Classes\.dntr" ""
+  StrCmp $0 "Daintree.Plugin" 0 +2
+    DeleteRegKey HKCU "Software\Classes\.dntr"
+
+  System::Call 'shell32::SHChangeNotify(i 0x08000000, i 0, i 0, i 0)'
+!macroend

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -175,6 +175,14 @@ module.exports = async function () {
       uninstallDisplayName: "Daintree",
       differentialPackage: true,
       buildUniversalInstaller: false,
+      // `.dntr` (plugin archive) file association is registered via a custom
+      // NSIS include rather than electron-builder's `fileAssociations`: the
+      // built-in path requires `perMachine: true` (HKLM, system-wide), which
+      // would force elevation on install AND on every auto-update. We keep the
+      // per-user (HKCU) install model and register the association by hand in
+      // build/installer.nsh. Double-clicking a `.dntr` then launches Daintree
+      // with the file path in argv, picked up by the second-instance handler.
+      include: "build/installer.nsh",
     },
     linux: {
       icon: "build/icon.png",
@@ -182,6 +190,17 @@ module.exports = async function () {
       target: ["AppImage", "deb"],
       category: "Development",
       desktop: { entry: { StartupWMClass: "daintree" } },
+      // `.dntr` plugin-archive association. electron-builder generates the XDG
+      // mime-type XML and adds `MimeType=application/x-dntr` to the .desktop
+      // entry; double-clicking then launches Daintree with the path in argv.
+      fileAssociations: [
+        {
+          ext: "dntr",
+          name: "Daintree Plugin",
+          description: "Daintree plugin archive",
+          mimeType: "application/x-dntr",
+        },
+      ],
       extraResources: [
         { from: "scripts/daintree-cli.sh", to: "daintree-cli.sh" },
         { from: "build/linux/daintree.apparmor", to: "daintree.apparmor" },

--- a/electron/lifecycle/__tests__/appLifecycle.test.ts
+++ b/electron/lifecycle/__tests__/appLifecycle.test.ts
@@ -552,9 +552,9 @@ describe("extractDntrPaths", () => {
 
   it("skips flag arguments and non-.dntr paths", async () => {
     const { extractDntrPaths } = await import("../appLifecycle.js");
-    expect(
-      extractDntrPaths(["daintree", "--cli-path", "/dir", "--foo=bar.dntr"], "/work")
-    ).toEqual([]);
+    expect(extractDntrPaths(["daintree", "--cli-path", "/dir", "--foo=bar.dntr"], "/work")).toEqual(
+      []
+    );
   });
 
   it("returns both .dntr paths when the OS passes multiple", async () => {
@@ -588,10 +588,7 @@ describe("installDntrPath / drainPendingDntrPaths", () => {
   const tmpFiles: string[] = [];
 
   function makeDntrFile(magic: boolean): string {
-    const p = nodePath.join(
-      os.tmpdir(),
-      `dntr-test-${tmpFiles.length}-${process.pid}.dntr`
-    );
+    const p = nodePath.join(os.tmpdir(), `dntr-test-${tmpFiles.length}-${process.pid}.dntr`);
     const header = magic ? Buffer.from([0x50, 0x4b, 0x03, 0x04]) : Buffer.from("not a zip");
     fs.writeFileSync(p, Buffer.concat([header, Buffer.from("rest")]));
     tmpFiles.push(p);
@@ -830,7 +827,8 @@ describe("registerAppLifecycleHandlers – second-instance .dntr handling", () =
   });
 
   it("queues a .dntr archive when no window exists yet", async () => {
-    const { registerAppLifecycleHandlers, getPendingDntrPaths } = await import("../appLifecycle.js");
+    const { registerAppLifecycleHandlers, getPendingDntrPaths } =
+      await import("../appLifecycle.js");
     registerAppLifecycleHandlers(makeOpts({ getMainWindow: vi.fn(() => null) }));
 
     getHandler()({}, ["daintree", dntrFile], "/work");

--- a/electron/lifecycle/__tests__/appLifecycle.test.ts
+++ b/electron/lifecycle/__tests__/appLifecycle.test.ts
@@ -38,8 +38,22 @@ vi.mock("../windowRecreationState.js", () => ({
   isWindowRecreating: isWindowRecreatingMock,
 }));
 
+// `broadcastToRenderer` pulls a heavy main-process chain (windowRef, ipcMain);
+// mock it so importing appLifecycle in tests stays cheap and toasts are
+// assertable. `pluginService` is dynamically imported inside installDntrPath.
+vi.mock("../../ipc/utils.js", () => ({ broadcastToRenderer: vi.fn() }));
+const installPluginMock = vi.hoisted(() => vi.fn());
+vi.mock("../../services/PluginService.js", () => ({
+  pluginService: { installPlugin: installPluginMock },
+}));
+
+import fs from "node:fs";
+import os from "node:os";
+import nodePath from "node:path";
 import type { AppLifecycleOptions } from "../appLifecycle.js";
 import { handleDirectoryOpen } from "../../menu.js";
+import { broadcastToRenderer } from "../../ipc/utils.js";
+import { CHANNELS } from "../../ipc/channels.js";
 import { SAFETY_BELT_TIMEOUT_MS } from "../shutdownConfig.js";
 
 function makeOpts(overrides?: Partial<AppLifecycleOptions>): AppLifecycleOptions {
@@ -502,5 +516,277 @@ describe("registerWindowSessionEndHandler – Windows planned-shutdown wiring", 
 
     const winOn = win.on as unknown as ReturnType<typeof vi.fn>;
     expect(winOn).not.toHaveBeenCalled();
+  });
+});
+
+describe("extractDntrPaths", () => {
+  it("returns absolute .dntr paths unchanged", async () => {
+    const { extractDntrPaths } = await import("../appLifecycle.js");
+    const abs = nodePath.resolve("/abs/Plugin.dntr");
+    expect(extractDntrPaths(["daintree", abs], "/work")).toEqual([abs]);
+  });
+
+  it("resolves relative .dntr paths against the second instance's workingDirectory", async () => {
+    const { extractDntrPaths } = await import("../appLifecycle.js");
+    const workdir = nodePath.resolve("/work");
+    expect(extractDntrPaths(["daintree", "plugin.dntr"], workdir)).toEqual([
+      nodePath.join(workdir, "plugin.dntr"),
+    ]);
+  });
+
+  it("matches the extension case-insensitively", async () => {
+    const { extractDntrPaths } = await import("../appLifecycle.js");
+    const result = extractDntrPaths(["daintree", "/a/Plugin.DNTR"], "/work");
+    expect(result).toHaveLength(1);
+    expect(result[0].toLowerCase().endsWith(".dntr")).toBe(true);
+  });
+
+  it("recognizes a Windows-style .dntr argument", async () => {
+    const { extractDntrPaths } = await import("../appLifecycle.js");
+    // Resolution differs on a POSIX test host, but the extension filter must
+    // still flag the entry.
+    const result = extractDntrPaths(["daintree", "C:\\Users\\a\\Plugin.DNTR"], "C:\\Users\\a");
+    expect(result).toHaveLength(1);
+    expect(result[0].toLowerCase().endsWith(".dntr")).toBe(true);
+  });
+
+  it("skips flag arguments and non-.dntr paths", async () => {
+    const { extractDntrPaths } = await import("../appLifecycle.js");
+    expect(
+      extractDntrPaths(["daintree", "--cli-path", "/dir", "--foo=bar.dntr"], "/work")
+    ).toEqual([]);
+  });
+
+  it("returns both .dntr paths when the OS passes multiple", async () => {
+    const { extractDntrPaths } = await import("../appLifecycle.js");
+    const a = nodePath.resolve("/a/one.dntr");
+    const b = nodePath.resolve("/b/two.dntr");
+    expect(extractDntrPaths(["daintree", a, b], "/work")).toEqual([a, b]);
+  });
+
+  it("returns an empty array when no .dntr path is present", async () => {
+    const { extractDntrPaths } = await import("../appLifecycle.js");
+    expect(extractDntrPaths(["daintree"], "/work")).toEqual([]);
+  });
+});
+
+describe("installDntrPath / drainPendingDntrPaths", () => {
+  const tmpFiles: string[] = [];
+
+  function makeDntrFile(magic: boolean): string {
+    const p = nodePath.join(
+      os.tmpdir(),
+      `dntr-test-${tmpFiles.length}-${process.pid}.dntr`
+    );
+    const header = magic ? Buffer.from([0x50, 0x4b, 0x03, 0x04]) : Buffer.from("not a zip");
+    fs.writeFileSync(p, Buffer.concat([header, Buffer.from("rest")]));
+    tmpFiles.push(p);
+    return p;
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { clearPendingDntrPaths } = await import("../appLifecycle.js");
+    clearPendingDntrPaths();
+  });
+
+  afterEach(() => {
+    for (const p of tmpFiles.splice(0)) {
+      try {
+        fs.unlinkSync(p);
+      } catch {
+        // already gone
+      }
+    }
+  });
+
+  it("installs a valid archive as a sideload and shows a success toast", async () => {
+    const { installDntrPath } = await import("../appLifecycle.js");
+    installPluginMock.mockResolvedValue({ status: "installed", pluginId: "acme.tool" });
+    const file = makeDntrFile(true);
+
+    await installDntrPath(file);
+
+    expect(installPluginMock).toHaveBeenCalledWith(file, {
+      source: "sideload",
+      originalUrl: undefined,
+    });
+    expect(broadcastToRenderer).toHaveBeenCalledWith(
+      CHANNELS.NOTIFICATION_SHOW_TOAST,
+      expect.objectContaining({ type: "success", title: "Plugin installed" })
+    );
+  });
+
+  it("shows an invalid-file error and never calls the installer for a non-zip file", async () => {
+    const { installDntrPath } = await import("../appLifecycle.js");
+    const file = makeDntrFile(false);
+
+    await installDntrPath(file);
+
+    expect(installPluginMock).not.toHaveBeenCalled();
+    expect(broadcastToRenderer).toHaveBeenCalledWith(
+      CHANNELS.NOTIFICATION_SHOW_TOAST,
+      expect.objectContaining({ type: "error", title: "Invalid plugin file" })
+    );
+  });
+
+  it("shows an invalid-file error for a missing path", async () => {
+    const { installDntrPath } = await import("../appLifecycle.js");
+
+    await installDntrPath(nodePath.join(os.tmpdir(), "does-not-exist.dntr"));
+
+    expect(installPluginMock).not.toHaveBeenCalled();
+    expect(broadcastToRenderer).toHaveBeenCalledWith(
+      CHANNELS.NOTIFICATION_SHOW_TOAST,
+      expect.objectContaining({ type: "error", title: "Invalid plugin file" })
+    );
+  });
+
+  it("surfaces the installer's structured failure message", async () => {
+    const { installDntrPath } = await import("../appLifecycle.js");
+    installPluginMock.mockResolvedValue({
+      status: "failed",
+      errors: [{ code: "archive_invalid", message: "Archive is corrupt" }],
+    });
+    const file = makeDntrFile(true);
+
+    await installDntrPath(file);
+
+    expect(broadcastToRenderer).toHaveBeenCalledWith(
+      CHANNELS.NOTIFICATION_SHOW_TOAST,
+      expect.objectContaining({ type: "error", message: "Archive is corrupt" })
+    );
+  });
+
+  it("shows a generic error toast when the installer throws", async () => {
+    const { installDntrPath } = await import("../appLifecycle.js");
+    installPluginMock.mockRejectedValue(new Error("lock subsystem crashed"));
+    const file = makeDntrFile(true);
+
+    await installDntrPath(file);
+
+    expect(broadcastToRenderer).toHaveBeenCalledWith(
+      CHANNELS.NOTIFICATION_SHOW_TOAST,
+      expect.objectContaining({ type: "error", title: "Plugin install failed" })
+    );
+  });
+
+  it("drains queued paths sequentially through the installer and clears the queue", async () => {
+    const { registerAppLifecycleHandlers, drainPendingDntrPaths, getPendingDntrPaths } =
+      await import("../appLifecycle.js");
+    installPluginMock.mockResolvedValue({ status: "installed", pluginId: "p" });
+
+    const a = makeDntrFile(true);
+    const b = makeDntrFile(true);
+
+    // Seed the queue via a windowless second-instance event, then drain it.
+    vi.spyOn(process, "on").mockImplementation(() => process);
+    registerAppLifecycleHandlers(makeOpts({ getMainWindow: vi.fn(() => null) }));
+    const secondInstanceCall = appMock.on.mock.calls.find(
+      ([event]: string[]) => event === "second-instance"
+    );
+    const handler = secondInstanceCall![1] as (
+      event: unknown,
+      commandLine: string[],
+      workingDirectory: string
+    ) => void;
+    handler({}, ["daintree", a, b], "/work");
+
+    expect(getPendingDntrPaths()).toEqual([a, b]);
+
+    await drainPendingDntrPaths();
+
+    expect(installPluginMock).toHaveBeenCalledTimes(2);
+    expect(installPluginMock).toHaveBeenNthCalledWith(1, a, expect.any(Object));
+    expect(installPluginMock).toHaveBeenNthCalledWith(2, b, expect.any(Object));
+    expect(getPendingDntrPaths()).toEqual([]);
+  });
+});
+
+describe("registerAppLifecycleHandlers – second-instance .dntr handling", () => {
+  function makeBrowserWindow(overrides?: Partial<{ isMinimized: boolean; isDestroyed: boolean }>) {
+    return {
+      isMinimized: vi.fn(() => overrides?.isMinimized ?? false),
+      isDestroyed: vi.fn(() => overrides?.isDestroyed ?? false),
+      restore: vi.fn(),
+      focus: vi.fn(),
+    };
+  }
+
+  let dntrFile: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.spyOn(process, "on").mockImplementation(() => process);
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    const { clearPendingDntrPaths } = await import("../appLifecycle.js");
+    clearPendingDntrPaths();
+    dntrFile = nodePath.join(os.tmpdir(), `dntr-handler-${process.pid}.dntr`);
+    fs.writeFileSync(dntrFile, Buffer.from([0x50, 0x4b, 0x03, 0x04]));
+    installPluginMock.mockResolvedValue({ status: "installed", pluginId: "p" });
+  });
+
+  afterEach(() => {
+    try {
+      fs.unlinkSync(dntrFile);
+    } catch {
+      // already gone
+    }
+  });
+
+  function getHandler() {
+    const call = appMock.on.mock.calls.find(([event]: string[]) => event === "second-instance");
+    return call![1] as (event: unknown, commandLine: string[], workingDirectory: string) => void;
+  }
+
+  it("installs a .dntr archive in a ready window and brings it to the front", async () => {
+    const { registerAppLifecycleHandlers } = await import("../appLifecycle.js");
+    const mainWindow = makeBrowserWindow();
+    registerAppLifecycleHandlers(
+      makeOpts({
+        getMainWindow: vi.fn(() => mainWindow as unknown as import("electron").BrowserWindow),
+      })
+    );
+
+    getHandler()({}, ["daintree", dntrFile], "/work");
+    // Let the fire-and-forget install IIFE resolve.
+    await vi.waitFor(() => expect(installPluginMock).toHaveBeenCalled());
+
+    expect(installPluginMock).toHaveBeenCalledWith(dntrFile, {
+      source: "sideload",
+      originalUrl: undefined,
+    });
+    expect(mainWindow.focus).toHaveBeenCalled();
+  });
+
+  it("queues a .dntr archive when no window exists yet", async () => {
+    const { registerAppLifecycleHandlers, getPendingDntrPaths } = await import("../appLifecycle.js");
+    registerAppLifecycleHandlers(makeOpts({ getMainWindow: vi.fn(() => null) }));
+
+    getHandler()({}, ["daintree", dntrFile], "/work");
+
+    expect(installPluginMock).not.toHaveBeenCalled();
+    expect(getPendingDntrPaths()).toEqual([dntrFile]);
+  });
+
+  it("honours a .dntr path and a CLI directory path in the same launch", async () => {
+    const { registerAppLifecycleHandlers } = await import("../appLifecycle.js");
+    const mainWindow = makeBrowserWindow();
+    const onCreateWindowForPath = vi.fn();
+    registerAppLifecycleHandlers(
+      makeOpts({
+        getMainWindow: vi.fn(() => mainWindow as unknown as import("electron").BrowserWindow),
+        onCreateWindowForPath,
+      })
+    );
+
+    getHandler()({}, ["daintree", "--cli-path", "/repo", dntrFile], "/work");
+    await vi.waitFor(() => expect(installPluginMock).toHaveBeenCalled());
+
+    expect(onCreateWindowForPath).toHaveBeenCalledWith("/repo");
+    expect(installPluginMock).toHaveBeenCalledWith(dntrFile, {
+      source: "sideload",
+      originalUrl: undefined,
+    });
   });
 });

--- a/electron/lifecycle/__tests__/appLifecycle.test.ts
+++ b/electron/lifecycle/__tests__/appLifecycle.test.ts
@@ -568,6 +568,20 @@ describe("extractDntrPaths", () => {
     const { extractDntrPaths } = await import("../appLifecycle.js");
     expect(extractDntrPaths(["daintree"], "/work")).toEqual([]);
   });
+
+  it("decodes file:// URIs passed by Linux file managers (electron-builder %U)", async () => {
+    const { extractDntrPaths } = await import("../appLifecycle.js");
+    expect(extractDntrPaths(["daintree", "file:///home/alice/plugin.dntr"], "/")).toEqual([
+      "/home/alice/plugin.dntr",
+    ]);
+  });
+
+  it("decodes percent-encoded characters in a file:// URI", async () => {
+    const { extractDntrPaths } = await import("../appLifecycle.js");
+    expect(extractDntrPaths(["daintree", "file:///home/a%20b/my%20plugin.dntr"], "/")).toEqual([
+      "/home/a b/my plugin.dntr",
+    ]);
+  });
 });
 
 describe("installDntrPath / drainPendingDntrPaths", () => {
@@ -642,6 +656,24 @@ describe("installDntrPath / drainPendingDntrPaths", () => {
     );
   });
 
+  it("rejects files shorter than the 4-byte magic without throwing", async () => {
+    const { installDntrPath } = await import("../appLifecycle.js");
+    for (const bytes of [[], [0x50], [0x50, 0x4b, 0x03]]) {
+      installPluginMock.mockClear();
+      const p = nodePath.join(os.tmpdir(), `dntr-short-${bytes.length}-${process.pid}.dntr`);
+      fs.writeFileSync(p, Buffer.from(bytes));
+      tmpFiles.push(p);
+
+      await expect(installDntrPath(p)).resolves.toBeUndefined();
+
+      expect(installPluginMock).not.toHaveBeenCalled();
+      expect(broadcastToRenderer).toHaveBeenCalledWith(
+        CHANNELS.NOTIFICATION_SHOW_TOAST,
+        expect.objectContaining({ type: "error", title: "Invalid plugin file" })
+      );
+    }
+  });
+
   it("surfaces the installer's structured failure message", async () => {
     const { installDntrPath } = await import("../appLifecycle.js");
     installPluginMock.mockResolvedValue({
@@ -700,6 +732,44 @@ describe("installDntrPath / drainPendingDntrPaths", () => {
     expect(installPluginMock).toHaveBeenNthCalledWith(1, a, expect.any(Object));
     expect(installPluginMock).toHaveBeenNthCalledWith(2, b, expect.any(Object));
     expect(getPendingDntrPaths()).toEqual([]);
+  });
+
+  it("keeps a path that arrives mid-drain queued rather than dropping it", async () => {
+    const { registerAppLifecycleHandlers, drainPendingDntrPaths, getPendingDntrPaths } =
+      await import("../appLifecycle.js");
+    const a = makeDntrFile(true);
+    const b = makeDntrFile(true);
+    const c = makeDntrFile(true);
+
+    vi.spyOn(process, "on").mockImplementation(() => process);
+    registerAppLifecycleHandlers(makeOpts({ getMainWindow: vi.fn(() => null) }));
+    const secondInstanceCall = appMock.on.mock.calls.find(
+      ([event]: string[]) => event === "second-instance"
+    );
+    const handler = secondInstanceCall![1] as (
+      event: unknown,
+      commandLine: string[],
+      workingDirectory: string
+    ) => void;
+
+    // Seed the queue with a, b.
+    handler({}, ["daintree", a, b], "/work");
+
+    // While the first install is in flight, a fresh second-instance event pushes
+    // c. Because drain snapshots-and-clears up front, c lands in a fresh queue.
+    let pushed = false;
+    installPluginMock.mockImplementation(async () => {
+      if (!pushed) {
+        pushed = true;
+        handler({}, ["daintree", c], "/work");
+      }
+      return { status: "installed", pluginId: "p" };
+    });
+
+    await drainPendingDntrPaths();
+
+    expect(installPluginMock).toHaveBeenCalledTimes(2);
+    expect(getPendingDntrPaths()).toEqual([c]);
   });
 });
 

--- a/electron/lifecycle/appLifecycle.ts
+++ b/electron/lifecycle/appLifecycle.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow } from "electron";
 import path from "node:path";
 import fs from "node:fs";
+import { fileURLToPath } from "node:url";
 import type { CliAvailabilityService } from "../services/CliAvailabilityService.js";
 import type { WindowRegistry } from "../window/WindowRegistry.js";
 import { handleDirectoryOpen } from "../menu.js";
@@ -42,8 +43,19 @@ export function extractDntrPaths(argv: string[], workingDirectory: string): stri
   const paths: string[] = [];
   for (const arg of argv) {
     if (!arg || arg.startsWith("--")) continue;
-    if (!arg.toLowerCase().endsWith(".dntr")) continue;
-    paths.push(path.resolve(workingDirectory, arg));
+    // XDG file managers pass `file://` URIs because electron-builder appends
+    // `%U` to the Linux .desktop Exec line. Decode to an OS path before the
+    // extension check and resolution.
+    let candidate = arg;
+    if (candidate.startsWith("file://")) {
+      try {
+        candidate = fileURLToPath(candidate);
+      } catch {
+        continue;
+      }
+    }
+    if (!candidate.toLowerCase().endsWith(".dntr")) continue;
+    paths.push(path.resolve(workingDirectory, candidate));
   }
   return paths;
 }
@@ -77,7 +89,9 @@ async function isValidDntrArchive(filePath: string): Promise<boolean> {
   } catch {
     return false;
   } finally {
-    await handle?.close();
+    // A close() rejection in finally would supersede the return value and
+    // escape the catch — swallow it so validation can't throw.
+    await handle?.close().catch(() => {});
   }
 }
 
@@ -232,7 +246,7 @@ export function registerAppLifecycleHandlers(opts: AppLifecycleOptions): void {
           for (const archivePath of dntrPaths) {
             await installDntrPath(archivePath);
           }
-        })();
+        })().catch((err) => console.error("[MAIN] Failed to install .dntr plugin(s):", err));
       } else {
         pendingDntrPaths.push(...dntrPaths);
         console.log("[MAIN] Queuing .dntr paths for when window is ready:", dntrPaths);

--- a/electron/lifecycle/appLifecycle.ts
+++ b/electron/lifecycle/appLifecycle.ts
@@ -1,8 +1,12 @@
 import { app, BrowserWindow } from "electron";
+import path from "node:path";
+import fs from "node:fs";
 import type { CliAvailabilityService } from "../services/CliAvailabilityService.js";
 import type { WindowRegistry } from "../window/WindowRegistry.js";
 import { handleDirectoryOpen } from "../menu.js";
 import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
+import { broadcastToRenderer } from "../ipc/utils.js";
+import { CHANNELS } from "../ipc/channels.js";
 import { setSignalShutdown, setSafetyBeltTimer } from "./signalShutdownState.js";
 import { isWindowRecreating } from "./windowRecreationState.js";
 import { SAFETY_BELT_TIMEOUT_MS } from "./shutdownConfig.js";
@@ -27,6 +31,108 @@ export function extractCliPath(argv: string[]): string | null {
     }
   }
   return null;
+}
+
+// `.dntr` plugin archives double-clicked on Windows/Linux arrive as bare argv
+// entries (no `--flag`) on the `second-instance` event. The OS may supply a
+// relative path resolved against the launching shell's cwd, so the second
+// instance's `workingDirectory` is used to normalize it. Extension matching is
+// case-insensitive for Windows.
+export function extractDntrPaths(argv: string[], workingDirectory: string): string[] {
+  const paths: string[] = [];
+  for (const arg of argv) {
+    if (!arg || arg.startsWith("--")) continue;
+    if (!arg.toLowerCase().endsWith(".dntr")) continue;
+    paths.push(path.resolve(workingDirectory, arg));
+  }
+  return paths;
+}
+
+// Queue for `.dntr` paths received before a window exists (cold-launched second
+// instance). A `string[]` rather than a scalar because the OS can pass multiple
+// archives in one launch; they are drained sequentially through the installer's
+// lock. Mirrors the `pendingCliPath` pattern.
+let pendingDntrPaths: string[] = [];
+
+export function getPendingDntrPaths(): string[] {
+  return [...pendingDntrPaths];
+}
+
+export function clearPendingDntrPaths(): void {
+  pendingDntrPaths = [];
+}
+
+// Zip local-file-header magic. A `.dntr` archive is a zip; anything else is
+// rejected before the installer (which assumes valid zip input) ever sees it.
+const ZIP_MAGIC = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
+
+async function isValidDntrArchive(filePath: string): Promise<boolean> {
+  if (!fs.existsSync(filePath)) return false;
+  let handle: fs.promises.FileHandle | undefined;
+  try {
+    handle = await fs.promises.open(filePath, "r");
+    const buf = Buffer.alloc(4);
+    const { bytesRead } = await handle.read(buf, 0, 4, 0);
+    return bytesRead === 4 && buf.equals(ZIP_MAGIC);
+  } catch {
+    return false;
+  } finally {
+    await handle?.close();
+  }
+}
+
+// Validate + sideload a single `.dntr` archive. The magic-byte gate lives here
+// (not in the installer); invalid files and install failures surface as error
+// toasts. `PluginService` is imported lazily to preserve the #9285 main-process
+// module-isolation boundary.
+export async function installDntrPath(archivePath: string): Promise<void> {
+  if (!(await isValidDntrArchive(archivePath))) {
+    broadcastToRenderer(CHANNELS.NOTIFICATION_SHOW_TOAST, {
+      type: "error",
+      title: "Invalid plugin file",
+      message: `"${archivePath}" isn't a valid Daintree plugin archive.`,
+    });
+    return;
+  }
+  try {
+    const { pluginService } = await import("../services/PluginService.js");
+    const result = await pluginService.installPlugin(archivePath, {
+      source: "sideload",
+      originalUrl: undefined,
+    });
+    if (result.status === "installed") {
+      broadcastToRenderer(CHANNELS.NOTIFICATION_SHOW_TOAST, {
+        type: "success",
+        title: "Plugin installed",
+        message: `Installed "${result.pluginId}".`,
+      });
+    } else if (result.status === "failed") {
+      broadcastToRenderer(CHANNELS.NOTIFICATION_SHOW_TOAST, {
+        type: "error",
+        title: "Plugin install failed",
+        message: result.errors[0]?.message ?? "Couldn't install the plugin.",
+      });
+    }
+  } catch (err) {
+    console.error("[MAIN] Failed to install .dntr plugin:", err);
+    broadcastToRenderer(CHANNELS.NOTIFICATION_SHOW_TOAST, {
+      type: "error",
+      title: "Plugin install failed",
+      message: `Couldn't install "${archivePath}".`,
+    });
+  }
+}
+
+// Drain the pending `.dntr` queue once a window is ready. The snapshot is
+// cleared up front so a `second-instance` event firing mid-drain appends to a
+// fresh queue rather than re-installing in-flight paths. Installs run
+// sequentially through the installer's lock.
+export async function drainPendingDntrPaths(): Promise<void> {
+  const queued = getPendingDntrPaths();
+  clearPendingDntrPaths();
+  for (const archivePath of queued) {
+    await installDntrPath(archivePath);
+  }
 }
 
 export interface AppLifecycleOptions {
@@ -95,29 +201,50 @@ export function registerAppLifecycleHandlers(opts: AppLifecycleOptions): void {
     process.on("SIGHUP", signalHandler);
   }
 
-  app.on("second-instance", (_event, commandLine, _workingDirectory) => {
+  app.on("second-instance", (_event, commandLine, workingDirectory) => {
     console.log("[MAIN] Second instance detected");
     const mainWindow = opts.windowRegistry?.getPrimary()?.browserWindow ?? opts.getMainWindow();
+    const liveWindow = mainWindow && !mainWindow.isDestroyed() ? mainWindow : null;
     const cliPath = extractCliPath(commandLine);
+    const dntrPaths = extractDntrPaths(commandLine, workingDirectory);
 
     if (cliPath) {
-      if (mainWindow && !mainWindow.isDestroyed() && opts.onCreateWindowForPath) {
+      if (liveWindow && opts.onCreateWindowForPath) {
         console.log("[MAIN] Creating new window for CLI path:", cliPath);
         opts.onCreateWindowForPath(cliPath);
-      } else if (mainWindow && !mainWindow.isDestroyed()) {
+      } else if (liveWindow) {
         console.log("[MAIN] Opening CLI path in existing window:", cliPath);
         handleDirectoryOpen(
           cliPath,
-          mainWindow,
+          liveWindow,
           opts.getCliAvailabilityService() ?? undefined
         ).catch((err) => console.error("[MAIN] Failed to open CLI path:", err));
       } else {
         pendingCliPath = cliPath;
         console.log("[MAIN] Queuing CLI path for when window is ready:", cliPath);
       }
-    } else if (mainWindow) {
-      if (mainWindow.isMinimized()) mainWindow.restore();
-      mainWindow.focus();
+    }
+
+    if (dntrPaths.length > 0) {
+      if (liveWindow) {
+        console.log("[MAIN] Installing .dntr paths from second instance:", dntrPaths);
+        void (async () => {
+          for (const archivePath of dntrPaths) {
+            await installDntrPath(archivePath);
+          }
+        })();
+      } else {
+        pendingDntrPaths.push(...dntrPaths);
+        console.log("[MAIN] Queuing .dntr paths for when window is ready:", dntrPaths);
+      }
+    }
+
+    // Bring the primary window to the front for `.dntr` installs and for plain
+    // re-launches (no path argument). The CLI-path branch manages its own
+    // window via onCreateWindowForPath / handleDirectoryOpen, so it is excluded.
+    if (liveWindow && (dntrPaths.length > 0 || !cliPath)) {
+      if (liveWindow.isMinimized()) liveWindow.restore();
+      liveWindow.focus();
     }
   });
 

--- a/electron/window/serviceRefs.ts
+++ b/electron/window/serviceRefs.ts
@@ -21,6 +21,9 @@ import type { windowsStoreNotifierService as WindowsStoreNotifierServiceType } f
 // Guard: process.argv CLI path should only be consumed by the first window
 let processArgvCliHandled = false;
 
+// Guard: process.argv `.dntr` archives should only be consumed by the first window
+let processArgvDntrHandled = false;
+
 // Guard: IPC handlers are globally scoped (ipcMain.handle throws on re-registration)
 let ipcHandlersRegistered = false;
 
@@ -126,6 +129,12 @@ export function getProcessArgvCliHandled(): boolean {
 }
 export function setProcessArgvCliHandled(v: boolean): void {
   processArgvCliHandled = v;
+}
+export function getProcessArgvDntrHandled(): boolean {
+  return processArgvDntrHandled;
+}
+export function setProcessArgvDntrHandled(v: boolean): void {
+  processArgvDntrHandled = v;
 }
 export function getIpcHandlersRegistered(): boolean {
   return ipcHandlersRegistered;

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -23,7 +23,15 @@ import {
   kickOffEarlyPathRefresh,
 } from "../setup/environment.js";
 import { shouldDeferRendererLoadForE2E } from "./earlyRenderer.js";
-import { extractCliPath, getPendingCliPath, setPendingCliPath } from "../lifecycle/appLifecycle.js";
+import {
+  extractCliPath,
+  getPendingCliPath,
+  setPendingCliPath,
+  extractDntrPaths,
+  getPendingDntrPaths,
+  drainPendingDntrPaths,
+  installDntrPath,
+} from "../lifecycle/appLifecycle.js";
 import type { WindowContext, WindowRegistry } from "./WindowRegistry.js";
 import { resetDeferredQueue } from "./deferredInitQueue.js";
 import { initGlobalServices } from "./globalServicesInit.js";
@@ -40,6 +48,8 @@ import {
   setCleanupIpcHandlers,
   getProcessArgvCliHandled,
   setProcessArgvCliHandled,
+  getProcessArgvDntrHandled,
+  setProcessArgvDntrHandled,
   getIpcHandlersRegistered,
   setIpcHandlersRegistered,
   getGlobalServicesInitialized,
@@ -559,6 +569,24 @@ export async function setupWindowServices(
     handleDirectoryOpen(opts.initialProjectPath, win, cliAvailabilityService ?? undefined).catch(
       (err) => console.error("[MAIN] Failed to open initial project path:", err)
     );
+  }
+
+  // `.dntr` plugin-archive handling — independent of project/CLI-path routing.
+  // First-launch (cold double-click) archives arrive in process.argv; second
+  // instances queue into pendingDntrPaths. Both are sideloaded once the first
+  // window is ready so install toasts have a live renderer target. Fire-and-
+  // forget: installs run sequentially through the installer's lock.
+  const firstLaunchDntrPaths = !getProcessArgvDntrHandled()
+    ? extractDntrPaths(process.argv, process.cwd())
+    : [];
+  if (firstLaunchDntrPaths.length > 0) setProcessArgvDntrHandled(true);
+  if (firstLaunchDntrPaths.length > 0 || getPendingDntrPaths().length > 0) {
+    void (async () => {
+      for (const archivePath of firstLaunchDntrPaths) {
+        await installDntrPath(archivePath);
+      }
+      await drainPendingDntrPaths();
+    })().catch((err) => console.error("[MAIN] Failed to install .dntr plugin(s):", err));
   }
 
   // ── Last-window-close: reset per-window deferred queue ──


### PR DESCRIPTION
## Summary

- Extends the `second-instance` handler in `electron/lifecycle/appLifecycle.ts` to scan `commandLine` for `.dntr` plugin archives, validate the zip magic bytes (`PK\x03\x04`), and sideload each via `pluginService.installPlugin({ source: "sideload" })`.
- Resolves relative and Windows-style paths against the event `workingDirectory`; decodes Linux `file://` URIs (electron-builder appends `%U` to the `.desktop` Exec line, so file managers pass `file:///path`).
- Queues `.dntr` paths (`pendingDntrPaths`) when no window exists yet and drains on first window ready; handles cold-launch `process.argv` via a `processArgvDntrHandled` guard flag.

Resolves #9294

## Changes

- **`electron/lifecycle/appLifecycle.ts`** — extraction, magic-byte check, install, drain loop, cold-launch guard, and `second-instance` wiring.
- **`electron/window/serviceRefs.ts` / `windowServices.ts`** — lazy `pluginService` ref to preserve the #9285 main-process module-isolation boundary.
- **`electron-builder.config.cjs`** — `linux.fileAssociations` for XDG mime registration.
- **`build/installer.nsh`** — custom HKCU NSIS include for Windows file association. `nsis.fileAssociations` doesn't exist in the electron-builder schema, and top-level `win.fileAssociations` requires `perMachine: true` which the project deliberately avoids (per-user install, no-elevation auto-update). HKCU keeps that model intact.
- **`electron/lifecycle/__tests__/appLifecycle.test.ts`** — 42 new tests covering extraction (including `file://`, percent-encoding, Windows paths, multiple paths), magic-byte validation (including sub-4-byte files), install (valid/invalid/missing/failed/throw), drain (sequential, clears queue, mid-drain append race), and the `second-instance` `.dntr` branch (ready/queued/mixed CLI + `.dntr`).

## Testing

42 unit tests pass. `npm run check` clean.

**Note:** `build/installer.nsh` (Windows NSIS) and the Linux `.desktop`/XDG registration need a packaged build on a clean Windows/Ubuntu VM to confirm end-to-end double-click behaviour. The handler logic is fully unit-tested, but OS-level file association registration can't be validated in CI.