### PR TITLE
fix(recipes): surface spawn failures on all non-panel launch paths

### DIFF
--- a/src/components/Layout/DockLaunchMenuItems.tsx
+++ b/src/components/Layout/DockLaunchMenuItems.tsx
@@ -202,12 +202,7 @@ export function DockLaunchMenuItems({
               void useRecipeStore
                 .getState()
                 .runRecipeWithResults(recipe.id, cwd, activeWorktreeId ?? undefined, recipeContext)
-                .then((results) =>
-                  notifyRecipeSpawnFailures(results, {
-                    recipeName: recipe.name,
-                    worktreeId: activeWorktreeId ?? undefined,
-                  })
-                )
+                .then((results) => notifyRecipeSpawnFailures(results, { recipeName: recipe.name }))
                 .catch((error) => logError("Recipe launch from dock failed", error))
             }
           >

--- a/src/components/Layout/DockLaunchMenuItems.tsx
+++ b/src/components/Layout/DockLaunchMenuItems.tsx
@@ -5,6 +5,8 @@ import { BrandMark, Workflow } from "@/components/icons";
 import { useRecipeStore } from "@/store/recipeStore";
 import { useActionMruStore } from "@/store/actionMruStore";
 import type { RecipeContext } from "@/utils/recipeVariables";
+import { notifyRecipeSpawnFailures } from "@/utils/recipeNotify";
+import { logError } from "@/utils/logger";
 import { actionService } from "@/services/ActionService";
 import type { ActionSource, AgentAvailabilityState } from "@shared/types";
 import { isAgentBlocked, isAgentLaunchable } from "@shared/utils/agentAvailability";
@@ -194,9 +196,19 @@ export function DockLaunchMenuItems({
           <C.Item
             key={recipe.id}
             onSelect={() =>
+              // Fire-and-forget, but surface spawn failures — the menu closes
+              // on select, so a toast/inbox entry is the only signal the user
+              // gets when terminals are dropped (e.g. panel limit).
               void useRecipeStore
                 .getState()
-                .runRecipe(recipe.id, cwd, activeWorktreeId ?? undefined, recipeContext)
+                .runRecipeWithResults(recipe.id, cwd, activeWorktreeId ?? undefined, recipeContext)
+                .then((results) =>
+                  notifyRecipeSpawnFailures(results, {
+                    recipeName: recipe.name,
+                    worktreeId: activeWorktreeId ?? undefined,
+                  })
+                )
+                .catch((error) => logError("Recipe launch from dock failed", error))
             }
           >
             <Workflow className="w-3.5 h-3.5 mr-2" />

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -30,6 +30,12 @@ vi.mock("@/utils/recipeNotify", () => ({
   notifyRecipeSpawnFailures: (...args: unknown[]) => notifySpawnFailuresMock(...args),
 }));
 
+const logErrorMock = vi.fn();
+vi.mock("@/utils/logger", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/utils/logger")>()),
+  logError: (...args: unknown[]) => logErrorMock(...args),
+}));
+
 vi.mock("@/store/actionMruStore", () => ({
   useActionMruStore: Object.assign(
     (selector: (s: { getSortedActionMruList: () => typeof mockMruEntries }) => unknown) =>
@@ -118,6 +124,7 @@ beforeEach(() => {
     failed: [],
   });
   notifySpawnFailuresMock.mockReset();
+  logErrorMock.mockReset();
   actionDispatchMock.mockReset();
   recordActionMruMock.mockReset();
   dropdownCloseAutoFocusSpy = null;
@@ -509,7 +516,7 @@ describe("DockLaunchButton", () => {
     await waitFor(() =>
       expect(notifySpawnFailuresMock).toHaveBeenCalledWith(
         { spawned: [{ index: 0, terminalId: "t-0" }], failed: [] },
-        { recipeName: "My recipe", worktreeId: "wt-1" }
+        { recipeName: "My recipe" }
       )
     );
   });
@@ -534,11 +541,29 @@ describe("DockLaunchButton", () => {
 
     fireEvent.click(getByText("My recipe"));
     await waitFor(() =>
-      expect(notifySpawnFailuresMock).toHaveBeenCalledWith(results, {
-        recipeName: "My recipe",
-        worktreeId: undefined,
-      })
+      expect(notifySpawnFailuresMock).toHaveBeenCalledWith(results, { recipeName: "My recipe" })
     );
+  });
+
+  it("logs dock recipe launch rejections without notifying", async () => {
+    mockRecipes = [{ id: "r-1", name: "My recipe", worktreeId: undefined }];
+    runRecipeWithResultsMock.mockRejectedValue(new Error("recipe gone"));
+
+    const { getByText } = render(
+      <DockLaunchButton
+        agents={AGENTS}
+        hasDevPreview={false}
+        onLaunchAgent={vi.fn()}
+        activeWorktreeId={null}
+        cwd="/tmp"
+      />
+    );
+
+    fireEvent.click(getByText("My recipe"));
+    await waitFor(() =>
+      expect(logErrorMock).toHaveBeenCalledWith("Recipe launch from dock failed", expect.any(Error))
+    );
+    expect(notifySpawnFailuresMock).not.toHaveBeenCalled();
   });
 
   describe("Recently launched band", () => {

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 
 let mockRecipes: Array<{
@@ -9,7 +9,8 @@ let mockRecipes: Array<{
   worktreeId?: string;
 }> = [];
 let mockMruEntries: Array<{ id: string; score: number; lastAccessedAt: number }> = [];
-const runRecipeMock = vi.fn();
+const runRecipeWithResultsMock = vi.fn();
+const notifySpawnFailuresMock = vi.fn();
 const actionDispatchMock = vi.fn();
 const recordActionMruMock = vi.fn();
 let dropdownCloseAutoFocusSpy: ((e: { preventDefault: () => void }) => void) | null = null;
@@ -20,9 +21,13 @@ vi.mock("@/store/recipeStore", () => ({
     (selector: (s: { recipes: typeof mockRecipes }) => unknown) =>
       selector({ recipes: mockRecipes }),
     {
-      getState: () => ({ runRecipe: runRecipeMock }),
+      getState: () => ({ runRecipeWithResults: runRecipeWithResultsMock }),
     }
   ),
+}));
+
+vi.mock("@/utils/recipeNotify", () => ({
+  notifyRecipeSpawnFailures: (...args: unknown[]) => notifySpawnFailuresMock(...args),
 }));
 
 vi.mock("@/store/actionMruStore", () => ({
@@ -108,7 +113,11 @@ const AGENTS: DockLaunchAgent[] = [
 beforeEach(() => {
   mockRecipes = [];
   mockMruEntries = [];
-  runRecipeMock.mockReset();
+  runRecipeWithResultsMock.mockReset().mockResolvedValue({
+    spawned: [{ index: 0, terminalId: "t-0" }],
+    failed: [],
+  });
+  notifySpawnFailuresMock.mockReset();
   actionDispatchMock.mockReset();
   recordActionMruMock.mockReset();
   dropdownCloseAutoFocusSpy = null;
@@ -468,7 +477,7 @@ describe("DockLaunchButton", () => {
     expect(resetPreventDefault).not.toHaveBeenCalled();
   });
 
-  it("invokes runRecipe with cwd, worktreeId, and recipe context when a recipe is selected", () => {
+  it("invokes runRecipeWithResults with cwd, worktreeId, and recipe context when a recipe is selected", async () => {
     mockRecipes = [{ id: "r-1", name: "My recipe", worktreeId: undefined }];
 
     const recipeContext = {
@@ -490,7 +499,46 @@ describe("DockLaunchButton", () => {
     );
 
     fireEvent.click(getByText("My recipe"));
-    expect(runRecipeMock).toHaveBeenCalledWith("r-1", "/path/to/wt", "wt-1", recipeContext);
+    expect(runRecipeWithResultsMock).toHaveBeenCalledWith(
+      "r-1",
+      "/path/to/wt",
+      "wt-1",
+      recipeContext
+    );
+    // Spawn results route through the failure notifier (which no-ops on success).
+    await waitFor(() =>
+      expect(notifySpawnFailuresMock).toHaveBeenCalledWith(
+        { spawned: [{ index: 0, terminalId: "t-0" }], failed: [] },
+        { recipeName: "My recipe", worktreeId: "wt-1" }
+      )
+    );
+  });
+
+  it("surfaces spawn failures from dock-launched recipes via the notifier", async () => {
+    mockRecipes = [{ id: "r-1", name: "My recipe", worktreeId: undefined }];
+    const results = {
+      spawned: [],
+      failed: [{ index: 0, error: "Panel limit reached" }],
+    };
+    runRecipeWithResultsMock.mockResolvedValue(results);
+
+    const { getByText } = render(
+      <DockLaunchButton
+        agents={AGENTS}
+        hasDevPreview={false}
+        onLaunchAgent={vi.fn()}
+        activeWorktreeId={null}
+        cwd="/tmp"
+      />
+    );
+
+    fireEvent.click(getByText("My recipe"));
+    await waitFor(() =>
+      expect(notifySpawnFailuresMock).toHaveBeenCalledWith(results, {
+        recipeName: "My recipe",
+        worktreeId: undefined,
+      })
+    );
   });
 
   describe("Recently launched band", () => {

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -13,6 +13,7 @@ import { useGitHubConfigStore } from "@github-renderer/stores/githubConfigStore"
 import { notify } from "@/lib/notify";
 import { systemClient } from "@/clients/systemClient";
 import { useRecipeStore } from "@/store/recipeStore";
+import { notifyRecipeSpawnFailures } from "@/utils/recipeNotify";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { logError } from "@/utils/logger";
 import { extractClosingIssueNumber } from "@/utils/closingIssueRef";
@@ -106,7 +107,7 @@ export function NewWorktreeDialog({
   const githubConfig = useGitHubConfigStore((s) => s.config);
   const initializeGitHubConfig = useGitHubConfigStore((s) => s.initialize);
   const refreshGitHubConfig = useGitHubConfigStore((s) => s.refresh);
-  const { recipes, runRecipe } = useRecipeStore();
+  const { recipes, runRecipeWithResults } = useRecipeStore();
   const currentProject = useProjectStore((s) => s.currentProject);
   const projectId = currentProject?.id ?? "";
   const lastSelectedWorktreeRecipeId = lastSelectedWorktreeRecipeIdByProject[projectId];
@@ -637,11 +638,20 @@ export function NewWorktreeDialog({
           }
         } else if (snapSelectedRecipe) {
           try {
-            await runRecipe(snapSelectedRecipe.id, snapWorktreePath, worktreeId, {
-              issueNumber: snapIssue?.number,
-              prNumber: snapInitialPR?.number,
-              worktreePath: snapWorktreePath,
-              branchName: fullBranchName,
+            const results = await runRecipeWithResults(
+              snapSelectedRecipe.id,
+              snapWorktreePath,
+              worktreeId,
+              {
+                issueNumber: snapIssue?.number,
+                prNumber: snapInitialPR?.number,
+                worktreePath: snapWorktreePath,
+                branchName: fullBranchName,
+              }
+            );
+            notifyRecipeSpawnFailures(results, {
+              recipeName: snapSelectedRecipe.name,
+              projectId,
             });
           } catch (recipeErr) {
             const message = formatErrorMessage(recipeErr, "Failed to run recipe");
@@ -662,9 +672,14 @@ export function NewWorktreeDialog({
                 {
                   label: "Retry recipe",
                   onClick: () => {
-                    runRecipe(recipeId, recipePath, recipeWorktreeId, recipeContext).catch((err) =>
-                      logError("Failed to run recipe", err)
-                    );
+                    runRecipeWithResults(recipeId, recipePath, recipeWorktreeId, recipeContext)
+                      .then((results) =>
+                        notifyRecipeSpawnFailures(results, {
+                          recipeName: snapSelectedRecipe.name,
+                          projectId,
+                        })
+                      )
+                      .catch((err) => logError("Failed to run recipe", err));
                   },
                 },
               ],

--- a/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
@@ -4,6 +4,7 @@ import { logError } from "@/utils/logger";
 import { actionService } from "@/services/ActionService";
 import { useMenuActionSource } from "@/components/ui/menu-source";
 import { useRecipeStore } from "@/store/recipeStore";
+import { notifyRecipeSpawnFailures } from "@/utils/recipeNotify";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { closeAndAnnounce } from "@/lib/accessibility";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
@@ -57,7 +58,7 @@ export function useWorktreeActions({
   onCopyTree: () => Promise<string | undefined> | void;
   teardownCommands: string[];
 }): UseWorktreeActionsResult {
-  const runRecipe = useRecipeStore((state) => state.runRecipe);
+  const runRecipeWithResults = useRecipeStore((state) => state.runRecipeWithResults);
 
   const [runningRecipeId, setRunningRecipeId] = useState<string | null>(null);
 
@@ -184,11 +185,16 @@ export function useWorktreeActions({
 
       setRunningRecipeId(recipeId);
       try {
-        await runRecipe(recipeId, worktree.path, worktree.id, {
+        const recipeState = useRecipeStore.getState();
+        const results = await runRecipeWithResults(recipeId, worktree.path, worktree.id, {
           issueNumber: worktree.issueNumber,
           prNumber: worktree.linked?.pr?.ref.number,
           worktreePath: worktree.path,
           branchName: worktree.branch,
+        });
+        notifyRecipeSpawnFailures(results, {
+          recipeName: recipeState.getRecipeById(recipeId)?.name,
+          projectId: recipeState.currentProjectId ?? undefined,
         });
       } catch (error) {
         logError("Failed to run recipe", error);
@@ -196,7 +202,7 @@ export function useWorktreeActions({
         setRunningRecipeId(null);
       }
     },
-    [runRecipe, worktree.path, worktree.id, runningRecipeId]
+    [runRecipeWithResults, worktree.path, worktree.id, runningRecipeId]
   );
 
   const handleDockAll = useCallback(() => {

--- a/src/services/actions/definitions/__tests__/recipeActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/recipeActions.adversarial.test.ts
@@ -240,8 +240,20 @@ describe("recipeActions adversarial", () => {
     expect(notifySpawnFailuresMock).toHaveBeenCalledWith(results, {
       recipeName: "My recipe",
       projectId: "proj-1",
-      worktreeId: "wt-1",
     });
+  });
+
+  it("recipe.run re-throws store rejections without notifying", async () => {
+    const runRecipeWithResults = vi.fn().mockRejectedValue(new Error("recipe gone"));
+    setRecipeState({ runRecipeWithResults });
+    setWorktreeMap(new Map([["wt-1", { path: "/repo/wt" }]]));
+
+    const run = setupActions();
+
+    await expect(run("recipe.run", { recipeId: "r1", worktreeId: "wt-1" }, {})).rejects.toThrow(
+      "recipe gone"
+    );
+    expect(notifySpawnFailuresMock).not.toHaveBeenCalled();
   });
 
   it("recipe.run throws when no terminals spawned but still notifies first", async () => {

--- a/src/services/actions/definitions/__tests__/recipeActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/recipeActions.adversarial.test.ts
@@ -9,8 +9,13 @@ const createWorktreeStoreMock = vi.hoisted(() => ({
   getCurrentViewStore: vi.fn(),
 }));
 
+const notifySpawnFailuresMock = vi.hoisted(() => vi.fn());
+
 vi.mock("@/store/recipeStore", () => ({ useRecipeStore: recipeStoreMock }));
 vi.mock("@/store/createWorktreeStore", () => createWorktreeStoreMock);
+vi.mock("@/utils/recipeNotify", () => ({
+  notifyRecipeSpawnFailures: notifySpawnFailuresMock,
+}));
 
 import { registerRecipeActions } from "../recipeActions";
 
@@ -64,6 +69,8 @@ afterEach(() => {
   Object.defineProperty(globalThis, "window", { value: undefined, configurable: true });
 });
 
+const OK_SPAWN_RESULTS = { spawned: [{ index: 0, terminalId: "term-1" }], failed: [] };
+
 function setRecipeState(state: {
   recipes?: Array<{
     id: string;
@@ -74,7 +81,7 @@ function setRecipeState(state: {
   }>;
   isLoading?: boolean;
   currentProjectId?: string | null;
-  runRecipe?: ReturnType<typeof vi.fn>;
+  runRecipeWithResults?: ReturnType<typeof vi.fn>;
   saveToRepo?: ReturnType<typeof vi.fn>;
   deleteRecipe?: ReturnType<typeof vi.fn>;
   generateRecipeFromActiveTerminals?: (id: string) => unknown[];
@@ -83,7 +90,8 @@ function setRecipeState(state: {
     recipes: state.recipes ?? [],
     isLoading: state.isLoading ?? false,
     currentProjectId: "currentProjectId" in state ? state.currentProjectId : "proj-1",
-    runRecipe: state.runRecipe ?? vi.fn().mockResolvedValue(undefined),
+    getRecipeById: vi.fn((id: string) => (state.recipes ?? []).find((r) => r.id === id)),
+    runRecipeWithResults: state.runRecipeWithResults ?? vi.fn().mockResolvedValue(OK_SPAWN_RESULTS),
     saveToRepo: state.saveToRepo ?? vi.fn().mockResolvedValue(undefined),
     deleteRecipe: state.deleteRecipe ?? vi.fn().mockResolvedValue(undefined),
     generateRecipeFromActiveTerminals: state.generateRecipeFromActiveTerminals ?? vi.fn(() => []),
@@ -98,8 +106,8 @@ function setWorktreeMap(map: Map<string, Worktree>) {
 
 describe("recipeActions adversarial", () => {
   it("recipe.run prefers explicit worktreeId over ctx.activeWorktreeId", async () => {
-    const runRecipe = vi.fn().mockResolvedValue(undefined);
-    setRecipeState({ runRecipe });
+    const runRecipeWithResults = vi.fn().mockResolvedValue(OK_SPAWN_RESULTS);
+    setRecipeState({ runRecipeWithResults });
     setWorktreeMap(
       new Map([
         ["wt-arg", { path: "/repo/arg", branch: "feat/a", issueNumber: 1 }],
@@ -114,7 +122,7 @@ describe("recipeActions adversarial", () => {
       { activeWorktreeId: "wt-ctx", projectPath: "/repo" }
     );
 
-    expect(runRecipe).toHaveBeenCalledWith(
+    expect(runRecipeWithResults).toHaveBeenCalledWith(
       "r1",
       "/repo/arg",
       "wt-arg",
@@ -129,8 +137,8 @@ describe("recipeActions adversarial", () => {
   });
 
   it("recipe.run threads ctx.dispatchSource into the run options", async () => {
-    const runRecipe = vi.fn().mockResolvedValue(undefined);
-    setRecipeState({ runRecipe });
+    const runRecipeWithResults = vi.fn().mockResolvedValue(OK_SPAWN_RESULTS);
+    setRecipeState({ runRecipeWithResults });
     setWorktreeMap(new Map([["wt-1", { path: "/repo/wt", branch: "feat/x" }]]));
 
     const run = setupActions();
@@ -140,7 +148,7 @@ describe("recipeActions adversarial", () => {
       { dispatchSource: "agent", projectPath: "/repo" }
     );
 
-    expect(runRecipe).toHaveBeenCalledWith(
+    expect(runRecipeWithResults).toHaveBeenCalledWith(
       "r1",
       "/repo/wt",
       "wt-1",
@@ -150,8 +158,8 @@ describe("recipeActions adversarial", () => {
   });
 
   it("recipe.run falls back to ctx.projectPath when the target worktree is missing from the view store", async () => {
-    const runRecipe = vi.fn().mockResolvedValue(undefined);
-    setRecipeState({ runRecipe });
+    const runRecipeWithResults = vi.fn().mockResolvedValue(OK_SPAWN_RESULTS);
+    setRecipeState({ runRecipeWithResults });
     setWorktreeMap(new Map());
 
     const run = setupActions();
@@ -161,7 +169,7 @@ describe("recipeActions adversarial", () => {
       { activeWorktreeId: "wt-missing", projectPath: "/repo/main" }
     );
 
-    expect(runRecipe).toHaveBeenCalledWith(
+    expect(runRecipeWithResults).toHaveBeenCalledWith(
       "r1",
       "/repo/main",
       "wt-missing",
@@ -176,8 +184,8 @@ describe("recipeActions adversarial", () => {
   });
 
   it("recipe.run throws when no path source exists", async () => {
-    const runRecipe = vi.fn().mockResolvedValue(undefined);
-    setRecipeState({ runRecipe });
+    const runRecipeWithResults = vi.fn().mockResolvedValue(OK_SPAWN_RESULTS);
+    setRecipeState({ runRecipeWithResults });
     setWorktreeMap(new Map());
 
     const run = setupActions();
@@ -185,7 +193,74 @@ describe("recipeActions adversarial", () => {
     await expect(run("recipe.run", { recipeId: "r1" }, {})).rejects.toThrow(
       /No worktree or project path/
     );
-    expect(runRecipe).not.toHaveBeenCalled();
+    expect(runRecipeWithResults).not.toHaveBeenCalled();
+  });
+
+  it("recipe.run returns structured spawn counts on full success", async () => {
+    const runRecipeWithResults = vi.fn().mockResolvedValue({
+      spawned: [
+        { index: 0, terminalId: "t-0" },
+        { index: 1, terminalId: "t-1" },
+      ],
+      failed: [],
+    });
+    setRecipeState({ runRecipeWithResults });
+    setWorktreeMap(new Map([["wt-1", { path: "/repo/wt" }]]));
+
+    const run = setupActions();
+    const result = await run("recipe.run", { recipeId: "r1", worktreeId: "wt-1" }, {});
+
+    expect(result).toEqual({ spawnedCount: 2, failedCount: 0, failedTerminals: [] });
+  });
+
+  it("recipe.run resolves with failure details on partial spawn and notifies", async () => {
+    const results = {
+      spawned: [{ index: 0, terminalId: "t-0" }],
+      failed: [{ index: 1, error: "Panel limit reached" }],
+    };
+    const runRecipeWithResults = vi.fn().mockResolvedValue(results);
+    setRecipeState({
+      recipes: [{ id: "r1", name: "My recipe", terminals: [] }],
+      runRecipeWithResults,
+    });
+    setWorktreeMap(new Map([["wt-1", { path: "/repo/wt" }]]));
+
+    const run = setupActions();
+    const result = await run(
+      "recipe.run",
+      { recipeId: "r1", worktreeId: "wt-1" },
+      { projectId: "proj-1" }
+    );
+
+    expect(result).toEqual({
+      spawnedCount: 1,
+      failedCount: 1,
+      failedTerminals: [{ index: 1, reason: "Panel limit reached" }],
+    });
+    expect(notifySpawnFailuresMock).toHaveBeenCalledWith(results, {
+      recipeName: "My recipe",
+      projectId: "proj-1",
+      worktreeId: "wt-1",
+    });
+  });
+
+  it("recipe.run throws when no terminals spawned but still notifies first", async () => {
+    const results = {
+      spawned: [],
+      failed: [
+        { index: 0, error: "Panel limit reached" },
+        { index: 1, error: "Panel limit reached" },
+      ],
+    };
+    setRecipeState({ runRecipeWithResults: vi.fn().mockResolvedValue(results) });
+    setWorktreeMap(new Map([["wt-1", { path: "/repo/wt" }]]));
+
+    const run = setupActions();
+
+    await expect(run("recipe.run", { recipeId: "r1", worktreeId: "wt-1" }, {})).rejects.toThrow(
+      /Recipe launch failed: Panel limit reached/
+    );
+    expect(notifySpawnFailuresMock).toHaveBeenCalledWith(results, expect.any(Object));
   });
 
   it("recipe.list with worktreeId includes global recipes (no worktreeId) and worktree-scoped recipes", async () => {

--- a/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
@@ -34,7 +34,11 @@ const selectorMock = vi.hoisted(() => ({
 }));
 
 const gitGetStagingStatusMock = vi.hoisted(() => vi.fn());
+const notifySpawnFailuresMock = vi.hoisted(() => vi.fn());
 
+vi.mock("@/utils/recipeNotify", () => ({
+  notifyRecipeSpawnFailures: notifySpawnFailuresMock,
+}));
 vi.mock("@/clients", () => ({
   worktreeClient: worktreeClientMock,
   githubClient: githubClientMock,
@@ -112,13 +116,25 @@ function setAssignPreference(value: boolean) {
   preferencesStoreMock.getState.mockReturnValue({ assignWorktreeToSelf: value });
 }
 
-function setRecipe(recipeId: string | null, runImpl?: () => Promise<void>) {
-  const runRecipe = vi.fn().mockImplementation(runImpl ?? (async () => {}));
+type SpawnResults = {
+  spawned: Array<{ index: number; terminalId: string }>;
+  failed: Array<{ index: number; error: string }>;
+};
+
+const OK_SPAWN_RESULTS: SpawnResults = {
+  spawned: [{ index: 0, terminalId: "term-recipe" }],
+  failed: [],
+};
+
+function setRecipe(recipeId: string | null, runImpl?: () => Promise<SpawnResults>) {
+  const runRecipeWithResults = vi
+    .fn()
+    .mockImplementation(runImpl ?? (async () => OK_SPAWN_RESULTS));
   recipeStoreMock.getState.mockReturnValue({
-    getRecipeById: vi.fn().mockReturnValue(recipeId ? { id: recipeId } : null),
-    runRecipe,
+    getRecipeById: vi.fn().mockReturnValue(recipeId ? { id: recipeId, name: "Recipe" } : null),
+    runRecipeWithResults,
   });
-  return runRecipe;
+  return runRecipeWithResults;
 }
 
 function setPanelTerminals(
@@ -281,27 +297,28 @@ describe("worktree.createWithRecipe", () => {
       url: "u",
     });
     worktreeClientMock.getDefaultPath.mockResolvedValue("/repo/contrib/feature-x");
-    const runRecipe = vi.fn().mockResolvedValue(undefined);
-    recipeStoreMock.getState.mockReturnValue({
-      getRecipeById: vi.fn().mockReturnValue({ id: "recipe-1" }),
-      runRecipe,
-    });
+    const runRecipeWithResults = setRecipe("recipe-1");
     const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
     const result = (await def.run(
       { pullRequestNumber: 42, recipeId: "recipe-1" },
       {} as never
     )) as Record<string, unknown>;
-    expect(runRecipe).toHaveBeenCalledWith("recipe-1", "/repo/contrib/feature-x", "wt-new", {
-      worktreePath: "/repo/contrib/feature-x",
-      branchName: "contrib/feature-x",
-      issueNumber: undefined,
-      prNumber: 42,
-    });
+    expect(runRecipeWithResults).toHaveBeenCalledWith(
+      "recipe-1",
+      "/repo/contrib/feature-x",
+      "wt-new",
+      {
+        worktreePath: "/repo/contrib/feature-x",
+        branchName: "contrib/feature-x",
+        issueNumber: undefined,
+        prNumber: 42,
+      }
+    );
     expect(result.recipeLaunched).toBe(true);
   });
 
   it("passes spawnedBy through to recipes launched from MCP-created worktrees", async () => {
-    const runRecipe = setRecipe("recipe-1");
+    const runRecipeWithResults = setRecipe("recipe-1");
     const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
 
     await def.run(
@@ -309,7 +326,7 @@ describe("worktree.createWithRecipe", () => {
       {} as never
     );
 
-    expect(runRecipe).toHaveBeenCalledWith(
+    expect(runRecipeWithResults).toHaveBeenCalledWith(
       "recipe-1",
       "/repo/feature/issue-6609-add-tools",
       "wt-new",
@@ -317,7 +334,7 @@ describe("worktree.createWithRecipe", () => {
         worktreePath: "/repo/feature/issue-6609-add-tools",
         branchName: "feature/issue-6609-add-tools",
       }),
-      { spawnedBy: "mcp" }
+      { spawnedBy: "mcp", focusPolicy: undefined }
     );
   });
 
@@ -338,6 +355,69 @@ describe("worktree.createWithRecipe", () => {
       expect(payload.partialResult.recipeLaunched).toBe(false);
     }
     expect(worktreeClientMock.create).toHaveBeenCalled();
+  });
+
+  it("reports recipeLaunched: false when every recipe terminal fails to spawn", async () => {
+    const results = {
+      spawned: [],
+      failed: [
+        { index: 0, error: "Panel limit reached" },
+        { index: 1, error: "Panel limit reached" },
+      ],
+    };
+    setRecipe("recipe-1", async () => results);
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+
+    const result = (await def.run(
+      { branchName: "feature/foo", recipeId: "recipe-1" },
+      {} as never
+    )) as Record<string, unknown>;
+
+    expect(result.recipeLaunched).toBe(false);
+    expect(result.spawnedTerminalCount).toBe(0);
+    expect(result.failedTerminalCount).toBe(2);
+    expect(notifySpawnFailuresMock).toHaveBeenCalledWith(results, {
+      recipeName: "Recipe",
+      projectId: "p1",
+      worktreeId: "wt-new",
+    });
+  });
+
+  it("reports recipeLaunched: true with failure counts on partial spawn", async () => {
+    setRecipe("recipe-1", async () => ({
+      spawned: [{ index: 0, terminalId: "t-0" }],
+      failed: [{ index: 1, error: "Panel limit reached" }],
+    }));
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+
+    const result = (await def.run(
+      { branchName: "feature/foo", recipeId: "recipe-1" },
+      {} as never
+    )) as Record<string, unknown>;
+
+    expect(result.recipeLaunched).toBe(true);
+    expect(result.spawnedTerminalCount).toBe(1);
+    expect(result.failedTerminalCount).toBe(1);
+  });
+
+  it("does not notify spawn failures when all recipe terminals spawn", async () => {
+    setRecipe("recipe-1");
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+
+    const result = (await def.run(
+      { branchName: "feature/foo", recipeId: "recipe-1" },
+      {} as never
+    )) as Record<string, unknown>;
+
+    expect(result.recipeLaunched).toBe(true);
+    expect(result.spawnedTerminalCount).toBe(1);
+    expect(result.failedTerminalCount).toBe(0);
+    // The helper itself no-ops on zero failures; the action still routes
+    // results through it so the gate lives in one place.
+    expect(notifySpawnFailuresMock).toHaveBeenCalledWith(
+      OK_SPAWN_RESULTS,
+      expect.objectContaining({ worktreeId: "wt-new" })
+    );
   });
 
   it("treats empty-string headRefName the same as missing", async () => {
@@ -488,6 +568,48 @@ describe("workflow.startWorkOnIssue", () => {
     ).rejects.toThrow(/PARTIAL_SUCCESS:/);
     expect(worktreeClientMock.create).toHaveBeenCalled();
     expect(callbacks.onLaunchAgent).not.toHaveBeenCalled();
+  });
+
+  it("reports recipeLaunched: false when every recipe terminal fails to spawn", async () => {
+    githubClientMock.getIssueByNumber.mockResolvedValue({ number: 1, title: "t", url: "u" });
+    const results = {
+      spawned: [],
+      failed: [{ index: 0, error: "Panel limit reached" }],
+    };
+    setRecipe("recipe-1", async () => results);
+    const def = setupActions(makeCallbacks())("workflow.startWorkOnIssue");
+
+    const result = (await def.run(
+      { issueNumber: 1, agentId: "claude", recipeId: "recipe-1" },
+      {} as never
+    )) as Record<string, unknown>;
+
+    expect(result.recipeLaunched).toBe(false);
+    expect(result.spawnedTerminalCount).toBe(0);
+    expect(result.failedTerminalCount).toBe(1);
+    expect(notifySpawnFailuresMock).toHaveBeenCalledWith(results, {
+      recipeName: "Recipe",
+      projectId: "p1",
+      worktreeId: "wt-new",
+    });
+  });
+
+  it("reports recipeLaunched: true with failure counts on partial spawn", async () => {
+    githubClientMock.getIssueByNumber.mockResolvedValue({ number: 1, title: "t", url: "u" });
+    setRecipe("recipe-1", async () => ({
+      spawned: [{ index: 0, terminalId: "t-0" }],
+      failed: [{ index: 1, error: "PTY spawn failed" }],
+    }));
+    const def = setupActions(makeCallbacks())("workflow.startWorkOnIssue");
+
+    const result = (await def.run(
+      { issueNumber: 1, agentId: "claude", recipeId: "recipe-1" },
+      {} as never
+    )) as Record<string, unknown>;
+
+    expect(result.recipeLaunched).toBe(true);
+    expect(result.spawnedTerminalCount).toBe(1);
+    expect(result.failedTerminalCount).toBe(1);
   });
 
   it("agent.launch throwing (not just returning null) becomes PARTIAL_SUCCESS", async () => {

--- a/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
@@ -312,7 +312,8 @@ describe("worktree.createWithRecipe", () => {
         branchName: "contrib/feature-x",
         issueNumber: undefined,
         prNumber: 42,
-      }
+      },
+      { spawnedBy: undefined, focusPolicy: undefined, dispatchSource: undefined }
     );
     expect(result.recipeLaunched).toBe(true);
   });
@@ -334,7 +335,24 @@ describe("worktree.createWithRecipe", () => {
         worktreePath: "/repo/feature/issue-6609-add-tools",
         branchName: "feature/issue-6609-add-tools",
       }),
-      { spawnedBy: "mcp", focusPolicy: undefined }
+      { spawnedBy: "mcp", focusPolicy: undefined, dispatchSource: undefined }
+    );
+  });
+
+  it("forwards ctx.dispatchSource so agent-driven recipe runs stay capped", async () => {
+    const runRecipeWithResults = setRecipe("recipe-1");
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+
+    await def.run({ branchName: "feature/foo", recipeId: "recipe-1" }, {
+      dispatchSource: "agent",
+    } as never);
+
+    expect(runRecipeWithResults).toHaveBeenCalledWith(
+      "recipe-1",
+      expect.any(String),
+      "wt-new",
+      expect.any(Object),
+      expect.objectContaining({ dispatchSource: "agent" })
     );
   });
 
@@ -379,7 +397,6 @@ describe("worktree.createWithRecipe", () => {
     expect(notifySpawnFailuresMock).toHaveBeenCalledWith(results, {
       recipeName: "Recipe",
       projectId: "p1",
-      worktreeId: "wt-new",
     });
   });
 
@@ -416,8 +433,20 @@ describe("worktree.createWithRecipe", () => {
     // results through it so the gate lives in one place.
     expect(notifySpawnFailuresMock).toHaveBeenCalledWith(
       OK_SPAWN_RESULTS,
-      expect.objectContaining({ worktreeId: "wt-new" })
+      expect.objectContaining({ recipeName: "Recipe" })
     );
+  });
+
+  it("does not notify when the recipe store throws (PARTIAL_SUCCESS path)", async () => {
+    setRecipe("recipe-1", async () => {
+      throw new Error("recipe boom");
+    });
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+
+    await expect(
+      def.run({ branchName: "feature/foo", recipeId: "recipe-1" }, {} as never)
+    ).rejects.toThrow(/PARTIAL_SUCCESS:/);
+    expect(notifySpawnFailuresMock).not.toHaveBeenCalled();
   });
 
   it("treats empty-string headRefName the same as missing", async () => {
@@ -590,7 +619,6 @@ describe("workflow.startWorkOnIssue", () => {
     expect(notifySpawnFailuresMock).toHaveBeenCalledWith(results, {
       recipeName: "Recipe",
       projectId: "p1",
-      worktreeId: "wt-new",
     });
   });
 
@@ -610,6 +638,29 @@ describe("workflow.startWorkOnIssue", () => {
     expect(result.recipeLaunched).toBe(true);
     expect(result.spawnedTerminalCount).toBe(1);
     expect(result.failedTerminalCount).toBe(1);
+  });
+
+  it("PARTIAL_SUCCESS from a failed agent launch preserves partial spawn counts", async () => {
+    githubClientMock.getIssueByNumber.mockResolvedValue({ number: 1, title: "t", url: "u" });
+    setRecipe("recipe-1", async () => ({
+      spawned: [{ index: 0, terminalId: "t-0" }],
+      failed: [{ index: 1, error: "Panel limit reached" }],
+    }));
+    const callbacks = makeCallbacks();
+    callbacks.onLaunchAgent.mockRejectedValue(new Error("PTY spawn failed"));
+    const def = setupActions(callbacks)("workflow.startWorkOnIssue");
+
+    try {
+      await def.run({ issueNumber: 1, agentId: "claude", recipeId: "recipe-1" }, {} as never);
+      throw new Error("expected throw");
+    } catch (err) {
+      const message = (err as Error).message;
+      expect(message).toContain("PARTIAL_SUCCESS:");
+      const payload = JSON.parse(message.slice(message.indexOf("{")));
+      expect(payload.partialResult.recipeLaunched).toBe(true);
+      expect(payload.partialResult.spawnedTerminalCount).toBe(1);
+      expect(payload.partialResult.failedTerminalCount).toBe(1);
+    }
   });
 
   it("agent.launch throwing (not just returning null) becomes PARTIAL_SUCCESS", async () => {

--- a/src/services/actions/definitions/recipeActions.ts
+++ b/src/services/actions/definitions/recipeActions.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import type { ActionContext } from "@shared/types/actions";
 import { useRecipeStore } from "@/store/recipeStore";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
+import { notifyRecipeSpawnFailures } from "@/utils/recipeNotify";
 import {
   TerminalSpawnSourceSchema,
   RecipeSummarySchema,
@@ -67,6 +68,14 @@ export function registerRecipeActions(actions: ActionRegistry, _callbacks: Actio
         spawnedBy: TerminalSpawnSourceSchema.optional(),
         focusPolicy: AddPanelFocusPolicySchema.optional(),
       }),
+      resultSchema: z.object({
+        spawnedCount: z.number().int().nonnegative(),
+        failedCount: z.number().int().nonnegative(),
+        failedTerminals: z.array(
+          z.object({ index: z.number().int().nonnegative(), reason: z.string() })
+        ),
+      }),
+      mcpOutputSchema: true,
       run: async ({ recipeId, worktreeId, spawnedBy, focusPolicy }, ctx: ActionContext) => {
         const targetWorktreeId = worktreeId ?? ctx.activeWorktreeId ?? undefined;
         const worktree = targetWorktreeId
@@ -87,13 +96,33 @@ export function registerRecipeActions(actions: ActionRegistry, _callbacks: Actio
         // Always forward dispatchSource so runRecipeWithResults can apply the
         // agent-source terminal cap. ActionService sets ctx.dispatchSource on
         // every dispatch, so this is the live path for all real invocations.
-        await useRecipeStore
+        const recipeName = useRecipeStore.getState().getRecipeById(recipeId)?.name;
+        const results = await useRecipeStore
           .getState()
-          .runRecipe(recipeId, worktreePath, targetWorktreeId, recipeContext, {
+          .runRecipeWithResults(recipeId, worktreePath, targetWorktreeId, recipeContext, {
             spawnedBy,
             focusPolicy,
             dispatchSource: ctx.dispatchSource,
           });
+
+        // Toast/inbox first so palette users see the failure even though the
+        // dispatch below also rejects (the rejection only reaches MCP callers).
+        notifyRecipeSpawnFailures(results, {
+          recipeName,
+          projectId: ctx.projectId,
+          worktreeId: targetWorktreeId,
+        });
+
+        if (results.spawned.length === 0 && results.failed.length > 0) {
+          const reasons = Array.from(new Set(results.failed.map((f) => f.error))).join("; ");
+          throw new Error(`Recipe launch failed: ${reasons}`);
+        }
+
+        return {
+          spawnedCount: results.spawned.length,
+          failedCount: results.failed.length,
+          failedTerminals: results.failed.map((f) => ({ index: f.index, reason: f.error })),
+        };
       },
     })
   );

--- a/src/services/actions/definitions/recipeActions.ts
+++ b/src/services/actions/definitions/recipeActions.ts
@@ -110,7 +110,6 @@ export function registerRecipeActions(actions: ActionRegistry, _callbacks: Actio
         notifyRecipeSpawnFailures(results, {
           recipeName,
           projectId: ctx.projectId,
-          worktreeId: targetWorktreeId,
         });
 
         if (results.spawned.length === 0 && results.failed.length > 0) {

--- a/src/services/actions/definitions/workflowCreationActions.ts
+++ b/src/services/actions/definitions/workflowCreationActions.ts
@@ -1,6 +1,7 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import { defineAction } from "../defineAction";
 import { z } from "zod";
+import type { ActionContext } from "@shared/types/actions";
 // eslint-disable-next-line no-restricted-imports
 import { worktreeClient, githubClient, copyTreeClient } from "@/clients";
 import { useProjectStore } from "@/store/projectStore";
@@ -87,18 +88,21 @@ export function registerWorkflowCreationActions(
         assignedUsername: z.string().nullable(),
         assignmentError: z.string().nullable(),
       }),
-      run: async ({
-        branchName,
-        baseBranch,
-        recipeId,
-        fromRemote,
-        useExistingBranch,
-        issueNumber,
-        pullRequestNumber,
-        assignToSelf,
-        spawnedBy,
-        focusPolicy,
-      }) => {
+      run: async (
+        {
+          branchName,
+          baseBranch,
+          recipeId,
+          fromRemote,
+          useExistingBranch,
+          issueNumber,
+          pullRequestNumber,
+          assignToSelf,
+          spawnedBy,
+          focusPolicy,
+        },
+        ctx: ActionContext
+      ) => {
         if (issueNumber !== undefined && pullRequestNumber !== undefined) {
           throw new Error("issueNumber and pullRequestNumber are mutually exclusive");
         }
@@ -195,17 +199,16 @@ export function registerWorkflowCreationActions(
               issueNumber,
               prNumber: pullRequestNumber,
             };
-            const results =
-              spawnedBy === undefined && focusPolicy === undefined
-                ? await useRecipeStore
-                    .getState()
-                    .runRecipeWithResults(recipeId, path, worktreeId, recipeContext)
-                : await useRecipeStore
-                    .getState()
-                    .runRecipeWithResults(recipeId, path, worktreeId, recipeContext, {
-                      spawnedBy,
-                      focusPolicy,
-                    });
+            // Forward dispatchSource so runRecipeWithResults applies the
+            // agent-source terminal cap to MCP-driven worktree+recipe combos,
+            // matching recipe.run.
+            const results = await useRecipeStore
+              .getState()
+              .runRecipeWithResults(recipeId, path, worktreeId, recipeContext, {
+                spawnedBy,
+                focusPolicy,
+                dispatchSource: ctx.dispatchSource,
+              });
             // "Launched" means at least one terminal actually spawned — a run
             // where every terminal was dropped (e.g. panel limit) must not
             // report success to agent callers.
@@ -215,7 +218,6 @@ export function registerWorkflowCreationActions(
             notifyRecipeSpawnFailures(results, {
               recipeName: useRecipeStore.getState().getRecipeById(recipeId)?.name,
               projectId: currentProject.id,
-              worktreeId,
             });
           } catch (err) {
             throw partialSuccessError(
@@ -332,17 +334,20 @@ export function registerWorkflowCreationActions(
         assignmentError: z.string().nullable(),
         contextInjected: z.boolean(),
       }),
-      run: async ({
-        issueNumber,
-        agentId,
-        branchName,
-        baseBranch,
-        recipeId,
-        assignToSelf,
-        injectContext,
-        spawnedBy,
-        focusPolicy,
-      }) => {
+      run: async (
+        {
+          issueNumber,
+          agentId,
+          branchName,
+          baseBranch,
+          recipeId,
+          assignToSelf,
+          injectContext,
+          spawnedBy,
+          focusPolicy,
+        },
+        ctx: ActionContext
+      ) => {
         const currentProject = useProjectStore.getState().currentProject;
         if (!currentProject) {
           throw new Error("No active project");
@@ -410,17 +415,16 @@ export function registerWorkflowCreationActions(
               branchName: availableBranch,
               issueNumber: issue.number,
             };
-            const results =
-              spawnedBy === undefined && focusPolicy === undefined
-                ? await useRecipeStore
-                    .getState()
-                    .runRecipeWithResults(recipeId, worktreePath, worktreeId, recipeContext)
-                : await useRecipeStore
-                    .getState()
-                    .runRecipeWithResults(recipeId, worktreePath, worktreeId, recipeContext, {
-                      spawnedBy,
-                      focusPolicy,
-                    });
+            // Forward dispatchSource so runRecipeWithResults applies the
+            // agent-source terminal cap to MCP-driven worktree+recipe combos,
+            // matching recipe.run.
+            const results = await useRecipeStore
+              .getState()
+              .runRecipeWithResults(recipeId, worktreePath, worktreeId, recipeContext, {
+                spawnedBy,
+                focusPolicy,
+                dispatchSource: ctx.dispatchSource,
+              });
             // "Launched" means at least one terminal actually spawned — a run
             // where every terminal was dropped (e.g. panel limit) must not
             // report success to agent callers.
@@ -430,7 +434,6 @@ export function registerWorkflowCreationActions(
             notifyRecipeSpawnFailures(results, {
               recipeName: useRecipeStore.getState().getRecipeById(recipeId)?.name,
               projectId: currentProject.id,
-              worktreeId,
             });
           } catch (err) {
             throw partialSuccessError(

--- a/src/services/actions/definitions/workflowCreationActions.ts
+++ b/src/services/actions/definitions/workflowCreationActions.ts
@@ -9,6 +9,7 @@ import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { usePreferencesStore } from "@/store/preferencesStore";
 import { TerminalSpawnSourceSchema, AddPanelFocusPolicySchema } from "./schemas";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { notifyRecipeSpawnFailures } from "@/utils/recipeNotify";
 import { partialSuccessError, slugifyForBranch } from "./workflowHelpers";
 
 export function registerWorkflowCreationActions(
@@ -80,6 +81,8 @@ export function registerWorkflowCreationActions(
         worktreePath: z.string(),
         branch: z.string(),
         recipeLaunched: z.boolean(),
+        spawnedTerminalCount: z.number().int().nonnegative(),
+        failedTerminalCount: z.number().int().nonnegative(),
         assignedToSelf: z.boolean(),
         assignedUsername: z.string().nullable(),
         assignmentError: z.string().nullable(),
@@ -182,6 +185,8 @@ export function registerWorkflowCreationActions(
         }
 
         let recipeLaunched = false;
+        let spawnedTerminalCount = 0;
+        let failedTerminalCount = 0;
         if (recipeId) {
           try {
             const recipeContext = {
@@ -190,15 +195,28 @@ export function registerWorkflowCreationActions(
               issueNumber,
               prNumber: pullRequestNumber,
             };
-            if (spawnedBy === undefined && focusPolicy === undefined) {
-              await useRecipeStore.getState().runRecipe(recipeId, path, worktreeId, recipeContext);
-            } else {
-              await useRecipeStore.getState().runRecipe(recipeId, path, worktreeId, recipeContext, {
-                spawnedBy,
-                focusPolicy,
-              });
-            }
-            recipeLaunched = true;
+            const results =
+              spawnedBy === undefined && focusPolicy === undefined
+                ? await useRecipeStore
+                    .getState()
+                    .runRecipeWithResults(recipeId, path, worktreeId, recipeContext)
+                : await useRecipeStore
+                    .getState()
+                    .runRecipeWithResults(recipeId, path, worktreeId, recipeContext, {
+                      spawnedBy,
+                      focusPolicy,
+                    });
+            // "Launched" means at least one terminal actually spawned — a run
+            // where every terminal was dropped (e.g. panel limit) must not
+            // report success to agent callers.
+            recipeLaunched = results.spawned.length > 0;
+            spawnedTerminalCount = results.spawned.length;
+            failedTerminalCount = results.failed.length;
+            notifyRecipeSpawnFailures(results, {
+              recipeName: useRecipeStore.getState().getRecipeById(recipeId)?.name,
+              projectId: currentProject.id,
+              worktreeId,
+            });
           } catch (err) {
             throw partialSuccessError(
               `Recipe ${recipeId} failed to run: ${formatErrorMessage(err, "unknown error")}`,
@@ -207,6 +225,8 @@ export function registerWorkflowCreationActions(
                 worktreePath: path,
                 branch: effectiveBranch,
                 recipeLaunched: false,
+                spawnedTerminalCount: 0,
+                failedTerminalCount: 0,
                 assignedToSelf: false,
                 assignedUsername: null,
                 assignmentError: null,
@@ -242,6 +262,8 @@ export function registerWorkflowCreationActions(
           worktreePath: path,
           branch: effectiveBranch,
           recipeLaunched,
+          spawnedTerminalCount,
+          failedTerminalCount,
           assignedToSelf,
           assignedUsername,
           assignmentError,
@@ -303,6 +325,8 @@ export function registerWorkflowCreationActions(
         branch: z.string(),
         terminalId: z.string().nullable(),
         recipeLaunched: z.boolean(),
+        spawnedTerminalCount: z.number().int().nonnegative(),
+        failedTerminalCount: z.number().int().nonnegative(),
         assignedToSelf: z.boolean(),
         assignedUsername: z.string().nullable(),
         assignmentError: z.string().nullable(),
@@ -377,6 +401,8 @@ export function registerWorkflowCreationActions(
         }
 
         let recipeLaunched = false;
+        let spawnedTerminalCount = 0;
+        let failedTerminalCount = 0;
         if (recipeId) {
           try {
             const recipeContext = {
@@ -384,19 +410,28 @@ export function registerWorkflowCreationActions(
               branchName: availableBranch,
               issueNumber: issue.number,
             };
-            if (spawnedBy === undefined && focusPolicy === undefined) {
-              await useRecipeStore
-                .getState()
-                .runRecipe(recipeId, worktreePath, worktreeId, recipeContext);
-            } else {
-              await useRecipeStore
-                .getState()
-                .runRecipe(recipeId, worktreePath, worktreeId, recipeContext, {
-                  spawnedBy,
-                  focusPolicy,
-                });
-            }
-            recipeLaunched = true;
+            const results =
+              spawnedBy === undefined && focusPolicy === undefined
+                ? await useRecipeStore
+                    .getState()
+                    .runRecipeWithResults(recipeId, worktreePath, worktreeId, recipeContext)
+                : await useRecipeStore
+                    .getState()
+                    .runRecipeWithResults(recipeId, worktreePath, worktreeId, recipeContext, {
+                      spawnedBy,
+                      focusPolicy,
+                    });
+            // "Launched" means at least one terminal actually spawned — a run
+            // where every terminal was dropped (e.g. panel limit) must not
+            // report success to agent callers.
+            recipeLaunched = results.spawned.length > 0;
+            spawnedTerminalCount = results.spawned.length;
+            failedTerminalCount = results.failed.length;
+            notifyRecipeSpawnFailures(results, {
+              recipeName: useRecipeStore.getState().getRecipeById(recipeId)?.name,
+              projectId: currentProject.id,
+              worktreeId,
+            });
           } catch (err) {
             throw partialSuccessError(
               `Recipe ${recipeId} failed to run: ${formatErrorMessage(err, "unknown error")}`,
@@ -409,6 +444,8 @@ export function registerWorkflowCreationActions(
                 branch: availableBranch,
                 terminalId: null,
                 recipeLaunched: false,
+                spawnedTerminalCount: 0,
+                failedTerminalCount: 0,
                 assignedToSelf: false,
                 assignedUsername: null,
                 assignmentError: null,
@@ -443,6 +480,8 @@ export function registerWorkflowCreationActions(
               branch: availableBranch,
               terminalId: null,
               recipeLaunched,
+              spawnedTerminalCount,
+              failedTerminalCount,
               assignedToSelf: false,
               assignedUsername: null,
               assignmentError: null,
@@ -460,6 +499,8 @@ export function registerWorkflowCreationActions(
             branch: availableBranch,
             terminalId: null,
             recipeLaunched,
+            spawnedTerminalCount,
+            failedTerminalCount,
             assignedToSelf: false,
             assignedUsername: null,
             assignmentError: null,
@@ -509,6 +550,8 @@ export function registerWorkflowCreationActions(
           branch: availableBranch,
           terminalId,
           recipeLaunched,
+          spawnedTerminalCount,
+          failedTerminalCount,
           assignedToSelf,
           assignedUsername,
           assignmentError,

--- a/src/utils/__tests__/recipeNotify.test.ts
+++ b/src/utils/__tests__/recipeNotify.test.ts
@@ -38,7 +38,7 @@ describe("notifyRecipeSpawnFailures", () => {
         spawned: [],
         failed: [failure(0, "Panel limit reached"), failure(1, "Panel limit reached")],
       },
-      { recipeName: "Dev setup", projectId: "p1", worktreeId: "wt-1" }
+      { recipeName: "Dev setup", projectId: "p1" }
     );
 
     expect(notifyMock).toHaveBeenCalledTimes(1);
@@ -47,15 +47,18 @@ describe("notifyRecipeSpawnFailures", () => {
     expect(payload.title).toBe("Recipe launch failed");
     expect(payload.message).toContain("'Dev setup'");
     expect(payload.message).toContain("Panel limit reached");
-    expect(payload.context).toEqual({ eventKind: "agent", projectId: "p1", worktreeId: "wt-1" });
+    expect(payload.context).toEqual({ eventKind: "agent", projectId: "p1" });
     // The banned error + priority:"low" combination silently drops the toast.
     expect(payload.priority).toBeUndefined();
+    // worktreeId would trigger notify()'s origin-surface suppression and
+    // swallow the toast when the failing worktree is active — must never be set.
+    expect(payload.context.worktreeId).toBeUndefined();
   });
 
   it("emits a warning when only some terminals failed", () => {
     notifyRecipeSpawnFailures(
       { spawned: [spawned(0), spawned(1)], failed: [failure(2, "Panel limit reached")] },
-      { recipeName: "Dev setup", worktreeId: "wt-1" }
+      { recipeName: "Dev setup" }
     );
 
     expect(notifyMock).toHaveBeenCalledTimes(1);
@@ -64,6 +67,22 @@ describe("notifyRecipeSpawnFailures", () => {
     expect(payload.title).toBe("Recipe partially launched");
     expect(payload.message).toContain("1 of 3 terminals");
     expect(payload.context.eventKind).toBe("agent");
+  });
+
+  it("counts mixed-reason partial failures without relaying a reason", () => {
+    notifyRecipeSpawnFailures(
+      {
+        spawned: [spawned(0), spawned(1)],
+        failed: [failure(2, "Panel limit reached"), failure(3, "spawn ENOENT")],
+      },
+      { recipeName: "Dev setup" }
+    );
+
+    const payload = notifyMock.mock.calls[0]![0];
+    expect(payload.type).toBe("warning");
+    expect(payload.message).toContain("2 of 4 terminals");
+    expect(payload.message).not.toContain("Panel limit reached");
+    expect(payload.message).not.toContain("ENOENT");
   });
 
   it("relays a single shared failure reason but omits mixed reasons", () => {

--- a/src/utils/__tests__/recipeNotify.test.ts
+++ b/src/utils/__tests__/recipeNotify.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const notifyMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/notify", () => ({ notify: notifyMock }));
+
+import { notifyRecipeSpawnFailures } from "../recipeNotify";
+
+function failure(index: number, error: string) {
+  return { index, error };
+}
+
+function spawned(index: number) {
+  return { index, terminalId: `term-${index}` };
+}
+
+beforeEach(() => {
+  notifyMock.mockReset();
+});
+
+describe("notifyRecipeSpawnFailures", () => {
+  it("does nothing when all terminals spawned", () => {
+    notifyRecipeSpawnFailures(
+      { spawned: [spawned(0), spawned(1)], failed: [] },
+      { recipeName: "Dev setup" }
+    );
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for an empty result set", () => {
+    notifyRecipeSpawnFailures({ spawned: [], failed: [] });
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("emits an error when no terminals spawned", () => {
+    notifyRecipeSpawnFailures(
+      {
+        spawned: [],
+        failed: [failure(0, "Panel limit reached"), failure(1, "Panel limit reached")],
+      },
+      { recipeName: "Dev setup", projectId: "p1", worktreeId: "wt-1" }
+    );
+
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+    const payload = notifyMock.mock.calls[0]![0];
+    expect(payload.type).toBe("error");
+    expect(payload.title).toBe("Recipe launch failed");
+    expect(payload.message).toContain("'Dev setup'");
+    expect(payload.message).toContain("Panel limit reached");
+    expect(payload.context).toEqual({ eventKind: "agent", projectId: "p1", worktreeId: "wt-1" });
+    // The banned error + priority:"low" combination silently drops the toast.
+    expect(payload.priority).toBeUndefined();
+  });
+
+  it("emits a warning when only some terminals failed", () => {
+    notifyRecipeSpawnFailures(
+      { spawned: [spawned(0), spawned(1)], failed: [failure(2, "Panel limit reached")] },
+      { recipeName: "Dev setup", worktreeId: "wt-1" }
+    );
+
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+    const payload = notifyMock.mock.calls[0]![0];
+    expect(payload.type).toBe("warning");
+    expect(payload.title).toBe("Recipe partially launched");
+    expect(payload.message).toContain("1 of 3 terminals");
+    expect(payload.context.eventKind).toBe("agent");
+  });
+
+  it("relays a single shared failure reason but omits mixed reasons", () => {
+    notifyRecipeSpawnFailures(
+      { spawned: [], failed: [failure(0, "Panel limit reached"), failure(1, "spawn ENOENT")] },
+      { recipeName: "Dev setup" }
+    );
+
+    const mixed = notifyMock.mock.calls[0]![0];
+    expect(mixed.message).not.toContain("Panel limit reached");
+    expect(mixed.message).not.toContain("ENOENT");
+
+    notifyMock.mockReset();
+    notifyRecipeSpawnFailures(
+      { spawned: [], failed: [failure(0, "spawn ENOENT"), failure(1, "spawn ENOENT")] },
+      { recipeName: "Dev setup" }
+    );
+    expect(notifyMock.mock.calls[0]![0].message).toContain("spawn ENOENT");
+  });
+
+  it("falls back to a generic name when the recipe name is unknown", () => {
+    notifyRecipeSpawnFailures({ spawned: [], failed: [failure(0, "boom")] });
+    expect(notifyMock.mock.calls[0]![0].message).toContain("the recipe");
+  });
+});

--- a/src/utils/recipeNotify.ts
+++ b/src/utils/recipeNotify.ts
@@ -1,0 +1,44 @@
+import { notify } from "@/lib/notify";
+import type { RecipeSpawnResults } from "@/store/recipeStore";
+
+export interface RecipeSpawnNotifyContext {
+  recipeName?: string;
+  projectId?: string;
+  worktreeId?: string;
+}
+
+// Surfaces partial or full recipe spawn failures for launch paths with no
+// panel-owned banner (dock menu, recipe.run action, workflow creation). The
+// RecipeRunner panel renders SpawnErrorBanner inline instead — callers that
+// own a banner must not also call this, or the user sees both.
+export function notifyRecipeSpawnFailures(
+  results: RecipeSpawnResults,
+  { recipeName, projectId, worktreeId }: RecipeSpawnNotifyContext = {}
+): void {
+  if (results.failed.length === 0) return;
+
+  const total = results.spawned.length + results.failed.length;
+  const name = recipeName ? `'${recipeName}'` : "the recipe";
+  const reasons = Array.from(new Set(results.failed.map((f) => f.error)));
+  // A single shared reason (e.g. "Panel limit reached") is worth relaying;
+  // mixed reasons would just be noise in a toast — the counts carry the signal.
+  const reason = reasons.length === 1 ? ` ${reasons[0]!.replace(/\.$/, "")}.` : "";
+
+  if (results.spawned.length === 0) {
+    // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
+    notify({
+      type: "error",
+      title: "Recipe launch failed",
+      message: `Couldn't start any terminals from ${name}.${reason}`,
+      context: { eventKind: "agent", projectId, worktreeId },
+    });
+    return;
+  }
+
+  notify({
+    type: "warning",
+    title: "Recipe partially launched",
+    message: `${results.failed.length} of ${total} terminals from ${name} couldn't start.${reason}`,
+    context: { eventKind: "agent", projectId, worktreeId },
+  });
+}

--- a/src/utils/recipeNotify.ts
+++ b/src/utils/recipeNotify.ts
@@ -4,16 +4,21 @@ import type { RecipeSpawnResults } from "@/store/recipeStore";
 export interface RecipeSpawnNotifyContext {
   recipeName?: string;
   projectId?: string;
-  worktreeId?: string;
 }
 
 // Surfaces partial or full recipe spawn failures for launch paths with no
 // panel-owned banner (dock menu, recipe.run action, workflow creation). The
 // RecipeRunner panel renders SpawnErrorBanner inline instead — callers that
 // own a banner must not also call this, or the user sees both.
+//
+// Deliberately no worktreeId in the notify context: notify()'s origin-surface
+// suppression drops the toast when the failing worktree is the active one —
+// the common case for these launch paths — and none of them render an inline
+// fallback, so the toast must always fire. projectId alone is not a surface
+// and never triggers suppression.
 export function notifyRecipeSpawnFailures(
   results: RecipeSpawnResults,
-  { recipeName, projectId, worktreeId }: RecipeSpawnNotifyContext = {}
+  { recipeName, projectId }: RecipeSpawnNotifyContext = {}
 ): void {
   if (results.failed.length === 0) return;
 
@@ -30,7 +35,7 @@ export function notifyRecipeSpawnFailures(
       type: "error",
       title: "Recipe launch failed",
       message: `Couldn't start any terminals from ${name}.${reason}`,
-      context: { eventKind: "agent", projectId, worktreeId },
+      context: { eventKind: "agent", projectId },
     });
     return;
   }
@@ -39,6 +44,6 @@ export function notifyRecipeSpawnFailures(
     type: "warning",
     title: "Recipe partially launched",
     message: `${results.failed.length} of ${total} terminals from ${name} couldn't start.${reason}`,
-    context: { eventKind: "agent", projectId, worktreeId },
+    context: { eventKind: "agent", projectId },
   });
 }


### PR DESCRIPTION
`runRecipeWithResults` returns `{ spawned[], failed[] }` but three launch paths were silently discarding the result.

- `recipe.run` (palette, keybindings, MCP) — no feedback on failure, no error thrown for MCP callers
- `workflow.createWithRecipe` + `workflow.startWorkOnIssue` — `recipeLaunched` was set to `true` even when zero terminals spawned; partial-success payloads had no spawn counts
- Dock launch menu — bare `void runRecipe(...)` call with a latent unhandled rejection

Resolves #9946

## Changes

- **`src/utils/recipeNotify.ts`** — new `notifyRecipeSpawnFailures` helper: error toast ("Recipe launch failed") on zero-spawn, warning ("Recipe partially launched") on partial; shared failure reason relayed for single failures, counts summarised for mixed; no `worktreeId` in context so origin-surface suppression doesn't swallow the toast for the active worktree
- **`recipeActions.ts`** — switched to `runRecipeWithResults`, calls notify then throws on zero-spawn so MCP callers get a structured error; added `spawnedCount`, `failedCount`, `failedTerminals` to `resultSchema` + `mcpOutputSchema: true`
- **`workflowCreationActions.ts`** — `recipeLaunched` now requires at least one spawned terminal; `spawnedTerminalCount`/`failedTerminalCount` added to result schemas and `PARTIAL_SUCCESS` payloads; forwards `ctx.dispatchSource` so MCP-driven worktree+recipe combos get the `MAX_AGENT_RECIPE_TERMINALS` cap
- **`DockLaunchMenuItems.tsx`** — `runRecipeWithResults().then(notify).catch(logError)` replacing the old bare void call

## Testing

New `src/utils/__tests__/recipeNotify.test.ts` (7 tests). Updated adversarial tests for `recipeActions`, `workflowCreationActions`, and `DockLaunchButton`. 140 tests pass across the affected suites. All checks green (`npm run check`); ESLint warnings −6 vs baseline.