### PR TITLE
fix(setup): mark collapsed system requirements panel inert

### DIFF
--- a/src/components/Setup/SystemRequirementsSection.tsx
+++ b/src/components/Setup/SystemRequirementsSection.tsx
@@ -111,6 +111,7 @@ export function SystemRequirementsSection({
 
       <m.div
         id="system-requirements-panel"
+        inert={!isExpanded || undefined}
         animate={{ height: isExpanded ? "auto" : 0 }}
         initial={false}
         transition={

--- a/src/components/Setup/__tests__/SystemRequirementsSection.test.tsx
+++ b/src/components/Setup/__tests__/SystemRequirementsSection.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, act } from "@testing-library/react";
+import { SystemRequirementsSection } from "../SystemRequirementsSection";
+import type { SystemHealthCheckState } from "../useSystemHealthCheck";
+
+const { healthCheckState } = vi.hoisted(() => ({
+  healthCheckState: {
+    specs: [],
+    checkStates: {},
+    isChecking: false,
+    error: null,
+    visibleSpecs: [],
+    allDone: true,
+    hasFatalFailure: false,
+    runCheck: vi.fn(() => Promise.resolve()),
+  },
+}));
+
+vi.mock("framer-motion", () => {
+  // Real <div> with forwarded props — a fragment passthrough would drop the
+  // inert attribute and silently invalidate the assertions below.
+  const Passthrough = React.forwardRef<
+    HTMLDivElement,
+    React.HTMLAttributes<HTMLDivElement> & {
+      animate?: unknown;
+      initial?: unknown;
+      transition?: unknown;
+    }
+  >(({ children, animate: _a, initial: _i, transition: _t, ...rest }, ref) => (
+    <div ref={ref} {...rest}>
+      {children}
+    </div>
+  ));
+  return {
+    LazyMotion: ({ children }: React.PropsWithChildren<unknown>) => <>{children}</>,
+    domAnimation: {},
+    useReducedMotion: () => true,
+    m: { div: Passthrough },
+    motion: { div: Passthrough },
+  };
+});
+
+vi.mock("../useSystemHealthCheck", () => ({
+  useSystemHealthCheck: () => healthCheckState as unknown as SystemHealthCheckState,
+}));
+
+vi.mock("../SystemToolsStep", () => ({
+  PrerequisiteCard: () => <div data-testid="prerequisite-card-stub" />,
+}));
+
+function renderSection() {
+  return render(
+    <SystemRequirementsSection onFatalFailureChange={vi.fn()} onCheckingChange={vi.fn()} />
+  );
+}
+
+function getPanel(): HTMLElement {
+  const panel = document.getElementById("system-requirements-panel");
+  if (!panel) throw new Error("panel not rendered");
+  return panel;
+}
+
+function getToggle(container: HTMLElement): HTMLButtonElement {
+  const toggle = container.querySelector<HTMLButtonElement>(
+    'button[aria-controls="system-requirements-panel"]'
+  );
+  if (!toggle) throw new Error("toggle not rendered");
+  return toggle;
+}
+
+describe("SystemRequirementsSection collapsed panel inert", () => {
+  beforeEach(() => {
+    healthCheckState.hasFatalFailure = false;
+  });
+
+  it("marks the panel inert when collapsed by default", () => {
+    renderSection();
+    expect(getPanel().hasAttribute("inert")).toBe(true);
+  });
+
+  it("removes inert when the user expands the panel and restores it on re-collapse", () => {
+    const { container } = renderSection();
+    const toggle = getToggle(container);
+
+    act(() => {
+      toggle.click();
+    });
+    expect(getPanel().hasAttribute("inert")).toBe(false);
+
+    act(() => {
+      toggle.click();
+    });
+    expect(getPanel().hasAttribute("inert")).toBe(true);
+  });
+
+  it("keeps the panel interactive when a fatal failure forces it open", () => {
+    healthCheckState.hasFatalFailure = true;
+    renderSection();
+    expect(getPanel().hasAttribute("inert")).toBe(false);
+  });
+});

--- a/src/components/Setup/__tests__/SystemRequirementsSection.test.tsx
+++ b/src/components/Setup/__tests__/SystemRequirementsSection.test.tsx
@@ -100,4 +100,29 @@ describe("SystemRequirementsSection collapsed panel inert", () => {
     renderSection();
     expect(getPanel().hasAttribute("inert")).toBe(false);
   });
+
+  it("removes inert when a fatal failure arrives after mount", () => {
+    const { container, rerender } = renderSection();
+    expect(getPanel().hasAttribute("inert")).toBe(true);
+
+    healthCheckState.hasFatalFailure = true;
+    rerender(
+      <SystemRequirementsSection onFatalFailureChange={vi.fn()} onCheckingChange={vi.fn()} />
+    );
+    expect(getPanel().hasAttribute("inert")).toBe(false);
+    expect(getToggle(container).getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("restores inert when a fatal failure clears and the user never expanded", () => {
+    healthCheckState.hasFatalFailure = true;
+    const { container, rerender } = renderSection();
+    expect(getPanel().hasAttribute("inert")).toBe(false);
+
+    healthCheckState.hasFatalFailure = false;
+    rerender(
+      <SystemRequirementsSection onFatalFailureChange={vi.fn()} onCheckingChange={vi.fn()} />
+    );
+    expect(getPanel().hasAttribute("inert")).toBe(true);
+    expect(getToggle(container).getAttribute("aria-expanded")).toBe("false");
+  });
 });


### PR DESCRIPTION
## Summary

- The System Requirements panel in the Agent Setup wizard was only hiding its body visually via a height-to-zero animation — the Re-check button and `PrerequisiteCard` controls stayed in the tab order and accessibility tree while clipped.
- Adds `inert={!isExpanded || undefined}` to the `<m.div id="system-requirements-panel">` so focused children drop out of sequential focus order and the a11y tree when collapsed (WCAG 2.4.3 / 2.4.7). Matches the `GettingStartedChecklist` pattern; avoids `aria-hidden` since ARIA 1.2 makes it redundant on an `inert` element and it trips the axe `aria-hidden-focus` rule.

Resolves #10025

## Changes

- `src/components/Setup/SystemRequirementsSection.tsx` — add `inert` prop to the animated collapsible div
- `src/components/Setup/__tests__/SystemRequirementsSection.test.tsx` — 5 new tests: collapsed default is inert; expand/re-collapse toggle; fatal failure forces open (initial + after-mount rerender); fatal cleared without user expansion restores inert

## Testing

Vitest Setup suite passes (86 tests including 5 new). `npm run check` clean — typecheck, lint, format, and channel/IPC/confirm-wiring guards all green.