### PR TITLE
fix(fleet): align broadcast preview unresolved-var detection with recipes

### DIFF
--- a/src/components/Fleet/__tests__/fleetExecution.test.ts
+++ b/src/components/Fleet/__tests__/fleetExecution.test.ts
@@ -666,5 +666,39 @@ describe("buildFleetTargetPreviews", () => {
       expect(previews[0]?.unresolvedVars).toEqual([]);
       expect(previews[0]?.resolvedPayload).toBe("see #9954");
     });
+
+    it("resolves {{number}} from prNumber when only a PR number is set", () => {
+      armOneEligible({ prNumber: 42 });
+      const previews = buildFleetTargetPreviews("see {{number}}");
+      expect(previews[0]?.unresolvedVars).toEqual([]);
+      expect(previews[0]?.resolvedPayload).toBe("see #42");
+    });
+
+    it("keeps warning and payload in agreement for mixed resolved/unknown drafts", () => {
+      // The original bug was a warning/payload disagreement, so both sides
+      // must be asserted together: the known var resolves, the unknown one
+      // stays literal, and neither shows up as unresolved.
+      armOneEligible({ branchName: "main" });
+      const previews = buildFleetTargetPreviews("{{branch_name}} {{foo}}");
+      expect(previews[0]?.unresolvedVars).toEqual([]);
+      expect(previews[0]?.resolvedPayload).toBe("main {{foo}}");
+    });
+
+    it("routes each target's own context (no cross-target context bleed)", () => {
+      seedPanels([makeAgent("t1"), makeAgent("t2")]);
+      useFleetArmingStore.getState().armIds(["t1", "t2"]);
+      buildFleetBroadcastRecipeContextMock.mockImplementation((id: string) =>
+        id === "t1" ? { branchName: "main" } : {}
+      );
+
+      const previews = buildFleetTargetPreviews("on {{branch_name}}");
+      const t1 = previews.find((p) => p.terminalId === "t1");
+      const t2 = previews.find((p) => p.terminalId === "t2");
+      expect(t1?.unresolvedVars).toEqual([]);
+      expect(t1?.resolvedPayload).toBe("on main");
+      expect(t2?.unresolvedVars).toEqual(["branch_name"]);
+      expect(buildFleetBroadcastRecipeContextMock).toHaveBeenCalledWith("t1");
+      expect(buildFleetBroadcastRecipeContextMock).toHaveBeenCalledWith("t2");
+    });
   });
 });

--- a/src/components/Fleet/__tests__/fleetExecution.test.ts
+++ b/src/components/Fleet/__tests__/fleetExecution.test.ts
@@ -12,10 +12,23 @@ import { usePanelStore } from "@/store/panelStore";
 import { useFleetBroadcastProgressStore } from "@/store/fleetBroadcastProgressStore";
 import type { PtyPanelData, PanelInstance } from "@shared/types/panel";
 
+import type { RecipeContext } from "@/utils/recipeVariables";
+
 const submitMock = vi.fn<(id: string, text: string) => Promise<void>>();
 const notifyUserInputMock = vi.hoisted(() => vi.fn<(id: string, data?: string) => void>());
 const notifyEnterPressedMock = vi.hoisted(() => vi.fn<(id: string) => void>());
 const clearDirectingStateMock = vi.hoisted(() => vi.fn<(id: string) => void>());
+const buildFleetBroadcastRecipeContextMock = vi.hoisted(() =>
+  vi.fn<(id: string) => RecipeContext | undefined>()
+);
+
+vi.mock("../fleetBroadcast", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../fleetBroadcast")>();
+  return {
+    ...actual,
+    buildFleetBroadcastRecipeContext: buildFleetBroadcastRecipeContextMock,
+  };
+});
 
 vi.mock("@/clients", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/clients")>();
@@ -78,6 +91,8 @@ function reset() {
   notifyUserInputMock.mockReset();
   notifyEnterPressedMock.mockReset();
   clearDirectingStateMock.mockReset();
+  buildFleetBroadcastRecipeContextMock.mockReset();
+  buildFleetBroadcastRecipeContextMock.mockReturnValue({});
   useFleetArmingStore.setState({
     armedIds: new Set<string>(),
     armOrder: [],
@@ -608,5 +623,48 @@ describe("buildFleetTargetPreviews", () => {
     const ghost = previews.find((p) => p.terminalId === "ghost");
     expect(ghost?.excluded).toBe(true);
     expect(ghost?.title).toBe("Unknown");
+  });
+
+  describe("unresolved-variable detection (#9954)", () => {
+    function armOneEligible(ctx: RecipeContext) {
+      seedPanels([makeAgent("t1")]);
+      useFleetArmingStore.getState().armIds(["t1"]);
+      buildFleetBroadcastRecipeContextMock.mockReturnValue(ctx);
+    }
+
+    it("does NOT flag unknown placeholders that recipes leave literal", () => {
+      // The root cause: the fleet preview must match the actual sent payload.
+      // `replaceRecipeVariables` leaves `{{foo}}` literal, so the preview must
+      // not warn about it — the warning and the payload have to agree.
+      armOneEligible({});
+      const previews = buildFleetTargetPreviews("hello {{foo}}");
+      expect(previews[0]?.unresolvedVars).toEqual([]);
+      expect(previews[0]?.resolvedPayload).toBe("hello {{foo}}");
+    });
+
+    it("flags a known variable with no value in context", () => {
+      armOneEligible({});
+      const previews = buildFleetTargetPreviews("on {{branch_name}}");
+      expect(previews[0]?.unresolvedVars).toEqual(["branch_name"]);
+    });
+
+    it("flags only the known-missing var in a mixed known/unknown draft", () => {
+      armOneEligible({});
+      const previews = buildFleetTargetPreviews("{{branch_name}} {{foo}}");
+      expect(previews[0]?.unresolvedVars).toEqual(["branch_name"]);
+    });
+
+    it("flags {{number}} when neither issue nor PR number is set", () => {
+      armOneEligible({});
+      const previews = buildFleetTargetPreviews("see {{number}}");
+      expect(previews[0]?.unresolvedVars).toEqual(["number"]);
+    });
+
+    it("resolves {{number}} from issueNumber and reports no unresolved vars", () => {
+      armOneEligible({ issueNumber: 9954 });
+      const previews = buildFleetTargetPreviews("see {{number}}");
+      expect(previews[0]?.unresolvedVars).toEqual([]);
+      expect(previews[0]?.resolvedPayload).toBe("see #9954");
+    });
   });
 });

--- a/src/components/Fleet/fleetExecution.ts
+++ b/src/components/Fleet/fleetExecution.ts
@@ -5,7 +5,7 @@ import { terminalClient } from "@/clients";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { isTerminalFleetEligible } from "@/store/fleetEligibility";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
-import { replaceRecipeVariables, type RecipeContext } from "@/utils/recipeVariables";
+import { replaceRecipeVariables, detectUnresolvedVariables } from "@/utils/recipeVariables";
 import {
   buildFleetBroadcastRecipeContext,
   classifyFleetRejectionReason,
@@ -65,7 +65,7 @@ export function buildFleetTargetPreviews(draft: string): FleetTargetPreview[] {
     if (isTerminalFleetEligible(panel)) {
       const ctx = buildFleetBroadcastRecipeContext(id) ?? {};
       const resolved = replaceRecipeVariables(draft, ctx);
-      const unresolvedVars = detectUnresolved(draft, ctx);
+      const unresolvedVars = detectUnresolvedVariables(draft, ctx);
 
       previews.push({
         terminalId: id,
@@ -89,22 +89,6 @@ export function buildFleetTargetPreviews(draft: string): FleetTargetPreview[] {
   return previews;
 }
 
-function detectUnresolved(text: string, ctx: RecipeContext): string[] {
-  const VARIABLE_PATTERN = /\{\{(\w+)\}\}/gi;
-  const unresolved: string[] = [];
-  const seen = new Set<string>();
-  let match: RegExpExecArray | null;
-  const pattern = new RegExp(VARIABLE_PATTERN.source, VARIABLE_PATTERN.flags);
-  while ((match = pattern.exec(text)) !== null) {
-    const name = match[1]!.toLowerCase();
-    if (seen.has(name)) continue;
-    seen.add(name);
-    const resolved = resolveVariable(name, ctx);
-    if (resolved === "") unresolved.push(name);
-  }
-  return unresolved;
-}
-
 /**
  * Drop ids whose backing panel is no longer fleet-eligible (trashed,
  * backgrounded, no PTY, etc.). Exported so the Enter-broadcast confirm
@@ -114,25 +98,6 @@ function detectUnresolved(text: string, ctx: RecipeContext): string[] {
 export function filterEligibleIds(ids: string[]): string[] {
   const { panelsById } = usePanelStore.getState();
   return ids.filter((id) => isTerminalFleetEligible(getNarrowPanel(panelsById, id)));
-}
-
-function resolveVariable(name: string, ctx: RecipeContext): string {
-  switch (name) {
-    case "issue_number":
-      return ctx.issueNumber != null ? `#${ctx.issueNumber}` : "";
-    case "pr_number":
-      return ctx.prNumber != null ? `#${ctx.prNumber}` : "";
-    case "number": {
-      const num = ctx.issueNumber ?? ctx.prNumber;
-      return num != null ? `#${num}` : "";
-    }
-    case "worktree_path":
-      return ctx.worktreePath ?? "";
-    case "branch_name":
-      return ctx.branchName ?? "";
-    default:
-      return "";
-  }
 }
 
 interface ResolvedSubmission {


### PR DESCRIPTION
## Summary

- The fleet broadcast preview was flagging unknown template placeholders (e.g. `{{foo}}`) as unresolved, but the actual send path via `replaceRecipeVariables` leaves them literal — so the warning disagreed with both the payload and the recipe surfaces
- Replaced the private `detectUnresolved`/`resolveVariable` pair in `fleetExecution.ts` with the canonical `detectUnresolvedVariables` from `recipeVariables.ts`, which was already imported — the same helper `useRecipeRunner` and `RecipeVariablePreview` use
- Removed the dead private helpers and a now-unused `RecipeContext` import; added regression tests covering unknown vars, known-missing vars, mixed drafts, per-target context routing, and the `{{number}}` alias

Resolves #9954

## Changes

- `src/components/Fleet/fleetExecution.ts`: drop `detectUnresolved`, `resolveVariable`, and dead `RecipeContext` import; call `detectUnresolvedVariables` directly
- `src/components/Fleet/__tests__/fleetExecution.test.ts`: five new regression cases on the unresolved-var path

## Testing

All 41 `fleetExecution` tests pass. `npm run check` clean — lint ratchet down by 1.