### PR TITLE
fix(window): set background color on project-switch views before loadURL

### DIFF
--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -30,6 +30,7 @@ import {
   injectSkeletonCss,
   injectSkeletonProjectIdentity,
   resolveInitialColorSchemeId,
+  resolveInitialCanvasBackgroundColor,
   INITIAL_COLOR_SCHEME_ARG,
   INITIAL_PROJECT_ID_ARG,
 } from "./skeletonCss.js";
@@ -970,7 +971,7 @@ export class ProjectViewManager {
       registerProtocolsForSession(ses, distPath);
     }
 
-    return new WebContentsView({
+    const view = new WebContentsView({
       webPreferences: {
         preload: path.join(this.dirname, "preload.cjs"),
         session: ses,
@@ -992,6 +993,10 @@ export class ProjectViewManager {
         ],
       },
     });
+    // Set the compositor background color before loadURL so the view never
+    // shows the default white background during the cold-start paint gap (#9573).
+    view.setBackgroundColor(resolveInitialCanvasBackgroundColor());
+    return view;
   }
 
   private loadView(view: WebContentsView, projectId: string): Promise<void> {

--- a/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
@@ -302,6 +302,44 @@ describe("ProjectViewManager adversarial", () => {
     expect(projBView?.setBackgroundColor).toHaveBeenCalledWith("#1f1b16");
     const setColorOrder = projBView?.setBackgroundColor.mock.invocationCallOrder[0] ?? 0;
     const loadUrlOrder = projBView?.webContents.loadURL.mock.invocationCallOrder[0] ?? Infinity;
+    const addChildOrder =
+      (win.contentView.addChildView as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0] ??
+      Infinity;
     expect(setColorOrder).toBeLessThan(loadUrlOrder);
+    expect(setColorOrder).toBeLessThan(addChildOrder);
+  });
+
+  it("LRU-evicted cold-start replacement view gets background color set (#9573)", async () => {
+    const win = createMockWindow();
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
+      cachedProjectViews: 2,
+    });
+
+    const initialWc = createMockWebContents();
+    manager.registerInitialView(
+      { webContents: initialWc, setBounds: vi.fn(), setBackgroundColor: vi.fn() } as never,
+      "proj-a",
+      "/a"
+    );
+
+    const projBWc = createMockWebContents();
+    wcQueue.push(projBWc);
+    await manager.switchTo("proj-b", "/b");
+    await manager.switchTo("proj-a", "/a");
+
+    projBWc.isDestroyed.mockReturnValue(true);
+
+    const replacementWc = createMockWebContents();
+    wcQueue.push(replacementWc);
+    const result = await manager.switchTo("proj-b", "/b");
+
+    expect(result.isNew).toBe(true);
+    const replacementView = result.view as {
+      setBackgroundColor: ReturnType<typeof vi.fn>;
+    };
+    expect(replacementView.setBackgroundColor).toHaveBeenCalledWith("#1f1b16");
   });
 });

--- a/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
@@ -74,7 +74,7 @@ function createMockWebContents(options?: { autoFinishLoad?: boolean }): MockWebC
 vi.mock("electron", () => {
   function MockWebContentsView() {
     const wc = wcQueue.shift();
-    return { webContents: wc, setBounds: vi.fn() };
+    return { webContents: wc, setBounds: vi.fn(), setBackgroundColor: vi.fn() };
   }
 
   return {
@@ -131,6 +131,7 @@ vi.mock("../skeletonCss.js", () => ({
   INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
   INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
   resolveInitialColorSchemeId: vi.fn(() => "daintree"),
+  resolveInitialCanvasBackgroundColor: vi.fn(() => "#1f1b16"),
 }));
 
 vi.mock("../../services/ProjectStore.js", () => ({
@@ -270,5 +271,37 @@ describe("ProjectViewManager adversarial", () => {
     expect(result.isNew).toBe(true);
     expect(result.view.webContents).toBe(replacementWc);
     expect(manager.getActiveProjectId()).toBe("proj-b");
+  });
+
+  it("sets background color on cold-start view before loadURL to prevent white flash (#9573)", async () => {
+    const win = createMockWindow();
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
+      cachedProjectViews: 3,
+    });
+
+    const initialWc = createMockWebContents({ autoFinishLoad: false });
+    const mockView = { webContents: initialWc, setBounds: vi.fn(), setBackgroundColor: vi.fn() };
+    manager.registerInitialView(mockView as never, "proj-a", "/a");
+
+    const projBWc = createMockWebContents();
+    wcQueue.push(projBWc);
+    await manager.switchTo("proj-b", "/b");
+
+    // The newly-created WebContentsView for proj-b must have had setBackgroundColor
+    // called with the resolved canvas color before loadURL fired.
+    const projBView = manager.getAllViews().find((v) => v.projectId === "proj-b")?.view as
+      | {
+          setBackgroundColor: ReturnType<typeof vi.fn>;
+          webContents: { loadURL: ReturnType<typeof vi.fn> };
+        }
+      | undefined;
+
+    expect(projBView?.setBackgroundColor).toHaveBeenCalledWith("#1f1b16");
+    const setColorOrder = projBView?.setBackgroundColor.mock.invocationCallOrder[0] ?? 0;
+    const loadUrlOrder = projBView?.webContents.loadURL.mock.invocationCallOrder[0] ?? Infinity;
+    expect(setColorOrder).toBeLessThan(loadUrlOrder);
   });
 });

--- a/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
@@ -337,7 +337,7 @@ describe("ProjectViewManager adversarial", () => {
     const result = await manager.switchTo("proj-b", "/b");
 
     expect(result.isNew).toBe(true);
-    const replacementView = result.view as {
+    const replacementView = result.view as unknown as {
       setBackgroundColor: ReturnType<typeof vi.fn>;
     };
     expect(replacementView.setBackgroundColor).toHaveBeenCalledWith("#1f1b16");

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -50,7 +50,7 @@ const mockGetAppMetrics = vi.fn<() => Electron.ProcessMetric[]>(() => []);
 vi.mock("electron", () => {
   function MockWebContentsView() {
     const wc = createMockWebContents();
-    return { webContents: wc, setBounds: vi.fn() };
+    return { webContents: wc, setBounds: vi.fn(), setBackgroundColor: vi.fn() };
   }
   return {
     app: {
@@ -115,6 +115,7 @@ vi.mock("../skeletonCss.js", () => ({
   INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
   INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
   resolveInitialColorSchemeId: vi.fn(() => "daintree"),
+  resolveInitialCanvasBackgroundColor: vi.fn(() => "#1f1b16"),
 }));
 
 vi.mock("../../services/ProjectStore.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
@@ -72,7 +72,7 @@ let wcQueue: MockWc[] = [];
 vi.mock("electron", () => {
   function MockWebContentsView() {
     const wc = wcQueue.shift();
-    return { webContents: wc, setBounds: vi.fn() };
+    return { webContents: wc, setBounds: vi.fn(), setBackgroundColor: vi.fn() };
   }
   return {
     app: { isPackaged: false, commandLine: { appendSwitch: vi.fn() }, getAppMetrics: () => [] },
@@ -137,6 +137,7 @@ vi.mock("../skeletonCss.js", () => ({
   INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
   INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
   resolveInitialColorSchemeId: vi.fn(() => "daintree"),
+  resolveInitialCanvasBackgroundColor: vi.fn(() => "#1f1b16"),
 }));
 
 vi.mock("../../services/ProjectStore.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.freeze.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.freeze.test.ts
@@ -30,7 +30,7 @@ function createMockWebContents() {
 vi.mock("electron", () => {
   function MockWebContentsView() {
     const wc = createMockWebContents();
-    return { webContents: wc, setBounds: vi.fn() };
+    return { webContents: wc, setBounds: vi.fn(), setBackgroundColor: vi.fn() };
   }
   return {
     app: { isPackaged: false, commandLine: { appendSwitch: vi.fn() } },
@@ -86,6 +86,7 @@ vi.mock("../skeletonCss.js", () => ({
   INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
   INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
   resolveInitialColorSchemeId: vi.fn(() => "daintree"),
+  resolveInitialCanvasBackgroundColor: vi.fn(() => "#1f1b16"),
 }));
 
 vi.mock("../../services/ProjectStore.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.gc.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.gc.test.ts
@@ -31,7 +31,7 @@ function createMockWebContents() {
 vi.mock("electron", () => {
   function MockWebContentsView() {
     const wc = createMockWebContents();
-    return { webContents: wc, setBounds: vi.fn() };
+    return { webContents: wc, setBounds: vi.fn(), setBackgroundColor: vi.fn() };
   }
   return {
     app: { isPackaged: false, commandLine: { appendSwitch: vi.fn() } },
@@ -87,6 +87,7 @@ vi.mock("../skeletonCss.js", () => ({
   INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
   INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
   resolveInitialColorSchemeId: vi.fn(() => "daintree"),
+  resolveInitialCanvasBackgroundColor: vi.fn(() => "#1f1b16"),
 }));
 
 vi.mock("../../services/ProjectStore.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -72,7 +72,7 @@ let wcQueue: MockWc[] = [];
 vi.mock("electron", () => {
   function MockWebContentsView() {
     const wc = wcQueue.shift();
-    return { webContents: wc, setBounds: vi.fn() };
+    return { webContents: wc, setBounds: vi.fn(), setBackgroundColor: vi.fn() };
   }
   return {
     app: { isPackaged: false, commandLine: { appendSwitch: vi.fn() }, getAppMetrics: () => [] },
@@ -137,6 +137,7 @@ vi.mock("../skeletonCss.js", () => ({
   INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
   INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
   resolveInitialColorSchemeId: vi.fn(() => "daintree"),
+  resolveInitialCanvasBackgroundColor: vi.fn(() => "#1f1b16"),
 }));
 
 vi.mock("../../services/ProjectStore.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -70,7 +70,7 @@ let wcQueue: MockWc[] = [];
 vi.mock("electron", () => {
   function MockWebContentsView() {
     const wc = wcQueue.shift();
-    return { webContents: wc, setBounds: vi.fn() };
+    return { webContents: wc, setBounds: vi.fn(), setBackgroundColor: vi.fn() };
   }
   return {
     app: { isPackaged: false, commandLine: { appendSwitch: vi.fn() } },
@@ -126,6 +126,7 @@ vi.mock("../skeletonCss.js", () => ({
   INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
   INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
   resolveInitialColorSchemeId: vi.fn(() => "daintree"),
+  resolveInitialCanvasBackgroundColor: vi.fn(() => "#1f1b16"),
 }));
 
 vi.mock("../../services/ProjectStore.js", () => ({

--- a/electron/window/__tests__/skeletonCss.test.ts
+++ b/electron/window/__tests__/skeletonCss.test.ts
@@ -15,7 +15,11 @@ vi.mock("electron", () => ({
   nativeTheme: { shouldUseDarkColors: true },
 }));
 
-import { injectSkeletonCss, injectSkeletonProjectIdentity } from "../skeletonCss.js";
+import {
+  injectSkeletonCss,
+  injectSkeletonProjectIdentity,
+  resolveInitialCanvasBackgroundColor,
+} from "../skeletonCss.js";
 
 interface FakeWc {
   insertCSS: ReturnType<typeof vi.fn>;
@@ -30,6 +34,36 @@ function makeWc(): FakeWc {
     isDestroyed: vi.fn(() => false),
   };
 }
+
+describe("resolveInitialCanvasBackgroundColor (#9573)", () => {
+  beforeEach(() => {
+    storeMock.get.mockClear();
+  });
+
+  it("returns a #RRGGBB hex string for the default dark scheme", () => {
+    storeMock.get.mockImplementation((key: string) => {
+      if (key === "appTheme") return { colorSchemeId: "daintree" };
+      return undefined;
+    });
+    const color = resolveInitialCanvasBackgroundColor();
+    expect(color).toMatch(/^#[0-9a-fA-F]{6}$/);
+  });
+
+  it("returns a #RRGGBB hex string for the light Bondi scheme", () => {
+    storeMock.get.mockImplementation((key: string) => {
+      if (key === "appTheme") return { colorSchemeId: "bondi" };
+      return undefined;
+    });
+    const color = resolveInitialCanvasBackgroundColor();
+    expect(color).toMatch(/^#[0-9a-fA-F]{6}$/);
+  });
+
+  it("falls back to the OS-default scheme when appTheme is missing", () => {
+    storeMock.get.mockImplementation(() => undefined);
+    const color = resolveInitialCanvasBackgroundColor();
+    expect(color).toMatch(/^#[0-9a-fA-F]{6}$/);
+  });
+});
 
 describe("injectSkeletonCss accent override (#9162)", () => {
   beforeEach(() => {

--- a/electron/window/__tests__/skeletonCss.test.ts
+++ b/electron/window/__tests__/skeletonCss.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveAppTheme } from "../../../shared/theme/index.js";
 
 const storeMock = vi.hoisted(() => ({
   get: vi.fn((key: string) => {
@@ -40,28 +41,29 @@ describe("resolveInitialCanvasBackgroundColor (#9573)", () => {
     storeMock.get.mockClear();
   });
 
-  it("returns a #RRGGBB hex string for the default dark scheme", () => {
+  it("returns the surface-canvas token for the default dark scheme", () => {
     storeMock.get.mockImplementation((key: string) => {
       if (key === "appTheme") return { colorSchemeId: "daintree" };
       return undefined;
     });
     const color = resolveInitialCanvasBackgroundColor();
-    expect(color).toMatch(/^#[0-9a-fA-F]{6}$/);
+    expect(color).toBe(resolveAppTheme("daintree", []).tokens["surface-canvas"]);
   });
 
-  it("returns a #RRGGBB hex string for the light Bondi scheme", () => {
+  it("returns the surface-canvas token for the light Bondi scheme", () => {
     storeMock.get.mockImplementation((key: string) => {
       if (key === "appTheme") return { colorSchemeId: "bondi" };
       return undefined;
     });
     const color = resolveInitialCanvasBackgroundColor();
-    expect(color).toMatch(/^#[0-9a-fA-F]{6}$/);
+    expect(color).toBe(resolveAppTheme("bondi", []).tokens["surface-canvas"]);
   });
 
-  it("falls back to the OS-default scheme when appTheme is missing", () => {
+  it("falls back to the OS-default scheme surface-canvas when appTheme is missing", () => {
     storeMock.get.mockImplementation(() => undefined);
     const color = resolveInitialCanvasBackgroundColor();
-    expect(color).toMatch(/^#[0-9a-fA-F]{6}$/);
+    // shouldUseDarkColors is true in this test environment → defaults to "daintree"
+    expect(color).toBe(resolveAppTheme("daintree", []).tokens["surface-canvas"]);
   });
 });
 

--- a/electron/window/skeletonCss.ts
+++ b/electron/window/skeletonCss.ts
@@ -67,6 +67,30 @@ export function resolveInitialColorSchemeId(): string {
 }
 
 /**
+ * Resolves the compositor background color for a cold-start WebContentsView.
+ * Called in ProjectViewManager.createView() before loadURL so the view's
+ * background clear color matches the app theme instead of defaulting to white
+ * (#9573). Accent override is intentionally omitted — applyAccentOverrideToScheme
+ * does not touch surface-canvas, so the base scheme value is correct.
+ */
+export function resolveInitialCanvasBackgroundColor(): string {
+  const colorSchemeId = resolveInitialColorSchemeId();
+  const themeConfig = store.get("appTheme") ?? {};
+  let customSchemes: AppColorScheme[] = [];
+  const rawSchemes = (themeConfig as Record<string, unknown>).customSchemes;
+  if (rawSchemes !== undefined) {
+    const result = migrateCustomSchemes(
+      rawSchemes,
+      appCustomSchemesReadSchema,
+      appCustomSchemesWriteSchema
+    );
+    customSchemes = result.schemes;
+  }
+  const scheme = resolveAppTheme(colorSchemeId, customSchemes);
+  return scheme.tokens["surface-canvas"];
+}
+
+/**
  * Inject the first-paint skeleton CSS custom properties. When a cold-start
  * project switch supplies the destination `project`, its accent color (when
  * set) overrides the theme's native accent tokens so the skeleton paints the


### PR DESCRIPTION
## Summary

- Project-switch `WebContentsView` instances were never having `setBackgroundColor` called before `loadURL`, so the default white background flashed through on cold-start swaps
- Added `resolveInitialCanvasBackgroundColor()` in `skeletonCss.ts` and called it in `ProjectViewManager.createView()` before returning the view — mirrors the identical guard already in `createWindow.ts`
- Seven test files updated with mock stubs; new tests cover call ordering (before `addChildView` and `loadURL`), LRU replacement, and adversarial edge cases

Resolves #9573

## Changes

- `electron/window/skeletonCss.ts` — `resolveInitialCanvasBackgroundColor()` helper
- `electron/window/ProjectViewManager.ts` — call the helper in `createView()` before the view is returned
- `electron/window/__tests__/skeletonCss.test.ts` — expanded test coverage
- `electron/window/__tests__/ProjectViewManager.adversarial.test.ts` — new ordering, LRU, and adversarial cases
- Six other `ProjectViewManager` test files updated with mock stubs for the new helper

## Testing

Unit tests cover the call-order invariant (background color set before `addChildView` and `loadURL`), the LRU eviction replacement path, and adversarial inputs. All existing tests pass with the new mock stubs in place.