### PR TITLE
feat(pulse): add legend and high-contrast support to heatmap

### DIFF
--- a/e2e/full/panels/core-pulse.spec.ts
+++ b/e2e/full/panels/core-pulse.spec.ts
@@ -27,6 +27,24 @@ test.describe.serial("Core: Project Pulse", () => {
     await expect(window.locator(SEL.pulse.heatmap)).toBeVisible({ timeout: T_LONG });
   });
 
+  test("legend is visible below the heatmap with Less and More labels", async () => {
+    const { window } = ctx;
+    const legend = window.locator(SEL.pulse.legend);
+    await expect(legend).toBeVisible({ timeout: T_MEDIUM });
+    await expect(legend).toContainText("Less", { timeout: T_SHORT });
+    await expect(legend).toContainText("More", { timeout: T_SHORT });
+  });
+
+  test("heatmap is described by a screen-reader-only intensity scale (issue #9819)", async () => {
+    const { window } = ctx;
+    const heatmap = window.locator(SEL.pulse.heatmap);
+    const describedBy = await heatmap.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    const description = window.locator(`#${describedBy}`);
+    await expect(description).toHaveCount(1);
+    await expect(description).toHaveText(/Heat intensity from few to many commits/);
+  });
+
   test("card header shows project name and default range", async () => {
     const { window } = ctx;
     const title = window.getByText(/pulse-test.*Project Pulse/i);

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -176,6 +176,7 @@ export const SEL = {
   },
   pulse: {
     heatmap: '[data-testid="pulse-heatmap"]',
+    legend: '[data-testid="pulse-heatmap-legend"]',
     rangeTrigger: '[aria-label="Activity range"]',
     refreshButton: '[aria-label="Refresh"]',
     lastUpdated: '[data-testid="pulse-last-updated"]',

--- a/src/components/Pulse/ProjectPulseCard.tsx
+++ b/src/components/Pulse/ProjectPulseCard.tsx
@@ -322,6 +322,22 @@ function OfflineHint() {
 
 const HEATMAP_LEGEND_GAP_PX = 3;
 
+// Explicit per-level switch (not a template literal) so the EXTENSION_KEYS
+// drift scanner registers each per-level var consumer individually. Mirrors
+// getHeatCellBackground() in PulseHeatmap.tsx.
+function getLegendSwatchBackground(level: 1 | 2 | 3 | 4): string {
+  switch (level) {
+    case 4:
+      return "var(--pulse-heat-4, var(--pulse-heat-color, var(--color-state-working)))";
+    case 3:
+      return "var(--pulse-heat-3, var(--pulse-heat-color, var(--color-state-working)))";
+    case 2:
+      return "var(--pulse-heat-2, var(--pulse-heat-color, var(--color-state-working)))";
+    default:
+      return "var(--pulse-heat-1, var(--pulse-heat-color, var(--color-state-working)))";
+  }
+}
+
 function PulseHeatmapLegend({
   dayCount,
   descriptionId,
@@ -342,7 +358,7 @@ function PulseHeatmapLegend({
         style={{ width: `${rowWidth}px`, gap: `${HEATMAP_LEGEND_GAP_PX}px` }}
       >
         <span>Less</span>
-        {[1, 2, 3, 4].map((level) => (
+        {([1, 2, 3, 4] as const).map((level) => (
           <span
             key={level}
             className="pulse-heat-cell relative overflow-hidden rounded-[2px] shrink-0"
@@ -350,7 +366,7 @@ function PulseHeatmapLegend({
             style={{
               width: 10,
               height: 10,
-              background: `var(--pulse-heat-${level}, var(--pulse-heat-color, var(--color-state-working)))`,
+              background: getLegendSwatchBackground(level),
             }}
           >
             {/* Inner shape span — display: none in default themes, flipped to

--- a/src/components/Pulse/ProjectPulseCard.tsx
+++ b/src/components/Pulse/ProjectPulseCard.tsx
@@ -345,14 +345,20 @@ function PulseHeatmapLegend({
         {[1, 2, 3, 4].map((level) => (
           <span
             key={level}
-            className="rounded-[2px] shrink-0"
+            className="pulse-heat-cell relative overflow-hidden rounded-[2px] shrink-0"
             data-heat-level={level}
             style={{
               width: 10,
               height: 10,
               background: `var(--pulse-heat-${level}, var(--pulse-heat-color, var(--color-state-working)))`,
             }}
-          />
+          >
+            {/* Inner shape span — display: none in default themes, flipped to
+                block by the @media (forced-colors: active) rule in
+                src/index.css. Reuses the cell-level size cue so the 4 swatches
+                stay distinguishable when the UA strips theme backgrounds. */}
+            <span aria-hidden="true" className="pulse-heat-cell-shape" />
+          </span>
         ))}
         <span>More</span>
       </div>

--- a/src/components/Pulse/ProjectPulseCard.tsx
+++ b/src/components/Pulse/ProjectPulseCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useRef, useState } from "react";
+import { useEffect, useCallback, useId, useRef, useState } from "react";
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 import { useShallow } from "zustand/react/shallow";
 import type { PulseRangeDays, ProjectPulse, ProjectHealthData } from "@shared/types";
@@ -22,7 +22,7 @@ import {
 import { Spinner } from "@/components/ui/Spinner";
 import { Activity } from "@/components/icons";
 import { GitHubIcon } from "@/components/icons/brands";
-import { PulseHeatmap } from "./PulseHeatmap";
+import { PulseHeatmap, getPulseHeatmapRowWidth } from "./PulseHeatmap";
 import { PulseSummary } from "./PulseSummary";
 import { useProjectHealth } from "@/hooks/useProjectHealth";
 import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
@@ -320,6 +320,46 @@ function OfflineHint() {
   );
 }
 
+const HEATMAP_LEGEND_GAP_PX = 3;
+
+function PulseHeatmapLegend({
+  dayCount,
+  descriptionId,
+}: {
+  dayCount: number;
+  descriptionId: string;
+}) {
+  const rowWidth = getPulseHeatmapRowWidth({ dayCount, compact: false });
+  return (
+    <>
+      <span id={descriptionId} className="sr-only">
+        Heat intensity from few to many commits
+      </span>
+      <div
+        aria-hidden="true"
+        data-testid="pulse-heatmap-legend"
+        className="flex items-center justify-end text-[10px] text-daintree-text/55 select-none"
+        style={{ width: `${rowWidth}px`, gap: `${HEATMAP_LEGEND_GAP_PX}px` }}
+      >
+        <span>Less</span>
+        {[1, 2, 3, 4].map((level) => (
+          <span
+            key={level}
+            className="rounded-[2px] shrink-0"
+            data-heat-level={level}
+            style={{
+              width: 10,
+              height: 10,
+              background: `var(--pulse-heat-${level}, var(--pulse-heat-color, var(--color-state-working)))`,
+            }}
+          />
+        ))}
+        <span>More</span>
+      </div>
+    </>
+  );
+}
+
 export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProps) {
   const projectName = useProjectStore((s) => s.currentProject?.name);
   const { health, loading: healthLoading, refresh: refreshHealth } = useProjectHealth();
@@ -337,6 +377,11 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
     );
 
   const title = projectName ? `${projectName} Project Pulse` : "Project Pulse";
+  // Stable id pair for the legend (aria-describedby link from the heatmap grid
+  // to a screen-reader description; the visual legend is aria-hidden because
+  // each cell already exposes its value via aria-label).
+  const baseId = useId();
+  const heatmapDescriptionId = `${baseId}-desc`;
 
   // Announce silent-refresh completion exactly once via a polite live region.
   // aria-busy alone does not satisfy WCAG 4.1.3 — assistive tech only re-reads
@@ -574,7 +619,13 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
       </div>
 
       <div className="p-4 space-y-4">
-        <PulseHeatmap cells={pulse.heatmap} rangeDays={pulse.rangeDays} />
+        <PulseHeatmap
+          cells={pulse.heatmap}
+          rangeDays={pulse.rangeDays}
+          describedBy={heatmapDescriptionId}
+        />
+
+        <PulseHeatmapLegend dayCount={pulse.heatmap.length} descriptionId={heatmapDescriptionId} />
 
         <p className="text-xs text-daintree-text/80">{getCoachLine(pulse)}</p>
 

--- a/src/components/Pulse/PulseHeatmap.tsx
+++ b/src/components/Pulse/PulseHeatmap.tsx
@@ -165,7 +165,11 @@ function PulseHeatmapCell({
           type="button"
           role="gridcell"
           data-cell-date={cell.date}
-          data-heat-level={cell.count > 0 ? cell.level : undefined}
+          // Clamp to >=1 for the CSS-level cue so a future renderer that emits
+          // a positive-count cell with level: 0 doesn't render a 0-sized
+          // CanvasText shape under forced-colors. The data layer currently
+          // never produces this combination, but the input type permits it.
+          data-heat-level={cell.count > 0 && cell.level > 0 ? Math.min(4, cell.level) : undefined}
           style={{
             width: `${cellSize}px`,
             height: `${cellSize}px`,

--- a/src/components/Pulse/PulseHeatmap.tsx
+++ b/src/components/Pulse/PulseHeatmap.tsx
@@ -8,6 +8,20 @@ interface PulseHeatmapProps {
   cells: HeatCell[];
   rangeDays: PulseRangeDays;
   compact?: boolean;
+  describedBy?: string;
+}
+
+export function getPulseHeatmapRowWidth({
+  dayCount,
+  compact,
+}: {
+  dayCount: number;
+  compact: boolean;
+}): number {
+  const columns = compact ? Math.min(COLUMNS_PER_ROW, dayCount) : COLUMNS_PER_ROW;
+  const cellSize = compact ? COMPACT_CELL_SIZE_PX : CELL_SIZE_PX;
+  const gap = compact ? COMPACT_GAP_PX : GAP_PX;
+  return columns > 0 ? cellSize * columns + gap * (columns - 1) : 0;
 }
 
 interface RenderCell extends HeatCell {
@@ -151,6 +165,7 @@ function PulseHeatmapCell({
           type="button"
           role="gridcell"
           data-cell-date={cell.date}
+          data-heat-level={cell.count > 0 ? cell.level : undefined}
           style={{
             width: `${cellSize}px`,
             height: `${cellSize}px`,
@@ -158,13 +173,15 @@ function PulseHeatmapCell({
             ...ringStyle,
           }}
           className={cn(
-            "rounded-[2px] shrink-0 border-0 p-0 cursor-default transition-[transform,background-color,box-shadow] duration-150",
+            "pulse-heat-cell relative overflow-hidden rounded-[2px] shrink-0 border-0 p-0 cursor-default transition-[transform,background-color,box-shadow] duration-150",
             cell.isMissedDay && "pulse-heat-cell-missed",
             cell.isMostRecentActive && "ring-1 ring-daintree-text/25 ring-offset-1"
           )}
           aria-label={`${formatted}: ${getTooltipText(cell)}`}
           tabIndex={isActive ? 0 : -1}
-        />
+        >
+          {cell.count > 0 && <span aria-hidden="true" className="pulse-heat-cell-shape" />}
+        </button>
       </TooltipTrigger>
       <TooltipContent side="top" className="text-xs">
         <span className="font-medium">{formatted}</span>
@@ -174,7 +191,12 @@ function PulseHeatmapCell({
   );
 }
 
-export function PulseHeatmap({ cells, rangeDays, compact = false }: PulseHeatmapProps) {
+export function PulseHeatmap({
+  cells,
+  rangeDays,
+  compact = false,
+  describedBy,
+}: PulseHeatmapProps) {
   const rows = useMemo(() => {
     const normalizedCells = [...cells]
       .filter((cell) => !Number.isNaN(new Date(cell.date).getTime()))
@@ -206,7 +228,7 @@ export function PulseHeatmap({ cells, rangeDays, compact = false }: PulseHeatmap
   const gap = compact ? COMPACT_GAP_PX : GAP_PX;
   const totalCells = rows.reduce((sum, r) => sum + r.length, 0);
   const columns = compact ? Math.min(COLUMNS_PER_ROW, totalCells) : COLUMNS_PER_ROW;
-  const rowWidth = columns > 0 ? cellSize * columns + gap * (columns - 1) : 0;
+  const rowWidth = getPulseHeatmapRowWidth({ dayCount: totalCells, compact });
 
   const cellRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
   const initialFocusKey = useMemo(() => {
@@ -349,6 +371,7 @@ export function PulseHeatmap({ cells, rangeDays, compact = false }: PulseHeatmap
       style={{ gap: `${gap}px`, width: `${rowWidth}px` }}
       role="grid"
       aria-label={`Activity over the last ${rangeDays} days`}
+      aria-describedby={describedBy}
       aria-rowcount={rows.length}
       aria-colcount={columns}
       data-testid="pulse-heatmap"

--- a/src/components/Pulse/__tests__/pulseContrast.test.ts
+++ b/src/components/Pulse/__tests__/pulseContrast.test.ts
@@ -5,6 +5,27 @@ import { resolve } from "path";
 const CARD_PATH = resolve(__dirname, "../ProjectPulseCard.tsx");
 const SUMMARY_PATH = resolve(__dirname, "../PulseSummary.tsx");
 const HEATMAP_PATH = resolve(__dirname, "../PulseHeatmap.tsx");
+const INDEX_CSS_PATH = resolve(__dirname, "../../../index.css");
+const PULSE_CSS_PATH = resolve(__dirname, "../../../styles/components/pulse.css");
+
+// Find a `@media (X)` opening brace and return the slice up to the matching
+// closing brace (or until the next top-level @media / @layer / @theme opens).
+// Forbids rules being placed in the wrong block — the dual-block guard.
+function mediaBlockSlice(content: string, mediaSelector: string): string {
+  const start = content.indexOf(mediaSelector);
+  if (start === -1) return "";
+  const openBrace = content.indexOf("{", start);
+  if (openBrace === -1) return "";
+  let depth = 1;
+  let i = openBrace + 1;
+  while (i < content.length && depth > 0) {
+    const ch = content[i];
+    if (ch === "{") depth += 1;
+    else if (ch === "}") depth -= 1;
+    i += 1;
+  }
+  return content.slice(openBrace, i);
+}
 
 describe("ProjectPulseCard — visual contrast (issue #2645)", () => {
   it("card shell uses pulse component vars for per-theme shell styling", async () => {
@@ -197,5 +218,112 @@ describe("ProjectPulseCard — accessibility (issue #7229)", () => {
   it("refresh spinner respects motion-reduce", async () => {
     const content = await readFile(CARD_PATH, "utf-8");
     expect(content).toContain("motion-reduce:animate-none");
+  });
+});
+
+describe("PulseHeatmap — legend (issue #9819)", () => {
+  it("ProjectPulseCard renders the legend testid", async () => {
+    const content = await readFile(CARD_PATH, "utf-8");
+    expect(content).toContain('data-testid="pulse-heatmap-legend"');
+  });
+
+  it("legend swatches are keyed by data-heat-level 1..4", async () => {
+    const content = await readFile(CARD_PATH, "utf-8");
+    expect(content).toContain("data-heat-level={level}");
+    expect(content).toContain("var(--pulse-heat-${level}");
+    // The template iterates [1,2,3,4]; verify the array is present so the
+    // literal substring check is anchored to the right loop.
+    expect(content).toContain("[1, 2, 3, 4]");
+  });
+
+  it("legend uses Less and More labels", async () => {
+    const content = await readFile(CARD_PATH, "utf-8");
+    expect(content).toContain(">Less<");
+    expect(content).toContain(">More<");
+  });
+
+  it("legend is decorative (aria-hidden) and ships an sr-only description for aria-describedby", async () => {
+    const content = await readFile(CARD_PATH, "utf-8");
+    expect(content).toContain('aria-hidden="true"');
+    expect(content).toContain("Heat intensity from few to many commits");
+    expect(content).toContain("useId()");
+    expect(content).toContain("describedBy=");
+  });
+
+  it("legend does NOT use the accent color (CLAUDE.md accent restraint)", async () => {
+    const content = await readFile(CARD_PATH, "utf-8");
+    // Strip the health-chip palette entry — it's a `tone: "accent"` chip on a
+    // separate surface, not part of the legend chrome.
+    const legendBlock = content.match(/function PulseHeatmapLegend[\s\S]*?^}/m);
+    expect(legendBlock).toBeTruthy();
+    expect(legendBlock![0]).not.toContain("text-accent-primary");
+    expect(legendBlock![0]).not.toContain("var(--color-accent-primary)");
+    expect(legendBlock![0]).not.toContain("ring-daintree-accent");
+  });
+
+  it("legend shares the heatmap row width via getPulseHeatmapRowWidth", async () => {
+    const content = await readFile(CARD_PATH, "utf-8");
+    expect(content).toContain("getPulseHeatmapRowWidth");
+  });
+});
+
+describe("PulseHeatmap — high-contrast shape cue (issue #9819)", () => {
+  it("PulseHeatmap tags non-empty cells with data-heat-level and a shape span", async () => {
+    const content = await readFile(HEATMAP_PATH, "utf-8");
+    expect(content).toContain("data-heat-level={cell.count > 0 ? cell.level : undefined}");
+    expect(content).toContain("pulse-heat-cell-shape");
+    expect(content).toContain('"pulse-heat-cell');
+  });
+
+  it("PulseHeatmap accepts a describedBy prop and applies aria-describedby", async () => {
+    const content = await readFile(HEATMAP_PATH, "utf-8");
+    expect(content).toContain("describedBy?: string");
+    expect(content).toContain("aria-describedby={describedBy}");
+  });
+
+  it("pulse.css defines a hidden base rule for the shape (default off, forced-colors flips on)", async () => {
+    const content = await readFile(PULSE_CSS_PATH, "utf-8");
+    expect(content).toContain(".pulse-heat-cell-shape");
+    expect(content).toMatch(/\.pulse-heat-cell-shape\s*{[^}]*display:\s*none/);
+    expect(content).toMatch(/\.pulse-heat-cell-shape\s*{[^}]*position:\s*absolute/);
+  });
+
+  it("forced-colors block paints the shape with CanvasText and sizes it per level", async () => {
+    const content = await readFile(INDEX_CSS_PATH, "utf-8");
+    const block = mediaBlockSlice(content, "@media (forced-colors: active)");
+    expect(block).toContain(".pulse-heat-cell-shape");
+    expect(block).toContain("CanvasText");
+    expect(block).toContain('.pulse-heat-cell[data-heat-level="1"] .pulse-heat-cell-shape');
+    expect(block).toContain('.pulse-heat-cell[data-heat-level="2"] .pulse-heat-cell-shape');
+    expect(block).toContain('.pulse-heat-cell[data-heat-level="3"] .pulse-heat-cell-shape');
+    expect(block).toContain('.pulse-heat-cell[data-heat-level="4"] .pulse-heat-cell-shape');
+  });
+
+  it("forced-colors block distinguishes missed-day via a solid CanvasText fill", async () => {
+    const content = await readFile(INDEX_CSS_PATH, "utf-8");
+    const block = mediaBlockSlice(content, "@media (forced-colors: active)");
+    expect(block).toContain(".pulse-heat-cell-missed");
+    // Missed cell must be the more salient signal (filled, not empty).
+    expect(block).toMatch(/\.pulse-heat-cell-missed\s*{[^}]*background:\s*CanvasText/);
+  });
+
+  it("prefers-contrast block bumps heat-cell border to 1px theme-text", async () => {
+    const content = await readFile(INDEX_CSS_PATH, "utf-8");
+    const block = mediaBlockSlice(content, "@media (prefers-contrast: more)");
+    expect(block).toContain(".pulse-heat-cell");
+    expect(block).toMatch(/\.pulse-heat-cell\s*{[^}]*border-width:\s*1px/);
+    expect(block).toContain("border-color: var(--color-daintree-text)");
+  });
+
+  it("the two contrast blocks stay separate (CLAUDE.md dual-block guard)", async () => {
+    const content = await readFile(INDEX_CSS_PATH, "utf-8");
+    const forcedStart = content.indexOf("@media (forced-colors: active)");
+    const contrastStart = content.indexOf("@media (prefers-contrast: more)");
+    expect(forcedStart).toBeGreaterThan(-1);
+    expect(contrastStart).toBeGreaterThan(forcedStart);
+    // The forced-colors block must close before the prefers-contrast block opens.
+    const forcedBlock = mediaBlockSlice(content, "@media (forced-colors: active)");
+    const forcedEnd = content.indexOf(forcedBlock) + forcedBlock.length;
+    expect(forcedEnd).toBeLessThanOrEqual(contrastStart);
   });
 });

--- a/src/components/Pulse/__tests__/pulseContrast.test.ts
+++ b/src/components/Pulse/__tests__/pulseContrast.test.ts
@@ -230,7 +230,11 @@ describe("PulseHeatmap — legend (issue #9819)", () => {
   it("legend swatches are keyed by data-heat-level 1..4", async () => {
     const content = await readFile(CARD_PATH, "utf-8");
     expect(content).toContain("data-heat-level={level}");
-    expect(content).toContain("var(--pulse-heat-${level}");
+    // Each per-level var is referenced explicitly (not via template literal)
+    // so the EXTENSION_KEYS drift scanner registers all four consumers.
+    for (const level of [1, 2, 3, 4]) {
+      expect(content).toContain(`var(--pulse-heat-${level},`);
+    }
     // The template iterates [1,2,3,4]; verify the array is present so the
     // literal substring check is anchored to the right loop.
     expect(content).toContain("[1, 2, 3, 4]");

--- a/src/components/Pulse/__tests__/pulseContrast.test.ts
+++ b/src/components/Pulse/__tests__/pulseContrast.test.ts
@@ -265,12 +265,26 @@ describe("PulseHeatmap — legend (issue #9819)", () => {
     const content = await readFile(CARD_PATH, "utf-8");
     expect(content).toContain("getPulseHeatmapRowWidth");
   });
+
+  it("legend swatches reuse the pulse-heat-cell shape cue so they stay distinguishable in forced-colors", async () => {
+    const content = await readFile(CARD_PATH, "utf-8");
+    // Each swatch is a pulse-heat-cell with an inner shape span, so the
+    // forced-colors size rules in src/index.css size the inner CanvasText
+    // square per level — sighted WHCM users see the same 4-step cue on the
+    // legend as on the grid itself.
+    expect(content).toContain("pulse-heat-cell relative overflow-hidden");
+    expect(content).toMatch(/pulse-heat-cell-shape/);
+  });
 });
 
 describe("PulseHeatmap — high-contrast shape cue (issue #9819)", () => {
   it("PulseHeatmap tags non-empty cells with data-heat-level and a shape span", async () => {
     const content = await readFile(HEATMAP_PATH, "utf-8");
-    expect(content).toContain("data-heat-level={cell.count > 0 ? cell.level : undefined}");
+    // Clamp to >=1 so a future renderer emitting (count > 0, level: 0) doesn't
+    // produce a 0-sized CanvasText shape under forced-colors. The current
+    // ProjectPulseService never emits this combination; the clamp is
+    // defensive.
+    expect(content).toContain("cell.count > 0 && cell.level > 0");
     expect(content).toContain("pulse-heat-cell-shape");
     expect(content).toContain('"pulse-heat-cell');
   });

--- a/src/index.css
+++ b/src/index.css
@@ -2936,6 +2936,41 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
   [role="switch"][data-state] span[data-state="unchecked"] {
     background-color: ButtonText;
   }
+
+  /* Project Pulse heatmap (issue #9819). Theme-authored backgrounds collapse
+   * to Canvas under forced-colors, so the four heat levels + missed-day cell
+   * become indistinguishable. Use a system-paint + size-coded inner square
+   * (GitHub's 2023+ contribution-graph approach) keyed off data-heat-level,
+   * and a solid fill for the missed-day streak-break signal. The shape span
+   * is rendered always (display: none baseline) so theme switches don't
+   * reflow; the !important on the heat cell background is required to beat
+   * the inline author style set in PulseHeatmap.getCellStyle. */
+  .pulse-heat-cell {
+    background: Canvas !important;
+  }
+  .pulse-heat-cell-shape {
+    display: block;
+    background: CanvasText !important;
+  }
+  .pulse-heat-cell[data-heat-level="1"] .pulse-heat-cell-shape {
+    width: 35%;
+    height: 35%;
+  }
+  .pulse-heat-cell[data-heat-level="2"] .pulse-heat-cell-shape {
+    width: 55%;
+    height: 55%;
+  }
+  .pulse-heat-cell[data-heat-level="3"] .pulse-heat-cell-shape {
+    width: 75%;
+    height: 75%;
+  }
+  .pulse-heat-cell[data-heat-level="4"] .pulse-heat-cell-shape {
+    width: 90%;
+    height: 90%;
+  }
+  .pulse-heat-cell-missed {
+    background: CanvasText !important;
+  }
 }
 
 /* Increased contrast mode — heavier borders for visibility.
@@ -2988,6 +3023,16 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
    * utility rule has equal specificity (0,1,0) and wins on source order. */
   [class*="text-daintree-text/"] {
     color: var(--color-daintree-text) !important;
+  }
+
+  /* Project Pulse heatmap (issue #9819). On macOS Increase Contrast the theme
+   * backgrounds still render, but low-alpha heat cells can wash out. A 1px
+   * theme-text border (overriding `border-0` in PulseHeatmap) gives every
+   * cell a visible boundary so the four levels stay distinguishable. */
+  .pulse-heat-cell {
+    border-width: 1px;
+    border-style: solid;
+    border-color: var(--color-daintree-text);
   }
 }
 

--- a/src/styles/components/pulse.css
+++ b/src/styles/components/pulse.css
@@ -50,6 +50,19 @@
   background: var(--pulse-missed-bg, var(--theme-status-danger));
 }
 
+/* Forced-colors shape cue: a child element painted with CanvasText whose size
+ * scales with the heat level, so the four levels stay distinguishable when the
+ * UA strips theme background colors (issue #9819). Display is none by default;
+ * the @media (forced-colors: active) block in src/index.css flips it to block.
+ * `position: absolute; inset: 0; margin: auto` centres the sized square. */
+.pulse-heat-cell-shape {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  display: none;
+  pointer-events: none;
+}
+
 /* Shape cue for the missed-day cell (P-Heat): a destructive-tier inset ring so
  * the streak-break signal survives colour-vision deficiency and never reads as
  * just another heat level. Inset box-shadow keeps the cell footprint identical


### PR DESCRIPTION
## Summary
- Adds a `Less/More` legend under the project pulse contribution heatmap, so the 4-step intensity scale stops being self-explanatory by inspection.
- Adds high-contrast support across both required media blocks: a `data-heat-level`-sized inner square painted with `CanvasText` for `forced-colors: active` (Windows), and a 1px theme-text border for `prefers-contrast: more` (macOS Increase Contrast).
- Missed-day streak-break cell now reads as a solid `CanvasText` fill under forced-colors, so it stays distinct from the four heat levels.

The two media blocks stay separate on purpose — macOS Increase Contrast fires only `prefers-contrast: more`, Windows fires only `forced-colors: active`, and consolidating them breaks one or the other. The dual-block invariant is locked in by a unit test.

## Changes
- `src/components/Pulse/ProjectPulseCard.tsx` — new `PulseHeatmapLegend` component (aria-hidden, sr-only description linked via `aria-describedby`), 4 `pulse-heat-cell` swatches keyed by `data-heat-level` so they share the forced-colors shape cue with the grid.
- `src/components/Pulse/PulseHeatmap.tsx` — accepts `describedBy`, tags non-empty cells with a clamped `data-heat-level` and an inner shape span, exports `getPulseHeatmapRowWidth` so the legend aligns with the grid.
- `src/index.css` — `@media (forced-colors: active)` block paints `.pulse-heat-cell` with `Canvas` and sizes the shape span per level (35 / 55 / 75 / 90%); `@media (prefers-contrast: more)` block bumps heat cells to a 1px theme-text border.
- `src/styles/components/pulse.css` — adds the `.pulse-heat-cell-shape` baseline (display: none, positioned, pointer-events: none) that the forced-colors block flips on.
- Legend deliberately avoids `--color-accent-primary` / `text-accent-primary` / `ring-daintree-accent`, per the project's accent-restraint rule.
- Unit tests cover legend rendering, accent-color absence, the `data-heat-level` / shape-span wiring, both CSS media blocks, and the dual-block guard.
- E2E test (`e2e/full/panels/core-pulse.spec.ts`) covers legend visibility and the `aria-describedby` link.

## Testing
- `npm run check` — all 10 verify checks pass.
- 42 unit tests pass (project pulse + legend + high-contrast coverage).
- E2E spec added to `e2e/full/panels/core-pulse.spec.ts`; new selector `pulse.legend` in `e2e/helpers/selectors.ts`.

Resolves #9819