### PR TITLE
fix(ui): drop blur filter from AnimatedLabel crossfade for crisp text

### DIFF
--- a/src/components/ui/__tests__/AnimatedLabel.test.tsx
+++ b/src/components/ui/__tests__/AnimatedLabel.test.tsx
@@ -2,6 +2,8 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, afterEach, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { act, render, cleanup } from "@testing-library/react";
 import { AnimatedLabel } from "../AnimatedLabel";
 
@@ -95,5 +97,37 @@ describe("AnimatedLabel", () => {
     rerender(<AnimatedLabel label="3" />);
     expect(container.querySelector(".animate-label-swap-in")?.textContent).toBe("3");
     expect(container.querySelector(".animate-label-swap-out")?.textContent).toBe("2");
+  });
+});
+
+// Regression guard for #9615: the crossfade must stay filter-free. A blur (or
+// any filter / will-change: filter) promotes the always-visible count text to a
+// composited layer that disables subpixel antialiasing and softens the glyphs
+// even at rest. JSDOM doesn't apply stylesheets, so we assert against the CSS
+// source directly — this fails if anyone reintroduces filter into the swap.
+describe("AnimatedLabel CSS contract", () => {
+  const css = readFileSync(resolve(process.cwd(), "src/index.css"), "utf8");
+
+  const extractBlock = (header: string) => {
+    const start = css.indexOf(header);
+    expect(start, `expected to find "${header}" in index.css`).toBeGreaterThanOrEqual(0);
+    const open = css.indexOf("{", start);
+    let depth = 0;
+    for (let i = open; i < css.length; i++) {
+      if (css[i] === "{") depth++;
+      else if (css[i] === "}" && --depth === 0) return css.slice(open + 1, i);
+    }
+    throw new Error(`unterminated block for "${header}"`);
+  };
+
+  it.each([
+    "@keyframes label-swap-out",
+    "@keyframes label-swap-in",
+    ".animate-label-swap-out {",
+    ".animate-label-swap-in {",
+  ])("keeps %s free of filter/blur", (header) => {
+    const block = extractBlock(header);
+    expect(block).not.toMatch(/\bfilter\s*:/);
+    expect(block).not.toMatch(/blur\(/);
   });
 });

--- a/src/index.css
+++ b/src/index.css
@@ -1368,8 +1368,10 @@ body,
 
 /* Label crossfade — used by AnimatedLabel for text/number swaps. Outgoing
  * label fades out & lifts up; incoming rises in from below. Opacity +
- * transform only (no filter) so the text never gets promoted to a composited
- * layer that would disable subpixel antialiasing and soften the glyphs.
+ * transform only (no filter): filter was the culprit — `will-change: filter`
+ * promotes the text to a composited layer even at rest, permanently disabling
+ * subpixel antialiasing and softening the glyphs. opacity/transform only
+ * promote transiently during the 150ms swap, not at rest.
  * Container holds both spans in a CSS grid cell so width is the natural max
  * of both labels and no layout shift occurs during the swap.
  */

--- a/src/index.css
+++ b/src/index.css
@@ -1367,7 +1367,9 @@ body,
 }
 
 /* Label crossfade — used by AnimatedLabel for text/number swaps. Outgoing
- * label fades out & lifts up + slight blur; incoming rises in from below.
+ * label fades out & lifts up; incoming rises in from below. Opacity +
+ * transform only (no filter) so the text never gets promoted to a composited
+ * layer that would disable subpixel antialiasing and soften the glyphs.
  * Container holds both spans in a CSS grid cell so width is the natural max
  * of both labels and no layout shift occurs during the swap.
  */
@@ -1375,12 +1377,10 @@ body,
   0% {
     opacity: 1;
     transform: translateY(0);
-    filter: blur(0);
   }
   100% {
     opacity: 0;
     transform: translateY(-4px);
-    filter: blur(2px);
   }
 }
 
@@ -1388,23 +1388,21 @@ body,
   0% {
     opacity: 0;
     transform: translateY(4px);
-    filter: blur(2px);
   }
   100% {
     opacity: 1;
     transform: translateY(0);
-    filter: blur(0);
   }
 }
 
 .animate-label-swap-out {
   animation: label-swap-out var(--duration-150) var(--ease-out-expo) both;
-  will-change: opacity, transform, filter;
+  will-change: opacity, transform;
 }
 
 .animate-label-swap-in {
   animation: label-swap-in var(--duration-150) var(--ease-out-expo) both;
-  will-change: opacity, transform, filter;
+  will-change: opacity, transform;
 }
 
 /* Card border accent flash — opacity-only sibling overlay so we never animate
@@ -1712,7 +1710,6 @@ body,
   .animate-label-swap-in {
     animation: none;
     transform: none !important;
-    filter: none !important;
     will-change: auto;
   }
 


### PR DESCRIPTION
## Summary

- Removed `filter: blur()` from the `label-swap-in` and `label-swap-out` keyframes in `src/index.css`, and dropped `filter` from both `will-change` declarations.
- The blur was promoting the label text to a composited GPU layer, which disabled subpixel antialiasing and caused permanent glyph softening — visible on the always-on count chips even when the animation had settled.
- `opacity` + `translateY` carry the crossfade motion without the fidelity cost. Also cleaned up the now-dead `filter: none !important` from the reduced-motion override.

Resolves #9615

## Changes

- `src/index.css` — `label-swap-in`/`label-swap-out` keyframes: drop `filter: blur()` lines; `will-change` reduced to `opacity, transform` on both `.animate-label-swap-*` classes; removed `filter: none !important` from the `prefers-reduced-motion` block.
- `src/components/ui/__tests__/AnimatedLabel.test.tsx` — CSS-contract regression guard: confirms neither keyframe class carries a `filter` property going forward.

## Testing

- Regression guard test added and passing — verifies the `filter` property is absent from `animate-label-swap-in` and `animate-label-swap-out`.
- `npm run check` clean (warnings pre-existing, no new errors).