### PR TITLE
fix(file-viewer): re-run hunk observer when collapsed diffs are expanded

### DIFF
--- a/src/components/FileViewer/FileViewerModal.tsx
+++ b/src/components/FileViewer/FileViewerModal.tsx
@@ -125,9 +125,10 @@ export function FileViewerModal({
   const currentHunkIndexRef = useRef<number>(-1);
   const [activeHunkIndex, setActiveHunkIndex] = useState<number>(-1);
   const [hunkCount, setHunkCount] = useState<number>(0);
-  // Bumped whenever a collapsed-by-default file is expanded inside DiffViewer, so
-  // the hunk-counting effect re-scans the DOM that only now contains its hunk rows.
-  const [expandRevision, setExpandRevision] = useState(0);
+  // Bumped whenever a file's collapse state is toggled inside DiffViewer, so the
+  // hunk-counting effect re-scans the DOM whose hunk rows just appeared (expand)
+  // or disappeared (collapse). See #10013.
+  const [collapseRevision, setCollapseRevision] = useState(0);
   const hunkRatiosRef = useRef<Map<number, number>>(new Map());
   const observerGenerationRef = useRef(0);
   const observerDisposedRef = useRef(false);
@@ -471,10 +472,10 @@ export function FileViewerModal({
       observerDisposedRef.current = true;
       observer.disconnect();
     };
-  }, [isOpen, mode, diff, diffViewType, expandRevision]);
+  }, [isOpen, mode, diff, diffViewType, collapseRevision]);
 
-  const handleDiffExpand = useCallback(() => {
-    setExpandRevision((r) => r + 1);
+  const handleDiffToggleCollapse = useCallback(() => {
+    setCollapseRevision((r) => r + 1);
   }, []);
 
   return (
@@ -752,7 +753,7 @@ export function FileViewerModal({
             viewType={diffViewType}
             rootPath={rootPath}
             onRetry={onRetryDiff}
-            onExpand={handleDiffExpand}
+            onToggleCollapse={handleDiffToggleCollapse}
           />
         )}
 

--- a/src/components/FileViewer/FileViewerModal.tsx
+++ b/src/components/FileViewer/FileViewerModal.tsx
@@ -125,6 +125,9 @@ export function FileViewerModal({
   const currentHunkIndexRef = useRef<number>(-1);
   const [activeHunkIndex, setActiveHunkIndex] = useState<number>(-1);
   const [hunkCount, setHunkCount] = useState<number>(0);
+  // Bumped whenever a collapsed-by-default file is expanded inside DiffViewer, so
+  // the hunk-counting effect re-scans the DOM that only now contains its hunk rows.
+  const [expandRevision, setExpandRevision] = useState(0);
   const hunkRatiosRef = useRef<Map<number, number>>(new Map());
   const observerGenerationRef = useRef(0);
   const observerDisposedRef = useRef(false);
@@ -468,7 +471,11 @@ export function FileViewerModal({
       observerDisposedRef.current = true;
       observer.disconnect();
     };
-  }, [isOpen, mode, diff, diffViewType]);
+  }, [isOpen, mode, diff, diffViewType, expandRevision]);
+
+  const handleDiffExpand = useCallback(() => {
+    setExpandRevision((r) => r + 1);
+  }, []);
 
   return (
     <AppDialog
@@ -745,6 +752,7 @@ export function FileViewerModal({
             viewType={diffViewType}
             rootPath={rootPath}
             onRetry={onRetryDiff}
+            onExpand={handleDiffExpand}
           />
         )}
 

--- a/src/components/FileViewer/__tests__/FileViewerModal.test.tsx
+++ b/src/components/FileViewer/__tests__/FileViewerModal.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { render, screen, waitFor, fireEvent, within } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { forwardRef, type ReactNode } from "react";
+import { forwardRef, useState, type ReactNode } from "react";
 
 let mockObserverInstances: MockIntersectionObserver[] = [];
 
@@ -89,26 +89,55 @@ vi.mock("@/components/ui/tooltip", () => ({
   TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
+// Controls whether the mock DiffViewer starts collapsed (no hunk rows in the
+// DOM until the user expands). Defaults to false so existing tests render hunks
+// immediately; the collapsed-by-default regression test flips it to true.
+const { mockDiffViewerControl } = vi.hoisted(() => ({
+  mockDiffViewerControl: { startCollapsed: false },
+}));
+
 vi.mock("@/components/Worktree/DiffViewer", () => ({
-  DiffViewer: forwardRef<HTMLDivElement, { onRetry?: () => void }>(({ onRetry }, ref) => (
-    <div ref={ref} data-testid="diff-viewer" data-has-retry={onRetry ? "true" : "false"}>
-      {/* Two stub hunk rows so hunk-nav tests have predictable targets.
-          Each tbody must contain a tr:first-child for the IntersectionObserver
-          to observe (tbody alone collapses to 0 height in Chromium). */}
-      <table>
-        <tbody className="diff-hunk" data-testid="hunk-0">
-          <tr>
-            <td>hunk 0</td>
-          </tr>
-        </tbody>
-        <tbody className="diff-hunk" data-testid="hunk-1">
-          <tr>
-            <td>hunk 1</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  )),
+  DiffViewer: forwardRef<HTMLDivElement, { onRetry?: () => void; onExpand?: () => void }>(
+    ({ onRetry, onExpand }, ref) => {
+      // Mirrors the real DiffViewer: when a file is collapsed by default, its
+      // hunk rows are absent from the DOM until the user expands, at which point
+      // it fires onExpand so the modal can re-scan. See #10013.
+      const [expanded, setExpanded] = useState(!mockDiffViewerControl.startCollapsed);
+      return (
+        <div ref={ref} data-testid="diff-viewer" data-has-retry={onRetry ? "true" : "false"}>
+          {!expanded && (
+            <button
+              type="button"
+              data-testid="expand-trigger"
+              onClick={() => {
+                onExpand?.();
+                setExpanded(true);
+              }}
+            >
+              Show diff
+            </button>
+          )}
+          {expanded && (
+            // Two stub hunk rows so hunk-nav tests have predictable targets.
+            // Each tbody must contain a tr:first-child for the IntersectionObserver
+            // to observe (tbody alone collapses to 0 height in Chromium).
+            <table>
+              <tbody className="diff-hunk" data-testid="hunk-0">
+                <tr>
+                  <td>hunk 0</td>
+                </tr>
+              </tbody>
+              <tbody className="diff-hunk" data-testid="hunk-1">
+                <tr>
+                  <td>hunk 1</td>
+                </tr>
+              </tbody>
+            </table>
+          )}
+        </div>
+      );
+    }
+  ),
 }));
 
 const setDiffViewTypeMock = vi.fn();
@@ -164,6 +193,7 @@ const scrollIntoViewCalls: HTMLElement[] = [];
 beforeEach(() => {
   vi.clearAllMocks();
   mockObserverInstances = [];
+  mockDiffViewerControl.startCollapsed = false;
   vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
   mockRead.mockResolvedValue({ content: "file content" });
   setDiffViewTypeMock.mockReset();
@@ -1006,6 +1036,39 @@ describe("FileViewerModal", () => {
       expect(() => {
         fireObserver(observer, [makeEntry(hunk0Row!, 1.0)]);
       }).not.toThrow();
+    });
+
+    // Regression for #10013: when a file is collapsed by default (generated
+    // files, large diffs), its hunk rows are absent at first scan, so no
+    // observer attaches. Expanding must re-scan and wire up the indicator.
+    it("wires up the indicator after a collapsed-by-default file is expanded", async () => {
+      mockDiffViewerControl.startCollapsed = true;
+      render(<FileViewerModal {...defaultProps} diff={diff} defaultMode="diff" />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("expand-trigger")).toBeTruthy();
+      });
+
+      // Collapsed: no hunk rows, so no observer and no indicator yet.
+      expect(screen.queryByTestId("hunk-0")).toBeNull();
+      expect(mockObserverInstances.length).toBe(0);
+      expect(screen.queryByTestId("hunk-position-indicator")).toBeNull();
+
+      // Expand the file — onExpand bumps expandRevision, re-running the scan.
+      fireEvent.click(screen.getByTestId("expand-trigger"));
+
+      await waitFor(() => {
+        expect(mockObserverInstances.length).toBe(1);
+      });
+
+      const observer = mockObserverInstances[0]!;
+      const hunk0Row = screen.getByTestId("hunk-0").querySelector("tr");
+      expect(hunk0Row).toBeTruthy();
+      fireObserver(observer, [makeEntry(hunk0Row!, 0.8)]);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("hunk-position-indicator").textContent).toBe("Hunk 1 of 2");
+      });
     });
   });
 

--- a/src/components/FileViewer/__tests__/FileViewerModal.test.tsx
+++ b/src/components/FileViewer/__tests__/FileViewerModal.test.tsx
@@ -97,26 +97,25 @@ const { mockDiffViewerControl } = vi.hoisted(() => ({
 }));
 
 vi.mock("@/components/Worktree/DiffViewer", () => ({
-  DiffViewer: forwardRef<HTMLDivElement, { onRetry?: () => void; onExpand?: () => void }>(
-    ({ onRetry, onExpand }, ref) => {
+  DiffViewer: forwardRef<HTMLDivElement, { onRetry?: () => void; onToggleCollapse?: () => void }>(
+    ({ onRetry, onToggleCollapse }, ref) => {
       // Mirrors the real DiffViewer: when a file is collapsed by default, its
       // hunk rows are absent from the DOM until the user expands, at which point
-      // it fires onExpand so the modal can re-scan. See #10013.
+      // it fires onToggleCollapse so the modal can re-scan. Collapsing again
+      // removes the rows and fires the callback once more. See #10013.
       const [expanded, setExpanded] = useState(!mockDiffViewerControl.startCollapsed);
       return (
         <div ref={ref} data-testid="diff-viewer" data-has-retry={onRetry ? "true" : "false"}>
-          {!expanded && (
-            <button
-              type="button"
-              data-testid="expand-trigger"
-              onClick={() => {
-                onExpand?.();
-                setExpanded(true);
-              }}
-            >
-              Show diff
-            </button>
-          )}
+          <button
+            type="button"
+            data-testid="collapse-toggle"
+            onClick={() => {
+              onToggleCollapse?.();
+              setExpanded((prev) => !prev);
+            }}
+          >
+            {expanded ? "Hide diff" : "Show diff"}
+          </button>
           {expanded && (
             // Two stub hunk rows so hunk-nav tests have predictable targets.
             // Each tbody must contain a tr:first-child for the IntersectionObserver
@@ -1046,7 +1045,7 @@ describe("FileViewerModal", () => {
       render(<FileViewerModal {...defaultProps} diff={diff} defaultMode="diff" />);
 
       await waitFor(() => {
-        expect(screen.getByTestId("expand-trigger")).toBeTruthy();
+        expect(screen.getByTestId("collapse-toggle")).toBeTruthy();
       });
 
       // Collapsed: no hunk rows, so no observer and no indicator yet.
@@ -1054,8 +1053,8 @@ describe("FileViewerModal", () => {
       expect(mockObserverInstances.length).toBe(0);
       expect(screen.queryByTestId("hunk-position-indicator")).toBeNull();
 
-      // Expand the file — onExpand bumps expandRevision, re-running the scan.
-      fireEvent.click(screen.getByTestId("expand-trigger"));
+      // Expand the file — onToggleCollapse bumps collapseRevision, re-running the scan.
+      fireEvent.click(screen.getByTestId("collapse-toggle"));
 
       await waitFor(() => {
         expect(mockObserverInstances.length).toBe(1);
@@ -1068,6 +1067,33 @@ describe("FileViewerModal", () => {
 
       await waitFor(() => {
         expect(screen.getByTestId("hunk-position-indicator").textContent).toBe("Hunk 1 of 2");
+      });
+    });
+
+    // Regression for #10013: re-collapsing after expand must clear the indicator —
+    // the hunk rows are gone, so "Hunk X of Y" should not linger over an empty body.
+    it("clears the indicator when an expanded file is re-collapsed", async () => {
+      render(<FileViewerModal {...defaultProps} diff={diff} defaultMode="diff" />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("diff-viewer")).toBeTruthy();
+      });
+
+      // Start expanded (default): observer fires, indicator shows.
+      const observer = mockObserverInstances[0]!;
+      const hunk0Row = screen.getByTestId("hunk-0").querySelector("tr");
+      fireObserver(observer, [makeEntry(hunk0Row!, 0.8)]);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("hunk-position-indicator").textContent).toBe("Hunk 1 of 2");
+      });
+
+      // Collapse — onToggleCollapse re-runs the scan, which finds 0 hunks.
+      fireEvent.click(screen.getByTestId("collapse-toggle"));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("hunk-0")).toBeNull();
+        expect(screen.queryByTestId("hunk-position-indicator")).toBeNull();
       });
     });
   });

--- a/src/components/Worktree/DiffViewer.tsx
+++ b/src/components/Worktree/DiffViewer.tsx
@@ -82,6 +82,8 @@ export interface DiffViewerProps {
   /** Absolute path to the worktree root, used to resolve per-file open-in-editor paths */
   rootPath?: string;
   onRetry?: () => void;
+  /** Fired when a collapsed file is expanded, so consumers can re-scan the newly rendered hunk rows */
+  onExpand?: () => void;
 }
 
 function useTokens(
@@ -134,7 +136,7 @@ function useTokens(
 }
 
 export const DiffViewer = forwardRef<HTMLDivElement, DiffViewerProps>(function DiffViewer(
-  { diff, viewType = "split", rootPath, onRetry },
+  { diff, viewType = "split", rootPath, onRetry, onExpand },
   ref
 ) {
   const files = useMemo(() => {
@@ -211,6 +213,7 @@ export const DiffViewer = forwardRef<HTMLDivElement, DiffViewerProps>(function D
           file={file}
           viewType={viewType}
           rootPath={rootPath}
+          onExpand={onExpand}
         />
       ))}
     </div>
@@ -221,9 +224,11 @@ interface FileDiffProps {
   file: ReturnType<typeof parseDiff>[0];
   viewType: ViewType;
   rootPath?: string;
+  /** Fired when this file transitions from collapsed to expanded */
+  onExpand?: () => void;
 }
 
-function FileDiff({ file, viewType, rootPath }: FileDiffProps) {
+function FileDiff({ file, viewType, rootPath, onExpand }: FileDiffProps) {
   const relPath = getFilePath(file);
   const language = useMemo(() => {
     const derived = getLanguageForFile(relPath);
@@ -271,7 +276,12 @@ function FileDiff({ file, viewType, rootPath }: FileDiffProps) {
     );
   };
 
-  const handleToggleCollapse = () => setIsCollapsed((prev) => !prev);
+  const handleToggleCollapse = () => {
+    // Notify consumers on collapse→expand so they can re-scan the now-rendered
+    // hunk rows (the hunk indicator / scroll tracking attaches to live DOM).
+    if (isCollapsed) onExpand?.();
+    setIsCollapsed((prev) => !prev);
+  };
 
   return (
     <div className="mb-2">

--- a/src/components/Worktree/DiffViewer.tsx
+++ b/src/components/Worktree/DiffViewer.tsx
@@ -82,8 +82,8 @@ export interface DiffViewerProps {
   /** Absolute path to the worktree root, used to resolve per-file open-in-editor paths */
   rootPath?: string;
   onRetry?: () => void;
-  /** Fired when a collapsed file is expanded, so consumers can re-scan the newly rendered hunk rows */
-  onExpand?: () => void;
+  /** Fired when a collapsible file is expanded or collapsed, so consumers can re-scan the hunk rows that just appeared or disappeared */
+  onToggleCollapse?: () => void;
 }
 
 function useTokens(
@@ -136,7 +136,7 @@ function useTokens(
 }
 
 export const DiffViewer = forwardRef<HTMLDivElement, DiffViewerProps>(function DiffViewer(
-  { diff, viewType = "split", rootPath, onRetry, onExpand },
+  { diff, viewType = "split", rootPath, onRetry, onToggleCollapse },
   ref
 ) {
   const files = useMemo(() => {
@@ -213,7 +213,7 @@ export const DiffViewer = forwardRef<HTMLDivElement, DiffViewerProps>(function D
           file={file}
           viewType={viewType}
           rootPath={rootPath}
-          onExpand={onExpand}
+          onToggleCollapse={onToggleCollapse}
         />
       ))}
     </div>
@@ -224,11 +224,11 @@ interface FileDiffProps {
   file: ReturnType<typeof parseDiff>[0];
   viewType: ViewType;
   rootPath?: string;
-  /** Fired when this file transitions from collapsed to expanded */
-  onExpand?: () => void;
+  /** Fired whenever this file's collapse state is toggled (expand or collapse) */
+  onToggleCollapse?: () => void;
 }
 
-function FileDiff({ file, viewType, rootPath, onExpand }: FileDiffProps) {
+function FileDiff({ file, viewType, rootPath, onToggleCollapse }: FileDiffProps) {
   const relPath = getFilePath(file);
   const language = useMemo(() => {
     const derived = getLanguageForFile(relPath);
@@ -277,9 +277,10 @@ function FileDiff({ file, viewType, rootPath, onExpand }: FileDiffProps) {
   };
 
   const handleToggleCollapse = () => {
-    // Notify consumers on collapse→expand so they can re-scan the now-rendered
-    // hunk rows (the hunk indicator / scroll tracking attaches to live DOM).
-    if (isCollapsed) onExpand?.();
+    // Notify consumers on every toggle so they can re-scan the hunk rows that
+    // just appeared (expand) or disappeared (collapse) — the hunk indicator and
+    // scroll tracking attach to live DOM and must follow both transitions.
+    onToggleCollapse?.();
     setIsCollapsed((prev) => !prev);
   };
 

--- a/src/components/Worktree/__tests__/DiffViewer.test.tsx
+++ b/src/components/Worktree/__tests__/DiffViewer.test.tsx
@@ -229,4 +229,27 @@ describe("DiffViewer collapse behavior", () => {
     expect(screen.queryByTestId("diff-element")).toBeNull();
     expect(screen.getByText("Show diff")).toBeTruthy();
   });
+
+  // #10013: consumers re-scan hunk rows on toggle, so the callback must fire on
+  // both expand and collapse — once per transition.
+  it("fires onToggleCollapse on each expand and collapse transition", () => {
+    const onToggleCollapse = vi.fn();
+    render(
+      wrap(
+        <DiffViewer
+          diff={LOCKFILE_DIFF}
+          filePath="package-lock.json"
+          onToggleCollapse={onToggleCollapse}
+        />
+      )
+    );
+
+    expect(onToggleCollapse).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText("Show diff"));
+    expect(onToggleCollapse).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText("Hide diff"));
+    expect(onToggleCollapse).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
## Summary

- When expanding a diff that was collapsed by default (generated files, diffs over 256KB), the hunk indicator and `IntersectionObserver`-based scroll tracking would stay dead because the counting `useEffect` in `FileViewerModal` had no dependency on collapse state
- Added an `onToggleCollapse` callback to `DiffViewer` and `FileDiff` that bumps a `collapseRevision` counter in `FileViewerModal` — the effect now re-runs on both expand and collapse, correctly wiring up or tearing down the observer

Resolves #10013

## Changes

- `FileViewerModal.tsx`: adds `collapseRevision` state and wires it as a dependency of the hunk-counting effect; passes `onToggleCollapse` down to `DiffViewer`
- `DiffViewer.tsx`: accepts and forwards `onToggleCollapse`; fires it whenever a file diff is toggled inside `FileDiff`
- `FileViewerModal.test.tsx`: regression tests for collapsed→expand (indicator appears) and expand→collapse (indicator clears)
- `DiffViewer.test.tsx`: verifies `onToggleCollapse` fires exactly once per transition

## Testing

All 80 tests pass. `npm run check` clean. Manually verified on a `package-lock.json` diff and a large (>256KB) diff — indicator and free-scroll tracking now work correctly after expanding.