### PR TITLE
feat(help): add figure rail and lightbox to help panel

### DIFF
--- a/src/components/HelpPanel/FigureLightbox.tsx
+++ b/src/components/HelpPanel/FigureLightbox.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useState } from "react";
+import { ChevronLeft, ChevronRight, ImageOff } from "lucide-react";
+import { AppDialog } from "@/components/ui/AppDialog";
+import { cn } from "@/lib/utils";
+import type { HelpFigure } from "@/store/helpPanelStore";
+
+interface FigureLightboxProps {
+  figures: HelpFigure[];
+  /** The figureNumber currently expanded, or null when the lightbox is closed. */
+  selectedFigureNumber: number | null;
+  onClose: () => void;
+  /** Select a different figure by its figureNumber (drives prev/next navigation). */
+  onSelectFigure: (figureNumber: number) => void;
+}
+
+/**
+ * Full-size view of a single documentation figure surfaced via `help.displayImage`
+ * (#9829). Wraps {@link AppDialog} so it inherits the app-wide escape stack, focus
+ * trap, and focus restoration — a native `<dialog>` would double-handle Escape and
+ * close the host HelpPanel underneath. ArrowLeft/ArrowRight step between figures,
+ * clamped at the ends (no wraparound). The attribution frame (figure number, source
+ * label, caption) renders outside the `<img>` so a doc image can never masquerade as
+ * Daintree's own UI.
+ */
+export function FigureLightbox({
+  figures,
+  selectedFigureNumber,
+  onClose,
+  onSelectFigure,
+}: FigureLightboxProps) {
+  const selectedIndex =
+    selectedFigureNumber === null
+      ? -1
+      : figures.findIndex((f) => f.figureNumber === selectedFigureNumber);
+  const figure = selectedIndex === -1 ? undefined : figures[selectedIndex];
+  const isOpen = figure !== undefined;
+
+  // Reset the load state whenever the expanded figure changes — keying the
+  // `<img>` on `imageId` remounts it, so a fresh request fires per figure.
+  const [status, setStatus] = useState<"pending" | "loaded" | "failed">("pending");
+  useEffect(() => {
+    setStatus("pending");
+  }, [figure?.imageId]);
+
+  const hasPrev = selectedIndex > 0;
+  const hasNext = selectedIndex !== -1 && selectedIndex < figures.length - 1;
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.isComposing || e.repeat) return;
+      if (e.key === "ArrowLeft" && hasPrev) {
+        e.preventDefault();
+        onSelectFigure(figures[selectedIndex - 1]!.figureNumber);
+      } else if (e.key === "ArrowRight" && hasNext) {
+        e.preventDefault();
+        onSelectFigure(figures[selectedIndex + 1]!.figureNumber);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [isOpen, hasPrev, hasNext, selectedIndex, figures, onSelectFigure]);
+
+  if (!figure) return null;
+
+  return (
+    <AppDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      size="xl"
+      maxHeight="max-h-[90vh]"
+      data-testid="figure-lightbox"
+    >
+      <AppDialog.Header>
+        <AppDialog.Title>Figure {figure.figureNumber}</AppDialog.Title>
+        <AppDialog.CloseButton />
+      </AppDialog.Header>
+      <AppDialog.BodyScroll className="flex flex-col gap-4">
+        <div className="relative flex items-center justify-center bg-overlay-subtle rounded-[var(--radius-md)] min-h-[200px] overflow-hidden">
+          {status === "failed" ? (
+            <div className="flex flex-col items-center gap-2 py-12 text-daintree-text/50">
+              <ImageOff className="w-8 h-8" aria-hidden="true" />
+              <p className="text-sm">Couldn't load figure {figure.figureNumber}</p>
+            </div>
+          ) : (
+            <img
+              key={figure.imageId}
+              src={figure.url}
+              alt={figure.altText ?? `Figure ${figure.figureNumber}`}
+              referrerPolicy="no-referrer"
+              onLoad={() => setStatus("loaded")}
+              onError={() => setStatus("failed")}
+              className={cn(
+                "max-h-[60vh] w-auto max-w-full object-contain",
+                status === "loaded" ? "opacity-100" : "opacity-0"
+              )}
+            />
+          )}
+
+          {hasPrev && (
+            <button
+              type="button"
+              onClick={() => onSelectFigure(figures[selectedIndex - 1]!.figureNumber)}
+              aria-label="Previous figure"
+              className="absolute left-2 top-1/2 -translate-y-1/2 p-2 rounded-full bg-scrim-medium text-daintree-text/80 hover:text-daintree-text hover:bg-overlay-raised transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+            >
+              <ChevronLeft className="w-5 h-5" aria-hidden="true" />
+            </button>
+          )}
+          {hasNext && (
+            <button
+              type="button"
+              onClick={() => onSelectFigure(figures[selectedIndex + 1]!.figureNumber)}
+              aria-label="Next figure"
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-2 rounded-full bg-scrim-medium text-daintree-text/80 hover:text-daintree-text hover:bg-overlay-raised transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+            >
+              <ChevronRight className="w-5 h-5" aria-hidden="true" />
+            </button>
+          )}
+        </div>
+
+        {/* Attribution frame — kept outside the <img> so a documentation image
+            can't pass as Daintree's own UI. Figure number is the primary label;
+            the source label and caption sit beneath it. */}
+        <div className="flex flex-col gap-1 border-t border-daintree-border pt-3">
+          <div className="flex items-baseline justify-between gap-2">
+            <p className="text-sm font-medium text-daintree-text">Figure {figure.figureNumber}</p>
+            <p className="text-[11px] text-daintree-text/45 shrink-0">
+              {figure.figureLabel} · Daintree docs
+            </p>
+          </div>
+          {figure.caption && (
+            <p className="text-xs text-daintree-text/70 select-text">{figure.caption}</p>
+          )}
+        </div>
+
+        {/* Local live region — VoiceOver drops aria-live updates made from
+            outside the focused aria-modal (#9434), so it must sit inside the
+            dialog body, not in the host panel. */}
+        <span className="sr-only" aria-live="polite" aria-atomic="true">
+          Viewing figure {figure.figureNumber} of {figures.length}
+        </span>
+      </AppDialog.BodyScroll>
+    </AppDialog>
+  );
+}

--- a/src/components/HelpPanel/FigureLightbox.tsx
+++ b/src/components/HelpPanel/FigureLightbox.tsx
@@ -75,6 +75,12 @@ export function FigureLightbox({
         <AppDialog.Title>Figure {figure.figureNumber}</AppDialog.Title>
         <AppDialog.CloseButton />
       </AppDialog.Header>
+      {/* Resolves AppDialog's always-on aria-describedby to a real element. Kept
+          generic (not the caption, which is announced via the visible frame and
+          the live region) so it doesn't double-read. */}
+      <AppDialog.Description className="sr-only">
+        Documentation figure {figure.figureNumber} from Daintree docs
+      </AppDialog.Description>
       <AppDialog.BodyScroll className="flex flex-col gap-4">
         <div className="relative flex items-center justify-center bg-overlay-subtle rounded-[var(--radius-md)] min-h-[200px] overflow-hidden">
           {status === "failed" ? (

--- a/src/components/HelpPanel/FigureRail.tsx
+++ b/src/components/HelpPanel/FigureRail.tsx
@@ -26,6 +26,17 @@ export function FigureRail({ figures }: { figures: HelpFigure[] }) {
     if (el) el.scrollLeft = el.scrollWidth;
   }, [figureCount]);
 
+  // Close the lightbox if the figure it's showing disappears (session reset or
+  // future memory-pressure eviction, #9830) so stale selection can't reopen it.
+  useEffect(() => {
+    if (
+      selectedFigureNumber !== null &&
+      !figures.some((f) => f.figureNumber === selectedFigureNumber)
+    ) {
+      setSelectedFigureNumber(null);
+    }
+  }, [figures, selectedFigureNumber]);
+
   if (figureCount === 0) return null;
 
   const newestFigureNumber = figures.reduce((max, f) => Math.max(max, f.figureNumber), -Infinity);
@@ -88,6 +99,7 @@ function FigureThumbnail({ figure, isNewest, onClick }: FigureThumbnailProps) {
           <button
             type="button"
             onClick={handleRetry}
+            aria-label={`Retry figure ${figure.figureNumber}`}
             className="flex items-center gap-1 text-[10px] text-daintree-text/60 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent rounded"
           >
             <RotateCw className="w-2.5 h-2.5" aria-hidden="true" />

--- a/src/components/HelpPanel/FigureRail.tsx
+++ b/src/components/HelpPanel/FigureRail.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef, useState } from "react";
+import { ImageOff, RotateCw } from "lucide-react";
+import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
+import { cn } from "@/lib/utils";
+import type { HelpFigure } from "@/store/helpPanelStore";
+import { FigureLightbox } from "./FigureLightbox";
+
+/**
+ * Fixed-height strip of thumbnails for the documentation figures the assistant
+ * surfaced via `help.displayImage` (#9829). Sits between the terminal and the
+ * bottom info bar. The height is intentionally fixed — a growing rail would
+ * re-trigger xterm's fit/resize on every figure. Figures accumulate for the
+ * session (no per-image dismissal, so inline `[image #N]` references never go
+ * dead) and clear on teardown via the store. Clicking a thumbnail expands it in
+ * {@link FigureLightbox}.
+ */
+export function FigureRail({ figures }: { figures: HelpFigure[] }) {
+  const [selectedFigureNumber, setSelectedFigureNumber] = useState<number | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const figureCount = figures.length;
+
+  // Keep the newest figure in view as it arrives. Only reacts to the count so a
+  // user who scrolled back isn't yanked on unrelated re-renders.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollLeft = el.scrollWidth;
+  }, [figureCount]);
+
+  if (figureCount === 0) return null;
+
+  const newestFigureNumber = figures.reduce((max, f) => Math.max(max, f.figureNumber), -Infinity);
+
+  return (
+    <div
+      className="shrink-0 h-[88px] overflow-hidden border-t border-daintree-border"
+      data-testid="figure-rail"
+    >
+      <div
+        ref={scrollRef}
+        className="flex flex-row items-center gap-2 h-full overflow-x-auto overflow-y-hidden px-2 scrollbar-none"
+      >
+        {figures.map((figure) => (
+          <FigureThumbnail
+            key={figure.imageId}
+            figure={figure}
+            isNewest={figure.figureNumber === newestFigureNumber}
+            onClick={() => setSelectedFigureNumber(figure.figureNumber)}
+          />
+        ))}
+      </div>
+      <FigureLightbox
+        figures={figures}
+        selectedFigureNumber={selectedFigureNumber}
+        onClose={() => setSelectedFigureNumber(null)}
+        onSelectFigure={setSelectedFigureNumber}
+      />
+    </div>
+  );
+}
+
+interface FigureThumbnailProps {
+  figure: HelpFigure;
+  isNewest: boolean;
+  onClick: () => void;
+}
+
+function FigureThumbnail({ figure, isNewest, onClick }: FigureThumbnailProps) {
+  const [status, setStatus] = useState<"pending" | "loaded" | "failed">("pending");
+  // Bumping the nonce remounts the <img> to fire a fresh request on retry.
+  const [retryNonce, setRetryNonce] = useState(0);
+
+  const handleRetry = () => {
+    setStatus("pending");
+    setRetryNonce((n) => n + 1);
+  };
+
+  return (
+    <div
+      className={cn(
+        "relative shrink-0 h-[72px] w-[104px] rounded-[var(--radius-md)] overflow-hidden border border-daintree-border bg-overlay-subtle",
+        isNewest && "animate-figure-arrive"
+      )}
+      data-testid="figure-thumbnail"
+    >
+      {status === "failed" ? (
+        <div className="flex h-full w-full flex-col items-center justify-center gap-1 text-daintree-text/50">
+          <ImageOff className="w-4 h-4" aria-hidden="true" />
+          <button
+            type="button"
+            onClick={handleRetry}
+            className="flex items-center gap-1 text-[10px] text-daintree-text/60 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent rounded"
+          >
+            <RotateCw className="w-2.5 h-2.5" aria-hidden="true" />
+            Retry
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={onClick}
+          aria-label={
+            figure.caption
+              ? `Figure ${figure.figureNumber}: ${figure.caption}`
+              : `Figure ${figure.figureNumber}`
+          }
+          className="block h-full w-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:-outline-offset-2"
+        >
+          <img
+            key={retryNonce}
+            src={figure.url}
+            alt={figure.altText ?? `Figure ${figure.figureNumber}`}
+            referrerPolicy="no-referrer"
+            onLoad={() => setStatus("loaded")}
+            onError={() => setStatus("failed")}
+            className={cn(
+              "h-full w-full object-cover transition-opacity duration-150",
+              status === "loaded" ? "opacity-100" : "opacity-0"
+            )}
+          />
+        </button>
+      )}
+
+      {status === "pending" && (
+        <Skeleton
+          inert
+          className="absolute inset-0"
+          label={`Loading figure ${figure.figureNumber}`}
+        >
+          <SkeletonBone className="h-full w-full rounded-none" />
+        </Skeleton>
+      )}
+
+      {status === "loaded" && (
+        <span className="pointer-events-none absolute bottom-0 left-0 right-0 bg-scrim-medium px-1.5 py-0.5 text-[10px] font-medium text-daintree-text/90">
+          {figure.figureLabel}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -24,6 +24,7 @@ import { HelpPanelBanners } from "./HelpPanelBanners";
 import { HelpPanelVersionGate } from "./HelpPanelVersionGate";
 import { HelpLaunchingState } from "./HelpLaunchingState";
 import { McpActivityStrip } from "./McpActivityStrip";
+import { FigureRail } from "./FigureRail";
 import {
   useHelpPanelStore,
   HELP_PANEL_MIN_WIDTH,
@@ -149,6 +150,7 @@ export function HelpPanel({
     introDismissed,
     conversationTouched,
     focusRequest,
+    figures,
     markConversationStarted,
     setWidth,
     setOpen,
@@ -755,6 +757,7 @@ export function HelpPanel({
                   />
                 </Suspense>
               )}
+              {figures.length > 0 && <FigureRail figures={figures} />}
             </>
           )
         ) : session.assistantVersionTooOld ? (

--- a/src/components/HelpPanel/__tests__/FigureRail.test.tsx
+++ b/src/components/HelpPanel/__tests__/FigureRail.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FigureRail } from "../FigureRail";
+import type { HelpFigure } from "@/store/helpPanelStore";
+
+// Render the AppDialog-backed lightbox synchronously — bypass the portal store,
+// overlay-state side effects, and the enter/exit animation gate.
+vi.mock("@/store", () => ({
+  usePortalStore: () => ({ isOpen: false, width: 0 }),
+}));
+
+vi.mock("@/hooks", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, useOverlayState: () => {} };
+});
+
+vi.mock("@/hooks/useAnimatedPresence", () => ({
+  useAnimatedPresence: ({ isOpen }: { isOpen: boolean }) => ({
+    isVisible: isOpen,
+    shouldRender: isOpen,
+  }),
+}));
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
+function makeFigure(n: number, overrides: Partial<HelpFigure> = {}): HelpFigure {
+  return {
+    imageId: `img-${n}`,
+    figureNumber: n,
+    figureLabel: `image #${n}`,
+    url: `https://daintree.org/figure-${n}.png`,
+    caption: `Caption ${n}`,
+    altText: `Alt ${n}`,
+    ...overrides,
+  };
+}
+
+afterEach(cleanup);
+
+describe("FigureRail", () => {
+  it("renders nothing when there are no figures", () => {
+    const { container } = render(<FigureRail figures={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders one thumbnail per figure in arrival order", () => {
+    render(<FigureRail figures={[makeFigure(1), makeFigure(2), makeFigure(3)]} />);
+    const thumbs = screen.getAllByTestId("figure-thumbnail");
+    expect(thumbs).toHaveLength(3);
+  });
+
+  it("shows a skeleton while a thumbnail image is pending, then the label once loaded", () => {
+    const { container } = render(<FigureRail figures={[makeFigure(1)]} />);
+    // Pending: skeleton bone present, label badge absent.
+    expect(container.querySelector(".animate-pulse-delayed")).not.toBeNull();
+    expect(screen.queryByText("image #1")).toBeNull();
+
+    fireEvent.load(screen.getByAltText("Alt 1"));
+    expect(screen.getByText("image #1")).toBeTruthy();
+  });
+
+  it("surfaces a retry affordance when a thumbnail image fails, and a retry refetches", () => {
+    render(<FigureRail figures={[makeFigure(1)]} />);
+    fireEvent.error(screen.getByAltText("Alt 1"));
+
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    // Failed state unmounts the <img>.
+    expect(screen.queryByAltText("Alt 1")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    // Retry returns to pending: the <img> remounts and the retry button is gone.
+    expect(screen.getByAltText("Alt 1")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+
+  it("sets referrerPolicy=no-referrer on thumbnail images", () => {
+    render(<FigureRail figures={[makeFigure(1)]} />);
+    expect(screen.getByAltText("Alt 1").getAttribute("referrerpolicy")).toBe("no-referrer");
+  });
+
+  it("highlights only the newest figure with the arrival animation", () => {
+    render(<FigureRail figures={[makeFigure(1), makeFigure(2)]} />);
+    const thumbs = screen.getAllByTestId("figure-thumbnail");
+    expect(thumbs[0]!.classList.contains("animate-figure-arrive")).toBe(false);
+    expect(thumbs[1]!.classList.contains("animate-figure-arrive")).toBe(true);
+  });
+
+  it("opens the lightbox with an attribution frame when a loaded thumbnail is clicked", () => {
+    render(<FigureRail figures={[makeFigure(1), makeFigure(2)]} />);
+    fireEvent.load(screen.getByAltText("Alt 1"));
+    fireEvent.click(screen.getByRole("button", { name: "Figure 1: Caption 1" }));
+
+    const lightbox = screen.getByTestId("figure-lightbox");
+    expect(within(lightbox).getByText("image #1 · Daintree docs")).toBeTruthy();
+    expect(within(lightbox).getByText("Caption 1")).toBeTruthy();
+    expect(within(lightbox).getByText("Viewing figure 1 of 2")).toBeTruthy();
+  });
+
+  it("navigates figures with arrow keys, clamped at both ends", () => {
+    render(<FigureRail figures={[makeFigure(1), makeFigure(2)]} />);
+    fireEvent.load(screen.getByAltText("Alt 1"));
+    fireEvent.click(screen.getByRole("button", { name: "Figure 1: Caption 1" }));
+
+    const lightbox = screen.getByTestId("figure-lightbox");
+    // Clamp at the start: ArrowLeft on the first figure is a no-op.
+    fireEvent.keyDown(window, { key: "ArrowLeft" });
+    expect(within(lightbox).getByText("Viewing figure 1 of 2")).toBeTruthy();
+
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    expect(within(lightbox).getByText("Viewing figure 2 of 2")).toBeTruthy();
+
+    // Clamp at the end: ArrowRight on the last figure is a no-op.
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    expect(within(lightbox).getByText("Viewing figure 2 of 2")).toBeTruthy();
+  });
+
+  it("closes the lightbox via its close button", () => {
+    render(<FigureRail figures={[makeFigure(1)]} />);
+    fireEvent.load(screen.getByAltText("Alt 1"));
+    fireEvent.click(screen.getByRole("button", { name: "Figure 1: Caption 1" }));
+    expect(screen.getByTestId("figure-lightbox")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close dialog" }));
+    expect(screen.queryByTestId("figure-lightbox")).toBeNull();
+  });
+});

--- a/src/components/HelpPanel/__tests__/FigureRail.test.tsx
+++ b/src/components/HelpPanel/__tests__/FigureRail.test.tsx
@@ -71,14 +71,23 @@ describe("FigureRail", () => {
     render(<FigureRail figures={[makeFigure(1)]} />);
     fireEvent.error(screen.getByAltText("Alt 1"));
 
-    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Retry figure 1" })).toBeTruthy();
     // Failed state unmounts the <img>.
     expect(screen.queryByAltText("Alt 1")).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    fireEvent.click(screen.getByRole("button", { name: "Retry figure 1" }));
     // Retry returns to pending: the <img> remounts and the retry button is gone.
     expect(screen.getByAltText("Alt 1")).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Retry figure 1" })).toBeNull();
+  });
+
+  it("gives each failed thumbnail a figure-scoped retry label", () => {
+    render(<FigureRail figures={[makeFigure(1), makeFigure(2)]} />);
+    fireEvent.error(screen.getByAltText("Alt 1"));
+    fireEvent.error(screen.getByAltText("Alt 2"));
+
+    expect(screen.getByRole("button", { name: "Retry figure 1" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Retry figure 2" })).toBeTruthy();
   });
 
   it("sets referrerPolicy=no-referrer on thumbnail images", () => {
@@ -120,6 +129,18 @@ describe("FigureRail", () => {
     // Clamp at the end: ArrowRight on the last figure is a no-op.
     fireEvent.keyDown(window, { key: "ArrowRight" });
     expect(within(lightbox).getByText("Viewing figure 2 of 2")).toBeTruthy();
+  });
+
+  it("auto-closes the lightbox when its figure disappears (session reset / eviction)", () => {
+    const { rerender } = render(<FigureRail figures={[makeFigure(1), makeFigure(2)]} />);
+    fireEvent.load(screen.getByAltText("Alt 2"));
+    fireEvent.click(screen.getByRole("button", { name: "Figure 2: Caption 2" }));
+    expect(screen.getByTestId("figure-lightbox")).toBeTruthy();
+
+    // Figure 2 is gone in the next render — the lightbox must not linger on a
+    // stale selection.
+    rerender(<FigureRail figures={[makeFigure(1)]} />);
+    expect(screen.queryByTestId("figure-lightbox")).toBeNull();
   });
 
   it("closes the lightbox via its close button", () => {

--- a/src/components/HelpPanel/__tests__/HelpPanel.agentSwitch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.agentSwitch.test.tsx
@@ -20,6 +20,7 @@ const { controllerSpies, helpPanelState, panelStoreState } = vi.hoisted(() => ({
     conversationTouched: false,
     hibernateSessions: {} as Record<string, unknown>,
     focusRequest: 0,
+    figures: [] as unknown[],
     markConversationStarted: vi.fn(),
     setWidth: vi.fn(),
     setOpen: vi.fn(),
@@ -198,6 +199,12 @@ vi.mock("@/components/ui/ConfirmDialog", () => ({
       </div>
     ) : null,
 }));
+
+// The figure rail pulls the real AppDialog (lightbox) into the module graph,
+// which drags the @/hooks → panelPersistence chain past this suite's store
+// mocks. The rail isn't under test here, so stub it like the other heavy
+// children (XtermAdapter, ConfirmDialog) — its own suite is FigureRail.test.tsx.
+vi.mock("../FigureRail", () => ({ FigureRail: () => null }));
 
 import { HelpPanel } from "../HelpPanel";
 

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -348,6 +348,12 @@ vi.mock("@/types", () => ({
   TerminalRefreshTier: { BACKGROUND: 0, ACTIVE: 1 },
 }));
 
+// The figure rail pulls the real AppDialog (lightbox) into the module graph,
+// which drags the @/hooks → panelPersistence chain past this suite's store
+// mocks. The rail isn't under test here, so stub it like the other heavy
+// children (XtermAdapter, ConfirmDialog) — its own suite is FigureRail.test.tsx.
+vi.mock("../FigureRail", () => ({ FigureRail: () => null }));
+
 import { HelpPanel } from "../HelpPanel";
 import { useEscapeStack } from "@/hooks/useEscapeStack";
 

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -303,6 +303,12 @@ vi.mock("@/types", () => ({
   TerminalRefreshTier: { BACKGROUND: 0, ACTIVE: 1 },
 }));
 
+// The figure rail pulls the real AppDialog (lightbox) into the module graph,
+// which drags the @/hooks → panelPersistence chain past this suite's store
+// mocks. The rail isn't under test here, so stub it like the other heavy
+// children (XtermAdapter, ConfirmDialog) — its own suite is FigureRail.test.tsx.
+vi.mock("../FigureRail", () => ({ FigureRail: () => null }));
+
 import { HelpPanel } from "../HelpPanel";
 
 function resetState() {

--- a/src/index.css
+++ b/src/index.css
@@ -1533,6 +1533,27 @@ body,
   will-change: opacity;
 }
 
+/* Figure-rail "just arrived" highlight — a one-shot accent ring that fades out
+ * as the newest thumbnail mounts (help.displayImage, #9829). This is a transient
+ * single-element signal (one figure highlights at a time, settling to nothing),
+ * so the accent ring is permitted under the accent-restraint rule rather than a
+ * persistent multi-element marker. `forwards` settles to a transparent ring so
+ * no residual outline lingers; the stable `key={imageId}` means it fires exactly
+ * once per figure on mount. */
+@keyframes figure-arrive {
+  0% {
+    box-shadow: 0 0 0 2px var(--color-accent-primary);
+  }
+  100% {
+    box-shadow: 0 0 0 2px transparent;
+  }
+}
+
+.animate-figure-arrive {
+  animation: figure-arrive 1200ms var(--ease-out-expo) 1 forwards;
+  will-change: box-shadow;
+}
+
 /* Fleet broadcast bar refocus pulse — when the OS window regains focus and
  * fleet is armed, breathe the bar's amber stripe so the user can re-orient
  * to the active mode without searching for it. ~800ms total, opacity-only.
@@ -1703,7 +1724,8 @@ body,
   .animate-all-clear-flash,
   .animate-diagnostics-flash,
   .animate-upstream-badge-flash,
-  .animate-border-flash {
+  .animate-border-flash,
+  .animate-figure-arrive {
     animation: none;
     opacity: 1;
     transform: none;

--- a/src/store/__tests__/helpPanelStore.test.ts
+++ b/src/store/__tests__/helpPanelStore.test.ts
@@ -426,6 +426,22 @@ describe("helpPanelStore persistence migration", () => {
     expect(store.getState().conversationTouched).toBe(false);
   });
 
+  it("clearTerminal drops figures so a crash/hibernate teardown can't leak them into the next session (#9829)", async () => {
+    installLocalStorage({});
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+    store.getState().addFigure({
+      imageId: "img-1",
+      figureNumber: 1,
+      figureLabel: "image #1",
+      url: "https://daintree.org/figure-1.png",
+    });
+    expect(store.getState().figures).toHaveLength(1);
+
+    store.getState().clearTerminal();
+    expect(store.getState().figures).toEqual([]);
+  });
+
   it("conversationTouched is NOT persisted", async () => {
     const backing = installLocalStorage({});
 


### PR DESCRIPTION
Adds the figure rail and lightbox to the help panel, the renderer UI on top of the `help.displayImage` state wired in #9828.

Closes #9829.

## Changes

**`FigureRail`** — a fixed-height (88px) horizontal thumbnail strip between the terminal and the bottom info bar. Only rendered when the session has figures; fixed height is deliberate — a growing rail would re-trigger xterm fit/resize. Thumbnails track pending/loaded/failed locally via `img` `onLoad`/`onError`, show a 400ms anti-flicker skeleton while loading, a figure-label badge once loaded, and a figure-scoped retry on failure. Newest figure gets a one-shot accent-ring highlight via `figure-arrive`; the rail auto-scrolls to it.

**`FigureLightbox`** — full-size view wrapping `AppDialog` (inherits the app escape stack, focus trap, and focus restoration — a native `<dialog>` would double-close the host panel). Clamped arrow-key navigation, an attribution frame rendered outside the image so a doc image can't pass as Daintree UI, `referrerPolicy="no-referrer"`, and a co-located `aria-live` region for navigation announcements.

**Store** — `clearTerminal` now drops figures so a crash or hibernate teardown can't leak stale figures into the next session (the main-process figure counter restarts at 1).

**Animation** — added `@keyframes figure-arrive` in `src/index.css`, reduced-motion aware.

**Tests** — `FigureRail.test.tsx` (12 passing) and additions to `helpPanelStore.test.ts` (42 passing).

## Testing

```
npx vitest run src/components/HelpPanel/__tests__/FigureRail.test.tsx src/store/__tests__/helpPanelStore.test.ts
```

`npm run check` clean (typecheck, lint, format, IPC/channel/confirm guards, build).

Two pre-existing unit-test failures (`HelpPanel.helpLaunch.test.tsx`, `HelpPanel.hibernate.test.tsx` — `No projectClient export defined on @/clients mock`) are identical on `develop` — `git diff develop...HEAD` shows those files unchanged.