### PR TITLE
fix(e2e): gate renderer backdoors behind __DAINTREE_E2E_MODE__ in production

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,10 +38,10 @@ import { useMcpBridge } from "./hooks/useMcpBridge";
 import { usePluginBridge } from "./hooks/usePluginBridge";
 import { useFileDropGuard } from "./hooks/useFileDropGuard";
 import { notifyViewPainted, removeStartupSkeleton } from "./utils/removeStartupSkeleton";
-// Attaches the notification E2E backdoor when launched with DAINTREE_E2E_MODE=1.
-// The installer self-gates on `__DAINTREE_E2E_MODE__`, so this is inert in
-// production sessions.
-import { installE2ENotificationBackdoor } from "./lib/e2eNotificationBackdoor";
+// Imported for its module side-effect: the module self-installs the notification
+// E2E backdoor at eval time, gated on `__DAINTREE_E2E_MODE__`, so it is inert in
+// production sessions. No symbol is referenced — the import is load-bearing.
+import "./lib/e2eNotificationBackdoor";
 import { useAppBoot } from "./hooks/app/useAppBoot";
 import { useCrashRecoveryGate } from "./hooks/app/useCrashRecoveryGate";
 import {
@@ -348,46 +348,49 @@ function AppInner() {
   useResourceProfile();
 
   useEffect(() => {
-    window.__DAINTREE_E2E_ERROR_STORE__ = () =>
-      useErrorStore.getState().errors.map((e) => ({
-        id: e.id,
-        source: e.source,
-        message: e.message,
-        fromPreviousSession: e.fromPreviousSession,
-      }));
-    window.__DAINTREE_E2E_ADD_ERROR__ = (message: string) => {
-      useErrorStore.getState().addError({
-        type: "unknown",
-        message,
-        retryability: "none",
-        source: "e2e-test",
-      });
-    };
-    window.__DAINTREE_E2E_CLEAR_ERRORS__ = () => {
-      useErrorStore.getState().reset();
-    };
-    // Refreshes the GitHub config store from the main process. Used by
-    // fault-mode tests to pick up a token seeded via __daintreeSeedGitHubToken
-    // so the no-token empty state doesn't short-circuit IPC fault paths.
-    window.__DAINTREE_E2E_REFRESH_GITHUB_CONFIG__ = () => useGitHubConfigStore.getState().refresh();
-    // Parks a synthetic in-repo recipe stale-write conflict so E2E can exercise
-    // the RecipeConflictDialog without racing a real on-disk file mutation. The
-    // returned promise resolves with the user's choice; tests don't await it —
-    // they assert the dialog renders and that reload/overwrite dismiss it.
-    window.__DAINTREE_E2E_TRIGGER_RECIPE_CONFLICT__ = (recipeName: string) => {
-      void useRecipeConflictStore.getState().requestConflict({
-        recipeId: `inrepo-${recipeName}`,
-        recipeName,
-        updates: { name: recipeName },
-      });
-    };
-
-    // Per-window store accessors for the multi-window isolation spec (#9599).
-    // Each project view is its own V8 context, so these Zustand singletons are
-    // per-window — mutating one window's store must not leak into another's.
-    // Gated on the preload-injected __DAINTREE_E2E_MODE__ flag (set only under
-    // DAINTREE_E2E_MODE=1) so the accessors never attach in production.
+    // All E2E renderer backdoors are gated on the preload-injected
+    // __DAINTREE_E2E_MODE__ flag (set only under DAINTREE_E2E_MODE=1 on
+    // non-packaged builds) so none of these store accessors attach in
+    // production sessions.
     if (window.__DAINTREE_E2E_MODE__ === true) {
+      window.__DAINTREE_E2E_ERROR_STORE__ = () =>
+        useErrorStore.getState().errors.map((e) => ({
+          id: e.id,
+          source: e.source,
+          message: e.message,
+          fromPreviousSession: e.fromPreviousSession,
+        }));
+      window.__DAINTREE_E2E_ADD_ERROR__ = (message: string) => {
+        useErrorStore.getState().addError({
+          type: "unknown",
+          message,
+          retryability: "none",
+          source: "e2e-test",
+        });
+      };
+      window.__DAINTREE_E2E_CLEAR_ERRORS__ = () => {
+        useErrorStore.getState().reset();
+      };
+      // Refreshes the GitHub config store from the main process. Used by
+      // fault-mode tests to pick up a token seeded via __daintreeSeedGitHubToken
+      // so the no-token empty state doesn't short-circuit IPC fault paths.
+      window.__DAINTREE_E2E_REFRESH_GITHUB_CONFIG__ = () =>
+        useGitHubConfigStore.getState().refresh();
+      // Parks a synthetic in-repo recipe stale-write conflict so E2E can exercise
+      // the RecipeConflictDialog without racing a real on-disk file mutation. The
+      // returned promise resolves with the user's choice; tests don't await it —
+      // they assert the dialog renders and that reload/overwrite dismiss it.
+      window.__DAINTREE_E2E_TRIGGER_RECIPE_CONFLICT__ = (recipeName: string) => {
+        void useRecipeConflictStore.getState().requestConflict({
+          recipeId: `inrepo-${recipeName}`,
+          recipeName,
+          updates: { name: recipeName },
+        });
+      };
+
+      // Per-window store accessors for the multi-window isolation spec (#9599).
+      // Each project view is its own V8 context, so these Zustand singletons are
+      // per-window — mutating one window's store must not leak into another's.
       window.__DAINTREE_E2E_DIAGNOSTICS_STATE__ = () => ({
         isOpen: useDiagnosticsStore.getState().isOpen,
       });
@@ -822,7 +825,7 @@ function AppInner() {
             skipDelayDuration={UI_TOOLTIP_SKIP_DELAY_DURATION}
             disableHoverableContent
           >
-            <E2EFaultInjector />
+            {window.__DAINTREE_E2E_MODE__ === true && <E2EFaultInjector />}
             <DndProvider>
               <VoiceRecordingAnnouncer />
               <AccessibilityAnnouncer />
@@ -1527,10 +1530,6 @@ function AppInner() {
 // the cold-start `#startup-skeleton` (a sibling of `#root`) visible during the
 // flight — it's removed by `removeStartupSkeleton()` once hydration completes.
 function App() {
-  useEffect(() => {
-    installE2ENotificationBackdoor();
-  }, []);
-
   // Signal the main process that React has committed its first frame so
   // ProjectViewManager can release the outgoing view of a cold project switch.
   // This lives in the Suspense *parent* (not `AppInner`) so it fires the moment

--- a/src/lib/__tests__/e2eNotificationBackdoor.test.ts
+++ b/src/lib/__tests__/e2eNotificationBackdoor.test.ts
@@ -81,6 +81,23 @@ describe("e2eNotificationBackdoor gate", () => {
     expect(fakeWindow.__daintreeNotificationsE2E).toBeUndefined();
   });
 
+  it.each([
+    ["false", false],
+    ["string 'true'", "true"],
+    ["number 1", 1],
+  ])(
+    "does not attach when __DAINTREE_E2E_MODE__ is %s (not boolean true)",
+    async (_label, mode) => {
+      const fakeWindow: Record<string, unknown> = { __DAINTREE_E2E_MODE__: mode };
+      restore = setWindow(fakeWindow);
+
+      vi.resetModules();
+      await import("../e2eNotificationBackdoor");
+
+      expect(fakeWindow.__daintreeNotificationsE2E).toBeUndefined();
+    }
+  );
+
   it("can attach after the E2E mode flag appears", async () => {
     const fakeWindow: Record<string, unknown> = {};
     restore = setWindow(fakeWindow);

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -2972,10 +2972,13 @@ class TerminalInstanceService {
 
 export const terminalInstanceService = new TerminalInstanceService();
 
-// Expose terminal buffer reader for E2E tests (WebGL renderer has no DOM text).
-// Registered unconditionally but gated at call time — the function is harmless
-// in production and avoids import-time env var timing issues.
-if (typeof window !== "undefined") {
+// Expose terminal introspection/control bridges for E2E tests (the WebGL
+// renderer has no DOM text, so specs read the buffer through these). Gated on
+// the preload-injected __DAINTREE_E2E_MODE__ flag (set only under
+// DAINTREE_E2E_MODE=1 on non-packaged builds), so none of these globals attach
+// in production sessions. The flag is injected via contextBridge before this
+// module evaluates, so the gate is reliable at import time.
+if (typeof window !== "undefined" && window.__DAINTREE_E2E_MODE__ === true) {
   (window as unknown as Record<string, unknown>).__daintreeReadTerminalBuffer = (
     panelId: string
   ): string => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.e2eGate.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.e2eGate.test.ts
@@ -134,4 +134,17 @@ describe("TerminalInstanceService E2E terminal-bridge gate", () => {
       expect(typeof windowProp(name), name).toBe("function");
     }
   });
+
+  it("leaves no __daintree*Terminal* bridge on window in production (guards bridges added outside the gate)", async () => {
+    // Scoped to the terminal-bridge naming convention rather than every
+    // __daintree* key: unrelated modules in the import graph attach their own
+    // (separately gated) E2E globals to the shared jsdom window, so a blanket
+    // scan would false-positive on those. Every bridge in this module's block
+    // contains "Terminal", so this still catches a new one added outside the gate.
+    await importServiceWithMode(undefined);
+    const leaked = Object.getOwnPropertyNames(window).filter((key) =>
+      /^__daintree.*Terminal/.test(key)
+    );
+    expect(leaked).toEqual([]);
+  });
 });

--- a/src/services/terminal/__tests__/TerminalInstanceService.e2eGate.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.e2eGate.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The module attaches a suite of __daintree* terminal introspection bridges to
+// `window` at eval time. They must only attach when the preload has injected
+// `window.__DAINTREE_E2E_MODE__ === true` (E2E, non-packaged builds) and must
+// never attach in production sessions. These mocks let the heavy service module
+// import cleanly under jsdom without exercising the real PTY/WebGL stack.
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    onData: vi.fn(() => vi.fn()),
+    onExit: vi.fn(() => vi.fn()),
+    onTierChanged: vi.fn(() => vi.fn()),
+    setActivityTier: vi.fn(),
+    wake: vi.fn().mockResolvedValue({ state: null }),
+    write: vi.fn(),
+    getSerializedState: vi.fn(),
+    getSharedBuffer: vi.fn(() => null),
+    acknowledgeData: vi.fn(),
+    acknowledgePortData: vi.fn(),
+  },
+  systemClient: { openExternal: vi.fn() },
+  appClient: { getHydrationState: vi.fn() },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(() => ({
+    dispose: vi.fn(),
+    onContextLoss: vi.fn(() => ({ dispose: vi.fn() })),
+  })),
+}));
+
+vi.mock("../TerminalAddonManager", () => ({
+  setupTerminalAddons: vi.fn(() => ({
+    fitAddon: { fit: vi.fn() },
+    serializeAddon: { serialize: vi.fn() },
+    imageAddon: { dispose: vi.fn() },
+    searchAddon: {},
+    fileLinksDisposable: { dispose: vi.fn() },
+    webLinksAddon: { dispose: vi.fn() },
+  })),
+  createImageAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createFileLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createImageLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createWebLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+}));
+
+// Every __daintree* bridge attached at module eval — both the window-cast and
+// the Object.assign call sites — so we assert the whole surface is gated, not
+// just one representative.
+const E2E_TERMINAL_GLOBALS = [
+  "__daintreeReadTerminalBuffer",
+  "__daintreeSelectTerminalAll",
+  "__daintreeGetTerminalBufferLength",
+  "__daintreeGetTerminalDimensions",
+  "__daintreeGetTerminalScrollState",
+  "__daintreeScrollTerminalLines",
+  "__daintreeApplyTerminalTier",
+  "__daintreeSimulateTerminalResize",
+  "__daintreeTriggerTerminalLink",
+  "__daintreeGetTerminalWebGLState",
+  "__daintreePromoteTerminalToAgentForE2E",
+  "__daintreeHibernateTerminalForE2E",
+] as const;
+
+function windowProp(name: string): unknown {
+  return (window as unknown as Record<string, unknown>)[name];
+}
+
+function clearGlobals(): void {
+  for (const name of E2E_TERMINAL_GLOBALS) {
+    delete (window as unknown as Record<string, unknown>)[name];
+  }
+  delete (window as unknown as Record<string, unknown>).__DAINTREE_E2E_MODE__;
+}
+
+async function importServiceWithMode(mode: unknown): Promise<void> {
+  clearGlobals();
+  if (mode !== undefined) {
+    (window as unknown as Record<string, unknown>).__DAINTREE_E2E_MODE__ = mode;
+  }
+  vi.resetModules();
+  await import("../TerminalInstanceService");
+}
+
+describe("TerminalInstanceService E2E terminal-bridge gate", () => {
+  beforeEach(() => {
+    (window as unknown as Record<string, unknown>).electron = {
+      terminal: {
+        reportTitleState: vi.fn(),
+        updateObservedTitle: vi.fn(),
+      },
+      clipboard: {
+        writeSelection: vi.fn().mockResolvedValue(undefined),
+        readSelection: vi.fn().mockResolvedValue({ text: "" }),
+      },
+    };
+  });
+
+  afterEach(() => {
+    clearGlobals();
+    vi.resetModules();
+  });
+
+  it("does not attach any terminal bridge when __DAINTREE_E2E_MODE__ is absent", async () => {
+    await importServiceWithMode(undefined);
+    for (const name of E2E_TERMINAL_GLOBALS) {
+      expect(windowProp(name), name).toBeUndefined();
+    }
+  });
+
+  it("does not attach when __DAINTREE_E2E_MODE__ is false", async () => {
+    await importServiceWithMode(false);
+    for (const name of E2E_TERMINAL_GLOBALS) {
+      expect(windowProp(name), name).toBeUndefined();
+    }
+  });
+
+  it("rejects truthy-but-not-true values (e.g. string 'true')", async () => {
+    await importServiceWithMode("true");
+    for (const name of E2E_TERMINAL_GLOBALS) {
+      expect(windowProp(name), name).toBeUndefined();
+    }
+  });
+
+  it("attaches every terminal bridge as a function when __DAINTREE_E2E_MODE__ is true", async () => {
+    await importServiceWithMode(true);
+    for (const name of E2E_TERMINAL_GLOBALS) {
+      expect(typeof windowProp(name), name).toBe("function");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- E2E test backdoors in the renderer were attaching unconditionally in every session, including production. This gates them all behind the existing `window.__DAINTREE_E2E_MODE__` flag, matching the pattern already used in `e2eNotificationBackdoor.ts`.
- Affected surfaces: store-mutating globals in `App.tsx`, the `E2EFaultInjector` mount, and ~12 module-level terminal globals in `TerminalInstanceService.ts` (including `__daintreeReadTerminalBuffer`, which exposes full terminal scrollback).
- Also removes a dead `installE2ENotificationBackdoor()` effect call in `App.tsx` — the module self-installs at import time.

Resolves #9915

## Changes

- `src/App.tsx` — five store-mutating globals (`__DAINTREE_E2E_ERROR_STORE__`, `__DAINTREE_E2E_ADD_ERROR__`, `__DAINTREE_E2E_CLEAR_ERRORS__`, `__DAINTREE_E2E_REFRESH_GITHUB_CONFIG__`, `__DAINTREE_E2E_TRIGGER_RECIPE_CONFLICT__`) moved inside the `__DAINTREE_E2E_MODE__` gate; `E2EFaultInjector` mount gated the same way; dead `installE2ENotificationBackdoor()` effect removed.
- `src/services/terminal/TerminalInstanceService.ts` — ~12 module-level window globals gated behind `__DAINTREE_E2E_MODE__ === true`.
- New `TerminalInstanceService.e2eGate.test.ts` — covers gate-on / gate-off for the terminal globals.
- `e2eNotificationBackdoor.test.ts` — extended with negative cases for `false`, `'true'`, and `1` to confirm the gate is strict.

## Testing

E2E specs are unaffected — `e2e/helpers/launch.ts` always sets `DAINTREE_E2E_MODE=1`, so all seven consuming specs still receive the globals. `npm run check` passes (typecheck, lint, format, IPC/channel/confirm-wiring guards). 34 relevant unit tests pass.