### PR TITLE
feat(settings): mirror toolbar two-sided layout in settings editor

### DIFF
--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -423,27 +423,33 @@ export function ToolbarSettingsTab() {
       return;
     }
 
-    const overItems = live[overContainer];
-    const activeIndex = overItems.indexOf(activeButtonId);
-    const overIndex =
-      over.id === overContainer ? overItems.length - 1 : overItems.indexOf(toButtonId(over.id));
-
-    const finalItems =
-      overIndex !== -1 && activeIndex !== -1 && activeIndex !== overIndex
-        ? arrayMove(overItems, activeIndex, overIndex)
-        : overItems;
-
     if (originalContainer === overContainer) {
-      // Same-side reorder — commit the reordered list directly.
+      // Same-side reorder — `onDragOver` leaves same-side drags untouched, so
+      // the dragged item is still in its original slot here; reorder toward
+      // the hovered item.
+      const items = live[overContainer];
+      const oldIndex = items.indexOf(activeButtonId);
+      const newIndex =
+        over.id === overContainer ? items.length - 1 : items.indexOf(toButtonId(over.id));
+      if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) {
+        clearDrag();
+        return;
+      }
+      const reordered = arrayMove(items, oldIndex, newIndex);
       if (overContainer === "left") {
-        setLeftButtons(finalItems);
+        setLeftButtons(reordered);
       } else {
-        setRightButtons(finalItems);
+        setRightButtons(reordered);
       }
     } else {
-      // Cross-side move — route through `moveButton` so its index fixup runs
-      // against the store's authoritative (un-mutated) arrays.
-      const toIndex = finalItems.indexOf(activeButtonId);
+      // Cross-side move — `onDragOver` already relocated the item into the
+      // target list at its drop position, so its index in `dragState` IS the
+      // final target index. Re-running `arrayMove` here would invert it.
+      const toIndex = live[overContainer].indexOf(activeButtonId);
+      if (toIndex === -1) {
+        clearDrag();
+        return;
+      }
       moveButton(activeButtonId, originalContainer, overContainer, toIndex);
     }
 

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -1,19 +1,27 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   DndContext,
-  closestCenter,
+  DragOverlay,
   KeyboardSensor,
   PointerSensor,
+  closestCorners,
+  pointerWithin,
+  useDroppable,
   useSensor,
   useSensors,
+  type CollisionDetection,
+  type DragCancelEvent,
   type DragEndEvent,
+  type DragOverEvent,
+  type DragStartEvent,
   type UniqueIdentifier,
 } from "@dnd-kit/core";
 import {
   SortableContext,
+  arrayMove,
+  rectSortingStrategy,
   sortableKeyboardCoordinates,
   useSortable,
-  verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { GripVertical, LayoutGrid, Rocket, RotateCcw } from "lucide-react";
@@ -31,17 +39,92 @@ import { getAgentConfig } from "@/config/agents";
 import { usePluginToolbarButtons } from "@/hooks/usePluginToolbarButtons";
 import { McpServerIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
-import { DRAG_GHOST_OPACITY } from "@/lib/animationUtils";
+import { DRAG_GHOST_OPACITY, EASE_OUT_EXPO, UI_ANIMATION_DURATION } from "@/lib/animationUtils";
 import { dispatchToolbarVisibility } from "@/lib/toolbarVisibilityDispatch";
 import { makeSortableAnnouncements } from "@/components/DragDrop/sortableAnnouncements";
 import { SettingsSection } from "./SettingsSection";
+import { SettingsSwitch } from "./SettingsSwitch";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
+
+type ToolbarSide = "left" | "right";
+
+type AllMetadata = Partial<Record<AnyToolbarButtonId, ToolbarButtonMetadata>>;
+
+interface SideLists {
+  left: AnyToolbarButtonId[];
+  right: AnyToolbarButtonId[];
+}
+
+// dnd-kit ids are `UniqueIdentifier` (string | number); toolbar button ids are
+// a string subset. Narrow in one place so the unavoidable assertion lives here.
+function toButtonId(id: UniqueIdentifier): AnyToolbarButtonId {
+  return id as AnyToolbarButtonId;
+}
+
+interface ToolbarButtonCardProps {
+  metadata: ToolbarButtonMetadata;
+  isVisible: boolean;
+  onToggle?: () => void;
+  /** Spread onto the grip handle — attributes + listeners from `useSortable`. */
+  gripProps?: Record<string, unknown>;
+  draggable: boolean;
+  /** Rendered inside `DragOverlay` — drops the live opacity/transition chrome. */
+  isOverlay?: boolean;
+}
+
+// Presentational chip shared by the sortable rows and the drag overlay. It
+// never calls `useSortable` so it is safe to render inside `DragOverlay`
+// (which mounts outside any `SortableContext`).
+function ToolbarButtonCard({
+  metadata,
+  isVisible,
+  onToggle,
+  gripProps,
+  draggable,
+  isOverlay,
+}: ToolbarButtonCardProps) {
+  const Icon = metadata.icon;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 px-2.5 py-2 rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg/30 transition-colors",
+        isOverlay && "shadow-md bg-daintree-bg cursor-grabbing"
+      )}
+    >
+      <div
+        {...(draggable && gripProps ? gripProps : {})}
+        className={cn(
+          draggable ? "cursor-grab active:cursor-grabbing" : "cursor-default",
+          "shrink-0"
+        )}
+        aria-hidden="true"
+      >
+        <GripVertical
+          className={cn("h-4 w-4", draggable ? "text-daintree-text/50" : "text-daintree-text/20")}
+        />
+      </div>
+      <div className="text-daintree-text shrink-0">
+        <Icon className="h-4 w-4" />
+      </div>
+      <span className="text-sm font-medium text-daintree-text truncate min-w-0 flex-1">
+        {metadata.label}
+      </span>
+      <SettingsSwitch
+        checked={isVisible}
+        onCheckedChange={() => onToggle?.()}
+        aria-label={`Toggle ${metadata.label} visibility`}
+        className="shrink-0"
+      />
+    </div>
+  );
+}
 
 interface SortableButtonItemProps {
   buttonId: AnyToolbarButtonId;
   isVisible: boolean;
   onToggle: (buttonId: AnyToolbarButtonId) => void;
-  allMetadata: Partial<Record<AnyToolbarButtonId, ToolbarButtonMetadata>>;
+  allMetadata: AllMetadata;
 }
 
 function SortableButtonItem({
@@ -56,6 +139,9 @@ function SortableButtonItem({
     disabled: !isVisible,
   });
 
+  // Keep the dnd-kit transform/transition/opacity on this single node (the
+  // drag-source). Nesting a second transform-holding wrapper would fight the
+  // sortable transform — see #9029.
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
@@ -63,37 +149,15 @@ function SortableButtonItem({
   };
 
   if (!metadata) return null;
-  const Icon = metadata.icon;
 
   return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      className="flex items-center gap-3 p-3 rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg/30"
-    >
-      <div
-        {...(isVisible ? { ...attributes, ...listeners } : {})}
-        className={cn(isVisible ? "cursor-grab active:cursor-grabbing" : "cursor-default")}
-      >
-        <GripVertical
-          className={cn("h-4 w-4", isVisible ? "text-daintree-text/50" : "text-daintree-text/20")}
-        />
-      </div>
-      <div className="flex items-center gap-2 flex-1">
-        <div className="text-daintree-text">
-          <Icon className="h-4 w-4" />
-        </div>
-        <div className="flex-1">
-          <div className="text-sm font-medium text-daintree-text">{metadata.label}</div>
-          <div className="text-xs text-daintree-text/50 select-text">{metadata.description}</div>
-        </div>
-      </div>
-      <input
-        type="checkbox"
-        checked={isVisible}
-        onChange={() => onToggle(buttonId)}
-        aria-label={`Toggle ${metadata.label} visibility`}
-        className="w-4 h-4 rounded border-border-strong bg-daintree-bg text-daintree-accent focus:ring-daintree-accent focus:ring-2"
+    <div ref={setNodeRef} style={style} className="shrink-0">
+      <ToolbarButtonCard
+        metadata={metadata}
+        isVisible={isVisible}
+        onToggle={() => onToggle(buttonId)}
+        gripProps={{ ...attributes, ...listeners }}
+        draggable={isVisible}
       />
     </div>
   );
@@ -106,10 +170,10 @@ interface PluginButtonRowProps {
   metadata: ToolbarButtonMetadata | undefined;
 }
 
-// Plugin buttons are hide-only — they're never persisted into
-// `layout.rightButtons`, so they get no drag handle. Reusing
-// `SortableButtonItem` would call `useSortable` outside a `SortableContext`
-// and crash; this is a plain non-sortable row mirroring its visual structure.
+// Plugin buttons are hide-only — they're never persisted into the position
+// arrays, so they get no drag handle and stay out of cross-side movement.
+// Reusing `SortableButtonItem` would call `useSortable` outside a
+// `SortableContext` and crash; this is a plain non-sortable row.
 function PluginButtonRow({ buttonId, isVisible, onToggle, metadata }: PluginButtonRowProps) {
   if (!metadata) return null;
   const Icon = metadata.icon;
@@ -119,31 +183,100 @@ function PluginButtonRow({ buttonId, isVisible, onToggle, metadata }: PluginButt
       style={{ opacity: isVisible ? 1 : 0.5 }}
       className="flex items-center gap-3 p-3 rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg/30"
     >
-      <div className="flex items-center gap-2 flex-1">
-        <div className="text-daintree-text">
+      <div className="flex items-center gap-2 flex-1 min-w-0">
+        <div className="text-daintree-text shrink-0">
           <Icon className="h-4 w-4" />
         </div>
-        <div className="flex-1">
-          <div className="text-sm font-medium text-daintree-text">{metadata.label}</div>
-          <div className="text-xs text-daintree-text/50 select-text">{metadata.description}</div>
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium text-daintree-text truncate">{metadata.label}</div>
+          <div className="text-xs text-daintree-text/50 select-text truncate">
+            {metadata.description}
+          </div>
         </div>
       </div>
-      <input
-        type="checkbox"
+      <SettingsSwitch
         checked={isVisible}
-        onChange={() => onToggle(buttonId)}
+        onCheckedChange={() => onToggle(buttonId)}
         aria-label={`Toggle ${metadata.label} visibility`}
-        className="w-4 h-4 rounded border-border-strong bg-daintree-bg text-daintree-accent focus:ring-daintree-accent focus:ring-2"
+        className="shrink-0"
       />
     </div>
   );
 }
+
+interface ToolbarSideColumnProps {
+  side: ToolbarSide;
+  label: string;
+  buttonIds: AnyToolbarButtonId[];
+  allMetadata: AllMetadata;
+  isVisible: (id: AnyToolbarButtonId) => boolean;
+  onToggle: (buttonId: AnyToolbarButtonId, side: ToolbarSide) => void;
+}
+
+function ToolbarSideColumn({
+  side,
+  label,
+  buttonIds,
+  allMetadata,
+  isVisible,
+  onToggle,
+}: ToolbarSideColumnProps) {
+  // The column id doubles as a droppable target so an empty side still accepts
+  // a cross-side drop (a `SortableContext` registers no droppable of its own
+  // when it holds zero items).
+  const { setNodeRef, isOver } = useDroppable({ id: side });
+  const visibleCount = buttonIds.filter(isVisible).length;
+
+  return (
+    <div className="flex-1 min-w-0">
+      <div className="mb-2 flex items-baseline justify-between gap-2">
+        <span className="text-xs font-medium uppercase tracking-wide text-daintree-text/60">
+          {label}
+        </span>
+        <span className="text-xs text-daintree-text/40 tabular-nums">
+          {visibleCount}/{buttonIds.length}
+        </span>
+      </div>
+      <SortableContext items={buttonIds} strategy={rectSortingStrategy}>
+        <div
+          ref={setNodeRef}
+          className={cn(
+            "flex flex-wrap content-start gap-2 rounded-[var(--radius-md)] bg-overlay-subtle p-2 min-h-[4rem] transition-colors",
+            isOver && "ring-1 ring-inset ring-daintree-border"
+          )}
+        >
+          {buttonIds.length === 0 ? (
+            <div className="flex w-full items-center justify-center py-3 text-xs text-daintree-text/30">
+              Drop a button here
+            </div>
+          ) : (
+            buttonIds.map((buttonId) => (
+              <SortableButtonItem
+                key={buttonId}
+                buttonId={buttonId}
+                isVisible={isVisible(buttonId)}
+                onToggle={(id) => onToggle(id, side)}
+                allMetadata={allMetadata}
+              />
+            ))
+          )}
+        </div>
+      </SortableContext>
+    </div>
+  );
+}
+
+const dropAnimation = {
+  duration: UI_ANIMATION_DURATION,
+  easing: EASE_OUT_EXPO,
+};
 
 export function ToolbarSettingsTab() {
   const layout = useToolbarPreferencesStore((s) => s.layout);
   const launcher = useToolbarPreferencesStore((s) => s.launcher);
   const setLeftButtons = useToolbarPreferencesStore((s) => s.setLeftButtons);
   const setRightButtons = useToolbarPreferencesStore((s) => s.setRightButtons);
+  const moveButton = useToolbarPreferencesStore((s) => s.moveButton);
   const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
   const setAlwaysShowDevServer = useToolbarPreferencesStore((s) => s.setAlwaysShowDevServer);
   const setDefaultSelection = useToolbarPreferencesStore((s) => s.setDefaultSelection);
@@ -152,6 +285,15 @@ export function ToolbarSettingsTab() {
   const agentSettings = useAgentSettingsStore((s) => s.settings);
   const setAgentPinned = useAgentSettingsStore((s) => s.setAgentPinned);
   const agentAvailability = useCliAvailabilityStore((s) => s.availability);
+
+  // In-flight side lists while a drag is active. `null` between drags so we
+  // re-render straight off the store; during a cross-side drag this holds the
+  // speculative placement that drives the gap animation.
+  const [dragState, setDragState] = useState<SideLists | null>(null);
+  const [activeId, setActiveId] = useState<AnyToolbarButtonId | null>(null);
+
+  const liveLeft = dragState?.left ?? layout.leftButtons;
+  const liveRight = dragState?.right ?? layout.rightButtons;
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -174,14 +316,11 @@ export function ToolbarSettingsTab() {
         };
       }
     }
-    return { ...TOOLBAR_BUTTON_METADATA, ...pluginMeta };
+    return { ...TOOLBAR_BUTTON_METADATA, ...pluginMeta } as AllMetadata;
   }, [pluginButtonIds, pluginConfigs]);
 
   const getToolbarButtonLabel = useCallback(
-    (id: UniqueIdentifier) => {
-      const meta = allMetadata as Partial<Record<AnyToolbarButtonId, ToolbarButtonMetadata>>;
-      return meta[id as AnyToolbarButtonId]?.label;
-    },
+    (id: UniqueIdentifier) => allMetadata[toButtonId(id)]?.label,
     [allMetadata]
   );
   const toolbarButtonAnnouncements = useMemo(
@@ -189,117 +328,186 @@ export function ToolbarSettingsTab() {
     [getToolbarButtonLabel]
   );
 
-  const handleLeftDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event;
-    if (!over || active.id === over.id) return;
+  const isVisible = useCallback(
+    (id: AnyToolbarButtonId) =>
+      isToolbarButtonVisible(id, layout.pinnedButtons, agentSettings, agentAvailability),
+    [layout.pinnedButtons, agentSettings, agentAvailability]
+  );
 
-    const oldIndex = layout.leftButtons.indexOf(active.id as AnyToolbarButtonId);
-    const newIndex = layout.leftButtons.indexOf(over.id as AnyToolbarButtonId);
-
-    if (oldIndex === -1 || newIndex === -1) return;
-
-    const newButtons = [...layout.leftButtons];
-    newButtons.splice(oldIndex, 1);
-    newButtons.splice(newIndex, 0, active.id as AnyToolbarButtonId);
-
-    setLeftButtons(newButtons);
+  const findContainer = (id: UniqueIdentifier, lists: SideLists): ToolbarSide | null => {
+    if (id === "left" || id === "right") return id;
+    const buttonId = toButtonId(id);
+    if (lists.left.includes(buttonId)) return "left";
+    if (lists.right.includes(buttonId)) return "right";
+    return null;
   };
 
-  const handleRightDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event;
-    if (!over || active.id === over.id) return;
+  // Prefer pointer-based hit testing (precise at the two-group boundary) and
+  // fall back to closest-corners when the pointer sits in neither column —
+  // closestCenter jitters at horizontal edges.
+  const collisionDetection: CollisionDetection = useCallback((args) => {
+    const pointerHits = pointerWithin(args);
+    return pointerHits.length > 0 ? pointerHits : closestCorners(args);
+  }, []);
 
-    const oldIndex = layout.rightButtons.indexOf(active.id as AnyToolbarButtonId);
-    const newIndex = layout.rightButtons.indexOf(over.id as AnyToolbarButtonId);
-
-    if (oldIndex === -1 || newIndex === -1) return;
-
-    const newButtons = [...layout.rightButtons];
-    newButtons.splice(oldIndex, 1);
-    newButtons.splice(newIndex, 0, active.id as AnyToolbarButtonId);
-
-    setRightButtons(newButtons);
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveId(toButtonId(event.active.id));
+    setDragState({ left: layout.leftButtons, right: layout.rightButtons });
   };
 
-  const handleToggleLeft = (buttonId: AnyToolbarButtonId) =>
-    dispatchToolbarVisibility(buttonId, "left", {
+  // Speculatively relocate the dragged button across columns so the target's
+  // gap animation renders live. Same-column moves are left to the sortable
+  // strategy and committed in `handleDragEnd`.
+  const handleDragOver = (event: DragOverEvent) => {
+    const { active, over } = event;
+    if (!over) return;
+    const activeButtonId = toButtonId(active.id);
+
+    setDragState((prev) => {
+      const base = prev ?? { left: layout.leftButtons, right: layout.rightButtons };
+      const activeContainer = findContainer(active.id, base);
+      const overContainer = findContainer(over.id, base);
+      if (!activeContainer || !overContainer || activeContainer === overContainer) {
+        return base;
+      }
+
+      const overItems = base[overContainer];
+      const overIndex = overItems.indexOf(toButtonId(over.id));
+
+      let newIndex: number;
+      if (over.id === overContainer) {
+        newIndex = overItems.length;
+      } else {
+        const translatedRight = active.rect.current.translated?.right;
+        const isAfterOver =
+          translatedRight != null && translatedRight > over.rect.left + over.rect.width / 2;
+        newIndex = overIndex >= 0 ? overIndex + (isAfterOver ? 1 : 0) : overItems.length;
+      }
+
+      return {
+        ...base,
+        [activeContainer]: base[activeContainer].filter((id) => id !== activeButtonId),
+        [overContainer]: [
+          ...overItems.slice(0, newIndex),
+          activeButtonId,
+          ...overItems.slice(newIndex),
+        ],
+      };
+    });
+  };
+
+  const clearDrag = () => {
+    setDragState(null);
+    setActiveId(null);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    const activeButtonId = toButtonId(active.id);
+
+    if (!over) {
+      clearDrag();
+      return;
+    }
+
+    const live = dragState ?? { left: layout.leftButtons, right: layout.rightButtons };
+    const overContainer = findContainer(over.id, live);
+    const originalContainer: ToolbarSide | null = layout.leftButtons.includes(activeButtonId)
+      ? "left"
+      : layout.rightButtons.includes(activeButtonId)
+        ? "right"
+        : null;
+
+    if (!overContainer || !originalContainer) {
+      clearDrag();
+      return;
+    }
+
+    const overItems = live[overContainer];
+    const activeIndex = overItems.indexOf(activeButtonId);
+    const overIndex =
+      over.id === overContainer ? overItems.length - 1 : overItems.indexOf(toButtonId(over.id));
+
+    const finalItems =
+      overIndex !== -1 && activeIndex !== -1 && activeIndex !== overIndex
+        ? arrayMove(overItems, activeIndex, overIndex)
+        : overItems;
+
+    if (originalContainer === overContainer) {
+      // Same-side reorder — commit the reordered list directly.
+      if (overContainer === "left") {
+        setLeftButtons(finalItems);
+      } else {
+        setRightButtons(finalItems);
+      }
+    } else {
+      // Cross-side move — route through `moveButton` so its index fixup runs
+      // against the store's authoritative (un-mutated) arrays.
+      const toIndex = finalItems.indexOf(activeButtonId);
+      moveButton(activeButtonId, originalContainer, overContainer, toIndex);
+    }
+
+    clearDrag();
+  };
+
+  const handleDragCancel = (_event: DragCancelEvent) => {
+    clearDrag();
+  };
+
+  const handleToggle = (buttonId: AnyToolbarButtonId, side: ToolbarSide) =>
+    dispatchToolbarVisibility(buttonId, side, {
       agentSettings,
       agentAvailability,
       setAgentPinned,
       toggleButtonVisibility,
     });
 
-  const handleToggleRight = (buttonId: AnyToolbarButtonId) =>
-    dispatchToolbarVisibility(buttonId, "right", {
-      agentSettings,
-      agentAvailability,
-      setAgentPinned,
-      toggleButtonVisibility,
-    });
+  const activeMetadata = activeId ? allMetadata[activeId] : undefined;
 
   return (
     <div className="space-y-6">
       <SettingsSection
         icon={LayoutGrid}
-        title="Left side buttons"
-        description={`Drag to reorder, uncheck to hide. ${layout.leftButtons.filter((id) => isToolbarButtonVisible(id, layout.pinnedButtons, agentSettings, agentAvailability)).length} of ${layout.leftButtons.length} visible.`}
+        title="Toolbar buttons"
+        description="Drag to reorder within a side or move a button between the left and right groups. Toggle to show or hide."
       >
         <DndContext
           sensors={sensors}
-          collisionDetection={closestCenter}
-          onDragEnd={handleLeftDragEnd}
+          collisionDetection={collisionDetection}
+          onDragStart={handleDragStart}
+          onDragOver={handleDragOver}
+          onDragEnd={handleDragEnd}
+          onDragCancel={handleDragCancel}
           accessibility={{ announcements: toolbarButtonAnnouncements }}
         >
-          <SortableContext items={layout.leftButtons} strategy={verticalListSortingStrategy}>
-            <div className="space-y-2">
-              {layout.leftButtons.map((buttonId) => (
-                <SortableButtonItem
-                  key={buttonId}
-                  buttonId={buttonId}
-                  isVisible={isToolbarButtonVisible(
-                    buttonId,
-                    layout.pinnedButtons,
-                    agentSettings,
-                    agentAvailability
-                  )}
-                  onToggle={handleToggleLeft}
-                  allMetadata={allMetadata}
-                />
-              ))}
-            </div>
-          </SortableContext>
-        </DndContext>
-      </SettingsSection>
-
-      <SettingsSection
-        icon={LayoutGrid}
-        title="Right side buttons"
-        description={`Drag to reorder, uncheck to hide. ${layout.rightButtons.filter((id) => isToolbarButtonVisible(id, layout.pinnedButtons, agentSettings, agentAvailability)).length} of ${layout.rightButtons.length} visible.`}
-      >
-        <DndContext
-          sensors={sensors}
-          collisionDetection={closestCenter}
-          onDragEnd={handleRightDragEnd}
-          accessibility={{ announcements: toolbarButtonAnnouncements }}
-        >
-          <SortableContext items={layout.rightButtons} strategy={verticalListSortingStrategy}>
-            <div className="space-y-2">
-              {layout.rightButtons.map((buttonId) => (
-                <SortableButtonItem
-                  key={buttonId}
-                  buttonId={buttonId}
-                  isVisible={isToolbarButtonVisible(
-                    buttonId,
-                    layout.pinnedButtons,
-                    agentSettings,
-                    agentAvailability
-                  )}
-                  onToggle={handleToggleRight}
-                  allMetadata={allMetadata}
-                />
-              ))}
-            </div>
-          </SortableContext>
+          <div className="flex flex-row gap-4">
+            <ToolbarSideColumn
+              side="left"
+              label="Left side"
+              buttonIds={liveLeft}
+              allMetadata={allMetadata}
+              isVisible={isVisible}
+              onToggle={handleToggle}
+            />
+            <ToolbarSideColumn
+              side="right"
+              label="Right side"
+              buttonIds={liveRight}
+              allMetadata={allMetadata}
+              isVisible={isVisible}
+              onToggle={handleToggle}
+            />
+          </div>
+          <DragOverlay dropAnimation={dropAnimation}>
+            {activeId && activeMetadata ? (
+              <ToolbarButtonCard
+                metadata={activeMetadata}
+                isVisible={isVisible(activeId)}
+                draggable
+                isOverlay
+              />
+            ) : null}
+          </DragOverlay>
         </DndContext>
       </SettingsSection>
 
@@ -307,25 +515,16 @@ export function ToolbarSettingsTab() {
         <SettingsSection
           icon={McpServerIcon}
           title="Plugin buttons"
-          description={`Uncheck to hide. ${pluginButtonIds.filter((id) => isToolbarButtonVisible(id, layout.pinnedButtons, agentSettings, agentAvailability)).length} of ${pluginButtonIds.length} visible.`}
+          description={`Toggle to show or hide. ${pluginButtonIds.filter((id) => isVisible(id)).length} of ${pluginButtonIds.length} visible.`}
         >
           <div className="space-y-2">
             {pluginButtonIds.map((buttonId) => (
               <PluginButtonRow
                 key={buttonId}
                 buttonId={buttonId}
-                isVisible={isToolbarButtonVisible(
-                  buttonId,
-                  layout.pinnedButtons,
-                  agentSettings,
-                  agentAvailability
-                )}
+                isVisible={isVisible(buttonId)}
                 onToggle={(id) => toggleButtonVisibility(id, "right")}
-                metadata={
-                  (allMetadata as Partial<Record<AnyToolbarButtonId, ToolbarButtonMetadata>>)[
-                    buttonId
-                  ]
-                }
+                metadata={allMetadata[buttonId]}
               />
             ))}
           </div>

--- a/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, act } from "@testing-library/react";
 import type { AgentSettings } from "@shared/types";
 
 const setLeftButtonsMock = vi.fn();
 const setRightButtonsMock = vi.fn();
+const moveButtonMock = vi.fn();
 const toggleButtonVisibilityMock = vi.fn();
 const setAlwaysShowDevServerMock = vi.fn();
 const setDefaultSelectionMock = vi.fn();
@@ -23,24 +24,47 @@ interface ToolbarState {
   };
   setLeftButtons: typeof setLeftButtonsMock;
   setRightButtons: typeof setRightButtonsMock;
+  moveButton: typeof moveButtonMock;
   toggleButtonVisibility: typeof toggleButtonVisibilityMock;
   setAlwaysShowDevServer: typeof setAlwaysShowDevServerMock;
   setDefaultSelection: typeof setDefaultSelectionMock;
   reset: typeof resetMock;
 }
 
-let mockToolbarState: ToolbarState = {
-  layout: { leftButtons: [], rightButtons: [], pinnedButtons: {} },
-  launcher: { alwaysShowDevServer: false, defaultSelection: undefined },
-  setLeftButtons: setLeftButtonsMock,
-  setRightButtons: setRightButtonsMock,
-  toggleButtonVisibility: toggleButtonVisibilityMock,
-  setAlwaysShowDevServer: setAlwaysShowDevServerMock,
-  setDefaultSelection: setDefaultSelectionMock,
-  reset: resetMock,
-};
+function makeToolbarState(
+  layout: ToolbarState["layout"] = {
+    // Mix of agent IDs and non-agent IDs so we can test both branches.
+    leftButtons: ["agent-tray", "claude", "gemini", "terminal"],
+    rightButtons: ["copy-tree", "settings"],
+    pinnedButtons: {},
+  }
+): ToolbarState {
+  return {
+    layout,
+    launcher: { alwaysShowDevServer: false, defaultSelection: undefined },
+    setLeftButtons: setLeftButtonsMock,
+    setRightButtons: setRightButtonsMock,
+    moveButton: moveButtonMock,
+    toggleButtonVisibility: toggleButtonVisibilityMock,
+    setAlwaysShowDevServer: setAlwaysShowDevServerMock,
+    setDefaultSelection: setDefaultSelectionMock,
+    reset: resetMock,
+  };
+}
 
+let mockToolbarState: ToolbarState = makeToolbarState();
 let mockAgentSettings: AgentSettings | null = null;
+
+function clearStoreMocks() {
+  setLeftButtonsMock.mockClear();
+  setRightButtonsMock.mockClear();
+  moveButtonMock.mockClear();
+  toggleButtonVisibilityMock.mockClear();
+  setAlwaysShowDevServerMock.mockClear();
+  setDefaultSelectionMock.mockClear();
+  resetMock.mockClear();
+  setAgentPinnedMock.mockClear();
+}
 
 vi.mock("@/store", () => ({
   useToolbarPreferencesStore: (selector: (s: ToolbarState) => unknown) =>
@@ -82,14 +106,23 @@ vi.mock("@/hooks/usePluginToolbarButtons", () => ({
   usePluginToolbarButtons: () => ({ buttonIds: [], configs: new Map() }),
 }));
 
-// @dnd-kit renders a sortable context plus listeners for each row. For unit
-// tests we only care about the rendered rows and the checkbox toggle paths —
-// stub the context and sortable hook so drag behavior doesn't need a real DOM.
+// Capture the single DndContext's props so tests can drive the drag handlers
+// directly — the mock renders children but never wires real pointer events.
+const dnd = vi.hoisted(() => ({
+  props: null as Record<string, (event: unknown) => void> | null,
+}));
+
 vi.mock("@dnd-kit/core", () => ({
-  DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  closestCenter: vi.fn(),
+  DndContext: (props: { children: React.ReactNode } & Record<string, unknown>) => {
+    dnd.props = props as unknown as Record<string, (event: unknown) => void>;
+    return <>{props.children}</>;
+  },
+  DragOverlay: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  closestCorners: vi.fn(),
+  pointerWithin: vi.fn(),
   KeyboardSensor: vi.fn(),
   PointerSensor: vi.fn(),
+  useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
   useSensor: vi.fn(),
   useSensors: () => [],
 }));
@@ -105,14 +138,17 @@ vi.mock("@dnd-kit/sortable", () => ({
     transition: null,
     isDragging: false,
   })),
-  verticalListSortingStrategy: vi.fn(),
+  rectSortingStrategy: vi.fn(),
+  arrayMove: <T,>(arr: T[], from: number, to: number): T[] => {
+    const next = arr.slice();
+    const [item] = next.splice(from, 1);
+    next.splice(to, 0, item as T);
+    return next;
+  },
 }));
 
 // Test-time helper for restoring the default useSortable return between
 // cases (the mock factory above is hoisted, so it can't reference this).
-// The component only reads transform/transition/isDragging/listeners/
-// attributes/setNodeRef; the cast keeps the partial shape without
-// reconstructing dnd-kit's full ~20-field return type.
 const defaultSortable = (): ReturnType<typeof useSortable> =>
   ({
     attributes: {},
@@ -147,6 +183,34 @@ vi.mock("../SettingsSwitchCard", () => ({
   SettingsSwitchCard: () => null,
 }));
 
+// Render the switch as a plain role="switch" button so tests stay decoupled
+// from Radix's pointer-event internals while preserving the aria contract.
+vi.mock("../SettingsSwitch", () => ({
+  SettingsSwitch: ({
+    checked,
+    onCheckedChange,
+    "aria-label": ariaLabel,
+    className,
+  }: {
+    checked: boolean;
+    onCheckedChange: (next: boolean) => void;
+    "aria-label"?: string;
+    className?: string;
+  }) => (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      data-state={checked ? "checked" : "unchecked"}
+      className={className}
+      onClick={() => onCheckedChange(!checked)}
+    >
+      {ariaLabel}
+    </button>
+  ),
+}));
+
 import { useSortable } from "@dnd-kit/sortable";
 import { DRAG_GHOST_OPACITY } from "@/lib/animationUtils";
 import { ToolbarSettingsTab } from "../ToolbarSettingsTab";
@@ -157,29 +221,9 @@ function agentSettings(overrides: Record<string, { pinned?: boolean }>): AgentSe
 
 describe("ToolbarSettingsTab — agent visibility routing", () => {
   beforeEach(() => {
-    setLeftButtonsMock.mockClear();
-    setRightButtonsMock.mockClear();
-    toggleButtonVisibilityMock.mockClear();
-    setAlwaysShowDevServerMock.mockClear();
-    setDefaultSelectionMock.mockClear();
-    resetMock.mockClear();
-    setAgentPinnedMock.mockClear();
-
-    mockToolbarState = {
-      layout: {
-        // Mix of agent IDs and non-agent IDs so we can test both branches.
-        leftButtons: ["agent-tray", "claude", "gemini", "terminal"],
-        rightButtons: ["copy-tree", "settings"],
-        pinnedButtons: {},
-      },
-      launcher: { alwaysShowDevServer: false, defaultSelection: undefined },
-      setLeftButtons: setLeftButtonsMock,
-      setRightButtons: setRightButtonsMock,
-      toggleButtonVisibility: toggleButtonVisibilityMock,
-      setAlwaysShowDevServer: setAlwaysShowDevServerMock,
-      setDefaultSelection: setDefaultSelectionMock,
-      reset: resetMock,
-    };
+    clearStoreMocks();
+    vi.mocked(useSortable).mockImplementation(defaultSortable);
+    mockToolbarState = makeToolbarState();
     mockAgentSettings = null;
   });
 
@@ -191,10 +235,12 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
 
     const { getByLabelText } = render(<ToolbarSettingsTab />);
 
-    const claudeCheckbox = getByLabelText("Toggle Claude agent visibility") as HTMLInputElement;
-    const geminiCheckbox = getByLabelText("Toggle Gemini agent visibility") as HTMLInputElement;
-    expect(claudeCheckbox.checked).toBe(true);
-    expect(geminiCheckbox.checked).toBe(false);
+    expect(getByLabelText("Toggle Claude agent visibility").getAttribute("aria-checked")).toBe(
+      "true"
+    );
+    expect(getByLabelText("Toggle Gemini agent visibility").getAttribute("aria-checked")).toBe(
+      "false"
+    );
   });
 
   it("ignores pinnedButtons for agent IDs (agentSettingsStore wins)", () => {
@@ -207,11 +253,12 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     });
 
     const { getByLabelText } = render(<ToolbarSettingsTab />);
-    const claudeCheckbox = getByLabelText("Toggle Claude agent visibility") as HTMLInputElement;
-    expect(claudeCheckbox.checked).toBe(true);
+    expect(getByLabelText("Toggle Claude agent visibility").getAttribute("aria-checked")).toBe(
+      "true"
+    );
   });
 
-  it("routes agent checkbox toggle to setAgentPinned (not toggleButtonVisibility)", () => {
+  it("routes agent switch toggle to setAgentPinned (not toggleButtonVisibility)", () => {
     mockAgentSettings = agentSettings({
       claude: { pinned: true },
     });
@@ -224,7 +271,7 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     expect(toggleButtonVisibilityMock).not.toHaveBeenCalled();
   });
 
-  it("routes agent checkbox toggle upward (unpinned → pinned) via setAgentPinned", () => {
+  it("routes agent switch toggle upward (unpinned → pinned) via setAgentPinned", () => {
     mockAgentSettings = agentSettings({
       gemini: { pinned: false },
     });
@@ -236,7 +283,7 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     expect(toggleButtonVisibilityMock).not.toHaveBeenCalled();
   });
 
-  it("keeps non-agent checkbox toggle on toggleButtonVisibility", () => {
+  it("keeps non-agent switch toggle on toggleButtonVisibility", () => {
     const { getByLabelText } = render(<ToolbarSettingsTab />);
     fireEvent.click(getByLabelText("Toggle Terminal visibility"));
 
@@ -247,8 +294,8 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
 
   it("dispatches `'right'` as the side argument for right-side non-agent toggles", () => {
     // Locks the side argument so future side-aware store changes can't
-    // silently swallow the right-side branch — both handlers (left, right)
-    // are nominally identical today but each is independently wired.
+    // silently swallow the right-side branch — both columns are nominally
+    // identical today but each is independently wired.
     const { getByLabelText } = render(<ToolbarSettingsTab />);
     fireEvent.click(getByLabelText("Toggle Copy context visibility"));
 
@@ -256,25 +303,25 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     expect(toggleButtonVisibilityMock).toHaveBeenCalledWith("copy-tree", "right");
   });
 
-  it("reflects pinned agents in the section visible-count summary", () => {
+  it("reflects pinned agents in the side visible-count summary", () => {
     mockAgentSettings = agentSettings({
       claude: { pinned: true },
       gemini: { pinned: false },
     });
 
-    const { getByTestId } = render(<ToolbarSettingsTab />);
+    const { getByText } = render(<ToolbarSettingsTab />);
     // Left side: agent-tray (visible), claude (pinned, visible),
     // gemini (unpinned, not visible), terminal (not hidden, visible) => 3 / 4.
-    const leftSection = getByTestId("section-Left side buttons");
-    expect(leftSection.getAttribute("data-description")).toContain("3 of 4 visible");
+    expect(getByText("3/4")).toBeTruthy();
   });
 
   it("treats null agentSettings as all-unpinned without crashing", () => {
     mockAgentSettings = null;
 
     const { getByLabelText } = render(<ToolbarSettingsTab />);
-    const claudeCheckbox = getByLabelText("Toggle Claude agent visibility") as HTMLInputElement;
-    expect(claudeCheckbox.checked).toBe(false);
+    expect(getByLabelText("Toggle Claude agent visibility").getAttribute("aria-checked")).toBe(
+      "false"
+    );
   });
 
   it("handles a right-side agent correctly (routes through setAgentPinned)", () => {
@@ -296,36 +343,108 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
   });
 });
 
+describe("ToolbarSettingsTab — drag reordering and cross-side moves", () => {
+  beforeEach(() => {
+    clearStoreMocks();
+    vi.mocked(useSortable).mockImplementation(defaultSortable);
+    mockToolbarState = makeToolbarState();
+    mockAgentSettings = null;
+  });
+
+  function fire(name: string, event: unknown) {
+    act(() => {
+      dnd.props?.[name]?.(event);
+    });
+  }
+
+  it("commits a same-side reorder via setLeftButtons (not moveButton)", () => {
+    render(<ToolbarSettingsTab />);
+
+    // Drag "agent-tray" (index 0) onto "terminal" (index 3) within the left side.
+    fire("onDragEnd", { active: { id: "agent-tray" }, over: { id: "terminal" } });
+
+    expect(setLeftButtonsMock).toHaveBeenCalledTimes(1);
+    expect(setLeftButtonsMock).toHaveBeenCalledWith(["claude", "gemini", "terminal", "agent-tray"]);
+    expect(moveButtonMock).not.toHaveBeenCalled();
+  });
+
+  it("commits a cross-side move via moveButton with the resolved target index", () => {
+    render(<ToolbarSettingsTab />);
+
+    // Drag "claude" from the left side onto "settings" (right side, index 1).
+    fire("onDragStart", { active: { id: "claude" } });
+    fire("onDragOver", {
+      active: { id: "claude", rect: { current: { translated: { right: 1000 } } } },
+      over: { id: "settings", rect: { left: 0, width: 100 } },
+    });
+    fire("onDragEnd", { active: { id: "claude" }, over: { id: "settings" } });
+
+    expect(moveButtonMock).toHaveBeenCalledTimes(1);
+    expect(moveButtonMock).toHaveBeenCalledWith("claude", "left", "right", 1);
+    expect(setLeftButtonsMock).not.toHaveBeenCalled();
+    expect(setRightButtonsMock).not.toHaveBeenCalled();
+  });
+
+  it("supports dropping onto an empty side without crashing", () => {
+    mockToolbarState = makeToolbarState({
+      leftButtons: ["agent-tray", "terminal"],
+      rightButtons: [],
+      pinnedButtons: {},
+    });
+
+    render(<ToolbarSettingsTab />);
+
+    fire("onDragStart", { active: { id: "terminal" } });
+    fire("onDragOver", {
+      active: { id: "terminal", rect: { current: { translated: { right: 1000 } } } },
+      over: { id: "right", rect: { left: 0, width: 100 } },
+    });
+    fire("onDragEnd", { active: { id: "terminal" }, over: { id: "right" } });
+
+    expect(moveButtonMock).toHaveBeenCalledWith("terminal", "left", "right", 0);
+  });
+
+  it("does not mutate the store when a drag is cancelled", () => {
+    render(<ToolbarSettingsTab />);
+
+    fire("onDragStart", { active: { id: "agent-tray" } });
+    fire("onDragCancel", {});
+
+    expect(setLeftButtonsMock).not.toHaveBeenCalled();
+    expect(setRightButtonsMock).not.toHaveBeenCalled();
+    expect(moveButtonMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores a drop with no target (over === null)", () => {
+    render(<ToolbarSettingsTab />);
+
+    fire("onDragEnd", { active: { id: "claude" }, over: null });
+
+    expect(setLeftButtonsMock).not.toHaveBeenCalled();
+    expect(setRightButtonsMock).not.toHaveBeenCalled();
+    expect(moveButtonMock).not.toHaveBeenCalled();
+  });
+});
+
 describe("ToolbarSettingsTab — drag-source vs hidden opacity deconfliction", () => {
   // The drag-source ghost (DRAG_GHOST_OPACITY) and the hidden-in-toolbar
   // preview (0.5) are semantically distinct states that previously shared a
   // magic 0.5. These tests lock the deconfliction so the two values can't
   // silently collapse back together.
   beforeEach(() => {
-    setAgentPinnedMock.mockClear();
+    clearStoreMocks();
     vi.mocked(useSortable).mockImplementation(defaultSortable);
-    mockToolbarState = {
-      layout: {
-        leftButtons: ["agent-tray", "claude", "gemini", "terminal"],
-        rightButtons: ["copy-tree", "settings"],
-        pinnedButtons: {},
-      },
-      launcher: { alwaysShowDevServer: false, defaultSelection: undefined },
-      setLeftButtons: setLeftButtonsMock,
-      setRightButtons: setRightButtonsMock,
-      toggleButtonVisibility: toggleButtonVisibilityMock,
-      setAlwaysShowDevServer: setAlwaysShowDevServerMock,
-      setDefaultSelection: setDefaultSelectionMock,
-      reset: resetMock,
-    };
+    mockToolbarState = makeToolbarState();
     mockAgentSettings = null;
   });
 
+  // The opacity-bearing node is the sortable wrapper (`setNodeRef` div): it is
+  // the switch's grandparent — switch → card root → sortable wrapper.
   function rowFor(label: string, container: HTMLElement): HTMLElement {
-    const checkbox = container.querySelector(
-      `input[aria-label="Toggle ${label} visibility"]`
-    ) as HTMLInputElement;
-    return checkbox.parentElement as HTMLElement;
+    const toggle = container.querySelector(
+      `button[role="switch"][aria-label="Toggle ${label} visibility"]`
+    ) as HTMLElement;
+    return toggle.parentElement!.parentElement as HTMLElement;
   }
 
   it("applies DRAG_GHOST_OPACITY to a dragged row (not the legacy 0.5)", () => {
@@ -353,7 +472,7 @@ describe("ToolbarSettingsTab — drag-source vs hidden opacity deconfliction", (
     }));
 
     const { container } = render(<ToolbarSettingsTab />);
-    const row = rowFor("Gemini Agent", container);
+    const row = rowFor("Gemini agent", container);
     expect(row.style.opacity).toBe(String(DRAG_GHOST_OPACITY));
   });
 
@@ -362,7 +481,7 @@ describe("ToolbarSettingsTab — drag-source vs hidden opacity deconfliction", (
     mockAgentSettings = agentSettings({ gemini: { pinned: false } });
 
     const { container } = render(<ToolbarSettingsTab />);
-    const row = rowFor("Gemini Agent", container);
+    const row = rowFor("Gemini agent", container);
     expect(row.style.opacity).toBe("0.5");
   });
 
@@ -370,7 +489,7 @@ describe("ToolbarSettingsTab — drag-source vs hidden opacity deconfliction", (
     mockAgentSettings = agentSettings({ claude: { pinned: true } });
 
     const { container } = render(<ToolbarSettingsTab />);
-    const row = rowFor("Claude Agent", container);
+    const row = rowFor("Claude agent", container);
     expect(row.style.opacity).toBe("1");
   });
 });

--- a/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
@@ -368,10 +368,12 @@ describe("ToolbarSettingsTab — drag reordering and cross-side moves", () => {
     expect(moveButtonMock).not.toHaveBeenCalled();
   });
 
-  it("commits a cross-side move via moveButton with the resolved target index", () => {
+  it("commits a cross-side move after the hovered item (right edge past midpoint)", () => {
     render(<ToolbarSettingsTab />);
 
-    // Drag "claude" from the left side onto "settings" (right side, index 1).
+    // Drag "claude" onto "settings" (right side, last at index 1) with its
+    // right edge well past the midpoint → it should land *after* settings,
+    // i.e. at index 2 (the end of the right list).
     fire("onDragStart", { active: { id: "claude" } });
     fire("onDragOver", {
       active: { id: "claude", rect: { current: { translated: { right: 1000 } } } },
@@ -380,7 +382,59 @@ describe("ToolbarSettingsTab — drag reordering and cross-side moves", () => {
     fire("onDragEnd", { active: { id: "claude" }, over: { id: "settings" } });
 
     expect(moveButtonMock).toHaveBeenCalledTimes(1);
-    expect(moveButtonMock).toHaveBeenCalledWith("claude", "left", "right", 1);
+    expect(moveButtonMock).toHaveBeenCalledWith("claude", "left", "right", 2);
+    expect(setLeftButtonsMock).not.toHaveBeenCalled();
+    expect(setRightButtonsMock).not.toHaveBeenCalled();
+  });
+
+  it("commits a cross-side move before the hovered item (right edge before midpoint)", () => {
+    render(<ToolbarSettingsTab />);
+
+    // Drag "claude" onto "copy-tree" (right side, first at index 0) with its
+    // right edge before the midpoint → it should land *before* copy-tree,
+    // i.e. at index 0.
+    fire("onDragStart", { active: { id: "claude" } });
+    fire("onDragOver", {
+      active: { id: "claude", rect: { current: { translated: { right: 0 } } } },
+      over: { id: "copy-tree", rect: { left: 0, width: 100 } },
+    });
+    fire("onDragEnd", { active: { id: "claude" }, over: { id: "copy-tree" } });
+
+    expect(moveButtonMock).toHaveBeenCalledTimes(1);
+    expect(moveButtonMock).toHaveBeenCalledWith("claude", "left", "right", 0);
+  });
+
+  it("moves the only button off a side, leaving it empty", () => {
+    mockToolbarState = makeToolbarState({
+      leftButtons: ["terminal"],
+      rightButtons: ["copy-tree"],
+      pinnedButtons: {},
+    });
+
+    render(<ToolbarSettingsTab />);
+
+    fire("onDragStart", { active: { id: "terminal" } });
+    fire("onDragOver", {
+      active: { id: "terminal", rect: { current: { translated: { right: 1000 } } } },
+      over: { id: "copy-tree", rect: { left: 0, width: 100 } },
+    });
+    fire("onDragEnd", { active: { id: "terminal" }, over: { id: "copy-tree" } });
+
+    expect(moveButtonMock).toHaveBeenCalledTimes(1);
+    expect(moveButtonMock).toHaveBeenCalledWith("terminal", "left", "right", 1);
+    expect(setLeftButtonsMock).not.toHaveBeenCalled();
+    expect(setRightButtonsMock).not.toHaveBeenCalled();
+  });
+
+  it("does not commit a cross-side drop that never ran onDragOver (no speculative state)", () => {
+    // Without an onDragOver pass the dragged button was never relocated into
+    // the target list, so its target index is unresolved — the guard must
+    // skip the commit rather than splice at -1.
+    render(<ToolbarSettingsTab />);
+
+    fire("onDragEnd", { active: { id: "claude" }, over: { id: "settings" } });
+
+    expect(moveButtonMock).not.toHaveBeenCalled();
     expect(setLeftButtonsMock).not.toHaveBeenCalled();
     expect(setRightButtonsMock).not.toHaveBeenCalled();
   });

--- a/src/components/__tests__/agentPinSync.integration.test.tsx
+++ b/src/components/__tests__/agentPinSync.integration.test.tsx
@@ -261,9 +261,12 @@ vi.mock("@/hooks/usePluginToolbarButtons", () => ({
 
 vi.mock("@dnd-kit/core", () => ({
   DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  closestCenter: vi.fn(),
+  DragOverlay: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  closestCorners: vi.fn(),
+  pointerWithin: vi.fn(),
   KeyboardSensor: vi.fn(),
   PointerSensor: vi.fn(),
+  useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
   useSensor: vi.fn(),
   useSensors: () => [],
 }));
@@ -279,7 +282,13 @@ vi.mock("@dnd-kit/sortable", () => ({
     transition: null,
     isDragging: false,
   }),
-  verticalListSortingStrategy: vi.fn(),
+  rectSortingStrategy: vi.fn(),
+  arrayMove: <T,>(arr: T[], from: number, to: number): T[] => {
+    const next = arr.slice();
+    const [item] = next.splice(from, 1);
+    next.splice(to, 0, item as T);
+    return next;
+  },
 }));
 
 vi.mock("@dnd-kit/utilities", () => ({ CSS: { Transform: { toString: () => "" } } }));
@@ -290,6 +299,31 @@ vi.mock("@/components/Settings/SettingsSection", () => ({
 
 vi.mock("@/components/Settings/SettingsSwitchCard", () => ({
   SettingsSwitchCard: () => null,
+}));
+
+// Render the switch as a plain role="switch" button so these cross-store sync
+// assertions stay decoupled from Radix internals (and so `aria-checked`
+// reflects the derived visibility state).
+vi.mock("@/components/Settings/SettingsSwitch", () => ({
+  SettingsSwitch: ({
+    checked,
+    onCheckedChange,
+    "aria-label": ariaLabel,
+  }: {
+    checked: boolean;
+    onCheckedChange: (next: boolean) => void;
+    "aria-label"?: string;
+  }) => (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      onClick={() => onCheckedChange(!checked)}
+    >
+      {ariaLabel}
+    </button>
+  ),
 }));
 
 import { AgentTrayButton } from "@/components/Layout/AgentTrayButton";
@@ -338,11 +372,9 @@ describe("agent pin sync — Settings > Toolbar and Agent Tray share state (#511
     tray.unmount();
 
     const settings = render(<ToolbarSettingsTab />);
-    const claudeCheckbox = settings.getByLabelText(
-      "Toggle Claude agent visibility"
-    ) as HTMLInputElement;
-    expect(claudeCheckbox.checked).toBe(true);
-    fireEvent.click(claudeCheckbox);
+    const claudeSwitch = settings.getByLabelText("Toggle Claude agent visibility");
+    expect(claudeSwitch.getAttribute("aria-checked")).toBe("true");
+    fireEvent.click(claudeSwitch);
     expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", false);
     settings.unmount();
 
@@ -366,10 +398,8 @@ describe("agent pin sync — Settings > Toolbar and Agent Tray share state (#511
 
     // Initial Settings render: gemini unchecked.
     const settings = render(<ToolbarSettingsTab />);
-    const geminiCheckboxA = settings.getByLabelText(
-      "Toggle Gemini agent visibility"
-    ) as HTMLInputElement;
-    expect(geminiCheckboxA.checked).toBe(false);
+    const geminiSwitchA = settings.getByLabelText("Toggle Gemini agent visibility");
+    expect(geminiSwitchA.getAttribute("aria-checked")).toBe("false");
     settings.unmount();
 
     // User clicks the pin indicator in the tray for gemini.
@@ -381,10 +411,8 @@ describe("agent pin sync — Settings > Toolbar and Agent Tray share state (#511
     // Re-render Settings — gemini is now checked because the shared store
     // picked up the tray's write.
     const settings2 = render(<ToolbarSettingsTab />);
-    const geminiCheckboxB = settings2.getByLabelText(
-      "Toggle Gemini agent visibility"
-    ) as HTMLInputElement;
-    expect(geminiCheckboxB.checked).toBe(true);
+    const geminiSwitchB = settings2.getByLabelText("Toggle Gemini agent visibility");
+    expect(geminiSwitchB.getAttribute("aria-checked")).toBe("true");
   });
 
   it("undefined-pin agent with ready availability renders checked and toggles to false", () => {
@@ -393,11 +421,9 @@ describe("agent pin sync — Settings > Toolbar and Agent Tray share state (#511
     sharedAvailability = { claude: "ready" } as unknown as CliAvailability;
 
     const settings = render(<ToolbarSettingsTab />);
-    const claudeCheckbox = settings.getByLabelText(
-      "Toggle Claude agent visibility"
-    ) as HTMLInputElement;
-    expect(claudeCheckbox.checked).toBe(true);
-    fireEvent.click(claudeCheckbox);
+    const claudeSwitch = settings.getByLabelText("Toggle Claude agent visibility");
+    expect(claudeSwitch.getAttribute("aria-checked")).toBe("true");
+    fireEvent.click(claudeSwitch);
     expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", false);
   });
 
@@ -406,11 +432,9 @@ describe("agent pin sync — Settings > Toolbar and Agent Tray share state (#511
     sharedAvailability = { gemini: "missing" } as unknown as CliAvailability;
 
     const settings = render(<ToolbarSettingsTab />);
-    const geminiCheckbox = settings.getByLabelText(
-      "Toggle Gemini agent visibility"
-    ) as HTMLInputElement;
-    expect(geminiCheckbox.checked).toBe(false);
-    fireEvent.click(geminiCheckbox);
+    const geminiSwitch = settings.getByLabelText("Toggle Gemini agent visibility");
+    expect(geminiSwitch.getAttribute("aria-checked")).toBe("false");
+    fireEvent.click(geminiSwitch);
     expect(setAgentPinnedMock).toHaveBeenCalledWith("gemini", true);
   });
 

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -197,7 +197,6 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
     "src/components/Settings/SettingsSubtabBar.tsx",
     "src/components/Settings/SettingsSwitchCard.tsx",
     "src/components/Settings/TerminalSettingsTab.tsx",
-    "src/components/Settings/ToolbarSettingsTab.tsx",
     "src/components/Settings/WorktreeSettingsTab.tsx",
     "src/components/Setup/AgentCliStep.tsx",
     "src/components/Terminal/ContentGridDefault.tsx",


### PR DESCRIPTION
## Summary

- The toolbar settings editor showed two stacked vertical drag lists with native accent-tinted checkboxes — a button's left/right side placement was invisible and immutable, even though `moveButton` in the store was already wired for cross-side moves. Half-shipped capability.
- Redesigned `ToolbarSettingsTab` into two side-by-side group columns (left/right) inside a single `DndContext` so side placement is legible at a glance and cross-side drag is live.
- Replaced native checkboxes with `SettingsSwitch` on every row (built-in + plugin), keeping state-invariant "Toggle {label} visibility" aria-labels.

Resolves #9826

## Changes

**Layout and DnD**
- Two columns, each a `useDroppable` target, so empty sides still accept drops
- `pointerWithin` → `closestCorners` collision detection
- `DragOverlay` backed by an extracted presentational `ToolbarButtonCard`
- `onDragOver` speculatively relocates across columns for live gap animation; `onDragEnd` commits — same-side via `setLeftButtons`/`setRightButtons` + `arrayMove`, cross-side via `moveButton` reading the speculative drop index
- Plugin buttons stay hide-only: no drag handle, no cross-side option

**Deviation from issue suggestion:** used `rectSortingStrategy` instead of `horizontalListSortingStrategy` — the chips wrap within each group panel and `horizontalListSortingStrategy` assumes a single non-wrapping row.

**Design details**
- Neutral `bg-overlay-subtle` surfaces, Tier-1 motion
- `SettingsSwitch` default scheme paints the checked track neutral (accent only on focus), so accent-restraint holds across all rows
- Single `makeSortableAnnouncements` wiring (#8990); `transform` kept on single `setNodeRef` node (#9029)

## Testing

21 unit tests pass — added cross-side placement and guard coverage, migrated checkbox assertions to `role=switch`. `npm run check` fully green: typecheck, IPC/confirm-wiring guards, lint ratchet warnings down 6, format clean.