### PR TITLE
fix(pattern-discovery): wire crush, goose, qwen fixtures into corpus-replay test

### DIFF
--- a/scripts/pattern-discovery/__tests__/corpus-replay.test.ts
+++ b/scripts/pattern-discovery/__tests__/corpus-replay.test.ts
@@ -69,6 +69,30 @@ describe("corpus-replay", () => {
     });
   });
 
+  describe("crush corpus replay", () => {
+    it("achieves >= 90% accuracy on crush sample corpus", () => {
+      const result = replayCorpus(path.join(CORPUS_DIR, "crush_sample.jsonl"), "crush");
+      expect(result.total).toBeGreaterThan(0);
+      expect(result.accuracy).toBeGreaterThanOrEqual(MIN_ACCURACY);
+    });
+  });
+
+  describe("goose corpus replay", () => {
+    it("achieves >= 90% accuracy on goose sample corpus", () => {
+      const result = replayCorpus(path.join(CORPUS_DIR, "goose_sample.jsonl"), "goose");
+      expect(result.total).toBeGreaterThan(0);
+      expect(result.accuracy).toBeGreaterThanOrEqual(MIN_ACCURACY);
+    });
+  });
+
+  describe("qwen corpus replay", () => {
+    it("achieves >= 90% accuracy on qwen sample corpus", () => {
+      const result = replayCorpus(path.join(CORPUS_DIR, "qwen_sample.jsonl"), "qwen");
+      expect(result.total).toBeGreaterThan(0);
+      expect(result.accuracy).toBeGreaterThanOrEqual(MIN_ACCURACY);
+    });
+  });
+
   describe("replay result structure", () => {
     it("returns detailed wrong entries for debugging", () => {
       const result = replayCorpus(path.join(CORPUS_DIR, "claude_sample.jsonl"), "claude");


### PR DESCRIPTION
## Summary

- crush, goose, and qwen each committed their corpus fixture files but never had the corresponding `describe` blocks added to the replay test — regressions in their detection patterns would have shipped without CI catching them
- Adds the three missing `describe` blocks to `scripts/pattern-discovery/__tests__/corpus-replay.test.ts`, following the same pattern established when aider was wired in

Resolves #10016

## Changes

- `scripts/pattern-discovery/__tests__/corpus-replay.test.ts` — three new `describe` / `it` blocks for crush, goose, and qwen corpus replay

## Testing

All 11 corpus-replay tests pass, including the three new blocks.