### PR TITLE
fix(web-preview): align screenshot aria-label and sentence-case cert heading

### DIFF
--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -1016,7 +1016,7 @@ export function BrowserToolbar({
                 buttonClass,
                 "disabled:hover:bg-transparent disabled:hover:shadow-none"
               )}
-              aria-label="Capture screenshot"
+              aria-label="Copy screenshot to clipboard"
             >
               {screenshotCopied ? (
                 <Check className="w-4 h-4 text-status-success" />

--- a/src/components/Browser/__tests__/BrowserToolbar.test.tsx
+++ b/src/components/Browser/__tests__/BrowserToolbar.test.tsx
@@ -283,6 +283,18 @@ describe("BrowserToolbar ARIA semantics", () => {
     expect(onCaptureScreenshot).toHaveBeenCalledOnce();
   });
 
+  it("screenshot button keeps its accessible name while disabled", () => {
+    const onCaptureScreenshot = vi.fn();
+    const { getByRole } = renderToolbar({
+      onCaptureScreenshot,
+      isWebviewReady: false,
+    });
+    const button = getByRole("button", { name: "Copy screenshot to clipboard" });
+    expect(button).toHaveProperty("disabled", true);
+    fireEvent.click(button);
+    expect(onCaptureScreenshot).not.toHaveBeenCalled();
+  });
+
   it("copy success announces in a polite live region", async () => {
     const { container, getByRole } = renderToolbar();
 

--- a/src/components/Browser/__tests__/BrowserToolbar.test.tsx
+++ b/src/components/Browser/__tests__/BrowserToolbar.test.tsx
@@ -267,6 +267,22 @@ describe("BrowserToolbar ARIA semantics", () => {
     expect(defaultProps.onOpenExternal).toHaveBeenCalledOnce();
   });
 
+  it("screenshot button accessible name matches its visible tooltip (WCAG 2.5.3)", () => {
+    const onCaptureScreenshot = vi.fn();
+    const { getByRole, queryByRole } = renderToolbar({
+      onCaptureScreenshot,
+      isWebviewReady: true,
+    });
+    // The visible tooltip reads "Copy screenshot to clipboard"; the accessible
+    // name (aria-label) must contain it, so the stale "Capture screenshot" name
+    // must be gone.
+    expect(queryByRole("button", { name: "Capture screenshot" })).toBeNull();
+    const button = getByRole("button", { name: "Copy screenshot to clipboard" });
+    expect(button).toBeTruthy();
+    fireEvent.click(button);
+    expect(onCaptureScreenshot).toHaveBeenCalledOnce();
+  });
+
   it("copy success announces in a polite live region", async () => {
     const { container, getByRole } = renderToolbar();
 

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1763,7 +1763,7 @@ export function DevPreviewPane({
                                   ? "No internet connection"
                                   : webviewLoadError.code === "cert" ||
                                       webviewLoadError.code === "ssl_protocol"
-                                    ? "Certificate Error"
+                                    ? "Certificate error"
                                     : "Page load failed"}
                       </h3>
                       <p className="text-xs text-daintree-text/50 text-center mb-3 max-w-md">

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -71,7 +71,11 @@ import { getDevPreviewWebContents, buildEmulationParams } from "./viewportEmulat
 import { logError } from "@/utils/logger";
 import { notify } from "@/lib/notify";
 import { loadWebviewUrl } from "./loadWebviewUrl";
-import { useDevPreviewLoadLifecycle, type SessionStorageEntry } from "./useDevPreviewLoadLifecycle";
+import {
+  useDevPreviewLoadLifecycle,
+  webviewLoadErrorHeading,
+  type SessionStorageEntry,
+} from "./useDevPreviewLoadLifecycle";
 
 import { BlockedNavBanner, blockedNavReducer } from "./BlockedNavBanner";
 import { looksLikeOAuthUrl } from "@shared/utils/urlUtils";
@@ -1751,20 +1755,7 @@ export function DevPreviewPane({
                     <div className="absolute inset-0 z-20 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
                       <AlertTriangle className="w-6 h-6 text-status-warning mb-3" />
                       <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
-                        {webviewLoadError.code === "timeout"
-                          ? "Page load timed out"
-                          : webviewLoadError.code === "aborted"
-                            ? "Load cancelled"
-                            : webviewLoadError.code === "connection_refused"
-                              ? "Dev server unreachable"
-                              : webviewLoadError.code === "name_not_resolved"
-                                ? "Couldn't resolve address"
-                                : webviewLoadError.code === "internet_disconnected"
-                                  ? "No internet connection"
-                                  : webviewLoadError.code === "cert" ||
-                                      webviewLoadError.code === "ssl_protocol"
-                                    ? "Certificate error"
-                                    : "Page load failed"}
+                        {webviewLoadErrorHeading(webviewLoadError.code)}
                       </h3>
                       <p className="text-xs text-daintree-text/50 text-center mb-3 max-w-md">
                         {webviewLoadError.message}

--- a/src/components/DevPreview/__tests__/DevPreviewPane.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.test.tsx
@@ -3,10 +3,7 @@ import type { BrowserHistory } from "@shared/types/browser";
 import type { DevPreviewStatus } from "@/hooks/useDevServer";
 import { normalizeBrowserUrl } from "../../Browser/browserUtils";
 import { computeDevServerUrl } from "../urlSync";
-import {
-  webviewLoadErrorHeading,
-  type WebviewLoadErrorCode,
-} from "../useDevPreviewLoadLifecycle";
+import { webviewLoadErrorHeading, type WebviewLoadErrorCode } from "../useDevPreviewLoadLifecycle";
 
 // ─── Browser History Logic ──────────────────────────────────────────
 // Extracted from DevPreviewPane to enable pure-function testing

--- a/src/components/DevPreview/__tests__/DevPreviewPane.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.test.tsx
@@ -3,6 +3,10 @@ import type { BrowserHistory } from "@shared/types/browser";
 import type { DevPreviewStatus } from "@/hooks/useDevServer";
 import { normalizeBrowserUrl } from "../../Browser/browserUtils";
 import { computeDevServerUrl } from "../urlSync";
+import {
+  webviewLoadErrorHeading,
+  type WebviewLoadErrorCode,
+} from "../useDevPreviewLoadLifecycle";
 
 // ─── Browser History Logic ──────────────────────────────────────────
 // Extracted from DevPreviewPane to enable pure-function testing
@@ -99,25 +103,6 @@ function determineRenderState(
   if (status === "error" && hasError) return "error";
   if (!currentUrl) return "waiting";
   return "webview";
-}
-
-// ─── Webview load-error heading ─────────────────────────────────────
-// Mirrors the heading ternary in DevPreviewPane's webviewLoadError overlay.
-// All headings use sentence case (first word capitalized only).
-function webviewErrorHeading(code: string): string {
-  return code === "timed_out"
-    ? "Page load timed out"
-    : code === "aborted"
-      ? "Load cancelled"
-      : code === "connection_refused"
-        ? "Dev server unreachable"
-        : code === "name_not_resolved"
-          ? "Couldn't resolve address"
-          : code === "internet_disconnected"
-            ? "No internet connection"
-            : code === "cert" || code === "ssl_protocol"
-              ? "Certificate error"
-              : "Page load failed";
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────
@@ -603,27 +588,29 @@ describe("DevPreviewPane", () => {
 
   describe("webview load-error heading", () => {
     it("uses sentence case for the certificate error heading (cert and ssl_protocol)", () => {
-      expect(webviewErrorHeading("cert")).toBe("Certificate error");
-      expect(webviewErrorHeading("ssl_protocol")).toBe("Certificate error");
+      expect(webviewLoadErrorHeading("cert")).toBe("Certificate error");
+      expect(webviewLoadErrorHeading("ssl_protocol")).toBe("Certificate error");
     });
 
-    it("renders every heading in sentence case (only the first character is uppercase)", () => {
-      const codes = [
-        "timed_out",
+    it("renders every WebviewLoadErrorCode in sentence case with no trailing period", () => {
+      const codes: WebviewLoadErrorCode[] = [
         "aborted",
-        "connection_refused",
+        "timeout",
         "name_not_resolved",
         "internet_disconnected",
+        "connection_refused",
         "cert",
         "ssl_protocol",
-        "unknown_code",
+        "failed",
       ];
       for (const code of codes) {
-        const heading = webviewErrorHeading(code);
-        // Sentence-case invariant: no interior word starts with an uppercase
-        // letter (proper nouns aside — none here), and there is no trailing period.
+        const heading = webviewLoadErrorHeading(code);
+        // Sentence-case invariant: the first character is uppercase, no interior
+        // word starts with an uppercase letter, and there is no trailing period.
+        const firstChar = heading.charAt(0);
+        expect(firstChar).toBe(firstChar.toUpperCase());
         const interiorWords = heading.split(" ").slice(1);
-        expect(interiorWords.every((w) => w === "" || w[0] !== w[0].toUpperCase())).toBe(true);
+        expect(interiorWords.every((w) => w === w.toLowerCase())).toBe(true);
         expect(heading.endsWith(".")).toBe(false);
       }
     });

--- a/src/components/DevPreview/__tests__/DevPreviewPane.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.test.tsx
@@ -101,6 +101,25 @@ function determineRenderState(
   return "webview";
 }
 
+// ─── Webview load-error heading ─────────────────────────────────────
+// Mirrors the heading ternary in DevPreviewPane's webviewLoadError overlay.
+// All headings use sentence case (first word capitalized only).
+function webviewErrorHeading(code: string): string {
+  return code === "timed_out"
+    ? "Page load timed out"
+    : code === "aborted"
+      ? "Load cancelled"
+      : code === "connection_refused"
+        ? "Dev server unreachable"
+        : code === "name_not_resolved"
+          ? "Couldn't resolve address"
+          : code === "internet_disconnected"
+            ? "No internet connection"
+            : code === "cert" || code === "ssl_protocol"
+              ? "Certificate error"
+              : "Page load failed";
+}
+
 // ─── Tests ──────────────────────────────────────────────────────────
 
 describe("DevPreviewPane", () => {
@@ -579,6 +598,34 @@ describe("DevPreviewPane", () => {
       const renderState = determineRenderState("stopped", false, "");
       const showWarning = renderState === "waiting" && !devCommand;
       expect(showWarning).toBe(false);
+    });
+  });
+
+  describe("webview load-error heading", () => {
+    it("uses sentence case for the certificate error heading (cert and ssl_protocol)", () => {
+      expect(webviewErrorHeading("cert")).toBe("Certificate error");
+      expect(webviewErrorHeading("ssl_protocol")).toBe("Certificate error");
+    });
+
+    it("renders every heading in sentence case (only the first character is uppercase)", () => {
+      const codes = [
+        "timed_out",
+        "aborted",
+        "connection_refused",
+        "name_not_resolved",
+        "internet_disconnected",
+        "cert",
+        "ssl_protocol",
+        "unknown_code",
+      ];
+      for (const code of codes) {
+        const heading = webviewErrorHeading(code);
+        // Sentence-case invariant: no interior word starts with an uppercase
+        // letter (proper nouns aside — none here), and there is no trailing period.
+        const interiorWords = heading.split(" ").slice(1);
+        expect(interiorWords.every((w) => w === "" || w[0] !== w[0].toUpperCase())).toBe(true);
+        expect(heading.endsWith(".")).toBe(false);
+      }
     });
   });
 });

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -1522,7 +1522,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         });
       });
 
-      expect(container.textContent).toContain("Certificate Error");
+      expect(container.textContent).toContain("Certificate error");
       expect(container.textContent).toContain("certificate couldn't be verified");
       expect(container.textContent).toContain("mkcert -install");
       expect(container.textContent).toContain("localhost:8443");
@@ -1570,7 +1570,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         });
       });
 
-      expect(container.textContent).toContain("Certificate Error");
+      expect(container.textContent).toContain("Certificate error");
       expect(container.textContent).toContain("SSL/TLS handshake failed");
       // -107 is also raised on protocol mismatch — the mkcert hint is wrong here
       expect(container.textContent).not.toContain("mkcert");
@@ -1591,7 +1591,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         });
       });
 
-      expect(container.textContent).toContain("Certificate Error");
+      expect(container.textContent).toContain("Certificate error");
       expect(container.textContent).toContain("mkcert -install");
     });
 
@@ -1627,7 +1627,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       // The stale retry must NOT have called loadURL
       expect(webview.loadURL).not.toHaveBeenCalled();
       // Cert error overlay must be visible
-      expect(container.textContent).toContain("Certificate Error");
+      expect(container.textContent).toContain("Certificate error");
     });
 
     it("classifies -299 (cert range lower bound) as cert, -199 and -300 fall through", () => {
@@ -1641,7 +1641,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
           validatedURL: "https://example.com/",
         });
       });
-      expect(c1.textContent).toContain("Certificate Error");
+      expect(c1.textContent).toContain("Certificate error");
 
       const { container: c2 } = render(<DevPreviewPane {...baseProps} />);
       const w2 = getWebviewElement(c2);

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -34,6 +34,27 @@ export interface WebviewLoadError {
   validatedURL?: string;
 }
 
+// Sentence-case headings for the webview load-error overlay.
+export function webviewLoadErrorHeading(code: WebviewLoadErrorCode): string {
+  switch (code) {
+    case "timeout":
+      return "Page load timed out";
+    case "aborted":
+      return "Load cancelled";
+    case "connection_refused":
+      return "Dev server unreachable";
+    case "name_not_resolved":
+      return "Couldn't resolve address";
+    case "internet_disconnected":
+      return "No internet connection";
+    case "cert":
+    case "ssl_protocol":
+      return "Certificate error";
+    default:
+      return "Page load failed";
+  }
+}
+
 // Chromium net error codes — see net/base/net_error_list.h
 const ERR_SSL_PROTOCOL_ERROR = -107;
 const ERR_CERT_RANGE_END = -200;


### PR DESCRIPTION
## Summary

- Screenshot button in `BrowserToolbar` had `aria-label="Capture screenshot"` while its visible tooltip reads "Copy screenshot to clipboard" — a WCAG 2.5.3 Label in Name violation. Aligned the `aria-label` to match the tooltip.
- Cert/SSL error heading in `DevPreviewPane` was `Certificate Error` (Title Case) while every sibling load-error heading is sentence case. Changed to `Certificate error`.
- Extracted `webviewLoadErrorHeading()` from `DevPreviewPane` into `useDevPreviewLoadLifecycle.ts` so the casing logic is unit-testable against the real component code.

Resolves #9970

## Changes

- `src/components/Browser/BrowserToolbar.tsx` — `aria-label` updated to match the tooltip text
- `src/components/DevPreview/DevPreviewPane.tsx` — cert/SSL heading lowercased; load-error heading now delegates to the extracted helper
- `src/components/DevPreview/useDevPreviewLoadLifecycle.ts` — `webviewLoadErrorHeading()` extracted and exported
- `src/components/Browser/__tests__/BrowserToolbar.test.tsx` — ARIA accessible-name tests for the screenshot button (enabled and disabled states)
- `src/components/DevPreview/__tests__/DevPreviewPane.test.tsx` — sentence-case heading tests for `cert`/`ssl_protocol` codes, plus an invariant across all `WebviewLoadErrorCode` values

## Testing

134 targeted tests pass. `npm run check` clean (zero errors).