### PR TITLE
fix(dock): keep empty dock interactive instead of inert

### DIFF
--- a/src/components/Layout/TerminalDockRegion.tsx
+++ b/src/components/Layout/TerminalDockRegion.tsx
@@ -35,7 +35,9 @@ export function TerminalDockRegion() {
       // don't announce a dead-end "Dock" region. `role="none"` strips the
       // landmark without affecting descendants — unlike `inert`, the always-
       // rendered launch button and right-click menu stay interactive so users
-      // can still spawn an agent from an empty dock.
+      // can still spawn an agent from an empty dock. Chromium honors
+      // `role="none"` here because tabIndex=-1 is not tab-order-reachable; the
+      // ARIA conflict-resolution clause only ignores the role for tabIndex>=0.
       role={shouldInertDock ? "none" : "region"}
       tabIndex={-1}
       aria-label={shouldInertDock ? undefined : "Dock"}

--- a/src/components/Layout/TerminalDockRegion.tsx
+++ b/src/components/Layout/TerminalDockRegion.tsx
@@ -31,12 +31,14 @@ export function TerminalDockRegion() {
   return (
     <aside
       ref={dockRegionRef}
-      role="region"
+      // When the dock is empty, drop the landmark role/name so screen readers
+      // don't announce a dead-end "Dock" region. `role="none"` strips the
+      // landmark without affecting descendants — unlike `inert`, the always-
+      // rendered launch button and right-click menu stay interactive so users
+      // can still spawn an agent from an empty dock.
+      role={shouldInertDock ? "none" : "region"}
       tabIndex={-1}
-      aria-label="Dock"
-      // `inert` removes the empty dock from focus / a11y tree so screen
-      // readers don't land on a dead-end landmark when nothing is docked.
-      inert={shouldInertDock || undefined}
+      aria-label={shouldInertDock ? undefined : "Dock"}
       data-macro-focus={isMacroFocused ? "true" : undefined}
       className="outline-hidden data-[macro-focus=true]:ring-2 data-[macro-focus=true]:ring-border-default data-[macro-focus=true]:ring-inset"
     >

--- a/src/components/Layout/__tests__/AppLayout.landmarks.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.landmarks.test.ts
@@ -57,9 +57,11 @@ describe("ARIA page landmarks — issue #5416", () => {
       source = await fs.readFile(TERMINAL_DOCK_PATH, "utf-8");
     });
 
-    it("uses an <aside> region landmark with an accessible name", () => {
-      expect(source).toMatch(/<aside[\s\S]*?aria-label="Dock"/);
-      expect(source).toMatch(/<aside[\s\S]*?role="region"/);
+    it("uses an <aside> region landmark with an accessible name when populated", () => {
+      // The landmark role/name are conditional on dock contents (#9527): a
+      // populated dock is a named "Dock" region; an empty one drops both.
+      expect(source).toMatch(/aria-label=\{shouldInertDock \? undefined : "Dock"\}/);
+      expect(source).toMatch(/role=\{shouldInertDock \? "none" : "region"\}/);
     });
 
     it("keeps tabIndex=-1 so the macro-focus cycler can target it", () => {
@@ -70,17 +72,18 @@ describe("ARIA page landmarks — issue #5416", () => {
       // The dock always renders interactive content (Help Agent button,
       // status containers), so aria-hidden would trap focusable controls
       // beneath aria-hidden=true and fail axe's aria-hidden-focus rule.
-      // `inert` is used instead — see test below.
+      // role="none" drops the empty landmark instead — see test below.
       expect(source).not.toMatch(/aria-hidden=\{[^}]*hasDocked[^}]*\}/);
       expect(source).not.toMatch(/aria-hidden="true"/);
     });
 
-    it("uses `inert` only when the dock has no interactive descendants", () => {
+    it("drops the landmark role instead of inerting the empty dock (#9527)", () => {
       // When no panels are docked and no status affordances are visible, the
-      // aside is a dead-end landmark. Trash/waiting status controls must keep
-      // the dock interactive so pointer and keyboard users can restore panels.
+      // aside is a dead-end landmark, so its role/name are dropped. It must NOT
+      // be `inert` — the launch button and context menu are always rendered and
+      // must stay interactive so users can spawn an agent from an empty dock.
       expect(source).toMatch(/const shouldInertDock = !hasDocked && !hasStatus;/);
-      expect(source).toMatch(/inert=\{shouldInertDock \|\| undefined\}/);
+      expect(source).not.toMatch(/inert=/);
     });
   });
 

--- a/src/components/Layout/__tests__/AppLayout.landmarks.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.landmarks.test.ts
@@ -73,8 +73,7 @@ describe("ARIA page landmarks — issue #5416", () => {
       // status containers), so aria-hidden would trap focusable controls
       // beneath aria-hidden=true and fail axe's aria-hidden-focus rule.
       // role="none" drops the empty landmark instead — see test below.
-      expect(source).not.toMatch(/aria-hidden=\{[^}]*hasDocked[^}]*\}/);
-      expect(source).not.toMatch(/aria-hidden="true"/);
+      expect(source).not.toMatch(/aria-hidden/);
     });
 
     it("drops the landmark role instead of inerting the empty dock (#9527)", () => {

--- a/src/components/Layout/__tests__/TerminalDockRegion.test.ts
+++ b/src/components/Layout/__tests__/TerminalDockRegion.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+
+const TERMINAL_DOCK_PATH = path.resolve(__dirname, "../TerminalDockRegion.tsx");
+
+// Regression coverage for #9527: an empty dock was made `inert`, which killed
+// pointer events and focus across the whole region — including the always-
+// rendered launch button and right-click menu in ContentDock. The fix swaps
+// `inert` for a conditional landmark role so the empty dock stays interactive
+// while still hiding the dead-end landmark from screen readers.
+describe("TerminalDockRegion — empty dock interactivity (#9527)", () => {
+  let source: string;
+  beforeEach(async () => {
+    source = await fs.readFile(TERMINAL_DOCK_PATH, "utf-8");
+  });
+
+  it("never inerts the dock region", () => {
+    // `inert` is a DOM-level kill switch with no CSS escape hatch for children,
+    // so it cannot be used while keeping the launch button interactive. Match
+    // the JSX attribute form so the explanatory comment above it is allowed.
+    expect(source).not.toMatch(/inert=/);
+  });
+
+  it("conditionally drops the landmark role when the dock is empty", () => {
+    expect(source).toMatch(/role=\{shouldInertDock \? "none" : "region"\}/);
+  });
+
+  it("drops the landmark name in lockstep with the role", () => {
+    // role="none" with a stale aria-label is contradictory; the name must be
+    // removed atomically with the role.
+    expect(source).toMatch(/aria-label=\{shouldInertDock \? undefined : "Dock"\}/);
+  });
+
+  it("keeps tabIndex=-1 so macroFocusStore can programmatically focus the region", () => {
+    expect(source).toMatch(/tabIndex=\{-1\}/);
+  });
+
+  it("preserves the empty-dock guard derivation", () => {
+    expect(source).toMatch(/const shouldInertDock = !hasDocked && !hasStatus;/);
+  });
+
+  it("keeps the macro-focus visibility gate keyed on hasDocked only", () => {
+    // This is the independent keyboard macro-nav guard that excludes an empty
+    // dock from region cycling — it must stay keyed on hasDocked, not hasStatus.
+    expect(source).toMatch(/setVisibility\("dock", hasDocked\)/);
+  });
+});


### PR DESCRIPTION
## Summary

- The empty dock was non-interactive because `inert` suppresses pointer events and focus across all descendants — including the `DockLaunchButton` and the right-click `ContextMenu` in `ContentDock`. Exactly the empty state where a user reaches for them.
- Fix: remove `inert`, replace with `role={shouldInertDock ? "none" : "region"}` + conditional `aria-label`. This drops the dead-end complementary landmark from screen readers without killing interactivity. `aria-hidden` was ruled out — focusable descendants under `aria-hidden` break WCAG 4.1.2.
- `tabIndex={-1}` kept; the `setVisibility("dock", hasDocked)` macro-nav guard is untouched — it independently excludes an empty dock from keyboard region cycling.

Resolves #9527

## Changes

- `src/components/Layout/TerminalDockRegion.tsx` — swap `inert` for conditional landmark role
- `src/components/Layout/__tests__/AppLayout.landmarks.test.ts` — update two landmark assertions
- `src/components/Layout/__tests__/TerminalDockRegion.test.ts` — new regression file covering the interactive/inert states

## Testing

41 layout tests pass. `npm run check` clean (typecheck + format + lint).