### PR TITLE
feat(terminal): signal lost agent sessions on silent respawn

### DIFF
--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -111,6 +111,14 @@ export interface AddPanelOptionsBase {
   isUsingFallback?: boolean;
   /** Chain index consumed so far from the primary preset's fallback list. */
   fallbackChainIndex?: number;
+  /**
+   * PTY-only, transient. True when session restore fell through to a fresh
+   * agent launch because no resume command (neither exact-session nor
+   * resume-latest) was available — the prior conversation is unreachable.
+   * Drives the "Session no longer reachable" restart banner. Never persisted;
+   * cleared on the next restart. See `serializePtyPanel` (intentionally omitted).
+   */
+  sessionLostOnRestore?: boolean;
 }
 
 /**

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -432,6 +432,13 @@ export interface PtyPanelData extends BasePanelData {
   isUsingFallback?: boolean;
   /** How many fallback hops have been consumed from the primary's chain (0-based index into fallbacks[]). */
   fallbackChainIndex?: number;
+  /**
+   * Live-only restore signal. True on first mount when the saved agent session
+   * could not be resumed and a fresh session was launched instead. Drives the
+   * "Session no longer reachable" restart banner. Cleared on restart; never
+   * serialized — see `serializePtyPanel`.
+   */
+  sessionLostOnRestore?: boolean;
 }
 
 export interface BrowserPanelData extends BasePanelData {

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -444,6 +444,7 @@ function TerminalPaneComponent({
         exitBehavior: pty?.exitBehavior,
         isTrashedOrRemoved: terminal?.location === "trash" || terminal === undefined,
         spawnStatus: pty?.spawnStatus,
+        sessionLostOnRestore: pty?.sessionLostOnRestore ?? false,
       };
     })
   );
@@ -455,6 +456,7 @@ function TerminalPaneComponent({
     exitBehavior,
     isTrashedOrRemoved,
     spawnStatus,
+    sessionLostOnRestore,
   } = terminalState;
   // Fleet-scope mounts pass `isInputLocked: true` to render the panel as a
   // read-only broadcast view. Prop takes precedence over the stored flag so
@@ -1151,6 +1153,7 @@ function TerminalPaneComponent({
     reconnectError,
     spawnError,
     backendStatus,
+    sessionLostOnRestore,
   });
   // Backend-dependent banners (restart / spawn / reconnect) describe failures
   // whose only recovery path runs through the host, so they're hidden while

--- a/src/components/Terminal/TerminalRestartStatusBanner.tsx
+++ b/src/components/Terminal/TerminalRestartStatusBanner.tsx
@@ -56,6 +56,27 @@ export function TerminalRestartStatusBanner({
         />
       );
 
+    case "session-resume-unavailable":
+      return (
+        <InlineStatusBanner
+          icon={XCircle}
+          title={RESTART_BANNER_COPY["session-resume-unavailable"].title}
+          description={RESTART_BANNER_COPY["session-resume-unavailable"].description}
+          severity="error"
+          animated={false}
+          role="alert"
+          action={{
+            id: "start-new-session",
+            label: "Start new session",
+            icon: RotateCcw,
+            variant: "dangerFilled",
+            onClick: onRestart,
+            title: "Start new session",
+            ariaLabel: "Start new session",
+          }}
+        />
+      );
+
     case "exit-error":
       return (
         <InlineStatusBanner

--- a/src/components/Terminal/__tests__/TerminalRestartStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalRestartStatusBanner.test.tsx
@@ -115,4 +115,58 @@ describe("TerminalRestartStatusBanner", () => {
     fireEvent.click(button);
     expect(onDismiss).toHaveBeenCalledOnce();
   });
+
+  describe("session-resume-unavailable variant (issue #9802)", () => {
+    it("renders neutral title and a non-accusatory description", () => {
+      render(
+        <TerminalRestartStatusBanner
+          variant={{ type: "session-resume-unavailable" }}
+          onRestart={vi.fn()}
+          onDismiss={vi.fn()}
+        />
+      );
+      expect(screen.getByText("Session no longer reachable")).toBeTruthy();
+      // Neutral phrasing — must not blame the user/agent.
+      const description = screen.getByText(/couldn't be restored/i);
+      expect(description.textContent).not.toMatch(/expired|you lost|agent closed/i);
+    });
+
+    it("uses role=alert without aria-live for an assertive interrupt", () => {
+      render(
+        <TerminalRestartStatusBanner
+          variant={{ type: "session-resume-unavailable" }}
+          onRestart={vi.fn()}
+          onDismiss={vi.fn()}
+        />
+      );
+      const region = screen.getByRole("alert");
+      expect(region.hasAttribute("aria-live")).toBe(false);
+    });
+
+    it("exposes a verb-noun recovery action that calls onRestart", () => {
+      const onRestart = vi.fn();
+      render(
+        <TerminalRestartStatusBanner
+          variant={{ type: "session-resume-unavailable" }}
+          onRestart={onRestart}
+          onDismiss={vi.fn()}
+        />
+      );
+      const button = screen.getByRole("button", { name: /start new session/i });
+      fireEvent.click(button);
+      expect(onRestart).toHaveBeenCalledOnce();
+    });
+
+    it("has no dismiss control — the banner is the recovery surface", () => {
+      const onDismiss = vi.fn();
+      render(
+        <TerminalRestartStatusBanner
+          variant={{ type: "session-resume-unavailable" }}
+          onRestart={vi.fn()}
+          onDismiss={onDismiss}
+        />
+      );
+      expect(screen.queryByRole("button", { name: "Dismiss" })).toBeNull();
+    });
+  });
 });

--- a/src/components/Terminal/__tests__/restartBannerCopy.test.ts
+++ b/src/components/Terminal/__tests__/restartBannerCopy.test.ts
@@ -18,4 +18,24 @@ describe("RESTART_BANNER_COPY", () => {
       "Session exited with code 137"
     );
   });
+
+  // issue #9802 — the session-lost copy must satisfy the CLAUDE.md microcopy
+  // constraints (neutral, non-accusatory; title is a period-free noun phrase).
+  describe("session-resume-unavailable copy", () => {
+    const copy = RESTART_BANNER_COPY["session-resume-unavailable"];
+
+    it("provides a non-empty title and description", () => {
+      expect(copy.title.length).toBeGreaterThan(0);
+      expect(copy.description.length).toBeGreaterThan(0);
+    });
+
+    it("keeps the title a period-free noun phrase", () => {
+      expect(copy.title.endsWith(".")).toBe(false);
+    });
+
+    it("avoids accusatory or blame-assigning phrasing", () => {
+      const text = `${copy.title} ${copy.description}`.toLowerCase();
+      expect(text).not.toMatch(/expired|you lost|your fault|agent closed|killed/);
+    });
+  });
 });

--- a/src/components/Terminal/__tests__/restartStatus.test.ts
+++ b/src/components/Terminal/__tests__/restartStatus.test.ts
@@ -241,3 +241,105 @@ describe("getRestartBannerVariant", () => {
     expect(result).toEqual({ type: "auto-restarting" });
   });
 });
+
+describe("getRestartBannerVariant — session-resume-unavailable (issue #9802)", () => {
+  // A panel that resumed cleanly: not exited, no errors. Isolates the
+  // sessionLostOnRestore signal from the exit-error path.
+  const restored: RestartBannerInput = {
+    isExited: false,
+    exitCode: null,
+    dismissedRestartPrompt: false,
+    restartError: undefined,
+    isRestarting: false,
+    isAutoRestarting: false,
+    exitBehavior: "keep",
+    backendStatus: "connected",
+  };
+
+  it("returns session-resume-unavailable when restore fell through to a fresh launch", () => {
+    const result = getRestartBannerVariant({ ...restored, sessionLostOnRestore: true });
+    expect(result).toEqual({ type: "session-resume-unavailable" });
+  });
+
+  it("returns none when sessionLostOnRestore is absent (resumed normally)", () => {
+    const result = getRestartBannerVariant({ ...restored, sessionLostOnRestore: false });
+    expect(result).toEqual({ type: "none" });
+  });
+
+  it("ignores backendStatus — the lost session is independent of host connectivity", () => {
+    const result = getRestartBannerVariant({
+      ...restored,
+      sessionLostOnRestore: true,
+      backendStatus: "disconnected",
+    });
+    expect(result).toEqual({ type: "session-resume-unavailable" });
+  });
+
+  it("yields to an in-flight restart (isRestarting wins)", () => {
+    const result = getRestartBannerVariant({
+      ...restored,
+      sessionLostOnRestore: true,
+      isRestarting: true,
+    });
+    expect(result).toEqual({ type: "restarting" });
+  });
+
+  it("yields to auto-restart (isAutoRestarting wins)", () => {
+    const result = getRestartBannerVariant({
+      ...restored,
+      sessionLostOnRestore: true,
+      isAutoRestarting: true,
+    });
+    expect(result).toEqual({ type: "auto-restarting" });
+  });
+
+  it("suppresses while a restartError is present", () => {
+    const result = getRestartBannerVariant({
+      ...restored,
+      sessionLostOnRestore: true,
+      restartError: {
+        message: "failed",
+        code: "RESTART_FAILED",
+        timestamp: Date.now(),
+        recoverable: false,
+      },
+    });
+    expect(result).toEqual({ type: "none" });
+  });
+
+  it("suppresses while a reconnectError is present", () => {
+    const result = getRestartBannerVariant({
+      ...restored,
+      sessionLostOnRestore: true,
+      reconnectError: {
+        message: "lost connection",
+        code: "RECONNECT_FAILED",
+        timestamp: Date.now(),
+      } as never,
+    });
+    expect(result).toEqual({ type: "none" });
+  });
+
+  it("suppresses while a spawnError is present", () => {
+    const result = getRestartBannerVariant({
+      ...restored,
+      sessionLostOnRestore: true,
+      spawnError: {
+        message: "spawn failed",
+        code: "SPAWN_FAILED",
+        timestamp: Date.now(),
+      } as never,
+    });
+    expect(result).toEqual({ type: "none" });
+  });
+
+  it("takes precedence over exit-error when both signals are present", () => {
+    const result = getRestartBannerVariant({
+      ...restored,
+      isExited: true,
+      exitCode: 1,
+      sessionLostOnRestore: true,
+    });
+    expect(result).toEqual({ type: "session-resume-unavailable" });
+  });
+});

--- a/src/components/Terminal/restartBannerCopy.ts
+++ b/src/components/Terminal/restartBannerCopy.ts
@@ -1,11 +1,19 @@
 export interface RestartBannerCopyMap {
   "auto-restarting": { title: string };
   restarting: { title: string };
+  "session-resume-unavailable": { title: string; description: string };
   "exit-error": (args: { exitCode: number }) => { title: string };
 }
 
 export const RESTART_BANNER_COPY: RestartBannerCopyMap = {
   "auto-restarting": { title: "Auto-restarting…" },
   restarting: { title: "Restarting…" },
+  // Neutral, non-accusatory copy per issue #9802 and the CLAUDE.md
+  // Title-Message-Action microcopy rule. Title is a noun phrase; the action
+  // label ("Start new session") lives in the banner component.
+  "session-resume-unavailable": {
+    title: "Session no longer reachable",
+    description: "The previous conversation couldn't be restored. Start a new session to continue.",
+  },
   "exit-error": ({ exitCode }) => ({ title: `Session exited with code ${exitCode}` }),
 };

--- a/src/components/Terminal/restartStatus.ts
+++ b/src/components/Terminal/restartStatus.ts
@@ -5,6 +5,7 @@ import type { BackendStatus } from "@/store/panelStore";
 export type RestartBannerVariant =
   | { type: "auto-restarting" }
   | { type: "restarting" }
+  | { type: "session-resume-unavailable" }
   | { type: "exit-error"; exitCode: number }
   | { type: "none" };
 
@@ -19,6 +20,8 @@ export interface RestartBannerInput {
   reconnectError?: TerminalReconnectError;
   spawnError?: SpawnError;
   backendStatus: BackendStatus;
+  /** True when restore fell through to a fresh agent launch (issue #9802). */
+  sessionLostOnRestore?: boolean;
 }
 
 export function getRestartBannerVariant(input: RestartBannerInput): RestartBannerVariant {
@@ -34,6 +37,22 @@ export function getRestartBannerVariant(input: RestartBannerInput): RestartBanne
     !input.spawnError
   ) {
     return { type: "restarting" };
+  }
+
+  // The previous agent session couldn't be resumed and restore fell through to a
+  // fresh launch. Surface it so the user isn't silently dropped into a clean
+  // session (issue #9802). Gated below the in-flight restart states (a live
+  // restart takes precedence) and above exit-error so a lost session is
+  // acknowledged before any prior exit prompt.
+  if (
+    input.sessionLostOnRestore &&
+    !input.isRestarting &&
+    !input.isAutoRestarting &&
+    !input.restartError &&
+    !input.reconnectError &&
+    !input.spawnError
+  ) {
+    return { type: "session-resume-unavailable" };
   }
 
   if (

--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -77,6 +77,9 @@ const PTY_FIELD_CLASSIFICATION = {
   lastCommand: false,
   restartKey: false,
   isRestarting: false,
+  // Transient restore-time signal (#9802) — drives the "Session no longer
+  // reachable" banner; must never be persisted or it resurfaces every restart.
+  sessionLostOnRestore: false,
   restartError: false,
   reconnectError: false,
   scrollbackRestoreError: false,

--- a/src/panels/terminal/__tests__/serializer.test.ts
+++ b/src/panels/terminal/__tests__/serializer.test.ts
@@ -147,3 +147,14 @@ describe("serializePtyPanel — detectedAgentId is never persisted", () => {
 // Since #8957 step 6 the field lives on BasePanelData and is written by the
 // base layer in panelToSnapshot, not by per-kind serializers — coverage
 // lives in panelPersistence tests instead.
+
+// sessionLostOnRestore (#9802) is a transient restore-time signal. Persisting it
+// would resurface the "Session no longer reachable" banner on every subsequent
+// restart, so the serializer must never write it into project JSON.
+describe("serializePtyPanel — sessionLostOnRestore is never persisted", () => {
+  it("omits sessionLostOnRestore even when the panel currently carries it", () => {
+    const panel = makePanel({ sessionLostOnRestore: true });
+    const snapshot = serializePtyPanel(panel) as Record<string, unknown>;
+    expect("sessionLostOnRestore" in snapshot).toBe(false);
+  });
+});

--- a/src/panels/terminal/serializer.ts
+++ b/src/panels/terminal/serializer.ts
@@ -17,6 +17,9 @@ export function serializePtyPanel(t: PtySerializeInput): Partial<PanelSnapshot> 
     ...(t.originalPresetId && { originalPresetId: t.originalPresetId }),
     ...(t.isUsingFallback && { isUsingFallback: true }),
     ...(typeof t.fallbackChainIndex === "number" && { fallbackChainIndex: t.fallbackChainIndex }),
+    // sessionLostOnRestore intentionally omitted — it's a transient restore-time
+    // signal. Persisting it would resurface the "Session no longer reachable"
+    // banner on every subsequent restart (issue #9802).
     // "directing" is a renderer-only ephemeral state owned by
     // TerminalAgentStateController; persisting it could resurrect a stuck
     // indicator on the next reload (issue #5832).

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -370,6 +370,7 @@ export const createAddPanelActions = (
       originalPresetId: options.originalPresetId ?? options.agentPresetId,
       isUsingFallback: options.isUsingFallback,
       fallbackChainIndex: options.fallbackChainIndex,
+      sessionLostOnRestore: options.sessionLostOnRestore,
       extensionState: options.extensionState,
       pluginId: ptyPluginId,
       spawnedBy: options.spawnedBy,

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -203,6 +203,10 @@ export const createRestartActions = (
         spawnError: undefined,
         scrollbackRestoreError: undefined,
         isRestarting: true,
+        // The user is explicitly starting a fresh session, so the
+        // session-lost restore signal has been acknowledged — clear it so the
+        // banner doesn't linger across the restart (issue #9802).
+        sessionLostOnRestore: undefined,
         ...(wasFailed ? { spawnStatus: undefined } : {}),
       }))
     );

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -514,6 +514,91 @@ describe("buildArgsForRespawn", () => {
     expect(result.launchAgentId).toBe("claude");
   });
 
+  // issue #9802 — surface the session-lost signal whenever restore falls
+  // through to a fresh launch, and only then.
+  describe("sessionLostOnRestore signal", () => {
+    it("is not set when an exact-session resume command succeeds", () => {
+      const result = buildArgsForRespawn(
+        {
+          id: "t1",
+          kind: "terminal" as const,
+          agentId: "claude",
+          cwd: "/p",
+          location: "grid",
+          agentSessionId: "sess-123",
+        },
+        "terminal",
+        "/p",
+        { agents: { claude: {} } },
+        false,
+        "/tmp"
+      );
+      expect(result.command).toBe("claude --resume sess-123");
+      expect(result.sessionLostOnRestore).toBeUndefined();
+    });
+
+    it("is set when a captured session can no longer be resumed (branch 2)", () => {
+      buildResumeCommandMock.mockReturnValue(undefined);
+      const result = buildArgsForRespawn(
+        {
+          id: "t1",
+          kind: "terminal" as const,
+          agentId: "claude",
+          cwd: "/p",
+          location: "grid",
+          agentSessionId: "sess-expired",
+        },
+        "terminal",
+        "/p",
+        { agents: { claude: {} } },
+        false,
+        "/tmp"
+      );
+      expect(result.command).toBe("claude --generated");
+      expect(result.sessionLostOnRestore).toBe(true);
+    });
+
+    it("is set when no session was captured and resume-latest is unavailable (branch 3)", () => {
+      buildResumeLatestCommandMock.mockReturnValue(undefined);
+      const result = buildArgsForRespawn(
+        { id: "t1", kind: "terminal" as const, agentId: "claude", cwd: "/p", location: "grid" },
+        "terminal",
+        "/p",
+        { agents: { claude: {} } },
+        false,
+        "/tmp"
+      );
+      expect(result.command).toBe("claude --generated");
+      expect(result.sessionLostOnRestore).toBe(true);
+    });
+
+    it("is not set when resume-latest succeeds as a fallback", () => {
+      buildResumeLatestCommandMock.mockReturnValue("claude --continue");
+      const result = buildArgsForRespawn(
+        { id: "t1", kind: "terminal" as const, agentId: "claude", cwd: "/p", location: "grid" },
+        "terminal",
+        "/p",
+        { agents: { claude: {} } },
+        false,
+        "/tmp"
+      );
+      expect(result.command).toBe("claude --continue");
+      expect(result.sessionLostOnRestore).toBeUndefined();
+    });
+
+    it("is not set for non-agent panels", () => {
+      const result = buildArgsForRespawn(
+        { id: "t1", kind: "terminal" as const, cwd: "/p", location: "grid" },
+        "terminal",
+        "/p",
+        undefined,
+        false,
+        undefined
+      );
+      expect(result.sessionLostOnRestore).toBeUndefined();
+    });
+  });
+
   it("preserves exitBehavior for non-agent panels", () => {
     const result = buildArgsForRespawn(
       { id: "t1", kind: "terminal" as const, cwd: "/p", location: "grid", exitBehavior: "keep" },

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -568,8 +568,35 @@ describe("buildArgsForRespawn", () => {
         false,
         "/tmp"
       );
+      // The resume-latest fallback must have been consulted before the
+      // fresh-launch fallthrough flips the signal — guards against a regression
+      // that flags the session lost without trying to recover it first.
+      expect(buildResumeLatestCommandMock).toHaveBeenCalledWith("claude", undefined);
       expect(result.command).toBe("claude --generated");
       expect(result.sessionLostOnRestore).toBe(true);
+    });
+
+    it("is left unset when agent settings are unavailable (no fresh launch produced)", () => {
+      // IPC hydrate failure: agentSettings undefined, no persisted flags. The
+      // respawn falls back to the saved command rather than generating a fresh
+      // one, so we don't claim the session was lost. Documents a known gap.
+      buildResumeCommandMock.mockReturnValue(undefined);
+      const result = buildArgsForRespawn(
+        {
+          id: "t1",
+          kind: "terminal" as const,
+          agentId: "claude",
+          cwd: "/p",
+          location: "grid",
+          agentSessionId: "sess-expired",
+        },
+        "terminal",
+        "/p",
+        undefined,
+        false,
+        "/tmp"
+      );
+      expect(result.sessionLostOnRestore).toBeUndefined();
     });
 
     it("is not set when resume-latest succeeds as a fallback", () => {

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -95,6 +95,7 @@ export interface HydrationOptions {
     originalPresetId?: string;
     isUsingFallback?: boolean;
     fallbackChainIndex?: number;
+    sessionLostOnRestore?: boolean;
     env?: Record<string, string>;
     extensionState?: Record<string, unknown>;
     pluginId?: string;

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -350,6 +350,10 @@ export function buildArgsForRespawn(
   const isAgentPanel = Boolean(effectiveAgentId);
   const agentId = effectiveAgentId;
   let command = saved.command?.trim() || undefined;
+  // True when we fall through to a fresh agent launch because no resume command
+  // was available — the user's prior conversation is unreachable and we must
+  // surface it rather than silently respawning a clean session (issue #9802).
+  let sessionLostOnRestore = false;
   let presetEnv: Record<string, string> | undefined;
   let preset: AgentPreset | undefined;
   const savedPresetIdForRespawn = readPresetId(saved);
@@ -388,12 +392,14 @@ export function buildArgsForRespawn(
         command = resumeCmd;
       } else if (hasPersistedFlags) {
         command = buildFromPersistedFlags();
+        sessionLostOnRestore = true;
       } else if (agentSettings) {
         command = generateAgentCommand(baseCommand, effectiveEntry, agentId, {
           clipboardDirectory,
           modelId: saved.agentModelId,
           presetArgs: preset?.args?.join(" "),
         });
+        sessionLostOnRestore = true;
       }
     } else {
       // No session ID was captured (graceful-shutdown pattern match missed or
@@ -404,12 +410,14 @@ export function buildArgsForRespawn(
         command = resumeLatestCmd;
       } else if (hasPersistedFlags) {
         command = buildFromPersistedFlags();
+        sessionLostOnRestore = true;
       } else if (agentSettings) {
         command = generateAgentCommand(baseCommand, effectiveEntry, agentId, {
           clipboardDirectory,
           modelId: saved.agentModelId,
           presetArgs: preset?.args?.join(" "),
         });
+        sessionLostOnRestore = true;
       }
     }
   }
@@ -458,6 +466,7 @@ export function buildArgsForRespawn(
     originalPresetId: respawnOriginalPresetId,
     isUsingFallback: presetWasStale ? undefined : saved.isUsingFallback,
     fallbackChainIndex: presetWasStale ? undefined : saved.fallbackChainIndex,
+    sessionLostOnRestore: sessionLostOnRestore || undefined,
     env: presetEnv,
     extensionState: saved.extensionState,
     pluginId: saved.pluginId,


### PR DESCRIPTION
## Summary

- When Daintree restores an agent panel after restart and the prior session can't be resumed (`buildResumeCommand` and `buildResumeLatestCommand` both return null), `statePatcher.ts` was silently respawning a clean terminal with no UI acknowledgement. CLAUDE.md explicitly forbids silent fallback defaults. The user could keep working in the new session without realising the previous conversation was gone.
- Adds a transient `sessionLostOnRestore` flag set on both fallback branches in `buildArgsForRespawn` — the captured-session-but-unresumable path and the no-session-and-resume-latest-unavailable path. Threads it through the hydration path and panel store into a new Tier-3 `RestartBannerVariant` (`session-resume-unavailable`) that renders "Session no longer reachable" with a "Start new session" recovery action (reusing the existing D1 restart path with confirm). The flag is cleared on restart and omitted from serialization so it can't resurface on later restarts.
- Deliberately scoped out the info-tier `session-suspended` variant. When a resume command succeeds the session IS resumed (no banner needed), and the only resume-available code path (`buildResumeLatestCommand` succeeding) is a degraded-but-successful resume with no recovery action the user can take. Per CLAUDE.md's signal-tier rule — demote a tier if ignoring the signal changes nothing the user could do — that doesn't warrant a Tier-3 banner. Happy to add it as a follow-up if a real needs-user-action-to-resume flow lands.

Resolves #9802.

## Changes

- `shared/types/addPanelOptions.ts` + `shared/types/panel.ts` — `sessionLostOnRestore` field on `AddTerminalArgs` and `PtyPanelData`
- `src/utils/stateHydration/statePatcher.ts` — sets flag on both silent-fallback branches
- `src/utils/stateHydration/index.ts` — threads flag through hydration
- `src/panels/terminal/serializer.ts` — explicitly excluded from serialization (never-persisted guarantee)
- `src/store/slices/panelRegistry/addPanel.ts` + `restart.ts` — stores flag, clears on restart
- `src/components/Terminal/restartStatus.ts` + `restartBannerCopy.ts` — new `session-resume-unavailable` variant
- `src/components/Terminal/TerminalRestartStatusBanner.tsx` + `TerminalPane.tsx` — renders the banner

**Pre-existing out-of-scope gap found during review:** `buildResumeLatestCommand` returns `undefined` for non-session-id agents (rolling-history/project-scoped, e.g. Kiro, Kimi) so those also respawn fresh. The new banner correctly reflects that the session is lost, but the underlying resume gap predates this change and warrants a separate issue.

## Testing

216 unit tests pass covering: `restartStatus` precedence logic, banner render and a11y, neutral-copy invariants, never-serialized guarantee, two-branch emission, and field-coverage. `tsc`/lint/format all clean (lint ratchet improved by 6 warnings).