### PR TITLE
fix(dev-preview): auto-start restored-stopped panel on first project switch

### DIFF
--- a/electron/ipc/handlers/__tests__/project.switch.test.ts
+++ b/electron/ipc/handlers/__tests__/project.switch.test.ts
@@ -769,6 +769,8 @@ describe("project:switch provenance (#9859)", () => {
 
     const call = sendMock.mock.calls.find((c) => c[0] === CHANNELS.PROJECT_ON_SWITCH);
     expect(call).toBeDefined();
-    expect((call![1] as { switchId: string }).switchId).toEqual(expect.any(String));
+    const switchId = (call![1] as { switchId: string }).switchId;
+    expect(typeof switchId).toBe("string");
+    expect(switchId.length).toBeGreaterThan(0);
   });
 });

--- a/electron/ipc/handlers/__tests__/project.switch.test.ts
+++ b/electron/ipc/handlers/__tests__/project.switch.test.ts
@@ -111,7 +111,7 @@ describe("project:switch multi-window PVM routing", () => {
 
   it("uses window 2's PVM when the IPC sender is window 2", async () => {
     const mockView = {
-      webContents: { id: 200, isDestroyed: () => false },
+      webContents: { id: 200, isDestroyed: () => false, send: vi.fn() },
     };
 
     const pvm1 = {
@@ -166,7 +166,7 @@ describe("project:switch multi-window PVM routing", () => {
 
   it("falls back to deps.projectViewManager when windowRegistry lookup fails", async () => {
     const mockView = {
-      webContents: { id: 100, isDestroyed: () => false },
+      webContents: { id: 100, isDestroyed: () => false, send: vi.fn() },
     };
 
     const pvmFallback = {
@@ -252,7 +252,7 @@ describe("project:switch multi-window PVM routing", () => {
 
   it("resolves correct PVM for handleProjectReopen", async () => {
     const mockView = {
-      webContents: { id: 200, isDestroyed: () => false },
+      webContents: { id: 200, isDestroyed: () => false, send: vi.fn() },
     };
 
     const pvm1 = {
@@ -307,7 +307,7 @@ describe("project:switch activeWorktreeId pre-apply (#5000)", () => {
 
   it("persists activeWorktreeId from outgoingState on project switch", async () => {
     const mockView = {
-      webContents: { id: 100, isDestroyed: () => false },
+      webContents: { id: 100, isDestroyed: () => false, send: vi.fn() },
     };
 
     const pvm = {
@@ -356,7 +356,7 @@ describe("project:switch activeWorktreeId pre-apply (#5000)", () => {
 
   it("clears stale activeWorktreeId when outgoingState sends undefined", async () => {
     const mockView = {
-      webContents: { id: 100, isDestroyed: () => false },
+      webContents: { id: 100, isDestroyed: () => false, send: vi.fn() },
     };
 
     const pvm = {
@@ -411,7 +411,7 @@ describe("project:switch activeWorktreeId pre-apply (#5000)", () => {
 
   it("persists activeWorktreeId from outgoingState on project reopen", async () => {
     const mockView = {
-      webContents: { id: 200, isDestroyed: () => false },
+      webContents: { id: 200, isDestroyed: () => false, send: vi.fn() },
     };
 
     const pvm = {
@@ -471,7 +471,7 @@ describe("project:switch outgoing tabGroups pre-apply (#5001)", () => {
 
   it("persists tabGroups from outgoingState on project switch", async () => {
     const mockView = {
-      webContents: { id: 100, isDestroyed: () => false },
+      webContents: { id: 100, isDestroyed: () => false, send: vi.fn() },
     };
 
     const pvm = {
@@ -525,7 +525,7 @@ describe("project:switch outgoing tabGroups pre-apply (#5001)", () => {
 
   it("does not include tabGroups when outgoingState has no tabGroups", async () => {
     const mockView = {
-      webContents: { id: 100, isDestroyed: () => false },
+      webContents: { id: 100, isDestroyed: () => false, send: vi.fn() },
     };
 
     const pvm = {
@@ -574,7 +574,7 @@ describe("project:switch outgoing tabGroups pre-apply (#5001)", () => {
 
   it("clears stale tabGroups when outgoingState sends empty array", async () => {
     const mockView = {
-      webContents: { id: 100, isDestroyed: () => false },
+      webContents: { id: 100, isDestroyed: () => false, send: vi.fn() },
     };
 
     const pvm = {
@@ -696,5 +696,79 @@ describe("project:switch worktree-load-status (#8400)", () => {
       projectId: "proj-new",
       worktreeLoadError: null,
     });
+  });
+});
+
+describe("project:switch provenance (#9859)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function runActivation(channel: string, projectOverrides: Record<string, unknown> = {}) {
+    const sendMock = vi.fn();
+    const mockView = {
+      webContents: { id: 300, isDestroyed: () => false, send: sendMock },
+    };
+    const pvm = {
+      switchTo: vi.fn().mockResolvedValue({ view: mockView, isNew: false }),
+      getProjectIdForWebContents: vi.fn(),
+    };
+
+    mockGetWindowForWebContents.mockReturnValue(null);
+
+    projectStoreMock.getCurrentProjectId.mockReturnValue("proj-old");
+    projectStoreMock.getProjectById.mockReturnValue({
+      id: "proj-new",
+      name: "New Project",
+      path: "/projects/new",
+      ...projectOverrides,
+    });
+    projectStoreMock.setCurrentProject.mockResolvedValue(undefined);
+
+    const deps = {
+      mainWindow: { id: 1 } as unknown,
+      projectViewManager: pvm,
+    } as unknown as HandlerDependencies;
+
+    registerProjectCrudHandlers(deps);
+
+    const handleMap = new Map<string, (...args: unknown[]) => unknown>();
+    for (const call of (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls) {
+      handleMap.set(call[0] as string, call[1] as (...args: unknown[]) => unknown);
+    }
+
+    await handleMap.get(channel)!({ sender: { id: 99 } }, "proj-new");
+    return sendMock;
+  }
+
+  it("emits PROJECT_ON_SWITCH with a string switchId to the activated view on switch", async () => {
+    const sendMock = await runActivation(CHANNELS.PROJECT_SWITCH);
+
+    const call = sendMock.mock.calls.find((c) => c[0] === CHANNELS.PROJECT_ON_SWITCH);
+    expect(call).toBeDefined();
+    const payload = call![1] as { project: { id: string }; switchId: string };
+    expect(payload.project).toEqual(expect.objectContaining({ id: "proj-new" }));
+    // Behavior, not a fixed literal: provenance must be a non-empty string so the
+    // renderer's cold-launch guard flips (a missing id would leave it null).
+    expect(typeof payload.switchId).toBe("string");
+    expect(payload.switchId.length).toBeGreaterThan(0);
+  });
+
+  it("emits a fresh switchId on each switch so repeat activations are distinguishable", async () => {
+    const first = await runActivation(CHANNELS.PROJECT_SWITCH);
+    const second = await runActivation(CHANNELS.PROJECT_SWITCH);
+
+    const idOf = (mock: ReturnType<typeof vi.fn>) =>
+      (mock.mock.calls.find((c) => c[0] === CHANNELS.PROJECT_ON_SWITCH)![1] as { switchId: string })
+        .switchId;
+    expect(idOf(first)).not.toBe(idOf(second));
+  });
+
+  it("emits PROJECT_ON_SWITCH on reopen as well", async () => {
+    const sendMock = await runActivation(CHANNELS.PROJECT_REOPEN, { status: "background" });
+
+    const call = sendMock.mock.calls.find((c) => c[0] === CHANNELS.PROJECT_ON_SWITCH);
+    expect(call).toBeDefined();
+    expect((call![1] as { switchId: string }).switchId).toEqual(expect.any(String));
   });
 });

--- a/electron/ipc/handlers/projectCrud/switch.ts
+++ b/electron/ipc/handlers/projectCrud/switch.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { CHANNELS } from "../../channels.js";
 import { typedHandleWithContext, broadcastToRenderer } from "../../utils.js";
 import { getWindowForWebContents } from "../../../window/webContentsRegistry.js";
@@ -197,6 +198,25 @@ async function activateProjectView(
   // WebContentsView stores keep stale MRU timestamps and the next
   // `Cmd+Alt+=` / project switcher pick targets the wrong project.
   broadcastProjectSwitchUpdates(previousProjectId, projectId);
+
+  // Mark the activated view as reached via an explicit in-session switch (#9859).
+  // The legacy `ProjectSwitchService` path emits this on the single shared
+  // renderer; the PVM path swaps WebContentsViews, so without a targeted send the
+  // newly-activated view can't tell a mid-session switch from a cold app launch.
+  // That distinction is what lets a `restored-stopped` dev preview auto-start on
+  // first activation while still honoring the no-respawn-on-launch contract
+  // (#9094): the initial app-launch view is created via `createWindow`, never
+  // through this handler, so it never receives the event. Targeted send (not a
+  // broadcast) so LRU-cached other-project views aren't falsely marked switched.
+  // `switchTo` already awaited `did-finish-load`, so the renderer's listener is
+  // registered (mirrors the targeted `PROJECT_WORKTREE_LOAD_STATUS` send below).
+  if (!view.webContents.isDestroyed()) {
+    const switchedProject = projectStore.getProjectById(projectId) ?? project;
+    view.webContents.send(CHANNELS.PROJECT_ON_SWITCH, {
+      project: switchedProject,
+      switchId: randomUUID(),
+    });
+  }
 
   // Reopen requires the workspace host to be resumed BEFORE loadProject so
   // the host is ready to accept worktree IPC from the newly-active view.

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -1,4 +1,5 @@
 import { Menu, dialog, BrowserWindow, app, webContents } from "electron";
+import { randomUUID } from "node:crypto";
 import { projectStore } from "./services/ProjectStore.js";
 import { openExternalUrl } from "./utils/openExternal.js";
 import { CHANNELS } from "./ipc/channels.js";
@@ -602,6 +603,19 @@ export async function handleDirectoryOpen(
       // departing and activated rows so cached views' MRU timestamps stay
       // fresh; otherwise the next `Cmd+Alt+=` targets the wrong project.
       broadcastProjectSwitchUpdates(previousProjectId, project.id);
+
+      // Mark the activated view as reached via an explicit in-session switch
+      // (#9859), mirroring activateProjectView. Opening a returning project's
+      // folder is a first-activation path too, so its restored-stopped dev
+      // preview should auto-start rather than stall on the restart CTA. Targeted
+      // send to the activated view only; the initial app-launch view never flows
+      // through here, so the #9094 no-respawn-on-launch contract is preserved.
+      if (!view.webContents.isDestroyed()) {
+        view.webContents.send(CHANNELS.PROJECT_ON_SWITCH, {
+          project: projectStore.getProjectById(project.id) ?? project,
+          switchId: randomUUID(),
+        });
+      }
 
       // Re-attach producer ports for cached-view reactivation. The IPC switch
       // handler (projectCrud/switch.ts:activateProjectView) does this in the

--- a/src/hooks/__tests__/useDevServer.adversarial.test.tsx
+++ b/src/hooks/__tests__/useDevServer.adversarial.test.tsx
@@ -6,6 +6,7 @@ import type { DevPreviewSessionState } from "@shared/types/ipc/devPreview";
 const { projectState, useProjectStoreMock } = vi.hoisted(() => {
   const projectState = {
     currentProject: { id: "project-1" } as { id: string } | null,
+    lastSwitchId: null as string | null,
   };
 
   const useProjectStoreMock = vi.fn((selector: (state: typeof projectState) => unknown) =>
@@ -59,6 +60,7 @@ describe("useDevServer adversarial races", () => {
     vi.clearAllMocks();
     _resetPersistedEnsureCacheForTests();
     projectState.currentProject = { id: "project-1" };
+    projectState.lastSwitchId = null;
 
     ensureMock = vi.fn(async (request: { projectId: string }) =>
       buildState({
@@ -1675,6 +1677,37 @@ describe("useDevServer adversarial races", () => {
       });
 
       expect(ensureMock).toHaveBeenCalledTimes(1);
+      expect(ensureMock).toHaveBeenCalledWith(
+        expect.objectContaining({ projectId: "project-1", devCommand: "npm run dev" })
+      );
+    });
+
+    it("auto-ensures a restored-stopped panel on the first mid-session switch (#9859)", async () => {
+      // A non-null lastSwitchId means the current project was reached via an
+      // explicit in-session switch, not cold launch — so the dev server the user
+      // had running should come back automatically instead of stalling on the
+      // restart CTA. The #9094 contract (no respawn on relaunch) is preserved by
+      // the cold-launch test above, where lastSwitchId stays null.
+      projectState.lastSwitchId = "switch-abc123";
+      getStateMock.mockImplementation(async (request: { projectId: string }) =>
+        buildState({
+          panelId: "panel-1",
+          projectId: request.projectId,
+          status: "restored-stopped",
+        })
+      );
+
+      renderHook(() =>
+        useDevServer({
+          panelId: "panel-1",
+          devCommand: "npm run dev",
+          cwd: "/repo",
+        })
+      );
+
+      await waitFor(() => {
+        expect(ensureMock).toHaveBeenCalledTimes(1);
+      });
       expect(ensureMock).toHaveBeenCalledWith(
         expect.objectContaining({ projectId: "project-1", devCommand: "npm run dev" })
       );

--- a/src/hooks/__tests__/useDevServer.adversarial.test.tsx
+++ b/src/hooks/__tests__/useDevServer.adversarial.test.tsx
@@ -1712,5 +1712,47 @@ describe("useDevServer adversarial races", () => {
         expect.objectContaining({ projectId: "project-1", devCommand: "npm run dev" })
       );
     });
+
+    it("auto-ensures when lastSwitchId flips null→string after mount (#9859 race)", async () => {
+      // The actual production sequence on a cold-started switched-to view: the
+      // panel hydrates restored-stopped (no ensure yet, lastSwitchId still null),
+      // THEN the PROJECT_ON_SWITCH event arrives and flips lastSwitchId to a
+      // string. The auto-ensure effect must re-run on that change and start the
+      // server — proving the bail at null isn't sticky.
+      getStateMock.mockImplementation(async (request: { projectId: string }) =>
+        buildState({
+          panelId: "panel-1",
+          projectId: request.projectId,
+          status: "restored-stopped",
+        })
+      );
+
+      const { result, rerender } = renderHook(() =>
+        useDevServer({
+          panelId: "panel-1",
+          devCommand: "npm run dev",
+          cwd: "/repo",
+        })
+      );
+
+      // Cold launch: restored-stopped surfaces, nothing auto-starts.
+      await waitFor(() => {
+        expect(result.current.status).toBe("restored-stopped");
+      });
+      expect(ensureMock).not.toHaveBeenCalled();
+
+      // The switch event lands → provenance flips non-null → effect re-runs.
+      act(() => {
+        projectState.lastSwitchId = "switch-late";
+      });
+      rerender();
+
+      await waitFor(() => {
+        expect(ensureMock).toHaveBeenCalledTimes(1);
+      });
+      expect(ensureMock).toHaveBeenCalledWith(
+        expect.objectContaining({ projectId: "project-1", devCommand: "npm run dev" })
+      );
+    });
   });
 });

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -117,6 +117,11 @@ export function useDevServer({
   turbopackEnabled,
 }: UseDevServerOptions): UseDevServerReturn {
   const currentProjectId = useProjectStore((state) => state.currentProject?.id ?? null);
+  // Non-null once the user has switched projects in this session (#9859). A
+  // restored-stopped panel must keep its restart CTA on cold launch (#9094), but
+  // auto-start on the first live switch to a project. `lastSwitchId` is the
+  // provenance signal: null = cold launch, UUID = reached via an explicit switch.
+  const lastSwitchId = useProjectStore((state) => state.lastSwitchId);
   const [status, setStatus] = useState<DevPreviewStatus>("stopped");
   const [url, setUrl] = useState<string | null>(null);
   const [terminalId, setTerminalId] = useState<string | null>(null);
@@ -458,7 +463,11 @@ export function useDevServer({
     // "restored-stopped" panel must surface its restart CTA, not silently
     // relaunch the dev server the user closed Daintree with (#9094).
     if (!initialStateResolved) return;
-    if (status === "restored-stopped") return;
+    // A restored-stopped panel surfaces its restart CTA on cold launch
+    // (lastSwitchId === null), but auto-starts on the first live switch to the
+    // project (#9859) — the user reactivating a project expects its dev server
+    // back, unlike a fresh app launch where silent respawn is wrong (#9094).
+    if (status === "restored-stopped" && lastSwitchId === null) return;
 
     const configKey = buildEnsureConfigKey({
       projectId: currentProjectId,
@@ -495,6 +504,7 @@ export function useDevServer({
     ensureLatestConfig,
     initialStateResolved,
     status,
+    lastSwitchId,
   ]);
 
   // Staged stuck-start escalation (#8276, retuned #9099). Replaces the

--- a/src/store/__tests__/projectStore.adversarial.test.ts
+++ b/src/store/__tests__/projectStore.adversarial.test.ts
@@ -306,6 +306,26 @@ describe("projectStore adversarial", () => {
     expect(useProjectStore.getState().lastSwitchId).toBe("switch-xyz");
   });
 
+  it("never hydrates lastSwitchId from persisted storage (#9094 contract)", async () => {
+    installProjectApi({});
+    installLocalStorage(
+      createStorageMock({
+        // Storage poisoning: even if a stale/forged switch id is persisted, it
+        // must not survive a cold launch — only a live onSwitch event may set it,
+        // otherwise the no-respawn-on-relaunch guard would be defeated.
+        "project-storage": JSON.stringify({
+          state: { projects: [projectA], lastSwitchId: "stale-switch" },
+          version: 0,
+        }),
+      })
+    );
+
+    const { useProjectStore } = await import("../projectStore");
+
+    expect(useProjectStore.getState().projects).toEqual([projectA]);
+    expect(useProjectStore.getState().lastSwitchId).toBeNull();
+  });
+
   it("ignores stale switch rejections once a newer switch has started", async () => {
     installProjectApi({});
     installLocalStorage(createStorageMock());

--- a/src/store/__tests__/projectStore.adversarial.test.ts
+++ b/src/store/__tests__/projectStore.adversarial.test.ts
@@ -38,6 +38,9 @@ const projectClientMock = vi.hoisted(() => ({
   close: vi.fn(),
   createFolder: vi.fn(),
   onWorktreeLoadStatus: vi.fn(() => () => {}),
+  onSwitch: vi.fn<
+    (cb: (payload: { project: ProjectShape; switchId?: unknown }) => void) => () => void
+  >(() => () => {}),
 }));
 
 const notifyMock = vi.hoisted(() => vi.fn());
@@ -274,6 +277,33 @@ describe("projectStore adversarial", () => {
 
     updatedCallbacks[0]!(projectB);
     expect(useProjectStore.getState().projects).toEqual([projectB]);
+  });
+
+  it("records lastSwitchId only from a string switchId via onSwitch (#9859)", async () => {
+    const switchCallbacks: Array<(payload: { project: ProjectShape; switchId?: unknown }) => void> =
+      [];
+    projectClientMock.onSwitch.mockImplementation((callback) => {
+      switchCallbacks.push(callback);
+      return vi.fn();
+    });
+    installProjectApi({});
+    installLocalStorage(createStorageMock());
+
+    const { useProjectStore } = await import("../projectStore");
+
+    // Cold launch: no switch event has fired, so the guard value stays null.
+    expect(useProjectStore.getState().lastSwitchId).toBeNull();
+    expect(switchCallbacks).toHaveLength(1);
+
+    // A missing/non-string switchId must NOT flip the cold-launch guard (#9094).
+    switchCallbacks[0]!({ project: projectA });
+    expect(useProjectStore.getState().lastSwitchId).toBeNull();
+    switchCallbacks[0]!({ project: projectA, switchId: 123 });
+    expect(useProjectStore.getState().lastSwitchId).toBeNull();
+
+    // A real live switch records its provenance id.
+    switchCallbacks[0]!({ project: projectA, switchId: "switch-xyz" });
+    expect(useProjectStore.getState().lastSwitchId).toBe("switch-xyz");
   });
 
   it("ignores stale switch rejections once a newer switch has started", async () => {

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -927,7 +927,12 @@ if (typeof window !== "undefined" && window.electron?.project) {
   if (typeof projectClient.onSwitch === "function" && !listenerState.switchRegistered) {
     listenerState.switchRegistered = true;
     projectClient.onSwitch((payload) => {
-      useProjectStore.setState({ lastSwitchId: payload.switchId });
+      // Only a string switchId flips the cold-launch guard. A missing/undefined
+      // switchId (preload drift, partial test double) must not become a truthy
+      // non-null value that silently bypasses the #9094 no-respawn-on-launch path.
+      if (typeof payload.switchId === "string") {
+        useProjectStore.setState({ lastSwitchId: payload.switchId });
+      }
     });
   }
 }

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -100,6 +100,14 @@ interface ProjectState {
    * — never persisted, cleared on the next switch start or a successful retry.
    */
   worktreeLoadError: string | null;
+  /**
+   * The `switchId` of the most recent in-session project switch, or `null` when
+   * the current project was reached via cold launch (no switch event fired yet).
+   * Distinguishes app launch from a live mid-session switch so a `restored-stopped`
+   * dev preview auto-starts on first activation (#9859) without re-spawning on
+   * relaunch (#9094). Transient — never persisted, set only by the `onSwitch` IPC.
+   */
+  lastSwitchId: string | null;
   gitInitDialogOpen: boolean;
   gitInitDirectoryPath: string | null;
   createFolderDialogOpen: boolean;
@@ -161,6 +169,7 @@ interface ProjectStoreListenerState {
   updatedRegistered: boolean;
   removedRegistered: boolean;
   worktreeLoadStatusRegistered: boolean;
+  switchRegistered: boolean;
 }
 
 const PROJECT_STORE_LISTENER_STATE_KEY = "__daintreeProjectStoreListenerState";
@@ -246,6 +255,7 @@ function getProjectStoreListenerState(): ProjectStoreListenerState {
     updatedRegistered: false,
     removedRegistered: false,
     worktreeLoadStatusRegistered: false,
+    switchRegistered: false,
   };
   target[PROJECT_STORE_LISTENER_STATE_KEY] = created;
   return created;
@@ -325,6 +335,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
   cloneRepoDialogOpen: false,
   error: null,
   worktreeLoadError: null,
+  lastSwitchId: null,
 
   addProjectByPath: async (path, options) => {
     set({ isLoading: true, error: null });
@@ -907,6 +918,16 @@ if (typeof window !== "undefined" && window.electron?.project) {
     listenerState.worktreeLoadStatusRegistered = true;
     projectClient.onWorktreeLoadStatus((payload) => {
       listenerState.applyWorktreeLoadStatus?.(payload);
+    });
+  }
+  // Record the switchId of every live project switch. `lastSwitchId` stays null
+  // on cold launch (no switch event fires), which is what lets a restored-stopped
+  // dev preview auto-start on first mid-session activation (#9859) while still
+  // honoring the no-auto-spawn-on-relaunch contract (#9094).
+  if (typeof projectClient.onSwitch === "function" && !listenerState.switchRegistered) {
+    listenerState.switchRegistered = true;
+    projectClient.onSwitch((payload) => {
+      useProjectStore.setState({ lastSwitchId: payload.switchId });
     });
   }
 }


### PR DESCRIPTION
## Summary

When switching to a project for the first time in a session, its dev preview panel was showing the "Dev server was running" restart banner instead of auto-starting. The `restored-stopped` status (written by the last-session manifest) was being unconditionally blocked from auto-ensure by a guard added for #9094 — that guard exists to stop silent respawns on app launch, but it was too broad.

The fix distinguishes cold app launch from live mid-session activation using the existing `PROJECT_ON_SWITCH` provenance signal. `lastSwitchId` (`string | null`) is added to `projectStore` — `null` at launch, set to the switchId UUID when `onSwitch` fires. The guard in `useDevServer` tightens from `if (status === "restored-stopped") return` to `if (status === "restored-stopped" && lastSwitchId === null) return`.

During review, a second gap surfaced: the production multi-view path (`activateProjectView` in `ProjectViewManager`) and the menu open-directory path (`menu.ts`) never emitted `PROJECT_ON_SWITCH` at all — only the legacy single-renderer `ProjectSwitchService` did. Both now send a targeted `webContents.send(PROJECT_ON_SWITCH, { project, switchId })` to the activated view only, so LRU-cached views for other projects aren't falsely flagged.

#9094 contract is intact: a dev server running when Daintree quit does not auto-restart on app launch (`lastSwitchId` stays `null`); it only auto-starts on the first live switch or open of that project within a session.

Resolves #9859

## Changes

- `src/store/projectStore.ts` — adds `lastSwitchId: string | null`, wired via `onSwitch` IPC subscription; never persisted or hydrated from storage
- `src/hooks/useDevServer.ts` — tightens the `restored-stopped` guard to also check `lastSwitchId === null`
- `electron/ipc/handlers/projectCrud/switch.ts` — emits `PROJECT_ON_SWITCH` from the `activateProjectView` path
- `electron/menu.ts` — emits `PROJECT_ON_SWITCH` from the open-directory menu path

## Testing

- Handler tests: `switch` and `reopen` paths emit a non-empty `switchId`, fresh UUID per activation
- Store tests: `onSwitch` wiring records `lastSwitchId`, ignores non-string values, never hydrates from storage
- Hook tests: mid-session auto-start fires, live `null`→string transition triggers auto-ensure, cold-launch path is a no-op
- Full suite: 31,165 tests passing; typecheck, lint, format, build all clean