### PR TITLE
fix(empty-state): give canvas scale real visual weight on full panel-grid

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -1431,7 +1431,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
               variant="zero-data"
               scale="sidebar"
               icon={<FolderOpen />}
-              title="Open a Git repository to get started"
+              title="Open a Git repository"
               action={
                 <span className="text-xs text-daintree-text/50">
                   Use{" "}

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -326,7 +326,7 @@ describe("SidebarContent zero-worktrees taxonomy alignment — issue #6934", () 
     const branchStart = source.indexOf("if (worktrees.length === 0) {");
     const branchEnd = source.indexOf("const hasNonMainWorktrees", branchStart);
     const branch = source.slice(branchStart, branchEnd);
-    expect(branch).toContain('title="Open a Git repository to get started"');
+    expect(branch).toContain('title="Open a Git repository"');
     expect(branch).not.toContain("No worktrees yet");
   });
 

--- a/src/components/Terminal/ContentGridEmptyState.tsx
+++ b/src/components/Terminal/ContentGridEmptyState.tsx
@@ -157,7 +157,7 @@ export function ContentGridEmptyState({
             scale="canvas"
             icon={<FolderOpen />}
             title="Select a worktree"
-            description="Choose a worktree from the sidebar to open it in the canvas."
+            description="Choose a worktree from the sidebar to open it in the canvas"
           />
         )}
         {!hasActiveWorktree && isWorktreeInitialized && !hasWorktrees && (
@@ -165,8 +165,8 @@ export function ContentGridEmptyState({
             variant="zero-data"
             scale="canvas"
             icon={<FolderOpen />}
-            title="Open a Git repository to get started"
-            description="Worktrees let you work on multiple tasks in isolated environments."
+            title="Open a Git repository"
+            description="Worktrees let you work on multiple tasks in isolated environments"
             action={
               <Button
                 variant="outline"

--- a/src/components/Terminal/__tests__/contentGridEmptyState.test.ts
+++ b/src/components/Terminal/__tests__/contentGridEmptyState.test.ts
@@ -61,9 +61,9 @@ describe("ContentGrid EmptyState — quiet no-worktree variants (issue #6935)", 
   it("branches empty state on hasWorktrees: select-worktree vs open-directory with button", async () => {
     const content = await readFile(EMPTY_STATE_PATH, "utf-8");
     expect(content).toContain("Select a worktree");
-    expect(content).toContain("Choose a worktree from the sidebar to open it in the canvas.");
-    expect(content).toContain("Open a Git repository to get started");
-    expect(content).toContain("Worktrees let you work on multiple tasks in isolated environments.");
+    expect(content).toContain("Choose a worktree from the sidebar to open it in the canvas");
+    expect(content).toContain("Open a Git repository");
+    expect(content).toContain("Worktrees let you work on multiple tasks in isolated environments");
     expect(content).toContain("Open directory...");
     expect(content).toContain('"project.add"');
   });

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -194,9 +194,7 @@ export function EmptyState(props: EmptyStateProps) {
           key={`current-${generation}`}
           className={cn(
             "[grid-area:1/1] flex flex-col items-center motion-safe:animate-in motion-safe:fade-in motion-safe:duration-150",
-            props.scale === "canvas"
-              ? "gap-3 @max-[280px]/empty-state:gap-2"
-              : "gap-2"
+            props.scale === "canvas" ? "gap-3 @max-[280px]/empty-state:gap-2" : "gap-2"
           )}
         >
           {renderInner(props, descriptionId, hasDescription, rawDescription)}
@@ -212,9 +210,7 @@ export function EmptyState(props: EmptyStateProps) {
             inert
             className={cn(
               "[grid-area:1/1] flex flex-col items-center pointer-events-none motion-safe:animate-out motion-safe:fade-out motion-safe:duration-[100ms]",
-              outgoing.scale === "canvas"
-                ? "gap-3 @max-[280px]/empty-state:gap-2"
-                : "gap-2"
+              outgoing.scale === "canvas" ? "gap-3 @max-[280px]/empty-state:gap-2" : "gap-2"
             )}
             onAnimationEnd={handleExitEnd}
           >

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -70,19 +70,33 @@ function renderInner(
 ) {
   const icon = props.variant === "filtered-empty" ? null : props.icon;
   const action = props.variant === "user-cleared" ? null : props.action;
+  // Canvas scale carries extra visual weight so a single empty state can hold
+  // its own on a full panel-grid canvas (issue #9813). The `@max-[280px]`
+  // named-container collapse brings the canvas treatment back down to the
+  // popover/sidebar register in narrow bounded cards (NotificationCenter
+  // 360px panel-style surface, McpServerSettingsTab dashed card, etc.) so
+  // the heavier default doesn't overflow. Popover and sidebar scales are
+  // intentionally unchanged.
+  const isCanvas = props.scale === "canvas";
+  const iconClass = isCanvas
+    ? "text-daintree-text/30 [&_svg]:h-10 [&_svg]:w-10 @max-[280px]/empty-state:[&_svg]:h-6 @max-[280px]/empty-state:[&_svg]:w-6"
+    : "text-daintree-text/30 [&_svg]:h-6 [&_svg]:w-6 @max-[280px]/empty-state:[&_svg]:h-4 @max-[280px]/empty-state:[&_svg]:w-4";
+  const titleClass = isCanvas
+    ? "text-lg font-semibold text-daintree-text/70 @max-[280px]/empty-state:text-sm @max-[280px]/empty-state:font-medium"
+    : "text-sm font-medium text-daintree-text/70";
+  const descriptionClass = isCanvas
+    ? "text-sm text-daintree-text/50 max-w-xs @max-[280px]/empty-state:text-xs"
+    : "text-xs text-daintree-text/50 max-w-xs";
   return (
     <>
       {icon ? (
-        <div
-          className="text-daintree-text/30 [&_svg]:h-6 [&_svg]:w-6 @max-[280px]/empty-state:[&_svg]:h-4 @max-[280px]/empty-state:[&_svg]:w-4"
-          aria-hidden="true"
-        >
+        <div className={iconClass} aria-hidden="true">
           {icon}
         </div>
       ) : null}
-      <p className="text-sm font-medium text-daintree-text/70">{props.title}</p>
+      <p className={titleClass}>{props.title}</p>
       {hasDescription ? (
-        <p id={descriptionId} className="text-xs text-daintree-text/50 max-w-xs">
+        <p id={descriptionId} className={descriptionClass}>
           {rawDescription}
         </p>
       ) : null}
@@ -178,7 +192,12 @@ export function EmptyState(props: EmptyStateProps) {
       <div className="grid">
         <div
           key={`current-${generation}`}
-          className="[grid-area:1/1] flex flex-col items-center gap-2 motion-safe:animate-in motion-safe:fade-in motion-safe:duration-150"
+          className={cn(
+            "[grid-area:1/1] flex flex-col items-center motion-safe:animate-in motion-safe:fade-in motion-safe:duration-150",
+            props.scale === "canvas"
+              ? "gap-3 @max-[280px]/empty-state:gap-2"
+              : "gap-2"
+          )}
         >
           {renderInner(props, descriptionId, hasDescription, rawDescription)}
         </div>
@@ -191,7 +210,12 @@ export function EmptyState(props: EmptyStateProps) {
             // "Clear search") can't take focus during the 100–250ms exit.
             // `aria-hidden` alone leaves it focusable via keyboard.
             inert
-            className="[grid-area:1/1] flex flex-col items-center gap-2 pointer-events-none motion-safe:animate-out motion-safe:fade-out motion-safe:duration-[100ms]"
+            className={cn(
+              "[grid-area:1/1] flex flex-col items-center pointer-events-none motion-safe:animate-out motion-safe:fade-out motion-safe:duration-[100ms]",
+              outgoing.scale === "canvas"
+                ? "gap-3 @max-[280px]/empty-state:gap-2"
+                : "gap-2"
+            )}
             onAnimationEnd={handleExitEnd}
           >
             {renderInner(

--- a/src/components/ui/__tests__/EmptyState.test.tsx
+++ b/src/components/ui/__tests__/EmptyState.test.tsx
@@ -511,10 +511,13 @@ describe("EmptyState", () => {
       // 200px minimum sidebar floor without affecting the 350px default.
       // Container queries can only style *descendants* of the container, so
       // density variants live on the icon wrapper, not on the container itself.
+      // Uses scale="sidebar" so the pre-#9813 narrow-collapse tokens (h-4)
+      // are still tested; canvas scale has its own collapse to h-6, covered
+      // by the dedicated "scale sizing" suite below.
       const { container } = render(
         <EmptyState
           variant="zero-data"
-          scale="canvas"
+          scale="sidebar"
           title="No items"
           icon={<svg data-testid="icon" />}
         />
@@ -526,6 +529,138 @@ describe("EmptyState", () => {
       const iconWrap = container.querySelector('[aria-hidden="true"]');
       expect(iconWrap?.className).toContain("@max-[280px]/empty-state:[&_svg]:h-4");
       expect(iconWrap?.className).toContain("@max-[280px]/empty-state:[&_svg]:w-4");
+    });
+  });
+
+  describe("scale sizing (issue #9813)", () => {
+    // Canvas scale must carry extra visual weight so a single empty state
+    // can hold its own on a full panel-grid canvas. Popover and sidebar
+    // scales must remain byte-identical to their pre-#9813 classes — the
+    // differential is the test, not the absolute values.
+
+    function getIconWrap(container: HTMLElement) {
+      return container.querySelector<HTMLElement>('[aria-hidden="true"]');
+    }
+    function getTitle(container: HTMLElement) {
+      // The title is the first non-description paragraph in the current cell.
+      const current = container.querySelector('[class*="motion-safe\\:animate-in"]');
+      return current?.querySelector("p") as HTMLElement | null;
+    }
+    function getDescription(container: HTMLElement) {
+      const current = container.querySelector('[class*="motion-safe\\:animate-in"]');
+      const paragraphs = current?.querySelectorAll("p") ?? [];
+      // The description is the second paragraph (title is the first).
+      return (paragraphs[1] ?? null) as HTMLElement | null;
+    }
+
+    it("canvas icon wrapper uses a larger size than sidebar", () => {
+      const { container: sidebarContainer } = render(
+        <EmptyState
+          variant="zero-data"
+          scale="sidebar"
+          title="No items"
+          icon={<svg data-testid="icon" />}
+        />
+      );
+      const { container: canvasContainer } = render(
+        <EmptyState
+          variant="zero-data"
+          scale="canvas"
+          title="No items"
+          icon={<svg data-testid="icon" />}
+        />
+      );
+      const sidebarWrap = getIconWrap(sidebarContainer);
+      const canvasWrap = getIconWrap(canvasContainer);
+      expect(sidebarWrap).toBeTruthy();
+      expect(canvasWrap).toBeTruthy();
+      // Canvas icon class is heavier than sidebar; sidebar must NOT carry the
+      // canvas-only size token.
+      expect(canvasWrap!.className).toContain("[&_svg]:h-10");
+      expect(canvasWrap!.className).toContain("[&_svg]:w-10");
+      expect(sidebarWrap!.className).not.toContain("[&_svg]:h-10");
+      expect(sidebarWrap!.className).not.toContain("[&_svg]:w-10");
+    });
+
+    it("canvas title uses a larger, bolder type than sidebar", () => {
+      const { container: sidebarContainer } = render(
+        <EmptyState variant="zero-data" scale="sidebar" title="No items" />
+      );
+      const { container: canvasContainer } = render(
+        <EmptyState variant="zero-data" scale="canvas" title="No items" />
+      );
+      const sidebarTitle = getTitle(sidebarContainer);
+      const canvasTitle = getTitle(canvasContainer);
+      expect(canvasTitle?.className).toContain("text-lg");
+      expect(canvasTitle?.className).toContain("font-semibold");
+      // Sidebar stays at the pre-#9813 size/weight — assert the differential
+      // tokens are absent on the sidebar title.
+      expect(sidebarTitle?.className).not.toContain("text-lg");
+      expect(sidebarTitle?.className).not.toContain("font-semibold");
+    });
+
+    it("canvas description uses a larger default size than the narrow-collapse fallback", () => {
+      // The discriminated union forbids description on popover/sidebar
+      // (text-xs), so we assert the canvas default directly: the rendered
+      // class must carry `text-sm` (the heavier default) and the only place
+      // `text-xs` can appear is in the `@max-[280px]/empty-state:` narrow
+      // collapse prefix.
+      const { container } = render(
+        <EmptyState
+          variant="zero-data"
+          scale="canvas"
+          title="No items"
+          description="desc"
+        />
+      );
+      const canvasDesc = getDescription(container);
+      expect(canvasDesc?.className).toContain("text-sm");
+      expect(canvasDesc?.className).toContain(
+        "@max-[280px]/empty-state:text-xs"
+      );
+      // The bare `text-xs` token (without a Tailwind v4 modifier prefix)
+      // must NOT be the default — that would be a regression to the
+      // pre-#9813 sidebar/popover size.
+      const classes = canvasDesc?.className.split(/\s+/) ?? [];
+      const bareTextXs = classes.filter((c) => c === "text-xs");
+      expect(bareTextXs).toEqual([]);
+    });
+
+    it("canvas cell uses a larger gap than sidebar", () => {
+      const { container: sidebarContainer } = render(
+        <EmptyState variant="zero-data" scale="sidebar" title="No items" />
+      );
+      const { container: canvasContainer } = render(
+        <EmptyState variant="zero-data" scale="canvas" title="No items" />
+      );
+      const sidebarCell = sidebarContainer.querySelector<HTMLElement>(
+        '[class*="motion-safe\\:animate-in"]'
+      );
+      const canvasCell = canvasContainer.querySelector<HTMLElement>(
+        '[class*="motion-safe\\:animate-in"]'
+      );
+      expect(canvasCell?.className).toContain("gap-3");
+      // Sidebar cell keeps the pre-#9813 gap-2 (no gap-3 token).
+      expect(sidebarCell?.className).not.toContain("gap-3");
+    });
+
+    it("canvas container-query collapse still brings the icon back to the popover size in narrow containers", () => {
+      // The narrow-container collapse uses Tailwind v4 named-container
+      // queries: `@max-[280px]/empty-state:` brings the canvas h-10 back
+      // down to h-6 in a ≤280px container. The collapse class must always
+      // be present on the canvas icon wrap so the JIT can compile it; the
+      // runtime behavior is the browser's job.
+      const { container } = render(
+        <EmptyState
+          variant="zero-data"
+          scale="canvas"
+          title="No items"
+          icon={<svg data-testid="icon" />}
+        />
+      );
+      const iconWrap = getIconWrap(container);
+      expect(iconWrap?.className).toContain("@max-[280px]/empty-state:[&_svg]:h-6");
+      expect(iconWrap?.className).toContain("@max-[280px]/empty-state:[&_svg]:w-6");
     });
   });
 

--- a/src/components/ui/__tests__/EmptyState.test.tsx
+++ b/src/components/ui/__tests__/EmptyState.test.tsx
@@ -662,6 +662,28 @@ describe("EmptyState", () => {
       expect(iconWrap?.className).toContain("@max-[280px]/empty-state:[&_svg]:h-6");
       expect(iconWrap?.className).toContain("@max-[280px]/empty-state:[&_svg]:w-6");
     });
+
+    it("fade-through outgoing cell preserves the previous scale's gap (sidebar→canvas flip)", () => {
+      // The outgoing cell in the fade-through transition uses the previous
+      // props' scale, not the new one — otherwise the outgoing cell jumps
+      // to the heavier canvas gap before the 100ms exit completes. The
+      // outgoing scale must be threaded through (`outgoing.scale`), which
+      // is the behavior the new cn() on the outgoing cell guards.
+      const { rerender, container } = render(
+        <EmptyState variant="zero-data" scale="sidebar" title="A" />
+      );
+      rerender(<EmptyState variant="zero-data" scale="canvas" title="B" />);
+      const outgoing = container.querySelector<HTMLElement>(
+        ".motion-safe\\:animate-out"
+      );
+      const incoming = container.querySelector<HTMLElement>(
+        ".motion-safe\\:animate-in"
+      );
+      // Outgoing is the previous (sidebar) state — no canvas gap-3.
+      expect(outgoing?.className).not.toContain("gap-3");
+      // Incoming is the new (canvas) state — carries the canvas gap-3.
+      expect(incoming?.className).toContain("gap-3");
+    });
   });
 
   describe("className passthrough", () => {

--- a/src/components/ui/__tests__/EmptyState.test.tsx
+++ b/src/components/ui/__tests__/EmptyState.test.tsx
@@ -606,18 +606,11 @@ describe("EmptyState", () => {
       // `text-xs` can appear is in the `@max-[280px]/empty-state:` narrow
       // collapse prefix.
       const { container } = render(
-        <EmptyState
-          variant="zero-data"
-          scale="canvas"
-          title="No items"
-          description="desc"
-        />
+        <EmptyState variant="zero-data" scale="canvas" title="No items" description="desc" />
       );
       const canvasDesc = getDescription(container);
       expect(canvasDesc?.className).toContain("text-sm");
-      expect(canvasDesc?.className).toContain(
-        "@max-[280px]/empty-state:text-xs"
-      );
+      expect(canvasDesc?.className).toContain("@max-[280px]/empty-state:text-xs");
       // The bare `text-xs` token (without a Tailwind v4 modifier prefix)
       // must NOT be the default — that would be a regression to the
       // pre-#9813 sidebar/popover size.
@@ -673,12 +666,8 @@ describe("EmptyState", () => {
         <EmptyState variant="zero-data" scale="sidebar" title="A" />
       );
       rerender(<EmptyState variant="zero-data" scale="canvas" title="B" />);
-      const outgoing = container.querySelector<HTMLElement>(
-        ".motion-safe\\:animate-out"
-      );
-      const incoming = container.querySelector<HTMLElement>(
-        ".motion-safe\\:animate-in"
-      );
+      const outgoing = container.querySelector<HTMLElement>(".motion-safe\\:animate-out");
+      const incoming = container.querySelector<HTMLElement>(".motion-safe\\:animate-in");
       // Outgoing is the previous (sidebar) state — no canvas gap-3.
       expect(outgoing?.className).not.toContain("gap-3");
       // Incoming is the new (canvas) state — carries the canvas gap-3.


### PR DESCRIPTION
The shared `EmptyState` component was rendering the canvas scale with the same tiny icon and small title as the sidebar scale, which left the full panel-grid empty state looking underweight next to the active-worktree variant on the same surface.

`renderInner` now branches on `scale === 'canvas'`. Canvas gets a larger icon, a `text-lg font-semibold` title, a `text-sm` description, and `gap-3` between the elements. Popover and sidebar scales are intentionally left byte-identical.

The existing `@max-[280px]` container query collapse brings the heavier canvas treatment back to the popover register inside narrow bounded cards (the `NotificationCenter` 360px surface, the `McpServerSettingsTab` dashed card), so the new weight doesn't overflow where there isn't room for it.

Two microcopy tweaks while the file was open:
- Drop "to get started" from the no-repo title in both `ContentGridEmptyState` and `SidebarContent` — just "Open a Git repository"
- Remove the trailing period from the two single-sentence subtitles, per the project's microcopy rule (periods only on multi-sentence body)

## Testing
- Differential scale-sizing tests assert canvas ≠ sidebar sizing
- Fade-through scale-divergence test exercises a sidebar→canvas flip and guards the outgoing cell's `gap-2` against leaking to `gap-3` during the 100ms exit
- Existing tests that pinned the old strings are updated

Resolves #9813