### PR TITLE
feat(terminal): make [image #N] references clickable in assistant terminal

### DIFF
--- a/src/services/terminal/ImageLinksAddon.ts
+++ b/src/services/terminal/ImageLinksAddon.ts
@@ -1,0 +1,92 @@
+import type { Terminal, ILinkProvider, ILink, IBufferRange } from "@xterm/xterm";
+
+/**
+ * Called when the user clicks an `[image #N]` reference. `openLightbox` is true
+ * for a modified click (meta/ctrl), matching `FileLinksAddon`'s convention —
+ * #9829 wires it to the lightbox; the highlight is the interim affordance.
+ */
+export type OnActivateFigure = (figureNumber: number, openLightbox: boolean) => void;
+
+// Bracketed `[image #3]` or bare `image #3`. The bare branch is guarded by
+// boundaries so `reimage #3` (leading word char) and `image #3a` (trailing
+// word char) don't match, and so the bracketed form's inner text is never
+// double-matched. Case-insensitive — assistant output capitalization varies.
+const IMAGE_REF_REGEX = /\[image #(\d+)\]|(?<![[\w])image #(\d+)(?![\w])/gi;
+
+export class ImageLinksAddon implements ILinkProvider {
+  private _terminal: Terminal;
+  private _getFigureNumbers: () => readonly number[];
+  private _onActivate: OnActivateFigure;
+
+  constructor(
+    terminal: Terminal,
+    getFigureNumbers: () => readonly number[],
+    onActivate: OnActivateFigure
+  ) {
+    this._terminal = terminal;
+    this._getFigureNumbers = getFigureNumbers;
+    this._onActivate = onActivate;
+  }
+
+  provideLinks(bufferLineNumber: number, callback: (links: ILink[] | undefined) => void): void {
+    if (bufferLineNumber < 1) {
+      callback(undefined);
+      return;
+    }
+    const line = this._terminal.buffer.active.getLine(bufferLineNumber - 1);
+    if (!line) {
+      callback(undefined);
+      return;
+    }
+
+    // Read figure state live on every hover so links activate the moment a
+    // figure arrives and go inert when the session resets — no re-registration.
+    const available = new Set(this._getFigureNumbers());
+    if (available.size === 0) {
+      callback(undefined);
+      return;
+    }
+
+    const lineText = line.translateToString(true);
+    const regex = new RegExp(IMAGE_REF_REGEX);
+    const links: ILink[] = [];
+    let match: RegExpExecArray | null;
+
+    while ((match = regex.exec(lineText)) !== null) {
+      const digits = match[1] ?? match[2];
+      if (digits === undefined) continue;
+      const figureNumber = Number(digits);
+      // Unknown figure numbers stay inert — no link, no hover affordance.
+      if (!available.has(figureNumber)) continue;
+
+      const startIndex = match.index;
+      const range: IBufferRange = {
+        start: { x: startIndex + 1, y: bufferLineNumber },
+        end: { x: startIndex + match[0].length, y: bufferLineNumber },
+      };
+
+      links.push(new ImageLink(range, match[0], figureNumber, this._onActivate));
+    }
+
+    callback(links.length > 0 ? links : undefined);
+  }
+
+  dispose(): void {}
+}
+
+class ImageLink implements ILink {
+  decorations = { pointerCursor: true, underline: true };
+
+  constructor(
+    public range: IBufferRange,
+    public text: string,
+    private _figureNumber: number,
+    private _onActivate: OnActivateFigure
+  ) {}
+
+  activate(event: MouseEvent, _text: string): void {
+    this._onActivate(this._figureNumber, event.metaKey || event.ctrlKey);
+  }
+
+  dispose?(): void {}
+}

--- a/src/services/terminal/ImageLinksAddon.ts
+++ b/src/services/terminal/ImageLinksAddon.ts
@@ -74,6 +74,11 @@ export class ImageLinksAddon implements ILinkProvider {
   dispose(): void {}
 }
 
+// No hover/leave callbacks on purpose: those feed `ManagedTerminal.hoveredLink`,
+// which drives the right-click "Open link" / "Copy link address" menu and the
+// open-hovered-link shortcut. An `[image #N]` reference is not a URL or path, so
+// surfacing it there would be misleading — the pointer/underline decorations are
+// the affordance, and click activation routes through the provider directly.
 class ImageLink implements ILink {
   decorations = { pointerCursor: true, underline: true };
 

--- a/src/services/terminal/TerminalAddonManager.ts
+++ b/src/services/terminal/TerminalAddonManager.ts
@@ -6,6 +6,7 @@ import { SearchAddon } from "@xterm/addon-search";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { FileLinksAddon, HoverCallback } from "./FileLinksAddon";
+import { ImageLinksAddon, OnActivateFigure } from "./ImageLinksAddon";
 
 const IMAGE_ADDON_OPTIONS = { pixelLimit: 2_000_000, storageLimit: 8 };
 
@@ -17,6 +18,7 @@ export interface TerminalAddons {
   imageAddon: ImageAddon | null;
   searchAddon: SearchAddon;
   fileLinksDisposable: IDisposable | null;
+  imageLinksDisposable: IDisposable | null;
   webLinksAddon: WebLinksAddon | null;
 }
 
@@ -59,6 +61,7 @@ export function setupTerminalAddons(terminal: Terminal): TerminalAddons {
     imageAddon: null,
     searchAddon,
     fileLinksDisposable: null,
+    imageLinksDisposable: null,
     webLinksAddon: null,
   };
 }
@@ -75,6 +78,15 @@ export function createFileLinksAddon(
   onHover?: HoverCallback
 ): IDisposable {
   const addon = new FileLinksAddon(terminal, getCwd, onHover);
+  return terminal.registerLinkProvider(addon);
+}
+
+export function createImageLinksAddon(
+  terminal: Terminal,
+  getFigureNumbers: () => readonly number[],
+  onActivate: OnActivateFigure
+): IDisposable {
+  const addon = new ImageLinksAddon(terminal, getFigureNumbers, onActivate);
   return terminal.registerLinkProvider(addon);
 }
 

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -18,6 +18,7 @@ import {
   setupTerminalAddons,
   createImageAddon,
   createFileLinksAddon,
+  createImageLinksAddon,
   createWebLinksAddon,
 } from "./TerminalAddonManager";
 import { TerminalOutputIngestService } from "./TerminalOutputIngestService";
@@ -43,6 +44,7 @@ import { reduceScrollback, restoreScrollback } from "./TerminalScrollbackControl
 import { DEFAULT_TERMINAL_FONT_FAMILY, onTerminalFontArrivedLate } from "@/config/terminalFont";
 import { getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 import { usePanelStore } from "@/store/panelStore";
+import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { logDebug, logWarn, logError } from "@/utils/logger";
 import { yieldToScheduler } from "@/lib/schedulerYield";
 import { SCROLLBACK_BACKGROUND } from "@shared/config/scrollback";
@@ -244,6 +246,14 @@ class TerminalInstanceService {
               /* ignore */
             }
             managed.fileLinksDisposable = null;
+          }
+          if (managed.imageLinksDisposable) {
+            try {
+              managed.imageLinksDisposable.dispose();
+            } catch {
+              /* ignore */
+            }
+            managed.imageLinksDisposable = null;
           }
           if (managed.webLinksAddon) {
             try {
@@ -1135,6 +1145,12 @@ class TerminalInstanceService {
       }
       managed.fileLinksDisposable = null;
       try {
+        managed.imageLinksDisposable?.dispose();
+      } catch {
+        /* ignore */
+      }
+      managed.imageLinksDisposable = null;
+      try {
         managed.webLinksAddon?.dispose();
       } catch {
         /* ignore */
@@ -1513,6 +1529,26 @@ class TerminalInstanceService {
         );
       } catch (err) {
         logWarn("Failed to create FileLinksAddon", { id, error: err });
+      }
+    }
+    // `[image #N]` references are clickable only in the assistant terminal,
+    // where the help session owns the figure state (#9830). Gating on the
+    // bound help terminal keeps grid terminals that happen to print the token
+    // inert, and the provider rebuilds with the rest on tier promotion.
+    if (!managed.imageLinksDisposable && useHelpPanelStore.getState().terminalId === id) {
+      try {
+        managed.imageLinksDisposable = createImageLinksAddon(
+          managed.terminal,
+          () => useHelpPanelStore.getState().figures.map((f) => f.figureNumber),
+          (figureNumber, openLightbox) => {
+            useHelpPanelStore.getState().setActiveFigureNumber(figureNumber);
+            // Lightbox open on modified-click lands with the figure rail
+            // (#9829); the highlight is the interim affordance until then.
+            void openLightbox;
+          }
+        );
+      } catch (err) {
+        logWarn("Failed to create ImageLinksAddon", { id, error: err });
       }
     }
     if (!managed.webLinksAddon) {
@@ -2855,6 +2891,11 @@ class TerminalInstanceService {
         managed.fileLinksDisposable?.dispose();
       } catch (error) {
         logWarn("Error disposing file links", { error });
+      }
+      try {
+        managed.imageLinksDisposable?.dispose();
+      } catch (error) {
+        logWarn("Error disposing image links", { error });
       }
       try {
         managed.webLinksAddon?.dispose();

--- a/src/services/terminal/__tests__/ImageLinksAddon.test.ts
+++ b/src/services/terminal/__tests__/ImageLinksAddon.test.ts
@@ -145,6 +145,26 @@ describe("ImageLinksAddon", () => {
       });
     });
 
+    it("stays inert for figure #0 when 0 is not a known figure", () => {
+      return new Promise<void>((resolve) => {
+        const { addon } = setup("[image #0]", [1, 2]);
+        addon.provideLinks(1, (links) => {
+          expect(links).toBeUndefined();
+          resolve();
+        });
+      });
+    });
+
+    it("stays inert for an out-of-range figure number", () => {
+      return new Promise<void>((resolve) => {
+        const { addon } = setup("[image #9007199254740993]", [1, 2]);
+        addon.provideLinks(1, (links) => {
+          expect(links).toBeUndefined();
+          resolve();
+        });
+      });
+    });
+
     it("does not match a missing figure number", () => {
       return new Promise<void>((resolve) => {
         const { addon } = setup("see [image #] here", [1, 2]);

--- a/src/services/terminal/__tests__/ImageLinksAddon.test.ts
+++ b/src/services/terminal/__tests__/ImageLinksAddon.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Terminal, IBufferLine } from "@xterm/xterm";
+import { ImageLinksAddon } from "../ImageLinksAddon";
+
+describe("ImageLinksAddon", () => {
+  const createMockTerminal = () => {
+    return {
+      buffer: {
+        active: {
+          getLine: vi.fn(),
+        },
+      },
+    } as unknown as Terminal;
+  };
+
+  const createMockLine = (text: string): IBufferLine => {
+    return {
+      translateToString: () => text,
+    } as IBufferLine;
+  };
+
+  const mouseEvent = (mods: Partial<MouseEvent> = {}): MouseEvent =>
+    ({ metaKey: false, ctrlKey: false, ...mods }) as unknown as MouseEvent;
+
+  const setup = (lineText: string, figureNumbers: number[]) => {
+    const terminal = createMockTerminal();
+    const onActivate = vi.fn();
+    const addon = new ImageLinksAddon(terminal, () => figureNumbers, onActivate);
+    vi.mocked(terminal.buffer.active.getLine).mockReturnValue(createMockLine(lineText));
+    return { terminal, addon, onActivate };
+  };
+
+  describe("matching", () => {
+    it("matches a bracketed reference when the figure exists", () => {
+      return new Promise<void>((resolve) => {
+        const { addon } = setup("See [image #2] for details", [1, 2, 3]);
+        addon.provideLinks(1, (links) => {
+          expect(links).toHaveLength(1);
+          expect(links![0]!.text).toBe("[image #2]");
+          resolve();
+        });
+      });
+    });
+
+    it("matches a bare reference when the figure exists", () => {
+      return new Promise<void>((resolve) => {
+        const { addon } = setup("Compare with image #3 above", [3]);
+        addon.provideLinks(1, (links) => {
+          expect(links).toHaveLength(1);
+          expect(links![0]!.text).toBe("image #3");
+          resolve();
+        });
+      });
+    });
+
+    it("matches case-insensitively", () => {
+      return new Promise<void>((resolve) => {
+        const { addon } = setup("See [IMAGE #2]", [2]);
+        addon.provideLinks(1, (links) => {
+          expect(links).toHaveLength(1);
+          expect(links![0]!.text).toBe("[IMAGE #2]");
+          resolve();
+        });
+      });
+    });
+
+    it("matches multiple references on one line", () => {
+      return new Promise<void>((resolve) => {
+        const { addon } = setup("[image #1] and [image #2]", [1, 2]);
+        addon.provideLinks(1, (links) => {
+          expect(links).toHaveLength(2);
+          expect(links![0]!.text).toBe("[image #1]");
+          expect(links![1]!.text).toBe("[image #2]");
+          resolve();
+        });
+      });
+    });
+
+    it("computes a 1-based inclusive range", () => {
+      return new Promise<void>((resolve) => {
+        const { addon } = setup("ab [image #5]", [5]);
+        addon.provideLinks(7, (links) => {
+          expect(links).toHaveLength(1);
+          const range = links![0]!.range;
+          // "[image #5]" starts at index 3 (1-based x = 4), length 10.
+          expect(range.start.x).toBe(4);
+          expect(range.end.x).toBe(13);
+          expect(range.start.y).toBe(7);
+          expect(range.end.y).toBe(7);
+          resolve();
+        });
+      });
+    });
+  });
+
+  describe("inert cases", () => {
+    it("returns undefined for an unknown figure number", () => {
+      return new Promise<void>((resolve) => {
+        const { addon } = setup("See [image #9]", [1, 2]);
+        addon.provideLinks(1, (links) => {
+          expect(links).toBeUndefined();
+          resolve();
+        });
+      });
+    });
+
+    it("returns undefined when no figures exist", () => {
+      return new Promise<void>((resolve) => {
+        const { addon } = setup("See [image #1]", []);
+        addon.provideLinks(1, (links) => {
+          expect(links).toBeUndefined();
+          resolve();
+        });
+      });
+    });
+
+    it("links only the known figures on a mixed line", () => {
+      return new Promise<void>((resolve) => {
+        const { addon } = setup("[image #1] then [image #9]", [1]);
+        addon.provideLinks(1, (links) => {
+          expect(links).toHaveLength(1);
+          expect(links![0]!.text).toBe("[image #1]");
+          resolve();
+        });
+      });
+    });
+
+    it("does not match when preceded by a word character", () => {
+      return new Promise<void>((resolve) => {
+        const { addon } = setup("reimage #2 done", [2]);
+        addon.provideLinks(1, (links) => {
+          expect(links).toBeUndefined();
+          resolve();
+        });
+      });
+    });
+
+    it("does not match when followed by a word character", () => {
+      return new Promise<void>((resolve) => {
+        const { addon } = setup("image #2abc", [2]);
+        addon.provideLinks(1, (links) => {
+          expect(links).toBeUndefined();
+          resolve();
+        });
+      });
+    });
+
+    it("does not match a missing figure number", () => {
+      return new Promise<void>((resolve) => {
+        const { addon } = setup("see [image #] here", [1, 2]);
+        addon.provideLinks(1, (links) => {
+          expect(links).toBeUndefined();
+          resolve();
+        });
+      });
+    });
+
+    it("returns undefined for line numbers below 1", () => {
+      return new Promise<void>((resolve) => {
+        const { addon } = setup("[image #1]", [1]);
+        addon.provideLinks(0, (links) => {
+          expect(links).toBeUndefined();
+          resolve();
+        });
+      });
+    });
+
+    it("returns undefined when the buffer line is missing", () => {
+      return new Promise<void>((resolve) => {
+        const terminal = createMockTerminal();
+        const addon = new ImageLinksAddon(terminal, () => [1], vi.fn());
+        vi.mocked(terminal.buffer.active.getLine).mockReturnValue(undefined);
+        addon.provideLinks(1, (links) => {
+          expect(links).toBeUndefined();
+          resolve();
+        });
+      });
+    });
+  });
+
+  describe("activation", () => {
+    it("activates with openLightbox=false on a plain click", () => {
+      return new Promise<void>((resolve) => {
+        const { addon, onActivate } = setup("[image #2]", [2]);
+        addon.provideLinks(1, (links) => {
+          links![0]!.activate(mouseEvent(), links![0]!.text);
+          expect(onActivate).toHaveBeenCalledWith(2, false);
+          resolve();
+        });
+      });
+    });
+
+    it("activates with openLightbox=true on a meta click", () => {
+      return new Promise<void>((resolve) => {
+        const { addon, onActivate } = setup("[image #2]", [2]);
+        addon.provideLinks(1, (links) => {
+          links![0]!.activate(mouseEvent({ metaKey: true }), links![0]!.text);
+          expect(onActivate).toHaveBeenCalledWith(2, true);
+          resolve();
+        });
+      });
+    });
+
+    it("activates with openLightbox=true on a ctrl click", () => {
+      return new Promise<void>((resolve) => {
+        const { addon, onActivate } = setup("[image #2]", [2]);
+        addon.provideLinks(1, (links) => {
+          links![0]!.activate(mouseEvent({ ctrlKey: true }), links![0]!.text);
+          expect(onActivate).toHaveBeenCalledWith(2, true);
+          resolve();
+        });
+      });
+    });
+  });
+
+  describe("live figure state", () => {
+    it("reflects figure changes without re-registration", () => {
+      return new Promise<void>((resolve) => {
+        const terminal = createMockTerminal();
+        let figures: number[] = [];
+        const addon = new ImageLinksAddon(terminal, () => figures, vi.fn());
+        vi.mocked(terminal.buffer.active.getLine).mockReturnValue(createMockLine("[image #4]"));
+
+        addon.provideLinks(1, (before) => {
+          expect(before).toBeUndefined();
+          figures = [4];
+          addon.provideLinks(1, (after) => {
+            expect(after).toHaveLength(1);
+            expect(after![0]!.text).toBe("[image #4]");
+            resolve();
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/services/terminal/__tests__/TerminalInstanceService.batchResize.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.batchResize.test.ts
@@ -136,6 +136,7 @@ function makeManaged(fixture: ManagedFixture): ManagedTerminal {
     imageAddon: null,
     searchAddon: {} as ManagedTerminal["searchAddon"],
     fileLinksDisposable: null,
+    imageLinksDisposable: null,
     webLinksAddon: null,
     hoveredLink: null,
   } as ManagedTerminal;

--- a/src/services/terminal/__tests__/TerminalInstanceService.resizePass.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.resizePass.test.ts
@@ -125,6 +125,7 @@ function makeManaged(visible = true): ManagedTerminal {
     imageAddon: null,
     searchAddon: {} as ManagedTerminal["searchAddon"],
     fileLinksDisposable: null,
+    imageLinksDisposable: null,
     webLinksAddon: null,
     hoveredLink: null,
   } as ManagedTerminal;

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -28,6 +28,7 @@ export interface ManagedTerminal {
   imageAddon: ImageAddon | null;
   searchAddon: SearchAddon;
   fileLinksDisposable: IDisposable | null;
+  imageLinksDisposable: IDisposable | null;
   webLinksAddon: WebLinksAddon | null;
   // Currently-hovered link (tracked via xterm addon hover/leave callbacks).
   // Read synchronously by the right-click context menu so it reflects the

--- a/src/store/__tests__/helpPanelStore.test.ts
+++ b/src/store/__tests__/helpPanelStore.test.ts
@@ -662,4 +662,61 @@ describe("helpPanelStore persistence migration", () => {
       expect(store.getState().introDismissed).toBe(true);
     });
   });
+
+  describe("activeFigureNumber (#9830)", () => {
+    it("starts as null on a fresh install", async () => {
+      installLocalStorage({});
+
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+      expect(store.getState().activeFigureNumber).toBeNull();
+    });
+
+    it("setActiveFigureNumber updates the active figure", async () => {
+      installLocalStorage({});
+
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+      store.getState().setActiveFigureNumber(3);
+
+      expect(store.getState().activeFigureNumber).toBe(3);
+
+      store.getState().setActiveFigureNumber(null);
+      expect(store.getState().activeFigureNumber).toBeNull();
+    });
+
+    it("clearFigures resets the active figure alongside the figures list", async () => {
+      installLocalStorage({});
+
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+      store.getState().addFigure({
+        imageId: "img-1",
+        figureNumber: 1,
+        figureLabel: "image #1",
+        url: "https://daintree.org/a.png",
+      });
+      store.getState().setActiveFigureNumber(1);
+      expect(store.getState().figures).toHaveLength(1);
+      expect(store.getState().activeFigureNumber).toBe(1);
+
+      store.getState().clearFigures();
+      expect(store.getState().figures).toHaveLength(0);
+      expect(store.getState().activeFigureNumber).toBeNull();
+    });
+
+    it("activeFigureNumber is NOT persisted", async () => {
+      const backing = installLocalStorage({});
+
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+      store.getState().setActiveFigureNumber(2);
+
+      const written = backing.get(STORAGE_KEY);
+      expect(written).toBeDefined();
+      const parsed = JSON.parse(written!) as {
+        version: number;
+        state: Record<string, unknown>;
+      };
+      expect(parsed.state).not.toHaveProperty("activeFigureNumber");
+      expect(store.getState().activeFigureNumber).toBe(2);
+    });
+  });
 });

--- a/src/store/__tests__/helpPanelStore.test.ts
+++ b/src/store/__tests__/helpPanelStore.test.ts
@@ -703,6 +703,25 @@ describe("helpPanelStore persistence migration", () => {
       expect(store.getState().activeFigureNumber).toBeNull();
     });
 
+    it("clearTerminal drops figures and the active figure (session-scoped reset)", async () => {
+      installLocalStorage({});
+
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+      store.getState().addFigure({
+        imageId: "img-1",
+        figureNumber: 1,
+        figureLabel: "image #1",
+        url: "https://daintree.org/a.png",
+      });
+      store.getState().setActiveFigureNumber(1);
+      expect(store.getState().figures).toHaveLength(1);
+      expect(store.getState().activeFigureNumber).toBe(1);
+
+      store.getState().clearTerminal();
+      expect(store.getState().figures).toHaveLength(0);
+      expect(store.getState().activeFigureNumber).toBeNull();
+    });
+
     it("activeFigureNumber is NOT persisted", async () => {
       const backing = installLocalStorage({});
 

--- a/src/store/helpPanelStore.ts
+++ b/src/store/helpPanelStore.ts
@@ -74,6 +74,12 @@ interface HelpPanelState {
    * empty, so stale image references can't survive an app restart.
    */
   figures: HelpFigure[];
+  /**
+   * The figure a clickable `[image #N]` reference last activated (#9830). The
+   * figure rail (#9829) consumes this to scroll-to and highlight the matching
+   * thumbnail. Session-scoped and never persisted — cleared on session reset.
+   */
+  activeFigureNumber: number | null;
 }
 
 interface HelpPanelActions {
@@ -96,6 +102,8 @@ interface HelpPanelActions {
   addFigure: (figure: HelpFigure) => void;
   /** Drop all figures — called when the conversation/terminal resets. */
   clearFigures: () => void;
+  /** Set the figure a clickable `[image #N]` reference activated (#9830). */
+  setActiveFigureNumber: (figureNumber: number | null) => void;
 }
 
 const initialState: HelpPanelState = {
@@ -111,6 +119,7 @@ const initialState: HelpPanelState = {
   hibernateSessions: {},
   focusRequest: 0,
   figures: [],
+  activeFigureNumber: null,
 };
 
 function isRecordOfUnknown(value: unknown): value is Record<string, unknown> {
@@ -208,7 +217,17 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
           return { figures: next };
         }),
 
-      clearFigures: () => set((s) => (s.figures.length === 0 ? s : { figures: [] })),
+      clearFigures: () =>
+        set((s) =>
+          s.figures.length === 0 && s.activeFigureNumber === null
+            ? s
+            : { figures: [], activeFigureNumber: null }
+        ),
+
+      setActiveFigureNumber: (figureNumber) =>
+        set((s) =>
+          s.activeFigureNumber === figureNumber ? s : { activeFigureNumber: figureNumber }
+        ),
     }),
     {
       name: "help-panel-storage",

--- a/src/store/helpPanelStore.ts
+++ b/src/store/helpPanelStore.ts
@@ -175,7 +175,17 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
         })),
 
       clearTerminal: () =>
-        set({ terminalId: null, agentId: null, sessionId: null, conversationTouched: false }),
+        set({
+          terminalId: null,
+          agentId: null,
+          sessionId: null,
+          conversationTouched: false,
+          // Figures are session-scoped — unbinding the terminal must drop them
+          // (and any active highlight) so a relaunched session can't navigate
+          // to a previous session's image (#9830).
+          figures: [],
+          activeFigureNumber: null,
+        }),
 
       setPreferredAgent: (agentId) =>
         set({ preferredAgentId: agentId, droppedPreferredAgentId: null }),


### PR DESCRIPTION
## Summary

- Adds `ImageLinksAddon`, a new xterm link provider that matches `[image #N]` and bare `image #N` patterns in assistant terminal output. Clicking activates the matching figure in the help panel's figure rail; modified click (meta/ctrl) flags the lightbox open.
- Links are only active when the referenced figure exists in the current session -- unknown numbers stay inert. The addon is registered only for the help terminal, not grid terminals.
- `helpPanelStore` gains transient `activeFigureNumber` / `setActiveFigureNumber` state (never persisted), reset on both `clearFigures` and `clearTerminal` so a relaunched session can't navigate to a prior session's image.

Resolves #9830

## Changes

- `src/services/terminal/ImageLinksAddon.ts` -- new xterm `ILinkProvider` addon; figure state read live via getter so links activate/inert as figures arrive without re-registration
- `src/services/terminal/TerminalAddonManager.ts` -- tracks `imageLinksDisposable` alongside `fileLinksDisposable`
- `src/services/terminal/TerminalInstanceService.ts` -- registers addon in `ensureDeferredAddons`, gated to the bound help terminal (`useHelpPanelStore.getState().terminalId === id`); disposed at all teardown sites (tier drop, hibernate, destroy) to avoid GC-root leaks
- `src/store/helpPanelStore.ts` -- `activeFigureNumber`, `setActiveFigureNumber`, reset paths
- `src/services/terminal/__tests__/ImageLinksAddon.test.ts` -- matching, inert/boundary/edge cases (figure #0, out-of-range), activation modifiers, live state
- `src/store/__tests__/helpPanelStore.test.ts` -- `activeFigureNumber` lifecycle and non-persistence

## Testing

- New `ImageLinksAddon.test.ts` covers matching patterns, inert states for unknown figure numbers (including #0 and out-of-range), modifier key routing, and live figure-state gating.
- `helpPanelStore.test.ts` additions verify `activeFigureNumber` is set, reset on `clearFigures` and `clearTerminal`, and excluded from persisted state.
- `npm run check` passes; ESLint warning count down 6 from baseline.

**Forward dependency:** the figure rail scroll-to/highlight and lightbox wiring land in #9829, which consumes the `activeFigureNumber` / `openLightbox` contract this PR provides.