### PR TITLE
fix(motion): move discrete-feedback animations onto the front-loaded easing token

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1228,7 +1228,7 @@ body,
 }
 
 .animate-badge-bump {
-  animation: badge-bump var(--terminal-select-duration, 200ms) cubic-bezier(0.4, 0, 0.2, 1) both;
+  animation: badge-bump var(--terminal-select-duration, 200ms) var(--ease-out-expo) both;
   will-change: transform;
 }
 
@@ -1247,7 +1247,7 @@ body,
 }
 
 .animate-action-row-bump {
-  animation: action-row-bump 200ms cubic-bezier(0.4, 0, 0.2, 1) both;
+  animation: action-row-bump 200ms var(--ease-out-expo) both;
   will-change: transform;
 }
 
@@ -1265,7 +1265,7 @@ body,
 }
 
 .animate-diagnostics-flash {
-  animation: diagnostics-state-flash 200ms cubic-bezier(0.4, 0, 0.2, 1) both;
+  animation: diagnostics-state-flash 200ms var(--ease-out-expo) both;
 }
 
 /* Upstream sync badge value-change flash — one-shot opacity dip when the
@@ -1284,7 +1284,7 @@ body,
 }
 
 .animate-upstream-badge-flash {
-  animation: upstream-badge-update-flash 200ms cubic-bezier(0.4, 0, 0.2, 1) both;
+  animation: upstream-badge-update-flash 200ms var(--ease-out-expo) both;
   will-change: opacity;
 }
 
@@ -1305,7 +1305,7 @@ body,
 }
 
 .animate-activity-blip {
-  animation: activity-blip 200ms cubic-bezier(0.4, 0, 0.2, 1) both;
+  animation: activity-blip 200ms var(--ease-out-expo) both;
 }
 
 /* Trash pulse animation - for trash icon when panels are added */
@@ -1325,7 +1325,7 @@ body,
 }
 
 .animate-trash-pulse {
-  animation: trash-pulse 200ms cubic-bezier(0.4, 0, 0.2, 1) both;
+  animation: trash-pulse 200ms var(--ease-out-expo) both;
 }
 
 /* All-clear flash: subtle full-screen overlay when all agents complete */
@@ -1468,7 +1468,7 @@ body,
 }
 
 .animate-fleet-bar-refocus-pulse::before {
-  animation: fleet-bar-refocus-pulse 800ms cubic-bezier(0.4, 0, 0.2, 1) 1 both;
+  animation: fleet-bar-refocus-pulse 800ms var(--ease-out-expo) 1 both;
   will-change: opacity;
 }
 
@@ -1489,7 +1489,7 @@ body,
 }
 
 .animate-fleet-bar-commit-flash::before {
-  animation: fleet-bar-commit-flash 140ms cubic-bezier(0.4, 0, 0.2, 1) 1 both;
+  animation: fleet-bar-commit-flash 140ms var(--ease-out-expo) 1 both;
   will-change: opacity;
 }
 
@@ -1516,7 +1516,7 @@ body,
   pointer-events: none;
   border-radius: inherit;
   box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--theme-tint) 35%, transparent);
-  animation: fleet-exit-pulse 220ms cubic-bezier(0.4, 0, 0.2, 1) 1 both;
+  animation: fleet-exit-pulse 220ms var(--ease-out-expo) 1 both;
   will-change: opacity;
   z-index: 2;
 }
@@ -1552,7 +1552,7 @@ body,
    * wildcard sets `animation: none`), avoiding a frozen static tint. */
   opacity: 0;
   background-color: color-mix(in oklch, var(--theme-tint) 20%, transparent);
-  animation: fleet-preview-enter 150ms cubic-bezier(0.4, 0, 0.2, 1) 1 both;
+  animation: fleet-preview-enter 150ms var(--ease-out-expo) 1 both;
   will-change: opacity;
   z-index: 2;
 }

--- a/src/lib/__tests__/animationUtils.test.ts
+++ b/src/lib/__tests__/animationUtils.test.ts
@@ -268,24 +268,56 @@ describe("discrete-feedback easing CSS contract", () => {
     ".fleet-preview-enter-overlay",
   ];
 
-  const extractBlock = (selector: string): string | null => {
+  const blockRegex = (selector: string): RegExp => {
     const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const match = css.match(new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\}`));
-    return match?.[1] ?? null;
+    return new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\}`, "g");
   };
+
+  const extractBlock = (selector: string): string | null =>
+    css.match(blockRegex(selector))?.[0].match(/\{([\s\S]*?)\}/)?.[1] ?? null;
+
+  it("anchors the swap to the source-of-truth token value", () => {
+    // The 10 swaps only matter if --ease-out-expo still resolves to the
+    // front-loaded curve. Link the CSS token to the TS constant so a silent
+    // redefinition can't pass the per-selector reference checks below.
+    const match = css.match(/--ease-out-expo\s*:\s*([^;]+);/);
+    expect(match?.[1]?.trim()).toBe(EASE_OUT_EXPO);
+  });
+
+  it.each(discreteFeedbackSelectors)(
+    "%s — any duplicate block only disables motion",
+    (selector) => {
+      // extractBlock reads the first (base) rule. These selectors legitimately
+      // recur inside the reduced-motion media query, but only to set
+      // `animation: none`. Guard the false-negative the review flagged: a later
+      // duplicate that reverted the easing to a real curve would win the cascade
+      // while the base-block checks below still passed.
+      const bodies = [...css.matchAll(blockRegex(selector))].map((m) => m[1]);
+      expect(bodies.length).toBeGreaterThanOrEqual(1);
+      bodies.slice(1).forEach((body) => {
+        expect(body).toMatch(/animation:\s*none/);
+      });
+    }
+  );
 
   it.each(discreteFeedbackSelectors)("%s references var(--ease-out-expo)", (selector) => {
     const block = extractBlock(selector);
     expect(block).not.toBeNull();
-    expect(block).toMatch(/animation:[^;]*var\(--ease-out-expo\)/);
+    // (?<!-) rules out a custom property like `--animation:` shadowing the real one.
+    expect(block).toMatch(/(?<!-)animation:[^;]*var\(--ease-out-expo\)/);
   });
 
   it.each(discreteFeedbackSelectors)(
-    "%s does not fall back to the symmetric Material literal",
+    "%s does not fall back to the symmetric Material curve (literal, alias, or longhand)",
     (selector) => {
       const block = extractBlock(selector);
       expect(block).not.toBeNull();
+      // Ban the raw literal, the --focus-transition-easing alias that resolves
+      // to it, and any animation-timing-function longhand that would silently
+      // override the shorthand's easing.
       expect(block).not.toMatch(/cubic-bezier\(0\.4,\s*0,\s*0\.2,\s*1\)/);
+      expect(block).not.toMatch(/var\(--focus-transition-easing\)/);
+      expect(block).not.toMatch(/animation-timing-function\s*:/);
     }
   );
 });

--- a/src/lib/__tests__/animationUtils.test.ts
+++ b/src/lib/__tests__/animationUtils.test.ts
@@ -242,3 +242,50 @@ describe("--anti-flicker-delay-palette CSS contract", () => {
     expect(UI_PALETTE_STALE_DELAY).toBeLessThan(UI_DOHERTY_THRESHOLD);
   });
 });
+
+describe("discrete-feedback easing CSS contract", () => {
+  // Discrete, user-triggered feedback animations must use the front-loaded
+  // --ease-out-expo token so they snap immediately on trigger. The symmetric
+  // Material curve cubic-bezier(0.4, 0, 0.2, 1) reads as sluggish for one-shot
+  // feedback — it belongs to ambient loops (terminal-ping wash) and interactive
+  // base transitions (--focus-transition-easing), which intentionally retain it.
+  // This contract guards against either drifting back onto the symmetric literal.
+  const css = readFileSync(resolve(__dirname, "../../index.css"), "utf8");
+
+  // Each selector's block is extracted individually so the negative assertion
+  // can't tunnel across a closing brace into a neighbouring rule that legitimately
+  // keeps the symmetric literal (terminal-ping, --focus-transition-easing).
+  const discreteFeedbackSelectors = [
+    ".animate-badge-bump",
+    ".animate-action-row-bump",
+    ".animate-diagnostics-flash",
+    ".animate-upstream-badge-flash",
+    ".animate-activity-blip",
+    ".animate-trash-pulse",
+    ".animate-fleet-bar-refocus-pulse::before",
+    ".animate-fleet-bar-commit-flash::before",
+    ".fleet-exit-pulse-overlay",
+    ".fleet-preview-enter-overlay",
+  ];
+
+  const extractBlock = (selector: string): string | null => {
+    const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const match = css.match(new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\}`));
+    return match?.[1] ?? null;
+  };
+
+  it.each(discreteFeedbackSelectors)("%s references var(--ease-out-expo)", (selector) => {
+    const block = extractBlock(selector);
+    expect(block).not.toBeNull();
+    expect(block).toMatch(/animation:[^;]*var\(--ease-out-expo\)/);
+  });
+
+  it.each(discreteFeedbackSelectors)(
+    "%s does not fall back to the symmetric Material literal",
+    (selector) => {
+      const block = extractBlock(selector);
+      expect(block).not.toBeNull();
+      expect(block).not.toMatch(/cubic-bezier\(0\.4,\s*0,\s*0\.2,\s*1\)/);
+    }
+  );
+});


### PR DESCRIPTION
The symmetric Material curve `cubic-bezier(0.4, 0, 0.2, 1)` is great for ambient and continuous motion, but it makes discrete, user-triggered feedback feel sluggish. Those should snap into place immediately, then ease out — which is exactly what the front-loaded `--ease-out-expo` token (`cubic-bezier(0.16, 1, 0.3, 1)`) gives us. It's already defined and already used by four animations in the file.

This PR swaps the symmetric curve for `var(--ease-out-expo)` on the 10 discrete feedback animations in `src/index.css`. Durations are unchanged — easing only.

Swapped:

- `.animate-badge-bump`
- `.animate-action-row-bump`
- `.animate-diagnostics-flash`
- `.animate-upstream-badge-flash`
- `.animate-activity-blip`
- `.animate-trash-pulse`
- `.animate-fleet-bar-refocus-pulse::before`
- `.animate-fleet-bar-commit-flash::before`
- `.fleet-exit-pulse-overlay`
- `.fleet-preview-enter-overlay`

Left on the symmetric curve on purpose, because they aren't discrete feedback: the `terminal-ping` wash animations (1600ms opacity loops), the `.terminal-pane` base interactive transitions, and the `--focus-transition-easing` token definition.

I also added a drift-contract test in `src/lib/__tests__/animationUtils.test.ts`. Per feedback block it anchors the swap to the source-of-truth token value, asserts the block references `var(--ease-out-expo)`, and rejects the symmetric literal — along with the `--focus-transition-easing` alias and any `animation-timing-function` longhand that could override the shorthand. The reduced-motion duplicate blocks are allowed to set `animation: none` and nothing else. That should catch any accidental drift back onto the slower curve.

Verification: 54 vitest assertions pass; `prettier`/`eslint`/`tsc` clean.

Closes #9616.
