### PR TITLE
fix(ipc): stop leaking raw Zod error detail to the renderer

### DIFF
--- a/electron/ipc/handlers/__tests__/appAgent.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/appAgent.handlers.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
+const appAgentServiceMock = vi.hoisted(() => ({
+  getConfig: vi.fn(() => ({})),
+  setConfig: vi.fn(),
+  hasApiKey: vi.fn(() => false),
+  testApiKey: vi.fn(),
+  testModel: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  ipcMain: ipcMainMock,
+}));
+
+vi.mock("../../../services/AppAgentService.js", () => ({
+  appAgentService: appAgentServiceMock,
+}));
+
+import { CHANNELS } from "../../channels.js";
+import { registerAppAgentHandlers } from "../appAgent.js";
+
+function getInvokeHandler(channel: string): (...args: unknown[]) => Promise<unknown> {
+  const call = (ipcMainMock.handle as Mock).mock.calls.find(
+    ([registered]) => registered === channel
+  );
+  if (!call) {
+    throw new Error(`No handler registered for channel: ${channel}`);
+  }
+  return call[1] as (...args: unknown[]) => Promise<unknown>;
+}
+
+describe("appAgent handlers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registerAppAgentHandlers({} as never);
+  });
+
+  const mockEvent = { sender: { id: 1 } } as never;
+
+  it("throws a sanitized ValidationError without Zod detail for invalid set-config payloads", async () => {
+    const handler = getInvokeHandler(CHANNELS.APP_AGENT_SET_CONFIG);
+
+    await expect(handler(mockEvent, { model: 123 } as never)).rejects.toThrow(
+      `IPC validation failed: ${CHANNELS.APP_AGENT_SET_CONFIG}`
+    );
+    expect(appAgentServiceMock.setConfig).not.toHaveBeenCalled();
+  });
+
+  it("does not leak Zod schema field names or values in the thrown message", async () => {
+    const handler = getInvokeHandler(CHANNELS.APP_AGENT_SET_CONFIG);
+
+    const rejection = await handler(mockEvent, { model: 123 } as never).then(
+      () => null,
+      (error: unknown) => error as Error
+    );
+
+    expect(rejection).toBeInstanceOf(Error);
+    expect(rejection?.message).toBe(`IPC validation failed: ${CHANNELS.APP_AGENT_SET_CONFIG}`);
+    expect(rejection?.message).not.toContain("expected");
+    expect(rejection?.message).not.toContain("received");
+    expect(rejection?.message).not.toContain("123");
+  });
+});

--- a/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
@@ -73,7 +73,7 @@ describe("copyTree handlers", () => {
 
     await expect(handler(mockEvent, null as never)).resolves.toEqual(
       expect.objectContaining({
-        error: expect.stringContaining("Invalid payload"),
+        error: expect.stringMatching(/^Invalid payload$/),
       })
     );
   });
@@ -83,7 +83,7 @@ describe("copyTree handlers", () => {
 
     await expect(handler(mockEvent, null as never)).resolves.toEqual(
       expect.objectContaining({
-        error: expect.stringContaining("Invalid payload"),
+        error: expect.stringMatching(/^Invalid payload$/),
       })
     );
   });
@@ -93,7 +93,7 @@ describe("copyTree handlers", () => {
 
     await expect(handler(mockEvent, null as never)).resolves.toEqual(
       expect.objectContaining({
-        error: expect.stringContaining("Invalid payload"),
+        error: expect.stringMatching(/^Invalid payload$/),
       })
     );
   });
@@ -103,7 +103,7 @@ describe("copyTree handlers", () => {
 
     await expect(handler(mockEvent, null as never)).resolves.toEqual(
       expect.objectContaining({
-        error: expect.stringContaining("Invalid payload"),
+        error: expect.stringMatching(/^Invalid payload$/),
       })
     );
   });
@@ -121,6 +121,23 @@ describe("copyTree handlers", () => {
         error: expect.not.stringContaining("Invalid payload"),
       })
     );
+  });
+
+  it("throws a sanitized ValidationError without Zod detail for invalid file tree requests", async () => {
+    const handler = getInvokeHandler(CHANNELS.COPYTREE_GET_FILE_TREE);
+
+    // copyTree channels share the "fileOps" rate-limit bucket; earlier handler
+    // calls in this suite exhaust the window. Advance past it so the rate
+    // limiter doesn't preempt the validation path under test.
+    vi.useFakeTimers();
+    try {
+      vi.advanceTimersByTime(11_000);
+      await expect(handler(mockEvent, null as never)).rejects.toThrow(
+        `IPC validation failed: ${CHANNELS.COPYTREE_GET_FILE_TREE}`
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/electron/ipc/handlers/appAgent.ts
+++ b/electron/ipc/handlers/appAgent.ts
@@ -1,4 +1,6 @@
+import { z } from "zod";
 import { CHANNELS } from "../channels.js";
+import { ValidationError } from "../validationError.js";
 import type { HandlerDependencies } from "../types.js";
 import { appAgentService } from "../../services/AppAgentService.js";
 import type { AppAgentConfig } from "../../../shared/types/appAgent.js";
@@ -16,7 +18,8 @@ export function registerAppAgentHandlers(_deps: HandlerDependencies): () => void
   const handleSetConfig = async (config: Partial<AppAgentConfig>) => {
     const configResult = AppAgentConfigSchema.partial().safeParse(config);
     if (!configResult.success) {
-      throw new Error(`Invalid config: ${configResult.error.message}`);
+      console.error("Invalid app agent config:", z.prettifyError(configResult.error));
+      throw new ValidationError(CHANNELS.APP_AGENT_SET_CONFIG);
     }
 
     appAgentService.setConfig(configResult.data);

--- a/electron/ipc/handlers/copyTree.ts
+++ b/electron/ipc/handlers/copyTree.ts
@@ -6,6 +6,7 @@ import { chmod, mkdir, writeFile } from "fs/promises";
 import { pathToFileURL } from "url";
 import { z } from "zod";
 import { CHANNELS } from "../channels.js";
+import { ValidationError } from "../validationError.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import {
   broadcastToRenderer,
@@ -230,7 +231,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       return {
         content: "",
         fileCount: 0,
-        error: `Invalid payload: ${parseResult.error.message}`,
+        error: "Invalid payload",
       };
     }
 
@@ -293,7 +294,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       return {
         content: "",
         fileCount: 0,
-        error: `Invalid payload: ${parseResult.error.message}`,
+        error: "Invalid payload",
       };
     }
 
@@ -443,7 +444,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       return {
         content: "",
         fileCount: 0,
-        error: `Invalid payload: ${parseResult.error.message}`,
+        error: "Invalid payload",
       };
     }
 
@@ -589,7 +590,8 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
     checkRateLimit(CHANNELS.COPYTREE_GET_FILE_TREE, 5, 10_000);
     const parseResult = CopyTreeGetFileTreePayloadSchema.safeParse(payload);
     if (!parseResult.success) {
-      throw new Error(`Invalid file tree request: ${parseResult.error.message}`);
+      console.error("Invalid CopyTree file tree request:", z.prettifyError(parseResult.error));
+      throw new ValidationError(CHANNELS.COPYTREE_GET_FILE_TREE);
     }
 
     const validated = parseResult.data;
@@ -637,7 +639,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
         includedFiles: 0,
         includedSize: 0,
         excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
-        error: `Invalid payload: ${parseResult.error.message}`,
+        error: "Invalid payload",
       };
     }
 


### PR DESCRIPTION
## Summary

Several IPC handlers were doing manual payload validation and embedding `ZodError.message` directly in renderer-bound error strings. In Zod v4, `ZodError.message` is a JSON-serialized array of issues — field paths, codes, expected/received types, and raw user values. That crossed the IPC trust boundary and, in the `copyTree` case, could surface as user-facing error text.

Six sites fixed across two files to conform to the canonical `ValidationError` pattern in `electron/ipc/validationError.ts`.

Resolves #9883

## Changes

- `electron/ipc/handlers/copyTree.ts`: four returned-result error sites (`generate`, `generate-and-copy`, `inject`, `test-config`) now return the static string `"Invalid payload"` — these bypass the throwing sanitizer entirely, so the Zod blob was reaching the renderer verbatim. The `get-file-tree` throw site now logs `z.prettifyError` server-side and throws `ValidationError(channel)`.
- `electron/ipc/handlers/appAgent.ts`: `handleSetConfig` now logs `z.prettifyError` server-side and throws `ValidationError(channel)`.
- `electron/ipc/handlers/__tests__/copyTree.handlers.test.ts`: existing assertions tightened to exact `"Invalid payload"` match; `get-file-tree` throw-site test added.
- `electron/ipc/handlers/__tests__/appAgent.handlers.test.ts`: new test file asserting the thrown message carries no Zod field names or raw values.

## Testing

- `npx vitest` — 27 tests pass.
- `npm run check` — typecheck, format, IPC/channel guards all pass; lint warning count dropped by 6 (the fixed sites).