### PR TITLE
feat(terminal): add reconciliation watchdog for visible terminal rendering

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -32,6 +32,7 @@ import { TerminalAgentStateController } from "./TerminalAgentStateController";
 import { TerminalRestoreController } from "./TerminalRestoreController";
 import { TerminalHibernationManager } from "./TerminalHibernationManager";
 import { TerminalReflowController, forceXtermReflow } from "./TerminalReflowController";
+import { TerminalReconciliationWatchdog } from "./TerminalReconciliationWatchdog";
 import { TerminalWriteController } from "./TerminalWriteController";
 import {
   installTerminalBoundListeners,
@@ -111,6 +112,7 @@ class TerminalInstanceService {
   private restoreController: TerminalRestoreController;
   private hibernationManager: TerminalHibernationManager;
   private reflowController: TerminalReflowController;
+  private reconciliationWatchdog: TerminalReconciliationWatchdog;
   private writeController: TerminalWriteController;
   private unsubTierChanged: (() => void) | null = null;
 
@@ -311,6 +313,27 @@ class TerminalInstanceService {
         // reach the same answer.
         this.applyCursorBlinkPolicy(managed);
       },
+    });
+
+    // Constructed last — its deps reach every other controller. The watchdog
+    // self-starts (interval + visibilitychange + pointerdown diagnostic) and
+    // is torn down in dispose().
+    this.reconciliationWatchdog = new TerminalReconciliationWatchdog({
+      getInstances: () => this.instances.entries(),
+      setVisible: (id) => this.setVisible(id, true),
+      applyRendererPolicy: (id, tier) => this.rendererPolicy.applyRendererPolicy(id, tier),
+      reassertActiveBackendTier: (id) => this.rendererPolicy.reassertActiveTier(id),
+      getBackendTier: (id) => this.rendererPolicy.getLastBackendTier(id),
+      getStalledBytes: (id) => this.dataBuffer.getStalledBytes(id),
+      getQueuedBytes: (id) => this.dataBuffer.getQueuedBytes(id),
+      resumeFlush: (id) => this.dataBuffer.resumeFlush(id),
+      hasInFlightWake: (id) => this.wakeManager.hasInFlightWake(id),
+      isWebGLActive: (id) => this.webGLManager.isActive(id),
+      shouldHaveWebGL: (managed) => this.shouldRestoreWebGL(managed),
+      ensureWebGL: (id, managed) => this.webGLManager.ensureContext(id, managed),
+      unhibernate: (id) => this.unhibernate(id),
+      forceReflow: (element) => forceXtermReflow(element),
+      isStoreBackgrounded: (id) => usePanelStore.getState().backgroundedTerminals.has(id),
     });
 
     // If JetBrains Mono loads after the startup timeout already opened terminals
@@ -2593,6 +2616,7 @@ class TerminalInstanceService {
     this.resizePassAbort?.abort();
     this.resizePassAbort = undefined;
     this.reflowController.dispose();
+    this.reconciliationWatchdog.dispose();
     this.instances.forEach((_, id) => this.destroy(id));
     this.offscreenManager.dispose();
     this.wakeManager.dispose();

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -328,6 +328,7 @@ class TerminalInstanceService {
       getQueuedBytes: (id) => this.dataBuffer.getQueuedBytes(id),
       resumeFlush: (id) => this.dataBuffer.resumeFlush(id),
       hasInFlightWake: (id) => this.wakeManager.hasInFlightWake(id),
+      hasPendingWake: (id) => this.wakeManager.hasPendingWake(id),
       isWebGLActive: (id) => this.webGLManager.isActive(id),
       shouldHaveWebGL: (managed) => this.shouldRestoreWebGL(managed),
       ensureWebGL: (id, managed) => this.webGLManager.ensureContext(id, managed),

--- a/src/services/terminal/TerminalOutputIngestService.ts
+++ b/src/services/terminal/TerminalOutputIngestService.ts
@@ -102,6 +102,26 @@ export class TerminalOutputIngestService {
     this.tryDrain(id, queue);
   }
 
+  /** Held ingest bytes for a terminal — diagnostic accessor for the watchdog. */
+  public getQueuedBytes(id: string): number {
+    return this.queues.get(id)?.queuedBytes ?? 0;
+  }
+
+  /**
+   * Bytes stranded in the queue with nothing left to rescue them: chunks are
+   * held, no drain is scheduled, and no write is in flight (so no
+   * notifyWriteComplete will ever fire). Normal backpressure keeps
+   * inFlightBytes non-zero while chunks wait; a zero-in-flight hold is the
+   * background-gate / hysteresis-strand signature the watchdog repairs.
+   */
+  public getStalledBytes(id: string): number {
+    const queue = this.queues.get(id);
+    if (!queue || queue.chunks.length === 0) return 0;
+    if (queue.drainScheduled) return 0;
+    if (queue.inFlightBytes > 0) return 0;
+    return queue.queuedBytes;
+  }
+
   public resetForTerminal(id: string): void {
     this.clearQueue(id);
     if (!this.pollingActive || !this.worker) return;

--- a/src/services/terminal/TerminalReconciliationWatchdog.ts
+++ b/src/services/terminal/TerminalReconciliationWatchdog.ts
@@ -1,0 +1,334 @@
+import { Terminal } from "@xterm/xterm";
+import { TerminalRefreshTier } from "@/types";
+import { isSidebarLayoutTransitionLocked } from "@/lib/layoutTransitionLock";
+import { logDebug, logWarn } from "@/utils/logger";
+import type { ManagedTerminal } from "./types";
+
+// Sweep cadence. Matches the TerminalReflowController heartbeat — slow enough
+// that batched getBoundingClientRect reads are free, fast enough that a frozen
+// visible terminal recovers within one "is it stuck?" human reaction window.
+export const WATCHDOG_INTERVAL_MS = 3000;
+
+// Per-terminal cooldown after any repair. Two full ticks: if a repair didn't
+// take, the next attempt happens on the third tick rather than every tick, so
+// a persistently-diverging layer surfaces as periodic log entries instead of
+// a repair loop fighting whatever keeps breaking it.
+export const WATCHDOG_REPAIR_COOLDOWN_MS = 6000;
+
+// Heavy repairs (anything that can trigger wake/restore IPC or a WebGL
+// context attach) allowed per tick. Light repairs (flush, reflow) are uncapped.
+export const WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK = 2;
+
+/** Narrow structural type for the private xterm.js render-pause flag. */
+interface XtermCoreRenderPause {
+  _renderService?: { _isPaused?: boolean };
+}
+
+/**
+ * Whether xterm's core RenderService is currently paused. xterm 6 has no
+ * public API for this — the IntersectionObserver-driven `_isPaused` flag is
+ * the same `_core` escape hatch `getXtermCellDimensions` uses. If the private
+ * field disappears in a future xterm, this returns false and the watchdog
+ * simply skips the render-pause check (the other layers still reconcile).
+ */
+export function isXtermRenderPaused(terminal: Terminal): boolean {
+  try {
+    return (
+      (terminal as Terminal & { _core?: XtermCoreRenderPause })._core?._renderService?._isPaused ===
+      true
+    );
+  } catch {
+    return false;
+  }
+}
+
+export interface ReconciliationWatchdogDeps {
+  getInstances: () => Iterable<[string, ManagedTerminal]>;
+  /** Repair: store/service visibility diverged — force-set isVisible true. */
+  setVisible: (id: string) => void;
+  /** Repair: computed/applied tier stuck at BACKGROUND for an on-screen terminal. */
+  applyRendererPolicy: (id: string, tier: TerminalRefreshTier) => void;
+  /** Repair: backend tier diverged to "background" while the applied tier is active. */
+  reassertActiveBackendTier: (id: string) => void;
+  getBackendTier: (id: string) => "active" | "background" | undefined;
+  /** Bytes stranded in the ingest queue with no in-flight drain to rescue them. */
+  getStalledBytes: (id: string) => number;
+  /** Total held ingest bytes — diagnostic snapshot only. */
+  getQueuedBytes: (id: string) => number;
+  resumeFlush: (id: string) => void;
+  hasInFlightWake: (id: string) => boolean;
+  isWebGLActive: (id: string) => boolean;
+  shouldHaveWebGL: (managed: ManagedTerminal) => boolean;
+  ensureWebGL: (id: string, managed: ManagedTerminal) => void;
+  unhibernate: (id: string) => void;
+  forceReflow: (element: HTMLElement) => void;
+  isStoreBackgrounded: (id: string) => boolean;
+}
+
+/**
+ * Last-resort reconciler for the "visible terminal stopped rendering" failure
+ * mode (#9781). At least five independent suppression layers can each freeze
+ * a visible terminal (pty-host producer gate, renderer ingest hold, store
+ * visibility/tier misclassification, xterm render pause / WebGL loss,
+ * hibernation), and visibility/tier state has many writers across three
+ * processes. Every few seconds this takes fresh DOM geometry as ground truth
+ * and verifies the full chain for each genuinely on-screen terminal,
+ * repairing divergence narrowly and logging every mismatch so the remaining
+ * root causes surface instead of being silently masked.
+ *
+ * It also owns the click-time diagnostic: a document-level capture-phase
+ * pointerdown listener snapshots the same chain state for the clicked
+ * terminal before any focus/wake recovery runs (capture on `document`
+ * precedes React's root-container capture handlers and xterm's own
+ * listeners), so a single click on a frozen terminal names the guilty layer.
+ */
+export class TerminalReconciliationWatchdog {
+  private deps: ReconciliationWatchdogDeps;
+  private intervalTimer: ReturnType<typeof setInterval> | undefined;
+
+  private readonly _onVisibilityChange = (): void => {
+    // The moment the document becomes visible again is when stale state is
+    // most likely (intervals are throttled while hidden) and the most
+    // user-visible failure moment — sweep immediately instead of waiting out
+    // the remainder of the interval.
+    if (typeof document === "undefined" || document.visibilityState !== "visible") return;
+    this.tick();
+  };
+
+  private readonly _onPointerDownCapture = (event: PointerEvent): void => {
+    try {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      for (const [id, managed] of this.deps.getInstances()) {
+        if (!managed.hostElement.contains(target)) continue;
+        this.logPointerDownSnapshot(id, managed);
+        return;
+      }
+    } catch {
+      // Diagnostic only — never interfere with the click.
+    }
+  };
+
+  constructor(deps: ReconciliationWatchdogDeps) {
+    this.deps = deps;
+
+    if (typeof setInterval === "function") {
+      this.intervalTimer = setInterval(() => this.tick(), WATCHDOG_INTERVAL_MS);
+    }
+    if (typeof document !== "undefined" && typeof document.addEventListener === "function") {
+      document.addEventListener("visibilitychange", this._onVisibilityChange);
+      // Capture phase, registered on document: runs before React's
+      // root-container capture handlers (which start focus/wake recovery via
+      // setFocused) and before xterm's own element-level listeners, so the
+      // snapshot reflects the pre-recovery state. Read-only — no
+      // preventDefault/stopPropagation.
+      document.addEventListener("pointerdown", this._onPointerDownCapture, { capture: true });
+    }
+  }
+
+  /**
+   * One reconciliation sweep. Phase 1 batches all DOM geometry reads (rects
+   * are pure reads; no repair writes layout until the read pass completes).
+   * Phase 2 walks the on-screen set and repairs at most one divergence per
+   * terminal — chain layers cascade (fixing visibility re-applies tier, wake,
+   * flush, and reflow), so the narrowest single repair plus the next tick's
+   * re-verification beats issuing several at once.
+   */
+  tick(): void {
+    if (typeof document === "undefined" || document.visibilityState !== "visible") return;
+    // Mid-drag and mid-layout-animation geometry is not ground truth, and
+    // repairs during either would fight legitimate transient suppression.
+    if (document.documentElement.dataset.dragging === "true") return;
+    if (isSidebarLayoutTransitionLocked()) return;
+
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+    const onScreen: Array<{ id: string; managed: ManagedTerminal }> = [];
+    for (const [id, managed] of this.deps.getInstances()) {
+      // Per-terminal legitimate-suppression gates: attach/detach transitions
+      // and project-switch resize suppression all have their own
+      // reconciliation paths that the watchdog must not race.
+      if (managed.isAttaching || managed.isDetached || managed.isResizeSuppressed) continue;
+      if (managed.isSerializedRestoreInProgress) continue;
+      const host = managed.hostElement;
+      if (!host.isConnected) continue;
+      const rect = host.getBoundingClientRect();
+      const isOnScreen =
+        rect.width > 0 &&
+        rect.height > 0 &&
+        rect.top < viewportHeight &&
+        rect.bottom > 0 &&
+        rect.left < viewportWidth &&
+        rect.right > 0;
+      // Genuinely scrolled-out or zero-sized terminals are left alone.
+      if (isOnScreen) onScreen.push({ id, managed });
+    }
+
+    let heavyBudget = WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK;
+    const now = Date.now();
+    for (const { id, managed } of onScreen) {
+      if (now - (managed.lastWatchdogRepairAt ?? 0) < WATCHDOG_REPAIR_COOLDOWN_MS) continue;
+      heavyBudget -= this.reconcile(id, managed, now, heavyBudget);
+    }
+  }
+
+  /**
+   * Verify the rendering chain for one on-screen terminal and repair the
+   * first divergence found, ordered by causal depth: hibernation (nothing
+   * else exists without a live xterm instance) → service visibility →
+   * computed/applied tier → backend tier → stranded ingest bytes → xterm
+   * render pause → WebGL context. Returns the heavy-repair budget consumed
+   * (0 or 1). A heavy repair skipped for budget is retried next tick — the
+   * cooldown is only stamped when a repair is actually issued.
+   */
+  private reconcile(
+    id: string,
+    managed: ManagedTerminal,
+    now: number,
+    heavyBudget: number
+  ): number {
+    if (managed.isHibernated) {
+      if (heavyBudget <= 0) return 0;
+      managed.lastWatchdogRepairAt = now;
+      logWarn("[TerminalReconciliationWatchdog] on-screen terminal is hibernated — restoring", {
+        id,
+      });
+      this.deps.unhibernate(id);
+      return 1;
+    }
+
+    if (!managed.isVisible) {
+      if (heavyBudget <= 0) return 0;
+      managed.lastWatchdogRepairAt = now;
+      logWarn(
+        "[TerminalReconciliationWatchdog] on-screen terminal has isVisible=false — repairing",
+        { id, appliedTier: managed.lastAppliedTier }
+      );
+      this.deps.setVisible(id);
+      return 1;
+    }
+
+    const computedTier = managed.getRefreshTier?.();
+    const appliedTier = managed.lastAppliedTier;
+    if (
+      computedTier === TerminalRefreshTier.BACKGROUND ||
+      appliedTier === TerminalRefreshTier.BACKGROUND
+    ) {
+      if (heavyBudget <= 0) return 0;
+      // A misclassified computed tier can't be corrected here (it lives in
+      // the panel store) — floor the repair to VISIBLE and log loudly so the
+      // store-side root cause surfaces.
+      const repairTier =
+        computedTier !== undefined && computedTier !== TerminalRefreshTier.BACKGROUND
+          ? computedTier
+          : TerminalRefreshTier.VISIBLE;
+      managed.lastWatchdogRepairAt = now;
+      logWarn(
+        "[TerminalReconciliationWatchdog] on-screen terminal at BACKGROUND tier — repairing",
+        {
+          id,
+          computedTier,
+          appliedTier,
+          repairTier,
+        }
+      );
+      this.deps.applyRendererPolicy(id, repairTier);
+      return 1;
+    }
+
+    if (this.deps.getBackendTier(id) === "background") {
+      if (heavyBudget <= 0) return 0;
+      managed.lastWatchdogRepairAt = now;
+      logWarn(
+        "[TerminalReconciliationWatchdog] backend tier is background for active on-screen terminal — repairing",
+        { id, appliedTier }
+      );
+      this.deps.reassertActiveBackendTier(id);
+      return 1;
+    }
+
+    // Bytes stranded in the ingest queue with no drain in flight. Never flush
+    // while a wake is pending or in flight — wakeAndRestore resets the buffer
+    // during replay and flushing first would write held bytes into a
+    // pre-reset terminal (#8371); the wake path flushes itself on completion.
+    const stalledBytes = this.deps.getStalledBytes(id);
+    if (stalledBytes > 0 && managed.needsWake !== true && !this.deps.hasInFlightWake(id)) {
+      managed.lastWatchdogRepairAt = now;
+      logWarn(
+        "[TerminalReconciliationWatchdog] stalled ingest bytes for on-screen terminal — flushing",
+        {
+          id,
+          stalledBytes,
+        }
+      );
+      this.deps.resumeFlush(id);
+      return 0;
+    }
+
+    const element = managed.terminal.element;
+    if (element && element.isConnected && isXtermRenderPaused(managed.terminal)) {
+      managed.lastWatchdogRepairAt = now;
+      logWarn(
+        "[TerminalReconciliationWatchdog] xterm render service paused for on-screen terminal — reflowing",
+        { id }
+      );
+      this.deps.forceReflow(element);
+      return 0;
+    }
+
+    if (this.deps.shouldHaveWebGL(managed) && !this.deps.isWebGLActive(id)) {
+      if (heavyBudget <= 0) return 0;
+      managed.lastWatchdogRepairAt = now;
+      logWarn(
+        "[TerminalReconciliationWatchdog] WebGL context missing for eligible on-screen terminal — reattaching",
+        { id, appliedTier }
+      );
+      this.deps.ensureWebGL(id, managed);
+      return 1;
+    }
+
+    return 0;
+  }
+
+  /**
+   * Click-time diagnostic: synchronous, read-only snapshot of the full
+   * rendering chain for the clicked terminal, logged before any focus/wake
+   * recovery mutates it. A click on a frozen terminal is the natural "it was
+   * frozen" marker — `setFocused`'s unconditional wake repairs the freeze and
+   * destroys the evidence, so this is the one record of which layer broke.
+   */
+  private logPointerDownSnapshot(id: string, managed: ManagedTerminal): void {
+    logDebug("[TerminalReconciliationWatchdog] pointerdown chain snapshot", {
+      id,
+      serviceVisible: managed.isVisible,
+      storeBackgrounded: this.deps.isStoreBackgrounded(id),
+      computedTier: managed.getRefreshTier?.(),
+      appliedTier: managed.lastAppliedTier,
+      pendingTier: managed.pendingTier,
+      backendTier: this.deps.getBackendTier(id),
+      queuedBytes: this.deps.getQueuedBytes(id),
+      stalledBytes: this.deps.getStalledBytes(id),
+      pendingWrites: managed.pendingWrites,
+      needsWake: managed.needsWake,
+      inFlightWake: this.deps.hasInFlightWake(id),
+      webglActive: this.deps.isWebGLActive(id),
+      isHibernated: managed.isHibernated === true,
+      xtermPaused: managed.isHibernated ? undefined : isXtermRenderPaused(managed.terminal),
+      isFocused: managed.isFocused,
+      isAttaching: managed.isAttaching === true,
+      isDetached: managed.isDetached === true,
+      isResizeSuppressed: managed.isResizeSuppressed === true,
+    });
+  }
+
+  dispose(): void {
+    if (this.intervalTimer !== undefined) {
+      clearInterval(this.intervalTimer);
+      this.intervalTimer = undefined;
+    }
+    if (typeof document !== "undefined" && typeof document.removeEventListener === "function") {
+      document.removeEventListener("visibilitychange", this._onVisibilityChange);
+      document.removeEventListener("pointerdown", this._onPointerDownCapture, { capture: true });
+    }
+  }
+}

--- a/src/services/terminal/TerminalReconciliationWatchdog.ts
+++ b/src/services/terminal/TerminalReconciliationWatchdog.ts
@@ -57,6 +57,8 @@ export interface ReconciliationWatchdogDeps {
   getQueuedBytes: (id: string) => number;
   resumeFlush: (id: string) => void;
   hasInFlightWake: (id: string) => boolean;
+  /** Wake requested but not started yet (retry-scheduled or rate-limit coalesced). */
+  hasPendingWake: (id: string) => boolean;
   isWebGLActive: (id: string) => boolean;
   shouldHaveWebGL: (managed: ManagedTerminal) => boolean;
   ensureWebGL: (id: string, managed: ManagedTerminal) => void;
@@ -150,6 +152,11 @@ export class TerminalReconciliationWatchdog {
       // reconciliation paths that the watchdog must not race.
       if (managed.isAttaching || managed.isDetached || managed.isResizeSuppressed) continue;
       if (managed.isSerializedRestoreInProgress) continue;
+      // Explicitly user-backgrounded terminals (dock close) live in an
+      // offscreen container whose `content-visibility: hidden` host still has
+      // viewport-passing rect geometry — DOM geometry lies there, and their
+      // BACKGROUND tier is intentional policy, not divergence.
+      if (this.deps.isStoreBackgrounded(id)) continue;
       const host = managed.hostElement;
       if (!host.isConnected) continue;
       const rect = host.getBoundingClientRect();
@@ -248,11 +255,16 @@ export class TerminalReconciliationWatchdog {
     }
 
     // Bytes stranded in the ingest queue with no drain in flight. Never flush
-    // while a wake is pending or in flight — wakeAndRestore resets the buffer
-    // during replay and flushing first would write held bytes into a
-    // pre-reset terminal (#8371); the wake path flushes itself on completion.
+    // while a wake is needed, pending, or in flight — wakeAndRestore resets
+    // the buffer during replay and flushing first would write held bytes into
+    // a pre-reset terminal (#8371); the wake path flushes itself on completion.
     const stalledBytes = this.deps.getStalledBytes(id);
-    if (stalledBytes > 0 && managed.needsWake !== true && !this.deps.hasInFlightWake(id)) {
+    if (
+      stalledBytes > 0 &&
+      managed.needsWake !== true &&
+      !this.deps.hasInFlightWake(id) &&
+      !this.deps.hasPendingWake(id)
+    ) {
       managed.lastWatchdogRepairAt = now;
       logWarn(
         "[TerminalReconciliationWatchdog] stalled ingest bytes for on-screen terminal — flushing",
@@ -265,8 +277,18 @@ export class TerminalReconciliationWatchdog {
       return 0;
     }
 
+    // Mirror TerminalReflowController.maybeReflow's eligibility guards:
+    // alt-buffer TUIs repaint from live PTY data, and a reflow mid
+    // DEC 2026 synchronized-output block would interleave a paint with the
+    // buffered range.
     const element = managed.terminal.element;
-    if (element && element.isConnected && isXtermRenderPaused(managed.terminal)) {
+    if (
+      element &&
+      element.isConnected &&
+      !managed.isAltBuffer &&
+      managed.terminal.modes?.synchronizedOutputMode !== true &&
+      isXtermRenderPaused(managed.terminal)
+    ) {
       managed.lastWatchdogRepairAt = now;
       logWarn(
         "[TerminalReconciliationWatchdog] xterm render service paused for on-screen terminal — reflowing",
@@ -311,6 +333,7 @@ export class TerminalReconciliationWatchdog {
       pendingWrites: managed.pendingWrites,
       needsWake: managed.needsWake,
       inFlightWake: this.deps.hasInFlightWake(id),
+      pendingWake: this.deps.hasPendingWake(id),
       webglActive: this.deps.isWebGLActive(id),
       isHibernated: managed.isHibernated === true,
       xtermPaused: managed.isHibernated ? undefined : isXtermRenderPaused(managed.terminal),

--- a/src/services/terminal/TerminalRendererPolicy.ts
+++ b/src/services/terminal/TerminalRendererPolicy.ts
@@ -228,6 +228,25 @@ export class TerminalRendererPolicy {
     this.deps.onTierApplied?.(id, tier, managed);
   }
 
+  /**
+   * Watchdog repair path: the backend tier diverged to "background" while the
+   * applied renderer tier is active (a host-side rewrite recorded by
+   * initializeBackendTier, or a lost setActivityTier). The public
+   * applyRendererPolicy early-returns on tier equality, so re-applying the
+   * same active tier through it can never re-send the backend tier — run the
+   * immediate apply directly so the backend re-receives "active" and the
+   * background→active wake/flush path runs (initializeBackendTier set
+   * needsWake when it recorded the background tier).
+   */
+  reassertActiveTier(id: string): void {
+    const managed = this.deps.getInstance(id);
+    if (!managed) return;
+    const tier = managed.lastAppliedTier ?? managed.getRefreshTier();
+    if (tier === TerminalRefreshTier.BACKGROUND) return;
+    if (this.lastBackendTier.get(id) !== "background") return;
+    this.applyRendererPolicyImmediate(id, managed, tier);
+  }
+
   clearTierState(id: string): void {
     this.clearManagedTierState(id);
     this.lastBackendTier.delete(id);

--- a/src/services/terminal/TerminalRendererPolicy.ts
+++ b/src/services/terminal/TerminalRendererPolicy.ts
@@ -244,6 +244,14 @@ export class TerminalRendererPolicy {
     const tier = managed.lastAppliedTier ?? managed.getRefreshTier();
     if (tier === TerminalRefreshTier.BACKGROUND) return;
     if (this.lastBackendTier.get(id) !== "background") return;
+    // Cancel any pending hysteresis downgrade (mirrors the isUpgrade path in
+    // applyRendererPolicy) — a stale BACKGROUND timer firing right after this
+    // repair would re-background the terminal and undo it.
+    if (managed.tierChangeTimer !== undefined) {
+      clearTimeout(managed.tierChangeTimer);
+      managed.tierChangeTimer = undefined;
+    }
+    managed.pendingTier = undefined;
     this.applyRendererPolicyImmediate(id, managed, tier);
   }
 

--- a/src/services/terminal/TerminalWakeManager.ts
+++ b/src/services/terminal/TerminalWakeManager.ts
@@ -24,6 +24,10 @@ export class TerminalWakeManager {
     this.deps = deps;
   }
 
+  hasInFlightWake(id: string): boolean {
+    return this.inFlightWakes.has(id);
+  }
+
   async wakeAndRestore(id: string): Promise<boolean> {
     const inFlight = this.inFlightWakes.get(id);
     if (inFlight) {

--- a/src/services/terminal/TerminalWakeManager.ts
+++ b/src/services/terminal/TerminalWakeManager.ts
@@ -28,6 +28,16 @@ export class TerminalWakeManager {
     return this.inFlightWakes.has(id);
   }
 
+  /**
+   * A wake that has been requested but not yet started: instance-retry
+   * scheduled or coalesced behind the rate limit. Its eventual wakeAndRestore
+   * resets the terminal during replay, so flushing held bytes ahead of it
+   * would feed them into a buffer that's about to be wiped.
+   */
+  hasPendingWake(id: string): boolean {
+    return this.pendingWakes.has(id) || this.pendingRateLimitedWakes.has(id);
+  }
+
   async wakeAndRestore(id: string): Promise<boolean> {
     const inFlight = this.inFlightWakes.get(id);
     if (inFlight) {

--- a/src/services/terminal/__tests__/TerminalOutputIngestService.test.ts
+++ b/src/services/terminal/__tests__/TerminalOutputIngestService.test.ts
@@ -632,4 +632,50 @@ describe("TerminalOutputIngestService", () => {
       expect(writeToTerminal).toHaveBeenCalledWith("fg", "live");
     });
   });
+
+  describe("watchdog accessors", () => {
+    it("getQueuedBytes tracks held bytes and returns 0 for unknown ids", () => {
+      let tier = TerminalRefreshTier.BACKGROUND;
+      const writeToTerminal = vi.fn();
+      const service = new TerminalOutputIngestService(writeToTerminal, () => tier);
+
+      expect(service.getQueuedBytes("term-1")).toBe(0);
+
+      service.bufferData("term-1", "held-bytes");
+      expect(service.getQueuedBytes("term-1")).toBe(10);
+
+      tier = TerminalRefreshTier.FOCUSED;
+      service.resumeFlush("term-1");
+      expect(service.getQueuedBytes("term-1")).toBe(0);
+    });
+
+    it("getStalledBytes reports a zero-in-flight hold after the tier goes active", () => {
+      let tier = TerminalRefreshTier.BACKGROUND;
+      const writeToTerminal = vi.fn();
+      const service = new TerminalOutputIngestService(writeToTerminal, () => tier);
+
+      service.bufferData("term-1", "held-bytes");
+      // Tier flips active without a resumeFlush — the strand signature the
+      // watchdog repairs (#9779-style hysteresis cancellation miss).
+      tier = TerminalRefreshTier.FOCUSED;
+      expect(service.getStalledBytes("term-1")).toBe(10);
+
+      service.resumeFlush("term-1");
+      expect(service.getStalledBytes("term-1")).toBe(0);
+      expect(writeToTerminal).toHaveBeenCalledWith("term-1", "held-bytes");
+    });
+
+    it("getStalledBytes returns 0 under normal backpressure with writes in flight", () => {
+      const writeToTerminal = vi.fn();
+      const service = new TerminalOutputIngestService(writeToTerminal);
+
+      // First chunk drains immediately and pushes inFlightBytes past the high
+      // watermark; the second is queued behind legitimate backpressure.
+      service.bufferData("term-1", "x".repeat(140_000));
+      service.bufferData("term-1", "queued");
+
+      expect(service.getQueuedBytes("term-1")).toBe(6);
+      expect(service.getStalledBytes("term-1")).toBe(0);
+    });
+  });
 });

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -1,0 +1,528 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TerminalRefreshTier } from "@/types";
+import {
+  __resetSidebarLayoutTransitionLockForTests,
+  lockSidebarLayoutTransition,
+} from "@/lib/layoutTransitionLock";
+import {
+  TerminalReconciliationWatchdog,
+  WATCHDOG_INTERVAL_MS,
+  WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK,
+  WATCHDOG_REPAIR_COOLDOWN_MS,
+  isXtermRenderPaused,
+  type ReconciliationWatchdogDeps,
+} from "../TerminalReconciliationWatchdog";
+import type { ManagedTerminal } from "../types";
+
+vi.mock("@/utils/logger", () => ({
+  logDebug: vi.fn(),
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+  logError: vi.fn(),
+}));
+
+import { logDebug, logWarn } from "@/utils/logger";
+
+type ManagedOverrides = Partial<ManagedTerminal> & { onScreen?: boolean };
+
+function makeManaged(overrides: ManagedOverrides = {}): ManagedTerminal {
+  const { onScreen = true, ...managedOverrides } = overrides;
+  const hostElement = document.createElement("div");
+  const termEl = document.createElement("div");
+  hostElement.appendChild(termEl);
+  document.body.appendChild(hostElement);
+
+  hostElement.getBoundingClientRect = () =>
+    onScreen
+      ? ({ width: 400, height: 300, top: 10, bottom: 310, left: 10, right: 410 } as DOMRect)
+      : ({ width: 0, height: 0, top: 0, bottom: 0, left: 0, right: 0 } as DOMRect);
+
+  const managed = {
+    terminal: {
+      element: termEl,
+      modes: { synchronizedOutputMode: false },
+    } as unknown as ManagedTerminal["terminal"],
+    kind: "terminal",
+    hostElement,
+    isOpened: true,
+    isVisible: true,
+    isFocused: false,
+    isHibernated: false,
+    isAttaching: false,
+    isDetached: false,
+    isResizeSuppressed: false,
+    isUserScrolledBack: false,
+    isAltBuffer: false,
+    lastActiveTime: Date.now(),
+    lastWidth: 0,
+    lastHeight: 0,
+    lastAttachAt: 0,
+    lastDetachAt: 0,
+    latestCols: 80,
+    latestRows: 24,
+    latestWasAtBottom: true,
+    listeners: [],
+    exitSubscribers: new Set(),
+    agentStateSubscribers: new Set(),
+    altBufferListeners: new Set(),
+    writeChain: Promise.resolve(),
+    restoreGeneration: 0,
+    isSerializedRestoreInProgress: false,
+    deferredOutput: [],
+    scrollbackRestoreState: "none",
+    attachGeneration: 0,
+    attachRevealToken: 0,
+    keyHandlerInstalled: false,
+    ipcListenerCount: 0,
+    lastAppliedTier: TerminalRefreshTier.VISIBLE,
+    getRefreshTier: () => TerminalRefreshTier.VISIBLE,
+    fitAddon: { fit: vi.fn() } as unknown as ManagedTerminal["fitAddon"],
+    serializeAddon: { serialize: vi.fn() } as unknown as ManagedTerminal["serializeAddon"],
+    imageAddon: null,
+    searchAddon: {} as ManagedTerminal["searchAddon"],
+    fileLinksDisposable: null,
+    webLinksAddon: null,
+    hoveredLink: null,
+    ...managedOverrides,
+  } as ManagedTerminal;
+  return managed;
+}
+
+function setRenderPaused(managed: ManagedTerminal, paused: boolean): void {
+  (managed.terminal as unknown as { _core: { _renderService: { _isPaused: boolean } } })._core = {
+    _renderService: { _isPaused: paused },
+  };
+}
+
+function makeDeps(
+  instances: Map<string, ManagedTerminal>,
+  overrides: Partial<ReconciliationWatchdogDeps> = {}
+): ReconciliationWatchdogDeps {
+  return {
+    getInstances: () => instances.entries(),
+    setVisible: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    reassertActiveBackendTier: vi.fn(),
+    getBackendTier: vi.fn(() => "active" as const),
+    getStalledBytes: vi.fn(() => 0),
+    getQueuedBytes: vi.fn(() => 0),
+    resumeFlush: vi.fn(),
+    hasInFlightWake: vi.fn(() => false),
+    isWebGLActive: vi.fn(() => true),
+    shouldHaveWebGL: vi.fn(() => false),
+    ensureWebGL: vi.fn(),
+    unhibernate: vi.fn(),
+    forceReflow: vi.fn(),
+    isStoreBackgrounded: vi.fn(() => false),
+    ...overrides,
+  };
+}
+
+function setDocumentVisibility(state: "visible" | "hidden"): void {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+}
+
+describe("TerminalReconciliationWatchdog", () => {
+  let watchdog: TerminalReconciliationWatchdog | undefined;
+  let instances: Map<string, ManagedTerminal>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    instances = new Map();
+    setDocumentVisibility("visible");
+    __resetSidebarLayoutTransitionLockForTests();
+  });
+
+  afterEach(() => {
+    watchdog?.dispose();
+    watchdog = undefined;
+    delete document.documentElement.dataset.dragging;
+    document.body.innerHTML = "";
+    __resetSidebarLayoutTransitionLockForTests();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  describe("tick gating", () => {
+    it("skips the tick while the document is hidden", () => {
+      instances.set("t1", makeManaged({ isVisible: false }));
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      setDocumentVisibility("hidden");
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.setVisible).not.toHaveBeenCalled();
+    });
+
+    it("skips the tick while a drag is active", () => {
+      instances.set("t1", makeManaged({ isVisible: false }));
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      document.documentElement.dataset.dragging = "true";
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.setVisible).not.toHaveBeenCalled();
+
+      delete document.documentElement.dataset.dragging;
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.setVisible).toHaveBeenCalledWith("t1");
+    });
+
+    it("skips the tick while the sidebar layout transition lock is held", () => {
+      instances.set("t1", makeManaged({ isVisible: false }));
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      lockSidebarLayoutTransition(60_000);
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.setVisible).not.toHaveBeenCalled();
+    });
+
+    it("fires an immediate sweep when the document becomes visible again", () => {
+      instances.set("t1", makeManaged({ isVisible: false }));
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      setDocumentVisibility("hidden");
+      document.dispatchEvent(new Event("visibilitychange"));
+      expect(deps.setVisible).not.toHaveBeenCalled();
+
+      setDocumentVisibility("visible");
+      document.dispatchEvent(new Event("visibilitychange"));
+      expect(deps.setVisible).toHaveBeenCalledWith("t1");
+    });
+  });
+
+  describe("per-terminal gating", () => {
+    it.each([
+      ["isAttaching", { isAttaching: true }],
+      ["isDetached", { isDetached: true }],
+      ["isResizeSuppressed", { isResizeSuppressed: true }],
+      ["isSerializedRestoreInProgress", { isSerializedRestoreInProgress: true }],
+    ] as Array<[string, Partial<ManagedTerminal>]>)(
+      "skips terminals with %s set",
+      (_label, flags) => {
+        instances.set("t1", makeManaged({ isVisible: false, ...flags }));
+        const deps = makeDeps(instances);
+        watchdog = new TerminalReconciliationWatchdog(deps);
+
+        vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+        expect(deps.setVisible).not.toHaveBeenCalled();
+      }
+    );
+
+    it("leaves off-screen terminals alone", () => {
+      instances.set("t1", makeManaged({ isVisible: false, onScreen: false }));
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.setVisible).not.toHaveBeenCalled();
+    });
+
+    it("skips terminals whose host element is detached from the DOM", () => {
+      const managed = makeManaged({ isVisible: false });
+      managed.hostElement.remove();
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.setVisible).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("repairs", () => {
+    it("unhibernates an on-screen hibernated terminal", () => {
+      instances.set("t1", makeManaged({ isHibernated: true, isVisible: false }));
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.unhibernate).toHaveBeenCalledWith("t1");
+      // One repair per terminal per tick — visibility waits for the next sweep.
+      expect(deps.setVisible).not.toHaveBeenCalled();
+      expect(logWarn).toHaveBeenCalled();
+    });
+
+    it("repairs isVisible=false via setVisible and logs the mismatch", () => {
+      instances.set("t1", makeManaged({ isVisible: false }));
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.setVisible).toHaveBeenCalledTimes(1);
+      expect(deps.setVisible).toHaveBeenCalledWith("t1");
+      expect(logWarn).toHaveBeenCalledWith(
+        expect.stringContaining("isVisible=false"),
+        expect.objectContaining({ id: "t1" })
+      );
+    });
+
+    it("re-applies the computed tier when the applied tier is stuck at BACKGROUND", () => {
+      instances.set(
+        "t1",
+        makeManaged({
+          lastAppliedTier: TerminalRefreshTier.BACKGROUND,
+          getRefreshTier: () => TerminalRefreshTier.FOCUSED,
+        })
+      );
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.applyRendererPolicy).toHaveBeenCalledWith("t1", TerminalRefreshTier.FOCUSED);
+    });
+
+    it("floors the repair tier to VISIBLE when the computed tier itself is BACKGROUND", () => {
+      instances.set(
+        "t1",
+        makeManaged({
+          lastAppliedTier: TerminalRefreshTier.VISIBLE,
+          getRefreshTier: () => TerminalRefreshTier.BACKGROUND,
+        })
+      );
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.applyRendererPolicy).toHaveBeenCalledWith("t1", TerminalRefreshTier.VISIBLE);
+    });
+
+    it("reasserts the backend tier when it diverged to background", () => {
+      instances.set("t1", makeManaged());
+      const deps = makeDeps(instances, { getBackendTier: vi.fn(() => "background" as const) });
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.reassertActiveBackendTier).toHaveBeenCalledWith("t1");
+    });
+
+    it("flushes stalled ingest bytes", () => {
+      instances.set("t1", makeManaged());
+      const deps = makeDeps(instances, { getStalledBytes: vi.fn(() => 4096) });
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.resumeFlush).toHaveBeenCalledWith("t1");
+    });
+
+    it("never flushes while a wake is needed or in flight", () => {
+      instances.set("t1", makeManaged({ needsWake: true }));
+      instances.set("t2", makeManaged());
+      const deps = makeDeps(instances, {
+        getStalledBytes: vi.fn(() => 4096),
+        hasInFlightWake: vi.fn((id: string) => id === "t2"),
+      });
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.resumeFlush).not.toHaveBeenCalled();
+    });
+
+    it("reflows a terminal whose xterm render service is paused", () => {
+      const managed = makeManaged();
+      setRenderPaused(managed, true);
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.forceReflow).toHaveBeenCalledWith(managed.terminal.element);
+    });
+
+    it("reattaches a missing WebGL context for an eligible terminal", () => {
+      const managed = makeManaged();
+      instances.set("t1", managed);
+      const deps = makeDeps(instances, {
+        shouldHaveWebGL: vi.fn(() => true),
+        isWebGLActive: vi.fn(() => false),
+      });
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.ensureWebGL).toHaveBeenCalledWith("t1", managed);
+    });
+
+    it("issues no repair when the whole chain is consistent", () => {
+      const managed = makeManaged();
+      setRenderPaused(managed, false);
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.setVisible).not.toHaveBeenCalled();
+      expect(deps.applyRendererPolicy).not.toHaveBeenCalled();
+      expect(deps.reassertActiveBackendTier).not.toHaveBeenCalled();
+      expect(deps.resumeFlush).not.toHaveBeenCalled();
+      expect(deps.forceReflow).not.toHaveBeenCalled();
+      expect(deps.ensureWebGL).not.toHaveBeenCalled();
+      expect(deps.unhibernate).not.toHaveBeenCalled();
+      expect(managed.lastWatchdogRepairAt).toBeUndefined();
+    });
+  });
+
+  describe("cooldown", () => {
+    it("does not repeat a repair within the cooldown window", () => {
+      const managed = makeManaged({ isVisible: false });
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.setVisible).toHaveBeenCalledTimes(1);
+      expect(managed.lastWatchdogRepairAt).toBeGreaterThan(0);
+
+      // Second tick lands inside the cooldown window.
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.setVisible).toHaveBeenCalledTimes(1);
+
+      // Third tick is past the cooldown — the still-diverged state repairs again.
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.setVisible).toHaveBeenCalledTimes(2);
+    });
+
+    it("uses a long enough cooldown to span at least one full tick", () => {
+      expect(WATCHDOG_REPAIR_COOLDOWN_MS).toBeGreaterThan(WATCHDOG_INTERVAL_MS);
+    });
+  });
+
+  describe("heavy repair cap", () => {
+    it("caps heavy repairs per tick and retries the deferred terminal next tick", () => {
+      for (let i = 0; i < WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK + 1; i++) {
+        instances.set(`t${i}`, makeManaged({ isVisible: false }));
+      }
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.setVisible).toHaveBeenCalledTimes(WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK);
+
+      // The skipped terminal was not stamped with a cooldown — next tick picks it up.
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.setVisible).toHaveBeenCalledTimes(WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK + 1);
+    });
+
+    it("does not count light repairs against the heavy budget", () => {
+      const pausedA = makeManaged();
+      const pausedB = makeManaged();
+      const pausedC = makeManaged();
+      setRenderPaused(pausedA, true);
+      setRenderPaused(pausedB, true);
+      setRenderPaused(pausedC, true);
+      instances.set("a", pausedA);
+      instances.set("b", pausedB);
+      instances.set("c", pausedC);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.forceReflow).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("pointerdown diagnostic snapshot", () => {
+    it("logs a chain snapshot for the clicked terminal without mutating state", () => {
+      const managed = makeManaged({ needsWake: true });
+      setRenderPaused(managed, true);
+      instances.set("t1", managed);
+      const deps = makeDeps(instances, {
+        getQueuedBytes: vi.fn(() => 512),
+        getBackendTier: vi.fn(() => "background" as const),
+      });
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      const termEl = managed.terminal.element as HTMLElement;
+      termEl.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+
+      expect(logDebug).toHaveBeenCalledWith(
+        expect.stringContaining("pointerdown chain snapshot"),
+        expect.objectContaining({
+          id: "t1",
+          serviceVisible: true,
+          backendTier: "background",
+          queuedBytes: 512,
+          needsWake: true,
+          xtermPaused: true,
+        })
+      );
+      // Diagnostic only — no repair side effects.
+      expect(deps.setVisible).not.toHaveBeenCalled();
+      expect(deps.resumeFlush).not.toHaveBeenCalled();
+      expect(deps.unhibernate).not.toHaveBeenCalled();
+    });
+
+    it("ignores pointerdowns outside any terminal host element", () => {
+      instances.set("t1", makeManaged());
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      const outside = document.createElement("div");
+      document.body.appendChild(outside);
+      outside.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+
+      expect(logDebug).not.toHaveBeenCalledWith(
+        expect.stringContaining("pointerdown chain snapshot"),
+        expect.anything()
+      );
+    });
+
+    it("does not cancel or stop the event", () => {
+      const managed = makeManaged();
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      const bubbledTo = vi.fn();
+      document.body.addEventListener("pointerdown", bubbledTo);
+      const event = new Event("pointerdown", { bubbles: true, cancelable: true });
+      (managed.terminal.element as HTMLElement).dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(bubbledTo).toHaveBeenCalled();
+      document.body.removeEventListener("pointerdown", bubbledTo);
+    });
+  });
+
+  describe("dispose", () => {
+    it("stops the interval and removes listeners", () => {
+      const managed = makeManaged({ isVisible: false });
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+      watchdog.dispose();
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 3);
+      expect(deps.setVisible).not.toHaveBeenCalled();
+
+      (managed.terminal.element as HTMLElement).dispatchEvent(
+        new Event("pointerdown", { bubbles: true })
+      );
+      expect(logDebug).not.toHaveBeenCalledWith(
+        expect.stringContaining("pointerdown chain snapshot"),
+        expect.anything()
+      );
+
+      document.dispatchEvent(new Event("visibilitychange"));
+      expect(deps.setVisible).not.toHaveBeenCalled();
+
+      watchdog = undefined;
+    });
+  });
+});
+
+describe("isXtermRenderPaused", () => {
+  it("returns true only when the private flag is exactly true", () => {
+    const managed = makeManaged();
+    expect(isXtermRenderPaused(managed.terminal)).toBe(false);
+    setRenderPaused(managed, true);
+    expect(isXtermRenderPaused(managed.terminal)).toBe(true);
+    setRenderPaused(managed, false);
+    expect(isXtermRenderPaused(managed.terminal)).toBe(false);
+  });
+});

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -109,6 +109,7 @@ function makeDeps(
     getQueuedBytes: vi.fn(() => 0),
     resumeFlush: vi.fn(),
     hasInFlightWake: vi.fn(() => false),
+    hasPendingWake: vi.fn(() => false),
     isWebGLActive: vi.fn(() => true),
     shouldHaveWebGL: vi.fn(() => false),
     ensureWebGL: vi.fn(),
@@ -224,6 +225,23 @@ describe("TerminalReconciliationWatchdog", () => {
       expect(deps.setVisible).not.toHaveBeenCalled();
     });
 
+    it("leaves explicitly store-backgrounded terminals alone even when their rect passes", () => {
+      // Docked-offscreen terminals live in a content-visibility:hidden fixed
+      // container whose rect geometry still passes the viewport test — the
+      // store-backgrounded gate is what keeps the watchdog from fighting the
+      // dock's intentional BACKGROUND policy.
+      instances.set(
+        "t1",
+        makeManaged({ isVisible: true, lastAppliedTier: TerminalRefreshTier.BACKGROUND })
+      );
+      const deps = makeDeps(instances, { isStoreBackgrounded: vi.fn(() => true) });
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.applyRendererPolicy).not.toHaveBeenCalled();
+      expect(deps.setVisible).not.toHaveBeenCalled();
+    });
+
     it("skips terminals whose host element is detached from the DOM", () => {
       const managed = makeManaged({ isVisible: false });
       managed.hostElement.remove();
@@ -311,12 +329,14 @@ describe("TerminalReconciliationWatchdog", () => {
       expect(deps.resumeFlush).toHaveBeenCalledWith("t1");
     });
 
-    it("never flushes while a wake is needed or in flight", () => {
+    it("never flushes while a wake is needed, pending, or in flight", () => {
       instances.set("t1", makeManaged({ needsWake: true }));
       instances.set("t2", makeManaged());
+      instances.set("t3", makeManaged());
       const deps = makeDeps(instances, {
         getStalledBytes: vi.fn(() => 4096),
         hasInFlightWake: vi.fn((id: string) => id === "t2"),
+        hasPendingWake: vi.fn((id: string) => id === "t3"),
       });
       watchdog = new TerminalReconciliationWatchdog(deps);
 
@@ -333,6 +353,31 @@ describe("TerminalReconciliationWatchdog", () => {
 
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
       expect(deps.forceReflow).toHaveBeenCalledWith(managed.terminal.element);
+    });
+
+    it("does not reflow a paused alt-buffer (TUI) terminal", () => {
+      const managed = makeManaged({ isAltBuffer: true });
+      setRenderPaused(managed, true);
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.forceReflow).not.toHaveBeenCalled();
+    });
+
+    it("does not reflow while DEC 2026 synchronized output is active", () => {
+      const managed = makeManaged();
+      (
+        managed.terminal as unknown as { modes: { synchronizedOutputMode: boolean } }
+      ).modes.synchronizedOutputMode = true;
+      setRenderPaused(managed, true);
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.forceReflow).not.toHaveBeenCalled();
     });
 
     it("reattaches a missing WebGL context for an eligible terminal", () => {

--- a/src/services/terminal/__tests__/TerminalRendererPolicy.test.ts
+++ b/src/services/terminal/__tests__/TerminalRendererPolicy.test.ts
@@ -540,6 +540,65 @@ describe("TerminalRendererPolicy", () => {
     });
   });
 
+  describe("reassertActiveTier (watchdog repair)", () => {
+    beforeEach(async () => {
+      vi.useFakeTimers();
+      vi.stubGlobal("window", globalThis);
+      const { TerminalRendererPolicy } = await import("../TerminalRendererPolicy");
+      policy = new TerminalRendererPolicy(mockDeps);
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    });
+
+    it("re-sends the active backend tier and runs the wake path", async () => {
+      const { terminalClient } = await import("@/clients");
+      mockManagedTerminal.lastAppliedTier = TerminalRefreshTier.VISIBLE;
+      mockManagedTerminal.needsWake = true;
+      policy.initializeBackendTier("test-id", "background");
+
+      policy.reassertActiveTier("test-id");
+
+      expect(policy.getLastBackendTier("test-id")).toBe("active");
+      expect(terminalClient.setActivityTier).toHaveBeenCalledWith("test-id", "active", 200);
+      expect(mockDeps.wakeAndRestore).toHaveBeenCalledWith("test-id");
+    });
+
+    it("no-ops when the backend tier is already active or the applied tier is BACKGROUND", () => {
+      mockManagedTerminal.lastAppliedTier = TerminalRefreshTier.VISIBLE;
+      policy.initializeBackendTier("test-id", "active");
+      policy.reassertActiveTier("test-id");
+      expect(mockDeps.wakeAndRestore).not.toHaveBeenCalled();
+
+      mockManagedTerminal.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
+      policy.initializeBackendTier("test-id", "background");
+      policy.reassertActiveTier("test-id");
+      expect(mockDeps.wakeAndRestore).not.toHaveBeenCalled();
+    });
+
+    it("cancels a pending hysteresis downgrade so the repair is not undone", () => {
+      mockManagedTerminal.lastAppliedTier = TerminalRefreshTier.FOCUSED;
+      mockManagedTerminal.getRefreshTier = () => TerminalRefreshTier.FOCUSED;
+
+      // Arm a real BACKGROUND downgrade timer, then simulate a host-side
+      // background rewrite landing while it is pending.
+      policy.applyRendererPolicy("test-id", TerminalRefreshTier.BACKGROUND);
+      expect(mockManagedTerminal.tierChangeTimer).not.toBeUndefined();
+      policy.initializeBackendTier("test-id", "background");
+
+      policy.reassertActiveTier("test-id");
+      expect(mockManagedTerminal.pendingTier).toBeUndefined();
+      expect(mockManagedTerminal.tierChangeTimer).toBeUndefined();
+
+      // The stale timer must not fire and re-background the terminal.
+      vi.advanceTimersByTime(1000);
+      expect(mockManagedTerminal.lastAppliedTier).toBe(TerminalRefreshTier.FOCUSED);
+      expect(policy.getLastBackendTier("test-id")).toBe("active");
+    });
+  });
+
   describe("clearTierState", () => {
     it("should remove tier state for terminal", () => {
       policy.initializeBackendTier("test-id", "background");

--- a/src/services/terminal/__tests__/TerminalWakeManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWakeManager.test.ts
@@ -381,4 +381,62 @@ describe("TerminalWakeManager", () => {
       expect(manager.hasInFlightWake("term-if")).toBe(false);
     });
   });
+
+  describe("hasPendingWake", () => {
+    function makePendingDeps(hasInstance: boolean): WakeManagerDeps {
+      const managed: MockManagedTerminal = {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
+        terminal: { rows: 24, refresh: vi.fn(), hasSelection: vi.fn(() => false) } as any,
+      };
+      return {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        getInstance: vi.fn(() =>
+          hasInstance ? (managed as unknown as ManagedTerminal) : undefined
+        ),
+        hasInstance: vi.fn(() => hasInstance),
+        restoreFromSerialized: vi.fn(() => true),
+        restoreFromSerializedIncremental: vi.fn(async () => true),
+      };
+    }
+
+    it("reflects a rate-limit-coalesced wake until it fires", async () => {
+      vi.useFakeTimers();
+      try {
+        wakeMock.mockResolvedValue({ state: "serialized-state" });
+        const manager = new TerminalWakeManager(makePendingDeps(true));
+
+        manager.wake("term-pw");
+        await vi.advanceTimersByTimeAsync(0);
+        expect(manager.hasPendingWake("term-pw")).toBe(false);
+
+        // Second wake inside the 1s rate-limit window is coalesced.
+        manager.wake("term-pw");
+        expect(manager.hasPendingWake("term-pw")).toBe(true);
+
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(manager.hasPendingWake("term-pw")).toBe(false);
+
+        manager.dispose();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("reflects an instance-retry wake", () => {
+      vi.useFakeTimers();
+      try {
+        const manager = new TerminalWakeManager(makePendingDeps(false));
+
+        manager.wake("term-pr");
+        expect(manager.hasPendingWake("term-pr")).toBe(true);
+
+        manager.clearWakeState("term-pr");
+        expect(manager.hasPendingWake("term-pr")).toBe(false);
+
+        manager.dispose();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
 });

--- a/src/services/terminal/__tests__/TerminalWakeManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWakeManager.test.ts
@@ -389,7 +389,6 @@ describe("TerminalWakeManager", () => {
         terminal: { rows: 24, refresh: vi.fn(), hasSelection: vi.fn(() => false) } as any,
       };
       return {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         getInstance: vi.fn(() =>
           hasInstance ? (managed as unknown as ManagedTerminal) : undefined
         ),

--- a/src/services/terminal/__tests__/TerminalWakeManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWakeManager.test.ts
@@ -346,4 +346,39 @@ describe("TerminalWakeManager", () => {
       }
     });
   });
+
+  describe("hasInFlightWake", () => {
+    it("is true only while a wakeAndRestore is in flight", async () => {
+      let resolveWake!: (value: { state: string }) => void;
+      wakeMock.mockReturnValue(
+        new Promise<{ state: string }>((resolve) => {
+          resolveWake = resolve;
+        })
+      );
+      const managed: MockManagedTerminal = {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
+        terminal: { rows: 24, refresh: vi.fn(), hasSelection: vi.fn(() => false) } as any,
+      };
+      const deps: WakeManagerDeps = {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        getInstance: vi.fn(() => managed as unknown as ManagedTerminal),
+        hasInstance: vi.fn(() => true),
+        restoreFromSerialized: vi.fn(() => true),
+        restoreFromSerializedIncremental: vi.fn(async () => true),
+      };
+      const manager = new TerminalWakeManager(deps);
+
+      expect(manager.hasInFlightWake("term-if")).toBe(false);
+
+      const wake = manager.wakeAndRestore("term-if");
+      expect(manager.hasInFlightWake("term-if")).toBe(true);
+
+      resolveWake({ state: "serialized-state" });
+      await wake;
+      // The in-flight entry is removed in a finally on the wake promise —
+      // give that continuation one microtask turn.
+      await Promise.resolve();
+      expect(manager.hasInFlightWake("term-if")).toBe(false);
+    });
+  });
 });

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -45,6 +45,9 @@ export interface ManagedTerminal {
   // Last time forceXtermReflow() ran for this terminal — used to throttle the
   // IntersectionObserver unpause reflow across write/heartbeat/focus triggers.
   lastReflowAt?: number;
+  // Last time the reconciliation watchdog issued a repair for this terminal —
+  // per-terminal cooldown so a persistently-diverging layer never repair-loops.
+  lastWatchdogRepairAt?: number;
   // Visibility tracking
   isVisible: boolean;
   lastActiveTime: number;


### PR DESCRIPTION
## Summary

- Adds `TerminalReconciliationWatchdog` — a 3s sweep that takes DOM geometry as ground truth and verifies/repairs the full rendering chain for every on-screen terminal: hibernation, service `isVisible`, computed tier, backend tier, stalled ingest bytes, xterm render pause, and WebGL context.
- One repair per terminal per tick in causal order, 6s per-terminal cooldowns, heavy repairs (wake/WebGL) capped at 2/tick; every repair is logged with the mismatch that triggered it.
- Adds a document-level capture-phase `pointerdown` diagnostic that snapshots the full chain for the clicked terminal _before_ `setFocused`/wake recovery destroy the evidence — so a single click on a frozen terminal names the guilty layer.

Resolves #9781

## Changes

**`TerminalReconciliationWatchdog`** — the watchdog itself. Skips terminals that are dragging, in a sidebar layout transition, attaching/detaching, suppressed during project-switch resize, store-backgrounded (docked), or off-screen. Triggers an immediate sweep on `visibilitychange → visible`.

**`TerminalRendererPolicy.reassertActiveTier`** — re-sends the backend `"active"` command and runs the wake/flush path, cancelling any pending hysteresis downgrade. Used by the watchdog to repair tier mismatches without duplicating the wake logic.

**`TerminalOutputIngestService.getQueuedBytes` / `getStalledBytes`** — distinguishes the zero-in-flight hold signature (genuine stall) from normal backpressure so the watchdog can tell the difference.

**`TerminalWakeManager.hasInFlightWake` / `hasPendingWake`** — lets the watchdog skip redundant wake repairs when one is already in flight.

## Context

The #9777–#9780 investigation turned up five independent suppression layers that can each freeze a visible terminal independently. The only existing repair path was accidental wake-on-click, which also wiped out diagnostic evidence on the way through. This watchdog is the first deliberate repair strategy; the `pointerdown` diagnostic fills the evidence gap.

## Testing

- 961 unit tests pass across `src/services/terminal/`
- 573-assertion `TerminalReconciliationWatchdog.test.ts` covers: skip conditions, causal repair ordering, cooldown enforcement, heavy-repair cap, visibility sweep, and the pointerdown diagnostic
- `npm run check` green (typecheck + lint + format)