### PR TITLE
fix(github): show real open issue/PR totals in toolbar badge

### DIFF
--- a/plugins/builtin/github/main/GitHubIssues.ts
+++ b/plugins/builtin/github/main/GitHubIssues.ts
@@ -618,6 +618,7 @@ export async function listIssues(
             hasNextPage: issues?.pageInfo?.hasNextPage ?? false,
             endCursor: issues?.pageInfo?.endCursor ?? null,
           },
+          totalCount,
         };
 
         issueListCache.set(cacheKey, result);

--- a/plugins/builtin/github/main/GitHubPRs.ts
+++ b/plugins/builtin/github/main/GitHubPRs.ts
@@ -514,6 +514,7 @@ export async function listPullRequests(
             hasNextPage: pullRequests?.pageInfo?.hasNextPage ?? false,
             endCursor: pullRequests?.pageInfo?.endCursor ?? null,
           },
+          totalCount,
         };
 
         prListCache.set(cacheKey, result);

--- a/plugins/builtin/github/main/GitHubStats.ts
+++ b/plugins/builtin/github/main/GitHubStats.ts
@@ -422,6 +422,7 @@ export async function getRepoStatsAndPage(
             hasNextPage: snapshot.issues.hasNextPage,
             endCursor: snapshot.issues.endCursor,
           },
+          totalCount: snapshot.issues.totalCount,
         });
         prListCache.set(prsListCacheKey, {
           items: snapshot.prs.items,
@@ -429,6 +430,7 @@ export async function getRepoStatsAndPage(
             hasNextPage: snapshot.prs.hasNextPage,
             endCursor: snapshot.prs.endCursor,
           },
+          totalCount: snapshot.prs.totalCount,
         });
         // Re-stamp the durable disk cache too. The 60s in-memory caches above
         // keep hot polls fast, but the disk cache is the failure-mode fallback:
@@ -560,10 +562,12 @@ export async function getRepoStatsAndPage(
     issueListCache.set(issuesListCacheKey, {
       items: issuesPage.items,
       pageInfo: { hasNextPage: issuesPage.hasNextPage, endCursor: issuesPage.endCursor },
+      totalCount: issuesPage.totalCount,
     });
     prListCache.set(prsListCacheKey, {
       items: prsPage.items,
       pageInfo: { hasNextPage: prsPage.hasNextPage, endCursor: prsPage.endCursor },
+      totalCount: prsPage.totalCount,
     });
 
     // Record the snapshot so the next poll can skip the heavy query when the

--- a/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
@@ -550,6 +550,32 @@ describe("GitHubResourceList SWR behavior", () => {
     });
   });
 
+  it("reports the server totalCount exactly for PR lists too (issue #9717)", async () => {
+    const prs = Array.from({ length: 20 }, (_, i) => ({
+      ...makeIssue(i + 1),
+      isDraft: false,
+      ciStatus: "SUCCESS" as const,
+    }));
+    mockListPRs.mockResolvedValue({
+      items: prs,
+      pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+      totalCount: 61,
+    });
+    const onCountUpdate = vi.fn();
+
+    render(
+      <GitHubResourceList type="pr" projectPath="/test/proj" onCountUpdate={onCountUpdate} />
+    );
+
+    await waitFor(() => {
+      expect(onCountUpdate).toHaveBeenCalled();
+    });
+    const [count, isApproximate] = onCountUpdate.mock.calls.at(-1) ?? [];
+    expect(count).toBe(61);
+    expect(count).not.toBe(prs.length);
+    expect(isApproximate).toBe(false);
+  });
+
   it("calls onCountUpdate again after a successful background revalidation", async () => {
     const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
     setCache(cacheKey, {
@@ -622,9 +648,11 @@ describe("GitHubResourceList SWR behavior", () => {
     onCountUpdate.mockClear();
 
     // Switch to the "closed" tab — a fresh first-page fetch fires for the
-    // closed filter key. It must NOT report into the open-count badge.
+    // closed filter key, carrying the closed totalCount. It must NOT report
+    // into the open-count badge (the open gate, not the count source, is the
+    // defense).
     mockListIssues.mockResolvedValue(
-      makeResponse([makeIssue(3), makeIssue(4), makeIssue(5), makeIssue(6)])
+      makeResponse([makeIssue(3), makeIssue(4), makeIssue(5), makeIssue(6)], 500)
     );
     act(() => {
       useGitHubFilterStore.getState().setIssueFilter("closed");

--- a/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
@@ -563,9 +563,7 @@ describe("GitHubResourceList SWR behavior", () => {
     });
     const onCountUpdate = vi.fn();
 
-    render(
-      <GitHubResourceList type="pr" projectPath="/test/proj" onCountUpdate={onCountUpdate} />
-    );
+    render(<GitHubResourceList type="pr" projectPath="/test/proj" onCountUpdate={onCountUpdate} />);
 
     await waitFor(() => {
       expect(onCountUpdate).toHaveBeenCalled();

--- a/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
@@ -185,9 +185,13 @@ const makeIssue = (n: number): GitHubIssue => ({
   commentCount: 0,
 });
 
-const makeResponse = (items: GitHubIssue[]): GitHubListResponse<GitHubIssue> => ({
+const makeResponse = (
+  items: GitHubIssue[],
+  totalCount?: number
+): GitHubListResponse<GitHubIssue> => ({
   items,
   pageInfo: { hasNextPage: false, endCursor: null },
+  ...(totalCount === undefined ? {} : { totalCount }),
 });
 
 beforeEach(() => {
@@ -486,7 +490,9 @@ describe("GitHubResourceList SWR behavior", () => {
     expect(mockListIssues.mock.calls[0]?.[0]?.bypassCache).toBe(false);
   });
 
-  it("reports hasMore=true via onCountUpdate when the first page is paginated", async () => {
+  it("falls back to loaded length + hasMore via onCountUpdate when no totalCount is present", async () => {
+    // No server totalCount (e.g. search/cache path): the badge approximates
+    // with the loaded length and the real hasNextPage flag, yielding "2+".
     mockListIssues.mockResolvedValue({
       items: [makeIssue(1), makeIssue(2)],
       pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
@@ -499,6 +505,48 @@ describe("GitHubResourceList SWR behavior", () => {
 
     await waitFor(() => {
       expect(onCountUpdate).toHaveBeenCalledWith(2, true);
+    });
+  });
+
+  it("reports the server totalCount as an exact count via onCountUpdate when paginated (issue #9717)", async () => {
+    // First page is capped at 20 with more pages, but the GraphQL response
+    // carries the real open total. The badge must show that total exactly,
+    // not "20+": the count is the totalCount and the approximate flag is false
+    // even though hasNextPage is true.
+    const items = Array.from({ length: 20 }, (_, i) => makeIssue(i + 1));
+    mockListIssues.mockResolvedValue({
+      items,
+      pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+      totalCount: 47,
+    });
+    const onCountUpdate = vi.fn();
+
+    render(
+      <GitHubResourceList type="issue" projectPath="/test/proj" onCountUpdate={onCountUpdate} />
+    );
+
+    await waitFor(() => {
+      expect(onCountUpdate).toHaveBeenCalled();
+    });
+    const [count, isApproximate] = onCountUpdate.mock.calls.at(-1) ?? [];
+    // totalCount is preferred over the loaded length (20)...
+    expect(count).toBe(47);
+    expect(count).not.toBe(items.length);
+    // ...and the count is exact, so the badge drops the "+" suffix.
+    expect(isApproximate).toBe(false);
+  });
+
+  it("treats a server totalCount of 0 as authoritative via onCountUpdate", async () => {
+    // `?? items.length` (not `|| items.length`) must keep a real zero total.
+    mockListIssues.mockResolvedValue(makeResponse([], 0));
+    const onCountUpdate = vi.fn();
+
+    render(
+      <GitHubResourceList type="issue" projectPath="/test/proj" onCountUpdate={onCountUpdate} />
+    );
+
+    await waitFor(() => {
+      expect(onCountUpdate).toHaveBeenCalledWith(0, false);
     });
   });
 

--- a/plugins/builtin/github/renderer/hooks/useGitHubResourceListSWR.ts
+++ b/plugins/builtin/github/renderer/hooks/useGitHubResourceListSWR.ts
@@ -274,14 +274,21 @@ export function useGitHubResourceListSWR({
                 timestamp: now,
               });
               setLastUpdatedAt(now);
-              // Bind the toolbar count badge to what the dropdown actually
-              // lists: the loaded first-page length plus whether more pages
-              // exist. Fires on cold-mount AND revalidation (NOT gated on
-              // `isRevalidate`) so the badge reconciles to the visible count
-              // the moment the dropdown first loads, not just on a later
-              // background refresh. The stats query's `totalCount` can exceed
-              // the loaded page, so the badge would otherwise assert a higher
-              // number than the list shows (issue #9693).
+              // Bind the toolbar count badge to the authoritative server total
+              // (`totalCount`) when the list query provides it, so the badge
+              // shows the real open count (e.g. "47") instead of the loaded
+              // first-page length with a "+" suffix ("20+", issue #9717). The
+              // `totalCount` comes from the same GraphQL response as the items,
+              // so it never claims more than is actually open (issue #9693).
+              // The second arg to `onCountUpdate` is the "count is approximate"
+              // flag that drives the badge's "+" suffix — when `totalCount` is
+              // known the count is exact, so it is `false`. Search results and
+              // cache hits carry no `totalCount`, so they fall back to the
+              // loaded length plus the real `hasNextPage`.
+              //
+              // Fires on cold-mount AND revalidation (NOT gated on
+              // `isRevalidate`) so the badge reconciles the moment the dropdown
+              // first loads, not just on a later background refresh.
               //
               // Gated to the `open` filter: the badge represents the OPEN
               // issue/PR count (its aria-label and tooltip say "open"). The
@@ -291,7 +298,10 @@ export function useGitHubResourceListSWR({
               // open badge. The last known open count stays correct while the
               // user browses other states.
               if (filterState === "open") {
-                onCountUpdate?.(result.items.length, result.pageInfo.hasNextPage);
+                onCountUpdate?.(
+                  result.totalCount ?? result.items.length,
+                  result.totalCount == null ? result.pageInfo.hasNextPage : false
+                );
               }
               // Notify parent (toolbar count badge) that fresh first-page data
               // landed. Gated on `isRevalidate` so it fires only when

--- a/shared/types/github.ts
+++ b/shared/types/github.ts
@@ -238,4 +238,11 @@ export interface GitHubListResponse<T> {
     /** Cursor for next page */
     endCursor: string | null;
   };
+  /**
+   * Server-side total for the requested states (GraphQL `totalCount`). Present
+   * only on the non-search list path; absent for search results, which have no
+   * stable "total open" count. Lets the toolbar badge show the real total
+   * instead of the loaded first-page length (issue #9717).
+   */
+  totalCount?: number;
 }


### PR DESCRIPTION
## Summary

- The toolbar issue/PR badge showed `20+` for any repo with more than one page of open items, because the count was bound to the first-page length (capped at 20 by the GraphQL page size).
- `totalCount` was already present in the GraphQL response but never wired to the renderer. This PR plumbs it through end-to-end.

Resolves #9717

## Changes

- Added optional `totalCount` to `GitHubListResponse<T>` in `shared/types/github.ts`.
- Populated it in `listIssues` (`GitHubIssues.ts`) and `listPullRequests` (`GitHubPRs.ts`) from the non-search GraphQL response.
- Wired it through both the network and snapshot-restore paths in `GitHubStats.ts` cache warming.
- `useGitHubResourceListSWR` now reports the authoritative `totalCount` with the `approximate` flag forced to `false` when present; falls back to `loaded.length + hasNextPage` for search and cache-miss paths.
- Search path intentionally untouched: the Search API total doesn't equal open count.

## Testing

- 93 unit tests pass, including new cases for `totalCount` preference, zero-total authority (`??` not `||`), PR exact-count, and a strengthened closed-filter no-poison test.
- `npm run check` passes (typecheck, lint, format, IPC codegen, confirm-wiring).