### PR TITLE
perf(renderer): visibility-gate stray ungated timers

### DIFF
--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -251,24 +251,53 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
     const timeouts: ReturnType<typeof setTimeout>[] = [];
     const intervals: ReturnType<typeof setInterval>[] = [];
 
-    if (isSessionMuted) {
-      const delay = Math.max(0, quietUntil - Date.now());
-      timeouts.push(setTimeout(tick, delay + 50));
-    }
+    const clearAll = () => {
+      for (const t of timeouts) clearTimeout(t);
+      for (const i of intervals) clearInterval(i);
+      timeouts.length = 0;
+      intervals.length = 0;
+    };
 
-    if (quietHoursEnabled) {
-      const msToNextMinute = 60_000 - (Date.now() % 60_000);
-      timeouts.push(
-        setTimeout(() => {
-          tick();
-          intervals.push(setInterval(tick, 60_000));
-        }, msToNextMinute + 50)
-      );
+    // Visibility may flip between scheduling and firing; bail out if hidden.
+    const tickIfVisible = () => {
+      if (document.hidden) return;
+      tick();
+    };
+
+    const schedule = () => {
+      if (isSessionMuted) {
+        const delay = Math.max(0, quietUntil - Date.now());
+        timeouts.push(setTimeout(tickIfVisible, delay + 50));
+      }
+
+      if (quietHoursEnabled) {
+        const msToNextMinute = 60_000 - (Date.now() % 60_000);
+        timeouts.push(
+          setTimeout(() => {
+            if (document.hidden) return;
+            tick();
+            intervals.push(setInterval(tickIfVisible, 60_000));
+          }, msToNextMinute + 50)
+        );
+      }
+    };
+
+    const handleVisibility = () => {
+      clearAll();
+      if (!document.hidden) {
+        tick();
+        schedule();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibility);
+    if (!document.hidden) {
+      schedule();
     }
 
     return () => {
-      for (const t of timeouts) clearTimeout(t);
-      for (const i of intervals) clearInterval(i);
+      document.removeEventListener("visibilitychange", handleVisibility);
+      clearAll();
     };
   }, [open, isSessionMuted, quietUntil, quietHoursEnabled]);
 

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -74,6 +74,7 @@ import { SidebarWorktreeRow } from "./SidebarWorktreeRow";
 import { WorktreeLoadErrorBanner } from "./WorktreeLoadErrorBanner";
 import { StaticWorktreeRow } from "./StaticWorktreeRow";
 import { WorktreeCardPlaceholder } from "./WorktreeCardPlaceholder";
+import { useVisibilityAwareInterval } from "@/hooks/useVisibilityAwareInterval";
 import { useScrollIndicator } from "./useScrollIndicator";
 import { useRecipeDialogState } from "./useRecipeDialogState";
 import { RecipeEditor } from "@/components/TerminalRecipe/RecipeEditor";
@@ -415,11 +416,11 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   // Effect re-runs on every new disconnect via `reconnectingAt` dep, so the
   // baseline is always fresh — no stale-closure risk.
   const [, setReconnectTick] = useState(0);
-  useEffect(() => {
-    if (!isReconnecting || reconnectingAt == null) return;
-    const id = setInterval(() => setReconnectTick((n) => n + 1), 1000);
-    return () => clearInterval(id);
-  }, [isReconnecting, reconnectingAt]);
+  useVisibilityAwareInterval(
+    () => setReconnectTick((n) => n + 1),
+    1000,
+    isReconnecting && reconnectingAt != null
+  );
   const showReconnectingEscalated =
     isReconnecting &&
     reconnectingAt !== null &&

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -413,8 +413,10 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   // 1Hz tick that drives the escalated "Reconnecting… last updated X ago"
   // copy. The store holds the start timestamp; this state forces a render so
   // `formatRelativeTime(reconnectingAt)` recomputes against the latest clock.
-  // Effect re-runs on every new disconnect via `reconnectingAt` dep, so the
-  // baseline is always fresh — no stale-closure risk.
+  // Visibility-gated so the tick pauses while the window is hidden (Chromium
+  // throttles hidden-tab intervals to ~1/min) and snaps back on restore. The
+  // callback reads no captured timestamp, so there's no stale-closure risk
+  // despite the hook only depending on [intervalMs, enabled].
   const [, setReconnectTick] = useState(0);
   useVisibilityAwareInterval(
     () => setReconnectTick((n) => n + 1),

--- a/src/components/Sidebar/__tests__/SidebarContent.reconnecting.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.reconnecting.test.ts
@@ -28,4 +28,16 @@ describe("SidebarContent reconnecting indicator — issue #8074", () => {
     expect(reconnectingSpan).not.toBeNull();
     expect(source).not.toMatch(/\{isReconnecting && \(\s*<span/);
   });
+
+  it("drives the reconnect tick via useVisibilityAwareInterval, not a bare setInterval — issue #9583", () => {
+    // Chromium intensively throttles hidden-tab setInterval to ~1/min after 10s,
+    // which corrupts the "last updated X ago" relative-time display. The tick
+    // must pause while hidden and snap back on restore via the visibility hook.
+    expect(source).toMatch(/import \{ useVisibilityAwareInterval \}/);
+    expect(source).toMatch(
+      /useVisibilityAwareInterval\(\s*\(\) => setReconnectTick\(\(n\) => n \+ 1\),\s*1000,\s*isReconnecting && reconnectingAt != null\s*\)/
+    );
+    // The old ungated reconnect interval must be gone.
+    expect(source).not.toMatch(/setInterval\(\(\) => setReconnectTick/);
+  });
 });

--- a/src/components/Terminal/TerminalInfoDialog.tsx
+++ b/src/components/Terminal/TerminalInfoDialog.tsx
@@ -10,6 +10,7 @@ import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { usePanelStore } from "@/store/panelStore";
 import { isPtyPanel } from "@shared/types/panel";
+import { useVisibilityAwareInterval } from "@/hooks/useVisibilityAwareInterval";
 
 const SYNC_MODE_POLL_MS = 250;
 
@@ -182,18 +183,21 @@ export function TerminalInfoDialog({ isOpen, onClose, terminalId }: TerminalInfo
 
   useEffect(() => {
     if (!isOpen) return;
-    // xterm 6 mutates terminal.modes asynchronously as the parser consumes
-    // BSU/ESU sequences, and there is no change event. Poll at the same
-    // cadence as REFLOW_THROTTLE_MS (250ms) — enough resolution to catch
-    // most BSU blocks while the dialog is open.
+    // Immediate read on open so the dialog reflects the current sync-mode
+    // before the first poll lands.
     setSyncMode(terminalInstanceService.getSynchronizedOutputMode(terminalId));
-    const intervalId = window.setInterval(() => {
-      setSyncMode(terminalInstanceService.getSynchronizedOutputMode(terminalId));
-    }, SYNC_MODE_POLL_MS);
-    return () => {
-      window.clearInterval(intervalId);
-    };
   }, [isOpen, terminalId]);
+
+  // xterm 6 mutates terminal.modes asynchronously as the parser consumes
+  // BSU/ESU sequences, and there is no change event. Poll at the same cadence
+  // as REFLOW_THROTTLE_MS (250ms) — enough resolution to catch most BSU blocks
+  // while the dialog is open. Visibility-gated so the poll pauses while the
+  // window is hidden and snaps back on restore.
+  useVisibilityAwareInterval(
+    () => setSyncMode(terminalInstanceService.getSynchronizedOutputMode(terminalId)),
+    SYNC_MODE_POLL_MS,
+    isOpen
+  );
 
   const launchAgentId = panel?.launchAgentId ?? info?.launchAgentId;
   const command = panel?.command ?? info?.command;


### PR DESCRIPTION
## Summary

- Three renderer `setInterval` sites weren't routed through `useVisibilityAwareInterval`, so they kept ticking at reduced fidelity while the tab was hidden. Chromium 146 throttles hidden-tab intervals to roughly once per minute after ~10s hidden, which left relative-time displays stale and polled state out of date on restore.
- All three now pause on `document.hidden` and snap-tick when visibility returns, matching the pattern already used elsewhere in the renderer.

Resolves #9583

## Changes

- **`SidebarContent.tsx`** — "Reconnecting… last updated X ago" 1Hz tick routed through `useVisibilityAwareInterval(cb, 1000, isReconnecting && reconnectingAt != null)`.
- **`TerminalInfoDialog.tsx`** — 250ms sync-mode poll gated; one-shot read-on-open kept in its own separate effect so it still fires immediately on mount.
- **`NotificationCenter.tsx`** — quiet-hours minute tick rewritten to match the existing visibility pattern in `NotificationCenterToolbarButton` (snap-tick on restore, session-mute one-shot gated by `open`).
- **`SidebarContent.reconnecting.test.ts`** — source-pattern assertions confirming the hook is used and the bare `setInterval` reconnect path is gone.

## Testing

Targeted vitest (3 tests) pass. `npm run check` passes — typecheck clean, lint ratchet down 2 warnings, format clean, IPC integrity OK.