### PR TITLE
fix(terminal): clear stale flow status on exit, restart, and host recovery

### DIFF
--- a/src/store/listeners/panel/__tests__/backendHealth.test.ts
+++ b/src/store/listeners/panel/__tests__/backendHealth.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { usePanelStore } from "@/store/panelStore";
 import { isPtyPanel } from "@shared/types/panel";
+import { enqueueFlowStatusUpdate, flushPanelStatusBuffer } from "@/store/panelStatusBuffer";
 
 vi.mock("@/utils/logger", () => ({
   logInfo: vi.fn(),
@@ -154,6 +155,31 @@ describe("onBackendReady — stale flow state cleared on host recovery (#9899)",
     getBackendReadyHandler()();
 
     expect(usePanelStore.getState().panelsById["browser-1"]).toEqual(browserPanel);
+  });
+
+  it("a flow patch buffered before the crash does not resurrect the pill after recovery", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "term-1": {
+          ...ptyBase,
+          id: "term-1",
+          isVisible: true,
+          runtimeStatus: "running",
+        },
+      },
+      panelIds: ["term-1"],
+    });
+
+    // A flow event was enqueued just before the host crashed; it never flushed.
+    enqueueFlowStatusUpdate("term-1", "paused-backpressure", 999);
+
+    getBackendReadyHandler()();
+
+    // Recovery cancels the buffer; a later flush must not write the stale patch.
+    flushPanelStatusBuffer();
+
+    expect(getPanel("term-1")?.flowStatus).toBeUndefined();
+    expect(getPanel("term-1")?.runtimeStatus).toBe("running");
   });
 
   it("does not rewrite already-clean PTY panels (referential stability)", () => {

--- a/src/store/listeners/panel/__tests__/backendHealth.test.ts
+++ b/src/store/listeners/panel/__tests__/backendHealth.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { usePanelStore } from "@/store/panelStore";
+import { isPtyPanel } from "@shared/types/panel";
+
+vi.mock("@/utils/logger", () => ({
+  logInfo: vi.fn(),
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    handleBackendRecovery: vi.fn(),
+  },
+}));
+
+const backendReadyHandlers = vi.hoisted(() => [] as Array<() => void>);
+vi.mock("@/controllers", () => {
+  const noopSub = () => () => {};
+  return {
+    terminalRegistryController: {
+      onBackendCrashed: vi.fn(noopSub),
+      onBackendRecovering: vi.fn(noopSub),
+      onBackendReady: vi.fn((handler: () => void) => {
+        backendReadyHandlers.push(handler);
+        return () => {};
+      }),
+    },
+  };
+});
+
+import { setupBackendHealthListeners } from "../backendHealth";
+
+function getBackendReadyHandler(): () => void {
+  backendReadyHandlers.length = 0;
+  setupBackendHealthListeners();
+  const handler = backendReadyHandlers.at(-1);
+  if (!handler) throw new Error("onBackendReady handler was not registered");
+  return handler;
+}
+
+function getPanel(id: string) {
+  const panel = usePanelStore.getState().panelsById[id];
+  if (!panel || !isPtyPanel(panel)) return undefined;
+  return panel;
+}
+
+const ptyBase = {
+  kind: "terminal" as const,
+  title: "Terminal",
+  cwd: "/tmp",
+  cols: 80,
+  rows: 24,
+  location: "grid" as const,
+};
+
+beforeEach(() => {
+  usePanelStore.setState({ panelsById: {}, panelIds: [] });
+  vi.useFakeTimers();
+});
+
+describe("onBackendReady — stale flow state cleared on host recovery (#9899)", () => {
+  it("clears flow fields and re-derives runtimeStatus on a paused PTY panel", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "term-1": {
+          ...ptyBase,
+          id: "term-1",
+          isVisible: true,
+          flowStatus: "paused-backpressure",
+          flowStatusTimestamp: 999,
+          heldDurationMs: 5000,
+          runtimeStatus: "paused-backpressure",
+        },
+      },
+      panelIds: ["term-1"],
+    });
+
+    getBackendReadyHandler()();
+
+    const panel = getPanel("term-1");
+    expect(panel?.flowStatus).toBeUndefined();
+    expect(panel?.flowStatusTimestamp).toBeUndefined();
+    expect(panel?.heldDurationMs).toBeUndefined();
+    // Visible, non-exited panel with no flow status derives back to "running".
+    expect(panel?.runtimeStatus).toBe("running");
+  });
+
+  it("clears flow state across multiple paused PTY panels in one pass", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "term-1": {
+          ...ptyBase,
+          id: "term-1",
+          isVisible: true,
+          flowStatus: "paused-backpressure",
+          runtimeStatus: "paused-backpressure",
+        },
+        "term-2": {
+          ...ptyBase,
+          id: "term-2",
+          isVisible: false,
+          flowStatus: "suspended",
+          runtimeStatus: "suspended",
+        },
+      },
+      panelIds: ["term-1", "term-2"],
+    });
+
+    getBackendReadyHandler()();
+
+    expect(getPanel("term-1")?.flowStatus).toBeUndefined();
+    expect(getPanel("term-1")?.runtimeStatus).toBe("running");
+    expect(getPanel("term-2")?.flowStatus).toBeUndefined();
+    // Backgrounded panel derives to "background", not "running".
+    expect(getPanel("term-2")?.runtimeStatus).toBe("background");
+  });
+
+  it("preserves runtimeStatus on exited panels (does not revive them)", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "term-1": {
+          ...ptyBase,
+          id: "term-1",
+          isVisible: true,
+          flowStatus: "paused-backpressure",
+          runtimeStatus: "exited",
+        },
+      },
+      panelIds: ["term-1"],
+    });
+
+    getBackendReadyHandler()();
+
+    const panel = getPanel("term-1");
+    expect(panel?.flowStatus).toBeUndefined();
+    expect(panel?.runtimeStatus).toBe("exited");
+  });
+
+  it("leaves non-PTY panels untouched", () => {
+    const browserPanel = {
+      id: "browser-1",
+      kind: "browser" as const,
+      title: "Browser",
+      location: "grid" as const,
+      url: "https://example.com",
+    };
+    usePanelStore.setState({
+      panelsById: { "browser-1": browserPanel },
+      panelIds: ["browser-1"],
+    });
+
+    getBackendReadyHandler()();
+
+    expect(usePanelStore.getState().panelsById["browser-1"]).toEqual(browserPanel);
+  });
+
+  it("does not rewrite already-clean PTY panels (referential stability)", () => {
+    const clean = {
+      ...ptyBase,
+      id: "term-1",
+      isVisible: true,
+      runtimeStatus: "running" as const,
+    };
+    usePanelStore.setState({
+      panelsById: { "term-1": clean },
+      panelIds: ["term-1"],
+    });
+
+    getBackendReadyHandler()();
+
+    // Same object reference — no spurious setState write for an unchanged panel.
+    expect(usePanelStore.getState().panelsById["term-1"]).toBe(clean);
+  });
+});

--- a/src/store/listeners/panel/__tests__/lifecycle.test.ts
+++ b/src/store/listeners/panel/__tests__/lifecycle.test.ts
@@ -592,4 +592,45 @@ describe("onExit — stale flow state cleared (#9899)", () => {
 
     expect(getPanel("term-1")?.flowStatus).toBeUndefined();
   });
+
+  it("a late flow event after exit does not revive the pill", () => {
+    setupPanel();
+    getExitHandler()("term-1", 1);
+    expect(getPanel("term-1")?.runtimeStatus).toBe("exited");
+
+    // A flow event arrives from the dead PTY after exit was processed.
+    enqueueFlowStatusUpdate("term-1", "paused-backpressure", 5000);
+    flushPanelStatusBuffer();
+
+    expect(getPanel("term-1")?.flowStatus).toBeUndefined();
+    expect(getPanel("term-1")?.runtimeStatus).toBe("exited");
+  });
+
+  it("evicting one terminal's buffer leaves another terminal's pending patch intact", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "term-1": { id: "term-1", kind: "terminal", title: "T1", cwd: "/tmp", location: "grid" },
+        "term-2": {
+          id: "term-2",
+          kind: "terminal",
+          title: "T2",
+          cwd: "/tmp",
+          location: "grid",
+          isVisible: true,
+        },
+      },
+      panelIds: ["term-1", "term-2"],
+    });
+
+    // Both terminals have a pending flow patch; only term-1 exits.
+    enqueueFlowStatusUpdate("term-1", "paused-backpressure", 100);
+    enqueueFlowStatusUpdate("term-2", "paused-backpressure", 100);
+
+    getExitHandler()("term-1", 1);
+    flushPanelStatusBuffer();
+
+    // term-1's patch was evicted; term-2's still applies.
+    expect(getPanel("term-1")?.flowStatus).toBeUndefined();
+    expect(getPanel("term-2")?.flowStatus).toBe("paused-backpressure");
+  });
 });

--- a/src/store/listeners/panel/__tests__/lifecycle.test.ts
+++ b/src/store/listeners/panel/__tests__/lifecycle.test.ts
@@ -28,6 +28,7 @@ const restoredHandlers = vi.hoisted(() => [] as Array<(data: { id: string }) => 
 const trashedHandlers = vi.hoisted(
   () => [] as Array<(data: { id: string; expiresAt: number }) => void>
 );
+const exitHandlers = vi.hoisted(() => [] as Array<(id: string, exitCode: number) => void>);
 const reliabilityMetricHandlers = vi.hoisted(
   () =>
     [] as Array<
@@ -51,7 +52,10 @@ vi.mock("@/controllers", () => {
         restoredHandlers.push(handler);
         return () => {};
       }),
-      onExit: vi.fn(noopSub),
+      onExit: vi.fn((handler: (id: string, exitCode: number) => void) => {
+        exitHandlers.push(handler);
+        return () => {};
+      }),
       onStatus: vi.fn(noopSub),
       onReliabilityMetric: vi.fn(
         (
@@ -74,7 +78,7 @@ vi.mock("@/controllers", () => {
 
 import { handleFallbackTriggered, setupLifecycleListeners } from "../lifecycle";
 import { notify } from "@/lib/notify";
-import { flushPanelStatusBuffer } from "@/store/panelStatusBuffer";
+import { flushPanelStatusBuffer, enqueueFlowStatusUpdate } from "@/store/panelStatusBuffer";
 import { isPtyPanel } from "@shared/types/panel";
 
 function getPtyHeldDuration(id: string): number | undefined {
@@ -538,5 +542,54 @@ describe("onReliabilityMetric — pause-duration-gauge routing", () => {
     flushPanelStatusBuffer();
 
     expect(getPtyHeldDuration("term-1")).toBeUndefined();
+  });
+});
+
+describe("onExit — stale flow state cleared (#9899)", () => {
+  function getExitHandler(): (id: string, exitCode: number) => void {
+    exitHandlers.length = 0;
+    setupLifecycleListeners();
+    const handler = exitHandlers.at(-1);
+    if (!handler) throw new Error("onExit handler was not registered");
+    return handler;
+  }
+
+  function getPanel(id: string) {
+    const panel = usePanelStore.getState().panelsById[id];
+    if (!panel || !isPtyPanel(panel)) return undefined;
+    return panel;
+  }
+
+  it("clears flowStatus, flowStatusTimestamp, and heldDurationMs on exit", () => {
+    // Non-zero exit code preserves the panel so we can inspect the cleared fields.
+    setupPanel({
+      flowStatus: "paused-backpressure",
+      flowStatusTimestamp: 12345,
+      heldDurationMs: 8000,
+    });
+
+    getExitHandler()("term-1", 1);
+
+    const panel = getPanel("term-1");
+    expect(panel?.flowStatus).toBeUndefined();
+    expect(panel?.flowStatusTimestamp).toBeUndefined();
+    expect(panel?.heldDurationMs).toBeUndefined();
+    expect(panel?.runtimeStatus).toBe("exited");
+    expect(panel?.exitCode).toBe(1);
+  });
+
+  it("a buffered flow-status patch does not resurrect the pill after exit", () => {
+    setupPanel({ flowStatus: "paused-backpressure", flowStatusTimestamp: 1 });
+
+    // Simulate an in-flight RAF: enqueue a flow-status patch that has not yet
+    // flushed when the terminal exits.
+    enqueueFlowStatusUpdate("term-1", "paused-backpressure", 999);
+
+    getExitHandler()("term-1", 1);
+
+    // The exit handler evicts the buffered patch; flushing must not write it back.
+    flushPanelStatusBuffer();
+
+    expect(getPanel("term-1")?.flowStatus).toBeUndefined();
   });
 });

--- a/src/store/listeners/panel/__tests__/lifecycle.test.ts
+++ b/src/store/listeners/panel/__tests__/lifecycle.test.ts
@@ -609,12 +609,22 @@ describe("onExit — stale flow state cleared (#9899)", () => {
   it("evicting one terminal's buffer leaves another terminal's pending patch intact", () => {
     usePanelStore.setState({
       panelsById: {
-        "term-1": { id: "term-1", kind: "terminal", title: "T1", cwd: "/tmp", location: "grid" },
+        "term-1": {
+          id: "term-1",
+          kind: "terminal",
+          title: "T1",
+          cwd: "/tmp",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
         "term-2": {
           id: "term-2",
           kind: "terminal",
           title: "T2",
           cwd: "/tmp",
+          cols: 80,
+          rows: 24,
           location: "grid",
           isVisible: true,
         },

--- a/src/store/listeners/panel/backendHealth.ts
+++ b/src/store/listeners/panel/backendHealth.ts
@@ -6,6 +6,7 @@ import { logInfo, logError, logWarn } from "@/utils/logger";
 import { DisposableStore, toDisposable } from "@/utils/disposable";
 import { usePanelStore } from "@/store/panelStore";
 import { deriveRuntimeStatus } from "@/store/slices/panelRegistry/helpers";
+import { cancelPanelStatusBuffer } from "@/store/panelStatusBuffer";
 
 /**
  * Clear stale flow state on every PTY panel after a pty-host crash + recovery.
@@ -15,16 +16,27 @@ import { deriveRuntimeStatus } from "@/store/slices/panelRegistry/helpers";
  * subscriber notifications; unchanged panels are left untouched (#9899).
  */
 function clearFlowStateOnRecovery(): void {
+  // Drop every buffered status patch first — they were enqueued before the
+  // crash and the recovered host won't re-emit them, so a pending RAF flush
+  // would otherwise restore the stale "paused" pill right after we clear it.
+  cancelPanelStatusBuffer();
+
   usePanelStore.setState((state) => {
     const nextById = { ...state.panelsById };
     let changed = false;
     for (const id of Object.keys(nextById)) {
       const panel = nextById[id];
       if (!panel || !isPtyPanel(panel)) continue;
+      const nextRuntimeStatus = deriveRuntimeStatus(
+        panel.isVisible,
+        undefined,
+        panel.runtimeStatus
+      );
       if (
         panel.flowStatus === undefined &&
         panel.flowStatusTimestamp === undefined &&
-        panel.heldDurationMs === undefined
+        panel.heldDurationMs === undefined &&
+        panel.runtimeStatus === nextRuntimeStatus
       ) {
         continue;
       }
@@ -33,7 +45,7 @@ function clearFlowStateOnRecovery(): void {
         flowStatus: undefined,
         flowStatusTimestamp: undefined,
         heldDurationMs: undefined,
-        runtimeStatus: deriveRuntimeStatus(panel.isVisible, undefined, panel.runtimeStatus),
+        runtimeStatus: nextRuntimeStatus,
       };
       changed = true;
     }

--- a/src/store/listeners/panel/backendHealth.ts
+++ b/src/store/listeners/panel/backendHealth.ts
@@ -1,9 +1,46 @@
 import type { CrashType } from "@shared/types/pty-host";
+import { isPtyPanel } from "@shared/types/panel";
 import { terminalRegistryController } from "@/controllers";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { logInfo, logError, logWarn } from "@/utils/logger";
 import { DisposableStore, toDisposable } from "@/utils/disposable";
 import { usePanelStore } from "@/store/panelStore";
+import { deriveRuntimeStatus } from "@/store/slices/panelRegistry/helpers";
+
+/**
+ * Clear stale flow state on every PTY panel after a pty-host crash + recovery.
+ * The host only re-emits flow status on a pause/resume transition, so a panel
+ * paused at crash time would keep showing the "Paused" pill forever once the
+ * host comes back. One batched setState handles all panels to avoid N Zustand
+ * subscriber notifications; unchanged panels are left untouched (#9899).
+ */
+function clearFlowStateOnRecovery(): void {
+  usePanelStore.setState((state) => {
+    const nextById = { ...state.panelsById };
+    let changed = false;
+    for (const id of Object.keys(nextById)) {
+      const panel = nextById[id];
+      if (!panel || !isPtyPanel(panel)) continue;
+      if (
+        panel.flowStatus === undefined &&
+        panel.flowStatusTimestamp === undefined &&
+        panel.heldDurationMs === undefined
+      ) {
+        continue;
+      }
+      nextById[id] = {
+        ...panel,
+        flowStatus: undefined,
+        flowStatusTimestamp: undefined,
+        heldDurationMs: undefined,
+        runtimeStatus: deriveRuntimeStatus(panel.isVisible, undefined, panel.runtimeStatus),
+      };
+      changed = true;
+    }
+    if (!changed) return state;
+    return { panelsById: nextById };
+  });
+}
 
 function normalizeCrashType(value: unknown): CrashType | null {
   const validTypes: CrashType[] = [
@@ -81,6 +118,10 @@ export function setupBackendHealthListeners(): DisposableStore {
         }
 
         usePanelStore.setState({ backendStatus: "recovering" });
+
+        // Clear flow state left over from before the crash — the recovered host
+        // won't re-emit it, so a paused-at-crash panel would stay "Paused" (#9899).
+        clearFlowStateOnRecovery();
 
         // Reset all xterm instances to fix white text
         terminalInstanceService.handleBackendRecovery();

--- a/src/store/listeners/panel/lifecycle.ts
+++ b/src/store/listeners/panel/lifecycle.ts
@@ -13,6 +13,7 @@ import {
   enqueueFlowStatusUpdate,
   enqueueHeldDurationUpdate,
   clearHeldDuration,
+  cancelTerminalFlowState,
 } from "@/store/panelStatusBuffer";
 import { DisposableStore, toDisposable } from "@/utils/disposable";
 import { getMergedPresets } from "@/config/agents";
@@ -298,14 +299,28 @@ export function setupLifecycleListeners(): DisposableStore {
         // Clean up resource metrics for exited terminal
         useResourceMonitoringStore.getState().removePanel(id);
 
-        // Store exit code on the terminal before applying exit behavior
+        // Drop any buffered flow-status/held-duration patches for this terminal
+        // before committing the clear below, so a pending RAF flush can't
+        // resurrect a stale "paused" pill on the just-exited panel (#9899).
+        cancelTerminalFlowState(id);
+
+        // Store exit code and clear the flow state on the terminal before
+        // applying exit behavior. Flow status must not outlive the PTY process
+        // that owned the pause — clear it atomically with the exit-code write so
+        // the paused pill and derived runtime status reset on exit (#9899).
         usePanelStore.setState((s) => {
           const existing = s.panelsById[id];
           if (!existing) return s;
           return {
             panelsById: {
               ...s.panelsById,
-              [id]: { ...existing, exitCode },
+              [id]: {
+                ...existing,
+                exitCode,
+                flowStatus: undefined,
+                flowStatusTimestamp: undefined,
+                heldDurationMs: undefined,
+              },
             },
           };
         });

--- a/src/store/panelStatusBuffer.ts
+++ b/src/store/panelStatusBuffer.ts
@@ -161,6 +161,12 @@ export function flushPanelStatusBuffer(): void {
         const terminal = nextById[id];
         if (!terminal || !isPtyPanel(terminal)) continue;
 
+        // A late flow event for a terminal that has already exited must not
+        // revive the "paused" pill. `deriveRuntimeStatus` already pins
+        // runtimeStatus at "exited", but flowStatus drives the header pill
+        // directly, so guard the write here too (#9899).
+        if (terminal.runtimeStatus === "exited") continue;
+
         const prevTs = terminal.flowStatusTimestamp;
         if (prevTs !== undefined && patch.timestamp < prevTs) continue;
 

--- a/src/store/panelStatusBuffer.ts
+++ b/src/store/panelStatusBuffer.ts
@@ -217,3 +217,17 @@ export function cancelPanelStatusBuffer(): void {
   flowStatusBuffer.clear();
   heldDurationBuffer.clear();
 }
+
+/**
+ * Drop a single terminal's pending flow-status and held-duration patches
+ * without touching the shared RAF or other terminals' buffers. Called when a
+ * terminal exits: a flow-status patch enqueued earlier in the same frame would
+ * otherwise survive the flush and resurrect a stale "paused" state on the
+ * just-exited panel — the fold's timestamp guard can't catch it because exit
+ * clears `flowStatusTimestamp` to `undefined`, defeating the `< prevTs` check.
+ * Activity patches are left intact; they don't drive the paused pill.
+ */
+export function cancelTerminalFlowState(terminalId: string): void {
+  flowStatusBuffer.delete(terminalId);
+  heldDurationBuffer.delete(terminalId);
+}

--- a/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
@@ -613,13 +613,15 @@ describe("restartTerminal stale flow state cleared (#9899)", () => {
     });
   });
 
-  it("clears flowStatus, flowStatusTimestamp, and heldDurationMs on restart", async () => {
+  it("clears flowStatus, flowStatusTimestamp, heldDurationMs, and re-derives runtimeStatus on restart", async () => {
     const paused = {
       ...agentPanelBase,
       agentState: "working" as const,
+      isVisible: true,
       flowStatus: "paused-backpressure" as const,
       flowStatusTimestamp: 12345,
       heldDurationMs: 7000,
+      runtimeStatus: "paused-backpressure" as const,
     };
     usePanelStore.setState({
       panelsById: { [paused.id]: paused },
@@ -632,6 +634,9 @@ describe("restartTerminal stale flow state cleared (#9899)", () => {
     expect(after?.flowStatus).toBeUndefined();
     expect(after?.flowStatusTimestamp).toBeUndefined();
     expect(after?.heldDurationMs).toBeUndefined();
+    // Dock pills / tab labels read runtimeStatus directly — it must not keep
+    // folding the now-cleared paused flow status.
+    expect(after?.runtimeStatus).not.toBe("paused-backpressure");
   });
 });
 

--- a/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
@@ -591,6 +591,50 @@ describe("restartTerminal resume-latest fallback (#8787)", () => {
   });
 });
 
+describe("restartTerminal stale flow state cleared (#9899)", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    getMergedPresetMock.mockReturnValue(undefined);
+    buildAgentLaunchFlagsMock.mockReturnValue([]);
+    const { agentSettingsClient, projectClient } = await import("@/clients");
+    (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (projectClient.getSettings as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const { reset } = usePanelStore.getState();
+    await reset();
+    usePanelStore.setState({
+      panelsById: {},
+      panelIds: [],
+      tabGroups: new Map(),
+      trashedTerminals: new Map(),
+      backgroundedTerminals: new Map(),
+      focusedId: null,
+      maximizedId: null,
+      commandQueue: [],
+    });
+  });
+
+  it("clears flowStatus, flowStatusTimestamp, and heldDurationMs on restart", async () => {
+    const paused = {
+      ...agentPanelBase,
+      agentState: "working" as const,
+      flowStatus: "paused-backpressure" as const,
+      flowStatusTimestamp: 12345,
+      heldDurationMs: 7000,
+    };
+    usePanelStore.setState({
+      panelsById: { [paused.id]: paused },
+      panelIds: [paused.id],
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    const after = usePanelStore.getState().panelsById["test-1"] as PtyPanelData | undefined;
+    expect(after?.flowStatus).toBeUndefined();
+    expect(after?.flowStatusTimestamp).toBeUndefined();
+    expect(after?.heldDurationMs).toBeUndefined();
+  });
+});
+
 describe("restartTerminal input lock + parallel IPC (#9164)", () => {
   beforeEach(async () => {
     vi.clearAllMocks();

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -29,6 +29,7 @@ import { saveNormalized } from "./persistence";
 import { optimizeForDock } from "./layout";
 import { deriveRuntimeStatus } from "./helpers";
 import { cancelReconnectErrorDebounce } from "./browser";
+import { cancelTerminalFlowState } from "@/store/panelStatusBuffer";
 import { logDebug, logWarn, logError } from "@/utils/logger";
 import {
   buildAgentLaunchFlagsForRuntimeSettings,
@@ -190,6 +191,12 @@ export const createRestartActions = (
     // after we've cleared the error inline below.
     cancelReconnectErrorDebounce(id);
 
+    // Evict any buffered flow-status/held-duration patch so a pending RAF flush
+    // can't resurrect the previous process's "paused" pill after the clear
+    // below (#9899). onExit skips this for restarts (markTerminalRestarting),
+    // so the restart path must do it itself.
+    cancelTerminalFlowState(id);
+
     // Also set the store flag for UI and other consumers
     // Track whether we're restarting from a failed spawn so we can clear
     // spawnStatus (allowing XtermAdapter to mount) and restore it on failure.
@@ -206,9 +213,12 @@ export const createRestartActions = (
         // process must not survive into it or the paused pill would linger
         // (#9899). The host only re-emits flow status on a pause/resume
         // transition, so without this the stale value persists indefinitely.
+        // Re-derive runtimeStatus too — dock pills and tab labels read it, and
+        // it would otherwise keep folding the now-cleared paused flow status.
         flowStatus: undefined,
         flowStatusTimestamp: undefined,
         heldDurationMs: undefined,
+        runtimeStatus: deriveRuntimeStatus(t.isVisible, undefined, t.runtimeStatus),
         isRestarting: true,
         // The user is explicitly starting a fresh session, so the
         // session-lost restore signal has been acknowledged — clear it so the

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -202,6 +202,13 @@ export const createRestartActions = (
         reconnectError: undefined,
         spawnError: undefined,
         scrollbackRestoreError: undefined,
+        // A restart spins up a fresh PTY process; flow state from the previous
+        // process must not survive into it or the paused pill would linger
+        // (#9899). The host only re-emits flow status on a pause/resume
+        // transition, so without this the stale value persists indefinitely.
+        flowStatus: undefined,
+        flowStatusTimestamp: undefined,
+        heldDurationMs: undefined,
         isRestarting: true,
         // The user is explicitly starting a fresh session, so the
         // session-lost restore signal has been acknowledged — clear it so the

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -29,7 +29,6 @@ import { saveNormalized } from "./persistence";
 import { optimizeForDock } from "./layout";
 import { deriveRuntimeStatus } from "./helpers";
 import { cancelReconnectErrorDebounce } from "./browser";
-import { cancelTerminalFlowState } from "@/store/panelStatusBuffer";
 import { logDebug, logWarn, logError } from "@/utils/logger";
 import {
   buildAgentLaunchFlagsForRuntimeSettings,
@@ -194,7 +193,11 @@ export const createRestartActions = (
     // Evict any buffered flow-status/held-duration patch so a pending RAF flush
     // can't resurrect the previous process's "paused" pill after the clear
     // below (#9899). onExit skips this for restarts (markTerminalRestarting),
-    // so the restart path must do it itself.
+    // so the restart path must do it itself. Dynamic-import panelStatusBuffer
+    // to avoid a static slice→panelStore cycle (the cold-graph init gate in
+    // worktreeStore.circularInit.test.ts); the await lands after the
+    // synchronous markTerminalRestarting, so the exit-race guard is unaffected.
+    const { cancelTerminalFlowState } = await import("@/store/panelStatusBuffer");
     cancelTerminalFlowState(id);
 
     // Also set the store flag for UI and other consumers

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -203,29 +203,32 @@ export const createRestartActions = (
     const ptyPanel = get().panelsById[id] as import("@shared/types/panel").PtyPanelData | undefined; // eslint-disable-line @typescript-eslint/no-unsafe-type-assertion -- narrow to PtyPanelData for spawnStatus access
     const wasFailed = ptyPanel?.spawnStatus === "failed";
     set((state) =>
-      updateTerminal(state, id, (t) => ({
-        ...t,
-        restartError: undefined,
-        reconnectError: undefined,
-        spawnError: undefined,
-        scrollbackRestoreError: undefined,
-        // A restart spins up a fresh PTY process; flow state from the previous
-        // process must not survive into it or the paused pill would linger
-        // (#9899). The host only re-emits flow status on a pause/resume
-        // transition, so without this the stale value persists indefinitely.
-        // Re-derive runtimeStatus too — dock pills and tab labels read it, and
-        // it would otherwise keep folding the now-cleared paused flow status.
-        flowStatus: undefined,
-        flowStatusTimestamp: undefined,
-        heldDurationMs: undefined,
-        runtimeStatus: deriveRuntimeStatus(t.isVisible, undefined, t.runtimeStatus),
-        isRestarting: true,
-        // The user is explicitly starting a fresh session, so the
-        // session-lost restore signal has been acknowledged — clear it so the
-        // banner doesn't linger across the restart (issue #9802).
-        sessionLostOnRestore: undefined,
-        ...(wasFailed ? { spawnStatus: undefined } : {}),
-      }))
+      updateTerminal(state, id, (t) => {
+        const ptyPanel = t as import("@shared/types/panel").PtyPanelData; // eslint-disable-line @typescript-eslint/no-unsafe-type-assertion -- guarded by isPtyPanel check above
+        return {
+          ...t,
+          restartError: undefined,
+          reconnectError: undefined,
+          spawnError: undefined,
+          scrollbackRestoreError: undefined,
+          // A restart spins up a fresh PTY process; flow state from the previous
+          // process must not survive into it or the paused pill would linger
+          // (#9899). The host only re-emits flow status on a pause/resume
+          // transition, so without this the stale value persists indefinitely.
+          // Re-derive runtimeStatus too — dock pills and tab labels read it, and
+          // it would otherwise keep folding the now-cleared paused flow status.
+          flowStatus: undefined,
+          flowStatusTimestamp: undefined,
+          heldDurationMs: undefined,
+          runtimeStatus: deriveRuntimeStatus(ptyPanel.isVisible, undefined, ptyPanel.runtimeStatus),
+          isRestarting: true,
+          // The user is explicitly starting a fresh session, so the
+          // session-lost restore signal has been acknowledged — clear it so the
+          // banner doesn't linger across the restart (issue #9802).
+          sessionLostOnRestore: undefined,
+          ...(wasFailed ? { spawnStatus: undefined } : {}),
+        };
+      })
     );
 
     // Validate configuration before attempting restart


### PR DESCRIPTION
## Summary

- The paused pill can get stuck on a terminal that's actually running. `flowStatus` on each panel is only ever written by the status event path — nothing clears it when a terminal exits while paused, when the user restarts it, or when the pty-host crashes and recovers.
- Three lifecycle points were all missing the reset: `onExit` in `lifecycle.ts`, `restartTerminal` in `restart.ts`, and `onBackendReady` in `backendHealth.ts`.
- A freshly respawned host has an empty status map and only emits on pause/resume transitions, so a restarted terminal never receives a corrective `running` event unless it hits backpressure again.

Resolves #9899

## Changes

- `panelStatusBuffer.ts` — new `cancelTerminalFlowState(id)` evicts buffered flow and held-duration patches for a single terminal; added a guard to skip flow patches for already-exited terminals.
- `lifecycle.ts` — `onExit` evicts the buffer and clears `flowStatus`, `flowStatusTimestamp`, and `heldDurationMs` atomically with the `exitCode` write.
- `restart.ts` — `restartTerminal` evicts the buffer, clears the three fields, and re-derives `runtimeStatus` before the restart.
- `backendHealth.ts` — `onBackendReady` cancels the status buffer and batch-clears flow state across all PTY panels, re-deriving `runtimeStatus` for each.

## Testing

46 unit tests across three new/extended test files. `npm run check` clean (all 11 checks).