### PR TITLE
fix(worktree): retry auth-suspended fetches on sync-badge click (#9736)

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -20,6 +20,7 @@ export const CHANNELS = {
   WORKTREE_HOST_DISCONNECTED: "worktree:host-disconnected",
   WORKTREE_RESTART_SERVICE: "worktree:restart-service",
   WORKTREE_RETRY_PROJECT_LOAD: "worktree:retry-project-load",
+  WORKTREE_RETRY_AUTH_FETCH: "worktree:retry-auth-fetch",
   PROJECT_WORKTREE_LOAD_STATUS: "project:worktree-load-status",
 
   TERMINAL_SPAWN: "terminal:spawn",

--- a/electron/ipc/handlers/worktree/lifecycle.ts
+++ b/electron/ipc/handlers/worktree/lifecycle.ts
@@ -149,6 +149,14 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
     }
   };
 
+  // User-triggered retry of auth-suspended fetches (#9736). Auth failures
+  // suspend a repo's fetch cache indefinitely; clicking the auth-failed sync
+  // badge clears the suspension and re-fetches. Silent no-op when the service
+  // is absent — matches handleWorktreeRefresh (not a hard error).
+  const handleWorktreeRetryAuthFetch = async (): Promise<void> => {
+    deps.worktreeService?.retryAuthFetch();
+  };
+
   const handleWorktreeDelete = async (
     ctx: IpcContext,
     payload: WorktreeDeletePayload
@@ -221,6 +229,7 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
       retryProjectLoad: op(CHANNELS.WORKTREE_RETRY_PROJECT_LOAD, handleWorktreeRetryProjectLoad, {
         withContext: true,
       }),
+      retryAuthFetch: op(CHANNELS.WORKTREE_RETRY_AUTH_FETCH, handleWorktreeRetryAuthFetch),
       delete: op(CHANNELS.WORKTREE_DELETE, handleWorktreeDelete, { withContext: true }),
     },
   });

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -791,6 +791,8 @@ const api: ElectronAPI = {
 
     retryProjectLoad: (): Promise<void> => _unwrappingInvoke(CHANNELS.WORKTREE_RETRY_PROJECT_LOAD),
 
+    retryAuthFetch: (): Promise<void> => _unwrappingInvoke(CHANNELS.WORKTREE_RETRY_AUTH_FETCH),
+
     onUpdate: (callback: (state: WorktreeState) => void) =>
       _eventBusOn("worktree:update", (payload) => callback(payload.worktree)),
 

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -304,6 +304,17 @@ export class WorkspaceClient extends EventEmitter {
     }
   }
 
+  /**
+   * User-triggered retry of auth-suspended fetches across every workspace-host.
+   * Clears the per-repo auth suspension and re-fetches — the only safe way out
+   * of indefinite auth suspension (see WorkspaceService.retryAuthFetch).
+   */
+  retryAuthFetch(): void {
+    for (const entry of this.pool.entries.values()) {
+      entry.host.send({ type: "retry-auth-fetch" });
+    }
+  }
+
   // ── Log overrides ──
 
   setLogLevelOverrides(overrides: Record<string, string>): void {

--- a/electron/services/__tests__/helpers/stubWorkspaceHost.worker.mjs
+++ b/electron/services/__tests__/helpers/stubWorkspaceHost.worker.mjs
@@ -36,6 +36,7 @@ port.on("message", (raw) => {
 
     case "set-log-level-overrides":
     case "update-forge-credentials":
+    case "retry-auth-fetch":
     case "attach-worktree-port":
     case "dispose":
     case "load-project":

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -666,6 +666,10 @@ port.on("message", async (rawMsg: any) => {
         workspaceService.updateForgeCredentials(request.providerId, request.credentials);
         break;
 
+      case "retry-auth-fetch":
+        workspaceService.retryAuthFetch();
+        break;
+
       case "get-file-tree": {
         const { requestId, worktreePath, dirPath } = request;
         try {

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -2745,6 +2745,24 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     }
   }
 
+  /**
+   * User-triggered retry of auth-suspended fetches. Auth failures suspend a
+   * repo's fetch cache indefinitely (AUTH_FAILURE_TTL_MS = POSITIVE_INFINITY) to
+   * avoid storming GitHub's secondary rate limits with repeated bad-token
+   * attempts. The only safe way out is an explicit user action — e.g. clicking
+   * the auth-failed sync badge — which clears the suspension and re-fetches.
+   * Mirrors the credential branch of updateForgeCredentials but without a
+   * credential update (the user may be retrying after fixing the token elsewhere).
+   */
+  retryAuthFetch(): void {
+    this.fetchCoordinator.clearAuthFailures();
+    for (const monitor of this.monitors.values()) {
+      if (monitor.isRunning) {
+        void monitor.triggerFetchNow();
+      }
+    }
+  }
+
   private initializePRService(): Promise<void> {
     if (!this.projectRootPath) {
       return Promise.resolve();

--- a/electron/workspace-host/__tests__/WorkspaceService.retryAuthFetch.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.retryAuthFetch.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+import type { WorkspaceService } from "../WorkspaceService.js";
+import type { WorktreeMonitor } from "../WorktreeMonitor.js";
+
+const mockSimpleGit = {
+  raw: vi.fn().mockResolvedValue(undefined),
+  branch: vi.fn().mockResolvedValue({ current: "main" }),
+};
+
+vi.mock("simple-git", () => ({
+  simpleGit: vi.fn(() => mockSimpleGit),
+}));
+
+vi.mock("../../utils/fs.js", () => ({
+  waitForPathExists: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../utils/hardenedGit.js", () => ({
+  createHardenedGit: vi.fn(() => mockSimpleGit),
+  validateCwd: vi.fn(),
+  validateBranchName: vi.fn(),
+}));
+
+vi.mock("../../utils/git.js", () => ({
+  invalidateGitStatusCache: vi.fn(),
+  getWorktreeChangesWithStats: vi.fn().mockResolvedValue({
+    head: "abc123",
+    isDirty: false,
+    stagedFileCount: 0,
+    unstagedFileCount: 0,
+    untrackedFileCount: 0,
+    conflictedFileCount: 0,
+    changedFileCount: 0,
+    changes: [],
+  }),
+}));
+
+vi.mock("../../utils/gitUtils.js", () => ({
+  getGitDir: vi.fn().mockReturnValue("/test/worktree/.git"),
+  getGitCommonDir: vi.fn().mockReturnValue(null),
+  clearGitDirCache: vi.fn(),
+}));
+
+vi.mock("../../services/worktree/mood.js", () => ({
+  categorizeWorktree: vi.fn().mockReturnValue("stable"),
+}));
+
+vi.mock("../../services/issueExtractor.js", () => ({
+  extractIssueNumberSync: vi.fn().mockReturnValue(null),
+  extractIssueNumber: vi.fn().mockResolvedValue(null),
+  deriveIssueTitleFromBranch: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock("../../services/worktree/index.js", () => ({
+  AdaptivePollingStrategy: vi.fn(function () {
+    return {
+      getCurrentInterval: vi.fn().mockReturnValue(2000),
+      updateInterval: vi.fn(),
+      reportActivity: vi.fn(),
+      updateConfig: vi.fn(),
+      isCircuitBreakerTripped: vi.fn().mockReturnValue(false),
+      reset: vi.fn(),
+      setBaseInterval: vi.fn(),
+      calculateNextInterval: vi.fn().mockReturnValue(2000),
+      recordSuccess: vi.fn(),
+      recordFailure: vi.fn(),
+      recordNoChange: vi.fn(),
+    };
+  }),
+  NoteFileReader: vi.fn(function () {
+    return { read: vi.fn().mockResolvedValue({}) };
+  }),
+}));
+
+vi.mock("../../services/github/GitHubAuth.js", () => ({
+  GitHubAuth: vi.fn().mockImplementation(() => ({
+    getToken: vi.fn().mockResolvedValue(null),
+  })),
+}));
+
+const mockPullRequestService = {
+  initialize: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn(),
+  reset: vi.fn(),
+  refresh: vi.fn(),
+  updateForgeCredentials: vi.fn(),
+  getStatus: vi.fn().mockReturnValue({
+    state: "idle",
+    isPolling: false,
+    candidateCount: 0,
+    resolvedCount: 0,
+    isEnabled: true,
+  }),
+};
+
+vi.mock("../../services/PullRequestService.js", () => ({
+  pullRequestService: mockPullRequestService,
+}));
+
+vi.mock("../../services/events.js", () => ({
+  events: new EventEmitter(),
+}));
+
+vi.mock("../../utils/gitFileWatcher.js", () => {
+  return {
+    GitFileWatcher: class {
+      start() {
+        return false;
+      }
+      dispose() {}
+    },
+  };
+});
+
+vi.mock("fs/promises", () => ({
+  stat: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  access: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  readFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  cp: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+describe("WorkspaceService.retryAuthFetch", () => {
+  let service: WorkspaceService;
+  let mockSendEvent: ReturnType<typeof vi.fn>;
+  let WorktreeMonitorClass: typeof WorktreeMonitor;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockSendEvent = vi.fn();
+
+    const WorkspaceServiceModule = await import("../WorkspaceService.js");
+    service = new WorkspaceServiceModule.WorkspaceService(mockSendEvent as any);
+
+    const WorktreeMonitorModule = await import("../WorktreeMonitor.js");
+    WorktreeMonitorClass = WorktreeMonitorModule.WorktreeMonitor;
+
+    service["projectRootPath"] = "/test/root";
+    service["git"] = mockSimpleGit as any;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function createMonitor(id: string): WorktreeMonitor {
+    const monitor = new WorktreeMonitorClass(
+      {
+        id,
+        path: id,
+        name: `feature/${id}`,
+        branch: `feature/${id}`,
+        isCurrent: false,
+        isMainWorktree: false,
+        gitDir: `${id}/.git`,
+      },
+      {
+        basePollingInterval: 10000,
+        adaptiveBackoff: false,
+        pollIntervalMax: 30000,
+        circuitBreakerThreshold: 3,
+        gitWatchEnabled: false,
+      },
+      { onUpdate: vi.fn() },
+      "main"
+    );
+    service["monitors"].set(id, monitor);
+    return monitor;
+  }
+
+  it("clears auth suspensions and triggers a fetch on every running monitor", () => {
+    const m1 = createMonitor("/test/wt-1");
+    const m2 = createMonitor("/test/wt-2");
+    m1.start();
+    m2.start();
+
+    const clearSpy = vi.spyOn(service["fetchCoordinator"], "clearAuthFailures");
+    const fetch1 = vi.spyOn(m1, "triggerFetchNow").mockResolvedValue(undefined);
+    const fetch2 = vi.spyOn(m2, "triggerFetchNow").mockResolvedValue(undefined);
+
+    service.retryAuthFetch();
+
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+    expect(fetch1).toHaveBeenCalledTimes(1);
+    expect(fetch2).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears auth suspensions even when no monitors are running", () => {
+    const stopped = createMonitor("/test/wt-stopped");
+    const clearSpy = vi.spyOn(service["fetchCoordinator"], "clearAuthFailures");
+    const fetchSpy = vi.spyOn(stopped, "triggerFetchNow").mockResolvedValue(undefined);
+
+    service.retryAuthFetch();
+
+    // Clearing must happen unconditionally so the next scheduled fetch retries;
+    // a stopped monitor must not be force-fetched.
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not force-fetch stopped monitors while still fetching running ones", () => {
+    const running = createMonitor("/test/wt-running");
+    const stopped = createMonitor("/test/wt-stopped");
+    running.start();
+
+    const runningFetch = vi.spyOn(running, "triggerFetchNow").mockResolvedValue(undefined);
+    const stoppedFetch = vi.spyOn(stopped, "triggerFetchNow").mockResolvedValue(undefined);
+
+    service.retryAuthFetch();
+
+    expect(runningFetch).toHaveBeenCalledTimes(1);
+    expect(stoppedFetch).not.toHaveBeenCalled();
+  });
+});

--- a/electron/workspace-host/__tests__/WorkspaceService.retryAuthFetch.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.retryAuthFetch.test.ts
@@ -205,6 +205,23 @@ describe("WorkspaceService.retryAuthFetch", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it("clears the suspension BEFORE triggering fetches (else the fetch short-circuits on auth-suspended)", () => {
+    const monitor = createMonitor("/test/wt-order");
+    monitor.start();
+
+    const order: string[] = [];
+    vi.spyOn(service["fetchCoordinator"], "clearAuthFailures").mockImplementation(() => {
+      order.push("clear");
+    });
+    vi.spyOn(monitor, "triggerFetchNow").mockImplementation(async () => {
+      order.push("fetch");
+    });
+
+    service.retryAuthFetch();
+
+    expect(order).toEqual(["clear", "fetch"]);
+  });
+
   it("does not force-fetch stopped monitors while still fetching running ones", () => {
     const running = createMonitor("/test/wt-running");
     const stopped = createMonitor("/test/wt-stopped");

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -211,6 +211,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     getAllIssueAssociations(): Promise<Record<string, IssueAssociation>>;
     restartService(): Promise<void>;
     retryProjectLoad(): Promise<void>;
+    retryAuthFetch(): Promise<void>;
     onUpdate(callback: (state: WorktreeState) => void): () => void;
     onRemove(callback: (data: { worktreeId: string }) => void): () => void;
     onActivated(callback: (data: { worktreeId: string }) => void): () => void;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1251,6 +1251,10 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: void;
   };
+  "worktree:retry-auth-fetch": {
+    args: [];
+    result: void;
+  };
   "worktree:retry-project-load": {
     args: [];
     result: void;

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -418,6 +418,8 @@ export type WorkspaceHostRequest =
   | { type: "has-resource-config"; requestId: string; rootPath: string }
   // Forge credential propagation
   | { type: "update-forge-credentials"; providerId: string; credentials: Credentials | null }
+  // User-triggered retry of auth-suspended fetches (e.g. clicking the auth-failed sync badge)
+  | { type: "retry-auth-fetch" }
   // Project environment variable propagation
   | { type: "update-project-env"; vars: Record<string, string> }
   // File tree operations

--- a/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
@@ -90,6 +90,11 @@ export function UpstreamSyncBadge({
 
   const handleSignInClick = useCallback((event: React.MouseEvent) => {
     event.stopPropagation();
+    // Auth failures suspend background fetches indefinitely (#9736). Clearing the
+    // suspension and re-fetching only happens on an explicit user action, so kick
+    // it off here — fire-and-forget, the settings tab below is the recovery path
+    // if the token still needs fixing.
+    void window.electron.worktree.retryAuthFetch();
     void actionService.dispatch(
       "app.settings.openTab",
       { tab: "code-forge", subtab: "github", sectionId: "github-token" },

--- a/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import { actionService } from "@/services/ActionService";
 import { formatRelativeTime } from "@/lib/formatRelativeTime";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
 
 interface UpstreamSyncBadgeProps {
   aheadCount: number | undefined;
@@ -94,7 +95,9 @@ export function UpstreamSyncBadge({
     // suspension and re-fetching only happens on an explicit user action, so kick
     // it off here — fire-and-forget, the settings tab below is the recovery path
     // if the token still needs fixing.
-    void window.electron.worktree.retryAuthFetch();
+    safeFireAndForget(window.electron.worktree.retryAuthFetch(), {
+      context: "Retry auth-suspended fetch from sync badge",
+    });
     void actionService.dispatch(
       "app.settings.openTab",
       { tab: "code-forge", subtab: "github", sectionId: "github-token" },

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -1160,7 +1160,7 @@ describe("WorktreeHeader collapsed alarm pill", () => {
   });
 });
 
-const mockRetryAuthFetch = vi.fn();
+const mockRetryAuthFetch = vi.fn().mockResolvedValue(undefined);
 
 describe("WorktreeHeader token-missing badge behavior", () => {
   beforeEach(() => {

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { WorktreeHeader, type WorktreeHeaderProps } from "../WorktreeHeader";
@@ -1160,6 +1160,8 @@ describe("WorktreeHeader collapsed alarm pill", () => {
   });
 });
 
+const mockRetryAuthFetch = vi.fn();
+
 describe("WorktreeHeader token-missing badge behavior", () => {
   beforeEach(() => {
     mockMissingToken = false;
@@ -1282,6 +1284,13 @@ describe("WorktreeHeader upstream sync indicator", () => {
   beforeEach(() => {
     mockMissingToken = false;
     vi.clearAllMocks();
+    // The auth-failed sync badge calls window.electron.worktree.retryAuthFetch();
+    // stub just that path so the click handler doesn't throw on the bare global.
+    vi.stubGlobal("electron", { worktree: { retryAuthFetch: mockRetryAuthFetch } });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("shows ahead/behind counts and renders the indicator", () => {
@@ -1399,6 +1408,9 @@ describe("WorktreeHeader upstream sync indicator", () => {
     });
     const indicator = screen.getByTestId("upstream-sync-indicator");
     fireEvent.click(indicator);
+    // Must retry the suspended fetch (the actual bug fix), not just open settings —
+    // without this the stripe stays stuck forever (#9736).
+    expect(mockRetryAuthFetch).toHaveBeenCalledTimes(1);
     expect(actionService.dispatch).toHaveBeenCalledWith(
       "app.settings.openTab",
       { tab: "code-forge", subtab: "github", sectionId: "github-token" },


### PR DESCRIPTION
## Summary

When a git fetch fails with an auth-classified error, `WorkspaceService` suspends fetching that repo indefinitely (`AUTH_FAILURE_TTL_MS = POSITIVE_INFINITY`). Every worktree card sharing that repo then shows a permanent "GitHub authentication failed" stripe. Clicking the stripe only opened the GitHub settings tab — it never cleared the suspension or triggered a retry, so the stripe was stuck until app restart.

This PR adds a `worktree:retry-auth-fetch` IPC path that calls `clearAuthFailures` on the repo then `triggerFetchNow` on every running monitor, mirroring the existing `updateForgeCredentials` pattern. The sync badge's sign-in click now fires this (via `safeFireAndForget`) alongside opening settings, so the stripe clears and the fetch retries immediately.

`AUTH_FAILURE_TTL_MS` stays at `POSITIVE_INFINITY` — this is deliberate. A finite auto-retry TTL risks hitting GitHub secondary rate limits and IP bans on shared-NAT connections (established in issues #9440/#9077). Recovery remains strictly user-triggered.

Resolves #9736

## Changes

- New `worktree:retry-auth-fetch` IPC channel — `channels.ts`, `lifecycle.ts` handler, `WorkspaceClient` client wrapper, `workspace-host.ts` registration, `preload.cts` exposure, `api.ts`/`generated.ts` types
- `WorkspaceService.retryAuthFetch` — clears per-repo auth suspension then force-fetches all running monitors in order
- `UpstreamSyncBadge` — sign-in click now fires `retryAuthFetch` via `safeFireAndForget` before navigating to settings

## Testing

- New `WorkspaceService.retryAuthFetch.test.ts` suite: clear-before-fetch ordering invariant, running-monitor gating (stopped monitors not fetched)
- `WorktreeHeader.test.tsx` auth-failed click case updated to assert `retryAuthFetch` is called