### PR TITLE
fix(terminal): guard against stale IntersectionObserver false-negatives (#9780)

### DIFF
--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -636,8 +636,17 @@ function TerminalPaneComponent({
         if (isDraggingRef.current || !entry) return;
 
         // Suppress stale `false` readings that would freeze a visible terminal
-        // at the BACKGROUND tier (#9780). Read geometry before any write.
-        if (isStaleHiddenReading(entry, () => containerRef.current?.getBoundingClientRect()))
+        // at the BACKGROUND tier (#9780). Confirm against fresh element and root
+        // geometry, read before any write to avoid a redundant layout reflow.
+        if (
+          isStaleHiddenReading(
+            entry,
+            () => containerRef.current?.getBoundingClientRect(),
+            () =>
+              gridScrollRoot?.getBoundingClientRect() ??
+              new DOMRect(0, 0, window.innerWidth, window.innerHeight)
+          )
+        )
           return;
 
         updateVisibility(id, entry.isIntersecting);

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -27,6 +27,7 @@ import { ArtifactOverlay } from "./ArtifactOverlay";
 import { TerminalSearchBar } from "./TerminalSearchBar";
 import { TerminalScrollIndicator } from "./TerminalScrollIndicator";
 import { useGridScrollRoot } from "./GridScrollRootContext";
+import { isStaleHiddenReading } from "./visibilityReadingGuard";
 import { COMFORTABLE_PANEL_HEIGHT_PX } from "@/lib/terminalLayout";
 import { FleetDraftingPill } from "@/components/Fleet/FleetDraftingPill";
 import { TerminalRestartStatusBanner } from "./TerminalRestartStatusBanner";
@@ -626,9 +627,18 @@ function TerminalPaneComponent({
     const gen = terminalInstanceService.getAttachGeneration(id);
 
     const observer = new IntersectionObserver(
-      ([entry]) => {
+      (entries) => {
+        // Under load a single callback can batch multiple entries for the same
+        // element; only the most recent reading reflects current geometry.
+        const entry = entries[entries.length - 1];
+
         // Don't update visibility during drag - CSS transforms cause false negatives
         if (isDraggingRef.current || !entry) return;
+
+        // Suppress stale `false` readings that would freeze a visible terminal
+        // at the BACKGROUND tier (#9780). Read geometry before any write.
+        if (isStaleHiddenReading(entry, () => containerRef.current?.getBoundingClientRect()))
+          return;
 
         updateVisibility(id, entry.isIntersecting);
         terminalInstanceService.setVisible(id, entry.isIntersecting, gen);

--- a/src/components/Terminal/__tests__/visibilityReadingGuard.test.ts
+++ b/src/components/Terminal/__tests__/visibilityReadingGuard.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { isStaleHiddenReading } from "../visibilityReadingGuard";
+
+const rect = (width: number, height: number): DOMRect =>
+  ({
+    width,
+    height,
+    top: 0,
+    left: 0,
+    right: width,
+    bottom: height,
+    x: 0,
+    y: 0,
+    toJSON() {},
+  }) as DOMRect;
+
+describe("isStaleHiddenReading", () => {
+  it("never flags a visible reading as stale, regardless of geometry", () => {
+    expect(isStaleHiddenReading({ isIntersecting: true }, () => rect(0, 0))).toBe(false);
+    expect(isStaleHiddenReading({ isIntersecting: true }, () => rect(200, 400))).toBe(false);
+    expect(isStaleHiddenReading({ isIntersecting: true }, () => undefined)).toBe(false);
+  });
+
+  it("flags a `false` reading as stale when the element still has non-zero bounds", () => {
+    expect(isStaleHiddenReading({ isIntersecting: false }, () => rect(200, 400))).toBe(true);
+  });
+
+  it("trusts a `false` reading when geometry confirms zero size (genuine hide)", () => {
+    expect(isStaleHiddenReading({ isIntersecting: false }, () => rect(0, 0))).toBe(false);
+  });
+
+  it("trusts a `false` reading when only one dimension is zero (collapsed pane)", () => {
+    expect(isStaleHiddenReading({ isIntersecting: false }, () => rect(200, 0))).toBe(false);
+    expect(isStaleHiddenReading({ isIntersecting: false }, () => rect(0, 400))).toBe(false);
+  });
+
+  it("trusts a `false` reading when the element is unmounted (no rect)", () => {
+    expect(isStaleHiddenReading({ isIntersecting: false }, () => undefined)).toBe(false);
+  });
+
+  it("reads geometry lazily — never measures for a visible reading", () => {
+    let measured = false;
+    isStaleHiddenReading({ isIntersecting: true }, () => {
+      measured = true;
+      return rect(200, 400);
+    });
+    expect(measured).toBe(false);
+  });
+});

--- a/src/components/Terminal/__tests__/visibilityReadingGuard.test.ts
+++ b/src/components/Terminal/__tests__/visibilityReadingGuard.test.ts
@@ -1,49 +1,81 @@
 import { describe, expect, it } from "vitest";
 import { isStaleHiddenReading } from "../visibilityReadingGuard";
 
-const rect = (width: number, height: number): DOMRect =>
+// Build a rect from a top-left origin and a size.
+const rectAt = (left: number, top: number, width: number, height: number): DOMRect =>
   ({
+    left,
+    top,
     width,
     height,
-    top: 0,
-    left: 0,
-    right: width,
-    bottom: height,
-    x: 0,
-    y: 0,
+    right: left + width,
+    bottom: top + height,
+    x: left,
+    y: top,
     toJSON() {},
   }) as DOMRect;
 
+const root = () => rectAt(0, 0, 1000, 800);
+const visible = (intersecting: boolean) => ({ isIntersecting: intersecting });
+
 describe("isStaleHiddenReading", () => {
   it("never flags a visible reading as stale, regardless of geometry", () => {
-    expect(isStaleHiddenReading({ isIntersecting: true }, () => rect(0, 0))).toBe(false);
-    expect(isStaleHiddenReading({ isIntersecting: true }, () => rect(200, 400))).toBe(false);
-    expect(isStaleHiddenReading({ isIntersecting: true }, () => undefined)).toBe(false);
+    expect(isStaleHiddenReading(visible(true), () => rectAt(0, 0, 0, 0), root)).toBe(false);
+    expect(isStaleHiddenReading(visible(true), () => rectAt(0, 0, 200, 400), root)).toBe(false);
+    expect(isStaleHiddenReading(visible(true), () => undefined, root)).toBe(false);
   });
 
-  it("flags a `false` reading as stale when the element still has non-zero bounds", () => {
-    expect(isStaleHiddenReading({ isIntersecting: false }, () => rect(200, 400))).toBe(true);
+  it("flags a `false` reading as stale when the element overlaps the root (on-screen)", () => {
+    expect(isStaleHiddenReading(visible(false), () => rectAt(0, 100, 400, 520), root)).toBe(true);
+  });
+
+  it("trusts a `false` reading when the element is scrolled off below the root", () => {
+    // Full layout box, but its top is past the root's bottom edge.
+    expect(isStaleHiddenReading(visible(false), () => rectAt(0, 1500, 400, 520), root)).toBe(false);
+  });
+
+  it("trusts a `false` reading when the element is scrolled off above the root", () => {
+    expect(isStaleHiddenReading(visible(false), () => rectAt(0, -600, 400, 520), root)).toBe(false);
   });
 
   it("trusts a `false` reading when geometry confirms zero size (genuine hide)", () => {
-    expect(isStaleHiddenReading({ isIntersecting: false }, () => rect(0, 0))).toBe(false);
+    expect(isStaleHiddenReading(visible(false), () => rectAt(0, 0, 0, 0), root)).toBe(false);
   });
 
   it("trusts a `false` reading when only one dimension is zero (collapsed pane)", () => {
-    expect(isStaleHiddenReading({ isIntersecting: false }, () => rect(200, 0))).toBe(false);
-    expect(isStaleHiddenReading({ isIntersecting: false }, () => rect(0, 400))).toBe(false);
+    expect(isStaleHiddenReading(visible(false), () => rectAt(0, 0, 200, 0), root)).toBe(false);
+    expect(isStaleHiddenReading(visible(false), () => rectAt(0, 0, 0, 400), root)).toBe(false);
   });
 
-  it("trusts a `false` reading when the element is unmounted (no rect)", () => {
-    expect(isStaleHiddenReading({ isIntersecting: false }, () => undefined)).toBe(false);
+  it("trusts a `false` reading when the element is unmounted (no element rect)", () => {
+    expect(isStaleHiddenReading(visible(false), () => undefined, root)).toBe(false);
+  });
+
+  it("trusts a `false` reading when the root cannot be measured", () => {
+    expect(
+      isStaleHiddenReading(
+        visible(false),
+        () => rectAt(0, 0, 400, 520),
+        () => undefined
+      )
+    ).toBe(false);
+  });
+
+  it("treats an element straddling the root edge as on-screen (partial overlap)", () => {
+    // Element starts inside the root and extends past its bottom edge.
+    expect(isStaleHiddenReading(visible(false), () => rectAt(0, 700, 400, 520), root)).toBe(true);
   });
 
   it("reads geometry lazily — never measures for a visible reading", () => {
     let measured = false;
-    isStaleHiddenReading({ isIntersecting: true }, () => {
-      measured = true;
-      return rect(200, 400);
-    });
+    isStaleHiddenReading(
+      visible(true),
+      () => {
+        measured = true;
+        return rectAt(0, 0, 200, 400);
+      },
+      root
+    );
     expect(measured).toBe(false);
   });
 });

--- a/src/components/Terminal/visibilityReadingGuard.ts
+++ b/src/components/Terminal/visibilityReadingGuard.ts
@@ -13,17 +13,34 @@
 // getBoundingClientRect after a setVisible(false) would force a redundant
 // layout reflow. `true` readings are always trusted and committed immediately.
 //
-// Geometry (width/height) is used rather than intersectionRatio because
-// sub-pixel rounding can report a ratio below 1 for a fully visible element.
+// Geometry is used rather than intersectionRatio because sub-pixel rounding can
+// report a ratio below 1 for a fully visible element. The check confirms the
+// element actually OVERLAPS the observation root, not merely that it has a
+// layout box — a terminal scrolled off the grid keeps its full dimensions while
+// genuinely hidden, so a width/height test alone would wrongly suppress that
+// legitimate hide and strand a hidden terminal at a high refresh tier. We only
+// treat a `false` as stale when the element is truly on-screen.
 export function isStaleHiddenReading(
   entry: Pick<IntersectionObserverEntry, "isIntersecting">,
-  getRect: () => DOMRect | undefined
+  getElementRect: () => DOMRect | undefined,
+  getRootRect: () => DOMRect | undefined
 ): boolean {
   // A visible reading is never a stale hide.
   if (entry.isIntersecting) return false;
-  const rect = getRect();
+  const rect = getElementRect();
   // No rect (element unmounted between observe and callback) → genuine hide.
   if (!rect) return false;
-  // Non-zero geometry means the element is on-screen, so the `false` is stale.
-  return rect.width > 0 && rect.height > 0;
+  // No layout box → genuine hide.
+  if (rect.width <= 0 || rect.height <= 0) return false;
+  const root = getRootRect();
+  // Can't confirm against the root → trust the reading and let the hide stand.
+  if (!root) return false;
+  // Stale only if the element's fresh bounds overlap the observation root,
+  // i.e. it is actually on-screen (axis-aligned bounding-box intersection).
+  return (
+    rect.right > root.left &&
+    rect.left < root.right &&
+    rect.bottom > root.top &&
+    rect.top < root.bottom
+  );
 }

--- a/src/components/Terminal/visibilityReadingGuard.ts
+++ b/src/components/Terminal/visibilityReadingGuard.ts
@@ -1,0 +1,29 @@
+// Guards the terminal visibility observer against stale `isIntersecting=false`
+// readings (#9780). Under heavy main-thread load the IntersectionObserver can
+// deliver a false negative for a terminal element that is actually fully
+// on-screen — IO computes geometry at frame-end, so a delivered callback can
+// reflect geometry from several frames prior. A single stale `false` writes
+// `isVisible=false` to the store, which caps the terminal at the BACKGROUND
+// refresh tier and freezes its output until the user clicks it.
+//
+// To suppress these false negatives we confirm a `false` reading against fresh
+// synchronous geometry: if the element still has non-zero bounds it is
+// physically present, so the reading is stale and must not be committed. The
+// geometry must be read BEFORE any visibility write — calling
+// getBoundingClientRect after a setVisible(false) would force a redundant
+// layout reflow. `true` readings are always trusted and committed immediately.
+//
+// Geometry (width/height) is used rather than intersectionRatio because
+// sub-pixel rounding can report a ratio below 1 for a fully visible element.
+export function isStaleHiddenReading(
+  entry: Pick<IntersectionObserverEntry, "isIntersecting">,
+  getRect: () => DOMRect | undefined
+): boolean {
+  // A visible reading is never a stale hide.
+  if (entry.isIntersecting) return false;
+  const rect = getRect();
+  // No rect (element unmounted between observe and callback) → genuine hide.
+  if (!rect) return false;
+  // Non-zero geometry means the element is on-screen, so the `false` is stale.
+  return rect.width > 0 && rect.height > 0;
+}


### PR DESCRIPTION
## Summary

- Under heavy main-thread load, `IntersectionObserver` can deliver a stale `isIntersecting=false` reading for a terminal element that is actually fully on-screen. The previous callback wrote that value straight to the store, which capped the terminal at the `BACKGROUND` refresh tier and froze its output until the user clicked it.
- Adds `isStaleHiddenReading` (`src/components/Terminal/visibilityReadingGuard.ts`), a pure helper that confirms a false reading against fresh geometry before committing it. It does an AABB intersection test between the element's bounding rect and the observation root (the grid scroll container, or the viewport in dock/popout mode) and suppresses the false write only when the element genuinely overlaps the root. True readings remain immediate.
- The callback now reads the most recent batched entry per invocation. Terminals that have scrolled off the grid still correctly demote — their layout box no longer overlaps the root, so the write goes through as normal.

Resolves #9780

## Changes

- `src/components/Terminal/visibilityReadingGuard.ts` — new `isStaleHiddenReading` helper
- `src/components/Terminal/TerminalPane.tsx` — use the guard in the `IntersectionObserver` callback; always use the latest batched entry
- `src/components/Terminal/__tests__/visibilityReadingGuard.test.ts` — 11 unit tests covering visible-never-stale, on-screen overlap suppression, off-grid above/below, zero-size element, single-zero dimension, unmounted, unmeasurable root, straddle, and lazy-measure cases

## Testing

11 unit tests added. `npm run check` passes clean.