### PR TITLE
fix(terminal): clamp negative DOM-renderer letter-spacing for emoji

### DIFF
--- a/e2e/full/terminal/core-terminal-panels.spec.ts
+++ b/e2e/full/terminal/core-terminal-panels.spec.ts
@@ -132,6 +132,41 @@ test.describe.serial("Core: Terminal & Panels", () => {
       await expect.poll(() => getGridPanelCount(window), { timeout: T_MEDIUM }).toBe(1);
     });
 
+    // Regression: xterm #5893 / #9812. The DOM renderer emits negative inline
+    // letter-spacing on emoji spans (OffscreenCanvas mismeasures them); our
+    // src/index.css override clamps only those to 0 while sparing positive
+    // corrections and spans outside .xterm-rows. Inject probe spans and read the
+    // computed cascade synchronously so re-renders can't race the assertion.
+    test("clamps negative letter-spacing only inside xterm rows", async () => {
+      const { window } = ctx;
+      const rows = window.locator(".xterm-rows").first();
+      await expect(rows).toBeVisible({ timeout: T_MEDIUM });
+
+      const computed = await rows.evaluate((rowsEl) => {
+        const make = (parent: Element, value: string) => {
+          const span = document.createElement("span");
+          span.style.letterSpacing = value;
+          span.textContent = "x";
+          parent.appendChild(span);
+          const result = getComputedStyle(span).letterSpacing;
+          parent.removeChild(span);
+          return result;
+        };
+        return {
+          negativeInside: make(rowsEl, "-5.5px"),
+          positiveInside: make(rowsEl, "0.5px"),
+          negativeOutside: make(document.body, "-5.5px"),
+        };
+      });
+
+      // Broken emoji spans get clamped to the container baseline (0).
+      expect(computed.negativeInside).toBe("0px");
+      // Legitimate positive corrections (e.g. wide CJK) are untouched.
+      expect(computed.positiveInside).toBe("0.5px");
+      // The override is scoped to .xterm-rows and leaves the rest of the app alone.
+      expect(computed.negativeOutside).toBe("-5.5px");
+    });
+
     test("rename terminal by editing title", async () => {
       const { window } = ctx;
 

--- a/src/index.css
+++ b/src/index.css
@@ -888,9 +888,13 @@ code.hljs {
 
   /* Mitigate xterm #5893 / #9812: the DOM renderer applies negative inline
      letter-spacing to emoji spans because OffscreenCanvas.measureText mismeasures
-     them. Clamp to 0 (container default); author !important wins over the inline
-     style at the same origin. Assumes Chromium serializes `letter-spacing: -Npx`
-     with a space. Remove when on @xterm/xterm >=7.0.0. */
+     them. Author !important wins over the inline style at the same origin. We clamp
+     to 0 rather than `initial` because Daintree sets letterSpacing: 0 (xtermConfig.ts),
+     so the .xterm-rows baseline is ~0px. Only negative values are matched: positive
+     corrections for wide glyphs (CJK) are measured correctly and left alone; sub-pixel
+     bleed from clamping a rare legitimate negative correction beats the multi-px emoji
+     collapse. Assumes Chromium serializes `letter-spacing: -Npx` with a space. Remove
+     when on @xterm/xterm >=7.0.0. */
   .xterm-rows span[style*="letter-spacing: -"] {
     letter-spacing: 0 !important;
   }

--- a/src/index.css
+++ b/src/index.css
@@ -886,6 +886,15 @@ code.hljs {
     display: none;
   }
 
+  /* Mitigate xterm #5893 / #9812: the DOM renderer applies negative inline
+     letter-spacing to emoji spans because OffscreenCanvas.measureText mismeasures
+     them. Clamp to 0 (container default); author !important wins over the inline
+     style at the same origin. Assumes Chromium serializes `letter-spacing: -Npx`
+     with a space. Remove when on @xterm/xterm >=7.0.0. */
+  .xterm-rows span[style*="letter-spacing: -"] {
+    letter-spacing: 0 !important;
+  }
+
   /* Consistent monospace font stack */
   code,
   kbd,


### PR DESCRIPTION
## Summary

- Adds a CSS override in `src/index.css` that clamps negative inline `letter-spacing` to `0` on `.xterm-rows span` elements — mitigating upstream xterm.js [#5893](https://github.com/xtermjs/xterm.js/issues/5893), where `OffscreenCanvas.measureText` mismeasures emoji and grapheme clusters, causing the DOM renderer to collapse them horizontally
- The selector targets negative values only, so legitimate positive corrections (e.g. CJK/wide chars) are left alone; `!important` beats xterm's same-origin inline `style.letterSpacing`
- Adds an E2E regression test in `core-terminal-panels.spec.ts` verifying the cascade: negative spacing inside `.xterm-rows` is clamped to `0`, positive spacing is untouched, and negative spacing outside `.xterm-rows` is unaffected

Resolves #9812

## Changes

- `src/index.css` — negative `letter-spacing` clamp rule under `.xterm-rows span`
- `e2e/full/terminal/core-terminal-panels.spec.ts` — cascade regression test for the xterm #5893 fix

## Testing

E2E regression test added that directly verifies the CSS cascade rule. The DOM renderer path is exercised above the 12-terminal WebGL threshold (`upperThreshold` in `TerminalWebGLConfig.ts`); the fix applies to any `letter-spacing` value set inline on `.xterm-rows span` elements by xterm's DOM renderer.