### PR TITLE
fix(layout): clear overflowClipMargin when sidebar is fully hidden

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -108,6 +108,54 @@ export function AppLayout({
   const showAssistant = !layout.gestureAssistantHidden && layout.helpPanelOpen;
   const effectiveAssistantWidth = showAssistant ? layout.helpPanelWidth : 0;
 
+  // Issue #9864: the sidebar wrapper carries overflowClipMargin: 6px so the
+  // resize handle's overhang paints outside the contain boundary. But
+  // overflow-clip-margin is a discrete (non-animatable) property — when the
+  // wrapper width animates to 0 on hide, the clip edge stays 6px out and the
+  // full-width inner content bleeds a 6px strip at the left edge. Track when
+  // the sidebar is *fully* hidden (after the collapse animation) and only then
+  // zero the clip margin, so the handle overhang survives the whole animation
+  // while no strip remains at rest. Initialize from !showSidebar to avoid a
+  // 6px flash on startup when the app boots with the sidebar hidden.
+  const [sidebarFullyHidden, setSidebarFullyHidden] = useState(() => !showSidebar);
+
+  useEffect(() => {
+    if (showSidebar) {
+      // Restore the clip margin immediately on show so the resize handle
+      // overhang is live before/throughout the reveal animation.
+      setSidebarFullyHidden(false);
+      return;
+    }
+    // Hiding: when no width transition will actually run, transitionend never
+    // fires, so flush synchronously. Transitions are suppressed by the in-app
+    // reduceAnimations toggle, an active drag-resize, or OS-level reduced
+    // motion (the motion-reduce:transition-none variant on the wrapper).
+    const prefersReducedMotion =
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (reduceAnimations || isSidebarResizing || prefersReducedMotion) {
+      setSidebarFullyHidden(true);
+    }
+  }, [showSidebar, reduceAnimations, isSidebarResizing]);
+
+  const handleSidebarTransitionEnd = useCallback(
+    (event: React.TransitionEvent<HTMLDivElement>) => {
+      // Only the wrapper's own width transition marks the end of the collapse.
+      // Filter on propertyName to ignore other transitioned properties and on
+      // target === currentTarget to ignore bubbled child transitions. Re-check
+      // visibility so a stale transitionend from a hide that was reversed
+      // mid-animation (hide then show) doesn't clip the now-visible sidebar.
+      if (
+        event.propertyName === "width" &&
+        event.target === event.currentTarget &&
+        !showSidebar
+      ) {
+        setSidebarFullyHidden(true);
+      }
+    },
+    [showSidebar]
+  );
+
   useEffect(() => {
     if (layout.performanceMode) {
       document.body.setAttribute("data-performance-mode", "true");
@@ -530,9 +578,10 @@ export function AppLayout({
                 "transition-[width] duration-[var(--duration-250)] ease-[var(--ease-out-expo)] motion-reduce:transition-none",
               !showSidebar && "pointer-events-none"
             )}
+            onTransitionEnd={handleSidebarTransitionEnd}
             style={{
               width: effectiveSidebarWidth,
-              overflowClipMargin: "6px",
+              overflowClipMargin: sidebarFullyHidden ? "0px" : "6px", // #9864
               contain: "layout paint",
               // The contain boundary makes this wrapper a stacking context, so
               // the resize handle's 6px overhang (-right-1.5, z-50) would fall

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -134,12 +134,7 @@ export function AppLayout({
     const prefersReducedMotion =
       typeof window !== "undefined" &&
       window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-    if (
-      reduceAnimations ||
-      isSidebarResizing ||
-      prefersReducedMotion ||
-      layout.performanceMode
-    ) {
+    if (reduceAnimations || isSidebarResizing || prefersReducedMotion || layout.performanceMode) {
       setSidebarFullyHidden(true);
     }
   }, [showSidebar, reduceAnimations, isSidebarResizing, layout.performanceMode]);
@@ -151,11 +146,7 @@ export function AppLayout({
       // target === currentTarget to ignore bubbled child transitions. Re-check
       // visibility so a stale transitionend from a hide that was reversed
       // mid-animation (hide then show) doesn't clip the now-visible sidebar.
-      if (
-        event.propertyName === "width" &&
-        event.target === event.currentTarget &&
-        !showSidebar
-      ) {
+      if (event.propertyName === "width" && event.target === event.currentTarget && !showSidebar) {
         setSidebarFullyHidden(true);
       }
     },

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -127,16 +127,22 @@ export function AppLayout({
       return;
     }
     // Hiding: when no width transition will actually run, transitionend never
-    // fires, so flush synchronously. Transitions are suppressed by the in-app
-    // reduceAnimations toggle, an active drag-resize, or OS-level reduced
-    // motion (the motion-reduce:transition-none variant on the wrapper).
+    // fires, so flush directly. The width transition is suppressed by the
+    // in-app reduceAnimations toggle, an active drag-resize, OS-level reduced
+    // motion (the motion-reduce:transition-none variant), or performance mode
+    // (data-performance-mode narrows transition-property to exclude width).
     const prefersReducedMotion =
       typeof window !== "undefined" &&
       window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-    if (reduceAnimations || isSidebarResizing || prefersReducedMotion) {
+    if (
+      reduceAnimations ||
+      isSidebarResizing ||
+      prefersReducedMotion ||
+      layout.performanceMode
+    ) {
       setSidebarFullyHidden(true);
     }
-  }, [showSidebar, reduceAnimations, isSidebarResizing]);
+  }, [showSidebar, reduceAnimations, isSidebarResizing, layout.performanceMode]);
 
   const handleSidebarTransitionEnd = useCallback(
     (event: React.TransitionEvent<HTMLDivElement>) => {

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -390,9 +390,17 @@ describe("AppLayout sidebar clip-margin state machine — issue #9864", () => {
     // else the 6px strip persists for reduced-motion users until re-show.
     expect(source).toMatch(/window\.matchMedia\("\(prefers-reduced-motion: reduce\)"\)/);
     expect(source).toMatch(
-      /reduceAnimations \|\| isSidebarResizing \|\| prefersReducedMotion[\s\S]{0,80}setSidebarFullyHidden\(true\)/
+      /reduceAnimations \|\|\s*isSidebarResizing \|\|\s*prefersReducedMotion \|\|\s*layout\.performanceMode[\s\S]{0,80}setSidebarFullyHidden\(true\)/
     );
-    // The guard effect must depend on all three inputs that gate the transition.
-    expect(source).toMatch(/\[showSidebar, reduceAnimations, isSidebarResizing\]/);
+  });
+
+  it("includes performanceMode in the synchronous-flush guard and its deps", () => {
+    // data-performance-mode narrows transition-property to exclude width
+    // (src/index.css), so the width transitionend never fires. Without this the
+    // 6px strip persists in performance mode — the original #9864 regression.
+    expect(source).toMatch(/\|\|\s*layout\.performanceMode/);
+    expect(source).toMatch(
+      /\[showSidebar, reduceAnimations, isSidebarResizing, layout\.performanceMode\]/
+    );
   });
 });

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -324,15 +324,75 @@ describe("AppLayout CSS layout containment — issue #9014", () => {
 
   it("preserves the sidebar wrapper's overflow-clip-margin alongside containment", () => {
     // `contain: paint` converts overflow:visible to overflow:clip at used-value
-    // time and honors overflow-clip-margin per spec — the existing 6px margin
-    // must stay intact so the sidebar's edge decorations aren't clipped tight.
-    expect(source).toContain('overflowClipMargin: "6px"');
+    // time and honors overflow-clip-margin per spec — the 6px margin must stay
+    // intact (while visible/animating) so the sidebar's resize-handle overhang
+    // isn't clipped tight. Issue #9864 made it a ternary that drops to 0px once
+    // fully hidden, so the margin literal now lives in the ternary, adjacent to
+    // the containment declaration.
+    expect(source).toContain('"0px" : "6px"');
     expect(source).toMatch(
-      /overflowClipMargin:\s*"6px",[\s\S]{0,40}contain:\s*"layout paint"|contain:\s*"layout paint",[\s\S]{0,40}overflowClipMargin:\s*"6px"/
+      /overflowClipMargin:\s*sidebarFullyHidden \? "0px" : "6px",[\s\S]{0,200}contain:\s*"layout paint"/
     );
   });
 
   it("applies contain: layout paint to the resizable assistant wrapper", () => {
     expect(source).toMatch(/width:\s*effectiveAssistantWidth,\s*contain:\s*"layout paint"/);
+  });
+});
+
+describe("AppLayout sidebar clip-margin state machine — issue #9864", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(APP_LAYOUT_PATH, "utf-8");
+  });
+
+  it("initializes sidebarFullyHidden from !showSidebar so no 6px strip flashes on startup", () => {
+    // overflow-clip-margin is discrete, so a wrong initial value paints a 6px
+    // strip on the first frame when the app boots with the sidebar hidden.
+    expect(source).toContain(
+      "const [sidebarFullyHidden, setSidebarFullyHidden] = useState(() => !showSidebar)"
+    );
+  });
+
+  it("drives the wrapper's overflowClipMargin from sidebarFullyHidden, not a static literal", () => {
+    expect(source).toContain('overflowClipMargin: sidebarFullyHidden ? "0px" : "6px"');
+    // The old unconditional 6px must not linger — that was the bug.
+    expect(source).not.toMatch(/overflowClipMargin:\s*"6px",/);
+  });
+
+  it("clears sidebarFullyHidden immediately on show so the handle overhang precedes the reveal", () => {
+    // The clip margin must be restored before the open animation, not after it,
+    // otherwise the resize handle is clipped off during the reveal.
+    expect(source).toMatch(
+      /if \(showSidebar\)\s*\{\s*\n[\s\S]{0,200}setSidebarFullyHidden\(false\)/
+    );
+  });
+
+  it("zeroes the clip margin only after the width transition ends, filtered to the wrapper's own width", () => {
+    // overflow-clip-margin is discrete — zeroing it at transition start would
+    // snap the handle off mid-slide. onTransitionEnd is the canonical
+    // completion signal (past lessons #4170/#6982/#7826). It must filter on
+    // propertyName === "width" and target === currentTarget to ignore bubbled
+    // child transitions, and re-check !showSidebar to ignore a reversed hide.
+    expect(source).toContain("onTransitionEnd={handleSidebarTransitionEnd}");
+    expect(source).toMatch(/event\.propertyName === "width"/);
+    expect(source).toMatch(/event\.target === event\.currentTarget/);
+    expect(source).toMatch(
+      /handleSidebarTransitionEnd = useCallback\([\s\S]{0,700}!showSidebar[\s\S]{0,120}setSidebarFullyHidden\(true\)/
+    );
+  });
+
+  it("flushes sidebarFullyHidden synchronously when no transition will fire transitionend", () => {
+    // With reduceAnimations, an active drag-resize, or OS-level reduced motion
+    // (motion-reduce:transition-none), the width transition never runs, so
+    // transitionend never fires. The hide path must flush the state directly,
+    // else the 6px strip persists for reduced-motion users until re-show.
+    expect(source).toMatch(/window\.matchMedia\("\(prefers-reduced-motion: reduce\)"\)/);
+    expect(source).toMatch(
+      /reduceAnimations \|\| isSidebarResizing \|\| prefersReducedMotion[\s\S]{0,80}setSidebarFullyHidden\(true\)/
+    );
+    // The guard effect must depend on all three inputs that gate the transition.
+    expect(source).toMatch(/\[showSidebar, reduceAnimations, isSidebarResizing\]/);
   });
 });


### PR DESCRIPTION
## Summary

The sidebar wrapper in `src/components/Layout/AppLayout.tsx` sets `overflowClipMargin: "6px"` so the resize handle's overhang can paint outside the `overflow: clip` boundary. The problem is that `overflow-clip-margin` is not animatable — when the wrapper width transitions to 0 on hide, the clip edge stays 6px out and the always-full-width inner content bleeds a 6px strip at the left edge.

Fix adds a `sidebarFullyHidden` boolean state (initialised from `!showSidebar`). While the sidebar is visible or animating, `overflowClipMargin` stays at 6px. Once the collapse transition ends, an `onTransitionEnd` handler — filtered to `propertyName === "width"`, `target === currentTarget`, and `!showSidebar` — zeros it out.

For cases where no width transition fires (`reduceAnimations`, active drag-resize, `prefers-reduced-motion`, or performance mode narrowing `transition-property` to exclude `width`), the state is flushed synchronously so nothing relies on `transitionend`.

Resolves #9864

## Changes

- `src/components/Layout/AppLayout.tsx` — add `sidebarFullyHidden` state; wire `onTransitionEnd` on the sidebar wrapper; synchronous-flush guard for animation-disabled paths
- `src/components/Layout/__tests__/AppLayout.sidebar.test.ts` — update existing `#9014` clip-margin test for the new ternary form; add `#9864` describe suite (6 source-scan tests: init, show-clear, `transitionend` filtering, synchronous-flush guard including performance mode)

## Testing

35 tests pass in `AppLayout.sidebar.test.ts`. `npm run check` fully green (typecheck, lint, format, all codegen guards).