### PR TITLE
fix(dev-preview): proxy IPv6-only Vite dev servers instead of 502ing

### DIFF
--- a/electron/services/DevPreviewProxyService.ts
+++ b/electron/services/DevPreviewProxyService.ts
@@ -13,7 +13,13 @@ import {
   parseDevPreviewProxyHost,
 } from "../../shared/utils/devPreviewProxy.js";
 
-const PROXY_HOST = "127.0.0.1";
+// The proxy binds IPv4 loopback only — it should be reachable from this machine, nothing else.
+const PROXY_LISTEN_HOST = "127.0.0.1";
+// Upstream target uses "localhost" (not a fixed IP) so Node's Happy Eyeballs (autoSelectFamily,
+// default since Node 20) tries the dev server on whichever family it bound — IPv6-first with an
+// IPv4 fallback. Vite 8 + macOS resolve `localhost` to [::1] and bind IPv6-only; hardcoding
+// 127.0.0.1 here made every proxied request ECONNREFUSED → 502 (#9747).
+const UPSTREAM_HOST = "localhost";
 // Drop a stalled upstream after this long rather than leaving the webview hanging — a
 // dev server mid-restart (or wedged) should surface a 502, not an indefinite spinner.
 const UPSTREAM_TIMEOUT_MS = 30_000;
@@ -161,11 +167,11 @@ export class DevPreviewProxyService {
         // back to an OS-assigned port; the live port is published via IPC, so callers never
         // assume the fixed value.
         server.once("error", reject);
-        server.listen(0, PROXY_HOST, resolvePort);
+        server.listen(0, PROXY_LISTEN_HOST, resolvePort);
       };
 
       server.once("error", onFirstError);
-      server.listen(DEV_PREVIEW_PROXY_PORT, PROXY_HOST, () => {
+      server.listen(DEV_PREVIEW_PROXY_PORT, PROXY_LISTEN_HOST, () => {
         server.removeListener("error", onFirstError);
         resolvePort();
       });
@@ -177,7 +183,7 @@ export class DevPreviewProxyService {
     // upstream. Gate it before resolving an upstream port so it works even while
     // the dev server is down (restarting), which is one of the cases it exists
     // to survive.
-    const url = new URL(req.url ?? "/", `http://${req.headers.host ?? PROXY_HOST}`);
+    const url = new URL(req.url ?? "/", `http://${req.headers.host ?? PROXY_LISTEN_HOST}`);
     if (url.pathname === DEV_PREVIEW_BOOTSTRAP_PATH) {
       this.handleBootstrap(req, res, url);
       return;
@@ -189,7 +195,7 @@ export class DevPreviewProxyService {
       return;
     }
     try {
-      await this.proxy!.web(req, res, { target: `http://${PROXY_HOST}:${port}` });
+      await this.proxy!.web(req, res, { target: `http://${UPSTREAM_HOST}:${port}` });
     } catch {
       this.send502(res, "The dev server isn't responding.");
     }
@@ -211,7 +217,12 @@ export class DevPreviewProxyService {
     try {
       // The 'upgrade' event types the socket as Duplex; httpxy's ws() wants net.Socket, which
       // is exactly the concrete type Node provides here.
-      await this.proxy!.ws(req, socket as Socket, { target: `http://${PROXY_HOST}:${port}` }, head);
+      await this.proxy!.ws(
+        req,
+        socket as Socket,
+        { target: `http://${UPSTREAM_HOST}:${port}` },
+        head
+      );
     } catch {
       socket.destroy();
     }

--- a/electron/services/__tests__/DevPreviewProxyService.test.ts
+++ b/electron/services/__tests__/DevPreviewProxyService.test.ts
@@ -27,7 +27,9 @@ function listenIpv6Only(server: http.Server): Promise<number> {
 // passing on a dual-stack upstream.
 function expectIpv4Refused(port: number): Promise<void> {
   return new Promise((resolve, reject) => {
-    const req = http.request({ host: "127.0.0.1", port, path: "/", agent: false }, () => {
+    const req = http.request({ host: "127.0.0.1", port, path: "/", agent: false }, (res) => {
+      res.destroy();
+      req.destroy();
       reject(new Error(`expected ECONNREFUSED on 127.0.0.1:${port} but the request connected`));
     });
     req.on("error", (err: NodeJS.ErrnoException) => {

--- a/electron/services/__tests__/DevPreviewProxyService.test.ts
+++ b/electron/services/__tests__/DevPreviewProxyService.test.ts
@@ -10,6 +10,44 @@ function listen(server: http.Server): Promise<number> {
   });
 }
 
+// Bind a server to the IPv6 loopback ONLY (no IPv4) — reproduces Vite 8 on macOS, which resolves
+// `localhost` to [::1] and binds IPv6-only. A proxy that hardcodes a 127.0.0.1 upstream can't
+// reach this (#9747).
+function listenIpv6Only(server: http.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen({ host: "::1", port: 0, ipv6Only: true }, () =>
+      resolve((server.address() as AddressInfo).port)
+    );
+  });
+}
+
+// Confirm the IPv6-only bind genuinely reproduces the bug: nothing is on IPv4, so a direct
+// 127.0.0.1 connection (what the old proxy did) is refused. Guards the new tests against silently
+// passing on a dual-stack upstream.
+function expectIpv4Refused(port: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: "127.0.0.1", port, path: "/", agent: false }, () => {
+      reject(new Error(`expected ECONNREFUSED on 127.0.0.1:${port} but the request connected`));
+    });
+    req.on("error", (err: NodeJS.ErrnoException) => {
+      if (err.code === "ECONNREFUSED") resolve();
+      else reject(err);
+    });
+    req.end();
+  });
+}
+
+// Some sandboxed/exotic environments can't bind [::1] at all — probe once and skip the IPv6-only
+// cases there rather than reporting a misleading pass. Ubuntu/macOS CI runners support it.
+const canBindIpv6Only = await new Promise<boolean>((resolve) => {
+  const probe = http.createServer();
+  probe.once("error", () => resolve(false));
+  probe.listen({ host: "::1", port: 0, ipv6Only: true }, () => {
+    probe.close(() => resolve(true));
+  });
+});
+
 interface ProxyResponse {
   status: number;
   body: string;
@@ -77,10 +115,66 @@ describe("DevPreviewProxyService", () => {
     expect(res.status).toBe(200);
     expect(res.body).toBe("hello from upstream");
     // changeOrigin rewrote the Host away from the proxy subdomain to the upstream — Vite/Next
-    // host checks depend on this.
-    expect(seenHost).toContain("127.0.0.1");
+    // host checks depend on this. The upstream target host is "localhost" (#9747), so the
+    // rewritten Host carries that hostname rather than the proxy's `dp-*` subdomain.
+    expect(seenHost).not.toContain("dp-test");
+    expect(seenHost).toContain("localhost");
     expect(seenHost).toContain(String(upstreamPort));
   });
+
+  it.skipIf(!canBindIpv6Only)(
+    "forwards an HTTP request to an IPv6-only upstream (Vite IPv6-only bind, #9747)",
+    async () => {
+      upstream = http.createServer((_req, res) => {
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.end("hello over ipv6");
+      });
+      const upstreamPort = await listenIpv6Only(upstream);
+      // Sanity-check the fixture: the old 127.0.0.1 upstream target can't reach this server.
+      await expectIpv4Refused(upstreamPort);
+
+      proxy = new DevPreviewProxyService((sub) => (sub === "dp-test" ? upstreamPort : null));
+      const proxyPort = await proxy.start();
+
+      const res = await request(proxyPort, `dp-test.localhost:${proxyPort}`);
+
+      // The proxy now targets `localhost`, so Node's Happy Eyeballs reaches the IPv6-only
+      // upstream instead of 502ing.
+      expect(res.status).toBe(200);
+      expect(res.body).toBe("hello over ipv6");
+    }
+  );
+
+  it.skipIf(!canBindIpv6Only)(
+    "forwards a WebSocket upgrade to an IPv6-only upstream (HMR over IPv6, #9747)",
+    async () => {
+      // ws's port option doesn't forward ipv6Only, so bind the http server ourselves and hand it
+      // to WebSocketServer. Assigning it to `upstream` lets afterEach close it.
+      const httpServer = http.createServer();
+      const upstreamPort = await listenIpv6Only(httpServer);
+      await expectIpv4Refused(upstreamPort);
+      upstream = httpServer;
+      wss = new WebSocketServer({ server: httpServer });
+      wss.on("connection", (socket) => {
+        socket.on("message", (msg) => socket.send(`echo:${msg}`));
+      });
+
+      proxy = new DevPreviewProxyService(() => upstreamPort);
+      const proxyPort = await proxy.start();
+
+      const client = new WebSocket(`ws://127.0.0.1:${proxyPort}/`, {
+        headers: { host: `dp-test.localhost:${proxyPort}` },
+      });
+      const reply = await new Promise<string>((resolve, reject) => {
+        client.on("open", () => client.send("ping"));
+        client.on("message", (data) => resolve(data.toString()));
+        client.on("error", reject);
+      });
+      client.close();
+
+      expect(reply).toBe("echo:ping");
+    }
+  );
 
   it("strips the Domain attribute from upstream Set-Cookie headers", async () => {
     upstream = http.createServer((_req, res) => {


### PR DESCRIPTION
## Summary

- The dev-preview reverse proxy used a single `PROXY_HOST` constant for both its listen address and the upstream target. When Vite 8 on macOS binds `[::1]`-only, every proxied request targeted `127.0.0.1`, got `ECONNREFUSED`, and returned 502 — even though the readiness probe was passing (it resolves `localhost`, which reaches `[::1]` fine).
- Fix splits the constant into `PROXY_LISTEN_HOST` (`127.0.0.1`, unchanged) and `UPSTREAM_HOST` (`localhost`), so Node's Happy Eyeballs picks whichever address family Vite actually bound.
- Added IPv6-only HTTP and WebSocket upstream tests, guarded by `it.skipIf` for environments where `[::1]` isn't available.

Resolves #9747

## Changes

- `electron/services/DevPreviewProxyService.ts` — replace `PROXY_HOST` with `PROXY_LISTEN_HOST` and `UPSTREAM_HOST`
- `electron/services/__tests__/DevPreviewProxyService.test.ts` — IPv6-only HTTP and WebSocket proxy tests

## Testing

Verified against a Vite 8 / SvelteKit project where `lsof` confirmed `[::1]`-only bind. Unit tests cover the IPv6-only HTTP and WebSocket upstream paths; `it.skipIf` keeps them from failing on hosts where `[::1]` isn't available.