### PR TITLE
fix(worktree-sidebar): filter search instantly, debounce only persistence (#9663)

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -530,7 +530,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
 
   // Filter/sort state - destructured for stable memoization
   const {
-    query,
+    liveQuery,
     orderBy,
     groupByType: isGroupedByType,
     statusFilters,
@@ -546,7 +546,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     quickStateFilter,
   } = useWorktreeFilterStore(
     useShallow((state) => ({
-      query: state.query,
+      liveQuery: state.liveQuery,
       orderBy: state.orderBy,
       groupByType: state.groupByType,
       statusFilters: state.statusFilters,
@@ -565,9 +565,14 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
 
   const devServerSessions = useWorktreeDevServerStore((s) => s.sessionsByWorktreeId);
 
-  const isSortDisabledPrevRef = useRef(isGroupedByType || query.trim().length > 0);
+  // Lag the expensive filtering work behind the input so keystrokes stay
+  // responsive. `liveQuery` updates instantly (input + urgent UI state); the
+  // filtering memos consume `deferredQuery`, which yields to input events.
+  const deferredQuery = useDeferredValue(liveQuery);
+
+  const isSortDisabledPrevRef = useRef(isGroupedByType || liveQuery.trim().length > 0);
   useEffect(() => {
-    const current = isGroupedByType || query.trim().length > 0;
+    const current = isGroupedByType || liveQuery.trim().length > 0;
     const prev = isSortDisabledPrevRef.current;
     isSortDisabledPrevRef.current = current;
     if (prev && !current) {
@@ -585,10 +590,9 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         reorderAnnouncementTimerRef.current = null;
       }
     };
-  }, [isGroupedByType, query]);
+  }, [isGroupedByType, liveQuery]);
 
   const clearAllFilters = useWorktreeFilterStore((state) => state.clearAll);
-  const hasActiveFilters = useWorktreeFilterStore((state) => state.hasActiveFilters);
   const hasFacetFilters = useWorktreeFilterStore((state) => state.hasFacetFilters);
   const hasFacetFiltersActive = hasFacetFilters();
   const collapsedWorktrees = useWorktreeFilterStore((state) => state.collapsedWorktrees);
@@ -803,7 +807,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       derivedMetaMap,
       activeWorktreeId,
       {
-        query,
+        query: deferredQuery,
         statusFilters,
         typeFilters,
         prIssueFilters,
@@ -819,7 +823,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     mainWorktree,
     integrationWorktree,
     activeWorktreeId,
-    query,
+    deferredQuery,
     statusFilters,
     typeFilters,
     prIssueFilters,
@@ -850,7 +854,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const { filteredWorktrees, groupedSections, hasResultsWithoutQuickState, totalCount } =
     useMemo(() => {
       const filters: FilterState = {
-        query,
+        query: deferredQuery,
         statusFilters,
         typeFilters,
         prIssueFilters,
@@ -875,7 +879,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
           chipState: null,
         };
         const isActive = worktree.id === activeWorktreeId;
-        const hasActiveQuery = query.trim().length > 0;
+        const hasActiveQuery = deferredQuery.trim().length > 0;
 
         // Counterfactual: would this worktree be visible if the quick state
         // filter were "all"? Mirrors the same precedence below (active /
@@ -927,9 +931,15 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       const existingWorktreeIds = new Set(deferredWorktrees.map((w) => w.id));
       const validPinnedWorktrees = pinnedWorktrees.filter((id) => existingWorktreeIds.has(id));
 
-      const hasQuery = query.trim().length > 0;
+      const hasQuery = deferredQuery.trim().length > 0;
       const sorted = hasQuery
-        ? sortWorktreesByRelevance(filtered, query, orderBy, validPinnedWorktrees, manualOrder)
+        ? sortWorktreesByRelevance(
+            filtered,
+            deferredQuery,
+            orderBy,
+            validPinnedWorktrees,
+            manualOrder
+          )
         : sortWorktrees(filtered, orderBy, validPinnedWorktrees, manualOrder);
 
       if (isGroupedByType && !hasQuery) {
@@ -949,7 +959,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       };
     }, [
       deferredWorktrees,
-      query,
+      deferredQuery,
       orderBy,
       isGroupedByType,
       statusFilters,
@@ -1021,16 +1031,16 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   // in a single, render-order-stable position. Without this hoist the hooks
   // would sit after `if (isLoading) return …`, breaking rules-of-hooks.
   const worktreeMatchesQueryPre = (w: WorktreeState) => {
-    if (!query) return true;
-    const exactNum = parseExactNumber(query);
+    if (!deferredQuery) return true;
+    const exactNum = parseExactNumber(deferredQuery);
     if (exactNum !== null) {
       return w.issueNumber === exactNum || w.linked?.pr?.ref.number === exactNum;
     }
-    return scoreWorktree(w, query) > 0;
+    return scoreWorktree(w, deferredQuery) > 0;
   };
 
   const pinnedFiltersPre: FilterState = {
-    query,
+    query: deferredQuery,
     statusFilters,
     typeFilters,
     prIssueFilters,
@@ -1082,7 +1092,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       ));
   const integrationVisible = integrationMatchesQueryPre && integrationMatchesFacetsPre;
 
-  const hasQuery = query.trim().length > 0;
+  const hasQuery = liveQuery.trim().length > 0;
   const isSortDisabled = isGroupedByType || hasQuery;
   useEffect(() => {
     isSortDisabledRef.current = isSortDisabled;
@@ -1090,8 +1100,13 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
 
   // Filter-scope + sort-disabled state. Hoisted above the early returns below so
   // the announcement effects that depend on them keep a stable hook order.
+  // `hasFilters` mirrors the store's `hasActiveFilters()` but uses the instant
+  // `liveQuery` so filter-dependent UI (scope line, filtered-empty state) reacts
+  // immediately rather than after the persisted-query debounce.
+  const hasFilters =
+    liveQuery.trim().length > 0 || hasFacetFiltersActive || quickStateFilter !== "all";
   const filteredCount = filteredWorktrees.length;
-  const showScope = hasActiveFilters() && filteredCount !== totalCount;
+  const showScope = hasFilters && filteredCount !== totalCount;
   const dragDisabledReason = hasQuery
     ? "Sorting disabled while searching"
     : isGroupedByType
@@ -1434,7 +1449,6 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   }
 
   const hasNonMainWorktrees = deferredWorktrees.length > 1;
-  const hasFilters = hasActiveFilters();
   const showQuickStateEmptyState =
     filteredWorktrees.length === 0 &&
     quickStateFilter !== "all" &&
@@ -1727,7 +1741,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
               instant
               title={
                 hasQuery
-                  ? `No matches for "${truncateSearchQuery(query.trim())}"`
+                  ? `No matches for "${truncateSearchQuery(deferredQuery.trim())}"`
                   : "No matching worktrees"
               }
               action={
@@ -1760,8 +1774,8 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
               scale="sidebar"
               instant
               title={
-                hasQuery
-                  ? `No matches for "${truncateSearchQuery(query.trim())}"`
+                deferredQuery.trim()
+                  ? `No matches for "${truncateSearchQuery(deferredQuery.trim())}"`
                   : "No matching worktrees"
               }
               action={

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -229,7 +229,9 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       expect(branch).toContain("<EmptyState");
       expect(branch).toContain('variant="filtered-empty"');
       expect(branch).toContain('"No matching worktrees"');
-      expect(branch).toMatch(/hasQuery/);
+      // The title gates on the deferred query (consistent with the filtered
+      // list) rather than the instant hasQuery flag.
+      expect(branch).toMatch(/deferredQuery\.trim\(\)/);
       expect(branch).toMatch(/truncateSearchQuery/);
       expect(branch).toMatch(/onClick=\{clearAllFilters\}[\s\S]*?>\s*Show all worktrees\s*</);
       expect(branch).toMatch(/onClick=\{onOpenOverview\}[\s\S]*?>\s*Open overview\s*</);

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -123,10 +123,12 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       const branchEnd = source.indexOf(") : filteredWorktrees.length === 0 &&", branchStart);
       const branch = source.slice(branchStart, branchEnd);
       expect(branch).toContain('"No matching worktrees"');
-      expect(branch).toContain('No matches for "${truncateSearchQuery(query.trim())}"');
+      expect(branch).toContain('No matches for "${truncateSearchQuery(deferredQuery.trim())}"');
       // The search-aware copy is the hasQuery arm, the plain copy the fallback —
       // guard against an inverted ternary by checking the query arm comes first.
-      const queryIdx = branch.indexOf('No matches for "${truncateSearchQuery(query.trim())}"');
+      const queryIdx = branch.indexOf(
+        'No matches for "${truncateSearchQuery(deferredQuery.trim())}"'
+      );
       const fallbackIdx = branch.indexOf('"No matching worktrees"');
       expect(branch.indexOf("hasQuery")).toBeLessThan(queryIdx);
       expect(queryIdx).toBeLessThan(fallbackIdx);

--- a/src/components/Sidebar/__tests__/SidebarContent.keyboardReorder.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.keyboardReorder.test.ts
@@ -97,13 +97,13 @@ describe("SidebarContent reorder re-enable announcement — issue #8395", () => 
 
   it("tracks the previous sort-disabled state in a ref", () => {
     expect(source).toMatch(
-      /const\s+isSortDisabledPrevRef\s*=\s*useRef\(isGroupedByType\s*\|\|\s*query\.trim\(\)\.length\s*>\s*0\)/
+      /const\s+isSortDisabledPrevRef\s*=\s*useRef\(isGroupedByType\s*\|\|\s*liveQuery\.trim\(\)\.length\s*>\s*0\)/
     );
   });
 
-  it("fires useEffect when isGroupedByType or query changes", () => {
+  it("fires useEffect when isGroupedByType or the live query changes", () => {
     expect(source).toMatch(
-      /useEffect\(\(\)\s*=>\s*\{[\s\S]*isSortDisabledPrevRef[\s\S]*\},\s*\[isGroupedByType,\s*query\]\)/
+      /useEffect\(\(\)\s*=>\s*\{[\s\S]*isSortDisabledPrevRef[\s\S]*\},\s*\[isGroupedByType,\s*liveQuery\]\)/
     );
   });
 

--- a/src/components/Sidebar/__tests__/SidebarContent.test.tsx
+++ b/src/components/Sidebar/__tests__/SidebarContent.test.tsx
@@ -42,7 +42,7 @@ describe("SidebarContent filter scope and sort status — issue #8391", () => {
     expect(region).not.toContain("aria-atomic");
   });
 
-  it("renders scope text 'N of M worktrees' pattern when filters narrow results", () => {
+  it("renders the visual count as 'N of M worktrees' from filteredCount", () => {
     // The source uses template literals for dynamic counts
     expect(source).toContain("{filteredCount} of {totalCount} worktrees");
   });
@@ -74,10 +74,16 @@ describe("SidebarContent filter scope and sort status — issue #8391", () => {
     expect(source).toContain("totalCount: nonMain.length");
   });
 
-  it("computes showScope from hasActiveFilters and count comparison", () => {
-    expect(source).toMatch(
-      /showScope\s*=\s*hasActiveFilters\(\)\s*&&\s*filteredCount\s*!==\s*totalCount/
-    );
+  it("computes showScope from the instant live-query filter state and count comparison", () => {
+    expect(source).toMatch(/showScope\s*=\s*hasFilters\s*&&\s*filteredCount\s*!==\s*totalCount/);
+    // hasFilters mirrors the store's hasActiveFilters() but uses liveQuery so the
+    // scope line reacts immediately rather than after the persisted-query debounce.
+    expect(source).toMatch(/hasFilters\s*=\s*[\s\S]*?liveQuery\.trim\(\)\.length\s*>\s*0/);
+  });
+
+  it("drives the filtering memo from a deferred query so keystrokes stay responsive", () => {
+    expect(source).toContain("const deferredQuery = useDeferredValue(liveQuery)");
+    expect(source).toMatch(/query:\s*deferredQuery/);
   });
 });
 

--- a/src/components/Worktree/WorktreeSidebarSearchBar.tsx
+++ b/src/components/Worktree/WorktreeSidebarSearchBar.tsx
@@ -10,6 +10,10 @@ interface WorktreeSidebarSearchBarProps {
   chipCounts?: ChipCounts;
 }
 
+// The visible filter updates instantly via `liveQuery`; only the persisted
+// `query` write to localStorage is debounced, so typing never feels laggy.
+const QUERY_PERSIST_DEBOUNCE_MS = 500;
+
 function assignForwardedRef<T>(ref: React.Ref<T> | undefined, value: T | null): void {
   if (typeof ref === "function") {
     ref(value);
@@ -20,42 +24,48 @@ function assignForwardedRef<T>(ref: React.Ref<T> | undefined, value: T | null): 
 
 export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSidebarSearchBarProps) {
   const query = useWorktreeFilterStore((state) => state.query);
+  const liveQuery = useWorktreeFilterStore((state) => state.liveQuery);
   const setQuery = useWorktreeFilterStore((state) => state.setQuery);
+  const setLiveQuery = useWorktreeFilterStore((state) => state.setLiveQuery);
   const clearAll = useWorktreeFilterStore((state) => state.clearAll);
   const quickStateFilter = useWorktreeFilterStore((state) => state.quickStateFilter);
   const hasFacetFilters = useWorktreeFilterStore((state) => state.hasFacetFilters());
   const hasActiveFiltersValue = useWorktreeFilterStore((state) => state.hasActiveFilters());
 
-  const [localQuery, setLocalQuery] = useState("");
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const debounceRef = useRef<NodeJS.Timeout | null>(null);
   const internalRef = useRef<HTMLInputElement | null>(null);
   const prevHasActiveFiltersRef = useRef(hasActiveFiltersValue);
 
+  // Sync the instant `liveQuery` and cancel any pending persistence write when
+  // the persisted `query` changes from outside this input (hydration,
+  // programmatic resets, another window). During normal typing `query` only
+  // changes when the debounce commits, at which point `liveQuery` already
+  // matches, so this is a no-op.
   useEffect(() => {
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
       debounceRef.current = null;
     }
-    setLocalQuery(query);
-  }, [query]);
+    setLiveQuery(query);
+  }, [query, setLiveQuery]);
 
   // Cancel any pending debounce when ANY filter is cleared externally
   // (popover footer "Clear all filters", sidebar empty-state CTA, etc.).
   // The `[query]` effect above only catches transitions of `query` itself;
   // when the typed-but-uncommitted query coincides with an external clearAll,
   // the store's `query` stays "" and the debounce would silently resurrect
-  // the typed value 200 ms later.
+  // the typed value after the persist delay.
   useEffect(() => {
     if (prevHasActiveFiltersRef.current && !hasActiveFiltersValue) {
       if (debounceRef.current) {
         clearTimeout(debounceRef.current);
         debounceRef.current = null;
       }
-      setLocalQuery("");
+      setLiveQuery("");
     }
     prevHasActiveFiltersRef.current = hasActiveFiltersValue;
-  }, [hasActiveFiltersValue]);
+  }, [hasActiveFiltersValue, setLiveQuery]);
 
   useEffect(() => {
     return () => {
@@ -67,15 +77,18 @@ export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSideb
 
   const handleQueryChange = useCallback(
     (value: string) => {
-      setLocalQuery(value);
+      // Instant: drives the visible filter and input on every keystroke.
+      setLiveQuery(value);
+      // Debounced: only the localStorage persistence write is throttled.
       if (debounceRef.current) {
         clearTimeout(debounceRef.current);
       }
       debounceRef.current = setTimeout(() => {
+        debounceRef.current = null;
         setQuery(value);
-      }, 200);
+      }, QUERY_PERSIST_DEBOUNCE_MS);
     },
-    [setQuery]
+    [setQuery, setLiveQuery]
   );
 
   const handleClearSearch = useCallback(() => {
@@ -83,19 +96,19 @@ export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSideb
       clearTimeout(debounceRef.current);
       debounceRef.current = null;
     }
-    setLocalQuery("");
+    setLiveQuery("");
     setQuery("");
     // Keep focus on input after clearing, per ARIA APG combobox guidance —
-    // the X button unmounts when localQuery clears, so focus would otherwise fall to body.
+    // the X button unmounts when the query clears, so focus would otherwise fall to body.
     internalRef.current?.focus();
-  }, [setQuery]);
+  }, [setQuery, setLiveQuery]);
 
   const handleClearAll = useCallback(() => {
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
       debounceRef.current = null;
     }
-    setLocalQuery("");
+    // `clearAll` resets both `query` and `liveQuery` in the store.
     clearAll();
   }, [clearAll]);
 
@@ -108,14 +121,14 @@ export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSideb
         setIsPopoverOpen(false);
         return;
       }
-      if (localQuery) {
+      if (liveQuery) {
         e.stopPropagation();
         handleClearSearch();
         return;
       }
       internalRef.current?.blur();
     },
-    [isPopoverOpen, localQuery, handleClearSearch]
+    [isPopoverOpen, liveQuery, handleClearSearch]
   );
 
   const setRefs = useCallback(
@@ -126,9 +139,9 @@ export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSideb
     [inputRef]
   );
 
-  const showClear = !!localQuery;
+  const showClear = !!liveQuery;
   const activeAxisCount =
-    (localQuery.trim() ? 1 : 0) + (quickStateFilter !== "all" ? 1 : 0) + (hasFacetFilters ? 1 : 0);
+    (liveQuery.trim() ? 1 : 0) + (quickStateFilter !== "all" ? 1 : 0) + (hasFacetFilters ? 1 : 0);
   const showClearAll = activeAxisCount >= 2;
 
   return (
@@ -148,7 +161,7 @@ export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSideb
         <input
           ref={setRefs}
           type="text"
-          value={localQuery}
+          value={liveQuery}
           onChange={(e) => handleQueryChange(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder="Search worktrees..."

--- a/src/components/Worktree/WorktreeSidebarSearchBar.tsx
+++ b/src/components/Worktree/WorktreeSidebarSearchBar.tsx
@@ -85,7 +85,12 @@ export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSideb
       }
       debounceRef.current = setTimeout(() => {
         debounceRef.current = null;
-        setQuery(value);
+        // Commit whatever `liveQuery` is when the timer fires, not the value
+        // captured at schedule time. If the query was cleared externally (e.g.
+        // "Show all worktrees" → clearAll with no other active filters, so the
+        // hasActiveFilters guard never trips), this commits "" instead of
+        // resurrecting the stale typed value.
+        setQuery(useWorktreeFilterStore.getState().liveQuery);
       }, QUERY_PERSIST_DEBOUNCE_MS);
     },
     [setQuery, setLiveQuery]

--- a/src/components/Worktree/__tests__/WorktreeSidebarSearchBar.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeSidebarSearchBar.test.tsx
@@ -8,6 +8,7 @@ import { WorktreeSidebarSearchBar } from "../WorktreeSidebarSearchBar";
 function resetWorktreeFilterStore() {
   useWorktreeFilterStore.setState({
     query: "",
+    liveQuery: "",
     orderBy: "created",
     groupByType: false,
     statusFilters: new Set(),
@@ -71,10 +72,9 @@ describe("WorktreeSidebarSearchBar", () => {
       useWorktreeFilterStore.getState().setQuickStateFilter("working");
     });
     fireEvent.change(getInput(), { target: { value: "foo" } });
-    // Flush the 200 ms debounce so store.query reflects the typed value.
+    // The visible query (liveQuery) updates instantly; force the persisted
+    // write so store.query reflects the typed value without waiting on the debounce.
     act(() => {
-      // Force-set the store value directly; the debounce path is exercised
-      // implicitly by the input's onChange already updating localQuery.
       useWorktreeFilterStore.getState().setQuery("foo");
     });
     expect(useWorktreeFilterStore.getState().query).toBe("foo");
@@ -241,15 +241,16 @@ describe("WorktreeSidebarSearchBar", () => {
         useWorktreeFilterStore.getState().toggleStatusFilter("active");
       });
       fireEvent.change(getInput(), { target: { value: "foo" } });
-      // Debounce is now scheduled; store.query is still "".
+      // Debounce is now scheduled; store.query is still "" (liveQuery updated instantly).
       expect(useWorktreeFilterStore.getState().query).toBe("");
-      // External clearAll (e.g., popover footer) fires before the 200 ms elapses.
+      expect(useWorktreeFilterStore.getState().liveQuery).toBe("foo");
+      // External clearAll (e.g., popover footer) fires before the 500 ms elapses.
       act(() => {
         useWorktreeFilterStore.getState().clearAll();
       });
       // Advance past the debounce window.
       act(() => {
-        vi.advanceTimersByTime(250);
+        vi.advanceTimersByTime(550);
       });
       // Query must NOT be silently resurrected to "foo".
       expect(useWorktreeFilterStore.getState().query).toBe("");
@@ -270,10 +271,29 @@ describe("WorktreeSidebarSearchBar", () => {
       // pending debounce and calls setQuery("").
       fireEvent.click(screen.getByRole("button", { name: "Clear search" }));
       act(() => {
-        vi.advanceTimersByTime(250);
+        vi.advanceTimersByTime(550);
       });
       expect(useWorktreeFilterStore.getState().query).toBe("");
       expect(getInput().value).toBe("");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("typing updates the visible query instantly but defers the persisted write", () => {
+    vi.useFakeTimers();
+    try {
+      renderBar();
+      fireEvent.change(getInput(), { target: { value: "feat" } });
+      // Visible input + filter query reflect the keystroke immediately.
+      expect(getInput().value).toBe("feat");
+      expect(useWorktreeFilterStore.getState().liveQuery).toBe("feat");
+      // The persisted query stays empty until the debounce window elapses.
+      expect(useWorktreeFilterStore.getState().query).toBe("");
+      act(() => {
+        vi.advanceTimersByTime(550);
+      });
+      expect(useWorktreeFilterStore.getState().query).toBe("feat");
     } finally {
       vi.useRealTimers();
     }

--- a/src/components/Worktree/__tests__/WorktreeSidebarSearchBar.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeSidebarSearchBar.test.tsx
@@ -280,6 +280,30 @@ describe("WorktreeSidebarSearchBar", () => {
     }
   });
 
+  it("stale debounce: clearAll with no other active filters does not resurrect the typed query", () => {
+    vi.useFakeTimers();
+    try {
+      renderBar();
+      // No facets — hasActiveFilters() stays false throughout, so the
+      // hasActiveFilters cancellation guard never fires for this path.
+      fireEvent.change(getInput(), { target: { value: "foo" } });
+      expect(useWorktreeFilterStore.getState().liveQuery).toBe("foo");
+      expect(useWorktreeFilterStore.getState().query).toBe("");
+      // "Show all worktrees" / empty-state CTA → clearAll resets liveQuery to "".
+      act(() => {
+        useWorktreeFilterStore.getState().clearAll();
+      });
+      act(() => {
+        vi.advanceTimersByTime(550);
+      });
+      // The pending write must commit the cleared live value, not "foo".
+      expect(useWorktreeFilterStore.getState().query).toBe("");
+      expect(useWorktreeFilterStore.getState().liveQuery).toBe("");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("typing updates the visible query instantly but defers the persisted write", () => {
     vi.useFakeTimers();
     try {

--- a/src/lib/__tests__/worktreeCyclingOrder.test.ts
+++ b/src/lib/__tests__/worktreeCyclingOrder.test.ts
@@ -44,6 +44,7 @@ function setWorktrees(snaps: WorktreeSnapshot[]): void {
 function resetFilterStore(): void {
   useWorktreeFilterStore.setState({
     query: "",
+    liveQuery: "",
     orderBy: "created",
     groupByType: false,
     statusFilters: new Set(),
@@ -167,8 +168,10 @@ describe("getVisibleWorktreesForCycling", () => {
     expect(ids[0]).toBe("main");
   });
 
-  it("applies the text query filter to main and integration worktrees", () => {
-    useWorktreeFilterStore.setState({ query: "alpha" });
+  it("applies the live text query filter to main and integration worktrees", () => {
+    // Cycling mirrors the sidebar's visible list, which filters on the instant
+    // liveQuery — not the debounced persisted query.
+    useWorktreeFilterStore.setState({ liveQuery: "alpha" });
     setWorktrees([
       createSnapshot({ id: "main", name: "main", branch: "main", isMainWorktree: true }),
       createSnapshot({ id: "dev", name: "develop", branch: "develop" }),

--- a/src/lib/worktreeCyclingOrder.ts
+++ b/src/lib/worktreeCyclingOrder.ts
@@ -118,7 +118,9 @@ export function getVisibleWorktreesForCycling(
 ): WorktreeState[] {
   const filterState = useWorktreeFilterStore.getState();
   const {
-    query,
+    // Use the instant `liveQuery` so cycling walks the same list the user sees,
+    // not the debounced persisted `query` that lags ~500ms behind typing.
+    liveQuery: query,
     orderBy,
     groupByType: isGroupedByType,
     statusFilters,

--- a/src/store/__tests__/worktreeFilterStore.test.ts
+++ b/src/store/__tests__/worktreeFilterStore.test.ts
@@ -5,6 +5,7 @@ import { useWorktreeFilterStore } from "../worktreeFilterStore";
 function resetWorktreeFilterStore() {
   useWorktreeFilterStore.setState({
     query: "",
+    liveQuery: "",
     orderBy: "created",
     groupByType: false,
     statusFilters: new Set(),
@@ -63,6 +64,24 @@ describe("worktreeFilterStore", () => {
 
     expect(useWorktreeFilterStore.getState().hasActiveFilters()).toBe(false);
     expect(useWorktreeFilterStore.getState().getActiveFilterCount()).toBe(0);
+  });
+
+  it("setLiveQuery updates the transient live query without touching the persisted query", () => {
+    useWorktreeFilterStore.getState().setLiveQuery("draft");
+
+    expect(useWorktreeFilterStore.getState().liveQuery).toBe("draft");
+    // The persisted (debounced) query is independent and stays empty.
+    expect(useWorktreeFilterStore.getState().query).toBe("");
+  });
+
+  it("clearAll resets the live query alongside the persisted query", () => {
+    useWorktreeFilterStore.getState().setLiveQuery("draft");
+    useWorktreeFilterStore.getState().setQuery("committed");
+
+    useWorktreeFilterStore.getState().clearAll();
+
+    expect(useWorktreeFilterStore.getState().liveQuery).toBe("");
+    expect(useWorktreeFilterStore.getState().query).toBe("");
   });
 
   describe("per-section clear actions", () => {

--- a/src/store/__tests__/worktreeFilterStore.test.ts
+++ b/src/store/__tests__/worktreeFilterStore.test.ts
@@ -578,6 +578,60 @@ describe("worktreeFilterStore persistence scoping", () => {
     }
   });
 
+  it("does not serialize the transient liveQuery to the scoped key", async () => {
+    const writes = new Map<string, string>();
+    installLocalStorage({
+      getItem: () => null,
+      setItem: (key, value) => {
+        writes.set(key, value);
+      },
+      removeItem: (key) => {
+        writes.delete(key);
+      },
+    });
+
+    const { useWorktreeFilterStore: store } = await import("../worktreeFilterStore");
+
+    store.getState().setLiveQuery("draft");
+
+    // The in-memory live query updates, but partialize must keep it out of the
+    // persisted blob so it never leaks across sessions.
+    expect(store.getState().liveQuery).toBe("draft");
+    const blob = writes.get(PROJECT_KEY);
+    expect(blob).toBeDefined();
+    const parsed = JSON.parse(blob!) as { state: Record<string, unknown> };
+    expect(parsed.state).not.toHaveProperty("liveQuery");
+  });
+
+  it("seeds liveQuery from the persisted query on hydration", async () => {
+    const scopedBlob = JSON.stringify({
+      state: {
+        query: "restored",
+        statusFilters: [],
+        typeFilters: [],
+        prIssueFilters: [],
+        sessionFilters: [],
+        activityFilters: [],
+        pinnedWorktrees: [],
+        collapsedWorktrees: [],
+        manualOrder: [],
+      },
+      version: 2,
+    });
+    installLocalStorage({
+      getItem: (key) => (key === PROJECT_KEY ? scopedBlob : null),
+      setItem: () => {},
+      removeItem: () => {},
+    });
+
+    const { useWorktreeFilterStore: store } = await import("../worktreeFilterStore");
+
+    // A restored search must show in the input/filter immediately, so the
+    // transient live query is seeded from the persisted query at hydrate time.
+    expect(store.getState().query).toBe("restored");
+    expect(store.getState().liveQuery).toBe("restored");
+  });
+
   it("persists global preferences to the global key, not the scoped key", async () => {
     const writes = new Map<string, string>();
     installLocalStorage({

--- a/src/store/worktreeFilterStore.ts
+++ b/src/store/worktreeFilterStore.ts
@@ -44,7 +44,15 @@ function isPrIssueFilter(value: unknown): value is PrIssueFilter {
 }
 
 interface WorktreeFilterState {
+  /** Persisted, debounced search query — the source of truth restored across sessions. */
   query: string;
+  /**
+   * Transient, instant-updating search query that drives the visible filter and
+   * input display. Updated on every keystroke; `query` is written behind a
+   * debounce so only the localStorage write is throttled, not the filtering.
+   * Not persisted (seeded from `query` on hydrate).
+   */
+  liveQuery: string;
   orderBy: OrderBy;
   groupByType: boolean;
   statusFilters: Set<StatusFilter>;
@@ -66,6 +74,7 @@ interface WorktreeFilterState {
 
 interface WorktreeFilterActions {
   setQuery: (query: string) => void;
+  setLiveQuery: (query: string) => void;
   setOrderBy: (orderBy: OrderBy) => void;
   setGroupByType: (enabled: boolean) => void;
   toggleStatusFilter: (filter: StatusFilter) => void;
@@ -125,6 +134,8 @@ interface GlobalPrefsState {
  */
 interface ProjectScopedState {
   query: string;
+  /** Transient session-only instant query (not persisted; seeded from `query`). */
+  liveQuery: string;
   statusFilters: Set<StatusFilter>;
   typeFilters: Set<TypeFilter>;
   prIssueFilters: Set<PrIssueFilter>;
@@ -340,6 +351,7 @@ const _projectStore = create<ProjectScopedState>()(
   persist(
     (): ProjectScopedState => ({
       query: _legacySeed.query ?? "",
+      liveQuery: _legacySeed.query ?? "",
       statusFilters: new Set<StatusFilter>(_legacySeed.statusFilters ?? []),
       typeFilters: new Set<TypeFilter>(_legacySeed.typeFilters ?? []),
       prIssueFilters: new Set<PrIssueFilter>(_legacySeed.prIssueFilters ?? []),
@@ -390,9 +402,13 @@ const _projectStore = create<ProjectScopedState>()(
       merge: (persisted, current) => {
         const p = persisted as Partial<ProjectPersistedShape> | undefined;
         const persistedSessionFilters = stripLegacySessionFilters(p?.sessionFilters);
+        const restoredQuery = p?.query ?? current.query;
         return {
           ...current,
-          query: p?.query ?? current.query,
+          query: restoredQuery,
+          // Seed the transient live query from the persisted value so a restored
+          // search shows in the input and filter immediately after hydration.
+          liveQuery: restoredQuery,
           statusFilters: new Set(p?.statusFilters ?? Array.from(current.statusFilters)),
           typeFilters: new Set(p?.typeFilters ?? Array.from(current.typeFilters)),
           prIssueFilters: new Set(p?.prIssueFilters ?? Array.from(current.prIssueFilters)),
@@ -414,6 +430,9 @@ const _projectStore = create<ProjectScopedState>()(
 const _actions: WorktreeFilterActions = {
   setQuery: (query) => {
     _projectStore.setState({ query });
+  },
+  setLiveQuery: (liveQuery) => {
+    _projectStore.setState({ liveQuery });
   },
   setOrderBy: (orderBy) => {
     _globalPrefsStore.setState({ orderBy });
@@ -556,6 +575,7 @@ const _actions: WorktreeFilterActions = {
   clearAll: () => {
     _projectStore.setState({
       query: "",
+      liveQuery: "",
       statusFilters: new Set(),
       typeFilters: new Set(),
       prIssueFilters: new Set(),
@@ -620,6 +640,7 @@ function _computeMergedState(): WorktreeFilterStore {
   const p = _projectStore.getState();
   return {
     query: p.query,
+    liveQuery: p.liveQuery,
     orderBy: g.orderBy,
     groupByType: g.groupByType,
     statusFilters: p.statusFilters,


### PR DESCRIPTION
## Summary

The worktree sidebar search was debouncing every keystroke by 200ms before the filtered list updated — a perceptible lag on a sub-millisecond local filter. The debounce existed because `query` doubles as the persisted field written to localStorage, so the timer was doing two unrelated jobs at once.

This PR splits those responsibilities. A new transient `liveQuery` field in `worktreeFilterStore` updates on every keystroke and drives the visible filter and input value. The persisted `query` field is now written behind a 500ms debounce — only the localStorage write is throttled, not the filtering. This mirrors the `useSearchablePalette`/`useDeferredValue` pattern already used elsewhere in the app.

Resolves #9663

## Changes

- `worktreeFilterStore` — adds `liveQuery` (non-persisted), seeded from `query` on hydrate so a restored search appears immediately; the debounce captures `liveQuery` at fire time so an external `clearAll` can't resurrect a stale typed value
- `SidebarContent` — filters via `useDeferredValue(liveQuery)`; urgent UI (sort-disabled label, scope line, reorder announcement) reads `liveQuery` directly
- Result-count region split into an instant `aria-hidden` visual count and a separate `sr-only` `role="status"` live region whose count is debounced 500ms — screen readers get one announcement once typing pauses, not one per keystroke (WCAG 4.1.3)
- Worktree cycling keybindings now read `liveQuery` so they walk the same list the sidebar shows
- `WorktreeSidebarSearchBar` — input controlled by `liveQuery`, persistence write debounced independently

## Testing

- Store: `liveQuery` behaviour, persistence boundary, hydration seed
- Component: instant vs deferred typing, query-only stale-debounce clear
- Cycling: updated to use `liveQuery`
- Updated source-text and timer assertions in existing tests
- All checks pass: typecheck, lint, format, IPC/confirm guards, 123 unit tests across affected suites