### PR TITLE
fix(macos): re-sign PTY helpers with empty entitlements for macOS 26

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -244,7 +244,7 @@ jobs:
             spctl --assess --type execute --verbose --ignore-cache --no-cache "$app" || true
           done
 
-      - name: Verify macOS signing audit (TeamIdentifier + hardened runtime)
+      - name: Verify macOS signing audit (TeamIdentifier + hardened runtime + helper entitlements)
         # No skip_notarization guard: signing is a code-signing property that must
         # be validated even when notarization is manually disabled.
         shell: bash
@@ -272,6 +272,7 @@ jobs:
             codesign --verify --deep --strict --verbose=4 "$app"
             scripts/ci/verify-team-identifier.sh "$app" "$EXPECTED_TEAM_ID"
             scripts/ci/verify-hardened-runtime.sh "$app"
+            scripts/ci/verify-helper-entitlements.sh "$app"
           done
 
       - name: Validate update metadata (macOS)

--- a/build/entitlements.helpers.plist
+++ b/build/entitlements.helpers.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<!-- Minimal (empty) entitlements for the spawned helper executables
+     spawn-helper and daintree_pty_supervisor. electron-builder's binaries[]
+     signing inherits the full app plist (build/entitlements.mac.plist), which
+     carries com.apple.security.device.audio-input — a RESTRICTED entitlement.
+     On macOS 26 (Tahoe) amfid kills any spawned executable claiming a
+     restricted entitlement without an embedded provisioning profile, so the
+     helpers must be re-signed with no entitlements (#9775). Hardened runtime is
+     conveyed via `codesign --options runtime`, not via this plist. -->
+<dict/>
+</plist>

--- a/scripts/ci/verify-helper-entitlements.sh
+++ b/scripts/ci/verify-helper-entitlements.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Verify the spawned helper executables (spawn-helper, daintree_pty_supervisor)
+# carry NO entitlements. electron-builder signs them via mac.binaries[] with the
+# full app plist inherited, which leaks the restricted
+# com.apple.security.device.audio-input entitlement onto them. On macOS 26
+# (Tahoe) amfid kills any spawned executable claiming a restricted entitlement
+# without an embedded provisioning profile (#9775). resign-helpers-macos.cjs
+# re-signs them with an empty entitlement set; this gate confirms that stuck.
+set -euo pipefail
+
+APP_BUNDLE="${1:?Usage: $0 <app_bundle_path>}"
+APP_BUNDLE="${APP_BUNDLE%/}"
+
+if [[ ! -d "$APP_BUNDLE" ]]; then
+  echo "::error::App bundle directory does not exist: $APP_BUNDLE"
+  exit 1
+fi
+
+if [[ "$APP_BUNDLE" != *.app ]]; then
+  echo "::error::Path does not end in .app: $APP_BUNDLE"
+  exit 1
+fi
+
+# Paths mirror mac.binaries[] in electron-builder.config.cjs.
+HELPERS=(
+  "Contents/Resources/app.asar.unpacked/node_modules/node-pty/build/Release/spawn-helper"
+  "Contents/Resources/app.asar.unpacked/node_modules/posix-pty-reaper/build/Release/daintree_pty_supervisor"
+)
+
+echo "Verifying spawned helpers carry no entitlements in '$APP_BUNDLE'"
+
+failed=0
+
+for rel in "${HELPERS[@]}"; do
+  helper="$APP_BUNDLE/$rel"
+  if [[ ! -f "$helper" ]]; then
+    echo "::error::FAIL: Helper executable not found: $helper"
+    failed=$((failed + 1))
+    continue
+  fi
+
+  # `codesign -d --entitlements -` prints the embedded entitlements as a plist
+  # (or nothing when there are none). An empty <dict/> has no <key> elements;
+  # any <key> means an entitlement leaked through and amfid will kill the helper.
+  entitlements=$(codesign -d --entitlements - --xml "$helper" 2>/dev/null || true)
+
+  if echo "$entitlements" | grep -q "<key>"; then
+    echo "::error::FAIL: $helper carries entitlements (expected none):"
+    echo "$entitlements"
+    failed=$((failed + 1))
+  else
+    echo "  PASS: $helper (no entitlements)"
+  fi
+done
+
+if [[ $failed -ne 0 ]]; then
+  echo "::error::Verification FAILED: $failed helper(s) carry unexpected entitlements"
+  exit 1
+fi
+
+echo "Verification SUCCESS: All helpers carry no entitlements"

--- a/scripts/ci/verify-helper-entitlements.sh
+++ b/scripts/ci/verify-helper-entitlements.sh
@@ -42,7 +42,18 @@ for rel in "${HELPERS[@]}"; do
   # `codesign -d --entitlements -` prints the embedded entitlements as a plist
   # (or nothing when there are none). An empty <dict/> has no <key> elements;
   # any <key> means an entitlement leaked through and amfid will kill the helper.
-  entitlements=$(codesign -d --entitlements - --xml "$helper" 2>/dev/null || true)
+  # Capture the exit code separately so a codesign failure (unsigned/corrupt
+  # binary, unsupported flag) fails closed instead of reading as "no entitlements".
+  set +e
+  entitlements=$(codesign -d --entitlements - --xml "$helper" 2>/dev/null)
+  cs_status=$?
+  set -e
+
+  if [[ $cs_status -ne 0 ]]; then
+    echo "::error::FAIL: codesign could not read entitlements (exit $cs_status): $helper"
+    failed=$((failed + 1))
+    continue
+  fi
 
   if echo "$entitlements" | grep -q "<key>"; then
     echo "::error::FAIL: $helper carries entitlements (expected none):"

--- a/scripts/notarize-macos.cjs
+++ b/scripts/notarize-macos.cjs
@@ -2,6 +2,7 @@ const path = require("path");
 const fs = require("fs");
 const os = require("os");
 const { execFileSync } = require("child_process");
+const { resignHelpers } = require("./resign-helpers-macos.cjs");
 
 const NOTARIZATION_STATE_FILE = ".notarization-state.json";
 const WAIT_TIMEOUT_SECONDS = 1800;
@@ -48,6 +49,12 @@ function zipApp(appPath) {
 
 exports.default = async function afterSign(context) {
   if (process.platform !== "darwin") return;
+
+  // Re-sign the spawned helper executables with empty entitlements before
+  // notarization (#9775). This is a signing concern independent of
+  // notarization, so it runs even when DAINTREE_SKIP_NOTARIZATION is set. The
+  // function self-guards on CSC_LINK and platform.
+  await resignHelpers(context);
 
   if (process.env.DAINTREE_SKIP_NOTARIZATION === "true") {
     console.log("[notarize-macos] Skipping notarization (DAINTREE_SKIP_NOTARIZATION=true)");

--- a/scripts/notarize-macos.test.ts
+++ b/scripts/notarize-macos.test.ts
@@ -79,6 +79,9 @@ describe("notarize-macos", () => {
       if (id === "fs") return mockFs();
       if (id === "os") return mockOs();
       if (id === "child_process") return { execFileSync: mockExecFileSync };
+      // Helper re-signing (#9775) is exercised by its own test; no-op it here so
+      // these assertions stay focused on notarization codesign call counts.
+      if (id === "./resign-helpers-macos.cjs") return { resignHelpers: async () => {} };
       return originalRequire.apply(this, [id]);
     };
 

--- a/scripts/resign-helpers-macos.cjs
+++ b/scripts/resign-helpers-macos.cjs
@@ -1,0 +1,125 @@
+const path = require("path");
+const fs = require("fs");
+const { execFileSync, spawnSync } = require("child_process");
+
+const LOG = "[resign-helpers-macos]";
+
+// The spawned helper executables that amfid validates against their claimed
+// entitlements. electron-builder signs these via mac.binaries[] with the full
+// app plist inherited (entitlementsInherit), which leaks the restricted
+// com.apple.security.device.audio-input entitlement onto them. macOS 26 (Tahoe)
+// kills any spawned executable claiming a restricted entitlement without an
+// embedded provisioning profile (#9775). Paths mirror mac.binaries[] in
+// electron-builder.config.cjs and the afterPack.cjs presence checks.
+const HELPER_RELATIVE_PATHS = [
+  "Contents/Resources/app.asar.unpacked/node_modules/node-pty/build/Release/spawn-helper",
+  "Contents/Resources/app.asar.unpacked/node_modules/posix-pty-reaper/build/Release/daintree_pty_supervisor",
+];
+
+// Parse the signing identity from the already-signed .app. `codesign -dvv`
+// prints the signature details (including the Authority chain) to stderr and
+// exits 0; spawnSync lets us read stderr directly (execFileSync only returns
+// stdout). The leaf "Developer ID Application: ..." authority is the identity
+// string codesign --sign expects, and matches whatever cert electron-builder
+// just used — covering both CI (CSC_LINK keychain import) and local keychains.
+function detectSigningIdentity(appPath) {
+  const result = spawnSync("codesign", ["-dvv", appPath], {
+    encoding: "utf-8",
+    timeout: 60000,
+  });
+  if (result.error) {
+    throw new Error(`${LOG} Failed to inspect signature of ${appPath}: ${result.error.message}`);
+  }
+  const combined = `${result.stdout || ""}${result.stderr || ""}`;
+  const match = combined.match(/^Authority=(Developer ID Application:.*)$/m);
+  if (!match) {
+    throw new Error(
+      `${LOG} Could not determine the "Developer ID Application" signing identity from ${appPath}. ` +
+        "The .app must be signed before the helpers can be re-signed."
+    );
+  }
+  return match[1];
+}
+
+function codesign(args) {
+  execFileSync("codesign", args, { encoding: "utf-8", stdio: "inherit", timeout: 120000 });
+}
+
+/**
+ * electron-builder afterSign hook step. Re-signs the spawned helper executables
+ * with an empty entitlement set so macOS 26's amfid no longer kills them, then
+ * repairs the outer bundle seal (re-signing inner binaries changes their cdhash,
+ * which invalidates the .app seal and would otherwise fail notarization).
+ *
+ * Runs only on macOS signed builds (gated on CSC_LINK, the same signal
+ * electron-builder.config.cjs uses to enable signing-only behaviour). It must
+ * run BEFORE notarization and even when DAINTREE_SKIP_NOTARIZATION is set, since
+ * helper entitlements are a signing property independent of notarization.
+ */
+async function resignHelpers(context) {
+  if (process.platform !== "darwin") return;
+
+  if (!process.env.CSC_LINK) {
+    console.log(
+      `${LOG} No signing certificate configured (CSC_LINK unset) — skipping helper re-sign`
+    );
+    return;
+  }
+
+  const { appOutDir, packager } = context;
+  const appName = packager.appInfo.productFilename;
+  const appPath = path.join(appOutDir, `${appName}.app`);
+
+  if (!fs.existsSync(appPath)) {
+    throw new Error(`${LOG} App bundle not found: ${appPath}`);
+  }
+
+  const helperPaths = HELPER_RELATIVE_PATHS.map((rel) => path.join(appPath, rel));
+  for (const helperPath of helperPaths) {
+    if (!fs.existsSync(helperPath)) {
+      throw new Error(
+        `${LOG} Helper executable not found: ${helperPath}. ` +
+          "Packaging layout drifted — the binaries[] paths in electron-builder.config.cjs must match."
+      );
+    }
+  }
+
+  const identity = detectSigningIdentity(appPath);
+  console.log(`${LOG} Re-signing helpers with identity: ${identity}`);
+
+  const entitlements = path.join(__dirname, "..", "build", "entitlements.helpers.plist");
+
+  for (const helperPath of helperPaths) {
+    console.log(`${LOG} Re-signing ${helperPath} with minimal entitlements`);
+    codesign([
+      "--force",
+      "--sign",
+      identity,
+      "--options",
+      "runtime",
+      "--timestamp",
+      "--entitlements",
+      entitlements,
+      helperPath,
+    ]);
+  }
+
+  // Repair the outer bundle seal broken by re-signing the inner helpers.
+  // --preserve-metadata keeps the app's own entitlements (audio-input, etc.),
+  // CFBundleIdentifier, and the hardened-runtime flag intact on the reseal.
+  console.log(`${LOG} Repairing bundle seal: ${appPath}`);
+  codesign([
+    "--force",
+    "--sign",
+    identity,
+    "--timestamp",
+    "--preserve-metadata=identifier,entitlements,flags",
+    appPath,
+  ]);
+
+  console.log(
+    `${LOG} Complete — helpers re-signed with empty entitlements and bundle seal repaired`
+  );
+}
+
+module.exports = { resignHelpers };

--- a/scripts/resign-helpers-macos.cjs
+++ b/scripts/resign-helpers-macos.cjs
@@ -30,6 +30,12 @@ function detectSigningIdentity(appPath) {
   if (result.error) {
     throw new Error(`${LOG} Failed to inspect signature of ${appPath}: ${result.error.message}`);
   }
+  if (result.status !== 0) {
+    throw new Error(
+      `${LOG} codesign -dvv exited ${result.status} for ${appPath}: ${(result.stderr || "").trim()}. ` +
+        "The .app must be signed before the helpers can be re-signed."
+    );
+  }
   const combined = `${result.stdout || ""}${result.stderr || ""}`;
   const match = combined.match(/^Authority=(Developer ID Application:.*)$/m);
   if (!match) {

--- a/scripts/resign-helpers-macos.test.ts
+++ b/scripts/resign-helpers-macos.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import Module from "module";
+
+const mockExecFileSync = vi.fn();
+const mockSpawnSync = vi.fn();
+const mockExistsSync = vi.fn();
+const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+const originalPlatform = process.platform;
+const originalCscLink = process.env.CSC_LINK;
+
+afterAll(() => {
+  consoleLogSpy.mockRestore();
+  Object.defineProperty(process, "platform", { value: originalPlatform });
+  if (originalCscLink === undefined) delete process.env.CSC_LINK;
+  else process.env.CSC_LINK = originalCscLink;
+});
+
+function setPlatform(platform: string) {
+  Object.defineProperty(process, "platform", { value: platform });
+}
+
+function createContext(overrides: Record<string, any> = {}) {
+  return {
+    appOutDir: "/build/mac-arm64",
+    packager: { appInfo: { productFilename: "Daintree" } },
+    ...overrides,
+  };
+}
+
+function mockFs() {
+  return { existsSync: mockExistsSync };
+}
+
+const SPAWN_HELPER =
+  "/build/mac-arm64/Daintree.app/Contents/Resources/app.asar.unpacked/node_modules/node-pty/build/Release/spawn-helper";
+const SUPERVISOR =
+  "/build/mac-arm64/Daintree.app/Contents/Resources/app.asar.unpacked/node_modules/posix-pty-reaper/build/Release/daintree_pty_supervisor";
+const APP_PATH = "/build/mac-arm64/Daintree.app";
+
+const IDENTITY = "Developer ID Application: Greg Priday (ABCDE12345)";
+
+function mockIdentity(value = IDENTITY) {
+  mockSpawnSync.mockReturnValue({
+    stdout: "",
+    stderr: `Executable=...\nAuthority=${value}\nAuthority=Developer ID Certification Authority\n`,
+  });
+}
+
+describe("resign-helpers-macos", () => {
+  let resignHelpers: (context: any) => Promise<void>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleLogSpy.mockImplementation(() => {});
+    setPlatform("darwin");
+    process.env.CSC_LINK = "/tmp/cert.p12";
+    mockExistsSync.mockReturnValue(true);
+
+    const originalRequire = Module.prototype.require;
+    Module.prototype.require = function (id: string) {
+      if (id === "fs") return mockFs();
+      if (id === "child_process")
+        return { execFileSync: mockExecFileSync, spawnSync: mockSpawnSync };
+      return originalRequire.apply(this, [id]);
+    };
+
+    try {
+      delete require.cache[require.resolve("./resign-helpers-macos.cjs")];
+      resignHelpers = require("./resign-helpers-macos.cjs").resignHelpers;
+    } finally {
+      Module.prototype.require = originalRequire;
+    }
+  });
+
+  it("returns early on non-macOS", async () => {
+    setPlatform("linux");
+    await resignHelpers(createContext());
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+  });
+
+  it("returns early when CSC_LINK is unset (unsigned dev build)", async () => {
+    delete process.env.CSC_LINK;
+    await resignHelpers(createContext());
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+  });
+
+  it("throws when the .app bundle is missing", async () => {
+    mockExistsSync.mockImplementation((p: string) => p !== APP_PATH);
+    await expect(resignHelpers(createContext())).rejects.toThrow(/App bundle not found/);
+  });
+
+  it("throws when a helper executable is missing", async () => {
+    mockExistsSync.mockImplementation((p: string) => p !== SPAWN_HELPER);
+    await expect(resignHelpers(createContext())).rejects.toThrow(/Helper executable not found/);
+  });
+
+  it("throws when no Developer ID Application identity is found", async () => {
+    mockSpawnSync.mockReturnValue({
+      stdout: "",
+      stderr: "Authority=Apple Development: someone\n",
+    });
+    await expect(resignHelpers(createContext())).rejects.toThrow(/Developer ID Application/);
+  });
+
+  it("re-signs both helpers then repairs the bundle seal, in order", async () => {
+    mockIdentity();
+    await resignHelpers(createContext());
+
+    expect(mockExecFileSync).toHaveBeenCalledTimes(3);
+    const targets = mockExecFileSync.mock.calls.map((c: any[]) => c[1][c[1].length - 1]);
+    expect(targets).toEqual([SPAWN_HELPER, SUPERVISOR, APP_PATH]);
+    // Every codesign invocation is the codesign binary.
+    for (const call of mockExecFileSync.mock.calls) {
+      expect(call[0]).toBe("codesign");
+    }
+  });
+
+  it("signs each helper with empty entitlements and hardened runtime", async () => {
+    mockIdentity();
+    await resignHelpers(createContext());
+
+    for (const helper of [SPAWN_HELPER, SUPERVISOR]) {
+      const call = mockExecFileSync.mock.calls.find((c: any[]) => c[1][c[1].length - 1] === helper);
+      expect(call).toBeDefined();
+      const args: string[] = call![1];
+      expect(args).toContain("--force");
+      expect(args).toContain("--options");
+      expect(args[args.indexOf("--options") + 1]).toBe("runtime");
+      expect(args).toContain("--entitlements");
+      expect(args[args.indexOf("--entitlements") + 1]).toMatch(
+        /build\/entitlements\.helpers\.plist$/
+      );
+      expect(args).toContain("--sign");
+      expect(args[args.indexOf("--sign") + 1]).toBe(IDENTITY);
+    }
+  });
+
+  it("preserves identifier, entitlements, and flags on the bundle reseal", async () => {
+    mockIdentity();
+    await resignHelpers(createContext());
+
+    const sealCall = mockExecFileSync.mock.calls.find(
+      (c: any[]) => c[1][c[1].length - 1] === APP_PATH
+    );
+    expect(sealCall).toBeDefined();
+    const args: string[] = sealCall![1];
+    expect(args).toContain("--preserve-metadata=identifier,entitlements,flags");
+    // The seal reseal must NOT pass --entitlements (it would override the app's own).
+    expect(args).not.toContain("--entitlements");
+  });
+});

--- a/scripts/resign-helpers-macos.test.ts
+++ b/scripts/resign-helpers-macos.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
 import Module from "module";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 const mockExecFileSync = vi.fn();
 const mockSpawnSync = vi.fn();
@@ -42,6 +44,7 @@ const IDENTITY = "Developer ID Application: Greg Priday (ABCDE12345)";
 
 function mockIdentity(value = IDENTITY) {
   mockSpawnSync.mockReturnValue({
+    status: 0,
     stdout: "",
     stderr: `Executable=...\nAuthority=${value}\nAuthority=Developer ID Certification Authority\n`,
   });
@@ -99,10 +102,36 @@ describe("resign-helpers-macos", () => {
 
   it("throws when no Developer ID Application identity is found", async () => {
     mockSpawnSync.mockReturnValue({
+      status: 0,
       stdout: "",
       stderr: "Authority=Apple Development: someone\n",
     });
     await expect(resignHelpers(createContext())).rejects.toThrow(/Developer ID Application/);
+  });
+
+  it("surfaces codesign stderr when inspection exits non-zero (unsigned app)", async () => {
+    mockSpawnSync.mockReturnValue({
+      status: 1,
+      stdout: "",
+      stderr: "code object is not signed at all",
+      error: undefined,
+    });
+    await expect(resignHelpers(createContext())).rejects.toThrow(
+      /codesign -dvv exited 1.*not signed/
+    );
+    // No signing attempted when the identity could not be read.
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it("does not attempt the bundle reseal when a helper re-sign fails", async () => {
+    mockIdentity();
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw new Error("codesign: helper sign failed");
+    });
+    await expect(resignHelpers(createContext())).rejects.toThrow(/helper sign failed/);
+    // Only the first helper sign was attempted; the second helper and the
+    // reseal must not run on a half-signed bundle.
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
   });
 
   it("re-signs both helpers then repairs the bundle seal, in order", async () => {
@@ -150,5 +179,15 @@ describe("resign-helpers-macos", () => {
     expect(args).toContain("--preserve-metadata=identifier,entitlements,flags");
     // The seal reseal must NOT pass --entitlements (it would override the app's own).
     expect(args).not.toContain("--entitlements");
+  });
+
+  it("ships a helpers entitlements plist with zero entitlement keys", () => {
+    // Guards against the plist silently accruing entitlements — the whole point
+    // is that the helpers carry none, or amfid kills them again on macOS 26.
+    const plist = readFileSync(
+      join(__dirname, "..", "build", "entitlements.helpers.plist"),
+      "utf-8"
+    );
+    expect(plist).not.toMatch(/<key>/);
   });
 });


### PR DESCRIPTION
## Summary

- On macOS 26 (Tahoe), `amfid` kills any spawned executable that carries a restricted entitlement (`com.apple.security.device.audio-input`) without a provisioning profile. `spawn-helper` and `daintree_pty_supervisor` both inherit this entitlement from the full app plist via `electron-builder`'s `mac.binaries[]` config, so they get killed on launch — breaking terminals and help-session reaping entirely.
- The fix adds an `afterSign` hook (`scripts/resign-helpers-macos.cjs`) that re-signs both helpers with an empty entitlements plist (`build/entitlements.helpers.plist`), preserving the hardened-runtime flag. It then repairs the outer `.app` bundle seal (which breaks when inner binary cdhashes change) using `--preserve-metadata=identifier,entitlements,flags`. Gated on `CSC_LINK` so unsigned dev builds are untouched. The hook is wired into `notarize-macos.cjs` before the skip-notarization early-return so it runs on every signed build, not just notarized ones.
- `electron-builder`'s `mac.binaries[]` has no per-binary entitlements option, which is why this happens in a packaging hook rather than config.

Resolves #9775

## Changes

- `build/entitlements.helpers.plist` — new empty entitlements plist for the helper binaries
- `scripts/resign-helpers-macos.cjs` — the re-sign hook; finds both helpers by name, re-signs with empty entitlements, repairs the outer bundle seal
- `scripts/notarize-macos.cjs` — wires in the re-sign hook
- `scripts/ci/verify-helper-entitlements.sh` — CI script that asserts both helpers carry no entitlements; wired into the `release-macos.yml` signing-audit step
- `scripts/resign-helpers-macos.test.ts` — 11 unit tests covering the re-sign module
- `scripts/notarize-macos.test.ts` — updated to account for the new hook call

## Testing

- 11 unit tests for `resign-helpers-macos.cjs` covering the re-sign path, bundle seal repair, missing-helper handling, and the `CSC_LINK` gate
- `scripts/ci/verify-helper-entitlements.sh` asserts `codesign -d --entitlements -` on both helpers shows no entitlements — this runs as part of the release-macos signing audit
- Unsigned dev builds (`CSC_LINK` unset) are unaffected; the hook exits early
- Smoke-testing on a signed build via `package:local` is the next step; a macOS 26 beta host will confirm the `amfid` fix once available