### PR TITLE
fix(eslint): require each test.skip() to carry its own annotation

### DIFF
--- a/scripts/eslint-rules/structured-test-skip-annotations.js
+++ b/scripts/eslint-rules/structured-test-skip-annotations.js
@@ -124,17 +124,15 @@ function isStaticSkipDeclaration(node) {
 }
 
 /**
- * Walk backward through the block body statements before `skipIndex` and
- * collect every annotation-push call.
+ * Returns the annotation from the statement immediately preceding `skipIndex`,
+ * or null when that statement is not an annotation push. The push must be the
+ * direct predecessor so that each test.skip() carries its own annotation — a
+ * backward scan would let a later skip borrow an earlier skip's annotation.
  */
 function findPrecedingAnnotation(body, skipIndex) {
-  for (let i = skipIndex - 1; i >= 0; i--) {
-    const stmt = body[i];
-    if (isAnnotationPush(stmt)) {
-      return extractAnnotation(stmt);
-    }
-  }
-  return null;
+  if (skipIndex <= 0) return null;
+  const prev = body[skipIndex - 1];
+  return isAnnotationPush(prev) ? extractAnnotation(prev) : null;
 }
 
 export default {

--- a/scripts/eslint-rules/structured-test-skip-annotations.test.mjs
+++ b/scripts/eslint-rules/structured-test-skip-annotations.test.mjs
@@ -112,5 +112,19 @@ ruleTester.run("structured-test-skip-annotations", rule, {
       `,
       errors: [{ messageId: "quarantineMissingDate" }],
     },
+    {
+      name: "static skip declaration with no annotation in details",
+      code: `
+        test.skip("static one", async () => {});
+      `,
+      errors: [{ messageId: "missingAnnotation" }],
+    },
+    {
+      name: "static skip quarantine annotation missing the YYYY-MM-DD prefix",
+      code: `
+        test.skip("static one", { annotation: { type: "quarantine", description: "flaky on CI" } }, async () => {});
+      `,
+      errors: [{ messageId: "quarantineMissingDate" }],
+    },
   ],
 });

--- a/scripts/eslint-rules/structured-test-skip-annotations.test.mjs
+++ b/scripts/eslint-rules/structured-test-skip-annotations.test.mjs
@@ -1,0 +1,116 @@
+import { RuleTester } from "eslint";
+import { describe, it } from "vitest";
+
+import rule from "./structured-test-skip-annotations.js";
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+const ruleTester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022 },
+});
+
+ruleTester.run("structured-test-skip-annotations", rule, {
+  valid: [
+    {
+      name: "single annotation immediately before skip",
+      code: `
+        test("a", async () => {
+          test.info().annotations.push({ type: "platform-skip", description: "linux only" });
+          test.skip();
+        });
+      `,
+    },
+    {
+      name: "two consecutive annotation+skip pairs each carry their own annotation",
+      code: `
+        test("a", async () => {
+          test.info().annotations.push({ type: "platform-skip", description: "linux only" });
+          test.skip();
+          test.info().annotations.push({ type: "conditional-skip", description: "needs api key" });
+          test.skip();
+        });
+      `,
+    },
+    {
+      name: "static skip declaration with details.annotation is untouched",
+      code: `
+        test.skip("static one", { annotation: { type: "platform-skip", description: "win only" } }, async () => {});
+      `,
+    },
+    {
+      name: "quarantine annotation with a dated description",
+      code: `
+        test("a", async () => {
+          test.info().annotations.push({ type: "quarantine", description: "2026-01-15 flaky on CI" });
+          test.skip();
+        });
+      `,
+    },
+    {
+      name: "comments and blank lines between annotation and skip are allowed",
+      code: `
+        test("a", async () => {
+          test.info().annotations.push({ type: "platform-skip", description: "linux only" });
+
+          // skip on non-linux
+          test.skip();
+        });
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: "skip with no preceding annotation",
+      code: `
+        test("a", async () => {
+          test.skip();
+        });
+      `,
+      errors: [{ messageId: "missingAnnotation" }],
+    },
+    {
+      name: "second skip borrows the first skip's annotation (the bug)",
+      code: `
+        test("a", async () => {
+          test.info().annotations.push({ type: "platform-skip", description: "linux only" });
+          test.skip();
+          test.skip();
+        });
+      `,
+      errors: [{ messageId: "missingAnnotation" }],
+    },
+    {
+      name: "intervening helper statement between annotation and skip",
+      code: `
+        test("a", async () => {
+          test.info().annotations.push({ type: "platform-skip", description: "linux only" });
+          doSomething();
+          test.skip();
+        });
+      `,
+      errors: [{ messageId: "missingAnnotation" }],
+    },
+    {
+      name: "annotation type not in the allowed set",
+      code: `
+        test("a", async () => {
+          test.info().annotations.push({ type: "flakey", description: "sometimes fails" });
+          test.skip();
+        });
+      `,
+      errors: [{ messageId: "invalidType" }],
+    },
+    {
+      name: "quarantine annotation missing the YYYY-MM-DD prefix",
+      code: `
+        test("a", async () => {
+          test.info().annotations.push({ type: "quarantine", description: "flaky on CI" });
+          test.skip();
+        });
+      `,
+      errors: [{ messageId: "quarantineMissingDate" }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

- `findPrecedingAnnotation` scanned backward through an entire block and returned the first annotation push it found, so a second `test.skip()` could borrow the annotation belonging to a previous one — lint stayed green even when the wrong quarantine metadata applied
- Fixed by only accepting the annotation as the immediately-preceding statement (`body[skipIndex - 1]`)
- Added a regression suite in `scripts/eslint-rules/structured-test-skip-annotations.test.mjs` covering 12 cases (valid and invalid, including the two-skips-one-annotation scenario from the issue)

Resolves #10041

## Changes

- `scripts/eslint-rules/structured-test-skip-annotations.js` — tightened `findPrecedingAnnotation` to only match the statement directly before the skip
- `scripts/eslint-rules/structured-test-skip-annotations.test.mjs` — new RuleTester/Vitest file with 12 cases

## Testing

Blast radius is zero — all existing e2e specs already place the annotation directly before each `test.skip()`. The static-skip path is untouched. New test file covers the regression case explicitly.