### PR TITLE
fix(settings): route forge subtabs on canonical provider ids

### DIFF
--- a/electron/ipc/__tests__/errorHandlers.test.ts
+++ b/electron/ipc/__tests__/errorHandlers.test.ts
@@ -1425,7 +1425,7 @@ describe("errorHandlers", () => {
       expect(sentError.recoveryAction).toEqual({
         label: "Sign in with GitHub",
         actionId: "app.settings.openTab",
-        args: { tab: "code-forge", subtab: "github" },
+        args: { tab: "code-forge", subtab: "daintree.github.github" },
       });
       expect(sentError.recoveryHint).toContain("credentials");
       expect(sentError.type).toBe("git");

--- a/electron/ipc/handlers/forge.ts
+++ b/electron/ipc/handlers/forge.ts
@@ -247,10 +247,12 @@ export function registerForgeHandlers(): () => void {
         // unregistered provider, provider throwing) collapses to the generic
         // "push failed" banner rather than surfacing an error.
         try {
-          const { namespaceId, providerId } = await resolveForCwd(payload.cwd);
+          const { namespaceId } = await resolveForCwd(payload.cwd);
           const impl = getImplForNamespace(namespaceId);
           const classification = impl.classifyPushError?.(payload.stderr) ?? null;
-          return { providerId, classification };
+          // Return the canonical `{pluginId}.{contributionId}` id — the
+          // settings CTA routes the Code-forge subtab on canonical ids (#9968).
+          return { providerId: namespaceId, classification };
         } catch {
           return null;
         }

--- a/electron/utils/__tests__/errorClassification.test.ts
+++ b/electron/utils/__tests__/errorClassification.test.ts
@@ -63,7 +63,7 @@ describe("classifyError", () => {
     expect(result.recoveryAction).toEqual({
       label: "Sign in with GitHub",
       actionId: "app.settings.openTab",
-      args: { tab: "code-forge", subtab: "github" },
+      args: { tab: "code-forge", subtab: "daintree.github.github" },
     });
   });
 

--- a/electron/workspace-host/__tests__/WorkspaceService.fetchPRBranch.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.fetchPRBranch.test.ts
@@ -213,7 +213,7 @@ describe("WorkspaceService.fetchPRBranch", () => {
         recoveryAction: {
           label: "Sign in with GitHub",
           actionId: "app.settings.openTab",
-          args: { tab: "code-forge", subtab: "github" },
+          args: { tab: "code-forge", subtab: "daintree.github.github" },
         },
       })
     );

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1358,10 +1358,11 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     ): () => void;
     /**
      * Classify a `git push` failure via the resolved forge provider. Returns
-     * the provider's `contribution.id` (for routing the push-error banner's
-     * settings CTA) plus the provider's classification (a stable error code,
-     * or `null` when the provider doesn't recognize the stderr). Resolves to
-     * `null` when no forge provider can be resolved for `cwd`.
+     * the provider's canonical `{pluginId}.{contributionId}` id (for routing
+     * the push-error banner's settings CTA) plus the provider's classification
+     * (a stable error code, or `null` when the provider doesn't recognize the
+     * stderr). Resolves to `null` when no forge provider can be resolved for
+     * `cwd`.
      */
     classifyPushError(payload: {
       cwd: string;

--- a/shared/utils/__tests__/gitOperationErrors.test.ts
+++ b/shared/utils/__tests__/gitOperationErrors.test.ts
@@ -280,7 +280,7 @@ describe("getGitRecoveryAction", () => {
     expect(getGitRecoveryAction("auth-failed")).toEqual({
       label: "Sign in with GitHub",
       actionId: "app.settings.openTab",
-      args: { tab: "code-forge", subtab: "github" },
+      args: { tab: "code-forge", subtab: "daintree.github.github" },
     });
     expect(getGitRecoveryAction("push-rejected-outdated")).toEqual({
       label: "Pull and rebase",

--- a/shared/utils/gitOperationErrors.ts
+++ b/shared/utils/gitOperationErrors.ts
@@ -1,4 +1,5 @@
 import type { GitOperationReason, RecoveryAction } from "../types/ipc/errors.js";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "./forgeProviderIds.js";
 
 /**
  * Pure classifier for simple-git errors.
@@ -151,7 +152,7 @@ const RECOVERY_ACTIONS: Partial<Record<GitOperationReason, RecoveryAction>> = {
   "auth-failed": {
     label: "Sign in with GitHub",
     actionId: "app.settings.openTab",
-    args: { tab: "code-forge", subtab: "github" },
+    args: { tab: "code-forge", subtab: BUILTIN_GITHUB_PROVIDER_ID },
   },
   "push-rejected-outdated": { label: "Pull and rebase", actionId: "git.pullRebase" },
   "conflict-unresolved": { label: "Resolve conflicts", actionId: "worktree.openReviewHub" },

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -25,6 +25,7 @@ import { useGitHubFilterStore } from "@github-renderer/stores/githubFilterStore"
 import { useRepositoryStats } from "@/hooks/useRepositoryStats";
 import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { useGitHubTokenExpiryNotification } from "@/hooks/useGitHubTokenExpiryNotification";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
 import {
   GitHubResourceListSkeleton,
   CommitListSkeleton,
@@ -782,7 +783,7 @@ export const GitHubStatsToolbarButton = memo(
     const openSettingsForToken = useCallback(() => {
       void actionService.dispatch(
         "app.settings.openTab",
-        { tab: "code-forge", subtab: "github", sectionId: "github-token" },
+        { tab: "code-forge", subtab: BUILTIN_GITHUB_PROVIDER_ID, sectionId: "github-token" },
         { source: "user" }
       );
     }, []);
@@ -913,7 +914,11 @@ export const GitHubStatsToolbarButton = memo(
                   setIssueSearchQuery("");
                   void actionService.dispatch(
                     "app.settings.openTab",
-                    { tab: "code-forge", subtab: "github", sectionId: "github-token" },
+                    {
+                      tab: "code-forge",
+                      subtab: BUILTIN_GITHUB_PROVIDER_ID,
+                      sectionId: "github-token",
+                    },
                     { source: "user" }
                   );
                   return;
@@ -1021,7 +1026,11 @@ export const GitHubStatsToolbarButton = memo(
                   setPrSearchQuery("");
                   void actionService.dispatch(
                     "app.settings.openTab",
-                    { tab: "code-forge", subtab: "github", sectionId: "github-token" },
+                    {
+                      tab: "code-forge",
+                      subtab: BUILTIN_GITHUB_PROVIDER_ID,
+                      sectionId: "github-token",
+                    },
                     { source: "user" }
                   );
                   return;

--- a/src/components/Recovery/GitHubTokenBanner.tsx
+++ b/src/components/Recovery/GitHubTokenBanner.tsx
@@ -1,6 +1,7 @@
 import { AlertTriangle } from "lucide-react";
 import { useGitHubTokenHealthStore } from "@/store/githubTokenHealthStore";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
 
 export function GitHubTokenBanner() {
   const isUnhealthy = useGitHubTokenHealthStore((s) => s.isUnhealthy);
@@ -10,7 +11,7 @@ export function GitHubTokenBanner() {
   const handleReconnect = () => {
     window.dispatchEvent(
       new CustomEvent("daintree:open-settings-tab", {
-        detail: { tab: "code-forge", subtab: "github" },
+        detail: { tab: "code-forge", subtab: BUILTIN_GITHUB_PROVIDER_ID },
       })
     );
   };

--- a/src/components/Settings/CodeForgeSettingsTab.tsx
+++ b/src/components/Settings/CodeForgeSettingsTab.tsx
@@ -12,7 +12,7 @@ import { GitHubIcon } from "@/components/icons/brands";
 import type { ForgeProviderContribution, ForgeProviderEntry } from "@shared/types";
 import type { ForgeAuditRecord, ForgeAuditStats } from "@shared/types/ipc/forge";
 import { FORGE_AUDIT_DEFAULT_MAX_RECORDS } from "@shared/types/ipc/forge";
-import { makeForgeProviderId } from "@shared/utils/forgeProviderIds";
+import { makeForgeProviderId, BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import {
@@ -37,7 +37,7 @@ function getForgeIcon(id: string): ForgeIcon {
 }
 
 const GENERAL_ID = "general";
-const GITHUB_ID = "github";
+const GITHUB_ID = BUILTIN_GITHUB_PROVIDER_ID;
 const CREDENTIAL_RESULT_DISPLAY_MS = 5000;
 const COPY_FEEDBACK_MS = 2000;
 
@@ -191,7 +191,7 @@ export function CodeForgeSettingsTab({ activeSubtab, onSubtabChange }: CodeForge
   const providerOptions = useMemo<ForgeProviderOption[]>(
     () =>
       providers.map((entry) => ({
-        id: entry.contribution.id,
+        id: makeForgeProviderId(entry.pluginId, entry.contribution.id),
         name: entry.contribution.name,
         pluginId: entry.pluginId,
       })),
@@ -209,7 +209,7 @@ export function CodeForgeSettingsTab({ activeSubtab, onSubtabChange }: CodeForge
   const isGeneral = effectiveSubtab === GENERAL_ID;
   const isGitHub = effectiveSubtab === GITHUB_ID;
   const selectedEntry = !isGeneral
-    ? providers.find((p) => p.contribution.id === effectiveSubtab)
+    ? providers.find((p) => makeForgeProviderId(p.pluginId, p.contribution.id) === effectiveSubtab)
     : null;
 
   return (

--- a/src/components/Settings/CodeForgeSettingsTab.tsx
+++ b/src/components/Settings/CodeForgeSettingsTab.tsx
@@ -32,8 +32,8 @@ import { logError } from "@/utils/logger";
 
 type ForgeIcon = ComponentType<{ className?: string; size?: number; "aria-hidden"?: boolean }>;
 
-function getForgeIcon(id: string): ForgeIcon {
-  return id === "github" ? GitHubIcon : GitBranch;
+function getForgeIcon(canonicalId: string): ForgeIcon {
+  return canonicalId === BUILTIN_GITHUB_PROVIDER_ID ? GitHubIcon : GitBranch;
 }
 
 const GENERAL_ID = "general";
@@ -275,7 +275,9 @@ export function CodeForgeSettingsTab({ activeSubtab, onSubtabChange }: CodeForge
         {!isGeneral && !isGitHub && selectedEntry && (
           <ForgeProviderCard
             name={selectedEntry.contribution.name}
-            Icon={getForgeIcon(selectedEntry.contribution.id)}
+            Icon={getForgeIcon(
+              makeForgeProviderId(selectedEntry.pluginId, selectedEntry.contribution.id)
+            )}
           >
             <ProviderSettingsBody
               providerId={makeForgeProviderId(

--- a/src/components/Settings/ForgeProviderSelectorDropdown.tsx
+++ b/src/components/Settings/ForgeProviderSelectorDropdown.tsx
@@ -3,8 +3,10 @@ import { cn } from "@/lib/utils";
 import { GitBranch, ChevronDown, Search } from "lucide-react";
 import { GitHubIcon } from "@/components/icons/brands";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
 
 export interface ForgeProviderOption {
+  /** Canonical `{pluginId}.{contributionId}` forge provider id. */
   id: string;
   name: string;
   pluginId: string;
@@ -13,7 +15,7 @@ export interface ForgeProviderOption {
 type ProviderIcon = ComponentType<{ size?: number; className?: string }>;
 
 function getProviderIcon(id: string): ProviderIcon {
-  return id === "github" ? GitHubIcon : GitBranch;
+  return id === BUILTIN_GITHUB_PROVIDER_ID ? GitHubIcon : GitBranch;
 }
 
 interface ForgeProviderSelectorDropdownProps {

--- a/src/components/Settings/__tests__/CodeForgeSettingsTab.credentials.test.tsx
+++ b/src/components/Settings/__tests__/CodeForgeSettingsTab.credentials.test.tsx
@@ -93,7 +93,7 @@ describe("CodeForgeSettingsTab — generic credential form", () => {
       ],
     });
 
-    render(<CodeForgeSettingsTab activeSubtab="gitea" onSubtabChange={vi.fn()} />);
+    render(<CodeForgeSettingsTab activeSubtab="acme.gitea" onSubtabChange={vi.fn()} />);
 
     await waitFor(() => {
       expect(screen.getByTestId("forge-credential-form")).toBeTruthy();
@@ -114,7 +114,7 @@ describe("CodeForgeSettingsTab — generic credential form", () => {
       setCredentialResult: { valid: true },
     });
 
-    render(<CodeForgeSettingsTab activeSubtab="gitea" onSubtabChange={vi.fn()} />);
+    render(<CodeForgeSettingsTab activeSubtab="acme.gitea" onSubtabChange={vi.fn()} />);
 
     const input = (await screen.findByLabelText("API token")) as HTMLInputElement;
     fireEvent.change(input, { target: { value: "secret-token" } });
@@ -142,7 +142,7 @@ describe("CodeForgeSettingsTab — generic credential form", () => {
       setCredentialResult: { valid: false, error: "Bad token" },
     });
 
-    render(<CodeForgeSettingsTab activeSubtab="gitea" onSubtabChange={vi.fn()} />);
+    render(<CodeForgeSettingsTab activeSubtab="acme.gitea" onSubtabChange={vi.fn()} />);
 
     const input = (await screen.findByLabelText("API token")) as HTMLInputElement;
     fireEvent.change(input, { target: { value: "nope" } });
@@ -169,7 +169,7 @@ describe("CodeForgeSettingsTab — generic credential form", () => {
       hasCredential: true,
     });
 
-    render(<CodeForgeSettingsTab activeSubtab="gitea" onSubtabChange={vi.fn()} />);
+    render(<CodeForgeSettingsTab activeSubtab="acme.gitea" onSubtabChange={vi.fn()} />);
 
     const clearButton = await screen.findByRole("button", { name: "Clear" });
     fireEvent.click(clearButton);
@@ -184,7 +184,7 @@ describe("CodeForgeSettingsTab — generic credential form", () => {
       providers: [makeProvider("acme", "plain", "Plain Forge")],
     });
 
-    render(<CodeForgeSettingsTab activeSubtab="plain" onSubtabChange={vi.fn()} />);
+    render(<CodeForgeSettingsTab activeSubtab="acme.plain" onSubtabChange={vi.fn()} />);
 
     await waitFor(() => {
       expect(screen.getByText("No configuration needed")).toBeTruthy();
@@ -205,17 +205,83 @@ describe("CodeForgeSettingsTab — generic credential form", () => {
     });
 
     const { rerender } = render(
-      <CodeForgeSettingsTab activeSubtab="gitea" onSubtabChange={vi.fn()} />
+      <CodeForgeSettingsTab activeSubtab="acme.gitea" onSubtabChange={vi.fn()} />
     );
 
     await waitFor(() => {
       expect(getCredentialStatus).toHaveBeenCalledWith("acme.gitea");
     });
 
-    rerender(<CodeForgeSettingsTab activeSubtab="gitlab" onSubtabChange={vi.fn()} />);
+    rerender(<CodeForgeSettingsTab activeSubtab="acme.gitlab" onSubtabChange={vi.fn()} />);
 
     await waitFor(() => {
       expect(getCredentialStatus).toHaveBeenCalledWith("acme.gitlab");
     });
+  });
+});
+
+describe("CodeForgeSettingsTab — canonical subtab routing", () => {
+  it("routes each provider by canonical id when two plugins share a contribution id", async () => {
+    const { getCredentialStatus } = installForgeMocks({
+      providers: [
+        makeProvider("acme", "forge", "Acme Forge", [
+          { id: "token", label: "API token", type: "password" },
+        ]),
+        makeProvider("globex", "forge", "Globex Forge", [
+          { id: "token", label: "API token", type: "password" },
+        ]),
+      ],
+    });
+
+    const { rerender } = render(
+      <CodeForgeSettingsTab activeSubtab="acme.forge" onSubtabChange={vi.fn()} />
+    );
+
+    await waitFor(() => {
+      expect(getCredentialStatus).toHaveBeenCalledWith("acme.forge");
+    });
+    expect(screen.getByText("Acme Forge settings")).toBeTruthy();
+
+    rerender(<CodeForgeSettingsTab activeSubtab="globex.forge" onSubtabChange={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(getCredentialStatus).toHaveBeenCalledWith("globex.forge");
+    });
+    expect(screen.getByText("Globex Forge settings")).toBeTruthy();
+  });
+
+  it("does not route a third-party 'github' contribution to the built-in GitHub card", async () => {
+    const { getCredentialStatus } = installForgeMocks({
+      providers: [
+        makeProvider("acme", "github", "Acme GitHub", [
+          { id: "token", label: "API token", type: "password" },
+        ]),
+      ],
+    });
+
+    render(<CodeForgeSettingsTab activeSubtab="acme.github" onSubtabChange={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(getCredentialStatus).toHaveBeenCalledWith("acme.github");
+    });
+    expect(screen.getByTestId("forge-credential-form")).toBeTruthy();
+    expect(screen.queryByTestId("github-settings-tab")).toBeNull();
+  });
+
+  it("falls back to the GitHub subtab for an unrecognized bare subtab id", async () => {
+    installForgeMocks({
+      providers: [
+        makeProvider("acme", "gitea", "Gitea", [
+          { id: "token", label: "API token", type: "password" },
+        ]),
+      ],
+    });
+
+    render(<CodeForgeSettingsTab activeSubtab="gitea" onSubtabChange={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("github-settings-tab")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("forge-credential-form")).toBeNull();
   });
 });

--- a/src/components/Settings/__tests__/CodeForgeSettingsTab.credentials.test.tsx
+++ b/src/components/Settings/__tests__/CodeForgeSettingsTab.credentials.test.tsx
@@ -268,6 +268,34 @@ describe("CodeForgeSettingsTab — canonical subtab routing", () => {
     expect(screen.queryByTestId("github-settings-tab")).toBeNull();
   });
 
+  it("routes the built-in GitHub card and a third-party 'github' contribution independently", async () => {
+    const { getCredentialStatus } = installForgeMocks({
+      providers: [
+        makeProvider("daintree.github", "github", "GitHub"),
+        makeProvider("acme", "github", "Acme GitHub", [
+          { id: "token", label: "API token", type: "password" },
+        ]),
+      ],
+    });
+
+    const { rerender } = render(
+      <CodeForgeSettingsTab activeSubtab="daintree.github.github" onSubtabChange={vi.fn()} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("github-settings-tab")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("forge-credential-form")).toBeNull();
+
+    rerender(<CodeForgeSettingsTab activeSubtab="acme.github" onSubtabChange={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(getCredentialStatus).toHaveBeenCalledWith("acme.github");
+    });
+    expect(screen.getByTestId("forge-credential-form")).toBeTruthy();
+    expect(screen.queryByTestId("github-settings-tab")).toBeNull();
+  });
+
   it("falls back to the GitHub subtab for an unrecognized bare subtab id", async () => {
     installForgeMocks({
       providers: [
@@ -277,11 +305,15 @@ describe("CodeForgeSettingsTab — canonical subtab routing", () => {
       ],
     });
 
-    render(<CodeForgeSettingsTab activeSubtab="gitea" onSubtabChange={vi.fn()} />);
+    const onSubtabChange = vi.fn();
+    render(<CodeForgeSettingsTab activeSubtab="gitea" onSubtabChange={onSubtabChange} />);
 
     await waitFor(() => {
       expect(screen.getByTestId("github-settings-tab")).toBeTruthy();
     });
     expect(screen.queryByTestId("forge-credential-form")).toBeNull();
+    // The fallback is display-only — the component must not rewrite the
+    // caller's subtab state.
+    expect(onSubtabChange).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Settings/settingsTabRegistry.tsx
+++ b/src/components/Settings/settingsTabRegistry.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import { DaintreeIcon, FolderGit2, Plug, McpServerIcon, Workflow } from "@/components/icons";
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
 import { AGENT_REGISTRY } from "@shared/config/agentRegistry";
 import { GeneralTab } from "./GeneralTab";
 
@@ -1061,7 +1062,7 @@ export const SETTINGS_REGISTRY = [
     sections: [
       {
         id: "github-token",
-        subtab: "github",
+        subtab: BUILTIN_GITHUB_PROVIDER_ID,
         subtabLabel: "GitHub",
         section: "Personal access token",
         title: "GitHub personal access token",

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -42,11 +42,12 @@ const {
   openPRMock: vi.fn().mockResolvedValue(undefined),
   openExternalMock: vi.fn().mockResolvedValue(undefined),
   // Mirrors the real GitHub forge provider: extracts a GH### code from stderr
-  // and reports the resolved provider id used to route the settings CTA.
+  // and reports the resolved canonical provider id used to route the
+  // settings CTA.
   classifyPushErrorMock: vi.fn(async (_cwd: string, stderr: string) => {
     const match = /\bGH\d{3,}\b/.exec(String(stderr));
     return {
-      providerId: "github",
+      providerId: "daintree.github.github",
       classification: match ? { code: match[0] } : null,
     };
   }),
@@ -405,7 +406,10 @@ describe("ReviewHub", () => {
     openExternalMock.mockReset().mockResolvedValue(undefined);
     classifyPushErrorMock.mockReset().mockImplementation(async (_cwd: string, stderr: string) => {
       const match = /\bGH\d{3,}\b/.exec(String(stderr));
-      return { providerId: "github", classification: match ? { code: match[0] } : null };
+      return {
+        providerId: "daintree.github.github",
+        classification: match ? { code: match[0] } : null,
+      };
     });
 
     Object.defineProperty(window, "electron", {
@@ -1826,7 +1830,7 @@ describe("ReviewHub", () => {
 
       expect(actionDispatchMock).toHaveBeenCalledWith(
         "app.settings.openTab",
-        { tab: "code-forge", subtab: "github" },
+        { tab: "code-forge", subtab: "daintree.github.github" },
         { source: "user" }
       );
     });
@@ -1893,7 +1897,7 @@ describe("ReviewHub", () => {
       expect(screen.queryByTestId("review-hub-push-error-code")).toBeNull();
 
       await act(async () => {
-        releaseSecond({ providerId: "github", classification: null });
+        releaseSecond({ providerId: "daintree.github.github", classification: null });
         await Promise.resolve();
       });
       expect(screen.queryByTestId("review-hub-push-error-code")).toBeNull();

--- a/src/components/Worktree/ReviewHub/reviewHubUtils.ts
+++ b/src/components/Worktree/ReviewHub/reviewHubUtils.ts
@@ -18,9 +18,10 @@ export interface PushErrorState {
 export type PushBannerCta =
   /**
    * Routes to the active forge provider's settings subtab. `providerId` is the
-   * resolved provider's `contribution.id` (the Code-forge settings subtab key),
-   * supplied at render time by {@link getPushBannerConfig} — the static config
-   * table can't know the runtime-resolved provider.
+   * resolved provider's canonical `{pluginId}.{contributionId}` id (the
+   * Code-forge settings subtab key), supplied at render time by
+   * {@link getPushBannerConfig} — the static config table can't know the
+   * runtime-resolved provider.
    */
   | { kind: "settings-forge"; label: string; providerId: string }
   | { kind: "retry"; label: string }

--- a/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
@@ -4,6 +4,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import { actionService } from "@/services/ActionService";
 import { formatRelativeTime } from "@/lib/formatRelativeTime";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
 
 interface UpstreamSyncBadgeProps {
   aheadCount: number | undefined;
@@ -100,7 +101,7 @@ export function UpstreamSyncBadge({
     });
     void actionService.dispatch(
       "app.settings.openTab",
-      { tab: "code-forge", subtab: "github", sectionId: "github-token" },
+      { tab: "code-forge", subtab: BUILTIN_GITHUB_PROVIDER_ID, sectionId: "github-token" },
       { source: "user" }
     );
   }, []);

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -1202,7 +1202,7 @@ describe("WorktreeHeader token-missing badge behavior", () => {
     fireEvent.click(issueButton);
     expect(actionService.dispatch).toHaveBeenCalledWith(
       "app.settings.openTab",
-      { tab: "code-forge", subtab: "github", sectionId: "github-token" },
+      { tab: "code-forge", subtab: "daintree.github.github", sectionId: "github-token" },
       { source: "user" }
     );
     expect(onOpenIssue).not.toHaveBeenCalled();
@@ -1241,7 +1241,7 @@ describe("WorktreeHeader token-missing badge behavior", () => {
     fireEvent.click(prButton);
     expect(actionService.dispatch).toHaveBeenCalledWith(
       "app.settings.openTab",
-      { tab: "code-forge", subtab: "github", sectionId: "github-token" },
+      { tab: "code-forge", subtab: "daintree.github.github", sectionId: "github-token" },
       { source: "user" }
     );
     expect(onOpenPR).not.toHaveBeenCalled();
@@ -1413,7 +1413,7 @@ describe("WorktreeHeader upstream sync indicator", () => {
     expect(mockRetryAuthFetch).toHaveBeenCalledTimes(1);
     expect(actionService.dispatch).toHaveBeenCalledWith(
       "app.settings.openTab",
-      { tab: "code-forge", subtab: "github", sectionId: "github-token" },
+      { tab: "code-forge", subtab: "daintree.github.github", sectionId: "github-token" },
       { source: "user" }
     );
   });

--- a/src/components/Worktree/WorktreeCard/hooks/useGitHubBadgeTooltip.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useGitHubBadgeTooltip.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from "react";
 import { actionService } from "@/services/ActionService";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
 
 interface UseGitHubBadgeTooltipParams {
   fetchTooltip: () => Promise<void>;
@@ -35,7 +36,7 @@ export function useGitHubBadgeTooltip({
     if (missingToken) {
       void actionService.dispatch(
         "app.settings.openTab",
-        { tab: "code-forge", subtab: "github", sectionId: "github-token" },
+        { tab: "code-forge", subtab: BUILTIN_GITHUB_PROVIDER_ID, sectionId: "github-token" },
         { source: "user" }
       );
       return;

--- a/src/hooks/__tests__/useGitHubTokenExpiryNotification.test.tsx
+++ b/src/hooks/__tests__/useGitHubTokenExpiryNotification.test.tsx
@@ -102,14 +102,14 @@ describe("useGitHubTokenExpiryNotification", () => {
     expect(payload.action?.actionId).toBe("app.settings.openTab");
     expect(payload.action?.actionArgs).toEqual({
       tab: "code-forge",
-      subtab: "github",
+      subtab: "daintree.github.github",
       sectionId: "github-token",
     });
 
     payload.action?.onClick();
     expect(dispatchMock).toHaveBeenCalledWith(
       "app.settings.openTab",
-      { tab: "code-forge", subtab: "github", sectionId: "github-token" },
+      { tab: "code-forge", subtab: "daintree.github.github", sectionId: "github-token" },
       { source: "user" }
     );
   });

--- a/src/hooks/app/__tests__/useSettingsDialog.test.ts
+++ b/src/hooks/app/__tests__/useSettingsDialog.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
+
+vi.mock("@/components/Settings/settingsTabRegistry", () => ({
+  isSettingsTab: (tab: string) => ["general", "code-forge", "appearance"].includes(tab),
+}));
+
+import { useSettingsDialog } from "../useSettingsDialog";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useSettingsDialog — forge subtab normalization", () => {
+  it("normalizes the legacy 'github' tab to code-forge with the canonical GitHub subtab", () => {
+    const { result } = renderHook(() => useSettingsDialog());
+
+    act(() => {
+      result.current.handleOpenSettingsTab({ tab: "github" });
+    });
+
+    expect(result.current.settingsTab).toBe("code-forge");
+    expect(result.current.settingsSubtab).toBe(BUILTIN_GITHUB_PROVIDER_ID);
+    expect(result.current.isSettingsOpen).toBe(true);
+  });
+
+  it("normalizes a legacy bare 'github' subtab on the code-forge tab to the canonical id", () => {
+    const { result } = renderHook(() => useSettingsDialog());
+
+    act(() => {
+      result.current.handleOpenSettingsTab({ tab: "code-forge", subtab: "github" });
+    });
+
+    expect(result.current.settingsTab).toBe("code-forge");
+    expect(result.current.settingsSubtab).toBe(BUILTIN_GITHUB_PROVIDER_ID);
+  });
+
+  it("passes an already-canonical forge subtab through unchanged", () => {
+    const { result } = renderHook(() => useSettingsDialog());
+
+    act(() => {
+      result.current.handleOpenSettingsTab({ tab: "code-forge", subtab: "acme.gitea" });
+    });
+
+    expect(result.current.settingsSubtab).toBe("acme.gitea");
+  });
+
+  it("leaves the 'general' forge subtab unchanged", () => {
+    const { result } = renderHook(() => useSettingsDialog());
+
+    act(() => {
+      result.current.handleOpenSettingsTab({ tab: "code-forge", subtab: "general" });
+    });
+
+    expect(result.current.settingsSubtab).toBe("general");
+  });
+
+  it("normalizes the legacy 'forge' tab to code-forge with the general subtab", () => {
+    const { result } = renderHook(() => useSettingsDialog());
+
+    act(() => {
+      result.current.handleOpenSettingsTab({ tab: "forge" });
+    });
+
+    expect(result.current.settingsTab).toBe("code-forge");
+    expect(result.current.settingsSubtab).toBe("general");
+  });
+
+  it("does not normalize subtabs on non-forge tabs", () => {
+    const { result } = renderHook(() => useSettingsDialog());
+
+    act(() => {
+      result.current.handleOpenSettingsTab({ tab: "appearance", subtab: "github" });
+    });
+
+    expect(result.current.settingsTab).toBe("appearance");
+    expect(result.current.settingsSubtab).toBe("github");
+  });
+});

--- a/src/hooks/app/__tests__/useSettingsDialog.test.ts
+++ b/src/hooks/app/__tests__/useSettingsDialog.test.ts
@@ -68,6 +68,22 @@ describe("useSettingsDialog — forge subtab normalization", () => {
     expect(result.current.settingsSubtab).toBe("general");
   });
 
+  it("normalizes a legacy bare 'github' subtab arriving via the open-settings-tab event", () => {
+    const { result } = renderHook(() => useSettingsDialog());
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("daintree:open-settings-tab", {
+          detail: { tab: "code-forge", subtab: "github" },
+        })
+      );
+    });
+
+    expect(result.current.settingsTab).toBe("code-forge");
+    expect(result.current.settingsSubtab).toBe(BUILTIN_GITHUB_PROVIDER_ID);
+    expect(result.current.isSettingsOpen).toBe(true);
+  });
+
   it("does not normalize subtabs on non-forge tabs", () => {
     const { result } = renderHook(() => useSettingsDialog());
 

--- a/src/hooks/app/useSettingsDialog.ts
+++ b/src/hooks/app/useSettingsDialog.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import type { SettingsTab, SettingsNavTarget } from "@/components/Settings";
 import { isSettingsTab } from "@/components/Settings/settingsTabRegistry";
+import { BUILTIN_GITHUB_PROVIDER_ID, normalizeProviderId } from "@shared/utils/forgeProviderIds";
 
 export function useSettingsDialog() {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
@@ -26,7 +27,7 @@ export function useSettingsDialog() {
       }
       normalized = {
         tab: "code-forge",
-        subtab: target.subtab ?? "github",
+        subtab: target.subtab ?? BUILTIN_GITHUB_PROVIDER_ID,
         sectionId: target.sectionId,
       };
     } else if (target.tab === "forge") {
@@ -43,7 +44,14 @@ export function useSettingsDialog() {
     }
     const tab = isSettingsTab(normalized.tab) ? normalized.tab : "general";
     setSettingsTab(tab);
-    setSettingsSubtab(normalized.subtab);
+    // Forge subtabs route on canonical `{pluginId}.{contributionId}` ids;
+    // normalize legacy bare forms ("github", "builtin.github") from in-flight
+    // callers at this read boundary. Other subtabs pass through unchanged.
+    const subtab =
+      tab === "code-forge" && normalized.subtab !== undefined && normalized.subtab !== "general"
+        ? (normalizeProviderId(normalized.subtab) ?? normalized.subtab)
+        : normalized.subtab;
+    setSettingsSubtab(subtab);
     setSettingsSectionId(normalized.sectionId);
     setIsSettingsOpen(true);
   }, []);

--- a/src/hooks/useGitHubTokenExpiryNotification.ts
+++ b/src/hooks/useGitHubTokenExpiryNotification.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import { notify } from "@/lib/notify";
 import { actionService } from "@/services/ActionService";
 import { useGitHubTokenHealthStore } from "@/store/githubTokenHealthStore";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
 
 const GITHUB_TOKEN_SUPERSEDE_KEY = "github.token";
 
@@ -43,11 +44,15 @@ export function useGitHubTokenExpiryNotification(isTokenError: boolean): void {
         action: {
           label: "Open GitHub settings",
           actionId: "app.settings.openTab",
-          actionArgs: { tab: "code-forge", subtab: "github", sectionId: "github-token" },
+          actionArgs: {
+            tab: "code-forge",
+            subtab: BUILTIN_GITHUB_PROVIDER_ID,
+            sectionId: "github-token",
+          },
           onClick: () => {
             void actionService.dispatch(
               "app.settings.openTab",
-              { tab: "code-forge", subtab: "github", sectionId: "github-token" },
+              { tab: "code-forge", subtab: BUILTIN_GITHUB_PROVIDER_ID, sectionId: "github-token" },
               { source: "user" }
             );
           },


### PR DESCRIPTION
## Summary

- Forge settings subtab routing, selection, and React keys used bare `contribution.id` instead of the canonical `{pluginId}.{contributionId}` form returned by `makeForgeProviderId`. Two plugins sharing a contribution id would collide (duplicate React keys, second provider unreachable).
- A hardcoded `GITHUB_ID = "github"` constant let any third-party contribution also named `"github"` hijack the built-in GitHub settings card.
- Fix: `providerOptions`, `selectedEntry`, and `GITHUB_ID` now use canonical ids throughout the dropdown, subtab selector, all deep-link call sites (`settingsTabRegistry`, `GitHubTokenBanner`, `GitHubStatsToolbarButton`, `UpstreamSyncBadge`, `useGitHubBadgeTooltip`, `useGitHubTokenExpiryNotification`, `gitOperationErrors` recovery CTA), and the push-error classifier in `reviewHubUtils`. A `normalizeProviderId` helper in `useSettingsDialog` normalises legacy bare ids at the read boundary. Credential storage was already canonical and is unchanged.

Resolves #9968

## Changes

- `CodeForgeSettingsTab`: `providerOptions` and selected-entry lookup switch to canonical ids; `GITHUB_ID` replaced with `BUILTIN_GITHUB_PROVIDER_ID`
- `ForgeProviderSelectorDropdown`: dropdown icon match uses canonical id
- `useSettingsDialog`: adds `normalizeProviderId` to coerce any legacy bare id to canonical before routing
- `reviewHubUtils` / `forge.ts` / `gitOperationErrors.ts`: push-error classifier returns canonical namespace id so third-party provider CTAs route correctly
- All deep-link call sites updated to pass canonical ids
- `shared/types/ipc/api.ts`: `FORGE_CLASSIFY_PUSH_ERROR` return type reflects canonical id

## Testing

- New `useSettingsDialog` suite: 7 cases covering canonical pass-through, bare-id normalisation, unknown-id fallback, and co-registration scenarios
- `CodeForgeSettingsTab.credentials.test.tsx`: collision routing, third-party non-hijack, bare-id fallback (display-only)
- Lockstep assertion updates across 7 test files to match canonical id expectations
- All 546+ affected tests passing; typecheck, lint (ratchet −6), format, and IPC guards green