### PR TITLE
fix(forge): stop routing panel flashing false empty state and hiding remotes

### DIFF
--- a/src/components/Settings/ForgeIntegrationsTab.tsx
+++ b/src/components/Settings/ForgeIntegrationsTab.tsx
@@ -71,9 +71,22 @@ export function ForgeIntegrationsTab() {
   useEffect(() => {
     remotesRef.current = remotes;
   }, [remotes]);
+  // Records the project whose remotes the current state reflects. Set inside the
+  // load effect, so during the render frame *before* that effect commits
+  // `remotesLoading=true` it still holds the previous project's id. That frame —
+  // on initial mount and on every project switch — is exactly when `remotes` is
+  // `[]` but no load flag is set yet; comparing it to `activeProjectId` lets us
+  // treat the pre-effect window as pending and avoid painting a false empty
+  // state for the freshly selected project (#9990).
+  const remotesLoadedForRef = useRef<string | undefined>(undefined);
   // Defer the "Loading remotes…" text past the Doherty threshold so fast IPC
   // resolutions don't flash a loading state for sub-400ms work.
   const showRemotesLoading = useDohertyGate(remotesLoading);
+  // Raw, un-gated "a load is or is about to be in flight" signal. Covers both
+  // the active load (`remotesLoading`) and the pre-effect render frame where the
+  // active project just changed but the load effect hasn't committed yet.
+  const remotesPending =
+    remotesLoading || (activeProjectId != null && remotesLoadedForRef.current !== activeProjectId);
 
   useEffect(() => {
     let cancelled = false;
@@ -103,11 +116,13 @@ export function ForgeIntegrationsTab() {
   // flag could fire out of expected order.
   useEffect(() => {
     if (!activeProjectId || !activeProjectPath) {
+      remotesLoadedForRef.current = activeProjectId;
       setRemotes([]);
       setRemotesLoading(false);
       setRemotesError(null);
       return;
     }
+    remotesLoadedForRef.current = activeProjectId;
     let cancelled = false;
     setRemotesLoading(true);
     setRemotesError(null);
@@ -277,9 +292,10 @@ export function ForgeIntegrationsTab() {
           activeProjectName={activeProject?.name}
           activeProjectId={activeProjectId}
           providersInstalled={providers.length}
+          providersLoading={loading}
           remotes={remotes}
           loading={showRemotesLoading}
-          pending={remotesLoading}
+          pending={remotesPending}
           error={remotesError}
         />
       </SettingsSection>
@@ -291,6 +307,9 @@ interface ProjectRoutingPanelProps {
   activeProjectName: string | undefined;
   activeProjectId: string | undefined;
   providersInstalled: number;
+  // Whether the top-level provider/settings load is still in flight. Used to
+  // avoid asserting "no plugins installed" before the provider list resolves.
+  providersLoading: boolean;
   remotes: RemoteRouting[];
   loading: boolean;
   // Raw (un-gated) loading flag. `loading` is the Doherty-gated flag that only
@@ -305,6 +324,7 @@ function ProjectRoutingPanel({
   activeProjectName,
   activeProjectId,
   providersInstalled,
+  providersLoading,
   remotes,
   loading,
   pending,
@@ -342,7 +362,7 @@ function ProjectRoutingPanel({
 
   return (
     <div className="space-y-2">
-      {providersInstalled === 0 && (
+      {providersInstalled === 0 && !providersLoading && (
         <p className="text-xs text-daintree-text/50">
           No forge plugins are installed. Each remote shows as unmatched until a provider plugin is
           installed.

--- a/src/components/Settings/ForgeIntegrationsTab.tsx
+++ b/src/components/Settings/ForgeIntegrationsTab.tsx
@@ -279,6 +279,7 @@ export function ForgeIntegrationsTab() {
           providersInstalled={providers.length}
           remotes={remotes}
           loading={showRemotesLoading}
+          pending={remotesLoading}
           error={remotesError}
         />
       </SettingsSection>
@@ -292,6 +293,11 @@ interface ProjectRoutingPanelProps {
   providersInstalled: number;
   remotes: RemoteRouting[];
   loading: boolean;
+  // Raw (un-gated) loading flag. `loading` is the Doherty-gated flag that only
+  // flips true past the 400ms threshold; during the sub-400ms window a load is
+  // in flight but `loading` is still false and `remotes` has been reset to [],
+  // which would otherwise flash the "no remotes" empty state on every load.
+  pending: boolean;
   error: string | null;
 }
 
@@ -301,12 +307,21 @@ function ProjectRoutingPanel({
   providersInstalled,
   remotes,
   loading,
+  pending,
   error,
 }: ProjectRoutingPanelProps) {
   if (!activeProjectId) {
     return (
       <p className="text-xs text-daintree-text/50">Open a project to view its forge routing.</p>
     );
+  }
+
+  // Sub-400ms in-flight window: a load is running but the Doherty gate hasn't
+  // surfaced the loading text yet. Render nothing rather than the false empty
+  // state. Scoped to remotes.length === 0 so an in-place refetch never blanks
+  // an already-resolved list.
+  if (pending && !loading && remotes.length === 0) {
+    return null;
   }
 
   if (loading) {
@@ -325,34 +340,36 @@ function ProjectRoutingPanel({
     );
   }
 
-  if (providersInstalled === 0) {
-    return (
-      <p className="text-xs text-daintree-text/50">
-        No forge plugins are installed. Each remote shows as unmatched until a provider plugin is
-        installed.
-      </p>
-    );
-  }
-
   return (
-    <ul className="space-y-2">
-      {remotes.map(({ remote, resolved }) => (
-        <li
-          key={remote.name}
-          className="flex items-center gap-3 justify-between rounded-[var(--radius-md)] border border-daintree-border/50 bg-overlay-subtle px-3 py-2"
-        >
-          <div className="min-w-0 flex-1">
-            <div className="flex items-baseline gap-2">
-              <span className="text-xs font-medium text-daintree-text">{remote.name}</span>
+    <div className="space-y-2">
+      {providersInstalled === 0 && (
+        <p className="text-xs text-daintree-text/50">
+          No forge plugins are installed. Each remote shows as unmatched until a provider plugin is
+          installed.
+        </p>
+      )}
+      <ul className="space-y-2">
+        {remotes.map(({ remote, resolved }) => (
+          <li
+            key={remote.name}
+            className="flex items-center gap-3 justify-between rounded-[var(--radius-md)] border border-daintree-border/50 bg-overlay-subtle px-3 py-2"
+          >
+            <div className="min-w-0 flex-1">
+              <div className="flex items-baseline gap-2">
+                <span className="text-xs font-medium text-daintree-text">{remote.name}</span>
+              </div>
+              <p
+                className="text-xs text-daintree-text/50 font-mono truncate"
+                title={remote.fetchUrl}
+              >
+                {remote.fetchUrl}
+              </p>
             </div>
-            <p className="text-xs text-daintree-text/50 font-mono truncate" title={remote.fetchUrl}>
-              {remote.fetchUrl}
-            </p>
-          </div>
-          <RoutingBadge resolved={resolved} />
-        </li>
-      ))}
-    </ul>
+            <RoutingBadge resolved={resolved} />
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 }
 

--- a/src/components/Settings/__tests__/ForgeIntegrationsTab.test.tsx
+++ b/src/components/Settings/__tests__/ForgeIntegrationsTab.test.tsx
@@ -178,7 +178,30 @@ describe("ForgeIntegrationsTab", () => {
     });
   });
 
-  it("shows a no-providers message when remotes exist but no plugins are installed", async () => {
+  it("does not flash the no-remotes empty state while a load is in flight (#9990)", async () => {
+    // listRemotes never resolves, so the load stays in flight: remotesLoading
+    // is true and remotes stays []. Within the 400ms Doherty window the gated
+    // `showRemotesLoading` is still false, which previously fell through to the
+    // "has no git remotes configured" empty state.
+    installForgeMocks({
+      providers: [makeProvider("builtin", "github", "GitHub", ["github.com"])],
+    });
+    window.electron.project.listRemotes = vi.fn(() => new Promise<RemoteInfo[]>(() => {}));
+    setProject({ id: "proj-pending", path: "/pending", name: "Pending" } as Project);
+
+    render(<ForgeIntegrationsTab />);
+
+    // Wait until the top-level settings load settles (providers resolved) so we
+    // know the component has rendered past its own loading state.
+    await waitFor(() => {
+      expect(screen.getByText("Active project routing")).toBeTruthy();
+    });
+    expect(window.electron.project.listRemotes).toHaveBeenCalledWith("/pending");
+    // The panel renders nothing during the in-flight window — no false empty state.
+    expect(screen.queryByText(/has no git remotes configured/i)).toBeNull();
+  });
+
+  it("shows the no-providers note alongside the remotes list when no plugins are installed", async () => {
     installForgeMocks({
       providers: [],
       remotes: [makeRemote("origin", "git@github.com:owner/repo.git")],
@@ -191,7 +214,12 @@ describe("ForgeIntegrationsTab", () => {
     render(<ForgeIntegrationsTab />);
 
     await waitFor(() => {
+      // The informational note remains visible…
       expect(screen.getByText(/No forge plugins are installed\./i)).toBeTruthy();
+      // …and the remote row with its "No match" badge is now rendered too,
+      // instead of being hidden behind a text-only early return (#9990).
+      expect(screen.getByText("origin")).toBeTruthy();
+      expect(screen.getByText("No match")).toBeTruthy();
     });
   });
 
@@ -281,6 +309,12 @@ describe("ForgeIntegrationsTab source guards", () => {
     expect(source).toMatch(/showRemotesLoading\s*=\s*useDohertyGate\(\s*remotesLoading\s*\)/);
     expect(source).toMatch(/loading=\{showRemotesLoading\}/);
     expect(source).not.toMatch(/loading=\{remotesLoading\}/);
+  });
+
+  it("passes the raw remotesLoading flag as the pending prop to suppress the sub-400ms empty state", () => {
+    expect(source).toMatch(/pending=\{remotesLoading\}/);
+    // The panel returns null during the in-flight window before the Doherty gate fires.
+    expect(source).toMatch(/if\s*\(\s*pending\s*&&\s*!loading\s*&&\s*remotes\.length === 0\s*\)/);
   });
 
   it("reads remotes through a ref in reresolveRemotes to avoid stale closures on project switch", () => {

--- a/src/components/Settings/__tests__/ForgeIntegrationsTab.test.tsx
+++ b/src/components/Settings/__tests__/ForgeIntegrationsTab.test.tsx
@@ -214,8 +214,10 @@ describe("ForgeIntegrationsTab", () => {
     render(<ForgeIntegrationsTab />);
 
     await waitFor(() => {
-      // The informational note remains visible…
-      expect(screen.getByText(/No forge plugins are installed\./i)).toBeTruthy();
+      // The informational note remains visible in the routing panel. Match the
+      // phrase unique to it — the default-provider section also says "No forge
+      // plugins are installed yet." which getByText would otherwise conflate.
+      expect(screen.getByText(/Each remote shows as unmatched/i)).toBeTruthy();
       // …and the remote row with its "No match" badge is now rendered too,
       // instead of being hidden behind a text-only early return (#9990).
       expect(screen.getByText("origin")).toBeTruthy();
@@ -311,8 +313,11 @@ describe("ForgeIntegrationsTab source guards", () => {
     expect(source).not.toMatch(/loading=\{remotesLoading\}/);
   });
 
-  it("passes the raw remotesLoading flag as the pending prop to suppress the sub-400ms empty state", () => {
-    expect(source).toMatch(/pending=\{remotesLoading\}/);
+  it("passes a raw pending flag to suppress the empty state during in-flight loads", () => {
+    expect(source).toMatch(/pending=\{remotesPending\}/);
+    // pending covers the active load AND the pre-effect frame on a project switch.
+    expect(source).toMatch(/remotesPending\s*=\s*\n?\s*remotesLoading\s*\|\|/);
+    expect(source).toMatch(/remotesLoadedForRef\.current\s*!==\s*activeProjectId/);
     // The panel returns null during the in-flight window before the Doherty gate fires.
     expect(source).toMatch(/if\s*\(\s*pending\s*&&\s*!loading\s*&&\s*remotes\.length === 0\s*\)/);
   });


### PR DESCRIPTION
## Summary

- `ProjectRoutingPanel` was hitting the empty-state branch during the 400ms Doherty gate window on every mount and project switch. The effect resets `remotes` to `[]` and flips `remotesLoading` true, but the Doherty-gated `showRemotesLoading` stays false for 400ms, so the panel saw an empty list with no loading flag and rendered a false "no git remotes configured" message. The fix adds a raw `remotesPending` signal (derived from `remotesLoading` plus a `remotesLoadedForRef` that lags one render frame) and a `null` guard that suppresses rendering entirely during the in-flight window.
- The zero-providers branch had an early return that showed copy describing "No match" badges and a remotes list that were never rendered. Removed the early return, always render the remotes list with `RoutingBadge` showing "No match" per remote, and demoted the no-plugins note to an inline line above the list gated on `providersLoading`.

Resolves #9990

## Changes

- `src/components/Settings/ForgeIntegrationsTab.tsx` — `remotesPending` derived signal + `null` guard; remove zero-providers early return; inline no-plugins note gated on `providersLoading`
- `src/components/Settings/__tests__/ForgeIntegrationsTab.test.tsx` — source guard extended for pending wiring; no-providers test updated to assert the note and remote row + badge both render; in-flight regression test added

## Testing

12 tests pass. Typecheck, lint, and Prettier all clean.