### PR TITLE
fix(terminal): extend reflow recovery to agent terminals

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1858,10 +1858,11 @@ class TerminalInstanceService {
       if (Number.isInteger(cols) && Number.isInteger(rows) && cols > 0 && rows > 0) {
         this.resizeController.sendPtyResize(id, cols, rows);
       }
-      // Clear throttle so any subsequent write triggers an immediate reflow;
-      // settled-strategy agents are WebGL so maybeReflowTerminal itself is a
-      // no-op, but the clear is cheap and keeps the post-wake contract
-      // uniform across paths.
+      // Clear throttle so the next write — or the 3s heartbeat — triggers an
+      // immediate reflow. We don't call maybeReflowTerminal() inline here
+      // because the deferred PTY resize above hasn't landed yet; reflowing
+      // mid-resize would jitter against the pending dimension change. The
+      // heartbeat and focus paths cover any IO unpause within 3s.
       managed.lastReflowAt = 0;
       return;
     }

--- a/src/services/terminal/TerminalReflowController.ts
+++ b/src/services/terminal/TerminalReflowController.ts
@@ -32,8 +32,7 @@ export interface ReflowControllerDeps {
 }
 
 /**
- * Owns the three layered IO-unpause recovery paths for standard (DOM-renderer)
- * terminals:
+ * Owns the three layered IO-unpause recovery paths for visible terminals:
  *  1. Per-write reflow via `maybeReflow()` (called from `onWriteParsedReflow`)
  *  2. 3 s heartbeat sweep — recovers a paused renderer with no writes
  *  3. Window focus / document visibilitychange — the moments a user is most
@@ -60,10 +59,11 @@ export class TerminalReflowController {
   constructor(deps: ReflowControllerDeps) {
     this.deps = deps;
 
-    // Periodic heartbeat: recovers a DOM-renderer terminal whose
-    // IntersectionObserver has paused rendering, even while no new writes are
-    // arriving. Cheap (~1–5ms per visible non-agent terminal). Skipped while
-    // the document is hidden — _onVisibilityChange triggers a sweep on regain.
+    // Periodic heartbeat: recovers a terminal whose IntersectionObserver has
+    // paused rendering, even while no new writes are arriving. The pause gate
+    // lives in xterm's core RenderService, so WebGL and DOM renderers alike
+    // are affected. Cheap (~1–5ms per visible terminal). Skipped while the
+    // document is hidden — _onVisibilityChange triggers a sweep on regain.
     if (typeof setInterval === "function") {
       this.heartbeatTimer = setInterval(() => {
         if (typeof document !== "undefined" && document.visibilityState !== "visible") return;
@@ -85,17 +85,18 @@ export class TerminalReflowController {
   }
 
   /**
-   * Force an IntersectionObserver reflow on a standard terminal if it's
-   * eligible — used by onWriteParsed, the periodic heartbeat, and
-   * visibility/focus recovery paths. All guards live here so every caller
-   * stays consistent.
+   * Force an IntersectionObserver reflow on a terminal if it's eligible —
+   * used by onWriteParsed, the periodic heartbeat, and visibility/focus
+   * recovery paths. All guards live here so every caller stays consistent.
    *
-   * Skips: agent terminals (WebGL, immune), hibernated/invisible/attaching
-   * terminals, alt-buffer (TUI) sessions, and terminals without a rendered
-   * element. Throttled per terminal.
+   * Applies to agent terminals too: xterm 6's pause gate lives in the core
+   * RenderService, so a WebGL-rendered terminal is just as susceptible as a
+   * DOM one (and after a webglcontextlost it falls back to the DOM renderer
+   * with no requeue). Skips: hibernated/invisible/attaching terminals,
+   * alt-buffer (TUI) sessions, and terminals without a rendered element.
+   * Throttled per terminal.
    */
   maybeReflow(managed: ManagedTerminal): void {
-    if (managed.runtimeAgentId) return;
     if (managed.isHibernated) return;
     if (!managed.isVisible) return;
     if (managed.isAttaching) return;

--- a/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
@@ -204,11 +204,14 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     expect(history2).toBeGreaterThan(history1);
   });
 
-  it("skips agent terminals (WebGL — immune)", () => {
+  it("reflows agent terminals — the xterm pause gate is renderer-agnostic", () => {
     const managed = makeManaged({ kind: "terminal", launchAgentId: "claude" });
+    expect(managed.runtimeAgentId).toBe("claude");
+
     service.maybeReflowTerminal(managed);
-    expect(paddingHistory(managed).length).toBe(0);
-    expect(managed.lastReflowAt).toBe(0);
+
+    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(managed.lastReflowAt).toBeGreaterThan(0);
   });
 
   it("skips hibernated terminals", () => {

--- a/src/services/terminal/__tests__/TerminalReflowController.test.ts
+++ b/src/services/terminal/__tests__/TerminalReflowController.test.ts
@@ -369,4 +369,21 @@ describe("TerminalReflowController dispose / listener cleanup", () => {
 
     controller.dispose();
   });
+
+  it("visibilitychange listener reflows agent terminals too", () => {
+    const managed = makeManaged({ launchAgentId: "claude" });
+    instances = [managed];
+
+    controller = new TerminalReflowController({ getInstances: () => instances });
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(paddingHistory(managed)).toContain("0.01px");
+
+    controller.dispose();
+  });
 });

--- a/src/services/terminal/__tests__/TerminalReflowController.test.ts
+++ b/src/services/terminal/__tests__/TerminalReflowController.test.ts
@@ -140,11 +140,14 @@ describe("TerminalReflowController.maybeReflow", () => {
     expect(paddingHistory(managed).length).toBeGreaterThan(before);
   });
 
-  it("skips agent terminals (WebGL — immune)", () => {
+  it("reflows agent terminals — the xterm pause gate is renderer-agnostic", () => {
     const managed = makeManaged({ launchAgentId: "claude" });
+    expect(managed.runtimeAgentId).toBe("claude");
+
     controller.maybeReflow(managed);
-    expect(paddingHistory(managed).length).toBe(0);
-    expect(managed.lastReflowAt).toBe(0);
+
+    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(managed.lastReflowAt).toBeGreaterThan(0);
   });
 
   it("skips hibernated terminals", () => {
@@ -251,6 +254,22 @@ describe("TerminalReflowController dispose / listener cleanup", () => {
     vi.useRealTimers();
   });
 
+  it("heartbeat reflows agent terminals too", () => {
+    vi.useFakeTimers();
+
+    const managed = makeManaged({ launchAgentId: "claude" });
+    instances = [managed];
+    controller = new TerminalReflowController({ getInstances: () => instances });
+
+    expect(paddingHistory(managed).length).toBe(0);
+
+    vi.advanceTimersByTime(3000);
+    expect(paddingHistory(managed)).toContain("0.01px");
+
+    controller.dispose();
+    vi.useRealTimers();
+  });
+
   it("heartbeat stops firing after dispose", () => {
     vi.useFakeTimers();
 
@@ -310,6 +329,18 @@ describe("TerminalReflowController dispose / listener cleanup", () => {
 
     expect(paddingHistory(a)).toContain("0.01px");
     expect(paddingHistory(b)).toContain("0.01px");
+
+    controller.dispose();
+  });
+
+  it("focus listener reflows agent terminals too", () => {
+    const managed = makeManaged({ launchAgentId: "claude" });
+    instances = [managed];
+
+    controller = new TerminalReflowController({ getInstances: () => instances });
+    window.dispatchEvent(new FocusEvent("focus"));
+
+    expect(paddingHistory(managed)).toContain("0.01px");
 
     controller.dispose();
   });


### PR DESCRIPTION
## Summary

- Agent terminals were unconditionally excluded from `TerminalReflowController`'s three recovery paths (per-write reflow, 3s heartbeat, focus/visibility) on the false assumption that WebGL was immune to xterm's render-pause gate. It isn't — `IntersectionObserver` lives in the core `RenderService` and is renderer-agnostic, and after a `webglcontextlost` the terminal falls back to DOM anyway.
- Removes the `runtimeAgentId` early-return in `maybeReflow` so agent terminals participate in all three paths. `forceXtermReflow` (sub-pixel padding jitter) is the correct mechanism here — `terminal.refresh()` is silently dropped while the terminal is paused.
- The existing guards (hibernated / invisible / attaching / alt-buffer / element-connected / `synchronizedOutput` / 250ms throttle) already apply correctly to agent terminals; no new code paths needed.

Also refreshed a stale post-wake comment in `TerminalInstanceService`.

Resolves #9777.

## Changes

- `TerminalReflowController.ts` — remove `runtimeAgentId` early-return from `maybeReflow`; agent terminals now go through per-write, heartbeat, and focus/visibility reflow
- `TerminalInstanceService.ts` — refresh stale comment
- `TerminalReflowController.test.ts` — flip agent-skip assertions to assert reflow; add heartbeat, focus, and `visibilitychange` regression tests
- `TerminalInstanceService.reflow.test.ts` — flip sibling agent-skip assertion

## Testing

46 unit tests pass. Full `npm run check` (typecheck / lint / format / build) clean.