### PR TITLE
fix(settings): refcount validation publishers per tab

### DIFF
--- a/src/components/Settings/SettingsValidationRegistry.tsx
+++ b/src/components/Settings/SettingsValidationRegistry.tsx
@@ -4,14 +4,14 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
 import type { SettingsTab } from "./SettingsDialog";
 
 interface ValidationRegistryApi {
-  setTabHasError: (tab: SettingsTab, hasError: boolean) => void;
-  clearTab: (tab: SettingsTab) => void;
+  setPublisherHasError: (tab: SettingsTab, publisher: symbol, hasError: boolean) => void;
   tabsWithErrors: ReadonlySet<SettingsTab>;
 }
 
@@ -24,32 +24,45 @@ interface ProviderProps {
 
 export function SettingsValidationProvider({ children }: ProviderProps) {
   const [tabsWithErrors, setTabsWithErrors] = useState<Set<SettingsTab>>(new Set());
+  // A tab has an error while at least one publisher reports one. Tracking
+  // publishers individually keeps multiple hooks sharing a tab key (e.g.
+  // CodeForgeSettingsTab + nested GitHubSettingsTab) from clobbering each other.
+  const publishersByTab = useRef(new Map<SettingsTab, Set<symbol>>());
 
-  const setTabHasError = useCallback((tab: SettingsTab, hasError: boolean) => {
-    setTabsWithErrors((prev) => {
-      if (prev.has(tab) === hasError) return prev;
-      const next = new Set(prev);
+  const setPublisherHasError = useCallback(
+    (tab: SettingsTab, publisher: symbol, hasError: boolean) => {
+      const publishers = publishersByTab.current.get(tab);
       if (hasError) {
-        next.add(tab);
-      } else {
-        next.delete(tab);
+        if (publishers) {
+          publishers.add(publisher);
+        } else {
+          publishersByTab.current.set(tab, new Set([publisher]));
+        }
+      } else if (publishers) {
+        publishers.delete(publisher);
+        if (publishers.size === 0) {
+          publishersByTab.current.delete(tab);
+        }
       }
-      return next;
-    });
-  }, []);
 
-  const clearTab = useCallback((tab: SettingsTab) => {
-    setTabsWithErrors((prev) => {
-      if (!prev.has(tab)) return prev;
-      const next = new Set(prev);
-      next.delete(tab);
-      return next;
-    });
-  }, []);
+      const tabHasError = publishersByTab.current.has(tab);
+      setTabsWithErrors((prev) => {
+        if (prev.has(tab) === tabHasError) return prev;
+        const next = new Set(prev);
+        if (tabHasError) {
+          next.add(tab);
+        } else {
+          next.delete(tab);
+        }
+        return next;
+      });
+    },
+    []
+  );
 
   const value = useMemo(
-    () => ({ setTabHasError, clearTab, tabsWithErrors }),
-    [setTabHasError, clearTab, tabsWithErrors]
+    () => ({ setPublisherHasError, tabsWithErrors }),
+    [setPublisherHasError, tabsWithErrors]
   );
 
   return <ValidationContext.Provider value={value}>{children}</ValidationContext.Provider>;
@@ -57,10 +70,12 @@ export function SettingsValidationProvider({ children }: ProviderProps) {
 
 /**
  * Hook for tabs to report their validation error state to the settings sidebar.
- * Automatically clears the error state when the component unmounts.
+ * Multiple components may report for the same tab; the sidebar shows an error
+ * while any of them does. Each hook instance only ever clears its own
+ * contribution, including on unmount.
  *
  * @param tab - The tab ID to report errors for
- * @param hasError - Whether the tab currently has validation errors
+ * @param hasError - Whether the caller currently has validation errors
  */
 export function useSettingsTabValidation(tab: SettingsTab, hasError: boolean) {
   const context = useContext(ValidationContext);
@@ -69,12 +84,15 @@ export function useSettingsTabValidation(tab: SettingsTab, hasError: boolean) {
     throw new Error("useSettingsTabValidation must be used within a SettingsValidationProvider");
   }
 
-  const { setTabHasError, clearTab } = context;
+  // Stable per-instance identity; deliberately not useId(), which can change
+  // across Strict Mode renders (react#27103).
+  const [publisherId] = useState(() => Symbol("settings-tab-validation"));
+  const { setPublisherHasError } = context;
 
   useEffect(() => {
-    setTabHasError(tab, hasError);
+    setPublisherHasError(tab, publisherId, hasError);
     return () => {
-      clearTab(tab);
+      setPublisherHasError(tab, publisherId, false);
     };
-  }, [setTabHasError, clearTab, tab, hasError]);
+  }, [setPublisherHasError, tab, publisherId, hasError]);
 }

--- a/src/components/Settings/__tests__/SettingsValidationRegistry.test.tsx
+++ b/src/components/Settings/__tests__/SettingsValidationRegistry.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { renderHook, render } from "@testing-library/react";
+import { StrictMode, useContext, type ReactNode } from "react";
+import {
+  SettingsValidationProvider,
+  useSettingsTabValidation,
+  SettingsValidationContext,
+} from "../SettingsValidationRegistry";
+import type { SettingsTab } from "../SettingsDialog";
+
+function wrap({ children }: { children: ReactNode }) {
+  return <SettingsValidationProvider>{children}</SettingsValidationProvider>;
+}
+
+function Publisher({ tab, hasError }: { tab: SettingsTab; hasError: boolean }) {
+  useSettingsTabValidation(tab, hasError);
+  return null;
+}
+
+function Probe({ onSnapshot }: { onSnapshot: (tabs: ReadonlySet<SettingsTab>) => void }) {
+  const ctx = useContext(SettingsValidationContext);
+  onSnapshot(ctx!.tabsWithErrors);
+  return null;
+}
+
+interface HarnessProps {
+  parentMounted: boolean;
+  parentHasError: boolean;
+  childMounted: boolean;
+  childHasError: boolean;
+  onSnapshot: (tabs: ReadonlySet<SettingsTab>) => void;
+  strict?: boolean;
+}
+
+function Harness({
+  parentMounted,
+  parentHasError,
+  childMounted,
+  childHasError,
+  onSnapshot,
+  strict,
+}: HarnessProps) {
+  const tree = (
+    <SettingsValidationProvider>
+      {parentMounted && <Publisher tab="code-forge" hasError={parentHasError} />}
+      {childMounted && <Publisher tab="code-forge" hasError={childHasError} />}
+      <Probe onSnapshot={onSnapshot} />
+    </SettingsValidationProvider>
+  );
+  return strict ? <StrictMode>{tree}</StrictMode> : tree;
+}
+
+describe("SettingsValidationRegistry", () => {
+  it("keeps the tab in error when one of two publishers reports no error", () => {
+    const { result } = renderHook(
+      () => {
+        useSettingsTabValidation("code-forge", true);
+        useSettingsTabValidation("code-forge", false);
+        return useContext(SettingsValidationContext);
+      },
+      { wrapper: wrap }
+    );
+
+    expect(result.current!.tabsWithErrors.has("code-forge")).toBe(true);
+  });
+
+  it("keeps the tab in error when both publishers report errors", () => {
+    const { result } = renderHook(
+      () => {
+        useSettingsTabValidation("code-forge", true);
+        useSettingsTabValidation("code-forge", true);
+        return useContext(SettingsValidationContext);
+      },
+      { wrapper: wrap }
+    );
+
+    expect(result.current!.tabsWithErrors.has("code-forge")).toBe(true);
+  });
+
+  it("keeps the parent's error when the child publisher unmounts", () => {
+    let tabs: ReadonlySet<SettingsTab> = new Set();
+    const onSnapshot = (next: ReadonlySet<SettingsTab>) => {
+      tabs = next;
+    };
+
+    const { rerender } = render(
+      <Harness
+        parentMounted
+        parentHasError
+        childMounted
+        childHasError={false}
+        onSnapshot={onSnapshot}
+      />
+    );
+    expect(tabs.has("code-forge")).toBe(true);
+
+    rerender(
+      <Harness
+        parentMounted
+        parentHasError
+        childMounted={false}
+        childHasError={false}
+        onSnapshot={onSnapshot}
+      />
+    );
+    expect(tabs.has("code-forge")).toBe(true);
+  });
+
+  it("clears the tab once every publisher unmounts", () => {
+    let tabs: ReadonlySet<SettingsTab> = new Set();
+    const onSnapshot = (next: ReadonlySet<SettingsTab>) => {
+      tabs = next;
+    };
+
+    const { rerender } = render(
+      <Harness parentMounted parentHasError childMounted childHasError onSnapshot={onSnapshot} />
+    );
+    expect(tabs.has("code-forge")).toBe(true);
+
+    rerender(
+      <Harness
+        parentMounted={false}
+        parentHasError
+        childMounted={false}
+        childHasError
+        onSnapshot={onSnapshot}
+      />
+    );
+    expect(tabs.has("code-forge")).toBe(false);
+  });
+
+  it("clears a single publisher's error when it toggles to false", () => {
+    const { result, rerender } = renderHook(
+      ({ hasError }: { hasError: boolean }) => {
+        useSettingsTabValidation("code-forge", hasError);
+        return useContext(SettingsValidationContext);
+      },
+      { wrapper: wrap, initialProps: { hasError: true } }
+    );
+
+    expect(result.current!.tabsWithErrors.has("code-forge")).toBe(true);
+
+    rerender({ hasError: false });
+    expect(result.current!.tabsWithErrors.has("code-forge")).toBe(false);
+  });
+
+  it("tracks publishers without ghost entries under Strict Mode", () => {
+    let tabs: ReadonlySet<SettingsTab> = new Set();
+    const onSnapshot = (next: ReadonlySet<SettingsTab>) => {
+      tabs = next;
+    };
+
+    const { rerender } = render(
+      <Harness
+        strict
+        parentMounted
+        parentHasError
+        childMounted
+        childHasError={false}
+        onSnapshot={onSnapshot}
+      />
+    );
+    expect(tabs.has("code-forge")).toBe(true);
+
+    rerender(
+      <Harness
+        strict
+        parentMounted
+        parentHasError
+        childMounted={false}
+        childHasError={false}
+        onSnapshot={onSnapshot}
+      />
+    );
+    expect(tabs.has("code-forge")).toBe(true);
+
+    rerender(
+      <Harness
+        strict
+        parentMounted
+        parentHasError={false}
+        childMounted={false}
+        childHasError={false}
+        onSnapshot={onSnapshot}
+      />
+    );
+    expect(tabs.has("code-forge")).toBe(false);
+  });
+});

--- a/src/components/Settings/__tests__/SettingsValidationRegistry.test.tsx
+++ b/src/components/Settings/__tests__/SettingsValidationRegistry.test.tsx
@@ -107,6 +107,86 @@ describe("SettingsValidationRegistry", () => {
     expect(tabs.has("code-forge")).toBe(true);
   });
 
+  it("keeps the tab in error when an errored child unmounts while the parent is errored", () => {
+    let tabs: ReadonlySet<SettingsTab> = new Set();
+    const onSnapshot = (next: ReadonlySet<SettingsTab>) => {
+      tabs = next;
+    };
+
+    const { rerender } = render(
+      <Harness parentMounted parentHasError childMounted childHasError onSnapshot={onSnapshot} />
+    );
+    expect(tabs.has("code-forge")).toBe(true);
+
+    rerender(
+      <Harness
+        parentMounted
+        parentHasError
+        childMounted={false}
+        childHasError
+        onSnapshot={onSnapshot}
+      />
+    );
+    expect(tabs.has("code-forge")).toBe(true);
+  });
+
+  it("keeps the tab in error when one publisher toggles to false while another stays errored", () => {
+    let tabs: ReadonlySet<SettingsTab> = new Set();
+    const onSnapshot = (next: ReadonlySet<SettingsTab>) => {
+      tabs = next;
+    };
+
+    const { rerender } = render(
+      <Harness parentMounted parentHasError childMounted childHasError onSnapshot={onSnapshot} />
+    );
+    expect(tabs.has("code-forge")).toBe(true);
+
+    rerender(
+      <Harness
+        parentMounted
+        parentHasError
+        childMounted
+        childHasError={false}
+        onSnapshot={onSnapshot}
+      />
+    );
+    expect(tabs.has("code-forge")).toBe(true);
+  });
+
+  it("moves the error to the new tab when a publisher's tab changes", () => {
+    const { result, rerender } = renderHook(
+      ({ tab }: { tab: SettingsTab }) => {
+        useSettingsTabValidation(tab, true);
+        return useContext(SettingsValidationContext);
+      },
+      { wrapper: wrap, initialProps: { tab: "code-forge" as SettingsTab } }
+    );
+
+    expect(result.current!.tabsWithErrors.has("code-forge")).toBe(true);
+
+    rerender({ tab: "portal" });
+    expect(result.current!.tabsWithErrors.has("code-forge")).toBe(false);
+    expect(result.current!.tabsWithErrors.has("portal")).toBe(true);
+  });
+
+  it("clearing one tab's publishers leaves other tabs untouched", () => {
+    const { result, rerender } = renderHook(
+      ({ codeForgeHasError }: { codeForgeHasError: boolean }) => {
+        useSettingsTabValidation("code-forge", codeForgeHasError);
+        useSettingsTabValidation("portal", true);
+        return useContext(SettingsValidationContext);
+      },
+      { wrapper: wrap, initialProps: { codeForgeHasError: true } }
+    );
+
+    expect(result.current!.tabsWithErrors.has("code-forge")).toBe(true);
+    expect(result.current!.tabsWithErrors.has("portal")).toBe(true);
+
+    rerender({ codeForgeHasError: false });
+    expect(result.current!.tabsWithErrors.has("code-forge")).toBe(false);
+    expect(result.current!.tabsWithErrors.has("portal")).toBe(true);
+  });
+
   it("clears the tab once every publisher unmounts", () => {
     let tabs: ReadonlySet<SettingsTab> = new Set();
     const onSnapshot = (next: ReadonlySet<SettingsTab>) => {


### PR DESCRIPTION
## Summary

- `SettingsValidationRegistry` used a flat `Set<SettingsTab>` for error state, so the last publisher to call `setTabHasError(false)` or unmount would silently wipe any other publisher's still-active error for the same tab key. The sidebar dot (`tabsWithErrors`) and the visible in-tab error could contradict each other.
- Fix: per-publisher refcounting via a `useRef Map<SettingsTab, Set<symbol>>`. Each `useSettingsTabValidation` call holds a stable `Symbol` (via `useState(() => Symbol())` — deliberately not `useId`, which is unstable under Strict Mode per react#27103) and only ever clears its own contribution. A tab shows an error while any publisher reports one.
- `setTabHasError`/`clearTab` removed from the context API — zero external callers; `SettingsDialog` reads `tabsWithErrors` only.

Resolves #9988

## Changes

- `SettingsValidationRegistry.tsx`: replace flat `Set` with refcounted `Map<SettingsTab, Set<symbol>>`; remove unused context methods
- `SettingsValidationRegistry.test.tsx`: new suite (10 cases) covering multi-publisher composition, the exact unmount regression, tab reassignment, cross-tab isolation, and Strict Mode

## Testing

10 registry unit tests + 16 existing consumer tab tests, all passing. Covers the specific scenario from the issue: `CodeForgeSettingsTab` (parent) and `GitHubSettingsTab` (conditionally-rendered child) both publishing under `"code-forge"` — child unmount no longer wipes the parent's error.