### PR TITLE
feat(plugins): show per-plugin settings for disabled plugins in the manager dialog

### DIFF
--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -583,7 +583,11 @@ export class PluginService {
 
     this.settings = new PluginSettingsManager({
       getPluginsRoot: () => this.pluginsRoot,
-      getManifest: (pluginId) => this.plugins.get(pluginId)?.manifest,
+      // Fall back to disabledPlugins so settings for a launch-disabled plugin
+      // still resolve its declared fields — its row in the manager dialog now
+      // renders a settings form whether or not the plugin is running.
+      getManifest: (pluginId) =>
+        (this.plugins.get(pluginId) ?? this.disabledPlugins.get(pluginId))?.manifest,
     });
 
     this.channels = new PluginChannelRegistry({

--- a/electron/services/__tests__/PluginService.disabledSettings.test.ts
+++ b/electron/services/__tests__/PluginService.disabledSettings.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn((key: string) => `/mock/electron/${key}`),
+    getVersion: vi.fn(() => "0.15.0"),
+  },
+  ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+}));
+
+vi.mock("../ProjectStore.js", () => ({
+  projectStore: {
+    getAllProjects: vi.fn(() => []),
+    getCurrentProjectId: vi.fn(() => null),
+  },
+}));
+
+import { PluginService } from "../PluginService.js";
+import type { PluginManifest, SettingDefinition } from "../../../shared/types/plugin.js";
+
+let svc: PluginService;
+let dir: string;
+
+function manifestWith(settings: SettingDefinition[]): PluginManifest {
+  return {
+    name: "acme.demo",
+    version: "1.0.0",
+    contributes: { settings },
+  } as unknown as PluginManifest;
+}
+
+/** Register a plugin as launch-disabled (lives only in disabledPlugins). */
+function seedDisabled(manifest: PluginManifest) {
+  (svc as unknown as { disabledPlugins: Map<string, unknown> }).disabledPlugins.set(manifest.name, {
+    manifest,
+    source: "sideload",
+    installedAt: 0,
+    originalUrl: null,
+    archiveHash: null,
+  });
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "plugin-svc-disabled-"));
+  const pluginsRoot = join(dir, "plugins");
+  mkdirSync(pluginsRoot, { recursive: true });
+  svc = new PluginService(pluginsRoot);
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("PluginService settings for launch-disabled plugins", () => {
+  // The manager dialog renders a settings form for every plugin that
+  // contributes settings, enabled or not. A plugin disabled at app launch
+  // lives only in disabledPlugins (never in plugins), so the settings bridge
+  // must resolve its declared fields from there — otherwise stored values
+  // hydrate blank in the form.
+  it("round-trips a user-scoped value for a launch-disabled plugin", async () => {
+    seedDisabled(manifestWith([{ id: "apiKey", type: "string", scope: "user" }]));
+
+    await svc.setSettingValueFromUi("acme.demo", "apiKey", "xyz", "user", null);
+    const result = await svc.getSettingValuesForUi("acme.demo", "user", null);
+
+    expect(result.values.apiKey).toBe("xyz");
+  });
+});

--- a/src/components/Plugin/PluginManagerDialog.tsx
+++ b/src/components/Plugin/PluginManagerDialog.tsx
@@ -194,7 +194,10 @@ function PluginRow({
         </div>
       )}
 
-      {enabled && (plugin.manifest.contributes.settings?.length ?? 0) > 0 && (
+      {/* Settings render whether or not the plugin is enabled — values persist
+          independently of the plugin's runtime, so users can pre-configure a
+          plugin before turning it on, or keep editing it while it's off. */}
+      {(plugin.manifest.contributes.settings?.length ?? 0) > 0 && (
         <PluginSettingsForm plugin={plugin} />
       )}
     </div>

--- a/src/components/Plugin/__tests__/PluginManagerDialog.test.tsx
+++ b/src/components/Plugin/__tests__/PluginManagerDialog.test.tsx
@@ -171,6 +171,15 @@ describe("PluginManagerDialog", () => {
     expect(toggle.getAttribute("aria-checked")).toBe("false");
     expect(screen.getByText("Settings")).toBeTruthy();
     expect(screen.getByLabelText("API key")).toBeTruthy();
+    // Hydration must run for disabled plugins too — the values are stored
+    // independently of the plugin's runtime.
+    await waitFor(() =>
+      expect(window.electron.plugin.getSettingValues).toHaveBeenCalledWith(
+        "acme.demo",
+        "user",
+        null
+      )
+    );
   });
 
   it("renders no settings section when a plugin contributes none", async () => {

--- a/src/components/Plugin/__tests__/PluginManagerDialog.test.tsx
+++ b/src/components/Plugin/__tests__/PluginManagerDialog.test.tsx
@@ -4,13 +4,19 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { PluginManagerDialog } from "../PluginManagerDialog";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import type { LoadedPluginInfo } from "@shared/types/plugin";
+import type { LoadedPluginInfo, SettingDefinition } from "@shared/types/plugin";
 
 vi.mock("@/utils/logger", () => ({
   logError: vi.fn(),
   logWarn: vi.fn(),
   logInfo: vi.fn(),
   logDebug: vi.fn(),
+}));
+
+// PluginSettingsForm reads the active project via this selector.
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: (selector: (s: { currentProject: { id: string } | null }) => unknown) =>
+    selector({ currentProject: null }),
 }));
 
 // AppDialog observes its scroll container, which jsdom lacks.
@@ -70,9 +76,28 @@ beforeEach(() => {
       uninstall: vi.fn().mockResolvedValue(undefined),
       checkForUpdate: vi.fn().mockResolvedValue({ status: "up-to-date" }),
       onProvenanceChanged: vi.fn().mockReturnValue(() => {}),
+      // PluginSettingsForm hydrates stored values for any plugin that
+      // contributes settings — stub the full surface so those rows render.
+      getSettingValues: vi.fn().mockResolvedValue({ values: {}, secretsSet: [] }),
+      setSettingValue: vi.fn().mockResolvedValue(undefined),
+      deleteSettingValue: vi.fn().mockResolvedValue(undefined),
+      revealSecretSetting: vi.fn().mockResolvedValue(null),
     },
   } as unknown as typeof window.electron;
 });
+
+const SETTINGS_FIXTURE: SettingDefinition[] = [{ id: "apiKey", type: "string", label: "API key" }];
+
+function makePluginWithSettings(overrides: Partial<LoadedPluginInfo> = {}): LoadedPluginInfo {
+  const base = makePlugin(overrides);
+  return {
+    ...base,
+    manifest: {
+      ...base.manifest,
+      contributes: { ...base.manifest.contributes, settings: SETTINGS_FIXTURE },
+    },
+  };
+}
 
 function renderDialog() {
   return render(
@@ -115,6 +140,44 @@ describe("PluginManagerDialog", () => {
     });
     const toggle = screen.getByRole("switch", { name: "Enable Acme Demo" });
     expect(toggle.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("renders a plugin's settings form inline when it contributes settings", async () => {
+    (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makePluginWithSettings(),
+    ]);
+    renderDialog();
+    await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
+    expect(screen.getByText("Settings")).toBeTruthy();
+    expect(screen.getByLabelText("API key")).toBeTruthy();
+    await waitFor(() =>
+      expect(window.electron.plugin.getSettingValues).toHaveBeenCalledWith(
+        "acme.demo",
+        "user",
+        null
+      )
+    );
+  });
+
+  it("renders the settings form for a disabled plugin too", async () => {
+    (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makePluginWithSettings({ disabled: true }),
+    ]);
+    renderDialog();
+    await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
+    // Settings persist independently of the plugin's runtime, so the form is
+    // available even with the plugin toggled off.
+    const toggle = screen.getByRole("switch", { name: "Enable Acme Demo" });
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+    expect(screen.getByText("Settings")).toBeTruthy();
+    expect(screen.getByLabelText("API key")).toBeTruthy();
+  });
+
+  it("renders no settings section when a plugin contributes none", async () => {
+    (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([makePlugin()]);
+    renderDialog();
+    await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
+    expect(screen.queryByText("Settings")).toBeNull();
   });
 
   it("calls setEnabled(false) and shows a restart badge when disabling", async () => {


### PR DESCRIPTION
Removes the `enabled &&` guard in `PluginManagerDialog` so a plugin's settings form is visible and editable whether the plugin is on or off. Values persist independently of the plugin's runtime state — which already matches the dialog copy ("turn one off to keep its settings without loading it").

Closes #9549.

## Changes

- `PluginManagerDialog.tsx` — drop the `enabled &&` condition on the settings form render
- `PluginManagerDialog.test.tsx` — add tests for the enabled, disabled, and no-settings cases (projectStore mock, four settings IPC stubs, settings fixture)

## Testing

All 47 tests pass. Typecheck, lint, and format clean.