### PR TITLE
feat(voice): learn dictionary words from transcript corrections

### DIFF
--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -58,6 +58,8 @@ const VOICE_INPUT_DEFAULTS: VoiceInputSettings = {
   organizationId: "",
   projectId: "",
   recordingMode: "toggle",
+  suggestedDictionary: [],
+  learnFromCorrections: true,
 };
 
 /** Read voiceInput settings with defaults for fields added after initial store creation. */

--- a/electron/services/__tests__/VoiceTranscriptionService.integration.test.ts
+++ b/electron/services/__tests__/VoiceTranscriptionService.integration.test.ts
@@ -40,6 +40,8 @@ describe("VoiceTranscriptionService integration", () => {
         organizationId: "",
         projectId: "",
         recordingMode: "toggle",
+        suggestedDictionary: [],
+        learnFromCorrections: true,
       });
 
       expect(result).toEqual({ ok: true });

--- a/electron/services/__tests__/VoiceTranscriptionService.test.ts
+++ b/electron/services/__tests__/VoiceTranscriptionService.test.ts
@@ -190,6 +190,8 @@ const OPENAI_SETTINGS: VoiceInputSettings = {
   organizationId: "",
   projectId: "",
   recordingMode: "toggle",
+  suggestedDictionary: [],
+  learnFromCorrections: true,
 };
 
 const DEEPGRAM_SETTINGS: VoiceInputSettings = {

--- a/electron/services/voice/__tests__/DeepgramTranscriptionProvider.test.ts
+++ b/electron/services/voice/__tests__/DeepgramTranscriptionProvider.test.ts
@@ -169,6 +169,8 @@ const BASE_SETTINGS: VoiceInputSettings = {
   organizationId: "",
   projectId: "",
   recordingMode: "toggle",
+  suggestedDictionary: [],
+  learnFromCorrections: true,
 };
 
 function latestInstance(): MockWebSocket {

--- a/electron/services/voice/__tests__/OpenAITranscriptionProvider.test.ts
+++ b/electron/services/voice/__tests__/OpenAITranscriptionProvider.test.ts
@@ -244,6 +244,8 @@ const BASE_SETTINGS: VoiceInputSettings = {
   organizationId: "",
   projectId: "",
   recordingMode: "toggle",
+  suggestedDictionary: [],
+  learnFromCorrections: true,
 };
 
 function latestInstance(): MockWebSocket {

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -22,6 +22,7 @@ import { PLUGIN_MCP_AUDIT_DEFAULT_MAX_RECORDS } from "../shared/types/ipc/plugin
 import type { PluginMcpConsentRecord } from "../shared/types/pluginMcpConsent.js";
 import { PLUGIN_MCP_DEFAULT_MAX_TOOLS_PER_SESSION } from "../shared/types/ipc/pluginMcp.js";
 import type { ForgeAuditRecord } from "../shared/types/ipc/forge.js";
+import type { SuggestedDictionaryEntry } from "../shared/types/ipc/api.js";
 import { FORGE_AUDIT_DEFAULT_MAX_RECORDS } from "../shared/types/ipc/forge.js";
 import type { BuiltInAgentId } from "../shared/config/agentIds.js";
 import type { AgentId } from "../shared/types/agent.js";
@@ -213,6 +214,9 @@ export interface StoreSchema {
     deviceId: string;
     organizationId: string;
     projectId: string;
+    recordingMode: string;
+    suggestedDictionary: SuggestedDictionaryEntry[];
+    learnFromCorrections: boolean;
   };
   mcpServer: {
     enabled: boolean;
@@ -503,6 +507,9 @@ const storeOptions = {
       deviceId: "",
       organizationId: "",
       projectId: "",
+      recordingMode: "toggle",
+      suggestedDictionary: [],
+      learnFromCorrections: true,
     },
     mcpServer: {
       enabled: false,

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -244,6 +244,7 @@ export type {
   ElectronAPI,
   NotificationSettings,
   VoiceInputSettings,
+  SuggestedDictionaryEntry,
   VoiceInputStatus,
   VoiceTranscriptionModel,
   VoiceTranscriptionProvider,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1702,6 +1702,25 @@ export interface VoiceInputSettings {
    * renderer. Ignored by non-Deepgram providers.
    */
   keyterms?: string[];
+  /**
+   * Words learned from the user's manual corrections to dictated text, pending
+   * explicit accept/dismiss. Never added to `customDictionary` silently.
+   */
+  suggestedDictionary: SuggestedDictionaryEntry[];
+  /** When enabled, manual corrections to dictated text surface as suggested dictionary words. Defaults to true. */
+  learnFromCorrections: boolean;
+}
+
+/** A dictionary word suggested from a user's manual correction, with provenance. */
+export interface SuggestedDictionaryEntry {
+  /** The corrected term, in the casing the user typed (e.g. "Zustand"). */
+  word: string;
+  /** The misheard phrase it replaced, shown as provenance (e.g. "zoo stand"). */
+  utterance: string;
+  /** Epoch ms when the suggestion was last observed. */
+  suggestedAt: number;
+  /** How many times this substitution has been seen. */
+  frequency: number;
 }
 
 export type HelpAssistantAuditRetention = 7 | 30 | 0;

--- a/shared/utils/__tests__/phoneticSimilarity.test.ts
+++ b/shared/utils/__tests__/phoneticSimilarity.test.ts
@@ -129,6 +129,17 @@ describe("findCorrectionCandidates", () => {
     expect(result.map((c) => c.word)).toEqual(["Zustand"]);
   });
 
+  it("strips leading and trailing punctuation from the suggested word", () => {
+    const result = findCorrectionCandidates("use zoo stand.", "use Zustand.");
+    expect(result.map((c) => c.word)).toEqual(["Zustand"]);
+  });
+
+  it("does not learn words the user typed after the dictated term", () => {
+    // "and"/"tests" were appended, not dictated — must not leak in as terms.
+    const result = findCorrectionCandidates("zoo stand", "Zustand and tests");
+    expect(result.map((c) => c.word)).not.toContain("tests");
+  });
+
   it("handles empty input without throwing", () => {
     expect(findCorrectionCandidates("", "")).toEqual([]);
     expect(findCorrectionCandidates("hello", "")).toEqual([]);

--- a/shared/utils/__tests__/phoneticSimilarity.test.ts
+++ b/shared/utils/__tests__/phoneticSimilarity.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import {
+  soundex,
+  levenshtein,
+  levenshteinRatio,
+  isLearnableTerm,
+  findCorrectionCandidates,
+} from "../phoneticSimilarity.js";
+
+describe("soundex", () => {
+  it("encodes a word as a letter followed by three digits", () => {
+    expect(soundex("Robert")).toBe("R163");
+    expect(soundex("Rupert")).toBe("R163");
+  });
+
+  it("pads short encodings with zeros", () => {
+    expect(soundex("Lee")).toBe("L000");
+  });
+
+  it("treats H and W as transparent between same-coded consonants", () => {
+    // Ashcraft: the S and C are both coded 2, separated by H — collapse to one.
+    expect(soundex("Pfister")).toHaveLength(4);
+  });
+
+  it("returns empty string for non-alphabetic input", () => {
+    expect(soundex("1234")).toBe("");
+    expect(soundex("")).toBe("");
+  });
+
+  it("gives 'zoo stand' (joined) and 'zustand' the same code", () => {
+    expect(soundex("zoostand")).toBe(soundex("zustand"));
+  });
+});
+
+describe("levenshtein", () => {
+  it("is zero for identical strings", () => {
+    expect(levenshtein("zustand", "zustand")).toBe(0);
+  });
+
+  it("counts single edits", () => {
+    expect(levenshtein("kitten", "sitting")).toBe(3);
+  });
+
+  it("equals the other length when one side is empty", () => {
+    expect(levenshtein("", "abc")).toBe(3);
+    expect(levenshtein("abc", "")).toBe(3);
+  });
+});
+
+describe("levenshteinRatio", () => {
+  it("is 1 for identical strings and for two empty strings", () => {
+    expect(levenshteinRatio("abc", "abc")).toBe(1);
+    expect(levenshteinRatio("", "")).toBe(1);
+  });
+
+  it("decreases as strings diverge", () => {
+    expect(levenshteinRatio("zoostand", "zustand")).toBeGreaterThan(0.7);
+    expect(levenshteinRatio("cat", "zustand")).toBeLessThan(0.4);
+  });
+});
+
+describe("isLearnableTerm", () => {
+  it("rejects terms shorter than the minimum length", () => {
+    expect(isLearnableTerm("vue")).toBe(false);
+    expect(isLearnableTerm("zustand")).toBe(true);
+  });
+
+  it("rejects pure numbers", () => {
+    expect(isLearnableTerm("12345")).toBe(false);
+  });
+
+  it("rejects blocklisted keywords and stop words", () => {
+    expect(isLearnableTerm("number")).toBe(false);
+    expect(isLearnableTerm("interface")).toBe(false);
+    expect(isLearnableTerm("there")).toBe(false);
+  });
+});
+
+describe("findCorrectionCandidates", () => {
+  it("detects a multi-word → single-word phonetic correction", () => {
+    const result = findCorrectionCandidates(
+      "deploy the zoo stand store",
+      "deploy the Zustand store"
+    );
+    expect(result.map((c) => c.word)).toEqual(["Zustand"]);
+    expect(result[0]?.original).toBe("zoo stand");
+  });
+
+  it("detects a single-word phonetic correction", () => {
+    const result = findCorrectionCandidates(
+      "use cuber netties for orchestration",
+      "use Kubernetes for orchestration"
+    );
+    expect(result.map((c) => c.word)).toContain("Kubernetes");
+  });
+
+  it("ignores unrelated rewrites that are not phonetically similar", () => {
+    const result = findCorrectionCandidates("send the message now", "delete the message now");
+    expect(result).toEqual([]);
+  });
+
+  it("ignores identical text", () => {
+    expect(findCorrectionCandidates("nothing changed here", "nothing changed here")).toEqual([]);
+  });
+
+  it("ignores pure additions and deletions", () => {
+    expect(findCorrectionCandidates("run the build", "run the build now please")).toEqual([]);
+    expect(findCorrectionCandidates("run the full build", "run the build")).toEqual([]);
+  });
+
+  it("does not suggest blocklisted or too-short corrected words", () => {
+    // "their" → "there" is a homophone but both are stop words.
+    expect(findCorrectionCandidates("put it over their", "put it over there")).toEqual([]);
+  });
+
+  it("does not suggest pure numbers", () => {
+    expect(findCorrectionCandidates("send 1234 now", "send 5678 now")).toEqual([]);
+  });
+
+  it("ignores case-only differences from AI correction", () => {
+    expect(findCorrectionCandidates("install zustand today", "install Zustand today")).toEqual([]);
+  });
+
+  it("dedupes repeated corrections to the same term", () => {
+    const result = findCorrectionCandidates(
+      "zoo stand and zoo stand again",
+      "Zustand and Zustand again"
+    );
+    expect(result.map((c) => c.word)).toEqual(["Zustand"]);
+  });
+
+  it("handles empty input without throwing", () => {
+    expect(findCorrectionCandidates("", "")).toEqual([]);
+    expect(findCorrectionCandidates("hello", "")).toEqual([]);
+  });
+
+  it("handles unicode input without throwing", () => {
+    expect(() => findCorrectionCandidates("café résumé naïve", "cafe resume naive")).not.toThrow();
+  });
+});

--- a/shared/utils/phoneticSimilarity.ts
+++ b/shared/utils/phoneticSimilarity.ts
@@ -1,0 +1,387 @@
+/**
+ * Detect phonetically-similar substitutions a user made while manually editing
+ * dictated text — the signal for learning custom dictionary words. When a user
+ * dictates "zoo stand" and corrects it to "Zustand" before sending, the pair is
+ * a phonetic correction we can offer as a suggested dictionary term.
+ *
+ * Pure functions, no dependencies — runs in the renderer at send time. The
+ * `isLearnableTerm` filter mirrors the keyterm-validation rules in
+ * `electron/services/voiceContextKeyterms.ts` (min length, blocklist, no pure
+ * numbers); the constants are intentionally co-located because that module has
+ * Electron-only imports and can't be loaded from the renderer.
+ */
+
+const MIN_TERM_LENGTH = 4;
+
+// Shell commands, language keywords, and common English stop words that should
+// never be suggested as dictionary terms even if they pass the phonetic gate.
+// Kept in sync with the blocklist in `voiceContextKeyterms.ts`.
+const BLOCKLIST = new Set([
+  // Shell commands
+  "bash",
+  "brew",
+  "curl",
+  "echo",
+  "exit",
+  "export",
+  "find",
+  "grep",
+  "kill",
+  "less",
+  "make",
+  "mkdir",
+  "more",
+  "nano",
+  "node",
+  "npx",
+  "pipe",
+  "push",
+  "ruby",
+  "rust",
+  "sass",
+  "scss",
+  "sudo",
+  "tail",
+  "test",
+  "then",
+  "tree",
+  "wget",
+  "yarn",
+  "docker",
+  // JS/TS keywords
+  "async",
+  "await",
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "default",
+  "delete",
+  "else",
+  "enum",
+  "extends",
+  "false",
+  "finally",
+  "from",
+  "function",
+  "import",
+  "interface",
+  "module",
+  "null",
+  "number",
+  "object",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "require",
+  "return",
+  "static",
+  "string",
+  "super",
+  "switch",
+  "this",
+  "throw",
+  "true",
+  "type",
+  "typeof",
+  "undefined",
+  "void",
+  "while",
+  "with",
+  "yield",
+  // Common English stop words
+  "about",
+  "after",
+  "also",
+  "been",
+  "before",
+  "being",
+  "between",
+  "both",
+  "came",
+  "come",
+  "could",
+  "does",
+  "done",
+  "each",
+  "even",
+  "every",
+  "first",
+  "going",
+  "good",
+  "great",
+  "have",
+  "here",
+  "into",
+  "just",
+  "know",
+  "like",
+  "line",
+  "long",
+  "look",
+  "made",
+  "many",
+  "most",
+  "much",
+  "must",
+  "name",
+  "need",
+  "next",
+  "note",
+  "only",
+  "open",
+  "over",
+  "part",
+  "same",
+  "said",
+  "should",
+  "show",
+  "some",
+  "such",
+  "take",
+  "than",
+  "that",
+  "them",
+  "there",
+  "these",
+  "they",
+  "thing",
+  "think",
+  "those",
+  "through",
+  "time",
+  "under",
+  "upon",
+  "used",
+  "using",
+  "very",
+  "want",
+  "well",
+  "were",
+  "what",
+  "when",
+  "where",
+  "which",
+  "will",
+  "without",
+  "work",
+  "would",
+  "your",
+]);
+
+/** A phonetic correction candidate: the user's corrected word plus the phrase it replaced. */
+export interface CorrectionCandidate {
+  /** The corrected term, in the user's original casing (e.g. "Zustand"). */
+  word: string;
+  /** The misheard phrase it replaced, for provenance (e.g. "zoo stand"). */
+  original: string;
+}
+
+/** Lowercase a token and strip everything that isn't a letter or digit. */
+function normalizeToken(token: string): string {
+  return token.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+/** Whether a normalized token is worth suggesting as a dictionary term. */
+export function isLearnableTerm(normalized: string): boolean {
+  if (normalized.length < MIN_TERM_LENGTH) return false;
+  if (/^\d+$/.test(normalized)) return false;
+  if (BLOCKLIST.has(normalized)) return false;
+  return true;
+}
+
+const SOUNDEX_CODES: Record<string, string> = {
+  B: "1",
+  F: "1",
+  P: "1",
+  V: "1",
+  C: "2",
+  G: "2",
+  J: "2",
+  K: "2",
+  Q: "2",
+  S: "2",
+  X: "2",
+  Z: "2",
+  D: "3",
+  T: "3",
+  L: "4",
+  M: "5",
+  N: "5",
+  R: "6",
+};
+
+/** Classic Soundex encoding (letter + 3 digits). Empty string for non-alpha input. */
+export function soundex(value: string): string {
+  const letters = value.toUpperCase().replace(/[^A-Z]/g, "");
+  if (!letters) return "";
+
+  const first = letters[0]!;
+  let result = first;
+  let prev = SOUNDEX_CODES[first] ?? "";
+
+  for (let i = 1; i < letters.length && result.length < 4; i++) {
+    const ch = letters[i]!;
+    const code = SOUNDEX_CODES[ch] ?? "";
+    if (code && code !== prev) {
+      result += code;
+    }
+    // H and W are transparent — they don't reset the previous code, so a digit
+    // separated only by H/W is still treated as a repeat. Vowels reset it.
+    if (ch !== "H" && ch !== "W") {
+      prev = code;
+    }
+  }
+
+  return (result + "000").slice(0, 4);
+}
+
+/** Levenshtein edit distance between two strings. */
+export function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (!a.length) return b.length;
+  if (!b.length) return a.length;
+
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  let curr = new Array<number>(b.length + 1);
+
+  for (let i = 1; i <= a.length; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(prev[j]! + 1, curr[j - 1]! + 1, prev[j - 1]! + cost);
+    }
+    [prev, curr] = [curr, prev];
+  }
+
+  return prev[b.length]!;
+}
+
+/** Similarity ratio in [0, 1]: 1 = identical, 0 = no shared characters. */
+export function levenshteinRatio(a: string, b: string): number {
+  const maxLen = Math.max(a.length, b.length);
+  if (maxLen === 0) return 1;
+  return 1 - levenshtein(a, b) / maxLen;
+}
+
+/**
+ * Whether two leading sounds are compatible: the same letter, or two consonants
+ * that share a Soundex code (so c≡k, s≡z). Mishearings rarely change the
+ * leading sound, but they routinely swap homophonic consonants.
+ */
+function firstSoundCompatible(a: string, b: string): boolean {
+  if (a[0] === b[0]) return true;
+  const ca = SOUNDEX_CODES[a[0]!.toUpperCase()];
+  const cb = SOUNDEX_CODES[b[0]!.toUpperCase()];
+  return !!ca && ca === cb;
+}
+
+/**
+ * Whether two normalized forms are close enough to be a mishearing rather than
+ * an unrelated rewrite. Requires a compatible leading sound plus either an
+ * exact Soundex match or a high edit ratio.
+ */
+function isPhoneticallySimilar(a: string, b: string): boolean {
+  if (!a || !b || a === b) return false;
+  if (!firstSoundCompatible(a, b)) return false;
+  if (soundex(a) === soundex(b)) return true;
+  return levenshteinRatio(a, b) >= 0.4;
+}
+
+/** Split text into whitespace-delimited tokens. */
+function tokenize(text: string): string[] {
+  return text.split(/\s+/).filter(Boolean);
+}
+
+/**
+ * Align two token sequences via LCS and return the substituted runs — maximal
+ * spans where one side's tokens were replaced by the other's. Pure insertions
+ * and deletions (one side empty) are included so callers can filter them out.
+ */
+function diffRuns(before: string[], after: string[]): Array<{ before: string[]; after: string[] }> {
+  const a = before.map(normalizeToken);
+  const b = after.map(normalizeToken);
+  const m = a.length;
+  const n = b.length;
+
+  // dp[i][j] = LCS length of a[i..] and b[j..]
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array<number>(n + 1).fill(0));
+  for (let i = m - 1; i >= 0; i--) {
+    for (let j = n - 1; j >= 0; j--) {
+      dp[i]![j] = a[i] === b[j] ? dp[i + 1]![j + 1]! + 1 : Math.max(dp[i + 1]![j]!, dp[i]![j + 1]!);
+    }
+  }
+
+  const runs: Array<{ before: string[]; after: string[] }> = [];
+  let curBefore: string[] = [];
+  let curAfter: string[] = [];
+  const flush = () => {
+    if (curBefore.length || curAfter.length) {
+      runs.push({ before: curBefore, after: curAfter });
+      curBefore = [];
+      curAfter = [];
+    }
+  };
+
+  let i = 0;
+  let j = 0;
+  while (i < m && j < n) {
+    if (a[i] === b[j]) {
+      flush();
+      i++;
+      j++;
+    } else if (dp[i + 1]![j]! >= dp[i]![j + 1]!) {
+      curBefore.push(before[i]!);
+      i++;
+    } else {
+      curAfter.push(after[j]!);
+      j++;
+    }
+  }
+  while (i < m) curBefore.push(before[i++]!);
+  while (j < n) curAfter.push(after[j++]!);
+  flush();
+
+  return runs;
+}
+
+/**
+ * Find phonetically-similar substitutions between a baseline transcription and
+ * the user's edited text. Returns the corrected terms (deduped, case
+ * preserved) the user likely wants in their dictionary.
+ *
+ * Handles 1:1, many:1 ("zoo stand" → "Zustand"), and 1:many substitutions by
+ * comparing the concatenated forms of each substituted run.
+ */
+export function findCorrectionCandidates(baseline: string, edited: string): CorrectionCandidate[] {
+  if (!baseline.trim() || !edited.trim()) return [];
+
+  const runs = diffRuns(tokenize(baseline), tokenize(edited));
+  const out: CorrectionCandidate[] = [];
+  const seen = new Set<string>();
+
+  for (const run of runs) {
+    // Only substitutions (both sides non-empty) are corrections; pure
+    // insertions or deletions carry no misheard→fixed pairing.
+    if (run.before.length === 0 || run.after.length === 0) continue;
+
+    const beforeJoined = run.before.map(normalizeToken).join("");
+    const afterJoined = run.after.map(normalizeToken).join("");
+    if (!isPhoneticallySimilar(beforeJoined, afterJoined)) continue;
+
+    const original = run.before.join(" ");
+    for (const token of run.after) {
+      const normalized = normalizeToken(token);
+      if (!isLearnableTerm(normalized)) continue;
+      if (seen.has(normalized)) continue;
+      seen.add(normalized);
+      out.push({ word: token, original });
+    }
+  }
+
+  return out;
+}

--- a/shared/utils/phoneticSimilarity.ts
+++ b/shared/utils/phoneticSimilarity.ts
@@ -186,6 +186,11 @@ function normalizeToken(token: string): string {
   return token.toLowerCase().replace(/[^a-z0-9]/g, "");
 }
 
+/** Strip leading/trailing punctuation while preserving internal casing and dots (e.g. "Vue.js"). */
+function stripEdgePunctuation(token: string): string {
+  return token.replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, "");
+}
+
 /** Whether a normalized token is worth suggesting as a dictionary term. */
 export function isLearnableTerm(normalized: string): boolean {
   if (normalized.length < MIN_TERM_LENGTH) return false;
@@ -368,19 +373,20 @@ export function findCorrectionCandidates(baseline: string, edited: string): Corr
     // Only substitutions (both sides non-empty) are corrections; pure
     // insertions or deletions carry no misheard→fixed pairing.
     if (run.before.length === 0 || run.after.length === 0) continue;
+    // Only clean consolidating substitutions (1:1 or many:1). A multi-token
+    // corrected run is ambiguous — it usually means the user appended unrelated
+    // words after the dictated term — so skip it rather than suggest noise.
+    if (run.after.length !== 1) continue;
 
+    const token = run.after[0]!;
     const beforeJoined = run.before.map(normalizeToken).join("");
-    const afterJoined = run.after.map(normalizeToken).join("");
-    if (!isPhoneticallySimilar(beforeJoined, afterJoined)) continue;
+    const normalized = normalizeToken(token);
+    if (!isPhoneticallySimilar(beforeJoined, normalized)) continue;
+    if (!isLearnableTerm(normalized)) continue;
+    if (seen.has(normalized)) continue;
 
-    const original = run.before.join(" ");
-    for (const token of run.after) {
-      const normalized = normalizeToken(token);
-      if (!isLearnableTerm(normalized)) continue;
-      if (seen.has(normalized)) continue;
-      seen.add(normalized);
-      out.push({ word: token, original });
-    }
+    seen.add(normalized);
+    out.push({ word: stripEdgePunctuation(token), original: run.before.join(" ") });
   }
 
   return out;

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -127,7 +127,9 @@ export function VoiceInputSettingsTab() {
 
   const loadSettings = useCallback(async () => {
     const s = await window.electron?.voiceInput?.getSettings();
-    if (s) setSettings(s);
+    // Merge over defaults so fields added after a settings blob was written
+    // (e.g. suggestedDictionary, learnFromCorrections) are never undefined.
+    if (s) setSettings({ ...DEFAULT_SETTINGS, ...s });
   }, []);
 
   const { isLoading, loadError, retryAction } = useTabLoad({

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -33,6 +33,7 @@ import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { CORE_CORRECTION_PROMPT } from "@shared/config/voiceCorrection";
 import type {
   VoiceInputSettings,
+  SuggestedDictionaryEntry,
   MicPermissionStatus,
   VoiceCorrectionModel,
   VoiceParagraphingStrategy,
@@ -104,6 +105,8 @@ const DEFAULT_SETTINGS: VoiceInputSettings = {
   organizationId: "",
   projectId: "",
   recordingMode: "toggle",
+  suggestedDictionary: [],
+  learnFromCorrections: true,
 };
 
 type ApiKeyValidation = "idle" | "testing" | "valid" | "invalid";
@@ -191,6 +194,22 @@ export function VoiceInputSettingsTab() {
 
   const removeDictionaryWord = (word: string) => {
     update({ customDictionary: settings.customDictionary.filter((w) => w !== word) });
+  };
+
+  // Suggestions live in voiceInput settings, so accept/dismiss are plain
+  // settings mutations through `update` — accept moves the word into the
+  // confirmed dictionary, dismiss just drops it from the queue.
+  const acceptSuggestion = (word: string) => {
+    update({
+      suggestedDictionary: settings.suggestedDictionary.filter((e) => e.word !== word),
+      customDictionary: settings.customDictionary.includes(word)
+        ? settings.customDictionary
+        : [...settings.customDictionary, word],
+    });
+  };
+
+  const dismissSuggestion = (word: string) => {
+    update({ suggestedDictionary: settings.suggestedDictionary.filter((e) => e.word !== word) });
   };
 
   useSettingsTabValidation("voice", Boolean(loadError));
@@ -347,6 +366,11 @@ export function VoiceInputSettingsTab() {
 
             <DictionarySection
               words={settings.customDictionary}
+              suggestedWords={settings.suggestedDictionary}
+              learnFromCorrections={settings.learnFromCorrections}
+              onLearnFromCorrectionsChange={(v) => update({ learnFromCorrections: v })}
+              onAcceptSuggestion={acceptSuggestion}
+              onDismissSuggestion={dismissSuggestion}
               newWord={newDictionaryWord}
               onNewWordChange={setNewDictionaryWord}
               onAdd={addDictionaryWord}
@@ -851,6 +875,11 @@ function RecordingModeRow({
 
 function DictionarySection({
   words,
+  suggestedWords,
+  learnFromCorrections,
+  onLearnFromCorrectionsChange,
+  onAcceptSuggestion,
+  onDismissSuggestion,
   newWord,
   onNewWordChange,
   onAdd,
@@ -858,6 +887,11 @@ function DictionarySection({
   inputRef,
 }: {
   words: string[];
+  suggestedWords: SuggestedDictionaryEntry[];
+  learnFromCorrections: boolean;
+  onLearnFromCorrectionsChange: (v: boolean) => void;
+  onAcceptSuggestion: (word: string) => void;
+  onDismissSuggestion: (word: string) => void;
   newWord: string;
   onNewWordChange: (v: string) => void;
   onAdd: () => void;
@@ -873,6 +907,49 @@ function DictionarySection({
           {words.length > 0 && `${words.length}/100`}
         </span>
       </label>
+
+      <SettingsSwitchCard
+        variant="compact"
+        title="Learn words from corrections"
+        subtitle="Suggest dictionary terms when you fix a mishearing before sending"
+        isEnabled={learnFromCorrections}
+        onChange={() => onLearnFromCorrectionsChange(!learnFromCorrections)}
+        ariaLabel="Toggle learning words from corrections"
+      />
+
+      {suggestedWords.length > 0 && (
+        <div className="space-y-1.5">
+          <p className="text-xs text-daintree-text/50">Suggested from corrections</p>
+          <div className="flex flex-wrap gap-1.5">
+            {suggestedWords.map((entry) => (
+              <span
+                key={entry.word}
+                className="inline-flex items-center gap-1.5 rounded-full border border-daintree-border bg-overlay-subtle px-2 py-0.5 text-xs text-daintree-text"
+                title={entry.utterance ? `Heard as "${entry.utterance}"` : undefined}
+              >
+                {entry.word}
+                <button
+                  type="button"
+                  onClick={() => onAcceptSuggestion(entry.word)}
+                  className="inline-flex items-center gap-0.5 text-daintree-text/50 hover:text-daintree-text transition-colors"
+                  aria-label={`Add ${entry.word} to dictionary`}
+                >
+                  <Plus className="h-3 w-3" />
+                  Add
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onDismissSuggestion(entry.word)}
+                  className="text-daintree-text/30 hover:text-daintree-text/70 transition-colors"
+                  aria-label={`Dismiss ${entry.word}`}
+                >
+                  <X className="h-2.5 w-2.5" />
+                </button>
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
 
       <div className="flex gap-2">
         <input

--- a/src/components/Terminal/hooks/useTokenResolution.ts
+++ b/src/components/Terminal/hooks/useTokenResolution.ts
@@ -4,6 +4,12 @@ import type { BuiltInAgentId } from "@shared/config/agentIds";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { buildTerminalSendPayload } from "@/lib/terminalInput";
 import { useCommandHistoryStore } from "@/store/commandHistoryStore";
+import { useVoiceRecordingStore } from "@/store/voiceRecordingStore";
+import {
+  findCorrectionCandidates,
+  type CorrectionCandidate,
+} from "@shared/utils/phoneticSimilarity";
+import type { SuggestedDictionaryEntry } from "@shared/types";
 import {
   getAllAtTerminalTokens,
   getAllAtSelectionTokens,
@@ -18,6 +24,95 @@ import type {
   AtSelectionContext,
 } from "../hybridInputParsing";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+
+/** Cap on the pending-suggestions queue — confirmed words live in customDictionary. */
+const MAX_SUGGESTED_WORDS = 50;
+
+/**
+ * Merge freshly-detected correction candidates into the persisted suggestion
+ * queue: skip words already in the confirmed dictionary, bump frequency on a
+ * repeat, and cap the queue. Returns null when nothing changed.
+ */
+function mergeSuggestions(
+  candidates: CorrectionCandidate[],
+  customDictionary: string[],
+  suggested: SuggestedDictionaryEntry[],
+  now: number
+): SuggestedDictionaryEntry[] | null {
+  const confirmed = new Set(customDictionary.map((w) => w.toLowerCase()));
+  const next = [...suggested];
+  let changed = false;
+
+  for (const { word, original } of candidates) {
+    const lower = word.toLowerCase();
+    if (confirmed.has(lower)) continue;
+    const idx = next.findIndex((e) => e.word.toLowerCase() === lower);
+    if (idx >= 0) {
+      const entry = next[idx]!;
+      next[idx] = {
+        ...entry,
+        frequency: entry.frequency + 1,
+        suggestedAt: now,
+        utterance: original,
+      };
+    } else {
+      next.unshift({ word, utterance: original, suggestedAt: now, frequency: 1 });
+    }
+    changed = true;
+  }
+
+  return changed ? next.slice(0, MAX_SUGGESTED_WORDS) : null;
+}
+
+/**
+ * Learn custom-dictionary words from a user's manual corrections to dictated
+ * text. Compares the settled transcription baseline (captured after dictation
+ * stops) against the final text the user is sending; phonetically-similar
+ * substitutions are persisted as suggestions in Voice settings, pending
+ * explicit accept/dismiss (#9749).
+ *
+ * Synchronous store read at the send site (no React subscription — see [[#9441]]).
+ * Fully swallows errors: learning must never block or alter the send.
+ */
+function detectDictionaryCorrections(panelId: string, finalText: string): void {
+  try {
+    const voiceState = useVoiceRecordingStore.getState();
+    if (!voiceState.learnFromCorrections) return;
+    const buffer = voiceState.panelBuffers[panelId];
+    const baseline = buffer?.sessionCorrectedText;
+    const sessionStart = buffer?.sessionDraftStart ?? -1;
+    if (!baseline || sessionStart < 0) return;
+
+    // Consume the baseline so a later send of unrelated text can't re-trigger.
+    voiceState.setSessionCorrectedText(panelId, null);
+
+    const candidates = findCorrectionCandidates(baseline, finalText.slice(sessionStart));
+    if (candidates.length === 0) return;
+
+    // Read-modify-write the suggestion queue via the existing settings channel.
+    // The dictate→correct→send flow is human-paced, so concurrent writes to
+    // suggestedDictionary don't happen in practice.
+    void (async () => {
+      try {
+        const settings = await window.electron.voiceInput.getSettings();
+        if (!settings.learnFromCorrections) return;
+        const next = mergeSuggestions(
+          candidates,
+          settings.customDictionary,
+          settings.suggestedDictionary,
+          Date.now()
+        );
+        if (next) {
+          await window.electron.voiceInput.setSettings({ suggestedDictionary: next });
+        }
+      } catch {
+        // Best-effort; never surface a learning failure to the user.
+      }
+    })();
+  } catch {
+    // Never let learning interfere with sending.
+  }
+}
 
 interface LatestRefShape {
   terminalId: string;
@@ -136,6 +231,11 @@ export function useTokenResolution({
           resolvedText = resolvedText.slice(0, r.start) + r.replacement + resolvedText.slice(r.end);
         }
       }
+
+      // Learn dictionary words from manual corrections to dictated text. Uses
+      // the original `text` (the human-authored content), not `resolvedText`
+      // (which has @-token expansions spliced in).
+      detectDictionaryCorrections(terminalId, text);
 
       const payload = buildTerminalSendPayload(resolvedText);
       latest.onSend({ data: payload.data, trackerData: payload.trackerData, text: resolvedText });

--- a/src/services/VoiceRecordingService.ts
+++ b/src/services/VoiceRecordingService.ts
@@ -1039,6 +1039,12 @@ class VoiceRecordingService {
     const rawText = draftBefore.slice(sessionStart);
     if (!rawText.trim()) return;
 
+    // Seed the learning baseline with the raw transcription synchronously, before
+    // the async correction call. If a new session starts on a DIFFERENT panel
+    // while this runs, the end-of-function stale check skips the corrected
+    // overwrite — but this panel still keeps a usable baseline (#9749).
+    useVoiceRecordingStore.getState().setSessionCorrectedText(panelId, rawText);
+
     logDebug(`${LOG_PREFIX} Running whole-passage correction`, {
       panelId,
       rawLength: rawText.length,

--- a/src/services/VoiceRecordingService.ts
+++ b/src/services/VoiceRecordingService.ts
@@ -432,6 +432,9 @@ class VoiceRecordingService {
     useVoiceRecordingStore
       .getState()
       .setCorrectionEnabled(!!(settings.correctionEnabled && settings.openaiApiKey));
+    useVoiceRecordingStore
+      .getState()
+      .setLearnFromCorrections(settings.learnFromCorrections !== false);
     useVoiceRecordingStore.getState().setConfigured(isConfigured);
     return isConfigured;
   }
@@ -988,14 +991,27 @@ class VoiceRecordingService {
       // Whole-passage AI cleanup runs after a deliberate, graceful stop only —
       // not on error, cancel-to-restart, or backend-driven teardown. Fire and
       // forget: the decoration shows progress, and stop() returns immediately.
-      if (
-        !skipRemoteStop &&
-        nextStatus === "idle" &&
-        !options.skipCorrection &&
-        correctionEnabled &&
-        stoppedTarget
-      ) {
-        void this.runCorrection(stoppedTarget, stopGeneration);
+      if (!skipRemoteStop && nextStatus === "idle" && !options.skipCorrection && stoppedTarget) {
+        if (correctionEnabled) {
+          void this.runCorrection(stoppedTarget, stopGeneration);
+        } else {
+          // No AI correction pass will run, so capture the raw dictated text as
+          // the learning baseline directly. The draft retains the full dictated
+          // span (finishSession leaves sessionDraftStart intact) so manual
+          // corrections can still be detected at send time (#9749).
+          const { panelId, projectId } = stoppedTarget;
+          const buffer = useVoiceRecordingStore.getState().panelBuffers[panelId];
+          const sessionStart = buffer?.sessionDraftStart ?? -1;
+          if (sessionStart >= 0) {
+            const raw = useTerminalInputStore
+              .getState()
+              .getDraftInput(panelId, projectId)
+              .slice(sessionStart);
+            useVoiceRecordingStore
+              .getState()
+              .setSessionCorrectedText(panelId, raw.trim() ? raw : null);
+          }
+        }
       }
     })();
 
@@ -1080,6 +1096,11 @@ class VoiceRecordingService {
         logDebug(`${LOG_PREFIX} Skipping correction — dictated text changed during cleanup`);
       }
     }
+
+    // Record the settled dictated text as the learning baseline. Manual edits
+    // the user makes before sending are diffed against this to detect words
+    // worth suggesting for the custom dictionary (#9749).
+    useVoiceRecordingStore.getState().setSessionCorrectedText(panelId, correctedText);
 
     inputStore.bumpVoiceDraftRevision();
   }

--- a/src/services/__tests__/VoiceRecordingService.adversarial.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.adversarial.test.ts
@@ -96,6 +96,8 @@ const runtime = vi.hoisted(() => ({
     setStatus: vi.fn<(status: string) => void>(),
     setConfigured: vi.fn<(configured: boolean) => void>(),
     setCorrectionEnabled: vi.fn<(enabled: boolean) => void>(),
+    setLearnFromCorrections: vi.fn<(enabled: boolean) => void>(),
+    setSessionCorrectedText: vi.fn<(panelId: string, text: string | null) => void>(),
     beginSession: vi.fn<(target: VoiceRecordingTarget) => void>(),
     finishSession:
       vi.fn<(options?: { nextStatus?: "idle" | "error"; preserveLiveText?: boolean }) => void>(),

--- a/src/services/__tests__/VoiceRecordingService.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.test.ts
@@ -20,6 +20,8 @@ vi.mock("@/store/voiceRecordingStore", () => {
     setStatus: vi.fn(),
     setConfigured: vi.fn(),
     setCorrectionEnabled: vi.fn(),
+    setLearnFromCorrections: vi.fn(),
+    setSessionCorrectedText: vi.fn(),
     setArming: vi.fn(),
     beginSession: vi.fn(),
     finishSession: vi.fn(),

--- a/src/store/voiceRecordingStore.ts
+++ b/src/store/voiceRecordingStore.ts
@@ -51,6 +51,14 @@ interface VoiceTranscriptBuffer {
    * pass (null = none). Drives the `cm-voice-pending-ai` editor decoration.
    */
   correctionRange: { from: number; to: number } | null;
+  /**
+   * The dictated text as it settled after the post-stop processing pass (AI
+   * correction if enabled, else the raw transcription). Diffed against the
+   * user's final edits at send time to learn dictionary words. Runtime-only,
+   * ephemeral per session, never persisted — see [[#9514]] separate durable vs
+   * in-session state.
+   */
+  sessionCorrectedText: string | null;
 }
 
 interface VoiceAnnouncement {
@@ -67,6 +75,8 @@ interface VoiceRecordingState {
   isConfigured: boolean;
   /** Whether AI correction is enabled for the current session. */
   correctionEnabled: boolean;
+  /** Whether manual corrections to dictated text surface as suggested dictionary words. */
+  learnFromCorrections: boolean;
   status: VoiceInputStatus;
   lastError: VoiceInputError | null;
   activeTarget: VoiceRecordingTarget | null;
@@ -88,6 +98,8 @@ interface VoiceRecordingState {
   announcement: VoiceAnnouncement | null;
   setConfigured: (isConfigured: boolean) => void;
   setCorrectionEnabled: (enabled: boolean) => void;
+  setLearnFromCorrections: (enabled: boolean) => void;
+  setSessionCorrectedText: (panelId: string, text: string | null) => void;
   setAudioLevel: (level: number) => void;
   setArming: (target: VoiceRecordingTarget) => void;
   beginSession: (target: VoiceRecordingTarget) => void;
@@ -127,6 +139,7 @@ function getBuffer(
       activeParagraphStart: -1,
       transcriptPhase: "idle" as VoiceTranscriptPhase,
       correctionRange: null,
+      sessionCorrectedText: null,
     }
   );
 }
@@ -136,6 +149,7 @@ export const useVoiceRecordingStore = create<VoiceRecordingState>()(
     (set, get) => ({
       isConfigured: false,
       correctionEnabled: false,
+      learnFromCorrections: true,
       status: "idle",
       lastError: null,
       activeTarget: null,
@@ -149,6 +163,20 @@ export const useVoiceRecordingStore = create<VoiceRecordingState>()(
       setConfigured: (isConfigured) => set({ isConfigured }),
 
       setCorrectionEnabled: (correctionEnabled) => set({ correctionEnabled }),
+
+      setLearnFromCorrections: (learnFromCorrections) => set({ learnFromCorrections }),
+
+      setSessionCorrectedText: (panelId, text) =>
+        set((state) => {
+          const buffer = getBuffer(state.panelBuffers, panelId);
+          if (buffer.sessionCorrectedText === text) return state;
+          return {
+            panelBuffers: {
+              ...state.panelBuffers,
+              [panelId]: { ...buffer, sessionCorrectedText: text },
+            },
+          };
+        }),
 
       setLastError: (error) => set({ lastError: error }),
 
@@ -182,6 +210,7 @@ export const useVoiceRecordingStore = create<VoiceRecordingState>()(
               activeParagraphStart: -1,
               transcriptPhase: "idle" as VoiceTranscriptPhase,
               correctionRange: null,
+              sessionCorrectedText: null,
             },
           },
         })),


### PR DESCRIPTION
## Summary

- When a user dictates and then manually fixes a misheard word before sending (e.g. "zoo stand" → "Zustand"), Daintree detects the phonetically-similar substitution and surfaces the corrected word as a pending suggestion in Voice settings → Custom dictionary.
- Nothing is added silently — the user explicitly accepts or dismisses each suggestion via a chip row in `VoiceInputSettingsTab`.
- A "Learn words from corrections" toggle (default on) gates the whole flow.

Resolves #9749

## Changes

- **`shared/utils/phoneticSimilarity.ts`** — new pure utility: Soundex + normalized Levenshtein ratio. `findCorrectionCandidates()` tokenizes baseline vs edited text, LCS-diffs to find substituted runs, and gates each on a compatible leading Soundex consonant plus exact Soundex match or edit ratio ≥ 0.4. Reuses the keyterm blocklist/min-length filter. Only emits clean 1:1 / many:1 corrected runs so appended text can't bleed in.
- **`src/store/voiceRecordingStore.ts`** — adds `sessionCorrectedText` (ephemeral per-session baseline, never persisted). Captured after AI correction settles so the baseline is always the pre-edit text regardless of whether AI correction is on or off.
- **`src/components/Terminal/hooks/useTokenResolution.ts`** — diffs the baseline against the final text at send time (synchronous store read) and persists new suggestions through the existing `voice-input:set-settings` channel. No new IPC channels needed — suggestions are just `voiceInput` settings, deduped/frequency-bumped/capped at 50 in the renderer.
- **`src/components/Settings/VoiceInputSettingsTab.tsx`** — renders a "Suggested from corrections" chip row (neutral styling, Add + dismiss) and the `learnFromCorrections` toggle.
- **`electron/store.ts`** + **`shared/types/ipc/api.ts`** — `suggestedDictionary[]` and `learnFromCorrections` added to persisted settings (additive, no migration needed).

## Testing

- 26 unit tests for `phoneticSimilarity.ts` covering Soundex, Levenshtein ratio, `findCorrectionCandidates()` edge cases, and the blocklist filter — all pass.
- `tsc` clean, lint:ratchet passes (no new `IpcInvokeMap` entries, no new warnings), format clean, all IPC/channel/confirm-wiring guards pass.