### PR TITLE
test(plugins): add E2E coverage for settings, permissions, and install-URL

### DIFF
--- a/e2e/full/plugins/core-plugin-install-url.spec.ts
+++ b/e2e/full/plugins/core-plugin-install-url.spec.ts
@@ -37,19 +37,20 @@ test.describe.serial("Core: Plugin install-from-URL dialog", () => {
 
     await window.locator(SEL.plugin.installFromUrlButton).click();
 
+    const urlDialog = window.locator(SEL.plugin.urlDialog);
     const urlInput = window.locator(SEL.plugin.urlInput);
     await expect(urlInput).toBeVisible({ timeout: T_MEDIUM });
 
-    // Empty URL → Install disabled (footer button, matched exactly so it doesn't
-    // collide with the "Install from file"/"Install from URL" trigger buttons).
-    const installButton = window.getByRole("button", { name: "Install", exact: true });
+    // Empty URL → Install disabled. Scope to the dialog so the footer button
+    // doesn't collide with the "Install from file"/"Install from URL" triggers.
+    const installButton = urlDialog.getByRole("button", { name: "Install", exact: true });
     await expect(installButton).toBeDisabled();
 
     await urlInput.fill("https://example.com/plugin.dntr");
     await expect(installButton).toBeEnabled();
 
     // Close without installing.
-    await window.getByRole("button", { name: "Cancel" }).click();
+    await urlDialog.getByRole("button", { name: "Cancel" }).click();
     await expect(urlInput).toBeHidden({ timeout: T_SHORT });
 
     await closePluginManager(window);
@@ -61,11 +62,12 @@ test.describe.serial("Core: Plugin install-from-URL dialog", () => {
 
     await window.locator(SEL.plugin.installFromUrlButton).click();
 
+    const urlDialog = window.locator(SEL.plugin.urlDialog);
     const urlInput = window.locator(SEL.plugin.urlInput);
     await expect(urlInput).toBeVisible({ timeout: T_MEDIUM });
     await urlInput.fill("http://example.com/plugin.dntr");
 
-    await window.getByRole("button", { name: "Install", exact: true }).click();
+    await urlDialog.getByRole("button", { name: "Install", exact: true }).click();
 
     // The non-HTTPS URL surfaces the "Install over HTTP?" confirm before any
     // download starts.
@@ -78,7 +80,7 @@ test.describe.serial("Core: Plugin install-from-URL dialog", () => {
 
     // The URL dialog stays open behind the dismissed gate — close it before the
     // manager so its focus trap doesn't swallow the manager-close click.
-    const urlDialogCancel = window.getByRole("button", { name: "Cancel" });
+    const urlDialogCancel = urlDialog.getByRole("button", { name: "Cancel" });
     if (await urlDialogCancel.isVisible().catch(() => false)) {
       await urlDialogCancel.click();
       await expect(urlInput).toBeHidden({ timeout: T_SHORT });

--- a/e2e/full/plugins/core-plugin-install-url.spec.ts
+++ b/e2e/full/plugins/core-plugin-install-url.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from "@playwright/test";
+import { closeApp, type AppContext } from "../../helpers/launch";
+import { SEL } from "../../helpers/selectors";
+import { T_SHORT, T_MEDIUM } from "../../helpers/timeouts";
+import {
+  launchWithSamplePlugin,
+  openPluginManager,
+  closePluginManager,
+} from "../../helpers/plugins";
+
+/**
+ * Install-from-URL dialog coverage (#9592). The actual download runs in the main
+ * process (`window.electron.plugin.installFromUrl`), so `page.route()` can't
+ * intercept it — this spec deliberately covers the renderer-side dialog flow
+ * only: open the dialog, the URL-gated enablement of the Install button, and the
+ * HTTPS-vs-HTTP confirm gate. No real install is performed (the HTTP path is
+ * always cancelled, and an HTTPS submit is never confirmed).
+ */
+test.describe.serial("Core: Plugin install-from-URL dialog", () => {
+  let ctx: AppContext;
+  let fixtureCleanup: (() => void) | undefined;
+
+  test.beforeAll(async () => {
+    const { ctx: launched, cleanup } = await launchWithSamplePlugin("plugin-install-url");
+    ctx = launched;
+    fixtureCleanup = cleanup;
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
+  });
+
+  test("opens the dialog and gates the Install button on a non-empty URL", async () => {
+    const { window } = ctx;
+    await openPluginManager(window);
+
+    await window.locator(SEL.plugin.installFromUrlButton).click();
+
+    const urlInput = window.locator(SEL.plugin.urlInput);
+    await expect(urlInput).toBeVisible({ timeout: T_MEDIUM });
+
+    // Empty URL → Install disabled (footer button, matched exactly so it doesn't
+    // collide with the "Install from file"/"Install from URL" trigger buttons).
+    const installButton = window.getByRole("button", { name: "Install", exact: true });
+    await expect(installButton).toBeDisabled();
+
+    await urlInput.fill("https://example.com/plugin.dntr");
+    await expect(installButton).toBeEnabled();
+
+    // Close without installing.
+    await window.getByRole("button", { name: "Cancel" }).click();
+    await expect(urlInput).toBeHidden({ timeout: T_SHORT });
+
+    await closePluginManager(window);
+  });
+
+  test("an http:// URL routes through the HTTP confirm gate, which can be cancelled", async () => {
+    const { window } = ctx;
+    await openPluginManager(window);
+
+    await window.locator(SEL.plugin.installFromUrlButton).click();
+
+    const urlInput = window.locator(SEL.plugin.urlInput);
+    await expect(urlInput).toBeVisible({ timeout: T_MEDIUM });
+    await urlInput.fill("http://example.com/plugin.dntr");
+
+    await window.getByRole("button", { name: "Install", exact: true }).click();
+
+    // The non-HTTPS URL surfaces the "Install over HTTP?" confirm before any
+    // download starts.
+    const httpDialog = window.locator(SEL.plugin.httpWarningDialog);
+    await expect(httpDialog).toBeVisible({ timeout: T_MEDIUM });
+
+    // Cancel the gate — no install happens.
+    await httpDialog.getByRole("button", { name: "Cancel" }).click();
+    await expect(httpDialog).toBeHidden({ timeout: T_SHORT });
+
+    // The URL dialog stays open behind the dismissed gate — close it before the
+    // manager so its focus trap doesn't swallow the manager-close click.
+    const urlDialogCancel = window.getByRole("button", { name: "Cancel" });
+    if (await urlDialogCancel.isVisible().catch(() => false)) {
+      await urlDialogCancel.click();
+      await expect(urlInput).toBeHidden({ timeout: T_SHORT });
+    }
+
+    await closePluginManager(window);
+  });
+});

--- a/e2e/full/plugins/core-plugin-permissions.spec.ts
+++ b/e2e/full/plugins/core-plugin-permissions.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from "@playwright/test";
+import { closeApp, type AppContext } from "../../helpers/launch";
+import { SEL } from "../../helpers/selectors";
+import { T_SHORT, T_MEDIUM } from "../../helpers/timeouts";
+import {
+  launchWithSamplePlugin,
+  openPluginManager,
+  closePluginManager,
+  waitForRichPluginReady,
+  RICH_PLUGIN_LABEL,
+  SAMPLE_PLUGIN_LABEL,
+} from "../../helpers/plugins";
+
+/**
+ * Plugin Permissions tab coverage (#9592). The existing manager spec only
+ * asserts the empty case ("No special permissions") against `hello-daintree`.
+ * This drives the populated case against `rich-daintree`, which declares
+ * `fs:project-read` (neutral), `fs:project-write` (warning + elevates the whole
+ * plugin to `pluginDanger: "confirm"`), and a scoped `network:fetch`.
+ *
+ * Asserts the danger summary banner, the per-capability rows with their
+ * severity-driven labels, and the scoped network URL — then re-checks the
+ * `hello-daintree` empty case so the two plugins coexisting under "Built-in"
+ * doesn't regress the original assertion.
+ */
+test.describe.serial("Core: Plugin permissions tab", () => {
+  let ctx: AppContext;
+  let fixtureCleanup: (() => void) | undefined;
+
+  test.beforeAll(async () => {
+    const { ctx: launched, cleanup } = await launchWithSamplePlugin("plugin-permissions");
+    ctx = launched;
+    fixtureCleanup = cleanup;
+    await waitForRichPluginReady(ctx.window);
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
+  });
+
+  test("shows the danger summary and capability rows for a capability-rich plugin", async () => {
+    const { window } = ctx;
+    await openPluginManager(window);
+
+    await window.locator(SEL.plugin.option).filter({ hasText: RICH_PLUGIN_LABEL }).first().click();
+
+    await window.locator(SEL.plugin.tabPermissions).click();
+    await expect(window.locator(SEL.plugin.tabPermissions)).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
+
+    // fs:project-write elevates the whole plugin to "confirm", so the warning
+    // summary banner renders above the capability list.
+    await expect(
+      window.getByText("Requests sensitive permissions — review before enabling")
+    ).toBeVisible({ timeout: T_MEDIUM });
+
+    // Warning-severity capability (write) and neutral-severity capability (read).
+    await expect(window.getByText("Write project files")).toBeVisible();
+    await expect(window.getByText("Read project files")).toBeVisible();
+
+    // network:fetch row plus its scoped allow-list URL rendered inline.
+    await expect(window.getByText("Make network requests")).toBeVisible();
+    await expect(window.getByText("https://api.example.com")).toBeVisible();
+
+    await closePluginManager(window);
+  });
+
+  test("still reads 'No special permissions' for the capability-free sample", async () => {
+    const { window } = ctx;
+    await openPluginManager(window);
+
+    await window
+      .locator(SEL.plugin.option)
+      .filter({ hasText: SAMPLE_PLUGIN_LABEL })
+      .first()
+      .click();
+
+    await window.locator(SEL.plugin.tabPermissions).click();
+    await expect(window.getByText("No special permissions")).toBeVisible({ timeout: T_SHORT });
+
+    // The danger banner must NOT appear for a plugin with no capabilities.
+    await expect(
+      window.getByText("Requests sensitive permissions — review before enabling")
+    ).toHaveCount(0);
+
+    await closePluginManager(window);
+  });
+});

--- a/e2e/full/plugins/core-plugin-settings.spec.ts
+++ b/e2e/full/plugins/core-plugin-settings.spec.ts
@@ -1,0 +1,219 @@
+import { test, expect, type Page } from "@playwright/test";
+import { closeApp, type AppContext } from "../../helpers/launch";
+import { SEL } from "../../helpers/selectors";
+import { T_MEDIUM } from "../../helpers/timeouts";
+import {
+  launchWithSamplePlugin,
+  openPluginManager,
+  closePluginManager,
+  waitForRichPluginReady,
+  RICH_PLUGIN_LABEL,
+} from "../../helpers/plugins";
+
+const PLUGIN_ID = "daintree.rich";
+
+/** Read the rich plugin's stored user-scope setting values over IPC. */
+async function userValues(page: Page): Promise<Record<string, unknown>> {
+  return page.evaluate(async (pluginId) => {
+    const res = await window.electron.plugin.getSettingValues(pluginId, "user", null);
+    return res.values;
+  }, PLUGIN_ID);
+}
+
+/** Read the rich plugin's stored user-scope secret key ids over IPC. */
+async function userSecretsSet(page: Page): Promise<string[]> {
+  return page.evaluate(async (pluginId) => {
+    const res = await window.electron.plugin.getSettingValues(pluginId, "user", null);
+    return res.secretsSet;
+  }, PLUGIN_ID);
+}
+
+/** Open the manager, select the rich plugin, and switch to its Settings tab. */
+async function openRichSettings(page: Page): Promise<void> {
+  await openPluginManager(page);
+  await page.locator(SEL.plugin.option).filter({ hasText: RICH_PLUGIN_LABEL }).first().click();
+  await page.locator(SEL.plugin.tabSettings).click();
+  await expect(page.locator(SEL.plugin.tabSettings)).toHaveAttribute("aria-selected", "true");
+}
+
+/**
+ * Plugin Settings form coverage (#9592). `hello-daintree` declares no
+ * `contributes.settings`, so the generated form has no E2E coverage. This drives
+ * the form against `rich-daintree`, which declares one field of every supported
+ * type, and asserts the fill → blur-commit → persisted round-trip for each
+ * (verified over IPC), plus number/JSON validation, secret reveal, reset, and a
+ * project-scoped field.
+ *
+ * The form disables controls until `getSettingValues` resolves and commits text
+ * fields on blur, so every interaction gates on `toBeEnabled()` and then blurs
+ * (Tab / click elsewhere) before asserting persistence.
+ */
+test.describe.serial("Core: Plugin settings form", () => {
+  let ctx: AppContext;
+  let fixtureCleanup: (() => void) | undefined;
+
+  test.beforeAll(async () => {
+    const { ctx: launched, cleanup } = await launchWithSamplePlugin("plugin-settings");
+    ctx = launched;
+    fixtureCleanup = cleanup;
+    await waitForRichPluginReady(ctx.window);
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
+  });
+
+  test("persists a string field on blur", async () => {
+    const { window } = ctx;
+    await openRichSettings(window);
+
+    const input = window.getByLabel("Greeting", { exact: true });
+    await expect(input).toBeEnabled({ timeout: T_MEDIUM });
+    await input.fill("howdy");
+    await window.keyboard.press("Tab");
+
+    await expect.poll(() => userValues(window)).toMatchObject({ greeting: "howdy" });
+
+    await closePluginManager(window);
+  });
+
+  test("persists a valid number and rejects an out-of-range one", async () => {
+    const { window } = ctx;
+    await openRichSettings(window);
+
+    const input = window.getByLabel("Retries", { exact: true });
+    await expect(input).toBeEnabled({ timeout: T_MEDIUM });
+    await input.fill("7");
+    await window.keyboard.press("Tab");
+    await expect.poll(() => userValues(window)).toMatchObject({ retries: 7 });
+
+    // Above max (10) → inline error, stored value unchanged.
+    await input.fill("99");
+    await window.keyboard.press("Tab");
+    await expect(window.getByText("Must be at most 10")).toBeVisible();
+    await expect.poll(() => userValues(window)).toMatchObject({ retries: 7 });
+
+    await closePluginManager(window);
+  });
+
+  test("toggles a boolean field", async () => {
+    const { window } = ctx;
+    await openRichSettings(window);
+
+    const toggle = window.getByRole("switch", { name: "Verbose mode" });
+    await expect(toggle).toBeEnabled({ timeout: T_MEDIUM });
+    await expect(toggle).toHaveAttribute("aria-checked", "false");
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-checked", "true");
+
+    await expect.poll(() => userValues(window)).toMatchObject({ verbose: true });
+
+    await closePluginManager(window);
+  });
+
+  test("persists an enum selection", async () => {
+    const { window } = ctx;
+    await openRichSettings(window);
+
+    const select = window.getByLabel("Log level", { exact: true });
+    await expect(select).toBeEnabled({ timeout: T_MEDIUM });
+    await select.selectOption("warn");
+
+    await expect.poll(() => userValues(window)).toMatchObject({ level: "warn" });
+
+    await closePluginManager(window);
+  });
+
+  test("persists valid JSON and rejects malformed JSON", async () => {
+    const { window } = ctx;
+    await openRichSettings(window);
+
+    const textarea = window.getByLabel("Extra config", { exact: true });
+    await expect(textarea).toBeEnabled({ timeout: T_MEDIUM });
+    await textarea.fill('{"key":"val"}');
+    await window.keyboard.press("Tab");
+    await expect.poll(() => userValues(window)).toMatchObject({ config: { key: "val" } });
+
+    // Malformed JSON → inline error, stored value unchanged.
+    await textarea.fill("{bad");
+    await window.keyboard.press("Tab");
+    await expect(window.getByText("Enter valid JSON")).toBeVisible();
+    await expect.poll(() => userValues(window)).toMatchObject({ config: { key: "val" } });
+
+    await closePluginManager(window);
+  });
+
+  test("stores a secret and reveals it on demand", async () => {
+    const { window } = ctx;
+    await openRichSettings(window);
+
+    const input = window.getByLabel("API key", { exact: true });
+    await expect(input).toBeEnabled({ timeout: T_MEDIUM });
+    await expect(input).toHaveAttribute("type", "password");
+    await input.fill("s3cr3t");
+    await window.keyboard.press("Tab");
+
+    // The secret is reported as set (its value never rides on getSettingValues).
+    await expect.poll(() => userSecretsSet(window)).toContain("apiKey");
+
+    // Revealing flips the input to plaintext and surfaces the stored value.
+    const reveal = window.getByRole("button", { name: "Reveal API key" });
+    await expect(reveal).toBeVisible({ timeout: T_MEDIUM });
+    await reveal.click();
+    await expect(input).toHaveAttribute("type", "text");
+    await expect(input).toHaveValue("s3cr3t");
+
+    await closePluginManager(window);
+  });
+
+  test("resets a field back to its default", async () => {
+    const { window } = ctx;
+    await openRichSettings(window);
+
+    // Give greeting a stored override.
+    const input = window.getByLabel("Greeting", { exact: true });
+    await expect(input).toBeEnabled({ timeout: T_MEDIUM });
+    await input.fill("temporary");
+    await window.keyboard.press("Tab");
+    await expect.poll(() => userValues(window)).toMatchObject({ greeting: "temporary" });
+
+    // The reset affordance only appears once a value is stored, and the form
+    // reads `storedValue` at mount — so remount the tab to pick up the override.
+    await window.locator(SEL.plugin.tabOverview).click();
+    await window.locator(SEL.plugin.tabSettings).click();
+
+    const reset = window.getByRole("button", { name: "Reset Greeting to default" });
+    await expect(reset).toBeVisible({ timeout: T_MEDIUM });
+    await reset.click();
+
+    // Reset drops the stored override (the field falls back to the manifest default).
+    await expect
+      .poll(async () => Object.prototype.hasOwnProperty.call(await userValues(window), "greeting"))
+      .toBe(false);
+
+    await closePluginManager(window);
+  });
+
+  test("persists a project-scoped field, verified by reload", async () => {
+    const { window } = ctx;
+    await openRichSettings(window);
+
+    const input = window.getByLabel("Project note", { exact: true });
+    await expect(input).toBeEnabled({ timeout: T_MEDIUM });
+    await input.fill("scoped-note");
+    await window.keyboard.press("Tab");
+
+    // Project-scoped values are keyed by the active project id (not exposed to
+    // the test), so verify persistence the way the form itself does: remount the
+    // tab and confirm the stored value re-hydrates the control.
+    await window.locator(SEL.plugin.tabOverview).click();
+    await window.locator(SEL.plugin.tabSettings).click();
+
+    const reloaded = window.getByLabel("Project note", { exact: true });
+    await expect(reloaded).toBeEnabled({ timeout: T_MEDIUM });
+    await expect(reloaded).toHaveValue("scoped-note");
+
+    await closePluginManager(window);
+  });
+});

--- a/e2e/helpers/plugins.ts
+++ b/e2e/helpers/plugins.ts
@@ -21,6 +21,13 @@ export const SAMPLE_PLUGINS_DIR = path.join(ROOT, "dist-electron/plugins/sample"
 /** Display label the sample plugin's manifest resolves to. */
 export const SAMPLE_PLUGIN_LABEL = "Hello Daintree";
 
+/**
+ * Display label for the capability- and settings-rich sample (#9592). Loaded
+ * from the same sideload dir as `hello-daintree`, so both appear under the
+ * manager's "Built-in" group in the same session.
+ */
+export const RICH_PLUGIN_LABEL = "Rich Daintree";
+
 const PLUGIN_READY_TIMEOUT = process.env.CI ? 60_000 : T_LONG;
 
 async function getPluginActionIds(page: Page): Promise<string[]> {
@@ -47,6 +54,18 @@ export async function waitForSamplePluginReady(page: Page): Promise<void> {
   await expect
     .poll(() => getPluginActionIds(page), { timeout: PLUGIN_READY_TIMEOUT })
     .toContain("daintree.hello.greet");
+}
+
+/**
+ * Poll until the rich sample plugin has activated and registered its sentinel
+ * `ready` action. The rich plugin sideloads alongside `hello-daintree`, but its
+ * activation is independent — specs that assert against its capabilities or
+ * settings must gate on this rather than `waitForSamplePluginReady`.
+ */
+export async function waitForRichPluginReady(page: Page): Promise<void> {
+  await expect
+    .poll(() => getPluginActionIds(page), { timeout: PLUGIN_READY_TIMEOUT })
+    .toContain("daintree.rich.ready");
 }
 
 /**

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -389,6 +389,8 @@ export const SEL = {
     tabOverview: '[role="tab"][data-tab="overview"]',
     tabSettings: '[role="tab"][data-tab="settings"]',
     tabPermissions: '[role="tab"][data-tab="capabilities"]',
+    installFromUrlButton: 'button:has-text("Install from URL")',
+    httpWarningDialog: '[role="dialog"]:has-text("Install over HTTP?")',
   },
   fleet: {
     ribbon: '[data-testid="fleet-arming-ribbon"]',

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -390,6 +390,7 @@ export const SEL = {
     tabSettings: '[role="tab"][data-tab="settings"]',
     tabPermissions: '[role="tab"][data-tab="capabilities"]',
     installFromUrlButton: 'button:has-text("Install from URL")',
+    urlDialog: '[role="dialog"]:has-text("Install from URL")',
     httpWarningDialog: '[role="dialog"]:has-text("Install over HTTP?")',
   },
   fleet: {

--- a/plugins/sample/rich-daintree/main/index.ts
+++ b/plugins/sample/rich-daintree/main/index.ts
@@ -1,0 +1,32 @@
+import type { PluginHostApi } from "../../../../shared/types/plugin.js";
+
+/**
+ * Rich Daintree — the capability- and settings-rich E2E fixture (#9592). Where
+ * `hello-daintree` is the minimal host-contract consumer, this one exists purely
+ * so the `full-plugins` bucket has a plugin whose manifest declares sensitive
+ * capabilities (`fs:project-write` elevates `pluginDanger` to `"confirm"`) and a
+ * `contributes.settings` field of every type — exercising the Permissions tab,
+ * the danger summary banner, and the generated settings form.
+ *
+ * Activation deliberately does nothing but register a sentinel action. It must
+ * NOT pre-write any setting: the settings specs assert default-vs-stored
+ * behaviour and a startup write would mask an unset field's default.
+ */
+export async function activate(host: PluginHostApi): Promise<() => void> {
+  // Sentinel the E2E harness polls for: the host namespaces this to
+  // `daintree.rich.ready`, so `waitForRichPluginReady` knows activation ran.
+  // The host unregisters plugin actions automatically on unload.
+  host.registerAction(
+    {
+      id: "ready",
+      title: "Rich: Ready",
+      description: "Sentinel action — fires once the rich sample plugin has activated.",
+      category: "Rich Daintree",
+      kind: "command",
+      danger: "safe",
+    },
+    () => ({ ready: true })
+  );
+
+  return () => {};
+}

--- a/plugins/sample/rich-daintree/plugin.json
+++ b/plugins/sample/rich-daintree/plugin.json
@@ -1,0 +1,67 @@
+{
+  "name": "daintree.rich",
+  "version": "0.1.0",
+  "displayName": "Rich Daintree",
+  "description": "Capability- and settings-rich sample plugin (#9592). Sideloaded alongside hello-daintree so the full-plugins E2E bucket can exercise the Permissions tab, the generated settings form, and the danger summary — surfaces hello-daintree's empty manifest leaves uncovered.",
+  "main": "main/index.js",
+  "engines": {
+    "daintree": ">=0.11.0"
+  },
+  "capabilities": ["fs:project-read", "fs:project-write", "network:fetch"],
+  "scopes": {
+    "network": {
+      "allowedUrls": ["https://api.example.com"]
+    }
+  },
+  "contributes": {
+    "settings": [
+      {
+        "id": "greeting",
+        "type": "string",
+        "label": "Greeting",
+        "description": "Text the plugin greets you with.",
+        "default": "hello"
+      },
+      {
+        "id": "retries",
+        "type": "number",
+        "label": "Retries",
+        "description": "How many times to retry.",
+        "default": 3,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "id": "verbose",
+        "type": "boolean",
+        "label": "Verbose mode",
+        "description": "Emit extra logging.",
+        "default": false
+      },
+      {
+        "id": "level",
+        "type": "enum",
+        "label": "Log level",
+        "options": ["debug", "info", "warn", "error"],
+        "default": "info"
+      },
+      {
+        "id": "config",
+        "type": "json",
+        "label": "Extra config",
+        "default": {}
+      },
+      {
+        "id": "apiKey",
+        "type": "secret",
+        "label": "API key"
+      },
+      {
+        "id": "projectNote",
+        "type": "string",
+        "label": "Project note",
+        "scope": "project"
+      }
+    ]
+  }
+}

--- a/scripts/build-main.mjs
+++ b/scripts/build-main.mjs
@@ -192,6 +192,9 @@ async function run() {
       // Sideloaded via `DAINTREE_E2E_SIDELOAD_PLUGIN_DIR`; absent in prod
       // because no `pluginsRoot` defaults to this directory.
       "plugins/sample/hello-daintree/main/index.ts",
+      // Capability- and settings-rich sample for the full-plugins E2E bucket
+      // (#9592). Sideloaded from the same dir as hello-daintree.
+      "plugins/sample/rich-daintree/main/index.ts",
     ],
     outdir: "dist-electron",
     outbase: ".",


### PR DESCRIPTION
## Summary

- The `full-plugins` bucket only exercised `hello-daintree` (no capabilities, no settings), so the Permissions tab populated state, the settings form field types, the danger summary banner, and the install-from-URL flow had no coverage.
- Added a second sample fixture plugin (`rich-daintree`) that declares `fs:project-read`/`fs:project-write` and scoped `network:fetch`, and contributes one setting of every field type (`string`/`number`/`boolean`/`enum`/`json`/`secret` plus a project-scoped string). Three new specs cover the gap.

Resolves #9592

## Changes

- `plugins/sample/rich-daintree/` — new fixture plugin; `plugin.json` declares capabilities and `contributes.settings`; activation registers a sentinel action only.
- `scripts/build-main.mjs` — adds `rich-daintree` to the esbuild entry list; manifest is auto-copied alongside `hello-daintree` via the existing sideload path.
- `e2e/helpers/plugins.ts` — `RICH_PLUGIN_LABEL` + `waitForRichPluginReady`; `e2e/helpers/selectors.ts` — install-URL/url-dialog selectors appended.
- `e2e/full/plugins/core-plugin-settings.spec.ts` — per-type fill→blur→persist round-trip verified over IPC, number/JSON validation, secret store+reveal, reset, project scope.
- `e2e/full/plugins/core-plugin-permissions.spec.ts` — danger banner + capability rows + scoped URL; no-regression check that `hello-daintree` still reads "No special permissions".
- `e2e/full/plugins/core-plugin-install-url.spec.ts` — URL-gated Install button + HTTP confirm gate (UI-only; the download is main-process IPC).

`hello-daintree` manifest is untouched. No new Playwright project. No new npm deps.

## Testing

`npm run build` and `npm run check` (typecheck + lint + format) pass. E2E not run locally — Electron binary not installable in the sandbox. The `full-plugins` CI bucket will execute all three new specs.