### PR TITLE
fix(keybindings): close docked terminal on Cmd+W instead of Assistant

### DIFF
--- a/src/hooks/__tests__/useGlobalKeybindings.test.tsx
+++ b/src/hooks/__tests__/useGlobalKeybindings.test.tsx
@@ -170,7 +170,7 @@ describe("useGlobalKeybindings — Cmd+W escape stack guard", () => {
     }
   });
 
-  it("routes Cmd+W to escape stack when focus is inside a dock panel", () => {
+  it("dispatches terminal.close when focus is inside a dock panel", () => {
     mocks.keybindingService.resolveKeybinding.mockReturnValue({
       match: { actionId: "terminal.close" },
       chordPrefix: false,
@@ -194,8 +194,12 @@ describe("useGlobalKeybindings — Cmd+W escape stack guard", () => {
 
       pressCmdW();
 
-      expect(escapeHandler).toHaveBeenCalledTimes(1);
-      expect(mocks.actionService.dispatch).not.toHaveBeenCalled();
+      expect(escapeHandler).not.toHaveBeenCalled();
+      expect(mocks.actionService.dispatch).toHaveBeenCalledWith(
+        "terminal.close",
+        undefined,
+        expect.objectContaining({ source: "keybinding" })
+      );
     } finally {
       dockPanel.remove();
     }

--- a/src/hooks/useGlobalKeybindings.ts
+++ b/src/hooks/useGlobalKeybindings.ts
@@ -151,14 +151,15 @@ export function useGlobalKeybindings(enabled: boolean = true): void {
         if (result.match) {
           // When a dialog/palette is open, route Cmd+W to the escape stack so it
           // dismisses the topmost layer instead of falling through to the terminal.
-          // Skip this diversion when focus is inside a grid panel — persistent
-          // docks like the assistant keep an escape handler registered the whole
-          // time they are open, but Cmd+W from a focused grid panel must close
-          // that panel rather than the dock.
+          // Skip this diversion when focus is inside a grid or dock panel —
+          // persistent docks like the assistant keep an escape handler registered
+          // the whole time they are open, but Cmd+W from a focused terminal panel
+          // (grid or dock) must close that panel rather than the dock.
           if (result.match.actionId === "terminal.close" && hasHandlers()) {
             const active = document.activeElement as HTMLElement | null;
-            const isFocusInsideGridPanel = active?.closest("[data-panel-location='grid']") != null;
-            if (!isFocusInsideGridPanel) {
+            const isFocusInsidePanel =
+              active?.closest("[data-panel-location='grid'],[data-panel-location='dock']") != null;
+            if (!isFocusInsidePanel) {
               dispatchEscape();
               return;
             }


### PR DESCRIPTION
## Summary

- `Cmd+W` was falling through to the escape stack and closing the Assistant whenever a docked terminal was focused, because the focus guard in `useGlobalKeybindings.ts` only checked for `[data-panel-location='grid']` — docked terminals use `[data-panel-location='dock']` and were excluded
- Broadened the check to cover both locations; renamed `isFocusInsideGridPanel` to `isFocusInsidePanel` to reflect the wider scope
- Inverted the existing unit test that documented the bug to assert the correct `terminal.close` dispatch

Resolves #9659

## Changes

- `src/hooks/useGlobalKeybindings.ts` — updated focus guard to match `grid` and `dock` panel locations
- `src/hooks/__tests__/useGlobalKeybindings.test.tsx` — flipped the dock-focus test expectation from escape-stack to `terminal.close`

## Testing

- 26 unit tests passing, including the corrected dock-terminal case
- Typecheck, lint, and format clean