### PR TITLE
fix(recipe-runner): align grid keyboard model with focused option

### DIFF
--- a/src/components/Terminal/RecipeRunner/RecipeRunner.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunner.tsx
@@ -135,7 +135,7 @@ export function RecipeRunner({ activeWorktreeId, defaultCwd }: RecipeRunnerProps
           onUnpin={runner.handleUnpin}
           onDelete={runner.handleDelete}
           onCreate={runner.handleCreate}
-          onKeyDown={runner.handleKeyDown}
+          setFocusedIndex={runner.setFocusedIndex}
         />
       )}
       {deleteDialog}

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerGrid.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerGrid.tsx
@@ -1,4 +1,5 @@
 import { Plus } from "lucide-react";
+import { useRef, useCallback } from "react";
 import { RecipeRunnerItem } from "./RecipeRunnerItem";
 import type { TerminalRecipe } from "@/types";
 
@@ -13,7 +14,24 @@ interface RecipeRunnerGridProps {
   onUnpin: (id: string) => void;
   onDelete: (id: string) => void;
   onCreate: () => void;
-  onKeyDown: (e: React.KeyboardEvent) => void;
+  setFocusedIndex: (i: number) => void;
+}
+
+function moveFocus(current: number, total: number, key: string): number {
+  switch (key) {
+    case "ArrowDown":
+    case "ArrowRight":
+      return (current + 1) % total;
+    case "ArrowUp":
+    case "ArrowLeft":
+      return (current - 1 + total) % total;
+    case "Home":
+      return 0;
+    case "End":
+      return total - 1;
+    default:
+      return current;
+  }
 }
 
 export function RecipeRunnerGrid({
@@ -27,51 +45,76 @@ export function RecipeRunnerGrid({
   onUnpin,
   onDelete,
   onCreate,
-  onKeyDown,
+  setFocusedIndex,
 }: RecipeRunnerGridProps) {
   const gridCols = recipes.length <= 2 ? "grid-cols-2" : "grid-cols-3";
+  const createIndex = recipes.length;
+  const focusableCount = recipes.length + 1;
+  const buttonRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const setButtonRef = useCallback(
+    (index: number) => (el: HTMLButtonElement | null) => {
+      buttonRefs.current[index] = el;
+    },
+    []
+  );
+
+  const handleOptionKeyDown = (index: number) => (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.altKey || e.ctrlKey || e.metaKey) return;
+    const next = moveFocus(index, focusableCount, e.key);
+    if (next === index) return;
+    e.preventDefault();
+    setFocusedIndex(next);
+    buttonRefs.current[next]?.focus();
+  };
 
   return (
-    <div onKeyDown={onKeyDown}>
-      <div
-        role="listbox"
-        id="recipe-listbox"
-        aria-label="Recipes"
-        className={`grid ${gridCols} gap-2`}
+    <div
+      role="listbox"
+      id="recipe-listbox"
+      aria-label="Recipes"
+      className={`grid ${gridCols} gap-2`}
+    >
+      {recipes.map((recipe, i) => (
+        <RecipeRunnerItem
+          key={recipe.id}
+          recipe={recipe}
+          isFocused={focusedIndex === i}
+          mode="grid"
+          disabled={disabled}
+          id={`recipe-option-${recipe.id}`}
+          tabIndex={focusedIndex === i ? 0 : -1}
+          buttonRef={setButtonRef(i)}
+          onFocus={() => setFocusedIndex(i)}
+          onKeyDown={handleOptionKeyDown(i)}
+          onRun={onRun}
+          onEdit={onEdit}
+          onDuplicate={onDuplicate}
+          onPin={onPin}
+          onUnpin={onUnpin}
+          onDelete={onDelete}
+        />
+      ))}
+      <button
+        id="recipe-option-create"
+        ref={setButtonRef(createIndex)}
+        role="option"
+        aria-selected={focusedIndex === createIndex}
+        type="button"
+        onClick={onCreate}
+        onFocus={() => setFocusedIndex(createIndex)}
+        onKeyDown={handleOptionKeyDown(createIndex)}
+        tabIndex={focusedIndex === createIndex ? 0 : -1}
+        className="group col-span-full flex items-center justify-center gap-2 px-3 py-2 mt-1 rounded-[var(--radius-md)] hover:bg-overlay-medium transition-colors text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent aria-selected:ring-2 aria-selected:ring-daintree-accent/60"
       >
-        {recipes.map((recipe, i) => (
-          <RecipeRunnerItem
-            key={recipe.id}
-            recipe={recipe}
-            isFocused={focusedIndex === i}
-            mode="grid"
-            disabled={disabled}
-            id={`recipe-option-${recipe.id}`}
-            onRun={onRun}
-            onEdit={onEdit}
-            onDuplicate={onDuplicate}
-            onPin={onPin}
-            onUnpin={onUnpin}
-            onDelete={onDelete}
-          />
-        ))}
-        <button
-          id="recipe-option-create"
-          role="option"
-          aria-selected={focusedIndex === recipes.length}
-          type="button"
-          onClick={onCreate}
-          className="group col-span-full flex items-center justify-center gap-2 px-3 py-2 mt-1 rounded-[var(--radius-md)] hover:bg-overlay-medium transition-colors text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent aria-selected:ring-2 aria-selected:ring-daintree-accent/60"
-        >
-          <Plus
-            className="h-3.5 w-3.5 text-text-muted group-hover:text-daintree-text transition-colors shrink-0"
-            aria-hidden
-          />
-          <span className="text-sm text-text-muted group-hover:text-daintree-text transition-colors">
-            Create new recipe…
-          </span>
-        </button>
-      </div>
+        <Plus
+          className="h-3.5 w-3.5 text-text-muted group-hover:text-daintree-text transition-colors shrink-0"
+          aria-hidden
+        />
+        <span className="text-sm text-text-muted group-hover:text-daintree-text transition-colors">
+          Create new recipe…
+        </span>
+      </button>
     </div>
   );
 }

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerGrid.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerGrid.tsx
@@ -104,7 +104,7 @@ export function RecipeRunnerGrid({
         onClick={onCreate}
         onFocus={() => setFocusedIndex(createIndex)}
         onKeyDown={handleOptionKeyDown(createIndex)}
-        tabIndex={focusedIndex === createIndex ? 0 : -1}
+        tabIndex={disabled || focusedIndex === createIndex ? 0 : -1}
         className="group col-span-full flex items-center justify-center gap-2 px-3 py-2 mt-1 rounded-[var(--radius-md)] hover:bg-overlay-medium transition-colors text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent aria-selected:ring-2 aria-selected:ring-daintree-accent/60"
       >
         <Plus

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx
@@ -16,6 +16,10 @@ interface RecipeRunnerItemProps {
   mode: "grid" | "list";
   disabled?: boolean;
   id: string;
+  tabIndex?: number;
+  buttonRef?: React.Ref<HTMLButtonElement>;
+  onFocus?: () => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLButtonElement>) => void;
   onRun: (id: string) => void;
   onEdit: (id: string) => void;
   onDuplicate: (id: string) => void;
@@ -30,6 +34,10 @@ export function RecipeRunnerItem({
   mode,
   disabled,
   id,
+  tabIndex,
+  buttonRef,
+  onFocus,
+  onKeyDown,
   onRun,
   onEdit,
   onDuplicate,
@@ -46,11 +54,15 @@ export function RecipeRunnerItem({
         <ContextMenuTrigger asChild>
           <button
             id={id}
+            ref={buttonRef}
             role="option"
             aria-selected={isFocused}
             type="button"
             onClick={() => onRun(recipe.id)}
+            onFocus={onFocus}
+            onKeyDown={onKeyDown}
             disabled={disabled}
+            tabIndex={disabled ? -1 : (tabIndex ?? 0)}
             className={cn(
               "group flex flex-col items-start gap-1.5 p-3 rounded-[var(--radius-md)] bg-overlay-subtle border border-border-subtle hover:bg-overlay-soft hover:border-border-default transition-colors text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-overlay-subtle disabled:hover:border-border-subtle aria-selected:ring-2 aria-selected:ring-daintree-accent/60",
               recipe.shadowedBy && "opacity-60"
@@ -98,11 +110,15 @@ export function RecipeRunnerItem({
       <ContextMenuTrigger asChild>
         <button
           id={id}
+          ref={buttonRef}
           role="option"
           aria-selected={isFocused}
           type="button"
           onClick={() => onRun(recipe.id)}
+          onFocus={onFocus}
+          onKeyDown={onKeyDown}
           disabled={disabled}
+          tabIndex={disabled ? -1 : (tabIndex ?? 0)}
           className={cn(
             "group w-full flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] bg-overlay-subtle border border-border-subtle hover:bg-overlay-soft hover:border-border-default transition-colors text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-overlay-subtle disabled:hover:border-border-subtle aria-selected:ring-2 aria-selected:ring-daintree-accent/60",
             recipe.shadowedBy && "opacity-60"

--- a/src/components/Terminal/RecipeRunner/__tests__/RecipeRunnerGrid.test.tsx
+++ b/src/components/Terminal/RecipeRunner/__tests__/RecipeRunnerGrid.test.tsx
@@ -1,0 +1,285 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useState } from "react";
+import { RecipeRunnerGrid } from "../RecipeRunnerGrid";
+import type { TerminalRecipe } from "@/types";
+
+function makeRecipe(
+  overrides: Partial<TerminalRecipe> & { id: string; name: string }
+): TerminalRecipe {
+  return {
+    terminals: [{ type: "terminal", env: {} }],
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+const noop = () => {};
+
+interface HarnessProps {
+  recipes: TerminalRecipe[];
+  initialFocusedIndex?: number;
+}
+
+function Harness({ recipes, initialFocusedIndex = 0 }: HarnessProps) {
+  const [focusedIndex, setFocusedIndex] = useState(initialFocusedIndex);
+  return (
+    <RecipeRunnerGrid
+      recipes={recipes}
+      focusedIndex={focusedIndex}
+      setFocusedIndex={setFocusedIndex}
+      onRun={noop}
+      onEdit={noop}
+      onDuplicate={noop}
+      onPin={noop}
+      onUnpin={noop}
+      onDelete={noop}
+      onCreate={noop}
+    />
+  );
+}
+
+function optionButton(recipe: TerminalRecipe) {
+  return screen.getByRole("option", { name: new RegExp(recipe.name) });
+}
+
+describe("RecipeRunnerGrid — roving tabindex", () => {
+  const recipes: TerminalRecipe[] = [
+    makeRecipe({ id: "alpha", name: "Alpha" }),
+    makeRecipe({ id: "beta", name: "Beta" }),
+    makeRecipe({ id: "gamma", name: "Gamma" }),
+  ];
+
+  it("renders one option per recipe plus the trailing create option", () => {
+    render(<Harness recipes={recipes} />);
+
+    expect(screen.getAllByRole("option")).toHaveLength(4);
+    expect(screen.getByRole("option", { name: /Create new recipe/ })).toBeTruthy();
+  });
+
+  it("places tabIndex=0 on the focused option and -1 on the rest", () => {
+    render(<Harness recipes={recipes} initialFocusedIndex={1} />);
+
+    const [alpha, beta, gamma] = recipes.map((r) => optionButton(r));
+    const create = screen.getByRole("option", { name: /Create new recipe/ });
+
+    expect(alpha!.getAttribute("tabindex")).toBe("-1");
+    expect(beta!.getAttribute("tabindex")).toBe("0");
+    expect(gamma!.getAttribute("tabindex")).toBe("-1");
+    expect(create.getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("marks only the focused option with aria-selected=true", () => {
+    render(<Harness recipes={recipes} initialFocusedIndex={2} />);
+
+    const [alpha, beta, gamma] = recipes.map((r) => optionButton(r));
+    const create = screen.getByRole("option", { name: /Create new recipe/ });
+
+    expect(alpha!.getAttribute("aria-selected")).toBe("false");
+    expect(beta!.getAttribute("aria-selected")).toBe("false");
+    expect(gamma!.getAttribute("aria-selected")).toBe("true");
+    expect(create.getAttribute("aria-selected")).toBe("false");
+  });
+});
+
+describe("RecipeRunnerGrid — focus-driven Enter runs the focused recipe", () => {
+  it("runs the focused recipe when Enter is pressed on its button, not index 0", () => {
+    const onRun = vi.fn();
+    const onCreate = vi.fn();
+    const recipes: TerminalRecipe[] = [
+      makeRecipe({ id: "alpha", name: "Alpha" }),
+      makeRecipe({ id: "beta", name: "Beta" }),
+      makeRecipe({ id: "gamma", name: "Gamma" }),
+    ];
+
+    function StatefulHarness() {
+      const [focusedIndex, setFocusedIndex] = useState(2);
+      return (
+        <RecipeRunnerGrid
+          recipes={recipes}
+          focusedIndex={focusedIndex}
+          setFocusedIndex={setFocusedIndex}
+          onRun={onRun}
+          onEdit={noop}
+          onDuplicate={noop}
+          onPin={noop}
+          onUnpin={noop}
+          onDelete={noop}
+          onCreate={onCreate}
+        />
+      );
+    }
+
+    render(<StatefulHarness />);
+
+    // Simulate the user Tab-focusing the third card (this is the bug scenario).
+    const gamma = optionButton(recipes[2]!);
+    gamma.focus();
+    fireEvent.click(gamma);
+    expect(onRun).toHaveBeenCalledWith("gamma");
+  });
+
+  it("fires onCreate when the create option is clicked after focus moves there", () => {
+    const onCreate = vi.fn();
+    const recipes: TerminalRecipe[] = [
+      makeRecipe({ id: "alpha", name: "Alpha" }),
+      makeRecipe({ id: "beta", name: "Beta" }),
+    ];
+
+    function StatefulHarness() {
+      const [focusedIndex, setFocusedIndex] = useState(2);
+      return (
+        <RecipeRunnerGrid
+          recipes={recipes}
+          focusedIndex={focusedIndex}
+          setFocusedIndex={setFocusedIndex}
+          onRun={noop}
+          onEdit={noop}
+          onDuplicate={noop}
+          onPin={noop}
+          onUnpin={noop}
+          onDelete={noop}
+          onCreate={onCreate}
+        />
+      );
+    }
+
+    render(<StatefulHarness />);
+
+    const create = screen.getByRole("option", { name: /Create new recipe/ });
+    create.focus();
+    fireEvent.click(create);
+    expect(onCreate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("RecipeRunnerGrid — arrow navigation", () => {
+  const recipes: TerminalRecipe[] = [
+    makeRecipe({ id: "alpha", name: "Alpha" }),
+    makeRecipe({ id: "beta", name: "Beta" }),
+    makeRecipe({ id: "gamma", name: "Gamma" }),
+  ];
+
+  it("ArrowDown moves focus and tabindex to the next option", () => {
+    render(<Harness recipes={recipes} initialFocusedIndex={0} />);
+    const [alpha, beta, gamma] = recipes.map((r) => optionButton(r));
+
+    alpha!.focus();
+    fireEvent.keyDown(alpha!, { key: "ArrowDown" });
+
+    expect(alpha!.getAttribute("tabindex")).toBe("-1");
+    expect(beta!.getAttribute("tabindex")).toBe("0");
+    expect(gamma!.getAttribute("tabindex")).toBe("-1");
+    expect(document.activeElement).toBe(beta);
+  });
+
+  it("ArrowUp moves focus to the previous option", () => {
+    render(<Harness recipes={recipes} initialFocusedIndex={1} />);
+    const [alpha, beta] = recipes.map((r) => optionButton(r));
+
+    beta!.focus();
+    fireEvent.keyDown(beta!, { key: "ArrowUp" });
+
+    expect(alpha!.getAttribute("tabindex")).toBe("0");
+    expect(beta!.getAttribute("tabindex")).toBe("-1");
+    expect(document.activeElement).toBe(alpha);
+  });
+
+  it("wraps from the last option to the first on ArrowDown", () => {
+    render(<Harness recipes={recipes} initialFocusedIndex={3} />);
+    const create = screen.getByRole("option", { name: /Create new recipe/ });
+    const alpha = optionButton(recipes[0]!);
+
+    create.focus();
+    fireEvent.keyDown(create, { key: "ArrowDown" });
+
+    expect(alpha.getAttribute("tabindex")).toBe("0");
+    expect(document.activeElement).toBe(alpha);
+  });
+
+  it("wraps from the first option to the last on ArrowUp", () => {
+    render(<Harness recipes={recipes} initialFocusedIndex={0} />);
+    const alpha = optionButton(recipes[0]!);
+    const create = screen.getByRole("option", { name: /Create new recipe/ });
+
+    alpha.focus();
+    fireEvent.keyDown(alpha, { key: "ArrowUp" });
+
+    expect(create.getAttribute("tabindex")).toBe("0");
+    expect(document.activeElement).toBe(create);
+  });
+
+  it("Home jumps to the first option", () => {
+    render(<Harness recipes={recipes} initialFocusedIndex={2} />);
+    const gamma = optionButton(recipes[2]!);
+    const alpha = optionButton(recipes[0]!);
+
+    gamma!.focus();
+    fireEvent.keyDown(gamma!, { key: "Home" });
+
+    expect(alpha!.getAttribute("tabindex")).toBe("0");
+    expect(document.activeElement).toBe(alpha);
+  });
+
+  it("End jumps to the last option (the create button)", () => {
+    render(<Harness recipes={recipes} initialFocusedIndex={0} />);
+    const alpha = optionButton(recipes[0]!);
+    const create = screen.getByRole("option", { name: /Create new recipe/ });
+
+    alpha!.focus();
+    fireEvent.keyDown(alpha!, { key: "End" });
+
+    expect(create.getAttribute("tabindex")).toBe("0");
+    expect(document.activeElement).toBe(create);
+  });
+
+  it("does not intercept keys when a modifier is held", () => {
+    render(<Harness recipes={recipes} initialFocusedIndex={0} />);
+    const alpha = optionButton(recipes[0]!);
+
+    alpha!.focus();
+    fireEvent.keyDown(alpha!, { key: "ArrowDown", metaKey: true });
+
+    // Focus should not have moved; meta+arrow is left alone.
+    expect(alpha!.getAttribute("tabindex")).toBe("0");
+    expect(document.activeElement).toBe(alpha);
+  });
+});
+
+describe("RecipeRunnerGrid — focus sync", () => {
+  const recipes: TerminalRecipe[] = [
+    makeRecipe({ id: "alpha", name: "Alpha" }),
+    makeRecipe({ id: "beta", name: "Beta" }),
+    makeRecipe({ id: "gamma", name: "Gamma" }),
+  ];
+
+  it("moves the roving tabindex to the focused option on focus events", () => {
+    function StatefulHarness() {
+      const [focusedIndex, setFocusedIndex] = useState(0);
+      return (
+        <RecipeRunnerGrid
+          recipes={recipes}
+          focusedIndex={focusedIndex}
+          setFocusedIndex={setFocusedIndex}
+          onRun={noop}
+          onEdit={noop}
+          onDuplicate={noop}
+          onPin={noop}
+          onUnpin={noop}
+          onDelete={noop}
+          onCreate={noop}
+        />
+      );
+    }
+
+    render(<StatefulHarness />);
+
+    const beta = optionButton(recipes[1]!);
+    const gamma = optionButton(recipes[2]!);
+    fireEvent.focus(beta);
+
+    expect(beta.getAttribute("tabindex")).toBe("0");
+    expect(gamma.getAttribute("tabindex")).toBe("-1");
+  });
+});

--- a/src/components/Terminal/RecipeRunner/__tests__/RecipeRunnerGrid.test.tsx
+++ b/src/components/Terminal/RecipeRunner/__tests__/RecipeRunnerGrid.test.tsx
@@ -84,9 +84,8 @@ describe("RecipeRunnerGrid — roving tabindex", () => {
 });
 
 describe("RecipeRunnerGrid — focus-driven Enter runs the focused recipe", () => {
-  it("runs the focused recipe when Enter is pressed on its button, not index 0", () => {
+  it("does not call preventDefault on Enter so the button's native activation is preserved", () => {
     const onRun = vi.fn();
-    const onCreate = vi.fn();
     const recipes: TerminalRecipe[] = [
       makeRecipe({ id: "alpha", name: "Alpha" }),
       makeRecipe({ id: "beta", name: "Beta" }),
@@ -106,21 +105,65 @@ describe("RecipeRunnerGrid — focus-driven Enter runs the focused recipe", () =
           onPin={noop}
           onUnpin={noop}
           onDelete={noop}
-          onCreate={onCreate}
+          onCreate={noop}
         />
       );
     }
 
     render(<StatefulHarness />);
 
-    // Simulate the user Tab-focusing the third card (this is the bug scenario).
+    // The bug: an ancestor onKeyDown called e.preventDefault() on Enter and
+    // dispatched handleRun(flat[focusedIndex]). With the fix the per-option
+    // onKeyDown only intercepts navigation keys, so Enter falls through to
+    // the button's native click handler.
     const gamma = optionButton(recipes[2]!);
-    gamma.focus();
-    fireEvent.click(gamma);
-    expect(onRun).toHaveBeenCalledWith("gamma");
+    const event = new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true });
+    gamma.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
   });
 
-  it("fires onCreate when the create option is clicked after focus moves there", () => {
+  it("runs the focused recipe when Enter activates its button, not index 0", () => {
+    const onRun = vi.fn();
+    const recipes: TerminalRecipe[] = [
+      makeRecipe({ id: "alpha", name: "Alpha" }),
+      makeRecipe({ id: "beta", name: "Beta" }),
+      makeRecipe({ id: "gamma", name: "Gamma" }),
+    ];
+
+    function StatefulHarness() {
+      const [focusedIndex, setFocusedIndex] = useState(2);
+      return (
+        <RecipeRunnerGrid
+          recipes={recipes}
+          focusedIndex={focusedIndex}
+          setFocusedIndex={setFocusedIndex}
+          onRun={onRun}
+          onEdit={noop}
+          onDuplicate={noop}
+          onPin={noop}
+          onUnpin={noop}
+          onDelete={noop}
+          onCreate={noop}
+        />
+      );
+    }
+
+    render(<StatefulHarness />);
+
+    // Browsers dispatch a click after Enter on a focused button; jsdom doesn't
+    // so we simulate both halves of that chain. The regression guard is
+    // that keyDown(Enter) does not preventDefault (asserted above) and the
+    // click still calls onRun with the focused recipe's id, not index 0.
+    const gamma = optionButton(recipes[2]!);
+    fireEvent.keyDown(gamma, { key: "Enter" });
+    fireEvent.click(gamma);
+
+    expect(onRun).toHaveBeenCalledWith("gamma");
+    expect(onRun).not.toHaveBeenCalledWith("alpha");
+  });
+
+  it("runs the create action when Enter is pressed on the focused create option", () => {
     const onCreate = vi.fn();
     const recipes: TerminalRecipe[] = [
       makeRecipe({ id: "alpha", name: "Alpha" }),
@@ -148,9 +191,38 @@ describe("RecipeRunnerGrid — focus-driven Enter runs the focused recipe", () =
     render(<StatefulHarness />);
 
     const create = screen.getByRole("option", { name: /Create new recipe/ });
-    create.focus();
+    fireEvent.keyDown(create, { key: "Enter" });
     fireEvent.click(create);
+
     expect(onCreate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("RecipeRunnerGrid — disabled entry point", () => {
+  it("keeps the create option tabbable when all recipes are disabled", () => {
+    const recipes: TerminalRecipe[] = [
+      makeRecipe({ id: "alpha", name: "Alpha" }),
+      makeRecipe({ id: "beta", name: "Beta" }),
+    ];
+
+    render(
+      <RecipeRunnerGrid
+        recipes={recipes}
+        focusedIndex={0}
+        setFocusedIndex={() => {}}
+        onRun={noop}
+        onEdit={noop}
+        onDuplicate={noop}
+        onPin={noop}
+        onUnpin={noop}
+        onDelete={noop}
+        onCreate={noop}
+        disabled
+      />
+    );
+
+    const create = screen.getByRole("option", { name: /Create new recipe/ });
+    expect(create.getAttribute("tabindex")).toBe("0");
   });
 });
 

--- a/src/components/Terminal/RecipeRunner/__tests__/useRecipeRunner.test.tsx
+++ b/src/components/Terminal/RecipeRunner/__tests__/useRecipeRunner.test.tsx
@@ -923,3 +923,53 @@ describe("useRecipeRunner — delete confirm flow", () => {
     });
   });
 });
+
+describe("useRecipeRunner — keyboard model", () => {
+  it("starts with focusedIndex 0 and focusedItemId pointing at the first recipe", () => {
+    recipes.push(
+      makeRecipe({ id: "alpha", name: "Alpha" }),
+      makeRecipe({ id: "beta", name: "Beta" }),
+      makeRecipe({ id: "gamma", name: "Gamma" })
+    );
+
+    const { result } = renderHook(() =>
+      useRecipeRunner({ activeWorktreeId: "wt-1", defaultCwd: "/tmp" })
+    );
+
+    expect(result.current.focusedIndex).toBe(0);
+    expect(result.current.focusedItemId).toBe("recipe-option-alpha");
+  });
+
+  it("updates focusedItemId when setFocusedIndex is called", () => {
+    recipes.push(
+      makeRecipe({ id: "alpha", name: "Alpha" }),
+      makeRecipe({ id: "beta", name: "Beta" }),
+      makeRecipe({ id: "gamma", name: "Gamma" })
+    );
+
+    const { result } = renderHook(() =>
+      useRecipeRunner({ activeWorktreeId: "wt-1", defaultCwd: "/tmp" })
+    );
+
+    act(() => {
+      result.current.setFocusedIndex(2);
+    });
+
+    expect(result.current.focusedIndex).toBe(2);
+    expect(result.current.focusedItemId).toBe("recipe-option-gamma");
+  });
+
+  it("exposes the create option id when focusedIndex is at the trailing button", () => {
+    recipes.push(makeRecipe({ id: "alpha", name: "Alpha" }));
+
+    const { result } = renderHook(() =>
+      useRecipeRunner({ activeWorktreeId: "wt-1", defaultCwd: "/tmp" })
+    );
+
+    act(() => {
+      result.current.setFocusedIndex(1);
+    });
+
+    expect(result.current.focusedItemId).toBe("recipe-option-create");
+  });
+});


### PR DESCRIPTION
## Summary

- The recipe runner grid had two focus models that weren't kept in sync: `Tab` moved native DOM focus to a button, but `Enter` still ran whatever was at the arrow-driven `focusedIndex`. Tabbing to a recipe and hitting Enter would launch the first one.
- Aligns the grid with the List mode keyboard model. Visual selection, DOM focus, and the recipe `Enter` runs now all point at the same item, with `aria-activedescendant` wired to the focused button.
- Keeps the create option tabbable when no recipes exist, so keyboard users can always reach it.

Resolves #9962

## Changes

- `src/components/Terminal/RecipeRunner/RecipeRunnerGrid.tsx` — switch to a roving `aria-activedescendant` listbox; arrow keys move real focus; `Enter` and `Space` activate the focused recipe; `Tab` reaches the create option.
- `src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx` — render the option id so the grid can reference it via `aria-activedescendant`.
- `src/components/Terminal/RecipeRunner/RecipeRunner.tsx` — pass the option id through to the grid.
- `src/components/Terminal/RecipeRunner/__tests__/RecipeRunnerGrid.test.tsx` — covers Tab-then-Enter, arrow navigation, and the create-only scenario.
- `src/components/Terminal/RecipeRunner/__tests__/useRecipeRunner.test.tsx` — covers the hook changes.

## Testing

- `npm run typecheck` passes.
- `npm run lint` and `prettier --check` clean on the changed files.
- New unit tests cover the Tab/Enter mismatch, arrow-driven focus movement, and the create-only flow.