### PR TITLE
fix(dock): add move-to-grid affordance and fix deprioritized contrast

### DIFF
--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -406,7 +406,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
                 }}
                 onPointerDown={(e) => e.stopPropagation()}
                 className="invisible opacity-0 pointer-events-none group-hover/chip:visible group-hover/chip:opacity-100 group-hover/chip:pointer-events-auto group-focus-within/chip:visible group-focus-within/chip:opacity-100 group-focus-within/chip:pointer-events-auto focus-visible:visible focus-visible:opacity-100 focus-visible:pointer-events-auto transition-[opacity,visibility] duration-150 motion-reduce:transition-none shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                aria-label="Open in grid"
+                aria-label={`Open ${displayTitle} in grid`}
               >
                 <SquareArrowOutUpRight className="w-3 h-3" aria-hidden="true" />
               </button>

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useDndMonitor } from "@dnd-kit/core";
+import { SquareArrowOutUpRight } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn, getBaseTitle } from "@/lib/utils";
 import { useTerminalInputStore, usePanelStore, useFocusStore } from "@/store";
@@ -174,6 +175,14 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
     [terminal.id, openDockTerminal, closeDockTerminal]
   );
 
+  // Move this terminal out of the dock and into the grid. Mirrors the
+  // double-click backstop: only close the dock popover if the move succeeded
+  // (the store wrapper clears activeDockTerminalId — see #4997).
+  const handleMoveToGrid = useCallback(() => {
+    const moved = moveTerminalToGrid(terminal.id);
+    if (moved) closeDockTerminal();
+  }, [terminal.id, moveTerminalToGrid, closeDockTerminal]);
+
   const presetCustomPresets = useAgentSettingsStore((s) =>
     terminal.launchAgentId ? s.settings?.agents?.[terminal.launchAgentId]?.customPresets : undefined
   );
@@ -298,89 +307,113 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   return (
     <DockPopoverChildProvider>
       <Popover open={isOpen} onOpenChange={handleOpenChange}>
-        <TerminalContextMenu terminalId={terminal.id} forceLocation="dock">
-          <PopoverTrigger asChild>
-            <button
-              data-dock-item=""
-              className={cn(
-                "flex items-center gap-1.5 px-3 h-[var(--dock-item-height)] rounded-[var(--radius-md)] text-xs border transition duration-150 max-w-[280px]",
-                "bg-[var(--dock-item-bg)] border-[var(--dock-item-border)] text-daintree-text/70",
-                "hover:text-daintree-text hover:bg-[var(--dock-item-bg-hover)]",
-                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]",
-                "cursor-grab active:cursor-grabbing",
-                isOpen &&
-                  "bg-[var(--dock-item-bg-active)] text-daintree-text border-[var(--dock-item-border-active)] ring-1 ring-inset ring-daintree-accent/30",
-                !isOpen &&
-                  showDockAgentHighlights &&
-                  blockedState === "waiting" &&
-                  "bg-[var(--dock-item-bg-waiting)] border-[var(--dock-item-border-waiting)]",
-                isDeprioritized && "opacity-50"
-              )}
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                if (e.detail >= 2) return;
-                if (isOpen) {
-                  closeDockTerminal();
-                } else {
-                  openDockTerminal(terminal.id);
-                }
-              }}
-              onDoubleClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                const moved = moveTerminalToGrid(terminal.id);
-                if (moved) closeDockTerminal();
-              }}
-              aria-label={`${terminal.title} - Click to preview, double-click to move to grid, drag to reorder`}
-            >
-              <div className="flex items-center justify-center shrink-0">
-                <TerminalIcon kind={terminal.kind} chrome={chrome} className="w-3.5 h-3.5" />
-              </div>
-              <span className="truncate min-w-[48px] max-w-[140px] font-sans font-medium">
-                {displayTitle}
-              </span>
+        <div className="relative group/chip flex items-center">
+          <TerminalContextMenu terminalId={terminal.id} forceLocation="dock">
+            <PopoverTrigger asChild>
+              <button
+                data-dock-item=""
+                className={cn(
+                  "flex items-center gap-1.5 px-3 h-[var(--dock-item-height)] rounded-[var(--radius-md)] text-xs border transition duration-150 max-w-[280px]",
+                  "bg-[var(--dock-item-bg)] border-[var(--dock-item-border)] text-daintree-text/70",
+                  "hover:text-daintree-text hover:bg-[var(--dock-item-bg-hover)]",
+                  "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]",
+                  "cursor-grab active:cursor-grabbing",
+                  isOpen &&
+                    "bg-[var(--dock-item-bg-active)] text-daintree-text border-[var(--dock-item-border-active)] ring-1 ring-inset ring-daintree-accent/30",
+                  !isOpen &&
+                    showDockAgentHighlights &&
+                    blockedState === "waiting" &&
+                    "bg-[var(--dock-item-bg-waiting)] border-[var(--dock-item-border-waiting)]",
+                  isDeprioritized && "text-daintree-text/40 border-[var(--dock-item-border)]/50"
+                )}
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  if (e.detail >= 2) return;
+                  if (isOpen) {
+                    closeDockTerminal();
+                  } else {
+                    openDockTerminal(terminal.id);
+                  }
+                }}
+                onDoubleClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  handleMoveToGrid();
+                }}
+                aria-label={`${terminal.title} - Click to preview, double-click to move to grid, drag to reorder`}
+              >
+                <div className="flex items-center justify-center shrink-0">
+                  <TerminalIcon kind={terminal.kind} chrome={chrome} className="w-3.5 h-3.5" />
+                </div>
+                <span className="truncate min-w-[48px] max-w-[140px] font-sans font-medium">
+                  {displayTitle}
+                </span>
 
-              {isActive && commandText && (
-                <>
-                  <div className="h-3 w-px bg-border-subtle shrink-0" aria-hidden="true" />
+                {isActive && commandText && (
+                  <>
+                    <div className="h-3 w-px bg-border-subtle shrink-0" aria-hidden="true" />
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="truncate flex-1 min-w-0 text-[11px] text-daintree-text/50 font-mono">
+                          {commandText}
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">{commandText}</TooltipContent>
+                    </Tooltip>
+                  </>
+                )}
+
+                {/* State icon (compact spacing from title) */}
+                {displayAgentState && StateIcon && (
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <span className="truncate flex-1 min-w-0 text-[11px] text-daintree-text/50 font-mono">
-                        {commandText}
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">{commandText}</TooltipContent>
-                  </Tooltip>
-                </>
-              )}
-
-              {/* State icon (compact spacing from title) */}
-              {displayAgentState && StateIcon && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div
-                      className={cn(
-                        "flex items-center shrink-0",
-                        getEffectiveStateColor(displayAgentState)
-                      )}
-                    >
-                      <StateIcon
+                      <div
                         className={cn(
-                          "w-3.5 h-3.5",
-                          displayAgentState === "working" && "animate-spin-slow",
-                          "motion-reduce:animate-none"
+                          "flex items-center shrink-0",
+                          getEffectiveStateColor(displayAgentState)
                         )}
-                        aria-hidden="true"
-                      />
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">{`Agent ${displayAgentState}`}</TooltipContent>
-                </Tooltip>
-              )}
-            </button>
-          </PopoverTrigger>
-        </TerminalContextMenu>
+                      >
+                        <StateIcon
+                          className={cn(
+                            "w-3.5 h-3.5",
+                            displayAgentState === "working" && "animate-spin-slow",
+                            "motion-reduce:animate-none"
+                          )}
+                          aria-hidden="true"
+                        />
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">{`Agent ${displayAgentState}`}</TooltipContent>
+                  </Tooltip>
+                )}
+              </button>
+            </PopoverTrigger>
+          </TerminalContextMenu>
+
+          {/* Reveal-on-hover/focus move-to-grid affordance. Rendered as a
+              sibling of the chip button (a button cannot be nested inside the
+              PopoverTrigger button). Double-click on the chip remains a
+              backstop. */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                data-no-dnd
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleMoveToGrid();
+                }}
+                onPointerDown={(e) => e.stopPropagation()}
+                className="invisible opacity-0 pointer-events-none group-hover/chip:visible group-hover/chip:opacity-100 group-hover/chip:pointer-events-auto group-focus-within/chip:visible group-focus-within/chip:opacity-100 group-focus-within/chip:pointer-events-auto focus-visible:visible focus-visible:opacity-100 focus-visible:pointer-events-auto transition-[opacity,visibility] duration-150 motion-reduce:transition-none shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                aria-label="Open in grid"
+              >
+                <SquareArrowOutUpRight className="w-3 h-3" aria-hidden="true" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Open in grid</TooltipContent>
+          </Tooltip>
+        </div>
 
         <PopoverContent
           className="w-[700px] max-w-[90vw] h-[500px] max-h-[80vh] p-0 bg-daintree-bg/95 backdrop-blur-sm border border-[var(--border-dock-popup)] shadow-[var(--shadow-dock-panel-popover)] rounded-[var(--radius-lg)] overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1"

--- a/src/components/Layout/__tests__/DockedTerminalItem.test.tsx
+++ b/src/components/Layout/__tests__/DockedTerminalItem.test.tsx
@@ -144,14 +144,26 @@ describe("DockedTerminalItem move-to-grid affordance (#9683)", () => {
 
   it("renders an Open in grid button on the chip", () => {
     render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
-    expect(screen.getByRole("button", { name: "Open in grid" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open Terminal in grid" })).toBeTruthy();
+  });
+
+  it("gives each chip's button a label naming its own terminal", () => {
+    render(
+      <>
+        <DockedTerminalItem terminal={makeTerminal({ id: "t-1", title: "Claude" })} />
+        <DockedTerminalItem terminal={makeTerminal({ id: "t-2", title: "Gemini" })} />
+      </>
+    );
+
+    expect(screen.getByRole("button", { name: "Open Claude in grid" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open Gemini in grid" })).toBeTruthy();
   });
 
   it("moves the terminal to the grid when the button is clicked", () => {
     moveTerminalToGridMock.mockReturnValue(true);
     render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Open in grid" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open Terminal in grid" }));
 
     expect(moveTerminalToGridMock).toHaveBeenCalledWith("t-1");
   });
@@ -160,7 +172,7 @@ describe("DockedTerminalItem move-to-grid affordance (#9683)", () => {
     moveTerminalToGridMock.mockReturnValue(true);
     render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Open in grid" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open Terminal in grid" }));
 
     expect(closeDockTerminalMock).toHaveBeenCalledTimes(1);
   });
@@ -169,7 +181,7 @@ describe("DockedTerminalItem move-to-grid affordance (#9683)", () => {
     moveTerminalToGridMock.mockReturnValue(false);
     render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Open in grid" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open Terminal in grid" }));
 
     expect(moveTerminalToGridMock).toHaveBeenCalledWith("t-1");
     expect(closeDockTerminalMock).not.toHaveBeenCalled();
@@ -179,7 +191,7 @@ describe("DockedTerminalItem move-to-grid affordance (#9683)", () => {
     moveTerminalToGridMock.mockReturnValue(true);
     render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Open in grid" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open Terminal in grid" }));
 
     expect(openDockTerminalMock).not.toHaveBeenCalled();
   });

--- a/src/components/Layout/__tests__/DockedTerminalItem.test.tsx
+++ b/src/components/Layout/__tests__/DockedTerminalItem.test.tsx
@@ -1,33 +1,197 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from "vitest";
-import { readFileSync } from "fs";
-import { resolve } from "path";
+/**
+ * DockedTerminalItem — move-to-grid affordance (#9683).
+ *
+ * The single docked chip exposes a reveal-on-hover "Open in grid" button (the
+ * gesture was previously only reachable via double-click / context menu). These
+ * tests drive the button and the double-click backstop through a render harness
+ * (no source-string assertions) and verify the store wiring: the dock popover
+ * only closes when moveTerminalToGrid succeeds.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { PtyPanelData } from "@shared/types/panel";
 
-describe("DockedTerminalItem", () => {
-  const content = readFileSync(resolve(__dirname, "../DockedTerminalItem.tsx"), "utf-8");
+const openDockTerminalMock = vi.fn();
+const closeDockTerminalMock = vi.fn();
+const moveTerminalToGridMock = vi.fn();
 
-  it("preserves click/double-click handler structure through the new wrappers", () => {
-    expect(content).toContain("onClick={");
-    expect(content).toContain("onDoubleClick={");
+let mockActiveDockTerminalId: string | null = null;
+
+vi.mock("@/store", () => ({
+  usePanelStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      activeDockTerminalId: mockActiveDockTerminalId,
+      openDockTerminal: openDockTerminalMock,
+      closeDockTerminal: closeDockTerminalMock,
+      moveTerminalToGrid: moveTerminalToGridMock,
+      backendStatus: "connected",
+      showDockAgentHighlights: false,
+    }),
+  useTerminalInputStore: (
+    selector: (s: { hybridInputEnabled: boolean; hybridInputAutoFocus: boolean }) => unknown
+  ) => selector({ hybridInputEnabled: false, hybridInputAutoFocus: false }),
+  usePortalStore: (selector: (s: { isOpen: boolean; width: number }) => unknown) =>
+    selector({ isOpen: false, width: 0 }),
+  useFocusStore: (
+    selector: (s: { isFocusMode: boolean; gestureSidebarHidden: boolean }) => unknown
+  ) => selector({ isFocusMode: false, gestureSidebarHidden: false }),
+  usePreferencesStore: (selector: (s: { showDockAgentHighlights: boolean }) => unknown) =>
+    selector({ showDockAgentHighlights: false }),
+}));
+
+vi.mock("@/store/agentSettingsStore", () => ({
+  useAgentSettingsStore: (selector: (s: { settings: null }) => unknown) =>
+    selector({ settings: null }),
+}));
+
+vi.mock("@/store/ccrPresetsStore", () => ({
+  useCcrPresetsStore: (selector: (s: { ccrPresetsByAgent: Record<string, unknown> }) => unknown) =>
+    selector({ ccrPresetsByAgent: {} }),
+}));
+
+vi.mock("@/store/projectPresetsStore", () => ({
+  useProjectPresetsStore: (selector: (s: { presetsByAgent: Record<string, unknown> }) => unknown) =>
+    selector({ presetsByAgent: {} }),
+}));
+
+vi.mock("@/config/agents", () => ({
+  getMergedPresets: () => [],
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    fit: () => ({ cols: 80, rows: 24 }),
+    applyRendererPolicy: vi.fn(),
+    focus: vi.fn(),
+  },
+}));
+
+vi.mock("../dockPanelPortalContext", () => ({
+  useDockPanelPortal: () => vi.fn(),
+}));
+
+vi.mock("../useDockBlockedState", () => ({
+  useDockBlockedState: () => null,
+  getDockDisplayAgentState: () => undefined,
+}));
+
+vi.mock("../dockPopoverGuard", () => ({
+  handleDockInteractOutside: vi.fn(),
+  handleDockEscapeKeyDown: vi.fn(),
+  handleDockFocusOutside: vi.fn(),
+}));
+
+vi.mock("@/utils/terminalChrome", () => ({
+  deriveTerminalChrome: () => ({ isAgent: false, color: "#abc" }),
+}));
+
+vi.mock("@/components/Worktree/terminalStateConfig", () => ({
+  getEffectiveStateIcon: () => null,
+  getEffectiveStateColor: () => "",
+}));
+
+vi.mock("@/components/Terminal/TerminalContextMenu", () => ({
+  TerminalContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/Terminal/TerminalIcon", () => ({
+  TerminalIcon: () => <span data-testid="terminal-icon" />,
+}));
+
+vi.mock("@/components/Terminal/terminalFocus", () => ({
+  getTerminalFocusTarget: () => "terminal",
+}));
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@dnd-kit/core", () => ({
+  useDndMonitor: vi.fn(),
+}));
+
+import { DockedTerminalItem } from "../DockedTerminalItem";
+
+function makeTerminal(overrides: Partial<PtyPanelData> = {}): PtyPanelData {
+  return {
+    id: "t-1",
+    title: "Terminal",
+    location: "dock",
+    kind: "terminal",
+    cwd: "/tmp",
+    cols: 80,
+    rows: 24,
+    ...overrides,
+  } as PtyPanelData;
+}
+
+describe("DockedTerminalItem move-to-grid affordance (#9683)", () => {
+  beforeEach(() => {
+    openDockTerminalMock.mockReset();
+    closeDockTerminalMock.mockReset();
+    moveTerminalToGridMock.mockReset();
+    mockActiveDockTerminalId = null;
   });
 
-  it("includes explicit animation classes on PopoverContent matching base popover Tier 2 timing", () => {
-    expect(content).toContain("data-[state=open]:animate-in");
-    expect(content).toContain("data-[state=closed]:animate-out");
-    expect(content).toContain("data-[state=open]:duration-200");
-    expect(content).toContain("data-[state=closed]:duration-[120ms]");
-    expect(content).toContain("data-[state=open]:fade-in-0");
-    expect(content).toContain("data-[state=closed]:fade-out-0");
-    expect(content).toContain("data-[state=open]:zoom-in-97");
-    expect(content).toContain("data-[state=closed]:zoom-out-97");
-    expect(content).toContain("data-[side=bottom]:slide-in-from-top-1");
-    expect(content).toContain("data-[side=left]:slide-in-from-right-1");
-    expect(content).toContain("data-[side=right]:slide-in-from-left-1");
-    expect(content).toContain("data-[side=top]:slide-in-from-bottom-1");
+  it("renders an Open in grid button on the chip", () => {
+    render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
+    expect(screen.getByRole("button", { name: "Open in grid" })).toBeTruthy();
   });
 
-  it("keeps existing dock popover guards intact", () => {
-    expect(content).toContain("handleDockInteractOutside");
-    expect(content).toContain("handleDockEscapeKeyDown");
+  it("moves the terminal to the grid when the button is clicked", () => {
+    moveTerminalToGridMock.mockReturnValue(true);
+    render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open in grid" }));
+
+    expect(moveTerminalToGridMock).toHaveBeenCalledWith("t-1");
+  });
+
+  it("closes the dock popover only when the move succeeds", () => {
+    moveTerminalToGridMock.mockReturnValue(true);
+    render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open in grid" }));
+
+    expect(closeDockTerminalMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not close the dock popover when the move is rejected", () => {
+    moveTerminalToGridMock.mockReturnValue(false);
+    render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open in grid" }));
+
+    expect(moveTerminalToGridMock).toHaveBeenCalledWith("t-1");
+    expect(closeDockTerminalMock).not.toHaveBeenCalled();
+  });
+
+  it("does not open the dock preview when the button is clicked", () => {
+    moveTerminalToGridMock.mockReturnValue(true);
+    render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open in grid" }));
+
+    expect(openDockTerminalMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps double-click on the chip as a move-to-grid backstop", () => {
+    moveTerminalToGridMock.mockReturnValue(true);
+    render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
+
+    const chip = screen.getByRole("button", { name: /double-click to move to grid/i });
+    fireEvent.doubleClick(chip);
+
+    expect(moveTerminalToGridMock).toHaveBeenCalledWith("t-1");
+    expect(closeDockTerminalMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

- Adds a reveal-on-hover/focus pop-out button (`SquareArrowOutUpRight`) to the single docked terminal chip, mirroring the existing pattern in `DockedTabGroup.tsx`. The move-to-grid gesture was only discoverable via double-click or the right-click context menu — nothing visible signalled it existed.
- Replaces `opacity-50` on deprioritized (idle/completed/exited) chips with per-property de-emphasis (`text-daintree-text/40` + `border-[var(--dock-item-border)]/50`). The blanket opacity compounded on the chip's already-reduced text opacity, producing ~35% effective contrast — a likely WCAG AA failure on a live control.
- Rewrites the chip tests from tautological source-string assertions to behavioral render tests.

Resolves #9683

## Changes

- `src/components/Layout/DockedTerminalItem.tsx` — pop-out button added as a sibling of the `PopoverTrigger` (can't nest buttons), hidden via `invisible pointer-events-none` / revealed via `group-hover group-focus-within`, with `data-no-dnd` and `stopPropagation` to avoid drag activation. `aria-label` names the specific terminal. Container `opacity-50` replaced with per-property token overrides.
- `src/components/Layout/__tests__/DockedTerminalItem.test.tsx` — tests rewritten to assert rendered behavior (button presence/absence, click handlers, aria attributes) rather than mirroring source strings.

## Testing

- Hover and keyboard focus on a single docked chip reveals the pop-out button; double-click still works as a backstop.
- Deprioritized chips render at readable contrast without a blanket opacity applied to the whole element.
- Unit tests pass.