### PR TITLE
fix(worktree): exclude closed/declined PRs from finished state

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -740,6 +740,8 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       const isComplete =
         !!worktree.issueNumber &&
         !!worktree.linked?.pr &&
+        worktree.linked.pr.state !== "closed" &&
+        worktree.linked.pr.state !== "declined" &&
         !hasChanges &&
         worktree.worktreeChanges !== null;
 

--- a/src/components/Worktree/WorktreeCard/hooks/__tests__/useWorktreeStatus.test.tsx
+++ b/src/components/Worktree/WorktreeCard/hooks/__tests__/useWorktreeStatus.test.tsx
@@ -201,6 +201,69 @@ describe("useWorktreeStatus — lifecycleStage", () => {
   });
 });
 
+describe("useWorktreeStatus — isComplete", () => {
+  function getIsComplete(overrides: Partial<WorktreeState> = {}): boolean {
+    const { result } = renderHook(() => useWorktreeStatus({ worktree: makeWorktree(overrides) }));
+    return result.current.isComplete;
+  }
+
+  it("is true when issue linked, open PR, and no local changes", () => {
+    expect(
+      getIsComplete({
+        issueNumber: 42,
+        prState: "open",
+        prNumber: 10,
+        ...prLinked({ prState: "open" }),
+        worktreeChanges: makeChanges({ changedFileCount: 0 }),
+      })
+    ).toBe(true);
+  });
+
+  it("is true when issue linked, merged PR, and no local changes", () => {
+    expect(
+      getIsComplete({
+        issueNumber: 42,
+        prState: "merged",
+        prNumber: 10,
+        ...prLinked({ prState: "merged" }),
+        worktreeChanges: makeChanges({ changedFileCount: 0 }),
+      })
+    ).toBe(true);
+  });
+
+  it("is false when the linked PR is closed without merging (issue #9731)", () => {
+    expect(
+      getIsComplete({
+        issueNumber: 42,
+        prState: "closed",
+        prNumber: 10,
+        ...prLinked({ prState: "closed" }),
+        worktreeChanges: makeChanges({ changedFileCount: 0 }),
+      })
+    ).toBe(false);
+  });
+
+  it("is false when the linked PR is declined (issue #9731)", () => {
+    expect(
+      getIsComplete({
+        issueNumber: 42,
+        prNumber: 10,
+        ...prLinked({ prState: "declined" }),
+        worktreeChanges: makeChanges({ changedFileCount: 0 }),
+      })
+    ).toBe(false);
+  });
+
+  it("is false when there is no linked PR at all", () => {
+    expect(
+      getIsComplete({
+        issueNumber: 42,
+        worktreeChanges: makeChanges({ changedFileCount: 0 }),
+      })
+    ).toBe(false);
+  });
+});
+
 describe("useWorktreeStatus — branchLabel", () => {
   function getStatus(overrides: Partial<WorktreeState> = {}) {
     const { result } = renderHook(() => useWorktreeStatus({ worktree: makeWorktree(overrides) }));

--- a/src/components/Worktree/WorktreeCard/hooks/useWorktreeStatus.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useWorktreeStatus.ts
@@ -201,6 +201,8 @@ export function useWorktreeStatus({
   const isComplete =
     !!worktree.issueNumber &&
     !!worktree.linked?.pr &&
+    worktree.linked.pr.state !== "closed" &&
+    worktree.linked.pr.state !== "declined" &&
     !hasChanges &&
     worktree.worktreeChanges !== null;
 

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -297,6 +297,8 @@ export function WorktreeOverviewModal({
       const isComplete =
         !!worktree.issueNumber &&
         !!worktree.linked?.pr &&
+        worktree.linked.pr.state !== "closed" &&
+        worktree.linked.pr.state !== "declined" &&
         !hasChanges &&
         worktree.worktreeChanges !== null;
       let lifecycleStage: "in-review" | "merged" | "ready-for-cleanup" | null = null;

--- a/src/lib/__tests__/worktreeCyclingOrder.test.ts
+++ b/src/lib/__tests__/worktreeCyclingOrder.test.ts
@@ -35,6 +35,30 @@ function createSnapshot(overrides: Partial<WorktreeSnapshot> = {}): WorktreeSnap
   };
 }
 
+function prLinkedSnapshot(
+  state: "open" | "merged" | "closed" | "declined"
+): Pick<WorktreeSnapshot, "linked"> {
+  return {
+    linked: {
+      providerId: "github",
+      pr: {
+        ref: { providerId: "github", owner: "test", repo: "test", number: 7, rawData: {} },
+        state,
+        url: "https://github.com/test/test/pull/7",
+      },
+    },
+  } as unknown as Pick<WorktreeSnapshot, "linked">;
+}
+
+function cleanChanges(id: string): WorktreeSnapshot["worktreeChanges"] {
+  return {
+    worktreeId: id,
+    rootPath: `/repo/${id}`,
+    changes: [],
+    changedFileCount: 0,
+  } as unknown as WorktreeSnapshot["worktreeChanges"];
+}
+
 function setWorktrees(snaps: WorktreeSnapshot[]): void {
   mocks.worktreeViewStore.setState({
     worktrees: new Map(snaps.map((s) => [s.id, s])),
@@ -329,6 +353,44 @@ describe("getVisibleWorktreesForCycling", () => {
     } as never);
     const ids = getVisibleWorktreesForCycling().map((w) => w.id);
     expect(ids).not.toContain("wt-eph");
+  });
+
+  it("excludes a worktree whose only PR is closed from the finished filter (issue #9731)", () => {
+    useWorktreeFilterStore.setState({ quickStateFilter: "finished" });
+    setWorktrees([
+      createSnapshot({ id: "main", name: "main", branch: "main", isMainWorktree: true }),
+      createSnapshot({
+        id: "wt-open",
+        name: "open",
+        branch: "feature/open",
+        issueNumber: 1,
+        ...prLinkedSnapshot("open"),
+        worktreeChanges: cleanChanges("wt-open"),
+      }),
+      createSnapshot({
+        id: "wt-closed",
+        name: "closed",
+        branch: "feature/closed",
+        issueNumber: 2,
+        ...prLinkedSnapshot("closed"),
+        worktreeChanges: cleanChanges("wt-closed"),
+      }),
+      createSnapshot({
+        id: "wt-declined",
+        name: "declined",
+        branch: "feature/declined",
+        issueNumber: 3,
+        ...prLinkedSnapshot("declined"),
+        worktreeChanges: cleanChanges("wt-declined"),
+      }),
+    ]);
+
+    const ids = getVisibleWorktreesForCycling().map((w) => w.id);
+    // Open PR with no local changes still counts as finished (positive control).
+    expect(ids).toContain("wt-open");
+    // Closed/declined PRs must NOT count as finished — that's the bug.
+    expect(ids).not.toContain("wt-closed");
+    expect(ids).not.toContain("wt-declined");
   });
 
   it("excludes non-agent terminals from quickStateFilter matching", () => {

--- a/src/lib/worktreeCyclingOrder.ts
+++ b/src/lib/worktreeCyclingOrder.ts
@@ -64,6 +64,8 @@ function buildDerivedMeta(
   const isComplete =
     !!worktree.issueNumber &&
     !!worktree.linked?.pr &&
+    worktree.linked.pr.state !== "closed" &&
+    worktree.linked.pr.state !== "declined" &&
     !hasChanges &&
     worktree.worktreeChanges !== null;
 


### PR DESCRIPTION
## Summary

- `isComplete` only checked that a linked PR existed, not what state it was in — a closed-without-merge PR satisfied it, so the worktree landed in the finished bucket while the card UI hid the closed PR entirely
- Added a state guard (`pr.state !== "closed" && pr.state !== "declined"`) at all four sites where `isComplete` is computed: `worktreeCyclingOrder.ts`, `useWorktreeStatus.ts`, `SidebarContent.tsx`, `WorktreeOverviewModal.tsx`
- Merged PRs are unaffected — cleanup behavior is preserved

Resolves #9731

## Changes

- `src/lib/worktreeCyclingOrder.ts` — state guard on `isComplete`
- `src/components/Worktree/WorktreeCard/hooks/useWorktreeStatus.ts` — state guard on `isComplete`
- `src/components/Sidebar/SidebarContent.tsx` — state guard on `isComplete`
- `src/components/Worktree/WorktreeOverviewModal.tsx` — state guard on `isComplete`
- `src/components/Worktree/WorktreeCard/hooks/__tests__/useWorktreeStatus.test.tsx` — regression tests for closed/declined PR cases
- `src/lib/__tests__/worktreeCyclingOrder.test.ts` — regression tests for closed/declined PR cases

## Testing

Added regression tests covering: closed PR not treated as finished, declined PR not treated as finished, merged PR still treated as finished (preserving cleanup behavior), open PR with linked issue still treated as in-review. 92 tests pass. Typecheck, lint, and format all clean.