### PR TITLE
fix(terminal): flush held bytes when a BACKGROUND downgrade flaps back (#9779)

### DIFF
--- a/src/services/terminal/TerminalRendererPolicy.ts
+++ b/src/services/terminal/TerminalRendererPolicy.ts
@@ -67,6 +67,23 @@ export class TerminalRendererPolicy {
     const managed = this.deps.getInstance(id);
     if (!managed) return;
 
+    // #9779: A pending BACKGROUND downgrade in the hysteresis window means the
+    // ingest queue is holding bytes (the computed-tier gate). If the computed
+    // tier flaps back to an active tier before the timer fires, the applied tier
+    // never transitions through "background", so applyRendererPolicyImmediate's
+    // resume-flush branch never runs and the held bytes strand until the next
+    // chunk self-heals (indefinitely if the producer is also quiet). Flush here
+    // at the debounce-cancellation site, before any branch clears the timer.
+    // resumeFlush re-checks the live computed tier and the queue length, so this
+    // is a safe no-op when nothing is held or the terminal is still backgrounded.
+    if (
+      managed.pendingTier === TerminalRefreshTier.BACKGROUND &&
+      managed.tierChangeTimer !== undefined &&
+      tier !== TerminalRefreshTier.BACKGROUND
+    ) {
+      this.deps.onResumeFlush?.(id);
+    }
+
     if (tier === TerminalRefreshTier.FOCUSED || tier === TerminalRefreshTier.BURST) {
       managed.lastActiveTime = Date.now();
     }

--- a/src/services/terminal/__tests__/TerminalRendererPolicy.test.ts
+++ b/src/services/terminal/__tests__/TerminalRendererPolicy.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { TerminalRefreshTier } from "../../../../shared/types/panel";
 import type { ManagedTerminal } from "../types";
 import type { RendererPolicyDeps } from "../TerminalRendererPolicy";
@@ -383,6 +383,114 @@ describe("TerminalRendererPolicy", () => {
       policy.applyRendererPolicy("test-id", TerminalRefreshTier.FOCUSED);
 
       expect(onTierApplied).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("flap-resolution flush (#9779)", () => {
+    let onResumeFlush: ReturnType<typeof vi.fn>;
+
+    beforeEach(async () => {
+      onResumeFlush = vi.fn();
+      mockDeps.onResumeFlush = onResumeFlush;
+      // The active-tier-supersede branch re-arms a downgrade timer via
+      // window.setTimeout; the node test env has no window, so stub it.
+      vi.stubGlobal("window", { setTimeout: vi.fn(() => 999), clearTimeout: vi.fn() });
+      const { TerminalRendererPolicy } = await import("../TerminalRendererPolicy");
+      policy = new TerminalRendererPolicy(mockDeps);
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    // A pending BACKGROUND downgrade is in flight (timer armed) and the computed
+    // tier flaps back to the SAME active tier it left. This lands in the
+    // equal-tier branch, which clears the timer without applying any tier change
+    // — so without the fix the held bytes would never flush.
+    it("flushes on the equal-tier flap-back (FOCUSED → BG-pending → FOCUSED)", () => {
+      mockManagedTerminal.lastAppliedTier = TerminalRefreshTier.FOCUSED;
+      mockManagedTerminal.getRefreshTier = () => TerminalRefreshTier.FOCUSED;
+      mockManagedTerminal.pendingTier = TerminalRefreshTier.BACKGROUND;
+      mockManagedTerminal.tierChangeTimer = 999 as unknown as number;
+
+      policy.applyRendererPolicy("test-id", TerminalRefreshTier.FOCUSED);
+
+      expect(onResumeFlush).toHaveBeenCalledExactlyOnceWith("test-id");
+    });
+
+    // The computed tier flaps to a MORE active tier than the applied one while a
+    // BACKGROUND downgrade is pending. This lands in the upgrade branch; the
+    // applied tier was active throughout so applyRendererPolicyImmediate's own
+    // flush branch (prevBackendTier !== "active") never fires.
+    it("flushes on the upgrade flap (VISIBLE applied, BG-pending → FOCUSED)", () => {
+      mockManagedTerminal.lastAppliedTier = TerminalRefreshTier.VISIBLE;
+      mockManagedTerminal.getRefreshTier = () => TerminalRefreshTier.FOCUSED;
+      mockManagedTerminal.pendingTier = TerminalRefreshTier.BACKGROUND;
+      mockManagedTerminal.tierChangeTimer = 999 as unknown as number;
+
+      policy.applyRendererPolicy("test-id", TerminalRefreshTier.FOCUSED);
+
+      expect(onResumeFlush).toHaveBeenCalledExactlyOnceWith("test-id");
+      // No wake: the applied tier never went to background.
+      expect(mockDeps.wakeAndRestore).not.toHaveBeenCalled();
+    });
+
+    // The pending BACKGROUND downgrade is superseded by a different active-tier
+    // downgrade (FOCUSED → VISIBLE). The old held bytes must drain now rather
+    // than waiting for the new tier's debounce timer to fire.
+    it("flushes when an active-tier downgrade supersedes the BG-pending one", () => {
+      mockManagedTerminal.lastAppliedTier = TerminalRefreshTier.FOCUSED;
+      mockManagedTerminal.getRefreshTier = () => TerminalRefreshTier.VISIBLE;
+      mockManagedTerminal.pendingTier = TerminalRefreshTier.BACKGROUND;
+      mockManagedTerminal.tierChangeTimer = 999 as unknown as number;
+
+      policy.applyRendererPolicy("test-id", TerminalRefreshTier.VISIBLE);
+
+      expect(onResumeFlush).toHaveBeenCalledExactlyOnceWith("test-id");
+    });
+
+    it("does not flush when no BACKGROUND downgrade is pending", () => {
+      mockManagedTerminal.lastAppliedTier = TerminalRefreshTier.VISIBLE;
+      mockManagedTerminal.getRefreshTier = () => TerminalRefreshTier.FOCUSED;
+      mockManagedTerminal.pendingTier = undefined;
+      mockManagedTerminal.tierChangeTimer = undefined;
+
+      policy.applyRendererPolicy("test-id", TerminalRefreshTier.FOCUSED);
+
+      expect(onResumeFlush).not.toHaveBeenCalled();
+    });
+
+    it("does not flush when the pending downgrade targets a non-BACKGROUND tier", () => {
+      mockManagedTerminal.lastAppliedTier = TerminalRefreshTier.FOCUSED;
+      mockManagedTerminal.getRefreshTier = () => TerminalRefreshTier.FOCUSED;
+      mockManagedTerminal.pendingTier = TerminalRefreshTier.VISIBLE;
+      mockManagedTerminal.tierChangeTimer = 999 as unknown as number;
+
+      policy.applyRendererPolicy("test-id", TerminalRefreshTier.FOCUSED);
+
+      expect(onResumeFlush).not.toHaveBeenCalled();
+    });
+
+    it("does not flush when the incoming tier is itself BACKGROUND", () => {
+      mockManagedTerminal.lastAppliedTier = TerminalRefreshTier.FOCUSED;
+      mockManagedTerminal.getRefreshTier = () => TerminalRefreshTier.BACKGROUND;
+      mockManagedTerminal.pendingTier = TerminalRefreshTier.BACKGROUND;
+      mockManagedTerminal.tierChangeTimer = 999 as unknown as number;
+
+      policy.applyRendererPolicy("test-id", TerminalRefreshTier.BACKGROUND);
+
+      expect(onResumeFlush).not.toHaveBeenCalled();
+    });
+
+    it("does not flush when a timer is armed but no tier is pending", () => {
+      mockManagedTerminal.lastAppliedTier = TerminalRefreshTier.FOCUSED;
+      mockManagedTerminal.getRefreshTier = () => TerminalRefreshTier.FOCUSED;
+      mockManagedTerminal.pendingTier = undefined;
+      mockManagedTerminal.tierChangeTimer = 999 as unknown as number;
+
+      policy.applyRendererPolicy("test-id", TerminalRefreshTier.FOCUSED);
+
+      expect(onResumeFlush).not.toHaveBeenCalled();
     });
   });
 

--- a/src/services/terminal/__tests__/TerminalRendererPolicy.test.ts
+++ b/src/services/terminal/__tests__/TerminalRendererPolicy.test.ts
@@ -494,6 +494,52 @@ describe("TerminalRendererPolicy", () => {
     });
   });
 
+  // Uses real (faked) timers to prove the flush hook coexists with — and the
+  // flap-back actually cancels — the armed downgrade timer. The sentinel-stub
+  // block above checks the hook fires; this verifies the timer never fires.
+  describe("flap-resolution timer cancellation (#9779)", () => {
+    let onResumeFlush: ReturnType<typeof vi.fn>;
+
+    beforeEach(async () => {
+      vi.useFakeTimers();
+      onResumeFlush = vi.fn();
+      mockDeps.onResumeFlush = onResumeFlush;
+      // The implementation arms timers via window.setTimeout; point window at
+      // the faked global timers so setTimeout/clearTimeout stay consistent.
+      vi.stubGlobal("window", globalThis);
+      const { TerminalRendererPolicy } = await import("../TerminalRendererPolicy");
+      policy = new TerminalRendererPolicy(mockDeps);
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    });
+
+    it("flushes once and cancels the armed timer so BACKGROUND never applies", () => {
+      mockManagedTerminal.lastAppliedTier = TerminalRefreshTier.FOCUSED;
+      mockManagedTerminal.getRefreshTier = () => TerminalRefreshTier.FOCUSED;
+
+      // Computed tier drops to BACKGROUND: arms the real 500ms downgrade timer.
+      policy.applyRendererPolicy("test-id", TerminalRefreshTier.BACKGROUND);
+      expect(mockManagedTerminal.pendingTier).toBe(TerminalRefreshTier.BACKGROUND);
+      expect(mockManagedTerminal.tierChangeTimer).not.toBeUndefined();
+      expect(onResumeFlush).not.toHaveBeenCalled();
+
+      // Flap back to FOCUSED before the timer fires.
+      policy.applyRendererPolicy("test-id", TerminalRefreshTier.FOCUSED);
+      expect(onResumeFlush).toHaveBeenCalledExactlyOnceWith("test-id");
+      expect(mockManagedTerminal.pendingTier).toBeUndefined();
+      expect(mockManagedTerminal.tierChangeTimer).toBeUndefined();
+
+      // Advancing past the hysteresis window must NOT apply BACKGROUND — the
+      // timer was cancelled, so the applied tier stays FOCUSED.
+      vi.advanceTimersByTime(1000);
+      expect(mockManagedTerminal.lastAppliedTier).toBe(TerminalRefreshTier.FOCUSED);
+      expect(onResumeFlush).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("clearTierState", () => {
     it("should remove tier state for terminal", () => {
       policy.initializeBackendTier("test-id", "background");

--- a/src/services/terminal/__tests__/TerminalRendererPolicy.test.ts
+++ b/src/services/terminal/__tests__/TerminalRendererPolicy.test.ts
@@ -391,7 +391,7 @@ describe("TerminalRendererPolicy", () => {
 
     beforeEach(async () => {
       onResumeFlush = vi.fn();
-      mockDeps.onResumeFlush = onResumeFlush;
+      mockDeps.onResumeFlush = onResumeFlush as unknown as ((id: string) => void) | undefined;
       // The active-tier-supersede branch re-arms a downgrade timer via
       // window.setTimeout; the node test env has no window, so stub it.
       vi.stubGlobal("window", { setTimeout: vi.fn(() => 999), clearTimeout: vi.fn() });
@@ -503,7 +503,7 @@ describe("TerminalRendererPolicy", () => {
     beforeEach(async () => {
       vi.useFakeTimers();
       onResumeFlush = vi.fn();
-      mockDeps.onResumeFlush = onResumeFlush;
+      mockDeps.onResumeFlush = onResumeFlush as unknown as ((id: string) => void) | undefined;
       // The implementation arms timers via window.setTimeout; point window at
       // the faked global timers so setTimeout/clearTimeout stay consistent.
       vi.stubGlobal("window", globalThis);


### PR DESCRIPTION
## Summary

When a terminal's computed refresh tier flaps to `BACKGROUND` and back within the `TIER_DOWNGRADE_HYSTERESIS_MS` debounce window, bytes held in the ingest queue during that window would strand indefinitely. The flush path (`resumeFlush`) only fires on applied-tier transitions — but because the debounce keeps the applied tier from changing during a short flap, no flush ever fires. New incoming data self-heals the queue, but if the PTY producer also goes quiet, the pane shows stale output until new data arrives.

The fix is a small hook at the top of `applyRendererPolicy`: when a pending `BACKGROUND` downgrade is being cancelled (flap-back, upgrade, or active-downgrade supersede), call `onResumeFlush` before clearing the timer. `resumeFlush` re-checks the live computed tier and queue length so it's a safe no-op when there's nothing to drain.

Resolves #9779

## Changes

- `TerminalRendererPolicy.ts`: 4-line hook in `applyRendererPolicy` detects a pending `BACKGROUND` downgrade being resolved to a non-background tier and calls `onResumeFlush`
- `TerminalRendererPolicy.test.ts`: 8 new tests — 3 positive branch variants (equal-tier flap-back, upgrade flap, active-downgrade supersede) + 4 negatives + 1 fake-timer test proving the 500ms timer is cancelled on flap-back so `BACKGROUND` never applies

## Testing

29 tests pass. `npm run check` passes (typecheck, lint-ratchet at baseline, format).