### PR TITLE
feat(dev-preview): use the agent-terminal spinner for loading states

### DIFF
--- a/src/components/DevPreview/DevPreviewLoadingState.tsx
+++ b/src/components/DevPreview/DevPreviewLoadingState.tsx
@@ -1,5 +1,6 @@
 import { useDohertyGate } from "@/hooks/useDeferredLoading";
-import { SkeletonBone, SkeletonHint } from "@/components/ui/Skeleton";
+import { SkeletonHint } from "@/components/ui/Skeleton";
+import { Spinner } from "@/components/ui/Spinner";
 
 interface DevPreviewLoadingStateProps {
   variant: "full" | "overlay";
@@ -18,39 +19,29 @@ function FullSkeleton({
   isLoading: boolean;
   onCancel?: () => void;
 }) {
-  const showPhaseLabel = useDohertyGate(isLoading);
+  const showSpinner = useDohertyGate(isLoading);
 
   return (
     <div className="relative flex flex-col items-center justify-center h-full bg-daintree-bg px-6">
       <div
-        className="flex flex-col items-center w-full max-w-md"
+        className="flex max-w-[28ch] flex-col items-center gap-3 text-center"
         role="status"
         aria-busy="true"
         aria-label={phaseLabel}
       >
         <span className="sr-only">{phaseLabel}</span>
 
-        <div className="w-full flex flex-col gap-4" aria-hidden="true">
-          <SkeletonBone className="h-3.5 w-3/4" />
-          <div className="space-y-2">
-            <SkeletonBone className="h-3 w-full" />
-            <SkeletonBone className="h-3 w-5/6" />
-            <SkeletonBone className="h-3 w-2/3" />
-          </div>
-          <div className="space-y-2 mt-3">
-            <SkeletonBone className="h-2.5 w-full" />
-            <SkeletonBone className="h-2.5 w-4/5" />
-            <SkeletonBone className="h-2.5 w-3/5" />
-          </div>
-        </div>
-
-        {/* Visible caption only — the role=status wrapper above owns the AT
+        {/* Spinner + visible caption gated by the Doherty threshold. The
+            caption is aria-hidden — the role=status wrapper above owns the AT
             announcement, and an aria-live here would be silenced by its
             aria-busy="true" anyway. The phase also flows through the hint. */}
-        {showPhaseLabel && (
-          <p aria-hidden="true" className="mt-6 text-xs text-daintree-text/60">
-            {phaseLabel}
-          </p>
+        {showSpinner && (
+          <>
+            <Spinner size="xl" className="text-daintree-text/45" />
+            <p aria-hidden="true" className="text-sm text-daintree-text/60 break-words">
+              {phaseLabel}
+            </p>
+          </>
         )}
       </div>
 
@@ -79,7 +70,7 @@ function OverlaySkeleton({
   return (
     <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg">
       <div
-        className="flex flex-col items-center gap-3"
+        className="flex max-w-[28ch] flex-col items-center gap-3 text-center"
         role="status"
         aria-busy="true"
         aria-label={phaseLabel}
@@ -88,7 +79,8 @@ function OverlaySkeleton({
 
         {/* Visible caption only (aria-hidden) — the wrapper owns the AT
             announcement; the phase also flows through the hint. */}
-        <p aria-hidden="true" className="text-xs text-daintree-text/60">
+        <Spinner size="xl" className="text-daintree-text/45" />
+        <p aria-hidden="true" className="text-sm text-daintree-text/60 break-words">
           {phaseLabel}
         </p>
       </div>

--- a/src/components/DevPreview/__tests__/DevPreviewLoadingState.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewLoadingState.test.tsx
@@ -19,11 +19,17 @@ describe("DevPreviewLoadingState", () => {
     });
   }
 
-  it("uses the shared SkeletonBone (animate-pulse-delayed) in the full variant", () => {
+  it("shows a spinner and caption in the full variant once the Doherty gate clears", () => {
     const { container } = render(
       <DevPreviewLoadingState variant="full" isLoading phaseLabel="Installing dependencies" />
     );
-    expect(container.querySelectorAll(".animate-pulse-delayed").length).toBeGreaterThan(0);
+    // Sub-400ms: the status region exists for AT, but no visible spinner yet.
+    expect(container.querySelector('[role="status"]')).toBeTruthy();
+    expect(container.querySelector('[role="status"] svg')).toBeNull();
+    advance(400);
+    expect(container.querySelector('[role="status"] svg')).toBeTruthy();
+    const caption = container.querySelector("p[aria-hidden='true']");
+    expect(caption?.textContent).toBe("Installing dependencies");
   });
 
   it("renders the SkeletonHint live region as a sibling, not nested in role=status", () => {

--- a/src/components/DevPreview/__tests__/DevPreviewLoadingState.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewLoadingState.test.tsx
@@ -3,6 +3,7 @@ import { act, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DevPreviewLoadingState } from "../DevPreviewLoadingState";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 
 describe("DevPreviewLoadingState", () => {
   beforeEach(() => {
@@ -23,13 +24,37 @@ describe("DevPreviewLoadingState", () => {
     const { container } = render(
       <DevPreviewLoadingState variant="full" isLoading phaseLabel="Installing dependencies" />
     );
-    // Sub-400ms: the status region exists for AT, but no visible spinner yet.
+    // Sub-threshold: the status region exists for AT, but no visible spinner yet.
     expect(container.querySelector('[role="status"]')).toBeTruthy();
     expect(container.querySelector('[role="status"] svg')).toBeNull();
-    advance(400);
+    advance(UI_DOHERTY_THRESHOLD);
     expect(container.querySelector('[role="status"] svg')).toBeTruthy();
     const caption = container.querySelector("p[aria-hidden='true']");
     expect(caption?.textContent).toBe("Installing dependencies");
+  });
+
+  it("never shows the spinner when loading resolves before the Doherty gate", () => {
+    const { container, rerender } = render(
+      <DevPreviewLoadingState variant="full" isLoading phaseLabel="Restarting" />
+    );
+    advance(UI_DOHERTY_THRESHOLD / 2);
+    rerender(<DevPreviewLoadingState variant="full" isLoading={false} phaseLabel="Restarting" />);
+    advance(UI_DOHERTY_THRESHOLD * 2);
+    expect(container.querySelector('[role="status"] svg')).toBeNull();
+    expect(container.querySelector("p[aria-hidden='true']")).toBeNull();
+  });
+
+  it("updates the visible caption when the phase label changes mid-load", () => {
+    const { container, rerender } = render(
+      <DevPreviewLoadingState variant="full" isLoading phaseLabel="Starting dev server" />
+    );
+    advance(UI_DOHERTY_THRESHOLD);
+    rerender(
+      <DevPreviewLoadingState variant="full" isLoading phaseLabel="Installing dependencies" />
+    );
+    expect(container.querySelector("p[aria-hidden='true']")?.textContent).toBe(
+      "Installing dependencies"
+    );
   });
 
   it("renders the SkeletonHint live region as a sibling, not nested in role=status", () => {
@@ -45,9 +70,9 @@ describe("DevPreviewLoadingState", () => {
     const { container } = render(
       <DevPreviewLoadingState variant="overlay" isLoading phaseLabel="Rehydrating preview" />
     );
-    // Sub-400ms: nothing rendered (Doherty gate).
+    // Sub-threshold: nothing rendered (Doherty gate).
     expect(container.querySelector("p")).toBeNull();
-    advance(400);
+    advance(UI_DOHERTY_THRESHOLD);
     const caption = container.querySelector("p[aria-hidden='true']");
     expect(caption?.textContent).toBe("Rehydrating preview");
   });
@@ -56,10 +81,13 @@ describe("DevPreviewLoadingState", () => {
     const { container } = render(
       <DevPreviewLoadingState variant="overlay" isLoading phaseLabel="Rehydrating preview" />
     );
-    advance(400);
-    // The only aria-live region is the SkeletonHint sibling, outside role=status.
+    advance(UI_DOHERTY_THRESHOLD);
+    // Every aria-live region lives outside the aria-busy status wrapper, where
+    // it would otherwise be silenced.
     const liveRegions = container.querySelectorAll("[aria-live]");
-    expect(liveRegions.length).toBe(1);
-    expect(liveRegions[0]!.closest('[role="status"]')).toBeNull();
+    expect(liveRegions.length).toBeGreaterThan(0);
+    for (const region of liveRegions) {
+      expect(region.closest('[role="status"]')).toBeNull();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Replaces the skeleton ghost-line loading states in `DevPreviewLoadingState.tsx` with a centered `Spinner` + caption pattern, matching `TerminalStartupPlaceholder`
- Both `FullSkeleton` and `OverlaySkeleton` variants now use `Spinner` size `xl` with an `aria-hidden` caption; the existing `useDohertyGate` 400ms anti-flicker wiring is preserved
- `SkeletonHint` stays outside the `role="status"` wrapper (aria-busy silencing invariant); no explicit `aria-live="polite"` added because `role="status"` implies it

Resolves #9763

## Changes

- `DevPreviewLoadingState.tsx` — both variants rewritten to use `Spinner size="xl"` + caption block; Doherty gate logic unchanged
- `DevPreviewLoadingState.test.tsx` — tests rewritten behaviorally: spinner appears only after the gate, hardcoded `400` replaced with `UI_DOHERTY_THRESHOLD`, live-region count replaced with structural invariant, gate-cancellation and mid-load caption-update coverage added

## Testing

6/6 tests pass. `npm run check` clean.