### PR TITLE
fix(pty-pool): warm non-empty envHash keys on project restore

### DIFF
--- a/electron/pty-host/handlers/__tests__/connection.test.ts
+++ b/electron/pty-host/handlers/__tests__/connection.test.ts
@@ -254,3 +254,131 @@ describe("set-active-project pool warming (#9774)", () => {
     expect(ctx.windowProjectMap.get(1)).toBe("proj-a");
   });
 });
+
+describe("set-active-project non-empty envHash warming (#9810)", () => {
+  interface FakePool {
+    drainAndRefill: ReturnType<typeof vi.fn>;
+    warmForKey: ReturnType<typeof vi.fn>;
+    getMaxEntries: () => number;
+    getMaxPoolSize: () => number;
+  }
+
+  function makePoolCtx(pool: FakePool) {
+    const stateRef = {
+      visualBuffers: [] as SharedRingBuffer[],
+      visualSignalView: null as Int32Array | null,
+      analysisBuffer: null as SharedRingBuffer | null,
+    };
+    const ctx = makeCtx(stateRef);
+    ctx.ptyPool = pool as unknown as HostContext["ptyPool"];
+    return ctx;
+  }
+
+  function makeFakePool(
+    overrides: Partial<FakePool> = {},
+    drainResult: Promise<void> = Promise.resolve()
+  ): FakePool {
+    return {
+      drainAndRefill: vi.fn(() => drainResult),
+      warmForKey: vi.fn(),
+      getMaxEntries: () => 8,
+      getMaxPoolSize: () => 2,
+      ...overrides,
+    };
+  }
+
+  it("warms each restored panel cwd with the project env hash when projectEnv is non-empty", async () => {
+    const pool = makeFakePool();
+    const handlers = createConnectionHandlers(makePoolCtx(pool));
+
+    const projectEnv = { MY_API_KEY: "x", NODE_ENV: "production" };
+    handlers["set-active-project"]({
+      windowId: 1,
+      projectId: "proj-a",
+      projectPath: "/repo",
+      panelCwds: ["/repo/wt-a", "/repo/wt-b"],
+      projectEnv,
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(pool.warmForKey).toHaveBeenCalledTimes(2);
+    // The non-empty env is passed as callerEnv so the warmed slot can serve
+    // acquires that carry the same merged env.
+    expect(pool.warmForKey.mock.calls[0]?.[0]).toBe("/repo/wt-a");
+    expect(pool.warmForKey.mock.calls[0]?.[1]).toEqual(projectEnv);
+    expect(pool.warmForKey.mock.calls[1]?.[0]).toBe("/repo/wt-b");
+    expect(pool.warmForKey.mock.calls[1]?.[1]).toEqual(projectEnv);
+    // Both warms use the SAME envHash — it was computed once from projectEnv
+    // and is reused for every panel cwd (one envHash, many cwds).
+    const envHashA = pool.warmForKey.mock.calls[0]?.[2];
+    const envHashB = pool.warmForKey.mock.calls[1]?.[2];
+    expect(typeof envHashA).toBe("string");
+    expect(envHashA).not.toBe("env-empty");
+    expect(envHashA).toBe(envHashB);
+  });
+
+  it("falls back to env-empty warm (callerEnv undefined) when projectEnv is null", async () => {
+    const pool = makeFakePool();
+    const handlers = createConnectionHandlers(makePoolCtx(pool));
+
+    handlers["set-active-project"]({
+      windowId: 1,
+      projectId: "proj-a",
+      projectPath: "/repo",
+      panelCwds: ["/repo/wt-a"],
+      projectEnv: null,
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(pool.warmForKey).toHaveBeenCalledTimes(1);
+    expect(pool.warmForKey.mock.calls[0]?.[1]).toBeUndefined();
+    expect(pool.warmForKey.mock.calls[0]?.[2]).toBe("env-empty");
+  });
+
+  it("falls back to env-empty warm when projectEnv is undefined (back-compat with #9774 callers)", async () => {
+    const pool = makeFakePool();
+    const handlers = createConnectionHandlers(makePoolCtx(pool));
+
+    handlers["set-active-project"]({
+      windowId: 1,
+      projectId: "proj-a",
+      projectPath: "/repo",
+      panelCwds: ["/repo/wt-a"],
+      // projectEnv omitted — must match pre-#9810 behaviour
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(pool.warmForKey).toHaveBeenCalledTimes(1);
+    expect(pool.warmForKey.mock.calls[0]?.[1]).toBeUndefined();
+    expect(pool.warmForKey.mock.calls[0]?.[2]).toBe("env-empty");
+  });
+
+  it("falls back to env-empty warm when projectEnv is an empty object (matches acquirePtyProcess contract)", async () => {
+    const pool = makeFakePool();
+    const handlers = createConnectionHandlers(makePoolCtx(pool));
+
+    handlers["set-active-project"]({
+      windowId: 1,
+      projectId: "proj-a",
+      projectPath: "/repo",
+      panelCwds: ["/repo/wt-a"],
+      projectEnv: {},
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // `{}` is filtered to nothing by computePoolEnvHash, so the warm collapses
+    // to the env-empty path — no point burning a slot on a hash that
+    // `acquireByKey` would also produce for the no-caller-env case.
+    expect(pool.warmForKey).toHaveBeenCalledTimes(1);
+    expect(pool.warmForKey.mock.calls[0]?.[1]).toBeUndefined();
+    expect(pool.warmForKey.mock.calls[0]?.[2]).toBe("env-empty");
+  });
+});

--- a/electron/pty-host/handlers/__tests__/connection.test.ts
+++ b/electron/pty-host/handlers/__tests__/connection.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { createConnectionHandlers } from "../connection.js";
 import { SharedRingBuffer } from "../../../../shared/utils/SharedRingBuffer.js";
+import { computePoolEnvHash } from "../../../services/pty/ptyPoolEnvHash.js";
 import type { HostContext } from "../types.js";
 
 function makeCtx(stateRef: {
@@ -317,6 +318,11 @@ describe("set-active-project non-empty envHash warming (#9810)", () => {
     expect(typeof envHashA).toBe("string");
     expect(envHashA).not.toBe("env-empty");
     expect(envHashA).toBe(envHashB);
+    // Lock down the hash VALUE: the warm must produce the exact same hash
+    // `acquireByKey` will look up at spawn time, so any drift in
+    // `computePoolEnvHash` (forgetting `filterSensitiveOnly`, shadowing the
+    // import, etc.) is caught here.
+    expect(envHashA).toBe(computePoolEnvHash(projectEnv));
   });
 
   it("falls back to env-empty warm (callerEnv undefined) when projectEnv is null", async () => {
@@ -377,6 +383,41 @@ describe("set-active-project non-empty envHash warming (#9810)", () => {
     // `{}` is filtered to nothing by computePoolEnvHash, so the warm collapses
     // to the env-empty path — no point burning a slot on a hash that
     // `acquireByKey` would also produce for the no-caller-env case.
+    expect(pool.warmForKey).toHaveBeenCalledTimes(1);
+    expect(pool.warmForKey.mock.calls[0]?.[1]).toBeUndefined();
+    expect(pool.warmForKey.mock.calls[0]?.[2]).toBe("env-empty");
+  });
+
+  it("collapses to env-empty warm when every projectEnv key is filtered by computePoolEnvHash (#9810)", async () => {
+    const pool = makeFakePool();
+    const handlers = createConnectionHandlers(makePoolCtx(pool));
+
+    // SHLVL, PWD, OLDPWD, _ are VOLATILE_ENV_KEYS — excluded from the hash.
+    // DAINTREE_PANE_ID/CWD/PROJECT_ID/WORKTREE_ID are auto-injected — also
+    // excluded. So a payload consisting only of those keys hashes to
+    // env-empty, and the warm must collapse to the env-empty path (callerEnv
+    // undefined) so the slot the next acquire looks up is the right one.
+    const allFilteredEnv = {
+      SHLVL: "1",
+      PWD: "/foo",
+      OLDPWD: "/bar",
+      _: "/usr/bin/env",
+      DAINTREE_PANE_ID: "p-1",
+      DAINTREE_CWD: "/repo",
+      DAINTREE_PROJECT_ID: "proj-a",
+      DAINTREE_WORKTREE_ID: "wt-1",
+    };
+    handlers["set-active-project"]({
+      windowId: 1,
+      projectId: "proj-a",
+      projectPath: "/repo",
+      panelCwds: ["/repo/wt-a"],
+      projectEnv: allFilteredEnv,
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
     expect(pool.warmForKey).toHaveBeenCalledTimes(1);
     expect(pool.warmForKey.mock.calls[0]?.[1]).toBeUndefined();
     expect(pool.warmForKey.mock.calls[0]?.[2]).toBe("env-empty");

--- a/electron/pty-host/handlers/connection.ts
+++ b/electron/pty-host/handlers/connection.ts
@@ -1,6 +1,6 @@
 import type { MessagePort } from "node:worker_threads";
 import { SharedRingBuffer } from "../../../shared/utils/SharedRingBuffer.js";
-import { POOL_ENV_EMPTY_HASH } from "../../services/pty/ptyPoolEnvHash.js";
+import { POOL_ENV_EMPTY_HASH, computePoolEnvHash } from "../../services/pty/ptyPoolEnvHash.js";
 import { PortBatcher, type PortBatcherFailedBatch } from "../index.js";
 import type { HandlerMap, HostContext } from "./types.js";
 
@@ -192,6 +192,15 @@ export function createConnectionHandlers(ctx: HostContext): HandlerMap {
           Math.floor(pool.getMaxEntries() / pool.getMaxPoolSize()) - 1
         );
         const panelCwds = (msg.panelCwds ?? []).slice(0, maxPanelKeys);
+        // Compute the envHash here (not in Main) so the warm key is guaranteed
+        // to match the `acquireByKey` lookup at spawn time — the same
+        // `computePoolEnvHash` over the same merged env produces both (#9810).
+        // When `projectEnv` is null/empty, `computePoolEnvHash` collapses to
+        // POOL_ENV_EMPTY_HASH and the warm path is identical to the pre-#9810
+        // behaviour.
+        const projectEnvHash = computePoolEnvHash(msg.projectEnv ?? undefined);
+        const warmCallerEnv =
+          projectEnvHash === POOL_ENV_EMPTY_HASH ? undefined : (msg.projectEnv ?? undefined);
         pool
           .drainAndRefill(msg.projectPath)
           .then(() => {
@@ -202,7 +211,7 @@ export function createConnectionHandlers(ctx: HostContext): HandlerMap {
             // warmForKey is idempotent, per-key capacity-capped, and circuit-
             // broken, so stale/deleted worktree paths self-limit.
             for (const cwd of panelCwds) {
-              pool.warmForKey(cwd, undefined, POOL_ENV_EMPTY_HASH);
+              pool.warmForKey(cwd, warmCallerEnv, projectEnvHash);
             }
           })
           .catch((err) => {

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -827,13 +827,15 @@ export class PtyClient extends EventEmitter {
     windowId: number,
     projectId: string | null,
     projectPath?: string,
-    panelCwds?: string[]
+    panelCwds?: string[],
+    projectEnv?: Record<string, string> | null
   ): void {
     this.activeProjectId = projectId;
-    // panelCwds is a transient warm hint for the first send only — it is NOT
-    // stored in windowProjectContexts. A host restart replays via
+    // panelCwds / projectEnv are transient warm hints for the first send only —
+    // they are NOT stored in windowProjectContexts. A host restart replays via
     // syncProjectContext against a freshly-empty pool with no pending restore
-    // spawns, so re-warming saved panel cwds would be wasted work.
+    // spawns, so re-warming saved panel cwds (or refiring the env hash) would
+    // be wasted work.
     this.windowProjectContexts.set(windowId, { projectId, projectPath, mode: "active" });
 
     if (!this.lifecycle.child) {
@@ -847,6 +849,7 @@ export class PtyClient extends EventEmitter {
       projectId,
       ...(projectPath ? { projectPath } : {}),
       ...(panelCwds && panelCwds.length > 0 ? { panelCwds } : {}),
+      ...(projectEnv ? { projectEnv } : {}),
     });
   }
 

--- a/electron/window/__tests__/restoreProjectEnv.test.ts
+++ b/electron/window/__tests__/restoreProjectEnv.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { mergeProjectEnv } from "../restoreProjectEnv.js";
+
+describe("mergeProjectEnv (#9810)", () => {
+  it("returns null when both inputs are missing", () => {
+    expect(mergeProjectEnv(undefined, undefined)).toBeNull();
+  });
+
+  it("returns null when both inputs are empty objects", () => {
+    expect(mergeProjectEnv({}, {})).toBeNull();
+  });
+
+  it("returns null when one is missing and the other is empty", () => {
+    expect(mergeProjectEnv(undefined, {})).toBeNull();
+    expect(mergeProjectEnv({}, undefined)).toBeNull();
+  });
+
+  it("returns the global env unchanged when project env is missing/empty", () => {
+    const global = { NODE_ENV: "production", PORT: "3000" };
+    expect(mergeProjectEnv(global, undefined)).toEqual(global);
+    expect(mergeProjectEnv(global, {})).toEqual(global);
+  });
+
+  it("returns the project env when global is missing/empty", () => {
+    const project = { MY_API_KEY: "x", DEBUG: "true" };
+    expect(mergeProjectEnv(undefined, project)).toEqual(project);
+    expect(mergeProjectEnv({}, project)).toEqual(project);
+  });
+
+  it("lets project keys override global keys on collision", () => {
+    const merged = mergeProjectEnv(
+      { FOO: "global", BAR: "from-global" },
+      { FOO: "project", BAZ: "from-project" }
+    );
+    expect(merged).toEqual({ FOO: "project", BAR: "from-global", BAZ: "from-project" });
+  });
+
+  it("returns a new object (does not alias caller-owned objects)", () => {
+    const global = { A: "1" };
+    const project = { B: "2" };
+    const merged = mergeProjectEnv(global, project);
+    expect(merged).not.toBe(global);
+    expect(merged).not.toBe(project);
+  });
+});

--- a/electron/window/restoreProjectEnv.ts
+++ b/electron/window/restoreProjectEnv.ts
@@ -1,0 +1,29 @@
+/**
+ * Merge the global + project environment variables for a PTY-pool warm hint.
+ *
+ * On session restore the pty-host needs to predictively warm (panelCwd,
+ * projectEnvHash) slots in addition to the env-empty (panelCwd) slots warmed
+ * by #9774. The hash is computed in the pty-host from the merged env, so this
+ * module only produces the merged env payload — no hashing here (#9810).
+ *
+ * Pure: no I/O, no side effects. Easy to unit test in isolation. The pty-host
+ * treats `null` as "fall back to the env-empty warm path" (no per-cwd envHash
+ * key to warm).
+ */
+export function mergeProjectEnv(
+  globalEnv: Record<string, string> | undefined,
+  projectEnv: Record<string, string> | undefined
+): Record<string, string> | null {
+  const global = globalEnv ?? {};
+  const project = projectEnv ?? {};
+
+  if (Object.keys(global).length === 0 && Object.keys(project).length === 0) {
+    return null;
+  }
+
+  // Project keys intentionally override global keys on collision — the project
+  // layer is the more specific scope, mirroring how the spawn path applies
+  // `options.env` on top of the filtered process env in
+  // `buildTerminalEnv` (terminalSpawn.ts:88-93).
+  return { ...global, ...project };
+}

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -17,6 +17,8 @@ import { getCurrentDiskSpaceStatus } from "../services/DiskSpaceMonitor.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { extractRestorePanelCwds } from "./restorePanelCwds.js";
+import { mergeProjectEnv } from "./restoreProjectEnv.js";
+import { store } from "../store.js";
 import {
   isSmokeTest,
   smokeTestStart,
@@ -365,6 +367,12 @@ export async function setupWindowServices(
   // projectStore.initialize's in-memory list), so racing it against
   // initialize() is safe.
   let restorePanelCwds: string[] = [];
+  // Merged env (global + project) for the pty-host's non-empty envHash warm
+  // (#9810). Computed from the same store reads above; on any failure the warm
+  // path collapses to env-empty, matching pre-#9810 behaviour. We read
+  // settings concurrently because the project state path already calls into
+  // the settings manager.
+  let restoreProjectEnv: Record<string, string> | null = null;
 
   try {
     const results = await Promise.allSettled([
@@ -373,6 +381,9 @@ export async function setupWindowServices(
       opts.initialProjectId
         ? projectStore.getProjectState(opts.initialProjectId)
         : Promise.resolve(null),
+      opts.initialProjectId
+        ? projectStore.getProjectSettings(opts.initialProjectId)
+        : Promise.resolve(null),
     ]);
 
     ptyReady = results[0].status === "fulfilled";
@@ -380,6 +391,13 @@ export async function setupWindowServices(
     if (results[2].status === "fulfilled") {
       restorePanelCwds = extractRestorePanelCwds(results[2].value);
     }
+    const globalEnv = store.get("globalEnvironmentVariables") as Record<string, string> | undefined;
+    const projectEnv =
+      results[3].status === "fulfilled"
+        ? ((results[3].value?.environmentVariables as Record<string, string> | undefined) ??
+          undefined)
+        : undefined;
+    restoreProjectEnv = mergeProjectEnv(globalEnv, projectEnv);
 
     if (ptyReady && workspaceReady && projectStoreReady) {
       console.log("[MAIN] All critical services ready");
@@ -421,7 +439,13 @@ export async function setupWindowServices(
     createAndDistributePorts(win, ctx);
 
     if (restoreProject) {
-      pty.setActiveProject(win.id, restoreProject.id, restoreProject.path, restorePanelCwds);
+      pty.setActiveProject(
+        win.id,
+        restoreProject.id,
+        restoreProject.path,
+        restorePanelCwds,
+        restoreProjectEnv
+      );
     } else {
       pty.setActiveProject(win.id, null);
     }

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -369,9 +369,9 @@ export async function setupWindowServices(
   let restorePanelCwds: string[] = [];
   // Merged env (global + project) for the pty-host's non-empty envHash warm
   // (#9810). Computed from the same store reads above; on any failure the warm
-  // path collapses to env-empty, matching pre-#9810 behaviour. We read
-  // settings concurrently because the project state path already calls into
-  // the settings manager.
+  // path falls back to whatever global env we can read; if both reads fail
+  // the env-empty warm path runs. We read settings concurrently because the
+  // project state path already calls into the settings manager.
   let restoreProjectEnv: Record<string, string> | null = null;
 
   try {
@@ -391,7 +391,7 @@ export async function setupWindowServices(
     if (results[2].status === "fulfilled") {
       restorePanelCwds = extractRestorePanelCwds(results[2].value);
     }
-    const globalEnv = store.get("globalEnvironmentVariables") as Record<string, string> | undefined;
+    const globalEnv = store.get("globalEnvironmentVariables") as Record<string, string>;
     const projectEnv =
       results[3].status === "fulfilled"
         ? ((results[3].value?.environmentVariables as Record<string, string> | undefined) ??

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -100,6 +100,15 @@ export type PtyHostRequest =
        * drain/refill so the first restored panel hits the pool (#9774).
        */
       panelCwds?: string[];
+      /**
+       * Merged project env (global + project settings) computed at the Main
+       * process, sent so the pty-host can warm non-empty envHash slots for
+       * plain PTY panels (#9810). `null` when neither global nor project env
+       * is present — the pty-host falls back to the env-empty warm path. The
+       * pty-host is the single owner of hash computation, which guarantees
+       * the warmed key matches the `acquireByKey` lookup at spawn time.
+       */
+      projectEnv?: Record<string, string> | null;
     }
   | {
       type: "project-switch";


### PR DESCRIPTION
## Summary

- The PTY pool only warmed one env-empty key shape, so any spawn with a non-empty `envHash` missed the pool and paid a full cold-spawn.
- Extend `set-active-project` IPC with a `projectEnv` field, then warm each restored panel cwd with a matching `(cwd, projectEnv, projectEnvHash)` tuple so the first plain PTY panel in a project with non-empty env additions hits the pool.
- Follow-up commit locks down `envHash` drift in tests, corrects a misleading `windowServices` comment about the failure fallback, and drops an over-broad `undefined` cast on the env store.

Resolves #9810

## Changes

- `shared/types/pty-host.ts`: add `projectEnv?` to the set-active-project payload.
- `electron/window/restoreProjectEnv.ts` (new): pure `mergeProjectEnv` helper. Returns `null` on empty inputs and lets project override global on collision.
- `electron/window/windowServices.ts`: read global and project env concurrently with the existing `panelCwd` read, merge, pass through to `setActiveProject`.
- `electron/services/PtyClient.ts`: thread `projectEnv` through `setActiveProject` as a transient warm hint (not stored on `windowProjectContexts`).
- `electron/pty-host/handlers/connection.ts`: compute `envHash` in the pty-host so the warm key is guaranteed to match `acquireByKey`'s lookup at spawn time. Empty or `null` `projectEnv` collapses to the env-empty warm (pre-#9810 path).
- `electron/pty-host/handlers/__tests__/connection.test.ts`: assert the warmed `envHash` equals `computePoolEnvHash(projectEnv)` (not just that two warm calls agree), plus a new case where every key is filtered out and the `POOL_ENV_EMPTY_HASH` short-circuit fires.
- `electron/window/__tests__/restoreProjectEnv.test.ts` (new): unit tests for `mergeProjectEnv`.

## Testing

- 47/47 targeted vitest tests pass.
- `npm run check` is clean across all 10 gates (typecheck, IPC channels, crash-loop constants, ipc, ipc-renderer, ipc-handwritten, help, confirm-wiring, lint ratchet, prettier).
- Manual review covered: envHash drift lockdown, fallback on null/empty `projectEnv`, fallback when every key is filtered, comment correction on the failure path.
