### PR TITLE
feat(plugins): surface declared capabilities and danger in plugin manager

### DIFF
--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -231,6 +231,21 @@ function manifestTriggersCompoundElevation(
   return false;
 }
 
+/**
+ * Aggregate danger verdict for a whole plugin (vs. the per-action
+ * `effectiveDanger` computed in {@link PluginService.validateAndBuildActionDescriptor}).
+ * Surfaced on {@link LoadedPluginInfo.pluginDanger} so the manager UI can show
+ * an effective-danger summary without re-deriving the lattice in the renderer.
+ * Single source of truth on main: reuses {@link CONFIRM_TRIGGERING_CAPABILITIES}
+ * and {@link manifestTriggersCompoundElevation} rather than spawning a third copy.
+ */
+function computePluginDanger(manifest: PluginManifest | undefined): "safe" | "confirm" {
+  const caps = manifest?.capabilities ?? [];
+  if (caps.some((c) => CONFIRM_TRIGGERING_CAPABILITIES.has(c))) return "confirm";
+  if (manifestTriggersCompoundElevation(manifest, caps)) return "confirm";
+  return "safe";
+}
+
 interface LoadedPlugin {
   manifest: PluginManifest;
   dir: string;
@@ -2512,6 +2527,7 @@ export class PluginService {
       // pendingRestart: desired state diverges from running state.
       // Running + now-disabled → unload pending; skipped + now-enabled → load pending.
       const pendingRestart = isRunning ? disabled : !disabled;
+      const pluginDanger = computePluginDanger(p.manifest);
       if (p.isBuiltin) {
         return {
           manifest: p.manifest,
@@ -2527,6 +2543,7 @@ export class PluginService {
           updateAvailable: null,
           devMode: false,
           pendingRestart,
+          pluginDanger,
         };
       }
       const record = installed[p.manifest.name];
@@ -2545,6 +2562,7 @@ export class PluginService {
         updateAvailable: record?.updateAvailable ?? null,
         devMode: record?.devMode ?? false,
         pendingRestart,
+        pluginDanger,
       };
     };
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -1073,6 +1073,24 @@ describe("PluginService", () => {
       expect(service.listPlugins()[0].pluginDanger).toBe("confirm");
     });
 
+    // Guards against accidental removal from CONFIRM_TRIGGERING_CAPABILITIES.
+    it.each([
+      "git:write",
+      "fs:project-write",
+      "fs:user-data-write",
+      "agent:invoke",
+      "agent:register",
+    ])("reports confirm for the flat-elevated capability %s", async (capability) => {
+      await writePlugin("flat", {
+        name: "acme.flat",
+        version: "1.0.0",
+        capabilities: [capability],
+      });
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+      expect(service.listPlugins()[0].pluginDanger).toBe("confirm");
+    });
+
     it("reports confirm via the compound lattice (sensitive read + unscoped network:fetch)", async () => {
       await writePlugin("exfil", {
         name: "acme.exfil",

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -1043,6 +1043,74 @@ describe("PluginService", () => {
     expect(() => service.setPluginArchiveHash("acme.nonexistent", "deadbeef")).not.toThrow();
   });
 
+  describe("listPlugins pluginDanger", () => {
+    it("reports safe for a plugin with no capabilities", async () => {
+      await writePlugin("safe-plugin", { name: "acme.safe", version: "1.0.0" });
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+      expect(service.listPlugins()[0].pluginDanger).toBe("safe");
+    });
+
+    it("reports safe for a read-only / clipboard capability set", async () => {
+      await writePlugin("reader", {
+        name: "acme.reader",
+        version: "1.0.0",
+        capabilities: ["fs:project-read", "git:read", "clipboard:read"],
+      });
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+      expect(service.listPlugins()[0].pluginDanger).toBe("safe");
+    });
+
+    it("reports confirm for an individually high-risk capability (shell:exec)", async () => {
+      await writePlugin("sheller", {
+        name: "acme.sheller",
+        version: "1.0.0",
+        capabilities: ["shell:exec"],
+      });
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+      expect(service.listPlugins()[0].pluginDanger).toBe("confirm");
+    });
+
+    it("reports confirm via the compound lattice (sensitive read + unscoped network:fetch)", async () => {
+      await writePlugin("exfil", {
+        name: "acme.exfil",
+        version: "1.0.0",
+        capabilities: ["fs:project-read", "network:fetch"],
+      });
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+      expect(service.listPlugins()[0].pluginDanger).toBe("confirm");
+    });
+
+    it("reports safe when a tight network scope attenuates the compound pair", async () => {
+      await writePlugin("scoped", {
+        name: "acme.scoped",
+        version: "1.0.0",
+        capabilities: ["fs:project-read", "network:fetch"],
+        scopes: { network: { allowedUrls: ["https://api.example.com/v1"] } },
+      });
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+      expect(service.listPlugins()[0].pluginDanger).toBe("safe");
+    });
+
+    it("computes pluginDanger for a launch-disabled plugin too", async () => {
+      storeMock._state.set("plugins", { disabled: ["acme.off-danger"] });
+      await writePlugin("off-danger", {
+        name: "acme.off-danger",
+        version: "1.0.0",
+        capabilities: ["shell:exec"],
+      });
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+      const info = service.listPlugins()[0];
+      expect(info.disabled).toBe(true);
+      expect(info.pluginDanger).toBe("confirm");
+    });
+  });
+
   it("rejects manifest with empty name", async () => {
     await writePlugin("empty-name", { name: "", version: "1.0.0" });
 

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -599,6 +599,19 @@ export interface LoadedPluginInfo {
    * survives a Preferences-tab remount.
    */
   pendingRestart?: boolean;
+  /**
+   * Aggregate danger verdict for the plugin's declared capabilities, computed
+   * once in the main process by `PluginService.listPlugins` from the flat
+   * `CONFIRM_TRIGGERING_CAPABILITIES` set plus the compound-capability lattice
+   * (`manifestTriggersCompoundElevation`). `"confirm"` means the plugin holds at
+   * least one individually high-risk capability, or a compound pair the lattice
+   * elevates (e.g. a sensitive read + an unconstrained network sink). The
+   * renderer reads this for the manager's effective-danger summary instead of
+   * re-deriving the lattice — the security logic stays single-source on main
+   * (the flat set is already duplicated once with `HIGH_RISK_CAPABILITIES` and
+   * must not gain a third copy).
+   */
+  pluginDanger: "safe" | "confirm";
 }
 
 export interface PluginIpcContext {

--- a/src/components/Plugin/PluginDetailPane.tsx
+++ b/src/components/Plugin/PluginDetailPane.tsx
@@ -1,9 +1,14 @@
-import { AlertCircle, RefreshCw, Trash2 } from "lucide-react";
+import { AlertCircle, AlertTriangle, RefreshCw, Trash2 } from "lucide-react";
 import { PluginSettingsForm } from "@/components/Settings/PluginSettingsForm";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { formatRelativeTime } from "@/lib/formatRelativeTime";
-import type { LoadedPluginInfo, PluginInstallSource } from "@shared/types/plugin";
+import {
+  BUILT_IN_PLUGIN_CAPABILITIES,
+  type BuiltInPluginCapability,
+  type LoadedPluginInfo,
+  type PluginInstallSource,
+} from "@shared/types/plugin";
 
 /** Provenance source → short badge label (built-in / file / URL / catalog). */
 export const SOURCE_BADGE_LABELS: Record<PluginInstallSource, string> = {
@@ -19,6 +24,184 @@ export function pluginLabel(plugin: LoadedPluginInfo): string {
 
 const BADGE_CLASS =
   "inline-flex items-center px-1.5 py-0.5 rounded-sm text-[10px] font-medium bg-overlay-subtle border border-daintree-border/50 text-daintree-text/60 uppercase tracking-wide";
+
+/**
+ * Per-capability display tier. `danger` is reserved for `shell:exec` —
+ * categorically irreversible arbitrary execution; `warning` covers the
+ * remaining write/mutation/network capabilities (which also individually
+ * trigger install-time confirmation); `neutral` covers read-only and clipboard
+ * capabilities. Colours follow the status tokens, never the accent — risk is
+ * not a focus signal (see CLAUDE.md accent-restraint).
+ */
+type CapabilitySeverity = "danger" | "warning" | "neutral";
+
+interface CapabilityMeta {
+  label: string;
+  description: string;
+  severity: CapabilitySeverity;
+}
+
+/**
+ * Human-readable copy and risk tier for every built-in capability. Lives in the
+ * renderer (presentation only) — the authoritative danger verdict for the whole
+ * plugin is `plugin.pluginDanger`, computed on main. Iterated in
+ * `BUILT_IN_PLUGIN_CAPABILITIES` order so the list is stable regardless of the
+ * manifest's declaration order.
+ */
+const CAPABILITY_META = {
+  "fs:project-read": {
+    label: "Read project files",
+    description: "View files in the open project",
+    severity: "neutral",
+  },
+  "fs:project-write": {
+    label: "Write project files",
+    description: "Create, edit, or delete files in the open project",
+    severity: "warning",
+  },
+  "fs:user-data-read": {
+    label: "Read app data",
+    description: "View Daintree's stored data",
+    severity: "neutral",
+  },
+  "fs:user-data-write": {
+    label: "Write app data",
+    description: "Modify Daintree's stored data",
+    severity: "warning",
+  },
+  "network:fetch": {
+    label: "Make network requests",
+    description: "Send and receive data over the network",
+    severity: "warning",
+  },
+  "agent:invoke": {
+    label: "Launch agents",
+    description: "Start agent sessions on your behalf",
+    severity: "warning",
+  },
+  "agent:read": {
+    label: "Read agent activity",
+    description: "Observe running agent sessions",
+    severity: "neutral",
+  },
+  "agent:register": {
+    label: "Register agent CLIs",
+    description: "Add launchable agent commands",
+    severity: "warning",
+  },
+  "git:read": {
+    label: "Read git status",
+    description: "View branch and change information",
+    severity: "neutral",
+  },
+  "git:write": {
+    label: "Run git commands",
+    description: "Commit, branch, and modify git state",
+    severity: "warning",
+  },
+  "clipboard:read": {
+    label: "Read clipboard",
+    description: "Access clipboard contents",
+    severity: "neutral",
+  },
+  "clipboard:write": {
+    label: "Write clipboard",
+    description: "Replace clipboard contents",
+    severity: "neutral",
+  },
+  "shell:exec": {
+    label: "Run shell commands",
+    description: "Execute arbitrary commands on your machine",
+    severity: "danger",
+  },
+} satisfies Record<BuiltInPluginCapability, CapabilityMeta>;
+
+const SEVERITY_TEXT_CLASS: Record<CapabilitySeverity, string> = {
+  danger: "text-status-danger",
+  warning: "text-status-warning",
+  neutral: "text-daintree-text/40",
+};
+
+function CapabilityRow({
+  capability,
+  allowedUrls,
+}: {
+  capability: BuiltInPluginCapability;
+  allowedUrls?: string[];
+}) {
+  const meta = CAPABILITY_META[capability];
+  const scoped = capability === "network:fetch" && allowedUrls && allowedUrls.length > 0;
+  return (
+    <li className="flex items-start gap-2">
+      {meta.severity === "danger" ? (
+        <AlertCircle className={`w-3.5 h-3.5 shrink-0 mt-0.5 ${SEVERITY_TEXT_CLASS.danger}`} />
+      ) : meta.severity === "warning" ? (
+        <AlertTriangle className={`w-3.5 h-3.5 shrink-0 mt-0.5 ${SEVERITY_TEXT_CLASS.warning}`} />
+      ) : (
+        <span
+          className="w-1.5 h-1.5 rounded-full bg-daintree-text/30 shrink-0 mt-[7px]"
+          aria-hidden
+        />
+      )}
+      <div className="min-w-0">
+        <div
+          className={`text-xs ${meta.severity === "neutral" ? "text-daintree-text/80" : SEVERITY_TEXT_CLASS[meta.severity]}`}
+        >
+          {meta.label}
+        </div>
+        <div className="text-[11px] text-daintree-text/40">{meta.description}</div>
+        {scoped && (
+          <ul className="mt-0.5 space-y-0.5">
+            {allowedUrls.map((url) => (
+              <li key={url} className="text-[11px] font-mono text-daintree-text/50 break-all">
+                {url}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </li>
+  );
+}
+
+/**
+ * Surfaces a plugin's declared capabilities (#9556) as a labelled, risk-coloured
+ * list with an effective-danger summary. Read-only — the data already rides on
+ * `LoadedPluginInfo`; this only presents it so users can audit what an installed
+ * plugin is allowed to do without re-opening the install dialog.
+ */
+function PluginCapabilityList({ plugin }: { plugin: LoadedPluginInfo }) {
+  const declared = new Set(plugin.manifest.capabilities ?? []);
+  const granted = BUILT_IN_PLUGIN_CAPABILITIES.filter((c) => declared.has(c));
+  const allowedUrls = plugin.manifest.scopes?.network?.allowedUrls;
+
+  return (
+    <div className="space-y-2">
+      <h4 className="text-[11px] font-medium uppercase tracking-wide text-daintree-text/40">
+        Permissions
+      </h4>
+      {granted.length === 0 ? (
+        <p className="text-xs text-daintree-text/40">No special permissions</p>
+      ) : (
+        <>
+          {plugin.pluginDanger === "confirm" && (
+            <div className="flex items-start gap-2 p-2 rounded-[var(--radius-md)] bg-status-warning/10 border border-status-warning/20">
+              <AlertTriangle className="w-3.5 h-3.5 text-status-warning shrink-0 mt-0.5" />
+              <p className="text-[11px] text-status-warning break-words">
+                Requests sensitive permissions — review before enabling
+              </p>
+            </div>
+          )}
+          <ul className="space-y-1.5">
+            {granted.map((capability) => (
+              <CapabilityRow key={capability} capability={capability} allowedUrls={allowedUrls} />
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+}
 
 interface PluginDetailPaneProps {
   plugin: LoadedPluginInfo;
@@ -159,6 +342,8 @@ export function PluginDetailPane({
           </p>
         </div>
       )}
+
+      <PluginCapabilityList plugin={plugin} />
 
       {/* Settings render whether or not the plugin is enabled — values persist
           independently of the plugin's runtime, so users can pre-configure a

--- a/src/components/Plugin/__tests__/PluginDetailPane.test.tsx
+++ b/src/components/Plugin/__tests__/PluginDetailPane.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { PluginDetailPane } from "../PluginDetailPane";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { BuiltInPluginCapability, LoadedPluginInfo } from "@shared/types/plugin";
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+// PluginSettingsForm reads the active project via this selector.
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: (selector: (s: { currentProject: { id: string } | null }) => unknown) =>
+    selector({ currentProject: null }),
+}));
+
+function makePlugin(overrides: Partial<LoadedPluginInfo> = {}): LoadedPluginInfo {
+  return {
+    manifest: {
+      name: "acme.demo",
+      version: "1.0.0",
+      displayName: "Acme Demo",
+      contributes: {
+        panels: [],
+        toolbarButtons: [],
+        menuItems: [],
+        commands: [],
+        experimental_views: [],
+        experimental_mcpServers: [],
+        keybindings: [],
+        contextMenus: [],
+        forgeProviders: [],
+        fileDecorationProviders: [],
+        agents: [],
+      },
+    },
+    dir: "/plugins/acme.demo",
+    loadedAt: 1,
+    isBuiltin: false,
+    disabled: false,
+    pendingRestart: false,
+    source: "sideload",
+    installedAt: 1,
+    archiveHash: null,
+    originalUrl: null,
+    loadError: null,
+    updateAvailable: null,
+    devMode: false,
+    pluginDanger: "safe",
+    ...overrides,
+  };
+}
+
+function withCapabilities(
+  caps: BuiltInPluginCapability[],
+  overrides: Partial<LoadedPluginInfo> = {}
+): LoadedPluginInfo {
+  const base = makePlugin(overrides);
+  return {
+    ...base,
+    manifest: { ...base.manifest, capabilities: caps, ...overrides.manifest },
+  };
+}
+
+function renderPane(plugin: LoadedPluginInfo) {
+  return render(
+    <TooltipProvider>
+      <PluginDetailPane
+        plugin={plugin}
+        checkingUpdate={false}
+        upToDate={false}
+        onUninstall={vi.fn()}
+        onCheckForUpdate={vi.fn()}
+      />
+    </TooltipProvider>
+  );
+}
+
+describe("PluginDetailPane capabilities", () => {
+  it("shows the no-permissions empty state when no capabilities are declared", () => {
+    renderPane(makePlugin());
+    expect(screen.getByText("No special permissions")).toBeTruthy();
+  });
+
+  it("renders a labelled row for each declared capability", () => {
+    renderPane(withCapabilities(["fs:project-read", "shell:exec"]));
+    expect(screen.getByText("Read project files")).toBeTruthy();
+    expect(screen.getByText("Run shell commands")).toBeTruthy();
+  });
+
+  it("does not show the danger summary banner when pluginDanger is safe", () => {
+    renderPane(withCapabilities(["fs:project-read"], { pluginDanger: "safe" }));
+    expect(screen.queryByText(/Requests sensitive permissions/)).toBeNull();
+  });
+
+  it("shows the danger summary banner when pluginDanger is confirm", () => {
+    renderPane(withCapabilities(["shell:exec"], { pluginDanger: "confirm" }));
+    expect(screen.getByText(/Requests sensitive permissions/)).toBeTruthy();
+  });
+
+  it("lists the network allowlist under the network:fetch row when scoped", () => {
+    const plugin = withCapabilities(["network:fetch"], {
+      pluginDanger: "safe",
+      manifest: {
+        ...makePlugin().manifest,
+        capabilities: ["network:fetch"],
+        scopes: { network: { allowedUrls: ["https://api.example.com/v1"] } },
+      },
+    });
+    renderPane(plugin);
+    expect(screen.getByText("https://api.example.com/v1")).toBeTruthy();
+  });
+
+  it("renders capabilities in BUILT_IN_PLUGIN_CAPABILITIES order, not manifest order", () => {
+    // Declared shell:exec first, but fs:project-read sorts earlier in the canon.
+    renderPane(withCapabilities(["shell:exec", "fs:project-read"]));
+    const list = screen.getByText("Read project files").closest("ul");
+    expect(list).toBeTruthy();
+    const labels = within(list as HTMLElement)
+      .getAllByText(/Read project files|Run shell commands/)
+      .map((el) => el.textContent);
+    expect(labels[0]).toBe("Read project files");
+    expect(labels[1]).toBe("Run shell commands");
+  });
+});

--- a/src/components/Plugin/__tests__/PluginDetailPane.test.tsx
+++ b/src/components/Plugin/__tests__/PluginDetailPane.test.tsx
@@ -4,7 +4,11 @@ import { describe, expect, it, vi } from "vitest";
 import { render, screen, within } from "@testing-library/react";
 import { PluginDetailPane } from "../PluginDetailPane";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import type { BuiltInPluginCapability, LoadedPluginInfo } from "@shared/types/plugin";
+import {
+  BUILT_IN_PLUGIN_CAPABILITIES,
+  type BuiltInPluginCapability,
+  type LoadedPluginInfo,
+} from "@shared/types/plugin";
 
 vi.mock("@/utils/logger", () => ({
   logError: vi.fn(),
@@ -114,6 +118,23 @@ describe("PluginDetailPane capabilities", () => {
     });
     renderPane(plugin);
     expect(screen.getByText("https://api.example.com/v1")).toBeTruthy();
+  });
+
+  it("renders a label for every built-in capability when all are declared", () => {
+    renderPane(withCapabilities([...BUILT_IN_PLUGIN_CAPABILITIES]));
+    // One representative label per family, covering all three severity tiers.
+    for (const label of [
+      "Read project files",
+      "Write project files",
+      "Make network requests",
+      "Launch agents",
+      "Register agent CLIs",
+      "Run git commands",
+      "Read clipboard",
+      "Run shell commands",
+    ]) {
+      expect(screen.getByText(label)).toBeTruthy();
+    }
   });
 
   it("renders capabilities in BUILT_IN_PLUGIN_CAPABILITIES order, not manifest order", () => {

--- a/src/components/Plugin/__tests__/PluginManagerDialog.test.tsx
+++ b/src/components/Plugin/__tests__/PluginManagerDialog.test.tsx
@@ -75,6 +75,7 @@ function makePlugin(overrides: Partial<LoadedPluginInfo> = {}): LoadedPluginInfo
     loadError: null,
     updateAvailable: null,
     devMode: false,
+    pluginDanger: "safe",
     ...overrides,
   };
 }

--- a/src/components/Settings/__tests__/PluginsTab.test.tsx
+++ b/src/components/Settings/__tests__/PluginsTab.test.tsx
@@ -51,6 +51,7 @@ function makePlugin(name: string): LoadedPluginInfo {
     loadError: null,
     updateAvailable: null,
     devMode: false,
+    pluginDanger: "safe",
   };
 }
 


### PR DESCRIPTION
## Summary

- Adds `pluginDanger` (`"safe"` | `"confirm"`) to `LoadedPluginInfo`, computed once in `PluginService.listPlugins` by reusing the existing `CONFIRM_TRIGGERING_CAPABILITIES` set and compound-capability lattice — no third renderer copy
- `PluginDetailPane` now renders a labelled permissions list with risk-coloured status treatment: danger for `shell:exec`, warning for `write`/`network`/`agent` capabilities, neutral for reads and clipboard; includes an effective-danger summary banner, the network allowlist under the `network:fetch` row, and a "No special permissions" empty state
- Read-only display of data already held in `LoadedPluginInfo` — no new permission machinery

Resolves #9556

## Changes

- `electron/services/PluginService.ts` — computes `pluginDanger` on each `LoadedPluginInfo` entry in `listPlugins`
- `shared/types/plugin.ts` — adds `pluginDanger` field and capability label/description helpers
- `src/components/Plugin/PluginDetailPane.tsx` — permissions list with risk-colour treatment, danger summary banner, network allowlist, empty state

## Testing

- `npm run check` clean (typecheck + lint + format + IPC checks)
- Build passes
- 503 tests pass across affected files; new tests cover `pluginDanger` logic in `PluginService` and the capability list rendering in `PluginDetailPane`