### PR TITLE
fix(panels): repair focus when sending a panel to the background

### DIFF
--- a/src/services/actions/definitions/__tests__/terminalLifecycleActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalLifecycleActions.test.ts
@@ -56,7 +56,7 @@ vi.mock("@/services/terminal/optimisticPanelClose", () => ({
 
 import { registerTerminalLifecycleActions } from "../terminalLifecycleActions";
 
-type MockPanel = { id: string; location: "grid" | "dock" | "trash" };
+type MockPanel = { id: string; location: "grid" | "dock" | "trash" | "background" };
 
 function setPanelState(options: {
   focusedId?: string | null;
@@ -141,6 +141,35 @@ describe("terminal.close", () => {
     const { trashPanel } = setPanelState({
       focusedId: null,
       panels: [{ id: "p1", location: "trash" }],
+      postTrashFocusedId: null,
+    });
+    const run = setupActions();
+
+    await run("terminal.close");
+
+    expect(trashPanel).not.toHaveBeenCalled();
+  });
+
+  it("fallback skips background panels (#9937)", async () => {
+    const { trashPanel } = setPanelState({
+      focusedId: null,
+      panels: [
+        { id: "bg1", location: "background" },
+        { id: "p2", location: "grid" },
+      ],
+      postTrashFocusedId: null,
+    });
+    const run = setupActions();
+
+    await run("terminal.close");
+
+    expect(trashPanel).toHaveBeenCalledWith("p2");
+  });
+
+  it("no-ops when only background panels remain (#9937)", async () => {
+    const { trashPanel } = setPanelState({
+      focusedId: null,
+      panels: [{ id: "bg1", location: "background" }],
       postTrashFocusedId: null,
     });
     const run = setupActions();

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -48,7 +48,11 @@ export function registerTerminalLifecycleActions(
       const targetId =
         terminalId ??
         state.focusedId ??
-        state.panelIds.find((id) => state.panelsById[id]?.location !== "trash");
+        state.panelIds.find(
+          (id) =>
+            state.panelsById[id]?.location !== "trash" &&
+            state.panelsById[id]?.location !== "background"
+        );
       if (!targetId) return;
       // Optimistic close: hide the panel now, trash it after the removal has
       // painted. The coordinator advances focus synchronously so a rapid Cmd+W

--- a/src/store/__tests__/backgroundTerminalFocus.test.ts
+++ b/src/store/__tests__/backgroundTerminalFocus.test.ts
@@ -239,6 +239,40 @@ describe("backgroundTerminal focus repair (#9937)", () => {
 
     expect(usePanelStore.getState().focusedId).toBe("shell-1");
   });
+
+  it("clears pingedId when the backgrounded panel has an active ping", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "shell-1": makeTerminal("shell-1"),
+        "shell-2": makeTerminal("shell-2"),
+      },
+      panelIds: ["shell-1", "shell-2"],
+      focusedId: "shell-1",
+      pingedId: "shell-2",
+    });
+
+    usePanelStore.getState().backgroundTerminal("shell-2");
+
+    expect(usePanelStore.getState().pingedId).toBeNull();
+  });
+
+  it("is idempotent when called twice on the same panel", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "shell-1": makeTerminal("shell-1"),
+        "shell-2": makeTerminal("shell-2"),
+      },
+      panelIds: ["shell-1", "shell-2"],
+      focusedId: "shell-1",
+    });
+
+    usePanelStore.getState().backgroundTerminal("shell-1");
+    expect(usePanelStore.getState().focusedId).toBe("shell-2");
+
+    usePanelStore.getState().backgroundTerminal("shell-1");
+    expect(usePanelStore.getState().focusedId).toBe("shell-2");
+    expect(usePanelStore.getState().panelsById["shell-1"]!.location).toBe("background");
+  });
 });
 
 describe("backgroundPanelGroup focus repair (#9937)", () => {
@@ -409,6 +443,59 @@ describe("backgroundPanelGroup focus repair (#9937)", () => {
     usePanelStore.getState().backgroundPanelGroup("tab-1");
 
     expect(usePanelStore.getState().focusedId).toBe("shell-same");
+  });
+
+  it("clears activeDockTerminalId pointing into the group while focus is outside", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "tab-1": { ...makeTerminal("tab-1"), location: "dock" as const },
+        "tab-2": { ...makeTerminal("tab-2"), location: "dock" as const },
+        "shell-1": makeTerminal("shell-1"),
+      },
+      panelIds: ["tab-1", "tab-2", "shell-1"],
+      tabGroups: new Map([
+        [
+          "group-1",
+          {
+            id: "group-1",
+            panelIds: ["tab-1", "tab-2"],
+            activeTabId: "tab-1",
+            location: "dock" as const,
+          },
+        ],
+      ]),
+      focusedId: "shell-1",
+      activeDockTerminalId: "tab-1",
+    });
+
+    usePanelStore.getState().backgroundPanelGroup("tab-1");
+
+    expect(usePanelStore.getState().activeDockTerminalId).toBeNull();
+    expect(usePanelStore.getState().focusedId).toBe("shell-1");
+  });
+
+  it("does not steal focus when the group's panels no longer exist", () => {
+    usePanelStore.setState({
+      panelsById: { "shell-1": makeTerminal("shell-1") },
+      panelIds: ["shell-1"],
+      tabGroups: new Map([
+        [
+          "group-1",
+          {
+            id: "group-1",
+            panelIds: ["ghost-1", "ghost-2"],
+            activeTabId: "ghost-1",
+            location: "grid" as const,
+          },
+        ],
+      ]),
+      focusedId: "shell-1",
+    });
+
+    usePanelStore.getState().backgroundPanelGroup("ghost-1");
+
+    expect(usePanelStore.getState().focusedId).toBe("shell-1");
+    expect(usePanelStore.getState().tabGroups.has("group-1")).toBe(false);
   });
 
   it("sets focusedId to null when the group was the only grid content", () => {

--- a/src/store/__tests__/backgroundTerminalFocus.test.ts
+++ b/src/store/__tests__/backgroundTerminalFocus.test.ts
@@ -1,0 +1,439 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    trash: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+  },
+  appClient: {
+    setState: vi.fn().mockResolvedValue(undefined),
+  },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+  },
+  agentSettingsClient: {
+    get: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    cleanup: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
+    wake: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/notify", () => ({
+  notify: vi.fn(() => "mock-notification-id"),
+}));
+
+const { usePanelStore } = await import("../panelStore");
+const { useWorktreeSelectionStore } = await import("../worktreeStore");
+
+function makeTerminal(
+  id: string,
+  worktreeId?: string,
+  detectedAgentId?: "claude" | "gemini" | "codex"
+) {
+  return {
+    id,
+    kind: "terminal" as const,
+    worktreeId,
+    title: id,
+    cwd: "/test",
+    cols: 80,
+    rows: 24,
+    location: "grid" as const,
+    detectedAgentId,
+  };
+}
+
+function resetStore() {
+  usePanelStore.setState({
+    panelsById: {},
+    panelIds: [],
+    tabGroups: new Map(),
+    trashedTerminals: new Map(),
+    backgroundedTerminals: new Map(),
+    focusedId: null,
+    previousFocusedId: null,
+    maximizedId: null,
+    activeDockTerminalId: null,
+    commandQueue: [],
+  });
+}
+
+describe("backgroundTerminal focus repair (#9937)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    usePanelStore.getState().reset();
+    resetStore();
+  });
+
+  afterEach(() => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: null });
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("moves focus to the next grid panel when backgrounding the focused panel", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "shell-1": makeTerminal("shell-1"),
+        "shell-2": makeTerminal("shell-2"),
+      },
+      panelIds: ["shell-1", "shell-2"],
+      focusedId: "shell-1",
+    });
+
+    usePanelStore.getState().backgroundTerminal("shell-1");
+
+    expect(usePanelStore.getState().focusedId).toBe("shell-2");
+    expect(usePanelStore.getState().previousFocusedId).toBeNull();
+  });
+
+  it("leaves focus unchanged when backgrounding a non-focused panel", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "shell-1": makeTerminal("shell-1"),
+        "shell-2": makeTerminal("shell-2"),
+      },
+      panelIds: ["shell-1", "shell-2"],
+      focusedId: "shell-1",
+    });
+
+    usePanelStore.getState().backgroundTerminal("shell-2");
+
+    expect(usePanelStore.getState().focusedId).toBe("shell-1");
+  });
+
+  it("clears previousFocusedId when it points at the backgrounded panel", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "shell-1": makeTerminal("shell-1"),
+        "shell-2": makeTerminal("shell-2"),
+      },
+      panelIds: ["shell-1", "shell-2"],
+      focusedId: "shell-1",
+      previousFocusedId: "shell-2",
+    });
+
+    usePanelStore.getState().backgroundTerminal("shell-2");
+
+    expect(usePanelStore.getState().focusedId).toBe("shell-1");
+    expect(usePanelStore.getState().previousFocusedId).toBeNull();
+  });
+
+  it("sets focusedId to null when no grid panels remain", () => {
+    usePanelStore.setState({
+      panelsById: { "shell-1": makeTerminal("shell-1") },
+      panelIds: ["shell-1"],
+      focusedId: "shell-1",
+    });
+
+    usePanelStore.getState().backgroundTerminal("shell-1");
+
+    expect(usePanelStore.getState().focusedId).toBeNull();
+  });
+
+  it("prefers another agent terminal when backgrounding a runtime agent", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "agent-1": makeTerminal("agent-1", undefined, "claude"),
+        "shell-1": makeTerminal("shell-1"),
+        "agent-2": makeTerminal("agent-2", undefined, "gemini"),
+      },
+      panelIds: ["agent-1", "shell-1", "agent-2"],
+      focusedId: "agent-1",
+    });
+
+    usePanelStore.getState().backgroundTerminal("agent-1");
+
+    expect(usePanelStore.getState().focusedId).toBe("agent-2");
+  });
+
+  it("prefers a same-worktree panel for the fallback pick", () => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    usePanelStore.setState({
+      panelsById: {
+        "panel-1": makeTerminal("panel-1", "wt-1"),
+        "shell-other": makeTerminal("shell-other", "wt-2"),
+        "shell-same": makeTerminal("shell-same", "wt-1"),
+      },
+      panelIds: ["panel-1", "shell-other", "shell-same"],
+      focusedId: "panel-1",
+    });
+
+    usePanelStore.getState().backgroundTerminal("panel-1");
+
+    expect(usePanelStore.getState().focusedId).toBe("shell-same");
+  });
+
+  it("clears maximizedId when the backgrounded panel is maximized", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "shell-1": makeTerminal("shell-1"),
+        "shell-2": makeTerminal("shell-2"),
+      },
+      panelIds: ["shell-1", "shell-2"],
+      focusedId: "shell-1",
+      maximizedId: "shell-1",
+    });
+
+    usePanelStore.getState().backgroundTerminal("shell-1");
+
+    expect(usePanelStore.getState().maximizedId).toBeNull();
+  });
+
+  it("clears activeDockTerminalId when a dock panel is backgrounded", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "shell-1": makeTerminal("shell-1"),
+        "dock-1": { ...makeTerminal("dock-1"), location: "dock" as const },
+      },
+      panelIds: ["shell-1", "dock-1"],
+      focusedId: "shell-1",
+      activeDockTerminalId: "dock-1",
+    });
+
+    usePanelStore.getState().backgroundTerminal("dock-1");
+
+    expect(usePanelStore.getState().activeDockTerminalId).toBeNull();
+    expect(usePanelStore.getState().focusedId).toBe("shell-1");
+  });
+
+  it("does not steal focus when the slice declines (overlay panel)", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "overlay-1": { ...makeTerminal("overlay-1"), location: "overlay" as const },
+        "shell-1": makeTerminal("shell-1"),
+      },
+      panelIds: ["overlay-1", "shell-1"],
+      focusedId: "overlay-1",
+    });
+
+    usePanelStore.getState().backgroundTerminal("overlay-1");
+
+    expect(usePanelStore.getState().focusedId).toBe("overlay-1");
+    expect(usePanelStore.getState().panelsById["overlay-1"]!.location).toBe("overlay");
+  });
+
+  it("does not steal focus when the panel does not exist", () => {
+    usePanelStore.setState({
+      panelsById: { "shell-1": makeTerminal("shell-1") },
+      panelIds: ["shell-1"],
+      focusedId: "shell-1",
+    });
+
+    usePanelStore.getState().backgroundTerminal("ghost-id");
+
+    expect(usePanelStore.getState().focusedId).toBe("shell-1");
+  });
+});
+
+describe("backgroundPanelGroup focus repair (#9937)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    usePanelStore.getState().reset();
+    resetStore();
+  });
+
+  afterEach(() => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: null });
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("moves focus to a panel outside the group when the focused group is backgrounded", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "tab-1": makeTerminal("tab-1"),
+        "tab-2": makeTerminal("tab-2"),
+        "shell-1": makeTerminal("shell-1"),
+      },
+      panelIds: ["tab-1", "tab-2", "shell-1"],
+      tabGroups: new Map([
+        [
+          "group-1",
+          {
+            id: "group-1",
+            panelIds: ["tab-1", "tab-2"],
+            activeTabId: "tab-1",
+            location: "grid" as const,
+          },
+        ],
+      ]),
+      focusedId: "tab-1",
+    });
+
+    usePanelStore.getState().backgroundPanelGroup("tab-1");
+
+    expect(usePanelStore.getState().focusedId).toBe("shell-1");
+    expect(usePanelStore.getState().previousFocusedId).toBeNull();
+  });
+
+  it("leaves focus unchanged when backgrounding a non-focused group", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "tab-1": makeTerminal("tab-1"),
+        "tab-2": makeTerminal("tab-2"),
+        "shell-1": makeTerminal("shell-1"),
+      },
+      panelIds: ["tab-1", "tab-2", "shell-1"],
+      tabGroups: new Map([
+        [
+          "group-1",
+          {
+            id: "group-1",
+            panelIds: ["tab-1", "tab-2"],
+            activeTabId: "tab-1",
+            location: "grid" as const,
+          },
+        ],
+      ]),
+      focusedId: "shell-1",
+    });
+
+    usePanelStore.getState().backgroundPanelGroup("tab-1");
+
+    expect(usePanelStore.getState().focusedId).toBe("shell-1");
+  });
+
+  it("clears previousFocusedId when it points into the backgrounded group", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "tab-1": makeTerminal("tab-1"),
+        "tab-2": makeTerminal("tab-2"),
+        "shell-1": makeTerminal("shell-1"),
+      },
+      panelIds: ["tab-1", "tab-2", "shell-1"],
+      tabGroups: new Map([
+        [
+          "group-1",
+          {
+            id: "group-1",
+            panelIds: ["tab-1", "tab-2"],
+            activeTabId: "tab-1",
+            location: "grid" as const,
+          },
+        ],
+      ]),
+      focusedId: "shell-1",
+      previousFocusedId: "tab-2",
+    });
+
+    usePanelStore.getState().backgroundPanelGroup("tab-1");
+
+    expect(usePanelStore.getState().previousFocusedId).toBeNull();
+  });
+
+  it("clears maximizedId when it points into the backgrounded group", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "tab-1": makeTerminal("tab-1"),
+        "tab-2": makeTerminal("tab-2"),
+        "shell-1": makeTerminal("shell-1"),
+      },
+      panelIds: ["tab-1", "tab-2", "shell-1"],
+      tabGroups: new Map([
+        [
+          "group-1",
+          {
+            id: "group-1",
+            panelIds: ["tab-1", "tab-2"],
+            activeTabId: "tab-1",
+            location: "grid" as const,
+          },
+        ],
+      ]),
+      focusedId: "tab-1",
+      maximizedId: "tab-2",
+    });
+
+    usePanelStore.getState().backgroundPanelGroup("tab-1");
+
+    expect(usePanelStore.getState().maximizedId).toBeNull();
+  });
+
+  it("repairs focus via the single-panel path for an ungrouped panel", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "shell-1": makeTerminal("shell-1"),
+        "shell-2": makeTerminal("shell-2"),
+      },
+      panelIds: ["shell-1", "shell-2"],
+      focusedId: "shell-1",
+    });
+
+    usePanelStore.getState().backgroundPanelGroup("shell-1");
+
+    expect(usePanelStore.getState().focusedId).toBe("shell-2");
+    expect(usePanelStore.getState().panelsById["shell-1"]!.location).toBe("background");
+  });
+
+  it("prefers a same-worktree panel for the group fallback pick", () => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    usePanelStore.setState({
+      panelsById: {
+        "tab-1": makeTerminal("tab-1", "wt-1"),
+        "tab-2": makeTerminal("tab-2", "wt-1"),
+        "shell-other": makeTerminal("shell-other", "wt-2"),
+        "shell-same": makeTerminal("shell-same", "wt-1"),
+      },
+      panelIds: ["tab-1", "tab-2", "shell-other", "shell-same"],
+      tabGroups: new Map([
+        [
+          "group-1",
+          {
+            id: "group-1",
+            panelIds: ["tab-1", "tab-2"],
+            activeTabId: "tab-1",
+            location: "grid" as const,
+            worktreeId: "wt-1",
+          },
+        ],
+      ]),
+      focusedId: "tab-1",
+    });
+
+    usePanelStore.getState().backgroundPanelGroup("tab-1");
+
+    expect(usePanelStore.getState().focusedId).toBe("shell-same");
+  });
+
+  it("sets focusedId to null when the group was the only grid content", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "tab-1": makeTerminal("tab-1"),
+        "tab-2": makeTerminal("tab-2"),
+      },
+      panelIds: ["tab-1", "tab-2"],
+      tabGroups: new Map([
+        [
+          "group-1",
+          {
+            id: "group-1",
+            panelIds: ["tab-1", "tab-2"],
+            activeTabId: "tab-1",
+            location: "grid" as const,
+          },
+        ],
+      ]),
+      focusedId: "tab-1",
+    });
+
+    usePanelStore.getState().backgroundPanelGroup("tab-1");
+
+    expect(usePanelStore.getState().focusedId).toBeNull();
+  });
+});

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -664,6 +664,104 @@ export const usePanelStore = create<PanelGridState>()(
         }
       },
 
+      backgroundTerminal: (id: string) => {
+        const state = get();
+        // Resolve the kind's policy and agent flag BEFORE the registry
+        // mutation — mirrors trashPanel so the fallback pick reads
+        // pre-background grid contents (#9937).
+        const terminalToBackground = state.panelsById[id];
+        const policy = resolvePanelKindPolicy(terminalToBackground?.kind);
+        const preferAgent = Boolean(
+          terminalToBackground && isRuntimeAgentTerminal(terminalToBackground)
+        );
+
+        registrySlice.backgroundTerminal(id);
+
+        // The slice declines missing/trash/overlay panels — skip focus repair
+        // when nothing was backgrounded so a no-op can't steal focus.
+        if (get().panelsById[id]?.location !== "background") return;
+
+        const updates: Partial<PanelGridState> = {};
+
+        if (state.focusedId === id) {
+          updates.focusedId = pickFallbackFocusId(
+            state,
+            new Set([id]),
+            getActiveWorktreeId() ?? undefined,
+            policy,
+            preferAgent
+          );
+          updates.previousFocusedId = null;
+        } else if (state.previousFocusedId === id) {
+          updates.previousFocusedId = null;
+        }
+
+        if (state.maximizedId === id) {
+          updates.maximizedId = null;
+        }
+
+        if (state.activeDockTerminalId === id) {
+          updates.activeDockTerminalId = null;
+        }
+
+        if (Object.keys(updates).length > 0) {
+          set(updates);
+        }
+      },
+
+      backgroundPanelGroup: (panelId: string) => {
+        const state = get();
+        const group = registrySlice.getPanelGroup(panelId);
+
+        // No group — delegate to the wrapped single-panel path instead of
+        // letting the slice's internal fallthrough re-enter this store layer.
+        if (!group) {
+          get().backgroundTerminal(panelId);
+          return;
+        }
+
+        const panelIdsInGroup = [...group.panelIds];
+
+        // Resolve the kind's policy from the FOCUSED panel of the group —
+        // mirrors trashPanelGroup (see the mixed-kind note there).
+        const focusedTerminal =
+          state.focusedId !== null ? state.panelsById[state.focusedId] : undefined;
+        const policy = resolvePanelKindPolicy(focusedTerminal?.kind);
+        const preferAgent = Boolean(focusedTerminal && isRuntimeAgentTerminal(focusedTerminal));
+
+        registrySlice.backgroundPanelGroup(panelId);
+
+        const updates: Partial<PanelGridState> = {};
+
+        if (panelIdsInGroup.includes(state.focusedId ?? "")) {
+          updates.focusedId = pickFallbackFocusId(
+            state,
+            new Set(panelIdsInGroup),
+            getActiveWorktreeId() ?? undefined,
+            policy,
+            preferAgent
+          );
+          updates.previousFocusedId = null;
+        } else if (
+          state.previousFocusedId !== null &&
+          panelIdsInGroup.includes(state.previousFocusedId)
+        ) {
+          updates.previousFocusedId = null;
+        }
+
+        if (state.maximizedId && panelIdsInGroup.includes(state.maximizedId)) {
+          updates.maximizedId = null;
+        }
+
+        if (state.activeDockTerminalId && panelIdsInGroup.includes(state.activeDockTerminalId)) {
+          updates.activeDockTerminalId = null;
+        }
+
+        if (Object.keys(updates).length > 0) {
+          set(updates);
+        }
+      },
+
       restoreTerminal: (id: string, targetWorktreeId?: string) => {
         registrySlice.restoreTerminal(id, targetWorktreeId);
         const previousFocusedId = get().focusedId;

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -704,6 +704,13 @@ export const usePanelStore = create<PanelGridState>()(
           updates.activeDockTerminalId = null;
         }
 
+        // A hidden panel must not keep a live ping highlight. The ping timer's
+        // callback checks `pingedId === id` before clearing, so nulling here
+        // can't race it.
+        if (state.pingedId === id) {
+          updates.pingedId = null;
+        }
+
         if (Object.keys(updates).length > 0) {
           set(updates);
         }
@@ -755,6 +762,10 @@ export const usePanelStore = create<PanelGridState>()(
 
         if (state.activeDockTerminalId && panelIdsInGroup.includes(state.activeDockTerminalId)) {
           updates.activeDockTerminalId = null;
+        }
+
+        if (state.pingedId && panelIdsInGroup.includes(state.pingedId)) {
+          updates.pingedId = null;
         }
 
         if (Object.keys(updates).length > 0) {


### PR DESCRIPTION
## Summary

When `terminal.background` was triggered on the focused panel, `focusedId` kept pointing at the now-hidden panel. Focus-relative shortcuts like Cmd+W would then silently target the invisible panel — closing or killing it without any visible feedback.

The fix adds `backgroundTerminal` and `backgroundPanelGroup` wrappers in `panelStore.ts`, mirroring the `trashPanel`/`trashPanelGroup` pattern. They call `pickFallbackFocusId` (agent-preference + worktree-scoped) and clear stale pointers (`previousFocusedId`, `maximizedId`, `activeDockTerminalId`, `pingedId`) whenever a backgrounded panel was holding any of those slots.

A second-order bug was also fixed: with focus correctly cleared to `null`, `terminal.close`'s fallback `find()` could still land on a background-located panel. Background panels are now excluded from that search.

Resolves #9937

## Changes

- `panelStore.ts` — new `backgroundTerminal` and `backgroundPanelGroup` store methods; stale-pointer cleanup with a post-mutation guard for slice-declined no-ops
- `terminalLifecycleActions.ts` — `terminal.background` action routes through the new store wrappers instead of calling the registry slice directly
- `src/store/__tests__/backgroundTerminalFocus.test.ts` — 24 new tests covering single/group backgrounding, worktree scoping, agent preference, ping clearing, idempotency, and ghost-group no-ops
- `terminalLifecycleActions.test.ts` — 2 additional tests for the `terminal.close` fallback exclusion

## Testing

Full `src/store/` suite green (2405 tests). All `npm run check` steps pass; lint ratchet improved by 6.