### PR TITLE
fix(file-viewer): surface real errors for SVG and image failures

### DIFF
--- a/src/components/FileViewer/FileViewerModal.tsx
+++ b/src/components/FileViewer/FileViewerModal.tsx
@@ -109,6 +109,8 @@ export function FileViewerModal({
   const [content, setContent] = useState<string | null>(null);
   const [loadState, setLoadState] = useState<LoadState>("loading");
   const [errorCode, setErrorCode] = useState<FileReadErrorCode | null>(null);
+  // Renderer-local failures (SVG sanitization, image decode) that have no FileReadErrorCode
+  const [displayErrorMessage, setDisplayErrorMessage] = useState<string | null>(null);
   const diffViewType = usePreferencesStore((s) => s.diffViewType);
   const setDiffViewType = usePreferencesStore((s) => s.setDiffViewType);
   const [diffCopied, setDiffCopied] = useState(false);
@@ -145,6 +147,7 @@ export function FileViewerModal({
       setContent(null);
       setLoadState("loading");
       setErrorCode(null);
+      setDisplayErrorMessage(null);
       setDiffCopied(false);
       setSanitizedSvg(null);
       requestRef.current++;
@@ -158,6 +161,7 @@ export function FileViewerModal({
     const requestId = ++requestRef.current;
     setLoadState("loading");
     setErrorCode(null);
+    setDisplayErrorMessage(null);
     hasSwitchedToDiffRef.current = false;
     currentHunkIndexRef.current = -1;
 
@@ -176,7 +180,7 @@ export function FileViewerModal({
             setSanitizedSvg(sanitized.svg);
             setLoadState("svg");
           } else {
-            setErrorCode("INVALID_PATH");
+            setDisplayErrorMessage(sanitized.error);
             setLoadState("error");
           }
         } else {
@@ -217,7 +221,7 @@ export function FileViewerModal({
   }, [filePath, initialLine, initialCol]);
 
   const handleImageError = useCallback(() => {
-    setErrorCode("NOT_FOUND");
+    setDisplayErrorMessage("Unable to display image");
     setLoadState("error");
   }, []);
 
@@ -684,9 +688,11 @@ export function FileViewerModal({
               </div>
             )}
 
-            {loadState === "error" && errorCode && (
+            {loadState === "error" && (displayErrorMessage || errorCode) && (
               <div className="flex flex-col items-center justify-center h-64 gap-3">
-                <p className="text-sm text-muted-foreground">{ERROR_MESSAGES[errorCode]}</p>
+                <p className="text-sm text-muted-foreground">
+                  {displayErrorMessage ?? (errorCode ? ERROR_MESSAGES[errorCode] : "")}
+                </p>
                 {imageFile ? (
                   <button
                     type="button"
@@ -694,7 +700,7 @@ export function FileViewerModal({
                     className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-daintree-text bg-daintree-border hover:bg-daintree-border/80 rounded transition-colors"
                   >
                     <ImageIcon className="w-3.5 h-3.5" />
-                    Open in Image Viewer
+                    Open in image viewer
                   </button>
                 ) : (
                   <button
@@ -703,7 +709,7 @@ export function FileViewerModal({
                     className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-daintree-text bg-daintree-border hover:bg-daintree-border/80 rounded transition-colors"
                   >
                     <ExternalLink className="w-3.5 h-3.5" />
-                    Open in Editor
+                    Open in editor
                   </button>
                 )}
               </div>

--- a/src/components/FileViewer/__tests__/FileViewerModal.test.tsx
+++ b/src/components/FileViewer/__tests__/FileViewerModal.test.tsx
@@ -144,12 +144,19 @@ vi.mock("@/services/ActionService", () => ({
   },
 }));
 
+const { mockSanitizeSvg } = vi.hoisted(() => ({
+  mockSanitizeSvg: vi.fn(
+    (
+      content: string
+    ): { ok: true; svg: string; modified: boolean } | { ok: false; error: string } => ({
+      ok: true,
+      svg: content,
+      modified: false,
+    })
+  ),
+}));
 vi.mock("@shared/utils/svgSanitizer", () => ({
-  sanitizeSvg: (content: string) => ({
-    ok: true,
-    svg: content,
-    modified: false,
-  }),
+  sanitizeSvg: mockSanitizeSvg,
 }));
 
 const scrollIntoViewCalls: HTMLElement[] = [];
@@ -245,6 +252,67 @@ describe("FileViewerModal", () => {
     expect(mockCreateTrustedHTML).toHaveBeenCalledWith(svg);
     expect(screen.getByLabelText("Open in image viewer")).toBeTruthy();
     expect(screen.queryByLabelText("Open in editor")).toBeNull();
+  });
+
+  it("shows the sanitizer's error message when SVG sanitization fails", async () => {
+    mockRead.mockResolvedValue({ content: "not an svg" });
+    mockSanitizeSvg.mockReturnValueOnce({
+      ok: false,
+      error: "Content does not appear to be a valid SVG",
+    });
+
+    render(<FileViewerModal {...defaultProps} filePath="/project/icon.svg" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Content does not appear to be a valid SVG")).toBeTruthy();
+    });
+
+    expect(screen.queryByText("Invalid file path")).toBeNull();
+    expect(screen.getAllByText("Open in image viewer").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Open in Image Viewer")).toBeNull();
+  });
+
+  it("shows a generic error when an image fails to load", async () => {
+    render(<FileViewerModal {...defaultProps} filePath="/project/photo.png" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("img")).toBeTruthy();
+    });
+
+    fireEvent.error(screen.getByRole("img"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Unable to display image")).toBeTruthy();
+    });
+
+    expect(screen.queryByText("File no longer exists")).toBeNull();
+  });
+
+  it("clears a stale SVG sanitization error when navigating to another file", async () => {
+    mockRead.mockResolvedValue({ content: "not an svg" });
+    mockSanitizeSvg.mockReturnValueOnce({
+      ok: false,
+      error: "Content does not appear to be a valid SVG",
+    });
+
+    const { rerender, container } = render(
+      <FileViewerModal {...defaultProps} filePath="/project/bad.svg" />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Content does not appear to be a valid SVG")).toBeTruthy();
+    });
+
+    mockRead.mockResolvedValue({
+      content: '<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>',
+    });
+
+    rerender(<FileViewerModal {...defaultProps} filePath="/project/good.svg" />);
+
+    await waitFor(() => {
+      expect(container.querySelector("svg")).toBeTruthy();
+    });
+    expect(screen.queryByText("Content does not appear to be a valid SVG")).toBeNull();
   });
 
   it("shows binary error with Open in Editor for non-image binaries", async () => {

--- a/src/components/FileViewer/__tests__/FileViewerModal.test.tsx
+++ b/src/components/FileViewer/__tests__/FileViewerModal.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent, within } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { forwardRef, type ReactNode } from "react";
 
@@ -268,7 +268,12 @@ describe("FileViewerModal", () => {
     });
 
     expect(screen.queryByText("Invalid file path")).toBeNull();
-    expect(screen.getAllByText("Open in image viewer").length).toBeGreaterThan(0);
+    const errorContainer = screen
+      .getByText("Content does not appear to be a valid SVG")
+      .closest("div")!;
+    expect(
+      within(errorContainer).getByRole("button", { name: "Open in image viewer" })
+    ).toBeTruthy();
     expect(screen.queryByText("Open in Image Viewer")).toBeNull();
   });
 
@@ -286,6 +291,24 @@ describe("FileViewerModal", () => {
     });
 
     expect(screen.queryByText("File no longer exists")).toBeNull();
+    const errorContainer = screen.getByText("Unable to display image").closest("div")!;
+    expect(
+      within(errorContainer).getByRole("button", { name: "Open in image viewer" })
+    ).toBeTruthy();
+  });
+
+  it("shows the file-read error message when reading an SVG fails", async () => {
+    mockRead.mockRejectedValue(
+      Object.assign(new Error("File not found"), { name: "AppError", code: "NOT_FOUND" })
+    );
+
+    render(<FileViewerModal {...defaultProps} filePath="/project/icon.svg" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("File no longer exists")).toBeTruthy();
+    });
+
+    expect(mockSanitizeSvg).not.toHaveBeenCalled();
   });
 
   it("clears a stale SVG sanitization error when navigating to another file", async () => {


### PR DESCRIPTION
## Summary

- SVG sanitization failures were showing "Invalid file path" (`INVALID_PATH`) instead of the sanitizer's own message — the sanitizer returns specific, actionable strings like "SVG is too large (0.30MB). Maximum size is 250KB." that were being silently dropped
- `handleImageError` was mapping every `<img>` load failure to `NOT_FOUND` ("File no longer exists"), even when the actual cause was a 413 response or decode error — replaced with a generic "Unable to display image"
- Error-state recovery buttons were using Title Case ("Open in Image Viewer", "Open in Editor") against the sentence-case rule; their `aria-label` and tooltip text were already correct

Resolves #10011

## Changes

- Added `displayErrorMessage` state to `FileViewerModal` that surfaces the sanitizer's own message on SVG failure and a neutral message on image error; `errorCode` no longer set for these cases
- Render guard relaxed from `errorCode &&` to `(displayErrorMessage || errorCode)` to cover failures that don't set `errorCode`
- `displayErrorMessage` cleared in both `loadFile()` reset paths so stale messages don't persist on navigation
- Button labels sentence-cased: "Open in image viewer" / "Open in editor"
- Converted `sanitizeSvg` mock to `vi.hoisted` `vi.fn`; added 4 new tests covering sanitize failure message, image error message, stale-error navigation, and SVG read-failure separation

## Testing

58/58 tests pass. Typecheck, lint, format, and build all green.