### PR TITLE
perf(build): preload the eager first-render chunk closure in index.html

### DIFF
--- a/scripts/check-first-render-chunk-budget.mjs
+++ b/scripts/check-first-render-chunk-budget.mjs
@@ -23,6 +23,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import path from "node:path";
 import { gzipSync } from "node:zlib";
 import { formatBudgetSummary, writeSummary } from "./budget-summary-lib.mjs";
+import { collectClosure as collectClosureGeneric } from "./first-render-closure-lib.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const ROOT = path.resolve(path.dirname(__filename), "..");
@@ -146,33 +147,19 @@ function readFirstRenderSeeds() {
 // always enqueued explicitly regardless of `followDynamic` — they're first-paint
 // paths by definition (a persisted browser/dev-preview/review panel restores
 // synchronously), not edges discovered by walking `dynamicImports[]`.
+//
+// Thin manifest adapter over the shared first-render-closure-lib traversal: the
+// firstRenderModulePreloadPlugin in vite.config.ts walks the same graph through
+// the OutputBundle (keyed by file name), so the gated closure measured here and
+// the preload set injected there share one BFS and can't drift (#9771). Default
+// `followDynamic: true` (the total walk) is preserved for the existing callers.
 export function collectClosure(manifest, seedKeys, { followDynamic = true } = {}) {
-  const visited = new Set();
-  const queue = [];
-
-  for (const seed of seedKeys) {
-    if (manifest[seed]) {
-      queue.push(seed);
-    }
-  }
-
-  while (queue.length > 0) {
-    const key = queue.shift();
-    if (visited.has(key)) continue;
-
-    const chunk = manifest[key];
-    // Skip keys not present in the manifest — the closure measures real
-    // chunks only, so a dangling import reference must not enter the set.
-    if (!chunk) continue;
-    visited.add(key);
-
-    for (const dep of chunk.imports ?? []) queue.push(dep);
-    if (followDynamic) {
-      for (const dep of chunk.dynamicImports ?? []) queue.push(dep);
-    }
-  }
-
-  return visited;
+  return collectClosureGeneric(seedKeys, {
+    getNode: (key) => manifest[key],
+    getStaticImports: (chunk) => chunk.imports,
+    getDynamicImports: (chunk) => chunk.dynamicImports,
+    followDynamic,
+  });
 }
 
 function findEntryKey(manifest) {

--- a/scripts/first-render-closure-lib.d.mts
+++ b/scripts/first-render-closure-lib.d.mts
@@ -1,0 +1,13 @@
+// Type surface for the plain-JS closure walk in first-render-closure-lib.mjs so
+// vite.config.ts (type-checked under tsconfig.node.json, no allowJs) can import
+// it. The .mjs stays dependency-free plain JS so the budget script can import it
+// from plain Node ESM.
+export function collectClosure<Node>(
+  seedKeys: Iterable<string>,
+  options: {
+    getNode: (key: string) => Node | undefined | null;
+    getStaticImports: (node: Node) => readonly string[] | undefined | null;
+    getDynamicImports: (node: Node) => readonly string[] | undefined | null;
+    followDynamic?: boolean;
+  }
+): Set<string>;

--- a/scripts/first-render-closure-lib.d.mts
+++ b/scripts/first-render-closure-lib.d.mts
@@ -11,3 +11,18 @@ export function collectClosure<Node>(
     followDynamic?: boolean;
   }
 ): Set<string>;
+
+interface PreloadChunkLike {
+  type: string;
+  fileName: string;
+  isEntry?: boolean;
+  facadeModuleId?: string | null;
+  imports?: string[];
+  dynamicImports?: string[];
+}
+
+export function computeFirstRenderPreloadFiles(
+  chunks: Iterable<PreloadChunkLike>,
+  seedSourcePaths: ReadonlySet<string>,
+  toRelativePosix: (facadeModuleId: string) => string
+): { files: string[]; matchedSeedCount: number };

--- a/scripts/first-render-closure-lib.mjs
+++ b/scripts/first-render-closure-lib.mjs
@@ -56,3 +56,55 @@ export function collectClosure(
 
   return visited;
 }
+
+// Computes the set of output file names to inject as `<link rel="modulepreload">`
+// for the first-render seed chunks, given a Rolldown OutputBundle's chunks. This
+// is the pure core of the firstRenderModulePreloadPlugin (vite.config.ts),
+// factored out so the seed-matching, entry-subtraction, and eager-only traversal
+// are unit-testable without the Vite build machinery.
+//
+//   • `chunks` — iterable of bundle outputs ({ type, fileName, isEntry,
+//     facadeModuleId, imports[], dynamicImports[] }). Non-"chunk" outputs
+//     (CSS/assets) are ignored, so no asset is ever preloaded as a module.
+//   • `seedSourcePaths` — Set of repo-relative POSIX source paths from the panel
+//     registry (getFirstRenderSeeds). A chunk is a seed when its facadeModuleId,
+//     normalized via `toRelativePosix`, is in this set.
+//   • `toRelativePosix` — maps an absolute facadeModuleId to the repo-relative
+//     POSIX form for comparison against the seeds (kept as a callback so this
+//     module stays free of node:path and cwd).
+//
+// Returns `{ files, matchedSeedCount }`. `files` is the eager static closure of
+// the matched seed chunks MINUS the entry chunks' eager static closure (what
+// Vite already auto-preloads), sorted and deduplicated — never following a
+// dynamicImports[] edge, so deferred subtrees stay off the first-paint path.
+// `matchedSeedCount` lets the caller warn on zero / partial seed resolution.
+export function computeFirstRenderPreloadFiles(chunks, seedSourcePaths, toRelativePosix) {
+  const chunksByFileName = new Map();
+  const seedFileNames = [];
+  const entryFileNames = [];
+
+  for (const output of chunks) {
+    if (output.type !== "chunk") continue;
+    chunksByFileName.set(output.fileName, output);
+    if (output.isEntry) entryFileNames.push(output.fileName);
+    if (output.facadeModuleId && seedSourcePaths.has(toRelativePosix(output.facadeModuleId))) {
+      seedFileNames.push(output.fileName);
+    }
+  }
+
+  if (seedFileNames.length === 0) {
+    return { files: [], matchedSeedCount: 0 };
+  }
+
+  const options = {
+    getNode: (fileName) => chunksByFileName.get(fileName),
+    getStaticImports: (chunk) => chunk.imports,
+    getDynamicImports: (chunk) => chunk.dynamicImports,
+    followDynamic: false,
+  };
+
+  const seedClosure = collectClosure(seedFileNames, options);
+  const entryClosure = collectClosure(entryFileNames, options);
+  const files = [...seedClosure].filter((fileName) => !entryClosure.has(fileName)).sort();
+  return { files, matchedSeedCount: seedFileNames.length };
+}

--- a/scripts/first-render-closure-lib.mjs
+++ b/scripts/first-render-closure-lib.mjs
@@ -1,0 +1,58 @@
+// Generic chunk-graph closure walk shared by two consumers that traverse the
+// SAME first-render dependency graph through different key schemes:
+//
+//   • scripts/check-first-render-chunk-budget.mjs walks the Vite MANIFEST,
+//     where nodes are keyed by source path and `imports[]` / `dynamicImports[]`
+//     reference other source-path keys.
+//   • the firstRenderModulePreloadPlugin in vite.config.ts walks the Rolldown
+//     OutputBundle, where chunks are keyed by hashed file name and `imports[]`
+//     / `dynamicImports[]` reference other file names.
+//
+// Both schemes are the same BFS over a directed graph; only the node lookup and
+// the edge accessors differ. Parameterizing those accessors lets ONE traversal
+// serve both, so the gated budget closure and the injected preload set cannot
+// drift — the whole point of #9771.
+//
+// `followDynamic` selects the closure semantics:
+//   • false (eager) — follow only `imports[]`: the entry plus everything
+//     statically reachable from it and from the explicit first-render seeds.
+//     This is the "download before interactive" set and the gated metric.
+//   • true  (total) — follow `imports[]` and `dynamicImports[]`: the entire
+//     reachable bundle. Report-only.
+//
+// Seeds are always enqueued explicitly (if present) regardless of
+// `followDynamic` — they're first-paint paths by definition (a persisted
+// browser/dev-preview/review panel restores synchronously), not edges
+// discovered by walking `dynamicImports[]`.
+//
+// Identity is the node KEY, so a chunk shared via multiple edges (vendor-react
+// imported by both the entry and vendor-motion) is visited exactly once. A seed
+// or edge that doesn't resolve to a node is skipped, so a dangling reference
+// never enters the closure.
+export function collectClosure(
+  seedKeys,
+  { getNode, getStaticImports, getDynamicImports, followDynamic = false } = {}
+) {
+  const visited = new Set();
+  const queue = [];
+
+  for (const seed of seedKeys) {
+    if (getNode(seed)) queue.push(seed);
+  }
+
+  while (queue.length > 0) {
+    const key = queue.shift();
+    if (visited.has(key)) continue;
+
+    const node = getNode(key);
+    if (!node) continue;
+    visited.add(key);
+
+    for (const dep of getStaticImports(node) ?? []) queue.push(dep);
+    if (followDynamic) {
+      for (const dep of getDynamicImports(node) ?? []) queue.push(dep);
+    }
+  }
+
+  return visited;
+}

--- a/scripts/first-render-closure-lib.test.mjs
+++ b/scripts/first-render-closure-lib.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { collectClosure } from "./first-render-closure-lib.mjs";
+import { collectClosure, computeFirstRenderPreloadFiles } from "./first-render-closure-lib.mjs";
 
 // Builds accessor options over a plain adjacency map: { key: { imports, dyn } }.
 // This is intentionally NOT the manifest or bundle shape — the lib is generic
@@ -123,5 +123,190 @@ describe("collectClosure — robustness", () => {
     };
     const closure = collectClosure(["s1", "s2"], graphOptions(graph));
     expect([...closure].sort()).toEqual(["a", "b", "s1", "s2"]);
+  });
+});
+
+// Identity normalizer for the common case where facadeModuleId is already the
+// repo-relative POSIX path. Cross-platform normalization is exercised separately.
+const identity = (id) => id;
+
+describe("computeFirstRenderPreloadFiles", () => {
+  it("subtracts the entry's static closure so Vite-preloaded chunks aren't duplicated", () => {
+    // entry statically imports vendor-react; the seed panel statically imports
+    // both its private vendor and the shared vendor-react. Only the chunks NOT
+    // already in the entry closure should be injected.
+    const chunks = [
+      {
+        type: "chunk",
+        fileName: "entry.js",
+        isEntry: true,
+        facadeModuleId: "src/main.tsx",
+        imports: ["vendor-react.js"],
+        dynamicImports: ["panel.js"],
+      },
+      { type: "chunk", fileName: "vendor-react.js", imports: [], dynamicImports: [] },
+      {
+        type: "chunk",
+        fileName: "panel.js",
+        facadeModuleId: "src/panels/browser/index.tsx",
+        imports: ["vendor-react.js", "vendor-browser.js"],
+        dynamicImports: [],
+      },
+      { type: "chunk", fileName: "vendor-browser.js", imports: [], dynamicImports: [] },
+    ];
+    const { files, matchedSeedCount } = computeFirstRenderPreloadFiles(
+      chunks,
+      new Set(["src/panels/browser/index.tsx"]),
+      identity
+    );
+    expect(matchedSeedCount).toBe(1);
+    // vendor-react is in the entry closure → excluded; panel + its private
+    // vendor are seed-only → injected.
+    expect(files).toEqual(["panel.js", "vendor-browser.js"]);
+    expect(files).not.toContain("vendor-react.js");
+  });
+
+  it("never injects a chunk reachable only through a dynamic import (the domMax guard)", () => {
+    const chunks = [
+      {
+        type: "chunk",
+        fileName: "entry.js",
+        isEntry: true,
+        facadeModuleId: "src/main.tsx",
+        imports: [],
+        dynamicImports: ["panel.js"],
+      },
+      {
+        type: "chunk",
+        fileName: "panel.js",
+        facadeModuleId: "src/panels/browser/index.tsx",
+        imports: ["panel-vendor.js"],
+        dynamicImports: ["dom-max.js"], // deferred subtree
+      },
+      { type: "chunk", fileName: "panel-vendor.js", imports: [], dynamicImports: [] },
+      { type: "chunk", fileName: "dom-max.js", imports: [], dynamicImports: [] },
+    ];
+    const { files } = computeFirstRenderPreloadFiles(
+      chunks,
+      new Set(["src/panels/browser/index.tsx"]),
+      identity
+    );
+    expect(files).toContain("panel.js");
+    expect(files).toContain("panel-vendor.js");
+    expect(files).not.toContain("dom-max.js");
+  });
+
+  it("matches seeds through a platform-specific facadeModuleId normalizer", () => {
+    // Simulate Windows absolute facadeModuleId + a normalizer that maps it to
+    // the repo-relative POSIX seed path.
+    const chunks = [
+      {
+        type: "chunk",
+        fileName: "panel.js",
+        facadeModuleId: "C:\\repo\\src\\panels\\browser\\index.tsx",
+        imports: [],
+        dynamicImports: [],
+      },
+    ];
+    const toPosix = (id) =>
+      id
+        .replace(/^C:\\repo\\/, "")
+        .split("\\")
+        .join("/");
+    const { files, matchedSeedCount } = computeFirstRenderPreloadFiles(
+      chunks,
+      new Set(["src/panels/browser/index.tsx"]),
+      toPosix
+    );
+    expect(matchedSeedCount).toBe(1);
+    expect(files).toEqual(["panel.js"]);
+  });
+
+  it("ignores non-chunk outputs so assets are never preloaded as modules", () => {
+    const chunks = [
+      {
+        type: "chunk",
+        fileName: "panel.js",
+        facadeModuleId: "src/panels/browser/index.tsx",
+        imports: [],
+        dynamicImports: [],
+      },
+      { type: "asset", fileName: "style.css" },
+    ];
+    const { files } = computeFirstRenderPreloadFiles(
+      chunks,
+      new Set(["src/panels/browser/index.tsx"]),
+      identity
+    );
+    expect(files).toEqual(["panel.js"]);
+    expect(files).not.toContain("style.css");
+  });
+
+  it("reports zero matches when no chunk facadeModuleId is a seed", () => {
+    const chunks = [
+      {
+        type: "chunk",
+        fileName: "entry.js",
+        isEntry: true,
+        facadeModuleId: "src/main.tsx",
+        imports: [],
+        dynamicImports: [],
+      },
+    ];
+    const { files, matchedSeedCount } = computeFirstRenderPreloadFiles(
+      chunks,
+      new Set(["src/panels/browser/index.tsx"]),
+      identity
+    );
+    expect(matchedSeedCount).toBe(0);
+    expect(files).toEqual([]);
+  });
+
+  it("reports a partial match count when only some seeds resolve", () => {
+    const chunks = [
+      {
+        type: "chunk",
+        fileName: "browser.js",
+        facadeModuleId: "src/panels/browser/index.tsx",
+        imports: [],
+        dynamicImports: [],
+      },
+      // The review panel seed has no matching chunk facadeModuleId.
+    ];
+    const { matchedSeedCount } = computeFirstRenderPreloadFiles(
+      chunks,
+      new Set(["src/panels/browser/index.tsx", "src/panels/review/ReviewPane.tsx"]),
+      identity
+    );
+    // Caller compares matchedSeedCount (1) against seedSourcePaths.size (2) to
+    // warn on incomplete coverage.
+    expect(matchedSeedCount).toBe(1);
+  });
+
+  it("deduplicates a chunk shared across multiple seeds", () => {
+    const chunks = [
+      {
+        type: "chunk",
+        fileName: "browser.js",
+        facadeModuleId: "src/panels/browser/index.tsx",
+        imports: ["shared.js"],
+        dynamicImports: [],
+      },
+      {
+        type: "chunk",
+        fileName: "review.js",
+        facadeModuleId: "src/panels/review/ReviewPane.tsx",
+        imports: ["shared.js"],
+        dynamicImports: [],
+      },
+      { type: "chunk", fileName: "shared.js", imports: [], dynamicImports: [] },
+    ];
+    const { files } = computeFirstRenderPreloadFiles(
+      chunks,
+      new Set(["src/panels/browser/index.tsx", "src/panels/review/ReviewPane.tsx"]),
+      identity
+    );
+    expect(files).toEqual(["browser.js", "review.js", "shared.js"]);
+    expect(files.filter((f) => f === "shared.js").length).toBe(1);
   });
 });

--- a/scripts/first-render-closure-lib.test.mjs
+++ b/scripts/first-render-closure-lib.test.mjs
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import { collectClosure } from "./first-render-closure-lib.mjs";
+
+// Builds accessor options over a plain adjacency map: { key: { imports, dyn } }.
+// This is intentionally NOT the manifest or bundle shape — the lib is generic
+// over the key scheme, and testing it against a synthetic graph proves the
+// traversal logic independently of either real consumer (manifest source paths
+// vs. bundle file names).
+function graphOptions(graph, followDynamic = false) {
+  return {
+    getNode: (key) => graph[key],
+    getStaticImports: (node) => node.imports,
+    getDynamicImports: (node) => node.dyn,
+    followDynamic,
+  };
+}
+
+describe("collectClosure — eager static walk (followDynamic: false)", () => {
+  it("collects every node reachable through imports[] from the seed", () => {
+    const graph = {
+      a: { imports: ["b", "c"] },
+      b: { imports: ["d"] },
+      c: { imports: [] },
+      d: { imports: [] },
+    };
+    const closure = collectClosure(["a"], graphOptions(graph));
+    expect([...closure].sort()).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("does NOT follow dynamic edges when followDynamic is false", () => {
+    const graph = {
+      a: { imports: ["b"], dyn: ["x"] },
+      b: { imports: [] },
+      x: { imports: ["y"] },
+      y: { imports: [] },
+    };
+    const closure = collectClosure(["a"], graphOptions(graph));
+    expect(closure.has("x")).toBe(false);
+    expect(closure.has("y")).toBe(false);
+    expect([...closure].sort()).toEqual(["a", "b"]);
+  });
+
+  it("returns just the seed when it has no static imports", () => {
+    const graph = { a: { imports: [] } };
+    const closure = collectClosure(["a"], graphOptions(graph));
+    expect([...closure]).toEqual(["a"]);
+  });
+});
+
+describe("collectClosure — total walk (followDynamic: true)", () => {
+  it("follows both static and dynamic edges", () => {
+    const graph = {
+      a: { imports: ["b"], dyn: ["x"] },
+      b: { imports: [] },
+      x: { imports: ["y"] },
+      y: { imports: [] },
+    };
+    const closure = collectClosure(["a"], graphOptions(graph, true));
+    expect([...closure].sort()).toEqual(["a", "b", "x", "y"]);
+  });
+});
+
+describe("collectClosure — robustness", () => {
+  it("terminates on a cycle and visits each node once", () => {
+    const graph = {
+      a: { imports: ["b"] },
+      b: { imports: ["c"] },
+      c: { imports: ["a"] }, // cycle back to a
+    };
+    const closure = collectClosure(["a"], graphOptions(graph));
+    expect([...closure].sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("visits a diamond-shared node exactly once", () => {
+    const graph = {
+      a: { imports: ["b", "c"] },
+      b: { imports: ["shared"] },
+      c: { imports: ["shared"] },
+      shared: { imports: [] },
+    };
+    const closure = collectClosure(["a"], graphOptions(graph));
+    expect([...closure].filter((k) => k === "shared").length).toBe(1);
+  });
+
+  it("skips seed keys that resolve to no node", () => {
+    const graph = { a: { imports: [] } };
+    const closure = collectClosure(["missing"], graphOptions(graph));
+    expect(closure.size).toBe(0);
+  });
+
+  it("skips edges that reference absent nodes", () => {
+    const graph = {
+      a: { imports: ["present", "absent"] },
+      present: { imports: [] },
+    };
+    const closure = collectClosure(["a"], graphOptions(graph));
+    expect(closure.has("present")).toBe(true);
+    expect(closure.has("absent")).toBe(false);
+  });
+
+  it("returns an empty set for an empty seed list", () => {
+    const graph = { a: { imports: ["b"] }, b: { imports: [] } };
+    const closure = collectClosure([], graphOptions(graph));
+    expect(closure.size).toBe(0);
+  });
+
+  it("tolerates nodes whose import accessors return undefined", () => {
+    const graph = {
+      a: { imports: ["b"] },
+      b: {}, // no imports/dyn fields at all
+    };
+    // followDynamic true exercises both accessors returning undefined.
+    const closure = collectClosure(["a"], graphOptions(graph, true));
+    expect([...closure].sort()).toEqual(["a", "b"]);
+  });
+
+  it("unions the closures of multiple seeds", () => {
+    const graph = {
+      s1: { imports: ["a"] },
+      s2: { imports: ["b"] },
+      a: { imports: [] },
+      b: { imports: [] },
+    };
+    const closure = collectClosure(["s1", "s2"], graphOptions(graph));
+    expect([...closure].sort()).toEqual(["a", "b", "s1", "s2"]);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, type Plugin } from "vite";
+import { defineConfig, type Plugin, type HtmlTagDescriptor } from "vite";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import { LintRules } from "babel-plugin-react-compiler";
 import babel from "@rolldown/plugin-babel";
@@ -11,6 +11,7 @@ import { gzipSync } from "node:zlib";
 import { getDevServerConfig } from "./shared/config/devServer";
 import { getDaintreeAppDevCSP, getDaintreeAppProdCSP } from "./shared/config/csp";
 import { getFirstRenderSeeds } from "./shared/config/panelKindRegistry";
+import { collectClosure } from "./scripts/first-render-closure-lib.mjs";
 
 const devServerConfig = getDevServerConfig();
 
@@ -531,6 +532,112 @@ function chunkModulesPlugin(): Plugin {
   };
 }
 
+// Minimal view of a Rolldown OutputChunk used by the preload walk. The bundle's
+// `imports[]` / `dynamicImports[]` hold output FILE NAMES (other bundle keys),
+// not the source-path keys the manifest uses — these are JS getters on the
+// native handle, so they're read lazily, never structured-cloned.
+interface BundleChunkLike {
+  type: string;
+  fileName: string;
+  isEntry?: boolean;
+  facadeModuleId?: string | null;
+  imports?: string[];
+  dynamicImports?: string[];
+}
+
+// Injects `<link rel="modulepreload">` for the eager static closure of the
+// first-render seed chunks (the lazy browser/dev-preview/review panels a
+// restored session renders immediately). Vite auto-preloads the entry chunk and
+// everything in its static `imports[]` closure, but NOT chunks reached only
+// through a dynamic import() boundary — so a restored panel's chunk and its
+// private vendor deps download serially (parse entry → discover the lazy import
+// → fetch the chunk → discover its deps → fetch those). Preloading the eager
+// closure of the seeds collapses that first-paint waterfall.
+//
+// Eager-only by construction: the BFS follows `imports[]` and NEVER
+// `dynamicImports[]`, so deliberately-deferred subtrees (vendor-motion's domMax,
+// #8821) are not pulled onto the first-paint path. It reuses the exact
+// `followDynamic: false` traversal the first-render-chunk budget gates on (via
+// scripts/first-render-closure-lib.mjs), so the injected preload set and the
+// measured budget cannot drift. Chunk membership is untouched — this only adds
+// <link> tags to the HTML.
+function firstRenderModulePreloadPlugin(): Plugin {
+  // getFirstRenderSeeds() returns repo-relative POSIX source paths; the bundle
+  // keys chunks by hashed file name and tags each lazy seed chunk with an
+  // absolute `facadeModuleId`, so seeds are matched by normalizing each
+  // facadeModuleId back to that same repo-relative POSIX form.
+  const seedSourcePaths = new Set(getFirstRenderSeeds());
+  const root = process.cwd();
+
+  return {
+    name: "first-render-modulepreload",
+    apply: "build",
+    // Default-order transformIndexHtml: runs AFTER bundling so `ctx.bundle` is
+    // populated (`order: "pre"` would see `ctx.bundle === undefined`). Emits
+    // only <link> tags, which don't participate in the CSP `script-src` hash, so
+    // ordering relative to host-import-map / csp-transform is irrelevant.
+    transformIndexHtml(_html, ctx) {
+      // Populated only for production builds — the dev server has no bundle.
+      if (!ctx.bundle) return;
+
+      const bundle = ctx.bundle as unknown as Record<string, BundleChunkLike>;
+
+      const chunksByFileName = new Map<string, BundleChunkLike>();
+      const seedFileNames: string[] = [];
+      const entryFileNames: string[] = [];
+
+      for (const output of Object.values(bundle)) {
+        if (output.type !== "chunk") continue;
+        chunksByFileName.set(output.fileName, output);
+        if (output.isEntry) entryFileNames.push(output.fileName);
+        if (output.facadeModuleId) {
+          const rel = path.relative(root, output.facadeModuleId).split(path.sep).join("/");
+          if (seedSourcePaths.has(rel)) seedFileNames.push(output.fileName);
+        }
+      }
+
+      if (seedFileNames.length === 0) {
+        // No seed chunk matched a registry source path — most likely a panel
+        // chunk was merged into a facade-less shared chunk by a future refactor.
+        // Warn and emit nothing rather than failing the build; the budget gate
+        // still measures the closure independently and would catch real drift.
+        console.warn(
+          "[first-render-modulepreload] no first-render seed chunk matched getFirstRenderSeeds() — emitting no preload tags"
+        );
+        return;
+      }
+
+      const closureOptions = {
+        getNode: (fileName: string) => chunksByFileName.get(fileName),
+        getStaticImports: (chunk: BundleChunkLike) => chunk.imports,
+        getDynamicImports: (chunk: BundleChunkLike) => chunk.dynamicImports,
+        followDynamic: false,
+      };
+
+      // The eager static closure of the first-render seed chunks.
+      const seedClosure = collectClosure(seedFileNames, closureOptions);
+      // What Vite already auto-preloads: every entry chunk plus its eager static
+      // closure. Subtract it so we never emit a duplicate <link> for a chunk
+      // Vite already covers (e.g. the shared vendor-react chunk).
+      const entryClosure = collectClosure(entryFileNames, closureOptions);
+
+      const toInject = [...seedClosure].filter((fileName) => !entryClosure.has(fileName)).sort();
+
+      // `base` is "./" (relative — required by the Electron app:// protocol) and
+      // Vite emits asset hrefs as base + fileName; match that exactly. The
+      // `crossorigin` boolean attr mirrors Vite's own modulepreload links so the
+      // preload matches the subsequent CORS module fetch instead of double-loading.
+      return toInject.map(
+        (fileName): HtmlTagDescriptor => ({
+          tag: "link",
+          attrs: { rel: "modulepreload", crossorigin: true, href: `./${fileName}` },
+          injectTo: "head",
+        })
+      );
+    },
+  };
+}
+
 export default defineConfig(({ command, mode }) => {
   const { logger: compilerLogger, plugin: compilerReportPlugin } =
     reactCompilerReportPlugin(command);
@@ -569,6 +676,7 @@ export default defineConfig(({ command, mode }) => {
       compilerReportPlugin,
       rendererBundleSizePlugin(),
       firstRenderSeedsPlugin(),
+      firstRenderModulePreloadPlugin(),
       chunkModulesPlugin(),
       xtermMinifyIdentifiersGuardPlugin(),
       ...(process.env.ANALYZE === "true"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,7 @@ import { gzipSync } from "node:zlib";
 import { getDevServerConfig } from "./shared/config/devServer";
 import { getDaintreeAppDevCSP, getDaintreeAppProdCSP } from "./shared/config/csp";
 import { getFirstRenderSeeds } from "./shared/config/panelKindRegistry";
-import { collectClosure } from "./scripts/first-render-closure-lib.mjs";
+import { computeFirstRenderPreloadFiles } from "./scripts/first-render-closure-lib.mjs";
 
 const devServerConfig = getDevServerConfig();
 
@@ -532,10 +532,10 @@ function chunkModulesPlugin(): Plugin {
   };
 }
 
-// Minimal view of a Rolldown OutputChunk used by the preload walk. The bundle's
-// `imports[]` / `dynamicImports[]` hold output FILE NAMES (other bundle keys),
-// not the source-path keys the manifest uses — these are JS getters on the
-// native handle, so they're read lazily, never structured-cloned.
+// Minimal view of a Rolldown OutputChunk passed to the preload helper. The
+// bundle's `imports[]` / `dynamicImports[]` hold output FILE NAMES (other bundle
+// keys), not the source-path keys the manifest uses — these are JS getters on
+// the native handle, so they're read lazily, never structured-cloned.
 interface BundleChunkLike {
   type: string;
   fileName: string;
@@ -554,13 +554,13 @@ interface BundleChunkLike {
 // → fetch the chunk → discover its deps → fetch those). Preloading the eager
 // closure of the seeds collapses that first-paint waterfall.
 //
-// Eager-only by construction: the BFS follows `imports[]` and NEVER
+// Eager-only by construction: the closure follows `imports[]` and NEVER
 // `dynamicImports[]`, so deliberately-deferred subtrees (vendor-motion's domMax,
-// #8821) are not pulled onto the first-paint path. It reuses the exact
-// `followDynamic: false` traversal the first-render-chunk budget gates on (via
-// scripts/first-render-closure-lib.mjs), so the injected preload set and the
-// measured budget cannot drift. Chunk membership is untouched — this only adds
-// <link> tags to the HTML.
+// #8821) are not pulled onto the first-paint path. The set-building logic lives
+// in computeFirstRenderPreloadFiles (scripts/first-render-closure-lib.mjs),
+// which shares the exact `followDynamic: false` traversal the first-render-chunk
+// budget gates on, so the injected preload set and the measured budget cannot
+// drift. Chunk membership is untouched — this only adds <link> tags to the HTML.
 function firstRenderModulePreloadPlugin(): Plugin {
   // getFirstRenderSeeds() returns repo-relative POSIX source paths; the bundle
   // keys chunks by hashed file name and tags each lazy seed chunk with an
@@ -568,6 +568,8 @@ function firstRenderModulePreloadPlugin(): Plugin {
   // facadeModuleId back to that same repo-relative POSIX form.
   const seedSourcePaths = new Set(getFirstRenderSeeds());
   const root = process.cwd();
+  const toRelativePosix = (facadeModuleId: string) =>
+    path.relative(root, facadeModuleId).split(path.sep).join("/");
 
   return {
     name: "first-render-modulepreload",
@@ -580,23 +582,14 @@ function firstRenderModulePreloadPlugin(): Plugin {
       // Populated only for production builds — the dev server has no bundle.
       if (!ctx.bundle) return;
 
-      const bundle = ctx.bundle as unknown as Record<string, BundleChunkLike>;
+      const chunks = Object.values(ctx.bundle as unknown as Record<string, BundleChunkLike>);
+      const { files, matchedSeedCount } = computeFirstRenderPreloadFiles(
+        chunks,
+        seedSourcePaths,
+        toRelativePosix
+      );
 
-      const chunksByFileName = new Map<string, BundleChunkLike>();
-      const seedFileNames: string[] = [];
-      const entryFileNames: string[] = [];
-
-      for (const output of Object.values(bundle)) {
-        if (output.type !== "chunk") continue;
-        chunksByFileName.set(output.fileName, output);
-        if (output.isEntry) entryFileNames.push(output.fileName);
-        if (output.facadeModuleId) {
-          const rel = path.relative(root, output.facadeModuleId).split(path.sep).join("/");
-          if (seedSourcePaths.has(rel)) seedFileNames.push(output.fileName);
-        }
-      }
-
-      if (seedFileNames.length === 0) {
+      if (matchedSeedCount === 0) {
         // No seed chunk matched a registry source path — most likely a panel
         // chunk was merged into a facade-less shared chunk by a future refactor.
         // Warn and emit nothing rather than failing the build; the budget gate
@@ -607,27 +600,21 @@ function firstRenderModulePreloadPlugin(): Plugin {
         return;
       }
 
-      const closureOptions = {
-        getNode: (fileName: string) => chunksByFileName.get(fileName),
-        getStaticImports: (chunk: BundleChunkLike) => chunk.imports,
-        getDynamicImports: (chunk: BundleChunkLike) => chunk.dynamicImports,
-        followDynamic: false,
-      };
-
-      // The eager static closure of the first-render seed chunks.
-      const seedClosure = collectClosure(seedFileNames, closureOptions);
-      // What Vite already auto-preloads: every entry chunk plus its eager static
-      // closure. Subtract it so we never emit a duplicate <link> for a chunk
-      // Vite already covers (e.g. the shared vendor-react chunk).
-      const entryClosure = collectClosure(entryFileNames, closureOptions);
-
-      const toInject = [...seedClosure].filter((fileName) => !entryClosure.has(fileName)).sort();
+      if (matchedSeedCount < seedSourcePaths.size) {
+        // Some — but not all — seeds resolved. Partial coverage is otherwise
+        // silent (the zero-match guard above doesn't fire), so the preload set
+        // would quietly miss a panel's closure. Surface it; the budget gate
+        // measures the manifest closure separately and can't catch this.
+        console.warn(
+          `[first-render-modulepreload] only ${matchedSeedCount} of ${seedSourcePaths.size} first-render seeds matched a chunk facadeModuleId — preload coverage is incomplete`
+        );
+      }
 
       // `base` is "./" (relative — required by the Electron app:// protocol) and
       // Vite emits asset hrefs as base + fileName; match that exactly. The
       // `crossorigin` boolean attr mirrors Vite's own modulepreload links so the
       // preload matches the subsequent CORS module fetch instead of double-loading.
-      return toInject.map(
+      return files.map(
         (fileName): HtmlTagDescriptor => ({
           tag: "link",
           attrs: { rel: "modulepreload", crossorigin: true, href: `./${fileName}` },


### PR DESCRIPTION
## Summary

- Adds a build-time Vite plugin (`firstRenderModulePreloadPlugin` in `vite.config.ts`) that injects `<link rel="modulepreload">` tags into the built `index.html` for the eager `imports[]`-only closure of the first-render seed chunks (the lazy browser, dev-preview, and review panels a restored session renders immediately), minus what Vite already auto-preloads from the entry chunk. This collapses the first-paint request waterfall into parallel preloads — the win on the local protocol is compile pipelining, not network.
- Eager-only by construction: follows `imports[]` and never `dynamicImports[]`, so deliberately-deferred subtrees (`vendor-motion` domMax, #8821) stay off the first-paint path. Verified end-to-end against the real build: 0 preloaded chunks outside the eager closure, the `motionFeatures`/`domMax` chunks correctly excluded, 83 unique tags with zero duplicates, budget gate green.
- Shares one traversal with the first-render-chunk budget script via a new dependency-free `scripts/first-render-closure-lib.mjs` (generic accessor-based `collectClosure` + `computeFirstRenderPreloadFiles`), so the injected preload set and the gated budget closure can't drift. The budget script's existing `collectClosure` now delegates to the lib (signature/behavior unchanged). A `.d.mts` declaration lets `vite.config.ts` (type-checked under `tsconfig.node.json`, no `allowJs`) import the `.mjs` cleanly.

Closes #9771

## Changes

- `vite.config.ts` — new `firstRenderModulePreloadPlugin` Vite plugin
- `scripts/first-render-closure-lib.mjs` — shared `collectClosure` + `computeFirstRenderPreloadFiles` helper
- `scripts/first-render-closure-lib.d.mts` — TypeScript declaration for the `.mjs` lib
- `scripts/check-first-render-chunk-budget.mjs` — refactored to delegate to the shared lib
- `scripts/first-render-closure-lib.test.mjs` — 50 new tests (dynamic exclusion, domMax guard, entry-closure subtraction dedup, cross-platform `facadeModuleId` normalisation, asset exclusion, zero/partial seed match)

## Testing

`npm run check` passes clean. 50 new unit tests cover the shared lib and plugin helper behaviour. No CSP changes needed — `<link rel="modulepreload">` is governed by `script-src 'self'`, same as the existing preloads on the same-origin `app://` protocol. Chunk membership is unchanged by construction (link tags only), so first-render-chunk, renderer-bundle, and chunk-modules budgets stay green.