### PR TITLE
perf(startup): instrument per-view preload evaluation cost (#9770)

### DIFF
--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -171,7 +171,7 @@ export function registerIpcHandlers(deps: HandlerDependencies): () => void {
     register(() => registerWatchdogHandlers(deps));
     register(() => registerPluginHandlers());
     register(() => registerPluginMcpHandlers());
-    register(() => registerPerfHandlers());
+    register(() => registerPerfHandlers(deps));
     register(() => registerConnectivityHandlers());
     register(() => registerScratchHandlers(deps));
   } catch (error) {

--- a/electron/ipc/handlers/__tests__/perf.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/perf.handlers.test.ts
@@ -143,6 +143,76 @@ describe("registerPerfHandlers", () => {
     expect(recordPreloadDuration).toHaveBeenCalledWith(99, 12);
   });
 
+  it("routes the preload duration to the per-window ProjectViewManager via the registry", () => {
+    const recordA = vi.fn();
+    const recordB = vi.fn();
+    const contexts: Record<
+      number,
+      { services: { projectViewManager: { recordPreloadDuration: typeof recordA } } }
+    > = {
+      11: { services: { projectViewManager: { recordPreloadDuration: recordA } } },
+      22: { services: { projectViewManager: { recordPreloadDuration: recordB } } },
+    };
+    const deps = {
+      // Static dep points at window A; the registry must override it for B.
+      projectViewManager: { recordPreloadDuration: recordA },
+      windowRegistry: {
+        getByWebContentsId: (id: number) => contexts[id],
+      },
+    } as unknown as HandlerDependencies;
+
+    registerPerfHandlers(deps);
+    const handler = getHandler();
+
+    handler(makeEvent(22), {
+      marks: [
+        {
+          mark: "preload.eval:end",
+          timestamp: "2026-01-01T00:00:00.000Z",
+          elapsedMs: 9,
+          meta: { durationMs: 9 },
+        },
+      ],
+      rendererTimeOrigin: 1_000_100,
+      rendererT0: 5,
+    });
+
+    expect(recordB).toHaveBeenCalledWith(22, 9);
+    expect(recordA).not.toHaveBeenCalled();
+  });
+
+  it("forwards the preload duration only once when a flush carries duplicate eval:end marks", () => {
+    const recordPreloadDuration = vi.fn();
+    const deps = {
+      projectViewManager: { recordPreloadDuration },
+    } as unknown as HandlerDependencies;
+
+    registerPerfHandlers(deps);
+    const handler = getHandler();
+
+    handler(makeEvent(99), {
+      marks: [
+        {
+          mark: "preload.eval:end",
+          timestamp: "2026-01-01T00:00:00.000Z",
+          elapsedMs: 12,
+          meta: { durationMs: 12 },
+        },
+        {
+          mark: "preload.eval:end",
+          timestamp: "2026-01-01T00:00:00.000Z",
+          elapsedMs: 13,
+          meta: { durationMs: 13 },
+        },
+      ],
+      rendererTimeOrigin: 1_000_100,
+      rendererT0: 5,
+    });
+
+    expect(recordPreloadDuration).toHaveBeenCalledTimes(1);
+    expect(recordPreloadDuration).toHaveBeenCalledWith(99, 12);
+  });
+
   it("does not forward a preload duration when the eval:end mark lacks a numeric durationMs", () => {
     const recordPreloadDuration = vi.fn();
     const deps = {

--- a/electron/ipc/handlers/__tests__/perf.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/perf.handlers.test.ts
@@ -21,6 +21,22 @@ vi.mock("../../../utils/performance.js", () => ({
 }));
 
 import { registerPerfHandlers } from "../perf.js";
+import type { HandlerDependencies } from "../../types.js";
+
+type FlushHandler = (event: Electron.IpcMainEvent, payload: unknown) => void;
+
+function makeEvent(id = 42, destroyed = false): Electron.IpcMainEvent {
+  return {
+    sender: {
+      id,
+      isDestroyed: () => destroyed,
+    },
+  } as unknown as Electron.IpcMainEvent;
+}
+
+function getHandler(): FlushHandler {
+  return ipcMainMock.on.mock.calls[0][1] as FlushHandler;
+}
 
 describe("registerPerfHandlers", () => {
   beforeEach(() => {
@@ -38,9 +54,9 @@ describe("registerPerfHandlers", () => {
 
   it("rebases renderer marks and appends them", () => {
     registerPerfHandlers();
-    const handler = ipcMainMock.on.mock.calls[0][1];
+    const handler = getHandler();
 
-    handler({} as Electron.IpcMainEvent, {
+    handler(makeEvent(), {
       marks: [
         {
           mark: "hydrate_start",
@@ -72,14 +88,107 @@ describe("registerPerfHandlers", () => {
     expect((second.meta as Record<string, unknown>).source).toBe("renderer");
   });
 
+  it("tags each rebased record with the sender's webContents id", () => {
+    registerPerfHandlers();
+    const handler = getHandler();
+
+    handler(makeEvent(7), {
+      marks: [{ mark: "hydrate_start", timestamp: "2026-01-01T00:00:00.000Z", elapsedMs: 100 }],
+      rendererTimeOrigin: 1_000_100,
+      rendererT0: 5,
+    });
+
+    const record = appendedPayloads[0] as Record<string, unknown>;
+    expect((record.meta as Record<string, unknown>).webContentsId).toBe(7);
+  });
+
+  it("omits webContents id when the sender is destroyed", () => {
+    registerPerfHandlers();
+    const handler = getHandler();
+
+    handler(makeEvent(7, /* destroyed */ true), {
+      marks: [{ mark: "hydrate_start", timestamp: "2026-01-01T00:00:00.000Z", elapsedMs: 100 }],
+      rendererTimeOrigin: 1_000_100,
+      rendererT0: 5,
+    });
+
+    const record = appendedPayloads[0] as Record<string, unknown>;
+    expect((record.meta as Record<string, unknown>).webContentsId).toBeUndefined();
+  });
+
+  it("forwards the preload eval duration to ProjectViewManager keyed by webContents id", () => {
+    const recordPreloadDuration = vi.fn();
+    const deps = {
+      projectViewManager: { recordPreloadDuration },
+    } as unknown as HandlerDependencies;
+
+    registerPerfHandlers(deps);
+    const handler = getHandler();
+
+    handler(makeEvent(99), {
+      marks: [
+        { mark: "preload.eval:start", timestamp: "2026-01-01T00:00:00.000Z", elapsedMs: 0 },
+        {
+          mark: "preload.eval:end",
+          timestamp: "2026-01-01T00:00:00.000Z",
+          elapsedMs: 12,
+          meta: { durationMs: 12 },
+        },
+      ],
+      rendererTimeOrigin: 1_000_100,
+      rendererT0: 5,
+    });
+
+    expect(recordPreloadDuration).toHaveBeenCalledTimes(1);
+    expect(recordPreloadDuration).toHaveBeenCalledWith(99, 12);
+  });
+
+  it("does not forward a preload duration when the eval:end mark lacks a numeric durationMs", () => {
+    const recordPreloadDuration = vi.fn();
+    const deps = {
+      projectViewManager: { recordPreloadDuration },
+    } as unknown as HandlerDependencies;
+
+    registerPerfHandlers(deps);
+    const handler = getHandler();
+
+    handler(makeEvent(99), {
+      marks: [{ mark: "preload.eval:end", timestamp: "2026-01-01T00:00:00.000Z", elapsedMs: 12 }],
+      rendererTimeOrigin: 1_000_100,
+      rendererT0: 5,
+    });
+
+    expect(recordPreloadDuration).not.toHaveBeenCalled();
+  });
+
+  it("does not crash when no ProjectViewManager is wired", () => {
+    registerPerfHandlers();
+    const handler = getHandler();
+
+    expect(() =>
+      handler(makeEvent(99), {
+        marks: [
+          {
+            mark: "preload.eval:end",
+            timestamp: "2026-01-01T00:00:00.000Z",
+            elapsedMs: 12,
+            meta: { durationMs: 12 },
+          },
+        ],
+        rendererTimeOrigin: 1_000_100,
+        rendererT0: 5,
+      })
+    ).not.toThrow();
+  });
+
   it("no-ops when capture is disabled", async () => {
     const { isPerformanceCaptureEnabled } = await import("../../../utils/performance.js");
     (isPerformanceCaptureEnabled as ReturnType<typeof vi.fn>).mockReturnValueOnce(false);
 
     registerPerfHandlers();
-    const handler = ipcMainMock.on.mock.calls[0][1];
+    const handler = getHandler();
 
-    handler({} as Electron.IpcMainEvent, {
+    handler(makeEvent(), {
       marks: [{ mark: "test", timestamp: "2026-01-01T00:00:00.000Z", elapsedMs: 50 }],
       rendererTimeOrigin: 1_000_100,
       rendererT0: 5,
@@ -90,11 +199,11 @@ describe("registerPerfHandlers", () => {
 
   it("handles invalid payload gracefully", () => {
     registerPerfHandlers();
-    const handler = ipcMainMock.on.mock.calls[0][1];
+    const handler = getHandler();
 
-    handler({} as Electron.IpcMainEvent, null);
-    handler({} as Electron.IpcMainEvent, { marks: "not-an-array" });
-    handler({} as Electron.IpcMainEvent, undefined);
+    handler(makeEvent(), null);
+    handler(makeEvent(), { marks: "not-an-array" });
+    handler(makeEvent(), undefined);
 
     expect(appendedPayloads).toHaveLength(0);
   });

--- a/electron/ipc/handlers/perf.ts
+++ b/electron/ipc/handlers/perf.ts
@@ -16,6 +16,9 @@ export function registerPerfHandlers(deps?: HandlerDependencies): () => void {
 
     const { marks, rendererTimeOrigin, rendererT0 } = payload;
     const webContentsId = event.sender.isDestroyed() ? undefined : event.sender.id;
+    // A preload reports exactly one eval:end mark per flush; guard so a
+    // malformed payload with duplicates forwards the cost only once (#9770).
+    let preloadRecorded = false;
 
     for (const record of marks) {
       if (typeof record.elapsedMs !== "number") continue;
@@ -37,10 +40,22 @@ export function registerPerfHandlers(deps?: HandlerDependencies): () => void {
       // Correlate the per-view preload eval cost (#9770) with the originating
       // WebContentsView so ProjectViewManager can surface it alongside the
       // projectview.revival log. The duration is carried on the eval:end mark.
-      if (record.mark === PERF_MARKS.PRELOAD_EVAL_END && webContentsId !== undefined) {
+      // IPC handlers are registered once globally with the first window's deps,
+      // so resolve the per-window ProjectViewManager via the registry (keyed by
+      // the sender's webContents id) before falling back to the static dep —
+      // otherwise a second window's preload flush would silently no-op.
+      if (
+        record.mark === PERF_MARKS.PRELOAD_EVAL_END &&
+        webContentsId !== undefined &&
+        !preloadRecorded
+      ) {
         const durationMs = (record.meta as { durationMs?: unknown } | undefined)?.durationMs;
         if (typeof durationMs === "number" && Number.isFinite(durationMs)) {
-          deps?.projectViewManager?.recordPreloadDuration(webContentsId, durationMs);
+          const projectViewManager =
+            deps?.windowRegistry?.getByWebContentsId(webContentsId)?.services.projectViewManager ??
+            deps?.projectViewManager;
+          projectViewManager?.recordPreloadDuration(webContentsId, durationMs);
+          preloadRecorded = true;
         }
       }
     }

--- a/electron/ipc/handlers/perf.ts
+++ b/electron/ipc/handlers/perf.ts
@@ -5,14 +5,17 @@ import {
   appendPayload,
   rebaseRendererElapsedMs,
 } from "../../utils/performance.js";
+import { PERF_MARKS } from "../../../shared/perf/marks.js";
 import type { RendererPerfFlushPayload } from "../../../shared/perf/marks.js";
+import type { HandlerDependencies } from "../types.js";
 
-export function registerPerfHandlers(): () => void {
-  const handleFlush = (_event: Electron.IpcMainEvent, payload: RendererPerfFlushPayload): void => {
+export function registerPerfHandlers(deps?: HandlerDependencies): () => void {
+  const handleFlush = (event: Electron.IpcMainEvent, payload: RendererPerfFlushPayload): void => {
     if (!isPerformanceCaptureEnabled()) return;
     if (!payload || !Array.isArray(payload.marks)) return;
 
     const { marks, rendererTimeOrigin, rendererT0 } = payload;
+    const webContentsId = event.sender.isDestroyed() ? undefined : event.sender.id;
 
     for (const record of marks) {
       if (typeof record.elapsedMs !== "number") continue;
@@ -27,8 +30,19 @@ export function registerPerfHandlers(): () => void {
           ...record.meta,
           source: "renderer",
           originalElapsedMs: record.elapsedMs,
+          webContentsId,
         },
       });
+
+      // Correlate the per-view preload eval cost (#9770) with the originating
+      // WebContentsView so ProjectViewManager can surface it alongside the
+      // projectview.revival log. The duration is carried on the eval:end mark.
+      if (record.mark === PERF_MARKS.PRELOAD_EVAL_END && webContentsId !== undefined) {
+        const durationMs = (record.meta as { durationMs?: unknown } | undefined)?.durationMs;
+        if (typeof durationMs === "number" && Number.isFinite(durationMs)) {
+          deps?.projectViewManager?.recordPreloadDuration(webContentsId, durationMs);
+        }
+      }
     }
   };
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -24,6 +24,7 @@ import type {
 import type { ActionContext, ActionDispatchResult } from "../shared/types/actions.js";
 import type { PushProgressEvent } from "../shared/types/ipc/gitPush.js";
 import { CHANNELS } from "./ipc/channels.js";
+import { PERF_MARKS } from "../shared/perf/marks.js";
 import {
   BrokerError,
   RequestResponseBroker,
@@ -147,6 +148,24 @@ import type { PanelKindConfig } from "../shared/config/panelKindRegistry.js";
 import type { ToolbarButtonConfig } from "../shared/config/toolbarButtonRegistry.js";
 
 export type { ElectronAPI };
+
+// Anchor for the per-view preload evaluation span (#9770). This is the first
+// executable statement in the bundled preload entry (esbuild hoists the import
+// `require()`s above it, so module-resolution cost is excluded by construction);
+// everything below — building the API surface and the contextBridge exposure —
+// is measured against it and flushed at preload bottom. Guarded so it is inert
+// in runtimes without the Web Performance API (none in Electron, but cheap).
+const preloadEvalStartMs =
+  typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : 0;
+
+// Monotonic clock reader shared by the preload-eval instrumentation below
+// (#9770). Falls back to 0 where the Web Performance API is unavailable.
+const perfNowMs = (): number =>
+  typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : 0;
 
 // True for packaged production builds. `process.resourcesPath` is undefined in
 // sandboxed preloads (sandbox: true), so the only reliable signal here is the
@@ -2680,6 +2699,10 @@ const api: ElectronAPI = {
 // same-origin route (index.html, and any future route) gets the full surface — using
 // isRecoveryPageUrl as the discriminator keeps the full surface as the safe default.
 const rendererUrl = window.location.href;
+// Sub-span around the contextBridge handoff (#9770). Both the recovery-page and
+// full-bridge branches are mutually exclusive, so bracketing the whole
+// conditional captures whichever exposure actually ran.
+const exposeStartMs = perfNowMs();
 if (window.top === window && isTrustedRendererUrl(rendererUrl)) {
   if (isRecoveryPageUrl(rendererUrl)) {
     contextBridge.exposeInMainWorld("electron", { recovery: api.recovery });
@@ -2718,6 +2741,7 @@ if (window.top === window && isTrustedRendererUrl(rendererUrl)) {
     );
   }
 }
+const exposeEndMs = perfNowMs();
 
 /// Private listener: reclaim renderer memory when notified by the main process.
 // Not exposed through window.electron — this is an internal optimization.
@@ -2856,5 +2880,49 @@ if (initialColorSchemeId) {
 if (initialProjectId) {
   contextBridge.exposeInMainWorld("__DAINTREE_INITIAL_PROJECT__", {
     id: initialProjectId,
+  });
+}
+
+// Flush the per-view preload evaluation cost (#9770). Runs at preload bottom —
+// before any renderer page script — so the main process can attribute the
+// `preload.eval` and `preload.exposeInMainWorld` spans to this WebContentsView
+// (via the IPC sender's id). Reuses the existing renderer-marks channel and its
+// rebasing math: the preload shares the renderer frame's `performance.timeOrigin`,
+// so each mark's elapsed value is relative to `preloadEvalStartMs`. Gated on the
+// same runtime flag as the rest of the perf pipeline; `process.env` is polyfilled
+// in the sandboxed preload, and the flag is intentionally NOT esbuild-stripped.
+if (process.env.DAINTREE_PERF_CAPTURE === "1") {
+  const preloadEvalEndMs = perfNowMs();
+  const timestamp = new Date().toISOString();
+  ipcRenderer.send(CHANNELS.PERF_FLUSH_RENDERER_MARKS, {
+    marks: [
+      {
+        mark: PERF_MARKS.PRELOAD_EVAL_START,
+        timestamp,
+        elapsedMs: 0,
+      },
+      {
+        mark: PERF_MARKS.PRELOAD_EXPOSE_IN_MAIN_WORLD_START,
+        timestamp,
+        elapsedMs: exposeStartMs - preloadEvalStartMs,
+      },
+      {
+        mark: PERF_MARKS.PRELOAD_EXPOSE_IN_MAIN_WORLD_END,
+        timestamp,
+        elapsedMs: exposeEndMs - preloadEvalStartMs,
+        meta: { durationMs: exposeEndMs - exposeStartMs },
+      },
+      {
+        mark: PERF_MARKS.PRELOAD_EVAL_END,
+        timestamp,
+        elapsedMs: preloadEvalEndMs - preloadEvalStartMs,
+        meta: { durationMs: preloadEvalEndMs - preloadEvalStartMs },
+      },
+    ],
+    rendererTimeOrigin:
+      typeof performance !== "undefined" && typeof performance.timeOrigin === "number"
+        ? performance.timeOrigin
+        : 0,
+    rendererT0: preloadEvalStartMs,
   });
 }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2699,17 +2699,23 @@ const api: ElectronAPI = {
 // same-origin route (index.html, and any future route) gets the full surface — using
 // isRecoveryPageUrl as the discriminator keeps the full surface as the safe default.
 const rendererUrl = window.location.href;
-// Sub-span around the contextBridge handoff (#9770). Both the recovery-page and
-// full-bridge branches are mutually exclusive, so bracketing the whole
-// conditional captures whichever exposure actually ran.
-const exposeStartMs = perfNowMs();
+// Sub-span around the `window.electron` contextBridge handoff (#9770). Bracketed
+// tightly around the exposeInMainWorld("electron", …) call in whichever branch
+// runs, so the Sentry bridge exposure and origin-rejection logging are excluded.
+// Defaults to a zero-width span for the untrusted path (no exposure happens).
+let exposeStartMs = perfNowMs();
+let exposeEndMs = exposeStartMs;
 if (window.top === window && isTrustedRendererUrl(rendererUrl)) {
   if (isRecoveryPageUrl(rendererUrl)) {
+    exposeStartMs = perfNowMs();
     contextBridge.exposeInMainWorld("electron", { recovery: api.recovery });
+    exposeEndMs = perfNowMs();
     // __SENTRY_IPC__ is intentionally withheld here: recovery.html has no Sentry
     // renderer SDK and exposing the transport would needlessly widen its surface.
   } else {
+    exposeStartMs = perfNowMs();
     contextBridge.exposeInMainWorld("electron", api);
+    exposeEndMs = perfNowMs();
     // Bridge for @sentry/electron/renderer's IPC transport. The renderer SDK
     // looks up window.__SENTRY_IPC__["sentry-ipc"] and uses these methods to
     // forward envelopes to the main process (which owns the real DSN and HTTP
@@ -2741,7 +2747,6 @@ if (window.top === window && isTrustedRendererUrl(rendererUrl)) {
     );
   }
 }
-const exposeEndMs = perfNowMs();
 
 /// Private listener: reclaim renderer memory when notified by the main process.
 // Not exposed through window.electron — this is an internal optimization.

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -149,6 +149,13 @@ interface ViewEntry {
   state: ViewState;
   crashTimestamps: number[];
   cleanupHandlers: () => void;
+  /**
+   * Cold-start preload (`preload.cts`) evaluation cost in ms, self-reported by
+   * the view's preload via PERF_FLUSH_RENDERER_MARKS (#9770). Set once per view
+   * (first-write); surfaced in the `projectview.revival` log so cache-pressure
+   * signals carry the preload cost that was paid when the view cold-started.
+   */
+  preloadEvalDurationMs?: number;
 }
 
 export interface ProjectViewManagerOptions {
@@ -440,6 +447,9 @@ export class ProjectViewManager {
           projectId,
           timeSinceEvictionMs: Date.now() - evictedAt,
           visibleMs,
+          ...(cached.preloadEvalDurationMs !== undefined
+            ? { preloadEvalDurationMs: cached.preloadEvalDurationMs }
+            : {}),
         });
         this.evictionTimestamps.delete(projectId);
       }
@@ -782,6 +792,23 @@ export class ProjectViewManager {
 
   getProjectIdForWebContents(webContentsId: number): string | null {
     return this.webContentsToProject.get(webContentsId) ?? null;
+  }
+
+  /**
+   * Record the cold-start preload evaluation cost for a view, keyed by its
+   * webContents id (#9770). Called from the perf IPC handler when a view's
+   * preload flushes its `preload.eval` span. First-write semantics: the cost is
+   * paid once per cold-started view, so a duplicate flush (e.g. a retried IPC)
+   * must not clobber the original measurement. No-ops silently when the id is
+   * unknown (the flush can race ahead of view registration, or arrive for a
+   * non-project webContents).
+   */
+  recordPreloadDuration(webContentsId: number, durationMs: number): void {
+    const projectId = this.webContentsToProject.get(webContentsId);
+    if (projectId === undefined) return;
+    const entry = this.views.get(projectId);
+    if (!entry || entry.preloadEvalDurationMs !== undefined) return;
+    entry.preloadEvalDurationMs = durationMs;
   }
 
   getAllViews(): ViewEntry[] {

--- a/electron/window/__tests__/ProjectViewManager.preload.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.preload.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+let nextWebContentsId = 100;
+let nextOsProcessId = 1000;
+
+type Handler = (...args: unknown[]) => void;
+
+function createMockWebContents() {
+  const id = nextWebContentsId++;
+  const osPid = nextOsProcessId++;
+  const handlers = new Map<string, Handler[]>();
+  const wc = {
+    id,
+    osPid,
+    isDestroyed: vi.fn(() => false),
+    executeJavaScript: vi.fn(() => Promise.resolve()),
+    loadURL: vi.fn(() => Promise.resolve()),
+    focus: vi.fn(),
+    close: vi.fn(),
+    reload: vi.fn(),
+    send: vi.fn(),
+    session: { flushStorageData: vi.fn() },
+    navigationHistory: { clear: vi.fn() },
+    getOSProcessId: vi.fn(() => osPid),
+    on: vi.fn((event: string, handler: Handler) => {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    }),
+    once: vi.fn((event: string, handler: Handler) => {
+      if (event === "did-finish-load") {
+        Promise.resolve().then(() => handler());
+      }
+    }),
+    removeListener: vi.fn((event: string, handler: Handler) => {
+      const list = handlers.get(event);
+      if (!list) return;
+      const idx = list.indexOf(handler);
+      if (idx >= 0) list.splice(idx, 1);
+    }),
+    setWindowOpenHandler: vi.fn(),
+    setIgnoreMenuShortcuts: vi.fn(),
+    listenerCount: (event: string) => handlers.get(event)?.length ?? 0,
+  };
+  return wc;
+}
+
+const mockGetAppMetrics = vi.fn<() => Electron.ProcessMetric[]>(() => []);
+
+vi.mock("electron", () => {
+  function MockWebContentsView() {
+    const wc = createMockWebContents();
+    return { webContents: wc, setBounds: vi.fn(), setBackgroundColor: vi.fn() };
+  }
+  return {
+    app: {
+      isPackaged: false,
+      commandLine: { appendSwitch: vi.fn() },
+      getAppMetrics: () => mockGetAppMetrics(),
+    },
+    BrowserWindow: vi.fn(),
+    WebContentsView: MockWebContentsView,
+    session: { fromPartition: vi.fn(() => ({ protocol: { handle: vi.fn() } })) },
+    ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+    nativeTheme: { shouldUseDarkColors: true },
+  };
+});
+
+vi.mock("../../services/ProcessMemoryMonitor.js", () => ({
+  forgetBlinkSample: vi.fn(),
+  forgetEluSample: vi.fn(),
+}));
+
+vi.mock("../webContentsRegistry.js", () => ({
+  registerWebContents: vi.fn(),
+  registerAppView: vi.fn(),
+  unregisterWebContents: vi.fn(),
+  registerProjectView: vi.fn(),
+  unregisterProjectView: vi.fn(),
+}));
+
+vi.mock("../../setup/protocols.js", () => ({
+  registerProtocolsForSession: vi.fn(),
+  getDistPath: vi.fn(() => "/dist"),
+}));
+
+vi.mock("../../../shared/config/devServer.js", () => ({
+  getDevServerUrl: vi.fn(() => "http://localhost:5173"),
+}));
+
+vi.mock("../../../shared/utils/trustedRenderer.js", () => ({
+  isTrustedRendererUrl: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock("../../../shared/utils/urlUtils.js", () => ({
+  isLocalhostUrl: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock("../../utils/openExternal.js", () => ({
+  canOpenExternalUrl: vi.fn(),
+  openExternalUrl: vi.fn(),
+}));
+
+vi.mock("../../services/CrashRecoveryService.js", () => ({
+  getCrashRecoveryService: vi.fn(() => ({ recordCrash: vi.fn() })),
+}));
+
+vi.mock("../../ipc/errorHandlers.js", () => ({
+  notifyError: vi.fn(),
+}));
+
+vi.mock("../skeletonCss.js", () => ({
+  injectSkeletonCss: vi.fn(),
+  injectSkeletonProjectIdentity: vi.fn(),
+  INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
+  INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
+  resolveInitialColorSchemeId: vi.fn(() => "daintree"),
+  resolveInitialCanvasBackgroundColor: vi.fn(() => "#1f1b16"),
+}));
+
+vi.mock("../../services/ProjectStore.js", () => ({
+  projectStore: { getProjectById: vi.fn(() => null) },
+}));
+
+vi.mock("../rendererConsoleCapture.js", () => ({
+  attachRendererConsoleCapture: vi.fn(),
+  detachRendererConsoleCapture: vi.fn(),
+}));
+
+vi.mock("../../utils/webContentsLifecycle.js", () => ({
+  freezeWebContents: vi.fn().mockResolvedValue(undefined),
+  unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
+  throttleCpuWebContents: vi.fn().mockResolvedValue(undefined),
+  unthrottleCpuWebContents: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+  createLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    name: "test-logger",
+  })),
+}));
+
+const mockGetAll = vi.fn<() => Array<{ projectId?: string; agentState?: string }>>(() => []);
+vi.mock("../../services/PtyManager.js", () => ({
+  getPtyManager: vi.fn(() => ({ getAll: mockGetAll })),
+}));
+
+import { ProjectViewManager } from "../ProjectViewManager.js";
+import { logInfo } from "../../utils/logger.js";
+
+function createMockWindow() {
+  return {
+    isDestroyed: vi.fn(() => false),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    getContentBounds: vi.fn(() => ({ x: 0, y: 0, width: 800, height: 600 })),
+    contentView: {
+      children: [] as unknown[],
+      addChildView: vi.fn(),
+      removeChildView: vi.fn(),
+    },
+    webContents: createMockWebContents(),
+  };
+}
+
+function webContentsIdFor(manager: ProjectViewManager, projectId: string): number {
+  const entry = manager.getAllViews().find((v) => v.projectId === projectId);
+  if (!entry) throw new Error(`no view for ${projectId}`);
+  return entry.view.webContents.id;
+}
+
+function preloadDurationFor(manager: ProjectViewManager, projectId: string): number | undefined {
+  return manager.getAllViews().find((v) => v.projectId === projectId)?.preloadEvalDurationMs;
+}
+
+describe("ProjectViewManager — preload eval cost (#9770)", () => {
+  let manager: ProjectViewManager;
+  let win: ReturnType<typeof createMockWindow>;
+
+  beforeEach(() => {
+    nextWebContentsId = 100;
+    nextOsProcessId = 1000;
+    vi.clearAllMocks();
+    mockGetAll.mockReset();
+    mockGetAll.mockReturnValue([]);
+    mockGetAppMetrics.mockReset();
+    mockGetAppMetrics.mockReturnValue([]);
+    win = createMockWindow();
+    manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
+      warmPaintGateTimeoutMs: 0,
+      warmPaintGateHardTimeoutMs: 0,
+      cachedProjectViews: 3,
+    });
+  });
+
+  it("records the preload duration on the matching view entry", () => {
+    const viewA = { webContents: createMockWebContents(), setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    manager.recordPreloadDuration(webContentsIdFor(manager, "proj-a"), 18.5);
+
+    expect(preloadDurationFor(manager, "proj-a")).toBe(18.5);
+  });
+
+  it("keeps the first measurement and ignores later duplicate flushes", () => {
+    const viewA = { webContents: createMockWebContents(), setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+    const wcId = webContentsIdFor(manager, "proj-a");
+
+    manager.recordPreloadDuration(wcId, 18.5);
+    manager.recordPreloadDuration(wcId, 999);
+
+    expect(preloadDurationFor(manager, "proj-a")).toBe(18.5);
+  });
+
+  it("no-ops for an unknown webContents id", () => {
+    const viewA = { webContents: createMockWebContents(), setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    expect(() => manager.recordPreloadDuration(999_999, 42)).not.toThrow();
+    expect(preloadDurationFor(manager, "proj-a")).toBeUndefined();
+  });
+
+  // A cache limit of 2 forces proj-a to be evicted (and carry an eviction
+  // timestamp), then re-cached, so a later cache hit fires the revival log.
+  function makeRevivalManager(): ProjectViewManager {
+    return new ProjectViewManager(win as never, {
+      dirname: "/test",
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
+      warmPaintGateTimeoutMs: 0,
+      warmPaintGateHardTimeoutMs: 0,
+      cachedProjectViews: 2,
+    });
+  }
+
+  it("surfaces the preload duration in the projectview.revival log when recorded", async () => {
+    const revivalManager = makeRevivalManager();
+    const viewA = { webContents: createMockWebContents(), setBounds: vi.fn() };
+    revivalManager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await revivalManager.switchTo("proj-b", "/path/b");
+    await revivalManager.switchTo("proj-c", "/path/c"); // evicts proj-a (ET set)
+    await revivalManager.switchTo("proj-a", "/path/a"); // cold start — proj-a re-created
+
+    revivalManager.recordPreloadDuration(webContentsIdFor(revivalManager, "proj-a"), 27.5);
+
+    // A cache hit on proj-a (still carrying its eviction timestamp) fires revival.
+    await revivalManager.switchTo("proj-c", "/path/c");
+    await revivalManager.switchTo("proj-a", "/path/a");
+
+    const revival = (logInfo as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([event, ctx]) =>
+        event === "projectview.revival" && (ctx as { projectId?: string }).projectId === "proj-a"
+    );
+    expect(revival).toBeDefined();
+    expect((revival?.[1] as Record<string, unknown>).preloadEvalDurationMs).toBe(27.5);
+  });
+
+  it("omits preloadEvalDurationMs from the revival log when none was recorded", async () => {
+    const revivalManager = makeRevivalManager();
+    const viewA = { webContents: createMockWebContents(), setBounds: vi.fn() };
+    revivalManager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await revivalManager.switchTo("proj-b", "/path/b");
+    await revivalManager.switchTo("proj-c", "/path/c");
+    await revivalManager.switchTo("proj-a", "/path/a");
+    await revivalManager.switchTo("proj-c", "/path/c");
+    await revivalManager.switchTo("proj-a", "/path/a");
+
+    const revival = (logInfo as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([event, ctx]) =>
+        event === "projectview.revival" && (ctx as { projectId?: string }).projectId === "proj-a"
+    );
+    expect(revival).toBeDefined();
+    expect(revival?.[1] as Record<string, unknown>).not.toHaveProperty("preloadEvalDurationMs");
+  });
+});

--- a/electron/window/__tests__/ProjectViewManager.preload.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.preload.test.ts
@@ -230,6 +230,27 @@ describe("ProjectViewManager — preload eval cost (#9770)", () => {
     expect(preloadDurationFor(manager, "proj-a")).toBeUndefined();
   });
 
+  it("no-ops for a flush that races in after the view was evicted", async () => {
+    const evictingManager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
+      warmPaintGateTimeoutMs: 0,
+      warmPaintGateHardTimeoutMs: 0,
+      cachedProjectViews: 2,
+    });
+    const viewA = { webContents: createMockWebContents(), setBounds: vi.fn() };
+    evictingManager.registerInitialView(viewA as never, "proj-a", "/path/a");
+    const staleWcId = webContentsIdFor(evictingManager, "proj-a");
+
+    // Evict proj-a (its webContents → project mapping is torn down).
+    await evictingManager.switchTo("proj-b", "/path/b");
+    await evictingManager.switchTo("proj-c", "/path/c");
+
+    expect(() => evictingManager.recordPreloadDuration(staleWcId, 42)).not.toThrow();
+    expect(evictingManager.getProjectIdForWebContents(staleWcId)).toBeNull();
+  });
+
   // A cache limit of 2 forces proj-a to be evicted (and carry an eviction
   // timestamp), then re-cached, so a later cache hit fires the revival log.
   function makeRevivalManager(): ProjectViewManager {
@@ -258,12 +279,12 @@ describe("ProjectViewManager — preload eval cost (#9770)", () => {
     await revivalManager.switchTo("proj-c", "/path/c");
     await revivalManager.switchTo("proj-a", "/path/a");
 
-    const revival = (logInfo as ReturnType<typeof vi.fn>).mock.calls.find(
+    const revivals = (logInfo as ReturnType<typeof vi.fn>).mock.calls.filter(
       ([event, ctx]) =>
         event === "projectview.revival" && (ctx as { projectId?: string }).projectId === "proj-a"
     );
-    expect(revival).toBeDefined();
-    expect((revival?.[1] as Record<string, unknown>).preloadEvalDurationMs).toBe(27.5);
+    expect(revivals).toHaveLength(1);
+    expect((revivals[0][1] as Record<string, unknown>).preloadEvalDurationMs).toBe(27.5);
   });
 
   it("omits preloadEvalDurationMs from the revival log when none was recorded", async () => {

--- a/scripts/perf/lib/coldStartAggregate.ts
+++ b/scripts/perf/lib/coldStartAggregate.ts
@@ -102,6 +102,15 @@ export const PHASE_PAIRS: Array<[string, string, string]> = [
     PERF_MARKS.HYDRATE_RESTORE_PANELS_END,
     "hydrate_restore_panels",
   ],
+  // Per-view preload evaluation cost (#9770). firstByMark pairs the initial
+  // (cold-start) view's spans, so this surfaces the headline preload-eval and
+  // contextBridge-exposure durations for the first project view.
+  [PERF_MARKS.PRELOAD_EVAL_START, PERF_MARKS.PRELOAD_EVAL_END, "preload.eval"],
+  [
+    PERF_MARKS.PRELOAD_EXPOSE_IN_MAIN_WORLD_START,
+    PERF_MARKS.PRELOAD_EXPOSE_IN_MAIN_WORLD_END,
+    "preload.exposeInMainWorld",
+  ],
 ];
 
 // Warn-only thresholds for the new first-launch quality signals introduced

--- a/shared/perf/marks.ts
+++ b/shared/perf/marks.ts
@@ -72,6 +72,15 @@ export const PERF_MARKS = {
 
   RENDERER_CLS_SAMPLE: "renderer_cls_sample",
   RENDERER_CLS_FINAL: "renderer_cls_final",
+
+  // Per-WebContentsView preload evaluation cost (#9770). Captured in the
+  // sandboxed preload and flushed via PERF_FLUSH_RENDERER_MARKS at preload
+  // bottom; the main-process handler correlates each pair with its view via
+  // the sender's webContents id.
+  PRELOAD_EVAL_START: "preload.eval:start",
+  PRELOAD_EVAL_END: "preload.eval:end",
+  PRELOAD_EXPOSE_IN_MAIN_WORLD_START: "preload.exposeInMainWorld:start",
+  PRELOAD_EXPOSE_IN_MAIN_WORLD_END: "preload.exposeInMainWorld:end",
 } as const;
 
 export type PerfMarkName = (typeof PERF_MARKS)[keyof typeof PERF_MARKS];


### PR DESCRIPTION
## Summary

- The startup perf pipeline had no visibility into per-view preload evaluation cost — this fills that gap.
- Captures two spans (`preload.eval` and `preload.exposeInMainWorld`) gated behind `DAINTREE_PERF_CAPTURE=1`, flushed via the existing `PERF_FLUSH_RENDERER_MARKS` channel (no new IPC; ratchet stays at 267).
- The main-side handler correlates each pair with its `WebContentsView` via sender id, caches the cold-start preload duration on `ViewEntry`, surfaces it in the `projectview.revival` log, and exposes it in `npm run perf:cold-start` via new phase pairs in the cold-start aggregator.

Resolves #9770

## Changes

- `shared/perf/marks.ts` — `preload.eval` and `preload.exposeInMainWorld` mark definitions
- `electron/preload.cts` — anchor capture wrapping the `contextBridge.exposeInMainWorld` call (anchor sits after the hoisted `require("electron")`, so module-resolution cost is excluded by construction)
- `electron/ipc/handlers/perf.ts` — per-view span correlation via sender id; cold-start preload duration cached on `ViewEntry`
- `electron/ipc/handlers.ts` — handler wired up
- `electron/window/ProjectViewManager.ts` — `preloadEvalMs` field on `ViewEntry`, surfaced in `projectview.revival` log
- `scripts/perf/lib/coldStartAggregate.ts` — `preload.eval` / `preload.exposeInMainWorld` phase pairs added to aggregator
- `electron/ipc/handlers/__tests__/perf.handlers.test.ts`, `electron/window/__tests__/ProjectViewManager.preload.test.ts` — 71 targeted unit tests

## Testing

`npm run check` passes (typecheck, lint, format, all IPC/channel/confirm guards; ratchet 267 unchanged, lint ratchet 1194 unchanged). 71 targeted unit tests pass. Production build verified — confirmed the anchor capture sits after the hoisted `require("electron")` in the dist output.