### PR TITLE
fix(github): fix token-expiry double-notify and banner reconnect routing

### DIFF
--- a/src/components/Recovery/GitHubTokenBanner.tsx
+++ b/src/components/Recovery/GitHubTokenBanner.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle } from "lucide-react";
 import { useGitHubTokenHealthStore } from "@/store/githubTokenHealthStore";
+import { actionService } from "@/services/ActionService";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
 
@@ -9,10 +10,14 @@ export function GitHubTokenBanner() {
   if (!isUnhealthy) return null;
 
   const handleReconnect = () => {
-    window.dispatchEvent(
-      new CustomEvent("daintree:open-settings-tab", {
-        detail: { tab: "code-forge", subtab: BUILTIN_GITHUB_PROVIDER_ID },
-      })
+    // Route through the action service with `sectionId` so the user lands on
+    // the token field, not the top of the Code Forge tab — matches every other
+    // recovery entry point (e.g. `useGitHubTokenExpiryNotification`). Use the
+    // canonical provider id for `subtab` to match the standardized forge routing.
+    void actionService.dispatch(
+      "app.settings.openTab",
+      { tab: "code-forge", subtab: BUILTIN_GITHUB_PROVIDER_ID, sectionId: "github-token" },
+      { source: "user" }
     );
   };
 

--- a/src/components/Recovery/__tests__/GitHubTokenBanner.test.tsx
+++ b/src/components/Recovery/__tests__/GitHubTokenBanner.test.tsx
@@ -1,8 +1,17 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch: vi.fn(),
+  },
+}));
+
 import { GitHubTokenBanner } from "../GitHubTokenBanner";
 import { useGitHubTokenHealthStore } from "@/store/githubTokenHealthStore";
+import { actionService } from "@/services/ActionService";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
 
 beforeAll(() => {
   Object.defineProperty(window, "matchMedia", {
@@ -23,6 +32,7 @@ beforeAll(() => {
 describe("GitHubTokenBanner", () => {
   beforeEach(() => {
     useGitHubTokenHealthStore.setState({ isUnhealthy: false });
+    vi.mocked(actionService.dispatch).mockClear();
     cleanup();
   });
 
@@ -41,19 +51,18 @@ describe("GitHubTokenBanner", () => {
     expect(screen.getByRole("button", { name: /Reconnect to GitHub/i })).toBeTruthy();
   });
 
-  it("dispatches open-settings-tab event when reconnect clicked", () => {
+  it("routes reconnect through the settings action with the token sectionId", () => {
     useGitHubTokenHealthStore.setState({ isUnhealthy: true });
-    const listener = vi.fn();
-    window.addEventListener("daintree:open-settings-tab", listener as EventListener);
 
     render(<GitHubTokenBanner />);
     fireEvent.click(screen.getByRole("button", { name: /Reconnect to GitHub/i }));
 
-    expect(listener).toHaveBeenCalledOnce();
-    const event = listener.mock.calls[0]![0] as CustomEvent<{ tab: string }>;
-    expect(event.detail.tab).toBe("code-forge");
-
-    window.removeEventListener("daintree:open-settings-tab", listener as EventListener);
+    expect(actionService.dispatch).toHaveBeenCalledOnce();
+    expect(actionService.dispatch).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "code-forge", subtab: BUILTIN_GITHUB_PROVIDER_ID, sectionId: "github-token" },
+      { source: "user" }
+    );
   });
 
   it("hides automatically when store transitions back to healthy", () => {

--- a/src/components/Recovery/__tests__/GitHubTokenBanner.test.tsx
+++ b/src/components/Recovery/__tests__/GitHubTokenBanner.test.tsx
@@ -53,6 +53,7 @@ describe("GitHubTokenBanner", () => {
 
   it("routes reconnect through the settings action with the token sectionId", () => {
     useGitHubTokenHealthStore.setState({ isUnhealthy: true });
+    const dispatchEventSpy = vi.spyOn(window, "dispatchEvent");
 
     render(<GitHubTokenBanner />);
     fireEvent.click(screen.getByRole("button", { name: /Reconnect to GitHub/i }));
@@ -63,6 +64,12 @@ describe("GitHubTokenBanner", () => {
       { tab: "code-forge", subtab: BUILTIN_GITHUB_PROVIDER_ID, sectionId: "github-token" },
       { source: "user" }
     );
+    // The legacy raw CustomEvent path must be gone — no settings event fired.
+    expect(
+      dispatchEventSpy.mock.calls.some(([event]) => event.type === "daintree:open-settings-tab")
+    ).toBe(false);
+
+    dispatchEventSpy.mockRestore();
   });
 
   it("hides automatically when store transitions back to healthy", () => {

--- a/src/hooks/__tests__/useGitHubTokenHealth.test.ts
+++ b/src/hooks/__tests__/useGitHubTokenHealth.test.ts
@@ -25,8 +25,10 @@ vi.mock("@/clients/githubClient", () => ({
 }));
 
 import { useGitHubTokenHealth } from "../useGitHubTokenHealth";
+import { notify, _resetRateLimitBuckets, _resetCoalesceMap } from "@/lib/notify";
 import { useGitHubTokenHealthStore } from "@/store/githubTokenHealthStore";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
+import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
 
 describe("useGitHubTokenHealth", () => {
   beforeEach(() => {
@@ -38,6 +40,12 @@ describe("useGitHubTokenHealth", () => {
       .mockResolvedValue({ status: "unknown", tokenVersion: 0, checkedAt: 0 });
     useGitHubTokenHealthStore.setState({ isUnhealthy: false });
     useNotificationHistoryStore.setState({ entries: [], unreadCount: 0 });
+    // notify() runs for real here — keep toasts enabled (so a re-promotion
+    // regression would actually mark `seenAsToast`) and clear cross-test
+    // rate-limit / coalesce state.
+    useNotificationSettingsStore.setState({ enabled: true });
+    _resetRateLimitBuckets();
+    _resetCoalesceMap();
   });
 
   it("subscribes on mount and cleans up on unmount", () => {
@@ -79,11 +87,11 @@ describe("useGitHubTokenHealth", () => {
     act(() => healthListener?.({ status: "unhealthy", tokenVersion: 0, checkedAt: 0 }));
 
     const entries = useNotificationHistoryStore.getState().entries;
-    const healthEntries = entries.filter((e) => e.correlationId === "github-token-health");
+    const healthEntries = entries.filter((e) => e.supersedeKey === "github.token");
     expect(healthEntries).toHaveLength(1);
   });
 
-  it("shares the github.token supersedeKey so the expiry-notification row can archive it", async () => {
+  it("writes an inbox-only backstop row that does not toast or count", async () => {
     renderHook(() => useGitHubTokenHealth());
     await act(async () => {});
 
@@ -91,22 +99,27 @@ describe("useGitHubTokenHealth", () => {
 
     const entry = useNotificationHistoryStore
       .getState()
-      .entries.find((e) => e.correlationId === "github-token-health");
+      .entries.find((e) => e.supersedeKey === "github.token");
     expect(entry?.supersedeKey).toBe("github.token");
-    // Inbox-only backstop: must not surface as a toast.
+    // Inbox-only backstop: must not surface as a toast, must not bump the badge.
     expect(entry?.seenAsToast).toBe(false);
+    expect(entry?.countable).toBe(false);
+    expect(useNotificationHistoryStore.getState().unreadCount).toBe(0);
   });
 
-  it("keeps a single active row when a later github.token write supersedes the backstop", async () => {
+  it("keeps a single active row when the toolbar's notify() supersedes the backstop", async () => {
     renderHook(() => useGitHubTokenHealth());
     await act(async () => {});
 
     act(() => healthListener?.({ status: "unhealthy", tokenVersion: 0, checkedAt: 0 }));
 
-    // Simulate the toolbar's expiry-notification path writing under the same key.
+    // Drive the toolbar's expiry-notification path through the real notify()
+    // so this exercises supersedeKey forwarding end-to-end, not a hand-rolled
+    // addEntry that could mask a notify() regression.
     act(() => {
-      useNotificationHistoryStore.getState().addEntry({
+      notify({
         type: "warning",
+        priority: "high",
         title: "GitHub authentication required",
         message: "Reconnect in settings.",
         correlationId: "github:token-expiry",
@@ -121,6 +134,56 @@ describe("useGitHubTokenHealth", () => {
     expect(active[0]?.correlationId).toBe("github:token-expiry");
   });
 
+  it("does not re-promote the backstop into a toast on a second expiry cycle", async () => {
+    renderHook(() => useGitHubTokenHealth());
+    await act(async () => {});
+
+    // First cycle: backstop fires, then the toolbar path archives it.
+    act(() => healthListener?.({ status: "unhealthy", tokenVersion: 0, checkedAt: 0 }));
+    act(() => {
+      notify({
+        type: "warning",
+        priority: "high",
+        title: "GitHub authentication required",
+        message: "Reconnect in settings.",
+        correlationId: "github:token-expiry",
+        supersedeKey: "github.token",
+      });
+    });
+    act(() => healthListener?.({ status: "healthy", tokenVersion: 0, checkedAt: 0 }));
+
+    // Second expiry: the backstop must stay inbox-only — no un-snooze re-toast.
+    act(() => healthListener?.({ status: "unhealthy", tokenVersion: 0, checkedAt: 0 }));
+
+    // Inspect the freshly written, still-active backstop row. (Superseded rows
+    // get `seenAsToast: true` flipped on archival — that's the resolved state,
+    // not a toast — so the active row is the one that reflects re-promotion.)
+    const active = useNotificationHistoryStore
+      .getState()
+      .entries.find(
+        (e) =>
+          e.supersedeKey === "github.token" && e.title === "GitHub token expired" && !e.archivedAt
+      );
+    expect(active).toBeDefined();
+    expect(active?.seenAsToast).toBe(false);
+  });
+
+  it("writes the backstop row on an unhealthy initial replay (no live push)", async () => {
+    getTokenHealthMock.mockResolvedValueOnce({
+      status: "unhealthy",
+      tokenVersion: 0,
+      checkedAt: 0,
+    });
+    renderHook(() => useGitHubTokenHealth());
+    await act(async () => {});
+
+    const backstops = useNotificationHistoryStore
+      .getState()
+      .entries.filter((e) => e.supersedeKey === "github.token");
+    expect(backstops).toHaveLength(1);
+    expect(backstops[0]?.countable).toBe(false);
+  });
+
   it("re-arms the inbox entry after recovery + a new failure", async () => {
     renderHook(() => useGitHubTokenHealth());
     await act(async () => {});
@@ -130,7 +193,7 @@ describe("useGitHubTokenHealth", () => {
     act(() => healthListener?.({ status: "unhealthy", tokenVersion: 0, checkedAt: 0 }));
 
     const entries = useNotificationHistoryStore.getState().entries;
-    expect(entries.filter((e) => e.correlationId === "github-token-health")).toHaveLength(2);
+    expect(entries.filter((e) => e.supersedeKey === "github.token")).toHaveLength(2);
   });
 
   it("replays initial state on mount via getTokenHealth", async () => {

--- a/src/hooks/__tests__/useGitHubTokenHealth.test.ts
+++ b/src/hooks/__tests__/useGitHubTokenHealth.test.ts
@@ -79,7 +79,46 @@ describe("useGitHubTokenHealth", () => {
     act(() => healthListener?.({ status: "unhealthy", tokenVersion: 0, checkedAt: 0 }));
 
     const entries = useNotificationHistoryStore.getState().entries;
-    expect(entries.filter((e) => e.correlationId === "github-token-health")).toHaveLength(1);
+    const healthEntries = entries.filter((e) => e.correlationId === "github-token-health");
+    expect(healthEntries).toHaveLength(1);
+  });
+
+  it("shares the github.token supersedeKey so the expiry-notification row can archive it", async () => {
+    renderHook(() => useGitHubTokenHealth());
+    await act(async () => {});
+
+    act(() => healthListener?.({ status: "unhealthy", tokenVersion: 0, checkedAt: 0 }));
+
+    const entry = useNotificationHistoryStore
+      .getState()
+      .entries.find((e) => e.correlationId === "github-token-health");
+    expect(entry?.supersedeKey).toBe("github.token");
+    // Inbox-only backstop: must not surface as a toast.
+    expect(entry?.seenAsToast).toBe(false);
+  });
+
+  it("keeps a single active row when a later github.token write supersedes the backstop", async () => {
+    renderHook(() => useGitHubTokenHealth());
+    await act(async () => {});
+
+    act(() => healthListener?.({ status: "unhealthy", tokenVersion: 0, checkedAt: 0 }));
+
+    // Simulate the toolbar's expiry-notification path writing under the same key.
+    act(() => {
+      useNotificationHistoryStore.getState().addEntry({
+        type: "warning",
+        title: "GitHub authentication required",
+        message: "Reconnect in settings.",
+        correlationId: "github:token-expiry",
+        supersedeKey: "github.token",
+      });
+    });
+
+    const active = useNotificationHistoryStore
+      .getState()
+      .entries.filter((e) => e.supersedeKey === "github.token" && !e.archivedAt);
+    expect(active).toHaveLength(1);
+    expect(active[0]?.correlationId).toBe("github:token-expiry");
   });
 
   it("re-arms the inbox entry after recovery + a new failure", async () => {

--- a/src/hooks/useGitHubTokenHealth.ts
+++ b/src/hooks/useGitHubTokenHealth.ts
@@ -35,12 +35,15 @@ export function useGitHubTokenHealth(): void {
         // case where the toolbar's `useGitHubTokenExpiryNotification` isn't
         // mounted. Shares `supersedeKey` with that hook so whichever fires
         // second archives the first — one active row per token-expiry event.
+        // No `correlationId`: it would only thread this row so that a second
+        // expiry cycle (after the toolbar archived the first row) re-promotes
+        // the backstop into an unwanted toast via the un-snooze re-toast path.
+        // The supersede dedup runs on `supersedeKey` alone.
         notify({
           type: "warning",
           priority: "low",
           title: "GitHub token expired",
           message: "GitHub token expired — reconnect to restore GitHub features.",
-          correlationId: "github-token-health",
           supersedeKey: "github.token",
           countable: false,
         });

--- a/src/hooks/useGitHubTokenHealth.ts
+++ b/src/hooks/useGitHubTokenHealth.ts
@@ -46,6 +46,7 @@ export function useGitHubTokenHealth(): void {
           message: "GitHub token expired — reconnect to restore GitHub features.",
           supersedeKey: "github.token",
           countable: false,
+          context: { eventKind: "connectivity" },
         });
       }
 

--- a/src/hooks/useGitHubTokenHealth.ts
+++ b/src/hooks/useGitHubTokenHealth.ts
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from "react";
 // eslint-disable-next-line no-restricted-imports
 import { githubClient } from "@/clients/githubClient";
+import { notify } from "@/lib/notify";
 import { useGitHubTokenHealthStore } from "@/store/githubTokenHealthStore";
-import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
 import type { GitHubTokenHealthPayload } from "@shared/types";
 
 /**
@@ -31,11 +31,17 @@ export function useGitHubTokenHealth(): void {
 
       if (isUnhealthy && !wasUnhealthy && !hasInboxedRef.current) {
         hasInboxedRef.current = true;
-        useNotificationHistoryStore.getState().addEntry({
+        // Inbox-only backstop (priority "low" → no toast) for the no-project
+        // case where the toolbar's `useGitHubTokenExpiryNotification` isn't
+        // mounted. Shares `supersedeKey` with that hook so whichever fires
+        // second archives the first — one active row per token-expiry event.
+        notify({
           type: "warning",
+          priority: "low",
           title: "GitHub token expired",
           message: "GitHub token expired — reconnect to restore GitHub features.",
           correlationId: "github-token-health",
+          supersedeKey: "github.token",
           countable: false,
         });
       }


### PR DESCRIPTION
Two bugs in the GitHub token expiry recovery flow.

## Summary

- A GitHub PAT expiry was producing two durable inbox rows plus a toast. `useGitHubTokenHealth`'s backstop used a raw `addEntry` with no `supersedeKey`; `useGitHubTokenExpiryNotification` used `notify()` with `supersedeKey: "github.token"` — so they never suppressed each other. Fix routes the backstop through `notify({ type: "warning", priority: "low", supersedeKey: "github.token", countable: false })`, making it inbox-only and sharing the key so whichever fires second archives the first. Also dropped `correlationId` from the backstop to cut the un-snooze re-toast path on a second expiry cycle.
- The "Reconnect to GitHub" button in `GitHubTokenBanner` dispatched a raw `CustomEvent` without `sectionId`, dropping the user at the top of the Code Forge settings tab. Fix routes through `actionService.dispatch("app.settings.openTab", { tab: "code-forge", subtab: "github", sectionId: "github-token" })` — consistent with every other recovery entry point.

Resolves #9961

## Changes

- `src/hooks/useGitHubTokenHealth.ts` — backstop notification via `notify()` with `priority: "low"`, shared `supersedeKey`, no `correlationId`
- `src/components/Recovery/GitHubTokenBanner.tsx` — reconnect button routes through `actionService.dispatch` instead of a raw `CustomEvent`
- 17 tests updated/added: `supersedeKey` sharing and archival, inbox-only backstop (no toast, no unread count), second-cycle no-retoast regression, replay-path backstop, banner action dispatch (legacy `CustomEvent` path asserted gone)

## Testing

Targeted vitest suite (17 tests) passes. Typecheck, lint, and format clean.