### PR TITLE
fix(forge): deliver saved credentials to the live provider impl

### DIFF
--- a/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
@@ -386,6 +386,37 @@ describe("registerForgeSettingsHandlers", () => {
     expect(result).toEqual({ valid: true, scopes: ["repo"] });
   });
 
+  it("setCredential delivers the password-typed field even when it is declared second", async () => {
+    registryMock.getRegisteredForgeProviders.mockReturnValue([
+      {
+        pluginId: "acme",
+        contribution: {
+          id: "gitea",
+          name: "Gitea",
+          matches: ["gitea.example.com"],
+          // Password field second so a `fields[0]`-always bug would validate/deliver the URL.
+          credentialFields: [
+            { id: "baseUrl", label: "Base URL", type: "text" },
+            { id: "token", label: "API token", type: "password" },
+          ],
+        },
+      },
+    ]);
+    const validateToken = vi.fn().mockResolvedValue({ valid: true });
+    const setCredentials = vi.fn();
+    registryMock.getForgeProviderImpl.mockReturnValue({ validateToken, setCredentials });
+    registerForgeSettingsHandlers();
+    const setCredential = findHandler("forge:set-credential");
+
+    await setCredential(null, "acme.gitea", {
+      baseUrl: "https://gitea.example.com",
+      token: "secret-token",
+    });
+
+    expect(validateToken).toHaveBeenCalledWith("secret-token");
+    expect(setCredentials).toHaveBeenCalledWith({ kind: "bearer", value: "secret-token" });
+  });
+
   it("setCredential succeeds when the impl does not implement the optional setCredentials", async () => {
     registerGiteaProvider();
     const validateToken = vi.fn().mockResolvedValue({ valid: true });

--- a/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
@@ -359,7 +359,8 @@ describe("registerForgeSettingsHandlers", () => {
   it("setCredential validates the primary field, persists the record, and syncs the host", async () => {
     registerGiteaProvider();
     const validateToken = vi.fn().mockResolvedValue({ valid: true, scopes: ["repo"] });
-    registryMock.getForgeProviderImpl.mockReturnValue({ validateToken });
+    const setCredentials = vi.fn();
+    registryMock.getForgeProviderImpl.mockReturnValue({ validateToken, setCredentials });
     registerForgeSettingsHandlers();
     const setCredential = findHandler("forge:set-credential");
 
@@ -375,11 +376,45 @@ describe("registerForgeSettingsHandlers", () => {
         baseUrl: "https://gitea.example.com",
       }),
     });
+    // The credential must reach the live impl as a bearer credential (#9983),
+    // not just the store — otherwise forge API calls run unauthenticated.
+    expect(setCredentials).toHaveBeenCalledWith({ kind: "bearer", value: "secret-token" });
     expect(workspaceClientMock.updateForgeCredentials).toHaveBeenCalledWith("acme.gitea", {
       kind: "bearer",
       value: "secret-token",
     });
     expect(result).toEqual({ valid: true, scopes: ["repo"] });
+  });
+
+  it("setCredential succeeds when the impl does not implement the optional setCredentials", async () => {
+    registerGiteaProvider();
+    const validateToken = vi.fn().mockResolvedValue({ valid: true });
+    // No setCredentials on the impl — the optional-call guard must not throw.
+    registryMock.getForgeProviderImpl.mockReturnValue({ validateToken });
+    registerForgeSettingsHandlers();
+    const setCredential = findHandler("forge:set-credential");
+
+    const result = await setCredential(null, "acme.gitea", { token: "secret-token" });
+
+    expect(result).toEqual({ valid: true });
+    expect(storeMock.set).toHaveBeenCalledWith("forgeCredentials", {
+      "acme.gitea": JSON.stringify({ token: "secret-token" }),
+    });
+  });
+
+  it("setCredential does not call setCredentials when validation fails", async () => {
+    registerGiteaProvider();
+    const setCredentials = vi.fn();
+    registryMock.getForgeProviderImpl.mockReturnValue({
+      validateToken: vi.fn().mockResolvedValue({ valid: false, error: "Bad token" }),
+      setCredentials,
+    });
+    registerForgeSettingsHandlers();
+    const setCredential = findHandler("forge:set-credential");
+
+    await setCredential(null, "acme.gitea", { token: "nope" });
+
+    expect(setCredentials).not.toHaveBeenCalled();
   });
 
   it("setCredential does not persist or sync when validation fails", async () => {
@@ -523,5 +558,27 @@ describe("registerForgeSettingsHandlers", () => {
       "corp.gitlab": JSON.stringify({ token: "b" }),
     });
     expect(workspaceClientMock.updateForgeCredentials).toHaveBeenCalledWith("acme.gitea", null);
+  });
+
+  it("clearCredential clears the live impl's in-memory auth via setCredentials(null)", async () => {
+    storeMock._data["forgeCredentials"] = { "acme.gitea": JSON.stringify({ token: "a" }) };
+    const setCredentials = vi.fn();
+    registryMock.getForgeProviderImpl.mockReturnValue({ setCredentials });
+    registerForgeSettingsHandlers();
+    const clearCredential = findHandler("forge:clear-credential");
+
+    await clearCredential(null, "acme.gitea");
+
+    expect(setCredentials).toHaveBeenCalledWith(null);
+  });
+
+  it("clearCredential is a no-op for the impl when none is bound (no throw)", async () => {
+    storeMock._data["forgeCredentials"] = { "acme.gitea": JSON.stringify({ token: "a" }) };
+    registryMock.getForgeProviderImpl.mockReturnValue(undefined);
+    registerForgeSettingsHandlers();
+    const clearCredential = findHandler("forge:clear-credential");
+
+    await expect(clearCredential(null, "acme.gitea")).resolves.toBeUndefined();
+    expect(storeMock.set).toHaveBeenCalledWith("forgeCredentials", {});
   });
 });

--- a/electron/ipc/handlers/forgeSettings.ts
+++ b/electron/ipc/handlers/forgeSettings.ts
@@ -197,6 +197,14 @@ export function registerForgeSettingsHandlers(): () => void {
         const existing = store.get("forgeCredentials") ?? {};
         store.set("forgeCredentials", { ...existing, [providerId]: JSON.stringify(record) });
 
+        // Deliver the credential to the live impl so forge API calls run
+        // authenticated. Without this the token only ever reached the store —
+        // the impl stayed unauthenticated despite the UI showing "connected"
+        // (#9983). `setCredentials` is optional; a synchronous throw here is a
+        // plugin bug that should surface, so it is intentionally uncaught,
+        // mirroring `validateToken` above.
+        impl.setCredentials?.({ kind: "bearer", value: primaryValue });
+
         await syncWorkspaceCredential(providerId, primaryValue);
 
         return validation;
@@ -225,6 +233,12 @@ export function registerForgeSettingsHandlers(): () => void {
         delete next[providerId];
         store.set("forgeCredentials", next);
       }
+      // Clear in-memory auth state on the live impl for symmetry with SET
+      // (#9983). The impl may be unbound here — a user can clear a credential
+      // without the provider plugin being active — so guard the lookup.
+      const impl = getForgeProviderImpl(providerId);
+      if (impl) impl.setCredentials?.(null);
+
       await syncWorkspaceCredential(providerId, null);
     })
   );

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -89,6 +89,8 @@ import {
   unregisterForgeProviderImpls,
   unregisterForgeProviders,
 } from "./forgeProviderRegistry.js";
+import { buildStoredCredentials } from "./forge/forgeCredentialUtils.js";
+import { makeForgeProviderId } from "../../shared/utils/forgeProviderIds.js";
 import {
   registerFileDecorationProviderImpl,
   registerFileDecorationProviders,
@@ -1754,6 +1756,25 @@ export class PluginService {
         }
 
         registerForgeProviderImpl(pluginId, contributionId, impl);
+
+        // Replay the persisted credential into the freshly bound impl so a
+        // cold start, plugin reload, or dev-mode rescan reaches the provider
+        // authenticated (#9983) — the store is the durable source of truth but
+        // nothing pushed it back into the impl on bind. Synchronous (the
+        // revoked guard above already holds), and wrapped in try/catch because
+        // a plugin's `setCredentials` throwing must not abort activation.
+        const replayId = makeForgeProviderId(pluginId, contributionId);
+        const storedCredentials = buildStoredCredentials(replayId);
+        if (storedCredentials) {
+          try {
+            impl.setCredentials?.(storedCredentials);
+          } catch (err) {
+            console.warn(
+              `[PluginService] registerForgeProvider: setCredentials replay failed for "${replayId}":`,
+              err
+            );
+          }
+        }
 
         let disposed = false;
         const dispose = (): void => {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -93,6 +93,7 @@ vi.mock("../forgeProviderRegistry.js", () => ({
   unregisterForgeProviderImpl: vi.fn(),
   unregisterForgeProviderImpls: vi.fn(),
   getForgeProviderImpl: vi.fn(),
+  getRegisteredForgeProviders: vi.fn(() => []),
   clearForgeProviderImplRegistry: vi.fn(),
 }));
 // Mocked so unload-cascade tests can simulate a throwing decoration unregister
@@ -4054,6 +4055,60 @@ describe("createHost — registerForgeProvider", () => {
     // path during unloadPlugin — independent from the bulk unregisterForgeProviderImpls
     // belt-and-suspenders call.
     expect(unregisterForgeProviderImpl).toHaveBeenCalledWith("acme.forge-flush", "github", impl);
+  });
+
+  it("replays a persisted credential into the freshly bound impl (#9983)", async () => {
+    await writePlugin("forge-replay", forgeManifest("acme.forge-replay"));
+    storeMock._state.set("forgeCredentials", {
+      "acme.forge-replay.github": JSON.stringify({ token: "stored-secret" }),
+    });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(
+      "acme.forge-replay"
+    );
+
+    const setCredentials = vi.fn();
+    host.registerForgeProvider({ id: "github" }, { setCredentials });
+
+    expect(setCredentials).toHaveBeenCalledWith({ kind: "bearer", value: "stored-secret" });
+  });
+
+  it("does not call setCredentials on bind when no credential is stored (#9983)", async () => {
+    await writePlugin("forge-noreplay", forgeManifest("acme.forge-noreplay"));
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(
+      "acme.forge-noreplay"
+    );
+
+    const setCredentials = vi.fn();
+    host.registerForgeProvider({ id: "github" }, { setCredentials });
+
+    expect(setCredentials).not.toHaveBeenCalled();
+  });
+
+  it("survives a setCredentials throw during replay without aborting registration (#9983)", async () => {
+    await writePlugin("forge-replaythrow", forgeManifest("acme.forge-replaythrow"));
+    storeMock._state.set("forgeCredentials", {
+      "acme.forge-replaythrow.github": JSON.stringify({ token: "stored-secret" }),
+    });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(
+      "acme.forge-replaythrow"
+    );
+
+    const setCredentials = vi.fn(() => {
+      throw new Error("boom");
+    });
+    // A plugin's setCredentials throwing must not propagate out of binding.
+    const dispose = host.registerForgeProvider({ id: "github" }, { setCredentials });
+    expect(setCredentials).toHaveBeenCalled();
+    expect(typeof dispose).toBe("function");
   });
 });
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -142,6 +142,7 @@ import {
 } from "../../../shared/config/toolbarButtonRegistry.js";
 import { registerPluginMenuItem, unregisterPluginMenuItems } from "../pluginMenuRegistry.js";
 import {
+  getRegisteredForgeProviders,
   registerForgeProviderImpl,
   registerForgeProviders,
   unregisterForgeProviderImpl,
@@ -4067,6 +4068,43 @@ describe("createHost — registerForgeProvider", () => {
 
     const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(
       "acme.forge-replay"
+    );
+
+    const setCredentials = vi.fn();
+    host.registerForgeProvider({ id: "github" }, { setCredentials });
+
+    expect(setCredentials).toHaveBeenCalledWith({ kind: "bearer", value: "stored-secret" });
+  });
+
+  it("replays the password-typed field (not the first field) on bind (#9983)", async () => {
+    await writePlugin("forge-replayfield", forgeManifest("acme.forge-replayfield"));
+    storeMock._state.set("forgeCredentials", {
+      "acme.forge-replayfield.github": JSON.stringify({
+        baseUrl: "https://github.example",
+        token: "stored-secret",
+      }),
+    });
+    // Provider declares the password field second, so a `fields[0]`-always bug
+    // would replay the base URL instead of the token.
+    vi.mocked(getRegisteredForgeProviders).mockReturnValueOnce([
+      {
+        pluginId: "acme.forge-replayfield",
+        contribution: {
+          id: "github",
+          name: "github",
+          matches: ["github.example"],
+          credentialFields: [
+            { id: "baseUrl", label: "Base URL", type: "text" },
+            { id: "token", label: "API token", type: "password" },
+          ],
+        },
+      },
+    ]);
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(
+      "acme.forge-replayfield"
     );
 
     const setCredentials = vi.fn();

--- a/electron/services/forge/__tests__/forgeCredentialUtils.test.ts
+++ b/electron/services/forge/__tests__/forgeCredentialUtils.test.ts
@@ -57,6 +57,52 @@ describe("buildStoredCredentials", () => {
     });
   });
 
+  it("selects the password-typed field even when it is not declared first", () => {
+    registryMock.getRegisteredForgeProviders.mockReturnValue([
+      {
+        pluginId: "acme",
+        contribution: {
+          id: "gitea",
+          name: "Gitea",
+          matches: ["gitea.example.com"],
+          // Password field deliberately second so a `fields[0]`-always bug fails.
+          credentialFields: [
+            { id: "baseUrl", label: "Base URL", type: "text" },
+            { id: "token", label: "API token", type: "password" },
+          ],
+        },
+      },
+    ]);
+    storeMock._data["forgeCredentials"] = {
+      "acme.gitea": JSON.stringify({ baseUrl: "https://gitea.example.com", token: "secret-token" }),
+    };
+    expect(buildStoredCredentials("acme.gitea")).toEqual({
+      kind: "bearer",
+      value: "secret-token",
+    });
+  });
+
+  it("falls back to the first declared field when none is a password field", () => {
+    registryMock.getRegisteredForgeProviders.mockReturnValue([
+      {
+        pluginId: "acme",
+        contribution: {
+          id: "gitea",
+          name: "Gitea",
+          matches: ["gitea.example.com"],
+          credentialFields: [
+            { id: "user", label: "User", type: "text" },
+            { id: "host", label: "Host", type: "text" },
+          ],
+        },
+      },
+    ]);
+    storeMock._data["forgeCredentials"] = {
+      "acme.gitea": JSON.stringify({ user: "alice", host: "gitea.example.com" }),
+    };
+    expect(buildStoredCredentials("acme.gitea")).toEqual({ kind: "bearer", value: "alice" });
+  });
+
   it("falls back to the first record value when the provider declares no fields", () => {
     registryMock.getRegisteredForgeProviders.mockReturnValue([]);
     storeMock._data["forgeCredentials"] = {

--- a/electron/services/forge/__tests__/forgeCredentialUtils.test.ts
+++ b/electron/services/forge/__tests__/forgeCredentialUtils.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ForgeProviderEntry } from "../../../../shared/types/forge.js";
+
+const storeMock = vi.hoisted(() => {
+  const data: Record<string, unknown> = {};
+  return {
+    get: vi.fn((key: string) => data[key]),
+    set: vi.fn((key: string, value: unknown) => {
+      data[key] = value;
+    }),
+    _data: data,
+  };
+});
+
+vi.mock("../../../store.js", () => ({ store: storeMock }));
+
+const registryMock = vi.hoisted(() => ({
+  getRegisteredForgeProviders: vi.fn<() => ForgeProviderEntry[]>(() => []),
+}));
+
+vi.mock("../../forgeProviderRegistry.js", () => registryMock);
+
+import { buildStoredCredentials } from "../forgeCredentialUtils.js";
+
+function registerGiteaProvider() {
+  registryMock.getRegisteredForgeProviders.mockReturnValue([
+    {
+      pluginId: "acme",
+      contribution: {
+        id: "gitea",
+        name: "Gitea",
+        matches: ["gitea.example.com"],
+        credentialFields: [
+          { id: "token", label: "API token", type: "password" },
+          { id: "baseUrl", label: "Base URL", type: "text" },
+        ],
+      },
+    },
+  ]);
+}
+
+describe("buildStoredCredentials", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const key of Object.keys(storeMock._data)) delete storeMock._data[key];
+    registryMock.getRegisteredForgeProviders.mockReturnValue([]);
+  });
+
+  it("returns the password-typed field as a bearer credential", () => {
+    registerGiteaProvider();
+    storeMock._data["forgeCredentials"] = {
+      "acme.gitea": JSON.stringify({ token: "secret-token", baseUrl: "https://gitea.example.com" }),
+    };
+    expect(buildStoredCredentials("acme.gitea")).toEqual({
+      kind: "bearer",
+      value: "secret-token",
+    });
+  });
+
+  it("falls back to the first record value when the provider declares no fields", () => {
+    registryMock.getRegisteredForgeProviders.mockReturnValue([]);
+    storeMock._data["forgeCredentials"] = {
+      "acme.gitea": JSON.stringify({ apiKey: "lone-value" }),
+    };
+    expect(buildStoredCredentials("acme.gitea")).toEqual({ kind: "bearer", value: "lone-value" });
+  });
+
+  it("returns null when no credential is stored for the provider", () => {
+    registerGiteaProvider();
+    storeMock._data["forgeCredentials"] = {
+      "corp.gitlab": JSON.stringify({ token: "other" }),
+    };
+    expect(buildStoredCredentials("acme.gitea")).toBeNull();
+  });
+
+  it("returns null when the forgeCredentials key is absent", () => {
+    registerGiteaProvider();
+    expect(buildStoredCredentials("acme.gitea")).toBeNull();
+  });
+
+  it("returns null when the primary value is empty or whitespace", () => {
+    registerGiteaProvider();
+    storeMock._data["forgeCredentials"] = {
+      "acme.gitea": JSON.stringify({ token: "   ", baseUrl: "https://gitea.example.com" }),
+    };
+    expect(buildStoredCredentials("acme.gitea")).toBeNull();
+  });
+
+  it("returns null for a malformed stored record", () => {
+    registerGiteaProvider();
+    storeMock._data["forgeCredentials"] = { "acme.gitea": "not-json{" };
+    expect(buildStoredCredentials("acme.gitea")).toBeNull();
+  });
+
+  it("returns null for an empty or invalid provider id", () => {
+    registerGiteaProvider();
+    expect(buildStoredCredentials("")).toBeNull();
+  });
+});

--- a/electron/services/forge/forgeCredentialUtils.ts
+++ b/electron/services/forge/forgeCredentialUtils.ts
@@ -1,0 +1,66 @@
+// eager-import-allow: reads the forgeCredentials store key via store.get inside buildStoredCredentials, invoked from forge provider registration (not at boot)
+import { store } from "../../store.js";
+import { getRegisteredForgeProviders } from "../forgeProviderRegistry.js";
+import { makeForgeProviderId } from "../../../shared/utils/forgeProviderIds.js";
+import type { CredentialField, Credentials } from "../../../shared/types/forge.js";
+
+/**
+ * Look up a registered provider's declared credential fields by canonical id.
+ * Returns `[]` when the provider declares none (or is not registered) — the
+ * caller treats that as a single-value credential. Mirrors the private helper
+ * in `forgeSettings.ts`; kept here so the boot-time replay in `PluginService`
+ * can reconstruct credentials without importing the IPC handler module.
+ */
+function credentialFieldsFor(providerId: string): CredentialField[] {
+  const entry = getRegisteredForgeProviders().find(
+    (p) => makeForgeProviderId(p.pluginId, p.contribution.id) === providerId
+  );
+  return entry?.contribution.credentialFields ?? [];
+}
+
+/**
+ * Pick the primary credential value from a stored record. The primary field is
+ * the first `"password"`-typed declared field, else the first declared field;
+ * with no declared fields, the first record value. Matches `pickPrimaryValue`
+ * in `forgeSettings.ts` so save-time and replay-time agree on the value.
+ */
+function pickPrimaryValue(fields: CredentialField[], credentials: Record<string, string>): string {
+  if (fields.length > 0) {
+    const primary = fields.find((f) => f.type === "password") ?? fields[0];
+    return credentials[primary.id] ?? "";
+  }
+  const first = Object.values(credentials)[0];
+  return typeof first === "string" ? first : "";
+}
+
+/**
+ * Reconstruct the {@link Credentials} object persisted for a provider so the
+ * host can replay it into a freshly bound impl via `setCredentials`. Reads the
+ * durable `forgeCredentials` store entry (a `JSON.stringify`'d
+ * `Record<string,string>`), extracts the primary value, and wraps it as a
+ * bearer credential — the same shape `syncWorkspaceCredential` constructs at
+ * save time. Returns `null` when no credential is stored, the record is
+ * malformed, or the primary value is empty.
+ */
+export function buildStoredCredentials(providerId: string): Credentials | null {
+  if (typeof providerId !== "string" || providerId.length === 0) return null;
+  const map = store.get("forgeCredentials") ?? {};
+  const raw = map[providerId];
+  if (!raw) return null;
+
+  let record: Record<string, string>;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    record = {};
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof v === "string") record[k] = v;
+    }
+  } catch {
+    return null;
+  }
+
+  const value = pickPrimaryValue(credentialFieldsFor(providerId), record).trim();
+  if (value.length === 0) return null;
+  return { kind: "bearer", value };
+}


### PR DESCRIPTION
## Summary

- `FORGE_SET_CREDENTIAL` was write-only: it persisted credentials to the `forgeCredentials` store but never called `impl.setCredentials`, so every non-GitHub forge provider ran unauthenticated despite the UI showing "connected".
- Fix delivers credentials to the impl at three points: on save, on clear, and as a replay into freshly bound impls at `registerForgeProvider` (covers cold start, plugin reload, and dev rescan).
- New helper `buildStoredCredentials` in `electron/services/forge/forgeCredentialUtils.ts` reconstructs the bearer credential from the persisted record. `setCredentials` is optional and guarded at all three call sites; the replay is wrapped in try/catch so a plugin throw can't abort activation.

Resolves #9983

## Changes

- `electron/ipc/handlers/forgeSettings.ts` — `FORGE_SET_CREDENTIAL` calls `impl.setCredentials({ kind: "bearer", value: primaryValue })` after persist; `FORGE_CLEAR_CREDENTIAL` calls `impl.setCredentials(null)` (guarded for unbound impl).
- `electron/services/forge/forgeCredentialUtils.ts` — new `buildStoredCredentials` helper.
- `electron/services/PluginService.ts` — `registerForgeProvider` replays the persisted credential into the impl via `buildStoredCredentials`.

## Testing

493 unit tests pass — `forgeSettings` handlers, the new `forgeCredentialUtils` suite, and `PluginService` replay coverage. `npm run check` clean.