### PR TITLE
refactor(assistant): give Assistant terminal an honest location value

### DIFF
--- a/electron/schemas/__tests__/terminalEntryValidation.test.ts
+++ b/electron/schemas/__tests__/terminalEntryValidation.test.ts
@@ -143,6 +143,19 @@ describe("Terminal Entry Validation Schemas", () => {
       expect(result.success).toBe(false);
     });
 
+    it("rejects overlay location (overlay terminals are never persisted to app state)", () => {
+      const entry = {
+        id: "term-123",
+        type: "terminal",
+        title: "Terminal",
+        cwd: "/Users/test",
+        location: "overlay",
+      };
+
+      const result = AppStateTerminalEntrySchema.safeParse(entry);
+      expect(result.success).toBe(false);
+    });
+
     it("rejects non-object values", () => {
       expect(AppStateTerminalEntrySchema.safeParse(null).success).toBe(false);
       expect(AppStateTerminalEntrySchema.safeParse(undefined).success).toBe(false);
@@ -260,8 +273,8 @@ describe("Terminal Entry Validation Schemas", () => {
       expect(result.success).toBe(true);
     });
 
-    it("accepts all locations including trash", () => {
-      const locations = ["grid", "dock", "trash"];
+    it("accepts all locations including trash and overlay", () => {
+      const locations = ["grid", "dock", "overlay", "trash", "background"];
 
       for (const location of locations) {
         const snapshot = {

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -23,7 +23,7 @@ export const AppStateTerminalLocationSchema = z.enum(["grid", "dock"]);
 /**
  * Schema for terminal location in project state - includes all locations.
  */
-export const TerminalLocationSchema = z.enum(["grid", "dock", "trash", "background"]);
+export const TerminalLocationSchema = z.enum(["grid", "dock", "overlay", "trash", "background"]);
 
 /**
  * Schema for panel/terminal kind - distinguishes built-in panel types.

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -16,7 +16,7 @@ export type { BuiltInPanelKind };
 export type PanelKind = BuiltInPanelKind | (string & {});
 
 /** Location of a panel instance in the UI */
-export type PanelLocation = "grid" | "dock" | "trash" | "background";
+export type PanelLocation = "grid" | "dock" | "overlay" | "trash" | "background";
 
 /** Tab group location (subset of PanelLocation, excludes trash) */
 export type TabGroupLocation = "grid" | "dock";

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -1343,7 +1343,7 @@ export class HelpSessionController {
       launchAgentId,
       command,
       cwd,
-      location: "dock",
+      location: "overlay",
       excludeFromPersistence: true,
       removeOnExit: true,
       ...(env && { env }),
@@ -1478,7 +1478,7 @@ export class HelpSessionController {
         "agent.launch",
         {
           agentId: launchAgentId,
-          location: "dock",
+          location: "overlay",
           cwd,
           excludeFromPersistence: true,
           removeOnExit: true,
@@ -1704,7 +1704,7 @@ export class HelpSessionController {
 
       const dispatchArgs: Record<string, unknown> = {
         agentId: launchAgentId,
-        location: "dock",
+        location: "overlay",
         cwd,
         excludeFromPersistence: true,
         removeOnExit: true,

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -389,7 +389,7 @@ describe("HelpSessionController — launch phase FSM", () => {
         excludeFromPersistence: true,
         removeOnExit: true,
       }),
-      expect.anything(),
+      expect.anything()
     );
     ctrl.stop();
   });

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -380,6 +380,12 @@ describe("HelpSessionController — launch phase FSM", () => {
     await vi.waitFor(() => {
       expect(ctrl.getSnapshot().phase).toBe("live");
     });
+    // The assistant terminal must spawn as an overlay panel, not a phantom dock item (#9640).
+    expect(vi.mocked(actionService.dispatch)).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.objectContaining({ location: "overlay" }),
+      expect.anything(),
+    );
     ctrl.stop();
   });
 

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -380,10 +380,15 @@ describe("HelpSessionController — launch phase FSM", () => {
     await vi.waitFor(() => {
       expect(ctrl.getSnapshot().phase).toBe("live");
     });
-    // The assistant terminal must spawn as an overlay panel, not a phantom dock item (#9640).
+    // The assistant terminal must spawn as an overlay panel, not a phantom dock item (#9640),
+    // and must stay out of persisted/restored app state.
     expect(vi.mocked(actionService.dispatch)).toHaveBeenCalledWith(
       "agent.launch",
-      expect.objectContaining({ location: "overlay" }),
+      expect.objectContaining({
+        location: "overlay",
+        excludeFromPersistence: true,
+        removeOnExit: true,
+      }),
       expect.anything(),
     );
     ctrl.stop();

--- a/src/services/actions/actionTypes.ts
+++ b/src/services/actions/actionTypes.ts
@@ -51,7 +51,7 @@ export interface ActionCallbacks {
   onLaunchAgent: (
     agentId: string,
     options?: {
-      location?: "grid" | "dock";
+      location?: "grid" | "dock" | "overlay";
       cwd?: string;
       worktreeId?: string;
       prompt?: string;

--- a/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
@@ -546,4 +546,29 @@ describe("agent.launch dispatch integration", () => {
       expect.objectContaining({ worktreeId: "wt-1", location: "grid" })
     );
   });
+
+  it("accepts overlay location through the schema so Assistant launches don't silently fail (#9640)", async () => {
+    const { ActionService } = await import("../../../ActionService");
+    const service = new ActionService();
+
+    const callbacks = makeCallbacks();
+    const registry: ActionRegistry = new Map();
+    registerAgentActions(registry, callbacks);
+
+    for (const [, factory] of registry) {
+      service.register(factory());
+    }
+
+    const result = await service.dispatch(
+      "agent.launch",
+      { agentId: "claude", cwd: "/help", location: "overlay", excludeFromPersistence: true },
+      { source: "user" }
+    );
+
+    expect(result.ok).toBe(true);
+    expect(callbacks.onLaunchAgent).toHaveBeenCalledWith(
+      "claude",
+      expect.objectContaining({ location: "overlay" })
+    );
+  });
 });

--- a/src/services/actions/definitions/__tests__/helpLaunchAgent.test.ts
+++ b/src/services/actions/definitions/__tests__/helpLaunchAgent.test.ts
@@ -134,7 +134,7 @@ describe("help.launchAgent", () => {
     expect(window.electron.help.getFolderPath).toHaveBeenCalled();
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",
-      expect.objectContaining({ agentId: "claude", cwd: "/mock/help", location: "dock" }),
+      expect.objectContaining({ agentId: "claude", cwd: "/mock/help", location: "overlay" }),
       { source: "user" }
     );
     expect(mockNotify).not.toHaveBeenCalled();
@@ -154,7 +154,7 @@ describe("help.launchAgent", () => {
 
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",
-      expect.objectContaining({ agentId: "gemini", cwd: "/mock/help", location: "dock" }),
+      expect.objectContaining({ agentId: "gemini", cwd: "/mock/help", location: "overlay" }),
       { source: "user" }
     );
   });
@@ -173,7 +173,7 @@ describe("help.launchAgent", () => {
 
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",
-      expect.objectContaining({ agentId: "claude", cwd: "/mock/help", location: "dock" }),
+      expect.objectContaining({ agentId: "claude", cwd: "/mock/help", location: "overlay" }),
       { source: "user" }
     );
   });
@@ -196,7 +196,7 @@ describe("help.launchAgent", () => {
 
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",
-      expect.objectContaining({ agentId: "codex", cwd: "/mock/help", location: "dock" }),
+      expect.objectContaining({ agentId: "codex", cwd: "/mock/help", location: "overlay" }),
       { source: "user" }
     );
   });
@@ -220,7 +220,7 @@ describe("help.launchAgent", () => {
 
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",
-      expect.objectContaining({ agentId: "claude", cwd: "/mock/help", location: "dock" }),
+      expect.objectContaining({ agentId: "claude", cwd: "/mock/help", location: "overlay" }),
       { source: "user" }
     );
   });
@@ -235,7 +235,7 @@ describe("help.launchAgent", () => {
 
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",
-      expect.objectContaining({ agentId: "codex", cwd: "/mock/help", location: "dock" }),
+      expect.objectContaining({ agentId: "codex", cwd: "/mock/help", location: "overlay" }),
       { source: "user" }
     );
   });

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -71,7 +71,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         force,
       } = args as {
         agentId: string;
-        location?: "grid" | "dock";
+        location?: "grid" | "dock" | "overlay";
         cwd?: string;
         worktreeId?: string;
         prompt?: string;
@@ -156,7 +156,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
       resultSchema: shortcutResultSchema,
       run: async (args: unknown) => {
         const { location, spawnedBy, focusPolicy } = (args ?? {}) as {
-          location?: "grid" | "dock";
+          location?: "grid" | "dock" | "overlay";
           spawnedBy?: TerminalSpawnSource;
           focusPolicy?: "auto" | "preserve" | "take";
         };
@@ -183,7 +183,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     resultSchema: shortcutResultSchema,
     run: async (args: unknown) => {
       const { location, spawnedBy, focusPolicy } = (args ?? {}) as {
-        location?: "grid" | "dock";
+        location?: "grid" | "dock" | "overlay";
         spawnedBy?: TerminalSpawnSource;
         focusPolicy?: "auto" | "preserve" | "take";
       };
@@ -209,7 +209,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     resultSchema: shortcutResultSchema,
     run: async (args: unknown) => {
       const { location, spawnedBy } = (args ?? {}) as {
-        location?: "grid" | "dock";
+        location?: "grid" | "dock" | "overlay";
         spawnedBy?: TerminalSpawnSource;
       };
       const result = await callbacks.onLaunchAgent("browser", {

--- a/src/services/actions/definitions/helpActions.ts
+++ b/src/services/actions/definitions/helpActions.ts
@@ -156,7 +156,7 @@ export function registerHelpActions(actions: ActionRegistry, callbacks: ActionCa
         {
           agentId,
           cwd,
-          location: "dock",
+          location: "overlay",
           prompt: helpPrompt,
           excludeFromPersistence: true,
           removeOnExit: true,

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -4,9 +4,9 @@ import { BUILT_IN_AGENT_IDS, BUILT_IN_TERMINAL_TYPES } from "@shared/config/agen
 export const AgentIdSchema = z.enum([...BUILT_IN_AGENT_IDS, "terminal", "browser", "dev-preview"]);
 
 export const LaunchLocationSchema = z
-  .enum(["grid", "dock"])
+  .enum(["grid", "dock", "overlay"])
   .describe(
-    'Where to place the panel. "grid" places it in the main panel grid (default). "dock" places it in the sidebar dock.'
+    'Where to place the panel. "grid" places it in the main panel grid (default). "dock" places it in the sidebar dock. "overlay" places it in a floating overlay (e.g. the Daintree Assistant), outside the grid and dock.'
   );
 
 /**

--- a/src/store/layoutUndoStore.ts
+++ b/src/store/layoutUndoStore.ts
@@ -9,7 +9,7 @@ const MAX_UNDO_HISTORY = 10;
 
 interface TerminalLayoutEntry {
   id: string;
-  location: "grid" | "dock" | "trash" | "background";
+  location: "grid" | "dock" | "overlay" | "trash" | "background";
   worktreeId?: string;
 }
 


### PR DESCRIPTION
## Summary

- The Assistant terminal was being spawned with `location: "dock"` but never actually participating in the dock — it doesn't go through `moveTerminalToDock`, isn't rendered by `TerminalDockRegion`, and isn't part of any tab group. Any code iterating `panelStore.panelsById` by location would silently treat it as a phantom dock item.
- Replaces `"dock"` with `"overlay"` at all four spawn sites and widens the type system and schemas to match. `AppStateTerminalLocationSchema` and `TabGroupLocationSchema` are intentionally kept narrow — `"overlay"` is never persisted to app state or joined to tab groups.

Resolves #9640

## Changes

- Add `"overlay"` to the `PanelLocation` union (`shared/types/panel.ts`)
- Accept `"overlay"` in `TerminalLocationSchema` (`electron/schemas/ipc.ts`); `AppStateTerminalLocationSchema` and `TabGroupLocationSchema` left narrow
- Widen `LaunchLocationSchema` (action arg schema) so `agent.launch` dispatches for the Assistant pass validation
- Fix all four spawn sites: three in `HelpSessionController` (`addPanel` + two `agent.launch` dispatches) and `help.launchAgent` in `helpActions.ts`
- Widen `onLaunchAgent` callback, `agentActions` arg casts, and `layoutUndoStore`'s `TerminalLayoutEntry` to include `"overlay"`

## Testing

- Schema coverage: `TerminalLocationSchema` accepts `"overlay"`; `AppStateTerminalLocationSchema` rejects it
- `agent.launch` overlay-acceptance regression test
- `helpLaunchAgent` action assertions updated to expect `"overlay"`
- Strengthened auto-launch assertion checks overlay location and correct persistence flags
- 150 vitest tests pass; all 10 `npm run check` gates pass