### PR TITLE
fix(browser): sentence-case error headings and add screenshot feedback

### DIFF
--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -198,6 +198,7 @@ export function BrowserPane({
   const loadTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [isSlowLoad, setIsSlowLoad] = useState(false);
   const slowLoadTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const screenshotInFlightRef = useRef(false);
 
   const hasBeenVisible = useHasBeenVisible(id, location);
 
@@ -559,6 +560,8 @@ export function BrowserPane({
       return;
     }
     if (!url || url === "about:blank") return;
+    if (screenshotInFlightRef.current) return;
+    screenshotInFlightRef.current = true;
     try {
       const image = await webview.capturePage();
       const pngData = new Uint8Array(image.toPNG());
@@ -568,8 +571,10 @@ export function BrowserPane({
       notify({
         type: "error",
         title: "Screenshot failed",
-        message: "Couldn't copy the screenshot to clipboard.",
+        message: "Couldn't copy the screenshot to clipboard",
       });
+    } finally {
+      screenshotInFlightRef.current = false;
     }
   }, [isWebviewReady]);
 

--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -35,6 +35,7 @@ import { useFindInPage } from "@/hooks/useFindInPage";
 import { useDohertyGate } from "@/hooks/useDeferredLoading";
 import { logError } from "@/utils/logger";
 import { buildBrowserPartition } from "@shared/utils/partitionUtils";
+import { notify } from "@/lib/notify";
 
 export interface BrowserPaneProps extends BasePanelProps {
   initialUrl: string;
@@ -514,7 +515,7 @@ export function BrowserPane({
         // Webview detached
       }
     }
-    setLoadError({ kind: "cancelled", message: "Load cancelled." });
+    setLoadError({ kind: "cancelled", message: "Load cancelled" });
   }, []);
 
   const handleRetryFromError = useCallback(() => {
@@ -562,8 +563,13 @@ export function BrowserPane({
       const image = await webview.capturePage();
       const pngData = new Uint8Array(image.toPNG());
       await window.electron.clipboard.writeImage(pngData);
-    } catch (err) {
-      logError("[BrowserPane] Screenshot capture failed", err);
+    } catch {
+      // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
+      notify({
+        type: "error",
+        title: "Screenshot failed",
+        message: "Couldn't copy the screenshot to clipboard.",
+      });
     }
   }, [isWebviewReady]);
 
@@ -840,14 +846,14 @@ export function BrowserPane({
                 <AlertTriangle className="w-6 h-6 text-status-warning mb-3" />
                 <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
                   {loadError.kind === "timeout"
-                    ? "Page Load Timed Out"
+                    ? "Page load timed out"
                     : loadError.kind === "cancelled"
-                      ? "Load Cancelled"
+                      ? "Load cancelled"
                       : loadError.kind === "cert"
-                        ? "Certificate Error"
+                        ? "Certificate error"
                         : loadError.kind === "network"
-                          ? "Connection Failed"
-                          : "Unable to Display Page"}
+                          ? "Connection failed"
+                          : "Unable to display page"}
                 </h3>
                 <p className="text-xs text-daintree-text/50 text-center mb-3 max-w-md">
                   {loadError.message}

--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -32,6 +32,7 @@ import { VIEWPORT_PRESET_LIST } from "@/panels/dev-preview/viewportPresets";
 import { logError } from "@/utils/logger";
 
 const LONG_PRESS_MS = 400;
+const COPIED_FEEDBACK_RESET_MS = 2000;
 
 const ZOOM_PRESETS = [
   { value: 0.25, label: "25%" },
@@ -450,7 +451,7 @@ export function BrowserToolbar({
         throw new Error(result.error.message);
       }
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      setTimeout(() => setCopied(false), COPIED_FEEDBACK_RESET_MS);
     } catch (err) {
       logError("Failed to copy URL", err);
     }
@@ -461,7 +462,10 @@ export function BrowserToolbar({
     await onCaptureScreenshot();
     setScreenshotCopied(true);
     if (screenshotCopiedTimerRef.current) clearTimeout(screenshotCopiedTimerRef.current);
-    screenshotCopiedTimerRef.current = setTimeout(() => setScreenshotCopied(false), 2000);
+    screenshotCopiedTimerRef.current = setTimeout(
+      () => setScreenshotCopied(false),
+      COPIED_FEEDBACK_RESET_MS
+    );
   }, [onCaptureScreenshot]);
 
   const handleZoomStep = useCallback(

--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -71,7 +71,7 @@ interface BrowserToolbarProps {
   onOpenExternal: () => void;
   onPromoteToPortal?: () => void;
   onZoomChange?: (zoomFactor: number) => void;
-  onCaptureScreenshot?: () => void;
+  onCaptureScreenshot?: () => void | Promise<void>;
   onToggleConsole?: () => void;
   onToggleDevTools?: () => void;
   onViewportPresetChange?: (preset: ViewportPresetId | undefined) => void;
@@ -118,6 +118,8 @@ export function BrowserToolbar({
   const [isEditing, setIsEditing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [screenshotCopied, setScreenshotCopied] = useState(false);
+  const screenshotCopiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [historyAnnouncement, setHistoryAnnouncement] = useState("");
@@ -179,6 +181,7 @@ export function BrowserToolbar({
   useEffect(() => {
     return () => {
       if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current);
+      if (screenshotCopiedTimerRef.current) clearTimeout(screenshotCopiedTimerRef.current);
     };
   }, []);
 
@@ -453,6 +456,14 @@ export function BrowserToolbar({
     }
   }, [terminalId, url]);
 
+  const handleCaptureScreenshot = useCallback(async () => {
+    if (!onCaptureScreenshot) return;
+    await onCaptureScreenshot();
+    setScreenshotCopied(true);
+    if (screenshotCopiedTimerRef.current) clearTimeout(screenshotCopiedTimerRef.current);
+    screenshotCopiedTimerRef.current = setTimeout(() => setScreenshotCopied(false), 2000);
+  }, [onCaptureScreenshot]);
+
   const handleZoomStep = useCallback(
     (direction: "in" | "out") => {
       if (!onZoomChange) return;
@@ -515,6 +526,9 @@ export function BrowserToolbar({
       </span>
       <span role="status" aria-live="polite" aria-atomic="true" className="sr-only">
         {copied ? "Copied to clipboard" : ""}
+      </span>
+      <span role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+        {screenshotCopied ? "Screenshot copied to clipboard" : ""}
       </span>
       {/* Navigation buttons */}
       <div className="relative">
@@ -992,7 +1006,7 @@ export function BrowserToolbar({
           <TooltipTrigger asChild>
             <button
               type="button"
-              onClick={onCaptureScreenshot}
+              onClick={handleCaptureScreenshot}
               disabled={!isWebviewReady}
               className={cn(
                 buttonClass,
@@ -1000,7 +1014,11 @@ export function BrowserToolbar({
               )}
               aria-label="Capture screenshot"
             >
-              <Camera className="w-4 h-4" />
+              {screenshotCopied ? (
+                <Check className="w-4 h-4 text-status-success" />
+              ) : (
+                <Camera className="w-4 h-4" />
+              )}
             </button>
           </TooltipTrigger>
           <TooltipContent side="bottom">Copy screenshot to clipboard</TooltipContent>

--- a/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
+++ b/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
@@ -146,6 +146,13 @@ vi.mock("@/components/Browser/BrowserToolbar", () => ({
   },
 }));
 
+const { notifyMock } = vi.hoisted(() => ({
+  notifyMock: vi.fn(),
+}));
+vi.mock("@/lib/notify", () => ({
+  notify: notifyMock,
+}));
+
 vi.mock("@/components/Panel", () => ({
   ContentPanel: ({
     children,
@@ -372,7 +379,7 @@ describe("BrowserPane webview lifecycle regression", () => {
 
     expect(webview.stop).toHaveBeenCalledTimes(1);
     expect(webview.reload).not.toHaveBeenCalled();
-    expect(container.textContent).toContain("Page Load Timed Out");
+    expect(container.textContent).toContain("Page load timed out");
   });
 
   it("clears stuck-load timeout on did-stop-loading", () => {
@@ -675,6 +682,36 @@ describe("BrowserPane webview lifecycle regression", () => {
       const mock = (window as any).electron.clipboard.writeImage;
       expect(mock).not.toHaveBeenCalled();
     });
+
+    it("surfaces an error notification when the clipboard write fails", async () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "dom-ready");
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).electron.clipboard.writeImage.mockRejectedValueOnce(
+        new Error("clipboard unavailable")
+      );
+
+      await act(async () => {
+        window.dispatchEvent(
+          new CustomEvent("daintree:browser-capture-screenshot", {
+            detail: { id: "browser-panel-1" },
+          })
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(notifyMock).toHaveBeenCalledTimes(1);
+      expect(notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "error", title: "Screenshot failed" })
+      );
+    });
   });
 
   describe("stale URL detection on initial load", () => {
@@ -809,7 +846,7 @@ describe("BrowserPane webview lifecycle regression", () => {
 
       expect(webview.stop).toHaveBeenCalledTimes(1);
       expect(webview.reload).not.toHaveBeenCalled();
-      expect(container.textContent).toContain("Page Load Timed Out");
+      expect(container.textContent).toContain("Page load timed out");
     });
 
     it("timeout error overlay shows Retry and Open External buttons", () => {
@@ -948,7 +985,7 @@ describe("BrowserPane webview lifecycle regression", () => {
         });
       });
 
-      expect(container.textContent).toContain("Certificate Error");
+      expect(container.textContent).toContain("Certificate error");
       expect(container.textContent).toContain("certificate couldn't be verified");
       expect(container.textContent).toContain("mkcert -install");
     });
@@ -966,7 +1003,7 @@ describe("BrowserPane webview lifecycle regression", () => {
         });
       });
 
-      expect(container.textContent).toContain("Certificate Error");
+      expect(container.textContent).toContain("Certificate error");
       expect(container.textContent).toContain("SSL/TLS handshake failed");
       // -107 is also raised on protocol mismatch — the mkcert hint is wrong here.
       expect(container.textContent).not.toContain("mkcert");
@@ -985,7 +1022,7 @@ describe("BrowserPane webview lifecycle regression", () => {
         });
       });
 
-      expect(container.textContent).toContain("Unable to Display Page");
+      expect(container.textContent).toContain("Unable to display page");
       expect(container.textContent).toContain("ERR_FILE_NOT_FOUND");
     });
 
@@ -1002,7 +1039,7 @@ describe("BrowserPane webview lifecycle regression", () => {
         });
       });
 
-      expect(container.textContent).not.toContain("Unable to Display Page");
+      expect(container.textContent).not.toContain("Unable to display page");
       expect(container.textContent).not.toContain("Couldn't resolve");
     });
 
@@ -1030,7 +1067,7 @@ describe("BrowserPane webview lifecycle regression", () => {
       });
 
       expect(webview.stop).toHaveBeenCalledTimes(1);
-      expect(container.textContent).toContain("Page Load Timed Out");
+      expect(container.textContent).toContain("Page load timed out");
     });
 
     it("stale ERR_ABORTED from a superseded navigation does not disarm new timers", () => {
@@ -1063,7 +1100,7 @@ describe("BrowserPane webview lifecycle regression", () => {
       });
 
       expect(webview.stop).toHaveBeenCalledTimes(1);
-      expect(container.textContent).toContain("Page Load Timed Out");
+      expect(container.textContent).toContain("Page load timed out");
     });
 
     it("shows connection-timeout message when validatedURL is empty", () => {
@@ -1079,9 +1116,9 @@ describe("BrowserPane webview lifecycle regression", () => {
         });
       });
 
-      expect(container.textContent).toContain("Connection Failed");
+      expect(container.textContent).toContain("Connection failed");
       expect(container.textContent).toContain("timed out");
-      expect(container.textContent).not.toContain("Unable to Display Page");
+      expect(container.textContent).not.toContain("Unable to display page");
     });
 
     it("cleans slow timer on unmount", () => {
@@ -1323,7 +1360,7 @@ describe("BrowserPane webview lifecycle regression", () => {
     it("clears stuck-load timer so a load timeout does not replace the crash banner", () => {
       // The load-error overlay is rendered as absolute z-30 over the entire
       // pane — without clearing the slow-load timer on crash, a pending 30s
-      // timeout would fire after the crash and stack a "Page Load Timed Out"
+      // timeout would fire after the crash and stack a "Page load timed out"
       // overlay on top of the in-flow crash banner, hiding it entirely.
       const { container } = render(<BrowserPane {...baseProps} />);
       const webview = getWebviewElement(container);
@@ -1344,7 +1381,7 @@ describe("BrowserPane webview lifecycle regression", () => {
 
       expect(webview.stop).not.toHaveBeenCalled();
       expect(container.textContent).toContain("Page process crashed");
-      expect(container.textContent).not.toContain("Page Load Timed Out");
+      expect(container.textContent).not.toContain("Page load timed out");
     });
 
     it("auto-reloads again on a crash that lands just outside the 60s window", () => {

--- a/src/components/Browser/__tests__/BrowserToolbar.test.tsx
+++ b/src/components/Browser/__tests__/BrowserToolbar.test.tsx
@@ -281,6 +281,25 @@ describe("BrowserToolbar ARIA semantics", () => {
     });
   });
 
+  it("screenshot capture announces success in a polite live region and flips to a check", async () => {
+    const onCaptureScreenshot = vi.fn(() => Promise.resolve());
+    const { container, getByRole } = renderToolbar({
+      onCaptureScreenshot,
+      isWebviewReady: true,
+    });
+
+    await act(async () => {
+      fireEvent.click(getByRole("button", { name: "Capture screenshot" }));
+    });
+
+    expect(onCaptureScreenshot).toHaveBeenCalledOnce();
+    await waitFor(() => {
+      const liveRegions = container.querySelectorAll('[role="status"]');
+      const texts = Array.from(liveRegions).map((node) => node.textContent);
+      expect(texts).toContain("Screenshot copied to clipboard");
+    });
+  });
+
   it("Shift+Delete on a highlighted suggestion announces removal", async () => {
     const { container, getByTestId } = renderToolbar();
     const input = openDropdown(getByTestId);


### PR DESCRIPTION
## Summary

Two small browser-pane polish fixes from #9944.

**1. Sentence-case error overlay headings.** The five `BrowserPane` error overlay headings now read in sentence case — "Page load timed out", "Load cancelled", "Certificate error", "Connection failed", "Unable to display page" — and the trailing period was dropped from the "Load cancelled" message, per the CLAUDE.md microcopy rules (sentence case; no period on single-clause subtitles).

**2. Screenshot-capture feedback.** The toolbar screenshot button now mirrors the existing Copy URL pattern: the Camera icon flips to a Check for two seconds on success and a polite aria-live region announces "Screenshot copied to clipboard". Capture failures now surface an error notification ("Screenshot failed") instead of being logged silently. An in-flight guard prevents rapid clicks from racing two concurrent clipboard writes.

## Implementation notes

- The toolbar Check reflects action-dispatch success, not the clipboard-write result — the `browser.captureScreenshot` action fires a fire-and-forget `CustomEvent`, so the toolbar can't observe the async clipboard outcome. The rare clipboard failure is authoritatively surfaced by the error toast from `BrowserPane`.
- The new aria-live span is always-mounted and text-swap-only, following past lesson #8990 (avoids silently dropped announcements in Chromium).
- Hoisted the 2s feedback-reset delay into `COPIED_FEEDBACK_RESET_MS`, shared by the Copy URL and screenshot timers.

## Tests

- Updated `BrowserPane.webview.test.tsx` Title Case assertions to sentence case; added a notify-on-clipboard-failure test.
- Added a `BrowserToolbar.test.tsx` test for the success live-region announcement.
- All 121 Browser unit tests pass; typecheck, format, and lint ratchet (net -7 warnings) clean.

Closes #9944
