### PR TITLE
fix(a11y): announce agent state on panel and dock tabs to screen readers

### DIFF
--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -38,6 +38,7 @@ import { getTerminalAgentDisplayState } from "@/utils/terminalAgentDisplayState"
 import {
   getEffectiveStateIcon,
   getEffectiveStateColor,
+  getEffectiveStateLabel,
 } from "@/components/Worktree/terminalStateConfig";
 import { TerminalRefreshTier } from "@/types";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
@@ -535,7 +536,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                 const moved = moveTerminalToGrid(activePanel.id);
                 if (moved) closeDockTerminal();
               }}
-              aria-label={`${activePanel.title} (${panels.length} tabs) - Click to preview, double-click to move to grid, drag to reorder`}
+              aria-label={`${activePanel.title}${displayAgentState ? ` — agent ${getEffectiveStateLabel(displayAgentState)}` : ""} (${panels.length} tabs) - Click to preview, double-click to move to grid, drag to reorder`}
             >
               <div className="flex items-center justify-center shrink-0">
                 <TerminalIcon

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -16,6 +16,7 @@ import { getTerminalAgentDisplayState } from "@/utils/terminalAgentDisplayState"
 import {
   getEffectiveStateIcon,
   getEffectiveStateColor,
+  getEffectiveStateLabel,
 } from "@/components/Worktree/terminalStateConfig";
 import { TerminalRefreshTier } from "@/types";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
@@ -342,7 +343,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
                   e.stopPropagation();
                   handleMoveToGrid();
                 }}
-                aria-label={`${terminal.title} - Click to preview, double-click to move to grid, drag to reorder`}
+                aria-label={`${terminal.title}${displayAgentState ? ` — agent ${getEffectiveStateLabel(displayAgentState)}` : ""} - Click to preview, double-click to move to grid, drag to reorder`}
               >
                 <div className="flex items-center justify-center shrink-0">
                   <TerminalIcon kind={terminal.kind} chrome={chrome} className="w-3.5 h-3.5" />

--- a/src/components/Layout/__tests__/DockedTerminalItem.test.tsx
+++ b/src/components/Layout/__tests__/DockedTerminalItem.test.tsx
@@ -17,6 +17,7 @@ const closeDockTerminalMock = vi.fn();
 const moveTerminalToGridMock = vi.fn();
 
 let mockActiveDockTerminalId: string | null = null;
+let mockDockAgentState: string | undefined = undefined;
 
 vi.mock("@/store", () => ({
   usePanelStore: (selector: (s: Record<string, unknown>) => unknown) =>
@@ -73,7 +74,7 @@ vi.mock("../dockPanelPortalContext", () => ({
 
 vi.mock("../useDockBlockedState", () => ({
   useDockBlockedState: () => null,
-  getDockDisplayAgentState: () => undefined,
+  getDockDisplayAgentState: () => mockDockAgentState,
   isDockAgentStateDeprioritized: () => false,
 }));
 
@@ -90,6 +91,7 @@ vi.mock("@/utils/terminalChrome", () => ({
 vi.mock("@/components/Worktree/terminalStateConfig", () => ({
   getEffectiveStateIcon: () => null,
   getEffectiveStateColor: () => "",
+  getEffectiveStateLabel: (state: string) => state,
 }));
 
 vi.mock("@/components/Terminal/TerminalContextMenu", () => ({
@@ -141,6 +143,21 @@ describe("DockedTerminalItem move-to-grid gesture", () => {
     closeDockTerminalMock.mockReset();
     moveTerminalToGridMock.mockReset();
     mockActiveDockTerminalId = null;
+    mockDockAgentState = undefined;
+  });
+
+  // #10024 — the dock chip's state icon is aria-hidden, so the agent state must
+  // be carried in the button's accessible name for screen-reader users.
+  it("announces the agent state in the chip aria-label when an agent is active", () => {
+    mockDockAgentState = "working";
+    render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
+    expect(screen.getByRole("button", { name: /— agent working/ })).not.toBeNull();
+  });
+
+  it("omits agent state from the chip aria-label for a plain shell", () => {
+    mockDockAgentState = undefined;
+    render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
+    expect(screen.queryByRole("button", { name: /agent/i })).toBeNull();
   });
 
   it("does not render a dedicated Open in grid button on the chip", () => {

--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -9,6 +9,7 @@ import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import {
   getEffectiveStateIcon,
   getEffectiveStateColor,
+  getEffectiveStateLabel,
 } from "@/components/Worktree/terminalStateConfig";
 import type { TerminalChromeDescriptor } from "@/utils/terminalChrome";
 import { getTerminalAgentDisplayState } from "@/utils/terminalAgentDisplayState";
@@ -341,6 +342,12 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
             >
               {title}
             </span>
+          )}
+
+          {/* Visually-hidden state text so the agent state icon (aria-hidden, decorative)
+              is announced as part of the tab's accessible name. */}
+          {displayAgentState && (
+            <span className="sr-only">Agent {getEffectiveStateLabel(displayAgentState)}</span>
           )}
 
           {document.body.dataset.performanceMode === "true" ? (

--- a/src/components/Panel/__tests__/TabButton.test.tsx
+++ b/src/components/Panel/__tests__/TabButton.test.tsx
@@ -590,9 +590,12 @@ describe("TabButton", () => {
 
     // #10024 — the visual state icon is aria-hidden, so a visually-hidden text
     // alternative carries the agent state into the tab's accessible name.
-    it("exposes the agent state as visually-hidden text when a state is shown", () => {
+    it("includes the agent state in the tab's accessible name when a state is shown", () => {
       render(<TabButton {...defaultProps} chrome={deriveTerminalChrome()} agentState="working" />);
-      expect(screen.queryByText("Agent working")).not.toBeNull();
+      // getByRole name computation proves the sr-only span lives inside the
+      // role="tab" element and participates in the accessible name alongside
+      // the visible title — queryByText alone wouldn't guarantee that.
+      expect(screen.getByRole("tab", { name: /Test Agent.*Agent working/ })).not.toBeNull();
     });
 
     it("uses the effective state label when state is coerced (idle -> waiting)", () => {
@@ -603,11 +606,22 @@ describe("TabButton", () => {
           agentState="idle"
         />
       );
-      expect(screen.queryByText("Agent waiting")).not.toBeNull();
+      expect(screen.getByRole("tab", { name: /Agent waiting/ })).not.toBeNull();
     });
 
     it("does not expose state text when no state is shown (plain shell)", () => {
       render(<TabButton {...defaultProps} chrome={deriveTerminalChrome()} />);
+      expect(screen.queryByText(/^Agent /)).toBeNull();
+    });
+
+    it("suppresses state text when the agent chrome has exited (stale state)", () => {
+      render(
+        <TabButton
+          {...defaultProps}
+          chrome={deriveTerminalChrome({ launchAgentId: "claude", exitCode: 0 })}
+          agentState="working"
+        />
+      );
       expect(screen.queryByText(/^Agent /)).toBeNull();
     });
   });

--- a/src/components/Panel/__tests__/TabButton.test.tsx
+++ b/src/components/Panel/__tests__/TabButton.test.tsx
@@ -587,5 +587,28 @@ describe("TabButton", () => {
       const { container } = render(<TabButton {...defaultProps} chrome={deriveTerminalChrome()} />);
       expect(queryStateIcon(container)).toBeUndefined();
     });
+
+    // #10024 — the visual state icon is aria-hidden, so a visually-hidden text
+    // alternative carries the agent state into the tab's accessible name.
+    it("exposes the agent state as visually-hidden text when a state is shown", () => {
+      render(<TabButton {...defaultProps} chrome={deriveTerminalChrome()} agentState="working" />);
+      expect(screen.queryByText("Agent working")).not.toBeNull();
+    });
+
+    it("uses the effective state label when state is coerced (idle -> waiting)", () => {
+      render(
+        <TabButton
+          {...defaultProps}
+          chrome={deriveTerminalChrome({ launchAgentId: "claude" })}
+          agentState="idle"
+        />
+      );
+      expect(screen.queryByText("Agent waiting")).not.toBeNull();
+    });
+
+    it("does not expose state text when no state is shown (plain shell)", () => {
+      render(<TabButton {...defaultProps} chrome={deriveTerminalChrome()} />);
+      expect(screen.queryByText(/^Agent /)).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Agent state icons on panel tabs and dock tabs were `aria-hidden` decorative elements, so screen readers never announced the agent's current state
- Added `sr-only` spans inside `role="tab"` elements so the state is part of the tab's accessible name without violating WCAG 2.5.3 (Label in Name); dock trigger buttons get the state appended to their existing `aria-label`
- Covers both cases in the dock: the single-chip `DockedTerminalItem` and the multi-tab `DockedTabGroup` trigger button

Resolves #10024

## Changes

- `src/components/Panel/TabButton.tsx` — visually-hidden `sr-only` span inside the tab renders "Agent {state}"; state icon stays `aria-hidden`
- `src/components/Layout/DockedTabGroup.tsx` — agent state appended to the multi-tab dock trigger `aria-label`
- `src/components/Layout/DockedTerminalItem.tsx` — agent state appended to the single docked terminal chip `aria-label`
- Both dock files import `getEffectiveStateLabel` for consistent state label resolution

## Testing

- `src/components/Panel/__tests__/TabButton.test.tsx` — accessible name composition, idle→waiting coercion, plain shell absence, exited-state suppression
- `src/components/Layout/__tests__/DockedTerminalItem.test.tsx` — chip `aria-label` announces agent state and omits for plain shell
- 41 relevant unit tests pass; `npm run check` clean