### PR TITLE
fix(forge): honor per-project provider override in resolveForCwd

### DIFF
--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 1314,
-  "moduleCount": 1314,
+  "count": 1318,
+  "moduleCount": 1318,
   "allowlist": [
     "electron/ipc/errorHandlers.ts",
     "electron/ipc/handlers/agentCapabilities.ts",
@@ -86,6 +86,7 @@
     "electron/utils/git.ts",
     "electron/utils/gitRepoOperationState.ts",
     "electron/utils/gpuDetection.ts",
+    "electron/utils/hostPerformance.ts",
     "electron/utils/logger.ts",
     "electron/utils/performance.ts",
     "electron/utils/worktreePattern.ts",
@@ -93,6 +94,7 @@
     "electron/window/createWindow.ts",
     "electron/window/globalServicesInit.ts",
     "electron/window/skeletonCss.ts",
+    "electron/window/windowServices.ts",
     "plugins/builtin/github/main/GitHubRateLimitService.ts"
   ],
   "syncViolations": [
@@ -183,7 +185,7 @@
     },
     {
       "file": "electron/ipc/handlers/forgeResolution.ts",
-      "line": 45,
+      "line": 60,
       "pattern": "sync-store-get"
     },
     {
@@ -298,12 +300,12 @@
     },
     {
       "file": "electron/ipc/handlers/pluginMcp.ts",
-      "line": 35,
+      "line": 36,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/pluginMcp.ts",
-      "line": 100,
+      "line": 101,
       "pattern": "sync-store-get"
     },
     {
@@ -388,17 +390,17 @@
     },
     {
       "file": "electron/lifecycle/appLifecycle.ts",
-      "line": 83,
+      "line": 84,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/main.ts",
-      "line": 170,
+      "line": 179,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/main.ts",
-      "line": 251,
+      "line": 260,
       "pattern": "sync-store-get"
     },
     {
@@ -478,7 +480,12 @@
     },
     {
       "file": "electron/services/AutoUpdaterService.ts",
-      "line": 604,
+      "line": 606,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/AutoUpdaterService.ts",
+      "line": 616,
       "pattern": "sync-store-get"
     },
     {
@@ -1103,22 +1110,22 @@
     },
     {
       "file": "electron/services/plugin/PluginInstalledRecordsStore.ts",
-      "line": 18,
+      "line": 19,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/plugin/PluginInstalledRecordsStore.ts",
-      "line": 29,
+      "line": 30,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/plugin/PluginInstalledRecordsStore.ts",
-      "line": 46,
+      "line": 47,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/plugin/PluginInstalledRecordsStore.ts",
-      "line": 84,
+      "line": 85,
       "pattern": "sync-store-get"
     },
     {
@@ -1463,7 +1470,7 @@
     },
     {
       "file": "electron/setup/protocols.ts",
-      "line": 547,
+      "line": 582,
       "pattern": "sync-fs"
     },
     {
@@ -1619,6 +1626,21 @@
     {
       "file": "electron/utils/gpuDetection.ts",
       "line": 51,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/hostPerformance.ts",
+      "line": 59,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/hostPerformance.ts",
+      "line": 60,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/hostPerformance.ts",
+      "line": 161,
       "pattern": "sync-fs"
     },
     {
@@ -1779,6 +1801,11 @@
     {
       "file": "electron/window/skeletonCss.ts",
       "line": 106,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/window/windowServices.ts",
+      "line": 394,
       "pattern": "sync-store-get"
     },
     {

--- a/electron/ipc/__tests__/handlers.registry.test.ts
+++ b/electron/ipc/__tests__/handlers.registry.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vite
 
 vi.mock("electron", () => ({
   app: {
-    getPath: vi.fn(),
+    getPath: vi.fn(() => "/tmp/test-user-data"),
     on: vi.fn(),
   },
   ipcMain: {
@@ -41,6 +41,8 @@ const registerMocks = vi.hoisted(() => ({
   registerHibernationHandlers: vi.fn(),
   registerIdleTerminalHandlers: vi.fn(),
   registerSystemSleepHandlers: vi.fn(),
+  registerAppVersionInfoHandlers: vi.fn(),
+  registerOsDndHandlers: vi.fn(),
   registerKeybindingHandlers: vi.fn(),
   registerWorktreeConfigHandlers: vi.fn(),
   registerNotificationHandlers: vi.fn(),
@@ -62,10 +64,14 @@ const registerMocks = vi.hoisted(() => ({
   registerMilestonesHandlers: vi.fn(),
   registerShortcutHintsHandlers: vi.fn(),
   registerForgeSettingsHandlers: vi.fn(),
+  registerForgeHandlers: vi.fn(),
+  registerForgeDataHandlers: vi.fn(),
+  registerForgeAuditHandlers: vi.fn(),
   registerVoiceInputHandlers: vi.fn(),
   registerMcpServerHandlers: vi.fn(),
   registerHelpAssistantHandlers: vi.fn(),
   registerWebviewHandlers: vi.fn(),
+  registerWebviewNavigationHandlers: vi.fn(),
   registerDiagnosticsHandlers: vi.fn(),
 
   registerAccessibilityHandlers: vi.fn(),
@@ -149,6 +155,12 @@ vi.mock("../handlers/idleTerminals.js", () => ({
 vi.mock("../handlers/systemSleep.js", () => ({
   registerSystemSleepHandlers: registerMocks.registerSystemSleepHandlers,
 }));
+vi.mock("../handlers/appVersionInfo.js", () => ({
+  registerAppVersionInfoHandlers: registerMocks.registerAppVersionInfoHandlers,
+}));
+vi.mock("../handlers/osDnd.js", () => ({
+  registerOsDndHandlers: registerMocks.registerOsDndHandlers,
+}));
 vi.mock("../handlers/keybinding.js", () => ({
   registerKeybindingHandlers: registerMocks.registerKeybindingHandlers,
 }));
@@ -212,6 +224,15 @@ vi.mock("../handlers/shortcutHints.js", () => ({
 vi.mock("../handlers/forgeSettings.js", () => ({
   registerForgeSettingsHandlers: registerMocks.registerForgeSettingsHandlers,
 }));
+vi.mock("../handlers/forge.js", () => ({
+  registerForgeHandlers: registerMocks.registerForgeHandlers,
+}));
+vi.mock("../handlers/forgeData.js", () => ({
+  registerForgeDataHandlers: registerMocks.registerForgeDataHandlers,
+}));
+vi.mock("../handlers/forgeAudit.js", () => ({
+  registerForgeAuditHandlers: registerMocks.registerForgeAuditHandlers,
+}));
 vi.mock("../handlers/voiceInput.js", () => ({
   registerVoiceInputHandlers: registerMocks.registerVoiceInputHandlers,
 }));
@@ -223,6 +244,9 @@ vi.mock("../handlers/helpAssistant.js", () => ({
 }));
 vi.mock("../handlers/webview.js", () => ({
   registerWebviewHandlers: registerMocks.registerWebviewHandlers,
+}));
+vi.mock("../handlers/webviewNavigation.js", () => ({
+  registerWebviewNavigationHandlers: registerMocks.registerWebviewNavigationHandlers,
 }));
 vi.mock("../handlers/diagnostics.js", () => ({
   registerDiagnosticsHandlers: registerMocks.registerDiagnosticsHandlers,

--- a/electron/ipc/handlers/__tests__/forgeResolution.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeResolution.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ForgeProviderEntry, ResolvedForgeProvider } from "../../../../shared/types/forge.js";
+import type { ResolveForgeProviderInputs } from "../../../services/forgeProviderResolver.js";
+
+const storeMock = vi.hoisted(() => {
+  const data: Record<string, unknown> = {};
+  return {
+    get: vi.fn((key: string) => data[key]),
+    set: vi.fn((key: string, value: unknown) => {
+      data[key] = value;
+    }),
+    _data: data,
+  };
+});
+
+vi.mock("../../../store.js", () => ({ store: storeMock }));
+
+const registryMock = vi.hoisted(() => ({
+  getForgeProviderImpl: vi.fn<(id: string) => unknown>(() => undefined),
+}));
+
+vi.mock("../../../services/forgeProviderRegistry.js", () => registryMock);
+
+const resolverMock = vi.hoisted(() => ({
+  resolveForgeProvider: vi.fn<(inputs: ResolveForgeProviderInputs) => ResolvedForgeProvider>(
+    () => ({ entry: null, resolvedVia: null })
+  ),
+}));
+
+vi.mock("../../../services/forgeProviderResolver.js", () => resolverMock);
+
+const projectStoreMock = vi.hoisted(() => ({
+  getProjectByPath: vi.fn(),
+  getProjectSettings: vi.fn(),
+}));
+
+vi.mock("../../../services/ProjectStore.js", () => ({ projectStore: projectStoreMock }));
+
+const gitServiceMock = vi.hoisted(() => ({
+  getRemoteUrl: vi.fn(),
+  listWorktrees: vi.fn(),
+}));
+const gitServiceCacheMock = vi.hoisted(() => ({ getGitService: vi.fn(() => gitServiceMock) }));
+
+vi.mock("../../../services/GitServiceCache.js", () => ({
+  gitServiceCache: gitServiceCacheMock,
+}));
+
+import { resolveForCwd } from "../forgeResolution.js";
+
+const giteaEntry: ForgeProviderEntry = {
+  pluginId: "acme",
+  contribution: { id: "gitea", name: "Gitea", matches: ["gitea.example.com"] },
+};
+
+function lastResolverInputs(): ResolveForgeProviderInputs {
+  const calls = resolverMock.resolveForgeProvider.mock.calls;
+  if (calls.length === 0) throw new Error("resolveForgeProvider was not called");
+  return calls[calls.length - 1]![0];
+}
+
+describe("resolveForCwd", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const key of Object.keys(storeMock._data)) {
+      delete storeMock._data[key];
+    }
+    gitServiceCacheMock.getGitService.mockReturnValue(gitServiceMock);
+    gitServiceMock.getRemoteUrl.mockResolvedValue("https://gitea.example.com/owner/repo.git");
+    gitServiceMock.listWorktrees.mockResolvedValue([
+      { path: "/repo", branch: "main", bare: false, isMainWorktree: true },
+    ]);
+    projectStoreMock.getProjectByPath.mockResolvedValue({ id: "project-1", path: "/repo" });
+    projectStoreMock.getProjectSettings.mockResolvedValue({ runCommands: [] });
+    registryMock.getForgeProviderImpl.mockReturnValue(undefined);
+    resolverMock.resolveForgeProvider.mockReturnValue({ entry: null, resolvedVia: null });
+  });
+
+  it("passes the per-project forgeProviderOverride to the resolver (#9984)", async () => {
+    projectStoreMock.getProjectSettings.mockResolvedValue({
+      runCommands: [],
+      forgeProviderOverride: "acme.gitea",
+    });
+    const parseRemote = vi.fn(() => ({ owner: "owner", repo: "repo" }));
+    registryMock.getForgeProviderImpl.mockReturnValue({ parseRemote });
+    resolverMock.resolveForgeProvider.mockReturnValue({
+      entry: giteaEntry,
+      resolvedVia: "override",
+    });
+
+    const result = await resolveForCwd("/repo");
+
+    expect(lastResolverInputs()).toEqual({
+      remoteUrl: "https://gitea.example.com/owner/repo.git",
+      forgeProviderOverride: "acme.gitea",
+      globalDefaultProviderId: null,
+    });
+    expect(result.providerId).toBe("gitea");
+    expect(result.namespaceId).toBe("acme.gitea");
+    expect(result.repoRef).toEqual({ owner: "owner", repo: "repo" });
+    expect(parseRemote).toHaveBeenCalledWith("https://gitea.example.com/owner/repo.git");
+  });
+
+  it("looks up the project by the main worktree path, not the linked-worktree cwd", async () => {
+    gitServiceMock.listWorktrees.mockResolvedValue([
+      { path: "/repo", branch: "main", bare: false, isMainWorktree: true },
+      { path: "/repo-worktrees/feature", branch: "feature", bare: false, isMainWorktree: false },
+    ]);
+
+    await resolveForCwd("/repo-worktrees/feature/src").catch(() => null);
+
+    expect(projectStoreMock.getProjectByPath).toHaveBeenCalledWith("/repo");
+    expect(projectStoreMock.getProjectSettings).toHaveBeenCalledWith("project-1");
+  });
+
+  it("falls back to the cwd for project lookup when listWorktrees fails", async () => {
+    gitServiceMock.listWorktrees.mockRejectedValue(new Error("not a work tree"));
+
+    await resolveForCwd("/repo").catch(() => null);
+
+    expect(projectStoreMock.getProjectByPath).toHaveBeenCalledWith("/repo");
+    expect(lastResolverInputs().forgeProviderOverride).toBeNull();
+  });
+
+  it("passes a null override when no project matches the path", async () => {
+    projectStoreMock.getProjectByPath.mockResolvedValue(null);
+
+    await resolveForCwd("/repo").catch(() => null);
+
+    expect(projectStoreMock.getProjectSettings).not.toHaveBeenCalled();
+    expect(lastResolverInputs().forgeProviderOverride).toBeNull();
+  });
+
+  it("passes a null override when the project lookup rejects", async () => {
+    projectStoreMock.getProjectByPath.mockRejectedValue(new Error("db locked"));
+
+    await resolveForCwd("/repo").catch(() => null);
+
+    expect(lastResolverInputs().forgeProviderOverride).toBeNull();
+  });
+
+  it("passes a null override when the settings fetch rejects", async () => {
+    projectStoreMock.getProjectSettings.mockRejectedValue(new Error("db locked"));
+
+    await resolveForCwd("/repo").catch(() => null);
+
+    expect(lastResolverInputs().forgeProviderOverride).toBeNull();
+  });
+
+  it("passes a null override when project settings have no override set", async () => {
+    await resolveForCwd("/repo").catch(() => null);
+
+    expect(lastResolverInputs().forgeProviderOverride).toBeNull();
+  });
+
+  it("still forwards the global default provider id alongside the override", async () => {
+    storeMock._data["forgeDefaultProviderId"] = "daintree.github.github";
+    projectStoreMock.getProjectSettings.mockResolvedValue({
+      runCommands: [],
+      forgeProviderOverride: "acme.gitea",
+    });
+
+    await resolveForCwd("/repo").catch(() => null);
+
+    expect(lastResolverInputs()).toEqual({
+      remoteUrl: "https://gitea.example.com/owner/repo.git",
+      forgeProviderOverride: "acme.gitea",
+      globalDefaultProviderId: "daintree.github.github",
+    });
+  });
+
+  it("rejects invalid cwd payloads before any lookup", async () => {
+    await expect(resolveForCwd("")).rejects.toThrow("Invalid working directory");
+    expect(gitServiceCacheMock.getGitService).not.toHaveBeenCalled();
+    expect(resolverMock.resolveForgeProvider).not.toHaveBeenCalled();
+  });
+
+  it("rejects when no remote URL is found, without touching project settings", async () => {
+    gitServiceMock.getRemoteUrl.mockResolvedValue(null);
+
+    await expect(resolveForCwd("/repo")).rejects.toThrow("No remote URL found");
+    expect(projectStoreMock.getProjectByPath).not.toHaveBeenCalled();
+    expect(resolverMock.resolveForgeProvider).not.toHaveBeenCalled();
+  });
+});

--- a/electron/ipc/handlers/__tests__/forgeResolution.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeResolution.test.ts
@@ -39,6 +39,7 @@ vi.mock("../../../services/ProjectStore.js", () => ({ projectStore: projectStore
 const gitServiceMock = vi.hoisted(() => ({
   getRemoteUrl: vi.fn(),
   listWorktrees: vi.fn(),
+  getRepositoryRoot: vi.fn(),
 }));
 const gitServiceCacheMock = vi.hoisted(() => ({ getGitService: vi.fn(() => gitServiceMock) }));
 
@@ -70,7 +71,10 @@ describe("resolveForCwd", () => {
     gitServiceMock.listWorktrees.mockResolvedValue([
       { path: "/repo", branch: "main", bare: false, isMainWorktree: true },
     ]);
-    projectStoreMock.getProjectByPath.mockResolvedValue({ id: "project-1", path: "/repo" });
+    gitServiceMock.getRepositoryRoot.mockResolvedValue("/repo");
+    projectStoreMock.getProjectByPath.mockImplementation(async (p: string) =>
+      p === "/repo" ? { id: "project-1", path: "/repo" } : null
+    );
     projectStoreMock.getProjectSettings.mockResolvedValue({ runCommands: [] });
     registryMock.getForgeProviderImpl.mockReturnValue(undefined);
     resolverMock.resolveForgeProvider.mockReturnValue({ entry: null, resolvedVia: null });
@@ -113,13 +117,37 @@ describe("resolveForCwd", () => {
     expect(projectStoreMock.getProjectSettings).toHaveBeenCalledWith("project-1");
   });
 
-  it("falls back to the cwd for project lookup when listWorktrees fails", async () => {
+  it("falls back to the repository root when listWorktrees fails and cwd is a subdirectory", async () => {
     gitServiceMock.listWorktrees.mockRejectedValue(new Error("not a work tree"));
+    projectStoreMock.getProjectSettings.mockResolvedValue({
+      runCommands: [],
+      forgeProviderOverride: "acme.gitea",
+    });
 
-    await resolveForCwd("/repo").catch(() => null);
+    await resolveForCwd("/repo/src").catch(() => null);
 
     expect(projectStoreMock.getProjectByPath).toHaveBeenCalledWith("/repo");
+    expect(lastResolverInputs().forgeProviderOverride).toBe("acme.gitea");
+  });
+
+  it("falls back to the raw cwd when both listWorktrees and getRepositoryRoot fail", async () => {
+    gitServiceMock.listWorktrees.mockRejectedValue(new Error("not a work tree"));
+    gitServiceMock.getRepositoryRoot.mockRejectedValue(new Error("not a git repo"));
+
+    await resolveForCwd("/repo/src").catch(() => null);
+
+    expect(projectStoreMock.getProjectByPath).toHaveBeenCalledWith("/repo/src");
     expect(lastResolverInputs().forgeProviderOverride).toBeNull();
+  });
+
+  it("falls back to the repository root when no worktree entry is marked main", async () => {
+    gitServiceMock.listWorktrees.mockResolvedValue([
+      { path: "/elsewhere", branch: "main", bare: false, isMainWorktree: false },
+    ]);
+
+    await resolveForCwd("/repo/src").catch(() => null);
+
+    expect(projectStoreMock.getProjectByPath).toHaveBeenCalledWith("/repo");
   });
 
   it("passes a null override when no project matches the path", async () => {
@@ -167,6 +195,17 @@ describe("resolveForCwd", () => {
       forgeProviderOverride: "acme.gitea",
       globalDefaultProviderId: "daintree.github.github",
     });
+  });
+
+  it("fails closed when the override names an unregistered provider", async () => {
+    projectStoreMock.getProjectSettings.mockResolvedValue({
+      runCommands: [],
+      forgeProviderOverride: "acme.unregistered",
+    });
+    resolverMock.resolveForgeProvider.mockReturnValue({ entry: null, resolvedVia: null });
+
+    await expect(resolveForCwd("/repo")).rejects.toThrow("No forge provider registered");
+    expect(lastResolverInputs().forgeProviderOverride).toBe("acme.unregistered");
   });
 
   it("rejects invalid cwd payloads before any lookup", async () => {

--- a/electron/ipc/handlers/forgeResolution.ts
+++ b/electron/ipc/handlers/forgeResolution.ts
@@ -3,6 +3,7 @@ import { store } from "../../store.js";
 import { getForgeProviderImpl } from "../../services/forgeProviderRegistry.js";
 import { resolveForgeProvider } from "../../services/forgeProviderResolver.js";
 import { gitServiceCache } from "../../services/GitServiceCache.js";
+import { projectStore } from "../../services/ProjectStore.js";
 import type { ForgeProviderImpl, RepoRef } from "../../../shared/types/forge.js";
 import {
   makeForgeProviderId,
@@ -42,11 +43,22 @@ export async function resolveForCwd(cwd: string): Promise<ResolvedForgeContext> 
     throw new Error("No remote URL found for this repository");
   }
 
+  // The cwd may be a linked-worktree subdirectory, so an exact match against
+  // `project.path` would miss. `git worktree list` reports the main worktree
+  // first from anywhere inside the repo — that path is what ProjectStore keys on.
+  const worktrees = await gitService.listWorktrees().catch(() => []);
+  const mainWorktreePath = worktrees.find((wt) => wt.isMainWorktree)?.path ?? cwd;
+  const project = await projectStore.getProjectByPath(mainWorktreePath).catch(() => null);
+  const settings = project
+    ? await projectStore.getProjectSettings(project.id).catch(() => null)
+    : null;
+  const forgeProviderOverride = settings?.forgeProviderOverride ?? null;
+
   const globalDefaultProviderId = normalizeProviderId(store.get("forgeDefaultProviderId"));
 
   const resolved = resolveForgeProvider({
     remoteUrl,
-    forgeProviderOverride: null,
+    forgeProviderOverride,
     globalDefaultProviderId,
   });
 

--- a/electron/ipc/handlers/forgeResolution.ts
+++ b/electron/ipc/handlers/forgeResolution.ts
@@ -47,7 +47,10 @@ export async function resolveForCwd(cwd: string): Promise<ResolvedForgeContext> 
   // `project.path` would miss. `git worktree list` reports the main worktree
   // first from anywhere inside the repo — that path is what ProjectStore keys on.
   const worktrees = await gitService.listWorktrees().catch(() => []);
-  const mainWorktreePath = worktrees.find((wt) => wt.isMainWorktree)?.path ?? cwd;
+  const mainWorktreePath =
+    worktrees.find((wt) => wt.isMainWorktree)?.path ??
+    (await gitService.getRepositoryRoot(cwd).catch(() => null)) ??
+    cwd;
   const project = await projectStore.getProjectByPath(mainWorktreePath).catch(() => null);
   const settings = project
     ? await projectStore.getProjectSettings(project.id).catch(() => null)

--- a/electron/utils/hostPerformance.ts
+++ b/electron/utils/hostPerformance.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: utility-process-safe perf helper for pty-host/workspace-host
 import fs from "node:fs";
 import { getCompileCacheDir } from "node:module";
 import path from "node:path";

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: multi-window service initialization
 import { app, BrowserWindow, dialog, webContents } from "electron";
 import os from "os";
 import { registerIpcHandlers, sendToRenderer } from "../ipc/handlers.js";


### PR DESCRIPTION
Closes #9984

## Problem

`resolveForCwd` in `electron/ipc/handlers/forgeResolution.ts` — the shared resolver behind every renderer-facing forge IPC handler (`forge.ts` open/assign, `forgeData.ts` list/get) — hardcoded `forgeProviderOverride: null`. The per-project forge provider override from project settings (#8111) was silently ignored by every actual forge operation, while `forge:resolve-provider` (`forgeSettings.ts`) and the workspace-host PR detection path honoured it — so the settings UI claimed one provider and operations used another.

## Fix

`resolveForCwd` now resolves the owning project and passes its real override:

- Derive the main worktree path via `gitService.listWorktrees()` and `.find(wt => wt.isMainWorktree)` — the cwd may be a linked-worktree subdirectory, and `ProjectStore` keys on the main worktree path
- Fall back to `getRepositoryRoot(cwd)`, then the raw cwd, when the worktree listing fails
- `projectStore.getProjectByPath(mainPath)` → `getProjectSettings(project.id)` → pass `forgeProviderOverride` to `resolveForgeProvider`
- Every lookup degrades non-fatally to a `null` override (the pre-fix behavior), matching the `forgeSettings.ts` pattern

Also refreshes `eager-import-baseline.json` (+4 modules from the intentional `ProjectStore` import; absorbs pre-existing line drift from develop merges that postdate the last regen) — the update script added `eager-import-allow` headers to `hostPerformance.ts` and `windowServices.ts`.

## Tests

New `electron/ipc/handlers/__tests__/forgeResolution.test.ts` with 13 cases: override pass-through to the resolver, main-worktree lookup from a linked-worktree subdir cwd, each fallback chain (listWorktrees failure → repo root → raw cwd, no-main-worktree parser drift), null-override degradation (project missing, lookup rejects, settings fetch rejects, override unset), fail-closed unregistered override, and rejection ordering for invalid cwd / missing remote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)