### PR TITLE
fix(forge): restore rate-limit guards dropped during github.* migration

### DIFF
--- a/electron/ipc/handlers/__tests__/forge.rateLimit.test.ts
+++ b/electron/ipc/handlers/__tests__/forge.rateLimit.test.ts
@@ -201,6 +201,8 @@ describe("forge handlers — rate limiting", () => {
 
       await expect(handler({}, "fake_token")).rejects.toThrow("Rate limit exceeded");
       expect(fakeImpl.validateToken).not.toHaveBeenCalled();
+      // The guard fires before provider lookup, not just before the API call.
+      expect(storeMock.get).not.toHaveBeenCalled();
     });
   });
 
@@ -217,6 +219,18 @@ describe("forge handlers — rate limiting", () => {
         "Rate limit exceeded"
       );
       expect(resolveForCwdMock).not.toHaveBeenCalled();
+    });
+
+    it("still collapses resolution failures to null when the guard passes", async () => {
+      resolveForCwdMock.mockRejectedValueOnce(new Error("No remote URL found"));
+      const handler = getInvokeHandler(CHANNELS.FORGE_CLASSIFY_PUSH_ERROR);
+
+      await expect(handler({}, { cwd: "/tmp/project", stderr: "boom" })).resolves.toBeNull();
+      expect(checkRateLimitMock).toHaveBeenCalledWith(
+        CHANNELS.FORGE_CLASSIFY_PUSH_ERROR,
+        10,
+        10_000
+      );
     });
   });
 

--- a/electron/ipc/handlers/__tests__/forge.rateLimit.test.ts
+++ b/electron/ipc/handlers/__tests__/forge.rateLimit.test.ts
@@ -1,0 +1,303 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import type { ForgeProviderImpl, RepoRef } from "../../../../shared/types/forge.js";
+
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
+const checkRateLimitMock = vi.hoisted(() => vi.fn());
+
+const openExternalUrlMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+// A fake forge provider — deliberately NOT GitHub. Proves the guards sit in
+// front of the normalized contract with no GitHub coupling.
+const fakeImpl = vi.hoisted(() => ({
+  buildIssuesUrl: vi.fn(),
+  buildPRsUrl: vi.fn(),
+  buildCommitsUrl: vi.fn(),
+  buildIssueUrl: vi.fn(),
+  assignIssue: vi.fn(),
+  unassignIssue: vi.fn(),
+  validateToken: vi.fn(),
+  classifyPushError: vi.fn(),
+  listIssues: vi.fn(),
+  listPRs: vi.fn(),
+  getIssue: vi.fn(),
+  getPR: vi.fn(),
+  getRepoMetadata: vi.fn(),
+}));
+
+const resolveForCwdMock = vi.hoisted(() => vi.fn());
+
+const storeMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  set: vi.fn(),
+}));
+
+vi.mock("electron", () => ({ ipcMain: ipcMainMock }));
+
+vi.mock("../../utils.js", () => ({
+  checkRateLimit: checkRateLimitMock,
+  typedHandle: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
+      (handler as (...a: unknown[]) => unknown)(...args)
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
+  typedHandleValidated: vi.fn(),
+  typedHandleWithContext: vi.fn(),
+  typedHandleWithContextValidated: vi.fn(),
+}));
+
+vi.mock("../../../utils/openExternal.js", () => ({
+  openExternalUrl: openExternalUrlMock,
+}));
+
+vi.mock("../forgeResolution.js", () => ({
+  resolveForCwd: resolveForCwdMock,
+  getImplForNamespace: () => fakeImpl,
+}));
+
+vi.mock("../../../store.js", () => ({ store: storeMock }));
+
+vi.mock("../../../services/forgeProviderRegistry.js", () => ({
+  getForgeProviderImpl: () => fakeImpl,
+  getRegisteredForgeProviders: () => [{ pluginId: "fake-plugin", contribution: { id: "fake" } }],
+}));
+
+vi.mock("../../../services/forge/forgeAuditService.js", () => ({
+  auditForgeCall: vi.fn((_meta: unknown, run: () => unknown) => run()),
+  summarizeForgeArgs: vi.fn(() => ""),
+}));
+
+import { CHANNELS } from "../../channels.js";
+import { registerForgeHandlers } from "../forge.js";
+import { registerForgeDataHandlers } from "../forgeData.js";
+
+const repoRef: RepoRef = { host: "fake.test", owner: "acme", repo: "widgets", rawData: null };
+
+function getInvokeHandler(channel: string): (...args: unknown[]) => Promise<unknown> {
+  const call = (ipcMainMock.handle as Mock).mock.calls.find(
+    ([registered]) => registered === channel
+  );
+  if (!call) {
+    throw new Error(`No handler registered for channel: ${channel}`);
+  }
+  return call[1] as (...args: unknown[]) => Promise<unknown>;
+}
+
+describe("forge handlers — rate limiting", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveForCwdMock.mockResolvedValue({
+      namespaceId: "fake-plugin.fake",
+      providerId: "fake",
+      repoRef,
+      impl: fakeImpl as unknown as ForgeProviderImpl,
+    });
+    fakeImpl.buildIssuesUrl.mockReturnValue("https://fake.test/acme/widgets/issues");
+    fakeImpl.buildPRsUrl.mockReturnValue("https://fake.test/acme/widgets/pulls");
+    fakeImpl.buildCommitsUrl.mockReturnValue("https://fake.test/acme/widgets/commits");
+    fakeImpl.buildIssueUrl.mockReturnValue("https://fake.test/acme/widgets/issues/1");
+    fakeImpl.assignIssue.mockResolvedValue(undefined);
+    fakeImpl.unassignIssue.mockResolvedValue(undefined);
+    fakeImpl.validateToken.mockResolvedValue({ valid: true, username: "user", avatarUrl: null });
+    fakeImpl.classifyPushError.mockReturnValue(null);
+    fakeImpl.listIssues.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
+    fakeImpl.listPRs.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
+    fakeImpl.getIssue.mockResolvedValue(null);
+    fakeImpl.getPR.mockResolvedValue(null);
+    fakeImpl.getRepoMetadata.mockResolvedValue({
+      defaultBranch: "main",
+      isPrivate: false,
+      isFork: false,
+      isArchived: false,
+      rawData: null,
+    });
+    registerForgeHandlers();
+    registerForgeDataHandlers();
+  });
+
+  describe("read family (forge:list-issues)", () => {
+    it("calls checkRateLimit with read limits (10, 10_000)", async () => {
+      const handler = getInvokeHandler(CHANNELS.FORGE_LIST_ISSUES);
+      await handler({}, { cwd: "/tmp/project" });
+
+      expect(checkRateLimitMock).toHaveBeenCalledWith(CHANNELS.FORGE_LIST_ISSUES, 10, 10_000);
+      expect(fakeImpl.listIssues).toHaveBeenCalled();
+    });
+
+    it("rejects and skips resolution + listIssues when rate limit throws", async () => {
+      checkRateLimitMock.mockImplementationOnce(() => {
+        throw new Error("Rate limit exceeded");
+      });
+      const handler = getInvokeHandler(CHANNELS.FORGE_LIST_ISSUES);
+
+      await expect(handler({}, { cwd: "/tmp/project" })).rejects.toThrow("Rate limit exceeded");
+      expect(resolveForCwdMock).not.toHaveBeenCalled();
+      expect(fakeImpl.listIssues).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("open family (forge:open-issues)", () => {
+    it("calls checkRateLimit with open limits (20, 10_000)", async () => {
+      const handler = getInvokeHandler(CHANNELS.FORGE_OPEN_ISSUES);
+      await handler({}, "/tmp/project", "bug", "open");
+
+      expect(checkRateLimitMock).toHaveBeenCalledWith(CHANNELS.FORGE_OPEN_ISSUES, 20, 10_000);
+      expect(openExternalUrlMock).toHaveBeenCalled();
+    });
+
+    it("rejects and skips openExternalUrl when rate limit throws", async () => {
+      checkRateLimitMock.mockImplementationOnce(() => {
+        throw new Error("Rate limit exceeded");
+      });
+      const handler = getInvokeHandler(CHANNELS.FORGE_OPEN_ISSUES);
+
+      await expect(handler({}, "/tmp/project", "bug", "open")).rejects.toThrow(
+        "Rate limit exceeded"
+      );
+      expect(openExternalUrlMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("mutation family (forge:assign-issue)", () => {
+    it("calls checkRateLimit with mutation limits (5, 10_000)", async () => {
+      const handler = getInvokeHandler(CHANNELS.FORGE_ASSIGN_ISSUE);
+      await handler({}, { cwd: "/tmp/project", issueNumber: 42, username: "octocat" });
+
+      expect(checkRateLimitMock).toHaveBeenCalledWith(CHANNELS.FORGE_ASSIGN_ISSUE, 5, 10_000);
+      expect(fakeImpl.assignIssue).toHaveBeenCalled();
+    });
+
+    it("rejects and skips assignIssue when rate limit throws", async () => {
+      checkRateLimitMock.mockImplementationOnce(() => {
+        throw new Error("Rate limit exceeded");
+      });
+      const handler = getInvokeHandler(CHANNELS.FORGE_ASSIGN_ISSUE);
+
+      await expect(
+        handler({}, { cwd: "/tmp/project", issueNumber: 42, username: "octocat" })
+      ).rejects.toThrow("Rate limit exceeded");
+      expect(fakeImpl.assignIssue).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("token family (forge:validate-token)", () => {
+    it("calls checkRateLimit with token limits (5, 10_000)", async () => {
+      const handler = getInvokeHandler(CHANNELS.FORGE_VALIDATE_TOKEN);
+      await handler({}, "fake_token");
+
+      expect(checkRateLimitMock).toHaveBeenCalledWith(CHANNELS.FORGE_VALIDATE_TOKEN, 5, 10_000);
+      expect(fakeImpl.validateToken).toHaveBeenCalled();
+    });
+
+    it("rejects and skips validateToken when rate limit throws", async () => {
+      checkRateLimitMock.mockImplementationOnce(() => {
+        throw new Error("Rate limit exceeded");
+      });
+      const handler = getInvokeHandler(CHANNELS.FORGE_VALIDATE_TOKEN);
+
+      await expect(handler({}, "fake_token")).rejects.toThrow("Rate limit exceeded");
+      expect(fakeImpl.validateToken).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("best-effort family (forge:classify-push-error)", () => {
+    it("propagates the rate-limit rejection instead of swallowing it to null", async () => {
+      // The handler collapses resolution failures to `null`; the rate-limit
+      // guard sits before that try block so a flood still rejects loudly.
+      checkRateLimitMock.mockImplementationOnce(() => {
+        throw new Error("Rate limit exceeded");
+      });
+      const handler = getInvokeHandler(CHANNELS.FORGE_CLASSIFY_PUSH_ERROR);
+
+      await expect(handler({}, { cwd: "/tmp/project", stderr: "boom" })).rejects.toThrow(
+        "Rate limit exceeded"
+      );
+      expect(resolveForCwdMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("all forge handlers are rate-limit-wired", () => {
+    type HandlerSpec = {
+      channel: string;
+      maxCalls: number;
+      invoke: (handler: (...args: unknown[]) => Promise<unknown>) => Promise<unknown>;
+    };
+
+    const cwd = "/tmp/project";
+    const specs: HandlerSpec[] = [
+      // open family: 20/10s (matches github:open-*)
+      { channel: CHANNELS.FORGE_OPEN_ISSUES, maxCalls: 20, invoke: (h) => h({}, cwd) },
+      { channel: CHANNELS.FORGE_OPEN_PRS, maxCalls: 20, invoke: (h) => h({}, cwd) },
+      { channel: CHANNELS.FORGE_OPEN_COMMITS, maxCalls: 20, invoke: (h) => h({}, cwd) },
+      {
+        channel: CHANNELS.FORGE_OPEN_ISSUE,
+        maxCalls: 20,
+        invoke: (h) => h({}, { cwd, issueNumber: 1 }),
+      },
+      // read family: 10/10s (matches github:get-issue-url / list / repo stats)
+      {
+        channel: CHANNELS.FORGE_GET_ISSUE_URL,
+        maxCalls: 10,
+        invoke: (h) => h({}, { cwd, issueNumber: 1 }),
+      },
+      { channel: CHANNELS.FORGE_LIST_ISSUES, maxCalls: 10, invoke: (h) => h({}, { cwd }) },
+      { channel: CHANNELS.FORGE_LIST_PRS, maxCalls: 10, invoke: (h) => h({}, { cwd }) },
+      { channel: CHANNELS.FORGE_GET_REPO_METADATA, maxCalls: 10, invoke: (h) => h({}, { cwd }) },
+      {
+        channel: CHANNELS.FORGE_CLASSIFY_PUSH_ERROR,
+        maxCalls: 10,
+        invoke: (h) => h({}, { cwd, stderr: "remote rejected" }),
+      },
+      // by-number lookups: 25/10s (matches github:get-issue-by-number / get-pr-by-number)
+      {
+        channel: CHANNELS.FORGE_GET_ISSUE,
+        maxCalls: 25,
+        invoke: (h) => h({}, { cwd, issueNumber: 1 }),
+      },
+      { channel: CHANNELS.FORGE_GET_PR, maxCalls: 25, invoke: (h) => h({}, { cwd, prNumber: 1 }) },
+      // token + mutation family: 5/10s (matches github:validate-token / assign-issue)
+      { channel: CHANNELS.FORGE_VALIDATE_TOKEN, maxCalls: 5, invoke: (h) => h({}, "fake_token") },
+      {
+        channel: CHANNELS.FORGE_ASSIGN_ISSUE,
+        maxCalls: 5,
+        invoke: (h) => h({}, { cwd, issueNumber: 1, username: "octocat" }),
+      },
+      {
+        channel: CHANNELS.FORGE_UNASSIGN_ISSUE,
+        maxCalls: 5,
+        invoke: (h) => h({}, { cwd, issueNumber: 1, username: "octocat" }),
+      },
+    ];
+
+    it("registers all 14 forge channels", () => {
+      expect(specs).toHaveLength(14);
+      expect(ipcMainMock.handle).toHaveBeenCalledTimes(14);
+    });
+
+    it.each(specs)(
+      "$channel calls checkRateLimit($channel, $maxCalls, 10_000)",
+      async ({ channel, maxCalls, invoke }) => {
+        const handler = getInvokeHandler(channel);
+        await invoke(handler);
+        expect(checkRateLimitMock).toHaveBeenCalledWith(channel, maxCalls, 10_000);
+      }
+    );
+
+    it.each(specs)(
+      "$channel rejects before any provider work when the guard throws",
+      async ({ channel, invoke }) => {
+        checkRateLimitMock.mockImplementationOnce(() => {
+          throw new Error("Rate limit exceeded");
+        });
+        const handler = getInvokeHandler(channel);
+
+        await expect(invoke(handler)).rejects.toThrow("Rate limit exceeded");
+        expect(resolveForCwdMock).not.toHaveBeenCalled();
+      }
+    );
+  });
+});

--- a/electron/ipc/handlers/__tests__/forgeResolution.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeResolution.test.ts
@@ -241,7 +241,7 @@ describe("resolveForCwd — cwd validation", () => {
     expect(gitServiceCacheMock.getGitService).not.toHaveBeenCalled();
   });
 
-  it.each(["./relative", "relative/path", "../escape"])(
+  it.each(["./relative", "relative/path", "../escape", "   "])(
     "rejects the non-absolute cwd %s before touching git",
     async (cwd) => {
       await expect(resolveForCwd(cwd)).rejects.toThrow(

--- a/electron/ipc/handlers/__tests__/forgeResolution.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeResolution.test.ts
@@ -222,3 +222,39 @@ describe("resolveForCwd", () => {
     expect(resolverMock.resolveForgeProvider).not.toHaveBeenCalled();
   });
 });
+
+describe("resolveForCwd — cwd validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    gitServiceCacheMock.getGitService.mockReturnValue(null);
+  });
+
+  it("rejects an empty cwd before touching git", async () => {
+    await expect(resolveForCwd("")).rejects.toThrow("Invalid working directory");
+    expect(gitServiceCacheMock.getGitService).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-string cwd", async () => {
+    await expect(resolveForCwd(42 as unknown as string)).rejects.toThrow(
+      "Invalid working directory"
+    );
+    expect(gitServiceCacheMock.getGitService).not.toHaveBeenCalled();
+  });
+
+  it.each(["./relative", "relative/path", "../escape"])(
+    "rejects the non-absolute cwd %s before touching git",
+    async (cwd) => {
+      await expect(resolveForCwd(cwd)).rejects.toThrow(
+        "Working directory must be an absolute path"
+      );
+      expect(gitServiceCacheMock.getGitService).not.toHaveBeenCalled();
+    }
+  );
+
+  it("lets an absolute cwd through to git resolution", async () => {
+    // gitService is null in this fixture, so passing the path gate surfaces
+    // the next failure in the chain rather than the validation error.
+    await expect(resolveForCwd("/abs/path")).rejects.toThrow("Not a git repository");
+    expect(gitServiceCacheMock.getGitService).toHaveBeenCalledWith("/abs/path");
+  });
+});

--- a/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
@@ -60,6 +60,7 @@ vi.mock("../../../services/GitServiceCache.js", () => ({
 }));
 
 import { registerForgeSettingsHandlers } from "../forgeSettings.js";
+import { _resetRateLimitQueuesForTest } from "../../utils.js";
 import { forgeAuditService } from "../../../services/forge/forgeAuditService.js";
 
 function findHandler(channel: string): (...args: unknown[]) => unknown {
@@ -71,6 +72,7 @@ function findHandler(channel: string): (...args: unknown[]) => unknown {
 describe("registerForgeSettingsHandlers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    _resetRateLimitQueuesForTest();
     for (const key of Object.keys(storeMock._data)) {
       delete storeMock._data[key];
     }
@@ -446,6 +448,24 @@ describe("registerForgeSettingsHandlers", () => {
     await setCredential(null, "acme.gitea", { token: "nope" });
 
     expect(setCredentials).not.toHaveBeenCalled();
+  });
+
+  it("setCredential rate-limits after 5 calls in the window and skips validation (#9956)", async () => {
+    registerGiteaProvider();
+    const validateToken = vi.fn().mockResolvedValue({ valid: true, scopes: ["repo"] });
+    registryMock.getForgeProviderImpl.mockReturnValue({ validateToken });
+    registerForgeSettingsHandlers();
+    const setCredential = findHandler("forge:set-credential");
+
+    for (let i = 0; i < 5; i++) {
+      await setCredential(null, "acme.gitea", { token: `secret-${i}` });
+    }
+    expect(validateToken).toHaveBeenCalledTimes(5);
+
+    await expect(setCredential(null, "acme.gitea", { token: "secret-6" })).rejects.toThrow(
+      "Rate limit exceeded"
+    );
+    expect(validateToken).toHaveBeenCalledTimes(5);
   });
 
   it("setCredential does not persist or sync when validation fails", async () => {

--- a/electron/ipc/handlers/forge.ts
+++ b/electron/ipc/handlers/forge.ts
@@ -1,7 +1,7 @@
 // eager-import-allow: reads forge config via store.get synchronously in the IPC handler
 import { CHANNELS } from "../channels.js";
 import { openExternalUrl } from "../../utils/openExternal.js";
-import { typedHandle } from "../utils.js";
+import { checkRateLimit, typedHandle } from "../utils.js";
 import { defineIpcNamespace, op } from "../define.js";
 import { store } from "../../store.js";
 import {
@@ -21,6 +21,7 @@ async function handleForgeUnassignIssue(payload: {
   issueNumber: number;
   username: string;
 }): Promise<void> {
+  checkRateLimit(CHANNELS.FORGE_UNASSIGN_ISSUE, 5, 10_000);
   if (!payload || typeof payload !== "object") {
     throw new Error("Invalid payload");
   }
@@ -64,6 +65,7 @@ export function registerForgeHandlers(): () => void {
 
   cleanups.push(
     typedHandle(CHANNELS.FORGE_OPEN_ISSUES, async (cwd: string, query?: string, state?: string) => {
+      checkRateLimit(CHANNELS.FORGE_OPEN_ISSUES, 20, 10_000);
       const { namespaceId, repoRef } = await resolveForCwd(cwd);
       const impl = getImplForNamespace(namespaceId);
       const url = impl.buildIssuesUrl(repoRef, { query, state });
@@ -73,6 +75,7 @@ export function registerForgeHandlers(): () => void {
 
   cleanups.push(
     typedHandle(CHANNELS.FORGE_OPEN_PRS, async (cwd: string, query?: string, state?: string) => {
+      checkRateLimit(CHANNELS.FORGE_OPEN_PRS, 20, 10_000);
       const { namespaceId, repoRef } = await resolveForCwd(cwd);
       const impl = getImplForNamespace(namespaceId);
       const url = impl.buildPRsUrl(repoRef, { query, state });
@@ -82,6 +85,7 @@ export function registerForgeHandlers(): () => void {
 
   cleanups.push(
     typedHandle(CHANNELS.FORGE_OPEN_COMMITS, async (cwd: string, branch?: string) => {
+      checkRateLimit(CHANNELS.FORGE_OPEN_COMMITS, 20, 10_000);
       if (branch !== undefined && (typeof branch !== "string" || !branch.trim())) {
         throw new Error("Invalid branch name");
       }
@@ -96,6 +100,7 @@ export function registerForgeHandlers(): () => void {
     typedHandle(
       CHANNELS.FORGE_OPEN_ISSUE,
       async (payload: { cwd: string; issueNumber: number }) => {
+        checkRateLimit(CHANNELS.FORGE_OPEN_ISSUE, 20, 10_000);
         if (!payload || typeof payload !== "object") {
           throw new Error("Invalid payload");
         }
@@ -121,6 +126,7 @@ export function registerForgeHandlers(): () => void {
     typedHandle(
       CHANNELS.FORGE_GET_ISSUE_URL,
       async (payload: { cwd: string; issueNumber: number }) => {
+        checkRateLimit(CHANNELS.FORGE_GET_ISSUE_URL, 10, 10_000);
         if (!payload || typeof payload !== "object") {
           throw new Error("Invalid payload");
         }
@@ -145,6 +151,7 @@ export function registerForgeHandlers(): () => void {
     typedHandle(
       CHANNELS.FORGE_ASSIGN_ISSUE,
       async (payload: { cwd: string; issueNumber: number; username: string }) => {
+        checkRateLimit(CHANNELS.FORGE_ASSIGN_ISSUE, 5, 10_000);
         if (!payload || typeof payload !== "object") {
           throw new Error("Invalid payload");
         }
@@ -182,6 +189,7 @@ export function registerForgeHandlers(): () => void {
 
   cleanups.push(
     typedHandle(CHANNELS.FORGE_VALIDATE_TOKEN, async (token: string) => {
+      checkRateLimit(CHANNELS.FORGE_VALIDATE_TOKEN, 5, 10_000);
       if (typeof token !== "string" || !token.trim()) {
         return { valid: false as const, error: "Token is required" };
       }
@@ -234,6 +242,7 @@ export function registerForgeHandlers(): () => void {
         providerId: string;
         classification: PushErrorClassification | null;
       } | null> => {
+        checkRateLimit(CHANNELS.FORGE_CLASSIFY_PUSH_ERROR, 10, 10_000);
         if (
           !payload ||
           typeof payload !== "object" ||

--- a/electron/ipc/handlers/forgeData.ts
+++ b/electron/ipc/handlers/forgeData.ts
@@ -1,5 +1,5 @@
 import { CHANNELS } from "../channels.js";
-import { typedHandle } from "../utils.js";
+import { checkRateLimit, typedHandle } from "../utils.js";
 import { resolveForCwd } from "./forgeResolution.js";
 import { auditForgeCall, summarizeForgeArgs } from "../../services/forge/forgeAuditService.js";
 import type { ListOptions } from "../../../shared/types/forge.js";
@@ -7,8 +7,10 @@ import type { ListOptions } from "../../../shared/types/forge.js";
 /**
  * Provider-agnostic forge *data* handlers (list/get queries). The sibling
  * `forge.ts` owns side-effectful actions (open in browser, assign);
- * `forgeSettings.ts` owns config CRUD. Splitting queries out keeps
- * rate-limit/error handling for reads from tangling with the action surface.
+ * `forgeSettings.ts` owns config CRUD. Splitting queries out keeps the read
+ * surface from tangling with the action surface. Every handler opens with a
+ * `checkRateLimit` guard whose budget matches the `github.*` channel it
+ * replaced (#9956).
  *
  * Every handler resolves `cwd → ForgeProviderImpl` via {@link resolveForCwd}
  * and delegates to the normalized contract — the renderer never sees
@@ -95,6 +97,7 @@ export function registerForgeDataHandlers(): () => void {
     typedHandle(
       CHANNELS.FORGE_LIST_ISSUES,
       async (payload: { cwd: string; opts?: ListOptions }) => {
+        checkRateLimit(CHANNELS.FORGE_LIST_ISSUES, 10, 10_000);
         if (!payload || typeof payload !== "object") {
           throw new Error("Invalid payload");
         }
@@ -119,6 +122,7 @@ export function registerForgeDataHandlers(): () => void {
 
   cleanups.push(
     typedHandle(CHANNELS.FORGE_LIST_PRS, async (payload: { cwd: string; opts?: ListOptions }) => {
+      checkRateLimit(CHANNELS.FORGE_LIST_PRS, 10, 10_000);
       if (!payload || typeof payload !== "object") {
         throw new Error("Invalid payload");
       }
@@ -142,6 +146,7 @@ export function registerForgeDataHandlers(): () => void {
 
   cleanups.push(
     typedHandle(CHANNELS.FORGE_GET_ISSUE, async (payload: { cwd: string; issueNumber: number }) => {
+      checkRateLimit(CHANNELS.FORGE_GET_ISSUE, 25, 10_000);
       if (!payload || typeof payload !== "object") {
         throw new Error("Invalid payload");
       }
@@ -166,6 +171,7 @@ export function registerForgeDataHandlers(): () => void {
 
   cleanups.push(
     typedHandle(CHANNELS.FORGE_GET_PR, async (payload: { cwd: string; prNumber: number }) => {
+      checkRateLimit(CHANNELS.FORGE_GET_PR, 25, 10_000);
       if (!payload || typeof payload !== "object") {
         throw new Error("Invalid payload");
       }
@@ -190,6 +196,7 @@ export function registerForgeDataHandlers(): () => void {
 
   cleanups.push(
     typedHandle(CHANNELS.FORGE_GET_REPO_METADATA, async (payload: { cwd: string }) => {
+      checkRateLimit(CHANNELS.FORGE_GET_REPO_METADATA, 10, 10_000);
       if (!payload || typeof payload !== "object") {
         throw new Error("Invalid payload");
       }

--- a/electron/ipc/handlers/forgeResolution.ts
+++ b/electron/ipc/handlers/forgeResolution.ts
@@ -1,4 +1,5 @@
 // eager-import-allow: reads forge-resolution config via store.get synchronously in the IPC handler
+import path from "node:path";
 import { store } from "../../store.js";
 import { getForgeProviderImpl } from "../../services/forgeProviderRegistry.js";
 import { resolveForgeProvider } from "../../services/forgeProviderResolver.js";
@@ -31,6 +32,9 @@ export interface ResolvedForgeContext {
 export async function resolveForCwd(cwd: string): Promise<ResolvedForgeContext> {
   if (typeof cwd !== "string" || !cwd) {
     throw new Error("Invalid working directory");
+  }
+  if (!path.isAbsolute(cwd)) {
+    throw new Error("Working directory must be an absolute path");
   }
 
   const gitService = gitServiceCache.getGitService(cwd);

--- a/electron/ipc/handlers/forgeSettings.ts
+++ b/electron/ipc/handlers/forgeSettings.ts
@@ -1,7 +1,7 @@
 // eager-import-allow: reads forge settings via store.get synchronously in the IPC handler
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
-import { typedHandle } from "../utils.js";
+import { checkRateLimit, typedHandle } from "../utils.js";
 import {
   getForgeProviderImpl,
   getRegisteredForgeProviders,
@@ -160,6 +160,9 @@ export function registerForgeSettingsHandlers(): () => void {
     typedHandle(
       CHANNELS.FORGE_SET_CREDENTIAL,
       async (providerId: unknown, credentials: unknown): Promise<AuthValidation> => {
+        // Same budget as github:set-token — each call hits the provider's
+        // token-validation API (#9956).
+        checkRateLimit(CHANNELS.FORGE_SET_CREDENTIAL, 5, 10_000);
         if (typeof providerId !== "string" || providerId.length === 0) {
           return { valid: false, error: "Provider id is required" };
         }


### PR DESCRIPTION
## Summary

- When `forge.*` handlers replaced `github.*` as the primary dispatch path, the per-channel `checkRateLimit` guards were never carried over — leaving 14 handler entry points completely uncapped, including `forge:open-issues` / `forge:open-prs` which call `openExternalUrl` and can flood browser tabs from a misbehaving renderer.
- Adds `checkRateLimit` as the first statement in all 9 handlers in `forge.ts` and all 5 in `forgeData.ts`, with budgets matching the `github.*` channels they replaced. Also adds the equivalent guard to `forge:set-credential` in `forgeSettings.ts`, which had the same migration gap.
- Restores the `path.isAbsolute` check on `resolveForCwd` in `forgeResolution.ts` and corrects the `forgeData.ts` header comment that falsely claimed rate-limit handling existed.

Closes #9956

## Changes

- `electron/ipc/handlers/forge.ts` — `checkRateLimit` added to all 9 handlers: `open-*` at 20/10s, `assign`/`unassign`/`validate-token` at 5/10s, `list-*` at 10/10s, `get-issue`/`get-pr` at 25/10s, `get-repo-metadata`/`get-issue-url`/`classify-push-error` at 10/10s. Per-channel buckets, no `channelToCategory` entries — same pattern as `github.*`.
- `electron/ipc/handlers/forgeData.ts` — same guards on all 5 data handlers. Header comment corrected.
- `electron/ipc/handlers/forgeSettings.ts` — `forge:set-credential` gets the same 5/10s guard as `github:set-token-equivalent`.
- `electron/ipc/handlers/forgeResolution.ts` — `resolveForCwd` now rejects non-absolute `cwd` with `"Working directory must be an absolute path"`, covering all forge handlers at one shared fix point.
- `forge:classify-push-error` guard sits before the error-swallowing `try` block so floods reject loudly instead of silently collapsing to `null`.

## Testing

- New `forge.rateLimit.test.ts` mirrors `github.rateLimit.test.ts`: exhaustive 14-channel `it.each` wiring specs + guard-throw rejection specs + family `describe` blocks.
- New `forgeResolution.test.ts` covers the `cwd` validation gate including whitespace and relative paths.
- `forgeSettings.handlers.test.ts` gains a behavioral 6th-call-rejects spec with per-test rate-limit state reset.
- 104 tests passing across all 4 forge suites. `npm run check` and build both green.