### PR TITLE
feat(drag): spring physics on panel drag overlay pickup

### DIFF
--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -59,7 +59,6 @@ import {
   type OverDropData,
 } from "./dropResolution";
 import {
-  UI_ANIMATION_DURATION,
   DURATION_100,
   DURATION_300,
   EASE_SNAPPY,
@@ -67,6 +66,8 @@ import {
   EASE_OUT_EXPO,
   DRAG_OVERLAY_ENTRY_SCALE,
   DRAG_OVERLAY_ENTRY_OPACITY,
+  DRAG_OVERLAY_SPRING_VISUAL_DURATION,
+  DRAG_OVERLAY_SPRING_BOUNCE,
   getUiAnimationDuration,
 } from "@/lib/animationUtils";
 
@@ -461,8 +462,15 @@ function DragOverlayWithCursorTracking({
               : { scale: DRAG_OVERLAY_ENTRY_SCALE, opacity: DRAG_OVERLAY_ENTRY_OPACITY }
           }
           animate={{ scale: 1, opacity: 1 }}
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion -- framer-motion v12 Easing type doesn't include CSS cubic-bezier strings
-          transition={{ duration: UI_ANIMATION_DURATION / 1000, ease: EASE_SNAPPY } as any}
+          transition={
+            prefersReducedMotion
+              ? { type: "tween", duration: 0 }
+              : {
+                  type: "spring",
+                  visualDuration: DRAG_OVERLAY_SPRING_VISUAL_DURATION,
+                  bounce: DRAG_OVERLAY_SPRING_BOUNCE,
+                }
+          }
         >
           {overlayContent}
         </m.div>

--- a/src/lib/__tests__/animationUtils.test.ts
+++ b/src/lib/__tests__/animationUtils.test.ts
@@ -9,6 +9,8 @@ import {
   DURATION_200,
   DURATION_250,
   DURATION_300,
+  DRAG_OVERLAY_SPRING_VISUAL_DURATION,
+  DRAG_OVERLAY_SPRING_BOUNCE,
   EASE_OUT_EXPO,
   EASE_SNAPPY,
   EASE_SPRING_CRITICAL,
@@ -42,6 +44,16 @@ describe("motion token constants", () => {
     expect(EASE_SNAPPY).toMatch(/^cubic-bezier\(/);
     expect(EASE_OUT_EXPO).toMatch(/^cubic-bezier\(/);
     expect(EASE_SPRING_CRITICAL).toMatch(/^linear\(/);
+  });
+
+  it("tunes the drag-overlay pickup spring in seconds with near-zero bounce", () => {
+    // Framer Motion's `visualDuration` is in seconds, not ms — a value >= 1
+    // would mean someone passed a millisecond figure and the pickup would crawl.
+    expect(DRAG_OVERLAY_SPRING_VISUAL_DURATION).toBeGreaterThan(0);
+    expect(DRAG_OVERLAY_SPRING_VISUAL_DURATION).toBeLessThan(1);
+    // Near-zero bounce keeps the pickup crisp; visible overshoot reads cheap.
+    expect(DRAG_OVERLAY_SPRING_BOUNCE).toBeGreaterThanOrEqual(0);
+    expect(DRAG_OVERLAY_SPRING_BOUNCE).toBeLessThan(0.1);
   });
 });
 

--- a/src/lib/animationUtils.ts
+++ b/src/lib/animationUtils.ts
@@ -175,6 +175,12 @@ export const DRAG_GHOST_OPACITY = 0.4;
 export const DRAG_GHOST_EASING = "easeOut";
 export const DRAG_OVERLAY_ENTRY_SCALE = 0.95;
 export const DRAG_OVERLAY_ENTRY_OPACITY = 0.8;
+/** Perceptual spring tuning for the drag-overlay pickup. `visualDuration` is in
+ *  seconds (Framer Motion 12 perceptual spring API) and tracks the prior ~150ms
+ *  tween feel; near-zero `bounce` keeps overshoot sub-pixel so the pickup reads
+ *  crisp in a dense grid rather than springy. */
+export const DRAG_OVERLAY_SPRING_VISUAL_DURATION = 0.15;
+export const DRAG_OVERLAY_SPRING_BOUNCE = 0.05;
 
 export const PANEL_MINIMIZE_EASING = "cubic-bezier(0.3, 0, 0.8, 0.15)";
 export const PANEL_RESTORE_EASING = EASE_OUT_EXPO;


### PR DESCRIPTION
## Summary

- Replaces the drag overlay pickup's flat 150ms tween with a Framer Motion 12 perceptual spring (`visualDuration: 0.15`, `bounce: 0.05`) — crisp, physical pickup with near-zero overshoot
- FM12 springs don't auto-bypass under reduced motion, so the transition explicitly branches on `prefersReducedMotion` to collapse to instant
- New constants `DRAG_OVERLAY_SPRING_VISUAL_DURATION` and `DRAG_OVERLAY_SPRING_BOUNCE` added to `animationUtils.ts`; removed the now-unused `UI_ANIMATION_DURATION` import and an unnecessary `as-any` cast

Resolves #9617

## Changes

- `src/components/DragDrop/DndProvider.tsx` — spring transition on `DragOverlay` entry, with explicit reduced-motion branch
- `src/lib/animationUtils.ts` — two new drag-overlay spring constants
- `src/lib/__tests__/animationUtils.test.ts` — unit guard on the new constants

## Testing

- Drag reorder in the panel grid: pickup animates with a physical spring settle
- Reduced-motion: enable "Reduce Motion" in System Preferences, drag a panel — pickup is instant
- Reorder, collision detection, and drop behaviour unchanged
- `animationUtils` unit test passes; drag E2E (`e2e/full/panels/core-drag-drop.spec.ts`) unaffected (asserts on final DOM position behind `T_SETTLE` waits)