### PR TITLE
perf(boot): verify compile cache and measure warm boots

### DIFF
--- a/electron/bootstrap.ts
+++ b/electron/bootstrap.ts
@@ -5,21 +5,42 @@
 // the correct directory before main.ts re-imports it (idempotent via ESM cache).
 import "./setup/environment.js";
 
-import { enableCompileCache } from "node:module";
+import { enableCompileCache, flushCompileCache, constants as moduleConstants } from "node:module";
 import fs from "node:fs";
 import path from "node:path";
 import { app, dialog } from "electron";
 import { runBootMigrations } from "./boot/migrations/index.js";
 import { isSafeModeActive } from "./services/CrashLoopGuardService.js";
+import { setCompileCacheEnableStatus } from "./utils/hostPerformance.js";
 import { initializeStore, _peekStoreInstance } from "./store.js";
 import { formatErrorMessage } from "../shared/utils/errorMessage.js";
 
 const cacheDir = path.join(app.getPath("userData"), "compile-cache");
-try {
-  fs.mkdirSync(cacheDir, { recursive: true });
-  enableCompileCache(cacheDir);
-} catch {
-  enableCompileCache();
+{
+  // Capture the enableCompileCache() status. It's the only runtime signal that
+  // the cache is actually active — status FAILED means the directory is
+  // unusable and the app silently runs without caching. We stash it so the
+  // APP_BOOT_START mark can surface it (see getCompileCacheMeta).
+  let result: ReturnType<typeof enableCompileCache> | undefined;
+  try {
+    fs.mkdirSync(cacheDir, { recursive: true });
+    result = enableCompileCache(cacheDir);
+  } catch {
+    try {
+      result = enableCompileCache();
+    } catch {
+      // enableCompileCache is best-effort; the app boots fine without it.
+    }
+  }
+  if (result) {
+    setCompileCacheEnableStatus(result.status);
+    if (result.status === moduleConstants.compileCacheStatus.FAILED) {
+      console.warn(
+        "[Bootstrap] Compile cache enablement failed — main-process modules will not be cached. Directory:",
+        cacheDir
+      );
+    }
+  }
 }
 
 // Run forward-only boot migrations before anything in main.ts touches state.
@@ -62,3 +83,18 @@ try {
 }
 
 await import("./main.js");
+
+// Persist any compile-cache entries written during boot. enableCompileCache()
+// only flushes on a clean process exit, so a crash or SIGKILL before the first
+// graceful quit would leave the cache empty forever — every launch staying
+// cache-cold. Flushing here, after the boot-critical main.js import resolves,
+// guarantees first-run writes survive an unclean exit. flushCompileCache() is
+// synchronous but cheap (one fs write) and runs after boot work, off the hot
+// path. Feature-detected and wrapped so a missing/throwing API can't break boot.
+try {
+  if (typeof flushCompileCache === "function") {
+    flushCompileCache();
+  }
+} catch (err) {
+  console.warn("[Bootstrap] flushCompileCache after boot failed:", err);
+}

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -1,3 +1,4 @@
+import { flushCompileCache } from "node:module";
 import { app, dialog } from "electron";
 import type { PtyClient } from "../services/PtyClient.js";
 import type { WorkspaceClient } from "../services/WorkspaceClient.js";
@@ -127,6 +128,18 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
       getCrashRecoveryService().takeBackup();
     } catch (err) {
       console.warn("[MAIN] Eager takeBackup at quit-intent failed:", err);
+    }
+
+    // Persist compile-cache entries on clean quit. Synchronous and cheap (one
+    // fs write), placed here before the async graceful-shutdown chain so it
+    // can't race the cleanup timeout. We've already committed to quitting
+    // (isQuitting = true), so this never fires on a cancelled quit dialog.
+    try {
+      if (typeof flushCompileCache === "function") {
+        flushCompileCache();
+      }
+    } catch (err) {
+      console.warn("[MAIN] flushCompileCache at quit failed:", err);
     }
 
     console.log("[MAIN] Starting graceful shutdown...");

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -17,6 +17,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { PERF_MARKS } from "../shared/perf/marks.js";
 import { getOsToAppBootMs, markPerformance } from "./utils/performance.js";
+import { getCompileCacheMeta } from "./utils/hostPerformance.js";
 import { enforceIpcSenderValidation, setupPermissionLockdown } from "./setup/security.js";
 import {
   registerAppProtocol,
@@ -96,9 +97,16 @@ import { emergencyLogMainFatal } from "./utils/emergencyLog.js";
 enforceIpcSenderValidation();
 {
   const osToAppBootMs = getOsToAppBootMs();
+  // Attach compile-cache state (enabled flag, status, cacheFileCount) so the
+  // cold-start aggregator can tell cache-cold from cache-warm runs and flag a
+  // silently-disabled cache. bootstrap.ts ran enableCompileCache() before this
+  // module evaluated, so the captured status is already available.
+  const compileCacheMeta = getCompileCacheMeta();
+  const bootMeta: Record<string, unknown> = { ...compileCacheMeta };
+  if (osToAppBootMs !== null) bootMeta.osToAppBootMs = osToAppBootMs;
   markPerformance(
     PERF_MARKS.APP_BOOT_START,
-    osToAppBootMs !== null ? { osToAppBootMs } : undefined
+    Object.keys(bootMeta).length > 0 ? bootMeta : undefined
   );
 }
 

--- a/electron/utils/__tests__/hostPerformance.test.ts
+++ b/electron/utils/__tests__/hostPerformance.test.ts
@@ -247,6 +247,20 @@ describe("getCompileCacheMeta", () => {
     expect(meta.cacheFileCount).toBeUndefined();
   });
 
+  it("reports compileCacheEnabled=false when getCompileCacheDir throws", async () => {
+    const mod = await loadModule({
+      DAINTREE_PERF_CAPTURE: "1",
+      DAINTREE_PERF_METRICS_FILE: "/tmp/marks.ndjson",
+    });
+    state.getCompileCacheDirImpl = () => {
+      throw new Error("boom");
+    };
+
+    const meta = mod.getCompileCacheMeta();
+    expect(meta.compileCacheEnabled).toBe(false);
+    expect(meta.cacheFileCount).toBeUndefined();
+  });
+
   it("omits status fields until setCompileCacheEnableStatus is called", async () => {
     const mod = await loadModule({
       DAINTREE_PERF_CAPTURE: "1",

--- a/electron/utils/__tests__/hostPerformance.test.ts
+++ b/electron/utils/__tests__/hostPerformance.test.ts
@@ -246,4 +246,52 @@ describe("getCompileCacheMeta", () => {
     expect(meta.compileCacheEnabled).toBe(false);
     expect(meta.cacheFileCount).toBeUndefined();
   });
+
+  it("omits status fields until setCompileCacheEnableStatus is called", async () => {
+    const mod = await loadModule({
+      DAINTREE_PERF_CAPTURE: "1",
+      DAINTREE_PERF_METRICS_FILE: "/tmp/marks.ndjson",
+    });
+
+    const meta = mod.getCompileCacheMeta();
+    expect(meta.compileCacheStatus).toBeUndefined();
+    expect(meta.compileCacheStatusName).toBeUndefined();
+  });
+
+  it("maps the captured enableCompileCache status to its human-readable name", async () => {
+    const mod = await loadModule({
+      DAINTREE_PERF_CAPTURE: "1",
+      DAINTREE_PERF_METRICS_FILE: "/tmp/marks.ndjson",
+    });
+
+    // ALREADY_ENABLED (2) is the normal production path (API dir arg was used).
+    mod.setCompileCacheEnableStatus(2);
+    const enabled = mod.getCompileCacheMeta();
+    expect(enabled.compileCacheStatus).toBe(2);
+    expect(enabled.compileCacheStatusName).toBe("ALREADY_ENABLED");
+  });
+
+  it("surfaces FAILED status so a silently-disabled cache is detectable", async () => {
+    const mod = await loadModule({
+      DAINTREE_PERF_CAPTURE: "1",
+      DAINTREE_PERF_METRICS_FILE: "/tmp/marks.ndjson",
+    });
+
+    mod.setCompileCacheEnableStatus(0);
+    const meta = mod.getCompileCacheMeta();
+    expect(meta.compileCacheStatus).toBe(0);
+    expect(meta.compileCacheStatusName).toBe("FAILED");
+  });
+
+  it("labels an out-of-range status as UNKNOWN rather than dropping it", async () => {
+    const mod = await loadModule({
+      DAINTREE_PERF_CAPTURE: "1",
+      DAINTREE_PERF_METRICS_FILE: "/tmp/marks.ndjson",
+    });
+
+    mod.setCompileCacheEnableStatus(99);
+    const meta = mod.getCompileCacheMeta();
+    expect(meta.compileCacheStatus).toBe(99);
+    expect(meta.compileCacheStatusName).toBe("UNKNOWN");
+  });
 });

--- a/electron/utils/hostPerformance.ts
+++ b/electron/utils/hostPerformance.ts
@@ -113,6 +113,35 @@ export function isHostPerformanceCaptureEnabled(): boolean {
   return CAPTURE_ENABLED;
 }
 
+// Result of the main-process `enableCompileCache()` call, captured in
+// bootstrap.ts. Node's `enableCompileCache()` returns `{ status, directory }`
+// but the status is otherwise invisible — there's no getter for it later. We
+// stash it here so `getCompileCacheMeta()` can attach it to the APP_BOOT_START
+// mark, making "cache silently disabled" (status FAILED/DISABLED) detectable
+// from NDJSON without a debug session. Utility-process hosts never call the
+// setter, so their marks omit the status fields (backward compatible).
+let _compileCacheEnableStatus: number | null = null;
+
+// Node's `module.constants.compileCacheStatus` values. Hardcoded here rather
+// than imported so this maps correctly even when `node:module` is mocked in
+// tests (the mock only stubs getCompileCacheDir). These are stable Node API
+// constants — FAILED=0, ENABLED=1, ALREADY_ENABLED=2, DISABLED=3.
+const COMPILE_CACHE_STATUS_NAMES: Record<number, string> = {
+  0: "FAILED",
+  1: "ENABLED",
+  2: "ALREADY_ENABLED",
+  3: "DISABLED",
+};
+
+/**
+ * Record the `status` returned by the main-process `enableCompileCache()` call
+ * so it can be surfaced in the APP_BOOT_START mark. Pass the raw integer status
+ * from the result object. Call once during bootstrap.
+ */
+export function setCompileCacheEnableStatus(status: number): void {
+  _compileCacheEnableStatus = status;
+}
+
 /**
  * Snapshot of the V8 compile-cache state for inclusion in `module_eval_complete`
  * marks. `cacheFileCount > 0` on a second launch confirms `enableCompileCache()`
@@ -135,11 +164,19 @@ export function getCompileCacheMeta(): Record<string, unknown> {
       // Directory might not exist yet on first launch — that's a 0 count.
     }
 
-    return {
+    const meta: Record<string, unknown> = {
       compileCacheEnabled: true,
       compileCacheDir: dir,
       cacheFileCount,
     };
+
+    if (_compileCacheEnableStatus !== null) {
+      meta.compileCacheStatus = _compileCacheEnableStatus;
+      meta.compileCacheStatusName =
+        COMPILE_CACHE_STATUS_NAMES[_compileCacheEnableStatus] ?? "UNKNOWN";
+    }
+
+    return meta;
   } catch {
     return { compileCacheEnabled: false };
   }

--- a/scripts/perf/__tests__/coldStartAggregate.test.ts
+++ b/scripts/perf/__tests__/coldStartAggregate.test.ts
@@ -330,6 +330,35 @@ describe("cache-kind bucketing", () => {
     expect(agg.byCacheKind.warm!.runs).toBe(1);
   });
 
+  it("excludes degraded runs from cache-kind buckets (wall-clock fallback skews durations)", () => {
+    const agg = aggregate([
+      makeRun({ index: 0, durationMs: 800, cacheKind: "warm", cacheFileCount: 10 }),
+      makeRun({
+        index: 1,
+        durationMs: 9999,
+        degraded: true,
+        cacheKind: "warm",
+        cacheFileCount: 10,
+      }),
+    ]);
+
+    expect(agg.byCacheKind.warm).not.toBeNull();
+    expect(agg.byCacheKind.warm!.runs).toBe(1);
+    expect(agg.byCacheKind.warm!.meanMs).toBe(800);
+  });
+
+  it("guards bucket stats against a malformed (NaN) duration", () => {
+    const agg = aggregate([
+      makeRun({ index: 0, durationMs: 1000, cacheKind: "cold" }),
+      makeRun({ index: 1, durationMs: Number.NaN as unknown as number, cacheKind: "cold" }),
+    ]);
+
+    expect(agg.byCacheKind.cold).not.toBeNull();
+    expect(agg.byCacheKind.cold!.runs).toBe(1);
+    expect(Number.isFinite(agg.byCacheKind.cold!.meanMs)).toBe(true);
+    expect(agg.byCacheKind.cold!.meanMs).toBe(1000);
+  });
+
   it("computes the bucket median cacheFileCount and ignores missing counts", () => {
     const agg = aggregate([
       makeRun({ index: 0, durationMs: 800, cacheKind: "warm", cacheFileCount: 40 }),

--- a/scripts/perf/__tests__/coldStartAggregate.test.ts
+++ b/scripts/perf/__tests__/coldStartAggregate.test.ts
@@ -279,6 +279,70 @@ describe("cold-start aggregate", () => {
   });
 });
 
+describe("cache-kind bucketing", () => {
+  it("splits successful runs into cold and warm buckets by cacheKind", () => {
+    const agg = aggregate([
+      makeRun({ index: 0, durationMs: 1000, cacheKind: "cold", cacheFileCount: 0 }),
+      makeRun({ index: 1, durationMs: 1200, cacheKind: "cold", cacheFileCount: 0 }),
+      makeRun({ index: 2, durationMs: 800, cacheKind: "warm", cacheFileCount: 42 }),
+      makeRun({ index: 3, durationMs: 820, cacheKind: "warm", cacheFileCount: 44 }),
+    ]);
+
+    expect(agg.byCacheKind.cold).not.toBeNull();
+    expect(agg.byCacheKind.warm).not.toBeNull();
+    expect(agg.byCacheKind.cold!.runs).toBe(2);
+    expect(agg.byCacheKind.warm!.runs).toBe(2);
+    // Warm bucket should be faster than cold here, and its median file count > 0.
+    expect(agg.byCacheKind.warm!.meanMs).toBeLessThan(agg.byCacheKind.cold!.meanMs);
+    expect(agg.byCacheKind.warm!.medianCacheFileCount).toBeGreaterThan(0);
+    expect(agg.byCacheKind.cold!.medianCacheFileCount).toBe(0);
+  });
+
+  it("leaves the warm bucket null when all runs are cold", () => {
+    const agg = aggregate([
+      makeRun({ index: 0, durationMs: 1000, cacheKind: "cold" }),
+      makeRun({ index: 1, durationMs: 1100, cacheKind: "cold" }),
+    ]);
+
+    expect(agg.byCacheKind.cold).not.toBeNull();
+    expect(agg.byCacheKind.cold!.runs).toBe(2);
+    expect(agg.byCacheKind.warm).toBeNull();
+  });
+
+  it("defaults runs without an explicit cacheKind to the cold bucket", () => {
+    const agg = aggregate([
+      makeRun({ index: 0, durationMs: 1000 }),
+      makeRun({ index: 1, durationMs: 1050 }),
+    ]);
+
+    expect(agg.byCacheKind.cold).not.toBeNull();
+    expect(agg.byCacheKind.cold!.runs).toBe(2);
+    expect(agg.byCacheKind.warm).toBeNull();
+  });
+
+  it("excludes failed runs from both cache-kind buckets", () => {
+    const agg = aggregate([
+      makeRun({ index: 0, durationMs: 900, cacheKind: "warm", cacheFileCount: 10 }),
+      makeRun({ index: 1, durationMs: -1, failed: true, cacheKind: "warm" }),
+    ]);
+
+    expect(agg.byCacheKind.warm).not.toBeNull();
+    expect(agg.byCacheKind.warm!.runs).toBe(1);
+  });
+
+  it("computes the bucket median cacheFileCount and ignores missing counts", () => {
+    const agg = aggregate([
+      makeRun({ index: 0, durationMs: 800, cacheKind: "warm", cacheFileCount: 40 }),
+      makeRun({ index: 1, durationMs: 810, cacheKind: "warm", cacheFileCount: 50 }),
+      // No cacheFileCount on this run — excluded from the median, not counted as 0.
+      makeRun({ index: 2, durationMs: 820, cacheKind: "warm" }),
+    ]);
+
+    expect(agg.byCacheKind.warm!.runs).toBe(3);
+    expect(agg.byCacheKind.warm!.medianCacheFileCount).toBe(45);
+  });
+});
+
 describe("normalizeLoafSourceURL", () => {
   it("strips 8-char lowercase hex Vite hash suffix before .js", () => {
     expect(normalizeLoafSourceURL("app://./assets/vendor-xterm-BcD3kf9a.js")).toBe(

--- a/scripts/perf/__tests__/parseBootDuration.test.ts
+++ b/scripts/perf/__tests__/parseBootDuration.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { parseBootDuration } from "../lib/packagedLaunch";
+import { countCompileCacheFiles, parseBootDuration } from "../lib/packagedLaunch";
 import { PERF_MARKS } from "../../../shared/perf/marks";
 
 interface MarkLine {
@@ -123,5 +123,61 @@ describe("parseBootDuration", () => {
     expect(result.metrics.serviceInitMs).toBe(300);
     expect(result.metrics.hydrateMs).toBe(400);
     expect(result.durationMs).toBe(1200);
+  });
+});
+
+describe("countCompileCacheFiles", () => {
+  const tmpDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tmpDirs) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // best effort
+      }
+    }
+    tmpDirs.length = 0;
+  });
+
+  function makeUserDataDir(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "perf-ccfiles-"));
+    tmpDirs.push(dir);
+    return dir;
+  }
+
+  it("returns 0 when the compile-cache dir does not exist", () => {
+    expect(countCompileCacheFiles(makeUserDataDir())).toBe(0);
+  });
+
+  it("returns 0 for an empty compile-cache dir (cache never written)", () => {
+    const userDataDir = makeUserDataDir();
+    fs.mkdirSync(path.join(userDataDir, "compile-cache"));
+    expect(countCompileCacheFiles(userDataDir)).toBe(0);
+  });
+
+  it("sums cache files inside the versioned subdir rather than counting the base dir", () => {
+    // Node nests cache files one level down: compile-cache/<version>/<hash files>.
+    // Counting the base dir would report 1 (the subdir); we want the file count.
+    const userDataDir = makeUserDataDir();
+    const versioned = path.join(userDataDir, "compile-cache", "v22.0.0-arm64-abcd1234");
+    fs.mkdirSync(versioned, { recursive: true });
+    for (let i = 0; i < 5; i += 1) {
+      fs.writeFileSync(path.join(versioned, `cache-${i}.bin`), "x");
+    }
+    expect(countCompileCacheFiles(userDataDir)).toBe(5);
+  });
+
+  it("sums across multiple versioned subdirs (e.g. after an app upgrade)", () => {
+    const userDataDir = makeUserDataDir();
+    const base = path.join(userDataDir, "compile-cache");
+    const v1 = path.join(base, "v22.0.0-arm64-aaaa");
+    const v2 = path.join(base, "v22.1.0-arm64-bbbb");
+    fs.mkdirSync(v1, { recursive: true });
+    fs.mkdirSync(v2, { recursive: true });
+    fs.writeFileSync(path.join(v1, "a.bin"), "x");
+    fs.writeFileSync(path.join(v1, "b.bin"), "x");
+    fs.writeFileSync(path.join(v2, "c.bin"), "x");
+    expect(countCompileCacheFiles(userDataDir)).toBe(3);
   });
 });

--- a/scripts/perf/cold-start.ts
+++ b/scripts/perf/cold-start.ts
@@ -424,7 +424,17 @@ Requires a packaged binary under release/. Build one first with:
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      console.error(`[warm] warmup launch failed: ${message} — measured runs may be cache-cold`);
+      // The cache was never populated, so reusing this dir would mislabel
+      // cache-cold runs as warm. Drop back to fresh cold profiles instead.
+      console.error(
+        `[warm] warmup launch failed: ${message} — falling back to cold runs (no warm bucket)`
+      );
+      try {
+        fs.rmSync(warmDir, { recursive: true, force: true });
+      } catch {
+        // Best effort.
+      }
+      warmDir = null;
     }
   }
 
@@ -467,7 +477,7 @@ Requires a packaged binary under release/. Build one first with:
           marks: [],
           failed: true,
           error: message,
-          cacheKind: warm ? "warm" : "cold",
+          cacheKind: warmDir ? "warm" : "cold",
         });
         if (!asJson) {
           console.error(`[run ${i + 1}/${runs}] FAILED: ${message}`);

--- a/scripts/perf/cold-start.ts
+++ b/scripts/perf/cold-start.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { parseArgs } from "node:util";
 import { findPackagedExecutable, launchPackagedAndMeasure } from "./lib/packagedLaunch";
@@ -33,6 +34,8 @@ interface JsonOutput {
     failed?: boolean;
     error?: string;
     degraded?: boolean;
+    cacheKind?: "cold" | "warm";
+    cacheFileCount?: number;
   }>;
   failedRuns: number;
   degradedRuns: number;
@@ -259,6 +262,31 @@ function renderTextReport(
     }
   }
 
+  const { cold, warm } = agg.byCacheKind;
+  if (cold || warm) {
+    const cacheRows = (["cold", "warm"] as const)
+      .map((kind) => ({ kind, stats: agg.byCacheKind[kind] }))
+      .filter((r): r is { kind: "cold" | "warm"; stats: NonNullable<typeof r.stats> } =>
+        Boolean(r.stats)
+      )
+      .map(({ kind, stats }) => ({
+        cacheKind: kind,
+        runs: String(stats.runs),
+        p50: formatMs(stats.p50Ms),
+        p95: stats.runs < MIN_SAMPLES_FOR_P95 ? "n/a (<20 runs)" : formatMs(stats.p95Ms),
+        mean: formatMs(stats.meanMs),
+        cacheFiles: String(stats.medianCacheFileCount),
+      }));
+    lines.push("Boot duration by compile-cache state (headline boot → first_interactive)");
+    lines.push(formatTable(cacheRows, ["cacheKind", "runs", "p50", "p95", "mean", "cacheFiles"]));
+    if (cold && warm) {
+      const delta = round(cold.meanMs - warm.meanMs);
+      const pct = cold.meanMs > 0 ? round((delta / cold.meanMs) * 100, 1) : 0;
+      lines.push(`  warm vs cold mean delta: ${formatMs(delta)} (${pct}% faster warm)`);
+    }
+    lines.push("");
+  }
+
   if (agg.eventLoopLag) {
     const lagSamples = agg.eventLoopLag.samples;
     lines.push(
@@ -303,6 +331,8 @@ function buildJsonOutput(runs: RunData[], agg: Aggregate): JsonOutput {
       failed: r.failed,
       error: r.error,
       degraded: r.degraded,
+      cacheKind: r.cacheKind,
+      cacheFileCount: r.cacheFileCount,
     })),
     failedRuns: runs.length - successful,
     degradedRuns: degraded,
@@ -316,6 +346,7 @@ async function main(): Promise<void> {
     options: {
       runs: { type: "string", short: "n", default: "5" },
       json: { type: "boolean", default: false },
+      warm: { type: "boolean", default: false },
       help: { type: "boolean", short: "h", default: false },
     },
     strict: true,
@@ -323,13 +354,18 @@ async function main(): Promise<void> {
   });
 
   if (values.help) {
-    console.log(`Usage: npm run perf:cold-start -- [--runs N] [--json]
+    console.log(`Usage: npm run perf:cold-start -- [--runs N] [--warm] [--json]
 
-Launch the packaged Daintree binary N times from a fresh profile dir,
-collect perf marks + IPC samples, and print aggregated p50/p95.
+Launch the packaged Daintree binary N times and print aggregated p50/p95.
+
+By default every run uses a fresh profile dir, so the Node compile cache is
+cold on every launch. With --warm, all runs share one persisted profile dir and
+a single unmeasured warmup boot populates the compile cache first, so the
+measured runs are cache-warm. Results are bucketed cold-vs-warm in the report.
 
 Options:
-  -n, --runs N    Number of launches (default 5)
+  -n, --runs N    Number of measured launches (default 5)
+      --warm      Reuse one profile dir + warmup boot so runs are cache-warm
       --json      Emit structured JSON instead of the text table
   -h, --help      Show this message
 
@@ -346,6 +382,7 @@ Requires a packaged binary under release/. Build one first with:
   }
   const runs = rawRuns;
   const asJson = Boolean(values.json);
+  const warm = Boolean(values.warm);
 
   const projectRoot = process.cwd();
   const executablePath = findPackagedExecutable(projectRoot);
@@ -365,45 +402,84 @@ Requires a packaged binary under release/. Build one first with:
 
   if (!asJson) {
     console.error(`Launching packaged binary at ${path.relative(projectRoot, executablePath)}`);
-    console.error(`Runs: ${runs}`);
+    console.error(`Runs: ${runs}${warm ? " (warm-cache mode)" : ""}`);
+  }
+
+  // In warm mode every run shares one persisted profile dir so the Node
+  // compile cache survives across launches. A single unmeasured warmup boot
+  // populates the cache (and flushes it on quit) before the measured runs.
+  let warmDir: string | null = null;
+  if (warm) {
+    warmDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-perf-warm-"));
+    if (!asJson) console.error(`[warm] persisted profile dir: ${warmDir}`);
+    try {
+      const warmup = await launchPackagedAndMeasure(executablePath, -1, {
+        projectRoot,
+        userDataDir: warmDir,
+      });
+      if (!asJson) {
+        console.error(
+          `[warm] warmup launch complete, cacheFileCount=${warmup.cacheFileCount ?? 0}`
+        );
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`[warm] warmup launch failed: ${message} — measured runs may be cache-cold`);
+    }
   }
 
   const results: RunData[] = [];
 
-  for (let i = 0; i < runs; i += 1) {
-    if (!asJson) {
-      console.error(`[run ${i + 1}/${runs}] starting...`);
-    }
-
-    try {
-      const result = await launchPackagedAndMeasure(executablePath, i, { projectRoot });
-      const marks = parseNdjson(result.ndjsonPath);
-      // Only true-degraded runs (wall-clock fallback) are excluded from
-      // mark/phase aggregates. A run that fell back from FI → RR still has
-      // valid marks; its `notes` is set but `degraded` is false.
-      results.push({
-        index: i,
-        durationMs: result.durationMs,
-        notes: result.notes,
-        marks,
-        degraded: Boolean(result.degraded),
-      });
-
+  try {
+    for (let i = 0; i < runs; i += 1) {
       if (!asJson) {
-        const suffix = result.notes ? ` (${result.notes})` : "";
-        console.error(`[run ${i + 1}/${runs}] ${formatMs(result.durationMs)}${suffix}`);
+        console.error(`[run ${i + 1}/${runs}] starting...`);
       }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      results.push({
-        index: i,
-        durationMs: -1,
-        marks: [],
-        failed: true,
-        error: message,
-      });
-      if (!asJson) {
-        console.error(`[run ${i + 1}/${runs}] FAILED: ${message}`);
+
+      try {
+        const result = await launchPackagedAndMeasure(executablePath, i, {
+          projectRoot,
+          ...(warmDir ? { userDataDir: warmDir } : {}),
+        });
+        const marks = parseNdjson(result.ndjsonPath);
+        // Only true-degraded runs (wall-clock fallback) are excluded from
+        // mark/phase aggregates. A run that fell back from FI → RR still has
+        // valid marks; its `notes` is set but `degraded` is false.
+        results.push({
+          index: i,
+          durationMs: result.durationMs,
+          notes: result.notes,
+          marks,
+          degraded: Boolean(result.degraded),
+          cacheKind: result.cacheKind,
+          cacheFileCount: result.cacheFileCount,
+        });
+
+        if (!asJson) {
+          const suffix = result.notes ? ` (${result.notes})` : "";
+          console.error(`[run ${i + 1}/${runs}] ${formatMs(result.durationMs)}${suffix}`);
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        results.push({
+          index: i,
+          durationMs: -1,
+          marks: [],
+          failed: true,
+          error: message,
+          cacheKind: warm ? "warm" : "cold",
+        });
+        if (!asJson) {
+          console.error(`[run ${i + 1}/${runs}] FAILED: ${message}`);
+        }
+      }
+    }
+  } finally {
+    if (warmDir) {
+      try {
+        fs.rmSync(warmDir, { recursive: true, force: true });
+      } catch {
+        // Best effort — a leftover temp dir is harmless.
       }
     }
   }

--- a/scripts/perf/lib/coldStartAggregate.ts
+++ b/scripts/perf/lib/coldStartAggregate.ts
@@ -16,6 +16,11 @@ export interface RunData {
   failed?: boolean;
   error?: string;
   degraded?: boolean;
+  // "cold" (fresh profile) or "warm" (persisted, pre-populated compile cache).
+  // Absent runs default to "cold" for backward compatibility.
+  cacheKind?: "cold" | "warm";
+  // Files in the compile-cache dir at the end of the run — corroborates warmth.
+  cacheFileCount?: number;
 }
 
 export interface MarkStats {
@@ -64,6 +69,16 @@ export interface EventLoopLagStats {
   totalAccumulatedMs: number;
 }
 
+export interface CacheKindBucketStats {
+  runs: number;
+  p50Ms: number;
+  p95Ms: number;
+  meanMs: number;
+  // Median compile-cache file count across the bucket's runs. 0 for a true
+  // cold bucket; >0 for a warm bucket confirms the cache populated.
+  medianCacheFileCount: number;
+}
+
 export interface Aggregate {
   marks: Record<string, MarkStats>;
   phaseDurations: Record<string, MarkStats>;
@@ -72,6 +87,10 @@ export interface Aggregate {
   cls: ClsStats | null;
   osToAppBoot: OsToAppBootStats | null;
   eventLoopLag: EventLoopLagStats | null;
+  // Headline boot-duration split by compile-cache state. Each bucket is null
+  // when no successful runs of that kind are present. The other aggregates pool
+  // all runs; this is the cache-cold vs cache-warm comparison (#9772).
+  byCacheKind: { cold: CacheKindBucketStats | null; warm: CacheKindBucketStats | null };
 }
 
 // Vite/Rolldown default chunkFileNames is `[name]-[hash].js`. The hash is 8
@@ -329,5 +348,31 @@ export function aggregate(runs: RunData[]): Aggregate {
         }
       : null;
 
-  return { marks, phaseDurations, ipc, loaf, cls, osToAppBoot, eventLoopLag };
+  const byCacheKind = {
+    cold: bucketByCacheKind(successful, "cold"),
+    warm: bucketByCacheKind(successful, "warm"),
+  };
+
+  return { marks, phaseDurations, ipc, loaf, cls, osToAppBoot, eventLoopLag, byCacheKind };
+}
+
+// Build headline boot-duration stats for one cache kind. Runs without an
+// explicit cacheKind default to "cold" so pre-#9772 data still buckets. Returns
+// null when the bucket has no runs.
+function bucketByCacheKind(runs: RunData[], kind: "cold" | "warm"): CacheKindBucketStats | null {
+  const bucket = runs.filter((r) => (r.cacheKind ?? "cold") === kind);
+  if (bucket.length === 0) return null;
+
+  const durations = bucket.map((r) => r.durationMs);
+  const cacheCounts = bucket
+    .map((r) => r.cacheFileCount)
+    .filter((c): c is number => typeof c === "number" && Number.isFinite(c));
+
+  return {
+    runs: bucket.length,
+    p50Ms: round(percentile(durations, 50)),
+    p95Ms: round(percentile(durations, 95)),
+    meanMs: round(mean(durations)),
+    medianCacheFileCount: cacheCounts.length > 0 ? round(percentile(cacheCounts, 50)) : 0,
+  };
 }

--- a/scripts/perf/lib/coldStartAggregate.ts
+++ b/scripts/perf/lib/coldStartAggregate.ts
@@ -357,19 +357,23 @@ export function aggregate(runs: RunData[]): Aggregate {
 }
 
 // Build headline boot-duration stats for one cache kind. Runs without an
-// explicit cacheKind default to "cold" so pre-#9772 data still buckets. Returns
-// null when the bucket has no runs.
+// explicit cacheKind default to "cold" so pre-#9772 data still buckets. Degraded
+// runs are excluded — their wall-clock fallback durationMs is systematically
+// higher than the mark-based duration, matching the phase-duration table's
+// policy. Returns null when the bucket has no qualifying runs.
 function bucketByCacheKind(runs: RunData[], kind: "cold" | "warm"): CacheKindBucketStats | null {
-  const bucket = runs.filter((r) => (r.cacheKind ?? "cold") === kind);
+  const bucket = runs.filter((r) => !r.degraded && (r.cacheKind ?? "cold") === kind);
   if (bucket.length === 0) return null;
 
-  const durations = bucket.map((r) => r.durationMs);
+  // Guard percentile/mean against malformed durations (NaN/Infinity/negative).
+  const durations = bucket.map((r) => r.durationMs).filter((d) => Number.isFinite(d) && d >= 0);
+  if (durations.length === 0) return null;
   const cacheCounts = bucket
     .map((r) => r.cacheFileCount)
     .filter((c): c is number => typeof c === "number" && Number.isFinite(c));
 
   return {
-    runs: bucket.length,
+    runs: durations.length,
     p50Ms: round(percentile(durations, 50)),
     p95Ms: round(percentile(durations, 95)),
     meanMs: round(mean(durations)),

--- a/scripts/perf/lib/packagedLaunch.ts
+++ b/scripts/perf/lib/packagedLaunch.ts
@@ -15,6 +15,13 @@ export interface PackagedLaunchResult {
   // RR present) is annotated via `notes` but the marks are still aggregatable
   // and `degraded` stays false.
   degraded?: boolean;
+  // "cold" (fresh profile, the default) or "warm" (caller supplied a persisted
+  // userDataDir that was pre-populated, so the compile cache should hit).
+  cacheKind: "cold" | "warm";
+  // Number of files in the compile-cache dir at the end of this launch. >0 on a
+  // warm run confirms enableCompileCache() populated the dir; the cold/warm
+  // bucketing in the aggregator uses cacheKind, this is a corroborating signal.
+  cacheFileCount?: number;
 }
 
 interface MarkRecord {
@@ -226,6 +233,18 @@ export function parseBootDuration(ndjsonPath: string): {
   return { durationMs: -1, metrics };
 }
 
+// Count files in the compile-cache subdir of a userData dir. The dir is created
+// lazily by enableCompileCache(), so a missing dir is a legitimate 0 count. The
+// directory uses opaque content-hash filenames, so a count is all we can get —
+// there's no programmatic cache hit/miss API in Node 22+.
+function countCompileCacheFiles(userDataDir: string): number {
+  try {
+    return fs.readdirSync(path.join(userDataDir, "compile-cache")).length;
+  } catch {
+    return 0;
+  }
+}
+
 export async function launchPackagedAndMeasure(
   executablePath: string,
   iteration: number,
@@ -233,11 +252,30 @@ export async function launchPackagedAndMeasure(
     projectRoot?: string;
     timeoutMs?: number;
     captureCdpMetrics?: boolean;
+    // When provided, reuse this directory instead of a fresh mkdtemp profile and
+    // skip the post-run cleanup (the caller owns the dir's lifecycle). This is
+    // how warm-cache runs reuse a populated compile cache across launches.
+    userDataDir?: string;
   } = {}
 ): Promise<PackagedLaunchResult> {
   const timeoutMs = options.timeoutMs ?? 30_000;
-  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), `daintree-perf-${iteration}-`));
+  const isWarm = Boolean(options.userDataDir);
+  const cacheKind: "cold" | "warm" = isWarm ? "warm" : "cold";
+  const userDataDir =
+    options.userDataDir ?? fs.mkdtempSync(path.join(os.tmpdir(), `daintree-perf-${iteration}-`));
   const ndjsonPath = path.join(userDataDir, "perf-metrics.ndjson");
+
+  // Marks are append-only. When reusing a warm userDataDir across launches the
+  // NDJSON would accumulate, and parseBootDuration's first-wins policy would
+  // read the warmup boot's marks instead of this run's. Clear it so each launch
+  // produces a clean timeline. Harmless on cold runs (file doesn't exist yet).
+  if (isWarm) {
+    try {
+      fs.rmSync(ndjsonPath, { force: true });
+    } catch {
+      // Best effort — a stale file just means parseBootDuration sees old marks.
+    }
+  }
 
   // Wall-clock anchor captured immediately before electron.launch() so the
   // Electron main process can compute `os_to_app_boot_ms` against a Unix-epoch
@@ -292,6 +330,7 @@ export async function launchPackagedAndMeasure(
 
     const { durationMs, metrics, degraded } = parseBootDuration(ndjsonPath);
     const wallClockMs = performance.now() - startMs;
+    const cacheFileCount = countCompileCacheFiles(userDataDir);
 
     if (durationMs < 0) {
       metrics.wallClockMs = wallClockMs;
@@ -301,10 +340,12 @@ export async function launchPackagedAndMeasure(
         ndjsonPath,
         notes: "RENDERER_READY mark not captured — using wall-clock fallback",
         degraded: true,
+        cacheKind,
+        cacheFileCount,
       };
     }
 
-    return { durationMs, metrics, ndjsonPath, notes: degraded };
+    return { durationMs, metrics, ndjsonPath, notes: degraded, cacheKind, cacheFileCount };
   } finally {
     if (app) {
       try {
@@ -330,13 +371,17 @@ export async function launchPackagedAndMeasure(
       // Directory may not exist
     }
 
-    // Clean up userDataDir after a brief delay (allow process shutdown)
-    setTimeout(() => {
-      try {
-        fs.rmSync(userDataDir, { recursive: true, force: true });
-      } catch {
-        // Best effort
-      }
-    }, 1000);
+    // Clean up userDataDir after a brief delay (allow process shutdown). Skip
+    // for caller-supplied warm dirs — the caller owns that dir's lifecycle and
+    // needs it to persist across the run loop to keep the compile cache warm.
+    if (!isWarm) {
+      setTimeout(() => {
+        try {
+          fs.rmSync(userDataDir, { recursive: true, force: true });
+        } catch {
+          // Best effort
+        }
+      }, 1000);
+    }
   }
 }

--- a/scripts/perf/lib/packagedLaunch.ts
+++ b/scripts/perf/lib/packagedLaunch.ts
@@ -233,16 +233,32 @@ export function parseBootDuration(ndjsonPath: string): {
   return { durationMs: -1, metrics };
 }
 
-// Count files in the compile-cache subdir of a userData dir. The dir is created
-// lazily by enableCompileCache(), so a missing dir is a legitimate 0 count. The
-// directory uses opaque content-hash filenames, so a count is all we can get —
-// there's no programmatic cache hit/miss API in Node 22+.
-function countCompileCacheFiles(userDataDir: string): number {
+// Count V8 cache files under a userData dir's compile-cache. The dir is created
+// lazily by enableCompileCache(), so a missing dir is a legitimate 0 count.
+// Node nests the actual cache files one level down in a versioned subdirectory
+// (e.g. `compile-cache/v22.x.x-arch-<hash>/`), so we sum the entries inside each
+// subdir rather than counting the base dir — which would only ever be 0 or 1.
+// The files use opaque content-hash names, so a count is all we can get; there's
+// no programmatic cache hit/miss API in Node 22+.
+export function countCompileCacheFiles(userDataDir: string): number {
+  const base = path.join(userDataDir, "compile-cache");
+  let total = 0;
   try {
-    return fs.readdirSync(path.join(userDataDir, "compile-cache")).length;
+    for (const entry of fs.readdirSync(base, { withFileTypes: true })) {
+      if (!entry.isDirectory()) {
+        total += 1;
+        continue;
+      }
+      try {
+        total += fs.readdirSync(path.join(base, entry.name)).length;
+      } catch {
+        // Subdir vanished mid-read — skip it.
+      }
+    }
   } catch {
     return 0;
   }
+  return total;
 }
 
 export async function launchPackagedAndMeasure(
@@ -305,6 +321,16 @@ export async function launchPackagedAndMeasure(
     }
   }
 
+  // Build the child env from the parent, then strip Node's compile-cache env
+  // vars. If NODE_COMPILE_CACHE is inherited (the agent shell / a dev machine
+  // may set it), Node enables the cache against that shared directory before the
+  // app's own enableCompileCache(userDataDir/compile-cache) runs — so a "cold"
+  // run would silently hit the inherited warm cache and report bogus baselines.
+  // Deleting both keys forces the app to own its compile cache inside userDataDir.
+  const launchEnv: Record<string, string | undefined> = { ...process.env, ...env };
+  delete launchEnv.NODE_COMPILE_CACHE;
+  delete launchEnv.NODE_DISABLE_COMPILE_CACHE;
+
   let app: ElectronApplication | null = null;
   const startMs = performance.now();
 
@@ -312,7 +338,7 @@ export async function launchPackagedAndMeasure(
     app = await electron.launch({
       executablePath,
       args,
-      env: { ...process.env, ...env },
+      env: launchEnv,
       timeout: timeoutMs,
     });
 


### PR DESCRIPTION
## Summary

- Captures `enableCompileCache()` status and warns if it fails, so a silently-disabled cache is detectable rather than invisible.
- Calls `flushCompileCache()` after the boot-critical `main.js` import and synchronously on clean quit (in `shutdown.ts`), so first-run cache writes survive crashes and aren't lost before the first clean exit.
- Adds a `--warm` mode to the cold-start perf script: one unmeasured warmup boot, then N cache-warm measured runs, with results bucketed by `cacheKind` and a warm-vs-cold delta in the report.

Resolves #9772.

## Changes

- `electron/bootstrap.ts`: capture and expose `enableCompileCache()` status; warn on `FAILED`; call `flushCompileCache()` after boot-critical import.
- `electron/lifecycle/shutdown.ts`: synchronous `flushCompileCache()` on clean quit, before the async graceful-shutdown chain.
- `electron/utils/hostPerformance.ts`: `setCompileCacheEnableStatus()` + `compileCacheStatus`/`compileCacheStatusName` fields in `getCompileCacheMeta()`.
- `electron/main.ts`: attach compile-cache meta to the `APP_BOOT_START` NDJSON mark.
- `scripts/perf/cold-start.ts` + `scripts/perf/lib/`: `--warm` opt-in mode; `cacheKind` tagging (`cold`/`warm`); bucketed aggregate reporting with delta; `countCompileCacheFiles` sums files in versioned subdirs; strips inherited `NODE_COMPILE_CACHE` so cold baselines stay genuinely cold.

## Testing

57 unit tests pass: status mapping, cache-kind bucketing including degraded/NaN guards, `countCompileCacheFiles` versioned-subdir counting, and the `getCompileCacheDir` throw path. `npm run check` clean (typecheck, lint, format, build, IPC guards).

Whether ASAR-packaged module paths produce V8 cache hits is an empirical question — run the packaged app twice against the same `--user-data-dir` with `NODE_DEBUG_NATIVE=COMPILE_CACHE` and look for hit lines on the second launch. This PR makes that measurable and ensures the cache survives unclean exits regardless.