### PR TITLE
fix(icons): match agent-state circle stroke weight to Lucide grid

### DIFF
--- a/src/components/icons/AgentStateCircles.tsx
+++ b/src/components/icons/AgentStateCircles.tsx
@@ -2,7 +2,9 @@ import type { SVGProps } from "react";
 
 type CircleProps = SVGProps<SVGSVGElement> & { className?: string };
 
-// r=6, strokeWidth=2 → 14px diameter in 16x16 viewBox (1px padding prevents clipping)
+// r=6, strokeWidth=1.333 → ~13.33px diameter in 16x16 viewBox. The 1.333 stroke
+// (= 2 × 16/24) normalizes these icons to Lucide's 24-viewBox / strokeWidth-2 grid
+// so they render the same line weight as adjacent Lucide icons (e.g. CheckCircle2).
 // Circumference = 2π × 6 = 37.699
 const DASH = "28.274"; // 270° arc (C × 0.75)
 const GAP = "9.425"; // 90° gap (C × 0.25)
@@ -16,7 +18,7 @@ export function SpinnerCircle({ className, ...props }: CircleProps) {
         cy="8"
         r="6"
         stroke="currentColor"
-        strokeWidth="2"
+        strokeWidth="1.333"
         strokeLinecap="round"
         strokeDasharray={`${DASH} ${GAP}`}
         strokeDashoffset={OFFSET}
@@ -28,7 +30,7 @@ export function SpinnerCircle({ className, ...props }: CircleProps) {
 export function HollowCircle({ className, ...props }: CircleProps) {
   return (
     <svg viewBox="0 0 16 16" fill="none" className={className} aria-hidden="true" {...props}>
-      <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="2" />
+      <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.333" />
     </svg>
   );
 }
@@ -36,14 +38,14 @@ export function HollowCircle({ className, ...props }: CircleProps) {
 export function InteractingCircle({ className, ...props }: CircleProps) {
   return (
     <svg viewBox="0 0 16 16" fill="none" className={className} aria-hidden="true" {...props}>
-      <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="2" />
+      <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.333" />
       <line
         x1="8"
         y1="5.5"
         x2="8"
         y2="10.5"
         stroke="currentColor"
-        strokeWidth="1.5"
+        strokeWidth="1.0"
         strokeLinecap="round"
       />
       <line
@@ -52,7 +54,7 @@ export function InteractingCircle({ className, ...props }: CircleProps) {
         x2="10.5"
         y2="8"
         stroke="currentColor"
-        strokeWidth="1.5"
+        strokeWidth="1.0"
         strokeLinecap="round"
       />
     </svg>
@@ -62,14 +64,14 @@ export function InteractingCircle({ className, ...props }: CircleProps) {
 export function ExitedCircle({ className, ...props }: CircleProps) {
   return (
     <svg viewBox="0 0 16 16" fill="none" className={className} aria-hidden="true" {...props}>
-      <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="2" />
+      <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.333" />
       <line
         x1="5"
         y1="8"
         x2="11"
         y2="8"
         stroke="currentColor"
-        strokeWidth="1.8"
+        strokeWidth="1.2"
         strokeLinecap="round"
       />
     </svg>

--- a/src/components/icons/__tests__/icons-a11y.test.tsx
+++ b/src/components/icons/__tests__/icons-a11y.test.tsx
@@ -10,6 +10,7 @@ import {
 } from "../AgentStateCircles";
 // Re-imported via the barrel to regression-test `export * from "./AgentStateCircles"`.
 import { SpinnerCircle } from "../index";
+import { CheckCircle2 } from "lucide-react";
 import { ClaudeIcon } from "../brands/ClaudeIcon";
 import { NpmIcon } from "../brands/NpmIcon";
 import { InterpreterIcon } from "../brands/InterpreterIcon";
@@ -53,6 +54,36 @@ describe("AgentStateCircles a11y", () => {
     expect(svg?.hasAttribute("aria-hidden")).toBe(false);
     expect(svg?.getAttribute("role")).toBe("img");
     expect(svg?.getAttribute("aria-label")).toBe("Working");
+  });
+
+  // Regression guard for #9705: the custom circles share a 16-unit viewBox while
+  // Lucide icons use a 24-unit one. The rendered line weight is strokeWidth/viewBox,
+  // so the chips only match Lucide visually when that ratio is equal. Asserting the
+  // ratio (a relationship between two icons read from the DOM), not the literal
+  // strokeWidth, keeps this from being a tautological style test: it fails if either
+  // icon's strokeWidth or viewBox drifts out of alignment with the other.
+  const strokeRatio = (svg: SVGSVGElement, strokeHost: Element | null) => {
+    const viewBoxWidth = Number(svg.getAttribute("viewBox")!.split(/\s+/)[2]);
+    const strokeWidth = parseFloat(strokeHost!.getAttribute("stroke-width")!);
+    return strokeWidth / viewBoxWidth;
+  };
+
+  it.each([
+    ["SpinnerCircle", DirectSpinnerCircle],
+    ["HollowCircle", HollowCircle],
+    ["InteractingCircle", InteractingCircle],
+    ["ExitedCircle", ExitedCircle],
+  ])("%s renders the same stroke weight as a Lucide icon at any size", (_name, Component) => {
+    const { container: custom } = render(<Component />);
+    const customSvg = custom.querySelector("svg")!;
+    // Custom icons carry stroke-width on the <circle>; Lucide carries it on the <svg>.
+    const customRatio = strokeRatio(customSvg, customSvg.querySelector("circle"));
+
+    const { container: lucide } = render(<CheckCircle2 />);
+    const lucideSvg = lucide.querySelector("svg")!;
+    const lucideRatio = strokeRatio(lucideSvg, lucideSvg);
+
+    expect(customRatio).toBeCloseTo(lucideRatio, 3);
   });
 
   it("re-exports SpinnerCircle through the barrel", () => {

--- a/src/components/icons/__tests__/icons-a11y.test.tsx
+++ b/src/components/icons/__tests__/icons-a11y.test.tsx
@@ -97,9 +97,7 @@ describe("AgentStateCircles a11y", () => {
     ["ExitedCircle", ExitedCircle, 0.9],
   ])("%s keeps its inner detail strokes proportional to the ring", (_name, Component, ratio) => {
     const { container } = render(<Component />);
-    const ringStroke = parseFloat(
-      container.querySelector("circle")!.getAttribute("stroke-width")!
-    );
+    const ringStroke = parseFloat(container.querySelector("circle")!.getAttribute("stroke-width")!);
     const lines = container.querySelectorAll("line");
     expect(lines.length).toBeGreaterThan(0);
     for (const line of lines) {

--- a/src/components/icons/__tests__/icons-a11y.test.tsx
+++ b/src/components/icons/__tests__/icons-a11y.test.tsx
@@ -86,6 +86,28 @@ describe("AgentStateCircles a11y", () => {
     expect(customRatio).toBeCloseTo(lucideRatio, 3);
   });
 
+  // InteractingCircle and ExitedCircle draw inner detail lines that are
+  // deliberately thinner than the outer ring (hand-tuned to 0.75x and 0.9x of the
+  // ring stroke). The #9705 fix scaled the ring AND the inner lines by the same
+  // factor, so this proportion must be preserved. Asserting the inner/outer ratio
+  // (not the literal stroke-width) catches a regression where the ring is rescaled
+  // but the inner lines are forgotten, or vice versa.
+  it.each([
+    ["InteractingCircle", InteractingCircle, 0.75],
+    ["ExitedCircle", ExitedCircle, 0.9],
+  ])("%s keeps its inner detail strokes proportional to the ring", (_name, Component, ratio) => {
+    const { container } = render(<Component />);
+    const ringStroke = parseFloat(
+      container.querySelector("circle")!.getAttribute("stroke-width")!
+    );
+    const lines = container.querySelectorAll("line");
+    expect(lines.length).toBeGreaterThan(0);
+    for (const line of lines) {
+      const lineStroke = parseFloat(line.getAttribute("stroke-width")!);
+      expect(lineStroke / ringStroke).toBeCloseTo(ratio, 2);
+    }
+  });
+
   it("re-exports SpinnerCircle through the barrel", () => {
     expect(SpinnerCircle).toBe(DirectSpinnerCircle);
     const { container } = render(<SpinnerCircle />);


### PR DESCRIPTION
## Summary

- The worktree filter chips rendered the working and waiting circles with a visibly heavier stroke than the finished `CheckCircle2` icon
- Root cause: the custom icons in `AgentStateCircles.tsx` use a `16×16` viewBox with `strokeWidth="2"`, while Lucide uses `24×24` — at the same render size the custom stroke was 1.5× heavier
- Fixed by setting `strokeWidth` to `1.333` (`2 × 16/24`) across all four custom circles and scaling inner detail strokes by the same `2/3` factor

Resolves #9705

## Changes

- `AgentStateCircles.tsx`: adjusted `strokeWidth` to `1.333` on `SpinnerCircle`, `HollowCircle`, `InteractingCircle`, and `ExitedCircle`; scaled inner detail strokes (`InteractingCircle` cross `1.5→1.0`, `ExitedCircle` dash `1.8→1.2`); geometry unchanged
- All four circles are fixed rather than just the two in the filter bar — the same icons render in `HelpPanelHeader` and the terminal state config, so fixing only two would introduce a new inconsistency
- `icons-a11y.test.tsx`: added a regression test asserting the custom circles' stroke-to-viewBox ratio matches Lucide's, and that inner detail strokes keep their proportional thinness

## Testing

- Regression test added and passing
- Manually verified stroke weights visually align across all three filter chip states