### PR TITLE
feat(plugins): group plugin manager list by source and state

### DIFF
--- a/src/components/Plugin/PluginManagerDialog.tsx
+++ b/src/components/Plugin/PluginManagerDialog.tsx
@@ -14,6 +14,36 @@ import type { LoadedPluginInfo, PluginDeepLinkIntent } from "@shared/types/plugi
 const ROW_BADGE_CLASS =
   "inline-flex items-center px-1.5 py-0.5 rounded-sm text-[10px] font-medium bg-overlay-subtle border border-daintree-border/50 text-daintree-text/60 uppercase tracking-wide";
 
+/**
+ * Section grouping for the installed list (#9554). A disabled plugin always
+ * lands in "Disabled" regardless of its source, so the section reads as a clean
+ * list of everything that isn't currently running. Built-in and Installed only
+ * hold enabled plugins. Order is the render order below; sections with no
+ * matches are omitted. Within a section, rows inherit the alphabetical order of
+ * `pm.plugins` (already sorted enabled-then-name by the hook).
+ */
+const PLUGIN_GROUPS: ReadonlyArray<{
+  id: string;
+  label: string;
+  match: (plugin: LoadedPluginInfo) => boolean;
+}> = [
+  {
+    id: "plugin-group-builtin",
+    label: "Built-in",
+    match: (plugin) => !plugin.disabled && plugin.isBuiltin,
+  },
+  {
+    id: "plugin-group-installed",
+    label: "Installed",
+    match: (plugin) => !plugin.disabled && !plugin.isBuiltin,
+  },
+  {
+    id: "plugin-group-disabled",
+    label: "Disabled",
+    match: (plugin) => plugin.disabled === true,
+  },
+];
+
 interface PluginRowProps {
   plugin: LoadedPluginInfo;
   selected: boolean;
@@ -293,7 +323,6 @@ export function PluginManagerDialog({
               </div>
             ) : null
           ) : !hasPlugins && !pm.error ? (
-            // Suppress the empty state when a load error is showing — the error
             // banner above owns that case so we don't invite a redundant install.
             <EmptyState
               variant="zero-data"
@@ -305,25 +334,39 @@ export function PluginManagerDialog({
           ) : !hasPlugins ? null : (
             <ScrollShadow
               className="flex-1 min-h-0"
-              scrollClassName="p-2 space-y-1"
+              scrollClassName="p-2 space-y-4"
               role="listbox"
               aria-label="Installed plugins"
             >
-              {pm.plugins.map((plugin) => (
-                <PluginRow
-                  key={plugin.manifest.name}
-                  plugin={plugin}
-                  selected={plugin.manifest.name === selectedPluginId}
-                  toggling={pm.pending.has(plugin.manifest.name)}
-                  onSelect={() => setSelectedPluginId(plugin.manifest.name)}
-                  onToggle={() => void pm.handleToggle(plugin)}
-                  highlighted={highlightedPluginId === plugin.manifest.name}
-                  innerRef={(el) => {
-                    if (el) rowRefs.current.set(plugin.manifest.name, el);
-                    else rowRefs.current.delete(plugin.manifest.name);
-                  }}
-                />
-              ))}
+              {PLUGIN_GROUPS.map(({ id, label, match }) => {
+                const groupPlugins = pm.plugins.filter(match);
+                if (groupPlugins.length === 0) return null;
+                return (
+                  <div key={id} role="group" aria-labelledby={id} className="space-y-1">
+                    <p
+                      id={id}
+                      className="px-3 text-[10px] font-medium uppercase tracking-wider text-daintree-text/40 select-none"
+                    >
+                      {label}
+                    </p>
+                    {groupPlugins.map((plugin) => (
+                      <PluginRow
+                        key={plugin.manifest.name}
+                        plugin={plugin}
+                        selected={plugin.manifest.name === selectedPluginId}
+                        toggling={pm.pending.has(plugin.manifest.name)}
+                        onSelect={() => setSelectedPluginId(plugin.manifest.name)}
+                        onToggle={() => void pm.handleToggle(plugin)}
+                        highlighted={highlightedPluginId === plugin.manifest.name}
+                        innerRef={(el) => {
+                          if (el) rowRefs.current.set(plugin.manifest.name, el);
+                          else rowRefs.current.delete(plugin.manifest.name);
+                        }}
+                      />
+                    ))}
+                  </div>
+                );
+              })}
             </ScrollShadow>
           )}
         </div>

--- a/src/components/Plugin/__tests__/PluginManagerDialog.test.tsx
+++ b/src/components/Plugin/__tests__/PluginManagerDialog.test.tsx
@@ -932,7 +932,11 @@ describe("PluginManagerDialog", () => {
     // Distinct manifest names + display names so each plugin is uniquely
     // addressable across sections. "Built-in" also appears as a per-row source
     // badge, so section assertions scope queries with role="group".
-    const named = (overrides: Partial<LoadedPluginInfo> = {}): LoadedPluginInfo => {
+    const named = (
+      overrides: Partial<Omit<LoadedPluginInfo, "manifest">> & {
+        manifest?: Partial<LoadedPluginInfo["manifest"]>;
+      } = {}
+    ): LoadedPluginInfo => {
       const { manifest: manifestOverride, ...rest } = overrides;
       const base = makePlugin(rest);
       return {
@@ -1009,6 +1013,19 @@ describe("PluginManagerDialog", () => {
       expect(within(builtinGroup()).getByText("Core Tools")).toBeTruthy();
       expect(within(installedGroup()).getByText("Acme Demo")).toBeTruthy();
       expect(within(disabledGroup()).getByText("Old Thing")).toBeTruthy();
+      // Each plugin lands in exactly one section.
+      expect(screen.getAllByText("Core Tools").length).toBe(1);
+      expect(screen.getAllByText("Acme Demo").length).toBe(1);
+      expect(screen.getAllByText("Old Thing").length).toBe(1);
+      // Sections render in the order Built-in → Installed → Disabled.
+      const ids = Array.from(document.querySelectorAll("[role='group']")).map((el) =>
+        el.getAttribute("aria-labelledby")
+      );
+      expect(ids).toEqual([
+        "plugin-group-builtin",
+        "plugin-group-installed",
+        "plugin-group-disabled",
+      ]);
     });
 
     it("omits the Disabled section when every plugin is enabled", async () => {

--- a/src/components/Plugin/__tests__/PluginManagerDialog.test.tsx
+++ b/src/components/Plugin/__tests__/PluginManagerDialog.test.tsx
@@ -453,7 +453,15 @@ describe("PluginManagerDialog", () => {
     ]);
     renderDialog();
     await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
-    expect(screen.getByText("Built-in")).toBeTruthy();
+    // "Built-in" now renders twice: the section heading (id=plugin-group-builtin)
+    // and the row's source badge alongside the display name. Assert the row badge
+    // by excluding the heading.
+    const builtinBadge = within(
+      screen.getByText("Acme Demo").closest("[role='group']") as HTMLElement
+    )
+      .getAllByText("Built-in")
+      .filter((el) => el.id !== "plugin-group-builtin");
+    expect(builtinBadge.length).toBe(1);
     // Uninstall lives in the detail pane now — select and confirm it's absent
     // for a built-in.
     await selectPlugin();
@@ -917,6 +925,123 @@ describe("PluginManagerDialog", () => {
       await waitFor(() =>
         expect(screen.getByText(/Plugin "missing\.plugin" isn't installed/)).toBeTruthy()
       );
+    });
+  });
+
+  describe("grouping", () => {
+    // Distinct manifest names + display names so each plugin is uniquely
+    // addressable across sections. "Built-in" also appears as a per-row source
+    // badge, so section assertions scope queries with role="group".
+    const named = (overrides: Partial<LoadedPluginInfo> = {}): LoadedPluginInfo => {
+      const { manifest: manifestOverride, ...rest } = overrides;
+      const base = makePlugin(rest);
+      return {
+        ...base,
+        manifest: { ...base.manifest, ...manifestOverride },
+      };
+    };
+
+    const builtinGroup = () => screen.getByRole("group", { name: "Built-in" });
+    const installedGroup = () => screen.getByRole("group", { name: "Installed" });
+    const disabledGroup = () => screen.getByRole("group", { name: "Disabled" });
+
+    it("places an enabled built-in plugin in the Built-in section", async () => {
+      (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+        named({
+          manifest: { name: "core.tools", displayName: "Core Tools" },
+          isBuiltin: true,
+          source: "builtin",
+        }),
+      ]);
+      renderDialog();
+      await waitFor(() => expect(screen.getByText("Core Tools")).toBeTruthy());
+      expect(within(builtinGroup()).getByText("Core Tools")).toBeTruthy();
+      expect(screen.queryByRole("group", { name: "Disabled" })).toBeNull();
+      expect(screen.queryByRole("group", { name: "Installed" })).toBeNull();
+    });
+
+    it("places an enabled user plugin in the Installed section", async () => {
+      (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+        named({ manifest: { name: "acme.demo", displayName: "Acme Demo" }, source: "sideload" }),
+      ]);
+      renderDialog();
+      await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
+      expect(within(installedGroup()).getByText("Acme Demo")).toBeTruthy();
+      expect(screen.queryByRole("group", { name: "Built-in" })).toBeNull();
+    });
+
+    it("places a disabled built-in in the Disabled section, not Built-in", async () => {
+      (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+        named({
+          manifest: { name: "core.tools", displayName: "Core Tools" },
+          isBuiltin: true,
+          source: "builtin",
+          disabled: true,
+        }),
+      ]);
+      renderDialog();
+      await waitFor(() => expect(screen.getByText("Core Tools")).toBeTruthy());
+      expect(within(disabledGroup()).getByText("Core Tools")).toBeTruthy();
+      expect(screen.queryByRole("group", { name: "Built-in" })).toBeNull();
+    });
+
+    it("places a disabled user plugin in the Disabled section", async () => {
+      (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+        named({ manifest: { name: "acme.demo", displayName: "Acme Demo" }, disabled: true }),
+      ]);
+      renderDialog();
+      await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
+      expect(within(disabledGroup()).getByText("Acme Demo")).toBeTruthy();
+    });
+
+    it("renders all three sections for a mixed list and hides none", async () => {
+      (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+        named({
+          manifest: { name: "core.tools", displayName: "Core Tools" },
+          isBuiltin: true,
+          source: "builtin",
+        }),
+        named({ manifest: { name: "acme.demo", displayName: "Acme Demo" }, source: "sideload" }),
+        named({ manifest: { name: "old.thing", displayName: "Old Thing" }, disabled: true }),
+      ]);
+      renderDialog();
+      await waitFor(() => expect(screen.getByText("Core Tools")).toBeTruthy());
+      expect(within(builtinGroup()).getByText("Core Tools")).toBeTruthy();
+      expect(within(installedGroup()).getByText("Acme Demo")).toBeTruthy();
+      expect(within(disabledGroup()).getByText("Old Thing")).toBeTruthy();
+    });
+
+    it("omits the Disabled section when every plugin is enabled", async () => {
+      (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+        named({ manifest: { name: "acme.demo", displayName: "Acme Demo" } }),
+      ]);
+      renderDialog();
+      await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
+      expect(screen.queryByRole("group", { name: "Disabled" })).toBeNull();
+    });
+
+    it("omits the Built-in and Installed sections when every plugin is disabled", async () => {
+      (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+        named({ manifest: { name: "acme.demo", displayName: "Acme Demo" }, disabled: true }),
+      ]);
+      renderDialog();
+      await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
+      expect(screen.queryByRole("group", { name: "Built-in" })).toBeNull();
+      expect(screen.queryByRole("group", { name: "Installed" })).toBeNull();
+      expect(disabledGroup()).toBeTruthy();
+    });
+
+    it("preserves alphabetical order within a section", async () => {
+      (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+        named({ manifest: { name: "z.plugin", displayName: "Zebra" } }),
+        named({ manifest: { name: "a.plugin", displayName: "Alpha" } }),
+      ]);
+      renderDialog();
+      await waitFor(() => expect(screen.getByText("Alpha")).toBeTruthy());
+      const labels = within(installedGroup())
+        .getAllByText(/Alpha|Zebra/)
+        .map((el) => el.textContent);
+      expect(labels).toEqual(["Alpha", "Zebra"]);
     });
   });
 });


### PR DESCRIPTION
## Summary

- The plugin manager showed all installed plugins in a single flat list; it now groups them into three labelled sections: **Built-in**, **Installed**, and **Disabled**
- Any disabled plugin routes to the Disabled section regardless of origin, so the list of what isn't currently running is always in one place
- Each non-empty section renders as a `role="group"` with an `aria-labelledby` heading (following the `ThemeSelector` pattern); empty sections are hidden; within-group alphabetical ordering is unchanged

Resolves #9554

## Changes

- `PluginManagerDialog.tsx` — added a `PLUGIN_GROUPS` predicate table and mapped it to three conditional section blocks in the render path; no IPC or type changes (uses existing `isBuiltin`, `source`, and `disabled` fields on `LoadedPluginInfo`)
- `PluginManagerDialog.test.tsx` — added 8 grouping tests covering routing logic, empty-section hiding, and cross-group ordering

## Testing

All 44 tests in `PluginManagerDialog.test.tsx` pass. Lint, format, and typecheck clean.