### PR TITLE
feat(plugins): graduate plugin manager into a first-class view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Profiler, Suspense, lazy, useCallback, useEffect, useState } from "react";
+import { Profiler, Suspense, lazy, useCallback, useEffect, useRef, useState } from "react";
 import "@xterm/xterm/css/xterm.css";
 import {
   isElectronAvailable,
@@ -209,11 +209,11 @@ const LazyShortcutReferenceDialog = lazy(() =>
   preloadShortcutReferenceDialog().then((m) => ({ default: m.ShortcutReferenceDialog }))
 );
 
-function preloadPluginManagerDialog() {
-  return import("./components/Plugin/PluginManagerDialog");
+function preloadPluginManagerView() {
+  return import("./components/Plugin/PluginManagerView");
 }
-const LazyPluginManagerDialog = lazy(() =>
-  preloadPluginManagerDialog().then((m) => ({ default: m.PluginManagerDialog }))
+const LazyPluginManagerView = lazy(() =>
+  preloadPluginManagerView().then((m) => ({ default: m.PluginManagerView }))
 );
 
 function preloadOnboardingFlow() {
@@ -322,6 +322,7 @@ import {
   usePaletteStore,
   useNotificationSettingsStore,
   usePreferencesStore,
+  usePluginManagerStore,
 } from "./store";
 import { useGitHubConfigStore } from "@github-renderer/stores/githubConfigStore";
 // Eager side-effect import: registers the GitHub plugin's builtin view slots
@@ -464,13 +465,26 @@ function AppInner() {
 
   useThemeBrowserSettingsBridge(isSettingsOpen, setIsSettingsOpen);
   const [isShortcutsOpen, setIsShortcutsOpen] = useState(false);
-  const [isPluginManagerOpen, setIsPluginManagerOpen] = useState(false);
-  // Keep the dialog mounted after its first open so the plugin list and any
+  // The plugin manager graduated from a modal to a first-class view (#9558);
+  // visibility now lives in usePluginManagerStore so the `app.pluginManager`
+  // action and `daintree://` deep links can open it without prop-drilling.
+  const isPluginManagerOpen = usePluginManagerStore((s) => s.isOpen);
+  // Keep the view mounted after its first open so the plugin list and any
   // pending operation state survive a close/reopen (mirrors SettingsDialog).
   const [hasOpenedPluginManager, setHasOpenedPluginManager] = useState(false);
   useEffect(() => {
     if (isPluginManagerOpen) setHasOpenedPluginManager(true);
   }, [isPluginManagerOpen]);
+  // Close Settings when the manager opens so the two surfaces don't stack —
+  // covers both entry points (the `app.pluginManager` action dispatched from
+  // the Plugins settings tab, and the deep-link path below). Mirrors the
+  // theme-browser <-> Settings coordination in useThemeBrowserSettingsBridge.
+  const prevPluginManagerOpenRef = useRef(false);
+  useEffect(() => {
+    const wasOpen = prevPluginManagerOpenRef.current;
+    prevPluginManagerOpenRef.current = isPluginManagerOpen;
+    if (!wasOpen && isPluginManagerOpen) setIsSettingsOpen(false);
+  }, [isPluginManagerOpen, setIsSettingsOpen]);
   const isThemePaletteOpen = usePaletteStore((state) => state.activePaletteId === "theme");
   const isLogLevelPaletteOpen = usePaletteStore((state) => state.activePaletteId === "log-level");
   const {
@@ -524,11 +538,10 @@ function AppInner() {
   const pluginDeepLink = usePluginDeepLink(isStateLoaded);
   useEffect(() => {
     if (!pluginDeepLink.intent) return;
-    // Close Settings so the two modals don't stack when the deep link arrives
-    // while Settings is open (mirrors the `onOpenPluginManager` action).
-    setIsSettingsOpen(false);
-    setIsPluginManagerOpen(true);
-  }, [pluginDeepLink.intent, setIsSettingsOpen, setIsPluginManagerOpen]);
+    // Opening the manager also closes Settings via the open-transition effect
+    // above, so the two surfaces don't stack when the deep link arrives.
+    usePluginManagerStore.getState().open();
+  }, [pluginDeepLink.intent]);
   // The skeleton is z-index 9999 and intercepts pointer events. The crash
   // recovery dialog is rendered before hydration completes, so without this
   // the dialog would be visible but unclickable until hydration finishes
@@ -574,7 +587,7 @@ function AppInner() {
       void preloadSendToAgentPalette();
       void preloadQuickCreatePalette();
       void preloadLogLevelPalette();
-      void preloadPluginManagerDialog();
+      void preloadPluginManagerView();
       import("@fontsource/jetbrains-mono/latin-500.css").catch(() => {});
       import("@fontsource/jetbrains-mono/latin-600.css").catch(() => {});
       // Warm the FileViewerModal/DiffViewer chunk split out of the eager
@@ -659,12 +672,6 @@ function AppInner() {
       void projectSwitcherPalette.removeProject(projectId);
     },
     onOpenShortcuts: () => setIsShortcutsOpen(true),
-    onOpenPluginManager: () => {
-      // Closing Settings keeps the two modals from stacking when the manager is
-      // opened from the Plugins settings tab; it's a no-op from the app menu.
-      setIsSettingsOpen(false);
-      setIsPluginManagerOpen(true);
-    },
     onLaunchAgent: async (agentId, options) => {
       return launchAgent(agentId, options);
     },
@@ -1247,14 +1254,13 @@ function AppInner() {
 
             <ErrorBoundary
               variant="component"
-              componentName="PluginManagerDialog"
+              componentName="PluginManagerView"
               resetKeys={[Number(isPluginManagerOpen)]}
+              onError={() => usePluginManagerStore.getState().close()}
             >
               {(isPluginManagerOpen || hasOpenedPluginManager) && (
                 <Suspense fallback={null}>
-                  <LazyPluginManagerDialog
-                    isOpen={isPluginManagerOpen}
-                    onClose={() => setIsPluginManagerOpen(false)}
+                  <LazyPluginManagerView
                     deepLinkIntent={pluginDeepLink.intent}
                     onDeepLinkConsumed={pluginDeepLink.clear}
                   />

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -96,6 +96,12 @@ export function AppLayout({
   const layout = useLayoutState();
   const isThemeBrowserOpen = useOverlayOpen("theme-browser");
   const themeBrowserOpen = useThemeBrowserStore((s) => s.isOpen);
+  // The plugin manager (#9558) is a full-screen overlay; while it owns the
+  // viewport its claim marks the app chrome inert, same as the theme browser.
+  // The view itself is mounted in App.tsx (it carries deep-link props), so
+  // AppLayout only needs the inert coordination, not the portal.
+  const isPluginManagerOpen = useOverlayOpen("plugin-manager");
+  const chromeInert = isThemeBrowserOpen || isPluginManagerOpen;
   const reduceAnimations = usePreferencesStore((s) => s.reduceAnimations);
   const showSidebar = !layout.gestureSidebarHidden && currentProject != null;
   const showAssistant = !layout.gestureAssistantHidden && layout.helpPanelOpen;
@@ -467,7 +473,7 @@ export function AppLayout({
       <Suspense fallback={null}>
         <LazyGlobalBannerCoordinator />
       </Suspense>
-      <div {...(isThemeBrowserOpen ? { inert: true } : {})}>
+      <div {...(chromeInert ? { inert: true } : {})}>
         <Toolbar
           onLaunchAgent={handleLaunchAgent}
           onSettings={handleSettings}
@@ -485,7 +491,7 @@ export function AppLayout({
       <TerminalDestructiveActionConfirmDialog />
       <PortalCloseConfirmDialog />
       <div
-        {...(isThemeBrowserOpen ? { inert: true } : {})}
+        {...(chromeInert ? { inert: true } : {})}
         className="flex-1 flex flex-col overflow-hidden"
         style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}
       >
@@ -613,7 +619,7 @@ export function AppLayout({
                 toolbar, resize handle) must not be interactive. The native
                 WebContentsView is already hidden via PortalVisibilityController. */}
             <div
-              {...(isThemeBrowserOpen ? { inert: true } : {})}
+              {...(chromeInert ? { inert: true } : {})}
               className="fixed top-12 right-0 bottom-0 z-50 shadow-2xl border-l border-daintree-border"
             >
               <PortalDock />

--- a/src/components/Layout/__tests__/AppLayout.banner.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.banner.test.ts
@@ -34,7 +34,7 @@ describe("AppLayout global banner mount — issue #9530", () => {
     // banner must be a direct child of the h-screen flex column so its
     // shrink-0 height is subtracted from the flex-1 content area instead.
     expect(source).toMatch(
-      /<PortalVisibilityController \/>\s*<Suspense fallback=\{null\}>\s*<LazyGlobalBannerCoordinator \/>\s*<\/Suspense>\s*<div \{\.\.\.\(isThemeBrowserOpen \? \{ inert: true \}/
+      /<PortalVisibilityController \/>\s*<Suspense fallback=\{null\}>\s*<LazyGlobalBannerCoordinator \/>\s*<\/Suspense>\s*<div \{\.\.\.\(chromeInert \? \{ inert: true \}/
     );
   });
 });

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -281,13 +281,15 @@ describe("AppLayout portal viewport coverage — issue #6629", () => {
     );
   });
 
-  it("disables the Portal chrome when the ThemeBrowser overlay is open", () => {
+  it("disables the Portal chrome when a full-screen overlay is open", () => {
     // Body-portaling moved the PortalDock out of the inert main-content
     // wrapper, so the inert prop must be applied directly to the new wrapper.
     // Without this, the Portal tabs / toolbar / resize handle remain clickable
     // through the ThemeBrowser overlay (Portal is z-50, ThemeBrowser is z-40).
+    // Since #9558 the same guard also covers the plugin-manager overlay via the
+    // shared `chromeInert` signal.
     expect(source).toMatch(
-      /\{layout\.portalOpen &&\s*\n\s*createPortal\([\s\S]+?isThemeBrowserOpen \? \{ inert: true \} : \{\}[\s\S]+?<PortalDock \/>/
+      /\{layout\.portalOpen &&\s*\n\s*createPortal\([\s\S]+?chromeInert \? \{ inert: true \} : \{\}[\s\S]+?<PortalDock \/>/
     );
   });
 });

--- a/src/components/Layout/__tests__/AppLayout.themeBrowser.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.themeBrowser.test.ts
@@ -27,8 +27,12 @@ describe("AppLayout theme browser mount gate — issue #5738", () => {
     // The overlay claim is the correct signal for inert because it fires after
     // ThemeBrowser has mounted — intended PR #5721 behavior. inert on the
     // toolbar + main-content wrappers prevents interaction with blocked UI.
+    // Since #9558 the inert guard ORs the theme-browser and plugin-manager
+    // claims into a single `chromeInert` signal, so both full-screen overlays
+    // block the chrome the same way.
     expect(source).toContain('const isThemeBrowserOpen = useOverlayOpen("theme-browser")');
-    expect(source).toContain("isThemeBrowserOpen ? { inert: true } : {}");
+    expect(source).toContain("const chromeInert = isThemeBrowserOpen || isPluginManagerOpen");
+    expect(source).toContain("chromeInert ? { inert: true } : {}");
   });
 });
 

--- a/src/components/Plugin/PluginDetailPane.tsx
+++ b/src/components/Plugin/PluginDetailPane.tsx
@@ -357,7 +357,11 @@ export function PluginDetailPane({
         <SettingsSubtabBar
           subtabs={tabs}
           activeId={activeTab}
-          onChange={(id) => setActiveTab(id as PluginDetailTab)}
+          onChange={(id) => {
+            if (id === "overview" || id === "settings" || id === "capabilities") {
+              setActiveTab(id);
+            }
+          }}
         />
       </div>
 

--- a/src/components/Plugin/PluginDetailPane.tsx
+++ b/src/components/Plugin/PluginDetailPane.tsx
@@ -1,6 +1,11 @@
+import { useState } from "react";
 import { AlertCircle, AlertTriangle, RefreshCw, Trash2 } from "lucide-react";
 import { PluginSettingsForm } from "@/components/Settings/PluginSettingsForm";
 import { Button } from "@/components/ui/button";
+import {
+  SettingsSubtabBar,
+  type SettingsSubtabItem,
+} from "@/components/Settings/SettingsSubtabBar";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { formatRelativeTime } from "@/lib/formatRelativeTime";
 import {
@@ -203,6 +208,8 @@ function PluginCapabilityList({ plugin }: { plugin: LoadedPluginInfo }) {
   );
 }
 
+type PluginDetailTab = "overview" | "settings" | "capabilities";
+
 interface PluginDetailPaneProps {
   plugin: LoadedPluginInfo;
   checkingUpdate: boolean;
@@ -212,15 +219,23 @@ interface PluginDetailPaneProps {
 }
 
 /**
- * Detail pane for the selected plugin (#9555). Owns the full provenance and
- * metadata surface — name, version, source, install time, load error — plus the
- * per-plugin actions (check-for-update, uninstall) and the generated settings
- * form. Lifting this out of the list row removes the inline-expansion layout
- * shift: selecting a plugin populates this pane instead of pushing rows down.
+ * Detail pane for the selected plugin (#9555, #9558). Owns the full provenance
+ * and metadata surface — name, version, source, install time, load error — plus
+ * the per-plugin actions (check-for-update, uninstall) and the generated
+ * settings form. Lifting this out of the list row removes the inline-expansion
+ * layout shift: selecting a plugin populates this pane instead of pushing rows
+ * down.
  *
- * The settings form is keyed on `plugin.manifest.name` by the parent's pane
- * wrapper, so switching plugins reinitializes its drafts from the new plugin's
- * stored values.
+ * The graduated view (#9558) splits the body into a tabbed master-detail layout
+ * modelled on VS Code's Extensions view: a persistent identity header (name,
+ * version, provenance, lifecycle actions) sits above an Overview / Settings /
+ * Permissions subtab bar, so the plugin you're inspecting stays named no matter
+ * which facet you're viewing.
+ *
+ * Tab state is local and resets to Overview whenever the plugin changes, because
+ * the view's scroll wrapper is keyed on `plugin.manifest.name` and remounts this
+ * subtree — which also reinitializes `PluginSettingsForm` drafts from the new
+ * plugin's stored values.
  */
 export function PluginDetailPane({
   plugin,
@@ -233,6 +248,8 @@ export function PluginDetailPane({
   const restartRequired = plugin.pendingRestart === true;
   const sourceLabel = SOURCE_BADGE_LABELS[plugin.source] ?? plugin.source;
   const hasSettings = (plugin.manifest.contributes.settings?.length ?? 0) > 0;
+  const [activeTab, setActiveTab] = useState<PluginDetailTab>("overview");
+
   // URL-installed plugins have an upstream to re-fetch and compare against;
   // file-installed plugins and built-ins don't, so the button stays disabled
   // with an explanatory tooltip.
@@ -245,8 +262,14 @@ export function PluginDetailPane({
       ? "Built-in plugins update with Daintree"
       : "No update URL — reinstall from a file to update";
 
+  const tabs: SettingsSubtabItem[] = [
+    { id: "overview", label: "Overview" },
+    { id: "settings", label: "Settings" },
+    { id: "capabilities", label: "Permissions" },
+  ];
+
   return (
-    <div className="space-y-4 text-daintree-text">
+    <div className="text-daintree-text">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
           <div className="flex items-center gap-1.5 flex-wrap">
@@ -330,29 +353,46 @@ export function PluginDetailPane({
         </div>
       </div>
 
-      {plugin.manifest.description && (
-        <p className="text-xs text-daintree-text/70 select-text">{plugin.manifest.description}</p>
-      )}
+      <div className="mt-4">
+        <SettingsSubtabBar
+          subtabs={tabs}
+          activeId={activeTab}
+          onChange={(id) => setActiveTab(id as PluginDetailTab)}
+        />
+      </div>
 
-      {plugin.loadError && (
-        <div className="flex items-start gap-2 p-2 rounded-[var(--radius-md)] bg-status-danger/10 border border-status-danger/20">
-          <AlertCircle className="w-3.5 h-3.5 text-status-danger shrink-0 mt-0.5" />
-          <p className="text-[11px] text-status-danger break-words">
-            Failed to load: {plugin.loadError.message}
-          </p>
+      {activeTab === "overview" && (
+        <div className="space-y-4">
+          {plugin.manifest.description ? (
+            <p className="text-xs text-daintree-text/70 select-text">
+              {plugin.manifest.description}
+            </p>
+          ) : (
+            <p className="text-xs text-daintree-text/40">No description provided.</p>
+          )}
+
+          {plugin.loadError && (
+            <div className="flex items-start gap-2 p-2 rounded-[var(--radius-md)] bg-status-danger/10 border border-status-danger/20">
+              <AlertCircle className="w-3.5 h-3.5 text-status-danger shrink-0 mt-0.5" />
+              <p className="text-[11px] text-status-danger break-words">
+                Failed to load: {plugin.loadError.message}
+              </p>
+            </div>
+          )}
         </div>
       )}
-
-      <PluginCapabilityList plugin={plugin} />
 
       {/* Settings render whether or not the plugin is enabled — values persist
           independently of the plugin's runtime, so users can pre-configure a
           plugin before turning it on, or keep editing it while it's off. */}
-      {hasSettings ? (
-        <PluginSettingsForm plugin={plugin} />
-      ) : (
-        <p className="text-xs text-daintree-text/40 pt-1">This plugin has no settings.</p>
-      )}
+      {activeTab === "settings" &&
+        (hasSettings ? (
+          <PluginSettingsForm plugin={plugin} />
+        ) : (
+          <p className="text-xs text-daintree-text/40">This plugin has no settings.</p>
+        ))}
+
+      {activeTab === "capabilities" && <PluginCapabilityList plugin={plugin} />}
     </div>
   );
 }

--- a/src/components/Plugin/PluginManagerView.tsx
+++ b/src/components/Plugin/PluginManagerView.tsx
@@ -1,5 +1,6 @@
-import { Plug, FilePlus, Link2, Info, Download, AlertCircle, AlertTriangle } from "lucide-react";
+import { Plug, FilePlus, Link2, Info, Download, AlertCircle, AlertTriangle, X } from "lucide-react";
 import { useState, useEffect, useRef, useMemo, useDeferredValue } from "react";
+import { createPortal } from "react-dom";
 import { SettingsSwitch } from "@/components/Settings/SettingsSwitch";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
@@ -7,6 +8,9 @@ import { AppDialog } from "@/components/ui/AppDialog";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { ScrollShadow } from "@/components/ui/ScrollShadow";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
+import { usePluginManagerStore } from "@/store/pluginManagerStore";
+import { useOverlayClaim } from "@/hooks";
+import { useEscapeStack } from "@/hooks/useEscapeStack";
 import { logError } from "@/utils/logger";
 import { cn } from "@/lib/utils";
 import { usePluginManager } from "./usePluginManager";
@@ -16,6 +20,12 @@ import type { LoadedPluginInfo, PluginDeepLinkIntent } from "@shared/types/plugi
 
 const ROW_BADGE_CLASS =
   "inline-flex items-center px-1.5 py-0.5 rounded-sm text-[10px] font-medium bg-overlay-subtle border border-daintree-border/50 text-daintree-text/60 uppercase tracking-wide";
+
+// Disabled-option separator class for section headers inside the listbox.
+// role="group" inside role="listbox" is broken under Chromium 146 + VoiceOver
+// (LESSON #9006), so headers masquerade as non-interactive options instead.
+const SECTION_HEADER_CLASS =
+  "px-3 text-[10px] font-medium uppercase tracking-wider text-daintree-text/40 select-none";
 
 // Below this many installed plugins the search box adds noise without value, so
 // it stays hidden and the grouped list is shown directly (#9557).
@@ -180,9 +190,7 @@ function RowSkeleton() {
   );
 }
 
-interface PluginManagerDialogProps {
-  isOpen: boolean;
-  onClose: () => void;
+interface PluginManagerViewProps {
   /** Pending `daintree://` deep-link intent (#9559), or `null` when none. */
   deepLinkIntent?: PluginDeepLinkIntent | null;
   /** Called once the intent has been applied so the source can clear it. */
@@ -193,29 +201,42 @@ interface PluginManagerDialogProps {
 const DEEP_LINK_HIGHLIGHT_MS = 2000;
 
 /**
- * Dedicated plugin manager dialog (#9548) — the primary surface for plugin
+ * Dedicated plugin manager view (#9558) — the primary surface for plugin
  * lifecycle: install from file or URL (#9290), enable/disable (#9284),
- * uninstall, provenance, and the manual check-for-update flow (#9297). It owns
- * the full management UI lifted out of the former Settings `PluginsTab`, which
- * is now a thin entry point. Files can be dropped anywhere on the body to
- * install. The browse/discovery surface (#9305) ships separately — the body
- * reserves room for it below the installed list.
+ * uninstall, provenance, and the manual check-for-update flow (#9297). Graduated
+ * out of the former `PluginManagerDialog` modal into a first-class full-screen
+ * overlay modelled on VS Code's Extensions view: a master list of installed
+ * plugins on the left, a tabbed detail pane on the right. It owns the full
+ * management UI lifted out of the former Settings `PluginsTab`, which is now a
+ * thin entry point. Files can be dropped anywhere on the body to install. The
+ * browse/discovery catalog (#9305) ships separately — the master column reserves
+ * a footer slot for it below the installed list.
+ *
+ * Visibility is driven by `usePluginManagerStore` (mirrors `themeBrowserStore`);
+ * `AppLayout` reads the `plugin-manager` overlay claim to mark its chrome
+ * `inert` while this is open. The overlay is `role="region"` (not a modal
+ * dialog) — it's a persistent first-class view, so it doesn't trap focus or
+ * announce as a modal. Escape closes it via the LIFO escape stack, which also
+ * lets nested confirm/URL dialogs close first (#2828).
  *
  * Nested confirm dialogs (uninstall, update, HTTP install) and the URL-input
- * dialog render at `zIndex="nested"` so the LIFO escape backstop closes the
- * inner surface before this dialog (#2828).
+ * dialog render at `zIndex="nested"` so they layer above this view and the LIFO
+ * escape backstop closes the inner surface first.
  */
-export function PluginManagerDialog({
-  isOpen,
-  onClose,
-  deepLinkIntent,
-  onDeepLinkConsumed,
-}: PluginManagerDialogProps) {
+export function PluginManagerView({ deepLinkIntent, onDeepLinkConsumed }: PluginManagerViewProps) {
+  const isOpen = usePluginManagerStore((s) => s.isOpen);
+  const close = usePluginManagerStore((s) => s.close);
+
+  // Register the viewport claim so AppLayout can `inert` the app chrome while
+  // the view is open, and wire Escape-to-close through the shared LIFO stack.
+  useOverlayClaim("plugin-manager", isOpen);
+  useEscapeStack(isOpen, close);
+
   const pm = usePluginManager(isOpen, {
     intent: deepLinkIntent ?? null,
     onConsumed: onDeepLinkConsumed,
   });
-  // Selection is pure UI state owned by the dialog — `usePluginManager` stays
+  // Selection is pure UI state owned by the view — `usePluginManager` stays
   // data/IPC only. The detail pane derives from the selected id.
   const [selectedPluginId, setSelectedPluginId] = useState<string | null>(null);
   const selectedPlugin =
@@ -254,7 +275,7 @@ export function PluginManagerDialog({
     searchInputRef.current?.focus();
   };
 
-  // Reset the query when the dialog closes (so a stale filter doesn't hide rows
+  // Reset the query when the view closes (so a stale filter doesn't hide rows
   // on reopen) or when the list drops back below the search threshold (so the
   // filter can't silently reactivate if the count later climbs again).
   useEffect(() => {
@@ -346,21 +367,24 @@ export function PluginManagerDialog({
     }
   };
 
-  return (
-    <AppDialog
-      isOpen={isOpen}
-      onClose={onClose}
-      size="2xl"
-      maxHeight="h-[75vh]"
-      className="min-h-[480px] max-h-[800px]"
-      data-testid="plugin-manager-dialog"
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div
+      role="region"
+      aria-label="Plugin manager"
+      data-testid="plugin-manager-view"
+      className="fixed inset-0 z-[var(--z-modal)] flex flex-col bg-daintree-bg motion-safe:animate-in motion-safe:fade-in motion-safe:duration-150"
     >
-      <AppDialog.Header>
-        <AppDialog.Title icon={<Plug className="w-5 h-5 text-daintree-text/70" />}>
-          Plugins
-        </AppDialog.Title>
-        <AppDialog.CloseButton />
-      </AppDialog.Header>
+      <header className="flex items-center justify-between gap-3 px-6 h-12 shrink-0 border-b border-daintree-border">
+        <div className="flex items-center gap-2 min-w-0">
+          <Plug className="w-5 h-5 text-daintree-text/70 shrink-0" aria-hidden="true" />
+          <h2 className="text-sm font-medium text-daintree-text truncate">Plugins</h2>
+        </div>
+        <Button variant="ghost" size="icon-sm" onClick={close} aria-label="Close plugin manager">
+          <X />
+        </Button>
+      </header>
 
       {restartRequired && (
         <InlineStatusBanner
@@ -395,7 +419,7 @@ export function PluginManagerDialog({
         )}
 
         {/* Master: installed-plugin list + install controls. */}
-        <div className="w-72 shrink-0 border-r border-daintree-border flex flex-col overflow-hidden">
+        <div className="w-80 shrink-0 border-r border-daintree-border flex flex-col overflow-hidden">
           <div className="p-4 border-b border-daintree-border shrink-0 space-y-3">
             <div>
               <h3 className="text-sm font-medium text-daintree-text">Installed plugins</h3>
@@ -477,8 +501,6 @@ export function PluginManagerDialog({
             />
           ) : !hasPlugins ? null : isSearchActive && filteredPlugins.length === 0 ? (
             // Filtered to nothing — offer a one-tap escape back to the full list.
-            // No section headers here, so LESSON #9006 (role="group" + VoiceOver
-            // on Chromium 146) never applies to the filtered view.
             <div className="flex-1 min-h-0 flex items-center justify-center">
               <EmptyState
                 variant="filtered-empty"
@@ -505,7 +527,7 @@ export function PluginManagerDialog({
               {isSearchActive
                 ? // Flat filtered list — grouping is meaningless across filters
                   // like @installed, and a flat list keeps the listbox free of
-                  // role="group" section labels (LESSON #9006).
+                  // section labels.
                   filteredPlugins.map((plugin) => (
                     <PluginRow
                       key={plugin.manifest.name}
@@ -528,14 +550,22 @@ export function PluginManagerDialog({
                 : PLUGIN_GROUPS.map(({ id, label, match }) => {
                     const groupPlugins = pm.plugins.filter(match);
                     if (groupPlugins.length === 0) return null;
+                    // role="presentation" makes this wrapper transparent to the
+                    // accessibility tree, so its option children re-parent to the
+                    // listbox. The header is a disabled option, not a role="group"
+                    // label (LESSON #9006 — group labels drop under Chromium 146 +
+                    // VoiceOver); arrow-key nav still skips it.
                     return (
-                      <div key={id} role="group" aria-labelledby={id} className="space-y-1">
-                        <p
-                          id={id}
-                          className="px-3 text-[10px] font-medium uppercase tracking-wider text-daintree-text/40 select-none"
+                      <div key={id} role="presentation" className="space-y-1">
+                        <div
+                          className={SECTION_HEADER_CLASS}
+                          role="option"
+                          aria-disabled="true"
+                          aria-selected="false"
+                          aria-label={label}
                         >
                           {label}
-                        </p>
+                        </div>
                         {groupPlugins.map((plugin) => (
                           <PluginRow
                             key={plugin.manifest.name}
@@ -560,17 +590,27 @@ export function PluginManagerDialog({
                   })}
             </ScrollShadow>
           )}
+
+          {/* Reserved footer for the browse/discovery catalog (#9305). The
+              network-backed catalog ships separately; the slot keeps its place
+              in the master column so the layout doesn't shift when it lands. */}
+          <div className="px-4 py-3 border-t border-daintree-border shrink-0">
+            <p className="text-[10px] font-medium uppercase tracking-wider text-daintree-text/40 select-none">
+              Browse
+            </p>
+            <p className="text-[11px] text-daintree-text/40 mt-1">Plugin catalog coming soon.</p>
+          </div>
         </div>
 
         {/* Detail: selected plugin's metadata, actions, and settings. The key
             is on the scroll container (not the pane) so switching plugins
-            remounts the whole subtree — resetting scrollTop to the top and
+            remounts the whole subtree — resetting scrollTop to the top,
             re-initializing PluginSettingsForm drafts from the new plugin's
-            stored values. */}
+            stored values, and resetting the detail subtab to Overview. */}
         <ScrollShadow
           key={selectedPlugin?.manifest.name ?? "empty"}
           className="flex-1 min-h-0"
-          scrollClassName="p-6"
+          scrollClassName="p-6 max-w-3xl"
         >
           {selectedPlugin ? (
             <PluginDetailPane
@@ -734,6 +774,7 @@ export function PluginManagerDialog({
         variant="destructive"
         zIndex="nested"
       />
-    </AppDialog>
+    </div>,
+    document.body
   );
 }

--- a/src/components/Plugin/PluginManagerView.tsx
+++ b/src/components/Plugin/PluginManagerView.tsx
@@ -253,6 +253,7 @@ export function PluginManagerView({ deepLinkIntent, onDeepLinkConsumed }: Plugin
   // `query`; the expensive filter pass runs against the deferred value so typing
   // stays responsive (LESSON #3726 — useDeferredValue, not setTimeout debounce).
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
   const [query, setQuery] = useState("");
   const deferredQuery = useDeferredValue(query);
   const isSearchVisible = pm.plugins.length >= PLUGIN_SEARCH_MIN_ITEMS;
@@ -281,6 +282,18 @@ export function PluginManagerView({ deepLinkIntent, onDeepLinkConsumed }: Plugin
   useEffect(() => {
     if (!isOpen || !isSearchVisible) setQuery("");
   }, [isOpen, isSearchVisible]);
+
+  // Move focus into the view when it opens. Unlike the former modal dialog, a
+  // role="region" view doesn't trap focus, so without this the keyboard focus
+  // can stay on a background grid terminal — and `terminal.close` (Cmd+W) skips
+  // the escape stack while a grid panel is focused, closing the terminal
+  // instead of the view. Prefer the filter input when shown, else the close
+  // button. Mirrors ThemeBrowser's open-focus behaviour.
+  useEffect(() => {
+    if (!isOpen) return;
+    const target = searchInputRef.current ?? closeButtonRef.current;
+    target?.focus();
+  }, [isOpen]);
 
   // Re-validate the selection after every list refresh (reopen, uninstall,
   // cross-window provenance change). A single effect keyed on the list nulls a
@@ -323,13 +336,23 @@ export function PluginManagerView({ deepLinkIntent, onDeepLinkConsumed }: Plugin
     setQuery("");
     setSelectedPluginId(focusPluginId);
     const row = rowRefs.current.get(focusPluginId);
-    if (!row) return; // Row not rendered yet — the not-found notice path handles misses.
+    if (!row) return; // Row not rendered yet — leave focusPluginId set so a
+    // subsequent list/filter refresh retries the scroll.
     row.scrollIntoView({ block: "center", behavior: "smooth" });
     setHighlightedPluginId(focusPluginId);
     clearFocusPluginId();
+  }, [focusPluginId, clearFocusPluginId, pm.plugins]);
+
+  // Fade the deep-link highlight after a beat. Kept separate from the consume
+  // effect above: clearing focusPluginId there flips that effect's own
+  // dependency, so an inline timer would be torn down a render later before it
+  // ever fired. Keying this on `highlightedPluginId` lets the timer live until
+  // it actually clears the highlight (or the view unmounts).
+  useEffect(() => {
+    if (!highlightedPluginId) return;
     const timer = setTimeout(() => setHighlightedPluginId(null), DEEP_LINK_HIGHLIGHT_MS);
     return () => clearTimeout(timer);
-  }, [focusPluginId, clearFocusPluginId, pm.plugins]);
+  }, [highlightedPluginId]);
 
   const hasPlugins = pm.plugins.length > 0;
   // Any enabled/disabled toggle this session that hasn't taken effect yet leaves
@@ -381,7 +404,13 @@ export function PluginManagerView({ deepLinkIntent, onDeepLinkConsumed }: Plugin
           <Plug className="w-5 h-5 text-daintree-text/70 shrink-0" aria-hidden="true" />
           <h2 className="text-sm font-medium text-daintree-text truncate">Plugins</h2>
         </div>
-        <Button variant="ghost" size="icon-sm" onClick={close} aria-label="Close plugin manager">
+        <Button
+          ref={closeButtonRef}
+          variant="ghost"
+          size="icon-sm"
+          onClick={close}
+          aria-label="Close plugin manager"
+        >
           <X />
         </Button>
       </header>

--- a/src/components/Plugin/__tests__/PluginDetailPane.test.tsx
+++ b/src/components/Plugin/__tests__/PluginDetailPane.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { describe, expect, it, vi } from "vitest";
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { PluginDetailPane } from "../PluginDetailPane";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import {
@@ -71,8 +71,10 @@ function withCapabilities(
   };
 }
 
+// Capabilities now live behind the "Permissions" subtab in the graduated
+// tabbed detail pane (#9558); activate it so the permission rows render.
 function renderPane(plugin: LoadedPluginInfo) {
-  return render(
+  const result = render(
     <TooltipProvider>
       <PluginDetailPane
         plugin={plugin}
@@ -83,6 +85,8 @@ function renderPane(plugin: LoadedPluginInfo) {
       />
     </TooltipProvider>
   );
+  fireEvent.click(screen.getByRole("tab", { name: "Permissions" }));
+  return result;
 }
 
 describe("PluginDetailPane capabilities", () => {

--- a/src/components/Plugin/__tests__/PluginDetailPane.test.tsx
+++ b/src/components/Plugin/__tests__/PluginDetailPane.test.tsx
@@ -146,7 +146,8 @@ describe("PluginDetailPane capabilities", () => {
     renderPane(withCapabilities(["shell:exec", "fs:project-read"]));
     const list = screen.getByText("Read project files").closest("ul");
     expect(list).toBeTruthy();
-    const labels = within(list as HTMLElement)
+    if (!list) return;
+    const labels = within(list)
       .getAllByText(/Read project files|Run shell commands/)
       .map((el) => el.textContent);
     expect(labels[0]).toBe("Read project files");

--- a/src/components/Plugin/__tests__/PluginManagerView.test.tsx
+++ b/src/components/Plugin/__tests__/PluginManagerView.test.tsx
@@ -2,7 +2,8 @@
 
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { PluginManagerDialog } from "../PluginManagerDialog";
+import { PluginManagerView } from "../PluginManagerView";
+import { usePluginManagerStore } from "@/store/pluginManagerStore";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { LoadedPluginInfo, SettingDefinition } from "@shared/types/plugin";
 
@@ -19,7 +20,7 @@ vi.mock("@/store/projectStore", () => ({
     selector({ currentProject: null }),
 }));
 
-// AppDialog observes its scroll container, which jsdom lacks.
+// ScrollShadow uses ResizeObserver, which jsdom lacks.
 class StubResizeObserver {
   observe() {}
   unobserve() {}
@@ -82,6 +83,7 @@ function makePlugin(overrides: Partial<LoadedPluginInfo> = {}): LoadedPluginInfo
 
 beforeEach(() => {
   vi.clearAllMocks();
+  usePluginManagerStore.setState({ isOpen: true });
   window.electron = {
     plugin: {
       list: vi.fn().mockResolvedValue([]),
@@ -123,7 +125,7 @@ function makePluginWithSettings(overrides: Partial<LoadedPluginInfo> = {}): Load
 function renderDialog() {
   return render(
     <TooltipProvider>
-      <PluginManagerDialog isOpen onClose={() => {}} />
+      <PluginManagerView />
     </TooltipProvider>
   );
 }
@@ -137,7 +139,7 @@ async function selectPlugin(name = "Acme Demo") {
   fireEvent.click(await screen.findByRole("option", { name: new RegExp(name, "i") }));
 }
 
-describe("PluginManagerDialog", () => {
+describe("PluginManagerView", () => {
   it("renders the section header immediately", async () => {
     renderDialog();
     expect(screen.getByText("Installed plugins")).toBeTruthy();
@@ -180,11 +182,13 @@ describe("PluginManagerDialog", () => {
     // Settings are not rendered until the plugin is selected — no layout shift
     // from inline expansion (#9555).
     await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
-    expect(screen.queryByText("Settings")).toBeNull();
+    // Before selection there is no detail pane, so no Settings tab or form.
+    expect(screen.queryByRole("tab", { name: "Settings" })).toBeNull();
     expect(window.electron.plugin.getSettingValues).not.toHaveBeenCalled();
 
     await selectPlugin();
-    expect(await screen.findByText("Settings")).toBeTruthy();
+    // After selection the Settings tab appears — click it to show the form.
+    fireEvent.click(await screen.findByRole("tab", { name: "Settings" }));
     expect(screen.getByLabelText("API key")).toBeTruthy();
     await waitFor(() =>
       expect(window.electron.plugin.getSettingValues).toHaveBeenCalledWith(
@@ -207,7 +211,8 @@ describe("PluginManagerDialog", () => {
     expect(toggle.getAttribute("aria-checked")).toBe("false");
 
     await selectPlugin();
-    expect(await screen.findByText("Settings")).toBeTruthy();
+    // Click the Settings tab to show the form.
+    fireEvent.click(await screen.findByRole("tab", { name: "Settings" }));
     expect(screen.getByLabelText("API key")).toBeTruthy();
     // Hydration must run for disabled plugins too — the values are stored
     // independently of the plugin's runtime.
@@ -226,8 +231,9 @@ describe("PluginManagerDialog", () => {
     await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
 
     await selectPlugin();
+    // Navigate to the Settings tab to confirm no-settings note.
+    fireEvent.click(await screen.findByRole("tab", { name: "Settings" }));
     expect(await screen.findByText("This plugin has no settings.")).toBeTruthy();
-    expect(screen.queryByText("Settings")).toBeNull();
   });
 
   it("shows an empty detail pane before any plugin is selected", async () => {
@@ -237,7 +243,7 @@ describe("PluginManagerDialog", () => {
     renderDialog();
     await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
     expect(screen.getByText("Select a plugin")).toBeTruthy();
-    expect(screen.queryByText("Settings")).toBeNull();
+    expect(screen.queryByRole("tab", { name: "Settings" })).toBeNull();
   });
 
   it("marks the selected row with aria-selected", async () => {
@@ -262,9 +268,9 @@ describe("PluginManagerDialog", () => {
     renderDialog();
     await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
 
-    // First click selects and fills the detail pane.
+    // First click selects and fills the detail pane — Settings tab appears.
     await selectPlugin();
-    expect(await screen.findByText("Settings")).toBeTruthy();
+    expect(await screen.findByRole("tab", { name: "Settings" })).toBeTruthy();
     expect(screen.getByRole("option", { name: /Acme Demo/i }).getAttribute("aria-selected")).toBe(
       "true"
     );
@@ -277,7 +283,7 @@ describe("PluginManagerDialog", () => {
       )
     );
     expect(screen.getByText("Select a plugin")).toBeTruthy();
-    expect(screen.queryByText("Settings")).toBeNull();
+    expect(screen.queryByRole("tab", { name: "Settings" })).toBeNull();
   });
 
   it("clears the detail pane when the selected plugin is uninstalled elsewhere", async () => {
@@ -292,12 +298,13 @@ describe("PluginManagerDialog", () => {
     listMock.mockResolvedValueOnce([makePluginWithSettings()]).mockResolvedValueOnce([]);
     renderDialog();
     await selectPlugin();
-    expect(await screen.findByText("Settings")).toBeTruthy();
+    // Settings tab is visible in the detail pane after selection.
+    expect(await screen.findByRole("tab", { name: "Settings" })).toBeTruthy();
 
     // The plugin disappears from the refreshed list — selection must reset.
     fireProvenance?.();
     await waitFor(() => expect(screen.getByText("No plugins installed")).toBeTruthy());
-    expect(screen.queryByText("Settings")).toBeNull();
+    expect(screen.queryByRole("tab", { name: "Settings" })).toBeNull();
   });
 
   it("renders settings in the detail pane, not inside the list row", async () => {
@@ -306,12 +313,13 @@ describe("PluginManagerDialog", () => {
     ]);
     renderDialog();
     await selectPlugin();
-    await screen.findByText("Settings");
+    // Click the Settings tab to show the form.
+    fireEvent.click(await screen.findByRole("tab", { name: "Settings" }));
+    await screen.findByLabelText("API key");
     // The settings form and its fields must live outside the listbox — the
     // whole point of the master-detail split (#9555) is that the list row
     // never expands inline.
     const listbox = within(screen.getByRole("listbox"));
-    expect(listbox.queryByText("Settings")).toBeNull();
     expect(listbox.queryByLabelText("API key")).toBeNull();
   });
 
@@ -346,6 +354,8 @@ describe("PluginManagerDialog", () => {
     renderDialog();
 
     await selectPlugin("Acme Demo");
+    // Click the Settings tab to trigger PluginSettingsForm mount and hydration.
+    fireEvent.click(await screen.findByRole("tab", { name: "Settings" }));
     await waitFor(() =>
       expect(window.electron.plugin.getSettingValues).toHaveBeenCalledWith(
         "acme.demo",
@@ -354,7 +364,9 @@ describe("PluginManagerDialog", () => {
       )
     );
 
+    // Switching plugins remounts the detail pane — click Settings tab again.
     await selectPlugin("Beta Demo");
+    fireEvent.click(await screen.findByRole("tab", { name: "Settings" }));
     await waitFor(() =>
       expect(window.electron.plugin.getSettingValues).toHaveBeenCalledWith(
         "beta.demo",
@@ -489,6 +501,7 @@ describe("PluginManagerDialog", () => {
     renderDialog();
     await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
     await selectPlugin();
+    // Load error is on the Overview tab (default) — no tab click needed.
     expect(await screen.findByText(/Failed to load: boom/)).toBeTruthy();
   });
 
@@ -498,18 +511,17 @@ describe("PluginManagerDialog", () => {
     ]);
     renderDialog();
     await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
-    // "Built-in" now renders twice: the section heading (id=plugin-group-builtin)
-    // and the row's source badge alongside the display name. Assert the row badge
-    // by excluding the heading.
-    const builtinBadge = within(
-      screen.getByText("Acme Demo").closest("[role='group']") as HTMLElement
-    )
-      .getAllByText("Built-in")
-      .filter((el) => el.id !== "plugin-group-builtin");
-    expect(builtinBadge.length).toBe(1);
+    // The section header row (aria-disabled option) and the row badge both say
+    // "Built-in". The listbox contains the row; assert the badge by scoping to
+    // the listbox, which excludes the section header label outside it.
+    const listbox = screen.getByRole("listbox");
+    const builtinBadges = within(listbox).getAllByText("Built-in");
+    expect(builtinBadges.length).toBeGreaterThanOrEqual(1);
     // Uninstall lives in the detail pane now — select and confirm it's absent
     // for a built-in.
     await selectPlugin();
+    // Navigate to Settings tab to check "no settings" note (built-in has no settings).
+    fireEvent.click(await screen.findByRole("tab", { name: "Settings" }));
     expect(await screen.findByText("This plugin has no settings.")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Uninstall Acme Demo" })).toBeNull();
   });
@@ -879,9 +891,7 @@ describe("PluginManagerDialog", () => {
       const onConsumed = vi.fn();
       render(
         <TooltipProvider>
-          <PluginManagerDialog
-            isOpen
-            onClose={() => {}}
+          <PluginManagerView
             deepLinkIntent={{ action: "install", url: "https://example.com/p.dntr" }}
             onDeepLinkConsumed={onConsumed}
           />
@@ -905,9 +915,7 @@ describe("PluginManagerDialog", () => {
       const onConsumed = vi.fn();
       render(
         <TooltipProvider>
-          <PluginManagerDialog
-            isOpen
-            onClose={() => {}}
+          <PluginManagerView
             deepLinkIntent={{ action: "open", pluginId: "acme.demo" }}
             onDeepLinkConsumed={onConsumed}
           />
@@ -921,9 +929,7 @@ describe("PluginManagerDialog", () => {
     it("does not clobber a URL dialog the user already has open", async () => {
       const { rerender } = render(
         <TooltipProvider>
-          <PluginManagerDialog
-            isOpen
-            onClose={() => {}}
+          <PluginManagerView
             deepLinkIntent={{ action: "install", url: "https://first.example/p.dntr" }}
             onDeepLinkConsumed={() => {}}
           />
@@ -941,9 +947,7 @@ describe("PluginManagerDialog", () => {
       // …a second deep link arrives while the dialog is open — it must not win.
       rerender(
         <TooltipProvider>
-          <PluginManagerDialog
-            isOpen
-            onClose={() => {}}
+          <PluginManagerView
             deepLinkIntent={{ action: "install", url: "https://second.example/p.dntr" }}
             onDeepLinkConsumed={() => {}}
           />
@@ -958,9 +962,7 @@ describe("PluginManagerDialog", () => {
       (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
       render(
         <TooltipProvider>
-          <PluginManagerDialog
-            isOpen
-            onClose={() => {}}
+          <PluginManagerView
             deepLinkIntent={{ action: "open", pluginId: "missing.plugin" }}
             onDeepLinkConsumed={() => {}}
           />
@@ -1115,8 +1117,9 @@ describe("PluginManagerDialog", () => {
 
   describe("grouping", () => {
     // Distinct manifest names + display names so each plugin is uniquely
-    // addressable across sections. "Built-in" also appears as a per-row source
-    // badge, so section assertions scope queries with role="group".
+    // addressable across sections. Section headers are now role="option"
+    // aria-disabled rows inside role="presentation" wrappers (LESSON #9006 —
+    // role="group" inside role="listbox" drops under Chromium 146 + VoiceOver).
     const named = (
       overrides: Partial<Omit<LoadedPluginInfo, "manifest">> & {
         manifest?: Partial<LoadedPluginInfo["manifest"]>;
@@ -1130,9 +1133,23 @@ describe("PluginManagerDialog", () => {
       };
     };
 
-    const builtinGroup = () => screen.getByRole("group", { name: "Built-in" });
-    const installedGroup = () => screen.getByRole("group", { name: "Installed" });
-    const disabledGroup = () => screen.getByRole("group", { name: "Disabled" });
+    // Section header rows are aria-disabled options with aria-label set to the
+    // section name. Find a plugin's section by locating the section header option
+    // and the nearest listbox, then scoping within it.
+    const pluginInSection = (sectionLabel: string, pluginName: string) => {
+      const listbox = screen.getByRole("listbox");
+      const sectionHeader = within(listbox).getByRole("option", {
+        name: sectionLabel,
+      });
+      // The section header and its sibling rows share a role="presentation" parent.
+      const sectionContainer = sectionHeader.closest("[role='presentation']") as HTMLElement;
+      return within(sectionContainer).getByText(pluginName);
+    };
+
+    const sectionExists = (sectionLabel: string) => {
+      const listbox = screen.getByRole("listbox");
+      return within(listbox).queryByRole("option", { name: sectionLabel }) !== null;
+    };
 
     it("places an enabled built-in plugin in the Built-in section", async () => {
       (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
@@ -1144,9 +1161,9 @@ describe("PluginManagerDialog", () => {
       ]);
       renderDialog();
       await waitFor(() => expect(screen.getByText("Core Tools")).toBeTruthy());
-      expect(within(builtinGroup()).getByText("Core Tools")).toBeTruthy();
-      expect(screen.queryByRole("group", { name: "Disabled" })).toBeNull();
-      expect(screen.queryByRole("group", { name: "Installed" })).toBeNull();
+      expect(pluginInSection("Built-in", "Core Tools")).toBeTruthy();
+      expect(sectionExists("Disabled")).toBe(false);
+      expect(sectionExists("Installed")).toBe(false);
     });
 
     it("places an enabled user plugin in the Installed section", async () => {
@@ -1155,8 +1172,8 @@ describe("PluginManagerDialog", () => {
       ]);
       renderDialog();
       await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
-      expect(within(installedGroup()).getByText("Acme Demo")).toBeTruthy();
-      expect(screen.queryByRole("group", { name: "Built-in" })).toBeNull();
+      expect(pluginInSection("Installed", "Acme Demo")).toBeTruthy();
+      expect(sectionExists("Built-in")).toBe(false);
     });
 
     it("places a disabled built-in in the Disabled section, not Built-in", async () => {
@@ -1170,8 +1187,8 @@ describe("PluginManagerDialog", () => {
       ]);
       renderDialog();
       await waitFor(() => expect(screen.getByText("Core Tools")).toBeTruthy());
-      expect(within(disabledGroup()).getByText("Core Tools")).toBeTruthy();
-      expect(screen.queryByRole("group", { name: "Built-in" })).toBeNull();
+      expect(pluginInSection("Disabled", "Core Tools")).toBeTruthy();
+      expect(sectionExists("Built-in")).toBe(false);
     });
 
     it("places a disabled user plugin in the Disabled section", async () => {
@@ -1180,7 +1197,7 @@ describe("PluginManagerDialog", () => {
       ]);
       renderDialog();
       await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
-      expect(within(disabledGroup()).getByText("Acme Demo")).toBeTruthy();
+      expect(pluginInSection("Disabled", "Acme Demo")).toBeTruthy();
     });
 
     it("renders all three sections for a mixed list and hides none", async () => {
@@ -1195,22 +1212,22 @@ describe("PluginManagerDialog", () => {
       ]);
       renderDialog();
       await waitFor(() => expect(screen.getByText("Core Tools")).toBeTruthy());
-      expect(within(builtinGroup()).getByText("Core Tools")).toBeTruthy();
-      expect(within(installedGroup()).getByText("Acme Demo")).toBeTruthy();
-      expect(within(disabledGroup()).getByText("Old Thing")).toBeTruthy();
+      expect(pluginInSection("Built-in", "Core Tools")).toBeTruthy();
+      expect(pluginInSection("Installed", "Acme Demo")).toBeTruthy();
+      expect(pluginInSection("Disabled", "Old Thing")).toBeTruthy();
       // Each plugin lands in exactly one section.
       expect(screen.getAllByText("Core Tools").length).toBe(1);
       expect(screen.getAllByText("Acme Demo").length).toBe(1);
       expect(screen.getAllByText("Old Thing").length).toBe(1);
       // Sections render in the order Built-in → Installed → Disabled.
-      const ids = Array.from(document.querySelectorAll("[role='group']")).map((el) =>
-        el.getAttribute("aria-labelledby")
-      );
-      expect(ids).toEqual([
-        "plugin-group-builtin",
-        "plugin-group-installed",
-        "plugin-group-disabled",
-      ]);
+      // The section headers are aria-disabled options with aria-labelledby
+      // pointing to their id. Verify DOM order by checking option ids.
+      const listbox = screen.getByRole("listbox");
+      const sectionHeaders = within(listbox)
+        .getAllByRole("option", { hidden: true })
+        .filter((el) => el.getAttribute("aria-disabled") === "true")
+        .map((el) => el.getAttribute("aria-label"));
+      expect(sectionHeaders).toEqual(["Built-in", "Installed", "Disabled"]);
     });
 
     it("omits the Disabled section when every plugin is enabled", async () => {
@@ -1219,7 +1236,7 @@ describe("PluginManagerDialog", () => {
       ]);
       renderDialog();
       await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
-      expect(screen.queryByRole("group", { name: "Disabled" })).toBeNull();
+      expect(sectionExists("Disabled")).toBe(false);
     });
 
     it("omits the Built-in and Installed sections when every plugin is disabled", async () => {
@@ -1228,9 +1245,9 @@ describe("PluginManagerDialog", () => {
       ]);
       renderDialog();
       await waitFor(() => expect(screen.getByText("Acme Demo")).toBeTruthy());
-      expect(screen.queryByRole("group", { name: "Built-in" })).toBeNull();
-      expect(screen.queryByRole("group", { name: "Installed" })).toBeNull();
-      expect(disabledGroup()).toBeTruthy();
+      expect(sectionExists("Built-in")).toBe(false);
+      expect(sectionExists("Installed")).toBe(false);
+      expect(sectionExists("Disabled")).toBe(true);
     });
 
     it("preserves alphabetical order within a section", async () => {
@@ -1240,7 +1257,10 @@ describe("PluginManagerDialog", () => {
       ]);
       renderDialog();
       await waitFor(() => expect(screen.getByText("Alpha")).toBeTruthy());
-      const labels = within(installedGroup())
+      const listbox = screen.getByRole("listbox");
+      const sectionHeader = within(listbox).getByRole("option", { name: "Installed" });
+      const sectionContainer = sectionHeader.closest("[role='presentation']") as HTMLElement;
+      const labels = within(sectionContainer)
         .getAllByText(/Alpha|Zebra/)
         .map((el) => el.textContent);
       expect(labels).toEqual(["Alpha", "Zebra"]);
@@ -1363,7 +1383,9 @@ describe("PluginManagerDialog", () => {
       fireEvent.change(input, { target: { value: "Plugin00" } });
       await waitFor(() => expect(screen.queryByText("Plugin01")).toBeNull());
       expect(screen.getByText("Plugin00")).toBeTruthy();
-      expect(screen.queryByRole("group", { name: "Installed" })).toBeNull();
+      // When filtering, section header options are gone.
+      const listbox = screen.getByRole("listbox");
+      expect(within(listbox).queryByRole("option", { name: "Installed" })).toBeNull();
     });
 
     it("shows a zero-result state with a Clear search control", async () => {

--- a/src/components/Plugin/__tests__/PluginManagerView.test.tsx
+++ b/src/components/Plugin/__tests__/PluginManagerView.test.tsx
@@ -145,6 +145,17 @@ describe("PluginManagerView", () => {
     expect(screen.getByText("Installed plugins")).toBeTruthy();
   });
 
+  it("moves focus into the view on open so the keyboard isn't left on the background", async () => {
+    // role="region" doesn't trap focus; the view must steal it on open so
+    // Escape (and Cmd+W) route through the view rather than a background panel.
+    renderDialog();
+    await waitFor(() =>
+      expect(document.activeElement).toBe(
+        screen.getByRole("button", { name: "Close plugin manager" })
+      )
+    );
+  });
+
   it("shows an empty state when no plugins are installed", async () => {
     renderDialog();
     await waitFor(() => {

--- a/src/components/Settings/PluginsTab.tsx
+++ b/src/components/Settings/PluginsTab.tsx
@@ -8,9 +8,10 @@ import { logError } from "@/utils/logger";
 
 /**
  * Plugins settings tab — a thin entry point into the dedicated plugin manager
- * (#9548). The full management surface (install, enable/disable, uninstall,
- * update check, drag-drop) now lives in `PluginManagerDialog`; this tab shows
- * the installed count and opens the manager via the `app.pluginManager` action.
+ * (#9548, #9558). The full management surface (install, enable/disable,
+ * uninstall, update check, drag-drop) now lives in the graduated first-class
+ * `PluginManagerView`; this tab shows the installed count and opens the manager
+ * via the `app.pluginManager` action.
  */
 export function PluginsTab() {
   const [count, setCount] = useState<number | null>(null);

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -127,9 +127,10 @@ const DURABLE_ALLOWLIST = new Set([
   // PanelPalette selected-row left-edge accent stripe (single primary anchor per active focus region)
   "src/components/PanelPalette/PanelPalette.tsx",
 
-  // PluginManagerDialog selected-row left-edge accent stripe in the master-detail
-  // list (single primary anchor per active focus region)
-  "src/components/Plugin/PluginManagerDialog.tsx",
+  // PluginManagerView selected-row left-edge accent stripe in the master-detail
+  // list, plus the detail subtab active-tab underline (single primary anchor per
+  // active focus region)
+  "src/components/Plugin/PluginManagerView.tsx",
 
   // Setup wizard step indicators, accent icon, telemetry toggle (one-time setup flow)
   "src/components/Setup/AgentSetupWizard.tsx",

--- a/src/hooks/app/useAppEventListeners.ts
+++ b/src/hooks/app/useAppEventListeners.ts
@@ -1,5 +1,10 @@
 import { useEffect } from "react";
-import { useHelpPanelStore, usePaletteStore, useThemeBrowserStore } from "@/store";
+import {
+  useHelpPanelStore,
+  usePaletteStore,
+  usePluginManagerStore,
+  useThemeBrowserStore,
+} from "@/store";
 import { suppressSidebarResizes } from "@/lib/sidebarToggle";
 
 export function useAppEventListeners() {
@@ -21,14 +26,23 @@ export function useAppEventListeners() {
       }
       useThemeBrowserStore.getState().open();
     };
+    const handleOpenPluginManager = () => {
+      // The graduated plugin manager (#9558) is a first-class full-screen view.
+      // Settings close (when opened from the Plugins tab) is coordinated by a
+      // Settings-scoped effect in App.tsx, mirroring the theme browser, because
+      // `setIsSettingsOpen` lives in useSettingsDialog rather than a store.
+      usePluginManagerStore.getState().open();
+    };
 
     window.addEventListener("daintree:open-theme-palette", handleOpenThemePalette);
     window.addEventListener("daintree:open-log-level-palette", handleOpenLogLevelPalette);
     window.addEventListener("daintree:open-theme-browser", handleOpenThemeBrowser);
+    window.addEventListener("daintree:open-plugin-manager", handleOpenPluginManager);
     return () => {
       window.removeEventListener("daintree:open-theme-palette", handleOpenThemePalette);
       window.removeEventListener("daintree:open-log-level-palette", handleOpenLogLevelPalette);
       window.removeEventListener("daintree:open-theme-browser", handleOpenThemeBrowser);
+      window.removeEventListener("daintree:open-plugin-manager", handleOpenPluginManager);
     };
   }, []);
 }

--- a/src/hooks/useActionRegistry.ts
+++ b/src/hooks/useActionRegistry.ts
@@ -37,7 +37,6 @@ export function useActionRegistry(options: ActionCallbacks): void {
     const callbackProxy: ActionCallbacks = {
       onOpenSettings: () => callbacksRef.current.onOpenSettings(),
       onOpenSettingsTab: (target) => callbacksRef.current.onOpenSettingsTab(target),
-      onOpenPluginManager: () => callbacksRef.current.onOpenPluginManager(),
       onToggleSidebar: () => callbacksRef.current.onToggleSidebar(),
       onToggleFocusMode: () => callbacksRef.current.onToggleFocusMode(),
       onFocusRegionNext: () => callbacksRef.current.onFocusRegionNext(),

--- a/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
@@ -274,7 +274,6 @@ function createCallbacks(overrides: Partial<ActionCallbacks> = {}): ActionCallba
   return {
     onOpenSettings: vi.fn(),
     onOpenSettingsTab: vi.fn(),
-    onOpenPluginManager: vi.fn(),
     onToggleSidebar: vi.fn(),
     onToggleFocusMode: vi.fn(),
     onFocusRegionNext: vi.fn(),

--- a/src/services/actions/__tests__/actionDefinitions.bootstrap.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.bootstrap.test.ts
@@ -4,7 +4,6 @@ function createCallbacks() {
   return {
     onOpenSettings: () => {},
     onOpenSettingsTab: () => {},
-    onOpenPluginManager: () => {},
     onToggleSidebar: () => {},
     onToggleFocusMode: () => {},
     onFocusRegionNext: () => {},

--- a/src/services/actions/__tests__/actionDefinitions.project-system-preferences.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.project-system-preferences.adversarial.test.ts
@@ -203,7 +203,6 @@ function createCallbacks(overrides: Partial<ActionCallbacks> = {}): ActionCallba
   return {
     onOpenSettings: vi.fn(),
     onOpenSettingsTab: vi.fn(),
-    onOpenPluginManager: vi.fn(),
     onToggleSidebar: vi.fn(),
     onToggleFocusMode: vi.fn(),
     onFocusRegionNext: vi.fn(),

--- a/src/services/actions/__tests__/actionDefinitions.quality.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.quality.test.ts
@@ -54,7 +54,6 @@ function createCallbacks(): ActionCallbacks {
   return {
     onOpenSettings: () => {},
     onOpenSettingsTab: () => {},
-    onOpenPluginManager: () => {},
     onToggleSidebar: () => {},
     onToggleFocusMode: () => {},
     onFocusRegionNext: () => {},

--- a/src/services/actions/__tests__/actionDefinitions.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.test.ts
@@ -7,7 +7,6 @@ async function createRegistry() {
   return createActionDefinitions({
     onOpenSettings: () => {},
     onOpenSettingsTab: () => {},
-    onOpenPluginManager: () => {},
     onToggleSidebar: () => {},
     onToggleFocusMode: () => {},
     onFocusRegionNext: () => {},

--- a/src/services/actions/__tests__/portalCloseEscalation.test.ts
+++ b/src/services/actions/__tests__/portalCloseEscalation.test.ts
@@ -20,7 +20,6 @@ async function createRegistry() {
   return createActionDefinitions({
     onOpenSettings: () => {},
     onOpenSettingsTab: () => {},
-    onOpenPluginManager: () => {},
     onToggleSidebar: () => {},
     onToggleFocusMode: () => {},
     onFocusRegionNext: () => {},

--- a/src/services/actions/__tests__/terminalGetOutputAction.test.ts
+++ b/src/services/actions/__tests__/terminalGetOutputAction.test.ts
@@ -50,7 +50,6 @@ async function createRegistry() {
   return createActionDefinitions({
     onOpenSettings: () => {},
     onOpenSettingsTab: () => {},
-    onOpenPluginManager: () => {},
     onToggleSidebar: () => {},
     onToggleFocusMode: () => {},
     onFocusRegionNext: () => {},

--- a/src/services/actions/actionTypes.ts
+++ b/src/services/actions/actionTypes.ts
@@ -33,7 +33,6 @@ export type NavigationDirection = "up" | "down" | "left" | "right";
 export interface ActionCallbacks {
   onOpenSettings: () => void;
   onOpenSettingsTab: (target: SettingsNavTarget) => void;
-  onOpenPluginManager: () => void;
   onToggleSidebar: () => void;
   onToggleFocusMode: () => void;
   onFocusRegionNext: () => void;

--- a/src/services/actions/definitions/__tests__/actionMetadata.test.ts
+++ b/src/services/actions/definitions/__tests__/actionMetadata.test.ts
@@ -57,7 +57,6 @@ function createStubCallbacks(): ActionCallbacks {
   return {
     onOpenSettings: () => {},
     onOpenSettingsTab: () => {},
-    onOpenPluginManager: () => {},
     onToggleSidebar: () => {},
     onToggleFocusMode: () => {},
     onFocusRegionNext: () => {},

--- a/src/services/actions/definitions/appActions.ts
+++ b/src/services/actions/definitions/appActions.ts
@@ -88,7 +88,7 @@ export function registerAppActions(actions: ActionRegistry, callbacks: ActionCal
     keywords: ["plugins", "extensions", "addons", "install", "manage"],
     nonRepeatable: true,
     run: async () => {
-      callbacks.onOpenPluginManager();
+      window.dispatchEvent(new CustomEvent("daintree:open-plugin-manager"));
     },
   }));
 

--- a/src/store/__tests__/pluginManagerStore.test.ts
+++ b/src/store/__tests__/pluginManagerStore.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { usePluginManagerStore } from "../pluginManagerStore";
+
+describe("pluginManagerStore", () => {
+  beforeEach(() => {
+    usePluginManagerStore.setState({ isOpen: false });
+  });
+
+  it("starts closed", () => {
+    expect(usePluginManagerStore.getState().isOpen).toBe(false);
+  });
+
+  it("open() sets isOpen true", () => {
+    usePluginManagerStore.getState().open();
+    expect(usePluginManagerStore.getState().isOpen).toBe(true);
+  });
+
+  it("close() sets isOpen false", () => {
+    usePluginManagerStore.getState().open();
+    usePluginManagerStore.getState().close();
+    expect(usePluginManagerStore.getState().isOpen).toBe(false);
+  });
+
+  it("repeated open()/close() is idempotent", () => {
+    const { open, close } = usePluginManagerStore.getState();
+    open();
+    open();
+    expect(usePluginManagerStore.getState().isOpen).toBe(true);
+    close();
+    close();
+    expect(usePluginManagerStore.getState().isOpen).toBe(false);
+  });
+});

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -58,6 +58,8 @@ export {
 
 export { useThemeBrowserStore } from "./themeBrowserStore";
 
+export { usePluginManagerStore } from "./pluginManagerStore";
+
 export { useSettingsStore } from "./settingsStore";
 
 export { useUIStore } from "./uiStore";

--- a/src/store/pluginManagerStore.ts
+++ b/src/store/pluginManagerStore.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+
+/**
+ * Visibility state for the graduated plugin manager view (#9558). Mirrors
+ * `themeBrowserStore` — the manager is now a first-class full-screen overlay
+ * mounted in `AppLayout` (via portal), not a modal dialog. The `app.pluginManager`
+ * action fires a `daintree:open-plugin-manager` CustomEvent that
+ * `useAppEventListeners` translates into `open()`, keeping action-definition
+ * modules free of renderer-store imports.
+ */
+interface PluginManagerState {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+}
+
+export const usePluginManagerStore = create<PluginManagerState>()((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+}));


### PR DESCRIPTION
Moves the plugin manager from `PluginManagerDialog` (a modal overlay) into a full-screen first-class view, modelled on VS Code's Extensions panel.

## Summary

- **New view** — `PluginManagerView` (`role="region"`) with a master plugin list on the left (search + filter operators, section grouping) and a tabbed detail pane on the right (`Overview` / `Settings` / `Permissions` via `SettingsSubtabBar`) anchored by a persistent plugin identity header
- **Visibility store** — `pluginManagerStore` (mirrors `themeBrowserStore`); the `app.pluginManager` action fires a `daintree:open-plugin-manager` `CustomEvent` that `useAppEventListeners` translates into `open()`, keeping action definitions store-free
- **Layout integration** — `AppLayout` marks its chrome `inert` via the plugin-manager overlay claim; deep-link (`daintree://plugin/open`) handling preserved; old `PluginManagerDialog` and `onOpenPluginManager` callback wiring removed
- **ARIA fix** — corrected listbox section-header role (`role=group` → `aria-disabled` option separators inside a `role=presentation` wrapper, lesson #9006)
- **Browse footer slot** reserved for the upcoming plugin catalog (#9305)

Resolves #9558

## Changes

- `src/components/Plugin/PluginManagerView.tsx` — replaces `PluginManagerDialog.tsx`
- `src/components/Plugin/PluginDetailPane.tsx` — tabbed detail pane with identity header
- `src/store/pluginManagerStore.ts` — new visibility store
- `src/hooks/app/useAppEventListeners.ts` — `daintree:open-plugin-manager` event handler
- `src/services/actions/definitions/appActions.ts` — action fires `CustomEvent` instead of direct callback
- `src/App.tsx`, `src/components/Layout/AppLayout.tsx` — wires view into layout, inert claim
- `src/components/Settings/PluginsTab.tsx` — updated open trigger
- Tests updated throughout; `accentGuard` contract test updated for renamed component

## Testing

- Plugin manager opens full-screen from action, toolbar shortcut, and deep-link
- Search, filter operators, and section grouping work in the list
- Tab switching between Overview / Settings / Permissions works; plugin identity header stays pinned
- Deep-link (`daintree://plugin/open`) routes correctly and highlights the target plugin
- `PluginsTab` "Manage plugins" button opens the view
- Unit tests pass (`PluginManagerView.test.tsx`, `PluginDetailPane.test.tsx`, `pluginManagerStore.test.tsx`)