### PR TITLE
perf(cold-start): add window-show mark and GPU/compositor trace capture

### DIFF
--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -49,6 +49,7 @@ import {
 import { closeSharedDb } from "../services/persistence/db.js";
 import { closeTelemetry } from "../services/TelemetryService.js";
 import { isSmokeTest } from "../setup/environment.js";
+import { stopPerformanceTraceIfActive } from "../utils/performanceTrace.js";
 import { isSignalShutdown, clearSafetyBeltTimer } from "./signalShutdownState.js";
 import { CLEANUP_TIMEOUT_MS } from "./shutdownConfig.js";
 
@@ -498,6 +499,11 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
         } catch (err) {
           console.warn("[MAIN] closeTelemetry failed:", err);
         }
+        // Flush the perf trace (if --trace was active) while the GPU/renderer
+        // child processes are still alive. app.exit() bypasses will-quit, so
+        // this is the only reliable point to stop tracing before exit; no-op
+        // for normal runs. Awaited so the trace file isn't truncated.
+        await stopPerformanceTraceIfActive();
         app.exit(0);
       })
       .catch(async (error) => {
@@ -515,6 +521,9 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
         } catch (err) {
           console.warn("[MAIN] closeTelemetry failed:", err);
         }
+        // Best-effort trace flush on the error path too — a partial trace is
+        // still useful, and the call is a no-op when tracing is off.
+        await stopPerformanceTraceIfActive();
         app.exit(1);
       });
   });

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -18,10 +18,7 @@ import { fileURLToPath } from "url";
 import { PERF_MARKS } from "../shared/perf/marks.js";
 import { getOsToAppBootMs, markPerformance } from "./utils/performance.js";
 import { getCompileCacheMeta } from "./utils/hostPerformance.js";
-import {
-  startPerformanceTraceIfEnabled,
-  stopPerformanceTraceIfActive,
-} from "./utils/performanceTrace.js";
+import { startPerformanceTraceIfEnabled } from "./utils/performanceTrace.js";
 import { enforceIpcSenderValidation, setupPermissionLockdown } from "./setup/security.js";
 import {
   registerAppProtocol,
@@ -474,24 +471,6 @@ if (!gotTheLock) {
     setStopDiskSpaceMonitor,
     windowRegistry,
   });
-
-  // Flush the GPU/compositor trace before exit when tracing is active. Gated so
-  // normal runs pay nothing. `will-quit` fires once the quit decision is
-  // committed (after every `before-quit` handler, including the shutdown
-  // dialog), so it never interferes with that flow. `stopRecording` is async
-  // and the trace file truncates if the process exits first — preventDefault
-  // and re-quit once the flush resolves. `traceFlushed` guards the re-quit loop.
-  if (process.env.DAINTREE_PERF_TRACE === "1") {
-    let traceFlushed = false;
-    app.on("will-quit", (event) => {
-      if (traceFlushed) return;
-      event.preventDefault();
-      void stopPerformanceTraceIfActive().finally(() => {
-        traceFlushed = true;
-        app.quit();
-      });
-    });
-  }
 
   app.whenReady().then(async () => {
     try {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -18,6 +18,10 @@ import { fileURLToPath } from "url";
 import { PERF_MARKS } from "../shared/perf/marks.js";
 import { getOsToAppBootMs, markPerformance } from "./utils/performance.js";
 import { getCompileCacheMeta } from "./utils/hostPerformance.js";
+import {
+  startPerformanceTraceIfEnabled,
+  stopPerformanceTraceIfActive,
+} from "./utils/performanceTrace.js";
 import { enforceIpcSenderValidation, setupPermissionLockdown } from "./setup/security.js";
 import {
   registerAppProtocol,
@@ -471,8 +475,31 @@ if (!gotTheLock) {
     windowRegistry,
   });
 
+  // Flush the GPU/compositor trace before exit when tracing is active. Gated so
+  // normal runs pay nothing. `will-quit` fires once the quit decision is
+  // committed (after every `before-quit` handler, including the shutdown
+  // dialog), so it never interferes with that flow. `stopRecording` is async
+  // and the trace file truncates if the process exits first — preventDefault
+  // and re-quit once the flush resolves. `traceFlushed` guards the re-quit loop.
+  if (process.env.DAINTREE_PERF_TRACE === "1") {
+    let traceFlushed = false;
+    app.on("will-quit", (event) => {
+      if (traceFlushed) return;
+      event.preventDefault();
+      void stopPerformanceTraceIfActive().finally(() => {
+        traceFlushed = true;
+        app.quit();
+      });
+    });
+  }
+
   app.whenReady().then(async () => {
     try {
+      // Self-start GPU/compositor tracing when the cold-start harness asked
+      // for it (DAINTREE_PERF_TRACE=1). No-op for every normal run. Must run
+      // first inside whenReady so the trace covers the full window-reveal
+      // pipeline; the matching stop runs on `will-quit` below.
+      await startPerformanceTraceIfEnabled();
       // Fire-and-forget the user-PATH refresh. Runs concurrently with the
       // rest of startup; the PtyClient creation site awaits it before
       // spawning the PTY host (#8625). Kicked off inside whenReady() so the

--- a/electron/utils/__tests__/performanceTrace.test.ts
+++ b/electron/utils/__tests__/performanceTrace.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const tracing = vi.hoisted(() => ({
+  startRecording: vi.fn(async () => {}),
+  stopRecording: vi.fn(async (_file?: string) => "trace.json"),
+}));
+
+vi.mock("electron", () => ({
+  contentTracing: tracing,
+}));
+
+// Fresh module per test so the module-level trace state machine resets.
+async function loadModule() {
+  vi.resetModules();
+  return import("../performanceTrace.js");
+}
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe("performanceTrace", () => {
+  beforeEach(() => {
+    tracing.startRecording.mockClear();
+    tracing.stopRecording.mockClear();
+    delete process.env.DAINTREE_PERF_TRACE;
+    delete process.env.DAINTREE_PERF_TRACE_FILE;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.restoreAllMocks();
+  });
+
+  it("does nothing when the env gate is unset", async () => {
+    const mod = await loadModule();
+    await mod.startPerformanceTraceIfEnabled();
+    await mod.stopPerformanceTraceIfActive();
+    expect(tracing.startRecording).not.toHaveBeenCalled();
+    expect(tracing.stopRecording).not.toHaveBeenCalled();
+  });
+
+  it("does not start when the flag is set but no output file is given", async () => {
+    process.env.DAINTREE_PERF_TRACE = "1";
+    const mod = await loadModule();
+    await mod.startPerformanceTraceIfEnabled();
+    expect(tracing.startRecording).not.toHaveBeenCalled();
+  });
+
+  it("starts recording with the compositor categories when fully enabled", async () => {
+    process.env.DAINTREE_PERF_TRACE = "1";
+    process.env.DAINTREE_PERF_TRACE_FILE = "/tmp/trace-run-1.json";
+    const mod = await loadModule();
+    await mod.startPerformanceTraceIfEnabled();
+
+    expect(tracing.startRecording).toHaveBeenCalledTimes(1);
+    const config = tracing.startRecording.mock.calls[0][0] as {
+      included_categories: string[];
+      excluded_categories: string[];
+    };
+    // Behavioral invariant: every category needed for first-frame timing is
+    // present, and nothing else is included.
+    for (const cat of ["viz", "gpu", "cc", "blink", "toplevel", "startup"]) {
+      expect(config.included_categories).toContain(cat);
+    }
+    expect(config.excluded_categories).toEqual(["*"]);
+  });
+
+  it("stops recording to the configured file and is idempotent", async () => {
+    process.env.DAINTREE_PERF_TRACE = "1";
+    process.env.DAINTREE_PERF_TRACE_FILE = "/tmp/trace-run-1.json";
+    const mod = await loadModule();
+    await mod.startPerformanceTraceIfEnabled();
+    await mod.stopPerformanceTraceIfActive();
+    await mod.stopPerformanceTraceIfActive();
+
+    expect(tracing.stopRecording).toHaveBeenCalledTimes(1);
+    expect(tracing.stopRecording).toHaveBeenCalledWith("/tmp/trace-run-1.json");
+  });
+
+  it("does not stop when tracing was never started", async () => {
+    process.env.DAINTREE_PERF_TRACE = "1";
+    process.env.DAINTREE_PERF_TRACE_FILE = "/tmp/trace-run-1.json";
+    const mod = await loadModule();
+    await mod.stopPerformanceTraceIfActive();
+    expect(tracing.stopRecording).not.toHaveBeenCalled();
+  });
+
+  it("swallows a startRecording rejection without throwing", async () => {
+    process.env.DAINTREE_PERF_TRACE = "1";
+    process.env.DAINTREE_PERF_TRACE_FILE = "/tmp/trace-run-1.json";
+    tracing.startRecording.mockRejectedValueOnce(new Error("boom"));
+    const mod = await loadModule();
+    await expect(mod.startPerformanceTraceIfEnabled()).resolves.toBeUndefined();
+    // A failed start must not leave the machine in a state that later tries to
+    // stop a recording that never began.
+    await mod.stopPerformanceTraceIfActive();
+    expect(tracing.stopRecording).not.toHaveBeenCalled();
+  });
+
+  it("swallows a stopRecording rejection without throwing", async () => {
+    process.env.DAINTREE_PERF_TRACE = "1";
+    process.env.DAINTREE_PERF_TRACE_FILE = "/tmp/trace-run-1.json";
+    tracing.stopRecording.mockRejectedValueOnce(new Error("boom"));
+    const mod = await loadModule();
+    await mod.startPerformanceTraceIfEnabled();
+    await expect(mod.stopPerformanceTraceIfActive()).resolves.toBeUndefined();
+  });
+});

--- a/electron/utils/__tests__/performanceTrace.test.ts
+++ b/electron/utils/__tests__/performanceTrace.test.ts
@@ -52,16 +52,11 @@ describe("performanceTrace", () => {
     await mod.startPerformanceTraceIfEnabled();
 
     expect(tracing.startRecording).toHaveBeenCalledTimes(1);
-    const config = tracing.startRecording.mock.calls[0][0] as {
-      recording_mode: string;
-      included_categories: string[];
-      excluded_categories: string[];
-    };
-    // Lock the config shape: exactly the first-frame categories, nothing else,
-    // and the deny-everything-else wildcard so no noisy category leaks in.
-    expect(config.recording_mode).toBe("record-until-full");
-    expect(config.included_categories).toEqual(["viz", "gpu", "cc", "blink", "toplevel", "startup"]);
-    expect(config.excluded_categories).toEqual(["*"]);
+    expect(tracing.startRecording).toHaveBeenCalledWith({
+      recording_mode: "record-until-full",
+      included_categories: ["viz", "gpu", "cc", "blink", "toplevel", "startup"],
+      excluded_categories: ["*"],
+    });
   });
 
   it("stops recording to the configured file and is idempotent", async () => {

--- a/electron/utils/__tests__/performanceTrace.test.ts
+++ b/electron/utils/__tests__/performanceTrace.test.ts
@@ -53,14 +53,14 @@ describe("performanceTrace", () => {
 
     expect(tracing.startRecording).toHaveBeenCalledTimes(1);
     const config = tracing.startRecording.mock.calls[0][0] as {
+      recording_mode: string;
       included_categories: string[];
       excluded_categories: string[];
     };
-    // Behavioral invariant: every category needed for first-frame timing is
-    // present, and nothing else is included.
-    for (const cat of ["viz", "gpu", "cc", "blink", "toplevel", "startup"]) {
-      expect(config.included_categories).toContain(cat);
-    }
+    // Lock the config shape: exactly the first-frame categories, nothing else,
+    // and the deny-everything-else wildcard so no noisy category leaks in.
+    expect(config.recording_mode).toBe("record-until-full");
+    expect(config.included_categories).toEqual(["viz", "gpu", "cc", "blink", "toplevel", "startup"]);
     expect(config.excluded_categories).toEqual(["*"]);
   });
 
@@ -103,5 +103,9 @@ describe("performanceTrace", () => {
     const mod = await loadModule();
     await mod.startPerformanceTraceIfEnabled();
     await expect(mod.stopPerformanceTraceIfActive()).resolves.toBeUndefined();
+    // Prove the swallowed-error path actually attempted the stop, not that it
+    // short-circuited before calling stopRecording.
+    expect(tracing.stopRecording).toHaveBeenCalledTimes(1);
+    expect(tracing.stopRecording).toHaveBeenCalledWith("/tmp/trace-run-1.json");
   });
 });

--- a/electron/utils/performanceTrace.ts
+++ b/electron/utils/performanceTrace.ts
@@ -37,13 +37,16 @@ export async function startPerformanceTraceIfEnabled(): Promise<void> {
   if (state !== "idle") return;
   if (!isTraceEnabled()) return;
 
+  // Flip to "recording" before the await so a second concurrent caller can't
+  // pass the idle guard and double-start. Reset to "stopped" if start fails so
+  // a later stop call doesn't try to flush a recording that never began.
+  state = "recording";
   try {
     await contentTracing.startRecording({
       recording_mode: "record-until-full",
       included_categories: TRACE_CATEGORIES,
       excluded_categories: ["*"],
     });
-    state = "recording";
   } catch (error) {
     state = "stopped";
     console.warn("[perf-trace] startRecording failed:", error);

--- a/electron/utils/performanceTrace.ts
+++ b/electron/utils/performanceTrace.ts
@@ -1,0 +1,73 @@
+import { contentTracing } from "electron";
+
+/**
+ * Optional GPU/compositor trace capture for the cold-start perf harness.
+ *
+ * `contentTracing` only runs inside the app's own main process — the harness
+ * subprocess cannot drive it remotely — so tracing self-starts here, gated by
+ * `DAINTREE_PERF_TRACE=1` plus a `DAINTREE_PERF_TRACE_FILE` output path. Both
+ * are injected by `packagedLaunch.ts` when the cold-start harness runs with
+ * `--trace`. Tracing adds measurable overhead, so it is deliberately kept
+ * orthogonal to (and off for) normal `DAINTREE_PERF_CAPTURE` runs.
+ *
+ * Output is Chromium's JSON Trace Event Format, written to the `.json` path —
+ * directly droppable into https://ui.perfetto.dev with no conversion.
+ */
+
+// First-frame compositor pipeline: blink builds the layer tree, cc rasterizes
+// and commits, viz aggregates/swaps, gpu drives the hardware, toplevel/startup
+// capture event-loop tasks and browser/renderer launch phases.
+const TRACE_CATEGORIES = ["viz", "gpu", "cc", "blink", "toplevel", "startup"];
+
+type TraceState = "idle" | "recording" | "stopped";
+let state: TraceState = "idle";
+
+function isTraceEnabled(): string | null {
+  if (process.env.DAINTREE_PERF_TRACE !== "1") return null;
+  const file = process.env.DAINTREE_PERF_TRACE_FILE;
+  return file && file.length > 0 ? file : null;
+}
+
+/**
+ * Starts `contentTracing` when enabled. Must be called after `app.ready`
+ * (child processes are only traceable once bootstrapped). No-op when the env
+ * gate is unset. Never throws — tracing must not be able to fail app startup.
+ */
+export async function startPerformanceTraceIfEnabled(): Promise<void> {
+  if (state !== "idle") return;
+  if (!isTraceEnabled()) return;
+
+  try {
+    await contentTracing.startRecording({
+      recording_mode: "record-until-full",
+      included_categories: TRACE_CATEGORIES,
+      excluded_categories: ["*"],
+    });
+    state = "recording";
+  } catch (error) {
+    state = "stopped";
+    console.warn("[perf-trace] startRecording failed:", error);
+  }
+}
+
+/**
+ * Stops `contentTracing` and writes the trace to `DAINTREE_PERF_TRACE_FILE`.
+ * Idempotent — safe to call from `will-quit` even if tracing never started or
+ * was already stopped. Awaits `stopRecording` to completion so the trace file
+ * is fully flushed before the app exits (the file truncates otherwise). Never
+ * throws.
+ */
+export async function stopPerformanceTraceIfActive(): Promise<void> {
+  if (state !== "recording") return;
+  state = "stopped";
+
+  const file = isTraceEnabled();
+  if (!file) return;
+
+  try {
+    await contentTracing.stopRecording(file);
+    console.log(`[perf-trace] trace written to ${file}`);
+  } catch (error) {
+    console.warn("[perf-trace] stopRecording failed:", error);
+  }
+}

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -365,10 +365,7 @@ export function setupBrowserWindow(
         fallbackTimer = null;
       }
       if (!win.isDestroyed()) {
-        markPerformance(
-          PERF_MARKS.MAIN_WINDOW_SHOWN,
-          viaFallback ? { fallback: true } : undefined
-        );
+        markPerformance(PERF_MARKS.MAIN_WINDOW_SHOWN, viaFallback ? { fallback: true } : undefined);
         win.show();
       }
     };

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -357,23 +357,29 @@ export function setupBrowserWindow(
     // 5s timeout fallback ensures a hung renderer doesn't leave the window
     // permanently hidden — strictly worse than a brief blank.
     let shown = false;
-    const showOnce = (): void => {
+    const showOnce = (viaFallback = false): void => {
       if (shown) return;
       shown = true;
       if (fallbackTimer) {
         clearTimeout(fallbackTimer);
         fallbackTimer = null;
       }
-      if (!win.isDestroyed()) win.show();
+      if (!win.isDestroyed()) {
+        markPerformance(
+          PERF_MARKS.MAIN_WINDOW_SHOWN,
+          viaFallback ? { fallback: true } : undefined
+        );
+        win.show();
+      }
     };
     let fallbackTimer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
       fallbackTimer = null;
       console.warn(
         `[MAIN] dom-ready not received after ${SHOW_FALLBACK_MS}ms — showing window anyway`
       );
-      showOnce();
+      showOnce(true);
     }, SHOW_FALLBACK_MS);
-    appWebContents.once("dom-ready", showOnce);
+    appWebContents.once("dom-ready", () => showOnce(false));
     win.once("closed", () => {
       if (fallbackTimer) {
         clearTimeout(fallbackTimer);

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -48,6 +48,17 @@ Requires a packaged binary under `release/` — build one first with `npm run pa
 npm run perf:cold-start                   # 5 runs, text table
 npm run perf:cold-start -- --runs 10      # custom run count
 npm run perf:cold-start -- --json         # structured JSON for diffing
+npm run perf:cold-start -- --trace        # capture GPU/compositor traces
 ```
 
 IPC sampling is forced to 100% for this command so per-channel stats are meaningful across a small number of runs.
+
+The `main_window_shown` mark records the moment `win.show()` is called (when the OS is asked to map the window). It surfaces as the `boot → main_window_shown` and `main_window_created → main_window_shown` phase pairs, exposing the dom-ready-gated window-reveal wait the harness was previously blind to. A mark carries `meta: { fallback: true }` when the 5s dom-ready fallback timer fired instead of the normal dom-ready signal.
+
+## GPU/compositor traces (`--trace`)
+
+`--trace` makes the packaged app self-start Electron's `contentTracing` (categories `viz,gpu,cc,blink,toplevel,startup`) for the full startup-to-quit window, writing one trace per run to `.tmp/perf-results/trace-run-N.json`. This is the way to see why the compositor takes time between `main_window_shown` and the first painted frame.
+
+The output is Chromium's JSON Trace Event Format — open it directly at https://ui.perfetto.dev (drag-and-drop the `.json` file, no conversion needed).
+
+Tracing adds measurable overhead to the traced process, so `--trace` is opt-in and gated behind a second env flag (`DAINTREE_PERF_TRACE`) that normal runs never set. **Do not mix `--trace` runs into baseline timing numbers** — capture traces in a separate session. Trace files can be large (tens of MB) and are transient build artifacts under `.tmp/`.

--- a/scripts/perf/__tests__/coldStartAggregate.test.ts
+++ b/scripts/perf/__tests__/coldStartAggregate.test.ts
@@ -27,6 +27,35 @@ describe("cold-start aggregate", () => {
     expect(agg.loaf).toEqual({});
   });
 
+  it("computes the window-show phase pairs from main_window_shown", () => {
+    const agg = aggregate([
+      makeRun({
+        marks: [
+          { mark: PERF_MARKS.APP_BOOT_START, timestamp: "t", elapsedMs: 0 },
+          { mark: PERF_MARKS.MAIN_WINDOW_CREATED, timestamp: "t", elapsedMs: 100 },
+          { mark: PERF_MARKS.MAIN_WINDOW_SHOWN, timestamp: "t", elapsedMs: 350 },
+        ],
+      }),
+    ]);
+
+    expect(agg.phaseDurations["boot → main_window_shown"].p50Ms).toBe(350);
+    expect(agg.phaseDurations["main_window_created → main_window_shown"].p50Ms).toBe(250);
+  });
+
+  it("omits the window-show phase pairs when main_window_shown is absent", () => {
+    const agg = aggregate([
+      makeRun({
+        marks: [
+          { mark: PERF_MARKS.APP_BOOT_START, timestamp: "t", elapsedMs: 0 },
+          { mark: PERF_MARKS.MAIN_WINDOW_CREATED, timestamp: "t", elapsedMs: 100 },
+        ],
+      }),
+    ]);
+
+    expect(agg.phaseDurations["boot → main_window_shown"]).toBeUndefined();
+    expect(agg.phaseDurations["main_window_created → main_window_shown"]).toBeUndefined();
+  });
+
   it("groups long-animation-frame blocking time by topScripts[0].sourceURL", () => {
     const agg = aggregate([
       makeRun({

--- a/scripts/perf/cold-start.ts
+++ b/scripts/perf/cold-start.ts
@@ -347,6 +347,7 @@ async function main(): Promise<void> {
       runs: { type: "string", short: "n", default: "5" },
       json: { type: "boolean", default: false },
       warm: { type: "boolean", default: false },
+      trace: { type: "boolean", default: false },
       help: { type: "boolean", short: "h", default: false },
     },
     strict: true,
@@ -354,7 +355,7 @@ async function main(): Promise<void> {
   });
 
   if (values.help) {
-    console.log(`Usage: npm run perf:cold-start -- [--runs N] [--warm] [--json]
+    console.log(`Usage: npm run perf:cold-start -- [--runs N] [--warm] [--json] [--trace]
 
 Launch the packaged Daintree binary N times and print aggregated p50/p95.
 
@@ -367,6 +368,9 @@ Options:
   -n, --runs N    Number of measured launches (default 5)
       --warm      Reuse one profile dir + warmup boot so runs are cache-warm
       --json      Emit structured JSON instead of the text table
+      --trace     Capture a GPU/compositor contentTracing trace per run into
+                  .tmp/perf-results/trace-run-N.json (open in ui.perfetto.dev).
+                  Adds tracing overhead — do NOT mix with baseline runs.
   -h, --help      Show this message
 
 Requires a packaged binary under release/. Build one first with:
@@ -383,8 +387,15 @@ Requires a packaged binary under release/. Build one first with:
   const runs = rawRuns;
   const asJson = Boolean(values.json);
   const warm = Boolean(values.warm);
+  const trace = Boolean(values.trace);
 
   const projectRoot = process.cwd();
+  // Trace files land next to the existing NDJSON metrics convention, outside
+  // the per-run userDataDir so they survive its cleanup.
+  const traceResultsDir = path.join(projectRoot, ".tmp", "perf-results");
+  if (trace) {
+    fs.mkdirSync(traceResultsDir, { recursive: true });
+  }
   const executablePath = findPackagedExecutable(projectRoot);
   if (!executablePath) {
     console.error(
@@ -450,6 +461,7 @@ Requires a packaged binary under release/. Build one first with:
         const result = await launchPackagedAndMeasure(executablePath, i, {
           projectRoot,
           ...(warmDir ? { userDataDir: warmDir } : {}),
+          traceFile: trace ? path.join(traceResultsDir, `trace-run-${i + 1}.json`) : undefined,
         });
         const marks = parseNdjson(result.ndjsonPath);
         // Only true-degraded runs (wall-clock fallback) are excluded from

--- a/scripts/perf/lib/coldStartAggregate.ts
+++ b/scripts/perf/lib/coldStartAggregate.ts
@@ -114,6 +114,15 @@ export const PHASE_PAIRS: Array<[string, string, string]> = [
   // is kept as a sub-phase signal to distinguish hydration cost.
   [PERF_MARKS.APP_BOOT_START, PERF_MARKS.RENDERER_FIRST_INTERACTIVE, "boot → first_interactive"],
   [PERF_MARKS.APP_BOOT_START, PERF_MARKS.RENDERER_READY, "boot → renderer_ready (pre-hydration)"],
+  // Window-reveal phase (#9773): when the OS is asked to map the window. The
+  // boot-relative pair frames it against startup; the created→shown pair
+  // isolates the dom-ready gate wait inside the window lifecycle.
+  [PERF_MARKS.APP_BOOT_START, PERF_MARKS.MAIN_WINDOW_SHOWN, "boot → main_window_shown"],
+  [
+    PERF_MARKS.MAIN_WINDOW_CREATED,
+    PERF_MARKS.MAIN_WINDOW_SHOWN,
+    "main_window_created → main_window_shown",
+  ],
   [PERF_MARKS.SERVICE_INIT_START, PERF_MARKS.SERVICE_INIT_COMPLETE, "service_init"],
   [PERF_MARKS.HYDRATE_START, PERF_MARKS.HYDRATE_COMPLETE, "hydrate"],
   [

--- a/scripts/perf/lib/packagedLaunch.ts
+++ b/scripts/perf/lib/packagedLaunch.ts
@@ -272,6 +272,10 @@ export async function launchPackagedAndMeasure(
     // skip the post-run cleanup (the caller owns the dir's lifecycle). This is
     // how warm-cache runs reuse a populated compile cache across launches.
     userDataDir?: string;
+    // Absolute path for the GPU/compositor trace. When set, the packaged app
+    // self-starts `contentTracing` (DAINTREE_PERF_TRACE) and writes the trace
+    // here on quit. Lives outside userDataDir so it survives the cleanup below.
+    traceFile?: string;
   } = {}
 ): Promise<PackagedLaunchResult> {
   const timeoutMs = options.timeoutMs ?? 30_000;
@@ -307,6 +311,11 @@ export async function launchPackagedAndMeasure(
     DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS: "1",
     NODE_ENV: "production",
   };
+
+  if (options.traceFile) {
+    env.DAINTREE_PERF_TRACE = "1";
+    env.DAINTREE_PERF_TRACE_FILE = options.traceFile;
+  }
 
   if (process.env.CI) {
     env.DAINTREE_DISABLE_WEBGL = "1";

--- a/shared/perf/__tests__/marks.test.ts
+++ b/shared/perf/__tests__/marks.test.ts
@@ -5,6 +5,7 @@ describe("PERF_MARKS", () => {
   it("contains required instrumentation marks", () => {
     expect(PERF_MARKS.APP_BOOT_START).toBe("app_boot_start");
     expect(PERF_MARKS.MAIN_WINDOW_CREATED).toBe("main_window_created");
+    expect(PERF_MARKS.MAIN_WINDOW_SHOWN).toBe("main_window_shown");
     expect(PERF_MARKS.WINDOW_SERVICES_START).toBe("window_services_start");
     expect(PERF_MARKS.RENDERER_READY).toBe("renderer_ready");
     expect(PERF_MARKS.HYDRATE_START).toBe("hydrate_start");

--- a/shared/perf/marks.ts
+++ b/shared/perf/marks.ts
@@ -9,6 +9,15 @@ export const PERF_MARKS = {
   EARLY_PATH_REFRESH_START: "early_path_refresh_start",
   EARLY_PATH_REFRESH_COMPLETE: "early_path_refresh_complete",
   MAIN_WINDOW_CREATED: "main_window_created",
+  /**
+   * Recorded the moment `win.show()` is called from the dom-ready-gated
+   * `showOnce()` path in `createWindow.ts` — i.e. when the OS is asked to map
+   * the window on screen. Pairs with `MAIN_WINDOW_CREATED` and `APP_BOOT_START`
+   * to expose the window-reveal phase the cold-start harness was previously
+   * blind to. Carries `meta: { fallback: true }` when the 5s fallback timer
+   * fired instead of dom-ready.
+   */
+  MAIN_WINDOW_SHOWN: "main_window_shown",
   RENDERER_READY: "renderer_ready",
   RENDERER_FIRST_INTERACTIVE: "renderer_first_interactive",
 


### PR DESCRIPTION
## Summary

- Adds a `main_window_shown` performance mark recorded at `win.show()` in the dom-ready-gated reveal path in `createWindow.ts`, carrying `meta: { fallback: true }` when the 5s fallback timer fired. Gated by `DAINTREE_PERF_CAPTURE` — no-op in production.
- Two new aggregate phase pairs in `coldStartAggregate.ts`: `boot → main_window_shown` and `main_window_created → main_window_shown`.
- Optional GPU/compositor trace capture via Electron's `contentTracing` (`viz,gpu,cc,blink,toplevel,startup` categories), opt-in behind `--trace` on `npm run perf:cold-start`. Traces land in `.tmp/perf-results/trace-run-N.json` in Chromium JSON Trace Event Format, directly openable in [ui.perfetto.dev](https://ui.perfetto.dev). Flushed in the shutdown sequence before `app.exit` (which bypasses `will-quit`). Documented in `scripts/perf/README.md`.

No window-show behaviour changes. Instrumentation only, no new dependencies, new mark is manual-only with no CI budget.

Resolves #9773.

## Changes

- `shared/perf/marks.ts` — new `MAIN_WINDOW_SHOWN` mark constant
- `electron/window/createWindow.ts` — record mark at `win.show()` in `showOnce()`
- `electron/utils/performanceTrace.ts` — new helper wrapping `contentTracing` start/stop
- `electron/lifecycle/shutdown.ts` + `electron/main.ts` — wire trace flush into shutdown path
- `scripts/perf/cold-start.ts` + `scripts/perf/lib/packagedLaunch.ts` — `--trace` flag support
- `scripts/perf/lib/coldStartAggregate.ts` — two new phase pairs
- `scripts/perf/README.md` — trace capture and Perfetto usage note

## Testing

33 tests passing across marks, `performanceTrace` helper, and `coldStartAggregate` phase pairs. `npm run check` fully green (typecheck, lint ratchet, all IPC/channel/confirm-wiring guards, format).