### PR TITLE
feat(worktree): show GitHub avatars in PR/issue tooltip metadata

### DIFF
--- a/src/components/Worktree/WorktreeCard/GitHubTooltipContent.tsx
+++ b/src/components/Worktree/WorktreeCard/GitHubTooltipContent.tsx
@@ -1,5 +1,5 @@
 import type { GitHubUser, IssueTooltipData, PRTooltipData } from "@shared/types/github";
-import { Calendar, KeyRound } from "lucide-react";
+import { Calendar, KeyRound, PenLine, UserCheck } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Avatar } from "@/components/ui/Avatar";
 
@@ -42,15 +42,19 @@ function GitHubAvatar({
   );
 }
 
-// Assignee metadata cell. One assignee → avatar + login (mirrors the author
-// row). Two or more → an overlapping avatar stack capped at 3 with a `+N`
-// overflow; the stack is aria-hidden and an sr-only sentence names everyone,
-// while each visible avatar exposes its login on hover via `title`.
+// Assignee metadata cell. A `UserCheck` glyph marks the role (vs the author
+// row's `PenLine`) so creator and assignee read apart at a glance. One assignee
+// → glyph + avatar + login. Two or more → an overlapping avatar stack capped at
+// 3 with a `+N` overflow; the stack is aria-hidden (each avatar exposes its
+// login on hover via a native `title`, which survives the app-level
+// `disableHoverableContent` provider) and an sr-only sentence names everyone.
 function AssigneeMeta({ assignees }: { assignees: GitHubUser[] }) {
   if (assignees.length === 1) {
     return (
       <span className="flex items-center gap-1">
+        <UserCheck className="w-3 h-3 shrink-0" aria-hidden="true" />
         <GitHubAvatar user={assignees[0]!} sizeClass="w-3.5 h-3.5" urlSize={28} />
+        <span className="sr-only">Assigned to </span>
         {assignees[0]!.login}
       </span>
     );
@@ -61,17 +65,18 @@ function AssigneeMeta({ assignees }: { assignees: GitHubUser[] }) {
 
   return (
     <span className="flex items-center gap-1">
+      <UserCheck className="w-3 h-3 shrink-0" aria-hidden="true" />
       <span className="flex items-center -space-x-1" aria-hidden="true">
         {shown.map((user, i) => (
           <span
             key={user.login}
+            title={user.login}
             className="relative inline-flex rounded-full"
             style={{ zIndex: shown.length - i }}
           >
             <Avatar
               src={withAvatarSize(user.avatarUrl, 24)}
               alt=""
-              title={user.login}
               className="w-3 h-3 shrink-0 rounded-full ring-2 ring-[var(--color-surface-sidebar)]"
             />
           </span>
@@ -158,7 +163,9 @@ export function IssueTooltipContent({ data }: IssueTooltipContentProps) {
 
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-daintree-text/50">
         <span className="flex items-center gap-1">
+          <PenLine className="w-3 h-3 shrink-0" aria-hidden="true" />
           <GitHubAvatar user={data.author} sizeClass="w-3.5 h-3.5" urlSize={28} />
+          <span className="sr-only">Created by </span>
           {data.author.login}
         </span>
 
@@ -225,7 +232,9 @@ export function PRTooltipContent({ data }: PRTooltipContentProps) {
 
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-daintree-text/50">
         <span className="flex items-center gap-1">
+          <PenLine className="w-3 h-3 shrink-0" aria-hidden="true" />
           <GitHubAvatar user={data.author} sizeClass="w-3.5 h-3.5" urlSize={28} />
+          <span className="sr-only">Created by </span>
           {data.author.login}
         </span>
 

--- a/src/components/Worktree/WorktreeCard/GitHubTooltipContent.tsx
+++ b/src/components/Worktree/WorktreeCard/GitHubTooltipContent.tsx
@@ -1,6 +1,7 @@
-import type { IssueTooltipData, PRTooltipData } from "@shared/types/github";
-import { User, Users, Calendar, KeyRound } from "lucide-react";
+import type { GitHubUser, IssueTooltipData, PRTooltipData } from "@shared/types/github";
+import { Calendar, KeyRound } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Avatar } from "@/components/ui/Avatar";
 
 function formatDate(dateString: string): string {
   const date = new Date(dateString);
@@ -9,6 +10,77 @@ function formatDate(dateString: string): string {
     day: "numeric",
     year: "numeric",
   });
+}
+
+// GitHub's avatar CDN honours a `?s=` pixel size. Request 2× the rendered size
+// for crisp HiDPI, replacing any existing `s=` so we never double up the param.
+function withAvatarSize(url: string | undefined, size: number): string {
+  if (!url) return "";
+  if (/[?&]s=\d+/.test(url)) {
+    return url.replace(/([?&])s=\d+/, `$1s=${size}`);
+  }
+  return `${url}${url.includes("?") ? "&" : "?"}s=${size}`;
+}
+
+// Author / single-assignee avatar: the login renders as adjacent text, so the
+// image is decorative (`alt=""`) and carries no redundant hover title.
+function GitHubAvatar({
+  user,
+  sizeClass,
+  urlSize,
+}: {
+  user: GitHubUser;
+  sizeClass: string;
+  urlSize: number;
+}) {
+  return (
+    <Avatar
+      src={withAvatarSize(user.avatarUrl, urlSize)}
+      alt=""
+      className={cn(sizeClass, "shrink-0")}
+    />
+  );
+}
+
+// Assignee metadata cell. One assignee → avatar + login (mirrors the author
+// row). Two or more → an overlapping avatar stack capped at 3 with a `+N`
+// overflow; the stack is aria-hidden and an sr-only sentence names everyone,
+// while each visible avatar exposes its login on hover via `title`.
+function AssigneeMeta({ assignees }: { assignees: GitHubUser[] }) {
+  if (assignees.length === 1) {
+    return (
+      <span className="flex items-center gap-1">
+        <GitHubAvatar user={assignees[0]!} sizeClass="w-3.5 h-3.5" urlSize={28} />
+        {assignees[0]!.login}
+      </span>
+    );
+  }
+
+  const shown = assignees.slice(0, 3);
+  const overflow = assignees.length - shown.length;
+
+  return (
+    <span className="flex items-center gap-1">
+      <span className="flex items-center -space-x-1" aria-hidden="true">
+        {shown.map((user, i) => (
+          <span
+            key={user.login}
+            className="relative inline-flex rounded-full"
+            style={{ zIndex: shown.length - i }}
+          >
+            <Avatar
+              src={withAvatarSize(user.avatarUrl, 24)}
+              alt=""
+              title={user.login}
+              className="w-3 h-3 shrink-0 rounded-full ring-2 ring-[var(--color-surface-sidebar)]"
+            />
+          </span>
+        ))}
+      </span>
+      {overflow > 0 && <span aria-hidden="true">+{overflow}</span>}
+      <span className="sr-only">Assigned to {assignees.map((u) => u.login).join(", ")}</span>
+    </span>
+  );
 }
 
 export function TooltipLoading() {
@@ -86,18 +158,11 @@ export function IssueTooltipContent({ data }: IssueTooltipContentProps) {
 
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-daintree-text/50">
         <span className="flex items-center gap-1">
-          <User className="w-3 h-3" />
+          <GitHubAvatar user={data.author} sizeClass="w-3.5 h-3.5" urlSize={28} />
           {data.author.login}
         </span>
 
-        {data.assignees.length > 0 && (
-          <span className="flex items-center gap-1">
-            <Users className="w-3 h-3" />
-            {data.assignees.length === 1
-              ? data.assignees[0]!.login
-              : `${data.assignees.length} assignees`}
-          </span>
-        )}
+        {data.assignees.length > 0 && <AssigneeMeta assignees={data.assignees} />}
 
         <span className="flex items-center gap-1">
           <Calendar className="w-3 h-3" />
@@ -160,18 +225,11 @@ export function PRTooltipContent({ data }: PRTooltipContentProps) {
 
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-daintree-text/50">
         <span className="flex items-center gap-1">
-          <User className="w-3 h-3" />
+          <GitHubAvatar user={data.author} sizeClass="w-3.5 h-3.5" urlSize={28} />
           {data.author.login}
         </span>
 
-        {data.assignees.length > 0 && (
-          <span className="flex items-center gap-1">
-            <Users className="w-3 h-3" />
-            {data.assignees.length === 1
-              ? data.assignees[0]!.login
-              : `${data.assignees.length} assignees`}
-          </span>
-        )}
+        {data.assignees.length > 0 && <AssigneeMeta assignees={data.assignees} />}
 
         <span className="flex items-center gap-1">
           <Calendar className="w-3 h-3" />

--- a/src/components/Worktree/WorktreeCard/__tests__/GitHubTooltipContent.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/GitHubTooltipContent.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { GitHubUser, IssueTooltipData, PRTooltipData } from "@shared/types/github";
+
+import { IssueTooltipContent, PRTooltipContent } from "../GitHubTooltipContent";
+
+// Avatar wraps in a Radix tooltip when `title` is set (the assignee stack). Stub
+// it so the stacked avatars render without a TooltipProvider in the test tree.
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+function user(
+  login: string,
+  avatarUrl = `https://avatars.githubusercontent.com/u/${login}`
+): GitHubUser {
+  return { login, avatarUrl };
+}
+
+const baseIssue: IssueTooltipData = {
+  number: 42,
+  title: "Something is broken",
+  bodyExcerpt: "",
+  state: "OPEN",
+  createdAt: "2025-06-15T12:00:00Z",
+  author: user("octocat"),
+  assignees: [],
+  labels: [],
+};
+
+function imgSrcs(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll("img")).map((img) => img.getAttribute("src") ?? "");
+}
+
+describe("GitHubTooltipContent avatars", () => {
+  it("requests a 2x avatar size, appending to a URL with no query string", () => {
+    const { container } = render(<IssueTooltipContent data={baseIssue} />);
+    const src = imgSrcs(container)[0]!;
+    expect(src).toBe("https://avatars.githubusercontent.com/u/octocat?s=28");
+  });
+
+  it("preserves an existing query string when adding the size param", () => {
+    const data = {
+      ...baseIssue,
+      author: user("octocat", "https://avatars.githubusercontent.com/u/1?v=4"),
+    };
+    const { container } = render(<IssueTooltipContent data={data} />);
+    const src = imgSrcs(container)[0]!;
+    expect(src).toContain("v=4");
+    expect(src).toContain("s=28");
+    expect(src.startsWith("https://avatars.githubusercontent.com/u/1?")).toBe(true);
+    // Single query separator — never a second `?`.
+    expect(src.indexOf("?")).toBe(src.lastIndexOf("?"));
+  });
+
+  it("replaces an existing s= param rather than duplicating it", () => {
+    const data = {
+      ...baseIssue,
+      author: user("octocat", "https://avatars.githubusercontent.com/u/1?s=40&v=4"),
+    };
+    const { container } = render(<IssueTooltipContent data={data} />);
+    const src = imgSrcs(container)[0]!;
+    expect(src).toContain("s=28");
+    expect(src).not.toContain("s=40");
+    expect(src.match(/s=/g)).toHaveLength(1);
+  });
+
+  it("renders the author login next to an avatar image", () => {
+    const { container } = render(<IssueTooltipContent data={baseIssue} />);
+    expect(screen.getByText("octocat")).toBeDefined();
+    expect(container.querySelectorAll("img")).toHaveLength(1);
+  });
+
+  it("renders a single assignee as avatar + login", () => {
+    const data = { ...baseIssue, assignees: [user("alice")] };
+    const { container } = render(<IssueTooltipContent data={data} />);
+    expect(screen.getByText("alice")).toBeDefined();
+    // Author avatar + assignee avatar.
+    expect(container.querySelectorAll("img")).toHaveLength(2);
+  });
+
+  it("caps the assignee stack at three avatars with a +N overflow", () => {
+    const data = {
+      ...baseIssue,
+      assignees: [user("alice"), user("bob"), user("carol"), user("dave")],
+    };
+    const { container } = render(<IssueTooltipContent data={data} />);
+    // Author (1) + three stacked assignees (3) = 4 images; the 4th assignee
+    // collapses into the overflow count.
+    expect(container.querySelectorAll("img")).toHaveLength(4);
+    expect(screen.getByText("+1")).toBeDefined();
+  });
+
+  it("names every assignee for screen readers even when avatars overflow", () => {
+    const data = {
+      ...baseIssue,
+      assignees: [user("alice"), user("bob"), user("carol"), user("dave")],
+    };
+    render(<IssueTooltipContent data={data} />);
+    expect(screen.getByText("Assigned to alice, bob, carol, dave")).toBeDefined();
+  });
+
+  it("handles a missing avatar URL without crashing", () => {
+    const data = { ...baseIssue, author: user("ghost", "") };
+    const { container } = render(<IssueTooltipContent data={data} />);
+    expect(imgSrcs(container)[0]).toBe("");
+    expect(screen.getByText("ghost")).toBeDefined();
+  });
+
+  it("applies the same avatar treatment to PR tooltips", () => {
+    const prData: PRTooltipData = {
+      number: 7,
+      title: "Add the thing",
+      bodyExcerpt: "",
+      state: "OPEN",
+      isDraft: false,
+      createdAt: "2025-06-15T12:00:00Z",
+      author: user("octocat"),
+      assignees: [user("alice"), user("bob")],
+      labels: [],
+    };
+    const { container } = render(<PRTooltipContent data={prData} />);
+    expect(screen.getByText("octocat")).toBeDefined();
+    // Author + two stacked assignees.
+    expect(container.querySelectorAll("img")).toHaveLength(3);
+    expect(screen.getByText("Assigned to alice, bob")).toBeDefined();
+  });
+});

--- a/src/components/Worktree/WorktreeCard/__tests__/GitHubTooltipContent.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/GitHubTooltipContent.test.tsx
@@ -68,6 +68,31 @@ describe("GitHubTooltipContent avatars", () => {
     expect(src.match(/s=/g)).toHaveLength(1);
   });
 
+  it("distinguishes the creator from the assignee role", () => {
+    const data = { ...baseIssue, assignees: [user("alice")] };
+    render(<IssueTooltipContent data={data} />);
+    // Distinct role labels mean the two chips are not interchangeable, even
+    // when the same person is both author and assignee.
+    expect(screen.getByText("Created by")).toBeDefined();
+    expect(screen.getByText("Assigned to")).toBeDefined();
+  });
+
+  it("requests smaller avatars for the stacked assignees than for the author", () => {
+    const data = {
+      ...baseIssue,
+      assignees: [user("alice"), user("bob"), user("carol"), user("dave")],
+    };
+    const { container } = render(<IssueTooltipContent data={data} />);
+    const srcs = imgSrcs(container);
+    // Author avatar renders first at the larger size; the stack follows at 2x
+    // of the smaller rendered size.
+    expect(srcs[0]).toContain("s=28");
+    expect(srcs.slice(1)).toHaveLength(3);
+    for (const src of srcs.slice(1)) {
+      expect(src).toContain("s=24");
+    }
+  });
+
   it("renders the author login next to an avatar image", () => {
     const { container } = render(<IssueTooltipContent data={baseIssue} />);
     expect(screen.getByText("octocat")).toBeDefined();


### PR DESCRIPTION
## Summary

- Replaces the generic `User`/`Users` Lucide icons in the worktree sidebar's PR/issue hover tooltips with real GitHub avatars and a clear creator-vs-assignee distinction
- Author chip: `PenLine` glyph + avatar + login; assignee chip: `UserCheck` glyph + avatar + login; multiple assignees collapse into an overlapping stack (capped at 3, +N overflow)
- Reuses the existing `Avatar` component and the `GitHubUser.avatarUrl` already on the tooltip data — no new deps, no type changes

Resolves #9695

## Changes

- `GitHubTooltipContent.tsx` — replaced static icon rows with avatar chips; added `withAvatarSize` helper that appends a `?s=` param to the GitHub CDN URL for 2x fetches; stacked-avatar layout for multi-assignee case
- Accessibility: decorative `alt=""` on avatars, `sr-only` "Created by"/"Assigned to {logins}" role labels, native `title` on stacked avatars (survives the app's `disableHoverableContent` tooltip provider)
- 11 component tests added covering single/multi-assignee, overflow count, avatar loading states, and sr-only labels

## Testing

`npm run check` clean. All 11 new tests passing alongside the existing suite.