### PR TITLE
fix(github): bind toolbar count badge to dropdown-loaded items

### DIFF
--- a/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
@@ -557,6 +557,37 @@ describe("GitHubResourceList SWR behavior", () => {
     expect(onCountUpdate).toHaveBeenCalledTimes(1);
   });
 
+  it("does not poison the badge count when the dropdown filter switches away from open", async () => {
+    // The badge shows the OPEN count. Switching the dropdown to Closed must
+    // not overwrite it with the closed count (the hook stays mounted across
+    // filter tabs).
+    mockListIssues.mockResolvedValueOnce(makeResponse([makeIssue(1), makeIssue(2)]));
+    const onCountUpdate = vi.fn();
+
+    render(
+      <GitHubResourceList type="issue" projectPath="/test/proj" onCountUpdate={onCountUpdate} />
+    );
+
+    await waitFor(() => {
+      expect(onCountUpdate).toHaveBeenCalledWith(2, false);
+    });
+    onCountUpdate.mockClear();
+
+    // Switch to the "closed" tab — a fresh first-page fetch fires for the
+    // closed filter key. It must NOT report into the open-count badge.
+    mockListIssues.mockResolvedValue(
+      makeResponse([makeIssue(3), makeIssue(4), makeIssue(5), makeIssue(6)])
+    );
+    act(() => {
+      useGitHubFilterStore.getState().setIssueFilter("closed");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("item-3")).toBeTruthy();
+    });
+    expect(onCountUpdate).not.toHaveBeenCalled();
+  });
+
   it("does not call onCountUpdate for search-filtered fetches", async () => {
     useGitHubFilterStore.getState().setIssueSearchQuery("needle");
     mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));

--- a/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
@@ -467,6 +467,113 @@ describe("GitHubResourceList SWR behavior", () => {
     expect(onFreshFetch).not.toHaveBeenCalled();
   });
 
+  it("calls onCountUpdate with the loaded length and hasMore on a cold-mount fetch (issue #9693)", async () => {
+    // No cache — cold mount. The badge must bind to what the list loads, not
+    // the stats query's totalCount, so onCountUpdate fires even though this is
+    // not a revalidation (unlike onFreshFetch).
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1), makeIssue(2)]));
+    const onCountUpdate = vi.fn();
+
+    render(
+      <GitHubResourceList type="issue" projectPath="/test/proj" onCountUpdate={onCountUpdate} />
+    );
+
+    await waitFor(() => {
+      expect(onCountUpdate).toHaveBeenCalledWith(2, false);
+    });
+    // Cold mount is the bypassCache:false path — onFreshFetch would skip here,
+    // but onCountUpdate must still fire.
+    expect(mockListIssues.mock.calls[0]?.[0]?.bypassCache).toBe(false);
+  });
+
+  it("reports hasMore=true via onCountUpdate when the first page is paginated", async () => {
+    mockListIssues.mockResolvedValue({
+      items: [makeIssue(1), makeIssue(2)],
+      pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+    });
+    const onCountUpdate = vi.fn();
+
+    render(
+      <GitHubResourceList type="issue" projectPath="/test/proj" onCountUpdate={onCountUpdate} />
+    );
+
+    await waitFor(() => {
+      expect(onCountUpdate).toHaveBeenCalledWith(2, true);
+    });
+  });
+
+  it("calls onCountUpdate again after a successful background revalidation", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(10)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+
+    // Revalidation lands a larger page — the badge must converge to it.
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(10), makeIssue(11)]));
+    const onCountUpdate = vi.fn();
+
+    render(
+      <GitHubResourceList type="issue" projectPath="/test/proj" onCountUpdate={onCountUpdate} />
+    );
+
+    await waitFor(() => {
+      expect(onCountUpdate).toHaveBeenCalledWith(2, false);
+    });
+    expect(mockListIssues.mock.calls[0]?.[0]?.bypassCache).toBe(true);
+  });
+
+  it("does not call onCountUpdate when loading more (append) pages", async () => {
+    mockListIssues.mockResolvedValueOnce({
+      items: [makeIssue(1), makeIssue(2)],
+      pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+    });
+    const onCountUpdate = vi.fn();
+
+    render(
+      <GitHubResourceList type="issue" projectPath="/test/proj" onCountUpdate={onCountUpdate} />
+    );
+
+    await waitFor(() => {
+      expect(onCountUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    // Second page (append) — must not move the badge count.
+    mockListIssues.mockResolvedValueOnce({
+      items: [makeIssue(3), makeIssue(4)],
+      pageInfo: { hasNextPage: false, endCursor: null },
+    });
+    const loadMore = await screen.findByRole("button", { name: /load more/i });
+    act(() => {
+      loadMore.click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("item-3")).toBeTruthy();
+    });
+    // Still exactly one onCountUpdate call — the append fetch is gated out.
+    expect(onCountUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onCountUpdate for search-filtered fetches", async () => {
+    useGitHubFilterStore.getState().setIssueSearchQuery("needle");
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+    const onCountUpdate = vi.fn();
+
+    render(
+      <GitHubResourceList type="issue" projectPath="/test/proj" onCountUpdate={onCountUpdate} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("item-1")).toBeTruthy();
+    });
+    // Search results aren't cached and must not drive the badge count, which
+    // tracks the unfiltered list.
+    expect(onCountUpdate).not.toHaveBeenCalled();
+  });
+
   it("different project paths use separate cache entries", async () => {
     const keyA = buildCacheKey("/proj-a", "issue", "open", "created");
     setCache(keyA, {

--- a/plugins/builtin/github/renderer/components/GitHubResourceList.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubResourceList.tsx
@@ -124,6 +124,14 @@ interface GitHubResourceListProps {
    * for the next 30s stats poll.
    */
   onFreshFetch?: () => void;
+  /**
+   * Called whenever fresh first-page data lands (cold-mount and revalidation)
+   * with the number of loaded items and whether more pages exist. The toolbar
+   * count badge uses this to display what the dropdown actually lists (e.g.
+   * `20+` when paginated) instead of the stats query's full `totalCount`,
+   * which can be higher than the loaded page (issue #9693).
+   */
+  onCountUpdate?: (count: number, hasMore: boolean) => void;
 }
 
 export function GitHubResourceList({
@@ -132,6 +140,7 @@ export function GitHubResourceList({
   onClose,
   initialCount,
   onFreshFetch,
+  onCountUpdate,
 }: GitHubResourceListProps) {
   const searchQuery = useGitHubFilterStore((s) =>
     type === "issue" ? s.issueSearchQuery : s.prSearchQuery
@@ -187,6 +196,7 @@ export function GitHubResourceList({
     sortOrder,
     githubConfig,
     onFreshFetch,
+    onCountUpdate,
   });
 
   const [activeIndex, setActiveIndex] = useState(-1);

--- a/plugins/builtin/github/renderer/hooks/useGitHubResourceListSWR.ts
+++ b/plugins/builtin/github/renderer/hooks/useGitHubResourceListSWR.ts
@@ -282,7 +282,17 @@ export function useGitHubResourceListSWR({
               // background refresh. The stats query's `totalCount` can exceed
               // the loaded page, so the badge would otherwise assert a higher
               // number than the list shows (issue #9693).
-              onCountUpdate?.(result.items.length, result.pageInfo.hasNextPage);
+              //
+              // Gated to the `open` filter: the badge represents the OPEN
+              // issue/PR count (its aria-label and tooltip say "open"). The
+              // hook is kept mounted across filter tabs, so without this gate
+              // switching the dropdown to Closed/Merged would fire
+              // `onCountUpdate` with the closed/merged count and poison the
+              // open badge. The last known open count stays correct while the
+              // user browses other states.
+              if (filterState === "open") {
+                onCountUpdate?.(result.items.length, result.pageInfo.hasNextPage);
+              }
               // Notify parent (toolbar count badge) that fresh first-page data
               // landed. Gated on `isRevalidate` so it fires only when
               // `bypassCache: true` was sent — the main process's

--- a/plugins/builtin/github/renderer/hooks/useGitHubResourceListSWR.ts
+++ b/plugins/builtin/github/renderer/hooks/useGitHubResourceListSWR.ts
@@ -46,6 +46,7 @@ interface UseGitHubResourceListSWRParams {
   sortOrder: GitHubSortOrder;
   githubConfig: { hasToken: boolean } | null;
   onFreshFetch?: () => void;
+  onCountUpdate?: (count: number, hasMore: boolean) => void;
 }
 
 export interface UseGitHubResourceListSWRReturn {
@@ -76,6 +77,7 @@ export function useGitHubResourceListSWR({
   sortOrder,
   githubConfig,
   onFreshFetch,
+  onCountUpdate,
 }: UseGitHubResourceListSWRParams): UseGitHubResourceListSWRReturn {
   const debouncedSearch = useDebounce(searchQuery, 300);
 
@@ -272,6 +274,15 @@ export function useGitHubResourceListSWR({
                 timestamp: now,
               });
               setLastUpdatedAt(now);
+              // Bind the toolbar count badge to what the dropdown actually
+              // lists: the loaded first-page length plus whether more pages
+              // exist. Fires on cold-mount AND revalidation (NOT gated on
+              // `isRevalidate`) so the badge reconciles to the visible count
+              // the moment the dropdown first loads, not just on a later
+              // background refresh. The stats query's `totalCount` can exceed
+              // the loaded page, so the badge would otherwise assert a higher
+              // number than the list shows (issue #9693).
+              onCountUpdate?.(result.items.length, result.pageInfo.hasNextPage);
               // Notify parent (toolbar count badge) that fresh first-page data
               // landed. Gated on `isRevalidate` so it fires only when
               // `bypassCache: true` was sent — the main process's
@@ -339,7 +350,16 @@ export function useGitHubResourceListSWR({
         }
       }
     },
-    [projectPath, debouncedSearch, filterState, type, sortOrder, numberQuery, onFreshFetch]
+    [
+      projectPath,
+      debouncedSearch,
+      filterState,
+      type,
+      sortOrder,
+      numberQuery,
+      onFreshFetch,
+      onCountUpdate,
+    ]
   );
 
   // ── Mount / filter-change effect ──────────────────────────────────────

--- a/src/components/Layout/GitHubStatPill.tsx
+++ b/src/components/Layout/GitHubStatPill.tsx
@@ -8,6 +8,13 @@ export interface GitHubStatPillProps {
   buttonRef: React.RefObject<HTMLButtonElement | null>;
   open: boolean;
   count: number | null;
+  /**
+   * Pre-formatted value to render in the badge when it should differ from the
+   * raw `count` — e.g. `"20+"` when the dropdown has loaded a first page but
+   * more items exist. `count` stays numeric for the digit-pulse animation
+   * delta comparisons; this is display-only. Falls back to `count` when unset.
+   */
+  displayCount?: number | string | null;
   animKey: number;
   ariaLabel: string;
   testId?: string;
@@ -34,6 +41,7 @@ export function GitHubStatPill({
   buttonRef,
   open,
   count,
+  displayCount,
   animKey,
   ariaLabel,
   testId,
@@ -83,7 +91,7 @@ export function GitHubStatPill({
                 animKey > 0 && "animate-badge-bump"
               )}
             >
-              {count ?? "—"}
+              {displayCount ?? count ?? "—"}
             </span>
             {activityChip}
           </Button>

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -181,6 +181,39 @@ export const GitHubStatsToolbarButton = memo(
     const prCount = stats?.prCount ?? null;
     const commitCount = stats?.commitCount ?? null;
 
+    // List-loaded counts reported by each dropdown's `onCountUpdate`. These
+    // track what the dropdown actually lists (loaded first-page length +
+    // whether more pages exist) so the badge can bind to the visible count
+    // rather than the stats query's `totalCount`, which can be higher than
+    // the loaded page (issue #9693). `null` until the dropdown first loads,
+    // at which point the badge falls back to the stats count.
+    const [issueListCount, setIssueListCount] = useState<number | null>(null);
+    const [issueListHasMore, setIssueListHasMore] = useState(false);
+    const [prListCount, setPrListCount] = useState<number | null>(null);
+    const [prListHasMore, setPrListHasMore] = useState(false);
+
+    const handleIssueListCountUpdate = useCallback((count: number, hasMore: boolean) => {
+      setIssueListCount(count);
+      setIssueListHasMore(hasMore);
+    }, []);
+    const handlePrListCountUpdate = useCallback((count: number, hasMore: boolean) => {
+      setPrListCount(count);
+      setPrListHasMore(hasMore);
+    }, []);
+
+    // Badge display value: the list-loaded count (suffixed with `+` when more
+    // pages exist, e.g. `20+`) once the dropdown has loaded, otherwise the
+    // stats `totalCount`. Stays separate from the numeric `issueCount` /
+    // `prCount` so the digit-pulse delta detection keeps comparing raw totals.
+    const issueDisplayCount: number | string | null =
+      issueListCount !== null
+        ? issueListHasMore
+          ? `${issueListCount}+`
+          : issueListCount
+        : issueCount;
+    const prDisplayCount: number | string | null =
+      prListCount !== null ? (prListHasMore ? `${prListCount}+` : prListCount) : prCount;
+
     // Eagerly resolve the dropdown body components so the click path renders
     // them concretely without going through Suspense. The toolbar is a
     // long-lived global UI surface and these dropdowns are commonly used,
@@ -549,6 +582,13 @@ export const GitHubStatsToolbarButton = memo(
         prevLastUpdatedRef.current = null;
         setIssuesPulseAt(null);
         setPrsPulseAt(null);
+        // Clear the list-loaded counts so the badge falls back to the new
+        // project's stats count (or "—") instead of showing the previous
+        // project's loaded-page count until its dropdown is opened.
+        setIssueListCount(null);
+        setIssueListHasMore(false);
+        setPrListCount(null);
+        setPrListHasMore(false);
         return;
       }
       if (prevLastUpdatedRef.current != null && lastUpdated > prevLastUpdatedRef.current) {
@@ -632,12 +672,13 @@ export const GitHubStatsToolbarButton = memo(
               buttonRef={issuesButtonRef}
               open={issuesOpen}
               count={issueCount}
+              displayCount={issueDisplayCount}
               animKey={issueAnimKey}
               testId="github-stat-pill-issues"
               ariaLabel={
                 isTokenError
                   ? "Configure GitHub token to see issues"
-                  : `${issueCount ?? "—"} open issues${
+                  : `${issueDisplayCount ?? "—"} open issues${
                       showIssuesChip ? " (new since last view)" : ""
                     }${freshnessSuffix(freshnessLevel, lastUpdated, now)}`
               }
@@ -646,7 +687,7 @@ export const GitHubStatsToolbarButton = memo(
                   ? "Configure GitHub token to see issues"
                   : freshnessLevel === "fresh"
                     ? "Browse GitHub Issues"
-                    : `${issueCount ?? "—"} open issues${freshnessSuffix(freshnessLevel, lastUpdated, now)}`
+                    : `${issueDisplayCount ?? "—"} open issues${freshnessSuffix(freshnessLevel, lastUpdated, now)}`
               }
               icon={CircleDot}
               iconClassName={isTokenError ? "text-muted-foreground" : "text-pr-open"}
@@ -667,6 +708,7 @@ export const GitHubStatsToolbarButton = memo(
                     }}
                     initialCount={stats?.issueCount}
                     onFreshFetch={handleListFreshFetch}
+                    onCountUpdate={handleIssueListCountUpdate}
                   />
                 ) : (
                   <Suspense
@@ -688,6 +730,7 @@ export const GitHubStatsToolbarButton = memo(
                       }}
                       initialCount={stats?.issueCount}
                       onFreshFetch={handleListFreshFetch}
+                      onCountUpdate={handleIssueListCountUpdate}
                     />
                   </Suspense>
                 )
@@ -742,12 +785,13 @@ export const GitHubStatsToolbarButton = memo(
               buttonRef={prsButtonRef}
               open={prsOpen}
               count={prCount}
+              displayCount={prDisplayCount}
               animKey={prAnimKey}
               testId="github-stat-pill-prs"
               ariaLabel={
                 isTokenError
                   ? "Configure GitHub token to see pull requests"
-                  : `${prCount ?? "—"} open pull requests${
+                  : `${prDisplayCount ?? "—"} open pull requests${
                       showPrsChip ? " (new since last view)" : ""
                     }${freshnessSuffix(freshnessLevel, lastUpdated, now)}`
               }
@@ -756,7 +800,7 @@ export const GitHubStatsToolbarButton = memo(
                   ? "Configure GitHub token to see pull requests"
                   : freshnessLevel === "fresh"
                     ? "Browse GitHub Pull Requests"
-                    : `${prCount ?? "—"} open PRs${freshnessSuffix(freshnessLevel, lastUpdated, now)}`
+                    : `${prDisplayCount ?? "—"} open PRs${freshnessSuffix(freshnessLevel, lastUpdated, now)}`
               }
               icon={GitPullRequest}
               iconClassName={isTokenError ? "text-muted-foreground" : "text-pr-merged"}
@@ -777,6 +821,7 @@ export const GitHubStatsToolbarButton = memo(
                     }}
                     initialCount={stats?.prCount}
                     onFreshFetch={handleListFreshFetch}
+                    onCountUpdate={handlePrListCountUpdate}
                   />
                 ) : (
                   <Suspense
@@ -794,6 +839,7 @@ export const GitHubStatsToolbarButton = memo(
                       }}
                       initialCount={stats?.prCount}
                       onFreshFetch={handleListFreshFetch}
+                      onCountUpdate={handlePrListCountUpdate}
                     />
                   </Suspense>
                 )

--- a/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshFetch.test.tsx
+++ b/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshFetch.test.tsx
@@ -281,9 +281,9 @@ describe("GitHubStatsToolbarButton list-count badge wiring", () => {
   });
 
   it("uses the display count in the issue + PR aria-labels and tooltips", () => {
-    expect(source).toContain("${issueDisplayCount ?? \"—\"} open issues");
-    expect(source).toContain("${prDisplayCount ?? \"—\"} open pull requests");
-    expect(source).toContain("${prDisplayCount ?? \"—\"} open PRs");
+    expect(source).toContain('${issueDisplayCount ?? "—"} open issues');
+    expect(source).toContain('${prDisplayCount ?? "—"} open pull requests');
+    expect(source).toContain('${prDisplayCount ?? "—"} open PRs');
   });
 
   it("resets the list counts on project switch (lastUpdated → null)", () => {

--- a/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshFetch.test.tsx
+++ b/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshFetch.test.tsx
@@ -215,8 +215,83 @@ describe("GitHubStatsToolbarButton corner activity chip wiring", () => {
 
   it("clears both chip pulses on project switch alongside the count refs", () => {
     const effectStart = source.indexOf("if (statsLoading || statsError)");
-    const slice = source.slice(effectStart, effectStart + 1500);
+    const slice = source.slice(effectStart, effectStart + 2000);
     expect(slice).toContain("setIssuesPulseAt(null)");
     expect(slice).toContain("setPrsPulseAt(null)");
+  });
+});
+
+/**
+ * Badge count bound to the dropdown's loaded items (issue #9693).
+ *
+ * The toolbar badge used to render the stats query's `totalCount`, which can
+ * exceed the first page the dropdown actually lists. The fix threads an
+ * `onCountUpdate(count, hasMore)` callback from each `GitHubResourceList` and
+ * derives a display value (`20+` when paginated) that binds the badge to what
+ * the dropdown shows. The numeric `count` prop stays on the stats path so the
+ * digit-pulse delta detection is unaffected.
+ */
+describe("GitHubStatsToolbarButton list-count badge wiring", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(TOOLBAR_PATH, "utf-8");
+  });
+
+  it("declares list-count + has-more state for issues and PRs", () => {
+    expect(source).toMatch(
+      /\[issueListCount,\s*setIssueListCount\]\s*=\s*useState<number\s*\|\s*null>\(null\)/
+    );
+    expect(source).toMatch(/\[issueListHasMore,\s*setIssueListHasMore\]\s*=\s*useState\(false\)/);
+    expect(source).toMatch(
+      /\[prListCount,\s*setPrListCount\]\s*=\s*useState<number\s*\|\s*null>\(null\)/
+    );
+    expect(source).toMatch(/\[prListHasMore,\s*setPrListHasMore\]\s*=\s*useState\(false\)/);
+  });
+
+  it("derives a truncated display count only when more pages exist", () => {
+    // issueDisplayCount: list count wins once loaded; suffixed with "+" when
+    // hasMore, otherwise the exact count; falls back to the stats total before
+    // the dropdown loads.
+    expect(source).toMatch(
+      /issueDisplayCount[\s\S]{0,160}?issueListCount\s*!==\s*null[\s\S]{0,120}?issueListHasMore[\s\S]{0,60}?`\$\{issueListCount\}\+`[\s\S]{0,80}?:\s*issueCount/
+    );
+    expect(source).toMatch(
+      /prDisplayCount[\s\S]{0,160}?prListCount\s*!==\s*null[\s\S]{0,120}?prListHasMore[\s\S]{0,60}?`\$\{prListCount\}\+`[\s\S]{0,80}?:\s*prCount/
+    );
+  });
+
+  it("passes displayCount to the issue and PR pills", () => {
+    expect(source).toContain("displayCount={issueDisplayCount}");
+    expect(source).toContain("displayCount={prDisplayCount}");
+  });
+
+  it("threads onCountUpdate to all four list instances (issue + PR × eager + lazy)", () => {
+    const issueMatches = source.match(/onCountUpdate=\{handleIssueListCountUpdate\}/g);
+    const prMatches = source.match(/onCountUpdate=\{handlePrListCountUpdate\}/g);
+    expect(issueMatches?.length).toBe(2);
+    expect(prMatches?.length).toBe(2);
+  });
+
+  it("keeps the numeric count prop on the stats path for animation deltas", () => {
+    // The digit-pulse compares raw stats counts, so the pill's `count` prop
+    // must stay numeric (issueCount/prCount), not the display string.
+    expect(source).toContain("count={issueCount}");
+    expect(source).toContain("count={prCount}");
+  });
+
+  it("uses the display count in the issue + PR aria-labels and tooltips", () => {
+    expect(source).toContain("${issueDisplayCount ?? \"—\"} open issues");
+    expect(source).toContain("${prDisplayCount ?? \"—\"} open pull requests");
+    expect(source).toContain("${prDisplayCount ?? \"—\"} open PRs");
+  });
+
+  it("resets the list counts on project switch (lastUpdated → null)", () => {
+    const effectStart = source.indexOf("if (statsLoading || statsError)");
+    const slice = source.slice(effectStart, effectStart + 2000);
+    expect(slice).toContain("setIssueListCount(null)");
+    expect(slice).toContain("setIssueListHasMore(false)");
+    expect(slice).toContain("setPrListCount(null)");
+    expect(slice).toContain("setPrListHasMore(false)");
   });
 });


### PR DESCRIPTION
## Summary

The badge showing open PR and issue counts in the toolbar was sourcing its number from a separate stats query that returns the full server-side total. The dropdown list only loads the first 20 items, so the badge routinely showed a higher number than the list — and only corrected itself once a background revalidation landed.

This fix binds the badge to what the dropdown actually loads. It shows `20+` when more pages exist and the exact count once everything is loaded. The stats query still runs as a fallback before the first list fetch resolves.

Resolves #9693

## Changes

- `useGitHubResourceListSWR` gains an `onCountUpdate(count, hasMore)` callback fired on cold-mount and revalidation fetches, gated to the open filter so Closed/Merged tabs can't affect the open-count badge
- `GitHubResourceList` forwards `onCountUpdate` down to the hook
- `GitHubStatsToolbarButton` holds per-type list counts, derives the display value (`20+` when paginated, exact count otherwise, stats fallback before first load), threads `onCountUpdate` to all four list instances, and resets on project switch; `aria-label` and tooltip update accordingly
- `GitHubStatPill` gains a `displayCount` prop so the pill can show `20+` while keeping the numeric count for the digit-pulse animation

## Testing

Extended `GitHubStatsToolbarButton.freshFetch.test.tsx` and `GitHubResourceList.swr.test.tsx` to cover cold-mount and revalidation firing, and to confirm append fetches, searches, and closed-filter fetches do not fire the callback. 119 tests pass. `npm run check` clean (typecheck, lint, format, IPC/channel/confirm guards, build).