### PR TITLE
fix(theme): make accent override low-contrast warning actionable

### DIFF
--- a/shared/theme/__tests__/contrast.test.ts
+++ b/shared/theme/__tests__/contrast.test.ts
@@ -530,20 +530,60 @@ describe("accentOverrideHasLowContrast", () => {
     const result = accentOverrideHasLowContrast(scheme);
     assert(result !== null);
     expect(result.mode).toBe("foreground");
+    // The foreground branch must not leak a surface key, and the reported ratio
+    // must be the foreground pair's ratio — not whichever surface scored worst.
+    expect(result.worstSurface).toBeNull();
+    expect(result.worstRatio).toBeCloseTo(contrastRatio("#a4a4a4", "#aaaaaa"), 5);
   });
 
-  it("does not flag when every contrast pair clears the 4.5:1 boundary", () => {
-    // Black accent + white foreground on white surfaces: foreground ~21:1, surfaces ~21:1.
+  it("returns the foreground failure mode when a non-hex accent-foreground is paired with a failing surface", () => {
+    // Non-hex foreground skips the foreground branch; a low-contrast surface then governs.
     const scheme = makeScheme({
-      "accent-primary": "#000000" as AppColorSchemeTokens["accent-primary"],
-      "accent-foreground": "#ffffff" as AppColorSchemeTokens["accent-foreground"],
-      "surface-grid": "#ffffff" as AppColorSchemeTokens["surface-grid"],
-      "surface-sidebar": "#ffffff" as AppColorSchemeTokens["surface-sidebar"],
-      "surface-canvas": "#ffffff" as AppColorSchemeTokens["surface-canvas"],
-      "surface-panel": "#ffffff" as AppColorSchemeTokens["surface-panel"],
-      "surface-panel-elevated": "#ffffff" as AppColorSchemeTokens["surface-panel-elevated"],
+      "accent-primary": "#ffffff" as AppColorSchemeTokens["accent-primary"],
+      "accent-foreground": "oklch(0.5 0.1 200)" as AppColorSchemeTokens["accent-foreground"],
+      "surface-grid": "#fdfdfd" as AppColorSchemeTokens["surface-grid"],
+      "surface-sidebar": "#fdfdfd" as AppColorSchemeTokens["surface-sidebar"],
+      "surface-canvas": "#fdfdfd" as AppColorSchemeTokens["surface-canvas"],
+      "surface-panel": "#fdfdfd" as AppColorSchemeTokens["surface-panel"],
+      "surface-panel-elevated": "#fdfdfd" as AppColorSchemeTokens["surface-panel-elevated"],
     });
-    expect(accentOverrideHasLowContrast(scheme)).toBeNull();
+    const result = accentOverrideHasLowContrast(scheme);
+    assert(result !== null);
+    // Foreground skipped (non-hex) → surface branch reports the near-white-on-white failure.
+    expect(result.mode).toBe("surface");
+    expect(result.worstRatio).toBeLessThan(4.5);
+    expect(result.worstSurface).not.toBeNull();
+  });
+
+  it("treats the 4.5:1 gate as strict — passes just above, fails just below", () => {
+    // WCAG reference greys on white: #767676 = 4.54:1 (clears), #777777 = 4.48:1 (fails).
+    // Surfaces are black so the surface branch never fires; the foreground gate governs.
+    const baseSurfaces = {
+      "surface-grid": "#000000",
+      "surface-sidebar": "#000000",
+      "surface-canvas": "#000000",
+      "surface-panel": "#000000",
+      "surface-panel-elevated": "#000000",
+    } as Partial<AppColorSchemeTokens>;
+
+    const justAbove = makeScheme({
+      "accent-primary": "#ffffff" as AppColorSchemeTokens["accent-primary"],
+      "accent-foreground": "#767676" as AppColorSchemeTokens["accent-foreground"],
+      ...baseSurfaces,
+    });
+    // Sanity-check the fixtures straddle the boundary so the test stays meaningful.
+    expect(contrastRatio("#767676", "#ffffff")).toBeGreaterThanOrEqual(4.5);
+    expect(accentOverrideHasLowContrast(justAbove)).toBeNull();
+
+    const justBelow = makeScheme({
+      "accent-primary": "#ffffff" as AppColorSchemeTokens["accent-primary"],
+      "accent-foreground": "#777777" as AppColorSchemeTokens["accent-foreground"],
+      ...baseSurfaces,
+    });
+    expect(contrastRatio("#777777", "#ffffff")).toBeLessThan(4.5);
+    const result = accentOverrideHasLowContrast(justBelow);
+    assert(result !== null);
+    expect(result.mode).toBe("foreground");
   });
 
   it("skips the foreground pair when accent-foreground is non-hex but still checks surfaces", () => {

--- a/shared/theme/__tests__/contrast.test.ts
+++ b/shared/theme/__tests__/contrast.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { assert, describe, expect, it } from "vitest";
 import {
   accentOverrideHasLowContrast,
   contrastRatio,
@@ -449,17 +449,22 @@ describe("accentOverrideHasLowContrast", () => {
 
   it("flags a white accent override on a light theme (invisible on light surfaces)", () => {
     const patched = applyAccentOverrideToScheme(lightScheme, "#ffffff");
-    expect(accentOverrideHasLowContrast(patched)).toBe(true);
+    const result = accentOverrideHasLowContrast(patched);
+    assert(result !== null);
+    // White accent on a light theme has legible button text but vanishes on surfaces.
+    expect(result.mode).toBe("surface");
+    expect(result.worstRatio).toBeLessThan(4.5);
+    expect(result.worstSurface).not.toBeNull();
   });
 
   it("does not flag a white accent override on a dark theme", () => {
     const patched = applyAccentOverrideToScheme(darkScheme, "#ffffff");
-    expect(accentOverrideHasLowContrast(patched)).toBe(false);
+    expect(accentOverrideHasLowContrast(patched)).toBeNull();
   });
 
   it("does not flag a strong dark accent override on a light theme", () => {
     const patched = applyAccentOverrideToScheme(lightScheme, "#1a1a1a");
-    expect(accentOverrideHasLowContrast(patched)).toBe(false);
+    expect(accentOverrideHasLowContrast(patched)).toBeNull();
   });
 
   it("flags via the accent-foreground/accent-primary pair when surfaces are fine", () => {
@@ -474,7 +479,71 @@ describe("accentOverrideHasLowContrast", () => {
       "surface-panel": "#000000" as AppColorSchemeTokens["surface-panel"],
       "surface-panel-elevated": "#000000" as AppColorSchemeTokens["surface-panel-elevated"],
     });
-    expect(accentOverrideHasLowContrast(scheme)).toBe(true);
+    const result = accentOverrideHasLowContrast(scheme);
+    assert(result !== null);
+    // Foreground branch: the offending pair is the near-match label, not a surface.
+    expect(result.mode).toBe("foreground");
+    expect(result.worstRatio).toBeLessThan(4.5);
+    expect(result.worstSurface).toBeNull();
+  });
+
+  it("reports the surface with the worst ratio, not just the first failing one", () => {
+    // Mid-grey accent fails harder against the lighter surface than the darker one;
+    // the scan must surface the lowest ratio and its key, not short-circuit on the first.
+    const scheme = makeScheme({
+      "accent-primary": "#808080" as AppColorSchemeTokens["accent-primary"],
+      "accent-foreground": "#000000" as AppColorSchemeTokens["accent-foreground"],
+      "surface-grid": "#000000" as AppColorSchemeTokens["surface-grid"],
+      "surface-sidebar": "#000000" as AppColorSchemeTokens["surface-sidebar"],
+      "surface-canvas": "#000000" as AppColorSchemeTokens["surface-canvas"],
+      "surface-panel": "#000000" as AppColorSchemeTokens["surface-panel"],
+      "surface-panel-elevated": "#9a9a9a" as AppColorSchemeTokens["surface-panel-elevated"],
+    });
+    const result = accentOverrideHasLowContrast(scheme);
+    assert(result !== null);
+    expect(result.mode).toBe("surface");
+    expect(result.worstSurface).toBe("surface-panel-elevated");
+    // The reported ratio must be the lowest of all surface pairs.
+    const reported = result.worstRatio;
+    for (const key of [
+      "surface-grid",
+      "surface-sidebar",
+      "surface-canvas",
+      "surface-panel",
+      "surface-panel-elevated",
+    ] as const) {
+      expect(reported).toBeLessThanOrEqual(contrastRatio("#808080", scheme.tokens[key]));
+    }
+  });
+
+  it("prioritizes the foreground failure when both modes fail", () => {
+    // Near-match foreground AND a vanishing accent on a same-toned surface: foreground wins.
+    const scheme = makeScheme({
+      "accent-primary": "#aaaaaa" as AppColorSchemeTokens["accent-primary"],
+      "accent-foreground": "#a4a4a4" as AppColorSchemeTokens["accent-foreground"],
+      "surface-grid": "#a8a8a8" as AppColorSchemeTokens["surface-grid"],
+      "surface-sidebar": "#a8a8a8" as AppColorSchemeTokens["surface-sidebar"],
+      "surface-canvas": "#a8a8a8" as AppColorSchemeTokens["surface-canvas"],
+      "surface-panel": "#a8a8a8" as AppColorSchemeTokens["surface-panel"],
+      "surface-panel-elevated": "#a8a8a8" as AppColorSchemeTokens["surface-panel-elevated"],
+    });
+    const result = accentOverrideHasLowContrast(scheme);
+    assert(result !== null);
+    expect(result.mode).toBe("foreground");
+  });
+
+  it("does not flag when every contrast pair clears the 4.5:1 boundary", () => {
+    // Black accent + white foreground on white surfaces: foreground ~21:1, surfaces ~21:1.
+    const scheme = makeScheme({
+      "accent-primary": "#000000" as AppColorSchemeTokens["accent-primary"],
+      "accent-foreground": "#ffffff" as AppColorSchemeTokens["accent-foreground"],
+      "surface-grid": "#ffffff" as AppColorSchemeTokens["surface-grid"],
+      "surface-sidebar": "#ffffff" as AppColorSchemeTokens["surface-sidebar"],
+      "surface-canvas": "#ffffff" as AppColorSchemeTokens["surface-canvas"],
+      "surface-panel": "#ffffff" as AppColorSchemeTokens["surface-panel"],
+      "surface-panel-elevated": "#ffffff" as AppColorSchemeTokens["surface-panel-elevated"],
+    });
+    expect(accentOverrideHasLowContrast(scheme)).toBeNull();
   });
 
   it("skips the foreground pair when accent-foreground is non-hex but still checks surfaces", () => {
@@ -489,14 +558,14 @@ describe("accentOverrideHasLowContrast", () => {
       "surface-panel-elevated": "#000000" as AppColorSchemeTokens["surface-panel-elevated"],
     });
     // White accent on black surfaces is high-contrast → no warning despite non-hex fg.
-    expect(accentOverrideHasLowContrast(scheme)).toBe(false);
+    expect(accentOverrideHasLowContrast(scheme)).toBeNull();
   });
 
   it("does not flag when a non-hex accent-primary cannot be evaluated", () => {
     const scheme = makeScheme({
       "accent-primary": "oklch(0.5 0.1 200)" as AppColorSchemeTokens["accent-primary"],
     });
-    expect(accentOverrideHasLowContrast(scheme)).toBe(false);
+    expect(accentOverrideHasLowContrast(scheme)).toBeNull();
   });
 });
 

--- a/shared/theme/contrast.ts
+++ b/shared/theme/contrast.ts
@@ -551,22 +551,52 @@ export function getThemeContrastWarnings(scheme: AppColorScheme): AppThemeValida
 const ACCENT_MIN_CONTRAST = 4.5;
 const ACCENT_OUTLINE_MIN_CONTRAST = 3.0;
 
-export function accentOverrideHasLowContrast(scheme: AppColorScheme): boolean {
-  const accent = scheme.tokens["accent-primary"];
-  if (!isHexColor(accent)) return false;
+// Structured result describing how an accent override fails its contrast gate, so
+// the theme picker can render a specific, actionable warning instead of a generic
+// one-liner. `mode` distinguishes the two materially different failures:
+//   - "foreground": accent-foreground text/icons are illegible on the accent fill
+//     (e.g. a button label vanishing into its own button)
+//   - "surface": the accent color itself is hard to see on a theme background
+// `worstRatio` is the lowest contrast ratio found for the reported mode, and
+// `worstSurface` names the offending background in surface mode (null otherwise).
+export type AccentContrastFailure = {
+  mode: "foreground" | "surface";
+  worstRatio: number;
+  worstSurface: AppThemeTokenKey | null;
+};
 
+export function accentOverrideHasLowContrast(scheme: AppColorScheme): AccentContrastFailure | null {
+  const accent = scheme.tokens["accent-primary"];
+  if (!isHexColor(accent)) return null;
+
+  // Foreground-first precedence: text-on-accent-button legibility is a higher-
+  // severity failure than accent-tint-on-background, so report it before scanning
+  // surfaces. The user should fix this before discovering any surface issue.
   const accentForeground = scheme.tokens["accent-foreground"];
-  if (
-    isHexColor(accentForeground) &&
-    contrastRatio(accentForeground, accent) < ACCENT_MIN_CONTRAST
-  ) {
-    return true;
+  if (isHexColor(accentForeground)) {
+    const fgRatio = contrastRatio(accentForeground, accent);
+    if (fgRatio < ACCENT_MIN_CONTRAST) {
+      return { mode: "foreground", worstRatio: fgRatio, worstSurface: null };
+    }
   }
 
-  return DISPLAY_SURFACES.some((key) => {
+  let worstRatio = Infinity;
+  let worstSurface: AppThemeTokenKey | null = null;
+  for (const key of DISPLAY_SURFACES) {
     const background = scheme.tokens[key];
-    return isHexColor(background) && contrastRatio(accent, background) < ACCENT_MIN_CONTRAST;
-  });
+    if (!isHexColor(background)) continue;
+    const ratio = contrastRatio(accent, background);
+    if (ratio < worstRatio) {
+      worstRatio = ratio;
+      worstSurface = key;
+    }
+  }
+
+  if (worstSurface !== null && worstRatio < ACCENT_MIN_CONTRAST) {
+    return { mode: "surface", worstRatio, worstSurface };
+  }
+
+  return null;
 }
 
 // ── Round-2 light validation matrix (E6) ─────────────────────────────────────

--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -16,6 +16,7 @@ import {
   accentOverrideHasLowContrast,
   applyAccentOverrideToScheme,
   resolveAppTheme,
+  type AccentContrastFailure,
 } from "@shared/theme";
 import { PaletteStrip } from "@/components/ui/PaletteStrip";
 import { Button } from "@/components/ui/button";
@@ -127,8 +128,8 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
 
   // Warn — non-blocking — when an accent override drops below WCAG AA 4.5:1 against the
   // active theme, either as button-label text or as accent-tinted text on the theme surfaces.
-  const accentContrastFail = useMemo(() => {
-    if (!accentColorOverride) return false;
+  const accentContrastFail = useMemo<AccentContrastFailure | null>(() => {
+    if (!accentColorOverride) return null;
     return accentOverrideHasLowContrast(
       applyAccentOverrideToScheme(selectedScheme, accentColorOverride)
     );
@@ -414,7 +415,9 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
         >
           <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-status-warning" />
           <p className="min-w-0 text-xs text-daintree-text">
-            Low contrast on {selectedScheme.name}
+            {accentContrastFail.mode === "foreground"
+              ? `Low contrast: button text scores only ${accentContrastFail.worstRatio.toFixed(2)}:1 on the accent color — pick a lighter or darker accent`
+              : `Low contrast: the accent scores only ${accentContrastFail.worstRatio.toFixed(2)}:1 on ${selectedScheme.name} surfaces — pick a more distinct accent`}
           </p>
         </div>
       )}

--- a/src/components/Settings/__tests__/AppThemePicker.shuffle.test.tsx
+++ b/src/components/Settings/__tests__/AppThemePicker.shuffle.test.tsx
@@ -38,7 +38,7 @@ vi.mock("@shared/theme", () => ({
   },
   getAppThemeWarnings: () => [],
   applyAccentOverrideToScheme: (scheme: unknown) => scheme,
-  accentOverrideHasLowContrast: vi.fn(() => false),
+  accentOverrideHasLowContrast: vi.fn((): AccentContrastFailure | null => null),
   resolveAppTheme: (id: string, customSchemes: { id: string }[]) => {
     const map: Record<string, { id: string; name: string; type: string; tokens: object }> = {
       "theme-a": { id: "theme-a", name: "Theme A", type: "dark", tokens: {} },
@@ -76,7 +76,7 @@ vi.mock("@/config/appColorSchemes", () => {
   };
 });
 
-import { accentOverrideHasLowContrast } from "@shared/theme";
+import { accentOverrideHasLowContrast, type AccentContrastFailure } from "@shared/theme";
 import { AppThemePicker } from "../AppThemePicker";
 
 describe("AppThemePicker shuffle button", () => {
@@ -303,27 +303,49 @@ describe("AppThemePicker accent contrast warning", () => {
     });
   });
 
-  it("shows a warning naming the active theme when an override has low contrast", () => {
-    vi.mocked(accentOverrideHasLowContrast).mockReturnValue(true);
+  it("shows a surface warning naming the active theme and ratio when contrast is low", () => {
+    vi.mocked(accentOverrideHasLowContrast).mockReturnValue({
+      mode: "surface",
+      worstRatio: 3.8,
+      worstSurface: "surface-panel",
+    });
     storeState.accentColorOverride = "#ffffff";
 
     render(<AppThemePicker />);
-    expect(screen.getByText("Low contrast on Theme A")).toBeTruthy();
+    // Surface copy names the theme and the two-decimal ratio, and keeps the
+    // "Low contrast" substring the E2E selector matches on.
+    expect(screen.getByText(/Low contrast.*3\.80:1 on Theme A surfaces/)).toBeTruthy();
+  });
+
+  it("shows a foreground-specific warning when button text is illegible on the accent", () => {
+    vi.mocked(accentOverrideHasLowContrast).mockReturnValue({
+      mode: "foreground",
+      worstRatio: 2.1,
+      worstSurface: null,
+    });
+    storeState.accentColorOverride = "#ffffff";
+
+    render(<AppThemePicker />);
+    expect(screen.getByText(/Low contrast.*button text scores only 2\.10:1/)).toBeTruthy();
   });
 
   it("does not show the warning when there is no accent override", () => {
-    vi.mocked(accentOverrideHasLowContrast).mockReturnValue(true);
+    vi.mocked(accentOverrideHasLowContrast).mockReturnValue({
+      mode: "surface",
+      worstRatio: 3.8,
+      worstSurface: "surface-panel",
+    });
     storeState.accentColorOverride = null;
 
     render(<AppThemePicker />);
-    expect(screen.queryByText(/Low contrast on/)).toBeNull();
+    expect(screen.queryByText(/Low contrast/)).toBeNull();
   });
 
   it("does not show the warning when the override has sufficient contrast", () => {
-    vi.mocked(accentOverrideHasLowContrast).mockReturnValue(false);
+    vi.mocked(accentOverrideHasLowContrast).mockReturnValue(null);
     storeState.accentColorOverride = "#000000";
 
     render(<AppThemePicker />);
-    expect(screen.queryByText(/Low contrast on/)).toBeNull();
+    expect(screen.queryByText(/Low contrast/)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- `accentOverrideHasLowContrast` in `shared/theme/contrast.ts` now returns `AccentContrastFailure | null` instead of a bare boolean, capturing the failure mode (`foreground` or `surface`), the worst contrast ratio, and the offending surface key
- `AppThemePicker.tsx` uses this to render mode-specific warning copy with the measured ratio — telling users whether to adjust the accent foreground or pick a lighter/darker accent color
- Surface scan now finds the worst ratio across all five `DISPLAY_SURFACES` rather than short-circuiting on the first failure

Resolves #10015

## Changes

- `shared/theme/contrast.ts` — new `AccentContrastFailure` type; updated function signature and scan logic
- `src/components/Settings/AppThemePicker.tsx` — mode-specific warning copy with `toFixed(2)` ratio; warning panel stays surface-neutral (no accent fill)
- Tests updated to assert computed contrast relationships, not literal values; added worst-surface-scan, foreground-priority, strict 4.5 boundary, and non-hex-foreground cases

## Testing

All 76 unit tests pass. `npm run check` clean. E2E selector `[role=status]:has-text("Low contrast")` preserved — both warning variants contain the phrase.