### PR TITLE
fix(theme): live theme switch leaves panel grid showing stale color until restart

### DIFF
--- a/electron/window/__tests__/skeletonCss.test.ts
+++ b/electron/window/__tests__/skeletonCss.test.ts
@@ -96,6 +96,43 @@ describe("injectSkeletonCss accent override (#9162)", () => {
   });
 });
 
+describe("injectSkeletonCss var scoping (#9716)", () => {
+  beforeEach(() => {
+    storeMock.get.mockClear();
+  });
+
+  it("scopes seeded theme vars to #startup-skeleton, never :root", () => {
+    const wc = makeWc();
+    injectSkeletonCss(wc as never);
+    const css = wc.insertCSS.mock.calls[0]?.[0] as string;
+    // A :root-scoped block would persist (user-origin insertCSS is never
+    // removed) and leak removed optional tokens after a theme switch.
+    expect(css).toContain("#startup-skeleton {");
+    expect(css).not.toMatch(/(^|\s):root\s*\{/);
+  });
+
+  it("emits the light theme's optional panel-grid-bg extension under #startup-skeleton, not :root", () => {
+    // Bondi is a light theme that defines the `panel-grid-bg` extension. Before
+    // the fix this was injected at `:root` and survived a light→dark switch
+    // because the dark theme removes the inline override, leaving the stale
+    // skeleton value to win the cascade.
+    storeMock.get.mockImplementation((key: string) => {
+      if (key === "appState") return { sidebarWidth: 350, focusMode: false };
+      if (key === "appTheme") return { colorSchemeId: "bondi" };
+      return undefined;
+    });
+    const wc = makeWc();
+    injectSkeletonCss(wc as never);
+    const css = wc.insertCSS.mock.calls[0]?.[0] as string;
+    // The extension token is still emitted (so the splash paints correctly)...
+    expect(css).toContain("--panel-grid-bg:");
+    // ...but the only selector wrapping it is the scoped one.
+    const selectors = css.match(/[^\s][^{]*\{/g) ?? [];
+    expect(selectors.some((s) => s.trim().startsWith("#startup-skeleton"))).toBe(true);
+    expect(selectors.some((s) => s.trim().startsWith(":root"))).toBe(false);
+  });
+});
+
 describe("injectSkeletonProjectIdentity (#9162)", () => {
   it("paints emoji and name into the title via executeJavaScript", () => {
     const wc = makeWc();

--- a/electron/window/__tests__/skeletonCss.test.ts
+++ b/electron/window/__tests__/skeletonCss.test.ts
@@ -98,7 +98,14 @@ describe("injectSkeletonCss accent override (#9162)", () => {
 
 describe("injectSkeletonCss var scoping (#9716)", () => {
   beforeEach(() => {
-    storeMock.get.mockClear();
+    // Reset to a deterministic default each test so the Bondi override below
+    // can't leak its implementation into adjacent tests.
+    storeMock.get.mockReset();
+    storeMock.get.mockImplementation((key: string) => {
+      if (key === "appState") return { sidebarWidth: 350, focusMode: false };
+      if (key === "appTheme") return { colorSchemeId: "daintree" };
+      return undefined;
+    });
   });
 
   it("scopes seeded theme vars to #startup-skeleton, never :root", () => {

--- a/electron/window/skeletonCss.ts
+++ b/electron/window/skeletonCss.ts
@@ -133,8 +133,19 @@ export function injectSkeletonCss(wc: WebContents, project?: Pick<Project, "colo
   const themedScheme = applyAccentOverrideToScheme(scheme, project?.color);
   const themeVars = getAppThemeCssVariables(themedScheme);
 
-  // Build CSS string
-  const lines: string[] = [":root {"];
+  // Scope the seeded vars to `#startup-skeleton`, NOT `:root`. This stylesheet
+  // is injected via user-origin `insertCSS` and is never removed — it persists
+  // for the whole session. Required `--theme-*` tokens are harmless because the
+  // renderer re-sets them inline on `documentElement` on every theme switch, and
+  // inline (author-origin) styles outrank user-origin rules (#9333). But OPTIONAL
+  // extension tokens (e.g. `--panel-grid-bg`, emitted only by light themes) are
+  // REMOVED inline on a light→dark switch — with no inline value left, a `:root`
+  // declaration here would win the cascade and leak the old light value until
+  // restart (#9716). Scoping to `#startup-skeleton` keeps the splash themed (its
+  // descendants inherit these vars) while ensuring nothing leaks into the live
+  // app, whose own vars live on `:root` via applyDefaultAppTheme. `#root` is a
+  // sibling of `#startup-skeleton`, so the app never inherits this block.
+  const lines: string[] = ["#startup-skeleton {"];
 
   // Theme tokens (--theme-surface-canvas, --theme-border-default, etc.)
   for (const [prop, value] of Object.entries(themeVars)) {

--- a/electron/window/skeletonCss.ts
+++ b/electron/window/skeletonCss.ts
@@ -173,7 +173,11 @@ export function injectSkeletonCss(wc: WebContents, project?: Pick<Project, "colo
     lines.push("#startup-skeleton .skeleton-sidebar { display: none; }");
   }
 
-  void wc.insertCSS(lines.join("\n"), { cssOrigin: "user" });
+  void wc.insertCSS(lines.join("\n"), { cssOrigin: "user" }).catch(() => {
+    // Best-effort first-paint seed: a destroyed/navigated WebContents during
+    // rapid project switching rejects here. Swallow — the index.html skeleton
+    // styles carry hardcoded fallbacks, so the splash still paints.
+  });
 }
 
 /**


### PR DESCRIPTION
The first-paint skeleton CSS injected via `insertCSS` was using `:root` scope. This meant optional extension tokens like `--panel-grid-bg` — present in light themes but absent from dark ones — stuck around after a theme switch and took precedence over the new theme's cascade. The panel grid background kept the old light color until the app restarted; everything else (Settings dialog, etc.) updated correctly.

The fix scopes the seeded block to `#startup-skeleton` instead of `:root`, so the live app (`#root`, a sibling) never inherits stale vars from the skeleton stylesheet. The splash markup still inherits what it needs; the persistent `insertCSS` stylesheet can no longer win the cascade for removed optional tokens. Generalizes to all optional extension tokens, not just `--panel-grid-bg`.

Also added a `.catch` guard on `insertCSS` so a rejection in a destroyed webContents doesn't surface as an unhandled promise, and tightened the test mock to isolate the `insertCSS` implementation.

Regression tests added covering the `:root` vs `#startup-skeleton` scoping and the light-theme extension token. `npm run check` clean.

Resolves #9716.