### PR TITLE
test(notifications): add e2e coverage for notification surfaces

### DIFF
--- a/e2e/full/panels/notification-center.spec.ts
+++ b/e2e/full/panels/notification-center.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect, type Page } from "@playwright/test";
+import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
+import { SEL } from "../../helpers/selectors";
+import { T_SHORT, T_MEDIUM } from "../../helpers/timeouts";
+import {
+  injectHistoryEntry,
+  archiveHistoryEntry,
+  snoozeThread,
+  resetNotifications,
+} from "../../helpers/notifications";
+
+// E2E coverage for the notification center inbox (`NotificationCenter.tsx`),
+// opened from the toolbar bell. Entries are seeded via the gated history-store
+// backdoor. Per lesson #6289 (Radix FocusScope contamination across serial
+// tests), every test closes the popover and waits for its list to unmount
+// before the next one runs. Entries are seeded as "info" so they never land in
+// the severity-pinned "Needs attention" rail, keeping row counts deterministic.
+
+let ctx: AppContext;
+
+async function openCenter(window: Page): Promise<void> {
+  const bell = window.locator(SEL.notifications.bellButton);
+  await expect(bell).toBeVisible({ timeout: T_MEDIUM });
+  if ((await bell.getAttribute("aria-expanded")) !== "true") {
+    await bell.click();
+  }
+  await expect(bell).toHaveAttribute("aria-expanded", "true", { timeout: T_SHORT });
+}
+
+async function closeCenter(window: Page): Promise<void> {
+  const bell = window.locator(SEL.notifications.bellButton);
+  if ((await bell.getAttribute("aria-expanded")) === "true") {
+    await window.keyboard.press("Escape");
+    await expect(bell).toHaveAttribute("aria-expanded", "false", { timeout: T_SHORT });
+  }
+  // Wait for the Radix popover portal to unmount so its FocusScope doesn't
+  // swallow keys in the next serial test (#6289).
+  await expect(window.locator(SEL.notifications.centerList)).toHaveCount(0, { timeout: T_SHORT });
+}
+
+test.describe.serial("Panels: Notification center", () => {
+  test.beforeAll(async () => {
+    ctx = await launchApp();
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+  });
+
+  test.beforeEach(async () => {
+    await resetNotifications(ctx.window);
+  });
+
+  test.afterEach(async () => {
+    await closeCenter(ctx.window);
+  });
+
+  test("All filter lists seeded entries", async () => {
+    const { window } = ctx;
+    await injectHistoryEntry(window, { type: "info", message: "Entry one" });
+    await injectHistoryEntry(window, { type: "info", message: "Entry two" });
+
+    await openCenter(window);
+    const rows = window.locator(SEL.notifications.centerList).locator(SEL.notifications.centerRow);
+    await expect(rows).toHaveCount(2, { timeout: T_MEDIUM });
+  });
+
+  test("Unread filter shows only unread entries", async () => {
+    const { window } = ctx;
+    await injectHistoryEntry(window, { type: "info", message: "Already read", seenAsToast: true });
+    await injectHistoryEntry(window, { type: "info", message: "Still unread", seenAsToast: false });
+
+    await openCenter(window);
+    await window.locator(SEL.notifications.centerFilter("Unread")).click();
+
+    const list = window.locator(SEL.notifications.centerList);
+    await expect(list.locator(SEL.notifications.centerRow)).toHaveCount(1, { timeout: T_MEDIUM });
+    await expect(list).toContainText("Still unread");
+    await expect(list).not.toContainText("Already read");
+  });
+
+  test("archived entries leave All and appear under Archived", async () => {
+    const { window } = ctx;
+    await injectHistoryEntry(window, { type: "info", message: "Stays active" });
+    const archivedId = await injectHistoryEntry(window, {
+      type: "info",
+      message: "Gets archived",
+    });
+    await archiveHistoryEntry(window, archivedId);
+
+    await openCenter(window);
+    const list = window.locator(SEL.notifications.centerList);
+    await expect(list).toContainText("Stays active", { timeout: T_MEDIUM });
+    await expect(list).not.toContainText("Gets archived");
+
+    await window.locator(SEL.notifications.centerFilter("Archived")).click();
+    await expect(list).toContainText("Gets archived", { timeout: T_MEDIUM });
+    await expect(list).not.toContainText("Stays active");
+  });
+
+  test("snoozed threads move to the Snoozed tab and out of All", async () => {
+    const { window } = ctx;
+    await injectHistoryEntry(window, {
+      type: "info",
+      message: "Snoozed item",
+      correlationId: "snooze-thread",
+    });
+    await snoozeThread(window, "snooze-thread", 60 * 60 * 1000);
+
+    await openCenter(window);
+    const list = window.locator(SEL.notifications.centerList);
+    // Hidden from All while snoozed.
+    await expect(list).not.toContainText("Snoozed item");
+
+    await window.locator(SEL.notifications.centerFilter("Snoozed")).click();
+    await expect(list).toContainText("Snoozed item", { timeout: T_MEDIUM });
+  });
+
+  test("Mark all read clears the unread state", async () => {
+    const { window } = ctx;
+    await injectHistoryEntry(window, { type: "info", message: "Unread A", seenAsToast: false });
+    await injectHistoryEntry(window, { type: "info", message: "Unread B", seenAsToast: false });
+
+    await openCenter(window);
+    const markAllRead = window.locator(SEL.notifications.markAllReadButton);
+    await expect(markAllRead).toBeVisible({ timeout: T_MEDIUM });
+    await markAllRead.click();
+
+    // With nothing unread, the Mark all read affordance disappears.
+    await expect(markAllRead).not.toBeVisible({ timeout: T_MEDIUM });
+  });
+});

--- a/e2e/full/panels/notification-center.spec.ts
+++ b/e2e/full/panels/notification-center.spec.ts
@@ -100,6 +100,10 @@ test.describe.serial("Panels: Notification center", () => {
 
   test("snoozed threads move to the Snoozed tab and out of All", async () => {
     const { window } = ctx;
+    // A non-snoozed sentinel keeps the All list rendered (the list only carries
+    // role="list" when rowCount > 0) so the "snoozed item is absent" assertion
+    // is non-vacuous — it runs against a present, populated list.
+    await injectHistoryEntry(window, { type: "info", message: "Active sibling" });
     await injectHistoryEntry(window, {
       type: "info",
       message: "Snoozed item",
@@ -109,11 +113,13 @@ test.describe.serial("Panels: Notification center", () => {
 
     await openCenter(window);
     const list = window.locator(SEL.notifications.centerList);
-    // Hidden from All while snoozed.
+    // All still renders the sibling; the snoozed item is hidden from it.
+    await expect(list).toContainText("Active sibling", { timeout: T_MEDIUM });
     await expect(list).not.toContainText("Snoozed item");
 
     await window.locator(SEL.notifications.centerFilter("Snoozed")).click();
     await expect(list).toContainText("Snoozed item", { timeout: T_MEDIUM });
+    await expect(list).not.toContainText("Active sibling");
   });
 
   test("Mark all read clears the unread state", async () => {

--- a/e2e/full/panels/notification-grid-banners.spec.ts
+++ b/e2e/full/panels/notification-grid-banners.spec.ts
@@ -1,0 +1,157 @@
+import { test, expect } from "@playwright/test";
+import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
+import { createFixtureRepo } from "../../helpers/fixtures";
+import { openAndOnboardProject } from "../../helpers/project";
+import { ensureWindowFocused } from "../../helpers/focus";
+import { openTerminal } from "../../helpers/panels";
+import { SEL } from "../../helpers/selectors";
+import { T_SHORT, T_MEDIUM } from "../../helpers/timeouts";
+import {
+  injectGridNotification,
+  backdateNotification,
+  resetNotifications,
+  setBackendStatus,
+  setWatchdogStatus,
+  setSafeMode,
+  setRestoreConfirmation,
+} from "../../helpers/notifications";
+
+// E2E coverage for the single-slot grid-bar (`GridNotificationBar.tsx`) and the
+// coordinator-arbitrated global recovery banners (`GlobalBannerCoordinator.tsx`).
+// Both surfaces are driven by injecting renderer store state via the gated
+// backdoor. The grid-bar requires a content grid (so a project + terminal is
+// opened); the banner coordinator mounts at the app-layout level. Banner store
+// state (backendStatus, safeMode, restoreConfirmation, watchdog) is set
+// directly — none of these are driven by a live heartbeat once connected, so an
+// injected value persists until the test resets it.
+
+let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
+
+test.describe.serial("Panels: Grid-bar & global banners", () => {
+  test.beforeAll(async () => {
+    const { dir, cleanup } = createFixtureRepo({ name: "notification-surfaces" });
+    fixtureCleanup = cleanup;
+    ctx = await launchApp();
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, dir, "Notification Surfaces");
+    await ensureWindowFocused(ctx.app);
+    // A grid panel is required for ContentGrid* (and thus GridNotificationBar) to mount.
+    await openTerminal(ctx.window);
+    await expect(ctx.window.locator(SEL.panel.gridPanel).first()).toBeVisible({
+      timeout: T_MEDIUM,
+    });
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
+  });
+
+  test.beforeEach(async () => {
+    await resetNotifications(ctx.window);
+  });
+
+  // ── Grid-bar ──────────────────────────────────────────────
+
+  test.describe.serial("Grid-bar", () => {
+    test("renders an injected grid-bar notification in its live region", async () => {
+      const { window } = ctx;
+      await injectGridNotification(window, {
+        type: "info",
+        title: "BUILD",
+        message: "Building project",
+      });
+
+      const status = window.locator(SEL.notifications.gridBarStatus);
+      await expect(status).toContainText("Building project", { timeout: T_MEDIUM });
+    });
+
+    test("holds the displayed notification through its dwell floor", async () => {
+      const { window } = ctx;
+      await injectGridNotification(window, { type: "info", message: "First grid event" });
+      const status = window.locator(SEL.notifications.gridBarStatus);
+      await expect(status).toContainText("First grid event", { timeout: T_MEDIUM });
+
+      // A higher-severity newcomer arriving inside the dwell floor must NOT
+      // preempt the in-read notification.
+      await injectGridNotification(window, {
+        type: "error",
+        priority: "watch",
+        message: "Second grid event",
+      });
+      await expect(status).toContainText("First grid event", { timeout: T_SHORT });
+      await expect(status).not.toContainText("Second grid event");
+    });
+
+    test("a higher-severity notification preempts once the dwell floor expires", async () => {
+      const { window } = ctx;
+      const firstId = await injectGridNotification(window, {
+        type: "info",
+        message: "Stale grid event",
+      });
+      const status = window.locator(SEL.notifications.gridBarStatus);
+      await expect(status).toContainText("Stale grid event", { timeout: T_MEDIUM });
+
+      // Backdate past the dwell floor so the lock is already expired, then a
+      // higher-severity newcomer can take the slot.
+      await backdateNotification(window, firstId, 6_000);
+      await injectGridNotification(window, {
+        type: "error",
+        priority: "watch",
+        message: "Fresh grid event",
+      });
+      await expect(status).toContainText("Fresh grid event", { timeout: T_MEDIUM });
+    });
+  });
+
+  // ── Global banner coordinator ─────────────────────────────
+
+  test.describe.serial("Global banner coordinator", () => {
+    test("safe-mode banner mounts and unmounts with store state", async () => {
+      const { window } = ctx;
+      await setSafeMode(window, true);
+      await expect(window.getByText(/Safe mode/)).toBeVisible({ timeout: T_MEDIUM });
+
+      await setSafeMode(window, true, true); // dismissed
+      await expect(window.getByText(/Safe mode/)).not.toBeVisible({ timeout: T_MEDIUM });
+    });
+
+    test("restore-confirmation banner mounts when visible", async () => {
+      const { window } = ctx;
+      await setRestoreConfirmation(window, true);
+      await expect(window.getByText(/Session recovered/)).toBeVisible({ timeout: T_MEDIUM });
+    });
+
+    test("renders only the highest-priority banner when several are active", async () => {
+      const { window } = ctx;
+      // Safe-mode outranks restore-confirmation: only safe-mode shows.
+      await setSafeMode(window, true);
+      await setRestoreConfirmation(window, true);
+      await expect(window.getByText(/Safe mode/)).toBeVisible({ timeout: T_MEDIUM });
+      await expect(window.getByText(/Session recovered/)).not.toBeVisible();
+
+      // Clearing safe-mode hands the slot to the next-highest active banner.
+      await setSafeMode(window, false);
+      await expect(window.getByText(/Session recovered/)).toBeVisible({ timeout: T_MEDIUM });
+      await expect(window.getByText(/Safe mode/)).not.toBeVisible();
+    });
+
+    test("watchdog-disabled outranks safe-mode", async () => {
+      const { window } = ctx;
+      await setSafeMode(window, true);
+      await setWatchdogStatus(window, "disabled");
+      await expect(window.getByText(/Crash watchdog disabled/)).toBeVisible({ timeout: T_MEDIUM });
+      await expect(window.getByText(/Safe mode/)).not.toBeVisible();
+    });
+
+    test("host-crash banner appears on backend disconnect and clears on reconnect", async () => {
+      const { window } = ctx;
+      await setBackendStatus(window, "disconnected");
+      const banner = window.getByRole("alert").filter({ hasText: /Terminal service/ });
+      await expect(banner).toBeVisible({ timeout: T_MEDIUM });
+
+      await setBackendStatus(window, "connected");
+      await expect(banner).not.toBeVisible({ timeout: T_MEDIUM });
+    });
+  });
+});

--- a/e2e/full/panels/notification-grid-banners.spec.ts
+++ b/e2e/full/panels/notification-grid-banners.spec.ts
@@ -9,6 +9,7 @@ import { T_SHORT, T_MEDIUM } from "../../helpers/timeouts";
 import {
   injectGridNotification,
   backdateNotification,
+  getGridBarDwellFloorMs,
   resetNotifications,
   setBackendStatus,
   setWatchdogStatus,
@@ -93,8 +94,10 @@ test.describe.serial("Panels: Grid-bar & global banners", () => {
       await expect(status).toContainText("Stale grid event", { timeout: T_MEDIUM });
 
       // Backdate past the dwell floor so the lock is already expired, then a
-      // higher-severity newcomer can take the slot.
-      await backdateNotification(window, firstId, 6_000);
+      // higher-severity newcomer can take the slot. Read the floor from the
+      // store constant so the test tracks it if the value changes.
+      const dwellFloorMs = await getGridBarDwellFloorMs(window);
+      await backdateNotification(window, firstId, dwellFloorMs + 1_000);
       await injectGridNotification(window, {
         type: "error",
         priority: "watch",

--- a/e2e/full/panels/notification-toasts.spec.ts
+++ b/e2e/full/panels/notification-toasts.spec.ts
@@ -1,0 +1,191 @@
+import { test, expect } from "@playwright/test";
+import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
+import { SEL } from "../../helpers/selectors";
+import { T_SHORT, T_MEDIUM } from "../../helpers/timeouts";
+import {
+  injectToast,
+  injectHistoryEntry,
+  resetNotifications,
+  getMaxVisibleToasts,
+} from "../../helpers/notifications";
+
+// E2E coverage for the toast surface (`src/components/ui/toaster.tsx`). Drives
+// the notification store directly via the gated backdoor
+// (`src/lib/e2eNotificationBackdoor.ts`) so each toast's type/duration/action is
+// fully controlled — no priority routing or focus gating. Timing-dependent
+// behavior (auto-dismiss, success dwell) uses short real durations + auto-
+// retrying `expect`, never `page.clock` (which can't retro-control the booted
+// renderer's already-registered timers).
+
+let ctx: AppContext;
+
+test.describe.serial("Panels: Notification toasts", () => {
+  test.beforeAll(async () => {
+    ctx = await launchApp();
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+  });
+
+  test.beforeEach(async () => {
+    await resetNotifications(ctx.window);
+  });
+
+  test("toast region exposes the labelled live-region landmark", async () => {
+    const { window } = ctx;
+    await injectToast(window, { type: "info", message: "Region landmark check" });
+
+    const region = window.locator(SEL.notifications.toastRegion);
+    await expect(region).toBeVisible({ timeout: T_MEDIUM });
+    await expect(region).toContainText("Region landmark check");
+  });
+
+  test("error toasts announce as alert, non-errors as status", async () => {
+    const { window } = ctx;
+    const region = window.locator(SEL.notifications.toastRegion);
+
+    await injectToast(window, { type: "error", message: "Boom" });
+    await expect(region.getByRole("alert")).toContainText("Boom", { timeout: T_MEDIUM });
+
+    await resetNotifications(window);
+
+    await injectToast(window, { type: "success", message: "All good" });
+    await expect(region.getByRole("status")).toContainText("All good", { timeout: T_MEDIUM });
+  });
+
+  test("close button dismisses the toast", async () => {
+    const { window } = ctx;
+    await injectToast(window, { type: "info", message: "Dismiss me", duration: 0 });
+
+    const region = window.locator(SEL.notifications.toastRegion);
+    await expect(region).toContainText("Dismiss me", { timeout: T_MEDIUM });
+
+    await window.locator(SEL.notifications.toastDismissButton).first().click();
+    await expect(region.getByText("Dismiss me")).not.toBeVisible({ timeout: T_MEDIUM });
+  });
+
+  test("auto-dismisses after its duration elapses", async () => {
+    const { window } = ctx;
+    await injectToast(window, { type: "info", message: "Fades away", duration: 300 });
+
+    const region = window.locator(SEL.notifications.toastRegion);
+    await expect(region.getByText("Fades away")).toBeVisible({ timeout: T_SHORT });
+    // Real-time auto-dismiss: the 300ms duration (×3 visible cap) elapses well
+    // within T_MEDIUM. No clock mock — the timer runs against the native clock.
+    await expect(region.getByText("Fades away")).not.toBeVisible({ timeout: T_MEDIUM });
+  });
+
+  test("hovering pauses the auto-dismiss timer", async () => {
+    const { window } = ctx;
+    await injectToast(window, { type: "info", message: "Sticky on hover", duration: 700 });
+
+    const region = window.locator(SEL.notifications.toastRegion);
+    const toast = region.getByText("Sticky on hover");
+    await expect(toast).toBeVisible({ timeout: T_SHORT });
+
+    // Park the cursor over the toast and confirm it outlives its 700ms duration.
+    await toast.hover();
+    await window.waitForTimeout(1500);
+    await expect(toast).toBeVisible();
+
+    // Move the cursor away — after the hover-grace window the timer resumes and
+    // the (now overdue) toast dismisses.
+    await window.mouse.move(5, 400);
+    await expect(toast).not.toBeVisible({ timeout: T_MEDIUM });
+  });
+
+  test("coalesces same-correlation toasts behind a count badge", async () => {
+    const { window } = ctx;
+    await injectToast(window, {
+      type: "info",
+      message: "First event",
+      correlationId: "coalesce-thread",
+      duration: 0,
+    });
+    await injectToast(window, {
+      type: "info",
+      message: "Second event",
+      correlationId: "coalesce-thread",
+      duration: 0,
+    });
+
+    const region = window.locator(SEL.notifications.toastRegion);
+    // Single merged toast showing the latest message and a count badge.
+    await expect(region.getByText("Second event")).toBeVisible({ timeout: T_MEDIUM });
+    const badge = window.locator(SEL.notifications.toastCoalesceBadge);
+    await expect(badge).toBeVisible({ timeout: T_SHORT });
+    await expect(badge).toContainText("2");
+  });
+
+  test("caps visible toasts and surfaces the overflow pill", async () => {
+    const { window } = ctx;
+    const max = await getMaxVisibleToasts(window);
+
+    // Each toast is linked to a (read) history entry so eviction increments the
+    // overflow counter that drives the pill.
+    for (let i = 0; i < max + 1; i++) {
+      const historyEntryId = await injectHistoryEntry(window, {
+        type: "info",
+        message: `Capped ${i}`,
+        seenAsToast: true,
+      });
+      await injectToast(window, {
+        type: "info",
+        message: `Capped ${i}`,
+        duration: 0,
+        historyEntryId,
+      });
+    }
+
+    const region = window.locator(SEL.notifications.toastRegion);
+    await expect(region.getByRole("status")).toHaveCount(max, { timeout: T_MEDIUM });
+    await expect(window.locator(SEL.notifications.toastOverflowPill)).toBeVisible({
+      timeout: T_MEDIUM,
+    });
+  });
+
+  test("async action button shows spinner then success confirmation", async () => {
+    const { window } = ctx;
+    await injectToast(window, {
+      type: "info",
+      message: "Pending op",
+      duration: 0,
+      actionLabel: "Retry",
+      successLabel: "Retried",
+      asyncAction: true,
+      asyncDelayMs: 800,
+    });
+
+    const region = window.locator(SEL.notifications.toastRegion);
+    await region.getByRole("button", { name: "Retry" }).click();
+
+    // 150ms after click the in-flight spinner appears (visible for the ~800ms op).
+    await expect(window.locator(SEL.notifications.toastActionSpinner)).toBeVisible({
+      timeout: T_SHORT,
+    });
+    // On resolve, the success flash swaps in the checkmark + past-tense label.
+    await expect(window.locator(SEL.notifications.toastActionCheckmark)).toBeVisible({
+      timeout: T_MEDIUM,
+    });
+    await expect(region).toContainText("Retried");
+  });
+
+  test("restores focus to the prior element after keyboard-driven dismiss", async () => {
+    const { window } = ctx;
+    // Anchor focus on a stable toolbar control before the toast mounts — the
+    // toast captures document.activeElement as its restore target on mount.
+    const sidebarToggle = window.locator(SEL.toolbar.toggleSidebar);
+    await sidebarToggle.focus();
+    await expect(sidebarToggle).toBeFocused();
+
+    await injectToast(window, { type: "info", message: "Focus return", duration: 0 });
+    const dismiss = window.locator(SEL.notifications.toastDismissButton).first();
+    await expect(dismiss).toBeVisible({ timeout: T_MEDIUM });
+
+    // Move focus into the toast, then dismiss — focus must return to the anchor.
+    await dismiss.focus();
+    await dismiss.click();
+    await expect(sidebarToggle).toBeFocused({ timeout: T_MEDIUM });
+  });
+});

--- a/e2e/helpers/notifications.ts
+++ b/e2e/helpers/notifications.ts
@@ -1,0 +1,209 @@
+import type { Page } from "@playwright/test";
+
+// Thin Playwright wrappers over the renderer-side notification backdoor exposed
+// by `src/lib/e2eNotificationBackdoor.ts` (gated on DAINTREE_E2E_MODE). Injection
+// goes straight at the store singletons so synthetic notifications are fully
+// deterministic — no priority routing, focus gating, or rate-limit interference.
+
+type NotificationType = "success" | "error" | "info" | "warning";
+type NotificationPriority = "high" | "low" | "watch";
+type NotificationPlacement = "toast" | "grid-bar";
+type BackendStatus = "connected" | "disconnected" | "recovering";
+type WatchdogStatus = "active" | "disabled";
+
+export interface InjectToastOptions {
+  type?: NotificationType;
+  message?: string;
+  title?: string;
+  priority?: NotificationPriority;
+  placement?: NotificationPlacement;
+  duration?: number;
+  correlationId?: string;
+  historyEntryId?: string;
+  actionLabel?: string;
+  successLabel?: string;
+  asyncAction?: boolean;
+  asyncDelayMs?: number;
+}
+
+export interface InjectHistoryOptions {
+  type?: NotificationType;
+  message?: string;
+  title?: string;
+  correlationId?: string;
+  seenAsToast?: boolean;
+}
+
+export async function injectToast(page: Page, opts: InjectToastOptions = {}): Promise<string> {
+  return page.evaluate((o) => {
+    const a = (
+      window as unknown as {
+        __daintreeNotificationsE2E?: { addToast: (input: unknown) => string };
+      }
+    ).__daintreeNotificationsE2E;
+    if (!a) throw new Error("__daintreeNotificationsE2E backdoor not attached");
+    return a.addToast({
+      type: o.type ?? "info",
+      message: o.message ?? "Test notification",
+      title: o.title,
+      priority: o.priority,
+      placement: o.placement,
+      duration: o.duration,
+      correlationId: o.correlationId,
+      historyEntryId: o.historyEntryId,
+      actionLabel: o.actionLabel,
+      successLabel: o.successLabel,
+      asyncAction: o.asyncAction,
+      asyncDelayMs: o.asyncDelayMs,
+    });
+  }, opts);
+}
+
+/** Injects a grid-bar notification (placement forced to "grid-bar"). */
+export async function injectGridNotification(
+  page: Page,
+  opts: InjectToastOptions = {}
+): Promise<string> {
+  return injectToast(page, { ...opts, placement: "grid-bar" });
+}
+
+/** Backdates a notification's firstShownAt by `ms` so the grid-bar dwell floor is already expired. */
+export async function backdateNotification(page: Page, id: string, ms: number): Promise<void> {
+  await page.evaluate(
+    ({ id, ms }) => {
+      const a = (
+        window as unknown as {
+          __daintreeNotificationsE2E?: { backdateNotification: (id: string, ts: number) => void };
+        }
+      ).__daintreeNotificationsE2E;
+      a?.backdateNotification(id, Date.now() - ms);
+    },
+    { id, ms }
+  );
+}
+
+export async function injectHistoryEntry(
+  page: Page,
+  opts: InjectHistoryOptions = {}
+): Promise<string> {
+  return page.evaluate((o) => {
+    const a = (
+      window as unknown as {
+        __daintreeNotificationsE2E?: { addHistoryEntry: (input: unknown) => string };
+      }
+    ).__daintreeNotificationsE2E;
+    if (!a) throw new Error("__daintreeNotificationsE2E backdoor not attached");
+    return a.addHistoryEntry({
+      type: o.type ?? "info",
+      message: o.message ?? "Test entry",
+      title: o.title,
+      correlationId: o.correlationId,
+      seenAsToast: o.seenAsToast,
+    });
+  }, opts);
+}
+
+export async function archiveHistoryEntry(page: Page, id: string): Promise<void> {
+  await page.evaluate((id) => {
+    (
+      window as unknown as {
+        __daintreeNotificationsE2E?: { archiveHistoryEntry: (id: string) => void };
+      }
+    ).__daintreeNotificationsE2E?.archiveHistoryEntry(id);
+  }, id);
+}
+
+export async function snoozeThread(
+  page: Page,
+  correlationId: string,
+  durationMs: number
+): Promise<void> {
+  await page.evaluate(
+    ({ correlationId, durationMs }) => {
+      (
+        window as unknown as {
+          __daintreeNotificationsE2E?: {
+            snoozeThread: (correlationId: string, until: number) => void;
+          };
+        }
+      ).__daintreeNotificationsE2E?.snoozeThread(correlationId, Date.now() + durationMs);
+    },
+    { correlationId, durationMs }
+  );
+}
+
+/** Full reset of all notification surfaces — call in beforeEach. */
+export async function resetNotifications(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const a = (
+      window as unknown as {
+        __daintreeNotificationsE2E?: {
+          resetToasts: () => void;
+          clearHistory: () => void;
+          resetNotifyInternals: () => void;
+          resetBanners: () => void;
+        };
+      }
+    ).__daintreeNotificationsE2E;
+    a?.resetToasts();
+    a?.clearHistory();
+    a?.resetNotifyInternals();
+    a?.resetBanners();
+  });
+}
+
+export async function setBackendStatus(page: Page, status: BackendStatus): Promise<void> {
+  await page.evaluate((status) => {
+    (
+      window as unknown as {
+        __daintreeNotificationsE2E?: { setBackendStatus: (s: string) => void };
+      }
+    ).__daintreeNotificationsE2E?.setBackendStatus(status);
+  }, status);
+}
+
+export async function setWatchdogStatus(page: Page, status: WatchdogStatus): Promise<void> {
+  await page.evaluate((status) => {
+    (
+      window as unknown as {
+        __daintreeNotificationsE2E?: { setWatchdogStatus: (s: string) => void };
+      }
+    ).__daintreeNotificationsE2E?.setWatchdogStatus(status);
+  }, status);
+}
+
+export async function setSafeMode(page: Page, safeMode: boolean, dismissed = false): Promise<void> {
+  await page.evaluate(
+    ({ safeMode, dismissed }) => {
+      (
+        window as unknown as {
+          __daintreeNotificationsE2E?: { setSafeMode: (s: boolean, d?: boolean) => void };
+        }
+      ).__daintreeNotificationsE2E?.setSafeMode(safeMode, dismissed);
+    },
+    { safeMode, dismissed }
+  );
+}
+
+export async function setRestoreConfirmation(page: Page, visible: boolean): Promise<void> {
+  await page.evaluate((visible) => {
+    (
+      window as unknown as {
+        __daintreeNotificationsE2E?: { setRestoreConfirmation: (v: boolean) => void };
+      }
+    ).__daintreeNotificationsE2E?.setRestoreConfirmation(visible);
+  }, visible);
+}
+
+/** Reads MAX_VISIBLE_TOASTS from the renderer so the test stays in sync with the store constant. */
+export async function getMaxVisibleToasts(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const a = (
+      window as unknown as {
+        __daintreeNotificationsE2E?: { MAX_VISIBLE_TOASTS: number };
+      }
+    ).__daintreeNotificationsE2E;
+    if (!a) throw new Error("__daintreeNotificationsE2E backdoor not attached");
+    return a.MAX_VISIBLE_TOASTS;
+  });
+}

--- a/e2e/helpers/notifications.ts
+++ b/e2e/helpers/notifications.ts
@@ -145,10 +145,13 @@ export async function resetNotifications(page: Page): Promise<void> {
         };
       }
     ).__daintreeNotificationsE2E;
-    a?.resetToasts();
-    a?.clearHistory();
-    a?.resetNotifyInternals();
-    a?.resetBanners();
+    // Throw on a missing backdoor so a misconfigured launch fails loudly in
+    // beforeEach instead of surfacing as a delayed positive-assertion timeout.
+    if (!a) throw new Error("__daintreeNotificationsE2E backdoor not attached");
+    a.resetToasts();
+    a.clearHistory();
+    a.resetNotifyInternals();
+    a.resetBanners();
   });
 }
 
@@ -205,5 +208,18 @@ export async function getMaxVisibleToasts(page: Page): Promise<number> {
     ).__daintreeNotificationsE2E;
     if (!a) throw new Error("__daintreeNotificationsE2E backdoor not attached");
     return a.MAX_VISIBLE_TOASTS;
+  });
+}
+
+/** Reads GRID_BAR_DWELL_FLOOR_MS from the renderer so dwell-floor tests track the store constant. */
+export async function getGridBarDwellFloorMs(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const a = (
+      window as unknown as {
+        __daintreeNotificationsE2E?: { GRID_BAR_DWELL_FLOOR_MS: number };
+      }
+    ).__daintreeNotificationsE2E;
+    if (!a) throw new Error("__daintreeNotificationsE2E backdoor not attached");
+    return a.GRID_BAR_DWELL_FLOOR_MS;
   });
 }

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -301,6 +301,23 @@ export const SEL = {
     emptyState: 'text="No notifications yet"',
     configureButton: 'button:has-text("Configure")',
     clearAllButton: 'button:has-text("Clear all")',
+    // Toast surfaces (toaster.tsx)
+    toastRegion: '[role="region"][aria-label="Notifications"]',
+    toastDismissButton: 'button[aria-label="Dismiss notification"]',
+    toastCoalesceBadge: '[data-testid="toast-coalesce-badge"]',
+    toastActionSpinner: '[data-testid="toast-action-spinner"]',
+    toastActionCheckmark: '[data-testid="toast-action-checkmark"]',
+    toastOverflowPill: '[data-testid="toast-overflow-pill"]',
+    // Grid-bar surface (GridNotificationBar.tsx)
+    gridBar: '[data-testid="grid-notification-bar"]',
+    gridBarStatus: '[data-testid="grid-notification-bar"] [role="status"]',
+    // Notification center (NotificationCenter.tsx)
+    centerList: '[role="list"][aria-label="Notifications"]',
+    centerRow: '[role="listitem"]',
+    centerFilter: (label: string) => `button[aria-pressed]:has-text("${label}")`,
+    markAllReadButton: 'button:has-text("Mark all read")',
+    mutedPill: '[data-testid="notification-muted-pill"]',
+    mutedEmptyState: '[data-testid="notification-muted-empty-state"]',
   },
   actionPalette: {
     dialog: '[role="dialog"][aria-label="Action palette"]',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,10 @@ import { usePluginBridge } from "./hooks/usePluginBridge";
 import { useFileDropGuard } from "./hooks/useFileDropGuard";
 import { useSoundPlaybackListener } from "./hooks/useSoundPlaybackListener";
 import { notifyViewPainted, removeStartupSkeleton } from "./utils/removeStartupSkeleton";
+// Side-effect import: attaches the notification E2E backdoor when launched with
+// DAINTREE_E2E_MODE=1. The module self-gates on `__DAINTREE_E2E_MODE__`, so this
+// is inert in production sessions.
+import "./lib/e2eNotificationBackdoor";
 import { useAppBoot } from "./hooks/app/useAppBoot";
 import { useCrashRecoveryGate } from "./hooks/app/useCrashRecoveryGate";
 import {

--- a/src/components/Terminal/GridNotificationBar.tsx
+++ b/src/components/Terminal/GridNotificationBar.tsx
@@ -242,6 +242,7 @@ export function GridNotificationBar({ className }: GridNotificationBarProps) {
 
   return (
     <div
+      data-testid="grid-notification-bar"
       className={cn(
         "grid-notification-wrapper shrink-0 overflow-hidden transition-[height,opacity]",
         isVisible

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -327,6 +327,7 @@ function Toast({ notification, isTopmost }: { notification: Notification; isTopm
               Number.isFinite(notification.count) &&
               notification.count > 1 && (
                 <span
+                  data-testid="toast-coalesce-badge"
                   aria-label={formatNotificationCountAriaLabel(notification.count)}
                   className={cn(
                     "shrink-0 rounded-full bg-tint/10 px-1.5 py-0.5 text-[10px] font-medium leading-none text-daintree-text/60 tabular-nums min-w-[3.5ch] text-center",
@@ -346,6 +347,7 @@ function Toast({ notification, isTopmost }: { notification: Notification; isTopm
           notification.count > 1 ? (
           <div>
             <span
+              data-testid="toast-coalesce-badge"
               aria-label={formatNotificationCountAriaLabel(notification.count)}
               className={cn(
                 "inline-block rounded-full bg-tint/10 px-1.5 py-0.5 text-[10px] font-medium leading-none text-daintree-text/60 tabular-nums min-w-[3.5ch] text-center",
@@ -481,12 +483,18 @@ function Toast({ notification, isTopmost }: { notification: Notification; isTopm
                     disabled={activeActionIndex !== null}
                   >
                     {isActive && showLoading ? (
-                      <span className="inline-flex items-center gap-1.5">
+                      <span
+                        data-testid="toast-action-spinner"
+                        className="inline-flex items-center gap-1.5"
+                      >
                         <Spinner size="xs" />
                         {action.label}
                       </span>
                     ) : isActive && isSuccess ? (
-                      <span className="inline-flex items-center gap-1">
+                      <span
+                        data-testid="toast-action-checkmark"
+                        className="inline-flex items-center gap-1"
+                      >
                         <Check className="h-3 w-3" />
                         {action.successLabel}
                       </span>

--- a/src/lib/e2eNotificationBackdoor.ts
+++ b/src/lib/e2eNotificationBackdoor.ts
@@ -1,0 +1,142 @@
+// E2E-only backdoor for driving the notification surfaces (toasts, grid-bar,
+// global recovery banners, notification center) from Playwright. Gated on the
+// preload-injected `__DAINTREE_E2E_MODE__` flag — mirrors the ActionService
+// dispatch backdoor at `src/services/ActionService.ts:710` — so the globals are
+// never attached in production sessions. Injection goes straight at the store
+// singletons rather than through `notify()`, keeping the synthetic events fully
+// deterministic (no priority routing, focus gating, or rate-limit interference).
+import {
+  MAX_VISIBLE_TOASTS,
+  GRID_BAR_DWELL_FLOOR_MS,
+  useNotificationStore,
+  type NotificationType,
+  type NotificationPriority,
+  type NotificationPlacement,
+} from "@/store/notificationStore";
+import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
+import {
+  _setQuietUntil,
+  _resetRateLimitBuckets,
+  _resetCoalesceMap,
+  _resetPendingSuppressedForTest,
+  _resetEscalationTrackers,
+} from "@/lib/notify";
+import { usePanelStore, type BackendStatus, type WatchdogStatus } from "@/store/panelStore";
+import { useSafeModeStore } from "@/store/safeModeStore";
+import { useRestoreConfirmationStore } from "@/store/restoreConfirmationStore";
+
+export interface E2EToastInput {
+  type: NotificationType;
+  message: string;
+  title?: string;
+  priority?: NotificationPriority;
+  placement?: NotificationPlacement;
+  /** ms; omit/0 for a sticky toast that never auto-dismisses. */
+  duration?: number;
+  correlationId?: string;
+  /** Links the toast to a history entry so eviction increments the overflow pill. */
+  historyEntryId?: string;
+  /** When set, renders an action button with this label. */
+  actionLabel?: string;
+  /** Past-tense confirmation label; enables the success-flash flow. */
+  successLabel?: string;
+  /** When true, the action's onClick resolves after `asyncDelayMs` (spinner path). */
+  asyncAction?: boolean;
+  asyncDelayMs?: number;
+}
+
+export interface E2EHistoryInput {
+  type: NotificationType;
+  message: string;
+  title?: string;
+  correlationId?: string;
+  /** Defaults to false (unread). Set true to seed a read entry. */
+  seenAsToast?: boolean;
+}
+
+export interface NotificationsE2EApi {
+  readonly MAX_VISIBLE_TOASTS: number;
+  readonly GRID_BAR_DWELL_FLOOR_MS: number;
+  addToast: (input: E2EToastInput) => string;
+  /** Directly overwrites `firstShownAt` on a grid-bar notification to drive dwell-floor expiry without a real wait. */
+  backdateNotification: (id: string, firstShownAt: number) => void;
+  resetToasts: () => void;
+  addHistoryEntry: (input: E2EHistoryInput) => string;
+  archiveHistoryEntry: (id: string) => void;
+  snoozeThread: (correlationId: string, snoozedUntil: number) => void;
+  clearHistory: () => void;
+  resetNotifyInternals: () => void;
+  setBackendStatus: (status: BackendStatus) => void;
+  setWatchdogStatus: (status: WatchdogStatus) => void;
+  setSafeMode: (safeMode: boolean, dismissed?: boolean) => void;
+  setRestoreConfirmation: (visible: boolean) => void;
+  resetBanners: () => void;
+}
+
+function buildApi(): NotificationsE2EApi {
+  return {
+    MAX_VISIBLE_TOASTS,
+    GRID_BAR_DWELL_FLOOR_MS,
+    addToast: (input) => {
+      const action = input.actionLabel
+        ? {
+            label: input.actionLabel,
+            successLabel: input.successLabel,
+            onClick: input.asyncAction
+              ? () => new Promise<void>((resolve) => setTimeout(resolve, input.asyncDelayMs ?? 300))
+              : () => {},
+          }
+        : undefined;
+      return useNotificationStore.getState().addNotification({
+        type: input.type,
+        message: input.message,
+        title: input.title,
+        priority: input.priority ?? "high",
+        placement: input.placement ?? "toast",
+        duration: input.duration,
+        correlationId: input.correlationId,
+        historyEntryId: input.historyEntryId,
+        action,
+      });
+    },
+    backdateNotification: (id, firstShownAt) => {
+      useNotificationStore.setState((state) => ({
+        notifications: state.notifications.map((n) => (n.id === id ? { ...n, firstShownAt } : n)),
+      }));
+    },
+    resetToasts: () => useNotificationStore.getState().reset(),
+    addHistoryEntry: (input) =>
+      useNotificationHistoryStore.getState().addEntry({
+        type: input.type,
+        message: input.message,
+        title: input.title,
+        correlationId: input.correlationId,
+        seenAsToast: input.seenAsToast ?? false,
+      }),
+    archiveHistoryEntry: (id) => useNotificationHistoryStore.getState().archiveEntry(id),
+    snoozeThread: (correlationId, snoozedUntil) =>
+      useNotificationHistoryStore.getState().snoozeThread(correlationId, snoozedUntil),
+    clearHistory: () => useNotificationHistoryStore.getState().clearAll(),
+    resetNotifyInternals: () => {
+      _resetRateLimitBuckets();
+      _resetCoalesceMap();
+      _resetPendingSuppressedForTest();
+      _resetEscalationTrackers();
+      _setQuietUntil(0);
+    },
+    setBackendStatus: (status) => usePanelStore.setState({ backendStatus: status }),
+    setWatchdogStatus: (status) => usePanelStore.setState({ watchdogStatus: status }),
+    setSafeMode: (safeMode, dismissed = false) =>
+      useSafeModeStore.setState({ safeMode, dismissed }),
+    setRestoreConfirmation: (visible) => useRestoreConfirmationStore.setState({ visible }),
+    resetBanners: () => {
+      usePanelStore.setState({ backendStatus: "connected", watchdogStatus: "active" });
+      useSafeModeStore.setState({ safeMode: false, dismissed: false });
+      useRestoreConfirmationStore.setState({ visible: false });
+    },
+  };
+}
+
+if (typeof window !== "undefined" && window.__DAINTREE_E2E_MODE__ === true) {
+  window.__daintreeNotificationsE2E = buildApi();
+}

--- a/src/lib/e2eNotificationBackdoor.ts
+++ b/src/lib/e2eNotificationBackdoor.ts
@@ -20,6 +20,7 @@ import {
   _resetCoalesceMap,
   _resetPendingSuppressedForTest,
   _resetEscalationTrackers,
+  _resetOverflowAnnouncements,
 } from "@/lib/notify";
 import { usePanelStore, type BackendStatus, type WatchdogStatus } from "@/store/panelStore";
 import { useSafeModeStore } from "@/store/safeModeStore";
@@ -122,6 +123,7 @@ function buildApi(): NotificationsE2EApi {
       _resetCoalesceMap();
       _resetPendingSuppressedForTest();
       _resetEscalationTrackers();
+      _resetOverflowAnnouncements();
       _setQuietUntil(0);
     },
     setBackendStatus: (status) => usePanelStore.setState({ backendStatus: status }),
@@ -131,7 +133,16 @@ function buildApi(): NotificationsE2EApi {
     setRestoreConfirmation: (visible) => useRestoreConfirmationStore.setState({ visible }),
     resetBanners: () => {
       usePanelStore.setState({ backendStatus: "connected", watchdogStatus: "active" });
-      useSafeModeStore.setState({ safeMode: false, dismissed: false });
+      // Clear the full safe-mode shape (not just safeMode/dismissed) so a prior
+      // test's crash metadata can't leak into a later SafeModeBanner render.
+      useSafeModeStore.setState({
+        safeMode: false,
+        dismissed: false,
+        crashCount: undefined,
+        skippedPanelCount: undefined,
+        lastCrashAt: undefined,
+        quarantinedPanels: undefined,
+      });
       useRestoreConfirmationStore.setState({ visible: false });
     },
   };

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -8,6 +8,7 @@ import type {
   CreateWorktreeOptions,
   TerminalInfoPayload,
 } from "@shared/types";
+import type { NotificationsE2EApi } from "@/lib/e2eNotificationBackdoor";
 
 declare global {
   interface Window {
@@ -37,6 +38,8 @@ declare global {
       args?: unknown,
       options?: { source?: string; confirmed?: boolean }
     ) => unknown;
+    /** E2E-only notification driver, attached by `src/lib/e2eNotificationBackdoor.ts` under DAINTREE_E2E_MODE. */
+    __daintreeNotificationsE2E?: NotificationsE2EApi;
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds Playwright E2E specs in `e2e/full/panels/` covering the full notification surface stack: toast lifecycle, grid-bar single-slot arbitration and preemption, `GlobalBannerCoordinator` cascade and precedence (including host-crash lifecycle), and notification center filtering and mark-all-read.
- Backed by a new renderer backdoor (`src/lib/e2eNotificationBackdoor.ts`) self-gated on `__DAINTREE_E2E_MODE__` with no preload surface, plus a Playwright helper at `e2e/helpers/notifications.ts`.
- Minimal footprint on production code: a few `data-testid` additions to `toaster.tsx` and `GridNotificationBar.tsx`, and append-only additions to `e2e/helpers/selectors.ts`.

Resolves #9591

## Changes

- `e2e/full/panels/notification-toasts.spec.ts` — toast region role, auto-dismiss, manual close, coalesce badge, pause-on-hover, async action spinner/success flow
- `e2e/full/panels/notification-grid-banners.spec.ts` — single-slot selection, preemption, 5s dwell-floor
- `e2e/full/panels/notification-center.spec.ts` — filter tabs (All/Unread/Archived), mark-all-read
- `e2e/helpers/notifications.ts` — shared Playwright helpers for injecting and observing notifications
- `src/lib/e2eNotificationBackdoor.ts` — renderer-side backdoor, dead in production (`__DAINTREE_E2E_MODE__` guard), no IPC/preload surface

Quiet-hours, per-source rate-limiting, and active-context-suppression internals are out of scope here — they're unit-test-covered and have no distinctive observable DOM to hook into.

## Testing

Local E2E was blocked by a missing Electron binary in the worktree `node_modules`. Relying on CI `full-panels` to verify. All three new spec files sit in the existing `full-panels` bucket and need no project config changes.