### PR TITLE
refactor(toolbar): unify status pips on a shared geometry class

### DIFF
--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -362,15 +362,11 @@ export function AgentButton({
       <BrandMark brandColor={toolbarBrandColor}>
         <config.icon brandColor={toolbarBrandColor} />
       </BrandMark>
-      {isSessionActive && dotColor && (
-        <span
-          className={cn(
-            "absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-1 ring-daintree-sidebar",
-            dotColor
-          )}
-          aria-hidden="true"
-        />
-      )}
+      <span
+        className={cn("toolbar-pip toolbar-badge", dotColor)}
+        data-visible={!!(isSessionActive && dotColor)}
+        aria-hidden="true"
+      />
     </div>
   );
 

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -139,13 +139,10 @@ function buildAgentRow(
 
 function RunningDot({ state }: { state: AgentState | null }) {
   const color = state ? agentStateDotColor(state) : null;
-  if (!color) return null;
   return (
     <span
-      className={cn(
-        "absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-1 ring-daintree-sidebar",
-        color
-      )}
+      className={cn("toolbar-pip toolbar-badge", color)}
+      data-visible={!!color}
       aria-hidden="true"
     />
   );

--- a/src/components/Layout/ToolbarAssistantButton.tsx
+++ b/src/components/Layout/ToolbarAssistantButton.tsx
@@ -164,28 +164,21 @@ export function ToolbarAssistantButton({
         >
           <div className="relative">
             <DaintreeIcon />
-            {pip ? (
-              <span
-                aria-hidden="true"
-                className={cn(
-                  "absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-1 ring-daintree-sidebar",
-                  pip.className,
-                  pip.delayed && "animate-pulse-delayed"
-                )}
-              />
-            ) : (
-              showAgentPip && (
-                <span
-                  aria-hidden="true"
-                  data-testid="assistant-working-pip"
-                  data-agent-state={agentState ?? ""}
-                  className={cn(
-                    "absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-1 ring-daintree-sidebar",
-                    agentPip!.className
-                  )}
-                />
-              )
-            )}
+            {/* One always-in-DOM pip; data-visible drives the @starting-style
+                enter/exit on .toolbar-badge. Precedence (MCP pip > agent pip)
+                stays in component logic — the className resolves to the winning
+                pip's color, with the pulse only on the delayed MCP state. */}
+            <span
+              aria-hidden="true"
+              data-testid="assistant-working-pip"
+              data-agent-state={agentState ?? ""}
+              data-visible={pip !== null || showAgentPip}
+              className={cn(
+                "toolbar-pip toolbar-badge",
+                pip?.className ?? agentPip?.className,
+                pip?.delayed && "animate-pulse-delayed"
+              )}
+            />
           </div>
         </Button>
       </TooltipTrigger>

--- a/src/components/Layout/ToolbarAssistantButton.tsx
+++ b/src/components/Layout/ToolbarAssistantButton.tsx
@@ -175,7 +175,7 @@ export function ToolbarAssistantButton({
               data-visible={pip !== null || showAgentPip}
               className={cn(
                 "toolbar-pip toolbar-badge",
-                pip?.className ?? agentPip?.className,
+                pip?.className ?? (showAgentPip ? agentPip?.className : undefined),
                 pip?.delayed && "animate-pulse-delayed"
               )}
             />

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -910,10 +910,11 @@ describe("AgentButton preset UX", () => {
       );
 
       const badge = container.querySelector('.relative span[aria-hidden="true"]');
-      expect(badge).not.toBeNull();
+      expect(badge?.getAttribute("data-visible")).toBe("true");
+      expect(badge!.className).toMatch(/bg-state-waiting/);
     });
 
-    it("does not render the badge span when the helper returns null (passive state)", () => {
+    it("hides the badge span when the helper returns null (passive state)", () => {
       mockSettings = settingsWith({ claude: {} });
       mockPanelsById = { "panel-1": activePanel("working") };
       mockPanelIds = ["panel-1"];
@@ -927,10 +928,10 @@ describe("AgentButton preset UX", () => {
       );
 
       const badge = container.querySelector('.relative span[aria-hidden="true"]');
-      expect(badge).toBeNull();
+      expect(badge?.getAttribute("data-visible")).toBe("false");
     });
 
-    it("does not render the badge span when there is no active session", () => {
+    it("hides the badge span when there is no active session", () => {
       mockSettings = settingsWith({ claude: {} });
       mockDominantState = null;
       mockDotColor = "bg-state-waiting";
@@ -940,7 +941,7 @@ describe("AgentButton preset UX", () => {
       );
 
       const badge = container.querySelector('.relative span[aria-hidden="true"]');
-      expect(badge).toBeNull();
+      expect(badge?.getAttribute("data-visible")).toBe("false");
     });
 
     it("propagates the 'waiting' state word to the launch tooltip and aria-label (issue #9823)", () => {

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -1400,19 +1400,16 @@ describe("AgentTrayButton", () => {
         const availability = arrangeClaudePanel(state);
         const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
         const row = getByTestId("agent-tray-row-claude");
-        expect(badgeIn(row)).not.toBeNull();
+        expect(badgeIn(row)?.getAttribute("data-visible")).toBe("true");
       }
     );
 
-    it.each([["working"], ["idle"]] as const)(
-      "does not render the badge for passive state %s",
-      (state) => {
-        const availability = arrangeClaudePanel(state);
-        const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
-        const row = getByTestId("agent-tray-row-claude");
-        expect(badgeIn(row)).toBeNull();
-      }
-    );
+    it.each([["working"], ["idle"]] as const)("hides the badge for passive state %s", (state) => {
+      const availability = arrangeClaudePanel(state);
+      const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+      const row = getByTestId("agent-tray-row-claude");
+      expect(badgeIn(row)?.getAttribute("data-visible")).toBe("false");
+    });
 
     // `completed` and `exited` are excluded from ACTIVE_AGENT_STATES, so the
     // panel never enters the dominant-state aggregation in the first place;
@@ -1420,22 +1417,22 @@ describe("AgentTrayButton", () => {
     // here so the consumer-level contract ("no badge for passive states") is
     // tested end-to-end regardless of which guard fires.
     it.each([["completed"], ["exited"]] as const)(
-      "does not render the badge for terminal state %s",
+      "hides the badge for terminal state %s",
       (state) => {
         const availability = arrangeClaudePanel(state);
         const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
         const row = getByTestId("agent-tray-row-claude");
-        expect(badgeIn(row)).toBeNull();
+        expect(badgeIn(row)?.getAttribute("data-visible")).toBe("false");
       }
     );
 
-    it("does not render the badge when there is no active session", () => {
+    it("hides the badge when there is no active session", () => {
       const availability = { claude: "ready" } as unknown as CliAvailability;
       mockSettings = settingsWith({ claude: { pinned: false } });
 
       const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
       const row = getByTestId("agent-tray-row-claude");
-      expect(badgeIn(row)).toBeNull();
+      expect(badgeIn(row)?.getAttribute("data-visible")).toBe("false");
     });
   });
 

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -1394,15 +1394,17 @@ describe("AgentTrayButton", () => {
       return row.querySelector('span.relative span[aria-hidden="true"]');
     }
 
-    it.each([["waiting"], ["directing"]] as const)(
-      "renders the badge for actionable state %s",
-      (state) => {
-        const availability = arrangeClaudePanel(state);
-        const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
-        const row = getByTestId("agent-tray-row-claude");
-        expect(badgeIn(row)?.getAttribute("data-visible")).toBe("true");
-      }
-    );
+    it.each([
+      ["waiting", /bg-state-waiting/],
+      ["directing", /bg-state-working/],
+    ] as const)("renders the badge for actionable state %s", (state, colorPattern) => {
+      const availability = arrangeClaudePanel(state);
+      const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+      const row = getByTestId("agent-tray-row-claude");
+      const badge = badgeIn(row);
+      expect(badge?.getAttribute("data-visible")).toBe("true");
+      expect(badge?.className).toMatch(colorPattern);
+    });
 
     it.each([["working"], ["idle"]] as const)("hides the badge for passive state %s", (state) => {
       const availability = arrangeClaudePanel(state);

--- a/src/components/Layout/__tests__/ToolbarAssistantButton.test.tsx
+++ b/src/components/Layout/__tests__/ToolbarAssistantButton.test.tsx
@@ -117,7 +117,7 @@ describe("ToolbarAssistantButton — agent state pip", () => {
     setPanel("t-1", "idle");
 
     const { queryByTestId } = render(<ToolbarAssistantButton />);
-    expect(queryByTestId("assistant-working-pip")).toBeNull();
+    expect(queryByTestId("assistant-working-pip")?.getAttribute("data-visible")).toBe("false");
   });
 
   it("renders a green pip when the assistant terminal's agentState is working", () => {
@@ -126,7 +126,7 @@ describe("ToolbarAssistantButton — agent state pip", () => {
 
     const { queryByTestId } = render(<ToolbarAssistantButton />);
     const pip = queryByTestId("assistant-working-pip");
-    expect(pip).not.toBeNull();
+    expect(pip?.getAttribute("data-visible")).toBe("true");
     expect(pip!.className).toMatch(/bg-state-working/);
     expect(pip!.className).not.toMatch(/animate-pulse/);
     expect(pip!.className).not.toMatch(/accent/);
@@ -140,7 +140,7 @@ describe("ToolbarAssistantButton — agent state pip", () => {
 
     const { queryByTestId, container } = render(<ToolbarAssistantButton />);
     const pip = queryByTestId("assistant-working-pip");
-    expect(pip).not.toBeNull();
+    expect(pip?.getAttribute("data-visible")).toBe("true");
     expect(pip!.className).toMatch(/bg-state-working/);
     expect(pip!.getAttribute("data-agent-state")).toBe("directing");
     // Coarse-signal design: directing intentionally surfaces as "working" in
@@ -157,7 +157,7 @@ describe("ToolbarAssistantButton — agent state pip", () => {
 
     const { queryByTestId } = render(<ToolbarAssistantButton />);
     const pip = queryByTestId("assistant-working-pip");
-    expect(pip).not.toBeNull();
+    expect(pip?.getAttribute("data-visible")).toBe("true");
     expect(pip!.className).toMatch(/bg-state-waiting/);
     expect(pip!.className).not.toMatch(/animate-pulse/);
     expect(pip!.getAttribute("data-agent-state")).toBe("waiting");
@@ -167,20 +167,20 @@ describe("ToolbarAssistantButton — agent state pip", () => {
     setHelpPanel({ isOpen: false, terminalId: "t-c" });
     setPanel("t-c", "completed");
     const { queryByTestId, rerender } = render(<ToolbarAssistantButton />);
-    expect(queryByTestId("assistant-working-pip")).toBeNull();
+    expect(queryByTestId("assistant-working-pip")?.getAttribute("data-visible")).toBe("false");
 
     act(() => {
       setPanel("t-c", "exited");
     });
     rerender(<ToolbarAssistantButton />);
-    expect(queryByTestId("assistant-working-pip")).toBeNull();
+    expect(queryByTestId("assistant-working-pip")?.getAttribute("data-visible")).toBe("false");
   });
 
   it("does not render the pip when there is no assistant terminal", () => {
     setHelpPanel({ isOpen: false, terminalId: null });
 
     const { queryByTestId } = render(<ToolbarAssistantButton />);
-    expect(queryByTestId("assistant-working-pip")).toBeNull();
+    expect(queryByTestId("assistant-working-pip")?.getAttribute("data-visible")).toBe("false");
   });
 
   it("hides the pip when the panel is open (the user can already see the state)", () => {
@@ -188,7 +188,7 @@ describe("ToolbarAssistantButton — agent state pip", () => {
     setPanel("t-3", "working");
 
     const { queryByTestId } = render(<ToolbarAssistantButton />);
-    expect(queryByTestId("assistant-working-pip")).toBeNull();
+    expect(queryByTestId("assistant-working-pip")?.getAttribute("data-visible")).toBe("false");
   });
 
   it("hides the pip when the panel is open even for waiting state", () => {
@@ -196,7 +196,7 @@ describe("ToolbarAssistantButton — agent state pip", () => {
     setPanel("t-3w", "waiting");
 
     const { queryByTestId } = render(<ToolbarAssistantButton />);
-    expect(queryByTestId("assistant-working-pip")).toBeNull();
+    expect(queryByTestId("assistant-working-pip")?.getAttribute("data-visible")).toBe("false");
   });
 
   it("MCP-health failed pip takes precedence over the agent pip when both would apply", () => {
@@ -209,7 +209,10 @@ describe("ToolbarAssistantButton — agent state pip", () => {
     setPanel("t-4", "working");
 
     const { container, queryByTestId } = render(<ToolbarAssistantButton />);
-    expect(queryByTestId("assistant-working-pip")).toBeNull();
+    const pip = queryByTestId("assistant-working-pip");
+    expect(pip?.getAttribute("data-visible")).toBe("true");
+    expect(pip!.className).toMatch(/bg-status-danger/);
+    expect(pip!.className).not.toMatch(/bg-state-/);
     expect(container.querySelector(".bg-status-danger")).not.toBeNull();
   });
 
@@ -223,7 +226,12 @@ describe("ToolbarAssistantButton — agent state pip", () => {
     setPanel("t-4w", "waiting");
 
     const { container, queryByTestId } = render(<ToolbarAssistantButton />);
-    expect(queryByTestId("assistant-working-pip")).toBeNull();
+    const pip = queryByTestId("assistant-working-pip");
+    expect(pip?.getAttribute("data-visible")).toBe("true");
+    expect(pip!.className).toMatch(/bg-status-warning/);
+    // `starting` is the delayed (pulsing) MCP state — preserved through the
+    // always-in-DOM conversion.
+    expect(pip!.className).toMatch(/animate-pulse-delayed/);
     expect(container.querySelector(".bg-status-warning")).not.toBeNull();
   });
 
@@ -238,13 +246,13 @@ describe("ToolbarAssistantButton — agent state pip", () => {
     act(() => {
       useHelpPanelStore.setState({ isOpen: true });
     });
-    expect(queryByTestId("assistant-working-pip")).toBeNull();
+    expect(queryByTestId("assistant-working-pip")?.getAttribute("data-visible")).toBe("false");
 
     // Closing without a state change leaves the pip suppressed.
     act(() => {
       useHelpPanelStore.setState({ isOpen: false });
     });
-    expect(queryByTestId("assistant-working-pip")).toBeNull();
+    expect(queryByTestId("assistant-working-pip")?.getAttribute("data-visible")).toBe("false");
   });
 
   it("re-shows the pip after acknowledgement when the agent state changes again", () => {
@@ -254,13 +262,13 @@ describe("ToolbarAssistantButton — agent state pip", () => {
     const { queryByTestId } = render(<ToolbarAssistantButton />);
     act(() => useHelpPanelStore.setState({ isOpen: true }));
     act(() => useHelpPanelStore.setState({ isOpen: false }));
-    expect(queryByTestId("assistant-working-pip")).toBeNull();
+    expect(queryByTestId("assistant-working-pip")?.getAttribute("data-visible")).toBe("false");
 
     act(() => {
       setPanel("t-ack2", "waiting");
     });
     const pip = queryByTestId("assistant-working-pip");
-    expect(pip).not.toBeNull();
+    expect(pip?.getAttribute("data-visible")).toBe("true");
     expect(pip!.className).toMatch(/bg-state-waiting/);
   });
 
@@ -272,7 +280,7 @@ describe("ToolbarAssistantButton — agent state pip", () => {
     // Acknowledge "waiting" on the old terminal.
     act(() => useHelpPanelStore.setState({ isOpen: true }));
     act(() => useHelpPanelStore.setState({ isOpen: false }));
-    expect(queryByTestId("assistant-working-pip")).toBeNull();
+    expect(queryByTestId("assistant-working-pip")?.getAttribute("data-visible")).toBe("false");
 
     // Respawn: a brand-new assistant terminal lands on the same state value.
     // The user has not seen *this* session, so the pip should fire.
@@ -281,7 +289,7 @@ describe("ToolbarAssistantButton — agent state pip", () => {
       useHelpPanelStore.setState({ terminalId: "t-new" });
     });
     const pip = queryByTestId("assistant-working-pip");
-    expect(pip).not.toBeNull();
+    expect(pip?.getAttribute("data-visible")).toBe("true");
     expect(pip!.className).toMatch(/bg-state-waiting/);
   });
 
@@ -290,7 +298,7 @@ describe("ToolbarAssistantButton — agent state pip", () => {
     setPanel("t-ack3", "working");
 
     const { queryByTestId } = render(<ToolbarAssistantButton />);
-    expect(queryByTestId("assistant-working-pip")).toBeNull();
+    expect(queryByTestId("assistant-working-pip")?.getAttribute("data-visible")).toBe("false");
 
     // State changes while panel is open — user can already see it via the
     // panel header, so closing afterwards must not flash the pip.
@@ -300,7 +308,7 @@ describe("ToolbarAssistantButton — agent state pip", () => {
     act(() => {
       useHelpPanelStore.setState({ isOpen: false });
     });
-    expect(queryByTestId("assistant-working-pip")).toBeNull();
+    expect(queryByTestId("assistant-working-pip")?.getAttribute("data-visible")).toBe("false");
   });
 
   describe("gesture-hidden desync", () => {
@@ -349,7 +357,7 @@ describe("ToolbarAssistantButton — agent state pip", () => {
 
       const { queryByTestId } = render(<ToolbarAssistantButton />);
       const pip = queryByTestId("assistant-working-pip");
-      expect(pip).not.toBeNull();
+      expect(pip?.getAttribute("data-visible")).toBe("true");
       expect(pip!.className).toMatch(/bg-state-working/);
 
       // Agent transitions while gesture-hidden — pip tracks the new state
@@ -358,7 +366,7 @@ describe("ToolbarAssistantButton — agent state pip", () => {
         setPanel("t-gh-3", "waiting");
       });
       const pip2 = queryByTestId("assistant-working-pip");
-      expect(pip2).not.toBeNull();
+      expect(pip2?.getAttribute("data-visible")).toBe("true");
       expect(pip2!.className).toMatch(/bg-state-waiting/);
     });
 
@@ -405,7 +413,7 @@ describe("ToolbarAssistantButton — agent state pip", () => {
 
     const { queryByTestId } = render(<ToolbarAssistantButton />);
     let pip = queryByTestId("assistant-working-pip");
-    expect(pip).not.toBeNull();
+    expect(pip?.getAttribute("data-visible")).toBe("true");
     expect(pip!.className).toMatch(/bg-state-working/);
 
     act(() => {
@@ -413,13 +421,13 @@ describe("ToolbarAssistantButton — agent state pip", () => {
     });
 
     pip = queryByTestId("assistant-working-pip");
-    expect(pip).not.toBeNull();
+    expect(pip?.getAttribute("data-visible")).toBe("true");
     expect(pip!.className).toMatch(/bg-state-waiting/);
 
     act(() => {
       setPanel("t-5", "idle");
     });
 
-    expect(queryByTestId("assistant-working-pip")).toBeNull();
+    expect(queryByTestId("assistant-working-pip")?.getAttribute("data-visible")).toBe("false");
   });
 });

--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -359,6 +359,25 @@
  *    reinforces a high-signal indicator instead of adding ring noise.
  */
 
+/* ── Shared pip geometry ──
+ * The semantic-status pips (AssistantButton MCP/agent pips, AgentButton and
+ * AgentTrayButton running-state pips) all float at the same corner offset with
+ * the same 6px circle and sidebar-colored ring cut-out. This class owns that
+ * geometry so render sites stop re-typing the literals; it carries no color and
+ * no visibility — color comes from a per-surface class, visibility/motion from
+ * .toolbar-badge. No forced-colors entry is needed here (no background-color of
+ * its own); the composed .toolbar-badge already covers that. The ring matches
+ * `ring-1 ring-daintree-sidebar`. */
+.toolbar-pip {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  height: 6px;
+  width: 6px;
+  border-radius: 9999px;
+  box-shadow: 0 0 0 1px var(--color-daintree-sidebar);
+}
+
 /* ── Badge entrance / exit ──
  * Tier 2 timing from animationUtils.ts: 200ms enter (UI_ENTER_DURATION),
  * 120ms exit (UI_EXIT_DURATION). @starting-style + allow-discrete handle


### PR DESCRIPTION
## Summary

- Extracts repeated pip geometry literals (`absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-1 ring-daintree-sidebar`) into a single `.toolbar-pip` class in `src/styles/components/toolbar.css` (geometry + ring only; no color, no visibility).
- Three outlier pips in `ToolbarAssistantButton`, `AgentButton`, and `AgentTrayButton` were conditionally mounted/unmounted, so they snapped in and out with no transition. Converts them to always-in-DOM elements driven by `data-visible`, so they animate via the existing `.toolbar-badge` `@starting-style` transitions.
- Pip precedence (MCP health wins over agent activity) stays in component logic. `forced-colors` is handled by composing `.toolbar-badge`, which already has the `forced-colors` block.

Resolves #9818

## Changes

- `src/styles/components/toolbar.css` — new `.toolbar-pip` class for shared geometry; `forced-colors` coverage comes from the composed `.toolbar-badge`
- `src/components/Layout/ToolbarAssistantButton.tsx` — MCP-health + agent-activity pips collapsed into one always-in-DOM `span`; visibility driven by `data-visible`
- `src/components/Layout/AgentButton.tsx` — running dot converted from conditional mount to `data-visible`
- `src/components/Layout/AgentTrayButton.tsx` — `RunningDot` helper updated to always-in-DOM with `data-visible`
- Tests updated to assert `data-visible` state rather than mount/unmount presence

## Testing

141 targeted tests pass. `npm run check` clean. Verified pip transitions animate in/out consistently with the rest of the toolbar badge vocabulary.