### PR TITLE
fix(theme): re-derive diff tokens and restore base values under CVD overrides

### DIFF
--- a/shared/theme/__tests__/paletteDistinguishability.test.ts
+++ b/shared/theme/__tests__/paletteDistinguishability.test.ts
@@ -290,11 +290,12 @@ describe("palette distinguishability", () => {
 
   describe("CVD override maps internal distinguishability", () => {
     // Only the opaque signal colors must be mutually distinguishable. The
-    // derived status-*-surface washes are translucent backgrounds, not signals,
-    // so they're excluded from this gate.
+    // derived status-*-surface and diff-*-background washes are translucent
+    // rgba() backgrounds, not signals (and unparseable by culori), so they're
+    // excluded from this gate.
     const signalHexValues = (map: Record<string, string>) =>
       Object.entries(map)
-        .filter(([token]) => !token.endsWith("-surface"))
+        .filter(([token]) => !token.endsWith("-surface") && !token.endsWith("-background"))
         .map(([, value]) => normHex(value));
     const RED_GREEN_UNIQUE = [...new Set(signalHexValues(RED_GREEN_OVERRIDES))];
     const BLUE_YELLOW_UNIQUE = [...new Set(signalHexValues(BLUE_YELLOW_OVERRIDES))];
@@ -349,5 +350,58 @@ describe("palette distinguishability", () => {
     testOverrideMap("RED_GREEN_OVERRIDES", RED_GREEN_UNIQUE, ["protanopia", "deuteranopia"]);
 
     testOverrideMap("BLUE_YELLOW_OVERRIDES", BLUE_YELLOW_UNIQUE, ["tritanopia"]);
+  });
+
+  describe("CVD diff token coverage", () => {
+    // The light-mode diff viewer reads pre-baked --color-diff-* tokens, which
+    // mirror --theme-diff-*. A CVD override must re-derive these from the
+    // overridden status colors or light-mode diff fills/gutters keep the
+    // original (non-CVD) hue. Only red-green overrides status-success/-danger,
+    // so only it should gain diff tokens; blue-yellow overrides neither.
+    const DIFF_TOKENS = [
+      "--theme-diff-insert-background",
+      "--theme-diff-insert-edit-background",
+      "--theme-diff-gutter-insert",
+      "--theme-diff-delete-background",
+      "--theme-diff-delete-edit-background",
+      "--theme-diff-gutter-delete",
+    ] as const;
+
+    // Floor for insert-vs-delete diff gutters under red-green CVD. Well above
+    // the 0.005 identity JND but below the Okabe-Ito calibration (~0.09) so it
+    // gates accidental collapse without locking the hand-tuned hex values.
+    const DIFF_DISTINGUISHABILITY_FLOOR = 0.05;
+
+    it("RED_GREEN_OVERRIDES defines all six diff tokens; BLUE_YELLOW_OVERRIDES defines none", () => {
+      for (const token of DIFF_TOKENS) {
+        expect(RED_GREEN_OVERRIDES, `red-green should define ${token}`).toHaveProperty(token);
+        expect(BLUE_YELLOW_OVERRIDES, `blue-yellow should not define ${token}`).not.toHaveProperty(
+          token
+        );
+      }
+    });
+
+    it("red-green diff gutters stay distinguishable under protanopia and deuteranopia", () => {
+      const insert = RED_GREEN_OVERRIDES["--theme-diff-gutter-insert"]!;
+      const del = RED_GREEN_OVERRIDES["--theme-diff-gutter-delete"]!;
+
+      for (const deficiency of ["protanopia", "deuteranopia"] as const) {
+        const dist = minPairwiseDistance([insert, del], deficiency);
+        expect(dist, `${deficiency}: gutter insert/delete distance`).not.toBeNull();
+        expect(
+          dist!,
+          `${deficiency}: insert/delete gutter distance ${dist?.toFixed(4)} below floor ${DIFF_DISTINGUISHABILITY_FLOOR}`
+        ).toBeGreaterThan(DIFF_DISTINGUISHABILITY_FLOOR);
+      }
+    });
+
+    it("red-green diff gutters mirror the overridden status colors", () => {
+      expect(normHex(RED_GREEN_OVERRIDES["--theme-diff-gutter-insert"]!)).toBe(
+        normHex(RED_GREEN_OVERRIDES["--theme-status-success"]!)
+      );
+      expect(normHex(RED_GREEN_OVERRIDES["--theme-diff-gutter-delete"]!)).toBe(
+        normHex(RED_GREEN_OVERRIDES["--theme-status-danger"]!)
+      );
+    });
   });
 });

--- a/shared/theme/__tests__/paletteDistinguishability.test.ts
+++ b/shared/theme/__tests__/paletteDistinguishability.test.ts
@@ -410,10 +410,14 @@ describe("palette distinguishability", () => {
       const rgb = (hex: string) => {
         const c = parse(hex)!;
         const to255 = (v: number) => Math.round((v as number) * 255);
+        // culori.parse() always returns RGB values (0-1 range), even when a mode is
+        // active, so we can safely access r, g, b as an any-typed object to avoid
+        // type errors from the discriminated union type.
+        const color = c as unknown as { r: number; g: number; b: number };
         return {
-          r: to255((c as Record<string, number>).r),
-          g: to255((c as Record<string, number>).g),
-          b: to255((c as Record<string, number>).b),
+          r: to255(color.r),
+          g: to255(color.g),
+          b: to255(color.b),
         };
       };
       const success = rgb(RED_GREEN_OVERRIDES["--theme-status-success"]!);

--- a/shared/theme/__tests__/paletteDistinguishability.test.ts
+++ b/shared/theme/__tests__/paletteDistinguishability.test.ts
@@ -403,5 +403,34 @@ describe("palette distinguishability", () => {
         normHex(RED_GREEN_OVERRIDES["--theme-status-danger"]!)
       );
     });
+
+    it("red-green diff backgrounds are the overridden status hue at the light-mode alphas", () => {
+      // Derive the expected rgba from the override's own status hex so a wrong
+      // alpha or a swapped insert/delete derivation fails — not a literal match.
+      const rgb = (hex: string) => {
+        const c = parse(hex)!;
+        const to255 = (v: number) => Math.round((v as number) * 255);
+        return {
+          r: to255((c as Record<string, number>).r),
+          g: to255((c as Record<string, number>).g),
+          b: to255((c as Record<string, number>).b),
+        };
+      };
+      const success = rgb(RED_GREEN_OVERRIDES["--theme-status-success"]!);
+      const danger = rgb(RED_GREEN_OVERRIDES["--theme-status-danger"]!);
+
+      expect(RED_GREEN_OVERRIDES["--theme-diff-insert-background"]).toBe(
+        `rgba(${success.r}, ${success.g}, ${success.b}, 0.1)`
+      );
+      expect(RED_GREEN_OVERRIDES["--theme-diff-insert-edit-background"]).toBe(
+        `rgba(${success.r}, ${success.g}, ${success.b}, 0.2)`
+      );
+      expect(RED_GREEN_OVERRIDES["--theme-diff-delete-background"]).toBe(
+        `rgba(${danger.r}, ${danger.g}, ${danger.b}, 0.1)`
+      );
+      expect(RED_GREEN_OVERRIDES["--theme-diff-delete-edit-background"]).toBe(
+        `rgba(${danger.r}, ${danger.g}, ${danger.b}, 0.2)`
+      );
+    });
   });
 });

--- a/shared/theme/colorVisionOverrides.ts
+++ b/shared/theme/colorVisionOverrides.ts
@@ -52,6 +52,9 @@ const STATUS_DIFF_TOKENS: Record<
   },
 };
 
+// Expects a 3- or 6-digit hex string (the form every override value uses).
+// Non-hex input (oklch(), rgb(), 8-digit hex) yields rgba(NaN, …), which CSS
+// silently drops — keep the maps hex-only.
 function hexToRgba(hex: string, alpha: number): string {
   const clean = hex.replace("#", "");
   const expanded =

--- a/shared/theme/colorVisionOverrides.ts
+++ b/shared/theme/colorVisionOverrides.ts
@@ -25,6 +25,33 @@ const STATUS_SURFACE_TOKENS: Record<string, string> = {
 // hue match is what matters under CVD.
 const CVD_STATUS_SURFACE_ALPHA = 0.1;
 
+// Status base token -> the diff tokens re-derived from it. The light-mode
+// diff-viewer CSS (.light .diff-viewer) reads the pre-baked --color-diff-*
+// tokens, which themes.ts derives from status-success / status-danger at
+// theme-build time. Patching --theme-status-* at runtime doesn't re-derive
+// these, so a CVD override would otherwise leave light-mode diff fills, edit
+// highlights, and gutters on the original (non-CVD) hue. Re-derive them here.
+// Dark mode is unaffected (its CSS reads --color-status-* directly), so we use
+// the light-polarity alphas only.
+const CVD_DIFF_BACKGROUND_ALPHA = 0.1;
+const CVD_DIFF_EDIT_BACKGROUND_ALPHA = 0.2;
+
+const STATUS_DIFF_TOKENS: Record<
+  string,
+  { background: string; editBackground: string; gutter: string }
+> = {
+  "--theme-status-success": {
+    background: "--theme-diff-insert-background",
+    editBackground: "--theme-diff-insert-edit-background",
+    gutter: "--theme-diff-gutter-insert",
+  },
+  "--theme-status-danger": {
+    background: "--theme-diff-delete-background",
+    editBackground: "--theme-diff-delete-edit-background",
+    gutter: "--theme-diff-gutter-delete",
+  },
+};
+
 function hexToRgba(hex: string, alpha: number): string {
   const clean = hex.replace("#", "");
   const expanded =
@@ -49,68 +76,84 @@ function withStatusSurfaces(overrides: Record<string, string>): Record<string, s
   return result;
 }
 
-export const RED_GREEN_OVERRIDES: Record<string, string> = withStatusSurfaces({
-  "--theme-status-success": "#009e73",
-  "--theme-status-danger": "#fe6100",
-  "--theme-activity-active": "#648fff",
-  "--theme-activity-working": "#648fff",
-  "--theme-pr-open": "#648fff",
-  "--theme-pr-closed": "#fe6100",
-  "--theme-terminal-selection": "#1a1f2e",
-  "--theme-terminal-red": "#d55e00",
-  "--theme-terminal-green": "#009e73",
-  "--theme-terminal-bright-red": "#fe6100",
-  "--theme-terminal-bright-green": "#48c9a0",
-  "--theme-terminal-magenta": "#cc79a7",
-  "--theme-terminal-bright-magenta": "#d98fc4",
-  "--theme-syntax-comment": "#999999",
-  "--theme-syntax-punctuation": "#555555",
-  "--theme-syntax-number": "#0072B2",
-  "--theme-syntax-string": "#E69F00",
-  "--theme-syntax-operator": "#555555",
-  "--theme-syntax-keyword": "#D55E00",
-  "--theme-syntax-function": "#0072B2",
-  "--theme-syntax-link": "#0072B2",
-  "--theme-syntax-quote": "#009E73",
-  "--theme-syntax-chip": "#CC79A7",
-  "--theme-category-blue": "#0072b2",
-  "--theme-category-orange": "#e69f00",
-  "--theme-category-teal": "#009e73",
-  "--theme-category-pink": "#cc79a7",
-  "--theme-category-amber": "#d55e00",
-  "--theme-category-violet": "#785ef0",
-  "--theme-category-indigo": "#648fff",
-  "--theme-category-cyan": "#56b4e9",
-});
+function withDiffSurfaces(overrides: Record<string, string>): Record<string, string> {
+  const result = { ...overrides };
+  for (const [baseToken, diffTokens] of Object.entries(STATUS_DIFF_TOKENS)) {
+    const hex = overrides[baseToken];
+    if (!hex) continue;
+    result[diffTokens.background] = hexToRgba(hex, CVD_DIFF_BACKGROUND_ALPHA);
+    result[diffTokens.editBackground] = hexToRgba(hex, CVD_DIFF_EDIT_BACKGROUND_ALPHA);
+    result[diffTokens.gutter] = hex;
+  }
+  return result;
+}
 
-export const BLUE_YELLOW_OVERRIDES: Record<string, string> = withStatusSurfaces({
-  "--theme-status-warning": "#94a3b8",
-  "--theme-activity-waiting": "#94a3b8",
-  "--theme-pr-merged": "#f97316",
-  "--theme-terminal-yellow": "#cc79a7",
-  "--theme-terminal-blue": "#0072b2",
-  "--theme-terminal-bright-yellow": "#d98fc4",
-  "--theme-terminal-bright-blue": "#56b4e9",
-  "--theme-status-info": "#333333",
-  "--theme-syntax-comment": "#999999",
-  "--theme-syntax-punctuation": "#555555",
-  "--theme-syntax-number": "#CC79A7",
-  "--theme-syntax-string": "#E69F00",
-  "--theme-syntax-operator": "#555555",
-  "--theme-syntax-keyword": "#D55E00",
-  "--theme-syntax-function": "#56B4E9",
-  "--theme-syntax-link": "#0072B2",
-  "--theme-syntax-quote": "#F0E442",
-  "--theme-syntax-chip": "#009E73",
-  "--theme-category-blue": "#dc267f",
-  "--theme-category-orange": "#fe6100",
-  "--theme-category-teal": "#009e73",
-  "--theme-category-pink": "#d55e00",
-  "--theme-category-amber": "#ffb000",
-  "--theme-category-violet": "#785ef0",
-  "--theme-category-indigo": "#648fff",
-  "--theme-category-cyan": "#228833",
-});
+export const RED_GREEN_OVERRIDES: Record<string, string> = withDiffSurfaces(
+  withStatusSurfaces({
+    "--theme-status-success": "#009e73",
+    "--theme-status-danger": "#fe6100",
+    "--theme-activity-active": "#648fff",
+    "--theme-activity-working": "#648fff",
+    "--theme-pr-open": "#648fff",
+    "--theme-pr-closed": "#fe6100",
+    "--theme-terminal-selection": "#1a1f2e",
+    "--theme-terminal-red": "#d55e00",
+    "--theme-terminal-green": "#009e73",
+    "--theme-terminal-bright-red": "#fe6100",
+    "--theme-terminal-bright-green": "#48c9a0",
+    "--theme-terminal-magenta": "#cc79a7",
+    "--theme-terminal-bright-magenta": "#d98fc4",
+    "--theme-syntax-comment": "#999999",
+    "--theme-syntax-punctuation": "#555555",
+    "--theme-syntax-number": "#0072B2",
+    "--theme-syntax-string": "#E69F00",
+    "--theme-syntax-operator": "#555555",
+    "--theme-syntax-keyword": "#D55E00",
+    "--theme-syntax-function": "#0072B2",
+    "--theme-syntax-link": "#0072B2",
+    "--theme-syntax-quote": "#009E73",
+    "--theme-syntax-chip": "#CC79A7",
+    "--theme-category-blue": "#0072b2",
+    "--theme-category-orange": "#e69f00",
+    "--theme-category-teal": "#009e73",
+    "--theme-category-pink": "#cc79a7",
+    "--theme-category-amber": "#d55e00",
+    "--theme-category-violet": "#785ef0",
+    "--theme-category-indigo": "#648fff",
+    "--theme-category-cyan": "#56b4e9",
+  })
+);
+
+export const BLUE_YELLOW_OVERRIDES: Record<string, string> = withDiffSurfaces(
+  withStatusSurfaces({
+    "--theme-status-warning": "#94a3b8",
+    "--theme-activity-waiting": "#94a3b8",
+    "--theme-pr-merged": "#f97316",
+    "--theme-terminal-yellow": "#cc79a7",
+    "--theme-terminal-blue": "#0072b2",
+    "--theme-terminal-bright-yellow": "#d98fc4",
+    "--theme-terminal-bright-blue": "#56b4e9",
+    "--theme-status-info": "#333333",
+    "--theme-syntax-comment": "#999999",
+    "--theme-syntax-punctuation": "#555555",
+    "--theme-syntax-number": "#CC79A7",
+    "--theme-syntax-string": "#E69F00",
+    "--theme-syntax-operator": "#555555",
+    "--theme-syntax-keyword": "#D55E00",
+    "--theme-syntax-function": "#56B4E9",
+    "--theme-syntax-link": "#0072B2",
+    "--theme-syntax-quote": "#F0E442",
+    "--theme-syntax-chip": "#009E73",
+    "--theme-category-blue": "#dc267f",
+    "--theme-category-orange": "#fe6100",
+    "--theme-category-teal": "#009e73",
+    "--theme-category-pink": "#d55e00",
+    "--theme-category-amber": "#ffb000",
+    "--theme-category-violet": "#785ef0",
+    "--theme-category-indigo": "#648fff",
+    "--theme-category-cyan": "#228833",
+  })
+);
 
 export const ALL_CVD_TOKENS: ReadonlySet<string> = new Set([
   ...Object.keys(RED_GREEN_OVERRIDES),

--- a/src/store/appThemeStore.ts
+++ b/src/store/appThemeStore.ts
@@ -50,7 +50,7 @@ function applySchemeToDOMNow(scheme: AppColorScheme): void {
   const effective = applyAccentOverrideToScheme(scheme, accentColorOverride);
   applyAppThemeToRoot(document.documentElement, effective);
   if (colorVisionMode !== "default") {
-    applyColorVisionMode(document.documentElement, colorVisionMode);
+    applyColorVisionMode(document.documentElement, colorVisionMode, effective);
   }
 }
 
@@ -162,7 +162,14 @@ export const useAppThemeStore = create<AppThemeState>()((set) => ({
 
   setColorVisionMode: (mode) => {
     set({ colorVisionMode: mode });
-    applyColorVisionMode(document.documentElement, mode);
+    // Pass the active scheme so base --theme-* values are restored for tokens
+    // the mode doesn't override, rather than stripped to undefined.
+    const { selectedSchemeId, customSchemes, accentColorOverride } = useAppThemeStore.getState();
+    const effective = applyAccentOverrideToScheme(
+      resolveAppTheme(selectedSchemeId, customSchemes),
+      accentColorOverride
+    );
+    applyColorVisionMode(document.documentElement, mode, effective);
   },
 
   setFollowSystem: (enabled) => set({ followSystem: enabled }),

--- a/src/theme/__tests__/applyAppTheme.test.ts
+++ b/src/theme/__tests__/applyAppTheme.test.ts
@@ -1,13 +1,28 @@
 // @vitest-environment jsdom
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { APP_THEME_TOKEN_KEYS, getAppThemeById, type AppColorScheme } from "@shared/theme";
+import {
+  APP_THEME_TOKEN_KEYS,
+  getAppThemeById,
+  getAppThemeCssVariables,
+  type AppColorScheme,
+} from "@shared/theme";
+import { RED_GREEN_OVERRIDES } from "@shared/theme/colorVisionOverrides";
 import {
   ALL_CVD_TOKENS,
   applyAppThemeToRoot,
   applyColorVisionMode,
   applyDefaultAppTheme,
 } from "../applyAppTheme";
+
+const DIFF_TOKENS = [
+  "--theme-diff-insert-background",
+  "--theme-diff-insert-edit-background",
+  "--theme-diff-gutter-insert",
+  "--theme-diff-delete-background",
+  "--theme-diff-delete-edit-background",
+  "--theme-diff-gutter-delete",
+] as const;
 
 function createTestScheme(
   id: string,
@@ -124,9 +139,9 @@ describe("applyColorVisionMode", () => {
   it("ALL_CVD_TOKENS covers the expected token count", () => {
     // Canary: if someone adds or removes tokens from either map,
     // this size changes and the test catches it for review.
-    // 33 red-green (incl. 2 status surfaces) + 28 blue-yellow (incl. 2 status
-    // surfaces) = 61 total, 43 unique after dedup
-    expect(ALL_CVD_TOKENS.size).toBe(43);
+    // 39 red-green (incl. 2 status surfaces + 6 diff tokens) + 28 blue-yellow
+    // (incl. 2 status surfaces) = 67 total, 49 unique after dedup
+    expect(ALL_CVD_TOKENS.size).toBe(49);
   });
 
   it("switches from blue-yellow to red-green clearing blue-yellow-only tokens", () => {
@@ -147,6 +162,74 @@ describe("applyColorVisionMode", () => {
     expect(root.style.getPropertyValue("--theme-syntax-keyword")).toBe("");
     expect(root.style.getPropertyValue("--theme-syntax-string")).toBe("");
     expect(root.style.getPropertyValue("--theme-category-blue")).toBe("");
+    expect(root.dataset.colorblind).toBeUndefined();
+  });
+});
+
+describe("applyColorVisionMode diff token restoration", () => {
+  // Regression: the --theme-diff-* tokens (consumed by .light .diff-viewer) and
+  // --theme-status-* have no stylesheet fallback. A mode that doesn't override
+  // them must restore their base values, not strip them to undefined, when the
+  // active scheme is supplied. Use a real built-in light scheme so
+  // getAppThemeCssVariables produces the genuine derived diff/status values.
+  const lightScheme = getAppThemeById("bondi")!;
+  const base = getAppThemeCssVariables(lightScheme);
+
+  it("red-green overrides the diff gutters to the CVD palette", () => {
+    const root = document.createElement("div");
+    applyAppThemeToRoot(root, lightScheme);
+    applyColorVisionMode(root, "red-green", lightScheme);
+
+    expect(root.style.getPropertyValue("--theme-diff-gutter-insert")).toBe(
+      RED_GREEN_OVERRIDES["--theme-diff-gutter-insert"]
+    );
+    expect(root.style.getPropertyValue("--theme-diff-gutter-delete")).toBe(
+      RED_GREEN_OVERRIDES["--theme-diff-gutter-delete"]
+    );
+    // Differs from the base scheme — the override actually took effect.
+    expect(root.style.getPropertyValue("--theme-diff-gutter-insert")).not.toBe(
+      base["--theme-diff-gutter-insert"]
+    );
+  });
+
+  it("blue-yellow restores base diff and status tokens instead of stripping them", () => {
+    const root = document.createElement("div");
+    applyAppThemeToRoot(root, lightScheme);
+    applyColorVisionMode(root, "blue-yellow", lightScheme);
+
+    for (const token of DIFF_TOKENS) {
+      expect(root.style.getPropertyValue(token), `${token} should keep its base value`).toBe(
+        base[token]
+      );
+    }
+    expect(root.style.getPropertyValue("--theme-status-success")).toBe(
+      base["--theme-status-success"]
+    );
+    expect(root.style.getPropertyValue("--theme-status-danger")).toBe(
+      base["--theme-status-danger"]
+    );
+  });
+
+  it("switching red-green to blue-yellow restores diff tokens to base", () => {
+    const root = document.createElement("div");
+    applyAppThemeToRoot(root, lightScheme);
+    applyColorVisionMode(root, "red-green", lightScheme);
+    applyColorVisionMode(root, "blue-yellow", lightScheme);
+
+    for (const token of DIFF_TOKENS) {
+      expect(root.style.getPropertyValue(token)).toBe(base[token]);
+    }
+  });
+
+  it("switching red-green to default restores diff tokens to base", () => {
+    const root = document.createElement("div");
+    applyAppThemeToRoot(root, lightScheme);
+    applyColorVisionMode(root, "red-green", lightScheme);
+    applyColorVisionMode(root, "default", lightScheme);
+
+    for (const token of DIFF_TOKENS) {
+      expect(root.style.getPropertyValue(token)).toBe(base[token]);
+    }
     expect(root.dataset.colorblind).toBeUndefined();
   });
 });

--- a/src/theme/applyAppTheme.ts
+++ b/src/theme/applyAppTheme.ts
@@ -43,10 +43,27 @@ export function applyAppThemeToRoot(root: HTMLElement, scheme: AppColorScheme): 
   root.classList.toggle("light", scheme.type === "light");
 }
 
-export function applyColorVisionMode(root: HTMLElement, mode: ColorVisionMode): void {
-  // Remove all previous CVD inline overrides so base theme values show through
+export function applyColorVisionMode(
+  root: HTMLElement,
+  mode: ColorVisionMode,
+  scheme?: AppColorScheme
+): void {
+  // Undo any previous CVD override. The --theme-* tokens have no stylesheet
+  // fallback — they exist only as the inline styles written by
+  // applyAppThemeToRoot — so removing the inline property leaves them undefined
+  // rather than revealing a base value. When the active scheme is known, restore
+  // each token to its base value; this matters for tokens a mode doesn't itself
+  // override (e.g. blue-yellow leaves status-success/-danger and the light-mode
+  // diff fills derived from them, which a bare removeProperty would erase). Fall
+  // back to removeProperty when no scheme is supplied.
+  const baseVariables = scheme ? getAppThemeCssVariables(scheme) : null;
   for (const token of ALL_CVD_TOKENS) {
-    root.style.removeProperty(token);
+    const baseValue = baseVariables?.[token];
+    if (baseValue != null) {
+      root.style.setProperty(token, baseValue);
+    } else {
+      root.style.removeProperty(token);
+    }
   }
 
   if (mode === "default") {
@@ -56,8 +73,8 @@ export function applyColorVisionMode(root: HTMLElement, mode: ColorVisionMode): 
 
   root.dataset.colorblind = mode;
 
-  // Re-apply base theme values for tokens we're about to override,
-  // then set CVD overrides as inline styles (same specificity as base theme)
+  // Layer the CVD overrides on top as inline styles (same specificity as the
+  // base theme).
   const overrides = CVD_OVERRIDES[mode];
   if (overrides) {
     for (const [name, value] of Object.entries(overrides)) {


### PR DESCRIPTION
## Summary

- Light-mode diff viewer was reading pre-baked `--color-diff-*` tokens derived at theme-build time, so CVD overrides applied at runtime had no effect on diff fills, edits, or gutters
- Token clearing was stripping inline `--theme-*` properties that have no stylesheet fallback, silently blanking status tokens not explicitly set by the active CVD mode
- Fixed both: `colorVisionOverrides.ts` now re-derives the six `--theme-diff-*` surface tokens from overridden status hex using light-mode alphas; `applyColorVisionMode` restores base theme values from the active scheme instead of stripping them

Resolves #10028

## Changes

- `shared/theme/colorVisionOverrides.ts`: added `withDiffSurfaces()` to re-derive `--theme-diff-*` tokens; applied to both CVD maps; `ALL_CVD_TOKENS` canary updated 43 → 49
- `src/theme/applyAppTheme.ts`: `applyColorVisionMode` now restores base token values from the active scheme on clear, rather than stripping inline properties
- `src/store/appThemeStore.ts`: threads the effective scheme through both `applyColorVisionMode` call sites
- `shared/theme/__tests__/paletteDistinguishability.test.ts`: new CVD diff-token coverage and alpha-value assertions; excluded `-background` washes from culori signal filter
- `src/theme/__tests__/applyAppTheme.test.ts`: new restoration tests verifying base values are reinstated when CVD is cleared

## Testing

- `npm run check` passes — typecheck, lint (net -6 warnings), format, build, and IPC/channel/confirm-wiring guards all green
- All unit tests pass including new CVD diff and restoration coverage
- Dark mode unaffected; only light-mode diff token derivation changed