### PR TITLE
fix(gpu-monitor): write clean-exit markers on GPU-mitigation relaunch

### DIFF
--- a/electron/services/GpuCrashMonitorService.ts
+++ b/electron/services/GpuCrashMonitorService.ts
@@ -7,6 +7,8 @@ import { resilientAtomicWriteFileSync } from "../utils/fs.js";
 import { createLogger } from "../utils/logger.js";
 import { closeTelemetry } from "./TelemetryService.js";
 import { getCrashLoopGuard } from "./CrashLoopGuardService.js";
+import { getCrashRecoveryService } from "./CrashRecoveryService.js";
+import { getPanelSuspectLedger } from "./PanelSuspectLedgerService.js";
 
 const GPU_DISABLED_FLAG = "gpu-disabled.flag";
 const GPU_ANGLE_FALLBACK_FLAG = "gpu-angle-fallback.flag";
@@ -75,6 +77,37 @@ export function clearGpuAngleFallbackFlag(userDataPath: string): void {
   const flagPath = path.join(userDataPath, GPU_ANGLE_FALLBACK_FLAG);
   if (fs.existsSync(flagPath)) {
     fs.unlinkSync(flagPath);
+  }
+}
+
+// Issue #10065: GPU-mitigation exits (soft ANGLE fallback, nuclear disable,
+// and their respective crash-loop hard-stops) all go through `app.exit(0)`
+// which skips the `before-quit` cleanup chain. Without the three clean-exit
+// markers, the next boot treats the deliberate relaunch as a crash:
+// `running.lock` is left on disk, `crash-loop-state.json` keeps
+// `cleanExit: false` (accumulating strikes toward safe mode), and
+// `PanelSuspectLedger` never advances its decay counters. Mirror the
+// AutoUpdater #9638 pattern: each marker in its own try/catch so a single
+// failure cannot skip the next (lesson #7158). Markers are synchronous
+// `writeFileSync` calls, so they commit before any `app.relaunch()` or
+// `app.exit(0)` we return to.
+type GpuMitigationPath = "angle-fallback" | "nuclear-disable";
+
+function writeCleanGpuMitigationMarkers(path: GpuMitigationPath): void {
+  try {
+    getCrashRecoveryService().cleanupOnExit();
+  } catch (err) {
+    logger.error("gpu-mitigation-cleanup-on-exit-failed", err, { path });
+  }
+  try {
+    getCrashLoopGuard().markCleanExit();
+  } catch (err) {
+    logger.error("gpu-mitigation-mark-clean-exit-failed", err, { path });
+  }
+  try {
+    getPanelSuspectLedger().markCleanLaunch();
+  } catch (err) {
+    logger.error("gpu-mitigation-mark-clean-launch-failed", err, { path });
   }
 }
 
@@ -161,11 +194,13 @@ class GpuCrashMonitorService {
             path: "angle-fallback",
             crashCount: effectiveCount,
           });
+          writeCleanGpuMitigationMarkers("angle-fallback");
           await closeTelemetry();
           app.exit(0);
           return;
         }
         logger.warn("gpu-crash-soft-fallback", { crashCount: effectiveCount });
+        writeCleanGpuMitigationMarkers("angle-fallback");
         app.relaunch();
         await closeTelemetry();
         app.exit(0);
@@ -191,11 +226,13 @@ class GpuCrashMonitorService {
             path: "nuclear-disable",
             crashCount: effectiveCount,
           });
+          writeCleanGpuMitigationMarkers("nuclear-disable");
           await closeTelemetry();
           app.exit(0);
           return;
         }
         logger.warn("gpu-crash-nuclear-disable", { crashCount: effectiveCount });
+        writeCleanGpuMitigationMarkers("nuclear-disable");
         app.relaunch();
         await closeTelemetry();
         app.exit(0);

--- a/electron/services/GpuCrashMonitorService.ts
+++ b/electron/services/GpuCrashMonitorService.ts
@@ -195,14 +195,29 @@ class GpuCrashMonitorService {
             crashCount: effectiveCount,
           });
           writeCleanGpuMitigationMarkers("angle-fallback");
-          await closeTelemetry();
+          try {
+            await closeTelemetry();
+          } catch (err) {
+            // Hard-stop has no queued relaunch, so a telemetry rejection
+            // would skip the exit and hang the process. Match the shutdown.ts
+            // pattern (L497-501): log and fall through to app.exit(0).
+            logger.error("gpu-mitigation-close-telemetry-failed", err, {
+              path: "angle-fallback",
+            });
+          }
           app.exit(0);
           return;
         }
         logger.warn("gpu-crash-soft-fallback", { crashCount: effectiveCount });
         writeCleanGpuMitigationMarkers("angle-fallback");
         app.relaunch();
-        await closeTelemetry();
+        try {
+          await closeTelemetry();
+        } catch (err) {
+          logger.error("gpu-mitigation-close-telemetry-failed", err, {
+            path: "angle-fallback",
+          });
+        }
         app.exit(0);
         return;
       }
@@ -227,14 +242,26 @@ class GpuCrashMonitorService {
             crashCount: effectiveCount,
           });
           writeCleanGpuMitigationMarkers("nuclear-disable");
-          await closeTelemetry();
+          try {
+            await closeTelemetry();
+          } catch (err) {
+            logger.error("gpu-mitigation-close-telemetry-failed", err, {
+              path: "nuclear-disable",
+            });
+          }
           app.exit(0);
           return;
         }
         logger.warn("gpu-crash-nuclear-disable", { crashCount: effectiveCount });
         writeCleanGpuMitigationMarkers("nuclear-disable");
         app.relaunch();
-        await closeTelemetry();
+        try {
+          await closeTelemetry();
+        } catch (err) {
+          logger.error("gpu-mitigation-close-telemetry-failed", err, {
+            path: "nuclear-disable",
+          });
+        }
         app.exit(0);
       }
     });

--- a/electron/services/__tests__/GpuCrashMonitorService.test.ts
+++ b/electron/services/__tests__/GpuCrashMonitorService.test.ts
@@ -478,6 +478,15 @@ describe("GpuCrashMonitorService", () => {
       });
       expect(appMock.relaunch).toHaveBeenCalledTimes(1);
       expect(appMock.exit).not.toHaveBeenCalled();
+      // Issue #10065: markers must commit before telemetry drain (shutdown.ts
+      // invariant). Lock the order so a future refactor can't invert it.
+      const cleanupOrder = crashRecoveryMock.cleanupOnExit.mock.invocationCallOrder[0];
+      const markExitOrder = crashLoopGuardMock.markCleanExit.mock.invocationCallOrder[0];
+      const markLaunchOrder = panelSuspectLedgerMock.markCleanLaunch.mock.invocationCallOrder[0];
+      const telemetryOrder = telemetryServiceMock.closeTelemetry.mock.invocationCallOrder[0];
+      expect(cleanupOrder).toBeLessThan(telemetryOrder);
+      expect(markExitOrder).toBeLessThan(telemetryOrder);
+      expect(markLaunchOrder).toBeLessThan(telemetryOrder);
 
       resolveClose();
 
@@ -713,7 +722,7 @@ describe("GpuCrashMonitorService", () => {
         expect(relaunchOrder).toBeLessThan(exitOrder);
       });
 
-      it("soft hard-stop writes all three markers, no relaunch()", async () => {
+      it("soft hard-stop writes all three markers in order before app.exit(0)", async () => {
         crashLoopGuardMock.shouldRelaunch.mockReturnValue(false);
         await loadAndInit();
         emitGpuCrash();
@@ -725,13 +734,15 @@ describe("GpuCrashMonitorService", () => {
         expect(crashLoopGuardMock.markCleanExit).toHaveBeenCalledTimes(1);
         expect(panelSuspectLedgerMock.markCleanLaunch).toHaveBeenCalledTimes(1);
         const cleanupOrder = crashRecoveryMock.cleanupOnExit.mock.invocationCallOrder[0];
+        const markExitOrder = crashLoopGuardMock.markCleanExit.mock.invocationCallOrder[0];
         const markLaunchOrder = panelSuspectLedgerMock.markCleanLaunch.mock.invocationCallOrder[0];
         const exitOrder = appMock.exit.mock.invocationCallOrder[0];
-        expect(cleanupOrder).toBeLessThan(exitOrder);
+        expect(cleanupOrder).toBeLessThan(markExitOrder);
+        expect(markExitOrder).toBeLessThan(markLaunchOrder);
         expect(markLaunchOrder).toBeLessThan(exitOrder);
       });
 
-      it("nuclear hard-stop writes all three markers, no relaunch()", async () => {
+      it("nuclear hard-stop writes all three markers in order before app.exit(0)", async () => {
         writeGpuAngleFallbackFlag(tmpDir);
         crashLoopGuardMock.shouldRelaunch.mockReturnValue(false);
         await loadAndInit();
@@ -745,6 +756,13 @@ describe("GpuCrashMonitorService", () => {
         expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalledTimes(1);
         expect(crashLoopGuardMock.markCleanExit).toHaveBeenCalledTimes(1);
         expect(panelSuspectLedgerMock.markCleanLaunch).toHaveBeenCalledTimes(1);
+        const cleanupOrder = crashRecoveryMock.cleanupOnExit.mock.invocationCallOrder[0];
+        const markExitOrder = crashLoopGuardMock.markCleanExit.mock.invocationCallOrder[0];
+        const markLaunchOrder = panelSuspectLedgerMock.markCleanLaunch.mock.invocationCallOrder[0];
+        const exitOrder = appMock.exit.mock.invocationCallOrder[0];
+        expect(cleanupOrder).toBeLessThan(markExitOrder);
+        expect(markExitOrder).toBeLessThan(markLaunchOrder);
+        expect(markLaunchOrder).toBeLessThan(exitOrder);
       });
 
       it("soft relaunch: marker writes still complete when cleanupOnExit throws", async () => {
@@ -820,6 +838,95 @@ describe("GpuCrashMonitorService", () => {
         expect(crashLoopGuardMock.markCleanExit).toHaveBeenCalledTimes(1);
         expect(panelSuspectLedgerMock.markCleanLaunch).toHaveBeenCalledTimes(1);
         expect(appMock.relaunch).not.toHaveBeenCalled();
+      });
+
+      it("nuclear relaunch: marker writes still complete when markCleanExit throws", async () => {
+        writeGpuAngleFallbackFlag(tmpDir);
+        crashLoopGuardMock.markCleanExit.mockImplementationOnce(() => {
+          throw new Error("markCleanExit failed");
+        });
+        await loadAndInit();
+        emitGpuCrash();
+        emitGpuCrash();
+        emitGpuCrash();
+        await vi.waitFor(() => {
+          expect(appMock.exit).toHaveBeenCalledWith(0);
+        });
+        expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalledTimes(1);
+        expect(panelSuspectLedgerMock.markCleanLaunch).toHaveBeenCalledTimes(1);
+        expect(appMock.relaunch).toHaveBeenCalledTimes(1);
+        expect(loggerMethods.error).toHaveBeenCalledWith(
+          "gpu-mitigation-mark-clean-exit-failed",
+          expect.any(Error),
+          expect.objectContaining({ path: "nuclear-disable" })
+        );
+      });
+
+      it("nuclear relaunch: relaunch still happens when markCleanLaunch throws", async () => {
+        writeGpuAngleFallbackFlag(tmpDir);
+        panelSuspectLedgerMock.markCleanLaunch.mockImplementationOnce(() => {
+          throw new Error("markCleanLaunch failed");
+        });
+        await loadAndInit();
+        emitGpuCrash();
+        emitGpuCrash();
+        emitGpuCrash();
+        await vi.waitFor(() => {
+          expect(appMock.exit).toHaveBeenCalledWith(0);
+        });
+        expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalledTimes(1);
+        expect(crashLoopGuardMock.markCleanExit).toHaveBeenCalledTimes(1);
+        expect(appMock.relaunch).toHaveBeenCalledTimes(1);
+        expect(loggerMethods.error).toHaveBeenCalledWith(
+          "gpu-mitigation-mark-clean-launch-failed",
+          expect.any(Error),
+          expect.objectContaining({ path: "nuclear-disable" })
+        );
+      });
+
+      it("soft hard-stop: app.exit(0) still happens when closeTelemetry rejects", async () => {
+        crashLoopGuardMock.shouldRelaunch.mockReturnValue(false);
+        telemetryServiceMock.closeTelemetry.mockRejectedValueOnce(
+          new Error("telemetry drain failed")
+        );
+        await loadAndInit();
+        emitGpuCrash();
+        await vi.waitFor(() => {
+          expect(appMock.exit).toHaveBeenCalledWith(0);
+        });
+        expect(appMock.relaunch).not.toHaveBeenCalled();
+        expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalledTimes(1);
+        expect(crashLoopGuardMock.markCleanExit).toHaveBeenCalledTimes(1);
+        expect(panelSuspectLedgerMock.markCleanLaunch).toHaveBeenCalledTimes(1);
+        expect(loggerMethods.error).toHaveBeenCalledWith(
+          "gpu-mitigation-close-telemetry-failed",
+          expect.any(Error),
+          expect.objectContaining({ path: "angle-fallback" })
+        );
+      });
+
+      it("nuclear hard-stop: app.exit(0) still happens when closeTelemetry rejects", async () => {
+        writeGpuAngleFallbackFlag(tmpDir);
+        crashLoopGuardMock.shouldRelaunch.mockReturnValue(false);
+        telemetryServiceMock.closeTelemetry.mockRejectedValueOnce(
+          new Error("telemetry drain failed")
+        );
+        await loadAndInit();
+        emitGpuCrash();
+        emitGpuCrash();
+        emitGpuCrash();
+        await vi.waitFor(() => {
+          expect(appMock.exit).toHaveBeenCalledWith(0);
+        });
+        expect(appMock.relaunch).not.toHaveBeenCalled();
+        expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalledTimes(1);
+        expect(crashLoopGuardMock.markCleanExit).toHaveBeenCalledTimes(1);
+        expect(panelSuspectLedgerMock.markCleanLaunch).toHaveBeenCalledTimes(1);
+        expect(loggerMethods.error).toHaveBeenCalledWith(
+          "gpu-mitigation-close-telemetry-failed",
+          expect.any(Error),
+          expect.objectContaining({ path: "nuclear-disable" })
+        );
       });
 
       it("non-GPU crashes do not call the cleanup helper", async () => {

--- a/electron/services/__tests__/GpuCrashMonitorService.test.ts
+++ b/electron/services/__tests__/GpuCrashMonitorService.test.ts
@@ -49,10 +49,27 @@ vi.mock("../TelemetryService.js", () => telemetryServiceMock);
 
 const crashLoopGuardMock = vi.hoisted(() => ({
   shouldRelaunch: vi.fn(() => true),
+  markCleanExit: vi.fn(),
+}));
+
+const crashRecoveryMock = vi.hoisted(() => ({
+  cleanupOnExit: vi.fn(),
+}));
+
+const panelSuspectLedgerMock = vi.hoisted(() => ({
+  markCleanLaunch: vi.fn(),
 }));
 
 vi.mock("../CrashLoopGuardService.js", () => ({
   getCrashLoopGuard: () => crashLoopGuardMock,
+}));
+
+vi.mock("../CrashRecoveryService.js", () => ({
+  getCrashRecoveryService: () => crashRecoveryMock,
+}));
+
+vi.mock("../PanelSuspectLedgerService.js", () => ({
+  getPanelSuspectLedger: () => panelSuspectLedgerMock,
 }));
 
 import {
@@ -643,6 +660,248 @@ describe("GpuCrashMonitorService", () => {
           expect(appMock.exit).toHaveBeenCalledWith(0);
         });
         expect(appMock.relaunch).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    // Issue #10065: GPU-mitigation exits skip the before-quit cleanup chain
+    // (app.exit does not emit before-quit / will-quit), so the next boot was
+    // treating the deliberate relaunch as a crash. Verify the three clean-exit
+    // markers are written in shutdown.ts order, in independent try/catch, and
+    // BEFORE app.relaunch() / app.exit(0) so the writes are not no-op'd by the
+    // process tear-down.
+    describe("clean-exit marker wiring (issue #10065)", () => {
+      it("soft relaunch writes all three markers in order before app.relaunch()", async () => {
+        await loadAndInit();
+        emitGpuCrash();
+        await vi.waitFor(() => {
+          expect(appMock.exit).toHaveBeenCalledWith(0);
+        });
+        expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalledTimes(1);
+        expect(crashLoopGuardMock.markCleanExit).toHaveBeenCalledTimes(1);
+        expect(panelSuspectLedgerMock.markCleanLaunch).toHaveBeenCalledTimes(1);
+        const cleanupOrder = crashRecoveryMock.cleanupOnExit.mock.invocationCallOrder[0];
+        const markExitOrder = crashLoopGuardMock.markCleanExit.mock.invocationCallOrder[0];
+        const markLaunchOrder = panelSuspectLedgerMock.markCleanLaunch.mock.invocationCallOrder[0];
+        const relaunchOrder = appMock.relaunch.mock.invocationCallOrder[0];
+        const exitOrder = appMock.exit.mock.invocationCallOrder[0];
+        expect(cleanupOrder).toBeLessThan(markExitOrder);
+        expect(markExitOrder).toBeLessThan(markLaunchOrder);
+        expect(markLaunchOrder).toBeLessThan(relaunchOrder);
+        expect(relaunchOrder).toBeLessThan(exitOrder);
+      });
+
+      it("nuclear relaunch writes all three markers in order before app.relaunch()", async () => {
+        writeGpuAngleFallbackFlag(tmpDir);
+        await loadAndInit();
+        emitGpuCrash();
+        emitGpuCrash();
+        emitGpuCrash();
+        await vi.waitFor(() => {
+          expect(appMock.exit).toHaveBeenCalledWith(0);
+        });
+        expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalledTimes(1);
+        expect(crashLoopGuardMock.markCleanExit).toHaveBeenCalledTimes(1);
+        expect(panelSuspectLedgerMock.markCleanLaunch).toHaveBeenCalledTimes(1);
+        const cleanupOrder = crashRecoveryMock.cleanupOnExit.mock.invocationCallOrder[0];
+        const markExitOrder = crashLoopGuardMock.markCleanExit.mock.invocationCallOrder[0];
+        const markLaunchOrder = panelSuspectLedgerMock.markCleanLaunch.mock.invocationCallOrder[0];
+        const relaunchOrder = appMock.relaunch.mock.invocationCallOrder[0];
+        const exitOrder = appMock.exit.mock.invocationCallOrder[0];
+        expect(cleanupOrder).toBeLessThan(markExitOrder);
+        expect(markExitOrder).toBeLessThan(markLaunchOrder);
+        expect(markLaunchOrder).toBeLessThan(relaunchOrder);
+        expect(relaunchOrder).toBeLessThan(exitOrder);
+      });
+
+      it("soft hard-stop writes all three markers, no relaunch()", async () => {
+        crashLoopGuardMock.shouldRelaunch.mockReturnValue(false);
+        await loadAndInit();
+        emitGpuCrash();
+        await vi.waitFor(() => {
+          expect(appMock.exit).toHaveBeenCalledWith(0);
+        });
+        expect(appMock.relaunch).not.toHaveBeenCalled();
+        expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalledTimes(1);
+        expect(crashLoopGuardMock.markCleanExit).toHaveBeenCalledTimes(1);
+        expect(panelSuspectLedgerMock.markCleanLaunch).toHaveBeenCalledTimes(1);
+        const cleanupOrder = crashRecoveryMock.cleanupOnExit.mock.invocationCallOrder[0];
+        const markLaunchOrder = panelSuspectLedgerMock.markCleanLaunch.mock.invocationCallOrder[0];
+        const exitOrder = appMock.exit.mock.invocationCallOrder[0];
+        expect(cleanupOrder).toBeLessThan(exitOrder);
+        expect(markLaunchOrder).toBeLessThan(exitOrder);
+      });
+
+      it("nuclear hard-stop writes all three markers, no relaunch()", async () => {
+        writeGpuAngleFallbackFlag(tmpDir);
+        crashLoopGuardMock.shouldRelaunch.mockReturnValue(false);
+        await loadAndInit();
+        emitGpuCrash();
+        emitGpuCrash();
+        emitGpuCrash();
+        await vi.waitFor(() => {
+          expect(appMock.exit).toHaveBeenCalledWith(0);
+        });
+        expect(appMock.relaunch).not.toHaveBeenCalled();
+        expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalledTimes(1);
+        expect(crashLoopGuardMock.markCleanExit).toHaveBeenCalledTimes(1);
+        expect(panelSuspectLedgerMock.markCleanLaunch).toHaveBeenCalledTimes(1);
+      });
+
+      it("soft relaunch: marker writes still complete when cleanupOnExit throws", async () => {
+        crashRecoveryMock.cleanupOnExit.mockImplementationOnce(() => {
+          throw new Error("cleanupOnExit failed");
+        });
+        await loadAndInit();
+        emitGpuCrash();
+        await vi.waitFor(() => {
+          expect(appMock.exit).toHaveBeenCalledWith(0);
+        });
+        expect(crashLoopGuardMock.markCleanExit).toHaveBeenCalledTimes(1);
+        expect(panelSuspectLedgerMock.markCleanLaunch).toHaveBeenCalledTimes(1);
+        expect(appMock.relaunch).toHaveBeenCalledTimes(1);
+        expect(loggerMethods.error).toHaveBeenCalledWith(
+          "gpu-mitigation-cleanup-on-exit-failed",
+          expect.any(Error),
+          expect.objectContaining({ path: "angle-fallback" })
+        );
+      });
+
+      it("soft relaunch: marker writes still complete when markCleanExit throws", async () => {
+        crashLoopGuardMock.markCleanExit.mockImplementationOnce(() => {
+          throw new Error("markCleanExit failed");
+        });
+        await loadAndInit();
+        emitGpuCrash();
+        await vi.waitFor(() => {
+          expect(appMock.exit).toHaveBeenCalledWith(0);
+        });
+        expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalledTimes(1);
+        expect(panelSuspectLedgerMock.markCleanLaunch).toHaveBeenCalledTimes(1);
+        expect(appMock.relaunch).toHaveBeenCalledTimes(1);
+        expect(loggerMethods.error).toHaveBeenCalledWith(
+          "gpu-mitigation-mark-clean-exit-failed",
+          expect.any(Error),
+          expect.objectContaining({ path: "angle-fallback" })
+        );
+      });
+
+      it("soft relaunch: relaunch still happens when markCleanLaunch throws", async () => {
+        panelSuspectLedgerMock.markCleanLaunch.mockImplementationOnce(() => {
+          throw new Error("markCleanLaunch failed");
+        });
+        await loadAndInit();
+        emitGpuCrash();
+        await vi.waitFor(() => {
+          expect(appMock.exit).toHaveBeenCalledWith(0);
+        });
+        expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalledTimes(1);
+        expect(crashLoopGuardMock.markCleanExit).toHaveBeenCalledTimes(1);
+        expect(appMock.relaunch).toHaveBeenCalledTimes(1);
+        expect(loggerMethods.error).toHaveBeenCalledWith(
+          "gpu-mitigation-mark-clean-launch-failed",
+          expect.any(Error),
+          expect.objectContaining({ path: "angle-fallback" })
+        );
+      });
+
+      it("nuclear hard-stop: marker writes still complete when cleanupOnExit throws", async () => {
+        writeGpuAngleFallbackFlag(tmpDir);
+        crashLoopGuardMock.shouldRelaunch.mockReturnValue(false);
+        crashRecoveryMock.cleanupOnExit.mockImplementationOnce(() => {
+          throw new Error("cleanupOnExit failed");
+        });
+        await loadAndInit();
+        emitGpuCrash();
+        emitGpuCrash();
+        emitGpuCrash();
+        await vi.waitFor(() => {
+          expect(appMock.exit).toHaveBeenCalledWith(0);
+        });
+        expect(crashLoopGuardMock.markCleanExit).toHaveBeenCalledTimes(1);
+        expect(panelSuspectLedgerMock.markCleanLaunch).toHaveBeenCalledTimes(1);
+        expect(appMock.relaunch).not.toHaveBeenCalled();
+      });
+
+      it("non-GPU crashes do not call the cleanup helper", async () => {
+        await loadAndInit();
+        emitChildProcessGone("Utility", "crashed", 1, "daintree-pty-host");
+        emitChildProcessGone("Utility", "crashed", 1, "daintree-pty-host");
+        emitChildProcessGone("Utility", "crashed", 1, "daintree-pty-host");
+        expect(crashRecoveryMock.cleanupOnExit).not.toHaveBeenCalled();
+        expect(crashLoopGuardMock.markCleanExit).not.toHaveBeenCalled();
+        expect(panelSuspectLedgerMock.markCleanLaunch).not.toHaveBeenCalled();
+      });
+
+      it("clean-exit / killed GPU exits do not call the cleanup helper", async () => {
+        await loadAndInit();
+        emitGpuCrash("clean-exit");
+        emitGpuCrash("killed");
+        emitGpuCrash("clean-exit");
+        expect(crashRecoveryMock.cleanupOnExit).not.toHaveBeenCalled();
+        expect(crashLoopGuardMock.markCleanExit).not.toHaveBeenCalled();
+        expect(panelSuspectLedgerMock.markCleanLaunch).not.toHaveBeenCalled();
+      });
+
+      it("already-disabled path does not call the cleanup helper", async () => {
+        writeGpuDisabledFlag(tmpDir);
+        await loadAndInit();
+        emitGpuCrash();
+        emitGpuCrash();
+        emitGpuCrash();
+        expect(crashRecoveryMock.cleanupOnExit).not.toHaveBeenCalled();
+        expect(crashLoopGuardMock.markCleanExit).not.toHaveBeenCalled();
+        expect(panelSuspectLedgerMock.markCleanLaunch).not.toHaveBeenCalled();
+      });
+
+      it("failed ANGLE flag write does not call the cleanup helper", async () => {
+        vi.doMock("../../utils/fs.js", async () => {
+          const actual =
+            await vi.importActual<typeof import("../../utils/fs.js")>("../../utils/fs.js");
+          return {
+            ...actual,
+            resilientAtomicWriteFileSync: vi.fn(() => {
+              throw new Error("EROFS: read-only filesystem");
+            }),
+          };
+        });
+        try {
+          await loadAndInit();
+          emitGpuCrash();
+          await new Promise((r) => setImmediate(r));
+          expect(crashRecoveryMock.cleanupOnExit).not.toHaveBeenCalled();
+          expect(crashLoopGuardMock.markCleanExit).not.toHaveBeenCalled();
+          expect(panelSuspectLedgerMock.markCleanLaunch).not.toHaveBeenCalled();
+          expect(appMock.relaunch).not.toHaveBeenCalled();
+        } finally {
+          vi.doUnmock("../../utils/fs.js");
+        }
+      });
+
+      it("failed nuclear disable write does not call the cleanup helper", async () => {
+        writeGpuAngleFallbackFlag(tmpDir);
+        vi.doMock("../../utils/fs.js", async () => {
+          const actual =
+            await vi.importActual<typeof import("../../utils/fs.js")>("../../utils/fs.js");
+          return {
+            ...actual,
+            resilientAtomicWriteFileSync: vi.fn(() => {
+              throw new Error("EROFS: read-only filesystem");
+            }),
+          };
+        });
+        try {
+          await loadAndInit();
+          emitGpuCrash();
+          emitGpuCrash();
+          emitGpuCrash();
+          await new Promise((r) => setImmediate(r));
+          expect(crashRecoveryMock.cleanupOnExit).not.toHaveBeenCalled();
+          expect(crashLoopGuardMock.markCleanExit).not.toHaveBeenCalled();
+          expect(panelSuspectLedgerMock.markCleanLaunch).not.toHaveBeenCalled();
+          expect(appMock.relaunch).not.toHaveBeenCalled();
+        } finally {
+          vi.doUnmock("../../utils/fs.js");
+        }
       });
     });
   });


### PR DESCRIPTION
## Summary

- Writes the three clean-exit markers before every GPU-mitigation relaunch or hard-stop, mirroring the AutoUpdater #9638 pattern.
- Fixes the deliberate self-relaunch being misread as a crashed session on next boot: stale recovery dialog, `native-crash` misclassification, crash-loop guard strike.
- Review hardening wraps `closeTelemetry()` in try/catch, adds hard-stop marker-ordering assertions, and symmetrises failure logging.

Resolves #10065

## Changes

- New `writeCleanGpuMitigationMarkers()` file-local helper in `electron/services/GpuCrashMonitorService.ts` calls `cleanupOnExit()`, `CrashLoopGuard.markCleanExit()`, and `PanelSuspectLedger.markCleanLaunch()` in independent try/catch blocks, in the same order as `electron/lifecycle/shutdown.ts`.
- Helper is wired into all four exit sites: soft relaunch, soft hard-stop, nuclear relaunch, nuclear hard-stop.
- Relaunch/exit still runs even if every marker write throws (lesson #7158).
- 12 new test cases in `electron/services/__tests__/GpuCrashMonitorService.test.ts` covering marker order, failure isolation, and negative paths (non-GPU crashes, clean-exit/killed, already-disabled, failed flag writes).
- Review pass: `closeTelemetry()` rejection now logged and isolated in the hard-stop branches, hard-stop ordering assertions added to match the relaunch branches, deferred-telemetry test asserts the three markers commit before `closeTelemetry` resolves.

## Testing

- 12 new unit tests pass; full `GpuCrashMonitorService` suite green.
- `npm run typecheck` clean.
- `npm run lint:fix` and `npm run format` clean.
- Manually traced: `app.relaunch() + app.exit(0)` path on a synthetic child-process-gone event now produces `running.lock` cleanup, `markCleanExit`, and `markCleanLaunch` markers, and the next boot no longer enters the crash-recovery dialog or accumulates a strike.
