### PR TITLE
fix(pulse): restore streak-flame color fidelity

### DIFF
--- a/src/components/Pulse/PulseSummary.tsx
+++ b/src/components/Pulse/PulseSummary.tsx
@@ -23,9 +23,12 @@ interface StatProps {
   label: string;
   highlight?: boolean;
   className?: string;
+  // StreakFlame carries its own tier color; defaulting to true keeps neutral
+  // icons dim while the flame renders at full strength.
+  dim?: boolean;
 }
 
-function Stat({ icon, value, label, highlight, className }: StatProps) {
+function Stat({ icon, value, label, highlight, className, dim = true }: StatProps) {
   return (
     <div
       className={cn(
@@ -34,7 +37,7 @@ function Stat({ icon, value, label, highlight, className }: StatProps) {
         className
       )}
     >
-      <span className="shrink-0 opacity-70">{icon}</span>
+      <span className={cn("shrink-0", dim && "opacity-70")}>{icon}</span>
       <span className="font-mono font-medium">{value}</span>
       <span className="hidden sm:inline text-daintree-text/55">{label}</span>
     </div>
@@ -66,6 +69,7 @@ export function PulseSummary({ pulse, compact = false }: PulseSummaryProps) {
             value={pulse.currentStreakDays!}
             label="streak"
             highlight
+            dim={false}
           />
         )}
         {hasUncommitted && (
@@ -99,6 +103,7 @@ export function PulseSummary({ pulse, compact = false }: PulseSummaryProps) {
             value={pulse.currentStreakDays!}
             label="day streak"
             highlight
+            dim={false}
           />
         )}
         {hasUncommitted && (

--- a/src/components/Pulse/StreakFlame.tsx
+++ b/src/components/Pulse/StreakFlame.tsx
@@ -2,7 +2,7 @@ import { type SVGProps } from "react";
 import { Flame } from "lucide-react";
 
 const STREAK_TIERS = [
-  { min: 240, color: "var(--color-accent-primary)" },
+  { min: 240, color: "#9333EA" },
   { min: 120, color: "#C026D3" },
   { min: 60, color: "#DC2626" },
   { min: 30, color: "#EF4444" },

--- a/src/components/Pulse/__tests__/pulseContrast.test.ts
+++ b/src/components/Pulse/__tests__/pulseContrast.test.ts
@@ -126,7 +126,12 @@ describe("PulseSummary — streak flame color fidelity (issue #9820)", () => {
     expect(flameMatches.length).toBe(2);
     for (const snippet of flameMatches) {
       expect(snippet).toContain("dim={false}");
+      // And the dim class must not survive inside the flame Stat's window.
+      expect(snippet).not.toContain("opacity-70");
     }
+    // Symmetric guard: the cn(...) definition still applies opacity-70 to
+    // the other neutral icons (GitCommit, Calendar, FilePenLine).
+    expect(content).toContain("opacity-70");
   });
 });
 

--- a/src/components/Pulse/__tests__/pulseContrast.test.ts
+++ b/src/components/Pulse/__tests__/pulseContrast.test.ts
@@ -117,6 +117,19 @@ describe("PulseSummary — visual contrast (issue #2645)", () => {
   });
 });
 
+describe("PulseSummary — streak flame color fidelity (issue #9820)", () => {
+  it("StreakFlame rows opt out of the opacity-70 dim so tier color renders at full strength", async () => {
+    const content = await readFile(SUMMARY_PATH, "utf-8");
+    // The `dim={false}` opt-out lives on the wrapping <Stat>, not the
+    // <StreakFlame .../> child — match a windowed slice of each call site.
+    const flameMatches = content.match(/<StreakFlame[\s\S]{0,400}?\n\s{10}\/>/g) ?? [];
+    expect(flameMatches.length).toBe(2);
+    for (const snippet of flameMatches) {
+      expect(snippet).toContain("dim={false}");
+    }
+  });
+});
+
 describe("PulseHeatmap — contrast on elevated card (issue #2645)", () => {
   it("heatmap uses square indicators and pulse component vars", async () => {
     const content = await readFile(HEATMAP_PATH, "utf-8");

--- a/src/components/Pulse/__tests__/streakFlame.test.ts
+++ b/src/components/Pulse/__tests__/streakFlame.test.ts
@@ -46,10 +46,20 @@ describe("getStreakColor — tier boundaries", () => {
     expect(mod.getStreakColor(239)).toBe("#C026D3");
   });
 
-  it("returns accent CSS var for days 240+", async () => {
+  it("returns a distinct celebratory hex for days 240+ (issue #9820)", async () => {
     const mod = await import("../StreakFlame");
-    expect(mod.getStreakColor(240)).toBe("var(--color-accent-primary)");
-    expect(mod.getStreakColor(10000)).toBe("var(--color-accent-primary)");
+    // The 240+ tier must read at full color fidelity in PulseSummary.Stat —
+    // not borrow --color-accent-primary, which the release chip in the same
+    // region already spends. A plain hex keeps it consistent with the other
+    // six tiers and avoids a second accent in one focus region.
+    const top240 = mod.getStreakColor(240);
+    const top10k = mod.getStreakColor(10000);
+    expect(top240).toMatch(/^#[0-9A-Fa-f]{6}$/);
+    expect(top10k).toBe(top240);
+    expect(top240).not.toContain("var(");
+    expect(top240).not.toBe("var(--color-accent-primary)");
+    expect(top240).not.toBe(mod.getStreakColor(120));
+    expect(top240).not.toBe(mod.getStreakColor(239));
   });
 
   it("returns amber for 0 days (fallback)", async () => {


### PR DESCRIPTION
## Summary

- `PulseSummary` wraps every stat icon in a generic `opacity-70` span to keep neutral glyphs from overpowering the card. That wrapper was landing on `StreakFlame`, so its deliberate tier color rendered at 70% strength. Adds a `dim` prop to `Stat` and opts the streak flame rows out.
- The 240-day tier in `STREAK_TIERS` used `--color-accent-primary`, but the pulse card already spends the accent on the release chip. Replaces it with a distinct celebratory hex (`#9333EA`) consistent with the other six tiers.

Resolves #9820

## Changes

- `src/components/Pulse/PulseSummary.tsx` — `Stat` gains a `dim` prop (defaults to `true`); the two `<Stat>` rows that render `<StreakFlame ... />` pass `dim={false}`.
- `src/components/Pulse/StreakFlame.tsx` — top tier color moves from `var(--color-accent-primary)` to `#9333EA`.
- `src/components/Pulse/__tests__/pulseContrast.test.ts` — locks the symmetric opacity-70 guard: flame rows opt out via `dim={false}`, and the `cn(...)` definition still applies `opacity-70` to the other neutral icons.
- `src/components/Pulse/__tests__/streakFlame.test.ts` — the 240+ tier now asserts a distinct celebratory hex (not the accent, not the 120/239 colors) and is consistent across the whole 240+ range.

## Testing

- `npm run format` (no changes)
- `npm run lint:fix` (no new errors)
- `npm run typecheck` (clean)
- Unit tests for `streakFlame.test.ts` and `pulseContrast.test.ts` updated to lock both behaviors; the `dim={false}` opt-out is asserted at both call sites so a future regression on either row is caught.