### PR TITLE
fix(help-panel): GC orphaned hibernateSessions on project delete/relocate

### DIFF
--- a/src/store/__tests__/projectStore.adversarial.test.ts
+++ b/src/store/__tests__/projectStore.adversarial.test.ts
@@ -41,6 +41,7 @@ const projectClientMock = vi.hoisted(() => ({
 }));
 
 const notifyMock = vi.hoisted(() => vi.fn());
+const clearHibernateSessionMock = vi.hoisted(() => vi.fn());
 const logErrorWithContextMock = vi.hoisted(() => vi.fn());
 const setProjectIdGetterMock = vi.hoisted(() => vi.fn());
 const panelPersistenceCancelMock = vi.hoisted(() => vi.fn());
@@ -76,6 +77,14 @@ vi.mock("../urlHistoryStore", () => ({
   useUrlHistoryStore: {
     getState: () => ({
       removeProjectHistory: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock("../helpPanelStore", () => ({
+  useHelpPanelStore: {
+    getState: () => ({
+      clearHibernateSession: clearHibernateSessionMock,
     }),
   },
 }));
@@ -478,5 +487,67 @@ describe("projectStore adversarial", () => {
 
     expect(useProjectStore.getState().projects).toEqual([closedProjectA]);
     expect(useProjectStore.getState().currentProject).toBeNull();
+  });
+
+  it("garbage-collects the hibernate session when a project is removed", async () => {
+    installProjectApi({});
+    installLocalStorage(createStorageMock());
+    projectClientMock.remove.mockResolvedValueOnce(undefined);
+    projectClientMock.getAll.mockResolvedValue([]);
+
+    const { useProjectStore } = await import("../projectStore");
+    await useProjectStore.getState().removeProject(projectA.id);
+
+    expect(clearHibernateSessionMock).toHaveBeenCalledTimes(1);
+    expect(clearHibernateSessionMock).toHaveBeenCalledWith(projectA.id);
+  });
+
+  it("does not GC the hibernate session when project removal fails", async () => {
+    installProjectApi({});
+    installLocalStorage(createStorageMock());
+    projectClientMock.remove.mockRejectedValueOnce(new Error("remove failed"));
+
+    const { useProjectStore } = await import("../projectStore");
+    await useProjectStore.getState().removeProject(projectA.id);
+
+    expect(clearHibernateSessionMock).not.toHaveBeenCalled();
+    expect(useProjectStore.getState().error).toBe("Failed to remove project");
+  });
+
+  it("GCs the old hibernate session when locating a project changes its id", async () => {
+    installProjectApi({});
+    installLocalStorage(createStorageMock());
+    const relocated = { ...projectA, id: "project-a-relocated", path: "/tmp/project-a-moved" };
+    projectClientMock.locate.mockResolvedValueOnce(relocated);
+    projectClientMock.getAll.mockResolvedValue([relocated]);
+
+    const { useProjectStore } = await import("../projectStore");
+    await useProjectStore.getState().locateProject(projectA.id);
+
+    expect(clearHibernateSessionMock).toHaveBeenCalledTimes(1);
+    expect(clearHibernateSessionMock).toHaveBeenCalledWith(projectA.id);
+  });
+
+  it("does not GC the hibernate session when locating returns the same id", async () => {
+    installProjectApi({});
+    installLocalStorage(createStorageMock());
+    projectClientMock.locate.mockResolvedValueOnce({ ...projectA });
+    projectClientMock.getAll.mockResolvedValue([projectA]);
+
+    const { useProjectStore } = await import("../projectStore");
+    await useProjectStore.getState().locateProject(projectA.id);
+
+    expect(clearHibernateSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("does not GC the hibernate session when locate returns null", async () => {
+    installProjectApi({});
+    installLocalStorage(createStorageMock());
+    projectClientMock.locate.mockResolvedValueOnce(null);
+
+    const { useProjectStore } = await import("../projectStore");
+    await useProjectStore.getState().locateProject(projectA.id);
+
+    expect(clearHibernateSessionMock).not.toHaveBeenCalled();
   });
 });

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -7,6 +7,7 @@ import { actionService } from "@/services/ActionService";
 import { logErrorWithContext } from "@/utils/errorContext";
 import { logDebug } from "@/utils/logger";
 import { useUrlHistoryStore } from "./urlHistoryStore";
+import { useHelpPanelStore } from "./helpPanelStore";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 import { panelPersistence, panelToSnapshot } from "./persistence/panelPersistence";
@@ -606,6 +607,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
         set({ currentProject: null });
       }
       useUrlHistoryStore.getState().removeProjectHistory(id);
+      useHelpPanelStore.getState().clearHibernateSession(id);
       set({ isLoading: false });
     } catch (error) {
       logErrorWithContext(error, {
@@ -744,6 +746,12 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     try {
       const updated = await projectClient.locate(projectId);
       if (updated) {
+        // Relocation regenerates the project id from its new path (sha256(path)),
+        // so the pre-relocation id is now dead. GC its orphaned hibernate session.
+        // Skip when the id is unchanged (canonicalization produced the same hash).
+        if (updated.id !== projectId) {
+          useHelpPanelStore.getState().clearHibernateSession(projectId);
+        }
         const projects = await projectClient.getAll();
         set({ projects });
       }


### PR DESCRIPTION
## Summary

- `helpPanelStore.hibernateSessions` is keyed by `projectId` and persisted under `help-panel-storage`, but entries were never cleaned up when a project was deleted or relocated. Stale entries could re-apply an invalid session token if the path was later re-added.
- Added `clearHibernateSession` calls in `projectStore`: in `removeProject` after a successful removal, and in `locateProject` when relocation produces a new `id` (guarded so a same-id canonicalization no-op doesn't discard a valid session).
- `updateProject` doesn't change the `id`, so no GC needed there. `closeProject`/`closeActiveProject` intentionally preserve sessions across close/reopen.

Fixes #9642

## Changes

- `src/store/projectStore.ts`: import `useHelpPanelStore` and call `clearHibernateSession` in `removeProject` and `locateProject` (mirrors the existing `useUrlHistoryStore` cleanup pattern)
- `src/store/__tests__/projectStore.adversarial.test.ts`: 5 new tests covering remove-GCs, remove-failure-no-GC, relocate-id-change-GCs, relocate-same-id-no-GC, locate-null-no-GC

## Testing

Vitest: 58 tests pass. Typecheck, lint, and format all clean.