### PR TITLE
fix(terminal): restore data-loss markers after hibernate/wake (#9907)

### DIFF
--- a/src/services/terminal/TerminalHibernationManager.ts
+++ b/src/services/terminal/TerminalHibernationManager.ts
@@ -18,6 +18,13 @@ export interface HibernationManagerDeps extends TerminalListenerInstallDeps {
   clearResizeJob: (managed: ManagedTerminal) => void;
   clearSettledTimer: (id: string) => void;
   applyDeferredResize: (id: string) => void;
+  /**
+   * Draws the "Output dropped" marker for a PTY data-loss signal. Required (not
+   * optional) so the wake path can never silently diverge from `getOrCreate()`
+   * and drop the OSC 57301 callback again (#9907) — the omission becomes a
+   * compile error instead.
+   */
+  drawDataLossMarker: (id: string, droppedBytes: number) => void;
   onHibernationChanged: (id: string) => void;
   /**
    * Builds the deferred Image/file-link/web-link addons on the fresh post-wake
@@ -175,10 +182,19 @@ export class TerminalHibernationManager {
     const hostElement = managed.hostElement;
     hostElement.replaceChildren();
 
-    // Re-create parser handler
-    managed.parserHandler = new TerminalParserHandler(managed, () => {
-      this.deps.applyDeferredResize(id);
-    });
+    // Re-create parser handler — mirror `getOrCreate()` exactly, including the
+    // data-loss callback, so woken terminals keep rendering the "Output
+    // dropped" marker (#9907). `id` is the live key, never a captured managed
+    // ref — `drawDataLossMarker` does its own `instances.get(id)` lookup.
+    managed.parserHandler = new TerminalParserHandler(
+      managed,
+      () => {
+        this.deps.applyDeferredResize(id);
+      },
+      (droppedBytes) => {
+        this.deps.drawDataLossMarker(id, droppedBytes);
+      }
+    );
 
     // Re-register terminal-bound listeners via the canonical installer so the
     // wake path stays in lockstep with `getOrCreate()`. IPC listeners

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -171,6 +171,7 @@ class TerminalInstanceService {
       clearResizeJob: (managed) => this.resizeController.clearResizeJob(managed),
       clearSettledTimer: (id) => this.resizeController.clearSettledTimer(id),
       applyDeferredResize: (id) => this.resizeController.applyDeferredResize(id),
+      drawDataLossMarker: (id, droppedBytes) => this.drawDataLossMarker(id, droppedBytes),
       ensureDeferredAddons: (id) => {
         const managed = this.instances.get(id);
         if (managed) this.ensureDeferredAddons(id, managed);

--- a/src/services/terminal/__tests__/TerminalHibernationManager.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.adversarial.test.ts
@@ -175,6 +175,7 @@ function makeMockDeps(managed?: ManagedTerminal): HibernationManagerDeps {
     clearResizeJob: vi.fn(),
     clearSettledTimer: vi.fn(),
     applyDeferredResize: vi.fn(),
+    drawDataLossMarker: vi.fn(),
     ensureDeferredAddons: vi.fn(),
     onHibernationChanged: vi.fn(),
     getIsBackgrounded: vi.fn(() => false),

--- a/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
@@ -157,6 +157,7 @@ function makeMockDeps(managed?: ManagedTerminal): HibernationManagerDeps {
     clearResizeJob: vi.fn(),
     clearSettledTimer: vi.fn(),
     applyDeferredResize: vi.fn(),
+    drawDataLossMarker: vi.fn(),
     ensureDeferredAddons: vi.fn(),
     onHibernationChanged: vi.fn(),
     getIsBackgrounded: vi.fn(() => false),

--- a/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
@@ -52,10 +52,21 @@ vi.mock("../TerminalAddonManager", () => ({
   })),
 }));
 
+// Captures the onDataLoss (3rd) constructor arg of the most recently
+// constructed parser handler so tests can assert the wake path re-wires it
+// (#9907).
+let lastParserOnDataLoss: ((droppedBytes: number) => void) | undefined;
+
 vi.mock("../TerminalParserHandler", () => ({
   TerminalParserHandler: class {
     dispose = vi.fn();
-    constructor(_managed: unknown, _onResize: () => void) {}
+    constructor(
+      _managed: unknown,
+      _onResize: () => void,
+      onDataLoss?: (droppedBytes: number) => void
+    ) {
+      lastParserOnDataLoss = onDataLoss;
+    }
   },
 }));
 
@@ -461,6 +472,18 @@ describe("TerminalHibernationManager", () => {
       callback!();
 
       expect(onWriteParsedReflow).toHaveBeenCalledWith(managed);
+    });
+
+    it("re-wires the data-loss callback to deps.drawDataLossMarker (#9907)", () => {
+      lastParserOnDataLoss = undefined;
+      manager.unhibernate("t1");
+
+      // The wake path must pass the onDataLoss callback as the 3rd parser
+      // arg, mirroring getOrCreate(); without it, post-wake data-loss
+      // markers stop rendering.
+      expect(lastParserOnDataLoss).toBeTypeOf("function");
+      lastParserOnDataLoss!(512);
+      expect(deps.drawDataLossMarker).toHaveBeenCalledWith("t1", 512);
     });
 
     it("should reset lastReflowAt so next reflow fires immediately", () => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.dataLoss.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.dataLoss.test.ts
@@ -138,6 +138,23 @@ describe("injectDataLossMarker", () => {
     expect(text).not.toContain("57301");
   });
 
+  it("keeps rendering the marker across repeated hibernate/wake cycles (#9907)", async () => {
+    createManagedTerminal("dl-cycles");
+    terminalInstanceService.hibernate("dl-cycles");
+    terminalInstanceService.unhibernate("dl-cycles");
+    terminalInstanceService.hibernate("dl-cycles");
+    terminalInstanceService.unhibernate("dl-cycles");
+
+    terminalInstanceService.injectDataLossMarker("dl-cycles", 512);
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+    // Each cycle disposes the old parser handler and re-registers a fresh
+    // one; the callback must survive every wake, not just the first.
+    const text = terminalInstanceService.captureBufferText("dl-cycles");
+    expect(text).toContain("Output dropped (~512 bytes)");
+  });
+
   it("uses a generic label when the dropped byte count is zero", async () => {
     createManagedTerminal("dl-4");
     terminalInstanceService.injectDataLossMarker("dl-4", 0);

--- a/src/services/terminal/__tests__/TerminalInstanceService.dataLoss.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.dataLoss.test.ts
@@ -121,6 +121,23 @@ describe("injectDataLossMarker", () => {
     expect(text).not.toContain("57301");
   });
 
+  it("still renders the marker after a hibernate/wake cycle (#9907)", async () => {
+    createManagedTerminal("dl-wake");
+    terminalInstanceService.hibernate("dl-wake");
+    terminalInstanceService.unhibernate("dl-wake");
+
+    terminalInstanceService.injectDataLossMarker("dl-wake", 512);
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+    // Regression guard: the wake path used to recreate the parser handler
+    // without the onDataLoss callback, so the OSC 57301 signal was silently
+    // consumed and no marker rendered post-wake.
+    const text = terminalInstanceService.captureBufferText("dl-wake");
+    expect(text).toContain("Output dropped (~512 bytes)");
+    expect(text).not.toContain("57301");
+  });
+
   it("uses a generic label when the dropped byte count is zero", async () => {
     createManagedTerminal("dl-4");
     terminalInstanceService.injectDataLossMarker("dl-4", 0);


### PR DESCRIPTION
## Summary

Fixes #9907 — after a terminal hibernates and wakes, the yellow "Output dropped" data-loss marker silently stopped rendering for the rest of that terminal's life.

**Root cause:** `TerminalHibernationManager.unhibernate()` recreated the `TerminalParserHandler` but omitted the `onDataLoss` callback (the 3rd constructor arg) that `getOrCreate()` wires to `drawDataLossMarker`. Because the OSC 57301 handler always consumes the sequence and returns `true`, post-wake data-loss signals from the pty-host were swallowed with no visible marker — a textbook recurrence of the "wake path drifts from create path" antipattern (#6674).

## Fix

- Add a **required** `drawDataLossMarker` dep to `HibernationManagerDeps` so any future divergence between the create and wake paths becomes a TypeScript compile error rather than a silent regression (precedent #6674).
- Wire the closure in the `TerminalInstanceService` constructor deps object.
- Pass it as the 3rd `TerminalParserHandler` arg in `unhibernate()`, mirroring `getOrCreate()` exactly. The callback uses a live `id` lookup and never captures a stale `managed` ref (precedent #4850).
- `drawDataLossMarker` stays private on the service; the `queueMicrotask` + `isHibernated` re-check inside it is load-bearing and unchanged (#8375).

## Tests

- New regression test: marker still renders after a hibernate→wake cycle.
- New integration test: marker survives repeated hibernate/wake cycles.
- New unit test: `unhibernate()` re-wires the `onDataLoss` callback to `deps.drawDataLossMarker` (closes the unit-level blind spot the two hibernation-manager mocks left open).

72 tests pass across the 3 affected suites. `npm run check` is fully green (typecheck, lint ratchet −6 warnings, format, IPC/confirm-wiring guards).

Closes #9907

🤖 Generated with [Claude Code](https://claude.com/claude-code)