### PR TITLE
fix(recipes): persist agentLaunchFlags for recipe-spawned agents

### DIFF
--- a/src/components/Worktree/__tests__/panelSpawning.test.ts
+++ b/src/components/Worktree/__tests__/panelSpawning.test.ts
@@ -146,6 +146,58 @@ describe("spawnPanelsFromRecipe", () => {
     expect(cb).toHaveBeenCalledWith(0, "panel-id-123");
   });
 
+  it("persists computed launch flags so resume reproduces the launch (#9650)", async () => {
+    // Real buildAgentLaunchFlags runs (only generateAgentCommand is mocked),
+    // so the dangerous flag and recipe args must surface in agentLaunchFlags.
+    await spawnPanelsFromRecipe({
+      terminals: [makeAgent({ args: "--recipe-arg value" })],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+      agentSettings: { agents: { claude: { dangerousEnabled: true } } },
+      clipboardDirectory: "/tmp/daintree/daintree-clipboard",
+    });
+
+    const call = mockAddPanel.mock.calls[0]?.[0] as { agentLaunchFlags?: string[] };
+    expect(call.agentLaunchFlags).toEqual(
+      expect.arrayContaining(["--dangerously-skip-permissions", "--recipe-arg", "value"])
+    );
+    // Never the stale (always-undefined) recipe-terminal field.
+    expect(call.agentLaunchFlags).not.toBeUndefined();
+  });
+
+  it("forwards recipe args to the initial command (#9650)", async () => {
+    await spawnPanelsFromRecipe({
+      terminals: [makeAgent({ args: "--recipe-arg" })],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+      agentSettings: { agents: { claude: {} } },
+      clipboardDirectory: "/tmp/daintree/daintree-clipboard",
+    });
+
+    expect(mockGenerateAgentCommand).toHaveBeenCalledWith(
+      "claude",
+      {},
+      "claude",
+      expect.objectContaining({ recipeArgs: "--recipe-arg" })
+    );
+  });
+
+  it("produces no blank flag tokens when recipe args are empty (#9650)", async () => {
+    await spawnPanelsFromRecipe({
+      terminals: [makeAgent({ args: "   " })],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+      agentSettings: { agents: { claude: { dangerousEnabled: true } } },
+      clipboardDirectory: "/tmp/daintree/daintree-clipboard",
+    });
+
+    const call = mockAddPanel.mock.calls[0]?.[0] as { agentLaunchFlags?: string[] };
+    expect(call.agentLaunchFlags).toEqual(
+      expect.arrayContaining(["--dangerously-skip-permissions"])
+    );
+    expect(call.agentLaunchFlags?.every((f) => f.trim().length > 0)).toBe(true);
+  });
+
   it("fetches agent settings internally when not provided", async () => {
     await spawnPanelsFromRecipe({
       terminals: [makeAgent()],

--- a/src/components/Worktree/panelSpawning.ts
+++ b/src/components/Worktree/panelSpawning.ts
@@ -1,7 +1,7 @@
 import { usePanelStore } from "@/store/panelStore";
 import { agentSettingsClient, systemClient } from "@/clients";
 import { getAgentConfig } from "@/config/agents";
-import { generateAgentCommand } from "@shared/types";
+import { generateAgentCommand, buildAgentLaunchFlags } from "@shared/types";
 import type { RecipeTerminal } from "@shared/types";
 import { preflightSpawnBatchLimit } from "@/store/panelLimitStore";
 import { isMcpSpawnFocusSuppressed } from "@/store/mcpSpawnFocusGuard";
@@ -108,7 +108,17 @@ export async function spawnPanelsFromRecipe(options: SpawnPanelsOptions): Promis
             const command = generateAgentCommand(baseCommand, entry, agentId, {
               clipboardDirectory,
               modelId: t.agentModelId,
+              recipeArgs: t.args?.trim() || undefined,
             });
+            // Compute launch flags from live settings rather than reading
+            // `t.agentLaunchFlags` (always undefined — disk persistence strips
+            // it). Persisting these lets restart/resume reproduce the launch,
+            // preventing `--dangerously-skip-permissions` and recipe args from
+            // being dropped on resume (#9650). Recipe args append as raw tokens.
+            const agentLaunchFlags = [
+              ...buildAgentLaunchFlags(entry, agentId, { modelId: t.agentModelId }),
+              ...(t.args?.trim().split(/\s+/).filter(Boolean) ?? []),
+            ];
 
             panelId = await store.addPanel({
               kind: "terminal",
@@ -119,7 +129,7 @@ export async function spawnPanelsFromRecipe(options: SpawnPanelsOptions): Promis
               worktreeId,
               exitBehavior: t.exitBehavior,
               agentModelId: t.agentModelId,
-              agentLaunchFlags: t.agentLaunchFlags,
+              agentLaunchFlags,
               bypassLimits: true,
             });
           } else {

--- a/src/components/Worktree/panelSpawning.ts
+++ b/src/components/Worktree/panelSpawning.ts
@@ -110,12 +110,14 @@ export async function spawnPanelsFromRecipe(options: SpawnPanelsOptions): Promis
               modelId: t.agentModelId,
               recipeArgs: t.args?.trim() || undefined,
             });
-            // Compute launch flags from live settings rather than reading
-            // `t.agentLaunchFlags` (always undefined — disk persistence strips
-            // it). Persisting these lets restart/resume reproduce the launch,
-            // preventing `--dangerously-skip-permissions` and recipe args from
-            // being dropped on resume (#9650). Recipe args append as raw tokens.
-            const agentLaunchFlags = [
+            // Preserve flags the caller already captured (the clone-layout path
+            // projects a live panel's `agentLaunchFlags` onto the recipe). For
+            // disk recipes the field is stripped (undefined), so compute from
+            // live settings instead — persisting these lets restart/resume
+            // reproduce the launch and prevents `--dangerously-skip-permissions`
+            // and recipe args from being dropped on resume (#9650). Recipe args
+            // append as raw tokens.
+            const agentLaunchFlags = t.agentLaunchFlags ?? [
               ...buildAgentLaunchFlags(entry, agentId, { modelId: t.agentModelId }),
               ...(t.args?.trim().split(/\s+/).filter(Boolean) ?? []),
             ];

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -964,6 +964,7 @@ describe("recipeStore", () => {
         .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1");
 
       const call = addTerminalMock.mock.calls[0]?.[0] as {
+        command?: string;
         agentLaunchFlags?: string[];
         agentModelId?: string;
       };
@@ -971,6 +972,9 @@ describe("recipeStore", () => {
         expect.arrayContaining(["--dangerously-skip-permissions", "--recipe-arg", "value"])
       );
       expect(call.agentModelId).toBe("sonnet");
+      // The initial command must also carry the model — without it the first run
+      // uses the default model and only restart (which replays the flags) fixes it.
+      expect(call.command).toContain("--model sonnet");
     });
 
     it("emits no blank flag tokens when an agent terminal has no recipe args (#9650)", async () => {

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -932,6 +932,75 @@ describe("recipeStore", () => {
       expect(results.spawned).toHaveLength(10);
       expect(results.failed).toHaveLength(0);
     });
+
+    it("persists agentLaunchFlags so resume keeps dangerous flag and recipe args (#9650)", async () => {
+      getAgentSettingsMock.mockResolvedValue({ agents: { claude: { dangerousEnabled: true } } });
+      addTerminalMock.mockResolvedValue("terminal-1");
+
+      useRecipeStore.setState({
+        recipes: [
+          {
+            id: "recipe-1",
+            name: "Agent Recipe",
+            projectId: "project-1",
+            terminals: [
+              {
+                type: "claude",
+                title: "Claude",
+                args: "--recipe-arg value",
+                agentModelId: "sonnet",
+                env: {},
+              },
+            ],
+            createdAt: Date.now(),
+          },
+        ],
+        isLoading: false,
+        currentProjectId: "project-1",
+      });
+
+      await useRecipeStore
+        .getState()
+        .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1");
+
+      const call = addTerminalMock.mock.calls[0]?.[0] as {
+        agentLaunchFlags?: string[];
+        agentModelId?: string;
+      };
+      expect(call.agentLaunchFlags).toEqual(
+        expect.arrayContaining(["--dangerously-skip-permissions", "--recipe-arg", "value"])
+      );
+      expect(call.agentModelId).toBe("sonnet");
+    });
+
+    it("emits no blank flag tokens when an agent terminal has no recipe args (#9650)", async () => {
+      getAgentSettingsMock.mockResolvedValue({ agents: { claude: { dangerousEnabled: true } } });
+      addTerminalMock.mockResolvedValue("terminal-1");
+
+      useRecipeStore.setState({
+        recipes: [
+          {
+            id: "recipe-1",
+            name: "Agent Recipe",
+            projectId: "project-1",
+            terminals: [{ type: "claude", title: "Claude", env: {} }],
+            createdAt: Date.now(),
+          },
+        ],
+        isLoading: false,
+        currentProjectId: "project-1",
+      });
+
+      await useRecipeStore
+        .getState()
+        .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1");
+
+      const call = addTerminalMock.mock.calls[0]?.[0] as { agentLaunchFlags?: string[] };
+      expect(call.agentLaunchFlags).toEqual(
+        expect.arrayContaining(["--dangerously-skip-permissions"])
+      );
+      expect(call.agentLaunchFlags?.every((f) => f.trim().length > 0)).toBe(true);
+    });
   });
 
   it("keeps importing valid terminals even when others are invalid", async () => {

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -812,10 +812,12 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
             // with `agentLaunchFlags: undefined` and the restart slice silently
             // regenerates the command from current settings, dropping
             // `--dangerously-skip-permissions` and the recipe's args (#9650).
-            // Computed from live settings (not the disk-stripped recipe state),
-            // mirroring useAgentLauncher; recipe args append as raw tokens since
-            // the restart command builder applies its own escaping.
-            const agentLaunchFlags = [
+            // Preserve flags an in-memory recipe already carries; for disk
+            // recipes the field is stripped (undefined), so compute from live
+            // settings (mirroring useAgentLauncher) and append recipe args as
+            // raw tokens since the restart command builder applies its own
+            // escaping.
+            const agentLaunchFlags = terminal.agentLaunchFlags ?? [
               ...buildAgentLaunchFlags(entry, agentId, { modelId: terminal.agentModelId }),
               ...(terminal.args?.trim().split(/\s+/).filter(Boolean) ?? []),
             ];

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -804,6 +804,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
             const command = generateAgentCommand(baseCommand, entry, agentId, {
               initialPrompt,
               clipboardDirectory,
+              modelId: terminal.agentModelId,
               recipeArgs: terminal.args?.trim() || undefined,
             });
             // Persist the process-level launch flags so restart/resume/continue

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -12,7 +12,7 @@ import {
 } from "@shared/types/panel";
 import { projectClient, agentSettingsClient, systemClient, globalRecipesClient } from "@/clients";
 import { getAgentConfig } from "@/config/agents";
-import { generateAgentCommand } from "@shared/types";
+import { generateAgentCommand, buildAgentLaunchFlags } from "@shared/types";
 import { replaceRecipeVariables, type RecipeContext } from "@/utils/recipeVariables";
 import { sanitizeRecipeTerminals, MAX_TERMINALS_PER_RECIPE } from "@shared/utils/recipeSanitizer";
 import type { ActionSource } from "@shared/types/actions";
@@ -806,6 +806,18 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
               clipboardDirectory,
               recipeArgs: terminal.args?.trim() || undefined,
             });
+            // Persist the process-level launch flags so restart/resume/continue
+            // reproduce the same configuration. Without this the panel arrives
+            // with `agentLaunchFlags: undefined` and the restart slice silently
+            // regenerates the command from current settings, dropping
+            // `--dangerously-skip-permissions` and the recipe's args (#9650).
+            // Computed from live settings (not the disk-stripped recipe state),
+            // mirroring useAgentLauncher; recipe args append as raw tokens since
+            // the restart command builder applies its own escaping.
+            const agentLaunchFlags = [
+              ...buildAgentLaunchFlags(entry, agentId, { modelId: terminal.agentModelId }),
+              ...(terminal.args?.trim().split(/\s+/).filter(Boolean) ?? []),
+            ];
             return terminalStore.addPanel({
               kind: "terminal",
               launchAgentId: agentId,
@@ -813,6 +825,8 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
               title: terminal.title,
               cwd: worktreePath,
               worktreeId: worktreeId,
+              agentLaunchFlags,
+              agentModelId: terminal.agentModelId,
               env: terminal.env,
               exitBehavior: terminal.exitBehavior,
               spawnedBy,


### PR DESCRIPTION
## Summary

- `runRecipeWithResults` (`src/store/recipeStore.ts`) and `spawnPanelsFromRecipe` (`src/components/Worktree/panelSpawning.ts`) both used `generateAgentCommand` to build the initial command string but never wrote `agentLaunchFlags` onto the panel. On restart or resume, the restart slice reads `agentLaunchFlags` (undefined) and regenerates the command from current settings, silently dropping `--dangerously-skip-permissions` and any recipe args.
- Fix calls `buildAgentLaunchFlags` at both spawn sites (matching `useAgentLauncher`), appends recipe args as raw tokens, and passes `agentLaunchFlags` and `agentModelId` through `addPanel`. Also passes `modelId` and `recipeArgs` into `generateAgentCommand` in `recipeStore` so the initial command is correct too.
- The restart path already handles non-undefined `agentLaunchFlags` correctly — no changes needed there.

Resolves #9650

## Changes

- `src/store/recipeStore.ts` — compute `agentLaunchFlags` via `buildAgentLaunchFlags`, pass `modelId`/`recipeArgs` into `generateAgentCommand`, forward `agentLaunchFlags`/`agentModelId` through `addPanel`
- `src/components/Worktree/panelSpawning.ts` — same pattern: compute `agentLaunchFlags`, append recipe args, pass through `addPanel`
- `src/store/__tests__/recipeStore.test.ts` — coverage for dangerous-flag, recipe-arg, and model persistence; empty-args case
- `src/components/Worktree/__tests__/panelSpawning.test.ts` — same coverage for the `spawnPanelsFromRecipe` path

## Testing

All targeted tests pass. `npm run check` clean (lint warning count down by 1 vs baseline).