### PR TITLE
fix(theme): use border ink for Arashiyama stats-pill dividers

### DIFF
--- a/shared/theme/__tests__/builtInThemes.test.ts
+++ b/shared/theme/__tests__/builtInThemes.test.ts
@@ -443,6 +443,7 @@ describe("built-in themes", () => {
       // toolbar-stats-bg fill tint instead, leaving the seams invisible (#10029).
       const toolbarDivider = extensions["toolbar-divider"];
       const statsDivider = extensions["toolbar-stats-divider"];
+      const statsBg = extensions["toolbar-stats-bg"];
       if (
         toolbarDivider !== undefined &&
         statsDivider !== undefined &&
@@ -451,6 +452,19 @@ describe("built-in themes", () => {
         failures.push(
           `${source.id} toolbar-stats-divider ("${statsDivider}") must equal toolbar-divider ` +
             `("${toolbarDivider}"); the stats pill uses the toolbar's separator ink (#10029)`
+        );
+      }
+      if (statsDivider !== undefined && statsDivider === statsBg) {
+        failures.push(
+          `${source.id} toolbar-stats-divider ("${statsDivider}") matches the toolbar-stats-bg ` +
+            `fill tint; the seams would be invisible against the pill fill (#10029)`
+        );
+      }
+      if (statsBg !== undefined && statsDivider === undefined) {
+        failures.push(
+          `${source.id} styles the stats pill (toolbar-stats-bg) without toolbar-stats-divider; ` +
+            `the seams would fall back to --theme-border-subtle instead of the toolbar's ` +
+            `separator ink (#10029)`
         );
       }
 

--- a/shared/theme/__tests__/builtInThemes.test.ts
+++ b/shared/theme/__tests__/builtInThemes.test.ts
@@ -437,6 +437,23 @@ describe("built-in themes", () => {
         }
       }
 
+      // Cross-key invariant: toolbar-stats-divider must match toolbar-divider —
+      // the stats pill's inter-segment seams use the same separator ink as the
+      // rest of the toolbar chrome. Arashiyama drifted by copy-pasting the
+      // toolbar-stats-bg fill tint instead, leaving the seams invisible (#10029).
+      const toolbarDivider = extensions["toolbar-divider"];
+      const statsDivider = extensions["toolbar-stats-divider"];
+      if (
+        toolbarDivider !== undefined &&
+        statsDivider !== undefined &&
+        statsDivider !== toolbarDivider
+      ) {
+        failures.push(
+          `${source.id} toolbar-stats-divider ("${statsDivider}") must equal toolbar-divider ` +
+            `("${toolbarDivider}"); the stats pill uses the toolbar's separator ink (#10029)`
+        );
+      }
+
       // Extra-key regression: no built-in source ships an unregistered extension
       // key. TypeScript enforces this at compile time, but a runtime check
       // catches `as unknown as` casts and ad-hoc fixture mutations.

--- a/shared/theme/builtInThemes/arashiyama.ts
+++ b/shared/theme/builtInThemes/arashiyama.ts
@@ -126,7 +126,7 @@ export const theme: BuiltInThemeSource = {
     "toolbar-project-shadow": "none",
     "toolbar-stats-bg": "rgba(241,235,228,0.05)",
     "toolbar-stats-border": "rgba(67,58,50,0.5)",
-    "toolbar-stats-divider": "rgba(241,235,228,0.05)",
+    "toolbar-stats-divider": "rgba(67,58,50,0.5)",
     "toolbar-stats-hover-bg": "rgba(241,235,228,0.08)",
     "worktree-section-hover-bg": "rgba(241,235,228,0.05)",
   },


### PR DESCRIPTION
## Summary

- `toolbar-stats-divider` in `arashiyama.ts` was set to `rgba(241,235,228,0.05)` — identical to `toolbar-stats-bg` — making the dividers between GitHub stats pill segments invisible against the pill fill.
- Corrected to `rgba(67,58,50,0.5)`, the border ink value used by every other toolbar divider in the theme (`toolbar-divider`, `toolbar-project-border`, `toolbar-stats-border`) and by all other dark built-in themes.
- Added three governance checks to `shared/theme/__tests__/builtInThemes.test.ts`: `toolbar-stats-divider` must equal `toolbar-divider` when both are present; must not equal the `toolbar-stats-bg` fill tint; and any theme defining `toolbar-stats-bg` must also define `toolbar-stats-divider`.

Resolves #10029

## Changes

- `shared/theme/builtInThemes/arashiyama.ts` — one-token fix
- `shared/theme/__tests__/builtInThemes.test.ts` — three new governance assertions in the extension-tier `it.each` block

## Testing

- 53 theme tests pass cleanly.
- Ran a negative-case check with the pre-fix value — produced exactly the expected governance failure, naming `arashiyama` and both values.
- `npm run check` fully clean (lint warning count down 6 from baseline).
- No component or renderer changes; frozen light-theme calibration untouched.