### PR TITLE
fix(dock): reopen dock popover when restoring a trashed docked terminal

### DIFF
--- a/src/store/listeners/panel/__tests__/lifecycle.test.ts
+++ b/src/store/listeners/panel/__tests__/lifecycle.test.ts
@@ -349,13 +349,26 @@ describe("onRestored — dock popover preservation (#8368)", () => {
     expect(usePanelStore.getState().activeDockTerminalId).toBe("dock-1");
   });
 
-  it("clears the dock popover when the restored terminal is the one displayed in it", () => {
-    setupPanel();
+  it("clears the dock popover when the restored terminal moved out of the dock", () => {
+    setupPanel({ location: "grid" });
     usePanelStore.setState({ activeDockTerminalId: "term-1", focusedId: "term-1" });
 
     getRestoredHandler()({ id: "term-1" });
 
     expect(usePanelStore.getState().activeDockTerminalId).toBeNull();
+  });
+
+  it("keeps the dock popover open when the restored terminal lands back in the dock (#9938)", () => {
+    setupPanel({ location: "dock" });
+    usePanelStore.setState({ activeDockTerminalId: "term-1", focusedId: "term-1" });
+
+    getRestoredHandler()({ id: "term-1" });
+
+    // A docked terminal restored from trash must keep its popover open so
+    // focus and the visible panel agree, rather than the listener nulling the
+    // dock pointer the restore wrapper just set.
+    expect(usePanelStore.getState().activeDockTerminalId).toBe("term-1");
+    expect(usePanelStore.getState().focusedId).toBe("term-1");
   });
 
   it("is a no-op on dock state when no dock popover is open", () => {

--- a/src/store/listeners/panel/lifecycle.ts
+++ b/src/store/listeners/panel/lifecycle.ts
@@ -254,12 +254,18 @@ export function setupLifecycleListeners(): DisposableStore {
       terminalRegistryController.onRestored((data: { id: string }) => {
         const { id } = data;
         usePanelStore.getState().markAsRestored(id);
-        const { focusedId: previousFocusedId, activeDockTerminalId } = usePanelStore.getState();
+        const {
+          focusedId: previousFocusedId,
+          activeDockTerminalId,
+          panelsById,
+        } = usePanelStore.getState();
         // Only clear the open dock popover when the restored terminal IS the
-        // one displayed in it. A background terminal waking from hibernation
-        // must not silently dismiss an unrelated dock session the user is
-        // typing into (#8368).
-        const clearsActiveDock = activeDockTerminalId === id;
+        // one displayed in it AND it did not land back in the dock. A terminal
+        // restored INTO the dock must keep the popover open so focus and the
+        // visible panel agree (#9938); a restore that lands elsewhere must not
+        // silently dismiss an unrelated dock session the user is typing into
+        // (#8368).
+        const clearsActiveDock = activeDockTerminalId === id && panelsById[id]?.location !== "dock";
         usePanelStore.setState({
           focusedId: id,
           ...(clearsActiveDock && { activeDockTerminalId: null }),

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -780,11 +780,18 @@ export const usePanelStore = create<PanelGridState>()(
         const restoredPanel = get().panelsById[id];
         if (!restoredPanel) return;
         const previousFocusedId = get().focusedId;
+        const landsInDock = restoredPanel.location === "dock" && isPtyPanel(restoredPanel);
         set({
           focusedId: id,
-          // Open the dock popover when the panel landed back in the dock;
-          // otherwise focus would point at an invisible panel (issue #9938).
-          activeDockTerminalId: restoredPanel.location === "dock" ? id : null,
+          // Open the dock popover when the panel landed back in the dock so
+          // focus and the visible panel agree (#9938). If it landed elsewhere,
+          // only clear the dock when this very panel was the one shown there —
+          // an unrelated open dock session must not be dismissed (#8368).
+          ...(landsInDock
+            ? { activeDockTerminalId: id }
+            : get().activeDockTerminalId === id
+              ? { activeDockTerminalId: null }
+              : {}),
           ...(previousFocusedId !== id && { previousFocusedId }),
         });
       },
@@ -807,20 +814,32 @@ export const usePanelStore = create<PanelGridState>()(
 
         registrySlice.restoreTrashedGroup(groupRestoreId, targetWorktreeId);
 
-        const focusId: string =
+        const preferredFocusId =
           anchorPanel?.groupMetadata?.activeTabId &&
           groupPanelIds.includes(anchorPanel.groupMetadata.activeTabId)
             ? anchorPanel.groupMetadata.activeTabId
             : groupPanelIds[0]!;
-        // Guard against a no-op restore leaving focus on a missing panel.
-        const restoredPanel = get().panelsById[focusId];
-        if (!restoredPanel) return;
+        // The preferred tab may have been pruned from panelsById during the
+        // trash window (expiry race); fall back to any surviving member so the
+        // restored group still gains focus and reopens its dock popover.
+        const focusId = get().panelsById[preferredFocusId]
+          ? preferredFocusId
+          : groupPanelIds.find((pid) => get().panelsById[pid]);
+        if (!focusId) return;
+        const restoredPanel = get().panelsById[focusId]!;
         const previousFocusedId = get().focusedId;
+        const landsInDock = restoredPanel.location === "dock" && isPtyPanel(restoredPanel);
         set({
           focusedId: focusId,
           // Match the restored panel's location so a docked group reopens the
-          // dock popover instead of focusing an invisible panel (issue #9938).
-          activeDockTerminalId: restoredPanel.location === "dock" ? focusId : null,
+          // dock popover instead of focusing an invisible panel (#9938); leave
+          // an unrelated open dock session untouched when it lands elsewhere
+          // (#8368).
+          ...(landsInDock
+            ? { activeDockTerminalId: focusId }
+            : get().activeDockTerminalId === focusId
+              ? { activeDockTerminalId: null }
+              : {}),
           ...(previousFocusedId !== focusId && { previousFocusedId }),
         });
 

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -775,10 +775,16 @@ export const usePanelStore = create<PanelGridState>()(
 
       restoreTerminal: (id: string, targetWorktreeId?: string) => {
         registrySlice.restoreTerminal(id, targetWorktreeId);
+        // The registry restore is a no-op when the id is gone; don't move
+        // focus onto a panel that doesn't exist.
+        const restoredPanel = get().panelsById[id];
+        if (!restoredPanel) return;
         const previousFocusedId = get().focusedId;
         set({
           focusedId: id,
-          activeDockTerminalId: null,
+          // Open the dock popover when the panel landed back in the dock;
+          // otherwise focus would point at an invisible panel (issue #9938).
+          activeDockTerminalId: restoredPanel.location === "dock" ? id : null,
           ...(previousFocusedId !== id && { previousFocusedId }),
         });
       },
@@ -806,10 +812,15 @@ export const usePanelStore = create<PanelGridState>()(
           groupPanelIds.includes(anchorPanel.groupMetadata.activeTabId)
             ? anchorPanel.groupMetadata.activeTabId
             : groupPanelIds[0]!;
+        // Guard against a no-op restore leaving focus on a missing panel.
+        const restoredPanel = get().panelsById[focusId];
+        if (!restoredPanel) return;
         const previousFocusedId = get().focusedId;
         set({
           focusedId: focusId,
-          activeDockTerminalId: null,
+          // Match the restored panel's location so a docked group reopens the
+          // dock popover instead of focusing an invisible panel (issue #9938).
+          activeDockTerminalId: restoredPanel.location === "dock" ? focusId : null,
           ...(previousFocusedId !== focusId && { previousFocusedId }),
         });
 

--- a/src/store/slices/panelRegistry/__tests__/restoreTrashedDockFocus.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restoreTrashedDockFocus.test.ts
@@ -116,6 +116,20 @@ describe("restore trashed dock focus (#9938)", () => {
     expect(state.activeDockTerminalId).toBeNull();
   });
 
+  it("does not dismiss an unrelated open dock when a grid terminal is restored", () => {
+    setTerminals([makeTerm("term-1", "grid"), makeTerm("other-dock", "dock")]);
+    usePanelStore.setState({ activeDockTerminalId: "other-dock", focusedId: "other-dock" });
+
+    usePanelStore.getState().trashPanel("term-1");
+    usePanelStore.getState().restoreTerminal("term-1");
+
+    const state = usePanelStore.getState();
+    // Restoring a grid terminal moves focus but must not close a dock session
+    // belonging to a different panel.
+    expect(state.focusedId).toBe("term-1");
+    expect(state.activeDockTerminalId).toBe("other-dock");
+  });
+
   it("does not move focus when restoring a missing terminal (no-op)", () => {
     setTerminals([makeTerm("visible-dock", "dock")]);
     usePanelStore.setState({ focusedId: "visible-dock", activeDockTerminalId: "visible-dock" });
@@ -150,6 +164,40 @@ describe("restore trashed dock focus (#9938)", () => {
     const state = usePanelStore.getState();
     expect(state.panelsById["term-2"]?.location).toBe("dock");
     // Focus and the dock popover both land on the originally-active tab.
+    expect(state.focusedId).toBe("term-2");
+    expect(state.activeDockTerminalId).toBe("term-2");
+  });
+
+  it("falls back to a surviving member when the preferred tab was pruned", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["term-1", "term-2", "term-3"],
+      activeTabId: "term-1",
+      location: "dock",
+    };
+    setTerminals([
+      makeTerm("term-1", "dock"),
+      makeTerm("term-2", "dock"),
+      makeTerm("term-3", "dock"),
+    ]);
+    usePanelStore.setState({ tabGroups: new Map([["group-1", group]]) });
+
+    usePanelStore.getState().trashPanelGroup("term-1");
+    const groupRestoreId = usePanelStore.getState().trashedTerminals.get("term-2")!.groupRestoreId!;
+
+    // Simulate the preferred active tab being garbage-collected from panelsById
+    // during the trash window while its trash metadata lingers.
+    usePanelStore.setState((state) => {
+      const panelsById = { ...state.panelsById };
+      delete panelsById["term-1"];
+      return { panelsById, panelIds: state.panelIds.filter((id) => id !== "term-1") };
+    });
+
+    usePanelStore.getState().restoreTrashedGroup(groupRestoreId);
+
+    const state = usePanelStore.getState();
+    // Focus and the dock popover land on a surviving member rather than being
+    // stranded because the preferred tab is gone.
     expect(state.focusedId).toBe("term-2");
     expect(state.activeDockTerminalId).toBe("term-2");
   });

--- a/src/store/slices/panelRegistry/__tests__/restoreTrashedDockFocus.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restoreTrashedDockFocus.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment jsdom
+/**
+ * Tests for restoring a trashed DOCK panel reopening the dock popover (#9938).
+ *
+ * The panelStore wrappers `restoreTerminal` / `restoreTrashedGroup` used to
+ * hardcode `activeDockTerminalId: null` while setting `focusedId` to the
+ * restored panel. When the panel was originally docked it landed back in the
+ * dock but the popover stayed closed, so focus pointed at an invisible panel
+ * and focus-relative shortcuts silently targeted it. The wrappers now derive
+ * `activeDockTerminalId` from the restored panel's `location`, and guard the
+ * no-op case (id absent after the registry call) so focus is never moved onto
+ * a panel that doesn't exist.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { TabGroup } from "@/types";
+import type { PtyPanelData } from "@shared/types/panel";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn().mockResolvedValue(undefined),
+    trash: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+  },
+  appClient: {
+    setState: vi.fn().mockResolvedValue(undefined),
+  },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+  },
+  agentSettingsClient: {
+    get: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    cleanup: vi.fn(),
+    destroy: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
+  },
+}));
+
+const { usePanelStore } = await import("../../../panelStore");
+
+type MockTerminal = Partial<PtyPanelData> & { id: string };
+
+function setTerminals(terminals: MockTerminal[]) {
+  usePanelStore.setState({
+    panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])) as Record<string, PtyPanelData>,
+    panelIds: terminals.map((t) => t.id),
+  });
+}
+
+function makeTerm(id: string, location: "grid" | "dock" = "grid"): MockTerminal {
+  return { id, title: `Shell ${id}`, cwd: "/test", cols: 80, rows: 24, location };
+}
+
+describe("restore trashed dock focus (#9938)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const { reset } = usePanelStore.getState();
+    reset();
+    usePanelStore.setState({
+      panelsById: {},
+      panelIds: [],
+      tabGroups: new Map(),
+      trashedTerminals: new Map(),
+      backgroundedTerminals: new Map(),
+      focusedId: null,
+      maximizedId: null,
+      activeDockTerminalId: null,
+      commandQueue: [],
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("opens the dock popover when a docked terminal is restored", () => {
+    setTerminals([makeTerm("term-1", "dock")]);
+
+    usePanelStore.getState().trashPanel("term-1");
+    expect(usePanelStore.getState().panelsById["term-1"]?.location).toBe("trash");
+
+    usePanelStore.getState().restoreTerminal("term-1");
+
+    const state = usePanelStore.getState();
+    expect(state.panelsById["term-1"]?.location).toBe("dock");
+    expect(state.focusedId).toBe("term-1");
+    // The restored panel is back in the dock — the popover must point at it so
+    // focus and the visible panel agree.
+    expect(state.activeDockTerminalId).toBe("term-1");
+    expect(state.activeDockTerminalId).toBe(state.focusedId);
+  });
+
+  it("leaves the dock closed when a grid terminal is restored", () => {
+    setTerminals([makeTerm("term-1", "grid")]);
+
+    usePanelStore.getState().trashPanel("term-1");
+    usePanelStore.getState().restoreTerminal("term-1");
+
+    const state = usePanelStore.getState();
+    expect(state.panelsById["term-1"]?.location).toBe("grid");
+    expect(state.focusedId).toBe("term-1");
+    expect(state.activeDockTerminalId).toBeNull();
+  });
+
+  it("does not move focus when restoring a missing terminal (no-op)", () => {
+    setTerminals([makeTerm("visible-dock", "dock")]);
+    usePanelStore.setState({ focusedId: "visible-dock", activeDockTerminalId: "visible-dock" });
+
+    usePanelStore.getState().restoreTerminal("ghost");
+
+    const state = usePanelStore.getState();
+    // The no-op restore must not retarget focus or close the open dock panel.
+    expect(state.focusedId).toBe("visible-dock");
+    expect(state.activeDockTerminalId).toBe("visible-dock");
+  });
+
+  it("opens the dock popover on the active tab when a docked group is restored", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["term-1", "term-2", "term-3"],
+      activeTabId: "term-2",
+      location: "dock",
+    };
+    setTerminals([
+      makeTerm("term-1", "dock"),
+      makeTerm("term-2", "dock"),
+      makeTerm("term-3", "dock"),
+    ]);
+    usePanelStore.setState({ tabGroups: new Map([["group-1", group]]) });
+
+    usePanelStore.getState().trashPanelGroup("term-1");
+    const groupRestoreId = usePanelStore.getState().trashedTerminals.get("term-1")!.groupRestoreId!;
+
+    usePanelStore.getState().restoreTrashedGroup(groupRestoreId);
+
+    const state = usePanelStore.getState();
+    expect(state.panelsById["term-2"]?.location).toBe("dock");
+    // Focus and the dock popover both land on the originally-active tab.
+    expect(state.focusedId).toBe("term-2");
+    expect(state.activeDockTerminalId).toBe("term-2");
+  });
+
+  it("leaves the dock closed when a grid group is restored", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["term-1", "term-2"],
+      activeTabId: "term-1",
+      location: "grid",
+    };
+    setTerminals([makeTerm("term-1", "grid"), makeTerm("term-2", "grid")]);
+    usePanelStore.setState({ tabGroups: new Map([["group-1", group]]) });
+
+    usePanelStore.getState().trashPanelGroup("term-1");
+    const groupRestoreId = usePanelStore.getState().trashedTerminals.get("term-1")!.groupRestoreId!;
+
+    usePanelStore.getState().restoreTrashedGroup(groupRestoreId);
+
+    const state = usePanelStore.getState();
+    expect(state.focusedId).toBe("term-1");
+    expect(state.activeDockTerminalId).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

When restoring a trashed dock terminal (from the trash popover or reopen-last-closed), the dock popover should open. It didn't — the panel came back as a closed chip while focus pointed at the invisible terminal, so focus-relative shortcuts like Cmd+W silently targeted it.

The root cause was in `restoreTerminal` and `restoreTrashedGroup` in `panelStore.ts`, which were hardcoding `activeDockTerminalId: null` instead of deriving the correct value from the restored panel's location. There was also an async race in the `onRestored` lifecycle listener that was clearing `activeDockTerminalId` for PTY dock terminals after the fact, undoing the fix.

A few other things cleaned up while I was here: a no-op guard when the restored panel is missing from `panelsById`, a surviving-member fallback for partial group restores, `isPtyPanel` guards around the `activeDockTerminalId` changes, and a check to ensure open dock sessions aren't dismissed on restore.

Resolves #9938

## Changes

- `src/store/panelStore.ts` — derive `activeDockTerminalId` from the restored panel's location in `restoreTerminal` and `restoreTrashedGroup` instead of hardcoding `null`; guard `focusedId` set against missing panels
- `src/store/listeners/panel/lifecycle.ts` — `onRestored` race fix: only clear `activeDockTerminalId` when the restored terminal moved out of the dock; add `isPtyPanel` guards
- `src/store/slices/panelRegistry/__tests__/restoreTrashedDockFocus.test.ts` — new suite covering wrapper fix and edge cases (297 tests pass)
- `src/store/listeners/panel/__tests__/lifecycle.test.ts` — extended to cover the `onRestored` race and lifecycle edge cases

## Testing

297 `panelRegistry` tests + the `lifecycle` suite all pass. `npm run check` is clean (typecheck, lint, format, IPC/confirm guards).