### PR TITLE
feat(sidebar): surface the worktree keyboard cursor as a visible row state

### DIFF
--- a/src/components/DragDrop/SortableWorktreeCard.tsx
+++ b/src/components/DragDrop/SortableWorktreeCard.tsx
@@ -37,6 +37,7 @@ interface SortableWorktreeCardProps {
   disabled?: boolean;
   ariaRowIndex: number;
   isActive: boolean;
+  isKeyboardCursor?: boolean;
   children: (props: {
     isDraggingSort: boolean;
     dragHandleListeners: SyntheticListenerMap | undefined;
@@ -53,6 +54,7 @@ function sortableWorktreeCardPropsAreEqual(
     prev.disabled !== next.disabled ||
     prev.ariaRowIndex !== next.ariaRowIndex ||
     prev.isActive !== next.isActive ||
+    prev.isKeyboardCursor !== next.isKeyboardCursor ||
     prev.children !== next.children
   ) {
     return false;
@@ -71,6 +73,7 @@ export const SortableWorktreeCard = React.memo(function SortableWorktreeCard({
   disabled,
   ariaRowIndex,
   isActive,
+  isKeyboardCursor,
   children,
 }: SortableWorktreeCardProps) {
   const dragData: WorktreeSortDragData = {
@@ -138,6 +141,7 @@ export const SortableWorktreeCard = React.memo(function SortableWorktreeCard({
       aria-current={isActive ? "true" : undefined}
       aria-keyshortcuts={disabled ? undefined : "Alt+ArrowUp Alt+ArrowDown"}
       data-worktree-row={worktreeId}
+      data-keyboard-cursor={isKeyboardCursor ? "true" : undefined}
       tabIndex={-1}
       className="relative"
       {...filteredAttributes}

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -166,6 +166,7 @@ type SidebarFlatItem = SidebarHeaderFlatItem | SidebarRowFlatItem;
 interface SidebarVirtuosoContext {
   activeWorktreeId: string | null;
   focusedWorktreeId: string | null;
+  keyboardCursorId: string | null;
   totalWorktreeCount: number;
   selectWorktree: (id: string) => void;
   worktreeActions: WorktreeActions;
@@ -253,6 +254,7 @@ function renderSidebarFlatItem(
         worktreeId={item.worktreeId}
         activeWorktreeId={context.activeWorktreeId}
         focusedWorktreeId={context.focusedWorktreeId}
+        keyboardCursorId={context.keyboardCursorId}
         totalWorktreeCount={context.totalWorktreeCount}
         selectWorktree={context.selectWorktree}
         worktreeActions={context.worktreeActions}
@@ -268,6 +270,7 @@ function renderSidebarFlatItem(
       worktreeId={item.worktreeId}
       activeWorktreeId={context.activeWorktreeId}
       focusedWorktreeId={context.focusedWorktreeId}
+      keyboardCursorId={context.keyboardCursorId}
       totalWorktreeCount={context.totalWorktreeCount}
       selectWorktree={context.selectWorktree}
       worktreeActions={context.worktreeActions}
@@ -1234,6 +1237,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const {
     gridRef,
     activeDescendantId,
+    keyboardCursorId,
     handleGridKeyDown,
     handleGridFocus,
     handleGridFocusCapture,
@@ -1249,6 +1253,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     () => ({
       activeWorktreeId,
       focusedWorktreeId,
+      keyboardCursorId,
       totalWorktreeCount: deferredWorktrees.length,
       selectWorktree,
       worktreeActions,
@@ -1261,6 +1266,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     [
       activeWorktreeId,
       focusedWorktreeId,
+      keyboardCursorId,
       deferredWorktrees.length,
       selectWorktree,
       worktreeActions,
@@ -1617,6 +1623,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
               worktreeId={mainWorktree.id}
               activeWorktreeId={activeWorktreeId}
               focusedWorktreeId={focusedWorktreeId}
+              keyboardCursorId={keyboardCursorId}
               totalWorktreeCount={deferredWorktrees.length}
               selectWorktree={selectWorktree}
               worktreeActions={worktreeActions}
@@ -1641,6 +1648,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
               worktreeId={integrationWorktree.id}
               activeWorktreeId={activeWorktreeId}
               focusedWorktreeId={focusedWorktreeId}
+              keyboardCursorId={keyboardCursorId}
               totalWorktreeCount={deferredWorktrees.length}
               selectWorktree={selectWorktree}
               worktreeActions={worktreeActions}

--- a/src/components/Sidebar/SidebarWorktreeRow.tsx
+++ b/src/components/Sidebar/SidebarWorktreeRow.tsx
@@ -14,6 +14,7 @@ interface SidebarWorktreeRowProps {
   worktreeId: string;
   activeWorktreeId: string | null;
   focusedWorktreeId: string | null;
+  keyboardCursorId: string | null;
   totalWorktreeCount: number;
   selectWorktree: (id: string) => void;
   worktreeActions: WorktreeActions;
@@ -31,6 +32,7 @@ function SidebarWorktreeRow({
   worktreeId,
   activeWorktreeId,
   focusedWorktreeId,
+  keyboardCursorId,
   totalWorktreeCount,
   selectWorktree,
   worktreeActions,
@@ -100,6 +102,7 @@ function SidebarWorktreeRow({
 
   const isActive = worktreeId === activeWorktreeId;
   const isFocused = worktreeId === focusedWorktreeId;
+  const isKeyboardCursor = worktreeId === keyboardCursorId;
   const isSingleWorktree = totalWorktreeCount === 1;
   const moveUpHandler = dragEnabled ? onMoveUp : undefined;
   const moveDownHandler = dragEnabled ? onMoveDown : undefined;
@@ -113,6 +116,7 @@ function SidebarWorktreeRow({
       disabled={isSortDisabled || isPinned}
       ariaRowIndex={ariaRowIndex}
       isActive={isActive}
+      isKeyboardCursor={isKeyboardCursor}
     >
       {({ isDraggingSort, dragHandleListeners, dragHandleActivatorRef }) => (
         <ErrorBoundary

--- a/src/components/Sidebar/StaticWorktreeRow.tsx
+++ b/src/components/Sidebar/StaticWorktreeRow.tsx
@@ -12,6 +12,7 @@ interface StaticWorktreeRowProps {
   worktreeId: string;
   activeWorktreeId: string | null;
   focusedWorktreeId: string | null;
+  keyboardCursorId: string | null;
   totalWorktreeCount: number;
   selectWorktree: (id: string) => void;
   worktreeActions: WorktreeActions;
@@ -27,6 +28,7 @@ function StaticWorktreeRow({
   worktreeId,
   activeWorktreeId,
   focusedWorktreeId,
+  keyboardCursorId,
   totalWorktreeCount,
   selectWorktree,
   worktreeActions,
@@ -71,12 +73,14 @@ function StaticWorktreeRow({
   if (!worktree) return null;
 
   const isActive = worktreeId === activeWorktreeId;
+  const isKeyboardCursor = worktreeId === keyboardCursorId;
 
   return (
     <div
       role="row"
       id={getWorktreeSidebarRowId(worktreeId)}
       data-worktree-row={worktreeId}
+      data-keyboard-cursor={isKeyboardCursor ? "true" : undefined}
       tabIndex={-1}
       aria-rowindex={ariaRowIndex}
       aria-current={isActive ? "true" : undefined}

--- a/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
@@ -441,12 +441,17 @@ describe("Worktree list keyboard grid — issue #6422 / virtualized rewrite", ()
 
     it("ships a forced-colors outline fallback for the cursor ring (box-shadow is stripped there)", async () => {
       const css = await fs.readFile(SIDEBAR_CSS_PATH, "utf-8");
-      const forcedColorsBlocks = css.match(/@media \(forced-colors: active\) \{[\s\S]*?\n\}/g) ?? [];
-      const hasCursorFallback = forcedColorsBlocks.some(
-        (block) =>
+      // Split on each forced-colors media query and inspect the segment up to
+      // the next media query — robust to brace indentation, unlike a lazy
+      // `\n}` block match which depends on prettier's exact formatting.
+      const segments = css.split("@media (forced-colors: active)").slice(1);
+      const hasCursorFallback = segments.some((seg) => {
+        const block = seg.split("@media")[0]!;
+        return (
           block.includes('data-keyboard-cursor="true"') &&
           /outline:\s*2px solid Highlight/.test(block)
-      );
+        );
+      });
       expect(hasCursorFallback).toBe(true);
     });
 

--- a/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
@@ -422,9 +422,7 @@ describe("Worktree list keyboard grid — issue #6422 / virtualized rewrite", ()
       // Without this the React.memo comparator would swallow cursor changes and
       // the ring would stick on a stale row as the user navigates.
       const sortableSource = await fs.readFile(SORTABLE_CARD_PATH, "utf-8");
-      expect(sortableSource).toMatch(
-        /prev\.isKeyboardCursor\s*!==\s*next\.isKeyboardCursor/
-      );
+      expect(sortableSource).toMatch(/prev\.isKeyboardCursor\s*!==\s*next\.isKeyboardCursor/);
     });
 
     it("styles the cursor ring with the neutral focus token, never the accent ring (one-accent rule)", async () => {

--- a/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
@@ -387,6 +387,77 @@ describe("Worktree list keyboard grid — issue #6422 / virtualized rewrite", ()
     });
   });
 
+  describe("issue #9667 — keyboard cursor surfaced as a visible row state", () => {
+    const SIDEBAR_CSS_PATH = path.resolve(__dirname, "../../../styles/components/sidebar.css");
+
+    it("exposes keyboardCursorId from the keyboard hook, mode-guarded to list mode", async () => {
+      const source = await fs.readFile(KEYBOARD_HOOK_PATH, "utf-8");
+      expect(source).toMatch(/keyboardCursorId:\s*string \| null/);
+      // Cursor only exists in list mode — toolbar mode hands the focus ring to
+      // the real DOM button, so the row-level cursor must read null there.
+      expect(source).toMatch(/keyboardCursorId\s*=\s*mode === "list" \? activeWorktreeId : null/);
+    });
+
+    it("threads keyboardCursorId through the Virtuoso context into both row paths", async () => {
+      const source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
+      expect(source).toMatch(/keyboardCursorId:\s*string \| null/);
+      expect(source).toContain("keyboardCursorId={context.keyboardCursorId}");
+      // The pinned (main + integration) rows live outside the Virtuoso surface
+      // and must receive the cursor id directly from the hook return.
+      expect(source).toContain("keyboardCursorId={keyboardCursorId}");
+    });
+
+    it("flags the cursor row via data-keyboard-cursor in both static and sortable paths", async () => {
+      const staticSource = await fs.readFile(STATIC_ROW_PATH, "utf-8");
+      const sortableSource = await fs.readFile(SORTABLE_CARD_PATH, "utf-8");
+      expect(staticSource).toContain(
+        'data-keyboard-cursor={isKeyboardCursor ? "true" : undefined}'
+      );
+      expect(sortableSource).toContain(
+        'data-keyboard-cursor={isKeyboardCursor ? "true" : undefined}'
+      );
+    });
+
+    it("includes isKeyboardCursor in the SortableWorktreeCard memo comparator so the ring updates", async () => {
+      // Without this the React.memo comparator would swallow cursor changes and
+      // the ring would stick on a stale row as the user navigates.
+      const sortableSource = await fs.readFile(SORTABLE_CARD_PATH, "utf-8");
+      expect(sortableSource).toMatch(
+        /prev\.isKeyboardCursor\s*!==\s*next\.isKeyboardCursor/
+      );
+    });
+
+    it("styles the cursor ring with the neutral focus token, never the accent ring (one-accent rule)", async () => {
+      const css = await fs.readFile(SIDEBAR_CSS_PATH, "utf-8");
+      const cursorRule = css.match(
+        /\[data-worktree-row\]\[data-keyboard-cursor="true"\] \.sidebar-worktree-card \{[^}]*\}/
+      );
+      expect(cursorRule).toBeTruthy();
+      // The current-worktree marker already owns --sidebar-ring (= accent); the
+      // cursor must use the neutral focus token so the region keeps one accent.
+      expect(cursorRule![0]).toContain("var(--theme-focus-ring)");
+      expect(cursorRule![0]).not.toContain("--sidebar-ring");
+    });
+
+    it("ships a forced-colors outline fallback for the cursor ring (box-shadow is stripped there)", async () => {
+      const css = await fs.readFile(SIDEBAR_CSS_PATH, "utf-8");
+      const forcedColorsBlocks = css.match(/@media \(forced-colors: active\) \{[\s\S]*?\n\}/g) ?? [];
+      const hasCursorFallback = forcedColorsBlocks.some(
+        (block) =>
+          block.includes('data-keyboard-cursor="true"') &&
+          /outline:\s*2px solid Highlight/.test(block)
+      );
+      expect(hasCursorFallback).toBe(true);
+    });
+
+    it("suppresses the cursor ring when the sidebar is not focused", async () => {
+      const css = await fs.readFile(SIDEBAR_CSS_PATH, "utf-8");
+      expect(css).toMatch(
+        /\.sidebar-root:not\(:focus-within\)[\s\S]*?\[data-keyboard-cursor="true"\][\s\S]*?box-shadow:\s*none/
+      );
+    });
+  });
+
   describe("issue #8389 — per-row sidebar subscription stops full-list re-renders", () => {
     let source: string;
     let staticSource: string;

--- a/src/components/Sidebar/__tests__/useWorktreeSidebarKeyboard.altArrow.test.tsx
+++ b/src/components/Sidebar/__tests__/useWorktreeSidebarKeyboard.altArrow.test.tsx
@@ -35,6 +35,7 @@ function Harness({ items, onKeyboardReorder, onSelectWorktree }: HarnessProps) {
   const {
     gridRef,
     activeDescendantId,
+    keyboardCursorId,
     handleGridKeyDown,
     handleGridFocus,
     handleGridFocusCapture,
@@ -51,6 +52,7 @@ function Harness({ items, onKeyboardReorder, onSelectWorktree }: HarnessProps) {
       role="grid"
       tabIndex={0}
       aria-activedescendant={activeDescendantId}
+      data-cursor-id={keyboardCursorId ?? ""}
       data-testid="grid"
       onKeyDown={handleGridKeyDown}
       onFocus={handleGridFocus}
@@ -63,6 +65,7 @@ function Harness({ items, onKeyboardReorder, onSelectWorktree }: HarnessProps) {
             id={getWorktreeSidebarRowId(item.worktreeId)}
             role="row"
             data-worktree-row={item.worktreeId}
+            data-keyboard-cursor={item.worktreeId === keyboardCursorId ? "true" : undefined}
             tabIndex={-1}
           >
             <div data-worktree-row-toolbar="">
@@ -242,6 +245,38 @@ describe("useWorktreeSidebarKeyboard — pinned rows in navigation", () => {
     // bounces the move when the worktree id isn't in the visible
     // (non-pinned) dragStartOrder. The hook itself just translates the key.
     expect(onKeyboardReorder).toHaveBeenCalledWith("main", 1);
+  });
+});
+
+describe("useWorktreeSidebarKeyboard — keyboard cursor exposure", () => {
+  it("exposes keyboardCursorId tracking the active row in list mode", () => {
+    const { getByTestId } = render(<Harness items={ITEMS} />);
+    const grid = getByTestId("grid");
+    fireEvent.focus(grid); // seeds wt1
+    expect(grid.getAttribute("data-cursor-id")).toBe("wt1");
+    fireEvent.keyDown(grid, { key: "ArrowDown" });
+    expect(grid.getAttribute("data-cursor-id")).toBe("wt2");
+  });
+
+  it("flags exactly one row with data-keyboard-cursor in list mode", () => {
+    const { getByTestId, container } = render(<Harness items={ITEMS} />);
+    const grid = getByTestId("grid");
+    fireEvent.focus(grid);
+    fireEvent.keyDown(grid, { key: "ArrowDown" });
+    const flagged = container.querySelectorAll('[data-keyboard-cursor="true"]');
+    expect(flagged).toHaveLength(1);
+    expect((flagged[0] as HTMLElement).dataset.worktreeRow).toBe("wt2");
+  });
+
+  it("clears keyboardCursorId in toolbar mode and restores it on Escape", () => {
+    const { getByTestId, container } = render(<Harness items={ITEMS} />);
+    const grid = getByTestId("grid");
+    grid.focus(); // → wt1 active in list mode
+    fireEvent.keyDown(grid, { key: "Enter" }); // enter toolbar mode
+    expect(grid.getAttribute("data-cursor-id")).toBe("");
+    expect(container.querySelectorAll('[data-keyboard-cursor="true"]')).toHaveLength(0);
+    fireEvent.keyDown(getByTestId("tb-wt1-1"), { key: "Escape" }); // back to list mode
+    expect(grid.getAttribute("data-cursor-id")).toBe("wt1");
   });
 });
 

--- a/src/components/Sidebar/useWorktreeSidebarKeyboard.ts
+++ b/src/components/Sidebar/useWorktreeSidebarKeyboard.ts
@@ -61,6 +61,15 @@ export interface UseWorktreeSidebarKeyboardOptions {
 export interface UseWorktreeSidebarKeyboardReturn {
   gridRef: React.RefObject<HTMLDivElement | null>;
   activeDescendantId: string | undefined;
+  /**
+   * Worktree id the keyboard navigation cursor currently points at, or null.
+   *
+   * The grid uses aria-activedescendant, so rows never take real DOM focus and
+   * `:focus-visible` never fires for arrow-key navigation. Rows consume this id
+   * to render a visible cursor ring on the active row. Null in toolbar mode
+   * (focus has moved into a real DOM button, which carries its own focus ring).
+   */
+  keyboardCursorId: string | null;
   handleGridKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
   handleGridFocus: (e: React.FocusEvent<HTMLDivElement>) => void;
   handleGridFocusCapture: (e: React.FocusEvent<HTMLDivElement>) => void;
@@ -527,9 +536,15 @@ export function useWorktreeSidebarKeyboard({
   const activeDescendantId =
     mode === "list" && activeWorktreeId ? getWorktreeSidebarRowId(activeWorktreeId) : undefined;
 
+  // Mirror the activeDescendant mode-guard: only expose a cursor in list mode.
+  // In toolbar mode focus has descended into a real DOM button, which owns the
+  // visible focus ring, so the row-level cursor ring would be a duplicate.
+  const keyboardCursorId = mode === "list" ? activeWorktreeId : null;
+
   return {
     gridRef,
     activeDescendantId,
+    keyboardCursorId,
     handleGridKeyDown,
     handleGridFocus,
     handleGridFocusCapture,

--- a/src/styles/components/sidebar.css
+++ b/src/styles/components/sidebar.css
@@ -51,12 +51,49 @@ html[data-dragging="true"] .sidebar-worktree-card[data-hovered="true"] {
     inset 0 0 0 2px var(--sidebar-ring);
 }
 
+/* Keyboard navigation cursor (aria-activedescendant). The grid container holds
+   the only real DOM focus, so `:focus-visible` never fires on a row during
+   arrow-key navigation — the active row is flagged with `data-keyboard-cursor`
+   instead. Render the ring with `--theme-focus-ring` (the neutral, dedicated
+   focus token), NOT `--sidebar-ring` (which resolves to the accent color the
+   current-worktree marker already owns) so the focus region carries a single
+   accent signal. */
+[data-worktree-row][data-keyboard-cursor="true"] .sidebar-worktree-card {
+  box-shadow: inset 0 0 0 2px var(--theme-focus-ring);
+}
+
+[data-worktree-row][data-keyboard-cursor="true"] .sidebar-worktree-card[data-active="true"] {
+  box-shadow:
+    inset 2px 0 0 var(--theme-overlay-selected),
+    inset 0 0 0 2px var(--theme-focus-ring);
+}
+
+/* Suppress the cursor ring when the sidebar isn't focused — the cursor only
+   matters while the user is navigating the grid. Mirrors the `data-active`
+   dimming above so a backgrounded sidebar reads as quiet. */
+.sidebar-root:not(:focus-within)
+  [data-worktree-row][data-keyboard-cursor="true"]
+  .sidebar-worktree-card {
+  box-shadow: none;
+}
+
+.sidebar-root:not(:focus-within)
+  [data-worktree-row][data-keyboard-cursor="true"]
+  .sidebar-worktree-card[data-active="true"] {
+  box-shadow: inset 2px 0 0 var(--theme-overlay-selected);
+}
+
 /* Reveal the per-row action toolbar whenever the row has keyboard focus
    (or any descendant does). Uses `:focus-visible` / `:has(:focus-visible)`
    rather than `:focus` / `:focus-within` so mousedown on a button does not
-   flash the toolbar before the click resolves. */
+   flash the toolbar before the click resolves. The cursor-row selector covers
+   grid-mode navigation, where focus stays on the container and the rules above
+   never match. */
 [data-worktree-row]:focus-visible [data-worktree-row-toolbar],
-[data-worktree-row]:has(:focus-visible) [data-worktree-row-toolbar] {
+[data-worktree-row]:has(:focus-visible) [data-worktree-row-toolbar],
+.sidebar-root:focus-within
+  [data-worktree-row][data-keyboard-cursor="true"]
+  [data-worktree-row-toolbar] {
   opacity: 1;
   pointer-events: auto;
 }
@@ -64,13 +101,26 @@ html[data-dragging="true"] .sidebar-worktree-card[data-hovered="true"] {
 /* Reveal the drag handle whenever the row has keyboard focus, matching the
    toolbar reveal pattern above. */
 [data-worktree-row]:focus-visible [data-worktree-row-drag-handle],
-[data-worktree-row]:has(:focus-visible) [data-worktree-row-drag-handle] {
+[data-worktree-row]:has(:focus-visible) [data-worktree-row-drag-handle],
+.sidebar-root:focus-within
+  [data-worktree-row][data-keyboard-cursor="true"]
+  [data-worktree-row-drag-handle] {
   color: color-mix(in srgb, var(--theme-text-primary) 30%, transparent);
   background-color: var(--theme-overlay-soft);
 }
 
 @media (forced-colors: active) {
   [data-worktree-row]:focus-visible .sidebar-worktree-card {
+    outline: 2px solid Highlight;
+    outline-offset: -2px;
+  }
+
+  /* box-shadow is stripped in forced-colors mode, so the cursor ring needs a
+     system-color outline fallback. Scope to the focused sidebar so a
+     backgrounded grid doesn't paint a stray cursor outline. */
+  .sidebar-root:focus-within
+    [data-worktree-row][data-keyboard-cursor="true"]
+    .sidebar-worktree-card {
     outline: 2px solid Highlight;
     outline-offset: -2px;
   }

--- a/src/styles/components/sidebar.css
+++ b/src/styles/components/sidebar.css
@@ -70,17 +70,13 @@ html[data-dragging="true"] .sidebar-worktree-card[data-hovered="true"] {
 
 /* Suppress the cursor ring when the sidebar isn't focused — the cursor only
    matters while the user is navigating the grid. Mirrors the `data-active`
-   dimming above so a backgrounded sidebar reads as quiet. */
+   dimming above (line 12 zeroes the active row's left-edge marker too) so a
+   backgrounded sidebar reads uniformly quiet, active row or not. The 0,5,0
+   specificity beats both the cursor rules and the focused active+cursor rule. */
 .sidebar-root:not(:focus-within)
   [data-worktree-row][data-keyboard-cursor="true"]
   .sidebar-worktree-card {
   box-shadow: none;
-}
-
-.sidebar-root:not(:focus-within)
-  [data-worktree-row][data-keyboard-cursor="true"]
-  .sidebar-worktree-card[data-active="true"] {
-  box-shadow: inset 2px 0 0 var(--theme-overlay-selected);
 }
 
 /* Reveal the per-row action toolbar whenever the row has keyboard focus
@@ -88,10 +84,13 @@ html[data-dragging="true"] .sidebar-worktree-card[data-hovered="true"] {
    rather than `:focus` / `:focus-within` so mousedown on a button does not
    flash the toolbar before the click resolves. The cursor-row selector covers
    grid-mode navigation, where focus stays on the container and the rules above
-   never match. */
+   never match. It scopes to the focused grid (not the whole sidebar) so the
+   action affordance hides when focus tabs out to the search bar — the cursor
+   ring lingers as a passive marker, but the interactive toolbar does not. */
 [data-worktree-row]:focus-visible [data-worktree-row-toolbar],
 [data-worktree-row]:has(:focus-visible) [data-worktree-row-toolbar],
-.sidebar-root:focus-within
+.sidebar-root
+  [role="grid"]:focus-within
   [data-worktree-row][data-keyboard-cursor="true"]
   [data-worktree-row-toolbar] {
   opacity: 1;
@@ -102,7 +101,8 @@ html[data-dragging="true"] .sidebar-worktree-card[data-hovered="true"] {
    toolbar reveal pattern above. */
 [data-worktree-row]:focus-visible [data-worktree-row-drag-handle],
 [data-worktree-row]:has(:focus-visible) [data-worktree-row-drag-handle],
-.sidebar-root:focus-within
+.sidebar-root
+  [role="grid"]:focus-within
   [data-worktree-row][data-keyboard-cursor="true"]
   [data-worktree-row-drag-handle] {
   color: color-mix(in srgb, var(--theme-text-primary) 30%, transparent);


### PR DESCRIPTION
## Summary

- The worktree sidebar uses `role="grid"` + `aria-activedescendant`, so rows have `tabIndex={-1}` and never take real DOM focus. Arrow-key navigation and `Alt+Arrow` reorder moved the cursor position without any visible change for sighted users — only screen-reader announcements fired.
- This PR exposes `keyboardCursorId` from the keyboard hook (mode-guarded to list mode), threads it through the Virtuoso context into the static, sortable, and pinned row paths, and flags the matching row with `data-keyboard-cursor`. The ring uses `--theme-focus-ring` (neutral) rather than `--sidebar-ring` (which resolves to the accent already spent on the `isCurrent` worktree marker), preserving the one-accent-per-focus-region rule.
- Also includes a `forced-colors` outline fallback, suppression when the sidebar loses focus, and toolbar/drag-handle reveal while navigating the grid.

Resolves #9667

## Changes

- `useWorktreeSidebarKeyboard.ts` — exposes `keyboardCursorId` in list mode
- `SidebarContent.tsx` — threads `keyboardCursorId` through the Virtuoso context
- `SortableWorktreeCard.tsx`, `SidebarWorktreeRow.tsx`, `StaticWorktreeRow.tsx` — consume `keyboardCursorId` and set `data-keyboard-cursor` on the matching row; `isKeyboardCursor` added to React.memo comparator to prevent stale rings
- `sidebar.css` — `[data-keyboard-cursor]` ring styled with `--theme-focus-ring`; `forced-colors` fallback; suppressed when `[data-sidebar-focused="false"]`; toolbar/handle revealed on cursor row

## Testing

- New unit tests in `SidebarContent.grid.test.ts` cover cursor exposure and clearing, the CSS token contract (`--theme-focus-ring` not `--sidebar-ring`), and the `forced-colors` outline block
- Existing `useWorktreeSidebarKeyboard.altArrow.test.tsx` extended to assert `keyboardCursorId` travels with a moved row on `Alt+Arrow`
- `npm run check` passes clean