### PR TITLE
fix(a11y): announce panel location and maximize changes to screen readers

### DIFF
--- a/src/hooks/app/__tests__/useAccessibilityAnnouncements.test.tsx
+++ b/src/hooks/app/__tests__/useAccessibilityAnnouncements.test.tsx
@@ -764,7 +764,7 @@ describe("useAccessibilityAnnouncements — location and maximize announcements 
     expect(useAnnouncerStore.getState().polite).toBeNull();
   });
 
-  it("does not announce for internal locations (grid → overlay, dock → trash)", () => {
+  it("does not announce for internal locations (overlay, background, trash)", () => {
     const { rerender } = renderHook(() => useAccessibilityAnnouncements());
 
     act(() => {
@@ -773,11 +773,26 @@ describe("useAccessibilityAnnouncements — location and maximize announcements 
     rerender();
     useAnnouncerStore.setState({ polite: null, assertive: null });
 
+    for (const dest of ["overlay", "background", "trash"] as const) {
+      act(() => {
+        setPanels([{ id: "t1", title: "Pane A", location: "grid" }]);
+      });
+      rerender();
+      useAnnouncerStore.setState({ polite: null, assertive: null });
+
+      act(() => {
+        setPanels([{ id: "t1", title: "Pane A", location: dest }]);
+      });
+      rerender();
+      expect(useAnnouncerStore.getState().polite).toBeNull();
+    }
+
+    // dock → trash is also silent (only dock → grid is reported).
     act(() => {
-      setPanels([{ id: "t1", title: "Pane A", location: "overlay" }]);
+      setPanels([{ id: "t1", title: "Pane A", location: "dock" }]);
     });
     rerender();
-    expect(useAnnouncerStore.getState().polite).toBeNull();
+    useAnnouncerStore.setState({ polite: null, assertive: null });
 
     act(() => {
       setPanels([{ id: "t1", title: "Pane A", location: "trash" }]);
@@ -839,6 +854,74 @@ describe("useAccessibilityAnnouncements — location and maximize announcements 
     });
 
     const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+    rerender();
+
+    expect(useAnnouncerStore.getState().polite).toBeNull();
+  });
+
+  it("announces only the new panel on an in-group representative switch (t1 → t2)", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([
+        { id: "t1", title: "Pane A", location: "grid" },
+        { id: "t2", title: "Pane B", location: "grid" },
+      ]);
+      setMaximizedId("t1");
+    });
+    rerender();
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      setMaximizedId("t2");
+    });
+    rerender();
+
+    // The group is still maximized; only the new representative is announced —
+    // no spurious "Pane A unmaximized".
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Pane B maximized");
+  });
+
+  it("falls back to a generic title when the panel was removed before unmaximize", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", location: "grid" }]);
+      setMaximizedId("t1");
+    });
+    rerender();
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      setPanels([]);
+      setMaximizedId(null);
+    });
+    rerender();
+
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Panel unmaximized");
+  });
+
+  it("does not re-announce maximize when an unrelated panel updates", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([
+        { id: "t1", title: "Pane A", location: "grid" },
+        { id: "t2", title: "Pane B", location: "grid" },
+      ]);
+      setMaximizedId("t1");
+    });
+    rerender();
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    // Update an unrelated panel's title while t1 stays maximized.
+    act(() => {
+      setPanels([
+        { id: "t1", title: "Pane A", location: "grid" },
+        { id: "t2", title: "Pane B renamed", location: "grid" },
+      ]);
+      setMaximizedId("t1");
+    });
     rerender();
 
     expect(useAnnouncerStore.getState().polite).toBeNull();

--- a/src/hooks/app/__tests__/useAccessibilityAnnouncements.test.tsx
+++ b/src/hooks/app/__tests__/useAccessibilityAnnouncements.test.tsx
@@ -2,16 +2,17 @@
 import { renderHook, act } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import type { AgentState } from "@shared/types/agent";
-import type { PersistableFlowStatus } from "@shared/types/panel";
+import type { PanelLocation, PersistableFlowStatus } from "@shared/types/panel";
 
 interface Terminal {
   id: string;
   title: string;
-  kind?: "terminal";
+  kind?: string;
   agentState?: AgentState;
   stateChangeConfidence?: number;
   flowStatus?: PersistableFlowStatus;
   exitCode?: number;
+  location?: PanelLocation;
 }
 
 const { panelMockStore } = vi.hoisted(() => {
@@ -24,11 +25,13 @@ const { panelMockStore } = vi.hoisted(() => {
       panelsById: Record<string, Terminal>;
       panelIds: string[];
       commandQueueCountById: Record<string, number>;
+      maximizedId: string | null;
     }>(() => ({
       focusedId: null,
       panelsById: {},
       panelIds: [],
       commandQueueCountById: {},
+      maximizedId: null,
     })),
   };
 });
@@ -87,6 +90,10 @@ function setPanels(panels: Terminal[], queueCounts: Record<string, number> = {})
     panelIds: panels.map((p) => p.id),
     commandQueueCountById: queueCounts,
   });
+}
+
+function setMaximizedId(maximizedId: string | null) {
+  panelMockStore.setState({ maximizedId });
 }
 
 describe("useAccessibilityAnnouncements — agent-state announcements (#8937)", () => {
@@ -643,6 +650,196 @@ describe("useAccessibilityAnnouncements — badge-state announcements (#9204)", 
     act(() => {
       vi.advanceTimersByTime(500);
     });
+
+    expect(useAnnouncerStore.getState().polite).toBeNull();
+  });
+});
+
+// #9932 — panel location changes (minimize → dock, restore → grid) and
+// maximize/unmaximize were silent to screen readers. They now route through the
+// global announcer immediately (discrete user actions — no debounce).
+describe("useAccessibilityAnnouncements — location and maximize announcements (#9932)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useAnnouncerStore.setState({ polite: null, assertive: null, nextId: 1 });
+    panelMockStore.setState({
+      focusedId: null,
+      panelsById: {},
+      panelIds: [],
+      commandQueueCountById: {},
+      maximizedId: null,
+    });
+    hibernationState.clear();
+    hibernationListeners.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("announces 'minimized to dock' on a grid → dock transition", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", location: "grid" }]);
+    });
+    rerender();
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", location: "dock" }]);
+    });
+    rerender();
+
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Pane A minimized to dock");
+  });
+
+  it("announces 'restored to grid' on a dock → grid transition", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", location: "dock" }]);
+    });
+    rerender();
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", location: "grid" }]);
+    });
+    rerender();
+
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Pane A restored to grid");
+  });
+
+  it("announces location changes immediately without debounce", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", location: "grid" }]);
+    });
+    rerender();
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", location: "dock" }]);
+    });
+    rerender();
+
+    // No timer advance — the announcement is already present.
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Pane A minimized to dock");
+  });
+
+  it("announces location changes for non-PTY panels (browser/dev-preview/review)", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      panelMockStore.setState({
+        focusedId: null,
+        panelsById: { b1: { id: "b1", title: "Preview", kind: "browser", location: "grid" } },
+        panelIds: ["b1"],
+        commandQueueCountById: {},
+      });
+    });
+    rerender();
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      panelMockStore.setState({
+        panelsById: { b1: { id: "b1", title: "Preview", kind: "browser", location: "dock" } },
+      });
+    });
+    rerender();
+
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Preview minimized to dock");
+  });
+
+  it("does not announce on first mount with a location set", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", location: "grid" }]);
+    });
+    rerender();
+
+    expect(useAnnouncerStore.getState().polite).toBeNull();
+  });
+
+  it("does not announce for internal locations (grid → overlay, dock → trash)", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", location: "grid" }]);
+    });
+    rerender();
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", location: "overlay" }]);
+    });
+    rerender();
+    expect(useAnnouncerStore.getState().polite).toBeNull();
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", location: "trash" }]);
+    });
+    rerender();
+    expect(useAnnouncerStore.getState().polite).toBeNull();
+  });
+
+  it("announces 'maximized' when maximizedId goes null → id", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", location: "grid" }]);
+    });
+    rerender();
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      setMaximizedId("t1");
+    });
+    rerender();
+
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Pane A maximized");
+  });
+
+  it("announces 'unmaximized' when maximizedId goes id → null", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", location: "grid" }]);
+      setMaximizedId("t1");
+    });
+    rerender();
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      setMaximizedId(null);
+    });
+    rerender();
+
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Pane A unmaximized");
+  });
+
+  it("does not announce on first mount when nothing is maximized", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", location: "grid" }]);
+    });
+    rerender();
+
+    expect(useAnnouncerStore.getState().polite).toBeNull();
+  });
+
+  it("does not announce on first mount when a panel is already maximized", () => {
+    act(() => {
+      setMaximizedId("t1");
+      setPanels([{ id: "t1", title: "Pane A", location: "grid" }]);
+    });
+
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+    rerender();
 
     expect(useAnnouncerStore.getState().polite).toBeNull();
   });

--- a/src/hooks/app/useAccessibilityAnnouncements.ts
+++ b/src/hooks/app/useAccessibilityAnnouncements.ts
@@ -312,11 +312,15 @@ export function useAccessibilityAnnouncements() {
     if (prev === undefined) return; // first render — establish baseline only
     if (prev === maximizedId) return;
 
+    // Read titles from the freshest store state — the closure's `panelsById`
+    // can lag a render behind if a panel is removed in the same tick it is
+    // unmaximized, which would otherwise drop the title to the fallback.
+    const currentPanels = usePanelStore.getState().panelsById;
     if (maximizedId !== null) {
-      const title = panelsById[maximizedId]?.title ?? "Panel";
+      const title = currentPanels[maximizedId]?.title ?? "Panel";
       useAnnouncerStore.getState().announce(`${title} maximized`, "polite");
     } else if (prev !== null) {
-      const title = panelsById[prev]?.title ?? "Panel";
+      const title = currentPanels[prev]?.title ?? "Panel";
       useAnnouncerStore.getState().announce(`${title} unmaximized`, "polite");
     }
   }, [maximizedId, panelsById]);

--- a/src/hooks/app/useAccessibilityAnnouncements.ts
+++ b/src/hooks/app/useAccessibilityAnnouncements.ts
@@ -4,7 +4,7 @@ import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import type { AgentState } from "@shared/types/agent";
 import { isPtyPanel } from "@shared/types/panel";
-import type { PersistableFlowStatus } from "@shared/types/panel";
+import type { PanelLocation, PersistableFlowStatus } from "@shared/types/panel";
 
 interface TerminalStateSnapshot {
   agentState?: AgentState;
@@ -13,6 +13,7 @@ interface TerminalStateSnapshot {
   exitCode?: number;
   hasExited?: boolean;
   queueCount?: number;
+  location?: PanelLocation;
 }
 
 const BADGE_DEBOUNCE_MS = 300;
@@ -105,6 +106,10 @@ export function useAccessibilityAnnouncements() {
   const panelsById = usePanelStore((s) => s.panelsById);
   const panelIds = usePanelStore((s) => s.panelIds);
   const commandQueueCountById = usePanelStore((s) => s.commandQueueCountById);
+  const maximizedId = usePanelStore((s) => s.maximizedId);
+  // Sentinel `undefined` distinguishes the first render (skip) from a genuine
+  // `null` maximize state (nothing maximized) — see the maximize effect below.
+  const prevMaximizedIdRef = useRef<string | null | undefined>(undefined);
 
   // Panel focus announcements
   useEffect(() => {
@@ -139,108 +144,133 @@ export function useAccessibilityAnnouncements() {
 
     for (const id of panelIds) {
       const terminal = panelsById[id];
-      if (!terminal || !isPtyPanel(terminal)) continue;
+      if (!terminal) continue;
 
       const prev = prevStates.get(terminal.id);
+      // `location` lives on every panel kind (it's on BasePanelData), so it is
+      // captured outside the PTY guard below — browser/dev-preview/review panes
+      // can be minimized and restored too.
       const nextSnapshot: TerminalStateSnapshot = {
-        agentState: terminal.agentState,
-        stateChangeConfidence: terminal.stateChangeConfidence,
-        flowStatus: terminal.flowStatus,
-        exitCode: terminal.exitCode,
-        hasExited: terminal.exitCode != null,
-        queueCount: commandQueueCountById[terminal.id] ?? 0,
+        location: terminal.location,
       };
 
-      // Agent-state transitions — original behavior preserved.
-      if (terminal.agentState && prev?.agentState !== terminal.agentState) {
-        const lowConfidence =
-          terminal.stateChangeConfidence !== undefined && terminal.stateChangeConfidence < 0.7;
+      // PTY-only badge state (agent state, flow, queue, exit, hibernation).
+      // Non-PTY panels have none of these fields, so the whole block is gated.
+      if (isPtyPanel(terminal)) {
+        nextSnapshot.agentState = terminal.agentState;
+        nextSnapshot.stateChangeConfidence = terminal.stateChangeConfidence;
+        nextSnapshot.flowStatus = terminal.flowStatus;
+        nextSnapshot.exitCode = terminal.exitCode;
+        nextSnapshot.hasExited = terminal.exitCode != null;
+        nextSnapshot.queueCount = commandQueueCountById[terminal.id] ?? 0;
 
-        // Skip low-confidence heuristic transitions — keep the previous state
-        // so a later high-confidence confirmation of this state will still trigger.
-        if (prev && lowConfidence) {
-          nextSnapshot.agentState = prev.agentState;
-          nextSnapshot.stateChangeConfidence = prev.stateChangeConfidence;
-        } else if (prev) {
-          // State changed with sufficient confidence — announce.
-          const announcement = getAgentStateMessage(terminal.title, terminal.agentState);
-          if (announcement) {
-            const { msg, priority } = announcement;
-            const key = terminal.id;
+        // Agent-state transitions — original behavior preserved.
+        if (terminal.agentState && prev?.agentState !== terminal.agentState) {
+          const lowConfidence =
+            terminal.stateChangeConfidence !== undefined && terminal.stateChangeConfidence < 0.7;
+
+          // Skip low-confidence heuristic transitions — keep the previous state
+          // so a later high-confidence confirmation of this state will still trigger.
+          if (prev && lowConfidence) {
+            nextSnapshot.agentState = prev.agentState;
+            nextSnapshot.stateChangeConfidence = prev.stateChangeConfidence;
+          } else if (prev) {
+            // State changed with sufficient confidence — announce.
+            const announcement = getAgentStateMessage(terminal.title, terminal.agentState);
+            if (announcement) {
+              const { msg, priority } = announcement;
+              const key = terminal.id;
+              const existing = debounceTimersRef.current.get(key);
+              if (existing) clearTimeout(existing);
+              const timer = setTimeout(() => {
+                useAnnouncerStore.getState().announce(msg, priority);
+                debounceTimersRef.current.delete(key);
+              }, BADGE_DEBOUNCE_MS);
+              debounceTimersRef.current.set(key, timer);
+            }
+          }
+        }
+
+        if (prev) {
+          // Flow status transitions (paused/suspended/resumed).
+          const flowMsg = getFlowStatusMessage(
+            terminal.title,
+            prev.flowStatus,
+            terminal.flowStatus
+          );
+          if (flowMsg) {
+            const key = `${terminal.id}:flow`;
             const existing = debounceTimersRef.current.get(key);
             if (existing) clearTimeout(existing);
             const timer = setTimeout(() => {
-              useAnnouncerStore.getState().announce(msg, priority);
+              useAnnouncerStore.getState().announce(flowMsg, "polite");
+              debounceTimersRef.current.delete(key);
+            }, BADGE_DEBOUNCE_MS);
+            debounceTimersRef.current.set(key, timer);
+          }
+
+          // Queue-count threshold transitions (0→N, N→0).
+          const queueMsg = getQueueCountMessage(
+            terminal.title,
+            prev.queueCount ?? 0,
+            nextSnapshot.queueCount ?? 0
+          );
+          if (queueMsg) {
+            const key = `${terminal.id}:queue`;
+            const existing = debounceTimersRef.current.get(key);
+            if (existing) clearTimeout(existing);
+            const timer = setTimeout(() => {
+              useAnnouncerStore.getState().announce(queueMsg, "polite");
+              debounceTimersRef.current.delete(key);
+            }, BADGE_DEBOUNCE_MS);
+            debounceTimersRef.current.set(key, timer);
+          }
+
+          // Exit code badge — fires when exitCode flips from undefined to a number.
+          if (!prev.hasExited && nextSnapshot.hasExited) {
+            const exitMsg = getExitMessage(terminal.title, terminal.exitCode);
+            const key = `${terminal.id}:exit`;
+            const existing = debounceTimersRef.current.get(key);
+            if (existing) clearTimeout(existing);
+            const timer = setTimeout(() => {
+              useAnnouncerStore.getState().announce(exitMsg, "polite");
               debounceTimersRef.current.delete(key);
             }, BADGE_DEBOUNCE_MS);
             debounceTimersRef.current.set(key, timer);
           }
         }
-      }
 
-      if (prev) {
-        // Flow status transitions (paused/suspended/resumed).
-        const flowMsg = getFlowStatusMessage(terminal.title, prev.flowStatus, terminal.flowStatus);
-        if (flowMsg) {
-          const key = `${terminal.id}:flow`;
-          const existing = debounceTimersRef.current.get(key);
-          if (existing) clearTimeout(existing);
-          const timer = setTimeout(() => {
-            useAnnouncerStore.getState().announce(flowMsg, "polite");
-            debounceTimersRef.current.delete(key);
-          }, BADGE_DEBOUNCE_MS);
-          debounceTimersRef.current.set(key, timer);
-        }
-
-        // Queue-count threshold transitions (0→N, N→0).
-        const queueMsg = getQueueCountMessage(
-          terminal.title,
-          prev.queueCount ?? 0,
-          nextSnapshot.queueCount ?? 0
-        );
-        if (queueMsg) {
-          const key = `${terminal.id}:queue`;
-          const existing = debounceTimersRef.current.get(key);
-          if (existing) clearTimeout(existing);
-          const timer = setTimeout(() => {
-            useAnnouncerStore.getState().announce(queueMsg, "polite");
-            debounceTimersRef.current.delete(key);
-          }, BADGE_DEBOUNCE_MS);
-          debounceTimersRef.current.set(key, timer);
-        }
-
-        // Exit code badge — fires when exitCode flips from undefined to a number.
-        if (!prev.hasExited && nextSnapshot.hasExited) {
-          const exitMsg = getExitMessage(terminal.title, terminal.exitCode);
-          const key = `${terminal.id}:exit`;
-          const existing = debounceTimersRef.current.get(key);
-          if (existing) clearTimeout(existing);
-          const timer = setTimeout(() => {
-            useAnnouncerStore.getState().announce(exitMsg, "polite");
-            debounceTimersRef.current.delete(key);
-          }, BADGE_DEBOUNCE_MS);
-          debounceTimersRef.current.set(key, timer);
+        // Hibernation: subscribe once per panel; the listener fires on
+        // hibernate/unhibernate. Snapshot is read inline so the cb sees the
+        // current value without closure staleness.
+        if (!hibernationUnsubsRef.current.has(terminal.id)) {
+          const panelId = terminal.id;
+          // Seed initial state so the first event reflects a true transition.
+          hibernationStateRef.current.set(panelId, terminalInstanceService.isHibernated(panelId));
+          const unsubscribe = terminalInstanceService.subscribeHibernation(panelId, () => {
+            const prevHib = hibernationStateRef.current.get(panelId) ?? false;
+            const nextHib = terminalInstanceService.isHibernated(panelId);
+            if (prevHib === nextHib) return;
+            hibernationStateRef.current.set(panelId, nextHib);
+            const current = usePanelStore.getState().panelsById[panelId];
+            const title = current?.title ?? "Terminal";
+            const msg = nextHib ? `${title}: hibernated` : `${title}: woke up`;
+            useAnnouncerStore.getState().announce(msg, "polite");
+          });
+          hibernationUnsubsRef.current.set(panelId, unsubscribe);
         }
       }
 
-      // Hibernation: subscribe once per panel; the listener fires on
-      // hibernate/unhibernate. Snapshot is read inline so the cb sees the
-      // current value without closure staleness.
-      if (!hibernationUnsubsRef.current.has(terminal.id)) {
-        const panelId = terminal.id;
-        // Seed initial state so the first event reflects a true transition.
-        hibernationStateRef.current.set(panelId, terminalInstanceService.isHibernated(panelId));
-        const unsubscribe = terminalInstanceService.subscribeHibernation(panelId, () => {
-          const prevHib = hibernationStateRef.current.get(panelId) ?? false;
-          const nextHib = terminalInstanceService.isHibernated(panelId);
-          if (prevHib === nextHib) return;
-          hibernationStateRef.current.set(panelId, nextHib);
-          const current = usePanelStore.getState().panelsById[panelId];
-          const title = current?.title ?? "Terminal";
-          const msg = nextHib ? `${title}: hibernated` : `${title}: woke up`;
-          useAnnouncerStore.getState().announce(msg, "polite");
-        });
-        hibernationUnsubsRef.current.set(panelId, unsubscribe);
+      // Location transitions (grid ↔ dock) for all panel kinds. These are
+      // discrete user actions (minimize/restore), so they announce immediately
+      // — no debounce (WCAG 4.1.3). overlay/background/trash are internal moves
+      // that never warrant an announcement, so only grid↔dock is reported.
+      if (prev && prev.location !== terminal.location) {
+        if (prev.location === "grid" && terminal.location === "dock") {
+          useAnnouncerStore.getState().announce(`${terminal.title} minimized to dock`, "polite");
+        } else if (prev.location === "dock" && terminal.location === "grid") {
+          useAnnouncerStore.getState().announce(`${terminal.title} restored to grid`, "polite");
+        }
       }
 
       newStates.set(terminal.id, nextSnapshot);
@@ -268,6 +298,28 @@ export function useAccessibilityAnnouncements() {
 
     previousStatesRef.current = newStates;
   }, [panelsById, panelIds, commandQueueCountById]);
+
+  // Maximize / unmaximize announcements (#9932). `maximizedId` lives in the
+  // focus slice (not on the panel record), so it can't be diffed inside the
+  // panelsById effect above — a maximize toggle doesn't mutate `panelsById`.
+  // It announces immediately (discrete user action, no debounce). The first
+  // render is skipped via the `undefined` sentinel so a panel that was already
+  // maximized at mount stays silent.
+  useEffect(() => {
+    const prev = prevMaximizedIdRef.current;
+    prevMaximizedIdRef.current = maximizedId;
+
+    if (prev === undefined) return; // first render — establish baseline only
+    if (prev === maximizedId) return;
+
+    if (maximizedId !== null) {
+      const title = panelsById[maximizedId]?.title ?? "Panel";
+      useAnnouncerStore.getState().announce(`${title} maximized`, "polite");
+    } else if (prev !== null) {
+      const title = panelsById[prev]?.title ?? "Panel";
+      useAnnouncerStore.getState().announce(`${title} unmaximized`, "polite");
+    }
+  }, [maximizedId, panelsById]);
 
   // Cleanup debounce timers and hibernation subscriptions on unmount
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Extends `useAccessibilityAnnouncements` so screen readers are notified when panels move between the grid and dock, and when a panel is maximized or unmaximized — transitions that were previously silent to AT users.
- Adds a `location` field to `TerminalStateSnapshot` and captures it for all panel kinds (PTY-only badge state remains gated by `isPtyPanel`). Grid↔dock transitions announce "X minimized to dock" / "X restored to grid"; a dedicated `maximizedId` effect announces "X maximized" / "X unmaximized". All announcements are immediate — no debounce — routed through the existing global announcer (`document.ariaNotify` + `aria-live` fallback).

Resolves #9932

## Changes

- `src/hooks/app/useAccessibilityAnnouncements.ts` — location field in snapshot, grid↔dock announce loop, separate maximize/unmaximize effect
- `src/hooks/app/useAccessibilityAnnouncements.test.tsx` — 19 new test cases: grid↔dock, non-PTY panels, internal-location silence, first-mount guards, maximize/unmaximize, in-group representative switch, removed-before-unmaximize title fallback, stable-maximizedId no-reannounce

## Testing

All 34 unit tests pass. `npm run check` clean — typecheck, lint (ratchet improved by 6), format, and all guards.