### PR TITLE
refactor(panels): split ephemeral flag into excludeFromPersistence + removeOnExit

### DIFF
--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -45,11 +45,17 @@ export interface AddPanelOptionsBase {
   /** Bypass panel limit checks (used during hydration/state restoration) */
   bypassLimits?: boolean;
   /**
-   * When true, the panel is excluded from persisted layout snapshots and is
-   * never rehydrated on app restart. Use for ad-hoc panels whose lifetime is
-   * bound to a transient UI surface (e.g. the Daintree assistant in the dock).
+   * When true, the panel is excluded from persisted layout snapshots and from
+   * user-visible terminal surfaces, and is never rehydrated on app restart. Use
+   * for ad-hoc panels whose lifetime is bound to a transient UI surface (e.g.
+   * the Daintree assistant in the dock). Independent of `removeOnExit`.
    */
-  ephemeral?: boolean;
+  excludeFromPersistence?: boolean;
+  /**
+   * When true, the panel is removed immediately when its PTY exits instead of
+   * being retained under the trash TTL. Independent of `excludeFromPersistence`.
+   */
+  removeOnExit?: boolean;
   /**
    * When the panel's *resolved* `location` is `"dock"`, atomically set it as
    * the open dock panel in the same `set()` that commits `panelsById`/

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -361,10 +361,17 @@ export interface PtyPanelData extends BasePanelData {
   /** Focus policy applied when this panel was created. */
   focusPolicy?: AddPanelFocusPolicy;
   /**
-   * When true, this panel is excluded from persisted layout snapshots and is
-   * never rehydrated on app restart (e.g. Daintree assistant dock terminals).
+   * When true, this panel is excluded from persisted layout snapshots and from
+   * user-visible terminal surfaces (counts, switchers, bulk actions). Such
+   * panels are never rehydrated on app restart (e.g. Daintree assistant dock
+   * terminals). Independent of `removeOnExit`.
    */
-  ephemeral?: boolean;
+  excludeFromPersistence?: boolean;
+  /**
+   * When true, this panel is removed immediately when its PTY exits instead of
+   * being retained under the trash TTL. Independent of `excludeFromPersistence`.
+   */
+  removeOnExit?: boolean;
   /** Timestamp when this terminal was created */
   startedAt?: number;
   /** Exit code from the last process exit */
@@ -595,10 +602,12 @@ export interface TerminalInstance {
   /** Focus policy applied when this panel was created. */
   focusPolicy?: AddPanelFocusPolicy;
   /**
-   * When true, this panel is excluded from persisted layout snapshots and is
-   * never rehydrated on app restart (e.g. Daintree assistant dock terminals).
+   * When true, this panel is excluded from persisted layout snapshots and from
+   * user-visible terminal surfaces (counts, switchers, bulk actions). Such
+   * panels are never rehydrated on app restart (e.g. Daintree assistant dock
+   * terminals).
    */
-  ephemeral?: boolean;
+  excludeFromPersistence?: boolean;
   /** Timestamp when this terminal was created */
   startedAt?: number;
   /** Exit code from the last process exit */

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -973,7 +973,8 @@ describe("HelpPanel — handleRunAnyway", () => {
         cwd: "/help",
         requestedId: expect.stringMatching(/^terminal-/),
         activateDockOnCreate: true,
-        ephemeral: true,
+        excludeFromPersistence: true,
+        removeOnExit: true,
         force: true,
       }),
       { source: "user" }
@@ -1842,7 +1843,8 @@ describe("HelpPanel — + New session destructive reset", () => {
         agentId: "claude",
         requestedId: expect.stringMatching(/^terminal-/),
         activateDockOnCreate: true,
-        ephemeral: true,
+        excludeFromPersistence: true,
+        removeOnExit: true,
       }),
       { source: "user" }
     );

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -470,7 +470,8 @@ describe("HelpPanel — resume from hibernated session", () => {
         launchAgentId: "claude",
         command: "claude --resume abc-123",
         cwd: "/tmp/help/proj-1",
-        ephemeral: true,
+        excludeFromPersistence: true,
+        removeOnExit: true,
       })
     );
     // Resume bypasses the standard agent.launch dispatch.

--- a/src/components/Terminal/TerminalCountWarning.tsx
+++ b/src/components/Terminal/TerminalCountWarning.tsx
@@ -22,7 +22,7 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
         const t = state.panelsById[id];
         if (!t || t.location === "trash") continue;
         const pty = isPtyPanel(t) ? t : undefined;
-        if (pty?.ephemeral === true) continue;
+        if (pty?.excludeFromPersistence === true) continue;
         active++;
         if (pty?.agentState === "completed" || pty?.agentState === "exited") completed++;
       }
@@ -87,7 +87,7 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
         const t = panelsById[id];
         if (!t || t.location === "trash") continue;
         const pty = isPtyPanel(t) ? t : undefined;
-        if (pty?.ephemeral === true) continue;
+        if (pty?.excludeFromPersistence === true) continue;
         if (pty?.agentState === "completed" || pty?.agentState === "exited") {
           idsToClose.push(t.id);
         }

--- a/src/components/Terminal/TerminalDestructiveActionConfirmDialog.tsx
+++ b/src/components/Terminal/TerminalDestructiveActionConfirmDialog.tsx
@@ -37,7 +37,7 @@ function buildCopy(pending: TerminalPendingDestructiveActionSnapshot): DialogCop
           : `${pending.runningAgentCount} have running agents.`;
       return {
         title: `Kill ${pending.targetCount} ${noun}?`,
-        description: `Killing every non-ephemeral terminal stops their processes and discards scrollback. ${agentNote} Active work and unsaved output will be lost.`,
+        description: `Killing every user-facing terminal stops their processes and discards scrollback. ${agentNote} Active work and unsaved output will be lost.`,
         confirmLabel: `Kill ${pending.targetCount} ${noun}`,
       };
     }

--- a/src/components/Terminal/__tests__/TerminalCountWarning.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalCountWarning.test.tsx
@@ -70,11 +70,11 @@ beforeAll(() => {
 
 beforeEach(() => {
   panelState.panelsById = {
-    a: { id: "a", location: "main", agentState: "working", ephemeral: false },
-    b: { id: "b", location: "main", agentState: "working", ephemeral: false },
-    c: { id: "c", location: "main", agentState: "working", ephemeral: false },
-    d: { id: "d", location: "main", agentState: "working", ephemeral: false },
-    e: { id: "e", location: "main", agentState: "working", ephemeral: false },
+    a: { id: "a", location: "main", agentState: "working", excludeFromPersistence: false },
+    b: { id: "b", location: "main", agentState: "working", excludeFromPersistence: false },
+    c: { id: "c", location: "main", agentState: "working", excludeFromPersistence: false },
+    d: { id: "d", location: "main", agentState: "working", excludeFromPersistence: false },
+    e: { id: "e", location: "main", agentState: "working", excludeFromPersistence: false },
   };
   panelState.panelIds = ["a", "b", "c", "d", "e"];
   panelState.trashPanel = vi.fn();
@@ -126,7 +126,7 @@ describe("TerminalCountWarning", () => {
       id: "f",
       location: "main",
       agentState: "completed",
-      ephemeral: false,
+      excludeFromPersistence: false,
     };
     panelState.panelIds = [...panelState.panelIds, "f"];
     render(<TerminalCountWarning />);
@@ -140,7 +140,7 @@ describe("TerminalCountWarning", () => {
       id: "f",
       location: "grid",
       agentState: "completed",
-      ephemeral: false,
+      excludeFromPersistence: false,
     };
     panelState.panelIds = [...panelState.panelIds, "f"];
     render(<TerminalCountWarning />);

--- a/src/components/Worktree/worktreeDeleteHelper.ts
+++ b/src/components/Worktree/worktreeDeleteHelper.ts
@@ -15,7 +15,7 @@ export function getLiveTerminalIdsForWorktree(worktreeId: string): string[] {
     return (
       panel?.worktreeId === worktreeId &&
       panel.location !== "trash" &&
-      (!isPtyPanel(panel) || panel.ephemeral !== true)
+      (!isPtyPanel(panel) || panel.excludeFromPersistence !== true)
     );
   });
 }

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -1344,7 +1344,8 @@ export class HelpSessionController {
       command,
       cwd,
       location: "dock",
-      ephemeral: true,
+      excludeFromPersistence: true,
+      removeOnExit: true,
       ...(env && { env }),
       ...(customLaunchFlags.length > 0 && { agentLaunchFlags: customLaunchFlags }),
     });
@@ -1479,7 +1480,8 @@ export class HelpSessionController {
           agentId: launchAgentId,
           location: "dock",
           cwd,
-          ephemeral: true,
+          excludeFromPersistence: true,
+          removeOnExit: true,
           ...(env && { env }),
           ...(customLaunchFlags.length > 0 && { agentLaunchFlags: customLaunchFlags }),
         },
@@ -1704,7 +1706,8 @@ export class HelpSessionController {
         agentId: launchAgentId,
         location: "dock",
         cwd,
-        ephemeral: true,
+        excludeFromPersistence: true,
+        removeOnExit: true,
       };
       if (env) dispatchArgs.env = env;
       if (customLaunchFlags.length > 0) dispatchArgs.agentLaunchFlags = customLaunchFlags;

--- a/src/hooks/__tests__/useTerminalSelectors.test.tsx
+++ b/src/hooks/__tests__/useTerminalSelectors.test.tsx
@@ -725,7 +725,7 @@ describe("buildWorktreeIds memoization", () => {
     const visible = {
       id: "t1",
       location: "grid" as const,
-      ephemeral: false,
+      excludeFromPersistence: false,
       worktreeId: "wt-1",
     } as const;
     expect(

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -66,10 +66,17 @@ export interface LaunchAgentOptions {
   env?: Record<string, string>;
   /**
    * When true, the spawned panel is excluded from persisted layout snapshots
-   * and is never rehydrated on app restart. Used by the help panel so the
-   * Daintree assistant terminal doesn't reappear in the dock after quit.
+   * and from user-visible terminal surfaces, and is never rehydrated on app
+   * restart. Used by the help panel so the Daintree assistant terminal doesn't
+   * reappear in the dock after quit. Independent of `removeOnExit`.
    */
-  ephemeral?: boolean;
+  excludeFromPersistence?: boolean;
+  /**
+   * When true, the spawned panel is removed immediately when its PTY exits
+   * instead of being retained under the trash TTL. Independent of
+   * `excludeFromPersistence`.
+   */
+  removeOnExit?: boolean;
   /**
    * Extra launch flags appended after the resolved settings/preset flags.
    * Used by the help panel to inject user-provided customArgs (e.g. `--model
@@ -490,7 +497,8 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               agentPresetColor: preset?.color,
               env: presetEnv,
               activateDockOnCreate: launchOptions?.activateDockOnCreate,
-              ephemeral: launchOptions?.ephemeral,
+              excludeFromPersistence: launchOptions?.excludeFromPersistence,
+              removeOnExit: launchOptions?.removeOnExit,
               spawnedBy,
               focusPolicy,
               requestedId: launchOptions?.requestedId,
@@ -503,7 +511,8 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               command,
               location: launchOptions?.location,
               activateDockOnCreate: launchOptions?.activateDockOnCreate,
-              ephemeral: launchOptions?.ephemeral,
+              excludeFromPersistence: launchOptions?.excludeFromPersistence,
+              removeOnExit: launchOptions?.removeOnExit,
               spawnedBy,
               focusPolicy,
               requestedId: launchOptions?.requestedId,
@@ -540,7 +549,8 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               startedAt: Date.now(),
               isVisible: true,
               extensionState: presetEnv ? { presetEnv } : undefined,
-              ephemeral: launchOptions?.ephemeral,
+              excludeFromPersistence: launchOptions?.excludeFromPersistence,
+              removeOnExit: launchOptions?.removeOnExit,
               spawnedBy,
               focusPolicy,
             };

--- a/src/hooks/useQuickSwitcher.ts
+++ b/src/hooks/useQuickSwitcher.ts
@@ -79,7 +79,7 @@ export function useQuickSwitcher(): UseQuickSwitcherReturn {
       if (!t) continue;
       if (t.location === "trash") continue;
       if (!isPtyPanel(t)) continue;
-      if (t.ephemeral === true) continue;
+      if (t.excludeFromPersistence === true) continue;
       if (t.hasPty === false) continue;
       const worktreeName = t.worktreeId ? worktreeMap.get(t.worktreeId)?.name : undefined;
       const isBackground = t.location === "background";

--- a/src/hooks/useTerminalSelectors.ts
+++ b/src/hooks/useTerminalSelectors.ts
@@ -112,7 +112,7 @@ export function useErrorTerminals(): PtyPanelData[] {
         if (!isPtyPanel(panel)) continue;
         if (panel.agentState !== "exited") continue;
         if (typeof panel.exitCode !== "number" || panel.exitCode === 0) continue;
-        // isTerminalVisible rejects trash/background/ephemeral/orphaned;
+        // isTerminalVisible rejects trash/background/excluded/orphaned;
         // isTerminalErrorClusterEligible adds the dock-location exclusion.
         // Without the orphan gate, clicking an entry from a deleted worktree
         // would call selectWorktree() on a stale ID and persist it.

--- a/src/hooks/useWorktreeTerminals.ts
+++ b/src/hooks/useWorktreeTerminals.ts
@@ -96,7 +96,7 @@ export function useWorktreeTerminals(worktreeId: string): UseWorktreeTerminalsRe
         if (!raw) continue;
         if (raw.location === "trash") continue;
         if (!isPtyPanel(raw)) continue;
-        if (raw.ephemeral === true) continue;
+        if (raw.excludeFromPersistence === true) continue;
         out.push(raw);
       }
       return out;

--- a/src/lib/__tests__/terminalVisibility.test.ts
+++ b/src/lib/__tests__/terminalVisibility.test.ts
@@ -65,6 +65,11 @@ describe("isTerminalVisible", () => {
     expect(isTerminalVisible(t, isInTrash, worktreeIds)).toBe(false);
   });
 
+  it("stays visible for removeOnExit-only terminals (flags are independent)", () => {
+    const t = makeTerminal({ removeOnExit: true, excludeFromPersistence: false });
+    expect(isTerminalVisible(t, isInTrash, worktreeIds)).toBe(true);
+  });
+
   it("returns false for orphaned terminals", () => {
     const t = makeTerminal({ worktreeId: "nonexistent" });
     expect(isTerminalVisible(t, isInTrash, worktreeIds)).toBe(false);

--- a/src/lib/__tests__/terminalVisibility.test.ts
+++ b/src/lib/__tests__/terminalVisibility.test.ts
@@ -7,7 +7,7 @@ function makeTerminal(overrides: Partial<PtyPanelData> = {}): PtyPanelData {
     id: "t1",
     worktreeId: "wt1",
     location: "grid" as const,
-    ephemeral: false,
+    excludeFromPersistence: false,
     agentState: "working",
     ...overrides,
   } as PtyPanelData;
@@ -60,8 +60,8 @@ describe("isTerminalVisible", () => {
     expect(isTerminalVisible(t, isInTrash, worktreeIds)).toBe(false);
   });
 
-  it("returns false for ephemeral terminals", () => {
-    const t = makeTerminal({ ephemeral: true });
+  it("returns false for excludeFromPersistence terminals", () => {
+    const t = makeTerminal({ excludeFromPersistence: true });
     expect(isTerminalVisible(t, isInTrash, worktreeIds)).toBe(false);
   });
 

--- a/src/lib/__tests__/worktreeCyclingOrder.test.ts
+++ b/src/lib/__tests__/worktreeCyclingOrder.test.ts
@@ -303,7 +303,7 @@ describe("getVisibleWorktreesForCycling", () => {
     expect(ids).not.toContain("wt-bg");
   });
 
-  it("excludes ephemeral terminals from quickStateFilter matching", () => {
+  it("excludes excludeFromPersistence terminals from quickStateFilter matching", () => {
     useWorktreeFilterStore.setState({ quickStateFilter: "waiting" });
     setWorktrees([
       createSnapshot({ id: "main", name: "main", branch: "main", isMainWorktree: true }),
@@ -317,7 +317,7 @@ describe("getVisibleWorktreesForCycling", () => {
           type: "terminal",
           worktreeId: "wt-eph",
           location: "grid",
-          ephemeral: true,
+          excludeFromPersistence: true,
           agentState: "waiting",
           detectedAgentId: "claude",
         },

--- a/src/lib/terminalVisibility.ts
+++ b/src/lib/terminalVisibility.ts
@@ -23,7 +23,7 @@ export function isTerminalVisible(
   if (isInTrash(terminal.id)) return false;
   if (terminal.location === "trash") return false;
   if (terminal.location === "background") return false;
-  if (isPtyPanel(terminal) && terminal.ephemeral === true) return false;
+  if (isPtyPanel(terminal) && terminal.excludeFromPersistence === true) return false;
   if (isTerminalOrphaned(terminal, worktreeIds)) return false;
   return true;
 }

--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -101,7 +101,8 @@ const PTY_FIELD_CLASSIFICATION = {
   detectedAgentId: false,
   spawnedBy: false,
   focusPolicy: false,
-  ephemeral: false,
+  excludeFromPersistence: false,
+  removeOnExit: false,
   startedAt: false,
   exitCode: false,
   // BasePanelData carrier-bookkeeping timestamps — written by the base

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -3964,7 +3964,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "terminal",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Hibernate every idle, completed, or exited terminal. Skips ephemeral panels and active agents.",
+    "description": "Hibernate every idle, completed, or exited terminal. Skips tooling-internal panels and active agents.",
     "examples": undefined,
     "id": "terminal.hibernateAllIdle",
     "keywords": [
@@ -4040,7 +4040,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
   {
     "category": "terminal",
     "danger": "confirm",
-    "dangerRationale": "Permanently kills every non-ephemeral terminal. All scrollback and session state are lost.",
+    "dangerRationale": "Permanently kills every user-facing terminal. All scrollback and session state are lost.",
     "description": "Permanently remove all terminals (cannot be undone)",
     "examples": undefined,
     "id": "terminal.killAll",

--- a/src/services/actions/actionTypes.ts
+++ b/src/services/actions/actionTypes.ts
@@ -60,7 +60,8 @@ export interface ActionCallbacks {
       presetId?: string | null;
       activateDockOnCreate?: boolean;
       env?: Record<string, string>;
-      ephemeral?: boolean;
+      excludeFromPersistence?: boolean;
+      removeOnExit?: boolean;
       agentLaunchFlags?: string[];
       spawnedBy?: TerminalSpawnSource;
       focusPolicy?: AddPanelFocusPolicy;

--- a/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
@@ -410,7 +410,7 @@ describe("agentActions adversarial", () => {
           id: "term-ephemeral",
           launchAgentId: "claude",
           agentState: "working",
-          ephemeral: true,
+          excludeFromPersistence: true,
         },
         "term-real": {
           id: "term-real",

--- a/src/services/actions/definitions/__tests__/terminalGetStatusAction.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalGetStatusAction.test.ts
@@ -152,7 +152,7 @@ describe("terminal.getStatus", () => {
     expect(byLocation.terminals.map((t) => t.terminalId)).toEqual(["t3"]);
   });
 
-  it("excludes ephemeral panels from filter results", async () => {
+  it("excludes excludeFromPersistence panels from filter results", async () => {
     panelStoreMock.getState.mockReturnValue({
       panelIds: ["t1", "t2"],
       panelsById: {
@@ -169,6 +169,26 @@ describe("terminal.getStatus", () => {
 
     const { terminals } = await callGetStatus(setupActions());
     expect(terminals.map((t) => t.terminalId)).toEqual(["t1"]);
+  });
+
+  it("includes removeOnExit-only panels in filter results (flags are independent)", async () => {
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: ["t1", "t2"],
+      panelsById: {
+        t1: { id: "t1", kind: "terminal", location: "dock", agentState: "idle" },
+        t2: {
+          id: "t2",
+          kind: "terminal",
+          location: "dock",
+          agentState: "idle",
+          removeOnExit: true,
+          excludeFromPersistence: false,
+        },
+      },
+    });
+
+    const { terminals } = await callGetStatus(setupActions());
+    expect(terminals.map((t) => t.terminalId)).toEqual(["t1", "t2"]);
   });
 
   it("prefers detectedAgentId over launchAgentId", async () => {

--- a/src/services/actions/definitions/__tests__/terminalGetStatusAction.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalGetStatusAction.test.ts
@@ -102,7 +102,7 @@ describe("terminal.getStatus", () => {
           kind: "terminal",
           location: "dock",
           agentState: "idle",
-          ephemeral: true,
+          excludeFromPersistence: true,
         },
       },
     });
@@ -162,7 +162,7 @@ describe("terminal.getStatus", () => {
           kind: "terminal",
           location: "dock",
           agentState: "idle",
-          ephemeral: true,
+          excludeFromPersistence: true,
         },
       },
     });

--- a/src/services/actions/definitions/__tests__/terminalLifecycleActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalLifecycleActions.test.ts
@@ -154,7 +154,7 @@ describe("terminal.close", () => {
 type AgentPanel = {
   id: string;
   location: "grid" | "dock" | "trash";
-  ephemeral?: boolean;
+  excludeFromPersistence?: boolean;
   detectedAgentId?: string;
   launchAgentId?: string;
   agentState?: string;
@@ -321,12 +321,12 @@ describe("terminal.restart confirm gate", () => {
 });
 
 describe("terminal.killAll confirm gate", () => {
-  it("kills all non-ephemeral panels immediately when no agents are running", async () => {
+  it("kills all user-facing panels immediately when no agents are running", async () => {
     const { removePanel } = setRichPanelState({
       panels: [
         { id: "p1", location: "grid" },
         { id: "p2", location: "grid" },
-        { id: "ephem", location: "dock", ephemeral: true },
+        { id: "ephem", location: "dock", excludeFromPersistence: true },
       ],
     });
     const run = setupActions();
@@ -339,7 +339,7 @@ describe("terminal.killAll confirm gate", () => {
     expect(pendingDestructiveStoreMock.state.request).not.toHaveBeenCalled();
   });
 
-  it("requests confirmation when any non-ephemeral panel has a running agent", async () => {
+  it("requests confirmation when any user-facing panel has a running agent", async () => {
     const { removePanel } = setRichPanelState({
       panels: [
         { id: "p1", location: "grid" },
@@ -525,7 +525,7 @@ describe("terminal.hibernateAllIdle", () => {
       kind?: string;
       location?: "grid" | "dock" | "trash";
       agentState?: string;
-      ephemeral?: boolean;
+      excludeFromPersistence?: boolean;
     }>
   ) {
     const panelsById: Record<string, unknown> = {};
@@ -535,7 +535,7 @@ describe("terminal.hibernateAllIdle", () => {
         kind: p.kind ?? "terminal",
         location: p.location ?? "grid",
         agentState: p.agentState,
-        ephemeral: p.ephemeral,
+        excludeFromPersistence: p.excludeFromPersistence,
       };
     }
     panelStoreMock.getState.mockImplementation(() => ({
@@ -544,7 +544,7 @@ describe("terminal.hibernateAllIdle", () => {
     }));
   }
 
-  it("hibernates idle and completed terminals; skips working and ephemeral", async () => {
+  it("hibernates idle and completed terminals; skips working and tooling-internal", async () => {
     setPanelsWithStates([
       { id: "idle1" },
       { id: "completed1", agentState: "completed" },
@@ -552,7 +552,7 @@ describe("terminal.hibernateAllIdle", () => {
       { id: "working1", agentState: "working" },
       { id: "waiting1", agentState: "waiting" },
       { id: "directing1", agentState: "directing" },
-      { id: "ephemeral1", ephemeral: true },
+      { id: "ephemeral1", excludeFromPersistence: true },
       { id: "trashed1", location: "trash" },
       { id: "browser1", kind: "browser" },
     ]);

--- a/src/services/actions/definitions/__tests__/terminalLifecycleActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalLifecycleActions.test.ts
@@ -155,6 +155,7 @@ type AgentPanel = {
   id: string;
   location: "grid" | "dock" | "trash";
   excludeFromPersistence?: boolean;
+  removeOnExit?: boolean;
   detectedAgentId?: string;
   launchAgentId?: string;
   agentState?: string;
@@ -337,6 +338,23 @@ describe("terminal.killAll confirm gate", () => {
     expect(removePanel).toHaveBeenCalledWith("p2");
     expect(removePanel).not.toHaveBeenCalledWith("ephem");
     expect(pendingDestructiveStoreMock.state.request).not.toHaveBeenCalled();
+  });
+
+  it("kills removeOnExit-only panels — only excludeFromPersistence is spared (flags independent)", async () => {
+    const { removePanel } = setRichPanelState({
+      panels: [
+        { id: "p1", location: "grid" },
+        { id: "rox", location: "grid", removeOnExit: true, excludeFromPersistence: false },
+        { id: "ephem", location: "dock", excludeFromPersistence: true },
+      ],
+    });
+    const run = setupActions();
+
+    await run("terminal.killAll");
+
+    expect(removePanel).toHaveBeenCalledWith("p1");
+    expect(removePanel).toHaveBeenCalledWith("rox");
+    expect(removePanel).not.toHaveBeenCalledWith("ephem");
   });
 
   it("requests confirmation when any user-facing panel has a running agent", async () => {

--- a/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
@@ -1013,9 +1013,10 @@ describe("workflow.focusNextAttention", () => {
     expect(result.state).toBe("none");
   });
 
-  it("ignores background and ephemeral terminals (mirrors isTerminalVisible)", async () => {
-    // A waiting terminal in a background panel and an ephemeral one would
-    // be skipped by focusNextWaiting — the macro must not claim focused: true.
+  it("ignores background and excluded terminals (mirrors isTerminalVisible)", async () => {
+    // A waiting terminal in a background panel and one excluded from
+    // persistence would be skipped by focusNextWaiting — the macro must not
+    // claim focused: true.
     setPanelTerminals(
       [
         { id: "t1", agentState: "waiting", worktreeId: "wt-1", location: "background" },
@@ -1023,10 +1024,16 @@ describe("workflow.focusNextAttention", () => {
       ],
       new Map([["wt-1", { worktreeId: "wt-1" }]])
     );
-    // mark t2 as ephemeral
+    // mark t2 as excluded from persistence
     selectorMock.selectOrderedTerminals.mockReturnValue([
       { id: "t1", agentState: "waiting", worktreeId: "wt-1", location: "background" },
-      { id: "t2", agentState: "waiting", worktreeId: "wt-1", location: "grid", ephemeral: true },
+      {
+        id: "t2",
+        agentState: "waiting",
+        worktreeId: "wt-1",
+        location: "grid",
+        excludeFromPersistence: true,
+      },
     ]);
     const def = setupActions(makeCallbacks())("workflow.focusNextAttention");
     const result = (await def.run(undefined, {} as never)) as Record<string, unknown>;

--- a/src/services/actions/definitions/__tests__/worktreeCreateActions.test.ts
+++ b/src/services/actions/definitions/__tests__/worktreeCreateActions.test.ts
@@ -13,7 +13,10 @@ const selectionStoreMock = vi.hoisted(() => ({
 
 let panelState: {
   panelIds: string[];
-  panelsById: Record<string, { worktreeId?: string; location?: string; ephemeral?: boolean }>;
+  panelsById: Record<
+    string,
+    { worktreeId?: string; location?: string; excludeFromPersistence?: boolean }
+  >;
   removePanel: ReturnType<typeof vi.fn>;
 };
 const originalWindow = globalThis.window;
@@ -73,7 +76,7 @@ describe("worktree.delete action", () => {
         "terminal-1": {
           worktreeId: "wt-1",
           location: "grid",
-          ephemeral: false,
+          excludeFromPersistence: false,
         },
       },
       removePanel: vi.fn(),

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -35,7 +35,8 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
       presetId: z.string().nullable().optional(),
       activateDockOnCreate: z.boolean().optional(),
       env: z.record(z.string(), z.string()).optional(),
-      ephemeral: z.boolean().optional(),
+      excludeFromPersistence: z.boolean().optional(),
+      removeOnExit: z.boolean().optional(),
       agentLaunchFlags: z.array(z.string()).optional(),
       spawnedBy: TerminalSpawnSourceSchema.optional(),
       focusPolicy: AddPanelFocusPolicySchema.optional(),
@@ -61,7 +62,8 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         presetId,
         activateDockOnCreate,
         env,
-        ephemeral,
+        excludeFromPersistence,
+        removeOnExit,
         agentLaunchFlags,
         spawnedBy,
         focusPolicy,
@@ -78,7 +80,8 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         presetId?: string | null;
         activateDockOnCreate?: boolean;
         env?: Record<string, string>;
-        ephemeral?: boolean;
+        excludeFromPersistence?: boolean;
+        removeOnExit?: boolean;
         agentLaunchFlags?: string[];
         spawnedBy?: TerminalSpawnSource;
         focusPolicy?: "auto" | "preserve" | "take";
@@ -95,7 +98,8 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         presetId,
         activateDockOnCreate,
         env,
-        ephemeral,
+        excludeFromPersistence,
+        removeOnExit,
         agentLaunchFlags,
         spawnedBy,
         focusPolicy,
@@ -389,10 +393,10 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
       const state = usePanelStore.getState();
       for (const id of state.panelIds) {
         const panel = state.panelsById[id];
-        // Skip ephemeral panels (e.g. the Daintree Assistant's own dock
+        // Skip tooling-internal panels (e.g. the Daintree Assistant's own dock
         // terminal) for the same reason terminal.list filters them — the
         // assistant must not be able to introspect its own process.
-        if (!panel || !isPtyPanel(panel) || panel.ephemeral === true) continue;
+        if (!panel || !isPtyPanel(panel) || panel.excludeFromPersistence === true) continue;
         const effectiveAgentId = panel.detectedAgentId ?? panel.launchAgentId;
         if (effectiveAgentId === agentId) {
           return {

--- a/src/services/actions/definitions/helpActions.ts
+++ b/src/services/actions/definitions/helpActions.ts
@@ -158,7 +158,8 @@ export function registerHelpActions(actions: ActionRegistry, callbacks: ActionCa
           cwd,
           location: "dock",
           prompt: helpPrompt,
-          ephemeral: true,
+          excludeFromPersistence: true,
+          removeOnExit: true,
           ...(env && { env }),
         },
         { source: "user" }

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -401,7 +401,7 @@ export function registerTerminalLifecycleActions(
     id: "terminal.hibernateAllIdle",
     title: "Sleep All Idle Terminals",
     description:
-      "Hibernate every idle, completed, or exited terminal. Skips ephemeral panels and active agents.",
+      "Hibernate every idle, completed, or exited terminal. Skips tooling-internal panels and active agents.",
     category: "terminal",
     kind: "command",
     danger: "safe",
@@ -414,7 +414,7 @@ export function registerTerminalLifecycleActions(
         if (!panel) continue;
         if (!panel.kind || !panelKindHasPty(panel.kind)) continue;
         if (panel.location === "trash") continue;
-        if ("ephemeral" in panel && panel.ephemeral === true) continue;
+        if (isPtyPanel(panel) && panel.excludeFromPersistence === true) continue;
         const agentState = "agentState" in panel ? panel.agentState : undefined;
         if (
           agentState !== undefined &&
@@ -441,14 +441,14 @@ export function registerTerminalLifecycleActions(
     run: async () => {
       const state = usePanelStore.getState();
       const activeWorktreeId = callbacks.getActiveWorktreeId();
-      // Skip ephemeral panels — the Daintree Assistant's own dock terminal
-      // shouldn't get swept up by a "close all" command.
+      // Skip tooling-internal panels — the Daintree Assistant's own dock
+      // terminal shouldn't get swept up by a "close all" command.
       const idsToClose = state.panelIds.filter((id) => {
         const t = state.panelsById[id];
         if (!t) return false;
-        const isEphemeral = isPtyPanel(t) && t.ephemeral === true;
+        const isToolingInternal = isPtyPanel(t) && t.excludeFromPersistence === true;
         return (
-          !isEphemeral &&
+          !isToolingInternal &&
           t.location !== "trash" &&
           (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined)
         );
@@ -473,19 +473,19 @@ export function registerTerminalLifecycleActions(
     danger: "confirm",
     scope: "renderer",
     dangerRationale:
-      "Permanently kills every non-ephemeral terminal. All scrollback and session state are lost.",
+      "Permanently kills every user-facing terminal. All scrollback and session state are lost.",
     keywords: ["terminate", "stop", "remove", "delete"],
     argsSchema: z.object({ confirmed: z.boolean().optional() }).optional(),
     run: async (args: unknown) => {
       // Don't reuse bulkCloseAll() — it indiscriminately removes every panel,
-      // including the ephemeral assistant terminal. Filter ephemerals out
+      // including the tooling-internal assistant terminal. Filter those out
       // before issuing per-panel removes.
       const state = usePanelStore.getState();
       const targets = state.panelIds
         .map((id) => state.panelsById[id])
         .filter((t): t is NonNullable<typeof t> => {
           if (t == null) return false;
-          return !(isPtyPanel(t) && t.ephemeral === true);
+          return !(isPtyPanel(t) && t.excludeFromPersistence === true);
         });
       if (targets.length === 0) return;
       const runningAgents = collectRunningAgentTerminals(targets);

--- a/src/services/actions/definitions/terminalQueryActions.ts
+++ b/src/services/actions/definitions/terminalQueryActions.ts
@@ -47,7 +47,8 @@ export function registerTerminalQueryActions(
       let terminals = state.panelIds
         .map((id) => state.panelsById[id])
         .filter(
-          (t): t is PanelInstance => t !== undefined && (!isPtyPanel(t) || t.ephemeral !== true)
+          (t): t is PanelInstance =>
+            t !== undefined && (!isPtyPanel(t) || t.excludeFromPersistence !== true)
         );
 
       // Filter by worktree if specified
@@ -253,9 +254,9 @@ export function registerTerminalQueryActions(
       if (terminalIds !== undefined) {
         for (const id of terminalIds) {
           const t = getNarrowPanel(panelsById, id);
-          // Treat ephemeral panels as not found — they're tooling-internal and
-          // must never expose state to MCP callers (mirrors terminal.list).
-          if (!t || (isPtyPanel(t) && t.ephemeral === true)) {
+          // Treat tooling-internal panels as not found — they must never expose
+          // state to MCP callers (mirrors terminal.list).
+          if (!t || (isPtyPanel(t) && t.excludeFromPersistence === true)) {
             resolved.push({ id, terminal: undefined });
           } else {
             resolved.push({ id, terminal: t });
@@ -265,7 +266,8 @@ export function registerTerminalQueryActions(
         let terminals = state.panelIds
           .map((id) => panelsById[id])
           .filter(
-            (t): t is PanelInstance => t !== undefined && (!isPtyPanel(t) || t.ephemeral !== true)
+            (t): t is PanelInstance =>
+              t !== undefined && (!isPtyPanel(t) || t.excludeFromPersistence !== true)
           );
 
         if (worktreeId) {

--- a/src/store/listeners/panel/lifecycle.ts
+++ b/src/store/listeners/panel/lifecycle.ts
@@ -299,10 +299,10 @@ export function setupLifecycleListeners(): DisposableStore {
           return;
         }
 
-        // Ephemeral panels (e.g. the help-panel assistant) are bound to a
+        // Remove-on-exit panels (e.g. the help-panel assistant) are bound to a
         // transient UI surface — on any exit, remove rather than preserve
         // so they don't linger in the dock as "exited" agents.
-        if (terminal.ephemeral === true) {
+        if (terminal.removeOnExit === true) {
           state.removePanel(id);
           return;
         }

--- a/src/store/persistence/panelPersistence.ts
+++ b/src/store/persistence/panelPersistence.ts
@@ -81,7 +81,7 @@ const DEFAULT_OPTIONS: Required<Omit<PanelPersistenceOptions, "getProjectId">> &
     t.location !== "trash" &&
     t.location !== "background" &&
     t.kind !== "assistant" &&
-    t.ephemeral !== true &&
+    t.excludeFromPersistence !== true &&
     !isSmokeTestTerminalId(t.id),
   transform: panelToSnapshot,
   getProjectId: undefined,

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -35,7 +35,7 @@ function shouldPersistTerminal(t: NonNullable<CarrierPanel>): boolean {
     // runtime can still hand us an assistant panel whose kind escapes the
     // declared union, so widen to string before comparing.
     (t.kind as string) !== "assistant" &&
-    !(isPtyPanel(t) && t.ephemeral === true) &&
+    !(isPtyPanel(t) && t.excludeFromPersistence === true) &&
     !isSmokeTestTerminalId(t.id)
   );
 }

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -185,7 +185,8 @@ export const createAddPanelActions = (
         runtimeStatus,
         extensionState: options.extensionState,
         pluginId,
-        ephemeral: options.ephemeral,
+        excludeFromPersistence: options.excludeFromPersistence,
+        removeOnExit: options.removeOnExit,
         ...kindFields,
       } as PanelInstance;
 
@@ -373,7 +374,8 @@ export const createAddPanelActions = (
       pluginId: ptyPluginId,
       spawnedBy: options.spawnedBy,
       focusPolicy: options.focusPolicy,
-      ephemeral: options.ephemeral,
+      excludeFromPersistence: options.excludeFromPersistence,
+      removeOnExit: options.removeOnExit,
       startedAt: Date.now(),
       spawnStatus,
     } as PanelInstance;

--- a/src/store/slices/panelRegistry/trashActions.ts
+++ b/src/store/slices/panelRegistry/trashActions.ts
@@ -45,10 +45,10 @@ export const createTrashActions = (
     // a panel that's been moved to trash (and reappear when the user undoes).
     cancelReconnectErrorDebounce(id);
 
-    // Ephemeral panels (e.g. the help-panel assistant terminal) are bound to
-    // a transient UI surface and must never linger in trash for the TTL window
-    // — they bypass the trash flow and are removed outright.
-    if (isPtyPanel(terminal) && terminal.ephemeral === true) {
+    // Remove-on-exit panels (e.g. the help-panel assistant terminal) are bound
+    // to a transient UI surface and must never linger in trash for the TTL
+    // window — they bypass the trash flow and are removed outright.
+    if (isPtyPanel(terminal) && terminal.removeOnExit === true) {
       get().removePanel(id);
       return;
     }

--- a/src/store/slices/terminalFocusSlice.ts
+++ b/src/store/slices/terminalFocusSlice.ts
@@ -562,7 +562,7 @@ export const createTerminalFocusSlice =
             t.location === "dock" &&
             (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined) &&
             isPtyPanel(t) &&
-            t.ephemeral !== true &&
+            t.excludeFromPersistence !== true &&
             t.agentState === "waiting"
         );
 


### PR DESCRIPTION
## Summary

- Splits `ephemeral?: boolean` on `PtyPanelData` into two independent flags: `excludeFromPersistence` (keeps the panel out of persisted layout snapshots and all user-visible terminal surfaces) and `removeOnExit` (removes the panel immediately when its PTY exits instead of holding it under the trash TTL).
- Help session callers (`HelpSessionController`, `helpActions`) set both flags true, preserving existing behavior. `agent.launch`, `AddPanelOptions`, and `useAgentLauncher` `LaunchOptions` expose the split directly.
- No snapshot migration needed — `ephemeral` panels were already filtered out before serialization, so the field never reached disk.

Resolves #9643.

## Changes

- `shared/types/panel.ts` — replaces `ephemeral` with `excludeFromPersistence` and `removeOnExit` on `PtyPanelData`; adds `excludeFromPersistence` to `TerminalInstance`
- `shared/types/addPanelOptions.ts` — splits the flag in `AddPanelOptions`
- `src/hooks/useAgentLauncher.ts` / `src/services/actions/actionTypes.ts` — splits the flag in `LaunchOptions` and action args
- `src/controllers/HelpSessionController.ts` / `helpActions.ts` — sets both flags true on help session panels
- Panel store, persistence, lifecycle listeners, terminal selectors, quick switcher, worktree terminals — all updated to use `excludeFromPersistence` and `removeOnExit` in place of `ephemeral`
- New flag-independence tests confirming the two flags can be set independently; fix for stale `killAll` dialog copy

## Testing

`npm run check` passes (typecheck across all tsconfigs, IPC/channel/confirm-wiring guards, lint-ratchet, format). Affected vitest suites pass — 326 tests plus the new flag-independence tests. Constraints honored: `clearTerminalStoreForSwitch` (#9639) and `PanelLocation` (#9640) untouched.