### PR TITLE
feat(assistant): expandable recent-call history popover

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -25,6 +25,7 @@ import { HelpPanelBanners } from "./HelpPanelBanners";
 import { HelpPanelVersionGate } from "./HelpPanelVersionGate";
 import { HelpLaunchingState } from "./HelpLaunchingState";
 import { McpToolActivityStrip } from "./McpToolActivityStrip";
+import { McpActivityStrip } from "./McpActivityStrip";
 import {
   useHelpPanelStore,
   HELP_PANEL_MIN_WIDTH,
@@ -892,6 +893,7 @@ export function HelpPanel({
               Daintree.org
             </button>
           </div>
+          <McpActivityStrip sessionId={sessionId} onOpenSettings={handleOpenSettings} />
         </div>
       )}
       <ConfirmDialog

--- a/src/components/HelpPanel/McpActivityStrip.tsx
+++ b/src/components/HelpPanel/McpActivityStrip.tsx
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Activity } from "@/components/icons";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { logWarn } from "@/utils/logger";
+import type { McpAuditRecord } from "@shared/types";
+import { RecentCallsPopover } from "./RecentCallsPopover";
+
+const MAX_RECENT_CALLS = 20;
+
+interface McpActivityStripProps {
+  /** Current assistant session. Empty string means hibernated — strip is hidden. */
+  sessionId: string;
+  onOpenSettings: () => void;
+}
+
+export function McpActivityStrip({ sessionId, onOpenSettings }: McpActivityStripProps) {
+  const [open, setOpen] = useState(false);
+  const [records, setRecords] = useState<McpAuditRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  // Monotonic token: discard any fetch that resolves after a newer open/session
+  // change so a slow response can't overwrite fresher state.
+  const fetchSeq = useRef(0);
+
+  // A session change invalidates the open popover — its calls belong to the old
+  // session. Close it and drop the stale list.
+  useEffect(() => {
+    setOpen(false);
+    setRecords([]);
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (!open || !sessionId) return;
+
+    const seq = ++fetchSeq.current;
+    setLoading(true);
+    setError(false);
+
+    void (async () => {
+      try {
+        const all = await window.electron.mcpServer.getAuditRecords();
+        if (fetchSeq.current !== seq) return;
+        const mine = all.filter((r) => r.sessionId === sessionId).slice(0, MAX_RECENT_CALLS);
+        setRecords(mine);
+        setLoading(false);
+      } catch (err) {
+        if (fetchSeq.current !== seq) return;
+        logWarn("[McpActivityStrip] Failed to load audit records", err);
+        setError(true);
+        setLoading(false);
+      }
+    })();
+  }, [open, sessionId]);
+
+  const handleViewFullAuditLog = useCallback(() => {
+    setOpen(false);
+    onOpenSettings();
+  }, [onOpenSettings]);
+
+  if (!sessionId) return null;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="flex items-center gap-1 hover:text-daintree-text/60 transition-colors duration-150 ease-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+        >
+          <Activity className="w-3.5 h-3.5 shrink-0" />
+          Recent activity
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        side="top"
+        align="start"
+        sideOffset={6}
+        collisionPadding={8}
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        aria-label="Recent tool calls"
+        className="w-72"
+      >
+        <RecentCallsPopover
+          records={records}
+          loading={loading}
+          error={error}
+          onViewFullAuditLog={handleViewFullAuditLog}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/HelpPanel/McpActivityStrip.tsx
+++ b/src/components/HelpPanel/McpActivityStrip.tsx
@@ -8,8 +8,8 @@ import { RecentCallsPopover } from "./RecentCallsPopover";
 const MAX_RECENT_CALLS = 20;
 
 interface McpActivityStripProps {
-  /** Current assistant session. Empty string means hibernated — strip is hidden. */
-  sessionId: string;
+  /** Current assistant session. Empty/null means hibernated — strip is hidden. */
+  sessionId: string | null;
   onOpenSettings: () => void;
 }
 
@@ -24,10 +24,14 @@ export function McpActivityStrip({ sessionId, onOpenSettings }: McpActivityStrip
   const fetchSeq = useRef(0);
 
   // A session change invalidates the open popover — its calls belong to the old
-  // session. Close it and drop the stale list.
+  // session. Close it, drop the stale list, and bump the fetch token so any
+  // in-flight request from the previous session can't land its results.
   useEffect(() => {
+    fetchSeq.current++;
     setOpen(false);
     setRecords([]);
+    setLoading(false);
+    setError(false);
   }, [sessionId]);
 
   useEffect(() => {
@@ -46,7 +50,7 @@ export function McpActivityStrip({ sessionId, onOpenSettings }: McpActivityStrip
         setLoading(false);
       } catch (err) {
         if (fetchSeq.current !== seq) return;
-        logWarn("[McpActivityStrip] Failed to load audit records", err);
+        logWarn("[McpActivityStrip] Failed to load audit records", { error: err });
         setError(true);
         setLoading(false);
       }

--- a/src/components/HelpPanel/RecentCallsPopover.tsx
+++ b/src/components/HelpPanel/RecentCallsPopover.tsx
@@ -1,0 +1,151 @@
+import { useMemo } from "react";
+import { ExternalLink } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { McpAuditRecord, McpAuditResult } from "@shared/types";
+
+// Local, deliberately-minimal mirror of the Settings audit viewer's styling.
+// The popover is a simpler read-only view; cross-importing from Settings would
+// create a HelpPanel → Settings layer dependency for two stable constants.
+const RESULT_DOT_CLASS: Record<McpAuditResult, string> = {
+  success: "bg-status-success",
+  error: "bg-status-danger",
+  "confirmation-pending": "bg-status-warning",
+  unauthorized: "bg-status-danger",
+  dedup: "bg-status-info",
+  collision: "bg-status-warning",
+  rate_limited: "bg-status-warning",
+};
+
+const RESULT_LABEL: Record<McpAuditResult, string> = {
+  success: "Success",
+  error: "Error",
+  "confirmation-pending": "Awaiting confirmation",
+  unauthorized: "Unauthorized",
+  dedup: "Deduplicated",
+  collision: "Key collision",
+  rate_limited: "Rate limited",
+};
+
+export function formatCallDuration(durationMs: number): string {
+  if (durationMs <= 0) return "0ms";
+  if (durationMs < 100) return "<100ms";
+  if (durationMs < 1000) return `${Math.round(durationMs)}ms`;
+  return `${(durationMs / 1000).toFixed(1)}s`;
+}
+
+export interface RecentCallGroup {
+  /** `turnId` for associated calls, or `null` for the unassociated bucket. */
+  turnId: string | null;
+  records: McpAuditRecord[];
+}
+
+/**
+ * Group records by `turnId`, preserving the input order (callers pass the
+ * newest-first ring-buffer slice). Records without a `turnId` collapse into a
+ * single trailing `turnId: null` group so they still surface in the list.
+ */
+export function groupCallsByTurn(records: McpAuditRecord[]): RecentCallGroup[] {
+  const byTurn = new Map<string, McpAuditRecord[]>();
+  const unassociated: McpAuditRecord[] = [];
+
+  for (const record of records) {
+    if (record.turnId) {
+      const list = byTurn.get(record.turnId);
+      if (list) list.push(record);
+      else byTurn.set(record.turnId, [record]);
+    } else {
+      unassociated.push(record);
+    }
+  }
+
+  const groups: RecentCallGroup[] = [];
+  for (const [turnId, recs] of byTurn) {
+    groups.push({ turnId, records: recs });
+  }
+  if (unassociated.length > 0) {
+    groups.push({ turnId: null, records: unassociated });
+  }
+  return groups;
+}
+
+interface RecentCallsPopoverProps {
+  records: McpAuditRecord[];
+  loading: boolean;
+  error: boolean;
+  onViewFullAuditLog: () => void;
+}
+
+export function RecentCallsPopover({
+  records,
+  loading,
+  error,
+  onViewFullAuditLog,
+}: RecentCallsPopoverProps) {
+  const groups = useMemo(() => groupCallsByTurn(records), [records]);
+
+  return (
+    <div className="flex flex-col text-[11px] text-daintree-text">
+      <div className="px-3 pt-2.5 pb-1.5 text-daintree-text/50 font-medium">Recent tool calls</div>
+
+      <div className="max-h-[min(320px,var(--radix-popover-content-available-height,320px))] overflow-y-auto px-1 pb-1">
+        {loading ? (
+          <div className="space-y-1.5 px-2 py-1.5" aria-hidden>
+            <div className="h-3 w-5/6 rounded bg-daintree-text/10 animate-pulse" />
+            <div className="h-3 w-4/6 rounded bg-daintree-text/10 animate-pulse" />
+            <div className="h-3 w-3/4 rounded bg-daintree-text/10 animate-pulse" />
+          </div>
+        ) : error ? (
+          <p className="px-2 py-3 text-daintree-text/50">Couldn't load recent calls</p>
+        ) : records.length === 0 ? (
+          <p className="px-2 py-3 text-daintree-text/50">No calls yet this session</p>
+        ) : (
+          <ul className="divide-y divide-daintree-border/60">
+            {groups.map((group, index) => (
+              <li key={group.turnId ?? `unassociated-${index}`} className="py-1">
+                <ul className="space-y-0.5">
+                  {group.records.map((record) => (
+                    <li
+                      key={record.id}
+                      className="grid grid-cols-[auto_1fr_auto] items-start gap-2 px-2 py-0.5"
+                    >
+                      <span
+                        aria-hidden
+                        className={cn(
+                          "mt-1 h-1.5 w-1.5 rounded-full shrink-0",
+                          RESULT_DOT_CLASS[record.result]
+                        )}
+                        title={RESULT_LABEL[record.result]}
+                      />
+                      <div className="min-w-0">
+                        <div className="font-mono text-daintree-text/80 truncate">
+                          {record.toolId}
+                        </div>
+                        <div className="font-mono text-daintree-text/45 truncate">
+                          {record.argsSummary || "{}"}
+                        </div>
+                      </div>
+                      <span className="text-daintree-text/40 whitespace-nowrap tabular-nums">
+                        {formatCallDuration(record.durationMs)}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="border-t border-daintree-border px-1 py-1">
+        <button
+          type="button"
+          onClick={onViewFullAuditLog}
+          className="flex w-full items-center gap-1.5 rounded-[var(--radius-md)] px-2 py-1.5 text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft transition-colors duration-150 ease-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+        >
+          <ExternalLink className="w-3.5 h-3.5 shrink-0" />
+          View full audit log
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/HelpPanel/RecentCallsPopover.tsx
+++ b/src/components/HelpPanel/RecentCallsPopover.tsx
@@ -29,8 +29,10 @@ const RESULT_LABEL: Record<McpAuditResult, string> = {
 export function formatCallDuration(durationMs: number): string {
   if (durationMs <= 0) return "0ms";
   if (durationMs < 100) return "<100ms";
-  if (durationMs < 1000) return `${Math.round(durationMs)}ms`;
-  return `${(durationMs / 1000).toFixed(1)}s`;
+  // Round before the threshold check so 999.5 reads as "1.0s", not "1000ms".
+  const ms = Math.round(durationMs);
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
 }
 
 export interface RecentCallGroup {

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -487,6 +487,7 @@ beforeEach(() => {
           onWake: mockSystemSleepOnWake,
         },
         mcpServer: {
+          getAuditRecords: vi.fn().mockResolvedValue([]),
           onTierNotPermitted: vi.fn(() => () => {}),
           onToolCallStarted: vi.fn(() => () => {}),
           onToolCallSettled: vi.fn(() => () => {}),

--- a/src/components/HelpPanel/__tests__/McpActivityStrip.test.tsx
+++ b/src/components/HelpPanel/__tests__/McpActivityStrip.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { McpAuditRecord } from "@shared/types";
 
@@ -76,6 +76,9 @@ describe("formatCallDuration", () => {
     expect(formatCallDuration(999)).toBe("999ms");
     expect(formatCallDuration(1000)).toBe("1.0s");
     expect(formatCallDuration(1500)).toBe("1.5s");
+    // Rounding happens before the threshold so 999.5 promotes to seconds.
+    expect(formatCallDuration(999.5)).toBe("1.0s");
+    expect(formatCallDuration(1000.4)).toBe("1.0s");
   });
 });
 
@@ -168,6 +171,31 @@ describe("McpActivityStrip", () => {
     render(<McpActivityStrip sessionId="session-a" onOpenSettings={vi.fn()} />);
     fireEvent.click(screen.getByRole("button", { name: /recent activity/i }));
     expect(await screen.findByText(/no calls yet this session/i)).toBeTruthy();
+  });
+
+  it("does not flash old-session records after the session changes mid-fetch", async () => {
+    let resolveFirst: (v: McpAuditRecord[]) => void = () => {};
+    const firstFetch = new Promise<McpAuditRecord[]>((res) => {
+      resolveFirst = res;
+    });
+    getAuditRecords.mockReturnValueOnce(firstFetch);
+
+    const { rerender } = render(
+      <McpActivityStrip sessionId="session-a" onOpenSettings={vi.fn()} />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /recent activity/i }));
+
+    // Session changes before the in-flight session-a fetch resolves.
+    rerender(<McpActivityStrip sessionId="session-b" onOpenSettings={vi.fn()} />);
+    await act(async () => {
+      resolveFirst([makeRecord({ id: "old", toolId: "stale-tool", sessionId: "session-a" })]);
+      await firstFetch;
+    });
+
+    // Reopen under session-b — the stale session-a result must not appear.
+    fireEvent.click(screen.getByRole("button", { name: /recent activity/i }));
+    expect(await screen.findByText(/no calls yet this session/i)).toBeTruthy();
+    expect(screen.queryByText("stale-tool")).toBeNull();
   });
 
   it("invokes onOpenSettings and closes when viewing the full audit log", async () => {

--- a/src/components/HelpPanel/__tests__/McpActivityStrip.test.tsx
+++ b/src/components/HelpPanel/__tests__/McpActivityStrip.test.tsx
@@ -20,7 +20,10 @@ vi.mock("@/components/ui/popover", async () => {
       React.createElement(Ctx.Provider, { value: { open, onOpenChange } }, children),
     PopoverTrigger: ({ children }: { children: React.ReactElement; asChild?: boolean }) => {
       const { open, onOpenChange } = React.useContext(Ctx);
-      return React.cloneElement(children, { onClick: () => onOpenChange?.(!open) });
+      return React.cloneElement(children, { onClick: () => onOpenChange?.(!open) } as Record<
+        string,
+        unknown
+      >);
     },
     PopoverContent: ({ children }: React.PropsWithChildren<unknown>) => {
       const { open } = React.useContext(Ctx);

--- a/src/components/HelpPanel/__tests__/McpActivityStrip.test.tsx
+++ b/src/components/HelpPanel/__tests__/McpActivityStrip.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { McpAuditRecord } from "@shared/types";
+
+vi.mock("@/lib/utils", () => ({ cn: (...args: unknown[]) => args.filter(Boolean).join(" ") }));
+vi.mock("@/utils/logger", () => ({ logWarn: vi.fn() }));
+
+// Deterministic popover: mirrors the controlled open/onOpenChange contract so
+// tests drive the strip's own state machine without Radix's async chunk load.
+vi.mock("@/components/ui/popover", async () => {
+  const React = await import("react");
+  const Ctx = React.createContext<{ open?: boolean; onOpenChange?: (v: boolean) => void }>({});
+  return {
+    Popover: ({
+      open,
+      onOpenChange,
+      children,
+    }: React.PropsWithChildren<{ open?: boolean; onOpenChange?: (v: boolean) => void }>) =>
+      React.createElement(Ctx.Provider, { value: { open, onOpenChange } }, children),
+    PopoverTrigger: ({ children }: { children: React.ReactElement; asChild?: boolean }) => {
+      const { open, onOpenChange } = React.useContext(Ctx);
+      return React.cloneElement(children, { onClick: () => onOpenChange?.(!open) });
+    },
+    PopoverContent: ({ children }: React.PropsWithChildren<unknown>) => {
+      const { open } = React.useContext(Ctx);
+      return open
+        ? React.createElement("div", { "data-testid": "popover-content" }, children)
+        : null;
+    },
+  };
+});
+
+import { McpActivityStrip } from "../McpActivityStrip";
+import { formatCallDuration, groupCallsByTurn } from "../RecentCallsPopover";
+
+function makeRecord(overrides: Partial<McpAuditRecord> = {}): McpAuditRecord {
+  return {
+    id: overrides.id ?? "rec-1",
+    timestamp: overrides.timestamp ?? 0,
+    toolId: overrides.toolId ?? "tool",
+    sessionId: overrides.sessionId ?? "session-a",
+    tier: overrides.tier ?? "workbench",
+    argsSummary: overrides.argsSummary ?? "{}",
+    result: overrides.result ?? "success",
+    durationMs: overrides.durationMs ?? 10,
+    schemaVersion: overrides.schemaVersion ?? 1,
+    severity: overrides.severity ?? "info",
+    ...overrides,
+  };
+}
+
+const getAuditRecords = vi.fn();
+
+beforeEach(() => {
+  getAuditRecords.mockReset();
+  getAuditRecords.mockResolvedValue([]);
+  Object.defineProperty(globalThis, "window", {
+    value: { electron: { mcpServer: { getAuditRecords } } },
+    writable: true,
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("formatCallDuration", () => {
+  it("renders boundary durations", () => {
+    expect(formatCallDuration(0)).toBe("0ms");
+    expect(formatCallDuration(-5)).toBe("0ms");
+    expect(formatCallDuration(50)).toBe("<100ms");
+    expect(formatCallDuration(99)).toBe("<100ms");
+    expect(formatCallDuration(100)).toBe("100ms");
+    expect(formatCallDuration(999)).toBe("999ms");
+    expect(formatCallDuration(1000)).toBe("1.0s");
+    expect(formatCallDuration(1500)).toBe("1.5s");
+  });
+});
+
+describe("groupCallsByTurn", () => {
+  it("returns an empty array for no records", () => {
+    expect(groupCallsByTurn([])).toEqual([]);
+  });
+
+  it("groups records by turnId preserving input order", () => {
+    const records = [
+      makeRecord({ id: "a", turnId: "t1" }),
+      makeRecord({ id: "b", turnId: "t2" }),
+      makeRecord({ id: "c", turnId: "t1" }),
+    ];
+    const groups = groupCallsByTurn(records);
+    expect(groups.map((g) => g.turnId)).toEqual(["t1", "t2"]);
+    expect(groups[0]!.records.map((r) => r.id)).toEqual(["a", "c"]);
+    expect(groups[1]!.records.map((r) => r.id)).toEqual(["b"]);
+  });
+
+  it("collapses records without a turnId into a trailing null group", () => {
+    const records = [
+      makeRecord({ id: "a", turnId: "t1" }),
+      makeRecord({ id: "b" }),
+      makeRecord({ id: "c" }),
+    ];
+    const groups = groupCallsByTurn(records);
+    const last = groups[groups.length - 1]!;
+    expect(last.turnId).toBeNull();
+    expect(last.records.map((r) => r.id)).toEqual(["b", "c"]);
+  });
+});
+
+describe("McpActivityStrip", () => {
+  it("renders nothing when the session is hibernated (empty sessionId)", () => {
+    const { container } = render(<McpActivityStrip sessionId="" onOpenSettings={vi.fn()} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a trigger button for an active session", () => {
+    render(<McpActivityStrip sessionId="session-a" onOpenSettings={vi.fn()} />);
+    expect(screen.getByRole("button", { name: /recent activity/i })).toBeTruthy();
+    expect(getAuditRecords).not.toHaveBeenCalled();
+  });
+
+  it("fetches and renders the session's calls on open", async () => {
+    getAuditRecords.mockResolvedValue([
+      makeRecord({ id: "1", toolId: "alpha-tool", sessionId: "session-a" }),
+      makeRecord({ id: "2", toolId: "beta-tool", sessionId: "session-a" }),
+    ]);
+    render(<McpActivityStrip sessionId="session-a" onOpenSettings={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: /recent activity/i }));
+    expect(await screen.findByText("alpha-tool")).toBeTruthy();
+    expect(screen.getByText("beta-tool")).toBeTruthy();
+  });
+
+  it("filters out records from other sessions", async () => {
+    getAuditRecords.mockResolvedValue([
+      makeRecord({ id: "1", toolId: "mine", sessionId: "session-a" }),
+      makeRecord({ id: "2", toolId: "theirs", sessionId: "session-b" }),
+    ]);
+    render(<McpActivityStrip sessionId="session-a" onOpenSettings={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: /recent activity/i }));
+    expect(await screen.findByText("mine")).toBeTruthy();
+    expect(screen.queryByText("theirs")).toBeNull();
+  });
+
+  it("keeps only the 20 newest calls", async () => {
+    const records = Array.from({ length: 21 }, (_, i) =>
+      makeRecord({ id: `r${i}`, toolId: `tool-${i}`, sessionId: "session-a" })
+    );
+    getAuditRecords.mockResolvedValue(records);
+    render(<McpActivityStrip sessionId="session-a" onOpenSettings={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: /recent activity/i }));
+    expect(await screen.findByText("tool-0")).toBeTruthy();
+    expect(screen.getByText("tool-19")).toBeTruthy();
+    // slice(0, 20) keeps the newest-first leading 20; the 21st is dropped.
+    expect(screen.queryByText("tool-20")).toBeNull();
+  });
+
+  it("shows an error state when the fetch rejects", async () => {
+    getAuditRecords.mockRejectedValue(new Error("boom"));
+    render(<McpActivityStrip sessionId="session-a" onOpenSettings={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: /recent activity/i }));
+    expect(await screen.findByText(/couldn't load recent calls/i)).toBeTruthy();
+  });
+
+  it("renders the empty state when the session has no calls", async () => {
+    getAuditRecords.mockResolvedValue([]);
+    render(<McpActivityStrip sessionId="session-a" onOpenSettings={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: /recent activity/i }));
+    expect(await screen.findByText(/no calls yet this session/i)).toBeTruthy();
+  });
+
+  it("invokes onOpenSettings and closes when viewing the full audit log", async () => {
+    getAuditRecords.mockResolvedValue([
+      makeRecord({ id: "1", toolId: "alpha-tool", sessionId: "session-a" }),
+    ]);
+    const onOpenSettings = vi.fn();
+    render(<McpActivityStrip sessionId="session-a" onOpenSettings={onOpenSettings} />);
+    fireEvent.click(screen.getByRole("button", { name: /recent activity/i }));
+    const footer = await screen.findByRole("button", { name: /view full audit log/i });
+    fireEvent.click(footer);
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId("popover-content")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a minimal MCP activity strip to the `HelpPanel` bottom info bar and the popover it triggers, since the live activity strip from #9759 wasn't yet in place.
- The popover fetches MCP audit records on open via `window.electron.mcpServer.getAuditRecords`, filtered to the current `sessionId` (newest 20), groups them by turn, and shows tool id, args summary, duration, and a result-status dot.
- Hidden when `sessionId` is empty (hibernated sessions). Read-only snapshot on open — no new IPC channel, no persistence.

Resolves #9760

## Changes

- `src/components/HelpPanel/McpActivityStrip.tsx` — new minimal activity-strip trigger in the bottom info bar
- `src/components/HelpPanel/RecentCallsPopover.tsx` — popover component using the Radix `PopoverContent` wrapper; Tier 1 ambient design, no accent color; footer button opens the assistant settings tab
- `src/components/HelpPanel/HelpPanel.tsx` — wires in the activity strip
- `src/components/HelpPanel/__tests__/McpActivityStrip.test.tsx` — full test coverage for the strip and popover

## Testing

118+ vitest pass. Full check suite green: typecheck, lint, format, IPC/channel/confirm-wiring guards, lint ratchet (no new warnings).