### PR TITLE
fix(hydration): preserve saved panels when backend terminal query fails

### DIFF
--- a/src/store/persistence/panelPersistence.ts
+++ b/src/store/persistence/panelPersistence.ts
@@ -371,6 +371,15 @@ export class PanelPersistence {
   }
 
   /**
+   * Drop the cached previous-snapshot entry for a project so the next
+   * `primeProject` reseeds it. Used when a project is removed and in tests that
+   * need a clean cache (the cache is otherwise process-lived).
+   */
+  clearProjectSnapshotCache(projectId: string): void {
+    this.persistedTerminalsByProject.delete(projectId);
+  }
+
+  /**
    * Returns a map of panel id → most-recent snapshot for the given project,
    * or `undefined` if no snapshots are tracked. Used by callers outside the
    * debounced save path (e.g., the synchronous outgoing-state capture on

--- a/src/utils/__tests__/stateHydration.test.ts
+++ b/src/utils/__tests__/stateHydration.test.ts
@@ -133,6 +133,7 @@ vi.mock("@/lib/notify", () => ({
 }));
 
 const { hydrateAppState } = await import("../stateHydration");
+const { panelPersistence } = await import("@/store/persistence/panelPersistence");
 
 function makeMockManagedTerminal(id: string) {
   const hostElement = document.createElement("div");
@@ -668,6 +669,63 @@ describe("hydrateAppState", () => {
     // Scrollback restore is deferred to background — flush to verify
     await flushPostTasks();
     expect(fetchAndRestoreMock).toHaveBeenCalledWith("agent-1");
+  });
+
+  it("restores saved panels and primes persistence when getForProject rejects (#9928)", async () => {
+    // Regression: a rejected backend-terminal query must not skip session restore.
+    // Previously the rejection was re-thrown into the outer catch, leaving the panel
+    // store empty so the first post-boot save wiped the saved session. The fetch
+    // failure should degrade to an empty backend map and let saved panels respawn.
+    appClientMock.hydrate.mockResolvedValue({
+      appState: {
+        terminals: [
+          {
+            id: "agent-1",
+            kind: "terminal",
+            type: "claude",
+            agentId: "claude",
+            title: "Claude Agent",
+            cwd: "/project",
+            location: "grid",
+            command: "claude",
+          },
+        ],
+        sidebarWidth: 350,
+      },
+      terminalConfig,
+      project,
+      agentSettings,
+    });
+
+    terminalClientMock.getForProject.mockRejectedValue(new Error("terminal query failed"));
+
+    const primeProjectSpy = vi.spyOn(panelPersistence, "primeProject");
+    const addPanel = vi.fn().mockResolvedValue("agent-1");
+
+    await hydrateAppState({
+      addPanel,
+      setActiveWorktree: vi.fn(),
+      loadRecipes: vi.fn().mockResolvedValue(undefined),
+      openDiagnosticsDock: vi.fn(),
+    });
+
+    // Persistence cache is primed with the saved panels before any save can fire,
+    // so the first post-boot save compares against the real snapshot, not an empty one.
+    expect(primeProjectSpy).toHaveBeenCalledWith(
+      "project-1",
+      expect.arrayContaining([expect.objectContaining({ id: "agent-1" })])
+    );
+
+    // Saved panel is respawned from disk (empty backend map → respawn path).
+    expect(addPanel).toHaveBeenCalledTimes(1);
+    expect(addPanel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "terminal",
+        requestedId: "agent-1",
+      })
+    );
+
+    primeProjectSpy.mockRestore();
   });
 
   it("schedules scrollback restore as background tasks, not blocking hydration", async () => {

--- a/src/utils/__tests__/stateHydration.test.ts
+++ b/src/utils/__tests__/stateHydration.test.ts
@@ -699,7 +699,11 @@ describe("hydrateAppState", () => {
 
     terminalClientMock.getForProject.mockRejectedValue(new Error("terminal query failed"));
 
-    const primeProjectSpy = vi.spyOn(panelPersistence, "primeProject");
+    // panelPersistence is a real singleton whose previous-snapshot cache survives
+    // across tests; clear project-1 so primeProject actually seeds (it early-returns
+    // when an entry already exists) and the assertion below reflects this run.
+    panelPersistence.clearProjectSnapshotCache("project-1");
+
     const addPanel = vi.fn().mockResolvedValue("agent-1");
 
     await hydrateAppState({
@@ -710,11 +714,10 @@ describe("hydrateAppState", () => {
     });
 
     // Persistence cache is primed with the saved panels before any save can fire,
-    // so the first post-boot save compares against the real snapshot, not an empty one.
-    expect(primeProjectSpy).toHaveBeenCalledWith(
-      "project-1",
-      expect.arrayContaining([expect.objectContaining({ id: "agent-1" })])
-    );
+    // so the first post-boot save compares against the real snapshot, not an empty
+    // one — this is what stops the destructive overwrite (#9928).
+    const primedSnapshots = panelPersistence.getPreviousSnapshotMap("project-1");
+    expect(primedSnapshots?.has("agent-1")).toBe(true);
 
     // Saved panel is respawned from disk (empty backend map → respawn path).
     expect(addPanel).toHaveBeenCalledTimes(1);
@@ -724,8 +727,6 @@ describe("hydrateAppState", () => {
         requestedId: "agent-1",
       })
     );
-
-    primeProjectSpy.mockRestore();
   });
 
   it("schedules scrollback restore as background tasks, not blocking hydration", async () => {

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -319,9 +319,13 @@ export async function hydrateAppState(
       : null;
     const getForProjectPromise: Promise<BackendTerminalInfo[]> = currentProjectId
       ? terminalClient.getForProject(currentProjectId).catch((error: unknown) => {
-          logWarn("Failed to query backend terminals; continuing with saved panel restore", {
-            error,
-          });
+          // Don't log for superseded runs — the project switch that started this
+          // query was already cancelled, so the failure is no longer relevant.
+          if (checkCurrent()) {
+            logWarn("Failed to query backend terminals; continuing with saved panel restore", {
+              error,
+            });
+          }
           return [];
         })
       : Promise.resolve([]);

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -301,8 +301,10 @@ export async function hydrateAppState(
     // Start the backend-terminal lookup alongside the other prefetch promises so
     // its IPC round-trip overlaps with draft-input restore and the rest of the
     // synchronous hydration work. The result is consumed inside the panel-restore
-    // block below; any rejection is captured and re-thrown there so the existing
-    // outer try/catch still logs and skips terminal restore.
+    // block below; any rejection is logged inline and converted to `[]` so saved
+    // panel restore still proceeds without live backend data — otherwise a failed
+    // query would skip restore and the first post-boot save would wipe the saved
+    // session (#9928).
     //
     // Perf span is split into startRendererSpan + manual finishGetForProject so
     // the `:end` mark only fires once `checkCurrent()` has confirmed the run is
@@ -310,7 +312,6 @@ export async function hydrateAppState(
     // emit `:end` after `hydrateAppState`'s `finally` flushes the buffer when a
     // mid-flight supersede happens, polluting the next run's marks with the
     // wrong `switchId`.
-    let terminalFetchError: unknown = null;
     const finishGetForProjectSpan = currentProjectId
       ? startRendererSpan(PERF_MARKS.HYDRATE_GET_TERMINALS, {
           switchId: _switchId ?? null,
@@ -318,7 +319,9 @@ export async function hydrateAppState(
       : null;
     const getForProjectPromise: Promise<BackendTerminalInfo[]> = currentProjectId
       ? terminalClient.getForProject(currentProjectId).catch((error: unknown) => {
-          terminalFetchError = error;
+          logWarn("Failed to query backend terminals; continuing with saved panel restore", {
+            error,
+          });
           return [];
         })
       : Promise.resolve([]);
@@ -342,7 +345,6 @@ export async function hydrateAppState(
         const backendTerminals = await getForProjectPromise;
         if (!checkCurrent()) return;
         finishGetForProjectSpan?.();
-        if (terminalFetchError) throw terminalFetchError;
 
         logHydrationInfo(
           `Found ${backendTerminals.length} running terminals for project ${currentProjectId}`
@@ -450,7 +452,7 @@ export async function hydrateAppState(
           });
         }
       } catch (error) {
-        logWarn("Failed to query backend terminals", { error });
+        logWarn("Failed to restore panels during hydration", { error });
       }
 
       // Restore tab groups after terminals are restored


### PR DESCRIPTION
## Summary

Fixes #9928. When `terminal:getForProject` rejected during cold-start hydration, the rejection was re-thrown into an outer `catch` that only `logWarn`'d — silently skipping both `panelPersistence.primeProject` and `restorePanelsPhase`. The panel store then started empty, so the first post-boot mutation (`saveNormalized` → `panelPersistence.save()`) wrote an empty array, **permanently overwriting the user's saved session**.

The fix degrades a failed backend terminal query to an empty backend map instead of skipping restore — exactly mirroring the already-working timeout path (`PtyClient.getTerminalsForProjectAsync` does `promise.catch(() => [])`). Saved panels respawn from disk via the respawn-from-saved path, and the persistence cache is seeded so the first save compares against the real snapshot rather than `[]`.

## Changes

- **`src/utils/stateHydration/index.ts`** — Remove the `if (terminalFetchError) throw terminalFetchError` re-throw and the now-dead `terminalFetchError` variable. The `getForProject` `.catch()` now logs inline (guarded by `checkCurrent()` so superseded/cancelled runs don't emit noise) and returns `[]`. Updated the stale comment and the outer-catch message to reflect the new behavior.
- **`src/store/persistence/panelPersistence.ts`** — Add `clearProjectSnapshotCache(projectId)` for per-project cache reset.
- **`src/utils/__tests__/stateHydration.test.ts`** — Add regression test asserting saved panels respawn and the persistence cache is primed (verified via the public `getPreviousSnapshotMap`) when `getForProject` rejects.

## Behavior notes

No toast/banner — this is a Tier 1 auto-recovering transient failure per the CLAUDE.md Runtime Signals rules. Panels come up in their normal reconnecting state, identical to a slow pty-host start.

## Testing

- `npm test -- --run src/utils/__tests__/stateHydration.test.ts` → PASS (66 tests)
- `npm run check` → all 9 checks pass (lint ratchet decreased by 6, format clean)

Closes #9928