### PR TITLE
fix(recipes): preserve docked panel placement in clone layout

### DIFF
--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -217,6 +217,8 @@ export interface RecipeTerminal {
   agentModelId?: string;
   /** Process-level launch flags captured at launch (agent types only). Transient — stripped before disk persistence. */
   agentLaunchFlags?: string[];
+  /** Clone-layout placement. Transient — stripped before disk persistence. Only "dock" is captured; absence means grid. */
+  location?: "dock";
 }
 
 /** A saved terminal recipe */

--- a/src/components/Worktree/__tests__/panelSpawning.test.ts
+++ b/src/components/Worktree/__tests__/panelSpawning.test.ts
@@ -459,6 +459,30 @@ describe("spawnPanelsFromRecipe", () => {
     expect(mockSetFocused).toHaveBeenCalledWith("panel-grid");
   });
 
+  it("focuses the last grid panel in a mixed dock/grid interleaving (#9764)", async () => {
+    mockAddPanel
+      .mockResolvedValueOnce("panel-dock-1")
+      .mockResolvedValueOnce("panel-grid-1")
+      .mockResolvedValueOnce("panel-dock-2")
+      .mockResolvedValueOnce("panel-grid-2");
+
+    await spawnPanelsFromRecipe({
+      terminals: [
+        makeTerminal({ title: "D1", location: "dock" }),
+        makeTerminal({ title: "G1" }),
+        makeTerminal({ title: "D2", location: "dock" }),
+        makeTerminal({ title: "G2" }),
+      ],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+    });
+
+    const locations = mockAddPanel.mock.calls.map((c) => (c[0] as { location?: string }).location);
+    expect(locations).toEqual(["dock", undefined, "dock", undefined]);
+    expect(mockSetFocused).toHaveBeenCalledTimes(1);
+    expect(mockSetFocused).toHaveBeenCalledWith("panel-grid-2");
+  });
+
   it("does not steal focus when only dock panels spawn (#9764)", async () => {
     await spawnPanelsFromRecipe({
       terminals: [makeTerminal({ location: "dock" })],

--- a/src/components/Worktree/__tests__/panelSpawning.test.ts
+++ b/src/components/Worktree/__tests__/panelSpawning.test.ts
@@ -413,6 +413,62 @@ describe("spawnPanelsFromRecipe", () => {
     expect(mockFlushSpawnBatch).toHaveBeenCalledTimes(1);
   });
 
+  it("forwards dock location to addPanel for all panel kinds (#9764)", async () => {
+    await spawnPanelsFromRecipe({
+      terminals: [
+        makeTerminal({ location: "dock" }),
+        makeAgent({ location: "dock" }),
+        makeDevPreview({ location: "dock" }),
+      ],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+      agentSettings: { agents: { claude: {} } },
+      clipboardDirectory: "/tmp/daintree/daintree-clipboard",
+    });
+
+    expect(mockAddPanel).toHaveBeenCalledTimes(3);
+    expect(
+      mockAddPanel.mock.calls.every((c) => (c[0] as { location?: string })?.location === "dock")
+    ).toBe(true);
+  });
+
+  it("leaves location undefined for terminals without one (grid default)", async () => {
+    await spawnPanelsFromRecipe({
+      terminals: [makeTerminal()],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+    });
+
+    const call = mockAddPanel.mock.calls[0]?.[0] as { location?: string };
+    expect(call.location).toBeUndefined();
+  });
+
+  it("focuses the last grid panel, skipping dock panels (#9764)", async () => {
+    mockAddPanel.mockResolvedValueOnce("panel-grid").mockResolvedValueOnce("panel-dock");
+
+    await spawnPanelsFromRecipe({
+      terminals: [
+        makeTerminal({ title: "Grid" }),
+        makeTerminal({ title: "Docked", location: "dock" }),
+      ],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+    });
+
+    expect(mockSetFocused).toHaveBeenCalledTimes(1);
+    expect(mockSetFocused).toHaveBeenCalledWith("panel-grid");
+  });
+
+  it("does not steal focus when only dock panels spawn (#9764)", async () => {
+    await spawnPanelsFromRecipe({
+      terminals: [makeTerminal({ location: "dock" })],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+    });
+
+    expect(mockSetFocused).not.toHaveBeenCalled();
+  });
+
   it("collects errors from multiple panels and throws single AggregateError", async () => {
     mockAddPanel.mockResolvedValueOnce(null).mockRejectedValueOnce(new Error("fail"));
 

--- a/src/components/Worktree/panelSpawning.ts
+++ b/src/components/Worktree/panelSpawning.ts
@@ -98,6 +98,7 @@ export async function spawnPanelsFromRecipe(options: SpawnPanelsOptions): Promis
               worktreeId,
               exitBehavior: t.exitBehavior,
               devCommand: t.devCommand?.trim() || undefined,
+              location: t.location,
               bypassLimits: true,
             });
           } else if (t.type !== "terminal") {
@@ -132,6 +133,7 @@ export async function spawnPanelsFromRecipe(options: SpawnPanelsOptions): Promis
               exitBehavior: t.exitBehavior,
               agentModelId: t.agentModelId,
               agentLaunchFlags,
+              location: t.location,
               bypassLimits: true,
             });
           } else {
@@ -142,6 +144,7 @@ export async function spawnPanelsFromRecipe(options: SpawnPanelsOptions): Promis
               worktreeId,
               exitBehavior: t.exitBehavior,
               command: t.command?.trim() || undefined,
+              location: t.location,
               bypassLimits: true,
             });
           }
@@ -171,7 +174,10 @@ export async function spawnPanelsFromRecipe(options: SpawnPanelsOptions): Promis
     }
 
     if (outcome.panelId != null) {
-      lastSpawnedId = outcome.panelId;
+      // Dock panels land silently — only grid panels are focus candidates.
+      if (terminals[outcome.index]?.location !== "dock") {
+        lastSpawnedId = outcome.panelId;
+      }
       try {
         onPanelSpawned?.(outcome.index, outcome.panelId);
       } catch {

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -189,6 +189,64 @@ describe("recipeStore", () => {
       expect(devEntry?.agentLaunchFlags).toBeUndefined();
     });
 
+    it("captures dock placement and omits location for grid-equivalent panels (#9764)", () => {
+      panelStoreState.panelIds = ["panel-dock", "panel-grid", "panel-overlay"];
+      panelStoreState.panelsById = {
+        "panel-dock": {
+          id: "panel-dock",
+          kind: "terminal",
+          title: "Docked",
+          worktreeId: "wt-1",
+          location: "dock",
+          command: "npm test",
+        },
+        "panel-grid": {
+          id: "panel-grid",
+          kind: "terminal",
+          title: "Grid",
+          worktreeId: "wt-1",
+          location: "grid",
+        },
+        "panel-overlay": {
+          id: "panel-overlay",
+          kind: "terminal",
+          title: "Overlay",
+          worktreeId: "wt-1",
+          location: "overlay",
+        },
+      };
+
+      const terminals = useRecipeStore.getState().generateRecipeFromActiveTerminals("wt-1");
+      expect(terminals).toHaveLength(3);
+      expect(terminals.find((t) => t.title === "Docked")?.location).toBe("dock");
+      expect(terminals.find((t) => t.title === "Grid")?.location).toBeUndefined();
+      // Transient system placements are not user layout choices — never cloned.
+      expect(terminals.find((t) => t.title === "Overlay")?.location).toBeUndefined();
+    });
+
+    it("strips location when persisting to disk via createRecipe (#9764)", async () => {
+      useRecipeStore.setState({ currentProjectId: "project-1" });
+      await useRecipeStore.getState().createRecipe(
+        "project-1",
+        "Layout",
+        undefined,
+        [
+          {
+            type: "terminal",
+            title: "Docked",
+            command: "npm test",
+            env: {},
+            location: "dock",
+          },
+        ],
+        false
+      );
+
+      expect(updateInRepoRecipeMock).toHaveBeenCalledTimes(1);
+      const persistedRecipe = updateInRepoRecipeMock.mock.calls[0]?.[1];
+      expect(persistedRecipe?.terminals?.[0]?.location).toBeUndefined();
+    });
+
     it("strips agentModelId and agentLaunchFlags when persisting to disk via createRecipe", async () => {
       useRecipeStore.setState({ currentProjectId: "project-1" });
       await useRecipeStore.getState().createRecipe(

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -356,6 +356,7 @@ describe("recipeStore", () => {
             env: {},
             agentModelId: "claude-opus-4-7",
             agentLaunchFlags: ["--resume", "old"],
+            location: "dock" as const,
           },
         ],
         createdAt: 1000,
@@ -369,6 +370,7 @@ describe("recipeStore", () => {
       const loaded = useRecipeStore.getState().inRepoRecipes[0];
       expect(loaded?.terminals[0]?.agentModelId).toBeUndefined();
       expect(loaded?.terminals[0]?.agentLaunchFlags).toBeUndefined();
+      expect(loaded?.terminals[0]?.location).toBeUndefined();
     });
   });
 

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -95,6 +95,7 @@ function sanitizeRecipeTerminal(terminal: RecipeTerminal): RecipeTerminal {
     // Session-scoped overrides must never leak into disk-saved recipes.
     agentModelId: undefined,
     agentLaunchFlags: undefined,
+    location: undefined,
   };
 }
 
@@ -113,6 +114,7 @@ function terminalToRecipeTerminal(terminal: PtyPanelData | DevPreviewPanelData):
       exitBehavior: terminal.exitBehavior,
       agentModelId: undefined,
       agentLaunchFlags: undefined,
+      location: terminal.location === "dock" ? "dock" : undefined,
     };
   }
 
@@ -128,6 +130,7 @@ function terminalToRecipeTerminal(terminal: PtyPanelData | DevPreviewPanelData):
     exitBehavior: terminal.exitBehavior,
     agentModelId: isAgent ? terminal.agentModelId : undefined,
     agentLaunchFlags: isAgent ? terminal.agentLaunchFlags : undefined,
+    location: terminal.location === "dock" ? "dock" : undefined,
   };
 }
 

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -56,17 +56,21 @@ function isAgentRecipeType(type: RecipeTerminalType): boolean {
   return type !== "terminal" && type !== "dev-preview";
 }
 
-// Recipes read from disk may still contain agentModelId/agentLaunchFlags if
-// they were written by an older build before those fields were stripped on
+// Recipes read from disk may still contain agentModelId/agentLaunchFlags/location
+// if they were written by an older build before those fields were stripped on
 // persist. Treat them as session-only state and drop them at load time.
 function stripSessionOverridesFromRecipe(recipe: TerminalRecipe): TerminalRecipe {
   let changed = false;
   const terminals = recipe.terminals.map((terminal) => {
-    if (terminal.agentModelId === undefined && terminal.agentLaunchFlags === undefined) {
+    if (
+      terminal.agentModelId === undefined &&
+      terminal.agentLaunchFlags === undefined &&
+      terminal.location === undefined
+    ) {
       return terminal;
     }
     changed = true;
-    const { agentModelId: _m, agentLaunchFlags: _f, ...rest } = terminal;
+    const { agentModelId: _m, agentLaunchFlags: _f, location: _l, ...rest } = terminal;
     return rest;
   });
   if (recipe.shadowedBy !== undefined) {


### PR DESCRIPTION
## Summary

- Cloning a worktree layout lost docked panel placement — `terminalToRecipeTerminal()` returned a `RecipeTerminal` with no `location` field, so `spawnPanelsFromRecipe()` replayed every panel into the grid
- Added a transient `location?: "dock"` field to `RecipeTerminal`; captured in `terminalToRecipeTerminal()` and forwarded through all three `addPanel` branches in `spawnPanelsFromRecipe()`
- Location is session-scoped and never persisted: stripped in `sanitizeRecipeTerminal()` on save and in `stripSessionOverridesFromRecipe()` on load (defense-in-depth)

Resolves #9764

## Changes

- `shared/types/project.ts` — `location?: "dock"` on `RecipeTerminal`
- `src/store/recipeStore.ts` — capture in `terminalToRecipeTerminal()`, strip in `sanitizeRecipeTerminal()` and `stripSessionOverridesFromRecipe()`
- `src/components/Worktree/panelSpawning.ts` — forward location through all three `addPanel` branches; post-batch focus tail restricted to grid panels so a trailing dock panel doesn't steal focus (no `activateDockOnCreate`, per lesson #6596)

## Testing

New tests in `panelSpawning.test.ts` and `recipeStore.test.ts` cover: location capture for dock/grid/overlay, disk-persistence strip, load strip, location forwarding for all three panel kinds, mixed dock/grid focus behavior, dock-only no-focus. 113 pass.