### PR TITLE
fix(theme): open fill step between hover and armed toolbar states on dark themes (#9827)

### DIFF
--- a/shared/theme/__tests__/builtInThemes.test.ts
+++ b/shared/theme/__tests__/builtInThemes.test.ts
@@ -381,50 +381,58 @@ describe("built-in themes", () => {
       }
 
       // Cross-key invariant: on dark, the toolbar-control armed/active fill
-      // must read as MORE prominent than the hover fill (#9827). Without this
-      // the armed and hover fills both fall through to overlay-emphasis
-      // (alpha 0.10) and the only signal separating them is a 1px hairline
-      // — the user can't see the toggle is on. The minimum step is 0.03 to
-      // leave room for the per-theme tint families (daintree/galapagos/etc.)
-      // while still rejecting a future "armed = hover" regression.
-      const toolbarHover = extensions["toolbar-control-hover-bg"];
-      const toolbarArmed = extensions["toolbar-control-armed-bg"];
-      const toolbarActive = extensions["toolbar-control-active-bg"];
-      if (toolbarHover !== undefined && toolbarArmed !== undefined && toolbarActive !== undefined) {
-        const hoverAlpha = parseAlpha(toolbarHover);
-        const armedAlpha = parseAlpha(toolbarArmed);
-        const activeAlpha = parseAlpha(toolbarActive);
-        if (Number.isNaN(hoverAlpha) || Number.isNaN(armedAlpha) || Number.isNaN(activeAlpha)) {
-          failures.push(
-            `${source.id} toolbar-control alpha unparseable; got hover="${toolbarHover}" ` +
-              `armed="${toolbarArmed}" active="${toolbarActive}"`
-          );
-        } else {
-          if (!(armedAlpha > hoverAlpha)) {
+      // must read as MORE prominent than the hover fill, with at least a
+      // +0.04 alpha step (#9827). Without this the armed and hover fills
+      // both fall through to overlay-emphasis (alpha 0.10) and the only
+      // signal separating them is a 1px hairline — the user can't see the
+      // toggle is on. Presence is enforced structurally by
+      // TOOLBAR_ARMED_FILL in the extension registry (required for dark,
+      // forbidWhenNotRequired for light); this block is the relationship
+      // check on top of structural enforcement.
+      if (polarity === "dark") {
+        const toolbarHover = extensions["toolbar-control-hover-bg"];
+        const toolbarArmed = extensions["toolbar-control-armed-bg"];
+        const toolbarActive = extensions["toolbar-control-active-bg"];
+        if (
+          toolbarHover !== undefined &&
+          toolbarArmed !== undefined &&
+          toolbarActive !== undefined
+        ) {
+          const hoverAlpha = parseAlpha(toolbarHover);
+          const armedAlpha = parseAlpha(toolbarArmed);
+          const activeAlpha = parseAlpha(toolbarActive);
+          if (Number.isNaN(hoverAlpha) || Number.isNaN(armedAlpha) || Number.isNaN(activeAlpha)) {
             failures.push(
-              `${source.id} toolbar-control-armed-bg (alpha ${armedAlpha}) must be stronger ` +
-                `than toolbar-control-hover-bg (alpha ${hoverAlpha})`
+              `${source.id} toolbar-control alpha unparseable; got hover="${toolbarHover}" ` +
+                `armed="${toolbarArmed}" active="${toolbarActive}"`
             );
-          }
-          if (!(activeAlpha > hoverAlpha)) {
-            failures.push(
-              `${source.id} toolbar-control-active-bg (alpha ${activeAlpha}) must be stronger ` +
-                `than toolbar-control-hover-bg (alpha ${hoverAlpha})`
-            );
-          }
-          if (armedAlpha - hoverAlpha < 0.03) {
-            failures.push(
-              `${source.id} toolbar-control armed-vs-hover alpha step ` +
-                `(${(armedAlpha - hoverAlpha).toFixed(2)}) is below the 0.03 minimum; the ` +
-                `fill separation will be invisible (#9827)`
-            );
-          }
-          if (activeAlpha - hoverAlpha < 0.03) {
-            failures.push(
-              `${source.id} toolbar-control active-vs-hover alpha step ` +
-                `(${(activeAlpha - hoverAlpha).toFixed(2)}) is below the 0.03 minimum; the ` +
-                `fill separation will be invisible (#9827)`
-            );
+          } else {
+            if (!(armedAlpha > hoverAlpha)) {
+              failures.push(
+                `${source.id} toolbar-control-armed-bg (alpha ${armedAlpha}) must be stronger ` +
+                  `than toolbar-control-hover-bg (alpha ${hoverAlpha})`
+              );
+            }
+            if (!(activeAlpha > hoverAlpha)) {
+              failures.push(
+                `${source.id} toolbar-control-active-bg (alpha ${activeAlpha}) must be stronger ` +
+                  `than toolbar-control-hover-bg (alpha ${hoverAlpha})`
+              );
+            }
+            if (armedAlpha - hoverAlpha < 0.04 - MIN_STEP_TOLERANCE) {
+              failures.push(
+                `${source.id} toolbar-control armed-vs-hover alpha step ` +
+                  `(${(armedAlpha - hoverAlpha).toFixed(2)}) is below the 0.04 minimum; the ` +
+                  `fill separation will be invisible (#9827)`
+              );
+            }
+            if (activeAlpha - hoverAlpha < 0.04 - MIN_STEP_TOLERANCE) {
+              failures.push(
+                `${source.id} toolbar-control active-vs-hover alpha step ` +
+                  `(${(activeAlpha - hoverAlpha).toFixed(2)}) is below the 0.04 minimum; the ` +
+                  `fill separation will be invisible (#9827)`
+              );
+            }
           }
         }
       }
@@ -784,6 +792,14 @@ function parseAlpha(value: string): number {
   const match = value.match(/rgba?\([^)]*?,\s*([0-9.]+)\s*\)/);
   return match ? Number(match[1]) : NaN;
 }
+
+// Epsilon for the toolbar-control alpha-step floor: rgba alpha values are
+// specified to 2 decimal places, but the difference of two such values can
+// drift below the spec value by a few ULPs of IEEE-754 (e.g. 0.12 - 0.08
+// computes as 0.03999999999999999, not 0.04). The tolerance below is
+// generous enough to absorb that drift without letting a 0.00 step slip
+// through (1e-9 is many orders of magnitude under the 0.01 UI threshold).
+const MIN_STEP_TOLERANCE = 1e-9;
 
 function hexToRgbTuple(hex: string): [number, number, number] {
   const clean = hex.replace("#", "");

--- a/shared/theme/__tests__/builtInThemes.test.ts
+++ b/shared/theme/__tests__/builtInThemes.test.ts
@@ -380,6 +380,55 @@ describe("built-in themes", () => {
         }
       }
 
+      // Cross-key invariant: on dark, the toolbar-control armed/active fill
+      // must read as MORE prominent than the hover fill (#9827). Without this
+      // the armed and hover fills both fall through to overlay-emphasis
+      // (alpha 0.10) and the only signal separating them is a 1px hairline
+      // — the user can't see the toggle is on. The minimum step is 0.03 to
+      // leave room for the per-theme tint families (daintree/galapagos/etc.)
+      // while still rejecting a future "armed = hover" regression.
+      const toolbarHover = extensions["toolbar-control-hover-bg"];
+      const toolbarArmed = extensions["toolbar-control-armed-bg"];
+      const toolbarActive = extensions["toolbar-control-active-bg"];
+      if (toolbarHover !== undefined && toolbarArmed !== undefined && toolbarActive !== undefined) {
+        const hoverAlpha = parseAlpha(toolbarHover);
+        const armedAlpha = parseAlpha(toolbarArmed);
+        const activeAlpha = parseAlpha(toolbarActive);
+        if (Number.isNaN(hoverAlpha) || Number.isNaN(armedAlpha) || Number.isNaN(activeAlpha)) {
+          failures.push(
+            `${source.id} toolbar-control alpha unparseable; got hover="${toolbarHover}" ` +
+              `armed="${toolbarArmed}" active="${toolbarActive}"`
+          );
+        } else {
+          if (!(armedAlpha > hoverAlpha)) {
+            failures.push(
+              `${source.id} toolbar-control-armed-bg (alpha ${armedAlpha}) must be stronger ` +
+                `than toolbar-control-hover-bg (alpha ${hoverAlpha})`
+            );
+          }
+          if (!(activeAlpha > hoverAlpha)) {
+            failures.push(
+              `${source.id} toolbar-control-active-bg (alpha ${activeAlpha}) must be stronger ` +
+                `than toolbar-control-hover-bg (alpha ${hoverAlpha})`
+            );
+          }
+          if (armedAlpha - hoverAlpha < 0.03) {
+            failures.push(
+              `${source.id} toolbar-control armed-vs-hover alpha step ` +
+                `(${(armedAlpha - hoverAlpha).toFixed(2)}) is below the 0.03 minimum; the ` +
+                `fill separation will be invisible (#9827)`
+            );
+          }
+          if (activeAlpha - hoverAlpha < 0.03) {
+            failures.push(
+              `${source.id} toolbar-control active-vs-hover alpha step ` +
+                `(${(activeAlpha - hoverAlpha).toFixed(2)}) is below the 0.03 minimum; the ` +
+                `fill separation will be invisible (#9827)`
+            );
+          }
+        }
+      }
+
       // Extra-key regression: no built-in source ships an unregistered extension
       // key. TypeScript enforces this at compile time, but a runtime check
       // catches `as unknown as` casts and ad-hoc fixture mutations.

--- a/shared/theme/builtInThemes/arashiyama.ts
+++ b/shared/theme/builtInThemes/arashiyama.ts
@@ -113,6 +113,8 @@ export const theme: BuiltInThemeSource = {
     "sidebar-active-bg": "rgba(255,255,255,0.05)",
     "sidebar-hover-bg": "rgba(255,255,255,0.03)",
     "toolbar-agent-hover-bg": "rgba(241,235,228,0.08)",
+    "toolbar-control-active-bg": "rgba(241,235,228,0.12)",
+    "toolbar-control-armed-bg": "rgba(241,235,228,0.12)",
     "toolbar-control-armed-shadow": "inset 0 0 0 1px rgba(255,255,255,0.12)",
     "toolbar-control-hover-bg": "rgba(241,235,228,0.08)",
     "toolbar-control-hover-fg": "#B85733",

--- a/shared/theme/builtInThemes/daintree.ts
+++ b/shared/theme/builtInThemes/daintree.ts
@@ -108,6 +108,8 @@ export const theme: BuiltInThemeSource = {
     "sidebar-active-bg": "rgba(255,255,255,0.05)",
     "sidebar-hover-bg": "rgba(255,255,255,0.03)",
     "toolbar-agent-hover-bg": "rgba(255,255,255,0.06)",
+    "toolbar-control-active-bg": "rgba(255,255,255,0.14)",
+    "toolbar-control-armed-bg": "rgba(255,255,255,0.14)",
     "toolbar-control-armed-shadow": "inset 0 0 0 1px rgba(255,255,255,0.12)",
     "toolbar-control-hover-bg": "rgba(255,255,255,0.10)",
     "toolbar-divider": "rgba(40,40,40,0.5)",

--- a/shared/theme/builtInThemes/fiordland.ts
+++ b/shared/theme/builtInThemes/fiordland.ts
@@ -117,6 +117,8 @@ export const theme: BuiltInThemeSource = {
     "sidebar-active-bg": "rgba(255,255,255,0.05)",
     "sidebar-hover-bg": "rgba(255,255,255,0.03)",
     "toolbar-agent-hover-bg": "rgba(180,220,240,0.06)",
+    "toolbar-control-active-bg": "rgba(180,220,240,0.14)",
+    "toolbar-control-armed-bg": "rgba(180,220,240,0.14)",
     "toolbar-control-armed-shadow": "inset 0 0 0 1px rgba(255,255,255,0.12)",
     "toolbar-control-hover-bg": "rgba(180,220,240,0.10)",
     "toolbar-divider": "rgba(28,46,64,0.5)",

--- a/shared/theme/builtInThemes/galapagos.ts
+++ b/shared/theme/builtInThemes/galapagos.ts
@@ -116,6 +116,8 @@ export const theme: BuiltInThemeSource = {
     "sidebar-active-bg": "rgba(255,255,255,0.05)",
     "sidebar-hover-bg": "rgba(255,255,255,0.03)",
     "toolbar-agent-hover-bg": "rgba(74,158,127,0.06)",
+    "toolbar-control-active-bg": "rgba(74,158,127,0.14)",
+    "toolbar-control-armed-bg": "rgba(74,158,127,0.14)",
     "toolbar-control-armed-shadow": "inset 0 0 0 1px rgba(255,255,255,0.12)",
     "toolbar-control-hover-bg": "rgba(74,158,127,0.10)",
     "toolbar-divider": "rgba(42,58,53,0.5)",

--- a/shared/theme/builtInThemes/highlands.ts
+++ b/shared/theme/builtInThemes/highlands.ts
@@ -113,6 +113,8 @@ export const theme: BuiltInThemeSource = {
     "sidebar-active-bg": "rgba(255,255,255,0.05)",
     "sidebar-hover-bg": "rgba(255,255,255,0.03)",
     "toolbar-agent-hover-bg": "rgba(195,185,210,0.06)",
+    "toolbar-control-active-bg": "rgba(195,185,210,0.14)",
+    "toolbar-control-armed-bg": "rgba(195,185,210,0.14)",
     "toolbar-control-armed-shadow": "inset 0 0 0 1px rgba(255,255,255,0.12)",
     "toolbar-control-hover-bg": "rgba(195,185,210,0.10)",
     "toolbar-divider": "rgba(60,55,66,0.5)",

--- a/shared/theme/builtInThemes/namib.ts
+++ b/shared/theme/builtInThemes/namib.ts
@@ -116,6 +116,8 @@ export const theme: BuiltInThemeSource = {
     "sidebar-active-bg": "rgba(255,255,255,0.05)",
     "sidebar-hover-bg": "rgba(255,255,255,0.03)",
     "toolbar-agent-hover-bg": "rgba(200,180,150,0.05)",
+    "toolbar-control-active-bg": "rgba(200,180,150,0.10)",
+    "toolbar-control-armed-bg": "rgba(200,180,150,0.10)",
     "toolbar-control-armed-shadow": "inset 0 0 0 1px rgba(255,255,255,0.12)",
     "toolbar-control-hover-bg": "rgba(200,180,150,0.06)",
     "toolbar-divider": "rgba(51,45,37,0.5)",

--- a/shared/theme/builtInThemes/redwoods.ts
+++ b/shared/theme/builtInThemes/redwoods.ts
@@ -110,6 +110,8 @@ export const theme: BuiltInThemeSource = {
     "sidebar-active-bg": "rgba(255,255,255,0.05)",
     "sidebar-hover-bg": "rgba(255,255,255,0.03)",
     "toolbar-agent-hover-bg": "rgba(180,140,120,0.08)",
+    "toolbar-control-active-bg": "rgba(180,140,120,0.14)",
+    "toolbar-control-armed-bg": "rgba(180,140,120,0.14)",
     "toolbar-control-armed-shadow": "inset 0 0 0 1px rgba(255,255,255,0.12)",
     "toolbar-control-hover-bg": "rgba(180,140,120,0.10)",
     "toolbar-divider": "rgba(54,36,26,0.5)",

--- a/shared/theme/extensionRegistry.ts
+++ b/shared/theme/extensionRegistry.ts
@@ -88,6 +88,37 @@ const TOOLBAR_ARMED: ExtensionKeyMetadata = {
   formatGuard: /inset\s+0\s+0\s+0\s+1px/,
 };
 
+// toolbar-control-hover-bg / toolbar-control-armed-bg / toolbar-control-active-bg
+// are polarity-conditional. On DARK, all three are required: without the
+// hover/armed/active overrides the CSS fallback to --theme-overlay-emphasis
+// (alpha 0.10) collapses armed and hover to the same fill, leaving only a 1px
+// hairline to signal the toggle (#9827). Per-theme tints differ (white,
+// green, warm, sand, cool slate, cream), so no expectedTint regex is
+// enforced at the registry level — the per-key alpha range + the
+// builtInThemes.test.ts relationship check together defend the spec.
+//
+// toolbar-control-hover-bg is also set by every light theme (their armed/
+// hover separation comes from #8175), so the hover key carries no
+// forbidWhenNotRequired — the existing light values are valid. Only the
+// armed/active pair forbids light overrides: a dark white-alpha copy-paste
+// would invert the layer order on a light toolbar.
+const TOOLBAR_HOVER_FILL: ExtensionKeyMetadata = {
+  required: (mode) => mode === "dark",
+  perceptibility: {
+    minAlpha: { dark: 0.05 },
+    maxAlpha: { dark: 0.2 },
+  },
+};
+
+const TOOLBAR_ARMED_FILL: ExtensionKeyMetadata = {
+  required: (mode) => mode === "dark",
+  forbidWhenNotRequired: true,
+  perceptibility: {
+    minAlpha: { dark: 0.05 },
+    maxAlpha: { dark: 0.3 },
+  },
+};
+
 const DOCK_SHADOW: ExtensionKeyMetadata = {
   required: false,
   formatGuard: /rgb\(from var\(--theme-shadow-color\) r g b \/ ([0-9.]+)\)/,
@@ -187,10 +218,10 @@ export const EXTENSION_KEY_REGISTRY = {
   // ship a per-theme white-tinted ring for crispness on dark chrome.
   "toolbar-agent-hover-bg": OPTIONAL,
   "toolbar-bg": OPTIONAL,
-  "toolbar-control-active-bg": OPTIONAL,
-  "toolbar-control-armed-bg": OPTIONAL,
+  "toolbar-control-active-bg": TOOLBAR_ARMED_FILL,
+  "toolbar-control-armed-bg": TOOLBAR_ARMED_FILL,
   "toolbar-control-armed-shadow": TOOLBAR_ARMED,
-  "toolbar-control-hover-bg": OPTIONAL,
+  "toolbar-control-hover-bg": TOOLBAR_HOVER_FILL,
   "toolbar-control-hover-fg": OPTIONAL,
   "toolbar-control-hover-shadow": OPTIONAL,
   "toolbar-divider": OPTIONAL,


### PR DESCRIPTION
## Summary

Dark built-in themes (Daintree, Highlands, Fiordland, Galapagos, Redwoods, Namib, Arashiyama) all pinned `toolbar-control-hover-bg` at 0.10 alpha, which is exactly the value the armed state fell back to via `overlay-emphasis`. Hover and armed looked almost identical, with the only real distinction being the 1px white ring. The same collapse happened on press/active.

This change adds `toolbar-control-armed-bg` and `toolbar-control-active-bg` overrides for each of the 7 dark themes, opening a roughly 4% fill step between hover and armed/active. The CSS fallback chain is left untouched; dark themes opt in via per-theme tokens on the extension registry. A follow-up commit enforces the gap structurally so it can't silently regress.

Resolves #9827

## Changes

- `shared/theme/extensionRegistry.ts` — add per-theme tokens for `toolbar-control-armed-bg` and `toolbar-control-active-bg`
- `shared/theme/builtInThemes/daintree.ts`, `highlands.ts`, `fiordland.ts`, `galapagos.ts`, `redwoods.ts`, `namib.ts`, `arashiyama.ts` — opt each into the new tokens
- `shared/theme/__tests__/builtInThemes.test.ts` — assert the fill step holds across all 7 dark themes

## Testing

- `npm run fix` and `npm run typecheck` clean for the touched files
- New structural guard in `builtInThemes.test.ts` prevents the gap from regressing
- Visually verified across all 7 dark themes