### PR TITLE
fix(crash-recovery): show panel count on renderer-crash recovery page

### DIFF
--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -125,6 +125,10 @@ export class CrashRecoveryService {
     if (!info.exists || !info.path) return null;
     const snapshot = this.readBackupFile(info.path);
     if (!snapshot) return null;
+    // Freshness gate: a snapshot from a previous session must not surface a
+    // panel count on the current session's recovery page. Mirrors the
+    // watchdog freshness check at consumeWatchdogKillFlag (line 637).
+    if (snapshot.capturedAt < this.sessionStartMs) return null;
     const fallbackState = snapshot.appState as Record<string, unknown> | undefined;
     const terminals = fallbackState?.terminals;
     return Array.isArray(terminals) ? terminals.length : null;

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -103,9 +103,30 @@ export class CrashRecoveryService {
     return info.exists && typeof info.timestamp === "number" ? info.timestamp : null;
   }
 
-  getBackupPanelCount(): number | null {
-    const appState = this.cachedBackupSnapshot?.appState as Record<string, unknown> | undefined;
-    const terminals = appState?.terminals;
+  getBackupPanelCount(allowDiskFallback: boolean = false): number | null {
+    // Cache wins unconditionally. It reflects the snapshot at the moment
+    // consumeMarker() learned about the main-process crash, so later disk
+    // state (rotations from a normal session tick) must not override it.
+    // Without this guard, a "simplify to disk-first" refactor would silently
+    // re-introduce the bleed-into-fresh-boot bug pinned by the test at
+    // CrashRecoveryService.test.ts:1346.
+    if (this.cachedBackupSnapshot) {
+      const appState = this.cachedBackupSnapshot.appState as Record<string, unknown> | undefined;
+      const terminals = appState?.terminals;
+      return Array.isArray(terminals) ? terminals.length : null;
+    }
+    if (!allowDiskFallback) return null;
+    // Renderer-crash mid-session: no marker was ever consumed, so the cache
+    // is empty. readBackupInfo() resolves the parseable rotation file
+    // (current → previous) and readBackupFile() returns null on torn
+    // writes or non-restorable content. Both helpers are observation-only —
+    // they never mutate marker or backup state.
+    const info = this.readBackupInfo();
+    if (!info.exists || !info.path) return null;
+    const snapshot = this.readBackupFile(info.path);
+    if (!snapshot) return null;
+    const fallbackState = snapshot.appState as Record<string, unknown> | undefined;
+    const terminals = fallbackState?.terminals;
     return Array.isArray(terminals) ? terminals.length : null;
   }
 

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -1389,6 +1389,112 @@ describe("CrashRecoveryService", () => {
 
       expect(svc.getBackupPanelCount()).toBeNull();
     });
+
+    it("falls back to disk when allowDiskFallback is true and no crash marker is present", () => {
+      // Renderer-crash mid-session: no marker was ever consumed, so the
+      // cache is empty. The default-arg call must still return null
+      // (the line-1346 contract), but opting in to the disk fallback must
+      // surface the live session's terminal count.
+      const backupDir = path.join(userData, "backups");
+      fs.mkdirSync(backupDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(backupDir, "session-state.json"),
+        JSON.stringify({
+          capturedAt: Date.now(),
+          appState: {
+            terminals: [
+              { id: "t1", kind: "terminal" },
+              { id: "t2", kind: "terminal" },
+              { id: "t3", kind: "browser" },
+              { id: "t4", kind: "terminal" },
+            ],
+          },
+        })
+      );
+
+      const svc = makeService();
+      svc.initialize();
+
+      expect(svc.getBackupPanelCount()).toBeNull();
+      expect(svc.getBackupPanelCount(true)).toBe(4);
+    });
+
+    it("returns cached count even when allowDiskFallback is true (cache wins over disk)", () => {
+      // consumeMarker() reads the disk backup into cachedBackupSnapshot.
+      // After that, the disk file is rotated/overwritten by the live backup
+      // tick. The cache must continue to drive getBackupPanelCount(true)
+      // so the main-crash dialog keeps showing the pre-crash panel count
+      // (mirrors the "snapshot at the moment we learned about the crash"
+      // contract on consumeMarker).
+      const backupDir = path.join(userData, "backups");
+      fs.mkdirSync(backupDir, { recursive: true });
+      const preCrash = {
+        capturedAt: Date.now() - 60_000,
+        appState: {
+          terminals: [
+            { id: "t1", kind: "terminal" },
+            { id: "t2", kind: "terminal" },
+            { id: "t3", kind: "terminal" },
+          ],
+        },
+      };
+      fs.writeFileSync(path.join(backupDir, "session-state.json"), JSON.stringify(preCrash));
+
+      const markerPath = path.join(userData, "running.lock");
+      fs.writeFileSync(
+        markerPath,
+        JSON.stringify({
+          sessionStartMs: Date.now() - 5000,
+          appVersion: "1.0.0",
+          platform: "darwin",
+        })
+      );
+
+      const svc = makeService();
+      svc.initialize();
+
+      // Overwrite the disk file with a divergent post-recovery snapshot.
+      // The cache must NOT be replaced; the fallback must not perturb it.
+      fs.writeFileSync(
+        path.join(backupDir, "session-state.json"),
+        JSON.stringify({
+          capturedAt: Date.now(),
+          appState: {
+            terminals: [
+              { id: "n1", kind: "terminal" },
+              { id: "n2", kind: "terminal" },
+              { id: "n3", kind: "terminal" },
+              { id: "n4", kind: "terminal" },
+              { id: "n5", kind: "browser" },
+              { id: "n6", kind: "terminal" },
+              { id: "n7", kind: "terminal" },
+            ],
+          },
+        })
+      );
+
+      expect(svc.getBackupPanelCount(true)).toBe(3);
+    });
+
+    it("returns null on malformed disk snapshot when fallback is allowed", () => {
+      // readBackupFile + Array.isArray already defend the wiring. This test
+      // pins that the fallback returns null (not garbage, not a throw) when
+      // the disk snapshot has a non-array `terminals` field.
+      const backupDir = path.join(userData, "backups");
+      fs.mkdirSync(backupDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(backupDir, "session-state.json"),
+        JSON.stringify({
+          capturedAt: Date.now(),
+          appState: { terminals: "not an array" },
+        })
+      );
+
+      const svc = makeService();
+      svc.initialize();
+
+      expect(svc.getBackupPanelCount(true)).toBeNull();
+    });
   });
 
   describe("resetToFresh", () => {

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -1495,6 +1495,31 @@ describe("CrashRecoveryService", () => {
 
       expect(svc.getBackupPanelCount(true)).toBeNull();
     });
+
+    it("returns null when on-disk snapshot is from a prior session (freshness gate)", () => {
+      // The freshness gate prevents a previous session's snapshot from
+      // surfacing on a fresh boot that happens to crash the renderer
+      // immediately. Mirrors the watchdog freshness pattern at
+      // consumeWatchdogKillFlag (line 637).
+      const backupDir = path.join(userData, "backups");
+      fs.mkdirSync(backupDir, { recursive: true });
+      const svc = makeService();
+      const sessionStart = Date.now();
+      // Service constructor already called Date.now() once for sessionStartMs;
+      // make the snapshot strictly older.
+      fs.writeFileSync(
+        path.join(backupDir, "session-state.json"),
+        JSON.stringify({
+          capturedAt: sessionStart - 5_000,
+          appState: {
+            terminals: [{ id: "t1", kind: "terminal" }],
+          },
+        })
+      );
+      svc.initialize();
+
+      expect(svc.getBackupPanelCount(true)).toBeNull();
+    });
   });
 
   describe("resetToFresh", () => {

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -1433,7 +1433,7 @@ export class ProjectViewManager {
           if (backupTimestamp !== null) {
             params.set("backupTimestamp", String(backupTimestamp));
           }
-          const panelCount = recoverySvc.getBackupPanelCount();
+          const panelCount = recoverySvc.getBackupPanelCount(true);
           if (panelCount !== null) {
             params.set("panelCount", String(panelCount));
           }


### PR DESCRIPTION
## Summary

The renderer-crash recovery page never displayed the number of panels that were open. This PR fixes that, with a freshness check to make sure we only show a count that came from the current session.

- `getBackupPanelCount` in `CrashRecoveryService` accepts a new `allowDiskFallback` parameter. The renderer-crash call site in `ProjectViewManager` opts in; the main-crash call site stays on cache-only to keep the existing dialog contract.
- The disk fallback path now compares `snapshot.capturedAt` to `this.sessionStartMs`. This mirrors the existing watchdog freshness pattern at `consumeWatchdogKillFlag`, so a previous session's snapshot can't show a panel count on a fresh boot that crashes the renderer immediately.

Resolves #10066.

## Changes

- `electron/services/CrashRecoveryService.ts` — add `allowDiskFallback` to `getBackupPanelCount`; add freshness gate against `sessionStartMs`
- `electron/window/ProjectViewManager.ts` — pass `true` for the renderer-crash call site
- `electron/services/__tests__/CrashRecoveryService.test.ts` — 4 new tests: disk fallback populates count, cache wins over disk, malformed disk file returns null, freshness gate blocks stale snapshot

## Testing

- Typecheck (5 projects) passes
- `npm run check` passes — channel-drift, crash-loop-constants, ipc-map, ipc-renderer, ipc-handwritten, help, confirm-wiring, lint:ratchet, format:check all clean
- 4 new unit tests cover the disk fallback and freshness gate