### PR TITLE
chore(fleet): drop unused recordedAt field from fleetFailureStore

### DIFF
--- a/src/components/Fleet/__tests__/FleetFailureBanner.test.tsx
+++ b/src/components/Fleet/__tests__/FleetFailureBanner.test.tsx
@@ -44,7 +44,6 @@ function resetStore() {
   useFleetFailureStore.setState({
     failedIds: new Set(),
     payload: null,
-    recordedAt: null,
   });
 }
 
@@ -63,7 +62,6 @@ describe("FleetFailureBanner", () => {
     useFleetFailureStore.setState({
       failedIds: new Set(["t1", "t2"]),
       payload: "ls\r",
-      recordedAt: Date.now(),
     });
     render(<FleetFailureBanner />);
     expect(screen.getByText("Broadcast failed")).toBeTruthy();
@@ -75,7 +73,6 @@ describe("FleetFailureBanner", () => {
     useFleetFailureStore.setState({
       failedIds: new Set(["t1"]),
       payload: "ls\r",
-      recordedAt: Date.now(),
     });
     render(<FleetFailureBanner />);
     expect(screen.getByText("1 terminal rejected the write.")).toBeTruthy();
@@ -85,7 +82,6 @@ describe("FleetFailureBanner", () => {
     useFleetFailureStore.setState({
       failedIds: new Set(["t1", "t2"]),
       payload: null,
-      recordedAt: Date.now(),
     });
     render(<FleetFailureBanner />);
     expect(
@@ -98,7 +94,6 @@ describe("FleetFailureBanner", () => {
     useFleetFailureStore.setState({
       failedIds: new Set(["t1"]),
       payload: "ls\r",
-      recordedAt: Date.now(),
     });
     render(<FleetFailureBanner />);
     fireEvent.click(screen.getByRole("button", { name: "Retry failed" }));
@@ -111,13 +106,11 @@ describe("FleetFailureBanner", () => {
     useFleetFailureStore.setState({
       failedIds: new Set(["t1"]),
       payload: "ls\r",
-      recordedAt: Date.now(),
     });
     render(<FleetFailureBanner />);
     fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
     const s = useFleetFailureStore.getState();
     expect(s.failedIds.size).toBe(0);
     expect(s.payload).toBeNull();
-    expect(s.recordedAt).toBeNull();
   });
 });

--- a/src/services/actions/definitions/__tests__/fleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/fleetActions.test.ts
@@ -89,7 +89,7 @@ function resetStores(): void {
     lastArmedId: null,
   });
   useFleetPendingActionStore.setState({ pending: null });
-  useFleetFailureStore.setState({ failedIds: new Set(), payload: null, recordedAt: null });
+  useFleetFailureStore.setState({ failedIds: new Set(), payload: null });
   usePanelStore.setState({
     panelsById: {},
     panelIds: [],
@@ -576,7 +576,6 @@ describe("fleet.retryFailures", () => {
     useFleetFailureStore.setState({
       failedIds: new Set(["t1", "t2"]),
       payload: null,
-      recordedAt: Date.now(),
     });
     const registry = await buildRegistry();
     await run(registry, "fleet.retryFailures");
@@ -587,7 +586,6 @@ describe("fleet.retryFailures", () => {
     useFleetFailureStore.setState({
       failedIds: new Set(),
       payload: "ls\r",
-      recordedAt: Date.now(),
     });
     const registry = await buildRegistry();
     await run(registry, "fleet.retryFailures");
@@ -598,7 +596,6 @@ describe("fleet.retryFailures", () => {
     useFleetFailureStore.setState({
       failedIds: new Set(["t1", "t2"]),
       payload: "ls\r",
-      recordedAt: Date.now(),
     });
     const registry = await buildRegistry();
     await run(registry, "fleet.retryFailures");
@@ -619,7 +616,6 @@ describe("fleet.retryFailures", () => {
     useFleetFailureStore.setState({
       failedIds: new Set(["t1", "t2", "t3"]),
       payload: "ls\r",
-      recordedAt: Date.now(),
     });
     const registry = await buildRegistry();
     await run(registry, "fleet.retryFailures");
@@ -637,21 +633,18 @@ describe("fleet.retryFailures", () => {
     useFleetFailureStore.setState({
       failedIds: new Set(["t1", "t2"]),
       payload: "ls\r",
-      recordedAt: Date.now(),
     });
     const registry = await buildRegistry();
     await run(registry, "fleet.retryFailures");
     const s = useFleetFailureStore.getState();
     expect(s.failedIds.size).toBe(0);
     expect(s.payload).toBeNull();
-    expect(s.recordedAt).toBeNull();
   });
 
   it("leaves the banner intact when invoked with a null payload (no silent clear)", async () => {
     useFleetFailureStore.setState({
       failedIds: new Set(["t1"]),
       payload: null,
-      recordedAt: Date.now(),
     });
     const registry = await buildRegistry();
     await run(registry, "fleet.retryFailures");
@@ -676,7 +669,6 @@ describe("fleet.retryFailures", () => {
     useFleetFailureStore.setState({
       failedIds: new Set(["t1"]),
       payload: "ls\r",
-      recordedAt: Date.now(),
     });
     const registry = await buildRegistry();
     const first = run(registry, "fleet.retryFailures");

--- a/src/store/__tests__/fleetFailureStore.test.ts
+++ b/src/store/__tests__/fleetFailureStore.test.ts
@@ -6,7 +6,7 @@ import { usePanelStore } from "../panelStore";
 import type { PtyPanelData } from "@shared/types/panel";
 
 function resetStores() {
-  useFleetFailureStore.setState({ failedIds: new Set(), payload: null, recordedAt: null });
+  useFleetFailureStore.setState({ failedIds: new Set(), payload: null });
   useFleetArmingStore.setState({
     armedIds: new Set<string>(),
     armOrder: [],
@@ -43,15 +43,13 @@ describe("useFleetFailureStore", () => {
     const s = useFleetFailureStore.getState();
     expect(s.failedIds.size).toBe(0);
     expect(s.payload).toBeNull();
-    expect(s.recordedAt).toBeNull();
   });
 
-  it("recordFailure populates ids, payload, and timestamp", () => {
+  it("recordFailure populates ids and payload", () => {
     useFleetFailureStore.getState().recordFailure("hello", ["a", "b"]);
     const s = useFleetFailureStore.getState();
     expect(s.failedIds).toEqual(new Set(["a", "b"]));
     expect(s.payload).toBe("hello");
-    expect(s.recordedAt).toBeGreaterThan(0);
   });
 
   it("recordFailure with empty ids resets state", () => {
@@ -60,7 +58,6 @@ describe("useFleetFailureStore", () => {
     const s = useFleetFailureStore.getState();
     expect(s.failedIds.size).toBe(0);
     expect(s.payload).toBeNull();
-    expect(s.recordedAt).toBeNull();
   });
 
   it("recordFailure accepts a null payload for non-replayable failures", () => {
@@ -71,7 +68,6 @@ describe("useFleetFailureStore", () => {
     const s = useFleetFailureStore.getState();
     expect(s.failedIds).toEqual(new Set(["a", "b"]));
     expect(s.payload).toBeNull();
-    expect(s.recordedAt).toBeGreaterThan(0);
   });
 
   it("dismissId removes a single id and preserves the rest", () => {
@@ -87,7 +83,6 @@ describe("useFleetFailureStore", () => {
     const s = useFleetFailureStore.getState();
     expect(s.failedIds.size).toBe(0);
     expect(s.payload).toBeNull();
-    expect(s.recordedAt).toBeNull();
   });
 
   it("clear resets everything", () => {
@@ -96,7 +91,6 @@ describe("useFleetFailureStore", () => {
     const s = useFleetFailureStore.getState();
     expect(s.failedIds.size).toBe(0);
     expect(s.payload).toBeNull();
-    expect(s.recordedAt).toBeNull();
   });
 
   it("auto-clears when the whole fleet drains", () => {

--- a/src/store/fleetFailureStore.ts
+++ b/src/store/fleetFailureStore.ts
@@ -21,8 +21,6 @@ export interface FleetFailureSnapshot {
   failedIds: Set<string>;
   /** The literal payload that should be re-fired on retry. */
   payload: string | null;
-  /** Wall clock of the most recent failure record (ms). */
-  recordedAt: number | null;
 }
 
 interface FleetFailureState extends FleetFailureSnapshot {
@@ -38,14 +36,13 @@ const EMPTY_SET: Set<string> = new Set();
 export const useFleetFailureStore = create<FleetFailureState>((set) => ({
   failedIds: EMPTY_SET,
   payload: null,
-  recordedAt: null,
   recordFailure: (payload, failedIds) => {
     const ids = new Set(failedIds);
     if (ids.size === 0) {
-      set({ failedIds: EMPTY_SET, payload: null, recordedAt: null });
+      set({ failedIds: EMPTY_SET, payload: null });
       return;
     }
-    set({ failedIds: ids, payload, recordedAt: Date.now() });
+    set({ failedIds: ids, payload });
   },
   dismissId: (id) =>
     set((s) => {
@@ -53,11 +50,11 @@ export const useFleetFailureStore = create<FleetFailureState>((set) => ({
       const next = new Set(s.failedIds);
       next.delete(id);
       if (next.size === 0) {
-        return { failedIds: EMPTY_SET, payload: null, recordedAt: null };
+        return { failedIds: EMPTY_SET, payload: null };
       }
       return { failedIds: next };
     }),
-  clear: () => set({ failedIds: EMPTY_SET, payload: null, recordedAt: null }),
+  clear: () => set({ failedIds: EMPTY_SET, payload: null }),
 }));
 
 /**


### PR DESCRIPTION
## Summary

- `recordedAt` was set on `recordFailure` and cleared on dismiss/clear, but never read anywhere in production code.
- A fleet broadcast failure is a discrete completed partial failure, not an auto-recovering ambient signal, so the runtime-signal-tier 30s stall-promotion that `recordedAt` would have fed doesn't apply.
- Renderer-only store with no persistence, so no behavioral change.

Resolves #9952

## Changes

- Drop `recordedAt` from `FleetFailureSnapshot` interface and all `set()` calls in `fleetFailureStore.ts`.
- Strip tautological timestamp fixtures and assertions from `FleetFailureBanner.test.tsx`, `fleetActions.test.ts`, and `fleetFailureStore.test.ts`.

## Testing

vitest 54 pass, tsc clean, `npm run check` all guards pass, `grep recordedAt` zero hits.