### PR TITLE
fix(toolbar): preserve button state in overflow menu

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -216,13 +216,13 @@ interface OverflowMenuProps {
   errorCount: number;
   notificationUnreadCount: number;
   agentDominantStates: Map<string, AgentState | null>;
+  hasActiveWorktree: boolean;
   githubStatsRef: React.RefObject<GitHubStatsHandle | null>;
   overflowActions: Partial<Record<AnyToolbarButtonId, () => void>>;
   pluginOverflowMeta: Record<string, OverflowMenuMeta>;
-  copyTreeShortcut: string | null;
-  notificationsShortcut: string | null;
-  commandPaletteShortcut: string | null;
-  devServerShortcut: string | null;
+  // Shortcut display strings keyed by toolbar button id, so each overflow item
+  // shows the same hint its visible button does (issue #9821).
+  shortcutById: Partial<Record<string, string | null>>;
 }
 
 // Overflow `…` menu. A component (not just a render helper) so the trigger can
@@ -238,16 +238,22 @@ function OverflowMenu({
   errorCount,
   notificationUnreadCount,
   agentDominantStates,
+  hasActiveWorktree,
   githubStatsRef,
   overflowActions,
   pluginOverflowMeta,
-  copyTreeShortcut,
-  notificationsShortcut,
-  commandPaletteShortcut,
-  devServerShortcut,
+  shortcutById,
 }: OverflowMenuProps) {
   const [open, setOpen] = useState(false);
   const isEmpty = overflowIds.length === 0;
+
+  // Keep the controlled `open` state in sync when the menu empties: Radix
+  // closes the popover when `open` is forced false, but `open` state would
+  // stay `true`, so the next non-empty transition would reopen the menu with
+  // no user action. Resetting here makes re-appearing overflow start closed.
+  useEffect(() => {
+    if (isEmpty) setOpen(false);
+  }, [isEmpty]);
   // Set in onPointerDownOutside, read in onCloseAutoFocus. Suppresses focus
   // restoration for pointer dismissals so the ellipsis button doesn't keep its
   // accent focus-visible ring; keyboard close (Escape/Enter) still gets default
@@ -269,13 +275,6 @@ function OverflowMenu({
   const ariaLabel = hasProblem
     ? `More toolbar items — ${n} ${n === 1 ? "problem" : "problems"} hidden`
     : `More toolbar items — ${n} hidden`;
-
-  const shortcutById: Partial<Record<string, string | null>> = {
-    "copy-tree": copyTreeShortcut,
-    "notification-center": notificationsShortcut,
-    "command-palette": commandPaletteShortcut,
-    "dev-server": devServerShortcut,
-  };
 
   const countSuffix = (id: AnyToolbarButtonId) => {
     if (id === "problems" && errorCount > 0) return ` (${errorCount})`;
@@ -374,8 +373,12 @@ function OverflowMenu({
           }
           const Icon = meta.icon;
           const shortcut = shortcutById[id];
+          // Mirror the visible copy-tree button, which is aria-disabled with an
+          // "Open a worktree first" tooltip when no worktree is active — without
+          // this the overflow item would silently close with no feedback.
+          const disabled = id === "copy-tree" && !hasActiveWorktree;
           return [
-            <DropdownMenuItem key={id} onClick={() => overflowActions[id]?.()}>
+            <DropdownMenuItem key={id} disabled={disabled} onClick={() => overflowActions[id]?.()}>
               <Icon className="mr-2 h-4 w-4" />
               <span className="flex-1">
                 {meta.label}
@@ -532,6 +535,10 @@ export function Toolbar({
   const devServerShortcut = useKeybindingDisplay("devServer.start");
   const notificationsShortcut = useKeybindingDisplay("notifications.toggle");
   const commandPaletteShortcut = useKeybindingDisplay("action.palette.open");
+  const settingsShortcut = useKeybindingDisplay("app.settings");
+  const problemsShortcut = useKeybindingDisplay("panel.toggleDiagnostics");
+  const terminalShortcut = useKeybindingDisplay("agent.terminal");
+  const browserShortcut = useKeybindingDisplay("agent.browser");
   const sidebarAriaShortcut = useAriaKeyshortcuts("nav.toggleSidebar");
   const copyTreeAriaShortcut = useAriaKeyshortcuts("worktree.copyTree");
 
@@ -1295,6 +1302,17 @@ export function Toolbar({
     ]
   );
 
+  const overflowShortcutById: Partial<Record<string, string | null>> = {
+    "copy-tree": copyTreeShortcut,
+    "notification-center": notificationsShortcut,
+    "command-palette": commandPaletteShortcut,
+    "dev-server": devServerShortcut,
+    settings: settingsShortcut,
+    problems: problemsShortcut,
+    terminal: terminalShortcut,
+    browser: browserShortcut,
+  };
+
   const renderOverflowMenu = (
     overflowIds: AnyToolbarButtonId[],
     side: "left" | "right",
@@ -1307,13 +1325,11 @@ export function Toolbar({
       errorCount={errorCount}
       notificationUnreadCount={notificationUnreadCount}
       agentDominantStates={agentDominantStates}
+      hasActiveWorktree={!!activeWorktree}
       githubStatsRef={githubStatsRef}
       overflowActions={overflowActions}
       pluginOverflowMeta={pluginOverflowMeta}
-      copyTreeShortcut={copyTreeShortcut}
-      notificationsShortcut={notificationsShortcut}
-      commandPaletteShortcut={commandPaletteShortcut}
-      devServerShortcut={devServerShortcut}
+      shortcutById={overflowShortcutById}
     />
   );
 

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -32,8 +32,11 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
@@ -67,7 +70,17 @@ import type {
 import { usePluginToolbarButtons } from "@/hooks/usePluginToolbarButtons";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
-import type { CliAvailability, AgentSettings } from "@shared/types";
+import { usePanelStore } from "@/store/panelStore";
+import { useShallow } from "zustand/react/shallow";
+import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
+import {
+  getDominantAgentState,
+  agentStateDotColor,
+} from "@/components/Worktree/AgentStatusIndicator";
+import { getRuntimeOrBootAgentId } from "@/utils/terminalType";
+import { isPtyPanel } from "@shared/types/panel";
+import { notify } from "@/lib/notify";
+import type { CliAvailability, AgentSettings, AgentState } from "@shared/types";
 import { isAgentToolbarVisible } from "../../../shared/utils/agentPinned";
 import { projectClient } from "@/clients";
 import { actionService } from "@/services/ActionService";
@@ -84,7 +97,7 @@ import { ToolbarPortalButton } from "./ToolbarPortalButton";
 import { ToolbarAssistantButton } from "./ToolbarAssistantButton";
 import { useOverflowBadgeSeverity, type OverflowBadgeSeverity } from "./useOverflowBadgeSeverity";
 
-import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
+import { BUILT_IN_AGENT_IDS, isBuiltInAgentId } from "@shared/config/agentIds";
 
 const AGENT_TOOLBAR_IDS = new Set<ToolbarButtonId>([
   "agent-tray",
@@ -111,6 +124,16 @@ const NO_PINNED_IDS: ReadonlySet<AnyToolbarButtonId> = new Set();
 // before reverting to its idle state. Long enough to register the success,
 // short enough that re-clicks don't feel stuck.
 const COPY_TREE_FEEDBACK_RESET_MS = 2000;
+
+// Agent states that count as an "active session" when deriving the per-agent
+// dominant state for the overflow menu dot. Mirrors AgentButton's own set so
+// the dot shown in overflow matches what the visible agent button would show.
+const ACTIVE_AGENT_STATES: ReadonlySet<AgentState | undefined> = new Set<AgentState | undefined>([
+  "idle",
+  "working",
+  "waiting",
+  "directing",
+]);
 
 function GitHubStatsPlaceholder() {
   return (
@@ -186,6 +209,226 @@ for (const [id, meta] of Object.entries(TOOLBAR_BUTTON_METADATA)) {
 export const OVERFLOW_MENU_META: Partial<Record<AnyToolbarButtonId, OverflowMenuMeta>> =
   overflowMenuMetaInit;
 
+interface OverflowMenuProps {
+  overflowIds: AnyToolbarButtonId[];
+  side: "left" | "right";
+  severity: OverflowBadgeSeverity;
+  errorCount: number;
+  notificationUnreadCount: number;
+  agentDominantStates: Map<string, AgentState | null>;
+  githubStatsRef: React.RefObject<GitHubStatsHandle | null>;
+  overflowActions: Partial<Record<AnyToolbarButtonId, () => void>>;
+  pluginOverflowMeta: Record<string, OverflowMenuMeta>;
+  copyTreeShortcut: string | null;
+  notificationsShortcut: string | null;
+  commandPaletteShortcut: string | null;
+  devServerShortcut: string | null;
+}
+
+// Overflow `…` menu. A component (not just a render helper) so the trigger can
+// stay mounted across the empty↔non-empty transition and animate its entry /
+// exit via CSS (issue #9821) while `open` stays controlled — avoiding React's
+// controlled/uncontrolled warning. Each menu item restores the contextual
+// state its source toolbar button carries: error/unread counts, agent-state
+// dots, and keyboard shortcut hints.
+function OverflowMenu({
+  overflowIds,
+  side,
+  severity,
+  errorCount,
+  notificationUnreadCount,
+  agentDominantStates,
+  githubStatsRef,
+  overflowActions,
+  pluginOverflowMeta,
+  copyTreeShortcut,
+  notificationsShortcut,
+  commandPaletteShortcut,
+  devServerShortcut,
+}: OverflowMenuProps) {
+  const [open, setOpen] = useState(false);
+  const isEmpty = overflowIds.length === 0;
+  // Set in onPointerDownOutside, read in onCloseAutoFocus. Suppresses focus
+  // restoration for pointer dismissals so the ellipsis button doesn't keep its
+  // accent focus-visible ring; keyboard close (Escape/Enter) still gets default
+  // focus return for WAI-ARIA. Local to this component so react-compiler doesn't
+  // flag mutating a ref passed in as a prop.
+  const overflowMenuPointerCloseRef = useRef(false);
+
+  // Keep the accessible name stable and terse: a comma-enumerated list
+  // re-announces the full set on every focus pass and goes stale as
+  // resize-driven overflow changes. Surface only the purpose plus a
+  // count, escalating the noun to "problem(s)" when severity is
+  // actionable (critical/warning) so screen-reader users still learn
+  // there's something to act on without the list churn.
+  const n = overflowIds.length;
+  const hasProblem = severity === "critical" || severity === "warning";
+  const tooltipText = hasProblem
+    ? `More — ${n} ${n === 1 ? "problem" : "problems"}`
+    : `More — ${n} ${n === 1 ? "item" : "items"}`;
+  const ariaLabel = hasProblem
+    ? `More toolbar items — ${n} ${n === 1 ? "problem" : "problems"} hidden`
+    : `More toolbar items — ${n} hidden`;
+
+  const shortcutById: Partial<Record<string, string | null>> = {
+    "copy-tree": copyTreeShortcut,
+    "notification-center": notificationsShortcut,
+    "command-palette": commandPaletteShortcut,
+    "dev-server": devServerShortcut,
+  };
+
+  const countSuffix = (id: AnyToolbarButtonId) => {
+    if (id === "problems" && errorCount > 0) return ` (${errorCount})`;
+    if (id === "notification-center" && notificationUnreadCount > 0)
+      return ` (${notificationUnreadCount})`;
+    return "";
+  };
+
+  return (
+    <DropdownMenu open={isEmpty ? false : open} onOpenChange={setOpen}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              data-toolbar-item=""
+              data-toolbar-overflow-trigger=""
+              data-toolbar-overflow-side={side}
+              data-visible={isEmpty ? "false" : "true"}
+              aria-hidden={isEmpty || undefined}
+              tabIndex={isEmpty ? -1 : undefined}
+              className={toolbarIconButtonClass}
+              aria-label={ariaLabel}
+            >
+              <Ellipsis />
+              <span
+                aria-hidden="true"
+                data-testid="toolbar-overflow-badge"
+                data-severity={severity}
+                data-visible={severity !== null}
+                className="toolbar-overflow-badge toolbar-badge absolute top-1.5 right-1.5 h-1.5 w-1.5 pointer-events-none"
+              />
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">{tooltipText}</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent
+        align={side === "left" ? "start" : "end"}
+        sideOffset={4}
+        onPointerDownOutside={() => {
+          overflowMenuPointerCloseRef.current = true;
+        }}
+        onCloseAutoFocus={(e) => {
+          if (overflowMenuPointerCloseRef.current) {
+            e.preventDefault();
+            overflowMenuPointerCloseRef.current = false;
+          }
+        }}
+      >
+        {overflowIds.flatMap((id, idx) => {
+          if (id === "github-stats") {
+            const ghStats = githubStatsRef.current?.stats;
+            const isLast = idx === overflowIds.length - 1;
+            return [
+              <DropdownMenuGroup key="gh-group">
+                <DropdownMenuLabel>GitHub</DropdownMenuLabel>
+                <DropdownMenuItem
+                  key="gh-issues"
+                  onClick={() => githubStatsRef.current?.openIssues()}
+                >
+                  <CircleDot className="mr-2 h-4 w-4 text-pr-open" />
+                  Issues {ghStats?.issueCount != null ? `(${ghStats.issueCount})` : ""}
+                </DropdownMenuItem>
+                <DropdownMenuItem key="gh-prs" onClick={() => githubStatsRef.current?.openPrs()}>
+                  <GitPullRequest className="mr-2 h-4 w-4 text-pr-merged" />
+                  Pull Requests {ghStats?.prCount != null ? `(${ghStats.prCount})` : ""}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  key="gh-commits"
+                  onClick={() => githubStatsRef.current?.openCommits()}
+                >
+                  <GitCommit className="mr-2 h-4 w-4" />
+                  Commits {ghStats?.commitCount != null ? `(${ghStats.commitCount})` : ""}
+                </DropdownMenuItem>
+              </DropdownMenuGroup>,
+              ...(isLast ? [] : [<DropdownMenuSeparator key="gh-sep" />]),
+            ];
+          }
+          const meta = OVERFLOW_MENU_META[id] ?? pluginOverflowMeta[id];
+          if (!meta) return [];
+          if (isBuiltInAgentId(id)) {
+            const dominantState = agentDominantStates.get(id) ?? null;
+            const dotColor = dominantState ? agentStateDotColor(dominantState) : null;
+            return [
+              <AgentOverflowItem
+                key={id}
+                id={id}
+                label={meta.label}
+                Icon={meta.icon}
+                dotColor={dotColor}
+                onSelect={() => overflowActions[id]?.()}
+              />,
+            ];
+          }
+          const Icon = meta.icon;
+          const shortcut = shortcutById[id];
+          return [
+            <DropdownMenuItem key={id} onClick={() => overflowActions[id]?.()}>
+              <Icon className="mr-2 h-4 w-4" />
+              <span className="flex-1">
+                {meta.label}
+                {countSuffix(id)}
+              </span>
+              {shortcut && <DropdownMenuShortcut>{shortcut}</DropdownMenuShortcut>}
+            </DropdownMenuItem>,
+          ];
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+// Overflow menu item for a built-in agent. A standalone component (hoisted, so
+// OverflowMenu above can reference it) so the per-agent keybinding lookup
+// (`useKeybindingDisplay`) runs at component scope rather than inside a `.map()`
+// callback (rules of hooks). Restores the two signals the bare overflow item
+// dropped: the colored agent-state dot and the keyboard shortcut hint.
+function AgentOverflowItem({
+  id,
+  label,
+  Icon,
+  dotColor,
+  onSelect,
+}: {
+  id: string;
+  label: string;
+  Icon: React.ComponentType<{ className?: string }>;
+  dotColor: string | null;
+  onSelect: () => void;
+}) {
+  const shortcut = useKeybindingDisplay(`agent.${id}`);
+  return (
+    <DropdownMenuItem onClick={onSelect}>
+      <span className="relative mr-2 inline-flex h-4 w-4 items-center justify-center">
+        <Icon className="h-4 w-4" />
+        {dotColor && (
+          <span
+            aria-hidden="true"
+            className={cn(
+              "absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-1 ring-daintree-bg",
+              dotColor
+            )}
+          />
+        )}
+      </span>
+      <span className="flex-1">{label}</span>
+      {shortcut && <DropdownMenuShortcut>{shortcut}</DropdownMenuShortcut>}
+    </DropdownMenuItem>
+  );
+}
+
 interface ToolbarProps {
   onLaunchAgent: (type: string) => void;
   onSettings: () => void;
@@ -222,6 +465,15 @@ export function Toolbar({
   );
   const branchName = activeWorktree?.branch;
   const watcherDegraded = useWorktreeStore((state) => state.watcherDegraded);
+
+  // Per-item state for the overflow menu, so evicted buttons keep the signal
+  // they carry on the visible toolbar (issue #9821). Reads mirror the
+  // selectors used by the source buttons (NotificationCenterToolbarButton,
+  // AgentButton) rather than extending useOverflowBadgeSeverity to return a
+  // composite map (would risk the selector-identity churn of lesson #3730).
+  const notificationUnreadCount = useNotificationHistoryStore((s) => s.unreadCount);
+  const panelsById = usePanelStore(useShallow((s) => s.panelsById));
+  const panelIds = usePanelStore(useShallow((s) => s.panelIds));
 
   useEffect(() => {
     loadProjects();
@@ -273,16 +525,13 @@ export function Toolbar({
   // nearest visible item to preserve keyboard navigation (WCAG 2.4.3).
   const prevFocusedToolbarItemRef = useRef<HTMLElement | null>(null);
   const githubStatsRef = useRef<GitHubStatsHandle>(null);
-  // Set in onPointerDownOutside, read in onCloseAutoFocus on the overflow
-  // dropdown. Suppresses focus restoration for pointer dismissals so the
-  // ellipsis button doesn't keep its accent focus-visible ring; keyboard
-  // close (Escape/Enter) still gets default focus return for WAI-ARIA.
-  const overflowMenuPointerCloseRef = useRef(false);
 
   const { handleCopyTree } = useWorktreeActions();
   const sidebarShortcut = useKeybindingDisplay("nav.toggleSidebar");
   const copyTreeShortcut = useKeybindingDisplay("worktree.copyTree");
   const devServerShortcut = useKeybindingDisplay("devServer.start");
+  const notificationsShortcut = useKeybindingDisplay("notifications.toggle");
+  const commandPaletteShortcut = useKeybindingDisplay("action.palette.open");
   const sidebarAriaShortcut = useAriaKeyshortcuts("nav.toggleSidebar");
   const copyTreeAriaShortcut = useAriaKeyshortcuts("worktree.copyTree");
 
@@ -372,6 +621,60 @@ export function Toolbar({
       setIsCopyingTree(false);
     }
   }, [isCopyingTree, activeWorktree, handleCopyTree]);
+
+  // Copy-tree invoked from the overflow menu. The visible toolbar button shows
+  // inline green-tick feedback, but that button is hidden when copy-tree is in
+  // overflow — so the overflow path surfaces a transient success toast instead
+  // (issue #9821). `transient: true` keeps it out of the inbox: the result is
+  // already on the clipboard, so no durable record is warranted.
+  const handleCopyTreeOverflow = useCallback(async () => {
+    if (isCopyingTree || !activeWorktree) return;
+    setIsCopyingTree(true);
+    try {
+      const resultMessage = await handleCopyTree(activeWorktree);
+      if (resultMessage) {
+        // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
+        notify({
+          type: "success",
+          title: "Context copied",
+          message: resultMessage,
+          transient: true,
+        });
+      }
+    } finally {
+      setIsCopyingTree(false);
+    }
+  }, [isCopyingTree, activeWorktree, handleCopyTree]);
+
+  // Per-agent dominant state across panels in the active worktree, used to draw
+  // the agent-state dot on overflow menu items. Mirrors the derivation in
+  // AgentTrayButton so the overflow dot matches the visible agent button.
+  const agentDominantStates = useMemo(() => {
+    const statesPerAgent = new Map<string, (AgentState | undefined)[]>();
+    for (const pid of panelIds) {
+      const p = panelsById[pid];
+      if (
+        !p ||
+        !isPtyPanel(p) ||
+        p.location === "trash" ||
+        p.location === "background" ||
+        p.location === "overlay"
+      )
+        continue;
+      const agentId = getRuntimeOrBootAgentId(p);
+      if (!agentId) continue;
+      if (activeWorktreeId && p.worktreeId !== activeWorktreeId) continue;
+      if (!ACTIVE_AGENT_STATES.has(p.agentState)) continue;
+      const arr = statesPerAgent.get(agentId) ?? [];
+      arr.push(p.agentState);
+      statesPerAgent.set(agentId, arr);
+    }
+    const result = new Map<string, AgentState | null>();
+    for (const [agentId, states] of statesPerAgent) {
+      result.set(agentId, getDominantAgentState(states));
+    }
+    return result;
+  }, [panelsById, panelIds, activeWorktreeId]);
 
   const getToolbarItems = useCallback(
     () =>
@@ -957,7 +1260,7 @@ export function Toolbar({
         void actionService.dispatch("notifications.toggle", undefined, { source: "user" });
       },
       "copy-tree": () => {
-        void handleCopyTreeClick();
+        void handleCopyTreeOverflow();
       },
       "command-palette": () => {
         void actionService.dispatch("action.palette.open", undefined, { source: "user" });
@@ -984,7 +1287,7 @@ export function Toolbar({
     }),
     [
       onLaunchAgent,
-      handleCopyTreeClick,
+      handleCopyTreeOverflow,
       onSettings,
       onToggleProblems,
       pluginButtonIds,
@@ -996,104 +1299,23 @@ export function Toolbar({
     overflowIds: AnyToolbarButtonId[],
     side: "left" | "right",
     severity: OverflowBadgeSeverity
-  ) => {
-    if (overflowIds.length === 0) return null;
-    // Keep the accessible name stable and terse: a comma-enumerated list
-    // re-announces the full set on every focus pass and goes stale as
-    // resize-driven overflow changes. Surface only the purpose plus a
-    // count, escalating the noun to "problem(s)" when severity is
-    // actionable (critical/warning) so screen-reader users still learn
-    // there's something to act on without the list churn.
-    const n = overflowIds.length;
-    const hasProblem = severity === "critical" || severity === "warning";
-    const tooltipText = hasProblem
-      ? `More — ${n} ${n === 1 ? "problem" : "problems"}`
-      : `More — ${n} ${n === 1 ? "item" : "items"}`;
-    const ariaLabel = hasProblem
-      ? `More toolbar items — ${n} ${n === 1 ? "problem" : "problems"} hidden`
-      : `More toolbar items — ${n} hidden`;
-    return (
-      <DropdownMenu>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                data-toolbar-item=""
-                data-toolbar-overflow-trigger=""
-                data-toolbar-overflow-side={side}
-                className={toolbarIconButtonClass}
-                aria-label={ariaLabel}
-              >
-                <Ellipsis />
-                <span
-                  aria-hidden="true"
-                  data-testid="toolbar-overflow-badge"
-                  data-severity={severity}
-                  data-visible={severity !== null}
-                  className="toolbar-overflow-badge toolbar-badge absolute top-1.5 right-1.5 h-1.5 w-1.5 pointer-events-none"
-                />
-              </Button>
-            </DropdownMenuTrigger>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">{tooltipText}</TooltipContent>
-        </Tooltip>
-        <DropdownMenuContent
-          align={side === "left" ? "start" : "end"}
-          sideOffset={4}
-          onPointerDownOutside={() => {
-            overflowMenuPointerCloseRef.current = true;
-          }}
-          onCloseAutoFocus={(e) => {
-            if (overflowMenuPointerCloseRef.current) {
-              e.preventDefault();
-              overflowMenuPointerCloseRef.current = false;
-            }
-          }}
-        >
-          {overflowIds.flatMap((id, idx) => {
-            if (id === "github-stats") {
-              const ghStats = githubStatsRef.current?.stats;
-              const items = [
-                <DropdownMenuItem
-                  key="gh-issues"
-                  onClick={() => githubStatsRef.current?.openIssues()}
-                >
-                  <CircleDot className="mr-2 h-4 w-4 text-pr-open" />
-                  Issues {ghStats?.issueCount != null ? `(${ghStats.issueCount})` : ""}
-                </DropdownMenuItem>,
-                <DropdownMenuItem key="gh-prs" onClick={() => githubStatsRef.current?.openPrs()}>
-                  <GitPullRequest className="mr-2 h-4 w-4 text-pr-merged" />
-                  Pull Requests {ghStats?.prCount != null ? `(${ghStats.prCount})` : ""}
-                </DropdownMenuItem>,
-                <DropdownMenuItem
-                  key="gh-commits"
-                  onClick={() => githubStatsRef.current?.openCommits()}
-                >
-                  <GitCommit className="mr-2 h-4 w-4" />
-                  Commits {ghStats?.commitCount != null ? `(${ghStats.commitCount})` : ""}
-                </DropdownMenuItem>,
-              ];
-              if (idx < overflowIds.length - 1) {
-                items.push(<DropdownMenuSeparator key="gh-sep" />);
-              }
-              return items;
-            }
-            const meta = OVERFLOW_MENU_META[id] ?? pluginOverflowMeta[id];
-            if (!meta) return [];
-            const Icon = meta.icon;
-            return [
-              <DropdownMenuItem key={id} onClick={() => overflowActions[id]?.()}>
-                <Icon className="mr-2 h-4 w-4" />
-                {meta.label}
-              </DropdownMenuItem>,
-            ];
-          })}
-        </DropdownMenuContent>
-      </DropdownMenu>
-    );
-  };
+  ) => (
+    <OverflowMenu
+      overflowIds={overflowIds}
+      side={side}
+      severity={severity}
+      errorCount={errorCount}
+      notificationUnreadCount={notificationUnreadCount}
+      agentDominantStates={agentDominantStates}
+      githubStatsRef={githubStatsRef}
+      overflowActions={overflowActions}
+      pluginOverflowMeta={pluginOverflowMeta}
+      copyTreeShortcut={copyTreeShortcut}
+      notificationsShortcut={notificationsShortcut}
+      commandPaletteShortcut={commandPaletteShortcut}
+      devServerShortcut={devServerShortcut}
+    />
+  );
 
   const isDropdownOpen = projectSwitcher.isOpen && projectSwitcher.mode === "dropdown";
   const handleDropdownClose = useCallback(() => {

--- a/src/components/Layout/__tests__/Toolbar.overflow.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.overflow.test.ts
@@ -75,6 +75,35 @@ describe("Toolbar overflow menu state preservation — issue #9821", () => {
       expect(source).toMatch(/"command-palette":\s*commandPaletteShortcut/);
       expect(source).toMatch(/"dev-server":\s*devServerShortcut/);
     });
+
+    it("covers the remaining shortcut-bearing buttons — settings, problems, terminal, browser", () => {
+      // These all show a shortcut hint on their visible toolbar button, so the
+      // overflow item must too (issue #9821).
+      expect(source).toContain('useKeybindingDisplay("app.settings")');
+      expect(source).toContain('useKeybindingDisplay("panel.toggleDiagnostics")');
+      expect(source).toContain('useKeybindingDisplay("agent.terminal")');
+      expect(source).toContain('useKeybindingDisplay("agent.browser")');
+      expect(source).toMatch(/settings:\s*settingsShortcut/);
+      expect(source).toMatch(/problems:\s*problemsShortcut/);
+      expect(source).toMatch(/terminal:\s*terminalShortcut/);
+      expect(source).toMatch(/browser:\s*browserShortcut/);
+    });
+  });
+
+  describe("review fixes", () => {
+    it("resets controlled open state when the menu empties so it doesn't self-reopen", () => {
+      // Without this, widening then re-narrowing the window pops the overflow
+      // menu open with no user action.
+      expect(source).toMatch(
+        /useEffect\(\(\)\s*=>\s*\{\s*if \(isEmpty\) setOpen\(false\);?\s*\}, \[isEmpty\]\)/
+      );
+    });
+
+    it("disables the overflow copy-tree item when there is no active worktree", () => {
+      // Mirrors the visible button's aria-disabled "Open a worktree first" state.
+      expect(source).toMatch(/id === "copy-tree" && !hasActiveWorktree/);
+      expect(source).toContain("disabled={disabled}");
+    });
   });
 
   describe("github-stats group label", () => {

--- a/src/components/Layout/__tests__/Toolbar.overflow.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.overflow.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+
+const TOOLBAR_PATH = path.resolve(__dirname, "../Toolbar.tsx");
+const TOOLBAR_CSS_PATH = path.resolve(__dirname, "../../../styles/components/toolbar.css");
+
+// Issue #9821 — the `…` overflow menu dropped every contextual signal the
+// evicted toolbar buttons carry (error/unread counts, agent-state dots,
+// keyboard shortcuts, the GitHub group label), gave no feedback when copy-tree
+// fired from overflow, and the trigger popped in/out without an animation.
+// These are static-source assertions (the rest of the Toolbar.* suite uses the
+// same approach — Toolbar.tsx has too many IPC dependencies to render in jsdom).
+describe("Toolbar overflow menu state preservation — issue #9821", () => {
+  let source: string;
+  let css: string;
+
+  beforeEach(async () => {
+    [source, css] = await Promise.all([
+      fs.readFile(TOOLBAR_PATH, "utf-8"),
+      fs.readFile(TOOLBAR_CSS_PATH, "utf-8"),
+    ]);
+  });
+
+  describe("imports", () => {
+    it("pulls in the dropdown primitives needed for shortcuts, labels, and groups", () => {
+      expect(source).toContain("DropdownMenuShortcut");
+      expect(source).toContain("DropdownMenuLabel");
+      expect(source).toContain("DropdownMenuGroup");
+    });
+
+    it("imports the agent-state dot helpers and notify", () => {
+      expect(source).toContain("agentStateDotColor");
+      expect(source).toContain("getDominantAgentState");
+      expect(source).toContain('import { notify } from "@/lib/notify"');
+    });
+  });
+
+  describe("per-item counts", () => {
+    it("reads the live notification unread count for the menu item", () => {
+      expect(source).toContain("useNotificationHistoryStore((s) => s.unreadCount)");
+    });
+
+    it("appends the error count to the problems item and unread count to notifications", () => {
+      // countSuffix derives both from the same primitives the source buttons use.
+      expect(source).toMatch(/id === "problems" && errorCount > 0/);
+      expect(source).toMatch(/id === "notification-center" && notificationUnreadCount > 0/);
+    });
+  });
+
+  describe("agent-state dots", () => {
+    it("derives a per-agent dominant state map scoped to the active worktree", () => {
+      expect(source).toContain("agentDominantStates");
+      expect(source).toMatch(/getDominantAgentState\(states\)/);
+    });
+
+    it("renders the dot through a dedicated component so the keybinding hook is at component scope", () => {
+      // A hook inside a .map() callback would violate the rules of hooks; the
+      // AgentOverflowItem component is the fix (mirrors AgentTrayButton).
+      expect(source).toContain("function AgentOverflowItem");
+      expect(source).toContain("useKeybindingDisplay(`agent.${id}`)");
+      expect(source).toContain("agentStateDotColor(dominantState)");
+    });
+  });
+
+  describe("keyboard shortcut hints", () => {
+    it("looks up shortcuts for the fixed-action overflow items", () => {
+      expect(source).toContain('useKeybindingDisplay("notifications.toggle")');
+      expect(source).toContain('useKeybindingDisplay("action.palette.open")');
+    });
+
+    it("maps each fixed-action item id to its shortcut", () => {
+      expect(source).toMatch(/"copy-tree":\s*copyTreeShortcut/);
+      expect(source).toMatch(/"notification-center":\s*notificationsShortcut/);
+      expect(source).toMatch(/"command-palette":\s*commandPaletteShortcut/);
+      expect(source).toMatch(/"dev-server":\s*devServerShortcut/);
+    });
+  });
+
+  describe("github-stats group label", () => {
+    it("wraps the three GitHub items in a labelled group", () => {
+      // DropdownMenuLabel alone is insufficient — the Group wires role=group +
+      // aria-labelledby so the boundary is announced.
+      expect(source).toMatch(
+        /<DropdownMenuGroup[\s\S]*?<DropdownMenuLabel>GitHub<\/DropdownMenuLabel>/
+      );
+    });
+  });
+
+  describe("copy-tree feedback from overflow", () => {
+    it("fires a transient success toast on the overflow path", () => {
+      expect(source).toContain("handleCopyTreeOverflow");
+      expect(source).toMatch(/notify\(\{[\s\S]*?transient: true[\s\S]*?\}\)/);
+    });
+
+    it("wires the overflow action to the toast handler, not the inline-feedback handler", () => {
+      expect(source).toMatch(/"copy-tree":\s*\(\)\s*=>\s*\{\s*void handleCopyTreeOverflow\(\)/);
+    });
+
+    it("keeps the eslint exception for an action-free notify", () => {
+      expect(source).toContain("notify-no-action: ok");
+    });
+  });
+
+  describe("trigger entry/exit animation", () => {
+    it("keeps the trigger mounted and toggles data-visible instead of returning null", () => {
+      expect(source).toContain('data-visible={isEmpty ? "false" : "true"}');
+      // The empty trigger must drop out of roving focus and not be clickable.
+      expect(source).toContain("aria-hidden={isEmpty || undefined}");
+      expect(source).toContain("tabIndex={isEmpty ? -1 : undefined}");
+    });
+
+    it("forces the menu closed when empty while staying controlled (no React warning)", () => {
+      expect(source).toMatch(/open=\{isEmpty \? false : open\}/);
+    });
+
+    it("animates the trigger via @starting-style + allow-discrete, opacity-only", () => {
+      expect(css).toMatch(
+        /\[data-toolbar-overflow-trigger\]\s*\{[\s\S]*?display:\s*none;[\s\S]*?allow-discrete/
+      );
+      expect(css).toMatch(
+        /\[data-toolbar-overflow-trigger\]\[data-visible="true"\][\s\S]*?@starting-style/
+      );
+      // Opacity-only — no scale transform like the pip badge uses.
+      const triggerBlock = css.match(
+        /\[data-toolbar-overflow-trigger\]\[data-visible="true"\]\s*\{[\s\S]*?\}/
+      )?.[0];
+      expect(triggerBlock).toBeDefined();
+      expect(triggerBlock).not.toContain("scale");
+    });
+
+    it("keeps a timed (not none) display swap under reduced motion — lesson #6182", () => {
+      // Inside the @variant reduce-motion block the trigger must still toggle
+      // display (display 0s, not transition: none) so the discrete swap lands.
+      expect(css).toMatch(
+        /@variant reduce-motion\s*\{[\s\S]*?\[data-toolbar-overflow-trigger\]\s*\{[\s\S]*?display\s+0s/
+      );
+    });
+  });
+});

--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -407,6 +407,40 @@
   }
 }
 
+/* ── Overflow `…` trigger entry / exit ──
+ * The trigger appears only while items are evicted into it. Without an
+ * animation it pops in/out instantly, unlike every other toolbar badge
+ * (issue #9821). Opacity-only (no scale) — the trigger is a full-size button,
+ * not a pip, so scaling would read as a glitch. @starting-style + allow-discrete
+ * drive entry/exit in pure CSS; the button stays mounted and toggles
+ * data-visible (going display:none when empty so it reclaims its layout slot
+ * and drops out of roving focus). color/background-color stay at 150ms so the
+ * hover tint still animates at its normal cadence.
+ */
+[data-toolbar-overflow-trigger] {
+  display: none;
+  opacity: 0;
+  transition:
+    display 120ms allow-discrete,
+    opacity 120ms ease,
+    color 150ms ease,
+    background-color 150ms ease;
+}
+
+[data-toolbar-overflow-trigger][data-visible="true"] {
+  display: inline-flex;
+  opacity: 1;
+  transition:
+    display 200ms allow-discrete,
+    opacity 200ms ease,
+    color 150ms ease,
+    background-color 150ms ease;
+
+  @starting-style {
+    opacity: 0;
+  }
+}
+
 /* ── Overflow severity dot ──
  * @property --overflow-badge-color (registered above) interpolates in OKLab
  * so severity class-swaps produce a smooth hue transition instead of a snap.
@@ -496,6 +530,16 @@
     transition:
       display 0s,
       opacity 200ms ease;
+  }
+
+  /* Keep a timed (not `none`) display swap so the discrete show/hide still
+   * completes (lesson #6182); the fade collapses to opacity-only. */
+  [data-toolbar-overflow-trigger] {
+    transition:
+      display 0s,
+      opacity 200ms ease,
+      color 150ms ease,
+      background-color 150ms ease;
   }
 }
 


### PR DESCRIPTION
Fixes #9821 — toolbar buttons evicted to the `…` overflow menu were losing the state they communicate in the main toolbar.

## Changes

- Problems error count and notification-center unread count shown as `(N)` suffix on the menu item.
- Agent buttons show their colored state dot, derived via `getDominantAgentState` to match the visible button exactly.
- Keyboard shortcut hints via `DropdownMenuShortcut` for copy-tree, notification-center, command-palette, dev-server, settings, problems, terminal, and browser.
- `github-stats` items wrapped in a `DropdownMenuGroup` with a "GitHub" label (`role=group` + `aria-labelledby`).
- Copy-tree from overflow fires a transient success toast; the visible button keeps its inline green-tick. Item is disabled when no worktree is active.
- The `…` trigger animates entry/exit via `@starting-style` + `allow-discrete` (opacity-only, reduced-motion safe) — stays mounted, toggling `data-visible` rather than mounting/unmounting.
- Extracted `OverflowMenu` and `AgentOverflowItem` at module level so per-agent `useKeybindingDisplay` runs at component scope, respecting the rules of hooks.
- Controlled `DropdownMenu` open state resets when overflow empties, preventing a resize from self-reopening the menu.
- New static-analysis test `Toolbar.overflow.test.ts`.

## Testing

`Toolbar.overflow`, `Toolbar.responsive`, and `useOverflowBadgeSeverity` all pass (48 tests). `tsc` clean. `npm run check` fully green — lint ratchet holds at 1194, no new warnings, build passes.