### PR TITLE
feat(plugins): add filter-operator search to the plugin manager

### DIFF
--- a/src/components/Plugin/PluginManagerDialog.tsx
+++ b/src/components/Plugin/PluginManagerDialog.tsx
@@ -1,5 +1,5 @@
 import { Plug, FilePlus, Link2, Info, Download, AlertCircle, AlertTriangle } from "lucide-react";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo, useDeferredValue } from "react";
 import { SettingsSwitch } from "@/components/Settings/SettingsSwitch";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
@@ -11,10 +11,25 @@ import { logError } from "@/utils/logger";
 import { cn } from "@/lib/utils";
 import { usePluginManager } from "./usePluginManager";
 import { PluginDetailPane, SOURCE_BADGE_LABELS, pluginLabel } from "./PluginDetailPane";
+import { filterPlugins, isQueryActive, parsePluginQuery } from "@/lib/pluginSearch";
 import type { LoadedPluginInfo, PluginDeepLinkIntent } from "@shared/types/plugin";
 
 const ROW_BADGE_CLASS =
   "inline-flex items-center px-1.5 py-0.5 rounded-sm text-[10px] font-medium bg-overlay-subtle border border-daintree-border/50 text-daintree-text/60 uppercase tracking-wide";
+
+// Below this many installed plugins the search box adds noise without value, so
+// it stays hidden and the grouped list is shown directly (#9557).
+const PLUGIN_SEARCH_MIN_ITEMS = 10;
+
+// Static operator chips surfaced below the search input so the filter syntax is
+// discoverable instead of hidden. `@cap:<value>` is omitted — its value set is
+// dynamic and would overflow the 288px pane — but stays typeable.
+const PLUGIN_FILTER_CHIPS: ReadonlyArray<{ token: string; label: string }> = [
+  { token: "@builtin", label: "Built-in" },
+  { token: "@installed", label: "Installed" },
+  { token: "@enabled", label: "Enabled" },
+  { token: "@disabled", label: "Disabled" },
+];
 
 /**
  * Section grouping for the installed list (#9554). A disabled plugin always
@@ -213,6 +228,37 @@ export function PluginManagerDialog({
   const rowRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const [highlightedPluginId, setHighlightedPluginId] = useState<string | null>(null);
 
+  // Free-text + operator filter (#9557). The input binds to the immediate
+  // `query`; the expensive filter pass runs against the deferred value so typing
+  // stays responsive (LESSON #3726 — useDeferredValue, not setTimeout debounce).
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const [query, setQuery] = useState("");
+  const deferredQuery = useDeferredValue(query);
+  const isSearchVisible = pm.plugins.length >= PLUGIN_SEARCH_MIN_ITEMS;
+  const isSearchActive = useMemo(
+    () => isSearchVisible && isQueryActive(parsePluginQuery(deferredQuery)),
+    [isSearchVisible, deferredQuery]
+  );
+  const filteredPlugins = useMemo(
+    () => (isSearchActive ? filterPlugins(pm.plugins, deferredQuery) : pm.plugins),
+    [isSearchActive, pm.plugins, deferredQuery]
+  );
+
+  const appendFilterToken = (token: string) => {
+    setQuery((prev) => {
+      const tokens = prev.split(/\s+/).filter(Boolean);
+      if (tokens.includes(token)) return prev; // don't duplicate an active token
+      return prev.length === 0 ? token : `${prev.trim()} ${token}`;
+    });
+    searchInputRef.current?.focus();
+  };
+
+  // Reset the query whenever the dialog closes so a stale filter doesn't hide
+  // rows on reopen.
+  useEffect(() => {
+    if (!isOpen) setQuery("");
+  }, [isOpen]);
+
   // Re-validate the selection after every list refresh (reopen, uninstall,
   // cross-window provenance change). A single effect keyed on the list nulls a
   // selection whose plugin is gone — kept here rather than in a second reset
@@ -226,6 +272,20 @@ export function PluginManagerDialog({
     }
   }, [pm.plugins, selectedPluginId]);
 
+  // When a filter is active, also null a selection whose plugin is no longer in
+  // the filtered set — otherwise the detail pane keeps showing a plugin that the
+  // current query hides (#9557). Separate from the full-list effect above so the
+  // two have independent dependency arrays and can't race.
+  useEffect(() => {
+    if (
+      isSearchActive &&
+      selectedPluginId !== null &&
+      !filteredPlugins.some((p) => p.manifest.name === selectedPluginId)
+    ) {
+      setSelectedPluginId(null);
+    }
+  }, [isSearchActive, filteredPlugins, selectedPluginId]);
+
   // When the hook resolves a deep-link `open` target to an installed plugin
   // (#9559), select it, scroll its row into view, and apply a transient neutral
   // highlight, then clear the focus request so it doesn't re-trigger on the next
@@ -235,6 +295,9 @@ export function PluginManagerDialog({
   useEffect(() => {
     if (!focusPluginId) return;
     if (!pm.plugins.some((p) => p.manifest.name === focusPluginId)) return;
+    // Clear any active filter so the deep-link target row is actually rendered
+    // and can be scrolled into view (#9557 + #9559).
+    setQuery("");
     setSelectedPluginId(focusPluginId);
     const row = rowRefs.current.get(focusPluginId);
     if (!row) return; // Row not rendered yet — the not-found notice path handles misses.
@@ -354,6 +417,31 @@ export function PluginManagerDialog({
                 Install from URL
               </Button>
             </div>
+            {isSearchVisible && (
+              <div className="space-y-2">
+                <input
+                  ref={searchInputRef}
+                  type="search"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Filter plugins"
+                  aria-label="Filter plugins"
+                  className="w-full px-3 py-2 text-sm rounded-[var(--radius-md)] bg-daintree-bg border border-daintree-border text-daintree-text placeholder:text-daintree-text/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+                />
+                <div className="flex flex-wrap gap-1">
+                  {PLUGIN_FILTER_CHIPS.map(({ token, label }) => (
+                    <button
+                      key={token}
+                      type="button"
+                      onClick={() => appendFilterToken(token)}
+                      className="px-1.5 py-0.5 rounded-sm text-[10px] font-medium bg-overlay-subtle border border-daintree-border/50 text-daintree-text/60 hover:text-daintree-text/80 hover:border-daintree-border transition-colors"
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
             {pm.notice && (
               <div className="flex items-start gap-2 p-2 rounded-[var(--radius-md)] bg-overlay-subtle border border-daintree-border">
                 <Info className="w-3.5 h-3.5 text-daintree-text/50 shrink-0 mt-0.5" />
@@ -385,46 +473,89 @@ export function PluginManagerDialog({
               title="No plugins installed"
               description="Install one from a file or URL to add panels, commands, and integrations."
             />
-          ) : !hasPlugins ? null : (
+          ) : !hasPlugins ? null : isSearchActive && filteredPlugins.length === 0 ? (
+            // Filtered to nothing — offer a one-tap escape back to the full list.
+            // No section headers here, so LESSON #9006 (role="group" + VoiceOver
+            // on Chromium 146) never applies to the filtered view.
+            <div className="flex-1 min-h-0 flex items-center justify-center">
+              <EmptyState
+                variant="filtered-empty"
+                scale="sidebar"
+                title="No matching plugins"
+                action={
+                  <button
+                    type="button"
+                    onClick={() => setQuery("")}
+                    className="text-xs text-daintree-text/60 hover:text-daintree-text underline underline-offset-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent rounded-sm"
+                  >
+                    Clear search
+                  </button>
+                }
+              />
+            </div>
+          ) : (
             <ScrollShadow
               className="flex-1 min-h-0"
               scrollClassName="p-2 space-y-4"
               role="listbox"
               aria-label="Installed plugins"
             >
-              {PLUGIN_GROUPS.map(({ id, label, match }) => {
-                const groupPlugins = pm.plugins.filter(match);
-                if (groupPlugins.length === 0) return null;
-                return (
-                  <div key={id} role="group" aria-labelledby={id} className="space-y-1">
-                    <p
-                      id={id}
-                      className="px-3 text-[10px] font-medium uppercase tracking-wider text-daintree-text/40 select-none"
-                    >
-                      {label}
-                    </p>
-                    {groupPlugins.map((plugin) => (
-                      <PluginRow
-                        key={plugin.manifest.name}
-                        plugin={plugin}
-                        selected={plugin.manifest.name === selectedPluginId}
-                        toggling={pm.pending.has(plugin.manifest.name)}
-                        onSelect={() =>
-                          setSelectedPluginId((prev) =>
-                            prev === plugin.manifest.name ? null : plugin.manifest.name
-                          )
-                        }
-                        onToggle={() => void pm.handleToggle(plugin)}
-                        highlighted={highlightedPluginId === plugin.manifest.name}
-                        innerRef={(el) => {
-                          if (el) rowRefs.current.set(plugin.manifest.name, el);
-                          else rowRefs.current.delete(plugin.manifest.name);
-                        }}
-                      />
-                    ))}
-                  </div>
-                );
-              })}
+              {isSearchActive
+                ? // Flat filtered list — grouping is meaningless across filters
+                  // like @installed, and a flat list keeps the listbox free of
+                  // role="group" section labels (LESSON #9006).
+                  filteredPlugins.map((plugin) => (
+                    <PluginRow
+                      key={plugin.manifest.name}
+                      plugin={plugin}
+                      selected={plugin.manifest.name === selectedPluginId}
+                      toggling={pm.pending.has(plugin.manifest.name)}
+                      onSelect={() =>
+                        setSelectedPluginId((prev) =>
+                          prev === plugin.manifest.name ? null : plugin.manifest.name
+                        )
+                      }
+                      onToggle={() => void pm.handleToggle(plugin)}
+                      highlighted={highlightedPluginId === plugin.manifest.name}
+                      innerRef={(el) => {
+                        if (el) rowRefs.current.set(plugin.manifest.name, el);
+                        else rowRefs.current.delete(plugin.manifest.name);
+                      }}
+                    />
+                  ))
+                : PLUGIN_GROUPS.map(({ id, label, match }) => {
+                    const groupPlugins = pm.plugins.filter(match);
+                    if (groupPlugins.length === 0) return null;
+                    return (
+                      <div key={id} role="group" aria-labelledby={id} className="space-y-1">
+                        <p
+                          id={id}
+                          className="px-3 text-[10px] font-medium uppercase tracking-wider text-daintree-text/40 select-none"
+                        >
+                          {label}
+                        </p>
+                        {groupPlugins.map((plugin) => (
+                          <PluginRow
+                            key={plugin.manifest.name}
+                            plugin={plugin}
+                            selected={plugin.manifest.name === selectedPluginId}
+                            toggling={pm.pending.has(plugin.manifest.name)}
+                            onSelect={() =>
+                              setSelectedPluginId((prev) =>
+                                prev === plugin.manifest.name ? null : plugin.manifest.name
+                              )
+                            }
+                            onToggle={() => void pm.handleToggle(plugin)}
+                            highlighted={highlightedPluginId === plugin.manifest.name}
+                            innerRef={(el) => {
+                              if (el) rowRefs.current.set(plugin.manifest.name, el);
+                              else rowRefs.current.delete(plugin.manifest.name);
+                            }}
+                          />
+                        ))}
+                      </div>
+                    );
+                  })}
             </ScrollShadow>
           )}
         </div>

--- a/src/components/Plugin/PluginManagerDialog.tsx
+++ b/src/components/Plugin/PluginManagerDialog.tsx
@@ -247,17 +247,19 @@ export function PluginManagerDialog({
   const appendFilterToken = (token: string) => {
     setQuery((prev) => {
       const tokens = prev.split(/\s+/).filter(Boolean);
-      if (tokens.includes(token)) return prev; // don't duplicate an active token
+      // Operators are case-insensitive, so dedup case-insensitively too.
+      if (tokens.some((t) => t.toLowerCase() === token.toLowerCase())) return prev;
       return prev.length === 0 ? token : `${prev.trim()} ${token}`;
     });
     searchInputRef.current?.focus();
   };
 
-  // Reset the query whenever the dialog closes so a stale filter doesn't hide
-  // rows on reopen.
+  // Reset the query when the dialog closes (so a stale filter doesn't hide rows
+  // on reopen) or when the list drops back below the search threshold (so the
+  // filter can't silently reactivate if the count later climbs again).
   useEffect(() => {
-    if (!isOpen) setQuery("");
-  }, [isOpen]);
+    if (!isOpen || !isSearchVisible) setQuery("");
+  }, [isOpen, isSearchVisible]);
 
   // Re-validate the selection after every list refresh (reopen, uninstall,
   // cross-window provenance change). A single effect keyed on the list nulls a

--- a/src/components/Plugin/__tests__/PluginManagerDialog.test.tsx
+++ b/src/components/Plugin/__tests__/PluginManagerDialog.test.tsx
@@ -1317,6 +1317,45 @@ describe("PluginManagerDialog", () => {
       expect(screen.queryByText("Plugin00")).toBeNull();
     });
 
+    it("appends an operator chip after existing free text", async () => {
+      (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue(manyPlugins(10));
+      renderDialog();
+      const input = await screen.findByLabelText<HTMLInputElement>("Filter plugins");
+      fireEvent.change(input, { target: { value: "notes" } });
+      fireEvent.click(screen.getByRole("button", { name: "Installed" }));
+      expect(screen.getByLabelText<HTMLInputElement>("Filter plugins").value).toBe(
+        "notes @installed"
+      );
+    });
+
+    it("does not duplicate an operator that is already present (case-insensitive)", async () => {
+      (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue(manyPlugins(10));
+      renderDialog();
+      const input = await screen.findByLabelText<HTMLInputElement>("Filter plugins");
+      fireEvent.change(input, { target: { value: "@BUILTIN" } });
+      fireEvent.click(screen.getByRole("button", { name: "Built-in" }));
+      expect(screen.getByLabelText<HTMLInputElement>("Filter plugins").value).toBe("@BUILTIN");
+    });
+
+    it("filters by the @cap operator with a colon-bearing value", async () => {
+      const plugins = [
+        ...manyPlugins(10),
+        make("NetPlugin", {
+          manifest: {
+            name: "pkg.net",
+            displayName: "NetPlugin",
+            capabilities: ["network:fetch"],
+          },
+        }),
+      ];
+      (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue(plugins);
+      renderDialog();
+      const input = await screen.findByLabelText("Filter plugins");
+      fireEvent.change(input, { target: { value: "@cap:network:fetch" } });
+      await waitFor(() => expect(screen.getByText("NetPlugin")).toBeTruthy());
+      expect(screen.queryByText("Plugin00")).toBeNull();
+    });
+
     it("renders a flat list with no group sections while filtering", async () => {
       (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue(manyPlugins(10));
       renderDialog();

--- a/src/components/Plugin/__tests__/PluginManagerDialog.test.tsx
+++ b/src/components/Plugin/__tests__/PluginManagerDialog.test.tsx
@@ -1246,4 +1246,112 @@ describe("PluginManagerDialog", () => {
       expect(labels).toEqual(["Alpha", "Zebra"]);
     });
   });
+
+  describe("search (#9557)", () => {
+    // The search box only appears once the list is long enough to need it
+    // (PLUGIN_SEARCH_MIN_ITEMS = 10). Generate distinct, addressable plugins.
+    const make = (
+      name: string,
+      overrides: Partial<Omit<LoadedPluginInfo, "manifest">> & {
+        manifest?: Partial<LoadedPluginInfo["manifest"]>;
+      } = {}
+    ): LoadedPluginInfo => {
+      const { manifest: manifestOverride, ...rest } = overrides;
+      const base = makePlugin(rest);
+      return {
+        ...base,
+        manifest: {
+          ...base.manifest,
+          name: `pkg.${name}`,
+          displayName: name,
+          ...manifestOverride,
+        },
+      };
+    };
+
+    const manyPlugins = (count: number) =>
+      Array.from({ length: count }, (_, i) => make(`Plugin${String(i).padStart(2, "0")}`));
+
+    it("hides the filter input below the item threshold", async () => {
+      (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue(manyPlugins(9));
+      renderDialog();
+      await waitFor(() => expect(screen.getByText("Plugin00")).toBeTruthy());
+      expect(screen.queryByLabelText("Filter plugins")).toBeNull();
+    });
+
+    it("shows the filter input at the item threshold", async () => {
+      (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue(manyPlugins(10));
+      renderDialog();
+      await waitFor(() => expect(screen.getByLabelText("Filter plugins")).toBeTruthy());
+    });
+
+    it("filters the list by free text", async () => {
+      const plugins = [
+        ...manyPlugins(10),
+        make("Notepad", { manifest: { name: "pkg.notepad", displayName: "Notepad" } }),
+      ];
+      (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue(plugins);
+      renderDialog();
+      const input = await screen.findByLabelText("Filter plugins");
+      fireEvent.change(input, { target: { value: "Notepad" } });
+      await waitFor(() => expect(screen.getByText("Notepad")).toBeTruthy());
+      expect(screen.queryByText("Plugin00")).toBeNull();
+    });
+
+    it("injects an operator token when a filter chip is clicked", async () => {
+      const plugins = [
+        ...manyPlugins(10),
+        make("CoreThing", {
+          manifest: { name: "pkg.core", displayName: "CoreThing" },
+          isBuiltin: true,
+          source: "builtin",
+        }),
+      ];
+      (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue(plugins);
+      renderDialog();
+      await screen.findByLabelText("Filter plugins");
+      fireEvent.click(screen.getByRole("button", { name: "Built-in" }));
+      const input = screen.getByLabelText<HTMLInputElement>("Filter plugins");
+      expect(input.value).toBe("@builtin");
+      await waitFor(() => expect(screen.getByText("CoreThing")).toBeTruthy());
+      expect(screen.queryByText("Plugin00")).toBeNull();
+    });
+
+    it("renders a flat list with no group sections while filtering", async () => {
+      (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue(manyPlugins(10));
+      renderDialog();
+      const input = await screen.findByLabelText("Filter plugins");
+      fireEvent.change(input, { target: { value: "Plugin00" } });
+      await waitFor(() => expect(screen.queryByText("Plugin01")).toBeNull());
+      expect(screen.getByText("Plugin00")).toBeTruthy();
+      expect(screen.queryByRole("group", { name: "Installed" })).toBeNull();
+    });
+
+    it("shows a zero-result state with a Clear search control", async () => {
+      (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue(manyPlugins(10));
+      renderDialog();
+      const input = await screen.findByLabelText("Filter plugins");
+      fireEvent.change(input, { target: { value: "zzzznomatch" } });
+      await waitFor(() => expect(screen.getByText("No matching plugins")).toBeTruthy());
+      fireEvent.click(screen.getByRole("button", { name: "Clear search" }));
+      await waitFor(() => expect(screen.getByText("Plugin00")).toBeTruthy());
+    });
+
+    it("clears the selected plugin when the filter hides it", async () => {
+      const plugins = [
+        ...manyPlugins(10),
+        make("Notepad", { manifest: { name: "pkg.notepad", displayName: "Notepad" } }),
+      ];
+      (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue(plugins);
+      renderDialog();
+      await screen.findByLabelText("Filter plugins");
+      fireEvent.click(await screen.findByRole("option", { name: /Plugin00/ }));
+      // Detail pane now shows the selected plugin's uninstall control.
+      await waitFor(() => expect(screen.getByRole("button", { name: /uninstall/i })).toBeTruthy());
+      const input = screen.getByLabelText("Filter plugins");
+      fireEvent.change(input, { target: { value: "Notepad" } });
+      // Plugin00 is filtered out, so the detail pane falls back to its empty state.
+      await waitFor(() => expect(screen.getByText("Select a plugin")).toBeTruthy());
+    });
+  });
 });

--- a/src/components/Plugin/usePluginManager.ts
+++ b/src/components/Plugin/usePluginManager.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useDeferredLoading } from "@/hooks";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -107,6 +107,9 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
   // matching row, then clears it. Held in a ref for the consumption effect so
   // `onConsumed` isn't a reactive dependency that re-fires the effect.
   const [focusPluginId, setFocusPluginId] = useState<string | null>(null);
+  // Stable identity so the consumer's deep-link highlight effect doesn't tear
+  // down its 2s timer the instant it clears the focus request (#9557 review).
+  const clearFocusPluginId = useCallback(() => setFocusPluginId(null), []);
   const deepLinkConsumedRef = useRef<(() => void) | undefined>(undefined);
   deepLinkConsumedRef.current = deepLink?.onConsumed;
   // Mirror `showUrlDialog` so the deep-link effect can read the latest value
@@ -617,6 +620,6 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
     handleDragLeave,
     handleDrop,
     focusPluginId,
-    clearFocusPluginId: () => setFocusPluginId(null),
+    clearFocusPluginId,
   };
 }

--- a/src/lib/__tests__/pluginSearch.test.ts
+++ b/src/lib/__tests__/pluginSearch.test.ts
@@ -79,6 +79,18 @@ describe("parsePluginQuery", () => {
     expect(parsed.operators).toEqual([{ key: "cap", value: null }]);
     expect(parsed.freeText).toBe("");
   });
+
+  it("stops the operator key at a non-letter so @builtin-extra yields @builtin + tail", () => {
+    const parsed = parsePluginQuery("@builtin-extra");
+    expect(parsed.operators).toEqual([{ key: "builtin", value: null }]);
+    expect(parsed.freeText).toBe("-extra");
+  });
+
+  it("keeps a colon-bearing capability value intact", () => {
+    const parsed = parsePluginQuery("@cap:network:fetch");
+    expect(parsed.operators).toEqual([{ key: "cap", value: "network:fetch" }]);
+    expect(parsed.freeText).toBe("");
+  });
 });
 
 describe("isQueryActive", () => {

--- a/src/lib/__tests__/pluginSearch.test.ts
+++ b/src/lib/__tests__/pluginSearch.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import type { LoadedPluginInfo, PluginCapability } from "@shared/types/plugin";
+import { filterPlugins, isQueryActive, parsePluginQuery, scorePlugin } from "../pluginSearch";
+
+function makePlugin(overrides: {
+  name: string;
+  displayName?: string;
+  description?: string;
+  isBuiltin?: boolean;
+  disabled?: boolean;
+  capabilities?: PluginCapability[];
+}): LoadedPluginInfo {
+  return {
+    manifest: {
+      name: overrides.name,
+      version: "1.0.0",
+      displayName: overrides.displayName,
+      description: overrides.description,
+      capabilities: overrides.capabilities,
+      contributes: {
+        panels: [],
+        toolbarButtons: [],
+        menuItems: [],
+        commands: [],
+        experimental_views: [],
+        experimental_mcpServers: [],
+        keybindings: [],
+        contextMenus: [],
+        forgeProviders: [],
+        fileDecorationProviders: [],
+        agents: [],
+      },
+    },
+    dir: `/plugins/${overrides.name}`,
+    loadedAt: 0,
+    isBuiltin: overrides.isBuiltin ?? false,
+    source: overrides.isBuiltin ? "builtin" : "sideload",
+    installedAt: 0,
+    archiveHash: null,
+    originalUrl: null,
+    loadError: null,
+    disabled: overrides.disabled ?? false,
+    updateAvailable: null,
+    devMode: false,
+  };
+}
+
+const names = (plugins: LoadedPluginInfo[]) => plugins.map((p) => p.manifest.name);
+
+describe("parsePluginQuery", () => {
+  it("splits operators from free text", () => {
+    const parsed = parsePluginQuery("@builtin notes");
+    expect(parsed.operators).toEqual([{ key: "builtin", value: null }]);
+    expect(parsed.freeText).toBe("notes");
+  });
+
+  it("is case-insensitive on operator keys and values", () => {
+    const parsed = parsePluginQuery("@Builtin @CAP:Network:Fetch");
+    expect(parsed.operators).toEqual([
+      { key: "builtin", value: null },
+      { key: "cap", value: "network:fetch" },
+    ]);
+  });
+
+  it("treats unknown @tokens as free text", () => {
+    const parsed = parsePluginQuery("@category:ui notes");
+    expect(parsed.operators).toEqual([]);
+    expect(parsed.freeText).toBe("@category:ui notes");
+  });
+
+  it("captures free text on both sides of an operator", () => {
+    const parsed = parsePluginQuery("foo @disabled bar");
+    expect(parsed.operators).toEqual([{ key: "disabled", value: null }]);
+    expect(parsed.freeText).toBe("foo bar");
+  });
+
+  it("parses @cap with an empty value as null", () => {
+    const parsed = parsePluginQuery("@cap:");
+    expect(parsed.operators).toEqual([{ key: "cap", value: null }]);
+    expect(parsed.freeText).toBe("");
+  });
+});
+
+describe("isQueryActive", () => {
+  it("is false for whitespace-only input", () => {
+    expect(isQueryActive(parsePluginQuery("   "))).toBe(false);
+  });
+
+  it("is true when an operator is present", () => {
+    expect(isQueryActive(parsePluginQuery("@enabled"))).toBe(true);
+  });
+
+  it("is true when free text is present", () => {
+    expect(isQueryActive(parsePluginQuery("notes"))).toBe(true);
+  });
+});
+
+describe("filterPlugins operators", () => {
+  const plugins = [
+    makePlugin({ name: "core.builtin", isBuiltin: true }),
+    makePlugin({ name: "core.builtin-off", isBuiltin: true, disabled: true }),
+    makePlugin({ name: "third.party" }),
+    makePlugin({ name: "third.party-off", disabled: true }),
+  ];
+
+  it("@builtin returns only enabled builtins", () => {
+    expect(names(filterPlugins(plugins, "@builtin"))).toEqual(["core.builtin"]);
+  });
+
+  it("@installed returns only enabled non-builtins", () => {
+    expect(names(filterPlugins(plugins, "@installed"))).toEqual(["third.party"]);
+  });
+
+  it("@enabled returns everything not disabled", () => {
+    expect(names(filterPlugins(plugins, "@enabled"))).toEqual(["core.builtin", "third.party"]);
+  });
+
+  it("@disabled returns only disabled plugins", () => {
+    expect(names(filterPlugins(plugins, "@disabled"))).toEqual([
+      "core.builtin-off",
+      "third.party-off",
+    ]);
+  });
+
+  it("AND-combines multiple operators", () => {
+    expect(names(filterPlugins(plugins, "@builtin @disabled"))).toEqual([]);
+    expect(names(filterPlugins(plugins, "@enabled @builtin"))).toEqual(["core.builtin"]);
+  });
+
+  it("returns all plugins for a blank query", () => {
+    expect(names(filterPlugins(plugins, "  "))).toEqual(names(plugins));
+  });
+});
+
+describe("filterPlugins @cap", () => {
+  const plugins = [
+    makePlugin({ name: "net.plugin", capabilities: ["network:fetch"] }),
+    makePlugin({ name: "fs.plugin", capabilities: ["fs:project-read"] }),
+    makePlugin({ name: "nocap.plugin" }),
+  ];
+
+  it("matches plugins declaring the capability", () => {
+    expect(names(filterPlugins(plugins, "@cap:network:fetch"))).toEqual(["net.plugin"]);
+  });
+
+  it("matches case-insensitively", () => {
+    expect(names(filterPlugins(plugins, "@cap:NETWORK:FETCH"))).toEqual(["net.plugin"]);
+  });
+
+  it("@cap with no value matches nothing", () => {
+    expect(names(filterPlugins(plugins, "@cap:"))).toEqual([]);
+  });
+
+  it("plugins without a capabilities array never match @cap", () => {
+    expect(names(filterPlugins(plugins, "@cap:fs:project-read"))).toEqual(["fs.plugin"]);
+  });
+});
+
+describe("filterPlugins free text", () => {
+  const plugins = [
+    makePlugin({ name: "a.notes", displayName: "Notes", description: "Take quick notes" }),
+    makePlugin({ name: "b.other", displayName: "Other", description: "Has notes in description" }),
+  ];
+
+  it("ranks a name match above a description-only match", () => {
+    expect(names(filterPlugins(plugins, "notes"))).toEqual(["a.notes", "b.other"]);
+  });
+
+  it("drops plugins matching neither name nor description", () => {
+    expect(names(filterPlugins(plugins, "zzzznomatch"))).toEqual([]);
+  });
+
+  it("combines operators with free text (AND)", () => {
+    const mixed = [
+      makePlugin({ name: "x.notes", displayName: "Notes", isBuiltin: true }),
+      makePlugin({ name: "y.notes", displayName: "Notes", isBuiltin: false }),
+    ];
+    expect(names(filterPlugins(mixed, "@builtin notes"))).toEqual(["x.notes"]);
+  });
+});
+
+describe("scorePlugin", () => {
+  it("returns 0 for empty free text", () => {
+    expect(scorePlugin(makePlugin({ name: "a", displayName: "Alpha" }), "")).toBe(0);
+  });
+
+  it("scores a name hit higher than a description hit for the same term", () => {
+    const nameHit = scorePlugin(makePlugin({ name: "a", displayName: "Logger" }), "logger");
+    const descHit = scorePlugin(
+      makePlugin({ name: "b", displayName: "Tool", description: "A logger tool" }),
+      "logger"
+    );
+    expect(nameHit).toBeGreaterThan(descHit);
+  });
+});

--- a/src/lib/__tests__/pluginSearch.test.ts
+++ b/src/lib/__tests__/pluginSearch.test.ts
@@ -42,6 +42,7 @@ function makePlugin(overrides: {
     disabled: overrides.disabled ?? false,
     updateAvailable: null,
     devMode: false,
+    pluginDanger: "safe",
   };
 }
 

--- a/src/lib/actionPaletteSearch.ts
+++ b/src/lib/actionPaletteSearch.ts
@@ -51,7 +51,7 @@ export function extractAcronym(field: string): string {
   return acronym;
 }
 
-function scoreSubsequence(lowerQuery: string, field: string, lowerField: string): number {
+export function scoreSubsequence(lowerQuery: string, field: string, lowerField: string): number {
   let score = 0;
   if (lowerField.includes(lowerQuery)) {
     score += 200;

--- a/src/lib/pluginSearch.ts
+++ b/src/lib/pluginSearch.ts
@@ -1,0 +1,147 @@
+import type { LoadedPluginInfo } from "@shared/types/plugin";
+import { scoreSubsequence } from "./actionPaletteSearch";
+
+const NAME_WEIGHT = 3;
+const DESCRIPTION_WEIGHT = 0.5;
+
+/**
+ * Filter operators recognized by the plugin manager search (#9557). VS
+ * Code–style `@token` flags that narrow the list before free-text scoring.
+ * `@cap:<value>` carries a value (a capability id); the boolean flags don't.
+ * `@category:` is intentionally absent — `PluginManifest` has no category
+ * field, so the operator would always match nothing.
+ */
+export type PluginFilterOperator = "builtin" | "installed" | "enabled" | "disabled" | "cap";
+
+const KNOWN_OPERATORS: ReadonlySet<string> = new Set<PluginFilterOperator>([
+  "builtin",
+  "installed",
+  "enabled",
+  "disabled",
+  "cap",
+]);
+
+export interface ParsedPluginQuery {
+  /** Recognized `@token` operators, in source order. */
+  operators: { key: PluginFilterOperator; value: string | null }[];
+  /** Everything that wasn't a recognized operator, joined for fuzzy matching. */
+  freeText: string;
+}
+
+// `@token` or `@token:value`; the value runs to the next whitespace or `@`.
+const OPERATOR_RE = /@([a-z]+)(?::([^\s@]*))?/gi;
+
+/**
+ * Split a raw query into recognized operators and residual free text. Unknown
+ * `@foo` tokens are treated as free text (kept verbatim) rather than silently
+ * dropped, so a user who misremembers a token still gets a name/description
+ * match attempt instead of an empty list.
+ */
+export function parsePluginQuery(raw: string): ParsedPluginQuery {
+  const operators: ParsedPluginQuery["operators"] = [];
+  const textParts: string[] = [];
+  let lastIndex = 0;
+
+  for (const match of raw.matchAll(OPERATOR_RE)) {
+    const key = match[1].toLowerCase();
+    if (!KNOWN_OPERATORS.has(key)) continue; // leave unknown tokens in the free text
+
+    // Capture any free text sitting between the previous token and this one.
+    const between = raw.slice(lastIndex, match.index);
+    if (between.trim()) textParts.push(between.trim());
+    lastIndex = match.index + match[0].length;
+
+    const rawValue = match[2];
+    operators.push({
+      key: key as PluginFilterOperator,
+      value: rawValue ? rawValue.toLowerCase() : null,
+    });
+  }
+
+  const tail = raw.slice(lastIndex);
+  if (tail.trim()) textParts.push(tail.trim());
+
+  return { operators, freeText: textParts.join(" ").trim() };
+}
+
+/** True when the parsed query would narrow the list (any operator or text). */
+export function isQueryActive(parsed: ParsedPluginQuery): boolean {
+  return parsed.operators.length > 0 || parsed.freeText.length > 0;
+}
+
+function matchesOperator(
+  plugin: LoadedPluginInfo,
+  op: { key: PluginFilterOperator; value: string | null }
+): boolean {
+  switch (op.key) {
+    case "builtin":
+      return plugin.isBuiltin && !plugin.disabled;
+    case "installed":
+      return !plugin.isBuiltin && !plugin.disabled;
+    case "enabled":
+      return !plugin.disabled;
+    case "disabled":
+      return plugin.disabled === true;
+    case "cap": {
+      if (!op.value) return false; // `@cap:` with no value matches nothing
+      return (plugin.manifest.capabilities ?? []).some((c) => c.toLowerCase() === op.value);
+    }
+  }
+}
+
+/**
+ * Fuzzy score for a plugin against free text. Name (displayName ?? name) is
+ * weighted well above description so a name hit always ranks first. Returns 0
+ * when neither field matches.
+ */
+export function scorePlugin(plugin: LoadedPluginInfo, freeText: string): number {
+  if (!freeText) return 0;
+  const lowerQuery = freeText.toLowerCase();
+
+  const name = plugin.manifest.displayName ?? plugin.manifest.name;
+  const nameScore = scoreSubsequence(lowerQuery, name, name.toLowerCase());
+
+  const description = plugin.manifest.description ?? "";
+  const descriptionScore =
+    description.length > 0
+      ? scoreSubsequence(lowerQuery, description, description.toLowerCase())
+      : 0;
+
+  if (nameScore <= 0 && descriptionScore <= 0) return 0;
+  return Math.max(0, nameScore) * NAME_WEIGHT + Math.max(0, descriptionScore) * DESCRIPTION_WEIGHT;
+}
+
+/**
+ * Apply a raw search query to the plugin list. Operators AND-combine as a
+ * pre-filter; free text then scores the survivors and drops non-matches,
+ * sorting by descending score with a name tie-break. With no free text the
+ * operator-filtered list keeps the caller's incoming order.
+ */
+export function filterPlugins(
+  plugins: readonly LoadedPluginInfo[],
+  raw: string
+): LoadedPluginInfo[] {
+  const parsed = parsePluginQuery(raw);
+  if (!isQueryActive(parsed)) return [...plugins];
+
+  const gated = plugins.filter((plugin) =>
+    parsed.operators.every((op) => matchesOperator(plugin, op))
+  );
+
+  if (!parsed.freeText) return gated;
+
+  const scored: Array<{ plugin: LoadedPluginInfo; score: number }> = [];
+  for (const plugin of gated) {
+    const score = scorePlugin(plugin, parsed.freeText);
+    if (score > 0) scored.push({ plugin, score });
+  }
+
+  scored.sort((a, b) => {
+    if (a.score !== b.score) return b.score - a.score;
+    const an = a.plugin.manifest.displayName ?? a.plugin.manifest.name;
+    const bn = b.plugin.manifest.displayName ?? b.plugin.manifest.name;
+    return an.localeCompare(bn, "en", { sensitivity: "base" });
+  });
+
+  return scored.map((entry) => entry.plugin);
+}

--- a/src/lib/pluginSearch.ts
+++ b/src/lib/pluginSearch.ts
@@ -13,13 +13,17 @@ const DESCRIPTION_WEIGHT = 0.5;
  */
 export type PluginFilterOperator = "builtin" | "installed" | "enabled" | "disabled" | "cap";
 
-const KNOWN_OPERATORS: ReadonlySet<string> = new Set<PluginFilterOperator>([
+const KNOWN_OPERATORS: ReadonlySet<string> = new Set([
   "builtin",
   "installed",
   "enabled",
   "disabled",
   "cap",
 ]);
+
+function isKnownOperator(key: unknown): key is PluginFilterOperator {
+  return typeof key === "string" && KNOWN_OPERATORS.has(key);
+}
 
 export interface ParsedPluginQuery {
   /** Recognized `@token` operators, in source order. */
@@ -42,18 +46,24 @@ export function parsePluginQuery(raw: string): ParsedPluginQuery {
   const textParts: string[] = [];
   let lastIndex = 0;
 
-  for (const match of raw.matchAll(OPERATOR_RE)) {
-    const key = match[1].toLowerCase();
-    if (!KNOWN_OPERATORS.has(key)) continue; // leave unknown tokens in the free text
+  const matches = Array.from(raw.matchAll(OPERATOR_RE));
+  for (const match of matches) {
+    // matchAll with a regex containing a capturing group always populates index and [1]
+    const matchIndex = match.index ?? 0;
+    const keyRaw = match[1];
+    if (keyRaw === undefined) continue; // safeguard
+
+    const key = keyRaw.toLowerCase();
+    if (!isKnownOperator(key)) continue; // leave unknown tokens in the free text
 
     // Capture any free text sitting between the previous token and this one.
-    const between = raw.slice(lastIndex, match.index);
+    const between = raw.slice(lastIndex, matchIndex);
     if (between.trim()) textParts.push(between.trim());
-    lastIndex = match.index + match[0].length;
+    lastIndex = matchIndex + match[0].length;
 
     const rawValue = match[2];
     operators.push({
-      key: key as PluginFilterOperator,
+      key,
       value: rawValue ? rawValue.toLowerCase() : null,
     });
   }


### PR DESCRIPTION
## Summary

Adds VS Code-style filter-operator search to the plugin manager dialog. The search box is gated at 10 items — below that, grouping and sort are enough and a search box is just noise. Operators combine with free-text and stay discoverable through chips rather than hidden syntax.

Resolves #9557

## Changes

- New `pluginSearch.ts` module: `parsePluginQuery` (regex tokenizer with `isKnownOperator` type guard), `isQueryActive`, `scorePlugin` (name 3× / description 0.5×), `filterPlugins` (operator AND-gate + fuzzy score + sort)
- Supported operators: `@builtin`, `@installed`, `@enabled`, `@disabled`, `@cap:<capability>` — unknown `@foo` tokens fall through to free text
- Exported `scoreSubsequence` from `actionPaletteSearch.ts` for reuse
- `PluginManagerDialog`: search input gated on `PLUGIN_SEARCH_MIN_ITEMS = 10` with `useDeferredValue`, operator chips that inject tokens, flat filtered list that bypasses grouping when a query is active, zero-result `EmptyState` with a clear action, selection re-validated against the filtered list, query reset on dialog close / threshold drop / deep-link
- `usePluginManager`: `clearFocusPluginId` memoized with `useCallback` to fix deep-link highlight timer teardown

## Testing

25 unit tests in `pluginSearch.test.ts` covering parse, score, and filter edge cases. New dialog integration tests for search interactions. 90 tests pass across both files.