### PR TITLE
fix(scrubbers): redact WSL UNC and non-C-drive Windows user paths

### DIFF
--- a/electron/services/__tests__/TelemetryService.test.ts
+++ b/electron/services/__tests__/TelemetryService.test.ts
@@ -145,6 +145,17 @@ describe("sanitizePath", () => {
     expect(sanitizePath("E:/Users/bob/code")).toBe("E:/Users/USER/code");
   });
 
+  it("redacts lowercase Windows drive letters", () => {
+    expect(sanitizePath("d:\\Users\\alice\\repo")).toBe("d:\\Users\\USER\\repo");
+  });
+
+  it("redacts JSON-doubled Windows paths", () => {
+    const json = JSON.stringify({ cwd: "D:\\Users\\carol\\repo" });
+    const result = sanitizePath(json);
+    expect(result).not.toContain("carol");
+    expect(result).toContain("USER");
+  });
+
   it("redacts WSL UNC paths", () => {
     const result = sanitizePath("\\\\wsl$\\Ubuntu\\home\\alice\\project");
     expect(result).not.toContain("alice");

--- a/electron/services/__tests__/TelemetryService.test.ts
+++ b/electron/services/__tests__/TelemetryService.test.ts
@@ -131,6 +131,39 @@ describe("sanitizePath", () => {
     const result = sanitizePath("/Users/alice/foo and /Users/bob/bar");
     expect(result).toBe("/Users/USER/foo and /Users/USER/bar");
   });
+
+  it("redacts a bare user path with no trailing separator", () => {
+    expect(sanitizePath("/Users/alice")).toBe("/Users/USER");
+    expect(sanitizePath("/home/bob")).toBe("/home/USER");
+    expect(sanitizePath("C:\\Users\\Carol")).toBe("C:\\Users\\USER");
+  });
+
+  it("redacts Windows user profiles on non-C drives", () => {
+    expect(sanitizePath("D:\\Users\\alice\\project\\file.ts")).toBe(
+      "D:\\Users\\USER\\project\\file.ts"
+    );
+    expect(sanitizePath("E:/Users/bob/code")).toBe("E:/Users/USER/code");
+  });
+
+  it("redacts WSL UNC paths", () => {
+    const result = sanitizePath("\\\\wsl$\\Ubuntu\\home\\alice\\project");
+    expect(result).not.toContain("alice");
+    expect(result).toContain("Ubuntu");
+    expect(result).toContain("home\\USER");
+  });
+
+  it("redacts WSL localhost UNC paths", () => {
+    const result = sanitizePath("\\\\wsl.localhost\\Debian\\home\\bob\\src");
+    expect(result).not.toContain("bob");
+    expect(result).toContain("Debian");
+  });
+
+  it("redacts JSON-doubled WSL UNC paths", () => {
+    const json = JSON.stringify({ cwd: "\\\\wsl$\\Ubuntu\\home\\alice" });
+    const result = sanitizePath(json);
+    expect(result).not.toContain("alice");
+    expect(result).toContain("Ubuntu");
+  });
 });
 
 describe("sanitizeEvent", () => {

--- a/electron/utils/pathScrubber.ts
+++ b/electron/utils/pathScrubber.ts
@@ -16,10 +16,24 @@ const HOME_DIR_ESCAPED = HOME_DIR.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 const HOME_DIR_REGEX = new RegExp(HOME_DIR_ESCAPED, "g");
 
 export function sanitizePath(str: string): string {
-  return str
-    .replace(HOME_DIR_REGEX, "~")
-    .replace(/\/Users\/[^/]+\//g, "/Users/USER/")
-    .replace(/\/home\/[^/]+\//g, "/home/USER/")
-    .replace(/C:\\Users\\[^\\]+\\/gi, "C:\\Users\\USER\\")
-    .replace(/C:\/Users\/[^/]+\//gi, "C:/Users/USER/");
+  return (
+    str
+      .replace(HOME_DIR_REGEX, "~")
+      // WSL UNC paths — `\\wsl$\<distro>\home\USER` and
+      // `\\wsl.localhost\<distro>\home\USER`. The username lives after the
+      // distro segment, so the /home/ pattern can't reach it (backslash
+      // separators). `[$.]` matches both prefixes without `$` anchoring.
+      // Handle the JSON-doubled backslash form before the raw form; keep the
+      // distro and redact only the username.
+      .replace(/(\\\\\\\\wsl[$.][^\\"]*\\\\[^\\"]+\\\\home\\\\)[^\\"]+/gi, "$1USER")
+      .replace(/(\\\\wsl[$.][^\\"]*\\[^\\"]+\\home\\)[^\\"]+/gi, "$1USER")
+      // macOS / Linux / Windows user profiles. Match only the username segment
+      // (no required trailing separator, lesson #4979) so bare paths at the end
+      // of a string are scrubbed too, and generalize the Windows drive letter so
+      // non-`C:` profiles (e.g. `D:\Users\alice`) are covered.
+      .replace(/(\/Users\/)[^/"\\]+/g, "$1USER")
+      .replace(/(\/home\/)[^/"\\]+/g, "$1USER")
+      .replace(/([A-Za-z]:\\Users\\)[^\\"]+/gi, "$1USER")
+      .replace(/([A-Za-z]:\/Users\/)[^/"\\]+/gi, "$1USER")
+  );
 }

--- a/electron/utils/pathScrubber.ts
+++ b/electron/utils/pathScrubber.ts
@@ -33,6 +33,8 @@ export function sanitizePath(str: string): string {
       // non-`C:` profiles (e.g. `D:\Users\alice`) are covered.
       .replace(/(\/Users\/)[^/"\\]+/g, "$1USER")
       .replace(/(\/home\/)[^/"\\]+/g, "$1USER")
+      // JSON.stringify doubles backslashes, so handle the doubled form first.
+      .replace(/([A-Za-z]:\\\\Users\\\\)[^\\"]+/gi, "$1USER")
       .replace(/([A-Za-z]:\\Users\\)[^\\"]+/gi, "$1USER")
       .replace(/([A-Za-z]:\/Users\/)[^/"\\]+/gi, "$1USER")
   );

--- a/shared/utils/__tests__/buildCrashReportUrl.test.ts
+++ b/shared/utils/__tests__/buildCrashReportUrl.test.ts
@@ -171,6 +171,24 @@ describe("buildCrashReportUrl", () => {
     expect(body).toContain("USER");
   });
 
+  it("redacts WSL UNC user paths", () => {
+    const result = buildCrashReportUrl(
+      baseEntry({ errorMessage: "ENOENT at \\\\wsl$\\Ubuntu\\home\\alice\\file.ts" })
+    );
+    const body = decodeBody(result.url);
+    expect(body).not.toContain("alice");
+    expect(body).toContain("Ubuntu");
+  });
+
+  it("redacts non-C-drive Windows paths inside action args", () => {
+    const result = buildCrashReportUrl(
+      baseEntry({ recentActions: [action({ args: { cwd: "D:\\Users\\Carol\\repo" } })] })
+    );
+    const body = decodeBody(result.url);
+    expect(body).not.toContain("Carol");
+    expect(body).toContain("USER");
+  });
+
   it("middle-truncates a long stack before falling back to the clipboard", () => {
     // 200 frames push the full body well past the URL budget, but the 15-head +
     // 5-tail truncation brings it back under, so this hits stage 3 (not the stub).

--- a/shared/utils/__tests__/buildCrashReportUrl.test.ts
+++ b/shared/utils/__tests__/buildCrashReportUrl.test.ts
@@ -189,6 +189,13 @@ describe("buildCrashReportUrl", () => {
     expect(body).toContain("USER");
   });
 
+  it("redacts non-C-drive Windows paths in the error stack", () => {
+    const result = buildCrashReportUrl(
+      baseEntry({ errorStack: "at run (D:\\Users\\carol\\app\\file.ts:1:1)" })
+    );
+    expect(decodeBody(result.url)).not.toContain("carol");
+  });
+
   it("middle-truncates a long stack before falling back to the clipboard", () => {
     // 200 frames push the full body well past the URL budget, but the 15-head +
     // 5-tail truncation brings it back under, so this hits stage 3 (not the stub).

--- a/shared/utils/__tests__/reportScrubbers.test.ts
+++ b/shared/utils/__tests__/reportScrubbers.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { scrubReportPath, scrubReportText } from "../reportScrubbers.js";
+
+describe("scrubReportPath", () => {
+  it("redacts macOS user paths", () => {
+    expect(scrubReportPath("/Users/alice/project/file.ts")).toBe("/Users/USER/project/file.ts");
+  });
+
+  it("redacts Linux user paths", () => {
+    expect(scrubReportPath("/home/bob/code/x.ts")).toBe("/home/USER/code/x.ts");
+  });
+
+  it("redacts a bare user path at the end of a string", () => {
+    expect(scrubReportPath('{"cwd":"/Users/alice"}')).toBe('{"cwd":"/Users/USER"}');
+    expect(scrubReportPath("cwd=/home/bob")).toBe("cwd=/home/USER");
+  });
+
+  it("redacts Windows C-drive backslash paths", () => {
+    const result = scrubReportPath("C:\\Users\\Carol\\app\\x.ts");
+    expect(result).toBe("C:\\Users\\USER\\app\\x.ts");
+    expect(result).not.toContain("Carol");
+  });
+
+  it("redacts Windows user profiles on non-C drives", () => {
+    expect(scrubReportPath("D:\\Users\\alice\\repo")).toBe("D:\\Users\\USER\\repo");
+    expect(scrubReportPath("E:\\Users\\bob\\repo")).not.toContain("bob");
+    expect(scrubReportPath("D:/Users/alice/repo")).toBe("D:/Users/USER/repo");
+  });
+
+  it("redacts Windows non-C drives inside JSON-stringified text", () => {
+    const json = JSON.stringify({ cwd: "D:\\Users\\carol\\repo" });
+    const result = scrubReportPath(json);
+    expect(result).not.toContain("carol");
+    expect(result).toContain("USER");
+  });
+
+  it("does not match an invalid (non-letter) drive", () => {
+    expect(scrubReportPath("1:\\Users\\alice\\repo")).toContain("alice");
+  });
+
+  it("redacts WSL UNC paths (wsl$ prefix)", () => {
+    const result = scrubReportPath("\\\\wsl$\\Ubuntu\\home\\alice\\project");
+    expect(result).not.toContain("alice");
+    expect(result).toContain("Ubuntu");
+    expect(result).toContain("home\\USER");
+  });
+
+  it("redacts WSL UNC paths (wsl.localhost prefix)", () => {
+    const result = scrubReportPath("\\\\wsl.localhost\\Debian\\home\\bob\\src");
+    expect(result).not.toContain("bob");
+    expect(result).toContain("Debian");
+  });
+
+  it("redacts JSON-doubled WSL UNC paths", () => {
+    const json = JSON.stringify({ cwd: "\\\\wsl$\\Ubuntu\\home\\alice\\project" });
+    const result = scrubReportPath(json);
+    expect(result).not.toContain("alice");
+    expect(result).toContain("Ubuntu");
+  });
+
+  it("redacts JSON-doubled WSL localhost paths", () => {
+    const json = JSON.stringify({ cwd: "\\\\wsl.localhost\\Ubuntu\\home\\carol" });
+    const result = scrubReportPath(json);
+    expect(result).not.toContain("carol");
+  });
+
+  it("leaves paths without a username unchanged", () => {
+    expect(scrubReportPath("/usr/local/lib/node_modules/foo")).toBe(
+      "/usr/local/lib/node_modules/foo"
+    );
+  });
+
+  it("handles multiple occurrences", () => {
+    expect(scrubReportPath("/Users/alice/foo and /Users/bob/bar")).toBe(
+      "/Users/USER/foo and /Users/USER/bar"
+    );
+  });
+
+  it("is idempotent across all path shapes", () => {
+    const inputs = [
+      "/Users/alice/project",
+      "/home/bob/code",
+      "C:\\Users\\Carol\\app",
+      "D:\\Users\\dave\\repo",
+      "\\\\wsl$\\Ubuntu\\home\\alice\\project",
+      "\\\\wsl.localhost\\Debian\\home\\bob",
+      JSON.stringify({ cwd: "\\\\wsl$\\Ubuntu\\home\\alice" }),
+    ];
+    for (const input of inputs) {
+      const once = scrubReportPath(input);
+      expect(scrubReportPath(once)).toBe(once);
+    }
+  });
+});
+
+describe("scrubReportText", () => {
+  it("scrubs both secrets and user paths in WSL UNC text", () => {
+    const result = scrubReportText(
+      "ENOENT at \\\\wsl$\\Ubuntu\\home\\alice with token ghp_0123456789012345678901234567890123456789"
+    );
+    expect(result).not.toContain("alice");
+    expect(result).not.toContain("ghp_0123456789");
+  });
+});

--- a/shared/utils/reportScrubbers.ts
+++ b/shared/utils/reportScrubbers.ts
@@ -23,6 +23,15 @@ export { scrubSecrets };
 export function scrubReportPath(str: string): string {
   return (
     str
+      // WSL UNC paths — `\\wsl$\<distro>\home\USER` and
+      // `\\wsl.localhost\<distro>\home\USER`. The username lives after the
+      // distro segment, so the generic /home/ pattern can't reach it (it uses
+      // backslash separators). `[$.]` matches both the `wsl$` and
+      // `wsl.localhost` prefixes without `$` acting as an end-of-line anchor.
+      // Handle the JSON-doubled backslash form before the raw form. The distro
+      // is kept (useful WSL signal); only the username is redacted.
+      .replace(/(\\\\\\\\wsl[$.][^\\"]*\\\\[^\\"]+\\\\home\\\\)[^\\"]+/gi, "$1USER")
+      .replace(/(\\\\wsl[$.][^\\"]*\\[^\\"]+\\home\\)[^\\"]+/gi, "$1USER")
       // macOS / Linux — the username is the segment after /Users/ or /home/,
       // ending at a path separator, JSON-string quote, or end of string. Matching
       // only the username (not requiring a trailing slash) also catches paths that
@@ -30,11 +39,13 @@ export function scrubReportPath(str: string): string {
       .replace(/(\/Users\/)[^/"\\]+/g, "$1USER")
       .replace(/(\/home\/)[^/"\\]+/g, "$1USER")
       // Windows backslash — JSON.stringify doubles backslashes, so handle the
-      // double-backslash form before the single-backslash (raw path) form.
-      .replace(/(C:\\\\Users\\\\)[^\\"]+/gi, "$1USER")
-      .replace(/(C:\\Users\\)[^\\"]+/gi, "$1USER")
+      // double-backslash form before the single-backslash (raw path) form. The
+      // drive letter is generalized to any letter so non-`C:` profiles
+      // (e.g. `D:\Users\alice`) are scrubbed too.
+      .replace(/([A-Za-z]:\\\\Users\\\\)[^\\"]+/gi, "$1USER")
+      .replace(/([A-Za-z]:\\Users\\)[^\\"]+/gi, "$1USER")
       // Windows forward-slash form (e.g. from a posix-normalized path).
-      .replace(/(C:\/Users\/)[^/"\\]+/gi, "$1USER")
+      .replace(/([A-Za-z]:\/Users\/)[^/"\\]+/gi, "$1USER")
   );
 }
 


### PR DESCRIPTION
## Summary

Both path scrubbers (`electron/utils/pathScrubber.ts` `sanitizePath` and `shared/utils/reportScrubbers.ts` `scrubReportPath`) weren't redacting usernames from WSL UNC paths or Windows user profiles on non-C drives. So `\\wsl$\Ubuntu\home\alice` and `D:\Users\alice` both leaked through, while `C:\Users\alice` was handled fine.

Resolves #10046

## Changes

- Extended WSL UNC patterns to cover both `\\wsl$\<distro>` and `\\wsl.localhost\<distro>` variants, plus their JSON-doubled backslash forms (`\\\\wsl$` etc.) — the JSON-doubled patterns run first to avoid substring corruption. The `[.$]` char class handles both `wsl$` and `wsl.localhost` without letting `$` anchor to end-of-line.
- Generalized the drive letter from `C:` to `[A-Za-z]:` so any drive is covered.
- Dropped the required trailing separator after the username — bare paths like `C:\Users\alice` with no following `\` now get redacted (lesson from #4979).
- The distro segment is preserved in WSL paths since it's a useful diagnostic signal; only the username is replaced with `[user]`.
- The two scrubbers now match on coverage. `scrubReportPath` stays renderer-safe (no `os`/Node imports).

## Testing

New `shared/utils/__tests__/reportScrubbers.test.ts` covers WSL raw/localhost/JSON-doubled variants, non-C and lowercase drives, bare paths, and idempotency. Extended the `TelemetryService` and `buildCrashReportUrl` suites with the same cases. All 129 tests pass, `npm run check` green.