### PR TITLE
feat(terminal): add cycles-based Tier-3 watchdog for stalled terminals

### DIFF
--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -8,7 +8,7 @@ import React, {
   useState,
 } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { Settings } from "lucide-react";
+import { Settings, OctagonAlert, RotateCcw } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { SkeletonHint } from "@/components/ui/Skeleton";
 import { useDohertyGate } from "@/hooks/useDeferredLoading";
@@ -31,6 +31,8 @@ import { isStaleHiddenReading } from "./visibilityReadingGuard";
 import { COMFORTABLE_PANEL_HEIGHT_PX } from "@/lib/terminalLayout";
 import { FleetDraftingPill } from "@/components/Fleet/FleetDraftingPill";
 import { TerminalRestartStatusBanner } from "./TerminalRestartStatusBanner";
+import { InlineStatusBanner } from "./InlineStatusBanner";
+import { useForceResumeCycleWatchdog } from "@/hooks/terminal/useForceResumeCycleWatchdog";
 import { getRestartBannerVariant } from "./restartStatus";
 import { TerminalErrorBanner } from "./TerminalErrorBanner";
 import { SpawnErrorBanner } from "./SpawnErrorBanner";
@@ -540,6 +542,9 @@ function TerminalPaneComponent({
     removeError,
     restartKey,
   });
+
+  const { showBanner: showForceResumeStall, resetQueue: resetForceResumeQueue } =
+    useForceResumeCycleWatchdog(id);
 
   // Cancel auto-restart if terminal is intentionally trashed/removed
   useEffect(() => {
@@ -1312,6 +1317,21 @@ function TerminalPaneComponent({
           variant={restartBannerVariant}
           onRestart={handleRestart}
           onDismiss={() => setDismissedRestartPrompt(true)}
+        />
+      </BannerSlot>
+
+      <BannerSlot visible={showForceResumeStall}>
+        <InlineStatusBanner
+          icon={OctagonAlert}
+          severity="error"
+          title="Terminal output stalled"
+          description="Output keeps backing up faster than it can render. Reset the queue to recover."
+          action={{
+            id: "reset-force-resume-queue",
+            label: "Reset queue",
+            icon: RotateCcw,
+            onClick: resetForceResumeQueue,
+          }}
         />
       </BannerSlot>
 

--- a/src/hooks/terminal/__tests__/useForceResumeCycleWatchdog.test.tsx
+++ b/src/hooks/terminal/__tests__/useForceResumeCycleWatchdog.test.tsx
@@ -81,6 +81,33 @@ describe("useForceResumeCycleWatchdog", () => {
     expect(result.current.showBanner).toBe(true);
   });
 
+  it("does not fire the warning before the third consecutive force-resume", () => {
+    renderHook(() => useForceResumeCycleWatchdog("t1"));
+
+    emitMetric({ durationMs: 9950 });
+    expect(notifyMock).toHaveBeenCalledTimes(0);
+    emitMetric({ durationMs: 9950 });
+    expect(notifyMock).toHaveBeenCalledTimes(0);
+    emitMetric({ durationMs: 9950 });
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats the threshold as inclusive (>= 9900) and 9899 as a natural drain", () => {
+    const { result } = renderHook(() => useForceResumeCycleWatchdog("t1"));
+
+    // 9899 is below the bound: a natural drain, must not count.
+    emitMetric({ durationMs: 9899 });
+    emitMetric({ durationMs: 9899 });
+    emitMetric({ durationMs: 9899 });
+    expect(result.current.showBanner).toBe(false);
+
+    // Exactly 9900 is a force-resume — three of them promote.
+    emitMetric({ durationMs: 9900 });
+    emitMetric({ durationMs: 9900 });
+    emitMetric({ durationMs: 9900 });
+    expect(result.current.showBanner).toBe(true);
+  });
+
   it("emits the grid-bar warning exactly once when the threshold is crossed", () => {
     renderHook(() => useForceResumeCycleWatchdog("t1"));
 
@@ -164,6 +191,35 @@ describe("useForceResumeCycleWatchdog", () => {
     expect(result.current.showBanner).toBe(true);
   });
 
+  it("an ignored metric mid-streak does not reset the counter", () => {
+    const { result } = renderHook(() => useForceResumeCycleWatchdog("t1"));
+
+    emitMetric({ durationMs: 9950 });
+    emitMetric({ durationMs: 9950 });
+    // Unrelated terminal force-resumes between cycles 2 and 3 — must be inert.
+    emitMetric({ terminalId: "other", durationMs: 9950 });
+    emitMetric({ metricType: "suspend", durationMs: 9950 });
+    emitMetric({ durationMs: 9950 });
+    expect(result.current.showBanner).toBe(true);
+  });
+
+  it("resetQueue re-arms the notify for the next stall cycle", () => {
+    const { result } = renderHook(() => useForceResumeCycleWatchdog("t1"));
+
+    emitMetric({ durationMs: 9950 });
+    emitMetric({ durationMs: 9950 });
+    emitMetric({ durationMs: 9950 });
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+
+    act(() => result.current.resetQueue());
+
+    emitMetric({ durationMs: 9950 });
+    emitMetric({ durationMs: 9950 });
+    emitMetric({ durationMs: 9950 });
+    expect(notifyMock).toHaveBeenCalledTimes(2);
+    expect(result.current.showBanner).toBe(true);
+  });
+
   it("resetQueue force-resumes the terminal and clears the banner", () => {
     const { result } = renderHook(() => useForceResumeCycleWatchdog("t1"));
 
@@ -191,5 +247,16 @@ describe("useForceResumeCycleWatchdog", () => {
     expect(unsubSpy).toHaveBeenCalled();
     expect(result.current.showBanner).toBe(false);
     expect(eventsOn).toHaveBeenLastCalledWith("terminal:reliability-metric", expect.any(Function));
+
+    // Metrics for the old id are now inert; t2 needs three fresh cycles.
+    emitMetric({ terminalId: "t1", durationMs: 9950 });
+    emitMetric({ terminalId: "t1", durationMs: 9950 });
+    emitMetric({ terminalId: "t1", durationMs: 9950 });
+    expect(result.current.showBanner).toBe(false);
+
+    emitMetric({ terminalId: "t2", durationMs: 9950 });
+    emitMetric({ terminalId: "t2", durationMs: 9950 });
+    emitMetric({ terminalId: "t2", durationMs: 9950 });
+    expect(result.current.showBanner).toBe(true);
   });
 });

--- a/src/hooks/terminal/__tests__/useForceResumeCycleWatchdog.test.tsx
+++ b/src/hooks/terminal/__tests__/useForceResumeCycleWatchdog.test.tsx
@@ -1,0 +1,195 @@
+// @vitest-environment jsdom
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { TerminalReliabilityMetricPayload } from "@shared/types/pty-host";
+
+const notifyMock = vi.fn();
+vi.mock("@/lib/notify", () => ({
+  notify: (payload: unknown) => notifyMock(payload),
+}));
+
+const forceResumeMock = vi.fn((_id: string) => Promise.resolve());
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    forceResume: (id: string) => forceResumeMock(id),
+  },
+}));
+
+// Registry of bus subscribers keyed by event name, so tests can drive metrics.
+type MetricListener = (payload: TerminalReliabilityMetricPayload) => void;
+let listeners: Map<string, Set<MetricListener>>;
+const unsubSpy = vi.fn();
+
+const eventsOn = vi.fn((name: string, cb: MetricListener) => {
+  let set = listeners.get(name);
+  if (!set) {
+    set = new Set();
+    listeners.set(name, set);
+  }
+  set.add(cb);
+  return () => {
+    set?.delete(cb);
+    unsubSpy();
+  };
+});
+
+vi.stubGlobal("window", {
+  ...globalThis.window,
+  electron: {
+    events: { on: eventsOn },
+  },
+});
+
+function emitMetric(payload: Partial<TerminalReliabilityMetricPayload>): void {
+  const full: TerminalReliabilityMetricPayload = {
+    terminalId: "t1",
+    metricType: "pause-end",
+    timestamp: 0,
+    ...payload,
+  };
+  act(() => {
+    for (const cb of listeners.get("terminal:reliability-metric") ?? []) {
+      cb(full);
+    }
+  });
+}
+
+import { useForceResumeCycleWatchdog } from "../useForceResumeCycleWatchdog";
+
+beforeEach(() => {
+  listeners = new Map();
+  notifyMock.mockClear();
+  forceResumeMock.mockClear();
+  unsubSpy.mockClear();
+  eventsOn.mockClear();
+});
+
+describe("useForceResumeCycleWatchdog", () => {
+  it("subscribes to the reliability-metric bus for the terminal", () => {
+    renderHook(() => useForceResumeCycleWatchdog("t1"));
+    expect(eventsOn).toHaveBeenCalledWith("terminal:reliability-metric", expect.any(Function));
+  });
+
+  it("promotes to the banner only after three consecutive force-resumes", () => {
+    const { result } = renderHook(() => useForceResumeCycleWatchdog("t1"));
+
+    emitMetric({ durationMs: 9950 });
+    expect(result.current.showBanner).toBe(false);
+    emitMetric({ durationMs: 9950 });
+    expect(result.current.showBanner).toBe(false);
+    emitMetric({ durationMs: 9950 });
+    expect(result.current.showBanner).toBe(true);
+  });
+
+  it("emits the grid-bar warning exactly once when the threshold is crossed", () => {
+    renderHook(() => useForceResumeCycleWatchdog("t1"));
+
+    emitMetric({ durationMs: 9950 });
+    emitMetric({ durationMs: 9950 });
+    emitMetric({ durationMs: 9950 });
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+    expect(notifyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "warning",
+        priority: "low",
+        placement: "grid-bar",
+        supersedeKey: "terminal-force-resume-stalled:t1",
+      })
+    );
+
+    // Subsequent force-resumes keep the banner up but stay silent.
+    emitMetric({ durationMs: 9950 });
+    emitMetric({ durationMs: 9950 });
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the counter on a confirmed natural drain", () => {
+    const { result } = renderHook(() => useForceResumeCycleWatchdog("t1"));
+
+    emitMetric({ durationMs: 9950 });
+    emitMetric({ durationMs: 9950 });
+    // Natural drain before the third force-resume — counter resets.
+    emitMetric({ durationMs: 120 });
+    expect(result.current.showBanner).toBe(false);
+
+    // It now takes three fresh force-resumes again, not one.
+    emitMetric({ durationMs: 9950 });
+    emitMetric({ durationMs: 9950 });
+    expect(result.current.showBanner).toBe(false);
+    emitMetric({ durationMs: 9950 });
+    expect(result.current.showBanner).toBe(true);
+  });
+
+  it("hides the banner and re-arms the notify on a drain after promotion", () => {
+    const { result } = renderHook(() => useForceResumeCycleWatchdog("t1"));
+
+    emitMetric({ durationMs: 9950 });
+    emitMetric({ durationMs: 9950 });
+    emitMetric({ durationMs: 9950 });
+    expect(result.current.showBanner).toBe(true);
+
+    emitMetric({ durationMs: 120 });
+    expect(result.current.showBanner).toBe(false);
+
+    // A fresh stall fires the notify again (re-armed).
+    emitMetric({ durationMs: 9950 });
+    emitMetric({ durationMs: 9950 });
+    emitMetric({ durationMs: 9950 });
+    expect(result.current.showBanner).toBe(true);
+    expect(notifyMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not count a metric with no durationMs, and does not reset on one", () => {
+    const { result } = renderHook(() => useForceResumeCycleWatchdog("t1"));
+
+    emitMetric({ durationMs: 9950 });
+    emitMetric({ durationMs: 9950 });
+    // Ambiguous metric: neither increments nor resets.
+    emitMetric({ durationMs: undefined });
+    expect(result.current.showBanner).toBe(false);
+    // The next force-resume still completes the threshold (count preserved).
+    emitMetric({ durationMs: 9950 });
+    expect(result.current.showBanner).toBe(true);
+  });
+
+  it("ignores metrics for other terminals and non-pause-end types", () => {
+    const { result } = renderHook(() => useForceResumeCycleWatchdog("t1"));
+
+    emitMetric({ terminalId: "other", durationMs: 9950 });
+    emitMetric({ metricType: "suspend", durationMs: 9950 });
+    emitMetric({ durationMs: 9950 });
+    emitMetric({ durationMs: 9950 });
+    expect(result.current.showBanner).toBe(false);
+    emitMetric({ durationMs: 9950 });
+    expect(result.current.showBanner).toBe(true);
+  });
+
+  it("resetQueue force-resumes the terminal and clears the banner", () => {
+    const { result } = renderHook(() => useForceResumeCycleWatchdog("t1"));
+
+    emitMetric({ durationMs: 9950 });
+    emitMetric({ durationMs: 9950 });
+    emitMetric({ durationMs: 9950 });
+    expect(result.current.showBanner).toBe(true);
+
+    act(() => result.current.resetQueue());
+    expect(forceResumeMock).toHaveBeenCalledWith("t1");
+    expect(result.current.showBanner).toBe(false);
+  });
+
+  it("tears down the old subscription and resets state when the id changes", () => {
+    const { result, rerender } = renderHook(({ id }) => useForceResumeCycleWatchdog(id), {
+      initialProps: { id: "t1" },
+    });
+
+    emitMetric({ durationMs: 9950 });
+    emitMetric({ durationMs: 9950 });
+    emitMetric({ durationMs: 9950 });
+    expect(result.current.showBanner).toBe(true);
+
+    rerender({ id: "t2" });
+    expect(unsubSpy).toHaveBeenCalled();
+    expect(result.current.showBanner).toBe(false);
+    expect(eventsOn).toHaveBeenLastCalledWith("terminal:reliability-metric", expect.any(Function));
+  });
+});

--- a/src/hooks/terminal/useForceResumeCycleWatchdog.ts
+++ b/src/hooks/terminal/useForceResumeCycleWatchdog.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffectEvent } from "react";
+import type { TerminalReliabilityMetricPayload } from "@shared/types/pty-host";
+import { terminalClient } from "@/clients";
+import { notify } from "@/lib/notify";
+
+/**
+ * A `pause-end` reliability metric whose `durationMs` reaches this threshold was
+ * a force-resume: the pty-host's bounded-pause safety timer fired at
+ * `IPC_MAX_PAUSE_MS` (10000ms — `electron/services/pty/types.ts`) because the
+ * renderer never drained to the low-watermark in time. The 100ms slack absorbs
+ * scheduling jitter between the timer firing and the metric timestamp. A
+ * natural drain always reports well under this; a missing `durationMs` is
+ * ambiguous and is treated as neither a force-resume nor a drain.
+ *
+ * Kept as a local constant rather than imported: `IPC_MAX_PAUSE_MS` lives in an
+ * Electron-main module and isn't part of the shared surface, so coupling the
+ * renderer to it just for this derived bound isn't worth a shared-types move.
+ */
+const FORCE_RESUME_THRESHOLD_MS = 9900;
+
+/**
+ * Consecutive force-resume cycles that promote the terminal from the ambient
+ * Tier-1 flow-status pill to a Tier-3 recovery banner. Three in a row means the
+ * renderer is genuinely stuck (JS deadlock, GC thrash) rather than briefly
+ * backpressured — the bounded-pause safety has fired repeatedly with no natural
+ * recovery in between.
+ */
+const FORCE_RESUME_TIER_3_COUNT = 3;
+
+export interface ForceResumeCycleWatchdog {
+  /** True once the terminal has been force-resumed `FORCE_RESUME_TIER_3_COUNT` times in a row. */
+  showBanner: boolean;
+  /** Clears the watchdog state and force-resumes the terminal's paused queue. */
+  resetQueue: () => void;
+}
+
+/**
+ * Watches the `terminal:reliability-metric` event bus for a terminal that is
+ * being force-resumed in a tight loop — the renderer never drains the IPC queue
+ * before the pty-host's bounded-pause safety timer fires, so output keeps
+ * stalling. After three consecutive force-resumes it surfaces a Tier-3 recovery
+ * banner (see CLAUDE.md "Runtime Signals") and emits a one-shot low-priority
+ * grid-bar warning. A single confirmed natural drain re-arms the watchdog.
+ */
+export function useForceResumeCycleWatchdog(id: string): ForceResumeCycleWatchdog {
+  const consecutiveRef = useRef(0);
+  const notifyFiredRef = useRef(false);
+  const [showBanner, setShowBanner] = useState(false);
+
+  const onMetric = useEffectEvent((payload: TerminalReliabilityMetricPayload) => {
+    if (payload.terminalId !== id || payload.metricType !== "pause-end") return;
+    // Ambiguous metric (pause-start time was lost upstream): don't count it as a
+    // force-resume, but don't reset either — resetting on an unknown outcome
+    // would mask a genuine stall loop (lesson #8558).
+    if (payload.durationMs === undefined) return;
+
+    if (payload.durationMs >= FORCE_RESUME_THRESHOLD_MS) {
+      consecutiveRef.current += 1;
+      if (consecutiveRef.current < FORCE_RESUME_TIER_3_COUNT) return;
+      setShowBanner(true);
+      if (notifyFiredRef.current) return;
+      notifyFiredRef.current = true;
+      notify({
+        type: "warning",
+        priority: "low",
+        placement: "grid-bar",
+        title: "Terminal output stalled",
+        message: "Reset the queue from the terminal banner to recover.",
+        supersedeKey: `terminal-force-resume-stalled:${id}`,
+        context: { eventKind: "recovery", panelId: id },
+      });
+    } else {
+      // Confirmed natural drain — the renderer caught up on its own. Re-arm.
+      consecutiveRef.current = 0;
+      notifyFiredRef.current = false;
+      setShowBanner(false);
+    }
+  });
+
+  useEffect(() => {
+    consecutiveRef.current = 0;
+    notifyFiredRef.current = false;
+    setShowBanner(false);
+    return window.electron.events.on("terminal:reliability-metric", onMetric);
+    // `onMetric` is a stable `useEffectEvent` ref — intentionally excluded from
+    // deps so a new `id` tears down the old subscription and resets the counter.
+  }, [id]);
+
+  const resetQueue = useCallback(() => {
+    consecutiveRef.current = 0;
+    notifyFiredRef.current = false;
+    setShowBanner(false);
+    void terminalClient.forceResume(id);
+  }, [id]);
+
+  return { showBanner, resetQueue };
+}

--- a/src/hooks/terminal/useForceResumeCycleWatchdog.ts
+++ b/src/hooks/terminal/useForceResumeCycleWatchdog.ts
@@ -3,6 +3,7 @@ import { useEffectEvent } from "react";
 import type { TerminalReliabilityMetricPayload } from "@shared/types/pty-host";
 import { terminalClient } from "@/clients";
 import { notify } from "@/lib/notify";
+import { logWarn } from "@/utils/logger";
 
 /**
  * A `pause-end` reliability metric whose `durationMs` reaches this threshold was
@@ -44,18 +45,23 @@ export interface ForceResumeCycleWatchdog {
  * grid-bar warning. A single confirmed natural drain re-arms the watchdog.
  */
 export function useForceResumeCycleWatchdog(id: string): ForceResumeCycleWatchdog {
+  // Counter is hook-instance-local by design: if the pane unmounts/remounts for
+  // the same id (LRU eviction → re-activation) the streak restarts from zero.
+  // That's the intended trade-off — a stall that survives a remount re-proves
+  // itself over three fresh cycles rather than persisting state in a store.
   const consecutiveRef = useRef(0);
   const notifyFiredRef = useRef(false);
   const [showBanner, setShowBanner] = useState(false);
 
   const onMetric = useEffectEvent((payload: TerminalReliabilityMetricPayload) => {
     if (payload.terminalId !== id || payload.metricType !== "pause-end") return;
-    // Ambiguous metric (pause-start time was lost upstream): don't count it as a
-    // force-resume, but don't reset either — resetting on an unknown outcome
-    // would mask a genuine stall loop (lesson #8558).
-    if (payload.durationMs === undefined) return;
+    const { durationMs } = payload;
+    // Ambiguous metric (pause-start time was lost upstream, or a non-finite
+    // delta): don't count it as a force-resume, but don't reset either —
+    // resetting on an unknown outcome would mask a genuine stall loop (lesson #8558).
+    if (durationMs === undefined || !Number.isFinite(durationMs)) return;
 
-    if (payload.durationMs >= FORCE_RESUME_THRESHOLD_MS) {
+    if (durationMs >= FORCE_RESUME_THRESHOLD_MS) {
       consecutiveRef.current += 1;
       if (consecutiveRef.current < FORCE_RESUME_TIER_3_COUNT) return;
       setShowBanner(true);
@@ -91,7 +97,9 @@ export function useForceResumeCycleWatchdog(id: string): ForceResumeCycleWatchdo
     consecutiveRef.current = 0;
     notifyFiredRef.current = false;
     setShowBanner(false);
-    void terminalClient.forceResume(id);
+    void terminalClient.forceResume(id).catch((err: unknown) => {
+      logWarn("Force-resume from stall banner failed", { terminalId: id, error: String(err) });
+    });
   }, [id]);
 
   return { showBanner, resetQueue };


### PR DESCRIPTION
## Summary

- Adds `useForceResumeCycleWatchdog` -- a renderer-side hook that counts consecutive force-resume cycles on the existing `terminal:reliability-metric` event bus. When a `pause-end` metric reports `durationMs >= 9900ms` (the pty-host's `IPC_MAX_PAUSE_MS` bounded-pause safety timer fired because the renderer never drained), it increments a per-terminal counter.
- After 3 consecutive force-resumes, promotes from the ambient Tier-1 flow-status pill to a Tier-3 `InlineStatusBanner` (severity `error`) with a "Reset queue" action calling `terminalClient.forceResume(id)`, and emits a one-shot low-priority `grid-bar` warning. A confirmed natural drain (`durationMs < 9900`) re-arms the watchdog; missing or non-finite `durationMs` values are ignored.
- No new IPC channel -- consumes the existing bus event. Wired into `TerminalPane` as a new banner slot.

Resolves #9808.

## Changes

- `src/hooks/terminal/useForceResumeCycleWatchdog.ts` -- new watchdog hook
- `src/components/Terminal/TerminalPane.tsx` -- wires the hook and mounts the banner
- `src/hooks/terminal/__tests__/useForceResumeCycleWatchdog.test.tsx` -- 13 unit tests

## Testing

13 unit tests cover: threshold boundary (9899ms vs 9900ms), consecutive counting, one-shot `notify` ordering, re-arm on natural drain and via `resetQueue`, mid-streak ignored metrics, terminal-ID filtering, and ID-change teardown.