### PR TITLE
perf(workspace-host): bound background git file-watchers via LRU budget

### DIFF
--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -697,6 +697,7 @@ export class ResourceProfileService {
           pollIntervalBackground: config.pollIntervalBackground,
           fetchIntervalActiveMs: config.fetchIntervalActiveMs,
           fetchIntervalBackgroundMs: config.fetchIntervalBackgroundMs,
+          backgroundGitWatcherCap: config.backgroundGitWatcherCap,
         });
       } catch {
         // non-critical

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -345,6 +345,7 @@ describe("ResourceProfileService", () => {
       pollIntervalBackground: RESOURCE_PROFILE_CONFIGS.efficiency.pollIntervalBackground,
       fetchIntervalActiveMs: RESOURCE_PROFILE_CONFIGS.efficiency.fetchIntervalActiveMs,
       fetchIntervalBackgroundMs: RESOURCE_PROFILE_CONFIGS.efficiency.fetchIntervalBackgroundMs,
+      backgroundGitWatcherCap: RESOURCE_PROFILE_CONFIGS.efficiency.backgroundGitWatcherCap,
     });
     expect(hib.setMemoryPressureThresholdMs).toHaveBeenCalledWith(
       RESOURCE_PROFILE_CONFIGS.efficiency.memoryPressureInactiveMs

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -585,83 +585,89 @@ export class WorkspaceService {
       }
     }
 
-    // Create or update monitors
-    for (const wt of worktrees) {
-      const existingMonitor = this.monitors.get(wt.id);
-      const isActive = wt.id === activeWorktreeId;
+    // Create or update monitors. The watcher-budget reconciliation runs in a
+    // finally so a mid-loop throw (e.g. a failed stat/note-file write in
+    // addNewWorktreeMonitor) still grants the deferred new monitors their
+    // watcher and re-asserts the cap, rather than leaving them poll-only until
+    // the next sync.
+    try {
+      for (const wt of worktrees) {
+        const existingMonitor = this.monitors.get(wt.id);
+        const isActive = wt.id === activeWorktreeId;
 
-      if (existingMonitor) {
-        const branchChanged = existingMonitor.branch !== wt.branch;
-        const isCurrentChanged = existingMonitor.isCurrent !== isActive;
-        existingMonitor.branch = wt.branch;
-        existingMonitor.name = wt.name;
-        existingMonitor.isCurrent = isActive;
-        existingMonitor.isMainWorktree = wt.isMainWorktree ?? false;
-        // Keep the base-branch divergence fallback fresh if the main worktree
-        // switched branches since this monitor was created.
-        existingMonitor.setMainBranch(this.mainBranch);
+        if (existingMonitor) {
+          const branchChanged = existingMonitor.branch !== wt.branch;
+          const isCurrentChanged = existingMonitor.isCurrent !== isActive;
+          existingMonitor.branch = wt.branch;
+          existingMonitor.name = wt.name;
+          existingMonitor.isCurrent = isActive;
+          existingMonitor.isMainWorktree = wt.isMainWorktree ?? false;
+          // Keep the base-branch divergence fallback fresh if the main worktree
+          // switched branches since this monitor was created.
+          existingMonitor.setMainBranch(this.mainBranch);
 
-        const interval = isActive ? this.pollIntervalActive : this.pollIntervalBackground;
-        existingMonitor.updateConfig({
-          basePollingInterval: interval,
-          adaptiveBackoff: this.adaptiveBackoff,
-          pollIntervalMax: this.pollIntervalMax,
-          circuitBreakerThreshold: this.circuitBreakerThreshold,
-          gitWatchEnabled: this.gitWatchEnabled,
-          gitWatchDebounceMs: this.gitWatchDebounceMs,
-          fetchIntervalActiveMs: this.throttledFetchActiveMs,
-          fetchIntervalBackgroundMs: this.throttledFetchBackgroundMs,
-        });
+          const interval = isActive ? this.pollIntervalActive : this.pollIntervalBackground;
+          existingMonitor.updateConfig({
+            basePollingInterval: interval,
+            adaptiveBackoff: this.adaptiveBackoff,
+            pollIntervalMax: this.pollIntervalMax,
+            circuitBreakerThreshold: this.circuitBreakerThreshold,
+            gitWatchEnabled: this.gitWatchEnabled,
+            gitWatchDebounceMs: this.gitWatchDebounceMs,
+            fetchIntervalActiveMs: this.throttledFetchActiveMs,
+            fetchIntervalBackgroundMs: this.throttledFetchBackgroundMs,
+          });
 
-        existingMonitor.ensureWatcherState();
+          existingMonitor.ensureWatcherState();
 
-        if (branchChanged && existingMonitor.hasWatcher) {
-          existingMonitor.restartWatcherIfRunning();
-        }
+          if (branchChanged && existingMonitor.hasWatcher) {
+            existingMonitor.restartWatcherIfRunning();
+          }
 
-        // Skip this emit when the branch also changed — the branch-change
-        // block below emits the full snapshot (with updated isCurrent and
-        // cleared PR) anyway. Emitting here first would surface an
-        // intermediate frame carrying the new branch with the old PR (#8079).
-        if (isCurrentChanged && !branchChanged && existingMonitor.hasInitialStatus) {
-          this.emitUpdate(existingMonitor);
-        }
+          // Skip this emit when the branch also changed — the branch-change
+          // block below emits the full snapshot (with updated isCurrent and
+          // cleared PR) anyway. Emitting here first would surface an
+          // intermediate frame carrying the new branch with the old PR (#8079).
+          if (isCurrentChanged && !branchChanged && existingMonitor.hasInitialStatus) {
+            this.emitUpdate(existingMonitor);
+          }
 
-        if (branchChanged && wt.branch) {
-          const syncIssueNumber = extractIssueNumberSync(wt.branch, wt.name);
-          if (syncIssueNumber) {
-            existingMonitor.setIssueNumber(syncIssueNumber);
-          } else {
+          if (branchChanged && wt.branch) {
+            const syncIssueNumber = extractIssueNumberSync(wt.branch, wt.name);
+            if (syncIssueNumber) {
+              existingMonitor.setIssueNumber(syncIssueNumber);
+            } else {
+              existingMonitor.setIssueNumber(undefined);
+              void this.extractIssueNumberAsync(existingMonitor, wt.branch, wt.name);
+            }
+            existingMonitor.setIssueTitle(undefined);
+            // Bundle the PR clear into this same branch-change emit so the
+            // renderer never renders the new branch with the old PR (#8079).
+            existingMonitor.clearPRInfo();
+            existingMonitor.clearLinked();
+            if (existingMonitor.hasInitialStatus) {
+              this.emitUpdate(existingMonitor);
+            }
+          } else if (branchChanged && !wt.branch) {
             existingMonitor.setIssueNumber(undefined);
-            void this.extractIssueNumberAsync(existingMonitor, wt.branch, wt.name);
+            existingMonitor.setIssueTitle(undefined);
+            existingMonitor.clearPRInfo();
+            existingMonitor.clearLinked();
+            if (existingMonitor.hasInitialStatus) {
+              this.emitUpdate(existingMonitor);
+            }
           }
-          existingMonitor.setIssueTitle(undefined);
-          // Bundle the PR clear into this same branch-change emit so the
-          // renderer never renders the new branch with the old PR (#8079).
-          existingMonitor.clearPRInfo();
-          existingMonitor.clearLinked();
-          if (existingMonitor.hasInitialStatus) {
-            this.emitUpdate(existingMonitor);
-          }
-        } else if (branchChanged && !wt.branch) {
-          existingMonitor.setIssueNumber(undefined);
-          existingMonitor.setIssueTitle(undefined);
-          existingMonitor.clearPRInfo();
-          existingMonitor.clearLinked();
-          if (existingMonitor.hasInitialStatus) {
-            this.emitUpdate(existingMonitor);
-          }
+        } else {
+          await this.addNewWorktreeMonitor(wt, isActive, skipInitialGitStatus, true);
         }
-      } else {
-        await this.addNewWorktreeMonitor(wt, isActive, skipInitialGitStatus, true);
       }
+    } finally {
+      // Final reconciliation pass (#9538): enforce the watcher budget after the
+      // whole create/update loop. This is the authoritative override of any
+      // `ensureWatcherState()` call above that re-armed an evicted background
+      // watcher, and the single budget application for the deferred new monitors.
+      this.applyWatcherBudget();
     }
-
-    // Final reconciliation pass (#9538): enforce the watcher budget after the
-    // whole create/update loop. This is the authoritative override of any
-    // `ensureWatcherState()` call above that re-armed an evicted background
-    // watcher, and the single budget application for the deferred new monitors.
-    this.applyWatcherBudget();
   }
 
   /**
@@ -2761,6 +2767,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
       monitor.stop();
     }
     this.monitors.clear();
+    this.backgroundGitWatcherLru.clear();
     // Drop in-flight fetch chains and per-repo failure state — the next
     // project's monitors get a clean coordinator and stale completions are
     // discarded by the generation guard.

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -61,6 +61,11 @@ export { probeGitLfsAvailable } from "./worktreeUtils.js";
 // Configuration
 const DEFAULT_ACTIVE_WORKTREE_INTERVAL_MS = 2000;
 const DEFAULT_BACKGROUND_WORKTREE_INTERVAL_MS = 10000;
+// Default cap on concurrent background `git-only` file watchers per
+// workspace-host. Matches the `balanced` profile's `backgroundGitWatcherCap`
+// in `shared/types/resourceProfile.ts` — that profile must mirror the
+// hardcoded defaults. Overridden per-profile via `updateMonitorConfig`.
+const DEFAULT_BACKGROUND_GIT_WATCHER_CAP = 12;
 const WORKTREE_REMOVE_LOCK_RETRY_DELAYS_MS = [250, 500, 1000, 2000, 3000, 5000, 8000];
 // Periodic safety-net reconcile cadence. On macOS the FSEvents-backed topology
 // watcher goes silent when `.git/worktrees/` is deleted (last worktree removed)
@@ -103,6 +108,19 @@ export class WorkspaceService {
   private circuitBreakerThreshold: number = 3;
   private gitWatchEnabled: boolean = true;
   private gitWatchDebounceMs: number = 300;
+  // Profile-aware ceiling on concurrent background `git-only` watchers (#9538).
+  // The focused worktree always keeps its (recursive) watcher and is excluded
+  // from this budget; background worktrees beyond the cap fall back to the
+  // adaptive poll path. Bounds the O(N) inotify/FSEvents/fd growth long
+  // sessions with many worktrees would otherwise hit. Per-instance (one
+  // workspace-host per project view), never global.
+  private backgroundGitWatcherCap: number = DEFAULT_BACKGROUND_GIT_WATCHER_CAP;
+  // Recency-ordered set of background worktree IDs eligible for a git-only
+  // watcher. ES Map preserves insertion order: head = least-recently-focused
+  // (LRU, first evicted), tail = most-recently-focused (MRU). The active
+  // worktree is never present here. Mutated via lruTouch/lruRemove; budget
+  // enforced by applyWatcherBudget().
+  private readonly backgroundGitWatcherLru = new Map<string, true>();
   private git: SimpleGit | null = null;
   private pollingEnabled: boolean = true;
   private projectRootPath: string | null = null;
@@ -530,6 +548,11 @@ export class WorkspaceService {
     if (monitorConfig?.fetchIntervalBackgroundMs !== undefined) {
       this.fetchIntervalBackgroundMs = monitorConfig.fetchIntervalBackgroundMs;
     }
+    if (monitorConfig?.backgroundGitWatcherCap !== undefined) {
+      this.backgroundGitWatcherCap = this.normalizeWatcherCap(
+        monitorConfig.backgroundGitWatcherCap
+      );
+    }
 
     const currentIds = new Set(worktrees.map((wt) => wt.id));
 
@@ -548,6 +571,7 @@ export class WorkspaceService {
         this.resourceActionExecutor.cleanupResourceActionState(id);
         monitor.stop();
         this.monitors.delete(id);
+        this.lruRemove(id);
         this.recoverWatcherIfNoMonitorsRemain();
         clearGitDirCache(monitor.path);
         invalidateGitStatusCache(monitor.path);
@@ -629,9 +653,15 @@ export class WorkspaceService {
           }
         }
       } else {
-        await this.addNewWorktreeMonitor(wt, isActive, skipInitialGitStatus);
+        await this.addNewWorktreeMonitor(wt, isActive, skipInitialGitStatus, true);
       }
     }
+
+    // Final reconciliation pass (#9538): enforce the watcher budget after the
+    // whole create/update loop. This is the authoritative override of any
+    // `ensureWatcherState()` call above that re-armed an evicted background
+    // watcher, and the single budget application for the deferred new monitors.
+    this.applyWatcherBudget();
   }
 
   /**
@@ -692,10 +722,78 @@ export class WorkspaceService {
     }
   }
 
+  // --- Background git-watcher budget (LRU) ---
+
+  /** Clamp a requested cap to a non-negative integer, ignoring junk values. */
+  private normalizeWatcherCap(value: number): number {
+    if (!Number.isFinite(value)) return this.backgroundGitWatcherCap;
+    return Math.max(0, Math.floor(value));
+  }
+
+  /** Move (or insert) a background worktree id to the MRU end of the LRU. */
+  private lruTouch(worktreeId: string): void {
+    this.backgroundGitWatcherLru.delete(worktreeId);
+    this.backgroundGitWatcherLru.set(worktreeId, true);
+  }
+
+  /** Drop a worktree id from the LRU (active-focus, removal, dispose). */
+  private lruRemove(worktreeId: string): void {
+    this.backgroundGitWatcherLru.delete(worktreeId);
+  }
+
+  /**
+   * Enforce the background watcher budget across every monitor. The focused
+   * worktree always keeps its watcher (excluded from the cap). Background
+   * monitors are granted a watcher for the `cap` most-recently-focused entries
+   * (LRU tail) and evicted otherwise — evicted monitors stop their watcher and
+   * fall back to adaptive polling.
+   *
+   * Revocations run before grants so freed inotify/fd handles are released
+   * before any new watcher arms, keeping the live handle count bounded by the
+   * cap even mid-reconcile. Idempotent: `setGitWatchBudgetAllowed` is a no-op
+   * when the flag is unchanged, so repeated calls don't churn watchers.
+   *
+   * Also the single reconciliation point that overrides `ensureWatcherState()`
+   * re-arming an evicted watcher during `syncMonitors` (#9538 pitfall): it must
+   * run AFTER any sync/focus mutation that could re-arm watchers.
+   */
+  private applyWatcherBudget(): void {
+    // Reconcile LRU membership against live monitors: the active worktree must
+    // never be in the pool; every other running monitor must be present.
+    for (const id of [...this.backgroundGitWatcherLru.keys()]) {
+      if (!this.monitors.has(id) || id === this.activeWorktreeId) {
+        this.backgroundGitWatcherLru.delete(id);
+      }
+    }
+    for (const id of this.monitors.keys()) {
+      if (id !== this.activeWorktreeId && !this.backgroundGitWatcherLru.has(id)) {
+        this.backgroundGitWatcherLru.set(id, true);
+      }
+    }
+
+    const ids = [...this.backgroundGitWatcherLru.keys()]; // LRU → MRU
+    const cap = this.backgroundGitWatcherCap;
+    const cutoff = Math.max(0, ids.length - cap);
+
+    // Evict the oldest (head) entries beyond the cap first to free handles.
+    for (let i = 0; i < cutoff; i++) {
+      this.monitors.get(ids[i])?.setGitWatchBudgetAllowed(false);
+    }
+    // The focused worktree always keeps its watcher.
+    if (this.activeWorktreeId) {
+      this.monitors.get(this.activeWorktreeId)?.setGitWatchBudgetAllowed(true);
+    }
+    // Grant the surviving MRU tail.
+    for (let i = cutoff; i < ids.length; i++) {
+      this.monitors.get(ids[i])?.setGitWatchBudgetAllowed(true);
+    }
+  }
+
   private async addNewWorktreeMonitor(
     wt: Worktree,
     isActive: boolean,
-    skipInitialGitStatus: boolean
+    skipInitialGitStatus: boolean,
+    deferWatcherBudget: boolean = false
   ): Promise<void> {
     if (this.monitors.has(wt.id)) {
       return;
@@ -781,7 +879,28 @@ export class WorkspaceService {
     monitor.setIssueNumber(issueNumber ?? undefined);
     monitor.setCreatedAt(createdAt);
 
+    // Withhold the watcher budget from a new *background* monitor before it
+    // starts so start() never arms a watcher we may be about to evict — this
+    // bounds the cold-start handle peak to the cap instead of O(N). The active
+    // worktree keeps the default-granted budget (it's excluded from the cap).
+    // applyWatcherBudget() below grants the surviving MRU tail (evicting the
+    // oldest if this push spilled over the cap).
+    if (!isActive) {
+      monitor.setGitWatchBudgetAllowed(false);
+    }
+
     this.monitors.set(wt.id, monitor);
+
+    if (isActive) {
+      this.lruRemove(wt.id);
+    } else {
+      this.lruTouch(wt.id);
+    }
+    // syncMonitors batches a single applyWatcherBudget() after its whole loop
+    // (deferWatcherBudget) to avoid O(N²) reconciliation across a cold start.
+    if (!deferWatcherBudget) {
+      this.applyWatcherBudget();
+    }
 
     if (skipInitialGitStatus) {
       monitor.startWithoutGitStatus();
@@ -1308,7 +1427,11 @@ export class WorkspaceService {
     this.resourceActionExecutor.cleanupResourceActionState(worktreeId);
     monitor.stop();
     this.monitors.delete(worktreeId);
+    this.lruRemove(worktreeId);
     this.recoverWatcherIfNoMonitorsRemain();
+    // A freed slot lets the next most-recently-focused evicted worktree
+    // reclaim a watcher.
+    this.applyWatcherBudget();
 
     clearGitDirCache(monitor.path);
     invalidateGitStatusCache(monitor.path);
@@ -1380,6 +1503,7 @@ export class WorkspaceService {
   }
 
   setActiveWorktree(requestId: string, worktreeId: string): void {
+    const previousActiveId = this.activeWorktreeId;
     this.activeWorktreeId = worktreeId;
 
     for (const [id, monitor] of this.monitors) {
@@ -1402,6 +1526,22 @@ export class WorkspaceService {
         this.emitUpdate(monitor);
       }
     }
+
+    // Watcher-budget LRU bookkeeping (#9538): the new active worktree leaves
+    // the background pool (it keeps a watcher unconditionally); the worktree
+    // that just lost focus enters as the most-recently-focused background
+    // entry, so it's the last to be evicted. applyWatcherBudget() then enforces
+    // the cap — evicting an over-budget background watcher overrides the 3s
+    // focus-downgrade hysteresis (the deliberate-eviction path bypasses it).
+    this.lruRemove(worktreeId);
+    if (
+      previousActiveId &&
+      previousActiveId !== worktreeId &&
+      this.monitors.has(previousActiveId)
+    ) {
+      this.lruTouch(previousActiveId);
+    }
+    this.applyWatcherBudget();
 
     this.sendEvent({ type: "set-active-result", requestId, success: true });
   }
@@ -2118,7 +2258,11 @@ export class WorkspaceService {
       this.resourceActionExecutor.cleanupResourceActionState(worktreeId);
       monitor.stop();
       this.monitors.delete(worktreeId);
+      this.lruRemove(worktreeId);
       this.recoverWatcherIfNoMonitorsRemain();
+      // A freed slot lets the next most-recently-focused evicted worktree
+      // reclaim a watcher.
+      this.applyWatcherBudget();
 
       // Monitor is cleaned up. Drop the pending entry now (cancelling its
       // safety valve): any still-buffered delete event for this name is
@@ -2422,6 +2566,15 @@ ${lines.map((l) => "+" + l).join("\n")}`;
       this.fetchIntervalBackgroundMs = config.fetchIntervalBackgroundMs;
     }
 
+    let watcherCapChanged = false;
+    if (config.backgroundGitWatcherCap !== undefined) {
+      const normalized = this.normalizeWatcherCap(config.backgroundGitWatcherCap);
+      if (normalized !== this.backgroundGitWatcherCap) {
+        this.backgroundGitWatcherCap = normalized;
+        watcherCapChanged = true;
+      }
+    }
+
     for (const [worktreeId, monitor] of this.monitors) {
       const isActive = worktreeId === this.activeWorktreeId;
       const baseInterval = isActive ? this.pollIntervalActive : this.pollIntervalBackground;
@@ -2430,6 +2583,12 @@ ${lines.map((l) => "+" + l).join("\n")}`;
         fetchIntervalActiveMs: this.throttledFetchActiveMs,
         fetchIntervalBackgroundMs: this.throttledFetchBackgroundMs,
       });
+    }
+
+    // A shrunk cap (e.g. profile → efficiency) must immediately evict the
+    // now-over-budget background watchers; a grown cap re-arms freed slots.
+    if (watcherCapChanged) {
+      this.applyWatcherBudget();
     }
   }
 
@@ -2729,6 +2888,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
       monitor.stop();
     }
     this.monitors.clear();
+    this.backgroundGitWatcherLru.clear();
     this.fetchCoordinator.destroy();
     this.pollQueue.clear();
     this.listService.invalidateCache();

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -172,6 +172,13 @@ export class WorktreeMonitor {
   // but written by the monitor or its callers).
   private readonly watcherController: WatcherController;
   private gitWatchEnabled: boolean;
+  // Per-view budget gate layered on top of `gitWatchEnabled`. When the
+  // WorkspaceService LRU evicts this (background) worktree past the watcher
+  // cap, it sets this false; the combined `gitWatchEnabled && gitWatchBudgetAllowed`
+  // signal the watcher controller observes then stops the watcher and the
+  // monitor falls back to adaptive polling. Always true for the focused
+  // worktree (which is never counted against the cap).
+  private gitWatchBudgetAllowed: boolean = true;
   private gitWatchDebounceMs: number;
   private lastGitStatusCompletedAt: number = 0;
   // Stamped by the watcher's onTriggerUpdate hook before a forced refresh
@@ -357,7 +364,11 @@ export class WorktreeMonitor {
         return monitor._isCurrent;
       },
       get gitWatchEnabled() {
-        return monitor.gitWatchEnabled;
+        // Combined gate: the per-view watcher budget can suppress the watcher
+        // for an evicted background worktree without touching the user/config
+        // `gitWatchEnabled` flag. The controller observes only this single
+        // signal, so budget enforcement stays transparent to it.
+        return monitor.gitWatchEnabled && monitor.gitWatchBudgetAllowed;
       },
       get gitWatchDebounceMs() {
         return monitor.gitWatchDebounceMs;
@@ -1180,6 +1191,32 @@ export class WorktreeMonitor {
 
   ensureWatcherState(): void {
     this.watcherController.ensureState();
+  }
+
+  /** True when this monitor is currently allowed a git file watcher by the
+   *  per-view watcher budget. Reflects the LRU eviction decision, not the
+   *  user/config `gitWatchEnabled` flag. */
+  get gitWatchBudgetGranted(): boolean {
+    return this.gitWatchBudgetAllowed;
+  }
+
+  /**
+   * Grant or revoke this monitor's watcher budget (WorkspaceService LRU
+   * eviction). Revoking stops the watcher via the combined host getter and
+   * reschedules polling so the evicted worktree immediately picks up the
+   * adaptive interval instead of waiting out the watcher's 300s heartbeat;
+   * granting re-arms the watcher at the desired granularity. No-op when the
+   * flag is unchanged.
+   */
+  setGitWatchBudgetAllowed(allowed: boolean): void {
+    if (this.gitWatchBudgetAllowed === allowed) return;
+    this.gitWatchBudgetAllowed = allowed;
+    // Reconcile the watcher against the new combined gate. ensureState() stops
+    // the watcher when the gate is now false, or (re)starts it when true.
+    this.watcherController.ensureState();
+    // The mode dropped to "none" on revoke (or rotated on grant); reschedule
+    // so scheduleNextPoll() re-reads the now-current poll cadence.
+    this.reschedulePolling();
   }
 
   restartWatcherIfRunning(): void {

--- a/electron/workspace-host/__tests__/WorkspaceService.gitWatcherBudget.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.gitWatcherBudget.test.ts
@@ -6,14 +6,28 @@ import type { WorkspaceService } from "../WorkspaceService.js";
 import type { WorktreeMonitor } from "../WorktreeMonitor.js";
 import type { Worktree } from "../../../shared/types/worktree.js";
 
+// Tracks live watcher instances + the peak ever held concurrently, so a test
+// can assert the budget never lets the live handle count exceed the cap even
+// mid-reconcile (evict-before-grant ordering).
+const watcherLive = { current: 0, peak: 0 };
+
 // Each git-only watcher arms successfully in these tests so `hasWatcher`
 // directly reflects the budget decision.
 vi.mock("../../utils/gitFileWatcher.js", () => ({
   GitFileWatcher: class {
+    private armed = false;
     start() {
+      this.armed = true;
+      watcherLive.current++;
+      watcherLive.peak = Math.max(watcherLive.peak, watcherLive.current);
       return true;
     }
-    dispose() {}
+    dispose() {
+      if (this.armed) {
+        this.armed = false;
+        watcherLive.current--;
+      }
+    }
   },
 }));
 
@@ -145,6 +159,8 @@ describe("WorkspaceService background git-watcher budget (#9538)", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    watcherLive.current = 0;
+    watcherLive.peak = 0;
     const WorkspaceServiceModule = await import("../WorkspaceService.js");
     service = new WorkspaceServiceModule.WorkspaceService(vi.fn() as any);
     const WorktreeMonitorModule = await import("../WorktreeMonitor.js");
@@ -322,6 +338,24 @@ describe("WorkspaceService background git-watcher budget (#9538)", () => {
 
     expect(service["backgroundGitWatcherLru"].has(b.id)).toBe(false);
     expect(a.hasWatcher).toBe(true);
+  });
+
+  it("cold-start via addNewWorktreeMonitor never arms beyond the cap", async () => {
+    service["backgroundGitWatcherCap"] = 3;
+    service["activeWorktreeId"] = null;
+
+    // Add 12 background worktrees through the real path. The pre-gate keeps a
+    // new background monitor from arming a watcher before applyWatcherBudget
+    // evicts the oldest, so the live count never spikes above the cap — the
+    // O(N) cold-start handle peak the issue is about.
+    for (let i = 0; i < 12; i++) {
+      await service["addNewWorktreeMonitor"](createTestWorktree(`bg-${i}`), false, true);
+    }
+
+    expect(watcherLive.peak).toBeLessThanOrEqual(3);
+    expect(watcherLive.current).toBe(3);
+    const armed = [...service["monitors"].values()].filter((m) => m.hasWatcher).length;
+    expect(armed).toBe(3);
   });
 
   it("normalizes junk cap values without throwing", () => {

--- a/electron/workspace-host/__tests__/WorkspaceService.gitWatcherBudget.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.gitWatcherBudget.test.ts
@@ -1,0 +1,334 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+import { resolve as pathResolve } from "path";
+import type { SimpleGit } from "simple-git";
+import type { WorkspaceService } from "../WorkspaceService.js";
+import type { WorktreeMonitor } from "../WorktreeMonitor.js";
+import type { Worktree } from "../../../shared/types/worktree.js";
+
+// Each git-only watcher arms successfully in these tests so `hasWatcher`
+// directly reflects the budget decision.
+vi.mock("../../utils/gitFileWatcher.js", () => ({
+  GitFileWatcher: class {
+    start() {
+      return true;
+    }
+    dispose() {}
+  },
+}));
+
+const mockSimpleGit = {
+  raw: vi.fn().mockResolvedValue(undefined),
+  branch: vi.fn().mockResolvedValue({ current: "main" }),
+};
+
+vi.mock("simple-git", () => ({
+  simpleGit: vi.fn(() => mockSimpleGit),
+}));
+
+vi.mock("../../utils/hardenedGit.js", () => ({
+  createHardenedGit: vi.fn(() => mockSimpleGit),
+  createWslHardenedGit: vi.fn(() => mockSimpleGit),
+  validateCwd: vi.fn(),
+  validateBranchName: vi.fn(),
+}));
+
+vi.mock("../../utils/git.js", () => ({
+  invalidateGitStatusCache: vi.fn(),
+  getWorktreeChangesWithStats: vi.fn().mockResolvedValue({
+    head: "abc123",
+    isDirty: false,
+    changedFileCount: 0,
+    changes: [],
+  }),
+}));
+
+vi.mock("../../utils/gitUtils.js", () => ({
+  getGitDir: vi.fn().mockReturnValue(null),
+  getGitCommonDir: vi.fn().mockReturnValue(null),
+  clearGitDirCache: vi.fn(),
+}));
+
+vi.mock("../../services/worktree/mood.js", () => ({
+  categorizeWorktree: vi.fn().mockReturnValue("stable"),
+}));
+
+vi.mock("../../services/issueExtractor.js", () => ({
+  extractIssueNumberSync: vi.fn().mockReturnValue(null),
+  extractIssueNumber: vi.fn().mockResolvedValue(null),
+  deriveIssueTitleFromBranch: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock("../../services/worktree/index.js", () => ({
+  AdaptivePollingStrategy: vi.fn(function () {
+    return {
+      getCurrentInterval: vi.fn().mockReturnValue(2000),
+      updateInterval: vi.fn(),
+      reportActivity: vi.fn(),
+      updateConfig: vi.fn(),
+      isCircuitBreakerTripped: vi.fn().mockReturnValue(false),
+      reset: vi.fn(),
+      setBaseInterval: vi.fn(),
+      calculateNextInterval: vi.fn().mockReturnValue(2000),
+      recordSuccess: vi.fn(),
+      recordFailure: vi.fn(),
+      recordNoChange: vi.fn(),
+      recordStateChange: vi.fn(),
+    };
+  }),
+  NoteFileReader: vi.fn(function () {
+    return { read: vi.fn().mockResolvedValue({}) };
+  }),
+}));
+
+vi.mock("../../services/github/GitHubAuth.js", () => ({
+  GitHubAuth: vi.fn().mockImplementation(() => ({
+    getToken: vi.fn().mockResolvedValue(null),
+  })),
+}));
+
+vi.mock("../../services/PullRequestService.js", () => ({
+  pullRequestService: {
+    initialize: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+    reset: vi.fn(),
+    refresh: vi.fn(),
+    getStatus: vi.fn().mockReturnValue({
+      state: "idle",
+      isPolling: false,
+      candidateCount: 0,
+      resolvedCount: 0,
+      isEnabled: true,
+    }),
+  },
+}));
+
+const mockEvents = new EventEmitter();
+vi.mock("../../services/events.js", () => ({
+  events: mockEvents,
+}));
+
+vi.mock("fs/promises", () => ({
+  stat: vi.fn().mockResolvedValue({ birthtimeMs: 1000, ctimeMs: 1000 }),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  access: vi.fn().mockResolvedValue(undefined),
+  readFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  cp: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+function wtPath(name: string): string {
+  return pathResolve(`/test/${name}`);
+}
+
+function createTestWorktree(name: string, overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: wtPath(name),
+    path: wtPath(name),
+    name,
+    branch: name,
+    isCurrent: false,
+    isMainWorktree: false,
+    gitDir: `${wtPath(name)}/.git`,
+    ...overrides,
+  };
+}
+
+describe("WorkspaceService background git-watcher budget (#9538)", () => {
+  let service: WorkspaceService;
+  let WorktreeMonitorClass: typeof WorktreeMonitor;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const WorkspaceServiceModule = await import("../WorkspaceService.js");
+    service = new WorkspaceServiceModule.WorkspaceService(vi.fn() as any);
+    const WorktreeMonitorModule = await import("../WorktreeMonitor.js");
+    WorktreeMonitorClass = WorktreeMonitorModule.WorktreeMonitor;
+
+    service["projectRootPath"] = "/test/root";
+    service["git"] = mockSimpleGit as any;
+    service["gitWatchEnabled"] = true;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Build a real, running monitor (git watch enabled) and register it directly
+   * in the service. Background monitors arm a git-only watcher; the active one
+   * arms recursive. Direct registration keeps the test off the async
+   * addNewWorktreeMonitor path while still exercising real eviction.
+   */
+  function registerMonitor(name: string, isCurrent = false): WorktreeMonitor {
+    const wt = createTestWorktree(name, { isCurrent });
+    const monitor = new WorktreeMonitorClass(
+      wt,
+      {
+        basePollingInterval: 10000,
+        adaptiveBackoff: false,
+        pollIntervalMax: 30000,
+        circuitBreakerThreshold: 3,
+        gitWatchEnabled: true,
+      },
+      { onUpdate: vi.fn() },
+      "main"
+    );
+    service["monitors"].set(wt.id, monitor);
+    monitor.startWithoutGitStatus();
+    return monitor;
+  }
+
+  function setActive(name: string): void {
+    service["activeWorktreeId"] = wtPath(name);
+  }
+
+  it("evicts background watchers beyond the cap, keeping the MRU set + active", () => {
+    service["backgroundGitWatcherCap"] = 2;
+    const active = registerMonitor("active", true);
+    const a = registerMonitor("a");
+    const b = registerMonitor("b");
+    const c = registerMonitor("c");
+    setActive("active");
+
+    // Recency: a (LRU) → b → c (MRU).
+    service["lruTouch"](a.id);
+    service["lruTouch"](b.id);
+    service["lruTouch"](c.id);
+
+    service["applyWatcherBudget"]();
+
+    expect(active.hasWatcher).toBe(true); // active always keeps its watcher
+    expect(a.hasWatcher).toBe(false); // oldest evicted
+    expect(b.hasWatcher).toBe(true);
+    expect(c.hasWatcher).toBe(true);
+  });
+
+  it("never counts the active worktree against the cap", () => {
+    service["backgroundGitWatcherCap"] = 1;
+    const active = registerMonitor("active", true);
+    const a = registerMonitor("a");
+    setActive("active");
+    service["lruTouch"](a.id);
+
+    service["applyWatcherBudget"]();
+
+    expect(active.hasWatcher).toBe(true);
+    expect(a.hasWatcher).toBe(true); // the single background slot
+  });
+
+  it("cap of 0 evicts every background watcher but keeps the active one", () => {
+    service["backgroundGitWatcherCap"] = 0;
+    const active = registerMonitor("active", true);
+    const a = registerMonitor("a");
+    const b = registerMonitor("b");
+    setActive("active");
+    service["lruTouch"](a.id);
+    service["lruTouch"](b.id);
+
+    service["applyWatcherBudget"]();
+
+    expect(active.hasWatcher).toBe(true);
+    expect(a.hasWatcher).toBe(false);
+    expect(b.hasWatcher).toBe(false);
+  });
+
+  it("updateMonitorConfig with a smaller cap evicts immediately", () => {
+    service["backgroundGitWatcherCap"] = 3;
+    const active = registerMonitor("active", true);
+    const a = registerMonitor("a");
+    const b = registerMonitor("b");
+    const c = registerMonitor("c");
+    setActive("active");
+    service["lruTouch"](a.id);
+    service["lruTouch"](b.id);
+    service["lruTouch"](c.id);
+    service["applyWatcherBudget"]();
+    expect([a, b, c].every((m) => m.hasWatcher)).toBe(true);
+
+    service.updateMonitorConfig({ backgroundGitWatcherCap: 1 });
+
+    expect(active.hasWatcher).toBe(true);
+    expect(a.hasWatcher).toBe(false);
+    expect(b.hasWatcher).toBe(false);
+    expect(c.hasWatcher).toBe(true); // MRU survives
+  });
+
+  it("a grown cap re-arms freed slots for evicted monitors", () => {
+    service["backgroundGitWatcherCap"] = 1;
+    registerMonitor("active", true);
+    const a = registerMonitor("a");
+    const b = registerMonitor("b");
+    setActive("active");
+    service["lruTouch"](a.id);
+    service["lruTouch"](b.id);
+    service["applyWatcherBudget"]();
+    expect(a.hasWatcher).toBe(false);
+    expect(b.hasWatcher).toBe(true);
+
+    service.updateMonitorConfig({ backgroundGitWatcherCap: 5 });
+
+    expect(a.hasWatcher).toBe(true);
+    expect(b.hasWatcher).toBe(true);
+  });
+
+  it("setActiveWorktree gives the newly focused worktree a watcher and demotes the old active to MRU background", () => {
+    service["backgroundGitWatcherCap"] = 1;
+    const active = registerMonitor("active", true);
+    const a = registerMonitor("a");
+    const b = registerMonitor("b");
+    setActive("active");
+    // a is MRU background, b is LRU and will be evicted under cap 1.
+    service["lruTouch"](b.id);
+    service["lruTouch"](a.id);
+    service["applyWatcherBudget"]();
+    expect(a.hasWatcher).toBe(true);
+    expect(b.hasWatcher).toBe(false);
+
+    // Focus b. It must gain a watcher; the previously-active worktree becomes
+    // the most-recently-focused background entry and keeps its watcher within
+    // the cap, while a (older) is evicted.
+    service.setActiveWorktree("req-1", b.id);
+
+    expect(b.hasWatcher).toBe(true);
+    expect(active.hasWatcher).toBe(true); // demoted active is MRU background
+    expect(a.hasWatcher).toBe(false);
+    expect(service["activeWorktreeId"]).toBe(b.id);
+  });
+
+  it("removing a monitor frees its LRU slot for the next evicted worktree", () => {
+    service["backgroundGitWatcherCap"] = 1;
+    registerMonitor("active", true);
+    const a = registerMonitor("a");
+    const b = registerMonitor("b");
+    setActive("active");
+    service["lruTouch"](a.id);
+    service["lruTouch"](b.id);
+    service["applyWatcherBudget"]();
+    expect(a.hasWatcher).toBe(false);
+    expect(b.hasWatcher).toBe(true);
+
+    // Drop b; a should reclaim the freed slot.
+    const bMonitor = service["monitors"].get(b.id)!;
+    bMonitor.stop();
+    service["monitors"].delete(b.id);
+    service["lruRemove"](b.id);
+    service["applyWatcherBudget"]();
+
+    expect(service["backgroundGitWatcherLru"].has(b.id)).toBe(false);
+    expect(a.hasWatcher).toBe(true);
+  });
+
+  it("normalizes junk cap values without throwing", () => {
+    service.updateMonitorConfig({ backgroundGitWatcherCap: -5 });
+    expect(service["backgroundGitWatcherCap"]).toBe(0);
+
+    service.updateMonitorConfig({ backgroundGitWatcherCap: 4.9 });
+    expect(service["backgroundGitWatcherCap"]).toBe(4);
+  });
+});

--- a/electron/workspace-host/__tests__/WorkspaceService.gitWatcherBudget.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.gitWatcherBudget.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { EventEmitter } from "events";
 import { resolve as pathResolve } from "path";
-import type { SimpleGit } from "simple-git";
 import type { WorkspaceService } from "../WorkspaceService.js";
 import type { WorktreeMonitor } from "../WorktreeMonitor.js";
 import type { Worktree } from "../../../shared/types/worktree.js";

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -1375,6 +1375,67 @@ describe("WorktreeMonitor", () => {
     });
   });
 
+  describe("git-watch budget gate (#9538)", () => {
+    const WATCH_CONFIG: WorktreeMonitorConfig = {
+      ...TEST_CONFIG,
+      gitWatchEnabled: true,
+    };
+
+    beforeEach(() => {
+      mockWatcherStartResult = true;
+      mockGetWorktreeChangesWithStats.mockResolvedValue({
+        worktreeId: "/test/worktree",
+        rootPath: "/test",
+        changes: [],
+        changedFileCount: 0,
+        lastUpdated: Date.now(),
+      });
+    });
+
+    it("revoking the budget stops the watcher; granting re-arms it", async () => {
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, WATCH_CONFIG, makeCallbacks(), "main");
+      await monitor.start();
+      expect(monitor.hasWatcher).toBe(true);
+      expect(monitor.gitWatchBudgetGranted).toBe(true);
+
+      monitor.setGitWatchBudgetAllowed(false);
+      expect(monitor.hasWatcher).toBe(false);
+      expect(monitor.gitWatchBudgetGranted).toBe(false);
+
+      monitor.setGitWatchBudgetAllowed(true);
+      expect(monitor.hasWatcher).toBe(true);
+      expect(monitor.gitWatchBudgetGranted).toBe(true);
+
+      monitor.stop();
+    });
+
+    it("is idempotent — re-applying the same value does not churn the watcher", async () => {
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, WATCH_CONFIG, makeCallbacks(), "main");
+      await monitor.start();
+      const startsAfterArm = watcherStartCallCount;
+
+      // Same value: no ensureState/start work.
+      monitor.setGitWatchBudgetAllowed(true);
+      expect(watcherStartCallCount).toBe(startsAfterArm);
+      expect(monitor.hasWatcher).toBe(true);
+
+      monitor.stop();
+    });
+
+    it("ensureWatcherState does not re-arm an evicted watcher", async () => {
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, WATCH_CONFIG, makeCallbacks(), "main");
+      await monitor.start();
+      monitor.setGitWatchBudgetAllowed(false);
+      expect(monitor.hasWatcher).toBe(false);
+
+      // Mirrors the syncMonitors reconcile that would otherwise re-arm.
+      monitor.ensureWatcherState();
+      expect(monitor.hasWatcher).toBe(false);
+
+      monitor.stop();
+    });
+  });
+
   describe("poll queue concurrency", () => {
     let PQueue: typeof import("p-queue").default;
 

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -1422,6 +1422,26 @@ describe("WorktreeMonitor", () => {
       monitor.stop();
     });
 
+    it("granting budget never arms a watcher when git watching is disabled", async () => {
+      const monitor = new WorktreeMonitor(
+        TEST_WORKTREE,
+        { ...TEST_CONFIG, gitWatchEnabled: false },
+        makeCallbacks(),
+        "main"
+      );
+      await monitor.start();
+      expect(monitor.hasWatcher).toBe(false);
+
+      // The combined gate is AND, not OR: budget alone must not arm a watcher
+      // the user disabled.
+      monitor.setGitWatchBudgetAllowed(false);
+      monitor.setGitWatchBudgetAllowed(true);
+      expect(watcherStartCallCount).toBe(0);
+      expect(monitor.hasWatcher).toBe(false);
+
+      monitor.stop();
+    });
+
     it("ensureWatcherState does not re-arm an evicted watcher", async () => {
       const monitor = new WorktreeMonitor(TEST_WORKTREE, WATCH_CONFIG, makeCallbacks(), "main");
       await monitor.start();

--- a/shared/types/resourceProfile.ts
+++ b/shared/types/resourceProfile.ts
@@ -5,6 +5,16 @@ export interface ResourceProfileConfig {
   pollIntervalActive: number;
   /** Workspace-host background worktree polling interval (ms) */
   pollIntervalBackground: number;
+  /**
+   * Maximum number of background worktrees allowed to hold a `git-only`
+   * file watcher concurrently, per workspace-host (per project view). The
+   * focused worktree always gets its (recursive) watcher and is excluded
+   * from this budget. Background worktrees beyond the cap fall back to the
+   * adaptive poll path. Bounds the O(N) inotify/FSEvents/fd growth that long
+   * sessions with many worktrees would otherwise produce. Smaller under
+   * efficiency to maximize headroom on constrained hardware.
+   */
+  backgroundGitWatcherCap: number;
   /** ProcessTreeCache polling interval (ms) */
   processTreePollInterval: number;
   /** ProjectStatsService polling interval (ms) */
@@ -78,6 +88,7 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, ResourceProfileCo
   performance: {
     pollIntervalActive: 1500,
     pollIntervalBackground: 5000,
+    backgroundGitWatcherCap: 20,
     processTreePollInterval: 2000,
     projectStatsPollInterval: 5000,
     // Performance pushes closer to Chromium's 16-context cap. Higher upper +
@@ -95,6 +106,7 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, ResourceProfileCo
   balanced: {
     pollIntervalActive: 2000,
     pollIntervalBackground: 10000,
+    backgroundGitWatcherCap: 12,
     processTreePollInterval: 2500,
     projectStatsPollInterval: 5000,
     webglUpperThreshold: 12,
@@ -113,6 +125,7 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, ResourceProfileCo
   efficiency: {
     pollIntervalActive: 4000,
     pollIntervalBackground: 20000,
+    backgroundGitWatcherCap: 6,
     processTreePollInterval: 5000,
     projectStatsPollInterval: 25000,
     // Efficiency kicks to DOM-mode sooner on constrained hardware where each

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -259,6 +259,13 @@ export interface MonitorConfig {
   circuitBreakerThreshold?: number;
   gitWatchEnabled?: boolean;
   gitWatchDebounceMs?: number;
+  /**
+   * Profile-aware cap on the number of background worktrees allowed to hold a
+   * `git-only` file watcher concurrently (per workspace-host). The focused
+   * worktree is excluded from this budget. Background worktrees beyond the cap
+   * fall back to the adaptive poll path. See `ResourceProfileConfig`.
+   */
+  backgroundGitWatcherCap?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds a per-project-view LRU cap on background `GitFileWatcher` instances to bound the O(N) inotify/FSEvents/fd growth that long sessions with many worktrees produce.
- The focused worktree always keeps its recursive watcher and is excluded from the cap; background worktrees beyond the profile-aware limit fall back to the existing adaptive poll path (`WatcherController` mode `"none"`), which continues running `git status` checks every 10–20s.
- Cap values: performance=20, balanced=12, efficiency=6. Eviction is driven by a most-recently-focused LRU in `WorkspaceService`; the budget gate is a flag on `WorktreeMonitor` combined with `gitWatchEnabled` so `WatcherController` is unchanged.

Resolves #9538

## Changes

- `WorkspaceService` — LRU budget tracking, `enforceBudget()` called after `syncMonitors`, on focus changes, on monitor add/removal, and on profile/cap changes.
- `WorktreeMonitor` — `withinWatcherBudget` flag; `ensureWatcherState()` gates on it alongside `gitWatchEnabled`.
- `ResourceProfileService` / `resourceProfile.ts` — exposes `gitWatcherBudget` per profile.
- `workspace-host.ts` — `gitWatcherBudget` added to `WorktreeInfo`.
- New test: `WorkspaceService.gitWatcherBudget.test.ts` (368 lines). Extensions to `WorktreeMonitor.test.ts` and `ResourceProfileService.test.ts`.

## Testing

New unit tests cover: budget enforcement at each profile tier, LRU eviction order, focus-change re-enforcement, monitor add/remove triggers, and profile-switch re-cap. All pass. `npm run check` clean.