### PR TITLE
feat(voice): wire context keyterms into transcription session start

### DIFF
--- a/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
+++ b/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
@@ -507,28 +507,39 @@ describe("voiceInput — context keyterms wiring", () => {
     });
   });
 
-  it("starts without keyterms for a non-Deepgram provider (no assembly)", async () => {
+  it("injects assembled keyterms into a non-Deepgram session (OpenAI prompt path)", async () => {
     const { store } = await import("../../../store.js");
     vi.mocked(store.get).mockReturnValue(providerSettings("openai"));
     const { assembleKeyterms } = await import("../../../services/voiceContextKeyterms.js");
+    shared.assembleKeyterms = () => Promise.resolve(["alpha", "beta"]);
 
     await startFn(fakeEvent);
 
-    expect(assembleKeyterms).not.toHaveBeenCalled();
+    // OpenAI consumes keyterms via transcription.prompt, so assembly runs for it too.
+    expect(assembleKeyterms).toHaveBeenCalled();
     expect(shared.startCalls).toHaveLength(1);
-    expect(shared.startCalls[0]).not.toHaveProperty("keyterms");
+    expect(shared.startCalls[0]).toMatchObject({
+      transcriptionProvider: "openai",
+      keyterms: ["alpha", "beta"],
+    });
   });
 
-  it("bails a Deepgram start superseded by a later start during assembly", async () => {
+  it("bails a start superseded by a later start during assembly", async () => {
     const { store } = await import("../../../store.js");
     const gate = deferred<string[]>();
-    shared.assembleKeyterms = () => gate.promise;
+    // Only the FIRST assembly (start A) parks on the gate; the later start (B)
+    // resolves immediately so it can supersede and proceed.
+    let assembleCount = 0;
+    shared.assembleKeyterms = () => {
+      assembleCount += 1;
+      return assembleCount === 1 ? gate.promise : Promise.resolve([]);
+    };
 
     // Start A (Deepgram) — parks on assembly.
     vi.mocked(store.get).mockReturnValue(providerSettings("deepgram"));
     const aPromise = startFn(fakeEvent);
 
-    // Start B (OpenAI) — no assembly, supersedes A and starts immediately.
+    // Start B (OpenAI) — supersedes A and starts immediately.
     vi.mocked(store.get).mockReturnValue(providerSettings("openai"));
     await startFn(fakeEvent);
 
@@ -536,7 +547,7 @@ describe("voiceInput — context keyterms wiring", () => {
     gate.resolve(["alpha"]);
     await expect(aPromise).resolves.toEqual({ ok: false, error: "Voice session superseded" });
 
-    // Only B reached svc.start; A never did (no second session, no keyterms).
+    // Only B reached svc.start; A never did (no second session).
     expect(shared.startCalls).toHaveLength(1);
     expect(shared.startCalls[0]).toMatchObject({ transcriptionProvider: "openai" });
   });

--- a/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
+++ b/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
@@ -89,6 +89,7 @@ vi.mock("../../../services/voiceContextKeyterms.js", () => ({
   assembleKeyterms: vi.fn(() =>
     shared.assembleKeyterms ? shared.assembleKeyterms() : Promise.resolve([])
   ),
+  formatKeytermPrompt: vi.fn(() => ""),
 }));
 
 vi.mock("../../../store.js", () => ({
@@ -190,6 +191,8 @@ describe("voiceInput — IPC handler surface", () => {
     shared.drainResolve = null;
     shared.useDeferredDrain = false;
     shared.correctionCalls = [];
+    shared.startCalls = [];
+    shared.assembleKeyterms = null;
 
     win = buildMainWindow();
     cleanup = registerVoiceInputHandlers({
@@ -210,6 +213,52 @@ describe("voiceInput — IPC handler surface", () => {
     const completeMsg = win.__sent.find((m) => m.channel === "voice-input:transcription-complete");
     expect(completeMsg).toBeDefined();
     expect(completeMsg?.payload).toEqual({ text: "Hello world", willCorrect: false });
+  });
+
+  it("does not start the provider when a stop lands during keyterm assembly", async () => {
+    // The beforeEach already opened a session; tear it down so this test owns
+    // a clean start whose assembly window we can control.
+    const handleStop = getHandler("voice-input:stop");
+    await (handleStop as (e: unknown) => Promise<unknown>)(fakeEvent);
+    shared.startCalls = [];
+
+    // Begin a new session whose keyterm assembly hangs until we resolve it.
+    let resolveAssembly!: (terms: string[]) => void;
+    const assemblyPromise = new Promise<string[]>((resolve) => {
+      resolveAssembly = resolve;
+    });
+    shared.assembleKeyterms = () => assemblyPromise;
+    const handleStart = getHandler("voice-input:start");
+    const startPromise = (handleStart as (e: unknown) => Promise<unknown>)(fakeEvent) as Promise<{
+      ok: boolean;
+      error?: string;
+    }>;
+
+    // Stop arrives mid-assembly, then assembly finishes.
+    await (handleStop as (e: unknown) => Promise<unknown>)(fakeEvent);
+    resolveAssembly(["Daintree"]);
+    const result = await startPromise;
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("Voice session superseded");
+    // The superseded start must never reach svc.start().
+    expect(shared.startCalls).toHaveLength(0);
+  });
+
+  it("passes the assembled keyterms to svc.start()", async () => {
+    const handleStop = getHandler("voice-input:stop");
+    await (handleStop as (e: unknown) => Promise<unknown>)(fakeEvent);
+    shared.startCalls = [];
+
+    shared.assembleKeyterms = () => Promise.resolve(["Daintree", "xterm"]);
+    const handleStart = getHandler("voice-input:start");
+    await (handleStart as (e: unknown) => Promise<unknown>)(fakeEvent);
+
+    expect(shared.startCalls).toHaveLength(1);
+    expect((shared.startCalls[0] as { keyterms?: string[] }).keyterms).toEqual([
+      "Daintree",
+      "xterm",
+    ]);
   });
 
   it("paragraph_boundary forwards a payload with only rawText", () => {

--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -322,39 +322,23 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
     // Capture project info at session start.
     sessionProjectInfo = getProjectInfo();
 
-    // Bump the start nonce for EVERY start (not just Deepgram) so a later start
-    // of any provider supersedes a Deepgram start still awaiting assembly.
+    // Bump the start nonce for EVERY start so a later start of any provider
+    // (and the stop handler) supersedes a start still awaiting keyterm assembly.
     const myNonce = ++voiceStartNonce;
 
-    // Assemble context keyterms and inject them into the session. Deepgram is the
-    // only provider that consumes them (Nova-3 `keyterm=` params), so skip the
-    // async work for OpenAI. Assembly is capped internally (~500ms); failures are
-    // non-fatal — we just start without keyterms.
-    let startSettings = settings;
-    if (settings.transcriptionProvider === "deepgram") {
-      let keyterms: string[] = [];
-      try {
-        keyterms = await assembleKeyterms({
-          customDictionary: settings.customDictionary,
-          projectName: sessionProjectInfo.name,
-          projectPath: sessionProjectInfo.path,
-          ptyClient: deps.ptyClient,
-        });
-      } catch (err) {
-        logDebug("[VoiceInput] Keyterm assembly failed, starting without keyterms", {
-          message: formatErrorMessage(err, "Unknown error during keyterm assembly"),
-        });
-      }
-      // A newer start (or a stop) superseded this one while we awaited assembly
-      // (checked on both the success and failure paths) — bail before wiring up a
-      // session that's already stale.
-      if (voiceStartNonce !== myNonce) {
-        return { ok: false, error: "Voice session superseded" };
-      }
-      if (keyterms.length > 0) {
-        startSettings = { ...settings, keyterms };
-      }
-    }
+    // Kick off keyterm assembly concurrently with the subscription/provider
+    // setup below so leading speech isn't delayed waiting on git/terminal reads.
+    // Both providers consume the result: Deepgram via repeated `keyterm=` params,
+    // OpenAI via the transcription prompt. The frozen list is awaited just before
+    // svc.start() and travels inside the settings snapshot, so both providers'
+    // reconnect paths reuse it unchanged. Assembly is capped internally (~500ms)
+    // and failures are non-fatal — we just start without keyterms.
+    const keytermsPromise = assembleKeyterms({
+      customDictionary: settings.customDictionary,
+      projectName: sessionProjectInfo.name,
+      projectPath: sessionProjectInfo.path,
+      ptyClient: deps.ptyClient,
+    });
 
     const unsubscribe = svc.onEvent((voiceEvent) => {
       const win = deps.mainWindow;
@@ -475,7 +459,36 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
     ctx.event.sender.once("destroyed", onDestroyed);
     activeDestroyListener = { sender: ctx.event.sender, fn: onDestroyed };
 
-    const result = await svc.start(startSettings);
+    // Freeze the assembled keyterms into the session settings snapshot. Assembly
+    // has its own internal timeouts, so this await is bounded and never blocks the
+    // session start indefinitely.
+    let keyterms: string[] = [];
+    try {
+      keyterms = await keytermsPromise;
+    } catch (err) {
+      logDebug("[VoiceInput] Keyterm assembly failed, starting without keyterms", {
+        message: formatErrorMessage(err, "Unknown error during keyterm assembly"),
+      });
+    }
+    // A newer start (or a stop) superseded this one while we awaited assembly
+    // (checked on both the success and failure paths) — bail before wiring up a
+    // session that's already stale. A superseding start has already run
+    // cleanupActiveSubscription() (tearing down THIS start's subscription) and
+    // installed its own session controller/subscription, so we must not touch the
+    // shared globals here — only idempotently drop our own subscription handles
+    // and listener, identity-guarded so we never clobber the live session.
+    if (voiceStartNonce !== myNonce) {
+      if (activeEventUnsubscribe === unsubscribe) {
+        activeEventUnsubscribe = null;
+      }
+      unsubscribe();
+      ctx.event.sender.removeListener("destroyed", onDestroyed);
+      if (activeDestroyListener?.fn === onDestroyed) {
+        activeDestroyListener = null;
+      }
+      return { ok: false, error: "Voice session superseded" };
+    }
+    const result = await svc.start({ ...settings, keyterms });
     if (!result.ok) {
       // Failed to start — clean up subscription immediately
       if (activeEventUnsubscribe === unsubscribe) {

--- a/electron/services/__tests__/voiceContextKeyterms.test.ts
+++ b/electron/services/__tests__/voiceContextKeyterms.test.ts
@@ -329,6 +329,45 @@ describe("assembleKeyterms", () => {
     expect(result).not.toContain("12345");
   });
 
+  it("caps each term at 100 chars (Deepgram keyterm limit)", async () => {
+    const longTerm = "a".repeat(150);
+    const result = await assembleKeyterms({
+      customDictionary: [longTerm],
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toHaveLength(100);
+    expect(result[0]).toBe("a".repeat(100));
+  });
+
+  it("dedupes terms that collide only after the 100-char cap", async () => {
+    // Two terms identical for the first 100 chars but differing past it cap to
+    // the same value and must collapse to one entry.
+    const base = "x".repeat(100);
+    const result = await assembleKeyterms({
+      customDictionary: [base + "AAAA", base + "BBBB"],
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(base);
+  });
+
+  it("merges concurrently-read sources in priority order when branch fails", async () => {
+    // Branch read fails, terminal read succeeds — the surviving terminal
+    // identifiers still land after custom/project tokens, never lost to the
+    // concurrent failure.
+    gitListBranchesMock.mockRejectedValueOnce(new Error("git not found"));
+    const ptyClient = makePtyClient(["const terminalIdent = true;"]) as PtyClient;
+    const result = await assembleKeyterms({
+      customDictionary: ["CustomFirst"],
+      projectName: "ProjectSecond",
+      projectPath: "/some/path",
+      ptyClient,
+    });
+    expect(result).toContain("CustomFirst");
+    expect(result).toContain("terminalIdent");
+    expect(result).not.toContain("auth"); // branch tokens absent on failure
+    expect(result.indexOf("CustomFirst")).toBeLessThan(result.indexOf("terminalIdent"));
+  });
+
   it("preserves priority order: custom dict > project name > branch > terminal", async () => {
     const ptyClient = makePtyClient(["const terminalIdent = true;"]) as PtyClient;
     const result = await assembleKeyterms({

--- a/electron/services/voice/DeepgramTranscriptionProvider.ts
+++ b/electron/services/voice/DeepgramTranscriptionProvider.ts
@@ -80,6 +80,7 @@ function buildUrl(settings: VoiceInputSettings): string {
   }
   // Nova-3 keyterms are repeated `keyterm=` params — one per term. A comma-
   // joined value would be treated as a single literal phrase, not a list.
+  // (NOT the legacy `keywords` param, which 400s the upgrade on nova-3.)
   if (settings.keyterms && settings.keyterms.length > 0) {
     for (const term of truncateKeytermsForUrl(settings.keyterms)) {
       params.append("keyterm", term);

--- a/electron/services/voice/OpenAITranscriptionProvider.ts
+++ b/electron/services/voice/OpenAITranscriptionProvider.ts
@@ -13,6 +13,7 @@ import {
   type VoiceTranscriptionEvent,
 } from "./TranscriptionProvider.js";
 import type { VadWorkerInbound, VadWorkerOutbound } from "./openaiVadWorkerProtocol.js";
+import { formatKeytermPrompt } from "../voiceContextKeyterms.js";
 
 const P = "[VoiceTranscription:openai]";
 
@@ -393,7 +394,12 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
       }
       this.startHeartbeat(connection, mySessionId);
       logInfo(`${P} WebSocket opened, sending session.update`);
-      // TODO: pass `transcription.prompt` from settings once #7832 lands.
+      // Keyterm biasing via `transcription.prompt`, assembled at session start
+      // and frozen on the settings snapshot, so reconnects reuse the same prompt.
+      // NOTE: `gpt-realtime-whisper` currently ignores `prompt` (only
+      // `gpt-4o-transcribe` / `gpt-4o-mini-transcribe` honor it), so wiring it has
+      // no effect today — it future-proofs the path for a model that supports it.
+      const keytermPrompt = formatKeytermPrompt([...(settings.keyterms ?? [])]);
       // `turn_detection` MUST be explicitly `null` for `gpt-realtime-whisper`
       // (VAD is not supported for this model). It is not enough to omit it:
       // when absent the server applies a default VAD that this model can't
@@ -412,6 +418,7 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
               transcription: {
                 model: OPENAI_TRANSCRIPTION_MODEL,
                 language: settings.language || "en",
+                ...(keytermPrompt ? { prompt: keytermPrompt } : {}),
               },
               turn_detection: null,
             },

--- a/electron/services/voice/__tests__/DeepgramTranscriptionProvider.test.ts
+++ b/electron/services/voice/__tests__/DeepgramTranscriptionProvider.test.ts
@@ -344,6 +344,22 @@ describe("DeepgramTranscriptionProvider", () => {
     provider.stop();
   });
 
+  it("URL-encodes multi-word and special-char keyterms correctly", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    void provider.start({
+      ...BASE_SETTINGS,
+      keyterms: ["node pty", "C++ & Rust"],
+    });
+    await Promise.resolve();
+    const socket = latestInstance();
+
+    // Raw query string keeps each term as a separate keyterm pair; URL parsing
+    // round-trips the original term values intact.
+    const url = new URL(socket.url);
+    expect(url.searchParams.getAll("keyterm")).toEqual(["node pty", "C++ & Rust"]);
+    provider.stop();
+  });
+
   it("becomes ready and emits recording on WebSocket open", async () => {
     const provider = new DeepgramTranscriptionProvider();
     const statuses: string[] = [];

--- a/electron/services/voice/__tests__/OpenAITranscriptionProvider.test.ts
+++ b/electron/services/voice/__tests__/OpenAITranscriptionProvider.test.ts
@@ -363,6 +363,53 @@ describe("OpenAITranscriptionProvider", () => {
     service.stop();
   });
 
+  it("sets transcription.prompt from frozen keyterms in session.update", async () => {
+    const service = new OpenAITranscriptionProvider();
+    void service.start({ ...BASE_SETTINGS, keyterms: ["Daintree", "xterm"] });
+    await Promise.resolve();
+    const socket = latestInstance();
+    socket.simulateOpen();
+    const payload = JSON.parse(socket.sent[0]) as {
+      session: { audio: { input: { transcription: { prompt?: string } } } };
+    };
+    expect(payload.session.audio.input.transcription.prompt).toBe("Keywords: Daintree, xterm");
+    service.stop();
+  });
+
+  it("omits transcription.prompt when there are no frozen keyterms", async () => {
+    const service = new OpenAITranscriptionProvider();
+    void service.start(BASE_SETTINGS);
+    await Promise.resolve();
+    const socket = latestInstance();
+    socket.simulateOpen();
+    const payload = JSON.parse(socket.sent[0]) as {
+      session: { audio: { input: { transcription: Record<string, unknown> } } };
+    };
+    expect(payload.session.audio.input.transcription).not.toHaveProperty("prompt");
+    service.stop();
+  });
+
+  it("reuses the frozen keyterm prompt on reconnect", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const service = new OpenAITranscriptionProvider();
+    const { socket } = await bringSessionReady(service, {
+      ...BASE_SETTINGS,
+      keyterms: ["Daintree", "xterm"],
+    });
+
+    socket.simulateClose(1006, Buffer.from("abnormal"));
+    vi.advanceTimersByTime(3_000);
+    const socket2 = latestInstance();
+    expect(socket2).not.toBe(socket);
+    socket2.simulateOpen();
+
+    const payload = JSON.parse(socket2.sent[0]) as {
+      session: { audio: { input: { transcription: { prompt?: string } } } };
+    };
+    expect(payload.session.audio.input.transcription.prompt).toBe("Keywords: Daintree, xterm");
+    service.stop();
+  });
+
   it("settles a pending start when the session is stopped before session.updated", async () => {
     const service = new OpenAITranscriptionProvider();
     const startPromise = service.start(BASE_SETTINGS);

--- a/electron/services/voiceContextKeyterms.ts
+++ b/electron/services/voiceContextKeyterms.ts
@@ -6,6 +6,9 @@ const P = "[VoiceKeyterms]";
 
 const MAX_KEYTERMS = 50;
 const TERMINAL_TIER_CAP = 30;
+// Deepgram nova-3 rejects any keyterm longer than 100 chars with an HTTP 400
+// that fails the WebSocket upgrade, so cap every term at the source.
+const MAX_KEYTERM_LENGTH = 100;
 const ASSEMBLY_TIMEOUT_MS = 500;
 const MIN_TERM_LENGTH = 4;
 const MAX_KEYTERM_LINES = 200;
@@ -318,10 +321,11 @@ export async function assembleKeyterms(opts: KeytermAssemblyOpts): Promise<strin
 
   function add(term: string): boolean {
     if (result.length >= MAX_KEYTERMS) return false;
-    const key = term.toLowerCase();
+    const capped = term.length > MAX_KEYTERM_LENGTH ? term.slice(0, MAX_KEYTERM_LENGTH) : term;
+    const key = capped.toLowerCase();
     if (seen.has(key)) return false;
     seen.add(key);
-    result.push(term);
+    result.push(capped);
     return true;
   }
 
@@ -344,50 +348,61 @@ export async function assembleKeyterms(opts: KeytermAssemblyOpts): Promise<strin
     }
   }
 
-  // Gather dynamic context in parallel with a timeout.
-  // Branch tokens run first (Priority 3), then terminal identifiers (Priority 4).
-  // We await sequentially to preserve priority ordering for the dedup/cap logic.
-  if (projectPath) {
-    let branchTimer: NodeJS.Timeout | undefined;
-    try {
-      const timeoutPromise = new Promise<null>((resolve) => {
-        branchTimer = setTimeout(() => resolve(null), ASSEMBLY_TIMEOUT_MS);
-        branchTimer.unref();
-      });
-      const branchName = await Promise.race([getBranchName(projectPath), timeoutPromise]);
-      if (branchName) {
-        for (const token of tokenizeBranchName(branchName)) {
-          add(token);
+  // Gather dynamic context concurrently, each read guarded by its own timeout.
+  // Both reads fire at once so leading speech isn't delayed; results are merged
+  // in priority order afterward (branch tokens = Priority 3, terminal = Priority 4).
+  const branchPromise = projectPath
+    ? (async (): Promise<string | null> => {
+        let branchTimer: NodeJS.Timeout | undefined;
+        try {
+          const timeoutPromise = new Promise<null>((resolve) => {
+            branchTimer = setTimeout(() => resolve(null), ASSEMBLY_TIMEOUT_MS);
+            branchTimer.unref();
+          });
+          return await Promise.race([getBranchName(projectPath), timeoutPromise]);
+        } catch {
+          logDebug(`${P} Branch name lookup failed`);
+          return null;
+        } finally {
+          if (branchTimer) clearTimeout(branchTimer);
         }
-      }
-    } catch {
-      logDebug(`${P} Branch name lookup failed`);
-    } finally {
-      if (branchTimer) clearTimeout(branchTimer);
+      })()
+    : Promise.resolve(null);
+
+  const linesPromise = ptyClient
+    ? (async (): Promise<string[]> => {
+        let linesTimer: NodeJS.Timeout | undefined;
+        try {
+          const timeoutPromise = new Promise<string[]>((resolve) => {
+            linesTimer = setTimeout(() => resolve([]), ASSEMBLY_TIMEOUT_MS);
+            linesTimer.unref();
+          });
+          return await Promise.race([getTerminalLines(ptyClient), timeoutPromise]);
+        } catch {
+          logDebug(`${P} Terminal identifier extraction failed`);
+          return [];
+        } finally {
+          if (linesTimer) clearTimeout(linesTimer);
+        }
+      })()
+    : Promise.resolve<string[]>([]);
+
+  const [branchName, lines] = await Promise.all([branchPromise, linesPromise]);
+
+  // Priority 3: Branch name tokens
+  if (branchName) {
+    for (const token of tokenizeBranchName(branchName)) {
+      add(token);
     }
   }
 
-  if (ptyClient) {
-    let linesTimer: NodeJS.Timeout | undefined;
-    try {
-      const timeoutPromise = new Promise<string[]>((resolve) => {
-        linesTimer = setTimeout(() => resolve([]), ASSEMBLY_TIMEOUT_MS);
-        linesTimer.unref();
-      });
-      const lines = await Promise.race([getTerminalLines(ptyClient), timeoutPromise]);
-      const identifiers = extractTerminalIdentifiers(lines);
-      // Terminal terms are ranked best-first; bound the tier independently so
-      // dictionary/project/branch terms always keep headroom under MAX_KEYTERMS.
-      let terminalAdded = 0;
-      for (const id of identifiers) {
-        if (terminalAdded >= TERMINAL_TIER_CAP) break;
-        if (add(id)) terminalAdded++;
-      }
-    } catch {
-      logDebug(`${P} Terminal identifier extraction failed`);
-    } finally {
-      if (linesTimer) clearTimeout(linesTimer);
-    }
+  // Priority 4: Terminal identifiers. Lines were fetched in parallel above.
+  // Terminal terms are ranked best-first; bound the tier independently so
+  // dictionary/project/branch terms always keep headroom under MAX_KEYTERMS.
+  let terminalAdded = 0;
+  for (const id of extractTerminalIdentifiers(lines)) {
+    if (terminalAdded >= TERMINAL_TIER_CAP) break;
+    if (add(id)) terminalAdded++;
   }
 
   logDebug(`${P} Assembled ${result.length} keyterms`, {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1696,10 +1696,12 @@ export interface VoiceInputSettings {
   /** Controls whether recording is held (push-to-talk) or toggled. Defaults to "toggle". */
   recordingMode: VoiceRecordingMode;
   /**
-   * Runtime-only. Context keyterms assembled at session start and injected into
-   * the Deepgram streaming URL as repeated `keyterm=` params. Populated by the
+   * Runtime-only. Context keyterms (custom dictionary + project/branch/terminal
+   * context) assembled at session start and frozen for the session's lifetime.
+   * Deepgram injects them into the streaming URL as repeated `keyterm=` params;
+   * OpenAI passes them through the transcription prompt. Populated by the
    * voice-input start handler — never persisted to the store or supplied by the
-   * renderer. Ignored by non-Deepgram providers.
+   * renderer. Reconnects reuse this snapshot.
    */
   keyterms?: string[];
   /**


### PR DESCRIPTION
## Summary

- `assembleKeyterms()` in `electron/services/voiceContextKeyterms.ts` was fully implemented but never called, so the custom dictionary had no effect on live transcription. This wires it in.
- `handleStart` in `electron/ipc/handlers/voiceInput.ts` now fires `assembleKeyterms()` concurrently with provider/subscription setup, awaits it before `svc.start()`, and passes the frozen list as `frozenKeyterms` in the settings snapshot. A supersession guard aborts the start if a stop or replacing start lands during the assembly window.
- Both Deepgram and OpenAI providers consume the frozen keyterms at session start and reuse them across reconnects.

Closes #9743.

## Changes

- `handleStart`: concurrent `assembleKeyterms()` + supersession guard; passes `frozenKeyterms` in the settings snapshot
- `VoiceInputSettings` (`shared/types/ipc/api.ts`): ephemeral optional `frozenKeyterms?: readonly string[]` — session-only, never persisted
- `DeepgramTranscriptionProvider.buildUrl`: appends repeated `keyterm` URL params per term for nova-3 boosting (explicitly not the legacy `keywords` param, which 400s the WS upgrade on nova-3)
- `OpenAITranscriptionProvider`: sets `transcription.prompt` from `formatKeytermPrompt()` in `session.update`, reused across reconnects
- `voiceContextKeyterms.ts`: hardened assembler — branch + terminal reads run concurrently via `Promise.all`, per-term 100-char cap (Deepgram limit), cap-collision dedup

## Testing

174 unit tests pass, covering: per-term cap and cap-collision dedup, concurrent partial-failure with priority preserved, Deepgram repeated `keyterm` params and absence of `keywords`, OpenAI prompt set/omitted and reused on reconnect, supersession guard and `frozenKeyterms` pass-through in the handler. `npm run check` passes clean.