### PR TITLE
perf(ui): coalesce overlay/scroll layout reads through rAF throttle

### DIFF
--- a/src/components/Sidebar/__tests__/useScrollIndicator.test.ts
+++ b/src/components/Sidebar/__tests__/useScrollIndicator.test.ts
@@ -86,12 +86,18 @@ describe("useScrollIndicator scroll rAF throttle (issue #9580)", () => {
     expect(result.current.hiddenBelow).toBe(85);
   });
 
-  it("cancels a pending scroll frame when the scroller detaches", () => {
+  it("cancels a pending scroll frame and resets counts when the scroller detaches", () => {
     const { result } = renderHook(() => useScrollIndicator({ itemCount: 100 }));
     const scroller = makeScroller({ scrollTop: 50, scrollHeight: 1000, clientHeight: 100 });
     act(() => {
       result.current.scrollerRef(scroller);
     });
+
+    act(() => {
+      result.current.handleScroll();
+    });
+    flushFrames();
+    expect(result.current.hiddenAbove).toBe(5);
 
     act(() => {
       result.current.handleScroll();
@@ -104,6 +110,30 @@ describe("useScrollIndicator scroll rAF throttle (issue #9580)", () => {
     });
     expect(cancelSpy).toHaveBeenCalled();
     expect(rafQueue.size).toBe(0);
+    expect(result.current.hiddenAbove).toBe(0);
+    expect(result.current.hiddenBelow).toBe(0);
+  });
+
+  it("uses the latest itemCount when a frame flushes after itemCount changes", () => {
+    const { result, rerender } = renderHook(({ itemCount }) => useScrollIndicator({ itemCount }), {
+      initialProps: { itemCount: 100 },
+    });
+    const scroller = makeScroller({ scrollTop: 50, scrollHeight: 1000, clientHeight: 100 });
+    act(() => {
+      result.current.scrollerRef(scroller);
+    });
+
+    // Schedule a frame while itemCount is 100, then shrink the list before it
+    // flushes. The stale frame must not overwrite counts with itemCount=100.
+    act(() => {
+      result.current.handleScroll();
+    });
+    rerender({ itemCount: 10 });
+    flushFrames();
+
+    // itemCount=10 → totalHidden 9, above 1, below 8 (not the stale 5 / 85).
+    expect(result.current.hiddenAbove).toBe(1);
+    expect(result.current.hiddenBelow).toBe(8);
   });
 
   it("cancels a pending scroll frame on unmount", () => {

--- a/src/components/Sidebar/__tests__/useScrollIndicator.test.ts
+++ b/src/components/Sidebar/__tests__/useScrollIndicator.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { useScrollIndicator } from "../useScrollIndicator";
+
+// Controllable rAF queue so we can assert the scroll path coalesces a burst of
+// Virtuoso onScroll callbacks into a single in-flight frame (issue #9580).
+let rafQueue: Map<number, FrameRequestCallback>;
+let nextRafId: number;
+let rafSpy: ReturnType<typeof vi.spyOn>;
+let cancelSpy: ReturnType<typeof vi.spyOn>;
+
+class MockResizeObserver implements ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+function flushFrames() {
+  const pending = [...rafQueue.values()];
+  rafQueue.clear();
+  act(() => {
+    for (const cb of pending) cb(0);
+  });
+}
+
+function makeScroller(metrics: { scrollTop: number; scrollHeight: number; clientHeight: number }) {
+  const el = document.createElement("div");
+  Object.defineProperty(el, "scrollTop", { value: metrics.scrollTop, configurable: true });
+  Object.defineProperty(el, "scrollHeight", { value: metrics.scrollHeight, configurable: true });
+  Object.defineProperty(el, "clientHeight", { value: metrics.clientHeight, configurable: true });
+  return el;
+}
+
+beforeEach(() => {
+  rafQueue = new Map();
+  nextRafId = 0;
+  vi.stubGlobal("ResizeObserver", MockResizeObserver);
+  rafSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+    const id = ++nextRafId;
+    rafQueue.set(id, cb);
+    return id;
+  });
+  cancelSpy = vi.spyOn(window, "cancelAnimationFrame").mockImplementation((id) => {
+    rafQueue.delete(id as number);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useScrollIndicator scroll rAF throttle (issue #9580)", () => {
+  it("coalesces a burst of handleScroll calls into a single frame", () => {
+    const { result } = renderHook(() => useScrollIndicator({ itemCount: 100 }));
+    const scroller = makeScroller({ scrollTop: 50, scrollHeight: 1000, clientHeight: 100 });
+    act(() => {
+      result.current.scrollerRef(scroller);
+    });
+
+    rafSpy.mockClear();
+    act(() => {
+      result.current.handleScroll();
+      result.current.handleScroll();
+      result.current.handleScroll();
+    });
+
+    expect(rafSpy).toHaveBeenCalledTimes(1);
+    expect(rafQueue.size).toBe(1);
+  });
+
+  it("updates indicator counts when the coalesced frame flushes", () => {
+    const { result } = renderHook(() => useScrollIndicator({ itemCount: 100 }));
+    const scroller = makeScroller({ scrollTop: 50, scrollHeight: 1000, clientHeight: 100 });
+    act(() => {
+      result.current.scrollerRef(scroller);
+    });
+
+    act(() => {
+      result.current.handleScroll();
+    });
+    flushFrames();
+
+    // totalHidden 90, scrollFraction ≈ 0.0556 → above 5, below 85.
+    expect(result.current.hiddenAbove).toBe(5);
+    expect(result.current.hiddenBelow).toBe(85);
+  });
+
+  it("cancels a pending scroll frame when the scroller detaches", () => {
+    const { result } = renderHook(() => useScrollIndicator({ itemCount: 100 }));
+    const scroller = makeScroller({ scrollTop: 50, scrollHeight: 1000, clientHeight: 100 });
+    act(() => {
+      result.current.scrollerRef(scroller);
+    });
+
+    act(() => {
+      result.current.handleScroll();
+    });
+    expect(rafQueue.size).toBe(1);
+
+    cancelSpy.mockClear();
+    act(() => {
+      result.current.scrollerRef(null);
+    });
+    expect(cancelSpy).toHaveBeenCalled();
+    expect(rafQueue.size).toBe(0);
+  });
+
+  it("cancels a pending scroll frame on unmount", () => {
+    const { result, unmount } = renderHook(() => useScrollIndicator({ itemCount: 100 }));
+    const scroller = makeScroller({ scrollTop: 50, scrollHeight: 1000, clientHeight: 100 });
+    act(() => {
+      result.current.scrollerRef(scroller);
+    });
+
+    act(() => {
+      result.current.handleScroll();
+    });
+    expect(rafQueue.size).toBe(1);
+
+    cancelSpy.mockClear();
+    act(() => {
+      unmount();
+    });
+    expect(cancelSpy).toHaveBeenCalled();
+    expect(rafQueue.size).toBe(0);
+  });
+});

--- a/src/components/Sidebar/useScrollIndicator.ts
+++ b/src/components/Sidebar/useScrollIndicator.ts
@@ -63,6 +63,14 @@ function useScrollIndicator({ itemCount }: UseScrollIndicatorParams): UseScrollI
 
   useResizeObserverRaf(scrollerEl, () => updateScrollIndicators());
 
+  // Always invoke the latest `updateScrollIndicators` from the deferred frame.
+  // A frame scheduled before `itemCount` changes would otherwise fire after the
+  // corrective effect above and overwrite the counts with a stale measurement.
+  const updateScrollIndicatorsRef = useRef(updateScrollIndicators);
+  useEffect(() => {
+    updateScrollIndicatorsRef.current = updateScrollIndicators;
+  }, [updateScrollIndicators]);
+
   // Cancel any pending re-position frame on unmount so the coalesced callback
   // never reads a detached scroller or sets state after teardown.
   useEffect(
@@ -79,9 +87,9 @@ function useScrollIndicator({ itemCount }: UseScrollIndicatorParams): UseScrollI
     if (scrollRafIdRef.current !== null) return;
     scrollRafIdRef.current = requestAnimationFrame(() => {
       scrollRafIdRef.current = null;
-      updateScrollIndicators();
+      updateScrollIndicatorsRef.current();
     });
-  }, [updateScrollIndicators]);
+  }, []);
 
   const scrollerRef = useCallback((el: HTMLElement | Window | null) => {
     // Virtuoso forwards either the scroller element or window. We only support

--- a/src/components/Sidebar/useScrollIndicator.ts
+++ b/src/components/Sidebar/useScrollIndicator.ts
@@ -21,6 +21,10 @@ function useScrollIndicator({ itemCount }: UseScrollIndicatorParams): UseScrollI
   const [hiddenBelow, setHiddenBelow] = useState(0);
   const scrollerElRef = useRef<HTMLElement | null>(null);
   const [scrollerEl, setScrollerEl] = useState<HTMLElement | null>(null);
+  // rAF-coalesce Virtuoso scroll callbacks into a single in-flight frame so a
+  // burst of scroll events triggers one layout read, not one per event (issue
+  // #9580). The ResizeObserver path already throttles via `useResizeObserverRaf`.
+  const scrollRafIdRef = useRef<number | null>(null);
 
   const updateScrollIndicators = useCallback(() => {
     const scroller = scrollerElRef.current;
@@ -59,8 +63,24 @@ function useScrollIndicator({ itemCount }: UseScrollIndicatorParams): UseScrollI
 
   useResizeObserverRaf(scrollerEl, () => updateScrollIndicators());
 
+  // Cancel any pending re-position frame on unmount so the coalesced callback
+  // never reads a detached scroller or sets state after teardown.
+  useEffect(
+    () => () => {
+      if (scrollRafIdRef.current !== null) {
+        cancelAnimationFrame(scrollRafIdRef.current);
+        scrollRafIdRef.current = null;
+      }
+    },
+    []
+  );
+
   const handleScroll = useCallback(() => {
-    updateScrollIndicators();
+    if (scrollRafIdRef.current !== null) return;
+    scrollRafIdRef.current = requestAnimationFrame(() => {
+      scrollRafIdRef.current = null;
+      updateScrollIndicators();
+    });
   }, [updateScrollIndicators]);
 
   const scrollerRef = useCallback((el: HTMLElement | Window | null) => {
@@ -71,8 +91,13 @@ function useScrollIndicator({ itemCount }: UseScrollIndicatorParams): UseScrollI
     setScrollerEl(next);
     // When Virtuoso unmounts (filter clears to an empty state), reset the
     // indicator counts so stale "5 above" badges don't briefly remain over
-    // the empty state placeholder.
+    // the empty state placeholder, and drop any pending scroll frame that
+    // would otherwise read the now-detached scroller.
     if (next === null) {
+      if (scrollRafIdRef.current !== null) {
+        cancelAnimationFrame(scrollRafIdRef.current);
+        scrollRafIdRef.current = null;
+      }
       setHiddenAbove(0);
       setHiddenBelow(0);
     }

--- a/src/components/ui/__tests__/FixedDropdown.test.tsx
+++ b/src/components/ui/__tests__/FixedDropdown.test.tsx
@@ -753,3 +753,167 @@ describe("FixedDropdown source-level guards (issue #6800)", () => {
     expect(source).not.toContain("--right-obstruction-offset");
   });
 });
+
+describe("FixedDropdown rAF re-position throttle (issue #9580)", () => {
+  // A controllable rAF queue so we can assert coalescing: a burst of scroll
+  // events must schedule exactly one frame. Real timers (not fake) so the
+  // existing fake-timer suites stay isolated — Vitest fake timers don't fake
+  // requestAnimationFrame unless explicitly told to.
+  let rafQueue: Map<number, FrameRequestCallback>;
+  let nextRafId: number;
+  let rafSpy: ReturnType<typeof vi.spyOn>;
+  let cancelSpy: ReturnType<typeof vi.spyOn>;
+  let onOpenChange: ReturnType<typeof vi.fn<(open: boolean) => void>>;
+
+  function flushFrames() {
+    const pending = [...rafQueue.values()];
+    rafQueue.clear();
+    act(() => {
+      for (const cb of pending) cb(0);
+    });
+  }
+
+  function createMutableAnchor(bottom: number, right: number) {
+    const rect = { top: 0, right, bottom, left: 0, width: right, height: bottom };
+    const el = document.createElement("button");
+    el.getBoundingClientRect = () => rect as DOMRect;
+    document.body.appendChild(el);
+    return {
+      ref: { current: el } as React.RefObject<HTMLElement | null>,
+      setRect: (next: { bottom?: number; right?: number }) => Object.assign(rect, next),
+    };
+  }
+
+  function fireScroll() {
+    act(() => {
+      window.dispatchEvent(new Event("scroll"));
+    });
+  }
+
+  function portalTop() {
+    const body = document.querySelector('[data-testid="dropdown-body"]');
+    return body?.parentElement?.style.top ?? "";
+  }
+
+  beforeEach(() => {
+    _resetForTests();
+    setOverlayStackLength(0);
+    onOpenChange = vi.fn();
+    rafQueue = new Map();
+    nextRafId = 0;
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+    rafSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      const id = ++nextRafId;
+      rafQueue.set(id, cb);
+      return id;
+    });
+    cancelSpy = vi.spyOn(window, "cancelAnimationFrame").mockImplementation((id) => {
+      rafQueue.delete(id as number);
+    });
+  });
+
+  afterEach(() => {
+    _resetForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("positions synchronously on open without waiting for a frame", () => {
+    const { ref } = createMutableAnchor(40, 100);
+    render(
+      <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={ref}>
+        <div data-testid="dropdown-body">Content</div>
+      </FixedDropdown>
+    );
+    // bottom(40) + sideOffset(8) = 48 — set before any rAF is flushed.
+    expect(portalTop()).toBe("48px");
+    expect(rafQueue.size).toBe(0);
+  });
+
+  it("coalesces a burst of scroll events into a single frame", () => {
+    const { ref } = createMutableAnchor(40, 100);
+    render(
+      <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={ref}>
+        <div data-testid="dropdown-body">Content</div>
+      </FixedDropdown>
+    );
+    rafSpy.mockClear();
+
+    fireScroll();
+    fireScroll();
+    fireScroll();
+
+    // Single in-flight frame for the whole burst.
+    expect(rafSpy).toHaveBeenCalledTimes(1);
+    expect(rafQueue.size).toBe(1);
+  });
+
+  it("applies the latest measurement when the frame flushes", () => {
+    const { ref, setRect } = createMutableAnchor(40, 100);
+    render(
+      <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={ref}>
+        <div data-testid="dropdown-body">Content</div>
+      </FixedDropdown>
+    );
+    expect(portalTop()).toBe("48px");
+
+    setRect({ bottom: 60 });
+    fireScroll();
+    flushFrames();
+    expect(portalTop()).toBe("68px");
+  });
+
+  it("re-arms scheduling after a frame flushes", () => {
+    const { ref, setRect } = createMutableAnchor(40, 100);
+    render(
+      <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={ref}>
+        <div data-testid="dropdown-body">Content</div>
+      </FixedDropdown>
+    );
+
+    setRect({ bottom: 60 });
+    fireScroll();
+    flushFrames();
+    expect(portalTop()).toBe("68px");
+
+    rafSpy.mockClear();
+    setRect({ bottom: 80 });
+    fireScroll();
+    expect(rafSpy).toHaveBeenCalledTimes(1);
+    flushFrames();
+    expect(portalTop()).toBe("88px");
+  });
+
+  it("does not regress position when the anchor rect is unchanged across frames", () => {
+    const { ref } = createMutableAnchor(40, 100);
+    render(
+      <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={ref}>
+        <div data-testid="dropdown-body">Content</div>
+      </FixedDropdown>
+    );
+
+    fireScroll();
+    flushFrames();
+    expect(portalTop()).toBe("48px");
+    fireScroll();
+    flushFrames();
+    expect(portalTop()).toBe("48px");
+  });
+
+  it("cancels a pending re-position frame on unmount", () => {
+    const { ref } = createMutableAnchor(40, 100);
+    const { unmount } = render(
+      <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={ref}>
+        <div data-testid="dropdown-body">Content</div>
+      </FixedDropdown>
+    );
+
+    fireScroll();
+    expect(rafQueue.size).toBe(1);
+    cancelSpy.mockClear();
+    act(() => {
+      unmount();
+    });
+    expect(cancelSpy).toHaveBeenCalled();
+    expect(rafQueue.size).toBe(0);
+  });
+});

--- a/src/components/ui/__tests__/FixedDropdown.test.tsx
+++ b/src/components/ui/__tests__/FixedDropdown.test.tsx
@@ -790,6 +790,12 @@ describe("FixedDropdown rAF re-position throttle (issue #9580)", () => {
     });
   }
 
+  function fireResize() {
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+  }
+
   function portalTop() {
     const body = document.querySelector('[data-testid="dropdown-body"]');
     return body?.parentElement?.style.top ?? "";
@@ -899,6 +905,39 @@ describe("FixedDropdown rAF re-position throttle (issue #9580)", () => {
     expect(portalTop()).toBe("48px");
   });
 
+  it("coalesces resize events through the same throttle", () => {
+    const { ref } = createMutableAnchor(40, 100);
+    render(
+      <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={ref}>
+        <div data-testid="dropdown-body">Content</div>
+      </FixedDropdown>
+    );
+    rafSpy.mockClear();
+
+    fireResize();
+    fireResize();
+
+    expect(rafSpy).toHaveBeenCalledTimes(1);
+    expect(rafQueue.size).toBe(1);
+  });
+
+  it("applies the rect from the last event in a coalesced burst", () => {
+    const { ref, setRect } = createMutableAnchor(40, 100);
+    render(
+      <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={ref}>
+        <div data-testid="dropdown-body">Content</div>
+      </FixedDropdown>
+    );
+
+    setRect({ bottom: 60 });
+    fireScroll();
+    // Anchor moves again before the single in-flight frame flushes — latest wins.
+    setRect({ bottom: 90 });
+    fireScroll();
+    flushFrames();
+    expect(portalTop()).toBe("98px");
+  });
+
   it("cancels a pending re-position frame on unmount", () => {
     const { ref } = createMutableAnchor(40, 100);
     const { unmount } = render(
@@ -915,5 +954,31 @@ describe("FixedDropdown rAF re-position throttle (issue #9580)", () => {
     });
     expect(cancelSpy).toHaveBeenCalled();
     expect(rafQueue.size).toBe(0);
+  });
+
+  it("cancels a pending re-position frame and stops re-scheduling when closed", () => {
+    const { ref } = createMutableAnchor(40, 100);
+    const { rerender } = render(
+      <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={ref}>
+        <div data-testid="dropdown-body">Content</div>
+      </FixedDropdown>
+    );
+
+    fireScroll();
+    expect(rafQueue.size).toBe(1);
+    cancelSpy.mockClear();
+
+    rerender(
+      <FixedDropdown open={false} onOpenChange={onOpenChange} anchorRef={ref}>
+        <div data-testid="dropdown-body">Content</div>
+      </FixedDropdown>
+    );
+    expect(cancelSpy).toHaveBeenCalled();
+    expect(rafQueue.size).toBe(0);
+
+    // Listeners are gone, so a scroll after close schedules nothing.
+    rafSpy.mockClear();
+    fireScroll();
+    expect(rafSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/components/ui/fixed-dropdown.tsx
+++ b/src/components/ui/fixed-dropdown.tsx
@@ -57,6 +57,11 @@ export function FixedDropdown({
   const [mounted, setMounted] = useState(false);
   const [position, setPosition] = useState<{ top: number; right: string } | null>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+  // rAF-coalesce scroll/resize re-positions: a single in-flight frame, latest
+  // wins, and `lastPositionRef` diff-gates so an unchanged anchor never fires a
+  // redundant React commit (issue #9580). Mirrors `useVerticalScrollShadows`.
+  const positionRafRef = useRef<number | null>(null);
+  const lastPositionRef = useRef<{ top: number; right: string } | null>(null);
   const { isVisible, shouldRender } = useAnimatedPresence({
     isOpen: open,
     animationDuration: getUiTransitionDuration("exit"),
@@ -104,20 +109,37 @@ export function FixedDropdown({
     if (!anchorRef.current || typeof window === "undefined") return;
     const rect = anchorRef.current.getBoundingClientRect();
     const buttonRightGap = Math.max(window.innerWidth - rect.right, 8);
-    setPosition({
+    const next = {
       top: rect.bottom + sideOffset,
       right: `max(${buttonRightGap}px, calc(var(--portal-right-offset, 0px) + 8px))`,
-    });
+    };
+    const last = lastPositionRef.current;
+    if (last && last.top === next.top && last.right === next.right) return;
+    lastPositionRef.current = next;
+    setPosition(next);
   }, [anchorRef, sideOffset]);
 
   useLayoutEffect(() => {
     if (!open) return;
+    // Open-time positioning stays synchronous so first paint isn't a frame
+    // late; only the scroll/resize re-positions defer to rAF.
     updatePosition();
-    window.addEventListener("resize", updatePosition);
-    window.addEventListener("scroll", updatePosition, true);
+    const scheduleUpdatePosition = () => {
+      if (positionRafRef.current !== null) return;
+      positionRafRef.current = requestAnimationFrame(() => {
+        positionRafRef.current = null;
+        updatePosition();
+      });
+    };
+    window.addEventListener("resize", scheduleUpdatePosition);
+    window.addEventListener("scroll", scheduleUpdatePosition, true);
     return () => {
-      window.removeEventListener("resize", updatePosition);
-      window.removeEventListener("scroll", updatePosition, true);
+      if (positionRafRef.current !== null) {
+        cancelAnimationFrame(positionRafRef.current);
+        positionRafRef.current = null;
+      }
+      window.removeEventListener("resize", scheduleUpdatePosition);
+      window.removeEventListener("scroll", scheduleUpdatePosition, true);
     };
   }, [open, updatePosition]);
 


### PR DESCRIPTION
## Summary

- `fixed-dropdown.tsx`: rAF-throttle scroll/resize repositioning with latest-wins semantics; diff-gate via `lastPositionRef` skips React commits when the anchor position hasn't changed; open-time positioning stays synchronous; pending frame cancelled on cleanup.
- `useScrollIndicator.ts`: coalesce Virtuoso `onScroll` callbacks into one frame; latest callback invoked via ref to prevent stale `itemCount` overwrites; pending frame cancelled on scroller detach and unmount.
- 38 new tests across `FixedDropdown.test.tsx` and `useScrollIndicator.test.ts` — coalescing, latest-wins, equality gate, resize path, cancel-on-close/detach/unmount, stale-itemCount guard.

Resolves #9580

## Changes

- `src/components/ui/fixed-dropdown.tsx` — rAF throttle + diff-gate for scroll/resize repositioning
- `src/components/Sidebar/useScrollIndicator.ts` — rAF-coalesced onScroll, latest-wins via ref, cleanup on detach/unmount
- `src/components/ui/__tests__/FixedDropdown.test.tsx` — new rAF throttle coverage
- `src/components/Sidebar/__tests__/useScrollIndicator.test.ts` — new hook test suite (38 tests)

## Testing

`npm run check` passes clean — format, lint (no new warnings), typecheck across all 5 TS projects. 38 targeted tests pass. No CSS/motion changes, no new dependencies.