### PR TITLE
fix(hydration): boot focus picks by recency and no longer corrupts it (#9933)

### DIFF
--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -119,6 +119,15 @@ export interface AddPanelOptionsBase {
    * cleared on the next restart. See `serializePtyPanel` (intentionally omitted).
    */
   sessionLostOnRestore?: boolean;
+  /**
+   * User-initiated focus timestamp from the saved snapshot, propagated
+   * from the hydration boundary (`statePatcher.ts:buildArgsFor*` →
+   * `sanitizeLastActiveAt`) to the live panel. Read by
+   * `useAppHydration`'s post-hydration focus picker so the active
+   * worktree's most-recently-focused panel wins the boot pick (#9933).
+   * Not used for fresh spawns — only hydration paths set it.
+   */
+  lastActiveAt?: number;
 }
 
 /**

--- a/src/hooks/app/__tests__/useAppHydration.test.ts
+++ b/src/hooks/app/__tests__/useAppHydration.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { pickBootFocusPanelId } from "../useAppHydration";
+
+type Panel = {
+  location?: string;
+  worktreeId?: string;
+  lastActiveAt?: number;
+};
+
+function makePanels(...panels: Array<[string, Panel]>): Record<string, Panel> {
+  return Object.fromEntries(panels);
+}
+
+describe("pickBootFocusPanelId (issue #9933)", () => {
+  it("returns null when panelIds is empty", () => {
+    expect(pickBootFocusPanelId([], {}, "w1")).toBeNull();
+  });
+
+  it("returns null when no panel matches the active worktree", () => {
+    const panelsById = makePanels(["a", { location: "grid", worktreeId: "w1" }]);
+    expect(pickBootFocusPanelId(["a"], panelsById, "w2")).toBeNull();
+  });
+
+  it("returns null when no panel is in the grid location", () => {
+    const panelsById = makePanels(
+      ["a", { location: "dock", worktreeId: "w1" }],
+      ["b", { location: "trash", worktreeId: "w1" }]
+    );
+    expect(pickBootFocusPanelId(["a", "b"], panelsById, "w1")).toBeNull();
+  });
+
+  it("returns the first-in-order eligible panel when none have lastActiveAt", () => {
+    // Legacy snapshot — `panelRestorePhase` falls back to saved order in
+    // the same way, so the boot pick must match for consistency.
+    const panelsById = makePanels(
+      ["a", { location: "grid", worktreeId: "w1" }],
+      ["b", { location: "grid", worktreeId: "w1" }]
+    );
+    expect(pickBootFocusPanelId(["a", "b"], panelsById, "w1")).toBe("a");
+    // Reversed order — first eligible still wins (panelIds iteration order).
+    expect(pickBootFocusPanelId(["b", "a"], panelsById, "w1")).toBe("b");
+  });
+
+  it("prefers the highest lastActiveAt, regardless of panelIds order", () => {
+    const panelsById = makePanels(
+      ["a", { location: "grid", worktreeId: "w1", lastActiveAt: 100 }],
+      ["b", { location: "grid", worktreeId: "w1", lastActiveAt: 200 }],
+      ["c", { location: "grid", worktreeId: "w1", lastActiveAt: 50 }]
+    );
+    // b has the highest timestamp even though it's not first in panelIds.
+    expect(pickBootFocusPanelId(["a", "b", "c"], panelsById, "w1")).toBe("b");
+    // Order-independent: try the reverse panelIds order.
+    expect(pickBootFocusPanelId(["c", "b", "a"], panelsById, "w1")).toBe("b");
+  });
+
+  it("ignores panels from other worktrees even when they have higher lastActiveAt", () => {
+    const panelsById = makePanels(
+      ["a", { location: "grid", worktreeId: "w1", lastActiveAt: 100 }],
+      ["b", { location: "grid", worktreeId: "w2", lastActiveAt: 9999 }]
+    );
+    // b is the most recent overall but belongs to a different worktree.
+    expect(pickBootFocusPanelId(["a", "b"], panelsById, "w1")).toBe("a");
+  });
+
+  it("ignores non-grid panels even when they have higher lastActiveAt", () => {
+    const panelsById = makePanels(
+      ["a", { location: "grid", worktreeId: "w1", lastActiveAt: 100 }],
+      ["b", { location: "dock", worktreeId: "w1", lastActiveAt: 9999 }]
+    );
+    expect(pickBootFocusPanelId(["a", "b"], panelsById, "w1")).toBe("a");
+  });
+
+  it("treats lastActiveAt <= 0 as 'no stamp' (mirrors panelRestorePhase)", () => {
+    const panelsById = makePanels(
+      ["a", { location: "grid", worktreeId: "w1", lastActiveAt: 0 }],
+      ["b", { location: "grid", worktreeId: "w1", lastActiveAt: -5 }],
+      ["c", { location: "grid", worktreeId: "w1" }]
+    );
+    // None of the stamps are valid; first eligible (in panelIds order) wins.
+    expect(pickBootFocusPanelId(["a", "b", "c"], panelsById, "w1")).toBe("a");
+  });
+
+  it("rejects NaN and ±Infinity lastActiveAt", () => {
+    const panelsById = makePanels(
+      ["a", { location: "grid", worktreeId: "w1", lastActiveAt: Number.NaN }],
+      ["b", { location: "grid", worktreeId: "w1", lastActiveAt: Number.POSITIVE_INFINITY }],
+      ["c", { location: "grid", worktreeId: "w1", lastActiveAt: Number.NEGATIVE_INFINITY }]
+    );
+    expect(pickBootFocusPanelId(["a", "b", "c"], panelsById, "w1")).toBe("a");
+  });
+
+  it("matches panels with worktreeId === undefined when activeWorktreeId is null", () => {
+    // Empty project / pre-worktree state: active worktree is null and
+    // some legacy panels have no worktreeId. The picker's null-null
+    // equivalence means they match.
+    const panelsById = makePanels(["a", { location: "grid", worktreeId: undefined }]);
+    expect(pickBootFocusPanelId(["a"], panelsById, null)).toBe("a");
+  });
+
+  it("does not match worktreeId === undefined when activeWorktreeId is set", () => {
+    const panelsById = makePanels(["a", { location: "grid", worktreeId: undefined }]);
+    expect(pickBootFocusPanelId(["a"], panelsById, "w1")).toBeNull();
+  });
+
+  it("skips unknown panelIds in panelsById (defensive against stale IDs)", () => {
+    const panelsById = makePanels(["a", { location: "grid", worktreeId: "w1" }]);
+    // "ghost" is in panelIds but missing from panelsById.
+    expect(pickBootFocusPanelId(["ghost", "a"], panelsById, "w1")).toBe("a");
+  });
+});

--- a/src/hooks/app/useAppHydration.ts
+++ b/src/hooks/app/useAppHydration.ts
@@ -4,10 +4,7 @@ import { isElectronAvailable } from "../useElectron";
 import { setStartupQuietPeriod } from "@/lib/notify";
 import { logError } from "@/utils/logger";
 import { usePanelStore } from "@/store";
-import {
-  suppressMruRecording,
-  useWorktreeSelectionStore,
-} from "@/store/worktreeStore";
+import { suppressMruRecording, useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useRecipeStore } from "@/store/recipeStore";
 import {
   useDiagnosticsStore,

--- a/src/hooks/app/useAppHydration.ts
+++ b/src/hooks/app/useAppHydration.ts
@@ -4,7 +4,10 @@ import { isElectronAvailable } from "../useElectron";
 import { setStartupQuietPeriod } from "@/lib/notify";
 import { logError } from "@/utils/logger";
 import { usePanelStore } from "@/store";
-import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import {
+  suppressMruRecording,
+  useWorktreeSelectionStore,
+} from "@/store/worktreeStore";
 import { useRecipeStore } from "@/store/recipeStore";
 import {
   useDiagnosticsStore,
@@ -13,6 +16,69 @@ import {
   useActionPrefsStore,
 } from "@/store";
 import type { HydrateResult } from "@shared/types/ipc/app";
+
+// Minimal shape the picker needs from a hydrated panel. We only read
+// `location` and `worktreeId` to filter, and `lastActiveAt` to rank. The
+// full `PanelInstance` is wider (kind, agentState, …) but irrelevant here
+// — keeping the surface narrow makes the helper trivially testable.
+type BootFocusCandidate = {
+  location?: string;
+  worktreeId?: string;
+  lastActiveAt?: number;
+};
+
+/**
+ * Pick the active worktree's grid panel to focus on boot (#9933).
+ *
+ * The batched hydration path skips the per-addPanel focus set (it would
+ * defeat the batch), so `focusedId` would otherwise be null after
+ * hydration — breaking any action keyed off the focused panel.
+ *
+ * Selection rule:
+ * - Iterate `panelIds` in order (so the fallback for snapshots with no
+ *   `lastActiveAt` is the first eligible panel, matching legacy behavior).
+ * - Among eligible panels (grid, matching worktreeId), prefer the one
+ *   with the highest valid `lastActiveAt` (mirrors the per-worktree
+ *   `maxLastActiveAtByWorktree` map built in `panelRestorePhase.ts`,
+ *   which already uses `Number.isFinite && > 0` to reject zero/NaN
+ *   stamps). Returning the panel-with-max wins regardless of insertion
+ *   order so a worktree's most-recently-active panel — not an
+ *   arbitrary older one — is the boot focus.
+ * - When no panel has a valid timestamp (legacy snapshot), the first
+ *   eligible panel is returned.
+ * - Returns `null` when there are no eligible panels (no grid panels on
+ *   the active worktree).
+ *
+ * Note: this picker does NOT call `setFocused` — the caller is
+ * responsible for routing the result through `setBootFocus` inside a
+ * `suppressMruRecording(true)/finally(false)` window.
+ */
+export function pickBootFocusPanelId(
+  panelIds: readonly string[],
+  panelsById: Readonly<Record<string, BootFocusCandidate | undefined>>,
+  activeWorktreeId: string | null | undefined
+): string | null {
+  const targetWorktreeId = activeWorktreeId ?? null;
+  let firstEligibleId: string | null = null;
+  let bestId: string | null = null;
+  let bestLastActiveAt = -1;
+
+  for (const panelId of panelIds) {
+    const panel = panelsById[panelId];
+    if (!panel) continue;
+    if (panel.location !== "grid") continue;
+    if ((panel.worktreeId ?? null) !== targetWorktreeId) continue;
+    if (firstEligibleId === null) firstEligibleId = panelId;
+    const ts = panel.lastActiveAt;
+    if (typeof ts !== "number" || !Number.isFinite(ts) || ts <= 0) continue;
+    if (ts > bestLastActiveAt) {
+      bestLastActiveAt = ts;
+      bestId = panelId;
+    }
+  }
+
+  return bestId ?? firstEligibleId;
+}
 
 export function useAppHydration(
   enabled: boolean = true,
@@ -73,19 +139,34 @@ export function useAppHydration(
         // grid panel, ending on whichever was added last. The batched path skips
         // that set (it would defeat the batch), so `focusedId` would otherwise be
         // null after hydration — breaking any action keyed off the focused panel.
+        //
+        // Two correctness fixes vs. the pre-#9933 implementation:
+        //  1. `pickBootFocusPanelId` selects by highest `lastActiveAt` so the
+        //     active worktree's most-recently-focused panel wins, falling back
+        //     to first-in-`panelIds`-order for snapshots with no recency data.
+        //  2. The pick routes through `setBootFocus` (bare focus commit, no
+        //     `stampLastActive`) and is wrapped in `suppressMruRecording` so
+        //     the orchestrator's MRU subscription doesn't re-prepend the boot
+        //     pick to `mruList`. The orchestrator's `trackTerminalFocus` and
+        //     `selectWorktree({ source: "focus" })` subscriptions still fire
+        //     — `lastFocusedTerminalByWorktree` is runtime-only and needs the
+        //     boot pick to seed it for future worktree switches to restore
+        //     last-focus (#9512).
         const panelState = usePanelStore.getState();
         const activeWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;
         if (panelState.focusedId === null && panelState.panelIds.length > 0) {
-          const firstGridPanelId = panelState.panelIds.find((panelId) => {
-            const panel = panelState.panelsById[panelId];
-            return (
-              panel &&
-              panel.location === "grid" &&
-              (panel.worktreeId ?? null) === (activeWorktreeId ?? null)
-            );
-          });
-          if (firstGridPanelId) {
-            panelState.setFocused(firstGridPanelId);
+          const selectedId = pickBootFocusPanelId(
+            panelState.panelIds,
+            panelState.panelsById,
+            activeWorktreeId
+          );
+          if (selectedId) {
+            try {
+              suppressMruRecording(true);
+              panelState.setBootFocus(selectedId);
+            } finally {
+              suppressMruRecording(false);
+            }
           }
         }
       } catch (error) {

--- a/src/store/__tests__/rendererStoreOrchestrator.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.test.ts
@@ -75,7 +75,8 @@ vi.mock("../worktreeStore", async (importOriginal) => {
 });
 
 const { usePanelStore } = await import("../panelStore");
-const { useWorktreeSelectionStore, persistMruList } = await import("../worktreeStore");
+const { useWorktreeSelectionStore, persistMruList, suppressMruRecording } =
+  await import("../worktreeStore");
 const { useTerminalInputStore } = await import("../terminalInputStore");
 const { useConsoleCaptureStore } = await import("../consoleCaptureStore");
 const { useResourceMonitoringStore } = await import("../resourceMonitoringStore");
@@ -322,6 +323,120 @@ describe("rendererStoreOrchestrator", () => {
     usePanelStore.setState({ focusedId: "term-1" });
 
     expect(trackSpy).not.toHaveBeenCalled();
+  });
+
+  // Issue #9933 — boot focus and suppression-window tests. Placed AFTER
+  // the existing "does not fire side effects" test because
+  // `vi.spyOn(useWorktreeSelectionStore.getState(), "trackTerminalFocus")`
+  // wraps the underlying StateCreator function (which is shared by every
+  // state object via the closure), so a spy installed in one test keeps
+  // receiving calls from later tests that re-install on the same function
+  // — Vitest returns the existing spy on re-wrap, and its mock state
+  // carries over. Running these after the existing side-effect test
+  // keeps the order predictable without requiring `vi.restoreAllMocks`.
+  it("skips MRU recording for boot focus when suppressMruRecording is on (issue #9933)", () => {
+    // Boot-time focus (post-hydration) must NOT prepend the panel to
+    // `mruList` — that would silently demote the user's actual
+    // last-focused terminal on every cold boot. The L1c subscription
+    // checks `isMruRecordingSuppressed()` and bails; the L1a (focus
+    // tracking) and L1b (worktree switch) subscriptions still fire so
+    // the boot pick correctly seeds `lastFocusedTerminalByWorktree`
+    // (which is runtime-only and has no other writer).
+    const recordMruSpy = vi.spyOn(usePanelStore.getState(), "recordMru");
+    const trackSpy = vi.spyOn(useWorktreeSelectionStore.getState(), "trackTerminalFocus");
+    trackSpy.mockClear();
+    recordMruSpy.mockClear();
+
+    usePanelStore.setState({
+      panelsById: {
+        "term-boot": {
+          id: "term-boot",
+          title: "T-boot",
+          kind: "terminal" as const,
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+          worktreeId: "wt-1",
+        },
+      },
+      panelIds: ["term-boot"],
+    });
+
+    suppressMruRecording(true);
+    try {
+      usePanelStore.setState({ focusedId: "term-boot" });
+    } finally {
+      suppressMruRecording(false);
+    }
+
+    // L1c: MRU recording gated.
+    expect(recordMruSpy).not.toHaveBeenCalled();
+    // L1a: focus tracking still fires — seeds `lastFocusedTerminalByWorktree`
+    // so future worktree switches can restore last-focus (#9512).
+    expect(trackSpy).toHaveBeenCalledWith("wt-1", "term-boot");
+  });
+
+  it("MRU recording resumes immediately after suppressMruRecording is lifted (issue #9933)", () => {
+    // Verifies the suppression window is correctly scoped to the boot pick
+    // and doesn't leak into subsequent user focus changes.
+    const recordMruSpy = vi.spyOn(usePanelStore.getState(), "recordMru");
+    recordMruSpy.mockClear();
+
+    usePanelStore.setState({
+      panelsById: {
+        "term-1": {
+          id: "term-1",
+          title: "T1",
+          kind: "terminal" as const,
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+          worktreeId: "wt-1",
+        },
+      },
+      panelIds: ["term-1"],
+    });
+
+    // Suppress window for the boot pick — a null→"term-1" change is
+    // gated, so no recordMru.
+    suppressMruRecording(true);
+    usePanelStore.setState({ focusedId: "term-1" });
+    suppressMruRecording(false);
+    recordMruSpy.mockClear();
+
+    // A subsequent user focus on a DIFFERENT panel (after suppress is
+    // lifted) MUST record. Using a different id is necessary because
+    // `subscribeWithSelector` compares with `Object.is` — a same-value
+    // set wouldn't fire the subscription at all.
+    usePanelStore.setState({
+      panelsById: {
+        "term-1": {
+          id: "term-1",
+          title: "T1",
+          kind: "terminal" as const,
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+          worktreeId: "wt-1",
+        },
+        "term-2": {
+          id: "term-2",
+          title: "T2",
+          kind: "terminal" as const,
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+          worktreeId: "wt-1",
+        },
+      },
+      panelIds: ["term-1", "term-2"],
+      focusedId: "term-2",
+    });
+    expect(recordMruSpy).toHaveBeenCalledWith("terminal:term-2");
   });
 
   it("handles rapid A→B focus changes correctly", () => {

--- a/src/store/slices/__tests__/terminalFocusSlice.test.ts
+++ b/src/store/slices/__tests__/terminalFocusSlice.test.ts
@@ -1543,3 +1543,105 @@ describe("TerminalFocusSlice - lastActiveAt stamping (issue #8703)", () => {
     expect(mockStampLastActive).not.toHaveBeenCalled();
   });
 });
+
+// Issue #9933 — the post-hydration focus pick must not corrupt persistence
+// (`lastActiveAt`, MRU). `setBootFocus` is the bare commit used by the boot
+// picker: it lands an initial `focusedId` but does NOT stamp activity, wake
+// the terminal, or ping it. Callers are responsible for wrapping the call in
+// `suppressMruRecording` if the orchestrator's MRU subscription must be
+// gated.
+describe("TerminalFocusSlice - boot focus (issue #9933)", () => {
+  const makeTerminal = (id: string): PtyPanelData =>
+    ({
+      id,
+      title: id,
+      cwd: "/test",
+      location: "grid",
+      agentState: "idle",
+      isVisible: true,
+      cols: 80,
+      rows: 24,
+      worktreeId: "worktree-1",
+    }) as PtyPanelData;
+
+  let terminals: PtyPanelData[];
+  let state: TerminalFocusSlice;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    terminals = [makeTerminal("a"), makeTerminal("b")];
+    const getTerminals = vi.fn(() => terminals);
+    const getState = vi.fn((): TerminalFocusSlice => state);
+    const setState = vi.fn(
+      (
+        updater:
+          | Partial<TerminalFocusSlice>
+          | ((s: TerminalFocusSlice) => Partial<TerminalFocusSlice>)
+      ) => {
+        const currentState = getState();
+        const updates = typeof updater === "function" ? updater(currentState) : updater;
+        state = { ...currentState, ...updates };
+      }
+    );
+    state = createTerminalFocusSlice(getTerminals, mockGetActiveWorktreeId, mockStampLastActive)(
+      setState as never,
+      getState as never,
+      {} as never
+    );
+  });
+
+  it("setBootFocus sets focusedId and clears activeDockTerminalId", () => {
+    state.focusedId = null;
+    state.activeDockTerminalId = "stale-dock";
+
+    state.setBootFocus("a");
+
+    expect(state.focusedId).toBe("a");
+    expect(state.activeDockTerminalId).toBeNull();
+  });
+
+  it("setBootFocus does NOT call stampLastActive", () => {
+    // The whole point of the new setter: persistence must not be touched.
+    // If this fires, the per-panel recency that `panelRestorePhase` uses
+    // to promote each worktree's most-recently-focused panel gets
+    // overwritten on every boot (#9933).
+    state.setBootFocus("a");
+    expect(mockStampLastActive).not.toHaveBeenCalled();
+  });
+
+  it("setBootFocus does NOT call terminalInstanceService.wake", () => {
+    // The boot pick targets a panel the restore pipeline already woke.
+    // Waking it again would be wasted work and could race with the
+    // restore-batch PTY spawn.
+    state.setBootFocus("a");
+    expect(terminalInstanceService.wake).not.toHaveBeenCalled();
+  });
+
+  it("setBootFocus updates previousFocusedId only when focus actually changes", () => {
+    // null → "a" changes focus: previousFocusedId should be preserved
+    // (the prior value was null, so it stays null — no real prior
+    // focus existed).
+    state.focusedId = null;
+    state.previousFocusedId = null;
+    state.setBootFocus("a");
+    expect(state.previousFocusedId).toBeNull();
+
+    // "a" → "b" changes focus: previousFocusedId should become "a".
+    state.setBootFocus("b");
+    expect(state.previousFocusedId).toBe("a");
+
+    // "b" → "b" is a no-op: previousFocusedId must NOT move to "b"
+    // (the toggle-anchor would lose its real prior value).
+    state.setBootFocus("b");
+    expect(state.previousFocusedId).toBe("a");
+  });
+
+  it("setBootFocus does NOT trigger pingTerminal (no user intent to visualize)", () => {
+    // Defensive: even though `setBootFocus` doesn't directly call
+    // pingTerminal, this guards against future regressions where
+    // someone adds an unconditional ping to the grid branch.
+    state.setBootFocus("a");
+    expect(state.pingedId).toBeNull();
+    expect(state.pingSeq).toBe(0);
+  });
+});

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -187,6 +187,13 @@ export const createAddPanelActions = (
         pluginId,
         excludeFromPersistence: options.excludeFromPersistence,
         removeOnExit: options.removeOnExit,
+        // Preserve the saved `lastActiveAt` from the snapshot so the
+        // post-hydration focus picker in `useAppHydration` can pick
+        // the active worktree's most-recently-focused panel (#9933).
+        // Validated upstream in `statePatcher.ts:buildArgsFor*` via
+        // `sanitizeLastActiveAt`; conditional spread avoids stamping
+        // `undefined` on freshly-created panels.
+        ...(options.lastActiveAt !== undefined && { lastActiveAt: options.lastActiveAt }),
         ...kindFields,
       } as PanelInstance;
 
@@ -379,6 +386,13 @@ export const createAddPanelActions = (
       removeOnExit: options.removeOnExit,
       startedAt: Date.now(),
       spawnStatus,
+      // Preserve the saved `lastActiveAt` from the snapshot so the
+      // post-hydration focus picker in `useAppHydration` can pick
+      // the active worktree's most-recently-focused panel (#9933).
+      // Validated upstream in `statePatcher.ts:buildArgsFor*` via
+      // `sanitizeLastActiveAt`; conditional spread avoids stamping
+      // `undefined` on freshly-created panels.
+      ...(options.lastActiveAt !== undefined && { lastActiveAt: options.lastActiveAt }),
     } as PanelInstance;
 
     // Commit the panel to `panelsById` BEFORE any async IPC (#5789 optimistic

--- a/src/store/slices/terminalFocusSlice.ts
+++ b/src/store/slices/terminalFocusSlice.ts
@@ -91,6 +91,23 @@ export interface TerminalFocusSlice {
   pingSeq: number;
   preMaximizeLayout: PreMaximizeLayoutSnapshot | null;
   setFocused: (id: string | null, shouldPing?: boolean) => void;
+  /**
+   * Synthetic boot-time focus: lands an initial `focusedId` without
+   * corrupting persistence. Mirrors the grid branch of `setFocused` (the
+   * post-hydration picker only ever targets grid panels) but skips
+   * `stampLastActive` (which would overwrite the per-panel recency that
+   * `panelRestorePhase` uses to promote each worktree's most-recently-
+   * focused panel) and skips `terminalInstanceService.wake` (the panel
+   * is already woken by the restore pipeline). The orchestrator's
+   * `trackTerminalFocus` and `selectWorktree({ source: "focus" })`
+   * subscriptions still fire — `lastFocusedTerminalByWorktree` is
+   * runtime-only and has no other writer, so the boot pick must seed it
+   * for future worktree switches to restore last-focus. Callers MUST wrap
+   * this in `suppressMruRecording(true)/(false)` if the MRU subscription
+   * should not re-prepend the boot pick to `mruList` (see
+   * `useAppHydration`).
+   */
+  setBootFocus: (id: string) => void;
   pingTerminal: (id: string) => void;
   toggleMaximize: (
     id: string,
@@ -220,6 +237,24 @@ export const createTerminalFocusSlice =
         } else {
           set({ focusedId: null, activeDockTerminalId: null });
         }
+      },
+
+      setBootFocus: (id) => {
+        // Bare focus commit — the boot pick is always a grid panel (the picker
+        // in `useAppHydration` filters `location === "grid"`), so the dock
+        // branch of `setFocused` is unreachable here. Skips `stampLastActive`
+        // (no disk write to per-panel recency), `terminalInstanceService.wake`
+        // (the restore pipeline already woke it), and `pingTerminal` (no
+        // user intent to visualize). `previousFocusedId` only moves when focus
+        // actually changes — the `null → bootPick` transition preserves the
+        // existing `previousFocusedId: null` (no real prior focus existed).
+        const previousFocusedId = get().focusedId;
+        const focusActuallyChanged = id !== previousFocusedId;
+        set({
+          focusedId: id,
+          activeDockTerminalId: null,
+          ...(focusActuallyChanged && { previousFocusedId }),
+        });
       },
 
       pingTerminal: (id) => {

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -2224,3 +2224,108 @@ describe("Adversarial: globalEnv merge in buildArgsForRespawn", () => {
     expect(result.env).toBeUndefined();
   });
 });
+
+// Issue #9933 — `lastActiveAt` must round-trip from the saved snapshot to
+// the live panel so `useAppHydration`'s post-hydration focus picker can
+// rank panels by recency instead of falling back to first-in-`panelIds`-
+// order. Each builder that consumes a `SavedTerminalData` must propagate
+// the field, and the propagation must apply the same `Number.isFinite &&
+// > 0` rejection as `panelRestorePhase.ts:109` so corrupted persisted
+// values never seed the picker with a sentinel that would always win.
+describe("lastActiveAt propagation (issue #9933)", () => {
+  it("buildArgsForBackendTerminal propagates a valid saved timestamp", () => {
+    const result = buildArgsForBackendTerminal(
+      { id: "t1", cwd: "/p", title: "T" },
+      { id: "t1", location: "grid", lastActiveAt: 1_700_000_000_000 },
+      "/p"
+    );
+    expect(result.lastActiveAt).toBe(1_700_000_000_000);
+  });
+
+  it("buildArgsForBackendTerminal drops a missing timestamp", () => {
+    const result = buildArgsForBackendTerminal(
+      { id: "t1", cwd: "/p", title: "T" },
+      { id: "t1", location: "grid" },
+      "/p"
+    );
+    expect(result.lastActiveAt).toBeUndefined();
+  });
+
+  it("buildArgsForBackendTerminal rejects lastActiveAt <= 0", () => {
+    // Mirrors `panelRestorePhase.ts:109` — a zero stamp is treated as
+    // "no stamp" so a corrupted writer that emits 0 can't promote an
+    // arbitrary panel to the boot focus.
+    const result = buildArgsForBackendTerminal(
+      { id: "t1", cwd: "/p", title: "T" },
+      { id: "t1", location: "grid", lastActiveAt: 0 },
+      "/p"
+    );
+    expect(result.lastActiveAt).toBeUndefined();
+  });
+
+  it("buildArgsForBackendTerminal rejects NaN / ±Infinity", () => {
+    // Defense in depth: even if the persisted file is corrupted, the
+    // sanitizer refuses to propagate non-finite values.
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      const result = buildArgsForBackendTerminal(
+        { id: "t1", cwd: "/p", title: "T" },
+        { id: "t1", location: "grid", lastActiveAt: bad },
+        "/p"
+      );
+      expect(result.lastActiveAt).toBeUndefined();
+    }
+  });
+
+  it("buildArgsForReconnectedFallback propagates a valid saved timestamp", () => {
+    const result = buildArgsForReconnectedFallback(
+      { id: "t1", cwd: "/p" },
+      { id: "t1", location: "grid", lastActiveAt: 1_700_000_000_000 },
+      "/p"
+    );
+    expect(result.lastActiveAt).toBe(1_700_000_000_000);
+  });
+
+  it("buildArgsForRespawn propagates a valid saved timestamp", () => {
+    const result = buildArgsForRespawn(
+      { id: "t1", cwd: "/p", location: "grid", lastActiveAt: 1_700_000_000_000 },
+      "terminal",
+      "/p",
+      undefined,
+      false,
+      undefined
+    );
+    expect(result.lastActiveAt).toBe(1_700_000_000_000);
+  });
+
+  it("buildArgsForRespawn drops a missing timestamp", () => {
+    const result = buildArgsForRespawn(
+      { id: "t1", cwd: "/p", location: "grid" },
+      "terminal",
+      "/p",
+      undefined,
+      false,
+      undefined
+    );
+    expect(result.lastActiveAt).toBeUndefined();
+  });
+
+  it("buildArgsForNonPtyRecreation propagates a valid saved timestamp", () => {
+    const result = buildArgsForNonPtyRecreation(
+      { id: "t1", cwd: "/p", location: "grid", lastActiveAt: 1_700_000_000_000 },
+      "browser",
+      "/p"
+    );
+    expect(result.lastActiveAt).toBe(1_700_000_000_000);
+  });
+
+  it("buildArgsForOrphanedTerminal never propagates lastActiveAt (no saved data)", () => {
+    // Orphans are panels alive in the backend but missing from the
+    // saved snapshot — there is no recency data to recover, so the
+    // builder deliberately doesn't accept or emit `lastActiveAt`.
+    const result = buildArgsForOrphanedTerminal(
+      { id: "t1", cwd: "/p" },
+      "/p"
+    );
+    expect(result).not.toHaveProperty("lastActiveAt");
+  });
+});

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -2322,10 +2322,7 @@ describe("lastActiveAt propagation (issue #9933)", () => {
     // Orphans are panels alive in the backend but missing from the
     // saved snapshot — there is no recency data to recover, so the
     // builder deliberately doesn't accept or emit `lastActiveAt`.
-    const result = buildArgsForOrphanedTerminal(
-      { id: "t1", cwd: "/p" },
-      "/p"
-    );
+    const result = buildArgsForOrphanedTerminal({ id: "t1", cwd: "/p" }, "/p");
     expect(result).not.toHaveProperty("lastActiveAt");
   });
 });

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -44,6 +44,16 @@ export interface AddTerminalArgs extends AddPanelOptionsBase {
   viewportDpr?: 1 | 2 | 3;
   viewportFit?: boolean;
   devPreviewScrollPosition?: { url: string; scrollY: number };
+  /**
+   * Preserved user-initiated focus timestamp from the saved snapshot. The
+   * post-hydration focus picker in `useAppHydration` reads this off
+   * `panelsById[id]` to pick the active worktree's most-recently-focused
+   * panel, so the data must survive the save→restore round-trip
+   * (#9933). Conditional on being a valid finite > 0 value; never
+   * defaults to `Date.now()` here — the restore path must reflect the
+   * user's last actual focus, not the current boot time.
+   */
+  lastActiveAt?: number;
 }
 
 export interface SavedTerminalData {
@@ -88,6 +98,16 @@ export interface SavedTerminalData {
   agentFlavorColor?: string;
   extensionState?: Record<string, unknown>;
   pluginId?: string;
+  /**
+   * User-initiated focus timestamp from the saved snapshot. Read at the
+   * hydration boundary and propagated to the live panel via the
+   * `AddTerminalArgs.lastActiveAt` field (#9933), so the post-hydration
+   * focus picker in `useAppHydration` can pick the active worktree's
+   * most-recently-focused panel. Without this field, the picker falls
+   * back to first-in-`panelIds`-order and silently regresses to the
+   * pre-#9933 behavior the issue was meant to fix.
+   */
+  lastActiveAt?: number;
 }
 
 function readPresetId(saved: SavedTerminalData): string | undefined {
@@ -194,6 +214,22 @@ function normalizePtyKind(kind: PanelKind | undefined): PanelKind {
   return kind;
 }
 
+/**
+ * Validate a `lastActiveAt` timestamp from a saved snapshot before
+ * propagating it to the live panel via `AddTerminalArgs.lastActiveAt`
+ * (#9933). Mirrors the rejection rule in `panelRestorePhase.ts:109`:
+ * `Number.isFinite && > 0`. Returns `undefined` for any other value
+ * (NaN, ±Infinity, <= 0, missing) so a corrupted persisted value can't
+ * silently seed the post-hydration focus picker with a sentinel that
+ * would always win (e.g. `Number.MAX_SAFE_INTEGER` from a buggy writer).
+ */
+function sanitizeLastActiveAt(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return value;
+}
+
 export function buildArgsForBackendTerminal(
   backendTerminal: BackendTerminalData,
   saved: SavedTerminalData,
@@ -257,6 +293,7 @@ export function buildArgsForBackendTerminal(
     fallbackChainIndex: saved.fallbackChainIndex,
     extensionState: saved.extensionState,
     pluginId: saved.pluginId,
+    lastActiveAt: sanitizeLastActiveAt(saved.lastActiveAt),
   };
 }
 
@@ -323,6 +360,7 @@ export function buildArgsForReconnectedFallback(
     fallbackChainIndex: saved.fallbackChainIndex,
     extensionState: saved.extensionState,
     pluginId: saved.pluginId,
+    lastActiveAt: sanitizeLastActiveAt(saved.lastActiveAt),
   };
 }
 
@@ -471,6 +509,7 @@ export function buildArgsForRespawn(
     extensionState: saved.extensionState,
     pluginId: saved.pluginId,
     restore: true,
+    lastActiveAt: sanitizeLastActiveAt(saved.lastActiveAt),
   };
 }
 
@@ -495,6 +534,7 @@ export function buildArgsForNonPtyRecreation(
     fallbackChainIndex: saved.fallbackChainIndex,
     extensionState: saved.extensionState,
     pluginId: saved.pluginId,
+    lastActiveAt: sanitizeLastActiveAt(saved.lastActiveAt),
   };
 
   const deserializer = getDeserializer(kind);


### PR DESCRIPTION
## Summary

After session restore, the post-hydration focus fallback in `useAppHydration` picked the first grid panel in saved order. It ran after `suppressMruRecording` had lifted, so `setFocused` stamped `Date.now()` on the arbitrary panel, persisted it, and pushed the panel to the head of the MRU list. The recency signal degraded a little more on every boot.

- The picker now selects the active worktree's grid panel with the highest saved `lastActiveAt` (first-in-order fallback when no timestamps exist).
- A new `setBootFocus` path on the focus slice handles the synthetic boot-time focus without stamping, MRU recording, or per-worktree focus overwrite.
- A follow-up commit propagates saved `lastActiveAt` to live panels on creation, so the picker has real data to work with (previously new panels always started at `0`).

Resolves #9933.

## Changes

- `src/store/slices/terminalFocusSlice.ts`: new `setBootFocus` action and `suppressMruRecording` wrap.
- `src/hooks/app/useAppHydration.ts`: picker keyed off max `lastActiveAt` with first-in-order fallback.
- `shared/types/addPanelOptions.ts`, `src/store/slices/panelRegistry/addPanel.ts`, `src/utils/stateHydration/statePatcher.ts`: propagate saved `lastActiveAt` to live panels via `AddPanelOptionsBase`, `AddTerminalArgs`, and `SavedTerminalData`; new `sanitizeLastActiveAt` helper.
- `src/utils/stateHydration/statePatcher.ts`: `lastActiveAt` threaded through all four `buildArgsFor*` functions.

## Testing

- New slice tests for `setBootFocus` (no stamp, no MRU, no per-worktree overwrite) and the recency picker.
- New `useAppHydration` test covering the picker (max `lastActiveAt`, first-in-order fallback) and `suppressMruRecording` wrap.
- New `rendererStoreOrchestrator` test asserting boot focus does not trigger MRU or per-worktree subscriptions.
- New `statePatcher` tests for `lastActiveAt` propagation across `buildArgsFor*` and `sanitizeLastActiveAt`.
- All 290 tests across the touched suites pass. `npm run typecheck` clean.