### PR TITLE
feat(voice): wire context keyterms into the Deepgram connection

### DIFF
--- a/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
+++ b/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
@@ -30,6 +30,10 @@ const shared = vi.hoisted(() => ({
   /** When true, stopGracefully uses a deferred promise instead of resolving immediately. */
   useDeferredDrain: false,
   correctionCalls: [] as Array<{ request: unknown; settings: unknown }>,
+  /** Settings objects passed to svc.start(), in call order. */
+  startCalls: [] as unknown[],
+  /** Optional override for assembleKeyterms — lets a test defer/control timing. */
+  assembleKeyterms: null as null | (() => Promise<string[]>),
 }));
 
 vi.mock("../../../services/VoiceTranscriptionService.js", () => ({
@@ -38,7 +42,8 @@ vi.mock("../../../services/VoiceTranscriptionService.js", () => ({
       shared.transcriptionEventCallback = cb;
       return () => {};
     };
-    this.start = function () {
+    this.start = function (settings: unknown) {
+      shared.startCalls.push(settings);
       return Promise.resolve({ ok: true });
     };
     this.stopGracefully = function () {
@@ -78,6 +83,12 @@ vi.mock("../../../services/ProjectStore.js", () => ({
     getCurrentProject: vi.fn(() => null),
     getCurrentProjectId: vi.fn(() => null),
   },
+}));
+
+vi.mock("../../../services/voiceContextKeyterms.js", () => ({
+  assembleKeyterms: vi.fn(() =>
+    shared.assembleKeyterms ? shared.assembleKeyterms() : Promise.resolve([])
+  ),
 }));
 
 vi.mock("../../../store.js", () => ({
@@ -425,6 +436,140 @@ describe("voiceInput — manual paragraphing strategy", () => {
   });
 });
 
+describe("voiceInput — context keyterms wiring", () => {
+  function deferred<T>() {
+    let resolve!: (v: T) => void;
+    let reject!: (e: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  }
+
+  function providerSettings(provider: "openai" | "deepgram") {
+    return {
+      enabled: true,
+      openaiApiKey: provider === "openai" ? "sk-test" : "",
+      deepgramApiKey: provider === "deepgram" ? "dg-test" : "",
+      language: "en",
+      customDictionary: [],
+      transcriptionProvider: provider,
+      transcriptionModel: "gpt-realtime-whisper",
+      correctionEnabled: false,
+      correctionModel: "gpt-5-mini",
+      correctionCustomInstructions: "",
+      paragraphingStrategy: "spoken-command",
+      resolveFileLinks: true,
+      deviceId: "",
+      organizationId: "",
+      projectId: "",
+      recordingMode: "toggle",
+    };
+  }
+
+  let cleanup: () => void;
+  let startFn: (e: unknown) => Promise<unknown>;
+  let stopFn: (e: unknown) => Promise<unknown>;
+  let setSettingsFn: (e: unknown, patch: unknown) => Promise<unknown>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    shared.transcriptionEventCallback = null;
+    shared.startCalls = [];
+    shared.assembleKeyterms = null;
+
+    const win = buildMainWindow();
+    cleanup = registerVoiceInputHandlers({
+      mainWindow: win as unknown as Electron.BrowserWindow,
+    } as Parameters<typeof registerVoiceInputHandlers>[0]);
+
+    startFn = getHandler("voice-input:start") as typeof startFn;
+    stopFn = getHandler("voice-input:stop") as typeof stopFn;
+    setSettingsFn = getHandler("voice-input:set-settings") as typeof setSettingsFn;
+  });
+
+  afterEach(() => {
+    cleanup?.();
+  });
+
+  it("injects assembled keyterms into the Deepgram session settings", async () => {
+    const { store } = await import("../../../store.js");
+    vi.mocked(store.get).mockReturnValue(providerSettings("deepgram"));
+    shared.assembleKeyterms = () => Promise.resolve(["alpha", "beta"]);
+
+    await startFn(fakeEvent);
+
+    expect(shared.startCalls).toHaveLength(1);
+    expect(shared.startCalls[0]).toMatchObject({
+      transcriptionProvider: "deepgram",
+      keyterms: ["alpha", "beta"],
+    });
+  });
+
+  it("starts without keyterms for a non-Deepgram provider (no assembly)", async () => {
+    const { store } = await import("../../../store.js");
+    vi.mocked(store.get).mockReturnValue(providerSettings("openai"));
+    const { assembleKeyterms } = await import("../../../services/voiceContextKeyterms.js");
+
+    await startFn(fakeEvent);
+
+    expect(assembleKeyterms).not.toHaveBeenCalled();
+    expect(shared.startCalls).toHaveLength(1);
+    expect(shared.startCalls[0]).not.toHaveProperty("keyterms");
+  });
+
+  it("bails a Deepgram start superseded by a later start during assembly", async () => {
+    const { store } = await import("../../../store.js");
+    const gate = deferred<string[]>();
+    shared.assembleKeyterms = () => gate.promise;
+
+    // Start A (Deepgram) — parks on assembly.
+    vi.mocked(store.get).mockReturnValue(providerSettings("deepgram"));
+    const aPromise = startFn(fakeEvent);
+
+    // Start B (OpenAI) — no assembly, supersedes A and starts immediately.
+    vi.mocked(store.get).mockReturnValue(providerSettings("openai"));
+    await startFn(fakeEvent);
+
+    // A's assembly now resolves — but A must detect it was superseded and bail.
+    gate.resolve(["alpha"]);
+    await expect(aPromise).resolves.toEqual({ ok: false, error: "Voice session superseded" });
+
+    // Only B reached svc.start; A never did (no second session, no keyterms).
+    expect(shared.startCalls).toHaveLength(1);
+    expect(shared.startCalls[0]).toMatchObject({ transcriptionProvider: "openai" });
+  });
+
+  it("bails a Deepgram start whose assembly throws after a stop", async () => {
+    const { store } = await import("../../../store.js");
+    const gate = deferred<string[]>();
+    shared.assembleKeyterms = () => gate.promise;
+
+    vi.mocked(store.get).mockReturnValue(providerSettings("deepgram"));
+    const aPromise = startFn(fakeEvent);
+
+    // Stop supersedes the in-flight assembly.
+    await stopFn(fakeEvent);
+
+    // Assembly then fails — the catch path must still honor the supersede.
+    gate.reject(new Error("assembly boom"));
+    await expect(aPromise).resolves.toEqual({ ok: false, error: "Voice session superseded" });
+    expect(shared.startCalls).toHaveLength(0);
+  });
+
+  it("does not persist runtime-only keyterms via setSettings", async () => {
+    const { store } = await import("../../../store.js");
+    vi.mocked(store.set).mockClear();
+
+    await setSettingsFn(fakeEvent, { keyterms: ["secret"], language: "fr" });
+
+    const setCalls = vi.mocked(store.set).mock.calls as unknown as Array<[string, unknown]>;
+    expect(setCalls.some(([key]) => key === "voiceInput.keyterms")).toBe(false);
+    expect(setCalls.some(([key]) => key === "voiceInput.language")).toBe(true);
+  });
+});
+
 describe("getVoiceSettings migration", () => {
   beforeEach(async () => {
     const { store } = await import("../../../store.js");
@@ -597,6 +742,19 @@ describe("getVoiceSettings migration", () => {
     const settings = getVoiceSettings();
 
     expect(settings.recordingMode).toBe("toggle");
+  });
+
+  it("drops a stale persisted keyterms field on read", async () => {
+    const { store } = await import("../../../store.js");
+    vi.mocked(store.get).mockReturnValueOnce({
+      enabled: true,
+      openaiApiKey: "sk-present",
+      keyterms: ["leaked"],
+    } as unknown as Record<string, unknown>);
+
+    const settings = getVoiceSettings();
+
+    expect(settings.keyterms).toBeUndefined();
   });
 
   it("preserves recordingMode='push-to-talk' when stored", async () => {

--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -13,6 +13,7 @@ import type {
 } from "../../../shared/types/ipc/api.js";
 import { logDebug } from "../../utils/logger.js";
 import { buildOpenAIHeaders } from "../../../shared/utils/openaiHeaders.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import { applyDictationCommands } from "../../services/voiceDictationCommands.js";
 import { assembleKeyterms } from "../../services/voiceContextKeyterms.js";
 import { getAppWebContents } from "../../window/webContentsRegistry.js";
@@ -339,7 +340,7 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
         });
       } catch (err) {
         logDebug("[VoiceInput] Keyterm assembly failed, starting without keyterms", {
-          message: err instanceof Error ? err.message : String(err),
+          message: formatErrorMessage(err, "Unknown error during keyterm assembly"),
         });
       }
       // A newer start (or a stop) superseded this one while we awaited assembly

--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -36,6 +36,10 @@ let voiceStartNonce = 0;
 
 const VALID_TRANSCRIPTION_PROVIDERS: VoiceTranscriptionProvider[] = ["openai", "deepgram"];
 
+// Fields on VoiceInputSettings that are assembled at runtime and must never be
+// written to the persisted store.
+const RUNTIME_ONLY_VOICE_FIELDS = new Set<string>(["keyterms"]);
+
 const VOICE_INPUT_DEFAULTS: VoiceInputSettings = {
   enabled: false,
   openaiApiKey: "",
@@ -66,8 +70,10 @@ export function getVoiceSettings(): VoiceInputSettings {
 
   // Pluck truly-legacy key fields so they don't leak into the merged object via
   // spread. `deepgramApiKey` is now a first-class field, so it flows through
-  // `rest` instead of being dropped.
-  const { apiKey, correctionApiKey, ...rest } = stored ?? {};
+  // `rest` instead of being dropped. `keyterms` is runtime-only — drop any value
+  // a stale store/migration left behind so it never seeds a session.
+  const { apiKey, correctionApiKey, keyterms, ...rest } = stored ?? {};
+  void keyterms;
   const merged: VoiceInputSettings = { ...VOICE_INPUT_DEFAULTS, ...rest };
 
   // Migrate prior OpenAI keys into the unified field.
@@ -286,6 +292,9 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
     if (!patch || typeof patch !== "object") return;
     for (const [field, value] of Object.entries(patch)) {
       if (value === undefined) continue;
+      // `keyterms` is runtime-only — assembled per session, never persisted. Skip
+      // it so a renderer patch can't seed stored keyterms into future sessions.
+      if (RUNTIME_ONLY_VOICE_FIELDS.has(field)) continue;
       store.set(`voiceInput.${field}`, value);
     }
   };
@@ -310,32 +319,37 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
     // Capture project info at session start.
     sessionProjectInfo = getProjectInfo();
 
+    // Bump the start nonce for EVERY start (not just Deepgram) so a later start
+    // of any provider supersedes a Deepgram start still awaiting assembly.
+    const myNonce = ++voiceStartNonce;
+
     // Assemble context keyterms and inject them into the session. Deepgram is the
     // only provider that consumes them (Nova-3 `keyterm=` params), so skip the
     // async work for OpenAI. Assembly is capped internally (~500ms); failures are
     // non-fatal — we just start without keyterms.
     let startSettings = settings;
     if (settings.transcriptionProvider === "deepgram") {
-      const myNonce = ++voiceStartNonce;
+      let keyterms: string[] = [];
       try {
-        const keyterms = await assembleKeyterms({
+        keyterms = await assembleKeyterms({
           customDictionary: settings.customDictionary,
           projectName: sessionProjectInfo.name,
           projectPath: sessionProjectInfo.path,
           ptyClient: deps.ptyClient,
         });
-        // A newer start (or a stop) superseded this one while we awaited
-        // assembly — bail before wiring up a session that's already stale.
-        if (voiceStartNonce !== myNonce) {
-          return { ok: false, error: "Voice session superseded" };
-        }
-        if (keyterms.length > 0) {
-          startSettings = { ...settings, keyterms };
-        }
       } catch (err) {
         logDebug("[VoiceInput] Keyterm assembly failed, starting without keyterms", {
           message: err instanceof Error ? err.message : String(err),
         });
+      }
+      // A newer start (or a stop) superseded this one while we awaited assembly
+      // (checked on both the success and failure paths) — bail before wiring up a
+      // session that's already stale.
+      if (voiceStartNonce !== myNonce) {
+        return { ok: false, error: "Voice session superseded" };
+      }
+      if (keyterms.length > 0) {
+        startSettings = { ...settings, keyterms };
       }
     }
 

--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -14,6 +14,7 @@ import type {
 import { logDebug } from "../../utils/logger.js";
 import { buildOpenAIHeaders } from "../../../shared/utils/openaiHeaders.js";
 import { applyDictationCommands } from "../../services/voiceDictationCommands.js";
+import { assembleKeyterms } from "../../services/voiceContextKeyterms.js";
 import { getAppWebContents } from "../../window/webContentsRegistry.js";
 import { voiceFileLinkResolver } from "../../services/VoiceFileLinkResolver.js";
 import { typedHandle, typedHandleValidated, typedHandleWithContext } from "../utils.js";
@@ -29,6 +30,9 @@ let activeDestroyListener: { sender: Electron.WebContents; fn: () => void } | nu
 let correctionService: VoiceCorrectionService | null = null;
 let sessionController: AbortController | null = null;
 let sessionProjectInfo: { name?: string; path?: string } = {};
+// Bumped on every start so a slow keyterm-assembly await can detect that a
+// newer start (or a stop) has superseded it and bail before calling svc.start.
+let voiceStartNonce = 0;
 
 const VALID_TRANSCRIPTION_PROVIDERS: VoiceTranscriptionProvider[] = ["openai", "deepgram"];
 
@@ -306,6 +310,35 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
     // Capture project info at session start.
     sessionProjectInfo = getProjectInfo();
 
+    // Assemble context keyterms and inject them into the session. Deepgram is the
+    // only provider that consumes them (Nova-3 `keyterm=` params), so skip the
+    // async work for OpenAI. Assembly is capped internally (~500ms); failures are
+    // non-fatal — we just start without keyterms.
+    let startSettings = settings;
+    if (settings.transcriptionProvider === "deepgram") {
+      const myNonce = ++voiceStartNonce;
+      try {
+        const keyterms = await assembleKeyterms({
+          customDictionary: settings.customDictionary,
+          projectName: sessionProjectInfo.name,
+          projectPath: sessionProjectInfo.path,
+          ptyClient: deps.ptyClient,
+        });
+        // A newer start (or a stop) superseded this one while we awaited
+        // assembly — bail before wiring up a session that's already stale.
+        if (voiceStartNonce !== myNonce) {
+          return { ok: false, error: "Voice session superseded" };
+        }
+        if (keyterms.length > 0) {
+          startSettings = { ...settings, keyterms };
+        }
+      } catch (err) {
+        logDebug("[VoiceInput] Keyterm assembly failed, starting without keyterms", {
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
     const unsubscribe = svc.onEvent((voiceEvent) => {
       const win = deps.mainWindow;
       if (!win || win.isDestroyed()) return;
@@ -425,7 +458,7 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
     ctx.event.sender.once("destroyed", onDestroyed);
     activeDestroyListener = { sender: ctx.event.sender, fn: onDestroyed };
 
-    const result = await svc.start(settings);
+    const result = await svc.start(startSettings);
     if (!result.ok) {
       // Failed to start — clean up subscription immediately
       if (activeEventUnsubscribe === unsubscribe) {
@@ -444,6 +477,9 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
   };
 
   const handleStop = async (): Promise<{ rawText: string | null }> => {
+    // Supersede any start still awaiting keyterm assembly so it bails instead of
+    // bringing up a session we're trying to stop.
+    voiceStartNonce++;
     // Snapshot the session controller so concurrent start/stop cannot cross-abort.
     const controller = sessionController;
 

--- a/electron/services/voice/DeepgramTranscriptionProvider.ts
+++ b/electron/services/voice/DeepgramTranscriptionProvider.ts
@@ -51,7 +51,8 @@ function truncateKeytermsForUrl(keyterms: string[]): string[] {
     const term = raw.trim();
     if (!term) continue;
     if (result.length >= MAX_DEEPGRAM_URL_KEYTERMS) break;
-    if (chars + term.length > MAX_DEEPGRAM_URL_KEYTERM_CHARS) break;
+    // Skip (don't stop on) an oversized term so smaller later terms still fit.
+    if (chars + term.length > MAX_DEEPGRAM_URL_KEYTERM_CHARS) continue;
     result.push(term);
     chars += term.length;
   }
@@ -259,8 +260,10 @@ export class DeepgramTranscriptionProvider implements TranscriptionProvider {
       } catch {
         // Ignore teardown errors
       }
-      this.clearConnectTimeout();
+      // Clear AFTER the stale guard: a 400 retry installs a fresh connectTimeout
+      // for the new socket, so the failed socket must not clear it on the way out.
       if (this.sessionId !== mySessionId || this.connection !== connection) return;
+      this.clearConnectTimeout();
       const statusCode = res.statusCode;
       // Retry once with keyterms stripped: a 400 here most plausibly means the
       // assembled keyterms overflowed Deepgram's token budget. The new socket
@@ -337,8 +340,10 @@ export class DeepgramTranscriptionProvider implements TranscriptionProvider {
     });
 
     connection.on("error", (err) => {
-      this.clearConnectTimeout();
+      // Clear AFTER the stale guard so a superseded socket (e.g. the failed
+      // first attempt of a keyterm retry) can't cancel the live socket's timers.
       if (this.sessionId !== mySessionId || this.connection !== connection) return;
+      this.clearConnectTimeout();
       const message = formatErrorMessage(err, "WebSocket error");
       logError(`${P} WebSocket error`, { message });
       // `ws` fires `close` right after `error`; a pre-ready transport error
@@ -353,9 +358,11 @@ export class DeepgramTranscriptionProvider implements TranscriptionProvider {
     });
 
     connection.on("close", (code, reason) => {
+      // Clear AFTER the stale guard so a superseded socket's trailing close
+      // can't cancel the live socket's connect timeout / keep-alive.
+      if (this.sessionId !== mySessionId || this.connection !== connection) return;
       this.clearConnectTimeout();
       this.clearKeepAlive();
-      if (this.sessionId !== mySessionId || this.connection !== connection) return;
       const wasReady = this.isReady;
       logInfo(`${P} WebSocket closed`, {
         code,

--- a/electron/services/voice/DeepgramTranscriptionProvider.ts
+++ b/electron/services/voice/DeepgramTranscriptionProvider.ts
@@ -28,6 +28,36 @@ const PRE_CONNECT_BUFFER_MAX = 100;
 // context is lost anyway. Matches the OpenAI provider's ceiling.
 const PRE_CONNECT_BUFFER_MAX_BYTES = 150_000;
 
+// Deepgram caps Nova-3 keyterms at 100 terms and 500 aggregate tokens. The
+// tokenizer is syllable-based (~5 tokens per single-word term), so the term
+// count alone doesn't bound tokens. We cap the URL injection well below both
+// ceilings — 50 terms is a 2x margin on the count, and a ~3000-char aggregate
+// guard backstops pathologically long terms before they blow the token budget.
+// This is deliberately tighter than the assembly-side MAX_KEYTERMS (96): that
+// constant governs how many terms to gather, this one governs how many survive
+// into the wire request.
+const MAX_DEEPGRAM_URL_KEYTERMS = 50;
+const MAX_DEEPGRAM_URL_KEYTERM_CHARS = 3_000;
+
+/**
+ * Conservatively trim assembled keyterms before they go on the streaming URL.
+ * Drops empty/whitespace-only terms, then accepts terms in priority order until
+ * either the term-count or aggregate-char budget is reached.
+ */
+function truncateKeytermsForUrl(keyterms: string[]): string[] {
+  const result: string[] = [];
+  let chars = 0;
+  for (const raw of keyterms) {
+    const term = raw.trim();
+    if (!term) continue;
+    if (result.length >= MAX_DEEPGRAM_URL_KEYTERMS) break;
+    if (chars + term.length > MAX_DEEPGRAM_URL_KEYTERM_CHARS) break;
+    result.push(term);
+    chars += term.length;
+  }
+  return result;
+}
+
 // Like the OpenAI provider we use the `ws` package rather than Node's global
 // WebSocket so the `Authorization` upgrade header can be sent. Deepgram differs
 // from OpenAI in two ways: audio is streamed as raw binary frames (not base64
@@ -46,6 +76,13 @@ function buildUrl(settings: VoiceInputSettings): string {
   });
   if (settings.language) {
     params.set("language", settings.language);
+  }
+  // Nova-3 keyterms are repeated `keyterm=` params — one per term. A comma-
+  // joined value would be treated as a single literal phrase, not a list.
+  if (settings.keyterms && settings.keyterms.length > 0) {
+    for (const term of truncateKeytermsForUrl(settings.keyterms)) {
+      params.append("keyterm", term);
+    }
   }
   return `${DEEPGRAM_BASE_URL}?${params.toString()}`;
 }
@@ -152,8 +189,17 @@ export class DeepgramTranscriptionProvider implements TranscriptionProvider {
     });
   }
 
-  private connect(mySessionId: number, settings: VoiceInputSettings): void {
-    const url = buildUrl(settings);
+  private connect(
+    mySessionId: number,
+    settings: VoiceInputSettings,
+    retryWithoutKeyterms = false
+  ): void {
+    // On a keyterm-overflow retry, strip keyterms from the URL but keep every
+    // other setting identical.
+    const effectiveSettings = retryWithoutKeyterms
+      ? { ...settings, keyterms: undefined }
+      : settings;
+    const url = buildUrl(effectiveSettings);
     let connection: WebSocket;
     try {
       connection = new WebSocket(url, {
@@ -174,7 +220,13 @@ export class DeepgramTranscriptionProvider implements TranscriptionProvider {
     }
 
     this.connection = connection;
-    logInfo(`${P} Opening Deepgram WebSocket`, { url, language: settings.language || "en" });
+    // Don't log the full URL — it carries the assembled keyterms (project/branch/
+    // terminal identifiers). The term count is enough to debug keyterm wiring.
+    logInfo(`${P} Opening Deepgram WebSocket`, {
+      keytermCount: effectiveSettings.keyterms?.length ?? 0,
+      language: settings.language || "en",
+      retryWithoutKeyterms,
+    });
 
     this.connectTimeout = setTimeout(() => {
       this.connectTimeout = null;
@@ -194,6 +246,42 @@ export class DeepgramTranscriptionProvider implements TranscriptionProvider {
       this.emit({ type: "status", status: "error" });
       this.settlePendingStart(mySessionId, { ok: false, error: "Connection timed out" });
     }, CONNECT_TIMEOUT_MS);
+
+    // A non-101 HTTP response to the WebSocket upgrade surfaces here (not via
+    // `error`), and only when we register this listener — which also disables
+    // ws's built-in abort, so we MUST drain and destroy the socket ourselves or
+    // it leaks. `res.statusCode` is the only reliable way to tell a 400 (likely
+    // keyterm overflow) from a 401 (bad API key).
+    connection.on("unexpected-response", (req, res) => {
+      try {
+        res.resume();
+        req.socket?.destroy();
+      } catch {
+        // Ignore teardown errors
+      }
+      this.clearConnectTimeout();
+      if (this.sessionId !== mySessionId || this.connection !== connection) return;
+      const statusCode = res.statusCode;
+      // Retry once with keyterms stripped: a 400 here most plausibly means the
+      // assembled keyterms overflowed Deepgram's token budget. The new socket
+      // becomes `this.connection`, so this old socket's trailing close is
+      // ignored by the `this.connection !== connection` guards.
+      if (statusCode === 400 && !retryWithoutKeyterms) {
+        logWarn(`${P} Deepgram rejected upgrade with HTTP 400 — retrying without keyterms`);
+        this.cleanupConnection();
+        this.connect(mySessionId, settings, true);
+        return;
+      }
+      // Any other status (401 auth, 403, 429, 5xx) — or a second 400 after the
+      // keyterm-free retry — is fatal.
+      const message = `Deepgram rejected the connection (HTTP ${statusCode ?? "unknown"})`;
+      logError(`${P} ${message}`);
+      this.handleFatalError(mySessionId, {
+        severity: "fatal",
+        code: "ws_http_error",
+        message,
+      });
+    });
 
     connection.on("open", () => {
       if (this.sessionId !== mySessionId) {

--- a/electron/services/voice/__tests__/DeepgramTranscriptionProvider.test.ts
+++ b/electron/services/voice/__tests__/DeepgramTranscriptionProvider.test.ts
@@ -308,6 +308,20 @@ describe("DeepgramTranscriptionProvider", () => {
     provider.stop();
   });
 
+  it("skips an oversized keyterm but keeps smaller later terms", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const huge = "z".repeat(4_000);
+    void provider.start({ ...BASE_SETTINGS, keyterms: [huge, "short1", "short2"] });
+    await Promise.resolve();
+    // The oversized leading term is skipped (continue, not break), so the small
+    // terms after it still make it into the URL.
+    expect(new URL(latestInstance().url).searchParams.getAll("keyterm")).toEqual([
+      "short1",
+      "short2",
+    ]);
+    provider.stop();
+  });
+
   it("logs the keyterm count, not the URL, when opening the socket", async () => {
     const provider = new DeepgramTranscriptionProvider();
     vi.mocked(logInfo).mockClear();
@@ -748,6 +762,25 @@ describe("DeepgramTranscriptionProvider", () => {
     expect(result.ok).toBe(false);
     expect(result.ok === false && result.error).toContain("HTTP 400");
     expect(events.some((e) => e.type === "error" && /HTTP 400/.test(e.error.message))).toBe(true);
+  });
+
+  it("keeps the retry socket's connect timeout when the failed socket closes", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const startPromise = provider.start({ ...BASE_SETTINGS, keyterms: ["alpha"] });
+    await Promise.resolve();
+    const first = latestInstance();
+
+    first.simulateUnexpectedResponse(400);
+    expect(instances).toHaveLength(2);
+
+    // The failed first socket now fires its trailing close. It must NOT cancel
+    // the retry socket's connect timeout (regression: stale close cleared it).
+    first.simulateClose(1006);
+
+    // The retry socket never opens — its connect timeout should still fire and
+    // resolve the start instead of hanging forever.
+    vi.advanceTimersByTime(10_000);
+    await expect(startPromise).resolves.toEqual({ ok: false, error: "Connection timed out" });
   });
 
   it("ignores an unexpected-response for a superseded session", async () => {

--- a/electron/services/voice/__tests__/DeepgramTranscriptionProvider.test.ts
+++ b/electron/services/voice/__tests__/DeepgramTranscriptionProvider.test.ts
@@ -93,6 +93,19 @@ class MockWebSocket {
     this.fire("error", err);
   }
 
+  // Mirrors ws's `unexpected-response` event: a non-101 HTTP upgrade response.
+  // Exposes the mock req/res so tests can assert the socket was drained/destroyed.
+  unexpectedReq?: { socket: { destroy: ReturnType<typeof vi.fn> } };
+  unexpectedRes?: { statusCode: number; resume: ReturnType<typeof vi.fn> };
+
+  simulateUnexpectedResponse(statusCode: number): void {
+    const req = { socket: { destroy: vi.fn() } };
+    const res = { statusCode, resume: vi.fn() };
+    this.unexpectedReq = req;
+    this.unexpectedRes = res;
+    this.fire("unexpected-response", req, res);
+  }
+
   simulateClose(code?: number, reason?: Buffer | string): void {
     this.readyState = MockWebSocket.CLOSED;
     this.fire("close", code, reason);
@@ -125,8 +138,17 @@ vi.mock("ws", () => {
   return { default: ctor };
 });
 
+// Mock the logger so the connect-log test can assert the URL is no longer logged.
+vi.mock("../../../utils/logger.js", () => ({
+  logDebug: vi.fn(),
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+  logError: vi.fn(),
+}));
+
 // Import AFTER vi.mock so the mocked `ws` is used.
 const { DeepgramTranscriptionProvider } = await import("../DeepgramTranscriptionProvider.js");
+const { logInfo } = await import("../../../utils/logger.js");
 type DeepgramTranscriptionProviderInstance = InstanceType<typeof DeepgramTranscriptionProvider>;
 type VoiceTranscriptionEvent = import("../TranscriptionProvider.js").VoiceTranscriptionEvent;
 
@@ -219,6 +241,90 @@ describe("DeepgramTranscriptionProvider", () => {
     expect(url.searchParams.get("endpointing")).toBe("300");
     expect(url.searchParams.get("language")).toBe("en");
     expect(socket.options.headers.Authorization).toBe("Token dg-abc");
+    provider.stop();
+  });
+
+  // ── Keyterm URL injection ─────────────────────────────────────────────────
+
+  it("appends one repeated keyterm= param per term (not comma-joined)", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    void provider.start({ ...BASE_SETTINGS, keyterms: ["alpha", "betaTerm", "gamma"] });
+    await Promise.resolve();
+    const url = new URL(latestInstance().url);
+
+    expect(url.searchParams.getAll("keyterm")).toEqual(["alpha", "betaTerm", "gamma"]);
+    // Nova-3 uses `keyterm`, not the legacy `keywords` parameter.
+    expect(url.searchParams.has("keywords")).toBe(false);
+    provider.stop();
+  });
+
+  it("omits the keyterm param when no keyterms are supplied", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    void provider.start({ ...BASE_SETTINGS, keyterms: [] });
+    await Promise.resolve();
+    expect(new URL(latestInstance().url).searchParams.has("keyterm")).toBe(false);
+
+    void provider.start({ ...BASE_SETTINGS, keyterms: undefined });
+    await Promise.resolve();
+    expect(new URL(latestInstance().url).searchParams.has("keyterm")).toBe(false);
+    provider.stop();
+  });
+
+  it("caps the injected keyterms at the URL term limit", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const many = Array.from({ length: 96 }, (_, i) => `term${i}`);
+    void provider.start({ ...BASE_SETTINGS, keyterms: many });
+    await Promise.resolve();
+    const injected = new URL(latestInstance().url).searchParams.getAll("keyterm");
+
+    // Fewer than supplied, and a prefix of the priority-ordered input.
+    expect(injected.length).toBeLessThan(many.length);
+    expect(injected.length).toBeGreaterThan(0);
+    expect(injected).toEqual(many.slice(0, injected.length));
+    provider.stop();
+  });
+
+  it("drops empty/whitespace keyterms before injecting", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    void provider.start({ ...BASE_SETTINGS, keyterms: ["  ", "real", "", "  spaced  "] });
+    await Promise.resolve();
+    expect(new URL(latestInstance().url).searchParams.getAll("keyterm")).toEqual([
+      "real",
+      "spaced",
+    ]);
+    provider.stop();
+  });
+
+  it("enforces the aggregate-char budget on long keyterms", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    // Each term is 1000 chars; the ~3000-char aggregate guard admits only 3.
+    const long = Array.from({ length: 10 }, (_, i) => `${"x".repeat(999)}${i}`);
+    void provider.start({ ...BASE_SETTINGS, keyterms: long });
+    await Promise.resolve();
+    const injected = new URL(latestInstance().url).searchParams.getAll("keyterm");
+
+    expect(injected.length).toBe(3);
+    expect(injected.reduce((n, t) => n + t.length, 0)).toBeLessThanOrEqual(3_000);
+    provider.stop();
+  });
+
+  it("logs the keyterm count, not the URL, when opening the socket", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    vi.mocked(logInfo).mockClear();
+    void provider.start({ ...BASE_SETTINGS, keyterms: ["alpha", "beta"] });
+    await Promise.resolve();
+
+    const openCall = vi
+      .mocked(logInfo)
+      .mock.calls.find(([msg]) => typeof msg === "string" && msg.includes("Opening Deepgram"));
+    expect(openCall).toBeDefined();
+    const meta = openCall?.[1] as Record<string, unknown>;
+    expect(meta.keytermCount).toBe(2);
+    expect(meta).not.toHaveProperty("url");
+    // Belt and braces: no logged argument should contain the streaming host.
+    for (const call of vi.mocked(logInfo).mock.calls) {
+      expect(JSON.stringify(call)).not.toContain("api.deepgram.com/v1/listen?");
+    }
     provider.stop();
   });
 
@@ -575,6 +681,92 @@ describe("DeepgramTranscriptionProvider", () => {
 
     expect(statuses).toContain("error");
     expect(statuses).not.toContain("idle");
+  });
+
+  // ── Keyterm-overflow retry (HTTP 400) ─────────────────────────────────────
+
+  it("retries once without keyterms on an HTTP 400 upgrade rejection", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const startPromise = provider.start({ ...BASE_SETTINGS, keyterms: ["alpha", "beta"] });
+    await Promise.resolve();
+    const first = latestInstance();
+    expect(new URL(first.url).searchParams.getAll("keyterm")).toEqual(["alpha", "beta"]);
+
+    first.simulateUnexpectedResponse(400);
+
+    // The failed socket must be drained and destroyed (ws leaks it otherwise).
+    expect(first.unexpectedRes?.resume).toHaveBeenCalled();
+    expect(first.unexpectedReq?.socket.destroy).toHaveBeenCalled();
+
+    // A second socket is opened with no keyterms; everything else is unchanged.
+    expect(instances).toHaveLength(2);
+    const second = latestInstance();
+    expect(new URL(second.url).searchParams.has("keyterm")).toBe(false);
+    expect(new URL(second.url).searchParams.get("model")).toBe("nova-3");
+
+    second.simulateOpen();
+    await expect(startPromise).resolves.toEqual({ ok: true });
+    provider.stop();
+  });
+
+  it("does not retry on a non-400 upgrade rejection (401)", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const events: VoiceTranscriptionEvent[] = [];
+    provider.onEvent((e) => events.push(e));
+
+    const startPromise = provider.start({ ...BASE_SETTINGS, keyterms: ["alpha"] });
+    await Promise.resolve();
+    const first = latestInstance();
+    first.simulateUnexpectedResponse(401);
+
+    expect(first.unexpectedRes?.resume).toHaveBeenCalled();
+    expect(first.unexpectedReq?.socket.destroy).toHaveBeenCalled();
+    expect(instances).toHaveLength(1);
+
+    const result = await startPromise;
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toContain("HTTP 401");
+    expect(events.some((e) => e.type === "error" && /HTTP 401/.test(e.error.message))).toBe(true);
+    expect(events.some((e) => e.type === "status" && e.status === "error")).toBe(true);
+  });
+
+  it("does not retry a second time if the keyterm-free retry also gets 400", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const events: VoiceTranscriptionEvent[] = [];
+    provider.onEvent((e) => events.push(e));
+
+    const startPromise = provider.start({ ...BASE_SETTINGS, keyterms: ["alpha"] });
+    await Promise.resolve();
+    latestInstance().simulateUnexpectedResponse(400);
+    expect(instances).toHaveLength(2);
+
+    latestInstance().simulateUnexpectedResponse(400);
+    // No third socket — the one-shot retry is exhausted.
+    expect(instances).toHaveLength(2);
+
+    const result = await startPromise;
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toContain("HTTP 400");
+    expect(events.some((e) => e.type === "error" && /HTTP 400/.test(e.error.message))).toBe(true);
+  });
+
+  it("ignores an unexpected-response for a superseded session", async () => {
+    const provider = new DeepgramTranscriptionProvider();
+    const startPromise = provider.start({ ...BASE_SETTINGS, keyterms: ["alpha"] });
+    await Promise.resolve();
+    const first = latestInstance();
+
+    // Stop the session — the first socket is now stale.
+    provider.stop();
+    first.simulateUnexpectedResponse(400);
+
+    // The socket is still drained/destroyed defensively...
+    expect(first.unexpectedRes?.resume).toHaveBeenCalled();
+    expect(first.unexpectedReq?.socket.destroy).toHaveBeenCalled();
+    // ...but no retry socket is created for the dead session.
+    expect(instances).toHaveLength(1);
+
+    await expect(startPromise).resolves.toEqual({ ok: false, error: "Voice session stopped" });
   });
 
   // ── Stale-session guard ──────────────────────────────────────────────────

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1695,6 +1695,13 @@ export interface VoiceInputSettings {
   projectId: string;
   /** Controls whether recording is held (push-to-talk) or toggled. Defaults to "toggle". */
   recordingMode: VoiceRecordingMode;
+  /**
+   * Runtime-only. Context keyterms assembled at session start and injected into
+   * the Deepgram streaming URL as repeated `keyterm=` params. Populated by the
+   * voice-input start handler — never persisted to the store or supplied by the
+   * renderer. Ignored by non-Deepgram providers.
+   */
+  keyterms?: string[];
 }
 
 export type HelpAssistantAuditRetention = 7 | 30 | 0;


### PR DESCRIPTION
## Summary

- Wires `assembleKeyterms()` into the Deepgram Nova-3 streaming connection so dictation is biased toward project, branch, and terminal vocabulary.
- Adds a one-shot HTTP-400 fallback: if Deepgram rejects the WebSocket upgrade due to keyterm overflow, the provider retries once with keyterms stripped.
- 86 new unit tests covering the full surface area of the feature.

Resolves #9744.

## Changes

- `buildUrl()` injects keyterms as repeated `keyterm=` query params (Nova-3 format, not the legacy `keywords` param), conservatively truncated to 50 terms / 3000 aggregate chars.
- Keyterms are assembled in the voice-input start handler (Deepgram-only; OpenAI skips the async work), flowed through a new runtime-only `VoiceInputSettings.keyterms` field that is never persisted or renderer-supplied.
- The 400 fallback uses the `ws` `unexpected-response` event to drain and destroy the failed socket, and distinguishes 400 from 401/auth via `res.statusCode`. No second retry.
- The connect log now records keyterm count only, not the full URL (which carries project/branch/terminal context).
- A start nonce guards against a later start or stop superseding a Deepgram start still awaiting assembly.

## Testing

86 unit tests across `DeepgramTranscriptionProvider.test.ts` and `voiceInput.paragraph.test.ts` covering: keyterm URL injection, term/char truncation, oversized-term skip, log redaction, 400 retry-without-keyterms, no-retry-on-401, no-second-retry, retry-timeout survival, supersede-by-start, supersede-by-stop-on-throw, no-persist, stale-read drop. Full `npm run check` passes.