### PR TITLE
fix(toolbar): sentence-case labels and add Customize entry to every menu

### DIFF
--- a/e2e/full/panels/core-toolbar-overflow.spec.ts
+++ b/e2e/full/panels/core-toolbar-overflow.spec.ts
@@ -18,7 +18,7 @@ function escapeRegExp(value: string): string {
 
 const overflowMenuLabels: Record<string, string> = {
   "Open settings": "Settings",
-  "Open Terminal": "Terminal",
+  "Open terminal": "Terminal",
 };
 
 async function expectToolbarActionReachable(page: AppContext["window"], name: string) {
@@ -94,7 +94,7 @@ test.describe.serial("Core: Toolbar Overflow", () => {
     // actions into overflow on constrained CI displays; the contract is
     // reachability from the toolbar surface.
     await expectToolbarActionReachable(window, "Open settings");
-    await expectToolbarActionReachable(window, "Open Terminal");
+    await expectToolbarActionReachable(window, "Open terminal");
     await expect(toolbarButton(window, "Toggle Sidebar")).toBeVisible({ timeout: T_SHORT });
   });
 
@@ -295,6 +295,6 @@ test.describe.serial("Core: Toolbar Overflow", () => {
     // that the actions are restored to the toolbar surface and remain
     // reachable, either directly or through overflow.
     await expectToolbarActionReachable(window, "Open settings");
-    await expectToolbarActionReachable(window, "Open Terminal");
+    await expectToolbarActionReachable(window, "Open terminal");
   });
 });

--- a/e2e/full/platform/core-accessibility.spec.ts
+++ b/e2e/full/platform/core-accessibility.spec.ts
@@ -448,7 +448,7 @@ test.describe.serial("Core: Accessibility", () => {
 
           const elementsToTest = [
             { selector: SEL.toolbar.openSettings, name: "Settings button" },
-            { selector: SEL.toolbar.openTerminal, name: "Open Terminal button" },
+            { selector: SEL.toolbar.openTerminal, name: "Open terminal button" },
             { selector: SEL.toolbar.toggleSidebar, name: "Toggle Sidebar button" },
           ];
 

--- a/e2e/helpers/panels.ts
+++ b/e2e/helpers/panels.ts
@@ -5,26 +5,28 @@ import { SEL } from "./selectors";
 const mod = process.platform === "darwin" ? "Meta" : "Control";
 
 const toolbarOverflowLabels: Record<string, string> = {
-  "Open Terminal": "Terminal",
-  "Open Browser": "Browser",
+  "Open terminal": "Terminal",
+  "Open browser": "Browser",
   "Open settings": "Settings",
-  "Copy Context": "Copy Context",
+  "Open dev preview": "Dev preview",
+  "Copy context": "Copy context",
   Notifications: "Notifications",
 };
 
 const toolbarButtonIds: Record<string, string> = {
-  "Open Terminal": "terminal",
-  "Open Browser": "browser",
+  "Open terminal": "terminal",
+  "Open browser": "browser",
   "Open settings": "settings",
-  "Copy Context": "copy-tree",
+  "Open dev preview": "dev-server",
+  "Copy context": "copy-tree",
   Notifications: "notification-center",
 };
 
 const toolbarShortcuts: Record<string, string> = {
-  "Open Terminal": `${mod}+Alt+t`,
-  "Open Browser": `${mod}+Alt+b`,
+  "Open terminal": `${mod}+Alt+t`,
+  "Open browser": `${mod}+Alt+b`,
   "Open settings": `${mod}+,`,
-  "Copy Context": `${mod}+Shift+c`,
+  "Copy context": `${mod}+Shift+c`,
 };
 
 function extractToolbarLabel(selector: string): string | null {

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -1,11 +1,11 @@
 export const SEL = {
   toolbar: {
     toggleSidebar: '[aria-label="Toggle Sidebar"]',
-    openTerminal: '[aria-label="Open Terminal"]',
+    openTerminal: '[aria-label="Open terminal"]',
     openSettings: '[aria-label="Open settings"]',
-    openBrowser: '[aria-label="Open Browser"]',
-    openDevPreview: '[aria-label="Open Dev Preview"]',
-    copyContext: '[aria-label="Copy Context"]',
+    openBrowser: '[aria-label="Open browser"]',
+    openDevPreview: '[aria-label="Open dev preview"]',
+    copyContext: '[aria-label="Copy context"]',
     projectSwitcherTrigger: '[data-testid="project-switcher-trigger"]',
     portalToggle: '[aria-label*="web chat"]',
   },

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -34,7 +34,7 @@ import {
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 import { MenuActionSourceContext, useMenuActionSource } from "@/components/ui/menu-source";
-import { ChevronDown, PanelBottom, Unplug } from "lucide-react";
+import { ChevronDown, PanelBottom } from "lucide-react";
 import type { BuiltInAgentId } from "@shared/config/agentIds";
 import type { AgentAvailabilityState, AgentState } from "@shared/types";
 import {
@@ -48,6 +48,7 @@ import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { ToolbarContextMenuItems } from "./ToolbarContextMenuItems";
 
 import { resolveEffectivePresetId } from "@shared/types";
 import {
@@ -157,7 +158,6 @@ export function AgentButton({
   const ariaShortcut = useAriaKeyshortcuts(`agent.${type}`);
   const hover = useShortcutHintHover(`agent.${type}`);
   const agentSettings = useAgentSettingsStore((s) => s.settings);
-  const setAgentPinned = useAgentSettingsStore((s) => s.setAgentPinned);
   const ccrPresets = useCcrPresetsStore((s) => s.ccrPresetsByAgent[type]);
   const projectPresets = useProjectPresetsStore((s) => s.presetsByAgent[type]);
 
@@ -324,10 +324,6 @@ export function AgentButton({
     }
   };
 
-  const handleUnpinFromToolbar = () => {
-    void setAgentPinned(type, false);
-  };
-
   // Persist the toolbar pick to the worktree-scoped slot so repeated launches
   // on the same worktree stay stable, while other worktrees keep their own
   // defaults. Pass `undefined` to clear the worktree override (returning the
@@ -422,10 +418,7 @@ export function AgentButton({
             </ContextMenuSub>
           )}
           <ContextMenuSeparator />
-          <ContextMenuItem onSelect={handleUnpinFromToolbar}>
-            <Unplug className="mr-2 h-3.5 w-3.5" />
-            Unpin from Toolbar
-          </ContextMenuItem>
+          <ToolbarContextMenuItems buttonId={type} side="left" />
           <ContextMenuActionItem
             actionId="app.settings.openTab"
             args={{ tab: "agents", subtab: type, sectionId: "agents-presets" }}
@@ -720,10 +713,7 @@ export function AgentButton({
           </ContextMenuSub>
         )}
         <ContextMenuSeparator />
-        <ContextMenuItem onSelect={handleUnpinFromToolbar}>
-          <Unplug className="mr-2 h-3.5 w-3.5" />
-          Unpin from Toolbar
-        </ContextMenuItem>
+        <ToolbarContextMenuItems buttonId={type} side="left" />
         <ContextMenuActionItem
           actionId="app.settings.openTab"
           args={{ tab: "agents", subtab: type, sectionId: "agents-presets" }}

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -158,6 +158,7 @@ export function AgentButton({
   const ariaShortcut = useAriaKeyshortcuts(`agent.${type}`);
   const hover = useShortcutHintHover(`agent.${type}`);
   const agentSettings = useAgentSettingsStore((s) => s.settings);
+  const setAgentPinned = useAgentSettingsStore((s) => s.setAgentPinned);
   const ccrPresets = useCcrPresetsStore((s) => s.ccrPresetsByAgent[type]);
   const projectPresets = useProjectPresetsStore((s) => s.presetsByAgent[type]);
 
@@ -324,6 +325,14 @@ export function AgentButton({
     }
   };
 
+  // Per-agent unpin: agent IDs read pin state from agentSettingsStore
+  // (tri-state — see isAgentToolbarVisible / #7673), not from
+  // pinnedButtons. The wrapper's default toggleButtonVisibility writes
+  // to the wrong store, so override it here.
+  const handleUnpinFromToolbar = () => {
+    void setAgentPinned(type, false);
+  };
+
   // Persist the toolbar pick to the worktree-scoped slot so repeated launches
   // on the same worktree stay stable, while other worktrees keep their own
   // defaults. Pass `undefined` to clear the worktree override (returning the
@@ -418,7 +427,7 @@ export function AgentButton({
             </ContextMenuSub>
           )}
           <ContextMenuSeparator />
-          <ToolbarContextMenuItems buttonId={type} side="left" />
+          <ToolbarContextMenuItems buttonId={type} side="left" onUnpin={handleUnpinFromToolbar} />
           <ContextMenuActionItem
             actionId="app.settings.openTab"
             args={{ tab: "agents", subtab: type, sectionId: "agents-presets" }}
@@ -713,7 +722,7 @@ export function AgentButton({
           </ContextMenuSub>
         )}
         <ContextMenuSeparator />
-        <ToolbarContextMenuItems buttonId={type} side="left" />
+        <ToolbarContextMenuItems buttonId={type} side="left" onUnpin={handleUnpinFromToolbar} />
         <ContextMenuActionItem
           actionId="app.settings.openTab"
           args={{ tab: "agents", subtab: type, sectionId: "agents-presets" }}

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -10,17 +10,14 @@ import {
   type KeyboardEvent,
   type PointerEvent as ReactPointerEvent,
 } from "react";
-import { Plug, Pin, Settings2, ChevronRight, Keyboard, Unplug } from "lucide-react";
+import { Plug, Pin, Settings2, ChevronRight, Keyboard } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuTrigger,
-} from "@/components/ui/context-menu";
+import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
+import { ToolbarContextMenuItems } from "./ToolbarContextMenuItems";
 import {
   DropdownMenu,
+  DropdownMenuActionItem,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
@@ -48,7 +45,11 @@ import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { usePanelStore } from "@/store/panelStore";
-import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
+import {
+  TOOLBAR_CUSTOMIZE_LABEL,
+  TOOLBAR_PIN_LABEL,
+  TOOLBAR_UNPIN_LABEL,
+} from "./toolbarMenuStrings";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 
 import { useKeybindingDisplay } from "@/hooks";
@@ -318,7 +319,6 @@ export function AgentTrayButton({
   const projectPresetsByAgent = useProjectPresetsStore((s) => s.presetsByAgent);
   const setAgentPinned = useAgentSettingsStore((s) => s.setAgentPinned);
   const updateWorktreePreset = useAgentSettingsStore((s) => s.updateWorktreePreset);
-  const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
 
   const getSortedActionMruList = useActionMruStore((s) => s.getSortedActionMruList);
 
@@ -589,10 +589,6 @@ export function AgentTrayButton({
     );
   };
 
-  const handleCustomizeToolbar = () => {
-    void actionService.dispatch("app.settings.openTab", { tab: "toolbar" }, { source: "user" });
-  };
-
   const handleManageAgents = () => {
     void actionService.dispatch("app.settings.openTab", { tab: "agents" }, { source: "user" });
   };
@@ -693,14 +689,11 @@ export function AgentTrayButton({
                   </Button>
                 </DropdownMenuTrigger>
               </TooltipTrigger>
-              <TooltipContent side="bottom">Agent Tray</TooltipContent>
+              <TooltipContent side="bottom">Agent tray</TooltipContent>
             </Tooltip>
           </ContextMenuTrigger>
           <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
-            <ContextMenuItem onSelect={() => toggleButtonVisibility("agent-tray", "left")}>
-              <Unplug className="mr-2 h-3.5 w-3.5" />
-              Unpin from Toolbar
-            </ContextMenuItem>
+            <ToolbarContextMenuItems buttonId="agent-tray" side="left" />
           </ContextMenuContent>
         </ContextMenu>
         <DropdownMenuContent
@@ -800,10 +793,14 @@ export function AgentTrayButton({
             <Settings2 className="mr-2 h-3.5 w-3.5 opacity-60" />
             Manage Agents
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleCustomizeToolbar} className="h-7">
+          <DropdownMenuActionItem
+            actionId="app.settings.openTab"
+            args={{ tab: "toolbar" }}
+            className="h-7"
+          >
             <Settings2 className="mr-2 h-3.5 w-3.5 opacity-60" />
-            Customize Toolbar
-          </DropdownMenuItem>
+            {TOOLBAR_CUSTOMIZE_LABEL}
+          </DropdownMenuActionItem>
           <DropdownMenuItem onSelect={handleOpenAgentSetupWizard} className="h-7">
             <Plug className="mr-2 h-3.5 w-3.5" />
             Set Up Agents
@@ -934,7 +931,7 @@ function LaunchRow({
         aria-hidden="true"
         data-testid={`agent-tray-pin-${row.id}`}
         data-pinned={row.pinned ? "true" : "false"}
-        title={row.pinned ? "Unpin from toolbar (P)" : "Pin to toolbar (P)"}
+        title={row.pinned ? `${TOOLBAR_UNPIN_LABEL} (P)` : `${TOOLBAR_PIN_LABEL} (P)`}
         onPointerDown={stopPointer}
         onPointerUp={stopPointer}
         onClick={(e) => {

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -11,18 +11,13 @@ import {
   memo,
   forwardRef,
 } from "react";
-import { CircleDot, GitPullRequest, GitCommit, Clock, Unplug } from "lucide-react";
+import { CircleDot, GitPullRequest, GitCommit, Clock } from "lucide-react";
 import { PRDetectionPausedIndicator } from "./PRDetectionPausedIndicator";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuTrigger,
-} from "@/components/ui/context-menu";
+import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
 import { actionService } from "@/services/ActionService";
-import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
+import { ToolbarContextMenuItems } from "./ToolbarContextMenuItems";
 import { usePRCircuitBreakerStore } from "@/store/prCircuitBreakerStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
@@ -146,8 +141,6 @@ export const GitHubStatsToolbarButton = memo(
 
     const setIssueSearchQuery = useGitHubFilterStore((s) => s.setIssueSearchQuery);
     const setPrSearchQuery = useGitHubFilterStore((s) => s.setPrSearchQuery);
-
-    const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
 
     const prCircuitTripped = usePRCircuitBreakerStore((s) => s.tripped);
 
@@ -1018,10 +1011,7 @@ export const GitHubStatsToolbarButton = memo(
           </div>
         </ContextMenuTrigger>
         <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
-          <ContextMenuItem onSelect={() => toggleButtonVisibility("github-stats", "right")}>
-            <Unplug className="mr-2 h-3.5 w-3.5" />
-            Unpin from Toolbar
-          </ContextMenuItem>
+          <ToolbarContextMenuItems buttonId="github-stats" side="right" />
         </ContextMenuContent>
       </ContextMenu>
     );

--- a/src/components/Layout/NotificationCenterToolbarButton.tsx
+++ b/src/components/Layout/NotificationCenterToolbarButton.tsx
@@ -1,18 +1,13 @@
 import { useRef, useEffect, useState, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { FixedDropdown } from "@/components/ui/fixed-dropdown";
-import { Bell, BellOff, Unplug } from "lucide-react";
+import { Bell, BellOff } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuTrigger,
-} from "@/components/ui/context-menu";
+import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
 import { NotificationCenter } from "@/components/Notifications/NotificationCenter";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
-import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
+import { ToolbarContextMenuItems } from "./ToolbarContextMenuItems";
 import { useUIStore } from "@/store/uiStore";
 import { actionService } from "@/services/ActionService";
 import { useShallow } from "zustand/react/shallow";
@@ -40,7 +35,6 @@ export function NotificationCenterToolbarButton({
   const notificationCenterButtonRef = useRef<HTMLButtonElement>(null);
   const notificationUnreadCount = useNotificationHistoryStore((s) => s.unreadCount);
   const evictedToInboxCount = useNotificationHistoryStore((s) => s.evictedToInboxCount);
-  const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
   const {
     enabled: notificationsEnabled,
     quietUntil,
@@ -276,10 +270,7 @@ export function NotificationCenterToolbarButton({
           </Tooltip>
         </ContextMenuTrigger>
         <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
-          <ContextMenuItem onSelect={() => toggleButtonVisibility("notification-center", "right")}>
-            <Unplug className="mr-2 h-3.5 w-3.5" />
-            Unpin from Toolbar
-          </ContextMenuItem>
+          <ToolbarContextMenuItems buttonId="notification-center" side="right" />
         </ContextMenuContent>
       </ContextMenu>
       <FixedDropdown

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -16,12 +16,12 @@ import {
   PinOff,
   Clipboard,
   Square,
-  Unplug,
   X,
 } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { Folders, McpServerIcon } from "@/components/icons";
 import { TOOLBAR_BUTTON_METADATA, isToolbarButtonVisible } from "./toolbarButtonMetadata";
+import { ToolbarContextMenuItems } from "./ToolbarContextMenuItems";
 import { cn } from "@/lib/utils";
 import { shortcutHintStore } from "@/store/shortcutHintStore";
 import { isMac, isLinux, isWindows } from "@/lib/platform";
@@ -142,7 +142,6 @@ export function PluginToolbarButton({
 }) {
   const hover = useShortcutHintHover(config.actionId);
   const ariaShortcut = useAriaKeyshortcuts(config.actionId);
-  const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
 
   return (
     <ContextMenu>
@@ -172,10 +171,7 @@ export function PluginToolbarButton({
         </Tooltip>
       </ContextMenuTrigger>
       <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
-        <ContextMenuItem onSelect={() => toggleButtonVisibility(pluginId, "right")}>
-          <Unplug className="mr-2 h-3.5 w-3.5" />
-          Unpin from Toolbar
-        </ContextMenuItem>
+        <ToolbarContextMenuItems buttonId={pluginId} side="right" />
       </ContextMenuContent>
     </ContextMenu>
   );
@@ -242,9 +238,6 @@ export function Toolbar({
   const showDeveloperTools = usePreferencesStore((state) => state.showDeveloperTools);
   const notificationsEnabled = useNotificationSettingsStore((s) => s.enabled);
   const toolbarLayout = useToolbarPreferencesStore((state) => state.layout);
-  const toggleButtonVisibility = useToolbarPreferencesStore(
-    (state) => state.toggleButtonVisibility
-  );
   // Live subscription so pin/unpin toggles from the AgentTrayButton immediately
   // update per-agent toolbar button visibility. The `agentSettings` prop is
   // sourced from `useAgentLauncher()`'s local useState which does not react to
@@ -590,21 +583,18 @@ export function Toolbar({
                         actionService.dispatch("devServer.start", undefined, { source: "user" })
                       }
                       className={toolbarIconButtonClass}
-                      aria-label="Open Dev Preview"
+                      aria-label="Open dev preview"
                     >
                       <MonitorPlay />
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent side="bottom">
-                    {createTooltipContent("Open Dev Preview", devServerShortcut)}
+                    {createTooltipContent("Open dev preview", devServerShortcut)}
                   </TooltipContent>
                 </Tooltip>
               </ContextMenuTrigger>
               <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
-                <ContextMenuItem onSelect={() => toggleButtonVisibility("dev-server", "left")}>
-                  <Unplug className="mr-2 h-3.5 w-3.5" />
-                  Unpin from Toolbar
-                </ContextMenuItem>
+                <ToolbarContextMenuItems buttonId="dev-server" side="left" />
               </ContextMenuContent>
             </ContextMenu>
           ) : (
@@ -661,7 +651,7 @@ export function Toolbar({
                       "aria-disabled:opacity-50 aria-disabled:cursor-not-allowed"
                     )}
                     aria-label={
-                      isCopyingTree ? "Copying…" : treeCopied ? "Context copied" : "Copy Context"
+                      isCopyingTree ? "Copying…" : treeCopied ? "Context copied" : "Copy context"
                     }
                     aria-keyshortcuts={copyTreeAriaShortcut}
                   >
@@ -678,16 +668,13 @@ export function Toolbar({
                   ) : !activeWorktree ? (
                     "Open a worktree first"
                   ) : (
-                    createTooltipContent("Copy Context", copyTreeShortcut)
+                    createTooltipContent("Copy context", copyTreeShortcut)
                   )}
                 </TooltipContent>
               </Tooltip>
             </ContextMenuTrigger>
             <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
-              <ContextMenuItem onSelect={() => toggleButtonVisibility("copy-tree", "right")}>
-                <Unplug className="mr-2 h-3.5 w-3.5" />
-                Unpin from Toolbar
-              </ContextMenuItem>
+              <ToolbarContextMenuItems buttonId="copy-tree" side="right" />
             </ContextMenuContent>
           </ContextMenu>
         ),
@@ -776,7 +763,6 @@ export function Toolbar({
       pluginConfigs,
       devServerShortcut,
       devServerHintHover,
-      toggleButtonVisibility,
     ]
   );
 

--- a/src/components/Layout/ToolbarCommandPaletteButton.tsx
+++ b/src/components/Layout/ToolbarCommandPaletteButton.tsx
@@ -1,16 +1,11 @@
 import { useCallback, useRef, useState } from "react";
-import { SquareMenu, Unplug } from "lucide-react";
+import { SquareMenu } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuTrigger,
-} from "@/components/ui/context-menu";
+import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
 import { createTooltipContent } from "@/lib/tooltipShortcut";
 import { useAriaKeyshortcuts, useKeybindingDisplay, useShortcutHintHover } from "@/hooks";
-import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
+import { ToolbarContextMenuItems } from "./ToolbarContextMenuItems";
 import { actionService } from "@/services/ActionService";
 import { shortcutHintStore } from "@/store/shortcutHintStore";
 
@@ -28,7 +23,6 @@ export function ToolbarCommandPaletteButton({
   const shortcut = useKeybindingDisplay(PALETTE_ACTION_ID);
   const ariaShortcut = useAriaKeyshortcuts(PALETTE_ACTION_ID);
   const hover = useShortcutHintHover(PALETTE_ACTION_ID);
-  const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
 
   // The action palette opens via dispatch and AppPaletteDialog imperatively
   // restores focus to this button on close (see AppPaletteDialog.tsx:55-68).
@@ -108,10 +102,7 @@ export function ToolbarCommandPaletteButton({
         </Tooltip>
       </ContextMenuTrigger>
       <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
-        <ContextMenuItem onSelect={() => toggleButtonVisibility("command-palette", "right")}>
-          <Unplug className="mr-2 h-3.5 w-3.5" />
-          Unpin from Toolbar
-        </ContextMenuItem>
+        <ToolbarContextMenuItems buttonId="command-palette" side="right" />
       </ContextMenuContent>
     </ContextMenu>
   );

--- a/src/components/Layout/ToolbarContextMenuItems.tsx
+++ b/src/components/Layout/ToolbarContextMenuItems.tsx
@@ -25,6 +25,17 @@ interface ToolbarContextMenuItemsProps {
    * the agent tray dropdown) gets the same Customize + Unpin items.
    */
   variant?: Variant;
+  /**
+   * Optional override for the unpin handler. Default is
+   * `useToolbarPreferencesStore.toggleButtonVisibility(buttonId, side)`, but
+   * built-in agent IDs (`claude` / `gemini` / `codex`) read pin state from
+   * `agentSettingsStore` (tri-state — see #7673 and `isAgentToolbarVisible`),
+   * not from `pinnedButtons`. Pass a callback that calls
+   * `setAgentPinned(id, false)` for those buttons so unpinning actually
+   * hides them. Buttons outside `BUILT_IN_AGENT_IDS` can rely on the
+   * default.
+   */
+  onUnpin?: () => void;
 }
 
 // Single source of truth for the "Customize toolbar…" and "Unpin from toolbar"
@@ -37,8 +48,10 @@ export function ToolbarContextMenuItems({
   buttonId,
   side,
   variant = "context",
+  onUnpin,
 }: ToolbarContextMenuItemsProps) {
   const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
+  const handleUnpin = onUnpin ?? (() => toggleButtonVisibility(buttonId, side));
 
   if (variant === "dropdown") {
     return (
@@ -52,7 +65,7 @@ export function ToolbarContextMenuItems({
           {TOOLBAR_CUSTOMIZE_LABEL}
         </DropdownMenuActionItem>
         <DropdownMenuSeparator />
-        <DropdownMenuItem onSelect={() => toggleButtonVisibility(buttonId, side)} className="h-7">
+        <DropdownMenuItem onSelect={handleUnpin} className="h-7">
           <Unplug className="mr-2 h-3.5 w-3.5" />
           {TOOLBAR_UNPIN_LABEL}
         </DropdownMenuItem>
@@ -66,7 +79,7 @@ export function ToolbarContextMenuItems({
         {TOOLBAR_CUSTOMIZE_LABEL}
       </ContextMenuActionItem>
       <ContextMenuSeparator />
-      <ContextMenuItem onSelect={() => toggleButtonVisibility(buttonId, side)}>
+      <ContextMenuItem onSelect={handleUnpin}>
         <Unplug className="mr-2 h-3.5 w-3.5" />
         {TOOLBAR_UNPIN_LABEL}
       </ContextMenuItem>

--- a/src/components/Layout/ToolbarContextMenuItems.tsx
+++ b/src/components/Layout/ToolbarContextMenuItems.tsx
@@ -1,0 +1,75 @@
+import { Settings2, Unplug } from "lucide-react";
+import {
+  ContextMenuActionItem,
+  ContextMenuItem,
+  ContextMenuSeparator,
+} from "@/components/ui/context-menu";
+import {
+  DropdownMenuActionItem,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
+import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
+import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
+import { TOOLBAR_CUSTOMIZE_LABEL, TOOLBAR_UNPIN_LABEL } from "./toolbarMenuStrings";
+
+type Variant = "context" | "dropdown";
+
+interface ToolbarContextMenuItemsProps {
+  buttonId: AnyToolbarButtonId;
+  side: "left" | "right";
+  /**
+   * `context` renders inside a Radix `ContextMenuContent`; `dropdown` inside
+   * a Radix `DropdownMenuContent`. The primitives aren't cross-compatible —
+   * the wrapper picks the matching pair so every right-click surface (and
+   * the agent tray dropdown) gets the same Customize + Unpin items.
+   */
+  variant?: Variant;
+}
+
+// Single source of truth for the "Customize toolbar…" and "Unpin from toolbar"
+// menu items that every right-click surface in the toolbar should expose
+// (issue #9825). The Customize entry dispatches the existing
+// `app.settings.openTab` action with `{ tab: "toolbar" }` so the action's
+// `source` tag (set by `useMenuActionSource`) is correct for each surface —
+// `context-menu` for the right-click, `menu` for the agent-tray dropdown.
+export function ToolbarContextMenuItems({
+  buttonId,
+  side,
+  variant = "context",
+}: ToolbarContextMenuItemsProps) {
+  const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
+
+  if (variant === "dropdown") {
+    return (
+      <>
+        <DropdownMenuActionItem
+          actionId="app.settings.openTab"
+          args={{ tab: "toolbar" }}
+          className="h-7"
+        >
+          <Settings2 className="mr-2 h-3.5 w-3.5 opacity-60" />
+          {TOOLBAR_CUSTOMIZE_LABEL}
+        </DropdownMenuActionItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => toggleButtonVisibility(buttonId, side)} className="h-7">
+          <Unplug className="mr-2 h-3.5 w-3.5" />
+          {TOOLBAR_UNPIN_LABEL}
+        </DropdownMenuItem>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <ContextMenuActionItem actionId="app.settings.openTab" args={{ tab: "toolbar" }}>
+        {TOOLBAR_CUSTOMIZE_LABEL}
+      </ContextMenuActionItem>
+      <ContextMenuSeparator />
+      <ContextMenuItem onSelect={() => toggleButtonVisibility(buttonId, side)}>
+        <Unplug className="mr-2 h-3.5 w-3.5" />
+        {TOOLBAR_UNPIN_LABEL}
+      </ContextMenuItem>
+    </>
+  );
+}

--- a/src/components/Layout/ToolbarLauncherButton.tsx
+++ b/src/components/Layout/ToolbarLauncherButton.tsx
@@ -1,16 +1,11 @@
 import { useCallback } from "react";
 import { Button } from "@/components/ui/button";
-import { SquareTerminal, Globe, Unplug } from "lucide-react";
+import { SquareTerminal, Globe } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuTrigger,
-} from "@/components/ui/context-menu";
+import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
 import { createTooltipContent } from "@/lib/tooltipShortcut";
 import { useAriaKeyshortcuts, useKeybindingDisplay, useShortcutHintHover } from "@/hooks";
-import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
+import { ToolbarContextMenuItems } from "./ToolbarContextMenuItems";
 
 type LauncherType = "terminal" | "browser";
 
@@ -25,14 +20,14 @@ const LAUNCHER_CONFIG: Record<
 > = {
   terminal: {
     icon: SquareTerminal,
-    label: "Open Terminal",
-    tooltipLabel: "Open Terminal",
+    label: "Open terminal",
+    tooltipLabel: "Open terminal",
     keybindingAction: "agent.terminal",
   },
   browser: {
     icon: Globe,
-    label: "Open Browser",
-    tooltipLabel: "Open Browser",
+    label: "Open browser",
+    tooltipLabel: "Open browser",
     keybindingAction: "agent.browser",
   },
 };
@@ -54,7 +49,6 @@ export function ToolbarLauncherButton({
   const shortcut = useKeybindingDisplay(config.keybindingAction);
   const ariaShortcut = useAriaKeyshortcuts(config.keybindingAction);
   const launcherHover = useShortcutHintHover(config.keybindingAction);
-  const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
 
   const handleClick = useCallback(() => {
     onLaunchAgent(type);
@@ -86,10 +80,7 @@ export function ToolbarLauncherButton({
         </Tooltip>
       </ContextMenuTrigger>
       <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
-        <ContextMenuItem onSelect={() => toggleButtonVisibility(type, "left")}>
-          <Unplug className="mr-2 h-3.5 w-3.5" />
-          Unpin from Toolbar
-        </ContextMenuItem>
+        <ToolbarContextMenuItems buttonId={type} side="left" />
       </ContextMenuContent>
     </ContextMenu>
   );

--- a/src/components/Layout/ToolbarProblemsButton.tsx
+++ b/src/components/Layout/ToolbarProblemsButton.tsx
@@ -1,17 +1,12 @@
 import { Button } from "@/components/ui/button";
-import { AlertCircle, Unplug } from "lucide-react";
+import { AlertCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuTrigger,
-} from "@/components/ui/context-menu";
+import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
 import { createTooltipContent } from "@/lib/tooltipShortcut";
 import { useAriaKeyshortcuts, useKeybindingDisplay, useShortcutHintHover } from "@/hooks";
 import { useDiagnosticsStore } from "@/store/diagnosticsStore";
-import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
+import { ToolbarContextMenuItems } from "./ToolbarContextMenuItems";
 import { DIAGNOSTICS_DOCK_REGION_ID } from "@/components/Diagnostics/DiagnosticsDock";
 
 const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text";
@@ -38,7 +33,6 @@ export function ToolbarProblemsButton({
   const diagnosticsAriaShortcut = useAriaKeyshortcuts("panel.toggleDiagnostics");
   const diagnosticsHover = useShortcutHintHover("panel.toggleDiagnostics");
   const isDockOpen = useDiagnosticsStore((state) => state.isOpen);
-  const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
 
   return (
     <ContextMenu>
@@ -76,15 +70,12 @@ export function ToolbarProblemsButton({
             </Button>
           </TooltipTrigger>
           <TooltipContent side="bottom">
-            {createTooltipContent("Show Problems Panel", diagnosticsShortcut)}
+            {createTooltipContent("Show problems panel", diagnosticsShortcut)}
           </TooltipContent>
         </Tooltip>
       </ContextMenuTrigger>
       <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
-        <ContextMenuItem onSelect={() => toggleButtonVisibility("problems", "right")}>
-          <Unplug className="mr-2 h-3.5 w-3.5" />
-          Unpin from Toolbar
-        </ContextMenuItem>
+        <ToolbarContextMenuItems buttonId="problems" side="right" />
       </ContextMenuContent>
     </ContextMenu>
   );

--- a/src/components/Layout/ToolbarSettingsButton.tsx
+++ b/src/components/Layout/ToolbarSettingsButton.tsx
@@ -1,15 +1,18 @@
 import { Button } from "@/components/ui/button";
-import { SlidersHorizontal } from "lucide-react";
+import { SlidersHorizontal, Unplug } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   ContextMenu,
   ContextMenuActionItem,
   ContextMenuContent,
+  ContextMenuItem,
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 import { createTooltipContent } from "@/lib/tooltipShortcut";
 import { useAriaKeyshortcuts, useKeybindingDisplay, useShortcutHintHover } from "@/hooks";
+import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
+import { TOOLBAR_UNPIN_LABEL } from "./toolbarMenuStrings";
 
 const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text relative";
 
@@ -36,6 +39,7 @@ export function ToolbarSettingsButton({
   const settingsShortcut = useKeybindingDisplay("app.settings");
   const settingsAriaShortcut = useAriaKeyshortcuts("app.settings");
   const settingsHover = useShortcutHintHover("app.settings");
+  const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
 
   return (
     <ContextMenu>
@@ -81,6 +85,11 @@ export function ToolbarSettingsButton({
         <ContextMenuActionItem actionId="app.settings.openTab" args={{ tab: "toolbar" }}>
           Customize toolbar…
         </ContextMenuActionItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem onSelect={() => toggleButtonVisibility("settings", "right")}>
+          <Unplug className="mr-2 h-3.5 w-3.5" />
+          {TOOLBAR_UNPIN_LABEL}
+        </ContextMenuItem>
       </ContextMenuContent>
     </ContextMenu>
   );

--- a/src/components/Layout/ToolbarSettingsButton.tsx
+++ b/src/components/Layout/ToolbarSettingsButton.tsx
@@ -1,17 +1,15 @@
 import { Button } from "@/components/ui/button";
-import { SlidersHorizontal, Unplug } from "lucide-react";
+import { SlidersHorizontal } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   ContextMenu,
   ContextMenuActionItem,
   ContextMenuContent,
-  ContextMenuItem,
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 import { createTooltipContent } from "@/lib/tooltipShortcut";
 import { useAriaKeyshortcuts, useKeybindingDisplay, useShortcutHintHover } from "@/hooks";
-import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
 
 const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text relative";
 
@@ -38,7 +36,6 @@ export function ToolbarSettingsButton({
   const settingsShortcut = useKeybindingDisplay("app.settings");
   const settingsAriaShortcut = useAriaKeyshortcuts("app.settings");
   const settingsHover = useShortcutHintHover("app.settings");
-  const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
 
   return (
     <ContextMenu>
@@ -66,7 +63,7 @@ export function ToolbarSettingsButton({
             </Button>
           </TooltipTrigger>
           <TooltipContent side="bottom">
-            {createTooltipContent("Open Settings", settingsShortcut)}
+            {createTooltipContent("Open settings", settingsShortcut)}
           </TooltipContent>
         </Tooltip>
       </ContextMenuTrigger>
@@ -77,17 +74,13 @@ export function ToolbarSettingsButton({
           </ContextMenuActionItem>
         ))}
         <ContextMenuSeparator />
-        <ContextMenuActionItem actionId="app.settings.openTab" args={{ tab: "toolbar" }}>
-          Customize Toolbar…
-        </ContextMenuActionItem>
         <ContextMenuActionItem actionId="app.settings.openTab" args={{ tab: "troubleshooting" }}>
           Troubleshooting
         </ContextMenuActionItem>
         <ContextMenuSeparator />
-        <ContextMenuItem onSelect={() => toggleButtonVisibility("settings", "right")}>
-          <Unplug className="mr-2 h-3.5 w-3.5" />
-          Unpin from Toolbar
-        </ContextMenuItem>
+        <ContextMenuActionItem actionId="app.settings.openTab" args={{ tab: "toolbar" }}>
+          Customize toolbar…
+        </ContextMenuActionItem>
       </ContextMenuContent>
     </ContextMenu>
   );

--- a/src/components/Layout/VoiceRecordingToolbarButton.tsx
+++ b/src/components/Layout/VoiceRecordingToolbarButton.tsx
@@ -1,17 +1,12 @@
 import { useEffect, useRef } from "react";
-import { Mic, Unplug } from "lucide-react";
+import { Mic } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuTrigger,
-} from "@/components/ui/context-menu";
+import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
 import { cn } from "@/lib/utils";
 import { useAriaKeyshortcuts, useKeybindingDisplay, useShortcutHintHover } from "@/hooks";
 import { useDohertyGate } from "@/hooks/useDeferredLoading";
-import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
+import { ToolbarContextMenuItems } from "./ToolbarContextMenuItems";
 import { useVoiceRecordingStore } from "@/store/voiceRecordingStore";
 import { voiceRecordingService } from "@/services/VoiceRecordingService";
 
@@ -57,7 +52,6 @@ export function VoiceRecordingToolbarButton({
   const pauseShortcut = useKeybindingDisplay("voiceInput.togglePause");
   const ariaShortcut = useAriaKeyshortcuts("voiceInput.toggle");
   const hover = useShortcutHintHover("voiceInput.toggle");
-  const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
 
   const isArming = status === "arming";
   const isConnecting = status === "connecting";
@@ -354,10 +348,7 @@ export function VoiceRecordingToolbarButton({
         </Tooltip>
       </ContextMenuTrigger>
       <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
-        <ContextMenuItem onSelect={() => toggleButtonVisibility("voice-recording", "right")}>
-          <Unplug className="mr-2 h-3.5 w-3.5" />
-          Unpin from Toolbar
-        </ContextMenuItem>
+        <ToolbarContextMenuItems buttonId="voice-recording" side="right" />
       </ContextMenuContent>
     </ContextMenu>
   );

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -17,7 +17,7 @@
  *    choices and warrants the picker.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, screen } from "@testing-library/react";
 import type { AgentSettings, CliAvailability } from "@shared/types";
 import { MenuActionSourceContext } from "@/components/ui/menu-source";
 
@@ -44,13 +44,15 @@ vi.mock("@/services/ActionService", () => ({
   actionService: { dispatch: (...args: unknown[]) => dispatchMock(...args) },
 }));
 
+const setAgentPinnedMock = vi.fn().mockResolvedValue(undefined);
+
 vi.mock("@/store/agentSettingsStore", () => ({
   useAgentSettingsStore: Object.assign(
-    (selector: (s: { settings: AgentSettings | null }) => unknown) =>
-      selector({ settings: mockSettings }),
+    (selector: (s: Record<string, unknown>) => unknown) =>
+      selector({ settings: mockSettings, setAgentPinned: setAgentPinnedMock }),
     {
       getState: () => ({
-        setAgentPinned: vi.fn(),
+        setAgentPinned: setAgentPinnedMock,
         updateWorktreePreset: updateWorktreePresetMock,
         updateAgent: updateAgentMock,
       }),
@@ -1311,5 +1313,75 @@ describe("AgentButton preset UX", () => {
       // accessible name.
       expect(primary!.getAttribute("aria-label")).toBe("Start Claude");
     });
+  });
+});
+
+describe("AgentButton right-click unpin — issue #9825", () => {
+  beforeEach(() => {
+    dispatchMock.mockClear();
+    updateWorktreePresetMock.mockClear();
+    updateAgentMock.mockClear();
+    setAgentPinnedMock.mockClear();
+    mockSettings = settingsWith({ claude: { pinned: true } });
+    mockActiveWorktreeId = null;
+    mockCcrPresetsByAgent = {};
+    mockMergedPresetsFn = () => [];
+    mockCliDetails = {};
+    mockDominantState = null;
+    mockDotColor = "";
+    mockPanelsById = {};
+    mockPanelIds = [];
+    mockPanelIdsByWorktreeId = {};
+    mockWorktrees = [];
+  });
+
+  it("routes the no-presets branch's unpin to setAgentPinned (not pinnedButtons)", () => {
+    render(
+      <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+    );
+    // The new wrapper routes the unpin via onUnpin override for agent IDs.
+    // The "Unpin from toolbar" item lives in the right-click content; find
+    // it and click it.
+    const items = screen.getAllByTestId("context-menu-item");
+    const unpin = items.find((el) => el.textContent?.includes("Unpin from toolbar"));
+    expect(unpin, "no Unpin-from-toolbar menu item rendered").toBeTruthy();
+    fireEvent.click(unpin!);
+    expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", false);
+  });
+
+  it("routes the has-presets branch's unpin to setAgentPinned", () => {
+    mockMergedPresetsFn = (id: string) => [
+      { id: `${id}-blue`, name: "Blue" },
+      { id: `${id}-green`, name: "Green" },
+    ];
+    render(
+      <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+    );
+    const items = screen.getAllByTestId("context-menu-item");
+    const unpin = items.find((el) => el.textContent?.includes("Unpin from toolbar"));
+    expect(unpin).toBeTruthy();
+    fireEvent.click(unpin!);
+    expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", false);
+  });
+
+  it("exposes the Customize toolbar… entry on the right-click content for both branches", () => {
+    const { rerender } = render(
+      <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+    );
+    const itemsNoPresets = screen.getAllByTestId("context-menu-item");
+    const customizeNoPresets = itemsNoPresets.find((el) =>
+      el.textContent?.includes("Customize toolbar")
+    );
+    expect(customizeNoPresets, "Customize entry missing in no-presets branch").toBeTruthy();
+
+    mockMergedPresetsFn = (id: string) => [{ id: `${id}-blue`, name: "Blue" }];
+    rerender(
+      <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+    );
+    const itemsHasPresets = screen.getAllByTestId("context-menu-item");
+    const customizeHasPresets = itemsHasPresets.find((el) =>
+      el.textContent?.includes("Customize toolbar")
+    );
+    expect(customizeHasPresets, "Customize entry missing in has-presets branch").toBeTruthy();
   });
 });

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, fireEvent, act } from "@testing-library/react";
 import type { AgentSettings, CliAvailability } from "@shared/types";
 import type { ActionFrecencyEntry } from "@shared/types/actions";
+import { TOOLBAR_CUSTOMIZE_LABEL } from "../toolbarMenuStrings";
 
 const dispatchMock = vi.fn();
 const setAgentPinnedMock = vi.fn().mockResolvedValue(undefined);
@@ -205,6 +206,48 @@ vi.mock("@/components/ui/context-menu", () => ({
       {children}
     </div>
   ),
+  ContextMenuActionItem: ({
+    actionId,
+    args,
+    children,
+    onSelect,
+  }: {
+    actionId: string;
+    args?: unknown;
+    children: React.ReactNode;
+    onSelect?: (e: { defaultPrevented: boolean; preventDefault: () => void }) => void;
+  }) => (
+    <div
+      role="menuitem"
+      data-action-id={actionId}
+      data-args={JSON.stringify(args)}
+      onClick={() => {
+        const fakeEvent = {
+          defaultPrevented: false,
+          preventDefault: () => {
+            (fakeEvent as { defaultPrevented: boolean }).defaultPrevented = true;
+          },
+        };
+        onSelect?.(fakeEvent);
+        if (!fakeEvent.defaultPrevented) {
+          void dispatchMock(actionId, args, { source: "user" });
+        }
+      }}
+    >
+      {children}
+    </div>
+  ),
+  ContextMenuSeparator: () => <hr />,
+  ContextMenuLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuSub: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuSubContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuSubTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuRadioGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuRadioItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuCheckboxItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuShortcut: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  ContextMenuPortal: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
 vi.mock("@/components/ui/dropdown-menu", () => ({
@@ -249,6 +292,42 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
       className={className}
       onClick={(e) => onSelect?.(e as unknown as Event)}
       onKeyDown={onKeyDown}
+      tabIndex={0}
+      {...props}
+    >
+      {children}
+    </div>
+  ),
+  DropdownMenuActionItem: ({
+    actionId,
+    args,
+    dispatchOptions,
+    children,
+    onSelect,
+    ...props
+  }: {
+    actionId: string;
+    args?: unknown;
+    dispatchOptions?: { source?: string };
+    children: React.ReactNode;
+    onSelect?: (e: { defaultPrevented: boolean; preventDefault: () => void }) => void;
+  } & React.HTMLAttributes<HTMLDivElement>) => (
+    <div
+      role="menuitem"
+      data-action-id={actionId}
+      data-args={JSON.stringify(args)}
+      onClick={() => {
+        const fakeEvent = {
+          defaultPrevented: false,
+          preventDefault: () => {
+            (fakeEvent as { defaultPrevented: boolean }).defaultPrevented = true;
+          },
+        };
+        onSelect?.(fakeEvent);
+        if (!fakeEvent.defaultPrevented) {
+          void dispatchMock(actionId, args, { source: "user" });
+        }
+      }}
       tabIndex={0}
       {...props}
     >
@@ -662,15 +741,18 @@ describe("AgentTrayButton", () => {
 
     const { container } = render(<AgentTrayButton agentAvailability={availability} />);
     const footer = Array.from(container.querySelectorAll('[role="menuitem"]')).find((el) =>
-      el.textContent?.includes("Customize Toolbar")
+      el.textContent?.includes(TOOLBAR_CUSTOMIZE_LABEL)
     );
     expect(footer).toBeTruthy();
     fireEvent.click(footer!);
-    expect(dispatchMock).toHaveBeenCalledWith(
-      "app.settings.openTab",
-      { tab: "toolbar" },
-      { source: "user" }
+    // The Customize entry routes through DropdownMenuActionItem, so the
+    // source is whatever the wrapping DropdownMenu provides ("menu" when
+    // Radix primitives load, "user" when the fallback path is taken).
+    const calls = dispatchMock.mock.calls.filter(
+      ([id, args]: unknown[]) =>
+        id === "app.settings.openTab" && JSON.stringify(args) === JSON.stringify({ tab: "toolbar" })
     );
+    expect(calls.length).toBeGreaterThan(0);
   });
 
   it("shows loading placeholder when availability is undefined", () => {

--- a/src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx
+++ b/src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx
@@ -89,13 +89,35 @@ vi.mock("@/components/ui/context-menu", () => ({
       {children}
     </div>
   ),
+  ContextMenuActionItem: ({
+    children,
+  }: {
+    actionId: string;
+    args?: unknown;
+    children: React.ReactNode;
+    onSelect?: (e: { defaultPrevented: boolean; preventDefault: () => void }) => void;
+  }) => <div role="menuitem">{children}</div>,
+  ContextMenuSeparator: () => <hr />,
+  ContextMenuLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuSub: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuSubContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuSubTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuRadioGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuRadioItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuCheckboxItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuShortcut: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  ContextMenuPortal: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
-vi.mock("lucide-react", () => ({
-  Bell: () => <span data-testid="icon-bell" />,
-  BellOff: () => <span data-testid="icon-bell-off" />,
-  Unplug: () => <span data-testid="icon-unplug" />,
-}));
+vi.mock("lucide-react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("lucide-react")>();
+  return {
+    ...actual,
+    Bell: () => <span data-testid="icon-bell" />,
+    BellOff: () => <span data-testid="icon-bell-off" />,
+  };
+});
 
 function resetStores() {
   useNotificationHistoryStore.setState({

--- a/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
@@ -90,22 +90,22 @@ describe("Toolbar shortcut tooltips — issue #3443", () => {
 
   describe("createTooltipContent usage", () => {
     it("uses createTooltipContent for terminal tooltip", () => {
-      expect(launcherSource).toContain('tooltipLabel: "Open Terminal"');
+      expect(launcherSource).toContain('tooltipLabel: "Open terminal"');
       expect(launcherSource).toContain("createTooltipContent(config.tooltipLabel, shortcut)");
     });
 
     it("uses createTooltipContent for browser tooltip", () => {
-      expect(launcherSource).toContain('tooltipLabel: "Open Browser"');
+      expect(launcherSource).toContain('tooltipLabel: "Open browser"');
       expect(launcherSource).toContain("createTooltipContent(config.tooltipLabel, shortcut)");
     });
 
     it("uses createTooltipContent for settings tooltip", () => {
-      expect(settingsSource).toContain('createTooltipContent("Open Settings", settingsShortcut)');
+      expect(settingsSource).toContain('createTooltipContent("Open settings", settingsShortcut)');
     });
 
     it("uses createTooltipContent for problems tooltip with dynamic shortcut", () => {
       expect(problemsSource).toContain(
-        'createTooltipContent("Show Problems Panel", diagnosticsShortcut)'
+        'createTooltipContent("Show problems panel", diagnosticsShortcut)'
       );
     });
 
@@ -115,11 +115,11 @@ describe("Toolbar shortcut tooltips — issue #3443", () => {
     });
 
     it("uses createTooltipContent for copy-tree tooltip", () => {
-      expect(source).toContain('createTooltipContent("Copy Context", copyTreeShortcut)');
+      expect(source).toContain('createTooltipContent("Copy context", copyTreeShortcut)');
     });
 
     it("uses createTooltipContent for dev-server tooltip", () => {
-      expect(source).toContain('createTooltipContent("Open Dev Preview", devServerShortcut)');
+      expect(source).toContain('createTooltipContent("Open dev preview", devServerShortcut)');
     });
 
     it("uses createTooltipContent for sidebar tooltip with dynamic shortcut", () => {

--- a/src/components/Layout/__tests__/ToolbarCommandPaletteButton.test.tsx
+++ b/src/components/Layout/__tests__/ToolbarCommandPaletteButton.test.tsx
@@ -72,6 +72,46 @@ vi.mock("@/components/ui/context-menu", () => ({
       {children}
     </button>
   ),
+  ContextMenuActionItem: ({
+    actionId,
+    args,
+    children,
+    onSelect,
+  }: {
+    actionId: string;
+    args?: unknown;
+    children: React.ReactNode;
+    onSelect?: (e: { defaultPrevented: boolean; preventDefault: () => void }) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="context-menu-action-item"
+      data-action-id={actionId}
+      data-args={JSON.stringify(args)}
+      onClick={() => {
+        const fakeEvent = {
+          defaultPrevented: false,
+          preventDefault: () => {
+            (fakeEvent as { defaultPrevented: boolean }).defaultPrevented = true;
+          },
+        };
+        onSelect?.(fakeEvent);
+      }}
+    >
+      {children}
+    </button>
+  ),
+  ContextMenuSeparator: () => <hr />,
+  ContextMenuLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuSub: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuSubContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuSubTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuRadioGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuRadioItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuCheckboxItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuShortcut: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  ContextMenuPortal: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
 vi.mock("@/lib/tooltipShortcut", () => ({

--- a/src/components/Layout/__tests__/ToolbarContextMenuItems.test.tsx
+++ b/src/components/Layout/__tests__/ToolbarContextMenuItems.test.tsx
@@ -121,6 +121,20 @@ beforeEach(() => {
 });
 
 describe("ToolbarContextMenuItems", () => {
+  it("uses the U+2026 ellipsis on Customize (not ASCII '...') — issue #9825", () => {
+    // Drift guard: the ellipsis on Customize matches the confirm-tier
+    // pattern in `src/components/ActionPalette/ActionPaletteItem.tsx:126`
+    // and signals "opens a dialog" — the only allowed ellipsis use per
+    // CLAUDE.md microcopy rules. A future rename to ASCII '...' would
+    // silently break the affordance.
+    expect(TOOLBAR_CUSTOMIZE_LABEL).toBe("Customize toolbar…");
+    expect(TOOLBAR_CUSTOMIZE_LABEL).not.toContain("...");
+  });
+
+  it("uses sentence case for the unpin label", () => {
+    expect(TOOLBAR_UNPIN_LABEL).toBe("Unpin from toolbar");
+  });
+
   it("renders the customize and unpin labels in the context variant", () => {
     const { getByText } = render(<ToolbarContextMenuItems buttonId="terminal" side="left" />);
     expect(getByText(TOOLBAR_CUSTOMIZE_LABEL)).toBeTruthy();
@@ -177,5 +191,21 @@ describe("ToolbarContextMenuItems", () => {
     const unpin = getByTestId("dropdown-menu-item");
     fireEvent.click(unpin);
     expect(toggleButtonVisibilityMock).toHaveBeenCalledWith("agent-tray", "left");
+  });
+
+  it("uses the onUnpin override when provided (agent IDs route to setAgentPinned)", () => {
+    // Regression guard for issue #9825 Critical 1: per-agent toolbar
+    // buttons read pin state from agentSettingsStore (tri-state — see
+    // isAgentToolbarVisible / #7673), so the wrapper's default
+    // toggleButtonVisibility writes to the wrong store. AgentButton
+    // passes `onUnpin` to redirect to setAgentPinned.
+    const onUnpinMock = vi.fn();
+    const { getByTestId } = render(
+      <ToolbarContextMenuItems buttonId="claude" side="left" onUnpin={onUnpinMock} />
+    );
+    const unpin = getByTestId("context-menu-item");
+    fireEvent.click(unpin);
+    expect(onUnpinMock).toHaveBeenCalledTimes(1);
+    expect(toggleButtonVisibilityMock).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Layout/__tests__/ToolbarContextMenuItems.test.tsx
+++ b/src/components/Layout/__tests__/ToolbarContextMenuItems.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { TOOLBAR_CUSTOMIZE_LABEL, TOOLBAR_UNPIN_LABEL } from "../toolbarMenuStrings";
+
+const dispatchMock = vi.fn();
+const toggleButtonVisibilityMock = vi.fn();
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch: (...args: unknown[]) => {
+      dispatchMock(...args);
+      return Promise.resolve({ ok: true });
+    },
+  },
+}));
+
+vi.mock("@/store/toolbarPreferencesStore", () => ({
+  useToolbarPreferencesStore: (
+    selector: (s: { toggleButtonVisibility: typeof toggleButtonVisibilityMock }) => unknown
+  ) => selector({ toggleButtonVisibility: toggleButtonVisibilityMock }),
+}));
+
+vi.mock("@/components/ui/context-menu", () => ({
+  ContextMenuActionItem: ({
+    actionId,
+    args,
+    children,
+    onSelect,
+  }: {
+    actionId: string;
+    args?: unknown;
+    children: React.ReactNode;
+    onSelect?: (e: { defaultPrevented: boolean; preventDefault: () => void }) => void;
+  }) => (
+    <button
+      data-testid="context-menu-action-item"
+      data-action-id={actionId}
+      data-args={JSON.stringify(args)}
+      onClick={() => {
+        const fakeEvent = {
+          defaultPrevented: false,
+          preventDefault: () => {
+            (fakeEvent as { defaultPrevented: boolean }).defaultPrevented = true;
+          },
+        };
+        onSelect?.(fakeEvent);
+        if (!fakeEvent.defaultPrevented) {
+          void dispatchMock(actionId, args, { source: "user" });
+        }
+      }}
+    >
+      {children}
+    </button>
+  ),
+  ContextMenuItem: ({
+    children,
+    onSelect,
+  }: {
+    children: React.ReactNode;
+    onSelect?: (e: Event) => void;
+  }) => (
+    <button data-testid="context-menu-item" onClick={(e) => onSelect?.(e as unknown as Event)}>
+      {children}
+    </button>
+  ),
+  ContextMenuSeparator: () => <hr data-testid="context-menu-separator" />,
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenuActionItem: ({
+    actionId,
+    args,
+    children,
+    onSelect,
+  }: {
+    actionId: string;
+    args?: unknown;
+    children: React.ReactNode;
+    onSelect?: (e: { defaultPrevented: boolean; preventDefault: () => void }) => void;
+  }) => (
+    <button
+      data-testid="dropdown-menu-action-item"
+      data-action-id={actionId}
+      data-args={JSON.stringify(args)}
+      onClick={() => {
+        const fakeEvent = {
+          defaultPrevented: false,
+          preventDefault: () => {
+            (fakeEvent as { defaultPrevented: boolean }).defaultPrevented = true;
+          },
+        };
+        onSelect?.(fakeEvent);
+        if (!fakeEvent.defaultPrevented) {
+          void dispatchMock(actionId, args, { source: "user" });
+        }
+      }}
+    >
+      {children}
+    </button>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+  }: {
+    children: React.ReactNode;
+    onSelect?: (e: Event) => void;
+  }) => (
+    <button data-testid="dropdown-menu-item" onClick={(e) => onSelect?.(e as unknown as Event)}>
+      {children}
+    </button>
+  ),
+  DropdownMenuSeparator: () => <hr data-testid="dropdown-menu-separator" />,
+}));
+
+import { ToolbarContextMenuItems } from "../ToolbarContextMenuItems";
+
+beforeEach(() => {
+  dispatchMock.mockClear();
+  toggleButtonVisibilityMock.mockClear();
+});
+
+describe("ToolbarContextMenuItems", () => {
+  it("renders the customize and unpin labels in the context variant", () => {
+    const { getByText } = render(<ToolbarContextMenuItems buttonId="terminal" side="left" />);
+    expect(getByText(TOOLBAR_CUSTOMIZE_LABEL)).toBeTruthy();
+    expect(getByText(TOOLBAR_UNPIN_LABEL)).toBeTruthy();
+  });
+
+  it("uses ContextMenu primitives for the default variant", () => {
+    const { queryAllByTestId, queryByTestId } = render(
+      <ToolbarContextMenuItems buttonId="terminal" side="left" />
+    );
+    expect(queryAllByTestId("context-menu-action-item").length).toBe(1);
+    expect(queryAllByTestId("context-menu-item").length).toBe(1);
+    expect(queryByTestId("dropdown-menu-action-item")).toBeNull();
+    expect(queryByTestId("dropdown-menu-item")).toBeNull();
+  });
+
+  it("uses DropdownMenu primitives for the dropdown variant", () => {
+    const { queryAllByTestId, queryByTestId } = render(
+      <ToolbarContextMenuItems buttonId="agent-tray" side="left" variant="dropdown" />
+    );
+    expect(queryAllByTestId("dropdown-menu-action-item").length).toBe(1);
+    expect(queryAllByTestId("dropdown-menu-item").length).toBe(1);
+    expect(queryByTestId("context-menu-action-item")).toBeNull();
+    expect(queryByTestId("context-menu-item")).toBeNull();
+  });
+
+  it("dispatches app.settings.openTab with the toolbar tab when the customize entry is clicked (context variant)", () => {
+    const { getByTestId } = render(<ToolbarContextMenuItems buttonId="dev-server" side="left" />);
+    const customize = getByTestId("context-menu-action-item");
+    fireEvent.click(customize);
+    // The ContextMenuActionItem wrapper passes the dispatchOptions to
+    // `actionService.dispatch`; in the test mock the source is the default
+    // "user" because there's no wrapping Radix context. We only assert the
+    // action id and args here — source assertion is exercised in
+    // AgentTrayButton.test.tsx.
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "toolbar" },
+      expect.objectContaining({})
+    );
+  });
+
+  it("calls toggleButtonVisibility(buttonId, side) when the unpin entry is clicked (context variant)", () => {
+    const { getByTestId } = render(<ToolbarContextMenuItems buttonId="copy-tree" side="right" />);
+    const unpin = getByTestId("context-menu-item");
+    fireEvent.click(unpin);
+    expect(toggleButtonVisibilityMock).toHaveBeenCalledWith("copy-tree", "right");
+  });
+
+  it("propagates buttonId and side to the dropdown variant's unpin handler", () => {
+    const { getByTestId } = render(
+      <ToolbarContextMenuItems buttonId="agent-tray" side="left" variant="dropdown" />
+    );
+    const unpin = getByTestId("dropdown-menu-item");
+    fireEvent.click(unpin);
+    expect(toggleButtonVisibilityMock).toHaveBeenCalledWith("agent-tray", "left");
+  });
+});

--- a/src/components/Layout/__tests__/ToolbarProblemsButton.test.tsx
+++ b/src/components/Layout/__tests__/ToolbarProblemsButton.test.tsx
@@ -28,6 +28,45 @@ vi.mock("@/components/ui/context-menu", () => ({
       {children}
     </div>
   ),
+  ContextMenuActionItem: ({
+    actionId,
+    args,
+    children,
+    onSelect,
+  }: {
+    actionId: string;
+    args?: unknown;
+    children: React.ReactNode;
+    onSelect?: (e: { defaultPrevented: boolean; preventDefault: () => void }) => void;
+  }) => (
+    <div
+      role="menuitem"
+      data-action-id={actionId}
+      data-args={JSON.stringify(args)}
+      onClick={() => {
+        const fakeEvent = {
+          defaultPrevented: false,
+          preventDefault: () => {
+            (fakeEvent as { defaultPrevented: boolean }).defaultPrevented = true;
+          },
+        };
+        onSelect?.(fakeEvent);
+      }}
+    >
+      {children}
+    </div>
+  ),
+  ContextMenuSeparator: () => <hr />,
+  ContextMenuLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuSub: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuSubContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuSubTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuRadioGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuRadioItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuCheckboxItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuShortcut: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  ContextMenuPortal: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
 vi.mock("@/components/ui/button", () => ({

--- a/src/components/Layout/__tests__/toolbarButtonMetadata.test.ts
+++ b/src/components/Layout/__tests__/toolbarButtonMetadata.test.ts
@@ -54,10 +54,11 @@ describe("TOOLBAR_BUTTON_METADATA — registry coverage", () => {
   it("uses the canonical agent display name for built-in agent labels", () => {
     // Drift guard for the original issue (#7668): the agent-tray icon and
     // labels must come from the same source the AgentButton renders so the
-    // Settings list and the overflow dropdown stay in sync.
+    // Settings list and the overflow dropdown stay in sync. Sentence-cased
+    // per #9825 (lowercase "agent" suffix).
     for (const id of BUILT_IN_AGENT_IDS) {
       const meta = TOOLBAR_BUTTON_METADATA[id as AnyToolbarButtonId];
-      expect(meta?.label, `agent "${id}" missing label`).toMatch(/Agent$/);
+      expect(meta?.label, `agent "${id}" missing label`).toMatch(/agent$/);
     }
   });
 });

--- a/src/components/Layout/toolbarButtonMetadata.ts
+++ b/src/components/Layout/toolbarButtonMetadata.ts
@@ -40,7 +40,7 @@ const AGENT_METADATA: Partial<Record<AnyToolbarButtonId, ToolbarButtonMetadata>>
       return [
         id,
         {
-          label: `${name} Agent`,
+          label: `${name} agent`,
           icon: Icon,
           description: `Launch ${name} AI agent`,
         },
@@ -50,7 +50,7 @@ const AGENT_METADATA: Partial<Record<AnyToolbarButtonId, ToolbarButtonMetadata>>
 
 export const TOOLBAR_BUTTON_METADATA: Partial<Record<AnyToolbarButtonId, ToolbarButtonMetadata>> = {
   "agent-tray": {
-    label: "Agent Tray",
+    label: "Agent tray",
     icon: Plug,
     description: "Dropdown for launching any agent and jumping into setup",
   },
@@ -66,7 +66,7 @@ export const TOOLBAR_BUTTON_METADATA: Partial<Record<AnyToolbarButtonId, Toolbar
     description: "Open browser panel",
   },
   "dev-server": {
-    label: "Dev Preview",
+    label: "Dev preview",
     icon: MonitorPlay,
     description: "Open dev preview panel",
   },
@@ -76,7 +76,7 @@ export const TOOLBAR_BUTTON_METADATA: Partial<Record<AnyToolbarButtonId, Toolbar
     description: "Persistent dictation indicator shown while recording is active",
   },
   "github-stats": {
-    label: "GitHub Stats",
+    label: "GitHub stats",
     icon: GitPullRequest,
     description: "GitHub issues, PRs, and commits",
   },
@@ -86,7 +86,7 @@ export const TOOLBAR_BUTTON_METADATA: Partial<Record<AnyToolbarButtonId, Toolbar
     description: "Notification history dropdown",
   },
   "copy-tree": {
-    label: "Copy Context",
+    label: "Copy context",
     icon: Folders,
     description: "Copy project context to clipboard",
   },

--- a/src/components/Layout/toolbarMenuStrings.ts
+++ b/src/components/Layout/toolbarMenuStrings.ts
@@ -1,0 +1,7 @@
+// Single-source constants for the toolbar right-click context menu entries
+// (issue #9825). The "Customize" entry uses the U+2026 ellipsis to signal
+// "opens a dialog" — same convention as `confirm`-tier action items
+// (`src/components/ActionPalette/ActionPaletteItem.tsx:126`).
+export const TOOLBAR_UNPIN_LABEL = "Unpin from toolbar";
+export const TOOLBAR_PIN_LABEL = "Pin to toolbar";
+export const TOOLBAR_CUSTOMIZE_LABEL = "Customize toolbar…";

--- a/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
@@ -191,8 +191,8 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
 
     const { getByLabelText } = render(<ToolbarSettingsTab />);
 
-    const claudeCheckbox = getByLabelText("Toggle Claude Agent visibility") as HTMLInputElement;
-    const geminiCheckbox = getByLabelText("Toggle Gemini Agent visibility") as HTMLInputElement;
+    const claudeCheckbox = getByLabelText("Toggle Claude agent visibility") as HTMLInputElement;
+    const geminiCheckbox = getByLabelText("Toggle Gemini agent visibility") as HTMLInputElement;
     expect(claudeCheckbox.checked).toBe(true);
     expect(geminiCheckbox.checked).toBe(false);
   });
@@ -207,7 +207,7 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     });
 
     const { getByLabelText } = render(<ToolbarSettingsTab />);
-    const claudeCheckbox = getByLabelText("Toggle Claude Agent visibility") as HTMLInputElement;
+    const claudeCheckbox = getByLabelText("Toggle Claude agent visibility") as HTMLInputElement;
     expect(claudeCheckbox.checked).toBe(true);
   });
 
@@ -217,7 +217,7 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     });
 
     const { getByLabelText } = render(<ToolbarSettingsTab />);
-    fireEvent.click(getByLabelText("Toggle Claude Agent visibility"));
+    fireEvent.click(getByLabelText("Toggle Claude agent visibility"));
 
     expect(setAgentPinnedMock).toHaveBeenCalledTimes(1);
     expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", false);
@@ -230,7 +230,7 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     });
 
     const { getByLabelText } = render(<ToolbarSettingsTab />);
-    fireEvent.click(getByLabelText("Toggle Gemini Agent visibility"));
+    fireEvent.click(getByLabelText("Toggle Gemini agent visibility"));
 
     expect(setAgentPinnedMock).toHaveBeenCalledWith("gemini", true);
     expect(toggleButtonVisibilityMock).not.toHaveBeenCalled();
@@ -250,7 +250,7 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     // silently swallow the right-side branch — both handlers (left, right)
     // are nominally identical today but each is independently wired.
     const { getByLabelText } = render(<ToolbarSettingsTab />);
-    fireEvent.click(getByLabelText("Toggle Copy Context visibility"));
+    fireEvent.click(getByLabelText("Toggle Copy context visibility"));
 
     expect(toggleButtonVisibilityMock).toHaveBeenCalledTimes(1);
     expect(toggleButtonVisibilityMock).toHaveBeenCalledWith("copy-tree", "right");
@@ -273,7 +273,7 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     mockAgentSettings = null;
 
     const { getByLabelText } = render(<ToolbarSettingsTab />);
-    const claudeCheckbox = getByLabelText("Toggle Claude Agent visibility") as HTMLInputElement;
+    const claudeCheckbox = getByLabelText("Toggle Claude agent visibility") as HTMLInputElement;
     expect(claudeCheckbox.checked).toBe(false);
   });
 
@@ -289,7 +289,7 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     });
 
     const { getByLabelText } = render(<ToolbarSettingsTab />);
-    fireEvent.click(getByLabelText("Toggle Codex Agent visibility"));
+    fireEvent.click(getByLabelText("Toggle Codex agent visibility"));
 
     expect(setAgentPinnedMock).toHaveBeenCalledWith("codex", false);
     expect(toggleButtonVisibilityMock).not.toHaveBeenCalled();

--- a/src/components/__tests__/agentPinSync.integration.test.tsx
+++ b/src/components/__tests__/agentPinSync.integration.test.tsx
@@ -164,6 +164,41 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
       {children}
     </div>
   ),
+  DropdownMenuActionItem: ({
+    actionId,
+    args,
+    children,
+    onSelect,
+    ...props
+  }: {
+    actionId: string;
+    args?: unknown;
+    children: React.ReactNode;
+    onSelect?: (e: Event) => void;
+  } & React.HTMLAttributes<HTMLDivElement>) => (
+    <div
+      role="menuitem"
+      data-action-id={actionId}
+      data-args={JSON.stringify(args)}
+      onClick={() => {
+        const fakeEvent = {
+          defaultPrevented: false,
+          preventDefault: () => {
+            (fakeEvent as { defaultPrevented: boolean }).defaultPrevented = true;
+          },
+        };
+        onSelect?.(fakeEvent as unknown as Event);
+        if (!fakeEvent.defaultPrevented) {
+          // Tests don't introspect the dispatch — they only need this row to
+          // exist so the ToolbarContextMenuItems wrapper renders.
+        }
+      }}
+      tabIndex={0}
+      {...props}
+    >
+      {children}
+    </div>
+  ),
   DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="menu-label">{children}</div>
   ),
@@ -304,7 +339,7 @@ describe("agent pin sync — Settings > Toolbar and Agent Tray share state (#511
 
     const settings = render(<ToolbarSettingsTab />);
     const claudeCheckbox = settings.getByLabelText(
-      "Toggle Claude Agent visibility"
+      "Toggle Claude agent visibility"
     ) as HTMLInputElement;
     expect(claudeCheckbox.checked).toBe(true);
     fireEvent.click(claudeCheckbox);
@@ -332,7 +367,7 @@ describe("agent pin sync — Settings > Toolbar and Agent Tray share state (#511
     // Initial Settings render: gemini unchecked.
     const settings = render(<ToolbarSettingsTab />);
     const geminiCheckboxA = settings.getByLabelText(
-      "Toggle Gemini Agent visibility"
+      "Toggle Gemini agent visibility"
     ) as HTMLInputElement;
     expect(geminiCheckboxA.checked).toBe(false);
     settings.unmount();
@@ -347,7 +382,7 @@ describe("agent pin sync — Settings > Toolbar and Agent Tray share state (#511
     // picked up the tray's write.
     const settings2 = render(<ToolbarSettingsTab />);
     const geminiCheckboxB = settings2.getByLabelText(
-      "Toggle Gemini Agent visibility"
+      "Toggle Gemini agent visibility"
     ) as HTMLInputElement;
     expect(geminiCheckboxB.checked).toBe(true);
   });
@@ -359,7 +394,7 @@ describe("agent pin sync — Settings > Toolbar and Agent Tray share state (#511
 
     const settings = render(<ToolbarSettingsTab />);
     const claudeCheckbox = settings.getByLabelText(
-      "Toggle Claude Agent visibility"
+      "Toggle Claude agent visibility"
     ) as HTMLInputElement;
     expect(claudeCheckbox.checked).toBe(true);
     fireEvent.click(claudeCheckbox);
@@ -372,7 +407,7 @@ describe("agent pin sync — Settings > Toolbar and Agent Tray share state (#511
 
     const settings = render(<ToolbarSettingsTab />);
     const geminiCheckbox = settings.getByLabelText(
-      "Toggle Gemini Agent visibility"
+      "Toggle Gemini agent visibility"
     ) as HTMLInputElement;
     expect(geminiCheckbox.checked).toBe(false);
     fireEvent.click(geminiCheckbox);
@@ -381,7 +416,7 @@ describe("agent pin sync — Settings > Toolbar and Agent Tray share state (#511
 
   it("Settings checkbox toggles for agent IDs never touch toolbarPreferencesStore.pinnedButtons", () => {
     const settings = render(<ToolbarSettingsTab />);
-    fireEvent.click(settings.getByLabelText("Toggle Claude Agent visibility"));
+    fireEvent.click(settings.getByLabelText("Toggle Claude agent visibility"));
     fireEvent.click(settings.getByLabelText("Toggle Terminal visibility"));
 
     // Agent -> setAgentPinned; non-agent -> toggleButtonVisibility.


### PR DESCRIPTION
## Summary

- Sentence-cases the toolbar button registry and the hardcoded aria-labels, tooltips, and menu items that bypass it
- Single-sources the unpin menu item, which was duplicated 14 times across 10 files
- Adds a Customize entry to the right-click context menu of every toolbar button, not just two of them

Resolves #9825

## Changes

- `src/components/Layout/toolbarButtonMetadata.ts` and the new `toolbarMenuStrings.ts` use sentence case throughout
- Hardcoded strings in `Toolbar.tsx` and the various `*ToolbarButton.tsx` components are updated to match
- A new `ToolbarContextMenuItems` module is shared by every button's context menu
- E2E helpers, panel E2E specs, and a handful of unit tests are updated to match the new labels

## Testing

- All 1666 unit tests pass
- `npm run check` (typecheck + lint + format + channel/IPC/confirm-wiring) passes