### PR TITLE
fix(layout): keep dock visible when a recovery banner shows

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -300,16 +300,6 @@ const LazyCrashRecoveryDialog = lazy(() =>
   preloadCrashRecoveryDialog().then((m) => ({ default: m.CrashRecoveryDialog }))
 );
 
-function preloadGlobalBannerCoordinator() {
-  return import("./components/Recovery/GlobalBannerCoordinator");
-}
-const LazyGlobalBannerCoordinator = lazy(() =>
-  preloadGlobalBannerCoordinator().then((m) => ({ default: m.GlobalBannerCoordinator }))
-);
-// Fetch eagerly: `safeMode` is set synchronously during hydration, so the
-// first post-hydration render can suspend before the idle preload fires.
-void preloadGlobalBannerCoordinator();
-
 import { Toaster } from "./components/ui/toaster";
 import { ShortcutHint } from "./components/ui/ShortcutHint";
 import { ReEntrySummary } from "./components/ui/ReEntrySummary";
@@ -558,7 +548,6 @@ function AppInner() {
       void preloadSendToAgentPalette();
       void preloadQuickCreatePalette();
       void preloadLogLevelPalette();
-      void preloadGlobalBannerCoordinator();
       import("@fontsource/jetbrains-mono/latin-500.css").catch(() => {});
       import("@fontsource/jetbrains-mono/latin-600.css").catch(() => {});
       // Warm the FileViewerModal/DiffViewer chunk split out of the eager
@@ -757,9 +746,6 @@ function AppInner() {
             disableHoverableContent
           >
             <E2EFaultInjector />
-            <Suspense fallback={null}>
-              <LazyGlobalBannerCoordinator />
-            </Suspense>
             <DndProvider>
               <VoiceRecordingAnnouncer />
               <AccessibilityAnnouncer />

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef, type ReactNode } from "react";
+import { useState, useCallback, useEffect, useRef, Suspense, lazy, type ReactNode } from "react";
 import { createPortal, flushSync } from "react-dom";
 import { cn } from "@/lib/utils";
 import { Toolbar } from "./Toolbar";
@@ -38,6 +38,16 @@ import { useLayoutState, useOverlayOpen } from "@/hooks";
 import type { UseProjectSwitcherPaletteReturn } from "@/hooks";
 import { suppressSidebarResizes } from "@/lib/sidebarToggle";
 import { logError } from "@/utils/logger";
+
+function preloadGlobalBannerCoordinator() {
+  return import("../Recovery/GlobalBannerCoordinator");
+}
+const LazyGlobalBannerCoordinator = lazy(() =>
+  preloadGlobalBannerCoordinator().then((m) => ({ default: m.GlobalBannerCoordinator }))
+);
+// Fetch eagerly: `safeMode` is set synchronously during hydration, so the
+// first post-hydration render can suspend before the idle preload fires.
+void preloadGlobalBannerCoordinator();
 
 interface AppLayoutProps {
   children?: ReactNode;
@@ -454,6 +464,9 @@ export function AppLayout({
       }}
     >
       <PortalVisibilityController />
+      <Suspense fallback={null}>
+        <LazyGlobalBannerCoordinator />
+      </Suspense>
       <div {...(isThemeBrowserOpen ? { inert: true } : {})}>
         <Toolbar
           onLaunchAgent={handleLaunchAgent}

--- a/src/components/Layout/__tests__/AppLayout.banner.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.banner.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+
+const APP_LAYOUT_PATH = path.resolve(__dirname, "../AppLayout.tsx");
+const APP_PATH = path.resolve(__dirname, "../../../App.tsx");
+
+describe("AppLayout global banner mount — issue #9530", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(APP_LAYOUT_PATH, "utf-8");
+  });
+
+  it("imports Suspense and lazy from react", () => {
+    // The coordinator now lives inside AppLayout, so AppLayout owns the lazy
+    // boundary it previously relied on App.tsx to provide.
+    expect(source).toMatch(/import \{[^}]*\bSuspense\b[^}]*\blazy\b[^}]*\} from "react"/);
+  });
+
+  it("lazily defines and eagerly preloads the GlobalBannerCoordinator", () => {
+    expect(source).toContain(
+      'function preloadGlobalBannerCoordinator() {\n  return import("../Recovery/GlobalBannerCoordinator");'
+    );
+    expect(source).toContain("const LazyGlobalBannerCoordinator = lazy(");
+    // safeMode is set synchronously during hydration, so the chunk must be
+    // inflight before the first post-hydration render can suspend.
+    expect(source).toContain("void preloadGlobalBannerCoordinator();");
+  });
+
+  it("mounts the banner inside the flex column, after PortalVisibilityController and before the inert toolbar wrapper", () => {
+    // Issue #9530: mounting the coordinator as a block-flow sibling above the
+    // 100vh AppLayout root overflowed the viewport and clipped the dock. The
+    // banner must be a direct child of the h-screen flex column so its
+    // shrink-0 height is subtracted from the flex-1 content area instead.
+    expect(source).toMatch(
+      /<PortalVisibilityController \/>\s*<Suspense fallback=\{null\}>\s*<LazyGlobalBannerCoordinator \/>\s*<\/Suspense>\s*<div \{\.\.\.\(isThemeBrowserOpen \? \{ inert: true \}/
+    );
+  });
+});
+
+describe("App.tsx no longer owns the global banner — issue #9530", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(APP_PATH, "utf-8");
+  });
+
+  it("does not import, lazy-define, or mount the GlobalBannerCoordinator", () => {
+    expect(source).not.toContain("GlobalBannerCoordinator");
+    expect(source).not.toContain("preloadGlobalBannerCoordinator");
+    expect(source).not.toContain("LazyGlobalBannerCoordinator");
+  });
+});


### PR DESCRIPTION
## Summary

- `GlobalBannerCoordinator` was mounted as a JSX sibling above `AppLayout` in `App.tsx`. `AppLayout` is pinned to `100vh`, so the banner pushed the combined height past the viewport and clipped the `DiagnosticsDock` off the bottom edge.
- Moved the coordinator inside `AppLayout`'s root flex column (after `PortalVisibilityController`, before the inert-gated toolbar wrapper). The banner's existing `shrink-0` now subtracts from the `flex-1` content area, so the dock stays in view.
- Relocated the `lazy()` definition and eager preload into `AppLayout` so the chunk still loads before the first post-hydration render.

Fixes #9530

## Changes

- `src/App.tsx` — removed `LazyGlobalBannerCoordinator` declaration and its render site above `AppLayout`
- `src/components/Layout/AppLayout.tsx` — added `lazy()` import, eager preload, and `<LazyGlobalBannerCoordinator />` inside the root flex column
- `src/components/Layout/__tests__/AppLayout.banner.test.ts` — source-scan regression test confirming the coordinator renders inside `AppLayout`

## Testing

All six banner variants flow through `GlobalBannerCoordinator` + `InlineStatusBanner` — the single-slot priority coordinator pattern is unchanged, just relocated. `AppLayout.banner.test.ts` added as a regression guard. `npm run check` (typecheck + lint + format) and build both pass.

Two pre-existing issues noted during review, out of scope for this fix: `PortalDock` `top-12` misalignment when a banner is visible, and the banner not being covered when the ThemeBrowser overlay is open.