### PR TITLE
fix(panels): stop Daintree Assistant overlay leaking into the grid

### DIFF
--- a/shared/types/__tests__/panel.test.ts
+++ b/shared/types/__tests__/panel.test.ts
@@ -3,8 +3,10 @@ import {
   isBuiltInPanelKind,
   isBrowserPanel,
   isDevPreviewPanel,
+  isGridPanelLocation,
   isPtyPanel,
   type PanelInstance,
+  type PanelLocation,
   type TerminalInstance,
 } from "../panel.js";
 import { BUILT_IN_PANEL_KINDS } from "../../config/panelKindRegistry.js";
@@ -31,6 +33,29 @@ describe("isBuiltInPanelKind", () => {
   it("is case-sensitive", () => {
     expect(isBuiltInPanelKind("Terminal")).toBe(false);
     expect(isBuiltInPanelKind("DEV-PREVIEW")).toBe(false);
+  });
+});
+
+describe("isGridPanelLocation", () => {
+  it("treats only grid and undefined as grid members", () => {
+    expect(isGridPanelLocation("grid")).toBe(true);
+    // Legacy panels persisted before the location field existed.
+    expect(isGridPanelLocation(undefined)).toBe(true);
+  });
+
+  it("excludes dock, overlay, trash, and background from the grid", () => {
+    expect(isGridPanelLocation("dock")).toBe(false);
+    // overlay = Daintree Assistant; must never be counted as a grid member (#9699).
+    expect(isGridPanelLocation("overlay")).toBe(false);
+    expect(isGridPanelLocation("trash")).toBe(false);
+    expect(isGridPanelLocation("background")).toBe(false);
+  });
+
+  it("classifies every PanelLocation value (no value silently defaults to grid)", () => {
+    const allLocations: PanelLocation[] = ["grid", "dock", "overlay", "trash", "background"];
+    const gridMembers = allLocations.filter((loc) => isGridPanelLocation(loc));
+    // Exactly one concrete location ("grid") is a grid member; the rest are not.
+    expect(gridMembers).toEqual(["grid"]);
   });
 });
 

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -22,6 +22,35 @@ export type PanelLocation = "grid" | "dock" | "overlay" | "trash" | "background"
 export type TabGroupLocation = "grid" | "dock";
 
 /**
+ * Maps every `PanelLocation` to whether a panel at that location is a member of
+ * the user-visible panel grid. `undefined` (legacy persisted panels written
+ * before the `location` field existed) is treated as grid.
+ *
+ * The `satisfies Record<PanelLocation, boolean>` annotation makes any future
+ * widening of `PanelLocation` a compile error here — forcing a placement
+ * decision for the new value instead of silently defaulting it into the grid
+ * (the root cause of issue #9699, where `"overlay"` leaked into grid filters).
+ */
+const GRID_MEMBER_BY_LOCATION = {
+  grid: true,
+  dock: false,
+  overlay: false,
+  trash: false,
+  background: false,
+} satisfies Record<PanelLocation, boolean>;
+
+/**
+ * Whether a panel at this location is a member of the user-visible panel grid.
+ *
+ * True only for `"grid"` and `undefined` (legacy panels). `"dock"`, `"overlay"`
+ * (Daintree Assistant), `"trash"`, and `"background"` are NOT grid members and
+ * must be excluded from grid fleet membership, counts, badges, and focus.
+ */
+export function isGridPanelLocation(location: PanelLocation | undefined): boolean {
+  return location === undefined || GRID_MEMBER_BY_LOCATION[location];
+}
+
+/**
  * Tab group - a collection of panels displayed as tabs
  *
  * INVARIANT: All panels in a group must have the same worktreeId as the group.

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -211,7 +211,8 @@ export function AgentButton({
         const p = state.panelsById[pid];
         if (!p || !isPtyPanel(p)) continue;
         if (getRuntimeOrBootAgentId(p) !== type) continue;
-        if (p.location === "trash" || p.location === "background") continue;
+        if (p.location === "trash" || p.location === "background" || p.location === "overlay")
+          continue;
         if (!ACTIVE_AGENT_STATES.has(p.agentState)) continue;
         if (!firstId) firstId = pid;
         states.push(p.agentState);

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -411,7 +411,14 @@ export function AgentTrayButton({
       // Runtime identity wins so a plain shell that starts Claude/Codex is
       // tracked under the same tray entry. Launch intent is only a boot-window
       // fallback before any detector result has committed.
-      if (!p || !isPtyPanel(p) || p.location === "trash" || p.location === "background") continue;
+      if (
+        !p ||
+        !isPtyPanel(p) ||
+        p.location === "trash" ||
+        p.location === "background" ||
+        p.location === "overlay"
+      )
+        continue;
       const agentId = getRuntimeOrBootAgentId(p);
       if (!agentId) continue;
       if (activeWorktreeId && p.worktreeId !== activeWorktreeId) continue;

--- a/src/components/Layout/useOverflowBadgeSeverity.ts
+++ b/src/components/Layout/useOverflowBadgeSeverity.ts
@@ -73,7 +73,14 @@ export function useOverflowBadgeSeverity(
       // meant to surface.
       for (const pid of panelIds) {
         const p = panelsById[pid];
-        if (!p || !isPtyPanel(p) || p.location === "trash" || p.location === "background") continue;
+        if (
+          !p ||
+          !isPtyPanel(p) ||
+          p.location === "trash" ||
+          p.location === "background" ||
+          p.location === "overlay"
+        )
+          continue;
         const agentId = getRuntimeOrBootAgentId(p);
         if (!agentId || !overflowedAgentSet.has(agentId)) continue;
         if (activeWorktreeId && p.worktreeId !== activeWorktreeId) continue;

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -1029,6 +1029,7 @@ function TerminalPaneComponent({
         t.id !== id &&
         t.location !== "trash" &&
         t.location !== "background" &&
+        t.location !== "overlay" &&
         (t.kind ? panelKindHasPty(t.kind) : true) &&
         (!isPtyPanel(t) || t.hasPty !== false)
       );

--- a/src/components/Terminal/__tests__/contentGridFleetPanels.test.ts
+++ b/src/components/Terminal/__tests__/contentGridFleetPanels.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { buildFleetPanels } from "../contentGridFleetPanels";
+import type { PanelLocation, PtyPanelData } from "@shared/types/panel";
+
+function makePanel(id: string, location: PanelLocation): PtyPanelData {
+  return { id, kind: "terminal", title: id, location } as PtyPanelData;
+}
+
+describe("buildFleetPanels", () => {
+  it("includes grid panels and excludes non-grid placements", () => {
+    const panels = {
+      g1: makePanel("g1", "grid"),
+      d1: makePanel("d1", "dock"),
+      o1: makePanel("o1", "overlay"),
+      t1: makePanel("t1", "trash"),
+      b1: makePanel("b1", "background"),
+    };
+    const order = ["g1", "d1", "o1", "t1", "b1"];
+    const armed = new Set(order);
+
+    const result = buildFleetPanels(order, armed, panels);
+
+    expect(result.map((p) => p.id)).toEqual(["g1"]);
+  });
+
+  it("never admits the overlay assistant into the fleet (#9699)", () => {
+    const panels = {
+      agent: makePanel("agent", "grid"),
+      assistant: makePanel("assistant", "overlay"),
+    };
+    const order = ["agent", "assistant"];
+
+    const result = buildFleetPanels(order, new Set(order), panels);
+
+    expect(result.map((p) => p.id)).toEqual(["agent"]);
+    expect(result.some((p) => p.id === "assistant")).toBe(false);
+  });
+
+  it("respects arm order and arm membership", () => {
+    const panels = {
+      a: makePanel("a", "grid"),
+      b: makePanel("b", "grid"),
+      c: makePanel("c", "grid"),
+    };
+    // c first in order, b not armed.
+    const result = buildFleetPanels(["c", "a", "b"], new Set(["c", "a"]), panels);
+
+    expect(result.map((p) => p.id)).toEqual(["c", "a"]);
+  });
+});

--- a/src/components/Terminal/contentGridFleetPanels.ts
+++ b/src/components/Terminal/contentGridFleetPanels.ts
@@ -1,5 +1,5 @@
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
-import type { PanelInstance } from "@shared/types/panel";
+import { isGridPanelLocation, type PanelInstance } from "@shared/types/panel";
 
 type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 
@@ -18,7 +18,7 @@ export function buildFleetPanels(
     if (!armedIds.has(id)) continue;
     const t = panelsById[id];
     if (!t) continue;
-    if (t.location === "trash" || t.location === "background" || t.location === "dock") continue;
+    if (!isGridPanelLocation(t.location)) continue;
     const narrowed = getNarrowPanel(panelsById, id);
     if (!narrowed) continue;
     result.push(narrowed);

--- a/src/hooks/useSendToAgentPalette.ts
+++ b/src/hooks/useSendToAgentPalette.ts
@@ -30,6 +30,7 @@ function hasSendTargets(sourceTerminalId: string | null): boolean {
       t.id !== sourceTerminalId &&
       t.location !== "trash" &&
       t.location !== "background" &&
+      t.location !== "overlay" &&
       isPtyPanel(t) &&
       t.hasPty !== false
     );
@@ -110,7 +111,8 @@ export function useSendToAgentPalette() {
       const t = panelsById[id];
       if (!t) continue;
       if (sourceId && t.id === sourceId) continue;
-      if (t.location === "trash" || t.location === "background") continue;
+      if (t.location === "trash" || t.location === "background" || t.location === "overlay")
+        continue;
       if (!isPtyPanel(t)) continue;
       if (t.hasPty === false) continue;
 

--- a/src/lib/terminalVisibility.ts
+++ b/src/lib/terminalVisibility.ts
@@ -23,6 +23,9 @@ export function isTerminalVisible(
   if (isInTrash(terminal.id)) return false;
   if (terminal.location === "trash") return false;
   if (terminal.location === "background") return false;
+  // Overlay panels (the Daintree Assistant) are never a member of the visible
+  // terminal set — counts, switchers, and waiting lists must skip them (#9699).
+  if (terminal.location === "overlay") return false;
   if (isPtyPanel(terminal) && terminal.excludeFromPersistence === true) return false;
   if (isTerminalOrphaned(terminal, worktreeIds)) return false;
   return true;

--- a/src/services/actions/definitions/terminalLayoutActions.ts
+++ b/src/services/actions/definitions/terminalLayoutActions.ts
@@ -290,6 +290,9 @@ export function registerTerminalLayoutActions(
           (t) =>
             t &&
             t.location !== "trash" &&
+            // Overlay panels (the Daintree Assistant) are not dock/grid members;
+            // including one would make `allDocked` permanently false (#9699).
+            t.location !== "overlay" &&
             (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined)
         );
       const allDocked = activeTerminals.every((t) => t!.location === "dock");

--- a/src/services/actions/definitions/worktreeSessionActions.ts
+++ b/src/services/actions/definitions/worktreeSessionActions.ts
@@ -71,7 +71,10 @@ export function registerWorktreeSessionActions(
         .map((id) => state.panelsById[id])
         .filter(
           (t): t is NonNullable<typeof t> =>
-            t != null && t.worktreeId === targetWorktreeId && t.location !== "trash"
+            t != null &&
+            t.worktreeId === targetWorktreeId &&
+            t.location !== "trash" &&
+            t.location !== "overlay"
         );
       if (targets.length === 0) return;
       const runningAgents = collectRunningAgentTerminals(targets);
@@ -160,7 +163,10 @@ export function registerWorktreeSessionActions(
         .map((id) => state.panelsById[id])
         .filter(
           (t): t is NonNullable<typeof t> =>
-            t != null && t.worktreeId === targetWorktreeId && t.location !== "trash"
+            t != null &&
+            t.worktreeId === targetWorktreeId &&
+            t.location !== "trash" &&
+            t.location !== "overlay"
         );
       if (targets.length === 0) return;
       if (confirmed !== true) {

--- a/src/store/__tests__/layoutUndoStore.test.ts
+++ b/src/store/__tests__/layoutUndoStore.test.ts
@@ -144,6 +144,24 @@ describe("layoutUndoStore", () => {
     expect(state.focusedId).toBe("t1");
   });
 
+  it("undo preserves an overlay assistant panel instead of orphaning it (#9699)", () => {
+    const grid = makeTerminal({ id: "grid1", location: "grid", worktreeId: "w1" });
+    const assistant = makeTerminal({ id: "assistant", location: "overlay", worktreeId: "w1" });
+    seedTerminals([grid, assistant]);
+
+    useLayoutUndoStore.getState().pushLayoutSnapshot();
+
+    // Simulate a layout change to the grid panel, then undo.
+    setTerminals([{ ...grid, location: "dock" }, assistant]);
+    useLayoutUndoStore.getState().undo();
+
+    const state = usePanelStore.getState();
+    // The assistant must still exist in the store and remain an overlay — the
+    // full-replacement rebuild in applySnapshot must not drop it.
+    expect(state.panelsById["assistant"]).toBeDefined();
+    expect(state.panelsById["assistant"]!.location).toBe("overlay");
+  });
+
   it("redo reverses undo", () => {
     const t1 = makeTerminal({ id: "t1", location: "grid" });
     seedTerminals([t1]);

--- a/src/store/fleetEligibility.ts
+++ b/src/store/fleetEligibility.ts
@@ -1,5 +1,10 @@
 import type { BuiltInAgentId } from "@shared/config/agentIds";
-import { isPtyPanel, type PanelInstance, type PtyPanelData } from "@shared/types/panel";
+import {
+  isGridPanelLocation,
+  isPtyPanel,
+  type PanelInstance,
+  type PtyPanelData,
+} from "@shared/types/panel";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { getBuiltInRuntimeAgentId } from "@/utils/terminalType";
 
@@ -21,7 +26,7 @@ export function isTerminalFleetEligible(
 ): t is PtyPanelData {
   if (!t) return false;
   if (!isPtyPanel(t)) return false;
-  if (t.location === "trash" || t.location === "background" || t.location === "dock") return false;
+  if (!isGridPanelLocation(t.location)) return false;
   if (t.hasPty === false) return false;
   // `runtimeStatus` is the renderer's authoritative liveness signal. `hasPty`
   // can lag after backend snapshots/reconnect for panels preserved after exit.
@@ -42,7 +47,7 @@ export function isTerminalErrorClusterEligible(
 ): t is PtyPanelData {
   if (!t) return false;
   if (!isPtyPanel(t)) return false;
-  if (t.location === "trash" || t.location === "background" || t.location === "dock") return false;
+  if (!isGridPanelLocation(t.location)) return false;
   if (t.hasPty === false) return false;
   return true;
 }

--- a/src/store/layoutUndoStore.ts
+++ b/src/store/layoutUndoStore.ts
@@ -37,7 +37,12 @@ function captureCurrentLayout(): LayoutSnapshot {
   return {
     terminals: state.panelIds
       .map((id) => state.panelsById[id])
-      .filter((t): t is CarrierPanel => Boolean(t) && t!.location !== "trash")
+      // Overlay panels (the Daintree Assistant) self-manage their lifecycle and
+      // must never be captured into a layout snapshot — restoring one would pin
+      // the assistant into the grid on undo/redo (#9699).
+      .filter(
+        (t): t is CarrierPanel => Boolean(t) && t!.location !== "trash" && t!.location !== "overlay"
+      )
       .map((t) => ({
         id: t.id,
         location: t.location,
@@ -72,7 +77,7 @@ function applySnapshot(snapshot: LayoutSnapshot): boolean {
   const postSnapshotEntries: TerminalLayoutEntry[] = [];
   for (const tid of panelIds) {
     const t = panelsById[tid];
-    if (t && !snapshotIds.has(t.id) && t.location !== "trash") {
+    if (t && !snapshotIds.has(t.id) && t.location !== "trash" && t.location !== "overlay") {
       postSnapshotEntries.push({ id: t.id, location: t.location, worktreeId: t.worktreeId });
     }
   }

--- a/src/store/layoutUndoStore.ts
+++ b/src/store/layoutUndoStore.ts
@@ -37,12 +37,7 @@ function captureCurrentLayout(): LayoutSnapshot {
   return {
     terminals: state.panelIds
       .map((id) => state.panelsById[id])
-      // Overlay panels (the Daintree Assistant) self-manage their lifecycle and
-      // must never be captured into a layout snapshot — restoring one would pin
-      // the assistant into the grid on undo/redo (#9699).
-      .filter(
-        (t): t is CarrierPanel => Boolean(t) && t!.location !== "trash" && t!.location !== "overlay"
-      )
+      .filter((t): t is CarrierPanel => Boolean(t) && t!.location !== "trash")
       .map((t) => ({
         id: t.id,
         location: t.location,
@@ -77,7 +72,7 @@ function applySnapshot(snapshot: LayoutSnapshot): boolean {
   const postSnapshotEntries: TerminalLayoutEntry[] = [];
   for (const tid of panelIds) {
     const t = panelsById[tid];
-    if (t && !snapshotIds.has(t.id) && t.location !== "trash" && t.location !== "overlay") {
+    if (t && !snapshotIds.has(t.id) && t.location !== "trash") {
       postSnapshotEntries.push({ id: t.id, location: t.location, worktreeId: t.worktreeId });
     }
   }

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -27,7 +27,7 @@ import {
   isAgentReady,
 } from "./slices";
 import type { TerminalRefreshTier, AddPanelFocusPolicy } from "@shared/types";
-import { isPtyPanel, type PtyPanelData } from "@shared/types/panel";
+import { isGridPanelLocation, isPtyPanel, type PtyPanelData } from "@shared/types/panel";
 import { TerminalRefreshTier as TerminalRefreshTierEnum } from "@/types";
 import { terminalRegistryController } from "@/controllers";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
@@ -126,8 +126,7 @@ function pickFallbackFocusId(
 }
 
 function isVisibleLivePtyTerminal(terminal: PtyPanelData): boolean {
-  const location = terminal.location ?? "grid";
-  if (location === "trash" || location === "background" || location === "dock") return false;
+  if (!isGridPanelLocation(terminal.location)) return false;
   if (terminal.isVisible === false) return false;
   if (terminal.hasPty === false) return false;
   if (terminal.runtimeStatus === "exited" || terminal.runtimeStatus === "error") return false;
@@ -170,9 +169,7 @@ export function getTerminalRefreshTier(
   if (
     options.isFleetArmed &&
     ptyTerminal?.hasPty !== false &&
-    terminal.location !== "trash" &&
-    terminal.location !== "background" &&
-    terminal.location !== "dock" &&
+    isGridPanelLocation(terminal.location) &&
     ptyTerminal?.runtimeStatus !== "exited" &&
     ptyTerminal?.runtimeStatus !== "error"
   ) {

--- a/src/store/slices/panelRegistry/background.ts
+++ b/src/store/slices/panelRegistry/background.ts
@@ -32,7 +32,15 @@ export const createBackgroundActions = (
   backgroundTerminal: (id) => {
     const terminal = get().panelsById[id];
     if (!terminal) return;
-    if (terminal.location === "trash" || terminal.location === "background") return;
+    // Overlay panels (the Daintree Assistant) self-manage and are never
+    // backgrounded — short-circuiting also prevents the `originalLocation`
+    // collapse below from recording a bogus "grid" restore target (#9699).
+    if (
+      terminal.location === "trash" ||
+      terminal.location === "background" ||
+      terminal.location === "overlay"
+    )
+      return;
 
     if (isDevPreviewPanel(terminal)) {
       stopDevPreviewByPanelId(id);

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -439,6 +439,10 @@ export const createCorePanelActions = (
   },
 
   moveTerminalToDock: (id) => {
+    // Overlay panels (the Daintree Assistant) self-manage their placement and
+    // must never be relocated into the dock by a layout action (#9699).
+    if (get().panelsById[id]?.location === "overlay") return;
+
     // Check if panel is in a group - if so, move the entire group
     const group = get().getPanelGroup(id);
     if (group) {
@@ -479,6 +483,10 @@ export const createCorePanelActions = (
   },
 
   moveTerminalToGrid: (id) => {
+    // Overlay panels (the Daintree Assistant) self-manage their placement and
+    // must never be relocated into the grid by a layout action (#9699).
+    if (get().panelsById[id]?.location === "overlay") return false;
+
     // Check if panel is in a group - if so, move the entire group
     const group = get().getPanelGroup(id);
     if (group) {

--- a/src/store/slices/panelRegistry/tabGroups.ts
+++ b/src/store/slices/panelRegistry/tabGroups.ts
@@ -591,7 +591,12 @@ export const createTabGroupActions = (
     const group = get().tabGroups.get(groupId);
     if (group) return group.activeTabId || null;
     const terminal = get().panelsById[groupId];
-    if (terminal && terminal.location !== "trash" && terminal.location !== "background") {
+    if (
+      terminal &&
+      terminal.location !== "trash" &&
+      terminal.location !== "background" &&
+      terminal.location !== "overlay"
+    ) {
       for (const g of get().tabGroups.values()) {
         if (g.panelIds.includes(groupId)) return null;
       }

--- a/src/store/slices/panelRegistry/tabGroups.ts
+++ b/src/store/slices/panelRegistry/tabGroups.ts
@@ -63,7 +63,15 @@ function collectUngroupedCandidateIds(
 function getPanelTabGroupLocation(
   panel: PanelInstance | CarrierPanel | undefined
 ): TabGroupLocation | null {
-  if (!panel || panel.location === "trash" || panel.location === "background") return null;
+  // Overlay panels (the Daintree Assistant) belong to no tab group — they
+  // self-manage and must never be folded into a grid or dock group (#9699).
+  if (
+    !panel ||
+    panel.location === "trash" ||
+    panel.location === "background" ||
+    panel.location === "overlay"
+  )
+    return null;
   return panel.location === "dock" ? "dock" : "grid";
 }
 

--- a/src/store/slices/terminalBulkActionsSlice.ts
+++ b/src/store/slices/terminalBulkActionsSlice.ts
@@ -219,8 +219,10 @@ export const createTerminalBulkActionsSlice = (
 
     bulkTrashByWorktree: (worktreeId) => {
       const terminals = getTerminals();
+      // Overlay panels (the Daintree Assistant) are not worktree sessions and
+      // must be excluded so execution matches the user-facing count (#9699).
       const activeTerminals = terminals.filter(
-        (t) => t.worktreeId === worktreeId && t.location !== "trash"
+        (t) => t.worktreeId === worktreeId && t.location !== "trash" && t.location !== "overlay"
       );
       activeTerminals.forEach((t) => trashPanel(t.id));
     },
@@ -229,7 +231,10 @@ export const createTerminalBulkActionsSlice = (
       const terminals = getTerminals();
       const activeTerminals = terminals.filter(
         (t): t is PtyPanelData =>
-          isPtyPanel(t) && t.worktreeId === worktreeId && t.location !== "trash"
+          isPtyPanel(t) &&
+          t.worktreeId === worktreeId &&
+          t.location !== "trash" &&
+          t.location !== "overlay"
       );
 
       const validationResults = await validateTerminals(activeTerminals);
@@ -253,7 +258,10 @@ export const createTerminalBulkActionsSlice = (
       const terminals = getTerminals();
       const activeTerminals = terminals.filter(
         (t): t is PtyPanelData =>
-          isPtyPanel(t) && t.worktreeId === worktreeId && t.location !== "trash"
+          isPtyPanel(t) &&
+          t.worktreeId === worktreeId &&
+          t.location !== "trash" &&
+          t.location !== "overlay"
       );
       if (activeTerminals.length === 0) return;
 

--- a/src/store/wakeActiveWorktreeTerminals.ts
+++ b/src/store/wakeActiveWorktreeTerminals.ts
@@ -60,11 +60,11 @@ async function wakeActiveWorktreeTerminalsInner(): Promise<void> {
     if ((panel.kind ?? "terminal") !== "terminal") continue;
     if ((panel.worktreeId ?? null) !== activeWorktreeId) continue;
     const location = panel.location ?? "grid";
-    if (location === "dock" || location === "trash") continue;
+    if (location === "dock" || location === "trash" || location === "overlay") continue;
     targets.push(id);
   }
 
-  // The Daintree Assistant terminal is a `location: "dock"` panel and so is
+  // The Daintree Assistant terminal is a `location: "overlay"` panel and so is
   // excluded by the loop above, but it's rendered persistently in `HelpPanel`
   // (not via the dock popover), so nothing else wakes it on view reactivation.
   // Without this it stays frozen — accumulating headless-mirror output but


### PR DESCRIPTION
## Summary

- `#9668` widened `PanelLocation` to add `"overlay"` for the Daintree Assistant but didn't audit the consuming filters. Exclusion lists and `=== "dock" ? "dock" : "grid"` coercions silently admitted `"overlay"` as a grid member, surfacing the assistant as a second agent in the fleet grid, badge counts, waiting lists, and worktree session actions.
- Adds `isGridPanelLocation()` to `shared/types/panel.ts` backed by a `satisfies Record<PanelLocation, boolean>` exhaustiveness guard — future union widening becomes a compile error rather than a silent leak.
- Applies the fix at every grid-membership callsite: `buildFleetPanels`, `fleetEligibility`, `panelStore` refresh tier, `terminalVisibility` gate (covers counts, switchers, waiting lists), `AgentButton`, `AgentTrayButton`, `useOverflowBadgeSeverity`, `tabGroups`, `background.ts`, `core.moveTerminalToDock/Grid`, wake fan-out, the send-to-agent palette, and worktree-scoped session bulk ops (`worktreeSessionActions`, `terminalBulkActionsSlice` worktree methods, `toggleDockAll`). The global kill-all/restart-all still includes the assistant intentionally — nuke-everything semantics, real PTY. `HelpSessionController` overlay spawn behavior is untouched.

Resolves #9699

## Changes

- `shared/types/panel.ts` — `isGridPanelLocation()` helper with exhaustiveness guard
- `shared/types/__tests__/panel.test.ts` — helper unit tests (all 5 locations + `undefined`)
- `src/components/Terminal/contentGridFleetPanels.ts` + test — overlay excluded from fleet
- `src/lib/terminalVisibility.ts` — overlay excluded from the central visibility gate
- `src/components/Layout/AgentButton.tsx`, `AgentTrayButton.tsx`, `useOverflowBadgeSeverity.ts` — badge/tray counts use the helper
- `src/store/slices/panelRegistry/tabGroups.ts`, `background.ts`, `core.ts` — tab-group membership and background/move guards
- `src/store/fleetEligibility.ts`, `panelStore.ts` — fleet and refresh-tier membership
- `src/store/wakeActiveWorktreeTerminals.ts` — wake fan-out
- `src/hooks/useSendToAgentPalette.ts` — send-to-agent palette
- `src/services/actions/definitions/worktreeSessionActions.ts`, `src/store/slices/terminalBulkActionsSlice.ts` — worktree-scoped session bulk ops
- `src/store/__tests__/layoutUndoStore.test.ts` — overlay-preservation-on-undo regression guard

## Testing

- Unit tests: `isGridPanelLocation` all 5 `PanelLocation` values plus `undefined`, `buildFleetPanels` overlay exclusion, `layoutUndoStore` overlay-preservation-on-undo regression guard
- `npm run check` passes clean