### PR TITLE
fix(dock): unify deprioritized pill dim and group zone spacing

### DIFF
--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -517,7 +517,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                   showDockAgentHighlights &&
                   blockedState === "waiting" &&
                   "bg-[var(--dock-item-bg-waiting)] border-[var(--dock-item-border-waiting)]",
-                isDeprioritized && "opacity-50"
+                isDeprioritized && "text-daintree-text/40 border-[var(--dock-item-border)]/50"
               )}
               onClick={(e) => {
                 e.preventDefault();
@@ -572,7 +572,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                   <TooltipTrigger asChild>
                     <div
                       className={cn(
-                        "flex items-center shrink-0",
+                        "ml-auto flex items-center shrink-0",
                         getEffectiveStateColor(displayAgentState)
                       )}
                     >

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -572,7 +572,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                   <TooltipTrigger asChild>
                     <div
                       className={cn(
-                        "ml-auto flex items-center shrink-0",
+                        "ml-1.5 flex items-center shrink-0",
                         getEffectiveStateColor(displayAgentState)
                       )}
                     >

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -20,7 +20,11 @@ import {
 import { TerminalRefreshTier } from "@/types";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { useDockPanelPortal } from "./dockPanelPortalContext";
-import { getDockDisplayAgentState, useDockBlockedState } from "./useDockBlockedState";
+import {
+  getDockDisplayAgentState,
+  isDockAgentStateDeprioritized,
+  useDockBlockedState,
+} from "./useDockBlockedState";
 import {
   handleDockInteractOutside,
   handleDockEscapeKeyDown,
@@ -299,9 +303,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   // state coerces to waiting so it never disappears mid-flight.
   const displayAgentState = getTerminalAgentDisplayState(chrome, agentState);
   const StateIcon = displayAgentState ? getEffectiveStateIcon(displayAgentState) : null;
-  const isDeprioritized =
-    !isOpen &&
-    (!agentState || agentState === "idle" || agentState === "completed" || agentState === "exited");
+  const isDeprioritized = !isOpen && isDockAgentStateDeprioritized(agentState);
 
   return (
     <DockPopoverChildProvider>
@@ -369,7 +371,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
                     <TooltipTrigger asChild>
                       <div
                         className={cn(
-                          "flex items-center shrink-0",
+                          "ml-auto flex items-center shrink-0",
                           getEffectiveStateColor(displayAgentState)
                         )}
                       >

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -371,7 +371,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
                     <TooltipTrigger asChild>
                       <div
                         className={cn(
-                          "ml-auto flex items-center shrink-0",
+                          "ml-1.5 flex items-center shrink-0",
                           getEffectiveStateColor(displayAgentState)
                         )}
                       >

--- a/src/components/Layout/__tests__/DockedTerminalItem.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTerminalItem.mountGuard.test.tsx
@@ -78,6 +78,7 @@ vi.mock("../dockPanelPortalContext", () => ({
 vi.mock("../useDockBlockedState", () => ({
   useDockBlockedState: () => null,
   getDockDisplayAgentState: () => undefined,
+  isDockAgentStateDeprioritized: () => false,
 }));
 
 vi.mock("../dockPopoverGuard", () => ({

--- a/src/components/Layout/__tests__/DockedTerminalItem.test.tsx
+++ b/src/components/Layout/__tests__/DockedTerminalItem.test.tsx
@@ -74,6 +74,7 @@ vi.mock("../dockPanelPortalContext", () => ({
 vi.mock("../useDockBlockedState", () => ({
   useDockBlockedState: () => null,
   getDockDisplayAgentState: () => undefined,
+  isDockAgentStateDeprioritized: () => false,
 }));
 
 vi.mock("../dockPopoverGuard", () => ({

--- a/src/components/Layout/__tests__/useDockBlockedState.test.ts
+++ b/src/components/Layout/__tests__/useDockBlockedState.test.ts
@@ -5,7 +5,6 @@ import {
   useDockBlockedState,
   getGroupBlockedAgentState,
   getGroupAmbientAgentState,
-  getDockDisplayAgentState,
   isDockAgentStateDeprioritized,
   isGroupDeprioritized,
 } from "../useDockBlockedState";
@@ -209,18 +208,19 @@ describe("isDockAgentStateDeprioritized", () => {
     }
   );
 
-  // The shared predicate is the single source of truth for both pill types:
-  // a single-panel group must recede exactly when the underlying state does,
-  // so DockedTerminalItem and DockedTabGroup can never drift apart.
-  it.each(["idle", "completed", "exited", "working", "waiting", "directing"] as const)(
-    "agrees with isGroupDeprioritized for a single panel in state %s",
-    (state) => {
-      const panel = { agentState: state };
-      expect(isGroupDeprioritized([panel])).toBe(
-        isDockAgentStateDeprioritized(getDockDisplayAgentState(panel))
-      );
-    }
-  );
+  // The shared predicate is the single source of truth for both pill types, so a
+  // single-panel group must recede under the same conditions as a lone pill. Assert
+  // the group helper's observable output for each state (not a copy of its body).
+  it.each([
+    ["idle", true],
+    ["completed", true],
+    ["exited", true],
+    ["working", false],
+    ["waiting", false],
+    ["directing", false],
+  ] as const)("isGroupDeprioritized for a single %s panel is %s", (state, expected) => {
+    expect(isGroupDeprioritized([{ agentState: state }])).toBe(expected);
+  });
 });
 
 describe("isGroupDeprioritized", () => {

--- a/src/components/Layout/__tests__/useDockBlockedState.test.ts
+++ b/src/components/Layout/__tests__/useDockBlockedState.test.ts
@@ -5,6 +5,8 @@ import {
   useDockBlockedState,
   getGroupBlockedAgentState,
   getGroupAmbientAgentState,
+  getDockDisplayAgentState,
+  isDockAgentStateDeprioritized,
   isGroupDeprioritized,
 } from "../useDockBlockedState";
 import type { AgentState } from "@shared/types/agent";
@@ -188,6 +190,37 @@ describe("getGroupAmbientAgentState", () => {
     const panels = [{ agentState: "completed" as const }, { agentState: "working" as const }];
     expect(getGroupAmbientAgentState(panels)).toBe("working");
   });
+});
+
+describe("isDockAgentStateDeprioritized", () => {
+  // States that recede: the pill should dim because nothing is in flight.
+  it.each([undefined, "idle", "completed", "exited"] as const)(
+    "returns true for receding state %s",
+    (state) => {
+      expect(isDockAgentStateDeprioritized(state)).toBe(true);
+    }
+  );
+
+  // Active states keep the pill at full emphasis.
+  it.each(["working", "waiting", "directing"] as const)(
+    "returns false for active state %s",
+    (state) => {
+      expect(isDockAgentStateDeprioritized(state)).toBe(false);
+    }
+  );
+
+  // The shared predicate is the single source of truth for both pill types:
+  // a single-panel group must recede exactly when the underlying state does,
+  // so DockedTerminalItem and DockedTabGroup can never drift apart.
+  it.each(["idle", "completed", "exited", "working", "waiting", "directing"] as const)(
+    "agrees with isGroupDeprioritized for a single panel in state %s",
+    (state) => {
+      const panel = { agentState: state };
+      expect(isGroupDeprioritized([panel])).toBe(
+        isDockAgentStateDeprioritized(getDockDisplayAgentState(panel))
+      );
+    }
+  );
 });
 
 describe("isGroupDeprioritized", () => {

--- a/src/components/Layout/useDockBlockedState.ts
+++ b/src/components/Layout/useDockBlockedState.ts
@@ -143,11 +143,14 @@ export function getGroupAmbientAgentState(
   return undefined;
 }
 
+// Shared recede predicate so single pills (DockedTerminalItem) and group pills
+// (DockedTabGroup) dim under identical conditions and cannot drift apart.
+export function isDockAgentStateDeprioritized(agentState: AgentState | undefined): boolean {
+  if (!agentState) return true;
+  return agentState === "idle" || agentState === "completed" || agentState === "exited";
+}
+
 export function isGroupDeprioritized(panels: ReadonlyArray<AgentStateSource>): boolean {
   if (panels.length === 0) return false;
-  return panels.every((p) => {
-    const state = getDockDisplayAgentState(p);
-    if (!state) return true;
-    return state === "idle" || state === "completed" || state === "exited";
-  });
+  return panels.every((p) => isDockAgentStateDeprioritized(getDockDisplayAgentState(p)));
 }


### PR DESCRIPTION
## Summary

- Extracted a shared `isDockAgentStateDeprioritized` predicate in `useDockBlockedState.ts` so `DockedTerminalItem` and `DockedTabGroup` recede under identical conditions and cannot drift independently.
- Replaced `opacity-50` on `DockedTabGroup` with the same token-level dim used by `DockedTerminalItem` (`text-daintree-text/40` + `border-[var(--dock-item-border)]/50`). `opacity < 1` creates a CSS stacking context that traps Popover/backdrop-blur on Chromium 148, and it double-dims the already low-contrast state icon to ~20% effective alpha (WCAG collapse on `completed`/`exited`). Token-level dim keeps mixed rows visually consistent and the trailing state icon legible.
- Added a fixed `ml-1.5` to the trailing state-icon wrapper on both pills so it reads as a distinct third zone (`[icon+title]` / `[command]` / `[state]`). Fixed margin rather than `ml-auto` because the content-sized pill has no free space for auto margins on deprioritized pills.

Resolves #9817

## Changes

- `useDockBlockedState.ts` — exported `isDockAgentStateDeprioritized` predicate; both components now import it
- `DockedTabGroup.tsx` — swapped `opacity-50` for token-level dim; added `ml-1.5` to state-icon wrapper
- `DockedTerminalItem.tsx` — switched to shared predicate; added `ml-1.5` to state-icon wrapper
- `useDockBlockedState.test.ts` — tests for shared predicate (receding vs active states) and single-panel group expectations covering `directing`/`exited`
- `DockedTerminalItem.test.tsx` / `DockedTerminalItem.mountGuard.test.tsx` — fixed `useDockBlockedState` mock to include new export

Deliberately excluded: `TerminalIcon` wrapper (it hardcodes its own colors; unifying both pills already achieves consistent icon treatment) and the state-icon `div` from the dim scope (carries `getEffectiveStateColor` and is intentionally lowest-emphasis).

## Testing

69 targeted tests pass. `npm run verify` (typecheck + format + all IPC/channel/confirm-wiring guards + `lint:ratchet` at baseline 1194) clean.