### PR TITLE
fix(terminal): scope Redraw renderer reset to one pane

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -2061,8 +2061,16 @@ class TerminalInstanceService {
 
       logDebug(`resetRenderer running for ${id}`);
 
-      managed.terminal.clearTextureAtlas();
-      managed.terminal.refresh(0, managed.terminal.rows - 1);
+      // Recover this terminal's renderer WITHOUT clearing the shared texture
+      // atlas: clearTextureAtlas() flushes xterm's module-global atlas shared by
+      // every WebGL terminal with matching font/theme, blanking co-owner panes
+      // until they get their own resize/click trigger (#9701). repairAtlasForReactivation
+      // does a local-only model reset + refresh on this terminal's pool entry and
+      // returns false for DOM-renderer terminals, where we fall back to a plain
+      // refresh so the targeted pane still repaints.
+      if (!this.webGLManager.repairAtlasForReactivation(id)) {
+        managed.terminal.refresh(0, managed.terminal.rows - 1);
+      }
 
       try {
         this.resizeController.fit(id);

--- a/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
@@ -53,6 +53,7 @@ type ReflowTestService = {
   resetRenderer: (id: string) => void;
   resizeController: { fit: (id: string) => unknown };
   getSynchronizedOutputMode: (id: string) => boolean | null;
+  webGLManager: { repairAtlasForReactivation: (id: string) => boolean };
 };
 
 function makeManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal {
@@ -291,7 +292,7 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     expect(managed.lastReflowAt).toBeGreaterThan(0);
   });
 
-  it("resetRenderer calls forceXtermReflow and clears the throttle", () => {
+  it("resetRenderer falls back to a local refresh for DOM-renderer terminals and never clears the shared atlas", () => {
     const managed = makeManaged({ lastReflowAt: 99999 });
     Object.defineProperty(managed.hostElement, "clientWidth", { value: 200, configurable: true });
     Object.defineProperty(managed.hostElement, "clientHeight", { value: 200, configurable: true });
@@ -306,14 +307,54 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     term.refresh = vi.fn();
     service.instances.set("t1", managed);
     vi.spyOn(service.resizeController, "fit").mockImplementation(() => null);
+    // DOM-renderer terminal (no WebGL pool entry) — repair declines and the
+    // caller owns the repaint.
+    const repair = vi
+      .spyOn(service.webGLManager, "repairAtlasForReactivation")
+      .mockReturnValue(false);
 
     service.resetRenderer("t1");
 
-    expect(term.clearTextureAtlas).toHaveBeenCalled();
+    // #9701: clearing the shared texture atlas blanks co-owner panes — it must
+    // never be called on the per-pane Redraw path.
+    expect(term.clearTextureAtlas).not.toHaveBeenCalled();
+    expect(repair).toHaveBeenCalledWith("t1");
+    // DOM-renderer fallback still repaints the targeted pane.
     expect(term.refresh).toHaveBeenCalledWith(0, 23);
     expect(paddingHistory(managed)).toContain("0.01px");
     // Throttle is cleared so the next onWriteParsed/heartbeat tick
     // reflows immediately.
+    expect(managed.lastReflowAt).toBe(0);
+  });
+
+  it("resetRenderer uses the local WebGL repair and skips the fallback refresh when a pool entry is repaired", () => {
+    const managed = makeManaged({ lastReflowAt: 99999 });
+    Object.defineProperty(managed.hostElement, "clientWidth", { value: 200, configurable: true });
+    Object.defineProperty(managed.hostElement, "clientHeight", { value: 200, configurable: true });
+    const term = managed.terminal as unknown as {
+      element: HTMLElement;
+      rows: number;
+      clearTextureAtlas: () => void;
+      refresh: (a: number, b: number) => void;
+    };
+    term.rows = 24;
+    term.clearTextureAtlas = vi.fn();
+    term.refresh = vi.fn();
+    service.instances.set("t1", managed);
+    vi.spyOn(service.resizeController, "fit").mockImplementation(() => null);
+    // WebGL terminal: repair handles its own local reset + refresh, so the
+    // caller must not issue a redundant fallback refresh.
+    const repair = vi
+      .spyOn(service.webGLManager, "repairAtlasForReactivation")
+      .mockReturnValue(true);
+
+    service.resetRenderer("t1");
+
+    expect(repair).toHaveBeenCalledWith("t1");
+    expect(term.clearTextureAtlas).not.toHaveBeenCalled();
+    expect(term.refresh).not.toHaveBeenCalled();
+    // forceXtermReflow still fires and the throttle is still cleared.
+    expect(paddingHistory(managed)).toContain("0.01px");
     expect(managed.lastReflowAt).toBe(0);
   });
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
@@ -372,6 +372,7 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     term.clearTextureAtlas = vi.fn();
     term.refresh = vi.fn();
     service.instances.set("t1", managed);
+    vi.spyOn(service.webGLManager, "repairAtlasForReactivation").mockReturnValue(false);
     vi.spyOn(service.resizeController, "fit").mockImplementation(() => {
       throw new Error("fit boom");
     });
@@ -380,6 +381,45 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     // The escape hatch — forceXtermReflow — must still run even if fit throws.
     expect(paddingHistory(managed)).toContain("0.01px");
     expect(managed.lastReflowAt).toBe(0);
+    // Even on the error path, Redraw never flushes the shared atlas.
+    expect(term.clearTextureAtlas).not.toHaveBeenCalled();
+  });
+
+  it("resetRenderer leaves sibling panes untouched (#9701 isolation)", () => {
+    const target = makeManaged({ lastReflowAt: 99999 });
+    Object.defineProperty(target.hostElement, "clientWidth", { value: 200, configurable: true });
+    Object.defineProperty(target.hostElement, "clientHeight", { value: 200, configurable: true });
+    const targetTerm = target.terminal as unknown as {
+      rows: number;
+      clearTextureAtlas: () => void;
+      refresh: (a: number, b: number) => void;
+    };
+    targetTerm.rows = 24;
+    targetTerm.clearTextureAtlas = vi.fn();
+    targetTerm.refresh = vi.fn();
+
+    // A co-owner pane that shares the WebGL texture atlas. Redraw on the target
+    // must not call anything on this terminal — the old clearTextureAtlas() path
+    // corrupted it until it got its own resize/click.
+    const sibling = makeManaged();
+    const siblingTerm = sibling.terminal as unknown as {
+      clearTextureAtlas: () => void;
+      refresh: (a: number, b: number) => void;
+    };
+    siblingTerm.clearTextureAtlas = vi.fn();
+    siblingTerm.refresh = vi.fn();
+
+    service.instances.set("t1", target);
+    service.instances.set("t2", sibling);
+    vi.spyOn(service.webGLManager, "repairAtlasForReactivation").mockReturnValue(false);
+    vi.spyOn(service.resizeController, "fit").mockImplementation(() => null);
+
+    service.resetRenderer("t1");
+
+    expect(siblingTerm.clearTextureAtlas).not.toHaveBeenCalled();
+    expect(siblingTerm.refresh).not.toHaveBeenCalled();
+    expect(paddingHistory(sibling).length).toBe(0);
+    expect(sibling.lastReflowAt).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

- `TerminalInstanceService.resetRenderer` was calling `clearTextureAtlas()`, which clears a module-global WebGL texture atlas shared across all terminals with a matching font/theme config — blanking every co-owner pane, not just the one being redrawn
- Fix routes the reset through `webGLManager.repairAtlasForReactivation(id)` for WebGL-renderer terminals, which resets only that pane's renderer without touching the shared atlas; DOM-renderer terminals fall back to a plain `refresh()` call
- No change to the public `resetRenderer` API or the action wiring — the fix is entirely in the implementation path

Resolves #9701

## Changes

- `src/services/terminal/TerminalInstanceService.ts`: replaced `clearTextureAtlas()` + `refresh()` with `repairAtlasForReactivation(id)` for WebGL path, plain `refresh()` fallback for DOM path
- `src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts`: added sibling-isolation test (resets one terminal, verifies co-owner is untouched) and explicit WebGL/DOM-path coverage

## Testing

25 reflow tests pass. Typecheck, lint (ratchet -1), format, and build all clean.