### PR TITLE
style(action-palette): polish row legibility and alignment

### DIFF
--- a/src/components/ActionPalette/ActionPaletteItem.test.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.test.tsx
@@ -10,7 +10,7 @@ vi.mock("@/lib/utils", () => ({
 
 vi.mock("@/config/categoryColors", () => ({
   ACTION_CATEGORY_COLORS: {
-    terminal: "bg-cat-blue/15 text-cat-blue",
+    terminal: "bg-category-blue-subtle text-category-blue-text border border-category-blue-border",
   },
   ACTION_CATEGORY_DEFAULT_COLOR: "bg-tint/[0.06] text-daintree-text/50",
 }));

--- a/src/components/ActionPalette/ActionPaletteItem.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.tsx
@@ -128,7 +128,7 @@ function ActionPaletteItemInner({
   return (
     <div
       className={cn(
-        "group relative w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] transition-colors",
+        "group relative w-full flex items-start gap-3 px-3 py-2 rounded-[var(--radius-md)] transition-colors",
         "border border-transparent text-daintree-text/70",
         "hover:bg-overlay-subtle hover:text-daintree-text",
         "aria-selected:bg-overlay-raised aria-selected:border-overlay aria-selected:text-daintree-text",
@@ -167,24 +167,26 @@ function ActionPaletteItemInner({
         <div className="flex-1 min-w-0">
           <div className="text-sm font-medium truncate">{displayTitle}</div>
           {item.description && (
-            <div className="text-xs text-daintree-text/50 truncate">{item.description}</div>
+            <div className="text-xs leading-snug text-daintree-text/50 truncate">
+              {item.description}
+            </div>
           )}
           {!item.enabled && item.disabledReason && (
-            <div className="text-[10px] text-daintree-text/40 italic truncate">
+            <div className="text-[10px] leading-snug text-daintree-text/50 italic truncate">
               {item.disabledReason}
             </div>
           )}
           {hasRationale && (
             <div
               id={rationaleId}
-              className="hidden group-aria-selected:block text-xs text-daintree-text/50 italic truncate"
+              className="hidden group-aria-selected:block text-xs leading-snug text-daintree-text/50 italic truncate"
             >
               {item.dangerRationale}
             </div>
           )}
           {pinRejected && (
             <div
-              className="text-[10px] text-status-error mt-0.5 truncate"
+              className="text-[10px] leading-snug text-status-error mt-0.5 truncate"
               role="status"
               aria-live="polite"
             >
@@ -194,7 +196,7 @@ function ActionPaletteItemInner({
         </div>
       </button>
 
-      <div className="shrink-0 flex items-center gap-1">
+      <div className="shrink-0 flex items-center gap-1 pt-0.5">
         {canShowHide && (
           <button
             type="button"
@@ -240,7 +242,7 @@ function ActionPaletteItemInner({
         )}
 
         {item.keybinding && (
-          <span className="text-[11px] font-mono text-daintree-text/40 transition-colors group-aria-selected:text-daintree-text/60">
+          <span className="text-[11px] font-mono text-daintree-text/50 transition-colors group-aria-selected:text-daintree-text/70">
             {item.keybinding}
           </span>
         )}

--- a/src/config/__tests__/categoryColors.test.ts
+++ b/src/config/__tests__/categoryColors.test.ts
@@ -8,6 +8,26 @@ import { ACTION_CATEGORY_COLORS, ACTION_CATEGORY_DEFAULT_COLOR } from "@/config/
  * raw `cat-{hue}/15` tints to the engineered `category-{hue}-*` set, so the
  * chip label keeps its WCAG-compliant contrast.
  */
+/**
+ * The hues with engineered `--color-category-{hue}-*` tokens defined in
+ * `src/index.css`. A chip class referencing any other hue would compile to a
+ * dead Tailwind utility, so entries must draw from this set.
+ */
+const VALID_HUES = new Set([
+  "blue",
+  "purple",
+  "cyan",
+  "green",
+  "amber",
+  "slate",
+  "orange",
+  "teal",
+  "indigo",
+  "rose",
+  "pink",
+  "violet",
+]);
+
 describe("ACTION_CATEGORY_COLORS", () => {
   const entries = Object.entries(ACTION_CATEGORY_COLORS);
 
@@ -29,6 +49,22 @@ describe("ACTION_CATEGORY_COLORS", () => {
         /\bborder-category-[a-z]+-border\b/.test(classes),
         `${category} missing border-category-*-border: ${classes}`
       ).toBe(true);
+      // The border-color token is invisible without the bare `border` width
+      // utility; guard against an entry that sets the colour but no width.
+      expect(
+        /\bborder\b(?!-)/.test(classes),
+        `${category} missing bare border width: ${classes}`
+      ).toBe(true);
+    }
+  });
+
+  it("only references hues with engineered tokens", () => {
+    for (const [category, classes] of entries) {
+      for (const [, hue] of classes.matchAll(/-category-([a-z]+)-(?:subtle|text|border)\b/g)) {
+        expect(VALID_HUES.has(hue), `${category} references unknown hue '${hue}': ${classes}`).toBe(
+          true
+        );
+      }
     }
   });
 

--- a/src/config/__tests__/categoryColors.test.ts
+++ b/src/config/__tests__/categoryColors.test.ts
@@ -61,9 +61,10 @@ describe("ACTION_CATEGORY_COLORS", () => {
   it("only references hues with engineered tokens", () => {
     for (const [category, classes] of entries) {
       for (const [, hue] of classes.matchAll(/-category-([a-z]+)-(?:subtle|text|border)\b/g)) {
-        expect(VALID_HUES.has(hue), `${category} references unknown hue '${hue}': ${classes}`).toBe(
-          true
-        );
+        expect(
+          VALID_HUES.has(hue!),
+          `${category} references unknown hue '${hue}': ${classes}`
+        ).toBe(true);
       }
     }
   });

--- a/src/config/__tests__/categoryColors.test.ts
+++ b/src/config/__tests__/categoryColors.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { ACTION_CATEGORY_COLORS, ACTION_CATEGORY_DEFAULT_COLOR } from "@/config/categoryColors";
+
+/**
+ * Contract tests for the action palette category chip tokens. These assert
+ * structural invariants (which token family each entry draws from), not the
+ * literal class strings — the goal is to guard the legibility migration from
+ * raw `cat-{hue}/15` tints to the engineered `category-{hue}-*` set, so the
+ * chip label keeps its WCAG-compliant contrast.
+ */
+describe("ACTION_CATEGORY_COLORS", () => {
+  const entries = Object.entries(ACTION_CATEGORY_COLORS);
+
+  it("maps at least one category", () => {
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  it("draws every category from the engineered category-{hue} token set", () => {
+    for (const [category, classes] of entries) {
+      expect(
+        /\bbg-category-[a-z]+-subtle\b/.test(classes),
+        `${category} missing bg-category-*-subtle: ${classes}`
+      ).toBe(true);
+      expect(
+        /\btext-category-[a-z]+-text\b/.test(classes),
+        `${category} missing text-category-*-text: ${classes}`
+      ).toBe(true);
+      expect(
+        /\bborder-category-[a-z]+-border\b/.test(classes),
+        `${category} missing border-category-*-border: ${classes}`
+      ).toBe(true);
+    }
+  });
+
+  it("never falls back to the flat cat-{hue} opacity tint", () => {
+    for (const [category, classes] of entries) {
+      expect(
+        /\b(?:bg|text|border)-cat-[a-z]+\b/.test(classes),
+        `${category} still uses a raw cat-* token: ${classes}`
+      ).toBe(false);
+    }
+  });
+
+  it("uses a single consistent hue per entry", () => {
+    for (const [category, classes] of entries) {
+      const hues = new Set(
+        [...classes.matchAll(/-category-([a-z]+)-(?:subtle|text|border)\b/g)].map((m) => m[1])
+      );
+      expect(hues.size, `${category} mixes hues: ${classes}`).toBe(1);
+    }
+  });
+
+  it("keeps the default fallback neutral (no hue token)", () => {
+    expect(/-category-[a-z]+-/.test(ACTION_CATEGORY_DEFAULT_COLOR)).toBe(false);
+    expect(/-cat-[a-z]+\b/.test(ACTION_CATEGORY_DEFAULT_COLOR)).toBe(false);
+  });
+});

--- a/src/config/categoryColors.ts
+++ b/src/config/categoryColors.ts
@@ -2,25 +2,35 @@ import type { EventCategory } from "@shared/types";
 
 /**
  * Action palette category badge colors.
- * Assigns one of 12 --color-cat-* hue tokens to each action category.
+ * Assigns one of 12 engineered category hue tokens to each action category.
  * Some categories intentionally share a hue (e.g. panels/browser both use cyan).
+ *
+ * Uses the `category-{hue}-subtle/-text/-border` token set (the same one Fleet
+ * and recipe chips consume) rather than raw `cat-{hue}/15` opacity tints: the
+ * engineered `-text` token is mixed toward `--theme-text-primary` in OKLCH so
+ * the 10px chip label clears WCAG 4.5:1 in both light and dark themes, where a
+ * flat 15% tint did not.
  */
 export const ACTION_CATEGORY_COLORS: Record<string, string> = {
-  terminal: "bg-cat-blue/15 text-cat-blue",
-  agents: "bg-cat-purple/15 text-cat-purple",
-  panels: "bg-cat-cyan/15 text-cat-cyan",
-  navigation: "bg-cat-green/15 text-cat-green",
-  worktree: "bg-cat-amber/15 text-cat-amber",
-  github: "bg-cat-slate/15 text-cat-slate",
-  git: "bg-cat-orange/15 text-cat-orange",
-  project: "bg-cat-teal/15 text-cat-teal",
-  preferences: "bg-cat-slate/15 text-cat-slate",
-  app: "bg-cat-indigo/15 text-cat-indigo",
-  system: "bg-cat-rose/15 text-cat-rose",
-  logs: "bg-cat-amber/15 text-cat-amber",
-  recipes: "bg-cat-pink/15 text-cat-pink",
-  portal: "bg-cat-violet/15 text-cat-violet",
-  browser: "bg-cat-cyan/15 text-cat-cyan",
+  terminal: "bg-category-blue-subtle text-category-blue-text border border-category-blue-border",
+  agents:
+    "bg-category-purple-subtle text-category-purple-text border border-category-purple-border",
+  panels: "bg-category-cyan-subtle text-category-cyan-text border border-category-cyan-border",
+  navigation:
+    "bg-category-green-subtle text-category-green-text border border-category-green-border",
+  worktree: "bg-category-amber-subtle text-category-amber-text border border-category-amber-border",
+  github: "bg-category-slate-subtle text-category-slate-text border border-category-slate-border",
+  git: "bg-category-orange-subtle text-category-orange-text border border-category-orange-border",
+  project: "bg-category-teal-subtle text-category-teal-text border border-category-teal-border",
+  preferences:
+    "bg-category-slate-subtle text-category-slate-text border border-category-slate-border",
+  app: "bg-category-indigo-subtle text-category-indigo-text border border-category-indigo-border",
+  system: "bg-category-rose-subtle text-category-rose-text border border-category-rose-border",
+  logs: "bg-category-amber-subtle text-category-amber-text border border-category-amber-border",
+  recipes: "bg-category-pink-subtle text-category-pink-text border border-category-pink-border",
+  portal:
+    "bg-category-violet-subtle text-category-violet-text border border-category-violet-border",
+  browser: "bg-category-cyan-subtle text-category-cyan-text border border-category-cyan-border",
 };
 
 export const ACTION_CATEGORY_DEFAULT_COLOR = "bg-tint/[0.06] text-daintree-text/50";


### PR DESCRIPTION
Presentation-only CSS polish for the action palette rows (#9816). Three changes:

1. **Legible category chip** — migrate the chip from raw low-contrast `cat-{hue}/15` opacity tints to the engineered `category-{hue}-subtle`/`-text`/`-border` token set (the same one Fleet and recipe chips use). The `-text` token is mixed toward `--theme-text-primary` in OKLCH, so the 10px chip label clears WCAG 4.5:1 in both light and dark themes where a flat 15% tint did not.
2. **Top-aligned row controls** — align the right-side controls (pin/hide/keybinding hint) to the top of the content on multi-line rows (outer row `items-center`→`items-start` + `pt-0.5` on the right cluster) instead of vertical-centering against the full row height. No single-line regression; `box-sizing: border-box` keeps the new 1px chip border within the chip's declared height.
3. **Secondary-text legibility** — raise the keybinding hint opacity (`/40`→`/50` resting, `/60`→`/70` selected) and the disabled-reason opacity (`/40`→`/50`); add `leading-snug` to the secondary text lines (description, disabled reason, danger rationale, pin-rejected) for a tighter multi-line stack.

### Scope & guardrails
- Added a pattern-invariant contract test (`src/config/__tests__/categoryColors.test.ts`) guarding the chip token migration — asserts the engineered token family, a single hue per entry, restriction to hues with defined tokens, presence of the bare `border` width utility, and a neutral default fallback. Structural invariants, not literal-class change-detectors.
- Left `CAT_COLOR_CLASSES` (drives `CommitAuthorAvatar` initials avatars — different surface, a border would be an unscoped visual change), `EVENT_CATEGORY_STYLES`, and `ACTION_CATEGORY_DEFAULT_COLOR` unchanged.
- Accent color stays reserved for the 2px selection bar only; no behavior, store, or IPC changes.

### Checks
- Tests: 110 pass (categoryColors + ActionPaletteItem + colorSystem.contract + accentGuard.contract).
- Verify: all 10 checks pass (typecheck, IPC/channel guards, confirm-wiring, lint ratchet at baseline 1194, format).

Closes #9816.

🤖 Generated with [Claude Code](https://claude.com/claude-code)