### PR TITLE
fix(mcp): derive destructiveHint from danger classification, not kind

### DIFF
--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -705,19 +705,19 @@ describe("McpServerService", () => {
       openWorldHint: true,
     });
 
-    // Override flips readOnly/idempotent on; destructiveHint and openWorldHint
-    // now come from the spec-conservative true defaults.
+    // Override flips readOnly/idempotent on; destructiveHint derives from
+    // danger: "safe" → false; openWorldHint defaults to true.
     expect(readOnlyCmd?.annotations).toEqual({
       title: "Read Only Command",
       readOnlyHint: true,
       idempotentHint: true,
-      destructiveHint: true,
+      destructiveHint: false,
       openWorldHint: true,
     });
 
-    // Explicit `false` overrides must win over kind-derived defaults —
+    // Explicit `false` overrides must win over danger-derived defaults —
     // this would silently break if `??` were ever swapped for `||`.
-    // destructiveHint is false for queries (!isQuery); openWorldHint defaults
+    // destructiveHint is false for queries (danger: "safe"); openWorldHint defaults
     // to true per spec.
     expect(queryFalse?.annotations).toEqual({
       title: "Query With False Overrides",

--- a/electron/services/mcp-server/__tests__/tierAuth.test.ts
+++ b/electron/services/mcp-server/__tests__/tierAuth.test.ts
@@ -14,6 +14,7 @@ vi.mock("../../McpPaneConfigService.js", () => ({
 }));
 
 import {
+  buildAnnotations,
   extractBearerToken,
   isAuthorized,
   parseToolArguments,
@@ -334,5 +335,43 @@ describe("shouldExposeTool", () => {
   it("still excludes hidden entries even with fullToolSurface", () => {
     const entry = makeEntry({ id: "actions.search", mcpVisibility: "hidden" });
     expect(shouldExposeTool(entry, "external", true)).toBe(false);
+  });
+});
+
+describe("buildAnnotations", () => {
+  it("safe command → destructiveHint: false", () => {
+    const entry = makeEntry({ kind: "command", danger: "safe" });
+    expect(buildAnnotations(entry).destructiveHint).toBe(false);
+  });
+
+  it("confirm command → destructiveHint: true", () => {
+    const entry = makeEntry({ kind: "command", danger: "confirm" });
+    expect(buildAnnotations(entry).destructiveHint).toBe(true);
+  });
+
+  it("query → readOnlyHint: true, idempotentHint: true, destructiveHint: false", () => {
+    const entry = makeEntry({ kind: "query", danger: "safe" });
+    const annotations = buildAnnotations(entry);
+    expect(annotations.readOnlyHint).toBe(true);
+    expect(annotations.idempotentHint).toBe(true);
+    expect(annotations.destructiveHint).toBe(false);
+  });
+
+  it("mcpAnnotations.destructiveHint: false overrides confirm default (??-guard regression)", () => {
+    const entry = makeEntry({
+      kind: "command",
+      danger: "confirm",
+      mcpAnnotations: { destructiveHint: false },
+    });
+    expect(buildAnnotations(entry).destructiveHint).toBe(false);
+  });
+
+  it("mcpAnnotations.destructiveHint: true overrides safe default", () => {
+    const entry = makeEntry({
+      kind: "command",
+      danger: "safe",
+      mcpAnnotations: { destructiveHint: true },
+    });
+    expect(buildAnnotations(entry).destructiveHint).toBe(true);
   });
 });

--- a/electron/services/mcp-server/__tests__/tierAuth.test.ts
+++ b/electron/services/mcp-server/__tests__/tierAuth.test.ts
@@ -374,4 +374,14 @@ describe("buildAnnotations", () => {
     });
     expect(buildAnnotations(entry).destructiveHint).toBe(true);
   });
+
+  it("confirm query with no override → destructiveHint: true (danger-derived, not kind-derived)", () => {
+    const entry = makeEntry({ kind: "query", danger: "confirm" });
+    expect(buildAnnotations(entry).destructiveHint).toBe(true);
+  });
+
+  it("restricted entry bypassing upstream gate → destructiveHint: false (not confirm)", () => {
+    const entry = makeEntry({ kind: "command", danger: "restricted" });
+    expect(buildAnnotations(entry).destructiveHint).toBe(false);
+  });
 });

--- a/electron/services/mcp-server/tierAuth.ts
+++ b/electron/services/mcp-server/tierAuth.ts
@@ -137,7 +137,7 @@ export function buildAnnotations(entry: ActionManifestEntry): ToolAnnotations {
     title: entry.title,
     readOnlyHint: overrides?.readOnlyHint ?? isQuery,
     idempotentHint: overrides?.idempotentHint ?? isQuery,
-    destructiveHint: overrides?.destructiveHint ?? !isQuery,
+    destructiveHint: overrides?.destructiveHint ?? (entry.danger === "confirm"),
     openWorldHint: overrides?.openWorldHint ?? true,
   };
 }

--- a/electron/services/mcp-server/tierAuth.ts
+++ b/electron/services/mcp-server/tierAuth.ts
@@ -137,7 +137,7 @@ export function buildAnnotations(entry: ActionManifestEntry): ToolAnnotations {
     title: entry.title,
     readOnlyHint: overrides?.readOnlyHint ?? isQuery,
     idempotentHint: overrides?.idempotentHint ?? isQuery,
-    destructiveHint: overrides?.destructiveHint ?? (entry.danger === "confirm"),
+    destructiveHint: overrides?.destructiveHint ?? entry.danger === "confirm",
     openWorldHint: overrides?.openWorldHint ?? true,
   };
 }


### PR DESCRIPTION
## Summary

- `buildAnnotations` was setting `destructiveHint` based on whether an action is a query, so every non-query action serialized `destructiveHint: true` regardless of its `danger` classification. Reversible `danger: "safe"` actions like `git.stageFile` and `terminal.new` were pushing MCP clients toward unnecessary confirmation prompts.
- The fix maps `destructiveHint` from the `danger` field instead: `danger: "confirm"` -> `true`, `danger: "safe"` -> `false`. `restricted` never reaches serialization.
- The per-action `mcpAnnotations` override keeps precedence as the escape hatch for the rare action whose true destructiveness diverges from its `danger` field.

This is purely a routing/UX fidelity fix. The annotation is an untrusted client hint, not an authorization gate. Real enforcement still lives in the tier allowlists and grant cache.

## Scope note on `idempotentHint`

Issue #9568 flags `idempotentHint` as having the same shape, but it's left as-is in this PR. Idempotence doesn't map cleanly to the `danger` classification, so deriving it from `danger` would be wrong: `terminal.new` is `danger: "safe"` but not idempotent (each call spawns a new terminal), while `git.stageAll` is `danger: "safe"` and idempotent. A correct fix needs a new per-action `idempotent` metadata field plumbed through the action definition, manifest entry, and `buildAnnotations`, plus a per-action audit to set it. That's larger than this PR and out of scope.

`idempotentHint` stays on its current conservative default (`isQuery`): queries report `true`, non-query commands report `false` unless an action explicitly overrides via `mcpAnnotations`. No correctness regression, and the override remains available for any action that needs `idempotentHint: true` today.

## Changes

- `electron/services/mcp-server/tierAuth.ts`: updated `buildAnnotations` to derive `destructiveHint` from the `danger` field rather than `isQuery`.
- `electron/services/mcp-server/__tests__/tierAuth.test.ts`: added regression tests confirming no `danger: "safe"` action serializes `destructiveHint: true`, that `danger: "confirm"` maps to `true`, that `restricted` is filtered before serialization, and that explicit `mcpAnnotations` overrides take precedence.
- `electron/services/__tests__/McpServerService.test.ts`: updated a stale `destructiveHint` assertion that asserted the old (incorrect) behavior.

## Testing

- New unit tests in `tierAuth.test.ts` cover the fixed mapping and override precedence.
- Existing `McpServerService.test.ts` updated so the corrected annotation value is asserted.
- `npm run check` passes clean.

Resolves #9568