### PR TITLE
Redesign the Serengeti light theme

### DIFF
--- a/shared/theme/builtInThemes/serengeti.ts
+++ b/shared/theme/builtInThemes/serengeti.ts
@@ -9,32 +9,38 @@ export const theme: BuiltInThemeSource = {
   heroImage: "/themes/serengeti.webp",
   palette: {
     type: "light",
+    // Deep savanna chrome (grid/sidebar) framing bright cream content
+    // (canvas/panel/elevated). The ladder is deliberately wider than the other
+    // light themes (#9713): OKLab L ~0.84 → 0.99 so the sidebar reads as a
+    // distinct warm column instead of the same shade as the canvas.
     surfaces: {
-      grid: "#E2D4AB",
-      sidebar: "#ECE0BF",
-      canvas: "#F2E8CE",
-      panel: "#F7EFD9",
-      elevated: "#FFFCF4",
+      grid: "#DCCB9D",
+      sidebar: "#E7D8B0",
+      canvas: "#F1E6C9",
+      panel: "#F8F0DA",
+      elevated: "#FFFEFA",
     },
     text: {
       primary: "#382818",
       secondary: "#5E4D33",
       muted: "#766338",
-      inverse: "#FFFCF4",
+      inverse: "#FFFEFA",
     },
-    border: "#D4C499",
+    border: "#C4B27E",
     accent: "#8B6D08",
     accentSecondary: "#467030",
+    // Status hues nudged a few percent deeper than the original Serengeti
+    // values so they clear the 3:1 graphical floor on the deeper grid chrome.
     status: {
-      success: "#4B862B",
-      warning: "#A86310",
+      success: "#467D28",
+      warning: "#A36010",
       danger: "#C2402F",
-      info: "#3A7AA8",
+      info: "#346C94",
     },
     activity: {
-      active: "#4B862B",
+      active: "#467D28",
       idle: "#8A7850",
-      working: "#4B862B",
+      working: "#467D28",
       waiting: "#A87529",
     },
     overlayTint: "#2C210F",
@@ -73,11 +79,15 @@ export const theme: BuiltInThemeSource = {
     strategy: {
       shadowStyle: "light",
       materialBlur: 12,
-      materialSaturation: 115,
+      materialSaturation: 100,
+      // Warm charcoal border ink (near text-primary) so the derived border
+      // ladder stays on-temperature; the engine's cool default reads as gray
+      // grime against the savanna tan.
+      borderInkOverride: "#3A2A18",
     },
   },
   tokens: {
-    "accent-foreground": "#FFFCF4",
+    "accent-foreground": "#FFFEFA",
     "category-amber": "oklch(0.60 0.15 75)",
     "category-blue": "oklch(0.54 0.11 235)",
     "category-cyan": "oklch(0.56 0.09 190)",
@@ -90,7 +100,7 @@ export const theme: BuiltInThemeSource = {
     "category-slate": "oklch(0.50 0.03 230)",
     "category-teal": "oklch(0.55 0.09 180)",
     "category-violet": "oklch(0.53 0.11 295)",
-    "focus-ring": "rgba(139,109,8,0.42)",
+    "focus-ring": "rgba(139,109,8,0.55)",
     "pr-closed": "#C81F2B",
     "pr-draft": "#656E79",
     "pr-merged": "#7340CC",
@@ -106,51 +116,64 @@ export const theme: BuiltInThemeSource = {
     "search-match-badge-text": "#3E6A2A",
     "search-selected-result-border": "#3E6A2A",
     "search-selected-result-icon": "#3E6A2A",
-    "surface-input": "#EBE0C7",
-    "surface-inset": "#EADEC0",
-    "surface-toolbar": "#EFE5C8",
+    // Warm-ink shadows: same magnitudes as the engine's "light" profile, but
+    // tinted with the theme's overlay ink (#2C210F) instead of the profile's
+    // cool blue-gray, which hazes gray over the warm tan surfaces.
+    "shadow-ambient": "0 8px 24px rgba(44, 33, 15, 0.10)",
+    "shadow-color": "rgba(44, 33, 15, 0.12)",
+    "shadow-dialog": "0 28px 64px rgba(44, 33, 15, 0.14)",
+    "shadow-floating": "0 18px 48px rgba(44, 33, 15, 0.13)",
     "terminal-black": "#2C2115",
     "terminal-white": "#E8DDC5",
     "text-link": "#6E5400",
     "text-placeholder": "#8E7C54",
   },
   extensions: {
-    "panel-grid-bg": "#E1D2A8",
-    "settings-dialog-bg": "#F7EFD9",
-    "settings-card-bg": "#FFFCF4",
-    "settings-list-item-bg": "#FFFCF4",
-    "pulse-card-bg": "#FFFCF4",
+    "panel-grid-bg": "#D9C796",
+    "settings-dialog-bg": "#F8F0DA",
+    "settings-card-bg": "#FFFEFA",
+    "settings-list-item-bg": "#FFFEFA",
+    "pulse-card-bg": "#FFFEFA",
     "pulse-card-shadow": "0 1px 3px rgba(44,33,15,0.08)",
     "pulse-control-hover-bg": "rgba(44,33,15,0.05)",
-    "pulse-empty-bg": "#F2E8CE",
+    "pulse-empty-bg": "#F1E6C9",
     "pulse-heat-color": "#3E7A1E",
     "pulse-heat-high-opacity": "0.88",
     "pulse-heat-low-opacity": "0.42",
     "pulse-heat-medium-opacity": "0.65",
     "pulse-missed-bg": "#C2402F",
-    "pulse-range-bg": "#F2E8CE",
-    "pulse-ring-offset": "#FFFCF4",
-    "pulse-skeleton-gradient": "linear-gradient(90deg, #E2D4AB 25%, #EFE3C4 50%, #E2D4AB 75%)",
+    "pulse-range-bg": "#F1E6C9",
+    "pulse-ring-offset": "#FFFEFA",
+    "pulse-skeleton-gradient": "linear-gradient(90deg, #DCCB9D 25%, #ECE0C0 50%, #DCCB9D 75%)",
     "settings-nav-active-bg": "#FBF5E6",
     "settings-nav-hover-bg": "rgba(139,109,8,0.08)",
-    "settings-search-bg": "#EADCBA",
-    "settings-sidebar-bg": "#E0D1A8",
+    // Settings nav rail drops to grid-chrome depth so the dialog gets the same
+    // chrome-frames-content separation as the main window.
+    "settings-sidebar-bg": "#DCCB9D",
     "sidebar-action-hover-bg": "rgba(139,109,8,0.08)",
-    "sidebar-active-bg": "#FAF4E2",
-    "sidebar-hover-bg": "#F2E9CF",
+    // Row states re-baselined as upward opaque lifts over the deeper sidebar:
+    // idle #E7D8B0 < hover #EFE2BF < active #F7EDCF < elevated.
+    "sidebar-active-bg": "#F7EDCF",
+    "sidebar-hover-bg": "#EFE2BF",
     "toolbar-agent-hover-bg": "rgba(139,109,8,0.07)",
     "toolbar-control-hover-bg": "rgba(139,109,8,0.08)",
-    "toolbar-divider": "rgba(212,196,153,0.55)",
+    "toolbar-divider": "rgba(196,178,126,0.55)",
     "toolbar-project-bg":
-      "linear-gradient(180deg, rgba(44,33,15,0.03), rgba(44,33,15,0.06)), linear-gradient(135deg, #EEE2C4, #DECFA6)",
-    "toolbar-project-border": "rgba(212,196,153,0.65)",
+      "linear-gradient(180deg, rgba(44,33,15,0.03), rgba(44,33,15,0.06)), linear-gradient(135deg, #ECDFBD, #DCCB9D)",
+    "toolbar-project-border": "rgba(196,178,126,0.65)",
     "toolbar-project-chip-bg": "rgba(44,33,15,0.06)",
-    "toolbar-project-chip-border": "rgba(212,196,153,0.65)",
-    "toolbar-project-shadow": "inset 0 1px 0 rgba(255,252,244,0.5)",
+    "toolbar-project-chip-border": "rgba(196,178,126,0.65)",
+    "toolbar-project-shadow": "inset 0 1px 0 rgba(255,254,250,0.5)",
     "toolbar-stats-bg": "rgba(139,109,8,0.07)",
-    "toolbar-stats-border": "rgba(212,196,153,0.55)",
-    "toolbar-stats-divider": "rgba(212,196,153,0.55)",
+    "toolbar-stats-border": "rgba(196,178,126,0.55)",
+    "toolbar-stats-divider": "rgba(196,178,126,0.55)",
     "toolbar-stats-hover-bg": "rgba(139,109,8,0.08)",
-    "worktree-section-hover-bg": "rgba(139,109,8,0.08)",
+    // Recessed savanna header band behind the worktree search/filter region —
+    // one step deeper and warmer than the sidebar so the top of the column
+    // reads as structured chrome instead of more of the same beige.
+    "worktree-filter-bar-bg": "#DBC894",
+    // Opaque warm lift (was an 8% gold alpha, which darkened on light — wrong
+    // polarity for the light selection matrix).
+    "worktree-section-hover-bg": "#F0E7CD",
   },
 };

--- a/shared/theme/builtInThemes/serengeti.ts
+++ b/shared/theme/builtInThemes/serengeti.ts
@@ -9,25 +9,30 @@ export const theme: BuiltInThemeSource = {
   heroImage: "/themes/serengeti.webp",
   palette: {
     type: "light",
-    // Deep savanna chrome (grid/sidebar) framing bright cream content
+    // Deep savanna chrome (grid/sidebar) framing warm-white content
     // (canvas/panel/elevated). The ladder is deliberately wider than the other
     // light themes (#9713): OKLab L ~0.84 → 0.99 so the sidebar reads as a
-    // distinct warm column instead of the same shade as the canvas.
+    // distinct warm column instead of the same shade as the canvas. Chroma
+    // falls as surfaces rise — the saturated tans live in the chrome and the
+    // content field rests near warm-white, so the app reads as "warm white
+    // with earth chrome" rather than uniformly tinted beige.
     surfaces: {
       grid: "#DCCB9D",
       sidebar: "#E7D8B0",
-      canvas: "#F1E6C9",
-      panel: "#F8F0DA",
+      canvas: "#F4EBD2",
+      panel: "#FAF4E4",
       elevated: "#FFFEFA",
     },
     text: {
       primary: "#382818",
       secondary: "#5E4D33",
-      muted: "#766338",
+      muted: "#6E5A2C",
       inverse: "#FFFEFA",
     },
-    border: "#C4B27E",
-    accent: "#8B6D08",
+    border: "#BBA86E",
+    // Sunlit acacia gold — saturated enough to register as the one accent
+    // against the warm browns of the text ramp.
+    accent: "#9C6400",
     accentSecondary: "#467030",
     // Status hues nudged a few percent deeper than the original Serengeti
     // values so they clear the 3:1 graphical floor on the deeper grid chrome.
@@ -37,10 +42,14 @@ export const theme: BuiltInThemeSource = {
       danger: "#C2402F",
       info: "#346C94",
     },
+    // Activity dots decoupled from the text-grade status colors: the dots are
+    // where the living acacia green shows against the dry-grass field, so they
+    // spend a little more chroma than status.success (which stays deep for
+    // contrast). Idle is a warm bark amber, not an olive smudge.
     activity: {
-      active: "#467D28",
-      idle: "#8A7850",
-      working: "#467D28",
+      active: "#3E8A24",
+      idle: "#9A7B3C",
+      working: "#3E8A24",
       waiting: "#A87529",
     },
     overlayTint: "#2C210F",
@@ -73,7 +82,7 @@ export const theme: BuiltInThemeSource = {
       keyword: "#90486A",
       function: "#2A6796",
       link: "#2A6796",
-      quote: "#766338",
+      quote: "#6E5A2C",
       chip: "#78B898",
     },
     strategy: {
@@ -100,7 +109,23 @@ export const theme: BuiltInThemeSource = {
     "category-slate": "oklch(0.50 0.03 230)",
     "category-teal": "oklch(0.55 0.09 180)",
     "category-violet": "oklch(0.53 0.11 295)",
-    "focus-ring": "rgba(139,109,8,0.55)",
+    // Engine border-strong is withAlpha(borderInk, 0.18); a touch more weight
+    // crisps the 1px frame on white-over-cream floating surfaces (tooltips,
+    // popovers, menus), which dissolve at the neutral-light default.
+    "border-strong": "rgba(58, 42, 24, 0.24)",
+    "focus-ring": "rgba(156,100,0,0.55)",
+    // The engine's lowest overlay rungs (0.02/0.03/0.05) are tuned for neutral
+    // light fields and vanish on Serengeti's saturated tans — the quick-state
+    // segmented control's active fill (overlay-subtle) was invisible on the
+    // filter band. Lift the lower ladder while keeping it monotonic below
+    // overlay-strong (0.08).
+    "overlay-subtle": "rgba(44, 33, 15, 0.045)",
+    "overlay-soft": "rgba(44, 33, 15, 0.06)",
+    "overlay-medium": "rgba(44, 33, 15, 0.075)",
+    // Menu/list selection primitive: a warm cream lift (sibling of
+    // sidebar-active-bg) instead of the engine's elevated-toward-ink mix,
+    // which reads as muddy gray on the warm palette.
+    "overlay-raised": "#F3E9CC",
     "pr-closed": "#C81F2B",
     "pr-draft": "#656E79",
     "pr-merged": "#7340CC",
@@ -122,7 +147,9 @@ export const theme: BuiltInThemeSource = {
     "shadow-ambient": "0 8px 24px rgba(44, 33, 15, 0.10)",
     "shadow-color": "rgba(44, 33, 15, 0.12)",
     "shadow-dialog": "0 28px 64px rgba(44, 33, 15, 0.14)",
-    "shadow-floating": "0 18px 48px rgba(44, 33, 15, 0.13)",
+    // Tighter + deeper than the profile default so near-white floating cards
+    // separate from the warm canvas instead of dissolving into it.
+    "shadow-floating": "0 14px 40px rgba(44, 33, 15, 0.17)",
     "terminal-black": "#2C2115",
     "terminal-white": "#E8DDC5",
     "text-link": "#6E5400",
@@ -130,44 +157,46 @@ export const theme: BuiltInThemeSource = {
   },
   extensions: {
     "panel-grid-bg": "#D9C796",
-    "settings-dialog-bg": "#F8F0DA",
+    "settings-dialog-bg": "#FAF4E4",
     "settings-card-bg": "#FFFEFA",
     "settings-list-item-bg": "#FFFEFA",
     "pulse-card-bg": "#FFFEFA",
     "pulse-card-shadow": "0 1px 3px rgba(44,33,15,0.08)",
     "pulse-control-hover-bg": "rgba(44,33,15,0.05)",
-    "pulse-empty-bg": "#F1E6C9",
-    "pulse-heat-color": "#3E7A1E",
+    "pulse-empty-bg": "#F4EBD2",
+    // The heatmap is the one sanctioned vivid-chroma surface — a brighter
+    // growth green keeps low-opacity cells from going muddy olive over cream.
+    "pulse-heat-color": "#3F8A1C",
     "pulse-heat-high-opacity": "0.88",
     "pulse-heat-low-opacity": "0.42",
     "pulse-heat-medium-opacity": "0.65",
     "pulse-missed-bg": "#C2402F",
-    "pulse-range-bg": "#F1E6C9",
+    "pulse-range-bg": "#F4EBD2",
     "pulse-ring-offset": "#FFFEFA",
     "pulse-skeleton-gradient": "linear-gradient(90deg, #DCCB9D 25%, #ECE0C0 50%, #DCCB9D 75%)",
     "settings-nav-active-bg": "#FBF5E6",
-    "settings-nav-hover-bg": "rgba(139,109,8,0.08)",
+    "settings-nav-hover-bg": "rgba(156,100,0,0.08)",
     // Settings nav rail drops to grid-chrome depth so the dialog gets the same
     // chrome-frames-content separation as the main window.
     "settings-sidebar-bg": "#DCCB9D",
-    "sidebar-action-hover-bg": "rgba(139,109,8,0.08)",
+    "sidebar-action-hover-bg": "rgba(156,100,0,0.08)",
     // Row states re-baselined as upward opaque lifts over the deeper sidebar:
-    // idle #E7D8B0 < hover #EFE2BF < active #F7EDCF < elevated.
+    // idle #E7D8B0 < hover #F2E7C7 < active #F7EDCF < elevated.
     "sidebar-active-bg": "#F7EDCF",
-    "sidebar-hover-bg": "#EFE2BF",
-    "toolbar-agent-hover-bg": "rgba(139,109,8,0.07)",
-    "toolbar-control-hover-bg": "rgba(139,109,8,0.08)",
-    "toolbar-divider": "rgba(196,178,126,0.55)",
+    "sidebar-hover-bg": "#F2E7C7",
+    "toolbar-agent-hover-bg": "rgba(156,100,0,0.07)",
+    "toolbar-control-hover-bg": "rgba(156,100,0,0.08)",
+    "toolbar-divider": "rgba(187,168,110,0.7)",
     "toolbar-project-bg":
       "linear-gradient(180deg, rgba(44,33,15,0.03), rgba(44,33,15,0.06)), linear-gradient(135deg, #ECDFBD, #DCCB9D)",
-    "toolbar-project-border": "rgba(196,178,126,0.65)",
+    "toolbar-project-border": "rgba(187,168,110,0.65)",
     "toolbar-project-chip-bg": "rgba(44,33,15,0.06)",
-    "toolbar-project-chip-border": "rgba(196,178,126,0.65)",
+    "toolbar-project-chip-border": "rgba(187,168,110,0.65)",
     "toolbar-project-shadow": "inset 0 1px 0 rgba(255,254,250,0.5)",
-    "toolbar-stats-bg": "rgba(139,109,8,0.07)",
-    "toolbar-stats-border": "rgba(196,178,126,0.55)",
-    "toolbar-stats-divider": "rgba(196,178,126,0.55)",
-    "toolbar-stats-hover-bg": "rgba(139,109,8,0.08)",
+    "toolbar-stats-bg": "rgba(156,100,0,0.07)",
+    "toolbar-stats-border": "rgba(187,168,110,0.65)",
+    "toolbar-stats-divider": "rgba(187,168,110,0.65)",
+    "toolbar-stats-hover-bg": "rgba(156,100,0,0.08)",
     // Recessed savanna header band behind the worktree search/filter region —
     // one step deeper and warmer than the sidebar so the top of the column
     // reads as structured chrome instead of more of the same beige.

--- a/shared/theme/extensionRegistry.ts
+++ b/shared/theme/extensionRegistry.ts
@@ -195,6 +195,7 @@ export const EXTENSION_KEY_REGISTRY = {
 
   // Worktree section
   "worktree-section-hover-bg": OPTIONAL,
+  "worktree-filter-bar-bg": OPTIONAL,
 } as const satisfies Record<ExtensionKey, ExtensionKeyMetadata>;
 
 export function isExtensionKeyRequired(key: ExtensionKey, mode: ColorMode): boolean {

--- a/shared/theme/types.ts
+++ b/shared/theme/types.ts
@@ -314,6 +314,7 @@ export const EXTENSION_KEYS = [
 
   // Worktree section
   "worktree-section-hover-bg",
+  "worktree-filter-bar-bg",
 ] as const;
 
 export type ExtensionKey = (typeof EXTENSION_KEYS)[number];

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -1027,7 +1027,9 @@ export function WorktreeOverviewModal({
             Stays mounted during selection mode so the user can refine the
             target set without losing the selection (visible-id sync drops
             hidden selections naturally — see selectedIds reconciliation). */}
-        {hasNonMainWorktrees && <WorktreeSidebarSearchBar chipCounts={chipCounts} />}
+        {hasNonMainWorktrees && (
+          <WorktreeSidebarSearchBar variant="modal" chipCounts={chipCounts} />
+        )}
 
         {/* Content */}
         <div className="flex-1 overflow-y-auto p-6">

--- a/src/components/Worktree/WorktreeSidebarSearchBar.tsx
+++ b/src/components/Worktree/WorktreeSidebarSearchBar.tsx
@@ -8,6 +8,13 @@ import type { ChipCounts } from "@/lib/worktreeFilters";
 interface WorktreeSidebarSearchBarProps {
   inputRef?: React.Ref<HTMLInputElement>;
   chipCounts?: ChipCounts;
+  /**
+   * Where the bar is mounted. The sidebar variant carries the optional
+   * `--worktree-filter-bar-bg` theme surface (a recessed strip at the top of
+   * the rail); the modal variant stays transparent so the strip doesn't leak
+   * onto the elevated overview dialog.
+   */
+  variant?: "sidebar" | "modal";
 }
 
 // The visible filter updates instantly via `liveQuery`; only the persisted
@@ -22,7 +29,11 @@ function assignForwardedRef<T>(ref: React.Ref<T> | undefined, value: T | null): 
   }
 }
 
-export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSidebarSearchBarProps) {
+export function WorktreeSidebarSearchBar({
+  inputRef,
+  chipCounts,
+  variant = "sidebar",
+}: WorktreeSidebarSearchBarProps) {
   const query = useWorktreeFilterStore((state) => state.query);
   const liveQuery = useWorktreeFilterStore((state) => state.liveQuery);
   const setQuery = useWorktreeFilterStore((state) => state.setQuery);
@@ -150,7 +161,12 @@ export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSideb
   const showClearAll = activeAxisCount >= 2;
 
   return (
-    <div className="px-3 py-2 border-b border-divider shrink-0">
+    <div
+      className={cn(
+        "px-3 py-2 border-b border-divider shrink-0",
+        variant === "sidebar" && "worktree-filter-bar"
+      )}
+    >
       <div
         role="search"
         className={cn(

--- a/src/styles/components/sidebar.css
+++ b/src/styles/components/sidebar.css
@@ -112,6 +112,15 @@ html[data-dragging="true"] .sidebar-worktree-card[data-hovered="true"] {
   background: var(--worktree-section-hover-bg, var(--theme-overlay-hover));
 }
 
+/* Optional distinct surface for the worktree filter/search/sort bar. A theme
+   that sets the `worktree-filter-bar-bg` extension gives the bar its own
+   tinted or recessed surface so the sidebar isn't a single flat shade; themes
+   that leave it unset fall through to `transparent` and the bar keeps
+   inheriting the sidebar surface exactly as before. */
+.worktree-filter-bar {
+  background: var(--worktree-filter-bar-bg, transparent);
+}
+
 @variant reduce-motion {
   .sidebar-worktree-card {
     transition: none;


### PR DESCRIPTION
This is a visual redesign of the Serengeti light theme, which #9713 described as ugly, unbalanced, and depressing. It already passed all our contrast checks, so it was never a legibility problem; it was a design quality problem. The redesign is deliberately conservative: the gold accent, sage secondary, and warm savanna hues all stay.

The main cause was the surface ladder. All five surfaces sat between OKLab L 0.87 and 0.99, so the sidebar and canvas were nearly the same flat beige and nothing framed anything. The ladder is now wider (~0.84 to 0.99): grid and sidebar chrome are deeper, richer tans that frame the brighter content surfaces, and cards genuinely lift off their backgrounds.

## Round 1 — structure

- Deepens `surface-grid` (`#E2D4AB` → `#DCCB9D`) and `surface-sidebar` (`#ECE0BF` → `#E7D8B0`), widening the sidebar/canvas separation from an imperceptible dL 0.024 to a clear chrome-vs-content split.
- Darkens the base border and adds a warm charcoal `borderInkOverride` so the derived border ladder stays on-temperature instead of reading as cool gray grime on tan.
- Retints `shadow-ambient` / `shadow-floating` / `shadow-dialog` with the theme's warm ink; the engine's `light` profile uses a cool blue-gray that hazes on these surfaces.
- Gives the worktree filter bar a recessed savanna band via the new opt-in `worktree-filter-bar-bg` extension. The shared infrastructure (`types.ts`, `extensionRegistry.ts`, `sidebar.css`, the `variant` prop on `WorktreeSidebarSearchBar`) is byte-identical to the hunks in #9723, so whichever PR merges second auto-resolves cleanly.
- Rebalances the sidebar row states as brighter opaque lifts over the deeper rail, and replaces the section-header hover, which was an 8% gold alpha that darkened on hover — the wrong polarity for light themes.
- Drops the explicit `surface-input` / `surface-inset` / `surface-toolbar` / `settings-search-bg` overrides; the #9708 engine derives better values from the new ladder.

## Round 2 — color and micro-detail

A second screenshot-review pass over nine captured states (dashboard, sidebar, settings, palette, filter popover, row hover, tooltip, project menu, terminal):

- Lifts `canvas` (`#F1E6C9` → `#F4EBD2`) and `panel` (`#F8F0DA` → `#FAF4E4`) so chroma falls as surfaces rise — the saturated tans live in the chrome and the content field rests near warm white, instead of the whole app reading as tinted beige.
- Brightens the accent to a saturated acacia gold (`#8B6D08` → `#9C6400`) so accented elements actually register against the brown text ramp, and deepens `text-muted` (`#766338` → `#6E5A2C`) so metadata stops receding.
- Decouples the activity dots from the text-grade status colors: dots get a livelier acacia green (`#3E8A24`) and the idle dot becomes a warm bark amber (`#9A7B3C`) instead of an olive smudge; `status.success` stays deep for contrast. The pulse heat green brightens to match.
- Sizes the lower overlay ladder for the saturated tans (`overlay-subtle/soft/medium` at 0.045/0.06/0.075) — the engine's neutral-light 0.02 rung made the quick-state segmented control's active fill invisible on the filter band.
- Retints the menu selection primitive (`overlay-raised`) as a warm cream lift instead of the engine's elevated-toward-ink mix, which read muddy gray on this palette, and weights `border-strong` / `shadow-floating` so tooltips, popovers, and menus separate cleanly from the warm canvas.

Status colors sit a few percent deeper than the originals to clear the 3:1 graphical floor on the deeper grid, and the info blue shifted slightly cyan (`#3A7AA8` → `#346C94`) to stay distinguishable from `category-violet` under color vision deficiency simulation.

All theme audit gates pass (surface ramp evenness, depth budget, border separation, accent prominence, the light selection matrix, and the CVD distinguishability suite), along with `npm run check`. Both rounds were verified against real before/after screenshots captured with the e2e screenshot harness, with a three-perspective design review (micro-detail, color harmony, art direction) driving the round-2 changes.

Resolves #9713
