### PR TITLE
fix(crash-recovery): surface classified cause in dialog and persist marker-only logs

### DIFF
--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -443,7 +443,7 @@ export class CrashRecoveryService {
         return null;
       }
 
-      // Move the live backup aside BEFORE deleting the marker. A kill
+      // Move the live backup aside BEFORE any state mutations. A kill
       // between the two operations would otherwise wipe the marker (and
       // skip crash detection on the next launch) while session-state.json
       // is still present and recoverable. preserveBackupForRecovery is
@@ -451,7 +451,12 @@ export class CrashRecoveryService {
       // from a partially-completed prior attempt it is reused.
       this.crashedBackupPath = this.preserveBackupForRecovery(marker.sessionStartMs);
 
-      this.deleteMarker();
+      // NOTE: deleteMarker() is called AFTER the synthesized crash log is
+      // written below (per the #8728 preserve-before-delete ordering rule).
+      // If a kill happens in the gap, the next launch re-runs consumeMarker
+      // and surfaces the recovery dialog against the persisted log.
+      // (Watchdog annotation rewrites for an existing logPath fire earlier
+      // in this block and are unaffected.)
 
       // Gate hasBackup on parseability: a renamed crashed-* file that fails
       // to parse (corrupted write, partial flush) shouldn't surface a
@@ -536,14 +541,22 @@ export class CrashRecoveryService {
       // For marker-only crashes (no original crashLogPath — e.g. external kill,
       // power loss, native crash), synthesize a real on-disk log so the
       // recovery dialog's "Open log file" affordance points at a file that
-      // actually exists. Persist BEFORE returning the PendingCrash so the
-      // dialog can openPath it immediately on mount. Failure is non-fatal —
-      // the in-memory entry is the source of truth and the dialog falls back
-      // to a softer warning if the file later can't be opened.
+      // actually exists. Persist BEFORE deleteMarker (per #8728's
+      // preserve-before-delete ordering rule) so a kill in this window still
+      // leaves the marker pointing at a real on-disk log, and the next
+      // launch re-runs consumeMarker to surface the recovery dialog. Failure
+      // is non-fatal — the in-memory entry is the source of truth and the
+      // dialog falls back to a softer warning if the file later can't be
+      // opened.
       let resolvedLogPath = logPath;
       if (!resolvedLogPath) {
         try {
           resolvedLogPath = this.writeCrashLog(entry);
+          // Honor the same MAX_CRASH_LOGS retention as recordCrash so 25
+          // consecutive external kills don't accumulate crash-{id}.json
+          // files. recordCrash also calls pruneOldLogs; folding it here keeps
+          // retention behavior consistent across both code paths.
+          this.pruneOldLogs();
         } catch (writeErr) {
           console.error("[CrashRecovery] Failed to persist synthesized crash log:", writeErr);
           // Fall back to the synthetic path so PendingCrash.logPath is stable
@@ -552,6 +565,12 @@ export class CrashRecoveryService {
           resolvedLogPath = path.join(this.crashesDir, `crash-${entry.id}.json`);
         }
       }
+
+      // Marker is unlinked LAST — after the synthesized crash log is on disk.
+      // A kill between preserveBackupForRecovery and this point still leaves
+      // the marker on disk and the next launch re-detects the crash against
+      // the persisted log.
+      this.deleteMarker();
 
       const panels = parseableBackupPath
         ? this.extractPanelSummaries(entry.timestamp, parseableBackupPath)

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -135,17 +135,33 @@ export class CrashRecoveryService {
     this.crashRecorded = true;
 
     try {
-      fs.mkdirSync(this.crashesDir, { recursive: true });
-
       const entry = this.buildCrashEntry(error);
-      const logPath = path.join(this.crashesDir, `crash-${entry.id}.json`);
-      resilientAtomicWriteFileSync(logPath, JSON.stringify(entry, null, 2), "utf-8");
+      // The only call site is the uncaughtException handler, so the cause is
+      // always "uncaught-exception" — but the field is additive, default only
+      // when absent so a future caller passing a more specific cause is honored.
+      if (entry.crashCause === undefined) entry.crashCause = "uncaught-exception";
+      const logPath = this.writeCrashLog(entry);
       this.writeMarker(entry);
       this.pruneOldLogs();
       console.log("[CrashRecovery] Crash recorded:", logPath);
     } catch (err) {
       console.error("[CrashRecovery] Failed to record crash:", err);
     }
+  }
+
+  /**
+   * Persist a crash log to `crashesDir/crash-{id}.json` using the same
+   * `resilientAtomicWriteFileSync` channel as `recordCrash` (handles Windows
+   * AV/indexer lock retries). Shared by `recordCrash` and the marker-only
+   * branch of `consumeMarker` so both call sites produce a real on-disk
+   * artifact and the dialog's "Open log file" affordance always points at a
+   * file that exists.
+   */
+  private writeCrashLog(entry: CrashLogEntry): string {
+    fs.mkdirSync(this.crashesDir, { recursive: true });
+    const logPath = path.join(this.crashesDir, `crash-${entry.id}.json`);
+    resilientAtomicWriteFileSync(logPath, JSON.stringify(entry, null, 2), "utf-8");
+    return logPath;
   }
 
   startBackupTimer(): void {
@@ -516,12 +532,33 @@ export class CrashRecoveryService {
           }
         }
       }
+
+      // For marker-only crashes (no original crashLogPath — e.g. external kill,
+      // power loss, native crash), synthesize a real on-disk log so the
+      // recovery dialog's "Open log file" affordance points at a file that
+      // actually exists. Persist BEFORE returning the PendingCrash so the
+      // dialog can openPath it immediately on mount. Failure is non-fatal —
+      // the in-memory entry is the source of truth and the dialog falls back
+      // to a softer warning if the file later can't be opened.
+      let resolvedLogPath = logPath;
+      if (!resolvedLogPath) {
+        try {
+          resolvedLogPath = this.writeCrashLog(entry);
+        } catch (writeErr) {
+          console.error("[CrashRecovery] Failed to persist synthesized crash log:", writeErr);
+          // Fall back to the synthetic path so PendingCrash.logPath is stable
+          // for the renderer; the dialog's defensive openPath handler covers
+          // the missing-file case.
+          resolvedLogPath = path.join(this.crashesDir, `crash-${entry.id}.json`);
+        }
+      }
+
       const panels = parseableBackupPath
         ? this.extractPanelSummaries(entry.timestamp, parseableBackupPath)
         : undefined;
 
       return {
-        logPath: logPath ?? path.join(this.crashesDir, `crash-${entry.id}.json`),
+        logPath: resolvedLogPath,
         entry,
         hasBackup: parseableBackupPath !== null,
         backupTimestamp,
@@ -841,6 +878,7 @@ export class CrashRecoveryService {
 
     this.enrichWithEnvironmentMetadata(entry);
     this.enrichWithPanelData(entry, this.readCrashedBackupAppState());
+    this.enrichWithRecentActions(entry);
 
     return entry;
   }

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -1843,18 +1843,10 @@ describe("CrashRecoveryService", () => {
         if (String(target).endsWith("running.lock")) events.push("unlink-marker");
         return realUnlink(target);
       }) as typeof fs.unlinkSync);
-      utilsMock.resilientAtomicWriteFileSync.mockImplementation(((
-        fp: string,
-        data: string,
-        enc?: BufferEncoding
-      ) => {
+      utilsMock.resilientAtomicWriteFileSync.mockImplementation((fp, data, enc) => {
         if (fp.includes("crash-") && !fp.includes("session-state")) events.push("write-crash-log");
         fs.writeFileSync(fp, data, enc ?? "utf-8");
-      }) as typeof utilsMock.resilientAtomicWriteFileSync.mockImplementation extends (
-        ...args: infer _A
-      ) => infer _R
-        ? (...args: _A) => _R
-        : never);
+      });
       try {
         fs.writeFileSync(
           path.join(userData, "running.lock"),

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -1831,6 +1831,55 @@ describe("CrashRecoveryService", () => {
       }
     });
 
+    it("writes the synthesized log before deleteMarker (preserve-before-delete per #8728)", () => {
+      const uptime = osUptimeSpy(24 * 60 * 60);
+      // Track the order in which the marker is unlinked and the synthesized
+      // crash log is written. The marker must still be present at the moment
+      // writeCrashLog fires — a kill in the gap would otherwise leave the
+      // next launch with a real log file but no marker to consume it.
+      const events: string[] = [];
+      const realUnlink = fs.unlinkSync;
+      const unlinkSpy = vi.spyOn(fs, "unlinkSync").mockImplementation(((target: fs.PathLike) => {
+        if (String(target).endsWith("running.lock")) events.push("unlink-marker");
+        return realUnlink(target);
+      }) as typeof fs.unlinkSync);
+      utilsMock.resilientAtomicWriteFileSync.mockImplementation(((
+        fp: string,
+        data: string,
+        enc?: BufferEncoding
+      ) => {
+        if (fp.includes("crash-") && !fp.includes("session-state")) events.push("write-crash-log");
+        fs.writeFileSync(fp, data, enc ?? "utf-8");
+      }) as typeof utilsMock.resilientAtomicWriteFileSync.mockImplementation extends (
+        ...args: infer _A
+      ) => infer _R
+        ? (...args: _A) => _R
+        : never);
+      try {
+        fs.writeFileSync(
+          path.join(userData, "running.lock"),
+          JSON.stringify({
+            sessionStartMs: Date.now() - 10 * 60 * 1000,
+            appVersion: "1.0.0",
+            platform: "darwin",
+            lastHeartbeatMs: Date.now() - 5 * 60 * 1000,
+          })
+        );
+
+        const svc = makeService();
+        svc.initialize();
+
+        // The crash log was written first; the marker was unlinked afterwards.
+        const writeIdx = events.indexOf("write-crash-log");
+        const unlinkIdx = events.indexOf("unlink-marker");
+        expect(writeIdx).toBeGreaterThanOrEqual(0);
+        expect(unlinkIdx).toBeGreaterThan(writeIdx);
+      } finally {
+        unlinkSpy.mockRestore();
+        uptime.mockRestore();
+      }
+    });
+
     it("falls back to the synthetic path without throwing when writeCrashLog fails", () => {
       const uptime = osUptimeSpy(24 * 60 * 60);
       // Force the atomic write to throw — the dialog's defensive openPath
@@ -1860,6 +1909,40 @@ describe("CrashRecoveryService", () => {
         expect(pending!.logPath).toBe(
           path.join(userData, "crashes", `crash-${pending!.entry.id}.json`)
         );
+      } finally {
+        uptime.mockRestore();
+      }
+    });
+
+    it("prunes old crash logs after writing a synthesized marker-only log", () => {
+      const uptime = osUptimeSpy(24 * 60 * 60);
+      try {
+        // Seed 12 pre-existing crash-{id}.json files to exceed MAX_CRASH_LOGS=10.
+        const crashesDir = path.join(userData, "crashes");
+        fs.mkdirSync(crashesDir, { recursive: true });
+        for (let i = 0; i < 12; i++) {
+          fs.writeFileSync(
+            path.join(crashesDir, `crash-seed-${i}.json`),
+            JSON.stringify({ id: `seed-${i}`, timestamp: Date.now() - (12 - i) * 1000 })
+          );
+        }
+
+        fs.writeFileSync(
+          path.join(userData, "running.lock"),
+          JSON.stringify({
+            sessionStartMs: Date.now() - 10 * 60 * 1000,
+            appVersion: "1.0.0",
+            platform: "darwin",
+            lastHeartbeatMs: Date.now() - 5 * 60 * 1000,
+          })
+        );
+
+        const svc = makeService();
+        svc.initialize();
+
+        const remaining = fs.readdirSync(crashesDir).filter((f) => f.startsWith("crash-"));
+        // 12 seeded + 1 synthesized = 13 → pruned down to MAX_CRASH_LOGS=10.
+        expect(remaining.length).toBeLessThanOrEqual(10);
       } finally {
         uptime.mockRestore();
       }

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -1767,6 +1767,119 @@ describe("CrashRecoveryService", () => {
     });
   });
 
+  describe("marker-only persistence", () => {
+    function osUptimeSpy(returnValue: number): ReturnType<typeof vi.spyOn> {
+      return vi.spyOn(os, "uptime").mockReturnValue(returnValue);
+    }
+
+    it("writes crash-{id}.json to crashesDir when marker has no crashLogPath (external-kill)", () => {
+      const uptime = osUptimeSpy(24 * 60 * 60);
+      try {
+        fs.writeFileSync(
+          path.join(userData, "running.lock"),
+          JSON.stringify({
+            sessionStartMs: Date.now() - 10 * 60 * 1000,
+            appVersion: "1.0.0",
+            platform: "darwin",
+            lastHeartbeatMs: Date.now() - 5 * 60 * 1000,
+          })
+        );
+
+        const svc = makeService();
+        svc.initialize();
+
+        const pending = svc.getPendingCrash();
+        expect(pending).not.toBeNull();
+        expect(pending!.entry.crashCause).toBe("external-kill");
+
+        // The on-disk log file is now real and lives under userData/crashes/.
+        const crashesDir = path.join(userData, "crashes");
+        const logFile = path.join(crashesDir, `crash-${pending!.entry.id}.json`);
+        expect(fs.existsSync(logFile)).toBe(true);
+        expect(pending!.logPath).toBe(logFile);
+
+        // Round-trip the JSON and verify the cause survives.
+        const persisted = JSON.parse(fs.readFileSync(logFile, "utf-8"));
+        expect(persisted.id).toBe(pending!.entry.id);
+        expect(persisted.crashCause).toBe("external-kill");
+      } finally {
+        uptime.mockRestore();
+      }
+    });
+
+    it("PendingCrash.logPath points at the persisted file for power-loss (marker-only)", () => {
+      const uptime = osUptimeSpy(10);
+      try {
+        fs.writeFileSync(
+          path.join(userData, "running.lock"),
+          JSON.stringify({
+            sessionStartMs: Date.now() - 5 * 60 * 1000,
+            appVersion: "1.0.0",
+            platform: "darwin",
+            lastHeartbeatMs: Date.now() - 60_000,
+          })
+        );
+
+        const svc = makeService();
+        svc.initialize();
+
+        const pending = svc.getPendingCrash();
+        expect(pending!.entry.crashCause).toBe("power-loss");
+        expect(fs.existsSync(pending!.logPath)).toBe(true);
+      } finally {
+        uptime.mockRestore();
+      }
+    });
+
+    it("falls back to the synthetic path without throwing when writeCrashLog fails", () => {
+      const uptime = osUptimeSpy(24 * 60 * 60);
+      // Force the atomic write to throw — the dialog's defensive openPath
+      // handler covers the missing-file case, but the path field must stay
+      // stable so the renderer never sees `undefined`.
+      utilsMock.resilientAtomicWriteFileSync.mockImplementationOnce(() => {
+        throw new Error("ENOSPC: disk full");
+      });
+      try {
+        fs.writeFileSync(
+          path.join(userData, "running.lock"),
+          JSON.stringify({
+            sessionStartMs: Date.now() - 10 * 60 * 1000,
+            appVersion: "1.0.0",
+            platform: "darwin",
+            lastHeartbeatMs: Date.now() - 5 * 60 * 1000,
+          })
+        );
+
+        const svc = makeService();
+        svc.initialize();
+
+        const pending = svc.getPendingCrash();
+        expect(pending).not.toBeNull();
+        expect(pending!.entry.crashCause).toBe("external-kill");
+        // Falls back to the synthetic path so the renderer always gets a string.
+        expect(pending!.logPath).toBe(
+          path.join(userData, "crashes", `crash-${pending!.entry.id}.json`)
+        );
+      } finally {
+        uptime.mockRestore();
+      }
+    });
+  });
+
+  describe("recordCrash crashCause default", () => {
+    it("persists crashCause: 'uncaught-exception' on the entry", () => {
+      const svc = makeService();
+      svc.recordCrash(new Error("boom"));
+
+      const crashesDir = path.join(userData, "crashes");
+      const files = fs.readdirSync(crashesDir).filter((f) => f.startsWith("crash-"));
+      expect(files.length).toBe(1);
+      const persisted = JSON.parse(fs.readFileSync(path.join(crashesDir, files[0]!), "utf-8"));
+      expect(persisted.crashCause).toBe("uncaught-exception");
+      expect(persisted.errorMessage).toBe("boom");
+    });
+  });
+
   describe("heartbeat and suspend stamping", () => {
     it("writes lastHeartbeatMs on initialize", () => {
       const before = Date.now();

--- a/shared/utils/__tests__/buildCrashReportUrl.test.ts
+++ b/shared/utils/__tests__/buildCrashReportUrl.test.ts
@@ -267,6 +267,35 @@ describe("buildCrashReportUrl", () => {
     expect(body).toContain("**Cause**: Watchdog deadlock (SIGKILL)");
     expect(body).not.toContain("External kill");
   });
+
+  it("does not throw on a future-schema crashCause value (defensive normalization)", () => {
+    // A log from a newer build with a cause enum value this build doesn't know
+    // about must not throw TypeError from CRASH_CAUSE_COPY[bad].title — the
+    // dialog and report preview both render during a crash-pending state.
+    const result = buildCrashReportUrl(
+      baseEntry({ errorMessage: undefined, crashCause: "future-value" as never })
+    );
+    const body = decodeBody(result.url);
+    // No Cause: line for unknown / future-schema values (would be "Unknown"
+    // noise).
+    expect(body).not.toContain("**Cause**:");
+    // Title falls back to the V1 generic for an unknown cause.
+    expect(decodeTitle(result.url)).toContain("Daintree closed unexpectedly");
+  });
+
+  it("does not throw on an out-of-range timestamp (safeIsoTime guards toISOString)", () => {
+    expect(() =>
+      buildCrashReportUrl(
+        baseEntry({
+          timestamp: Number.MAX_VALUE,
+          watchdogKilledAt: Number.MAX_VALUE,
+          cause: "watchdog-deadlock",
+          watchdogMissedBeats: 3,
+          watchdogMainPid: 42,
+        })
+      )
+    ).not.toThrow();
+  });
 });
 
 describe("buildCrashReportUrlFromBody", () => {

--- a/shared/utils/__tests__/buildCrashReportUrl.test.ts
+++ b/shared/utils/__tests__/buildCrashReportUrl.test.ts
@@ -217,6 +217,56 @@ describe("buildCrashReportUrl", () => {
     );
     expect(result.url).toContain(encodeURIComponent("watchdog-deadlock"));
   });
+
+  it("uses a cause-aware title when no errorMessage and no precise cause", () => {
+    const result = buildCrashReportUrl(
+      baseEntry({ errorMessage: undefined, crashCause: "power-loss" })
+    );
+    const title = decodeTitle(result.url);
+    expect(title).toContain("Power was interrupted");
+  });
+
+  it("uses a cause-aware title for external-kill when no errorMessage", () => {
+    const result = buildCrashReportUrl(
+      baseEntry({ errorMessage: undefined, crashCause: "external-kill" })
+    );
+    expect(decodeTitle(result.url)).toContain("Daintree was forced to close");
+  });
+
+  it("falls back to the generic V1 title when neither errorMessage nor crashCause is set", () => {
+    const result = buildCrashReportUrl(
+      baseEntry({ errorMessage: undefined, crashCause: undefined })
+    );
+    expect(decodeTitle(result.url)).toContain("Daintree closed unexpectedly");
+  });
+
+  it("renders a Cause line in the body for non-uncaught-exception crashCause values", () => {
+    const result = buildCrashReportUrl(baseEntry({ crashCause: "power-loss" }));
+    const body = decodeBody(result.url);
+    expect(body).toContain("**Cause**: Power loss or system reboot");
+  });
+
+  it("renders a Cause line for external-kill in the body", () => {
+    const result = buildCrashReportUrl(baseEntry({ crashCause: "external-kill" }));
+    const body = decodeBody(result.url);
+    expect(body).toContain("**Cause**: External kill");
+  });
+
+  it("skips the Cause line for uncaught-exception (redundant with the Error line)", () => {
+    const result = buildCrashReportUrl(baseEntry({ crashCause: "uncaught-exception" }));
+    const body = decodeBody(result.url);
+    expect(body).not.toMatch(/\*\*Cause\*\*:/);
+  });
+
+  it("preserves the watchdog Cause line byte-identical when watchdog is set", () => {
+    const result = buildCrashReportUrl(
+      baseEntry({ cause: "watchdog-deadlock", crashCause: "external-kill" })
+    );
+    const body = decodeBody(result.url);
+    // Watchdog exact wording is load-bearing for downstream regex extraction.
+    expect(body).toContain("**Cause**: Watchdog deadlock (SIGKILL)");
+    expect(body).not.toContain("External kill");
+  });
 });
 
 describe("buildCrashReportUrlFromBody", () => {

--- a/shared/utils/__tests__/crashCauseCopy.test.ts
+++ b/shared/utils/__tests__/crashCauseCopy.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import {
+  CRASH_CAUSE_COPY,
+  getCrashCauseTitle,
+  getCrashCauseDescription,
+  getCrashCauseReportLabel,
+} from "../crashCauseCopy.js";
+import type { CrashCause } from "../../types/ipc/crashRecovery.js";
+
+describe("CRASH_CAUSE_COPY", () => {
+  it("has a copy entry for every CrashCause value (exhaustive)", () => {
+    const allCauses: CrashCause[] = [
+      "uncaught-exception",
+      "native-crash",
+      "suspended-then-lost",
+      "power-loss",
+      "external-kill",
+      "unknown",
+    ];
+    for (const cause of allCauses) {
+      const copy = CRASH_CAUSE_COPY[cause];
+      expect(copy).toBeDefined();
+      expect(copy.title).toBeTypeOf("string");
+      expect(copy.title.length).toBeGreaterThan(0);
+      expect(copy.title.endsWith(".")).toBe(false); // sentence-case, no trailing period on titles
+      expect(copy.description).toBeTypeOf("string");
+      expect(copy.description.length).toBeGreaterThan(0);
+      expect(copy.reportLabel).toBeTypeOf("string");
+      expect(copy.reportLabel.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("renders the unknown cause with the V1-generic title for log-fallback parity", () => {
+    expect(CRASH_CAUSE_COPY.unknown.title).toBe("Daintree closed unexpectedly");
+  });
+
+  it("keeps cause-specific titles distinct from the generic fallback", () => {
+    const distinctCauses: CrashCause[] = [
+      "uncaught-exception",
+      "native-crash",
+      "suspended-then-lost",
+      "power-loss",
+      "external-kill",
+    ];
+    const titles = new Set(distinctCauses.map((c) => CRASH_CAUSE_COPY[c].title));
+    expect(titles.size).toBe(distinctCauses.length);
+  });
+});
+
+describe("getCrashCauseTitle", () => {
+  it("returns the title for a known cause", () => {
+    expect(getCrashCauseTitle("power-loss")).toBe("Power was interrupted");
+    expect(getCrashCauseTitle("external-kill")).toBe("Daintree was forced to close");
+  });
+
+  it("falls back to the V1 generic title for undefined", () => {
+    expect(getCrashCauseTitle(undefined)).toBe("Daintree closed unexpectedly");
+  });
+
+  it("returns the generic title for the 'unknown' cause", () => {
+    expect(getCrashCauseTitle("unknown")).toBe("Daintree closed unexpectedly");
+  });
+});
+
+describe("getCrashCauseDescription", () => {
+  it("returns the description for a known cause", () => {
+    const desc = getCrashCauseDescription("power-loss");
+    expect(desc).toContain("rebooted");
+  });
+
+  it("falls back to the V1 generic description for undefined", () => {
+    expect(getCrashCauseDescription(undefined)).toContain("unexpectedly");
+  });
+});
+
+describe("getCrashCauseReportLabel", () => {
+  it("returns the report label for a known cause", () => {
+    expect(getCrashCauseReportLabel("external-kill")).toContain("External kill");
+  });
+
+  it("returns 'Unknown' for undefined (V1 log fallback)", () => {
+    expect(getCrashCauseReportLabel(undefined)).toBe("Unknown");
+  });
+});

--- a/shared/utils/buildCrashReportUrl.ts
+++ b/shared/utils/buildCrashReportUrl.ts
@@ -1,6 +1,7 @@
 import type { ActionBreadcrumb, CrashLogEntry } from "../types/ipc/crashRecovery.js";
 import { scrubReportText } from "./reportScrubbers.js";
 import { URL_BODY_BUDGET, capForBudget, makeUrl, truncateStackMiddle } from "./githubIssueUrl.js";
+import { getCrashCauseReportLabel, getCrashCauseTitle } from "./crashCauseCopy.js";
 
 export interface CrashReportResult {
   url: string;
@@ -138,6 +139,12 @@ function formatCrashBody(
       causeParts.push(`main PID ${e.watchdogMainPid}`);
     }
     lines.push(`- ${causeParts.join(" — ")}`);
+  } else if (e.crashCause && e.crashCause !== "uncaught-exception") {
+    // The `**Error**:` line right below already names the uncaught exception
+    // message, so adding `**Cause**: Uncaught JavaScript exception` would be
+    // redundant noise. For every other cause, surface the heuristic so the
+    // report is searchable for "power-loss", "external-kill", etc.
+    lines.push(`- **Cause**: ${getCrashCauseReportLabel(e.crashCause)}`);
   }
 
   if (e.errorMessage) {
@@ -182,8 +189,17 @@ function buildStubBody(entry: CrashLogEntry): string {
 function makeCrashTitle(entry: CrashLogEntry): string {
   // Scrub the title too — it carries the error message, which can contain user
   // paths or secrets that would otherwise leak in the URL's `title=` param.
+  // Fallback order: error message (most specific) → precise `cause` code
+  // (e.g. "watchdog-deadlock") wins over the heuristic `crashCause` title
+  // because the precise attribution is the load-bearing signal in the title;
+  // the heuristic title fills in when only a heuristic is available.
   return scrubReportText(
-    `Crash: ${entry.errorMessage || entry.cause || "Daintree closed unexpectedly"}`
+    `Crash: ${
+      entry.errorMessage ||
+      entry.cause ||
+      getCrashCauseTitle(entry.crashCause) ||
+      "Daintree closed unexpectedly"
+    }`
   );
 }
 

--- a/shared/utils/buildCrashReportUrl.ts
+++ b/shared/utils/buildCrashReportUrl.ts
@@ -1,7 +1,11 @@
 import type { ActionBreadcrumb, CrashLogEntry } from "../types/ipc/crashRecovery.js";
 import { scrubReportText } from "./reportScrubbers.js";
 import { URL_BODY_BUDGET, capForBudget, makeUrl, truncateStackMiddle } from "./githubIssueUrl.js";
-import { getCrashCauseReportLabel, getCrashCauseTitle } from "./crashCauseCopy.js";
+import {
+  getCrashCauseReportLabel,
+  getCrashCauseTitle,
+  normalizeCrashCause,
+} from "./crashCauseCopy.js";
 
 export interface CrashReportResult {
   url: string;
@@ -125,7 +129,7 @@ function formatCrashBody(
   if (e.gpuAccelerationDisabled !== undefined)
     lines.push(`- **GPU Acceleration**: ${e.gpuAccelerationDisabled ? "Disabled" : "Enabled"}`);
 
-  lines.push(`- **Crashed at**: ${new Date(e.timestamp).toISOString()}`);
+  lines.push(`- **Crashed at**: ${safeIsoTime(e.timestamp)}`);
 
   if (e.cause === "watchdog-deadlock") {
     const causeParts: string[] = [`**Cause**: Watchdog deadlock (SIGKILL)`];
@@ -133,17 +137,23 @@ function formatCrashBody(
       causeParts.push(`${e.watchdogMissedBeats} missed heartbeats`);
     }
     if (e.watchdogKilledAt !== undefined) {
-      causeParts.push(`killed at ${new Date(e.watchdogKilledAt).toISOString()}`);
+      causeParts.push(`killed at ${safeIsoTime(e.watchdogKilledAt)}`);
     }
     if (e.watchdogMainPid !== undefined) {
       causeParts.push(`main PID ${e.watchdogMainPid}`);
     }
     lines.push(`- ${causeParts.join(" — ")}`);
-  } else if (e.crashCause && e.crashCause !== "uncaught-exception") {
+  } else if (
+    e.crashCause &&
+    e.crashCause !== "uncaught-exception" &&
+    normalizeCrashCause(e.crashCause) !== "unknown"
+  ) {
     // The `**Error**:` line right below already names the uncaught exception
     // message, so adding `**Cause**: Uncaught JavaScript exception` would be
-    // redundant noise. For every other cause, surface the heuristic so the
-    // report is searchable for "power-loss", "external-kill", etc.
+    // redundant noise. Unknown / future-schema crashCause values are skipped
+    // (rather than rendered as "Cause: Unknown") so the report stays free of
+    // non-actionable labels — getCrashCauseReportLabel() still normalizes
+    // the value defensively, but the body just doesn't carry the line.
     lines.push(`- **Cause**: ${getCrashCauseReportLabel(e.crashCause)}`);
   }
 

--- a/shared/utils/crashCauseCopy.ts
+++ b/shared/utils/crashCauseCopy.ts
@@ -1,0 +1,69 @@
+import type { CrashCause } from "../types/ipc/crashRecovery.js";
+
+export interface CrashCauseCopy {
+  /** Short, sentence-case title (no trailing period). Shown in the recovery dialog headline. */
+  title: string;
+  /** One-sentence sub-line shown under the dialog headline. Sentence case, may end in a period. */
+  description: string;
+  /** Short label used in the GitHub report's `**Cause**:` line. Sentence case, no trailing period. */
+  reportLabel: string;
+}
+
+/**
+ * Per-cause copy. Each entry surfaces a single, user-facing interpretation of
+ * the heuristic `crashCause` classification in the recovery dialog and the
+ * GitHub crash report. The classification itself is heuristic-only and
+ * complements the precise `cause: "watchdog-deadlock"` annotation.
+ *
+ * `unknown` mirrors the V1 log fallback (no cause) so older crash logs read
+ * back through `readCrashLog`'s permissive parse and a user who upgrades then
+ * re-crashes see the same generic headline.
+ */
+export const CRASH_CAUSE_COPY: Record<CrashCause, CrashCauseCopy> = {
+  "uncaught-exception": {
+    title: "Daintree hit an error",
+    description: "An unhandled error ended the previous session.",
+    reportLabel: "Uncaught JavaScript exception",
+  },
+  "native-crash": {
+    title: "Daintree crashed unexpectedly",
+    description: "A native crash ended the previous session, often a segfault or GPU fault.",
+    reportLabel: "Native crash (Crashpad minidump)",
+  },
+  "suspended-then-lost": {
+    title: "Daintree didn't come back from sleep",
+    description: "Daintree was suspended and never resumed cleanly.",
+    reportLabel: "Suspended and never resumed",
+  },
+  "power-loss": {
+    title: "Power was interrupted",
+    description: "The system lost power or rebooted while Daintree was running.",
+    reportLabel: "Power loss or system reboot",
+  },
+  "external-kill": {
+    title: "Daintree was forced to close",
+    description:
+      "Daintree was killed by the OS, the system running low on memory, or another external process.",
+    reportLabel: "External kill (SIGKILL, OOM killer, or force-quit)",
+  },
+  unknown: {
+    title: "Daintree closed unexpectedly",
+    description: "The previous session ended unexpectedly.",
+    reportLabel: "Unknown",
+  },
+};
+
+/** Dialog headline title for the given `crashCause`. Falls back to the V1 generic for `undefined`. */
+export function getCrashCauseTitle(cause: CrashCause | undefined): string {
+  return CRASH_CAUSE_COPY[cause ?? "unknown"].title;
+}
+
+/** Dialog sub-line description for the given `crashCause`. Falls back to the V1 generic for `undefined`. */
+export function getCrashCauseDescription(cause: CrashCause | undefined): string {
+  return CRASH_CAUSE_COPY[cause ?? "unknown"].description;
+}
+
+/** Short label for the GitHub report's `**Cause**:` line. */
+export function getCrashCauseReportLabel(cause: CrashCause | undefined): string {
+  return CRASH_CAUSE_COPY[cause ?? "unknown"].reportLabel;
+}

--- a/shared/utils/crashCauseCopy.ts
+++ b/shared/utils/crashCauseCopy.ts
@@ -55,15 +55,28 @@ export const CRASH_CAUSE_COPY: Record<CrashCause, CrashCauseCopy> = {
 
 /** Dialog headline title for the given `crashCause`. Falls back to the V1 generic for `undefined`. */
 export function getCrashCauseTitle(cause: CrashCause | undefined): string {
-  return CRASH_CAUSE_COPY[cause ?? "unknown"].title;
+  return CRASH_CAUSE_COPY[normalizeCrashCause(cause)].title;
 }
 
 /** Dialog sub-line description for the given `crashCause`. Falls back to the V1 generic for `undefined`. */
 export function getCrashCauseDescription(cause: CrashCause | undefined): string {
-  return CRASH_CAUSE_COPY[cause ?? "unknown"].description;
+  return CRASH_CAUSE_COPY[normalizeCrashCause(cause)].description;
 }
 
 /** Short label for the GitHub report's `**Cause**:` line. */
 export function getCrashCauseReportLabel(cause: CrashCause | undefined): string {
-  return CRASH_CAUSE_COPY[cause ?? "unknown"].reportLabel;
+  return CRASH_CAUSE_COPY[normalizeCrashCause(cause)].reportLabel;
+}
+
+/**
+ * Normalize an unknown `crashCause` from a persisted log to a known
+ * `CrashCause`. A future-schema log (e.g. an enum value added in a later
+ * build) or a hand-edited crash-{id}.json must not throw `TypeError` from
+ * `CRASH_CAUSE_COPY[badValue].title` — the dialog and report preview render
+ * during a crash-pending state, so any throw here would mask the recovery UI
+ * behind a render error.
+ */
+export function normalizeCrashCause(cause: CrashCause | undefined): CrashCause {
+  if (cause === undefined) return "unknown";
+  return CRASH_CAUSE_COPY[cause] !== undefined ? cause : "unknown";
 }

--- a/src/components/Recovery/CrashRecoveryDialog.tsx
+++ b/src/components/Recovery/CrashRecoveryDialog.tsx
@@ -33,6 +33,7 @@ import {
   buildCrashReportUrl,
   buildCrashReportUrlFromBody,
 } from "@shared/utils/buildCrashReportUrl";
+import { getCrashCauseTitle, getCrashCauseDescription } from "@shared/utils/crashCauseCopy";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
 import type {
   PendingCrash,
@@ -180,11 +181,17 @@ export function CrashRecoveryDialog({
   const handleOpenLogFile = useCallback(() => {
     window.electron.system.openPath(crash.logPath).catch((err) => {
       logError("Failed to open crash log path", err);
+      // shell.openPath rejects when the file is missing or inaccessible. After
+      // the consumeMarker() persistence fix this is exceptional (corruption,
+      // AV lock), but a corrupt V1 log from an older build can still hit it.
+      // Soft warning — the cause-aware title above already tells the user why
+      // the session ended, so an error toast here is more noise than signal.
       // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
       notify({
         type: "error",
-        title: "Couldn't open log file",
-        message: formatErrorMessage(err, "Failed to open log file"),
+        priority: "low",
+        title: "Log file isn't available",
+        message: formatErrorMessage(err, "The on-disk crash log couldn't be opened"),
         duration: 6000,
       });
     });
@@ -243,13 +250,14 @@ export function CrashRecoveryDialog({
       >
         <AppDialog.Header>
           <AppDialog.Title icon={<AlertTriangle className="h-5 w-5 text-status-warning" />}>
-            Daintree closed unexpectedly
+            {getCrashCauseTitle(crash.entry.crashCause)}
           </AppDialog.Title>
         </AppDialog.Header>
 
         <AppDialog.Body className="space-y-4">
           <p className="text-sm text-daintree-text/80">
-            The previous session ended unexpectedly on {crashDate}.
+            {getCrashCauseDescription(crash.entry.crashCause)} The previous session ended on{" "}
+            {crashDate}.
             {hasPanels ? " Select which panels to restore:" : " Choose how to continue:"}
           </p>
 

--- a/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
+++ b/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
@@ -231,6 +231,41 @@ describe("CrashRecoveryDialog", () => {
     expect(screen.getByText("Daintree closed unexpectedly")).toBeTruthy();
   });
 
+  describe("cause-aware copy", () => {
+    it("shows a power-loss specific title and description", () => {
+      setup({ crash: { entry: { ...mockCrash.entry, crashCause: "power-loss" } } });
+      expect(screen.getByText("Power was interrupted")).toBeTruthy();
+      expect(screen.getByText(/lost power or rebooted/i)).toBeTruthy();
+    });
+
+    it("shows an external-kill specific title", () => {
+      setup({ crash: { entry: { ...mockCrash.entry, crashCause: "external-kill" } } });
+      expect(screen.getByText("Daintree was forced to close")).toBeTruthy();
+    });
+
+    it("shows a suspended-then-lost specific title", () => {
+      setup({
+        crash: { entry: { ...mockCrash.entry, crashCause: "suspended-then-lost" } },
+      });
+      expect(screen.getByText("Daintree didn't come back from sleep")).toBeTruthy();
+    });
+
+    it("shows a native-crash specific title", () => {
+      setup({ crash: { entry: { ...mockCrash.entry, crashCause: "native-crash" } } });
+      expect(screen.getByText("Daintree crashed unexpectedly")).toBeTruthy();
+    });
+
+    it("falls back to the generic title when crashCause is undefined (V1 log compat)", () => {
+      setup({ crash: { entry: { ...mockCrash.entry, crashCause: undefined } } });
+      expect(screen.getByText("Daintree closed unexpectedly")).toBeTruthy();
+    });
+
+    it("falls back to the generic title for the unknown cause", () => {
+      setup({ crash: { entry: { ...mockCrash.entry, crashCause: "unknown" } } });
+      expect(screen.getByText("Daintree closed unexpectedly")).toBeTruthy();
+    });
+  });
+
   describe("with panels (selective restore)", () => {
     it("renders panel list with checkboxes", () => {
       setup();
@@ -637,7 +672,7 @@ describe("CrashRecoveryDialog", () => {
     expect(window.electron.system.openPath).toHaveBeenCalledWith(mockCrash.logPath);
   });
 
-  it("shows error notification when openPath fails", async () => {
+  it("shows soft notification when openPath fails", async () => {
     (window.electron.system.openPath as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
       new Error("ENOENT")
     );
@@ -649,7 +684,7 @@ describe("CrashRecoveryDialog", () => {
       expect(notifyMock).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "error",
-          title: "Couldn't open log file",
+          title: "Log file isn't available",
         })
       );
     });


### PR DESCRIPTION
## Summary
- Surface the classified crashCause in the recovery dialog and the GitHub crash report's Cause line, so an OOM kill, power loss, or external kill no longer reports as a generic 'closed unexpectedly'.
- Persist the marker-derived entry to the crashes/ directory so logPath resolves to a real file for crashes that have no log (external kill, watchdog kill, power loss).
- Add a new crashCauseCopy helper to keep the per-cause strings (title, body, cause label) in one place, with a sentinel unknown branch to keep the generic fallback reachable.

Resolves #10063

## Changes
- electron/services/CrashRecoveryService.ts — buildCrashEntryFromMarker() now writes the in-memory entry to disk for marker-only crashes, and consumeMarker()'s logPath always points at a real file. classifyCrashCause output flows into the new entry's cause field.
- shared/utils/crashCauseCopy.ts (new) — per-cause copy for the dialog (title, body) and crash report (cause label). No dark mode of cause string after recovery; the same crashCause is used end to end.
- shared/utils/buildCrashReportUrl.ts — the Cause line now renders the classified crashCause, not just watchdog-deadlock. The report title falls back to entry.errorMessage || entry.cause || crashCause so the file-name prefix carries signal.
- src/components/Recovery/CrashRecoveryDialog.tsx — reads crashCause from the entry and shows the matching title/body; 'Open log file' now works for the marker-only classes.

## Testing
- 224 vitest tests pass across the four affected files (CrashRecoveryService, buildCrashReportUrl, crashCauseCopy, CrashRecoveryDialog).
- New cases cover: cause round-tripping into the persisted entry, logPath resolving to a real file for marker-only crashes, dialog copy per cause, and the Cause line in the GitHub report URL.
- tsc --noEmit, prettier, and eslint . all clean. The lint ratchet count is unchanged (warnings on this branch are pre-existing in test files).