### PR TITLE
Redesign the Hokkaido light theme to the Bondi standard

### DIFF
--- a/shared/theme/builtInThemes/hokkaido.ts
+++ b/shared/theme/builtInThemes/hokkaido.ts
@@ -9,22 +9,42 @@ export const theme: BuiltInThemeSource = {
   heroImage: "/themes/hokkaido.webp",
   palette: {
     type: "light",
+    // Winter-dawn composition (#9712, Bondi-standard rebuild): ONE lavender
+    // snow family for the whole field (H~292-298) with white-crust content on
+    // top. The frozen lake appears only as detail — the violet accent, the
+    // deep-indigo terminal, info blue, search highlights — and the dawn sky
+    // only as a whisper on the project pill, never as a field surface.
+    // Everything that carries content lifts TOWARD white — never a darker
+    // fill on a light container.
+    // Ramp L 0.882/0.937/0.958/0.978/1.0: steps 0.0204-0.0555 (gate ≥ 0.02,
+    // runaway ratio 2.72 < 3), span 0.118, panel→elevated not the smallest
+    // step. The grid is SHADOWED SNOW at the lake edge — a full register
+    // deeper and richer in chroma than the drifted-snow sidebar, so
+    // chrome/field/well read as three planes and white panels get real
+    // figure-ground pop (the old ramp packed all five tiers into 0.11 L with
+    // sub-perceptual chroma steps and read as one violet-gray sheet).
     surfaces: {
-      grid: "#D6D3E3",
-      sidebar: "#DEDBEA",
-      canvas: "#E5E3EF",
-      panel: "#EDEBF4",
-      elevated: "#FBF9FD",
+      grid: "#D9D5E8",
+      sidebar: "#EAE9F2",
+      canvas: "#F1F0F7",
+      panel: "#F8F7FC",
+      elevated: "#FFFFFF",
     },
     text: {
-      primary: "#2B2F42",
-      secondary: "#565C78",
-      muted: "#5E6685",
+      primary: "#282630",
+      // Near-neutral ink (C ≤ 0.012) — the old #565C78/#5E6685 carried enough
+      // blue-violet chroma to read dirty on the hued field: secondary now
+      // 6.1:1 on the grid, muted 4.9:1 on the grid and 6.2:1 on canvas.
+      secondary: "#4B4A52",
+      muted: "#5A585F",
       inverse: "#FDFCFF",
     },
-    border: "#BFBBD2",
+    border: "#D3CFDD",
     accent: "#6E57DB",
     accentSecondary: "#2C7458",
+    // success/danger/warning render as TEXT (diff numerals, status labels) on
+    // the near-white chips — all hold ≥ 3.5:1 on the grid and ≥ 4.4:1 on
+    // every content surface up to #FFFFFF.
     status: {
       success: "#2C7458",
       warning: "#9A6310",
@@ -35,21 +55,27 @@ export const theme: BuiltInThemeSource = {
       active: "#2E8A66",
       idle: "#6C7494",
       working: "#2E8A66",
-      // B2: working (h163 green) and waiting (h83 amber) were near-isoluminant
-      // (dL 0.0099) — a single luminance channel left them separable by hue only,
-      // which collapses on the deuteranope confusion line on a 6px dot. Lift
-      // waiting's L within its own amber family (#9A7314 → #A57A10) so it now
-      // clears the JND vs working (dL 0.0368) while holding ≥3:1 vs canvas (3.07).
+      // working (h163 green) and waiting amber stay deuteranope-separable by
+      // luminance (ΔE 0.150), and waiting holds ≥ 3.4:1 on the new canvas.
       waiting: "#A57A10",
     },
-    overlayTint: "#525276",
+    // Violet ink, not the old slate-mauve #525276: the overlay/wash ladder
+    // composites onto the snow field, and a mid-L chromatic tint there reads
+    // as grime — the ink must be a dark near-neutral in the field's own hue.
+    overlayTint: "#33313D",
     terminal: {
+      // The terminal is the frozen lake at dusk — its own deep-indigo
+      // environment below the snow field.
       background: "#22273B",
       foreground: "#E2E8F4",
-      muted: "#80A0D6",
+      // Quieter than ANSI blue (the old value aliased terminal-blue #80A0D6,
+      // giving "muted" full ANSI salience); 3.9:1 on the terminal background.
+      muted: "#76849F",
       cursor: "#C2A170",
       selection: "#313963",
-      red: "#C87070",
+      // 4.77:1 on the terminal background (the old #C87070 sat at 4.23:1) —
+      // every ANSI slot clears ~4.5:1.
+      red: "#D17A7A",
       green: "#7AA889",
       yellow: "#C2A170",
       blue: "#80A0D6",
@@ -64,7 +90,8 @@ export const theme: BuiltInThemeSource = {
       brightWhite: "#F2F4FA",
     },
     syntax: {
-      comment: "#71708A",
+      // 4.9:1 on the brighter canvas (the old #71708A fell to 4.2:1 there).
+      comment: "#67667E",
       punctuation: "#525A74",
       number: "#92496A",
       string: "#356C62",
@@ -77,13 +104,16 @@ export const theme: BuiltInThemeSource = {
     },
     strategy: {
       shadowStyle: "light",
-      materialBlur: 10,
+      materialBlur: 12,
       materialSaturation: 115,
     },
   },
   tokens: {
     "accent-muted": "rgba(110,87,219,0.30)",
     "accent-soft": "rgba(110,87,219,0.18)",
+    // Curated category ramp: the engine's light defaults collide with
+    // hokkaido's status set under CVD (category-indigo vs status-info #3A6FC0
+    // collapses to ΔE 0.002 under deuteranopia).
     "category-amber": "oklch(0.60 0.11 72)",
     "category-blue": "oklch(0.55 0.12 246)",
     "category-cyan": "oklch(0.58 0.08 214)",
@@ -96,123 +126,139 @@ export const theme: BuiltInThemeSource = {
     "category-slate": "oklch(0.53 0.025 248)",
     "category-teal": "oklch(0.57 0.09 186)",
     "category-violet": "oklch(0.55 0.11 292)",
-    "focus-ring": "rgba(110,87,219,0.30)",
-    // AA 4.5:1 on hokkaido's near-white panel (#EDEBF4) & elevated (#FBF9FD);
-    // prior values were 4.11/2.39/3.86/3.91:1. Darkened keeping hue (E6/B1).
-    "pr-closed": "#C02631",
-    "pr-draft": "#525B66",
-    "pr-merged": "#7544CA",
-    "pr-open": "#1A722F",
-    "label-pill-bg-opacity": "0.10",
-    "label-pill-border-opacity": "0.18",
-    // filter-selected (membership, never accent): elevate-to-select. The engine
-    // darkening default left strong-vs-soft at ΔE 0.019 (sub-JND merge on hokkaido's
-    // tight violet ramp); explicit opaque lifts clear the JND (soft-vs-panel 0.021,
-    // strong-vs-soft 0.023). panel #EDEBF4 < soft < strong toward elevated #FBF9FD.
-    "filter-selected-bg-soft": "#F4F2FA",
-    "filter-selected-bg-strong": "#FCFAFE",
-    "shadow-color": "rgba(38,33,58,0.12)",
-    // E7: scrim overrides dropped. The engine now derives the light scrim from the
-    // hued overlayBase (overlayTint #525276) at lowered alphas (soft 0.22 / medium
-    // 0.36 / strong 0.55) — same cool-violet temperature these overrides carried,
-    // but lighter so the dim behind a modal reads as a veil over a near-white
-    // workbench rather than a heavy slab. Inheriting keeps hokkaido on the shared
-    // model instead of pinning its own heavier values.
-    // scrollbar-thumb must clear 3:1 vs panel & canvas (E6): #9BA3BE was 2.12/1.98.
+    "focus-ring": "rgba(110,87,219,0.35)",
+    "overlay-hover": "rgba(51,49,61,0.08)",
+    // Derived 3% is sub-threshold over near-white surfaces.
+    "overlay-soft": "rgba(51,49,61,0.055)",
+    // Opaque elevate-to-select for menu/palette rows on white popovers; kept
+    // in the lavender family so a selected row reads as the same material,
+    // not a gray slab.
+    "overlay-raised": "#EAE8F0",
+    // The engine's pr-merged purple (#7544CC) sits ΔE 0.045 from hokkaido's
+    // violet accent — a merged badge would read as a second accent signal.
+    // Shift it to plum (h322, ΔE 0.125 from the accent, 6.2:1 on the panel)
+    // and re-ink the draft slate onto the field temperature.
+    "pr-draft": "#5E5A6E",
+    "pr-merged": "#8A3D96",
     "scrollbar-thumb": "#6A7290",
-    "scrollbar-thumb-hover": "color-mix(in oklab, #6A7290 85%, #2B2F42)",
+    "scrollbar-thumb-hover": "color-mix(in oklab, #6A7290 85%, #282630)",
+    // Engine light scrims (0.22/0.36/0.55) read as a storm front here.
+    "scrim-soft": "rgba(51,49,61,0.16)",
+    "scrim-medium": "rgba(51,49,61,0.28)",
+    "scrim-strong": "rgba(51,49,61,0.46)",
     "search-highlight-background": "rgba(58,111,192,0.22)",
     "search-highlight-text": "#27539A",
     "search-match-badge-background": "rgba(58,111,192,0.22)",
     "search-match-badge-text": "#27539A",
     "search-selected-result-border": "#3A6FC0",
     "search-selected-result-icon": "#27539A",
-    "overlay-hover": "rgba(82,82,118,0.10)",
-    "state-chip-bg-opacity": "0.12",
-    "state-chip-border-opacity": "0.32",
-    // E8: surface-input override dropped. It used to pin the input to #FAF8FD
-    // (L 0.982 — the brightest plane, the opposite of the macOS / VS Code inset
-    // well). The engine now derives surface-input RECESSED on light
-    // (color-mix(surface-canvas 96%, text-primary) ≈ just below canvas) so the
-    // input field sits in a well; placeholder over it clears ~3:1 at the raised
-    // 0.58 alpha. Inheriting the recessed default is the E8 fix.
-    "surface-inset": "#CECBDD",
-    "surface-toolbar": "#DAD7E7",
-    "terminal-black": "#2D334A",
+    // Two-layer contact+spread in the violet ink; the engine "light" single
+    // penumbra has no contact edge on a near-white field.
+    "shadow-ambient": "0 1px 2px rgba(43,41,55,0.10), 0 6px 16px rgba(43,41,55,0.10)",
+    // Dialogs sit a full z-tier above menus/popovers (the floating fallback
+    // would give a centered modal the same shadow as a context menu).
+    "shadow-dialog": "0 2px 6px rgba(43,41,55,0.10), 0 24px 60px rgba(43,41,55,0.18)",
+    "shadow-floating": "0 1px 3px rgba(43,41,55,0.12), 0 12px 32px rgba(43,41,55,0.14)",
+    // The engine's rgba(0,0,0,0.12) shadow ink is off-temperature on the
+    // lavender field; dock-shadow re-alphas these channels via rgb(from ...).
+    "shadow-color": "rgba(43,41,55,0.12)",
+    // In-card chips: a lavender-stone inset one quiet step below the white
+    // card, not a recessed slab (the old #CECBDD sat two registers down and
+    // read as grime).
+    "surface-inset": "#F3F1F9",
+    // Inputs are raised on light, never recessed (overrides the engine's
+    // recessed derivation; promote to the engine once the light family is
+    // rebuilt from Bondi).
+    "surface-input": "#FCFBFF",
+    // Snow chrome: the frame (toolbar/dock/panel caps/dialog headers) carries
+    // Hokkaido's lavender note at whisper chroma (H~294), one register apart
+    // from the field surfaces rather than a darker slab.
+    "surface-toolbar": "#EDECF2",
     "terminal-bright-black": "#6A708C",
     "terminal-white": "#E2E8F4",
     "text-link": "#574EC0",
-    "text-placeholder": "rgba(43,47,66,0.55)",
+    // 4.3:1 on the raised input (0.55 sat at 3.8:1 and fell away).
+    "text-placeholder": "rgba(40,38,48,0.62)",
   },
   extensions: {
-    // G1: panel-grid-bg is the gutter behind the panel tiles. It was #E5E3EF
-    // (= canvas, L 0.921) — BRIGHTER than the panel tiles, a figure-ground
-    // inversion that made the tiles read as wells. Drop it to #D2CFE0 (L 0.862,
-    // at/below surface-grid L 0.874) so the gutter recedes and the tiles read as
-    // raised figures against it.
-    "panel-grid-bg": "#D2CFE0",
-    "pulse-card-bg": "#FBF9FD",
-    "pulse-control-hover-bg": "rgba(82,82,118,0.065)",
-    "pulse-empty-bg": "#E9E7F2",
+    "dock-bg": "#EDECF2",
+    "dock-input-bg": "#FCFBFF",
+    // Registry format guard: shadow-color channels, alpha ≥ 0.25.
+    "dock-shadow": "0 -2px 8px rgb(from var(--theme-shadow-color) r g b / 0.25)",
+    // Panel title bars join the snow chrome; the focused pane's cap brightens.
+    "panel-header-bg": "#EFEEF3",
+    "panel-header-focus-bg": "#F5F4F8",
+    // Emoji tiles get a white-gloss lift instead of the dark-theme black wash
+    // (which rendered murky gray chips on the light field).
+    "project-tile-wash":
+      "linear-gradient(to bottom, rgba(255,255,255,0.40), rgba(255,255,255,0.10))",
+    "project-tile-shadow": "inset 0 1px 1px rgba(43,41,55,0.10), 0 0 0 1px rgba(43,41,55,0.10)",
+    "pulse-before-bg": "#D9D5E8",
+    "pulse-card-bg": "#FFFFFF",
+    "pulse-card-header-bg": "#F7F6FB",
+    "pulse-card-shadow": "0 1px 2px rgba(43,41,55,0.10), 0 4px 10px rgba(43,41,55,0.08)",
+    "pulse-control-hover-bg": "rgba(51,49,61,0.05)",
+    "pulse-empty-bg": "#F1F0F7",
     "pulse-heat-high-opacity": "0.85",
     "pulse-heat-low-opacity": "0.38",
     "pulse-heat-medium-opacity": "0.62",
-    // P-Heat: missed-day is a destructive streak-break signal. It was a ~12% red
-    // film (≈1.2:1 vs the empty cell — invisible). Make it an opaque brighter
-    // danger fill (status-danger #BE3C48 = 4.37:1 vs pulse-empty-bg) so the gap
-    // reads as a real break; the P-Heat consumer also adds an inset danger ring
-    // shape cue on light.
+    "pulse-heat-color": "#2C7458",
+    // Opaque so the streak-break signal clears the 3:1 graphical floor.
     "pulse-missed-bg": "#BE3C48",
-    "pulse-range-bg": "#E9E7F2",
-    "pulse-ring-offset": "#FBF9FD",
-    "pulse-skeleton-gradient": "linear-gradient(90deg, #D8D5E6 25%, #E6E3F1 50%, #D8D5E6 75%)",
-    // S1: the settings dialog body was pinned at #FBF9FD (= elevated, L 0.985 —
-    // the ceiling), so cards/list-items that default to surface-panel-elevated
-    // collapsed flush into the body. Recess the body to #EDEBF4 (= surface-panel)
-    // so cards on the elevated plane lift above it (the S1 "cards above the dialog
-    // body" model). Card/list-item bg are intentionally left unset — they inherit
-    // the surface-panel-elevated fallback the S1 consumer ships.
-    "settings-dialog-bg": "#EDEBF4",
-    "dialog-header-bg": "rgba(222,219,234,0.55)",
-    "settings-kbd-bg": "#E2DFEE",
-    // S1: the single load-bearing accent in the settings nav is the 2px marker
-    // (before:bg-daintree-accent). The active-row FILL must not be a second accent
-    // cue, so drop the accent-rgb tint (was rgba(110,87,219,0.16)) for a NEUTRAL
-    // elevated hex (#F4F2FA, L 0.965 — a lift over the recessed nav). The accent
-    // inset ring (settings-nav-active-shadow) is retired below.
-    "settings-nav-active-bg": "#F4F2FA",
-    "settings-nav-hover-bg": "rgba(82,82,118,0.065)",
-    "settings-search-bg": "#FAF8FD",
-    "settings-sidebar-bg": "rgba(214,211,227,0.78)",
-    "sidebar-action-hover-bg": "rgba(82,82,118,0.065)",
-    // Issue 1: the selected worktree row must ELEVATE on light, not darken. These
-    // were rgba(0,0,0,*) ink (the selected row sank below its own recessed
-    // sidebar container — grime, not lift). Replace with OPAQUE surfaces stepping
-    // UP from the sidebar (L 0.898): hover #EBE9F3 (L 0.939, dL +0.040) then
-    // selected #F8F6FC (L 0.976, dL +0.078 vs sidebar, +0.038 vs hover) — idle <
-    // hover < selected, every step clearing the JND. The sidebar.css consumer
-    // pairs this lift with a border-strong containment edge. NOTE: this trips the
-    // extensionRegistry SIDEBAR_ACTIVE/SIDEBAR_HOVER perceptibility guard, which
-    // still mandates the old rgba(0,0,0,*) darken form — see flagged notes.
-    "sidebar-active-bg": "#F8F6FC",
-    "sidebar-hover-bg": "#EBE9F3",
-    "toolbar-agent-hover-bg": "rgba(82,82,118,0.065)",
-    "toolbar-control-hover-bg": "rgba(82,82,118,0.065)",
-    "toolbar-control-hover-fg": "#6E57DB",
-    "toolbar-divider": "rgba(191,187,210,0.6)",
+    "pulse-range-bg": "#F1F0F7",
+    "pulse-ring-offset": "#FFFFFF",
+    "pulse-skeleton-gradient": "linear-gradient(90deg, #D9D5E8 25%, #F1F0F7 50%, #D9D5E8 75%)",
+    "dialog-header-bg": "#F9F8FD",
+    "review-commit-input-bg": "#FCFBFF",
+    "settings-kbd-bg": "#F3F1F9",
+    "settings-kbd-border": "#D3CFDD",
+    // Nav selection elevates to white + the 2px accent marker; the inherited
+    // overlay-raised darker-lift is for menu rows on white popovers only.
+    "settings-nav-active-bg": "#FFFFFF",
+    // Flat like the dark themes: the white fill + 2px accent marker carry
+    // selection, no ring or shadow.
+    "settings-nav-active-shadow": "none",
+    "settings-nav-hover-bg": "rgba(56,52,82,0.05)",
+    // Scope pill elevates to white on the tinted settings sidebar.
+    "settings-scope-bg": "#FFFFFF",
+    "settings-sidebar-bg": "rgba(234,233,242,0.60)",
+    "sidebar-action-hover-bg": "rgba(56,52,82,0.05)",
+    // Worktree cards are paper highlights on the snow field; hover brightens
+    // toward white; selected is pure white + the accent rail.
+    // idle < hover < selected is audit-enforced; the old ladder ran hover
+    // BELOW the idle card's natural plane — these sit ~1.6 OKLab points
+    // apart. Soft contact shadow only — no ring: the card must not read as
+    // bordered (selection = bg + right accent border).
+    "sidebar-card-bg": "#F4F2FA",
+    "sidebar-card-shadow": "0 1px 2px rgba(43,40,58,0.05)",
+    "sidebar-active-bg": "#FFFFFF",
+    "sidebar-hover-bg": "#F9F8FC",
+    "toolbar-agent-hover-bg": "rgba(40,38,48,0.06)",
+    "toolbar-control-hover-bg": "rgba(40,38,48,0.06)",
+    // Accent restraint: hover affordance is the bg, not a violet foreground.
+    "toolbar-control-hover-fg": "#282630",
+    "toolbar-control-hover-shadow": "none",
+    "toolbar-divider": "rgba(211,207,221,0.7)",
+    "toolbar-pill-radius": "0.5rem",
+    // One dawn-pink whisper on the project pill — the sunrise from the hero
+    // shot; everything else quiet ink. Pills sit LIGHTER than the chrome
+    // strip (raised, like all content).
     "toolbar-project-bg":
-      "linear-gradient(180deg, rgba(110,87,219,0.05), rgba(82,82,118,0.05)), linear-gradient(135deg, rgba(255,255,255,0.85), rgba(222,219,234,0.92))",
-    "toolbar-project-border": "rgba(191,187,210,0.7)",
-    "toolbar-project-chip-bg": "rgba(82,82,118,0.055)",
-    "toolbar-project-chip-border": "rgba(191,187,210,0.7)",
-    "toolbar-stats-bg": "rgba(82,82,118,0.055)",
-    "toolbar-stats-border": "rgba(191,187,210,0.6)",
-    "toolbar-stats-divider": "rgba(191,187,210,0.6)",
-    "toolbar-stats-hover-bg": "rgba(82,82,118,0.065)",
-    "worktree-section-hover-bg": "rgba(82,82,118,0.065)",
-    "dock-bg": "#D2CFE0",
-    "dock-border": "rgba(82,82,118,0.16)",
-    "dock-shadow":
-      "inset 0 1px 0 rgba(255,255,255,0.55), 0 -2px 8px rgb(from var(--theme-shadow-color) r g b / 0.35)",
+      "linear-gradient(180deg, rgba(226,139,177,0.08), rgba(40,38,48,0.02)), #F8F7FB",
+    "toolbar-project-border": "rgba(211,207,221,0.75)",
+    "toolbar-project-chip-bg": "rgba(40,38,48,0.04)",
+    "toolbar-project-chip-border": "rgba(211,207,221,0.75)",
+    "toolbar-project-shadow": "inset 0 1px 0 rgba(255,255,255,0.5)",
+    "toolbar-shadow": "0 1px 2px rgba(43,41,55,0.06)",
+    "toolbar-stats-bg": "#F8F7FB",
+    "toolbar-stats-border": "rgba(211,207,221,0.7)",
+    "toolbar-stats-divider": "rgba(211,207,221,0.7)",
+    "toolbar-stats-hover-bg": "#FBFAFD",
+    // Filter rail sits flush on the field; the raised search input carries it.
+    "worktree-filter-bar-bg": "#EAE9F2",
+    // Active quick-state tab lifts to white under its inset underline.
+    "worktree-quick-state-active-bg": "#FFFFFF",
+    "worktree-search-input-bg": "#FCFBFF",
+    "worktree-section-hover-bg": "rgba(56,52,82,0.05)",
   },
 };


### PR DESCRIPTION
This is a complete visual rebuild of the Hokkaido light theme, bringing it up to the standard set by Bondi Beach (#9727). Bondi is the literal template here: same token keys, same extension keys, same structural decisions, with every value re-derived for Hokkaido's identity. Resolves #9712.

## Design

The identity is a winter dawn at a frozen lake in Hokkaido: a lavender-snow field, a deep indigo lake for the terminal, and one dawn-pink whisper on the toolbar project pill. The whole field sits in a single hue family (H≈292-298), so there's no temperature seam anywhere in the workbench.

* Five-surface depth ramp `#D9D5E8 → #EAE9F2 → #F1F0F7 → #F8F7FC → #FFFFFF` (L 0.882 → 1.0). The grid is shadowed snow at the lake edge: a full register deeper and richer in chroma than the sidebar, so chrome, field, and well read as three planes. The old ramp packed all five tiers into 0.11 L and read as one violet-gray sheet.
* Everything that carries content lifts toward white. Inputs are raised (`surface-input #FCFBFF`), worktree cards run idle `#F4F2FA` → hover `#F9F8FC` → selected `#FFFFFF`, and settings nav selection elevates to white under the 2px accent marker.
* The invisible ladders are re-inked from the field hue: `overlayTint #33313D`, scrims, shadows, and `overlay-raised` all carry the violet ink instead of the old mid-L slate-mauve washes.
* Chrome (`surface-toolbar #EDECF2`, panel caps, dock, dialog headers) is one quiet register apart from the field. Toolbar hover drops the violet foreground for plain ink.
* The terminal stays the deep indigo lake (`#22273B`); ANSI red moved to `#D17A7A` so all sixteen slots clear roughly 4.5:1.

Two semantic fixes that came out of review: `pr-merged` shifts to plum `#8A3D96` so a merged badge doesn't read as a second accent next to Hokkaido's violet (`#6E57DB`, ΔE 0.125 vs the engine default's 0.045), and `terminal.muted` drops to `#76849F` so it sits below ANSI blue's salience instead of aliasing it.

## Verification

* All 219 theme tests pass with zero ramp-audit warnings: surface gates (steps ≥ 0.02 L, span 0.118, runaway 2.72), the light elevation matrix, WCAG floors, and CVD distinguishability. The curated `category-*` ramp stays because the engine's default `category-indigo` collapses into `status-info` under deuteranopia.
* Text is near-neutral and floored: secondary 6.1:1 and muted 4.9:1 on the deepest surface, placeholder 4.3:1 on the raised input.
* Screenshots were captured with the `theme-review` harness and compared view by view against Bondi: workbench, sidebar states, palettes, menus, dialogs, settings, review hub, popovers. The design went through two review rounds with sign-off.

One note from the capture run: the terminal/dock and confirm-dialog steps crash the renderer in my local capture environment for Bondi as well, so those two views were verified against a rendered swatch board plus the contrast math rather than in-app shots.
