### PR TITLE
fix(pty-host): reconcile renderer tier state on host-side recompute

### DIFF
--- a/electron/__tests__/pty-host.adversarial.test.ts
+++ b/electron/__tests__/pty-host.adversarial.test.ts
@@ -966,4 +966,78 @@ describe("pty-host adversarial", () => {
     expect(queueManager.events).toEqual(["resumeAll", "dispose"]);
     expect(terminal.ptyProcess.resume).toHaveBeenCalledTimes(1);
   });
+
+  it("TIER_CHANGED_BROADCAST_RESPECTS_PROJECT_FILTER", async () => {
+    // recomputeActivityTiers must push a tier-changed reconciliation message to
+    // exactly the renderer ports that also receive the terminal's data — i.e.
+    // the same per-window project filter as the data path. Otherwise the
+    // renderer's dedupe baseline goes stale and output freezes (issue #9778).
+    const parentPort = await loadHost();
+    hostState.terminals.set("t1", createTerminal("t1", "project-1"));
+
+    const portA = createRendererPort();
+    const portB = createRendererPort();
+    parentPort.emit("message", { data: { type: "connect-port", windowId: 1 }, ports: [portA] });
+    parentPort.emit("message", { data: { type: "connect-port", windowId: 2 }, ports: [portB] });
+    await flushMicrotasks();
+
+    // Window 2 owns project-2 first so the later window-1 recompute is the one
+    // under assertion; clear both ports of the intermediate broadcast.
+    parentPort.emit("message", { type: "set-active-project", windowId: 2, projectId: "project-2" });
+    await flushMicrotasks();
+    portA.postMessage.mockClear();
+    portB.postMessage.mockClear();
+
+    // Window 1 activates project-1 (t1's project) → recompute → broadcast.
+    parentPort.emit("message", { type: "set-active-project", windowId: 1, projectId: "project-1" });
+    await flushMicrotasks();
+
+    const tierA = portA.postMessage.mock.calls
+      .map((c: unknown[]) => c[0])
+      .filter((m: { type?: string }) => m?.type === "tier-changed");
+    const tierB = portB.postMessage.mock.calls
+      .map((c: unknown[]) => c[0])
+      .filter((m: { type?: string }) => m?.type === "tier-changed");
+
+    // Window 1 (project-1) is the consumer of t1 — it gets the reconciliation.
+    expect(tierA).toContainEqual({ type: "tier-changed", id: "t1", tier: "active" });
+    // Window 2 (project-2) is project-filtered away from t1 — nothing leaks to it.
+    expect(tierB.some((m: { id?: string }) => m.id === "t1")).toBe(false);
+  });
+
+  it("UNDEFINED_PROJECT_TERMINAL_STAYS_ACTIVE_WHEN_PROJECTS_ACTIVE", async () => {
+    // Aggravating #9778 detail: a terminal with no project association is
+    // global/shared, not orphaned. It must stay active whenever any project is
+    // active, while a terminal genuinely belonging to an inactive project is
+    // correctly backgrounded.
+    const parentPort = await loadHost();
+    const backpressure = hostState.backpressureManagers[0];
+    hostState.terminals.set("t-global", createTerminal("t-global")); // undefined projectId
+    hostState.terminals.set("t-other", createTerminal("t-other", "project-2"));
+
+    parentPort.emit("message", { type: "set-active-project", windowId: 1, projectId: "project-1" });
+    await flushMicrotasks();
+
+    expect(backpressure.getActivityTier("t-global")).toBe("active");
+    expect(backpressure.getActivityTier("t-other")).toBe("background");
+  });
+
+  it("RECOMPUTE_WITH_NO_RENDERER_CONNECTIONS_IS_SAFE", async () => {
+    // With no connected ports the broadcast loop must no-op without throwing,
+    // while tiers are still applied to the backpressure manager.
+    const parentPort = await loadHost();
+    const backpressure = hostState.backpressureManagers[0];
+    hostState.terminals.set("t1", createTerminal("t1", "project-1"));
+
+    expect(() =>
+      parentPort.emit("message", {
+        type: "set-active-project",
+        windowId: 1,
+        projectId: "project-1",
+      })
+    ).not.toThrow();
+    await flushMicrotasks();
+
+    expect(backpressure.getActivityTier("t1")).toBe("active");
+  });
 });

--- a/electron/__tests__/pty-host.adversarial.test.ts
+++ b/electron/__tests__/pty-host.adversarial.test.ts
@@ -994,15 +994,30 @@ describe("pty-host adversarial", () => {
 
     const tierA = portA.postMessage.mock.calls
       .map((c: unknown[]) => c[0])
-      .filter((m: { type?: string }) => m?.type === "tier-changed");
+      .filter(
+        (m: unknown): m is { type: string } =>
+          typeof m === "object" &&
+          m !== null &&
+          (m as Record<string, unknown>).type === "tier-changed"
+      );
     const tierB = portB.postMessage.mock.calls
       .map((c: unknown[]) => c[0])
-      .filter((m: { type?: string }) => m?.type === "tier-changed");
+      .filter(
+        (m: unknown): m is { type: string } =>
+          typeof m === "object" &&
+          m !== null &&
+          (m as Record<string, unknown>).type === "tier-changed"
+      );
 
     // Window 1 (project-1) is the consumer of t1 — it gets the reconciliation.
     expect(tierA).toContainEqual({ type: "tier-changed", id: "t1", tier: "active" });
     // Window 2 (project-2) is project-filtered away from t1 — nothing leaks to it.
-    expect(tierB.some((m: { id?: string }) => m.id === "t1")).toBe(false);
+    expect(
+      tierB.some(
+        (m: unknown) =>
+          typeof m === "object" && m !== null && (m as Record<string, unknown>).id === "t1"
+      )
+    ).toBe(false);
   });
 
   it("UNDEFINED_PROJECT_TERMINAL_STAYS_ACTIVE_WHEN_PROJECTS_ACTIVE", async () => {
@@ -1063,7 +1078,12 @@ describe("pty-host adversarial", () => {
 
     const tierHealthy = portHealthy.postMessage.mock.calls
       .map((c: unknown[]) => c[0])
-      .filter((m: { type?: string }) => m?.type === "tier-changed");
+      .filter(
+        (m: unknown): m is { type: string } =>
+          typeof m === "object" &&
+          m !== null &&
+          (m as Record<string, unknown>).type === "tier-changed"
+      );
     expect(tierHealthy).toContainEqual({ type: "tier-changed", id: "t1", tier: "active" });
   });
 

--- a/electron/__tests__/pty-host.adversarial.test.ts
+++ b/electron/__tests__/pty-host.adversarial.test.ts
@@ -1022,6 +1022,51 @@ describe("pty-host adversarial", () => {
     expect(backpressure.getActivityTier("t-other")).toBe("background");
   });
 
+  it("TIER_CHANGED_BROADCAST_TOLERATES_A_CLOSING_PORT", async () => {
+    // A port that throws on postMessage (closing mid-iteration) must not block
+    // the reconciliation from reaching the other still-open ports. Window 1 is
+    // connected first, so it is iterated first and exercises the try/catch.
+    const parentPort = await loadHost();
+    hostState.terminals.set("t1", createTerminal("t1", "project-1"));
+
+    const portThrowing = createRendererPort();
+    const portHealthy = createRendererPort();
+    parentPort.emit("message", {
+      data: { type: "connect-port", windowId: 1 },
+      ports: [portThrowing],
+    });
+    parentPort.emit("message", {
+      data: { type: "connect-port", windowId: 2 },
+      ports: [portHealthy],
+    });
+    await flushMicrotasks();
+
+    // Both windows own t1's project, so both are broadcast targets.
+    parentPort.emit("message", { type: "set-active-project", windowId: 1, projectId: "project-1" });
+    parentPort.emit("message", { type: "set-active-project", windowId: 2, projectId: "project-1" });
+    await flushMicrotasks();
+    portThrowing.postMessage.mockClear();
+    portHealthy.postMessage.mockClear();
+    portThrowing.postMessage.mockImplementation(() => {
+      throw new Error("port closing");
+    });
+
+    // Re-applying window 2's project triggers a fresh recompute + broadcast.
+    expect(() =>
+      parentPort.emit("message", {
+        type: "set-active-project",
+        windowId: 2,
+        projectId: "project-1",
+      })
+    ).not.toThrow();
+    await flushMicrotasks();
+
+    const tierHealthy = portHealthy.postMessage.mock.calls
+      .map((c: unknown[]) => c[0])
+      .filter((m: { type?: string }) => m?.type === "tier-changed");
+    expect(tierHealthy).toContainEqual({ type: "tier-changed", id: "t1", tier: "active" });
+  });
+
   it("RECOMPUTE_WITH_NO_RENDERER_CONNECTIONS_IS_SAFE", async () => {
     // With no connected ports the broadcast loop must no-op without throwing,
     // while tiers are still applied to the backpressure manager.

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -215,12 +215,36 @@ function recomputeActivityTiers(): void {
   }
 
   for (const terminal of ptyManager.getAll()) {
+    // A terminal with no project association is global/shared, not orphaned —
+    // it must stay active whenever any window is connected. The old condition
+    // (`projectId !== undefined && activeProjects.has(projectId)`) demoted such
+    // terminals to background the moment any project became active, silently
+    // freezing their output (issue #9778).
     const isActiveInAnyWindow =
       activeProjects.size === 0 ||
-      (terminal.projectId !== undefined && activeProjects.has(terminal.projectId));
+      terminal.projectId === undefined ||
+      activeProjects.has(terminal.projectId);
     const tier = isActiveInAnyWindow ? "active" : "background";
     backpressureManager.setActivityTier(terminal.id, tier);
     ptyManager.setActivityMonitorTier(terminal.id, tier === "active" ? 50 : 500);
+
+    // Reconcile the renderer's dedupe baseline. The host rewrites tiers here
+    // unilaterally, but TerminalRendererPolicy.setBackendTier dedupes outbound
+    // tier messages against its last-known tier — so without this push the
+    // renderer can believe a terminal is still "active" while the producer gate
+    // suppresses its bytes, leaving the pane frozen (issue #9778). Posted on the
+    // same per-window MessagePort as data so it stays FIFO-ordered ahead of any
+    // subsequently gated chunk. Projects are filtered exactly like the data path.
+    const termProject = terminal.projectId ?? null;
+    for (const [windowId, conn] of rendererConnections) {
+      const windowProject = windowProjectMap.get(windowId) ?? null;
+      if (windowProject !== null && termProject !== windowProject) continue;
+      try {
+        conn.port.postMessage({ type: "tier-changed", id: terminal.id, tier });
+      } catch {
+        // Port closing between iteration and post — disconnect handles cleanup.
+      }
+    }
   }
 }
 

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -567,13 +567,26 @@ export type RendererToPtyHostMessage =
 /**
  * Messages sent from Pty Host → Renderer via MessagePort (direct channel).
  * These bypass the Main process for low-latency terminal output.
+ *
+ * `tier-changed` reconciles the renderer's dedupe baseline when the host
+ * rewrites a terminal's activity tier on its own (window connect/disconnect/
+ * project switch via `recomputeActivityTiers`). It rides the same per-window
+ * MessagePort as `data`, so it is FIFO-ordered ahead of any subsequently
+ * suppressed/emitted chunk — routing it through the Main process instead would
+ * race the direct data path and lose that ordering guarantee.
  */
-export type PtyHostToRendererMessage = {
-  type: "data";
-  id: string;
-  data: Uint8Array;
-  bytes: number;
-};
+export type PtyHostToRendererMessage =
+  | {
+      type: "data";
+      id: string;
+      data: Uint8Array;
+      bytes: number;
+    }
+  | {
+      type: "tier-changed";
+      id: string;
+      tier: "active" | "background";
+    };
 
 /** Per-process resource breakdown entry */
 export interface TerminalResourceProcess {

--- a/src/clients/__tests__/terminalClient.test.ts
+++ b/src/clients/__tests__/terminalClient.test.ts
@@ -346,4 +346,84 @@ describe("terminalClient MessagePort data routing", () => {
       }, 50);
     });
   });
+
+  it("dispatches MessagePort tier-changed messages to onTierChanged callbacks", () => {
+    const port = acquirePort();
+    const received: Array<{ id: string; tier: string }> = [];
+
+    terminalClient.onTierChanged((id, tier) => received.push({ id, tier }));
+
+    port.postMessage({ type: "tier-changed", id: "term-1", tier: "background" });
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(received).toEqual([{ id: "term-1", tier: "background" }]);
+        resolve();
+      }, 50);
+    });
+  });
+
+  it("does NOT ack or buffer tier-changed messages (no byte accounting)", () => {
+    const port = acquirePort();
+
+    terminalClient.onTierChanged(() => {});
+
+    // A tier-changed message carries no bytes — it must never enter the ACK loop
+    // the way unconsumed data does (which would emit an immediate early-buffer ack).
+    port.postMessage({ type: "tier-changed", id: "term-1", tier: "active" });
+
+    return new Promise<void>((resolve) => {
+      const acks: Record<string, unknown>[] = [];
+      port.addEventListener("message", (event: MessageEvent) => {
+        const msg = event.data as Record<string, unknown>;
+        if (msg?.type === "ack") acks.push(msg);
+      });
+      port.start();
+
+      setTimeout(() => {
+        expect(acks).toEqual([]);
+        resolve();
+      }, 100);
+    });
+  });
+
+  it("stops dispatching tier-changed after unsubscribe", () => {
+    const port = acquirePort();
+    const received: string[] = [];
+
+    const unsub = terminalClient.onTierChanged((id) => received.push(id));
+    unsub();
+
+    port.postMessage({ type: "tier-changed", id: "term-1", tier: "background" });
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(received).toEqual([]);
+        resolve();
+      }, 50);
+    });
+  });
+
+  it("ignores unknown message types without throwing or emitting acks", () => {
+    const port = acquirePort();
+    const tierReceived: string[] = [];
+    terminalClient.onTierChanged((id) => tierReceived.push(id));
+
+    port.postMessage({ type: "totally-unknown", id: "term-1" } as unknown);
+
+    return new Promise<void>((resolve) => {
+      const acks: Record<string, unknown>[] = [];
+      port.addEventListener("message", (event: MessageEvent) => {
+        const msg = event.data as Record<string, unknown>;
+        if (msg?.type === "ack") acks.push(msg);
+      });
+      port.start();
+
+      setTimeout(() => {
+        expect(acks).toEqual([]);
+        expect(tierReceived).toEqual([]);
+        resolve();
+      }, 100);
+    });
+  });
 });

--- a/src/clients/__tests__/terminalClient.test.ts
+++ b/src/clients/__tests__/terminalClient.test.ts
@@ -404,6 +404,27 @@ describe("terminalClient MessagePort data routing", () => {
     });
   });
 
+  it("tolerates tier-changed for an unknown terminal and keeps dispatching", () => {
+    const port = acquirePort();
+    const received: Array<{ id: string; tier: string }> = [];
+    terminalClient.onTierChanged((id, tier) => received.push({ id, tier }));
+
+    // A tier-changed for a terminal the consumer doesn't track must not throw
+    // or wedge the dispatcher — the consumer routes by id internally.
+    port.postMessage({ type: "tier-changed", id: "no-such-terminal", tier: "background" });
+    port.postMessage({ type: "tier-changed", id: "term-1", tier: "active" });
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(received).toEqual([
+          { id: "no-such-terminal", tier: "background" },
+          { id: "term-1", tier: "active" },
+        ]);
+        resolve();
+      }, 50);
+    });
+  });
+
   it("ignores unknown message types without throwing or emitting acks", () => {
     const port = acquirePort();
     const tierReceived: string[] = [];

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -24,9 +24,22 @@ const earlyDataBuffer = new Map<string, Array<string | Uint8Array>>();
 const pendingPortAckBytes = new Map<string, number[]>();
 const MAX_EARLY_BUFFER_CHUNKS = 500;
 
+// Single global subscriber set — the host pushes tier-changed reconciliation
+// messages for any terminal, and the lone consumer (TerminalInstanceService)
+// routes by id internally. No per-terminal map and no ACK accounting: these
+// control messages carry no byte count and must never enter pendingPortAckBytes.
+const tierChangedCallbacks = new Set<(id: string, tier: "active" | "background") => void>();
+
 function installPortDataHandler(port: MessagePort): void {
   port.addEventListener("message", (event: MessageEvent) => {
     const msg = event.data as PtyHostToRendererMessage;
+    if (msg?.type === "tier-changed" && typeof msg.id === "string") {
+      // Host-pushed tier reconciliation — no ACK, no byte accounting.
+      for (const cb of tierChangedCallbacks) {
+        cb(msg.id, msg.tier);
+      }
+      return;
+    }
     if (msg?.type === "data" && typeof msg.id === "string") {
       const byteCount = msg.bytes ?? 0;
 
@@ -282,6 +295,21 @@ export const terminalClient = {
         if (set.size === 0) dataCallbacks.delete(id);
       }
       ipcCleanup();
+    };
+  },
+
+  /**
+   * Subscribe to host-pushed activity-tier reconciliation messages.
+   * The PTY host emits these whenever it rewrites a terminal's tier on its own
+   * (window connect/disconnect/project switch) so the renderer can re-arm its
+   * dedupe baseline (TerminalRendererPolicy.initializeBackendTier) before the
+   * producer gate suppresses output. Rides the per-window MessagePort, so it is
+   * FIFO-ordered ahead of subsequent data chunks. Returns a cleanup function.
+   */
+  onTierChanged: (callback: (id: string, tier: "active" | "background") => void): (() => void) => {
+    tierChangedCallbacks.add(callback);
+    return () => {
+      tierChangedCallbacks.delete(callback);
     };
   },
 

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -318,13 +318,19 @@ class TerminalInstanceService {
     // The service is a page-lifetime singleton, so the unsubscribe is intentionally
     // discarded — the subscription is one-shot and never needs teardown.
     onTerminalFontArrivedLate(() => this.repairFontGrid());
+  }
 
-    // Reconcile our renderer-side dedupe baseline when the PTY host rewrites a
-    // terminal's tier on its own (window connect/disconnect/project switch).
-    // initializeBackendTier updates lastBackendTier without echoing back to the
-    // host, so a later applyRendererPolicy correctly re-sends "active" instead
-    // of dedupe-dropping it and leaving the pane frozen (issue #9778, the
-    // same-tier no-op re-arm trap from #8998).
+  // Reconcile our renderer-side dedupe baseline when the PTY host rewrites a
+  // terminal's tier on its own (window connect/disconnect/project switch).
+  // initializeBackendTier updates lastBackendTier without echoing back to the
+  // host, so a later applyRendererPolicy correctly re-sends "active" instead of
+  // dedupe-dropping it and leaving the pane frozen (issue #9778, the same-tier
+  // no-op re-arm trap from #8998). Installed lazily on first terminal creation
+  // — the same point onData/onExit are wired — so merely constructing the
+  // singleton never reaches into terminalClient (keeps it out of the hot import
+  // graph for unrelated component tests).
+  private ensureHostTierSubscription(): void {
+    if (this.unsubTierChanged) return;
     this.unsubTierChanged = terminalClient.onTierChanged((id, tier) => {
       this.rendererPolicy.initializeBackendTier(id, tier);
     });
@@ -1031,6 +1037,9 @@ class TerminalInstanceService {
     const listeners: Array<() => void> = [];
     const exitSubscribers = new Set<(exitCode: number) => void>();
     const agentStateSubscribers = new Set<AgentStateCallback>();
+
+    // Wire the host→renderer tier reconciliation on first terminal creation.
+    this.ensureHostTierSubscription();
 
     const unsubData = terminalClient.onData(id, (data: string | Uint8Array) => {
       if (this.dataBuffer.isPolling()) return;

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -112,6 +112,7 @@ class TerminalInstanceService {
   private hibernationManager: TerminalHibernationManager;
   private reflowController: TerminalReflowController;
   private writeController: TerminalWriteController;
+  private unsubTierChanged: (() => void) | null = null;
 
   constructor() {
     if (canAutoInitializeTerminalIngest()) {
@@ -317,6 +318,16 @@ class TerminalInstanceService {
     // The service is a page-lifetime singleton, so the unsubscribe is intentionally
     // discarded — the subscription is one-shot and never needs teardown.
     onTerminalFontArrivedLate(() => this.repairFontGrid());
+
+    // Reconcile our renderer-side dedupe baseline when the PTY host rewrites a
+    // terminal's tier on its own (window connect/disconnect/project switch).
+    // initializeBackendTier updates lastBackendTier without echoing back to the
+    // host, so a later applyRendererPolicy correctly re-sends "active" instead
+    // of dedupe-dropping it and leaving the pane frozen (issue #9778, the
+    // same-tier no-op re-arm trap from #8998).
+    this.unsubTierChanged = terminalClient.onTierChanged((id, tier) => {
+      this.rendererPolicy.initializeBackendTier(id, tier);
+    });
   }
 
   setGPUHardwareAvailable(available: boolean): void {
@@ -2566,6 +2577,8 @@ class TerminalInstanceService {
 
   dispose(): void {
     this.stopPolling();
+    this.unsubTierChanged?.();
+    this.unsubTierChanged = null;
     // Abort any in-flight chunked resize pass so its yielded continuation
     // doesn't resume against a torn-down service.
     this.resizePassAbort?.abort();

--- a/src/services/terminal/__tests__/TerminalInstanceService.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.adversarial.test.ts
@@ -13,6 +13,7 @@ const testState = vi.hoisted(() => ({
     resize: vi.fn(),
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onTierChanged: vi.fn(() => vi.fn()),
     write: vi.fn(),
     setActivityTier: vi.fn(),
     wake: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.attach.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.attach.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/clients", () => ({
     resize: vi.fn(),
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onTierChanged: vi.fn(() => vi.fn()),
     write: vi.fn(),
     setActivityTier: vi.fn(),
     wake: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.batchResize.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.batchResize.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/clients", () => ({
     resize: vi.fn(),
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onTierChanged: vi.fn(() => vi.fn()),
     write: vi.fn(),
     setActivityTier: vi.fn(),
     wake: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.captureBufferText.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.captureBufferText.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/clients", () => ({
     resize: vi.fn(),
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onTierChanged: vi.fn(() => vi.fn()),
     write: vi.fn(),
     setActivityTier: vi.fn(),
     wake: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.dataLoss.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.dataLoss.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/clients", () => ({
     resize: vi.fn(),
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onTierChanged: vi.fn(() => vi.fn()),
     write: vi.fn(),
     setActivityTier: vi.fn(),
     wake: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.detach.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.detach.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/clients", () => ({
     resize: vi.fn(),
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onTierChanged: vi.fn(() => vi.fn()),
     write: vi.fn(),
     setActivityTier: vi.fn(),
     wake: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/clients", () => ({
     resize: vi.fn(),
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onTierChanged: vi.fn(() => vi.fn()),
     write: vi.fn(),
     setActivityTier: vi.fn(),
     wake: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
@@ -6,6 +6,7 @@ import { AGENT_IDLE_SILENCE_MS, HIBERNATION_DELAY_MS } from "../types";
 const mockTerminalClient = {
   onData: vi.fn(() => vi.fn()),
   onExit: vi.fn(() => vi.fn()),
+  onTierChanged: vi.fn(() => vi.fn()),
   setActivityTier: vi.fn(),
   wake: vi.fn().mockResolvedValue({ state: null }),
   write: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.hoveredLink.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.hoveredLink.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/clients", () => ({
     resize: vi.fn(),
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onTierChanged: vi.fn(() => vi.fn()),
     write: vi.fn(),
     setActivityTier: vi.fn(),
     wake: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.installerCallSite.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.installerCallSite.test.ts
@@ -16,6 +16,7 @@ vi.mock("../TerminalListenerInstaller", () => ({
 const mockTerminalClient = {
   onData: vi.fn(() => vi.fn()),
   onExit: vi.fn(() => vi.fn()),
+  onTierChanged: vi.fn(() => vi.fn()),
   setActivityTier: vi.fn(),
   wake: vi.fn().mockResolvedValue({ state: null }),
   write: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.lastActivity.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.lastActivity.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/clients", () => ({
     resize: vi.fn(),
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onTierChanged: vi.fn(() => vi.fn()),
     write: vi.fn(),
     setActivityTier: vi.fn(),
     wake: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/clients", () => ({
   terminalClient: {
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onTierChanged: vi.fn(() => vi.fn()),
     setActivityTier: vi.fn(),
     wake: vi.fn(),
     resize: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.postWake.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.postWake.test.ts
@@ -5,6 +5,7 @@ const { mockTerminalClient } = vi.hoisted(() => ({
     resize: vi.fn(),
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onTierChanged: vi.fn(() => vi.fn()),
     write: vi.fn(),
     setActivityTier: vi.fn(),
     wake: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/clients", () => ({
     resize: vi.fn(),
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onTierChanged: vi.fn(() => vi.fn()),
     write: vi.fn(),
     setActivityTier: vi.fn(),
     wake: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.resizePass.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.resizePass.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/clients", () => ({
     resize: vi.fn(),
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onTierChanged: vi.fn(() => vi.fn()),
     write: vi.fn(),
     setActivityTier: vi.fn(),
     wake: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.restore.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.restore.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/clients", () => ({
   terminalClient: {
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onTierChanged: vi.fn(() => vi.fn()),
     setActivityTier: vi.fn(),
     wake: vi.fn(),
     getSerializedState: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.scrollback.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.scrollback.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/clients", () => ({
     resize: vi.fn(),
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onTierChanged: vi.fn(() => vi.fn()),
     write: vi.fn(),
     setActivityTier: vi.fn(),
     wake: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.selection.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.selection.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/clients", () => ({
     resize: vi.fn(),
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onTierChanged: vi.fn(() => vi.fn()),
     write: vi.fn(),
     setActivityTier: vi.fn(),
     wake: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
@@ -2,9 +2,17 @@
 import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
 import { TerminalRefreshTier } from "../../../../shared/types/panel";
 
+// Captured at service construction so tests can drive the host→renderer tier
+// reconciliation path even after vi.clearAllMocks() wipes spy call history.
+let capturedTierChangedCb: ((id: string, tier: "active" | "background") => void) | null = null;
+
 const mockTerminalClient = {
   onData: vi.fn(() => vi.fn()),
   onExit: vi.fn(() => vi.fn()),
+  onTierChanged: vi.fn((cb: (id: string, tier: "active" | "background") => void) => {
+    capturedTierChangedCb = cb;
+    return vi.fn();
+  }),
   setActivityTier: vi.fn(),
   wake: vi.fn(),
   getSerializedState: vi.fn(),
@@ -288,6 +296,42 @@ describe("TerminalInstanceService - Activity Tier", () => {
     it("should be documented as part of the hydration flow", () => {
       // Unit tests for the actual logic are in TerminalRendererPolicy.test.ts
       expect(true).toBe(true);
+    });
+  });
+
+  describe("host-pushed tier reconciliation (issue #9778)", () => {
+    it("subscribes to terminalClient.onTierChanged at construction", () => {
+      // The service must register a single global subscription that reconciles
+      // the renderer's dedupe baseline whenever the PTY host rewrites a tier.
+      expect(capturedTierChangedCb).toBeTypeOf("function");
+    });
+
+    it("re-arms needsWake when the host pushes a background demotion", () => {
+      const managed = makeMockManaged({
+        lastAppliedTier: TerminalRefreshTier.FOCUSED,
+        needsWake: false,
+      });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      // Simulate the host's recomputeActivityTiers demoting this terminal and
+      // pushing the tier-changed control message over the MessagePort. The
+      // wiring must funnel it into rendererPolicy.initializeBackendTier, which
+      // for a background tier sets needsWake so the next activation wakes/flushes.
+      capturedTierChangedCb?.("t1", "background");
+
+      expect(managed.needsWake).toBe(true);
+    });
+
+    it("does not force a wake when the host pushes an active tier", () => {
+      const managed = makeMockManaged({
+        lastAppliedTier: TerminalRefreshTier.FOCUSED,
+        needsWake: false,
+      });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      capturedTierChangedCb?.("t1", "active");
+
+      expect(managed.needsWake).toBe(false);
     });
   });
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
@@ -300,13 +300,18 @@ describe("TerminalInstanceService - Activity Tier", () => {
   });
 
   describe("host-pushed tier reconciliation (issue #9778)", () => {
-    it("subscribes to terminalClient.onTierChanged at construction", () => {
-      // The service must register a single global subscription that reconciles
-      // the renderer's dedupe baseline whenever the PTY host rewrites a tier.
+    it("subscribes to terminalClient.onTierChanged on first terminal creation", () => {
+      // The subscription is installed lazily (alongside onData/onExit) so that
+      // merely constructing the singleton never reaches into terminalClient —
+      // keeping it out of unrelated component tests' import graph.
+      service.prewarmTerminal("warm", "terminal", {});
       expect(capturedTierChangedCb).toBeTypeOf("function");
     });
 
     it("re-arms needsWake when the host pushes a background demotion", () => {
+      // Create a terminal so the lazy onTierChanged subscription is installed.
+      service.prewarmTerminal("warm", "terminal", {});
+
       const managed = makeMockManaged({
         lastAppliedTier: TerminalRefreshTier.FOCUSED,
         needsWake: false,
@@ -323,6 +328,8 @@ describe("TerminalInstanceService - Activity Tier", () => {
     });
 
     it("does not force a wake when the host pushes an active tier", () => {
+      service.prewarmTerminal("warm", "terminal", {});
+
       const managed = makeMockManaged({
         lastAppliedTier: TerminalRefreshTier.FOCUSED,
         needsWake: false,

--- a/src/services/terminal/__tests__/TerminalInstanceService.viewportPinning.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.viewportPinning.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/clients", () => ({
     resize: vi.fn(),
     onData: vi.fn(() => vi.fn()),
     onExit: vi.fn(() => vi.fn()),
+    onTierChanged: vi.fn(() => vi.fn()),
     write: vi.fn(),
     setActivityTier: vi.fn(),
     wake: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
@@ -6,6 +6,7 @@ import { preloadMockWebglAddon } from "./_preloadWebglAddon";
 const mockTerminalClient = {
   onData: vi.fn(() => vi.fn()),
   onExit: vi.fn(() => vi.fn()),
+  onTierChanged: vi.fn(() => vi.fn()),
   setActivityTier: vi.fn(),
   wake: vi.fn().mockResolvedValue({ state: null }),
   write: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalRendererPolicy.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalRendererPolicy.adversarial.test.ts
@@ -281,6 +281,47 @@ describe("TerminalRendererPolicy adversarial", () => {
     expect(deps.onResumeFlush).not.toHaveBeenCalled();
   });
 
+  it("HOST_PUSHED_BACKGROUND_REARMS_DEDUPE_SO_NEXT_ACTIVE_RESENDS", async () => {
+    // Issue #9778 / lesson #8998 (same-tier no-op trap): when the PTY host
+    // silently demotes a terminal to "background" via recomputeActivityTiers,
+    // it pushes a tier-changed message that the renderer applies through
+    // initializeBackendTier. That MUST re-arm the outbound dedupe baseline so a
+    // subsequent "active" is actually resent to the host instead of being
+    // dropped as a redundant same-tier call — which is exactly what left the
+    // producer gate suppressing bytes while the pane looked active.
+    const managed = createManagedTerminal();
+    const deps: RendererPolicyDeps = {
+      getInstance: vi.fn(() => managed),
+      wakeAndRestore: vi.fn(async () => true),
+    };
+
+    const { TerminalRendererPolicy } = await import("../TerminalRendererPolicy");
+    const { terminalClient } = await import("@/clients");
+    const policy = new TerminalRendererPolicy(deps);
+
+    // Renderer's last outbound tier is "active".
+    policy.setBackendTier("terminal-1", "active");
+    expect(terminalClient.setActivityTier).toHaveBeenCalledTimes(1);
+
+    // Re-sending "active" without any intervening change dedupes (proves the
+    // trap exists — this is the no-op that would strand a host-demoted terminal).
+    policy.setBackendTier("terminal-1", "active");
+    expect(terminalClient.setActivityTier).toHaveBeenCalledTimes(1);
+
+    // Host-pushed demotion arrives over the MessagePort and re-arms the baseline.
+    policy.initializeBackendTier("terminal-1", "background");
+    expect(managed.needsWake).toBe(true);
+
+    // Now the renderer reactivating sends a real "active" to the host again.
+    policy.setBackendTier("terminal-1", "active");
+    expect(terminalClient.setActivityTier).toHaveBeenCalledTimes(2);
+    expect(terminalClient.setActivityTier).toHaveBeenLastCalledWith(
+      "terminal-1",
+      "active",
+      undefined
+    );
+  });
+
   it("CLEAR_TIER_STATE_CANCELS_PENDING_WAKE_AND_RELEASES_GENERATION", async () => {
     const wake = deferred<boolean>();
     const managed = createManagedTerminal({


### PR DESCRIPTION
## Summary

- `recomputeActivityTiers()` in the pty-host silently demoted terminals to `background` on window connect/disconnect/project-switch without notifying the renderer. The renderer deduped outbound tier messages against its last-known state, so once it believed a terminal was active it never resent — leaving the host suppressing visual bytes while the pane looked fully visible. Frozen output, repaired only by accident on click via `wake-terminal`.
- Fix: after `setActivityTier`, the host broadcasts a `{type:"tier-changed", id, tier}` control message over each per-window MessagePort. Riding the port keeps it FIFO-ordered with data chunks (routing through Main-process IPC would race the direct data path). The renderer dispatches `tier-changed` to a new `onTierChanged` subscription and calls the pre-existing `initializeBackendTier` to re-arm the dedupe baseline without echoing back to the host.
- Also fixed: terminals with an undefined `projectId` were demoted to `background` whenever any window had a project mapping. Condition changed to treat `undefined` as a wildcard that stays active.

Closes #9778

## Changes

- `shared/types/pty-host.ts` — `PtyHostToRendererMessage` expanded to a discriminated union with the `tier-changed` variant
- `electron/pty-host.ts` — `recomputeActivityTiers` broadcasts `tier-changed` per-port after each `setActivityTier` call; undefined-`projectId` wildcard fix
- `src/clients/terminalClient.ts` — `onTierChanged` subscription; dispatches host broadcast to registered callbacks
- `src/services/terminal/TerminalInstanceService.ts` — subscribes to `onTierChanged` and calls `initializeBackendTier` to re-arm the dedupe baseline

## Testing

76 tests passing across 4 files:

- Host: broadcast after recompute, per-window project filter, undefined-`projectId` wildcard, closing-port tolerance
- Client: dispatch to `onTierChanged`, no-ack, unsubscribe, unknown-id handling
- Renderer policy: dedupe re-arm on `tier-changed`
- Service: subscription wiring and `needsWake` re-arm