### PR TITLE
fix(assistant): resume instead of restart on project switch-back (#9639)

### DIFF
--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -247,6 +247,14 @@ export class HelpSessionService {
   private mcpRegistry: WindowRegistry | null = null;
   private ptyClient: PtyKillClient | null = null;
   private pendingHibernationStore: PendingHelpHibernationStore | null = null;
+  // #9639: tracks the in-flight capture owner per project (projectId →
+  // sessionId) while `gracefulKill` is outstanding. A placeholder
+  // pending-hibernation entry is written synchronously before the kill so a
+  // racing project switch-back resumes instead of fresh-launching; this map
+  // decides who is allowed to overwrite/clear that placeholder afterwards so a
+  // mid-kill displacement can't let a stale resume ID shadow the new session.
+  // In-memory only — no in-flight capture is meaningful across an app restart.
+  private readonly pendingCapturesByProject = new Map<string, string>();
   private onMcpSessionRevokedFn: ((token: string) => void) | null = null;
   private disposed = false;
 
@@ -840,6 +848,32 @@ export class HelpSessionService {
     // the previous behaviour of always losing the conversation.
     let capturedAgentSessionId: string | null = null;
     if (opts?.captureHibernation && terminalId && this.ptyClient) {
+      // #9639: write a placeholder resume entry SYNCHRONOUSLY (memory-first
+      // via `set`) before the gracefulKill round-trip. The eviction path that
+      // calls us is fire-and-forget, so a project switch-back can load the new
+      // renderer view and call `takePendingHibernation` before gracefulKill
+      // resolves. Without the placeholder it gets null and starts a *fresh*
+      // assistant session — the visible "restart" this issue is about. The
+      // empty-`agentSessionId` sentinel routes the renderer down the
+      // resume-latest path instead; once gracefulKill returns we overwrite the
+      // placeholder with the agent's real resume ID (below).
+      if (this.pendingHibernationStore) {
+        this.pendingCapturesByProject.set(record.projectId, sessionId);
+        void this.pendingHibernationStore
+          .set(record.projectId, {
+            agentId: record.agentId,
+            agentSessionId: "",
+            cwd: record.sessionPath,
+            capturedAt: Date.now(),
+          })
+          .catch((err) => {
+            console.warn(
+              "[HelpSessionService] Failed to persist pending hibernation placeholder:",
+              record.projectId,
+              err
+            );
+          });
+      }
       try {
         capturedAgentSessionId = await this.ptyClient.gracefulKill(terminalId);
       } catch (err) {
@@ -902,21 +936,34 @@ export class HelpSessionService {
       );
     }
 
-    if (capturedAgentSessionId && this.pendingHibernationStore && !displacedDuringCapture) {
-      void this.pendingHibernationStore
-        .set(record.projectId, {
-          agentId: record.agentId,
-          agentSessionId: capturedAgentSessionId,
-          cwd: record.sessionPath,
-          capturedAt: Date.now(),
-        })
-        .catch((err) => {
-          console.warn(
-            "[HelpSessionService] Failed to persist pending hibernation:",
-            record.projectId,
-            err
-          );
-        });
+    // #9639: finalize the placeholder written before gracefulKill. Only act if
+    // we still own the capture — a same-project re-provision that ran
+    // `displacePriorSessions` during the await clears our ownership and the
+    // placeholder, so the old resume ID can't shadow the fresh session that
+    // took the slot. When we still own it: overwrite with the real resume ID
+    // if gracefulKill yielded one, otherwise leave the empty-sentinel in place
+    // (resume-latest beats a fresh launch). Then release ownership.
+    if (
+      this.pendingHibernationStore &&
+      this.pendingCapturesByProject.get(record.projectId) === sessionId
+    ) {
+      if (capturedAgentSessionId) {
+        void this.pendingHibernationStore
+          .set(record.projectId, {
+            agentId: record.agentId,
+            agentSessionId: capturedAgentSessionId,
+            cwd: record.sessionPath,
+            capturedAt: Date.now(),
+          })
+          .catch((err) => {
+            console.warn(
+              "[HelpSessionService] Failed to persist pending hibernation:",
+              record.projectId,
+              err
+            );
+          });
+      }
+      this.pendingCapturesByProject.delete(record.projectId);
     }
 
     // Claude bakes a literal session bearer into `.mcp.json`; Copilot
@@ -965,6 +1012,19 @@ export class HelpSessionService {
       prior.revoked = true;
       this.sessionsByToken.delete(prior.token);
       this.sessionsById.delete(prior.sessionId);
+      // #9639: if this displaced session owns an in-flight capture placeholder,
+      // drop it (and release ownership) so the old, soon-to-be-stale resume ID
+      // can't shadow the fresh session now taking the project's slot.
+      if (this.pendingCapturesByProject.get(projectId) === prior.sessionId) {
+        this.pendingCapturesByProject.delete(projectId);
+        void this.pendingHibernationStore?.clear(projectId).catch((err) => {
+          console.warn(
+            "[HelpSessionService] Failed to clear displaced pending hibernation:",
+            projectId,
+            err
+          );
+        });
+      }
       const terminalId = this.terminalBySessionId.get(prior.sessionId);
       if (terminalId) {
         this.terminalBySessionId.delete(prior.sessionId);

--- a/electron/services/PendingHelpHibernationStore.ts
+++ b/electron/services/PendingHelpHibernationStore.ts
@@ -86,11 +86,13 @@ export class PendingHelpHibernationStore {
   private isValid(value: unknown): value is PendingHelpHibernation {
     if (!value || typeof value !== "object") return false;
     const v = value as Record<string, unknown>;
+    // An empty `agentSessionId` is the valid resume-latest sentinel (#9639):
+    // it routes the renderer down `buildResumeLatestCommand` rather than a
+    // fresh launch. Only the field's type is required, not non-emptiness.
     return (
       typeof v.agentId === "string" &&
       v.agentId !== "" &&
       typeof v.agentSessionId === "string" &&
-      v.agentSessionId !== "" &&
       typeof v.cwd === "string" &&
       v.cwd !== "" &&
       typeof v.capturedAt === "number" &&

--- a/electron/services/PendingHelpHibernationStore.ts
+++ b/electron/services/PendingHelpHibernationStore.ts
@@ -96,7 +96,11 @@ export class PendingHelpHibernationStore {
       typeof v.cwd === "string" &&
       v.cwd !== "" &&
       typeof v.capturedAt === "number" &&
-      Number.isFinite(v.capturedAt)
+      Number.isFinite(v.capturedAt) &&
+      // Reject far-future timestamps (corruption / clock skew): the staleness
+      // cutoff is `capturedAt < now - 14d`, so a future stamp would never age
+      // out and would pin a dead resume entry permanently.
+      v.capturedAt <= Date.now()
     );
   }
 

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -1062,8 +1062,12 @@ describe("HelpSessionService", () => {
       expect(mockPtyGracefulKill).toHaveBeenCalledWith("term-evicted");
       // Hard kill is skipped because gracefulKill captured a real ID.
       expect(mockPtyKill).not.toHaveBeenCalled();
-      expect(hibernationStore.set).toHaveBeenCalledWith(
-        "proj-evicted",
+      // #9639: an empty-sentinel placeholder is written SYNCHRONOUSLY before
+      // gracefulKill so a racing switch-back resumes rather than fresh-launches;
+      // the real resume ID overwrites it once gracefulKill resolves.
+      const setCalls = hibernationStore.set.mock.calls.filter((c) => c[0] === "proj-evicted");
+      expect(setCalls[0][1].agentSessionId).toBe("");
+      expect(setCalls[setCalls.length - 1][1]).toEqual(
         expect.objectContaining({
           agentId: "claude",
           agentSessionId: "agent-resume-id-123",
@@ -1073,7 +1077,7 @@ describe("HelpSessionService", () => {
       expect(service.validateToken(result.token)).toBe(false);
     });
 
-    it("falls back to hard kill when gracefulKill returns null and skips writing a pending entry", async () => {
+    it("writes an empty-sentinel placeholder and leaves it intact when gracefulKill returns null", async () => {
       mockPtyGracefulKill.mockResolvedValueOnce(null);
 
       const result = await service.provisionSession({
@@ -1088,7 +1092,12 @@ describe("HelpSessionService", () => {
       await Promise.resolve();
 
       expect(mockPtyKill).toHaveBeenCalledWith("term-no-resume", "help-session-revoked");
-      expect(hibernationStore.set).not.toHaveBeenCalled();
+      // #9639: with no real resume ID, the empty-sentinel placeholder stays —
+      // resume-latest on next open beats a fresh launch. Exactly one write
+      // (the placeholder), never overwritten.
+      const setCalls = hibernationStore.set.mock.calls.filter((c) => c[0] === "proj-no-resume");
+      expect(setCalls).toHaveLength(1);
+      expect(setCalls[0][1].agentSessionId).toBe("");
     });
 
     it("does NOT capture on a user-driven revokeSession (newSession / explicit close)", async () => {
@@ -1211,8 +1220,14 @@ describe("HelpSessionService", () => {
       await Promise.resolve();
 
       // The stale capture must NOT clobber the new active session by writing
-      // an old resume ID into pendingHibernation for the same project.
-      expect(hibernationStore.set).not.toHaveBeenCalled();
+      // an old resume ID into pendingHibernation for the same project. The
+      // #9639 placeholder was written synchronously, but displacement clears it
+      // and releases ownership so the post-gracefulKill overwrite is skipped.
+      expect(hibernationStore.set).not.toHaveBeenCalledWith(
+        "proj-race",
+        expect.objectContaining({ agentSessionId: "stale-resume-id-from-displaced-session" })
+      );
+      expect(hibernationStore.clear).toHaveBeenCalledWith("proj-race");
     });
 
     it("a gracefulKill rejection does not abort the eviction revoke — bearer still invalidated", async () => {
@@ -1228,10 +1243,75 @@ describe("HelpSessionService", () => {
       await service.revokeByWebContentsId(5);
       await Promise.resolve();
 
-      // No capture written; hard kill fires as fallback; token is dead.
-      expect(hibernationStore.set).not.toHaveBeenCalled();
+      // The #9639 placeholder is written synchronously before gracefulKill; the
+      // rejection leaves it as the empty-sentinel (no real id to overwrite).
+      // Hard kill fires as fallback and the token is dead.
+      const setCalls = hibernationStore.set.mock.calls;
+      expect(setCalls).toHaveLength(1);
+      expect(setCalls[0][1].agentSessionId).toBe("");
       expect(mockPtyKill).toHaveBeenCalledWith("term-pty-down", "help-session-revoked");
       expect(service.validateToken(result.token)).toBe(false);
+    });
+
+    it("placeholder is visible to takePendingHibernation before gracefulKill resolves, then overwritten with the real id (#9639)", async () => {
+      // The core race: eviction's revokeByWebContentsId is fire-and-forget, so
+      // the renderer can reopen and call takePendingHibernation while
+      // gracefulKill is still in flight. A stateful store proves the synchronous
+      // placeholder is observable in that window.
+      type PendingHelpHibernationLike = {
+        agentId: string;
+        agentSessionId: string;
+        cwd: string;
+        capturedAt: number;
+      };
+      const backing = new Map<string, PendingHelpHibernationLike>();
+      const statefulStore = {
+        get: vi.fn((projectId: string) => backing.get(projectId) ?? null),
+        set: vi.fn((projectId: string, entry: PendingHelpHibernationLike) => {
+          backing.set(projectId, entry);
+          return Promise.resolve();
+        }),
+        clear: vi.fn((projectId: string) => {
+          backing.delete(projectId);
+          return Promise.resolve();
+        }),
+      };
+      service.setPendingHibernationStore(statefulStore as never);
+
+      let resolveGraceful: (value: string | null) => void = () => {};
+      mockPtyGracefulKill.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveGraceful = resolve;
+          })
+      );
+
+      const result = await service.provisionSession({
+        ...provisionInput(),
+        projectViewWebContentsId: 77,
+        projectId: "proj-visible",
+      });
+      if (!result) throw new Error("expected provision");
+      expect(service.markTerminalForToken(result.token, "term-visible")).toBe(true);
+
+      // Kick off eviction-revoke; it hangs on gracefulKill.
+      const revokePromise = service.revokeByWebContentsId(77);
+
+      // Before gracefulKill resolves, the renderer's takePendingHibernation
+      // sees the empty-sentinel placeholder — so it resumes instead of starting
+      // a fresh session (the visible "restart" this issue fixes).
+      const early = await service.takePendingHibernation("proj-visible");
+      expect(early).toEqual(
+        expect.objectContaining({ agentId: "claude", agentSessionId: "", cwd: result.sessionPath })
+      );
+
+      // gracefulKill finally yields the real resume id; the placeholder is
+      // overwritten so a later open resumes the exact session.
+      resolveGraceful("real-resume-id-xyz");
+      await revokePromise;
+      await Promise.resolve();
+
+      expect(backing.get("proj-visible")?.agentSessionId).toBe("real-resume-id-xyz");
     });
   });
 

--- a/electron/services/__tests__/PendingHelpHibernationStore.test.ts
+++ b/electron/services/__tests__/PendingHelpHibernationStore.test.ts
@@ -165,6 +165,30 @@ describe("PendingHelpHibernationStore", () => {
     expect(store.get("proj-stale-sentinel")).toBeNull();
   });
 
+  it("rejects entries with a far-future capturedAt (corruption / clock skew)", async () => {
+    // A future timestamp would never satisfy the `capturedAt < now - 14d` stale
+    // cutoff, pinning a dead resume entry forever — isValid must drop it.
+    await fs.writeFile(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        entries: {
+          "proj-future-stamp": {
+            agentId: "claude",
+            agentSessionId: "future-id",
+            cwd: "/future",
+            capturedAt: Date.now() + 999_999_999_999,
+          },
+        },
+      }),
+      "utf-8"
+    );
+
+    const store = new PendingHelpHibernationStore(filePath);
+    await store.load();
+    expect(store.get("proj-future-stamp")).toBeNull();
+  });
+
   it("ignores entries with the wrong shape", async () => {
     await fs.writeFile(
       filePath,

--- a/electron/services/__tests__/PendingHelpHibernationStore.test.ts
+++ b/electron/services/__tests__/PendingHelpHibernationStore.test.ts
@@ -118,6 +118,53 @@ describe("PendingHelpHibernationStore", () => {
     expect(store.get("proj-fresh")).not.toBeNull();
   });
 
+  it("accepts an empty agentSessionId as the resume-latest sentinel (#9639)", async () => {
+    // The empty-sentinel placeholder written before gracefulKill must survive a
+    // round-trip through load — dropping it would reintroduce the fresh-launch
+    // race after an app restart mid-capture.
+    const capturedAt = Date.now();
+    const store = new PendingHelpHibernationStore(filePath);
+    await store.load();
+    await store.set("proj-sentinel", {
+      agentId: "claude",
+      agentSessionId: "",
+      cwd: "/sessions/proj-sentinel",
+      capturedAt,
+    });
+
+    const fresh = new PendingHelpHibernationStore(filePath);
+    await fresh.load();
+    expect(fresh.get("proj-sentinel")).toEqual({
+      agentId: "claude",
+      agentSessionId: "",
+      cwd: "/sessions/proj-sentinel",
+      capturedAt,
+    });
+  });
+
+  it("still drops a stale empty-sentinel entry past the 14-day cutoff (#9639)", async () => {
+    const stalePast = Date.now() - 15 * 24 * 60 * 60 * 1000;
+    await fs.writeFile(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        entries: {
+          "proj-stale-sentinel": {
+            agentId: "claude",
+            agentSessionId: "",
+            cwd: "/stale",
+            capturedAt: stalePast,
+          },
+        },
+      }),
+      "utf-8"
+    );
+
+    const store = new PendingHelpHibernationStore(filePath);
+    await store.load();
+    expect(store.get("proj-stale-sentinel")).toBeNull();
+  });
+
   it("ignores entries with the wrong shape", async () => {
     await fs.writeFile(
       filePath,

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -2289,6 +2289,62 @@ describe("HelpPanel — resume from main-captured hibernation (eviction recovery
     );
   });
 
+  it("resumes via resume-latest when main returns the empty-sentinel placeholder (#9639)", async () => {
+    // The eviction race fix writes an empty-`agentSessionId` placeholder before
+    // gracefulKill resolves. A switch-back that lands in that window pulls the
+    // sentinel — the controller must take the resume-latest path (claude
+    // `--continue`) rather than a fresh `agent.launch`, so the user's assistant
+    // resumes instead of visibly restarting.
+    helpPanelState.terminalId = null;
+    helpPanelState.agentId = null;
+    helpPanelState.preferredAgentId = "claude";
+    helpPanelState.sessionId = null;
+    helpPanelState.hibernateSessions = {};
+
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockTakePendingHibernation.mockResolvedValueOnce({
+      agentId: "claude",
+      agentSessionId: "",
+      cwd: "/help/session-dir",
+    });
+    helpPanelState.setHibernateSession = vi.fn(
+      (projectId: string, entry: { sessionId: string; cwd: string; agentId: string }) => {
+        helpPanelState.hibernateSessions[projectId] = entry;
+      }
+    );
+    panelStoreState.addPanel.mockResolvedValueOnce("term-resumed-latest");
+
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => false });
+    await act(async () => {
+      render(<HelpPanel width={380} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(helpPanelState.setHibernateSession).toHaveBeenCalledWith(
+      projectStoreState.currentProject?.id,
+      expect.objectContaining({ sessionId: "", agentId: "claude" })
+    );
+    // Resume-latest spawns through addPanel with the `--continue` flag.
+    expect(panelStoreState.addPanel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "terminal",
+        launchAgentId: "claude",
+        command: expect.stringContaining("--continue"),
+      })
+    );
+    // The visible "restart" — a fresh launch — must NOT fire.
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      "agent.launch",
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
   it("falls through to a fresh launch when main has no pending hibernation", async () => {
     helpPanelState.terminalId = null;
     helpPanelState.agentId = null;


### PR DESCRIPTION
Fixes a race condition where switching between projects caused the Daintree Assistant to appear to restart, losing its session, while all other agent terminals resumed normally.

The root cause was in `HelpSessionService.revokeSession` — a fire-and-forget path that only wrote the pending hibernation entry after `gracefulKill` resolved. A fast switch-back called `takePendingHibernation` before that write landed, got `null`, and started a fresh session.

Resolves #9639

## Changes

- Write an empty-sentinel placeholder to the pending hibernation store **synchronously** before `gracefulKill` — a racing switch-back now resumes via the agent's `resume-latest` command instead of launching fresh
- Once `gracefulKill` resolves, overwrite the placeholder with the real resume id
- Per-project capture-ownership tracking clears the placeholder if the same project re-provisions mid-kill, so a stale resume id can't shadow a freshly started session
- `PendingHelpHibernationStore.isValid` now accepts the empty-sentinel `agentSessionId` and rejects far-future `capturedAt` timestamps

## Testing

248 targeted unit tests pass across `HelpSessionService`, `PendingHelpHibernationStore`, and `HelpPanel.helpLaunch`. `npm run check` clean (typecheck, IPC/channel guards, lint ratchet, format).