### PR TITLE
fix(panels): clear maximize when a maximized panel leaves grid scope (#9936)

### DIFF
--- a/src/store/__tests__/panelStore.adversarial.test.ts
+++ b/src/store/__tests__/panelStore.adversarial.test.ts
@@ -369,6 +369,26 @@ describe("panelStore adversarial", () => {
       expectMaximizeCleared();
     });
 
+    it("moveTabGroupToLocation clears maximize when the maximized group is dragged into the dock", () => {
+      seedMaximizedGroup();
+      usePanelStore.getState().moveTabGroupToLocation("g1", "dock");
+      expectMaximizeCleared();
+    });
+
+    it("moveTerminalToDock clears maximize when a sibling of the maximized group is docked", () => {
+      seedMaximizedGroup();
+      // p2 is in the maximized group; p1 is the tracking panel. Docking p2
+      // routes through moveTabGroupToLocation internally.
+      usePanelStore.getState().moveTerminalToDock("p2");
+      expectMaximizeCleared();
+    });
+
+    it("backgroundPanelGroup clears maximize for an ungrouped maximized panel via delegation", () => {
+      seedMaximizedPanel();
+      usePanelStore.getState().backgroundPanelGroup("p1");
+      expectMaximizeCleared();
+    });
+
     it("moveTerminalToPosition clears maximize when the maximized panel is dragged into the dock", () => {
       seedMaximizedPanel();
       usePanelStore.getState().moveTerminalToPosition("p1", 0, "dock");
@@ -383,6 +403,22 @@ describe("panelStore adversarial", () => {
       expect(s.maximizedId).toBe("p1");
       expect(s.maximizeTarget).toEqual({ type: "panel", id: "p1" });
       expect(s.preMaximizeLayout).not.toBeNull();
+    });
+
+    it("leaves maximize untouched on a within-grid reposition (location stays grid)", () => {
+      seedMaximizedPanel();
+      usePanelStore.getState().moveTerminalToPosition("p1", 1, "grid");
+      const s = usePanelStore.getState();
+      expect(s.maximizedId).toBe("p1");
+      expect(s.maximizeTarget).toEqual({ type: "panel", id: "p1" });
+    });
+
+    it("leaves maximize untouched on a same-worktree no-op move", () => {
+      seedMaximizedPanel();
+      usePanelStore.getState().moveTerminalToWorktree("p1", "wt-1");
+      const s = usePanelStore.getState();
+      expect(s.maximizedId).toBe("p1");
+      expect(s.maximizeTarget).toEqual({ type: "panel", id: "p1" });
     });
   });
 });

--- a/src/store/__tests__/panelStore.adversarial.test.ts
+++ b/src/store/__tests__/panelStore.adversarial.test.ts
@@ -279,4 +279,110 @@ describe("panelStore adversarial", () => {
 
     expect(usePanelStore.getState().lastClosedConfig).toBe(priorSnapshot);
   });
+
+  describe("maximize state cleared on out-of-grid moves (#9936)", () => {
+    function makePanel(id: string, overrides: Record<string, unknown> = {}) {
+      return {
+        id,
+        title: id,
+        cwd: "/a",
+        location: "grid",
+        createdAt: 1,
+        type: "terminal",
+        kind: "terminal",
+        worktreeId: "wt-1",
+        ...overrides,
+      } as unknown as never;
+    }
+
+    function makeGroup() {
+      return {
+        id: "g1",
+        location: "grid",
+        activeTabId: "p1",
+        panelIds: ["p1", "p2"],
+        worktreeId: "wt-1",
+      };
+    }
+
+    function seedMaximizedPanel() {
+      usePanelStore.setState({
+        panelsById: { p1: makePanel("p1"), p2: makePanel("p2") },
+        panelIds: ["p1", "p2"],
+        panelIdsByWorktreeId: { "wt-1": ["p1", "p2"] },
+        maximizedId: "p1",
+        maximizeTarget: { type: "panel", id: "p1" },
+        preMaximizeLayout: { kind: "snapshot" } as unknown as never,
+      });
+    }
+
+    function seedMaximizedGroup() {
+      usePanelStore.setState({
+        panelsById: { p1: makePanel("p1"), p2: makePanel("p2") },
+        panelIds: ["p1", "p2"],
+        panelIdsByWorktreeId: { "wt-1": ["p1", "p2"] },
+        tabGroups: new Map([["g1", makeGroup()]]) as never,
+        // Group-maximize tracks the triggering PANEL in maximizedId; the group
+        // id lives in maximizeTarget.id.
+        maximizedId: "p1",
+        maximizeTarget: { type: "group", id: "g1" },
+        preMaximizeLayout: { kind: "snapshot" } as unknown as never,
+      });
+    }
+
+    function expectMaximizeCleared() {
+      const s = usePanelStore.getState();
+      expect(s.maximizedId).toBeNull();
+      expect(s.maximizeTarget).toBeNull();
+      expect(s.preMaximizeLayout).toBeNull();
+    }
+
+    it("backgroundTerminal clears maximize when the maximized panel is sent to background", () => {
+      seedMaximizedPanel();
+      usePanelStore.getState().backgroundTerminal("p1");
+      expectMaximizeCleared();
+    });
+
+    it("backgroundTerminal clears maximize when a sibling of the maximized group is backgrounded", () => {
+      seedMaximizedGroup();
+      // Background p2 — not the tracking panel (p1) but a member of the
+      // maximized group, so maximize must still clear.
+      usePanelStore.getState().backgroundTerminal("p2");
+      expectMaximizeCleared();
+    });
+
+    it("backgroundPanelGroup clears maximize when the maximized group is backgrounded", () => {
+      seedMaximizedGroup();
+      usePanelStore.getState().backgroundPanelGroup("p1");
+      expectMaximizeCleared();
+    });
+
+    it("moveTerminalToWorktree clears maximize when the maximized panel changes worktree", () => {
+      seedMaximizedPanel();
+      usePanelStore.getState().moveTerminalToWorktree("p1", "wt-2");
+      expectMaximizeCleared();
+    });
+
+    it("moveTabGroupToWorktree clears maximize when the maximized group changes worktree", () => {
+      seedMaximizedGroup();
+      usePanelStore.getState().moveTabGroupToWorktree("g1", "wt-2");
+      expectMaximizeCleared();
+    });
+
+    it("moveTerminalToPosition clears maximize when the maximized panel is dragged into the dock", () => {
+      seedMaximizedPanel();
+      usePanelStore.getState().moveTerminalToPosition("p1", 0, "dock");
+      expectMaximizeCleared();
+    });
+
+    it("leaves maximize untouched when an unrelated panel is moved out of grid scope", () => {
+      seedMaximizedPanel();
+      // p2 is neither the maximized panel nor in its group.
+      usePanelStore.getState().backgroundTerminal("p2");
+      const s = usePanelStore.getState();
+      expect(s.maximizedId).toBe("p1");
+      expect(s.maximizeTarget).toEqual({ type: "panel", id: "p1" });
+      expect(s.preMaximizeLayout).not.toBeNull();
+    });
+  });
 });

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -472,17 +472,22 @@ export const usePanelStore = create<PanelGridState>()(
             ...(nextFocusedId !== previousFocusedId && { previousFocusedId }),
           });
         } else {
+          const updates: Partial<PanelGridState> = {};
           const focusedId = get().focusedId;
           if (focusedId && groupBeforeMove.panelIds.includes(focusedId)) {
             // The previously focused panel is now in the dock and `focusedId`
             // is being cleared as a side effect of the move, not a user
             // navigation. Clear the alternate pointer to keep round-trip
             // semantics tied to explicit focus changes.
-            set({
-              focusedId: null,
-              activeDockTerminalId: groupBeforeMove.activeTabId,
-              previousFocusedId: null,
-            });
+            updates.focusedId = null;
+            updates.activeDockTerminalId = groupBeforeMove.activeTabId;
+            updates.previousFocusedId = null;
+          }
+          // Dragging a maximized group into the dock takes it out of grid scope —
+          // clear maximize so the grid doesn't render blank (#9936).
+          Object.assign(updates, buildMaximizeClearPatch(get().maximizedId, "", groupBeforeMove));
+          if (Object.keys(updates).length > 0) {
+            set(updates);
           }
         }
 

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -235,6 +235,31 @@ export interface PanelGridState
   restoreLastTrashed: () => void;
 }
 
+/**
+ * Build the maximize-clearing patch for a panel leaving the active worktree's
+ * grid. Returns `{ maximizedId, maximizeTarget, preMaximizeLayout }` set to null
+ * when `panelId` is the maximized panel itself, or a member of the maximized
+ * group; otherwise an empty patch.
+ *
+ * Fixes #9936: "Send to Background", "Move to Worktree", and drag-to-dock could
+ * relocate a maximized panel out of grid scope while `maximizedId` stayed set,
+ * so `ContentGrid` rendered `null` and the whole grid went blank for every
+ * worktree that didn't contain the panel. `group` MUST be snapshotted before the
+ * registry mutation — backgrounding and dock moves dissolve the group. Mirrors
+ * the check `moveTerminalToDock` already performs.
+ */
+function buildMaximizeClearPatch(
+  maximizedId: string | null,
+  panelId: string,
+  group: { panelIds: string[] } | undefined
+): Partial<PanelGridState> {
+  if (!maximizedId) return {};
+  if (maximizedId === panelId || (group?.panelIds.includes(maximizedId) ?? false)) {
+    return { maximizedId: null, maximizeTarget: null, preMaximizeLayout: null };
+  }
+  return {};
+}
+
 export const usePanelStore = create<PanelGridState>()(
   subscribeWithSelector((set, get, api) => {
     const getTerminals = () => selectOrderedTerminals(get().panelsById, get().panelIds);
@@ -381,6 +406,10 @@ export const usePanelStore = create<PanelGridState>()(
         // concurrent rendering.
         const movingKind = state.panelsById[id]?.kind;
         const policy = resolvePanelKindPolicy(movingKind);
+        // Snapshot group membership before the move — a grouped dock move
+        // relocates the group intact, but reading it up front keeps the
+        // maximize check identical to the dissolving paths (background/drag).
+        const group = registrySlice.getPanelGroup(id);
         registrySlice.moveTerminalToDock(id);
 
         const updates: Partial<PanelGridState> = {};
@@ -402,14 +431,7 @@ export const usePanelStore = create<PanelGridState>()(
           updates.previousFocusedId = null;
         }
 
-        if (state.maximizedId) {
-          const group = registrySlice.getPanelGroup(id);
-          if (state.maximizedId === id || (group && group.panelIds.includes(state.maximizedId))) {
-            updates.maximizedId = null;
-            updates.maximizeTarget = null;
-            updates.preMaximizeLayout = null;
-          }
-        }
+        Object.assign(updates, buildMaximizeClearPatch(state.maximizedId, id, group));
 
         if (Object.keys(updates).length > 0) {
           set(updates);
@@ -464,6 +486,58 @@ export const usePanelStore = create<PanelGridState>()(
           }
         }
 
+        return moved;
+      },
+
+      backgroundTerminal: (id: string) => {
+        const { maximizedId } = get();
+        // Snapshot the group before the move — backgrounding dissolves it.
+        const group = registrySlice.getPanelGroup(id);
+        registrySlice.backgroundTerminal(id);
+        const patch = buildMaximizeClearPatch(maximizedId, id, group);
+        if (Object.keys(patch).length > 0) {
+          set(patch);
+        }
+      },
+
+      backgroundPanelGroup: (panelId: string) => {
+        const { maximizedId } = get();
+        // Snapshot the group before the move — backgrounding dissolves it. The
+        // ungrouped path delegates to the (wrapped) backgroundTerminal, which
+        // clears maximize on its own; this patch covers the grouped path.
+        const group = registrySlice.getPanelGroup(panelId);
+        registrySlice.backgroundPanelGroup(panelId);
+        const patch = buildMaximizeClearPatch(maximizedId, panelId, group);
+        if (Object.keys(patch).length > 0) {
+          set(patch);
+        }
+      },
+
+      moveTerminalToWorktree: (id: string, worktreeId: string) => {
+        const { maximizedId, panelsById } = get();
+        const panel = panelsById[id];
+        const group = registrySlice.getPanelGroup(id);
+        registrySlice.moveTerminalToWorktree(id, worktreeId);
+        // Same-worktree no-op leaves maximize valid; grouped moves delegate to
+        // the moveTabGroupToWorktree wrapper (via get()), which clears there.
+        if (group || !panel || panel.worktreeId === worktreeId) return;
+        const patch = buildMaximizeClearPatch(maximizedId, id, undefined);
+        if (Object.keys(patch).length > 0) {
+          set(patch);
+        }
+      },
+
+      moveTabGroupToWorktree: (groupId: string, worktreeId: string) => {
+        const { maximizedId } = get();
+        const group = get().tabGroups.get(groupId);
+        const moved = registrySlice.moveTabGroupToWorktree(groupId, worktreeId);
+        // Only clear on an actual cross-worktree move of the maximized group.
+        if (moved && group && group.worktreeId !== worktreeId) {
+          const patch = buildMaximizeClearPatch(maximizedId, "", group);
+          if (Object.keys(patch).length > 0) {
+            set(patch);
+          }
+        }
         return moved;
       },
 
@@ -657,6 +731,10 @@ export const usePanelStore = create<PanelGridState>()(
         // branch's pick-rule reads the moving panel's kind.
         const movingKind = state.panelsById[id]?.kind;
         const policy = resolvePanelKindPolicy(movingKind);
+        // Snapshot group membership before the move — moveTerminalToPosition
+        // prunes the panel from its tab group, so the maximize check must read
+        // it up front (#9936).
+        const group = registrySlice.getPanelGroup(id);
         registrySlice.moveTerminalToPosition(id, toIndex, location, worktreeId);
 
         if (location === "grid") {
@@ -666,19 +744,26 @@ export const usePanelStore = create<PanelGridState>()(
             activeDockTerminalId: null,
             ...(previousFocusedId !== id && { previousFocusedId }),
           });
-        } else if (state.focusedId === id) {
-          // Auto-fallback focus when the focused panel is moved to dock —
-          // not a user navigation, so the alternate pointer becomes stale.
-          set({
-            focusedId: pickFallbackFocusId(
+        } else {
+          const updates: Partial<PanelGridState> = {};
+          if (state.focusedId === id) {
+            // Auto-fallback focus when the focused panel is moved to dock —
+            // not a user navigation, so the alternate pointer becomes stale.
+            updates.focusedId = pickFallbackFocusId(
               state,
               new Set([id]),
               getActiveWorktreeId() ?? undefined,
               policy,
               false
-            ),
-            previousFocusedId: null,
-          });
+            );
+            updates.previousFocusedId = null;
+          }
+          // Dragging a maximized panel into the dock takes it out of grid scope —
+          // clear maximize so the grid doesn't render blank (#9936).
+          Object.assign(updates, buildMaximizeClearPatch(state.maximizedId, id, group));
+          if (Object.keys(updates).length > 0) {
+            set(updates);
+          }
         }
       },
 


### PR DESCRIPTION
## Summary

- When a maximized panel left the active worktree's grid (send to background, move to worktree, drag panel to dock, drag tab-group to dock), `maximizedId` and `maximizeTarget` stayed set — causing `ContentGrid` to return `null` and the entire grid to go blank for any worktree that didn't contain the panel.
- Added a `buildMaximizeClearPatch` helper to `panelStore` and threaded it through every code path that can move a panel out of grid scope: `backgroundTerminal`, `backgroundPanelGroup`, `moveTerminalToWorktree`, `moveTabGroupToWorktree`, `moveTerminalToDock`, `moveTerminalToPosition`, and `moveTabGroupToLocation`. The patch only fires when the moved panel is the maximized panel or a member of the maximized group.
- 12 new adversarial tests, 19 total — single-panel and group-maximize across all four exit paths, plus within-grid/same-worktree negative guards to make sure we don't clear unnecessarily. All passing.

Resolves #9936

## Changes

- `src/store/panelStore.ts` — `buildMaximizeClearPatch` helper; patched `backgroundTerminal`, `backgroundPanelGroup`, `moveTerminalToWorktree`, `moveTabGroupToWorktree`, `moveTerminalToDock`, `moveTerminalToPosition`, `moveTabGroupToLocation`
- `src/store/__tests__/panelStore.adversarial.test.ts` — 12 new tests covering all exit paths and negative cases

## Testing

Typecheck, lint, format, and build all clean. All 19 unit tests pass. No new dependencies.