### PR TITLE
fix(worktree): tighten PR/issue tooltip metadata layout and align badges

### DIFF
--- a/src/components/Worktree/WorktreeCard/GitHubTooltipContent.tsx
+++ b/src/components/Worktree/WorktreeCard/GitHubTooltipContent.tsx
@@ -104,7 +104,7 @@ function freshnessItem(
     case "rate-limit": {
       let label = "rate limited";
       const { rateLimitResetAt, now } = freshness;
-      if (rateLimitResetAt != null && rateLimitResetAt > now) {
+      if (rateLimitResetAt != null && Number.isFinite(rateLimitResetAt) && rateLimitResetAt > now) {
         const retryTime = new Intl.DateTimeFormat("en-US", {
           hour: "numeric",
           minute: "2-digit",

--- a/src/components/Worktree/WorktreeCard/GitHubTooltipContent.tsx
+++ b/src/components/Worktree/WorktreeCard/GitHubTooltipContent.tsx
@@ -1,5 +1,7 @@
 import type { GitHubUser, IssueTooltipData, PRTooltipData } from "@shared/types/github";
-import { Calendar, KeyRound, PenLine, UserCheck } from "lucide-react";
+import { Calendar, KeyRound, PenLine, UserCheck, Clock, CirclePause } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { BadgeFreshnessCause } from "@/components/Layout/FreshnessUtils";
 import { cn } from "@/lib/utils";
 import { Avatar } from "@/components/ui/Avatar";
 
@@ -88,6 +90,60 @@ function AssigneeMeta({ assignees }: { assignees: GitHubUser[] }) {
   );
 }
 
+export interface TooltipFreshness {
+  cause: BadgeFreshnessCause | undefined;
+  now: number;
+  rateLimitResetAt?: number | null;
+}
+
+function freshnessItem(
+  freshness: TooltipFreshness | undefined
+): { Icon: LucideIcon; label: string } | null {
+  if (!freshness) return null;
+  switch (freshness.cause) {
+    case "rate-limit": {
+      let label = "rate limited";
+      const { rateLimitResetAt, now } = freshness;
+      if (rateLimitResetAt != null && rateLimitResetAt > now) {
+        const retryTime = new Intl.DateTimeFormat("en-US", {
+          hour: "numeric",
+          minute: "2-digit",
+        }).format(new Date(rateLimitResetAt));
+        label += `, retry at ${retryTime}`;
+      }
+      return { Icon: Clock, label };
+    }
+    case "circuit-breaker":
+      return { Icon: CirclePause, label: "data may be stale — PR detection paused" };
+    default:
+      return null;
+  }
+}
+
+/**
+ * Freshness status as a metadata-row item: a small Lucide icon + label that
+ * matches the author/assignee/date entries. Folds the old `·`-prefixed block
+ * line (#9696) onto the metadata row. Rendered standalone with a `className`
+ * (e.g. `mt-1`) by the badges when the tooltip body has no data row to host it.
+ */
+export function FreshnessMetaItem({
+  freshness,
+  className,
+}: {
+  freshness?: TooltipFreshness;
+  className?: string;
+}) {
+  const item = freshnessItem(freshness);
+  if (!item) return null;
+  const { Icon, label } = item;
+  return (
+    <span className={cn("flex items-center gap-1", className)}>
+      <Icon className="w-3 h-3 shrink-0" aria-hidden="true" />
+      {label}
+    </span>
+  );
+}
+
 export function TooltipLoading() {
   // Doherty-gated skeleton: `animate-pulse-delayed` keeps the bars invisible
   // for the first 400ms, so a fast cache-warm response (the common case after
@@ -145,9 +201,10 @@ function LabelBadge({ name, color }: LabelBadgeProps) {
 
 interface IssueTooltipContentProps {
   data: IssueTooltipData;
+  freshness?: TooltipFreshness;
 }
 
-export function IssueTooltipContent({ data }: IssueTooltipContentProps) {
+export function IssueTooltipContent({ data, freshness }: IssueTooltipContentProps) {
   const stateColor = data.state === "OPEN" ? "text-pr-open" : "text-pr-merged";
 
   return (
@@ -175,6 +232,8 @@ export function IssueTooltipContent({ data }: IssueTooltipContentProps) {
           <Calendar className="w-3 h-3" />
           {formatDate(data.createdAt)}
         </span>
+
+        <FreshnessMetaItem freshness={freshness} />
       </div>
 
       {data.labels.length > 0 && (
@@ -195,9 +254,10 @@ export function IssueTooltipContent({ data }: IssueTooltipContentProps) {
 
 interface PRTooltipContentProps {
   data: PRTooltipData;
+  freshness?: TooltipFreshness;
 }
 
-export function PRTooltipContent({ data }: PRTooltipContentProps) {
+export function PRTooltipContent({ data, freshness }: PRTooltipContentProps) {
   const stateColor =
     data.state === "MERGED"
       ? "text-pr-merged"
@@ -244,6 +304,8 @@ export function PRTooltipContent({ data }: PRTooltipContentProps) {
           <Calendar className="w-3 h-3" />
           {formatDate(data.createdAt)}
         </span>
+
+        <FreshnessMetaItem freshness={freshness} />
       </div>
 
       {data.labels.length > 0 && (

--- a/src/components/Worktree/WorktreeCard/IssueBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/IssueBadge.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { CircleDot, CloudOff } from "lucide-react";
 import { useDohertyGate } from "@/hooks/useDeferredLoading";
@@ -6,8 +6,14 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import { useIssueTooltip } from "@/hooks/useGitHubTooltip";
 import { useGitHubBadgeTooltip } from "./hooks/useGitHubBadgeTooltip";
 import { useGitHubBadgeFreshness } from "./hooks/useGitHubBadgeFreshness";
-import { freshnessClass, badgeFreshnessSuffix } from "@/components/Layout/FreshnessUtils";
-import { IssueTooltipContent, TooltipLoading, TokenMissingTooltip } from "./GitHubTooltipContent";
+import { freshnessClass } from "@/components/Layout/FreshnessUtils";
+import {
+  IssueTooltipContent,
+  TooltipLoading,
+  TokenMissingTooltip,
+  FreshnessMetaItem,
+  type TooltipFreshness,
+} from "./GitHubTooltipContent";
 
 interface IssueBadgeProps {
   issueNumber: number;
@@ -64,10 +70,7 @@ export function IssueBadge({
   const { freshnessLevel, freshnessCause, rateLimitResetAt, now } =
     useGitHubBadgeFreshness("issue");
 
-  const freshnessSuffixStr = useMemo(
-    () => badgeFreshnessSuffix(freshnessCause, now, rateLimitResetAt),
-    [freshnessCause, rateLimitResetAt, now]
-  );
+  const freshness: TooltipFreshness = { cause: freshnessCause, now, rateLimitResetAt };
 
   const showPausedGlyph = freshnessCause === "rate-limit" && !missingToken;
 
@@ -79,9 +82,9 @@ export function IssueBadge({
           onClick={handleClick}
           data-no-dnd
           className={cn(
-            "flex items-center gap-1.5 text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent min-w-0",
+            "flex items-center gap-1 text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent min-w-0",
             freshnessClass(freshnessLevel),
-            isHeadline ? "text-[13px]" : "text-xs"
+            isHeadline ? "gap-1.5 text-[13px]" : "text-xs"
           )}
           aria-disabled={!isActive || undefined}
           aria-label={
@@ -133,14 +136,14 @@ export function IssueBadge({
         ) : showTooltipLoading ? (
           <TooltipLoading />
         ) : data ? (
-          <IssueTooltipContent data={data} />
+          <IssueTooltipContent data={data} freshness={freshness} />
         ) : error ? (
           <span className="text-xs text-text-secondary">Failed to load issue details</span>
         ) : (
           <span className="text-xs text-text-secondary">Issue #{issueNumber}</span>
         )}
-        {freshnessSuffixStr && (
-          <span className="block text-[11px] text-text-muted mt-1">{freshnessSuffixStr}</span>
+        {!data && (
+          <FreshnessMetaItem freshness={freshness} className="text-[11px] text-text-muted mt-1" />
         )}
       </TooltipContent>
     </Tooltip>

--- a/src/components/Worktree/WorktreeCard/PRBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/PRBadge.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { CloudOff, CornerDownRight, GitPullRequest } from "lucide-react";
 import type { CIStatus } from "@shared/types/forge";
@@ -8,8 +8,13 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import { usePRTooltip } from "@/hooks/useGitHubTooltip";
 import { useGitHubBadgeTooltip } from "./hooks/useGitHubBadgeTooltip";
 import { useGitHubBadgeFreshness } from "./hooks/useGitHubBadgeFreshness";
-import { badgeFreshnessSuffix } from "@/components/Layout/FreshnessUtils";
-import { PRTooltipContent, TooltipLoading, TokenMissingTooltip } from "./GitHubTooltipContent";
+import {
+  PRTooltipContent,
+  TooltipLoading,
+  TokenMissingTooltip,
+  FreshnessMetaItem,
+  type TooltipFreshness,
+} from "./GitHubTooltipContent";
 import { getCIStatusVisual } from "@/lib/worktreeCIStatus";
 
 interface PRBadgeProps {
@@ -108,10 +113,7 @@ export function PRBadge({
           ? " — PR detection paused"
           : "");
 
-  const freshnessSuffixStr = useMemo(
-    () => badgeFreshnessSuffix(freshnessCause, now, rateLimitResetAt),
-    [freshnessCause, rateLimitResetAt, now]
-  );
+  const freshness: TooltipFreshness = { cause: freshnessCause, now, rateLimitResetAt };
 
   return (
     <Tooltip open={isOpen} onOpenChange={handleOpenChange} delayDuration={300}>
@@ -199,14 +201,14 @@ export function PRBadge({
         ) : showTooltipLoading ? (
           <TooltipLoading />
         ) : data ? (
-          <PRTooltipContent data={data} />
+          <PRTooltipContent data={data} freshness={freshness} />
         ) : error ? (
           <span className="text-xs text-text-secondary">Failed to load PR details</span>
         ) : (
           <span className="text-xs text-text-secondary">PR #{prNumber}</span>
         )}
-        {freshnessSuffixStr && (
-          <span className="block text-[11px] text-text-muted mt-1">{freshnessSuffixStr}</span>
+        {!data && (
+          <FreshnessMetaItem freshness={freshness} className="text-[11px] text-text-muted mt-1" />
         )}
       </TooltipContent>
     </Tooltip>

--- a/src/components/Worktree/WorktreeCard/__tests__/GitHubTooltipContent.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/GitHubTooltipContent.test.tsx
@@ -154,3 +154,96 @@ describe("GitHubTooltipContent avatars", () => {
     expect(screen.getByText("Assigned to alice, bob")).toBeDefined();
   });
 });
+
+const issueData: IssueTooltipData = {
+  number: 42,
+  title: "Something is broken",
+  bodyExcerpt: "Steps to reproduce…",
+  state: "OPEN",
+  createdAt: "2026-01-02T00:00:00.000Z",
+  author: user("octocat"),
+  assignees: [],
+  labels: [],
+};
+
+const prData: PRTooltipData = {
+  number: 7,
+  title: "Fix the thing",
+  bodyExcerpt: "This fixes the thing.",
+  state: "OPEN",
+  isDraft: false,
+  createdAt: "2026-01-02T00:00:00.000Z",
+  author: user("octocat"),
+  assignees: [],
+  labels: [],
+};
+
+describe("IssueTooltipContent freshness item", () => {
+  it("renders no freshness item when freshness is absent", () => {
+    const { container } = render(<IssueTooltipContent data={issueData} />);
+    expect(container.querySelector(".lucide-clock")).toBeNull();
+    expect(container.querySelector(".lucide-circle-pause")).toBeNull();
+    expect(screen.queryByText(/rate limited/)).toBeNull();
+  });
+
+  it("renders no freshness item when the cause is undefined", () => {
+    const { container } = render(
+      <IssueTooltipContent data={issueData} freshness={{ cause: undefined, now: 1000 }} />
+    );
+    expect(container.querySelector(".lucide-clock")).toBeNull();
+    expect(container.querySelector(".lucide-circle-pause")).toBeNull();
+  });
+
+  it("folds a rate-limit cause onto the metadata row as a Clock + label", () => {
+    const { container } = render(
+      <IssueTooltipContent data={issueData} freshness={{ cause: "rate-limit", now: 1000 }} />
+    );
+    expect(container.querySelector(".lucide-clock")).toBeTruthy();
+    expect(screen.getByText(/^rate limited$/)).toBeTruthy();
+  });
+
+  it("includes the retry time when a future reset is provided", () => {
+    const now = 1000;
+    const { container } = render(
+      <IssueTooltipContent
+        data={issueData}
+        freshness={{ cause: "rate-limit", now, rateLimitResetAt: now + 60_000 }}
+      />
+    );
+    expect(container.querySelector(".lucide-clock")).toBeTruthy();
+    expect(screen.getByText(/rate limited, retry at /)).toBeTruthy();
+  });
+
+  it("renders a circuit-breaker cause as a PauseCircle, not a Clock", () => {
+    const { container } = render(
+      <IssueTooltipContent data={issueData} freshness={{ cause: "circuit-breaker", now: 1000 }} />
+    );
+    expect(container.querySelector(".lucide-circle-pause")).toBeTruthy();
+    expect(container.querySelector(".lucide-clock")).toBeNull();
+    expect(screen.getByText(/data may be stale/)).toBeTruthy();
+  });
+});
+
+describe("PRTooltipContent freshness item", () => {
+  it("renders no freshness item when freshness is absent", () => {
+    const { container } = render(<PRTooltipContent data={prData} />);
+    expect(container.querySelector(".lucide-clock")).toBeNull();
+    expect(container.querySelector(".lucide-circle-pause")).toBeNull();
+  });
+
+  it("folds a rate-limit cause onto the metadata row as a Clock + label", () => {
+    const { container } = render(
+      <PRTooltipContent data={prData} freshness={{ cause: "rate-limit", now: 1000 }} />
+    );
+    expect(container.querySelector(".lucide-clock")).toBeTruthy();
+    expect(screen.getByText(/^rate limited$/)).toBeTruthy();
+  });
+
+  it("renders a circuit-breaker cause as a PauseCircle", () => {
+    const { container } = render(
+      <PRTooltipContent data={prData} freshness={{ cause: "circuit-breaker", now: 1000 }} />
+    );
+    expect(container.querySelector(".lucide-circle-pause")).toBeTruthy();
+    expect(screen.getByText(/data may be stale/)).toBeTruthy();
+  });
+});

--- a/src/components/Worktree/WorktreeCard/__tests__/GitHubTooltipContent.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/GitHubTooltipContent.test.tsx
@@ -214,6 +214,29 @@ describe("IssueTooltipContent freshness item", () => {
     expect(screen.getByText(/rate limited, retry at /)).toBeTruthy();
   });
 
+  it.each([
+    ["null", null],
+    ["past", 999],
+    ["equal to now", 1000],
+    ["non-finite", Number.POSITIVE_INFINITY],
+  ])("omits the retry time when reset is %s", (_label, rateLimitResetAt) => {
+    render(
+      <IssueTooltipContent
+        data={issueData}
+        freshness={{ cause: "rate-limit", now: 1000, rateLimitResetAt }}
+      />
+    );
+    expect(screen.getByText("rate limited")).toBeTruthy();
+    expect(screen.queryByText(/retry at/)).toBeNull();
+  });
+
+  it("renders a single freshness item — no duplicate when data is present", () => {
+    const { container } = render(
+      <IssueTooltipContent data={issueData} freshness={{ cause: "rate-limit", now: 1000 }} />
+    );
+    expect(container.querySelectorAll(".lucide-clock")).toHaveLength(1);
+  });
+
   it("renders a circuit-breaker cause as a PauseCircle, not a Clock", () => {
     const { container } = render(
       <IssueTooltipContent data={issueData} freshness={{ cause: "circuit-breaker", now: 1000 }} />

--- a/src/components/Worktree/WorktreeCard/__tests__/PRBadge.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/PRBadge.test.tsx
@@ -105,13 +105,30 @@ describe("PRBadge freshness glyphs", () => {
     expect(button.querySelector(".lucide-cloud-off")).toBeNull();
   });
 
-  it("never shows a Clock glyph — plain age is no longer surfaced", () => {
+  it("never shows a Clock glyph on the badge button — plain age is no longer surfaced", () => {
     for (const cause of [undefined, "rate-limit", "circuit-breaker"] as const) {
       mockFreshnessCause = cause;
-      const { container, unmount } = renderBadge();
-      expect(container.querySelector(".lucide-clock")).toBeNull();
+      const { unmount } = renderBadge();
+      const button = screen.getByRole("button");
+      expect(button.querySelector(".lucide-clock")).toBeNull();
       unmount();
     }
+  });
+
+  it("surfaces the rate-limit freshness as a Clock-iconed tooltip line", () => {
+    mockFreshnessCause = "rate-limit";
+    renderBadge();
+
+    expect(document.querySelector(".lucide-clock")).toBeTruthy();
+    expect(screen.getAllByText(/rate limited/).length).toBeGreaterThan(0);
+  });
+
+  it("surfaces the circuit-breaker freshness with a PauseCircle, not a Clock", () => {
+    mockFreshnessCause = "circuit-breaker";
+    renderBadge();
+
+    expect(document.querySelector(".lucide-circle-pause")).toBeTruthy();
+    expect(document.querySelector(".lucide-clock")).toBeNull();
   });
 
   it("shows CloudOff when freshnessCause is rate-limit", () => {


### PR DESCRIPTION
Two layout fixes for the worktree sidebar PR and issue hover tooltips.

## Changes

**Freshness folded inline:** the freshness status (rate-limited / circuit-breaker paused) used to render on its own dotted line below the tooltip body. It now sits on the existing author/assignee/date metadata row as a matching small-icon + label item — `Clock` for rate-limit (with an optional "retry at H:MM" suffix), `CirclePause` for the paused circuit breaker. A shared `FreshnessMetaItem` in `GitHubTooltipContent` renders both the in-row item (when tooltip data is loaded) and the standalone line (loading / error / fallback states), so freshness stays visible in every state exactly as before.

**Tooltip alignment:** `IssueBadge`'s trigger gap was `gap-1.5` while `PRBadge` used `gap-1` (base) / `gap-1.5` (headline), so the issue tooltip anchored slightly further left. `IssueBadge` now mirrors `PRBadge`'s gap exactly, lining the two tooltips up.

## Testing

New `GitHubTooltipContent.test.tsx` covers folded freshness rendering: icon choice, retry-time suffix, null / past / equal / non-finite reset boundaries, single-render. `PRBadge.test.tsx` updated for the new in-tooltip `Clock` / `CirclePause`. 47 tests pass; typecheck / lint / format clean.

- [ ] PR tooltip rate-limited: `Clock` icon + "rate limited[, retry at ...]" inline on the metadata row, no separate line
- [ ] Issue/PR tooltip circuit-breaker: `CirclePause` icon + "data may be stale — PR detection paused" inline
- [ ] Issue and PR tooltips line up at the same horizontal offset
- [ ] Freshness still visible during loading / error / fallback tooltip states

Resolves #9696