### PR TITLE
perf(agent-detection): trim redundant per-chunk allocations

### DIFF
--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -393,11 +393,13 @@ export class ActivityMonitor {
     }
   }
 
-  private isEscInterruptFallback(input: string): boolean {
-    return (
-      input.toLowerCase().includes("esc to interrupt") ||
-      input.toLowerCase().includes("esc to cancel")
-    );
+  /**
+   * @param lowerInput Pre-lowercased, ANSI-stripped text. Callers must lowercase
+   *   before calling — this avoids re-allocating a lowercased copy of the rolling
+   *   buffer on the per-chunk hot path. Both call sites already pass lowercased text.
+   */
+  private isEscInterruptFallback(lowerInput: string): boolean {
+    return lowerInput.includes("esc to interrupt") || lowerInput.includes("esc to cancel");
   }
 
   onInput(data: string): void {
@@ -476,7 +478,7 @@ export class ActivityMonitor {
 
       // Check for working patterns in the rolling buffer
       const patternResult = this.patternDetector
-        ? this.patternDetector.detect(bufferText)
+        ? this.patternDetector.detect(bufferText, { alreadyStripped: true })
         : undefined;
       if (patternResult) {
         this.lastPatternResult = patternResult;

--- a/electron/services/pty/AgentPatternDetector.ts
+++ b/electron/services/pty/AgentPatternDetector.ts
@@ -190,37 +190,18 @@ export class AgentPatternDetector {
   }
 
   /**
-   * Detect working state from raw terminal output.
-   *
-   * @param output Raw terminal output (may include ANSI codes)
-   * @returns Detection result with working state and confidence
+   * Run the configured pattern tiers against pre-windowed, ANSI-stripped text.
+   * Uses `RegExp.test` rather than `String.match` to avoid allocating a match
+   * array on the per-chunk hot path — the matched substring is never consumed.
    */
-  detect(output: string): PatternDetectionResult {
-    if (!output || output.length === 0) {
-      return {
-        isWorking: false,
-        confidence: 0,
-        matchTier: "none",
-      };
-    }
-
-    // Strip ANSI codes for reliable pattern matching
-    const cleanOutput = stripAnsi(output);
-
-    // Split into lines and take the last N lines
-    const lines = cleanOutput.split("\n");
-    const scanLines = lines.slice(-this.scanLineCount);
-    const textToScan = scanLines.join("\n");
-
+  private matchPatterns(textToScan: string): PatternDetectionResult {
     // Try primary patterns first (high confidence)
     for (const pattern of this.config.primaryPatterns) {
-      const match = textToScan.match(pattern);
-      if (match) {
+      if (pattern.test(textToScan)) {
         return {
           isWorking: true,
           confidence: this.config.primaryConfidence ?? 0.95,
           matchTier: "primary",
-          matchedText: match[0],
         };
       }
     }
@@ -228,13 +209,11 @@ export class AgentPatternDetector {
     // Try fallback patterns (medium confidence)
     if (this.config.fallbackPatterns) {
       for (const pattern of this.config.fallbackPatterns) {
-        const match = textToScan.match(pattern);
-        if (match) {
+        if (pattern.test(textToScan)) {
           return {
             isWorking: true,
             confidence: this.config.fallbackConfidence ?? 0.75,
             matchTier: "fallback",
-            matchedText: match[0],
           };
         }
       }
@@ -246,6 +225,55 @@ export class AgentPatternDetector {
       confidence: 0,
       matchTier: "none",
     };
+  }
+
+  /**
+   * Find the offset of the last `scanLineCount` lines within `text` without
+   * allocating a per-line array. Equivalent to
+   * `text.split("\n").slice(-scanLineCount).join("\n")` but returns a single
+   * slice offset, avoiding the intermediate array and segment strings.
+   */
+  private lastLinesOffset(text: string): number {
+    let startOffset = 0;
+    let searchFrom = text.length;
+    for (let i = 0; i < this.scanLineCount; i++) {
+      const nl = text.lastIndexOf("\n", searchFrom - 1);
+      if (nl === -1) {
+        // Fewer than scanLineCount lines — scan the whole string.
+        return 0;
+      }
+      startOffset = nl + 1;
+      searchFrom = nl;
+    }
+    return startOffset;
+  }
+
+  /**
+   * Detect working state from terminal output.
+   *
+   * @param output Terminal output. Raw (may include ANSI codes) unless
+   *   `opts.alreadyStripped` is set.
+   * @param opts.alreadyStripped When true, `output` is assumed to already be
+   *   ANSI-stripped and the internal strip is skipped (hot-path callers that
+   *   strip once and reuse the result).
+   * @returns Detection result with working state and confidence
+   */
+  detect(output: string, opts?: { alreadyStripped?: boolean }): PatternDetectionResult {
+    if (!output || output.length === 0) {
+      return {
+        isWorking: false,
+        confidence: 0,
+        matchTier: "none",
+      };
+    }
+
+    // Strip ANSI codes for reliable pattern matching (unless already stripped).
+    const cleanOutput = opts?.alreadyStripped ? output : stripAnsi(output);
+
+    // Scan only the last N lines.
+    const textToScan = cleanOutput.slice(this.lastLinesOffset(cleanOutput));
+
+    return this.matchPatterns(textToScan);
   }
 
   /**
@@ -271,41 +299,7 @@ export class AgentPatternDetector {
     const cleanedLines = scanLines.map((line) => stripAnsi(line));
     const textToScan = cleanedLines.join("\n");
 
-    // Reuse main detection logic
-    // Try primary patterns first (high confidence)
-    for (const pattern of this.config.primaryPatterns) {
-      const match = textToScan.match(pattern);
-      if (match) {
-        return {
-          isWorking: true,
-          confidence: this.config.primaryConfidence ?? 0.95,
-          matchTier: "primary",
-          matchedText: match[0],
-        };
-      }
-    }
-
-    // Try fallback patterns (medium confidence)
-    if (this.config.fallbackPatterns) {
-      for (const pattern of this.config.fallbackPatterns) {
-        const match = textToScan.match(pattern);
-        if (match) {
-          return {
-            isWorking: true,
-            confidence: this.config.fallbackConfidence ?? 0.75,
-            matchTier: "fallback",
-            matchedText: match[0],
-          };
-        }
-      }
-    }
-
-    // No patterns matched
-    return {
-      isWorking: false,
-      confidence: 0,
-      matchTier: "none",
-    };
+    return this.matchPatterns(textToScan);
   }
 }
 

--- a/electron/services/pty/AgentPatternDetector.ts
+++ b/electron/services/pty/AgentPatternDetector.ts
@@ -197,6 +197,9 @@ export class AgentPatternDetector {
   private matchPatterns(textToScan: string): PatternDetectionResult {
     // Try primary patterns first (high confidence)
     for (const pattern of this.config.primaryPatterns) {
+      // Reset lastIndex so a stateful (/g, /y) pattern can't carry position
+      // across calls — restores the per-call semantics the old .match() had.
+      pattern.lastIndex = 0;
       if (pattern.test(textToScan)) {
         return {
           isWorking: true,
@@ -209,6 +212,7 @@ export class AgentPatternDetector {
     // Try fallback patterns (medium confidence)
     if (this.config.fallbackPatterns) {
       for (const pattern of this.config.fallbackPatterns) {
+        pattern.lastIndex = 0;
         if (pattern.test(textToScan)) {
           return {
             isWorking: true,

--- a/electron/services/pty/__tests__/AgentPatternDetector.test.ts
+++ b/electron/services/pty/__tests__/AgentPatternDetector.test.ts
@@ -618,4 +618,92 @@ wraps to the next line where the escape hint appears: esc to interrupt)`;
       expect(result.isWorking).toBe(true);
     });
   });
+
+  describe("alreadyStripped option", () => {
+    it("strips by default and yields the same result as pre-stripped input", () => {
+      const detector = buildTestDetector("codex");
+      const raw = "\x1b[34m•\x1b[0m Exploring the codebase (4s • esc to interrupt)";
+      const fromRaw = detector.detect(raw);
+      const fromStripped = detector.detect(stripAnsi(raw), { alreadyStripped: true });
+
+      expect(fromRaw.isWorking).toBe(true);
+      expect(fromRaw.matchTier).toBe("primary");
+      expect(fromStripped).toEqual(fromRaw);
+    });
+
+    it("skips the internal strip when alreadyStripped is true", () => {
+      const detector = buildTestDetector("claude");
+      // ANSI codes sit between the spinner and the verb, so the fallback
+      // pattern (spinner + whitespace + verb + ellipsis) only matches once
+      // stripped. With alreadyStripped:true the strip is skipped, so no match.
+      const raw = "✽\x1b[0m Thinking…";
+
+      expect(detector.detect(raw).isWorking).toBe(true);
+      expect(detector.detect(raw, { alreadyStripped: true }).isWorking).toBe(false);
+    });
+  });
+
+  describe("last-N-lines scan window", () => {
+    const detector = buildTestDetector("claude");
+    const pattern = "✽ Thinking…";
+
+    it("detects a pattern on the 10th line from the end", () => {
+      const noise = Array(9).fill("noise").join("\n");
+      const result = detector.detect(`${pattern}\n${noise}`);
+      expect(result.isWorking).toBe(true);
+    });
+
+    it("ignores a pattern on the 11th line from the end", () => {
+      const noise = Array(10).fill("noise").join("\n");
+      const result = detector.detect(`${pattern}\n${noise}`);
+      expect(result.isWorking).toBe(false);
+    });
+
+    it("detects a pattern on the final line with a trailing newline", () => {
+      const result = detector.detect(`${pattern}\n`);
+      expect(result.isWorking).toBe(true);
+    });
+
+    it("detects a pattern when there is no trailing newline", () => {
+      const result = detector.detect(`leading line\n${pattern}`);
+      expect(result.isWorking).toBe(true);
+    });
+
+    it("matches split/slice/join window semantics across boundary inputs", () => {
+      // Parity oracle: the old implementation joined the last scanLineCount
+      // lines. The new lastIndexOf scan must scan exactly the same text.
+      const scanLineCount = 10;
+      const oracleWindow = (text: string) => text.split("\n").slice(-scanLineCount).join("\n");
+
+      for (const lineCount of [1, 9, 10, 11, 25]) {
+        for (const trailing of ["", "\n"]) {
+          const lines = Array.from({ length: lineCount }, (_, i) =>
+            i === 0 ? pattern : `noise-${i}`
+          );
+          const text = lines.join("\n") + trailing;
+          const windowed = oracleWindow(text);
+          // Detection on the full text must equal detection on the oracle window.
+          expect(detector.detect(text).isWorking).toBe(detector.detect(windowed).isWorking);
+        }
+      }
+    });
+  });
+
+  describe("hot-path allocation guarantees", () => {
+    it("does not populate matchedText (debug field retired)", () => {
+      const detector = buildTestDetector("claude");
+      const result = detector.detect("✽ Deliberating… (esc to interrupt · 15s)");
+      expect(result.isWorking).toBe(true);
+      expect(result.matchedText).toBeUndefined();
+    });
+
+    it("returns identical results on repeated calls (no lastIndex mutation)", () => {
+      const detector = buildTestDetector("claude");
+      const output = "✽ Deliberating… (esc to interrupt · 15s)";
+      const first = detector.detect(output);
+      const second = detector.detect(output);
+      expect(first).toEqual(second);
+      expect(first.isWorking).toBe(true);
+    });
+  });
 });

--- a/electron/services/pty/__tests__/AgentPatternDetector.test.ts
+++ b/electron/services/pty/__tests__/AgentPatternDetector.test.ts
@@ -682,8 +682,24 @@ wraps to the next line where the escape hint appears: esc to interrupt)`;
           );
           const text = lines.join("\n") + trailing;
           const windowed = oracleWindow(text);
-          // Detection on the full text must equal detection on the oracle window.
-          expect(detector.detect(text).isWorking).toBe(detector.detect(windowed).isWorking);
+          // Detecting on the full text (new lastIndexOf window) must produce the
+          // exact same result as detecting on the oracle-windowed text (old
+          // split/slice/join). Full-object equality — not just isWorking — so a
+          // tier/confidence drift can't hide behind a matching boolean.
+          expect(detector.detect(text)).toEqual(detector.detect(windowed));
+        }
+      }
+    });
+  });
+
+  describe("pattern flag invariants", () => {
+    it("no configured pattern uses a stateful (/g, /y) flag", () => {
+      const configs = [...Object.values(AGENT_PATTERN_CONFIGS), UNIVERSAL_PATTERN_CONFIG];
+      for (const config of configs) {
+        const patterns = [...config.primaryPatterns, ...(config.fallbackPatterns ?? [])];
+        for (const pattern of patterns) {
+          expect(pattern.flags).not.toContain("g");
+          expect(pattern.flags).not.toContain("y");
         }
       }
     });
@@ -704,6 +720,19 @@ wraps to the next line where the escape hint appears: esc to interrupt)`;
       const second = detector.detect(output);
       expect(first).toEqual(second);
       expect(first.isWorking).toBe(true);
+    });
+
+    it("stays deterministic even with a stateful (/g) custom pattern", () => {
+      // Guards the lastIndex reset in matchPatterns: a /g pattern would
+      // otherwise advance lastIndex and miss on alternating calls.
+      const detector = createPatternDetector(undefined, {
+        primaryPatterns: [/working/g],
+        scanLineCount: 10,
+        primaryConfidence: 0.9,
+      });
+      expect(detector.detect("working").isWorking).toBe(true);
+      expect(detector.detect("working").isWorking).toBe(true);
+      expect(detector.detect("working").isWorking).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Four allocation reductions on the per-chunk agent-state detection hot path in `AgentPatternDetector.ts` and `ActivityMonitor.ts`. No behavior changes — detection logic, the 10-line scan window, and all patterns are untouched.

Resolves #9581

## Changes

- `detect()` now accepts an `alreadyStripped` flag. The polling call site already passes `stripAnsi`'d text, so it can skip the redundant whole-buffer strip. The non-polling call site (raw `PatternBuffer` text) still strips internally.
- Replaced `split('\n').slice(-10).join('\n')` with a backward `lastIndexOf` scan that yields a single slice offset — no per-line array, no intermediate segment strings.
- Switched pattern loops from `String.match()` to `RegExp.test()` (no match-array allocation). The `matchedText` return field had zero consumers so it's no longer populated. Loops are extracted into a shared `matchPatterns()` helper; `lastIndex` is reset per call so a stateful `/g` or `/y` config can't carry position between invocations.
- `ActivityMonitor.isEscInterruptFallback()` now takes pre-lowercased input. Both call sites already lowercase, so the internal `toLowerCase()` was redundant.

## Testing

All 84 `AgentPatternDetector` tests pass. All 280 tests across `ActivityMonitor`, `AgentStateDetection`, `terminalActivityPatterns`, and `AgentStateService` suites pass.

New coverage added:
- `alreadyStripped` raw-vs-prestripped parity + skip-strip proof
- Last-N-lines window boundary + full `split`/`slice`/`join` parity oracle
- `matchedText` omission
- `detect()` idempotency
- `/g` flag `lastIndex`-reset determinism
- Registry invariant (no pattern uses `/g` or `/y`)

`npm run check`: all 10 checks green, lint ratchet -1.