### PR TITLE
fix(window): detect probable OOM and handle memory-eviction in renderer-gone handler

### DIFF
--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -715,6 +715,10 @@ export class ProjectViewManager {
     }
   }
 
+  getLowMemoryFreeThresholdMb(): number | null {
+    return this.lowMemoryFreeThresholdMb;
+  }
+
   /**
    * Toggle CDP freeze on cached (non-active) project views. Called by
    * ResourceProfileService when transitioning into / out of the efficiency
@@ -1193,9 +1197,13 @@ export class ProjectViewManager {
         details.reason,
         details.exitCode
       );
-      getCrashRecoveryService().recordCrash(
-        new Error(`View renderer gone: ${details.reason} (exit code ${details.exitCode})`)
-      );
+      // Memory eviction is not a crash — skip the one-shot crash log so a
+      // genuine crash in the same session can still be recorded.
+      if (details.reason !== "memory-eviction") {
+        getCrashRecoveryService().recordCrash(
+          new Error(`View renderer gone: ${details.reason} (exit code ${details.exitCode})`)
+        );
+      }
 
       if (win.isDestroyed()) return;
 

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -1216,6 +1216,42 @@ export class ProjectViewManager {
         this.onViewCrashed?.(wc);
       }
 
+      // "oom" is Windows-specific (pagefile exhaustion). On macOS/Linux, V8
+      // heap exhaustion surfaces as "crashed" and the OS OOM-killer surfaces
+      // as "killed". We detect probable OOM by checking available memory
+      // against the profile threshold. exitCode is intentionally not used —
+      // sources disagree on its value for V8 heap OOM (5 vs 132).
+      // Performance profile sets the threshold to null to disable the
+      // heuristic for memory-unconstrained sessions.
+      const availableMb = this.getAvailableMemoryMb();
+      const isProbableOom =
+        details.reason === "oom" ||
+        ((details.reason === "crashed" || details.reason === "killed") &&
+          this.lowMemoryFreeThresholdMb !== null &&
+          availableMb !== null &&
+          availableMb < this.lowMemoryFreeThresholdMb);
+
+      // OS-pressure memory eviction is distinct from a crash: the renderer is
+      // reclaimed by the OS without a V8 abort. The view goes blank and does
+      // not auto-reload, so an explicit reload is required. It does not count
+      // toward the crash-loop guard because repeated OS evictions under memory
+      // pressure are not a sign of a looping crash bug.
+      if (details.reason === "memory-eviction") {
+        if (projectId && projectId === this.activeProjectId) {
+          notifyError(new Error("A project view was reloaded due to memory pressure."), {
+            source: "renderer-crash",
+          });
+        } else {
+          console.warn(
+            `[ProjectViewManager] Cached view reloaded due to memory pressure (project: ${projectId})`
+          );
+        }
+        setImmediate(() => {
+          if (!wc.isDestroyed()) wc.reload();
+        });
+        return;
+      }
+
       const crashTimestamps = crashEntry?.crashTimestamps ?? [];
       const now = Date.now();
       while (crashTimestamps.length > 0 && now - crashTimestamps[0] > CRASH_LOOP_WINDOW_MS) {
@@ -1249,7 +1285,7 @@ export class ProjectViewManager {
             wc.loadURL(`app://daintree/recovery.html?${params}`);
           }
         });
-      } else if (details.reason === "oom" && this.onRecreateWindow) {
+      } else if (isProbableOom && this.onRecreateWindow) {
         console.warn("[ProjectViewManager] OOM crash, destroying and recreating window");
         notifyError(new Error("A project view ran out of memory and the window was recreated."), {
           source: "renderer-crash",

--- a/electron/window/__tests__/rendererRecovery.test.ts
+++ b/electron/window/__tests__/rendererRecovery.test.ts
@@ -109,7 +109,9 @@ function setupCrashRecovery(
   win.webContents.on("render-process-gone", (_event, ...args) => {
     const details = args[0] as { reason: string; exitCode: number };
     if (details.reason === "clean-exit") return;
-    recordCrash(details);
+    if (details.reason !== "memory-eviction") {
+      recordCrash(details);
+    }
 
     if (win.isDestroyed()) return;
 
@@ -655,6 +657,45 @@ describe("renderer crash recovery", () => {
     const errorArg = vi.mocked(notifyError).mock.calls[0][0] as Error;
     expect(errorArg.message).not.toContain("crashed");
     expect(errorArg.message).toContain("memory pressure");
+  });
+
+  it('"memory-eviction" with onRecreateWindow provided still reloads, does not recreate (#9572)', () => {
+    const win = createMockWindow();
+    const onRecreateWindow = vi.fn().mockResolvedValue(undefined);
+    setupCrashRecovery(win, { onRecreateWindow });
+
+    win._emitWc("render-process-gone", { reason: "memory-eviction", exitCode: 0 });
+    vi.advanceTimersByTime(0);
+
+    expect(win.webContents.reload).toHaveBeenCalledOnce();
+    expect(onRecreateWindow).not.toHaveBeenCalled();
+    expect(win.destroy).not.toHaveBeenCalled();
+  });
+
+  it('"crashed" at exactly the threshold does not trigger OOM path (boundary check, #9572)', () => {
+    const win = createMockWindow();
+    const onRecreateWindow = vi.fn().mockResolvedValue(undefined);
+    setupCrashRecovery(win, {
+      onRecreateWindow,
+      lowMemoryFreeThresholdMb: 768,
+      getAvailableMemoryMb: () => 768,
+    });
+
+    win._emitWc("render-process-gone", { reason: "crashed", exitCode: 1 });
+    vi.advanceTimersByTime(0);
+
+    // availableMb === threshold: condition is <, not <=, so NOT probable OOM
+    expect(win.webContents.reload).toHaveBeenCalledOnce();
+    expect(onRecreateWindow).not.toHaveBeenCalled();
+  });
+
+  it('"memory-eviction" does not call recordCrash (#9572)', () => {
+    const win = createMockWindow();
+    const { recordCrash: mockRecordCrash } = setupCrashRecovery(win);
+
+    win._emitWc("render-process-gone", { reason: "memory-eviction", exitCode: 0 });
+
+    expect(mockRecordCrash).not.toHaveBeenCalled();
   });
 });
 

--- a/electron/window/__tests__/rendererRecovery.test.ts
+++ b/electron/window/__tests__/rendererRecovery.test.ts
@@ -80,13 +80,20 @@ function createMockWindow() {
 interface CrashRecoveryOptions {
   onRecreateWindow?: () => Promise<void>;
   backupTimestamp?: number | null;
+  lowMemoryFreeThresholdMb?: number | null;
+  getAvailableMemoryMb?: () => number | null;
 }
 
 function setupCrashRecovery(
   win: ReturnType<typeof createMockWindow>,
   options: CrashRecoveryOptions = {}
 ) {
-  const { onRecreateWindow, backupTimestamp = null } = options;
+  const {
+    onRecreateWindow,
+    backupTimestamp = null,
+    lowMemoryFreeThresholdMb = null,
+    getAvailableMemoryMb = () => null,
+  } = options;
   const rendererCrashTimestamps: number[] = [];
   const oomRecreationTimestamps: number[] = [];
   const recordCrash = vi.fn();
@@ -106,6 +113,25 @@ function setupCrashRecovery(
 
     if (win.isDestroyed()) return;
 
+    if (details.reason === "memory-eviction") {
+      notifyError(new Error("A project view was reloaded due to memory pressure."), {
+        source: "renderer-crash",
+      });
+      setImmediate(() => {
+        if (win.isDestroyed()) return;
+        win.webContents.reload();
+      });
+      return;
+    }
+
+    const availableMb = getAvailableMemoryMb();
+    const isProbableOom =
+      details.reason === "oom" ||
+      ((details.reason === "crashed" || details.reason === "killed") &&
+        lowMemoryFreeThresholdMb !== null &&
+        availableMb !== null &&
+        availableMb < lowMemoryFreeThresholdMb);
+
     const now = Date.now();
     while (
       rendererCrashTimestamps.length > 0 &&
@@ -115,14 +141,12 @@ function setupCrashRecovery(
     }
     rendererCrashTimestamps.push(now);
 
-    const isOom = details.reason === "oom";
-
     if (rendererCrashTimestamps.length >= CRASH_LOOP_THRESHOLD) {
       setImmediate(() => {
         if (win.isDestroyed()) return;
         win.webContents.loadURL(getRecoveryUrl(details.reason, details.exitCode));
       });
-    } else if (isOom && onRecreateWindow) {
+    } else if (isProbableOom && onRecreateWindow) {
       const now2 = Date.now();
       while (
         oomRecreationTimestamps.length > 0 &&
@@ -544,6 +568,93 @@ describe("renderer crash recovery", () => {
     const url = win.webContents.loadURL.mock.calls[0][0] as string;
     expect(url).toContain("reason=killed");
     expect(url).toContain("exitCode=137");
+  });
+
+  it('"crashed" with low available memory routes to OOM path (#9572)', () => {
+    const win = createMockWindow();
+    const onRecreateWindow = vi.fn().mockResolvedValue(undefined);
+    setupCrashRecovery(win, {
+      onRecreateWindow,
+      lowMemoryFreeThresholdMb: 768,
+      getAvailableMemoryMb: () => 500,
+    });
+
+    win._emitWc("render-process-gone", { reason: "crashed", exitCode: 5 });
+    vi.advanceTimersByTime(0);
+
+    expect(win.destroy).toHaveBeenCalledOnce();
+    expect(onRecreateWindow).toHaveBeenCalledOnce();
+    expect(win.webContents.reload).not.toHaveBeenCalled();
+    const errorArg = vi.mocked(notifyError).mock.calls[0][0] as Error;
+    expect(errorArg.message).toContain("out of memory");
+  });
+
+  it('"killed" with low available memory routes to OOM path (#9572)', () => {
+    const win = createMockWindow();
+    const onRecreateWindow = vi.fn().mockResolvedValue(undefined);
+    setupCrashRecovery(win, {
+      onRecreateWindow,
+      lowMemoryFreeThresholdMb: 768,
+      getAvailableMemoryMb: () => 200,
+    });
+
+    win._emitWc("render-process-gone", { reason: "killed", exitCode: 9 });
+    vi.advanceTimersByTime(0);
+
+    expect(win.destroy).toHaveBeenCalledOnce();
+    expect(onRecreateWindow).toHaveBeenCalledOnce();
+    expect(win.webContents.reload).not.toHaveBeenCalled();
+    const errorArg = vi.mocked(notifyError).mock.calls[0][0] as Error;
+    expect(errorArg.message).toContain("out of memory");
+  });
+
+  it('"crashed" with high available memory routes to regular crash path (#9572)', () => {
+    const win = createMockWindow();
+    const onRecreateWindow = vi.fn().mockResolvedValue(undefined);
+    setupCrashRecovery(win, {
+      onRecreateWindow,
+      lowMemoryFreeThresholdMb: 768,
+      getAvailableMemoryMb: () => 2048,
+    });
+
+    win._emitWc("render-process-gone", { reason: "crashed", exitCode: 1 });
+    vi.advanceTimersByTime(0);
+
+    expect(win.webContents.reload).toHaveBeenCalledOnce();
+    expect(onRecreateWindow).not.toHaveBeenCalled();
+    expect(win.destroy).not.toHaveBeenCalled();
+    const errorArg = vi.mocked(notifyError).mock.calls[0][0] as Error;
+    expect(errorArg.message).toContain("crashed");
+  });
+
+  it('"memory-eviction" reloads without counting toward crash-loop guard (#9572)', () => {
+    const win = createMockWindow();
+    setupCrashRecovery(win);
+
+    win._emitWc("render-process-gone", { reason: "memory-eviction", exitCode: 0 });
+    vi.advanceTimersByTime(0);
+    expect(win.webContents.reload).toHaveBeenCalledOnce();
+
+    win._emitWc("render-process-gone", { reason: "memory-eviction", exitCode: 0 });
+    vi.advanceTimersByTime(0);
+    expect(win.webContents.reload).toHaveBeenCalledTimes(2);
+
+    win._emitWc("render-process-gone", { reason: "memory-eviction", exitCode: 0 });
+    vi.advanceTimersByTime(0);
+    expect(win.webContents.reload).toHaveBeenCalledTimes(3);
+    expect(win.webContents.loadURL).not.toHaveBeenCalled();
+  });
+
+  it('"memory-eviction" fires memory-pressure notification, not crash toast (#9572)', () => {
+    const win = createMockWindow();
+    setupCrashRecovery(win);
+
+    win._emitWc("render-process-gone", { reason: "memory-eviction", exitCode: 0 });
+
+    expect(notifyError).toHaveBeenCalledOnce();
+    const errorArg = vi.mocked(notifyError).mock.calls[0][0] as Error;
+    expect(errorArg.message).not.toContain("crashed");
+    expect(errorArg.message).toContain("memory pressure");
   });
 });
 

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -45,6 +45,25 @@ import {
 const CRASH_LOOP_WINDOW_MS = 60_000;
 const CRASH_LOOP_THRESHOLD = 3;
 
+function getAvailableMemoryMb(): number | null {
+  try {
+    const getInfo = (
+      process as {
+        getSystemMemoryInfo?: () => { free: number; purgeable?: number; total: number };
+      }
+    ).getSystemMemoryInfo;
+    if (typeof getInfo !== "function") return null;
+    const info = getInfo.call(process);
+    const freeKb = typeof info.free === "number" ? info.free : 0;
+    const purgeableKb = typeof info.purgeable === "number" ? info.purgeable : 0;
+    const availableKb = freeKb + purgeableKb;
+    if (availableKb <= 0) return null;
+    return availableKb / 1024;
+  } catch {
+    return null;
+  }
+}
+
 let windowIpcHandlersRegistered = false;
 
 function registerWindowIpcHandlers(onCreateWindow?: (projectPath?: string) => Promise<void>): void {
@@ -476,11 +495,37 @@ export function setupBrowserWindow(
   appWebContents.on("render-process-gone", (_event, details) => {
     if (details.reason === "clean-exit") return;
     console.error("[MAIN] Renderer process gone:", details.reason, details.exitCode);
-    getCrashRecoveryService().recordCrash(
-      new Error(`Renderer process gone: ${details.reason} (exit code ${details.exitCode})`)
-    );
+    // Memory eviction is not a crash — skip the one-shot crash log so a
+    // genuine crash in the same session can still be recorded.
+    if (details.reason !== "memory-eviction") {
+      getCrashRecoveryService().recordCrash(
+        new Error(`Renderer process gone: ${details.reason} (exit code ${details.exitCode})`)
+      );
+    }
 
     if (win.isDestroyed()) return;
+
+    // OS-pressure memory eviction: reload without counting toward crash-loop
+    // guard (the view goes blank and will not auto-recover on its own).
+    if (details.reason === "memory-eviction") {
+      notifyError(new Error("The renderer was reloaded due to memory pressure."), {
+        source: "renderer-crash",
+      });
+      setImmediate(() => {
+        if (win.isDestroyed()) return;
+        appWebContents.reload();
+      });
+      return;
+    }
+
+    const availableMb = getAvailableMemoryMb();
+    const lowMemThresholdMb = getProjectViewManager()?.getLowMemoryFreeThresholdMb() ?? null;
+    const isProbableOom =
+      details.reason === "oom" ||
+      ((details.reason === "crashed" || details.reason === "killed") &&
+        lowMemThresholdMb !== null &&
+        availableMb !== null &&
+        availableMb < lowMemThresholdMb);
 
     const now = Date.now();
     while (
@@ -491,8 +536,6 @@ export function setupBrowserWindow(
     }
     rendererCrashTimestamps.push(now);
 
-    const isOom = details.reason === "oom";
-
     if (rendererCrashTimestamps.length >= CRASH_LOOP_THRESHOLD) {
       console.error("[MAIN] Crash loop detected, loading recovery page");
       setImmediate(() => {
@@ -500,7 +543,7 @@ export function setupBrowserWindow(
         const recoveryUrl = getRecoveryUrl(details.reason, details.exitCode);
         appWebContents.loadURL(recoveryUrl);
       });
-    } else if (isOom && onRecreateWindow) {
+    } else if (isProbableOom && onRecreateWindow) {
       const now2 = Date.now();
       while (
         oomRecreationTimestamps.length > 0 &&


### PR DESCRIPTION
## Summary

- The `render-process-gone` handler in `ProjectViewManager` only matched the literal `"oom"` reason for out-of-memory recovery, missing the common case where V8/Blink heap exhaustion surfaces as `"crashed"` and the OS OOM-killer surfaces as `"killed"`. Added probable-OOM detection using `getAvailableMemoryMb() < getLowMemoryFreeThresholdMb()` for those two reasons.
- Added a dedicated `"memory-eviction"` branch: explicit reload (the view stays blank without it), no crash-loop counter increment, memory-pressure toast for active views / `console.warn` for cached ones. The same fixes are applied to the `appWebContents` handler in `createWindow.ts`.
- `getCrashRecoveryService().recordCrash()` is skipped for memory-eviction — OS-pressure reclaim is not a crash and pollutes the one-shot crash log.

Resolves #9572

## Changes

- `electron/window/ProjectViewManager.ts` — probable-OOM branch for `"crashed"`/`"killed"`, dedicated `"memory-eviction"` branch, `getLowMemoryFreeThresholdMb()` public getter
- `electron/window/createWindow.ts` — same probable-OOM detection using module-level `getAvailableMemoryMb()` helper, dedicated eviction branch
- `electron/window/__tests__/rendererRecovery.test.ts` — 34 tests covering all new branches (5 new in first commit + 4 more tightening edge cases)

## Testing

- 34 unit tests covering probable-OOM routing for `"crashed"` and `"killed"`, `"memory-eviction"` reload and signal behaviour, crash-loop guard exclusion for eviction, and crash-record skip for eviction in both handlers.
- Known limitation: crash-loop timestamps live on `ViewEntry`, which is destroyed on OOM window recreation, so the OOM recreate loop guard resets on recreation. This is a pre-existing issue (it existed before this PR for the `"oom"` reason) and requires a separate architectural change.