### PR TITLE
fix(updater): mark clean exit on auto-update relaunch

### DIFF
--- a/electron/services/AutoUpdaterService.ts
+++ b/electron/services/AutoUpdaterService.ts
@@ -8,6 +8,8 @@ import * as semver from "semver";
 import { CHANNELS } from "../ipc/channels.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
 import { getCrashRecoveryService } from "./CrashRecoveryService.js";
+import { getCrashLoopGuard } from "./CrashLoopGuardService.js";
+import { getPanelSuspectLedger } from "./PanelSuspectLedgerService.js";
 import { getSystemSleepService } from "./SystemSleepService.js";
 import { trackEvent } from "./TelemetryService.js";
 import { store } from "../store.js";
@@ -247,6 +249,26 @@ class AutoUpdaterService {
       getCrashRecoveryService().cleanupOnExit();
     } catch (err) {
       console.error("[MAIN] Crash recovery cleanup before quit-and-install failed:", err);
+    }
+    // An update relaunch is a clean exit, but quitAndInstall() bypasses the
+    // before-quit cleanup chain (issue #9638), so the two clean-exit markers the
+    // normal shutdown path writes are skipped — leaving cleanExit:false and
+    // firing a false crash-recovery prompt on the post-update boot. Mirror
+    // shutdown.ts: each marker in its own try/catch so one failure can't skip
+    // the next (lesson #7158). markCleanExit/markCleanLaunch are synchronous
+    // writeFileSync, so they commit before the setImmediate-deferred install.
+    try {
+      getCrashLoopGuard().markCleanExit();
+    } catch (err) {
+      console.error("[MAIN] CrashLoopGuard.markCleanExit before quit-and-install failed:", err);
+    }
+    try {
+      getPanelSuspectLedger().markCleanLaunch();
+    } catch (err) {
+      console.error(
+        "[MAIN] PanelSuspectLedger.markCleanLaunch before quit-and-install failed:",
+        err
+      );
     }
     // Disarm the before-quit listener so the explicit quitAndInstall() path
     // and the autoInstallOnAppQuit path don't race the installer subprocess.
@@ -719,6 +741,22 @@ class AutoUpdaterService {
           getCrashRecoveryService().cleanupOnExit();
         } catch (err) {
           console.error("[MAIN] Crash recovery cleanup before quit-and-install failed:", err);
+        }
+        // Issue #9638: write the clean-exit markers the before-quit chain would
+        // otherwise skip on an update relaunch. Independent try/catch per marker
+        // (lesson #7158); both are synchronous so they commit before the install.
+        try {
+          getCrashLoopGuard().markCleanExit();
+        } catch (err) {
+          console.error("[MAIN] CrashLoopGuard.markCleanExit before quit-and-install failed:", err);
+        }
+        try {
+          getPanelSuspectLedger().markCleanLaunch();
+        } catch (err) {
+          console.error(
+            "[MAIN] PanelSuspectLedger.markCleanLaunch before quit-and-install failed:",
+            err
+          );
         }
         autoUpdater.autoInstallOnAppQuit = false;
         this.executeQuitAndInstall();

--- a/electron/services/__tests__/AutoUpdaterService.test.ts
+++ b/electron/services/__tests__/AutoUpdaterService.test.ts
@@ -470,6 +470,16 @@ describe("AutoUpdaterService", () => {
       expect(markCleanLaunchMock).not.toHaveBeenCalled();
     });
 
+    it("writes the markers only once on a rapid double-IPC", () => {
+      downloadedHandler({ version: "2.0.0" });
+
+      quitAndInstallHandler(TRUSTED_SENDER);
+      quitAndInstallHandler(TRUSTED_SENDER);
+
+      expect(markCleanExitMock).toHaveBeenCalledTimes(1);
+      expect(markCleanLaunchMock).toHaveBeenCalledTimes(1);
+    });
+
     it("still writes markCleanLaunch and installs when cleanupOnExit throws", () => {
       downloadedHandler({ version: "2.0.0" });
       cleanupOnExitMock.mockImplementationOnce(() => {
@@ -1932,6 +1942,18 @@ describe("AutoUpdaterService", () => {
       vi.advanceTimersToNextTimer();
 
       expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
+    });
+
+    it("still writes both markers when cleanupOnExit throws", () => {
+      downloadedHandler({ version: "2.0.0" });
+      cleanupOnExitMock.mockImplementationOnce(() => {
+        throw new Error("cleanup failed");
+      });
+
+      expect(autoUpdaterService.quitAndInstallIfReady()).toBe(true);
+
+      expect(markCleanExitMock).toHaveBeenCalledTimes(1);
+      expect(markCleanLaunchMock).toHaveBeenCalledTimes(1);
     });
 
     it("a rapid double-call only schedules a single quitAndInstall (idempotency)", () => {

--- a/electron/services/__tests__/AutoUpdaterService.test.ts
+++ b/electron/services/__tests__/AutoUpdaterService.test.ts
@@ -61,6 +61,8 @@ const storeMock = vi.hoisted(() => ({
 }));
 
 const cleanupOnExitMock = vi.hoisted(() => vi.fn());
+const markCleanExitMock = vi.hoisted(() => vi.fn());
+const markCleanLaunchMock = vi.hoisted(() => vi.fn());
 
 const fsMock = vi.hoisted(() => ({
   existsSync: vi.fn(() => false),
@@ -71,6 +73,14 @@ vi.mock("fs", () => fsMock);
 
 vi.mock("../CrashRecoveryService.js", () => ({
   getCrashRecoveryService: () => ({ cleanupOnExit: cleanupOnExitMock }),
+}));
+
+vi.mock("../CrashLoopGuardService.js", () => ({
+  getCrashLoopGuard: () => ({ markCleanExit: markCleanExitMock }),
+}));
+
+vi.mock("../PanelSuspectLedgerService.js", () => ({
+  getPanelSuspectLedger: () => ({ markCleanLaunch: markCleanLaunchMock }),
 }));
 
 vi.mock("../TelemetryService.js", () => ({
@@ -421,6 +431,80 @@ describe("AutoUpdaterService", () => {
       quitAndInstallHandler(TRUSTED_SENDER);
 
       expect(cleanupOnExitMock).toHaveBeenCalledTimes(1);
+      vi.advanceTimersToNextTimer();
+      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
+    });
+
+    // Issue #9638: the update relaunch must write the same clean-exit markers
+    // the normal shutdown chain does, so the post-update boot isn't treated as
+    // a crash.
+    it("writes clean-exit markers before the deferred quitAndInstall", () => {
+      downloadedHandler({ version: "2.0.0" });
+
+      quitAndInstallHandler(TRUSTED_SENDER);
+
+      expect(markCleanExitMock).toHaveBeenCalledTimes(1);
+      expect(markCleanLaunchMock).toHaveBeenCalledTimes(1);
+      vi.advanceTimersToNextTimer();
+      expect(markCleanExitMock.mock.invocationCallOrder[0]).toBeLessThan(
+        autoUpdaterMock.quitAndInstall.mock.invocationCallOrder[0]
+      );
+      expect(markCleanLaunchMock.mock.invocationCallOrder[0]).toBeLessThan(
+        autoUpdaterMock.quitAndInstall.mock.invocationCallOrder[0]
+      );
+    });
+
+    it("does not write clean-exit markers when no update is downloaded", () => {
+      quitAndInstallHandler(TRUSTED_SENDER);
+
+      expect(markCleanExitMock).not.toHaveBeenCalled();
+      expect(markCleanLaunchMock).not.toHaveBeenCalled();
+    });
+
+    it("does not write clean-exit markers for an untrusted sender", () => {
+      downloadedHandler({ version: "2.0.0" });
+
+      quitAndInstallHandler({ senderFrame: { url: "https://evil.example.com/x.html" } });
+
+      expect(markCleanExitMock).not.toHaveBeenCalled();
+      expect(markCleanLaunchMock).not.toHaveBeenCalled();
+    });
+
+    it("still writes markCleanLaunch and installs when cleanupOnExit throws", () => {
+      downloadedHandler({ version: "2.0.0" });
+      cleanupOnExitMock.mockImplementationOnce(() => {
+        throw new Error("cleanup failed");
+      });
+
+      quitAndInstallHandler(TRUSTED_SENDER);
+
+      expect(markCleanExitMock).toHaveBeenCalledTimes(1);
+      expect(markCleanLaunchMock).toHaveBeenCalledTimes(1);
+      vi.advanceTimersToNextTimer();
+      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
+    });
+
+    it("still writes markCleanLaunch and installs when markCleanExit throws", () => {
+      downloadedHandler({ version: "2.0.0" });
+      markCleanExitMock.mockImplementationOnce(() => {
+        throw new Error("markCleanExit failed");
+      });
+
+      quitAndInstallHandler(TRUSTED_SENDER);
+
+      expect(markCleanLaunchMock).toHaveBeenCalledTimes(1);
+      vi.advanceTimersToNextTimer();
+      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
+    });
+
+    it("still installs when markCleanLaunch throws", () => {
+      downloadedHandler({ version: "2.0.0" });
+      markCleanLaunchMock.mockImplementationOnce(() => {
+        throw new Error("markCleanLaunch failed");
+      });
+
+      quitAndInstallHandler(TRUSTED_SENDER);
+
       vi.advanceTimersToNextTimer();
       expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
     });
@@ -1874,6 +1958,67 @@ describe("AutoUpdaterService", () => {
       autoUpdaterService.quitAndInstallIfReady();
 
       expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(false);
+    });
+
+    // Issue #9638: mirror the shutdown chain's clean-exit markers so an update
+    // relaunch isn't counted as a crash on the next boot.
+    it("writes clean-exit markers before the deferred quitAndInstall when ready", () => {
+      downloadedHandler({ version: "2.0.0" });
+
+      autoUpdaterService.quitAndInstallIfReady();
+
+      expect(markCleanExitMock).toHaveBeenCalledTimes(1);
+      expect(markCleanLaunchMock).toHaveBeenCalledTimes(1);
+      // Markers must commit before the install runs.
+      expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
+      vi.advanceTimersToNextTimer();
+      expect(markCleanExitMock.mock.invocationCallOrder[0]).toBeLessThan(
+        autoUpdaterMock.quitAndInstall.mock.invocationCallOrder[0]
+      );
+      expect(markCleanLaunchMock.mock.invocationCallOrder[0]).toBeLessThan(
+        autoUpdaterMock.quitAndInstall.mock.invocationCallOrder[0]
+      );
+    });
+
+    it("does not write clean-exit markers when state is idle", () => {
+      autoUpdaterService.quitAndInstallIfReady();
+
+      expect(markCleanExitMock).not.toHaveBeenCalled();
+      expect(markCleanLaunchMock).not.toHaveBeenCalled();
+    });
+
+    it("writes the markers only once on a rapid double-call", () => {
+      downloadedHandler({ version: "2.0.0" });
+
+      autoUpdaterService.quitAndInstallIfReady();
+      autoUpdaterService.quitAndInstallIfReady();
+
+      expect(markCleanExitMock).toHaveBeenCalledTimes(1);
+      expect(markCleanLaunchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("still writes markCleanLaunch and installs when markCleanExit throws", () => {
+      downloadedHandler({ version: "2.0.0" });
+      markCleanExitMock.mockImplementationOnce(() => {
+        throw new Error("markCleanExit failed");
+      });
+
+      expect(autoUpdaterService.quitAndInstallIfReady()).toBe(true);
+
+      expect(markCleanLaunchMock).toHaveBeenCalledTimes(1);
+      vi.advanceTimersToNextTimer();
+      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
+    });
+
+    it("still installs when markCleanLaunch throws", () => {
+      downloadedHandler({ version: "2.0.0" });
+      markCleanLaunchMock.mockImplementationOnce(() => {
+        throw new Error("markCleanLaunch failed");
+      });
+
+      expect(autoUpdaterService.quitAndInstallIfReady()).toBe(true);
+      vi.advanceTimersToNextTimer();
+      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## Summary

The auto-update relaunch path in `AutoUpdaterService` (`quitAndInstallIfReady()` and the `UPDATE_QUIT_AND_INSTALL` IPC handler) called `getCrashRecoveryService().cleanupOnExit()` but skipped the two other clean-exit markers the normal shutdown path in `electron/lifecycle/shutdown.ts` always writes: `getCrashLoopGuard().markCleanExit()` and `getPanelSuspectLedger().markCleanLaunch()`. The result: `crash-loop-state.json` kept `cleanExit: false`, so the first boot after an update was counted as a crash — firing a false crash-recovery / safe-mode prompt.

- Adds both marker calls to both call sites, each in its own independent `try/catch` so one marker failure can't skip the next (matching `shutdown.ts` and lesson #7158)
- Markers are placed synchronously before the `setImmediate`-deferred install, so they commit to disk before the process exits
- 13 new behavior tests covering both call sites: markers written once on the ready path, not written on not-ready/idle/untrusted-sender paths, written only once on rapid double-call, and full failure-isolation

Resolves #9638

## Changes

- `electron/services/AutoUpdaterService.ts` — add `markCleanExit()` + `markCleanLaunch()` to `quitAndInstallIfReady()` and the IPC handler
- `electron/services/__tests__/AutoUpdaterService.test.ts` — 13 new tests; `CrashLoopGuard` and `PanelSuspectLedger` mocked alongside the existing `CrashRecoveryService` mock

## Testing

192 tests pass. `npm run check` is green.