### PR TITLE
fix(settings): render project settings chrome immediately during load

### DIFF
--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -62,6 +62,8 @@ import {
   type ProjectSettingsFormContext,
 } from "@/hooks/useProjectSettingsForm";
 import { useFlushOnHide } from "@/hooks/useFlushOnHide";
+import { useDohertyGate } from "@/hooks/useDeferredLoading";
+import { SettingsLoadErrorBanner } from "./SettingsLoadErrorBanner";
 import {
   SettingsValidationProvider,
   SettingsValidationContext,
@@ -346,6 +348,7 @@ function SettingsDialogInner({
   ]);
 
   const projectForm = useProjectSettingsForm({ projectId: projectId ?? null, isOpen });
+  const showProjectLoading = useDohertyGate(projectForm.projectIsLoading);
   const projectLabel =
     projectForm.currentProject?.name ?? projectForm.currentProject?.id ?? "project";
 
@@ -796,18 +799,14 @@ function SettingsDialogInner({
                 {/* Project settings panels */}
                 {activeScope === "project" && projectId && (
                   <>
-                    {projectForm.projectIsLoading && (
-                      <div className="text-sm text-daintree-text/60 text-center py-8">
-                        Loading settings...
-                      </div>
-                    )}
                     {projectForm.projectError && (
-                      <div
-                        className="text-sm text-status-error bg-status-error/10 border border-status-error/20 rounded p-3 mb-4"
-                        role="alert"
-                      >
-                        Failed to load settings: {projectForm.projectError}
-                      </div>
+                      <SettingsLoadErrorBanner
+                        message={`Failed to load settings: ${projectForm.projectError}`}
+                        onRetry={projectForm.refreshProjectSettings}
+                      />
+                    )}
+                    {showProjectLoading && (
+                      <p className="text-sm text-daintree-text/60 py-2">Loading settings…</p>
                     )}
                     {projectForm.projectAutoSaveError && (
                       <div
@@ -817,39 +816,37 @@ function SettingsDialogInner({
                         {projectForm.projectAutoSaveError}
                       </div>
                     )}
-                    {!projectForm.projectIsLoading &&
-                      !projectForm.projectError &&
-                      SETTINGS_REGISTRY.filter((e) => e.scope === "project").map((entry) => {
-                        const tabId = entry.id as SettingsTab;
-                        const isActive = activeTab === tabId;
-                        return (
-                          <div
-                            key={entry.id}
-                            role="tabpanel"
-                            id={`settings-panel-${entry.id}`}
-                            aria-labelledby={`settings-tab-${entry.id}`}
-                            tabIndex={0}
-                            className={isActive ? "" : "hidden"}
-                          >
-                            {visitedTabs.has(tabId) && (
-                              <Suspense fallback={null}>
-                                <ProjectFormTabContent
-                                  entry={entry as LazySettingsTabEntry}
-                                  projectForm={projectForm}
-                                  projectId={projectId}
-                                  isOpen={isOpen}
-                                  globalEnvVars={globalEnvVars}
-                                  globalScrollbackLines={scrollbackLines}
-                                  projectLabel={projectLabel}
-                                  isActive={isActive && !isSearching}
-                                  scrollToSectionId={scrollToSection}
-                                  onScrollToSectionHandled={handleScrollToSectionHandled}
-                                />
-                              </Suspense>
-                            )}
-                          </div>
-                        );
-                      })}
+                    {SETTINGS_REGISTRY.filter((e) => e.scope === "project").map((entry) => {
+                      const tabId = entry.id as SettingsTab;
+                      const isActive = activeTab === tabId;
+                      return (
+                        <div
+                          key={entry.id}
+                          role="tabpanel"
+                          id={`settings-panel-${entry.id}`}
+                          aria-labelledby={`settings-tab-${entry.id}`}
+                          tabIndex={0}
+                          className={isActive ? "" : "hidden"}
+                        >
+                          {visitedTabs.has(tabId) && (
+                            <Suspense fallback={null}>
+                              <ProjectFormTabContent
+                                entry={entry as LazySettingsTabEntry}
+                                projectForm={projectForm}
+                                projectId={projectId}
+                                isOpen={isOpen}
+                                globalEnvVars={globalEnvVars}
+                                globalScrollbackLines={scrollbackLines}
+                                projectLabel={projectLabel}
+                                isActive={isActive && !isSearching}
+                                scrollToSectionId={scrollToSection}
+                                onScrollToSectionHandled={handleScrollToSectionHandled}
+                              />
+                            </Suspense>
+                          )}
+                        </div>
+                      );
+                    })}
                   </>
                 )}
               </>

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -806,7 +806,9 @@ function SettingsDialogInner({
                       />
                     )}
                     {showProjectLoading && (
-                      <p className="text-sm text-daintree-text/60 py-2">Loading settings…</p>
+                      <p className="text-sm text-daintree-text/60 py-2" aria-live="polite">
+                        Loading settings…
+                      </p>
                     )}
                     {projectForm.projectAutoSaveError && (
                       <div

--- a/src/hooks/__tests__/useProjectSettingsForm.test.tsx
+++ b/src/hooks/__tests__/useProjectSettingsForm.test.tsx
@@ -11,9 +11,11 @@ const {
   mockDisableInRepoSettings,
   mockProjects,
   mockIsLoading,
+  mockRefresh,
 } = vi.hoisted(() => ({
   mockSettings: { value: null as ProjectSettings | null },
   mockSaveSettings: vi.fn().mockResolvedValue(undefined),
+  mockRefresh: vi.fn().mockResolvedValue(undefined),
   mockUpdateProject: vi.fn().mockResolvedValue(undefined),
   mockEnableInRepoSettings: vi.fn(),
   mockDisableInRepoSettings: vi.fn(),
@@ -37,6 +39,7 @@ vi.mock("@/hooks/useProjectSettings", () => ({
     saveSettings: mockSaveSettings,
     isLoading: mockIsLoading.value,
     error: null,
+    refresh: mockRefresh,
   }),
 }));
 
@@ -341,6 +344,20 @@ describe("useProjectSettingsForm", () => {
     expect(typeof result.current.enableInRepoSettings).toBe("function");
     expect(typeof result.current.disableInRepoSettings).toBe("function");
     expect(typeof result.current.flush).toBe("function");
+    expect(typeof result.current.refreshProjectSettings).toBe("function");
+  });
+
+  it("exposes refreshProjectSettings that delegates to useProjectSettings.refresh", async () => {
+    const { result } = renderOpenForm("proj-1");
+    await waitFor(() => {
+      expect(result.current.projectIsInitialized).toBe(true);
+    });
+
+    expect(mockRefresh).not.toHaveBeenCalled();
+    await act(async () => {
+      await result.current.refreshProjectSettings();
+    });
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
   });
 
   it("initializes correctly when settings are already loaded at dialog open", async () => {

--- a/src/hooks/__tests__/useProjectSettingsForm.test.tsx
+++ b/src/hooks/__tests__/useProjectSettingsForm.test.tsx
@@ -347,6 +347,20 @@ describe("useProjectSettingsForm", () => {
     expect(typeof result.current.refreshProjectSettings).toBe("function");
   });
 
+  it("stays uninitialized while loading with no settings yet (backs the Doherty loader)", async () => {
+    mockIsLoading.value = true;
+    mockSettings.value = null;
+    const { result, rerender } = renderHook(
+      ({ isOpen, projectId }: FormProps) => useProjectSettingsForm({ projectId, isOpen }),
+      { initialProps: { isOpen: false, tick: 0, projectId: "proj-1" } }
+    );
+    rerender({ isOpen: true, tick: 1, projectId: "proj-1" });
+
+    expect(result.current.projectIsLoading).toBe(true);
+    expect(result.current.projectIsInitialized).toBe(false);
+    expect(mockSaveSettings).not.toHaveBeenCalled();
+  });
+
   it("exposes refreshProjectSettings that delegates to useProjectSettings.refresh", async () => {
     const { result } = renderOpenForm("proj-1");
     await waitFor(() => {

--- a/src/hooks/useProjectSettingsForm.ts
+++ b/src/hooks/useProjectSettingsForm.ts
@@ -34,6 +34,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     saveSettings: saveProjectSettings,
     isLoading: projectIsLoading,
     error: projectError,
+    refresh: refreshProjectSettings,
   } = useProjectSettings(projectId ?? "");
   const projects = useProjectStore((state) => state.projects);
   const updateProject = useProjectStore((state) => state.updateProject);
@@ -524,6 +525,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     projectSettings,
     projectIsLoading,
     projectError,
+    refreshProjectSettings,
     currentProject,
     enableInRepoSettings,
     disableInRepoSettings,


### PR DESCRIPTION
## Summary

The project settings tab in `SettingsDialog` withheld **all** section chrome (headers, labels, controls) behind a full-area `Loading settings...` placeholder until the IPC settings read resolved. This violates the CLAUDE.md design rule that settings tabs must render section chrome immediately from safe defaults and populate when the bridge call resolves — never a full-area spinner/placeholder.

## Changes

- Always render the project tab panels from the form hook's safe defaults (still gated by `visitedTabs` + `Suspense fallback={null}` as before); removed the `!projectIsLoading && !projectError` gate and the full-area `Loading settings...` div.
- Replaced the full-area placeholder with a 400ms Doherty-gated inline `Loading settings…` text (`useDohertyGate`), with `aria-live="polite"` so screen readers announce it.
- Swapped the raw error `<div>` for the existing `SettingsLoadErrorBanner`, wired to a `Retry` that refreshes project settings.
- Threaded `refresh` from `useProjectSettings` through `useProjectSettingsForm` as `refreshProjectSettings` to back the retry.
- Preserved the separate `projectAutoSaveError` block unchanged.

## Testing

- `npx vitest run src/hooks/__tests__/useProjectSettingsForm.test.tsx` → PASS (23 tests), including new coverage for `refreshProjectSettings` delegation and the loading-not-initialized state.
- `npm run check` → PASS (typecheck, lint ratchet, format, IPC/channel/confirm-wiring guards all clean).

Closes #10045