### PR TITLE
feat(browser): group and frame controls in the browser/dev-preview toolbar

### DIFF
--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -729,7 +729,15 @@ export function BrowserToolbar({
                     aria-checked={isSelected}
                     aria-label={preset.label}
                     data-viewport-preset-id={preset.id}
-                    tabIndex={isSelected || chipFocusedIndex === index ? 0 : -1}
+                    tabIndex={
+                      chipFocusedIndex >= 0
+                        ? chipFocusedIndex === index
+                          ? 0
+                          : -1
+                        : isSelected
+                          ? 0
+                          : -1
+                    }
                     onClick={() => {
                       if (!isSelected) onViewportPresetChange(preset.id);
                     }}
@@ -748,7 +756,7 @@ export function BrowserToolbar({
           )}
           {viewportPreset && (
             <>
-              <div aria-hidden="true" className="toolbar-divider w-px h-5" />
+              <div aria-hidden="true" className="toolbar-divider w-px h-5 shrink-0" />
               <div className="flex items-center gap-1">
                 {onViewportRotateToggle && (
                   <Tooltip>
@@ -965,7 +973,7 @@ export function BrowserToolbar({
       </div>
 
       {/* Action buttons */}
-      <div aria-hidden="true" className="toolbar-divider w-px h-5" />
+      <div aria-hidden="true" className="toolbar-divider w-px h-5 shrink-0" />
       <Tooltip>
         <TooltipTrigger asChild>
           <button type="button" onClick={handleCopy} className={buttonClass} aria-label="Copy URL">
@@ -986,7 +994,10 @@ export function BrowserToolbar({
               type="button"
               onClick={onCaptureScreenshot}
               disabled={!isWebviewReady}
-              className={cn(buttonClass, "disabled:hover:bg-transparent")}
+              className={cn(
+                buttonClass,
+                "disabled:hover:bg-transparent disabled:hover:shadow-none"
+              )}
               aria-label="Capture screenshot"
             >
               <Camera className="w-4 h-4" />
@@ -1022,7 +1033,10 @@ export function BrowserToolbar({
               type="button"
               onClick={onToggleDevTools}
               disabled={!isWebviewReady}
-              className={cn(buttonClass, "disabled:hover:bg-transparent")}
+              className={cn(
+                buttonClass,
+                "disabled:hover:bg-transparent disabled:hover:shadow-none"
+              )}
               aria-label="Toggle DevTools"
             >
               <Code className="w-4 h-4" />
@@ -1051,7 +1065,12 @@ export function BrowserToolbar({
 
       <Tooltip>
         <TooltipTrigger asChild>
-          <button type="button" onClick={onOpenExternal} className={buttonClass}>
+          <button
+            type="button"
+            onClick={onOpenExternal}
+            className={buttonClass}
+            aria-label="Open in browser"
+          >
             <ExternalLink className="w-4 h-4" />
           </button>
         </TooltipTrigger>

--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -506,7 +506,7 @@ export function BrowserToolbar({
   }, [url]);
 
   const buttonClass =
-    "p-1.5 rounded hover:bg-overlay-medium disabled:opacity-30 disabled:cursor-not-allowed transition-colors";
+    "toolbar-icon-button p-1.5 rounded disabled:opacity-30 disabled:cursor-not-allowed";
 
   return (
     <div className="flex items-center gap-1.5 px-2 py-1.5 bg-surface border-b border-overlay">
@@ -691,7 +691,7 @@ export function BrowserToolbar({
 
       {/* Viewport preset selector (dev-preview only) */}
       {onViewportPresetChange && (
-        <div className="flex items-center">
+        <div className="flex items-center gap-1">
           <Tooltip>
             <TooltipTrigger asChild>
               <button
@@ -703,10 +703,7 @@ export function BrowserToolbar({
                     onViewportPresetChange(lastViewportPresetRef.current);
                   }
                 }}
-                className={cn(
-                  buttonClass,
-                  viewportPreset && "bg-overlay-emphasis text-daintree-text"
-                )}
+                className={cn(buttonClass, viewportPreset && "text-daintree-text")}
                 aria-label="Viewport preset"
                 aria-pressed={!!viewportPreset}
               >
@@ -720,7 +717,7 @@ export function BrowserToolbar({
               ref={chipRowRef}
               role="radiogroup"
               aria-label="Select viewport preset"
-              className="flex items-center ml-0.5"
+              className="flex items-center gap-0.5 rounded-md bg-overlay-subtle p-0.5"
             >
               {VIEWPORT_PRESET_LIST.map((preset, index) => {
                 const isSelected = viewportPreset === preset.id;
@@ -739,12 +736,8 @@ export function BrowserToolbar({
                     onFocus={() => setChipFocusedIndex(index)}
                     onBlur={() => setChipFocusedIndex(-1)}
                     className={cn(
-                      "px-1.5 py-1 rounded text-[10px] font-medium transition-colors",
-                      "hover:bg-overlay-medium",
-                      "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
-                      isSelected
-                        ? "bg-overlay-emphasis text-daintree-text"
-                        : "text-daintree-text/50"
+                      "toolbar-icon-button px-1.5 py-1 rounded text-xs font-medium",
+                      isSelected ? "text-daintree-text" : "text-daintree-text/50"
                     )}
                   >
                     {preset.label}
@@ -754,85 +747,77 @@ export function BrowserToolbar({
             </div>
           )}
           {viewportPreset && (
-            <div className="flex items-center ml-1 pl-1.5 border-l border-overlay">
-              {onViewportRotateToggle && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      onClick={onViewportRotateToggle}
-                      className={cn(
-                        buttonClass,
-                        viewportRotated && "bg-overlay-emphasis text-daintree-text"
-                      )}
-                      aria-label="Rotate viewport"
-                      aria-pressed={viewportRotated}
-                    >
-                      <RotateCw className="w-4 h-4" />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    {viewportRotated ? "Portrait" : "Landscape"}
-                  </TooltipContent>
-                </Tooltip>
-              )}
-              {onViewportDprChange && (
-                <div
-                  ref={dprRowRef}
-                  role="radiogroup"
-                  aria-label="Device pixel ratio"
-                  className="flex items-center ml-0.5"
-                >
-                  {([1, 2, 3] as const).map((dpr) => {
-                    const isSelected = viewportDpr === dpr;
-                    return (
+            <>
+              <div aria-hidden="true" className="toolbar-divider w-px h-5" />
+              <div className="flex items-center gap-1">
+                {onViewportRotateToggle && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
                       <button
-                        key={dpr}
                         type="button"
-                        role="radio"
-                        aria-checked={isSelected}
-                        aria-label={`Device pixel ratio ${dpr}x`}
-                        data-dpr={dpr}
-                        tabIndex={isSelected ? 0 : -1}
-                        onClick={() => {
-                          if (!isSelected) onViewportDprChange(dpr);
-                        }}
-                        className={cn(
-                          "px-1.5 py-1 rounded text-[10px] font-medium transition-colors",
-                          "hover:bg-overlay-medium",
-                          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
-                          isSelected
-                            ? "bg-overlay-emphasis text-daintree-text"
-                            : "text-daintree-text/50"
-                        )}
+                        onClick={onViewportRotateToggle}
+                        className={cn(buttonClass, viewportRotated && "text-daintree-text")}
+                        aria-label="Rotate viewport"
+                        aria-pressed={viewportRotated}
                       >
-                        {dpr}×
+                        <RotateCw className="w-4 h-4" />
                       </button>
-                    );
-                  })}
-                </div>
-              )}
-              {onViewportFitToggle && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      onClick={onViewportFitToggle}
-                      className={cn(
-                        buttonClass,
-                        "ml-0.5",
-                        viewportFit && "bg-overlay-emphasis text-daintree-text"
-                      )}
-                      aria-label="Zoom to fit"
-                      aria-pressed={viewportFit}
-                    >
-                      <Maximize2 className="w-4 h-4" />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">Zoom to fit</TooltipContent>
-                </Tooltip>
-              )}
-            </div>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      {viewportRotated ? "Portrait" : "Landscape"}
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+                {onViewportDprChange && (
+                  <div
+                    ref={dprRowRef}
+                    role="radiogroup"
+                    aria-label="Device pixel ratio"
+                    className="flex items-center gap-0.5 rounded-md bg-overlay-subtle p-0.5"
+                  >
+                    {([1, 2, 3] as const).map((dpr) => {
+                      const isSelected = viewportDpr === dpr;
+                      return (
+                        <button
+                          key={dpr}
+                          type="button"
+                          role="radio"
+                          aria-checked={isSelected}
+                          aria-label={`Device pixel ratio ${dpr}x`}
+                          data-dpr={dpr}
+                          tabIndex={isSelected ? 0 : -1}
+                          onClick={() => {
+                            if (!isSelected) onViewportDprChange(dpr);
+                          }}
+                          className={cn(
+                            "toolbar-icon-button px-1.5 py-1 rounded text-xs font-medium",
+                            isSelected ? "text-daintree-text" : "text-daintree-text/50"
+                          )}
+                        >
+                          {dpr}×
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+                {onViewportFitToggle && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        onClick={onViewportFitToggle}
+                        className={cn(buttonClass, viewportFit && "text-daintree-text")}
+                        aria-label="Zoom to fit"
+                        aria-pressed={viewportFit}
+                      >
+                        <Maximize2 className="w-4 h-4" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">Zoom to fit</TooltipContent>
+                  </Tooltip>
+                )}
+              </div>
+            </>
           )}
         </div>
       )}
@@ -844,11 +829,13 @@ export function BrowserToolbar({
             {isHttps ? (
               <Lock
                 data-testid="browser-url-scheme-lock"
+                aria-hidden="true"
                 className="absolute left-2 w-3.5 h-3.5 text-daintree-text/40 pointer-events-none"
               />
             ) : (
               <Globe
                 data-testid="browser-url-scheme-globe"
+                aria-hidden="true"
                 className="absolute left-2 w-3.5 h-3.5 text-daintree-text/40 pointer-events-none"
               />
             )}
@@ -880,6 +867,7 @@ export function BrowserToolbar({
                 "w-full pl-7 pr-2 py-1 text-xs rounded",
                 "bg-daintree-bg border border-overlay",
                 "focus:outline-hidden focus:border-border-strong",
+                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
                 "text-daintree-text placeholder:text-daintree-text/40",
                 error && "border-status-error/50"
               )}
@@ -977,6 +965,7 @@ export function BrowserToolbar({
       </div>
 
       {/* Action buttons */}
+      <div aria-hidden="true" className="toolbar-divider w-px h-5" />
       <Tooltip>
         <TooltipTrigger asChild>
           <button type="button" onClick={handleCopy} className={buttonClass} aria-label="Copy URL">
@@ -1013,7 +1002,7 @@ export function BrowserToolbar({
             <button
               type="button"
               onClick={onToggleConsole}
-              className={cn(buttonClass, isConsoleOpen && "bg-overlay-emphasis text-daintree-text")}
+              className={cn(buttonClass, isConsoleOpen && "text-daintree-text")}
               aria-label="Toggle console"
               aria-pressed={isConsoleOpen}
             >

--- a/src/components/Browser/__tests__/BrowserToolbar.test.tsx
+++ b/src/components/Browser/__tests__/BrowserToolbar.test.tsx
@@ -259,6 +259,14 @@ describe("BrowserToolbar ARIA semantics", () => {
     expect(button).toBeTruthy();
   });
 
+  it("Open in browser button is exposed by accessible name", () => {
+    const { getByRole } = renderToolbar();
+    const button = getByRole("button", { name: "Open in browser" });
+    expect(button).toBeTruthy();
+    fireEvent.click(button);
+    expect(defaultProps.onOpenExternal).toHaveBeenCalledOnce();
+  });
+
   it("copy success announces in a polite live region", async () => {
     const { container, getByRole } = renderToolbar();
 
@@ -763,6 +771,25 @@ describe("BrowserToolbar viewport presets", () => {
       expect(pixelRadio.getAttribute("tabindex")).toBe("0");
     });
 
+    it("keeps exactly one radio tabbable after ArrowRight (no transient dual tab stop)", () => {
+      // The roving-tabindex contract requires a single tab stop. Before the fix,
+      // the freshly focused chip AND the still-selected chip both reported
+      // tabIndex=0 until the parent rerendered with the new preset, briefly
+      // exposing two tab stops to keyboard/AT users.
+      renderWithViewport();
+      const iphoneRadio = document.querySelector(
+        '[data-viewport-preset-id="iphone"]'
+      )! as HTMLElement;
+
+      iphoneRadio.focus();
+      fireEvent.keyDown(iphoneRadio, { key: "ArrowRight" });
+
+      const tabbable = Array.from(document.querySelectorAll('[role="radio"]')).filter(
+        (r) => r.getAttribute("tabindex") === "0"
+      );
+      expect(tabbable.length).toBe(1);
+    });
+
     it("ArrowRight on the focused radio activates the next preset immediately (APG automatic activation)", () => {
       renderWithViewport();
       const iphoneRadio = document.querySelector(
@@ -837,6 +864,57 @@ describe("BrowserToolbar viewport presets", () => {
       fireEvent.keyDown(iphoneRadio, { key: "ArrowRight" });
 
       expect(document.activeElement).toBe(pixelRadio);
+    });
+  });
+
+  describe("DPR radiogroup keyboard navigation", () => {
+    function renderWithDpr(overrides = {}) {
+      return renderWithViewport({ onViewportDprChange: vi.fn(), viewportDpr: 1, ...overrides });
+    }
+
+    function dprRadios() {
+      const group = document.querySelector('[aria-label="Device pixel ratio"]')!;
+      return Array.from(group.querySelectorAll('[role="radio"]')) as HTMLElement[];
+    }
+
+    it("renders a DPR radiogroup with one radio per ratio", () => {
+      renderWithDpr();
+      const radios = dprRadios();
+      expect(radios.map((r) => r.getAttribute("data-dpr"))).toEqual(["1", "2", "3"]);
+    });
+
+    it("ArrowRight moves focus to the next ratio and selection follows focus", () => {
+      const onViewportDprChange = vi.fn();
+      renderWithDpr({ onViewportDprChange });
+      const radios = dprRadios();
+
+      radios[0]!.focus();
+      fireEvent.keyDown(radios[0]!, { key: "ArrowRight" });
+
+      expect(document.activeElement).toBe(radios[1]);
+      expect(onViewportDprChange).toHaveBeenCalledWith(2);
+    });
+
+    it("ArrowRight wraps from the last ratio back to the first", () => {
+      renderWithDpr({ viewportDpr: 3 });
+      const radios = dprRadios();
+
+      radios[2]!.focus();
+      fireEvent.keyDown(radios[2]!, { key: "ArrowRight" });
+
+      expect(document.activeElement).toBe(radios[0]);
+    });
+
+    it("Home/End jump to the first and last ratios", () => {
+      renderWithDpr({ viewportDpr: 2 });
+      const radios = dprRadios();
+
+      radios[1]!.focus();
+      fireEvent.keyDown(radios[1]!, { key: "Home" });
+      expect(document.activeElement).toBe(radios[0]);
+
+      fireEvent.keyDown(radios[0]!, { key: "End" });
+      expect(document.activeElement).toBe(radios[2]);
     });
   });
 });

--- a/src/components/Browser/__tests__/BrowserToolbar.test.tsx
+++ b/src/components/Browser/__tests__/BrowserToolbar.test.tsx
@@ -421,6 +421,29 @@ describe("BrowserToolbar address-bar scheme icon and input", () => {
     const reload = getByTestId("browser-reload");
     expect(reload.className).not.toContain("animate-spin");
   });
+
+  it("scheme icon is decorative and hidden from the accessibility tree", () => {
+    const lock = renderToolbar({ url: "https://example.com/" }).getByTestId(
+      "browser-url-scheme-lock"
+    );
+    expect(lock.getAttribute("aria-hidden")).toBe("true");
+
+    const globe = renderToolbar({ url: "http://localhost:3000/" }).getByTestId(
+      "browser-url-scheme-globe"
+    );
+    expect(globe.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("address bar exposes a focus-visible ring without suppressing the forced-colors outline", () => {
+    const { getByTestId } = renderToolbar();
+    const input = getByTestId("browser-address-bar");
+    // A focus-visible indicator must be present (the accent ring is the address bar's
+    // sole accent signal per CLAUDE.md) and outline-hidden must be preserved so the
+    // transparent forced-colors outline survives (lesson #6185 — never outline-none).
+    expect(input.className).toContain("focus-visible:outline-daintree-accent");
+    expect(input.className).toContain("focus:outline-hidden");
+    expect(input.className).not.toContain("outline-none");
+  });
 });
 
 describe("BrowserToolbar viewport presets", () => {
@@ -480,6 +503,31 @@ describe("BrowserToolbar viewport presets", () => {
 
       const galaxyRadio = document.querySelector('[data-viewport-preset-id="galaxy"]');
       expect(galaxyRadio!.getAttribute("aria-label")).toBe("Galaxy S25");
+    });
+  });
+
+  describe("armed-state styling", () => {
+    it("selected preset chip drives state via toolbar-icon-button + aria-checked, not a hardcoded fill", () => {
+      renderWithViewport();
+      const selected = document.querySelector('[data-viewport-preset-id="iphone"]')! as HTMLElement;
+      // The selected chip must participate in the theme-aware armed-state recipe
+      // (toolbar.css keys off .toolbar-icon-button[aria-checked="true"]) rather than
+      // hardcoding bg-overlay-emphasis, which reads as a dark smudge on light themes.
+      expect(selected.getAttribute("aria-checked")).toBe("true");
+      expect(selected.className).toContain("toolbar-icon-button");
+      expect(selected.className).not.toContain("bg-overlay-emphasis");
+    });
+
+    it("selected DPR chip uses the same armed-state contract", () => {
+      renderWithViewport({ onViewportDprChange: vi.fn(), viewportDpr: 2 });
+      const dprGroup = document.querySelector('[aria-label="Device pixel ratio"]')!;
+      const selected = Array.from(dprGroup.querySelectorAll('[role="radio"]')).find(
+        (r) => r.getAttribute("aria-checked") === "true"
+      ) as HTMLElement;
+      expect(selected).toBeTruthy();
+      expect(selected.getAttribute("data-dpr")).toBe("2");
+      expect(selected.className).toContain("toolbar-icon-button");
+      expect(selected.className).not.toContain("bg-overlay-emphasis");
     });
   });
 

--- a/src/components/Layout/__tests__/Toolbar.responsive.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.responsive.test.ts
@@ -245,6 +245,25 @@ describe("Toolbar responsive design — issue #4133", () => {
       expect(armedBlock).toContain('.toolbar-agent-button[aria-pressed="true"]');
     });
 
+    it("radio chips (aria-checked) share the armed-state recipe across base, light, and forced-colors blocks", () => {
+      // Segmented radio chips (viewport preset / DPR) carry role=radio + aria-checked
+      // rather than aria-pressed. For them to read with the same theme-aware armed
+      // styling — and not fall back to a hardcoded fill that smudges on light themes —
+      // every armed block must enumerate aria-checked alongside aria-pressed.
+      const armedSelectorIndex = css.indexOf('.toolbar-icon-button[aria-checked="true"]');
+      const lightFlipIndex = css.indexOf(
+        ':where(.light, [data-color-mode="light"]) .toolbar-icon-button[aria-checked="true"]'
+      );
+      const forcedColorsBlock = css.match(
+        /@media \(forced-colors: active\)\s*\{[\s\S]*?aria-pressed[\s\S]*?\}\s*\}/
+      )?.[0];
+
+      expect(armedSelectorIndex).toBeGreaterThan(-1);
+      expect(lightFlipIndex).toBeGreaterThan(-1);
+      expect(forcedColorsBlock).toBeDefined();
+      expect(forcedColorsBlock).toContain('.toolbar-icon-button[aria-checked="true"]');
+    });
+
     it("armed selectors appear after :hover in source order so armed survives hover-over-armed", () => {
       // Hover and armed have equal specificity, so later-in-source wins. If a
       // refactor moves the armed block above hover, hovering an armed button

--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -125,6 +125,7 @@
  * hover and :active, preserving both the source-order tiebreaker above and
  * the momentary :active background on other pressed buttons. */
 .toolbar-icon-button[aria-pressed="true"]:where(:not([data-sidebar-toggle])),
+.toolbar-icon-button[aria-checked="true"],
 .toolbar-icon-button[aria-expanded="true"],
 .toolbar-icon-button[data-state="open"],
 .toolbar-agent-button[aria-pressed="true"],
@@ -152,6 +153,7 @@
  * override still wins on light. Dark never matches this block. */
 :where(.light, [data-color-mode="light"])
   .toolbar-icon-button[aria-pressed="true"]:where(:not([data-sidebar-toggle])),
+:where(.light, [data-color-mode="light"]) .toolbar-icon-button[aria-checked="true"],
 :where(.light, [data-color-mode="light"]) .toolbar-icon-button[aria-expanded="true"],
 :where(.light, [data-color-mode="light"]) .toolbar-icon-button[data-state="open"],
 :where(.light, [data-color-mode="light"]) .toolbar-agent-button[aria-pressed="true"],
@@ -504,6 +506,7 @@
    opt-out) to keep the same scope. */
 @media (forced-colors: active) {
   .toolbar-icon-button[aria-pressed="true"]:where(:not([data-sidebar-toggle])),
+  .toolbar-icon-button[aria-checked="true"],
   .toolbar-icon-button[aria-expanded="true"],
   .toolbar-icon-button[data-state="open"],
   .toolbar-agent-button[aria-pressed="true"],


### PR DESCRIPTION
Closes #9815.

## What

Visual/UX refactor of the shared `BrowserToolbar` (used by both the browser and dev-preview panels) so the toolbar's controls read as a coherent, grouped family.

## Changes

- **Framed segmented controls.** The three mutually-exclusive segmented controls (zoom stepper, viewport-preset chips, DPR chips) now share the same `rounded-md bg-overlay-subtle p-0.5` frame the zoom group already had — they read as one family instead of one framed + two loose.
- **Theme-aware armed state for chips.** Extended `toolbar.css` with `.toolbar-icon-button[aria-checked="true"]` across the base, `:where(.light)` flip, and `@media (forced-colors: active)` blocks, and migrated the chips/buttons to `.toolbar-icon-button`. Selected chips now use the polarity-correct armed recipe (overlay-raised lift + `border-strong` ring on light) instead of the hardcoded `bg-overlay-emphasis` that smudged on light themes ("selection by grime").
- **Cluster separation.** `toolbar-divider` hairlines (themed via `--theme-border-divider`) separate the viewport-preset cluster from the viewport-tools cluster and the URL bar from the trailing action run (copy / screenshot / console / devtools / portal / external).
- **Address-bar focus ring.** Added a `focus-visible` accent ring — the single accent signal for that focus region — while preserving `focus:outline-hidden` so the transparent forced-colors outline survives (lesson #6185; never `outline-none`).
- **Accessibility.** Decorative scheme icons (lock/globe) are now `aria-hidden`; the external-link action button gained an accessible name.
- **Polish.** Normalized chip text to `text-xs` (was an inconsistent `text-[10px]`); made roving tabindex a single tab stop during the focus-follows-selection transient; added `shrink-0` so the 1px dividers survive extreme compression; suppressed hover box-shadow on disabled buttons for custom themes.

## Design-rule adherence

- Accent reserved for one signal per focus region — the address-bar ring. Selected/membership states use overlay tiers + `border-strong`, never accent.
- Motion stays Tier 1 (150ms) via `.toolbar-icon-button`'s scoped `color`/`background-color` transition; no widening to `transition-all`.
- Sentence-case microcopy.

## Tests

- `BrowserToolbar.test.tsx`: scheme-icon `aria-hidden`, address-bar focus-ring / forced-colors safety, selected viewport+DPR chip armed-state contract, DPR radiogroup keyboard navigation, roving-tabindex exclusivity, external-link accessible name.
- `Toolbar.responsive.test.ts`: `aria-checked` wired into all three armed blocks.
- 95 tests pass in the two affected suites; full typecheck / lint / format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)