### PR TITLE
feat(plugins): add contributes.agents plugin contribution point (#9560)

### DIFF
--- a/docs/plugins/contribution-points.md
+++ b/docs/plugins/contribution-points.md
@@ -517,7 +517,9 @@ Teaches Daintree about a launchable agent CLI it doesn't ship in-tree, so the CL
 | `supportsContextInjection` | no | Whether copy-tree context injection targets this agent. Defaults to `false`. |
 | `detection` | no | Reserved for the full-tracking tier. The shape (bounded, well-formed detection patterns) is **validated** at manifest-parse time but not yet wired into the live PTY matcher — minimal-tier agents launch as named, untracked terminals. |
 
-The **minimal tier** (shipped) makes the agent launchable and selectable as a named entry in the effective registry. The **full tier** (planned) will relax the built-in-only gate in output detection so a plugin-supplied, validated `detection` config drives working/waiting state, resume, and MCP wiring. Bad or malformed detection input degrades gracefully to a generic shell and never breaks detection for other terminals.
+The **minimal tier** (shipped) makes the agent launchable and selectable as a named entry in the effective registry; detection is not run, so the agent always launches as a named terminal. The **full tier** (planned) will relax the built-in-only gate in output detection so a plugin-supplied `detection` config drives working/waiting state, resume, and MCP wiring.
+
+A malformed `detection` config (an un-compilable pattern, an over-long or over-numerous pattern set, or a construct prone to catastrophic backtracking) is rejected at manifest validation — the plugin fails to load loudly rather than silently shipping a bad matcher. Once the full tier lands, a _well-formed_ config that simply never matches at runtime leaves the agent launching as a named terminal and never affects detection for other terminals.
 
 ## What's missing and why
 

--- a/docs/plugins/contribution-points.md
+++ b/docs/plugins/contribution-points.md
@@ -481,11 +481,49 @@ Registers a forge backend — issues, pull/merge requests, reviews, CI roll-up, 
 
 The manifest entry is read eagerly so the provider populates Preferences and the remote-routing table before any plugin code runs; the implementation binds lazily in `activate()` via [`registerForgeProvider`](./host-api.md#registerforgeprovider). For the end-to-end walkthrough — implementing `ForgeProviderImpl`, state normalization, capabilities, and tests — see [Implementing a forge provider](./forge-provider.md).
 
+## Agents — _Shipped (minimal tier)_
+
+Teaches Daintree about a launchable agent CLI it doesn't ship in-tree, so the CLI shows up as a named, selectable agent rather than a generic shell. Requires the `agent:register` capability, which is surfaced to the user at install time.
+
+```json
+{
+  "capabilities": ["agent:register"],
+  "contributes": {
+    "agents": [
+      {
+        "id": "acme",
+        "name": "Acme Agent",
+        "command": "acme",
+        "args": ["--interactive"],
+        "color": "#3366ff",
+        "iconId": "terminal",
+        "supportsContextInjection": true
+      }
+    ]
+  }
+}
+```
+
+**Fields:**
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `id` | yes | Bare agent id (alphanumerics, `.`, `-`, `_`; ≤64 chars). Additive for **new** IDs only — a collision with a built-in agent id is rejected at the manifest gate, and built-in entries always shadow plugin entries. Cross-plugin id conflicts resolve first-registered-wins. |
+| `name` | yes | Display label for the agent. |
+| `command` | yes | CLI binary to launch. Same safe-id pattern as `id` (no shell metacharacters). |
+| `args` | no | Default launch arguments (≤20 entries; no control characters). |
+| `color` | yes | Brand color as a 6-digit hex (`#rrggbb`). |
+| `iconId` | yes | Icon id used for the agent. |
+| `supportsContextInjection` | no | Whether copy-tree context injection targets this agent. Defaults to `false`. |
+| `detection` | no | Reserved for the full-tracking tier. The shape (bounded, well-formed detection patterns) is **validated** at manifest-parse time but not yet wired into the live PTY matcher — minimal-tier agents launch as named, untracked terminals. |
+
+The **minimal tier** (shipped) makes the agent launchable and selectable as a named entry in the effective registry. The **full tier** (planned) will relax the built-in-only gate in output detection so a plugin-supplied, validated `detection` config drives working/waiting state, resume, and MCP wiring. Bad or malformed detection input degrades gracefully to a generic shell and never breaks detection for other terminals.
+
 ## What's missing and why
 
 A few surfaces I've decided **not** to expose as dedicated contribution points:
 
-- **Agent provider plugins.** Adding a new model backend is handled via OpenAI-compatible base URL configuration in Daintree's settings, not a plugin API. The complexity of a full provider SDK isn't justified when 95% of users just need to point Daintree at a different endpoint.
+- **Agent provider SDKs.** Registering a launchable agent CLI is a contribution point (see [Agents](#agents--shipped-minimal-tier)), but a full model-provider SDK is not. Adding a new model backend is handled via OpenAI-compatible base URL configuration in Daintree's settings — the complexity of a full provider SDK isn't justified when 95% of users just need to point Daintree at a different endpoint.
 - **Agent lifecycle hooks (PreToolUse, PostToolUse, Stop).** Use an MCP server instead. A plugin that wants to intercept tool calls ships an MCP server that the agent talks to; the server can refuse or annotate tool calls. This is simpler than a dedicated hook API and reuses the MCP ecosystem.
 - **Subagents.** Daintree spawns fresh agents natively. Plugins that want to compose agents use skills + MCP to drive the orchestration, not a dedicated subagent contribution.
 - **Status bar items, tree views, editor decorations.** Daintree isn't an editor; these surfaces don't map cleanly to what we render. Revisit if a specific need emerges.

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -816,6 +816,7 @@ export const CHANNELS = {
   PLUGIN_ACTIONS_REGISTER: "plugin:actions-register",
   PLUGIN_ACTIONS_UNREGISTER: "plugin:actions-unregister",
   PLUGIN_PANEL_KINDS_GET: "plugin:panel-kinds-get",
+  PLUGIN_AGENTS_GET: "plugin:agents-get",
   PLUGIN_FORGE_PROVIDERS_GET: "plugin:forge-providers-get",
   PLUGIN_FILE_DECORATIONS_GET: "plugin:file-decorations-get",
   PLUGIN_GET_AUDIT_RECORDS: "plugin:get-audit-records",

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -115,7 +115,7 @@ beforeEach(() => {
 describe("registerPluginHandlers", () => {
   it("registers handlers for all plugin channels", () => {
     registerPluginHandlers();
-    expect(mockIpcMainHandle).toHaveBeenCalledTimes(31);
+    expect(mockIpcMainHandle).toHaveBeenCalledTimes(32);
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:list", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:install", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:set-enabled", expect.any(Function));
@@ -149,6 +149,7 @@ describe("registerPluginHandlers", () => {
       expect.any(Function)
     );
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:panel-kinds-get", expect.any(Function));
+    expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:agents-get", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith(
       "plugin:forge-providers-get",
       expect.any(Function)
@@ -215,6 +216,7 @@ describe("registerPluginHandlers", () => {
     expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:actions-register");
     expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:actions-unregister");
     expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:panel-kinds-get");
+    expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:agents-get");
     expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:forge-providers-get");
   });
 

--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -61,6 +61,7 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
   "plugin:menu-items-changed": "external",
   "plugin:keybindings-changed": "external",
   "plugin:context-menu-items-changed": "external",
+  "plugin:agents-changed": "external",
   "plugin:decorations-changed": "external",
   "plugin:provenance-changed": "external",
   "terminal:exit": "external",

--- a/electron/ipc/handlers/plugin.preload.ts
+++ b/electron/ipc/handlers/plugin.preload.ts
@@ -23,6 +23,7 @@ export const PLUGIN_METHOD_CHANNELS = {
   registerAction: "plugin:actions-register",
   unregisterAction: "plugin:actions-unregister",
   getPanelKinds: "plugin:panel-kinds-get",
+  getAgents: "plugin:agents-get",
   getForgeProviders: "plugin:forge-providers-get",
   getDecorations: "plugin:file-decorations-get",
   getAuditRecords: "plugin:get-audit-records",

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -44,6 +44,8 @@ import {
 import { getPluginMenuItems } from "../../services/pluginMenuRegistry.js";
 import { getPluginKeybindings } from "../../services/pluginKeybindingRegistry.js";
 import { getPluginContextMenuItems } from "../../services/pluginContextMenuRegistry.js";
+import { getPluginAgentRegistry } from "../../../shared/config/pluginAgentRegistry.js";
+import type { AgentConfig } from "../../../shared/config/agentRegistry.js";
 import {
   getRegisteredForgeProviders,
   type RegisteredForgeProvider,
@@ -474,6 +476,11 @@ async function handleForgeProvidersGet(): Promise<RegisteredForgeProvider[]> {
   return getRegisteredForgeProviders();
 }
 
+async function handleAgentsGet(): Promise<Record<string, AgentConfig>> {
+  await pluginService.waitForInit();
+  return getPluginAgentRegistry();
+}
+
 /**
  * Per-provider budget for a single `provideDecorations` call. A provider that
  * never settles its promise would otherwise hang the whole IPC invocation
@@ -771,6 +778,7 @@ export const pluginNamespace = defineIpcNamespace({
     registerAction: op(PLUGIN_METHOD_CHANNELS.registerAction, handleActionsRegister),
     unregisterAction: op(PLUGIN_METHOD_CHANNELS.unregisterAction, handleActionsUnregister),
     getPanelKinds: op(PLUGIN_METHOD_CHANNELS.getPanelKinds, handlePanelKindsGet),
+    getAgents: op(PLUGIN_METHOD_CHANNELS.getAgents, handleAgentsGet),
     getForgeProviders: op(PLUGIN_METHOD_CHANNELS.getForgeProviders, handleForgeProvidersGet),
     getDecorations: op(PLUGIN_METHOD_CHANNELS.getDecorations, handleFileDecorationsGet),
     getAuditRecords: op(PLUGIN_METHOD_CHANNELS.getAuditRecords, handleGetAuditRecords),

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2489,6 +2489,12 @@ const api: ElectronAPI = {
       _eventBusOn("plugin:provenance-changed", callback),
     onPanelKindsChanged: (callback: (payload: { kinds: PanelKindConfig[] }) => void) =>
       _eventBusOn("plugin:panel-kinds-changed", callback),
+    onAgentsChanged: (
+      callback: (payload: {
+        agents: Record<string, import("../shared/config/agentRegistry.js").AgentConfig>;
+        complete: boolean;
+      }) => void
+    ) => _eventBusOn("plugin:agents-changed", callback),
     onToolbarButtonsChanged: (
       callback: (payload: { buttons: ToolbarButtonConfig[]; complete: boolean }) => void
     ) => _eventBusOn("plugin:toolbar-buttons-changed", callback),

--- a/electron/schemas/__tests__/agentContribution.test.ts
+++ b/electron/schemas/__tests__/agentContribution.test.ts
@@ -60,6 +60,12 @@ describe("AgentContributionSchema (issue #9560)", () => {
     ).toBe(false);
   });
 
+  it("rejects reserved ids that could pollute the registry object", () => {
+    for (const id of ["__proto__", "constructor", "prototype"]) {
+      expect(AgentContributionSchema.safeParse({ ...VALID_AGENT, id }).success).toBe(false);
+    }
+  });
+
   it("rejects control characters in args and caps arg count at 20", () => {
     expect(
       AgentContributionSchema.safeParse({ ...VALID_AGENT, args: ["ok", "bad\nflag"] }).success
@@ -90,6 +96,22 @@ describe("AgentDetectionContributionSchema bounded-regex contract (issue #9560)"
     expect(AgentDetectionContributionSchema.safeParse({ primaryPatterns: ["(a+)+"] }).success).toBe(
       false
     );
+  });
+
+  it("rejects ReDoS families that a naive nested-quantifier check would miss", () => {
+    // Quantified alternation, optional-quantified group, and doubly-nested
+    // quantified groups all backtrack catastrophically.
+    for (const pattern of ["(a|aa)+", "(a?)+", "((a)*)*", "(.*)*", "(a+){2,}"]) {
+      expect(
+        AgentDetectionContributionSchema.safeParse({ primaryPatterns: [pattern] }).success
+      ).toBe(false);
+    }
+  });
+
+  it("accepts a plain quantified group with no risky body", () => {
+    expect(
+      AgentDetectionContributionSchema.safeParse({ primaryPatterns: ["(foo)+", "bar*"] }).success
+    ).toBe(true);
   });
 
   it("rejects a pattern longer than 250 chars and more than 8 patterns", () => {
@@ -141,5 +163,17 @@ describe("manifest-level agent contribution gates (issue #9560)", () => {
     if (result.success) {
       expect(result.data.contributes.agents).toEqual([]);
     }
+  });
+
+  it("rejects the whole manifest when an agent's detection config is malformed", () => {
+    const result = schema.safeParse(
+      manifestWith({
+        capabilities: ["agent:register"],
+        contributes: {
+          agents: [{ ...VALID_AGENT, detection: { primaryPatterns: ["("] } }],
+        },
+      })
+    );
+    expect(result.success).toBe(false);
   });
 });

--- a/electron/schemas/__tests__/agentContribution.test.ts
+++ b/electron/schemas/__tests__/agentContribution.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import {
+  AgentContributionSchema,
+  AgentDetectionContributionSchema,
+  getPluginManifestSchema,
+} from "../plugin.js";
+
+const VALID_AGENT = {
+  id: "acme-agent",
+  name: "Acme Agent",
+  command: "acme",
+  color: "#3366ff",
+  iconId: "terminal",
+};
+
+function manifestWith(overrides: Record<string, unknown>) {
+  return {
+    name: "acme.my-plugin",
+    version: "1.0.0",
+    ...overrides,
+  };
+}
+
+describe("AgentContributionSchema (issue #9560)", () => {
+  it("accepts a minimal agent contribution and defaults supportsContextInjection to false", () => {
+    const result = AgentContributionSchema.safeParse(VALID_AGENT);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.supportsContextInjection).toBe(false);
+    }
+  });
+
+  it("accepts args, supportsContextInjection, and a detection block", () => {
+    const result = AgentContributionSchema.safeParse({
+      ...VALID_AGENT,
+      args: ["--flag", "value"],
+      supportsContextInjection: true,
+      detection: { primaryPatterns: ["thinking", "working\\.\\.\\."] },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unknown top-level fields (strict)", () => {
+    expect(
+      AgentContributionSchema.safeParse({ ...VALID_AGENT, resume: { kind: "rolling-history" } })
+        .success
+    ).toBe(false);
+  });
+
+  it("rejects a malformed color", () => {
+    expect(AgentContributionSchema.safeParse({ ...VALID_AGENT, color: "blue" }).success).toBe(
+      false
+    );
+  });
+
+  it("rejects an id or command with shell metacharacters", () => {
+    expect(AgentContributionSchema.safeParse({ ...VALID_AGENT, id: "bad id" }).success).toBe(false);
+    expect(
+      AgentContributionSchema.safeParse({ ...VALID_AGENT, command: "acme; rm -rf /" }).success
+    ).toBe(false);
+  });
+
+  it("rejects control characters in args and caps arg count at 20", () => {
+    expect(
+      AgentContributionSchema.safeParse({ ...VALID_AGENT, args: ["ok", "bad\nflag"] }).success
+    ).toBe(false);
+    expect(
+      AgentContributionSchema.safeParse({
+        ...VALID_AGENT,
+        args: Array.from({ length: 21 }, (_, i) => `--flag${i}`),
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe("AgentDetectionContributionSchema bounded-regex contract (issue #9560)", () => {
+  it("rejects an invalid regular expression", () => {
+    expect(AgentDetectionContributionSchema.safeParse({ primaryPatterns: ["("] }).success).toBe(
+      false
+    );
+  });
+
+  it("rejects backreferences, lookarounds, and nested quantifiers", () => {
+    expect(
+      AgentDetectionContributionSchema.safeParse({ primaryPatterns: ["(foo)\\1"] }).success
+    ).toBe(false);
+    expect(
+      AgentDetectionContributionSchema.safeParse({ primaryPatterns: ["foo(?=bar)"] }).success
+    ).toBe(false);
+    expect(AgentDetectionContributionSchema.safeParse({ primaryPatterns: ["(a+)+"] }).success).toBe(
+      false
+    );
+  });
+
+  it("rejects a pattern longer than 250 chars and more than 8 patterns", () => {
+    expect(
+      AgentDetectionContributionSchema.safeParse({ primaryPatterns: ["a".repeat(251)] }).success
+    ).toBe(false);
+    expect(
+      AgentDetectionContributionSchema.safeParse({
+        primaryPatterns: Array.from({ length: 9 }, (_, i) => `p${i}`),
+      }).success
+    ).toBe(false);
+  });
+
+  it("rejects unknown detection fields (strict)", () => {
+    expect(
+      AgentDetectionContributionSchema.safeParse({ titleStatePatterns: { working: ["x"] } }).success
+    ).toBe(false);
+  });
+});
+
+describe("manifest-level agent contribution gates (issue #9560)", () => {
+  const schema = getPluginManifestSchema(false);
+
+  it("rejects contributes.agents without the agent:register capability", () => {
+    const result = schema.safeParse(manifestWith({ contributes: { agents: [VALID_AGENT] } }));
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts contributes.agents when agent:register is declared", () => {
+    const result = schema.safeParse(
+      manifestWith({ capabilities: ["agent:register"], contributes: { agents: [VALID_AGENT] } })
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a plugin agent id that collides with a built-in", () => {
+    const result = schema.safeParse(
+      manifestWith({
+        capabilities: ["agent:register"],
+        contributes: { agents: [{ ...VALID_AGENT, id: "claude" }] },
+      })
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("defaults contributes.agents to an empty array when omitted", () => {
+    const result = schema.safeParse(manifestWith({}));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.contributes.agents).toEqual([]);
+    }
+  });
+});

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -212,8 +212,29 @@ const MAX_DETECTION_PATTERNS_PER_FIELD = 8;
 const BACKREFERENCE_RE = /\\[1-9]/;
 /** Lookahead/lookbehind: `(?=`, `(?!`, `(?<=`, `(?<!`. */
 const LOOKAROUND_RE = /\(\?<?[=!]/;
-/** Quantified group whose body is itself quantified, e.g. `(a+)+`, `(.*)*`. */
-const NESTED_QUANTIFIER_RE = /\([^)]*[+*][^)]*\)[+*]/;
+/**
+ * A group whose body contains a quantifier (`* + ? {`) or an alternation (`|`)
+ * and that is itself quantified with an unbounded outer quantifier
+ * (`* + {`). Catches the classic catastrophic-backtracking families
+ * `(a+)+`, `(.*)*`, `(a?)+`, and quantified-alternation `(a|aa)+`. Outer `?`
+ * is excluded because an optional group does not repeat unboundedly.
+ */
+const QUANTIFIED_COMPLEX_GROUP_RE = /\([^)]*[*+?{|][^)]*\)[*+{]/;
+/**
+ * Two nested quantified groups, e.g. `((a)*)*` — the inner group is closed and
+ * quantified, then re-closed and quantified again. The single-group regex above
+ * can't span the inner `)`, so this catches the nesting separately.
+ */
+const NESTED_QUANTIFIED_GROUP_RE = /\)[*+?][^(]*\)[*+{]/;
+
+function hasCatastrophicBacktrackingRisk(pattern: string): boolean {
+  return (
+    BACKREFERENCE_RE.test(pattern) ||
+    LOOKAROUND_RE.test(pattern) ||
+    QUANTIFIED_COMPLEX_GROUP_RE.test(pattern) ||
+    NESTED_QUANTIFIED_GROUP_RE.test(pattern)
+  );
+}
 
 const BoundedDetectionPatternSchema = z
   .string()
@@ -232,16 +253,10 @@ const BoundedDetectionPatternSchema = z
     },
     { message: "Detection pattern is not a valid regular expression" }
   )
-  .refine(
-    (pattern) =>
-      !BACKREFERENCE_RE.test(pattern) &&
-      !LOOKAROUND_RE.test(pattern) &&
-      !NESTED_QUANTIFIER_RE.test(pattern),
-    {
-      message:
-        "Detection pattern may not use backreferences, lookarounds, or nested quantifiers (catastrophic-backtracking risk)",
-    }
-  );
+  .refine((pattern) => !hasCatastrophicBacktrackingRisk(pattern), {
+    message:
+      "Detection pattern may not use backreferences, lookarounds, quantified alternation, or nested quantifiers (catastrophic-backtracking risk)",
+  });
 
 const BoundedDetectionPatternArraySchema = z
   .array(BoundedDetectionPatternSchema)
@@ -275,9 +290,18 @@ export const AgentDetectionContributionSchema = z
  * required — also enforced at the manifest level so the message can reference
  * the whole contribution set.
  */
+const RESERVED_AGENT_IDS = new Set(["__proto__", "constructor", "prototype"]);
+
 export const AgentContributionSchema = z
   .object({
-    id: z.string().min(1).max(64).regex(SAFE_ID_PATTERN),
+    id: z
+      .string()
+      .min(1)
+      .max(64)
+      .regex(SAFE_ID_PATTERN)
+      .refine((id) => !RESERVED_AGENT_IDS.has(id), {
+        message: "Agent id cannot be a reserved key (__proto__, constructor, prototype)",
+      }),
     name: z.string().min(1).max(100),
     command: z.string().min(1).max(256).regex(SAFE_ID_PATTERN),
     args: z

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -3,6 +3,7 @@ import ipaddr from "ipaddr.js";
 import * as semver from "semver";
 import { z } from "zod";
 import { BUILT_IN_PLUGIN_CAPABILITIES } from "../../shared/types/plugin.js";
+import { isBuiltInAgentId } from "../../shared/config/agentIds.js";
 import type {
   PluginManifest,
   PanelContribution,
@@ -191,6 +192,109 @@ export const FileDecorationContributionSchema = z
   .object({
     id: z.string().min(1).max(64).regex(SAFE_ID_PATTERN),
     scopes: z.array(z.string().min(1)).min(1),
+  })
+  .strict();
+
+/**
+ * Detection patterns run against live PTY output for every terminal, so a
+ * plugin-supplied pattern needs a tight contract — bounded length, a bounded
+ * count, well-formedness, and no constructs prone to catastrophic backtracking.
+ * RE2 (linear-time) is deliberately not added as a native dependency (#9560);
+ * instead each pattern is validated structurally at manifest-parse time, which
+ * is off the hot PTY path. A pattern that compiles but uses backreferences,
+ * lookarounds, or nested quantifiers is rejected so a malicious manifest can't
+ * stall the matcher.
+ */
+const MAX_DETECTION_PATTERN_LENGTH = 250;
+const MAX_DETECTION_PATTERNS_PER_FIELD = 8;
+
+/** Backreference, e.g. `\1`. */
+const BACKREFERENCE_RE = /\\[1-9]/;
+/** Lookahead/lookbehind: `(?=`, `(?!`, `(?<=`, `(?<!`. */
+const LOOKAROUND_RE = /\(\?<?[=!]/;
+/** Quantified group whose body is itself quantified, e.g. `(a+)+`, `(.*)*`. */
+const NESTED_QUANTIFIER_RE = /\([^)]*[+*][^)]*\)[+*]/;
+
+const BoundedDetectionPatternSchema = z
+  .string()
+  .min(1)
+  .max(MAX_DETECTION_PATTERN_LENGTH, {
+    message: `Detection pattern must be at most ${MAX_DETECTION_PATTERN_LENGTH} characters`,
+  })
+  .refine(
+    (pattern) => {
+      try {
+        new RegExp(pattern);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    { message: "Detection pattern is not a valid regular expression" }
+  )
+  .refine(
+    (pattern) =>
+      !BACKREFERENCE_RE.test(pattern) &&
+      !LOOKAROUND_RE.test(pattern) &&
+      !NESTED_QUANTIFIER_RE.test(pattern),
+    {
+      message:
+        "Detection pattern may not use backreferences, lookarounds, or nested quantifiers (catastrophic-backtracking risk)",
+    }
+  );
+
+const BoundedDetectionPatternArraySchema = z
+  .array(BoundedDetectionPatternSchema)
+  .max(MAX_DETECTION_PATTERNS_PER_FIELD, {
+    message: `At most ${MAX_DETECTION_PATTERNS_PER_FIELD} detection patterns are allowed per field`,
+  });
+
+/**
+ * Plugin-supplied output-detection config (#9560). Validated here but not yet
+ * wired into the live matcher — the minimal tier launches plugin agents as
+ * named, untracked terminals. Strict so an unrecognised field surfaces as a
+ * manifest error rather than silently dropping.
+ */
+export const AgentDetectionContributionSchema = z
+  .object({
+    primaryPatterns: BoundedDetectionPatternArraySchema.optional(),
+    fallbackPatterns: BoundedDetectionPatternArraySchema.optional(),
+    promptPatterns: BoundedDetectionPatternArraySchema.optional(),
+    bootCompletePatterns: BoundedDetectionPatternArraySchema.optional(),
+    completionPatterns: BoundedDetectionPatternArraySchema.optional(),
+    scanLineCount: z.number().int().min(1).max(50).optional(),
+    debounceMs: z.number().int().min(500).max(30_000).optional(),
+  })
+  .strict();
+
+/**
+ * One `contributes.agents` entry (#9560). `id` and `command` use the shared
+ * safe-id pattern (no shell metacharacters); a contribution whose `id` collides
+ * with a built-in agent is rejected by the manifest-level `superRefine`. Strict
+ * so unknown fields are rejected loudly. The `agent:register` capability is
+ * required — also enforced at the manifest level so the message can reference
+ * the whole contribution set.
+ */
+export const AgentContributionSchema = z
+  .object({
+    id: z.string().min(1).max(64).regex(SAFE_ID_PATTERN),
+    name: z.string().min(1).max(100),
+    command: z.string().min(1).max(256).regex(SAFE_ID_PATTERN),
+    args: z
+      .array(
+        z
+          .string()
+          .max(256)
+          .refine((arg) => !/[\r\n\0]/.test(arg), {
+            message: "Args cannot contain control characters (\\r, \\n, \\0)",
+          })
+      )
+      .max(20)
+      .optional(),
+    color: z.string().regex(/^#[0-9A-Fa-f]{6}$/),
+    iconId: z.string().min(1).max(64),
+    supportsContextInjection: z.boolean().default(false),
+    detection: AgentDetectionContributionSchema.optional(),
   })
   .strict();
 
@@ -495,6 +599,7 @@ export function getPluginManifestSchema(isBuiltin: boolean) {
           experimental_mcpServers: z.array(McpServerContributionSchema).default([]),
           forgeProviders: z.array(ForgeProviderContributionSchema).default([]),
           fileDecorationProviders: z.array(FileDecorationContributionSchema).default([]),
+          agents: z.array(AgentContributionSchema).default([]),
           settings: z.array(SettingDefinitionSchema).default([]),
         })
         .default({
@@ -508,6 +613,7 @@ export function getPluginManifestSchema(isBuiltin: boolean) {
           experimental_mcpServers: [],
           forgeProviders: [],
           fileDecorationProviders: [],
+          agents: [],
           settings: [],
         }),
     })
@@ -520,6 +626,33 @@ export function getPluginManifestSchema(isBuiltin: boolean) {
           params: { errorCode: "namespace_reserved" },
         });
       }
+
+      // `contributes.agents` registers a launchable agent CLI — gate it behind
+      // the explicit `agent:register` capability so the contribution is
+      // surfaced to the user at install time (#9560).
+      const agents = manifest.contributes.agents;
+      if (agents.length > 0 && !manifest.capabilities.includes("agent:register")) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["contributes", "agents"],
+          message:
+            'contributes.agents requires the "agent:register" capability to be declared in capabilities.',
+          params: { errorCode: "agent_register_capability_required" },
+        });
+      }
+
+      // Plugin agent IDs are additive for new IDs only — they may never shadow
+      // or patch a built-in agent.
+      agents.forEach((agent, index) => {
+        if (isBuiltInAgentId(agent.id)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["contributes", "agents", index, "id"],
+            message: `Plugin agent id "${agent.id}" collides with a built-in agent — plugin agents must use new IDs.`,
+            params: { errorCode: "agent_id_reserved" },
+          });
+        }
+      });
     });
 }
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -97,6 +97,10 @@ import {
   unregisterFileDecorationProviderImpls,
   unregisterFileDecorationProviders,
 } from "./fileDecorationRegistry.js";
+import {
+  registerPluginAgents,
+  unregisterPluginAgents,
+} from "../../shared/config/pluginAgentRegistry.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
 import { CHANNELS } from "../ipc/channels.js";
 import type { LoadedPluginInfo } from "../../shared/types/plugin.js";
@@ -153,6 +157,10 @@ const CONFIRM_TRIGGERING_CAPABILITIES: ReadonlySet<BuiltInPluginCapability> = ne
   "fs:project-write",
   "fs:user-data-write",
   "agent:invoke",
+  // Registering a launchable agent CLI (with its own command/args, and a
+  // detection config in the full tier) is a runtime side effect on par with
+  // `agent:invoke` — a plugin holding it elevates its actions to "confirm".
+  "agent:register",
 ]);
 
 /**
@@ -1049,6 +1057,11 @@ export class PluginService {
 
     if (manifest.contributes.fileDecorationProviders.length > 0) {
       registerFileDecorationProviders(manifest.name, manifest.contributes.fileDecorationProviders);
+    }
+
+    if (manifest.contributes.agents.length > 0) {
+      registerPluginAgents(manifest.name, manifest.contributes.agents);
+      this.broadcaster.scheduleAgentsBroadcast(false);
     }
 
     // Insert the plugin into the registry BEFORE importing its main module so
@@ -2382,6 +2395,10 @@ export class PluginService {
     );
     runUnloadStep(pluginId, "unregisterFileDecorationProviderImpls", () =>
       unregisterFileDecorationProviderImpls(pluginId)
+    );
+    runUnloadStep(pluginId, "unregisterPluginAgents", () => unregisterPluginAgents(pluginId));
+    runUnloadStep(pluginId, "scheduleAgentsBroadcast", () =>
+      this.broadcaster.scheduleAgentsBroadcast(true)
     );
     // Subscriber disposers already fired in flushPluginEventCleanups() above;
     // this drops any leftover subscriber-set entry and the in-memory settings

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -493,16 +493,35 @@ describe("PluginService integration — agent contributions (issue #9560)", () =
 
     const service = new PluginService(tmpDir, "0.0.0");
     await service.initialize();
+    // Flush the coalesced microtask broadcast scheduled on load.
+    await Promise.resolve();
 
     expect(getPluginAgentRegistry()["acme-agent"]).toBeDefined();
     const config = getEffectiveAgentConfig("acme-agent");
     expect(config?.name).toBe("Acme Agent");
     expect(config?.command).toBe("acme");
 
+    expect(vi.mocked(broadcastToRenderer)).toHaveBeenCalledWith("events:push", {
+      name: "plugin:agents-changed",
+      payload: {
+        agents: expect.objectContaining({ "acme-agent": expect.anything() }),
+        complete: false,
+      },
+    });
+
+    vi.mocked(broadcastToRenderer).mockClear();
     service.unloadPlugin("acme.agent-plugin");
+    await Promise.resolve();
 
     expect(getPluginAgentRegistry()["acme-agent"]).toBeUndefined();
     expect(getEffectiveAgentConfig("acme-agent")).toBeUndefined();
+    expect(vi.mocked(broadcastToRenderer)).toHaveBeenCalledWith(
+      "events:push",
+      expect.objectContaining({
+        name: "plugin:agents-changed",
+        payload: expect.objectContaining({ complete: true }),
+      })
+    );
   });
 
   it("does not register agents when the manifest omits the agent:register capability", async () => {

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -71,6 +71,11 @@ import {
   getFileDecorationImpls,
   getRegisteredFileDecorationProviders,
 } from "../fileDecorationRegistry.js";
+import {
+  clearPluginAgentRegistryForTests,
+  getPluginAgentRegistry,
+} from "../../../shared/config/pluginAgentRegistry.js";
+import { getEffectiveAgentConfig } from "../../../shared/config/agentRegistry.js";
 import { broadcastToRenderer } from "../../ipc/utils.js";
 
 function makeCtx(pluginId: string, overrides: Partial<PluginIpcContext> = {}): PluginIpcContext {
@@ -88,6 +93,7 @@ type PluginManifestShape = {
   version: string;
   displayName?: string;
   main?: string;
+  capabilities?: string[];
   contributes?: {
     panels?: unknown[];
     toolbarButtons?: unknown[];
@@ -96,6 +102,7 @@ type PluginManifestShape = {
     mcpServers?: unknown[];
     forgeProviders?: unknown[];
     fileDecorationProviders?: unknown[];
+    agents?: unknown[];
   };
 };
 
@@ -148,6 +155,7 @@ afterEach(async () => {
     clearForgeProviderRegistry();
     clearFileDecorationRegistry();
     clearFileDecorationImplRegistry();
+    clearPluginAgentRegistryForTests();
     storeState.clear();
     for (const key of globalMarkers) {
       delete (globalThis as Record<string, unknown>)[key];
@@ -460,6 +468,66 @@ describe("PluginService integration — forge provider contributions", () => {
     expect(getRegisteredForgeProviders()).toHaveLength(2);
     expect(listMatchingProviders("https://primary.example/repo")).toHaveLength(1);
     expect(listMatchingProviders("https://secondary.example/repo")).toHaveLength(1);
+  });
+});
+
+describe("PluginService integration — agent contributions (issue #9560)", () => {
+  it("registers a manifest agents entry and unregisters it on unload", async () => {
+    await writePlugin("acme.agent-plugin", {
+      name: "acme.agent-plugin",
+      version: "1.0.0",
+      capabilities: ["agent:register"],
+      contributes: {
+        agents: [
+          {
+            id: "acme-agent",
+            name: "Acme Agent",
+            command: "acme",
+            args: ["--flag"],
+            color: "#3366ff",
+            iconId: "terminal",
+          },
+        ],
+      },
+    });
+
+    const service = new PluginService(tmpDir, "0.0.0");
+    await service.initialize();
+
+    expect(getPluginAgentRegistry()["acme-agent"]).toBeDefined();
+    const config = getEffectiveAgentConfig("acme-agent");
+    expect(config?.name).toBe("Acme Agent");
+    expect(config?.command).toBe("acme");
+
+    service.unloadPlugin("acme.agent-plugin");
+
+    expect(getPluginAgentRegistry()["acme-agent"]).toBeUndefined();
+    expect(getEffectiveAgentConfig("acme-agent")).toBeUndefined();
+  });
+
+  it("does not register agents when the manifest omits the agent:register capability", async () => {
+    await writePlugin("acme.no-cap", {
+      name: "acme.no-cap",
+      version: "1.0.0",
+      contributes: {
+        agents: [
+          {
+            id: "uncapped-agent",
+            name: "Uncapped",
+            command: "uncapped",
+            color: "#3366ff",
+            iconId: "terminal",
+          },
+        ],
+      },
+    });
+
+    const service = new PluginService(tmpDir, "0.0.0");
+    await service.initialize();
+
+    // The manifest fails strict validation (capability gate), so the plugin
+    // never loads its agent into the registry.
+    expect(getPluginAgentRegistry()["uncapped-agent"]).toBeUndefined();
   });
 });
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -403,6 +403,7 @@ describe("PluginManifestSchema capabilities field", () => {
     expect(BUILT_IN_PLUGIN_CAPABILITIES).toContain("network:fetch");
     expect(BUILT_IN_PLUGIN_CAPABILITIES).toContain("agent:invoke");
     expect(BUILT_IN_PLUGIN_CAPABILITIES).toContain("agent:read");
+    expect(BUILT_IN_PLUGIN_CAPABILITIES).toContain("agent:register");
     expect(BUILT_IN_PLUGIN_CAPABILITIES).toContain("git:read");
     expect(BUILT_IN_PLUGIN_CAPABILITIES).toContain("git:write");
     expect(BUILT_IN_PLUGIN_CAPABILITIES).toContain("clipboard:read");
@@ -410,9 +411,9 @@ describe("PluginManifestSchema capabilities field", () => {
     expect(BUILT_IN_PLUGIN_CAPABILITIES).toContain("shell:exec");
   });
 
-  it("BUILT_IN_PLUGIN_CAPABILITIES has exactly 12 unique entries", () => {
-    expect(BUILT_IN_PLUGIN_CAPABILITIES).toHaveLength(12);
-    expect(new Set(BUILT_IN_PLUGIN_CAPABILITIES).size).toBe(12);
+  it("BUILT_IN_PLUGIN_CAPABILITIES has exactly 13 unique entries", () => {
+    expect(BUILT_IN_PLUGIN_CAPABILITIES).toHaveLength(13);
+    expect(new Set(BUILT_IN_PLUGIN_CAPABILITIES).size).toBe(13);
   });
 
   it("rejects null capabilities value", () => {
@@ -7054,7 +7055,7 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
     await expect(waiter).resolves.toBeUndefined();
   });
 
-  it("pushSnapshotTo() sends actions, panel kinds, toolbar buttons, menu items, and context-menu items to the target webContents", async () => {
+  it("pushSnapshotTo() sends actions, panel kinds, toolbar buttons, menu items, context-menu items, and agents to the target webContents", async () => {
     const service = new PluginService(tmpDir);
     await service.activateStartupFinishedPlugins();
     const send = vi.fn();
@@ -7062,7 +7063,7 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
 
     await service.pushSnapshotTo(wc);
 
-    expect(send).toHaveBeenCalledTimes(6);
+    expect(send).toHaveBeenCalledTimes(7);
     // Every replay goes through the EVENTS_PUSH channel — the same channel the
     // renderer hooks' persistent push listeners consume, so no renderer-side
     // changes are needed for the cold-restore path.
@@ -7076,6 +7077,7 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
     expect(names).toContain("plugin:menu-items-changed");
     expect(names).toContain("plugin:keybindings-changed");
     expect(names).toContain("plugin:context-menu-items-changed");
+    expect(names).toContain("plugin:agents-changed");
     // The keybindings replay is a full authoritative snapshot — the renderer
     // hook full-replaces its plugin bindings on every push, so `complete: true`
     // is consistent with that replace-all semantics.
@@ -7120,13 +7122,14 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
 
     await service.pushSnapshotTo(wc);
 
-    expect(send).toHaveBeenCalledTimes(6);
+    expect(send).toHaveBeenCalledTimes(7);
     const names = send.mock.calls.map((c) => (c[1] as { name?: string })?.name);
     expect(names).toContain("plugin:panel-kinds-changed");
     expect(names).toContain("plugin:toolbar-buttons-changed");
     expect(names).toContain("plugin:menu-items-changed");
     expect(names).toContain("plugin:keybindings-changed");
     expect(names).toContain("plugin:context-menu-items-changed");
+    expect(names).toContain("plugin:agents-changed");
   });
 
   it("pushSnapshotTo() skips a destroyed webContents", async () => {
@@ -7154,7 +7157,7 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
 
     await service.activateStartupFinishedPlugins();
     await inFlight;
-    expect(send).toHaveBeenCalledTimes(6);
+    expect(send).toHaveBeenCalledTimes(7);
   });
 
   it("pushSnapshotTo() does not send after dispose()", async () => {

--- a/electron/services/__tests__/PluginSettingsManager.scope.test.ts
+++ b/electron/services/__tests__/PluginSettingsManager.scope.test.ts
@@ -30,6 +30,7 @@ function manifestWith(settings: SettingDefinition[]): PluginManifest {
       experimental_mcpServers: [],
       forgeProviders: [],
       fileDecorationProviders: [],
+      agents: [],
       settings,
     },
   };

--- a/electron/services/plugin/PluginContributionBroadcaster.ts
+++ b/electron/services/plugin/PluginContributionBroadcaster.ts
@@ -5,6 +5,7 @@ import { getAllPluginToolbarButtonConfigs } from "../../../shared/config/toolbar
 import { getPluginMenuItems } from "../pluginMenuRegistry.js";
 import { getPluginKeybindings } from "../pluginKeybindingRegistry.js";
 import { getPluginContextMenuItems } from "../pluginContextMenuRegistry.js";
+import { getPluginAgentRegistry } from "../../../shared/config/pluginAgentRegistry.js";
 import type { PluginActionDescriptor } from "../../../shared/types/plugin.js";
 
 interface PluginContributionBroadcasterDeps {
@@ -65,6 +66,14 @@ export class PluginContributionBroadcaster {
   private contextMenuItemsBroadcastPending = false;
   /** Mirrors {@link menuItemsBroadcastComplete} for context-menu items. */
   private contextMenuItemsBroadcastComplete = false;
+  /**
+   * Same coalescing rationale as {@link menuItemsBroadcastPending}. Plugin
+   * agents are mutated only from `loadPlugin()` / `unloadPlugin()`, so the two
+   * call sites invoke {@link scheduleAgentsBroadcast} directly.
+   */
+  private agentsBroadcastPending = false;
+  /** Mirrors {@link menuItemsBroadcastComplete} for plugin agents. */
+  private agentsBroadcastComplete = false;
 
   constructor(deps: PluginContributionBroadcasterDeps) {
     this.deps = deps;
@@ -208,6 +217,32 @@ export class PluginContributionBroadcaster {
   }
 
   /**
+   * Same shape as {@link scheduleMenuItemsBroadcast}; see that method for the
+   * coalescing and `complete`-OR-accumulation rationale. Plugin agents are
+   * mutated only from `loadPlugin()` / `unloadPlugin()`.
+   */
+  scheduleAgentsBroadcast(complete: boolean): void {
+    if (this.deps.isDisposed()) return;
+    if (complete) this.agentsBroadcastComplete = true;
+    if (this.agentsBroadcastPending) return;
+    this.agentsBroadcastPending = true;
+    queueMicrotask(() => {
+      this.agentsBroadcastPending = false;
+      const drained = this.agentsBroadcastComplete;
+      this.agentsBroadcastComplete = false;
+      if (this.deps.isDisposed()) return;
+      this.broadcastPluginAgents(drained);
+    });
+  }
+
+  private broadcastPluginAgents(complete: boolean): void {
+    broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
+      name: "plugin:agents-changed",
+      payload: { agents: getPluginAgentRegistry(), complete },
+    });
+  }
+
+  /**
    * Replay the current actions / panel-kinds / toolbar-button snapshots to a
    * single target webContents. Used by the cold-start view-ready hook so a
    * freshly-restored WebContentsView (post-LRU eviction or first cold load on
@@ -249,6 +284,10 @@ export class PluginContributionBroadcaster {
       {
         name: "plugin:context-menu-items-changed",
         payload: { items: getPluginContextMenuItems(), complete: false },
+      },
+      {
+        name: "plugin:agents-changed",
+        payload: { agents: getPluginAgentRegistry(), complete: false },
       },
     ];
     for (const event of events) {

--- a/shared/config/__tests__/pluginAgentRegistry.test.ts
+++ b/shared/config/__tests__/pluginAgentRegistry.test.ts
@@ -123,4 +123,13 @@ describe("pluginAgentRegistry (issue #9560)", () => {
     expect(registry["acme-agent"]).toBeDefined();
     expect(registry["claude"]).toBeDefined();
   });
+
+  it("does not let a reserved id pollute the snapshot prototype", () => {
+    // The manifest schema rejects reserved ids, but the registry must also be
+    // defensive: a `__proto__` id must not reassign the snapshot's prototype.
+    registerPluginAgents("acme.plugin", [{ ...ACME_AGENT, id: "__proto__" }]);
+    const snapshot = getPluginAgentRegistry();
+    expect(Object.getPrototypeOf(snapshot)).toBeNull();
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
 });

--- a/shared/config/__tests__/pluginAgentRegistry.test.ts
+++ b/shared/config/__tests__/pluginAgentRegistry.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  registerPluginAgents,
+  unregisterPluginAgents,
+  getPluginAgentRegistry,
+  setPluginAgentRegistry,
+  clearPluginAgentRegistryForTests,
+} from "../pluginAgentRegistry.js";
+import {
+  getEffectiveAgentConfig,
+  getEffectiveRegistry,
+  isEffectivelyRegisteredAgent,
+  isBuiltInAgent,
+  setUserRegistry,
+} from "../agentRegistry.js";
+import { isBuiltInAgentId } from "../agentIds.js";
+import type { PluginAgentContribution } from "../../types/plugin.js";
+
+const ACME_AGENT: PluginAgentContribution = {
+  id: "acme-agent",
+  name: "Acme Agent",
+  command: "acme",
+  args: ["--flag"],
+  color: "#3366ff",
+  iconId: "terminal",
+};
+
+describe("pluginAgentRegistry (issue #9560)", () => {
+  beforeEach(() => {
+    clearPluginAgentRegistryForTests();
+    setUserRegistry({});
+  });
+  afterEach(() => {
+    clearPluginAgentRegistryForTests();
+    setUserRegistry({});
+  });
+
+  it("registers a plugin agent into the effective registry as an AgentConfig", () => {
+    registerPluginAgents("acme.plugin", [ACME_AGENT]);
+    const config = getEffectiveAgentConfig("acme-agent");
+    expect(config).toBeDefined();
+    expect(config?.name).toBe("Acme Agent");
+    expect(config?.command).toBe("acme");
+    expect(config?.args).toEqual(["--flag"]);
+    expect(config?.supportsContextInjection).toBe(false);
+    expect(isEffectivelyRegisteredAgent("acme-agent")).toBe(true);
+    // Plugin agents are not built-ins
+    expect(isBuiltInAgentId("acme-agent")).toBe(false);
+    expect(isBuiltInAgent("acme-agent")).toBe(false);
+  });
+
+  it("removes the agent on unregister", () => {
+    registerPluginAgents("acme.plugin", [ACME_AGENT]);
+    unregisterPluginAgents("acme.plugin");
+    expect(getEffectiveAgentConfig("acme-agent")).toBeUndefined();
+    expect(isEffectivelyRegisteredAgent("acme-agent")).toBe(false);
+  });
+
+  it("isolates per-plugin: unloading one plugin keeps another's agent", () => {
+    registerPluginAgents("acme.plugin", [ACME_AGENT]);
+    registerPluginAgents("other.plugin", [{ ...ACME_AGENT, id: "other-agent" }]);
+    unregisterPluginAgents("acme.plugin");
+    expect(getEffectiveAgentConfig("acme-agent")).toBeUndefined();
+    expect(getEffectiveAgentConfig("other-agent")).toBeDefined();
+  });
+
+  it("resolves a cross-plugin id collision first-registered-wins with a warning", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    registerPluginAgents("acme.plugin", [{ ...ACME_AGENT, name: "First" }]);
+    registerPluginAgents("dup.plugin", [{ ...ACME_AGENT, name: "Second" }]);
+    expect(getEffectiveAgentConfig("acme-agent")?.name).toBe("First");
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("never shadows a built-in even if a plugin registers the same id", () => {
+    // The schema rejects this at the manifest gate, but the registry must be
+    // defensive too: built-ins win in getEffectiveRegistry's merge order.
+    registerPluginAgents("acme.plugin", [{ ...ACME_AGENT, id: "claude", name: "Fake Claude" }]);
+    expect(getEffectiveAgentConfig("claude")?.name).not.toBe("Fake Claude");
+  });
+
+  it("ranks plugin agents below user-registry entries with the same id", () => {
+    registerPluginAgents("acme.plugin", [{ ...ACME_AGENT, name: "Plugin Wins?" }]);
+    setUserRegistry({
+      "acme-agent": {
+        id: "acme-agent",
+        name: "User Wins",
+        command: "acme",
+        color: "#ffffff",
+        iconId: "terminal",
+        supportsContextInjection: false,
+      },
+    });
+    expect(getEffectiveAgentConfig("acme-agent")?.name).toBe("User Wins");
+  });
+
+  it("replaces a plugin's agents on re-register (idempotent reload)", () => {
+    registerPluginAgents("acme.plugin", [ACME_AGENT, { ...ACME_AGENT, id: "acme-two" }]);
+    registerPluginAgents("acme.plugin", [ACME_AGENT]);
+    expect(getEffectiveAgentConfig("acme-agent")).toBeDefined();
+    expect(getEffectiveAgentConfig("acme-two")).toBeUndefined();
+  });
+
+  it("setPluginAgentRegistry replaces the snapshot wholesale (renderer mirror path)", () => {
+    setPluginAgentRegistry({
+      "mirror-agent": {
+        id: "mirror-agent",
+        name: "Mirror",
+        command: "mirror",
+        color: "#000000",
+        iconId: "terminal",
+        supportsContextInjection: false,
+      },
+    });
+    expect(getEffectiveAgentConfig("mirror-agent")).toBeDefined();
+    expect(getPluginAgentRegistry()["mirror-agent"]?.name).toBe("Mirror");
+  });
+
+  it("getEffectiveRegistry includes plugin agents alongside built-ins", () => {
+    registerPluginAgents("acme.plugin", [ACME_AGENT]);
+    const registry = getEffectiveRegistry();
+    expect(registry["acme-agent"]).toBeDefined();
+    expect(registry["claude"]).toBeDefined();
+  });
+});

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -546,6 +546,7 @@ import { config as kiroConfig } from "./agents/kiro.js";
 // `BUILT_IN_AGENT_IDS` directly — but we mirror the order for readability.
 import { BUILT_IN_AGENT_IDS, isBuiltInAgentId } from "./agentIds.js";
 import type { BuiltInAgentId } from "./agentIds.js";
+import { getPluginAgentRegistry } from "./pluginAgentRegistry.js";
 
 /**
  * Mapping from `models.dev/api.json` provider keys to our agent IDs. The
@@ -601,7 +602,10 @@ export function getUserRegistry(): Record<string, AgentConfig> {
 }
 
 export function getEffectiveRegistry(): Record<string, AgentConfig> {
-  return { ...userRegistry, ...AGENT_REGISTRY };
+  // Merge order is priority order (later spreads win): plugin agents are the
+  // lowest tier (additive, never shadowing), user-registry overlays them, and
+  // built-ins always win last so a plugin or user can never patch a built-in.
+  return { ...getPluginAgentRegistry(), ...userRegistry, ...AGENT_REGISTRY };
 }
 
 export function getEffectiveAgentIds(): string[] {

--- a/shared/config/pluginAgentRegistry.ts
+++ b/shared/config/pluginAgentRegistry.ts
@@ -1,0 +1,113 @@
+import type { AgentConfig } from "./agentRegistry.js";
+import type { PluginAgentContribution } from "../types/plugin.js";
+
+/**
+ * Process-global registry of plugin-contributed agents (#9560).
+ *
+ * Two population paths converge on this module, one per process:
+ *
+ * - **Main** calls {@link registerPluginAgents} / {@link unregisterPluginAgents}
+ *   from `PluginService` load/unload. Entries are tracked per-plugin in
+ *   {@link byPlugin} (a compound map) so unloading plugin A never evicts an
+ *   agent that plugin B also declared with the same id. The flattened
+ *   {@link snapshot} is rebuilt on every mutation.
+ * - **Renderer** (a separate V8 context) never registers agents directly; it
+ *   mirrors main's authoritative set by calling {@link setPluginAgentRegistry}
+ *   with the flattened record carried on the `plugin:agents-changed` broadcast.
+ *
+ * `getEffectiveRegistry()` in `./agentRegistry.ts` merges {@link snapshot} at
+ * the lowest priority (below user-registry and built-in agents), so plugin
+ * agents are purely additive for new IDs and can never shadow a built-in.
+ */
+const byPlugin = new Map<string, Map<string, AgentConfig>>();
+
+let snapshot: Record<string, AgentConfig> = {};
+
+function contributionToAgentConfig(contribution: PluginAgentContribution): AgentConfig {
+  // Minimal tier: surface only the launch-relevant fields. `detection` is
+  // validated at the manifest gate but deliberately not mapped here — the
+  // full-tracking tier wires it into the PTY matcher separately.
+  return {
+    id: contribution.id,
+    name: contribution.name,
+    command: contribution.command,
+    args: contribution.args,
+    color: contribution.color,
+    iconId: contribution.iconId,
+    supportsContextInjection: contribution.supportsContextInjection ?? false,
+  };
+}
+
+/**
+ * Rebuild the flattened {@link snapshot} from {@link byPlugin}. Iteration
+ * follows insertion order (plugin load order, then per-plugin contribution
+ * order), so a cross-plugin id collision resolves first-registered-wins with a
+ * warning rather than silently clobbering.
+ */
+function rebuildSnapshot(): void {
+  const next: Record<string, AgentConfig> = {};
+  for (const [pluginId, agents] of byPlugin) {
+    for (const [agentId, config] of agents) {
+      if (Object.prototype.hasOwnProperty.call(next, agentId)) {
+        console.warn(
+          `[pluginAgentRegistry] Plugin "${pluginId}" declares agent id "${agentId}" already registered by another plugin — ignoring the later registration`
+        );
+        continue;
+      }
+      next[agentId] = config;
+    }
+  }
+  snapshot = next;
+}
+
+/**
+ * Register the agents one plugin contributes. Replaces any prior set for the
+ * same `pluginId` (idempotent reload). Pass an empty array to clear the
+ * plugin's entries. Main-process only.
+ */
+export function registerPluginAgents(
+  pluginId: string,
+  contributions: PluginAgentContribution[]
+): void {
+  if (typeof pluginId !== "string" || pluginId.length === 0) return;
+  if (!Array.isArray(contributions) || contributions.length === 0) {
+    if (byPlugin.delete(pluginId)) rebuildSnapshot();
+    return;
+  }
+  const agents = new Map<string, AgentConfig>();
+  for (const contribution of contributions) {
+    agents.set(contribution.id, Object.freeze(contributionToAgentConfig(contribution)));
+  }
+  byPlugin.set(pluginId, agents);
+  rebuildSnapshot();
+}
+
+/** Remove every agent contributed by `pluginId`. Idempotent. Main-process only. */
+export function unregisterPluginAgents(pluginId: string): void {
+  if (typeof pluginId !== "string" || pluginId.length === 0) return;
+  if (byPlugin.delete(pluginId)) rebuildSnapshot();
+}
+
+/**
+ * The flattened plugin-agent record consulted by `getEffectiveRegistry()` and
+ * broadcast to the renderer. Returns the live snapshot reference — callers must
+ * not mutate it.
+ */
+export function getPluginAgentRegistry(): Record<string, AgentConfig> {
+  return snapshot;
+}
+
+/**
+ * Replace the flattened snapshot wholesale. Used by the renderer to mirror the
+ * `plugin:agents-changed` broadcast; the renderer has no per-plugin tracking of
+ * its own. No-op-safe with an empty record.
+ */
+export function setPluginAgentRegistry(record: Record<string, AgentConfig>): void {
+  snapshot = record ?? {};
+}
+
+/** Test-isolation helper: clear both the per-plugin map and the snapshot. */
+export function clearPluginAgentRegistryForTests(): void {
+  byPlugin.clear();
+  snapshot = {};
+}

--- a/shared/config/pluginAgentRegistry.ts
+++ b/shared/config/pluginAgentRegistry.ts
@@ -45,7 +45,10 @@ function contributionToAgentConfig(contribution: PluginAgentContribution): Agent
  * warning rather than silently clobbering.
  */
 function rebuildSnapshot(): void {
-  const next: Record<string, AgentConfig> = {};
+  // Null-prototype object so a reserved id like `__proto__` is written as an own
+  // property rather than reassigning the prototype (defense in depth — the
+  // manifest schema also rejects reserved ids before they reach here).
+  const next: Record<string, AgentConfig> = Object.create(null) as Record<string, AgentConfig>;
   for (const [pluginId, agents] of byPlugin) {
     for (const [agentId, config] of agents) {
       if (Object.prototype.hasOwnProperty.call(next, agentId)) {

--- a/shared/types/__tests__/plugin-sdk.test.ts
+++ b/shared/types/__tests__/plugin-sdk.test.ts
@@ -141,6 +141,7 @@ describe("plugin-sdk boundary", () => {
           contextMenus: [],
           forgeProviders: [],
           fileDecorationProviders: [],
+          agents: [],
         },
       };
       expectTypeOf(manifest.name).toEqualTypeOf<string>();

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1514,6 +1514,13 @@ export interface ElectronAPI extends GeneratedElectronAPI {
         kinds: import("../../config/panelKindRegistry.js").PanelKindConfig[];
       }) => void
     ): () => void;
+    /** Subscribe to plugin agent registry changes. Returns a cleanup. */
+    onAgentsChanged(
+      callback: (payload: {
+        agents: Record<string, import("../../config/agentRegistry.js").AgentConfig>;
+        complete: boolean;
+      }) => void
+    ): () => void;
     /** Subscribe to plugin toolbar button registry changes. Returns a cleanup. */
     onToolbarButtonsChanged(
       callback: (payload: {

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -359,6 +359,9 @@ export interface GeneratedElectronAPI {
     getActions(
       ...args: IpcInvokeMap["plugin:actions-get"]["args"]
     ): Promise<IpcInvokeMap["plugin:actions-get"]["result"]>;
+    getAgents(
+      ...args: IpcInvokeMap["plugin:agents-get"]["args"]
+    ): Promise<IpcInvokeMap["plugin:agents-get"]["result"]>;
     getAuditConfig(
       ...args: IpcInvokeMap["plugin:get-audit-config"]["args"]
     ): Promise<IpcInvokeMap["plugin:get-audit-config"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -623,6 +623,10 @@ export interface GeneratedIpcInvokeMap {
     args: [pluginId: string, actionId: string];
     result: void;
   };
+  "plugin:agents-get": {
+    args: [];
+    result: Record<string, import("../../config/agentRegistry.js").AgentConfig>;
+  };
   "plugin:check-for-update": {
     args: [pluginId: string];
     result: import("../plugin.js").PluginCheckUpdateResult;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1907,6 +1907,16 @@ export interface IpcEventMap {
     complete: boolean;
   };
 
+  // Plugin agent registry events (main → renderer). Carries the flattened
+  // plugin-agent record so the renderer can mirror main's effective registry.
+  // Same `complete` flag semantics as toolbar buttons / menu items: true for an
+  // authoritative post-unload snapshot, false for partial/growing load-time
+  // broadcasts.
+  "plugin:agents-changed": {
+    agents: Record<string, import("../../config/agentRegistry.js").AgentConfig>;
+    complete: boolean;
+  };
+
   // Plugin file-decoration invalidation (main → renderer). Carries only the
   // changed scope (optionally narrowed to `paths`) — never decoration data.
   // The renderer re-pulls fresh decorations via `plugin:file-decorations-get`.
@@ -2000,6 +2010,8 @@ export type IpcEventBusMap = Pick<
   | "plugin:keybindings-changed"
   // Plugin context-menu item registry (global broadcast)
   | "plugin:context-menu-items-changed"
+  // Plugin agent registry (global broadcast)
+  | "plugin:agents-changed"
   // Plugin file-decoration invalidation (global broadcast)
   | "plugin:decorations-changed"
   // Plugin provenance record changed (global broadcast)

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -45,6 +45,7 @@ export const BUILT_IN_PLUGIN_CAPABILITIES = [
   "network:fetch",
   "agent:invoke",
   "agent:read",
+  "agent:register",
   "git:read",
   "git:write",
   "clipboard:read",
@@ -187,6 +188,52 @@ export interface PluginManifestScopes {
   fs?: PluginFsScope;
 }
 
+/**
+ * Pattern-based output-detection config a plugin may supply alongside an agent
+ * contribution (#9560). The shape mirrors the safe subset of the built-in
+ * `AgentDetectionConfig`. It is **validated** at manifest-parse time (each
+ * pattern is length-bounded, must compile, and must not use backreferences,
+ * lookarounds, or nested quantifiers — see `electron/schemas/plugin.ts`) but is
+ * **not yet wired** into the live PTY matcher: the minimal tier launches plugin
+ * agents as named, untracked terminals. The field exists now so manifests stay
+ * forward-compatible with the full-tracking tier without the strict schema
+ * rejecting an unknown key. Bad input degrades to a generic shell rather than
+ * breaking detection for other terminals.
+ */
+export interface PluginAgentDetectionContribution {
+  primaryPatterns?: string[];
+  fallbackPatterns?: string[];
+  promptPatterns?: string[];
+  bootCompletePatterns?: string[];
+  completionPatterns?: string[];
+  scanLineCount?: number;
+  debounceMs?: number;
+}
+
+/**
+ * A plugin-contributed agent entry (#9560). Lets a plugin teach Daintree about
+ * a launchable agent CLI it doesn't ship, so the CLI shows up as a named,
+ * selectable agent rather than a generic shell. Requires the `agent:register`
+ * capability (enforced at the manifest gate). Plugin agent IDs are additive for
+ * new IDs only — a contribution whose `id` collides with a built-in is rejected
+ * at parse time, and built-in entries always shadow plugin entries in
+ * `getEffectiveRegistry`. Cross-plugin ID conflicts resolve first-registered-wins.
+ *
+ * The minimal tier surfaces `id`, `name`, `command`, `args`, `color`, `iconId`,
+ * and `supportsContextInjection`; `detection` is reserved for the full-tracking
+ * tier (see {@link PluginAgentDetectionContribution}).
+ */
+export interface PluginAgentContribution {
+  id: string;
+  name: string;
+  command: string;
+  args?: string[];
+  color: string;
+  iconId: string;
+  supportsContextInjection?: boolean;
+  detection?: PluginAgentDetectionContribution;
+}
+
 export interface PluginManifest {
   name: string;
   version: string;
@@ -223,6 +270,13 @@ export interface PluginManifest {
     experimental_mcpServers: McpServerContribution[];
     forgeProviders: ForgeProviderContribution[];
     fileDecorationProviders: FileDecorationContribution[];
+    /**
+     * Plugin-contributed launchable agents (#9560). Each entry registers an
+     * {@link PluginAgentContribution} into the effective agent registry at load
+     * time so the CLI is selectable as a named agent. Requires the
+     * `agent:register` capability. Empty unless the plugin opts in.
+     */
+    agents: PluginAgentContribution[];
     /**
      * Declared plugin settings. Reserved for F29 — absent from parsed manifests
      * until that schema lands, so `host.settings.set()` accepts any key for now.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import { useGitHubRateLimit } from "./hooks/useGitHubRateLimit";
 import { useActionRegistry } from "./hooks/useActionRegistry";
 import { usePluginActions } from "./hooks/usePluginActions";
 import { usePluginPanelKinds } from "./hooks/usePluginPanelKinds";
+import { usePluginAgents } from "./hooks/usePluginAgents";
 import { usePluginKeybindings } from "./hooks/usePluginKeybindings";
 import { useUpdateListener } from "./hooks/useUpdateListener";
 import { useStoreUpdateListener } from "./hooks/useStoreUpdateListener";
@@ -670,6 +671,7 @@ function AppInner() {
 
   usePluginActions();
   usePluginPanelKinds();
+  usePluginAgents();
   usePluginKeybindings();
 
   useMenuActions();

--- a/src/components/Plugin/__tests__/PluginManagerDialog.test.tsx
+++ b/src/components/Plugin/__tests__/PluginManagerDialog.test.tsx
@@ -45,6 +45,7 @@ function makePlugin(overrides: Partial<LoadedPluginInfo> = {}): LoadedPluginInfo
         contextMenus: [],
         forgeProviders: [],
         fileDecorationProviders: [],
+        agents: [],
       },
     },
     dir: "/plugins/acme.demo",

--- a/src/components/Settings/__tests__/PluginSettingsForm.test.tsx
+++ b/src/components/Settings/__tests__/PluginSettingsForm.test.tsx
@@ -34,6 +34,7 @@ function makePlugin(settings: SettingDefinition[]): LoadedPluginInfo {
         experimental_mcpServers: [],
         forgeProviders: [],
         fileDecorationProviders: [],
+        agents: [],
         settings,
       },
     },

--- a/src/components/Settings/__tests__/PluginsTab.test.tsx
+++ b/src/components/Settings/__tests__/PluginsTab.test.tsx
@@ -36,6 +36,7 @@ function makePlugin(name: string): LoadedPluginInfo {
         contextMenus: [],
         forgeProviders: [],
         fileDecorationProviders: [],
+        agents: [],
       },
     },
     dir: `/plugins/${name}`,

--- a/src/hooks/usePluginAgents.ts
+++ b/src/hooks/usePluginAgents.ts
@@ -1,0 +1,47 @@
+import { useEffect } from "react";
+import { setPluginAgentRegistry } from "@shared/config/pluginAgentRegistry";
+import { logWarn } from "@/utils/logger";
+
+/**
+ * Mirror the main process's plugin-agent registry into the renderer's own
+ * (separate V8 context) copy so `getEffectiveAgentConfig` resolves plugin
+ * agents for icon/name/color display and launch (#9560).
+ *
+ * Pull-on-mount is a safety net for cached `WebContentsView`s that may have
+ * missed a broadcast; push-on-change is authoritative — once a push arrives,
+ * any later-resolving mount-time pull is dropped to avoid rolling back state
+ * (mirrors {@link usePluginPanelKinds}). The broadcast always carries the full
+ * plugin-agent snapshot, so the renderer replaces wholesale rather than
+ * reconciling per-plugin.
+ */
+export function usePluginAgents(): void {
+  useEffect(() => {
+    let disposed = false;
+    let pushReceived = false;
+
+    const electron = typeof window !== "undefined" ? window.electron : undefined;
+    if (!electron?.plugin) return;
+
+    void electron.plugin
+      .getAgents()
+      .then((agents) => {
+        if (disposed || pushReceived) return;
+        setPluginAgentRegistry(agents);
+      })
+      .catch((err: unknown) => {
+        logWarn("[PluginAgents] Failed to fetch initial plugin agents", { error: err });
+      });
+
+    const cleanup = electron.plugin.onAgentsChanged((payload) => {
+      if (disposed) return;
+      pushReceived = true;
+      setPluginAgentRegistry(payload.agents);
+    });
+
+    return () => {
+      disposed = true;
+      cleanup();
+      setPluginAgentRegistry({});
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary

- Adds a new `contributes.agents` contribution point, gated behind the `agent:register` capability, so plugins can register named, launchable agent CLIs into the effective agent registry
- Registry merging keeps precedence unambiguous: built-ins win over user-registry, user-registry wins over plugin agents — plugins are strictly additive and can't shadow anything already registered
- Zod validation in the plugin schema guards detection patterns against catastrophic backtracking (rejects backreferences, lookarounds, quantified alternation, nested quantifiers) before they can touch the live PTY matcher

Resolves #9560

## Changes

- `shared/types/plugin.ts` — new `agent:register` capability + `PluginAgentContribution` manifest types
- `shared/config/pluginAgentRegistry.ts` — per-plugin compound-keyed registry; merged into `getEffectiveRegistry()` at lowest priority
- `electron/schemas/plugin.ts` — Zod validation with ReDoS guards, capability gate, built-in id-collision rejection, reserved-id rejection
- `electron/services/PluginService.ts` — load/unload wiring with `runUnloadStep` cleanup and coalesced broadcast
- `electron/services/plugin/PluginContributionBroadcaster.ts` — new `plugin:agents-changed` broadcast
- IPC: `plugin:agents-get` handler, preload exposure, `electron.d.ts` types
- `src/hooks/usePluginAgents.ts` — renderer hook that subscribes to the broadcast and hydrates from the IPC call
- `docs/plugins/contribution-points.md` — Agents contribution point documented, Tier 1/2 split noted

Tier 2 (relaxing the `isBuiltInAgentId` gate in `TerminalAgentDetection.ts`, `AGENT_CLI_NAMES`, and pty-host registry sync) is deliberately deferred. The detection-config schema is validated now for forward-compatibility but not yet wired into the live matcher.

## Testing

`tsc` clean, `eslint` clean, `prettier` clean. Three new test suites:

- `shared/config/__tests__/pluginAgentRegistry.test.ts` — registry merge logic and priority ordering
- `electron/schemas/__tests__/agentContribution.test.ts` — schema validation including ReDoS bypass cases, reserved-id rejection, and malformed detection pattern rejection
- `electron/services/__tests__/PluginService.integration.test.ts` — load/unload lifecycle + broadcast assertions

28 unit + 43 integration tests all green locally.