### PR TITLE
fix(webview): guard undefined view.webContents in CDP teardown race

### DIFF
--- a/electron/ipc/handlers/webview.ts
+++ b/electron/ipc/handlers/webview.ts
@@ -332,15 +332,58 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
       // Bind CDP message listener once per webContents
       if (!session.messageListener) {
         const listener = (_event: Electron.Event, method: string, params: unknown) => {
-          if (method === "Runtime.consoleAPICalled") {
-            handleConsoleApiCalled(webContentsId, session, params);
-          } else if (method === "Runtime.exceptionThrown") {
-            handleExceptionThrown(session, params);
-          } else if (method === "Log.entryAdded") {
-            handleLogEntryAdded(session, params);
-          } else if (method === "Runtime.executionContextsCleared") {
+          // CDP events can arrive synchronously mid-teardown (the renderer's
+          // detach hasn't flushed the buffered emit). Guard the whole body so a
+          // teardown-race access never escapes as an uncaught main-process crash.
+          try {
+            if (method === "Runtime.consoleAPICalled") {
+              handleConsoleApiCalled(webContentsId, session, params);
+            } else if (method === "Runtime.exceptionThrown") {
+              handleExceptionThrown(session, params);
+            } else if (method === "Log.entryAdded") {
+              handleLogEntryAdded(session, params);
+            } else if (method === "Runtime.executionContextsCleared") {
+              session.navigationGeneration++;
+              // Reset group depth and clear stale objectIds for all panes
+              for (const pid of session.paneIds) {
+                session.groupDepthByPane.set(pid, 0);
+                session.objectIdsByPane.get(pid)?.clear();
+                const payload = {
+                  paneId: pid,
+                  navigationGeneration: session.navigationGeneration,
+                };
+                if (session.ownerWindow && !session.ownerWindow.isDestroyed()) {
+                  sendToRenderer(
+                    session.ownerWindow,
+                    CHANNELS.WEBVIEW_CONSOLE_CONTEXT_CLEARED,
+                    payload
+                  );
+                } else {
+                  broadcastToRenderer(CHANNELS.WEBVIEW_CONSOLE_CONTEXT_CLEARED, payload);
+                }
+              }
+            }
+          } catch (err) {
+            logWarn("CDP message listener failed mid-teardown", {
+              webContentsId,
+              method,
+              error: formatErrorMessage(err, "CDP message listener failed"),
+            });
+          }
+        };
+        session.messageListener = listener;
+        wc.debugger.on("message", listener);
+      }
+
+      if (!session.detachListener) {
+        const detachListener = (_event: Electron.Event, _reason: string) => {
+          try {
+            session.runtimeEnabled = false;
+            session.logEnabled = false;
+            // Debugger detach automatically removes all listeners, so just null our refs
+            session.messageListener = null;
+            session.detachListener = null;
             session.navigationGeneration++;
-            // Reset group depth and clear stale objectIds for all panes
             for (const pid of session.paneIds) {
               session.groupDepthByPane.set(pid, 0);
               session.objectIdsByPane.get(pid)?.clear();
@@ -358,36 +401,11 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
                 broadcastToRenderer(CHANNELS.WEBVIEW_CONSOLE_CONTEXT_CLEARED, payload);
               }
             }
-          }
-        };
-        session.messageListener = listener;
-        wc.debugger.on("message", listener);
-      }
-
-      if (!session.detachListener) {
-        const detachListener = (_event: Electron.Event, _reason: string) => {
-          session.runtimeEnabled = false;
-          session.logEnabled = false;
-          // Debugger detach automatically removes all listeners, so just null our refs
-          session.messageListener = null;
-          session.detachListener = null;
-          session.navigationGeneration++;
-          for (const pid of session.paneIds) {
-            session.groupDepthByPane.set(pid, 0);
-            session.objectIdsByPane.get(pid)?.clear();
-            const payload = {
-              paneId: pid,
-              navigationGeneration: session.navigationGeneration,
-            };
-            if (session.ownerWindow && !session.ownerWindow.isDestroyed()) {
-              sendToRenderer(
-                session.ownerWindow,
-                CHANNELS.WEBVIEW_CONSOLE_CONTEXT_CLEARED,
-                payload
-              );
-            } else {
-              broadcastToRenderer(CHANNELS.WEBVIEW_CONSOLE_CONTEXT_CLEARED, payload);
-            }
+          } catch (err) {
+            logWarn("CDP detach listener failed mid-teardown", {
+              webContentsId,
+              error: formatErrorMessage(err, "CDP detach listener failed"),
+            });
           }
         };
         session.detachListener = detachListener;

--- a/electron/window/__tests__/webContentsRegistry.test.ts
+++ b/electron/window/__tests__/webContentsRegistry.test.ts
@@ -128,6 +128,44 @@ describe("webContentsRegistry", () => {
     expect(getAppView(win)).toBeNull();
   });
 
+  it("falls back to win.webContents when the app view's webContents is destroyed but still present", async () => {
+    const { getAppView, getAppWebContents, registerAppView } = await loadRegistry();
+    const win = createWindow(1);
+    const wc = createWebContents(107);
+    const view = createView(wc);
+
+    registerAppView(win, view);
+    expect(getAppWebContents(win)).toBe(wc);
+
+    // webContents object is still present (not undefined) but reports destroyed —
+    // exercises the second half of the `view.webContents && !isDestroyed()` guard
+    // without firing the `destroyed` event that would prune the map.
+    wc.setDestroyed(true);
+
+    expect(getAppWebContents(win)).toBe(win.webContents);
+    expect(getAppView(win)).toBeNull();
+  });
+
+  it("getAllAppWebContents prunes only the stale window's app view, not live ones", async () => {
+    const { getAllAppWebContents, getAppView, registerAppView } = await loadRegistry();
+    const winA = createWindow(1);
+    const winB = createWindow(2);
+    const wcA = createWebContents(108);
+    const wcB = createWebContents(109);
+    const viewA = createView(wcA);
+    const viewB = createView(wcB);
+
+    registerAppView(winA, viewA);
+    registerAppView(winB, viewB);
+
+    (viewA as unknown as { webContents: unknown }).webContents = undefined;
+
+    const result = getAllAppWebContents();
+    expect(result).toEqual([wcB]);
+    expect(getAppView(winA)).toBeNull();
+    expect(getAppView(winB)).toBe(viewB);
+  });
+
   it("getAllAppWebContents prunes app views whose webContents became undefined", async () => {
     const { getAllAppWebContents, getAppView, registerAppView } = await loadRegistry();
     const win = createWindow(1);

--- a/electron/window/__tests__/webContentsRegistry.test.ts
+++ b/electron/window/__tests__/webContentsRegistry.test.ts
@@ -109,6 +109,58 @@ describe("webContentsRegistry", () => {
     expect(getProjectForWebContents(wc.id)).toBe("project-a");
   });
 
+  it("does not throw and falls back to win.webContents when the app view's webContents is undefined", async () => {
+    const { getAppWebContents, getAppView, registerAppView } = await loadRegistry();
+    const win = createWindow(1);
+    const wc = createWebContents(104);
+    const view = createView(wc);
+
+    registerAppView(win, view);
+    expect(getAppWebContents(win)).toBe(wc);
+
+    // Electron 41 teardown race: the view is destroyed and view.webContents
+    // becomes undefined before the `destroyed` event prunes windowToAppView.
+    (view as unknown as { webContents: unknown }).webContents = undefined;
+
+    expect(() => getAppWebContents(win)).not.toThrow();
+    expect(getAppWebContents(win)).toBe(win.webContents);
+    // Stale entry is pruned eagerly on read.
+    expect(getAppView(win)).toBeNull();
+  });
+
+  it("getAllAppWebContents prunes app views whose webContents became undefined", async () => {
+    const { getAllAppWebContents, getAppView, registerAppView } = await loadRegistry();
+    const win = createWindow(1);
+    const wc = createWebContents(105);
+    const view = createView(wc);
+
+    registerAppView(win, view);
+
+    (view as unknown as { webContents: unknown }).webContents = undefined;
+    // Fallback path returns live BrowserWindow webContents.
+    electronMock.getAllWindows.mockReturnValue([win as unknown as never]);
+
+    let result: WebContents[] = [];
+    expect(() => {
+      result = getAllAppWebContents();
+    }).not.toThrow();
+    expect(result).toEqual([win.webContents]);
+    expect(getAppView(win)).toBeNull();
+  });
+
+  it("unregisterAppView does not throw when the view's webContents is undefined", async () => {
+    const { getAppWebContents, registerAppView, unregisterAppView } = await loadRegistry();
+    const win = createWindow(1);
+    const wc = createWebContents(106);
+    const view = createView(wc);
+
+    registerAppView(win, view);
+    (view as unknown as { webContents: unknown }).webContents = undefined;
+
+    expect(() => unregisterAppView(win)).not.toThrow();
+    expect(getAppWebContents(win)).toBe(win.webContents);
+  });
+
   it("allows unregister and later re-register without leaving stale listener state", async () => {
     const { registerWebContents, unregisterWebContents } = await loadRegistry();
     const firstWindow = createWindow(1);

--- a/electron/window/webContentsRegistry.ts
+++ b/electron/window/webContentsRegistry.ts
@@ -151,7 +151,8 @@ export function registerAppView(win: BrowserWindow, view: WebContentsView): void
 export function unregisterAppView(win: BrowserWindow): void {
   const view = windowToAppView.get(win.id);
   if (view) {
-    if (!view.webContents.isDestroyed()) {
+    // Electron 41: view.webContents is undefined once the view is destroyed.
+    if (view.webContents && !view.webContents.isDestroyed()) {
       unregisterWebContents(view.webContents);
     }
     windowToAppView.delete(win.id);
@@ -164,8 +165,14 @@ export function unregisterAppView(win: BrowserWindow): void {
  */
 export function getAppWebContents(win: BrowserWindow): WebContents {
   const view = windowToAppView.get(win.id);
-  if (view && !view.webContents.isDestroyed()) {
-    return view.webContents;
+  // Electron 41: view.webContents is undefined once the view is destroyed, but
+  // the windowToAppView entry can linger until the `destroyed` event fires.
+  // Guard the property and prune the stale entry so the fallback is reached.
+  if (view) {
+    if (view.webContents && !view.webContents.isDestroyed()) {
+      return view.webContents;
+    }
+    windowToAppView.delete(win.id);
   }
   return win.webContents;
 }
@@ -185,8 +192,9 @@ export function getAllAppWebContents(): WebContents[] {
   const result: WebContents[] = [];
 
   // Active app view per window — typically the currently-visible project view.
+  // Electron 41: view.webContents is undefined once the view is destroyed.
   for (const [winId, view] of windowToAppView) {
-    if (!view.webContents.isDestroyed()) {
+    if (view.webContents && !view.webContents.isDestroyed()) {
       if (!seen.has(view.webContents.id)) {
         seen.add(view.webContents.id);
         result.push(view.webContents);


### PR DESCRIPTION
## Summary

- Fixes a main-process crash where a CDP debugger listener reads `view.webContents` on a stale `WebContentsView` that Electron 41 has already set to `undefined`, before the `once('destroyed')` cleanup fires.
- Guards `getAppWebContents`, `getAllAppWebContents`, and `unregisterAppView` in `electron/window/webContentsRegistry.ts` to prune the stale map entry on read, so the live `BrowserWindow` fallback is reached instead of crashing.
- Wraps the CDP `message` and `detach` listener bodies in `electron/ipc/handlers/webview.ts` with `try/catch` as defense-in-depth against future teardown-race variants.

Resolves #9647

## Changes

- `electron/window/webContentsRegistry.ts` — three guard sites; eagerly prune `windowToAppView` when `view.webContents` is `undefined` or destroyed.
- `electron/ipc/handlers/webview.ts` — `try/catch` around both CDP listener bodies, logging via `logWarn`.
- `electron/window/__tests__/webContentsRegistry.test.ts` — 5 new regression tests covering undefined-webContents and destroyed-but-present teardown races, including a multi-window prune case.

**Follow-up (not in scope here):** `ProjectViewManager.ts` has roughly 10 unguarded `view.webContents` reads — same bug class but a different trigger path. Worth a separate audit.

## Testing

`webContentsRegistry.test.ts` (8 tests) and `webview.test.ts` (33 tests) pass. `npm run check` is clean — typecheck, lint, format, and all guards pass.