### PR TITLE
fix(sidebar): sentence-case microcopy in worktree filtered empty-state

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -563,13 +563,6 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const hasActiveFilters = useWorktreeFilterStore((state) => state.hasActiveFilters);
   const hasFacetFilters = useWorktreeFilterStore((state) => state.hasFacetFilters);
   const hasFacetFiltersActive = hasFacetFilters();
-  const activeFacetFilterCount =
-    statusFilters.size +
-    typeFilters.size +
-    prIssueFilters.size +
-    sessionFilters.size +
-    activityFilters.size +
-    devServerFilters.size;
   const collapsedWorktrees = useWorktreeFilterStore((state) => state.collapsedWorktrees);
   const pruneStaleWorktreeIds = useWorktreeFilterStore((state) => state.pruneStaleWorktreeIds);
   const setQuickStateFilter = useWorktreeFilterStore((state) => state.setQuickStateFilter);
@@ -1664,9 +1657,11 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
               variant="filtered-empty"
               scale="sidebar"
               instant
-              title={`No worktrees match ${QUICK_STATE_LABELS[quickStateFilter]} with ${activeFacetFilterCount} ${
-                activeFacetFilterCount === 1 ? "filter" : "filters"
-              }`}
+              title={
+                hasQuery
+                  ? `No matches for "${truncateSearchQuery(query.trim())}"`
+                  : "No matching worktrees"
+              }
               action={
                 <>
                   <button

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -112,38 +112,22 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       expect(branch).not.toContain("clearAllFilters");
     });
 
-    it("names both axes when a facet filter is active alongside the quick-state — issue #7971", () => {
+    it("uses sentence-case copy in the facet-filtered quick-state branch — issue #9664", () => {
       // When the quick-state filter and one or more facet filters are active
-      // together and produce zero results, the title must call out both axes
-      // (e.g. "No worktrees match Working with 2 filters"). The dual-axis
-      // branch is now gated on `showQuickStateEmptyState && hasFacetFiltersActive`
-      // (only entered when facet filters are active alongside quick-state).
+      // together and produce zero results, the title must stay sentence-case
+      // per the CLAUDE.md microcopy rule — no title-cased filter label or
+      // "N filters" suffix interpolated mid-sentence. The branch reuses the
+      // generic filtered-empty copy: a search-aware "No matches for ..." when a
+      // query is present, "No matching worktrees" otherwise.
       const branchStart = source.indexOf("showQuickStateEmptyState && hasFacetFiltersActive ?");
       const branchEnd = source.indexOf(") : filteredWorktrees.length === 0 &&", branchStart);
       const branch = source.slice(branchStart, branchEnd);
-      expect(branch).toMatch(
-        /`No worktrees match \$\{QUICK_STATE_LABELS\[quickStateFilter\]\} with \$\{activeFacetFilterCount\} \$\{[\s\S]*?activeFacetFilterCount === 1 \? "filter" : "filters"[\s\S]*?\}`/
-      );
+      expect(branch).toContain('"No matching worktrees"');
+      expect(branch).toContain('No matches for "${truncateSearchQuery(query.trim())}"');
+      // The old title-cased, count-suffixed copy is gone.
+      expect(branch).not.toContain("QUICK_STATE_LABELS[quickStateFilter]");
+      expect(branch).not.toContain("activeFacetFilterCount");
       expect(branch).toContain('variant="filtered-empty"');
-    });
-
-    it("derives the active facet filter count from the six facet Set sizes — issues #7971, #9087", () => {
-      // The combined-axis title needs the actual number of facet filters
-      // selected. Sum the six facet axes (status, type, github, session,
-      // activity, dev server) — the same axes hasFacetFilters() reads. Do not
-      // include query or quickStateFilter, which are named separately in the title.
-      expect(source).toMatch(
-        /const activeFacetFilterCount =\s*statusFilters\.size \+\s*typeFilters\.size \+\s*prIssueFilters\.size \+\s*sessionFilters\.size \+\s*activityFilters\.size \+\s*devServerFilters\.size;/
-      );
-    });
-
-    it("maps quick-state filter values to title-cased labels for the combined-axis title — issue #7971", () => {
-      // The raw quickStateFilter values are lowercase ("working", "waiting",
-      // "finished"). The combined-axis title displays them title-cased via a
-      // module-level QUICK_STATE_LABELS map so the prose reads naturally.
-      expect(source).toMatch(
-        /const QUICK_STATE_LABELS: Record<"working" \| "waiting" \| "finished", string> = \{\s*working: "Working",\s*waiting: "Waiting",\s*finished: "Finished",\s*\};/
-      );
     });
 
     it("uses both user-cleared and filtered-empty variants in the quick-state branch", () => {

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -124,6 +124,12 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       const branch = source.slice(branchStart, branchEnd);
       expect(branch).toContain('"No matching worktrees"');
       expect(branch).toContain('No matches for "${truncateSearchQuery(query.trim())}"');
+      // The search-aware copy is the hasQuery arm, the plain copy the fallback —
+      // guard against an inverted ternary by checking the query arm comes first.
+      const queryIdx = branch.indexOf('No matches for "${truncateSearchQuery(query.trim())}"');
+      const fallbackIdx = branch.indexOf('"No matching worktrees"');
+      expect(branch.indexOf("hasQuery")).toBeLessThan(queryIdx);
+      expect(queryIdx).toBeLessThan(fallbackIdx);
       // The old title-cased, count-suffixed copy is gone.
       expect(branch).not.toContain("QUICK_STATE_LABELS[quickStateFilter]");
       expect(branch).not.toContain("activeFacetFilterCount");


### PR DESCRIPTION
## Summary

- The facet-active empty-state branch was capitalising a quick-state filter label mid-sentence, producing titles like `No worktrees match Waiting with 2 filters`
- Replaced that branch with the existing generic fallbacks (`No matches for "<query>"` / `No matching worktrees`), which already handle the same recovery path
- Removed the now-unused `activeFacetFilterCount` derivation and two tautological tests that mirrored source string values directly

Closes #9664

## Changes

- `SidebarContent.tsx`: collapse the facet-active title branch into the generic fallbacks; drop the per-filter count variable
- `SidebarContent.emptyState.test.ts`: replace the three old title tests with one behavioral assertion that guards the `hasQuery` ternary polarity

## Testing

Typecheck, lint, format, and 51 unit tests all pass.