### PR TITLE
fix(sidebar): compute offscreen-count pills from real item geometry

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -972,25 +972,6 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       hasFacetFiltersActive,
     ]);
 
-  const {
-    hiddenAbove,
-    hiddenBelow,
-    scrollToTop,
-    scrollToBottom,
-    scrollerRef: scrollIndicatorScrollerRef,
-    handleScroll,
-  } = useScrollIndicator({
-    itemCount: filteredWorktrees.length,
-  });
-
-  const setScrollerElement = useCallback(
-    (el: HTMLElement | Window | null) => {
-      scrollerElementRef.current = el instanceof HTMLElement ? el : null;
-      scrollIndicatorScrollerRef(el);
-    },
-    [scrollIndicatorScrollerRef]
-  );
-
   const worktreeActions = useWorktreeActions({
     onOpenRecipeEditor: handleOpenRecipeEditor,
   });
@@ -1213,6 +1194,29 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     pinnedWorktrees,
     dragStartOrder,
   ]);
+
+  // Computed after `sidebarItems` because the indicator counts hidden worktree
+  // rows directly from the flat list geometry (variable-height rows + section
+  // headers, issue #9666), so it needs the full item array as its input.
+  const {
+    hiddenAbove,
+    hiddenBelow,
+    scrollToTop,
+    scrollToBottom,
+    scrollerRef: scrollIndicatorScrollerRef,
+    handleScroll,
+    handleItemsRendered,
+  } = useScrollIndicator({
+    items: sidebarItems,
+  });
+
+  const setScrollerElement = useCallback(
+    (el: HTMLElement | Window | null) => {
+      scrollerElementRef.current = el instanceof HTMLElement ? el : null;
+      scrollIndicatorScrollerRef(el);
+    },
+    [scrollIndicatorScrollerRef]
+  );
 
   // The pinned main + integration rows live OUTSIDE the Virtuoso surface but
   // INSIDE the role="grid" container, so keyboard navigation must visit them
@@ -1795,6 +1799,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
               itemContent={renderSidebarFlatItem}
               scrollerRef={setScrollerElement}
               onScroll={handleScroll}
+              itemsRendered={handleItemsRendered}
               className="absolute inset-0 overflow-y-auto scrollbar-none"
             />
           ) : (
@@ -1811,6 +1816,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                 itemContent={renderSidebarFlatItem}
                 scrollerRef={setScrollerElement}
                 onScroll={handleScroll}
+                itemsRendered={handleItemsRendered}
                 className="absolute inset-0 overflow-y-auto scrollbar-none"
               />
             </SortableContext>

--- a/src/components/Sidebar/__tests__/useScrollIndicator.test.ts
+++ b/src/components/Sidebar/__tests__/useScrollIndicator.test.ts
@@ -153,9 +153,9 @@ describe("useScrollIndicator hidden-row counts (issue #9666)", () => {
     expect(result.current.hiddenBelow).toBe(10);
   });
 
-  it("treats a barely-visible row as visible at the epsilon boundary", () => {
-    const items = makeItems(["row", "row"]);
-    const { result, rerender } = renderHook(() => useScrollIndicator({ items }));
+  it("counts a row hidden within 1px of an edge, visible past it (epsilon)", () => {
+    const items = makeItems(["row", "row", "row"]);
+    const { result } = renderHook(() => useScrollIndicator({ items }));
     const scroller = makeScroller({ scrollTop: 99, clientHeight: 100 });
     act(() => {
       result.current.scrollerRef(scroller);
@@ -163,23 +163,94 @@ describe("useScrollIndicator hidden-row counts (issue #9666)", () => {
     const rendered = makeRendered([
       { index: 0, offset: 0, size: 100, kind: "row" },
       { index: 1, offset: 100, size: 100, kind: "row" },
+      { index: 2, offset: 200, size: 100, kind: "row" },
     ]);
     act(() => {
       result.current.handleItemsRendered(rendered);
     });
 
-    // scrollTop 99: row 0's bottom (100) is within 1px of the viewport top, so
-    // it counts as hidden-above.
+    // Top edge — scrollTop 99, viewport [99, 199]: row 0's bottom (100) is
+    // within 1px of the viewport top, so it counts as hidden-above. Row 2's top
+    // (200) is within 1px of the viewport bottom (199), so it's hidden-below.
     expect(result.current.hiddenAbove).toBe(1);
+    expect(result.current.hiddenBelow).toBe(1);
 
-    // scrollTop 98: row 0 now shows 2px — past the epsilon — so it's visible.
+    // scrollTop 98, viewport [98, 198]: row 0 now shows 2px (past epsilon) so
+    // it's visible; row 2's top (200) is 2px below the viewport bottom (198) so
+    // it stays hidden-below.
     scroller.scrollTop = 98;
     act(() => {
       result.current.handleScroll();
     });
     flushFrames();
-    rerender();
     expect(result.current.hiddenAbove).toBe(0);
+    expect(result.current.hiddenBelow).toBe(1);
+  });
+
+  it("ignores section headers that sit outside the rendered window", () => {
+    // header, row, row, header, row, row — only indices 3..5 are mounted.
+    const items = makeItems(["header", "row", "row", "header", "row", "row"]);
+    const { result } = renderHook(() => useScrollIndicator({ items }));
+    const scroller = makeScroller({ scrollTop: 400, clientHeight: 100 });
+    act(() => {
+      result.current.scrollerRef(scroller);
+    });
+    act(() => {
+      result.current.handleItemsRendered(
+        makeRendered([
+          { index: 3, offset: 230, size: 30, kind: "header" },
+          { index: 4, offset: 260, size: 100, kind: "row" },
+          { index: 5, offset: 360, size: 100, kind: "row" },
+        ])
+      );
+    });
+
+    // Unrendered prefix items[0..2] = header + 2 rows → only the 2 rows count
+    // above (the header is ignored). Viewport [400, 500]: rendered row 4
+    // (260..360) is fully above → +1; row 5 (360..460) overlaps the viewport so
+    // it's visible. Total hidden-above = 2 unrendered rows + row 4 = 3.
+    expect(result.current.hiddenAbove).toBe(3);
+    expect(result.current.hiddenBelow).toBe(0);
+  });
+
+  it("applies fresh geometry tagged for the new list right after an items change", () => {
+    const itemsA = makeItems(["row", "row", "row"]);
+    const itemsB = makeItems(["row", "row", "row", "row"]);
+    const { result, rerender } = renderHook(({ items }) => useScrollIndicator({ items }), {
+      initialProps: { items: itemsA },
+    });
+    const scroller = makeScroller({ scrollTop: 250, clientHeight: 50 });
+    act(() => {
+      result.current.scrollerRef(scroller);
+    });
+    act(() => {
+      result.current.handleItemsRendered(
+        makeRendered([
+          { index: 0, offset: 0, size: 100, kind: "row" },
+          { index: 1, offset: 100, size: 100, kind: "row" },
+          { index: 2, offset: 200, size: 100, kind: "row" },
+        ])
+      );
+    });
+    expect(result.current.hiddenAbove).toBe(2);
+
+    // Swap the list, then immediately deliver fresh geometry for the new layout
+    // (the order Virtuoso fires in). The identity guard must accept geometry
+    // tagged for the current list — counts must reflect itemsB, not fall to 0/0.
+    rerender({ items: itemsB });
+    act(() => {
+      result.current.handleItemsRendered(
+        makeRendered([
+          { index: 0, offset: 0, size: 100, kind: "row" },
+          { index: 1, offset: 100, size: 100, kind: "row" },
+          { index: 2, offset: 200, size: 100, kind: "row" },
+          { index: 3, offset: 300, size: 100, kind: "row" },
+        ])
+      );
+    });
+    // Viewport [250, 300]: rows 0,1 above, row 2 visible, row 3 below.
+    expect(result.current.hiddenAbove).toBe(2);
+    expect(result.current.hiddenBelow).toBe(1);
   });
 
   it("reports 0/0 before any itemsRendered geometry has been captured", () => {

--- a/src/components/Sidebar/__tests__/useScrollIndicator.test.ts
+++ b/src/components/Sidebar/__tests__/useScrollIndicator.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { renderHook, act } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { ListItem } from "react-virtuoso";
 import { useScrollIndicator } from "../useScrollIndicator";
 
 // Controllable rAF queue so we can assert the scroll path coalesces a burst of
@@ -24,12 +25,42 @@ function flushFrames() {
   });
 }
 
-function makeScroller(metrics: { scrollTop: number; scrollHeight: number; clientHeight: number }) {
+// Scroller with a mutable scrollTop so a test can scroll the container after
+// caching geometry and assert the onScroll path recomputes against the new
+// position without a fresh itemsRendered call.
+function makeScroller(metrics: { scrollTop: number; scrollHeight?: number; clientHeight: number }) {
   const el = document.createElement("div");
-  Object.defineProperty(el, "scrollTop", { value: metrics.scrollTop, configurable: true });
-  Object.defineProperty(el, "scrollHeight", { value: metrics.scrollHeight, configurable: true });
+  let scrollTop = metrics.scrollTop;
+  Object.defineProperty(el, "scrollTop", {
+    get: () => scrollTop,
+    set: (v: number) => {
+      scrollTop = v;
+    },
+    configurable: true,
+  });
+  Object.defineProperty(el, "scrollHeight", {
+    value: metrics.scrollHeight ?? 1000,
+    configurable: true,
+  });
   Object.defineProperty(el, "clientHeight", { value: metrics.clientHeight, configurable: true });
   return el;
+}
+
+type Kind = "header" | "row";
+
+function makeItems(kinds: Kind[]): { kind: string }[] {
+  return kinds.map((kind) => ({ kind }));
+}
+
+function makeRendered(
+  specs: Array<{ index: number; offset: number; size: number; kind: Kind }>
+): ListItem<{ kind: string }>[] {
+  return specs.map((s) => ({
+    index: s.index,
+    offset: s.offset,
+    size: s.size,
+    data: { kind: s.kind },
+  })) as ListItem<{ kind: string }>[];
 }
 
 beforeEach(() => {
@@ -50,10 +81,154 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("useScrollIndicator scroll rAF throttle (issue #9580)", () => {
+describe("useScrollIndicator hidden-row counts (issue #9666)", () => {
+  it("counts only worktree rows, excluding section headers", () => {
+    // 2 headers + 8 rows, all within the rendered window. Header heights (30px)
+    // differ from row heights (100px) — the old fraction estimate would have
+    // mis-weighted them; the geometry walk must ignore headers entirely.
+    const items = makeItems([
+      "header",
+      "row",
+      "row",
+      "row",
+      "header",
+      "row",
+      "row",
+      "row",
+      "row",
+      "row",
+    ]);
+    const { result } = renderHook(() => useScrollIndicator({ items }));
+    const scroller = makeScroller({ scrollTop: 250, clientHeight: 300 });
+    act(() => {
+      result.current.scrollerRef(scroller);
+    });
+
+    act(() => {
+      result.current.handleItemsRendered(
+        makeRendered([
+          { index: 0, offset: 0, size: 30, kind: "header" },
+          { index: 1, offset: 30, size: 100, kind: "row" },
+          { index: 2, offset: 130, size: 100, kind: "row" },
+          { index: 3, offset: 230, size: 100, kind: "row" },
+          { index: 4, offset: 330, size: 30, kind: "header" },
+          { index: 5, offset: 360, size: 100, kind: "row" },
+          { index: 6, offset: 460, size: 100, kind: "row" },
+          { index: 7, offset: 560, size: 100, kind: "row" },
+          { index: 8, offset: 660, size: 100, kind: "row" },
+          { index: 9, offset: 760, size: 100, kind: "row" },
+        ])
+      );
+    });
+
+    // Viewport [250, 550]. Rows 1,2 fully above; rows 7,8,9 fully below; rows
+    // 3,5,6 visible. Headers never counted.
+    expect(result.current.hiddenAbove).toBe(2);
+    expect(result.current.hiddenBelow).toBe(3);
+  });
+
+  it("counts rows that sit outside the rendered overscan window", () => {
+    // 20 rows; only indices 5..12 are mounted (rest unmounted past overscan).
+    const items = makeItems(Array.from({ length: 20 }, () => "row" as Kind));
+    const { result } = renderHook(() => useScrollIndicator({ items }));
+    const scroller = makeScroller({ scrollTop: 700, clientHeight: 300 });
+    act(() => {
+      result.current.scrollerRef(scroller);
+    });
+
+    act(() => {
+      result.current.handleItemsRendered(
+        makeRendered(
+          Array.from({ length: 8 }, (_, k) => {
+            const index = k + 5;
+            return { index, offset: index * 100, size: 100, kind: "row" as Kind };
+          })
+        )
+      );
+    });
+
+    // Viewport [700, 1000]. Unrendered: 5 rows above (0..4), 7 rows below
+    // (13..19). Rendered above: idx 5,6. Rendered below: idx 10,11,12.
+    expect(result.current.hiddenAbove).toBe(7);
+    expect(result.current.hiddenBelow).toBe(10);
+  });
+
+  it("treats a barely-visible row as visible at the epsilon boundary", () => {
+    const items = makeItems(["row", "row"]);
+    const { result, rerender } = renderHook(() => useScrollIndicator({ items }));
+    const scroller = makeScroller({ scrollTop: 99, clientHeight: 100 });
+    act(() => {
+      result.current.scrollerRef(scroller);
+    });
+    const rendered = makeRendered([
+      { index: 0, offset: 0, size: 100, kind: "row" },
+      { index: 1, offset: 100, size: 100, kind: "row" },
+    ]);
+    act(() => {
+      result.current.handleItemsRendered(rendered);
+    });
+
+    // scrollTop 99: row 0's bottom (100) is within 1px of the viewport top, so
+    // it counts as hidden-above.
+    expect(result.current.hiddenAbove).toBe(1);
+
+    // scrollTop 98: row 0 now shows 2px — past the epsilon — so it's visible.
+    scroller.scrollTop = 98;
+    act(() => {
+      result.current.handleScroll();
+    });
+    flushFrames();
+    rerender();
+    expect(result.current.hiddenAbove).toBe(0);
+  });
+
+  it("reports 0/0 before any itemsRendered geometry has been captured", () => {
+    const items = makeItems(["row", "row", "row"]);
+    const { result } = renderHook(() => useScrollIndicator({ items }));
+    const scroller = makeScroller({ scrollTop: 250, clientHeight: 100 });
+    act(() => {
+      result.current.scrollerRef(scroller);
+    });
+
+    expect(result.current.hiddenAbove).toBe(0);
+    expect(result.current.hiddenBelow).toBe(0);
+  });
+
+  it("resets counts when the backing list changes until new geometry arrives", () => {
+    const itemsA = makeItems(["row", "row", "row"]);
+    const itemsB = makeItems(["row", "row"]);
+    const { result, rerender } = renderHook(({ items }) => useScrollIndicator({ items }), {
+      initialProps: { items: itemsA },
+    });
+    const scroller = makeScroller({ scrollTop: 250, clientHeight: 100 });
+    act(() => {
+      result.current.scrollerRef(scroller);
+    });
+    act(() => {
+      result.current.handleItemsRendered(
+        makeRendered([
+          { index: 0, offset: 0, size: 100, kind: "row" },
+          { index: 1, offset: 100, size: 100, kind: "row" },
+          { index: 2, offset: 200, size: 100, kind: "row" },
+        ])
+      );
+    });
+    // Viewport [250, 350]: rows 0,1 above, row 2 visible.
+    expect(result.current.hiddenAbove).toBe(2);
+
+    // Swapping the list drops the stale geometry; counts fall back to 0/0 until
+    // Virtuoso re-fires itemsRendered against the new layout.
+    rerender({ items: itemsB });
+    expect(result.current.hiddenAbove).toBe(0);
+    expect(result.current.hiddenBelow).toBe(0);
+  });
+});
+
+describe("useScrollIndicator scroll path (issues #9580, #9666)", () => {
   it("coalesces a burst of handleScroll calls into a single frame", () => {
-    const { result } = renderHook(() => useScrollIndicator({ itemCount: 100 }));
-    const scroller = makeScroller({ scrollTop: 50, scrollHeight: 1000, clientHeight: 100 });
+    const items = makeItems(["row", "row", "row"]);
+    const { result } = renderHook(() => useScrollIndicator({ items }));
+    const scroller = makeScroller({ scrollTop: 50, clientHeight: 100 });
     act(() => {
       result.current.scrollerRef(scroller);
     });
@@ -69,35 +244,56 @@ describe("useScrollIndicator scroll rAF throttle (issue #9580)", () => {
     expect(rafQueue.size).toBe(1);
   });
 
-  it("updates indicator counts when the coalesced frame flushes", () => {
-    const { result } = renderHook(() => useScrollIndicator({ itemCount: 100 }));
-    const scroller = makeScroller({ scrollTop: 50, scrollHeight: 1000, clientHeight: 100 });
+  it("recomputes counts on scroll using cached itemsRendered geometry", () => {
+    const items = makeItems(["row", "row", "row"]);
+    const { result, rerender } = renderHook(() => useScrollIndicator({ items }));
+    const scroller = makeScroller({ scrollTop: 0, clientHeight: 100 });
     act(() => {
       result.current.scrollerRef(scroller);
     });
+    act(() => {
+      result.current.handleItemsRendered(
+        makeRendered([
+          { index: 0, offset: 0, size: 100, kind: "row" },
+          { index: 1, offset: 100, size: 100, kind: "row" },
+          { index: 2, offset: 200, size: 100, kind: "row" },
+        ])
+      );
+    });
+    // Viewport [0, 100]: row 0 visible, rows 1,2 below.
+    expect(result.current.hiddenAbove).toBe(0);
+    expect(result.current.hiddenBelow).toBe(2);
 
+    // Scroll down without a fresh itemsRendered — the onScroll path must reuse
+    // the cached geometry against the new scrollTop.
+    scroller.scrollTop = 250;
     act(() => {
       result.current.handleScroll();
     });
     flushFrames();
-
-    // totalHidden 90, scrollFraction ≈ 0.0556 → above 5, below 85.
-    expect(result.current.hiddenAbove).toBe(5);
-    expect(result.current.hiddenBelow).toBe(85);
+    rerender();
+    // Viewport [250, 350]: rows 0,1 above, row 2 visible.
+    expect(result.current.hiddenAbove).toBe(2);
+    expect(result.current.hiddenBelow).toBe(0);
   });
 
   it("cancels a pending scroll frame and resets counts when the scroller detaches", () => {
-    const { result } = renderHook(() => useScrollIndicator({ itemCount: 100 }));
-    const scroller = makeScroller({ scrollTop: 50, scrollHeight: 1000, clientHeight: 100 });
+    const items = makeItems(["row", "row", "row"]);
+    const { result } = renderHook(() => useScrollIndicator({ items }));
+    const scroller = makeScroller({ scrollTop: 250, clientHeight: 100 });
     act(() => {
       result.current.scrollerRef(scroller);
     });
-
     act(() => {
-      result.current.handleScroll();
+      result.current.handleItemsRendered(
+        makeRendered([
+          { index: 0, offset: 0, size: 100, kind: "row" },
+          { index: 1, offset: 100, size: 100, kind: "row" },
+          { index: 2, offset: 200, size: 100, kind: "row" },
+        ])
+      );
     });
-    flushFrames();
-    expect(result.current.hiddenAbove).toBe(5);
+    expect(result.current.hiddenAbove).toBe(2);
 
     act(() => {
       result.current.handleScroll();
@@ -114,31 +310,43 @@ describe("useScrollIndicator scroll rAF throttle (issue #9580)", () => {
     expect(result.current.hiddenBelow).toBe(0);
   });
 
-  it("uses the latest itemCount when a frame flushes after itemCount changes", () => {
-    const { result, rerender } = renderHook(({ itemCount }) => useScrollIndicator({ itemCount }), {
-      initialProps: { itemCount: 100 },
+  it("a deferred scroll frame applies the latest hook closure after items change", () => {
+    const itemsA = makeItems(["row", "row", "row"]);
+    const itemsB = makeItems(["row"]);
+    const { result, rerender } = renderHook(({ items }) => useScrollIndicator({ items }), {
+      initialProps: { items: itemsA },
     });
-    const scroller = makeScroller({ scrollTop: 50, scrollHeight: 1000, clientHeight: 100 });
+    const scroller = makeScroller({ scrollTop: 250, clientHeight: 100 });
     act(() => {
       result.current.scrollerRef(scroller);
     });
+    act(() => {
+      result.current.handleItemsRendered(
+        makeRendered([
+          { index: 0, offset: 0, size: 100, kind: "row" },
+          { index: 1, offset: 100, size: 100, kind: "row" },
+          { index: 2, offset: 200, size: 100, kind: "row" },
+        ])
+      );
+    });
 
-    // Schedule a frame while itemCount is 100, then shrink the list before it
-    // flushes. The stale frame must not overwrite counts with itemCount=100.
+    // Schedule a frame under itemsA, then swap to itemsB before it flushes. The
+    // deferred frame must read the latest closure (cleared geometry), not the
+    // stale itemsA counts.
     act(() => {
       result.current.handleScroll();
     });
-    rerender({ itemCount: 10 });
+    rerender({ items: itemsB });
     flushFrames();
 
-    // itemCount=10 → totalHidden 9, above 1, below 8 (not the stale 5 / 85).
-    expect(result.current.hiddenAbove).toBe(1);
-    expect(result.current.hiddenBelow).toBe(8);
+    expect(result.current.hiddenAbove).toBe(0);
+    expect(result.current.hiddenBelow).toBe(0);
   });
 
   it("cancels a pending scroll frame on unmount", () => {
-    const { result, unmount } = renderHook(() => useScrollIndicator({ itemCount: 100 }));
-    const scroller = makeScroller({ scrollTop: 50, scrollHeight: 1000, clientHeight: 100 });
+    const items = makeItems(["row", "row", "row"]);
+    const { result, unmount } = renderHook(() => useScrollIndicator({ items }));
+    const scroller = makeScroller({ scrollTop: 50, clientHeight: 100 });
     act(() => {
       result.current.scrollerRef(scroller);
     });

--- a/src/components/Sidebar/useScrollIndicator.ts
+++ b/src/components/Sidebar/useScrollIndicator.ts
@@ -38,11 +38,24 @@ function useScrollIndicator({ items }: UseScrollIndicatorParams): UseScrollIndic
   const [hiddenBelow, setHiddenBelow] = useState(0);
   const scrollerElRef = useRef<HTMLElement | null>(null);
   const [scrollerEl, setScrollerEl] = useState<HTMLElement | null>(null);
+  // Latest `items` mirrored into a ref so the stable callbacks below always read
+  // the current list without taking it as a dependency (which would churn their
+  // identity and break the rAF coalescing). Written during render — safe for a
+  // "latest value" ref.
+  const itemsRef = useRef(items);
+  itemsRef.current = items;
   // Latest per-item geometry from Virtuoso's `itemsRendered`. Held in a ref (not
   // state) because `itemsRendered` only fires when the rendered set changes —
   // intra-overscan scrolls reuse this cached geometry via `handleScroll`, so it
   // must be readable without forcing a re-render.
   const renderedItemsRef = useRef<ListItem<ScrollIndicatorItem>[]>([]);
+  // The exact `items` array the cached geometry was measured against. After a
+  // filter/sort/group change the offsets/indices describe a different layout, so
+  // geometry whose tag no longer matches the live list is treated as absent.
+  // This identity check is ordering-independent: it never discards geometry that
+  // Virtuoso just refreshed for the current list, and never trusts geometry left
+  // over from a previous one — no reliance on effect-vs-callback timing.
+  const geometryItemsRef = useRef<ReadonlyArray<ScrollIndicatorItem> | null>(null);
   // rAF-coalesce Virtuoso scroll callbacks into a single in-flight frame so a
   // burst of scroll events triggers one layout read, not one per event (issue
   // #9580). The ResizeObserver path already throttles via `useResizeObserverRaf`.
@@ -52,10 +65,12 @@ function useScrollIndicator({ items }: UseScrollIndicatorParams): UseScrollIndic
     const scroller = scrollerElRef.current;
     if (!scroller) return;
 
+    const items = itemsRef.current;
     const rendered = renderedItemsRef.current;
-    // No geometry yet (pre-first-render, or just cleared on an items change).
-    // Virtuoso re-fires `itemsRendered` with fresh offsets momentarily.
-    if (rendered.length === 0) {
+    // No usable geometry: either nothing has been measured yet, or the cached
+    // geometry belongs to a previous list layout. Virtuoso re-fires
+    // `itemsRendered` for the current list momentarily, refreshing the tag.
+    if (rendered.length === 0 || geometryItemsRef.current !== items) {
       setHiddenAbove(0);
       setHiddenBelow(0);
       return;
@@ -93,25 +108,15 @@ function useScrollIndicator({ items }: UseScrollIndicatorParams): UseScrollIndic
 
     setHiddenAbove(above);
     setHiddenBelow(below);
-  }, [items]);
+  }, []);
 
-  // Always invoke the latest `updateScrollIndicators` from deferred frames and
-  // callbacks. A frame scheduled before `items` changes would otherwise fire
-  // after the corrective effect below and overwrite the counts with a stale
-  // measurement taken against the previous list layout.
-  const updateScrollIndicatorsRef = useRef(updateScrollIndicators);
+  // Recompute when the backing list changes (filter, sort, group toggle). Until
+  // Virtuoso re-fires `itemsRendered` with geometry tagged for the new list, the
+  // identity guard inside `updateScrollIndicators` yields a conservative 0/0
+  // rather than measuring stale offsets against the new layout.
   useEffect(() => {
-    updateScrollIndicatorsRef.current = updateScrollIndicators;
-  }, [updateScrollIndicators]);
-
-  // When the backing list changes (filter, sort, group toggle), the cached
-  // geometry describes a different index space — drop it so stale offsets are
-  // never measured against the new layout. Virtuoso re-fires `itemsRendered`
-  // with fresh geometry right after, so the brief 0/0 lasts at most a frame.
-  useEffect(() => {
-    renderedItemsRef.current = [];
     updateScrollIndicators();
-  }, [updateScrollIndicators]);
+  }, [items, updateScrollIndicators]);
 
   useResizeObserverRaf(scrollerEl, () => updateScrollIndicators());
 
@@ -131,14 +136,20 @@ function useScrollIndicator({ items }: UseScrollIndicatorParams): UseScrollIndic
     if (scrollRafIdRef.current !== null) return;
     scrollRafIdRef.current = requestAnimationFrame(() => {
       scrollRafIdRef.current = null;
-      updateScrollIndicatorsRef.current();
+      updateScrollIndicators();
     });
-  }, []);
+  }, [updateScrollIndicators]);
 
-  const handleItemsRendered = useCallback((rendered: ListItem<ScrollIndicatorItem>[]) => {
-    renderedItemsRef.current = rendered;
-    updateScrollIndicatorsRef.current();
-  }, []);
+  const handleItemsRendered = useCallback(
+    (rendered: ListItem<ScrollIndicatorItem>[]) => {
+      renderedItemsRef.current = rendered;
+      // Tag the geometry with the list it was measured against so a later
+      // recompute can tell whether it still applies.
+      geometryItemsRef.current = itemsRef.current;
+      updateScrollIndicators();
+    },
+    [updateScrollIndicators]
+  );
 
   const scrollerRef = useCallback((el: HTMLElement | Window | null) => {
     // Virtuoso forwards either the scroller element or window. We only support
@@ -156,6 +167,7 @@ function useScrollIndicator({ items }: UseScrollIndicatorParams): UseScrollIndic
         scrollRafIdRef.current = null;
       }
       renderedItemsRef.current = [];
+      geometryItemsRef.current = null;
       setHiddenAbove(0);
       setHiddenBelow(0);
     }

--- a/src/components/Sidebar/useScrollIndicator.ts
+++ b/src/components/Sidebar/useScrollIndicator.ts
@@ -1,8 +1,23 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { ListItem } from "react-virtuoso";
 import { useResizeObserverRaf } from "@/hooks/useResizeObserverRaf";
 
+// A row is treated as hidden only once it has fully cleared the viewport edge.
+// The 1px tolerance absorbs sub-pixel offset/scroll rounding so a row sitting
+// flush against an edge doesn't flicker between "visible" and "hidden".
+const VISIBILITY_EPSILON_PX = 1;
+
+interface ScrollIndicatorItem {
+  kind: string;
+}
+
 interface UseScrollIndicatorParams {
-  itemCount: number;
+  /**
+   * The full flat list backing the Virtuoso surface. Used to count worktree
+   * rows (`kind === "row"`) that sit entirely outside the rendered window, and
+   * to ignore section headers (`kind === "header"`) when tallying hidden rows.
+   */
+  items: ReadonlyArray<ScrollIndicatorItem>;
 }
 
 interface UseScrollIndicatorReturn {
@@ -14,13 +29,20 @@ interface UseScrollIndicatorReturn {
   scrollerRef: (el: HTMLElement | Window | null) => void;
   /** Plug into Virtuoso's `onScroll` prop. */
   handleScroll: () => void;
+  /** Plug into Virtuoso's `itemsRendered` prop. Captures per-item geometry. */
+  handleItemsRendered: (rendered: ListItem<ScrollIndicatorItem>[]) => void;
 }
 
-function useScrollIndicator({ itemCount }: UseScrollIndicatorParams): UseScrollIndicatorReturn {
+function useScrollIndicator({ items }: UseScrollIndicatorParams): UseScrollIndicatorReturn {
   const [hiddenAbove, setHiddenAbove] = useState(0);
   const [hiddenBelow, setHiddenBelow] = useState(0);
   const scrollerElRef = useRef<HTMLElement | null>(null);
   const [scrollerEl, setScrollerEl] = useState<HTMLElement | null>(null);
+  // Latest per-item geometry from Virtuoso's `itemsRendered`. Held in a ref (not
+  // state) because `itemsRendered` only fires when the rendered set changes —
+  // intra-overscan scrolls reuse this cached geometry via `handleScroll`, so it
+  // must be readable without forcing a re-render.
+  const renderedItemsRef = useRef<ListItem<ScrollIndicatorItem>[]>([]);
   // rAF-coalesce Virtuoso scroll callbacks into a single in-flight frame so a
   // burst of scroll events triggers one layout read, not one per event (issue
   // #9580). The ResizeObserver path already throttles via `useResizeObserverRaf`.
@@ -30,46 +52,68 @@ function useScrollIndicator({ itemCount }: UseScrollIndicatorParams): UseScrollI
     const scroller = scrollerElRef.current;
     if (!scroller) return;
 
-    const { scrollTop, scrollHeight, clientHeight } = scroller;
-
-    if (scrollHeight <= clientHeight + 1) {
+    const rendered = renderedItemsRef.current;
+    // No geometry yet (pre-first-render, or just cleared on an items change).
+    // Virtuoso re-fires `itemsRendered` with fresh offsets momentarily.
+    if (rendered.length === 0) {
       setHiddenAbove(0);
       setHiddenBelow(0);
       return;
     }
 
-    const scrollableHeight = scrollHeight - clientHeight;
-    if (scrollableHeight <= 0) {
-      setHiddenAbove(0);
-      setHiddenBelow(0);
-      return;
+    const { scrollTop, clientHeight } = scroller;
+    const viewportTop = scrollTop;
+    const viewportBottom = scrollTop + clientHeight;
+
+    const firstRenderedIndex = rendered[0]!.index;
+    const lastRenderedIndex = rendered[rendered.length - 1]!.index;
+
+    let above = 0;
+    let below = 0;
+
+    // Rows that sit entirely outside the rendered window are unmounted, so they
+    // carry no geometry — count them straight from the backing list by index.
+    for (let i = 0; i < firstRenderedIndex && i < items.length; i++) {
+      if (items[i]!.kind === "row") above++;
+    }
+    for (let i = lastRenderedIndex + 1; i < items.length; i++) {
+      if (items[i]!.kind === "row") below++;
     }
 
-    const scrollFraction = Math.min(1, Math.max(0, scrollTop / scrollableHeight));
-    const visibleFraction = clientHeight / scrollHeight;
-    const approxVisible = Math.max(1, Math.round(itemCount * visibleFraction));
-    const totalHidden = Math.max(0, itemCount - approxVisible);
-
-    const above = Math.round(totalHidden * scrollFraction);
-    const below = totalHidden - above;
+    // Rendered rows: classify each against the live viewport using its measured
+    // offset/size. A partially-visible row counts as visible (not hidden).
+    for (const item of rendered) {
+      if (item.data?.kind !== "row") continue;
+      if (item.offset + item.size <= viewportTop + VISIBILITY_EPSILON_PX) {
+        above++;
+      } else if (item.offset >= viewportBottom - VISIBILITY_EPSILON_PX) {
+        below++;
+      }
+    }
 
     setHiddenAbove(above);
     setHiddenBelow(below);
-  }, [itemCount]);
+  }, [items]);
 
-  useEffect(() => {
-    updateScrollIndicators();
-  }, [updateScrollIndicators, itemCount]);
-
-  useResizeObserverRaf(scrollerEl, () => updateScrollIndicators());
-
-  // Always invoke the latest `updateScrollIndicators` from the deferred frame.
-  // A frame scheduled before `itemCount` changes would otherwise fire after the
-  // corrective effect above and overwrite the counts with a stale measurement.
+  // Always invoke the latest `updateScrollIndicators` from deferred frames and
+  // callbacks. A frame scheduled before `items` changes would otherwise fire
+  // after the corrective effect below and overwrite the counts with a stale
+  // measurement taken against the previous list layout.
   const updateScrollIndicatorsRef = useRef(updateScrollIndicators);
   useEffect(() => {
     updateScrollIndicatorsRef.current = updateScrollIndicators;
   }, [updateScrollIndicators]);
+
+  // When the backing list changes (filter, sort, group toggle), the cached
+  // geometry describes a different index space — drop it so stale offsets are
+  // never measured against the new layout. Virtuoso re-fires `itemsRendered`
+  // with fresh geometry right after, so the brief 0/0 lasts at most a frame.
+  useEffect(() => {
+    renderedItemsRef.current = [];
+    updateScrollIndicators();
+  }, [updateScrollIndicators]);
+
+  useResizeObserverRaf(scrollerEl, () => updateScrollIndicators());
 
   // Cancel any pending re-position frame on unmount so the coalesced callback
   // never reads a detached scroller or sets state after teardown.
@@ -91,6 +135,11 @@ function useScrollIndicator({ itemCount }: UseScrollIndicatorParams): UseScrollI
     });
   }, []);
 
+  const handleItemsRendered = useCallback((rendered: ListItem<ScrollIndicatorItem>[]) => {
+    renderedItemsRef.current = rendered;
+    updateScrollIndicatorsRef.current();
+  }, []);
+
   const scrollerRef = useCallback((el: HTMLElement | Window | null) => {
     // Virtuoso forwards either the scroller element or window. We only support
     // element scrolling here (the sidebar is always an in-container scroller).
@@ -100,12 +149,13 @@ function useScrollIndicator({ itemCount }: UseScrollIndicatorParams): UseScrollI
     // When Virtuoso unmounts (filter clears to an empty state), reset the
     // indicator counts so stale "5 above" badges don't briefly remain over
     // the empty state placeholder, and drop any pending scroll frame that
-    // would otherwise read the now-detached scroller.
+    // would otherwise read the now-detached scroller and stale geometry.
     if (next === null) {
       if (scrollRafIdRef.current !== null) {
         cancelAnimationFrame(scrollRafIdRef.current);
         scrollRafIdRef.current = null;
       }
+      renderedItemsRef.current = [];
       setHiddenAbove(0);
       setHiddenBelow(0);
     }
@@ -122,7 +172,15 @@ function useScrollIndicator({ itemCount }: UseScrollIndicatorParams): UseScrollI
     }
   }, []);
 
-  return { hiddenAbove, hiddenBelow, scrollToTop, scrollToBottom, scrollerRef, handleScroll };
+  return {
+    hiddenAbove,
+    hiddenBelow,
+    scrollToTop,
+    scrollToBottom,
+    scrollerRef,
+    handleScroll,
+    handleItemsRendered,
+  };
 }
 
 export { useScrollIndicator };


### PR DESCRIPTION
## Summary

- The `N more above` / `N more below` pills were deriving their counts from a scroll-height fraction estimate that assumed uniform row heights. Rows vary in height and section headers are mixed in, so the counts were systematically wrong.
- Replaces the estimate with exact per-item geometry from react-virtuoso's `itemsRendered` callback (index, offset, size). Visible boundaries are derived by comparing each item's offset against the live scroll position — the rendered range alone would give wrong counts because it's inflated by the 600px overscan.
- Only worktree rows are counted (`kind: "row"`), not section headers. Cached geometry is tagged with the items array it was measured against, so a filter/sort/group change can't measure stale offsets against a new layout.

Resolves #9666

## Changes

- `useScrollIndicator.ts` — replaces height-ratio estimation with geometry-based visible-boundary computation; `onScroll` retains rAF coalescing and recomputes from cached geometry (since `itemsRendered` doesn't fire on intra-overscan scrolls)
- `SidebarContent.tsx` — wires the `itemsRendered` callback to feed geometry into `useScrollIndicator`
- `useScrollIndicator.test.ts` — rewritten around the new geometry API (12 tests)

## Testing

- 12 unit tests covering visible-boundary derivation, overscan exclusion, section-header exclusion, stale-geometry invalidation, and scroll handler coalescing
- `npm run check` passes (typecheck, lint, format, IPC/channel/confirm-wiring guards)