### PR TITLE
fix(help): wake Daintree Assistant terminal on project return

### DIFF
--- a/src/store/__tests__/wakeActiveWorktreeTerminals.test.ts
+++ b/src/store/__tests__/wakeActiveWorktreeTerminals.test.ts
@@ -359,6 +359,21 @@ describe("wakeActiveWorktreeTerminals", () => {
     expect(fullWakeMock).not.toHaveBeenCalledWith("gone");
   });
 
+  it("does not double-wake when the assistant id is already a grid target", async () => {
+    mockActiveWorktreeId = "wt-1";
+    // The assistant id resolves to a grid-located panel that the main loop
+    // already picked up — the inclusion guard must not push it a second time.
+    const assistant = panel("assistant", { worktreeId: "wt-1", location: "grid" });
+    mockPanelIds = ["assistant"];
+    mockPanelsById = { assistant };
+    mockHelpTerminalId = "assistant";
+
+    await wakeActiveWorktreeTerminals();
+
+    expect(fullWakeMock).toHaveBeenCalledTimes(1);
+    expect(fullWakeMock).toHaveBeenCalledWith("assistant");
+  });
+
   it("wakes the assistant terminal when it is the only terminal to wake", async () => {
     mockActiveWorktreeId = "wt-1";
     const assistant = panel("assistant", { worktreeId: "wt-1", location: "dock" });

--- a/src/store/__tests__/wakeActiveWorktreeTerminals.test.ts
+++ b/src/store/__tests__/wakeActiveWorktreeTerminals.test.ts
@@ -19,6 +19,7 @@ vi.mock("@/utils/logger", () => ({
 let mockActiveWorktreeId: string | null = null;
 let mockPanelIds: string[] = [];
 let mockPanelsById: Record<string, PanelInstance> = {};
+let mockHelpTerminalId: string | null = null;
 
 vi.mock("@/store/worktreeStore", () => ({
   useWorktreeSelectionStore: {
@@ -29,6 +30,12 @@ vi.mock("@/store/worktreeStore", () => ({
 vi.mock("@/store/panelStore", () => ({
   usePanelStore: {
     getState: () => ({ panelIds: mockPanelIds, panelsById: mockPanelsById }),
+  },
+}));
+
+vi.mock("@/store/helpPanelStore", () => ({
+  useHelpPanelStore: {
+    getState: () => ({ terminalId: mockHelpTerminalId }),
   },
 }));
 
@@ -53,6 +60,7 @@ beforeEach(() => {
   mockActiveWorktreeId = null;
   mockPanelIds = [];
   mockPanelsById = {};
+  mockHelpTerminalId = null;
 });
 
 describe("wakeActiveWorktreeTerminals", () => {
@@ -301,5 +309,66 @@ describe("wakeActiveWorktreeTerminals", () => {
     // done never resolves because a hangs — but b and c made progress.
     // Drop reference; vitest cleanup will handle the pending promise.
     void done;
+  });
+
+  // #9637 — the Daintree Assistant terminal is a `location: "dock"` panel but
+  // is rendered persistently in HelpPanel, so it must be woken on project
+  // return even though ordinary dock terminals are excluded.
+  it("wakes the help-panel assistant terminal even though it is dock-located", async () => {
+    mockActiveWorktreeId = "wt-1";
+    const a = panel("a", { worktreeId: "wt-1" });
+    const assistant = panel("assistant", { worktreeId: "wt-1", location: "dock" });
+    mockPanelIds = ["a", "assistant"];
+    mockPanelsById = { a, assistant };
+    mockHelpTerminalId = "assistant";
+
+    await wakeActiveWorktreeTerminals();
+
+    expect(fullWakeMock).toHaveBeenCalledTimes(2);
+    expect(fullWakeMock).toHaveBeenCalledWith("a");
+    expect(fullWakeMock).toHaveBeenCalledWith("assistant");
+  });
+
+  it("still excludes dock terminals that are not the assistant terminal", async () => {
+    mockActiveWorktreeId = "wt-1";
+    const a = panel("a", { worktreeId: "wt-1" });
+    const assistant = panel("assistant", { worktreeId: "wt-1", location: "dock" });
+    const otherDock = panel("other-dock", { worktreeId: "wt-1", location: "dock" });
+    mockPanelIds = ["a", "assistant", "other-dock"];
+    mockPanelsById = { a, assistant, "other-dock": otherDock };
+    mockHelpTerminalId = "assistant";
+
+    await wakeActiveWorktreeTerminals();
+
+    expect(fullWakeMock).toHaveBeenCalledTimes(2);
+    expect(fullWakeMock).toHaveBeenCalledWith("a");
+    expect(fullWakeMock).toHaveBeenCalledWith("assistant");
+    expect(fullWakeMock).not.toHaveBeenCalledWith("other-dock");
+  });
+
+  it("ignores a stale assistant terminal id with no matching panel", async () => {
+    mockActiveWorktreeId = "wt-1";
+    const a = panel("a", { worktreeId: "wt-1" });
+    mockPanelIds = ["a"];
+    mockPanelsById = { a };
+    mockHelpTerminalId = "gone";
+
+    await expect(wakeActiveWorktreeTerminals()).resolves.toBeUndefined();
+    expect(fullWakeMock).toHaveBeenCalledTimes(1);
+    expect(fullWakeMock).toHaveBeenCalledWith("a");
+    expect(fullWakeMock).not.toHaveBeenCalledWith("gone");
+  });
+
+  it("wakes the assistant terminal when it is the only terminal to wake", async () => {
+    mockActiveWorktreeId = "wt-1";
+    const assistant = panel("assistant", { worktreeId: "wt-1", location: "dock" });
+    mockPanelIds = ["assistant"];
+    mockPanelsById = { assistant };
+    mockHelpTerminalId = "assistant";
+
+    await wakeActiveWorktreeTerminals();
+
+    expect(fullWakeMock).toHaveBeenCalledTimes(1);
+    expect(fullWakeMock).toHaveBeenCalledWith("assistant");
   });
 });

--- a/src/store/wakeActiveWorktreeTerminals.ts
+++ b/src/store/wakeActiveWorktreeTerminals.ts
@@ -1,4 +1,5 @@
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { logWarn } from "@/utils/logger";
@@ -49,6 +50,19 @@ export async function wakeActiveWorktreeTerminals(): Promise<void> {
     const location = panel.location ?? "grid";
     if (location === "dock" || location === "trash") continue;
     targets.push(id);
+  }
+
+  // The Daintree Assistant terminal is a `location: "dock"` panel and so is
+  // excluded by the loop above, but it's rendered persistently in `HelpPanel`
+  // (not via the dock popover), so nothing else wakes it on view reactivation.
+  // Without this it stays frozen — accumulating headless-mirror output but
+  // never syncing its xterm buffer — until a manual resize (#9637). Pull its
+  // id straight from the help-panel store and fold it into the same fan-out;
+  // `fullWakeForVisibilityRestore` guards on disposal internally, so a stale
+  // id whose panel was cleared on project switch safely misses the lookup.
+  const assistantId = useHelpPanelStore.getState().terminalId;
+  if (assistantId && panelsById[assistantId] && !targets.includes(assistantId)) {
+    targets.push(assistantId);
   }
 
   if (targets.length === 0) return;


### PR DESCRIPTION
## Summary

- The Daintree Assistant terminal was excluded from the `wakeActiveWorktreeTerminals` fan-out, so switching away from a project and back left it frozen with no new output rendered
- Fix adds the help-panel terminal id to the fan-out so `fullWakeForVisibilityRestore` runs on it at project return, same as any other active worktree terminal
- Adds a test covering the double-wake guard to confirm idempotency

Resolves #9637

## Changes

- `src/store/wakeActiveWorktreeTerminals.ts` — include help-panel terminal id in the wake fan-out
- `src/store/__tests__/wakeActiveWorktreeTerminals.test.ts` — new test for assistant wake and double-wake guard

## Testing

- Unit tests added and passing
- Manual: switch away from a project with an active Daintree Assistant terminal, let it produce output, switch back — output now renders immediately without needing a resize