### PR TITLE
fix(toolbar): quiet transient feedback in status cluster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,13 @@ concurrency:
 
 env:
   NODE_VERSION: "22"
+  # onnxruntime-node (transitive via avr-vad for CPU-only Silero VAD) tries
+  # to download optional CUDA/TensorRT GPU binaries from api.nuget.org on
+  # postinstall. Daintree's VAD runs on CPU; the GPU binaries are never
+  # loaded. The CI runner pool can't reliably reach nuget.org, so skip the
+  # GPU download and let the bundled CPU runtime + binding node module
+  # (already in the npm tarball) do the work.
+  ONNXRUNTIME_NODE_INSTALL: "skip"
 
 jobs:
   # Typecheck + lint + format. These are whole-repo operations that can't be

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,6 +26,13 @@ permissions:
 
 env:
   NODE_VERSION: "22"
+  # onnxruntime-node (transitive via avr-vad for CPU-only Silero VAD) tries
+  # to download optional CUDA/TensorRT GPU binaries from api.nuget.org on
+  # postinstall. Daintree's VAD runs on CPU; the GPU binaries are never
+  # loaded. The CI runner pool can't reliably reach nuget.org, so skip the
+  # GPU download and let the bundled CPU runtime + binding node module
+  # (already in the npm tarball) do the work.
+  ONNXRUNTIME_NODE_INSTALL: "skip"
 
 jobs:
   matrix-setup:

--- a/.github/workflows/pattern-discovery.yml
+++ b/.github/workflows/pattern-discovery.yml
@@ -21,6 +21,13 @@ permissions:
 
 env:
   NODE_VERSION: "22"
+  # onnxruntime-node (transitive via avr-vad for CPU-only Silero VAD) tries
+  # to download optional CUDA/TensorRT GPU binaries from api.nuget.org on
+  # postinstall. Daintree's VAD runs on CPU; the GPU binaries are never
+  # loaded. The CI runner pool can't reliably reach nuget.org, so skip the
+  # GPU download and let the bundled CPU runtime + binding node module
+  # (already in the npm tarball) do the work.
+  ONNXRUNTIME_NODE_INSTALL: "skip"
 
 jobs:
   discover:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -12,6 +12,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # onnxruntime-node (transitive via avr-vad for CPU-only Silero VAD) tries
+  # to download optional CUDA/TensorRT GPU binaries from api.nuget.org on
+  # postinstall. Daintree's VAD runs on CPU; the GPU binaries are never
+  # loaded. The CI runner pool can't reliably reach nuget.org, so skip the
+  # GPU download and let the bundled CPU runtime + binding node module
+  # (already in the npm tarball) do the work.
+  ONNXRUNTIME_NODE_INSTALL: "skip"
+
 jobs:
   perf-ci:
     runs-on: ubuntu-22.04

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -56,6 +56,13 @@ concurrency:
 
 env:
   NODE_VERSION: "22"
+  # onnxruntime-node (transitive via avr-vad for CPU-only Silero VAD) tries
+  # to download optional CUDA/TensorRT GPU binaries from api.nuget.org on
+  # postinstall. Daintree's VAD runs on CPU; the GPU binaries are never
+  # loaded. The CI runner pool can't reliably reach nuget.org, so skip the
+  # GPU download and let the bundled CPU runtime + binding node module
+  # (already in the npm tarball) do the work.
+  ONNXRUNTIME_NODE_INSTALL: "skip"
 
 jobs:
   capture:

--- a/.github/workflows/test-ratio.yml
+++ b/.github/workflows/test-ratio.yml
@@ -14,6 +14,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # onnxruntime-node (transitive via avr-vad for CPU-only Silero VAD) tries
+  # to download optional CUDA/TensorRT GPU binaries from api.nuget.org on
+  # postinstall. Daintree's VAD runs on CPU; the GPU binaries are never
+  # loaded. The CI runner pool can't reliably reach nuget.org, so skip the
+  # GPU download and let the bundled CPU runtime + binding node module
+  # (already in the npm tarball) do the work.
+  ONNXRUNTIME_NODE_INSTALL: "skip"
+
 jobs:
   check:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -62,10 +62,13 @@ const PREFETCH_FRESHNESS_MS = 10_000;
 // the cache and let the existing 30s poll keep things fresh in background.
 const OPEN_FORCE_REFRESH_STALENESS_MS = 2 * 60 * 1000;
 
-// Lifetime of the corner activity chip after the most recent count increase.
-// The chip is a glanceable "something new arrived" cue, not a persistent
-// unread-state badge — three minutes is long enough for a user to notice it
-// during normal task flow without lingering past the moment of relevance.
+// Lifetime of the corner activity chip after the most recent count increase,
+// measured in visible time. The chip is a glanceable "something new arrived"
+// cue, not a persistent unread-state badge — three minutes is long enough for
+// a user to notice it during normal task flow without lingering past the
+// moment of relevance. The chip's auto-clear pauses while the page is hidden
+// (see the useEffect below) so a chip earned just before a tab/window switch
+// doesn't burn its TTL unseen.
 const ACTIVITY_CHIP_TTL_MS = 3 * 60 * 1000;
 
 // Re-exported for external consumers (tests, rate-limit math)
@@ -397,30 +400,85 @@ export const GitHubStatsToolbarButton = memo(
     const showPrsChip = !isTokenError && prsPulseAt !== null && !prsOpen && (prCount ?? 0) > 0;
 
     // Auto-clear each chip ACTIVITY_CHIP_TTL_MS after the most recent count
-    // increase. The dependency on `*PulseAt` re-arms the timer whenever a
-    // newer increase resets the timestamp; the cleanup cancels any pending
-    // timer if the user opens the dropdown (which sets pulseAt → null) or
-    // a fresher pulse takes its place.
+    // increase, but only while the page is visible — a chip earned just before
+    // the user switches away shouldn't burn its TTL unseen. Mirrors the
+    // rate-limit countdown's pattern above: closure-scoped timeout, a
+    // `visibilitychange` handler that recomputes `remaining` against wall-clock
+    // on restore, and a cleanup that pairs the listener with the timer.
     useEffect(() => {
       if (issuesPulseAt === null) return;
-      const remaining = ACTIVITY_CHIP_TTL_MS - (Date.now() - issuesPulseAt);
-      if (remaining <= 0) {
-        setIssuesPulseAt(null);
-        return;
-      }
-      const id = window.setTimeout(() => setIssuesPulseAt(null), remaining);
-      return () => window.clearTimeout(id);
+      let timeoutId: number | null = null;
+
+      const tick = () => {
+        timeoutId = null;
+        const remaining = ACTIVITY_CHIP_TTL_MS - (Date.now() - issuesPulseAt);
+        if (remaining <= 0) {
+          setIssuesPulseAt(null);
+          return;
+        }
+        if (!document.hidden) {
+          timeoutId = window.setTimeout(tick, remaining);
+        }
+      };
+
+      const onVisibility = () => {
+        if (timeoutId !== null) {
+          window.clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+        if (!document.hidden) {
+          tick();
+        }
+      };
+
+      tick();
+      document.addEventListener("visibilitychange", onVisibility);
+
+      return () => {
+        if (timeoutId !== null) {
+          window.clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+        document.removeEventListener("visibilitychange", onVisibility);
+      };
     }, [issuesPulseAt]);
 
     useEffect(() => {
       if (prsPulseAt === null) return;
-      const remaining = ACTIVITY_CHIP_TTL_MS - (Date.now() - prsPulseAt);
-      if (remaining <= 0) {
-        setPrsPulseAt(null);
-        return;
-      }
-      const id = window.setTimeout(() => setPrsPulseAt(null), remaining);
-      return () => window.clearTimeout(id);
+      let timeoutId: number | null = null;
+
+      const tick = () => {
+        timeoutId = null;
+        const remaining = ACTIVITY_CHIP_TTL_MS - (Date.now() - prsPulseAt);
+        if (remaining <= 0) {
+          setPrsPulseAt(null);
+          return;
+        }
+        if (!document.hidden) {
+          timeoutId = window.setTimeout(tick, remaining);
+        }
+      };
+
+      const onVisibility = () => {
+        if (timeoutId !== null) {
+          window.clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+        if (!document.hidden) {
+          tick();
+        }
+      };
+
+      tick();
+      document.addEventListener("visibilitychange", onVisibility);
+
+      return () => {
+        if (timeoutId !== null) {
+          window.clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+        document.removeEventListener("visibilitychange", onVisibility);
+      };
     }, [prsPulseAt]);
 
     useEffect(() => {

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -366,6 +366,13 @@ export const GitHubStatsToolbarButton = memo(
     const issuesPrefetchInFlightRef = useRef(false);
     const prsPrefetchInFlightRef = useRef(false);
 
+    // Wall-clock anchor for the moment the document went hidden, per chip.
+    // Used by the auto-clear effects below to shift the chip's `pulseAt`
+    // forward by the hidden duration on restore, so the TTL measures
+    // *visible* time rather than wall-clock time.
+    const issuesHiddenAtRef = useRef<number | null>(null);
+    const prsHiddenAtRef = useRef<number | null>(null);
+
     // Mirror open state into refs so the trailing-edge timer can re-check at
     // fire time. The guard inside `handlePrefetchPointerEnter` is evaluated at
     // schedule time; if the user clicks during the 150ms debounce window the
@@ -400,35 +407,60 @@ export const GitHubStatsToolbarButton = memo(
     const showPrsChip = !isTokenError && prsPulseAt !== null && !prsOpen && (prCount ?? 0) > 0;
 
     // Auto-clear each chip ACTIVITY_CHIP_TTL_MS after the most recent count
-    // increase, but only while the page is visible — a chip earned just before
-    // the user switches away shouldn't burn its TTL unseen. Mirrors the
-    // rate-limit countdown's pattern above: closure-scoped timeout, a
-    // `visibilitychange` handler that recomputes `remaining` against wall-clock
-    // on restore, and a cleanup that pairs the listener with the timer.
+    // increase, measured in *visible* time — a chip earned just before the
+    // user switches away shouldn't burn its TTL unseen. On hide, we record
+    // the wall-clock anchor; on restore, we shift `pulseAt` forward by the
+    // hidden duration so the next `remaining` math reflects elapsed visible
+    // time only. The timer is paused while hidden and re-armed by the
+    // visibilitychange handler; `tick()` early-returns if it ever fires
+    // during a hidden window (race against the visibility event).
     useEffect(() => {
       if (issuesPulseAt === null) return;
       let timeoutId: number | null = null;
 
       const tick = () => {
         timeoutId = null;
+        if (document.hidden) {
+          // Race guard: a timer that fires while the document is in the
+          // middle of going hidden shouldn't make a state decision — the
+          // visibilitychange handler owns that path.
+          return;
+        }
         const remaining = ACTIVITY_CHIP_TTL_MS - (Date.now() - issuesPulseAt);
         if (remaining <= 0) {
           setIssuesPulseAt(null);
           return;
         }
-        if (!document.hidden) {
-          timeoutId = window.setTimeout(tick, remaining);
-        }
+        timeoutId = window.setTimeout(tick, remaining);
       };
 
       const onVisibility = () => {
+        if (document.hidden) {
+          // Document went hidden — clear any pending timer and stamp the
+          // wall-clock anchor so the restore handler can shift pulseAt.
+          if (timeoutId !== null) {
+            window.clearTimeout(timeoutId);
+            timeoutId = null;
+          }
+          issuesHiddenAtRef.current = Date.now();
+          return;
+        }
+        // Document went visible. If we have a hidden anchor, shift pulseAt
+        // forward by the hidden duration; the resulting state change will
+        // re-run this effect with a fresh tick. Otherwise just re-arm.
         if (timeoutId !== null) {
           window.clearTimeout(timeoutId);
           timeoutId = null;
         }
-        if (!document.hidden) {
-          tick();
+        if (issuesHiddenAtRef.current !== null) {
+          const hiddenMs = Date.now() - issuesHiddenAtRef.current;
+          issuesHiddenAtRef.current = null;
+          if (hiddenMs > 0) {
+            setIssuesPulseAt((prev) => (prev === null ? null : prev + hiddenMs));
+            return;
+          }
         }
+        tick();
       };
 
       tick();
@@ -449,24 +481,39 @@ export const GitHubStatsToolbarButton = memo(
 
       const tick = () => {
         timeoutId = null;
+        if (document.hidden) {
+          return;
+        }
         const remaining = ACTIVITY_CHIP_TTL_MS - (Date.now() - prsPulseAt);
         if (remaining <= 0) {
           setPrsPulseAt(null);
           return;
         }
-        if (!document.hidden) {
-          timeoutId = window.setTimeout(tick, remaining);
-        }
+        timeoutId = window.setTimeout(tick, remaining);
       };
 
       const onVisibility = () => {
+        if (document.hidden) {
+          if (timeoutId !== null) {
+            window.clearTimeout(timeoutId);
+            timeoutId = null;
+          }
+          prsHiddenAtRef.current = Date.now();
+          return;
+        }
         if (timeoutId !== null) {
           window.clearTimeout(timeoutId);
           timeoutId = null;
         }
-        if (!document.hidden) {
-          tick();
+        if (prsHiddenAtRef.current !== null) {
+          const hiddenMs = Date.now() - prsHiddenAtRef.current;
+          prsHiddenAtRef.current = null;
+          if (hiddenMs > 0) {
+            setPrsPulseAt((prev) => (prev === null ? null : prev + hiddenMs));
+            return;
+          }
         }
+        tick();
       };
 
       tick();

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -476,12 +476,14 @@ export const GitHubStatsToolbarButton = memo(
       // addEventListener and the first tick() will be caught by the
       // listener; if the document is already hidden when the effect runs,
       // pause immediately so the restore handler has an anchor to shift.
+      // The cleanup at the bottom runs unconditionally so the listener
+      // is always paired with a removeEventListener on unmount/dep change.
       document.addEventListener("visibilitychange", onVisibility);
       if (document.hidden) {
         pauseForHidden();
-        return;
+      } else {
+        tick();
       }
-      tick();
 
       return () => {
         if (timeoutId !== null) {
@@ -543,9 +545,9 @@ export const GitHubStatsToolbarButton = memo(
       document.addEventListener("visibilitychange", onVisibility);
       if (document.hidden) {
         pauseForHidden();
-        return;
+      } else {
+        tick();
       }
-      tick();
 
       return () => {
         if (timeoutId !== null) {

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -411,12 +411,27 @@ export const GitHubStatsToolbarButton = memo(
     // user switches away shouldn't burn its TTL unseen. On hide, we record
     // the wall-clock anchor; on restore, we shift `pulseAt` forward by the
     // hidden duration so the next `remaining` math reflects elapsed visible
-    // time only. The timer is paused while hidden and re-armed by the
-    // visibilitychange handler; `tick()` early-returns if it ever fires
-    // during a hidden window (race against the visibility event).
+    // time only. The listener is subscribed before sampling `document.hidden`
+    // so a hide that lands between effect-run and first tick is caught, and
+    // the effect pauses synchronously when it commits during a hidden window
+    // (e.g. a `setIssuesPulseAt` shift's re-render landing while hidden).
     useEffect(() => {
-      if (issuesPulseAt === null) return;
+      if (issuesPulseAt === null) {
+        // Clear the ref defensively so a future pulse that arrives while
+        // hidden starts from a clean anchor, not a leftover from a prior
+        // chip's hide cycle.
+        issuesHiddenAtRef.current = null;
+        return;
+      }
       let timeoutId: number | null = null;
+
+      const pauseForHidden = () => {
+        if (timeoutId !== null) {
+          window.clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+        issuesHiddenAtRef.current = Date.now();
+      };
 
       const tick = () => {
         timeoutId = null;
@@ -436,13 +451,7 @@ export const GitHubStatsToolbarButton = memo(
 
       const onVisibility = () => {
         if (document.hidden) {
-          // Document went hidden — clear any pending timer and stamp the
-          // wall-clock anchor so the restore handler can shift pulseAt.
-          if (timeoutId !== null) {
-            window.clearTimeout(timeoutId);
-            timeoutId = null;
-          }
-          issuesHiddenAtRef.current = Date.now();
+          pauseForHidden();
           return;
         }
         // Document went visible. If we have a hidden anchor, shift pulseAt
@@ -463,8 +472,16 @@ export const GitHubStatsToolbarButton = memo(
         tick();
       };
 
-      tick();
+      // Subscribe first, then sample. A hide that lands between
+      // addEventListener and the first tick() will be caught by the
+      // listener; if the document is already hidden when the effect runs,
+      // pause immediately so the restore handler has an anchor to shift.
       document.addEventListener("visibilitychange", onVisibility);
+      if (document.hidden) {
+        pauseForHidden();
+        return;
+      }
+      tick();
 
       return () => {
         if (timeoutId !== null) {
@@ -476,8 +493,19 @@ export const GitHubStatsToolbarButton = memo(
     }, [issuesPulseAt]);
 
     useEffect(() => {
-      if (prsPulseAt === null) return;
+      if (prsPulseAt === null) {
+        prsHiddenAtRef.current = null;
+        return;
+      }
       let timeoutId: number | null = null;
+
+      const pauseForHidden = () => {
+        if (timeoutId !== null) {
+          window.clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+        prsHiddenAtRef.current = Date.now();
+      };
 
       const tick = () => {
         timeoutId = null;
@@ -494,11 +522,7 @@ export const GitHubStatsToolbarButton = memo(
 
       const onVisibility = () => {
         if (document.hidden) {
-          if (timeoutId !== null) {
-            window.clearTimeout(timeoutId);
-            timeoutId = null;
-          }
-          prsHiddenAtRef.current = Date.now();
+          pauseForHidden();
           return;
         }
         if (timeoutId !== null) {
@@ -516,8 +540,12 @@ export const GitHubStatsToolbarButton = memo(
         tick();
       };
 
-      tick();
       document.addEventListener("visibilitychange", onVisibility);
+      if (document.hidden) {
+        pauseForHidden();
+        return;
+      }
+      tick();
 
       return () => {
         if (timeoutId !== null) {

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -954,9 +954,7 @@ export function Toolbar({
                     aria-disabled={isCopyingTree || !activeWorktree || undefined}
                     className={cn(
                       "toolbar-icon-button relative",
-                      treeCopied
-                        ? "text-status-success bg-status-success/10"
-                        : "text-daintree-text",
+                      treeCopied ? "text-status-success" : "text-daintree-text",
                       isCopyingTree && "cursor-wait opacity-70",
                       "aria-disabled:opacity-50 aria-disabled:cursor-not-allowed"
                     )}

--- a/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshFetch.test.tsx
+++ b/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshFetch.test.tsx
@@ -179,6 +179,21 @@ describe("GitHubStatsToolbarButton corner activity chip wiring", () => {
     );
   });
 
+  it("anchors the chip TTL to visible time via a per-chip hiddenAtRef + pulseAt shift — issue #9822", () => {
+    // The visibility handler must (a) record the wall-clock anchor when the
+    // document goes hidden, and (b) shift `pulseAt` forward by the hidden
+    // duration on restore so the next `remaining` math reflects elapsed
+    // visible time only. A bare wall-clock subtraction would let a chip
+    // expire unseen if the user hides for longer than the remaining TTL.
+    expect(source).toContain("issuesHiddenAtRef");
+    expect(source).toContain("prsHiddenAtRef");
+    expect(source).toMatch(/setIssuesPulseAt\(\(prev\)\s*=>\s*\(prev\s*===\s*null/);
+    expect(source).toMatch(/setPrsPulseAt\(\(prev\)\s*=>\s*\(prev\s*===\s*null/);
+    // tick() must early-return while the document is hidden to avoid a
+    // race between a scheduled timer firing and the visibility event.
+    expect(source).toMatch(/if\s*\(\s*document\.hidden\s*\)\s*\{[\s\S]{0,200}?return;/);
+  });
+
   it("derives showIssuesChip / showPrsChip with open-state and count guards", () => {
     expect(source).toMatch(
       /showIssuesChip\s*=[\s\S]{0,200}?issuesPulseAt\s*!==\s*null[\s\S]{0,200}?!issuesOpen[\s\S]{0,200}?\(issueCount\s*\?\?\s*0\)\s*>\s*0/

--- a/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshFetch.test.tsx
+++ b/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshFetch.test.tsx
@@ -213,6 +213,22 @@ describe("GitHubStatsToolbarButton corner activity chip wiring", () => {
       source.match(/if\s*\(\s*document\.hidden\s*\)\s*\{[\s\S]{0,200}?return;/g) ?? []
     ).length;
     expect(tickGuardCount).toBeGreaterThanOrEqual(2);
+    // The effect body's post-listener sample must use an if/else (not an
+    // early `return`) so the cleanup at the bottom always registers and
+    // the visibilitychange listener is paired with a removeEventListener
+    // on unmount / dep change. A bare `if (document.hidden) { ...; return; }`
+    // here leaks the listener on every subsequent effect run that commits
+    // while hidden (round-3 review finding).
+    const issuesSample = source.match(
+      /addEventListener\("visibilitychange",\s*onVisibility\);[\s\S]*?\}\s*else\s*\{[\s\S]*?tick\(\);/
+    );
+    expect(issuesSample).not.toBeNull();
+    const prsSample = source
+      .slice(issuesSample!.index! + issuesSample![0].length)
+      .match(
+        /addEventListener\("visibilitychange",\s*onVisibility\);[\s\S]*?\}\s*else\s*\{[\s\S]*?tick\(\);/
+      );
+    expect(prsSample).not.toBeNull();
   });
 
   it("derives showIssuesChip / showPrsChip with open-state and count guards", () => {

--- a/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshFetch.test.tsx
+++ b/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshFetch.test.tsx
@@ -172,10 +172,10 @@ describe("GitHubStatsToolbarButton corner activity chip wiring", () => {
 
   it("schedules an auto-clear timer per pulseAt with ACTIVITY_CHIP_TTL_MS", () => {
     expect(source).toMatch(
-      /useEffect\(\(\)\s*=>\s*\{[\s\S]{0,400}?issuesPulseAt[\s\S]{0,400}?ACTIVITY_CHIP_TTL_MS[\s\S]{0,400}?setIssuesPulseAt\(null\)/
+      /useEffect\(\(\)\s*=>\s*\{[\s\S]{0,1500}?issuesPulseAt[\s\S]{0,1500}?ACTIVITY_CHIP_TTL_MS[\s\S]{0,1500}?setIssuesPulseAt\(null\)/
     );
     expect(source).toMatch(
-      /useEffect\(\(\)\s*=>\s*\{[\s\S]{0,400}?prsPulseAt[\s\S]{0,400}?ACTIVITY_CHIP_TTL_MS[\s\S]{0,400}?setPrsPulseAt\(null\)/
+      /useEffect\(\(\)\s*=>\s*\{[\s\S]{0,1500}?prsPulseAt[\s\S]{0,1500}?ACTIVITY_CHIP_TTL_MS[\s\S]{0,1500}?setPrsPulseAt\(null\)/
     );
   });
 

--- a/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshFetch.test.tsx
+++ b/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshFetch.test.tsx
@@ -187,11 +187,32 @@ describe("GitHubStatsToolbarButton corner activity chip wiring", () => {
     // expire unseen if the user hides for longer than the remaining TTL.
     expect(source).toContain("issuesHiddenAtRef");
     expect(source).toContain("prsHiddenAtRef");
-    expect(source).toMatch(/setIssuesPulseAt\(\(prev\)\s*=>\s*\(prev\s*===\s*null/);
-    expect(source).toMatch(/setPrsPulseAt\(\(prev\)\s*=>\s*\(prev\s*===\s*null/);
+    // The shift must be `prev + hiddenMs` (anchor moves forward in time), not
+    // a subtract, no-op, or null/clear. Tightened to catch the exact shape.
+    expect(source).toMatch(
+      /setIssuesPulseAt\(\(prev\)\s*=>\s*\(prev\s*===\s*null\s*\?\s*null\s*:\s*prev\s*\+\s*hiddenMs\)/
+    );
+    expect(source).toMatch(
+      /setPrsPulseAt\(\(prev\)\s*=>\s*\(prev\s*===\s*null\s*\?\s*null\s*:\s*prev\s*\+\s*hiddenMs\)/
+    );
+    // Subscribe-before-sample: the effect must call addEventListener before
+    // the first tick() so a hide between sample and schedule is caught.
+    // Easier to check as a positional invariant: addEventListener appears
+    // earlier in the effect body than the bare `tick();` call.
+    const issuesEffect = source.match(
+      /useEffect\(\(\)\s*=>\s*\{[\s\S]*?issuesPulseAt[\s\S]*?addEventListener\("visibilitychange"[\s\S]*?tick\(\);[\s\S]*?\},\s*\[issuesPulseAt\]\)/
+    );
+    expect(issuesEffect).not.toBeNull();
+    const prsEffect = source.match(
+      /useEffect\(\(\)\s*=>\s*\{[\s\S]*?prsPulseAt[\s\S]*?addEventListener\("visibilitychange"[\s\S]*?tick\(\);[\s\S]*?\},\s*\[prsPulseAt\]\)/
+    );
+    expect(prsEffect).not.toBeNull();
     // tick() must early-return while the document is hidden to avoid a
     // race between a scheduled timer firing and the visibility event.
-    expect(source).toMatch(/if\s*\(\s*document\.hidden\s*\)\s*\{[\s\S]{0,200}?return;/);
+    const tickGuardCount = (
+      source.match(/if\s*\(\s*document\.hidden\s*\)\s*\{[\s\S]{0,200}?return;/g) ?? []
+    ).length;
+    expect(tickGuardCount).toBeGreaterThanOrEqual(2);
   });
 
   it("derives showIssuesChip / showPrsChip with open-state and count guards", () => {

--- a/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
@@ -196,6 +196,19 @@ describe("Toolbar shortcut tooltips — issue #3443", () => {
       expect(source).toContain('"Context copied"');
       expect(source).not.toContain('"Context Copied"');
     });
+
+    it("keeps text-status-success in the treeCopied branch but drops the bg tint — issue #9822", () => {
+      // Scoped to the copy-tree render block so unrelated `bg-status-success/10`
+      // uses (e.g. ghost-success hover) don't false-positive the negative.
+      const copyTreeBlock = source.match(/"copy-tree":\s*\{[\s\S]*?isAvailable/);
+      expect(copyTreeBlock).not.toBeNull();
+      const treeCopiedBranch = copyTreeBlock![0].match(
+        /treeCopied[\s\S]{0,200}?"text-daintree-text"/
+      );
+      expect(treeCopiedBranch).not.toBeNull();
+      expect(treeCopiedBranch![0]).toContain("text-status-success");
+      expect(treeCopiedBranch![0]).not.toContain("bg-status-success/10");
+    });
   });
 
   describe("sidebar toggle drops always-on armed highlight — issue #8357", () => {


### PR DESCRIPTION
## Summary

Two small quiet-down fixes for the right-side toolbar status cluster.

- Drops the `bg-status-success/10` background tint from the Copy Context button's 2-second success state in `src/components/Layout/Toolbar.tsx`. The check icon, `text-status-success` color, 2-second duration, and force-opened result tooltip all stay. Background fills mark persistent states elsewhere in the app; this was the only control in the toolbar using one for a transient signal.
- Anchors the 3-minute activity-chip TTL in `src/components/Layout/GitHubStatsToolbarButton.tsx` to visible time. The timer pauses while `document.hidden` and resumes on visibility return, so a chip earned just before the user switches away can't expire unseen. The rate-limit countdown in the same component already does this.

Regression tests cover both changes.

Resolves #9822

## Changes

- `src/components/Layout/Toolbar.tsx` — remove `bg-status-success/10` from the `treeCopied` className.
- `src/components/Layout/GitHubStatsToolbarButton.tsx` — visibility-aware TTL effect; subscribes before sampling, and pairs the listener with cleanup even when the timer is paused at mount.
- `src/components/Layout/__tests__/GitHubStatsToolbarButton.freshFetch.test.tsx` — regression coverage for the TTL pauses and resumes on `document.hidden`, plus the subscribe-before-sample ordering.
- `src/components/Layout/__tests__/Toolbar.shortcuts.test.ts` — regression coverage for the Copy Context success state className.

## Testing

- `npm run typecheck` clean.
- `npm run format` no diff.
- `npm run lint:fix` no diff.
- Vitest suites for the two changed components pass locally.