### PR TITLE
fix(crash-recovery): estimate crash time from marker, not relaunch time

### DIFF
--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -463,10 +463,21 @@ export class CrashRecoveryService {
         }
       }
       if (parseableBackupPath) {
-        try {
-          backupTimestamp = fs.statSync(parseableBackupPath).mtimeMs;
-        } catch {
-          // best-effort: backup timestamp is informational only
+        // Read the timestamp from the parsed snapshot's `capturedAt` rather
+        // than the file's disk mtime. On the Windows/EPERM copy-fallback
+        // path in preserveBackupForRecovery, the new crashed-* file's mtime
+        // is the relaunch time — feeding that into the priority chain
+        // would win over the heartbeat and re-introduce the #10062 bug we
+        // just fixed. `capturedAt` is the pre-crash write time stamped
+        // by captureSessionSnapshot, which is exactly what we want.
+        if (this.cachedBackupSnapshot) {
+          backupTimestamp = this.cachedBackupSnapshot.capturedAt;
+        } else {
+          try {
+            backupTimestamp = fs.statSync(parseableBackupPath).mtimeMs;
+          } catch {
+            // best-effort: backup timestamp is informational only
+          }
         }
       }
 
@@ -636,14 +647,19 @@ export class CrashRecoveryService {
         // would pass a bare `typeof === "number"` check and produce a
         // misleading attribution. Real values from buildWatchdogKillPayload
         // are always positive (killedAt = Date.now(), missedBeats >= 1,
-        // mainPid > 0).
+        // mainPid > 0). `JSON.parse('{"killedAt":1e309}')` returns
+        // `Infinity` which passes `> 0` but corrupts the report
+        // ("Infinity" in the GitHub crash URL), so finiteness is required.
         if (
           typeof parsed.killedAt === "number" &&
           parsed.killedAt > 0 &&
+          Number.isFinite(parsed.killedAt) &&
           typeof parsed.missedBeats === "number" &&
           parsed.missedBeats >= 1 &&
+          Number.isFinite(parsed.missedBeats) &&
           typeof parsed.mainPid === "number" &&
-          parsed.mainPid > 0
+          parsed.mainPid > 0 &&
+          Number.isFinite(parsed.mainPid)
         ) {
           annotation = {
             killedAt: parsed.killedAt,
@@ -1174,6 +1190,8 @@ function isValidMarker(value: unknown): value is MarkerFile {
     typeof value === "object" &&
     value !== null &&
     typeof (value as MarkerFile).sessionStartMs === "number" &&
+    Number.isFinite((value as MarkerFile).sessionStartMs) &&
+    (value as MarkerFile).sessionStartMs > 0 &&
     typeof (value as MarkerFile).appVersion === "string"
   );
 }

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -471,7 +471,22 @@ export class CrashRecoveryService {
       }
 
       const logPath = marker.crashLogPath ?? null;
-      const entry = logPath ? this.readCrashLog(logPath) : this.buildCrashEntryFromMarker(marker);
+      // Compute the best available estimate of when the previous session
+      // actually died. Marker-only entries (no crashLogPath) had no in-process
+      // recorder to stamp a real crash time, so without this they'd inherit
+      // the relaunch time and mislead the recovery dialog, GitHub crash
+      // report, and 30s panel-suspect window. Existing crash logs already
+      // carry their own timestamp from the recorder path and are unaffected.
+      const nowMs = Date.now();
+      const crashTimestamp = this.resolveMarkerCrashTimestamp(
+        marker,
+        watchdogAnnotation,
+        backupTimestamp,
+        nowMs
+      );
+      const entry = logPath
+        ? this.readCrashLog(logPath)
+        : this.buildCrashEntryFromMarker(marker, crashTimestamp);
       entry.crashCause = this.classifyCrashCause(marker);
       if (watchdogAnnotation) {
         entry.cause = "watchdog-deadlock";
@@ -794,22 +809,64 @@ export class CrashRecoveryService {
     return entry;
   }
 
-  private buildCrashEntryFromMarker(marker: MarkerFile): CrashLogEntry {
+  private buildCrashEntryFromMarker(marker: MarkerFile, crashTimestamp: number): CrashLogEntry {
     const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const entry: CrashLogEntry = {
       id,
-      timestamp: Date.now(),
+      timestamp: crashTimestamp,
       appVersion: marker.appVersion ?? app.getVersion(),
       platform: marker.platform ?? process.platform,
       osVersion: os.release(),
       arch: os.arch(),
-      sessionDurationMs: marker.sessionStartMs ? Date.now() - marker.sessionStartMs : undefined,
+      sessionDurationMs: marker.sessionStartMs
+        ? Math.max(0, crashTimestamp - marker.sessionStartMs)
+        : undefined,
     };
 
     this.enrichWithEnvironmentMetadata(entry);
     this.enrichWithPanelData(entry, this.readCrashedBackupAppState());
 
     return entry;
+  }
+
+  /**
+   * Pick the best available estimate of when the previous session actually
+   * died, for entries synthesized from a marker with no crash log.
+   *
+   * Priority chain (strongest signal first):
+   *   1. watchdogAnnotation.killedAt — exact SIGKILL time the watchdog wrote
+   *   2. marker.lastSuspendStart — power loss during sleep
+   *   3. backupTimestamp — last parseable backup mtime, a floor on
+   *      "what state was on disk when death occurred"
+   *   4. marker.lastHeartbeatMs — the heartbeat we tick every backup
+   *      interval; a marker with no heartbeat would have to be from a code
+   *      path that pre-dates this service, so it's effectively unreachable.
+   *
+   * The chosen value is clamped to [sessionStartMs, nowMs] so it can never
+   * precede the session (negative `sessionDurationMs` would break
+   * `formatDuration` in the dialog) and never exceed the relaunch time
+   * (would mislead the 30s suspect window and produce a future-dated crash
+   * report). When no candidate is valid the fallback is the clamped
+   * relaunch time — the only honest answer in that pathological case.
+   */
+  private resolveMarkerCrashTimestamp(
+    marker: MarkerFile,
+    watchdogAnnotation: WatchdogKillAnnotation | null,
+    backupTimestamp: number | undefined,
+    nowMs: number
+  ): number {
+    const candidates: Array<number | null | undefined> = [
+      watchdogAnnotation?.killedAt,
+      marker.lastSuspendStart,
+      backupTimestamp,
+      marker.lastHeartbeatMs,
+    ];
+    for (const candidate of candidates) {
+      if (typeof candidate === "number" && Number.isFinite(candidate) && candidate > 0) {
+        return Math.max(marker.sessionStartMs, Math.min(candidate, nowMs));
+      }
+    }
+    return Math.max(marker.sessionStartMs, nowMs);
   }
 
   private readCrashedBackupAppState(): unknown {

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -2269,4 +2269,264 @@ describe("CrashRecoveryService", () => {
       expect(svc.getPendingCrash()!.entry.cause).toBeUndefined();
     });
   });
+
+  describe("marker-only crash timestamp", () => {
+    // Each test pins a marker at T0, advances the wall clock by DEAD_MS, then
+    // initializes. The dead interval is the gap between when the previous
+    // session died and when the current session discovered its corpse; the
+    // bug (per #10062) was that the new entry stamped DEAD_MS as its
+    // sessionDurationMs and relaunch time as the crash time.
+
+    const T0 = 1_700_000_000_000;
+    const DEAD_MS = 7_200_000; // 2 hours
+
+    function writeMarkerWithHeartbeat(lastHeartbeatMs: number, extras: Record<string, unknown> = {}): void {
+      fs.writeFileSync(
+        path.join(userData, "running.lock"),
+        JSON.stringify({
+          sessionStartMs: T0,
+          appVersion: "1.0.0",
+          platform: "darwin",
+          lastHeartbeatMs,
+          ...extras,
+        })
+      );
+    }
+
+    function writeBackup(terminals: Array<{ id: string; createdAt: number }>): string {
+      const backupDir = path.join(userData, "backups");
+      fs.mkdirSync(backupDir, { recursive: true });
+      const backupPath = path.join(backupDir, "session-state.json");
+      fs.writeFileSync(
+        backupPath,
+        JSON.stringify({ capturedAt: T0 + 60_000, appState: { terminals } })
+      );
+      return backupPath;
+    }
+
+    beforeEach(() => {
+      // Fake timers must include Date so Date.now() advances with the clock —
+      // the existing boundary test (1018-1069) collapses T0 and now because
+      // they share the same tick, hiding the bug. Lesson #7917.
+      vi.useFakeTimers({
+        toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval", "Date"],
+      });
+      vi.setSystemTime(T0 + DEAD_MS);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("uses the last heartbeat as the crash time when no other signal exists", () => {
+      const heartbeat = T0 + 5 * 60_000; // 5 minutes into the session
+      writeMarkerWithHeartbeat(heartbeat);
+
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      expect(pending).not.toBeNull();
+      // The bug: this used to be T0 + DEAD_MS (relaunch time).
+      expect(pending!.entry.timestamp).toBe(heartbeat);
+      expect(pending!.entry.sessionDurationMs).toBe(heartbeat - T0);
+    });
+
+    it("prefers the watchdog killedAt over the heartbeat when both exist", () => {
+      const heartbeat = T0 + 30 * 60_000;
+      const killedAt = T0 + 45 * 60_000;
+      writeMarkerWithHeartbeat(heartbeat);
+      // Flag mtime must be fresh (>= sessionStartMs - GRACE_MS) for
+      // consumeWatchdogKillFlag to surface the annotation.
+      const flagPath = path.join(userData, "watchdog-kill.flag");
+      fs.writeFileSync(
+        flagPath,
+        JSON.stringify({ killedAt, missedBeats: 3, mainPid: 4242 }),
+        "utf8"
+      );
+      fs.utimesSync(flagPath, new Date(killedAt), new Date(killedAt));
+
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      expect(pending).not.toBeNull();
+      expect(pending!.entry.timestamp).toBe(killedAt);
+      expect(pending!.entry.sessionDurationMs).toBe(killedAt - T0);
+      expect(pending!.entry.cause).toBe("watchdog-deadlock");
+    });
+
+    it("prefers lastSuspendStart over backup mtime and heartbeat", () => {
+      const heartbeat = T0 + 30 * 60_000;
+      const suspendStart = T0 + 50 * 60_000;
+      // Write a backup whose mtime is later than suspendStart; if the
+      // priority order is wrong (suspend < backup), this test will fail.
+      const backupPath = writeBackup([{ id: "t1", createdAt: T0 }]);
+      const backupMtime = suspendStart + 5 * 60_000;
+      fs.utimesSync(backupPath, new Date(backupMtime), new Date(backupMtime));
+
+      writeMarkerWithHeartbeat(heartbeat, { lastSuspendStart: suspendStart });
+
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      expect(pending).not.toBeNull();
+      expect(pending!.entry.timestamp).toBe(suspendStart);
+      expect(pending!.entry.crashCause).toBe("suspended-then-lost");
+    });
+
+    it("prefers backup mtime over the heartbeat when suspend/watchdog are absent", () => {
+      const heartbeat = T0 + 30 * 60_000;
+      const backupMtime = T0 + 40 * 60_000;
+      const backupPath = writeBackup([{ id: "t1", createdAt: T0 }]);
+      fs.utimesSync(backupPath, new Date(backupMtime), new Date(backupMtime));
+
+      writeMarkerWithHeartbeat(heartbeat);
+
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      expect(pending).not.toBeNull();
+      expect(pending!.entry.timestamp).toBe(backupMtime);
+    });
+
+    it("clamps a heartbeat in the future down to the relaunch time", () => {
+      // Clock skew: heartbeat is 5 minutes past relaunch (laptop woke from
+      // sleep, NTP correction, or fs mtime precision drift). Must clamp to
+      // relaunch time so sessionDurationMs is non-negative and the suspect
+      // window is not future-dated.
+      const futureHeartbeat = T0 + DEAD_MS + 5 * 60_000;
+      writeMarkerWithHeartbeat(futureHeartbeat);
+
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      expect(pending).not.toBeNull();
+      expect(pending!.entry.timestamp).toBe(T0 + DEAD_MS);
+      expect(pending!.entry.sessionDurationMs).toBe(DEAD_MS);
+    });
+
+    it("ignores NaN/Infinity candidates and falls through to a finite one", () => {
+      const heartbeat = T0 + 5 * 60_000;
+      writeMarkerWithHeartbeat(heartbeat, {
+        lastSuspendStart: Number.NaN,
+        // backup mtime is undefined (no backup), but the marker has
+        // a finite heartbeat that must still win.
+      });
+
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      expect(pending).not.toBeNull();
+      expect(pending!.entry.timestamp).toBe(heartbeat);
+    });
+
+    it("falls back to the relaunch time when no candidate is usable", () => {
+      // Marker with no heartbeat, no suspend, no backup — pathological but
+      // the fallback must still produce a finite, clamped timestamp.
+      fs.writeFileSync(
+        path.join(userData, "running.lock"),
+        JSON.stringify({
+          sessionStartMs: T0,
+          appVersion: "1.0.0",
+          platform: "darwin",
+        })
+      );
+
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      expect(pending).not.toBeNull();
+      expect(pending!.entry.timestamp).toBe(T0 + DEAD_MS);
+      expect(pending!.entry.sessionDurationMs).toBe(DEAD_MS);
+    });
+
+    it("drives the suspect window from the corrected timestamp (#10062 regression)", () => {
+      // Headline regression test: a panel created 5min into the session
+      // should be flagged as a suspect after a 2h dead interval, because
+      // the crash happened (per the heartbeat) at T0+5min, not at the
+      // relaunch time. The pre-fix code stamped relaunch time and the
+      // panel would have been classified as safe — silently breaking
+      // the OOM-kill-loop signal in PanelSuspectLedgerService.
+      const heartbeat = T0 + 5 * 60_000;
+      const backupPath = writeBackup([
+        { id: "near", createdAt: heartbeat - 5_000 },
+        { id: "far", createdAt: heartbeat + 3 * 60_000 },
+      ]);
+      // Pin the backup mtime to the heartbeat so the priority chain picks
+      // the heartbeat-derived estimate (the file's natural mtime would
+      // be the relaunch time, which would win over the heartbeat by
+      // priority and re-introduce the bug we just fixed).
+      fs.utimesSync(backupPath, new Date(heartbeat), new Date(heartbeat));
+      writeMarkerWithHeartbeat(heartbeat);
+
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      expect(pending).not.toBeNull();
+      const near = pending!.panels!.find((p) => p.id === "near")!;
+      const far = pending!.panels!.find((p) => p.id === "far")!;
+      expect(near.isSuspect).toBe(true);
+      expect(near.suspectReason).toBe("crash-window");
+      // 3min past heartbeat is well outside the 30s window.
+      expect(far.isSuspect).toBe(false);
+      expect(far.suspectReason).toBeUndefined();
+    });
+
+    it("preserves the timestamp of an existing crash log (does not override with killedAt)", () => {
+      // The recorder path wrote a crash log with its own timestamp; the
+      // marker-only fix must not touch that path. The watchdog annotation
+      // (cause + watchdogKilledAt) still applies, but the entry's timestamp
+      // is the recorder's.
+      const crashDir = path.join(userData, "crashes");
+      fs.mkdirSync(crashDir, { recursive: true });
+      const crashLogPath = path.join(crashDir, "crash-recorder.json");
+      const recorderTimestamp = T0 + 12 * 60_000;
+      fs.writeFileSync(
+        crashLogPath,
+        JSON.stringify({
+          id: "recorder",
+          timestamp: recorderTimestamp,
+          appVersion: "1.0.0",
+          platform: "darwin",
+          osVersion: "23.0",
+          arch: "arm64",
+          errorMessage: "uncaught exception",
+        })
+      );
+      fs.writeFileSync(
+        path.join(userData, "running.lock"),
+        JSON.stringify({
+          sessionStartMs: T0,
+          appVersion: "1.0.0",
+          platform: "darwin",
+          lastHeartbeatMs: T0 + 10 * 60_000,
+          crashLogPath,
+        })
+      );
+      const killedAt = T0 + 14 * 60_000;
+      const flagPath = path.join(userData, "watchdog-kill.flag");
+      fs.writeFileSync(
+        flagPath,
+        JSON.stringify({ killedAt, missedBeats: 3, mainPid: 4242 }),
+        "utf8"
+      );
+      fs.utimesSync(flagPath, new Date(killedAt), new Date(killedAt));
+
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      expect(pending).not.toBeNull();
+      expect(pending!.entry.timestamp).toBe(recorderTimestamp);
+      expect(pending!.entry.errorMessage).toBe("uncaught exception");
+      expect(pending!.entry.cause).toBe("watchdog-deadlock");
+    });
+  });
 });

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -2280,7 +2280,10 @@ describe("CrashRecoveryService", () => {
     const T0 = 1_700_000_000_000;
     const DEAD_MS = 7_200_000; // 2 hours
 
-    function writeMarkerWithHeartbeat(lastHeartbeatMs: number, extras: Record<string, unknown> = {}): void {
+    function writeMarkerWithHeartbeat(
+      lastHeartbeatMs: number,
+      extras: Record<string, unknown> = {}
+    ): void {
       fs.writeFileSync(
         path.join(userData, "running.lock"),
         JSON.stringify({
@@ -2578,6 +2581,7 @@ describe("CrashRecoveryService", () => {
       const flagPath = path.join(userData, "watchdog-kill.flag");
       fs.writeFileSync(
         flagPath,
+        // eslint-disable-next-line no-loss-of-precision -- sentinel: forces Infinity, exercises 2f134fabf hardening
         JSON.stringify({ killedAt: 1e309, missedBeats: 3, mainPid: 4242 }),
         "utf8"
       );

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -2376,11 +2376,17 @@ describe("CrashRecoveryService", () => {
       expect(pending!.entry.crashCause).toBe("suspended-then-lost");
     });
 
-    it("prefers backup mtime over the heartbeat when suspend/watchdog are absent", () => {
+    it("prefers backup capturedAt over the heartbeat when suspend/watchdog are absent", () => {
       const heartbeat = T0 + 30 * 60_000;
-      const backupMtime = T0 + 40 * 60_000;
+      const capturedAt = T0 + 40 * 60_000;
       const backupPath = writeBackup([{ id: "t1", createdAt: T0 }]);
-      fs.utimesSync(backupPath, new Date(backupMtime), new Date(backupMtime));
+      // Override capturedAt — it's the in-snapshot timestamp the resolver
+      // reads, not the on-disk mtime. (See the Windows/EPERM regression
+      // test below for why we trust capturedAt over the file mtime.)
+      const raw = JSON.parse(fs.readFileSync(backupPath, "utf-8"));
+      raw.capturedAt = capturedAt;
+      fs.writeFileSync(backupPath, JSON.stringify(raw));
+      fs.utimesSync(backupPath, new Date(T0 + 50 * 60_000), new Date(T0 + 50 * 60_000));
 
       writeMarkerWithHeartbeat(heartbeat);
 
@@ -2389,7 +2395,7 @@ describe("CrashRecoveryService", () => {
 
       const pending = svc.getPendingCrash();
       expect(pending).not.toBeNull();
-      expect(pending!.entry.timestamp).toBe(backupMtime);
+      expect(pending!.entry.timestamp).toBe(capturedAt);
     });
 
     it("clamps a heartbeat in the future down to the relaunch time", () => {
@@ -2458,10 +2464,15 @@ describe("CrashRecoveryService", () => {
         { id: "near", createdAt: heartbeat - 5_000 },
         { id: "far", createdAt: heartbeat + 3 * 60_000 },
       ]);
-      // Pin the backup mtime to the heartbeat so the priority chain picks
-      // the heartbeat-derived estimate (the file's natural mtime would
-      // be the relaunch time, which would win over the heartbeat by
-      // priority and re-introduce the bug we just fixed).
+      // Pin the backup's capturedAt to the heartbeat. The resolver reads
+      // capturedAt (not disk mtime) per the Windows/EPERM fix, so this
+      // is the value that wins the priority chain. Make it equal to the
+      // heartbeat so the heartbeat is the chosen estimate; set
+      // heartbeat a hair after capturedAt so the "near" panel lands
+      // inside the 30s window.
+      const raw = JSON.parse(fs.readFileSync(backupPath, "utf-8"));
+      raw.capturedAt = heartbeat - 1_000; // just before heartbeat
+      fs.writeFileSync(backupPath, JSON.stringify(raw));
       fs.utimesSync(backupPath, new Date(heartbeat), new Date(heartbeat));
       writeMarkerWithHeartbeat(heartbeat);
 
@@ -2527,6 +2538,100 @@ describe("CrashRecoveryService", () => {
       expect(pending!.entry.timestamp).toBe(recorderTimestamp);
       expect(pending!.entry.errorMessage).toBe("uncaught exception");
       expect(pending!.entry.cause).toBe("watchdog-deadlock");
+    });
+
+    it("uses the snapshot capturedAt as backup mtime (not the disk mtime of the copied crashed-* file)", () => {
+      // Windows/EPERM copy-fallback regression: when preserveBackupForRecovery
+      // falls back to copy-then-unlink, the new crashed-* file's disk mtime
+      // is the relaunch time. Reading capturedAt from the parsed snapshot
+      // (in-memory, set by the backup write itself) preserves the pre-crash
+      // mtime, so the priority chain picks the heartbeat-derived estimate
+      // instead of the relaunch time.
+      const heartbeat = T0 + 5 * 60_000;
+      const capturedAt = T0 + 4 * 60_000; // snapshot's capturedAt (older than heartbeat)
+      const backupPath = writeBackup([{ id: "t1", createdAt: T0 }]);
+      // Simulate the snapshot's capturedAt being the pre-crash write time.
+      const raw = JSON.parse(fs.readFileSync(backupPath, "utf-8"));
+      raw.capturedAt = capturedAt;
+      fs.writeFileSync(backupPath, JSON.stringify(raw));
+      writeMarkerWithHeartbeat(heartbeat);
+
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      expect(pending).not.toBeNull();
+      // capturedAt (T0+4m) wins over the heartbeat (T0+5m) per the
+      // priority chain. Without the capturedAt fix, the on-disk mtime
+      // (≈T0+DEAD_MS) would win and reproduce #10062.
+      expect(pending!.entry.timestamp).toBe(capturedAt);
+    });
+
+    it("rejects Infinity in the watchdog killedAt payload", () => {
+      // JSON.parse('{"killedAt":1e309}') returns Infinity, which passes
+      // `typeof === "number" && > 0`. Without the Number.isFinite guard
+      // the report would render "Crashed at: Infinity" and the dialog
+      // would show "Invalid Date".
+      const sessionStartMs = T0;
+      const flagMtime = T0 + 5 * 60_000;
+      writeMarkerWithHeartbeat(sessionStartMs);
+      const flagPath = path.join(userData, "watchdog-kill.flag");
+      fs.writeFileSync(
+        flagPath,
+        JSON.stringify({ killedAt: 1e309, missedBeats: 3, mainPid: 4242 }),
+        "utf8"
+      );
+      fs.utimesSync(flagPath, new Date(flagMtime), new Date(flagMtime));
+
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      expect(pending).not.toBeNull();
+      expect(pending!.entry.cause).toBeUndefined();
+      expect(pending!.entry.watchdogKilledAt).toBeUndefined();
+      // The resolver should still surface a real crash time from the
+      // heartbeat — Infinity must not poison the priority chain.
+      expect(pending!.entry.timestamp).toBe(T0);
+    });
+
+    it("clamps an out-of-range suspendStart to the relaunch time (not the heartbeat)", () => {
+      // The clamp is applied to every priority source, not just the
+      // heartbeat. A future suspendStart (e.g. clock-skewed file) must
+      // clamp to nowMs.
+      const heartbeat = T0 + 5 * 60_000;
+      const futureSuspend = T0 + DEAD_MS + 60_000;
+      writeMarkerWithHeartbeat(heartbeat, { lastSuspendStart: futureSuspend });
+
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      expect(pending).not.toBeNull();
+      expect(pending!.entry.timestamp).toBe(T0 + DEAD_MS);
+    });
+
+    it("ignores a marker with a non-finite or non-positive sessionStartMs", () => {
+      // isValidMarker was tightened to require finite positive sessionStartMs.
+      // Infinity, -1, NaN, or 0 in sessionStartMs would let the resolver
+      // clamp to zero / produce a negative sessionDurationMs.
+      for (const bad of [Number.POSITIVE_INFINITY, -1, Number.NaN, 0]) {
+        fs.writeFileSync(
+          path.join(userData, "running.lock"),
+          JSON.stringify({
+            sessionStartMs: bad,
+            appVersion: "1.0.0",
+            platform: "darwin",
+            lastHeartbeatMs: T0 + 5 * 60_000,
+          })
+        );
+
+        const svc = makeService();
+        svc.initialize();
+
+        // Corrupt marker is rejected — no pending crash, no entry built.
+        expect(svc.getPendingCrash()).toBeNull();
+      }
     });
   });
 });


### PR DESCRIPTION
Resolves #10062

When we built a marker-only crash entry on the next launch (no prior crash log written — external kill, OOM, watchdog kill, power loss), we stamped `Date.now()` as the crash time. That meant the recovery dialog dated the crash to relaunch time, the GitHub crash report's "Crashed at" / "Session duration" lines were both wrong, and the 30s panel-suspect window almost never matched. The repeat-suspect quarantine machinery in #8704 only kicks in from `isSuspect`, so it was effectively dead for the classes it matters most for, like OOM kill loops.

This PR resolves the timestamp in `consumeMarker()` from a priority chain and passes it into `buildCrashEntryFromMarker`:

`watchdogAnnotation.killedAt` > `marker.lastSuspendStart` > `cachedBackupSnapshot.capturedAt` > `marker.lastHeartbeatMs`

That value is clamped to `[sessionStartMs, Date.now()]` so it can never read as a future time or predate the session.

## Changes

- `electron/services/CrashRecoveryService.ts`: priority chain in `consumeMarker()`, `buildCrashEntryFromMarker` takes the resolved timestamp, `isValidMarker` tightened to require a finite positive `sessionStartMs`.
- `electron/services/__tests__/CrashRecoveryService.test.ts`: 4 new regression tests, including a dead-interval test the existing one couldn't catch (its crashTime and relaunchTime collapse to the same value).

Two follow-up commits harden the resolver:

- Read the backup timestamp from `cachedBackupSnapshot.capturedAt`, not `statSync` mtime. The Windows/EPERM copy-fallback in `preserveBackupForRecovery` writes a new `crashed-*` file whose mtime is the relaunch time, so the disk-mtime path would re-introduce this bug. `capturedAt` is already in memory from `capturedSessionSnapshot`.
- Reject `Infinity` in the watchdog `killedAt` payload. `JSON.parse` of an oversize number literal returns `Infinity`, which passed the `typeof === "number" && > 0` check, then rendered as `"Infinity"` in the GitHub report and `"Invalid Date"` in the dialog. `Number.isFinite` now gates it.

## Testing

- 112/112 tests in `CrashRecoveryService.test.ts` pass.
- `npm run check` (typecheck + lint + format + channel/IPC/confirm-wiring guards) is clean.