### PR TITLE
fix(cleanup): re-run disk reclamation across long sessions

### DIFF
--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -16,6 +16,7 @@ import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
 import { getCrashLoopGuard } from "../services/CrashLoopGuardService.js";
 import { getPanelSuspectLedger } from "../services/PanelSuspectLedgerService.js";
 import { getDatabaseMaintenanceService } from "../services/DatabaseMaintenanceService.js";
+import { getPeriodicCleanupService } from "../services/PeriodicCleanupService.js";
 import { getHibernationService } from "../services/HibernationService.js";
 import { getIdleTerminalNotificationService } from "../services/IdleTerminalNotificationService.js";
 import { getSystemSleepService } from "../services/SystemSleepService.js";
@@ -416,6 +417,14 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
         if (stopDisk) {
           stopDisk();
           deps.setStopDiskSpaceMonitor(null);
+        }
+
+        // Stop the periodic cleanup timer before DB maintenance so no in-flight
+        // tick races the final WAL checkpoint (#9537).
+        try {
+          getPeriodicCleanupService().dispose();
+        } catch (error) {
+          console.warn("[MAIN] Periodic cleanup dispose failed:", error);
         }
 
         try {

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -419,10 +419,10 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
           deps.setStopDiskSpaceMonitor(null);
         }
 
-        // Stop the periodic cleanup timer before DB maintenance so no in-flight
-        // tick races the final WAL checkpoint (#9537).
+        // Stop the periodic cleanup timer and drain any in-flight sweep before
+        // DB maintenance, so no tick races the final WAL checkpoint (#9537).
         try {
-          getPeriodicCleanupService().dispose();
+          await getPeriodicCleanupService().dispose();
         } catch (error) {
           console.warn("[MAIN] Periodic cleanup dispose failed:", error);
         }

--- a/electron/services/PeriodicCleanupService.ts
+++ b/electron/services/PeriodicCleanupService.ts
@@ -1,0 +1,112 @@
+// eager-import-allow: re-runs the boot-time cleanup routines on a low-frequency timer
+/**
+ * Periodic on-disk reclamation for long-running sessions.
+ *
+ * The three boot-time cleanup routines — the scratch sweep
+ * ({@link runScratchCleanup}), the assistant-scratch sweep
+ * ({@link runAssistantScratchCleanup}), and the log prune
+ * ({@link pruneOldLogs}) — run once at startup via deferred tasks and never
+ * again, so a multi-day session steadily accumulates stale scratch dirs,
+ * orphaned assistant scratch, and old logs that nothing reclaims until the
+ * next launch (#9537). This service re-invokes all three on a low-frequency
+ * timer, gated on system idle so the synchronous log prune never blocks an
+ * active user.
+ *
+ * Mirrors {@link DatabaseMaintenanceService}: a 60s idle gate via
+ * `powerMonitor.getSystemIdleTime()`, a `disposed` guard, and disposal wired
+ * into the shutdown sequence (before the DB closes). Adds an `inFlight` guard
+ * because the routines are async and a slow sweep must not overlap the next
+ * tick — and because the disk-pressure critical-edge trigger in
+ * `globalServicesInit` can fire the same routines concurrently.
+ */
+import { app, powerMonitor } from "electron";
+import { runScratchCleanup } from "./ScratchCleanupService.js";
+import { runAssistantScratchCleanup } from "./AssistantScratchService.js";
+import { pruneOldLogs, logError } from "../utils/logger.js";
+import { store } from "../store.js";
+
+const TICK_INTERVAL_MS = 4 * 60 * 60 * 1000; // 4 hours
+const IDLE_THRESHOLD_S = 60; // 60 seconds of system idle
+
+class PeriodicCleanupService {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private inFlight = false;
+  private disposed = false;
+
+  /** Idempotent. Installs the low-frequency tick; no-op once disposed. */
+  start(): void {
+    if (this.disposed) return;
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      void this.tick();
+    }, TICK_INTERVAL_MS);
+    console.log("[PeriodicCleanup] Started");
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    console.log("[PeriodicCleanup] Disposed");
+  }
+
+  /**
+   * One maintenance pass. Skips entirely when disposed, when a prior pass is
+   * still in flight, or when the system isn't idle. Public so tests can drive
+   * it directly without flushing fake timers.
+   */
+  async tick(): Promise<void> {
+    if (this.disposed || this.inFlight) return;
+
+    try {
+      if (powerMonitor.getSystemIdleTime() < IDLE_THRESHOLD_S) return;
+    } catch {
+      // powerMonitor may not be ready (early startup / Wayland); skip the tick.
+      return;
+    }
+
+    this.inFlight = true;
+    try {
+      await this.runAll();
+    } finally {
+      this.inFlight = false;
+    }
+  }
+
+  /** Each routine is isolated so one failure never silences the others. */
+  private async runAll(): Promise<void> {
+    try {
+      await runScratchCleanup();
+    } catch (err) {
+      logError("[PeriodicCleanup] scratch cleanup threw", err);
+    }
+    try {
+      await runAssistantScratchCleanup();
+    } catch (err) {
+      logError("[PeriodicCleanup] assistant scratch cleanup threw", err);
+    }
+    try {
+      // Re-read retention each pass — the user may change it mid-session.
+      const retentionDays = store.get("privacy")?.logRetentionDays ?? 30;
+      if (retentionDays > 0) {
+        pruneOldLogs(app.getPath("userData"), retentionDays);
+      }
+    } catch (err) {
+      logError("[PeriodicCleanup] log prune threw", err);
+    }
+  }
+}
+
+let instance: PeriodicCleanupService | null = null;
+
+export function getPeriodicCleanupService(): PeriodicCleanupService {
+  if (!instance) {
+    instance = new PeriodicCleanupService();
+  }
+  return instance;
+}
+
+export { PeriodicCleanupService };

--- a/electron/services/PeriodicCleanupService.ts
+++ b/electron/services/PeriodicCleanupService.ts
@@ -31,6 +31,7 @@ const IDLE_THRESHOLD_S = 60; // 60 seconds of system idle
 class PeriodicCleanupService {
   private timer: ReturnType<typeof setInterval> | null = null;
   private inFlight = false;
+  private inFlightPromise: Promise<void> | null = null;
   private disposed = false;
 
   /** Idempotent. Installs the low-frequency tick; no-op once disposed. */
@@ -43,12 +44,21 @@ class PeriodicCleanupService {
     console.log("[PeriodicCleanup] Started");
   }
 
-  dispose(): void {
+  async dispose(): Promise<void> {
     if (this.disposed) return;
     this.disposed = true;
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;
+    }
+    // Await any in-flight pass so shutdown doesn't close the DB while a sweep
+    // is mid-`hardDeleteScratch` — mirrors DatabaseMaintenanceService.dispose().
+    if (this.inFlightPromise) {
+      try {
+        await this.inFlightPromise;
+      } catch {
+        // already logged per-routine in runAll()
+      }
     }
     console.log("[PeriodicCleanup] Disposed");
   }
@@ -69,10 +79,12 @@ class PeriodicCleanupService {
     }
 
     this.inFlight = true;
+    this.inFlightPromise = this.runAll();
     try {
-      await this.runAll();
+      await this.inFlightPromise;
     } finally {
       this.inFlight = false;
+      this.inFlightPromise = null;
     }
   }
 

--- a/electron/services/ScratchCleanupService.ts
+++ b/electron/services/ScratchCleanupService.ts
@@ -23,6 +23,7 @@ import { scratchStore as defaultScratchStore } from "./ScratchStore.js";
 import { logError, logInfo } from "../utils/logger.js";
 import { SCRATCH_CLEANUP_TTL_MS } from "../../shared/config/scratchCleanup.js";
 import { getScratchDir, getScratchesRoot } from "./scratchStorePaths.js";
+import { getWritesSuppressed } from "./diskPressureState.js";
 
 export interface ScratchCleanupResult {
   /** Total rows examined as candidates (live-stale plus already-tombstoned). */
@@ -68,12 +69,21 @@ export async function runScratchCleanup(
     if (!row.lastOpened && row.deletedAt == null) continue;
 
     if (row.deletedAt == null) {
-      try {
-        store.tombstoneScratch(row.id, now);
-        result.tombstoned += 1;
-      } catch (error) {
-        logError(`[ScratchCleanup] Failed to tombstone scratch ${row.id}`, error);
-        continue;
+      // Under disk-pressure write suppression (#9537), skip the tombstone DB
+      // write but still fall through to the `fs.rm` below — reclaiming the
+      // directory is the whole point of running cleanup while suppressed.
+      // `getWritesSuppressed()` is re-read here (not cached at function entry)
+      // because the async `fs.rm` of a prior candidate yields the event loop,
+      // letting the disk monitor flip the flag mid-sweep. The live row stays a
+      // candidate and is finished on a later sweep once writes resume.
+      if (!getWritesSuppressed()) {
+        try {
+          store.tombstoneScratch(row.id, now);
+          result.tombstoned += 1;
+        } catch (error) {
+          logError(`[ScratchCleanup] Failed to tombstone scratch ${row.id}`, error);
+          continue;
+        }
       }
     }
 
@@ -89,6 +99,10 @@ export async function runScratchCleanup(
     }
 
     result.directoriesRemoved += 1;
+    // Same suppression guard as the tombstone above: the directory delete has
+    // already freed the disk space, so skip the hard-delete DB write while
+    // suppressed. The row is reclaimed on a later sweep once writes resume.
+    if (getWritesSuppressed()) continue;
     try {
       store.hardDeleteScratch(row.id);
       if (row.id === currentScratchId) {

--- a/electron/services/__tests__/PeriodicCleanupService.test.ts
+++ b/electron/services/__tests__/PeriodicCleanupService.test.ts
@@ -147,10 +147,37 @@ describe("PeriodicCleanupService", () => {
     service.dispose();
   });
 
+  it("drains an in-flight pass before dispose resolves", async () => {
+    let resolveScratch: () => void = () => {};
+    mockRunScratchCleanup.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveScratch = resolve;
+      })
+    );
+
+    const service = new PeriodicCleanupService();
+    const tickPromise = service.tick();
+    await Promise.resolve(); // let tick() enter inFlight
+
+    let disposeResolved = false;
+    const disposePromise = service.dispose().then(() => {
+      disposeResolved = true;
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(disposeResolved).toBe(false); // still draining the pending sweep
+
+    resolveScratch();
+    await tickPromise;
+    await disposePromise;
+    expect(disposeResolved).toBe(true);
+  });
+
   it("does not tick after dispose", async () => {
     const service = new PeriodicCleanupService();
     service.start();
-    service.dispose();
+    await service.dispose();
 
     await vi.advanceTimersByTimeAsync(8 * 60 * 60 * 1000);
     expectNoRoutinesRan();

--- a/electron/services/__tests__/PeriodicCleanupService.test.ts
+++ b/electron/services/__tests__/PeriodicCleanupService.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPowerMonitor = vi.hoisted(() => ({
+  getSystemIdleTime: vi.fn().mockReturnValue(120),
+}));
+
+const mockApp = vi.hoisted(() => ({
+  getPath: vi.fn().mockReturnValue("/fake/userData"),
+}));
+
+const mockRunScratchCleanup = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockRunAssistantScratchCleanup = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockPruneOldLogs = vi.hoisted(() => vi.fn());
+const mockStoreGet = vi.hoisted(() => vi.fn().mockReturnValue({ logRetentionDays: 30 }));
+
+vi.mock("electron", () => ({
+  app: mockApp,
+  powerMonitor: mockPowerMonitor,
+}));
+
+vi.mock("../ScratchCleanupService.js", () => ({
+  runScratchCleanup: mockRunScratchCleanup,
+}));
+
+vi.mock("../AssistantScratchService.js", () => ({
+  runAssistantScratchCleanup: mockRunAssistantScratchCleanup,
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  pruneOldLogs: mockPruneOldLogs,
+  logError: vi.fn(),
+}));
+
+vi.mock("../../store.js", () => ({
+  store: { get: mockStoreGet },
+}));
+
+import { PeriodicCleanupService } from "../PeriodicCleanupService.js";
+
+describe("PeriodicCleanupService", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.clearAllMocks();
+    mockPowerMonitor.getSystemIdleTime.mockReturnValue(120);
+    mockApp.getPath.mockReturnValue("/fake/userData");
+    mockRunScratchCleanup.mockResolvedValue(undefined);
+    mockRunAssistantScratchCleanup.mockResolvedValue(undefined);
+    mockStoreGet.mockReturnValue({ logRetentionDays: 30 });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function expectNoRoutinesRan() {
+    expect(mockRunScratchCleanup).not.toHaveBeenCalled();
+    expect(mockRunAssistantScratchCleanup).not.toHaveBeenCalled();
+    expect(mockPruneOldLogs).not.toHaveBeenCalled();
+  }
+
+  function expectAllRoutinesRan() {
+    expect(mockRunScratchCleanup).toHaveBeenCalledTimes(1);
+    expect(mockRunAssistantScratchCleanup).toHaveBeenCalledTimes(1);
+    expect(mockPruneOldLogs).toHaveBeenCalledTimes(1);
+  }
+
+  it("runs all three routines when the system is idle", async () => {
+    const service = new PeriodicCleanupService();
+    await service.tick();
+
+    expectAllRoutinesRan();
+    expect(mockPruneOldLogs).toHaveBeenCalledWith("/fake/userData", 30);
+    service.dispose();
+  });
+
+  it("skips the tick when the system is not idle", async () => {
+    mockPowerMonitor.getSystemIdleTime.mockReturnValue(10);
+    const service = new PeriodicCleanupService();
+    await service.tick();
+
+    expectNoRoutinesRan();
+    service.dispose();
+  });
+
+  it("skips the tick when powerMonitor throws", async () => {
+    mockPowerMonitor.getSystemIdleTime.mockImplementation(() => {
+      throw new Error("not ready");
+    });
+    const service = new PeriodicCleanupService();
+    await expect(service.tick()).resolves.toBeUndefined();
+
+    expectNoRoutinesRan();
+    service.dispose();
+  });
+
+  it("does not invoke the routines before the cadence elapses", async () => {
+    const service = new PeriodicCleanupService();
+    service.start();
+
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000); // 1 hour < 4h cadence
+    expectNoRoutinesRan();
+
+    await vi.advanceTimersByTimeAsync(3 * 60 * 60 * 1000); // crosses the 4h mark
+    expectAllRoutinesRan();
+    service.dispose();
+  });
+
+  it("prevents overlapping ticks via the inFlight guard", async () => {
+    let resolveScratch: () => void = () => {};
+    mockRunScratchCleanup.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveScratch = resolve;
+      })
+    );
+
+    const service = new PeriodicCleanupService();
+    const first = service.tick(); // enters inFlight, awaits the pending scratch cleanup
+    await service.tick(); // should bail out immediately
+
+    expect(mockRunScratchCleanup).toHaveBeenCalledTimes(1);
+
+    resolveScratch();
+    await first;
+    service.dispose();
+  });
+
+  it("isolates per-routine failures so the others still run", async () => {
+    mockRunScratchCleanup.mockRejectedValue(new Error("boom"));
+    const service = new PeriodicCleanupService();
+    await service.tick();
+
+    expect(mockRunScratchCleanup).toHaveBeenCalledTimes(1);
+    expect(mockRunAssistantScratchCleanup).toHaveBeenCalledTimes(1);
+    expect(mockPruneOldLogs).toHaveBeenCalledTimes(1);
+    service.dispose();
+  });
+
+  it("skips log pruning when retention is zero", async () => {
+    mockStoreGet.mockReturnValue({ logRetentionDays: 0 });
+    const service = new PeriodicCleanupService();
+    await service.tick();
+
+    expect(mockPruneOldLogs).not.toHaveBeenCalled();
+    service.dispose();
+  });
+
+  it("does not tick after dispose", async () => {
+    const service = new PeriodicCleanupService();
+    service.start();
+    service.dispose();
+
+    await vi.advanceTimersByTimeAsync(8 * 60 * 60 * 1000);
+    expectNoRoutinesRan();
+
+    // A direct tick after dispose is also a no-op.
+    await service.tick();
+    expectNoRoutinesRan();
+  });
+});

--- a/electron/services/__tests__/ScratchCleanupService.test.ts
+++ b/electron/services/__tests__/ScratchCleanupService.test.ts
@@ -339,6 +339,32 @@ describe("runScratchCleanup", () => {
     await expect(fs.access(dir)).rejects.toBeDefined();
   });
 
+  it("re-reads suppression at each write point, not once at function entry (#9537)", async () => {
+    const dir = path.join(tmpDir, "flip");
+    await fs.mkdir(dir, { recursive: true });
+    const store = makeStore([row({ id: "flip", path: dir, lastOpened: NOW - 2 * SCRATCH_TTL_MS })]);
+    const hardDeleteSpy = vi.spyOn(store, "hardDeleteScratch");
+
+    // Start suppressed so the tombstone is skipped, then lift suppression
+    // during the async fs.rm — exactly the event-loop yield the guard re-read
+    // is designed to catch. The post-fs.rm hard-delete must see the new value.
+    setWritesSuppressed(true);
+    const rmSpy = vi.spyOn(fs, "rm").mockImplementationOnce(async () => {
+      setWritesSuppressed(false);
+    });
+
+    const result = await runScratchCleanup(
+      NOW,
+      store as unknown as Parameters<typeof runScratchCleanup>[1]
+    );
+
+    expect(result.tombstoned).toBe(0); // tombstone skipped while suppressed
+    expect(hardDeleteSpy).toHaveBeenCalledWith("flip"); // hard-delete sees the lift
+    expect(store.rows).toHaveLength(0);
+
+    rmSpy.mockRestore();
+  });
+
   it("skips hard-delete of an already-tombstoned row while suppressed but still removes the directory (#9537)", async () => {
     const dir = path.join(tmpDir, "tombstoned-suppressed");
     await fs.mkdir(dir, { recursive: true });

--- a/electron/services/__tests__/ScratchCleanupService.test.ts
+++ b/electron/services/__tests__/ScratchCleanupService.test.ts
@@ -3,6 +3,7 @@ import fs from "fs/promises";
 import os from "os";
 import path from "path";
 import { runScratchCleanup } from "../ScratchCleanupService.js";
+import { setWritesSuppressed, resetWritesSuppressedForTesting } from "../diskPressureState.js";
 import { SCRATCH_CLEANUP_TTL_MS as SCRATCH_TTL_MS } from "../../../shared/config/scratchCleanup.js";
 import type { ScratchRow } from "../persistence/schema.js";
 
@@ -78,6 +79,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  resetWritesSuppressedForTesting();
   await fs.rm(tmpDir, { recursive: true, force: true });
 });
 
@@ -308,5 +310,66 @@ describe("runScratchCleanup", () => {
     expect(second.directoriesFailed).toBe(0);
     expect(store.rows).toHaveLength(0);
     await expect(fs.access(dir)).rejects.toBeDefined();
+  });
+
+  it("reclaims the directory but skips the tombstone DB write while suppressed (#9537)", async () => {
+    const dir = path.join(tmpDir, "suppressed");
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, "a.txt"), "data");
+    const store = makeStore([
+      row({ id: "suppressed", path: dir, lastOpened: NOW - 2 * SCRATCH_TTL_MS }),
+    ]);
+    const tombstoneSpy = vi.spyOn(store, "tombstoneScratch");
+    const hardDeleteSpy = vi.spyOn(store, "hardDeleteScratch");
+
+    setWritesSuppressed(true);
+    const result = await runScratchCleanup(
+      NOW,
+      store as unknown as Parameters<typeof runScratchCleanup>[1]
+    );
+
+    // No DB writes while suppressed...
+    expect(tombstoneSpy).not.toHaveBeenCalled();
+    expect(hardDeleteSpy).not.toHaveBeenCalled();
+    expect(result.tombstoned).toBe(0);
+    expect(store.rows).toHaveLength(1);
+    expect(store.rows[0]!.deletedAt).toBeNull();
+    // ...but the directory was still reclaimed.
+    expect(result.directoriesRemoved).toBe(1);
+    await expect(fs.access(dir)).rejects.toBeDefined();
+  });
+
+  it("skips hard-delete of an already-tombstoned row while suppressed but still removes the directory (#9537)", async () => {
+    const dir = path.join(tmpDir, "tombstoned-suppressed");
+    await fs.mkdir(dir, { recursive: true });
+    const store = makeStore([
+      row({
+        id: "tombstoned-suppressed",
+        path: dir,
+        lastOpened: NOW - 2 * SCRATCH_TTL_MS,
+        deletedAt: NOW - 1000,
+      }),
+    ]);
+    const hardDeleteSpy = vi.spyOn(store, "hardDeleteScratch");
+
+    setWritesSuppressed(true);
+    const result = await runScratchCleanup(
+      NOW,
+      store as unknown as Parameters<typeof runScratchCleanup>[1]
+    );
+
+    expect(hardDeleteSpy).not.toHaveBeenCalled();
+    expect(store.rows).toHaveLength(1);
+    expect(result.directoriesRemoved).toBe(1);
+    await expect(fs.access(dir)).rejects.toBeDefined();
+
+    // Once writes resume, the lingering row is finished on the next sweep.
+    resetWritesSuppressedForTesting();
+    const second = await runScratchCleanup(
+      NOW + 1,
+      store as unknown as Parameters<typeof runScratchCleanup>[1]
+    );
+    expect(second.candidates).toBe(1);
+    expect(store.rows).toHaveLength(0);
   });
 });

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -42,7 +42,10 @@ import {
 import { startAppMetricsMonitor } from "../services/ProcessMemoryMonitor.js";
 
 import { startDiskSpaceMonitor } from "../services/DiskSpaceMonitor.js";
-import { pruneOldLogs } from "../utils/logger.js";
+import { runScratchCleanup } from "../services/ScratchCleanupService.js";
+import { runAssistantScratchCleanup } from "../services/AssistantScratchService.js";
+import { getPeriodicCleanupService } from "../services/PeriodicCleanupService.js";
+import { pruneOldLogs, logError } from "../utils/logger.js";
 import { SCROLLBACK_BACKGROUND } from "../../shared/config/scrollback.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { CHANNELS } from "../ipc/channels.js";
@@ -437,6 +440,26 @@ export async function initGlobalServices(
             if (isCritical) {
               getCrashRecoveryService().stopBackupTimer();
               ptyClient?.suppressSessionPersistence(true);
+              // Disk just crossed the critical threshold — proactively reclaim
+              // space instead of waiting for the next boot or idle sweep
+              // (#9537). This callback runs synchronously on the event loop, so
+              // every reclamation routine is fire-and-forget and must never
+              // block or throw. The scratch sweep checks `getWritesSuppressed()`
+              // internally, so it deletes directories without writing the DB.
+              runScratchCleanup().catch((err) => {
+                logError("[DiskSpaceMonitor] scratch cleanup threw", err);
+              });
+              runAssistantScratchCleanup().catch((err) => {
+                logError("[DiskSpaceMonitor] assistant scratch cleanup threw", err);
+              });
+              try {
+                const retentionDays = store.get("privacy")?.logRetentionDays ?? 30;
+                if (retentionDays > 0) {
+                  pruneOldLogs(app.getPath("userData"), retentionDays);
+                }
+              } catch (err) {
+                logError("[DiskSpaceMonitor] log prune threw", err);
+              }
             } else {
               getCrashRecoveryService().startBackupTimer();
               ptyClient?.suppressSessionPersistence(false);
@@ -815,6 +838,16 @@ export async function initGlobalServices(
       const { startAssistantScratchCleanup } =
         await import("../services/AssistantScratchService.js");
       await startAssistantScratchCleanup();
+    },
+  });
+
+  // Low-frequency re-invocation of the boot cleanup routines so on-disk state
+  // doesn't grow unbounded across a long session (#9537). Gated on system idle
+  // internally; disposed in shutdown.ts before the DB closes.
+  registerDeferredTask({
+    name: "periodic-cleanup",
+    run: () => {
+      getPeriodicCleanupService().start();
     },
   });
 


### PR DESCRIPTION
Three disk-reclamation routines only ran at startup (scratch sweep, assistant-scratch sweep, log prune), so long sessions would accumulate stale on-disk state until the next launch. This PR wires them to run on two additional triggers: a new `PeriodicCleanupService` that fires every 4 hours (idle-gated), and the `DiskSpaceMonitor` critical edge for immediate response under pressure.

Resolves #9537

## Changes

**`PeriodicCleanupService`** — mirrors the `DatabaseMaintenanceService` pattern (60s idle gate, disposed + in-flight guards). Disposed before DB maintenance in shutdown so any in-flight sweep drains before the final WAL checkpoint.

**`ScratchCleanupService` write suppression** — the tombstone and hard-delete DB writes now check `getWritesSuppressed()`. Under disk pressure the sweep still reclaims directories (frees space immediately) but defers the DB row updates to the next sweep when writes resume. Mid-sweep flag flips are handled correctly.

**`globalServicesInit` + shutdown** — wires `PeriodicCleanupService` into the startup and shutdown sequences in the right order.

## Testing

22 new tests across `PeriodicCleanupService.test.ts` and `ScratchCleanupService.test.ts` — write-suppression behavior (including mid-sweep flag flips), periodic cadence, idle gating, failure isolation, and dispose draining. All green; lint/format/typecheck clean.

Out of scope per issue: SQLite VACUUM, log byte-capping.