### PR TITLE
fix(fleet): correct 'worktree' noun in fleet trash confirm copy

### DIFF
--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -362,6 +362,21 @@ describe("FleetArmingRibbon", () => {
     expect(useFleetPendingActionStore.getState().pending).toBeNull();
   });
 
+  it("renders 'Trash N terminals?' for the trash pending kind", () => {
+    // Regression guard for issue #9947: the trash confirmation must use
+    // 'terminal(s)' (matching the sibling kill case), not 'worktree(s)' —
+    // the action moves armed terminal panels to trash, not worktrees.
+    useFleetArmingStore.getState().armIds(["a", "b", "c", "d", "e"]);
+    useFleetPendingActionStore.setState({
+      pending: { kind: "trash", targetCount: 5, sessionLossCount: 0 },
+    });
+    render(<FleetArmingRibbon />);
+    const ribbon = screen.getByTestId("fleet-arming-ribbon");
+    expect(ribbon.getAttribute("data-pending-action")).toBe("trash");
+    expect(screen.getByText(/Trash 5 terminals\?/)).toBeTruthy();
+    expect(ribbon.textContent).not.toMatch(/worktree/i);
+  });
+
   it("keeps the confirmation view visible when armed count drops to 1", () => {
     // Ribbon hides the normal view at armedCount < 2, but confirmation must
     // stay reachable: fleet.restart / fleet.kill always require confirmation

--- a/src/components/Fleet/__tests__/buildConfirmMessage.test.ts
+++ b/src/components/Fleet/__tests__/buildConfirmMessage.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { buildConfirmMessage } from "../buildConfirmMessage";
+
+describe("buildConfirmMessage", () => {
+  describe("trash", () => {
+    it("uses 'terminal' (singular) when count is 1", () => {
+      expect(buildConfirmMessage("trash", 1, 0)).toBe("Trash 1 terminal?");
+    });
+
+    it("uses 'terminals' (plural) when count is 2", () => {
+      expect(buildConfirmMessage("trash", 2, 0)).toBe("Trash 2 terminals?");
+    });
+
+    it("uses 'terminals' (plural) for larger counts", () => {
+      expect(buildConfirmMessage("trash", 5, 0)).toBe("Trash 5 terminals?");
+    });
+  });
+
+  describe("kill (sibling regression guard)", () => {
+    it("uses 'terminal' (singular) when count is 1", () => {
+      expect(buildConfirmMessage("kill", 1, 0)).toBe("Kill 1 terminal?");
+    });
+
+    it("uses 'terminals' (plural) when count is 3", () => {
+      expect(buildConfirmMessage("kill", 3, 0)).toBe("Kill 3 terminals?");
+    });
+  });
+});

--- a/src/components/Fleet/buildConfirmMessage.ts
+++ b/src/components/Fleet/buildConfirmMessage.ts
@@ -28,6 +28,6 @@ export function buildConfirmMessage(
     case "kill":
       return `Kill ${count} ${count === 1 ? "terminal" : "terminals"}?`;
     case "trash":
-      return `Trash ${count} ${count === 1 ? "worktree" : "worktrees"}?`;
+      return `Trash ${count} ${count === 1 ? "terminal" : "terminals"}?`;
   }
 }


### PR DESCRIPTION
## Summary

The fleet trash confirm was lying. It said "Trash N worktrees?" but the action moves armed terminal panels to trash, not worktrees. Worse, the same UI ribbon shows a `FleetCountChip` reading "M worktrees" where M is the unique worktree count, so for 5 terminals across 2 worktrees the chip says "5 in fleet · 2 worktrees" and the confirm says "Trash 5 worktrees?". Two different meanings of "worktrees" inches apart.

The fix swaps the noun in the `trash` case of `buildConfirmMessage` to match the action's `title`, `description`, and `dangerRationale`, which all use "terminal".

Resolves #9947

## Changes

- `src/components/Fleet/buildConfirmMessage.ts`: `trash` case now returns "Trash N terminal(s)?" matching the actual operation.
- `src/components/Fleet/__tests__/buildConfirmMessage.test.ts`: regression test for the corrected copy (singular and plural).
- `src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx`: regression guard for the rendered confirm string.

## Testing

- Unit tests cover the corrected confirm message for both `count === 1` and plural cases.
- A pending-render regression test in `FleetArmingRibbon.test.tsx` asserts the rendered confirm no longer mentions "worktrees" when the action is `trash`.
- Existing 76 tests across the two test files pass.