### PR TITLE
perf(protocols): serve app:// assets from disk instead of net.fetch

### DIFF
--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -1783,6 +1783,7 @@ describe("createAppProtocolHandler — direct disk read", () => {
     const fs = await import("fs/promises");
     vi.mocked(fs.stat).mockResolvedValue({
       mtime: new Date(0),
+      isFile: () => true,
     } as Awaited<ReturnType<typeof fs.stat>>);
     vi.mocked(fs.open).mockResolvedValue(
       makeFileHandle() as unknown as Awaited<ReturnType<typeof fs.open>>
@@ -1821,7 +1822,9 @@ describe("createAppProtocolHandler — direct disk read", () => {
   it("builds the 200 response headers from the validator stats (Last-Modified / Cache-Control)", async () => {
     const fs = await import("fs/promises");
     const appProtocol = await import("../../utils/appProtocol.js");
-    const stats = { mtime: new Date(1000) } as Awaited<ReturnType<typeof fs.stat>>;
+    const stats = { mtime: new Date(1000), isFile: () => true } as Awaited<
+      ReturnType<typeof fs.stat>
+    >;
     vi.mocked(fs.stat).mockResolvedValue(stats);
 
     const handler = await captureHandler();
@@ -1832,6 +1835,26 @@ describe("createAppProtocolHandler — direct disk read", () => {
       stats,
       filePath: "/tmp/dist/assets/index-abc123.js",
     });
+  });
+
+  it("returns 404 for a directory URL even when the validator matches (no spurious 304)", async () => {
+    const fs = await import("fs/promises");
+    const appProtocol = await import("../../utils/appProtocol.js");
+    vi.mocked(fs.stat).mockResolvedValue({
+      mtime: new Date(0),
+      isFile: () => false,
+    } as Awaited<ReturnType<typeof fs.stat>>);
+    vi.mocked(appProtocol.isNotModified).mockReturnValue(true);
+
+    const handler = await captureHandler();
+    const response = await handler(
+      makeRequest("/assets/", {
+        headers: { "If-Modified-Since": new Date(0).toUTCString() },
+      })
+    );
+
+    expect(response.status).toBe(404);
+    expect(fs.open).not.toHaveBeenCalled();
   });
 
   it("short-circuits to 304 without opening the file when the validator matches", async () => {
@@ -1947,6 +1970,18 @@ describe("createAppProtocolHandler — direct disk read", () => {
     expect(response.status).toBe(500);
   });
 
+  it("closes the file handle on the success path", async () => {
+    const fs = await import("fs/promises");
+    const handle = makeFileHandle("bytes");
+    vi.mocked(fs.open).mockResolvedValue(handle as unknown as Awaited<ReturnType<typeof fs.open>>);
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest());
+
+    expect(response.status).toBe(200);
+    expect(handle.close).toHaveBeenCalledTimes(1);
+  });
+
   it("returns 200 when close() rejects after a successful read (close errors are swallowed)", async () => {
     const fs = await import("fs/promises");
     const handle = {
@@ -1960,5 +1995,6 @@ describe("createAppProtocolHandler — direct disk read", () => {
 
     expect(response.status).toBe(200);
     expect(await response.text()).toBe("ok");
+    expect(handle.close).toHaveBeenCalledTimes(1);
   });
 });

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -1791,7 +1791,6 @@ describe("createAppProtocolHandler — direct disk read", () => {
     const appProtocol = await import("../../utils/appProtocol.js");
     vi.mocked(appProtocol.resolveAppUrlToDistPath).mockReturnValue({
       filePath: "/tmp/dist/assets/index-abc123.js",
-      error: null,
     } as ReturnType<typeof appProtocol.resolveAppUrlToDistPath>);
     vi.mocked(appProtocol.getMimeType).mockReturnValue("text/javascript");
     vi.mocked(appProtocol.buildHeaders).mockReturnValue({

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -69,6 +69,7 @@ vi.mock("../../utils/appProtocol.js", () => ({
   getMimeType: vi.fn(),
   buildHeaders: vi.fn(),
   isImmutableAppAsset: vi.fn(() => false),
+  isNotModified: vi.fn(() => false),
 }));
 
 // Real-ish flag values matter: the protocol handler passes
@@ -1747,5 +1748,217 @@ describe("createPluginProtocolHandler", () => {
     } finally {
       relativeSpy.mockRestore();
     }
+  });
+});
+
+describe("createAppProtocolHandler — direct disk read", () => {
+  type ProtocolHandler = (request: GlobalRequest) => Promise<Response>;
+
+  async function captureHandler(): Promise<ProtocolHandler> {
+    const handle = vi.fn();
+    const mockSession = { protocol: { handle } } as unknown as Electron.Session;
+    registerProtocolsForSession(mockSession, "/tmp/dist");
+    const call = handle.mock.calls.find((c) => c[0] === "app");
+    if (!call) throw new Error("handler for app not registered");
+    return call[1] as ProtocolHandler;
+  }
+
+  function makeRequest(
+    pathname = "/assets/index-abc123.js",
+    init?: { method?: string; headers?: Record<string, string> }
+  ): GlobalRequest {
+    return new Request(`app://daintree${pathname}`, init) as GlobalRequest;
+  }
+
+  function makeFileHandle(content: string | Buffer = "bytes") {
+    const buffer = typeof content === "string" ? Buffer.from(content) : content;
+    return {
+      readFile: vi.fn().mockResolvedValue(buffer),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const fs = await import("fs/promises");
+    vi.mocked(fs.stat).mockResolvedValue({
+      mtime: new Date(0),
+    } as Awaited<ReturnType<typeof fs.stat>>);
+    vi.mocked(fs.open).mockResolvedValue(
+      makeFileHandle() as unknown as Awaited<ReturnType<typeof fs.open>>
+    );
+    const appProtocol = await import("../../utils/appProtocol.js");
+    vi.mocked(appProtocol.resolveAppUrlToDistPath).mockReturnValue({
+      filePath: "/tmp/dist/assets/index-abc123.js",
+      error: null,
+    } as ReturnType<typeof appProtocol.resolveAppUrlToDistPath>);
+    vi.mocked(appProtocol.getMimeType).mockReturnValue("text/javascript");
+    vi.mocked(appProtocol.buildHeaders).mockReturnValue({
+      "Content-Type": "text/javascript",
+    } as ReturnType<typeof appProtocol.buildHeaders>);
+    vi.mocked(appProtocol.isNotModified).mockReturnValue(false);
+  });
+
+  it("serves the file straight off disk with fs.open(O_RDONLY) and never touches net.fetch", async () => {
+    const { net } = await import("electron");
+    const fs = await import("fs/promises");
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("bytes");
+    // The whole point of #9768: read directly, no Chromium network-stack hop.
+    expect(vi.mocked(net.fetch)).not.toHaveBeenCalled();
+    expect(fs.open).toHaveBeenCalledTimes(1);
+    const openArgs = vi.mocked(fs.open).mock.calls[0];
+    expect(openArgs[0]).toBe("/tmp/dist/assets/index-abc123.js");
+    // No O_NOFOLLOW — app:// uses lexical containment with no realpath, so there
+    // is no TOCTOU window for the flag to close.
+    expect(openArgs[1]).toBe(fs.constants.O_RDONLY);
+  });
+
+  it("builds the 200 response headers from the validator stats (Last-Modified / Cache-Control)", async () => {
+    const fs = await import("fs/promises");
+    const appProtocol = await import("../../utils/appProtocol.js");
+    const stats = { mtime: new Date(1000) } as Awaited<ReturnType<typeof fs.stat>>;
+    vi.mocked(fs.stat).mockResolvedValue(stats);
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest());
+
+    expect(response.status).toBe(200);
+    expect(appProtocol.buildHeaders).toHaveBeenCalledWith("text/javascript", {
+      stats,
+      filePath: "/tmp/dist/assets/index-abc123.js",
+    });
+  });
+
+  it("short-circuits to 304 without opening the file when the validator matches", async () => {
+    const fs = await import("fs/promises");
+    const appProtocol = await import("../../utils/appProtocol.js");
+    vi.mocked(appProtocol.isNotModified).mockReturnValue(true);
+
+    const handler = await captureHandler();
+    const response = await handler(
+      makeRequest("/assets/index-abc123.js", {
+        headers: { "If-Modified-Since": new Date(0).toUTCString() },
+      })
+    );
+
+    expect(response.status).toBe(304);
+    expect(fs.open).not.toHaveBeenCalled();
+  });
+
+  it("returns 405 for non-GET/HEAD methods without resolving a path", async () => {
+    const appProtocol = await import("../../utils/appProtocol.js");
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest("/assets/index-abc123.js", { method: "POST" }));
+
+    expect(response.status).toBe(405);
+    expect(appProtocol.resolveAppUrlToDistPath).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the URL resolves outside the dist root", async () => {
+    const fs = await import("fs/promises");
+    const appProtocol = await import("../../utils/appProtocol.js");
+    vi.mocked(appProtocol.resolveAppUrlToDistPath).mockReturnValue({
+      filePath: "",
+      error: "path traversal",
+    } as ReturnType<typeof appProtocol.resolveAppUrlToDistPath>);
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest("/../../etc/passwd"));
+
+    expect(response.status).toBe(404);
+    expect(fs.stat).not.toHaveBeenCalled();
+    expect(fs.open).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when stat fails (missing file)", async () => {
+    const fs = await import("fs/promises");
+    vi.mocked(fs.stat).mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest());
+
+    expect(response.status).toBe(404);
+    expect(fs.open).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when fs.open rejects with ENOENT", async () => {
+    const fs = await import("fs/promises");
+    vi.mocked(fs.open).mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest());
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 404 when fs.open rejects with EISDIR (directory URL on Windows)", async () => {
+    const fs = await import("fs/promises");
+    vi.mocked(fs.open).mockRejectedValue(Object.assign(new Error("EISDIR"), { code: "EISDIR" }));
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest());
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 404 when readFile rejects with EISDIR (directory open succeeds on macOS/Linux)", async () => {
+    const fs = await import("fs/promises");
+    const handle = {
+      readFile: vi.fn().mockRejectedValue(Object.assign(new Error("EISDIR"), { code: "EISDIR" })),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(fs.open).mockResolvedValue(handle as unknown as Awaited<ReturnType<typeof fs.open>>);
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest());
+
+    expect(response.status).toBe(404);
+    expect(handle.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 500 and closes the handle when readFile fails unexpectedly", async () => {
+    const fs = await import("fs/promises");
+    const handle = {
+      readFile: vi.fn().mockRejectedValue(Object.assign(new Error("EIO"), { code: "EIO" })),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(fs.open).mockResolvedValue(handle as unknown as Awaited<ReturnType<typeof fs.open>>);
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest());
+
+    expect(response.status).toBe(500);
+    expect(handle.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 500 when fs.open rejects with an unexpected error", async () => {
+    const fs = await import("fs/promises");
+    vi.mocked(fs.open).mockRejectedValue(Object.assign(new Error("EACCES"), { code: "EACCES" }));
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest());
+
+    expect(response.status).toBe(500);
+  });
+
+  it("returns 200 when close() rejects after a successful read (close errors are swallowed)", async () => {
+    const fs = await import("fs/promises");
+    const handle = {
+      readFile: vi.fn().mockResolvedValue(Buffer.from("ok")),
+      close: vi.fn().mockRejectedValue(new Error("EBADF")),
+    };
+    vi.mocked(fs.open).mockResolvedValue(handle as unknown as Awaited<ReturnType<typeof fs.open>>);
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("ok");
   });
 });

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -1,10 +1,9 @@
 // eager-import-allow: sets up custom protocols (daintree, plugin) and security headers (CSP) eagerly on startup
-import { app, protocol, net, session } from "electron";
+import { app, protocol, session } from "electron";
 import { getWindowForWebContents, getAppWebContents } from "../window/webContentsRegistry.js";
 import path from "path";
 import fs from "fs/promises";
 import { readFileSync } from "node:fs";
-import { pathToFileURL } from "url";
 import {
   resolveAppUrlToDistPath,
   getMimeType,
@@ -84,31 +83,56 @@ function createAppProtocolHandler(distPath: string) {
       });
     }
 
+    // Read the bytes directly off disk instead of round-tripping through
+    // net.fetch(). Custom-scheme responses never enter Chromium's HTTP disk
+    // cache, so the fetch path added a Chromium network-stack hop plus a second
+    // in-memory copy on every asset load for no caching benefit. No O_NOFOLLOW:
+    // unlike daintree-file:// / plugin://, resolveAppUrlToDistPath does lexical
+    // (path.resolve + startsWith) containment with no realpath, so there is no
+    // realpath/open TOCTOU window for the flag to close — adding it would imply
+    // a defense that isn't set up here. dist assets are application-owned.
+    let fileHandle: Awaited<ReturnType<typeof fs.open>>;
     try {
-      const fileUrl = pathToFileURL(filePath).toString();
-      const response = await net.fetch(fileUrl);
-
-      if (!response.ok) {
+      fileHandle = await fs.open(filePath, fs.constants.O_RDONLY);
+    } catch (err) {
+      const errCode = (err as NodeJS.ErrnoException).code;
+      if (errCode === "ENOENT" || errCode === "EISDIR") {
         return new Response("Not Found", {
           status: 404,
           headers: buildHeaders("text/plain"),
         });
       }
-
-      const mimeType = getMimeType(filePath);
-      const headers = buildHeaders(mimeType, { stats, filePath });
-      const buffer = await response.arrayBuffer();
-
-      return new Response(buffer, {
-        status: 200,
-        headers: headers,
-      });
-    } catch (err) {
       console.error("[MAIN] Error serving file:", filePath, err);
       return new Response("Internal Server Error", {
         status: 500,
         headers: buildHeaders("text/plain"),
       });
+    }
+
+    try {
+      const buffer = await fileHandle.readFile();
+      return new Response(buffer, {
+        status: 200,
+        headers: buildHeaders(getMimeType(filePath), { stats, filePath }),
+      });
+    } catch (err) {
+      // fs.open on a directory succeeds on macOS/Linux; the EISDIR only surfaces
+      // here at readFile. Map it to 404 like the open path so a directory URL
+      // never returns a 500.
+      if ((err as NodeJS.ErrnoException).code === "EISDIR") {
+        return new Response("Not Found", {
+          status: 404,
+          headers: buildHeaders("text/plain"),
+        });
+      }
+      console.error("[MAIN] Error serving file:", filePath, err);
+      return new Response("Internal Server Error", {
+        status: 500,
+        headers: buildHeaders("text/plain"),
+      });
+    } finally {
+      // Swallow close errors so they don't mask a preceding readFile failure.
+      await fileHandle.close().catch(() => {});
     }
   };
 }

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -75,6 +75,16 @@ function createAppProtocolHandler(distPath: string) {
       });
     }
 
+    // stat() succeeds on directories, so guard before the 304 short-circuit:
+    // without this a directory URL carrying If-Modified-Since would return 304
+    // instead of falling through to the open/read 404 path.
+    if (!stats.isFile()) {
+      return new Response("Not Found", {
+        status: 404,
+        headers: buildHeaders("text/plain"),
+      });
+    }
+
     const ifModifiedSince = request.headers.get("If-Modified-Since");
     if (isNotModified(ifModifiedSince, stats.mtime)) {
       return new Response(null, {


### PR DESCRIPTION
## Summary

Replaces `net.fetch` with direct `fs.open` + `fileHandle.readFile` to serve `app://` assets in `createAppProtocolHandler`. Custom-scheme responses don't enter Chromium's HTTP disk cache, so the old path added a Chromium network-stack hop and a second in-memory copy on every asset load with no caching benefit. Removes the now-unused `net` and `pathToFileURL` imports.

## Changes

All prior behaviour is preserved:
- `buildHeaders`, stats validator, 405 method guard
- `If-Modified-Since` → 304 short-circuit (required for V8 bytecode cache, #8624)
- Buffered non-streamed body (Electron #42612 still open in Electron 41)

Error mapping:
- `ENOENT` / `EISDIR` at `open` → 404
- `EISDIR` at `readFile` → 404 (directory `open` succeeds on macOS/Linux)
- Other errors → 500

Adds a `stats.isFile()` guard so a directory URL with `If-Modified-Since` can't return a spurious 304.

No `O_NOFOLLOW`: `app://` resolves paths via `resolveAppUrlToDistPath` using lexical `path.resolve` + `startsWith` containment (no `realpath`), so there's no TOCTOU window the flag would close — unlike the sibling `daintree-file://` / `plugin://` handlers.

Adds a 14-test suite for `createAppProtocolHandler` covering 200/304/404/500 paths, `O_RDONLY` flag assertion, `net.fetch`-not-called regression guard, directory-304 guard, and handle cleanup. Full file: 106 tests pass, `npm run check` clean.

## Testing

- New test suite: 14 cases, all passing
- Full protocols test file: 106 tests pass
- `npm run check` clean

Resolves #9768