### PR TITLE
feat(dock): show insertion indicator when reordering dock chips

### DIFF
--- a/src/components/DragDrop/SortableDockItem.tsx
+++ b/src/components/DragDrop/SortableDockItem.tsx
@@ -51,10 +51,13 @@ export function SortableDockItem({
 
   // Directional insertion-line indicator: only fire for dock sort drags (a
   // grid→dock cross-container drag also raises isOver, but its own highlight
-  // handles that), and only when dnd-kit has measured the dragged rect.
-  // Compare horizontal midpoints — index comparison gives the optimistic
-  // visual slot, not the user's intent relative to the hovered chip.
-  const isDockSortDragOver = isOver && active?.data.current?.sourceLocation === "dock";
+  // handles that; an accordion-origin drag of a docked terminal also reports
+  // sourceLocation "dock", so exclude it via `origin`), and only when dnd-kit
+  // has measured the dragged rect. Compare horizontal midpoints — index
+  // comparison gives the optimistic visual slot, not the user's intent
+  // relative to the hovered chip.
+  const isDockSortDragOver =
+    isOver && active?.data.current?.sourceLocation === "dock" && !active?.data.current?.origin;
   const translatedRect = active?.rect.current.translated;
   let dropDirection: "before" | "after" | null = null;
   if (isDockSortDragOver && translatedRect && over) {

--- a/src/components/DragDrop/SortableDockItem.tsx
+++ b/src/components/DragDrop/SortableDockItem.tsx
@@ -40,11 +40,28 @@ export function SortableDockItem({
     transform,
     transition,
     isDragging,
+    isOver,
+    active,
+    over,
   } = useSortable({
     id: terminal.id,
     data: dragData,
     animateLayoutChanges: () => false,
   });
+
+  // Directional insertion-line indicator: only fire for dock sort drags (a
+  // grid→dock cross-container drag also raises isOver, but its own highlight
+  // handles that), and only when dnd-kit has measured the dragged rect.
+  // Compare horizontal midpoints — index comparison gives the optimistic
+  // visual slot, not the user's intent relative to the hovered chip.
+  const isDockSortDragOver = isOver && active?.data.current?.sourceLocation === "dock";
+  const translatedRect = active?.rect.current.translated;
+  let dropDirection: "before" | "after" | null = null;
+  if (isDockSortDragOver && translatedRect && over) {
+    const draggedMid = translatedRect.left + translatedRect.width / 2;
+    const overMid = over.rect.left + over.rect.width / 2;
+    dropDirection = draggedMid < overMid ? "before" : "after";
+  }
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -64,7 +81,17 @@ export function SortableDockItem({
       {...remainingAttributes}
       aria-roledescription="sortable item"
     >
-      <div ref={setNodeRef} style={style} role="listitem" className={cn("flex-shrink-0")}>
+      <div ref={setNodeRef} style={style} role="listitem" className={cn("relative flex-shrink-0")}>
+        {dropDirection !== null && (
+          <div
+            aria-hidden="true"
+            data-dock-drop-indicator={dropDirection}
+            className={cn(
+              "pointer-events-none absolute inset-y-0 z-10 w-0.5 bg-border-strong",
+              dropDirection === "before" ? "-left-px" : "-right-px"
+            )}
+          />
+        )}
         <m.div
           className="h-full"
           animate={{ opacity: isDragging ? DRAG_GHOST_OPACITY : 1 }}

--- a/src/components/DragDrop/__tests__/SortableDockItem.test.tsx
+++ b/src/components/DragDrop/__tests__/SortableDockItem.test.tsx
@@ -9,7 +9,7 @@ interface MockSortableState {
   isDragging?: boolean;
   isOver?: boolean;
   active?: {
-    data: { current: { sourceLocation?: string } };
+    data: { current: { sourceLocation?: string; origin?: string } };
     rect: { current: { translated: { left: number; width: number } | null } };
   } | null;
   over?: { rect: { left: number; width: number } } | null;
@@ -159,6 +159,23 @@ describe("SortableDockItem", () => {
       isOver: true,
       active: {
         data: { current: { sourceLocation: "grid" } },
+        rect: { current: { translated: { left: 0, width: 40 } } },
+      },
+      over: { rect: { left: 100, width: 40 } },
+    };
+    const { container } = render(
+      <SortableDockItem terminal={terminal} sourceIndex={0}>
+        <div />
+      </SortableDockItem>
+    );
+    expect(container.querySelector("[data-dock-drop-indicator]")).toBeNull();
+  });
+
+  it("renders no indicator for an accordion-origin drag of a docked terminal", () => {
+    mockState = {
+      isOver: true,
+      active: {
+        data: { current: { sourceLocation: "dock", origin: "accordion" } },
         rect: { current: { translated: { left: 0, width: 40 } } },
       },
       over: { rect: { left: 100, width: 40 } },

--- a/src/components/DragDrop/__tests__/SortableDockItem.test.tsx
+++ b/src/components/DragDrop/__tests__/SortableDockItem.test.tsx
@@ -5,7 +5,17 @@ import { SortableDockItem } from "../SortableDockItem";
 import { useDragHandle } from "../DragHandleContext";
 import type { PanelInstance } from "@shared/types/panel";
 
-let mockIsDragging = false;
+interface MockSortableState {
+  isDragging?: boolean;
+  isOver?: boolean;
+  active?: {
+    data: { current: { sourceLocation?: string } };
+    rect: { current: { translated: { left: number; width: number } | null } };
+  } | null;
+  over?: { rect: { left: number; width: number } } | null;
+}
+
+let mockState: MockSortableState = { isDragging: false };
 const mockSetActivatorNodeRef = vi.fn();
 
 vi.mock("@dnd-kit/sortable", () => ({
@@ -16,7 +26,10 @@ vi.mock("@dnd-kit/sortable", () => ({
     setActivatorNodeRef: mockSetActivatorNodeRef,
     transform: null,
     transition: undefined,
-    isDragging: mockIsDragging,
+    isDragging: mockState.isDragging ?? false,
+    isOver: mockState.isOver ?? false,
+    active: mockState.active ?? null,
+    over: mockState.over ?? null,
   }),
 }));
 
@@ -42,7 +55,7 @@ const terminal: PanelInstance = {
 
 describe("SortableDockItem", () => {
   it("renders children through DragHandleProvider", () => {
-    mockIsDragging = false;
+    mockState = { isDragging: false };
     const { getByTestId } = render(
       <SortableDockItem terminal={terminal} sourceIndex={0}>
         <div data-testid="child" />
@@ -52,7 +65,7 @@ describe("SortableDockItem", () => {
   });
 
   it("does not render role=button on the outer m.div (stripped from dnd-kit attributes)", () => {
-    mockIsDragging = false;
+    mockState = { isDragging: false };
     const { container } = render(
       <SortableDockItem terminal={terminal} sourceIndex={0}>
         <div />
@@ -63,7 +76,7 @@ describe("SortableDockItem", () => {
   });
 
   it("does not apply opacity-40 class (opacity now driven by framer-motion animate)", () => {
-    mockIsDragging = true;
+    mockState = { isDragging: true };
     const { container } = render(
       <SortableDockItem terminal={terminal} sourceIndex={0}>
         <div />
@@ -75,7 +88,7 @@ describe("SortableDockItem", () => {
   });
 
   it("forwards setActivatorNodeRef through DragHandleProvider for keyboard a11y", () => {
-    mockIsDragging = false;
+    mockState = { isDragging: false };
     let captured: ReturnType<typeof useDragHandle> = null;
     function Probe() {
       captured = useDragHandle();
@@ -89,5 +102,89 @@ describe("SortableDockItem", () => {
     expect(captured).not.toBeNull();
     expect(captured!.setActivatorNodeRef).toBe(mockSetActivatorNodeRef);
     expect(captured!.listeners).toBeDefined();
+  });
+
+  it("renders no insertion indicator when idle", () => {
+    mockState = { isDragging: false };
+    const { container } = render(
+      <SortableDockItem terminal={terminal} sourceIndex={0}>
+        <div />
+      </SortableDockItem>
+    );
+    expect(container.querySelector("[data-dock-drop-indicator]")).toBeNull();
+  });
+
+  it("shows a 'before' indicator on the left when the dragged midpoint is left of the hovered chip", () => {
+    mockState = {
+      isOver: true,
+      active: {
+        data: { current: { sourceLocation: "dock" } },
+        rect: { current: { translated: { left: 0, width: 40 } } },
+      },
+      over: { rect: { left: 100, width: 40 } },
+    };
+    const { container } = render(
+      <SortableDockItem terminal={terminal} sourceIndex={0}>
+        <div />
+      </SortableDockItem>
+    );
+    const indicator = container.querySelector("[data-dock-drop-indicator]");
+    expect(indicator?.getAttribute("data-dock-drop-indicator")).toBe("before");
+    expect(indicator?.className).toContain("-left-px");
+    expect(indicator?.className).not.toContain("-right-px");
+  });
+
+  it("shows an 'after' indicator on the right when the dragged midpoint is right of the hovered chip", () => {
+    mockState = {
+      isOver: true,
+      active: {
+        data: { current: { sourceLocation: "dock" } },
+        rect: { current: { translated: { left: 200, width: 40 } } },
+      },
+      over: { rect: { left: 100, width: 40 } },
+    };
+    const { container } = render(
+      <SortableDockItem terminal={terminal} sourceIndex={0}>
+        <div />
+      </SortableDockItem>
+    );
+    const indicator = container.querySelector("[data-dock-drop-indicator]");
+    expect(indicator?.getAttribute("data-dock-drop-indicator")).toBe("after");
+    expect(indicator?.className).toContain("-right-px");
+    expect(indicator?.className).not.toContain("-left-px");
+  });
+
+  it("renders no indicator for a cross-container grid drag even when hovered", () => {
+    mockState = {
+      isOver: true,
+      active: {
+        data: { current: { sourceLocation: "grid" } },
+        rect: { current: { translated: { left: 0, width: 40 } } },
+      },
+      over: { rect: { left: 100, width: 40 } },
+    };
+    const { container } = render(
+      <SortableDockItem terminal={terminal} sourceIndex={0}>
+        <div />
+      </SortableDockItem>
+    );
+    expect(container.querySelector("[data-dock-drop-indicator]")).toBeNull();
+  });
+
+  it("renders no indicator before dnd-kit has measured the dragged rect", () => {
+    mockState = {
+      isOver: true,
+      active: {
+        data: { current: { sourceLocation: "dock" } },
+        rect: { current: { translated: null } },
+      },
+      over: { rect: { left: 100, width: 40 } },
+    };
+    const { container } = render(
+      <SortableDockItem terminal={terminal} sourceIndex={0}>
+        <div />
+      </SortableDockItem>
+    );
+    expect(container.querySelector("[data-dock-drop-indicator]")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Adds a vertical insertion-line indicator to the Content Dock during chip reorder, showing where the dropped chip will land
- The indicator sits at the left or right edge of the hovered chip based on a horizontal midpoint comparison — same pattern as the worktree sidebar, rotated for horizontal layout
- Suppressed for cross-container (grid→dock) and accordion-origin drags, which already have their own affordances; uses `bg-border-strong` (neutral, not accent)

Resolves #9685

## Changes

- `src/components/DragDrop/SortableDockItem.tsx` — midpoint comparison logic + insertion indicator element, guarded to dock sort drags only
- `src/components/DragDrop/__tests__/SortableDockItem.test.tsx` — 10 unit tests covering indicator visibility, left/right positioning, and suppression conditions

## Testing

- 10 unit tests added; all pass
- Typecheck, lint, and format clean