### PR TITLE
fix(activity-monitor): remove dead OSC 9;4 idle timer, document as advisory

### DIFF
--- a/docs/architecture/agent-activity-monitoring.md
+++ b/docs/architecture/agent-activity-monitoring.md
@@ -70,10 +70,10 @@ Spinner and time-counter frames are activity evidence. Cosmetic-only frames can 
 State codes follow the de-facto ConEmu spec that Claude Code adopted (v2.0.56):
 
 - `1` (normal/determinate) and `3` (indeterminate) mean working;
-- `0` (remove/hide) is emitted between every tool call, so the idle path is debounced (200ms) — any working state inside that window cancels it;
+- `0` (remove/hide) is emitted between every tool call, so it is treated as advisory only — `onOscProgressIdle` is a deliberate no-op; real idle comes from natural `lastActivityTimestamp` decay through the 8s gate;
 - `2` (error) and `4` (paused) are ignored — there is no matching agent state.
 
-The parser is a read-only side channel. `IdleSequenceFilter.stripIdleTerminalSequences` still removes the sequence from the byte-volume and renderer-bound paths downstream, so other detectors stay clean. `onOscProgressWorking` acts as a heartbeat: it refreshes the working hold without bypassing focus suppression or the `MAX_WORKING_SILENCE_MS` safety net.
+The parser is a read-only side channel. `IdleSequenceFilter.stripIdleTerminalSequences` still removes the sequence from the ActivityMonitor byte-volume / activity-gate path, so those detectors stay clean (the renderer keeps the raw bytes and renders the progress bar). `onOscProgressWorking` acts as a heartbeat: it refreshes the working hold without bypassing focus suppression or the `MAX_WORKING_SILENCE_MS` safety net.
 
 ### Visible-Tail Temperature Layer
 

--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -48,12 +48,6 @@ const COMPLETION_HOLD_MS = 500;
 const WORKING_INDICATOR_TTL_MS = 5000;
 const CPU_HIGH_THRESHOLD = 10;
 const CPU_LOW_THRESHOLD = 3;
-// Claude Code emits OSC 9;4 state=0 between every tool call (the "remove
-// progress" marker). Without debouncing, a brief state=0 → state=1 flicker
-// would act on idle prematurely. 200ms is comfortably above Claude's
-// inter-tool gap upper bound and well under the 8s IDLE_DEBOUNCE_MS, so it
-// suppresses flicker without delaying real idle detection.
-const OSC_IDLE_DEBOUNCE_MS = 200;
 
 export interface ProcessStateValidator {
   hasActiveChildren(): boolean;
@@ -144,7 +138,6 @@ export class ActivityMonitor {
   private state: "busy" | "idle" = "idle";
   private isDisposed = false;
   private debounceTimer: NodeJS.Timeout | null = null;
-  private oscIdleTimer: NodeJS.Timeout | null = null;
   private readonly IDLE_DEBOUNCE_MS: number;
   private readonly PROMPT_FAST_PATH_MIN_QUIET_MS: number;
   private readonly MAX_WORKING_SILENCE_MS: number;
@@ -784,10 +777,6 @@ export class ActivityMonitor {
       clearTimeout(this.debounceTimer);
       this.debounceTimer = null;
     }
-    if (this.oscIdleTimer) {
-      clearTimeout(this.oscIdleTimer);
-      this.oscIdleTimer = null;
-    }
     this.completionTimer.dispose();
     this.inputTracker.reset();
     this.outputVolumeDetector.reset();
@@ -858,10 +847,6 @@ export class ActivityMonitor {
   // untouched — this is a heartbeat, not a permanent hold (lesson #4974).
   onOscProgressWorking(now: number = Date.now()): void {
     if (this.isDisposed) return;
-    if (this.oscIdleTimer) {
-      clearTimeout(this.oscIdleTimer);
-      this.oscIdleTimer = null;
-    }
     this.lastActivityTimestamp = now;
     this.lastDataTimestamp = now;
     if (this.state !== "busy") {
@@ -876,25 +861,18 @@ export class ActivityMonitor {
     this.resetDebounceTimer();
   }
 
-  // OSC 9;4 state=0 (#8701). Claude Code emits this between every tool call,
-  // not just on completion, so the signal needs a 200ms debounce: any state=1/3
-  // arriving inside that window cancels the timer (handled in
-  // `onOscProgressWorking` above). Once the debounce elapses without
-  // interruption, the OSC heartbeat has truly stopped — but we do NOT force
-  // idle here. The existing `lastActivityTimestamp`-driven idle path in the
-  // simpleOutputState polling cycle (line 893) takes over via natural decay
-  // (working signals stop refreshing the timestamp, so the 8s gate eventually
-  // fires). Mutating `workingHoldUntil` directly here would risk clobbering
-  // holds set by other signal paths.
+  // OSC 9;4 state=0 (#8701). Intentionally advisory — a no-op by design.
+  // Claude Code emits state=0 between every tool call, not just on completion,
+  // so it cannot be an authoritative idle trigger: forcing idle here would
+  // flicker working→idle→working on every tool boundary. We deliberately do
+  // not act on it (and in particular do not mutate `workingHoldUntil`, which
+  // would risk clobbering holds set by other signal paths). Real idle is left
+  // to the `lastActivityTimestamp`-driven gate in the simpleOutputState polling
+  // cycle: once working signals (OSC state=1/3 or output) stop refreshing the
+  // timestamp, the 8s IDLE_DEBOUNCE_MS gate fires via natural decay. The method
+  // is kept as the documented sink for `Osc94Parser`'s onIdle callback.
   onOscProgressIdle(_now: number = Date.now()): void {
     if (this.isDisposed) return;
-    if (this.oscIdleTimer) {
-      clearTimeout(this.oscIdleTimer);
-    }
-    this.oscIdleTimer = setTimeout(() => {
-      this.oscIdleTimer = null;
-    }, OSC_IDLE_DEBOUNCE_MS);
-    this.oscIdleTimer.unref?.();
   }
 
   notifyResize(suppressionMs = 500): void {

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -5560,7 +5560,7 @@ describe("ActivityMonitor", () => {
       monitor.dispose();
     });
 
-    it("debounces idle: a working signal within 200ms cancels the pending idle timer", () => {
+    it("OSC idle is advisory: a later working signal keeps the monitor busy", () => {
       vi.setSystemTime(3000);
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("osc-debounce", 100, onStateChange, {
@@ -5572,11 +5572,11 @@ describe("ActivityMonitor", () => {
       });
 
       monitor.onOscProgressWorking(3000);
+      // OSC idle is advisory (a no-op); it never arms a timer or forces idle.
       monitor.onOscProgressIdle(3050);
-      // Working arrives well inside the 200ms debounce window.
       vi.setSystemTime(3100);
       monitor.onOscProgressWorking(3100);
-      // Advance past the original 200ms window — no idle should fire.
+      // Advance well past any former debounce window — state stays busy.
       vi.advanceTimersByTime(300);
 
       expect(monitor.getState()).toBe("busy");
@@ -5600,11 +5600,11 @@ describe("ActivityMonitor", () => {
       monitor.onOscProgressIdle(4010);
       vi.advanceTimersByTime(199);
 
-      // Under the 200ms debounce, no transition fires (and nothing else has).
+      // OSC idle is a no-op — no transition fires (and nothing else has).
       expect(monitor.getState()).toBe("busy");
       expect(onStateChange).not.toHaveBeenCalled();
 
-      // After the debounce fires, state is still busy — OSC idle is advisory.
+      // Advancing time changes nothing — OSC idle is advisory.
       vi.advanceTimersByTime(2);
       expect(monitor.getState()).toBe("busy");
 
@@ -5668,7 +5668,7 @@ describe("ActivityMonitor", () => {
       monitor.onOscProgressIdle(15050);
       onStateChange.mockClear();
 
-      // Cross the 200ms OSC debounce — no transition yet (advisory only).
+      // OSC idle is advisory (a no-op) — no transition fires.
       vi.advanceTimersByTime(201);
       expect(monitor.getState()).toBe("busy");
 
@@ -5680,7 +5680,7 @@ describe("ActivityMonitor", () => {
       monitor.dispose();
     });
 
-    it("dispose() while an OSC idle timer is pending does not throw", () => {
+    it("dispose() after onOscProgressIdle does not throw", () => {
       vi.setSystemTime(6000);
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("osc-dispose", 100, onStateChange, {
@@ -5688,9 +5688,9 @@ describe("ActivityMonitor", () => {
       });
 
       monitor.onOscProgressIdle(6000);
-      // Don't advance — leave the timer pending.
+      // onOscProgressIdle is a no-op; there is no timer to leave pending.
       expect(() => monitor.dispose()).not.toThrow();
-      // Advancing afterwards must not throw either (timer cleared).
+      // Advancing afterwards must not throw either.
       expect(() => vi.advanceTimersByTime(500)).not.toThrow();
     });
 

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -5611,6 +5611,36 @@ describe("ActivityMonitor", () => {
       monitor.dispose();
     });
 
+    it("OSC idle does not mutate activity timestamps — advisory no-op contract", () => {
+      // Guards the advisory contract: state=0 must leave the natural-decay
+      // inputs untouched. A future change that refreshes (or zeroes) these on
+      // idle receipt would silently shift when the 8s gate fires.
+      vi.setSystemTime(8000);
+      const monitor = new ActivityMonitor("osc-idle-no-mutate", 100, vi.fn(), {
+        agentId: "claude",
+        initialState: "busy",
+        skipInitialStateEmit: true,
+      });
+
+      type MonitorInternals = {
+        lastActivityTimestamp: number;
+        lastDataTimestamp: number;
+      };
+      const internals = monitor as unknown as MonitorInternals;
+
+      monitor.onOscProgressWorking(8000);
+      const activityTs = internals.lastActivityTimestamp;
+      const dataTs = internals.lastDataTimestamp;
+
+      vi.setSystemTime(8500);
+      monitor.onOscProgressIdle(8500);
+
+      expect(internals.lastActivityTimestamp).toBe(activityTs);
+      expect(internals.lastDataTimestamp).toBe(dataTs);
+
+      monitor.dispose();
+    });
+
     it("respects MAX_WORKING_SILENCE_MS — OSC working does not bypass the safety timeout (#4974 regression)", () => {
       // Bug #4974: a working signal that never decays leaves the agent stuck.
       // The OSC heartbeat must refresh `lastDataTimestamp` like real output, so

--- a/electron/services/pty/IdleSequenceFilter.ts
+++ b/electron/services/pty/IdleSequenceFilter.ts
@@ -17,7 +17,7 @@
 // maxBytesPerFrame cap is the secondary defense for those cases.
 //
 // `?2026h` / `?2026l` (DEC mode 2026 — Synchronized Output) is stripped here
-// for the renderer-bound and byte-volume paths, but the headless terminal in
+// for the byte-volume / activity-gate path, but the headless terminal in
 // TerminalProcess writes the raw PTY data straight through, which lets
 // SynchronizedFrameDetector hook xterm's parser for frame-close events
 // (#6668). Removing 2026 from this list would re-introduce the false-positive

--- a/electron/services/pty/Osc94Parser.ts
+++ b/electron/services/pty/Osc94Parser.ts
@@ -11,7 +11,8 @@
 // OSC 9;4 format: `\x1b]9;4;<state>;<progress>\x07` or terminated by ST
 // (`\x1b\\`). State codes (from the de-facto Windows ConEmu spec that Claude
 // Code adopted in v2.0.56):
-//   0 — remove/hide (between tool calls; debounced in `ActivityMonitor`)
+//   0 — remove/hide (between tool calls; advisory only — `onOscProgressIdle`
+//       is a deliberate no-op in `ActivityMonitor`)
 //   1 — normal/determinate (working, percent follows)
 //   2 — error
 //   3 — indeterminate (working, no percent)

--- a/electron/services/pty/Osc94Parser.ts
+++ b/electron/services/pty/Osc94Parser.ts
@@ -3,9 +3,10 @@
 // react to a viewport-independent signal — the existing simpleOutputState path
 // only sees N visible terminal lines, which starves detection in small grid
 // tiles. This parser is read-only; the OSC_NOISE stripper in
-// `IdleSequenceFilter` still removes the sequence from the renderer-bound and
-// byte-volume paths so downstream detectors stay clean (the strip-on-success
-// invariant is the same one `OscResponder` follows for OSC 10/11).
+// `IdleSequenceFilter` still removes the sequence from the ActivityMonitor
+// byte-volume / activity-gate path so those detectors stay clean (the
+// renderer receives the raw bytes and renders the progress bar). The
+// strip-on-success invariant is the same one `OscResponder` follows for OSC 10/11.
 //
 // OSC 9;4 format: `\x1b]9;4;<state>;<progress>\x07` or terminated by ST
 // (`\x1b\\`). State codes (from the de-facto Windows ConEmu spec that Claude

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1595,8 +1595,9 @@ export class TerminalProcess {
     // Tap OSC 9;4 progress sequences upstream of the rest of the pipeline so
     // the agent-state signal is viewport-independent (#8701). The parser is
     // a read-only side channel; `IdleSequenceFilter.stripIdleTerminalSequences`
-    // still removes the sequence from the byte-volume / renderer paths
-    // downstream, so other detectors stay clean.
+    // still removes the sequence from the ActivityMonitor byte-volume /
+    // activity-gate path, so those detectors stay clean (the renderer keeps
+    // the raw bytes — see TerminalProcess.osc.test.ts).
     this.osc94Parser.feed(data, now);
 
     if (this.activityMonitor) {


### PR DESCRIPTION
## Summary

Fixes a dead code path in `ActivityMonitor` where the OSC 9;4 idle signal was parsed and routed to `onOscProgressIdle`, but the 200ms debounce timer the handler managed was completely inert. The expiry callback only nulled its own handle — nothing ever checked whether the timer was pending. The handler was a behavioural no-op. This takes Option 1 from the issue: delete the dead timer machinery and document `onOscProgressIdle` as intentionally advisory. Real idle still comes from `lastActivityTimestamp` natural decay through the 8s `IDLE_DEBOUNCE_MS` gate. (Option 2 — feeding the elapsed debounce into decay/completion — was rejected because `state=0` fires between every tool call, so acting on it authoritatively would flicker working→idle→working and risk clobbering `workingHoldUntil`.)

Closes #9866

## Changes

- Removed `OSC_IDLE_DEBOUNCE_MS`, the `oscIdleTimer` field, two `clearTimeout` blocks, and the no-op `setTimeout` body from `ActivityMonitor.ts`. `onOscProgressIdle` is now an `isDisposed`-guarded no-op with a comment documenting the advisory contract. The method is kept because `Osc94Parser`'s `onIdle` callback needs a sink. `onOscProgressWorking` is untouched apart from dropping the dead timer clear.
- Corrected stale comments in four places (`Osc94Parser.ts` header + state table, `TerminalProcess.ts` tap comment, `IdleSequenceFilter.ts` DEC-2026 paragraph, `docs/architecture/agent-activity-monitoring.md`) that claimed `stripIdleTerminalSequences` strips idle sequences from the renderer. It doesn't — the renderer receives raw bytes, as asserted by `TerminalProcess.osc.test.ts`.
- Reworded OSC idle tests that referenced the removed timer to advisory-no-op framing and added a regression test asserting `onOscProgressIdle` does not mutate `lastActivityTimestamp` or `lastDataTimestamp`.

## Testing

`npm run check` (typecheck + lint + format + channel/IPC/confirm-wiring guards) all green; lint ratchet decreased by 1. Targeted vitest: `ActivityMonitor.test.ts` 208 tests pass, `TerminalProcess.osc.test.ts` 22 tests pass. Behaviour is unchanged — the removed timer never had a downstream effect.