### PR TITLE
fix(terminal): repair mis-sized grid when font loads after timeout

### DIFF
--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -49,10 +49,13 @@ export function XtermAdapter({
   hasBottomBar = false,
 }: XtermAdapterProps) {
   // Gate xterm's grid measurement (which happens at `terminal.open()` inside
-  // `terminalInstanceService.attach`) on the JetBrains Mono font being ready.
-  // xterm does not re-measure after open, so measuring with the fallback stack
-  // would leave a permanently mis-sized grid. The promise is a module-level
-  // singleton so `use()` sees a stable reference across re-renders.
+  // `terminalInstanceService.attach`) on the JetBrains Mono font being ready, so
+  // the common case opens against the real font and never shows a fallback->JBM
+  // reflow. The gate gives up after a 3s timeout (see `terminalFont.ts`); if the
+  // font then arrives late, `TerminalInstanceService` repairs the mis-sized grid
+  // out-of-band via `repairFontGrid()` (wired once to `onTerminalFontArrivedLate`
+  // in its constructor). The promise is a module-level singleton so `use()` sees
+  // a stable reference across re-renders.
   use(terminalFontReady);
 
   const containerRef = useRef<HTMLDivElement>(null);

--- a/src/config/__tests__/terminalFont.test.ts
+++ b/src/config/__tests__/terminalFont.test.ts
@@ -161,6 +161,52 @@ describe("onTerminalFontArrivedLate", () => {
     expect(first).toHaveBeenCalledTimes(1);
     expect(second).toHaveBeenCalledTimes(1);
   });
+
+  it("fires when one weight arrives late even if the other fails", async () => {
+    // Regular weight loads late; bold rejects. The regular JetBrains Mono face
+    // still changes cell metrics, so the grid must be repaired (allSettled).
+    let resolveRegular!: (value: unknown) => void;
+    let rejectBold!: (reason: unknown) => void;
+    const regular = new Promise((resolve) => {
+      resolveRegular = resolve;
+    });
+    const bold = new Promise((_resolve, reject) => {
+      rejectBold = reject;
+    });
+    // Avoid an unhandled-rejection warning for the deliberately-rejected weight.
+    bold.catch(() => {});
+    loadMock.mockImplementation((spec: string) => (spec.startsWith("bold") ? bold : regular));
+
+    const mod = await import("../terminalFont");
+    mod.ensureTerminalFontLoaded();
+    const callback = vi.fn();
+    mod.onTerminalFontArrivedLate(callback);
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    rejectBold(new Error("bold failed"));
+    resolveRegular([{ family: "JetBrains Mono" }]);
+    await vi.runAllTimersAsync();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("isolates a throwing callback so the others still fire", async () => {
+    const mod = await import("../terminalFont");
+    mod.ensureTerminalFontLoaded();
+    const throwing = vi.fn(() => {
+      throw new Error("boom");
+    });
+    const second = vi.fn();
+    mod.onTerminalFontArrivedLate(throwing);
+    mod.onTerminalFontArrivedLate(second);
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    resolveLoad([{ family: "JetBrains Mono" }]);
+    await vi.runAllTimersAsync();
+
+    expect(throwing).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("terminalFontReady", () => {

--- a/src/config/__tests__/terminalFont.test.ts
+++ b/src/config/__tests__/terminalFont.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("ensureTerminalFontLoaded", () => {
   let loadMock: ReturnType<typeof vi.fn>;
@@ -51,6 +51,115 @@ describe("ensureTerminalFontLoaded", () => {
     loadMock.mockRejectedValue(new Error("network error"));
     const { ensureTerminalFontLoaded } = await import("../terminalFont");
     await expect(ensureTerminalFontLoaded()).resolves.toBeUndefined();
+  });
+});
+
+describe("onTerminalFontArrivedLate", () => {
+  let resolveLoad: (value: unknown) => void;
+  let rejectLoad: (reason: unknown) => void;
+  let loadMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    // A single shared deferred drives both the regular and bold load calls so
+    // the test controls exactly when the real font load settles relative to the
+    // 3s timeout.
+    const deferred = new Promise((resolve, reject) => {
+      resolveLoad = resolve;
+      rejectLoad = reject;
+    });
+    loadMock = vi.fn().mockReturnValue(deferred);
+    Object.defineProperty(globalThis, "document", {
+      value: { fonts: { load: loadMock } },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fires registered callbacks when the font arrives after the timeout", async () => {
+    const mod = await import("../terminalFont");
+    mod.ensureTerminalFontLoaded();
+    const callback = vi.fn();
+    mod.onTerminalFontArrivedLate(callback);
+
+    // Timeout wins the race first — terminal would open against the fallback.
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(callback).not.toHaveBeenCalled();
+
+    // Real font load settles afterwards: the grid must be repaired.
+    resolveLoad([{ family: "JetBrains Mono" }]);
+    await vi.runAllTimersAsync();
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire when the font loads before the timeout", async () => {
+    const mod = await import("../terminalFont");
+    mod.ensureTerminalFontLoaded();
+    const callback = vi.fn();
+    mod.onTerminalFontArrivedLate(callback);
+
+    // Font resolves before the 3s timeout elapses — on-time, no repair needed.
+    resolveLoad([{ family: "JetBrains Mono" }]);
+    await vi.runAllTimersAsync();
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("fires synchronously when subscribing after the font already arrived late", async () => {
+    const mod = await import("../terminalFont");
+    mod.ensureTerminalFontLoaded();
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    resolveLoad([{ family: "JetBrains Mono" }]);
+    await vi.runAllTimersAsync();
+
+    const callback = vi.fn();
+    mod.onTerminalFontArrivedLate(callback);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire an unsubscribed callback", async () => {
+    const mod = await import("../terminalFont");
+    mod.ensureTerminalFontLoaded();
+    const callback = vi.fn();
+    const unsubscribe = mod.onTerminalFontArrivedLate(callback);
+    unsubscribe();
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    resolveLoad([{ family: "JetBrains Mono" }]);
+    await vi.runAllTimersAsync();
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("does not fire when the font load fails", async () => {
+    const mod = await import("../terminalFont");
+    mod.ensureTerminalFontLoaded();
+    const callback = vi.fn();
+    mod.onTerminalFontArrivedLate(callback);
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    rejectLoad(new Error("network error"));
+    await vi.runAllTimersAsync();
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("fires every registered callback exactly once", async () => {
+    const mod = await import("../terminalFont");
+    mod.ensureTerminalFontLoaded();
+    const first = vi.fn();
+    const second = vi.fn();
+    mod.onTerminalFontArrivedLate(first);
+    mod.onTerminalFontArrivedLate(second);
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    resolveLoad([{ family: "JetBrains Mono" }]);
+    await vi.runAllTimersAsync();
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/config/terminalFont.ts
+++ b/src/config/terminalFont.ts
@@ -48,16 +48,21 @@ export function ensureTerminalFontLoaded(): Promise<void> {
   const size = `${DEFAULT_TERMINAL_FONT_SIZE}px 'JetBrains Mono'`;
   // The race times out terminal creation, but the underlying font fetch keeps
   // running — `document.fonts.load` is not cancelled. Hold a reference to the
-  // real load so we can tell when JetBrains Mono actually arrived.
-  const realLoad = Promise.all([document.fonts.load(size), document.fonts.load(`bold ${size}`)]);
+  // real load so we can tell when JetBrains Mono actually arrived. `allSettled`
+  // (not `all`) so one weight failing — e.g. bold erroring after regular already
+  // loaded — doesn't mask that the other weight arrived and changed cell metrics.
+  const realLoad = Promise.allSettled([
+    document.fonts.load(size),
+    document.fonts.load(`bold ${size}`),
+  ]);
 
   let timedOut = false;
   fontLoadPromise = Promise.race([
     realLoad,
-    new Promise<FontFace[]>((resolve) =>
+    new Promise<void>((resolve) =>
       setTimeout(() => {
         timedOut = true;
-        resolve([]);
+        resolve();
       }, FONT_LOAD_TIMEOUT_MS)
     ),
   ]).then(
@@ -65,19 +70,16 @@ export function ensureTerminalFontLoaded(): Promise<void> {
     () => undefined
   );
 
-  // If the real load only settles after the timeout already unblocked the gate,
-  // the font arrived late and any terminal opened in the meantime is mis-sized.
-  // Chaining off `realLoad` (rather than a `document.fonts` `loadingdone`
-  // listener) keys the signal to JetBrains Mono specifically, so an unrelated
-  // late font load can't trigger a spurious repair.
-  void realLoad.then(
-    () => {
-      if (timedOut) notifyTerminalFontArrivedLate();
-    },
-    () => {
-      // Genuine load failure: nothing arrived, so there is nothing to repair.
-    }
-  );
+  // If the real load only settles after the timeout already unblocked the gate
+  // and at least one weight actually loaded, the font arrived late and any
+  // terminal opened in the meantime is mis-sized. Chaining off `realLoad`
+  // (rather than a `document.fonts` `loadingdone` listener) keys the signal to
+  // JetBrains Mono specifically, so an unrelated late font load can't trigger a
+  // spurious repair.
+  void realLoad.then((results) => {
+    const anyLoaded = results.some((result) => result.status === "fulfilled");
+    if (timedOut && anyLoaded) notifyTerminalFontArrivedLate();
+  });
 
   return fontLoadPromise;
 }

--- a/src/config/terminalFont.ts
+++ b/src/config/terminalFont.ts
@@ -14,6 +14,29 @@ const FONT_LOAD_TIMEOUT_MS = 3_000;
 
 let fontLoadPromise: Promise<void> | null = null;
 
+// Set once JetBrains Mono finishes loading *after* the startup timeout already
+// unblocked terminal creation. In that window terminals open and measure their
+// cell metrics against the fallback monospace stack, so the grid is sized wrong
+// for the rest of the session (#9776) until something forces a re-measure.
+let fontArrivedLate = false;
+const lateArrivalCallbacks = new Set<() => void>();
+
+function notifyTerminalFontArrivedLate(): void {
+  if (fontArrivedLate) return;
+  fontArrivedLate = true;
+  // Snapshot then clear: this is a one-shot signal, and a callback must not be
+  // able to re-register itself into the set we're iterating.
+  const callbacks = [...lateArrivalCallbacks];
+  lateArrivalCallbacks.clear();
+  for (const callback of callbacks) {
+    try {
+      callback();
+    } catch {
+      // A misbehaving subscriber must not prevent the others from repairing.
+    }
+  }
+}
+
 export function ensureTerminalFontLoaded(): Promise<void> {
   if (fontLoadPromise) return fontLoadPromise;
 
@@ -23,15 +46,59 @@ export function ensureTerminalFontLoaded(): Promise<void> {
   }
 
   const size = `${DEFAULT_TERMINAL_FONT_SIZE}px 'JetBrains Mono'`;
+  // The race times out terminal creation, but the underlying font fetch keeps
+  // running — `document.fonts.load` is not cancelled. Hold a reference to the
+  // real load so we can tell when JetBrains Mono actually arrived.
+  const realLoad = Promise.all([document.fonts.load(size), document.fonts.load(`bold ${size}`)]);
+
+  let timedOut = false;
   fontLoadPromise = Promise.race([
-    Promise.all([document.fonts.load(size), document.fonts.load(`bold ${size}`)]),
-    new Promise<FontFace[]>((resolve) => setTimeout(() => resolve([]), FONT_LOAD_TIMEOUT_MS)),
+    realLoad,
+    new Promise<FontFace[]>((resolve) =>
+      setTimeout(() => {
+        timedOut = true;
+        resolve([]);
+      }, FONT_LOAD_TIMEOUT_MS)
+    ),
   ]).then(
     () => undefined,
     () => undefined
   );
 
+  // If the real load only settles after the timeout already unblocked the gate,
+  // the font arrived late and any terminal opened in the meantime is mis-sized.
+  // Chaining off `realLoad` (rather than a `document.fonts` `loadingdone`
+  // listener) keys the signal to JetBrains Mono specifically, so an unrelated
+  // late font load can't trigger a spurious repair.
+  void realLoad.then(
+    () => {
+      if (timedOut) notifyTerminalFontArrivedLate();
+    },
+    () => {
+      // Genuine load failure: nothing arrived, so there is nothing to repair.
+    }
+  );
+
   return fontLoadPromise;
+}
+
+/**
+ * Subscribe to the rare case where JetBrains Mono finishes loading *after* the
+ * startup timeout already unblocked terminal creation (#9776). Fires at most
+ * once. If the font already arrived late by the time you subscribe, the callback
+ * runs synchronously. No-op if the font loads on time or fails to load.
+ *
+ * @returns an unsubscribe function.
+ */
+export function onTerminalFontArrivedLate(callback: () => void): () => void {
+  if (fontArrivedLate) {
+    callback();
+    return () => {};
+  }
+  lateArrivalCallbacks.add(callback);
+  return () => {
+    lateArrivalCallbacks.delete(callback);
+  };
 }
 
 // Eagerly kick off the font load at module import so components can `use()`

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -38,6 +38,7 @@ import {
   type TerminalListenerInstallDeps,
 } from "./TerminalListenerInstaller";
 import { reduceScrollback, restoreScrollback } from "./TerminalScrollbackController";
+import { DEFAULT_TERMINAL_FONT_FAMILY, onTerminalFontArrivedLate } from "@/config/terminalFont";
 import { getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 import { usePanelStore } from "@/store/panelStore";
 import { logDebug, logWarn, logError } from "@/utils/logger";
@@ -310,6 +311,10 @@ class TerminalInstanceService {
         this.applyCursorBlinkPolicy(managed);
       },
     });
+
+    // If JetBrains Mono loads after the startup timeout already opened terminals
+    // against the fallback stack, repair every live grid once it arrives (#9776).
+    onTerminalFontArrivedLate(() => this.repairFontGrid());
   }
 
   setGPUHardwareAvailable(available: boolean): void {
@@ -2214,6 +2219,39 @@ class TerminalInstanceService {
         if ("theme" in options) {
           managed.terminal.refresh(0, managed.terminal.rows - 1);
         }
+      }
+    });
+  }
+
+  /**
+   * Re-measure character cell metrics for every live terminal and refit.
+   *
+   * Called when JetBrains Mono finishes loading *after* the startup font timeout
+   * already unblocked `terminal.open()` (#9776). Those terminals measured their
+   * cell size against the fallback monospace stack, so the grid is sized wrong
+   * for the rest of the session. xterm's CharSizeService only re-measures on a
+   * genuine `fontFamily`/`fontSize` change — `OptionsService` dedups same-value
+   * sets — so we briefly poke `fontFamily` to a distinct (but visually
+   * identical, trailing-space) string and restore it, firing the re-measure,
+   * then refit so cols/rows recompute against the corrected cell metrics.
+   */
+  repairFontGrid(): void {
+    this.instances.forEach((managed, id) => {
+      if (managed.isHibernated) return;
+      try {
+        const current = managed.terminal.options.fontFamily ?? DEFAULT_TERMINAL_FONT_FAMILY;
+        // A trailing space parses identically in CSS (no visible flicker) but is
+        // a distinct string, so it defeats OptionsService's same-value dedup and
+        // fires onMultipleOptionChange -> CharSizeService.measure() twice.
+        managed.terminal.options.fontFamily = `${current} `;
+        managed.terminal.options.fontFamily = current;
+        // fit() doesn't read these, but the ResizeObserver-driven resize() path
+        // dedups by pixel size — reset so the next observation isn't suppressed.
+        managed.lastWidth = 0;
+        managed.lastHeight = 0;
+        this.resizeController.fit(id);
+      } catch (error) {
+        logError("Failed to repair terminal font grid", error, { id });
       }
     });
   }

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -314,6 +314,8 @@ class TerminalInstanceService {
 
     // If JetBrains Mono loads after the startup timeout already opened terminals
     // against the fallback stack, repair every live grid once it arrives (#9776).
+    // The service is a page-lifetime singleton, so the unsubscribe is intentionally
+    // discarded — the subscription is one-shot and never needs teardown.
     onTerminalFontArrivedLate(() => this.repairFontGrid());
   }
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.fontGrid.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.fontGrid.test.ts
@@ -1,0 +1,277 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { TerminalRefreshTier } from "../../../../shared/types/panel";
+
+const MOCK_FONT_FAMILY = "MockMono, monospace";
+
+// Capture the callback the service registers in its constructor so the tests can
+// simulate JetBrains Mono arriving after the startup timeout (#9776) without
+// touching the real `document.fonts` load path.
+let registeredLateArrivalCallback: (() => void) | null = null;
+vi.mock("@/config/terminalFont", () => ({
+  DEFAULT_TERMINAL_FONT_FAMILY: MOCK_FONT_FAMILY,
+  DEFAULT_TERMINAL_FONT_SIZE: 12,
+  ensureTerminalFontLoaded: () => Promise.resolve(),
+  terminalFontReady: Promise.resolve(),
+  onTerminalFontArrivedLate: (cb: () => void) => {
+    registeredLateArrivalCallback = cb;
+    return () => {};
+  },
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(() => ({
+    dispose: vi.fn(),
+    onContextLoss: vi.fn(() => ({ dispose: vi.fn() })),
+  })),
+}));
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    onData: vi.fn(() => vi.fn()),
+    onExit: vi.fn(() => vi.fn()),
+    setActivityTier: vi.fn(),
+    wake: vi.fn(),
+    resize: vi.fn(),
+    getSerializedState: vi.fn(),
+    getSharedBuffer: vi.fn(() => null),
+  },
+  systemClient: {
+    openExternal: vi.fn(),
+  },
+  appClient: {
+    getHydrationState: vi.fn(),
+  },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("../TerminalAddonManager", () => ({
+  setupTerminalAddons: vi.fn(() => ({
+    fitAddon: { fit: vi.fn() },
+    serializeAddon: { serialize: vi.fn() },
+    imageAddon: { dispose: vi.fn() },
+    searchAddon: {},
+    fileLinksDisposable: { dispose: vi.fn() },
+    webLinksAddon: { dispose: vi.fn() },
+  })),
+  createImageAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createFileLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createWebLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+}));
+
+const mockDocument = {
+  createElement: vi.fn(() => ({
+    style: {},
+    className: "",
+    appendChild: vi.fn(),
+    removeChild: vi.fn(),
+    parentElement: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    remove: vi.fn(),
+    checkVisibility: vi.fn(() => true),
+    getBoundingClientRect: vi.fn(() => ({ width: 800, height: 600 })),
+  })),
+  body: {
+    appendChild: vi.fn(),
+  },
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion
+(global as any).document = mockDocument;
+
+function stubMatchMedia(): void {
+  window.matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+  });
+}
+
+describe("TerminalInstanceService - repairFontGrid (#9776)", () => {
+  it("registers a late-font-arrival callback in its constructor", async () => {
+    await import("../TerminalInstanceService");
+    expect(typeof registeredLateArrivalCallback).toBe("function");
+  });
+
+  it("calls fit on every non-hibernated instance", async () => {
+    const { terminalInstanceService } = await import("../TerminalInstanceService");
+    stubMatchMedia();
+
+    const m1 = terminalInstanceService.getOrCreate(
+      "repair-fit-1",
+      undefined,
+      {},
+      () => TerminalRefreshTier.FOCUSED,
+      undefined
+    );
+    const m2 = terminalInstanceService.getOrCreate(
+      "repair-fit-2",
+      undefined,
+      {},
+      () => TerminalRefreshTier.FOCUSED,
+      undefined
+    );
+
+    const f1 = vi.spyOn(m1.fitAddon, "fit");
+    const f2 = vi.spyOn(m2.fitAddon, "fit");
+
+    terminalInstanceService.repairFontGrid();
+
+    expect(f1).toHaveBeenCalled();
+    expect(f2).toHaveBeenCalled();
+
+    terminalInstanceService.destroy("repair-fit-1");
+    terminalInstanceService.destroy("repair-fit-2");
+  });
+
+  it("skips hibernated instances", async () => {
+    const { terminalInstanceService } = await import("../TerminalInstanceService");
+    stubMatchMedia();
+
+    const active = terminalInstanceService.getOrCreate(
+      "repair-active",
+      undefined,
+      {},
+      () => TerminalRefreshTier.FOCUSED,
+      undefined
+    );
+    const hibernated = terminalInstanceService.getOrCreate(
+      "repair-hibernated",
+      undefined,
+      {},
+      () => TerminalRefreshTier.FOCUSED,
+      undefined
+    );
+    hibernated.isHibernated = true;
+
+    const fActive = vi.spyOn(active.fitAddon, "fit");
+    const fHibernated = vi.spyOn(hibernated.fitAddon, "fit");
+
+    terminalInstanceService.repairFontGrid();
+
+    expect(fActive).toHaveBeenCalled();
+    expect(fHibernated).not.toHaveBeenCalled();
+
+    terminalInstanceService.destroy("repair-active");
+    terminalInstanceService.destroy("repair-hibernated");
+  });
+
+  it("pokes fontFamily to a distinct value then restores the original", async () => {
+    const { terminalInstanceService } = await import("../TerminalInstanceService");
+    stubMatchMedia();
+
+    const managed = terminalInstanceService.getOrCreate(
+      "repair-poke",
+      undefined,
+      {},
+      () => TerminalRefreshTier.FOCUSED,
+      undefined
+    );
+
+    const original = "Original Mono, monospace";
+    // Replace the real OptionsService getter/setter so we can observe the exact
+    // sequence of values written — the dedup-defeating poke must set a string
+    // different from the current one (else xterm's OptionsService no-ops it),
+    // then restore the original.
+    let stored = original;
+    const setLog: string[] = [];
+    Object.defineProperty(managed.terminal.options, "fontFamily", {
+      configurable: true,
+      get: () => stored,
+      set: (value: string) => {
+        setLog.push(value);
+        stored = value;
+      },
+    });
+
+    terminalInstanceService.repairFontGrid();
+
+    expect(setLog).toHaveLength(2);
+    expect(setLog[0]).not.toBe(original); // genuine change defeats same-value dedup
+    expect(setLog[1]).toBe(original); // restored
+    expect(stored).toBe(original); // final value is the original
+
+    terminalInstanceService.destroy("repair-poke");
+  });
+
+  it("falls back to the default font family when none is set", async () => {
+    const { terminalInstanceService } = await import("../TerminalInstanceService");
+    stubMatchMedia();
+
+    const managed = terminalInstanceService.getOrCreate(
+      "repair-default",
+      undefined,
+      {},
+      () => TerminalRefreshTier.FOCUSED,
+      undefined
+    );
+
+    let stored: string | undefined = undefined;
+    const setLog: string[] = [];
+    Object.defineProperty(managed.terminal.options, "fontFamily", {
+      configurable: true,
+      get: () => stored,
+      set: (value: string) => {
+        setLog.push(value);
+        stored = value;
+      },
+    });
+
+    terminalInstanceService.repairFontGrid();
+
+    expect(setLog).toHaveLength(2);
+    expect(setLog[1]).toBe(MOCK_FONT_FAMILY); // restored to the default
+
+    terminalInstanceService.destroy("repair-default");
+  });
+
+  it("resets lastWidth/lastHeight so the next resize is not deduped", async () => {
+    const { terminalInstanceService } = await import("../TerminalInstanceService");
+    stubMatchMedia();
+
+    const managed = terminalInstanceService.getOrCreate(
+      "repair-dims",
+      undefined,
+      {},
+      () => TerminalRefreshTier.FOCUSED,
+      undefined
+    );
+    managed.lastWidth = 640;
+    managed.lastHeight = 480;
+
+    terminalInstanceService.repairFontGrid();
+
+    expect(managed.lastWidth).toBe(0);
+    expect(managed.lastHeight).toBe(0);
+
+    terminalInstanceService.destroy("repair-dims");
+  });
+
+  it("repairs every live grid when the late-arrival callback fires", async () => {
+    const { terminalInstanceService } = await import("../TerminalInstanceService");
+    stubMatchMedia();
+
+    expect(registeredLateArrivalCallback).toBeTypeOf("function");
+
+    const managed = terminalInstanceService.getOrCreate(
+      "repair-callback",
+      undefined,
+      {},
+      () => TerminalRefreshTier.FOCUSED,
+      undefined
+    );
+    const fit = vi.spyOn(managed.fitAddon, "fit");
+
+    registeredLateArrivalCallback?.();
+
+    expect(fit).toHaveBeenCalled();
+
+    terminalInstanceService.destroy("repair-callback");
+  });
+});


### PR DESCRIPTION
## Summary

- The terminal grid stayed permanently mis-sized whenever JetBrains Mono finished loading after the 3-second startup font timeout — the font arrived but nothing told xterm to re-measure its cell dimensions.
- Root cause: `terminalFont.ts` raced `document.fonts.load()` against a 3s timeout and discarded the outcome in both branches. When the timeout won, xterm measured cell dimensions against the fallback monospace stack, then `CharSizeService` never re-measured because `OptionsService` deduplicates same-value `fontFamily` sets — so a plain `fit()` reused stale metrics for the whole session.
- Fix: track the real font load promise beyond the timeout, detect late arrival, and force a re-measure on every live terminal by poking `fontFamily` to a distinct (trailing-space, visually identical) string before restoring it — which is the only reliable way to invalidate `CharSizeService`'s cache without a full teardown.

Resolves #9776

## Changes

- `src/config/terminalFont.ts` — keep a reference to the real `Promise.allSettled` load (regular + bold weights) and expose a one-shot `onTerminalFontArrivedLate(cb)` subscription; `allSettled` so a failed weight doesn't mask the other arriving
- `src/services/terminal/TerminalInstanceService.ts` — new `repairFontGrid()` pokes each live terminal's `fontFamily` to force `CharSizeService` to re-measure, skips hibernated instances, then refits so `cols`/`rows` recompute; wired once to `onTerminalFontArrivedLate` in the constructor
- `src/components/Terminal/XtermAdapter.tsx` — updated stale comment to document the out-of-band late-font repair path
- New tests: late-arrival detection (after timeout, on-time, sync-on-late-subscribe, unsubscribe, load failure, partial-weight failure, throwing-callback isolation) and `repairFontGrid` (fit per non-hibernated instance, skip hibernated, poke-distinct-then-restore, default fallback, `lastWidth`/`lastHeight` reset, constructor wire) — 23 tests total

## Testing

`npx vitest run terminalFont.test.ts` and `npx vitest run TerminalInstanceService.fontGrid.test.ts` — 23 passing. `npm run check` clean (typecheck, lint, format, IPC/channel guards, build).