### PR TITLE
Redesign the Atacama light theme

### DIFF
--- a/docs/themes/theme-tokens.md
+++ b/docs/themes/theme-tokens.md
@@ -394,7 +394,7 @@ Add a `tokens` object to override any semantic values that don't derive well. Co
 
 Add an `extensions` object for component-specific overrides. These become bare CSS custom properties. Only add what you need — omitted extensions fall back to semantic tokens.
 
-Common extension families: `toolbar-*`, `sidebar-*`, `settings-*`, `pulse-*`, `dock-*`, `panel-grid-bg`, `worktree-section-hover-bg`.
+Common extension families: `toolbar-*`, `sidebar-*`, `settings-*`, `pulse-*`, `dock-*`, `panel-grid-bg`, `worktree-section-hover-bg`, `worktree-filter-bar-bg` (opt-in distinct surface for the worktree sidebar's filter/search bar — unset themes keep the bar transparent).
 
 ### 4. Register the theme
 

--- a/shared/theme/builtInThemes/atacama.ts
+++ b/shared/theme/builtInThemes/atacama.ts
@@ -9,12 +9,17 @@ export const theme: BuiltInThemeSource = {
   heroImage: "/themes/atacama.webp",
   palette: {
     type: "light",
+    // Lightness rebalance (bondi precedent): the ramp lifted a few L-points and
+    // desaturated (canvas C ~0.024 -> ~0.016 — it was the most saturated canvas
+    // of the warm cohort and read as a tan slab). Hue stays in the desert band
+    // (h 79-85); depth is carried by the solid border, the recessed sidebar
+    // band, and the opaque inset wells instead of surface saturation.
     surfaces: {
-      grid: "#E0D4C0",
-      sidebar: "#E9DECC",
-      canvas: "#EFE6D6",
-      panel: "#F4EDE2",
-      elevated: "#FCF9F2",
+      grid: "#E5DBCA",
+      sidebar: "#ECE3D5",
+      canvas: "#F2ECE1",
+      panel: "#F8F3EB",
+      elevated: "#FEFCF8",
     },
     text: {
       primary: "#2E2620",
@@ -22,7 +27,13 @@ export const theme: BuiltInThemeSource = {
       muted: "#6E6155",
       inverse: "#F9F7F4",
     },
-    border: "rgba(51,43,35,0.16)",
+    // Solid warm sand-taupe border (was the lone alpha border among the light
+    // themes — rgba(51,43,35,0.16) composited to a washed cool grime ~1.35:1 on
+    // the brightest surface). An opaque on-temperature hex keeps its warm hue
+    // and reads as a crisp desert line across every surface (clears the 1.18
+    // light-border floor: elevated ~1.8, grid ~1.3), matching the polished
+    // siblings (table-mountain #C2B9AC, serengeti #D4C499).
+    border: "#C9BCA5",
     accent: "#B25024",
     accentSecondary: "#3E7A50",
     status: {
@@ -73,9 +84,25 @@ export const theme: BuiltInThemeSource = {
     strategy: {
       materialBlur: 12,
       materialSaturation: 118,
+      // Warm charcoal ink for the derived border ladder (subtle/strong/divider/
+      // interactive). The engine default is a cool near-black (#0f141b) that
+      // reads grey-blue against warm sand; this is the documented Atacama use
+      // case for the knob (see ThemeStrategy.borderInkOverride). Reuses the
+      // overlayTint charcoal so all composited lines share one warm ink.
+      borderInkOverride: "#332B23",
     },
   },
   tokens: {
+    // Opaque recessed wells (bondi's grid-floor pattern). The engine-derived
+    // light values are faint alpha washes (surface-inset = 6% warm charcoal)
+    // that read as mud inside the near-white worktree cards; pinning them to
+    // opaque sand steps makes the detail/terminal sections and inputs read as
+    // true recessed planes. inset sits just below the grid floor; input just
+    // below canvas (the light input-well idiom); toolbar pinned to sidebar so
+    // the top chrome stays one coherent band as the ramp shifts.
+    "surface-inset": "#E0D4C0",
+    "surface-input": "#EEE7DA",
+    "surface-toolbar": "#ECE3D5",
     "text-link": "#9B3F18",
     "text-placeholder": "rgba(46,38,32,0.55)",
     "overlay-hover": "rgba(51,43,35,0.075)",
@@ -96,7 +123,7 @@ export const theme: BuiltInThemeSource = {
     "focus-ring": "rgba(178,80,36,0.32)",
     "pr-closed": "#C72B36",
     "pr-draft": "#646B75",
-    // AA on atacama's near-white panel (#F4EDE2): the prior #8254DB/#1C823B were
+    // AA on atacama's near-white panel (#F8F3EB): the prior #8254DB/#1C823B were
     // 4.26/4.19:1 (just under 4.5); darkened keeping hue (E6/B1).
     "pr-merged": "#7444CC",
     "pr-open": "#166E30",
@@ -113,40 +140,38 @@ export const theme: BuiltInThemeSource = {
     "terminal-white": "#DFD7CD",
   },
   extensions: {
-    "panel-grid-bg": "#EBE1D0",
-    "settings-dialog-bg": "#F4EDE2",
-    "settings-card-bg": "#FCF9F2",
-    "settings-list-item-bg": "#FCF9F2",
-    "pulse-before-bg": "#E0D4C0",
-    "pulse-card-bg": "#FCF9F2",
+    // G1: the gutter behind panel tiles must sit at/just-below surface-grid
+    // (#E5DBCA) so tiles read as raised figures, not wells.
+    "panel-grid-bg": "#E3D8C6",
+    "pulse-before-bg": "#E5DBCA",
+    "pulse-card-bg": "#FEFCF8",
     "pulse-card-header-bg": "#DDE8EE",
-    "pulse-card-shadow": "0 1px 3px rgba(51,43,35,0.07)",
+    "pulse-card-shadow": "0 1px 3px rgba(51,43,35,0.11)",
     "pulse-control-hover-bg": "rgba(51,43,35,0.05)",
-    "pulse-empty-bg": "#E9DECC",
+    "pulse-empty-bg": "#ECE3D5",
     "pulse-heat-color": "#2E8550",
-    "pulse-heat-high-opacity": "0.85",
+    "pulse-heat-high-opacity": "0.88",
     "pulse-heat-low-opacity": "0.38",
     "pulse-heat-medium-opacity": "0.62",
     "pulse-missed-bg": "#B23E32",
-    "pulse-range-bg": "#E9DECC",
-    "pulse-ring-offset": "#FCF9F2",
-    "pulse-skeleton-gradient": "linear-gradient(90deg, #DBCFBA 25%, #E7DCCA 50%, #DBCFBA 75%)",
+    "pulse-range-bg": "#ECE3D5",
+    "pulse-ring-offset": "#FEFCF8",
+    "pulse-skeleton-gradient": "linear-gradient(90deg, #E0D4C0 25%, #ECE3D5 50%, #E0D4C0 75%)",
     "settings-kbd-border": "#C5BDB2",
-    "settings-nav-active-bg": "#FCF9F2",
     "settings-nav-hover-bg": "rgba(178,80,36,0.08)",
     "sidebar-action-hover-bg": "rgba(178,80,36,0.08)",
     // Issue 1: selection elevates, container recedes. Selected lifts to panel
-    // (L 0.949 vs sidebar 0.905), hover to canvas (L 0.928) — idle < hover < selected.
-    "sidebar-active-bg": "#F4EDE2",
-    "sidebar-hover-bg": "#EFE6D6",
+    // (L 0.966 vs sidebar 0.919), hover to canvas (L 0.945) — idle < hover < selected.
+    "sidebar-active-bg": "#F8F3EB",
+    "sidebar-hover-bg": "#F2ECE1",
     "toolbar-agent-hover-bg": "rgba(178,80,36,0.08)",
     "toolbar-control-hover-bg": "rgba(178,80,36,0.08)",
     "toolbar-control-hover-fg": "#9B3F18",
     "toolbar-divider": "rgba(197,189,178,0.6)",
     "toolbar-project-bg":
-      "linear-gradient(180deg, rgba(178,80,36,0.05), rgba(51,43,35,0.04)), linear-gradient(135deg, #E7DECF, #D8CFBE)",
+      "linear-gradient(180deg, rgba(178,80,36,0.05), rgba(51,43,35,0.04)), linear-gradient(135deg, #EEE7DA, #E5DBCA)",
     "toolbar-project-border": "rgba(197,189,178,0.6)",
-    "toolbar-project-chip-bg": "#F4EDE2",
+    "toolbar-project-chip-bg": "#F8F3EB",
     "toolbar-project-chip-border": "rgba(197,189,178,0.7)",
     "toolbar-project-shadow": "inset 0 1px 0 rgba(255,252,248,0.45), 0 1px 3px rgba(51,43,35,0.07)",
     "toolbar-stats-bg": "rgba(178,80,36,0.05)",
@@ -154,6 +179,12 @@ export const theme: BuiltInThemeSource = {
     "toolbar-stats-divider": "rgba(197,189,178,0.6)",
     "toolbar-stats-hover-bg": "rgba(178,80,36,0.08)",
     "worktree-section-hover-bg": "rgba(178,80,36,0.08)",
+    // Recessed chrome strip for the worktree search/filter bars (#9712 infra:
+    // opt-in, unset themes keep the bars transparent). #DBCFBA sits ~0.07 L
+    // below the sidebar — deliberately below even the grid floor, so the
+    // chrome recedes and the worktree cards read as content on the brighter
+    // sidebar plane ("not everything the same shade of light").
+    "worktree-filter-bar-bg": "#DBCFBA",
     "dock-shadow":
       "inset 0 1px 0 rgba(255,252,248,0.5), 0 -2px 10px rgb(from var(--theme-shadow-color) r g b / 0.3)",
   },

--- a/shared/theme/builtInThemes/atacama.ts
+++ b/shared/theme/builtInThemes/atacama.ts
@@ -103,6 +103,25 @@ export const theme: BuiltInThemeSource = {
     "surface-inset": "#E0D4C0",
     "surface-input": "#EEE7DA",
     "surface-toolbar": "#ECE3D5",
+    // Warm-ink shadow system (Hokkaido pattern). The derived "light" profile
+    // composites from a cool slate ink and the default shadow-color is pure
+    // black — both dissolve into an off-temperature haze on warm sand, leaving
+    // floating surfaces to hang on hairlines. A two-layer contact+spread
+    // ladder in the theme's own charcoal (51,43,35 = overlayTint) gives
+    // palettes/menus/dialogs real lift that stays on-temperature.
+    "shadow-color": "rgba(51,43,35,0.13)",
+    "shadow-ambient": "0 1px 2px rgba(51,43,35,0.10), 0 4px 12px rgba(51,43,35,0.10)",
+    "shadow-floating": "0 2px 4px rgba(51,43,35,0.12), 0 10px 28px rgba(51,43,35,0.14)",
+    "shadow-dialog": "0 4px 8px rgba(51,43,35,0.14), 0 18px 44px rgba(51,43,35,0.18)",
+    // Selected/raised fill (menus, active tabs, settings nav): the engine
+    // default is elevated pulled toward charcoal — an inert grey nudge beside
+    // Atacama's terracotta-tinted hover language. Elevated nudged ~10% toward
+    // the accent instead: the same warmth as the rgba(178,80,36,0.08) hovers,
+    // as a fill only (no second accent anchor).
+    "overlay-raised": "#F6EBE3",
+    // Derived divider (8.5% ink) vanishes on the elevated menu surface; 12%
+    // keeps it a quiet warm hairline that actually registers.
+    "border-divider": "rgba(51,43,35,0.12)",
     "text-link": "#9B3F18",
     "text-placeholder": "rgba(46,38,32,0.55)",
     "overlay-hover": "rgba(51,43,35,0.075)",
@@ -120,7 +139,9 @@ export const theme: BuiltInThemeSource = {
     "category-rose": "oklch(0.61 0.14 14)",
     "category-teal": "oklch(0.60 0.12 178)",
     "category-violet": "oklch(0.59 0.13 295)",
-    "focus-ring": "rgba(178,80,36,0.32)",
+    // The one load-bearing focus signal — 0.32 read as a pale wash on the
+    // bright field; 0.45 is unmistakable while staying translucent.
+    "focus-ring": "rgba(178,80,36,0.45)",
     "pr-closed": "#C72B36",
     "pr-draft": "#646B75",
     // AA on atacama's near-white panel (#F8F3EB): the prior #8254DB/#1C823B were
@@ -145,8 +166,12 @@ export const theme: BuiltInThemeSource = {
     "panel-grid-bg": "#E3D8C6",
     "pulse-before-bg": "#E5DBCA",
     "pulse-card-bg": "#FEFCF8",
-    "pulse-card-header-bg": "#DDE8EE",
-    "pulse-card-shadow": "0 1px 3px rgba(51,43,35,0.11)",
+    // Warm sand header — the old #DDE8EE cool blue was the one off-biome
+    // surface in the workbench and broke the desert envelope.
+    "pulse-card-header-bg": "#EFE6D6",
+    // Contact + spread pair so the hero card visibly floats over the canvas
+    // instead of hanging on its border.
+    "pulse-card-shadow": "0 1px 2px rgba(51,43,35,0.10), 0 6px 18px rgba(51,43,35,0.12)",
     "pulse-control-hover-bg": "rgba(51,43,35,0.05)",
     "pulse-empty-bg": "#ECE3D5",
     "pulse-heat-color": "#2E8550",
@@ -160,14 +185,18 @@ export const theme: BuiltInThemeSource = {
     "settings-kbd-border": "#C5BDB2",
     "settings-nav-hover-bg": "rgba(178,80,36,0.08)",
     "sidebar-action-hover-bg": "rgba(178,80,36,0.08)",
-    // Issue 1: selection elevates, container recedes. Selected lifts to panel
-    // (L 0.966 vs sidebar 0.919), hover to canvas (L 0.945) — idle < hover < selected.
-    "sidebar-active-bg": "#F8F3EB",
+    // Issue 1: selection elevates, container recedes. Selected lifts between
+    // panel and elevated (L ~0.974 vs sidebar 0.919), hover to canvas
+    // (L 0.945) — idle < hover < selected, with the surface carrying more of
+    // the lift so the accent edge-bar isn't doing all the work.
+    "sidebar-active-bg": "#FBF7F0",
     "sidebar-hover-bg": "#F2ECE1",
     "toolbar-agent-hover-bg": "rgba(178,80,36,0.08)",
     "toolbar-control-hover-bg": "rgba(178,80,36,0.08)",
     "toolbar-control-hover-fg": "#9B3F18",
-    "toolbar-divider": "rgba(197,189,178,0.6)",
+    // 0.85 (was 0.6): the chrome/canvas seam needs a firmer line now that the
+    // toolbar shares the sidebar tone.
+    "toolbar-divider": "rgba(197,189,178,0.85)",
     "toolbar-project-bg":
       "linear-gradient(180deg, rgba(178,80,36,0.05), rgba(51,43,35,0.04)), linear-gradient(135deg, #EEE7DA, #E5DBCA)",
     "toolbar-project-border": "rgba(197,189,178,0.6)",
@@ -180,11 +209,12 @@ export const theme: BuiltInThemeSource = {
     "toolbar-stats-hover-bg": "rgba(178,80,36,0.08)",
     "worktree-section-hover-bg": "rgba(178,80,36,0.08)",
     // Recessed chrome strip for the worktree search/filter bars (#9712 infra:
-    // opt-in, unset themes keep the bars transparent). #DBCFBA sits ~0.07 L
-    // below the sidebar — deliberately below even the grid floor, so the
-    // chrome recedes and the worktree cards read as content on the brighter
-    // sidebar plane ("not everything the same shade of light").
-    "worktree-filter-bar-bg": "#DBCFBA",
+    // opt-in, unset themes keep the bars transparent). Sits ~0.07 L below the
+    // sidebar — deliberately below even the grid floor, so the chrome recedes
+    // and the worktree cards read as content on the brighter sidebar plane
+    // ("not everything the same shade of light"). Hue nudged toward rust
+    // (~70) so the strip reads salt-crust warm rather than plain dim beige.
+    "worktree-filter-bar-bg": "#DCCDB8",
     "dock-shadow":
       "inset 0 1px 0 rgba(255,252,248,0.5), 0 -2px 10px rgb(from var(--theme-shadow-color) r g b / 0.3)",
   },

--- a/shared/theme/extensionRegistry.ts
+++ b/shared/theme/extensionRegistry.ts
@@ -195,6 +195,7 @@ export const EXTENSION_KEY_REGISTRY = {
 
   // Worktree section
   "worktree-section-hover-bg": OPTIONAL,
+  "worktree-filter-bar-bg": OPTIONAL,
 } as const satisfies Record<ExtensionKey, ExtensionKeyMetadata>;
 
 export function isExtensionKeyRequired(key: ExtensionKey, mode: ColorMode): boolean {

--- a/shared/theme/types.ts
+++ b/shared/theme/types.ts
@@ -314,6 +314,7 @@ export const EXTENSION_KEYS = [
 
   // Worktree section
   "worktree-section-hover-bg",
+  "worktree-filter-bar-bg",
 ] as const;
 
 export type ExtensionKey = (typeof EXTENSION_KEYS)[number];

--- a/src/components/Worktree/QuickStateFilterBar.tsx
+++ b/src/components/Worktree/QuickStateFilterBar.tsx
@@ -42,7 +42,7 @@ export function QuickStateFilterBar({
   const workingActive = counts !== undefined && counts.working > 0;
   return (
     <div
-      className="flex border-b border-border-default"
+      className="worktree-filter-bar flex border-b border-border-default"
       role="toolbar"
       aria-label="Quick state filter"
     >

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -1027,7 +1027,9 @@ export function WorktreeOverviewModal({
             Stays mounted during selection mode so the user can refine the
             target set without losing the selection (visible-id sync drops
             hidden selections naturally — see selectedIds reconciliation). */}
-        {hasNonMainWorktrees && <WorktreeSidebarSearchBar chipCounts={chipCounts} />}
+        {hasNonMainWorktrees && (
+          <WorktreeSidebarSearchBar variant="modal" chipCounts={chipCounts} />
+        )}
 
         {/* Content */}
         <div className="flex-1 overflow-y-auto p-6">

--- a/src/components/Worktree/WorktreeSidebarSearchBar.tsx
+++ b/src/components/Worktree/WorktreeSidebarSearchBar.tsx
@@ -8,6 +8,13 @@ import type { ChipCounts } from "@/lib/worktreeFilters";
 interface WorktreeSidebarSearchBarProps {
   inputRef?: React.Ref<HTMLInputElement>;
   chipCounts?: ChipCounts;
+  /**
+   * Where the bar is mounted. The sidebar variant carries the optional
+   * `--worktree-filter-bar-bg` theme surface (a recessed strip at the top of
+   * the rail); the modal variant stays transparent so the strip doesn't leak
+   * onto the elevated overview dialog.
+   */
+  variant?: "sidebar" | "modal";
 }
 
 // The visible filter updates instantly via `liveQuery`; only the persisted
@@ -22,7 +29,11 @@ function assignForwardedRef<T>(ref: React.Ref<T> | undefined, value: T | null): 
   }
 }
 
-export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSidebarSearchBarProps) {
+export function WorktreeSidebarSearchBar({
+  inputRef,
+  chipCounts,
+  variant = "sidebar",
+}: WorktreeSidebarSearchBarProps) {
   const query = useWorktreeFilterStore((state) => state.query);
   const liveQuery = useWorktreeFilterStore((state) => state.liveQuery);
   const setQuery = useWorktreeFilterStore((state) => state.setQuery);
@@ -150,7 +161,12 @@ export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSideb
   const showClearAll = activeAxisCount >= 2;
 
   return (
-    <div className="px-3 py-2 border-b border-divider shrink-0">
+    <div
+      className={cn(
+        "px-3 py-2 border-b border-divider shrink-0",
+        variant === "sidebar" && "worktree-filter-bar"
+      )}
+    >
       <div
         role="search"
         className={cn(

--- a/src/styles/components/sidebar.css
+++ b/src/styles/components/sidebar.css
@@ -112,6 +112,15 @@ html[data-dragging="true"] .sidebar-worktree-card[data-hovered="true"] {
   background: var(--worktree-section-hover-bg, var(--theme-overlay-hover));
 }
 
+/* Optional distinct surface for the worktree filter/search/sort bar. A theme
+   that sets the `worktree-filter-bar-bg` extension gives the bar its own
+   tinted or recessed surface so the sidebar isn't a single flat shade; themes
+   that leave it unset fall through to `transparent` and the bar keeps
+   inheriting the sidebar surface exactly as before. */
+.worktree-filter-bar {
+  background: var(--worktree-filter-bar-bg, transparent);
+}
+
 @variant reduce-motion {
   .sidebar-worktree-card {
     transition: none;


### PR DESCRIPTION
This PR is a visual redesign of the Atacama light theme. The dark themes look great, but the light themes look flat and muddy. Closes #9709.

There were a few things going on here:

- Atacama was the only light theme still using a translucent border (`rgba(51,43,35,0.16)`), which washes out to almost nothing on light surfaces. Composited over the brightest surface it landed at roughly 1.35:1, so the search bar, card edges and dividers all dissolved.
- The derived border lines (`border-subtle`/`strong`/`divider`/`interactive`) composite from the engine's cool near-black ink, which reads grey against the warm sand palette.
- The surface ramp was too saturated. The canvas had the highest chroma of the warm light themes, so the whole workbench read as one flat tan sheet.

The redesign keeps the desert palette but tightens everything up:

- Lifts and desaturates the five surfaces. Hue stays in the desert band; canvas chroma roughly halves.
- Switches to a solid warm border (`#C9BCA5`) and sets `borderInkOverride: "#332B23"`, so every derived line shares the same warm charcoal ink. This is the documented Atacama use case for the knob from #9708.
- Pins opaque recessed wells for `surface-inset`, `surface-input` and `surface-toolbar`. The engine's translucent washes read as mud inside the near-white worktree cards.
- Gives the worktree sidebar's search and filter bars a darker recessed strip (`worktree-filter-bar-bg: #DBCFBA`), so the sidebar isn't one flat shade. The chrome recedes and the worktree cards read as content on the brighter plane.
- Re-anchors the extensions that referenced the old ramp (sidebar hover/active lift, pulse surfaces, panel-grid gutter, toolbar project pill) and drops four settings overrides that just restated the engine defaults.

The `worktree-filter-bar-bg` infrastructure is shared with #9723 (Hokkaido). The hunks here are byte-identical, so whichever PR lands first, the other rebases cleanly. One addition on top of that infra: the quick-state filter bar (`QuickStateFilterBar`) also picks up the recessed strip, not just the search bar. Flagging it because Hokkaido's quick-state bar will pick up its strip too once both are in.

Verified with before and after captures from the e2e screenshot harness (workbench, sidebar crop, settings, action palette), plus a dark theme run to confirm the fallbacks leave dark themes byte-for-byte unchanged. All 219 theme audits pass and `npm run check` is clean.

**Update — second polish pass.** A screenshot-driven review round (tooltips, context menus, popovers, hover and focus states) surfaced a handful of detail fixes, now included: a warm-ink shadow ladder to replace the cool slate/black defaults that dissolved on sand (floating surfaces now actually lift instead of hanging on hairlines), the Project Pulse header moved from cool blue to warm sand (it was the one off-biome surface left), `overlay-raised` nudged toward terracotta so menu and selected fills share the theme's accent-tinted hover language, plus smaller bumps to `border-divider`, `toolbar-divider`, `focus-ring`, `sidebar-active-bg` and a rust-leaning filter strip.
