### PR TITLE
test(resilience): add e2e coverage for adaptive recovery and multi-window isolation

### DIFF
--- a/e2e/full/resilience/adaptive-recovery.spec.ts
+++ b/e2e/full/resilience/adaptive-recovery.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from "@playwright/test";
+import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
+import { createFixtureRepos } from "../../helpers/fixtures";
+import { openAndOnboardProject } from "../../helpers/project";
+import { T_LONG } from "../../helpers/timeouts";
+
+// Exercises ResourceProfileService's adaptive transitions under SYNTHETIC
+// pressure. The service normally moves balanced ⇄ performance ⇄ efficiency off
+// real memory/thermal/event-loop signals — CI can't reproduce those reliably,
+// so the fault-mode hook `__daintreeForceResourceProfile` drives `applyProfile`
+// directly. The observable side-effect is the per-profile low-memory floor that
+// `applyProfile` fans out to every window's ProjectViewManager, read back via
+// the existing `__daintreeGetPvm` accessor. Values mirror RESOURCE_PROFILE_CONFIGS
+// (shared/types/resourceProfile.ts): performance→null, balanced→768, efficiency→1024.
+
+let ctx: AppContext;
+let fixtureCleanups: Array<() => void> = [];
+
+type ResourceProfile = "performance" | "balanced" | "efficiency";
+
+async function forceProfile(app: AppContext["app"], profile: ResourceProfile): Promise<void> {
+  await app.evaluate((_electron, p) => {
+    const g = globalThis as Record<string, unknown>;
+    const force = g.__daintreeForceResourceProfile as ((x: string) => void) | undefined;
+    if (!force) throw new Error("__daintreeForceResourceProfile not present");
+    force(p);
+  }, profile);
+}
+
+async function readLowMemoryFloor(app: AppContext["app"]): Promise<number | null> {
+  return app.evaluate(() => {
+    const g = globalThis as Record<string, unknown>;
+    const getPvm = g.__daintreeGetPvm as (() => unknown) | undefined;
+    const pvm = getPvm?.() as
+      | { getLowMemoryFreeThresholdMb: () => number | null }
+      | null
+      | undefined;
+    return pvm?.getLowMemoryFreeThresholdMb() ?? null;
+  });
+}
+
+// The ResourceProfileService is created by a deferred init task, so the hook may
+// throw until it settles. Poll the first force call until it lands, then assert.
+async function waitUntilProfileForceable(app: AppContext["app"]): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        try {
+          await forceProfile(app, "balanced");
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      { timeout: T_LONG, intervals: [200, 400, 800] }
+    )
+    .toBe(true);
+}
+
+test.describe.serial("Resilience: adaptive resource-profile recovery", () => {
+  test.beforeAll(async () => {
+    test.setTimeout(180_000);
+    const [repo] = createFixtureRepos(1);
+    fixtureCleanups = [repo.cleanup];
+    ctx = await launchApp({ env: { DAINTREE_E2E_FAULT_MODE: "1" } });
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "adaptive-project");
+    await waitUntilProfileForceable(ctx.app);
+  });
+
+  test.afterAll(async () => {
+    // Restore the default profile so a leaked efficiency floor doesn't bleed
+    // into any later spec sharing the runner.
+    if (ctx?.app) {
+      await forceProfile(ctx.app, "balanced").catch(() => undefined);
+      await closeApp(ctx.app);
+    }
+    for (const cleanup of fixtureCleanups) cleanup();
+  });
+
+  test("efficiency entry arms the low-memory floor on the active window's PVM", async () => {
+    await forceProfile(ctx.app, "efficiency");
+    expect(await readLowMemoryFloor(ctx.app)).toBe(1024);
+  });
+
+  test("upgrading out of efficiency releases the stricter floor", async () => {
+    // efficiency → performance must clear the floor entirely (null), proving the
+    // exit branch in applyProfile runs and isn't left stuck at the strict value.
+    await forceProfile(ctx.app, "efficiency");
+    expect(await readLowMemoryFloor(ctx.app)).toBe(1024);
+
+    await forceProfile(ctx.app, "performance");
+    expect(await readLowMemoryFloor(ctx.app)).toBeNull();
+  });
+
+  test("each profile pushes its own configured floor", async () => {
+    await forceProfile(ctx.app, "balanced");
+    expect(await readLowMemoryFloor(ctx.app)).toBe(768);
+
+    await forceProfile(ctx.app, "performance");
+    expect(await readLowMemoryFloor(ctx.app)).toBeNull();
+
+    await forceProfile(ctx.app, "efficiency");
+    expect(await readLowMemoryFloor(ctx.app)).toBe(1024);
+  });
+});

--- a/e2e/full/resilience/multi-window-isolation.spec.ts
+++ b/e2e/full/resilience/multi-window-isolation.spec.ts
@@ -1,0 +1,144 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- window globals are untyped in Playwright evaluate() */
+import { test, expect, type Page } from "@playwright/test";
+import {
+  launchApp,
+  closeApp,
+  openSecondWindow,
+  getWindowPage,
+  type AppContext,
+} from "../../helpers/launch";
+import { createFixtureRepos } from "../../helpers/fixtures";
+import { openAndOnboardProject } from "../../helpers/project";
+import { SEL } from "../../helpers/selectors";
+import { T_LONG } from "../../helpers/timeouts";
+
+// Verifies per-window store isolation. Each project opens in its own
+// WebContentsView with an independent V8 context, so the renderer Zustand
+// singletons (errorStore, diagnosticsStore, perfMetricsStore,
+// performanceModeStore) are per-window — a mutation in one window must not leak
+// into another. The contrast case is the watchdog-disabled broadcast, which is
+// INTENTIONALLY shared: it reaches every window via an EVENTS_PUSH fan-out, not
+// module-level state, so seeing it in both windows is correct, not a leak.
+
+let ctx: AppContext;
+let pageA: Page;
+let pageB: Page;
+let fixtureCleanups: Array<() => void> = [];
+
+async function waitForE2EAccessors(page: Page): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          () =>
+            typeof (window as any).__DAINTREE_E2E_PERF_MODE_STATE__ === "function" &&
+            typeof (window as any).__DAINTREE_E2E_DIAGNOSTICS_STATE__ === "function"
+        ),
+      { timeout: T_LONG, intervals: [200, 400, 800] }
+    )
+    .toBe(true);
+}
+
+test.describe.serial("Resilience: multi-window store isolation", () => {
+  test.beforeAll(async () => {
+    test.setTimeout(300_000);
+    const fixtures = createFixtureRepos(2);
+    fixtureCleanups = fixtures.map((f) => f.cleanup);
+    const [repoA, repoB] = fixtures.map((f) => f.dir);
+
+    ctx = await launchApp({ env: { DAINTREE_E2E_FAULT_MODE: "1" } });
+    pageA = await openAndOnboardProject(ctx.app, ctx.window, repoA, "window-A");
+    ctx.window = pageA;
+
+    const handle = await openSecondWindow(ctx.app, pageA, { projectPath: repoB });
+    pageB = await getWindowPage(ctx.app, handle.windowId);
+
+    await waitForE2EAccessors(pageA);
+    await waitForE2EAccessors(pageB);
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    for (const cleanup of fixtureCleanups) cleanup();
+  });
+
+  test("errorStore mutations stay scoped to the originating window", async () => {
+    await pageA.evaluate(() => (window as any).__DAINTREE_E2E_CLEAR_ERRORS__?.());
+    await pageB.evaluate(() => (window as any).__DAINTREE_E2E_CLEAR_ERRORS__?.());
+
+    await pageA.evaluate(() => (window as any).__DAINTREE_E2E_ADD_ERROR__?.("isolation-probe-A"));
+
+    const aErrors = await pageA.evaluate(
+      () => (window as any).__DAINTREE_E2E_ERROR_STORE__?.() ?? []
+    );
+    const bErrors = await pageB.evaluate(
+      () => (window as any).__DAINTREE_E2E_ERROR_STORE__?.() ?? []
+    );
+
+    expect(aErrors.some((e: { message: string }) => e.message === "isolation-probe-A")).toBe(true);
+    expect(bErrors.some((e: { message: string }) => e.message === "isolation-probe-A")).toBe(false);
+  });
+
+  test("diagnostics dock open state is scoped to the originating window", async () => {
+    await pageA.evaluate(() => (window as any).__DAINTREE_E2E_OPEN_DIAGNOSTICS__?.());
+
+    const aOpen = await pageA.evaluate(
+      () => (window as any).__DAINTREE_E2E_DIAGNOSTICS_STATE__?.().isOpen ?? null
+    );
+    const bOpen = await pageB.evaluate(
+      () => (window as any).__DAINTREE_E2E_DIAGNOSTICS_STATE__?.().isOpen ?? null
+    );
+
+    expect(aOpen).toBe(true);
+    expect(bOpen).toBe(false);
+  });
+
+  test("perfMetricsStore live metrics are scoped to the originating window", async () => {
+    await pageA.evaluate(() => (window as any).__DAINTREE_E2E_SET_PERF_METRIC__?.(42));
+
+    const aFps = await pageA.evaluate(
+      () => (window as any).__DAINTREE_E2E_PERF_METRICS_STATE__?.().fps ?? null
+    );
+    const bFps = await pageB.evaluate(
+      () => (window as any).__DAINTREE_E2E_PERF_METRICS_STATE__?.().fps ?? null
+    );
+
+    expect(aFps).toBe(42);
+    expect(bFps).not.toBe(42);
+  });
+
+  test("performance-mode toggle is scoped to the originating window", async () => {
+    await pageA.evaluate(() => (window as any).__DAINTREE_E2E_SET_PERF_MODE__?.(true));
+
+    const aMode = await pageA.evaluate(
+      () => (window as any).__DAINTREE_E2E_PERF_MODE_STATE__?.().performanceMode ?? null
+    );
+    const bMode = await pageB.evaluate(
+      () => (window as any).__DAINTREE_E2E_PERF_MODE_STATE__?.().performanceMode ?? null
+    );
+
+    expect(aMode).toBe(true);
+    expect(bMode).toBe(false);
+  });
+
+  test("watchdog-disabled is intentionally broadcast to every window", async () => {
+    // The contrast case: a genuinely app-wide signal must reach BOTH windows.
+    // This is fan-out via EVENTS_PUSH, not leaked module state — so seeing the
+    // banner in both windows is the correct behavior, the inverse of the
+    // per-window store assertions above.
+    await ctx.app.evaluate(() => {
+      const fn = (globalThis as Record<string, unknown>).__daintreeSimulateWatchdogDisabled as
+        | (() => void)
+        | undefined;
+      if (!fn) throw new Error("__daintreeSimulateWatchdogDisabled not present");
+      fn();
+    });
+
+    await expect(pageA.locator(SEL.recovery.watchdogDisabledBanner)).toBeVisible({
+      timeout: T_LONG,
+    });
+    await expect(pageB.locator(SEL.recovery.watchdogDisabledBanner)).toBeVisible({
+      timeout: T_LONG,
+    });
+  });
+});

--- a/e2e/full/resilience/watchdog-disabled-restart.spec.ts
+++ b/e2e/full/resilience/watchdog-disabled-restart.spec.ts
@@ -60,12 +60,14 @@ test.describe.serial("Resilience: watchdog disabled banner + restart", () => {
     await expect(banner).toBeVisible({ timeout: T_LONG });
   });
 
-  test("the disabled banner exposes a single recovery action", async () => {
-    // The banner is already visible from the prior test (serial). Title-Message-
-    // Action: exactly one actionable button, no "Dismiss".
-    await expect(ctx.window.locator(SEL.recovery.watchdogDisabledBanner)).toBeVisible({
-      timeout: T_SHORT,
-    });
+  test("the disabled banner exposes exactly one recovery action", async () => {
+    // Self-contained: re-arm the banner so this test passes in isolation too.
+    await simulateWatchdogDisabled(ctx.app);
+    const banner = ctx.window.locator(SEL.recovery.watchdogDisabledBanner);
+    await expect(banner).toBeVisible({ timeout: T_LONG });
+
+    // Title-Message-Action: a single contextual button, no "Dismiss".
+    await expect(banner.locator("button")).toHaveCount(1, { timeout: T_SHORT });
     await expect(ctx.window.locator(SEL.recovery.watchdogRestartButton)).toBeVisible({
       timeout: T_SHORT,
     });

--- a/e2e/full/resilience/watchdog-disabled-restart.spec.ts
+++ b/e2e/full/resilience/watchdog-disabled-restart.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from "@playwright/test";
+import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
+import { createFixtureRepos } from "../../helpers/fixtures";
+import { openAndOnboardProject } from "../../helpers/project";
+import { SEL } from "../../helpers/selectors";
+import { T_LONG, T_SHORT } from "../../helpers/timeouts";
+
+// Exercises the watchdog cap-hit → disabled-banner → manual-restart → re-arm
+// cycle. The real path requires three genuine watchdog-host crashes inside the
+// rapid-crash window; the fault-mode hook `__daintreeSimulateWatchdogDisabled`
+// fires the same `notifyDisabled()` → `watchdog:disabled` broadcast instead.
+// The banner (`WatchdogDisabledBanner`, role="alert") then drives the real
+// `watchdog.restart` action, which broadcasts `watchdog:active` and resets the
+// once-per-cycle `disabledNotified` guard so a second cap-hit can re-fire.
+
+let ctx: AppContext;
+let fixtureCleanups: Array<() => void> = [];
+
+async function simulateWatchdogDisabled(app: AppContext["app"]): Promise<void> {
+  await app.evaluate(() => {
+    const g = globalThis as Record<string, unknown>;
+    const fn = g.__daintreeSimulateWatchdogDisabled as (() => void) | undefined;
+    if (!fn) throw new Error("__daintreeSimulateWatchdogDisabled not present");
+    fn();
+  });
+}
+
+test.describe.serial("Resilience: watchdog disabled banner + restart", () => {
+  test.beforeAll(async () => {
+    test.setTimeout(180_000);
+    const [repo] = createFixtureRepos(1);
+    fixtureCleanups = [repo.cleanup];
+    ctx = await launchApp({ env: { DAINTREE_E2E_FAULT_MODE: "1" } });
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "watchdog-project");
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    for (const cleanup of fixtureCleanups) cleanup();
+  });
+
+  test("disabled signal surfaces the banner, restart clears it, and a second signal re-fires", async () => {
+    const banner = ctx.window.locator(SEL.recovery.watchdogDisabledBanner);
+
+    // 1. Synthetic cap-hit → banner appears (IPC push + render).
+    await simulateWatchdogDisabled(ctx.app);
+    await expect(banner).toBeVisible({ timeout: T_LONG });
+
+    // 2. Restart via the banner's own action. This dispatches `watchdog.restart`
+    //    (re-wires the broadcast, calls client.restart(), broadcasts
+    //    `watchdog:active`) so the banner clears.
+    await ctx.window.locator(SEL.recovery.watchdogRestartButton).click();
+    await expect(banner).toBeHidden({ timeout: T_LONG });
+
+    // 3. A second synthetic cap-hit must re-fire — proving restart() reset the
+    //    once-per-cycle `disabledNotified` guard. Without the reset the
+    //    notifyDisabled() short-circuit would swallow this and the banner would
+    //    never reappear.
+    await simulateWatchdogDisabled(ctx.app);
+    await expect(banner).toBeVisible({ timeout: T_LONG });
+  });
+
+  test("the disabled banner exposes a single recovery action", async () => {
+    // The banner is already visible from the prior test (serial). Title-Message-
+    // Action: exactly one actionable button, no "Dismiss".
+    await expect(ctx.window.locator(SEL.recovery.watchdogDisabledBanner)).toBeVisible({
+      timeout: T_SHORT,
+    });
+    await expect(ctx.window.locator(SEL.recovery.watchdogRestartButton)).toBeVisible({
+      timeout: T_SHORT,
+    });
+  });
+});

--- a/e2e/full/resilience/worktree-portbroker-recovery.spec.ts
+++ b/e2e/full/resilience/worktree-portbroker-recovery.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from "@playwright/test";
+import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
+import { createFixtureRepos } from "../../helpers/fixtures";
+import { openAndOnboardProject } from "../../helpers/project";
+import { T_LONG } from "../../helpers/timeouts";
+
+// Exercises WorktreePortBroker recovery after a workspace-host crash. Killing
+// the host's UtilityProcess (`__daintreeCrashWorkspaceHostForWindow`) drives the
+// real exit → auto-restart → `host-restarted` → `reBrokerForHost` path wired in
+// windowServices.ts. The view must end up with a live MessagePort again, and the
+// per-port webContents listeners (`did-start-navigation`, `destroyed`,
+// port-close) must NOT accumulate across the crash — `closePortsForView` runs
+// `cleanupListeners()` before each re-broker, so the count returns to baseline.
+
+let ctx: AppContext;
+let fixtureCleanups: Array<() => void> = [];
+
+async function getWindowId(app: AppContext["app"]): Promise<number> {
+  const id = await app.evaluate(({ BrowserWindow }) => {
+    const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed());
+    return win?.id ?? null;
+  });
+  if (id === null) throw new Error("No BrowserWindow found");
+  return id;
+}
+
+// Find the webContents id the broker actually holds a port for, rather than
+// assuming the active view's id — the initial broker target (`appWc` in
+// windowServices.ts) is the safest source of truth across the WebContentsView
+// architecture.
+async function findPortedWebContentsId(app: AppContext["app"]): Promise<number | null> {
+  return app.evaluate(() => {
+    const g = globalThis as Record<string, unknown>;
+    const getPvm = g.__daintreeGetPvm as (() => unknown) | undefined;
+    const has = g.__daintreeWorktreeHasPort as ((id: number) => boolean) | undefined;
+    const pvm = getPvm?.() as { getAllWebContentsIds?: () => number[] } | null | undefined;
+    if (!pvm?.getAllWebContentsIds || !has) return null;
+    for (const id of pvm.getAllWebContentsIds()) {
+      if (has(id)) return id;
+    }
+    return null;
+  });
+}
+
+async function hasPort(app: AppContext["app"], wcId: number): Promise<boolean> {
+  return app.evaluate((_electron, id) => {
+    const g = globalThis as Record<string, unknown>;
+    const fn = g.__daintreeWorktreeHasPort as ((x: number) => boolean) | undefined;
+    if (!fn) throw new Error("__daintreeWorktreeHasPort not present");
+    return fn(id);
+  }, wcId);
+}
+
+async function navigationListenerCount(app: AppContext["app"], wcId: number): Promise<number> {
+  return app.evaluate(({ webContents }, id) => {
+    const wc = webContents.fromId(id);
+    return wc && !wc.isDestroyed() ? wc.listenerCount("did-start-navigation") : -1;
+  }, wcId);
+}
+
+async function crashWorkspaceHost(app: AppContext["app"], windowId: number): Promise<boolean> {
+  return app.evaluate((_electron, id) => {
+    const g = globalThis as Record<string, unknown>;
+    const fn = g.__daintreeCrashWorkspaceHostForWindow as ((x: number) => boolean) | undefined;
+    if (!fn) throw new Error("__daintreeCrashWorkspaceHostForWindow not present");
+    return fn(id);
+  }, windowId);
+}
+
+test.describe.serial("Resilience: worktree port broker recovery after host crash", () => {
+  test.beforeAll(async () => {
+    test.setTimeout(180_000);
+    const [repo] = createFixtureRepos(1);
+    fixtureCleanups = [repo.cleanup];
+    ctx = await launchApp({ env: { DAINTREE_E2E_FAULT_MODE: "1" } });
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "portbroker-project");
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    for (const cleanup of fixtureCleanups) cleanup();
+  });
+
+  test("the active view keeps a live port and stable listeners across a host crash", async () => {
+    test.slow();
+    const windowId = await getWindowId(ctx.app);
+
+    // The port is brokered when the view attaches to its host — poll until a
+    // ported view appears, then pin that wcId for the rest of the test.
+    await expect.poll(() => findPortedWebContentsId(ctx.app), { timeout: T_LONG }).not.toBeNull();
+    const wcId = (await findPortedWebContentsId(ctx.app))!;
+
+    expect(await hasPort(ctx.app, wcId)).toBe(true);
+    const baselineListeners = await navigationListenerCount(ctx.app, wcId);
+    expect(baselineListeners).toBeGreaterThanOrEqual(1);
+
+    // Crash the workspace host's UtilityProcess.
+    expect(await crashWorkspaceHost(ctx.app, windowId)).toBe(true);
+
+    // After auto-restart + host-restarted, the broker re-establishes a port for
+    // the same view. The renderer is unchanged (same wcId), so the worktree
+    // store re-hydrates over the fresh port rather than staying stale.
+    await expect.poll(() => hasPort(ctx.app, wcId), { timeout: T_LONG }).toBe(true);
+
+    // No listener accumulation: each re-broker removes the prior view's
+    // listeners before attaching new ones, so the count must not climb.
+    const afterListeners = await navigationListenerCount(ctx.app, wcId);
+    expect(afterListeners).toBeLessThanOrEqual(baselineListeners);
+
+    // A second crash must recover identically — proving the recovery path is
+    // repeatable and not a one-shot.
+    expect(await crashWorkspaceHost(ctx.app, windowId)).toBe(true);
+    await expect.poll(() => hasPort(ctx.app, wcId), { timeout: T_LONG }).toBe(true);
+    expect(await navigationListenerCount(ctx.app, wcId)).toBeLessThanOrEqual(baselineListeners);
+  });
+
+  test("the sidebar worktree list survives the recovery", async () => {
+    // Re-hydration is observable in the UI: the worktree the fixture repo seeds
+    // is still listed after the crashes above (the store re-fetched over the
+    // re-brokered port instead of being stuck on a loading skeleton).
+    await expect(
+      ctx.window
+        .locator(
+          '[data-worktree-branch], [data-worktree-is-main="true"], [aria-label="Worktrees"] a, .worktree-item'
+        )
+        .first()
+    ).toBeVisible({ timeout: T_LONG });
+  });
+});

--- a/e2e/full/resilience/worktree-portbroker-recovery.spec.ts
+++ b/e2e/full/resilience/worktree-portbroker-recovery.spec.ts
@@ -94,12 +94,17 @@ test.describe.serial("Resilience: worktree port broker recovery after host crash
     const baselineListeners = await navigationListenerCount(ctx.app, wcId);
     expect(baselineListeners).toBeGreaterThanOrEqual(1);
 
-    // Crash the workspace host's UtilityProcess.
+    // Crash the workspace host's UtilityProcess. A `true` return proves a live
+    // child existed and was killed — so the recovery poll below is exercised
+    // against a genuine crash, not a no-op.
     expect(await crashWorkspaceHost(ctx.app, windowId)).toBe(true);
 
     // After auto-restart + host-restarted, the broker re-establishes a port for
     // the same view. The renderer is unchanged (same wcId), so the worktree
-    // store re-hydrates over the fresh port rather than staying stale.
+    // store re-hydrates over the fresh port rather than staying stale. We assert
+    // the recovered end-state (port present) rather than the transient gap — the
+    // host-restarted re-broker path keeps the view's map entry across the crash,
+    // so `hasPort` may never observably dip to false in between.
     await expect.poll(() => hasPort(ctx.app, wcId), { timeout: T_LONG }).toBe(true);
 
     // No listener accumulation: each re-broker removes the prior view's

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -518,4 +518,8 @@ export const SEL = {
     toggleButton: "[data-getting-started-checklist] button[aria-expanded]",
     item: (id: string) => `[data-checklist-item="${id}"]`,
   },
+  recovery: {
+    watchdogDisabledBanner: '[role="alert"]:has-text("Crash watchdog disabled")',
+    watchdogRestartButton: 'button:has-text("Restart watchdog")',
+  },
 } as const;

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -370,6 +370,25 @@ if (!gotTheLock) {
         nodeV8.writeHeapSnapshot(filePath);
     }
 
+    // E2E hook: crash a window's workspace host to exercise the
+    // WorktreePortBroker teardown → host auto-restart → port re-broker path
+    // (#9599). Resolved lazily so the workspace client need not exist at
+    // registration time. Gated on DAINTREE_E2E_FAULT_MODE — stricter than the
+    // PVM accessor above — so this crash seam never ships in production.
+    if (process.env.DAINTREE_E2E_FAULT_MODE === "1") {
+      (globalThis as Record<string, unknown>).__daintreeCrashWorkspaceHostForWindow = (
+        windowId: number
+      ): boolean => {
+        const host = getWorkspaceClientRef()?.getHostForWindow(windowId);
+        return host?._crashForTesting() ?? false;
+      };
+      (globalThis as Record<string, unknown>).__daintreeWorktreeHasPort = (
+        webContentsId: number
+      ): boolean => {
+        return getWorktreePortBrokerRef()?.hasPort(webContentsId) ?? false;
+      };
+    }
+
     // Clean up ProjectViewManager when the window's cleanup runs.
     // Registered before setupWindowServices so pvm.dispose() runs first —
     // views must close before per-window ports/event-buffer disconnect.

--- a/electron/services/MainProcessWatchdogClient.ts
+++ b/electron/services/MainProcessWatchdogClient.ts
@@ -377,6 +377,17 @@ export class MainProcessWatchdogClient {
     this.startHost();
   }
 
+  /**
+   * E2E seam: fire the disabled-notification path (telemetry + the `onDisabled`
+   * listener that broadcasts `watchdog:disabled`) without driving three real
+   * crashes. Respects the once-per-cycle `disabledNotified` guard exactly like
+   * the production cap-hit path, so a subsequent `restart()` re-arms it. Gated
+   * to `DAINTREE_E2E_FAULT_MODE` at the call site; never invoked in production.
+   */
+  _emitDisabledForTesting(): void {
+    this.notifyDisabled();
+  }
+
   /** Stop the watchdog cleanly. Idempotent. */
   dispose(): void {
     if (this.isDisposed) return;

--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -202,6 +202,17 @@ export class ResourceProfileService {
     return this.currentProfile;
   }
 
+  /**
+   * E2E seam: synchronously drive a profile transition, bypassing the
+   * pressure-scoring and hold-timer machinery so fault-mode specs can assert
+   * `applyProfile`'s side-effects (PVM fan-out, the `resource:profile-changed`
+   * broadcast) deterministically. Gated to `DAINTREE_E2E_FAULT_MODE` at the
+   * sole call site in `globalServicesInit.ts`; never invoked in production.
+   */
+  _forceProfileForTesting(profile: ResourceProfile): void {
+    this.applyProfile(profile);
+  }
+
   start(): void {
     if (this.evalCleanup) return;
     this.disposed = false;

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -320,6 +320,25 @@ export class WorkspaceHostProcess extends EventEmitter {
     }
   }
 
+  /**
+   * E2E seam: force-kill the host child to exercise the real crash →
+   * auto-restart → `restarted` → port re-broker path. Mirrors the health-check
+   * watchdog's SIGKILL. Gated to `DAINTREE_E2E_FAULT_MODE` at the main-process
+   * call site; never invoked in production. Returns false if there is no live
+   * child to kill.
+   */
+  _crashForTesting(): boolean {
+    if (this.isDisposed || !this.child) return false;
+    const pid = this.child.pid;
+    if (!pid) return false;
+    try {
+      process.kill(pid, "SIGKILL");
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   dispose(): void {
     if (this.isDisposed) return;
     this.isDisposed = true;

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -59,10 +59,12 @@ import { isSmokeTest } from "../setup/environment.js";
 import { projectStore } from "../services/ProjectStore.js";
 import { store } from "../store.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+import type { ResourceProfile } from "../../shared/types/resourceProfile.js";
 import {
   setCcrConfigService,
   getResourceProfileService,
   setResourceProfileService,
+  getMainProcessWatchdogClientRef,
   getStopAppMetricsMonitor,
   setStopAppMetricsMonitor,
   getStopDiskSpaceMonitor,
@@ -227,6 +229,24 @@ export async function initGlobalServices(
     };
     (globalThis as Record<string, unknown>).__daintreeClearGitHubToken = () => {
       GitHubAuth.setMemoryToken(null);
+    };
+
+    // Adaptive-recovery + watchdog E2E seams (#9599). Drive a synthetic
+    // resource-profile transition and a synthetic watchdog cap-hit so the
+    // full-resilience specs can assert the side-effects (PVM fan-out, the
+    // `watchdog:disabled` broadcast) without real memory pressure or three
+    // genuine watchdog crashes. Same gating as the GitHub-token seams above.
+    (globalThis as Record<string, unknown>).__daintreeForceResourceProfile = (
+      profile: ResourceProfile
+    ) => {
+      const svc = getResourceProfileService();
+      if (!svc) throw new Error("ResourceProfileService not initialized");
+      svc._forceProfileForTesting(profile);
+    };
+    (globalThis as Record<string, unknown>).__daintreeSimulateWatchdogDisabled = () => {
+      const client = getMainProcessWatchdogClientRef();
+      if (!client) throw new Error("MainProcessWatchdogClient not initialized");
+      client._emitDisabledForTesting();
     };
   }
 

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -236,9 +236,17 @@ export async function initGlobalServices(
     // full-resilience specs can assert the side-effects (PVM fan-out, the
     // `watchdog:disabled` broadcast) without real memory pressure or three
     // genuine watchdog crashes. Same gating as the GitHub-token seams above.
+    const VALID_RESOURCE_PROFILES = new Set<ResourceProfile>([
+      "performance",
+      "balanced",
+      "efficiency",
+    ]);
     (globalThis as Record<string, unknown>).__daintreeForceResourceProfile = (
       profile: ResourceProfile
     ) => {
+      if (!VALID_RESOURCE_PROFILES.has(profile)) {
+        throw new Error(`__daintreeForceResourceProfile: unknown profile "${profile}"`);
+      }
       const svc = getResourceProfileService();
       if (!svc) throw new Error("ResourceProfileService not initialized");
       svc._forceProfileForTesting(profile);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -327,7 +327,10 @@ import {
   useNotificationSettingsStore,
   usePreferencesStore,
   usePluginManagerStore,
+  useDiagnosticsStore,
+  usePerformanceModeStore,
 } from "./store";
+import { usePerfMetricsStore } from "./store/perfMetricsStore";
 import { useGitHubConfigStore } from "@github-renderer/stores/githubConfigStore";
 import { useRecipeConflictStore } from "./store/recipeConflictStore";
 // Eager side-effect import: registers the GitHub plugin's builtin view slots
@@ -393,12 +396,42 @@ function AppInner() {
         updates: { name: recipeName },
       });
     };
+
+    // Per-window store accessors for the multi-window isolation spec (#9599).
+    // Each project view is its own V8 context, so these Zustand singletons are
+    // per-window — mutating one window's store must not leak into another's.
+    // Gated on the preload-injected __DAINTREE_E2E_MODE__ flag (set only under
+    // DAINTREE_E2E_MODE=1) so the accessors never attach in production.
+    if (window.__DAINTREE_E2E_MODE__ === true) {
+      window.__DAINTREE_E2E_DIAGNOSTICS_STATE__ = () => ({
+        isOpen: useDiagnosticsStore.getState().isOpen,
+      });
+      window.__DAINTREE_E2E_OPEN_DIAGNOSTICS__ = () => useDiagnosticsStore.getState().openDock();
+      window.__DAINTREE_E2E_PERF_METRICS_STATE__ = () => {
+        const s = usePerfMetricsStore.getState();
+        return { fps: s.fps, lafCount30s: s.lafCount30s, cls30s: s.cls30s };
+      };
+      window.__DAINTREE_E2E_SET_PERF_METRIC__ = (fps: number) =>
+        usePerfMetricsStore.getState().setLiveMetrics({ fps, lafCount30s: 0, cls30s: 0 });
+      window.__DAINTREE_E2E_PERF_MODE_STATE__ = () => ({
+        performanceMode: usePerformanceModeStore.getState().performanceMode,
+      });
+      window.__DAINTREE_E2E_SET_PERF_MODE__ = (enabled: boolean) =>
+        usePerformanceModeStore.getState().setPerformanceMode(enabled);
+    }
+
     return () => {
       delete window.__DAINTREE_E2E_ERROR_STORE__;
       delete window.__DAINTREE_E2E_ADD_ERROR__;
       delete window.__DAINTREE_E2E_CLEAR_ERRORS__;
       delete window.__DAINTREE_E2E_REFRESH_GITHUB_CONFIG__;
       delete window.__DAINTREE_E2E_TRIGGER_RECIPE_CONFLICT__;
+      delete window.__DAINTREE_E2E_DIAGNOSTICS_STATE__;
+      delete window.__DAINTREE_E2E_OPEN_DIAGNOSTICS__;
+      delete window.__DAINTREE_E2E_PERF_METRICS_STATE__;
+      delete window.__DAINTREE_E2E_SET_PERF_METRIC__;
+      delete window.__DAINTREE_E2E_PERF_MODE_STATE__;
+      delete window.__DAINTREE_E2E_SET_PERF_MODE__;
     };
   }, []);
 

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -24,6 +24,17 @@ declare global {
     __DAINTREE_E2E_CLEAR_ERRORS__?: () => void;
     __DAINTREE_E2E_REFRESH_GITHUB_CONFIG__?: () => Promise<void>;
     __DAINTREE_E2E_TRIGGER_RECIPE_CONFLICT__?: (recipeName: string) => void;
+    /** Per-window store accessors for the multi-window isolation spec (#9599). */
+    __DAINTREE_E2E_DIAGNOSTICS_STATE__?: () => { isOpen: boolean };
+    __DAINTREE_E2E_OPEN_DIAGNOSTICS__?: () => void;
+    __DAINTREE_E2E_PERF_METRICS_STATE__?: () => {
+      fps: number | null;
+      lafCount30s: number;
+      cls30s: number;
+    };
+    __DAINTREE_E2E_SET_PERF_METRIC__?: (fps: number) => void;
+    __DAINTREE_E2E_PERF_MODE_STATE__?: () => { performanceMode: boolean };
+    __DAINTREE_E2E_SET_PERF_MODE__?: (enabled: boolean) => void;
     __DAINTREE_E2E_IPC__?: {
       getRendererListenerCount: (channel: string) => number;
     };


### PR DESCRIPTION
Adds 4 new E2E specs to the `full-resilience` bucket covering adaptive recovery and multi-window isolation.

Resolves #9599

## New specs

- `adaptive-recovery` — `ResourceProfileService` profile transitions arm/release the PVM low-memory floor
- `watchdog-disabled-restart` — watchdog disabled banner displays, restart re-arms the watchdog
- `worktree-portbroker-recovery` — `WorktreePortBroker` re-brokers cleanly and doesn't accumulate listeners after a host crash
- `multi-window-isolation` — per-window Zustand store isolation (`errorStore`, `diagnosticsStore`, `perfMetricsStore`, `performance-mode`) vs the intentionally-shared `watchdog:disabled` broadcast

## Production test seams

All seams are strictly gated — never active in production builds. Follows the strip-backdoors-from-prod discipline from #9309.

**Class-level seams** (internal, not exported):
- `ResourceProfileService._forceProfileForTesting`
- `MainProcessWatchdogClient._emitDisabledForTesting`
- `WorkspaceHostProcess._crashForTesting`

**Fault-mode globals** gated on `DAINTREE_E2E_FAULT_MODE`:
- `__daintreeForceResourceProfile`
- `__daintreeSimulateWatchdogDisabled`
- `__daintreeCrashWorkspaceHostForWindow`
- `__daintreeWorktreeHasPort`

**Per-window renderer store accessors** gated on `__DAINTREE_E2E_MODE__`, deleted on cleanup.

## Other changes

- `e2e/helpers/selectors.ts` — append-only, new recovery group added

## CI

PR CI doesn't run E2E (no change to that policy). These specs gate nightly and release runs in the `full-resilience` bucket. Typecheck passes, lint ratchets at -1 warning / zero new, format clean.