### PR TITLE
fix(dock): recover keyboard focus when a focused chip unmounts

### DIFF
--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -162,6 +162,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const activeDockIndexRef = useRef(0);
+  const prevFocusedDockItemRef = useRef<HTMLElement | null>(null);
   const { canScrollLeft, canScrollRight, scrollLeft, scrollRight } =
     useHorizontalScrollControls(scrollContainerRef);
 
@@ -194,6 +195,23 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
     const clamped = Math.min(activeDockIndexRef.current, items.length - 1);
     activeDockIndexRef.current = clamped;
     syncDockTabStops(items, clamped);
+
+    // Issue #9681 — when the focused chip unmounts (terminal closed, group
+    // collapsed), the roving tabindex above re-homes the tab stop but focus
+    // has already fallen to <body>. Redirect it onto the promoted chip so
+    // keyboard navigation survives. Mirrors Toolbar.tsx's recovery pattern.
+    const prevFocused = prevFocusedDockItemRef.current;
+    if (prevFocused && !items.includes(prevFocused)) {
+      // Clear unconditionally — a stale ref left set would trigger a phantom
+      // redirect on an unrelated later render even when focus moved elsewhere.
+      prevFocusedDockItemRef.current = null;
+      // Only reclaim focus when it genuinely fell to <body>. Focus inside a
+      // Radix portal (tooltip, context menu) sets activeElement to the portal
+      // node, not body, and must not be hijacked.
+      if (document.activeElement === document.body) {
+        items[clamped]?.focus();
+      }
+    }
   });
 
   const handleDockFocusCapture = useCallback(
@@ -203,6 +221,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
       const idx = items.indexOf(target);
       if (idx !== -1) {
         activeDockIndexRef.current = idx;
+        prevFocusedDockItemRef.current = target;
         syncDockTabStops(items, idx);
       }
     },
@@ -357,6 +376,8 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
                     <button
                       type="button"
                       onClick={scrollLeft}
+                      tabIndex={-1}
+                      aria-hidden="true"
                       className={cn(
                         "pointer-events-auto p-1.5 text-daintree-text/60 hover:text-daintree-text",
                         "rounded-[var(--radius-md)] transition-colors",
@@ -382,7 +403,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
               onKeyDown={handleDockKeyDown}
               onFocusCapture={handleDockFocusCapture}
               className={cn(
-                "flex items-center gap-[var(--dock-gap)] overflow-x-auto overscroll-x-none flex-1 min-h-[var(--dock-item-height)] no-scrollbar scroll-smooth px-1 transition-[color,background-color,box-shadow]",
+                "flex items-center gap-[var(--dock-gap)] overflow-x-auto overscroll-x-none flex-1 min-h-[var(--dock-item-height)] no-scrollbar scroll-smooth scroll-px-4 px-1 transition-[color,background-color,box-shadow]",
                 isWorktreeSortDragging && "cursor-no-drop",
                 isOver &&
                   !isWorktreeSortDragging &&
@@ -436,6 +457,8 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
                     <button
                       type="button"
                       onClick={scrollRight}
+                      tabIndex={-1}
+                      aria-hidden="true"
                       className={cn(
                         "pointer-events-auto p-1.5 text-daintree-text/60 hover:text-daintree-text",
                         "rounded-[var(--radius-md)] transition-colors",

--- a/src/components/Layout/__tests__/ContentDock.test.tsx
+++ b/src/components/Layout/__tests__/ContentDock.test.tsx
@@ -262,9 +262,7 @@ describe("ContentDock regression test", () => {
     it("tracks the previously focused chip in a dedicated ref", () => {
       const content = readFileSync(resolve(__dirname, "../ContentDock.tsx"), "utf-8");
 
-      expect(content).toContain(
-        "prevFocusedDockItemRef = useRef<HTMLElement | null>(null)"
-      );
+      expect(content).toContain("prevFocusedDockItemRef = useRef<HTMLElement | null>(null)");
       // The recovery ref sits alongside the existing roving-index ref.
       const indexRefIdx = content.indexOf("activeDockIndexRef = useRef");
       const focusRefIdx = content.indexOf("prevFocusedDockItemRef = useRef");
@@ -290,9 +288,7 @@ describe("ContentDock regression test", () => {
       const content = readFileSync(resolve(__dirname, "../ContentDock.tsx"), "utf-8");
 
       // Eviction detection: prev focused chip no longer in the live list.
-      expect(content).toMatch(
-        /if\s*\(prevFocused\s*&&\s*!items\.includes\(prevFocused\)\)/
-      );
+      expect(content).toMatch(/if\s*\(prevFocused\s*&&\s*!items\.includes\(prevFocused\)\)/);
       // The portal guard must gate the .focus() call.
       const guard = content.indexOf("document.activeElement === document.body");
       const focusCall = content.indexOf("items[clamped]?.focus()");

--- a/src/components/Layout/__tests__/ContentDock.test.tsx
+++ b/src/components/Layout/__tests__/ContentDock.test.tsx
@@ -248,4 +248,91 @@ describe("ContentDock regression test", () => {
       expect(tabGroup).toContain('data-dock-item=""');
     });
   });
+
+  // Issue #9681 — when the focused chip unmounts, the roving-tabindex
+  // useLayoutEffect re-homes the tab stop but focus has already dropped to
+  // <body>, killing keyboard navigation. The dock mirrors Toolbar.tsx's
+  // prevFocusedToolbarItemRef recovery: track the focused chip, and on
+  // eviction redirect focus onto the promoted chip — but only when focus
+  // genuinely fell to <body> (not into a Radix portal). Two further fixes:
+  // the scroll chevrons are decorative pointer-only controls and must leave
+  // the tab order, and the scroll container needs scroll-padding so focused
+  // edge chips are not parked behind the gradient scrim.
+  describe("focus recovery — issue #9681", () => {
+    it("tracks the previously focused chip in a dedicated ref", () => {
+      const content = readFileSync(resolve(__dirname, "../ContentDock.tsx"), "utf-8");
+
+      expect(content).toContain(
+        "prevFocusedDockItemRef = useRef<HTMLElement | null>(null)"
+      );
+      // The recovery ref sits alongside the existing roving-index ref.
+      const indexRefIdx = content.indexOf("activeDockIndexRef = useRef");
+      const focusRefIdx = content.indexOf("prevFocusedDockItemRef = useRef");
+      expect(indexRefIdx).toBeGreaterThan(0);
+      expect(focusRefIdx).toBeGreaterThan(indexRefIdx);
+    });
+
+    it("records the focused chip in handleDockFocusCapture", () => {
+      const content = readFileSync(resolve(__dirname, "../ContentDock.tsx"), "utf-8");
+
+      // The assignment must live inside handleDockFocusCapture's idx-found
+      // branch so the ref always reflects the live focused chip.
+      const handlerStart = content.indexOf("handleDockFocusCapture = useCallback");
+      const assign = content.indexOf("prevFocusedDockItemRef.current = target", handlerStart);
+      const handlerEnd = content.indexOf("handleDockKeyDown = useCallback", handlerStart);
+
+      expect(handlerStart).toBeGreaterThan(0);
+      expect(assign).toBeGreaterThan(handlerStart);
+      expect(assign).toBeLessThan(handlerEnd);
+    });
+
+    it("redirects focus to the promoted chip only when focus fell to <body>", () => {
+      const content = readFileSync(resolve(__dirname, "../ContentDock.tsx"), "utf-8");
+
+      // Eviction detection: prev focused chip no longer in the live list.
+      expect(content).toMatch(
+        /if\s*\(prevFocused\s*&&\s*!items\.includes\(prevFocused\)\)/
+      );
+      // The portal guard must gate the .focus() call.
+      const guard = content.indexOf("document.activeElement === document.body");
+      const focusCall = content.indexOf("items[clamped]?.focus()");
+      expect(guard).toBeGreaterThan(0);
+      expect(focusCall).toBeGreaterThan(guard);
+    });
+
+    it("clears the recovery ref unconditionally on eviction (before the body guard)", () => {
+      const content = readFileSync(resolve(__dirname, "../ContentDock.tsx"), "utf-8");
+
+      // A stale ref would trigger a phantom redirect on a later unrelated
+      // render, so the clear must precede the activeElement guard.
+      const clear = content.indexOf("prevFocusedDockItemRef.current = null");
+      const guard = content.indexOf("document.activeElement === document.body");
+      expect(clear).toBeGreaterThan(0);
+      expect(guard).toBeGreaterThan(clear);
+    });
+
+    it("removes the scroll chevrons from the tab order", () => {
+      const content = readFileSync(resolve(__dirname, "../ContentDock.tsx"), "utf-8");
+
+      // Both decorative chevron buttons must carry tabIndex={-1} + aria-hidden.
+      const tabIndexCount = (content.match(/tabIndex=\{-1\}/g) ?? []).length;
+      expect(tabIndexCount).toBeGreaterThanOrEqual(2);
+
+      // Anchor each aria-hidden to its chevron's label so the assertion can't
+      // pass on an unrelated pre-existing aria-hidden elsewhere in the file.
+      const leftBtn = content.indexOf("onClick={scrollLeft}");
+      const leftLabel = content.indexOf('aria-label="Scroll left"', leftBtn);
+      expect(content.slice(leftBtn, leftLabel)).toContain('aria-hidden="true"');
+
+      const rightBtn = content.indexOf("onClick={scrollRight}");
+      const rightLabel = content.indexOf('aria-label="Scroll right"', rightBtn);
+      expect(content.slice(rightBtn, rightLabel)).toContain('aria-hidden="true"');
+    });
+
+    it("applies scroll-padding so focused edge chips clear the gradient scrim", () => {
+      const content = readFileSync(resolve(__dirname, "../ContentDock.tsx"), "utf-8");
+
+      expect(content).toContain("scroll-px-4");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- When a focused dock chip unmounts, `useLayoutEffect` reassigns the roving `tabIndex` but never calls `.focus()` — keyboard navigation dies. This PR adds `prevFocusedDockItemRef` (set in `handleDockFocusCapture`) and redirects focus to the promoted chip on eviction, guarded on `document.activeElement === document.body` so Radix portals (tooltip, context menu) are never hijacked. Same pattern as `prevFocusedToolbarItemRef` in `Toolbar.tsx`.
- Scroll chevrons removed from the tab order with `tabIndex={-1}` + `aria-hidden="true"` — they're pointer-only shortcuts; arrow-key roving already handles full navigation.
- Added `scroll-px-4` to the `role=toolbar` scroll container so focused edge chips aren't parked behind the gradient scrim.

Resolves #9681.

## Changes

- `src/components/Layout/ContentDock.tsx` — focus recovery ref, chevron `tabIndex`/`aria-hidden`, `scroll-px-4` on overflow container
- `src/components/Layout/__tests__/ContentDock.test.tsx` — 6 new static-analysis tests in a `describe("focus recovery — issue #9681")` block

## Testing

All 30 tests pass. Lint, format, and typecheck clean.