### PR TITLE
fix(sidebar): stop re-announcing persistent status text on every keystroke

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -1131,15 +1131,18 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     };
   }, [showScope, filteredCount, totalCount]);
 
-  // Announce the sort-disabled reason once, only when it first appears. The
-  // re-enable transition ("Manual reorder available") is handled by the
-  // isSortDisabledPrevRef effect above, so we deliberately skip the
-  // string → null direction here to avoid double-speaking.
+  // Announce the sort-disabled reason whenever it appears or changes — covers
+  // null → reason (sorting becomes disabled) and reason → reason (e.g. switching
+  // from group-by-type to an active search). The reason → null re-enable
+  // transition ("Manual reorder available") is owned by the isSortDisabledPrevRef
+  // effect above, so we skip it here to avoid double-speaking. Initialising the
+  // ref to the current value keeps mount silent: a sidebar that opens with a
+  // persisted filter shows the visual text rather than announcing stale state.
   const prevDragDisabledReasonRef = useRef<string | null>(dragDisabledReason);
   useEffect(() => {
     const prev = prevDragDisabledReasonRef.current;
     prevDragDisabledReasonRef.current = dragDisabledReason;
-    if (prev === null && dragDisabledReason !== null) {
+    if (dragDisabledReason !== null && prev !== dragDisabledReason) {
       useAnnouncerStore.getState().announce(dragDisabledReason);
     }
   }, [dragDisabledReason]);

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -46,6 +46,8 @@ import {
   isWorktreeSortDragData,
 } from "@/components/DragDrop/SortableWorktreeCard";
 import { applyManualWorktreeReorder } from "@/lib/worktreeReorder";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { usePanelStore, useWorktreeSelectionStore, useProjectStore } from "@/store";
 import type { PendingCreation } from "@/store/worktreeStore";
 import { useFleetArmingStore, collectFilterArmEligibleIds } from "@/store/fleetArmingStore";
@@ -1103,6 +1105,45 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     isSortDisabledRef.current = isSortDisabled;
   }, [isSortDisabled]);
 
+  // Filter-scope + sort-disabled state. Hoisted above the early returns below so
+  // the announcement effects that depend on them keep a stable hook order.
+  const filteredCount = filteredWorktrees.length;
+  const showScope = hasActiveFilters() && filteredCount !== totalCount;
+  const dragDisabledReason = hasQuery
+    ? "Sorting disabled while searching"
+    : isGroupedByType
+      ? "Sorting disabled while grouped by type"
+      : null;
+
+  // Announce the filtered worktree count to screen readers, debounced so rapid
+  // typing in the search box doesn't flood the AT speech queue. Routed through
+  // the global announcer (document.ariaNotify + always-mounted fallback) rather
+  // than a persistent aria-atomic live region — that region re-announced the
+  // whole status line, including the persistent sort-disabled text, on every
+  // keystroke (#9665).
+  useEffect(() => {
+    if (!showScope) return;
+    const timer = window.setTimeout(() => {
+      useAnnouncerStore.getState().announce(`${filteredCount} of ${totalCount} worktrees`);
+    }, UI_DOHERTY_THRESHOLD);
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [showScope, filteredCount, totalCount]);
+
+  // Announce the sort-disabled reason once, only when it first appears. The
+  // re-enable transition ("Manual reorder available") is handled by the
+  // isSortDisabledPrevRef effect above, so we deliberately skip the
+  // string → null direction here to avoid double-speaking.
+  const prevDragDisabledReasonRef = useRef<string | null>(dragDisabledReason);
+  useEffect(() => {
+    const prev = prevDragDisabledReasonRef.current;
+    prevDragDisabledReasonRef.current = dragDisabledReason;
+    if (prev === null && dragDisabledReason !== null) {
+      useAnnouncerStore.getState().announce(dragDisabledReason);
+    }
+  }, [dragDisabledReason]);
+
   const mainRowIndex = mainVisible ? 1 : 0;
   const integrationRowIndex = integrationVisible ? mainRowIndex + 1 : mainRowIndex;
   const firstScrollableRowIndex = integrationRowIndex + 1;
@@ -1438,14 +1479,6 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       <TooltipContent side="bottom">{armMatchingLabel}</TooltipContent>
     </Tooltip>
   );
-  const filteredCount = filteredWorktrees.length;
-  const showScope = hasActiveFilters() && filteredCount !== totalCount;
-  const dragDisabledReason = hasQuery
-    ? "Sorting disabled while searching"
-    : isGroupedByType
-      ? "Sorting disabled while grouped by type"
-      : null;
-
   return (
     <div className="flex flex-col h-full">
       {worktreeLoadErrorBanner}
@@ -1517,14 +1550,12 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         </div>
       </div>
 
-      {/* Filter scope and sort-disabled status */}
+      {/* Filter scope and sort-disabled status. Visual-only — screen readers
+          are served by the debounced announcer effects above, not a live region
+          here, so the persistent sort-disabled text isn't re-announced on every
+          keystroke (#9665). */}
       {(showScope || dragDisabledReason) && (
-        <div
-          role="status"
-          aria-live="polite"
-          aria-atomic="true"
-          className="px-4 shrink-0 text-xs text-daintree-text/50 leading-5"
-        >
+        <div className="px-4 shrink-0 text-xs text-daintree-text/50 leading-5">
           {showScope && (
             <span>
               {filteredCount} of {totalCount} worktrees

--- a/src/components/Sidebar/__tests__/SidebarContent.test.tsx
+++ b/src/components/Sidebar/__tests__/SidebarContent.test.tsx
@@ -14,7 +14,7 @@ describe("SidebarContent filter scope and sort status — issue #8391", () => {
   // Slice from the header group to the inline search bar comment to isolate
   // the status line region. This sits between the header and the search bar.
   function statusLineRegion(src: string): string {
-    const start = src.indexOf("{/* Filter scope and sort-disabled status */}");
+    const start = src.indexOf("{/* Filter scope and sort-disabled status");
     const end = src.indexOf("{/* Inline search bar", start);
     expect(start).toBeGreaterThan(-1);
     expect(end).toBeGreaterThan(start);
@@ -30,11 +30,16 @@ describe("SidebarContent filter scope and sort status — issue #8391", () => {
     expect(region).toMatch(/\{\(showScope \|\| dragDisabledReason\) &&/);
   });
 
-  it("uses ARIA live region for screen reader announcements", () => {
+  it("keeps the visible status line free of live-region attributes (#9665)", () => {
+    // The status line mixes a dynamic filter count with persistent
+    // sort-disabled text. role="status" carries an implicit aria-atomic, so a
+    // live region here re-announced the whole line — including the persistent
+    // text — on every keystroke. Announcements are now routed through the
+    // debounced global announcer instead.
     const region = statusLineRegion(source);
-    expect(region).toContain('role="status"');
-    expect(region).toContain('aria-live="polite"');
-    expect(region).toContain('aria-atomic="true"');
+    expect(region).not.toContain('role="status"');
+    expect(region).not.toContain("aria-live");
+    expect(region).not.toContain("aria-atomic");
   });
 
   it("renders scope text 'N of M worktrees' pattern when filters narrow results", () => {
@@ -73,5 +78,42 @@ describe("SidebarContent filter scope and sort status — issue #8391", () => {
     expect(source).toMatch(
       /showScope\s*=\s*hasActiveFilters\(\)\s*&&\s*filteredCount\s*!==\s*totalCount/
     );
+  });
+});
+
+describe("SidebarContent screen-reader announcements — issue #9665", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
+  });
+
+  it("routes announcements through the global announcer store", () => {
+    expect(source).toContain(
+      'import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore"'
+    );
+    expect(source).toContain("useAnnouncerStore.getState().announce(");
+  });
+
+  it("debounces the count announcement on the shared Doherty threshold", () => {
+    expect(source).toContain('import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils"');
+    // The count announcement is scheduled on a timer cleared on re-run, so
+    // rapid keystrokes coalesce into a single late announcement.
+    expect(source).toMatch(
+      /setTimeout\([\s\S]*?announce\(`\$\{filteredCount\} of \$\{totalCount\} worktrees`\)[\s\S]*?\},\s*UI_DOHERTY_THRESHOLD\)/
+    );
+    expect(source).toMatch(/clearTimeout\(timer\)/);
+  });
+
+  it("gates the count announcement on showScope being active", () => {
+    // No filters narrowing the list → no count announcement at all.
+    expect(source).toMatch(/if \(!showScope\) return;/);
+  });
+
+  it("announces the sort-disabled reason only on the null → string transition", () => {
+    // Persistent text must not re-fire while the reason stays set; the
+    // re-enable path is owned by the isSortDisabledPrevRef effect.
+    expect(source).toContain("prevDragDisabledReasonRef");
+    expect(source).toMatch(/prev === null && dragDisabledReason !== null/);
   });
 });

--- a/src/components/Sidebar/__tests__/SidebarContent.test.tsx
+++ b/src/components/Sidebar/__tests__/SidebarContent.test.tsx
@@ -110,10 +110,11 @@ describe("SidebarContent screen-reader announcements — issue #9665", () => {
     expect(source).toMatch(/if \(!showScope\) return;/);
   });
 
-  it("announces the sort-disabled reason only on the null → string transition", () => {
-    // Persistent text must not re-fire while the reason stays set; the
-    // re-enable path is owned by the isSortDisabledPrevRef effect.
+  it("announces the sort-disabled reason on appear/change but not on re-enable", () => {
+    // Fires on null → reason and reason → reason, but not reason → null (the
+    // re-enable path is owned by the isSortDisabledPrevRef effect) and not when
+    // the reason is unchanged (so a stable reason isn't re-spoken every render).
     expect(source).toContain("prevDragDisabledReasonRef");
-    expect(source).toMatch(/prev === null && dragDisabledReason !== null/);
+    expect(source).toMatch(/dragDisabledReason !== null && prev !== dragDisabledReason/);
   });
 });


### PR DESCRIPTION
## Summary

- The sidebar worktree status line combined a dynamic filter count and a persistent sort-disabled reason inside a single `role="status"` `aria-atomic` live region, causing screen readers to re-announce the whole line on every keystroke
- Stripped `role`, `aria-live`, and `aria-atomic` from the visual status div (now visual-only) and routed the filter count through the global announcer store, debounced on `UI_DOHERTY_THRESHOLD` so rapid typing coalesces into one announcement
- The sort-disabled reason is now announced only on appear and on reason-to-reason change; the re-enable path is already handled by the existing `isSortDisabledPrevRef` effect

Resolves #9665

## Changes

- `src/components/Sidebar/SidebarContent.tsx` — removed live-region attributes from status div; added `useAnnouncerStore` calls for filter count and sort-disabled reason
- `src/components/Sidebar/__tests__/SidebarContent.test.tsx` — updated tests to cover the new announcement behaviour

## Testing

- Verified announcements coalesce on rapid typing rather than firing per keystroke
- Confirmed the sort-disabled reason announces on appear and on reason change, but not on re-enable
- Unit tests updated and passing