### PR TITLE
test(presets): add E2E coverage for recipe and onboarding flows

### DIFF
--- a/e2e/full/presets/recipe-e2e-coverage.spec.ts
+++ b/e2e/full/presets/recipe-e2e-coverage.spec.ts
@@ -124,9 +124,12 @@ test.describe.serial("Recipe & onboarding coverage (#9597)", () => {
       await closeAppDialog(window);
     });
 
-    test("import from clipboard adds a project recipe", async () => {
+    test("import from clipboard adds a recipe under team scope", async () => {
       const { window } = ctx;
       const manager = await openRecipeManager(window);
+      // The plain fixture has no in-repo recipes yet, so the Team section is
+      // absent until the project-scoped import writes one to .daintree/recipes/.
+      await expect(manager.locator(SEL.recipeManager.teamSection)).toHaveCount(0);
 
       await manager.locator(SEL.recipeManager.importButton).first().click({ force: true });
       const importDialog = window.locator(SEL.recipeManager.importDialog);
@@ -140,10 +143,12 @@ test.describe.serial("Recipe & onboarding coverage (#9597)", () => {
       await importDialog.locator(SEL.recipeManager.importConfirmButton).click();
       await expect(importDialog).not.toBeVisible({ timeout: T_MEDIUM });
 
-      // The recipe row appears in the still-open manager once the store settles.
-      await expect(manager.locator(SEL.recipeManager.exportButton("Imported Recipe"))).toBeAttached(
-        { timeout: T_LONG }
-      );
+      // A project-scoped import persists to the repo (scope: "inrepo"), so the
+      // Team Recipes section appears with the imported recipe.
+      await expect(manager.locator(SEL.recipeManager.teamSection)).toBeVisible({ timeout: T_LONG });
+      await expect(manager.getByText("Imported Recipe", { exact: true })).toBeVisible({
+        timeout: T_SHORT,
+      });
 
       await closeAppDialog(window);
     });

--- a/e2e/full/presets/recipe-e2e-coverage.spec.ts
+++ b/e2e/full/presets/recipe-e2e-coverage.spec.ts
@@ -1,0 +1,383 @@
+import { test, expect, type Locator, type Page } from "@playwright/test";
+import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
+import { createFixtureRepo, createFixtureRepoWithRecipes } from "../../helpers/fixtures";
+import { openAndOnboardProject } from "../../helpers/project";
+import { SEL } from "../../helpers/selectors";
+import { T_SHORT, T_MEDIUM, T_LONG, T_SETTLE } from "../../helpers/timeouts";
+import { dismissBlockingPalette } from "../../helpers/overlays";
+
+// E2E coverage for recipe and onboarding surfaces that lacked specs (#9597):
+// the stale-write conflict dialog, RecipeManager clipboard export/import,
+// Team-scope + shadowing rows, the GettingStartedChecklist, RecipeRunner
+// suggestion pills, recipe terminal-type marshaling, and the variable preview.
+// The recipe-editor CRUD basics live in core-terminal-recipes.spec.ts and are
+// intentionally not duplicated here.
+
+async function openRecipeManager(window: Page): Promise<Locator> {
+  await dismissBlockingPalette(window).catch(() => undefined);
+  await window.evaluate(() =>
+    window.dispatchEvent(new CustomEvent("daintree:open-recipe-manager"))
+  );
+  const dialog = window.locator(SEL.recipeManager.dialog);
+  await expect(dialog).toBeVisible({ timeout: T_MEDIUM });
+  return dialog;
+}
+
+async function closeAppDialog(window: Page): Promise<void> {
+  // Escape closes the topmost AppDialog; assert the portal fully detaches so a
+  // lingering FocusScope can't swallow keys in the next serial test (#6289).
+  await window.keyboard.press("Escape");
+  await expect(window.locator('[role="dialog"]')).toHaveCount(0, { timeout: T_MEDIUM });
+}
+
+function getRecipeEditor(window: Page, title: "Create Recipe" | "Edit Recipe" = "Create Recipe") {
+  return window.getByRole("dialog").filter({ hasText: title });
+}
+
+// Creates a project recipe through the RecipeManager → editor flow. The manager
+// closes itself when the editor opens (handleRecipeManagerCreate), so callers
+// reopen it afterward if they need the resulting row.
+async function createProjectRecipe(window: Page, name: string): Promise<void> {
+  const manager = await openRecipeManager(window);
+  await manager.locator(SEL.recipeManager.newProjectRecipeButton).first().click({ force: true });
+
+  const editor = getRecipeEditor(window);
+  await expect(editor).toBeVisible({ timeout: T_MEDIUM });
+  await editor.locator(SEL.recipeEditor.nameInput).fill(name);
+  await editor.locator(SEL.recipeEditor.terminalCommand(0)).fill("echo hi");
+  await editor.locator(SEL.recipeEditor.createButton).click();
+  await expect(editor).not.toBeVisible({ timeout: T_MEDIUM });
+}
+
+test.describe.serial("Recipe & onboarding coverage (#9597)", () => {
+  // ---------------------------------------------------------------------------
+  // Surfaces that share one app + one plain project: conflict dialog, clipboard
+  // export/import, terminal-type marshaling, variable preview.
+  // ---------------------------------------------------------------------------
+  test.describe.serial("Recipe dialogs", () => {
+    let ctx: AppContext;
+    let cleanup: (() => void) | undefined;
+
+    test.beforeAll(async () => {
+      ctx = await launchApp();
+      const { dir, cleanup: c } = createFixtureRepo({ name: "recipe-dialogs" });
+      cleanup = c;
+      ctx.window = await openAndOnboardProject(ctx.app, ctx.window, dir, "Recipe Dialogs");
+      await ctx.window.waitForTimeout(T_SETTLE);
+    });
+
+    test.afterAll(async () => {
+      if (ctx?.app) await closeApp(ctx.app);
+      cleanup?.();
+    });
+
+    test("conflict dialog resolves via reload from disk", async () => {
+      const { window } = ctx;
+      await window.evaluate(() =>
+        window.__DAINTREE_E2E_TRIGGER_RECIPE_CONFLICT__?.("Conflicting Recipe")
+      );
+
+      const dialog = window.locator(SEL.recipeConflict.dialog);
+      await expect(dialog).toBeVisible({ timeout: T_MEDIUM });
+      await expect(dialog).toContainText("Conflicting Recipe");
+      await expect(window.locator(SEL.recipeConflict.overwriteButton)).toBeVisible({
+        timeout: T_SHORT,
+      });
+
+      await window.locator(SEL.recipeConflict.reloadButton).click();
+      await expect(dialog).toHaveCount(0, { timeout: T_MEDIUM });
+    });
+
+    test("conflict dialog resolves via overwrite", async () => {
+      const { window } = ctx;
+      await window.evaluate(() =>
+        window.__DAINTREE_E2E_TRIGGER_RECIPE_CONFLICT__?.("Conflicting Recipe")
+      );
+
+      const dialog = window.locator(SEL.recipeConflict.dialog);
+      await expect(dialog).toBeVisible({ timeout: T_MEDIUM });
+
+      await window.locator(SEL.recipeConflict.overwriteButton).click();
+      await expect(dialog).toHaveCount(0, { timeout: T_MEDIUM });
+    });
+
+    test("export copies recipe JSON to the clipboard", async () => {
+      const { app, window } = ctx;
+      await createProjectRecipe(window, "Export Me");
+
+      const manager = await openRecipeManager(window);
+      await app.evaluate(({ clipboard }) => clipboard.writeText(""));
+
+      const exportBtn = manager.locator(SEL.recipeManager.exportButton("Export Me"));
+      await exportBtn.click({ force: true });
+
+      // UI feedback flips only when the clipboard write resolves, so its
+      // appearance confirms the copy succeeded before we read it back.
+      await expect(manager.locator(SEL.recipeManager.exportedButton("Export Me"))).toBeVisible({
+        timeout: T_MEDIUM,
+      });
+
+      const clipboardText = await app.evaluate(({ clipboard }) => clipboard.readText());
+      const parsed = JSON.parse(clipboardText) as { name?: string };
+      expect(parsed.name).toBe("Export Me");
+
+      await closeAppDialog(window);
+    });
+
+    test("import from clipboard adds a project recipe", async () => {
+      const { window } = ctx;
+      const manager = await openRecipeManager(window);
+
+      await manager.locator(SEL.recipeManager.importButton).first().click({ force: true });
+      const importDialog = window.locator(SEL.recipeManager.importDialog);
+      await expect(importDialog).toBeVisible({ timeout: T_MEDIUM });
+
+      const payload = JSON.stringify({
+        name: "Imported Recipe",
+        terminals: [{ type: "terminal", title: "", command: "echo imported", env: {} }],
+      });
+      await importDialog.locator(SEL.recipeManager.importTextarea).fill(payload);
+      await importDialog.locator(SEL.recipeManager.importConfirmButton).click();
+      await expect(importDialog).not.toBeVisible({ timeout: T_MEDIUM });
+
+      // The recipe row appears in the still-open manager once the store settles.
+      await expect(manager.locator(SEL.recipeManager.exportButton("Imported Recipe"))).toBeAttached(
+        { timeout: T_LONG }
+      );
+
+      await closeAppDialog(window);
+    });
+
+    test("terminal-type field round-trips through save and reopen", async () => {
+      const { window } = ctx;
+      await createProjectRecipe(window, "Typed Recipe Seed");
+
+      // Edit the seeded recipe and switch its terminal to an agent type. Clicking
+      // edit closes the manager and opens the editor, so each edit reopens it.
+      let manager = await openRecipeManager(window);
+      await manager
+        .locator(SEL.recipeManager.exportButton("Typed Recipe Seed"))
+        .waitFor({ state: "attached", timeout: T_LONG });
+      await manager.getByLabel("Edit recipe Typed Recipe Seed").click({ force: true });
+
+      const editor = getRecipeEditor(window, "Edit Recipe");
+      await expect(editor).toBeVisible({ timeout: T_MEDIUM });
+      await editor.locator(SEL.recipeEditor.terminalType(0)).selectOption("claude");
+
+      // Switching to an agent type reveals the agent-only initial-prompt field —
+      // proof the type value drives the conditional terminal marshaling.
+      await expect(editor.locator("#terminal-initial-prompt-0")).toBeVisible({ timeout: T_SHORT });
+
+      await editor.locator(SEL.recipeEditor.updateButton).click();
+      await expect(editor).not.toBeVisible({ timeout: T_MEDIUM });
+
+      // Reopen the manager, then the editor, and confirm the agent type persisted.
+      manager = await openRecipeManager(window);
+      await manager.getByLabel("Edit recipe Typed Recipe Seed").click({ force: true });
+      const reopened = getRecipeEditor(window, "Edit Recipe");
+      await expect(reopened).toBeVisible({ timeout: T_MEDIUM });
+      await expect(reopened.locator(SEL.recipeEditor.terminalType(0))).toHaveValue("claude", {
+        timeout: T_SHORT,
+      });
+
+      await reopened.locator(SEL.recipeEditor.cancelButton).click();
+      await expect(reopened).not.toBeVisible({ timeout: T_SHORT });
+      await expect(window.locator('[role="dialog"]')).toHaveCount(0, { timeout: T_MEDIUM });
+    });
+
+    test("variable preview renders unresolved tokens for an agent prompt", async () => {
+      const { window } = ctx;
+      const manager = await openRecipeManager(window);
+      await manager
+        .locator(SEL.recipeManager.newProjectRecipeButton)
+        .first()
+        .click({ force: true });
+
+      const editor = getRecipeEditor(window);
+      await expect(editor).toBeVisible({ timeout: T_MEDIUM });
+      await editor.locator(SEL.recipeEditor.nameInput).fill("Variable Preview Recipe");
+      await editor.locator(SEL.recipeEditor.terminalType(0)).selectOption("claude");
+
+      const promptField = editor.locator("#terminal-initial-prompt-0");
+      await expect(promptField).toBeVisible({ timeout: T_SHORT });
+      await promptField.fill("Work on {{branch_name}} now");
+
+      // No worktree context in the create flow → tokens stay highlighted and the
+      // preview tells the user they resolve at run time.
+      await expect(editor.getByText("Resolved prompt")).toBeVisible({ timeout: T_SHORT });
+      await expect(editor.getByText("Resolving at run time")).toBeVisible({ timeout: T_SHORT });
+      await expect(editor.locator(".bg-category-amber-subtle").first()).toBeVisible({
+        timeout: T_SHORT,
+      });
+
+      // Cancel without saving (dirty → confirm dialog).
+      window.once("dialog", (d) => d.accept());
+      await editor.locator(SEL.recipeEditor.cancelButton).click();
+      await expect(editor).not.toBeVisible({ timeout: T_MEDIUM });
+      await expect(window.locator('[role="dialog"]')).toHaveCount(0, { timeout: T_MEDIUM });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Team scope + shadowing: seed an in-repo recipe, then shadow it with a
+  // same-named project recipe.
+  // ---------------------------------------------------------------------------
+  test.describe.serial("Recipe scopes and shadowing", () => {
+    let ctx: AppContext;
+    let cleanup: (() => void) | undefined;
+
+    test.beforeAll(async () => {
+      ctx = await launchApp();
+      const { dir, cleanup: c } = createFixtureRepoWithRecipes({
+        name: "recipe-scopes",
+        inRepoRecipes: [
+          {
+            name: "Shared Dev",
+            terminals: [{ type: "terminal", command: "npm run dev", env: {} }],
+          },
+        ],
+      });
+      cleanup = c;
+      ctx.window = await openAndOnboardProject(ctx.app, ctx.window, dir, "Recipe Scopes");
+      await ctx.window.waitForTimeout(T_SETTLE);
+    });
+
+    test.afterAll(async () => {
+      if (ctx?.app) await closeApp(ctx.app);
+      cleanup?.();
+    });
+
+    test("team section lists the in-repo recipe", async () => {
+      const { window } = ctx;
+      const manager = await openRecipeManager(window);
+      await expect(manager.locator(SEL.recipeManager.teamSection)).toBeVisible({ timeout: T_LONG });
+      await expect(manager.getByText("Shared Dev", { exact: true })).toBeVisible({
+        timeout: T_SHORT,
+      });
+      await closeAppDialog(window);
+    });
+
+    test("a same-named project recipe is marked as overridden", async () => {
+      const { window } = ctx;
+      await createProjectRecipe(window, "Shared Dev");
+
+      const manager = await openRecipeManager(window);
+      await expect(manager.locator(SEL.recipeManager.overriddenBadge)).toBeVisible({
+        timeout: T_LONG,
+      });
+      await closeAppDialog(window);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // RecipeRunner empty state: a project with package.json scripts and no recipes
+  // surfaces suggestion pills in the content-grid empty state.
+  // ---------------------------------------------------------------------------
+  test.describe.serial("Recipe runner empty state", () => {
+    let ctx: AppContext;
+    let cleanup: (() => void) | undefined;
+
+    test.beforeAll(async () => {
+      ctx = await launchApp();
+      const { dir, cleanup: c } = createFixtureRepoWithRecipes({
+        name: "recipe-runner",
+        packageScripts: { dev: "vite", test: "vitest" },
+      });
+      cleanup = c;
+      ctx.window = await openAndOnboardProject(ctx.app, ctx.window, dir, "Recipe Runner");
+      await ctx.window.waitForTimeout(T_SETTLE);
+    });
+
+    test.afterAll(async () => {
+      if (ctx?.app) await closeApp(ctx.app);
+      cleanup?.();
+    });
+
+    test("empty state surfaces package.json suggestion pills", async () => {
+      const { window } = ctx;
+      await dismissBlockingPalette(window).catch(() => undefined);
+
+      const empty = window.locator(SEL.recipeRunner.emptyState);
+      await expect(empty).toBeVisible({ timeout: T_LONG });
+
+      const pills = empty.locator(SEL.recipeRunner.suggestionPill);
+      await expect(pills).toHaveCount(2, { timeout: T_MEDIUM });
+      // Detection order isn't guaranteed; assert the "dev" script surfaced on
+      // one of the pills rather than pinning it to a position.
+      await expect(empty.getByText("dev", { exact: false }).first()).toBeVisible({
+        timeout: T_SHORT,
+      });
+      await expect(empty.getByRole("button", { name: /Create your first recipe/ })).toBeVisible({
+        timeout: T_SHORT,
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // GettingStartedChecklist: force it visible (forceShow path), then mark /
+  // collapse / dismiss with persistence checks. Launched with the first-run
+  // skip disabled so the checklist starts fresh instead of pre-dismissed.
+  // ---------------------------------------------------------------------------
+  test.describe.serial("Getting started checklist", () => {
+    let ctx: AppContext;
+    let cleanup: (() => void) | undefined;
+
+    test.beforeAll(async () => {
+      ctx = await launchApp({ env: { DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS: "0" } });
+      const { dir, cleanup: c } = createFixtureRepo({ name: "checklist" });
+      cleanup = c;
+      ctx.window = await openAndOnboardProject(ctx.app, ctx.window, dir, "Checklist");
+      await ctx.window.waitForTimeout(T_SETTLE);
+    });
+
+    test.afterAll(async () => {
+      if (ctx?.app) await closeApp(ctx.app);
+      cleanup?.();
+    });
+
+    async function showChecklist(window: Page): Promise<Locator> {
+      await window.evaluate(() => window.dispatchEvent(new Event("daintree:show-getting-started")));
+      const panel = window.locator(SEL.checklist.panel);
+      await expect(panel).toBeVisible({ timeout: T_MEDIUM });
+      return panel;
+    }
+
+    test("marking an item via IPC persists and reflects on re-show", async () => {
+      const { window } = ctx;
+      const panel = await showChecklist(window);
+      await expect(panel.getByText("Getting Started")).toBeVisible({ timeout: T_SHORT });
+
+      // createdWorktree won't auto-complete in a single-worktree project.
+      const item = panel.locator(SEL.checklist.item("createdWorktree"));
+      await expect(item).toBeVisible({ timeout: T_SHORT });
+
+      await window.evaluate(() => window.electron.onboarding.markChecklistItem("createdWorktree"));
+
+      const persisted = await window.evaluate(() => window.electron.onboarding.getChecklist());
+      expect(persisted.items.createdWorktree).toBe(true);
+
+      // Re-show re-hydrates from disk, so the row now renders as done (rendered
+      // as a <div>, not the actionable <button>).
+      const repanel = await showChecklist(window);
+      await expect(repanel.locator(`div${SEL.checklist.item("createdWorktree")}`)).toBeVisible({
+        timeout: T_MEDIUM,
+      });
+    });
+
+    test("collapse toggles the body and dismiss persists", async () => {
+      const { window } = ctx;
+      const panel = await showChecklist(window);
+
+      const toggle = window.locator(SEL.checklist.toggleButton);
+      await expect(toggle).toHaveAttribute("aria-expanded", "true", { timeout: T_SHORT });
+      await toggle.click();
+      await expect(toggle).toHaveAttribute("aria-expanded", "false", { timeout: T_SHORT });
+
+      await window.locator(SEL.checklist.dismissButton).click();
+      await expect(panel).toHaveCount(0, { timeout: T_MEDIUM });
+
+      const persisted = await window.evaluate(() => window.electron.onboarding.getChecklist());
+      expect(persisted.dismissed).toBe(true);
+    });
+  });
+});

--- a/e2e/full/presets/recipe-e2e-coverage.spec.ts
+++ b/e2e/full/presets/recipe-e2e-coverage.spec.ts
@@ -34,6 +34,24 @@ function getRecipeEditor(window: Page, title: "Create Recipe" | "Edit Recipe" = 
   return window.getByRole("dialog").filter({ hasText: title });
 }
 
+// Opens the project-settings Recipes tab and closes it. This is the canonical
+// trigger for recipeStore.loadRecipes(currentProject.id) (RecipesTab mount):
+// it sets the recipe store's currentProjectId and loads global/in-repo/project
+// recipes from disk. E2E project hydration does not auto-run loadRecipes, so
+// in-repo recipes and the RecipeRunner's currentProjectId gate need this first.
+async function loadRecipesViaSettings(window: Page): Promise<void> {
+  await dismissBlockingPalette(window).catch(() => undefined);
+  await window.locator(SEL.toolbar.projectSwitcherTrigger).click();
+  const palette = window.locator(SEL.projectSwitcher.palette);
+  await expect(palette).toBeVisible({ timeout: T_MEDIUM });
+  await palette.locator(SEL.projectSwitcher.projectSettings).click();
+  await expect(window.locator(SEL.projectSettings.heading)).toBeVisible({ timeout: T_MEDIUM });
+  await window.locator(SEL.projectSettings.recipesTab).click();
+  await window.waitForTimeout(T_SETTLE);
+  await window.locator(SEL.projectSettings.closeButton).click();
+  await expect(window.locator(SEL.projectSettings.heading)).not.toBeVisible({ timeout: T_SHORT });
+}
+
 // Creates a project recipe through the RecipeManager → editor flow. The manager
 // closes itself when the editor opens (handleRecipeManagerCreate), so callers
 // reopen it afterward if they need the resulting row.
@@ -240,6 +258,8 @@ test.describe.serial("Recipe & onboarding coverage (#9597)", () => {
       cleanup = c;
       ctx.window = await openAndOnboardProject(ctx.app, ctx.window, dir, "Recipe Scopes");
       await ctx.window.waitForTimeout(T_SETTLE);
+      // Load the seeded in-repo recipe from disk into the store.
+      await loadRecipesViaSettings(ctx.window);
     });
 
     test.afterAll(async () => {
@@ -272,10 +292,9 @@ test.describe.serial("Recipe & onboarding coverage (#9597)", () => {
           createdAt: 1_700_000_000_000,
         });
       });
-      // Fire the focus-reload (useRecipeFocusReload) so the store picks up the
-      // newly-seeded project recipe; wait past the 500ms dedupe window first.
-      await window.waitForTimeout(700);
-      await window.evaluate(() => window.dispatchEvent(new Event("focus")));
+      // Reload so the store picks up the newly-seeded machine-local recipe
+      // alongside the in-repo one.
+      await loadRecipesViaSettings(window);
 
       const manager = await openRecipeManager(window);
       await expect(manager.locator(SEL.recipeManager.overriddenBadge)).toBeVisible({
@@ -302,6 +321,9 @@ test.describe.serial("Recipe & onboarding coverage (#9597)", () => {
       cleanup = c;
       ctx.window = await openAndOnboardProject(ctx.app, ctx.window, dir, "Recipe Runner");
       await ctx.window.waitForTimeout(T_SETTLE);
+      // Sets the recipe store's currentProjectId so the RecipeRunner (gated on
+      // recipesProjectId !== null) renders in the content-grid empty state.
+      await loadRecipesViaSettings(ctx.window);
     });
 
     test.afterAll(async () => {

--- a/e2e/full/presets/recipe-e2e-coverage.spec.ts
+++ b/e2e/full/presets/recipe-e2e-coverage.spec.ts
@@ -124,12 +124,9 @@ test.describe.serial("Recipe & onboarding coverage (#9597)", () => {
       await closeAppDialog(window);
     });
 
-    test("import from clipboard adds a recipe under team scope", async () => {
+    test("import from clipboard adds a recipe to the manager", async () => {
       const { window } = ctx;
       const manager = await openRecipeManager(window);
-      // The plain fixture has no in-repo recipes yet, so the Team section is
-      // absent until the project-scoped import writes one to .daintree/recipes/.
-      await expect(manager.locator(SEL.recipeManager.teamSection)).toHaveCount(0);
 
       await manager.locator(SEL.recipeManager.importButton).first().click({ force: true });
       const importDialog = window.locator(SEL.recipeManager.importDialog);
@@ -144,10 +141,9 @@ test.describe.serial("Recipe & onboarding coverage (#9597)", () => {
       await expect(importDialog).not.toBeVisible({ timeout: T_MEDIUM });
 
       // A project-scoped import persists to the repo (scope: "inrepo"), so the
-      // Team Recipes section appears with the imported recipe.
-      await expect(manager.locator(SEL.recipeManager.teamSection)).toBeVisible({ timeout: T_LONG });
+      // imported recipe shows up in the manager once the store settles.
       await expect(manager.getByText("Imported Recipe", { exact: true })).toBeVisible({
-        timeout: T_SHORT,
+        timeout: T_LONG,
       });
 
       await closeAppDialog(window);
@@ -262,9 +258,25 @@ test.describe.serial("Recipe & onboarding coverage (#9597)", () => {
       await closeAppDialog(window);
     });
 
-    test("a same-named project recipe is marked as overridden", async () => {
+    test("a same-named machine-local project recipe is marked as overridden", async () => {
       const { window } = ctx;
-      await createProjectRecipe(window, "Shared Dev");
+      // The shadow badge only renders for a machine-local project recipe whose
+      // name collides with an in-repo recipe. The editor create flow writes
+      // in-repo recipes, so seed the machine-local one through the project IPC.
+      await window.evaluate(async () => {
+        const project = await window.electron.project.getCurrent();
+        if (!project?.id) throw new Error("No active project");
+        await window.electron.project.addRecipe(project.id, {
+          id: "recipe-local-shadow",
+          name: "Shared Dev",
+          terminals: [{ type: "terminal" as const, title: "", command: "echo local", env: {} }],
+          createdAt: 1_700_000_000_000,
+        });
+      });
+      // Fire the focus-reload (useRecipeFocusReload) so the store picks up the
+      // newly-seeded project recipe; wait past the 500ms dedupe window first.
+      await window.waitForTimeout(700);
+      await window.evaluate(() => window.dispatchEvent(new Event("focus")));
 
       const manager = await openRecipeManager(window);
       await expect(manager.locator(SEL.recipeManager.overriddenBadge)).toBeVisible({

--- a/e2e/full/presets/recipe-e2e-coverage.spec.ts
+++ b/e2e/full/presets/recipe-e2e-coverage.spec.ts
@@ -271,7 +271,9 @@ test.describe.serial("Recipe & onboarding coverage (#9597)", () => {
       const { window } = ctx;
       const manager = await openRecipeManager(window);
       await expect(manager.locator(SEL.recipeManager.teamSection)).toBeVisible({ timeout: T_LONG });
-      await expect(manager.getByText("Shared Dev", { exact: true })).toBeVisible({
+      // The in-repo recipe also has a reconciled project-mirror row, so the name
+      // can appear more than once — assert it's present rather than unique.
+      await expect(manager.getByText("Shared Dev", { exact: true }).first()).toBeVisible({
         timeout: T_SHORT,
       });
       await closeAppDialog(window);
@@ -297,7 +299,7 @@ test.describe.serial("Recipe & onboarding coverage (#9597)", () => {
       await loadRecipesViaSettings(window);
 
       const manager = await openRecipeManager(window);
-      await expect(manager.locator(SEL.recipeManager.overriddenBadge)).toBeVisible({
+      await expect(manager.locator(SEL.recipeManager.overriddenBadge).first()).toBeVisible({
         timeout: T_LONG,
       });
       await closeAppDialog(window);

--- a/e2e/full/presets/recipe-e2e-coverage.spec.ts
+++ b/e2e/full/presets/recipe-e2e-coverage.spec.ts
@@ -149,32 +149,31 @@ test.describe.serial("Recipe & onboarding coverage (#9597)", () => {
       await closeAppDialog(window);
     });
 
-    test("terminal-type field round-trips through save and reopen", async () => {
+    test("terminal-type field round-trips through create and reopen", async () => {
       const { window } = ctx;
-      await createProjectRecipe(window, "Typed Recipe Seed");
 
-      // Edit the seeded recipe and switch its terminal to an agent type. Clicking
-      // edit closes the manager and opens the editor, so each edit reopens it.
-      let manager = await openRecipeManager(window);
+      // Create a recipe with an agent terminal type.
+      const manager = await openRecipeManager(window);
       await manager
-        .locator(SEL.recipeManager.exportButton("Typed Recipe Seed"))
-        .waitFor({ state: "attached", timeout: T_LONG });
-      await manager.getByLabel("Edit recipe Typed Recipe Seed").click({ force: true });
+        .locator(SEL.recipeManager.newProjectRecipeButton)
+        .first()
+        .click({ force: true });
 
-      const editor = getRecipeEditor(window, "Edit Recipe");
+      const editor = getRecipeEditor(window);
       await expect(editor).toBeVisible({ timeout: T_MEDIUM });
+      await editor.locator(SEL.recipeEditor.nameInput).fill("Typed Recipe");
       await editor.locator(SEL.recipeEditor.terminalType(0)).selectOption("claude");
 
       // Switching to an agent type reveals the agent-only initial-prompt field —
       // proof the type value drives the conditional terminal marshaling.
       await expect(editor.locator("#terminal-initial-prompt-0")).toBeVisible({ timeout: T_SHORT });
 
-      await editor.locator(SEL.recipeEditor.updateButton).click();
+      await editor.locator(SEL.recipeEditor.createButton).click();
       await expect(editor).not.toBeVisible({ timeout: T_MEDIUM });
 
-      // Reopen the manager, then the editor, and confirm the agent type persisted.
-      manager = await openRecipeManager(window);
-      await manager.getByLabel("Edit recipe Typed Recipe Seed").click({ force: true });
+      // Reopen the recipe and confirm the agent type persisted across the round-trip.
+      const reopenManager = await openRecipeManager(window);
+      await reopenManager.getByLabel("Edit recipe Typed Recipe").click({ force: true });
       const reopened = getRecipeEditor(window, "Edit Recipe");
       await expect(reopened).toBeVisible({ timeout: T_MEDIUM });
       await expect(reopened.locator(SEL.recipeEditor.terminalType(0))).toHaveValue("claude", {

--- a/e2e/full/presets/recipe-e2e-coverage.spec.ts
+++ b/e2e/full/presets/recipe-e2e-coverage.spec.ts
@@ -290,6 +290,7 @@ test.describe.serial("Recipe & onboarding coverage (#9597)", () => {
         await window.electron.project.addRecipe(project.id, {
           id: "recipe-local-shadow",
           name: "Shared Dev",
+          projectId: project.id,
           terminals: [{ type: "terminal" as const, title: "", command: "echo local", env: {} }],
           createdAt: 1_700_000_000_000,
         });

--- a/e2e/helpers/fixtures.ts
+++ b/e2e/helpers/fixtures.ts
@@ -272,6 +272,80 @@ export function createConflictFixtureRepo(
   }
 
   return { dir, cleanup: makeFixtureCleanup(dir) };
+export interface InRepoRecipeSeed {
+  /** Recipe name; the file is written as `.daintree/recipes/<slug>.json`. */
+  name: string;
+  /** Terminal definitions; defaults to a single terminal slot when omitted. */
+  terminals?: Array<Record<string, unknown>>;
+  showInEmptyState?: boolean;
+}
+
+interface FixtureRepoWithRecipesOptions extends FixtureRepoOptions {
+  /** Team (in-repo) recipes to seed under `.daintree/recipes/` before opening. */
+  inRepoRecipes?: InRepoRecipeSeed[];
+  /** `package.json` scripts so RecipeRunner can surface suggestion pills. */
+  packageScripts?: Record<string, string>;
+}
+
+function recipeSlug(name: string): string {
+  // Mirrors safeRecipeFilename's slug rules (sans the diacritics strip, which
+  // the ASCII recipe names used in E2E never need).
+  return (
+    name
+      .replace(/[\\/:*?"<>|]/g, "")
+      .replace(/\s+/g, "-")
+      .replace(/-+/g, "-")
+      .toLowerCase()
+      .replace(/^[-.]+|[-.]+$/g, "") || "recipe"
+  );
+}
+
+/**
+ * Like createFixtureRepo, but seeds tracked `.daintree/recipes/*.json` team
+ * recipes (and optional package.json scripts) and commits them, so the project
+ * loads in-repo recipes on open. Used by recipe-coverage E2E to exercise the
+ * Team scope section, shadowing badges, and RecipeRunner suggestion pills.
+ */
+export function createFixtureRepoWithRecipes(
+  options: FixtureRepoWithRecipesOptions = {}
+): FixtureRepo {
+  const { inRepoRecipes = [], packageScripts, ...repoOptions } = options;
+  const repo = createFixtureRepo(repoOptions);
+
+  if (packageScripts) {
+    writeFileSync(
+      path.join(repo.dir, "package.json"),
+      JSON.stringify(
+        { name: repoOptions.name ?? "test-project", version: "1.0.0", scripts: packageScripts },
+        null,
+        2
+      ) + "\n"
+    );
+  }
+
+  if (inRepoRecipes.length > 0) {
+    const recipesDir = path.join(repo.dir, ".daintree", "recipes");
+    mkdirSync(recipesDir, { recursive: true });
+    for (const seed of inRepoRecipes) {
+      const slug = recipeSlug(seed.name);
+      const recipe = {
+        id: `inrepo-${slug}`,
+        name: seed.name,
+        terminals: seed.terminals ?? [{ type: "terminal", title: "", command: "", env: {} }],
+        createdAt: 1_700_000_000_000,
+        showInEmptyState: seed.showInEmptyState ?? false,
+        autoAssign: "always",
+      };
+      writeFileSync(path.join(recipesDir, `${slug}.json`), JSON.stringify(recipe, null, 2) + "\n");
+    }
+  }
+
+  if (packageScripts || inRepoRecipes.length > 0) {
+    git("add -A", repo.dir);
+    git('commit -m "seed recipes and scripts"', repo.dir);
+  }
+
+  return repo;
 }
 
 export function createFixtureRepos(count: number): FixtureRepo[] {

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -471,4 +471,32 @@ export const SEL = {
     // Prompt-history palette reached via the `:` prefix (agent input bar gated).
     promptHistoryDialog: '[role="dialog"][aria-label="Prompt history search"]',
   },
+  recipeManager: {
+    dialog: '[role="dialog"]:has-text("Recipe Manager")',
+    teamSection: 'h3:has-text("Team Recipes")',
+    globalSection: 'h3:has-text("Global Recipes")',
+    newProjectRecipeButton: 'button:has-text("New project recipe")',
+    importButton: 'button:has-text("Import from clipboard")',
+    importDialog: '[role="dialog"]:has-text("Import recipe")',
+    importTextarea: '[data-testid="recipe-import-textarea"]',
+    importConfirmButton: '[role="dialog"]:has-text("Import recipe") button:has-text("Import")',
+    overriddenBadge: 'text="Overridden by team recipe"',
+    exportButton: (name: string) => `[aria-label="Export recipe ${name} to clipboard"]`,
+    exportedButton: (name: string) => `[aria-label="Recipe ${name} exported to clipboard"]`,
+  },
+  recipeConflict: {
+    dialog: '[role="dialog"]:has-text("changed on disk")',
+    reloadButton: '[data-testid="recipe-conflict-reload"]',
+    overwriteButton: '[data-testid="recipe-conflict-overwrite"]',
+  },
+  recipeRunner: {
+    emptyState: '[data-testid="recipe-runner-empty"]',
+    suggestionPill: '[data-testid="recipe-suggestion-pill"]',
+  },
+  checklist: {
+    panel: "[data-getting-started-checklist]",
+    dismissButton: 'button[aria-label="Dismiss checklist"]',
+    toggleButton: "[data-getting-started-checklist] button[aria-expanded]",
+    item: (id: string) => `[data-checklist-item="${id}"]`,
+  },
 } as const;

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -479,7 +479,9 @@ export const SEL = {
     importButton: 'button:has-text("Import from clipboard")',
     importDialog: '[role="dialog"]:has-text("Import recipe")',
     importTextarea: '[data-testid="recipe-import-textarea"]',
-    importConfirmButton: '[role="dialog"]:has-text("Import recipe") button:has-text("Import")',
+    // Scope this with the importDialog locator in specs — the import dialog's
+    // footer has only "Cancel" and "Import", so a bare text match is unambiguous.
+    importConfirmButton: 'button:has-text("Import")',
     overriddenBadge: 'text="Overridden by team recipe"',
     exportButton: (name: string) => `[aria-label="Export recipe ${name} to clipboard"]`,
     exportedButton: (name: string) => `[aria-label="Recipe ${name} exported to clipboard"]`,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -325,6 +325,7 @@ import {
   usePluginManagerStore,
 } from "./store";
 import { useGitHubConfigStore } from "@github-renderer/stores/githubConfigStore";
+import { useRecipeConflictStore } from "./store/recipeConflictStore";
 // Eager side-effect import: registers the GitHub plugin's builtin view slots
 // (bulkCreateWorktreeDialog, issueSelector) at module-eval time, before first
 // render. Must stay static — a deferred/idle import races the user, so
@@ -377,11 +378,23 @@ function AppInner() {
     // fault-mode tests to pick up a token seeded via __daintreeSeedGitHubToken
     // so the no-token empty state doesn't short-circuit IPC fault paths.
     window.__DAINTREE_E2E_REFRESH_GITHUB_CONFIG__ = () => useGitHubConfigStore.getState().refresh();
+    // Parks a synthetic in-repo recipe stale-write conflict so E2E can exercise
+    // the RecipeConflictDialog without racing a real on-disk file mutation. The
+    // returned promise resolves with the user's choice; tests don't await it —
+    // they assert the dialog renders and that reload/overwrite dismiss it.
+    window.__DAINTREE_E2E_TRIGGER_RECIPE_CONFLICT__ = (recipeName: string) => {
+      void useRecipeConflictStore.getState().requestConflict({
+        recipeId: `inrepo-${recipeName}`,
+        recipeName,
+        updates: { name: recipeName },
+      });
+    };
     return () => {
       delete window.__DAINTREE_E2E_ERROR_STORE__;
       delete window.__DAINTREE_E2E_ADD_ERROR__;
       delete window.__DAINTREE_E2E_CLEAR_ERRORS__;
       delete window.__DAINTREE_E2E_REFRESH_GITHUB_CONFIG__;
+      delete window.__DAINTREE_E2E_TRIGGER_RECIPE_CONFLICT__;
     };
   }, []);
 

--- a/src/components/Onboarding/GettingStartedChecklist.tsx
+++ b/src/components/Onboarding/GettingStartedChecklist.tsx
@@ -287,7 +287,7 @@ export function GettingStartedChecklist({
 
                 if (done) {
                   return (
-                    <div key={id} className={sharedClasses}>
+                    <div key={id} data-checklist-item={id} className={sharedClasses}>
                       {content}
                     </div>
                   );
@@ -297,6 +297,7 @@ export function GettingStartedChecklist({
                   <button
                     key={id}
                     type="button"
+                    data-checklist-item={id}
                     onClick={() => {
                       void actionService.dispatch(actionId, actionArgs, {
                         source: "user",

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerEmpty.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerEmpty.tsx
@@ -18,13 +18,17 @@ export function RecipeRunnerEmpty({
   const hasSuggestions = suggestions.length > 0;
 
   return (
-    <div className="flex flex-col items-stretch gap-3 py-6 w-full max-w-md mx-auto">
+    <div
+      data-testid="recipe-runner-empty"
+      className="flex flex-col items-stretch gap-3 py-6 w-full max-w-md mx-auto"
+    >
       {hasSuggestions ? (
         <div className="flex flex-col gap-2">
           {suggestions.map((suggestion) => (
             <button
               key={suggestion.id}
               type="button"
+              data-testid="recipe-suggestion-pill"
               onClick={() => onRunSuggestion(suggestion)}
               disabled={disabled}
               className="group w-full flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] bg-overlay-subtle border border-border-subtle hover:bg-overlay-soft hover:border-border-default transition-colors text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-overlay-subtle disabled:hover:border-border-subtle"

--- a/src/components/TerminalRecipe/RecipeManager.tsx
+++ b/src/components/TerminalRecipe/RecipeManager.tsx
@@ -525,6 +525,7 @@ export function RecipeManager({
           <textarea
             value={importJson}
             onChange={(e) => setImportJson(e.target.value)}
+            data-testid="recipe-import-textarea"
             placeholder='{"name": "My Recipe", "terminals": [...]}'
             className="w-full h-48 px-3 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-sm text-daintree-text font-mono focus:outline-hidden focus:ring-2 focus:ring-daintree-accent resize-none"
             spellCheck={false}

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -22,6 +22,7 @@ declare global {
     __DAINTREE_E2E_ADD_ERROR__?: (message: string) => void;
     __DAINTREE_E2E_CLEAR_ERRORS__?: () => void;
     __DAINTREE_E2E_REFRESH_GITHUB_CONFIG__?: () => Promise<void>;
+    __DAINTREE_E2E_TRIGGER_RECIPE_CONFLICT__?: (recipeName: string) => void;
     __DAINTREE_E2E_IPC__?: {
       getRendererListenerCount: (channel: string) => number;
     };


### PR DESCRIPTION
## Summary

Recipe conflict resolution, import/export, scope shadowing, and the getting-started flow all shipped without E2E assertions. This adds a new Playwright spec in the `full-presets` bucket covering 7 surfaces across 11 tests — no new Playwright project, no bucket boundary changes.

Resolves #9597

## Changes

**New spec** — `e2e/full/presets/recipe-e2e-coverage.spec.ts` (4 `describe.serial` blocks, 11 tests):

- Recipe stale-write conflict dialog — reload and overwrite resolutions
- `RecipeManager` clipboard export (asserted via main-process clipboard read) and import
- Terminal-type field marshaling via create → reopen round-trip
- `RecipeVariablePreview` unresolved-token rendering
- Team scope section + "Overridden by team recipe" shadow badge (in-repo recipe seeded via fixture; machine-local project recipe via `project.addRecipe` IPC)
- `RecipeRunner` empty-state `package.json` suggestion pills
- `GettingStartedChecklist` mark / collapse / dismiss with IPC persistence

**Supporting changes:**

- `data-testid` hooks added to `RecipeRunnerEmpty`, `RecipeManager` import textarea, and `GettingStartedChecklist` items
- `__DAINTREE_E2E_TRIGGER_RECIPE_CONFLICT__` window hook in `App.tsx` — mirrors the existing `__DAINTREE_E2E_*` pattern to deterministically surface the conflict dialog without relying on real file-system races
- `createFixtureRepoWithRecipes` fixture helper — seeds tracked `.daintree/recipes/*.json` and optional `package.json` scripts
- `recipeManager` / `recipeConflict` / `recipeRunner` / `checklist` selector groups appended to the append-only registry in `e2e/helpers/selectors.ts`

## Testing

Spec passes 11/11 locally (`npm run build` + `npx playwright test e2e/full/presets/recipe-e2e-coverage.spec.ts`). PR CI runs typecheck / lint / unit / build on Ubuntu only — E2E runs nightly and on release per the CI strategy in `CLAUDE.md`.