### PR TITLE
feat(worktree): add finished chip and neutralize quick-state filter labels

### DIFF
--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -871,7 +871,13 @@ export function WorktreeOverviewModal({
                       )}
                     >
                       <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-state-working)] motion-safe:animate-pulse" />
-                      <span className="text-[var(--color-state-working)]">
+                      <span
+                        className={
+                          quickStateFilter === "working"
+                            ? "text-daintree-text"
+                            : "text-daintree-text/60"
+                        }
+                      >
                         {aggregateStats.workingCount} working
                       </span>
                     </button>
@@ -892,7 +898,13 @@ export function WorktreeOverviewModal({
                       )}
                     >
                       <span className="w-1.5 h-1.5 rounded-full bg-status-warning" />
-                      <span className="text-status-warning">
+                      <span
+                        className={
+                          quickStateFilter === "waiting"
+                            ? "text-daintree-text"
+                            : "text-daintree-text/60"
+                        }
+                      >
                         {aggregateStats.waitingCount} waiting
                       </span>
                     </button>
@@ -912,8 +924,14 @@ export function WorktreeOverviewModal({
                           : "hover:bg-tint/[0.04]"
                       )}
                     >
-                      <span className="w-1.5 h-1.5 rounded-full bg-daintree-text/30" />
-                      <span className="text-daintree-text/70">
+                      <span className="w-1.5 h-1.5 rounded-full bg-category-blue" />
+                      <span
+                        className={
+                          quickStateFilter === "finished"
+                            ? "text-daintree-text"
+                            : "text-daintree-text/60"
+                        }
+                      >
                         {aggregateStats.finishedCount} finished
                       </span>
                     </button>

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -363,6 +363,7 @@ export function WorktreeOverviewModal({
   const aggregateStats = useMemo(() => {
     let workingCount = 0;
     let waitingCount = 0;
+    let finishedCount = 0;
 
     // Count worktrees (not terminals) with specific agent states
     // Use same visibility logic as filtered list to keep stats in sync
@@ -377,9 +378,11 @@ export function WorktreeOverviewModal({
 
       if (derived.hasWorkingAgent) workingCount++;
       if (derived.hasWaitingAgent) waitingCount++;
+      // Mirror matchesQuickStateFilter("finished") so the chip count and filter stay in sync
+      if (derived.chipState === "complete" || derived.chipState === "cleanup") finishedCount++;
     }
 
-    return { workingCount, waitingCount };
+    return { workingCount, waitingCount, finishedCount };
   }, [worktrees, derivedMetaMap, hideMainWorktree]);
 
   // Check if only main worktree exists (to hide the filter toggle)
@@ -844,7 +847,9 @@ export function WorktreeOverviewModal({
                 {filteredWorktrees.length !== worktrees.length && ` of ${worktrees.length}`})
               </span>
               {/* Aggregate activity statistics — clickable chips that set quickStateFilter */}
-              {(aggregateStats.workingCount > 0 || aggregateStats.waitingCount > 0) && (
+              {(aggregateStats.workingCount > 0 ||
+                aggregateStats.waitingCount > 0 ||
+                aggregateStats.finishedCount > 0) && (
                 <div
                   className="flex items-center gap-1 ml-2 pl-3 border-l border-divider"
                   role="group"
@@ -889,6 +894,27 @@ export function WorktreeOverviewModal({
                       <span className="w-1.5 h-1.5 rounded-full bg-status-warning" />
                       <span className="text-status-warning">
                         {aggregateStats.waitingCount} waiting
+                      </span>
+                    </button>
+                  )}
+                  {aggregateStats.finishedCount > 0 && (
+                    <button
+                      type="button"
+                      aria-pressed={quickStateFilter === "finished"}
+                      onClick={() =>
+                        setQuickStateFilter(quickStateFilter === "finished" ? "all" : "finished")
+                      }
+                      className={cn(
+                        "flex items-center gap-1 text-xs tabular-nums rounded-full px-2 py-0.5 transition-colors",
+                        "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent",
+                        quickStateFilter === "finished"
+                          ? "bg-overlay-subtle shadow-[inset_0_-2px_0_0_var(--color-text-secondary)]"
+                          : "hover:bg-tint/[0.04]"
+                      )}
+                    >
+                      <span className="w-1.5 h-1.5 rounded-full bg-daintree-text/30" />
+                      <span className="text-daintree-text/70">
+                        {aggregateStats.finishedCount} finished
                       </span>
                     </button>
                   )}

--- a/src/components/Worktree/__tests__/WorktreeOverviewModal.test.ts
+++ b/src/components/Worktree/__tests__/WorktreeOverviewModal.test.ts
@@ -163,23 +163,6 @@ describe("WorktreeOverviewModal — clickable aggregate stats (#8385)", () => {
   });
 
   describe("finished chip (#9607)", () => {
-    function statsSlice(src: string): string {
-      const start = src.indexOf("Aggregate activity statistics");
-      let depth = 0;
-      let i = start;
-      let found = false;
-      for (; i < src.length; i++) {
-        if (src.slice(i, i + 4) === "<div") {
-          depth++;
-        } else if (src.slice(i, i + 6) === "</div>") {
-          depth--;
-          if (depth === 0 && found) break;
-        }
-        if (depth > 0 && !found) found = true;
-      }
-      return src.slice(start, i + 6);
-    }
-
     it("computes finishedCount in the aggregateStats loop", () => {
       expect(source).toMatch(/finishedCount\+\+/);
       expect(source).toMatch(/return\s*\{\s*workingCount,\s*waitingCount,\s*finishedCount\s*\}/);

--- a/src/components/Worktree/__tests__/WorktreeOverviewModal.test.ts
+++ b/src/components/Worktree/__tests__/WorktreeOverviewModal.test.ts
@@ -162,6 +162,77 @@ describe("WorktreeOverviewModal — clickable aggregate stats (#8385)", () => {
     });
   });
 
+  describe("finished chip (#9607)", () => {
+    function statsSlice(src: string): string {
+      const start = src.indexOf("Aggregate activity statistics");
+      let depth = 0;
+      let i = start;
+      let found = false;
+      for (; i < src.length; i++) {
+        if (src.slice(i, i + 4) === "<div") {
+          depth++;
+        } else if (src.slice(i, i + 6) === "</div>") {
+          depth--;
+          if (depth === 0 && found) break;
+        }
+        if (depth > 0 && !found) found = true;
+      }
+      return src.slice(start, i + 6);
+    }
+
+    it("computes finishedCount in the aggregateStats loop", () => {
+      expect(source).toMatch(/finishedCount\+\+/);
+      expect(source).toMatch(/return\s*\{\s*workingCount,\s*waitingCount,\s*finishedCount\s*\}/);
+    });
+
+    it("derives finishedCount from chipState (mirrors matchesQuickStateFilter), not terminal flags", () => {
+      // Must match the filter's source of truth so the count and filter stay in sync.
+      expect(source).toMatch(
+        /derived\.chipState\s*===\s*"complete"\s*\|\|\s*derived\.chipState\s*===\s*"cleanup"\)\s*finishedCount\+\+/
+      );
+    });
+
+    it("includes finishedCount in the chip-row visibility gate", () => {
+      expect(source).toMatch(/aggregateStats\.finishedCount\s*>\s*0/);
+    });
+
+    it("sets aria-pressed based on quickStateFilter for finished chip", () => {
+      expect(source).toMatch(/aria-pressed=\{quickStateFilter\s*===\s*"finished"\}/);
+    });
+
+    it("finished chip onClick toggles between 'finished' and 'all'", () => {
+      expect(source).toMatch(
+        /setQuickStateFilter\(quickStateFilter\s*===\s*"finished"\s*\?\s*"all"\s*:\s*"finished"\)/
+      );
+    });
+
+    it("uses the shared neutral selected styling (no per-state color) on the finished chip", () => {
+      // The finished chip reuses the same bg-overlay-subtle + inset underline pattern.
+      const stats = statsSlice(source);
+      expect(stats).toContain("finished");
+      expect(stats).toContain("bg-overlay-subtle");
+    });
+
+    it("uses a neutral dot/text color for finished (no per-state token on dot/text)", () => {
+      // Neutral fill on the dot and muted text — the focus ring may still use
+      // the accent (single focus anchor, not selection state coloring).
+      expect(source).toContain("bg-daintree-text/30");
+      expect(source).toContain("text-daintree-text/70");
+      const finishedSlice = source.slice(
+        source.indexOf('aria-pressed={quickStateFilter === "finished"}'),
+        source.indexOf("} finished")
+      );
+      expect(finishedSlice).not.toContain("color-state-working");
+      expect(finishedSlice).not.toContain("status-warning");
+      expect(finishedSlice).not.toContain("bg-daintree-accent");
+      expect(finishedSlice).not.toContain("text-daintree-accent");
+    });
+
+    it("renders the finished count text", () => {
+      expect(source).toMatch(/\baggregateStats\.finishedCount\b/);
+    });
+  });
+
   describe("multi-select and keyboard navigation (#8653)", () => {
     it("imports the overview keyboard hook", () => {
       expect(source).toMatch(/useWorktreeOverviewKeyboard/);

--- a/src/components/Worktree/__tests__/WorktreeOverviewModal.test.ts
+++ b/src/components/Worktree/__tests__/WorktreeOverviewModal.test.ts
@@ -206,30 +206,58 @@ describe("WorktreeOverviewModal — clickable aggregate stats (#8385)", () => {
       );
     });
 
-    it("uses the shared neutral selected styling (no per-state color) on the finished chip", () => {
-      // The finished chip reuses the same bg-overlay-subtle + inset underline pattern.
-      const stats = statsSlice(source);
-      expect(stats).toContain("finished");
-      expect(stats).toContain("bg-overlay-subtle");
+    // Slice tightly around the finished chip's button so assertions can't be
+    // satisfied by the working/waiting buttons that share the same group div.
+    function finishedChipSlice(src: string): string {
+      const start = src.indexOf('aria-pressed={quickStateFilter === "finished"}');
+      return src.slice(start, src.indexOf("} finished", start));
+    }
+
+    it("reuses the shared neutral selected styling (bg-overlay-subtle underline) on the finished chip", () => {
+      const chip = finishedChipSlice(source);
+      expect(chip).toContain("bg-overlay-subtle");
+      expect(chip).toContain("shadow-[inset_0_-2px_0_0_var(--color-text-secondary)]");
     });
 
-    it("uses a neutral dot/text color for finished (no per-state token on dot/text)", () => {
-      // Neutral fill on the dot and muted text — the focus ring may still use
-      // the accent (single focus anchor, not selection state coloring).
-      expect(source).toContain("bg-daintree-text/30");
-      expect(source).toContain("text-daintree-text/70");
-      const finishedSlice = source.slice(
-        source.indexOf('aria-pressed={quickStateFilter === "finished"}'),
-        source.indexOf("} finished")
-      );
-      expect(finishedSlice).not.toContain("color-state-working");
-      expect(finishedSlice).not.toContain("status-warning");
-      expect(finishedSlice).not.toContain("bg-daintree-accent");
-      expect(finishedSlice).not.toContain("text-daintree-accent");
+    it("uses a semantic category-blue dot for finished, matching the WorktreeCard complete chip", () => {
+      const chip = finishedChipSlice(source);
+      expect(chip).toContain("bg-category-blue");
+    });
+
+    it("uses neutral (non-state-colored) text on the finished chip label", () => {
+      const chip = finishedChipSlice(source);
+      // Label text is neutral; only the dot carries semantic color.
+      expect(chip).toMatch(/quickStateFilter === "finished"\s*\?\s*"text-daintree-text"/);
+      expect(chip).not.toContain("text-status-warning");
+      expect(chip).not.toContain("text-[var(--color-state-working)]");
+      expect(chip).not.toContain("text-daintree-accent");
     });
 
     it("renders the finished count text", () => {
       expect(source).toMatch(/\baggregateStats\.finishedCount\b/);
+    });
+  });
+
+  describe("neutral chip labels (#9607)", () => {
+    // The working/waiting chips previously wrapped their whole label in a
+    // per-state color, a one-off treatment. Labels are now neutral; only the
+    // dot keeps semantic color (mirrors the sidebar QuickStateFilterBar).
+    it("working chip label is neutral, not state-colored", () => {
+      const start = source.indexOf('aria-pressed={quickStateFilter === "working"}');
+      const chip = source.slice(start, source.indexOf("} working", start));
+      expect(chip).toMatch(/quickStateFilter === "working"\s*\?\s*"text-daintree-text"/);
+      expect(chip).not.toContain("text-[var(--color-state-working)]");
+      // The dot keeps its semantic state color.
+      expect(chip).toContain("bg-[var(--color-state-working)]");
+    });
+
+    it("waiting chip label is neutral, not state-colored", () => {
+      const start = source.indexOf('aria-pressed={quickStateFilter === "waiting"}');
+      const chip = source.slice(start, source.indexOf("} waiting", start));
+      expect(chip).toMatch(/quickStateFilter === "waiting"\s*\?\s*"text-daintree-text"/);
+      expect(chip).not.toContain("text-status-warning");
+      // The dot keeps its semantic color.
+      expect(chip).toContain("bg-status-warning");
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds a `finished` chip to the `WorktreeOverviewModal` quick-state filter row. `finishedCount` is computed in `aggregateStats` from worktrees where `chipState === "complete" || "cleanup"`, mirroring the existing `matchesQuickStateFilter("finished")` logic so the count and filter stay in sync.
- Updates the chip-row visibility gate to show whenever any of `workingCount`, `waitingCount`, or `finishedCount` is non-zero, so the row appears as soon as there's anything to filter.
- Neutralizes the chip label text to match the sidebar `QuickStateFilterBar` precedent: active label uses `text-daintree-text`, inactive uses `text-daintree-text/60`. Semantic dot colors are preserved (working pulse, waiting amber, finished `bg-category-blue`).

Resolves #9607

## Changes

- `src/components/Worktree/WorktreeOverviewModal.tsx` — adds `finishedCount` to `aggregateStats`, adds the finished chip to the filter row, updates visibility gate, neutralizes all three chip label colors.
- `src/components/Worktree/__tests__/WorktreeOverviewModal.test.ts` — adds assertions for the finished chip and neutral label styling.

## Testing

Unit tests cover the finished chip rendering and the neutral label treatment. The filter logic itself was already tested via `matchesQuickStateFilter`; the new assertions confirm the count and chip wire up correctly through the component.