### PR TITLE
feat(plugins): build daintree-plugin CLI (new/validate/package/install/uninstall)

### DIFF
--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -146,7 +146,7 @@ const ZIP_MAGIC = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
  * back as structured `{ status: "failed" }` data (never thrown) so the tab can
  * render an inline message.
  */
-async function handleInstallFromPath(path: string): Promise<PluginInstallResult> {
+export async function handleInstallFromPath(path: string): Promise<PluginInstallResult> {
   const fail = (message: string): PluginInstallResult => ({
     status: "failed",
     errors: [{ code: "archive_invalid", message }],
@@ -193,7 +193,7 @@ async function handleInstallFromPath(path: string): Promise<PluginInstallResult>
  * (PluginService extracts into its own temp dir and doesn't take ownership of
  * the download artifact).
  */
-async function handleInstallFromUrl(url: string): Promise<PluginInstallResult> {
+export async function handleInstallFromUrl(url: string): Promise<PluginInstallResult> {
   if (typeof url !== "string" || url.trim().length === 0) {
     return { status: "invalid-url" };
   }
@@ -316,7 +316,7 @@ async function handleInstallFromUrl(url: string): Promise<PluginInstallResult> {
   }
 }
 
-async function handleUninstall(pluginId: string, deleteSettings?: boolean): Promise<void> {
+export async function handleUninstall(pluginId: string, deleteSettings?: boolean): Promise<void> {
   if (typeof pluginId !== "string" || pluginId.trim().length === 0) {
     throw new Error("uninstall: pluginId must be a non-empty string");
   }

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -234,6 +234,11 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
           import("../services/PluginMcpSupervisor.js")
             .then(({ getPluginMcpSupervisor }) => getPluginMcpSupervisor().shutdownAll())
             .catch(() => {}),
+          // Close the CLI control socket and unlink the socket file (F32). Same
+          // lazy-import guard — the module only loaded if the deferred task ran.
+          import("../services/PluginCliServer.js")
+            .then(({ stopPluginCliServer }) => stopPluginCliServer())
+            .catch(() => {}),
           new Promise<void>((resolve) => {
             // Global singletons that previously tore down on last-window-close
             // (electron/window/windowServices.ts) live here now so they cover

--- a/electron/services/PluginArchive.ts
+++ b/electron/services/PluginArchive.ts
@@ -59,6 +59,17 @@ function matchesExclusionPattern(name: string, sourcemaps: boolean): boolean {
   return false;
 }
 
+/**
+ * Apply the normative `.dntr` exclusion list to a POSIX-relative path.
+ * Shared with the `daintree-plugin` CLI packager (F32) so the CLI's
+ * `.gitignore`-aware file collection still drops `node_modules/`, `.git/`,
+ * source files, and (unless `sourcemaps`) source maps using the exact same
+ * predicate the host packs with — keeping the wire format in one place.
+ */
+export function isExcludedArchiveEntry(name: string, sourcemaps = false): boolean {
+  return matchesExclusionPattern(name, sourcemaps);
+}
+
 async function collectFiles(dir: string, baseDir: string, sourcemaps: boolean): Promise<string[]> {
   const entries = await fs.readdir(dir, { withFileTypes: true });
   const files: string[] = [];
@@ -98,7 +109,25 @@ export async function packPluginArchive(
 ): Promise<string> {
   const sourcemaps = opts.sourcemaps ?? false;
   const files = await collectFiles(sourceDir, sourceDir, sourcemaps);
-  const sorted = sortEntries(files);
+  return packPluginArchiveFromFiles(sourceDir, outputPath, files);
+}
+
+/**
+ * Pack an explicit, pre-filtered list of POSIX-relative paths under
+ * `sourceDir` into a deterministic `.dntr` archive. The `daintree-plugin` CLI
+ * uses this after it has done its own `.gitignore`-aware collection (F32) so
+ * the host's normative ordering, `plugin.json`-first rule, MS-DOS-epoch
+ * timestamps, and pre-stat insertion guard all stay in this one place. The
+ * caller owns exclusion filtering; this function still sorts and enforces the
+ * `plugin.json`-present invariant. Returns the SHA-256 hex digest of the
+ * written archive bytes.
+ */
+export async function packPluginArchiveFromFiles(
+  sourceDir: string,
+  outputPath: string,
+  files: readonly string[]
+): Promise<string> {
+  const sorted = sortEntries([...files]);
 
   if (!sorted.includes("plugin.json")) {
     throw new Error("plugin.json not found in source directory");

--- a/electron/services/PluginArchive.ts
+++ b/electron/services/PluginArchive.ts
@@ -215,6 +215,10 @@ function openZip(archivePath: string): Promise<yauzl.ZipFile> {
  * the rest. The entry must be the first in the zip's local file order.
  */
 export async function readArchiveManifest(archivePath: string): Promise<PluginManifest> {
+  const stat = await fs.stat(archivePath);
+  if (stat.size > MAX_DNTR_BYTES) {
+    throw new Error(`Archive size ${stat.size} exceeds ${MAX_DNTR_BYTES} byte limit`);
+  }
   const zipfile = await openZip(archivePath);
 
   return new Promise((resolve, reject) => {
@@ -226,6 +230,15 @@ export async function readArchiveManifest(archivePath: string): Promise<PluginMa
         settled = true;
         zipfile.close();
         return reject(new Error(`First entry must be plugin.json, got "${entry.fileName}"`));
+      }
+
+      // Guard against a zip whose compressed form fits the cap but whose
+      // plugin.json declares a multi-hundred-MB uncompressed size — without
+      // this, the chunk buffer below would exhaust the main-process heap.
+      if (entry.uncompressedSize > MAX_DNTR_BYTES) {
+        settled = true;
+        zipfile.close();
+        return reject(new Error(`plugin.json exceeds ${MAX_DNTR_BYTES} byte limit`));
       }
 
       zipfile.openReadStream(entry, (err, stream) => {

--- a/electron/services/PluginCliServer.ts
+++ b/electron/services/PluginCliServer.ts
@@ -148,6 +148,8 @@ export function createPluginCliServer(config: PluginCliServerConfig): PluginCliS
   }
 
   function handleConnection(socket: net.Socket): void {
+    openSockets.add(socket);
+    socket.once("close", () => openSockets.delete(socket));
     socket.setEncoding("utf8");
     let buffer = "";
     let overflowed = false;
@@ -178,6 +180,7 @@ export function createPluginCliServer(config: PluginCliServerConfig): PluginCliS
   }
 
   let server: net.Server | null = null;
+  const openSockets = new Set<net.Socket>();
 
   async function listen(): Promise<void> {
     if (server) return;
@@ -206,6 +209,12 @@ export function createPluginCliServer(config: PluginCliServerConfig): PluginCliS
     const srv = server;
     server = null;
     if (!srv) return;
+    // Drop any half-open client connections so `server.close()` resolves
+    // promptly instead of waiting on a client that never sent a full frame.
+    for (const socket of openSockets) {
+      socket.destroy();
+    }
+    openSockets.clear();
     await new Promise<void>((resolve) => srv.close(() => resolve()));
     if (isFileSocket(socketPath)) {
       await fs.rm(socketPath, { force: true }).catch(() => {});
@@ -242,8 +251,11 @@ export async function startPluginCliServer(): Promise<void> {
       uninstall: ({ pluginId, deleteSettings }) => handleUninstall(pluginId, deleteSettings),
     },
   });
-  singleton = server;
+  // Only claim the singleton once the socket is actually bound — if listen()
+  // throws (EADDRINUSE, permissions), a later retry must not be blocked by a
+  // dead reference.
   await server.listen();
+  singleton = server;
 }
 
 /** Stop the singleton CLI control server (best-effort). */

--- a/electron/services/PluginCliServer.ts
+++ b/electron/services/PluginCliServer.ts
@@ -1,0 +1,255 @@
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs/promises";
+import { z } from "zod";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+
+/**
+ * Local control socket that lets the `daintree-plugin` CLI drive a running
+ * Daintree instance for `install` / `uninstall` (F32). The CLI connects over a
+ * Unix domain socket (`~/.daintree/cli.sock`) or a Windows named pipe
+ * (`\\.\pipe\daintree-cli`) and exchanges newline-delimited JSON frames:
+ *
+ *   request:  { "id": <string|number>, "method": <string>, "params"?: <object> }
+ *   response: { "id": <id>, "result": <value> }  |  { "id": <id>, "error": { "message": <string> } }
+ *
+ * Every CLI install/uninstall routes through the SAME handler functions the IPC
+ * surface uses, so the path/magic-byte/`.dntr` guards and the scoped-name check
+ * are never re-implemented or bypassed. The server only binds after the plugin
+ * service has finished initializing — a `plugin.install` arriving mid-activation
+ * would otherwise race the load path.
+ */
+
+const MAX_FRAME_BYTES = 64 * 1024;
+
+/** Request envelope. `params` shape is validated per-method. */
+const RequestSchema = z.object({
+  id: z.union([z.string(), z.number()]),
+  method: z.string().min(1),
+  params: z.unknown().optional(),
+});
+
+const InstallParamsSchema = z
+  .object({
+    path: z.string().min(1).optional(),
+    url: z.string().min(1).optional(),
+  })
+  .refine((p) => Boolean(p.path) || Boolean(p.url), {
+    message: "install requires a 'path' or 'url' parameter",
+  });
+
+const UninstallParamsSchema = z.object({
+  pluginId: z.string().min(1),
+  deleteSettings: z.boolean().optional(),
+});
+
+export interface PluginCliServerHandlers {
+  install: (params: { path?: string; url?: string }) => Promise<unknown>;
+  uninstall: (params: { pluginId: string; deleteSettings?: boolean }) => Promise<void>;
+}
+
+export interface PluginCliServerConfig {
+  socketPath: string;
+  /** Resolves once the host is ready to accept install/uninstall calls. */
+  waitForReady: () => Promise<void>;
+  handlers: PluginCliServerHandlers;
+}
+
+export interface PluginCliServer {
+  listen: () => Promise<void>;
+  close: () => Promise<void>;
+  readonly socketPath: string;
+}
+
+/**
+ * Platform socket path: a named pipe on Windows (which doesn't live on disk),
+ * else `~/.daintree/cli.sock`. Kept in lockstep with the CLI client's resolver.
+ */
+export function getCliSocketPath(): string {
+  const override = process.env.DAINTREE_CLI_SOCKET;
+  if (override && override.length > 0) {
+    return override;
+  }
+  if (process.platform === "win32") {
+    return "\\\\.\\pipe\\daintree-cli";
+  }
+  return path.join(os.homedir(), ".daintree", "cli.sock");
+}
+
+/** True for filesystem-backed sockets (everything but Windows named pipes). */
+function isFileSocket(socketPath: string): boolean {
+  return process.platform !== "win32" && !socketPath.startsWith("\\\\");
+}
+
+function writeResponse(socket: net.Socket, payload: Record<string, unknown>): void {
+  if (socket.destroyed) return;
+  try {
+    socket.write(JSON.stringify(payload) + "\n");
+  } catch {
+    // Client vanished mid-write — nothing to recover, the connection is dead.
+  }
+}
+
+/**
+ * Create (but do not yet bind) a CLI control server. `listen()` awaits
+ * `waitForReady()` before binding so no request is serviced before the host
+ * can honor it; `close()` tears the socket down and removes the on-disk file.
+ */
+export function createPluginCliServer(config: PluginCliServerConfig): PluginCliServer {
+  const { socketPath, waitForReady, handlers } = config;
+
+  async function dispatchMethod(method: string, params: unknown): Promise<unknown> {
+    switch (method) {
+      case "plugin.ping":
+        return { status: "ok", pid: process.pid };
+      case "plugin.install": {
+        const p = InstallParamsSchema.parse(params ?? {});
+        return handlers.install(p);
+      }
+      case "plugin.uninstall": {
+        const p = UninstallParamsSchema.parse(params ?? {});
+        await handlers.uninstall(p);
+        return { status: "ok" };
+      }
+      default:
+        throw new Error(`Unknown method: ${method}`);
+    }
+  }
+
+  async function dispatchFrame(socket: net.Socket, line: string): Promise<void> {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) return;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      writeResponse(socket, { id: null, error: { message: "Malformed JSON request" } });
+      return;
+    }
+
+    const req = RequestSchema.safeParse(parsed);
+    if (!req.success) {
+      writeResponse(socket, { id: null, error: { message: "Invalid request shape" } });
+      return;
+    }
+
+    const { id, method, params } = req.data;
+    try {
+      const result = await dispatchMethod(method, params);
+      writeResponse(socket, { id, result });
+    } catch (err) {
+      writeResponse(socket, {
+        id,
+        error: { message: formatErrorMessage(err, "Plugin CLI request failed") },
+      });
+    }
+  }
+
+  function handleConnection(socket: net.Socket): void {
+    socket.setEncoding("utf8");
+    let buffer = "";
+    let overflowed = false;
+
+    socket.on("data", (chunk: string) => {
+      if (overflowed) return;
+      buffer += chunk;
+      if (buffer.length > MAX_FRAME_BYTES) {
+        overflowed = true;
+        writeResponse(socket, { id: null, error: { message: "Request exceeds size limit" } });
+        socket.destroy();
+        return;
+      }
+      let newlineIndex = buffer.indexOf("\n");
+      while (newlineIndex >= 0) {
+        const frame = buffer.slice(0, newlineIndex);
+        buffer = buffer.slice(newlineIndex + 1);
+        // Fire concurrently — each response carries its own id so the client
+        // matches replies; install/uninstall serialize on the plugin lock.
+        void dispatchFrame(socket, frame);
+        newlineIndex = buffer.indexOf("\n");
+      }
+    });
+
+    // A client that disconnects (or errors) mid-request is normal; swallow so
+    // it can't crash the host.
+    socket.on("error", () => {});
+  }
+
+  let server: net.Server | null = null;
+
+  async function listen(): Promise<void> {
+    if (server) return;
+    await waitForReady();
+
+    if (isFileSocket(socketPath)) {
+      await fs.mkdir(path.dirname(socketPath), { recursive: true });
+      // Remove any stale socket left by a crashed prior run; otherwise listen()
+      // fails with EADDRINUSE on a file that no process is bound to.
+      await fs.rm(socketPath, { force: true }).catch(() => {});
+    }
+
+    const srv = net.createServer(handleConnection);
+    await new Promise<void>((resolve, reject) => {
+      const onError = (err: Error) => reject(err);
+      srv.once("error", onError);
+      srv.listen(socketPath, () => {
+        srv.off("error", onError);
+        resolve();
+      });
+    });
+    server = srv;
+  }
+
+  async function close(): Promise<void> {
+    const srv = server;
+    server = null;
+    if (!srv) return;
+    await new Promise<void>((resolve) => srv.close(() => resolve()));
+    if (isFileSocket(socketPath)) {
+      await fs.rm(socketPath, { force: true }).catch(() => {});
+    }
+  }
+
+  return { listen, close, socketPath };
+}
+
+// ── Process-wide singleton wiring ──────────────────────────────────────────
+
+let singleton: PluginCliServer | null = null;
+
+/**
+ * Start the CLI control server for this app instance. Idempotent. Wires the
+ * real socket path, gates binding behind `pluginService.waitForInit()`, and
+ * routes install/uninstall through the existing IPC handler trust gates.
+ */
+export async function startPluginCliServer(): Promise<void> {
+  if (singleton) return;
+  const { pluginService } = await import("./PluginService.js");
+  const { handleInstallFromPath, handleInstallFromUrl, handleUninstall } =
+    await import("../ipc/handlers/plugin.js");
+
+  const server = createPluginCliServer({
+    socketPath: getCliSocketPath(),
+    waitForReady: () => pluginService.waitForInit(),
+    handlers: {
+      install: ({ path: installPath, url }) => {
+        if (url) return handleInstallFromUrl(url);
+        if (installPath) return handleInstallFromPath(installPath);
+        return Promise.reject(new Error("install requires a 'path' or 'url' parameter"));
+      },
+      uninstall: ({ pluginId, deleteSettings }) => handleUninstall(pluginId, deleteSettings),
+    },
+  });
+  singleton = server;
+  await server.listen();
+}
+
+/** Stop the singleton CLI control server (best-effort). */
+export async function stopPluginCliServer(): Promise<void> {
+  const server = singleton;
+  singleton = null;
+  if (!server) return;
+  await server.close();
+}

--- a/electron/services/__tests__/PluginArchive.integration.test.ts
+++ b/electron/services/__tests__/PluginArchive.integration.test.ts
@@ -4,9 +4,11 @@ import path from "path";
 import os from "os";
 import {
   packPluginArchive,
+  packPluginArchiveFromFiles,
   computeArchiveHash,
   readArchiveManifest,
   verifyPluginArchive,
+  isExcludedArchiveEntry,
 } from "../PluginArchive.js";
 
 let tmpDir: string;
@@ -264,5 +266,98 @@ describe("verifyPluginArchive", () => {
     } catch {
       // packPluginArchive might succeed since it only checks for existence
     }
+  });
+});
+
+describe("packPluginArchiveFromFiles (CLI packager surface)", () => {
+  it("hoists plugin.json to the first entry regardless of input order", async () => {
+    const sourceDir = path.join(tmpDir, "source");
+    await createFixture(sourceDir, {
+      "plugin.json": JSON.stringify(validManifest({ main: "dist/index.js" })),
+      "dist/index.js": "console.log('hi')",
+      "icons/logo.svg": "<svg/>",
+    });
+
+    const archivePath = path.join(tmpDir, "out.dntr");
+    // Deliberately unsorted, plugin.json last.
+    await packPluginArchiveFromFiles(sourceDir, archivePath, [
+      "icons/logo.svg",
+      "dist/index.js",
+      "plugin.json",
+    ]);
+
+    const manifest = await readArchiveManifest(archivePath);
+    expect(manifest.name).toBe("acme.test-plugin");
+    const result = await verifyPluginArchive(archivePath);
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.entryCount).toBe(3);
+    }
+  });
+
+  it("produces byte-identical output across repeated runs with the same file list", async () => {
+    const sourceDir = path.join(tmpDir, "source");
+    await createFixture(sourceDir, {
+      "plugin.json": JSON.stringify(validManifest({ main: "dist/index.js" })),
+      "dist/index.js": "export const x = 1;",
+      "dist/util.js": "export const y = 2;",
+    });
+
+    const files = ["dist/util.js", "dist/index.js", "plugin.json"];
+    const first = path.join(tmpDir, "first.dntr");
+    const second = path.join(tmpDir, "second.dntr");
+    const hashA = await packPluginArchiveFromFiles(sourceDir, first, files);
+    const hashB = await packPluginArchiveFromFiles(sourceDir, second, files);
+    expect(hashA).toBe(hashB);
+    expect(await computeArchiveHash(first)).toBe(await computeArchiveHash(second));
+  });
+
+  it("matches packPluginArchive output for the same effective file set", async () => {
+    const sourceDir = path.join(tmpDir, "source");
+    await createFixture(sourceDir, {
+      "plugin.json": JSON.stringify(validManifest({ main: "dist/index.js" })),
+      "dist/index.js": "export const x = 1;",
+    });
+
+    const viaWalk = path.join(tmpDir, "walk.dntr");
+    const viaList = path.join(tmpDir, "list.dntr");
+    const walkHash = await packPluginArchive(sourceDir, viaWalk);
+    const listHash = await packPluginArchiveFromFiles(sourceDir, viaList, [
+      "plugin.json",
+      "dist/index.js",
+    ]);
+    expect(listHash).toBe(walkHash);
+  });
+
+  it("throws when the file list omits plugin.json", async () => {
+    const sourceDir = path.join(tmpDir, "source");
+    await createFixture(sourceDir, {
+      "plugin.json": JSON.stringify(validManifest()),
+      "dist/index.js": "export const x = 1;",
+    });
+
+    await expect(
+      packPluginArchiveFromFiles(sourceDir, path.join(tmpDir, "out.dntr"), ["dist/index.js"])
+    ).rejects.toThrow(/plugin\.json/);
+  });
+});
+
+describe("isExcludedArchiveEntry (shared CLI exclusion predicate)", () => {
+  it("excludes node_modules, .git, and source files", () => {
+    expect(isExcludedArchiveEntry("node_modules/foo/index.js")).toBe(true);
+    expect(isExcludedArchiveEntry(".git/config")).toBe(true);
+    expect(isExcludedArchiveEntry("src/index.ts")).toBe(true);
+    expect(isExcludedArchiveEntry("src/Panel.tsx")).toBe(true);
+  });
+
+  it("excludes source maps by default, includes them when sourcemaps=true", () => {
+    expect(isExcludedArchiveEntry("dist/index.js.map")).toBe(true);
+    expect(isExcludedArchiveEntry("dist/index.js.map", true)).toBe(false);
+  });
+
+  it("keeps compiled output and assets", () => {
+    expect(isExcludedArchiveEntry("plugin.json")).toBe(false);
+    expect(isExcludedArchiveEntry("dist/index.js")).toBe(false);
+    expect(isExcludedArchiveEntry("icons/logo.svg")).toBe(false);
   });
 });

--- a/electron/services/__tests__/PluginCliServer.test.ts
+++ b/electron/services/__tests__/PluginCliServer.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs/promises";
+import { createPluginCliServer, type PluginCliServer } from "../PluginCliServer.js";
+
+// Windows named pipes don't live on disk, so the file-socket lifecycle assertions
+// only make sense on POSIX. The dispatch assertions run everywhere.
+const isWindows = process.platform === "win32";
+
+let tmpDir: string;
+let socketPath: string;
+let server: PluginCliServer | null = null;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-cli-sock-"));
+  socketPath = isWindows
+    ? `\\\\.\\pipe\\daintree-cli-test-${process.pid}-${Math.floor(performance.now())}`
+    : path.join(tmpDir, "cli.sock");
+});
+
+afterEach(async () => {
+  if (server) {
+    await server.close().catch(() => {});
+    server = null;
+  }
+  await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+});
+
+/** Send one NDJSON request and resolve with the parsed response frame. */
+function request(payload: unknown): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection({ path: socketPath });
+    let buffer = "";
+    socket.setEncoding("utf8");
+    socket.on("connect", () => {
+      socket.write(JSON.stringify(payload) + "\n");
+    });
+    socket.on("data", (chunk: string) => {
+      buffer += chunk;
+      const idx = buffer.indexOf("\n");
+      if (idx >= 0) {
+        const line = buffer.slice(0, idx);
+        socket.end();
+        try {
+          resolve(JSON.parse(line));
+        } catch (err) {
+          reject(err);
+        }
+      }
+    });
+    socket.on("error", reject);
+  });
+}
+
+function noopHandlers() {
+  return {
+    install: vi.fn(async () => ({ status: "installed" })),
+    uninstall: vi.fn(async () => {}),
+  };
+}
+
+describe("createPluginCliServer", () => {
+  it("does not bind until waitForReady resolves", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    server = createPluginCliServer({
+      socketPath,
+      waitForReady: () => gate,
+      handlers: noopHandlers(),
+    });
+
+    const listenPromise = server.listen();
+    // Give the event loop a tick; the server must not be listening yet.
+    await new Promise((r) => setTimeout(r, 20));
+    if (!isWindows) {
+      await expect(fs.access(socketPath)).rejects.toBeTruthy();
+    }
+
+    release();
+    await listenPromise;
+    if (!isWindows) {
+      await expect(fs.access(socketPath)).resolves.toBeUndefined();
+    }
+  });
+
+  it("routes plugin.install to the install handler and returns the result", async () => {
+    const handlers = noopHandlers();
+    server = createPluginCliServer({
+      socketPath,
+      waitForReady: () => Promise.resolve(),
+      handlers,
+    });
+    await server.listen();
+
+    const res = await request({
+      id: 1,
+      method: "plugin.install",
+      params: { path: "/tmp/foo.dntr" },
+    });
+    expect(res.id).toBe(1);
+    expect(res.result).toEqual({ status: "installed" });
+    expect(handlers.install).toHaveBeenCalledWith({ path: "/tmp/foo.dntr" });
+  });
+
+  it("routes plugin.uninstall to the uninstall handler", async () => {
+    const handlers = noopHandlers();
+    server = createPluginCliServer({
+      socketPath,
+      waitForReady: () => Promise.resolve(),
+      handlers,
+    });
+    await server.listen();
+
+    const res = await request({
+      id: "u1",
+      method: "plugin.uninstall",
+      params: { pluginId: "acme.demo", deleteSettings: true },
+    });
+    expect(res.id).toBe("u1");
+    expect(res.result).toEqual({ status: "ok" });
+    expect(handlers.uninstall).toHaveBeenCalledWith({
+      pluginId: "acme.demo",
+      deleteSettings: true,
+    });
+  });
+
+  it("answers plugin.ping for liveness checks", async () => {
+    server = createPluginCliServer({
+      socketPath,
+      waitForReady: () => Promise.resolve(),
+      handlers: noopHandlers(),
+    });
+    await server.listen();
+
+    const res = await request({ id: 9, method: "plugin.ping" });
+    expect(res.id).toBe(9);
+    expect((res.result as { status: string }).status).toBe("ok");
+  });
+
+  it("returns an error frame for malformed JSON", async () => {
+    server = createPluginCliServer({
+      socketPath,
+      waitForReady: () => Promise.resolve(),
+      handlers: noopHandlers(),
+    });
+    await server.listen();
+
+    const res = await new Promise<Record<string, unknown>>((resolve, reject) => {
+      const socket = net.createConnection({ path: socketPath });
+      let buffer = "";
+      socket.setEncoding("utf8");
+      socket.on("connect", () => socket.write("{ not json\n"));
+      socket.on("data", (chunk: string) => {
+        buffer += chunk;
+        const idx = buffer.indexOf("\n");
+        if (idx >= 0) {
+          socket.end();
+          resolve(JSON.parse(buffer.slice(0, idx)));
+        }
+      });
+      socket.on("error", reject);
+    });
+    expect(res.error).toBeTruthy();
+    expect((res.error as { message: string }).message).toMatch(/Malformed JSON/);
+  });
+
+  it("returns an error frame for an unknown method", async () => {
+    server = createPluginCliServer({
+      socketPath,
+      waitForReady: () => Promise.resolve(),
+      handlers: noopHandlers(),
+    });
+    await server.listen();
+
+    const res = await request({ id: 2, method: "plugin.bogus" });
+    expect(res.id).toBe(2);
+    expect((res.error as { message: string }).message).toMatch(/Unknown method/);
+  });
+
+  it("returns an error frame when install params are missing path and url", async () => {
+    const handlers = noopHandlers();
+    server = createPluginCliServer({
+      socketPath,
+      waitForReady: () => Promise.resolve(),
+      handlers,
+    });
+    await server.listen();
+
+    const res = await request({ id: 3, method: "plugin.install", params: {} });
+    expect(res.id).toBe(3);
+    expect(res.error).toBeTruthy();
+    expect(handlers.install).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a handler rejection as an error frame", async () => {
+    server = createPluginCliServer({
+      socketPath,
+      waitForReady: () => Promise.resolve(),
+      handlers: {
+        install: vi.fn(async () => {
+          throw new Error("disk on fire");
+        }),
+        uninstall: vi.fn(async () => {}),
+      },
+    });
+    await server.listen();
+
+    const res = await request({
+      id: 4,
+      method: "plugin.install",
+      params: { path: "/tmp/x.dntr" },
+    });
+    expect((res.error as { message: string }).message).toMatch(/disk on fire/);
+  });
+
+  it("handles concurrent requests on one connection, matching ids", async () => {
+    server = createPluginCliServer({
+      socketPath,
+      waitForReady: () => Promise.resolve(),
+      handlers: {
+        install: vi.fn(async () => ({ status: "installed" })),
+        uninstall: vi.fn(async () => {}),
+      },
+    });
+    await server.listen();
+
+    const responses = await new Promise<Record<string, unknown>[]>((resolve, reject) => {
+      const socket = net.createConnection({ path: socketPath });
+      const frames: Record<string, unknown>[] = [];
+      let buffer = "";
+      socket.setEncoding("utf8");
+      socket.on("connect", () => {
+        socket.write(JSON.stringify({ id: 1, method: "plugin.ping" }) + "\n");
+        socket.write(JSON.stringify({ id: 2, method: "plugin.ping" }) + "\n");
+        socket.write(JSON.stringify({ id: 3, method: "plugin.ping" }) + "\n");
+      });
+      socket.on("data", (chunk: string) => {
+        buffer += chunk;
+        let idx = buffer.indexOf("\n");
+        while (idx >= 0) {
+          frames.push(JSON.parse(buffer.slice(0, idx)));
+          buffer = buffer.slice(idx + 1);
+          if (frames.length === 3) {
+            socket.end();
+            resolve(frames);
+            return;
+          }
+          idx = buffer.indexOf("\n");
+        }
+      });
+      socket.on("error", reject);
+    });
+
+    expect(responses.map((r) => r.id).sort()).toEqual([1, 2, 3]);
+  });
+
+  it("close() tears down the server and removes the socket file", async () => {
+    server = createPluginCliServer({
+      socketPath,
+      waitForReady: () => Promise.resolve(),
+      handlers: noopHandlers(),
+    });
+    await server.listen();
+    if (!isWindows) {
+      await expect(fs.access(socketPath)).resolves.toBeUndefined();
+    }
+    await server.close();
+    server = null;
+    if (!isWindows) {
+      await expect(fs.access(socketPath)).rejects.toBeTruthy();
+    }
+  });
+});

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -185,6 +185,7 @@ vi.mock("../../services/ProjectStore.js", () => ({
 
 vi.mock("../../setup/environment.js", () => ({
   exposeGc: vi.fn(),
+  isSmokeTest: false,
 }));
 
 vi.mock("../../services/HelpSessionService.js", () => ({

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -52,6 +52,7 @@ import type { WindowRegistry } from "./WindowRegistry.js";
 import type { ProjectViewManager } from "./ProjectViewManager.js";
 import { getProjectStatsService } from "../ipc/handlers/projectCrud/index.js";
 import { registerDeferredTask } from "./deferredInitQueue.js";
+import { isSmokeTest } from "../setup/environment.js";
 import { projectStore } from "../services/ProjectStore.js";
 import { store } from "../store.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
@@ -321,6 +322,26 @@ export async function initGlobalServices(
       void pluginService.activateStartupFinishedPlugins();
     },
   });
+
+  // CLI control socket (F32) — lets the `daintree-plugin` CLI install/uninstall
+  // into this running instance. Registered after `plugin-service` and gated
+  // internally on `pluginService.waitForInit()`, so the socket only accepts a
+  // `plugin.install` once activation has settled. Skipped under smoke test (no
+  // CLI driving a headless boot) to avoid leaving a socket behind.
+  if (!isSmokeTest) {
+    registerDeferredTask({
+      name: "plugin-cli-server",
+      run: async () => {
+        try {
+          const { startPluginCliServer } = await import("../services/PluginCliServer.js");
+          await startPluginCliServer();
+          console.log("[MAIN] Plugin CLI control socket listening");
+        } catch (err) {
+          console.warn("[MAIN] Plugin CLI control socket failed to start (non-fatal):", err);
+        }
+      },
+    });
+  }
 
   // ── Deferred global service starts ──
   // These were previously run on the same tick as loadRenderer(), contending

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -332,13 +332,17 @@ export async function initGlobalServices(
     registerDeferredTask({
       name: "plugin-cli-server",
       run: async () => {
-        try {
-          const { startPluginCliServer } = await import("../services/PluginCliServer.js");
-          await startPluginCliServer();
-          console.log("[MAIN] Plugin CLI control socket listening");
-        } catch (err) {
-          console.warn("[MAIN] Plugin CLI control socket failed to start (non-fatal):", err);
-        }
+        // Fire-and-forget: startPluginCliServer() internally awaits
+        // pluginService.waitForInit() (which only settles after startup
+        // activation), so awaiting it here would stall every later deferred
+        // task behind plugin activation. The waitForReady gate guarantees no
+        // CLI request is serviced before init settles, so binding async is safe.
+        const { startPluginCliServer } = await import("../services/PluginCliServer.js");
+        void startPluginCliServer()
+          .then(() => console.log("[MAIN] Plugin CLI control socket listening"))
+          .catch((err) =>
+            console.warn("[MAIN] Plugin CLI control socket failed to start (non-fatal):", err)
+          );
       },
     });
   }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1034,6 +1034,9 @@ export default tseslint.config(
       "dist/**",
       "dist-electron/**",
       "dist-typecheck/**",
+      // Built output of the workspace CLI packages (tsup). Bundled JS isn't
+      // source and trips no-undef on Node globals when linted locally.
+      "packages/*/dist/**",
       "release/**",
       "node_modules/**",
       "*.config.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -704,6 +704,27 @@
         "specificity": "bin/cli.js"
       }
     },
+    "node_modules/@clack/core": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.5.0.tgz",
+      "integrity": "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==",
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.11.0.tgz",
+      "integrity": "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "0.5.0",
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.20.2",
       "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.2.tgz",
@@ -6771,6 +6792,395 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
@@ -8461,6 +8871,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/app-builder-bin": {
       "version": "5.0.0-alpha.12",
       "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.12.tgz",
@@ -9302,6 +9719,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -9310,6 +9743,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -9501,6 +9944,22 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "license": "MIT"
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/chownr": {
       "version": "3.0.0",
@@ -9972,6 +10431,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
@@ -10151,6 +10627,10 @@
         "node": ">=18"
       }
     },
+    "node_modules/create-daintree-plugin": {
+      "resolved": "packages/create-daintree-plugin",
+      "link": true
+    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
@@ -10269,6 +10749,10 @@
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
+    },
+    "node_modules/daintree-plugin": {
+      "resolved": "packages/daintree-plugin",
+      "link": true
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -12771,6 +13255,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -13209,6 +13705,47 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globby": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.3",
+        "path-type": "^6.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/gopd": {
@@ -14216,6 +14753,16 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -14741,6 +15288,26 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lint-staged": {
       "version": "17.0.5",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.5.tgz",
@@ -14863,6 +15430,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/locate-path": {
@@ -15327,6 +15904,19 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
@@ -15374,6 +15964,18 @@
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
       }
     },
     "node_modules/nanoid": {
@@ -16265,6 +16867,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/path-type": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -16331,7 +16945,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -16346,6 +16959,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -16354,6 +16977,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
       }
     },
     "node_modules/playwright": {
@@ -16444,6 +17079,49 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/postcss-selector-parser": {
@@ -17136,6 +17814,20 @@
         "url": "https://github.com/sponsors/yqnn"
       }
     },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/refractor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/refractor/-/refractor-5.0.0.tgz",
@@ -17233,6 +17925,16 @@
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -17452,6 +18154,51 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/rollup-plugin-visualizer": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-7.0.1.tgz",
@@ -17550,6 +18297,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
       }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -18271,6 +19025,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
@@ -18641,6 +19413,39 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/sumchecker": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
@@ -18891,6 +19696,29 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/tiny-async-pool": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz",
@@ -19093,6 +19921,13 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/ts-morph": {
       "version": "28.0.0",
       "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-28.0.0.tgz",
@@ -19109,6 +19944,550 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/tsup/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tsx": {
       "version": "4.22.3",
@@ -19270,6 +20649,13 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uint8array-extras": {
       "version": "1.5.0",
@@ -20442,7 +21828,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -20499,6 +21884,45 @@
         "use-sync-external-store": {
           "optional": true
         }
+      }
+    },
+    "packages/create-daintree-plugin": {
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "daintree-plugin": "*"
+      },
+      "bin": {
+        "create-daintree-plugin": "dist/create.js"
+      },
+      "devDependencies": {
+        "tsup": "^8.5.0"
+      },
+      "engines": {
+        "node": ">=22.13"
+      }
+    },
+    "packages/daintree-plugin": {
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@clack/prompts": "^0.11.0",
+        "archiver": "^8.0.0",
+        "commander": "^14.0.0",
+        "execa": "^9.6.0",
+        "globby": "^14.1.0",
+        "semver": "^7.8.0",
+        "yauzl": "^2.10.0",
+        "zod": "^4.4.0"
+      },
+      "bin": {
+        "daintree-plugin": "dist/cli.js"
+      },
+      "devDependencies": {
+        "tsup": "^8.5.0"
+      },
+      "engines": {
+        "node": ">=22.13"
       }
     },
     "packages/plugin-vite": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "knip": "knip",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "typecheck": "tsc --noEmit && tsc -b electron/tsconfig.json && tsc --noEmit -p electron/tsconfig.preload.json",
+    "typecheck": "tsc --noEmit && tsc -b electron/tsconfig.json && tsc --noEmit -p electron/tsconfig.preload.json && tsc --noEmit -p packages/daintree-plugin/tsconfig.json && tsc --noEmit -p packages/create-daintree-plugin/tsconfig.json",
     "check:channels": "node scripts/ci/check-channel-drift.mjs",
     "check:preload-backdoors": "node scripts/ci/check-preload-backdoors.mjs",
     "check:crash-loop-constants": "node scripts/ci/check-crash-loop-constants.mjs",

--- a/packages/create-daintree-plugin/package.json
+++ b/packages/create-daintree-plugin/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "create-daintree-plugin",
+  "version": "0.1.0",
+  "description": "Scaffold a new Daintree plugin. Shim for `npm create daintree-plugin`.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "bin": {
+    "create-daintree-plugin": "./dist/create.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=22.13"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "daintree-plugin": "*"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.0"
+  }
+}

--- a/packages/create-daintree-plugin/src/create.ts
+++ b/packages/create-daintree-plugin/src/create.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import { runNew } from "daintree-plugin";
+
+/**
+ * `npm create daintree-plugin <name>` / `npx create-daintree-plugin <name>`.
+ * A thin shim that forwards the positional name to `daintree-plugin new`.
+ */
+function messageOf(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+const name = process.argv[2];
+
+runNew(name).catch((err: unknown) => {
+  console.error(messageOf(err));
+  process.exit(1);
+});

--- a/packages/create-daintree-plugin/tsconfig.json
+++ b/packages/create-daintree-plugin/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "../../electron/types/archiver.d.ts"]
+}

--- a/packages/create-daintree-plugin/tsup.config.ts
+++ b/packages/create-daintree-plugin/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: { create: "src/create.ts" },
+  format: ["esm"],
+  target: "node22",
+  platform: "node",
+  clean: true,
+  // `daintree-plugin` is a declared runtime dependency — resolve it from
+  // node_modules rather than bundling a duplicate copy.
+  external: ["daintree-plugin", "electron"],
+});

--- a/packages/daintree-plugin/package.json
+++ b/packages/daintree-plugin/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "daintree-plugin",
+  "version": "0.1.0",
+  "description": "CLI for building, validating, packaging, and installing Daintree plugins.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "bin": {
+    "daintree-plugin": "./dist/cli.js"
+  },
+  "main": "./dist/index.js",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=22.13"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@clack/prompts": "^0.11.0",
+    "archiver": "^8.0.0",
+    "commander": "^14.0.0",
+    "execa": "^9.6.0",
+    "globby": "^14.1.0",
+    "semver": "^7.8.0",
+    "yauzl": "^2.10.0",
+    "zod": "^4.4.0"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.0"
+  }
+}

--- a/packages/daintree-plugin/src/__tests__/install.test.ts
+++ b/packages/daintree-plugin/src/__tests__/install.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import net from "node:net";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { runInstall } from "../commands/install.js";
+import { runUninstall } from "../commands/uninstall.js";
+import { DaintreeUnavailableError } from "../ipc/client.js";
+
+let tmpDir: string;
+let socketPath: string;
+let server: net.Server | null = null;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-install-test-"));
+  socketPath = path.join(tmpDir, "cli.sock");
+  process.env.DAINTREE_CLI_SOCKET = socketPath;
+});
+
+afterEach(async () => {
+  delete process.env.DAINTREE_CLI_SOCKET;
+  if (server) {
+    await new Promise<void>((resolve) => server!.close(() => resolve()));
+    server = null;
+  }
+  await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+});
+
+/** Stand up a one-shot server that replies to the first request with `reply`. */
+async function serve(
+  onRequest: (req: { method: string; params?: unknown }) => Record<string, unknown>
+): Promise<void> {
+  server = net.createServer((socket) => {
+    let buffer = "";
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk: string) => {
+      buffer += chunk;
+      const idx = buffer.indexOf("\n");
+      if (idx < 0) return;
+      const req = JSON.parse(buffer.slice(0, idx));
+      const reply = onRequest(req);
+      socket.write(JSON.stringify({ id: req.id, ...reply }) + "\n");
+    });
+  });
+  await new Promise<void>((resolve) => server!.listen(socketPath, () => resolve()));
+}
+
+describe("runInstall", () => {
+  it("resolves a local path and reports success", async () => {
+    let received: { method: string; params?: unknown } | null = null;
+    await serve((req) => {
+      received = req;
+      return { result: { status: "installed", pluginId: "acme.demo" } };
+    });
+
+    await runInstall("./my-plugin.dntr");
+    expect(received!.method).toBe("plugin.install");
+    expect((received!.params as { path: string }).path).toBe(
+      path.resolve(process.cwd(), "./my-plugin.dntr")
+    );
+  });
+
+  it("passes URLs through unchanged", async () => {
+    let received: { params?: unknown } | null = null;
+    await serve((req) => {
+      received = req;
+      return { result: { status: "installed", pluginId: "acme.demo" } };
+    });
+
+    await runInstall("https://example.com/plugin.dntr");
+    expect((received!.params as { url: string }).url).toBe("https://example.com/plugin.dntr");
+  });
+
+  it("throws with the host's error detail on failure", async () => {
+    await serve(() => ({
+      result: { status: "failed", errors: [{ message: "bad archive" }] },
+    }));
+    await expect(runInstall("./x.dntr")).rejects.toThrow(/bad archive/);
+  });
+
+  it("gives a friendly 'not running' error naming the socket when nothing listens", async () => {
+    // No server started — ENOENT on the socket path.
+    await expect(runInstall("./x.dntr")).rejects.toBeInstanceOf(DaintreeUnavailableError);
+    await expect(runInstall("./x.dntr")).rejects.toThrow(socketPath);
+  });
+});
+
+describe("runUninstall", () => {
+  it("sends the pluginId and resolves on ok", async () => {
+    let received: { method: string; params?: unknown } | null = null;
+    await serve((req) => {
+      received = req;
+      return { result: { status: "ok" } };
+    });
+
+    await runUninstall("acme.demo");
+    expect(received!.method).toBe("plugin.uninstall");
+    expect((received!.params as { pluginId: string }).pluginId).toBe("acme.demo");
+  });
+
+  it("surfaces a host rejection (e.g. bad id) as an error", async () => {
+    await serve(() => ({ error: { message: "pluginId must be a scoped plugin name" } }));
+    await expect(runUninstall("bogus")).rejects.toThrow(/scoped plugin name/);
+  });
+});

--- a/packages/daintree-plugin/src/__tests__/install.test.ts
+++ b/packages/daintree-plugin/src/__tests__/install.test.ts
@@ -83,6 +83,22 @@ describe("runInstall", () => {
     await expect(runInstall("./x.dntr")).rejects.toBeInstanceOf(DaintreeUnavailableError);
     await expect(runInstall("./x.dntr")).rejects.toThrow(socketPath);
   });
+
+  it("rejects promptly when the server accepts then closes without responding", async () => {
+    server = net.createServer((socket) => socket.destroy());
+    await new Promise<void>((resolve) => server!.listen(socketPath, () => resolve()));
+    await expect(runInstall("./x.dntr")).rejects.toBeInstanceOf(DaintreeUnavailableError);
+  });
+
+  it("trims surrounding whitespace before deciding path vs url", async () => {
+    let received: { params?: unknown } | null = null;
+    await serve((req) => {
+      received = req;
+      return { result: { status: "installed", pluginId: "acme.demo" } };
+    });
+    await runInstall("  https://example.com/p.dntr  ");
+    expect((received!.params as { url: string }).url).toBe("https://example.com/p.dntr");
+  });
 });
 
 describe("runUninstall", () => {

--- a/packages/daintree-plugin/src/__tests__/new.test.ts
+++ b/packages/daintree-plugin/src/__tests__/new.test.ts
@@ -86,6 +86,25 @@ describe("scaffoldPlugin", () => {
     ).rejects.toThrow(/Plugin name/);
   });
 
+  it("escapes a hostile displayName so generated source stays well-formed", async () => {
+    const displayName = 'Bob "The" Tool';
+    const result = await scaffoldPlugin({
+      cwd: tmpDir,
+      targetDir: "inject",
+      publisher: "acme",
+      displayName,
+      template: "command",
+    });
+    const src = await fs.readFile(path.join(result.dir, "src", "index.ts"), "utf8");
+    // Values are embedded via JSON.stringify, so inner quotes are escaped rather
+    // than left raw to break the surrounding double-quoted literal.
+    expect(src).toContain(JSON.stringify(`${displayName}: Run`));
+    expect(src).toContain(JSON.stringify(`Hello from ${displayName}`));
+    // plugin.json remains valid JSON with the verbatim display name.
+    const manifest = await readJson(path.join(result.dir, "plugin.json"));
+    expect(manifest.displayName).toBe(displayName);
+  });
+
   it("view template contributes a panel view with a built componentPath", async () => {
     const result = await scaffoldPlugin({
       cwd: tmpDir,

--- a/packages/daintree-plugin/src/__tests__/new.test.ts
+++ b/packages/daintree-plugin/src/__tests__/new.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { scaffoldPlugin } from "../commands/new.js";
+import { getPluginManifestSchema } from "../../../../electron/schemas/plugin.js";
+import { TEMPLATE_KINDS } from "../scaffold/templates.js";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-new-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+async function readJson(file: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await fs.readFile(file, "utf8"));
+}
+
+describe("scaffoldPlugin", () => {
+  for (const template of TEMPLATE_KINDS) {
+    it(`scaffolds a valid project from the "${template}" template`, async () => {
+      const result = await scaffoldPlugin({
+        cwd: tmpDir,
+        targetDir: "issue-helper",
+        publisher: "acme",
+        displayName: "Issue Helper",
+        template,
+      });
+
+      expect(result.scopedName).toBe("acme.issue-helper");
+      expect(result.dir).toBe(path.join(tmpDir, "issue-helper"));
+
+      // plugin.json passes the host's manifest schema.
+      const manifest = await readJson(path.join(result.dir, "plugin.json"));
+      const parsed = getPluginManifestSchema(false).safeParse(manifest);
+      expect(parsed.success).toBe(true);
+      expect(manifest.name).toBe("acme.issue-helper");
+
+      // package.json + entry exist.
+      const pkg = await readJson(path.join(result.dir, "package.json"));
+      expect(pkg.name).toBe("acme.issue-helper");
+      expect((pkg.scripts as Record<string, string>).package).toContain("daintree-plugin package");
+      await expect(fs.access(path.join(result.dir, "src", "index.ts"))).resolves.toBeUndefined();
+      await expect(fs.access(path.join(result.dir, ".gitignore"))).resolves.toBeUndefined();
+    });
+  }
+
+  it("refuses to overwrite an existing directory", async () => {
+    await fs.mkdir(path.join(tmpDir, "taken"));
+    await expect(
+      scaffoldPlugin({
+        cwd: tmpDir,
+        targetDir: "taken",
+        publisher: "acme",
+        displayName: "Taken",
+        template: "command",
+      })
+    ).rejects.toThrow(/already exists/);
+  });
+
+  it("rejects an invalid publisher segment", async () => {
+    await expect(
+      scaffoldPlugin({
+        cwd: tmpDir,
+        targetDir: "ok-name",
+        publisher: "Acme Corp",
+        displayName: "x",
+        template: "command",
+      })
+    ).rejects.toThrow(/Publisher/);
+  });
+
+  it("rejects an invalid plugin-name segment", async () => {
+    await expect(
+      scaffoldPlugin({
+        cwd: tmpDir,
+        targetDir: "Bad_Name",
+        publisher: "acme",
+        displayName: "x",
+        template: "command",
+      })
+    ).rejects.toThrow(/Plugin name/);
+  });
+
+  it("view template contributes a panel view with a built componentPath", async () => {
+    const result = await scaffoldPlugin({
+      cwd: tmpDir,
+      targetDir: "viewer",
+      publisher: "acme",
+      displayName: "Viewer",
+      template: "view",
+    });
+    const manifest = await readJson(path.join(result.dir, "plugin.json"));
+    const views = (manifest.contributes as { experimental_views: Array<{ componentPath: string }> })
+      .experimental_views;
+    expect(views[0].componentPath).toBe("dist/panel.js");
+    await expect(fs.access(path.join(result.dir, "src", "panel.tsx"))).resolves.toBeUndefined();
+  });
+});

--- a/packages/daintree-plugin/src/__tests__/package.test.ts
+++ b/packages/daintree-plugin/src/__tests__/package.test.ts
@@ -86,4 +86,27 @@ describe("runPackage", () => {
     await writeFile("dist/index.js", "export const x = 1;");
     await expect(runPackage({ dir: tmpDir, skipBuild: true })).rejects.toThrow(/validation failed/);
   });
+
+  it("keeps the output filename inside the plugin dir for a malicious version", async () => {
+    await writeFile(
+      "plugin.json",
+      JSON.stringify({
+        name: "acme.packtest",
+        version: "../../escape",
+        main: "dist/index.js",
+        engines: { daintree: "^0.11.0" },
+      })
+    );
+    await writeFile("dist/index.js", "export const x = 1;");
+    const result = await runPackage({ dir: tmpDir, skipBuild: true });
+    expect(path.dirname(result.outputPath!)).toBe(tmpDir);
+    expect(result.outputPath!).not.toContain("/..");
+  });
+
+  it("dry run never invokes the Vite build (no vite in fixture)", async () => {
+    await fixture();
+    // No node_modules/.bin/vite exists; if dry-run tried to build it would throw.
+    const result = await runPackage({ dir: tmpDir, dryRun: true });
+    expect(result.outputPath).toBeUndefined();
+  });
 });

--- a/packages/daintree-plugin/src/__tests__/package.test.ts
+++ b/packages/daintree-plugin/src/__tests__/package.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { runPackage } from "../commands/package.js";
+import { verifyPluginArchive } from "../../../../electron/services/PluginArchive.js";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-package-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+async function writeFile(rel: string, content: string): Promise<void> {
+  const full = path.join(tmpDir, rel);
+  await fs.mkdir(path.dirname(full), { recursive: true });
+  await fs.writeFile(full, content, "utf8");
+}
+
+async function fixture(): Promise<void> {
+  await writeFile(
+    "plugin.json",
+    JSON.stringify({
+      name: "acme.packtest",
+      version: "0.2.0",
+      main: "dist/index.js",
+      engines: { daintree: "^0.11.0" },
+    })
+  );
+  await writeFile("dist/index.js", "export const x = 1;");
+  await writeFile("dist/index.js.map", '{"version":3}');
+  await writeFile("src/index.ts", "export const x: number = 1;");
+  await writeFile("node_modules/dep/index.js", "module.exports = {}");
+  // dist/ and node_modules/ are gitignored — dist must still ship (build output).
+  await writeFile(".gitignore", "dist/\nnode_modules/\n");
+}
+
+describe("runPackage", () => {
+  it("dry run lists files without writing a .dntr", async () => {
+    await fixture();
+    const result = await runPackage({ dir: tmpDir, dryRun: true, skipBuild: true });
+    expect(result.outputPath).toBeUndefined();
+    const entries = await fs.readdir(tmpDir);
+    expect(entries.some((e) => e.endsWith(".dntr"))).toBe(false);
+  });
+
+  it("includes built output, excludes source and node_modules", async () => {
+    await fixture();
+    const result = await runPackage({ dir: tmpDir, dryRun: true, skipBuild: true });
+    expect(result.files).toContain("plugin.json");
+    expect(result.files).toContain("dist/index.js");
+    expect(result.files).not.toContain("src/index.ts");
+    expect(result.files.some((f) => f.startsWith("node_modules/"))).toBe(false);
+    // Source maps excluded by default.
+    expect(result.files).not.toContain("dist/index.js.map");
+  });
+
+  it("includes source maps when sourcemaps=true", async () => {
+    await fixture();
+    const result = await runPackage({
+      dir: tmpDir,
+      dryRun: true,
+      skipBuild: true,
+      sourcemaps: true,
+    });
+    expect(result.files).toContain("dist/index.js.map");
+  });
+
+  it("writes a verifiable .dntr archive", async () => {
+    await fixture();
+    const result = await runPackage({ dir: tmpDir, skipBuild: true });
+    expect(result.outputPath).toBe(path.join(tmpDir, "acme.packtest-0.2.0.dntr"));
+    const verify = await verifyPluginArchive(result.outputPath!);
+    expect(verify.valid).toBe(true);
+    if (verify.valid) {
+      expect(verify.manifest.name).toBe("acme.packtest");
+    }
+  });
+
+  it("fails on an invalid manifest", async () => {
+    await writeFile("plugin.json", JSON.stringify({ name: "no-dot", version: "1.0.0" }));
+    await writeFile("dist/index.js", "export const x = 1;");
+    await expect(runPackage({ dir: tmpDir, skipBuild: true })).rejects.toThrow(/validation failed/);
+  });
+});

--- a/packages/daintree-plugin/src/__tests__/validate.test.ts
+++ b/packages/daintree-plugin/src/__tests__/validate.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { runValidate } from "../commands/validate.js";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-validate-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+async function writeManifest(obj: unknown): Promise<void> {
+  await fs.writeFile(path.join(tmpDir, "plugin.json"), JSON.stringify(obj), "utf8");
+}
+
+describe("runValidate", () => {
+  it("passes a valid manifest", async () => {
+    await writeManifest({
+      name: "acme.demo",
+      version: "1.0.0",
+      engines: { daintree: "^0.11.0" },
+    });
+    const result = await runValidate({ dir: tmpDir });
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("reports schema errors for an invalid name", async () => {
+    await writeManifest({ name: "NoDotName", version: "1.0.0" });
+    const result = await runValidate({ dir: tmpDir });
+    expect(result.ok).toBe(false);
+    expect(result.errors.join("\n")).toMatch(/name/);
+  });
+
+  it("fails when plugin.json is missing", async () => {
+    const result = await runValidate({ dir: tmpDir });
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toMatch(/Couldn't read plugin\.json/);
+  });
+
+  it("warns when engines.daintree is omitted", async () => {
+    await writeManifest({ name: "acme.demo", version: "1.0.0" });
+    const result = await runValidate({ dir: tmpDir });
+    expect(result.ok).toBe(true);
+    expect(result.warnings.join("\n")).toMatch(/engines\.daintree omitted/);
+  });
+
+  it("warns when a command has no keywords", async () => {
+    await writeManifest({
+      name: "acme.demo",
+      version: "1.0.0",
+      engines: { daintree: "^0.11.0" },
+      contributes: {
+        commands: [
+          {
+            id: "run",
+            title: "Run",
+            description: "Run it",
+            category: "Demo",
+            kind: "command",
+            danger: "safe",
+          },
+        ],
+      },
+    });
+    const result = await runValidate({ dir: tmpDir });
+    expect(result.ok).toBe(true);
+    expect(result.warnings.join("\n")).toMatch(/keywords is empty/);
+  });
+
+  it("--env errors when a ${settings:…} token has no value", async () => {
+    await writeManifest({
+      name: "acme.demo",
+      version: "1.0.0",
+      engines: { daintree: "^0.11.0" },
+      contributes: {
+        experimental_mcpServers: [
+          {
+            id: "main",
+            name: "Server",
+            command: "node",
+            args: ["server.js"],
+            env: { TOKEN: "${settings:apiToken}" },
+          },
+        ],
+      },
+    });
+    const result = await runValidate({ dir: tmpDir, env: true });
+    expect(result.ok).toBe(false);
+    expect(result.errors.join("\n")).toMatch(/apiToken/);
+  });
+
+  it("--env resolves tokens present in .daintree-plugin-env", async () => {
+    await writeManifest({
+      name: "acme.demo",
+      version: "1.0.0",
+      engines: { daintree: "^0.11.0" },
+      contributes: {
+        experimental_mcpServers: [
+          {
+            id: "main",
+            name: "Server",
+            command: "node",
+            args: ["server.js"],
+            env: { TOKEN: "${settings:apiToken}" },
+          },
+        ],
+      },
+    });
+    await fs.writeFile(
+      path.join(tmpDir, ".daintree-plugin-env"),
+      "# comment\napiToken=secret-value\n",
+      "utf8"
+    );
+    const result = await runValidate({ dir: tmpDir, env: true });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/packages/daintree-plugin/src/cli.ts
+++ b/packages/daintree-plugin/src/cli.ts
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+import { Command } from "commander";
+import { runNew } from "./commands/new.js";
+import { runValidate } from "./commands/validate.js";
+import { runPackage } from "./commands/package.js";
+import { runInstall } from "./commands/install.js";
+import { runUninstall } from "./commands/uninstall.js";
+
+function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+const program = new Command();
+
+program
+  .name("daintree-plugin")
+  .description("Build, validate, package, and install Daintree plugins")
+  .version("0.1.0");
+
+program
+  .command("new")
+  .argument("[name]", "plugin name (also the directory)")
+  .description("Scaffold a new plugin project")
+  .action(async (name?: string) => {
+    try {
+      await runNew(name);
+    } catch (err) {
+      fail((err as Error).message);
+    }
+  });
+
+program
+  .command("validate")
+  .description("Validate plugin.json against Daintree's manifest schema")
+  .option("--env", "resolve ${settings:…} tokens against .daintree-plugin-env")
+  .action(async (opts: { env?: boolean }) => {
+    try {
+      const result = await runValidate({ env: opts.env });
+      if (result.ok) {
+        console.log("✓ plugin.json is valid");
+      }
+      for (const warning of result.warnings) {
+        console.log(`⚠  ${warning}`);
+      }
+      if (!result.ok) {
+        for (const error of result.errors) {
+          console.error(`✗  ${error}`);
+        }
+        process.exit(1);
+      }
+    } catch (err) {
+      fail((err as Error).message);
+    }
+  });
+
+program
+  .command("package")
+  .description("Produce a distributable .dntr file")
+  .option("--verbose", "list every included file")
+  .option("--dry-run", "preview the file list without writing the archive")
+  .option("--sourcemaps", "include source maps in the archive")
+  .option("--skip-build", "skip the Vite build step")
+  .action(
+    async (opts: {
+      verbose?: boolean;
+      dryRun?: boolean;
+      sourcemaps?: boolean;
+      skipBuild?: boolean;
+    }) => {
+      try {
+        await runPackage({
+          verbose: opts.verbose,
+          dryRun: opts.dryRun,
+          sourcemaps: opts.sourcemaps,
+          skipBuild: opts.skipBuild,
+        });
+      } catch (err) {
+        fail((err as Error).message);
+      }
+    }
+  );
+
+program
+  .command("install")
+  .argument("<path-or-url>", "a .dntr file path or URL")
+  .description("Install a plugin into the running Daintree")
+  .action(async (target: string) => {
+    try {
+      await runInstall(target);
+    } catch (err) {
+      fail((err as Error).message);
+    }
+  });
+
+program
+  .command("uninstall")
+  .argument("<pluginId>", "scoped plugin id (publisher.name)")
+  .description("Uninstall a plugin from the running Daintree")
+  .action(async (pluginId: string) => {
+    try {
+      await runUninstall(pluginId);
+    } catch (err) {
+      fail((err as Error).message);
+    }
+  });
+
+program
+  .command("dev")
+  .description("Start the hot-reload dev loop (not yet available — planned for F32b)")
+  .action(() => {
+    fail("The hot-reload dev loop isn't available yet — planned for a later release (F32b).");
+  });
+
+program.parseAsync(process.argv).catch((err) => {
+  fail((err as Error).message);
+});

--- a/packages/daintree-plugin/src/commands/install.ts
+++ b/packages/daintree-plugin/src/commands/install.ts
@@ -1,0 +1,39 @@
+import path from "node:path";
+import { sendCliRequest } from "../ipc/client.js";
+
+interface InstallResponse {
+  status: string;
+  pluginId?: string;
+  errors?: Array<{ message: string }>;
+}
+
+function isUrl(target: string): boolean {
+  return /^https?:\/\//i.test(target);
+}
+
+/**
+ * Install a `.dntr` file or URL into the running Daintree instance. Local paths
+ * are resolved against the cwd; URLs are passed through unchanged so the host
+ * owns the bounded download. Throws with a clear message if Daintree isn't
+ * running or the install fails.
+ */
+export async function runInstall(target: string): Promise<void> {
+  const params = isUrl(target) ? { url: target } : { path: path.resolve(process.cwd(), target) };
+
+  const result = (await sendCliRequest("plugin.install", params)) as InstallResponse;
+
+  if (result.status === "installed") {
+    console.log(`Installed ${result.pluginId ?? target}`);
+    return;
+  }
+
+  if (result.status === "cancelled") {
+    throw new Error("Install was cancelled by Daintree");
+  }
+
+  const detail =
+    result.errors && result.errors.length > 0
+      ? result.errors.map((e) => e.message).join("; ")
+      : result.status;
+  throw new Error(`Install failed: ${detail}`);
+}

--- a/packages/daintree-plugin/src/commands/install.ts
+++ b/packages/daintree-plugin/src/commands/install.ts
@@ -17,7 +17,8 @@ function isUrl(target: string): boolean {
  * owns the bounded download. Throws with a clear message if Daintree isn't
  * running or the install fails.
  */
-export async function runInstall(target: string): Promise<void> {
+export async function runInstall(rawTarget: string): Promise<void> {
+  const target = rawTarget.trim();
   const params = isUrl(target) ? { url: target } : { path: path.resolve(process.cwd(), target) };
 
   const result = (await sendCliRequest("plugin.install", params)) as InstallResponse;

--- a/packages/daintree-plugin/src/commands/new.ts
+++ b/packages/daintree-plugin/src/commands/new.ts
@@ -1,0 +1,169 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import * as p from "@clack/prompts";
+import { SCOPED_PLUGIN_NAME_PATTERN } from "../../../../electron/schemas/plugin.js";
+import {
+  buildTemplateFiles,
+  TEMPLATE_KINDS,
+  type ScaffoldContext,
+  type TemplateKind,
+} from "../scaffold/templates.js";
+
+/** A single publisher/plugin name segment (the half on either side of the dot). */
+const SEGMENT_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export interface ScaffoldPluginOptions {
+  /** Parent directory the plugin folder is created under. */
+  cwd: string;
+  /** Folder name; doubles as the plugin segment of the scoped name. */
+  targetDir: string;
+  publisher: string;
+  displayName: string;
+  template: TemplateKind;
+}
+
+export interface ScaffoldResult {
+  dir: string;
+  scopedName: string;
+  files: string[];
+}
+
+function segmentError(value: string, label: string): string | null {
+  if (!SEGMENT_PATTERN.test(value)) {
+    return `${label} must be lowercase letters, digits, and single hyphens (e.g. "acme" or "issue-helper")`;
+  }
+  return null;
+}
+
+/**
+ * Write a plugin project from a template. Does no prompting — `runNew` handles
+ * interactivity, this is the unit-testable core. Refuses to write into an
+ * existing directory (Tier D1: never silently clobber an author's work).
+ */
+export async function scaffoldPlugin(opts: ScaffoldPluginOptions): Promise<ScaffoldResult> {
+  const pubErr = segmentError(opts.publisher, "Publisher");
+  if (pubErr) throw new Error(pubErr);
+  const nameErr = segmentError(opts.targetDir, "Plugin name");
+  if (nameErr) throw new Error(nameErr);
+
+  const scopedName = `${opts.publisher}.${opts.targetDir}`;
+  if (!SCOPED_PLUGIN_NAME_PATTERN.test(scopedName)) {
+    throw new Error(`"${scopedName}" is not a valid plugin name (expected publisher.name)`);
+  }
+
+  const dir = path.resolve(opts.cwd, opts.targetDir);
+  let dirExists = false;
+  try {
+    await fs.access(dir);
+    dirExists = true;
+  } catch {
+    dirExists = false;
+  }
+  if (dirExists) {
+    throw new Error(`Directory already exists: ${dir}`);
+  }
+
+  const ctx: ScaffoldContext = {
+    scopedName,
+    publisher: opts.publisher,
+    pluginName: opts.targetDir,
+    displayName: opts.displayName,
+    template: opts.template,
+  };
+  const files = buildTemplateFiles(ctx);
+
+  for (const [relPath, content] of Object.entries(files)) {
+    const fullPath = path.join(dir, relPath);
+    await fs.mkdir(path.dirname(fullPath), { recursive: true });
+    await fs.writeFile(fullPath, content, "utf8");
+  }
+
+  return { dir, scopedName, files: Object.keys(files).sort() };
+}
+
+function cancelled<T>(value: T | symbol): value is symbol {
+  return p.isCancel(value);
+}
+
+/**
+ * Interactive `daintree-plugin new`. Prompts for publisher, display name, and
+ * template, then scaffolds the project. The directory name is the positional
+ * `name` arg (prompted for when omitted).
+ */
+export async function runNew(name?: string): Promise<void> {
+  p.intro("Create a Daintree plugin");
+
+  let targetDir = name;
+  if (!targetDir) {
+    const answer = await p.text({
+      message: "Plugin name (also the directory)",
+      placeholder: "issue-helper",
+      validate: (value) => segmentError(value, "Plugin name") ?? undefined,
+    });
+    if (cancelled(answer)) {
+      p.cancel("Cancelled");
+      return;
+    }
+    targetDir = answer;
+  } else {
+    const err = segmentError(targetDir, "Plugin name");
+    if (err) {
+      p.cancel(err);
+      return;
+    }
+  }
+
+  const publisher = await p.text({
+    message: "Publisher",
+    placeholder: "acme",
+    validate: (value) => segmentError(value, "Publisher") ?? undefined,
+  });
+  if (cancelled(publisher)) {
+    p.cancel("Cancelled");
+    return;
+  }
+
+  const displayName = await p.text({
+    message: "Display name",
+    placeholder: "Issue Helper",
+    defaultValue: targetDir,
+  });
+  if (cancelled(displayName)) {
+    p.cancel("Cancelled");
+    return;
+  }
+
+  const template = await p.select({
+    message: "Template",
+    options: TEMPLATE_KINDS.map((kind) => ({
+      value: kind,
+      label: kind,
+      hint: TEMPLATE_HINTS[kind],
+    })),
+  });
+  if (cancelled(template)) {
+    p.cancel("Cancelled");
+    return;
+  }
+
+  const result = await scaffoldPlugin({
+    cwd: process.cwd(),
+    targetDir,
+    publisher,
+    displayName: displayName || targetDir,
+    template: template as TemplateKind,
+  });
+
+  p.outro(
+    `Created ${result.scopedName} in ${path.relative(process.cwd(), result.dir) || "."}\n` +
+      `Next: cd ${targetDir} && npm install && npx daintree-plugin package\n` +
+      `(The @daintreehq/plugin-sdk dev dependency must be available for npm install to succeed.)`
+  );
+}
+
+const TEMPLATE_HINTS: Record<TemplateKind, string> = {
+  command: "single command with a handler",
+  view: "panel view + React component",
+  mcp: "skeleton MCP server",
+  full: "command + view + MCP example",
+};

--- a/packages/daintree-plugin/src/commands/new.ts
+++ b/packages/daintree-plugin/src/commands/new.ts
@@ -52,13 +52,10 @@ export async function scaffoldPlugin(opts: ScaffoldPluginOptions): Promise<Scaff
   }
 
   const dir = path.resolve(opts.cwd, opts.targetDir);
-  let dirExists = false;
-  try {
-    await fs.access(dir);
-    dirExists = true;
-  } catch {
-    dirExists = false;
-  }
+  const dirExists = await fs
+    .access(dir)
+    .then(() => true)
+    .catch(() => false);
   if (dirExists) {
     throw new Error(`Directory already exists: ${dir}`);
   }

--- a/packages/daintree-plugin/src/commands/package.ts
+++ b/packages/daintree-plugin/src/commands/package.ts
@@ -1,0 +1,140 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { globby } from "globby";
+import { execa } from "execa";
+import {
+  packPluginArchiveFromFiles,
+  isExcludedArchiveEntry,
+  verifyPluginArchive,
+} from "../../../../electron/services/PluginArchive.js";
+import { runValidate } from "./validate.js";
+
+export interface PackageOptions {
+  dir?: string;
+  verbose?: boolean;
+  dryRun?: boolean;
+  sourcemaps?: boolean;
+  skipBuild?: boolean;
+}
+
+export interface PackageResult {
+  /** Absolute path to the written `.dntr`, or undefined for a dry run. */
+  outputPath?: string;
+  /** POSIX-relative paths included in the archive, sorted. */
+  files: string[];
+}
+
+interface MinimalManifest {
+  name: string;
+  version: string;
+  main?: string;
+  contributes?: {
+    experimental_views?: Array<{ componentPath?: string }>;
+  };
+}
+
+/**
+ * Top-level directories that must be packaged even when `.gitignore` lists them
+ * (build output is gitignored by convention but is exactly what ships). Derived
+ * from `main` and any view `componentPath`, defaulting to `dist`.
+ */
+function protectedDirs(manifest: MinimalManifest): string[] {
+  const dirs = new Set<string>(["dist"]);
+  const add = (ref?: string) => {
+    if (!ref) return;
+    const normalized = ref.replace(/\\/g, "/");
+    const top = normalized.split("/")[0];
+    if (top && top !== "." && top !== "..") dirs.add(top);
+  };
+  add(manifest.main);
+  for (const view of manifest.contributes?.experimental_views ?? []) {
+    add(view.componentPath);
+  }
+  return [...dirs];
+}
+
+async function runViteBuild(dir: string): Promise<void> {
+  const binName = process.platform === "win32" ? "vite.cmd" : "vite";
+  const bin = path.join(dir, "node_modules", ".bin", binName);
+  try {
+    await fs.access(bin);
+  } catch {
+    throw new Error(
+      `Couldn't find Vite at ${bin}. Run npm install in the plugin directory, or pass --skip-build.`
+    );
+  }
+  await execa(bin, ["build"], { cwd: dir, stdio: "inherit" });
+}
+
+/**
+ * Build (unless `--skip-build`), collect files honoring `.gitignore` plus the
+ * normative `.dntr` exclusion list, and write a deterministic
+ * `{pluginId}-{version}.dntr`. Reuses the host's archive writer so CLI output
+ * is byte-identical to Daintree's own packer on the same OS.
+ */
+export async function runPackage(opts: PackageOptions = {}): Promise<PackageResult> {
+  const dir = path.resolve(opts.dir ?? process.cwd());
+
+  const validation = await runValidate({ dir });
+  if (!validation.ok) {
+    throw new Error(`Manifest validation failed:\n  ${validation.errors.join("\n  ")}`);
+  }
+
+  const manifest = JSON.parse(
+    await fs.readFile(path.join(dir, "plugin.json"), "utf8")
+  ) as MinimalManifest;
+
+  if (!opts.skipBuild) {
+    await runViteBuild(dir);
+  }
+
+  // Candidate set honoring .gitignore (drops cruft like .env, coverage/).
+  const gitignored = await globby("**/*", {
+    cwd: dir,
+    gitignore: true,
+    dot: false,
+    onlyFiles: true,
+  });
+
+  // Build output / manifest-referenced dirs must ship even if gitignored.
+  const preserved = await globby(
+    protectedDirs(manifest).map((d) => `${d}/**/*`),
+    { cwd: dir, dot: false, onlyFiles: true }
+  );
+
+  const candidates = new Set<string>([...gitignored, ...preserved, "plugin.json"]);
+
+  const sourcemaps = opts.sourcemaps ?? false;
+  const files = [...candidates]
+    .filter((f) => !f.endsWith(".dntr"))
+    .filter((f) => !isExcludedArchiveEntry(f, sourcemaps))
+    .sort();
+
+  if (!files.includes("plugin.json")) {
+    throw new Error("plugin.json not found in the plugin directory");
+  }
+
+  if (opts.verbose || opts.dryRun) {
+    for (const f of files) {
+      console.log(`  ${f}`);
+    }
+  }
+
+  const outputName = `${manifest.name}-${manifest.version}.dntr`;
+  const outputPath = path.join(dir, outputName);
+
+  if (opts.dryRun) {
+    console.log(`Dry run — would write ${outputName} (${files.length} files)`);
+    return { files };
+  }
+
+  await packPluginArchiveFromFiles(dir, outputPath, files);
+
+  const verifyResult = await verifyPluginArchive(outputPath);
+  if (!verifyResult.valid) {
+    throw new Error(`Packaged archive failed verification: ${verifyResult.error}`);
+  }
+
+  console.log(`Wrote ${outputName} (${files.length} files)`);
+  return { outputPath, files };
+}

--- a/packages/daintree-plugin/src/commands/package.ts
+++ b/packages/daintree-plugin/src/commands/package.ts
@@ -84,7 +84,8 @@ export async function runPackage(opts: PackageOptions = {}): Promise<PackageResu
     await fs.readFile(path.join(dir, "plugin.json"), "utf8")
   ) as MinimalManifest;
 
-  if (!opts.skipBuild) {
+  // A dry run is a no-side-effects preview — never trigger the Vite build.
+  if (!opts.skipBuild && !opts.dryRun) {
     await runViteBuild(dir);
   }
 
@@ -120,7 +121,11 @@ export async function runPackage(opts: PackageOptions = {}): Promise<PackageResu
     }
   }
 
-  const outputName = `${manifest.name}-${manifest.version}.dntr`;
+  // `name` is regex-guarded by the schema, but `version` is only `min(1)` —
+  // strip any path-significant characters so a hostile `"version": "../../x"`
+  // can't write the archive outside the plugin directory.
+  const safeVersion = manifest.version.replace(/[^\w.\-]/g, "");
+  const outputName = `${manifest.name}-${safeVersion}.dntr`;
   const outputPath = path.join(dir, outputName);
 
   if (opts.dryRun) {

--- a/packages/daintree-plugin/src/commands/package.ts
+++ b/packages/daintree-plugin/src/commands/package.ts
@@ -124,7 +124,7 @@ export async function runPackage(opts: PackageOptions = {}): Promise<PackageResu
   // `name` is regex-guarded by the schema, but `version` is only `min(1)` —
   // strip any path-significant characters so a hostile `"version": "../../x"`
   // can't write the archive outside the plugin directory.
-  const safeVersion = manifest.version.replace(/[^\w.\-]/g, "");
+  const safeVersion = manifest.version.replace(/[^\w.-]/g, "");
   const outputName = `${manifest.name}-${safeVersion}.dntr`;
   const outputPath = path.join(dir, outputName);
 

--- a/packages/daintree-plugin/src/commands/uninstall.ts
+++ b/packages/daintree-plugin/src/commands/uninstall.ts
@@ -1,0 +1,11 @@
+import { sendCliRequest } from "../ipc/client.js";
+
+/**
+ * Uninstall a plugin by its scoped id (`publisher.name`) from the running
+ * Daintree instance. The host validates the id format and removes the install;
+ * throws with a clear message if Daintree isn't running or the id is rejected.
+ */
+export async function runUninstall(pluginId: string): Promise<void> {
+  await sendCliRequest("plugin.uninstall", { pluginId });
+  console.log(`Uninstalled ${pluginId}`);
+}

--- a/packages/daintree-plugin/src/commands/validate.ts
+++ b/packages/daintree-plugin/src/commands/validate.ts
@@ -1,0 +1,122 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { getPluginManifestSchema } from "../../../../electron/schemas/plugin.js";
+
+export interface ValidateOptions {
+  /** Plugin project directory (default: cwd). */
+  dir?: string;
+  /** Resolve `${settings:KEY}` tokens against `.daintree-plugin-env`. */
+  env?: boolean;
+}
+
+export interface ValidateResult {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+/** Match `${settings:KEY}` interpolation tokens used in mcpServers env/args. */
+const SETTINGS_TOKEN = /\$\{settings:([^}]+)\}/g;
+
+function parseEnvFile(content: string): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq < 0) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (key.length > 0) map.set(key, value);
+  }
+  return map;
+}
+
+/**
+ * Validate `plugin.json` against the same Zod schema Daintree uses at load.
+ * Returns structured errors and advisory warnings; the CLI layer prints and
+ * sets the exit code. With `env`, also checks that every `${settings:KEY}`
+ * token in the manifest resolves against `.daintree-plugin-env`.
+ */
+export async function runValidate(opts: ValidateOptions = {}): Promise<ValidateResult> {
+  const dir = opts.dir ?? process.cwd();
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const manifestPath = path.join(dir, "plugin.json");
+  let raw: string;
+  try {
+    raw = await fs.readFile(manifestPath, "utf8");
+  } catch {
+    return { ok: false, errors: [`Couldn't read plugin.json at ${manifestPath}`], warnings };
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch {
+    return { ok: false, errors: ["plugin.json is not valid JSON"], warnings };
+  }
+
+  const result = getPluginManifestSchema(false).safeParse(json);
+  if (!result.success) {
+    for (const issue of result.error.issues) {
+      const where = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+      errors.push(`${where}: ${issue.message}`);
+    }
+    return { ok: false, errors, warnings };
+  }
+
+  const manifest = result.data;
+
+  if (!manifest.engines?.daintree) {
+    warnings.push("engines.daintree omitted — consider pinning a range, e.g. ^0.11.0");
+  }
+
+  for (const [index, command] of manifest.contributes.commands.entries()) {
+    if (!command.keywords || command.keywords.length === 0) {
+      warnings.push(
+        `commands[${index}].keywords is empty — 2–3 terms help discoverability in the palette`
+      );
+    }
+  }
+
+  if (opts.env) {
+    const envPath = path.join(dir, ".daintree-plugin-env");
+    let envMap = new Map<string, string>();
+    let envExists = true;
+    try {
+      envMap = parseEnvFile(await fs.readFile(envPath, "utf8"));
+    } catch {
+      envExists = false;
+    }
+
+    const referenced = new Set<string>();
+    for (const match of raw.matchAll(SETTINGS_TOKEN)) {
+      const key = match[1]?.trim();
+      if (key) referenced.add(key);
+    }
+
+    if (referenced.size === 0) {
+      warnings.push("--env passed but no ${settings:…} tokens were found in plugin.json");
+    } else if (!envExists) {
+      errors.push(
+        `--env passed but ${envPath} is missing; can't resolve: ${[...referenced].join(", ")}`
+      );
+    } else {
+      for (const key of referenced) {
+        if (!envMap.has(key)) {
+          errors.push(`\${settings:${key}} has no value in .daintree-plugin-env`);
+        }
+      }
+    }
+  }
+
+  return { ok: errors.length === 0, errors, warnings };
+}

--- a/packages/daintree-plugin/src/index.ts
+++ b/packages/daintree-plugin/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Library surface for `daintree-plugin`. Consumed by `create-daintree-plugin`
+ * (the `npm create daintree-plugin` shim) to reuse the scaffold entry point.
+ */
+export { runNew, scaffoldPlugin } from "./commands/new.js";
+export type { ScaffoldPluginOptions, ScaffoldResult } from "./commands/new.js";
+export { runValidate } from "./commands/validate.js";
+export type { ValidateOptions, ValidateResult } from "./commands/validate.js";
+export { runPackage } from "./commands/package.js";
+export type { PackageOptions, PackageResult } from "./commands/package.js";
+export { runInstall } from "./commands/install.js";
+export { runUninstall } from "./commands/uninstall.js";
+export { TEMPLATE_KINDS, type TemplateKind } from "./scaffold/templates.js";

--- a/packages/daintree-plugin/src/ipc/client.ts
+++ b/packages/daintree-plugin/src/ipc/client.ts
@@ -1,0 +1,103 @@
+import net from "node:net";
+import { getCliSocketPath } from "../lib/socketPath.js";
+
+const REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Daintree isn't reachable on the control socket. `ENOENT` means no instance is
+ * running (the socket file is absent); `ECONNREFUSED` means a stale socket file
+ * was left by a crashed instance. Both name the socket path tried so authors
+ * can debug on Linux (lesson #4463).
+ */
+export class DaintreeUnavailableError extends Error {
+  constructor(
+    message: string,
+    readonly socketPath: string
+  ) {
+    super(message);
+    this.name = "DaintreeUnavailableError";
+  }
+}
+
+interface CliResponse {
+  id: string | number;
+  result?: unknown;
+  error?: { message: string };
+}
+
+/**
+ * Send one request frame to the running Daintree instance and resolve with the
+ * `result` (or reject with the `error.message`). Connection-level failures map
+ * to {@link DaintreeUnavailableError} with a human-facing message.
+ */
+export function sendCliRequest(method: string, params?: unknown): Promise<unknown> {
+  const socketPath = getCliSocketPath();
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection({ path: socketPath });
+    let buffer = "";
+    let settled = false;
+
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      socket.destroy();
+      fn();
+    };
+
+    const timer = setTimeout(() => {
+      finish(() => reject(new Error("Timed out waiting for Daintree to respond")));
+    }, REQUEST_TIMEOUT_MS);
+
+    socket.setEncoding("utf8");
+
+    socket.on("connect", () => {
+      socket.write(JSON.stringify({ id: 1, method, params }) + "\n");
+    });
+
+    socket.on("data", (chunk: string) => {
+      buffer += chunk;
+      const idx = buffer.indexOf("\n");
+      if (idx < 0) return;
+      const line = buffer.slice(0, idx);
+      let res: CliResponse;
+      try {
+        res = JSON.parse(line);
+      } catch {
+        finish(() => reject(new Error("Received a malformed response from Daintree")));
+        return;
+      }
+      if (res.error) {
+        finish(() => reject(new Error(res.error?.message ?? "Daintree returned an error")));
+        return;
+      }
+      finish(() => resolve(res.result));
+    });
+
+    socket.on("error", (err: NodeJS.ErrnoException) => {
+      if (err.code === "ENOENT") {
+        finish(() =>
+          reject(
+            new DaintreeUnavailableError(
+              `Daintree isn't running. Start Daintree and try again. (tried: ${socketPath})`,
+              socketPath
+            )
+          )
+        );
+        return;
+      }
+      if (err.code === "ECONNREFUSED") {
+        finish(() =>
+          reject(
+            new DaintreeUnavailableError(
+              `Couldn't connect to Daintree (stale socket at ${socketPath}). Restart Daintree and try again.`,
+              socketPath
+            )
+          )
+        );
+        return;
+      }
+      finish(() => reject(err));
+    });
+  });
+}

--- a/packages/daintree-plugin/src/ipc/client.ts
+++ b/packages/daintree-plugin/src/ipc/client.ts
@@ -74,6 +74,20 @@ export function sendCliRequest(method: string, params?: unknown): Promise<unknow
       finish(() => resolve(res.result));
     });
 
+    // The peer accepted the connection then closed it without a complete
+    // response frame — treat as an unusable/stale endpoint rather than hanging
+    // until the request timeout fires.
+    socket.on("close", () => {
+      finish(() =>
+        reject(
+          new DaintreeUnavailableError(
+            `Daintree closed the connection without responding (socket: ${socketPath}). Restart Daintree and try again.`,
+            socketPath
+          )
+        )
+      );
+    });
+
     socket.on("error", (err: NodeJS.ErrnoException) => {
       if (err.code === "ENOENT") {
         finish(() =>
@@ -86,11 +100,15 @@ export function sendCliRequest(method: string, params?: unknown): Promise<unknow
         );
         return;
       }
-      if (err.code === "ECONNREFUSED") {
+      // ECONNREFUSED: stale socket file with no listener. ECONNRESET/EPIPE: the
+      // peer accepted then dropped the connection mid-request (e.g. a process
+      // holding the path that doesn't speak the protocol). All mean "can't
+      // complete the request against this endpoint".
+      if (err.code === "ECONNREFUSED" || err.code === "ECONNRESET" || err.code === "EPIPE") {
         finish(() =>
           reject(
             new DaintreeUnavailableError(
-              `Couldn't connect to Daintree (stale socket at ${socketPath}). Restart Daintree and try again.`,
+              `Couldn't connect to Daintree (stale or unresponsive socket at ${socketPath}). Restart Daintree and try again.`,
               socketPath
             )
           )

--- a/packages/daintree-plugin/src/lib/socketPath.ts
+++ b/packages/daintree-plugin/src/lib/socketPath.ts
@@ -1,0 +1,19 @@
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Path to the running Daintree instance's CLI control socket. A named pipe on
+ * Windows (which doesn't live on disk), else `~/.daintree/cli.sock`. Kept in
+ * lockstep with the host's `getCliSocketPath()` in
+ * `electron/services/PluginCliServer.ts`.
+ */
+export function getCliSocketPath(): string {
+  const override = process.env.DAINTREE_CLI_SOCKET;
+  if (override && override.length > 0) {
+    return override;
+  }
+  if (process.platform === "win32") {
+    return "\\\\.\\pipe\\daintree-cli";
+  }
+  return path.join(os.homedir(), ".daintree", "cli.sock");
+}

--- a/packages/daintree-plugin/src/scaffold/templates.ts
+++ b/packages/daintree-plugin/src/scaffold/templates.ts
@@ -1,0 +1,301 @@
+/**
+ * Starter templates for `daintree-plugin new`. Each template returns a map of
+ * POSIX-relative path → file content. Content is embedded as strings so the
+ * published CLI is self-contained (no `templates/` directory to ship). The
+ * reference for the host API surface is `plugins/sample/hello-daintree/`.
+ */
+
+export type TemplateKind = "command" | "view" | "mcp" | "full";
+
+export const TEMPLATE_KINDS: readonly TemplateKind[] = ["command", "view", "mcp", "full"] as const;
+
+export interface ScaffoldContext {
+  /** Full scoped manifest name, e.g. `acme.issue-helper`. */
+  scopedName: string;
+  /** Publisher segment, e.g. `acme`. */
+  publisher: string;
+  /** Plugin segment, e.g. `issue-helper`. */
+  pluginName: string;
+  /** Human-facing display name. */
+  displayName: string;
+  template: TemplateKind;
+}
+
+const DAINTREE_ENGINE_RANGE = ">=0.11.0";
+
+function manifest(ctx: ScaffoldContext, contributes: Record<string, unknown>): string {
+  const obj = {
+    name: ctx.scopedName,
+    version: "0.1.0",
+    displayName: ctx.displayName,
+    description: `${ctx.displayName} — a Daintree plugin.`,
+    main: "dist/index.js",
+    engines: { daintree: DAINTREE_ENGINE_RANGE },
+    capabilities: [] as string[],
+    contributes,
+  };
+  return JSON.stringify(obj, null, 2) + "\n";
+}
+
+function packageJson(ctx: ScaffoldContext, needsReact: boolean): string {
+  const deps: Record<string, string> = {};
+  const devDeps: Record<string, string> = {
+    "@daintreehq/plugin-sdk": "^0.1.0",
+    "@daintreehq/plugin-vite": "^0.1.0",
+    typescript: "^5.6.0",
+    vite: "^8.0.0",
+  };
+  if (needsReact) {
+    devDeps.react = "^19.0.0";
+    devDeps["react-dom"] = "^19.0.0";
+  }
+  const obj = {
+    name: ctx.scopedName,
+    version: "0.1.0",
+    description: `${ctx.displayName} — a Daintree plugin.`,
+    type: "module",
+    private: true,
+    scripts: {
+      build: "vite build",
+      validate: "daintree-plugin validate",
+      package: "daintree-plugin package",
+    },
+    dependencies: deps,
+    devDependencies: devDeps,
+  };
+  return JSON.stringify(obj, null, 2) + "\n";
+}
+
+function tsconfig(jsx: boolean): string {
+  const compilerOptions: Record<string, unknown> = {
+    target: "ES2022",
+    module: "ESNext",
+    moduleResolution: "bundler",
+    lib: jsx ? ["ES2022", "DOM", "DOM.Iterable"] : ["ES2022"],
+    strict: true,
+    skipLibCheck: true,
+    noEmit: true,
+    isolatedModules: true,
+    esModuleInterop: true,
+  };
+  if (jsx) compilerOptions.jsx = "react-jsx";
+  return JSON.stringify({ compilerOptions, include: ["src"] }, null, 2) + "\n";
+}
+
+function viteConfig(entries: Record<string, string>): string {
+  const entryLiteral = JSON.stringify(entries, null, 6).replace(/\n/g, "\n  ");
+  return `import { daintreePlugin } from "@daintreehq/plugin-vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [daintreePlugin()],
+  build: {
+    lib: {
+      entry: ${entryLiteral},
+      formats: ["es"],
+    },
+    outDir: "dist",
+    sourcemap: true,
+  },
+});
+`;
+}
+
+const GITIGNORE = `node_modules/
+dist/
+*.dntr
+`;
+
+function commandEntry(ctx: ScaffoldContext): string {
+  return `import type { PluginHostApi } from "@daintreehq/plugin-sdk";
+
+/**
+ * ${ctx.displayName} — command plugin entry. Daintree calls \`activate\` once
+ * when the plugin loads; return a disposer to clean up on unload.
+ */
+export async function activate(host: PluginHostApi): Promise<() => void> {
+  const dispose = host.registerAction(
+    {
+      id: "run",
+      title: "${ctx.displayName}: Run",
+      description: "Run the ${ctx.displayName} command.",
+      category: "${ctx.displayName}",
+      kind: "command",
+      danger: "safe",
+    },
+    async () => {
+      await host.showToast({ message: "Hello from ${ctx.displayName}", type: "success" });
+      return { ran: true };
+    }
+  );
+
+  return () => {
+    dispose();
+  };
+}
+`;
+}
+
+function viewEntry(ctx: ScaffoldContext): string {
+  return `import type { PluginHostApi } from "@daintreehq/plugin-sdk";
+
+/**
+ * ${ctx.displayName} — view plugin entry. The panel UI lives in \`src/panel.tsx\`
+ * and is wired through \`contributes.experimental_views\` in plugin.json.
+ */
+export async function activate(_host: PluginHostApi): Promise<() => void> {
+  return () => {};
+}
+`;
+}
+
+function panelComponent(ctx: ScaffoldContext): string {
+  return `import React from "react";
+
+/**
+ * Panel view for ${ctx.displayName}. Rendered by Daintree when the user opens
+ * the contributed view.
+ */
+export default function Panel(): React.ReactElement {
+  return <div style={{ padding: 16 }}>Hello from ${ctx.displayName}</div>;
+}
+`;
+}
+
+function mcpEntry(ctx: ScaffoldContext): string {
+  return `import type { PluginHostApi } from "@daintreehq/plugin-sdk";
+
+/**
+ * ${ctx.displayName} — MCP plugin entry. The MCP server process is declared in
+ * \`contributes.experimental_mcpServers\` (see plugin.json) and spawned by
+ * Daintree; \`src/server.ts\` is its skeleton implementation.
+ */
+export async function activate(_host: PluginHostApi): Promise<() => void> {
+  return () => {};
+}
+`;
+}
+
+function mcpServer(ctx: ScaffoldContext): string {
+  return `#!/usr/bin/env node
+/**
+ * Minimal stdio MCP server skeleton for ${ctx.displayName}. Replace this with a
+ * real implementation using \`@modelcontextprotocol/sdk\`. Daintree spawns it
+ * per the \`command\`/\`args\` in plugin.json and speaks MCP over stdio.
+ */
+process.stdin.on("data", () => {
+  // Wire up an MCP server here (tools/list, tools/call, …).
+});
+`;
+}
+
+export function buildTemplateFiles(ctx: ScaffoldContext): Record<string, string> {
+  switch (ctx.template) {
+    case "command": {
+      return {
+        "plugin.json": manifest(ctx, {
+          commands: [
+            {
+              id: "run",
+              title: `${ctx.displayName}: Run`,
+              description: `Run the ${ctx.displayName} command.`,
+              category: ctx.displayName,
+              kind: "command",
+              danger: "safe",
+              keywords: [ctx.pluginName, "run"],
+            },
+          ],
+        }),
+        "package.json": packageJson(ctx, false),
+        "tsconfig.json": tsconfig(false),
+        "vite.config.ts": viteConfig({ index: "src/index.ts" }),
+        ".gitignore": GITIGNORE,
+        "src/index.ts": commandEntry(ctx),
+      };
+    }
+    case "view": {
+      return {
+        "plugin.json": manifest(ctx, {
+          experimental_views: [
+            {
+              id: "main",
+              name: ctx.displayName,
+              componentPath: "dist/panel.js",
+              location: "panel",
+            },
+          ],
+        }),
+        "package.json": packageJson(ctx, true),
+        "tsconfig.json": tsconfig(true),
+        "vite.config.ts": viteConfig({ index: "src/index.ts", panel: "src/panel.tsx" }),
+        ".gitignore": GITIGNORE,
+        "src/index.ts": viewEntry(ctx),
+        "src/panel.tsx": panelComponent(ctx),
+      };
+    }
+    case "mcp": {
+      return {
+        "plugin.json": manifest(ctx, {
+          experimental_mcpServers: [
+            {
+              id: "main",
+              name: ctx.displayName,
+              command: "node",
+              args: ["dist/server.js"],
+            },
+          ],
+        }),
+        "package.json": packageJson(ctx, false),
+        "tsconfig.json": tsconfig(false),
+        "vite.config.ts": viteConfig({ index: "src/index.ts", server: "src/server.ts" }),
+        ".gitignore": GITIGNORE,
+        "src/index.ts": mcpEntry(ctx),
+        "src/server.ts": mcpServer(ctx),
+      };
+    }
+    case "full": {
+      return {
+        "plugin.json": manifest(ctx, {
+          commands: [
+            {
+              id: "run",
+              title: `${ctx.displayName}: Run`,
+              description: `Run the ${ctx.displayName} command.`,
+              category: ctx.displayName,
+              kind: "command",
+              danger: "safe",
+              keywords: [ctx.pluginName, "run"],
+            },
+          ],
+          experimental_views: [
+            {
+              id: "main",
+              name: ctx.displayName,
+              componentPath: "dist/panel.js",
+              location: "panel",
+            },
+          ],
+          experimental_mcpServers: [
+            {
+              id: "main",
+              name: ctx.displayName,
+              command: "node",
+              args: ["dist/server.js"],
+            },
+          ],
+        }),
+        "package.json": packageJson(ctx, true),
+        "tsconfig.json": tsconfig(true),
+        "vite.config.ts": viteConfig({
+          index: "src/index.ts",
+          panel: "src/panel.tsx",
+          server: "src/server.ts",
+        }),
+        ".gitignore": GITIGNORE,
+        "src/index.ts": commandEntry(ctx),
+        "src/panel.tsx": panelComponent(ctx),
+        "src/server.ts": mcpServer(ctx),
+      };
+    }
+  }
+}

--- a/packages/daintree-plugin/src/scaffold/templates.ts
+++ b/packages/daintree-plugin/src/scaffold/templates.ts
@@ -23,6 +23,17 @@ export interface ScaffoldContext {
 
 const DAINTREE_ENGINE_RANGE = ">=0.11.0";
 
+/** A safely-quoted JS/TS string literal for embedding author text in source. */
+function q(value: string): string {
+  return JSON.stringify(value);
+}
+
+/** Single-line, comment-safe rendering of author text: strips newlines and any
+ * block-comment terminator so it can't break the generated JSDoc. */
+function c(value: string): string {
+  return value.replace(/\*\//g, "* /").replace(/[\r\n]+/g, " ");
+}
+
 function manifest(ctx: ScaffoldContext, contributes: Record<string, unknown>): string {
   const obj = {
     name: ctx.scopedName,
@@ -107,24 +118,28 @@ dist/
 `;
 
 function commandEntry(ctx: ScaffoldContext): string {
+  const title = q(`${ctx.displayName}: Run`);
+  const description = q(`Run the ${ctx.displayName} command.`);
+  const category = q(ctx.displayName);
+  const message = q(`Hello from ${ctx.displayName}`);
   return `import type { PluginHostApi } from "@daintreehq/plugin-sdk";
 
 /**
- * ${ctx.displayName} — command plugin entry. Daintree calls \`activate\` once
+ * ${c(ctx.displayName)} — command plugin entry. Daintree calls \`activate\` once
  * when the plugin loads; return a disposer to clean up on unload.
  */
 export async function activate(host: PluginHostApi): Promise<() => void> {
   const dispose = host.registerAction(
     {
       id: "run",
-      title: "${ctx.displayName}: Run",
-      description: "Run the ${ctx.displayName} command.",
-      category: "${ctx.displayName}",
+      title: ${title},
+      description: ${description},
+      category: ${category},
       kind: "command",
       danger: "safe",
     },
     async () => {
-      await host.showToast({ message: "Hello from ${ctx.displayName}", type: "success" });
+      await host.showToast({ message: ${message}, type: "success" });
       return { ran: true };
     }
   );
@@ -140,7 +155,7 @@ function viewEntry(ctx: ScaffoldContext): string {
   return `import type { PluginHostApi } from "@daintreehq/plugin-sdk";
 
 /**
- * ${ctx.displayName} — view plugin entry. The panel UI lives in \`src/panel.tsx\`
+ * ${c(ctx.displayName)} — view plugin entry. The panel UI lives in \`src/panel.tsx\`
  * and is wired through \`contributes.experimental_views\` in plugin.json.
  */
 export async function activate(_host: PluginHostApi): Promise<() => void> {
@@ -153,11 +168,11 @@ function panelComponent(ctx: ScaffoldContext): string {
   return `import React from "react";
 
 /**
- * Panel view for ${ctx.displayName}. Rendered by Daintree when the user opens
+ * Panel view for ${c(ctx.displayName)}. Rendered by Daintree when the user opens
  * the contributed view.
  */
 export default function Panel(): React.ReactElement {
-  return <div style={{ padding: 16 }}>Hello from ${ctx.displayName}</div>;
+  return <div style={{ padding: 16 }}>{${q(`Hello from ${ctx.displayName}`)}}</div>;
 }
 `;
 }
@@ -166,7 +181,7 @@ function mcpEntry(ctx: ScaffoldContext): string {
   return `import type { PluginHostApi } from "@daintreehq/plugin-sdk";
 
 /**
- * ${ctx.displayName} — MCP plugin entry. The MCP server process is declared in
+ * ${c(ctx.displayName)} — MCP plugin entry. The MCP server process is declared in
  * \`contributes.experimental_mcpServers\` (see plugin.json) and spawned by
  * Daintree; \`src/server.ts\` is its skeleton implementation.
  */
@@ -179,7 +194,7 @@ export async function activate(_host: PluginHostApi): Promise<() => void> {
 function mcpServer(ctx: ScaffoldContext): string {
   return `#!/usr/bin/env node
 /**
- * Minimal stdio MCP server skeleton for ${ctx.displayName}. Replace this with a
+ * Minimal stdio MCP server skeleton for ${c(ctx.displayName)}. Replace this with a
  * real implementation using \`@modelcontextprotocol/sdk\`. Daintree spawns it
  * per the \`command\`/\`args\` in plugin.json and speaks MCP over stdio.
  */

--- a/packages/daintree-plugin/tsconfig.json
+++ b/packages/daintree-plugin/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "../../electron/types/archiver.d.ts"]
+}

--- a/packages/daintree-plugin/tsup.config.ts
+++ b/packages/daintree-plugin/tsup.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    cli: "src/cli.ts",
+    index: "src/index.ts",
+  },
+  format: ["esm"],
+  target: "node22",
+  platform: "node",
+  // No .d.ts emit — create-daintree-plugin resolves daintree-plugin's types via
+  // the package's `exports.types` → `src/index.ts` condition (source), so a
+  // built declaration is unnecessary and avoids a TS6-deprecation build failure.
+  dts: false,
+  clean: true,
+  // `src/cli.ts` carries a `#!/usr/bin/env node` shebang; tsup preserves it and
+  // marks the output executable.
+  shims: false,
+  // `electron` must never be pulled into the standalone CLI bundle. The schema
+  // and archive modules we reuse are pure Node, but externalizing electron makes
+  // the build fail loudly if that boundary is ever crossed. The declared runtime
+  // dependencies (archiver, yauzl, semver, zod, commander, execa, globby,
+  // @clack/prompts) resolve from node_modules and stay external by default.
+  external: ["electron"],
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -4,6 +4,7 @@
 // that need to verify the throwing behavior (e.g. `ipcGuard.test.ts`) reset
 // the flag explicitly via `_resetIpcGuardForTesting()`.
 
+import { vi } from "vitest";
 import { markIpcSecurityReady } from "./electron/ipc/ipcGuard.js";
 import { primeRadix } from "./src/components/ui/radix-loader";
 
@@ -38,14 +39,24 @@ if (typeof globalThis !== "undefined") {
 // rAF in production. Install a sync default that runs the callback inline so
 // tests retain synchronous expectations without each file repeating the shim.
 // Tests that exercise rAF pacing explicitly override these globals locally.
+//
+// Use `vi.stubGlobal` rather than a raw `globalThis` assignment: forks-pool
+// workers are reused across files, and a raw shim installed while a node-env
+// file runs gets adopted as the "original" global by the next file's jsdom
+// environment setup, then restored on its teardown — permanently shadowing
+// jsdom's async rAF for every later jsdom file in that worker (which made
+// async-effect renders flush in the wrong order, e.g. PluginSettingsForm's
+// reveal-secret control intermittently missing). Stubbed globals are tracked
+// and cleared by vitest between files, so the shim can't leak across the
+// node→jsdom boundary.
 if (typeof globalThis.requestAnimationFrame !== "function") {
-  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback): number => {
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback): number => {
     cb(0);
     return 0;
-  }) as typeof globalThis.requestAnimationFrame;
+  });
 }
 if (typeof globalThis.cancelAnimationFrame !== "function") {
-  globalThis.cancelAnimationFrame = (() => {}) as typeof globalThis.cancelAnimationFrame;
+  vi.stubGlobal("cancelAnimationFrame", () => {});
 }
 
 // Node 25 exposes a broken native `localStorage` stub on `globalThis` (no


### PR DESCRIPTION
Implements #9303 — a `daintree-plugin` CLI for plugin authors, a `create-daintree-plugin` npx shim, and a control socket server in Electron.

## Commands

- `new` — interactive scaffold via `@clack/prompts`, four templates: `command`, `view`, `mcp`, `full`
- `validate` — reuses `getPluginManifestSchema` from the host; warns on missing `engines.daintree` and empty command keywords; `--env` flag resolves `${settings:…}` tokens against `.daintree-plugin-env`
- `package` — validate → Vite subprocess build → gitignore-aware file collection with build-output carve-out → byte-deterministic `.dntr` via the host's `packPluginArchiveFromFiles` → verify round-trip
- `install` / `uninstall` — over the local NDJSON control socket at `~/.daintree/cli.sock` / `\\.\pipe\daintree-cli` (overridable via `DAINTREE_CLI_SOCKET`)
- `dev` — stub announcing F32b (hot-reload, out of scope for this PR)

## Other changes

- **`packages/create-daintree-plugin`** — thin shim re-exporting the `new` entry for `npm create daintree-plugin`
- **`electron/services/PluginCliServer.ts`** — NDJSON control socket, bound after `pluginService.waitForInit()`, routes install/uninstall through the existing IPC handler trust gates, wired as a deferred fire-and-forget task and disposed on shutdown
- **`PluginArchive`** — exposes `packPluginArchiveFromFiles` + `isExcludedArchiveEntry` so the CLI reuses the host's exact wire format; adds a size guard to `readArchiveManifest`

## Tests

New unit tests: archive surface (20), control socket (10), all CLI commands (31). Lifecycle order + shutdown tests updated (49). `npm run check` passes (typecheck, channel/IPC/help checks, lint:ratchet, format).

Closes #9303