### PR TITLE
fix(dev-preview): use overflow glyph for restart options trigger

### DIFF
--- a/src/components/DevPreview/ConsoleDrawer.tsx
+++ b/src/components/DevPreview/ConsoleDrawer.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useState, useCallback, useEffect, useRef } from "react";
-import { ChevronUp, ChevronDown, RotateCw, CircleStop } from "lucide-react";
+import { ChevronUp, MoreHorizontal, RotateCw, CircleStop } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -334,7 +334,7 @@ export function ConsoleDrawer({
                           if (chevronDisabled) e.preventDefault();
                         }}
                       >
-                        <ChevronDown className="h-3.5 w-3.5" />
+                        <MoreHorizontal className="h-3.5 w-3.5" />
                       </button>
                     </span>
                   </DropdownMenuTrigger>

--- a/src/components/DevPreview/__tests__/ConsoleDrawer.test.tsx
+++ b/src/components/DevPreview/__tests__/ConsoleDrawer.test.tsx
@@ -256,10 +256,27 @@ describe("ConsoleDrawer", () => {
       expect(screen.queryByRole("button", { name: "More restart options" })).toBeNull();
     });
 
-    it("renders primary restart button and chevron when handler is provided", () => {
+    it("renders primary restart button and overflow trigger when handler is provided", () => {
       renderDrawer({ defaultOpen: false, onRestartDevServer: vi.fn(), status: "running" });
       expect(screen.getByRole("button", { name: "Restart dev server" })).toBeTruthy();
       expect(screen.getByRole("button", { name: "More restart options" })).toBeTruthy();
+    });
+
+    it("uses a non-chevron glyph for the overflow trigger so it is distinct from the drawer toggle", () => {
+      renderDrawer({ defaultOpen: true, onRestartDevServer: vi.fn(), status: "running" });
+      const toggleIconClass = getToggleButton().querySelector("svg")?.getAttribute("class") ?? "";
+      const overflowIconClass =
+        screen
+          .getByRole("button", { name: "More restart options" })
+          .querySelector("svg")
+          ?.getAttribute("class") ?? "";
+
+      // The collapse toggle is a chevron; the overflow trigger must not be — otherwise
+      // both header controls render the same down-chevron and read as duplicate collapse
+      // actions (issue #9748).
+      expect(toggleIconClass).toContain("chevron");
+      expect(overflowIconClass).not.toContain("chevron");
+      expect(overflowIconClass).not.toBe(toggleIconClass);
     });
 
     it("renders all four tier options in dropdown", () => {


### PR DESCRIPTION
## Summary

- The output drawer header had two identical `ChevronDown` glyphs side by side: the drawer collapse toggle and the \"More restart options\" split-button dropdown trigger. They looked like two collapse buttons.
- Swapped the dropdown trigger to `MoreHorizontal` (`h-3.5 w-3.5`), matching the convention already used by `BannerOverflowMenu`, `WorktreeActionsToolbar`, and `FleetArmingRibbon`. Dropped the now-unused `ChevronDown` import.

Resolves #9748

## Changes

- `src/components/DevPreview/ConsoleDrawer.tsx` — swap `ChevronDown` for `MoreHorizontal` on the restart options dropdown trigger
- `src/components/DevPreview/__tests__/ConsoleDrawer.test.tsx` — regression test asserting the overflow trigger renders a non-chevron glyph distinct from the drawer toggle

## Testing

40 unit tests pass. Full verify gate (typecheck, lint ratchet, format, IPC/confirm-wiring guards) clean.