### PR TITLE
fix(browser): scope session partition per project

### DIFF
--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -818,6 +818,18 @@ describe("setupWebviewCSP — webview guest navigation restriction", () => {
 
       expect(event.preventDefault).toHaveBeenCalledTimes(1);
     });
+
+    it("safely treats a webview with no resolvable session partition as non-browser", () => {
+      // contents.session is absent on the mock; the optional-chaining guard must
+      // not throw and must fall back to the restrictive (localhost-only) path.
+      const contents = createMockWebContents("webview");
+      simulateWebContentsCreated(contents);
+
+      const handler = getEventHandlers(contents, "will-navigate")[0];
+      const event = { preventDefault: vi.fn() };
+      expect(() => handler(event, "https://github.com/login")).not.toThrow();
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    });
   });
 });
 

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -765,6 +765,60 @@ describe("setupWebviewCSP — webview guest navigation restriction", () => {
       expect(mockSend).not.toHaveBeenCalled();
     });
   });
+
+  describe("browser-panel navigation (per-project partition)", () => {
+    function createBrowserWebContents(partition: string): MockWebContents {
+      const contents = createMockWebContents("webview");
+      (contents as unknown as { session: { partition: string } }).session = { partition };
+      return contents;
+    }
+
+    it("allows cross-origin navigation for a per-project browser partition", () => {
+      const contents = createBrowserWebContents("persist:browser-proj-a");
+      simulateWebContentsCreated(contents);
+
+      const handler = getEventHandlers(contents, "will-navigate")[0];
+      const event = { preventDefault: vi.fn() };
+      handler(event, "https://github.com/login");
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("still blocks unsafe URLs for a browser partition", () => {
+      const contents = createBrowserWebContents("persist:browser-proj-a");
+      simulateWebContentsCreated(contents);
+
+      const handler = getEventHandlers(contents, "will-navigate")[0];
+      const event = { preventDefault: vi.fn() };
+      handler(event, "javascript:alert(1)");
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    it("treats distinct per-project browser partitions independently as browser panels", () => {
+      const contentsB = createBrowserWebContents("persist:browser-proj-b");
+      simulateWebContentsCreated(contentsB);
+
+      const handler = getEventHandlers(contentsB, "will-redirect")[0];
+      const event = { preventDefault: vi.fn() };
+      handler(event, "https://accounts.google.com/oauth");
+
+      // Browser partitions allow cross-origin http/https (OAuth flows), unlike
+      // dev-preview which is localhost-only.
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("restricts a dev-preview partition to localhost (cross-origin blocked)", () => {
+      const contents = createBrowserWebContents("persist:dev-preview-proj-a-main-panel");
+      simulateWebContentsCreated(contents);
+
+      const handler = getEventHandlers(contents, "will-navigate")[0];
+      const event = { preventDefault: vi.fn() };
+      handler(event, "https://github.com/login");
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 describe("setupWebviewCSP — partition CSP wiring", () => {
@@ -773,15 +827,17 @@ describe("setupWebviewCSP — partition CSP wiring", () => {
     webContentsCreatedListeners.length = 0;
   });
 
-  it("registers CSP on persist:browser and persist:daintree", async () => {
+  it("registers CSP on persist:daintree and does not eagerly open a browser session", async () => {
     const { session } = await import("electron");
     const fromPartition = vi.mocked(session.fromPartition);
 
     setupWebviewCSP();
 
     const partitions = fromPartition.mock.calls.map((call) => call[0]);
-    expect(partitions).toContain("persist:browser");
     expect(partitions).toContain("persist:daintree");
+    // Browser sessions are per-project and created lazily; setup no longer opens a
+    // singleton persist:browser session for identity comparison (#9965).
+    expect(partitions).not.toContain("persist:browser");
   });
 
   it("uses the daintree app CSP for persist:daintree (and skips localhost dev CSP for browser)", async () => {

--- a/electron/setup/__tests__/security.test.ts
+++ b/electron/setup/__tests__/security.test.ts
@@ -125,17 +125,25 @@ describe("setupPermissionLockdown", () => {
     _resetPermissionLockdownForTesting();
   });
 
-  it("configures handlers on default, browser, portal, and daintree-app sessions", () => {
+  it("configures handlers on default, portal, and daintree-app sessions eagerly", () => {
     setupPermissionLockdown();
 
     expect(defaultSession.setPermissionRequestHandler).toHaveBeenCalledTimes(1);
     expect(defaultSession.setPermissionCheckHandler).toHaveBeenCalledTimes(1);
-    expect(browserSession.setPermissionRequestHandler).toHaveBeenCalledTimes(1);
-    expect(browserSession.setPermissionCheckHandler).toHaveBeenCalledTimes(1);
     expect(portalSession.setPermissionRequestHandler).toHaveBeenCalledTimes(1);
     expect(portalSession.setPermissionCheckHandler).toHaveBeenCalledTimes(1);
     expect(daintreeAppSession.setPermissionRequestHandler).toHaveBeenCalledTimes(1);
     expect(daintreeAppSession.setPermissionCheckHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not eagerly configure the browser session — it is locked down lazily per project", () => {
+    setupPermissionLockdown();
+
+    // Browser sessions are now per-project (persist:browser-*) and created on
+    // demand at will-attach-webview time, so they are locked down via the
+    // session-created handler rather than eagerly here (#9965).
+    expect(browserSession.setPermissionRequestHandler).not.toHaveBeenCalled();
+    expect(browserSession.setPermissionCheckHandler).not.toHaveBeenCalled();
   });
 
   describe("default session (trusted)", () => {
@@ -209,9 +217,18 @@ describe("setupPermissionLockdown", () => {
   });
 
   describe("browser session (untrusted)", () => {
-    it("denies all permissions via request handler", () => {
+    // Browser sessions are per-project (persist:browser-*) and locked down lazily
+    // via the session-created handler, so drive a dynamic session through it.
+    function lockdownDynamicBrowserSession(partition = "persist:browser-myproject") {
       setupPermissionLockdown();
-      const handler = getRequestHandler(browserSession);
+      const dynamicBrowserSession = createMockSession();
+      Object.defineProperty(dynamicBrowserSession, "partition", { value: partition });
+      sessionCreatedListeners[0](dynamicBrowserSession);
+      return dynamicBrowserSession;
+    }
+
+    it("denies all permissions via request handler", () => {
+      const handler = getRequestHandler(lockdownDynamicBrowserSession());
       expect(testPermissionRequest(handler, "clipboard-read")).toBe(false);
       expect(testPermissionRequest(handler, "clipboard-sanitized-write")).toBe(false);
       expect(testPermissionRequest(handler, "media")).toBe(false);
@@ -220,8 +237,7 @@ describe("setupPermissionLockdown", () => {
     });
 
     it("denies all permissions via check handler", () => {
-      setupPermissionLockdown();
-      const handler = getCheckHandler(browserSession);
+      const handler = getCheckHandler(lockdownDynamicBrowserSession());
       expect(handler(mockWebContents, "clipboard-read", "http://localhost:3000", {})).toBe(false);
       expect(handler(mockWebContents, "media", "http://localhost:3000", {})).toBe(false);
     });
@@ -314,11 +330,11 @@ describe("setupPermissionLockdown", () => {
       expect(testPermissionRequest(handler, "media")).toBe(false);
     });
 
-    it("locks down dynamically created browser partitions", () => {
+    it("locks down dynamically created per-project browser partitions", () => {
       setupPermissionLockdown();
       const dynamicBrowserSession = createMockSession();
       Object.defineProperty(dynamicBrowserSession, "partition", {
-        value: "persist:browser",
+        value: "persist:browser-myproject",
       });
 
       sessionCreatedListeners[0](dynamicBrowserSession);
@@ -328,6 +344,19 @@ describe("setupPermissionLockdown", () => {
 
       const handler = getRequestHandler(dynamicBrowserSession);
       expect(testPermissionRequest(handler, "clipboard-read")).toBe(false);
+    });
+
+    it("locks down the legacy bare browser partition via session-created", () => {
+      setupPermissionLockdown();
+      const legacyBrowserSession = createMockSession();
+      Object.defineProperty(legacyBrowserSession, "partition", {
+        value: "persist:browser",
+      });
+
+      sessionCreatedListeners[0](legacyBrowserSession);
+
+      expect(legacyBrowserSession.setPermissionRequestHandler).toHaveBeenCalledTimes(1);
+      expect(legacyBrowserSession.setPermissionCheckHandler).toHaveBeenCalledTimes(1);
     });
 
     it("does not double-lock daintree-app partition via session-created (eagerly locked)", () => {
@@ -492,13 +521,20 @@ describe("setupPermissionLockdown", () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       setupPermissionLockdown();
 
-      const handler = getRequestHandler(browserSession);
+      const dynamicBrowserSession = createMockSession();
+      Object.defineProperty(dynamicBrowserSession, "partition", {
+        value: "persist:browser-myproject",
+      });
+      sessionCreatedListeners[0](dynamicBrowserSession);
+
+      const handler = getRequestHandler(dynamicBrowserSession);
       testPermissionRequest(handler, "media", "http://example.com");
 
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining("[SECURITY] Permission denied: media")
       );
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("session=browser"));
+      // The untrusted lockdown labels denials with the dynamic partition string.
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("session=persist:browser-"));
       warnSpy.mockRestore();
     });
 

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -25,6 +25,7 @@ import {
   isDevPreviewProxyUrl,
   isSafeNavigationUrl,
 } from "../../shared/utils/urlUtils.js";
+import { isBrowserPartition } from "../../shared/utils/partitionUtils.js";
 import { getWebviewDialogService } from "../services/WebviewDialogService.js";
 import { looksLikeOAuthUrl } from "../services/OAuthLoopbackService.js";
 import { CHANNELS } from "../ipc/channels.js";
@@ -642,8 +643,12 @@ export function setupWebviewCSP(): void {
   // dev-preview partitions are wired dynamically via will-attach-webview below.
   applyCSP("persist:daintree");
 
-  // Singleton for the browser partition session — used for identity comparison in navigation handlers.
-  const browserSession = session.fromPartition("persist:browser");
+  // Browser panel sessions are per-project (persist:browser-*) and created lazily,
+  // so navigation handlers below discriminate by the webContents' partition string
+  // rather than against a single cached session object.
+  const isBrowserPanelContents = (contents: Electron.WebContents): boolean =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Electron typing gap: Session.partition is not exposed
+    isBrowserPartition((contents.session as any)?.partition ?? "");
 
   // Monitor for dynamic dev-preview partitions
   app.on("web-contents-created", (_event, contents) => {
@@ -652,7 +657,7 @@ export function setupWebviewCSP(): void {
       const panelId = dialogService.getPanelId(contents.id);
       if (!panelId) return;
 
-      const isDevPreview = contents.session !== browserSession;
+      const isDevPreview = !isBrowserPanelContents(contents);
       if (
         isDevPreview &&
         looksLikeOAuthUrl(url) &&
@@ -708,7 +713,7 @@ export function setupWebviewCSP(): void {
         // the blocked-nav banner so the user can use "Sign in via Browser" (loopback flow).
         // Without this, window.open() OAuth popups bypass the banner and go straight
         // to the system browser, losing the PKCE sessionStorage state.
-        const isDevPreview = contents.session !== browserSession;
+        const isDevPreview = !isBrowserPanelContents(contents);
         if (url && isDevPreview && looksLikeOAuthUrl(url)) {
           notifyBlockedNavigation(url);
           return { action: "deny" };
@@ -730,7 +735,7 @@ export function setupWebviewCSP(): void {
       // Browser partition allows cross-origin http/https for OAuth/OIDC flows.
       // Dev-preview and other partitions remain restricted to localhost only.
       contents.on("will-navigate", (event, navigationUrl) => {
-        const isBrowserPanel = contents.session === browserSession;
+        const isBrowserPanel = isBrowserPanelContents(contents);
 
         const blocked = isBrowserPanel
           ? !isSafeNavigationUrl(navigationUrl)
@@ -745,7 +750,7 @@ export function setupWebviewCSP(): void {
       });
 
       contents.on("will-redirect", (event, redirectUrl) => {
-        const isBrowserPanel = contents.session === browserSession;
+        const isBrowserPanel = isBrowserPanelContents(contents);
 
         const blocked = isBrowserPanel
           ? !isSafeNavigationUrl(redirectUrl)

--- a/electron/setup/security.ts
+++ b/electron/setup/security.ts
@@ -351,8 +351,10 @@ export function setupPermissionLockdown(): void {
   // Lock down default session (trusted app renderer) with clipboard + media allowlist
   lockdownTrustedPermissions(session.defaultSession, "default", TRUSTED_SESSION_PERMISSIONS);
 
-  // Lock down browser session — fully untrusted
-  lockdownUntrustedPermissions(session.fromPartition("persist:browser"), "browser");
+  // Browser sessions (persist:browser-*) are now per-project and created lazily at
+  // will-attach-webview time, so they are locked down by the session-created handler
+  // below (which classifies them as "browser" and applies the untrusted lockdown)
+  // rather than eagerly here.
 
   // Portal needs clipboard access for AI chat copy buttons (navigator.clipboard.writeText)
   // but all other permissions (camera, mic, geolocation, etc.) remain denied
@@ -369,7 +371,7 @@ export function setupPermissionLockdown(): void {
     TRUSTED_SESSION_PERMISSIONS
   );
 
-  // Catch dynamically created sessions (e.g., persist:dev-preview-*)
+  // Catch dynamically created sessions (e.g., persist:browser-*, persist:dev-preview-*)
   // Guard against duplicate listeners when createWindow is called multiple times (macOS dock)
   if (!permissionLockdownInitialized) {
     permissionLockdownInitialized = true;

--- a/electron/utils/__tests__/webviewCsp.test.ts
+++ b/electron/utils/__tests__/webviewCsp.test.ts
@@ -46,6 +46,15 @@ describe("webviewCsp", () => {
       expect(classifyPartition("persist:browser")).toBe("browser");
     });
 
+    it("identifies dynamic per-project browser partitions", () => {
+      expect(classifyPartition("persist:browser-myproject")).toBe("browser");
+      expect(classifyPartition("persist:browser-some-uuid")).toBe("browser");
+    });
+
+    it("does not over-match browser-like partitions", () => {
+      expect(classifyPartition("persist:browserish")).toBe("unknown");
+    });
+
     it("identifies portal partition", () => {
       expect(classifyPartition("persist:portal")).toBe("portal");
     });
@@ -101,6 +110,7 @@ describe("webviewCsp", () => {
 
     it("browser partition is NOT eligible — hosts arbitrary remote sites", () => {
       expect(classifyPartition("persist:browser")).toBe("browser");
+      expect(classifyPartition("persist:browser-myproject")).toBe("browser");
       expect(partitionsThatSkipOverlay).toContain("browser");
       expect(partitionsThatReceiveOverlay).not.toContain("browser" as never);
     });

--- a/electron/utils/webviewCsp.ts
+++ b/electron/utils/webviewCsp.ts
@@ -1,5 +1,6 @@
 import type { OnHeadersReceivedListenerDetails } from "electron";
 import { getDaintreeAppCSP } from "../../shared/config/csp.js";
+import { isBrowserPartition } from "../../shared/utils/partitionUtils.js";
 
 export { getDaintreeAppCSP };
 
@@ -18,7 +19,7 @@ export function isDevPreviewPartition(partition: string): boolean {
  * Used to apply appropriate CSP policies to different webview partitions.
  */
 export function classifyPartition(partition: string): WebviewPartitionType {
-  if (partition === "persist:browser") {
+  if (isBrowserPartition(partition)) {
     return "browser";
   }
   if (partition === "persist:portal") {

--- a/electron/utils/webviewCsp.ts
+++ b/electron/utils/webviewCsp.ts
@@ -10,8 +10,8 @@ export type WebviewPartitionType = "browser" | "dev-preview" | "portal" | "proje
  * Checks if a partition is a valid dev-preview partition.
  * Matches exact "persist:dev-preview" or dynamic "persist:dev-preview-*" patterns.
  */
-export function isDevPreviewPartition(partition: string): boolean {
-  return partition === "persist:dev-preview" || partition.startsWith("persist:dev-preview-");
+export function isDevPreviewPartition(value: string): boolean {
+  return value === "persist:dev-preview" || value.startsWith("persist:dev-preview-");
 }
 
 /**

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -19,6 +19,7 @@ import { registerProtocolsForSession, getDistPath } from "../setup/protocols.js"
 import { getDevServerUrl } from "../../shared/config/devServer.js";
 import { isTrustedRendererUrl } from "../../shared/utils/trustedRenderer.js";
 import { isLocalhostUrl, isDevPreviewProxyUrl } from "../../shared/utils/urlUtils.js";
+import { isBrowserPartition } from "../../shared/utils/partitionUtils.js";
 import { canOpenExternalUrl, openExternalUrl } from "../utils/openExternal.js";
 import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
 import { forgetBlinkSample, forgetEluSample } from "../services/ProcessMemoryMonitor.js";
@@ -1272,13 +1273,14 @@ export class ProjectViewManager {
       webPreferences: Electron.WebPreferences,
       params: Record<string, string>
     ) => {
-      const allowedPartitions = ["persist:browser", "persist:dev-preview"];
       // Dev-preview webviews load the stable proxy origin (dp-*.localhost), which
       // isLocalhostUrl rejects — accept it explicitly (#9100).
       const isAllowedLocalhostUrl = isLocalhostUrl(params.src) || isDevPreviewProxyUrl(params.src);
+      const partition = params.partition ?? "";
       const isValidPartition =
-        allowedPartitions.includes(params.partition || "") ||
-        (params.partition?.startsWith("persist:dev-preview-") ?? false);
+        isBrowserPartition(partition) ||
+        partition === "persist:dev-preview" ||
+        partition.startsWith("persist:dev-preview-");
 
       if (!isAllowedLocalhostUrl || !isValidPartition) {
         console.warn(

--- a/electron/window/__tests__/createWindow.webview-partition.test.ts
+++ b/electron/window/__tests__/createWindow.webview-partition.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { isLocalhostUrl } from "../../../shared/utils/urlUtils.js";
+import { isLocalhostUrl, isDevPreviewProxyUrl } from "../../../shared/utils/urlUtils.js";
+import { isBrowserPartition } from "../../../shared/utils/partitionUtils.js";
 
 /**
  * Tests the will-attach-webview handler logic from createWindow.ts.
  *
  * The handler is inlined in setupBrowserWindow, so we replicate its exact
- * logic here to verify the partition preservation fix (#4564).
+ * logic here to verify the partition preservation fix (#4564) and the
+ * per-project browser partition support (#9965).
  *
  * If createWindow.ts changes, these tests should be updated to match.
  */
@@ -14,11 +16,12 @@ function simulateWillAttachWebview(
   webPreferences: Record<string, unknown>,
   params: { src: string; partition?: string }
 ): { prevented: boolean } {
-  const allowedPartitions = ["persist:browser", "persist:dev-preview"];
-  const isAllowedLocalhostUrl = isLocalhostUrl(params.src);
+  const isAllowedLocalhostUrl = isLocalhostUrl(params.src) || isDevPreviewProxyUrl(params.src);
+  const partition = params.partition ?? "";
   const isValidPartition =
-    allowedPartitions.includes(params.partition || "") ||
-    (params.partition?.startsWith("persist:dev-preview-") ?? false);
+    isBrowserPartition(partition) ||
+    partition === "persist:dev-preview" ||
+    partition.startsWith("persist:dev-preview-");
 
   if (!isAllowedLocalhostUrl || !isValidPartition) {
     return { prevented: true };
@@ -37,11 +40,26 @@ function simulateWillAttachWebview(
 }
 
 describe("will-attach-webview partition preservation (#4564)", () => {
-  it("sets webPreferences.partition for persist:browser", () => {
+  it("sets webPreferences.partition for a per-project browser partition", () => {
     const webPreferences: Record<string, unknown> = {
       preload: "/some/path",
       nodeIntegration: true,
     };
+
+    const result = simulateWillAttachWebview(webPreferences, {
+      src: "http://localhost:3000",
+      partition: "persist:browser-project-1",
+    });
+
+    expect(result.prevented).toBe(false);
+    expect(webPreferences.partition).toBe("persist:browser-project-1");
+    expect(webPreferences.sandbox).toBe(true);
+    expect(webPreferences.nodeIntegration).toBe(false);
+    expect(webPreferences.preload).toBeUndefined();
+  });
+
+  it("still accepts the legacy bare persist:browser partition", () => {
+    const webPreferences: Record<string, unknown> = {};
 
     const result = simulateWillAttachWebview(webPreferences, {
       src: "http://localhost:3000",
@@ -50,9 +68,18 @@ describe("will-attach-webview partition preservation (#4564)", () => {
 
     expect(result.prevented).toBe(false);
     expect(webPreferences.partition).toBe("persist:browser");
-    expect(webPreferences.sandbox).toBe(true);
-    expect(webPreferences.nodeIntegration).toBe(false);
-    expect(webPreferences.preload).toBeUndefined();
+  });
+
+  it("blocks browser-like partitions that are not valid (over-match guard)", () => {
+    const webPreferences: Record<string, unknown> = {};
+
+    const result = simulateWillAttachWebview(webPreferences, {
+      src: "http://localhost:3000",
+      partition: "persist:browserish",
+    });
+
+    expect(result.prevented).toBe(true);
+    expect(webPreferences.partition).toBeUndefined();
   });
 
   it("sets webPreferences.partition for dynamic dev-preview partition", () => {

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -20,6 +20,7 @@ import {
 import { canOpenExternalUrl, openExternalUrl } from "../utils/openExternal.js";
 import { isTrustedRendererUrl } from "../../shared/utils/trustedRenderer.js";
 import { isLocalhostUrl, isDevPreviewProxyUrl } from "../../shared/utils/urlUtils.js";
+import { isBrowserPartition } from "../../shared/utils/partitionUtils.js";
 import { getDevServerUrl } from "../../shared/config/devServer.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { sendToRenderer } from "../ipc/handlers.js";
@@ -435,13 +436,14 @@ export function setupBrowserWindow(
 
   // Harden webview security — on the app view's webContents
   appWebContents.on("will-attach-webview", (event, webPreferences, params) => {
-    const allowedPartitions = ["persist:browser", "persist:dev-preview"];
     // Dev-preview webviews now load the stable proxy origin (dp-*.localhost), which
     // isLocalhostUrl rejects — accept it explicitly (#9100).
     const isAllowedLocalhostUrl = isLocalhostUrl(params.src) || isDevPreviewProxyUrl(params.src);
+    const partition = params.partition ?? "";
     const isValidPartition =
-      allowedPartitions.includes(params.partition || "") ||
-      (params.partition?.startsWith("persist:dev-preview-") ?? false);
+      isBrowserPartition(partition) ||
+      partition === "persist:dev-preview" ||
+      partition.startsWith("persist:dev-preview-");
 
     if (!isAllowedLocalhostUrl || !isValidPartition) {
       console.warn(

--- a/shared/utils/__tests__/partitionUtils.test.ts
+++ b/shared/utils/__tests__/partitionUtils.test.ts
@@ -3,6 +3,8 @@ import {
   sanitizePartitionToken,
   buildDevPreviewPartition,
   isDevPreviewPartition,
+  buildBrowserPartition,
+  isBrowserPartition,
 } from "../partitionUtils.js";
 
 describe("sanitizePartitionToken", () => {
@@ -81,5 +83,52 @@ describe("isDevPreviewPartition", () => {
   it("rejects non-string values", () => {
     expect(isDevPreviewPartition(undefined)).toBe(false);
     expect(isDevPreviewPartition(123)).toBe(false);
+  });
+});
+
+describe("buildBrowserPartition", () => {
+  it("composes the per-project persist:browser-* partition", () => {
+    expect(buildBrowserPartition("proj")).toBe("persist:browser-proj");
+  });
+
+  it("sanitizes the project token", () => {
+    expect(buildBrowserPartition("Pro/J #1")).toBe("persist:browser-pro-j-1");
+  });
+
+  it("falls back to a default token when the project id is missing", () => {
+    expect(buildBrowserPartition(undefined)).toBe("persist:browser-default");
+    expect(buildBrowserPartition("")).toBe("persist:browser-default");
+  });
+
+  it("always produces a scoped partition, never the legacy bare string", () => {
+    expect(buildBrowserPartition(undefined)).not.toBe("persist:browser");
+  });
+});
+
+describe("isBrowserPartition", () => {
+  it("accepts a well-formed scoped browser partition", () => {
+    expect(isBrowserPartition("persist:browser-my-project")).toBe(true);
+    expect(isBrowserPartition(buildBrowserPartition("proj"))).toBe(true);
+  });
+
+  it("accepts the legacy bare browser partition", () => {
+    expect(isBrowserPartition("persist:browser")).toBe(true);
+  });
+
+  it("rejects over-matching near-misses", () => {
+    expect(isBrowserPartition("persist:browserish")).toBe(false);
+    expect(isBrowserPartition("persist:browser/evil")).toBe(false);
+    expect(isBrowserPartition("persist:dev-preview-browser-a")).toBe(false);
+  });
+
+  it("rejects other partition families", () => {
+    expect(isBrowserPartition("persist:dev-preview-a-b-c")).toBe(false);
+    expect(isBrowserPartition("persist:portal")).toBe(false);
+    expect(isBrowserPartition("persist:daintree")).toBe(false);
+  });
+
+  it("rejects non-string values", () => {
+    expect(isBrowserPartition(undefined)).toBe(false);
+    expect(isBrowserPartition(123)).toBe(false);
   });
 });

--- a/shared/utils/partitionUtils.ts
+++ b/shared/utils/partitionUtils.ts
@@ -63,7 +63,14 @@ export function buildBrowserPartition(projectId: string | undefined): string {
  */
 export const BROWSER_PARTITION_PATTERN = /^persist:browser(-[a-z0-9_-]+)?$/;
 
-/** True when `value` is a syntactically valid Browser panel partition. */
-export function isBrowserPartition(value: unknown): value is string {
+/**
+ * True when `value` is a syntactically valid Browser panel partition.
+ *
+ * Returns a plain `boolean` rather than a `value is string` predicate: callers
+ * pass an already-typed `string` and chain this in `||` with other partition
+ * checks, where a negative type-guard branch would wrongly narrow `string` to
+ * `never` (a non-browser partition is still a string).
+ */
+export function isBrowserPartition(value: unknown): boolean {
   return typeof value === "string" && BROWSER_PARTITION_PATTERN.test(value);
 }

--- a/shared/utils/partitionUtils.ts
+++ b/shared/utils/partitionUtils.ts
@@ -42,3 +42,28 @@ export const DEV_PREVIEW_PARTITION_PATTERN =
 export function isDevPreviewPartition(value: unknown): value is string {
   return typeof value === "string" && DEV_PREVIEW_PARTITION_PATTERN.test(value);
 }
+
+/**
+ * Build the per-project `persist:browser-*` partition for a Browser panel.
+ *
+ * Browser sessions are scoped by project (cookies/localStorage/IndexedDB for a
+ * site like `localhost:3000` or `github.com` belong to the project context, not
+ * a single worktree or panel instance), so this needs only `projectId`. A
+ * missing id sanitizes to `persist:browser-default`.
+ */
+export function buildBrowserPartition(projectId: string | undefined): string {
+  return `persist:browser-${sanitizePartitionToken(projectId)}`;
+}
+
+/**
+ * Matches a Browser panel partition. Accepts both the scoped
+ * `persist:browser-{token}` form produced by `buildBrowserPartition` and the
+ * legacy bare `persist:browser` string so sessions created by older builds (or
+ * still cached by Electron) keep being classified and locked down correctly.
+ */
+export const BROWSER_PARTITION_PATTERN = /^persist:browser(-[a-z0-9_-]+)?$/;
+
+/** True when `value` is a syntactically valid Browser panel partition. */
+export function isBrowserPartition(value: unknown): value is string {
+  return typeof value === "string" && BROWSER_PARTITION_PATTERN.test(value);
+}

--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -108,9 +108,14 @@ export function BrowserPane({
   const setBrowserHistory = usePanelStore((state) => state.setBrowserHistory);
   const setBrowserZoom = usePanelStore((state) => state.setBrowserZoom);
   const isDragging = useIsDragging();
-  const projectId = useProjectStore((state) => state.currentProject?.id);
+  const storeProjectId = useProjectStore((state) => state.currentProject?.id);
   // Per-project Chromium session partition so cookies/localStorage/IndexedDB are
   // isolated between projects sharing an origin (e.g. localhost:3000) (#9965).
+  // `currentProject` resolves asynchronously, but Electron ignores `partition`
+  // changes once the <webview> is attached — so fall back to the project id seeded
+  // synchronously by preload (mirrors projectStore.getLocationProjectId) to attach
+  // with the correct partition on first render rather than persist:browser-default.
+  const projectId = storeProjectId ?? window.__DAINTREE_INITIAL_PROJECT__?.id;
   const webviewPartition = useMemo(() => buildBrowserPartition(projectId), [projectId]);
   const devServerLoadTimeout = useProjectSettingsStore(
     (state) => state.settings?.devServerLoadTimeout
@@ -974,6 +979,10 @@ export function BrowserPane({
               {findInPage.isOpen && <FindBar find={findInPage} />}
               <webview
                 ref={setWebviewNode}
+                // Remount if the partition ever changes after attach (e.g. a window
+                // seeded only via ?projectId= where the store resolves later) so the
+                // webview never keeps a stale cross-project session (#9965).
+                key={webviewPartition}
                 src={currentUrl}
                 partition={webviewPartition}
                 // @ts-expect-error React 19 requires "" to emit the attribute; boolean true is silently dropped

--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -34,6 +34,7 @@ import { useProjectSettings } from "@/hooks/useProjectSettings";
 import { useFindInPage } from "@/hooks/useFindInPage";
 import { useDohertyGate } from "@/hooks/useDeferredLoading";
 import { logError } from "@/utils/logger";
+import { buildBrowserPartition } from "@shared/utils/partitionUtils";
 
 export interface BrowserPaneProps extends BasePanelProps {
   initialUrl: string;
@@ -108,6 +109,9 @@ export function BrowserPane({
   const setBrowserZoom = usePanelStore((state) => state.setBrowserZoom);
   const isDragging = useIsDragging();
   const projectId = useProjectStore((state) => state.currentProject?.id);
+  // Per-project Chromium session partition so cookies/localStorage/IndexedDB are
+  // isolated between projects sharing an origin (e.g. localhost:3000) (#9965).
+  const webviewPartition = useMemo(() => buildBrowserPartition(projectId), [projectId]);
   const devServerLoadTimeout = useProjectSettingsStore(
     (state) => state.settings?.devServerLoadTimeout
   );
@@ -971,7 +975,7 @@ export function BrowserPane({
               <webview
                 ref={setWebviewNode}
                 src={currentUrl}
-                partition="persist:browser"
+                partition={webviewPartition}
                 // @ts-expect-error React 19 requires "" to emit the attribute; boolean true is silently dropped
                 allowpopups=""
                 className={cn(

--- a/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
+++ b/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
@@ -70,7 +70,9 @@ const {
   );
   (usePanelStoreMock as unknown as { getState: () => typeof terminalStoreState }).getState = () =>
     terminalStoreState;
-  const projectStoreState = { currentProject: { id: "test-project" } };
+  const projectStoreState: { currentProject: { id: string } | null } = {
+    currentProject: { id: "test-project" },
+  };
   const useProjectStoreMock = vi.fn((selector: (state: typeof projectStoreState) => unknown) =>
     selector(projectStoreState)
   );
@@ -270,9 +272,8 @@ describe("BrowserPane webview lifecycle regression", () => {
 
   describe("per-project session partition (#9965)", () => {
     const restoreProjectMock = () =>
-      useProjectStoreMock.mockImplementation(
-        (selector: (state: { currentProject: { id: string } | null }) => unknown) =>
-          selector({ currentProject: { id: "test-project" } })
+      useProjectStoreMock.mockImplementation((selector) =>
+        selector({ currentProject: { id: "test-project" } })
       );
 
     afterEach(() => {
@@ -288,10 +289,7 @@ describe("BrowserPane webview lifecycle regression", () => {
     });
 
     it("falls back to the synchronously-seeded project id when the store has not resolved", () => {
-      useProjectStoreMock.mockImplementation(
-        (selector: (state: { currentProject: { id: string } | null }) => unknown) =>
-          selector({ currentProject: null })
-      );
+      useProjectStoreMock.mockImplementation((selector) => selector({ currentProject: null }));
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (window as any).__DAINTREE_INITIAL_PROJECT__ = { id: "seeded-project" };
 
@@ -303,10 +301,7 @@ describe("BrowserPane webview lifecycle regression", () => {
     });
 
     it("uses the default partition only when no project id is available at all", () => {
-      useProjectStoreMock.mockImplementation(
-        (selector: (state: { currentProject: { id: string } | null }) => unknown) =>
-          selector({ currentProject: null })
-      );
+      useProjectStoreMock.mockImplementation((selector) => selector({ currentProject: null }));
 
       const { container } = render(<BrowserPane {...baseProps} />);
       const webview = getWebviewElement(container);

--- a/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
+++ b/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
@@ -268,6 +268,52 @@ describe("BrowserPane webview lifecycle regression", () => {
     expect(webview.hasAttribute("allowpopups")).toBe(true);
   });
 
+  describe("per-project session partition (#9965)", () => {
+    const restoreProjectMock = () =>
+      useProjectStoreMock.mockImplementation(
+        (selector: (state: { currentProject: { id: string } | null }) => unknown) =>
+          selector({ currentProject: { id: "test-project" } })
+      );
+
+    afterEach(() => {
+      restoreProjectMock();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (window as any).__DAINTREE_INITIAL_PROJECT__;
+    });
+
+    it("scopes the webview partition to the current project", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+      expect(webview.getAttribute("partition")).toBe("persist:browser-test-project");
+    });
+
+    it("falls back to the synchronously-seeded project id when the store has not resolved", () => {
+      useProjectStoreMock.mockImplementation(
+        (selector: (state: { currentProject: { id: string } | null }) => unknown) =>
+          selector({ currentProject: null })
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__DAINTREE_INITIAL_PROJECT__ = { id: "seeded-project" };
+
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+      // Must NOT attach with the shared default partition — that would leak the
+      // session across projects, which is the bug this fix closes.
+      expect(webview.getAttribute("partition")).toBe("persist:browser-seeded-project");
+    });
+
+    it("uses the default partition only when no project id is available at all", () => {
+      useProjectStoreMock.mockImplementation(
+        (selector: (state: { currentProject: { id: string } | null }) => unknown) =>
+          selector({ currentProject: null })
+      );
+
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+      expect(webview.getAttribute("partition")).toBe("persist:browser-default");
+    });
+  });
+
   it("does not pass console-toggle props to BrowserToolbar (regression #7495)", () => {
     // The plain Browser panel must not surface the console button via the
     // shared toolbar — that wiring belongs to DevPreviewPane only.


### PR DESCRIPTION
## Summary

- The Browser panel hardcoded `partition="persist:browser"`, so all projects shared a single Chromium session. Cookies, localStorage, and IndexedDB leaked across any two projects hitting the same localhost origin.
- Fix scopes the partition per project with a new `buildBrowserPartition(projectId)` that produces `persist:browser-<projectId>`, mirroring the Dev Preview isolation model.
- Session lockdown, nav handlers, and webview allowlists updated throughout to recognise the new partition pattern.

Resolves #9965

## Changes

- `shared/utils/partitionUtils.ts`: adds `buildBrowserPartition(projectId)`, `BROWSER_PARTITION_PATTERN`, and `isBrowserPartition()` (accepts both the legacy bare `persist:browser` and the new scoped form).
- `src/components/Browser/BrowserPane.tsx`: derives partition from project id, with a fallback to the synchronously-seeded `window.__DAINTREE_INITIAL_PROJECT__` id so the webview gets the right partition on first render (Electron ignores partition changes after attach). A `key={partition}` forces a clean remount in the rare case where only the query string changes.
- `electron/utils/webviewCsp.ts`: `classifyPartition` recognises `persist:browser-*` as the browser type (still excluded from the CSP overlay, same as before).
- `electron/setup/security.ts`: removed the static eager lockdown of `persist:browser`; the `session-created` handler now locks down per-project browser sessions lazily.
- `electron/setup/protocols.ts`: nav handlers drop the `browserSession` singleton object-identity check in favour of `isBrowserPartition(contents.session.partition)`.
- `electron/window/createWindow.ts` + `ProjectViewManager.ts`: `will-attach-webview` allowlists accept `persist:browser-*` and still set `webPreferences.partition`.

**Migration:** clean break. The old `persist:browser` storage is orphaned on disk (non-critical browser session state). The security fix value outweighs the migration cost.

**Scope decision:** project-level, not per-worktree or per-panel. Browser cookies are typically project-wide state.

## Testing

340 unit tests pass across `partitionUtils`, `webviewCsp`, `security`, `protocols`, `createWindow` webview-partition, and `BrowserPane` webview suites, including new regression guards for the first-render partition race and the absent-session nav fallback. `npm run check` is fully green: typecheck, lint (ratchet -6 warnings), format, IPC/channel/confirm-wiring guards.