### PR TITLE
perf(settings): migrate audit-log viewers onto shared minute ticker

### DIFF
--- a/src/components/Settings/ForgeAuditLogViewer.tsx
+++ b/src/components/Settings/ForgeAuditLogViewer.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Check, Clock, Copy, Download, Eye, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
 import type { ForgeAnomalyKind, ForgeAuditRecord, ForgeAuditResult } from "@shared/types/ipc/forge";
@@ -14,8 +15,6 @@ const TIME_RANGE_MS: Record<Exclude<TimeRange, "all">, number> = {
   "1h": 3_600_000,
   "24h": 86_400_000,
 };
-
-const RELATIVE_TIMESTAMP_REFRESH_MS = 30_000;
 
 const RESULT_LABEL: Record<ForgeAuditResult, string> = {
   success: "Success",
@@ -89,12 +88,12 @@ export function ForgeAuditLogViewer({
   const [timeRange, setTimeRange] = useState<TimeRange>("all");
   const [showSuccessful, setShowSuccessful] = useState(false);
   const [ignoreLastHour, setIgnoreLastHour] = useState(false);
-  const [nowTick, setNowTick] = useState(Date.now());
 
-  useEffect(() => {
-    const id = setInterval(() => setNowTick(Date.now()), RELATIVE_TIMESTAMP_REFRESH_MS);
-    return () => clearInterval(id);
-  }, []);
+  const tick = useGlobalMinuteTicker();
+  const now = useMemo(() => {
+    void tick;
+    return Date.now();
+  }, [tick]);
 
   // The toggle is the user's expressed intent, but `resultFilter === "success"`
   // means the user explicitly asked for that bucket — don't filter them back out.
@@ -103,7 +102,7 @@ export function ForgeAuditLogViewer({
   const filteredRecords = useMemo(() => {
     const needle = methodFilter.trim().toLowerCase();
     const search = searchQuery.trim().toLowerCase();
-    const cutoffMs = timeRange !== "all" ? nowTick - TIME_RANGE_MS[timeRange] : undefined;
+    const cutoffMs = timeRange !== "all" ? now - TIME_RANGE_MS[timeRange] : undefined;
     return records.filter((record) => {
       if (cutoffMs !== undefined && record.timestamp < cutoffMs) return false;
       if (suppressSuccess && record.result === "success") return false;
@@ -124,9 +123,9 @@ export function ForgeAuditLogViewer({
       }
       return true;
     });
-  }, [records, methodFilter, searchQuery, resultFilter, suppressSuccess, timeRange, nowTick]);
+  }, [records, methodFilter, searchQuery, resultFilter, suppressSuccess, timeRange, now]);
 
-  const oneHourAgo = nowTick - 3_600_000;
+  const oneHourAgo = now - 3_600_000;
   const visibleSignals = useMemo(() => {
     if (anomalySuppressed) return [];
     return ignoreLastHour
@@ -331,7 +330,7 @@ export function ForgeAuditLogViewer({
                   )}
                 </div>
                 <div className="text-right text-daintree-text/40 whitespace-nowrap">
-                  <div>{formatRelativeTimestamp(record.timestamp, nowTick)}</div>
+                  <div>{formatRelativeTimestamp(record.timestamp, now)}</div>
                   <div>{record.durationMs}ms</div>
                 </div>
               </li>

--- a/src/components/Settings/McpAuditLogViewer.tsx
+++ b/src/components/Settings/McpAuditLogViewer.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Check, Clock, Copy, Download, Layers, RefreshCw, ShieldOff } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
 import type {
@@ -45,8 +46,6 @@ const TIME_RANGE_MS: Record<Exclude<TimeRange, "all">, number> = {
   "1h": 3_600_000,
   "24h": 86_400_000,
 };
-
-const RELATIVE_TIMESTAMP_REFRESH_MS = 30_000;
 
 const OUTCOME_LABEL: Record<string, string> = {
   answered: "Answered",
@@ -161,14 +160,14 @@ export function McpAuditLogViewer({
   const [resultFilter, setResultFilter] = useState<AuditResultFilter>("all");
   const [timeRange, setTimeRange] = useState<TimeRange>("all");
   const [searchQuery, setSearchQuery] = useState("");
-  const [nowTick, setNowTick] = useState(Date.now());
   const [groupByTurn, setGroupByTurn] = useState(false);
   const [ignoreLastHour, setIgnoreLastHour] = useState(false);
 
-  useEffect(() => {
-    const id = setInterval(() => setNowTick(Date.now()), RELATIVE_TIMESTAMP_REFRESH_MS);
-    return () => clearInterval(id);
-  }, []);
+  const tick = useGlobalMinuteTicker();
+  const now = useMemo(() => {
+    void tick;
+    return Date.now();
+  }, [tick]);
 
   const visibleRecords = useMemo(() => {
     if (!includeRecord) return records;
@@ -183,7 +182,7 @@ export function McpAuditLogViewer({
   const filteredRecords = useMemo(() => {
     const needle = toolFilter.trim().toLowerCase();
     const searchNeedle = searchQuery.trim().toLowerCase();
-    const cutoffMs = timeRange !== "all" ? nowTick - TIME_RANGE_MS[timeRange] : undefined;
+    const cutoffMs = timeRange !== "all" ? now - TIME_RANGE_MS[timeRange] : undefined;
     return visibleRecords.filter((record) => {
       if (cutoffMs !== undefined && record.timestamp < cutoffMs) return false;
       if (resultFilter !== "all" && record.result !== resultFilter) return false;
@@ -195,7 +194,7 @@ export function McpAuditLogViewer({
         return false;
       return true;
     });
-  }, [visibleRecords, resultFilter, toolFilter, timeRange, searchQuery, nowTick]);
+  }, [visibleRecords, resultFilter, toolFilter, timeRange, searchQuery, now]);
 
   const turnGroups = useMemo(() => {
     if (!groupByTurn || !turnRecords || turnRecords.length === 0) return null;
@@ -204,7 +203,7 @@ export function McpAuditLogViewer({
 
   const showCopyAll = filteredRecords.length === visibleRecords.length;
 
-  const oneHourAgo = Date.now() - 3_600_000;
+  const oneHourAgo = now - 3_600_000;
   const visibleSignals = useMemo(() => {
     if (anomalySuppressed) return [];
     return ignoreLastHour
@@ -382,7 +381,7 @@ export function McpAuditLogViewer({
                     {OUTCOME_LABEL[group.turnRecord.outcome] ?? group.turnRecord.outcome}
                   </span>
                   <span className="text-daintree-text/40">
-                    {formatRelativeTimestamp(group.turnRecord.timestamp, nowTick)}
+                    {formatRelativeTimestamp(group.turnRecord.timestamp, now)}
                   </span>
                   <span className="text-daintree-text/40">
                     {group.callCount} call{group.callCount !== 1 ? "s" : ""}
@@ -520,7 +519,7 @@ export function McpAuditLogViewer({
                   )}
                 </div>
                 <div className="text-right text-daintree-text/40 whitespace-nowrap">
-                  <div>{formatRelativeTimestamp(record.timestamp, nowTick)}</div>
+                  <div>{formatRelativeTimestamp(record.timestamp, now)}</div>
                   <div>{record.durationMs}ms</div>
                 </div>
               </li>

--- a/src/components/Settings/PluginActionAuditLogViewer.tsx
+++ b/src/components/Settings/PluginActionAuditLogViewer.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Check, Copy, Download, Eye, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
 import type { PluginActionAuditRecord, PluginActionAuditResult } from "@shared/types";
@@ -28,8 +29,6 @@ const TIME_RANGE_MS: Record<Exclude<TimeRange, "all">, number> = {
   "1h": 3_600_000,
   "24h": 86_400_000,
 };
-
-const RELATIVE_TIMESTAMP_REFRESH_MS = 30_000;
 
 function formatRelativeTimestamp(ts: number, now: number): string {
   const diffMs = now - ts;
@@ -78,12 +77,12 @@ export function PluginActionAuditLogViewer({
   const [resultFilter, setResultFilter] = useState<ResultFilter>("all");
   const [timeRange, setTimeRange] = useState<TimeRange>("all");
   const [showSuccessful, setShowSuccessful] = useState(false);
-  const [nowTick, setNowTick] = useState(Date.now());
 
-  useEffect(() => {
-    const id = setInterval(() => setNowTick(Date.now()), RELATIVE_TIMESTAMP_REFRESH_MS);
-    return () => clearInterval(id);
-  }, []);
+  const tick = useGlobalMinuteTicker();
+  const now = useMemo(() => {
+    void tick;
+    return Date.now();
+  }, [tick]);
 
   // Whether the rendered list will visibly hide successful records. The toggle
   // is the user's expressed intent, but `resultFilter === "success"` means the
@@ -93,7 +92,7 @@ export function PluginActionAuditLogViewer({
   const filteredRecords = useMemo(() => {
     const needle = pluginFilter.trim().toLowerCase();
     const search = searchQuery.trim().toLowerCase();
-    const cutoffMs = timeRange !== "all" ? nowTick - TIME_RANGE_MS[timeRange] : undefined;
+    const cutoffMs = timeRange !== "all" ? now - TIME_RANGE_MS[timeRange] : undefined;
     return records.filter((record) => {
       if (cutoffMs !== undefined && record.ts < cutoffMs) return false;
       if (suppressSuccess && record.result === "success") return false;
@@ -114,7 +113,7 @@ export function PluginActionAuditLogViewer({
       }
       return true;
     });
-  }, [records, pluginFilter, searchQuery, resultFilter, suppressSuccess, timeRange, nowTick]);
+  }, [records, pluginFilter, searchQuery, resultFilter, suppressSuccess, timeRange, now]);
 
   const isFiltering =
     pluginFilter.trim().length > 0 ||
@@ -266,7 +265,7 @@ export function PluginActionAuditLogViewer({
                   ) : null}
                 </div>
                 <div className="text-right text-daintree-text/40 whitespace-nowrap">
-                  <div>{formatRelativeTimestamp(record.ts, nowTick)}</div>
+                  <div>{formatRelativeTimestamp(record.ts, now)}</div>
                   <div>{record.durationMs}ms</div>
                 </div>
               </li>

--- a/src/components/Settings/__tests__/AuditLogViewers.globalTicker.test.ts
+++ b/src/components/Settings/__tests__/AuditLogViewers.globalTicker.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+
+/**
+ * Audit-log viewers — shared minute-ticker wiring (issue #9582).
+ *
+ * The three settings audit-log viewers (`McpAuditLogViewer`,
+ * `ForgeAuditLogViewer`, `PluginActionAuditLogViewer`) previously each ran
+ * their own 30s `setInterval` to refresh relative timestamps — firing even
+ * when the window was hidden. They now derive `now` from the shared
+ * visibility-gated `useGlobalMinuteTicker` singleton (the same pattern as
+ * `GitHubStatsToolbarButton`).
+ *
+ * These are source assertions rather than render tests: the viewers have no
+ * jsdom setup and the migration is a non-behavioral timer-source swap, so
+ * locking the wiring in source prevents a future copy of the old per-component
+ * timer pattern from drifting back in.
+ */
+const VIEWERS = [
+  "McpAuditLogViewer.tsx",
+  "ForgeAuditLogViewer.tsx",
+  "PluginActionAuditLogViewer.tsx",
+] as const;
+
+describe("audit-log viewers — shared minute-ticker wiring (issue #9582)", () => {
+  const sources = new Map<string, string>();
+
+  beforeAll(async () => {
+    for (const file of VIEWERS) {
+      sources.set(file, await fs.readFile(path.resolve(__dirname, "..", file), "utf-8"));
+    }
+  });
+
+  it.each(VIEWERS)("%s imports and reads the shared minute ticker", (file) => {
+    const source = sources.get(file)!;
+    expect(source).toContain('from "@/hooks/useGlobalMinuteTicker"');
+    expect(source).toMatch(/const\s+tick\s*=\s*useGlobalMinuteTicker\(\)/);
+  });
+
+  it.each(VIEWERS)(
+    "%s derives now via useMemo(() => { void tick; return Date.now() }, [tick])",
+    (file) => {
+      const source = sources.get(file)!;
+      expect(source).toMatch(
+        /const\s+now\s*=\s*useMemo\(\s*\(\)\s*=>\s*\{\s*void tick;\s*return Date\.now\(\);\s*\}\s*,\s*\[tick\]\s*\)/
+      );
+    }
+  );
+
+  it.each(VIEWERS)("%s no longer hand-rolls a per-component timer", (file) => {
+    const source = sources.get(file)!;
+    expect(source).not.toContain("setInterval");
+    expect(source).not.toContain("clearInterval");
+    expect(source).not.toContain("RELATIVE_TIMESTAMP_REFRESH_MS");
+    expect(source).not.toContain("nowTick");
+  });
+
+  it("McpAuditLogViewer derives the one-hour cutoff from the ticker, not a fresh Date.now()", () => {
+    const source = sources.get("McpAuditLogViewer.tsx")!;
+    expect(source).toContain("const oneHourAgo = now - 3_600_000");
+    expect(source).not.toContain("Date.now() - 3_600_000");
+  });
+});

--- a/src/components/Settings/__tests__/AuditLogViewers.globalTicker.test.ts
+++ b/src/components/Settings/__tests__/AuditLogViewers.globalTicker.test.ts
@@ -50,8 +50,11 @@ describe("audit-log viewers — shared minute-ticker wiring (issue #9582)", () =
 
   it.each(VIEWERS)("%s no longer hand-rolls a per-component timer", (file) => {
     const source = sources.get(file)!;
-    expect(source).not.toContain("setInterval");
-    expect(source).not.toContain("clearInterval");
+    // Ban the bare names and their window/globalThis-qualified forms so a
+    // requalified timer can't sneak the old pattern back past the check.
+    expect(source).not.toMatch(/\b(?:window\.|globalThis\.)?setInterval\b/);
+    expect(source).not.toMatch(/\b(?:window\.|globalThis\.)?clearInterval\b/);
+    expect(source).not.toMatch(/\b(?:window\.|globalThis\.)?setTimeout\b/);
     expect(source).not.toContain("RELATIVE_TIMESTAMP_REFRESH_MS");
     expect(source).not.toContain("nowTick");
   });


### PR DESCRIPTION
## Summary

- Migrates `McpAuditLogViewer`, `ForgeAuditLogViewer`, and `PluginActionAuditLogViewer` off hand-rolled per-component `setInterval` timestamp refreshers onto `useGlobalMinuteTicker` — the same visibility-gated singleton the toolbar already uses
- Timer cadence stays 30s, but timers now pause when the window is hidden instead of running unconditionally
- Also fixes a latent stale-cutoff bug in `McpAuditLogViewer` where the one-hour anomaly cutoff was derived from a free-variable `Date.now()` rather than the ticker, so it could be stale by up to 30s

Resolves #9582

## Changes

- Each viewer now derives `now` via `const tick = useGlobalMinuteTicker(); const now = useMemo(() => { void tick; return Date.now(); }, [tick]);`
- Removed the duplicated `RELATIVE_TIMESTAMP_REFRESH_MS` constant and unused `useEffect` import from all three components
- Added `AuditLogViewers.globalTicker.test.ts` — a source-assertion test modelled on `GitHubStatsToolbarButton.freshness.test.ts` that locks in the wiring and bans reintroduction of per-component timers

## Testing

- Typecheck passes, format clean, lint ratchet improved (1195 → 1194 warnings)
- 10 test assertions pass in the new source-assertion test
- React Compiler pattern confirmed safe