### PR TITLE
fix(state): serialize concurrent per-project state writes

### DIFF
--- a/electron/ipc/__tests__/app.state.test.ts
+++ b/electron/ipc/__tests__/app.state.test.ts
@@ -55,6 +55,7 @@ vi.mock("../../services/ProjectStore.js", () => ({
     getProjectById: vi.fn(() => null),
     getProjectStateWithRecovery: vi.fn(),
     saveProjectState: vi.fn(),
+    enqueueProjectStateUpdate: vi.fn(async () => undefined),
   },
 }));
 

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -139,11 +139,11 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
           focusPanelStateToUse = globalAppState.focusPanelState;
 
           // Save the migrated focus mode to per-project state
-          await projectStore.saveProjectState(projectId, {
-            ...projectState,
+          await projectStore.enqueueProjectStateUpdate(projectId, (existing) => ({
+            ...(existing ?? projectState),
             focusMode: focusModeToUse,
             focusPanelState: focusPanelStateToUse,
-          });
+          }));
 
           console.log(
             `[AppHydrate] Migrated focusMode (${focusModeToUse}) to per-project state for ${currentProject?.name}`
@@ -184,14 +184,14 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
             : undefined;
 
           // Include focus mode in migration
-          await projectStore.saveProjectState(projectId, {
+          await projectStore.enqueueProjectStateUpdate(projectId, () => ({
             projectId,
             activeWorktreeId: globalAppState.activeWorktreeId,
             sidebarWidth: globalAppState.sidebarWidth ?? 350,
             terminals: migratedTerminals,
             focusMode: globalAppState.focusMode,
             focusPanelState: normalizedFocusPanelState,
-          });
+          }));
 
           console.log(
             `[AppHydrate] Migrated ${migratedTerminals.length} terminals and focusMode to per-project state`
@@ -212,14 +212,14 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
             : undefined;
 
           // No terminals to migrate but still save empty state to mark migration complete
-          await projectStore.saveProjectState(projectId, {
+          await projectStore.enqueueProjectStateUpdate(projectId, () => ({
             projectId,
             activeWorktreeId: globalAppState.activeWorktreeId,
             sidebarWidth: globalAppState.sidebarWidth ?? 350,
             terminals: [],
             focusMode: globalAppState.focusMode,
             focusPanelState: normalizedFocusPanelState,
-          });
+          }));
         }
       } else {
         // Normalize legacy focusPanelState
@@ -237,14 +237,18 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
           : undefined;
 
         // No per-project state and no global terminals - create fresh state with focus mode migration
-        await projectStore.saveProjectState(projectId, {
+        await projectStore.enqueueProjectStateUpdate(
           projectId,
-          activeWorktreeId: globalAppState.activeWorktreeId,
-          sidebarWidth: globalAppState.sidebarWidth ?? 350,
-          terminals: [],
-          focusMode: globalAppState.focusMode,
-          focusPanelState: normalizedFocusPanelState,
-        });
+          (existing) =>
+            existing ?? {
+              projectId,
+              activeWorktreeId: globalAppState.activeWorktreeId,
+              sidebarWidth: globalAppState.sidebarWidth ?? 350,
+              terminals: [],
+              focusMode: globalAppState.focusMode,
+              focusPanelState: normalizedFocusPanelState,
+            }
+        );
       }
     } else {
       // No project - use global terminals (legacy/fallback)

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -184,7 +184,8 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
             : undefined;
 
           // Include focus mode in migration
-          await projectStore.enqueueProjectStateUpdate(projectId, () => ({
+          await projectStore.enqueueProjectStateUpdate(projectId, (existing) => ({
+            ...(existing ?? {}),
             projectId,
             activeWorktreeId: globalAppState.activeWorktreeId,
             sidebarWidth: globalAppState.sidebarWidth ?? 350,
@@ -212,11 +213,12 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
             : undefined;
 
           // No terminals to migrate but still save empty state to mark migration complete
-          await projectStore.enqueueProjectStateUpdate(projectId, () => ({
+          await projectStore.enqueueProjectStateUpdate(projectId, (existing) => ({
+            ...(existing ?? {}),
             projectId,
             activeWorktreeId: globalAppState.activeWorktreeId,
             sidebarWidth: globalAppState.sidebarWidth ?? 350,
-            terminals: [],
+            terminals: existing?.terminals ?? [],
             focusMode: globalAppState.focusMode,
             focusPanelState: normalizedFocusPanelState,
           }));

--- a/electron/ipc/handlers/terminalLayout.ts
+++ b/electron/ipc/handlers/terminalLayout.ts
@@ -95,8 +95,7 @@ export const terminalLayoutNamespace = defineIpcNamespace({
 
         const validTerminals = sanitizeTerminals(terminals, `project:set-terminals(${projectId})`);
 
-        const existingState = await projectStore.getProjectState(projectId);
-        const newState = {
+        await projectStore.enqueueProjectStateUpdate(projectId, (existingState) => ({
           projectId,
           activeWorktreeId: existingState?.activeWorktreeId,
           sidebarWidth: existingState?.sidebarWidth ?? 350,
@@ -107,9 +106,7 @@ export const terminalLayoutNamespace = defineIpcNamespace({
           focusPanelState: existingState?.focusPanelState,
           terminalSizes: existingState?.terminalSizes,
           draftInputs: existingState?.draftInputs,
-        };
-
-        await projectStore.saveProjectState(projectId, newState);
+        }));
       }
     ),
     getTerminalSizes: op(
@@ -146,8 +143,7 @@ export const terminalLayoutNamespace = defineIpcNamespace({
 
         const sanitizedSizes = sanitizeTerminalSizes(terminalSizes as Record<string, unknown>);
 
-        const existingState = await projectStore.getProjectState(projectId);
-        const newState = {
+        await projectStore.enqueueProjectStateUpdate(projectId, (existingState) => ({
           projectId,
           activeWorktreeId: existingState?.activeWorktreeId,
           sidebarWidth: existingState?.sidebarWidth ?? 350,
@@ -158,9 +154,7 @@ export const terminalLayoutNamespace = defineIpcNamespace({
           focusPanelState: existingState?.focusPanelState,
           terminalSizes: sanitizedSizes,
           draftInputs: existingState?.draftInputs,
-        };
-
-        await projectStore.saveProjectState(projectId, newState);
+        }));
       }
     ),
     getTabGroups: op(
@@ -189,8 +183,7 @@ export const terminalLayoutNamespace = defineIpcNamespace({
 
         const sanitizedTabGroups = sanitizeTabGroups(tabGroups, projectId) as TabGroup[];
 
-        const existingState = await projectStore.getProjectState(projectId);
-        const newState = {
+        await projectStore.enqueueProjectStateUpdate(projectId, (existingState) => ({
           projectId,
           activeWorktreeId: existingState?.activeWorktreeId,
           sidebarWidth: existingState?.sidebarWidth ?? 350,
@@ -201,8 +194,7 @@ export const terminalLayoutNamespace = defineIpcNamespace({
           focusPanelState: existingState?.focusPanelState,
           terminalSizes: existingState?.terminalSizes,
           draftInputs: existingState?.draftInputs,
-        };
-        await projectStore.saveProjectState(projectId, newState);
+        }));
       }
     ),
     getFocusMode: op(TERMINAL_LAYOUT_METHOD_CHANNELS.getFocusMode, async (projectId: string) => {
@@ -255,8 +247,7 @@ export const terminalLayoutNamespace = defineIpcNamespace({
           };
         }
 
-        const existingState = await projectStore.getProjectState(projectId);
-        const newState = {
+        await projectStore.enqueueProjectStateUpdate(projectId, (existingState) => ({
           projectId,
           activeWorktreeId: existingState?.activeWorktreeId,
           sidebarWidth: existingState?.sidebarWidth ?? 350,
@@ -267,9 +258,7 @@ export const terminalLayoutNamespace = defineIpcNamespace({
           focusPanelState: validFocusPanelState,
           terminalSizes: existingState?.terminalSizes,
           draftInputs: existingState?.draftInputs,
-        };
-
-        await projectStore.saveProjectState(projectId, newState);
+        }));
       }
     ),
     getDraftInputs: op(
@@ -306,8 +295,7 @@ export const terminalLayoutNamespace = defineIpcNamespace({
 
         const sanitized = sanitizeDraftInputs(draftInputs as Record<string, unknown>);
 
-        const existingState = await projectStore.getProjectState(projectId);
-        const newState = {
+        await projectStore.enqueueProjectStateUpdate(projectId, (existingState) => ({
           projectId,
           activeWorktreeId: existingState?.activeWorktreeId,
           sidebarWidth: existingState?.sidebarWidth ?? 350,
@@ -318,9 +306,7 @@ export const terminalLayoutNamespace = defineIpcNamespace({
           focusPanelState: existingState?.focusPanelState,
           terminalSizes: existingState?.terminalSizes,
           draftInputs: sanitized,
-        };
-
-        await projectStore.saveProjectState(projectId, newState);
+        }));
       }
     ),
   },

--- a/electron/lifecycle/__tests__/shutdown.test.ts
+++ b/electron/lifecycle/__tests__/shutdown.test.ts
@@ -18,6 +18,7 @@ const projectStoreMock = vi.hoisted(() => ({
   getAllProjects: vi.fn(() => []),
   getProjectState: vi.fn(),
   saveProjectState: vi.fn(),
+  enqueueProjectStateUpdate: vi.fn(async () => undefined),
 }));
 
 vi.mock("../../services/ProjectStore.js", () => ({

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -166,16 +166,16 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
           const captured = results.filter((r) => r.agentSessionId);
           if (captured.length === 0) continue;
 
-          const state = await projectStore.getProjectState(projectIds[i]);
-          if (!state?.terminals) continue;
-
-          for (const result of captured) {
-            const snapshot = state.terminals.find((t: { id: string }) => t.id === result.id);
-            if (snapshot) {
-              snapshot.agentSessionId = result.agentSessionId ?? undefined;
+          await projectStore.enqueueProjectStateUpdate(projectIds[i], (state) => {
+            if (!state?.terminals) return null;
+            for (const result of captured) {
+              const snapshot = state.terminals.find((t: { id: string }) => t.id === result.id);
+              if (snapshot) {
+                snapshot.agentSessionId = result.agentSessionId ?? undefined;
+              }
             }
-          }
-          await projectStore.saveProjectState(projectIds[i], state);
+            return state;
+          });
         }
       } catch (error) {
         console.warn("[MAIN] Graceful agent shutdown incomplete:", error);

--- a/electron/services/ProjectStateManager.ts
+++ b/electron/services/ProjectStateManager.ts
@@ -25,6 +25,7 @@ export interface ProjectStateReadResult {
 export class ProjectStateManager {
   private projectStateCache = new Map<string, ProjectStateCacheEntry>();
   private pendingQuarantines = new Map<string, string>();
+  private writeQueues = new Map<string, Promise<void>>();
 
   constructor(private projectsConfigDir: string) {}
 
@@ -58,6 +59,41 @@ export class ProjectStateManager {
       return;
     }
     this.projectStateCache.clear();
+  }
+
+  /**
+   * Serialize read-merge-write updates per project. ipcMain.handle runs
+   * handlers concurrently, so two unqueued read-modify-write cycles for the
+   * same projectId read the same snapshot and the last write silently reverts
+   * the other's field. Each queued updater sees the previous update's
+   * committed state. Returning null from the updater skips the save.
+   */
+  enqueueProjectStateUpdate(
+    projectId: string,
+    updater: (existing: ProjectState | null) => ProjectState | null | Promise<ProjectState | null>
+  ): Promise<void> {
+    const current = this.writeQueues.get(projectId) ?? Promise.resolve();
+    // .catch() keeps one failed update from poisoning the chain for later
+    // updates; the failure still propagates to that update's own caller.
+    const next = current
+      .catch(() => {})
+      .then(async () => {
+        const existing = await this.getProjectState(projectId);
+        const updated = await updater(existing);
+        if (updated !== null) {
+          await this.saveProjectState(projectId, updated);
+        }
+      });
+    this.writeQueues.set(projectId, next);
+    const cleanup = () => {
+      if (this.writeQueues.get(projectId) === next) {
+        this.writeQueues.delete(projectId);
+      }
+    };
+    // .then(cleanup, cleanup) instead of .finally(): .finally would create a
+    // new rejected promise nobody handles when the update fails.
+    next.then(cleanup, cleanup);
+    return next;
   }
 
   async saveProjectState(projectId: string, state: ProjectState): Promise<void> {

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -717,6 +717,21 @@ export class ProjectStore {
     return this.stateManager.saveProjectState(projectId, state);
   }
 
+  async enqueueProjectStateUpdate(
+    projectId: string,
+    updater: (existing: ProjectState | null) => ProjectState | null | Promise<ProjectState | null>
+  ): Promise<void> {
+    return this.stateManager.enqueueProjectStateUpdate(projectId, async (existing) => {
+      const updated = await updater(existing);
+      if (updated !== null) {
+        // Same contract as saveProjectState: invalidate before the write so an
+        // in-flight prefetch can't clobber the cache with pre-mutation state.
+        invalidatePrefetchCache(projectId);
+      }
+      return updated;
+    });
+  }
+
   async getProjectState(projectId: string): Promise<ProjectState | null> {
     return this.stateManager.getProjectState(projectId);
   }

--- a/electron/services/__tests__/ProjectStateManager.adversarial.test.ts
+++ b/electron/services/__tests__/ProjectStateManager.adversarial.test.ts
@@ -121,6 +121,69 @@ describe("ProjectStateManager.clearProjectState adversarial", () => {
   });
 });
 
+describe("ProjectStateManager.enqueueProjectStateUpdate adversarial", () => {
+  let tempDir: string;
+  let manager: ProjectStateManager;
+  let projectId: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    utilsMock.resilientAtomicWriteFile.mockResolvedValue(undefined);
+    utilsMock.resilientRename.mockResolvedValue(undefined);
+    utilsMock.resilientUnlink.mockResolvedValue(undefined);
+    fsPromisesMock.mkdir.mockResolvedValue(undefined);
+    fsPromisesMock.readFile.mockRejectedValue(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+    );
+
+    tempDir = path.join(os.tmpdir(), "daintree-queue-adv");
+    manager = new ProjectStateManager(tempDir);
+    projectId = generateProjectId("/test/adversarial-queue-project");
+  });
+
+  it("a write failure rejects its caller but does not poison subsequent queued updates", async () => {
+    const epipe = Object.assign(new Error("EPIPE"), { code: "EPIPE" });
+    utilsMock.resilientAtomicWriteFile.mockRejectedValueOnce(epipe);
+
+    const first = manager.enqueueProjectStateUpdate(projectId, () =>
+      makeState({ sidebarWidth: 1 })
+    );
+    const second = manager.enqueueProjectStateUpdate(projectId, () =>
+      makeState({ sidebarWidth: 2 })
+    );
+
+    await expect(first).rejects.toThrow("EPIPE");
+    await expect(second).resolves.toBeUndefined();
+    expect(utilsMock.resilientAtomicWriteFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("returning null from the updater skips the disk write entirely", async () => {
+    await manager.enqueueProjectStateUpdate(projectId, () => null);
+
+    expect(utilsMock.resilientAtomicWriteFile).not.toHaveBeenCalled();
+  });
+
+  it("the second queued update reads the first's committed cache, not stale disk", async () => {
+    const seen: Array<number | null> = [];
+
+    await Promise.all([
+      manager.enqueueProjectStateUpdate(projectId, (existing) => {
+        seen.push(existing?.sidebarWidth ?? null);
+        return makeState({ sidebarWidth: 123 });
+      }),
+      manager.enqueueProjectStateUpdate(projectId, (existing) => {
+        seen.push(existing?.sidebarWidth ?? null);
+        return { ...existing!, sidebarWidth: existing!.sidebarWidth + 1 };
+      }),
+    ]);
+
+    expect(seen).toEqual([null, 123]);
+    // The second read is served from the post-save cache — only the initial
+    // cache miss hits the disk.
+    expect(fsPromisesMock.readFile).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("ProjectStateManager.getProjectState ENOENT branch (mocked fs)", () => {
   let tempDir: string;
   let manager: ProjectStateManager;

--- a/electron/services/__tests__/ProjectStateManager.test.ts
+++ b/electron/services/__tests__/ProjectStateManager.test.ts
@@ -214,6 +214,24 @@ describe("ProjectStateManager.enqueueProjectStateUpdate concurrency", () => {
     expect(order).toEqual(["fast", "slow"]);
   });
 
+  it("both concurrent updates survive a disk read by a fresh manager instance", async () => {
+    await Promise.all([
+      manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+        ...(existing ?? makeState()),
+        sidebarWidth: 640,
+      })),
+      manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+        ...(existing ?? makeState()),
+        draftInputs: { t1: "draft" },
+      })),
+    ]);
+
+    const freshManager = new ProjectStateManager(tempDir);
+    const result = await freshManager.getProjectState(projectId);
+    expect(result!.sidebarWidth).toBe(640);
+    expect(result!.draftInputs).toEqual({ t1: "draft" });
+  });
+
   it("sequential updates after the queue drains still see committed state", async () => {
     await manager.enqueueProjectStateUpdate(projectId, () => makeState({ sidebarWidth: 1 }));
     await manager.enqueueProjectStateUpdate(projectId, (existing) => ({

--- a/electron/services/__tests__/ProjectStateManager.test.ts
+++ b/electron/services/__tests__/ProjectStateManager.test.ts
@@ -96,6 +96,136 @@ describe("ProjectStateManager clone isolation", () => {
   });
 });
 
+describe("ProjectStateManager.enqueueProjectStateUpdate concurrency", () => {
+  let tempDir: string;
+  let manager: ProjectStateManager;
+  let projectId: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-state-queue-"));
+    manager = new ProjectStateManager(tempDir);
+    projectId = generateProjectId("/test/queue-project");
+    await fs.mkdir(path.join(tempDir, projectId), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("concurrent updates to different fields both land (issue #9913)", async () => {
+    await manager.saveProjectState(projectId, makeState({ tabGroups: [] }));
+    manager.invalidateProjectStateCache(projectId);
+
+    const newTerminals = [
+      { id: "t9", title: "New", location: "grid" as const, kind: "terminal" as const, cwd: "/tmp" },
+    ];
+    const newTabGroups = [
+      { id: "g1", location: "grid" as const, activeTabId: "t9", panelIds: ["t9"] },
+    ];
+
+    await Promise.all([
+      manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+        ...existing!,
+        terminals: newTerminals,
+      })),
+      manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+        ...existing!,
+        tabGroups: newTabGroups,
+      })),
+    ]);
+
+    const result = await manager.getProjectState(projectId);
+    expect(result!.terminals.map((t) => t.id)).toEqual(["t9"]);
+    expect(result!.tabGroups).toEqual(newTabGroups);
+  });
+
+  it("each queued updater sees the previous update's committed state", async () => {
+    await manager.saveProjectState(projectId, makeState({ sidebarWidth: 100 }));
+
+    const seen: number[] = [];
+    await Promise.all([
+      manager.enqueueProjectStateUpdate(projectId, (existing) => {
+        seen.push(existing!.sidebarWidth);
+        return { ...existing!, sidebarWidth: 200 };
+      }),
+      manager.enqueueProjectStateUpdate(projectId, (existing) => {
+        seen.push(existing!.sidebarWidth);
+        return { ...existing!, sidebarWidth: existing!.sidebarWidth + 1 };
+      }),
+    ]);
+
+    expect(seen).toEqual([100, 200]);
+    const result = await manager.getProjectState(projectId);
+    expect(result!.sidebarWidth).toBe(201);
+  });
+
+  it("a failing updater rejects its own caller but does not block later updates", async () => {
+    await manager.saveProjectState(projectId, makeState({ sidebarWidth: 100 }));
+
+    const failing = manager.enqueueProjectStateUpdate(projectId, () => {
+      throw new Error("updater boom");
+    });
+    const following = manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+      ...existing!,
+      sidebarWidth: 400,
+    }));
+
+    await expect(failing).rejects.toThrow("updater boom");
+    await expect(following).resolves.toBeUndefined();
+    const result = await manager.getProjectState(projectId);
+    expect(result!.sidebarWidth).toBe(400);
+  });
+
+  it("creates state through the queue when none exists yet", async () => {
+    const seen: Array<ProjectState | null> = [];
+    await manager.enqueueProjectStateUpdate(projectId, (existing) => {
+      seen.push(existing);
+      return makeState({ sidebarWidth: 777 });
+    });
+
+    expect(seen).toEqual([null]);
+    const result = await manager.getProjectState(projectId);
+    expect(result!.sidebarWidth).toBe(777);
+  });
+
+  it("updates for different projects do not serialize behind one another", async () => {
+    const otherProjectId = generateProjectId("/test/queue-project-other");
+    await fs.mkdir(path.join(tempDir, otherProjectId), { recursive: true });
+
+    let releaseFirst!: () => void;
+    const gate = new Promise<void>((resolve) => (releaseFirst = resolve));
+    const order: string[] = [];
+
+    const slow = manager.enqueueProjectStateUpdate(projectId, async () => {
+      await gate;
+      order.push("slow");
+      return makeState();
+    });
+    const fast = manager.enqueueProjectStateUpdate(otherProjectId, () => {
+      order.push("fast");
+      return makeState({ projectId: otherProjectId });
+    });
+
+    await fast;
+    expect(order).toEqual(["fast"]);
+
+    releaseFirst();
+    await slow;
+    expect(order).toEqual(["fast", "slow"]);
+  });
+
+  it("sequential updates after the queue drains still see committed state", async () => {
+    await manager.enqueueProjectStateUpdate(projectId, () => makeState({ sidebarWidth: 1 }));
+    await manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+      ...existing!,
+      sidebarWidth: existing!.sidebarWidth + 1,
+    }));
+
+    const result = await manager.getProjectState(projectId);
+    expect(result!.sidebarWidth).toBe(2);
+  });
+});
+
 describe("ProjectStateManager telemetry", () => {
   let tempDir: string;
   let manager: ProjectStateManager;


### PR DESCRIPTION
## Summary

- Five `set*` IPC handlers in `terminalLayout.ts` each did an unserialized read-merge-write on the per-project state file. `ipcMain.handle` runs handlers concurrently, so two same-`projectId` calls in the same tick (e.g. debounced `setTerminals` + `setTabGroups` firing together) both read the same stale snapshot — the last write silently reverts the other's field, and the renderer's persisted-snapshot cache keeps that stale state sticky across restarts.
- Fix: `ProjectStateManager.enqueueProjectStateUpdate(projectId, updater)` — a per-project promise-chain queue using the same keyed-tail pattern as `RepoFetchCoordinator`. Each updater sees its predecessor's committed cache, `.catch()` anti-poisoning prevents one failed write from starving later updates, and returning `null` from an updater skips the save.
- Migrated all five `terminalLayout` `set*` handlers, the four `app:hydrate` migration writes (now spreading queue-committed existing state so concurrent layout writes aren't dropped), and the shutdown `agentSessionId` patch.

Resolves #9913

## Changes

- `electron/services/ProjectStateManager.ts` — adds `enqueueProjectStateUpdate`; `ProjectStore` delegate preserves the `invalidatePrefetchCache` contract
- `electron/ipc/handlers/terminalLayout.ts` — all five `set*` handlers migrated to the queue
- `electron/ipc/handlers/app/state.ts` — four hydrate migration writes queued with existing-state spread
- `electron/lifecycle/shutdown.ts` — `agentSessionId` patch migrated to the queue

## Testing

10 new tests across `ProjectStateManager.test.ts` and `ProjectStateManager.adversarial.test.ts`: both-fields-land under concurrency, predecessor-visibility, anti-poisoning, create-when-null, cross-project independence, sequential drain, fresh-manager disk readback, EPIPE doesn't poison the queue, `null` skips the disk write, second update served from committed cache.