### PR TITLE
feat(assistant): show live MCP tool-call activity strip (#9759)

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -656,6 +656,18 @@ export const CHANNELS = {
    * grant state is session-scoped and never broadcast.
    */
   MCP_GRANT_LIFECYCLE: "mcp-server:grant-lifecycle",
+  /**
+   * Push channel: an MCP tool dispatch entered the call path for the
+   * help-session pinned to this renderer. Drives the Assistant panel's live
+   * activity strip (#9759). Targeted send — never broadcast.
+   */
+  MCP_TOOL_CALL_STARTED: "mcp-server:tool-call-started",
+  /**
+   * Push channel: an MCP tool dispatch announced via `MCP_TOOL_CALL_STARTED`
+   * settled. Carries the audit-aligned outcome (duration, result, severity)
+   * so the activity strip can dim to a glyph. Targeted send — never broadcast.
+   */
+  MCP_TOOL_CALL_SETTLED: "mcp-server:tool-call-settled",
 
   // Voice Input channels
   VOICE_INPUT_GET_SETTINGS: "voice-input:get-settings",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -18,6 +18,8 @@ import type {
   McpRuntimeSnapshot,
   McpGrantLifecyclePayload,
   McpBearerIdentity,
+  McpToolCallStartedPayload,
+  McpToolCallSettledPayload,
 } from "../shared/types/ipc/mcpServer.js";
 import type { ActionContext, ActionDispatchResult } from "../shared/types/actions.js";
 import type { PushProgressEvent } from "../shared/types/ipc/gitPush.js";
@@ -2425,6 +2427,10 @@ const api: ElectronAPI = {
     ) => _typedOn(CHANNELS.MCP_TIER_NOT_PERMITTED, callback),
     onGrantLifecycle: (callback: (payload: McpGrantLifecyclePayload) => void) =>
       _typedOn(CHANNELS.MCP_GRANT_LIFECYCLE, callback),
+    onToolCallStarted: (callback: (payload: McpToolCallStartedPayload) => void) =>
+      _typedOn(CHANNELS.MCP_TOOL_CALL_STARTED, callback),
+    onToolCallSettled: (callback: (payload: McpToolCallSettledPayload) => void) =>
+      _typedOn(CHANNELS.MCP_TOOL_CALL_SETTLED, callback),
   },
 
   helpAssistant: buildHelpAssistantPreloadBindings(_unwrappingInvoke),

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -1181,6 +1181,41 @@ describe("CallTool live activity notifications (#9759)", () => {
     expect(started).toHaveBeenCalledWith(expect.objectContaining({ danger: true }));
   });
 
+  it("emits started (danger:false) + settled for the waitUntilIdle short-circuit", async () => {
+    const started = vi.fn();
+    const settled = vi.fn();
+    const handleWaitUntilIdle = vi.fn().mockResolvedValue({
+      idleReason: "idle" as const,
+      durationMs: 10,
+      finalState: "idle",
+    });
+    const deps = fakeDeps({
+      // waitUntilIdle is in ACTION_TIER_ADDONS — use an action-tier session so
+      // the call clears the tier floor and reaches the dispatch path.
+      sessionStore: fakeSessionStore("action"),
+      notifyToolCallStarted: started,
+      notifyToolCallSettled: settled,
+      handleWaitUntilIdle,
+    });
+    const server = createSessionServer("session-W", deps);
+    await server.connect(makeMockTransport());
+
+    await callTool(server, {
+      name: "terminal.waitUntilIdle",
+      arguments: { terminalId: "t1", timeoutMs: 10 },
+    });
+
+    expect(started).toHaveBeenCalledWith(
+      expect.objectContaining({ toolId: "terminal.waitUntilIdle", danger: false })
+    );
+    expect(settled).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolId: "terminal.waitUntilIdle",
+        outcome: expect.objectContaining({ kind: "result" }),
+      })
+    );
+  });
+
   it("survives a notifyToolCallStarted throw without failing the dispatch", async () => {
     const started = vi.fn(() => {
       throw new Error("boom");

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -1094,6 +1094,110 @@ describe("sessionServer tier-mismatch notifier", () => {
   });
 });
 
+describe("CallTool live activity notifications (#9759)", () => {
+  it("emits started then settled for a permitted dispatch", async () => {
+    const started = vi.fn();
+    const settled = vi.fn();
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
+    const deps = fakeDeps({
+      notifyToolCallStarted: started,
+      notifyToolCallSettled: settled,
+      dispatchAction,
+    });
+    const server = createSessionServer("session-A", deps);
+    await server.connect(makeMockTransport());
+
+    await callTool(server, { name: "worktree.list", arguments: {} });
+
+    expect(started).toHaveBeenCalledTimes(1);
+    expect(started).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: "session-A", toolId: "worktree.list", danger: false })
+    );
+    expect(settled).toHaveBeenCalledTimes(1);
+    expect(settled).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "session-A",
+        toolId: "worktree.list",
+        outcome: expect.objectContaining({ kind: "result" }),
+      })
+    );
+    // Started must precede settled.
+    expect(started.mock.invocationCallOrder[0]).toBeLessThan(settled.mock.invocationCallOrder[0]);
+  });
+
+  it("does not emit started/settled for a pre-dispatch tier rejection", async () => {
+    const started = vi.fn();
+    const settled = vi.fn();
+    const deps = fakeDeps({ notifyToolCallStarted: started, notifyToolCallSettled: settled });
+    const server = createSessionServer("session-B", deps);
+    await server.connect(makeMockTransport());
+
+    // worktree.delete is system-tier — denied at the default workbench tier.
+    await callTool(server, { name: "worktree.delete", arguments: {} });
+
+    expect(started).not.toHaveBeenCalled();
+    expect(settled).not.toHaveBeenCalled();
+  });
+
+  it("does not emit started/settled for a rate-limited rejection", async () => {
+    const started = vi.fn();
+    const settled = vi.fn();
+    const sessionStore = fakeSessionStore("workbench");
+    (sessionStore.consumeRateLimitToken as ReturnType<typeof vi.fn>).mockReturnValue({
+      allowed: false,
+      retryAfter: 5,
+    });
+    const deps = fakeDeps({
+      sessionStore,
+      notifyToolCallStarted: started,
+      notifyToolCallSettled: settled,
+    });
+    const server = createSessionServer("session-C", deps);
+    await server.connect(makeMockTransport());
+
+    await callTool(server, { name: "worktree.list", arguments: {} });
+
+    expect(started).not.toHaveBeenCalled();
+    expect(settled).not.toHaveBeenCalled();
+  });
+
+  it('flags danger:"confirm" tools on the started event', async () => {
+    const started = vi.fn();
+    const requestManifest = vi
+      .fn()
+      .mockResolvedValue([
+        { id: "worktree.list", title: "List", description: "d", danger: "confirm" },
+      ]);
+    const deps = fakeDeps({
+      notifyToolCallStarted: started,
+      requestManifest,
+      dispatchAction: vi.fn().mockResolvedValue({ result: { ok: true, result: null } }),
+    });
+    const server = createSessionServer("session-D", deps);
+    await server.connect(makeMockTransport());
+
+    await callTool(server, { name: "worktree.list", arguments: {} });
+
+    expect(started).toHaveBeenCalledWith(expect.objectContaining({ danger: true }));
+  });
+
+  it("survives a notifyToolCallStarted throw without failing the dispatch", async () => {
+    const started = vi.fn(() => {
+      throw new Error("boom");
+    });
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: null } });
+    const deps = fakeDeps({ notifyToolCallStarted: started, dispatchAction });
+    const server = createSessionServer("session-E", deps);
+    await server.connect(makeMockTransport());
+
+    const result = (await callTool(server, { name: "worktree.list", arguments: {} })) as {
+      isError?: boolean;
+    };
+    expect(result.isError).toBeFalsy();
+    expect(dispatchAction).toHaveBeenCalled();
+  });
+});
+
 describe("CallTool error envelope (integration through sessionServer)", () => {
   async function callTool(
     server: ReturnType<typeof createSessionServer>,

--- a/electron/services/mcp-server/auditLog.ts
+++ b/electron/services/mcp-server/auditLog.ts
@@ -123,27 +123,7 @@ export class AuditService {
     result: McpAuditResult;
     errorCode?: string;
   } {
-    if (outcome.kind === "throw") {
-      return { result: "error", errorCode: "DISPATCH_THREW" };
-    }
-    if (outcome.kind === "unauthorized") {
-      return { result: "unauthorized", errorCode: TIER_NOT_PERMITTED_CODE };
-    }
-    if (outcome.kind === "dedup") {
-      return { result: "dedup" };
-    }
-    if (outcome.kind === "collision") {
-      return { result: "collision", errorCode: MCP_DEDUP_KEY_COLLISION_CODE };
-    }
-    if (outcome.kind === "rate_limited") {
-      return { result: "rate_limited", errorCode: MCP_RATE_LIMITED_CODE };
-    }
-    const value = outcome.value;
-    if (value.ok) return { result: "success" };
-    if (value.error.code === CONFIRMATION_REQUIRED_CODE) {
-      return { result: "confirmation-pending", errorCode: value.error.code };
-    }
-    return { result: "error", errorCode: value.error.code };
+    return classifyMcpDispatchResult(outcome);
   }
 
   private deriveConfirmationDecision(
@@ -604,3 +584,36 @@ export type AuditOutcome =
   | { kind: "dedup" }
   | { kind: "collision" }
   | { kind: "rate_limited"; retryAfter: number };
+
+/**
+ * Map a dispatch {@link AuditOutcome} to its persisted `result` class and
+ * optional `errorCode`. Shared between the audit-record writer and the live
+ * tool-activity push (#9759) so the activity strip's glyph/severity matches
+ * exactly what the audit log records for the same dispatch.
+ */
+export function classifyMcpDispatchResult(outcome: AuditOutcome): {
+  result: McpAuditResult;
+  errorCode?: string;
+} {
+  if (outcome.kind === "throw") {
+    return { result: "error", errorCode: "DISPATCH_THREW" };
+  }
+  if (outcome.kind === "unauthorized") {
+    return { result: "unauthorized", errorCode: TIER_NOT_PERMITTED_CODE };
+  }
+  if (outcome.kind === "dedup") {
+    return { result: "dedup" };
+  }
+  if (outcome.kind === "collision") {
+    return { result: "collision", errorCode: MCP_DEDUP_KEY_COLLISION_CODE };
+  }
+  if (outcome.kind === "rate_limited") {
+    return { result: "rate_limited", errorCode: MCP_RATE_LIMITED_CODE };
+  }
+  const value = outcome.value;
+  if (value.ok) return { result: "success" };
+  if (value.error.code === CONFIRMATION_REQUIRED_CODE) {
+    return { result: "confirmation-pending", errorCode: value.error.code };
+  }
+  return { result: "error", errorCode: value.error.code };
+}

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -34,6 +34,8 @@ import {
 import { createSessionServer, cleanupResourceSubscriptions } from "./sessionServer.js";
 import type { SessionStore } from "./sessionStore.js";
 import type { AuditService } from "./auditLog.js";
+import { classifyMcpDispatchResult } from "./auditLog.js";
+import { computeMcpAuditSeverity } from "../../../shared/types/ipc/mcpServer.js";
 import type { TurnOutcomeService } from "./turnOutcomeLog.js";
 import type { AbusePolicy } from "./abusePolicy.js";
 import {
@@ -1176,6 +1178,58 @@ export class HttpLifecycle {
         }
       };
 
+    const notifyToolCallStarted: import("./sessionServer.js").SessionServerDeps["notifyToolCallStarted"] =
+      (payload) => {
+        // Help-session bearers only — targeted at the pinned WebContents so the
+        // assistant panel that triggered the call gets the live activity event,
+        // even if a different project view is focused. External/api-key sessions
+        // have no panel to show the strip, so the map lookup no-ops for them.
+        const id = this.deps.sessionStore.sessionWebContentsMap.get(payload.sessionId);
+        if (id === undefined) return;
+        const wc = webContentsModule.fromId(id);
+        if (!wc || wc.isDestroyed()) return;
+        // Redact args with the same pipeline the audit record uses so the strip
+        // never shows raw bearer tokens or absolute paths (#9759).
+        const turnId = this.deps.turnOutcomeService.getCurrentTurnIdForSession(payload.sessionId);
+        try {
+          wc.send(CHANNELS.MCP_TOOL_CALL_STARTED, {
+            sessionId: payload.sessionId,
+            toolId: payload.toolId,
+            argsSummary: summarizeMcpArgs(payload.args, (s) => scrubSecrets(sanitizePath(s))),
+            startedAt: payload.startedAt,
+            danger: payload.danger,
+            ...(turnId !== null ? { turnId } : {}),
+          });
+        } catch (err) {
+          console.error("[MCP] tool-call-started send failed:", err);
+        }
+      };
+
+    const notifyToolCallSettled: import("./sessionServer.js").SessionServerDeps["notifyToolCallSettled"] =
+      (payload) => {
+        const id = this.deps.sessionStore.sessionWebContentsMap.get(payload.sessionId);
+        if (id === undefined) return;
+        const wc = webContentsModule.fromId(id);
+        if (!wc || wc.isDestroyed()) return;
+        // Derive result/errorCode/severity from the same classifier the audit
+        // writer uses, so the strip's glyph and red-tint match the audit log.
+        const { result, errorCode } = classifyMcpDispatchResult(payload.outcome);
+        const turnId = this.deps.turnOutcomeService.getCurrentTurnIdForSession(payload.sessionId);
+        try {
+          wc.send(CHANNELS.MCP_TOOL_CALL_SETTLED, {
+            sessionId: payload.sessionId,
+            toolId: payload.toolId,
+            durationMs: Math.max(0, Math.round(payload.durationMs)),
+            result,
+            ...(errorCode !== undefined ? { errorCode } : {}),
+            severity: computeMcpAuditSeverity(result, errorCode),
+            ...(turnId !== null ? { turnId } : {}),
+          });
+        } catch (err) {
+          console.error("[MCP] tool-call-settled send failed:", err);
+        }
+      };
+
     return {
       sessionStore: this.deps.sessionStore,
       requestManifest,
@@ -1201,6 +1255,8 @@ export class HttpLifecycle {
       clearDenialState: (sessionId) => {
         this.deps.abusePolicy.dropSession(sessionId);
       },
+      notifyToolCallStarted,
+      notifyToolCallSettled,
     };
   }
 

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -447,9 +447,9 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     let toolCallStartedEmitted = false;
     const emitToolCallStarted = (danger: boolean): void => {
       if (!notifyToolCallStarted) return;
-      toolCallStartedEmitted = true;
       try {
         notifyToolCallStarted({ sessionId, toolId: actionId, args, startedAt, danger });
+        toolCallStartedEmitted = true;
       } catch (err) {
         console.error("[MCP] Failed to notify tool-call-started:", err);
       }
@@ -608,13 +608,16 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
         });
       } finally {
         const settledOutcome = outcome ?? { kind: "throw" as const, error: new Error("unknown") };
+        // Compute the duration once so the audit record and the live strip
+        // report the same wall-clock, not two reads a few µs apart (#9759).
+        const durationMs = Date.now() - startedAt;
         try {
           appendAuditRecord({
             toolId: actionId,
             sessionId,
             tier,
             args,
-            durationMs: Date.now() - startedAt,
+            durationMs,
             outcome: settledOutcome,
             confirmationDecision,
           });
@@ -622,14 +625,14 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
           console.error("[MCP] Failed to append audit record:", err);
         }
         // Settle the live activity strip for the matching started push. Guarded
-        // so a dispatch that never announced (impossible today, but cheap
-        // insurance) can't emit a dangling settle (#9759).
+        // so a dispatch that never announced (pre-dispatch rejection, or a
+        // started-notify that threw) can't emit a dangling settle (#9759).
         if (toolCallStartedEmitted && notifyToolCallSettled) {
           try {
             notifyToolCallSettled({
               sessionId,
               toolId: actionId,
-              durationMs: Date.now() - startedAt,
+              durationMs,
               outcome: settledOutcome,
             });
           } catch (err) {

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -143,6 +143,34 @@ export interface SessionServerDeps {
    * doesn't inherit stale counters. Called after revokeSession and drain().
    */
   clearDenialState?: (sessionId: string) => void;
+  /**
+   * Optional renderer notifier fired when an MCP tool dispatch enters the call
+   * path (after tier/rate/dedup guards pass and the manifest entry resolves).
+   * Drives the Assistant panel's live activity strip (#9759). Implemented by
+   * httpLifecycle for help-session bearers (pinned WebContents) — it computes
+   * the redacted `argsSummary` and resolves the `turnId` before the targeted
+   * send. Absent for external/api-key sessions, which have no associated UI.
+   */
+  notifyToolCallStarted?: (payload: {
+    sessionId: string;
+    toolId: string;
+    args: unknown;
+    startedAt: number;
+    /** True when the resolved manifest entry is `danger: "confirm"`. */
+    danger: boolean;
+  }) => void;
+  /**
+   * Optional renderer notifier fired when a dispatch announced via
+   * {@link SessionServerDeps.notifyToolCallStarted} settles. Receives the same
+   * `AuditOutcome` the audit record is written from so the strip's result glyph
+   * and severity match the audit log exactly (#9759).
+   */
+  notifyToolCallSettled?: (payload: {
+    sessionId: string;
+    toolId: string;
+    durationMs: number;
+    outcome: AuditOutcome;
+  }) => void;
 }
 
 export function createSessionServer(sessionId: string, deps: SessionServerDeps): Server {
@@ -158,6 +186,8 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     recordDenial,
     notifySessionRevoked,
     clearDenialState,
+    notifyToolCallStarted,
+    notifyToolCallSettled,
   } = deps;
 
   const server = new Server(
@@ -410,6 +440,20 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
       | import("../../../shared/types/ipc/mcpServer.js").McpConfirmationDecision
       | undefined;
     let dispatchConfirmed = false;
+    // Tracks whether a live "tool-call-started" push fired for this dispatch so
+    // the shared `finally` only emits the matching "settled" push for calls the
+    // activity strip is actually showing (#9759). Pre-dispatch rejections never
+    // reach the IIFE, so they never set this — and never settle the strip.
+    let toolCallStartedEmitted = false;
+    const emitToolCallStarted = (danger: boolean): void => {
+      if (!notifyToolCallStarted) return;
+      toolCallStartedEmitted = true;
+      try {
+        notifyToolCallStarted({ sessionId, toolId: actionId, args, startedAt, danger });
+      } catch (err) {
+        console.error("[MCP] Failed to notify tool-call-started:", err);
+      }
+    };
 
     // Wrapped in an inner IIFE so the dedup guard below can register this
     // Promise in `dedupInFlight` (singleflight) and attach a `.then()` cache
@@ -423,6 +467,9 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
         // for the multi-hour waits external sessions may request. Audit unifies
         // via the shared finally.
         if (actionId === TERMINAL_WAIT_UNTIL_IDLE_TOOL) {
+          // waitUntilIdle is never `danger: "confirm"` — it's a passive wait,
+          // so the strip shows a plain in-flight row (no "awaiting confirmation").
+          emitToolCallStarted(false);
           try {
             // Interactive help sessions (workbench/action/system tiers) have a
             // human waiting on the conversation — a tool call held open blocks
@@ -466,6 +513,10 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
         }
 
         const entry = await lookupManifestEntry(actionId, getCachedManifest, requestManifest);
+        // Announce the in-flight call now that `danger` is known — before any
+        // elicitation await, so the strip can show "awaiting confirmation"
+        // while the user decides on a `danger: "confirm"` dispatch (#9759).
+        emitToolCallStarted(entry?.danger === "confirm");
         if (!dispatchConfirmed && entry?.danger === "confirm") {
           const supportsForm = server.getClientCapabilities()?.elicitation?.form !== undefined;
           if (supportsForm) {
@@ -556,6 +607,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
           details: outcome.value.error.details,
         });
       } finally {
+        const settledOutcome = outcome ?? { kind: "throw" as const, error: new Error("unknown") };
         try {
           appendAuditRecord({
             toolId: actionId,
@@ -563,11 +615,26 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
             tier,
             args,
             durationMs: Date.now() - startedAt,
-            outcome: outcome ?? { kind: "throw", error: new Error("unknown") },
+            outcome: settledOutcome,
             confirmationDecision,
           });
         } catch (err) {
           console.error("[MCP] Failed to append audit record:", err);
+        }
+        // Settle the live activity strip for the matching started push. Guarded
+        // so a dispatch that never announced (impossible today, but cheap
+        // insurance) can't emit a dangling settle (#9759).
+        if (toolCallStartedEmitted && notifyToolCallSettled) {
+          try {
+            notifyToolCallSettled({
+              sessionId,
+              toolId: actionId,
+              durationMs: Date.now() - startedAt,
+              outcome: settledOutcome,
+            });
+          } catch (err) {
+            console.error("[MCP] Failed to notify tool-call-settled:", err);
+          }
         }
       }
     })();

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1422,6 +1422,20 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     onGrantLifecycle(
       callback: (payload: import("./mcpServer.js").McpGrantLifecyclePayload) => void
     ): () => void;
+    /**
+     * Subscribe to live tool-call-started pushes for the pinned help-session
+     * in this WebContents. Drives the Assistant panel's activity strip (#9759).
+     */
+    onToolCallStarted(
+      callback: (payload: import("./mcpServer.js").McpToolCallStartedPayload) => void
+    ): () => void;
+    /**
+     * Subscribe to live tool-call-settled pushes that match a prior
+     * `onToolCallStarted` for this WebContents' pinned help-session (#9759).
+     */
+    onToolCallSettled(
+      callback: (payload: import("./mcpServer.js").McpToolCallSettledPayload) => void
+    ): () => void;
   };
   // helpAssistant is generated — see GeneratedElectronAPI.
   mcpBridge: {

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1672,6 +1672,17 @@ export interface IpcEventMap {
    */
   "mcp-server:grant-lifecycle": import("./mcpServer.js").McpGrantLifecyclePayload;
 
+  /**
+   * Targeted push: an MCP tool dispatch entered the call path for the pinned
+   * help-session. Drives the Assistant panel's live activity strip (#9759).
+   */
+  "mcp-server:tool-call-started": import("./mcpServer.js").McpToolCallStartedPayload;
+  /**
+   * Targeted push: an MCP tool dispatch announced via `tool-call-started`
+   * settled. Carries the audit-aligned outcome for the activity strip (#9759).
+   */
+  "mcp-server:tool-call-settled": import("./mcpServer.js").McpToolCallSettledPayload;
+
   // Error events
   "error:notify": ErrorRecord;
   "error:retry-progress": RetryProgressPayload;

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -242,6 +242,45 @@ export interface McpGrantLifecyclePayload {
 }
 
 /**
+ * Live event marking the start of an MCP tool dispatch, pushed to the pinned
+ * help-session renderer so the Assistant panel can show an in-flight activity
+ * strip (#9759). Emitted once per dispatch that actually enters the call path,
+ * after the manifest entry is resolved (so `danger` is known) and before any
+ * elicitation await. Pre-dispatch rejections (unauthorized, rate-limited,
+ * dedup) do not emit — they settle in microseconds and would only flicker the
+ * strip. Send is targeted to the minting WebContents, never broadcast.
+ *
+ * `argsSummary` is the same redacted single-level view persisted on
+ * {@link McpAuditRecord} — raw argument values never cross the bridge.
+ * `danger` is true when the resolved manifest entry is `danger: "confirm"`,
+ * letting the strip show "awaiting confirmation" while the user decides.
+ */
+export interface McpToolCallStartedPayload {
+  sessionId: string;
+  toolId: string;
+  argsSummary: string;
+  startedAt: number;
+  turnId?: string;
+  danger: boolean;
+}
+
+/**
+ * Live event marking the settlement of an MCP tool dispatch previously
+ * announced by {@link McpToolCallStartedPayload}. Carries the audit-aligned
+ * outcome fields so the activity strip can dim to a result glyph, show the
+ * duration, and tint red on error. Send is targeted, never broadcast.
+ */
+export interface McpToolCallSettledPayload {
+  sessionId: string;
+  toolId: string;
+  durationMs: number;
+  result: McpAuditResult;
+  errorCode?: string;
+  severity: McpAuditSeverity;
+  turnId?: string;
+}
+
+/**
  * Result of a renderer-driven `revokeSessionGrants` IPC. The handler
  * deletes every grant for the named session and reports how many entries
  * were affected — useful for UI confirmation copy ("Revoked N grants").

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -24,6 +24,7 @@ import { HelpPanelHeader } from "./HelpPanelHeader";
 import { HelpPanelBanners } from "./HelpPanelBanners";
 import { HelpPanelVersionGate } from "./HelpPanelVersionGate";
 import { HelpLaunchingState } from "./HelpLaunchingState";
+import { McpToolActivityStrip } from "./McpToolActivityStrip";
 import {
   useHelpPanelStore,
   HELP_PANEL_MIN_WIDTH,
@@ -840,6 +841,7 @@ export function HelpPanel({
       {/* Bottom info bar */}
       {showTerminal && agentConfig && !isMissingCli && (
         <div className="flex flex-col gap-1 border-t border-daintree-border shrink-0 px-3 py-1.5 text-[11px] text-daintree-text/40">
+          {session.mcpActivity && <McpToolActivityStrip activity={session.mcpActivity} />}
           {pinnedContext && (
             <span
               className="flex items-center gap-1.5 min-w-0"

--- a/src/components/HelpPanel/McpToolActivityStrip.tsx
+++ b/src/components/HelpPanel/McpToolActivityStrip.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useRef, useState } from "react";
+import { Check, CircleSlash, Loader2, TriangleAlert, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import type { McpToolActivityState } from "@/controllers/HelpSessionController";
+
+/** Cadence of the in-flight elapsed-timer tick — one second of resolution is plenty for an ambient strip. */
+const ELAPSED_TICK_MS = 1000;
+
+/**
+ * Ambient single-line strip in the Assistant panel's info bar showing the
+ * live MCP tool call (#9759). In-flight: tool id + args + an elapsed timer.
+ * Settled: dimmed glyph + duration, red when errored. Tier-1 ambient chrome —
+ * no accent color, 150ms state transition.
+ *
+ * Doherty gate: the animated in-flight row is withheld for the first 400ms so a
+ * sub-400ms call settles first and renders its settled state directly, never
+ * flickering the spinner ("<400ms: show nothing"). The elapsed timer mutates
+ * the DOM directly via a ref so its per-second tick never re-renders the panel.
+ */
+export function McpToolActivityStrip({ activity }: { activity: McpToolActivityState }) {
+  const inFlight = activity.status === "in-flight";
+  // Stable identity for the current row: a coalesced burst shares its turnId,
+  // so the gate isn't re-armed (and the row isn't re-hidden) on each new call
+  // within the turn. Non-coalescing calls fall back to their start timestamp.
+  const rowKey = activity.turnId ?? String(activity.startedAt);
+  const [shownKey, setShownKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!inFlight || shownKey === rowKey) return;
+    const id = setTimeout(() => setShownKey(rowKey), UI_DOHERTY_THRESHOLD);
+    return () => clearTimeout(id);
+  }, [inFlight, rowKey, shownKey]);
+
+  // Sub-400ms in-flight: show nothing until it either crosses the gate or
+  // settles (settled rows always render).
+  if (inFlight && shownKey !== rowKey) return null;
+
+  // A settled call under the Doherty threshold never animated in, so it must
+  // not fade on settle either — render its resting state directly.
+  const skipTransition =
+    activity.status === "settled" &&
+    activity.durationMs !== undefined &&
+    activity.durationMs < UI_DOHERTY_THRESHOLD;
+
+  const coalesced = activity.callCount > 1;
+  const label = coalesced ? `${activity.callCount} calls · ${activity.toolId}` : activity.toolId;
+
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-1.5 min-w-0",
+        !skipTransition && "transition-colors duration-150",
+        activity.isError
+          ? "text-status-danger"
+          : inFlight
+            ? "text-daintree-text/55"
+            : "text-daintree-text/30"
+      )}
+      title={buildTitle(activity)}
+    >
+      <ActivityGlyph activity={activity} inFlight={inFlight} />
+      {/* Tool id wins the row — never truncates. */}
+      <span className="shrink-0 font-medium truncate max-w-[60%]">{label}</span>
+      {activity.danger && inFlight ? (
+        <span className="shrink-0">awaiting confirmation</span>
+      ) : (
+        !coalesced &&
+        activity.argsSummary &&
+        activity.argsSummary !== "{}" && (
+          // Args truncate first when the row is tight.
+          <span className="truncate min-w-0 opacity-80">{activity.argsSummary}</span>
+        )
+      )}
+      <TrailingMetric activity={activity} inFlight={inFlight} />
+    </span>
+  );
+}
+
+function ActivityGlyph({
+  activity,
+  inFlight,
+}: {
+  activity: McpToolActivityState;
+  inFlight: boolean;
+}) {
+  if (inFlight) {
+    return <Loader2 aria-hidden className="w-3 h-3 shrink-0 animate-spin" />;
+  }
+  if (activity.isError) {
+    return <X aria-hidden className="w-3 h-3 shrink-0" />;
+  }
+  if (activity.result === "unauthorized" || activity.result === "rate_limited") {
+    return <CircleSlash aria-hidden className="w-3 h-3 shrink-0" />;
+  }
+  if (activity.severity === "warning" || activity.severity === "notice") {
+    return <TriangleAlert aria-hidden className="w-3 h-3 shrink-0" />;
+  }
+  return <Check aria-hidden className="w-3 h-3 shrink-0" />;
+}
+
+/**
+ * The right-aligned metric: a live elapsed timer while in-flight, the final
+ * duration once settled. The elapsed value is written straight to the DOM node
+ * on a 1s interval — `startedAt` is read once at mount, so the closure stays
+ * stable and the tick never triggers a React render.
+ */
+function TrailingMetric({
+  activity,
+  inFlight,
+}: {
+  activity: McpToolActivityState;
+  inFlight: boolean;
+}) {
+  const elapsedRef = useRef<HTMLSpanElement>(null);
+  const startedAt = activity.startedAt;
+
+  useEffect(() => {
+    if (!inFlight) return;
+    const node = elapsedRef.current;
+    if (!node) return;
+    const tick = () => {
+      node.textContent = formatElapsed(Date.now() - startedAt);
+    };
+    tick();
+    const id = setInterval(tick, ELAPSED_TICK_MS);
+    return () => clearInterval(id);
+  }, [inFlight, startedAt]);
+
+  if (inFlight) {
+    // The "awaiting confirmation" state has no meaningful elapsed wait to show.
+    if (activity.danger) return null;
+    return (
+      <span ref={elapsedRef} className="shrink-0 ml-auto tabular-nums">
+        {formatElapsed(Math.max(0, Date.now() - startedAt))}
+      </span>
+    );
+  }
+
+  if (activity.durationMs === undefined) return null;
+  return (
+    <span className="shrink-0 ml-auto tabular-nums">{formatDuration(activity.durationMs)}</span>
+  );
+}
+
+function buildTitle(activity: McpToolActivityState): string {
+  const parts: string[] = [activity.toolId];
+  if (activity.callCount > 1) parts.push(`${activity.callCount} calls this turn`);
+  if (activity.argsSummary && activity.argsSummary !== "{}") parts.push(activity.argsSummary);
+  if (activity.status === "settled" && activity.result) parts.push(activity.result);
+  return parts.join(" — ");
+}
+
+/** Elapsed wall-clock for an in-flight call: `0s`, `12s`, `3m 04s`. */
+function formatElapsed(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
+}
+
+/** Settled duration: sub-second as `840ms`, else reuse the elapsed format. */
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return formatElapsed(ms);
+}

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -488,6 +488,8 @@ beforeEach(() => {
         },
         mcpServer: {
           onTierNotPermitted: vi.fn(() => () => {}),
+          onToolCallStarted: vi.fn(() => () => {}),
+          onToolCallSettled: vi.fn(() => () => {}),
           setSessionTier: vi.fn().mockResolvedValue({ sessionId: "", tier: "workbench" }),
           issueGrant: vi.fn().mockResolvedValue({
             sessionId: "",

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -416,6 +416,8 @@ beforeEach(() => {
         },
         mcpServer: {
           onTierNotPermitted: vi.fn(() => () => {}),
+          onToolCallStarted: vi.fn(() => () => {}),
+          onToolCallSettled: vi.fn(() => () => {}),
           setSessionTier: vi.fn().mockResolvedValue({ sessionId: "", tier: "workbench" }),
           issueGrant: vi.fn().mockResolvedValue({
             sessionId: "",

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -85,6 +85,38 @@ export interface LaunchErrorState {
   kind: LaunchErrorKind;
 }
 
+/**
+ * Live MCP tool-call activity for the Assistant panel's ambient activity strip
+ * (#9759). One row at a time: an in-flight call (tool id + args + elapsed) that
+ * settles to a dimmed glyph + duration. Bursts within the same turn coalesce to
+ * `callCount` ("N calls · latest tool"). `null` when no call has happened yet
+ * (the strip is absent). An errored settle persists until the next call starts.
+ */
+export interface McpToolActivityState {
+  /** "in-flight" while the call runs; "settled" once it resolves. */
+  status: "in-flight" | "settled";
+  /** The latest tool in the (possibly coalesced) burst. */
+  toolId: string;
+  /** Redacted single-line args summary for the latest call. */
+  argsSummary: string;
+  /** Epoch ms the latest call started — drives the elapsed timer. */
+  startedAt: number;
+  /** True when the latest in-flight call is a `danger: "confirm"` dispatch awaiting the user. */
+  danger: boolean;
+  /** Number of calls coalesced within the current turn (1 for a single call). */
+  callCount: number;
+  /** Turn the burst is coalesced under; absent for calls outside a turn boundary. */
+  turnId?: string;
+  /** Settled wall-clock duration in ms. Absent while in-flight. */
+  durationMs?: number;
+  /** Audit-aligned result class. Absent while in-flight. */
+  result?: import("@shared/types/ipc/mcpServer").McpAuditResult;
+  /** Audit-aligned severity. Absent while in-flight. */
+  severity?: import("@shared/types/ipc/mcpServer").McpAuditSeverity;
+  /** True when the settled outcome is an error/critical severity (red tint, persists). */
+  isError: boolean;
+}
+
 export interface HelpSessionSnapshot {
   phase: HelpSessionPhase;
   showResumeBanner: boolean;
@@ -99,6 +131,8 @@ export interface HelpSessionSnapshot {
    */
   isCheckingVersion: boolean;
   launchError: LaunchErrorState | null;
+  /** Live MCP tool-call activity for the ambient strip (#9759); null when idle. */
+  mcpActivity: McpToolActivityState | null;
 }
 
 export interface HelpProjectRef {
@@ -378,6 +412,7 @@ const INITIAL_SNAPSHOT: HelpSessionSnapshot = Object.freeze({
   isApprovingTier: false,
   isCheckingVersion: false,
   launchError: null,
+  mcpActivity: null,
 });
 
 /**
@@ -475,6 +510,14 @@ export class HelpSessionController {
     });
     this._disposers.push(disposeTier);
 
+    const disposeToolStarted = window.electron.mcpServer.onToolCallStarted((payload) => {
+      this._onToolCallStarted(payload);
+    });
+    const disposeToolSettled = window.electron.mcpServer.onToolCallSettled((payload) => {
+      this._onToolCallSettled(payload);
+    });
+    this._disposers.push(disposeToolStarted, disposeToolSettled);
+
     const offSuspend = window.electron.systemSleep.onSuspend(() => {
       this._isSystemSuspended = true;
     });
@@ -565,6 +608,9 @@ export class HelpSessionController {
     revokeHelpSession(store.sessionId);
     this._hasAutoLaunched = false;
     store.clearTerminal();
+    // The bound session is gone — drop any lingering activity row so the strip
+    // doesn't show stale tool calls for a dead session (#9759).
+    this.clearMcpActivity();
   }
 
   /**
@@ -705,6 +751,8 @@ export class HelpSessionController {
         revokeHelpSession(previousSessionId);
         if (reservedId) this._revokePendingSession();
         useHelpPanelStore.getState().clearTerminal();
+        // Replacing the session — clear the prior session's activity row (#9759).
+        this.clearMcpActivity();
       }
       // Discarding the current conversation invalidates any persisted
       // hibernate entry for this project — leaving it would resume the
@@ -951,6 +999,71 @@ export class HelpSessionController {
     }
   }
 
+  /**
+   * Handle a live `tool-call-started` push (#9759). Coalesces bursts within
+   * the same turn into a single row ("N calls · latest tool") and clears any
+   * lingering errored row — a new call always supersedes the previous result.
+   */
+  private _onToolCallStarted(
+    payload: import("@shared/types/ipc/mcpServer").McpToolCallStartedPayload
+  ): void {
+    const prev = this._snapshot.mcpActivity;
+    // Coalesce only within the same turn: a burst of calls the model fires in
+    // one turn collapses to a count, but a new turn starts a fresh row. Calls
+    // outside a turn boundary (`turnId` absent) never coalesce — last wins.
+    const sameTurn =
+      prev !== null &&
+      payload.turnId !== undefined &&
+      prev.turnId !== undefined &&
+      prev.turnId === payload.turnId;
+    const callCount = sameTurn && prev ? prev.callCount + 1 : 1;
+    this._patch({
+      mcpActivity: {
+        status: "in-flight",
+        toolId: payload.toolId,
+        argsSummary: payload.argsSummary,
+        startedAt: payload.startedAt,
+        danger: payload.danger,
+        callCount,
+        ...(payload.turnId !== undefined ? { turnId: payload.turnId } : {}),
+        isError: false,
+      },
+    });
+  }
+
+  /**
+   * Handle a live `tool-call-settled` push (#9759). Transitions the current
+   * in-flight row to its settled (dimmed glyph + duration) appearance. A push
+   * with no current row is ignored — there's nothing on screen to settle.
+   */
+  private _onToolCallSettled(
+    payload: import("@shared/types/ipc/mcpServer").McpToolCallSettledPayload
+  ): void {
+    const prev = this._snapshot.mcpActivity;
+    if (prev === null) return;
+    const isError = payload.severity === "error" || payload.severity === "critical";
+    this._patch({
+      mcpActivity: {
+        ...prev,
+        status: "settled",
+        // Reflect the settled call's tool so the glyph labels the right call
+        // even when a burst's latest started differs from what just settled.
+        toolId: payload.toolId,
+        danger: false,
+        durationMs: payload.durationMs,
+        result: payload.result,
+        severity: payload.severity,
+        isError,
+      },
+    });
+  }
+
+  /** Clear the live activity strip (e.g. on session teardown). */
+  clearMcpActivity(): void {
+    if (this._snapshot.mcpActivity === null) return;
+    this._patch({ mcpActivity: null });
+  }
+
   private _patch(partial: Partial<HelpSessionSnapshot>): void {
     // Spread-merge first, then structurally compare per-field. Reusing the
     // same snapshot reference when nothing changed keeps Object.is stable
@@ -964,7 +1077,8 @@ export class HelpSessionController {
       next.preflightSnapshot === this._snapshot.preflightSnapshot &&
       next.isApprovingTier === this._snapshot.isApprovingTier &&
       next.isCheckingVersion === this._snapshot.isCheckingVersion &&
-      next.launchError === this._snapshot.launchError
+      next.launchError === this._snapshot.launchError &&
+      next.mcpActivity === this._snapshot.mcpActivity
     ) {
       return;
     }

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -3,17 +3,23 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockMcpOnTierNotPermitted,
+  mockMcpOnToolCallStarted,
+  mockMcpOnToolCallSettled,
   mockMcpSetSessionTier,
   mockMcpIssueGrant,
   mockSystemSleepOnSuspend,
   mockSystemSleepOnWake,
   systemSleepListeners,
   tierListeners,
+  toolStartedListeners,
+  toolSettledListeners,
   helpPanelState,
   panelStoreState,
   projectStoreState,
 } = vi.hoisted(() => ({
   mockMcpOnTierNotPermitted: vi.fn(),
+  mockMcpOnToolCallStarted: vi.fn(),
+  mockMcpOnToolCallSettled: vi.fn(),
   mockMcpSetSessionTier: vi.fn().mockResolvedValue(undefined),
   mockMcpIssueGrant: vi.fn().mockResolvedValue({
     sessionId: "",
@@ -28,6 +34,8 @@ const {
     wake: [] as Array<() => void>,
   },
   tierListeners: [] as Array<(payload: unknown) => void>,
+  toolStartedListeners: [] as Array<(payload: unknown) => void>,
+  toolSettledListeners: [] as Array<(payload: unknown) => void>,
   helpPanelState: {
     isOpen: false,
     terminalId: null as string | null,
@@ -120,6 +128,8 @@ beforeEach(() => {
   systemSleepListeners.suspend.length = 0;
   systemSleepListeners.wake.length = 0;
   tierListeners.length = 0;
+  toolStartedListeners.length = 0;
+  toolSettledListeners.length = 0;
 
   mockMcpOnTierNotPermitted.mockReset();
   mockMcpOnTierNotPermitted.mockImplementation((cb: (payload: unknown) => void) => {
@@ -127,6 +137,22 @@ beforeEach(() => {
     return () => {
       const idx = tierListeners.indexOf(cb);
       if (idx >= 0) tierListeners.splice(idx, 1);
+    };
+  });
+  mockMcpOnToolCallStarted.mockReset();
+  mockMcpOnToolCallStarted.mockImplementation((cb: (payload: unknown) => void) => {
+    toolStartedListeners.push(cb);
+    return () => {
+      const idx = toolStartedListeners.indexOf(cb);
+      if (idx >= 0) toolStartedListeners.splice(idx, 1);
+    };
+  });
+  mockMcpOnToolCallSettled.mockReset();
+  mockMcpOnToolCallSettled.mockImplementation((cb: (payload: unknown) => void) => {
+    toolSettledListeners.push(cb);
+    return () => {
+      const idx = toolSettledListeners.indexOf(cb);
+      if (idx >= 0) toolSettledListeners.splice(idx, 1);
     };
   });
   mockMcpSetSessionTier.mockReset();
@@ -179,6 +205,8 @@ beforeEach(() => {
         },
         mcpServer: {
           onTierNotPermitted: mockMcpOnTierNotPermitted,
+          onToolCallStarted: mockMcpOnToolCallStarted,
+          onToolCallSettled: mockMcpOnToolCallSettled,
           setSessionTier: mockMcpSetSessionTier,
           issueGrant: mockMcpIssueGrant,
         },
@@ -245,6 +273,7 @@ describe("HelpSessionController — subscribe / getSnapshot", () => {
     expect(snap.isApprovingTier).toBe(false);
     expect(snap.isCheckingVersion).toBe(false);
     expect(snap.launchError).toBeNull();
+    expect(snap.mcpActivity).toBeNull();
   });
 
   it("returns the same snapshot reference when no state changes (Object.is stable)", () => {
@@ -892,6 +921,198 @@ describe("HelpSessionController — launch error routing", () => {
 
     ctrl.syncInputs(inputs("codex"));
     expect(ctrl.getSnapshot().launchError).toBeNull();
+    ctrl.stop();
+  });
+});
+
+describe("HelpSessionController — MCP tool activity strip (#9759)", () => {
+  function startCtrl() {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    return ctrl;
+  }
+  const fireStarted = (payload: Record<string, unknown>) => toolStartedListeners[0]!(payload);
+  const fireSettled = (payload: Record<string, unknown>) => toolSettledListeners[0]!(payload);
+
+  it("start() arms the tool-call started/settled subscriptions", () => {
+    const ctrl = startCtrl();
+    expect(mockMcpOnToolCallStarted).toHaveBeenCalledTimes(1);
+    expect(mockMcpOnToolCallSettled).toHaveBeenCalledTimes(1);
+    ctrl.stop();
+  });
+
+  it("a started event populates an in-flight row", () => {
+    const ctrl = startCtrl();
+    fireStarted({
+      sessionId: "s1",
+      toolId: "terminal.list",
+      argsSummary: "{}",
+      startedAt: 1000,
+      danger: false,
+    });
+    const a = ctrl.getSnapshot().mcpActivity;
+    expect(a?.status).toBe("in-flight");
+    expect(a?.toolId).toBe("terminal.list");
+    expect(a?.callCount).toBe(1);
+    expect(a?.isError).toBe(false);
+    ctrl.stop();
+  });
+
+  it("a settled event transitions the row to settled with duration and result", () => {
+    const ctrl = startCtrl();
+    fireStarted({
+      sessionId: "s1",
+      toolId: "terminal.list",
+      argsSummary: "{}",
+      startedAt: 1000,
+      danger: false,
+    });
+    fireSettled({
+      sessionId: "s1",
+      toolId: "terminal.list",
+      durationMs: 1200,
+      result: "success",
+      severity: "info",
+    });
+    const a = ctrl.getSnapshot().mcpActivity;
+    expect(a?.status).toBe("settled");
+    expect(a?.durationMs).toBe(1200);
+    expect(a?.result).toBe("success");
+    expect(a?.isError).toBe(false);
+    ctrl.stop();
+  });
+
+  it("an error-severity settle marks the row as error (red, persists)", () => {
+    const ctrl = startCtrl();
+    fireStarted({ sessionId: "s1", toolId: "x", argsSummary: "{}", startedAt: 1, danger: false });
+    fireSettled({
+      sessionId: "s1",
+      toolId: "x",
+      durationMs: 50,
+      result: "error",
+      severity: "error",
+    });
+    expect(ctrl.getSnapshot().mcpActivity?.isError).toBe(true);
+    ctrl.stop();
+  });
+
+  it("coalesces bursts within the same turn into a single counted row", () => {
+    const ctrl = startCtrl();
+    fireStarted({
+      sessionId: "s1",
+      toolId: "a",
+      argsSummary: "{}",
+      startedAt: 1,
+      danger: false,
+      turnId: "T1",
+    });
+    fireStarted({
+      sessionId: "s1",
+      toolId: "b",
+      argsSummary: "{}",
+      startedAt: 2,
+      danger: false,
+      turnId: "T1",
+    });
+    fireStarted({
+      sessionId: "s1",
+      toolId: "c",
+      argsSummary: "{}",
+      startedAt: 3,
+      danger: false,
+      turnId: "T1",
+    });
+    const a = ctrl.getSnapshot().mcpActivity;
+    expect(a?.callCount).toBe(3);
+    expect(a?.toolId).toBe("c");
+    ctrl.stop();
+  });
+
+  it("a new turn starts a fresh row (no coalescing across turns)", () => {
+    const ctrl = startCtrl();
+    fireStarted({
+      sessionId: "s1",
+      toolId: "a",
+      argsSummary: "{}",
+      startedAt: 1,
+      danger: false,
+      turnId: "T1",
+    });
+    fireStarted({
+      sessionId: "s1",
+      toolId: "b",
+      argsSummary: "{}",
+      startedAt: 2,
+      danger: false,
+      turnId: "T2",
+    });
+    expect(ctrl.getSnapshot().mcpActivity?.callCount).toBe(1);
+    expect(ctrl.getSnapshot().mcpActivity?.toolId).toBe("b");
+    ctrl.stop();
+  });
+
+  it("calls without a turnId never coalesce (last wins)", () => {
+    const ctrl = startCtrl();
+    fireStarted({ sessionId: "s1", toolId: "a", argsSummary: "{}", startedAt: 1, danger: false });
+    fireStarted({ sessionId: "s1", toolId: "b", argsSummary: "{}", startedAt: 2, danger: false });
+    expect(ctrl.getSnapshot().mcpActivity?.callCount).toBe(1);
+    expect(ctrl.getSnapshot().mcpActivity?.toolId).toBe("b");
+    ctrl.stop();
+  });
+
+  it("a new call clears a lingering errored row", () => {
+    const ctrl = startCtrl();
+    fireStarted({ sessionId: "s1", toolId: "x", argsSummary: "{}", startedAt: 1, danger: false });
+    fireSettled({
+      sessionId: "s1",
+      toolId: "x",
+      durationMs: 5,
+      result: "error",
+      severity: "error",
+    });
+    expect(ctrl.getSnapshot().mcpActivity?.isError).toBe(true);
+    fireStarted({ sessionId: "s1", toolId: "y", argsSummary: "{}", startedAt: 2, danger: false });
+    const a = ctrl.getSnapshot().mcpActivity;
+    expect(a?.status).toBe("in-flight");
+    expect(a?.isError).toBe(false);
+    expect(a?.toolId).toBe("y");
+    ctrl.stop();
+  });
+
+  it("carries danger through for an awaiting-confirmation row", () => {
+    const ctrl = startCtrl();
+    fireStarted({
+      sessionId: "s1",
+      toolId: "git.push",
+      argsSummary: "{}",
+      startedAt: 1,
+      danger: true,
+    });
+    expect(ctrl.getSnapshot().mcpActivity?.danger).toBe(true);
+    ctrl.stop();
+  });
+
+  it("a settle with no current row is ignored", () => {
+    const ctrl = startCtrl();
+    fireSettled({
+      sessionId: "s1",
+      toolId: "x",
+      durationMs: 5,
+      result: "success",
+      severity: "info",
+    });
+    expect(ctrl.getSnapshot().mcpActivity).toBeNull();
+    ctrl.stop();
+  });
+
+  it("handleTerminalPanelMissing clears the activity row", () => {
+    const ctrl = startCtrl();
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.sessionId = "sess-1";
+    fireStarted({ sessionId: "s1", toolId: "x", argsSummary: "{}", startedAt: 1, danger: false });
+    expect(ctrl.getSnapshot().mcpActivity).not.toBeNull();
+    ctrl.handleTerminalPanelMissing({ terminalId: "term-1", terminalExists: false });
+    expect(ctrl.getSnapshot().mcpActivity).toBeNull();
     ctrl.stop();
   });
 });

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -247,10 +247,14 @@ describe("HelpSessionController — lifecycle", () => {
     const ctrl = new HelpSessionController();
     ctrl.start();
     expect(tierListeners).toHaveLength(1);
+    expect(toolStartedListeners).toHaveLength(1);
+    expect(toolSettledListeners).toHaveLength(1);
     expect(systemSleepListeners.suspend).toHaveLength(1);
     expect(systemSleepListeners.wake).toHaveLength(1);
     ctrl.stop();
     expect(tierListeners).toHaveLength(0);
+    expect(toolStartedListeners).toHaveLength(0);
+    expect(toolSettledListeners).toHaveLength(0);
     expect(systemSleepListeners.suspend).toHaveLength(0);
     expect(systemSleepListeners.wake).toHaveLength(0);
   });
@@ -1094,6 +1098,22 @@ describe("HelpSessionController — MCP tool activity strip (#9759)", () => {
 
   it("a settle with no current row is ignored", () => {
     const ctrl = startCtrl();
+    fireSettled({
+      sessionId: "s1",
+      toolId: "x",
+      durationMs: 5,
+      result: "success",
+      severity: "info",
+    });
+    expect(ctrl.getSnapshot().mcpActivity).toBeNull();
+    ctrl.stop();
+  });
+
+  it("a settle arriving after clearMcpActivity() does not resurrect a row", () => {
+    const ctrl = startCtrl();
+    fireStarted({ sessionId: "s1", toolId: "x", argsSummary: "{}", startedAt: 1, danger: false });
+    ctrl.clearMcpActivity();
+    expect(ctrl.getSnapshot().mcpActivity).toBeNull();
     fireSettled({
       sessionId: "s1",
       toolId: "x",


### PR DESCRIPTION
## Summary

- Adds a one-line ambient activity strip to the Assistant (HelpPanel) bottom info bar showing live MCP tool calls.
- In-flight: tool id + redacted args summary + elapsed timer. Settled: dimmed glyph + duration. Errors tint red and persist until the next call. Bursts within a turn coalesce to "N calls · latest tool". `danger:"confirm"` shows "awaiting confirmation". Absent when idle.
- 400ms Doherty gate — sub-400ms calls render settled directly, no spinner flicker.

Closes #9759.

## Changes

Two new IPC push channels — `MCP_TOOL_CALL_STARTED` / `MCP_TOOL_CALL_SETTLED` — emitted from the `sessionServer` dispatch path (after manifest lookup so `danger` is known, before elicitation; settled in the `finally`). Sent only to the pinned help-session `WebContents`; never broadcast, so there's no per-subscriber teardown concern.

Renderer state lives in `HelpSessionController`'s snapshot and is consumed via `useSyncExternalStore`. `McpToolActivityStrip` drives the elapsed timer with direct DOM mutation rather than state updates, avoiding re-render storms on fast-ticking calls.

`argsSummary` reuses the existing audit scrubbing pipeline (`scrubSecrets` + `sanitizePath`). `classifyMcpDispatchResult` is extracted from the audit log and shared so the strip and the audit log derive severity from the same logic.

Pre-dispatch rejections (unauthorised, rate-limited, dedup) are skipped — the channel only fires when a call actually reaches the MCP.

## Testing

`HelpSessionController` tests cover coalescing, error-clear, teardown, orphan-settle, and subscription cleanup. `sessionServer` emission tests cover started+settled ordering, pre-dispatch-rejection skip, rate-limit skip, danger flag, `waitUntilIdle` path, and notify-throw resilience. All project checks (`npm run check`) pass.