### PR TITLE
fix(stores): prune orphaned diagnostic entries on panel/worktree removal

### DIFF
--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -341,9 +341,11 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
     // invalidate any key that disappeared. `applyRemove`/`applySnapshot` always
     // build a fresh `new Map(...)` on real changes (the value-equality fast path
     // preserves the same ref), so the ref-equality guard reliably skips
-    // unrelated-slice updates. `invalidate` is synchronous and a no-op for
-    // absent ids, so re-invalidating a key the event path already handled is
-    // safe (#9536).
+    // unrelated-slice updates. `invalidate` is synchronous and functionally
+    // idempotent — it clears whatever is present and corrupts nothing on an
+    // already-clean key — so on a normal single removal the `worktree-removed`
+    // event path and this subscription each fire it once for the same id
+    // (the second call re-publishes correct state, nothing more) (#9536).
     cleanups.push(
       store.subscribe((state, prevState) => {
         if (state.worktrees === prevState.worktrees) return;

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -333,6 +333,28 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
       })
     );
 
+    // Pulse-cache pruning backstop: the `worktree-removed` event invalidates a
+    // single worktree, but `applySnapshot` on a host restart can replace the
+    // whole `worktrees` Map with a smaller set WITHOUT firing per-id removal
+    // events — leaving stale entries in pulseStore's worktree-keyed maps
+    // (pulses/loading/errors/retry). Diff the Map on every state change and
+    // invalidate any key that disappeared. `applyRemove`/`applySnapshot` always
+    // build a fresh `new Map(...)` on real changes (the value-equality fast path
+    // preserves the same ref), so the ref-equality guard reliably skips
+    // unrelated-slice updates. `invalidate` is synchronous and a no-op for
+    // absent ids, so re-invalidating a key the event path already handled is
+    // safe (#9536).
+    cleanups.push(
+      store.subscribe((state, prevState) => {
+        if (state.worktrees === prevState.worktrees) return;
+        for (const id of prevState.worktrees.keys()) {
+          if (!state.worktrees.has(id)) {
+            usePulseStore.getState().invalidate(id);
+          }
+        }
+      })
+    );
+
     cleanups.push(
       worktreePort.onEvent("worktree-activated", (data) => {
         const event = data as WorktreeActivatedEvent;

--- a/src/contexts/__tests__/WorktreeStoreContext.snapshotPrune.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.snapshotPrune.test.tsx
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useContext } from "react";
+
+import { useProjectStore } from "@/store/projectStore";
+import { usePulseStore } from "@/store/pulseStore";
+import type { ProjectPulse, WorktreeSnapshot, WorktreeEventVersion } from "@shared/types";
+import type { Project } from "@shared/types/project";
+
+const TEST_EPOCH = "test-epoch";
+let _seq = 0;
+function nextV(): WorktreeEventVersion {
+  return { epoch: TEST_EPOCH, seq: ++_seq };
+}
+
+type PortEventName =
+  | "worktree-update"
+  | "worktree-removed"
+  | "worktree-activated"
+  | "pr-detected"
+  | "pr-cleared"
+  | "pr-detection-state"
+  | "issue-detected"
+  | "issue-not-found"
+  | "inotify-limit-reached"
+  | "emfile-limit-reached"
+  | "watcher-recovered";
+
+const listeners = new Map<PortEventName, Set<(data: unknown) => void>>();
+
+function makeWorktree(id: string, overrides: Partial<WorktreeSnapshot> = {}): WorktreeSnapshot {
+  return {
+    id,
+    worktreeId: id,
+    path: `/repo/${id}`,
+    name: id,
+    isCurrent: false,
+    branch: "main",
+    isMainWorktree: false,
+    ...overrides,
+  } as WorktreeSnapshot;
+}
+
+function seedPulse(worktreeId: string): void {
+  usePulseStore.setState((prev) => ({
+    pulses: new Map(prev.pulses).set(worktreeId, { commits: [] } as unknown as ProjectPulse),
+    loading: new Map(prev.loading).set(worktreeId, false),
+    errors: new Map(prev.errors).set(worktreeId, null),
+  }));
+}
+
+function setCurrentProject(path: string | null): void {
+  const project = path ? ({ id: "p1", name: "p1", path } as unknown as Project) : null;
+  useProjectStore.setState({ currentProject: project });
+}
+
+beforeEach(() => {
+  listeners.clear();
+  setCurrentProject("/repo/proj");
+  _seq = 0;
+  usePulseStore.getState().invalidateAll();
+
+  (globalThis as unknown as { window: Window }).window.electron = {
+    worktreePort: {
+      isReady: () => true,
+      request: (_name: string) =>
+        Promise.resolve({ states: [] as WorktreeSnapshot[], epoch: TEST_EPOCH, seq: 0 }),
+      onEvent: (name: PortEventName, cb: (data: unknown) => void) => {
+        let set = listeners.get(name);
+        if (!set) {
+          set = new Set();
+          listeners.set(name, set);
+        }
+        set.add(cb);
+        return () => set?.delete(cb);
+      },
+      onReady: (_cb: () => void) => () => {},
+      onDisconnected: (_cb: () => void) => () => {},
+      onFatalDisconnect: (_cb: () => void) => () => {},
+    },
+    worktree: {
+      getAllIssueAssociations: () => Promise.resolve({}),
+      getPRStatus: () => Promise.resolve(null),
+    },
+  } as unknown as typeof window.electron;
+});
+
+afterEach(() => {
+  listeners.clear();
+  setCurrentProject(null);
+  usePulseStore.getState().invalidateAll();
+  vi.restoreAllMocks();
+});
+
+async function renderProvider() {
+  const { WorktreeStoreProvider, WorktreeStoreContext } = await import("../WorktreeStoreContext");
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <WorktreeStoreProvider>{children}</WorktreeStoreProvider>
+  );
+  const rendered = renderHook(() => useContext(WorktreeStoreContext), { wrapper });
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  if (!rendered.result.current) throw new Error("WorktreeStoreContext is null");
+  return { store: rendered.result.current, unmount: rendered.unmount };
+}
+
+describe("WorktreeStoreProvider — pulse-cache snapshot pruning", () => {
+  it("invalidates pulse entries for worktrees dropped by applySnapshot", async () => {
+    const { store } = await renderProvider();
+
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1"), makeWorktree("wt-2")], nextV());
+    });
+    seedPulse("wt-1");
+    seedPulse("wt-2");
+    expect(usePulseStore.getState().pulses.has("wt-1")).toBe(true);
+    expect(usePulseStore.getState().pulses.has("wt-2")).toBe(true);
+
+    // Host restart delivers a smaller authoritative snapshot — wt-2 is gone but
+    // no per-id `worktree-removed` event fires.
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+    });
+
+    expect(usePulseStore.getState().pulses.has("wt-1")).toBe(true);
+    expect(usePulseStore.getState().pulses.has("wt-2")).toBe(false);
+    expect(usePulseStore.getState().loading.has("wt-2")).toBe(false);
+    expect(usePulseStore.getState().errors.has("wt-2")).toBe(false);
+  });
+
+  it("does not invalidate when an unrelated slice changes (worktrees ref stable)", async () => {
+    const { store } = await renderProvider();
+
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+    });
+    seedPulse("wt-1");
+
+    const invalidateSpy = vi.spyOn(usePulseStore.getState(), "invalidate");
+
+    act(() => {
+      store.getState().setWatcherDegraded(true);
+    });
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+    expect(usePulseStore.getState().pulses.has("wt-1")).toBe(true);
+  });
+
+  it("invalidates every worktree when the snapshot empties the set", async () => {
+    const { store } = await renderProvider();
+
+    act(() => {
+      store
+        .getState()
+        .applySnapshot([makeWorktree("wt-1"), makeWorktree("wt-2"), makeWorktree("wt-3")], nextV());
+    });
+    seedPulse("wt-1");
+    seedPulse("wt-2");
+    seedPulse("wt-3");
+
+    act(() => {
+      store.getState().applySnapshot([], nextV());
+    });
+
+    expect(usePulseStore.getState().pulses.has("wt-1")).toBe(false);
+    expect(usePulseStore.getState().pulses.has("wt-2")).toBe(false);
+    expect(usePulseStore.getState().pulses.has("wt-3")).toBe(false);
+  });
+
+  it("stops pruning after the provider unmounts", async () => {
+    const { store, unmount } = await renderProvider();
+
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1"), makeWorktree("wt-2")], nextV());
+    });
+    seedPulse("wt-2");
+
+    // Tear down inside act() so the effect cleanup (which removes the
+    // subscription) flushes synchronously before the next snapshot.
+    act(() => {
+      unmount();
+    });
+
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+    });
+
+    // Entry remains because the subscription was torn down on unmount.
+    expect(usePulseStore.getState().pulses.has("wt-2")).toBe(true);
+  });
+});

--- a/src/contexts/__tests__/WorktreeStoreContext.snapshotPrune.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.snapshotPrune.test.tsx
@@ -42,12 +42,36 @@ function makeWorktree(id: string, overrides: Partial<WorktreeSnapshot> = {}): Wo
   } as WorktreeSnapshot;
 }
 
-function seedPulse(worktreeId: string): void {
+// Seed every worktree-keyed map `invalidate` touches so a regression that
+// stops clearing any one of the seven is caught. `timer` lets a test plant a
+// real retry timer to verify it gets cancelled on prune.
+function seedPulse(worktreeId: string, timer?: ReturnType<typeof setTimeout>): void {
   usePulseStore.setState((prev) => ({
     pulses: new Map(prev.pulses).set(worktreeId, { commits: [] } as unknown as ProjectPulse),
-    loading: new Map(prev.loading).set(worktreeId, false),
-    errors: new Map(prev.errors).set(worktreeId, null),
+    loading: new Map(prev.loading).set(worktreeId, true),
+    errors: new Map(prev.errors).set(worktreeId, "boom"),
+    requestIds: new Map(prev.requestIds).set(worktreeId, 123),
+    retryCount: new Map(prev.retryCount).set(worktreeId, 2),
+    lastRetryTimestamp: new Map(prev.lastRetryTimestamp).set(worktreeId, 456),
+    ...(timer ? { retryTimers: new Map(prev.retryTimers).set(worktreeId, timer) } : {}),
   }));
+}
+
+const PULSE_MAP_KEYS = [
+  "pulses",
+  "loading",
+  "errors",
+  "requestIds",
+  "retryCount",
+  "lastRetryTimestamp",
+  "retryTimers",
+] as const;
+
+function expectFullyPruned(worktreeId: string): void {
+  const state = usePulseStore.getState();
+  for (const key of PULSE_MAP_KEYS) {
+    expect(state[key].has(worktreeId)).toBe(false);
+  }
 }
 
 function setCurrentProject(path: string | null): void {
@@ -126,9 +150,27 @@ describe("WorktreeStoreProvider — pulse-cache snapshot pruning", () => {
     });
 
     expect(usePulseStore.getState().pulses.has("wt-1")).toBe(true);
-    expect(usePulseStore.getState().pulses.has("wt-2")).toBe(false);
-    expect(usePulseStore.getState().loading.has("wt-2")).toBe(false);
-    expect(usePulseStore.getState().errors.has("wt-2")).toBe(false);
+    // All seven worktree-keyed maps must be cleared for the dropped worktree.
+    expectFullyPruned("wt-2");
+  });
+
+  it("cancels the pending retry timer for a worktree dropped by applySnapshot", async () => {
+    const { store } = await renderProvider();
+
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1"), makeWorktree("wt-2")], nextV());
+    });
+
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    const timer = setTimeout(() => {}, 60_000);
+    seedPulse("wt-2", timer);
+
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+    });
+
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(timer);
+    expect(usePulseStore.getState().retryTimers.has("wt-2")).toBe(false);
   });
 
   it("does not invalidate when an unrelated slice changes (worktrees ref stable)", async () => {

--- a/src/store/__tests__/rendererStoreOrchestrator.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.test.ts
@@ -625,6 +625,86 @@ describe("rendererStoreOrchestrator", () => {
     expect(useResourceMonitoringStore.getState().metrics.size).toBe(0);
   });
 
+  it("prunes metrics for every panel in a bulk removal, keeping survivors", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "m-1": {
+          id: "m-1",
+          title: "1",
+          kind: "terminal" as const,
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        "m-2": {
+          id: "m-2",
+          title: "2",
+          kind: "terminal" as const,
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        "m-3": {
+          id: "m-3",
+          title: "3",
+          kind: "terminal" as const,
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      },
+      panelIds: ["m-1", "m-2", "m-3"],
+    });
+
+    useResourceMonitoringStore.getState().updateMetrics({
+      "m-1": { cpuPercent: 1, memoryKb: 100, breakdown: [] },
+      "m-2": { cpuPercent: 2, memoryKb: 200, breakdown: [] },
+      "m-3": { cpuPercent: 3, memoryKb: 300, breakdown: [] },
+    });
+
+    // Shrink to a single survivor in one setState (e.g. worktree teardown).
+    usePanelStore.setState({
+      panelsById: { "m-3": usePanelStore.getState().panelsById["m-3"]! },
+      panelIds: ["m-3"],
+    });
+
+    expect(useResourceMonitoringStore.getState().metrics.has("m-1")).toBe(false);
+    expect(useResourceMonitoringStore.getState().metrics.has("m-2")).toBe(false);
+    expect(useResourceMonitoringStore.getState().metrics.has("m-3")).toBe(true);
+  });
+
+  it("removePanel stays a no-op when metrics were already pruned (onExit + force-removal)", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "dup-1": {
+          id: "dup-1",
+          title: "T1",
+          kind: "terminal" as const,
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      },
+      panelIds: ["dup-1"],
+    });
+
+    useResourceMonitoringStore.getState().updateMetrics({
+      "dup-1": { cpuPercent: 5, memoryKb: 1000, breakdown: [] },
+    });
+
+    // Simulate the PTY onExit path (lifecycle.ts) pruning first.
+    useResourceMonitoringStore.getState().removePanel("dup-1");
+    expect(useResourceMonitoringStore.getState().metrics.has("dup-1")).toBe(false);
+
+    // Then the orchestrator's force-removal path fires for the same id.
+    expect(() => usePanelStore.getState().removePanel("dup-1")).not.toThrow();
+    expect(useResourceMonitoringStore.getState().metrics.has("dup-1")).toBe(false);
+  });
+
   it("does not error when removing terminal without voice buffer", () => {
     usePanelStore.setState({
       panelsById: {

--- a/src/store/__tests__/rendererStoreOrchestrator.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.test.ts
@@ -78,6 +78,7 @@ const { usePanelStore } = await import("../panelStore");
 const { useWorktreeSelectionStore, persistMruList } = await import("../worktreeStore");
 const { useTerminalInputStore } = await import("../terminalInputStore");
 const { useConsoleCaptureStore } = await import("../consoleCaptureStore");
+const { useResourceMonitoringStore } = await import("../resourceMonitoringStore");
 const { useVoiceRecordingStore } = await import("../voiceRecordingStore");
 const { unregisterInputController } = await import("../terminalInputStore");
 const { semanticAnalysisService } = await import("@/services/SemanticAnalysisService");
@@ -107,6 +108,7 @@ describe("rendererStoreOrchestrator", () => {
     });
     useWorktreeSelectionStore.getState().reset();
     useConsoleCaptureStore.setState({ messages: new Map() });
+    useResourceMonitoringStore.setState({ metrics: new Map() });
     useVoiceRecordingStore.setState({ panelBuffers: {} });
   });
 
@@ -561,6 +563,66 @@ describe("rendererStoreOrchestrator", () => {
     usePanelStore.getState().removePanel(panelId);
 
     expect(useVoiceRecordingStore.getState().panelBuffers[panelId]).toBeUndefined();
+  });
+
+  it("prunes resource-monitoring metrics for the removed panel only", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "term-a": {
+          id: "term-a",
+          title: "A",
+          kind: "terminal" as const,
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        "term-b": {
+          id: "term-b",
+          title: "B",
+          kind: "terminal" as const,
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      },
+      panelIds: ["term-a", "term-b"],
+    });
+
+    useResourceMonitoringStore.getState().updateMetrics({
+      "term-a": { cpuPercent: 5, memoryKb: 1000, breakdown: [] },
+      "term-b": { cpuPercent: 7, memoryKb: 2000, breakdown: [] },
+    });
+    expect(useResourceMonitoringStore.getState().metrics.has("term-a")).toBe(true);
+    expect(useResourceMonitoringStore.getState().metrics.has("term-b")).toBe(true);
+
+    usePanelStore.getState().removePanel("term-a");
+
+    expect(useResourceMonitoringStore.getState().metrics.has("term-a")).toBe(false);
+    expect(useResourceMonitoringStore.getState().metrics.has("term-b")).toBe(true);
+  });
+
+  it("does not error when removing a panel without resource metrics", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "term-no-metrics": {
+          id: "term-no-metrics",
+          title: "T1",
+          kind: "terminal" as const,
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      },
+      panelIds: ["term-no-metrics"],
+    });
+
+    expect(useResourceMonitoringStore.getState().metrics.has("term-no-metrics")).toBe(false);
+
+    expect(() => usePanelStore.getState().removePanel("term-no-metrics")).not.toThrow();
+    expect(useResourceMonitoringStore.getState().metrics.size).toBe(0);
   });
 
   it("does not error when removing terminal without voice buffer", () => {

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -9,6 +9,7 @@ import { useFleetArmingStore, subscribeFleetArmingPanelPruning } from "./fleetAr
 import { useTerminalInputStore, unregisterInputController } from "./terminalInputStore";
 import { semanticAnalysisService } from "@/services/SemanticAnalysisService";
 import { useConsoleCaptureStore } from "./consoleCaptureStore";
+import { useResourceMonitoringStore } from "./resourceMonitoringStore";
 import { useVoiceRecordingStore } from "./voiceRecordingStore";
 import { useLayoutUndoStore } from "./layoutUndoStore";
 import { useCliAvailabilityStore } from "./cliAvailabilityStore";
@@ -189,6 +190,13 @@ export function initStoreOrchestrator(): () => void {
           for (const removedId of removedIds) {
             useTerminalInputStore.getState().clearTerminalState(removedId);
             useConsoleCaptureStore.getState().removePane(removedId);
+            // Prune the panel's resource-metrics entry. The PTY `onExit` path
+            // (lifecycle.ts) already calls this for terminals that exit cleanly,
+            // but force-removal (browser/dev-preview panels, or worktree teardown
+            // shrinking `panelIds` without a PTY exit) bypasses that path and
+            // would otherwise leak the `metrics` Map entry. `removePanel` is a
+            // no-op when the id is absent, so the double-call is safe (#9536).
+            useResourceMonitoringStore.getState().removePanel(removedId);
             useVoiceRecordingStore.getState().clearPanelBuffer(removedId);
             // Drop the dictation lock if it was pinned to this panel — panelIds
             // are ephemeral and a stale lock would silently break routing.


### PR DESCRIPTION
## Summary

Two Map-keyed Zustand stores had cleanup methods defined but never wired up, letting stale entries accumulate for the life of a session. Slow growth only visible in long-running multi-day sessions.

Resolves #9536

## Changes

**`resourceMonitoringStore.removePanel`** — the panel-removal prune loop in `rendererStoreOrchestrator` already clears `consoleCaptureStore`, `terminalInputStore`, and others on every `panelIds` change, but never called `removePanel`. Force-removed browser/dev-preview panels and terminals removed via worktree teardown all left stale `metrics` Map entries. Fixed by wiring `removePanel` into the existing loop.

**`pulseStore` worktree delete** — `WorktreeStoreContext` receives a full snapshot on host restart via `applySnapshot`, which can drop worktrees without firing per-id `worktree-removed` events. The `pulseStore` delete method had no caller on this path, leaving stale `pulses`, `loading`, `errors`, and retry entries. Fixed by adding a Map-diff subscription in `WorktreeStoreContext` that detects dropped worktrees and calls the delete method.

## Testing

- Orchestrator metrics-pruning: single removal, bulk removal, idempotent double-call
- New `WorktreeStoreContext.snapshotPrune` suite: all 7 maps invalidated on drop, unrelated-slice no-op, full-to-empty, retry timer cancellation, unmount teardown
- Typecheck and lint clean