### PR TITLE
feat(terminal): add batch-scoped scrollback restore surface

### DIFF
--- a/src/components/Terminal/BatchScrollbackRestoreBar.tsx
+++ b/src/components/Terminal/BatchScrollbackRestoreBar.tsx
@@ -1,0 +1,95 @@
+import { useCallback, type CSSProperties } from "react";
+import { History, Loader2, RotateCcw } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useShallow } from "zustand/react/shallow";
+import { usePanelStore, type PanelGridState } from "@/store/panelStore";
+import { isPtyPanel } from "@shared/types/panel";
+import { useDohertyGate } from "@/hooks/useDeferredLoading";
+import { useScrollbackRestoreAggregate } from "@/hooks/useScrollbackRestoreAggregate";
+import { InlineStatusBanner } from "./InlineStatusBanner";
+import { retryFailedScrollbackRestoreBatch } from "@/utils/stateHydration/scrollbackRestoreScheduler";
+
+function SpinnerIcon({ className, style }: { className?: string; style?: CSSProperties }) {
+  return (
+    <Loader2
+      className={cn("animate-spin motion-reduce:animate-none", className)}
+      style={style}
+      aria-hidden="true"
+    />
+  );
+}
+
+// Panels whose last scrollback restore failed. The per-panel banner inside each
+// TerminalPane handles individual dismissal/reset; this batch banner aggregates
+// them for a single "Retry batch" recovery. Dismissing every per-panel banner
+// empties this list, which auto-hides the batch banner.
+function selectFailedScrollbackRestoreIds(state: PanelGridState): string[] {
+  const ids: string[] = [];
+  for (const id of state.panelIds) {
+    const panel = state.panelsById[id];
+    if (!panel || !isPtyPanel(panel) || panel.location === "trash") continue;
+    if (panel.scrollbackRestoreError) ids.push(id);
+  }
+  return ids;
+}
+
+/**
+ * Grid-level surface for batch scrollback restore. Renders, in priority order:
+ *  - Tier 3 error banner with a "Retry batch" action when any panel's restore
+ *    failed (persists until retried or all per-panel errors are cleared);
+ *  - Tier 1 ambient "Restoring N of M" progress, gated by the 400ms Doherty
+ *    threshold so sub-400ms restores never flash;
+ *  - nothing when idle.
+ */
+export function BatchScrollbackRestoreBar({ className }: { className?: string }) {
+  const { pendingCount, inProgressCount, totalCount } = useScrollbackRestoreAggregate();
+  const failedIds = usePanelStore(useShallow(selectFailedScrollbackRestoreIds));
+
+  const isRestoring = pendingCount + inProgressCount > 0;
+  const showProgress = useDohertyGate(isRestoring);
+
+  const handleRetry = useCallback(() => {
+    retryFailedScrollbackRestoreBatch(failedIds);
+  }, [failedIds]);
+
+  if (failedIds.length > 0) {
+    const count = failedIds.length;
+    return (
+      <InlineStatusBanner
+        icon={History}
+        title={`Restore failed for ${count} panel${count !== 1 ? "s" : ""}`}
+        description="Some panels couldn't replay their earlier output. The terminals still work."
+        severity="error"
+        role="alert"
+        ariaLive="assertive"
+        className={className}
+        action={{
+          id: "retry-batch",
+          label: "Retry batch",
+          icon: RotateCcw,
+          variant: "primary",
+          onClick: handleRetry,
+          ariaLabel: "Retry batch",
+        }}
+      />
+    );
+  }
+
+  if (showProgress) {
+    const doneCount = Math.max(0, totalCount - pendingCount - inProgressCount);
+    return (
+      <InlineStatusBanner
+        icon={SpinnerIcon}
+        title={`Restoring ${doneCount} of ${totalCount}`}
+        severity="info"
+        animated={false}
+        role="status"
+        ariaLive="polite"
+        className={className}
+        actions={[]}
+      />
+    );
+  }
+
+  return null;
+}

--- a/src/components/Terminal/ContentGridDefault.tsx
+++ b/src/components/Terminal/ContentGridDefault.tsx
@@ -15,6 +15,7 @@ import {
 import { GridShell } from "./GridShell";
 import { GridScrollbar, GRID_SCROLLBAR_GUTTER_PX } from "./GridScrollbar";
 import { TerminalCountWarning } from "./TerminalCountWarning";
+import { BatchScrollbackRestoreBar } from "./BatchScrollbackRestoreBar";
 import { ContentGridEmptyState } from "./ContentGridEmptyState";
 import type { ContentGridContext } from "./useContentGridContext";
 
@@ -67,6 +68,7 @@ export function ContentGridDefault({
       >
         <GridNotificationBar className="mx-1 mt-1 shrink-0" />
         <TerminalCountWarning className="mx-1 mt-1 shrink-0" />
+        <BatchScrollbackRestoreBar className="mx-1 mt-1 shrink-0" />
         <div className="relative flex-1 min-h-0">
           <SortableContext id="grid-container" items={ctx.panelIds} strategy={rectSortingStrategy}>
             <GridShell

--- a/src/components/Terminal/ContentGridTwoPaneSplit.tsx
+++ b/src/components/Terminal/ContentGridTwoPaneSplit.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/lib/utils";
 import { GridNotificationBar } from "./GridNotificationBar";
+import { BatchScrollbackRestoreBar } from "./BatchScrollbackRestoreBar";
 import { TwoPaneSplitLayout } from "./TwoPaneSplitLayout";
 import { GridShell } from "./GridShell";
 import type { ContentGridContext } from "./useContentGridContext";
@@ -35,6 +36,7 @@ export function ContentGridTwoPaneSplit({
       )}
     >
       <GridNotificationBar className="mx-1 mt-1 shrink-0" />
+      <BatchScrollbackRestoreBar className="mx-1 mt-1 shrink-0" />
       <GridShell ctx={ctx}>
         <div
           ref={bindCombinedGrid}

--- a/src/components/Terminal/__tests__/BatchScrollbackRestoreBar.test.tsx
+++ b/src/components/Terminal/__tests__/BatchScrollbackRestoreBar.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+vi.mock("zustand/react/shallow", () => ({
+  useShallow: (fn: (...args: unknown[]) => unknown) => fn,
+}));
+
+vi.mock("@shared/types/panel", () => ({
+  isPtyPanel: (panel: { kind?: string }) => panel?.kind !== "browser",
+}));
+
+// Real Doherty gate (useDeferredLoading) so the 400ms anti-flicker is exercised
+// with fake timers, but a controllable aggregate hook so we drive the counts.
+let aggregate = { pendingCount: 0, inProgressCount: 0, totalCount: 0 };
+vi.mock("@/hooks/useScrollbackRestoreAggregate", () => ({
+  useScrollbackRestoreAggregate: () => aggregate,
+}));
+
+const panelState = {
+  panelsById: {} as Record<string, unknown>,
+  panelIds: [] as string[],
+};
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: Object.assign(
+    (selector: (s: typeof panelState) => unknown) => selector(panelState),
+    { getState: () => panelState }
+  ),
+}));
+
+const retryMock = vi.hoisted(() => vi.fn());
+vi.mock("@/utils/stateHydration/scrollbackRestoreScheduler", () => ({
+  retryFailedScrollbackRestoreBatch: retryMock,
+}));
+
+import { BatchScrollbackRestoreBar } from "../BatchScrollbackRestoreBar";
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      // Force reduced-motion so InlineStatusBanner skips its rAF entry animation.
+      matches: query.includes("prefers-reduced-motion"),
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  aggregate = { pendingCount: 0, inProgressCount: 0, totalCount: 0 };
+  panelState.panelsById = {};
+  panelState.panelIds = [];
+  retryMock.mockReset();
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+});
+
+function setFailed(ids: string[]) {
+  panelState.panelIds = ids;
+  panelState.panelsById = Object.fromEntries(
+    ids.map((id) => [
+      id,
+      {
+        id,
+        kind: "pty",
+        location: "main",
+        scrollbackRestoreError: { type: "error", message: "x", timestamp: 1 },
+      },
+    ])
+  );
+}
+
+describe("BatchScrollbackRestoreBar — idle", () => {
+  it("renders nothing when no panels are restoring or failed", () => {
+    const { container } = render(<BatchScrollbackRestoreBar />);
+    expect(container.innerHTML).toBe("");
+  });
+});
+
+describe("BatchScrollbackRestoreBar — Doherty-gated progress", () => {
+  it("shows no banner before 400ms then reveals 'Restoring N of M'", () => {
+    aggregate = { pendingCount: 3, inProgressCount: 0, totalCount: 3 };
+    render(<BatchScrollbackRestoreBar />);
+
+    // Before the Doherty threshold: nothing.
+    expect(screen.queryByRole("status")).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    const banner = screen.getByRole("status");
+    expect(banner.textContent).toContain("Restoring 0 of 3");
+  });
+
+  it("computes done-count as total minus pending minus in-progress", () => {
+    aggregate = { pendingCount: 1, inProgressCount: 1, totalCount: 3 };
+    render(<BatchScrollbackRestoreBar />);
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(screen.getByRole("status").textContent).toContain("Restoring 1 of 3");
+  });
+
+  it("never flashes a banner when the batch resolves under 400ms", () => {
+    aggregate = { pendingCount: 2, inProgressCount: 0, totalCount: 2 };
+    const { rerender } = render(<BatchScrollbackRestoreBar />);
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    // Restore completes before the gate elapses.
+    aggregate = { pendingCount: 0, inProgressCount: 0, totalCount: 2 };
+    rerender(<BatchScrollbackRestoreBar />);
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+});
+
+describe("BatchScrollbackRestoreBar — failure", () => {
+  it("shows the error banner immediately (no Doherty delay) with a singular count", () => {
+    setFailed(["t1"]);
+    render(<BatchScrollbackRestoreBar />);
+    const banner = screen.getByRole("alert");
+    expect(banner.textContent).toContain("Restore failed for 1 panel");
+    expect(screen.getByRole("button", { name: "Retry batch" })).toBeTruthy();
+  });
+
+  it("pluralizes the failed-panel count", () => {
+    setFailed(["t1", "t2", "t3"]);
+    render(<BatchScrollbackRestoreBar />);
+    expect(screen.getByRole("alert").textContent).toContain("Restore failed for 3 panels");
+  });
+
+  it("invokes retryFailedScrollbackRestoreBatch with the failed ids on click", () => {
+    setFailed(["t1", "t2"]);
+    render(<BatchScrollbackRestoreBar />);
+    fireEvent.click(screen.getByRole("button", { name: "Retry batch" }));
+    expect(retryMock).toHaveBeenCalledWith(["t1", "t2"]);
+  });
+
+  it("prioritizes the failure banner over the in-progress indicator", () => {
+    aggregate = { pendingCount: 2, inProgressCount: 0, totalCount: 4 };
+    setFailed(["t1"]);
+    render(<BatchScrollbackRestoreBar />);
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(screen.getByRole("alert")).toBeTruthy();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+});

--- a/src/hooks/useScrollbackRestoreAggregate.ts
+++ b/src/hooks/useScrollbackRestoreAggregate.ts
@@ -1,0 +1,33 @@
+import { useCallback, useSyncExternalStore } from "react";
+import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import type { ScrollbackRestoreAggregate } from "@/services/terminal/scrollbackRestoreAggregate";
+
+/**
+ * Reactively read the batch scrollback-restore aggregate from
+ * `TerminalInstanceService`. Three separate `useSyncExternalStore` calls, each
+ * returning a primitive `number`, keep snapshots referentially stable — a
+ * single object snapshot would allocate a new reference every render and loop
+ * indefinitely.
+ */
+export function useScrollbackRestoreAggregate(): ScrollbackRestoreAggregate {
+  const subscribe = useCallback(
+    (onStoreChange: () => void) =>
+      terminalInstanceService.subscribeScrollbackRestoreState(onStoreChange),
+    []
+  );
+
+  const pendingCount = useSyncExternalStore(
+    subscribe,
+    useCallback(() => terminalInstanceService.getScrollbackRestorePendingCount(), [])
+  );
+  const inProgressCount = useSyncExternalStore(
+    subscribe,
+    useCallback(() => terminalInstanceService.getScrollbackRestoreInProgressCount(), [])
+  );
+  const totalCount = useSyncExternalStore(
+    subscribe,
+    useCallback(() => terminalInstanceService.getScrollbackRestoreTotalCount(), [])
+  );
+
+  return { pendingCount, inProgressCount, totalCount };
+}

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -13,6 +13,7 @@ import {
   HIBERNATION_DELAY_PRESSURE_TIER1_MS,
   HIBERNATION_DELAY_PRESSURE_TIER2_MS,
 } from "./types";
+import { tallyScrollbackRestoreStates } from "./scrollbackRestoreAggregate";
 import {
   setupTerminalAddons,
   createImageAddon,
@@ -111,6 +112,7 @@ class TerminalInstanceService {
   private suppressedExitUntil = new Map<string, number>();
   private unseenTracker = new TerminalUnseenOutputTracker();
   private hibernationListeners = new Map<string, Set<() => void>>();
+  private scrollbackRestoreListeners = new Set<() => void>();
   private cwdProviders = new Map<string, () => string>();
   private readinessWaiters = new Map<string, Waiter[]>();
   private attachSettledWaiters = new Map<string, Waiter[]>();
@@ -2083,6 +2085,55 @@ class TerminalInstanceService {
     }
   }
 
+  /**
+   * Subscribe to batch scrollback-restore state changes. The scheduler
+   * (`scrollbackRestoreScheduler`) drives every `scrollbackRestoreState`
+   * transition and calls `notifyScrollbackRestoreListeners` after each, so
+   * the grid-level `BatchScrollbackRestoreBar` can reflect progress without
+   * polling. Listeners are batch-scoped (no per-id keying) — the aggregate
+   * counts span every managed terminal. Returns an unsubscribe cleanup.
+   */
+  subscribeScrollbackRestoreState(listener: () => void): () => void {
+    this.scrollbackRestoreListeners.add(listener);
+    return () => {
+      this.scrollbackRestoreListeners.delete(listener);
+    };
+  }
+
+  notifyScrollbackRestoreListeners(): void {
+    for (const listener of this.scrollbackRestoreListeners) {
+      try {
+        listener();
+      } catch (error) {
+        logWarn("Scrollback restore listener error", { error });
+      }
+    }
+  }
+
+  // Three primitive accessors rather than one object snapshot: useSyncExternalStore
+  // re-renders whenever getSnapshot returns a new reference, so each subscriber
+  // reads a stable `number`. The instance map is small, so re-tallying per
+  // accessor is cheap and avoids snapshot-caching invalidation bugs.
+  getScrollbackRestorePendingCount(): number {
+    return this.tallyScrollbackRestore().pendingCount;
+  }
+
+  getScrollbackRestoreInProgressCount(): number {
+    return this.tallyScrollbackRestore().inProgressCount;
+  }
+
+  getScrollbackRestoreTotalCount(): number {
+    return this.tallyScrollbackRestore().totalCount;
+  }
+
+  private tallyScrollbackRestore() {
+    const states: ManagedTerminal["scrollbackRestoreState"][] = [];
+    for (const managed of this.instances.values()) {
+      states.push(managed.scrollbackRestoreState);
+    }
+    return tallyScrollbackRestoreStates(states);
+  }
+
   getUnseenOutputSnapshot(id: string): UnseenOutputSnapshot {
     return this.unseenTracker.getSnapshot(id);
   }
@@ -2725,6 +2776,9 @@ class TerminalInstanceService {
     managed.scrollbackRestoreState = "none";
 
     this.instances.delete(id);
+    // Keep the batch aggregate honest when a terminal is torn down mid-restore
+    // (e.g. the user closes a pane while it is still pending/in-progress).
+    this.notifyScrollbackRestoreListeners();
 
     for (const unsub of managed.listeners) {
       try {

--- a/src/services/terminal/__tests__/scrollbackRestoreAggregate.test.ts
+++ b/src/services/terminal/__tests__/scrollbackRestoreAggregate.test.ts
@@ -40,6 +40,27 @@ describe("tallyScrollbackRestoreStates", () => {
     expect(result.totalCount - result.pendingCount - result.inProgressCount).toBe(1);
   });
 
+  it("excludes 'lazy-pending' from every count (deferred restores never pin the indicator)", () => {
+    const states: ScrollbackRestoreState[] = ["lazy-pending", "lazy-pending"];
+    expect(tallyScrollbackRestoreStates(states)).toEqual({
+      pendingCount: 0,
+      inProgressCount: 0,
+      totalCount: 0,
+    });
+  });
+
+  it("counts an eager batch alongside ignored lazy-pending terminals", () => {
+    const states: ScrollbackRestoreState[] = [
+      "pending",
+      "in-progress",
+      "done",
+      "lazy-pending",
+      "lazy-pending",
+    ];
+    const result = tallyScrollbackRestoreStates(states);
+    expect(result).toEqual({ pendingCount: 1, inProgressCount: 1, totalCount: 3 });
+  });
+
   it("is order-independent", () => {
     const a = tallyScrollbackRestoreStates(["pending", "done", "in-progress"]);
     const b = tallyScrollbackRestoreStates(["done", "in-progress", "pending"]);

--- a/src/services/terminal/__tests__/scrollbackRestoreAggregate.test.ts
+++ b/src/services/terminal/__tests__/scrollbackRestoreAggregate.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import {
+  tallyScrollbackRestoreStates,
+  type ScrollbackRestoreState,
+} from "../scrollbackRestoreAggregate";
+
+describe("tallyScrollbackRestoreStates", () => {
+  it("returns all-zero for an empty set", () => {
+    expect(tallyScrollbackRestoreStates([])).toEqual({
+      pendingCount: 0,
+      inProgressCount: 0,
+      totalCount: 0,
+    });
+  });
+
+  it("excludes 'none' terminals from every count", () => {
+    const states: ScrollbackRestoreState[] = ["none", "none"];
+    expect(tallyScrollbackRestoreStates(states)).toEqual({
+      pendingCount: 0,
+      inProgressCount: 0,
+      totalCount: 0,
+    });
+  });
+
+  it("counts 'done' toward total but not pending or in-progress", () => {
+    const states: ScrollbackRestoreState[] = ["done", "done", "done"];
+    const result = tallyScrollbackRestoreStates(states);
+    expect(result.totalCount).toBe(3);
+    expect(result.pendingCount).toBe(0);
+    expect(result.inProgressCount).toBe(0);
+  });
+
+  it("tallies a mixed batch with total = sum of non-'none' states", () => {
+    const states: ScrollbackRestoreState[] = ["none", "pending", "pending", "in-progress", "done"];
+    const result = tallyScrollbackRestoreStates(states);
+    expect(result.pendingCount).toBe(2);
+    expect(result.inProgressCount).toBe(1);
+    expect(result.totalCount).toBe(4);
+    // The "N of M" done denominator is derivable: done = total - pending - inProgress.
+    expect(result.totalCount - result.pendingCount - result.inProgressCount).toBe(1);
+  });
+
+  it("is order-independent", () => {
+    const a = tallyScrollbackRestoreStates(["pending", "done", "in-progress"]);
+    const b = tallyScrollbackRestoreStates(["done", "in-progress", "pending"]);
+    expect(a).toEqual(b);
+  });
+});

--- a/src/services/terminal/scrollbackRestoreAggregate.ts
+++ b/src/services/terminal/scrollbackRestoreAggregate.ts
@@ -1,0 +1,29 @@
+export type ScrollbackRestoreState = "none" | "pending" | "in-progress" | "done";
+
+export interface ScrollbackRestoreAggregate {
+  /** Terminals queued for restore but not yet started. */
+  pendingCount: number;
+  /** Terminals actively replaying their buffer. */
+  inProgressCount: number;
+  /**
+   * Terminals participating in the batch — every state except `"none"`,
+   * including those already `"done"`. Drives the "N of M" denominator;
+   * `"none"` terminals never entered the batch so they are excluded.
+   */
+  totalCount: number;
+}
+
+export function tallyScrollbackRestoreStates(
+  states: Iterable<ScrollbackRestoreState>
+): ScrollbackRestoreAggregate {
+  let pendingCount = 0;
+  let inProgressCount = 0;
+  let totalCount = 0;
+  for (const state of states) {
+    if (state === "none") continue;
+    totalCount++;
+    if (state === "pending") pendingCount++;
+    else if (state === "in-progress") inProgressCount++;
+  }
+  return { pendingCount, inProgressCount, totalCount };
+}

--- a/src/services/terminal/scrollbackRestoreAggregate.ts
+++ b/src/services/terminal/scrollbackRestoreAggregate.ts
@@ -1,14 +1,19 @@
-export type ScrollbackRestoreState = "none" | "pending" | "in-progress" | "done";
+export type ScrollbackRestoreState = "none" | "pending" | "lazy-pending" | "in-progress" | "done";
 
 export interface ScrollbackRestoreAggregate {
-  /** Terminals queued for restore but not yet started. */
+  /** Terminals eagerly queued for restore but not yet started. */
   pendingCount: number;
   /** Terminals actively replaying their buffer. */
   inProgressCount: number;
   /**
-   * Terminals participating in the batch — every state except `"none"`,
-   * including those already `"done"`. Drives the "N of M" denominator;
-   * `"none"` terminals never entered the batch so they are excluded.
+   * Terminals participating in the eager batch — `"pending"`, `"in-progress"`,
+   * and `"done"`. Drives the "N of M" denominator.
+   *
+   * `"none"` (never entered) and `"lazy-pending"` are excluded: a lazy restore
+   * is deferred until the user scrolls its panel into view and may never fire,
+   * so counting it would pin the ambient progress indicator open for the whole
+   * session. A lazy terminal only joins the tally once it actually starts
+   * (`"in-progress"`).
    */
   totalCount: number;
 }
@@ -20,7 +25,7 @@ export function tallyScrollbackRestoreStates(
   let inProgressCount = 0;
   let totalCount = 0;
   for (const state of states) {
-    if (state === "none") continue;
+    if (state === "none" || state === "lazy-pending") continue;
     totalCount++;
     if (state === "pending") pendingCount++;
     else if (state === "in-progress") inProgressCount++;

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -152,8 +152,12 @@ export interface ManagedTerminal {
   isSerializedRestoreInProgress: boolean;
   deferredOutput: Array<string | Uint8Array>;
 
-  // Deferred scrollback restore state — prevents double-restore and tracks lifecycle
-  scrollbackRestoreState: "none" | "pending" | "in-progress" | "done";
+  // Deferred scrollback restore state — prevents double-restore and tracks
+  // lifecycle. "lazy-pending" is a deferred (scroll-triggered) restore awaiting
+  // its first wheel/PageUp event; it transitions to "in-progress" only once the
+  // user scrolls the panel into view, so the batch progress aggregate excludes
+  // it (a never-scrolled panel would otherwise pin the indicator open).
+  scrollbackRestoreState: "none" | "pending" | "lazy-pending" | "in-progress" | "done";
   scrollbackRestoreDisposable?: { dispose: () => void };
   // Out-of-band failure channel set by TerminalRestoreController catch blocks
   // when the deferred restore replay fails (write timeout, parse error). The

--- a/src/utils/__tests__/stateHydration.test.ts
+++ b/src/utils/__tests__/stateHydration.test.ts
@@ -118,6 +118,8 @@ vi.mock("@/services/TerminalInstanceService", () => ({
     get: getManagedTerminalMock,
     setGPUHardwareAvailable: setGPUHardwareAvailableMock,
     setTargetSize: setTargetSizeMock,
+    notifyScrollbackRestoreListeners: vi.fn(),
+    notifyRestoreSettledWaiters: vi.fn(),
   },
 }));
 
@@ -136,7 +138,12 @@ function makeMockManagedTerminal(id: string) {
   const hostElement = document.createElement("div");
   return {
     id,
-    scrollbackRestoreState: "none" as "none" | "pending" | "in-progress" | "done",
+    scrollbackRestoreState: "none" as
+      | "none"
+      | "pending"
+      | "lazy-pending"
+      | "in-progress"
+      | "done",
     scrollbackRestoreDisposable: undefined as { dispose: () => void } | undefined,
     hostElement,
     listeners: [] as Array<() => void>,
@@ -989,7 +996,7 @@ describe("hydrateAppState", () => {
 
     // Background terminal restores lazily — simulate scroll event on its host element
     const bgManaged = managedTerminals.get("terminal-background")!;
-    expect(bgManaged.scrollbackRestoreState).toBe("pending");
+    expect(bgManaged.scrollbackRestoreState).toBe("lazy-pending");
 
     bgManaged.hostElement.dispatchEvent(new Event("wheel"));
     await flushPostTasks();

--- a/src/utils/__tests__/stateHydration.test.ts
+++ b/src/utils/__tests__/stateHydration.test.ts
@@ -138,12 +138,7 @@ function makeMockManagedTerminal(id: string) {
   const hostElement = document.createElement("div");
   return {
     id,
-    scrollbackRestoreState: "none" as
-      | "none"
-      | "pending"
-      | "lazy-pending"
-      | "in-progress"
-      | "done",
+    scrollbackRestoreState: "none" as "none" | "pending" | "lazy-pending" | "in-progress" | "done",
     scrollbackRestoreDisposable: undefined as { dispose: () => void } | undefined,
     hostElement,
     listeners: [] as Array<() => void>,

--- a/src/utils/stateHydration/__tests__/scrollbackRestoreScheduler.test.ts
+++ b/src/utils/stateHydration/__tests__/scrollbackRestoreScheduler.test.ts
@@ -9,21 +9,25 @@ vi.mock("@/utils/logger", () => ({
 const fetchAndRestoreMock = vi.fn();
 const getMock = vi.fn();
 const notifyRestoreSettledWaitersMock = vi.fn();
+const notifyScrollbackRestoreListenersMock = vi.fn();
 
 vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     get: (id: string) => getMock(id),
     fetchAndRestore: (id: string) => fetchAndRestoreMock(id),
     notifyRestoreSettledWaiters: (id: string) => notifyRestoreSettledWaitersMock(id),
+    notifyScrollbackRestoreListeners: () => notifyScrollbackRestoreListenersMock(),
   },
 }));
 
 const setScrollbackRestoreErrorMock = vi.fn();
+const clearScrollbackRestoreErrorMock = vi.fn();
 
 vi.mock("@/store", () => ({
   usePanelStore: {
     getState: () => ({
       setScrollbackRestoreError: setScrollbackRestoreErrorMock,
+      clearScrollbackRestoreError: clearScrollbackRestoreErrorMock,
     }),
   },
 }));
@@ -42,7 +46,11 @@ vi.mock("../batchScheduler", async () => {
   };
 });
 
-const { scheduleScrollbackRestore } = await import("../scrollbackRestoreScheduler");
+const {
+  scheduleScrollbackRestore,
+  retryFailedScrollbackRestoreBatch,
+  resetScrollbackRestoreBatch,
+} = await import("../scrollbackRestoreScheduler");
 
 function getScheduledDoRestore(callIndex = 0): () => Promise<void> {
   const cb = scheduleBackgroundFetchAndRestoreMock.mock.calls[callIndex]?.[0];
@@ -71,6 +79,9 @@ beforeEach(() => {
   registerLazyScrollRestoreMock.mockReset();
   setScrollbackRestoreErrorMock.mockReset();
   notifyRestoreSettledWaitersMock.mockReset();
+  clearScrollbackRestoreErrorMock.mockReset();
+  notifyScrollbackRestoreListenersMock.mockReset();
+  resetScrollbackRestoreBatch();
 });
 
 afterEach(() => {
@@ -417,5 +428,134 @@ describe("scheduleScrollbackRestore — lazy mode", () => {
     const cleanup = managed.listeners[0]!;
     cleanup();
     expect(dispose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("scheduleScrollbackRestore — listener notifications", () => {
+  it("notifies once after the initial batch of 'pending' transitions", () => {
+    getMock.mockImplementation(() => fakeManaged("none"));
+    scheduleScrollbackRestore(
+      [
+        { terminalId: "t1", label: "a", location: "grid" },
+        { terminalId: "t2", label: "b", location: "grid" },
+      ],
+      () => true,
+      "background"
+    );
+    // A single batch notify for the two pending transitions, not one per task.
+    expect(notifyScrollbackRestoreListenersMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not notify when no task passes the schedule gate", () => {
+    getMock.mockReturnValue(fakeManaged("done"));
+    scheduleScrollbackRestore(
+      [{ terminalId: "t1", label: "a", location: "grid" }],
+      () => true,
+      "background"
+    );
+    expect(notifyScrollbackRestoreListenersMock).not.toHaveBeenCalled();
+  });
+
+  it("notifies on the in-progress and done transitions during a successful restore", async () => {
+    const managed = fakeManaged("none");
+    getMock.mockReturnValue(managed);
+    fetchAndRestoreMock.mockResolvedValue(undefined);
+
+    scheduleScrollbackRestore(
+      [{ terminalId: "t1", label: "a", location: "grid" }],
+      () => true,
+      "background"
+    );
+    notifyScrollbackRestoreListenersMock.mockClear(); // drop the pending-batch notify
+
+    await getScheduledDoRestore()();
+
+    // One notify for in-progress, one for done.
+    expect(notifyScrollbackRestoreListenersMock).toHaveBeenCalledTimes(2);
+    expect(managed.scrollbackRestoreState).toBe("done");
+  });
+
+  it("notifies on the failure transition when a restore error surfaces", async () => {
+    const managed = fakeManaged("none");
+    getMock.mockReturnValue(managed);
+    fetchAndRestoreMock.mockImplementation(async () => {
+      managed.lastScrollbackRestoreError = { type: "timeout", message: "slow", timestamp: 1 };
+      return false;
+    });
+
+    scheduleScrollbackRestore(
+      [{ terminalId: "t1", label: "a", location: "grid" }],
+      () => true,
+      "background"
+    );
+    notifyScrollbackRestoreListenersMock.mockClear();
+
+    await getScheduledDoRestore()();
+
+    // in-progress + failure-reset transitions both notify.
+    expect(notifyScrollbackRestoreListenersMock).toHaveBeenCalledTimes(2);
+    expect(managed.scrollbackRestoreState).toBe("none");
+  });
+});
+
+describe("retryFailedScrollbackRestoreBatch", () => {
+  it("clears stored errors and re-queues only the captured failed tasks", async () => {
+    const managed = fakeManaged("none");
+    getMock.mockReturnValue(managed);
+    fetchAndRestoreMock.mockImplementation(async () => {
+      managed.lastScrollbackRestoreError = { type: "error", message: "boom", timestamp: 1 };
+      return false;
+    });
+
+    // Original schedule captures the task, then fails (state resets to "none").
+    scheduleScrollbackRestore(
+      [{ terminalId: "t1", label: "first", location: "grid", worktreeId: "wt-1" }],
+      () => true,
+      "background"
+    );
+    await getScheduledDoRestore(0)();
+    expect(managed.scrollbackRestoreState).toBe("none");
+
+    // Retry: clears error, re-submits the captured task definition. A real
+    // fetchAndRestore resets lastScrollbackRestoreError at the start of a fresh
+    // attempt (TerminalRestoreController), so model that here.
+    fetchAndRestoreMock.mockReset();
+    fetchAndRestoreMock.mockImplementation(async () => {
+      managed.lastScrollbackRestoreError = undefined;
+    });
+    retryFailedScrollbackRestoreBatch(["t1"]);
+
+    expect(clearScrollbackRestoreErrorMock).toHaveBeenCalledWith("t1");
+    expect(scheduleBackgroundFetchAndRestoreMock).toHaveBeenCalledTimes(2);
+
+    await getScheduledDoRestore(1)();
+    expect(fetchAndRestoreMock).toHaveBeenCalledWith("t1");
+    expect(managed.scrollbackRestoreState).toBe("done");
+  });
+
+  it("clears the error but schedules nothing when no captured task matches", () => {
+    retryFailedScrollbackRestoreBatch(["unknown"]);
+    expect(clearScrollbackRestoreErrorMock).toHaveBeenCalledWith("unknown");
+    expect(scheduleBackgroundFetchAndRestoreMock).not.toHaveBeenCalled();
+  });
+
+  it("does not re-queue a still-restoring terminal (scheduler gate holds)", async () => {
+    const managed = fakeManaged("none");
+    getMock.mockReturnValue(managed);
+    fetchAndRestoreMock.mockResolvedValue(undefined);
+
+    scheduleScrollbackRestore(
+      [{ terminalId: "t1", label: "a", location: "grid" }],
+      () => true,
+      "background"
+    );
+    // Task captured but terminal is now "done" — a spurious retry must no-op.
+    await getScheduledDoRestore(0)();
+    expect(managed.scrollbackRestoreState).toBe("done");
+
+    scheduleBackgroundFetchAndRestoreMock.mockClear();
+    retryFailedScrollbackRestoreBatch(["t1"]);
+    expect(clearScrollbackRestoreErrorMock).toHaveBeenCalledWith("t1");
+    expect(scheduleBackgroundFetchAndRestoreMock).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/stateHydration/__tests__/scrollbackRestoreScheduler.test.ts
+++ b/src/utils/stateHydration/__tests__/scrollbackRestoreScheduler.test.ts
@@ -410,6 +410,66 @@ describe("scheduleScrollbackRestore — lazy mode", () => {
     expect(registerLazyScrollRestoreMock).not.toHaveBeenCalled();
   });
 
+  it("marks a lazy-registered terminal as 'lazy-pending' (excluded from the progress aggregate)", () => {
+    registerLazyScrollRestoreMock.mockReturnValue({ dispose: vi.fn() });
+    const managed = fakeManaged("none");
+    managed.hostElement = document.createElement("div");
+    getMock.mockReturnValue(managed);
+
+    scheduleScrollbackRestore(
+      [{ terminalId: "t1", label: "x", location: "grid" }],
+      () => true,
+      "lazy"
+    );
+
+    expect(managed.scrollbackRestoreState).toBe("lazy-pending");
+  });
+
+  it("a lazy doRestore transitions lazy-pending → in-progress → done when its trigger fires", async () => {
+    let lazyDoRestore: () => Promise<void> = async () => {};
+    registerLazyScrollRestoreMock.mockImplementation((_managed, fn: () => Promise<void>) => {
+      lazyDoRestore = fn;
+      return { dispose: vi.fn() };
+    });
+    const managed = fakeManaged("none");
+    managed.hostElement = document.createElement("div");
+    getMock.mockReturnValue(managed);
+    fetchAndRestoreMock.mockResolvedValue(undefined);
+
+    scheduleScrollbackRestore(
+      [{ terminalId: "t1", label: "x", location: "grid" }],
+      () => true,
+      "lazy"
+    );
+    expect(managed.scrollbackRestoreState).toBe("lazy-pending");
+
+    await lazyDoRestore();
+    expect(fetchAndRestoreMock).toHaveBeenCalledWith("t1");
+    expect(managed.scrollbackRestoreState).toBe("done");
+  });
+
+  it("a lazy-pending terminal that bails (stale) resets to 'none'", async () => {
+    let lazyDoRestore: () => Promise<void> = async () => {};
+    registerLazyScrollRestoreMock.mockImplementation((_managed, fn: () => Promise<void>) => {
+      lazyDoRestore = fn;
+      return { dispose: vi.fn() };
+    });
+    const managed = fakeManaged("none");
+    managed.hostElement = document.createElement("div");
+    getMock.mockReturnValue(managed);
+
+    scheduleScrollbackRestore(
+      [{ terminalId: "t1", label: "x", location: "grid" }],
+      () => false, // stale: project switched before the user scrolled
+      "lazy"
+    );
+    expect(managed.scrollbackRestoreState).toBe("lazy-pending");
+
+    await lazyDoRestore();
+    expect(fetchAndRestoreMock).not.toHaveBeenCalled();
+    expect(managed.scrollbackRestoreState).toBe("none");
+  });
+
   it("registered listener cleanup invokes the disposable.dispose()", () => {
     const dispose = vi.fn();
     registerLazyScrollRestoreMock.mockReturnValue({ dispose });
@@ -533,9 +593,11 @@ describe("retryFailedScrollbackRestoreBatch", () => {
     expect(managed.scrollbackRestoreState).toBe("done");
   });
 
-  it("clears the error but schedules nothing when no captured task matches", () => {
+  it("does not clear the error or schedule when no captured task matches", () => {
+    // The failure banner is the only recovery affordance — never dismiss it
+    // without queuing an actual retry.
     retryFailedScrollbackRestoreBatch(["unknown"]);
-    expect(clearScrollbackRestoreErrorMock).toHaveBeenCalledWith("unknown");
+    expect(clearScrollbackRestoreErrorMock).not.toHaveBeenCalled();
     expect(scheduleBackgroundFetchAndRestoreMock).not.toHaveBeenCalled();
   });
 

--- a/src/utils/stateHydration/batchScheduler.ts
+++ b/src/utils/stateHydration/batchScheduler.ts
@@ -91,7 +91,15 @@ export function registerLazyScrollRestore(
     if (disposed) return;
     disposed = true;
     cleanup();
-    if (managed.scrollbackRestoreState !== "pending") return;
+    // Lazy restores are registered in the "lazy-pending" state; "pending" is
+    // tolerated too in case a background re-schedule promoted the terminal
+    // between registration and the trigger firing.
+    if (
+      managed.scrollbackRestoreState !== "lazy-pending" &&
+      managed.scrollbackRestoreState !== "pending"
+    ) {
+      return;
+    }
     void restoreFn().catch((error) => {
       logWarn("Lazy scroll restore failed", { error });
     });

--- a/src/utils/stateHydration/scrollbackRestoreScheduler.ts
+++ b/src/utils/stateHydration/scrollbackRestoreScheduler.ts
@@ -39,20 +39,27 @@ export function scheduleScrollbackRestore(
     const managed = terminalInstanceService.get(task.terminalId);
     if (!managed || managed.scrollbackRestoreState !== "none") continue;
 
+    // Lazy restores wait for a scroll event and may never fire; they get a
+    // distinct "lazy-pending" state so the batch progress aggregate ignores
+    // them (a never-scrolled panel must not pin the indicator open).
+    const willLazyRegister = mode === "lazy" && !!managed.hostElement;
     lastBatchTaskMap.set(task.terminalId, task);
-    managed.scrollbackRestoreState = "pending";
+    managed.scrollbackRestoreState = willLazyRegister ? "lazy-pending" : "pending";
     scheduledAny = true;
 
     const doRestore = async () => {
-      // On bail paths where state is still "pending" (we never started),
-      // reset to "none" so a subsequent scheduleScrollbackRestore call —
-      // e.g. after the user navigates back into a project view — picks the
-      // terminal up again. Without this reset, a project switch mid-flight
-      // permanently strands the terminal in "pending" and scrollback is
-      // never restored. The "state !== 'pending'" bail below is left alone:
-      // there, external code (destroy/done) already set a deliberate state.
-      const resetIfStillPending = () => {
-        if (managed.scrollbackRestoreState === "pending") {
+      // On bail paths where state is still queued (we never started), reset to
+      // "none" so a subsequent scheduleScrollbackRestore call — e.g. after the
+      // user navigates back into a project view — picks the terminal up again.
+      // Without this reset, a project switch mid-flight permanently strands the
+      // terminal as queued and scrollback is never restored. The post-start
+      // bail below is left alone: there, external code (destroy/done) already
+      // set a deliberate state.
+      const resetIfStillQueued = () => {
+        if (
+          managed.scrollbackRestoreState === "pending" ||
+          managed.scrollbackRestoreState === "lazy-pending"
+        ) {
           managed.scrollbackRestoreState = "none";
           // Bailed before starting (project switch mid-flight). The restore
           // outcome is no longer relevant to this terminal in the new context,
@@ -63,15 +70,20 @@ export function scheduleScrollbackRestore(
       };
 
       if (!isCurrent()) {
-        resetIfStillPending();
+        resetIfStillQueued();
         return;
       }
       const current = terminalInstanceService.get(task.terminalId);
       if (!current || current !== managed) {
-        resetIfStillPending();
+        resetIfStillQueued();
         return;
       }
-      if (managed.scrollbackRestoreState !== "pending") return;
+      if (
+        managed.scrollbackRestoreState !== "pending" &&
+        managed.scrollbackRestoreState !== "lazy-pending"
+      ) {
+        return;
+      }
 
       managed.scrollbackRestoreState = "in-progress";
       notifyRestoreListeners();
@@ -113,7 +125,7 @@ export function scheduleScrollbackRestore(
       }
     };
 
-    if (mode === "lazy" && managed.hostElement) {
+    if (willLazyRegister) {
       const disposable = registerLazyScrollRestore(managed, doRestore);
       managed.scrollbackRestoreDisposable = disposable;
       managed.listeners.push(() => disposable.dispose());
@@ -122,27 +134,29 @@ export function scheduleScrollbackRestore(
     }
   }
 
-  // One notify for the whole batch of "pending" transitions above — the
+  // One notify for the whole batch of initial transitions above — the
   // per-terminal `doRestore` transitions notify individually as they fire.
   if (scheduledAny) notifyRestoreListeners();
 }
 
 /**
- * Re-queue scrollback restore for the panels that previously failed. Clears
- * each panel's stored error first (so the failure banner clears and the
- * scheduler's `"none"` gate allows re-entry — failure paths already reset
- * managed state to `"none"`), then re-submits only the failed tasks using
- * their captured definitions. `isCurrent` is `() => true`: by retry time the
- * original hydration closure is gone, and the scheduler/instance guards make a
- * post-teardown retry a safe no-op (the terminals would no longer exist).
+ * Re-queue scrollback restore for the panels that previously failed. Only
+ * clears a panel's stored error when a captured task exists to re-submit — so
+ * the failure banner (the sole recovery affordance) is never dismissed without
+ * an actual retry being queued. Clearing the error also reopens the scheduler's
+ * `"none"` gate (failure paths already reset managed state to `"none"`).
+ * `isCurrent` is `() => true`: by retry time the original hydration closure is
+ * gone, and the scheduler/instance guards make a post-teardown retry a safe
+ * no-op (the terminals would no longer exist).
  */
 export function retryFailedScrollbackRestoreBatch(failedTerminalIds: string[]): void {
   const panelStore = usePanelStore.getState();
   const retryTasks: TerminalRestoreTask[] = [];
   for (const id of failedTerminalIds) {
-    panelStore.clearScrollbackRestoreError(id);
     const task = lastBatchTaskMap.get(id);
-    if (task) retryTasks.push(task);
+    if (!task) continue;
+    panelStore.clearScrollbackRestoreError(id);
+    retryTasks.push(task);
   }
   if (retryTasks.length === 0) return;
   scheduleScrollbackRestore(retryTasks, () => true, "background");

--- a/src/utils/stateHydration/scrollbackRestoreScheduler.ts
+++ b/src/utils/stateHydration/scrollbackRestoreScheduler.ts
@@ -16,16 +16,32 @@ function classifySchedulerError(error: unknown): TerminalScrollbackRestoreError 
   return { type: "error", message: String(error), timestamp };
 }
 
+// Tasks captured at schedule time, keyed by terminalId, so "Retry batch" can
+// re-queue a failed restore using its original location/worktree without
+// re-reading the (possibly stale) panel store at click time (lesson #9514).
+// Merged across the critical + deferred calls of a single hydration run; the
+// `isCurrent` guard ensures only one logical batch is ever live, so a flat map
+// is safe. Entries for already-restored terminals are harmless — the scheduler
+// gate (`scrollbackRestoreState !== "none"`) skips them on re-submit.
+const lastBatchTaskMap = new Map<string, TerminalRestoreTask>();
+
+function notifyRestoreListeners(): void {
+  terminalInstanceService.notifyScrollbackRestoreListeners();
+}
+
 export function scheduleScrollbackRestore(
   tasks: TerminalRestoreTask[],
   isCurrent: () => boolean,
   mode: "background" | "lazy"
 ): void {
+  let scheduledAny = false;
   for (const task of tasks) {
     const managed = terminalInstanceService.get(task.terminalId);
     if (!managed || managed.scrollbackRestoreState !== "none") continue;
 
+    lastBatchTaskMap.set(task.terminalId, task);
     managed.scrollbackRestoreState = "pending";
+    scheduledAny = true;
 
     const doRestore = async () => {
       // On bail paths where state is still "pending" (we never started),
@@ -42,6 +58,7 @@ export function scheduleScrollbackRestore(
           // outcome is no longer relevant to this terminal in the new context,
           // so unblock any fully-settle waiters that gated on it.
           terminalInstanceService.notifyRestoreSettledWaiters(task.terminalId);
+          notifyRestoreListeners();
         }
       };
 
@@ -57,6 +74,7 @@ export function scheduleScrollbackRestore(
       if (managed.scrollbackRestoreState !== "pending") return;
 
       managed.scrollbackRestoreState = "in-progress";
+      notifyRestoreListeners();
       try {
         await terminalInstanceService.fetchAndRestore(task.terminalId);
 
@@ -77,6 +95,7 @@ export function scheduleScrollbackRestore(
           managed.scrollbackRestoreState = "done";
         }
         terminalInstanceService.notifyRestoreSettledWaiters(task.terminalId);
+        notifyRestoreListeners();
       } catch (error) {
         // IPC-level failure from terminalClient.getSerializedState (the
         // controller's own catch returns false rather than rethrowing for
@@ -90,6 +109,7 @@ export function scheduleScrollbackRestore(
         }
         logWarn(`Scrollback restore failed for ${task.label}`, { error });
         terminalInstanceService.notifyRestoreSettledWaiters(task.terminalId);
+        notifyRestoreListeners();
       }
     };
 
@@ -101,4 +121,34 @@ export function scheduleScrollbackRestore(
       scheduleBackgroundFetchAndRestore(doRestore);
     }
   }
+
+  // One notify for the whole batch of "pending" transitions above — the
+  // per-terminal `doRestore` transitions notify individually as they fire.
+  if (scheduledAny) notifyRestoreListeners();
+}
+
+/**
+ * Re-queue scrollback restore for the panels that previously failed. Clears
+ * each panel's stored error first (so the failure banner clears and the
+ * scheduler's `"none"` gate allows re-entry — failure paths already reset
+ * managed state to `"none"`), then re-submits only the failed tasks using
+ * their captured definitions. `isCurrent` is `() => true`: by retry time the
+ * original hydration closure is gone, and the scheduler/instance guards make a
+ * post-teardown retry a safe no-op (the terminals would no longer exist).
+ */
+export function retryFailedScrollbackRestoreBatch(failedTerminalIds: string[]): void {
+  const panelStore = usePanelStore.getState();
+  const retryTasks: TerminalRestoreTask[] = [];
+  for (const id of failedTerminalIds) {
+    panelStore.clearScrollbackRestoreError(id);
+    const task = lastBatchTaskMap.get(id);
+    if (task) retryTasks.push(task);
+  }
+  if (retryTasks.length === 0) return;
+  scheduleScrollbackRestore(retryTasks, () => true, "background");
+}
+
+/** Clear the captured retry tasks. Exported for test isolation and teardown. */
+export function resetScrollbackRestoreBatch(): void {
+  lastBatchTaskMap.clear();
 }


### PR DESCRIPTION
## Summary

- Adds a grid-level `BatchScrollbackRestoreBar` that shows "Restoring N of M" (Tier 1, 400ms Doherty-gated) while a batch is active, and promotes to a Tier 3 inline error banner with a "Retry batch" action when any panel fails.
- Deferred lazy restores use a distinct `lazy-pending` state excluded from the aggregate, so off-screen panels never pin the indicator open.
- Retry only clears a panel's error when a captured task exists to re-queue — the failure banner is never dismissed without an actual retry.

Resolves #9806

## Changes

- New `scrollbackRestoreAggregate.ts` helper (`tallyScrollbackRestoreStates`) computing pending/in-progress/total counts from per-terminal states.
- `TerminalInstanceService` gains subscribe/notify pub-sub for restore state plus three primitive count accessors (separate `useSyncExternalStore` reads keep snapshots referentially stable).
- Scrollback restore scheduler notifies listeners at every state transition, captures per-batch tasks for retry (keyed by `terminalId`, schedule-time capture per lesson #9514), and exposes `retryFailedScrollbackRestoreBatch`.
- New `useScrollbackRestoreAggregate` hook and `BatchScrollbackRestoreBar` component — info+spinner for Tier 1, error+retry for Tier 3, matching existing `TerminalRestartStatusBanner` conventions; no accent color.
- Mounted in `ContentGridDefault` and `ContentGridTwoPaneSplit` (not maximized modes, not the global banner coordinator).

## Testing

57 targeted tests pass: aggregate unit tests, scheduler tests (notify-at-transition, retry, `lazy-pending` lifecycle), and component tests (Doherty gate, error/progress/idle states, retry wiring). `npm run check` fully green (typecheck, lint ratchet, format, build, IPC/confirm-wiring guards).