### PR TITLE
feat(dock): tighten waiting-agents popover rows

### DIFF
--- a/src/components/Layout/WaitingContainer.tsx
+++ b/src/components/Layout/WaitingContainer.tsx
@@ -323,7 +323,7 @@ function WaitingSingleItem({
       <div className="flex-1 flex items-center gap-1.5 min-w-0">
         <span
           className={cn(
-            "truncate font-medium text-daintree-text/80 group-hover/row:text-daintree-text transition-colors",
+            "min-w-0 truncate font-medium text-daintree-text/80 group-hover/row:text-daintree-text transition-colors",
             compact ? "text-[11px]" : "text-xs"
           )}
         >

--- a/src/components/Layout/WaitingContainer.tsx
+++ b/src/components/Layout/WaitingContainer.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useCallback } from "react";
-import { ChevronDown, ChevronRight, Layers, X } from "lucide-react";
+import { ChevronDown, ChevronRight, Layers, Trash2 } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
@@ -15,7 +15,7 @@ import { useWorktrees } from "@/hooks/useWorktrees";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
 import { LiveTimeAgo } from "@/components/Worktree/LiveTimeAgo";
-import { STATE_ICONS, STATE_LABELS, STATE_COLORS } from "@/components/Worktree/terminalStateConfig";
+import { STATE_ICONS } from "@/components/Worktree/terminalStateConfig";
 import type { TabGroup } from "@/types";
 
 interface WaitingContainerProps {
@@ -285,9 +285,6 @@ function WaitingSingleItem({
   compact = false,
 }: WaitingSingleItemProps) {
   const agentState = terminal.agentState;
-  const StateIcon = agentState ? STATE_ICONS[agentState] : null;
-  const stateLabel = agentState ? STATE_LABELS[agentState] : null;
-  const stateColor = agentState ? STATE_COLORS[agentState] : null;
   const title = terminal.title || "Terminal";
 
   return (
@@ -310,12 +307,12 @@ function WaitingSingleItem({
         }
       }}
       className={cn(
-        "flex items-start gap-2 px-2 py-1.5 rounded-[var(--radius-sm)] border-l-2 border-l-transparent hover:bg-tint/5 focus:bg-tint/5 focus-visible:outline-2 focus-visible:outline-daintree-accent outline-hidden transition-colors group cursor-pointer w-full",
+        "flex items-center gap-2 px-2 py-1.5 rounded-[var(--radius-sm)] border-l-2 border-l-transparent hover:bg-tint/5 focus:bg-tint/5 focus-visible:outline-2 focus-visible:outline-daintree-accent outline-hidden transition-colors group/row cursor-pointer w-full",
         compact && "py-1 pl-1.5"
       )}
       aria-label={`Focus ${title}`}
     >
-      <div className="shrink-0 mt-0.5 opacity-70 group-hover:opacity-100 transition-opacity">
+      <div className="shrink-0 opacity-70 group-hover/row:opacity-100 transition-opacity">
         <TerminalIcon
           kind={terminal.kind}
           chrome={deriveTerminalChrome(terminal)}
@@ -323,46 +320,39 @@ function WaitingSingleItem({
         />
       </div>
 
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-1.5 min-w-0">
-          <span
-            className={cn(
-              "truncate font-medium text-daintree-text/80 group-hover:text-daintree-text transition-colors",
-              compact ? "text-[11px]" : "text-xs"
+      <div className="flex-1 flex items-center gap-1.5 min-w-0">
+        <span
+          className={cn(
+            "truncate font-medium text-daintree-text/80 group-hover/row:text-daintree-text transition-colors",
+            compact ? "text-[11px]" : "text-xs"
+          )}
+        >
+          {title}
+        </span>
+        {(worktreeName || terminal.activityHeadline) && (
+          <span className="flex items-center gap-1 min-w-0 truncate text-[10px] text-daintree-text/45">
+            {worktreeName && <span className="truncate">{worktreeName}</span>}
+            {worktreeName && terminal.activityHeadline && (
+              <span className="text-daintree-text/30">·</span>
             )}
-          >
-            {title}
-          </span>
-          {terminal.lastStateChange != null && (
-            <LiveTimeAgo
-              timestamp={terminal.lastStateChange}
-              className="text-[10px] text-daintree-text/40 shrink-0"
-            />
-          )}
-        </div>
-        <div className="flex items-center gap-1.5 mt-0.5 text-[11px] text-daintree-text/55">
-          {worktreeName && <span className="truncate">{worktreeName}</span>}
-          {worktreeName && (stateLabel || terminal.activityHeadline) && (
-            <span className="text-daintree-text/30">·</span>
-          )}
-          {StateIcon && stateLabel && (
-            <span className={cn("inline-flex items-center gap-1 shrink-0", stateColor)}>
-              <StateIcon className="h-2.5 w-2.5" />
-              <span>{stateLabel}</span>
-            </span>
-          )}
-          {terminal.activityHeadline && (
-            <>
-              {(worktreeName || stateLabel) && <span className="text-daintree-text/30">·</span>}
-              <span className="truncate italic text-daintree-text/50">
+            {terminal.activityHeadline && (
+              <span className="truncate italic text-daintree-text/40">
                 {terminal.activityHeadline}
               </span>
-            </>
-          )}
-        </div>
+            )}
+          </span>
+        )}
       </div>
 
-      <div className="flex gap-0.5 shrink-0 mt-0.5">
+      {terminal.lastStateChange != null && (
+        <LiveTimeAgo
+          timestamp={terminal.lastStateChange}
+          noTooltip
+          className="text-[10px] text-daintree-text/40 shrink-0"
+        />
+      )}
+
+      <div className="flex gap-0.5 shrink-0 invisible opacity-0 pointer-events-none transition-[opacity,visibility] duration-150 delay-75 motion-reduce:transition-none group-hover/row:visible group-hover/row:opacity-100 group-hover/row:pointer-events-auto group-focus-within/row:visible group-focus-within/row:opacity-100 group-focus-within/row:pointer-events-auto">
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
@@ -375,7 +365,7 @@ function WaitingSingleItem({
               aria-label={`Kill ${title}`}
               data-testid="waiting-kill-button"
             >
-              <X aria-hidden="true" />
+              <Trash2 aria-hidden="true" />
             </Button>
           </TooltipTrigger>
           <TooltipContent side="bottom">{`Kill ${title}`}</TooltipContent>

--- a/src/components/Layout/__tests__/WaitingContainer.test.tsx
+++ b/src/components/Layout/__tests__/WaitingContainer.test.tsx
@@ -256,11 +256,14 @@ describe("WaitingContainer", () => {
       expect(within(row).getByTestId("live-time-ago")).toBeTruthy();
     });
 
-    it("does not repeat the shared state word on each row (surfaced once in the header)", () => {
+    it("does not render the redundant per-row state chip (state is surfaced once in the header)", () => {
       mockTerminals = [makeTerminal({ id: "t1", title: "Fix auth bug" })];
       render(<WaitingContainer />);
       const row = screen.getByTestId("waiting-single-item");
-      expect((row.textContent ?? "").toLowerCase()).not.toContain("waiting");
+      // The removed state chip carried STATE_COLORS.waiting ("text-state-waiting");
+      // asserting on the class (not row text) avoids false-failing on titles/headlines
+      // that legitimately contain the substring "waiting" (e.g. "Awaiting permission").
+      expect(row.querySelector(".text-state-waiting")).toBeNull();
     });
 
     it("keeps the kill button hidden until row hover/focus (invisible, not just transparent)", () => {

--- a/src/components/Layout/__tests__/WaitingContainer.test.tsx
+++ b/src/components/Layout/__tests__/WaitingContainer.test.tsx
@@ -238,7 +238,7 @@ describe("WaitingContainer", () => {
   });
 
   describe("row metadata", () => {
-    it("renders worktree name, state label, headline, and live time", () => {
+    it("renders title, worktree name, headline, and live time on a single line", () => {
       mockTerminals = [
         makeTerminal({
           id: "t1",
@@ -252,9 +252,23 @@ describe("WaitingContainer", () => {
       const text = row.textContent ?? "";
       expect(text).toContain("Fix auth bug");
       expect(text).toContain("feature-auth");
-      expect(text).toContain("waiting");
       expect(text).toContain("Awaiting permission");
       expect(within(row).getByTestId("live-time-ago")).toBeTruthy();
+    });
+
+    it("does not repeat the shared state word on each row (surfaced once in the header)", () => {
+      mockTerminals = [makeTerminal({ id: "t1", title: "Fix auth bug" })];
+      render(<WaitingContainer />);
+      const row = screen.getByTestId("waiting-single-item");
+      expect((row.textContent ?? "").toLowerCase()).not.toContain("waiting");
+    });
+
+    it("keeps the kill button hidden until row hover/focus (invisible, not just transparent)", () => {
+      mockTerminals = [makeTerminal({ id: "t1" })];
+      render(<WaitingContainer />);
+      const killWrapper = screen.getByTestId("waiting-kill-button").parentElement;
+      expect(killWrapper?.className).toContain("invisible");
+      expect(killWrapper?.className).toContain("group-focus-within/row:visible");
     });
 
     it("uses a transparent border placeholder (no amber tint on every row)", () => {


### PR DESCRIPTION
## Summary

- Collapses each waiting-agent row in the Dock popover from two lines to one: terminal icon left, truncating title, muted worktree·headline metadata, right-aligned live time
- Removes the per-row state word — every row in the list shares the same state, and the popover header already surfaces it; repeating it on each row just wastes space
- Demotes the kill button from always-visible to hover/focus-reveal using the `invisible` + `group-focus-within` pattern, keeping it keyboard-reachable when the row is focused; swaps the glyph from `X` (dismiss) to `Trash2` (destroy) — `ConfirmDialog` confirmation step kept

Resolves #9658

## Changes

- `src/components/Layout/WaitingContainer.tsx` — single-line row layout, hover-reveal kill button, `Trash2` glyph
- `src/components/Layout/__tests__/WaitingContainer.test.tsx` — updated for single-line layout, added hover-reveal class-contract guard

## Testing

25 unit tests pass. `npm run check` clean.