### PR TITLE
fix(dev-preview): surface ERR_FILE_NOT_FOUND on main-frame load failure

### DIFF
--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -1486,6 +1486,23 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       expect(container.textContent).toContain("No internet connection");
     });
 
+    it("surfaces ERR_FILE_NOT_FOUND (-6) as a load failure", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -6,
+          errorDescription: "ERR_FILE_NOT_FOUND",
+          isMainFrame: true,
+          validatedURL: "http://localhost:5173/missing",
+        });
+      });
+
+      expect(container.textContent).toContain("Page load failed");
+      expect(container.textContent).toContain("ERR_FILE_NOT_FOUND");
+    });
+
     it("retry-exhausted error includes URL", () => {
       const { container } = render(<DevPreviewPane {...baseProps} />);
       const webview = getWebviewElement(container);

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -1503,6 +1503,96 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       expect(container.textContent).toContain("ERR_FILE_NOT_FOUND");
     });
 
+    it("cancels pending connection-refused retry when ERR_FILE_NOT_FOUND arrives", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      // Fire a connection-refused to schedule a retry at 500ms
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -102,
+          errorDescription: "ERR_CONNECTION_REFUSED",
+          isMainFrame: true,
+          validatedURL: "http://localhost:5173/",
+        });
+      });
+
+      // Before the retry fires, a file-not-found error arrives
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -6,
+          errorDescription: "ERR_FILE_NOT_FOUND",
+          isMainFrame: true,
+          validatedURL: "http://localhost:5173/missing",
+        });
+      });
+
+      // Advance past the retry timeout
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      // The stale retry must NOT have called loadURL
+      expect(webview.loadURL).not.toHaveBeenCalled();
+      // Failure overlay must be visible
+      expect(container.textContent).toContain("Page load failed");
+      expect(container.textContent).toContain("ERR_FILE_NOT_FOUND");
+    });
+
+    it("ignores subframe ERR_FILE_NOT_FOUND failures", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -6,
+          errorDescription: "ERR_FILE_NOT_FOUND",
+          isMainFrame: false,
+          validatedURL: "http://localhost:5173/iframe-asset",
+        });
+      });
+
+      expect(container.textContent).not.toContain("Page load failed");
+    });
+
+    it("falls back to the numeric error code when errorDescription is empty", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -6,
+          errorDescription: "",
+          isMainFrame: true,
+          validatedURL: "http://localhost:5173/missing",
+        });
+      });
+
+      expect(container.textContent).toContain("Page load failed");
+      expect(container.textContent).toContain("Error code -6");
+    });
+
+    it("does not schedule a retry for ERR_FILE_NOT_FOUND", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -6,
+          errorDescription: "ERR_FILE_NOT_FOUND",
+          isMainFrame: true,
+          validatedURL: "http://localhost:5173/missing",
+        });
+      });
+
+      // Advance beyond every backoff window
+      act(() => {
+        vi.advanceTimersByTime(8000);
+      });
+
+      expect(webview.loadURL).not.toHaveBeenCalled();
+    });
+
     it("retry-exhausted error includes URL", () => {
       const { container } = render(<DevPreviewPane {...baseProps} />);
       const webview = getWebviewElement(container);

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -469,9 +469,14 @@ export function useDevPreviewLoadLifecycle({
         }
       }
 
-      // Catch-all for unhandled error codes (-2 ERR_FAILED, -7 ERR_TIMED_OUT,
-      // -104 ERR_CONNECTION_FAILED, and any other unexpected codes).
+      // Catch-all for unhandled error codes (-2 ERR_FAILED, -6 ERR_FILE_NOT_FOUND,
+      // -7 ERR_TIMED_OUT, -104 ERR_CONNECTION_FAILED, and any other unexpected codes).
       // Without this branch the webview shows a blank white screen with no error.
+      if (failLoadRetryRef.current) {
+        clearTimeout(failLoadRetryRef.current);
+        failLoadRetryRef.current = null;
+      }
+      failLoadRetryCountRef.current = 0;
       const desc = e.errorDescription || `Error code ${e.errorCode}`;
       setWebviewLoadError({
         code: "failed",

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -343,8 +343,6 @@ export function useDevPreviewLoadLifecycle({
     const handleDidFailLoad = (e: Electron.DidFailLoadEvent) => {
       // Ignore aborted loads (e.g., navigation interrupted by another navigation)
       if (e.errorCode === -3) return;
-      // Ignore cancellations
-      if (e.errorCode === -6) return;
       // Ignore subframe failures — they don't affect the main-frame load state
       if (!e.isMainFrame) return;
 


### PR DESCRIPTION
## Summary

- The Dev Preview pane was silently swallowing `ERR_FILE_NOT_FOUND` on main-frame load failures — webview went blank with no error overlay and no retry
- Root cause: a mislabeled early return in `handleDidFailLoad` checked for error code `-6` and skipped it as a cancellation; `-6` is `ERR_FILE_NOT_FOUND`, not a cancellation (`ERR_ABORTED` is `-3` and was already handled correctly on the line above)
- Removed the bogus `-6` guard so the error falls through to the existing catch-all overlay, aligning Dev Preview with the sibling Browser pane handler (`useWebviewEvents.ts`) which already surfaces `-6`

Resolves #9966

## Changes

- `useDevPreviewLoadLifecycle.ts`: removed the erroneous `if (e.errorCode === -6) return;` early return from `handleDidFailLoad`
- Hardening: catch-all now clears `failLoadRetryRef` and resets `failLoadRetryCountRef`, so a stale connection-refused retry can't fire after a terminal error overlay has been shown
- `DevPreviewPane.webview.test.tsx`: added regression test for the `-6` surface case plus 4 hardening tests (stale retry cancelled by `-6`, subframe `-6` ignored, empty `errorDescription` fallback, no retry scheduled for `-6`)

## Testing

60/60 tests pass in `DevPreviewPane.webview.test.tsx`. Full verify suite passed — typecheck, all channel/IPC/confirm guards, format, lint (ratchet improved 1187 → 1186).