### PR TITLE
fix(github): keep toolbar issue/PR counts fresh via recency arbitration and adaptive poll cadence

### DIFF
--- a/plugins/builtin/github/main/GitHubStats.ts
+++ b/plugins/builtin/github/main/GitHubStats.ts
@@ -163,6 +163,14 @@ export interface RepoStatsAndPageResult {
     totalCount: number;
   } | null;
   source?: "network" | "memory-cache";
+  /**
+   * Adaptive delay (ms) until the next background poll, from
+   * {@link eventsProbeDelayMs} — ~60s while changes land, growing toward ~5min
+   * when idle (issue #9741). Set on every successful stats return so the
+   * renderer's visible-poll scheduler can match the probe cadence; omitted on
+   * error / disk-fallback paths where the renderer applies its own backoff.
+   */
+  nextPollIntervalMs?: number;
   error?: string;
 }
 
@@ -370,6 +378,7 @@ export async function getRepoStatsAndPage(
           totalCount: cachedStats.prCount,
         },
         source: "memory-cache",
+        nextPollIntervalMs: eventsProbeDelayMs(cacheKey),
       };
     }
   }
@@ -448,6 +457,7 @@ export async function getRepoStatsAndPage(
           issues: { ...snapshot.issues },
           prs: { ...snapshot.prs },
           source: "network",
+          nextPollIntervalMs: eventsProbeDelayMs(cacheKey),
         };
       }
     }
@@ -591,7 +601,13 @@ export async function getRepoStatsAndPage(
       }
     }
 
-    return { stats, issues: issuesPage, prs: prsPage, source: "network" };
+    return {
+      stats,
+      issues: issuesPage,
+      prs: prsPage,
+      source: "network",
+      nextPollIntervalMs: eventsProbeDelayMs(cacheKey),
+    };
   } catch (error) {
     if (!_retried && isRepoNotFoundError(error)) {
       repoContextCache.invalidate(cwd);
@@ -716,6 +732,7 @@ export async function getRepoStatsComplete(
       rateLimitResetAt:
         rateLimitState.blocked && rateLimitState.resetAt ? rateLimitState.resetAt : undefined,
       rateLimitKind: rateLimitState.blocked ? (rateLimitState.kind ?? undefined) : undefined,
+      nextPollIntervalMs: statsResult.nextPollIntervalMs,
     };
 
     return {

--- a/plugins/builtin/github/main/__tests__/GitHubStats.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubStats.test.ts
@@ -527,6 +527,67 @@ describe("getRepoStatsAndPage — REST events activity-probe gate (issues #8757,
     });
   });
 
+  describe("next-poll interval surface (issue #9741)", () => {
+    it("returns the floor cadence on a fresh fetch with changes landing", async () => {
+      mockClient.mockResolvedValue(statsResponse(5, 3));
+      mockFetch.mockResolvedValue(eventsResponse(200, { etag: '"e1"' }));
+
+      const result = await getRepoStatsAndPage("/test", false);
+
+      // No consecutive no-change polls yet → cadence pinned to the 60s floor.
+      expect(result.nextPollIntervalMs).toBe(60_000);
+    });
+
+    it("grows the cadence toward the 5-minute ceiling as no-change probes accrue", async () => {
+      mockClient.mockResolvedValue(statsResponse(5, 3));
+      mockFetch
+        .mockResolvedValueOnce(eventsResponse(200, { etag: '"e1"' }))
+        .mockResolvedValue(eventsResponse(304));
+
+      await getRepoStatsAndPage("/test", false); // seed (200)
+
+      const intervals: number[] = [];
+      for (let i = 0; i < 6; i++) {
+        expireMemoryCaches();
+        expireBackoffWindow();
+        const r = await getRepoStatsAndPage("/test", false); // 304 short-circuit
+        expect(r.source).toBe("network");
+        intervals.push(r.nextPollIntervalMs ?? 0);
+      }
+
+      // Monotonic non-decreasing growth, floored at 60s and capped at 5× = 5min.
+      expect(intervals[0]).toBe(60_000); // noChange 1 (< engage threshold)
+      expect(intervals[intervals.length - 1]).toBe(300_000); // reached the ceiling
+      for (let i = 1; i < intervals.length; i++) {
+        expect(intervals[i]).toBeGreaterThanOrEqual(intervals[i - 1]);
+        expect(intervals[i]).toBeLessThanOrEqual(300_000);
+      }
+    });
+
+    it("snaps the cadence back to the floor once a change resets the backoff", async () => {
+      mockClient.mockResolvedValue(statsResponse(5, 3));
+      mockFetch
+        .mockResolvedValueOnce(eventsResponse(200, { etag: '"e1"' }))
+        .mockResolvedValueOnce(eventsResponse(304))
+        .mockResolvedValueOnce(eventsResponse(304))
+        .mockResolvedValueOnce(eventsResponse(304))
+        .mockResolvedValue(eventsResponse(200, { etag: '"e2"' }));
+
+      await getRepoStatsAndPage("/test", false); // seed
+      for (let i = 0; i < 3; i++) {
+        expireMemoryCaches();
+        expireBackoffWindow();
+        await getRepoStatsAndPage("/test", false); // 304s grow the cadence
+      }
+
+      expireMemoryCaches();
+      expireBackoffWindow();
+      const changed = await getRepoStatsAndPage("/test", false); // 200 resets cadence
+
+      expect(changed.nextPollIntervalMs).toBe(60_000);
+    });
+  });
+
   it("returns unknown and still runs the full query when the core bucket is blocked", async () => {
     mockClient.mockResolvedValue(statsResponse(5, 3));
     mockFetch.mockResolvedValue(eventsResponse(200, { etag: '"e1"' }));

--- a/shared/types/ipc/github.ts
+++ b/shared/types/ipc/github.ts
@@ -21,6 +21,14 @@ export interface RepositoryStats {
   rateLimitResetAt?: number;
   /** Kind of active GitHub rate limit (primary quota vs secondary abuse) */
   rateLimitKind?: GitHubRateLimitKind;
+  /**
+   * Suggested delay (ms) until the next background stats poll, derived from the
+   * main-process `/events` activity probe's adaptive backoff (issue #9741):
+   * ~60s while changes are landing, growing toward ~5min on an idle repo. The
+   * renderer's visible-poll scheduler honors this so the badge stays fresh
+   * without polling excessively. Absent on error/disk-fallback results.
+   */
+  nextPollIntervalMs?: number;
 }
 
 /** Push payload describing the current GitHub rate-limit state */

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -42,6 +42,7 @@ import { useGitHubConfigStore } from "@github-renderer/stores/githubConfigStore"
 import type { Project } from "@shared/types";
 import type { GitHubRateLimitDetails, RepositoryStats } from "@shared/types";
 import { freshnessSuffix } from "./FreshnessUtils";
+import { resolveGitHubDisplayCount } from "./githubStatsCountDisplay";
 import {
   formatRateLimitCountdown,
   msUntilNextLabelChange,
@@ -192,27 +193,49 @@ export const GitHubStatsToolbarButton = memo(
     const [prListCount, setPrListCount] = useState<number | null>(null);
     const [prListHasMore, setPrListHasMore] = useState(false);
 
+    // Epoch-ms timestamp of the most recent `onCountUpdate` for each kind, used
+    // to arbitrate recency against the stats poll's `lastUpdated` (issue #9741).
+    // A ref, not state — the timestamp only feeds the display derivation below,
+    // which already re-renders whenever the count state or `lastUpdated` change,
+    // so it needs no re-render of its own. Cleared on project switch alongside
+    // the count state so the previous project's timestamp can't suppress the
+    // new project's first list load.
+    const issueListTimestampRef = useRef<number | null>(null);
+    const prListTimestampRef = useRef<number | null>(null);
+
     const handleIssueListCountUpdate = useCallback((count: number, hasMore: boolean) => {
+      issueListTimestampRef.current = Date.now();
       setIssueListCount(count);
       setIssueListHasMore(hasMore);
     }, []);
     const handlePrListCountUpdate = useCallback((count: number, hasMore: boolean) => {
+      prListTimestampRef.current = Date.now();
       setPrListCount(count);
       setPrListHasMore(hasMore);
     }, []);
 
-    // Badge display value: the list-loaded count (suffixed with `+` when more
-    // pages exist, e.g. `20+`) once the dropdown has loaded, otherwise the
-    // stats `totalCount`. Stays separate from the numeric `issueCount` /
-    // `prCount` so the digit-pulse delta detection keeps comparing raw totals.
-    const issueDisplayCount: number | string | null =
-      issueListCount !== null
-        ? issueListHasMore
-          ? `${issueListCount}+`
-          : issueListCount
-        : issueCount;
-    const prDisplayCount: number | string | null =
-      prListCount !== null ? (prListHasMore ? `${prListCount}+` : prListCount) : prCount;
+    // Badge display value: whichever of the list-loaded count (suffixed with
+    // `+` when approximate, e.g. `20+`) and the stats `totalCount` was updated
+    // most recently (issue #9741). Before #9741 the list count won
+    // unconditionally once set, freezing the badge until the dropdown reopened
+    // even when a fresher poll had landed. Stays separate from the numeric
+    // `issueCount` / `prCount` so the digit-pulse delta detection keeps
+    // comparing raw totals. Reads the timestamp refs during render (a ref read
+    // in render is fine — they're only written from event callbacks).
+    const issueDisplayCount: number | string | null = resolveGitHubDisplayCount(
+      issueCount,
+      lastUpdated,
+      issueListCount,
+      issueListHasMore,
+      issueListTimestampRef.current
+    );
+    const prDisplayCount: number | string | null = resolveGitHubDisplayCount(
+      prCount,
+      lastUpdated,
+      prListCount,
+      prListHasMore,
+      prListTimestampRef.current
+    );
 
     // Eagerly resolve the dropdown body components so the click path renders
     // them concretely without going through Suspense. The toolbar is a
@@ -584,11 +607,16 @@ export const GitHubStatsToolbarButton = memo(
         setPrsPulseAt(null);
         // Clear the list-loaded counts so the badge falls back to the new
         // project's stats count (or "—") instead of showing the previous
-        // project's loaded-page count until its dropdown is opened.
+        // project's loaded-page count until its dropdown is opened. Also clear
+        // the recency timestamps (issue #9741) — a stale timestamp from project
+        // A would otherwise out-rank project B's first stats poll and suppress
+        // its fresh count.
         setIssueListCount(null);
         setIssueListHasMore(false);
         setPrListCount(null);
         setPrListHasMore(false);
+        issueListTimestampRef.current = null;
+        prListTimestampRef.current = null;
         return;
       }
       if (prevLastUpdatedRef.current != null && lastUpdated > prevLastUpdatedRef.current) {

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -214,6 +214,24 @@ export const GitHubStatsToolbarButton = memo(
       setPrListHasMore(hasMore);
     }, []);
 
+    // Clear the list-loaded counts and their recency timestamps whenever the
+    // project changes (issue #9741). Keyed directly on the project path rather
+    // than riding on the `lastUpdated == null` reset effect below: on a fast
+    // project switch the stats poll flips `statsLoading` true in the same batch
+    // that nulls `lastUpdated`, and that effect early-returns behind its
+    // `statsLoading` guard — leaving the previous project's counts to win the
+    // recency arbitration until the new project's first poll lands. A
+    // project-scoped effect clears them deterministically on every switch. Runs
+    // once on mount as a no-op (state already null).
+    useEffect(() => {
+      setIssueListCount(null);
+      setIssueListHasMore(false);
+      setPrListCount(null);
+      setPrListHasMore(false);
+      issueListTimestampRef.current = null;
+      prListTimestampRef.current = null;
+    }, [currentProject?.path]);
+
     // Badge display value: whichever of the list-loaded count (suffixed with
     // `+` when approximate, e.g. `20+`) and the stats `totalCount` was updated
     // most recently (issue #9741). Before #9741 the list count won
@@ -605,18 +623,11 @@ export const GitHubStatsToolbarButton = memo(
         prevLastUpdatedRef.current = null;
         setIssuesPulseAt(null);
         setPrsPulseAt(null);
-        // Clear the list-loaded counts so the badge falls back to the new
-        // project's stats count (or "—") instead of showing the previous
-        // project's loaded-page count until its dropdown is opened. Also clear
-        // the recency timestamps (issue #9741) — a stale timestamp from project
-        // A would otherwise out-rank project B's first stats poll and suppress
-        // its fresh count.
-        setIssueListCount(null);
-        setIssueListHasMore(false);
-        setPrListCount(null);
-        setPrListHasMore(false);
-        issueListTimestampRef.current = null;
-        prListTimestampRef.current = null;
+        // List-loaded counts and their recency timestamps are reset by the
+        // dedicated project-path effect below — not here — because a fast
+        // project switch can leave `statsLoading` true while `lastUpdated` is
+        // null, and this branch sits behind the `statsLoading` guard above
+        // (issue #9741).
         return;
       }
       if (prevLastUpdatedRef.current != null && lastUpdated > prevLastUpdatedRef.current) {

--- a/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshFetch.test.tsx
+++ b/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshFetch.test.tsx
@@ -249,16 +249,34 @@ describe("GitHubStatsToolbarButton list-count badge wiring", () => {
     expect(source).toMatch(/\[prListHasMore,\s*setPrListHasMore\]\s*=\s*useState\(false\)/);
   });
 
-  it("derives a truncated display count only when more pages exist", () => {
-    // issueDisplayCount: list count wins once loaded; suffixed with "+" when
-    // hasMore, otherwise the exact count; falls back to the stats total before
-    // the dropdown loads.
+  it("derives the display count via the recency resolver (issue #9741)", () => {
+    // The badge no longer prefers the list count unconditionally — it defers to
+    // `resolveGitHubDisplayCount`, which arbitrates the list count against the
+    // stats poll's `lastUpdated` so a fresher poll wins.
+    expect(source).toContain('from "./githubStatsCountDisplay"');
     expect(source).toMatch(
-      /issueDisplayCount[\s\S]{0,160}?issueListCount\s*!==\s*null[\s\S]{0,120}?issueListHasMore[\s\S]{0,60}?`\$\{issueListCount\}\+`[\s\S]{0,80}?:\s*issueCount/
+      /issueDisplayCount[\s\S]{0,80}?=\s*resolveGitHubDisplayCount\(\s*issueCount,\s*lastUpdated,\s*issueListCount,\s*issueListHasMore,\s*issueListTimestampRef\.current/
     );
     expect(source).toMatch(
-      /prDisplayCount[\s\S]{0,160}?prListCount\s*!==\s*null[\s\S]{0,120}?prListHasMore[\s\S]{0,60}?`\$\{prListCount\}\+`[\s\S]{0,80}?:\s*prCount/
+      /prDisplayCount[\s\S]{0,80}?=\s*resolveGitHubDisplayCount\(\s*prCount,\s*lastUpdated,\s*prListCount,\s*prListHasMore,\s*prListTimestampRef\.current/
     );
+  });
+
+  it("stamps a recency timestamp when each list count updates (issue #9741)", () => {
+    expect(source).toMatch(/issueListTimestampRef\s*=\s*useRef<number\s*\|\s*null>\(null\)/);
+    expect(source).toMatch(/prListTimestampRef\s*=\s*useRef<number\s*\|\s*null>\(null\)/);
+    // Each handler must record Date.now() so the resolver can compare it to the
+    // stats poll's lastUpdated.
+    const issueHandler = source.slice(
+      source.indexOf("handleIssueListCountUpdate = useCallback"),
+      source.indexOf("handlePrListCountUpdate = useCallback")
+    );
+    expect(issueHandler).toContain("issueListTimestampRef.current = Date.now()");
+    const prHandler = source.slice(
+      source.indexOf("handlePrListCountUpdate = useCallback"),
+      source.indexOf("handlePrListCountUpdate = useCallback") + 300
+    );
+    expect(prHandler).toContain("prListTimestampRef.current = Date.now()");
   });
 
   it("passes displayCount to the issue and PR pills", () => {
@@ -293,5 +311,9 @@ describe("GitHubStatsToolbarButton list-count badge wiring", () => {
     expect(slice).toContain("setIssueListHasMore(false)");
     expect(slice).toContain("setPrListCount(null)");
     expect(slice).toContain("setPrListHasMore(false)");
+    // Recency timestamps must clear too (issue #9741) or project A's timestamp
+    // would suppress project B's first stats poll.
+    expect(slice).toContain("issueListTimestampRef.current = null");
+    expect(slice).toContain("prListTimestampRef.current = null");
   });
 });

--- a/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshFetch.test.tsx
+++ b/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshFetch.test.tsx
@@ -304,15 +304,21 @@ describe("GitHubStatsToolbarButton list-count badge wiring", () => {
     expect(source).toContain('${prDisplayCount ?? "—"} open PRs');
   });
 
-  it("resets the list counts on project switch (lastUpdated → null)", () => {
-    const effectStart = source.indexOf("if (statsLoading || statsError)");
-    const slice = source.slice(effectStart, effectStart + 2000);
+  it("resets the list counts + timestamps via a project-path effect (issue #9741)", () => {
+    // The reset is keyed on currentProject?.path, not the stats `lastUpdated`
+    // reset effect — a fast project switch can leave statsLoading true while
+    // lastUpdated is null, masking that effect's guarded reset.
+    const depIdx = source.lastIndexOf("[currentProject?.path]");
+    expect(depIdx).toBeGreaterThan(-1);
+    // The effect body precedes its dependency array — scan the window just
+    // above the dep marker for the resets.
+    const slice = source.slice(Math.max(0, depIdx - 600), depIdx);
     expect(slice).toContain("setIssueListCount(null)");
     expect(slice).toContain("setIssueListHasMore(false)");
     expect(slice).toContain("setPrListCount(null)");
     expect(slice).toContain("setPrListHasMore(false)");
-    // Recency timestamps must clear too (issue #9741) or project A's timestamp
-    // would suppress project B's first stats poll.
+    // Recency timestamps must clear too or project A's timestamp would suppress
+    // project B's first stats poll.
     expect(slice).toContain("issueListTimestampRef.current = null");
     expect(slice).toContain("prListTimestampRef.current = null");
   });

--- a/src/components/Layout/__tests__/githubStatsCountDisplay.test.ts
+++ b/src/components/Layout/__tests__/githubStatsCountDisplay.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { resolveGitHubDisplayCount } from "../githubStatsCountDisplay";
+
+/**
+ * Recency arbitration between the stats poll and the list-derived count
+ * (issue #9741). Behavioral tests on the pure resolver — no React/jsdom, so
+ * none of the toolbar's dynamic-import teardown races apply.
+ */
+describe("resolveGitHubDisplayCount", () => {
+  it("falls back to the stats count before the dropdown has loaded", () => {
+    expect(resolveGitHubDisplayCount(7, 1000, null, false, null)).toBe(7);
+  });
+
+  it("uses the list count when there is no stats baseline yet", () => {
+    // statsLastUpdated == null → no poll has resolved; a present list count is
+    // the best available value regardless of its own timestamp.
+    expect(resolveGitHubDisplayCount(null, null, 5, false, null)).toBe(5);
+    expect(resolveGitHubDisplayCount(null, null, 5, false, 1000)).toBe(5);
+  });
+
+  it("prefers the list count when it is strictly newer than the stats poll", () => {
+    expect(resolveGitHubDisplayCount(7, 1000, 5, false, 2000)).toBe(5);
+  });
+
+  it("prefers the list count on a same-millisecond tie (>= boundary)", () => {
+    // The list is the higher-fidelity source, so a tie must not drop it.
+    expect(resolveGitHubDisplayCount(7, 1500, 5, false, 1500)).toBe(5);
+  });
+
+  it("yields to the stats count once a later poll lands", () => {
+    // The core bug: a fresher stats read must beat the older list count.
+    expect(resolveGitHubDisplayCount(9, 3000, 5, false, 2000)).toBe(9);
+  });
+
+  it("yields to the stats count when the list count has no timestamp but stats do", () => {
+    expect(resolveGitHubDisplayCount(9, 3000, 5, false, null)).toBe(9);
+  });
+
+  it("suffixes the winning list count with + only when approximate", () => {
+    expect(resolveGitHubDisplayCount(7, 1000, 20, true, 2000)).toBe("20+");
+    expect(resolveGitHubDisplayCount(7, 1000, 20, false, 2000)).toBe(20);
+  });
+
+  it("does not suffix the stats count even when the list is approximate but stale", () => {
+    // The approximate flag belongs to the list source; when stats win, the
+    // exact stats total is shown without a "+".
+    expect(resolveGitHubDisplayCount(9, 3000, 20, true, 2000)).toBe(9);
+  });
+
+  it("returns null when both sources are empty", () => {
+    expect(resolveGitHubDisplayCount(null, null, null, false, null)).toBeNull();
+  });
+
+  it("preserves a genuine zero from whichever source wins", () => {
+    expect(resolveGitHubDisplayCount(3, 3000, 0, false, 4000)).toBe(0);
+    expect(resolveGitHubDisplayCount(0, 3000, 5, false, 2000)).toBe(0);
+  });
+});

--- a/src/components/Layout/githubStatsCountDisplay.ts
+++ b/src/components/Layout/githubStatsCountDisplay.ts
@@ -1,0 +1,46 @@
+/**
+ * Recency arbitration for the toolbar issue/PR count badge (issue #9741).
+ *
+ * Two sources feed each count: the periodic stats poll (`useRepositoryStats`,
+ * carrying `lastUpdated`) and the dropdown's list-derived count (`onCountUpdate`
+ * in `useGitHubResourceListSWR`, added in #9694, switched to real totals in
+ * #9718). The list count used to win unconditionally once set, so the badge
+ * froze on the list's number until the dropdown was reopened — even while a
+ * fresher background poll had newer data.
+ *
+ * This helper shows whichever source was updated most recently. The list count
+ * still wins immediately after a fresh dropdown fetch (its timestamp is newer);
+ * it just yields once a later stats poll lands. Both timestamps are epoch ms
+ * from the same `Date.now()` clock — the toolbar stamps the list timestamp when
+ * `onCountUpdate` fires, and `lastUpdated` is set by the stats fetch.
+ *
+ * @param statsCount       Total from the stats poll, or null when unavailable.
+ * @param statsLastUpdated Epoch ms of the last stats fetch, or null before the
+ *                         first poll resolves (no stats baseline yet).
+ * @param listCount        Count reported by the dropdown list, or null before
+ *                         the dropdown has loaded.
+ * @param listApproximate  Whether the list count is approximate (cache hit
+ *                         without a real `totalCount`) — drives the `+` suffix.
+ * @param listTimestamp    Epoch ms when the list count was last reported, or
+ *                         null if it never has.
+ */
+export function resolveGitHubDisplayCount(
+  statsCount: number | null,
+  statsLastUpdated: number | null,
+  listCount: number | null,
+  listApproximate: boolean,
+  listTimestamp: number | null
+): number | string | null {
+  // The list count wins when it exists AND is at least as fresh as the stats
+  // poll. `statsLastUpdated == null` means there is no stats baseline yet, so a
+  // present list count is the best available value. `>=` (not `>`) keeps the
+  // higher-fidelity list count on a same-millisecond tie.
+  const listWins =
+    listCount !== null &&
+    (statsLastUpdated == null || (listTimestamp != null && listTimestamp >= statsLastUpdated));
+
+  if (listWins) {
+    return listApproximate ? `${listCount}+` : listCount;
+  }
+  return statsCount;
+}

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -104,6 +104,11 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
   // closures (push subscribers). Used to skip stale stat pushes whose
   // `fetchedAt` is older than what we've already applied.
   const lastUpdatedRef = useRef<number | null>(null);
+  // Adaptive visible-poll cadence (ms) suggested by the main-process `/events`
+  // activity probe (issue #9741): ~60s while changes are landing, growing
+  // toward ~5min on an idle repo. Read synchronously by `calculateNextInterval`
+  // when the document is visible; `null` falls back to the fixed active poll.
+  const nextPollIntervalRef = useRef<number | null>(null);
 
   // Tracks whether any result (success, error, or stale) has already been
   // applied to state. Set to true by applyStatsResult on first write, reset
@@ -188,6 +193,13 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       lastUpdatedRef.current = nextLastUpdated;
       setLastUpdated(nextLastUpdated);
 
+      // Carry the probe-derived cadence forward only on successful reads — a
+      // stale/errored result has no fresh cadence to offer, so the existing
+      // value (or the fixed fallback) keeps driving the schedule.
+      if (!shouldPreserve && repoStats.nextPollIntervalMs != null) {
+        nextPollIntervalRef.current = repoStats.nextPollIntervalMs;
+      }
+
       const nextResetAt = repoStats.rateLimitResetAt ?? null;
       const nextKind = repoStats.rateLimitKind ?? null;
       rateLimitResetAtRef.current = nextResetAt;
@@ -269,7 +281,19 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
         return resetAt - Date.now() + RATE_LIMIT_RESUME_BUFFER_MS;
       }
       if (lastErrorRef.current) return ERROR_BACKOFF_INTERVAL;
-      if (isVisible) return ACTIVE_POLL_INTERVAL;
+      if (isVisible) {
+        // Honor the main-process probe's adaptive cadence (issue #9741): poll
+        // ~every minute while changes are landing, backing off toward the idle
+        // ceiling on a quiet repo. Clamp to [ACTIVE_POLL_INTERVAL,
+        // IDLE_POLL_INTERVAL] so a malformed hint can't poll faster than 30s or
+        // stall longer than the idle cadence. Falls back to the fixed active
+        // interval until the first successful poll reports a cadence.
+        const adaptive = nextPollIntervalRef.current;
+        if (adaptive != null && Number.isFinite(adaptive) && adaptive > 0) {
+          return Math.min(Math.max(adaptive, ACTIVE_POLL_INTERVAL), IDLE_POLL_INTERVAL);
+        }
+        return ACTIVE_POLL_INTERVAL;
+      }
       const multiplier = useGitHubRateLimitStore.getState().throttleMultiplier ?? 1;
       return IDLE_POLL_INTERVAL * multiplier;
     },
@@ -283,6 +307,9 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       setIsStale(false);
       lastUpdatedRef.current = null;
       setLastUpdated(null);
+      // Drop the previous project's probe cadence so the new project starts at
+      // the fixed active interval until its first poll reports one (issue #9741).
+      nextPollIntervalRef.current = null;
       rateLimitResetAtRef.current = null;
       setRateLimitResetAt(null);
       setRateLimitKind(null);

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -195,9 +195,12 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
 
       // Carry the probe-derived cadence forward only on successful reads — a
       // stale/errored result has no fresh cadence to offer, so the existing
-      // value (or the fixed fallback) keeps driving the schedule.
-      if (!shouldPreserve && repoStats.nextPollIntervalMs != null) {
-        nextPollIntervalRef.current = repoStats.nextPollIntervalMs;
+      // value keeps driving the schedule. On a success that reports no cadence
+      // (e.g. a future main-process path that omits it), fall back to null so
+      // `calculateNextInterval` reverts to the fixed active interval rather than
+      // sticking on a now-meaningless previous value.
+      if (!shouldPreserve) {
+        nextPollIntervalRef.current = repoStats.nextPollIntervalMs ?? null;
       }
 
       const nextResetAt = repoStats.rateLimitResetAt ?? null;


### PR DESCRIPTION
## Summary

Fixes a bug where toolbar issue/PR count badges went stale once the dropdown list-derived count took over from the background stats poll. Once the list reported a count it won unconditionally, so the badge froze on that number until the dropdown was reopened, even when a fresher background poll had newer data.

Two fixes:

- **Recency arbitration:** new pure helper `resolveGitHubDisplayCount` (`src/components/Layout/githubStatsCountDisplay.ts`) picks whichever count source has the newer timestamp. The toolbar stamps a per-kind timestamp on each `onCountUpdate` and clears both the timestamps and counts via a dedicated `currentProject?.path` effect, so a fast project switch can't leave a stale timestamp suppressing the new project's first poll. The list count still wins immediately after a fresh dropdown fetch; it just yields to a later poll.
- **Adaptive poll cadence:** the existing `/events` ETag activity probe already implements adaptive backoff (floor ~60s, growing toward ~5min after consecutive 304s via `eventsProbeDelayMs`). That cadence is now surfaced as `RepositoryStats.nextPollIntervalMs` and honored by the renderer's visible-poll scheduler (clamped to [30s, 5min]). The badge refreshes roughly every minute while changes land and backs off when idle, with no-change polls staying cheap 304s.

Badge/dropdown agreement (#9694) is preserved — `updateRepoStatsCount` in the main process keeps the cached per-kind count consistent with the list count.

Resolves #9741

## Changes

- `src/components/Layout/githubStatsCountDisplay.ts` — new recency arbitration helper
- `src/components/Layout/GitHubStatsToolbarButton.tsx` — per-kind timestamps, project-switch reset, honor `nextPollIntervalMs`
- `plugins/builtin/github/main/GitHubStats.ts` — surface `nextPollIntervalMs` from `eventsProbeDelayMs`
- `shared/types/ipc/github.ts` — `nextPollIntervalMs` field on `RepositoryStats`
- `src/hooks/useRepositoryStats.ts` — pass `nextPollIntervalMs` through to callers

## Testing

- New unit tests for `resolveGitHubDisplayCount` (10 cases including the `>=` same-ms boundary and zero preservation)
- Updated source-assertions for toolbar wiring and project-path reset in `GitHubStatsToolbarButton.freshFetch.test.tsx`
- New cadence-surface tests in `GitHubStats.test.ts` (floor on fresh fetch, monotonic growth to the 5-min ceiling, snap-back to floor on a change)
- Full `npm run check` + build pass