### PR TITLE
fix(telemetry): harden sanitizeEvent — scrub parsed URLs and walk tags/user/contexts (#10047)

### DIFF
--- a/electron/services/TelemetryService.ts
+++ b/electron/services/TelemetryService.ts
@@ -83,13 +83,11 @@ export function sanitizeEvent(event: SentryEvent): SentryEvent | null {
   // silently. Fail closed on unexpected input rather than leaking unscrubbed
   // data by returning the event as-is.
   //
-  // Deliberately skips deep-walking event.tags / event.user / event.contexts.
-  // This is safe only while: zero Sentry.setUser() calls exist in the codebase;
-  // the sole setTag() call (setOnboardingCompleteTag) passes fixed "true"/"false"
-  // strings; initial-scope tags are process-controlled (platform, arch, node);
-  // and @sentry/electron's MainContext integration does not capture process.argv
-  // into app_arguments. Adding user-populated data to any of these fields would
-  // silently bypass scrubbing with no warning at the call site.
+  // event.tags / event.user / event.contexts are deep-walked below: renderer
+  // error paths (ErrorBoundary, onUncaughtError) inject caller-supplied tags
+  // and contexts (e.g. React componentStack), so these fields can carry user
+  // data. New Sentry scope-setter call sites outside this file are lint-banned
+  // (see eslint.config.js, #10047).
   try {
     if (Array.isArray(event.exception?.values)) {
       for (const ex of event.exception.values) {
@@ -132,7 +130,8 @@ export function sanitizeEvent(event: SentryEvent): SentryEvent | null {
           u.hash = "";
           u.username = "";
           u.password = "";
-          event.request.url = u.toString();
+          // Path segments can still carry user paths or token-shaped strings.
+          event.request.url = sanitizeString(u.toString());
         } catch {
           // Not parseable as an absolute URL (relative path, mailto:, etc.)
           // Still scrub any inline free-text secrets before giving up.
@@ -168,6 +167,15 @@ export function sanitizeEvent(event: SentryEvent): SentryEvent | null {
     }
     if (event.extra && typeof event.extra === "object") {
       event.extra = sanitizeStringsDeep(event.extra) as Record<string, unknown>;
+    }
+    if (event.tags && typeof event.tags === "object") {
+      event.tags = sanitizeStringsDeep(event.tags) as Record<string, unknown>;
+    }
+    if (event.user && typeof event.user === "object") {
+      event.user = sanitizeStringsDeep(event.user) as Record<string, unknown>;
+    }
+    if (event.contexts && typeof event.contexts === "object") {
+      event.contexts = sanitizeStringsDeep(event.contexts) as Record<string, unknown>;
     }
     return event;
   } catch {
@@ -468,6 +476,7 @@ export function addActionBreadcrumb(crumb: ActionBreadcrumb): void {
 
 export function setOnboardingCompleteTag(completed: boolean): void {
   try {
+    // eslint-disable-next-line no-restricted-syntax -- sentry-scope-setter: ok — sole authorized scope mutator; fixed "true"/"false" values
     sentryModule?.setTag("onboarding_complete", completed ? "true" : "false");
   } catch {
     // never let telemetry errors escape into product code paths

--- a/electron/services/__tests__/TelemetryService.test.ts
+++ b/electron/services/__tests__/TelemetryService.test.ts
@@ -408,6 +408,22 @@ describe("sanitizeEvent", () => {
     expect(JSON.stringify(result)).not.toContain(secret);
   });
 
+  it("documents the depth-cap invariant: containers beyond the cap pass through unscrubbed", () => {
+    const secret = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123456";
+    const event: SentryEvent = {
+      extra: {
+        a: { b: { c: { d: { e: { f: { g: { h: { i: { j: { k: { token: secret } } } } } } } } } } },
+      },
+    };
+    const result = sanitizeEvent(event);
+    // The container at depth 11 is returned unchanged — only scalar strings
+    // scrub past the cap. This shape is unreachable in production: Sentry's
+    // normalizeDepth (pinned to MAX_DEEP_SANITIZE_DEPTH in init) flattens
+    // deeper containers into "[Object]"/"[Array]" strings before beforeSend
+    // fires. If this assertion starts failing, the cap semantics changed.
+    expect(JSON.stringify(result)).toContain(secret);
+  });
+
   it("returns null when sanitization throws (fail-closed)", () => {
     const event = {
       // Getter that throws — forces the outer try/catch to kick in. If
@@ -524,6 +540,18 @@ describe("sanitizeEvent", () => {
     expect(result?.request?.url).not.toContain("alice");
   });
 
+  it("scrubs token-shaped path segments from parsed request.url", () => {
+    const secret = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123456";
+    const event: SentryEvent = {
+      request: {
+        url: `https://api.example.com/download/${secret}/artifact`,
+      },
+    };
+    const result = sanitizeEvent(event);
+    expect(result?.request?.url).not.toContain(secret);
+    expect(result?.request?.url).toContain("[REDACTED]");
+  });
+
   it("scrubs secret values in event.tags and preserves non-string values", () => {
     const secret = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123456";
     const event: SentryEvent = {
@@ -534,6 +562,22 @@ describe("sanitizeEvent", () => {
     expect(tags.token).toBe("[REDACTED]");
     expect(tags.source).toBe("react-uncaught");
     expect(tags.count).toBe(3);
+  });
+
+  it("preserves non-string leaves in tags and reaches nested sub-objects in user", () => {
+    const secret = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123456";
+    const event: SentryEvent = {
+      tags: { count: 42, flag: true, name: null },
+      user: { profile: { home: "/Users/alice/Projects", pat: secret } },
+    };
+    const result = sanitizeEvent(event);
+    const tags = result?.tags as Record<string, unknown>;
+    expect(tags.count).toBe(42);
+    expect(tags.flag).toBe(true);
+    expect(tags.name).toBeNull();
+    const profile = (result?.user as { profile: Record<string, unknown> }).profile;
+    expect(profile.home).toBe("/Users/USER/Projects");
+    expect(profile.pat).toBe("[REDACTED]");
   });
 
   it("scrubs home paths in event.user and passes null user through unchanged", () => {

--- a/electron/services/__tests__/TelemetryService.test.ts
+++ b/electron/services/__tests__/TelemetryService.test.ts
@@ -510,6 +510,71 @@ describe("sanitizeEvent", () => {
     expect(frame?.post_context).toBeUndefined();
     expect(frame?.vars).toBeUndefined();
   });
+
+  it("scrubs user paths from parsed request.url path segments", () => {
+    const event: SentryEvent = {
+      request: {
+        url: "https://api.example.com/Users/alice/repos",
+      },
+    };
+    const result = sanitizeEvent(event);
+    // URL() parses fine, so the try branch runs — the path segment must
+    // still go through sanitizeString, not just the search/hash clears.
+    expect(result?.request?.url).toBe("https://api.example.com/Users/USER/repos");
+    expect(result?.request?.url).not.toContain("alice");
+  });
+
+  it("scrubs secret values in event.tags and preserves non-string values", () => {
+    const secret = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123456";
+    const event: SentryEvent = {
+      tags: { source: "react-uncaught", token: secret, count: 3 },
+    };
+    const result = sanitizeEvent(event);
+    const tags = result?.tags as Record<string, unknown>;
+    expect(tags.token).toBe("[REDACTED]");
+    expect(tags.source).toBe("react-uncaught");
+    expect(tags.count).toBe(3);
+  });
+
+  it("scrubs home paths in event.user and passes null user through unchanged", () => {
+    const event: SentryEvent = {
+      user: { id: "abc123", lastProjectPath: "/Users/alice/Projects/daintree" },
+    };
+    const result = sanitizeEvent(event);
+    const user = result?.user as Record<string, unknown>;
+    expect(user.lastProjectPath).toBe("/Users/USER/Projects/daintree");
+    expect(user.id).toBe("abc123");
+
+    const nullUserEvent = { user: null } as unknown as SentryEvent;
+    expect(() => sanitizeEvent(nullUserEvent)).not.toThrow();
+    expect(sanitizeEvent(nullUserEvent)?.user).toBeNull();
+  });
+
+  it("scrubs home paths from event.contexts (React componentStack)", () => {
+    const secret = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123456";
+    const event: SentryEvent = {
+      contexts: {
+        react: {
+          componentStack: `at App (/Users/alice/Projects/daintree/src/App.tsx:10:5) token=${secret}`,
+        },
+      },
+    };
+    const result = sanitizeEvent(event);
+    const contexts = result?.contexts as { react: { componentStack: string } };
+    expect(contexts.react.componentStack).toContain("/Users/USER/");
+    expect(contexts.react.componentStack).not.toContain("alice");
+    expect(contexts.react.componentStack).not.toContain(secret);
+    expect(contexts.react.componentStack).toContain("[REDACTED]");
+  });
+
+  it("leaves events without tags, user, or contexts unchanged", () => {
+    const event: SentryEvent = { message: "plain message" };
+    const result = sanitizeEvent(event);
+    expect(result).not.toBeNull();
+    expect(result?.tags).toBeUndefined();
+    expect(result?.user).toBeUndefined();
+    expect(result?.contexts).toBeUndefined();
+  });
 });
 
 describe("getTelemetryLevel", () => {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -214,6 +214,18 @@ export default tseslint.config(
           message:
             "Use z.flattenError(err) (shape-consuming) or z.prettifyError(err) (log-only) instead of deprecated ZodError instance methods .flatten() / .format(). See #8566.",
         },
+        {
+          // why: values written via Sentry scope setters land in
+          // event.tags/user/contexts. sanitizeEvent deep-walks those fields,
+          // but centralizing setter call sites in TelemetryService.ts keeps
+          // every injection point reviewable against the scrubbing contract.
+          // Matches member calls (Sentry.setTag, sentryModule?.setTag,
+          // scope.setUser) and bare named-import calls. See #10047.
+          selector:
+            "CallExpression:matches([callee.type='MemberExpression'][callee.property.name=/^(setTag|setUser|setContext)$/], [callee.type='Identifier'][callee.name=/^(setTag|setUser|setContext)$/])",
+          message:
+            "Sentry scope setters (setTag/setUser/setContext) are centralized in TelemetryService.ts so every value entering event.tags/user/contexts stays within the scrubbing contract. Annotate a legitimate site with `// eslint-disable-next-line no-restricted-syntax -- sentry-scope-setter: ok` plus a rationale. See #10047.",
+        },
       ],
     },
   },
@@ -320,6 +332,14 @@ export default tseslint.config(
             "AssignmentExpression[left.type='MemberExpression'][left.object.name='autoUpdater']:matches([left.property.name='channel'], [left.property.value='channel'])",
           message:
             "Don't assign to autoUpdater.channel directly — the setter unconditionally flips allowDowngrade=true, silently breaking the stable-channel rollback guard from #7573. Route channel changes through AutoUpdaterService (setFeedURL + explicit allowDowngrade). See #9123.",
+        },
+        {
+          // Mirrored from the global block (flat-config last-write-wins).
+          // See #10047.
+          selector:
+            "CallExpression:matches([callee.type='MemberExpression'][callee.property.name=/^(setTag|setUser|setContext)$/], [callee.type='Identifier'][callee.name=/^(setTag|setUser|setContext)$/])",
+          message:
+            "Sentry scope setters (setTag/setUser/setContext) are centralized in TelemetryService.ts so every value entering event.tags/user/contexts stays within the scrubbing contract. Annotate a legitimate site with `// eslint-disable-next-line no-restricted-syntax -- sentry-scope-setter: ok` plus a rationale. See #10047.",
         },
       ],
     },
@@ -539,6 +559,14 @@ export default tseslint.config(
             "CallExpression[callee.type='MemberExpression'][callee.property.name=/^(flatten|format)$/]:matches([callee.object.property.name=/^(error|err)$/], [callee.object.name=/^(error|err)$/])",
           message:
             "Use z.flattenError(err) (shape-consuming) or z.prettifyError(err) (log-only) instead of deprecated ZodError instance methods .flatten() / .format(). See #8566.",
+        },
+        {
+          // Mirrored from the global block (flat-config last-write-wins).
+          // See #10047.
+          selector:
+            "CallExpression:matches([callee.type='MemberExpression'][callee.property.name=/^(setTag|setUser|setContext)$/], [callee.type='Identifier'][callee.name=/^(setTag|setUser|setContext)$/])",
+          message:
+            "Sentry scope setters (setTag/setUser/setContext) are centralized in TelemetryService.ts so every value entering event.tags/user/contexts stays within the scrubbing contract. Annotate a legitimate site with `// eslint-disable-next-line no-restricted-syntax -- sentry-scope-setter: ok` plus a rationale. See #10047.",
         },
       ],
     },
@@ -800,6 +828,14 @@ export default tseslint.config(
           message:
             "Don't register IPC handlers with the legacy typedHandle* helpers from electron/ipc/utils. Use `defineIpcNamespace` from electron/ipc/define instead — it gives a single declarative surface for routing, validation, and error handling. See #8577.",
         },
+        {
+          // Mirrored from the global block (flat-config last-write-wins).
+          // See #10047.
+          selector:
+            "CallExpression:matches([callee.type='MemberExpression'][callee.property.name=/^(setTag|setUser|setContext)$/], [callee.type='Identifier'][callee.name=/^(setTag|setUser|setContext)$/])",
+          message:
+            "Sentry scope setters (setTag/setUser/setContext) are centralized in TelemetryService.ts so every value entering event.tags/user/contexts stays within the scrubbing contract. Annotate a legitimate site with `// eslint-disable-next-line no-restricted-syntax -- sentry-scope-setter: ok` plus a rationale. See #10047.",
+        },
       ],
     },
   },
@@ -852,6 +888,14 @@ export default tseslint.config(
             "AssignmentExpression[left.type='MemberExpression'][left.object.name='autoUpdater']:matches([left.property.name='channel'], [left.property.value='channel'])",
           message:
             "Don't assign to autoUpdater.channel directly — the setter unconditionally flips allowDowngrade=true, silently breaking the stable-channel rollback guard from #7573. Route channel changes through AutoUpdaterService (setFeedURL + explicit allowDowngrade). See #9123.",
+        },
+        {
+          // Mirrored from the global block (flat-config last-write-wins).
+          // See #10047.
+          selector:
+            "CallExpression:matches([callee.type='MemberExpression'][callee.property.name=/^(setTag|setUser|setContext)$/], [callee.type='Identifier'][callee.name=/^(setTag|setUser|setContext)$/])",
+          message:
+            "Sentry scope setters (setTag/setUser/setContext) are centralized in TelemetryService.ts so every value entering event.tags/user/contexts stays within the scrubbing contract. Annotate a legitimate site with `// eslint-disable-next-line no-restricted-syntax -- sentry-scope-setter: ok` plus a rationale. See #10047.",
         },
       ],
     },
@@ -980,6 +1024,14 @@ export default tseslint.config(
             "CallExpression[callee.name=/^(typedHandle|typedHandleWithContext|typedHandleValidated|typedHandleWithContextValidated)$/]",
           message:
             "Don't register IPC handlers with the legacy typedHandle* helpers from electron/ipc/utils. Use `defineIpcNamespace` from electron/ipc/define instead — it gives a single declarative surface for routing, validation, and error handling. See #8577.",
+        },
+        {
+          // Mirrored from the global block (flat-config last-write-wins).
+          // See #10047.
+          selector:
+            "CallExpression:matches([callee.type='MemberExpression'][callee.property.name=/^(setTag|setUser|setContext)$/], [callee.type='Identifier'][callee.name=/^(setTag|setUser|setContext)$/])",
+          message:
+            "Sentry scope setters (setTag/setUser/setContext) are centralized in TelemetryService.ts so every value entering event.tags/user/contexts stays within the scrubbing contract. Annotate a legitimate site with `// eslint-disable-next-line no-restricted-syntax -- sentry-scope-setter: ok` plus a rationale. See #10047.",
         },
       ],
     },


### PR DESCRIPTION
## Summary

Three gaps in `sanitizeEvent` (`electron/services/TelemetryService.ts`) where user-identifiable data could slip past scrubbing:

- Parsed `request.url` was assigned back to the event unscrubbed. It now passes through `sanitizeString` after auth, search, and hash fields are cleared — path segments carrying `/Users/alice/...` or token-shaped strings are caught.
- `event.tags`, `event.user`, and `event.contexts` weren't being walked. They're now deep-walked with `sanitizeStringsDeep` (same guard+cast pattern as `event.extra`). Renderer error paths (`ErrorBoundary`, `onUncaughtError`) inject caller-supplied tags and React `componentStack` contexts, and `@sentry/electron`'s `EventToMain` integration merges renderer scope before `beforeSend` fires — so these fields can carry user data.
- The comment-only omission contract on Sentry scope setters is replaced with a `no-restricted-syntax` ESLint ban on `setTag`/`setUser`/`setContext`. The rule is replicated across all six `no-restricted-syntax` blocks in `eslint.config.js` (flat config is last-write-wins per rule). The one authorized call site (`setOnboardingCompleteTag`) is annotated with `-- sentry-scope-setter: ok`.

Resolves #10047

## Changes

- `electron/services/TelemetryService.ts` — scrub parsed URL path, walk `tags`/`user`/`contexts`
- `eslint.config.js` — `no-restricted-syntax` ban on Sentry scope setters in all six rule blocks
- `electron/services/__tests__/TelemetryService.test.ts` — 8 new `sanitizeEvent` cases

## Testing

8 new unit tests: parsed-URL path scrubbing (username segment + token-shaped segment), `tags`/`user`/`contexts` walks (flat + nested), non-string leaf preservation, null `user` passthrough, absent-field no-op, and a depth-cap invariant test. All 90 tests pass; `npm run check` clean.

**Known limitation:** `pathScrubber`'s `/Users/[^/]+/` regex requires a trailing slash, so a URL ending in a bare username segment (e.g. `.../Users/alice` with nothing after) is only scrubbed when it matches `HOME_DIR`. Widening the regex risks over-matching free text and affects other `pathScrubber` consumers — left for a follow-up if it comes up in practice.