### PR TITLE
fix(panels): paint recipe-launched terminal on first mount (#9649)

### DIFF
--- a/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
@@ -460,6 +460,41 @@ describe("hydration batch (#5196)", () => {
       }
     });
 
+    it("surfaces a batched grid panel via getTabGroups before flush (#9649)", async () => {
+      // Regression for the blank recipe-launched terminal: during the spawn
+      // batch window the worktree index is committed eagerly but panelIds is
+      // deferred. getTabGroups must still return the panel as a virtual group
+      // so the grid paints on first mount. Drives the real addPanel batch path
+      // — guards against addPanel ever dropping its addToWorktreeIndex call.
+      const { beginSpawnBatch, flushSpawnBatch, addPanel, getTabGroups } = usePanelStore.getState();
+
+      const token = beginSpawnBatch();
+      expect(token).not.toBeNull();
+      await addPanel({
+        kind: "terminal",
+        launchAgentId: "claude",
+        command: "claude",
+        requestedId: "recipe-term",
+        cwd: "/",
+        worktreeId: "wt-a",
+        location: "grid",
+        bypassLimits: true,
+      });
+
+      // Pre-flush: panelIds is still empty, but the index already has the panel.
+      expect(usePanelStore.getState().panelIds).toEqual([]);
+      expect(usePanelStore.getState().panelIdsByWorktreeId["wt-a"]).toContain("recipe-term");
+
+      const groups = getTabGroups("grid", "wt-a");
+      expect(groups.flatMap((g) => g.panelIds)).toContain("recipe-term");
+
+      // Post-flush: still exactly one group, no duplicate from the id now being
+      // in both panelIds and the index.
+      flushSpawnBatch(token);
+      const afterIds = getTabGroups("grid", "wt-a").flatMap((g) => g.panelIds);
+      expect(afterIds).toEqual(["recipe-term"]);
+    });
+
     it("refuses to open a nested batch and sweeps overlapping ids via the active flush", async () => {
       const { beginSpawnBatch, flushSpawnBatch, addPanel } = usePanelStore.getState();
 

--- a/src/store/slices/panelRegistry/__tests__/tabGroupWorktreeInvariant.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/tabGroupWorktreeInvariant.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TerminalRefreshTier } from "@/types";
 import type { PtyPanelData, TabGroup } from "@shared/types/panel";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { NO_WORKTREE } from "../worktreeIndex";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -557,7 +558,7 @@ describe("Tab Group Worktree Invariant", () => {
     function commitOnePanelToIndexOnly(panel: PtyPanelData, committedIds: string[] = []) {
       const byId: Record<string, PtyPanelData> = { [panel.id]: panel };
       const index: Record<string, string[]> = {};
-      const bucket = panel.worktreeId ?? "__none__";
+      const bucket = panel.worktreeId ?? NO_WORKTREE;
       index[bucket] = [...committedIds, panel.id];
       usePanelStore.setState({
         panelsById: byId,
@@ -577,8 +578,15 @@ describe("Tab Group Worktree Invariant", () => {
       expect(state.panelIdsByWorktreeId["wt-a"]).toContain("recipe-1");
 
       const groups = state.getTabGroups("grid", "wt-a");
-      const allIds = groups.flatMap((g) => g.panelIds);
-      expect(allIds).toContain("recipe-1");
+      expect(groups).toEqual([
+        {
+          id: "recipe-1",
+          location: "grid",
+          worktreeId: "wt-a",
+          activeTabId: "recipe-1",
+          panelIds: ["recipe-1"],
+        },
+      ]);
     });
 
     it("includes a global dock panel in a worktree-scoped dock query before flush", () => {
@@ -587,7 +595,7 @@ describe("Tab Group Worktree Invariant", () => {
 
       const state = usePanelStore.getState();
       expect(state.panelIds).not.toContain("dock-1");
-      expect(state.panelIdsByWorktreeId["__none__"]).toContain("dock-1");
+      expect(state.panelIdsByWorktreeId[NO_WORKTREE]).toContain("dock-1");
 
       // Dock-global rule: a panel with worktreeId === undefined must still
       // appear in a dock query scoped to a concrete worktree.
@@ -605,6 +613,21 @@ describe("Tab Group Worktree Invariant", () => {
       expect(allIds).not.toContain("recipe-1");
     });
 
+    it("keeps a global pending panel out of a concrete worktree's grid", () => {
+      // The NO_WORKTREE bucket is scanned for grid queries too, but the in-loop
+      // panelMatchesWorktreeScope filter must still keep global panels out of a
+      // worktree-scoped grid (only dock queries surface them).
+      const globalPanel = createMockTerminal("global-1", undefined, "grid");
+      commitOnePanelToIndexOnly(globalPanel);
+
+      const state = usePanelStore.getState();
+      expect(state.panelIdsByWorktreeId[NO_WORKTREE]).toContain("global-1");
+
+      const groups = state.getTabGroups("grid", "wt-a");
+      const allIds = groups.flatMap((g) => g.panelIds);
+      expect(allIds).not.toContain("global-1");
+    });
+
     it("preserves committed panelIds ordering and appends batched panels last", () => {
       const committed = createMockTerminal("committed-1", "wt-a", "grid");
       const batched = createMockTerminal("batched-2", "wt-a", "grid");
@@ -618,6 +641,21 @@ describe("Tab Group Worktree Invariant", () => {
       const groups = usePanelStore.getState().getTabGroups("grid", "wt-a");
       const orderedIds = groups.flatMap((g) => g.panelIds);
       expect(orderedIds).toEqual(["committed-1", "batched-2"]);
+    });
+
+    it("does not duplicate a panel once it lands in both panelIds and the index after flush", () => {
+      const panel = createMockTerminal("recipe-1", "wt-a", "grid");
+      // Post-flush state: the id is now in BOTH panelIds and the index bucket.
+      usePanelStore.setState({
+        panelsById: { "recipe-1": panel },
+        panelIds: ["recipe-1"],
+        panelIdsByWorktreeId: { "wt-a": ["recipe-1"] },
+        tabGroups: new Map(),
+      });
+
+      const groups = usePanelStore.getState().getTabGroups("grid", "wt-a");
+      const allIds = groups.flatMap((g) => g.panelIds);
+      expect(allIds).toEqual(["recipe-1"]);
     });
   });
 });

--- a/src/store/slices/panelRegistry/__tests__/tabGroupWorktreeInvariant.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/tabGroupWorktreeInvariant.test.ts
@@ -544,4 +544,80 @@ describe("Tab Group Worktree Invariant", () => {
       expect(persistedGroups.has("g1")).toBe(true);
     });
   });
+
+  // Regression for #9649: a recipe-launched panel spawns inside a
+  // beginSpawnBatch/flushSpawnBatch window where the worktree index
+  // (panelIdsByWorktreeId) is committed eagerly but panelIds only appends at
+  // flush. getTabGroups must surface the batched panel from the index so the
+  // grid paints on first mount instead of staying blank until a worktree
+  // switch forces a re-derive.
+  describe("getTabGroups pre-flush batch visibility (#9649)", () => {
+    // Simulate Commit #1 of a spawn batch: panelsById + the worktree index hold
+    // the new panel, but panelIds does NOT yet contain it (deferred to flush).
+    function commitOnePanelToIndexOnly(panel: PtyPanelData, committedIds: string[] = []) {
+      const byId: Record<string, PtyPanelData> = { [panel.id]: panel };
+      const index: Record<string, string[]> = {};
+      const bucket = panel.worktreeId ?? "__none__";
+      index[bucket] = [...committedIds, panel.id];
+      usePanelStore.setState({
+        panelsById: byId,
+        panelIds: committedIds,
+        panelIdsByWorktreeId: index,
+        tabGroups: new Map(),
+      });
+    }
+
+    it("returns a virtual grid group for a batched panel before panelIds flush", () => {
+      const recipePanel = createMockTerminal("recipe-1", "wt-a", "grid");
+      commitOnePanelToIndexOnly(recipePanel);
+
+      const state = usePanelStore.getState();
+      // Precondition: panelIds is still stale (deferred), index already has it.
+      expect(state.panelIds).not.toContain("recipe-1");
+      expect(state.panelIdsByWorktreeId["wt-a"]).toContain("recipe-1");
+
+      const groups = state.getTabGroups("grid", "wt-a");
+      const allIds = groups.flatMap((g) => g.panelIds);
+      expect(allIds).toContain("recipe-1");
+    });
+
+    it("includes a global dock panel in a worktree-scoped dock query before flush", () => {
+      const dockPanel = createMockTerminal("dock-1", undefined, "dock");
+      commitOnePanelToIndexOnly(dockPanel);
+
+      const state = usePanelStore.getState();
+      expect(state.panelIds).not.toContain("dock-1");
+      expect(state.panelIdsByWorktreeId["__none__"]).toContain("dock-1");
+
+      // Dock-global rule: a panel with worktreeId === undefined must still
+      // appear in a dock query scoped to a concrete worktree.
+      const groups = state.getTabGroups("dock", "wt-a");
+      const allIds = groups.flatMap((g) => g.panelIds);
+      expect(allIds).toContain("dock-1");
+    });
+
+    it("keeps a batched panel out of a different worktree's grid", () => {
+      const recipePanel = createMockTerminal("recipe-1", "wt-a", "grid");
+      commitOnePanelToIndexOnly(recipePanel);
+
+      const groups = usePanelStore.getState().getTabGroups("grid", "wt-b");
+      const allIds = groups.flatMap((g) => g.panelIds);
+      expect(allIds).not.toContain("recipe-1");
+    });
+
+    it("preserves committed panelIds ordering and appends batched panels last", () => {
+      const committed = createMockTerminal("committed-1", "wt-a", "grid");
+      const batched = createMockTerminal("batched-2", "wt-a", "grid");
+      usePanelStore.setState({
+        panelsById: { "committed-1": committed, "batched-2": batched },
+        panelIds: ["committed-1"],
+        panelIdsByWorktreeId: { "wt-a": ["committed-1", "batched-2"] },
+        tabGroups: new Map(),
+      });
+
+      const groups = usePanelStore.getState().getTabGroups("grid", "wt-a");
+      const orderedIds = groups.flatMap((g) => g.panelIds);
+      expect(orderedIds).toEqual(["committed-1", "batched-2"]);
+    });
+  });
 });

--- a/src/store/slices/panelRegistry/tabGroups.ts
+++ b/src/store/slices/panelRegistry/tabGroups.ts
@@ -10,10 +10,55 @@ import { TerminalRefreshTier } from "@/types";
 import { saveNormalized, saveTabGroups } from "./persistence";
 import { optimizeForDock } from "./layout";
 import { deriveRuntimeStatus, dissolvePanelFromGroup } from "./helpers";
-import { transferBetweenWorktreeIndex } from "./worktreeIndex";
+import { NO_WORKTREE, transferBetweenWorktreeIndex } from "./worktreeIndex";
 
 type Set = PanelRegistryStoreApi["setState"];
 type Get = PanelRegistryStoreApi["getState"];
+
+/**
+ * Candidate panel ids for the ungrouped-panel scan in `getTabGroups`.
+ *
+ * Iterates `panelIds` first (preserving committed order so explicit/virtual
+ * group ordering and drag-reorder via `reorderTabGroups` stay correct), then
+ * appends any ids present in `panelIdsByWorktreeId` but not yet in `panelIds`.
+ *
+ * That tail is the fix for #9649: during a `beginSpawnBatch`/`flushSpawnBatch`
+ * window, the worktree index is updated eagerly at panel creation while
+ * `panelIds` only appends at flush. Reading `panelIds` alone left freshly-
+ * batched recipe panels out of every virtual group until a worktree switch
+ * forced a re-derive. `gridPanelIds` in `useContentGridContext` already reads
+ * the index, so including its pending ids keeps the ungrouped source consistent
+ * with the grid's structural dep — the panel paints on first mount.
+ *
+ * For a concrete `worktreeId`, the tail scans that worktree's bucket plus the
+ * `NO_WORKTREE` bucket (dock-global panels are visible in every worktree-scoped
+ * dock — the per-panel `panelMatchesWorktreeScope` filter inside the loop keeps
+ * them out of grid queries). For `worktreeId === undefined`, it scans every
+ * bucket.
+ */
+function collectUngroupedCandidateIds(
+  panelIds: string[],
+  panelIdsByWorktreeId: Record<string, string[]>,
+  worktreeId: string | undefined
+): string[] {
+  const seen = new Set(panelIds);
+  const buckets =
+    worktreeId === undefined
+      ? Object.values(panelIdsByWorktreeId)
+      : [panelIdsByWorktreeId[worktreeId], panelIdsByWorktreeId[NO_WORKTREE]];
+
+  let pending: string[] | undefined;
+  for (const bucket of buckets) {
+    if (!bucket) continue;
+    for (const id of bucket) {
+      if (seen.has(id)) continue;
+      seen.add(id);
+      (pending ??= []).push(id);
+    }
+  }
+
+  return pending ? [...panelIds, ...pending] : panelIds;
+}
 
 function getPanelTabGroupLocation(
   panel: PanelInstance | CarrierPanel | undefined
@@ -271,9 +316,15 @@ export const createTabGroupActions = (
       }
     }
 
-    // Find ungrouped panels
+    // Find ungrouped panels. Source from the eagerly-committed worktree index
+    // (not `panelIds`, which lags during a spawn batch) so freshly-batched
+    // panels paint immediately rather than after a worktree switch (#9649).
     const ungroupedPanels: CarrierPanel[] = [];
-    for (const tid of state.panelIds) {
+    for (const tid of collectUngroupedCandidateIds(
+      state.panelIds,
+      state.panelIdsByWorktreeId,
+      worktreeId
+    )) {
       const t = state.panelsById[tid];
       if (!t) continue;
       if (t.location === "trash" || trashedTerminals.has(t.id)) continue;

--- a/src/store/slices/panelRegistry/worktreeIndex.ts
+++ b/src/store/slices/panelRegistry/worktreeIndex.ts
@@ -13,7 +13,7 @@
 export type PanelIdsByWorktreeId = Record<string, string[]>;
 
 /** Bucket key for panels with `worktreeId === undefined`. */
-const NO_WORKTREE = "__none__";
+export const NO_WORKTREE = "__none__";
 
 function bucketKey(worktreeId: string | undefined | null): string {
   return worktreeId ?? NO_WORKTREE;


### PR DESCRIPTION
## Summary

- Recipe-launched agent terminals rendered blank until a worktree switch forced re-derive. The switch-and-back workaround was the tell.
- Root cause: a spawn-batch state tear. `addPanel` commits to the worktree index (`panelIdsByWorktreeId`) eagerly but defers to `panelIds` until `flushSpawnBatch`. `getTabGroups` was reading `panelIds` alone, so the freshly-launched panel landed in no virtual group and the grid rendered blank.
- Fix: `getTabGroups` now sources ungrouped candidates from `panelIds` plus any ids present in `panelIdsByWorktreeId` but not yet flushed, via a new `collectUngroupedCandidateIds` helper. Also exports `NO_WORKTREE` from `worktreeIndex` for the dock-global bucket. Deferring `panelIdsByWorktreeId` to flush was considered and rejected -- it violates the batch invariant since the index is a live mid-spawn lookup used by `applyWorktreeTerminalPolicy`.

Resolves #9649

## Changes

- `src/store/slices/panelRegistry/tabGroups.ts` -- `collectUngroupedCandidateIds` helper; `getTabGroups` reads both sources, iterating `panelIds` first to preserve committed order
- `src/store/slices/panelRegistry/worktreeIndex.ts` -- export `NO_WORKTREE`
- `src/store/slices/panelRegistry/__tests__/tabGroupWorktreeInvariant.test.ts` -- 5 new regression tests: pre-flush virtual group visibility, dock-global inclusion, grid-scope isolation, committed-ordering preservation, post-flush idempotency
- `src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts` -- 1 integration test driving `beginSpawnBatch` + `addPanel` and asserting `getTabGroups` surfaces the panel before flush

## Testing

All 6 new tests pass. `npm run check` clean (ESLint warnings down by 1 vs baseline).