### PR TITLE
fix(focus): snapshot helpPanelStore.isOpen on focus-mode gesture entry

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -21,6 +21,7 @@ import {
   useDiagnosticsStore,
   useDockStore,
   useFocusStore,
+  useHelpPanelStore,
   usePreferencesStore,
   useUIStore,
   type PanelState,
@@ -224,15 +225,27 @@ export function AppLayout({
     // only the worktree sidebar, and using it here would treat that single
     // toolbar action as a gesture exit (clearing the sidebar gesture instead
     // of entering the gesture and hiding the assistant).
-    const gestureActive = useFocusStore.getState().gestureSnapshot !== null;
+    const snapshot = useFocusStore.getState().gestureSnapshot;
+    const gestureActive = snapshot !== null;
     if (gestureActive) {
       if (layout.savedPanelState) {
         setSidebarWidth((layout.savedPanelState as PanelState).sidebarWidth);
       }
+      // Read the assistant's pre-entry isOpen before toggleFocusMode clears the
+      // snapshot. Restore it only when the gesture itself hid the assistant —
+      // symmetric with the sidebar revert, which the store gates on hidSidebar
+      // ("the snapshot only owns the deltas it caused"). If the assistant was
+      // never gesture-hidden (e.g. a sidebar-only gesture), an explicit toolbar
+      // open during focus mode must survive the exit rather than be snapped shut.
+      const restoreAssistant = snapshot.hidAssistant;
+      const assistantWasOpen = snapshot.assistantWasOpen;
       layout.toggleFocusMode({
         sidebarWidth,
         diagnosticsOpen: layout.diagnosticsOpen,
       } as PanelState);
+      if (restoreAssistant) {
+        useHelpPanelStore.getState().setOpen(assistantWasOpen);
+      }
       // Persist to per-project state
       if (currentProject?.id) {
         try {
@@ -253,10 +266,17 @@ export function AppLayout({
         sidebarWidth,
         diagnosticsOpen: layout.diagnosticsOpen,
       };
-      layout.toggleFocusMode(currentPanelState, {
-        sidebarVisible: showSidebar,
-        assistantVisible: showAssistant,
-      });
+      // Capture the persistent toolbar preference synchronously at gesture
+      // entry so the exit path can restore it (see GestureSnapshot.assistantWasOpen).
+      const assistantWasOpen = useHelpPanelStore.getState().isOpen;
+      layout.toggleFocusMode(
+        currentPanelState,
+        {
+          sidebarVisible: showSidebar,
+          assistantVisible: showAssistant,
+        },
+        assistantWasOpen
+      );
       // Persist to per-project state — only when something actually changed.
       // toggleFocusMode is a no-op if neither sidebar was visible.
       const persistFocusMode = useFocusStore.getState().isFocusMode || showSidebar || showAssistant;

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -268,12 +268,15 @@ export function AppLayout({
       };
       // Capture the persistent toolbar preference synchronously at gesture
       // entry so the exit path can restore it (see GestureSnapshot.assistantWasOpen).
+      // Derive assistantVisible from the same live read rather than the render
+      // closure's showAssistant, so the snapshot's hidAssistant and
+      // assistantWasOpen can't diverge if isOpen changed since the last render.
       const assistantWasOpen = useHelpPanelStore.getState().isOpen;
       layout.toggleFocusMode(
         currentPanelState,
         {
           sidebarVisible: showSidebar,
-          assistantVisible: showAssistant,
+          assistantVisible: !layout.gestureAssistantHidden && assistantWasOpen,
         },
         assistantWasOpen
       );

--- a/src/components/Layout/__tests__/AppLayout.focusAssistant.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.focusAssistant.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+
+const APP_LAYOUT_PATH = path.resolve(__dirname, "../AppLayout.tsx");
+
+// Issue #9641: focus-mode gesture and the toolbar toggle are independent gates
+// over Assistant visibility. AppLayout must snapshot the toolbar preference
+// (helpPanelStore.isOpen) on gesture entry and restore it on exit — symmetric
+// with the sidebar — without collapsing the two gates into one flag.
+describe("AppLayout focus-mode assistant reconciliation — issue #9641", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(APP_LAYOUT_PATH, "utf-8");
+  });
+
+  it("captures the toolbar isOpen preference at gesture entry and passes it to toggleFocusMode", () => {
+    // The capture must read from the store imperatively (synchronously) at
+    // entry so the value can't drift before the exit restores it.
+    expect(source).toContain("const assistantWasOpen = useHelpPanelStore.getState().isOpen");
+  });
+
+  it("restores the assistant via helpPanelStore.setOpen on gesture exit", () => {
+    expect(source).toContain("useHelpPanelStore.getState().setOpen(assistantWasOpen)");
+  });
+
+  it("gates the exit restore on the gesture having hidden the assistant", () => {
+    // Symmetric with the sidebar revert ("the snapshot only owns the deltas it
+    // caused"): an assistant the gesture never hid must not be touched on exit.
+    expect(source).toContain("const restoreAssistant = snapshot.hidAssistant");
+    expect(source).toMatch(/if \(restoreAssistant\) \{\s*\n\s*useHelpPanelStore\.getState\(\)\.setOpen/);
+  });
+
+  it("keeps the two visibility gates independent — showAssistant stays a compound predicate", () => {
+    // The fix must not collapse helpPanelOpen and gestureAssistantHidden into a
+    // single source of truth (locked decision on the issue).
+    expect(source).toContain(
+      "const showAssistant = !layout.gestureAssistantHidden && layout.helpPanelOpen"
+    );
+  });
+});

--- a/src/components/Layout/__tests__/AppLayout.focusAssistant.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.focusAssistant.test.ts
@@ -29,7 +29,9 @@ describe("AppLayout focus-mode assistant reconciliation — issue #9641", () => 
     // Symmetric with the sidebar revert ("the snapshot only owns the deltas it
     // caused"): an assistant the gesture never hid must not be touched on exit.
     expect(source).toContain("const restoreAssistant = snapshot.hidAssistant");
-    expect(source).toMatch(/if \(restoreAssistant\) \{\s*\n\s*useHelpPanelStore\.getState\(\)\.setOpen/);
+    expect(source).toMatch(
+      /if \(restoreAssistant\) \{\s*\n\s*useHelpPanelStore\.getState\(\)\.setOpen/
+    );
   });
 
   it("keeps the two visibility gates independent — showAssistant stays a compound predicate", () => {

--- a/src/hooks/useLayoutState.ts
+++ b/src/hooks/useLayoutState.ts
@@ -16,7 +16,8 @@ export interface LayoutState {
   gestureAssistantHidden: boolean;
   toggleFocusMode: (
     currentState: PanelState,
-    visibility?: { sidebarVisible: boolean; assistantVisible: boolean }
+    visibility?: { sidebarVisible: boolean; assistantVisible: boolean },
+    assistantWasOpen?: boolean
   ) => void;
   setFocusMode: (mode: boolean, savedState?: PanelState) => void;
   setSidebarGestureHidden: (hidden: boolean, currentPanelState?: PanelState) => void;

--- a/src/store/__tests__/focusStore.adversarial.test.ts
+++ b/src/store/__tests__/focusStore.adversarial.test.ts
@@ -143,7 +143,8 @@ describe("focusStore independent gestures (issue #6659)", () => {
     expect(useFocusStore.getState().gestureSnapshot).toEqual({
       hidSidebar: true,
       hidAssistant: true,
-      assistantWasOpen: false,
+      // No 3rd arg passed → falls back to assistantVisible (true here).
+      assistantWasOpen: true,
     });
   });
 
@@ -312,13 +313,16 @@ describe("focusStore assistant isOpen restore (issue #9641)", () => {
     expect(useFocusStore.getState().gestureSnapshot?.assistantWasOpen).toBe(false);
   });
 
-  it("defaults assistantWasOpen to false when the argument is omitted", () => {
+  it("falls back to assistantVisible for assistantWasOpen when the argument is omitted", () => {
+    // assistantVisible equals the pre-entry isOpen at gesture entry, so it's the
+    // safest fallback — a caller that forgets the 3rd arg still restores a
+    // logically-open assistant rather than silently closing it on exit.
     useFocusStore.getState().toggleFocusMode(panelState, {
       sidebarVisible: true,
       assistantVisible: true,
     });
 
-    expect(useFocusStore.getState().gestureSnapshot?.assistantWasOpen).toBe(false);
+    expect(useFocusStore.getState().gestureSnapshot?.assistantWasOpen).toBe(true);
   });
 });
 
@@ -382,6 +386,23 @@ describe("focus-mode exit assistant reconciliation contract (issue #9641)", () =
 
     // The gesture never owned the assistant, so exiting must not snap it shut.
     expect(useHelpPanelStore.getState().isOpen).toBe(true);
+  });
+
+  it("restores the assistant on an assistant-only gesture round-trip without touching the sidebar", () => {
+    useHelpPanelStore.setState({ isOpen: true });
+    useFocusStore.getState().toggleFocusMode(
+      panelState,
+      { sidebarVisible: false, assistantVisible: true },
+      true
+    );
+    // Assistant masked by the gesture; user closes it via toolbar mid-focus.
+    useHelpPanelStore.getState().setOpen(false);
+
+    exitFocusGesture();
+
+    expect(useHelpPanelStore.getState().isOpen).toBe(true);
+    expect(useFocusStore.getState().gestureSidebarHidden).toBe(false);
+    expect(useFocusStore.getState().gestureSnapshot).toBeNull();
   });
 
   it("keeps the assistant closed when it was closed at entry and gesture hid only the sidebar", () => {

--- a/src/store/__tests__/focusStore.adversarial.test.ts
+++ b/src/store/__tests__/focusStore.adversarial.test.ts
@@ -294,21 +294,17 @@ describe("focusStore assistant isOpen restore (issue #9641)", () => {
   const panelState: PanelState = { sidebarWidth: 320, diagnosticsOpen: false };
 
   it("captures assistantWasOpen in the snapshot when passed true", () => {
-    useFocusStore.getState().toggleFocusMode(
-      panelState,
-      { sidebarVisible: true, assistantVisible: true },
-      true
-    );
+    useFocusStore
+      .getState()
+      .toggleFocusMode(panelState, { sidebarVisible: true, assistantVisible: true }, true);
 
     expect(useFocusStore.getState().gestureSnapshot?.assistantWasOpen).toBe(true);
   });
 
   it("captures assistantWasOpen in the snapshot when passed false", () => {
-    useFocusStore.getState().toggleFocusMode(
-      panelState,
-      { sidebarVisible: true, assistantVisible: false },
-      false
-    );
+    useFocusStore
+      .getState()
+      .toggleFocusMode(panelState, { sidebarVisible: true, assistantVisible: false }, false);
 
     expect(useFocusStore.getState().gestureSnapshot?.assistantWasOpen).toBe(false);
   });
@@ -357,11 +353,9 @@ describe("focus-mode exit assistant reconciliation contract (issue #9641)", () =
   it("reopens an assistant that was open at entry, even after a toolbar close during focus mode", () => {
     // Assistant open via toolbar, gesture hides it (captures assistantWasOpen=true).
     useHelpPanelStore.setState({ isOpen: true });
-    useFocusStore.getState().toggleFocusMode(
-      panelState,
-      { sidebarVisible: true, assistantVisible: true },
-      true
-    );
+    useFocusStore
+      .getState()
+      .toggleFocusMode(panelState, { sidebarVisible: true, assistantVisible: true }, true);
     // User closes the assistant via the toolbar while in focus mode.
     useHelpPanelStore.getState().setOpen(false);
 
@@ -374,11 +368,9 @@ describe("focus-mode exit assistant reconciliation contract (issue #9641)", () =
   it("leaves a mid-focus toolbar-opened assistant open when the gesture never hid it (sidebar-only gesture)", () => {
     // Assistant closed at entry; gesture hides only the sidebar (hidAssistant=false).
     useHelpPanelStore.setState({ isOpen: false });
-    useFocusStore.getState().toggleFocusMode(
-      panelState,
-      { sidebarVisible: true, assistantVisible: false },
-      false
-    );
+    useFocusStore
+      .getState()
+      .toggleFocusMode(panelState, { sidebarVisible: true, assistantVisible: false }, false);
     // User opens the assistant via the toolbar while in focus mode.
     useHelpPanelStore.getState().setOpen(true);
 
@@ -390,11 +382,9 @@ describe("focus-mode exit assistant reconciliation contract (issue #9641)", () =
 
   it("restores the assistant on an assistant-only gesture round-trip without touching the sidebar", () => {
     useHelpPanelStore.setState({ isOpen: true });
-    useFocusStore.getState().toggleFocusMode(
-      panelState,
-      { sidebarVisible: false, assistantVisible: true },
-      true
-    );
+    useFocusStore
+      .getState()
+      .toggleFocusMode(panelState, { sidebarVisible: false, assistantVisible: true }, true);
     // Assistant masked by the gesture; user closes it via toolbar mid-focus.
     useHelpPanelStore.getState().setOpen(false);
 
@@ -407,11 +397,9 @@ describe("focus-mode exit assistant reconciliation contract (issue #9641)", () =
 
   it("keeps the assistant closed when it was closed at entry and gesture hid only the sidebar", () => {
     useHelpPanelStore.setState({ isOpen: false });
-    useFocusStore.getState().toggleFocusMode(
-      panelState,
-      { sidebarVisible: true, assistantVisible: false },
-      false
-    );
+    useFocusStore
+      .getState()
+      .toggleFocusMode(panelState, { sidebarVisible: true, assistantVisible: false }, false);
 
     exitFocusGesture();
 

--- a/src/store/__tests__/focusStore.adversarial.test.ts
+++ b/src/store/__tests__/focusStore.adversarial.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { useFocusStore, type PanelState } from "../focusStore";
+import { useHelpPanelStore } from "../helpPanelStore";
 
 const cleanState = {
   gestureSidebarHidden: false,
@@ -142,6 +143,7 @@ describe("focusStore independent gestures (issue #6659)", () => {
     expect(useFocusStore.getState().gestureSnapshot).toEqual({
       hidSidebar: true,
       hidAssistant: true,
+      assistantWasOpen: false,
     });
   });
 
@@ -244,6 +246,7 @@ describe("focusStore independent gestures (issue #6659)", () => {
     expect(useFocusStore.getState().gestureSnapshot).toEqual({
       hidSidebar: true,
       hidAssistant: false,
+      assistantWasOpen: false,
     });
   });
 
@@ -283,5 +286,114 @@ describe("focusStore independent gestures (issue #6659)", () => {
     expect(useFocusStore.getState().gestureSidebarHidden).toBe(true);
     expect(useFocusStore.getState().gestureAssistantHidden).toBe(false);
     expect(useFocusStore.getState().isFocusMode).toBe(true);
+  });
+});
+
+describe("focusStore assistant isOpen restore (issue #9641)", () => {
+  const panelState: PanelState = { sidebarWidth: 320, diagnosticsOpen: false };
+
+  it("captures assistantWasOpen in the snapshot when passed true", () => {
+    useFocusStore.getState().toggleFocusMode(
+      panelState,
+      { sidebarVisible: true, assistantVisible: true },
+      true
+    );
+
+    expect(useFocusStore.getState().gestureSnapshot?.assistantWasOpen).toBe(true);
+  });
+
+  it("captures assistantWasOpen in the snapshot when passed false", () => {
+    useFocusStore.getState().toggleFocusMode(
+      panelState,
+      { sidebarVisible: true, assistantVisible: false },
+      false
+    );
+
+    expect(useFocusStore.getState().gestureSnapshot?.assistantWasOpen).toBe(false);
+  });
+
+  it("defaults assistantWasOpen to false when the argument is omitted", () => {
+    useFocusStore.getState().toggleFocusMode(panelState, {
+      sidebarVisible: true,
+      assistantVisible: true,
+    });
+
+    expect(useFocusStore.getState().gestureSnapshot?.assistantWasOpen).toBe(false);
+  });
+});
+
+// The user-visible restore (helpPanelStore.isOpen) is wired in
+// AppLayout.handleToggleFocusMode, not in focusStore — the store deliberately
+// never imports helpPanelStore. These tests replicate that exit reconciliation
+// against the live stores to lock the cross-store contract: the snapshot must
+// carry enough information for the exit path to restore the assistant's
+// pre-entry isOpen, and the restore must be gated on the gesture having
+// actually hidden the assistant (symmetric with the sidebar revert).
+describe("focus-mode exit assistant reconciliation contract (issue #9641)", () => {
+  const panelState: PanelState = { sidebarWidth: 320, diagnosticsOpen: false };
+
+  beforeEach(() => {
+    useHelpPanelStore.setState({ isOpen: false });
+  });
+  afterEach(() => {
+    useHelpPanelStore.setState({ isOpen: false });
+  });
+
+  // Mirrors AppLayout.handleToggleFocusMode's gesture-exit branch.
+  function exitFocusGesture() {
+    const snapshot = useFocusStore.getState().gestureSnapshot;
+    const restoreAssistant = snapshot?.hidAssistant ?? false;
+    const assistantWasOpen = snapshot?.assistantWasOpen ?? false;
+    useFocusStore.getState().toggleFocusMode(panelState);
+    if (restoreAssistant) {
+      useHelpPanelStore.getState().setOpen(assistantWasOpen);
+    }
+  }
+
+  it("reopens an assistant that was open at entry, even after a toolbar close during focus mode", () => {
+    // Assistant open via toolbar, gesture hides it (captures assistantWasOpen=true).
+    useHelpPanelStore.setState({ isOpen: true });
+    useFocusStore.getState().toggleFocusMode(
+      panelState,
+      { sidebarVisible: true, assistantVisible: true },
+      true
+    );
+    // User closes the assistant via the toolbar while in focus mode.
+    useHelpPanelStore.getState().setOpen(false);
+
+    exitFocusGesture();
+
+    expect(useHelpPanelStore.getState().isOpen).toBe(true);
+    expect(useFocusStore.getState().gestureAssistantHidden).toBe(false);
+  });
+
+  it("leaves a mid-focus toolbar-opened assistant open when the gesture never hid it (sidebar-only gesture)", () => {
+    // Assistant closed at entry; gesture hides only the sidebar (hidAssistant=false).
+    useHelpPanelStore.setState({ isOpen: false });
+    useFocusStore.getState().toggleFocusMode(
+      panelState,
+      { sidebarVisible: true, assistantVisible: false },
+      false
+    );
+    // User opens the assistant via the toolbar while in focus mode.
+    useHelpPanelStore.getState().setOpen(true);
+
+    exitFocusGesture();
+
+    // The gesture never owned the assistant, so exiting must not snap it shut.
+    expect(useHelpPanelStore.getState().isOpen).toBe(true);
+  });
+
+  it("keeps the assistant closed when it was closed at entry and gesture hid only the sidebar", () => {
+    useHelpPanelStore.setState({ isOpen: false });
+    useFocusStore.getState().toggleFocusMode(
+      panelState,
+      { sidebarVisible: true, assistantVisible: false },
+      false
+    );
+
+    exitFocusGesture();
+
+    expect(useHelpPanelStore.getState().isOpen).toBe(false);
   });
 });

--- a/src/store/focusStore.ts
+++ b/src/store/focusStore.ts
@@ -104,7 +104,10 @@ const createFocusStore: StateCreator<FocusState> = (set, get) => ({
         gestureSnapshot: {
           hidSidebar: sidebarVisible,
           hidAssistant: assistantVisible,
-          assistantWasOpen: assistantWasOpen ?? false,
+          // Fall back to assistantVisible (which equals the pre-entry isOpen at
+          // gesture entry) when a caller omits the value, so the exit restore
+          // can't silently snap a logically-open assistant shut.
+          assistantWasOpen: assistantWasOpen ?? assistantVisible,
         },
         savedPanelState: { ...currentPanelState },
       };

--- a/src/store/focusStore.ts
+++ b/src/store/focusStore.ts
@@ -8,6 +8,13 @@ export interface PanelState {
 interface GestureSnapshot {
   hidSidebar: boolean;
   hidAssistant: boolean;
+  // `helpPanelStore.isOpen` captured at gesture entry. The gesture hides the
+  // assistant via `gestureAssistantHidden` but never touches `isOpen` (the
+  // persistent toolbar preference, owned by a separate store). Recording the
+  // pre-entry value lets the exit path restore it symmetrically with the
+  // sidebar — otherwise a toolbar toggle during focus mode would leave the
+  // assistant at whatever `isOpen` drifted to instead of its pre-entry state.
+  assistantWasOpen: boolean;
 }
 
 interface FocusState {
@@ -35,7 +42,8 @@ interface FocusState {
 
   toggleFocusMode: (
     currentPanelState: PanelState,
-    visibility?: { sidebarVisible: boolean; assistantVisible: boolean }
+    visibility?: { sidebarVisible: boolean; assistantVisible: boolean },
+    assistantWasOpen?: boolean
   ) => void;
   setFocusMode: (enabled: boolean, currentPanelState?: PanelState) => void;
   setSidebarGestureHidden: (hidden: boolean, currentPanelState?: PanelState) => void;
@@ -52,7 +60,7 @@ const createFocusStore: StateCreator<FocusState> = (set, get) => ({
   gestureSnapshot: null,
   savedPanelState: null,
 
-  toggleFocusMode: (currentPanelState, visibility) =>
+  toggleFocusMode: (currentPanelState, visibility, assistantWasOpen) =>
     set((state) => {
       // Exit only when the double-click gesture itself is active (snapshot
       // present). The combined `isFocusMode` flag also flips for sidebar-only
@@ -93,7 +101,11 @@ const createFocusStore: StateCreator<FocusState> = (set, get) => ({
         gestureSidebarHidden: sidebarVisible || state.gestureSidebarHidden,
         gestureAssistantHidden: assistantVisible || state.gestureAssistantHidden,
         isFocusMode: true,
-        gestureSnapshot: { hidSidebar: sidebarVisible, hidAssistant: assistantVisible },
+        gestureSnapshot: {
+          hidSidebar: sidebarVisible,
+          hidAssistant: assistantVisible,
+          assistantWasOpen: assistantWasOpen ?? false,
+        },
         savedPanelState: { ...currentPanelState },
       };
     }),
@@ -111,7 +123,9 @@ const createFocusStore: StateCreator<FocusState> = (set, get) => ({
           gestureSidebarHidden: true,
           gestureAssistantHidden: false,
           isFocusMode: true,
-          gestureSnapshot: { hidSidebar: true, hidAssistant: false },
+          // Hydration never hides the assistant (hidAssistant: false), so there's
+          // no isOpen to restore on exit — assistantWasOpen is irrelevant here.
+          gestureSnapshot: { hidSidebar: true, hidAssistant: false, assistantWasOpen: false },
           savedPanelState: cloned,
         };
       } else if (!enabled && state.isFocusMode) {


### PR DESCRIPTION
## Summary

- Two independent flags gate Assistant visibility (`gestureAssistantHidden` + `helpPanelStore.isOpen`), but `toggleFocusMode` only snapshotted sidebar state. Exiting focus mode restored the sidebar and left the Assistant at whatever `isOpen` had drifted to.
- Adds `assistantWasOpen: boolean` to `GestureSnapshot` in `focusStore.ts`, captured at gesture entry via an optional third param to `toggleFocusMode`. `AppLayout.handleToggleFocusMode` reads `useHelpPanelStore.getState().isOpen` synchronously at entry and passes it in; on exit restores via `useHelpPanelStore.getState().setOpen`, gated on `snapshot.hidAssistant` so the revert only undoes what the gesture actually hid.
- `focusStore` never imports `helpPanelStore` — cross-store coordination lives in `AppLayout`, keeping store isolation intact.

Resolves #9641

## Changes

- `src/store/focusStore.ts` — `GestureSnapshot` gains `assistantWasOpen`; `toggleFocusMode` accepts optional `assistantWasOpen` param; exit path gates the `setOpen` restore on `hidAssistant`
- `src/hooks/useLayoutState.ts` — minor type alignment
- `src/components/Layout/AppLayout.tsx` — `handleToggleFocusMode` captures and passes `isOpen`; restores on exit
- `src/store/__tests__/focusStore.adversarial.test.ts` — snapshot capture (true/false/fallback), cross-store exit reconciliation, sidebar-only gesture leaves a mid-focus-opened assistant untouched
- `src/components/Layout/__tests__/AppLayout.focusAssistant.test.ts` — AppLayout wiring tests (new file)

## Testing

33 tests passing across the two test files. `npm run check` clean — typecheck passes, lint ratchet down 1 from baseline, format verified, IPC/channel/confirm-wiring guards all green.