### PR TITLE
fix(toolbar): make agent split-button seam and state dot legible

### DIFF
--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -55,6 +55,7 @@ import {
   getDominantAgentState,
   agentStateDotColor,
 } from "@/components/Worktree/AgentStatusIndicator";
+import { STATE_LABELS } from "@/components/Worktree/terminalStateConfig";
 import { getRuntimeOrBootAgentId } from "@/utils/terminalType";
 import { isPtyPanel } from "@shared/types/panel";
 
@@ -275,13 +276,24 @@ export function AgentButton({
   // because the CLI itself will prompt for sign-in on first run.
   const signInUnconfirmed = isAgentUnauthenticated(availability);
 
+  // Same gate the corner dot uses (issue #9823, #5900). When a dot renders,
+  // dominantState is one of {waiting, directing} — STATE_LABELS has a human
+  // word for every dot-bearing state, so the suffix is always meaningful.
+  // Moved above the tooltip/aria ternaries so they can consume it.
+  const dotColor = dominantState ? agentStateDotColor(dominantState) : null;
+  const visibleStateSuffix = dotColor ? ` — ${STATE_LABELS[dominantState!]}` : "";
+  // Suppress the at-rest split-button seam when the chevron is gated — the
+  // chevron blocks clicks in these states anyway (issue #8131), so a seam
+  // would advertise a control that isn't usable.
+  const showSeam = !isLoading && isLaunchable;
+
   const presetSegment = activePresetName ? ` · ${activePresetName}` : "";
   const tooltipLabel = isLoading
     ? `Checking ${config.name} CLI…`
     : isLaunchable
       ? signInUnconfirmed
-        ? `Start ${config.name}${presetSegment} — sign-in not detected`
-        : `Start ${config.name}${presetSegment}${tooltipDetails}`
+        ? `Start ${config.name}${presetSegment}${visibleStateSuffix} — sign-in not detected`
+        : `Start ${config.name}${presetSegment}${visibleStateSuffix}${tooltipDetails}`
       : needsSetup
         ? `Configure ${config.name}`
         : `Install ${config.name} CLI`;
@@ -301,7 +313,7 @@ export function AgentButton({
   const ariaLabel = isLoading
     ? `Checking ${config.name} CLI`
     : isLaunchable
-      ? `Start ${config.name}`
+      ? `Start ${config.name}${visibleStateSuffix}`
       : needsSetup
         ? `Configure ${config.name}`
         : `Install ${config.name} CLI`;
@@ -344,7 +356,6 @@ export function AgentButton({
     void useAgentSettingsStore.getState().updateWorktreePreset(type, activeWorktreeId, presetId);
   };
 
-  const dotColor = dominantState ? agentStateDotColor(dominantState) : null;
   const toolbarBrandColor = getBrandColorHex(type);
   const iconElement = (
     <div className="relative">
@@ -448,7 +459,7 @@ export function AgentButton({
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
-        <span className="inline-flex">
+        <span className="inline-flex group/agent-split">
           <Tooltip open={primaryTooltipOpen} onOpenChange={handlePrimaryTooltipOpenChange}>
             <TooltipTrigger asChild>
               <Button
@@ -467,6 +478,7 @@ export function AgentButton({
                 onBlur={hover.onBlur}
                 className={cn(
                   "toolbar-agent-button text-daintree-text rounded-r-none border-r border-transparent relative",
+                  showSeam && "toolbar-agent-split-seam",
                   needsSetup && "opacity-70",
                   "aria-disabled:opacity-50 aria-disabled:cursor-not-allowed"
                 )}

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -957,7 +957,7 @@ describe("AgentButton preset UX", () => {
       mockDominantState = "waiting";
       mockDotColor = "bg-state-waiting";
 
-      const { container, getAllByRole, getAllByTestId } = render(
+      const { container, getAllByRole, getAllByTestId, getByTestId } = render(
         <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
       );
 
@@ -965,7 +965,7 @@ describe("AgentButton preset UX", () => {
       const launchTooltip = tooltipTexts.find((t) => t.startsWith("Start "));
       expect(launchTooltip).toContain("— waiting");
 
-      const chevronIcon = getAllByTestId("chevron-icon")[0];
+      const chevronIcon = getByTestId("chevron-icon");
       const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
       expect(primary?.getAttribute("aria-label")).toBe("Start Claude — waiting");
 
@@ -987,7 +987,7 @@ describe("AgentButton preset UX", () => {
       mockDominantState = "directing";
       mockDotColor = "bg-state-working";
 
-      const { getAllByRole, getAllByTestId } = render(
+      const { getAllByRole, getAllByTestId, getByTestId } = render(
         <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
       );
 
@@ -995,7 +995,7 @@ describe("AgentButton preset UX", () => {
       const launchTooltip = tooltipTexts.find((t) => t.startsWith("Start "));
       expect(launchTooltip).toContain("— directing");
 
-      const chevronIcon = getAllByTestId("chevron-icon")[0];
+      const chevronIcon = getByTestId("chevron-icon");
       const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
       expect(primary?.getAttribute("aria-label")).toBe("Start Claude — directing");
     });
@@ -1042,7 +1042,7 @@ describe("AgentButton preset UX", () => {
       mockDominantState = "working";
       mockDotColor = null;
 
-      const { getAllByRole, getAllByTestId } = render(
+      const { getAllByRole, getAllByTestId, getByTestId } = render(
         <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
       );
 
@@ -1053,7 +1053,7 @@ describe("AgentButton preset UX", () => {
       expect(launchTooltip).not.toContain("— directing");
       expect(launchTooltip).not.toContain("— waiting");
 
-      const chevronIcon = getAllByTestId("chevron-icon")[0];
+      const chevronIcon = getByTestId("chevron-icon");
       const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
       expect(primary?.getAttribute("aria-label")).toBe("Start Claude");
     });
@@ -1064,7 +1064,7 @@ describe("AgentButton preset UX", () => {
       mockDominantState = null;
       mockDotColor = "bg-state-waiting";
 
-      const { getAllByRole, getAllByTestId } = render(
+      const { getAllByRole, getAllByTestId, getByTestId } = render(
         <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
       );
 
@@ -1072,7 +1072,7 @@ describe("AgentButton preset UX", () => {
       const launchTooltip = tooltipTexts.find((t) => t.startsWith("Start "));
       expect(launchTooltip).toBe("Start Claude · Blue");
 
-      const chevronIcon = getAllByTestId("chevron-icon")[0];
+      const chevronIcon = getByTestId("chevron-icon");
       const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
       expect(primary?.getAttribute("aria-label")).toBe("Start Claude");
     });
@@ -1089,11 +1089,11 @@ describe("AgentButton preset UX", () => {
       mockSettings = settingsWith({ claude: {} });
       mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
 
-      const { getAllByTestId, getAllByRole } = render(
+      const { getAllByRole, getByTestId } = render(
         <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
       );
 
-      const chevronIcon = getAllByTestId("chevron-icon")[0];
+      const chevronIcon = getByTestId("chevron-icon");
       const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
       const chevron = getAllByRole("button").find((b) => b.contains(chevronIcon));
       expect(primary).toBeTruthy();
@@ -1113,11 +1113,11 @@ describe("AgentButton preset UX", () => {
         { id: "user-red", name: "Red" },
       ];
 
-      const { getAllByTestId, getAllByRole } = render(
+      const { getAllByRole, getByTestId } = render(
         <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
       );
 
-      const chevronIcon = getAllByTestId("chevron-icon")[0];
+      const chevronIcon = getByTestId("chevron-icon");
       const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
       const chevron = getAllByRole("button").find((b) => b.contains(chevronIcon));
       expect(primary!.className).toContain("toolbar-agent-split-seam");
@@ -1129,11 +1129,11 @@ describe("AgentButton preset UX", () => {
       // claim a usable chevron when neither half is clickable.
       mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
 
-      const { getAllByTestId, getAllByRole } = render(
+      const { getAllByRole, getByTestId } = render(
         <AgentButton type="claude" availability={undefined} />
       );
 
-      const chevronIcon = getAllByTestId("chevron-icon")[0];
+      const chevronIcon = getByTestId("chevron-icon");
       const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
       expect(primary).toBeTruthy();
       expect(primary!.className).not.toContain("toolbar-agent-split-seam");
@@ -1142,11 +1142,11 @@ describe("AgentButton preset UX", () => {
     it("omits the seam class when the CLI is missing", () => {
       mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
 
-      const { getAllByTestId, getAllByRole } = render(
+      const { getAllByRole, getByTestId } = render(
         <AgentButton type="claude" availability={"missing" as unknown as CliAvailability[string]} />
       );
 
-      const chevronIcon = getAllByTestId("chevron-icon")[0];
+      const chevronIcon = getByTestId("chevron-icon");
       const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
       expect(primary!.className).not.toContain("toolbar-agent-split-seam");
     });
@@ -1154,14 +1154,14 @@ describe("AgentButton preset UX", () => {
     it("omits the seam class when the CLI is installed but not launchable (needs setup)", () => {
       mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
 
-      const { getAllByTestId, getAllByRole } = render(
+      const { getAllByRole, getByTestId } = render(
         <AgentButton
           type="claude"
           availability={"installed" as unknown as CliAvailability[string]}
         />
       );
 
-      const chevronIcon = getAllByTestId("chevron-icon")[0];
+      const chevronIcon = getByTestId("chevron-icon");
       const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
       expect(primary!.className).not.toContain("toolbar-agent-split-seam");
     });
@@ -1188,11 +1188,11 @@ describe("AgentButton preset UX", () => {
       mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
       mockSettings = settingsWith({ claude: {} });
 
-      const { getAllByTestId, getAllByRole } = render(
+      const { getAllByRole, getByTestId } = render(
         <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
       );
 
-      const chevronIcon = getAllByTestId("chevron-icon")[0];
+      const chevronIcon = getByTestId("chevron-icon");
       const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
       expect(primary!.className).toContain("border-r");
       expect(primary!.className).toContain("border-transparent");

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -353,6 +353,12 @@ vi.mock("lucide-react", () => ({
   ChevronDown: () => <span data-testid="chevron-icon" />,
   PanelBottom: () => <span data-testid="panel-bottom-icon" />,
   Unplug: () => <span data-testid="unplug-icon" />,
+  // terminalStateConfig.tsx (imported transitively for STATE_LABELS — #9823)
+  // needs Circle and CheckCircle2 to satisfy its import graph. The icon
+  // components themselves are not exercised in these tests, so a stub is
+  // sufficient.
+  Circle: () => null,
+  CheckCircle2: () => null,
 }));
 
 import { AgentButton } from "../AgentButton";
@@ -935,6 +941,217 @@ describe("AgentButton preset UX", () => {
 
       const badge = container.querySelector('.relative span[aria-hidden="true"]');
       expect(badge).toBeNull();
+    });
+
+    it("propagates the 'waiting' state word to the launch tooltip and aria-label (issue #9823)", () => {
+      // WCAG 1.4.1: the corner dot is aria-hidden, so screen readers would
+      // learn nothing about the actionable state without verbal copy. The
+      // suffix follows the established `— <state>` em-dash convention
+      // (#8173) and reuses STATE_LABELS for the wording.
+      mockSettings = settingsWith({ claude: { presetId: "user-blue" } });
+      mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
+      mockPanelsById = { "panel-1": activePanel("waiting") };
+      mockPanelIds = ["panel-1"];
+      mockPanelIdsByWorktreeId = { "wt-1": ["panel-1"] };
+      mockActiveWorktreeId = "wt-1";
+      mockDominantState = "waiting";
+      mockDotColor = "bg-state-waiting";
+
+      const { getAllByRole, getAllByTestId } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+
+      const tooltipTexts = getAllByTestId("tooltip-content").map((el) => el.textContent ?? "");
+      const launchTooltip = tooltipTexts.find((t) => t.startsWith("Start "));
+      expect(launchTooltip).toContain("— waiting");
+
+      const chevronIcon = getAllByTestId("chevron-icon")[0];
+      const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
+      expect(primary?.getAttribute("aria-label")).toBe("Start Claude — waiting");
+    });
+
+    it("propagates the 'directing' state word to the launch tooltip and aria-label (issue #9823)", () => {
+      mockSettings = settingsWith({ claude: { presetId: "user-blue" } });
+      mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
+      mockPanelsById = { "panel-1": activePanel("directing") };
+      mockPanelIds = ["panel-1"];
+      mockPanelIdsByWorktreeId = { "wt-1": ["panel-1"] };
+      mockActiveWorktreeId = "wt-1";
+      mockDominantState = "directing";
+      mockDotColor = "bg-state-working";
+
+      const { getAllByRole, getAllByTestId } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+
+      const tooltipTexts = getAllByTestId("tooltip-content").map((el) => el.textContent ?? "");
+      const launchTooltip = tooltipTexts.find((t) => t.startsWith("Start "));
+      expect(launchTooltip).toContain("— directing");
+
+      const chevronIcon = getAllByTestId("chevron-icon")[0];
+      const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
+      expect(primary?.getAttribute("aria-label")).toBe("Start Claude — directing");
+    });
+
+    it("omits the state suffix in passive states (no dot → no verbal state)", () => {
+      // working is a passive state — agentStateDotColor returns null so the
+      // dot doesn't render. The verbal-state suffix must mirror that gate,
+      // otherwise we'd add words to a control that has no visible state.
+      mockSettings = settingsWith({ claude: { presetId: "user-blue" } });
+      mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
+      mockPanelsById = { "panel-1": activePanel("working") };
+      mockPanelIds = ["panel-1"];
+      mockPanelIdsByWorktreeId = { "wt-1": ["panel-1"] };
+      mockActiveWorktreeId = "wt-1";
+      mockDominantState = "working";
+      mockDotColor = null;
+
+      const { getAllByRole, getAllByTestId } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+
+      const tooltipTexts = getAllByTestId("tooltip-content").map((el) => el.textContent ?? "");
+      const launchTooltip = tooltipTexts.find((t) => t.startsWith("Start "));
+      expect(launchTooltip).toBeDefined();
+      expect(launchTooltip).not.toContain("— working");
+      expect(launchTooltip).not.toContain("— directing");
+      expect(launchTooltip).not.toContain("— waiting");
+
+      const chevronIcon = getAllByTestId("chevron-icon")[0];
+      const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
+      expect(primary?.getAttribute("aria-label")).toBe("Start Claude");
+    });
+
+    it("omits the state suffix when there is no active session", () => {
+      mockSettings = settingsWith({ claude: { presetId: "user-blue" } });
+      mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
+      mockDominantState = null;
+      mockDotColor = "bg-state-waiting";
+
+      const { getAllByRole, getAllByTestId } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+
+      const tooltipTexts = getAllByTestId("tooltip-content").map((el) => el.textContent ?? "");
+      const launchTooltip = tooltipTexts.find((t) => t.startsWith("Start "));
+      expect(launchTooltip).toBe("Start Claude · Blue");
+
+      const chevronIcon = getAllByTestId("chevron-icon")[0];
+      const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
+      expect(primary?.getAttribute("aria-label")).toBe("Start Claude");
+    });
+  });
+
+  describe("split-button seam class (issue #9823)", () => {
+    // The seam is implemented as a custom toolbar.css class, not a Tailwind
+    // utility, because .border-divider resolves to the plain --border-divider
+    // alias and skips the --toolbar-divider override chain. The chevron's
+    // open-state suppression lives in CSS via the :has() group selector and
+    // is asserted in Toolbar.responsive.test.ts as a CSS source guard.
+
+    it("applies toolbar-agent-split-seam to the primary half when ready + 1 preset", () => {
+      mockSettings = settingsWith({ claude: {} });
+      mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
+
+      const { getAllByTestId, getAllByRole } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+
+      const chevronIcon = getAllByTestId("chevron-icon")[0];
+      const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
+      expect(primary).toBeTruthy();
+      expect(primary!.className).toContain("toolbar-agent-split-seam");
+    });
+
+    it("applies toolbar-agent-split-seam when ready + multiple presets", () => {
+      mockSettings = settingsWith({ claude: {} });
+      mockMergedPresetsFn = () => [
+        { id: "user-blue", name: "Blue" },
+        { id: "user-red", name: "Red" },
+      ];
+
+      const { getAllByTestId, getAllByRole } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+
+      const chevronIcon = getAllByTestId("chevron-icon")[0];
+      const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
+      expect(primary!.className).toContain("toolbar-agent-split-seam");
+    });
+
+    it("omits the seam class while the agent is loading (availability === undefined)", () => {
+      // Loading disables both halves (#8131) — advertising a seam here would
+      // claim a usable chevron when neither half is clickable.
+      mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
+
+      const { getAllByTestId, getAllByRole } = render(
+        <AgentButton type="claude" availability={undefined} />
+      );
+
+      const chevronIcon = getAllByTestId("chevron-icon")[0];
+      const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
+      expect(primary).toBeTruthy();
+      expect(primary!.className).not.toContain("toolbar-agent-split-seam");
+    });
+
+    it("omits the seam class when the CLI is missing", () => {
+      mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
+
+      const { getAllByTestId, getAllByRole } = render(
+        <AgentButton type="claude" availability={"missing" as unknown as CliAvailability[string]} />
+      );
+
+      const chevronIcon = getAllByTestId("chevron-icon")[0];
+      const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
+      expect(primary!.className).not.toContain("toolbar-agent-split-seam");
+    });
+
+    it("omits the seam class when the CLI is installed but not launchable (needs setup)", () => {
+      mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
+
+      const { getAllByTestId, getAllByRole } = render(
+        <AgentButton
+          type="claude"
+          availability={"installed" as unknown as CliAvailability[string]}
+        />
+      );
+
+      const chevronIcon = getAllByTestId("chevron-icon")[0];
+      const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
+      expect(primary!.className).not.toContain("toolbar-agent-split-seam");
+    });
+
+    it("does not apply the seam class in the no-presets (plain button) branch", () => {
+      // The seam is only meaningful on the split-button JSX — the plain
+      // button branch doesn't render a chevron and shouldn't carry the
+      // class even when launchable.
+      mockMergedPresetsFn = () => [];
+      mockSettings = settingsWith({ claude: {} });
+
+      const { getByRole } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+
+      const button = getByRole("button");
+      expect(button.className).not.toContain("toolbar-agent-split-seam");
+    });
+
+    it("keeps border-r and border-transparent in the className so geometry is constant", () => {
+      // The seam is a color swap, not a layout shift. `border-r` stays in
+      // both states so the 1px width is constant; the color moves between
+      // `border-transparent` and the toolbar-divider token.
+      mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
+      mockSettings = settingsWith({ claude: {} });
+
+      const { getAllByTestId, getAllByRole } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+
+      const chevronIcon = getAllByTestId("chevron-icon")[0];
+      const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
+      expect(primary!.className).toContain("border-r");
+      expect(primary!.className).toContain("border-transparent");
+      expect(primary!.className).toContain("toolbar-agent-split-seam");
     });
   });
 

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -957,7 +957,7 @@ describe("AgentButton preset UX", () => {
       mockDominantState = "waiting";
       mockDotColor = "bg-state-waiting";
 
-      const { getAllByRole, getAllByTestId } = render(
+      const { container, getAllByRole, getAllByTestId } = render(
         <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
       );
 
@@ -968,6 +968,13 @@ describe("AgentButton preset UX", () => {
       const chevronIcon = getAllByTestId("chevron-icon")[0];
       const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
       expect(primary?.getAttribute("aria-label")).toBe("Start Claude — waiting");
+
+      // Combined dot+suffix invariant — the suffix is only meaningful when
+      // the dot is also painting. A regression that decouples the two (e.g.
+      // dot removed, suffix kept) would mislead screen readers into thinking
+      // a state is actionable when it isn't visible to the user.
+      const badge = container.querySelector('.relative span[aria-hidden="true"]');
+      expect(badge).not.toBeNull();
     });
 
     it("propagates the 'directing' state word to the launch tooltip and aria-label (issue #9823)", () => {
@@ -991,6 +998,35 @@ describe("AgentButton preset UX", () => {
       const chevronIcon = getAllByTestId("chevron-icon")[0];
       const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
       expect(primary?.getAttribute("aria-label")).toBe("Start Claude — directing");
+    });
+
+    it("orders state suffix before sign-in suffix when both apply (issue #9823 + #8173)", () => {
+      // The sign-in-not-detected and state suffixes are independent cues
+      // that can co-occur (a launchable agent with a session in `waiting`
+      // and a passive auth probe that came back empty). The issue contract
+      // locks the order: state first, sign-in caveat second. The two
+      // em-dashes are the densest form the project uses, but the order is
+      // a regression target — a swap would read as the sign-in being a
+      // sub-cause of the state instead of a parallel caveat.
+      mockSettings = settingsWith({ claude: { presetId: "user-blue" } });
+      mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
+      mockPanelsById = { "panel-1": activePanel("waiting") };
+      mockPanelIds = ["panel-1"];
+      mockPanelIdsByWorktreeId = { "wt-1": ["panel-1"] };
+      mockActiveWorktreeId = "wt-1";
+      mockDominantState = "waiting";
+      mockDotColor = "bg-state-waiting";
+
+      const { getAllByTestId } = render(
+        <AgentButton
+          type="claude"
+          availability={"unauthenticated" as unknown as CliAvailability[string]}
+        />
+      );
+
+      const tooltipTexts = getAllByTestId("tooltip-content").map((el) => el.textContent ?? "");
+      const launchTooltip = tooltipTexts.find((t) => t.startsWith("Start "));
+      expect(launchTooltip).toBe("Start Claude · Blue — waiting — sign-in not detected");
     });
 
     it("omits the state suffix in passive states (no dot → no verbal state)", () => {
@@ -1059,8 +1095,15 @@ describe("AgentButton preset UX", () => {
 
       const chevronIcon = getAllByTestId("chevron-icon")[0];
       const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
+      const chevron = getAllByRole("button").find((b) => b.contains(chevronIcon));
       expect(primary).toBeTruthy();
       expect(primary!.className).toContain("toolbar-agent-split-seam");
+      // The seam paints the right border of the primary half; the chevron
+      // would never carry the class because the divider would be on the
+      // wrong side and would clash with the chevron's own armed-state
+      // ring. Pin this so a future refactor that propagates the class via
+      // a shared string doesn't silently double-paint.
+      expect(chevron!.className).not.toContain("toolbar-agent-split-seam");
     });
 
     it("applies toolbar-agent-split-seam when ready + multiple presets", () => {
@@ -1076,7 +1119,9 @@ describe("AgentButton preset UX", () => {
 
       const chevronIcon = getAllByTestId("chevron-icon")[0];
       const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
+      const chevron = getAllByRole("button").find((b) => b.contains(chevronIcon));
       expect(primary!.className).toContain("toolbar-agent-split-seam");
+      expect(chevron!.className).not.toContain("toolbar-agent-split-seam");
     });
 
     it("omits the seam class while the agent is loading (availability === undefined)", () => {

--- a/src/components/Layout/__tests__/Toolbar.responsive.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.responsive.test.ts
@@ -355,4 +355,52 @@ describe("Toolbar responsive design — issue #4133", () => {
       );
     });
   });
+
+  describe("agent split-button seam — issue #9823", () => {
+    // The seam is implemented as a custom toolbar.css class (not a Tailwind
+    // utility) because .border-divider resolves to the plain --border-divider
+    // alias and skips the --toolbar-divider override chain. The chevron's
+    // open-state suppression is asserted as a CSS source guard so a future
+    // refactor cannot silently drop the suppression — which would let the
+    // 1px right border stack with the chevron's inset 1px border-strong
+    // armed ring into a 2px smudge on light themes (the same failure mode
+    // the L97-117 comment block above documents).
+
+    it("declares the toolbar-agent-split-seam class", () => {
+      expect(css).toContain(".toolbar-agent-split-seam");
+    });
+
+    it("paints the seam with the --toolbar-divider chain (matches .toolbar-divider)", () => {
+      // Verify the seam rule body uses the same fallback chain as the
+      // existing .toolbar-divider so per-theme --toolbar-divider overrides
+      // apply identically. A regression that hardcodes a color here would
+      // break the theme-tokened contract.
+      const seamBlock = css.match(/\.toolbar-agent-split-seam\s*\{[^}]*\}/)?.[0];
+      expect(seamBlock).toBeDefined();
+      expect(seamBlock).toContain("border-right-color");
+      expect(seamBlock).toContain("var(--toolbar-divider, var(--theme-border-divider))");
+    });
+
+    it("suppresses the seam when the chevron is armed via :has() on group/agent-split", () => {
+      // The suppression anchors on .toolbar-agent-button[data-state="open"]
+      // (the same selector the existing armed-state block above uses) so
+      // the trigger path is shared. The :has() sits on .group\/agent-split
+      // to scope the rule to the split-button JSX, not bare toolbar buttons.
+      // (CSS escapes the `/` so the on-disk literal is `\/`.)
+      expect(css).toContain('.group\\/agent-split:has(.toolbar-agent-button[data-state="open"])');
+      expect(css).toContain("border-right-color: transparent");
+    });
+
+    it("provides a forced-colors fallback so the seam survives Windows High Contrast", () => {
+      // Without the ButtonText fallback, Windows High Contrast would force
+      // the seam to Canvas (invisible) and the split-button structure would
+      // read as a single button — losing the discoverability win the issue
+      // asks for.
+      const forcedColorsBlock = css.match(
+        /@media \(forced-colors: active\)\s*\{[\s\S]*?\.toolbar-agent-split-seam[\s\S]*?\}/
+      )?.[0];
+      expect(forcedColorsBlock).toBeDefined();
+      expect(forcedColorsBlock).toContain("border-right-color: ButtonText");
+    });
+  });
 });

--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -169,6 +169,28 @@
   background: var(--toolbar-divider, var(--theme-border-divider));
 }
 
+/* Split-button seam: persistent 1px hairline at rest so the chevron half
+ * reads as a separate control. The color chain mirrors .toolbar-divider so
+ * per-theme --toolbar-divider overrides apply identically. Suppressed when
+ * the chevron dropdown is open via the named group/agent-split parent: the
+ * chevron's armed-state inset ring (above) would otherwise stack with this
+ * 1px right border and read as a 2px smudge on light themes (same failure
+ * the L97-117 comment block above documents). Forced-colors mode keeps a
+ * 1px system-color edge so the seam survives Windows High Contrast. */
+.toolbar-agent-split-seam {
+  border-right-color: var(--toolbar-divider, var(--theme-border-divider));
+}
+
+.group\/agent-split:has(.toolbar-agent-button[data-state="open"]) .toolbar-agent-split-seam {
+  border-right-color: transparent;
+}
+
+@media (forced-colors: active) {
+  .toolbar-agent-split-seam {
+    border-right-color: ButtonText;
+  }
+}
+
 .toolbar-stats {
   --_bg: var(--toolbar-stats-bg, var(--theme-overlay-hover));
   --_border: var(--toolbar-stats-border, var(--theme-border-subtle));


### PR DESCRIPTION
## Summary

- The agent split-button seam now reads at rest using the existing `--toolbar-divider` token chain, so the chevron half is discoverable without hovering. Suppressed when the agent isn't launchable or the dropdown is armed, since the armed-state inset ring would otherwise stack into a 2px smudge on light themes.
- When the corner dot renders, the primary half's tooltip and aria-label carry the state in words, closing the WCAG 1.4.1 gap. Reuses `STATE_LABELS` and follows the #8173 em-dash suffix convention.
- New `.toolbar-agent-split-seam` rule in `src/styles/components/toolbar.css` rather than a Tailwind utility, since `.border-divider` resolves to the plain `--border-divider` alias and skips the override chain. Forced-colors fallback keeps a `ButtonText` edge on Windows High Contrast.

Resolves #9823

## Changes

- `src/components/Layout/AgentButton.tsx` — conditional seam class on the primary half, state suffix on `tooltipLabel` / `ariaLabel` when a dot renders.
- `src/styles/components/toolbar.css` — new `.toolbar-agent-split-seam` rule with the `--toolbar-divider` source and `forced-colors` fallback.
- `src/components/Layout/__tests__/AgentButton.test.tsx` — 11 new cases (4 dot/suffix, 7 seam class), including the seam-doesn't-leak-into-chevron invariant and the sign-in + state combination test pinning the exact suffix order.
- `src/components/Layout/__tests__/Toolbar.responsive.test.ts` — 4 CSS source guards pinning the seam/divider class chain and the high-contrast fallback.

## Testing

- `npm run check` clean.
- `npm run build` clean.
- Targeted unit tests pass.