### PR TITLE
fix(pty-pool): warm restored panel cwds so the first terminal hits the pool (#9774)

### DIFF
--- a/electron/pty-host/handlers/__tests__/connection.test.ts
+++ b/electron/pty-host/handlers/__tests__/connection.test.ts
@@ -127,3 +127,130 @@ describe("init-buffers handler", () => {
     expect(ctx.recomputeActivityTiers).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("set-active-project pool warming (#9774)", () => {
+  interface FakePool {
+    drainAndRefill: ReturnType<typeof vi.fn>;
+    warmForKey: ReturnType<typeof vi.fn>;
+    getMaxEntries: () => number;
+    getMaxPoolSize: () => number;
+  }
+
+  function makePoolCtx(pool: FakePool) {
+    const stateRef = {
+      visualBuffers: [] as SharedRingBuffer[],
+      visualSignalView: null as Int32Array | null,
+      analysisBuffer: null as SharedRingBuffer | null,
+    };
+    const ctx = makeCtx(stateRef);
+    ctx.ptyPool = pool as unknown as HostContext["ptyPool"];
+    return ctx;
+  }
+
+  function makeFakePool(
+    overrides: Partial<FakePool> = {},
+    drainResult: Promise<void> = Promise.resolve()
+  ): FakePool {
+    return {
+      drainAndRefill: vi.fn(() => drainResult),
+      warmForKey: vi.fn(),
+      getMaxEntries: () => 8,
+      getMaxPoolSize: () => 2,
+      ...overrides,
+    };
+  }
+
+  it("warms each restored panel cwd with the env-empty hash after drain resolves", async () => {
+    const pool = makeFakePool();
+    const handlers = createConnectionHandlers(makePoolCtx(pool));
+
+    handlers["set-active-project"]({
+      windowId: 1,
+      projectId: "proj-a",
+      projectPath: "/repo",
+      panelCwds: ["/repo/wt-a", "/repo/wt-b"],
+    });
+
+    expect(pool.drainAndRefill).toHaveBeenCalledWith("/repo");
+    // Warms fire only after the drain promise resolves.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(pool.warmForKey).toHaveBeenCalledTimes(2);
+    expect(pool.warmForKey.mock.calls[0]?.[0]).toBe("/repo/wt-a");
+    expect(pool.warmForKey.mock.calls[1]?.[0]).toBe("/repo/wt-b");
+    // Each warm uses the env-empty hash (3rd arg) matching plain-shell acquires.
+    for (const call of pool.warmForKey.mock.calls) {
+      expect(call[1]).toBeUndefined();
+      expect(typeof call[2]).toBe("string");
+      expect(call[2]).toBe(pool.warmForKey.mock.calls[0]?.[2]);
+    }
+  });
+
+  it("does not warm panel cwds before the root drain resolves", async () => {
+    let resolveDrain!: () => void;
+    const deferred = new Promise<void>((resolve) => {
+      resolveDrain = resolve;
+    });
+    const pool = makeFakePool({}, deferred);
+    const handlers = createConnectionHandlers(makePoolCtx(pool));
+
+    handlers["set-active-project"]({
+      windowId: 1,
+      projectId: "proj-a",
+      projectPath: "/repo",
+      panelCwds: ["/repo/wt-a"],
+    });
+
+    // Drain is in flight — no warms yet.
+    await Promise.resolve();
+    expect(pool.warmForKey).not.toHaveBeenCalled();
+
+    resolveDrain();
+    await deferred;
+    await Promise.resolve();
+    expect(pool.warmForKey).toHaveBeenCalledTimes(1);
+  });
+
+  it("caps warmed panel cwds so high-priority entries aren't evicted (#9774)", async () => {
+    // maxEntries=8, poolSize=2 → root takes 2, leaving room for 3 panel keys.
+    const pool = makeFakePool();
+    const handlers = createConnectionHandlers(makePoolCtx(pool));
+
+    handlers["set-active-project"]({
+      windowId: 1,
+      projectId: "proj-a",
+      projectPath: "/repo",
+      panelCwds: ["/wt/a", "/wt/b", "/wt/c", "/wt/d", "/wt/e"],
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Only the first 3 (highest priority) cwds are warmed; lower-priority
+    // ones are dropped rather than evicting the earlier warms.
+    expect(pool.warmForKey).toHaveBeenCalledTimes(3);
+    expect(pool.warmForKey.mock.calls.map((c) => c[0])).toEqual(["/wt/a", "/wt/b", "/wt/c"]);
+  });
+
+  it("skips warming when no pool is present (e.g. Windows)", () => {
+    const stateRef = {
+      visualBuffers: [] as SharedRingBuffer[],
+      visualSignalView: null as Int32Array | null,
+      analysisBuffer: null as SharedRingBuffer | null,
+    };
+    const ctx = makeCtx(stateRef);
+    // ctx.ptyPool stays null (default) — mirrors the Windows pool-disabled path.
+    const handlers = createConnectionHandlers(ctx);
+
+    expect(() =>
+      handlers["set-active-project"]({
+        windowId: 1,
+        projectId: "proj-a",
+        projectPath: "/repo",
+        panelCwds: ["/repo/wt-a"],
+      })
+    ).not.toThrow();
+    expect(ctx.windowProjectMap.get(1)).toBe("proj-a");
+  });
+});

--- a/electron/pty-host/handlers/connection.ts
+++ b/electron/pty-host/handlers/connection.ts
@@ -1,5 +1,6 @@
 import type { MessagePort } from "node:worker_threads";
 import { SharedRingBuffer } from "../../../shared/utils/SharedRingBuffer.js";
+import { POOL_ENV_EMPTY_HASH } from "../../services/pty/ptyPoolEnvHash.js";
 import { PortBatcher, type PortBatcherFailedBatch } from "../index.js";
 import type { HandlerMap, HostContext } from "./types.js";
 
@@ -180,9 +181,23 @@ export function createConnectionHandlers(ctx: HostContext): HandlerMap {
       recomputeActivityTiers();
       const pool = ctx.ptyPool;
       if (msg.projectPath && pool) {
-        pool.drainAndRefill(msg.projectPath).catch((err) => {
-          console.error("[PtyHost] drainAndRefill failed:", err);
-        });
+        const panelCwds = msg.panelCwds ?? [];
+        pool
+          .drainAndRefill(msg.projectPath)
+          .then(() => {
+            // Warm the restored panels' own cwds AFTER the root drain/refill
+            // resolves. drainAndRefill bumps the drain epoch synchronously and
+            // clears stale entries; warming here (not before) guarantees these
+            // entries are tagged with the current epoch and survive (#9774).
+            // warmForKey is idempotent, per-key capacity-capped, and circuit-
+            // broken, so stale/deleted worktree paths self-limit.
+            for (const cwd of panelCwds) {
+              pool.warmForKey(cwd, undefined, POOL_ENV_EMPTY_HASH);
+            }
+          })
+          .catch((err) => {
+            console.error("[PtyHost] drainAndRefill failed:", err);
+          });
       }
     },
 

--- a/electron/pty-host/handlers/connection.ts
+++ b/electron/pty-host/handlers/connection.ts
@@ -181,7 +181,17 @@ export function createConnectionHandlers(ctx: HostContext): HandlerMap {
       recomputeActivityTiers();
       const pool = ctx.ptyPool;
       if (msg.projectPath && pool) {
-        const panelCwds = msg.panelCwds ?? [];
+        // Bound the warm set to what the pool can hold alongside the root entry
+        // without LRU-evicting the entries we just warmed. The root drain/refill
+        // takes poolSize slots; each panel cwd takes up to poolSize more. Cap
+        // the distinct panel cwds so root + panels never exceed maxEntries —
+        // otherwise warming a low-priority cwd would evict the oldest entry,
+        // which is the high-priority (active-worktree) cwd warmed first (#9774).
+        const maxPanelKeys = Math.max(
+          0,
+          Math.floor(pool.getMaxEntries() / pool.getMaxPoolSize()) - 1
+        );
+        const panelCwds = (msg.panelCwds ?? []).slice(0, maxPanelKeys);
         pool
           .drainAndRefill(msg.projectPath)
           .then(() => {

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -823,8 +823,17 @@ export class PtyClient extends EventEmitter {
     }
   }
 
-  setActiveProject(windowId: number, projectId: string | null, projectPath?: string): void {
+  setActiveProject(
+    windowId: number,
+    projectId: string | null,
+    projectPath?: string,
+    panelCwds?: string[]
+  ): void {
     this.activeProjectId = projectId;
+    // panelCwds is a transient warm hint for the first send only — it is NOT
+    // stored in windowProjectContexts. A host restart replays via
+    // syncProjectContext against a freshly-empty pool with no pending restore
+    // spawns, so re-warming saved panel cwds would be wasted work.
     this.windowProjectContexts.set(windowId, { projectId, projectPath, mode: "active" });
 
     if (!this.lifecycle.child) {
@@ -837,6 +846,7 @@ export class PtyClient extends EventEmitter {
       windowId,
       projectId,
       ...(projectPath ? { projectPath } : {}),
+      ...(panelCwds && panelCwds.length > 0 ? { panelCwds } : {}),
     });
   }
 

--- a/electron/services/PtyPool.ts
+++ b/electron/services/PtyPool.ts
@@ -8,6 +8,8 @@ import {
   ensureUtf8Locale,
 } from "./pty/EnvironmentFilter.js";
 import { POOL_ENV_EMPTY_HASH } from "./pty/ptyPoolEnvHash.js";
+import { isHostPerformanceCaptureEnabled, markHostPerformance } from "../utils/hostPerformance.js";
+import { PERF_MARKS } from "../../shared/perf/marks.js";
 
 export interface PtyPoolConfig {
   poolSize?: number;
@@ -431,6 +433,9 @@ export class PtyPool {
       if (process.env.DAINTREE_VERBOSE) {
         console.log(`[PtyPool] Miss on key ${wantedKey}; pool size: ${this.pool.size}`);
       }
+      if (isHostPerformanceCaptureEnabled()) {
+        markHostPerformance(PERF_MARKS.POOL_MISS, { cwd, envHash });
+      }
       return null;
     }
 
@@ -461,6 +466,9 @@ export class PtyPool {
       entry.dataDisposable.dispose();
       destroyPty(entry.process);
       this.warmForKey(cwd, entry.env, envHash);
+      if (isHostPerformanceCaptureEnabled()) {
+        markHostPerformance(PERF_MARKS.POOL_MISS, { cwd, envHash });
+      }
       return null;
     }
 
@@ -472,6 +480,14 @@ export class PtyPool {
       console.log(
         `[PtyPool] Acquired PTY ${id} for key ${wantedKey} (prelude=${prelude.length}B), ${this.pool.size} remaining`
       );
+    }
+
+    if (isHostPerformanceCaptureEnabled()) {
+      markHostPerformance(PERF_MARKS.POOL_HIT, {
+        cwd,
+        envHash,
+        preludeBytes: prelude.length,
+      });
     }
 
     // Refill the same key so the next acquire is also instant. Fire-and-

--- a/electron/services/__tests__/PtyPool.test.ts
+++ b/electron/services/__tests__/PtyPool.test.ts
@@ -554,6 +554,69 @@ describe("PtyPool", () => {
       pool.dispose();
     });
 
+    it("warms multiple restored panel cwds after drainAndRefill so each later acquire hits (#9774)", async () => {
+      const root = createFakeProcess(1801);
+      const wtA = createFakeProcess(1802);
+      const wtB = createFakeProcess(1803);
+      spawnMock.mockReturnValueOnce(root).mockReturnValueOnce(wtA).mockReturnValueOnce(wtB);
+
+      const pool = new PtyPool({ poolSize: 1, defaultCwd: "/home/tester" });
+
+      // Mirror the connection handler: root drain/refill first, then warm each
+      // restored panel cwd at the env-empty key.
+      await pool.drainAndRefill("/repo");
+      pool.warmForKey("/repo/wt-a", undefined, "env-empty");
+      pool.warmForKey("/repo/wt-b", undefined, "env-empty");
+      await flushMicrotasks();
+
+      expect(spawnMock).toHaveBeenCalledTimes(3);
+      expect(spawnMock.mock.calls[1]?.[2]).toMatchObject({ cwd: "/repo/wt-a" });
+      expect(spawnMock.mock.calls[2]?.[2]).toMatchObject({ cwd: "/repo/wt-b" });
+
+      // A restored panel spawning at its own worktree cwd now hits the pool
+      // instead of paying a full cold spawn.
+      expect(pool.acquireByKey("/repo/wt-a", "env-empty")?.process).toBe(wtA);
+      expect(pool.acquireByKey("/repo/wt-b", "env-empty")?.process).toBe(wtB);
+      pool.dispose();
+    });
+
+    it("survives the drain epoch when panel cwds are warmed after drainAndRefill resolves (#9774)", async () => {
+      const stale = createFakeProcess(1901);
+      const root = createFakeProcess(1902);
+      const panel = createFakeProcess(1903);
+      spawnMock.mockReturnValueOnce(stale).mockReturnValueOnce(root).mockReturnValueOnce(panel);
+
+      const pool = new PtyPool({ poolSize: 1, defaultCwd: "/old" });
+      await pool.warmPool();
+
+      // drainAndRefill bumps the epoch and kills the stale entry; the panel
+      // warm fires only after it resolves, so the new entry is tagged with the
+      // current epoch and is not rejected as stale.
+      await pool.drainAndRefill("/repo");
+      pool.warmForKey("/repo/wt-a", undefined, "env-empty");
+      await flushMicrotasks();
+
+      expect(pool.acquireByKey("/repo/wt-a", "env-empty")?.process).toBe(panel);
+      pool.dispose();
+    });
+
+    it("keeps total entries bounded by maxEntries when warming many panel cwds (#9774)", async () => {
+      spawnMock.mockImplementation(() => createFakeProcess(2100 + spawnMock.mock.calls.length));
+      const pool = new PtyPool({ poolSize: 1, maxEntries: 3, defaultCwd: "/home/tester" });
+
+      await pool.drainAndRefill("/repo");
+      // Warm more distinct cwds than the global cap allows; LRU eviction must
+      // hold the pool at maxEntries rather than growing unbounded.
+      pool.warmForKey("/repo/wt-a", undefined, "env-empty");
+      pool.warmForKey("/repo/wt-b", undefined, "env-empty");
+      pool.warmForKey("/repo/wt-c", undefined, "env-empty");
+      pool.warmForKey("/repo/wt-d", undefined, "env-empty");
+      await flushMicrotasks();
+
+      expect(pool.getPoolSize()).toBeLessThanOrEqual(3);
+      pool.dispose();
+    });
+
     it("destroys the pooled PTY on unexpected exit so the master FD is released (#7892)", async () => {
       const first = createFakeProcess(2001);
       const second = createFakeProcess(2002);

--- a/electron/services/pty/__tests__/terminalSpawn.pool.test.ts
+++ b/electron/services/pty/__tests__/terminalSpawn.pool.test.ts
@@ -136,6 +136,49 @@ describe("acquirePtyProcess pool handling", () => {
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
+  it("hits a pool slot warmed at a restored worktree cwd, not just the project root (#9774)", () => {
+    const pooled = createFakePooledPty();
+    const dataHandoff = createFakeDataHandoff();
+    // The pool root is the project path, but the restored panel spawns at its
+    // own worktree cwd. Pre-warming that cwd (the #9774 fix) means acquireByKey
+    // is consulted with — and hits on — the worktree cwd, so no cold spawn.
+    const worktreeCwd = "/repo/.worktrees/feature-a";
+    const acquireByKey = vi.fn<
+      (
+        cwd: string,
+        envHash: string
+      ) => {
+        process: FakePooledPty;
+        prelude: string;
+        dataHandoff: FakeDataHandoff;
+      } | null
+    >((cwd) => (cwd === worktreeCwd ? { process: pooled, prelude: "", dataHandoff } : null));
+    const warmForKey =
+      vi.fn<(cwd: string, env: Record<string, string> | undefined, envHash: string) => void>();
+    const pool = createFakePool({
+      defaultCwd: "/repo",
+      acquireByKey,
+      warmForKey,
+    });
+
+    const result = acquirePtyProcess(
+      "t1",
+      { ...baseOptions, cwd: worktreeCwd },
+      {},
+      "/bin/bash",
+      [],
+      pool,
+      () => {}
+    );
+
+    expect(acquireByKey).toHaveBeenCalledTimes(1);
+    expect(acquireByKey.mock.calls[0]?.[0]).toBe(worktreeCwd);
+    expect(result.ptyProcess).toBe(pooled);
+    // Hit ⇒ no fresh cold spawn and no background warm needed for this key.
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(warmForKey).not.toHaveBeenCalled();
+  });
+
   it("does NOT write a shell-level `cd` command or any preamble to pooled PTYs (#5097 regression guard)", () => {
     const pooled = createFakePooledPty();
     const pool = createFakePool({

--- a/electron/window/__tests__/restorePanelCwds.test.ts
+++ b/electron/window/__tests__/restorePanelCwds.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { extractRestorePanelCwds } from "../restorePanelCwds.js";
+import type { ProjectState, PanelSnapshot } from "../../../shared/types/project.js";
+
+function panel(overrides: Partial<PanelSnapshot>): PanelSnapshot {
+  return {
+    id: overrides.id ?? "p",
+    title: overrides.title ?? "Terminal",
+    location: overrides.location ?? "grid",
+    kind: "terminal",
+    ...overrides,
+  } as PanelSnapshot;
+}
+
+function state(terminals: PanelSnapshot[], overrides: Partial<ProjectState> = {}): ProjectState {
+  return {
+    projectId: "proj",
+    sidebarWidth: 350,
+    terminals,
+    ...overrides,
+  };
+}
+
+describe("extractRestorePanelCwds", () => {
+  it("returns an empty array for null state or empty terminals", () => {
+    expect(extractRestorePanelCwds(null)).toEqual([]);
+    expect(extractRestorePanelCwds(state([]))).toEqual([]);
+  });
+
+  it("includes plain PTY panels and excludes agent/command panels (#7961)", () => {
+    const result = extractRestorePanelCwds(
+      state([
+        panel({ id: "a", cwd: "/repo/plain" }),
+        panel({ id: "b", cwd: "/repo/agent", launchAgentId: "claude" }),
+        panel({ id: "c", cwd: "/repo/cmd", command: "npm run dev" }),
+      ])
+    );
+    expect(result).toEqual(["/repo/plain"]);
+  });
+
+  it("excludes non-PTY panel kinds and blank/missing cwds", () => {
+    const result = extractRestorePanelCwds(
+      state([
+        panel({ id: "a", cwd: "/repo/term" }),
+        panel({ id: "b", cwd: "/repo/browser", kind: "browser" }),
+        panel({ id: "c", cwd: "   " }),
+        panel({ id: "d" }),
+      ])
+    );
+    expect(result).toEqual(["/repo/term"]);
+  });
+
+  it("orders active-worktree panels first, then by lastActiveAt descending", () => {
+    const result = extractRestorePanelCwds(
+      state(
+        [
+          panel({ id: "old-other", cwd: "/wt/other-old", worktreeId: "wt-2", lastActiveAt: 10 }),
+          panel({ id: "new-other", cwd: "/wt/other-new", worktreeId: "wt-2", lastActiveAt: 30 }),
+          panel({ id: "active-old", cwd: "/wt/active-old", worktreeId: "wt-1", lastActiveAt: 5 }),
+          panel({ id: "active-new", cwd: "/wt/active-new", worktreeId: "wt-1", lastActiveAt: 20 }),
+        ],
+        { activeWorktreeId: "wt-1" }
+      )
+    );
+    // Active worktree (wt-1) first, newest-active first within each group.
+    expect(result).toEqual(["/wt/active-new", "/wt/active-old", "/wt/other-new", "/wt/other-old"]);
+  });
+
+  it("dedupes repeated cwds while preserving priority order", () => {
+    const result = extractRestorePanelCwds(
+      state(
+        [
+          panel({ id: "a", cwd: "/wt/shared", worktreeId: "wt-1", lastActiveAt: 5 }),
+          panel({ id: "b", cwd: "/wt/shared", worktreeId: "wt-1", lastActiveAt: 50 }),
+          panel({ id: "c", cwd: "/wt/other", worktreeId: "wt-2", lastActiveAt: 99 }),
+        ],
+        { activeWorktreeId: "wt-1" }
+      )
+    );
+    expect(result).toEqual(["/wt/shared", "/wt/other"]);
+  });
+});

--- a/electron/window/restorePanelCwds.ts
+++ b/electron/window/restorePanelCwds.ts
@@ -1,0 +1,46 @@
+import { panelKindHasPty } from "../../shared/config/panelKindRegistry.js";
+import type { ProjectState } from "../../shared/types/project.js";
+
+/**
+ * Extract the working directories of restorable PTY panels from saved project
+ * state, in pool-warm priority order. On session restore each panel spawns at
+ * its own worktree cwd, so the pty-host must pre-warm these (not just the
+ * project root) for the first terminal to hit the pool (#9774).
+ *
+ * Filtered to plain shell panels — agent/command panels set `options.shell`/
+ * `options.args` at spawn, which disqualifies them from the pool regardless
+ * (#7961), so warming their cwds would only burn slots. Ordering: panels in the
+ * active worktree first, then by `lastActiveAt` descending, so the cwd of the
+ * panel the user is most likely to see first is warmed first. Exact cwd strings
+ * are preserved (no normalization) to match the `acquireByKey` lookup (#5102).
+ */
+export function extractRestorePanelCwds(state: ProjectState | null): string[] {
+  if (!state || !Array.isArray(state.terminals)) return [];
+
+  const candidates = state.terminals.filter(
+    (panel) =>
+      typeof panel.cwd === "string" &&
+      panel.cwd.trim() !== "" &&
+      panelKindHasPty(panel.kind ?? "terminal") &&
+      !panel.command &&
+      !panel.launchAgentId
+  );
+
+  const activeWorktreeId = state.activeWorktreeId;
+  candidates.sort((a, b) => {
+    const aActive = activeWorktreeId !== undefined && a.worktreeId === activeWorktreeId;
+    const bActive = activeWorktreeId !== undefined && b.worktreeId === activeWorktreeId;
+    if (aActive !== bActive) return aActive ? -1 : 1;
+    return (b.lastActiveAt ?? 0) - (a.lastActiveAt ?? 0);
+  });
+
+  const seen = new Set<string>();
+  const cwds: string[] = [];
+  for (const panel of candidates) {
+    const cwd = panel.cwd as string;
+    if (seen.has(cwd)) continue;
+    seen.add(cwd);
+    cwds.push(cwd);
+  }
+  return cwds;
+}

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -16,6 +16,7 @@ import { markPerformance } from "../utils/performance.js";
 import { getCurrentDiskSpaceStatus } from "../services/DiskSpaceMonitor.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+import { extractRestorePanelCwds } from "./restorePanelCwds.js";
 import {
   isSmokeTest,
   smokeTestStart,
@@ -356,14 +357,27 @@ export async function setupWindowServices(
     console.warn("[MAIN] Scratch store init failed:", err);
   });
 
+  // Read saved panel cwds concurrently with PTY/store init so the warm hint is
+  // ready the instant `setActiveProject` fires — before the renderer hydrates
+  // and starts requesting restore spawns. getProjectState reads directly by
+  // configDir+projectId (no dependency on projectStore.initialize's in-memory
+  // list), so racing it against initialize() is safe.
+  let restorePanelCwds: string[] = [];
+
   try {
     const results = await Promise.allSettled([
       getPtyClient()!.waitForReady(),
       projectStore.initialize(),
+      opts.initialProjectId
+        ? projectStore.getProjectState(opts.initialProjectId)
+        : Promise.resolve(null),
     ]);
 
     ptyReady = results[0].status === "fulfilled";
     const projectStoreReady = results[1].status === "fulfilled";
+    if (results[2].status === "fulfilled") {
+      restorePanelCwds = extractRestorePanelCwds(results[2].value);
+    }
 
     if (ptyReady && workspaceReady && projectStoreReady) {
       console.log("[MAIN] All critical services ready");
@@ -405,7 +419,7 @@ export async function setupWindowServices(
     createAndDistributePorts(win, ctx);
 
     if (restoreProject) {
-      pty.setActiveProject(win.id, restoreProject.id, restoreProject.path);
+      pty.setActiveProject(win.id, restoreProject.id, restoreProject.path, restorePanelCwds);
     } else {
       pty.setActiveProject(win.id, null);
     }

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -358,10 +358,12 @@ export async function setupWindowServices(
   });
 
   // Read saved panel cwds concurrently with PTY/store init so the warm hint is
-  // ready the instant `setActiveProject` fires — before the renderer hydrates
-  // and starts requesting restore spawns. getProjectState reads directly by
-  // configDir+projectId (no dependency on projectStore.initialize's in-memory
-  // list), so racing it against initialize() is safe.
+  // ready the instant `setActiveProject` fires — typically before the renderer
+  // hydrates and starts requesting restore spawns (best-effort: a spawn that
+  // races ahead simply misses the pool and cold-spawns, as it did pre-fix).
+  // getProjectState reads directly by configDir+projectId (no dependency on
+  // projectStore.initialize's in-memory list), so racing it against
+  // initialize() is safe.
   let restorePanelCwds: string[] = [];
 
   try {

--- a/shared/perf/marks.ts
+++ b/shared/perf/marks.ts
@@ -67,6 +67,15 @@ export const PERF_MARKS = {
   TERMINAL_DATA_PARSED: "terminal_data_parsed",
   TERMINAL_DATA_RENDERED: "terminal_data_rendered",
 
+  /**
+   * Emitted per spawn from the pty-host when `acquireByKey` finds (HIT) or
+   * misses (MISS) a pre-warmed entry for the requested (cwd, envHash). Lets
+   * `perf:cold-start` measure pool hit rate on session restore instead of the
+   * DAINTREE_VERBOSE-only log line (#9774).
+   */
+  POOL_HIT: "pty_pool_hit",
+  POOL_MISS: "pty_pool_miss",
+
   IPC_REQUEST_START: "ipc_request_start",
   IPC_REQUEST_END: "ipc_request_end",
 

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -91,6 +91,15 @@ export type PtyHostRequest =
       projectId: string | null;
       /** Filesystem path of the project; used to warm the PTY pool at the project root. */
       projectPath?: string;
+      /**
+       * Per-panel working directories from restored session state, in
+       * warm-priority order (active worktree first, then most-recently-active).
+       * On session restore each panel spawns at its own worktree cwd rather
+       * than the project root, so warming only `projectPath` always misses the
+       * first terminal. The pty-host warms these extra cwds after the root
+       * drain/refill so the first restored panel hits the pool (#9774).
+       */
+      panelCwds?: string[];
     }
   | {
       type: "project-switch";


### PR DESCRIPTION
## Problem

On session restore, `set-active-project` warmed the PTY pool using **only the project root path**. Restored panels carry per-worktree working directories, so when `acquirePtyProcess` looked up `(worktree-cwd, envHash)` it always missed — the first terminal paid the full shell spawn + rc-file cost. The pool effectively never served the first terminal after a restore.

## Fix

- **Extend `set-active-project` IPC** with `panelCwds` — a warm-priority list of the restored panels' worktree cwds (`shared/types/pty-host.ts`).
- **`electron/window/restorePanelCwds.ts` (new):** `extractRestorePanelCwds(state)` filters saved terminals to plain shells (non-blank cwd, `panelKindHasPty`, no `command`/`launchAgentId`), sorts active-worktree-first then by `lastActiveAt` desc, and dedups while preserving order.
- **`windowServices.ts`:** reads `projectStore.getProjectState` concurrently with PTY/store init (folded into the existing `Promise.allSettled`) and passes the extracted cwds to `setActiveProject`.
- **`PtyClient.setActiveProject`:** threads `panelCwds` into the send only (not stored for resync — a host restart gets a fresh empty pool with no pending restore spawns).
- **`connection.ts`:** after `drainAndRefill(projectPath)` resolves, warms each panel cwd via `warmForKey(cwd, undefined, POOL_ENV_EMPTY_HASH)`.
- **Telemetry:** adds `POOL_HIT`/`POOL_MISS` perf marks emitted from `acquireByKey` (gated on host perf capture) so `perf:cold-start` can measure pool hit rate instead of the `DAINTREE_VERBOSE`-only log line.

## Design notes

- Warms run **after** `drainAndRefill` resolves, so the new entries are tagged with the current drain epoch and survive (the epoch is bumped synchronously at drain start).
- Warm set capped to `floor(maxEntries/poolSize) - 1` distinct cwds so a low-priority cwd can never LRU-evict the active-worktree entries warmed first.
- Agent/command panels filtered out — they set `options.shell`/`options.args` and never hit the pool anyway (#7961).
- Exact cwd strings preserved (no normalization) to match `acquireByKey` lookups (#5102); `POOL_ENV_EMPTY_HASH` used for plain-shell warms (#7623); per-key circuit breaker self-limits stale/deleted-worktree cwds (#7893); priority ordering follows #9514.
- macOS/Linux only — the PTY pool is disabled on Windows (ConPTY guard); the warm path no-ops when `ctx.ptyPool` is null.

## Tests

72 passing across:
- `PtyPool.test.ts` — multi-cwd warm after drain, drain-epoch survival, capacity bound.
- `terminalSpawn.pool.test.ts` — restored worktree cwd hits the pool (no cold spawn).
- `restorePanelCwds.test.ts` — filter/sort/dedup.
- `connection.test.ts` — warm-after-drain ordering, env-empty hash, capacity cap, null-pool (Windows) skip.

## Verification

`npm run check` clean — typecheck, lint ratchet (no new warnings), format, and IPC/channel/confirm-wiring guards all pass.

Closes #9774.