### PR TITLE
fix(actions): deep-clone cached manifest schemas to prevent mutation leaks

### DIFF
--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -1,15 +1,15 @@
 {
-  "count": 1198,
+  "count": 1195,
   "byRule": {
     "@typescript-eslint/no-explicit-any": 54,
     "@typescript-eslint/no-floating-promises": 93,
-    "@typescript-eslint/no-unsafe-type-assertion": 504,
+    "@typescript-eslint/no-unsafe-type-assertion": 505,
     "no-restricted-imports": 8,
-    "no-restricted-syntax": 410,
+    "no-restricted-syntax": 407,
     "no-useless-assignment": 20,
     "preserve-caught-error": 52,
-    "react-compiler/react-compiler": 17,
+    "react-compiler/react-compiler": 16,
     "react-hooks/exhaustive-deps": 40
   },
-  "updatedAt": "2026-05-28T15:52:47.139Z"
+  "updatedAt": "2026-06-01T09:36:22.659Z"
 }

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -184,26 +184,34 @@ function computeRequiresArgs(definition: AnyActionDefinition): boolean {
  * Recursively freezes a value in DEV so any consumer that mutates a cached
  * schema — including nested `properties`/`items`/`$defs` that a shallow
  * `Object.freeze` leaves writable — fails loudly in tests rather than silently
- * poisoning the shared cache (issue #9569). No-op in production. Bounded by
- * JSON Schema nesting depth, so no stack-overflow risk.
+ * poisoning the shared cache (issue #9569). No-op in production. The `seen`
+ * guard keeps it safe against a cyclic `rawInputSchema` (an unconstrained
+ * plugin-supplied object), which would otherwise overflow the stack.
  */
-function deepFreeze(val: unknown): void {
+function deepFreeze(val: unknown, seen: WeakSet<object> = new WeakSet()): void {
   if (!import.meta.env.DEV || val === null || typeof val !== "object") return;
+  if (seen.has(val)) return;
+  seen.add(val);
   Object.freeze(val);
   for (const child of Object.values(val as Record<string, unknown>)) {
-    deepFreeze(child);
+    deepFreeze(child, seen);
   }
 }
 
 function computeSchemas(definition: AnyActionDefinition): CachedSchemas {
+  // Zod-derived schemas are fresh objects per call, but raw plugin-supplied
+  // schemas are the definition's live reference — clone them so the cache (and
+  // the DEV freeze below) never aliases or mutates the plugin's own object.
   const inputSchema = definition.argsSchema
     ? zodSchemaToJsonSchema(definition.argsSchema)
-    : definition.rawInputSchema;
+    : definition.rawInputSchema
+      ? structuredClone(definition.rawInputSchema)
+      : undefined;
   const outputSchema =
     definition.mcpOutputSchema && definition.resultSchema
       ? zodSchemaToJsonSchema(definition.resultSchema, "output")
-      : definition.mcpOutputSchema
-        ? definition.rawOutputSchema
+      : definition.mcpOutputSchema && definition.rawOutputSchema
+        ? structuredClone(definition.rawOutputSchema)
         : undefined;
   // Freeze the cached copies only (DEV). toManifestEntry hands consumers a
   // fresh structuredClone, so this never restricts callers that legitimately

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -107,6 +107,7 @@ function zodSchemaToJsonSchema(
       unrepresentable: "any",
       reused: "inline",
       cycles: "ref",
+      target: "draft-2020-12",
     }) as Record<string, unknown>;
   } catch (err) {
     logWarn("Failed to convert zod schema to JSON Schema", { error: err });
@@ -179,18 +180,37 @@ function computeRequiresArgs(definition: AnyActionDefinition): boolean {
     : rawSchemaRequiresArgs(definition.rawInputSchema);
 }
 
+/**
+ * Recursively freezes a value in DEV so any consumer that mutates a cached
+ * schema — including nested `properties`/`items`/`$defs` that a shallow
+ * `Object.freeze` leaves writable — fails loudly in tests rather than silently
+ * poisoning the shared cache (issue #9569). No-op in production. Bounded by
+ * JSON Schema nesting depth, so no stack-overflow risk.
+ */
+function deepFreeze(val: unknown): void {
+  if (!import.meta.env.DEV || val === null || typeof val !== "object") return;
+  Object.freeze(val);
+  for (const child of Object.values(val as Record<string, unknown>)) {
+    deepFreeze(child);
+  }
+}
+
 function computeSchemas(definition: AnyActionDefinition): CachedSchemas {
-  return {
-    inputSchema: definition.argsSchema
-      ? zodSchemaToJsonSchema(definition.argsSchema)
-      : definition.rawInputSchema,
-    outputSchema:
-      definition.mcpOutputSchema && definition.resultSchema
-        ? zodSchemaToJsonSchema(definition.resultSchema, "output")
-        : definition.mcpOutputSchema
-          ? definition.rawOutputSchema
-          : undefined,
-  };
+  const inputSchema = definition.argsSchema
+    ? zodSchemaToJsonSchema(definition.argsSchema)
+    : definition.rawInputSchema;
+  const outputSchema =
+    definition.mcpOutputSchema && definition.resultSchema
+      ? zodSchemaToJsonSchema(definition.resultSchema, "output")
+      : definition.mcpOutputSchema
+        ? definition.rawOutputSchema
+        : undefined;
+  // Freeze the cached copies only (DEV). toManifestEntry hands consumers a
+  // fresh structuredClone, so this never restricts callers that legitimately
+  // mutate their own manifest entry — it only catches writes back into the cache.
+  deepFreeze(inputSchema);
+  deepFreeze(outputSchema);
+  return { inputSchema, outputSchema };
 }
 
 export class ActionService {
@@ -476,10 +496,13 @@ export class ActionService {
       this.schemaCache.set(definition.id, schemas);
     }
 
-    // Shallow-copy the cached schemas so that if a downstream consumer
-    // (e.g. an MCP adapter normalizing in place) mutates entry.inputSchema
-    // at the top level, it can't poison subsequent list()/get() reads.
-    // Mirrors the mcpAnnotations isolation pattern below.
+    // Deep-clone the cached schemas so a downstream consumer (e.g. an MCP
+    // adapter normalizing in place) that mutates entry.inputSchema — including
+    // nested `properties`/`items`/`$defs`, which Zod v4's `reused: "inline"`
+    // physically shares — can't poison subsequent list()/get() reads. A shallow
+    // spread only isolated the top level (issue #9569). structuredClone is safe
+    // here: z.toJSONSchema finalizes through a JSON round-trip, so the cached
+    // value has no cycles or non-cloneable shapes.
     return {
       id: definition.id,
       name: definition.id,
@@ -493,8 +516,8 @@ export class ActionService {
         danger: definition.danger,
         category: definition.category,
       }),
-      inputSchema: schemas?.inputSchema ? { ...schemas.inputSchema } : undefined,
-      outputSchema: schemas?.outputSchema ? { ...schemas.outputSchema } : undefined,
+      inputSchema: schemas?.inputSchema ? structuredClone(schemas.inputSchema) : undefined,
+      outputSchema: schemas?.outputSchema ? structuredClone(schemas.outputSchema) : undefined,
       enabled,
       disabledReason,
       requiresArgs,
@@ -502,7 +525,7 @@ export class ActionService {
       ...(definition.mcpAnnotations ? { mcpAnnotations: { ...definition.mcpAnnotations } } : {}),
       ...(definition.mcpVisibility ? { mcpVisibility: definition.mcpVisibility } : {}),
       ...(definition.pluginId ? { pluginId: definition.pluginId } : {}),
-      ...(definition.examples ? { examples: [...definition.examples] } : {}),
+      ...(definition.examples ? { examples: structuredClone(definition.examples) } : {}),
       ...(definition.dangerRationale ? { dangerRationale: definition.dangerRationale } : {}),
     };
   }

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -1991,7 +1991,8 @@ describe("ActionService", () => {
       const action = {
         id: "acme.plugin.raw" as ActionId,
         title: "Raw",
-        description: "Plugin action with a raw input schema for mutation-isolation testing of the cache.",
+        description:
+          "Plugin action with a raw input schema for mutation-isolation testing of the cache.",
         category: "plugin",
         kind: "command",
         danger: "safe",
@@ -2020,7 +2021,8 @@ describe("ActionService", () => {
       const action = {
         id: "acme.plugin.raw" as ActionId,
         title: "Raw",
-        description: "Plugin action with a raw input schema, verifying the source object stays writable.",
+        description:
+          "Plugin action with a raw input schema, verifying the source object stays writable.",
         category: "plugin",
         kind: "command",
         danger: "safe",

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -1982,6 +1982,61 @@ describe("ActionService", () => {
       expect((second.properties as Record<string, unknown>).poisoned).toBeUndefined();
     });
 
+    it("isolates a raw plugin inputSchema from source-object mutation", () => {
+      const rawInputSchema = {
+        type: "object",
+        properties: { name: { type: "string" } },
+        required: ["name"],
+      };
+      const action = {
+        id: "acme.plugin.raw" as ActionId,
+        title: "Raw",
+        description: "Plugin action with a raw input schema for mutation-isolation testing of the cache.",
+        category: "plugin",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        rawInputSchema,
+        run: vi.fn().mockResolvedValue(undefined),
+      };
+      service.register(action as unknown as ActionDefinition);
+
+      // Trigger schema compilation, then mutate the plugin's own source object.
+      service.get("acme.plugin.raw" as ActionId);
+      (rawInputSchema.properties as Record<string, unknown>).poisoned = { type: "string" };
+
+      const entry = service.get("acme.plugin.raw" as ActionId);
+      expect(
+        (entry!.inputSchema as { properties: Record<string, unknown> }).properties.poisoned
+      ).toBeUndefined();
+    });
+
+    it("does not freeze a plugin's own raw schema object (clones before DEV freeze)", () => {
+      const rawInputSchema = {
+        type: "object",
+        properties: { name: { type: "string" } },
+        required: ["name"],
+      };
+      const action = {
+        id: "acme.plugin.raw" as ActionId,
+        title: "Raw",
+        description: "Plugin action with a raw input schema, verifying the source object stays writable.",
+        category: "plugin",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        rawInputSchema,
+        run: vi.fn().mockResolvedValue(undefined),
+      };
+      service.register(action as unknown as ActionDefinition);
+
+      // Compilation must clone before the DEV freeze, leaving the source writable.
+      service.get("acme.plugin.raw" as ActionId);
+      expect(() => {
+        (rawInputSchema.properties as Record<string, unknown>).extra = { type: "number" };
+      }).not.toThrow();
+    });
+
     it("evicts cache entry on unregister so re-register picks up new schema", () => {
       const schemaA = z.object({ a: z.string() });
       service.register({

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -1021,6 +1021,28 @@ describe("ActionService", () => {
       );
     });
 
+    it("isolates examples[].args from caller mutations", () => {
+      const action: ActionDefinition = {
+        id: "test.examples" as ActionId,
+        title: "Test Examples Action",
+        description: "An action with examples for nested mutation-isolation testing.",
+        category: "test",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        examples: [{ args: { key: "value" }, description: "Example invocation" }],
+        run: vi.fn().mockResolvedValue(undefined),
+      };
+
+      service.register(action);
+      // A shallow array copy ([...examples]) would leave examples[0].args aliased
+      // to the static definition, so this nested write would leak (issue #9569).
+      const first = service.get("test.examples" as ActionId)!;
+      (first.examples![0]!.args as Record<string, unknown>).key = "mutated";
+      const second = service.get("test.examples" as ActionId)!;
+      expect((second.examples![0]!.args as Record<string, unknown>).key).toBe("value");
+    });
+
     it("omits examples and dangerRationale from manifest entry when not defined", () => {
       const action: ActionDefinition = {
         id: "test.noexamples" as ActionId,
@@ -1928,8 +1950,36 @@ describe("ActionService", () => {
 
       const first = service.list()[0]!.inputSchema as Record<string, unknown>;
       first.poisoned = "x";
+      // Nested mutation: a shallow copy would leave `properties` aliased to the
+      // cache, so this write would leak across reads (issue #9569).
+      (first.properties as Record<string, unknown>).poisoned = "x";
       const second = service.list()[0]!.inputSchema as Record<string, unknown>;
       expect(second.poisoned).toBeUndefined();
+      expect((second.properties as Record<string, unknown>).poisoned).toBeUndefined();
+    });
+
+    it("isolates outputSchema from caller mutations", () => {
+      const argsSchema = z.object({ count: z.number() });
+      const resultSchema = z.object({ total: z.number() });
+      service.register({
+        id: "actions.list" as ActionId,
+        title: "Test",
+        description:
+          "Test action for validating ActionService definition invariant warnings and registration behavior.",
+        category: "test",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        argsSchema,
+        resultSchema,
+        mcpOutputSchema: true,
+        run: vi.fn().mockResolvedValue({ total: 1 }),
+      });
+
+      const first = service.list()[0]!.outputSchema as Record<string, unknown>;
+      (first.properties as Record<string, unknown>).poisoned = "x";
+      const second = service.list()[0]!.outputSchema as Record<string, unknown>;
+      expect((second.properties as Record<string, unknown>).poisoned).toBeUndefined();
     });
 
     it("evicts cache entry on unregister so re-register picks up new schema", () => {


### PR DESCRIPTION
## Summary

- `toManifestEntry` was using shallow spreads to protect the `schemaCache` from downstream consumers, but nested fields (`properties`, `items`, `$defs`) were still shared references. With Zod 4's `reused: "inline"`, a single write to a nested node can corrupt the same schema object in multiple places. Replaced with `structuredClone` so every `list()`/`get()` read gets a fully isolated copy.
- Deep-clones the `examples` array too -- each `ActionExample` carries a nested `args` object that the shallow copy wasn't protecting.
- Adds a DEV-only recursive `Object.freeze` (with cycle guard) on the cached `inputSchema`/`outputSchema` in `computeSchemas`, so any future mutating consumer fails loudly in tests rather than silently corrupting the cache. Gated on `import.meta.env.DEV`, matching the existing `validateActionDefinition` convention.
- Clones raw plugin schemas before caching and freezing, and pins `target: "draft-2020-12"` explicitly in `zodSchemaToJsonSchema` as a defensive pin against a future Zod default change.

Resolves #9569

## Changes

- `src/services/ActionService.ts` -- `structuredClone` in `toManifestEntry`, deep-clone examples, `deepFreeze` helper with cycle guard, `target: "draft-2020-12"` in `zodSchemaToJsonSchema`, clone raw plugin schemas before cache write
- `src/services/__tests__/ActionService.test.ts` -- mutation-isolation tests for input schema, output schema, examples array, and raw plugin schemas

## Testing

105 unit tests pass. Added four dedicated mutation-isolation tests that write to nested schema fields and the examples array after a `list()`/`get()` call and assert the cache is unaffected. `npm run check` clean.