### PR TITLE
chore(ci): centralize vitest shard denominator into SHARD_TOTAL env var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,11 +72,12 @@ jobs:
       - name: Check (typecheck + lint + format)
         run: npm run check
 
-  # Unit tests, sharded across 4 runners via vitest's native --shard. Vitest
-  # splits test files deterministically across shards with no merge step (we
-  # don't collect coverage in CI). Each shard pays its own npm ci, but they run
-  # in parallel so the test phase wall-clock drops to ~1/4. To change the shard
-  # count, update both the `shard:` matrix list and the `/4` denominator below.
+  # Unit tests, sharded across SHARD_TOTAL runners via vitest's native --shard.
+  # Vitest splits test files deterministically across shards with no merge step
+  # (we don't collect coverage in CI). Each shard pays its own npm ci, but they
+  # run in parallel so the test phase wall-clock drops to ~1/SHARD_TOTAL. To
+  # change the shard count, update SHARD_TOTAL and keep the `shard:` matrix
+  # list as [1, 2, ..., SHARD_TOTAL].
   test:
     strategy:
       fail-fast: false
@@ -85,6 +86,8 @@ jobs:
         shard: [1, 2, 3, 4]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    env:
+      SHARD_TOTAL: 4
 
     steps:
       - name: Check out repository
@@ -105,8 +108,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Test (vitest unit, shard ${{ matrix.shard }}/4)
-        run: npm run test -- --shard=${{ matrix.shard }}/4
+      - name: Test (vitest unit, shard ${{ matrix.shard }}/${{ env.SHARD_TOTAL }})
+        run: npm run test -- --shard=${{ matrix.shard }}/${{ env.SHARD_TOTAL }}
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

The vitest shard denominator was hardcoded as `/4` in two places — the step name and the `--shard` run argument — independent of the matrix shard list `[1, 2, 3, 4]`. Changing the matrix without updating the denominator literals mis-shards silently: drop the list to `[1, 2, 3]` and leave `/4`, and vitest partition `4/4` is never scheduled, roughly a quarter of test files never run, and every required check stays green.

Fix introduces a job-level env var `SHARD_TOTAL: 4` on the `test` job; both denominator literals now reference `${{ env.SHARD_TOTAL }}`. The matrix list stays a literal — GHA env context isn't available at `strategy.matrix` evaluation time, and `strategy.job-total` was rejected because it returns the `os × shard` Cartesian product (8 on `os=both` dispatch, not the shard count). A missing or mistyped `SHARD_TOTAL` now fails loudly as a vitest parse error rather than silently skipping tests.

Resolves #10006.

## Changes

- Added `SHARD_TOTAL: 4` as a job-level env var on the `test` job in `.github/workflows/ci.yml`
- Both `/4` denominator literals (step name and `--shard` arg) now reference `${{ env.SHARD_TOTAL }}`
- Maintenance comment updated to say: update `SHARD_TOTAL` and keep the matrix list as `[1, 2, ..., SHARD_TOTAL]`

## Testing

CI workflow change only — no application code affected. Verified locally with `npm run check` (green). Shard references are straightforward string substitution; the new failure mode (missing `SHARD_TOTAL` → vitest parse error) is preferable to the old one (silent coverage loss).