### PR TITLE
feat(plugins): add daintree:// deep-link scheme for plugin install and open

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -32,6 +32,13 @@ module.exports = async function () {
     asar: true,
     appId: "org.daintree.app",
     productName: "Daintree",
+    // Register the `daintree://` deep-link scheme at the OS level (#9559).
+    // electron-builder injects `CFBundleURLTypes` on macOS, an HKCU registry
+    // write in the NSIS installer (per-user, no elevation), and
+    // `x-scheme-handler/daintree` into the Linux `.desktop` entry. External
+    // pages and catalog entries deep-link into the plugin install / open flow;
+    // installs still route through the in-app confirm + security gates.
+    protocols: [{ name: "Daintree", schemes: ["daintree"] }],
     publish: [publishEntry],
     electronUpdaterCompatibility: ">=2.16",
     npmRebuild: true,

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -40,6 +40,7 @@ import { markPerformance } from "../../../utils/performance.js";
 import { PERF_MARKS } from "../../../../shared/perf/marks.js";
 import { consumePrefetchedHydrateResult } from "../../../services/prefetchHydrateCache.js";
 import { getWindowForWebContents } from "../../../window/webContentsRegistry.js";
+import { notifyAppViewPainted } from "../../../setup/deepLinkInstall.js";
 import { resolveScopedProjectForIpcContext } from "../../projectContext.js";
 import type { HandlerDependencies, IpcContext } from "../../types.js";
 
@@ -742,6 +743,9 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
           deps?.windowRegistry?.getByWindowId(senderWindow.id)?.services?.projectViewManager) ??
         deps?.projectViewManager;
       pvm?.signalViewPainted(ctx.webContentsId);
+      // Flush any pending `daintree://` deep link now the view has painted — its
+      // renderer-side listener is guaranteed mounted at this point (#9559).
+      notifyAppViewPainted(ctx.event.sender);
     })
   );
 

--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -64,6 +64,7 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
   "plugin:agents-changed": "external",
   "plugin:decorations-changed": "external",
   "plugin:provenance-changed": "external",
+  "plugin:deep-link": "external",
   "terminal:exit": "external",
   "terminal:spawn-result": "external",
 } as const satisfies Record<keyof IpcEventBusMap, "bus" | "external">;

--- a/electron/lifecycle/appLifecycle.ts
+++ b/electron/lifecycle/appLifecycle.ts
@@ -11,6 +11,7 @@ import { CHANNELS } from "../ipc/channels.js";
 import { setSignalShutdown, setSafetyBeltTimer } from "./signalShutdownState.js";
 import { isWindowRecreating } from "./windowRecreationState.js";
 import { SAFETY_BELT_TIMEOUT_MS } from "./shutdownConfig.js";
+import { extractDaintreeUrl, handleDaintreeUrl } from "../setup/deepLinkInstall.js";
 
 let pendingCliPath: string | null = null;
 
@@ -221,6 +222,13 @@ export function registerAppLifecycleHandlers(opts: AppLifecycleOptions): void {
     const liveWindow = mainWindow && !mainWindow.isDestroyed() ? mainWindow : null;
     const cliPath = extractCliPath(commandLine);
     const dntrPaths = extractDntrPaths(commandLine, workingDirectory);
+    // Windows/Linux: a warm `daintree://` deep link arrives as an argv entry on
+    // the relaunched second instance. Route it through the same handler as the
+    // macOS `open-url` path — it targets the primary window itself.
+    const daintreeUrl = extractDaintreeUrl(commandLine);
+    if (daintreeUrl) {
+      handleDaintreeUrl(daintreeUrl);
+    }
 
     if (cliPath) {
       if (liveWindow && opts.onCreateWindowForPath) {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -21,9 +21,11 @@ import { enforceIpcSenderValidation, setupPermissionLockdown } from "./setup/sec
 import {
   registerAppProtocol,
   registerDaintreeFileProtocol,
+  registerDeepLinkProtocolClient,
   registerPluginProtocol,
   setupWebviewCSP,
 } from "./setup/protocols.js";
+import { activateDeepLinkHandler } from "./setup/deepLinkInstall.js";
 import {
   registerAppLifecycleHandlers,
   registerWindowSessionEndHandler,
@@ -448,6 +450,7 @@ if (!gotTheLock) {
         markPerformance(PERF_MARKS.EARLY_PATH_REFRESH_COMPLETE);
       });
       setupPermissionLockdown();
+      registerDeepLinkProtocolClient();
       registerAppProtocol(distPath);
       registerDaintreeFileProtocol();
       const { pluginService } = await import("./services/PluginService.js");
@@ -457,6 +460,12 @@ if (!gotTheLock) {
       // that PluginService can install them. Fire-and-forget — install runs
       // concurrently with the rest of startup. #9293
       void activateOpenFileInstaller(pluginService);
+      // Wire the `daintree://` deep-link path (#9559): take over live macOS
+      // `open-url` events and drain any cold-launch URL (queued `open-url` on
+      // macOS, `process.argv` on Windows/Linux). Routed to the primary window
+      // once it paints, where the Plugin Manager opens — installs still go
+      // through the existing confirm/security gates, never silently.
+      activateDeepLinkHandler(windowRegistry);
       setupWebviewCSP();
       // Prime the hydrate prefetch cache for the last-active project so the
       // renderer's first `app:boot` invoke resolves as a cache hit instead of

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -670,6 +670,17 @@ type EventBusSubscriber = (payload: unknown) => void;
 const _eventBusSubscribers = new Map<keyof IpcEventBusMap, Set<EventBusSubscriber>>();
 let _eventBusWired = false;
 
+// Events safe to replay to a late first subscriber. A `daintree://` deep link
+// (#9559) is delivered by main on the primary view's first paint — which fires
+// from the Suspense *parent* before `AppInner` (the component that owns the
+// subscription) has mounted past its `app:boot` gate. Without a replay buffer
+// the intent would land with no subscriber and be dropped on a slow cold
+// launch. Only latest-wins, single-shot, low-frequency signals belong here —
+// replaying a high-frequency or stale state event to a late subscriber would be
+// wrong.
+const _eventBusReplayable: ReadonlySet<keyof IpcEventBusMap> = new Set(["plugin:deep-link"]);
+const _eventBusBuffered = new Map<keyof IpcEventBusMap, unknown>();
+
 function _ensureEventBusWired(): void {
   if (_eventBusWired) return;
   _eventBusWired = true;
@@ -677,7 +688,14 @@ function _ensureEventBusWired(): void {
     if (!envelope || typeof envelope !== "object") return;
     if (typeof envelope.name !== "string") return;
     const subs = _eventBusSubscribers.get(envelope.name);
-    if (!subs || subs.size === 0) return;
+    if (!subs || subs.size === 0) {
+      // No subscriber yet: buffer replayable events so a late-mounting
+      // subscriber (e.g. one behind a Suspense boundary) still receives them.
+      if (_eventBusReplayable.has(envelope.name)) {
+        _eventBusBuffered.set(envelope.name, envelope.payload);
+      }
+      return;
+    }
     // Snapshot before iterating: a subscriber may unsubscribe itself or
     // another subscriber during dispatch; iterating the live Set would make
     // delivery to surviving subscribers depend on insertion order.
@@ -703,6 +721,17 @@ function _eventBusOn<K extends keyof IpcEventBusMap>(
   }
   const wrapped = callback as EventBusSubscriber;
   set.add(wrapped);
+  // Replay a buffered event to the first subscriber (see _eventBusReplayable) so
+  // a signal delivered before this subscriber mounted isn't lost.
+  if (_eventBusBuffered.has(name)) {
+    const buffered = _eventBusBuffered.get(name);
+    _eventBusBuffered.delete(name);
+    try {
+      wrapped(buffered);
+    } catch (err) {
+      console.error("[Preload] events:push replay threw for", name, err);
+    }
+  }
   return () => {
     const current = _eventBusSubscribers.get(name);
     if (!current) return;

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -139,6 +139,7 @@ import type {
   MenuItemContribution,
   PluginKeybindingDescriptor,
   ContextMenuContribution,
+  PluginDeepLinkIntent,
 } from "../shared/types/plugin.js";
 import type { PanelKindConfig } from "../shared/config/panelKindRegistry.js";
 import type { ToolbarButtonConfig } from "../shared/config/toolbarButtonRegistry.js";
@@ -2515,6 +2516,8 @@ const api: ElectronAPI = {
     ) => _eventBusOn("plugin:context-menu-items-changed", callback),
     onDecorationsChanged: (callback: (payload: { scope: string; paths?: string[] }) => void) =>
       _eventBusOn("plugin:decorations-changed", callback),
+    onDeepLink: (callback: (intent: PluginDeepLinkIntent) => void) =>
+      _eventBusOn("plugin:deep-link", callback),
   },
 
   pluginMcp: buildPluginMcpPreloadBindings(_unwrappingInvoke),

--- a/electron/setup/__tests__/deepLinkInstall.test.ts
+++ b/electron/setup/__tests__/deepLinkInstall.test.ts
@@ -24,17 +24,20 @@ vi.mock("../../schemas/plugin.js", () => ({
 type FakeWebContents = {
   id: number;
   send: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
   once: ReturnType<typeof vi.fn>;
   isDestroyed: () => boolean;
 };
 
 function makeWebContents(id: number): FakeWebContents {
-  return { id, send: vi.fn(), once: vi.fn(), isDestroyed: () => false };
+  return { id, send: vi.fn(), on: vi.fn(), once: vi.fn(), isDestroyed: () => false };
 }
 
-function makeRegistry(wc: FakeWebContents | null) {
+// The registry resolves the primary window to whichever webContents
+// `getAppWebContents` is mocked to return.
+function makeRegistry(primary: boolean) {
   return {
-    getPrimary: () => (wc ? { browserWindow: { isDestroyed: () => false } } : undefined),
+    getPrimary: () => (primary ? { browserWindow: { isDestroyed: () => false } } : undefined),
   };
 }
 
@@ -130,7 +133,7 @@ describe("handleDaintreeUrl / notifyAppViewPainted", () => {
     mod._resetDeepLinkStateForTest();
     const wc = makeWebContents(7);
     registryMock.getAppWebContents.mockReturnValue(wc);
-    mod.activateDeepLinkHandler(makeRegistry(wc) as never);
+    mod.activateDeepLinkHandler(makeRegistry(true) as never);
 
     // Paint first (warm), then the deep link arrives.
     mod.notifyAppViewPainted(wc as never);
@@ -147,7 +150,7 @@ describe("handleDaintreeUrl / notifyAppViewPainted", () => {
     mod._resetDeepLinkStateForTest();
     const wc = makeWebContents(9);
     registryMock.getAppWebContents.mockReturnValue(wc);
-    mod.activateDeepLinkHandler(makeRegistry(wc) as never);
+    mod.activateDeepLinkHandler(makeRegistry(true) as never);
 
     // Deep link arrives before paint — nothing delivered yet.
     mod.handleDaintreeUrl("daintree://plugin/install?url=https://example.com/p.dntr");
@@ -171,7 +174,7 @@ describe("handleDaintreeUrl / notifyAppViewPainted", () => {
     mod._resetDeepLinkStateForTest();
     const wc = makeWebContents(11);
     registryMock.getAppWebContents.mockReturnValue(wc);
-    mod.activateDeepLinkHandler(makeRegistry(wc) as never);
+    mod.activateDeepLinkHandler(makeRegistry(true) as never);
     mod.notifyAppViewPainted(wc as never);
 
     mod.handleDaintreeUrl("daintree://plugin/install?url=javascript:alert(1)");
@@ -185,7 +188,7 @@ describe("handleDaintreeUrl / notifyAppViewPainted", () => {
     const wc = makeWebContents(13);
     registryMock.getAppWebContents.mockReturnValue(wc);
 
-    mod.activateDeepLinkHandler(makeRegistry(wc) as never);
+    mod.activateDeepLinkHandler(makeRegistry(true) as never);
     expect(envMock.clearPendingDaintreeUrls).toHaveBeenCalledOnce();
 
     // Held until paint, then delivered.
@@ -194,5 +197,51 @@ describe("handleDaintreeUrl / notifyAppViewPainted", () => {
       name: "plugin:deep-link",
       payload: { action: "open", pluginId: "acme.notes" },
     });
+  });
+
+  it("does not deliver to a non-primary view that paints first (lesson #9533)", async () => {
+    const mod = await import("../deepLinkInstall.js");
+    mod._resetDeepLinkStateForTest();
+    const primary = makeWebContents(1);
+    const secondary = makeWebContents(2);
+    registryMock.getAppWebContents.mockReturnValue(primary);
+    mod.activateDeepLinkHandler(makeRegistry(true) as never);
+
+    mod.handleDaintreeUrl("daintree://plugin/open?id=acme.notes");
+    // A non-primary view paints first — the intent stays queued for the primary.
+    mod.notifyAppViewPainted(secondary as never);
+    expect(secondary.send).not.toHaveBeenCalled();
+    expect(primary.send).not.toHaveBeenCalled();
+
+    // The primary paints — now it delivers, to the primary only.
+    mod.notifyAppViewPainted(primary as never);
+    expect(primary.send).toHaveBeenCalledTimes(1);
+    expect(secondary.send).not.toHaveBeenCalled();
+  });
+
+  it("re-holds the intent after a reload drops the painted id", async () => {
+    const mod = await import("../deepLinkInstall.js");
+    mod._resetDeepLinkStateForTest();
+    const wc = makeWebContents(5);
+    registryMock.getAppWebContents.mockReturnValue(wc);
+    mod.activateDeepLinkHandler(makeRegistry(true) as never);
+
+    // Paint, then capture the `did-start-loading` handler wired on first paint.
+    mod.notifyAppViewPainted(wc as never);
+    const didStartLoading = wc.on.mock.calls.find(([evt]) => evt === "did-start-loading")?.[1] as
+      | (() => void)
+      | undefined;
+    expect(didStartLoading).toBeTypeOf("function");
+
+    // Reload: the renderer's listener unmounts; the id leaves the painted set.
+    didStartLoading?.();
+
+    // A deep link now is held (not delivered to the unmounted renderer)…
+    mod.handleDaintreeUrl("daintree://plugin/open?id=acme.notes");
+    expect(wc.send).not.toHaveBeenCalled();
+
+    // …until the fresh paint flushes it.
+    mod.notifyAppViewPainted(wc as never);
+    expect(wc.send).toHaveBeenCalledTimes(1);
   });
 });

--- a/electron/setup/__tests__/deepLinkInstall.test.ts
+++ b/electron/setup/__tests__/deepLinkInstall.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const envMock = vi.hoisted(() => ({
+  getPendingDaintreeUrls: vi.fn<() => string[]>(() => []),
+  clearPendingDaintreeUrls: vi.fn(),
+  setDaintreeUrlConsumer: vi.fn<(c: ((url: string) => void) | null) => void>(),
+}));
+
+const registryMock = vi.hoisted(() => ({
+  getAppWebContents: vi.fn(),
+}));
+
+vi.mock("../deepLinkUrlQueue.js", () => envMock);
+vi.mock("../../window/webContentsRegistry.js", () => registryMock);
+vi.mock("../../ipc/channels.js", () => ({
+  CHANNELS: { EVENTS_PUSH: "events:push" },
+}));
+vi.mock("../../schemas/plugin.js", () => ({
+  // Mirror the real pattern so id validation is exercised without pulling the
+  // zod-backed schema module into the unit test.
+  SCOPED_PLUGIN_NAME_PATTERN: /^[a-z0-9]+(?:-[a-z0-9]+)*\.[a-z0-9]+(?:-[a-z0-9]+)*$/,
+}));
+
+type FakeWebContents = {
+  id: number;
+  send: ReturnType<typeof vi.fn>;
+  once: ReturnType<typeof vi.fn>;
+  isDestroyed: () => boolean;
+};
+
+function makeWebContents(id: number): FakeWebContents {
+  return { id, send: vi.fn(), once: vi.fn(), isDestroyed: () => false };
+}
+
+function makeRegistry(wc: FakeWebContents | null) {
+  return {
+    getPrimary: () => (wc ? { browserWindow: { isDestroyed: () => false } } : undefined),
+  };
+}
+
+describe("parseDaintreeUrl", () => {
+  it("parses a valid install link", async () => {
+    const { parseDaintreeUrl } = await import("../deepLinkInstall.js");
+    expect(
+      parseDaintreeUrl("daintree://plugin/install?url=https%3A%2F%2Fexample.com%2Fp.dntr")
+    ).toEqual({ action: "install", url: "https://example.com/p.dntr" });
+  });
+
+  it("parses a plaintext http install link (gate enforced downstream)", async () => {
+    const { parseDaintreeUrl } = await import("../deepLinkInstall.js");
+    expect(parseDaintreeUrl("daintree://plugin/install?url=http://example.com/p.dntr")).toEqual({
+      action: "install",
+      url: "http://example.com/p.dntr",
+    });
+  });
+
+  it("parses a valid open link", async () => {
+    const { parseDaintreeUrl } = await import("../deepLinkInstall.js");
+    expect(parseDaintreeUrl("daintree://plugin/open?id=acme.notes")).toEqual({
+      action: "open",
+      pluginId: "acme.notes",
+    });
+  });
+
+  it("rejects a javascript: install url", async () => {
+    const { parseDaintreeUrl } = await import("../deepLinkInstall.js");
+    expect(parseDaintreeUrl("daintree://plugin/install?url=javascript:alert(1)")).toBeNull();
+  });
+
+  it("rejects a file: install url", async () => {
+    const { parseDaintreeUrl } = await import("../deepLinkInstall.js");
+    expect(parseDaintreeUrl("daintree://plugin/install?url=file:///etc/passwd")).toBeNull();
+  });
+
+  it("rejects a nested daintree: install url", async () => {
+    const { parseDaintreeUrl } = await import("../deepLinkInstall.js");
+    expect(parseDaintreeUrl("daintree://plugin/install?url=daintree://plugin/install")).toBeNull();
+  });
+
+  it("rejects an install link with no url param", async () => {
+    const { parseDaintreeUrl } = await import("../deepLinkInstall.js");
+    expect(parseDaintreeUrl("daintree://plugin/install")).toBeNull();
+  });
+
+  it("rejects an open link with a malformed id", async () => {
+    const { parseDaintreeUrl } = await import("../deepLinkInstall.js");
+    expect(parseDaintreeUrl("daintree://plugin/open?id=Not Valid")).toBeNull();
+  });
+
+  it("rejects an unknown host", async () => {
+    const { parseDaintreeUrl } = await import("../deepLinkInstall.js");
+    expect(parseDaintreeUrl("daintree://settings/open?id=x")).toBeNull();
+  });
+
+  it("rejects an unknown path", async () => {
+    const { parseDaintreeUrl } = await import("../deepLinkInstall.js");
+    expect(parseDaintreeUrl("daintree://plugin/uninstall?id=acme.notes")).toBeNull();
+  });
+
+  it("rejects a non-daintree scheme", async () => {
+    const { parseDaintreeUrl } = await import("../deepLinkInstall.js");
+    expect(parseDaintreeUrl("https://example.com/install")).toBeNull();
+    expect(parseDaintreeUrl("not a url at all")).toBeNull();
+  });
+});
+
+describe("extractDaintreeUrl", () => {
+  it("returns the first daintree:// argv entry", async () => {
+    const { extractDaintreeUrl } = await import("../deepLinkInstall.js");
+    expect(
+      extractDaintreeUrl(["/path/to/app", "--flag", "daintree://plugin/open?id=acme.notes"])
+    ).toBe("daintree://plugin/open?id=acme.notes");
+  });
+
+  it("returns null when no deep link is present", async () => {
+    const { extractDaintreeUrl } = await import("../deepLinkInstall.js");
+    expect(extractDaintreeUrl(["/path/to/app", "--cli-path", "/repo"])).toBeNull();
+  });
+});
+
+describe("handleDaintreeUrl / notifyAppViewPainted", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    envMock.getPendingDaintreeUrls.mockReturnValue([]);
+  });
+
+  it("delivers immediately when the primary view has already painted (warm)", async () => {
+    const mod = await import("../deepLinkInstall.js");
+    mod._resetDeepLinkStateForTest();
+    const wc = makeWebContents(7);
+    registryMock.getAppWebContents.mockReturnValue(wc);
+    mod.activateDeepLinkHandler(makeRegistry(wc) as never);
+
+    // Paint first (warm), then the deep link arrives.
+    mod.notifyAppViewPainted(wc as never);
+    mod.handleDaintreeUrl("daintree://plugin/open?id=acme.notes");
+
+    expect(wc.send).toHaveBeenCalledWith("events:push", {
+      name: "plugin:deep-link",
+      payload: { action: "open", pluginId: "acme.notes" },
+    });
+  });
+
+  it("holds the intent until the view paints (cold), then flushes once", async () => {
+    const mod = await import("../deepLinkInstall.js");
+    mod._resetDeepLinkStateForTest();
+    const wc = makeWebContents(9);
+    registryMock.getAppWebContents.mockReturnValue(wc);
+    mod.activateDeepLinkHandler(makeRegistry(wc) as never);
+
+    // Deep link arrives before paint — nothing delivered yet.
+    mod.handleDaintreeUrl("daintree://plugin/install?url=https://example.com/p.dntr");
+    expect(wc.send).not.toHaveBeenCalled();
+
+    // Paint flushes it exactly once.
+    mod.notifyAppViewPainted(wc as never);
+    expect(wc.send).toHaveBeenCalledTimes(1);
+    expect(wc.send).toHaveBeenCalledWith("events:push", {
+      name: "plugin:deep-link",
+      payload: { action: "install", url: "https://example.com/p.dntr" },
+    });
+
+    // A second paint does not re-deliver the consumed intent.
+    mod.notifyAppViewPainted(wc as never);
+    expect(wc.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores an invalid deep link without delivering", async () => {
+    const mod = await import("../deepLinkInstall.js");
+    mod._resetDeepLinkStateForTest();
+    const wc = makeWebContents(11);
+    registryMock.getAppWebContents.mockReturnValue(wc);
+    mod.activateDeepLinkHandler(makeRegistry(wc) as never);
+    mod.notifyAppViewPainted(wc as never);
+
+    mod.handleDaintreeUrl("daintree://plugin/install?url=javascript:alert(1)");
+    expect(wc.send).not.toHaveBeenCalled();
+  });
+
+  it("drains macOS pending open-url URLs on activation", async () => {
+    envMock.getPendingDaintreeUrls.mockReturnValue(["daintree://plugin/open?id=acme.notes"]);
+    const mod = await import("../deepLinkInstall.js");
+    mod._resetDeepLinkStateForTest();
+    const wc = makeWebContents(13);
+    registryMock.getAppWebContents.mockReturnValue(wc);
+
+    mod.activateDeepLinkHandler(makeRegistry(wc) as never);
+    expect(envMock.clearPendingDaintreeUrls).toHaveBeenCalledOnce();
+
+    // Held until paint, then delivered.
+    mod.notifyAppViewPainted(wc as never);
+    expect(wc.send).toHaveBeenCalledWith("events:push", {
+      name: "plugin:deep-link",
+      payload: { action: "open", pluginId: "acme.notes" },
+    });
+  });
+});

--- a/electron/setup/deepLinkInstall.ts
+++ b/electron/setup/deepLinkInstall.ts
@@ -97,6 +97,9 @@ let pendingIntent: PluginDeepLinkIntent | null = null;
 // signal guarantees the listener is live — delivering earlier would race it
 // onto the floor (#8465).
 const paintedWebContentsIds = new Set<number>();
+// Ids whose lifecycle listeners are already attached, so re-paints don't stack
+// duplicate `did-start-loading` / `destroyed` handlers.
+const wiredWebContentsIds = new Set<number>();
 
 function primaryAppWebContents(): Electron.WebContents | null {
   const win = windowRegistry?.getPrimary()?.browserWindow;
@@ -105,12 +108,35 @@ function primaryAppWebContents(): Electron.WebContents | null {
   return wc && !wc.isDestroyed() ? wc : null;
 }
 
-function deliver(webContents: Electron.WebContents, intent: PluginDeepLinkIntent): void {
+/**
+ * Send the intent to a renderer. Returns whether the send succeeded so the
+ * caller only clears `pendingIntent` on success — a teardown-race failure keeps
+ * the intent queued for the next paint rather than silently dropping it.
+ */
+function deliver(webContents: Electron.WebContents, intent: PluginDeepLinkIntent): boolean {
   try {
     webContents.send(CHANNELS.EVENTS_PUSH, { name: "plugin:deep-link", payload: intent });
+    return true;
   } catch {
-    // Send can fail mid-teardown — drop silently, the intent is non-critical.
+    return false;
   }
+}
+
+/**
+ * Attach lifecycle listeners (once per id) that drop the id from the painted
+ * set: a reload restarts loading (the renderer's listener unmounts and must
+ * re-register), and destroy removes the view entirely. Without this a deep link
+ * after a reload would deliver to a not-yet-mounted renderer.
+ */
+function wireWebContentsLifecycle(webContents: Electron.WebContents): void {
+  const id = webContents.id;
+  if (wiredWebContentsIds.has(id)) return;
+  wiredWebContentsIds.add(id);
+  webContents.on("did-start-loading", () => paintedWebContentsIds.delete(id));
+  webContents.once("destroyed", () => {
+    paintedWebContentsIds.delete(id);
+    wiredWebContentsIds.delete(id);
+  });
 }
 
 /**
@@ -127,8 +153,7 @@ export function handleDaintreeUrl(raw: string): void {
   }
 
   const wc = primaryAppWebContents();
-  if (wc && paintedWebContentsIds.has(wc.id)) {
-    deliver(wc, intent);
+  if (wc && paintedWebContentsIds.has(wc.id) && deliver(wc, intent)) {
     pendingIntent = null;
   } else {
     pendingIntent = intent;
@@ -136,22 +161,23 @@ export function handleDaintreeUrl(raw: string): void {
 }
 
 /**
- * Record that an app view has painted and flush any pending deep-link intent to
- * it. Called from the `app:view-painted` IPC handler. Delivering on paint (not
- * on window creation) ensures the renderer's deep-link listener is mounted.
+ * Record that an app view has painted and flush any pending deep-link intent.
+ * Called from the `app:view-painted` IPC handler. Delivering on paint (not on
+ * window creation) ensures the renderer's deep-link listener is mounted.
+ *
+ * Delivery always targets the primary window (lesson #9533): if a non-primary
+ * view paints first while the primary hasn't, the intent stays queued for the
+ * primary rather than opening the Plugin Manager in the wrong window.
  */
 export function notifyAppViewPainted(webContents: Electron.WebContents): void {
-  const id = webContents.id;
-  paintedWebContentsIds.add(id);
-  webContents.once("destroyed", () => paintedWebContentsIds.delete(id));
+  wireWebContentsLifecycle(webContents);
+  paintedWebContentsIds.add(webContents.id);
 
   if (!pendingIntent) return;
-  // Prefer the primary view; fall back to the view that just painted if the
-  // primary hasn't painted yet (rare multi-window cold launch).
   const primary = primaryAppWebContents();
-  const target = primary && paintedWebContentsIds.has(primary.id) ? primary : webContents;
-  deliver(target, pendingIntent);
-  pendingIntent = null;
+  if (primary && paintedWebContentsIds.has(primary.id) && deliver(primary, pendingIntent)) {
+    pendingIntent = null;
+  }
 }
 
 /**
@@ -182,4 +208,5 @@ export function _resetDeepLinkStateForTest(): void {
   windowRegistry = null;
   pendingIntent = null;
   paintedWebContentsIds.clear();
+  wiredWebContentsIds.clear();
 }

--- a/electron/setup/deepLinkInstall.ts
+++ b/electron/setup/deepLinkInstall.ts
@@ -1,0 +1,185 @@
+import { CHANNELS } from "../ipc/channels.js";
+import { SCOPED_PLUGIN_NAME_PATTERN } from "../schemas/plugin.js";
+import { getAppWebContents } from "../window/webContentsRegistry.js";
+import {
+  clearPendingDaintreeUrls,
+  getPendingDaintreeUrls,
+  setDaintreeUrlConsumer,
+} from "./deepLinkUrlQueue.js";
+import type { WindowRegistry } from "../window/WindowRegistry.js";
+import type { PluginDeepLinkIntent } from "../../shared/types/plugin.js";
+
+export const DAINTREE_DEEP_LINK_SCHEME = "daintree";
+const SCHEME_PREFIX = `${DAINTREE_DEEP_LINK_SCHEME}://`;
+
+// Cap the URL we echo into logs. A deep link is fully attacker-controlled (any
+// web page can fire one), so a hostile actor could otherwise flood the log with
+// a megabyte-long URI. Mirrors `UNTRUSTED_URL_MAX_CHARS` in plugin.ts.
+const UNTRUSTED_URL_MAX_CHARS = 200;
+
+function truncateForLog(raw: string): string {
+  return raw.length > UNTRUSTED_URL_MAX_CHARS ? `${raw.slice(0, UNTRUSTED_URL_MAX_CHARS)}…` : raw;
+}
+
+/**
+ * Validate and narrow a raw `daintree://` URI to a {@link PluginDeepLinkIntent},
+ * or `null` if it isn't a deep link we recognise. The URL is untrusted; every
+ * branch fails closed.
+ *
+ * Accepted shapes:
+ * - `daintree://plugin/install?url=<http(s) archive url>`
+ * - `daintree://plugin/open?id=<publisher.name>`
+ *
+ * The nested install `url` is only required to be `http:`/`https:` here — the
+ * full SSRF / private-host / size gates live in `handleInstallFromUrl`, which
+ * the renderer routes through when the user presses install. This parser's job
+ * is to reject non-web schemes (`javascript:`, `file:`, `daintree:`) so a
+ * hostile deep link can't pre-fill the dialog with something dangerous.
+ */
+export function parseDaintreeUrl(raw: string): PluginDeepLinkIntent | null {
+  if (typeof raw !== "string" || !raw.startsWith(SCHEME_PREFIX)) return null;
+
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== `${DAINTREE_DEEP_LINK_SCHEME}:`) return null;
+  // Only the `plugin` host is defined today; reject everything else so future
+  // hosts must opt in explicitly rather than fall through to a plugin action.
+  if (url.hostname !== "plugin") return null;
+
+  if (url.pathname === "/install") {
+    const target = url.searchParams.get("url");
+    if (!target) return null;
+    let nested: URL;
+    try {
+      nested = new URL(target);
+    } catch {
+      return null;
+    }
+    if (nested.protocol !== "https:" && nested.protocol !== "http:") return null;
+    return { action: "install", url: target };
+  }
+
+  if (url.pathname === "/open") {
+    const pluginId = url.searchParams.get("id");
+    if (!pluginId || !SCOPED_PLUGIN_NAME_PATTERN.test(pluginId)) return null;
+    return { action: "open", pluginId };
+  }
+
+  return null;
+}
+
+/**
+ * Extract the first `daintree://` URL from an argv array. On Windows/Linux a
+ * deep link arrives as a bare argv entry — in `process.argv` for a cold launch,
+ * or in the `second-instance` `commandLine` for a warm one. Unlike `.dntr`
+ * paths, the OS delivers a single deep link per launch, so the first match
+ * wins.
+ */
+export function extractDaintreeUrl(argv: readonly string[]): string | null {
+  for (const arg of argv) {
+    if (typeof arg === "string" && arg.startsWith(SCHEME_PREFIX)) return arg;
+  }
+  return null;
+}
+
+let windowRegistry: WindowRegistry | null = null;
+// Latest deep-link intent awaiting a painted renderer. Latest-wins: a deep link
+// is a discrete user action, so a newer one supersedes an unconsumed older one
+// rather than queuing.
+let pendingIntent: PluginDeepLinkIntent | null = null;
+// App-view webContents ids that have reported first paint. The deep-link
+// renderer listener attaches during React mount (before paint), so a paint
+// signal guarantees the listener is live — delivering earlier would race it
+// onto the floor (#8465).
+const paintedWebContentsIds = new Set<number>();
+
+function primaryAppWebContents(): Electron.WebContents | null {
+  const win = windowRegistry?.getPrimary()?.browserWindow;
+  if (!win || win.isDestroyed()) return null;
+  const wc = getAppWebContents(win);
+  return wc && !wc.isDestroyed() ? wc : null;
+}
+
+function deliver(webContents: Electron.WebContents, intent: PluginDeepLinkIntent): void {
+  try {
+    webContents.send(CHANNELS.EVENTS_PUSH, { name: "plugin:deep-link", payload: intent });
+  } catch {
+    // Send can fail mid-teardown — drop silently, the intent is non-critical.
+  }
+}
+
+/**
+ * Route one raw deep-link URI to the renderer. If the primary view has already
+ * painted (warm launch), deliver immediately; otherwise hold the intent until a
+ * paint signal arrives (cold launch). Invalid URIs are logged and ignored — a
+ * deep link must never crash the app.
+ */
+export function handleDaintreeUrl(raw: string): void {
+  const intent = parseDaintreeUrl(raw);
+  if (!intent) {
+    console.warn(`[MAIN] Ignoring unrecognised daintree:// deep link: ${truncateForLog(raw)}`);
+    return;
+  }
+
+  const wc = primaryAppWebContents();
+  if (wc && paintedWebContentsIds.has(wc.id)) {
+    deliver(wc, intent);
+    pendingIntent = null;
+  } else {
+    pendingIntent = intent;
+  }
+}
+
+/**
+ * Record that an app view has painted and flush any pending deep-link intent to
+ * it. Called from the `app:view-painted` IPC handler. Delivering on paint (not
+ * on window creation) ensures the renderer's deep-link listener is mounted.
+ */
+export function notifyAppViewPainted(webContents: Electron.WebContents): void {
+  const id = webContents.id;
+  paintedWebContentsIds.add(id);
+  webContents.once("destroyed", () => paintedWebContentsIds.delete(id));
+
+  if (!pendingIntent) return;
+  // Prefer the primary view; fall back to the view that just painted if the
+  // primary hasn't painted yet (rare multi-window cold launch).
+  const primary = primaryAppWebContents();
+  const target = primary && paintedWebContentsIds.has(primary.id) ? primary : webContents;
+  deliver(target, pendingIntent);
+  pendingIntent = null;
+}
+
+/**
+ * Wire the `daintree://` deep-link path once the window registry is available.
+ * Takes over live macOS `open-url` events, then drains the cold-launch sources:
+ * the macOS pre-ready `open-url` queue and the Windows/Linux `process.argv`
+ * scan. Call once, after the primary window has been created.
+ */
+export function activateDeepLinkHandler(registry: WindowRegistry): void {
+  windowRegistry = registry;
+
+  // Take over live macOS `open-url` events first, so an event arriving mid-drain
+  // routes through the consumer instead of landing in a queue we've snapshotted.
+  setDaintreeUrlConsumer((url) => handleDaintreeUrl(url));
+
+  // Windows/Linux cold launch: the deep link is an argv entry of this instance.
+  const argvUrl = extractDaintreeUrl(process.argv);
+  if (argvUrl) handleDaintreeUrl(argvUrl);
+
+  // macOS cold launch: drain any `open-url` events queued before activation.
+  const pending = getPendingDaintreeUrls();
+  clearPendingDaintreeUrls();
+  for (const url of pending) handleDaintreeUrl(url);
+}
+
+/** Test-only: reset module state between cases. */
+export function _resetDeepLinkStateForTest(): void {
+  windowRegistry = null;
+  pendingIntent = null;
+  paintedWebContentsIds.clear();
+}

--- a/electron/setup/deepLinkUrlQueue.ts
+++ b/electron/setup/deepLinkUrlQueue.ts
@@ -1,0 +1,53 @@
+import { app } from "electron";
+
+// macOS `daintree://` deep-link queue + `open-url` listener (#9559). Kept in its
+// own lightweight module — separate from the heavy `environment.ts` (which runs
+// `app.getPath`/`setPath` and other fs work at module load) — so importers that
+// only need the queue accessors (e.g. `deepLinkInstall.ts`, and via it the
+// `second-instance` lifecycle handler) don't pull that startup machinery into
+// their graph.
+//
+// The listener is registered synchronously at module load, the same timing
+// rationale as the `open-file` handler in `environment.ts`: on a cold launch the
+// OS delivers `open-url` during early startup, and a listener added inside the
+// `whenReady` chain would miss it. `environment.ts` side-effect-imports this
+// module so it loads on the existing early path. URLs that arrive before the
+// deep-link handler is wired are queued; `activateDeepLinkHandler`
+// (./deepLinkInstall.ts) drains the queue and takes over live events.
+//
+// macOS-only — Windows/Linux deliver deep links through argv / `second-instance`.
+
+const _pendingDaintreeUrls: string[] = [];
+let _daintreeUrlConsumer: ((url: string) => void) | null = null;
+
+/** Snapshot (copy) of deep-link URLs queued before the handler was activated. */
+export function getPendingDaintreeUrls(): string[] {
+  return [..._pendingDaintreeUrls];
+}
+
+export function clearPendingDaintreeUrls(): void {
+  _pendingDaintreeUrls.length = 0;
+}
+
+/**
+ * Install the live `open-url` consumer. Once set, incoming URLs route directly
+ * to it instead of the pre-ready queue. Pass `null` to detach.
+ */
+export function setDaintreeUrlConsumer(consumer: ((url: string) => void) | null): void {
+  _daintreeUrlConsumer = consumer;
+}
+
+if (process.platform === "darwin") {
+  app.on("open-url", (event, url) => {
+    // Required: without preventDefault, Chromium's default handling may try to
+    // navigate the focused window to the deep-link URL.
+    event.preventDefault();
+    if (_daintreeUrlConsumer) {
+      _daintreeUrlConsumer(url);
+    } else if (!_pendingDaintreeUrls.includes(url)) {
+      // Dedup: a burst of identical deep links before activation shouldn't
+      // queue N copies and re-trigger the same intent N times.
+      _pendingDaintreeUrls.push(url);
+    }
+  });
+}

--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -26,6 +26,10 @@ import { existsSync } from "fs";
 import os from "os";
 import { isLinuxWaylandHybridGpu } from "../utils/gpuDetection.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+// Side-effect import: registers the macOS `daintree://` `open-url` listener on
+// the early-load path (#9559). environment.ts is imported first in main.ts, so
+// the listener is live before `app.whenReady()` resolves — see deepLinkUrlQueue.
+import "./deepLinkUrlQueue.js";
 
 export let exposeGc: (() => void) | undefined;
 try {

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -495,6 +495,22 @@ export function registerAppProtocol(distPath: string): void {
   protocol.handle("app", createAppProtocolHandler(distPath));
 }
 
+/**
+ * Claim the `daintree://` URI scheme as this build's OS-level default protocol
+ * client (#9559) so deep links route to the running app. The durable OS
+ * association is declared in `electron-builder.config.cjs` (`protocols`); this
+ * runtime call ensures the launched build owns the scheme.
+ *
+ * Packaged-only: an unsigned dev/E2E build registering `daintree://` would
+ * point the OS at the dev binary and pollute the user's Launch Services / XDG
+ * handler database — the same reasoning that gates the macOS `.dntr`
+ * `fileAssociations` on `CSC_LINK`.
+ */
+export function registerDeepLinkProtocolClient(): void {
+  if (!app.isPackaged) return;
+  app.setAsDefaultProtocolClient("daintree");
+}
+
 export function registerDaintreeFileProtocol(): void {
   protocol.handle("daintree-file", createDaintreeFileProtocolHandler());
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "sideEffects": [
     "**/*.css",
     "./electron/setup/environment.ts",
+    "./electron/setup/deepLinkUrlQueue.ts",
     "./src/main.tsx",
     "./src/lib/trustedTypesPolicy.ts",
     "./src/config/terminalFont.ts",

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1508,6 +1508,12 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     onDecorationsChanged(
       callback: (payload: { scope: string; paths?: string[] }) => void
     ): () => void;
+    /**
+     * Subscribe to `daintree://` deep-link intents (#9559). Fires when the OS
+     * hands the app a deep link; the callback opens the Plugin Manager. Returns
+     * a cleanup.
+     */
+    onDeepLink(callback: (intent: import("../plugin.js").PluginDeepLinkIntent) => void): () => void;
     /** Subscribe to plugin panel kind registry changes. Returns a cleanup. */
     onPanelKindsChanged(
       callback: (payload: {

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1929,6 +1929,12 @@ export interface IpcEventMap {
   // renderer re-pulls via `plugin:list` for the full data.
   "plugin:provenance-changed": Record<string, never>;
 
+  // `daintree://` deep-link intent (main → renderer, #9559). Delivered to the
+  // primary window once it has painted; the renderer opens the Plugin Manager
+  // (URL pre-filled for install, or scrolled to the plugin for open). Routing
+  // installs through the existing manager flow keeps every security gate intact.
+  "plugin:deep-link": import("../plugin.js").PluginDeepLinkIntent;
+
   // Resource profile change (main → renderer)
   "resource:profile-changed": import("../resourceProfile.js").ResourceProfilePayload;
 
@@ -2016,6 +2022,8 @@ export type IpcEventBusMap = Pick<
   | "plugin:decorations-changed"
   // Plugin provenance record changed (global broadcast)
   | "plugin:provenance-changed"
+  // Plugin deep-link intent (targeted at the primary window)
+  | "plugin:deep-link"
   // Terminal lifecycle (non-data) — exit, spawn-result, backend crash/ready
   | "terminal:exit"
   | "terminal:backend-crashed"

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -386,6 +386,23 @@ export interface SettingsApi {
 export type PluginInstallSource = "builtin" | "sideload" | "url" | "catalog";
 
 /**
+ * Parsed intent of a `daintree://` deep link (#9559). The OS hands the raw URI
+ * to the main process via `open-url` (macOS) or `second-instance` / `process.argv`
+ * (Windows/Linux); `parseDaintreeUrl` validates and narrows it to one of these
+ * shapes before it crosses to the renderer.
+ *
+ * - `install` — `daintree://plugin/install?url=<https-or-http-archive-url>`: opens
+ *   the Plugin Manager with the URL pre-filled in the install dialog. The user
+ *   still presses install, so the existing HTTP-warning and security gates fire;
+ *   a deep link never installs silently.
+ * - `open` — `daintree://plugin/open?id=<publisher.name>`: opens the Plugin
+ *   Manager scrolled to the named plugin.
+ */
+export type PluginDeepLinkIntent =
+  | { action: "install"; url: string }
+  | { action: "open"; pluginId: string };
+
+/**
  * Discriminant for {@link PluginCheckUpdateResult}. A manual update check
  * (`plugin:check-for-update`) re-fetches the plugin's `originalUrl`, hashes the
  * archive, and compares it against the installed `archiveHash` — the check is

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,6 +59,7 @@ import {
   useOrchestrationMilestones,
   useAgentWaitingNudge,
   useFocusOnActivateIntent,
+  usePluginDeepLink,
   useNotificationHistoryPruning,
   useRecipeFocusReload,
   useUnloadCleanup,
@@ -518,6 +519,16 @@ function AppInner() {
   // paint signal arrives before panel state is loaded — a direct dispatch
   // would silently no-op against an empty panelStore).
   useFocusOnActivateIntent(isStateLoaded);
+  // `daintree://` deep-link receiver (#9559). Surfaces the intent once hydration
+  // settles; the effect below opens the Plugin Manager, which consumes it.
+  const pluginDeepLink = usePluginDeepLink(isStateLoaded);
+  useEffect(() => {
+    if (!pluginDeepLink.intent) return;
+    // Close Settings so the two modals don't stack when the deep link arrives
+    // while Settings is open (mirrors the `onOpenPluginManager` action).
+    setIsSettingsOpen(false);
+    setIsPluginManagerOpen(true);
+  }, [pluginDeepLink.intent]);
   // The skeleton is z-index 9999 and intercepts pointer events. The crash
   // recovery dialog is rendered before hydration completes, so without this
   // the dialog would be visible but unclickable until hydration finishes
@@ -1244,6 +1255,8 @@ function AppInner() {
                   <LazyPluginManagerDialog
                     isOpen={isPluginManagerOpen}
                     onClose={() => setIsPluginManagerOpen(false)}
+                    deepLinkIntent={pluginDeepLink.intent}
+                    onDeepLinkConsumed={pluginDeepLink.clear}
                   />
                 </Suspense>
               )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -528,7 +528,7 @@ function AppInner() {
     // while Settings is open (mirrors the `onOpenPluginManager` action).
     setIsSettingsOpen(false);
     setIsPluginManagerOpen(true);
-  }, [pluginDeepLink.intent]);
+  }, [pluginDeepLink.intent, setIsSettingsOpen, setIsPluginManagerOpen]);
   // The skeleton is z-index 9999 and intercepts pointer events. The crash
   // recovery dialog is rendered before hydration completes, so without this
   // the dialog would be visible but unclickable until hydration finishes

--- a/src/components/Plugin/PluginManagerDialog.tsx
+++ b/src/components/Plugin/PluginManagerDialog.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import {
   Plug,
   AlertCircle,
@@ -17,7 +18,11 @@ import { EmptyState } from "@/components/ui/EmptyState";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { formatRelativeTime } from "@/lib/formatRelativeTime";
 import { usePluginManager } from "./usePluginManager";
-import type { LoadedPluginInfo, PluginInstallSource } from "@shared/types/plugin";
+import type {
+  LoadedPluginInfo,
+  PluginDeepLinkIntent,
+  PluginInstallSource,
+} from "@shared/types/plugin";
 
 /** Provenance source → short badge label (built-in / file / URL / catalog). */
 const SOURCE_BADGE_LABELS: Record<PluginInstallSource, string> = {
@@ -39,6 +44,10 @@ interface PluginRowProps {
   onToggle: () => void;
   onUninstall: () => void;
   onCheckForUpdate: () => void;
+  /** Attached to the row root so a deep-link `open` can scroll it into view. */
+  innerRef?: (el: HTMLDivElement | null) => void;
+  /** Transient neutral highlight when a deep-link `open` targets this row. */
+  highlighted?: boolean;
 }
 
 /**
@@ -57,6 +66,8 @@ function PluginRow({
   onToggle,
   onUninstall,
   onCheckForUpdate,
+  innerRef,
+  highlighted,
 }: PluginRowProps) {
   const label = pluginLabel(plugin);
   const enabled = plugin.disabled !== true;
@@ -75,7 +86,12 @@ function PluginRow({
       : "No update URL — reinstall from a file to update";
 
   return (
-    <div className="relative w-full p-4 rounded-[var(--radius-lg)] border border-daintree-border text-daintree-text">
+    <div
+      ref={innerRef}
+      className={`relative w-full p-4 rounded-[var(--radius-lg)] border text-daintree-text transition-colors ${
+        highlighted ? "border-daintree-text/40 bg-overlay-subtle" : "border-daintree-border"
+      }`}
+    >
       <div className="flex items-start justify-between gap-3">
         <div className="flex items-start gap-3 min-w-0">
           <Plug
@@ -222,7 +238,14 @@ function RowSkeleton() {
 interface PluginManagerDialogProps {
   isOpen: boolean;
   onClose: () => void;
+  /** Pending `daintree://` deep-link intent (#9559), or `null` when none. */
+  deepLinkIntent?: PluginDeepLinkIntent | null;
+  /** Called once the intent has been applied so the source can clear it. */
+  onDeepLinkConsumed?: () => void;
 }
+
+// How long the deep-link `open` target row stays highlighted before fading back.
+const DEEP_LINK_HIGHLIGHT_MS = 2000;
 
 /**
  * Dedicated plugin manager dialog (#9548) — the primary surface for plugin
@@ -237,8 +260,37 @@ interface PluginManagerDialogProps {
  * dialog render at `zIndex="nested"` so the LIFO escape backstop closes the
  * inner surface before this dialog (#2828).
  */
-export function PluginManagerDialog({ isOpen, onClose }: PluginManagerDialogProps) {
-  const pm = usePluginManager(isOpen);
+export function PluginManagerDialog({
+  isOpen,
+  onClose,
+  deepLinkIntent,
+  onDeepLinkConsumed,
+}: PluginManagerDialogProps) {
+  const pm = usePluginManager(isOpen, {
+    intent: deepLinkIntent ?? null,
+    onConsumed: onDeepLinkConsumed,
+  });
+
+  // Row elements keyed by plugin name, so a `daintree://plugin/open` can scroll
+  // its target into view.
+  const rowRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  const [highlightedPluginId, setHighlightedPluginId] = useState<string | null>(null);
+
+  // When the hook resolves a deep-link `open` target to an installed plugin,
+  // scroll its row into view and apply a transient neutral highlight, then clear
+  // the focus request so it doesn't re-trigger on the next render.
+  const focusPluginId = pm.focusPluginId;
+  const clearFocusPluginId = pm.clearFocusPluginId;
+  useEffect(() => {
+    if (!focusPluginId) return;
+    const row = rowRefs.current.get(focusPluginId);
+    if (!row) return; // Row not rendered yet — the not-found notice path handles misses.
+    row.scrollIntoView({ block: "center", behavior: "smooth" });
+    setHighlightedPluginId(focusPluginId);
+    clearFocusPluginId();
+    const timer = setTimeout(() => setHighlightedPluginId(null), DEEP_LINK_HIGHLIGHT_MS);
+    return () => clearTimeout(timer);
+  }, [focusPluginId, clearFocusPluginId, pm.plugins]);
 
   return (
     <AppDialog isOpen={isOpen} onClose={onClose} size="lg" data-testid="plugin-manager-dialog">
@@ -326,6 +378,11 @@ export function PluginManagerDialog({ isOpen, onClose }: PluginManagerDialogProp
                   onToggle={() => void pm.handleToggle(plugin)}
                   onUninstall={() => pm.armUninstall(plugin)}
                   onCheckForUpdate={() => void pm.handleCheckForUpdate(plugin)}
+                  highlighted={highlightedPluginId === plugin.manifest.name}
+                  innerRef={(el) => {
+                    if (el) rowRefs.current.set(plugin.manifest.name, el);
+                    else rowRefs.current.delete(plugin.manifest.name);
+                  }}
                 />
               ))}
             </div>

--- a/src/components/Plugin/__tests__/PluginManagerDialog.test.tsx
+++ b/src/components/Plugin/__tests__/PluginManagerDialog.test.tsx
@@ -705,6 +705,42 @@ describe("PluginManagerDialog", () => {
       expect(onConsumed).toHaveBeenCalledOnce();
     });
 
+    it("does not clobber a URL dialog the user already has open", async () => {
+      const { rerender } = render(
+        <TooltipProvider>
+          <PluginManagerDialog
+            isOpen
+            onClose={() => {}}
+            deepLinkIntent={{ action: "install", url: "https://first.example/p.dntr" }}
+            onDeepLinkConsumed={() => {}}
+          />
+        </TooltipProvider>
+      );
+      await waitFor(() =>
+        expect((screen.getByLabelText("Plugin URL") as HTMLInputElement).value).toBe(
+          "https://first.example/p.dntr"
+        )
+      );
+      // User edits the field…
+      fireEvent.change(screen.getByLabelText("Plugin URL"), {
+        target: { value: "https://user-typed.example/p.dntr" },
+      });
+      // …a second deep link arrives while the dialog is open — it must not win.
+      rerender(
+        <TooltipProvider>
+          <PluginManagerDialog
+            isOpen
+            onClose={() => {}}
+            deepLinkIntent={{ action: "install", url: "https://second.example/p.dntr" }}
+            onDeepLinkConsumed={() => {}}
+          />
+        </TooltipProvider>
+      );
+      expect((screen.getByLabelText("Plugin URL") as HTMLInputElement).value).toBe(
+        "https://user-typed.example/p.dntr"
+      );
+    });
+
     it("shows a notice when an open intent targets an uninstalled plugin", async () => {
       (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
       render(

--- a/src/components/Plugin/__tests__/PluginManagerDialog.test.tsx
+++ b/src/components/Plugin/__tests__/PluginManagerDialog.test.tsx
@@ -655,4 +655,72 @@ describe("PluginManagerDialog", () => {
     await waitFor(() => expect(screen.getByText(/backend down/)).toBeTruthy());
     expect(screen.queryByText("No plugins installed")).toBeNull();
   });
+
+  describe("deep links (#9559)", () => {
+    // jsdom lacks scrollIntoView; the open-route effect calls it.
+    beforeEach(() => {
+      Element.prototype.scrollIntoView = vi.fn();
+    });
+
+    it("pre-fills the URL dialog for an install intent without installing", async () => {
+      const onConsumed = vi.fn();
+      render(
+        <TooltipProvider>
+          <PluginManagerDialog
+            isOpen
+            onClose={() => {}}
+            deepLinkIntent={{ action: "install", url: "https://example.com/p.dntr" }}
+            onDeepLinkConsumed={onConsumed}
+          />
+        </TooltipProvider>
+      );
+
+      await waitFor(() =>
+        expect((screen.getByLabelText("Plugin URL") as HTMLInputElement).value).toBe(
+          "https://example.com/p.dntr"
+        )
+      );
+      // Never auto-installs — the user must press install (gates stay intact).
+      expect(window.electron.plugin.installFromUrl).not.toHaveBeenCalled();
+      expect(onConsumed).toHaveBeenCalledOnce();
+    });
+
+    it("scrolls to and highlights the target row for an open intent", async () => {
+      (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+        makePlugin({ manifest: { ...makePlugin().manifest, name: "acme.demo" } }),
+      ]);
+      const onConsumed = vi.fn();
+      render(
+        <TooltipProvider>
+          <PluginManagerDialog
+            isOpen
+            onClose={() => {}}
+            deepLinkIntent={{ action: "open", pluginId: "acme.demo" }}
+            onDeepLinkConsumed={onConsumed}
+          />
+        </TooltipProvider>
+      );
+
+      await waitFor(() => expect(Element.prototype.scrollIntoView).toHaveBeenCalled());
+      expect(onConsumed).toHaveBeenCalledOnce();
+    });
+
+    it("shows a notice when an open intent targets an uninstalled plugin", async () => {
+      (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      render(
+        <TooltipProvider>
+          <PluginManagerDialog
+            isOpen
+            onClose={() => {}}
+            deepLinkIntent={{ action: "open", pluginId: "missing.plugin" }}
+            onDeepLinkConsumed={() => {}}
+          />
+        </TooltipProvider>
+      );
+
+      await waitFor(() =>
+        expect(screen.getByText(/Plugin "missing\.plugin" isn't installed/)).toBeTruthy()
+      );
+    });
+  });
 });

--- a/src/components/Plugin/usePluginManager.ts
+++ b/src/components/Plugin/usePluginManager.ts
@@ -3,7 +3,11 @@ import { useDeferredLoading } from "@/hooks";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { logError } from "@/utils/logger";
-import type { LoadedPluginInfo, PluginInstallError } from "@shared/types/plugin";
+import type {
+  LoadedPluginInfo,
+  PluginDeepLinkIntent,
+  PluginInstallError,
+} from "@shared/types/plugin";
 
 /** Enabled plugins first, then alphabetically by display name. */
 function sortPlugins(list: readonly LoadedPluginInfo[]): LoadedPluginInfo[] {
@@ -57,7 +61,14 @@ type PendingUpdate = {
  * counter rather than splitting into a second list-fetching effect that would
  * cross-cancel the initial load (#4958).
  */
-export function usePluginManager(isOpen: boolean) {
+export interface PluginManagerDeepLink {
+  /** The pending `daintree://` intent, or `null` when none. */
+  intent: PluginDeepLinkIntent | null;
+  /** Called once the intent has been applied so the source can clear it. */
+  onConsumed?: () => void;
+}
+
+export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLink) {
   const [plugins, setPlugins] = useState<LoadedPluginInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const showInlineLoading = useDeferredLoading(loading, UI_DOHERTY_THRESHOLD);
@@ -92,6 +103,12 @@ export function usePluginManager(isOpen: boolean) {
   const [showUrlDialog, setShowUrlDialog] = useState(false);
   const [urlInput, setUrlInput] = useState("");
   const [isInstalling, setIsInstalling] = useState(false);
+  // `daintree://plugin/open` target — the dialog scrolls to and highlights the
+  // matching row, then clears it. Held in a ref for the consumption effect so
+  // `onConsumed` isn't a reactive dependency that re-fires the effect.
+  const [focusPluginId, setFocusPluginId] = useState<string | null>(null);
+  const deepLinkConsumedRef = useRef<(() => void) | undefined>(undefined);
+  deepLinkConsumedRef.current = deepLink?.onConsumed;
   // Update-check state. `checkingUpdate` drives the per-row spinner; the ref is
   // the synchronous reentrancy guard (state batches, leaving a double-click
   // window — #4703). `upToDateId` shows the transient "Already up to date" note;
@@ -173,6 +190,36 @@ export function usePluginManager(isOpen: boolean) {
     setIsDragOverFiles(false);
     setRefreshKey((k) => k + 1);
   }, [isOpen]);
+
+  // Apply a pending `daintree://` deep-link intent. Defined after the reopen
+  // reset above so that on a reopen it runs second and its writes win — the
+  // reset clears `urlInput`/`showUrlDialog`, then this re-applies them. For an
+  // install the URL is pre-filled and the dialog opened (the user still presses
+  // install, so the HTTP-warning and security gates fire — never silent). For
+  // an open the target row is flagged for scroll/highlight. `onConsumed` clears
+  // the source intent so it can't re-fire on the next reopen.
+  const deepLinkIntent = deepLink?.intent ?? null;
+  useEffect(() => {
+    if (!isOpen || !deepLinkIntent) return;
+    if (deepLinkIntent.action === "install") {
+      setUrlInput(deepLinkIntent.url);
+      setShowUrlDialog(true);
+    } else {
+      setFocusPluginId(deepLinkIntent.pluginId);
+    }
+    deepLinkConsumedRef.current?.();
+  }, [isOpen, deepLinkIntent]);
+
+  // A `daintree://plugin/open` for a plugin that isn't installed gets a quiet
+  // inline notice rather than a silent no-op. Waits for the list to settle so a
+  // mid-load check doesn't false-negative.
+  useEffect(() => {
+    if (!focusPluginId || loading) return;
+    if (!plugins.some((p) => p.manifest.name === focusPluginId)) {
+      setNotice(`Plugin "${focusPluginId}" isn't installed.`);
+      setFocusPluginId(null);
+    }
+  }, [focusPluginId, loading, plugins]);
 
   // Re-pull when any view installs or uninstalls a plugin (#9285 cross-view
   // propagation). The event carries no payload, so always re-fetch the full
@@ -557,5 +604,7 @@ export function usePluginManager(isOpen: boolean) {
     handleDragOver,
     handleDragLeave,
     handleDrop,
+    focusPluginId,
+    clearFocusPluginId: () => setFocusPluginId(null),
   };
 }

--- a/src/components/Plugin/usePluginManager.ts
+++ b/src/components/Plugin/usePluginManager.ts
@@ -109,6 +109,11 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
   const [focusPluginId, setFocusPluginId] = useState<string | null>(null);
   const deepLinkConsumedRef = useRef<(() => void) | undefined>(undefined);
   deepLinkConsumedRef.current = deepLink?.onConsumed;
+  // Mirror `showUrlDialog` so the deep-link effect can read the latest value
+  // without taking it as a dependency — otherwise opening the dialog would
+  // re-run the effect and fire `onConsumed` twice for one intent.
+  const showUrlDialogRef = useRef(showUrlDialog);
+  showUrlDialogRef.current = showUrlDialog;
   // Update-check state. `checkingUpdate` drives the per-row spinner; the ref is
   // the synchronous reentrancy guard (state batches, leaving a double-click
   // window — #4703). `upToDateId` shows the transient "Already up to date" note;
@@ -202,8 +207,13 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
   useEffect(() => {
     if (!isOpen || !deepLinkIntent) return;
     if (deepLinkIntent.action === "install") {
-      setUrlInput(deepLinkIntent.url);
-      setShowUrlDialog(true);
+      // Don't clobber an install dialog the user already has open — they may be
+      // mid-edit, and silently swapping in a fresh (attacker-supplied) URL is a
+      // social-engineering risk. Skip the pre-fill; the user can paste it.
+      if (!showUrlDialogRef.current) {
+        setUrlInput(deepLinkIntent.url);
+        setShowUrlDialog(true);
+      }
     } else {
       setFocusPluginId(deepLinkIntent.pluginId);
     }

--- a/src/hooks/app/__tests__/usePluginDeepLink.test.tsx
+++ b/src/hooks/app/__tests__/usePluginDeepLink.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { PluginDeepLinkIntent } from "@shared/types/plugin";
+
+const onDeepLinkMock = vi.hoisted(() =>
+  vi.fn<(cb: (intent: PluginDeepLinkIntent) => void) => () => void>()
+);
+
+vi.stubGlobal("window", {
+  ...globalThis.window,
+  electron: {
+    plugin: {
+      onDeepLink: onDeepLinkMock,
+    },
+  },
+});
+
+import { usePluginDeepLink } from "../usePluginDeepLink";
+
+const INSTALL: PluginDeepLinkIntent = { action: "install", url: "https://example.com/p.dntr" };
+const OPEN: PluginDeepLinkIntent = { action: "open", pluginId: "acme.notes" };
+
+describe("usePluginDeepLink", () => {
+  let lastCallback: ((intent: PluginDeepLinkIntent) => void) | null = null;
+  let unsubscribe: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    unsubscribe = vi.fn();
+    lastCallback = null;
+    onDeepLinkMock.mockImplementation((cb) => {
+      lastCallback = cb;
+      return unsubscribe as () => void;
+    });
+  });
+
+  it("subscribes on mount regardless of isStateLoaded", () => {
+    renderHook(({ loaded }) => usePluginDeepLink(loaded), { initialProps: { loaded: false } });
+    expect(onDeepLinkMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("buffers the intent until hydration completes", () => {
+    const { result, rerender } = renderHook(({ loaded }) => usePluginDeepLink(loaded), {
+      initialProps: { loaded: false },
+    });
+
+    act(() => lastCallback?.(INSTALL));
+    expect(result.current.intent).toBeNull();
+
+    rerender({ loaded: true });
+    expect(result.current.intent).toEqual(INSTALL);
+  });
+
+  it("surfaces the intent immediately when already hydrated", () => {
+    const { result } = renderHook(({ loaded }) => usePluginDeepLink(loaded), {
+      initialProps: { loaded: true },
+    });
+
+    act(() => lastCallback?.(OPEN));
+    expect(result.current.intent).toEqual(OPEN);
+  });
+
+  it("clear() resets the intent", () => {
+    const { result } = renderHook(({ loaded }) => usePluginDeepLink(loaded), {
+      initialProps: { loaded: true },
+    });
+
+    act(() => lastCallback?.(OPEN));
+    expect(result.current.intent).toEqual(OPEN);
+
+    act(() => result.current.clear());
+    expect(result.current.intent).toBeNull();
+  });
+
+  it("latest-wins when a second intent arrives", () => {
+    const { result } = renderHook(({ loaded }) => usePluginDeepLink(loaded), {
+      initialProps: { loaded: true },
+    });
+
+    act(() => lastCallback?.(INSTALL));
+    act(() => lastCallback?.(OPEN));
+    expect(result.current.intent).toEqual(OPEN);
+  });
+
+  it("unsubscribes on unmount", () => {
+    const { unmount } = renderHook(({ loaded }) => usePluginDeepLink(loaded), {
+      initialProps: { loaded: false },
+    });
+    unmount();
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/app/index.ts
+++ b/src/hooks/app/index.ts
@@ -20,6 +20,8 @@ export { useActiveWorktreeSync } from "./useActiveWorktreeSync";
 export { useOrchestrationMilestones } from "./useOrchestrationMilestones";
 export { useAgentWaitingNudge } from "./useAgentWaitingNudge";
 export { useFocusOnActivateIntent } from "./useFocusOnActivateIntent";
+export { usePluginDeepLink } from "./usePluginDeepLink";
+export type { PluginDeepLinkState } from "./usePluginDeepLink";
 export { useNotificationHistoryPruning } from "./useNotificationHistoryPruning";
 export { useRecipeFocusReload } from "./useRecipeFocusReload";
 export { useWorktreeDevServerStateSync } from "./useWorktreeDevServerStateSync";

--- a/src/hooks/app/usePluginDeepLink.ts
+++ b/src/hooks/app/usePluginDeepLink.ts
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { PluginDeepLinkIntent } from "@shared/types/plugin";
+
+export interface PluginDeepLinkState {
+  /** The deep-link intent awaiting handling, or `null` when none is pending. */
+  intent: PluginDeepLinkIntent | null;
+  /** Clear the current intent once it has been consumed (e.g. dialog opened). */
+  clear: () => void;
+}
+
+/**
+ * `daintree://` deep-link receiver (#9559).
+ *
+ * The main process delivers the intent on `plugin:deep-link` once the primary
+ * window has painted. This hook subscribes unconditionally on mount so the
+ * listener is live before the paint signal fires, then surfaces the intent
+ * gated on `isStateLoaded`: the deep link can arrive between first paint and
+ * the end of hydration, and opening the Plugin Manager against an unhydrated
+ * app would race the panel/plugin stores (#8465). Intents that land early are
+ * buffered and released on the hydration transition.
+ *
+ * Latest-wins, mirroring the main-side `pendingIntent`: a newer deep link
+ * supersedes an unconsumed older one.
+ */
+export function usePluginDeepLink(isStateLoaded: boolean): PluginDeepLinkState {
+  const [intent, setIntent] = useState<PluginDeepLinkIntent | null>(null);
+  const bufferedRef = useRef<PluginDeepLinkIntent | null>(null);
+  const loadedRef = useRef(isStateLoaded);
+
+  useEffect(() => {
+    loadedRef.current = isStateLoaded;
+  }, [isStateLoaded]);
+
+  useEffect(() => {
+    return window.electron.plugin.onDeepLink((next) => {
+      if (loadedRef.current) {
+        setIntent(next);
+      } else {
+        bufferedRef.current = next;
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    if (isStateLoaded && bufferedRef.current) {
+      setIntent(bufferedRef.current);
+      bufferedRef.current = null;
+    }
+  }, [isStateLoaded]);
+
+  const clear = useCallback(() => setIntent(null), []);
+
+  return { intent, clear };
+}


### PR DESCRIPTION
Adds a `daintree://` URI scheme that deep-links into the plugin install and open flow.

Two intents:

- `daintree://plugin/install?url=<https-archive>` — opens the Plugin Manager with the URL pre-filled in the install dialog. The user still confirms the install, so the existing HTTP-warning gate and SSRF/size checks always fire. No silent installs.
- `daintree://plugin/open?id=<publisher.name>` — opens the Plugin Manager scrolled to that plugin, or shows a quiet notice if it isn't installed.

**OS registration** via `electron-builder` `protocols` entry (`CFBundleURLTypes` on macOS, NSIS `HKCU` write on Windows, `x-scheme-handler` on Linux) plus `app.setAsDefaultProtocolClient` in packaged builds.

**Main-side delivery:** macOS `open-url` event registered at module scope (early, before `app.ready`); Windows/Linux cold-launch `process.argv` scan and `second-instance` `commandLine`. URIs are validated (scheme, host, `/install`|`/open` path, `https`-only nested `url`, scoped plugin `id`) then pushed over the existing `events:push` bus once the primary window has painted.

**Renderer-side:** `usePluginDeepLink` buffers the intent until hydration completes, then opens the Plugin Manager. A preload replay buffer in `deepLinkUrlQueue` guards the cold-launch race where the paint signal fires before the renderer subscription mounts.

Installs route through the existing `handleInstallFromUrl` path — no parallel installer added.

## Changes

- `electron/setup/deepLinkInstall.ts` — URI parser, validation, and main-side delivery
- `electron/setup/deepLinkUrlQueue.ts` — preload replay buffer
- `electron/setup/protocols.ts` — `app.setAsDefaultProtocolClient` wiring
- `electron-builder.config.cjs` — OS protocol registration
- `src/hooks/app/usePluginDeepLink.ts` — renderer hydration buffer + intent dispatch
- `src/components/Plugin/PluginManagerDialog.tsx` + `usePluginManager.ts` — pre-fill, focus, and open-by-id support

## Testing

- `electron/setup/__tests__/deepLinkInstall.test.ts` — parser/validation, cold-launch, warm-launch, reload, primary-window-only targeting
- `src/hooks/app/__tests__/usePluginDeepLink.test.tsx` — renderer hydration buffer (pre/post hydration, replay)
- `src/components/Plugin/__tests__/PluginManagerDialog.test.tsx` — dialog pre-fill, focus, open-by-id notice, non-clobber of existing input

Closes #9559.