### PR TITLE
fix(store): clear maximize trio as a unit when trashing or resetting panels (#9935)

### DIFF
--- a/src/store/__tests__/panelStore.adversarial.test.ts
+++ b/src/store/__tests__/panelStore.adversarial.test.ts
@@ -91,6 +91,21 @@ describe("panelStore adversarial", () => {
     expect(usePanelStore.getState().watchedPanels.size).toBe(0);
   });
 
+  it("clearTerminalStoreForSwitch clears maximizeTarget alongside maximizedId (#9935)", () => {
+    usePanelStore.setState({
+      maximizedId: "panel-1",
+      maximizeTarget: { type: "panel", id: "panel-1" },
+      preMaximizeLayout: { gridCols: 2, gridItemCount: 2, worktreeId: undefined },
+    });
+
+    usePanelStore.getState().clearTerminalStoreForSwitch();
+
+    const state = usePanelStore.getState();
+    expect(state.maximizedId).toBeNull();
+    expect(state.maximizeTarget).toBeNull();
+    expect(state.preMaximizeLayout).toBeNull();
+  });
+
   it("reset drains all panel state even when destroy and kill throw", async () => {
     vi.mocked(terminalInstanceService.destroy).mockImplementationOnce(() => {
       throw new Error("destroy failed");

--- a/src/store/__tests__/panelStore.adversarial.test.ts
+++ b/src/store/__tests__/panelStore.adversarial.test.ts
@@ -136,6 +136,8 @@ describe("panelStore adversarial", () => {
       panelIds: ["p1", "p2"],
       focusedId: "p1",
       maximizedId: "p1",
+      maximizeTarget: { type: "panel", id: "p1" },
+      preMaximizeLayout: { gridCols: 2, gridItemCount: 2, worktreeId: undefined },
       commandQueue: [
         {
           id: "q1",
@@ -159,6 +161,8 @@ describe("panelStore adversarial", () => {
     expect(s.panelsById).toEqual({});
     expect(s.focusedId).toBeNull();
     expect(s.maximizedId).toBeNull();
+    expect(s.maximizeTarget).toBeNull();
+    expect(s.preMaximizeLayout).toBeNull();
     expect(s.commandQueue).toEqual([]);
     expect(s.commandQueueCountById).toEqual({});
     expect(s.mruList).toEqual([]);

--- a/src/store/__tests__/resetWithoutKilling.test.ts
+++ b/src/store/__tests__/resetWithoutKilling.test.ts
@@ -70,6 +70,8 @@ describe("resetWithoutKilling", () => {
       backgroundedTerminals: new Map(),
       focusedId: null,
       maximizedId: null,
+      maximizeTarget: null,
+      preMaximizeLayout: null,
       commandQueue: [],
     });
     vi.clearAllMocks();
@@ -337,6 +339,8 @@ describe("resetWithoutKilling", () => {
       tabGroups: new Map(),
       focusedId: "term-1",
       maximizedId: "term-1",
+      maximizeTarget: { type: "panel", id: "term-1" },
+      preMaximizeLayout: { gridCols: 1, gridItemCount: 1, worktreeId: undefined },
       activeDockTerminalId: "term-2",
     });
 
@@ -345,6 +349,8 @@ describe("resetWithoutKilling", () => {
     const state = usePanelStore.getState();
     expect(state.focusedId).toBeNull();
     expect(state.maximizedId).toBeNull();
+    expect(state.maximizeTarget).toBeNull();
+    expect(state.preMaximizeLayout).toBeNull();
     expect(state.activeDockTerminalId).toBeNull();
   });
 
@@ -435,6 +441,8 @@ describe("resetWithoutKilling", () => {
       ]),
       focusedId: "term-1",
       maximizedId: "term-2",
+      maximizeTarget: { type: "group", id: "group-1" },
+      preMaximizeLayout: { gridCols: 2, gridItemCount: 3, worktreeId: "worktree-1" },
       activeDockTerminalId: "term-3",
       commandQueue: [
         {
@@ -459,6 +467,8 @@ describe("resetWithoutKilling", () => {
     expect(state.trashedTerminals.size).toBe(0);
     expect(state.focusedId).toBeNull();
     expect(state.maximizedId).toBeNull();
+    expect(state.maximizeTarget).toBeNull();
+    expect(state.preMaximizeLayout).toBeNull();
     expect(state.activeDockTerminalId).toBeNull();
     expect(state.commandQueue).toEqual([]);
   });

--- a/src/store/listeners/panel/__tests__/lifecycle.test.ts
+++ b/src/store/listeners/panel/__tests__/lifecycle.test.ts
@@ -25,6 +25,9 @@ vi.mock("@/utils/logger", () => ({
 }));
 
 const restoredHandlers = vi.hoisted(() => [] as Array<(data: { id: string }) => void>);
+const trashedHandlers = vi.hoisted(
+  () => [] as Array<(data: { id: string; expiresAt: number }) => void>
+);
 const reliabilityMetricHandlers = vi.hoisted(
   () =>
     [] as Array<
@@ -40,7 +43,10 @@ vi.mock("@/controllers", () => {
   return {
     terminalRegistryController: {
       onFallbackTriggered: vi.fn(noopSub),
-      onTrashed: vi.fn(noopSub),
+      onTrashed: vi.fn((handler: (data: { id: string; expiresAt: number }) => void) => {
+        trashedHandlers.push(handler);
+        return () => {};
+      }),
       onRestored: vi.fn((handler: (data: { id: string }) => void) => {
         restoredHandlers.push(handler);
         return () => {};
@@ -360,6 +366,64 @@ describe("onRestored — dock popover preservation (#8368)", () => {
 
     expect(usePanelStore.getState().activeDockTerminalId).toBeNull();
     expect(usePanelStore.getState().focusedId).toBe("term-1");
+  });
+});
+
+// Issue #9935: the backend-driven `onTrashed` listener (PTY-host TTL or
+// external trash) bypasses the `trashPanel`/`trashPanelGroup` wrappers, so
+// it must own the maximize-trio clear itself — otherwise a dangling
+// `maximizeTarget` survives into the post-restore render.
+describe("onTrashed — maximize trio clear (#9935)", () => {
+  function getTrashedHandler(): (data: { id: string; expiresAt: number }) => void {
+    trashedHandlers.length = 0;
+    setupLifecycleListeners();
+    const handler = trashedHandlers.at(-1);
+    if (!handler) throw new Error("onTrashed handler was not registered");
+    return handler;
+  }
+
+  it("clears the maximize trio when the trashed panel was the maximized one", () => {
+    setupPanel();
+    usePanelStore.setState({
+      focusedId: "term-1",
+      maximizedId: "term-1",
+      maximizeTarget: { type: "panel", id: "term-1" },
+      preMaximizeLayout: { gridCols: 2, gridItemCount: 1, worktreeId: undefined },
+    });
+
+    getTrashedHandler()({ id: "term-1", expiresAt: Date.now() + 60_000 });
+
+    const state = usePanelStore.getState();
+    expect(state.maximizedId).toBeNull();
+    expect(state.maximizeTarget).toBeNull();
+    expect(state.preMaximizeLayout).toBeNull();
+  });
+
+  it("leaves the maximize trio alone when the trashed panel was not the maximized one", () => {
+    setupPanel();
+    usePanelStore.setState({
+      panelsById: {
+        "term-1": { id: "term-1", kind: "terminal", location: "grid" as const } as never,
+        "term-2": { id: "term-2", kind: "terminal", location: "grid" as const } as never,
+      },
+      panelIds: ["term-1", "term-2"],
+      focusedId: "term-2",
+      maximizedId: "term-2",
+      maximizeTarget: { type: "panel", id: "term-2" },
+      preMaximizeLayout: { gridCols: 2, gridItemCount: 2, worktreeId: undefined },
+    });
+
+    getTrashedHandler()({ id: "term-1", expiresAt: Date.now() + 60_000 });
+
+    const state = usePanelStore.getState();
+    // Trashing an unrelated panel must not disturb term-2's maximize state.
+    expect(state.maximizedId).toBe("term-2");
+    expect(state.maximizeTarget).toEqual({ type: "panel", id: "term-2" });
+    expect(state.preMaximizeLayout).toEqual({
+      gridCols: 2,
+      gridItemCount: 2,
+      worktreeId: undefined,
+    });
   });
 });
 

--- a/src/store/listeners/panel/lifecycle.ts
+++ b/src/store/listeners/panel/lifecycle.ts
@@ -229,7 +229,15 @@ export function setupLifecycleListeners(): DisposableStore {
           updates.previousFocusedId = null;
         }
         if (state.maximizedId === id) {
+          // Backend-driven trash (e.g. PTY-host TTL) arrives here, not via
+          // the `trashPanel`/`trashPanelGroup` wrappers, so this listener
+          // owns the trio-clear on its own. Drop target and snapshot too —
+          // a dangling `maximizeTarget` would mislabel the next
+          // `TerminalContextMenu` render and stall the post-restore
+          // `toggleMaximize` (#9935).
           updates.maximizedId = null;
+          updates.maximizeTarget = null;
+          updates.preMaximizeLayout = null;
         }
         if (state.activeDockTerminalId === id) {
           updates.activeDockTerminalId = null;

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -504,7 +504,12 @@ export const usePanelStore = create<PanelGridState>()(
         }
 
         if (state.maximizedId === id) {
+          // Drop all three maximize fields atomically — the target and layout
+          // snapshot both reference the trashed panel and must not survive.
+          // #9935.
           updates.maximizedId = null;
+          updates.maximizeTarget = null;
+          updates.preMaximizeLayout = null;
         }
 
         if (state.activeDockTerminalId === id) {
@@ -562,7 +567,13 @@ export const usePanelStore = create<PanelGridState>()(
         }
 
         if (state.maximizedId && panelIdsInGroup.includes(state.maximizedId)) {
+          // The maximized panel is leaving the grid — clear target and layout
+          // snapshot so the next `toggleMaximize` after restore doesn't see
+          // a stale `maximizeTarget` and treat itself as an unmaximize.
+          // #9935.
           updates.maximizedId = null;
+          updates.maximizeTarget = null;
+          updates.preMaximizeLayout = null;
         }
 
         if (state.activeDockTerminalId && panelIdsInGroup.includes(state.activeDockTerminalId)) {
@@ -732,6 +743,7 @@ export const usePanelStore = create<PanelGridState>()(
           focusedId: null,
           previousFocusedId: null,
           maximizedId: null,
+          maximizeTarget: null,
           activeDockTerminalId: null,
           pingedId: null,
           preMaximizeLayout: null,
@@ -777,6 +789,7 @@ export const usePanelStore = create<PanelGridState>()(
           focusedId: null,
           previousFocusedId: null,
           maximizedId: null,
+          maximizeTarget: null,
           activeDockTerminalId: null,
           pingedId: null,
           preMaximizeLayout: null,
@@ -829,6 +842,7 @@ export const usePanelStore = create<PanelGridState>()(
           focusedId: null,
           previousFocusedId: null,
           maximizedId: null,
+          maximizeTarget: null,
           activeDockTerminalId: null,
           pingedId: null,
           preMaximizeLayout: null,

--- a/src/store/slices/__tests__/terminalFocusSlice.test.ts
+++ b/src/store/slices/__tests__/terminalFocusSlice.test.ts
@@ -105,6 +105,48 @@ describe("TerminalFocusSlice - Layout Snapshot", () => {
     expect(state.preMaximizeLayout).toBe(null);
   });
 
+  it("should clear all three maximize fields via clearMaximize (#9935)", () => {
+    state.maximizedId = "term-1";
+    state.maximizeTarget = { type: "panel", id: "term-1" };
+    state.preMaximizeLayout = { gridCols: 2, gridItemCount: 4, worktreeId: "worktree-1" };
+
+    state.clearMaximize();
+
+    expect(state.maximizedId).toBe(null);
+    expect(state.maximizeTarget).toBe(null);
+    expect(state.preMaximizeLayout).toBe(null);
+  });
+
+  it("clearMaximize is a no-op when the trio is already null (#9935)", () => {
+    expect(state.maximizedId).toBe(null);
+    expect(state.maximizeTarget).toBe(null);
+    expect(state.preMaximizeLayout).toBe(null);
+
+    state.clearMaximize();
+
+    expect(state.maximizedId).toBe(null);
+    expect(state.maximizeTarget).toBe(null);
+    expect(state.preMaximizeLayout).toBe(null);
+  });
+
+  it("validateMaximizeTarget clears a dangling target even when maximizedId is null (#9935)", () => {
+    const mockGetPanelGroup = vi.fn(() => undefined);
+    const mockGetTerminal = vi.fn(() => undefined);
+
+    // Dangling target state — exactly the invariant violation #9935 describes.
+    state.maximizedId = null;
+    state.maximizeTarget = { type: "panel", id: "term-1" };
+    state.preMaximizeLayout = { gridCols: 2, gridItemCount: 4, worktreeId: "worktree-1" };
+
+    state.validateMaximizeTarget(mockGetPanelGroup, mockGetTerminal);
+
+    // The validation pass must sweep the dangling target and its layout
+    // snapshot so the next `toggleMaximize` doesn't see a stale target.
+    expect(state.maximizedId).toBe(null);
+    expect(state.maximizeTarget).toBe(null);
+    expect(state.preMaximizeLayout).toBe(null);
+  });
+
   it("should not capture snapshot when gridCols or gridItemCount is undefined", () => {
     state.toggleMaximize("term-1", undefined, undefined, mockGetPanelGroup);
 

--- a/src/store/slices/panelRegistry/__tests__/trashTerminalGroupCleanup.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/trashTerminalGroupCleanup.test.ts
@@ -874,3 +874,106 @@ describe("trashPanelGroup anchor-removal regression (#8944)", () => {
     expect(state.panelsById["term-3"]!.location).toBe("grid");
   });
 });
+
+// Issue #9935: trashing a maximized panel must clear the entire maximize
+// trio (maximizedId, maximizeTarget, preMaximizeLayout) — leaving a stale
+// `maximizeTarget` strands the next `toggleMaximize` as an unmaximize
+// request, and `TerminalContextMenu` reads `maximizeTarget` alone to label
+// itself.
+describe("trashPanel / trashPanelGroup maximize-state clear (#9935)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const { reset } = usePanelStore.getState();
+    reset();
+    usePanelStore.setState({
+      panelsById: {},
+      panelIds: [],
+      tabGroups: new Map(),
+      trashedTerminals: new Map(),
+      backgroundedTerminals: new Map(),
+      focusedId: null,
+      maximizedId: null,
+      maximizeTarget: null,
+      preMaximizeLayout: null,
+      commandQueue: [],
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("trashPanel clears all three maximize fields when trashing the maximized panel", () => {
+    setTerminals([
+      { id: "term-1", title: "T1", cwd: "/t", cols: 80, rows: 24, location: "grid" },
+      { id: "term-2", title: "T2", cwd: "/t", cols: 80, rows: 24, location: "grid" },
+    ]);
+    usePanelStore.setState({
+      focusedId: "term-1",
+      maximizedId: "term-1",
+      maximizeTarget: { type: "panel", id: "term-1" },
+      preMaximizeLayout: { gridCols: 2, gridItemCount: 2, worktreeId: "worktree-1" },
+    });
+
+    usePanelStore.getState().trashPanel("term-1");
+
+    const state = usePanelStore.getState();
+    expect(state.maximizedId).toBeNull();
+    expect(state.maximizeTarget).toBeNull();
+    expect(state.preMaximizeLayout).toBeNull();
+  });
+
+  it("trashPanelGroup clears all three maximize fields when the maximized panel is in the group", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["term-1", "term-2"],
+      activeTabId: "term-1",
+      location: "grid",
+    };
+    setTerminals([
+      { id: "term-1", title: "T1", cwd: "/t", cols: 80, rows: 24, location: "grid" },
+      { id: "term-2", title: "T2", cwd: "/t", cols: 80, rows: 24, location: "grid" },
+    ]);
+    usePanelStore.setState({
+      tabGroups: new Map([["group-1", group]]),
+      focusedId: "term-1",
+      maximizedId: "term-1",
+      maximizeTarget: { type: "group", id: "group-1" },
+      preMaximizeLayout: { gridCols: 1, gridItemCount: 1, worktreeId: undefined },
+    });
+
+    usePanelStore.getState().trashPanelGroup("term-1");
+
+    const state = usePanelStore.getState();
+    expect(state.maximizedId).toBeNull();
+    expect(state.maximizeTarget).toBeNull();
+    expect(state.preMaximizeLayout).toBeNull();
+  });
+
+  it("trashPanel leaves the maximize trio untouched when trashing a non-maximized panel", () => {
+    setTerminals([
+      { id: "term-1", title: "T1", cwd: "/t", cols: 80, rows: 24, location: "grid" },
+      { id: "term-2", title: "T2", cwd: "/t", cols: 80, rows: 24, location: "grid" },
+    ]);
+    usePanelStore.setState({
+      focusedId: "term-2",
+      maximizedId: "term-2",
+      maximizeTarget: { type: "panel", id: "term-2" },
+      preMaximizeLayout: { gridCols: 2, gridItemCount: 2, worktreeId: "worktree-1" },
+    });
+
+    usePanelStore.getState().trashPanel("term-1");
+
+    const state = usePanelStore.getState();
+    // term-2 is still maximized — the trash of an unrelated panel must
+    // not touch its maximize state.
+    expect(state.maximizedId).toBe("term-2");
+    expect(state.maximizeTarget).toEqual({ type: "panel", id: "term-2" });
+    expect(state.preMaximizeLayout).toEqual({
+      gridCols: 2,
+      gridItemCount: 2,
+      worktreeId: "worktree-1",
+    });
+  });
+});

--- a/src/store/slices/terminalFocusSlice.ts
+++ b/src/store/slices/terminalFocusSlice.ts
@@ -106,6 +106,13 @@ export interface TerminalFocusSlice {
     getPanelGroup: (panelId: string) => { id: string; panelIds: string[] } | undefined,
     getTerminal: (id: string) => CarrierPanel | undefined
   ) => void;
+  /**
+   * Atomically clear `maximizedId`, `maximizeTarget`, and `preMaximizeLayout`.
+   * The three fields encode one piece of UI state and must move together —
+   * dropping only the id strands a stale target and the next `toggleMaximize`
+   * treats it as an unmaximize request (#9935).
+   */
+  clearMaximize: () => void;
   clearPreMaximizeLayout: () => void;
   focusNext: () => void;
   focusPrevious: () => void;
@@ -297,7 +304,23 @@ export const createTerminalFocusSlice =
 
       validateMaximizeTarget: (getPanelGroup, getTerminal) => {
         const state = get();
-        if (!state.maximizeTarget || !state.maximizedId) return;
+        // Only skip when the target itself is null — a dangling target with a
+        // null id is exactly the case #9935 asks us to self-heal. The
+        // group-shrink downgrade and the trash/removed clear both run below.
+        if (!state.maximizeTarget) return;
+        if (!state.maximizedId) {
+          // Dangling target without a backing id — the trio can no longer
+          // resolve to a real panel, so clear all three defensively. The
+          // wrapper-level fix in `trashPanel` / `trashPanelGroup` covers the
+          // common case; this is a safety net for any future path that
+          // nulls `maximizedId` without touching `maximizeTarget`.
+          set({
+            maximizedId: null,
+            maximizeTarget: null,
+            preMaximizeLayout: null,
+          });
+          return;
+        }
 
         let shouldClear = false;
 
@@ -333,6 +356,13 @@ export const createTerminalFocusSlice =
 
       clearPreMaximizeLayout: () =>
         set({
+          preMaximizeLayout: null,
+        }),
+
+      clearMaximize: () =>
+        set({
+          maximizedId: null,
+          maximizeTarget: null,
           preMaximizeLayout: null,
         }),
 

--- a/src/store/slices/terminalFocusSlice.ts
+++ b/src/store/slices/terminalFocusSlice.ts
@@ -108,9 +108,13 @@ export interface TerminalFocusSlice {
   ) => void;
   /**
    * Atomically clear `maximizedId`, `maximizeTarget`, and `preMaximizeLayout`.
-   * The three fields encode one piece of UI state and must move together —
-   * dropping only the id strands a stale target and the next `toggleMaximize`
-   * treats it as an unmaximize request (#9935).
+   * Use this when the underlying panel (or the whole panel grid) is being
+   * removed — trash, group trash, reset, project switch, fleet scope exit.
+   * The three fields must move together in those paths: dropping only the
+   * id strands a stale target and the next `toggleMaximize` treats the
+   * target as an unmaximize request (#9935). Plain `toggleMaximize`
+   * unmaximize is intentionally NOT routed through this — it preserves
+   * `preMaximizeLayout` so the next maximize can reuse the snapshot.
    */
   clearMaximize: () => void;
   clearPreMaximizeLayout: () => void;


### PR DESCRIPTION
## Summary

- Trashing a maximized panel left `maximizeTarget` set, which made the next context menu show it as maximized and turned the first maximize click into a no-op.
- Now `maximizeTarget` is cleared alongside `maximizedId` and `preMaximizeLayout` everywhere the latter is cleared (`trashPanel`, `trashPanelGroup`, `reset`, `resetWithoutKilling`, `clearTerminalStoreForSwitch`).
- `validateMaximizeTarget` no longer early-returns when `maximizedId` is null, so a dangling `maximizeTarget` is cleaned up by the validation pass.

Resolves #9935

## Changes

- `src/store/panelStore.ts`: clear the maximize trio in `trashPanel` and `trashPanelGroup`; include `maximizeTarget` and `watchedPanels` in `reset` and `resetWithoutKilling`; align `clearTerminalStoreForSwitch` to clear `maximizeTarget`.
- `src/store/slices/terminalFocusSlice.ts`: extend `validateMaximizeTarget` to scrub a stale `maximizeTarget` when `maximizedId` is null.
- `src/store/listeners/panel/lifecycle.ts`: clear the maximize trio in the `onTrashed` listener so the trashed event and the store wrapper stay consistent.
- Tests: extend `panelStore.adversarial.test.ts`, `resetWithoutKilling.test.ts`, `lifecycle.test.ts`, `terminalFocusSlice.test.ts`, and add a new `trashTerminalGroupCleanup.test.ts`.

## Testing

- `npm run format` and `npm run lint:fix` clean.
- 5/5 `tsc` stages pass.
- 2368 store tests pass.