### PR TITLE
fix(terminal): wake mid-attach and frozen-renderer panes on switch-back

### DIFF
--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -581,12 +581,42 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
     // workspace host's `refreshOnWake` already mirrors via `worktree-update`
     // push events. Re-entering this handler for short alt-tabs no longer
     // triggers redundant `get-all-states` fetches.
+    // De-dupe guard: on warm reactivation Chromium fires the Page Lifecycle
+    // `resume` event immediately before `visibilitychange` in the same turn
+    // (#9702). Coalesce both into a single wake fan-out via a microtask so a
+    // resume+visibilitychange pair doesn't run the fan-out twice.
+    let wakePending = false;
+    function scheduleWake() {
+      if (wakePending) return;
+      wakePending = true;
+      void Promise.resolve().then(() => {
+        wakePending = false;
+        if (document.visibilityState === "visible") {
+          void wakeActiveWorktreeTerminals();
+        }
+      });
+    }
+
     function handleVisibilityChange() {
       if (document.visibilityState !== "visible") return;
-      void wakeActiveWorktreeTerminals();
+      scheduleWake();
     }
     document.addEventListener("visibilitychange", handleVisibilityChange);
     cleanups.push(() => document.removeEventListener("visibilitychange", handleVisibilityChange));
+
+    // `resume` fires when a frozen renderer is thawed (CDP
+    // Page.setWebLifecycleState("active")). On project switch-back the queued
+    // `visibilitychange` can be processed while the renderer is still frozen
+    // and the wake fan-out then runs in a lifecycle that can't execute it
+    // (#9702). The `resume` event is the renderer's authoritative "now
+    // executable" signal, so re-run the fan-out here too — coalesced with the
+    // visibilitychange path above.
+    function handleResume() {
+      if (document.visibilityState !== "visible") return;
+      scheduleWake();
+    }
+    document.addEventListener("resume", handleResume);
+    cleanups.push(() => document.removeEventListener("resume", handleResume));
 
     // Missed-event guard: if the view is already visible by the time this
     // listener installs (fast cached reactivation), the visibilitychange

--- a/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
@@ -11,9 +11,16 @@ import {
   _resetForTests as resetCache,
 } from "@/lib/githubResourceCache";
 import { useProjectStore } from "@/store/projectStore";
+import { wakeActiveWorktreeTerminals } from "@/store/wakeActiveWorktreeTerminals";
 import type { GitHubPR, GitHubPRCIStatus } from "@shared/types/github";
 import type { WorktreeSnapshot, WorktreeEventVersion } from "@shared/types";
 import type { Project } from "@shared/types/project";
+
+vi.mock("@/store/wakeActiveWorktreeTerminals", () => ({
+  wakeActiveWorktreeTerminals: vi.fn(() => Promise.resolve()),
+}));
+
+const wakeMock = vi.mocked(wakeActiveWorktreeTerminals);
 
 // Host-minted `(epoch, seq)` versions (#8403). The mock host uses a fixed
 // epoch; `get-all-states` reports seq 0 and push events advance the seq.
@@ -1221,6 +1228,66 @@ describe("WorktreeStoreProvider visibilitychange (#8066 consolidation)", () => {
     });
 
     expect(requestMock.mock.calls.length).toBe(initialCallCount);
+  });
+});
+
+describe("WorktreeStoreProvider resume event (#9702)", () => {
+  function setVisibility(state: "visible" | "hidden"): void {
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => state,
+    });
+  }
+
+  it("does not wake when resume fires while the document is hidden", async () => {
+    setVisibility("hidden");
+    await renderProvider();
+    wakeMock.mockClear();
+
+    act(() => {
+      document.dispatchEvent(new Event("resume"));
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(wakeMock).not.toHaveBeenCalled();
+  });
+
+  it("wakes once when resume fires while visible", async () => {
+    setVisibility("visible");
+    await renderProvider();
+    wakeMock.mockClear();
+
+    act(() => {
+      document.dispatchEvent(new Event("resume"));
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(wakeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces a resume + visibilitychange pair into a single wake", async () => {
+    setVisibility("visible");
+    await renderProvider();
+    wakeMock.mockClear();
+
+    // Chromium fires resume immediately before visibilitychange on thaw; both
+    // land in the same turn and must collapse to one fan-out.
+    act(() => {
+      document.dispatchEvent(new Event("resume"));
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(wakeMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -854,10 +854,17 @@ class TerminalInstanceService {
     // flag (e.g. a prior skip whose deferred re-run we are now satisfying).
     current.pendingVisibilityWake = false;
 
+    // Unlock symmetrically with the relock in the finally below: bypass the
+    // lock whenever resize is suppressed, even if the suppression end time was
+    // already cleared (the timer can fire between switch-back and this deferred
+    // wake). Without the unlock, applyDeferredResize would no-op under the lock
+    // and geometry would stay stale.
     const needsLockBypass = current.isResizeSuppressed === true;
     let remainingMs = 0;
-    if (needsLockBypass && current.resizeSuppressionEndTime) {
-      remainingMs = Math.max(0, current.resizeSuppressionEndTime - Date.now());
+    if (needsLockBypass) {
+      remainingMs = current.resizeSuppressionEndTime
+        ? Math.max(0, current.resizeSuppressionEndTime - Date.now())
+        : 0;
       this.resizeController.lockResize(id, false);
     }
     try {

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -812,11 +812,13 @@ class TerminalInstanceService {
 
   /**
    * Run the full click-equivalent wake sequence on a visible terminal whose
-   * project view just regained visibility (#8562). `wake(id)` only triggers
-   * buffer restore + xterm.refresh; the click/focus path additionally runs
-   * `applyDeferredResize`, `forceXtermReflow`, `handlePostWake`, and
-   * `dataBuffer.resumeFlush`. Without those steps, visible terminals show
-   * stale geometry and missing recent output until the user clicks each pane.
+   * project view just regained visibility (#8562). This method is the complete
+   * path: it runs `applyDeferredResize`, `forceXtermReflow`,
+   * `repairAtlasForReactivation`, `wakeAndRestore`, `xterm.refresh`,
+   * `handlePostWake`, and `dataBuffer.resumeFlush`. The plain `wake(id)` path
+   * (used on click/focus) only triggers buffer restore + xterm.refresh. Without
+   * the full sequence, visible terminals show stale geometry and missing recent
+   * output until the user clicks each pane.
    *
    * Bypasses {@link TerminalRendererPolicy.applyRendererPolicy} — that path
    * early-returns on tier equality and a backgrounded view's terminals stay
@@ -838,10 +840,19 @@ class TerminalInstanceService {
     if (!current) return;
     if (!current.isOpened) return;
 
-    // Attach is in progress — its post-rAF reconciliation (around L1166) will
-    // apply the renderer policy and run the wake. A second path here would
-    // race.
-    if (current.isAttaching) return;
+    // Attach is in progress — running the wake now would race the attach's own
+    // post-rAF reconciliation. That reconciliation path does NOT run the full
+    // visibility-restore sequence, so we can't simply defer to it: mark the
+    // terminal so notifyAttachSettledWaiters re-runs this wake once attach
+    // settles (#9702).
+    if (current.isAttaching) {
+      current.pendingVisibilityWake = true;
+      return;
+    }
+
+    // We're proceeding with the full wake now, so clear any stale deferred-wake
+    // flag (e.g. a prior skip whose deferred re-run we are now satisfying).
+    current.pendingVisibilityWake = false;
 
     const needsLockBypass = current.isResizeSuppressed === true;
     let remainingMs = 0;
@@ -1212,15 +1223,31 @@ class TerminalInstanceService {
 
   private notifyAttachSettledWaiters(id: string): void {
     if (!this.isAttachSettled(id)) return;
-    const waiters = this.attachSettledWaiters.get(id);
-    if (!waiters) return;
 
-    for (const waiter of waiters) {
-      clearTimeout(waiter.timeout);
-      waiter.resolve();
+    // Consume a deferred visibility wake that was skipped while this terminal
+    // was mid-attach (#9702). Read and clear the flag before dispatching so a
+    // re-entrant call can't double-fire; fullWakeForVisibilityRestore guards
+    // against stale/replaced instances on its own.
+    const managed = this.instances.get(id);
+    const deferredWake = managed?.pendingVisibilityWake === true;
+    if (managed) managed.pendingVisibilityWake = false;
+
+    const waiters = this.attachSettledWaiters.get(id);
+    if (waiters) {
+      for (const waiter of waiters) {
+        clearTimeout(waiter.timeout);
+        waiter.resolve();
+      }
+      this.attachSettledWaiters.delete(id);
     }
 
-    this.attachSettledWaiters.delete(id);
+    if (deferredWake) {
+      void this.fullWakeForVisibilityRestore(id).catch((error) => {
+        logWarn(`deferred fullWakeForVisibilityRestore failed for ${id}`, {
+          error,
+        });
+      });
+    }
   }
 
   private removeAttachSettledWaiter(id: string, resolve: () => void): void {

--- a/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
@@ -68,6 +68,7 @@ type ManagedTerminalMock = {
   isVisible: boolean;
   isResizeSuppressed: boolean;
   resizeSuppressionEndTime: number | undefined;
+  pendingVisibilityWake?: boolean;
   latestCols: number;
   latestRows: number;
   terminal: {
@@ -91,6 +92,7 @@ type FullWakeTestService = {
   handlePostWake: (id: string) => void;
   unhibernate: (id: string) => void;
   fullWakeForVisibilityRestore: (id: string) => Promise<void>;
+  notifyAttachSettledWaiters: (id: string) => void;
 };
 
 function makeInstance(overrides: Partial<ManagedTerminalMock> = {}): ManagedTerminalMock {
@@ -303,7 +305,7 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
     expect(wakeAndRestore).not.toHaveBeenCalled();
   });
 
-  it("bails when terminal is currently attaching", async () => {
+  it("bails when terminal is currently attaching and marks it for a deferred wake (#9702)", async () => {
     const id = "fw-6";
     const instance = makeInstance({ isAttaching: true });
     service.instances.set(id, instance);
@@ -317,6 +319,72 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
 
     expect(applyDeferredResize).not.toHaveBeenCalled();
     expect(wakeAndRestore).not.toHaveBeenCalled();
+    // The skipped wake must leave a flag so it re-runs once attach settles.
+    expect(instance.pendingVisibilityWake).toBe(true);
+  });
+
+  it("clears a stale pendingVisibilityWake flag when proceeding with an immediate wake (#9702)", async () => {
+    const id = "fw-clear";
+    const instance = makeInstance({ pendingVisibilityWake: true });
+    service.instances.set(id, instance);
+
+    vi.spyOn(service.resizeController, "applyDeferredResize").mockImplementation(() => {});
+    vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue(true);
+    vi.spyOn(service, "handlePostWake").mockImplementation(() => {});
+    vi.spyOn(service.dataBuffer, "resumeFlush").mockImplementation(() => {});
+
+    await service.fullWakeForVisibilityRestore(id);
+
+    expect(instance.pendingVisibilityWake).toBe(false);
+  });
+
+  it("re-runs the deferred wake via notifyAttachSettledWaiters once attach settles (#9702)", async () => {
+    const id = "fw-deferred";
+    // hostElement must be connected for isAttachSettled() to return true.
+    const hostElement = document.createElement("div");
+    document.body.appendChild(hostElement);
+    const instance = makeInstance({
+      isAttaching: false,
+      pendingVisibilityWake: true,
+      hostElement,
+    });
+    service.instances.set(id, instance);
+
+    const applyDeferredResize = vi
+      .spyOn(service.resizeController, "applyDeferredResize")
+      .mockImplementation(() => {});
+    const wakeAndRestore = vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue(true);
+    vi.spyOn(service, "handlePostWake").mockImplementation(() => {});
+    vi.spyOn(service.dataBuffer, "resumeFlush").mockImplementation(() => {});
+
+    service.notifyAttachSettledWaiters(id);
+    // The deferred wake is dispatched as a floating promise; flush microtasks.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(instance.pendingVisibilityWake).toBe(false);
+    expect(applyDeferredResize).toHaveBeenCalledWith(id);
+    expect(wakeAndRestore).toHaveBeenCalledWith(id);
+
+    document.body.removeChild(hostElement);
+  });
+
+  it("does not fire a deferred wake when pendingVisibilityWake is unset (#9702)", async () => {
+    const id = "fw-nodefer";
+    const hostElement = document.createElement("div");
+    document.body.appendChild(hostElement);
+    const instance = makeInstance({ isAttaching: false, hostElement });
+    service.instances.set(id, instance);
+
+    const wakeAndRestore = vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue(true);
+
+    service.notifyAttachSettledWaiters(id);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(wakeAndRestore).not.toHaveBeenCalled();
+
+    document.body.removeChild(hostElement);
   });
 
   it("no-ops cleanly when terminal does not exist", async () => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
@@ -271,6 +271,36 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
     expect(relockTtl).toBeLessThanOrEqual(1500);
   });
 
+  it("still bypasses the resize lock when isResizeSuppressed is true but the end time is missing", async () => {
+    const id = "fw-3b";
+    const instance = makeInstance({
+      isResizeSuppressed: true,
+      resizeSuppressionEndTime: undefined,
+    });
+    service.instances.set(id, instance);
+
+    const calls: string[] = [];
+    const lockResize = vi
+      .spyOn(service.resizeController, "lockResize")
+      .mockImplementation((_id, locked) => {
+        calls.push(locked ? "lock" : "unlock");
+      });
+    vi.spyOn(service.resizeController, "applyDeferredResize").mockImplementation(() => {
+      calls.push("applyDeferredResize");
+    });
+    vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue(true);
+    vi.spyOn(service, "handlePostWake").mockImplementation(() => {});
+    vi.spyOn(service.dataBuffer, "resumeFlush").mockImplementation(() => {});
+
+    await service.fullWakeForVisibilityRestore(id);
+
+    // Unlock must precede the resize so geometry resyncs, then relock after —
+    // even with no end time (TTL falls back to 0).
+    expect(calls).toEqual(["unlock", "applyDeferredResize", "lock"]);
+    expect(lockResize).toHaveBeenNthCalledWith(1, id, false);
+    expect(lockResize).toHaveBeenNthCalledWith(2, id, true, 0);
+  });
+
   it("does not touch the resize lock when isResizeSuppressed is false", async () => {
     const id = "fw-4";
     const instance = makeInstance({ isResizeSuppressed: false });

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -99,6 +99,12 @@ export interface ManagedTerminal {
   pendingWrites?: number;
   needsWake?: boolean;
 
+  // One-shot flag (#9702): a fullWakeForVisibilityRestore was requested while
+  // this terminal was mid-attach (isAttaching) and skipped to avoid racing the
+  // attach. Consumed by notifyAttachSettledWaiters, which re-runs the wake once
+  // attach has settled.
+  pendingVisibilityWake?: boolean;
+
   // Typing burst timer
   inputBurstTimer?: number;
 


### PR DESCRIPTION
## Summary

- On warm project switch-back, terminals mid-attach when the visibility wake fan-out ran were silently skipped with no retry. Added a `pendingVisibilityWake` flag on `ManagedTerminal`; when `fullWakeForVisibilityRestore` skips an attaching terminal it sets the flag, and `notifyAttachSettledWaiters` consumes it once attach completes and re-runs the full wake sequence.
- The `visibilitychange`-driven fan-out could fire while the renderer was still frozen (CDP `Page.setWebLifecycleState` unfreeze in-flight). Added a `document` `resume` listener in `WorktreeStoreContext` alongside `visibilitychange`, both routed through a microtask de-dupe so a `resume`+`visibilitychange` pair coalesces into one fan-out. `resume` is the authoritative "renderer thawed" signal from the Page Lifecycle API.
- Fixed `fullWakeForVisibilityRestore` unlocking the resize lock symmetrically even when `resizeSuppressionEndTime` is already cleared, so the deferred wake actually resyncs geometry.
- Corrected the inverted `fullWakeForVisibilityRestore` docstring.

Resolves #9702

## Changes

- `src/services/terminal/types.ts` — `pendingVisibilityWake` flag on `ManagedTerminal`
- `src/services/terminal/TerminalInstanceService.ts` — deferred wake on skip, symmetric lock release
- `src/contexts/WorktreeStoreContext.tsx` — `resume` listener + microtask de-dupe coalescing
- `src/services/terminal/TerminalInstanceService.fullWake.test.ts` — deferred-wake lifecycle, missing end-time lock bypass
- `src/contexts/WorktreeStoreContext.prDetected.test.tsx` — `resume` event describe block (hidden→no wake, visible→one wake, resume+visibilitychange coalesce)

## Testing

Extended the `fullWake` suite to cover the deferred-wake flag lifecycle and the missing `resizeSuppressionEndTime` lock bypass. Added a `resume` event describe block to the `WorktreeStoreContext` tests covering the three coalescing scenarios. All targeted tests pass; `npm run check` clean.