### PR TITLE
fix(terminal): apply appearance changes in-place instead of reattaching

### DIFF
--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -530,7 +530,10 @@ export function XtermAdapter({
   // forwarded — a theme hover must not refit every mounted terminal, and an
   // unchanged scrollback write must not touch xterm's CircularList. The
   // applied-vs-current check also makes this a no-op on the commits where the
-  // attach effect already passed current options to getOrCreate.
+  // attach effect already passed current options to getOrCreate. The five
+  // diffed keys are the only runtime-variable outputs of getXtermOptions —
+  // everything else is a static BASE_TERMINAL_OPTIONS constant; extend the
+  // diff if a new option ever becomes user-configurable.
   useLayoutEffect(() => {
     const applied = appliedOptionsRef.current;
     appliedOptionsRef.current = terminalOptions;

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useLayoutEffect, useMemo, useRef, useEffect, useState } from "react";
+import type { ITerminalOptions } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { cn } from "@/lib/utils";
 import { TerminalRefreshTier } from "@/types";
@@ -157,6 +158,18 @@ export function XtermAdapter({
     ]
   );
 
+  // Appearance changes must not re-run the attach effect — detaching and
+  // reattaching every mounted terminal made theme-picker hover previews
+  // heavyweight and silently blurred the focused terminal (#9929). The attach
+  // effect reads the latest options through this ref instead of closing over
+  // `terminalOptions`; `appliedOptionsRef` records what the terminal actually
+  // received so the options effect below only forwards real deltas.
+  const terminalOptionsRef = useRef(terminalOptions);
+  const appliedOptionsRef = useRef<ITerminalOptions | null>(null);
+  useLayoutEffect(() => {
+    terminalOptionsRef.current = terminalOptions;
+  }, [terminalOptions]);
+
   // Push-based resize handler using ResizeObserver dimensions directly
   const handleResizeEntry = useCallback(
     (entry: ResizeObserverEntry) => {
@@ -235,11 +248,15 @@ export function XtermAdapter({
     const managed = terminalInstanceService.getOrCreate(
       terminalId,
       launchAgentId,
-      terminalOptions,
+      terminalOptionsRef.current,
       stableRefreshTierProvider,
       stableOnInput,
       stableCwdProvider
     );
+    // getOrCreate applies the current options itself (creation or its internal
+    // updateOptions call for existing instances) — record them so the options
+    // effect doesn't re-apply the same values on this commit.
+    appliedOptionsRef.current = terminalOptionsRef.current;
 
     const wasDetachedForSwitch = managed.isDetached === true;
     const hasSavedTargetDims = !!(managed.targetCols && managed.targetRows);
@@ -499,7 +516,6 @@ export function XtermAdapter({
   }, [
     terminalId,
     launchAgentId,
-    terminalOptions,
     performFit,
     stableRefreshTierProvider,
     stableOnInput,
@@ -507,6 +523,35 @@ export function XtermAdapter({
     restoreOnAttach,
     hasVisibleBufferContent,
   ]);
+
+  // Apply appearance changes in-place. updateOptions keys on presence
+  // ("theme" in options → full-row refresh; any text-metric key → refit and
+  // dimension-cache reset), so only the keys that actually changed are
+  // forwarded — a theme hover must not refit every mounted terminal, and an
+  // unchanged scrollback write must not touch xterm's CircularList. The
+  // applied-vs-current check also makes this a no-op on the commits where the
+  // attach effect already passed current options to getOrCreate.
+  useLayoutEffect(() => {
+    const applied = appliedOptionsRef.current;
+    appliedOptionsRef.current = terminalOptions;
+    if (!applied || applied === terminalOptions) return;
+
+    const delta: Partial<ITerminalOptions> = {};
+    if (applied.theme !== terminalOptions.theme) delta.theme = terminalOptions.theme;
+    if (applied.fontSize !== terminalOptions.fontSize) delta.fontSize = terminalOptions.fontSize;
+    if (applied.fontFamily !== terminalOptions.fontFamily) {
+      delta.fontFamily = terminalOptions.fontFamily;
+    }
+    if (applied.screenReaderMode !== terminalOptions.screenReaderMode) {
+      delta.screenReaderMode = terminalOptions.screenReaderMode;
+    }
+    if (applied.scrollback !== terminalOptions.scrollback) {
+      delta.scrollback = terminalOptions.scrollback;
+    }
+    if (Object.keys(delta).length === 0) return;
+
+    terminalInstanceService.updateOptions(terminalId, delta);
+  }, [terminalId, terminalOptions]);
 
   useLayoutEffect(() => {
     terminalInstanceService.setInputLocked(terminalId, !!isInputLocked);

--- a/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
+++ b/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
@@ -12,6 +12,17 @@ const mocks = vi.hoisted(() => {
   let keyHandler: ((event: KeyboardEvent) => boolean) | null = null;
   let exitHandler: ((exitCode: number) => void) | null = null;
 
+  const defaultAppearance = {
+    fontSize: 14,
+    fontFamily: "JetBrains Mono",
+    performanceMode: false,
+    scrollbackLines: 1_000,
+    projectScrollback: undefined as number | undefined,
+    wrapperBackground: "rgb(0, 0, 0)",
+    screenReaderMode: false,
+  };
+  const appearance = { ...defaultAppearance, effectiveTheme: {} as object };
+
   const managed = {
     terminal: {
       rows: 24,
@@ -51,6 +62,7 @@ const mocks = vi.hoisted(() => {
     get: vi.fn(() => managed),
     flushResize: vi.fn(),
     detach: vi.fn(),
+    updateOptions: vi.fn(),
     updateRefreshTierProvider: vi.fn(),
     applyRendererPolicy: vi.fn(),
     boostRefreshRate: vi.fn(),
@@ -61,7 +73,7 @@ const mocks = vi.hoisted(() => {
   };
 
   return {
-    effectiveTheme: {},
+    appearance,
     managed,
     terminalInstanceService,
     writeTerminalInputOrFleet: vi.fn(),
@@ -74,6 +86,7 @@ const mocks = vi.hoisted(() => {
       managed.isInputLocked = false;
       managed.isAttaching = false;
       (managed as { keyHandlerInstalled?: boolean }).keyHandlerInstalled = false;
+      Object.assign(appearance, defaultAppearance, { effectiveTheme: {} });
     },
   };
 });
@@ -91,20 +104,28 @@ vi.mock("../useTerminalFileTransfer", () => ({
 }));
 
 vi.mock("@/hooks/useTerminalAppearance", () => ({
-  useTerminalAppearance: () => ({
-    fontSize: 14,
-    fontFamily: "JetBrains Mono",
-    performanceMode: false,
-    scrollbackLines: 1_000,
-    projectScrollback: undefined,
-    effectiveTheme: mocks.effectiveTheme,
-    wrapperBackground: "rgb(0, 0, 0)",
-    screenReaderMode: false,
-  }),
+  // Reads the mutable appearance object so tests can change appearance values
+  // between rerenders (#9929 regression coverage).
+  useTerminalAppearance: () => ({ ...mocks.appearance }),
 }));
 
 vi.mock("@/config/xtermConfig", () => ({
-  getXtermOptions: vi.fn(() => ({ cursorBlink: true })),
+  getXtermOptions: vi.fn(
+    (config: {
+      fontSize: number;
+      fontFamily: string;
+      scrollback: number;
+      theme?: object;
+      screenReaderMode?: boolean;
+    }) => ({
+      cursorBlink: true,
+      fontSize: config.fontSize,
+      fontFamily: config.fontFamily,
+      theme: config.theme,
+      scrollback: config.scrollback,
+      screenReaderMode: config.screenReaderMode ?? false,
+    })
+  ),
 }));
 
 vi.mock("@/config/terminalFont", () => ({
@@ -449,6 +470,83 @@ describe("XtermAdapter lifecycle", () => {
         TerminalRefreshTier.VISIBLE
       )
     );
+    expect(mocks.terminalInstanceService.attach).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies theme changes in-place without detaching or reattaching (#9929)", async () => {
+    const view = renderAdapter();
+
+    await waitFor(() => expect(mocks.terminalInstanceService.attach).toHaveBeenCalledTimes(1));
+    // Mount applies options through getOrCreate — no redundant updateOptions call.
+    expect(mocks.terminalInstanceService.updateOptions).not.toHaveBeenCalled();
+
+    const newTheme = { background: "#ff0000" };
+    mocks.appearance.effectiveTheme = newTheme;
+
+    view.rerender(
+      <Suspense fallback={null}>
+        <XtermAdapter
+          terminalId="term-1"
+          launchAgentId="claude"
+          onReady={vi.fn()}
+          onExit={vi.fn()}
+          onInput={vi.fn()}
+          getRefreshTier={() => TerminalRefreshTier.FOCUSED}
+          cwd="/repo/initial"
+        />
+      </Suspense>
+    );
+
+    // Theme-only change forwards exactly the theme key — including unchanged
+    // fontSize/fontFamily would trigger a refit of every mounted terminal.
+    await waitFor(() =>
+      expect(mocks.terminalInstanceService.updateOptions).toHaveBeenCalledWith("term-1", {
+        theme: newTheme,
+      })
+    );
+    expect(mocks.terminalInstanceService.updateOptions).toHaveBeenCalledTimes(1);
+
+    // The attach lifecycle must not re-run: no detach (which blurs the focused
+    // terminal), no re-attach, no visibility flicker, no instance re-creation.
+    expect(mocks.terminalInstanceService.detach).not.toHaveBeenCalled();
+    expect(mocks.terminalInstanceService.attach).toHaveBeenCalledTimes(1);
+    expect(mocks.terminalInstanceService.getOrCreate).toHaveBeenCalledTimes(1);
+    expect(
+      mocks.terminalInstanceService.setVisible.mock.calls.some(([, visible]) => visible === false)
+    ).toBe(false);
+
+    // Real unmount still tears down through detach exactly once.
+    view.unmount();
+    expect(mocks.terminalInstanceService.detach).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies font size changes via updateOptions without an attach cycle (#9929)", async () => {
+    const view = renderAdapter();
+
+    await waitFor(() => expect(mocks.terminalInstanceService.attach).toHaveBeenCalledTimes(1));
+
+    mocks.appearance.fontSize = 16;
+
+    view.rerender(
+      <Suspense fallback={null}>
+        <XtermAdapter
+          terminalId="term-1"
+          launchAgentId="claude"
+          onReady={vi.fn()}
+          onExit={vi.fn()}
+          onInput={vi.fn()}
+          getRefreshTier={() => TerminalRefreshTier.FOCUSED}
+          cwd="/repo/initial"
+        />
+      </Suspense>
+    );
+
+    await waitFor(() =>
+      expect(mocks.terminalInstanceService.updateOptions).toHaveBeenCalledWith("term-1", {
+        fontSize: 16,
+      })
+    );
+    expect(mocks.terminalInstanceService.detach).not.toHaveBeenCalled();
     expect(mocks.terminalInstanceService.attach).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
+++ b/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
@@ -477,7 +477,11 @@ describe("XtermAdapter lifecycle", () => {
     const view = renderAdapter();
 
     await waitFor(() => expect(mocks.terminalInstanceService.attach).toHaveBeenCalledTimes(1));
-    // Mount applies options through getOrCreate — no redundant updateOptions call.
+    // Mount applies options through getOrCreate — no redundant updateOptions
+    // call. (The real getOrCreate routes existing instances through
+    // updateOptions internally; the adapter records what it passed to
+    // getOrCreate as applied, which is what keeps this assertion valid with
+    // the simplified mock.)
     expect(mocks.terminalInstanceService.updateOptions).not.toHaveBeenCalled();
 
     const newTheme = { background: "#ff0000" };
@@ -548,5 +552,62 @@ describe("XtermAdapter lifecycle", () => {
     );
     expect(mocks.terminalInstanceService.detach).not.toHaveBeenCalled();
     expect(mocks.terminalInstanceService.attach).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call updateOptions when appearance is unchanged across rerenders (#9929)", async () => {
+    const view = renderAdapter();
+
+    await waitFor(() => expect(mocks.terminalInstanceService.attach).toHaveBeenCalledTimes(1));
+
+    view.rerender(
+      <Suspense fallback={null}>
+        <XtermAdapter
+          terminalId="term-1"
+          launchAgentId="claude"
+          onReady={vi.fn()}
+          onExit={vi.fn()}
+          onInput={vi.fn()}
+          getRefreshTier={() => TerminalRefreshTier.FOCUSED}
+          cwd="/repo/next"
+        />
+      </Suspense>
+    );
+
+    expect(mocks.terminalInstanceService.updateOptions).not.toHaveBeenCalled();
+    expect(mocks.terminalInstanceService.detach).not.toHaveBeenCalled();
+    expect(mocks.terminalInstanceService.getOrCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("batches simultaneous appearance changes into a single delta call (#9929)", async () => {
+    const view = renderAdapter();
+
+    await waitFor(() => expect(mocks.terminalInstanceService.attach).toHaveBeenCalledTimes(1));
+
+    const newTheme = { background: "#00ff00" };
+    mocks.appearance.effectiveTheme = newTheme;
+    mocks.appearance.fontSize = 18;
+
+    view.rerender(
+      <Suspense fallback={null}>
+        <XtermAdapter
+          terminalId="term-1"
+          launchAgentId="claude"
+          onReady={vi.fn()}
+          onExit={vi.fn()}
+          onInput={vi.fn()}
+          getRefreshTier={() => TerminalRefreshTier.FOCUSED}
+          cwd="/repo/initial"
+        />
+      </Suspense>
+    );
+
+    await waitFor(() =>
+      expect(mocks.terminalInstanceService.updateOptions).toHaveBeenCalledWith("term-1", {
+        theme: newTheme,
+        fontSize: 18,
+      })
+    );
+    expect(mocks.terminalInstanceService.updateOptions).toHaveBeenCalledTimes(1);
+    expect(mocks.terminalInstanceService.detach).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- `XtermAdapter`'s attach `useLayoutEffect` had `terminalOptions` in its dependency array, so any appearance change (theme hover, font size, scrollback, screen-reader toggle) tore down and re-ran the full attach lifecycle for every mounted terminal — including `detach()`'s unconditional `terminal.blur()`, which silently stole keyboard focus
- Fix removes `terminalOptions` from the attach effect's deps and reads the latest options via a `terminalOptionsRef` instead; a new separate options `useLayoutEffect` diffs current vs last-applied options and forwards only changed keys through `terminalInstanceService.updateOptions`, which already handles refit/refresh/cursor-blink policy in-place
- Delta-only forwarding matters because `updateOptions` keys on presence — passing unchanged text-metric keys on a theme hover would trigger a refit on every terminal, and a mount-time full-options call would break the saved-dims reattach contract; an applied-options handshake (attach effect records what `getOrCreate` received) makes the options effect a no-op on attach commits

Resolves #9929

## Changes

- `src/components/Terminal/XtermAdapter.tsx` — split the monolithic attach effect: attach/detach keyed on terminal ID and stable callbacks only; separate options effect diffs and forwards deltas via `updateOptions`
- `src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx` — regression suite covering theme-only change (single delta call, no detach/attach/getOrCreate churn, no visibility flicker), fontSize change (delta call only), unchanged appearance re-render (no `updateOptions`), and combined theme + fontSize (single batched delta call)

## Testing

9/9 unit tests pass in `XtermAdapter.lifecycle.test.tsx`. Typecheck, lint, and format all clean.