### PR TITLE
Redesign the Svalbard light theme

### DIFF
--- a/shared/theme/builtInThemes/svalbard.ts
+++ b/shared/theme/builtInThemes/svalbard.ts
@@ -156,8 +156,5 @@ export const theme: BuiltInThemeSource = {
     "toolbar-project-shadow": "inset 0 1px 0 rgba(255,255,255,0.45)",
     "toolbar-stats-border": "rgba(162,177,189,0.55)",
     "toolbar-stats-divider": "rgba(162,177,189,0.55)",
-    // Recessed filter strip ~0.05 L below the sidebar rail. Inert until the
-    // `worktree-filter-bar-bg` extension infra lands with #9723 (Hokkaido).
-    "worktree-filter-bar-bg": "#C5D4DF",
   },
 };

--- a/shared/theme/builtInThemes/svalbard.ts
+++ b/shared/theme/builtInThemes/svalbard.ts
@@ -15,14 +15,14 @@ export const theme: BuiltInThemeSource = {
     // clean glacial white while the structural floor (grid) and the sidebar rail
     // hold the cool chroma. The sidebar→canvas step is the largest in the ramp
     // (dL≈0.033) so the navigation rail reads as a distinct deeper zone instead
-    // of merging into the canvas. Audit-clean: even ramp, span 0.106,
+    // of merging into the canvas. Audit-clean: even ramp, span 0.104,
     // panel→elevated keeps the strongest top-tier lift.
     surfaces: {
       grid: "#CFDDE8",
       sidebar: "#D7E4ED",
       canvas: "#E6EEF3",
       panel: "#F1F6F9",
-      elevated: "#FCFEFF",
+      elevated: "#FAFEFF",
     },
     text: {
       primary: "#1B2A38",
@@ -35,7 +35,10 @@ export const theme: BuiltInThemeSource = {
     accentSecondary: "#1F7E62",
     status: {
       success: "#1E7A5C",
-      warning: "#8A661A",
+      // Cold-sunlight amber (OKLCH hue ~62) instead of the old olive #8A661A
+      // (hue ~81) — the lone khaki note on an otherwise cool field read as
+      // mustard against arctic blue. Same lightness, AA-clean on all surfaces.
+      warning: "#9A5F24",
       danger: "#C0413E",
       info: "#2E6E96",
     },
@@ -43,14 +46,16 @@ export const theme: BuiltInThemeSource = {
       active: "#1E7A5C",
       idle: "#586B7E",
       working: "#1E7A5C",
-      waiting: "#8A661A",
+      waiting: "#9A5F24",
     },
     overlayTint: "#142332",
     terminal: {
       background: "#1C2630",
       foreground: "#D2D9E0",
       muted: "#8C9E94",
-      cursor: "#8F7335",
+      // Icy caret (5.8:1 on the dark field) — the old muddy gold #8F7335 was
+      // the one warm spike on the cold terminal and sat at 3.4:1.
+      cursor: "#7DA4C0",
       selection: "#2A3A4A",
       red: "#C87878",
       green: "#5DA88A",
@@ -86,8 +91,15 @@ export const theme: BuiltInThemeSource = {
   },
   tokens: {
     "accent-hover": "color-mix(in oklab, #1577A8 90%, #ffffff)",
+    // Two-layer contact+spread shadows tinted in Svalbard's own ink
+    // (rgb(20,35,50), the overlayTint) — the derived "light" profile's wide
+    // thin blur renders zero visible pixels against this theme's near-white
+    // surfaces, so tooltips/popovers/cards separated by border alone.
+    "shadow-ambient": "0 1px 2px rgba(20,35,50,0.10), 0 4px 12px rgba(20,35,50,0.09)",
+    "shadow-floating": "0 2px 6px rgba(20,35,50,0.12), 0 14px 36px rgba(20,35,50,0.15)",
+    "shadow-dialog": "0 4px 10px rgba(20,35,50,0.13), 0 26px 60px rgba(20,35,50,0.18)",
     "text-link": "#1E5A72",
-    "text-placeholder": "#67737E",
+    "text-placeholder": "#5E6B77",
     "category-amber": "oklch(0.60 0.110 75)",
     "category-blue": "oklch(0.58 0.110 242)",
     "category-cyan": "oklch(0.59 0.080 198)",
@@ -116,16 +128,18 @@ export const theme: BuiltInThemeSource = {
     "search-selected-result-border": "#1A5066",
     "search-selected-result-icon": "#1A5066",
     "surface-input": "#E2EAF0",
-    "surface-inset": "#D5E1E9",
+    // A real well: deep enough to read as recessed on the sidebar rail
+    // (dL -0.027), not just on the snow-white selected row.
+    "surface-inset": "#CEDBE5",
     "surface-toolbar": "#DAE5ED",
     "terminal-black": "#1C2630",
     "terminal-bright-black": "#52606B",
     "terminal-white": "#D2D9E0",
   },
   extensions: {
-    "panel-grid-bg": "#D0DEE8",
+    "panel-grid-bg": "#C9D7E2",
     "pulse-before-bg": "#D7E4ED",
-    "pulse-card-bg": "#FCFEFF",
+    "pulse-card-bg": "#FAFEFF",
     "pulse-control-hover-bg": "rgba(20,35,50,0.05)",
     "pulse-empty-bg": "#E6EEF3",
     "pulse-heat-high-opacity": "0.90",
@@ -133,18 +147,18 @@ export const theme: BuiltInThemeSource = {
     "pulse-heat-medium-opacity": "0.66",
     "pulse-missed-bg": "#C0413E",
     "pulse-range-bg": "#E6EEF3",
-    "pulse-ring-offset": "#FCFEFF",
-    "pulse-skeleton-gradient": "linear-gradient(90deg, #D5E1E9 25%, #E6EEF3 50%, #D5E1E9 75%)",
-    "settings-card-bg": "#FCFEFF",
-    "settings-kbd-bg": "#D5E1E9",
+    "pulse-ring-offset": "#FAFEFF",
+    "pulse-skeleton-gradient": "linear-gradient(90deg, #CEDBE5 25%, #E6EEF3 50%, #CEDBE5 75%)",
+    "settings-card-bg": "#FAFEFF",
+    "settings-kbd-bg": "#CEDBE5",
     "settings-kbd-border": "rgba(20,35,50,0.10)",
-    "settings-list-item-bg": "#FCFEFF",
-    "settings-nav-active-bg": "#FCFEFF",
+    "settings-list-item-bg": "#FAFEFF",
+    "settings-nav-active-bg": "#FAFEFF",
     "settings-search-bg": "#E2EAF0",
     "settings-sidebar-bg": "#D7E4ED",
     // Issue 1: selection elevates, container recedes. Selected lifts to elevated
-    // (L 0.996 vs sidebar 0.912), hover to canvas (L 0.944) — idle < hover < selected.
-    "sidebar-active-bg": "#FCFEFF",
+    // (L 0.994 vs sidebar 0.912), hover to canvas (L 0.944) — idle < hover < selected.
+    "sidebar-active-bg": "#FAFEFF",
     "sidebar-hover-bg": "#E6EEF3",
     "toolbar-control-hover-fg": "#1577A8",
     "toolbar-divider": "rgba(162,177,189,0.55)",

--- a/shared/theme/builtInThemes/svalbard.ts
+++ b/shared/theme/builtInThemes/svalbard.ts
@@ -9,12 +9,20 @@ export const theme: BuiltInThemeSource = {
   heroImage: "/themes/svalbard.webp",
   palette: {
     type: "light",
+    // Ramp rebalance (#9714): the prior band floored at L≈0.87 (grid #C9D6E2),
+    // which read as an overcast mid-gray rather than arctic snow. Lifted into an
+    // airy band where the content surfaces (canvas/panel/elevated) trend toward
+    // clean glacial white while the structural floor (grid) and the sidebar rail
+    // hold the cool chroma. The sidebar→canvas step is the largest in the ramp
+    // (dL≈0.033) so the navigation rail reads as a distinct deeper zone instead
+    // of merging into the canvas. Audit-clean: even ramp, span 0.106,
+    // panel→elevated keeps the strongest top-tier lift.
     surfaces: {
-      grid: "#C9D6E2",
-      sidebar: "#D2DEE8",
-      canvas: "#DCE6EE",
-      panel: "#E6EFF5",
-      elevated: "#F4F9FC",
+      grid: "#CFDDE8",
+      sidebar: "#D7E4ED",
+      canvas: "#E6EEF3",
+      panel: "#F1F6F9",
+      elevated: "#FCFEFF",
     },
     text: {
       primary: "#1B2A38",
@@ -22,7 +30,7 @@ export const theme: BuiltInThemeSource = {
       muted: "#586B7E",
       inverse: "#FFFFFF",
     },
-    border: "#9DAEBD",
+    border: "#A2B1BD",
     accent: "#1577A8",
     accentSecondary: "#1F7E62",
     status: {
@@ -107,46 +115,49 @@ export const theme: BuiltInThemeSource = {
     "search-match-badge-text": "#1A5066",
     "search-selected-result-border": "#1A5066",
     "search-selected-result-icon": "#1A5066",
-    "surface-input": "#D6E1EA",
-    "surface-inset": "#CFDBE5",
-    "surface-toolbar": "#D8E3EC",
+    "surface-input": "#E2EAF0",
+    "surface-inset": "#D5E1E9",
+    "surface-toolbar": "#DAE5ED",
     "terminal-black": "#1C2630",
     "terminal-bright-black": "#52606B",
     "terminal-white": "#D2D9E0",
   },
   extensions: {
-    "panel-grid-bg": "#D8E2EB",
-    "pulse-before-bg": "#D2DEE8",
-    "pulse-card-bg": "#F4F9FC",
+    "panel-grid-bg": "#D0DEE8",
+    "pulse-before-bg": "#D7E4ED",
+    "pulse-card-bg": "#FCFEFF",
     "pulse-control-hover-bg": "rgba(20,35,50,0.05)",
-    "pulse-empty-bg": "#D8E3EC",
+    "pulse-empty-bg": "#E6EEF3",
     "pulse-heat-high-opacity": "0.90",
     "pulse-heat-low-opacity": "0.42",
     "pulse-heat-medium-opacity": "0.66",
     "pulse-missed-bg": "#C0413E",
-    "pulse-range-bg": "#D8E3EC",
-    "pulse-ring-offset": "#F4F9FC",
-    "pulse-skeleton-gradient": "linear-gradient(90deg, #CFDBE5 25%, #DDE7EF 50%, #CFDBE5 75%)",
-    "settings-card-bg": "#F4F9FC",
-    "settings-kbd-bg": "#CFDBE5",
+    "pulse-range-bg": "#E6EEF3",
+    "pulse-ring-offset": "#FCFEFF",
+    "pulse-skeleton-gradient": "linear-gradient(90deg, #D5E1E9 25%, #E6EEF3 50%, #D5E1E9 75%)",
+    "settings-card-bg": "#FCFEFF",
+    "settings-kbd-bg": "#D5E1E9",
     "settings-kbd-border": "rgba(20,35,50,0.10)",
-    "settings-list-item-bg": "#F4F9FC",
-    "settings-nav-active-bg": "#F4F9FC",
-    "settings-search-bg": "#D6E1EA",
-    "settings-sidebar-bg": "#D2DEE8",
-    // Issue 1: selection elevates, container recedes. Selected lifts to panel
-    // (L 0.947 vs sidebar 0.894), hover to canvas (L 0.920) — idle < hover < selected.
-    "sidebar-active-bg": "#E6EFF5",
-    "sidebar-hover-bg": "#DCE6EE",
+    "settings-list-item-bg": "#FCFEFF",
+    "settings-nav-active-bg": "#FCFEFF",
+    "settings-search-bg": "#E2EAF0",
+    "settings-sidebar-bg": "#D7E4ED",
+    // Issue 1: selection elevates, container recedes. Selected lifts to elevated
+    // (L 0.996 vs sidebar 0.912), hover to canvas (L 0.944) — idle < hover < selected.
+    "sidebar-active-bg": "#FCFEFF",
+    "sidebar-hover-bg": "#E6EEF3",
     "toolbar-control-hover-fg": "#1577A8",
-    "toolbar-divider": "rgba(157,174,189,0.55)",
+    "toolbar-divider": "rgba(162,177,189,0.55)",
     "toolbar-project-bg":
-      "linear-gradient(180deg, rgba(21,119,168,0.06), rgba(20,35,50,0.05)), linear-gradient(135deg, #D6E2EB, #BFCEDB)",
-    "toolbar-project-border": "rgba(157,174,189,0.65)",
+      "linear-gradient(180deg, rgba(21,119,168,0.06), rgba(20,35,50,0.05)), linear-gradient(135deg, #DCE7EF, #CFDDE8)",
+    "toolbar-project-border": "rgba(162,177,189,0.65)",
     "toolbar-project-chip-bg": "rgba(20,35,50,0.05)",
-    "toolbar-project-chip-border": "rgba(157,174,189,0.65)",
+    "toolbar-project-chip-border": "rgba(162,177,189,0.65)",
     "toolbar-project-shadow": "inset 0 1px 0 rgba(255,255,255,0.45)",
-    "toolbar-stats-border": "rgba(157,174,189,0.55)",
-    "toolbar-stats-divider": "rgba(157,174,189,0.55)",
+    "toolbar-stats-border": "rgba(162,177,189,0.55)",
+    "toolbar-stats-divider": "rgba(162,177,189,0.55)",
+    // Recessed filter strip ~0.05 L below the sidebar rail. Inert until the
+    // `worktree-filter-bar-bg` extension infra lands with #9723 (Hokkaido).
+    "worktree-filter-bar-bg": "#C5D4DF",
   },
 };


### PR DESCRIPTION
This is a redesign of the Svalbard light theme, which #9714 called out as ugly, unbalanced, and depressing. It's deliberately conservative: the arctic blue identity stays, and the text, accent, and syntax tokens are untouched.

The main issue was the surface ramp sitting in a dark band. The grid floored at OKLCH lightness 0.87, so the whole UI read as an overcast gray, and the sidebar barely separated from the canvas.

## Round 1 — surface rebalance

- Lifts the five surfaces into a lighter band (grid `#C9D6E2` → `#CFDDE8`, elevated up to `#FAFEFF`). The content surfaces (canvas, panel, elevated) lose most of their blue tint and trend toward glacial white, while the structural surfaces (grid, sidebar) keep it.
- Makes the sidebar-to-canvas step the largest in the ramp (~0.033 OKLCH L), so the rail reads as its own zone instead of merging into the canvas.
- Lifts the selected worktree row to near-white with hover at canvas, so idle < hover < selected actually reads in the sidebar.
- Re-anchors the extension surfaces (settings cards, pulse card, toolbar project pill, `panel-grid-bg`, inputs and insets) to the new band, and softens the base border to `#A2B1BD`.

## Round 2 — micro polish from screenshot review

A second pass over real screenshots of the tooltips, popovers, terminal-in-grid, and sidebar interaction states:

- **Ink-tinted shadow ladder** (`shadow-ambient`/`floating`/`dialog`): pixel-sampling the screenshots showed the derived "light" shadow profile renders zero visible pixels on these near-white surfaces, so tooltips, the filter popover, and the Pulse card separated by hairline border alone. Two-layer contact+spread shadows in Svalbard's own ink (`rgba(20,35,50)`, the overlayTint) restore real lift — same approach Hokkaido used.
- **Warning re-hued off olive**: `#8A661A` (OKLCH hue ~81, khaki) was the lone warm-mustard note on the cold field; now a cold-sunlight amber `#9A5F24` (hue ~62), same lightness, `activity.waiting` in lockstep.
- **Icy terminal caret**: the muddy-gold cursor `#8F7335` (3.4:1) was the one warm spike on the blue-black terminal; now glacial `#7DA4C0` at 5.8:1.
- **Consistent inset wells**: `surface-inset` deepened to `#CEDBE5` so the sidebar commit chips read as recessed on idle rows too, not only on the snow-white selected row.
- **Elevated re-tinted** from neutral `#FCFEFF` to faintly glacial `#FAFEFF` so the brightest tier (selected rows, cards) reads as sunlit snow rather than plain white; `panel-grid-bg` deepened so the grid gutter cradles panels; `text-placeholder` darkened to clear 4.5:1 in the search field.

## Worktree filter bar

Svalbard's recessed filter-bar strip is `"worktree-filter-bar-bg": "#C5D4DF"` (~0.05 L below the rail), but the opt-in extension key only lands with #9723, and the extension type plus the governance test reject it until then. The value is deliberately left out of this PR so it stays green standalone; it's a one-line follow-up once #9723 is in develop. I verified the strip renders correctly by applying the #9723 infrastructure locally.

All theme audit gates pass (ramp evenness and span, panel-to-elevated rule, border separation, selection/elevation matrix, full contrast suite — 219/219). Both rounds were verified against real before/after screenshots of the workbench, sidebar, terminal grid, tooltips, popovers, and settings, with a multi-perspective design review over the screenshots driving the round-2 changes.

Resolves #9714.