### PR TITLE
feat(terminal): add held-duration, queue-depth, and data-loss gauges to reliability-metric

### DIFF
--- a/electron/__tests__/pty-host.adversarial.test.ts
+++ b/electron/__tests__/pty-host.adversarial.test.ts
@@ -579,7 +579,7 @@ vi.mock("../pty-host/index.js", async () => {
   };
 });
 
-import { BACKPRESSURE_SAFETY_TIMEOUT_MS } from "../pty-host/index.js";
+import { BACKPRESSURE_SAFETY_TIMEOUT_MS, metricsEnabled } from "../pty-host/index.js";
 import { getPtyPool } from "../services/PtyPool.js";
 
 const originalParentPortDescriptor = Object.getOwnPropertyDescriptor(process, "parentPort");
@@ -632,6 +632,8 @@ describe("pty-host adversarial", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.mocked(getPtyPool).mockClear();
+    // Restore the module-default (metrics off) so per-test overrides don't leak.
+    vi.mocked(metricsEnabled).mockReturnValue(false);
   });
 
   afterEach(async () => {
@@ -701,6 +703,9 @@ describe("pty-host adversarial", () => {
   });
 
   it("IPC_QUEUE_FULL_EMITS_DATA_LOSS_STATUS", async () => {
+    // Metrics on so the gated reliability-metric wire emission fires; the
+    // data-loss status event is ungated and fires regardless.
+    vi.mocked(metricsEnabled).mockReturnValue(true);
     const parentPort = await loadHost();
     const terminal = createTerminal("t1");
     hostState.terminals.set("t1", terminal);
@@ -731,20 +736,34 @@ describe("pty-host adversarial", () => {
     });
 
     // The reliability metric must still fire alongside the new status event —
-    // existing telemetry consumers must keep working.
-    const backpressure = hostState.backpressureManagers[0];
-    expect(backpressure.emitReliabilityMetric).toHaveBeenCalledTimes(1);
-    expect(backpressure.emitReliabilityMetric).toHaveBeenCalledWith(
-      expect.objectContaining({
+    // existing telemetry consumers must keep working. The host funnel
+    // (`emitReliabilityMetricWithTracking`) TERMINATES the chain by emitting
+    // the wire event directly via sendEvent; it must NOT re-enter the manager
+    // (which in prod is wired with its `emitReliabilityMetric` dep pointing
+    // back at this same funnel — re-entering would recurse to a stack
+    // overflow). So we assert on the actual wire event, not the manager
+    // method, and confirm the manager was never re-invoked by the funnel.
+    const reliabilityEvents = parentPort.postMessage.mock.calls
+      .map((call: unknown[]) => call[0])
+      .filter(
+        (msg: unknown): msg is Record<string, unknown> =>
+          typeof msg === "object" &&
+          msg !== null &&
+          (msg as { type?: string }).type === "terminal-reliability-metric"
+      );
+    expect(reliabilityEvents).toHaveLength(1);
+    expect(reliabilityEvents[0]).toMatchObject({
+      type: "terminal-reliability-metric",
+      payload: {
         terminalId: "t1",
         metricType: "suspend",
         bufferUtilization: 100,
-      }),
-      // Second arg is the `forceEmit` flag on `BackpressureManager.emitReliabilityMetric`.
-      // The funnel passes its own `forceEmit` through (default `false` for
-      // non-pulse events); the test asserts the payload shape, not the flag.
-      expect.any(Boolean)
-    );
+      },
+    });
+    // The funnel does NOT route back through the manager — that path is the
+    // production recursion cycle and must stay broken.
+    const backpressure = hostState.backpressureManagers[0];
+    expect(backpressure.emitReliabilityMetric).not.toHaveBeenCalled();
 
     // Drop path returns early, so addBytes and the data event are never sent.
     expect(ipcQueue.addBytes).not.toHaveBeenCalled();

--- a/electron/__tests__/pty-host.adversarial.test.ts
+++ b/electron/__tests__/pty-host.adversarial.test.ts
@@ -540,6 +540,7 @@ vi.mock("../pty-host/index.js", async () => {
       this.events.push("dispose");
       this.pausedIds.clear();
     });
+    getPausedTerminalIds = vi.fn(() => this.pausedIds.values());
 
     markPaused(id: string): void {
       this.pausedIds.add(id);
@@ -738,7 +739,11 @@ describe("pty-host adversarial", () => {
         terminalId: "t1",
         metricType: "suspend",
         bufferUtilization: 100,
-      })
+      }),
+      // Second arg is the `forceEmit` flag on `BackpressureManager.emitReliabilityMetric`.
+      // The funnel passes its own `forceEmit` through (default `false` for
+      // non-pulse events); the test asserts the payload shape, not the flag.
+      expect.any(Boolean)
     );
 
     // Drop path returns early, so addBytes and the data event are never sent.

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -132,6 +132,7 @@ import type {
   TerminalResourceBatchPayload,
   BroadcastWriteResultPayload,
   FdLeakWarningPayload,
+  TerminalReliabilityMetricPayload,
 } from "../shared/types/pty-host.js";
 
 type SpawnResultPayload = SpawnResult;
@@ -970,6 +971,10 @@ const api: ElectronAPI = {
 
     onStatus: (callback: (data: TerminalStatusPayload) => void) =>
       _typedOn(CHANNELS.TERMINAL_STATUS, callback),
+
+    onReliabilityMetric: (
+      callback: (data: TerminalReliabilityMetricPayload) => void
+    ): (() => void) => _eventBusOn("terminal:reliability-metric", callback),
 
     onResourceMetrics: (
       callback: (data: { metrics: TerminalResourceBatchPayload; timestamp: number }) => void

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -246,7 +246,18 @@ function emitReliabilityMetricWithTracking(
   ) {
     clearAllPauseSources(payload.terminalId);
   }
-  backpressureManager.emitReliabilityMetric(payload, forceEmit);
+  // This funnel TERMINATES the chain: emit the wire event directly. We must
+  // NOT call `backpressureManager.emitReliabilityMetric` here — in production
+  // the manager is constructed with its `emitReliabilityMetric` dep wired
+  // back to this funnel (see construction below), so re-entering it would
+  // route straight back here and recurse until the stack overflows. The gate
+  // (`metricsEnabled()`, bypassed by `forceEmit` for the data-loss pulse)
+  // mirrors the manager's legacy default branch.
+  if (!forceEmit && !metricsEnabled()) return;
+  sendEvent({
+    type: "terminal-reliability-metric",
+    payload,
+  });
 }
 
 // Terminals that need IPC data mirroring (e.g., dev-preview sessions that

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -144,40 +144,107 @@ const textDecoder = new TextDecoder();
 // iterator invalidation during Map iteration.
 let throughputAccumulator = new Map<string, { totalBytes: number; packetCount: number }>();
 
-// Pause-duration gauge: closure-scoped map of `terminalId → pause-start time`
-// aggregated across SAB, IPC, and per-window MessagePort pause sources. Each
-// entry is added when a `pause-start` reliability metric flows through the
-// canonical `backpressureManager.emitReliabilityMetric` funnel and removed
-// when the matching `pause-end` (or suspend) flows through. The map lives
-// here (not in any single queue manager) because each queue manager only
-// sees its own path; aggregating at the funnel keeps a single source of
-// truth for the renderer-facing `heldDurationMs` value.
-const pausedTerminals = new Map<string, number>();
+// Pause-duration gauge: closure-scoped map of `terminalId → set of pause
+// sources currently holding the terminal`. Aggregated across SAB, IPC, and
+// per-window MessagePort pause sources. The `Set` is keyed by source id
+// (`"sab"`, `"ipc"`, `"port-{windowId}"`) so a `pause-end` from one path
+// only clears that path's hold — a terminal paused by both IPC and a port
+// window stays in the map until BOTH paths resume. Each pause source
+// also records its own start time so the renderer-facing `heldDurationMs`
+// reflects the oldest still-held start (the user-meaningful "how long has
+// this been paused?" answer).
+type PauseSource = "sab" | "ipc" | `port-${number}`;
+interface PauseSourceEntry {
+  startTime: number;
+}
+const pausedTerminals = new Map<string, Map<PauseSource, PauseSourceEntry>>();
+
+/**
+ * Add a pause source to the per-terminal tracking set. Records the
+ * pause-start time for the source (later start times are ignored —
+ * the first source to pause owns the held-duration clock).
+ */
+function addPauseSource(terminalId: string, source: PauseSource, startTime: number): void {
+  let sources = pausedTerminals.get(terminalId);
+  if (!sources) {
+    sources = new Map();
+    pausedTerminals.set(terminalId, sources);
+  }
+  if (!sources.has(source)) {
+    sources.set(source, { startTime });
+  }
+}
+
+/**
+ * Remove a pause source from the per-terminal tracking set. Returns
+ * `true` if the terminal still has other sources holding (kept in the
+ * map), `false` if all sources cleared (terminal removed from map).
+ */
+function removePauseSource(terminalId: string, source: PauseSource): boolean {
+  const sources = pausedTerminals.get(terminalId);
+  if (!sources) return false;
+  sources.delete(source);
+  if (sources.size === 0) {
+    pausedTerminals.delete(terminalId);
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Remove all pause sources for a terminal (used by terminal-exit
+ * cleanup, where any pending sources are stale and the panel is gone).
+ */
+function clearAllPauseSources(terminalId: string): void {
+  pausedTerminals.delete(terminalId);
+}
 
 // Data-loss counter: closure-scoped accumulator of dropped-bytes and
 // drop-event counts since the last snapshot. The counter is incremented
 // unconditionally at the drop site so regression detection is observable
 // even when metrics are gated off; the wire emission itself is gated by
-// `metricsEnabled()` in `emitDataLossCount`. Reset semantics mirror
-// `throughputAccumulator` (snapshot-and-reset at tick boundary).
+// `metricsEnabled()` in `emitDataLossCount`. Reset semantics: the counter
+// is reset on EVERY tick (not just on the gated emit path) so toggling
+// metrics on doesn't dump the entire historical backlog as a single
+// false "regression" on the first emit after the gate opens.
 let dropAccumulator = { droppedBytes: 0, dataLossCount: 0 };
 
 /**
  * Canonical funnel for terminal reliability-metric events. Wraps the
  * `backpressureManager.emitReliabilityMetric` call (which is wired into
- * every queue manager and the inline SAB-path emits) so we can observe
+ * every queue manager, the inline SAB-path emits, and now the
+ * `BackpressureManager` itself via a constructor dep) so we can observe
  * `pause-start` / `pause-end` pairs to maintain the `pausedTerminals`
  * map. The `forceEmit` escape hatch on the underlying call still works
  * (passthrough) for the data-loss pulse that bypasses the metric gate.
+ *
+ * `source` identifies the pause source so multi-source attribution
+ * works (e.g., a port-window disconnect only removes the
+ * `port-{windowId}` source — if IPC is also pausing the same terminal,
+ * the terminal stays in the map).
  */
 function emitReliabilityMetricWithTracking(
   payload: import("../shared/types/pty-host.js").TerminalReliabilityMetricPayload,
+  source: PauseSource | null,
   forceEmit = false
 ): void {
-  if (payload.metricType === "pause-start") {
-    pausedTerminals.set(payload.terminalId, payload.timestamp);
-  } else if (payload.metricType === "pause-end" || payload.metricType === "suspend") {
-    pausedTerminals.delete(payload.terminalId);
+  if (source !== null) {
+    if (payload.metricType === "pause-start") {
+      addPauseSource(payload.terminalId, source, payload.timestamp);
+    } else if (payload.metricType === "pause-end" || payload.metricType === "suspend") {
+      removePauseSource(payload.terminalId, source);
+    }
+  } else if (
+    // `null` source + `pause-end`/`suspend` = user/system force-resume
+    // (e.g., the `pause-end` emitted by the force-resume handler at
+    // `electron/pty-host/handlers/backpressure.ts:215` after `clearQueue`
+    // tore down the queue managers' internal pause maps). Clear ALL
+    // sources for the terminal — attribution is moot when the user has
+    // explicitly asked for a full resume.
+    payload.metricType === "pause-end" ||
+    payload.metricType === "suspend"
+  ) {
+    clearAllPauseSources(payload.terminalId);
   }
   backpressureManager.emitReliabilityMetric(payload, forceEmit);
 }
@@ -216,11 +283,21 @@ function sendEvent(event: PtyHostEvent): void {
 }
 
 // Instantiate managers with dependency injection
+// `backpressureManager.emitReliabilityMetric` is the canonical funnel
+// for SAB-path emissions. Routing through it (via the `emitReliabilityMetric`
+// dep) means the closure-scoped per-source pause-tracking map stays in
+// sync with every reliability-metric event the manager emits — including
+// the internal `suspend` from `suspendVisualStream`'s safety-timeout
+// path. Source is `null` for these internal calls (we don't attribute
+// SAB-path sources to a specific window) — only the IPC and port queue
+// paths carry real source ids.
 const backpressureManager = new BackpressureManager({
   getTerminal: (id) => ptyManager.getTerminal(id),
   getPauseCoordinator,
   sendEvent,
   metricsEnabled,
+  emitReliabilityMetric: (payload, forceEmit) =>
+    emitReliabilityMetricWithTracking(payload, null, forceEmit),
 });
 
 const ipcQueueManager = new IpcQueueManager({
@@ -229,7 +306,7 @@ const ipcQueueManager = new IpcQueueManager({
   sendEvent,
   metricsEnabled,
   emitTerminalStatus: (...args) => backpressureManager.emitTerminalStatus(...args),
-  emitReliabilityMetric: (payload) => emitReliabilityMetricWithTracking(payload),
+  emitReliabilityMetric: (payload) => emitReliabilityMetricWithTracking(payload, "ipc"),
 });
 
 // PortQueueManager deps factory — creates per-window instances with unique pause tokens
@@ -240,7 +317,8 @@ function createPortQueueManager(windowId: number): PortQueueManager {
     sendEvent,
     metricsEnabled,
     emitTerminalStatus: (...args) => backpressureManager.emitTerminalStatus(...args),
-    emitReliabilityMetric: (payload) => emitReliabilityMetricWithTracking(payload),
+    emitReliabilityMetric: (payload) =>
+      emitReliabilityMetricWithTracking(payload, `port-${windowId}` as PauseSource),
     pauseToken: `port-queue-${windowId}`,
   });
 }
@@ -300,6 +378,15 @@ function disconnectWindow(windowId: number, reason: string): void {
   conn.batcher.dispose();
   // Release port-queue pause holds before disposing
   conn.portQueueManager.resumeAll();
+  // Clear this window's per-source pause-tracking entries. Multi-source
+  // attribution: a terminal paused by BOTH the port window and the IPC
+  // queue must NOT lose its held-duration tracking when just the window
+  // disconnects — `removePauseSource` keeps the entry alive while the
+  // IPC path still holds. The renderer is informed via the queue
+  // manager's own resume flow + tier-changed message.
+  for (const terminalId of conn.portQueueManager.pausedTerminalsMap.keys()) {
+    removePauseSource(terminalId, `port-${windowId}` as PauseSource);
+  }
   conn.portQueueManager.dispose();
   try {
     conn.port.close();
@@ -386,13 +473,21 @@ const resourceGovernor = new ResourceGovernor({
   getPausedDurationsSnapshot: () => {
     // Read from the closure-scoped `pausedTerminals` map. The map is
     // maintained by `emitReliabilityMetricWithTracking` so every pause
-    // source (SAB, IPC, per-window port) contributes. Empty-array fast
-    // path matches the `pending-bytes-gauge` skip-when-empty contract.
+    // source (SAB, IPC, per-window port) contributes. A terminal is
+    // included as long as ANY source is still holding — multi-source
+    // attribution via the per-source `Set` means a `pause-end` from
+    // one path only clears that path's hold. The held duration uses
+    // the OLDEST start time across all sources, so the renderer sees
+    // the user-meaningful "how long has this been paused?" answer.
     if (pausedTerminals.size === 0) return [];
     const now = Date.now();
     const out: Array<{ terminalId: string; heldDurationMs: number }> = [];
-    for (const [terminalId, startTime] of pausedTerminals) {
-      out.push({ terminalId, heldDurationMs: Math.max(0, now - startTime) });
+    for (const [terminalId, sources] of pausedTerminals) {
+      let oldestStart = Number.POSITIVE_INFINITY;
+      for (const { startTime } of sources.values()) {
+        if (startTime < oldestStart) oldestStart = startTime;
+      }
+      out.push({ terminalId, heldDurationMs: Math.max(0, now - oldestStart) });
     }
     return out;
   },
@@ -594,13 +689,16 @@ ptyManager.on("data", (id: string, data: string | Uint8Array) => {
             backpressureManager.emitTerminalStatus(id, "paused-backpressure", utilization);
 
             // Emit metrics for pause-start
-            emitReliabilityMetricWithTracking({
-              terminalId: id,
-              metricType: "pause-start",
-              timestamp: pauseStartTime,
-              bufferUtilization: utilization,
-              shardIndex,
-            });
+            emitReliabilityMetricWithTracking(
+              {
+                terminalId: id,
+                metricType: "pause-start",
+                timestamp: pauseStartTime,
+                bufferUtilization: utilization,
+                shardIndex,
+              },
+              "sab"
+            );
 
             // Safety timeout: if ack-driven resume doesn't clear backpressure in time,
             // suspend the stream and rely on wake to restore state.
@@ -622,13 +720,16 @@ ptyManager.on("data", (id: string, data: string | Uint8Array) => {
                 if (!timeoutCoord?.isPaused) {
                   backpressureManager.emitTerminalStatus(id, "running", util, dur);
                 }
-                emitReliabilityMetricWithTracking({
-                  terminalId: id,
-                  metricType: "pause-end",
-                  timestamp: Date.now(),
-                  durationMs: dur,
-                  bufferUtilization: util,
-                });
+                emitReliabilityMetricWithTracking(
+                  {
+                    terminalId: id,
+                    metricType: "pause-end",
+                    timestamp: Date.now(),
+                    durationMs: dur,
+                    bufferUtilization: util,
+                  },
+                  "sab"
+                );
               }
             }, BACKPRESSURE_SAFETY_TIMEOUT_MS);
 
@@ -689,12 +790,20 @@ ptyManager.on("data", (id: string, data: string | Uint8Array) => {
       // gated separately in ResourceGovernor.emitDataLossCount.
       dropAccumulator.droppedBytes += dataBytes;
       dropAccumulator.dataLossCount += 1;
-      emitReliabilityMetricWithTracking({
-        terminalId: id,
-        metricType: "suspend",
-        timestamp: Date.now(),
-        bufferUtilization: utilization,
-      });
+      // `null` source: the suspend pulse is a data-path signal, not a
+      // pause-source attribution. The funnel still forwards to the wire
+      // emission; it just doesn't touch the per-source tracking map.
+      // (The map entry is removed by the corresponding `pause-end` from
+      // the IPC queue's own backpressure path.)
+      emitReliabilityMetricWithTracking(
+        {
+          terminalId: id,
+          metricType: "suspend",
+          timestamp: Date.now(),
+          bufferUtilization: utilization,
+        },
+        null
+      );
       // Surface the drop to the renderer so a discontinuity marker is shown.
       // Bypasses BackpressureManager.emitTerminalStatus() because each drop
       // is a distinct pulse — the dedup guard there would silently swallow
@@ -744,10 +853,15 @@ ptyManager.on("exit", (id: string, exitCode: number, signal?: number) => {
     pauseCoordinators.delete(id);
   }
 
-  // Drop any tracked pause-duration entry for this terminal so the next
+  // Drop any tracked pause-duration sources for this terminal so the next
   // `pause-duration-gauge` tick doesn't emit a stale `heldDurationMs`
-  // for a terminal that no longer exists.
-  pausedTerminals.delete(id);
+  // for a terminal that no longer exists. Cleanup paths (this one,
+  // `disconnectWindow`, `clearQueue`, `dispose`) bypass the funnel
+  // because they don't carry a wire emission — a disconnected window
+  // or torn-down queue manager shouldn't trigger a "pause-end" wire
+  // event. The renderer is informed separately via terminal-exit /
+  // disconnect flows.
+  clearAllPauseSources(id);
 
   // Clean up any active backpressure monitoring for this terminal
   backpressureManager.cleanupTerminal(id);
@@ -969,13 +1083,16 @@ function resumePausedTerminal(id: string): void {
   if (!coordinator?.isPaused) {
     backpressureManager.emitTerminalStatus(id, "running", utilization, pauseDuration);
   }
-  emitReliabilityMetricWithTracking({
-    terminalId: id,
-    metricType: "pause-end",
-    timestamp: Date.now(),
-    durationMs: pauseDuration,
-    bufferUtilization: utilization,
-  });
+  emitReliabilityMetricWithTracking(
+    {
+      terminalId: id,
+      metricType: "pause-end",
+      timestamp: Date.now(),
+      durationMs: pauseDuration,
+      bufferUtilization: utilization,
+    },
+    "sab"
+  );
 
   backpressureManager.stats.resumeCount++;
 }

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -384,7 +384,7 @@ function disconnectWindow(windowId: number, reason: string): void {
   // disconnects — `removePauseSource` keeps the entry alive while the
   // IPC path still holds. The renderer is informed via the queue
   // manager's own resume flow + tier-changed message.
-  for (const terminalId of conn.portQueueManager.pausedTerminalsMap.keys()) {
+  for (const terminalId of conn.portQueueManager.getPausedTerminalIds()) {
     removePauseSource(terminalId, `port-${windowId}` as PauseSource);
   }
   conn.portQueueManager.dispose();

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -144,6 +144,44 @@ const textDecoder = new TextDecoder();
 // iterator invalidation during Map iteration.
 let throughputAccumulator = new Map<string, { totalBytes: number; packetCount: number }>();
 
+// Pause-duration gauge: closure-scoped map of `terminalId → pause-start time`
+// aggregated across SAB, IPC, and per-window MessagePort pause sources. Each
+// entry is added when a `pause-start` reliability metric flows through the
+// canonical `backpressureManager.emitReliabilityMetric` funnel and removed
+// when the matching `pause-end` (or suspend) flows through. The map lives
+// here (not in any single queue manager) because each queue manager only
+// sees its own path; aggregating at the funnel keeps a single source of
+// truth for the renderer-facing `heldDurationMs` value.
+const pausedTerminals = new Map<string, number>();
+
+// Data-loss counter: closure-scoped accumulator of dropped-bytes and
+// drop-event counts since the last snapshot. The counter is incremented
+// unconditionally at the drop site so regression detection is observable
+// even when metrics are gated off; the wire emission itself is gated by
+// `metricsEnabled()` in `emitDataLossCount`. Reset semantics mirror
+// `throughputAccumulator` (snapshot-and-reset at tick boundary).
+let dropAccumulator = { droppedBytes: 0, dataLossCount: 0 };
+
+/**
+ * Canonical funnel for terminal reliability-metric events. Wraps the
+ * `backpressureManager.emitReliabilityMetric` call (which is wired into
+ * every queue manager and the inline SAB-path emits) so we can observe
+ * `pause-start` / `pause-end` pairs to maintain the `pausedTerminals`
+ * map. The `forceEmit` escape hatch on the underlying call still works
+ * (passthrough) for the data-loss pulse that bypasses the metric gate.
+ */
+function emitReliabilityMetricWithTracking(
+  payload: import("../shared/types/pty-host.js").TerminalReliabilityMetricPayload,
+  forceEmit = false
+): void {
+  if (payload.metricType === "pause-start") {
+    pausedTerminals.set(payload.terminalId, payload.timestamp);
+  } else if (payload.metricType === "pause-end" || payload.metricType === "suspend") {
+    pausedTerminals.delete(payload.terminalId);
+  }
+  backpressureManager.emitReliabilityMetric(payload, forceEmit);
+}
+
 // Terminals that need IPC data mirroring (e.g., dev-preview sessions that
 // need main-process URL detection even when SharedArrayBuffer is active)
 const ipcDataMirrorTerminals = new Set<string>();
@@ -191,7 +229,7 @@ const ipcQueueManager = new IpcQueueManager({
   sendEvent,
   metricsEnabled,
   emitTerminalStatus: (...args) => backpressureManager.emitTerminalStatus(...args),
-  emitReliabilityMetric: (payload) => backpressureManager.emitReliabilityMetric(payload),
+  emitReliabilityMetric: (payload) => emitReliabilityMetricWithTracking(payload),
 });
 
 // PortQueueManager deps factory — creates per-window instances with unique pause tokens
@@ -202,7 +240,7 @@ function createPortQueueManager(windowId: number): PortQueueManager {
     sendEvent,
     metricsEnabled,
     emitTerminalStatus: (...args) => backpressureManager.emitTerminalStatus(...args),
-    emitReliabilityMetric: (payload) => backpressureManager.emitReliabilityMetric(payload),
+    emitReliabilityMetric: (payload) => emitReliabilityMetricWithTracking(payload),
     pauseToken: `port-queue-${windowId}`,
   });
 }
@@ -344,6 +382,55 @@ const resourceGovernor = new ResourceGovernor({
       perTerminal,
       pauseCount: backpressureManager.stats.pauseCount,
     };
+  },
+  getPausedDurationsSnapshot: () => {
+    // Read from the closure-scoped `pausedTerminals` map. The map is
+    // maintained by `emitReliabilityMetricWithTracking` so every pause
+    // source (SAB, IPC, per-window port) contributes. Empty-array fast
+    // path matches the `pending-bytes-gauge` skip-when-empty contract.
+    if (pausedTerminals.size === 0) return [];
+    const now = Date.now();
+    const out: Array<{ terminalId: string; heldDurationMs: number }> = [];
+    for (const [terminalId, startTime] of pausedTerminals) {
+      out.push({ terminalId, heldDurationMs: Math.max(0, now - startTime) });
+    }
+    return out;
+  },
+  getQueueDepthSnapshot: () => {
+    // Live IPC + per-window MessagePort paths only. The FUTURE_SAB path is
+    // dead in production (SharedArrayBuffer is not supported in
+    // Electron UtilityProcess) and is intentionally excluded so the
+    // dead-code and live paths stay independently observable. Each entry
+    // carries the path `layer` so consumers can split per-transport
+    // attribution in one pass.
+    const out: Array<{
+      terminalId: string;
+      layer: "ipc" | "port";
+      pendingBytes: number;
+    }> = [];
+    const ipc = ipcQueueManager.getQueueSnapshot();
+    for (const { terminalId, pendingBytes } of ipc.perTerminal) {
+      if (pendingBytes > 0) out.push({ terminalId, layer: "ipc", pendingBytes });
+    }
+    for (const conn of rendererConnections.values()) {
+      const port = conn.portQueueManager.getQueueSnapshot();
+      for (const { terminalId, pendingBytes } of port.perTerminal) {
+        if (pendingBytes > 0) out.push({ terminalId, layer: "port", pendingBytes });
+      }
+    }
+    return out;
+  },
+  getDropSnapshot: () => {
+    // Snapshot-and-reset. Mirrors `getThroughputSnapshot` so a tick with
+    // no drops produces a zero-delta payload and the gated emission site
+    // correctly skips the wire event. Counter itself is incremented
+    // unconditionally at the drop site (independent of this function).
+    const snapshot = {
+      droppedBytesDelta: dropAccumulator.droppedBytes,
+      dataLossCountDelta: dropAccumulator.dataLossCount,
+    };
+    dropAccumulator = { droppedBytes: 0, dataLossCount: 0 };
+    return snapshot;
   },
 });
 
@@ -507,7 +594,7 @@ ptyManager.on("data", (id: string, data: string | Uint8Array) => {
             backpressureManager.emitTerminalStatus(id, "paused-backpressure", utilization);
 
             // Emit metrics for pause-start
-            backpressureManager.emitReliabilityMetric({
+            emitReliabilityMetricWithTracking({
               terminalId: id,
               metricType: "pause-start",
               timestamp: pauseStartTime,
@@ -535,7 +622,7 @@ ptyManager.on("data", (id: string, data: string | Uint8Array) => {
                 if (!timeoutCoord?.isPaused) {
                   backpressureManager.emitTerminalStatus(id, "running", util, dur);
                 }
-                backpressureManager.emitReliabilityMetric({
+                emitReliabilityMetricWithTracking({
                   terminalId: id,
                   metricType: "pause-end",
                   timestamp: Date.now(),
@@ -597,7 +684,12 @@ ptyManager.on("data", (id: string, data: string | Uint8Array) => {
       console.warn(
         `[PtyHost] IPC queue full (${utilization.toFixed(1)}%). Dropping ${dataBytes} bytes for terminal ${id}`
       );
-      backpressureManager.emitReliabilityMetric({
+      // Counter is unconditional — regression detection must work even
+      // when metrics are gated off. The wire emission of the gauge is
+      // gated separately in ResourceGovernor.emitDataLossCount.
+      dropAccumulator.droppedBytes += dataBytes;
+      dropAccumulator.dataLossCount += 1;
+      emitReliabilityMetricWithTracking({
         terminalId: id,
         metricType: "suspend",
         timestamp: Date.now(),
@@ -651,6 +743,11 @@ ptyManager.on("exit", (id: string, exitCode: number, signal?: number) => {
     coordinator.forceReleaseAll();
     pauseCoordinators.delete(id);
   }
+
+  // Drop any tracked pause-duration entry for this terminal so the next
+  // `pause-duration-gauge` tick doesn't emit a stale `heldDurationMs`
+  // for a terminal that no longer exists.
+  pausedTerminals.delete(id);
 
   // Clean up any active backpressure monitoring for this terminal
   backpressureManager.cleanupTerminal(id);
@@ -872,7 +969,7 @@ function resumePausedTerminal(id: string): void {
   if (!coordinator?.isPaused) {
     backpressureManager.emitTerminalStatus(id, "running", utilization, pauseDuration);
   }
-  backpressureManager.emitReliabilityMetric({
+  emitReliabilityMetricWithTracking({
     terminalId: id,
     metricType: "pause-end",
     timestamp: Date.now(),

--- a/electron/pty-host/ResourceGovernor.ts
+++ b/electron/pty-host/ResourceGovernor.ts
@@ -39,6 +39,36 @@ export interface ResourceGovernorDeps {
     perTerminal: Array<{ terminalId: string; byteCount: number; packetCount: number }>;
     pauseCount: number;
   } | null;
+  /**
+   * Per-paused-terminal held duration snapshot, aggregated across SAB, IPC,
+   * and per-window MessagePort pause sources via a closure-scoped map in
+   * pty-host.ts. `heldDurationMs` is sampled at the metric tick.
+   */
+  getPausedDurationsSnapshot?: () => Array<{
+    terminalId: string;
+    heldDurationMs: number;
+  }>;
+  /**
+   * Per-terminal queue depth for the live IPC + per-window MessagePort
+   * paths. Excludes the FUTURE_SAB path (dead in production). Each entry
+   * is tagged with the path `layer` so consumers can attribute bytes per
+   * transport.
+   */
+  getQueueDepthSnapshot?: () => Array<{
+    terminalId: string;
+    layer: "ipc" | "port";
+    pendingBytes: number;
+  }>;
+  /**
+   * Data-loss counter snapshot. Returns accumulated drop-event count and
+   * dropped bytes since the last call. Counter is unconditional in
+   * pty-host.ts (gated only by drop site entry); this emission is gated
+   * separately by `metricsEnabled()`. Reset semantics: snapshot-and-reset.
+   */
+  getDropSnapshot?: () => {
+    droppedBytesDelta: number;
+    dataLossCountDelta: number;
+  };
 }
 
 export class ResourceGovernor {
@@ -243,6 +273,9 @@ export class ResourceGovernor {
     this.checkFdUsage();
     this.emitPendingBytesGauge();
     this.emitThroughputRateGauge();
+    this.emitPausedDurationGauge();
+    this.emitQueueDepthGauge();
+    this.emitDataLossCount();
   }
 
   private checkFdUsage(): void {
@@ -362,6 +395,65 @@ export class ResourceGovernor {
     });
 
     this.prevThroughputTimestamp = snapshot.timestamp;
+  }
+
+  private emitPausedDurationGauge(): void {
+    if (!metricsEnabled()) return;
+    if (!this.deps.getPausedDurationsSnapshot) return;
+
+    const snapshot = this.deps.getPausedDurationsSnapshot();
+    if (snapshot.length === 0) return;
+
+    this.deps.sendEvent({
+      type: "terminal-reliability-metric",
+      payload: {
+        terminalId: "resource-governor",
+        metricType: "pause-duration-gauge",
+        timestamp: Date.now(),
+        perTerminalHeld: snapshot,
+      },
+    });
+  }
+
+  private emitQueueDepthGauge(): void {
+    if (!metricsEnabled()) return;
+    if (!this.deps.getQueueDepthSnapshot) return;
+
+    const snapshot = this.deps.getQueueDepthSnapshot();
+    if (snapshot.length === 0) return;
+
+    this.deps.sendEvent({
+      type: "terminal-reliability-metric",
+      payload: {
+        terminalId: "resource-governor",
+        metricType: "queue-depth-gauge",
+        timestamp: Date.now(),
+        perTerminalQueueDepth: snapshot,
+      },
+    });
+  }
+
+  private emitDataLossCount(): void {
+    if (!metricsEnabled()) return;
+    if (!this.deps.getDropSnapshot) return;
+
+    const snapshot = this.deps.getDropSnapshot();
+    // Skip-when-zero matches the throughput-rate gauge contract: a tick
+    // with no drops produces no wire event. Counter is reset on every
+    // snapshot-and-reset, so re-entry on the same tick would see zero
+    // deltas and skip — this is intentional, not a bug.
+    if (snapshot.dataLossCountDelta === 0 && snapshot.droppedBytesDelta === 0) return;
+
+    this.deps.sendEvent({
+      type: "terminal-reliability-metric",
+      payload: {
+        terminalId: "resource-governor",
+        metricType: "data-loss-count",
+        timestamp: Date.now(),
+        dataLossCountDelta: snapshot.dataLossCountDelta,
+        droppedBytesDelta: snapshot.droppedBytesDelta,
+      },
+    });
   }
 
   private engageThrottle(currentUsageMb: number, percent: number): void {

--- a/electron/pty-host/ResourceGovernor.ts
+++ b/electron/pty-host/ResourceGovernor.ts
@@ -434,14 +434,18 @@ export class ResourceGovernor {
   }
 
   private emitDataLossCount(): void {
-    if (!metricsEnabled()) return;
     if (!this.deps.getDropSnapshot) return;
 
+    // Always call the snapshotter so the counter resets on every tick
+    // regardless of the metrics gate. Without this, the counter would
+    // accumulate indefinitely while `DAINTREE_TERMINAL_METRICS=0`, then
+    // dump the entire historical backlog as a single "regression" on the
+    // first emit after the gate opens. Counter is therefore bounded to
+    // "since last tick" regardless of gate state.
     const snapshot = this.deps.getDropSnapshot();
+    if (!metricsEnabled()) return;
     // Skip-when-zero matches the throughput-rate gauge contract: a tick
-    // with no drops produces no wire event. Counter is reset on every
-    // snapshot-and-reset, so re-entry on the same tick would see zero
-    // deltas and skip — this is intentional, not a bug.
+    // with no drops produces no wire event.
     if (snapshot.dataLossCountDelta === 0 && snapshot.droppedBytesDelta === 0) return;
 
     this.deps.sendEvent({

--- a/electron/pty-host/__tests__/ResourceGovernor.test.ts
+++ b/electron/pty-host/__tests__/ResourceGovernor.test.ts
@@ -1045,6 +1045,99 @@ describe("ResourceGovernor", () => {
 
       governor.dispose();
     });
+
+    it("always resets the drop counter on each tick, even when metrics are disabled", () => {
+      // Locks in the regression-detection contract: the counter must NOT
+      // accumulate indefinitely while metrics are gated off, otherwise the
+      // first emit after toggling metrics on would dump the entire
+      // historical backlog as a false "regression" — defeating the
+      // purpose of the gauge.
+      vi.mocked(metricsEnabled).mockReturnValue(false);
+
+      let snapshotCount = 0;
+      const deps = createMockDeps({
+        getDropSnapshot: vi.fn().mockImplementation(() => {
+          snapshotCount++;
+          // Each tick the mock reports 100 new bytes / 1 new drop.
+          return { droppedBytesDelta: 100, dataLossCountDelta: 1 };
+        }),
+      });
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+
+      // Three ticks with metrics off. Snapshot must be called on every
+      // tick (gated emission is what was failing here).
+      vi.advanceTimersByTime(2000);
+      vi.advanceTimersByTime(2000);
+      vi.advanceTimersByTime(2000);
+
+      expect(snapshotCount).toBe(3);
+      // No wire emissions because metrics are gated.
+      const calls = (deps.sendEvent as ReturnType<typeof vi.fn>).mock.calls;
+      const gaugeCalls = calls.filter(
+        (c: unknown[]) =>
+          (c[0] as Record<string, unknown>)?.type === "terminal-reliability-metric" &&
+          ((c[0] as Record<string, unknown>)?.payload as Record<string, unknown>)?.metricType ===
+            "data-loss-count"
+      );
+      expect(gaugeCalls).toHaveLength(0);
+
+      governor.dispose();
+    });
+
+    it("emits a bounded delta after toggling metrics on (not the historical backlog)", () => {
+      // Continuation of the previous test: after a metrics-off period,
+      // the first emit after the gate opens must report only the drops
+      // accumulated since the gate opened — not the historical total.
+      vi.mocked(metricsEnabled).mockReturnValue(false);
+
+      // Track call index so the mock can simulate "drops only after
+      // metrics flip on" — the counter reset on every tick means the
+      // gauge never accumulates a backlog.
+      let callIdx = 0;
+      const dropsByTick = [0, 0, 0, 5]; // 3 off-ticks with 0 drops, then 1 drop after flip
+
+      const deps = createMockDeps({
+        getDropSnapshot: vi.fn().mockImplementation(() => {
+          const drops = dropsByTick[callIdx] ?? 0;
+          callIdx++;
+          return { droppedBytesDelta: drops * 1024, dataLossCountDelta: drops };
+        }),
+      });
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+
+      // 3 ticks with metrics off.
+      vi.advanceTimersByTime(2000);
+      vi.advanceTimersByTime(2000);
+      vi.advanceTimersByTime(2000);
+
+      // Flip metrics on.
+      vi.mocked(metricsEnabled).mockReturnValue(true);
+
+      vi.advanceTimersByTime(2000);
+
+      // The post-flip emit must reflect ONLY the post-flip drop, not
+      // the historical 0+0+0+5 = 5 backlog. The counter is reset on
+      // every tick (the off-ticks reset to 0, the post-flip tick
+      // captured the fresh 5).
+      const calls = (deps.sendEvent as ReturnType<typeof vi.fn>).mock.calls;
+      const gaugeCalls = calls.filter(
+        (c: unknown[]) =>
+          (c[0] as Record<string, unknown>)?.type === "terminal-reliability-metric" &&
+          ((c[0] as Record<string, unknown>)?.payload as Record<string, unknown>)?.metricType ===
+            "data-loss-count"
+      );
+      expect(gaugeCalls).toHaveLength(1);
+      expect((gaugeCalls[0][0] as Record<string, unknown>).payload).toMatchObject({
+        droppedBytesDelta: 5 * 1024,
+        dataLossCountDelta: 5,
+      });
+
+      governor.dispose();
+    });
   });
 
   describe("host-memory-warning", () => {

--- a/electron/pty-host/__tests__/ResourceGovernor.test.ts
+++ b/electron/pty-host/__tests__/ResourceGovernor.test.ts
@@ -742,6 +742,311 @@ describe("ResourceGovernor", () => {
     });
   });
 
+  describe("pause-duration-gauge", () => {
+    it("emits pause-duration-gauge with per-terminal held durations when metrics enabled", () => {
+      vi.mocked(metricsEnabled).mockReturnValue(true);
+
+      const deps = createMockDeps({
+        getPausedDurationsSnapshot: vi.fn().mockReturnValue([
+          { terminalId: "t1", heldDurationMs: 4000 },
+          { terminalId: "t2", heldDurationMs: 12000 },
+        ]),
+      });
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+
+      vi.advanceTimersByTime(2000);
+
+      expect(deps.sendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "terminal-reliability-metric",
+          payload: expect.objectContaining({
+            terminalId: "resource-governor",
+            metricType: "pause-duration-gauge",
+            perTerminalHeld: [
+              { terminalId: "t1", heldDurationMs: 4000 },
+              { terminalId: "t2", heldDurationMs: 12000 },
+            ],
+          }),
+        })
+      );
+
+      governor.dispose();
+    });
+
+    it("does not emit gauge when metrics are disabled", () => {
+      vi.mocked(metricsEnabled).mockReturnValue(false);
+
+      const deps = createMockDeps({
+        getPausedDurationsSnapshot: vi
+          .fn()
+          .mockReturnValue([{ terminalId: "t1", heldDurationMs: 4000 }]),
+      });
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      vi.advanceTimersByTime(2000);
+
+      const calls = (deps.sendEvent as ReturnType<typeof vi.fn>).mock.calls;
+      const gaugeCalls = calls.filter(
+        (c: unknown[]) =>
+          (c[0] as Record<string, unknown>)?.type === "terminal-reliability-metric" &&
+          ((c[0] as Record<string, unknown>)?.payload as Record<string, unknown>)?.metricType ===
+            "pause-duration-gauge"
+      );
+      expect(gaugeCalls).toHaveLength(0);
+
+      governor.dispose();
+    });
+
+    it("does not emit gauge when snapshot is empty", () => {
+      vi.mocked(metricsEnabled).mockReturnValue(true);
+
+      const deps = createMockDeps({
+        getPausedDurationsSnapshot: vi.fn().mockReturnValue([]),
+      });
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      vi.advanceTimersByTime(2000);
+
+      const calls = (deps.sendEvent as ReturnType<typeof vi.fn>).mock.calls;
+      const gaugeCalls = calls.filter(
+        (c: unknown[]) =>
+          (c[0] as Record<string, unknown>)?.type === "terminal-reliability-metric" &&
+          ((c[0] as Record<string, unknown>)?.payload as Record<string, unknown>)?.metricType ===
+            "pause-duration-gauge"
+      );
+      expect(gaugeCalls).toHaveLength(0);
+
+      governor.dispose();
+    });
+
+    it("gracefully handles missing getPausedDurationsSnapshot dep", () => {
+      const deps = createMockDeps();
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+
+      expect(() => vi.advanceTimersByTime(2000)).not.toThrow();
+
+      governor.dispose();
+    });
+  });
+
+  describe("queue-depth-gauge", () => {
+    it("emits queue-depth-gauge with layer-tagged entries when metrics enabled", () => {
+      vi.mocked(metricsEnabled).mockReturnValue(true);
+
+      const deps = createMockDeps({
+        getQueueDepthSnapshot: vi.fn().mockReturnValue([
+          { terminalId: "t1", layer: "ipc", pendingBytes: 1024 },
+          { terminalId: "t1", layer: "port", pendingBytes: 2048 },
+          { terminalId: "t2", layer: "port", pendingBytes: 512 },
+        ]),
+      });
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      vi.advanceTimersByTime(2000);
+
+      expect(deps.sendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "terminal-reliability-metric",
+          payload: expect.objectContaining({
+            terminalId: "resource-governor",
+            metricType: "queue-depth-gauge",
+            perTerminalQueueDepth: [
+              { terminalId: "t1", layer: "ipc", pendingBytes: 1024 },
+              { terminalId: "t1", layer: "port", pendingBytes: 2048 },
+              { terminalId: "t2", layer: "port", pendingBytes: 512 },
+            ],
+          }),
+        })
+      );
+
+      governor.dispose();
+    });
+
+    it("does not emit gauge when metrics are disabled", () => {
+      vi.mocked(metricsEnabled).mockReturnValue(false);
+
+      const deps = createMockDeps({
+        getQueueDepthSnapshot: vi
+          .fn()
+          .mockReturnValue([{ terminalId: "t1", layer: "ipc", pendingBytes: 1024 }]),
+      });
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      vi.advanceTimersByTime(2000);
+
+      const calls = (deps.sendEvent as ReturnType<typeof vi.fn>).mock.calls;
+      const gaugeCalls = calls.filter(
+        (c: unknown[]) =>
+          (c[0] as Record<string, unknown>)?.type === "terminal-reliability-metric" &&
+          ((c[0] as Record<string, unknown>)?.payload as Record<string, unknown>)?.metricType ===
+            "queue-depth-gauge"
+      );
+      expect(gaugeCalls).toHaveLength(0);
+
+      governor.dispose();
+    });
+
+    it("does not emit gauge when snapshot is empty", () => {
+      vi.mocked(metricsEnabled).mockReturnValue(true);
+
+      const deps = createMockDeps({
+        getQueueDepthSnapshot: vi.fn().mockReturnValue([]),
+      });
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      vi.advanceTimersByTime(2000);
+
+      const calls = (deps.sendEvent as ReturnType<typeof vi.fn>).mock.calls;
+      const gaugeCalls = calls.filter(
+        (c: unknown[]) =>
+          (c[0] as Record<string, unknown>)?.type === "terminal-reliability-metric" &&
+          ((c[0] as Record<string, unknown>)?.payload as Record<string, unknown>)?.metricType ===
+            "queue-depth-gauge"
+      );
+      expect(gaugeCalls).toHaveLength(0);
+
+      governor.dispose();
+    });
+
+    it("gracefully handles missing getQueueDepthSnapshot dep", () => {
+      const deps = createMockDeps();
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+
+      expect(() => vi.advanceTimersByTime(2000)).not.toThrow();
+
+      governor.dispose();
+    });
+  });
+
+  describe("data-loss-count", () => {
+    it("emits data-loss-count with non-zero deltas when metrics enabled", () => {
+      vi.mocked(metricsEnabled).mockReturnValue(true);
+
+      const deps = createMockDeps({
+        getDropSnapshot: vi.fn().mockReturnValue({
+          droppedBytesDelta: 4096,
+          dataLossCountDelta: 3,
+        }),
+      });
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      vi.advanceTimersByTime(2000);
+
+      expect(deps.sendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "terminal-reliability-metric",
+          payload: expect.objectContaining({
+            terminalId: "resource-governor",
+            metricType: "data-loss-count",
+            droppedBytesDelta: 4096,
+            dataLossCountDelta: 3,
+          }),
+        })
+      );
+
+      governor.dispose();
+    });
+
+    it("does not emit when both deltas are zero (skip-when-zero)", () => {
+      vi.mocked(metricsEnabled).mockReturnValue(true);
+
+      const deps = createMockDeps({
+        getDropSnapshot: vi.fn().mockReturnValue({
+          droppedBytesDelta: 0,
+          dataLossCountDelta: 0,
+        }),
+      });
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      vi.advanceTimersByTime(2000);
+
+      const calls = (deps.sendEvent as ReturnType<typeof vi.fn>).mock.calls;
+      const gaugeCalls = calls.filter(
+        (c: unknown[]) =>
+          (c[0] as Record<string, unknown>)?.type === "terminal-reliability-metric" &&
+          ((c[0] as Record<string, unknown>)?.payload as Record<string, unknown>)?.metricType ===
+            "data-loss-count"
+      );
+      expect(gaugeCalls).toHaveLength(0);
+
+      governor.dispose();
+    });
+
+    it("emits when only one of the two deltas is non-zero (idempotent guard)", () => {
+      vi.mocked(metricsEnabled).mockReturnValue(true);
+
+      const deps = createMockDeps({
+        getDropSnapshot: vi.fn().mockReturnValue({
+          droppedBytesDelta: 0,
+          dataLossCountDelta: 2,
+        }),
+      });
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      vi.advanceTimersByTime(2000);
+
+      expect(deps.sendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            metricType: "data-loss-count",
+            droppedBytesDelta: 0,
+            dataLossCountDelta: 2,
+          }),
+        })
+      );
+
+      governor.dispose();
+    });
+
+    it("does not emit gauge when metrics are disabled", () => {
+      vi.mocked(metricsEnabled).mockReturnValue(false);
+
+      const deps = createMockDeps({
+        getDropSnapshot: vi.fn().mockReturnValue({
+          droppedBytesDelta: 4096,
+          dataLossCountDelta: 3,
+        }),
+      });
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      vi.advanceTimersByTime(2000);
+
+      const calls = (deps.sendEvent as ReturnType<typeof vi.fn>).mock.calls;
+      const gaugeCalls = calls.filter(
+        (c: unknown[]) =>
+          (c[0] as Record<string, unknown>)?.type === "terminal-reliability-metric" &&
+          ((c[0] as Record<string, unknown>)?.payload as Record<string, unknown>)?.metricType ===
+            "data-loss-count"
+      );
+      expect(gaugeCalls).toHaveLength(0);
+
+      governor.dispose();
+    });
+
+    it("gracefully handles missing getDropSnapshot dep", () => {
+      const deps = createMockDeps();
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+
+      expect(() => vi.advanceTimersByTime(2000)).not.toThrow();
+
+      governor.dispose();
+    });
+  });
+
   describe("host-memory-warning", () => {
     it("emits host-memory-warning when crossing warning threshold", () => {
       const deps = createMockDeps();

--- a/electron/pty-host/__tests__/backpressure.adversarial.test.ts
+++ b/electron/pty-host/__tests__/backpressure.adversarial.test.ts
@@ -439,5 +439,57 @@ describe("BackpressureManager adversarial", () => {
         })
       );
     });
+
+    it("does not recurse when the dep funnel re-enters the manager (prod wiring shape)", () => {
+      // Production wiring: the host constructs the manager with an
+      // `emitReliabilityMetric` dep pointing at the host funnel
+      // (`emitReliabilityMetricWithTracking`). That funnel MUST terminate the
+      // chain by emitting the wire event itself — if it instead called back
+      // into `manager.emitReliabilityMetric`, the manager would forward to the
+      // dep again and recurse until the stack overflows. This pins the
+      // invariant: a funnel-shaped dep that does its tracking and then sends
+      // directly yields exactly one wire emission, with the manager's
+      // dep-forwarding path entered exactly once (no loop).
+      const trackingCalls: Array<{ metricType: string; forceEmit: boolean }> = [];
+
+      // Matches the fixed `emitReliabilityMetricWithTracking`: it does its
+      // pause-source bookkeeping (elided here) and then TERMINATES by emitting
+      // the wire event directly. It does NOT re-enter the manager.
+      const funnel = vi.fn((payload: { metricType: string }, forceEmit: boolean) => {
+        trackingCalls.push({ metricType: payload.metricType, forceEmit });
+        sendEvent({ type: "terminal-reliability-metric", payload });
+      });
+
+      const manager = new BackpressureManager({
+        getTerminal: vi.fn(),
+        getPauseCoordinator: (id) =>
+          coordinators.get(id) as unknown as PtyPauseCoordinator | undefined,
+        sendEvent,
+        metricsEnabled: () => true,
+        emitReliabilityMetric: (payload, forceEmit = false) =>
+          funnel(payload as { metricType: string }, forceEmit),
+      });
+
+      expect(() =>
+        manager.emitReliabilityMetric({
+          terminalId: "term-1",
+          metricType: "pause-start",
+          timestamp: 1000,
+        })
+      ).not.toThrow();
+
+      // The funnel (dep) is invoked exactly once — one originating emit, no
+      // recursive re-entry.
+      expect(funnel).toHaveBeenCalledTimes(1);
+      expect(trackingCalls).toEqual([{ metricType: "pause-start", forceEmit: false }]);
+      // Exactly one wire emission reaches the transport.
+      expect(sendEvent).toHaveBeenCalledTimes(1);
+      expect(sendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "terminal-reliability-metric",
+          payload: expect.objectContaining({ metricType: "pause-start", terminalId: "term-1" }),
+        })
+      );
+    });
   });
 });

--- a/electron/pty-host/__tests__/backpressure.adversarial.test.ts
+++ b/electron/pty-host/__tests__/backpressure.adversarial.test.ts
@@ -361,4 +361,83 @@ describe("BackpressureManager adversarial", () => {
   it.todo(
     "safety-timeout force-resume behavior is orchestrated in electron/pty-host.ts rather than BackpressureManager"
   );
+
+  describe("emitReliabilityMetric dep funnel", () => {
+    // When the host wires `emitReliabilityMetric` as a dep, every
+    // internal reliability-metric emission must route through it
+    // (so the closure-scoped pause-tracking map in pty-host.ts can
+    // observe pause-start / pause-end / suspend). Without the dep,
+    // the manager falls back to the legacy inline wire emission.
+    it("routes internal emissions through the dep when provided", () => {
+      const dep = vi.fn();
+      const backpressure = new BackpressureManager({
+        getTerminal: vi.fn(),
+        getPauseCoordinator: (id) =>
+          coordinators.get(id) as unknown as PtyPauseCoordinator | undefined,
+        sendEvent,
+        metricsEnabled: () => true,
+        emitReliabilityMetric: dep,
+      });
+
+      backpressure.emitReliabilityMetric({
+        terminalId: "term-1",
+        metricType: "pause-start",
+        timestamp: 1000,
+      });
+
+      expect(dep).toHaveBeenCalledWith(
+        expect.objectContaining({ metricType: "pause-start", terminalId: "term-1" }),
+        false
+      );
+      // sendEvent must NOT be called when the dep is provided — the
+      // dep owns the wire emission.
+      expect(sendEvent).not.toHaveBeenCalled();
+    });
+
+    it("suspendVisualStream's internal suspend emission routes through the dep", () => {
+      const dep = vi.fn();
+      const backpressure = new BackpressureManager({
+        getTerminal: vi.fn(),
+        getPauseCoordinator: (id) =>
+          coordinators.get(id) as unknown as PtyPauseCoordinator | undefined,
+        sendEvent,
+        metricsEnabled: () => true,
+        emitReliabilityMetric: dep,
+      });
+
+      backpressure.suspendVisualStream("term-1", "stall", 85.0, 500, 1);
+
+      // The internal `suspend` emission from suspendVisualStream must
+      // also route through the dep (with forceEmit=true so the data-loss
+      // pulse still fires when metrics are off).
+      const suspendCalls = dep.mock.calls.filter(
+        (c) => (c[0] as { metricType: string }).metricType === "suspend"
+      );
+      expect(suspendCalls).toHaveLength(1);
+      expect(suspendCalls[0][1]).toBe(true);
+    });
+
+    it("falls back to inline wire emission when no dep is provided (legacy behavior)", () => {
+      const backpressure = new BackpressureManager({
+        getTerminal: vi.fn(),
+        getPauseCoordinator: (id) =>
+          coordinators.get(id) as unknown as PtyPauseCoordinator | undefined,
+        sendEvent,
+        metricsEnabled: () => true,
+      });
+
+      backpressure.emitReliabilityMetric({
+        terminalId: "term-1",
+        metricType: "pause-start",
+        timestamp: 1000,
+      });
+
+      expect(sendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "terminal-reliability-metric",
+          payload: expect.objectContaining({ metricType: "pause-start" }),
+        })
+      );
+    });
+  });
 });

--- a/electron/pty-host/backpressure.ts
+++ b/electron/pty-host/backpressure.ts
@@ -41,6 +41,14 @@ export interface BackpressureDeps {
   getPauseCoordinator: (id: string) => PtyPauseCoordinator | undefined;
   sendEvent: (event: PtyHostEvent) => void;
   metricsEnabled: () => boolean;
+  /**
+   * Optional override for the canonical reliability-metric funnel. When
+   * supplied, internal `pause-start` / `pause-end` / `suspend` emissions
+   * route through this dep (so the host can update its per-source
+   * pause-tracking map before the wire event fires). When omitted, the
+   * internal default just sends the wire event (legacy behavior).
+   */
+  emitReliabilityMetric?: (payload: TerminalReliabilityMetricPayload, forceEmit?: boolean) => void;
 }
 
 export class BackpressureManager {
@@ -239,6 +247,15 @@ export class BackpressureManager {
   }
 
   emitReliabilityMetric(payload: TerminalReliabilityMetricPayload, forceEmit = false): void {
+    if (this.deps.emitReliabilityMetric) {
+      // Route through the host-supplied funnel so per-source pause
+      // tracking (held-duration map) stays in sync with wire emissions.
+      this.deps.emitReliabilityMetric(payload, forceEmit);
+      return;
+    }
+    // Legacy default: just emit the wire event. The funnel dep is the
+    // canonical path; this branch is kept only for tests/embedders that
+    // construct BackpressureManager without supplying one.
     if (!forceEmit && !this.deps.metricsEnabled()) return;
     this.deps.sendEvent({
       type: "terminal-reliability-metric",

--- a/electron/pty-host/portQueue.ts
+++ b/electron/pty-host/portQueue.ts
@@ -95,6 +95,18 @@ export class PortQueueManager {
     return this.pausedTerminals.has(id);
   }
 
+  /**
+   * Iterator over the terminal IDs currently held by this port-queue
+   * manager's pause tokens. Used by the host's `disconnectWindow` path
+   * to clear per-source pause-tracking entries scoped to the
+   * disconnecting window — multi-source attribution means the IPC
+   * queue may still hold the same terminal and we must not clobber
+   * that path's tracking.
+   */
+  getPausedTerminalIds(): IterableIterator<string> {
+    return this.pausedTerminals.keys();
+  }
+
   applyBackpressure(id: string, utilization: number): boolean {
     const highWatermarkBytes = (IPC_MAX_QUEUE_BYTES * IPC_HIGH_WATERMARK_PERCENT) / 100;
     const currentBytes = this.queuedBytes.get(id) ?? 0;

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -140,6 +140,7 @@ import type {
   TerminalResourceBatchPayload,
   BroadcastWriteResultPayload,
   FdLeakWarningPayload,
+  TerminalReliabilityMetricPayload,
 } from "../pty-host.js";
 import type {
   FileSearchPayload,
@@ -266,6 +267,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     onRestored(callback: (data: { id: string }) => void): () => void;
     forceResume(id: string): Promise<void>;
     onStatus(callback: (data: TerminalStatusPayload) => void): () => void;
+    onReliabilityMetric(callback: (data: TerminalReliabilityMetricPayload) => void): () => void;
     onResourceMetrics(
       callback: (data: { metrics: TerminalResourceBatchPayload; timestamp: number }) => void
     ): () => void;

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -327,6 +327,17 @@ export interface PtyPanelData extends BasePanelData {
   flowStatusTimestamp?: number;
   /** Whether user input is locked (read-only monitor mode) */
   isInputLocked?: boolean;
+  /**
+   * Held duration gauge for currently-paused terminals, sampled by the
+   * `pause-duration-gauge` reliability metric (2s tick). Distinct from
+   * `flowStatus` (a transition) and from `pauseDuration` on the
+   * `terminal-status` event (a one-shot at transition time) — this is a
+   * continuous observation that updates while the terminal is paused and
+   * is cleared on `pause-end`. Surfaced in the Tier-1 status pill
+   * tooltip so users can tell "5s pause for a big burst" from
+   * "renderer wedged for two minutes".
+   */
+  heldDurationMs?: number;
   /** Current URL for browser/dev-preview panels */
   browserUrl?: string;
   /** Navigation history for browser/dev-preview panels */

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -547,7 +547,10 @@ export interface TerminalReliabilityMetricPayload {
     | "pending-byte-cap-hit"
     | "pending-bytes-gauge"
     | "throughput-rate"
-    | "tier-transition";
+    | "tier-transition"
+    | "pause-duration-gauge"
+    | "queue-depth-gauge"
+    | "data-loss-count";
   timestamp: number;
   durationMs?: number;
   bufferUtilization?: number;
@@ -571,6 +574,33 @@ export interface TerminalReliabilityMetricPayload {
   tierTransitionReason?: string;
   /** Snapshot of pause-coordinator holds at transition time (sorted, possibly empty). */
   tierTransitionHeldTokens?: string[];
+  /**
+   * Used by `pause-duration-gauge`: per-paused-terminal held duration sampled
+   * at the metric tick. Field name `heldDurationMs` distinguishes the gauge
+   * (a point-in-time state) from `durationMs` on `pause-end` (a span resolved
+   * at resume).
+   */
+  perTerminalHeld?: Array<{ terminalId: string; heldDurationMs: number }>;
+  /**
+   * Used by `queue-depth-gauge`: per-terminal queue depth for the live IPC
+   * and per-window MessagePort paths. Excludes the FUTURE_SAB path
+   * (dead in production) so the dead-code and live paths stay independently
+   * observable. The `layer` discriminator lets consumers split per-path
+   * attribution in one pass.
+   */
+  perTerminalQueueDepth?: Array<{
+    terminalId: string;
+    layer: "ipc" | "port";
+    pendingBytes: number;
+  }>;
+  /**
+   * Used by `data-loss-count`: number of bytes dropped since the last tick.
+   * Always paired with `dataLossCountDelta` (one or more chunks may be
+   * dropped per drop event).
+   */
+  droppedBytesDelta?: number;
+  /** Used by `data-loss-count`: number of drop events since the last tick. */
+  dataLossCountDelta?: number;
 }
 
 /**

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -11,7 +11,10 @@ import type {
   BroadcastWriteResultPayload,
   SpawnResult,
 } from "@shared/types";
-import type { PtyHostToRendererMessage } from "@shared/types/pty-host";
+import type {
+  PtyHostToRendererMessage,
+  TerminalReliabilityMetricPayload,
+} from "@shared/types/pty-host";
 import { logDebug, logWarn } from "@/utils/logger";
 
 let messagePort: MessagePort | null = null;
@@ -452,6 +455,18 @@ export const terminalClient = {
    */
   onStatus: (callback: (data: TerminalStatusPayload) => void): (() => void) => {
     return window.electron.terminal.onStatus(callback);
+  },
+
+  /**
+   * Listen for terminal reliability metrics (pause-start/end, suspend,
+   * pending-bytes-gauge, throughput-rate, pause-duration-gauge,
+   * queue-depth-gauge, data-loss-count). Emitted by the host's
+   * `ResourceGovernor` tick and the queue managers' pause/resume paths.
+   */
+  onReliabilityMetric: (
+    callback: (data: TerminalReliabilityMetricPayload) => void
+  ): (() => void) => {
+    return window.electron.terminal.onReliabilityMetric(callback);
   },
 
   /**

--- a/src/components/Terminal/TerminalHeaderContent.tsx
+++ b/src/components/Terminal/TerminalHeaderContent.tsx
@@ -396,11 +396,11 @@ export function TerminalHeaderContent({
             <div className="flex flex-col gap-0.5">
               <span className="font-medium">System memory pressure</span>
               <span>Paused to reduce memory pressure. Recovers automatically.</span>
-              {heldDurationMs != null && heldDurationMs > 0 && (
-                <span className="text-daintree-text/60 tabular-nums">
-                  Paused for {formatElapsedDuration(heldDurationMs)}
-                </span>
-              )}
+              {/* Held-duration gauge intentionally omitted: ResourceGovernor
+                  pauses via the coordinator but does not emit `pause-start`
+                  / `pause-end` reliability metrics, so the
+                  `pause-duration-gauge` funnel never tracks it. Showing
+                  a frozen "Paused for Xs" line would be a lie. */}
             </div>
           </TooltipContent>
         </Tooltip>

--- a/src/components/Terminal/TerminalHeaderContent.tsx
+++ b/src/components/Terminal/TerminalHeaderContent.tsx
@@ -158,6 +158,7 @@ export function TerminalHeaderContent({
     stateChangeConfidence,
     sessionCost,
     sessionTokens,
+    heldDurationMs,
   } = usePanelStore(
     useShallow((state) => {
       const t = state.panelsById[id];
@@ -170,6 +171,7 @@ export function TerminalHeaderContent({
         stateChangeConfidence: pty?.stateChangeConfidence,
         sessionCost: pty?.sessionCost,
         sessionTokens: pty?.sessionTokens,
+        heldDurationMs: pty?.heldDurationMs,
       };
     })
   );
@@ -366,6 +368,11 @@ export function TerminalHeaderContent({
             <div className="flex flex-col gap-0.5">
               <span className="font-medium">Buffer overflow</span>
               <span>Output paused to prevent data loss.</span>
+              {heldDurationMs != null && heldDurationMs > 0 && (
+                <span className="text-daintree-text/60 tabular-nums">
+                  Paused for {formatElapsedDuration(heldDurationMs)}
+                </span>
+              )}
             </div>
           </TooltipContent>
         </Tooltip>
@@ -389,6 +396,11 @@ export function TerminalHeaderContent({
             <div className="flex flex-col gap-0.5">
               <span className="font-medium">System memory pressure</span>
               <span>Paused to reduce memory pressure. Recovers automatically.</span>
+              {heldDurationMs != null && heldDurationMs > 0 && (
+                <span className="text-daintree-text/60 tabular-nums">
+                  Paused for {formatElapsedDuration(heldDurationMs)}
+                </span>
+              )}
             </div>
           </TooltipContent>
         </Tooltip>
@@ -412,6 +424,11 @@ export function TerminalHeaderContent({
             <div className="flex flex-col gap-0.5">
               <span className="font-medium">Output suspended</span>
               <span>Streaming stalled. Recovers automatically on focus.</span>
+              {heldDurationMs != null && heldDurationMs > 0 && (
+                <span className="text-daintree-text/60 tabular-nums">
+                  Paused for {formatElapsedDuration(heldDurationMs)}
+                </span>
+              )}
             </div>
           </TooltipContent>
         </Tooltip>

--- a/src/controllers/TerminalRegistryController.ts
+++ b/src/controllers/TerminalRegistryController.ts
@@ -25,6 +25,7 @@ import type {
   TerminalStatusPayload,
   SpawnResult,
 } from "@shared/types";
+import type { TerminalReliabilityMetricPayload } from "@shared/types/pty-host";
 import { getAgentConfig } from "@/config/agents";
 import { getTerminalAppearanceSnapshot } from "@/hooks/useTerminalAppearance";
 import { getScrollbackForType, PERFORMANCE_MODE_SCROLLBACK } from "@/utils/scrollbackConfig";
@@ -302,6 +303,10 @@ class TerminalRegistryController {
 
   onStatus(handler: (data: TerminalStatusPayload) => void) {
     return terminalClient.onStatus(handler);
+  }
+
+  onReliabilityMetric(handler: (data: TerminalReliabilityMetricPayload) => void) {
+    return terminalClient.onReliabilityMetric(handler);
   }
 
   onBackendCrashed(

--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -109,6 +109,10 @@ const PTY_FIELD_CLASSIFICATION = {
   // serialization layer in panelToSnapshot, not the PTY serializer.
   createdAt: false,
   lastActiveAt: false,
+  // Held-duration gauge — observational, sampled by the host's
+  // `pause-duration-gauge` reliability metric; not part of the
+  // persistent terminal snapshot.
+  heldDurationMs: false,
 } as const satisfies Record<keyof PtySerializeInput, boolean>;
 
 // ── Browser field classification ─────────────────────────────────────

--- a/src/store/__tests__/panelStore.processDetectionListeners.test.ts
+++ b/src/store/__tests__/panelStore.processDetectionListeners.test.ts
@@ -33,6 +33,11 @@ type TrashedHandler = (data: { id: string; expiresAt: number }) => void;
 type RestoredHandler = (data: { id: string }) => void;
 type ExitHandler = (id: string, exitCode: number) => void;
 type StatusHandler = (data: { id: string; status: string; timestamp: number }) => void;
+type ReliabilityMetricHandler = (data: {
+  metricType: string;
+  terminalId?: string;
+  perTerminalHeld?: Array<{ terminalId: string; heldDurationMs: number }>;
+}) => void;
 type BackendCrashedHandler = (data: {
   crashType: string;
   code: number | null;
@@ -57,6 +62,7 @@ const handlers: {
   restored?: RestoredHandler;
   exit?: ExitHandler;
   status?: StatusHandler;
+  reliabilityMetric?: ReliabilityMetricHandler;
   backendCrashed?: BackendCrashedHandler;
   backendRecovering?: BackendRecoveringHandler;
   backendReady?: BackendReadyHandler;
@@ -72,6 +78,7 @@ const unsubs = {
   restored: vi.fn(),
   exit: vi.fn(),
   status: vi.fn(),
+  reliabilityMetric: vi.fn(),
   backendCrashed: vi.fn(),
   backendRecovering: vi.fn(),
   backendReady: vi.fn(),
@@ -109,6 +116,10 @@ const onExitMock = vi.fn((cb: ExitHandler) => {
 const onStatusMock = vi.fn((cb: StatusHandler) => {
   handlers.status = cb;
   return unsubs.status;
+});
+const onReliabilityMetricMock = vi.fn((cb: ReliabilityMetricHandler) => {
+  handlers.reliabilityMetric = cb;
+  return unsubs.reliabilityMetric;
 });
 const onBackendCrashedMock = vi.fn((cb: BackendCrashedHandler) => {
   handlers.backendCrashed = cb;
@@ -153,6 +164,7 @@ vi.mock("@/clients", () => ({
     onTrashed: onTrashedMock,
     onRestored: onRestoredMock,
     onStatus: onStatusMock,
+    onReliabilityMetric: onReliabilityMetricMock,
     onBackendCrashed: onBackendCrashedMock,
     onBackendRecovering: onBackendRecoveringMock,
     onBackendReady: onBackendReadyMock,

--- a/src/store/listeners/panel/__tests__/lifecycle.test.ts
+++ b/src/store/listeners/panel/__tests__/lifecycle.test.ts
@@ -25,6 +25,16 @@ vi.mock("@/utils/logger", () => ({
 }));
 
 const restoredHandlers = vi.hoisted(() => [] as Array<(data: { id: string }) => void>);
+const reliabilityMetricHandlers = vi.hoisted(
+  () =>
+    [] as Array<
+      (payload: {
+        metricType: string;
+        terminalId?: string;
+        perTerminalHeld?: Array<{ terminalId: string; heldDurationMs: number }>;
+      }) => void
+    >
+);
 vi.mock("@/controllers", () => {
   const noopSub = () => () => {};
   return {
@@ -37,6 +47,18 @@ vi.mock("@/controllers", () => {
       }),
       onExit: vi.fn(noopSub),
       onStatus: vi.fn(noopSub),
+      onReliabilityMetric: vi.fn(
+        (
+          handler: (payload: {
+            metricType: string;
+            terminalId?: string;
+            perTerminalHeld?: Array<{ terminalId: string; heldDurationMs: number }>;
+          }) => void
+        ) => {
+          reliabilityMetricHandlers.push(handler);
+          return () => {};
+        }
+      ),
       onSpawnResult: vi.fn(noopSub),
       onReduceScrollback: vi.fn(noopSub),
       onRestoreScrollback: vi.fn(noopSub),
@@ -46,6 +68,14 @@ vi.mock("@/controllers", () => {
 
 import { handleFallbackTriggered, setupLifecycleListeners } from "../lifecycle";
 import { notify } from "@/lib/notify";
+import { flushPanelStatusBuffer } from "@/store/panelStatusBuffer";
+import { isPtyPanel } from "@shared/types/panel";
+
+function getPtyHeldDuration(id: string): number | undefined {
+  const panel = usePanelStore.getState().panelsById[id];
+  if (!panel || !isPtyPanel(panel)) return undefined;
+  return panel.heldDurationMs;
+}
 
 const actionMatcher = {
   label: "Open agent settings",
@@ -330,5 +360,80 @@ describe("onRestored — dock popover preservation (#8368)", () => {
 
     expect(usePanelStore.getState().activeDockTerminalId).toBeNull();
     expect(usePanelStore.getState().focusedId).toBe("term-1");
+  });
+});
+
+describe("onReliabilityMetric — pause-duration-gauge routing", () => {
+  function getReliabilityHandler(): (payload: {
+    metricType: string;
+    terminalId?: string;
+    perTerminalHeld?: Array<{ terminalId: string; heldDurationMs: number }>;
+  }) => void {
+    reliabilityMetricHandlers.length = 0;
+    setupLifecycleListeners();
+    const handler = reliabilityMetricHandlers.at(-1);
+    if (!handler) throw new Error("onReliabilityMetric handler was not registered");
+    return handler;
+  }
+
+  it("routes perTerminalHeld entries to heldDurationMs on matching PTY panels", () => {
+    setupPanel();
+    const handler = getReliabilityHandler();
+
+    handler({
+      metricType: "pause-duration-gauge",
+      perTerminalHeld: [{ terminalId: "term-1", heldDurationMs: 4500 }],
+    });
+
+    // Flush the RAF-coalesced buffer.
+    flushPanelStatusBuffer();
+
+    expect(getPtyHeldDuration("term-1")).toBe(4500);
+  });
+
+  it("clears heldDurationMs for terminals on a pause-end (resumed)", () => {
+    setupPanel({ heldDurationMs: 5000 });
+    const handler = getReliabilityHandler();
+
+    handler({ metricType: "pause-end", terminalId: "term-1" });
+    flushPanelStatusBuffer();
+
+    expect(getPtyHeldDuration("term-1")).toBeUndefined();
+  });
+
+  it("clears heldDurationMs for terminals on a suspend (dropped-don't-block)", () => {
+    setupPanel({ heldDurationMs: 9000 });
+    const handler = getReliabilityHandler();
+
+    handler({ metricType: "suspend", terminalId: "term-1" });
+    flushPanelStatusBuffer();
+
+    expect(getPtyHeldDuration("term-1")).toBeUndefined();
+  });
+
+  it("ignores non-pause-duration-gauge metric types", () => {
+    setupPanel();
+    const handler = getReliabilityHandler();
+
+    handler({ metricType: "queue-depth-gauge" });
+    handler({ metricType: "data-loss-count" });
+    handler({ metricType: "throughput-rate" });
+    flushPanelStatusBuffer();
+
+    expect(getPtyHeldDuration("term-1")).toBeUndefined();
+  });
+
+  it("ignores pause-duration-gauge entries for terminals that don't exist as panels", () => {
+    setupPanel();
+    const handler = getReliabilityHandler();
+
+    handler({
+      metricType: "pause-duration-gauge",
+      perTerminalHeld: [{ terminalId: "ghost-terminal", heldDurationMs: 9999 }],
+    });
+    flushPanelStatusBuffer();
+
+    expect(getPtyHeldDuration("term-1")).toBeUndefined();
+    expect(usePanelStore.getState().panelsById["ghost-terminal"]).toBeUndefined();
   });
 });

--- a/src/store/listeners/panel/__tests__/lifecycle.test.ts
+++ b/src/store/listeners/panel/__tests__/lifecycle.test.ts
@@ -436,4 +436,30 @@ describe("onReliabilityMetric — pause-duration-gauge routing", () => {
     expect(getPtyHeldDuration("term-1")).toBeUndefined();
     expect(usePanelStore.getState().panelsById["ghost-terminal"]).toBeUndefined();
   });
+
+  it("pause-end clears a buffered (but unflushed) heldDurationMs patch", () => {
+    // Locks in the cross-frame race fix: a `pause-duration-gauge`
+    // patch enqueues a value into the RAF buffer; a `pause-end` arrives
+    // before the RAF flushes; the committed (post-flush) value is still
+    // `undefined` so an old guard would skip the clear. With the guard
+    // removed, the buffer's null-wins semantics correctly clear the
+    // buffered non-null patch before flush.
+    setupPanel();
+    const handler = getReliabilityHandler();
+
+    // Frame 1: gauge arrives, enqueues non-null into buffer (no flush).
+    handler({
+      metricType: "pause-duration-gauge",
+      perTerminalHeld: [{ terminalId: "term-1", heldDurationMs: 2000 }],
+    });
+    // Do NOT flush — simulate the in-flight RAF.
+
+    // Frame 1 continued: pause-end arrives synchronously, enqueues null.
+    handler({ metricType: "pause-end", terminalId: "term-1" });
+
+    // Now flush — the null-wins behavior must clobber the buffered 2000.
+    flushPanelStatusBuffer();
+
+    expect(getPtyHeldDuration("term-1")).toBeUndefined();
+  });
 });

--- a/src/store/listeners/panel/__tests__/panelStatusBuffer.test.ts
+++ b/src/store/listeners/panel/__tests__/panelStatusBuffer.test.ts
@@ -4,8 +4,10 @@ import { usePanelStore } from "@/store/panelStore";
 import type { PtyPanelData } from "@shared/types/panel";
 import {
   cancelPanelStatusBuffer,
+  clearHeldDuration,
   enqueueActivityUpdate,
   enqueueFlowStatusUpdate,
+  enqueueHeldDurationUpdate,
   flushPanelStatusBuffer,
 } from "@/store/panelStatusBuffer";
 
@@ -291,5 +293,72 @@ describe("panelStatusBuffer — lifecycle", () => {
     enqueueFlowStatusUpdate("term-1", "suspended", 100);
 
     expect(raf.callbacks).toHaveLength(1);
+  });
+});
+
+describe("panelStatusBuffer — held-duration batching", () => {
+  it("applies per-terminal held duration patches on flush", () => {
+    seedPanel("term-1");
+    enqueueHeldDurationUpdate("term-1", 4000);
+    raf.flushAll();
+    expect(getPtyPanel("term-1")?.heldDurationMs).toBe(4000);
+  });
+
+  it("last-write-wins within a frame for the same terminal", () => {
+    seedPanel("term-1");
+    enqueueHeldDurationUpdate("term-1", 1000);
+    enqueueHeldDurationUpdate("term-1", 2000);
+    raf.flushAll();
+    expect(getPtyPanel("term-1")?.heldDurationMs).toBe(2000);
+  });
+
+  it("clearHeldDuration sets heldDurationMs to undefined", () => {
+    seedPanel("term-1", { heldDurationMs: 5000 });
+    clearHeldDuration("term-1");
+    raf.flushAll();
+    expect(getPtyPanel("term-1")?.heldDurationMs).toBeUndefined();
+  });
+
+  it("non-null patch does not clobber a pending null for the same terminal", () => {
+    // A fresh tick reporting the terminal is no longer paused (null)
+    // must win over a stale non-null entry from a previous tick.
+    seedPanel("term-1", { heldDurationMs: 8000 });
+    clearHeldDuration("term-1");
+    enqueueHeldDurationUpdate("term-1", 12000);
+    raf.flushAll();
+    expect(getPtyPanel("term-1")?.heldDurationMs).toBeUndefined();
+  });
+
+  it("clearHeldDuration is a no-op when a null is already buffered", () => {
+    seedPanel("term-1", { heldDurationMs: 5000 });
+    clearHeldDuration("term-1");
+    clearHeldDuration("term-1");
+    enqueueHeldDurationUpdate("term-1", 9999);
+    raf.flushAll();
+    // Second null is a fast-path no-op; the subsequent non-null must
+    // be ignored (null wins). Final value is undefined.
+    expect(getPtyPanel("term-1")?.heldDurationMs).toBeUndefined();
+  });
+
+  it("combines with activity + flow-status in a single flush", () => {
+    seedPanel("term-1", { isVisible: true });
+    enqueueActivityUpdate("term-1", "Working", "working", "interactive", 100, "cmd");
+    enqueueFlowStatusUpdate("term-1", "paused-backpressure", 100);
+    enqueueHeldDurationUpdate("term-1", 6000);
+    const setSpy = vi.spyOn(usePanelStore, "setState");
+    raf.flushAll();
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    const t = getPtyPanel("term-1");
+    expect(t?.activityHeadline).toBe("Working");
+    expect(t?.flowStatus).toBe("paused-backpressure");
+    expect(t?.heldDurationMs).toBe(6000);
+  });
+
+  it("flush is a no-op when only held-duration buffer is empty", () => {
+    seedPanel("term-1");
+    const setSpy = vi.spyOn(usePanelStore, "setState");
+    // Force a "tick" by enqueuing an empty flush — no buffers populated.
+    flushPanelStatusBuffer();
+    expect(setSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/store/listeners/panel/lifecycle.ts
+++ b/src/store/listeners/panel/lifecycle.ts
@@ -1,4 +1,5 @@
 import type { TerminalStatusPayload } from "@shared/types";
+import type { TerminalReliabilityMetricPayload } from "@shared/types/pty-host";
 import { isPtyPanel } from "@shared/types/panel";
 import { terminalRegistryController } from "@/controllers";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
@@ -8,7 +9,11 @@ import { isAgentTerminal } from "@/utils/terminalType";
 import { logInfo, logError } from "@/utils/logger";
 import { isTerminalRestarting } from "@/store/restartExitSuppression";
 import { usePanelStore, type PanelGridState } from "@/store/panelStore";
-import { enqueueFlowStatusUpdate } from "@/store/panelStatusBuffer";
+import {
+  enqueueFlowStatusUpdate,
+  enqueueHeldDurationUpdate,
+  clearHeldDuration,
+} from "@/store/panelStatusBuffer";
 import { DisposableStore, toDisposable } from "@/utils/disposable";
 import { getMergedPresets } from "@/config/agents";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
@@ -362,6 +367,54 @@ export function setupLifecycleListeners(): DisposableStore {
           terminalInstanceService.wake(id);
         }
       })
+    )
+  );
+
+  d.add(
+    toDisposable(
+      terminalRegistryController.onReliabilityMetric(
+        (payload: TerminalReliabilityMetricPayload) => {
+          // `pause-end` and `suspend` are the canonical resume signals —
+          // clear the held-duration gauge for the terminal so a stale
+          // value doesn't outlive the actual pause. `pause-duration-gauge`
+          // is the skip-when-empty gauge that drives the held-duration
+          // tooltip body. Other metric types (queue-depth-gauge,
+          // data-loss-count, pending-bytes-gauge, throughput-rate) are
+          // host-side telemetry sinks — observable via the host log
+          // stream and ignored here.
+          if (payload.metricType === "pause-end" || payload.metricType === "suspend") {
+            const terminal = usePanelStore.getState().panelsById[payload.terminalId];
+            if (terminal && isPtyPanel(terminal) && terminal.heldDurationMs !== undefined) {
+              clearHeldDuration(payload.terminalId);
+            }
+            return;
+          }
+          if (payload.metricType !== "pause-duration-gauge") return;
+          const entries = payload.perTerminalHeld;
+
+          // Snapshot the panel map once per tick so we can both update
+          // terminals present in the gauge AND clear terminals absent from
+          // it (a terminal that was paused on the last tick but is no
+          // longer in the gauge has resumed — clear its stale value).
+          const panelsById = usePanelStore.getState().panelsById;
+          const seenIds = new Set<string>();
+          if (entries) {
+            for (const entry of entries) {
+              const terminal = panelsById[entry.terminalId];
+              if (!terminal || !isPtyPanel(terminal)) continue;
+              seenIds.add(entry.terminalId);
+              enqueueHeldDurationUpdate(entry.terminalId, entry.heldDurationMs);
+            }
+          }
+          for (const id of Object.keys(panelsById)) {
+            if (seenIds.has(id)) continue;
+            const terminal = panelsById[id];
+            if (!terminal || !isPtyPanel(terminal)) continue;
+            if (terminal.heldDurationMs === undefined) continue;
+            clearHeldDuration(id);
+          }
+        }
+      )
     )
   );
 

--- a/src/store/listeners/panel/lifecycle.ts
+++ b/src/store/listeners/panel/lifecycle.ts
@@ -384,7 +384,15 @@ export function setupLifecycleListeners(): DisposableStore {
           // stream and ignored here.
           if (payload.metricType === "pause-end" || payload.metricType === "suspend") {
             const terminal = usePanelStore.getState().panelsById[payload.terminalId];
-            if (terminal && isPtyPanel(terminal) && terminal.heldDurationMs !== undefined) {
+            if (terminal && isPtyPanel(terminal)) {
+              // Always enqueue the clear — the buffer's null-wins
+              // semantics correctly handle the cross-frame race where a
+              // non-null `pause-duration-gauge` patch was enqueued but
+              // hasn't been flushed yet. Skipping the enqueue based on
+              // the committed (post-flush) `heldDurationMs` would let
+              // the buffered non-null value resurrect after the
+              // terminal resumed. The fold's same-value skip makes a
+              // redundant enqueue cheap when nothing is buffered.
               clearHeldDuration(payload.terminalId);
             }
             return;

--- a/src/store/panelStatusBuffer.ts
+++ b/src/store/panelStatusBuffer.ts
@@ -26,8 +26,19 @@ interface FlowStatusPatch {
   timestamp: number;
 }
 
+/**
+ * Held-duration gauge patch. `null` clears the value (terminal no longer
+ * paused); a number sets it. A `null` patch always wins within a single
+ * frame so a fresh "no longer paused" signal isn't clobbered by a stale
+ * non-null patch from the same flush.
+ */
+interface HeldDurationPatch {
+  heldDurationMs: number | null;
+}
+
 const activityBuffer = new Map<string, ActivityPatch>();
 const flowStatusBuffer = new Map<string, FlowStatusPatch>();
+const heldDurationBuffer = new Map<string, HeldDurationPatch>();
 let rafId: number | null = null;
 
 function schedule(): void {
@@ -70,17 +81,51 @@ export function enqueueFlowStatusUpdate(
   schedule();
 }
 
+/**
+ * Set the held-duration gauge for a currently-paused terminal. Sampled
+ * by the host's `pause-duration-gauge` reliability metric on each 2s
+ * tick; consumers should expect the value to grow monotonically while
+ * paused and to clear shortly after `pause-end`.
+ */
+export function enqueueHeldDurationUpdate(terminalId: string, heldDurationMs: number): void {
+  // Non-null patches do not clobber a pending null for the same terminal —
+  // a `null` from a fresh tick (terminal no longer in the gauge) wins
+  // because the host has already stopped emitting it. Without this guard
+  // a stale non-null entry from a previous tick could resurrect a value
+  // for a terminal that's already resumed.
+  const existing = heldDurationBuffer.get(terminalId);
+  if (existing?.heldDurationMs === null) return;
+  heldDurationBuffer.set(terminalId, { heldDurationMs });
+  schedule();
+}
+
+/**
+ * Clear the held-duration gauge for a terminal that is no longer paused.
+ * Safe to call when no gauge is set — the no-op is a fast path. Schedules
+ * a flush if needed.
+ */
+export function clearHeldDuration(terminalId: string): void {
+  const existing = heldDurationBuffer.get(terminalId);
+  if (existing?.heldDurationMs === null) return;
+  heldDurationBuffer.set(terminalId, { heldDurationMs: null });
+  schedule();
+}
+
 export function flushPanelStatusBuffer(): void {
   rafId = null;
-  if (activityBuffer.size === 0 && flowStatusBuffer.size === 0) return;
+  if (activityBuffer.size === 0 && flowStatusBuffer.size === 0 && heldDurationBuffer.size === 0) {
+    return;
+  }
 
   // Snapshot and clear before the setState updater runs. Clearing first lets
   // re-entrant enqueues during subscriber callbacks land in a fresh frame
   // rather than being silently dropped by a later iteration of this fold.
   const activity = activityBuffer.size > 0 ? new Map(activityBuffer) : null;
   const flow = flowStatusBuffer.size > 0 ? new Map(flowStatusBuffer) : null;
+  const held = heldDurationBuffer.size > 0 ? new Map(heldDurationBuffer) : null;
   activityBuffer.clear();
   flowStatusBuffer.clear();
+  heldDurationBuffer.clear();
 
   usePanelStore.setState((state) => {
     const nextById = { ...state.panelsById };
@@ -142,6 +187,22 @@ export function flushPanelStatusBuffer(): void {
       }
     }
 
+    if (held) {
+      for (const [id, patch] of held) {
+        const terminal = nextById[id];
+        if (!terminal || !isPtyPanel(terminal)) continue;
+        if (terminal.heldDurationMs === patch.heldDurationMs) continue;
+        nextById[id] = {
+          ...terminal,
+          // `null` clears the field via destructuring-rest; a number sets it.
+          ...(patch.heldDurationMs === null
+            ? { heldDurationMs: undefined }
+            : { heldDurationMs: patch.heldDurationMs }),
+        };
+        changed = true;
+      }
+    }
+
     if (!changed) return state;
     return { panelsById: nextById };
   });
@@ -154,4 +215,5 @@ export function cancelPanelStatusBuffer(): void {
   rafId = null;
   activityBuffer.clear();
   flowStatusBuffer.clear();
+  heldDurationBuffer.clear();
 }


### PR DESCRIPTION
## Summary

Extends the existing `terminal-reliability-metric` event with the three natural gaps that remain: a held-duration gauge for currently-paused terminals, a per-terminal queue-depth gauge, and a data-loss counter. No new IPC channel — the existing event gets three new `metricType` discriminants and the held duration surfaces in the Tier-1 status pill tooltip so users can tell a 5-second pause for a big burst apart from a renderer that's wedged for two minutes.

Resolves #9807

## Changes

- `pause-duration-gauge` — closure-scoped `pausedTerminals` map in `pty-host.ts` with per-source attribution (SAB, IPC, `port-{windowId}`). Aggregated across all pause sources so a `pause-end` from one path only clears that path's hold. Held duration is the oldest start across all sources.
- `queue-depth-gauge` — per-terminal queue depth for the live IPC and per-window port paths (SAB is dead-code, excluded). Each entry tagged with `layer: "ipc" | "port"`.
- `data-loss-count` — closure-scoped `dropAccumulator` incremented unconditionally at the drop site. Emitted as delta-style `dataLossCountDelta` + `droppedBytesDelta`; the counter is reset on every tick regardless of the metrics gate to prevent false backfill.
- Renderer: new `heldDurationMs?` field on `PtyPanelData`, populated by a new listener on `terminal-reliability-metric` that routes `pause-duration-gauge` to a RAF-coalesced buffer and clears it on `pause-end` / `suspend`. Surfaced as a third informational line in the paused-backpressure and suspended Tier-1 status pill tooltips (resource-governor intentionally omits it — `ResourceGovernor` doesn't emit reliability metrics).
- New `PortQueueManager.getPausedTerminalIds()` helper so disconnect cleanup can release the matching per-window holds.

## Testing

- `npm run check` clean: typecheck, `check:channels`, `check:crash-loop-constants`, `check:ipc`, `check:ipc-renderer`, `check:ipc-handwritten` (267 baseline unchanged), `check:help`, `check:confirm-wiring`, `lint:ratchet` (1194 baseline unchanged), `format:check`.
- 2684 vitest tests pass locally, including new coverage for `ResourceGovernor` and the new backpressure adversarial cases.