### PR TITLE
fix(keybinding): make loadOverrides self-catch IPC rejection

### DIFF
--- a/src/services/KeybindingService.ts
+++ b/src/services/KeybindingService.ts
@@ -17,6 +17,7 @@ import { KEY_ACTION_VALUES } from "@shared/types/keymap";
 import { evaluate } from "@shared/utils/whenClause/evaluator";
 import { parse } from "@shared/utils/whenClause/parser";
 import type { WhenClauseContext } from "@shared/utils/whenClause/types";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 export * from "./keybindingUtils";
 export * from "./defaultKeybindings";
@@ -87,13 +88,15 @@ class KeybindingService {
         this.notifyListeners();
       } catch (error) {
         // Mirrors useUserAgentRegistryStore.initialize() — non-fatal degradation.
-        // `this.bindings` retains DEFAULT_KEYBINDINGS (seeded in constructor) and
-        // `this.overrides` is left empty, so the user gets stock shortcuts. The
-        // caller (hydrate bootstrap, settings tabs, settings-changed IPC) keeps
-        // running instead of aborting the entire session restore.
-        const message = error instanceof Error ? error.message : String(error);
+        // `this.bindings` retains DEFAULT_KEYBINDINGS (seeded in constructor).
+        // On a fresh service, `this.overrides` is empty, so the user gets stock
+        // shortcuts. On a service that has loaded overrides before, the prior
+        // overrides persist as last-known-good — a failed reload does not
+        // silently clobber the user's customizations. The caller (hydrate
+        // bootstrap, settings tabs, settings-changed IPC) keeps running
+        // instead of aborting the entire session restore.
         console.warn(
-          `[KeybindingService] Failed to load keybinding overrides; using defaults: ${message}`
+          `[KeybindingService] Failed to load keybinding overrides; keeping prior state: ${formatErrorMessage(error, "Unknown keybinding override load failure")}`
         );
       }
     }

--- a/src/services/KeybindingService.ts
+++ b/src/services/KeybindingService.ts
@@ -69,21 +69,33 @@ class KeybindingService {
 
   async loadOverrides(): Promise<void> {
     if (typeof window !== "undefined" && window.electron?.keybinding) {
-      const overrides = await window.electron.keybinding.getOverrides();
-      this.overrides.clear();
-      if (overrides && typeof overrides === "object") {
-        for (const [actionId, combos] of Object.entries(overrides)) {
-          if (!Array.isArray(combos)) continue;
-          if (!builtInActionIdSet.has(actionId) && !this.bindings.has(actionId)) {
-            console.warn(
-              `[KeybindingService] Dropping override for unknown action "${actionId}" — not a built-in or registered binding.`
-            );
-            continue;
+      try {
+        const overrides = await window.electron.keybinding.getOverrides();
+        this.overrides.clear();
+        if (overrides && typeof overrides === "object") {
+          for (const [actionId, combos] of Object.entries(overrides)) {
+            if (!Array.isArray(combos)) continue;
+            if (!builtInActionIdSet.has(actionId) && !this.bindings.has(actionId)) {
+              console.warn(
+                `[KeybindingService] Dropping override for unknown action "${actionId}" — not a built-in or registered binding.`
+              );
+              continue;
+            }
+            this.overrides.set(actionId, combos as string[]);
           }
-          this.overrides.set(actionId, combos as string[]);
         }
+        this.notifyListeners();
+      } catch (error) {
+        // Mirrors useUserAgentRegistryStore.initialize() — non-fatal degradation.
+        // `this.bindings` retains DEFAULT_KEYBINDINGS (seeded in constructor) and
+        // `this.overrides` is left empty, so the user gets stock shortcuts. The
+        // caller (hydrate bootstrap, settings tabs, settings-changed IPC) keeps
+        // running instead of aborting the entire session restore.
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(
+          `[KeybindingService] Failed to load keybinding overrides; using defaults: ${message}`
+        );
       }
-      this.notifyListeners();
     }
   }
 

--- a/src/services/__tests__/KeybindingService.test.ts
+++ b/src/services/__tests__/KeybindingService.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_KEYBINDINGS,
   KeybindingService,

--- a/src/services/__tests__/KeybindingService.test.ts
+++ b/src/services/__tests__/KeybindingService.test.ts
@@ -1784,6 +1784,74 @@ describe("KeybindingService", () => {
     });
   });
 
+  describe("loadOverrides degradation on IPC rejection — issue #9931", () => {
+    function mockElectronGetOverridesRejection(reason: unknown) {
+      vi.stubGlobal("window", {
+        electron: {
+          keybinding: {
+            getOverrides: vi.fn().mockRejectedValue(reason),
+            setOverride: vi.fn().mockResolvedValue(undefined),
+            removeOverride: vi.fn().mockResolvedValue(undefined),
+            resetAll: vi.fn().mockResolvedValue(undefined),
+          },
+        },
+      });
+    }
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      vi.restoreAllMocks();
+    });
+
+    it("resolves with defaults and warns when getOverrides rejects with an Error", async () => {
+      setPlatform("MacIntel");
+      mockElectronGetOverridesRejection(new Error("boom"));
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const service = new KeybindingService();
+
+      await expect(service.loadOverrides()).resolves.toBeUndefined();
+
+      // Defaults remain active — no override installed because the IPC failed
+      expect(service.getOverride("terminal.close")).toBeUndefined();
+      expect(service.getEffectiveCombo("terminal.close")).toBe(
+        service.getDefaultCombo("terminal.close")
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "[KeybindingService] Failed to load keybinding overrides; using defaults: boom"
+        )
+      );
+    });
+
+    it("handles non-Error rejection values without throwing", async () => {
+      setPlatform("MacIntel");
+      mockElectronGetOverridesRejection("string-only failure");
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const service = new KeybindingService();
+
+      await expect(service.loadOverrides()).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "[KeybindingService] Failed to load keybinding overrides; using defaults: string-only failure"
+        )
+      );
+    });
+
+    it("does not notify listeners on degradation (constructor seed is the stable state)", async () => {
+      setPlatform("MacIntel");
+      mockElectronGetOverridesRejection(new Error("boom"));
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const service = new KeybindingService();
+      const listener = vi.fn();
+      service.subscribe(listener);
+
+      await service.loadOverrides();
+
+      expect(listener).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+  });
+
   describe("Windows shortcut conventions — issue #7943", () => {
     it("registers both Shift+F10 and ContextMenu as defaults for terminal.contextMenu", () => {
       const combos = DEFAULT_KEYBINDINGS.filter((b) => b.actionId === "terminal.contextMenu").map(

--- a/src/services/__tests__/KeybindingService.test.ts
+++ b/src/services/__tests__/KeybindingService.test.ts
@@ -1785,6 +1785,19 @@ describe("KeybindingService", () => {
   });
 
   describe("loadOverrides degradation on IPC rejection — issue #9931", () => {
+    function mockElectronOverrides(overrides: Record<string, string[]>) {
+      vi.stubGlobal("window", {
+        electron: {
+          keybinding: {
+            getOverrides: vi.fn().mockResolvedValue(overrides),
+            setOverride: vi.fn().mockResolvedValue(undefined),
+            removeOverride: vi.fn().mockResolvedValue(undefined),
+            resetAll: vi.fn().mockResolvedValue(undefined),
+          },
+        },
+      });
+    }
+
     function mockElectronGetOverridesRejection(reason: unknown) {
       vi.stubGlobal("window", {
         electron: {
@@ -1818,7 +1831,7 @@ describe("KeybindingService", () => {
       );
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining(
-          "[KeybindingService] Failed to load keybinding overrides; using defaults: boom"
+          "[KeybindingService] Failed to load keybinding overrides; keeping prior state: boom"
         )
       );
     });
@@ -1832,7 +1845,7 @@ describe("KeybindingService", () => {
       await expect(service.loadOverrides()).resolves.toBeUndefined();
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining(
-          "[KeybindingService] Failed to load keybinding overrides; using defaults: string-only failure"
+          "[KeybindingService] Failed to load keybinding overrides; keeping prior state: string-only failure"
         )
       );
     });
@@ -1848,6 +1861,114 @@ describe("KeybindingService", () => {
       await service.loadOverrides();
 
       expect(listener).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it("tolerates hostile rejection values whose String() throws", async () => {
+      // Some preloads can hand back objects with throwing String coercion.
+      // The catch must not re-throw via String(error) — otherwise we re-introduce
+      // the #9931 failure mode. formatErrorMessage is hostile-safe.
+      setPlatform("MacIntel");
+      const hostile = {
+        toString() {
+          throw new Error("format boom");
+        },
+        [Symbol.toPrimitive]() {
+          throw new Error("format boom");
+        },
+      };
+      mockElectronGetOverridesRejection(hostile);
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const service = new KeybindingService();
+
+      await expect(service.loadOverrides()).resolves.toBeUndefined();
+      // formatErrorMessage falls back to the supplied message for hostile values.
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "[KeybindingService] Failed to load keybinding overrides; keeping prior state: Unknown keybinding override load failure"
+        )
+      );
+    });
+
+    it("catches synchronous throws from getOverrides too", async () => {
+      setPlatform("MacIntel");
+      vi.stubGlobal("window", {
+        electron: {
+          keybinding: {
+            getOverrides: vi.fn(() => {
+              throw new Error("sync boom");
+            }),
+            setOverride: vi.fn().mockResolvedValue(undefined),
+            removeOverride: vi.fn().mockResolvedValue(undefined),
+            resetAll: vi.fn().mockResolvedValue(undefined),
+          },
+        },
+      });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const service = new KeybindingService();
+
+      await expect(service.loadOverrides()).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "[KeybindingService] Failed to load keybinding overrides; keeping prior state: sync boom"
+        )
+      );
+    });
+
+    it("keeps prior overrides as last-known-good when a reload rejects", async () => {
+      setPlatform("MacIntel");
+      const service = new KeybindingService();
+
+      // First load: success — install a custom override.
+      mockElectronOverrides({ "terminal.close": ["Cmd+Shift+W"] });
+      await service.loadOverrides();
+      expect(service.getEffectiveCombo("terminal.close")).toBe("Cmd+Shift+W");
+
+      // Second load: IPC rejects. Prior override must persist (not silently
+      // clobbered) and the user keeps their customization.
+      mockElectronGetOverridesRejection(new Error("reload boom"));
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      await service.loadOverrides();
+
+      expect(service.getOverride("terminal.close")).toEqual(["Cmd+Shift+W"]);
+      expect(service.getEffectiveCombo("terminal.close")).toBe("Cmd+Shift+W");
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "[KeybindingService] Failed to load keybinding overrides; keeping prior state: reload boom"
+        )
+      );
+    });
+
+    it("recovers cleanly when a subsequent loadOverrides succeeds", async () => {
+      setPlatform("MacIntel");
+      const service = new KeybindingService();
+
+      mockElectronGetOverridesRejection(new Error("first call fails"));
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      await service.loadOverrides();
+      expect(service.getOverride("terminal.close")).toBeUndefined();
+
+      // A successful reload installs fresh overrides and notifies listeners.
+      mockElectronOverrides({ "terminal.close": ["Cmd+K"] });
+      const listener = vi.fn();
+      service.subscribe(listener);
+      await service.loadOverrides();
+      expect(service.getEffectiveCombo("terminal.close")).toBe("Cmd+K");
+      expect(listener).toHaveBeenCalledTimes(1);
+      warnSpy.mockRestore();
+    });
+
+    it("setOverride still works after a failed loadOverrides", async () => {
+      setPlatform("MacIntel");
+      const service = new KeybindingService();
+
+      mockElectronGetOverridesRejection(new Error("load fails"));
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      await service.loadOverrides();
+
+      await service.setOverride("terminal.close", ["Cmd+Shift+W"]);
+      expect(service.getOverride("terminal.close")).toEqual(["Cmd+Shift+W"]);
+      expect(service.getEffectiveCombo("terminal.close")).toBe("Cmd+Shift+W");
       warnSpy.mockRestore();
     });
   });

--- a/src/utils/stateHydration/__tests__/bootstrapGuard.test.ts
+++ b/src/utils/stateHydration/__tests__/bootstrapGuard.test.ts
@@ -45,19 +45,24 @@ describe("ensureHydrationBootstrap", () => {
     expect(initializeMock).toHaveBeenCalledTimes(1);
   });
 
-  it("clears the singleton on failure so the next call retries", async () => {
-    loadOverridesMock.mockRejectedValueOnce(new Error("boom"));
+  it("resolves and reuses the singleton when loadOverrides rejects (non-fatal degradation — issue #9931)", async () => {
+    // Mirror the production contract: the underlying IPC rejects, but
+    // loadOverrides() self-catches and resolves with defaults. Use
+    // mockImplementationOnce so the real promise rejection happens and is
+    // observed by the test before the public method returns.
+    loadOverridesMock.mockImplementationOnce(() =>
+      Promise.reject(new Error("boom")).catch(() => undefined)
+    );
 
-    await expect(ensureHydrationBootstrap()).rejects.toThrow("boom");
+    // loadOverrides() resolves with the constructor-seeded defaults, so the
+    // bootstrap completes successfully and the rest of hydrateAppState continues.
+    await expect(ensureHydrationBootstrap()).resolves.toBeUndefined();
 
-    // Second call should re-attempt
-    loadOverridesMock.mockResolvedValueOnce(undefined);
+    // Singleton is not reset on non-fatal degradation; subsequent calls reuse
+    // the resolved promise and do not re-invoke either task.
     await ensureHydrationBootstrap();
-
-    expect(loadOverridesMock).toHaveBeenCalledTimes(2);
-    // initialize() runs concurrently with loadOverrides() via Promise.all,
-    // so it fires on the failing first attempt too: 1 (failed call) + 1 (retry).
-    expect(initializeMock).toHaveBeenCalledTimes(2);
+    expect(loadOverridesMock).toHaveBeenCalledTimes(1);
+    expect(initializeMock).toHaveBeenCalledTimes(1);
   });
 
   it("propagates initialize() rejections and clears the singleton", async () => {
@@ -120,13 +125,18 @@ describe("ensureHydrationBootstrap", () => {
       expect(bootstrapMarks()).toEqual([]);
     });
 
-    it("emits start + end for both spans when loadOverrides fails (steps run in parallel)", async () => {
-      loadOverridesMock.mockRejectedValueOnce(new Error("boom"));
+    it("emits start + end for both spans when loadOverrides IPC rejects (non-fatal degradation — issue #9931)", async () => {
+      // Mirror production: IPC rejects, loadOverrides() self-catches and resolves.
+      loadOverridesMock.mockImplementationOnce(() =>
+        Promise.reject(new Error("boom")).catch(() => undefined)
+      );
 
-      await expect(ensureHydrationBootstrap()).rejects.toThrow("boom");
+      // Bootstrap resolves because loadOverrides resolved. withRendererSpan's
+      // try/finally fires the :end mark regardless of the inner IPC outcome.
+      await expect(ensureHydrationBootstrap()).resolves.toBeUndefined();
 
-      // init_user_agents() runs concurrently with loadOverrides() via Promise.all,
-      // so its span still fires even when loadOverrides rejects.
+      // Both spans still fire — loadOverrides completes (with defaults) and
+      // initialize() runs concurrently via Promise.all.
       const marks = bootstrapMarks();
       expect(marks).toContain("hydrate_bootstrap_load_overrides:start");
       expect(marks).toContain("hydrate_bootstrap_load_overrides:end");

--- a/src/utils/stateHydration/__tests__/bootstrapGuard.test.ts
+++ b/src/utils/stateHydration/__tests__/bootstrapGuard.test.ts
@@ -46,10 +46,12 @@ describe("ensureHydrationBootstrap", () => {
   });
 
   it("resolves and reuses the singleton when loadOverrides rejects (non-fatal degradation — issue #9931)", async () => {
-    // Mirror the production contract: the underlying IPC rejects, but
-    // loadOverrides() self-catches and resolves with defaults. Use
-    // mockImplementationOnce so the real promise rejection happens and is
-    // observed by the test before the public method returns.
+    // This is a unit test of bootstrap behavior given the post-fix contract
+    // that loadOverrides() self-catches IPC rejections. The boundary contract
+    // (production try/catch in loadOverrides) is covered in
+    // KeybindingService.test.ts. Use mockImplementationOnce so the real
+    // promise rejection happens and is observed before the public method
+    // returns — emulating the production self-catch shape.
     loadOverridesMock.mockImplementationOnce(() =>
       Promise.reject(new Error("boom")).catch(() => undefined)
     );
@@ -126,7 +128,8 @@ describe("ensureHydrationBootstrap", () => {
     });
 
     it("emits start + end for both spans when loadOverrides IPC rejects (non-fatal degradation — issue #9931)", async () => {
-      // Mirror production: IPC rejects, loadOverrides() self-catches and resolves.
+      // Mirror production: IPC rejects, loadOverrides() self-catches and
+      // resolves. The boundary contract is covered in KeybindingService.test.ts.
       loadOverridesMock.mockImplementationOnce(() =>
         Promise.reject(new Error("boom")).catch(() => undefined)
       );


### PR DESCRIPTION
## Summary

- Wrap `keybindingService.loadOverrides()` IPC await in try/catch so a rejection from `window.electron.keybinding.getOverrides()` no longer aborts session restore on cold start.
- Mirrors `useUserAgentRegistryStore.initialize()` self-catch contract; the sibling task in the same `Promise.all` already degrades, this brings the keybinding side into line.
- Last-known-good semantics: prior overrides are preserved on a failed reload, so a transient IPC failure cannot silently clobber user customizations.

## Changes

- `src/services/KeybindingService.ts` — try/catch around the `getOverrides()` await, warn with `formatErrorMessage` from `@shared/utils/errorMessage`, keep prior `this.overrides` and `this.bindings` (defaults) on failure.
- `src/services/__tests__/KeybindingService.test.ts` — new `describe` block with 8 regression tests: Error rejection, non-Error rejection, hostile rejection values, sync throws, prior overrides preserved, recovery on subsequent load, `setOverride` after failed load, no listener notify on degradation.
- `src/utils/stateHydration/__tests__/bootstrapGuard.test.ts` — 2 tests updated to assert resolution + singleton reuse on the non-fatal path; mock contract mirrors production self-catch.

## Testing

- `npm run typecheck` clean
- `npm run lint:fix` clean (0 errors, only pre-existing warnings on unrelated files)
- 141 vitest tests pass across `KeybindingService.test.ts` and `bootstrapGuard.test.ts`
- `npm run format` no diff

Resolves #9931