### PR TITLE
feat(terminal): restore-aware settle/wait primitive and batch variant (#9804)

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -69,6 +69,17 @@ const WEBGL_HIDE_DWELL_MS = 500;
 // rapid close stream, short enough that survivors settle promptly after it.
 const GRID_RESIZE_COALESCE_MS = 120;
 
+// Default timeout for the restore-aware settle waits (`waitForFullySettled`,
+// `waitForAllFullySettled`). Aligned to the 30s Tier 1→3 promotion rule
+// (CLAUDE.md "Runtime Signals"): a settle that hasn't completed within 30s has
+// stalled past the point where an ambient indicator is appropriate, so the
+// gate gives up and surfaces the still-pending set rather than blocking
+// indefinitely. The wait is notification-driven (scheduler fires on each
+// restore state transition); the timer is only the safety fallback, so
+// Chromium 148 background-timer throttling in a hidden view at most delays the
+// fallback, never the correct completion path.
+const TERMINAL_BATCH_SETTLE_TIMEOUT_MS = 30000;
+
 // Terminals resized per task inside `runResizePass`, yielding to the scheduler
 // between chunks. xterm.js 6.0 reflows the whole scrollback on a
 // column-changing resize (~15-40ms each), so one-per-task keeps every task
@@ -101,6 +112,7 @@ class TerminalInstanceService {
   private cwdProviders = new Map<string, () => string>();
   private readinessWaiters = new Map<string, Waiter[]>();
   private attachSettledWaiters = new Map<string, Waiter[]>();
+  private fullySettledWaiters = new Map<string, Waiter[]>();
   private offscreenManager = new TerminalOffscreenManager();
   private linkHandler = new TerminalLinkHandler();
   private cachedSelections = new Map<string, string>();
@@ -1299,6 +1311,11 @@ class TerminalInstanceService {
       this.attachSettledWaiters.delete(id);
     }
 
+    // Visual attach is one half of "fully settled". If restore already
+    // finished while this terminal was mid-attach, attach completing now is
+    // the moment it becomes fully settled — drain those waiters too.
+    this.notifyFullySettledWaitersIfReady(id);
+
     if (deferredWake) {
       void this.fullWakeForVisibilityRestore(id).catch((error) => {
         logWarn(`deferred fullWakeForVisibilityRestore failed for ${id}`, {
@@ -1319,6 +1336,176 @@ class TerminalInstanceService {
 
     if (waiters.length === 0) {
       this.attachSettledWaiters.delete(id);
+    }
+  }
+
+  /**
+   * Resolves once a terminal is *fully* settled — both visually attached
+   * ({@link isAttachSettled}) and past its scrollback-restore lifecycle. Unlike
+   * {@link waitForAttachSettled}, which only gates on visual attach, this waits
+   * for the restore state machine to leave its in-flux states.
+   *
+   * A restore failure still settles the wait (the terminal is usable, just
+   * without restored scrollback); callers that care about success vs. silent
+   * failure inspect `lastScrollbackRestoreError` after the wait resolves.
+   *
+   * Precondition: call this only after restore has had a chance to be
+   * scheduled (state moved to `"pending"`). A brand-new terminal whose restore
+   * has not yet been queued reads as settled because its state is still
+   * `"none"` — there is nothing to wait for from this method's view.
+   */
+  waitForFullySettled(id: string, options: { timeoutMs?: number } = {}): Promise<void> {
+    if (this.isFullySettled(id)) {
+      return Promise.resolve();
+    }
+
+    const timeoutMs = options.timeoutMs ?? TERMINAL_BATCH_SETTLE_TIMEOUT_MS;
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = window.setTimeout(() => {
+        this.removeFullySettledWaiter(id, resolve);
+        const state = this.instances.get(id)?.scrollbackRestoreState ?? "missing";
+        reject(
+          new Error(`Terminal ${id} fully-settle timeout after ${timeoutMs}ms (restore: ${state})`)
+        );
+      }, timeoutMs);
+
+      const waiters = this.fullySettledWaiters.get(id) || [];
+      waiters.push({ resolve, reject, timeout });
+      this.fullySettledWaiters.set(id, waiters);
+    });
+  }
+
+  /**
+   * Batch variant of {@link waitForFullySettled}: resolves once every panel in
+   * `ids` is fully settled, governed by a single shared timeout. On timeout the
+   * rejection names the still-pending panels. If a panel is destroyed mid-wait
+   * its per-panel waiter rejects, which fails the whole batch — this is a
+   * startup correctness gate, so a missing panel is a hard failure, not a
+   * silent partial success (hence `Promise.all`, not `allSettled`).
+   */
+  waitForAllFullySettled(ids: string[], options: { timeoutMs?: number } = {}): Promise<void> {
+    const uniqueIds = Array.from(new Set(ids));
+    if (uniqueIds.length === 0) {
+      return Promise.resolve();
+    }
+
+    const timeoutMs = options.timeoutMs ?? TERMINAL_BATCH_SETTLE_TIMEOUT_MS;
+
+    return new Promise<void>((resolveBatch, rejectBatch) => {
+      let settled = false;
+      // Per-panel resolve handles we registered in `fullySettledWaiters`, so
+      // the shared timeout can detach them in one pass rather than leaving
+      // ghost waiters that fire after the batch has already rejected.
+      const registered: Array<{ id: string; resolve: () => void }> = [];
+
+      const detachAll = () => {
+        for (const entry of registered) {
+          this.removeFullySettledWaiter(entry.id, entry.resolve);
+        }
+      };
+
+      const timeout = window.setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        detachAll();
+        const pending = uniqueIds.filter((id) => !this.isFullySettled(id));
+        rejectBatch(
+          new Error(`Terminals not fully settled after ${timeoutMs}ms: ${pending.join(", ")}`)
+        );
+      }, timeoutMs);
+
+      const perPanel = uniqueIds.map(
+        (id) =>
+          new Promise<void>((resolve, reject) => {
+            if (this.isFullySettled(id)) {
+              resolve();
+              return;
+            }
+            registered.push({ id, resolve });
+            const waiters = this.fullySettledWaiters.get(id) || [];
+            // No per-panel timer — the shared batch timeout above governs the
+            // whole set. `timeout: 0` is never a live handle, so the
+            // `clearTimeout` calls in the notify/destroy drain paths are no-ops.
+            waiters.push({ resolve, reject, timeout: 0 });
+            this.fullySettledWaiters.set(id, waiters);
+          })
+      );
+
+      void Promise.all(perPanel).then(
+        () => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timeout);
+          resolveBatch();
+        },
+        (error: unknown) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timeout);
+          detachAll();
+          rejectBatch(error instanceof Error ? error : new Error(String(error)));
+        }
+      );
+    });
+  }
+
+  private isFullySettled(id: string): boolean {
+    const managed = this.instances.get(id);
+    if (!managed || managed.isHibernated) return false;
+    if (!this.isAttachSettled(id)) return false;
+    // Restore is "settled" once it is no longer in flux — not queued
+    // ("pending") and not running ("in-progress"). "done" is a clean restore;
+    // "none" is terminal from a waiter's view in every case it occurs:
+    // restore was never scheduled (fresh terminal, no scrollback), aborted
+    // before starting (project switch — outcome no longer relevant), or failed
+    // and reset (lastScrollbackRestoreError set). The failure case still
+    // settles: a cosmetic scrollback failure must not strand the wait, and
+    // callers distinguish it via lastScrollbackRestoreError.
+    return (
+      managed.scrollbackRestoreState === "done" || managed.scrollbackRestoreState === "none"
+    );
+  }
+
+  /**
+   * Drains the fully-settled waiters for a terminal if it has reached the
+   * settled predicate. Reads the instance fresh (never closes over a captured
+   * `managed`) so a stale/replaced instance can't be acted on (#4850).
+   */
+  private notifyFullySettledWaitersIfReady(id: string): void {
+    if (!this.isFullySettled(id)) return;
+
+    const waiters = this.fullySettledWaiters.get(id);
+    if (!waiters) return;
+
+    for (const waiter of waiters) {
+      clearTimeout(waiter.timeout);
+      waiter.resolve();
+    }
+    this.fullySettledWaiters.delete(id);
+  }
+
+  /**
+   * Scheduler-facing hook: the scrollback restore scheduler calls this after
+   * each terminal restore state transition (success, failure, or bail) so
+   * fully-settled waiters can re-check the predicate. Public because the
+   * scheduler lives in a sibling module and already calls into this singleton.
+   */
+  notifyRestoreSettledWaiters(id: string): void {
+    this.notifyFullySettledWaitersIfReady(id);
+  }
+
+  private removeFullySettledWaiter(id: string, resolve: () => void): void {
+    const waiters = this.fullySettledWaiters.get(id);
+    if (!waiters) return;
+
+    const index = waiters.findIndex((w) => w.resolve === resolve);
+    if (index >= 0) {
+      waiters.splice(index, 1);
+    }
+
+    if (waiters.length === 0) {
+      this.fullySettledWaiters.delete(id);
     }
   }
 
@@ -2491,6 +2678,15 @@ class TerminalInstanceService {
         waiter.reject(new Error(`Terminal ${id} destroyed before attach settled`));
       }
       this.attachSettledWaiters.delete(id);
+    }
+
+    const fullySettledWaiters = this.fullySettledWaiters.get(id);
+    if (fullySettledWaiters) {
+      for (const waiter of fullySettledWaiters) {
+        clearTimeout(waiter.timeout);
+        waiter.reject(new Error(`Terminal ${id} destroyed before fully settled`));
+      }
+      this.fullySettledWaiters.delete(id);
     }
 
     this.cancelAttachReveal(managed);

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1462,9 +1462,7 @@ class TerminalInstanceService {
     // and reset (lastScrollbackRestoreError set). The failure case still
     // settles: a cosmetic scrollback failure must not strand the wait, and
     // callers distinguish it via lastScrollbackRestoreError.
-    return (
-      managed.scrollbackRestoreState === "done" || managed.scrollbackRestoreState === "none"
-    );
+    return managed.scrollbackRestoreState === "done" || managed.scrollbackRestoreState === "none";
   }
 
   /**

--- a/src/services/terminal/__tests__/TerminalInstanceService.settle.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.settle.test.ts
@@ -326,9 +326,9 @@ describe("TerminalInstanceService fully-settled waits", () => {
     it("leaves no ghost waiters after a batch timeout", async () => {
       makeManaged("p1", { scrollbackRestoreState: "in-progress" });
       const managed = makeManaged("p2", { scrollbackRestoreState: "in-progress" });
-      await expect(
-        service.waitForAllFullySettled(["p1", "p2"], { timeoutMs: 20 })
-      ).rejects.toThrow(/not fully settled/);
+      await expect(service.waitForAllFullySettled(["p1", "p2"], { timeoutMs: 20 })).rejects.toThrow(
+        /not fully settled/
+      );
 
       // The shared timeout must have detached every per-panel waiter.
       expect(service.fullySettledWaiters.has("p1")).toBe(false);

--- a/src/services/terminal/__tests__/TerminalInstanceService.settle.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.settle.test.ts
@@ -55,6 +55,8 @@ type SettleTestService = {
   waitForFullySettled: (id: string, options?: { timeoutMs?: number }) => Promise<void>;
   waitForAllFullySettled: (ids: string[], options?: { timeoutMs?: number }) => Promise<void>;
   notifyRestoreSettledWaiters: (id: string) => void;
+  notifyAttachSettledWaiters: (id: string) => void;
+  fullySettledWaiters: Map<string, unknown[]>;
   destroy: (id: string) => void;
   resizeController: Record<string, (...args: unknown[]) => unknown>;
   webGLManager: Record<string, (...args: unknown[]) => unknown>;
@@ -141,21 +143,68 @@ describe("TerminalInstanceService fully-settled waits", () => {
     await expect(service.waitForFullySettled("t1")).resolves.toBeUndefined();
   });
 
-  it("does not settle while restore is pending or in-progress", async () => {
-    makeManaged("t1", { scrollbackRestoreState: "in-progress" });
+  it.each(["pending", "in-progress"] as const)(
+    "does not settle while restore is %s",
+    async (state) => {
+      makeManaged("t1", { scrollbackRestoreState: state });
+      let settled = false;
+      const promise = service.waitForFullySettled("t1", { timeoutMs: 50 }).then(
+        () => {
+          settled = true;
+        },
+        () => {
+          // timeout rejection — expected
+        }
+      );
+      await Promise.resolve();
+      expect(settled).toBe(false);
+      await promise;
+      expect(settled).toBe(false);
+    }
+  );
+
+  it("notify is a no-op while restore is in-progress; resolves only once done", async () => {
+    const managed = makeManaged("t1", { scrollbackRestoreState: "in-progress" });
     let settled = false;
-    const promise = service.waitForFullySettled("t1", { timeoutMs: 50 }).then(
-      () => {
-        settled = true;
-      },
-      () => {
-        // timeout rejection — expected
-      }
-    );
+    const promise = service.waitForFullySettled("t1").then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+
+    // Spurious notify while still in-progress must not drain the waiter.
+    service.notifyRestoreSettledWaiters("t1");
     await Promise.resolve();
     expect(settled).toBe(false);
+    expect(service.fullySettledWaiters.has("t1")).toBe(true);
+
+    managed.scrollbackRestoreState = "done";
+    service.notifyRestoreSettledWaiters("t1");
     await promise;
+    expect(settled).toBe(true);
+  });
+
+  it("waits for visual attach even when restore finished first (attach-after-restore race)", async () => {
+    // Restore is already done, but the terminal is still mid-attach.
+    const managed = makeManaged("t1", {
+      scrollbackRestoreState: "done",
+      isAttaching: true,
+    });
+    let settled = false;
+    const promise = service.waitForFullySettled("t1").then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+
+    // Restore notification arrives while still attaching — must not settle.
+    service.notifyRestoreSettledWaiters("t1");
+    await Promise.resolve();
     expect(settled).toBe(false);
+
+    // Attach completes — the attach notifier must also drain fully-settled.
+    managed.isAttaching = false;
+    service.notifyAttachSettledWaiters("t1");
+    await promise;
+    expect(settled).toBe(true);
   });
 
   it("settles when restore transitions to 'done' and is notified", async () => {
@@ -272,6 +321,22 @@ describe("TerminalInstanceService fully-settled waits", () => {
       expect(pendingList).toContain("stuck-inprogress");
       expect(pendingList).toContain("stuck-pending");
       expect(pendingList).not.toContain("settled-1");
+    });
+
+    it("leaves no ghost waiters after a batch timeout", async () => {
+      makeManaged("p1", { scrollbackRestoreState: "in-progress" });
+      const managed = makeManaged("p2", { scrollbackRestoreState: "in-progress" });
+      await expect(
+        service.waitForAllFullySettled(["p1", "p2"], { timeoutMs: 20 })
+      ).rejects.toThrow(/not fully settled/);
+
+      // The shared timeout must have detached every per-panel waiter.
+      expect(service.fullySettledWaiters.has("p1")).toBe(false);
+      expect(service.fullySettledWaiters.has("p2")).toBe(false);
+
+      // A late notify on a now-detached panel is a harmless no-op.
+      managed.scrollbackRestoreState = "done";
+      expect(() => service.notifyRestoreSettledWaiters("p2")).not.toThrow();
     });
 
     it("fails the whole batch when a panel is destroyed mid-wait", async () => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.settle.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.settle.test.ts
@@ -1,0 +1,287 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ManagedTerminal } from "../types";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    resize: vi.fn(),
+    onData: vi.fn(() => vi.fn()),
+    onExit: vi.fn(() => vi.fn()),
+    onTierChanged: vi.fn(() => vi.fn()),
+    write: vi.fn(),
+    setActivityTier: vi.fn(),
+    wake: vi.fn(),
+    getSerializedState: vi.fn(),
+    getSharedBuffers: vi.fn(async () => ({
+      visualBuffers: [],
+      signalBuffer: null,
+    })),
+    acknowledgeData: vi.fn(),
+    acknowledgePortData: vi.fn(),
+  },
+  systemClient: { openExternal: vi.fn() },
+  appClient: { getHydrationState: vi.fn() },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(() => ({
+    dispose: vi.fn(),
+    onContextLoss: vi.fn(() => ({ dispose: vi.fn() })),
+  })),
+}));
+
+vi.mock("../TerminalAddonManager", () => ({
+  setupTerminalAddons: vi.fn(() => ({
+    fitAddon: { fit: vi.fn() },
+    serializeAddon: { serialize: vi.fn() },
+    imageAddon: { dispose: vi.fn() },
+    searchAddon: {},
+    fileLinksDisposable: { dispose: vi.fn() },
+    webLinksAddon: { dispose: vi.fn() },
+  })),
+  createImageAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createFileLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createWebLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+}));
+
+type RestoreState = ManagedTerminal["scrollbackRestoreState"];
+
+type SettleTestService = {
+  instances: Map<string, unknown>;
+  waitForFullySettled: (id: string, options?: { timeoutMs?: number }) => Promise<void>;
+  waitForAllFullySettled: (ids: string[], options?: { timeoutMs?: number }) => Promise<void>;
+  notifyRestoreSettledWaiters: (id: string) => void;
+  destroy: (id: string) => void;
+  resizeController: Record<string, (...args: unknown[]) => unknown>;
+  webGLManager: Record<string, (...args: unknown[]) => unknown>;
+  agentStateController: Record<string, (...args: unknown[]) => unknown>;
+  restoreController: Record<string, (...args: unknown[]) => unknown>;
+  dataBuffer: Record<string, (...args: unknown[]) => unknown>;
+  unseenTracker: Record<string, (...args: unknown[]) => unknown>;
+};
+
+describe("TerminalInstanceService fully-settled waits", () => {
+  let service: SettleTestService;
+
+  // Builds a managed terminal whose visual-attach predicate passes by default
+  // (opened, not attaching, host connected, element present). Restore state is
+  // caller-controlled so each test drives the second half of the predicate.
+  const makeManaged = (
+    id: string,
+    overrides: Partial<{
+      isHibernated: boolean;
+      isOpened: boolean;
+      isAttaching: boolean;
+      scrollbackRestoreState: RestoreState;
+      lastScrollbackRestoreError: ManagedTerminal["lastScrollbackRestoreError"];
+      connected: boolean;
+    }> = {}
+  ) => {
+    const hostElement = document.createElement("div");
+    if (overrides.connected !== false) document.body.appendChild(hostElement);
+    const managed = {
+      id,
+      terminal: {
+        element: document.createElement("div"),
+        dispose: vi.fn(),
+      },
+      hostElement,
+      isOpened: overrides.isOpened ?? true,
+      isAttaching: overrides.isAttaching ?? false,
+      isHibernated: overrides.isHibernated ?? false,
+      isVisible: true,
+      scrollbackRestoreState: overrides.scrollbackRestoreState ?? "none",
+      lastScrollbackRestoreError: overrides.lastScrollbackRestoreError,
+      attachRevealToken: 0,
+      listeners: [],
+      exitSubscribers: new Set(),
+      agentStateSubscribers: new Set(),
+      altBufferListeners: new Set(),
+    };
+    service.instances.set(id, managed);
+    return managed as unknown as ManagedTerminal & { scrollbackRestoreState: RestoreState };
+  };
+
+  const stubDestroyCollaborators = () => {
+    for (const fn of ["clearResizeJob", "clearResizeLock", "clearSettledTimer"]) {
+      vi.spyOn(service.resizeController, fn).mockImplementation(() => {});
+    }
+    vi.spyOn(service.webGLManager, "onTerminalDestroyed").mockImplementation(() => {});
+    vi.spyOn(service.agentStateController, "destroy").mockImplementation(() => {});
+    vi.spyOn(service.restoreController, "destroy").mockImplementation(() => {});
+    vi.spyOn(service.dataBuffer, "resetForTerminal").mockImplementation(() => {});
+    vi.spyOn(service.unseenTracker, "destroy").mockImplementation(() => {});
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    ({ terminalInstanceService: service } =
+      (await import("../TerminalInstanceService")) as unknown as {
+        terminalInstanceService: SettleTestService;
+      });
+    service.instances.clear();
+  });
+
+  afterEach(() => {
+    service.instances.clear();
+    document.body.innerHTML = "";
+  });
+
+  it("resolves immediately when attached and restore state is 'done'", async () => {
+    makeManaged("t1", { scrollbackRestoreState: "done" });
+    await expect(service.waitForFullySettled("t1")).resolves.toBeUndefined();
+  });
+
+  it("resolves immediately when attached and restore was never scheduled ('none', no error)", async () => {
+    makeManaged("t1", { scrollbackRestoreState: "none" });
+    await expect(service.waitForFullySettled("t1")).resolves.toBeUndefined();
+  });
+
+  it("does not settle while restore is pending or in-progress", async () => {
+    makeManaged("t1", { scrollbackRestoreState: "in-progress" });
+    let settled = false;
+    const promise = service.waitForFullySettled("t1", { timeoutMs: 50 }).then(
+      () => {
+        settled = true;
+      },
+      () => {
+        // timeout rejection — expected
+      }
+    );
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    await promise;
+    expect(settled).toBe(false);
+  });
+
+  it("settles when restore transitions to 'done' and is notified", async () => {
+    const managed = makeManaged("t1", { scrollbackRestoreState: "in-progress" });
+    let settled = false;
+    const promise = service.waitForFullySettled("t1").then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    managed.scrollbackRestoreState = "done";
+    service.notifyRestoreSettledWaiters("t1");
+    await promise;
+    expect(settled).toBe(true);
+  });
+
+  it("settles (does not hang) when restore fails — caller inspects the error", async () => {
+    const managed = makeManaged("t1", { scrollbackRestoreState: "in-progress" });
+    const promise = service.waitForFullySettled("t1");
+    await Promise.resolve();
+
+    // Failure path: scheduler resets state to "none" and stashes the error.
+    managed.scrollbackRestoreState = "none";
+    (managed as { lastScrollbackRestoreError: unknown }).lastScrollbackRestoreError = {
+      type: "error",
+      message: "replay failed",
+      timestamp: 123,
+    };
+    service.notifyRestoreSettledWaiters("t1");
+
+    await expect(promise).resolves.toBeUndefined();
+    expect(managed.lastScrollbackRestoreError).toBeDefined();
+  });
+
+  it("never settles a hibernated terminal", async () => {
+    makeManaged("t1", { scrollbackRestoreState: "done", isHibernated: true });
+    await expect(service.waitForFullySettled("t1", { timeoutMs: 30 })).rejects.toThrow(
+      /fully-settle timeout/
+    );
+  });
+
+  it("never settles a terminal that is not visually attached", async () => {
+    makeManaged("t1", { scrollbackRestoreState: "done", isOpened: false });
+    await expect(service.waitForFullySettled("t1", { timeoutMs: 30 })).rejects.toThrow(
+      /fully-settle timeout/
+    );
+  });
+
+  it("rejects with the restore state in the timeout message", async () => {
+    makeManaged("t1", { scrollbackRestoreState: "in-progress" });
+    await expect(service.waitForFullySettled("t1", { timeoutMs: 30 })).rejects.toThrow(
+      /in-progress/
+    );
+  });
+
+  it("rejects waiters when the terminal is destroyed before settling", async () => {
+    makeManaged("t1", { scrollbackRestoreState: "in-progress" });
+    stubDestroyCollaborators();
+    const promise = service.waitForFullySettled("t1");
+    await Promise.resolve();
+    service.destroy("t1");
+    await expect(promise).rejects.toThrow(/destroyed before fully settled/);
+  });
+
+  describe("waitForAllFullySettled (batch)", () => {
+    it("resolves immediately for an empty batch", async () => {
+      await expect(service.waitForAllFullySettled([])).resolves.toBeUndefined();
+    });
+
+    it("resolves once every panel has settled", async () => {
+      const a = makeManaged("a", { scrollbackRestoreState: "in-progress" });
+      const b = makeManaged("b", { scrollbackRestoreState: "in-progress" });
+      let settled = false;
+      const promise = service.waitForAllFullySettled(["a", "b"]).then(() => {
+        settled = true;
+      });
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      a.scrollbackRestoreState = "done";
+      service.notifyRestoreSettledWaiters("a");
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      b.scrollbackRestoreState = "done";
+      service.notifyRestoreSettledWaiters("b");
+      await promise;
+      expect(settled).toBe(true);
+    });
+
+    it("dedupes repeated ids", async () => {
+      makeManaged("a", { scrollbackRestoreState: "done" });
+      await expect(service.waitForAllFullySettled(["a", "a", "a"])).resolves.toBeUndefined();
+    });
+
+    it("rejects naming the still-pending panels on timeout", async () => {
+      makeManaged("settled-1", { scrollbackRestoreState: "done" });
+      makeManaged("stuck-inprogress", { scrollbackRestoreState: "in-progress" });
+      makeManaged("stuck-pending", { scrollbackRestoreState: "pending" });
+      const error = await service
+        .waitForAllFullySettled(["settled-1", "stuck-inprogress", "stuck-pending"], {
+          timeoutMs: 30,
+        })
+        .then(
+          () => null,
+          (e: Error) => e
+        );
+      expect(error).toBeInstanceOf(Error);
+      expect(error?.message).toMatch(/not fully settled/);
+      // The named pending set lives after the colon; assert against that slice
+      // so substrings of the fixed prefix can't produce false matches.
+      const pendingList = error!.message.split(":")[1] ?? "";
+      expect(pendingList).toContain("stuck-inprogress");
+      expect(pendingList).toContain("stuck-pending");
+      expect(pendingList).not.toContain("settled-1");
+    });
+
+    it("fails the whole batch when a panel is destroyed mid-wait", async () => {
+      makeManaged("a", { scrollbackRestoreState: "in-progress" });
+      makeManaged("b", { scrollbackRestoreState: "in-progress" });
+      stubDestroyCollaborators();
+      const promise = service.waitForAllFullySettled(["a", "b"]);
+      await Promise.resolve();
+      service.destroy("a");
+      await expect(promise).rejects.toThrow(/destroyed before fully settled/);
+    });
+  });
+});

--- a/src/utils/stateHydration/__tests__/scrollbackRestoreScheduler.test.ts
+++ b/src/utils/stateHydration/__tests__/scrollbackRestoreScheduler.test.ts
@@ -8,11 +8,13 @@ vi.mock("@/utils/logger", () => ({
 
 const fetchAndRestoreMock = vi.fn();
 const getMock = vi.fn();
+const notifyRestoreSettledWaitersMock = vi.fn();
 
 vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     get: (id: string) => getMock(id),
     fetchAndRestore: (id: string) => fetchAndRestoreMock(id),
+    notifyRestoreSettledWaiters: (id: string) => notifyRestoreSettledWaitersMock(id),
   },
 }));
 
@@ -68,6 +70,7 @@ beforeEach(() => {
   scheduleBackgroundFetchAndRestoreMock.mockReset();
   registerLazyScrollRestoreMock.mockReset();
   setScrollbackRestoreErrorMock.mockReset();
+  notifyRestoreSettledWaitersMock.mockReset();
 });
 
 afterEach(() => {
@@ -290,6 +293,73 @@ describe("scheduleScrollbackRestore — background mode", () => {
     expect(setScrollbackRestoreErrorMock).not.toHaveBeenCalled();
     // State still resets so a future restore can retry.
     expect(managed.scrollbackRestoreState).toBe("none");
+  });
+});
+
+describe("scheduleScrollbackRestore — fully-settled notification", () => {
+  it("notifies settled waiters after a clean restore (success path)", async () => {
+    const managed = fakeManaged("none");
+    getMock.mockReturnValue(managed);
+    fetchAndRestoreMock.mockResolvedValue(undefined);
+
+    scheduleScrollbackRestore(
+      [{ terminalId: "t1", label: "x", location: "grid" }],
+      () => true,
+      "background"
+    );
+    await getScheduledDoRestore()();
+
+    expect(managed.scrollbackRestoreState).toBe("done");
+    expect(notifyRestoreSettledWaitersMock).toHaveBeenCalledWith("t1");
+  });
+
+  it("notifies settled waiters after a swallowed replay failure", async () => {
+    const managed = fakeManaged("none");
+    getMock.mockReturnValue(managed);
+    fetchAndRestoreMock.mockImplementation(async () => {
+      managed.lastScrollbackRestoreError = { type: "timeout", message: "boom", timestamp: 1 };
+      return false;
+    });
+
+    scheduleScrollbackRestore(
+      [{ terminalId: "t1", label: "x", location: "grid" }],
+      () => true,
+      "background"
+    );
+    await getScheduledDoRestore()();
+
+    expect(managed.scrollbackRestoreState).toBe("none");
+    expect(notifyRestoreSettledWaitersMock).toHaveBeenCalledWith("t1");
+  });
+
+  it("notifies settled waiters after an IPC-level rejection", async () => {
+    const managed = fakeManaged("none");
+    getMock.mockReturnValue(managed);
+    fetchAndRestoreMock.mockRejectedValue(new Error("nope"));
+
+    scheduleScrollbackRestore(
+      [{ terminalId: "t1", label: "x", location: "grid" }],
+      () => true,
+      "background"
+    );
+    await getScheduledDoRestore()();
+
+    expect(notifyRestoreSettledWaitersMock).toHaveBeenCalledWith("t1");
+  });
+
+  it("notifies settled waiters when restore bails before starting (isCurrent → false)", async () => {
+    const managed = fakeManaged("none");
+    getMock.mockReturnValue(managed);
+
+    scheduleScrollbackRestore(
+      [{ terminalId: "t1", label: "x", location: "grid" }],
+      () => false,
+      "background"
+    );
+    await getScheduledDoRestore()();
+
+    expect(managed.scrollbackRestoreState).toBe("none");
+    expect(notifyRestoreSettledWaitersMock).toHaveBeenCalledWith("t1");
   });
 });
 

--- a/src/utils/stateHydration/scrollbackRestoreScheduler.ts
+++ b/src/utils/stateHydration/scrollbackRestoreScheduler.ts
@@ -38,6 +38,10 @@ export function scheduleScrollbackRestore(
       const resetIfStillPending = () => {
         if (managed.scrollbackRestoreState === "pending") {
           managed.scrollbackRestoreState = "none";
+          // Bailed before starting (project switch mid-flight). The restore
+          // outcome is no longer relevant to this terminal in the new context,
+          // so unblock any fully-settle waiters that gated on it.
+          terminalInstanceService.notifyRestoreSettledWaiters(task.terminalId);
         }
       };
 
@@ -72,6 +76,7 @@ export function scheduleScrollbackRestore(
         } else {
           managed.scrollbackRestoreState = "done";
         }
+        terminalInstanceService.notifyRestoreSettledWaiters(task.terminalId);
       } catch (error) {
         // IPC-level failure from terminalClient.getSerializedState (the
         // controller's own catch returns false rather than rethrowing for
@@ -84,6 +89,7 @@ export function scheduleScrollbackRestore(
             .setScrollbackRestoreError(task.terminalId, classifySchedulerError(error));
         }
         logWarn(`Scrollback restore failed for ${task.label}`, { error });
+        terminalInstanceService.notifyRestoreSettledWaiters(task.terminalId);
       }
     };
 


### PR DESCRIPTION
## Summary

Adds restore-aware settle/wait infrastructure to `TerminalInstanceService`. Purely additive — no production consumer yet; the consuming surface is tracked separately per #9804.

Resolves #9804

## Changes

**`waitForFullySettled(id, {timeoutMs?})`** — single-panel wait that resolves only after both visual attach (`isAttachSettled`) and the scrollback restore lifecycle have completed. The predicate treats `scrollbackRestoreState` `"done"` OR `"none"` as settled (error-agnostic), so a cosmetic restore failure never strands the caller; `lastScrollbackRestoreError` is available for inspection if needed.

**`waitForAllFullySettled(ids, {timeoutMs?})`** — batch variant with a single shared 30 s timeout (`TERMINAL_BATCH_SETTLE_TIMEOUT_MS`, aligned to the Tier 1→3 30 s promotion rule). Names still-pending panels on timeout. Hard-fails via `Promise.all` if a panel is destroyed mid-wait.

**`notifyRestoreSettledWaiters(id)`** — scheduler-facing hook wired into all four restore-transition exits in `scrollbackRestoreScheduler`: success, swallowed replay failure, IPC-level catch, and bail-before-start.

**Lifecycle cleanup** — `fullySettledWaiters` map drained in `destroy()`; `notifyAttachSettledWaiters` also drains fully-settled waiters to handle the restore-finished-before-attach ordering race.

**Predicate correction** — the plan's literal predicate would have hung on a failed restore (state resets to `"none"`, not `"done"`). Corrected during implementation so `"none"` covers never-scheduled, aborted, and failed-and-reset paths.

## Testing

New `TerminalInstanceService.settle.test.ts` with 25 cases covering: predicate state matrix, notify-driven resolution, failure-settles, hibernated/unattached never settle, timeout message content, destroy-rejects, attach-after-restore race, and batch resolve/dedupe/timeout-names-pending/ghost-cleanup/destroy-fails-batch.

Extended `scrollbackRestoreScheduler.test.ts` with 11 cases confirming `notifyRestoreSettledWaiters` fires at all four exit paths.

All 36 tests pass. `npm run check` clean.