### PR TITLE
perf(boot): defer plugin-MCP audit pre-warming off the cold-boot path

### DIFF
--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -10,6 +10,16 @@ let migrationCurrentVersion = 1;
 let migrationShouldThrow = false;
 let mockLogRetentionDays: number | undefined = 30;
 const { pruneOldLogs } = vi.hoisted(() => ({ pruneOldLogs: vi.fn() }));
+const { pluginMcpHydrate, getPluginMcpAuditService, getPluginMcpConsentService } = vi.hoisted(
+  () => {
+    const pluginMcpHydrate = vi.fn();
+    return {
+      pluginMcpHydrate,
+      getPluginMcpAuditService: vi.fn(() => ({ hydrate: pluginMcpHydrate })),
+      getPluginMcpConsentService: vi.fn(),
+    };
+  }
+);
 
 vi.mock("../../utils/performance.js", () => ({
   markPerformance: vi.fn(),
@@ -94,6 +104,11 @@ vi.mock("../../services/PreAgentSnapshotService.js", () => ({
 
 vi.mock("../../services/ActionBreadcrumbService.js", () => ({
   getActionBreadcrumbService: () => ({ initialize: vi.fn() }),
+}));
+
+vi.mock("../../services/plugin-mcp/instances.js", () => ({
+  getPluginMcpAuditService,
+  getPluginMcpConsentService,
 }));
 
 vi.mock("../../services/HibernationService.js", () => ({
@@ -225,6 +240,9 @@ describe("initGlobalServices task ordering", () => {
     // leak into the next — keeps tests independent as the suite grows.
     setMcpRegistry.mockReset();
     pruneOldLogs.mockReset();
+    pluginMcpHydrate.mockClear();
+    getPluginMcpAuditService.mockClear();
+    getPluginMcpConsentService.mockClear();
     (app.exit as ReturnType<typeof vi.fn>).mockReset();
     migrationCurrentVersion = 1;
     migrationShouldThrow = false;
@@ -337,6 +355,31 @@ describe("initGlobalServices task ordering", () => {
 
     expect(registeredTaskNames).toContain("ccr-config");
     expect(registeredTaskNames).toContain("plugin-service");
+  });
+
+  it("does not touch plugin-MCP audit/consent services eagerly during initGlobalServices() (#10073)", async () => {
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    // The eager hydrate + consent allocation were removed from the cold-boot
+    // path — neither getter may fire until the deferred queue drains.
+    expect(getPluginMcpAuditService).not.toHaveBeenCalled();
+    expect(getPluginMcpConsentService).not.toHaveBeenCalled();
+    expect(registeredTaskNames).toContain("plugin-mcp-audit-warm");
+  });
+
+  it("plugin-mcp-audit-warm task hydrates the audit service when run (#10073)", async () => {
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    const run = registeredTaskRuns.get("plugin-mcp-audit-warm");
+    expect(run).toBeDefined();
+    await run!();
+
+    expect(pluginMcpHydrate).toHaveBeenCalledTimes(1);
+    // Consent service stays purely on-demand — the warm task must not
+    // allocate it (PluginInstaller constructs it lazily at first real use).
+    expect(getPluginMcpConsentService).not.toHaveBeenCalled();
   });
 
   it("registers prune-old-logs as a deferred task so it doesn't block cold start (#8622)", async () => {

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -10,16 +10,20 @@ let migrationCurrentVersion = 1;
 let migrationShouldThrow = false;
 let mockLogRetentionDays: number | undefined = 30;
 const { pruneOldLogs } = vi.hoisted(() => ({ pruneOldLogs: vi.fn() }));
-const { pluginMcpHydrate, getPluginMcpAuditService, getPluginMcpConsentService } = vi.hoisted(
-  () => {
-    const pluginMcpHydrate = vi.fn();
-    return {
-      pluginMcpHydrate,
-      getPluginMcpAuditService: vi.fn(() => ({ hydrate: pluginMcpHydrate })),
-      getPluginMcpConsentService: vi.fn(),
-    };
-  }
-);
+const {
+  pluginMcpHydrate,
+  getPluginMcpAuditService,
+  getPluginMcpConsentService,
+  getPluginMcpConsentStore,
+} = vi.hoisted(() => {
+  const pluginMcpHydrate = vi.fn();
+  return {
+    pluginMcpHydrate,
+    getPluginMcpAuditService: vi.fn(() => ({ hydrate: pluginMcpHydrate })),
+    getPluginMcpConsentService: vi.fn(),
+    getPluginMcpConsentStore: vi.fn(),
+  };
+});
 
 vi.mock("../../utils/performance.js", () => ({
   markPerformance: vi.fn(),
@@ -109,6 +113,7 @@ vi.mock("../../services/ActionBreadcrumbService.js", () => ({
 vi.mock("../../services/plugin-mcp/instances.js", () => ({
   getPluginMcpAuditService,
   getPluginMcpConsentService,
+  getPluginMcpConsentStore,
 }));
 
 vi.mock("../../services/HibernationService.js", () => ({
@@ -243,6 +248,7 @@ describe("initGlobalServices task ordering", () => {
     pluginMcpHydrate.mockClear();
     getPluginMcpAuditService.mockClear();
     getPluginMcpConsentService.mockClear();
+    getPluginMcpConsentStore.mockClear();
     (app.exit as ReturnType<typeof vi.fn>).mockReset();
     migrationCurrentVersion = 1;
     migrationShouldThrow = false;
@@ -365,7 +371,8 @@ describe("initGlobalServices task ordering", () => {
     // path — neither getter may fire until the deferred queue drains.
     expect(getPluginMcpAuditService).not.toHaveBeenCalled();
     expect(getPluginMcpConsentService).not.toHaveBeenCalled();
-    expect(registeredTaskNames).toContain("plugin-mcp-audit-warm");
+    expect(getPluginMcpConsentStore).not.toHaveBeenCalled();
+    expect(registeredTaskNames.filter((n) => n === "plugin-mcp-audit-warm")).toHaveLength(1);
   });
 
   it("plugin-mcp-audit-warm task hydrates the audit service when run (#10073)", async () => {
@@ -377,9 +384,10 @@ describe("initGlobalServices task ordering", () => {
     await run!();
 
     expect(pluginMcpHydrate).toHaveBeenCalledTimes(1);
-    // Consent service stays purely on-demand — the warm task must not
-    // allocate it (PluginInstaller constructs it lazily at first real use).
+    // Consent service/store stay purely on-demand — the warm task must not
+    // allocate them (PluginInstaller constructs them lazily at first real use).
     expect(getPluginMcpConsentService).not.toHaveBeenCalled();
+    expect(getPluginMcpConsentStore).not.toHaveBeenCalled();
   });
 
   it("registers prune-old-logs as a deferred task so it doesn't block cold start (#8622)", async () => {

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -18,10 +18,6 @@ import { preAgentSnapshotService } from "../services/PreAgentSnapshotService.js"
 import { getActionBreadcrumbService } from "../services/ActionBreadcrumbService.js";
 import { getPluginActionAuditService } from "../services/PluginActionAuditService.js";
 import {
-  getPluginMcpAuditService,
-  getPluginMcpConsentService,
-} from "../services/plugin-mcp/instances.js";
-import {
   initializeHibernationService,
   getHibernationService,
 } from "../services/HibernationService.js";
@@ -272,14 +268,6 @@ export async function initGlobalServices(
     isPlaintextEnabled: () => store.get("appState")?.developerMode?.pluginAuditPlaintext === true,
   });
 
-  // Plugin-MCP inbound audit + TOFU consent stores (#9234). Hydrate eagerly so
-  // the first plugin-MCP tool call from the supervisor (#9233, TODO) does not
-  // race the lazy store read. The consent service has no subscribers itself —
-  // it's invoked synchronously from the supervisor's tools/call interception
-  // path once that lands.
-  getPluginMcpAuditService().hydrate();
-  getPluginMcpConsentService();
-
   registerDeferredTask({
     name: "agent-notification-service",
     run: async () => {
@@ -377,6 +365,19 @@ export async function initGlobalServices(
       },
     });
   }
+
+  // Plugin-MCP inbound audit log (#9234) — warm the hydrate() store read off
+  // the cold-boot path (#10073). hydrate() is idempotent, and append() demand-
+  // hydrates anyway, so this is purely pre-warming for when the supervisor
+  // (#9233) lands. The consent service is not pre-warmed: its constructor is
+  // bare allocation and PluginInstaller already constructs it lazily on demand.
+  registerDeferredTask({
+    name: "plugin-mcp-audit-warm",
+    run: async () => {
+      const { getPluginMcpAuditService } = await import("../services/plugin-mcp/instances.js");
+      getPluginMcpAuditService().hydrate();
+    },
+  });
 
   // ── Deferred global service starts ──
   // These were previously run on the same tick as loadRenderer(), contending


### PR DESCRIPTION
Closes #10073.

`initGlobalServices()` eagerly ran `getPluginMcpAuditService().hydrate()` (a synchronous electron-store read plus an audit-record normalization loop) and `getPluginMcpConsentService()` (allocation) on the cold-boot critical path — even though neither service has active callers until the supervisor (#9233) lands.

## Changes

- Removed both eager calls and the now-unused static import of `plugin-mcp/instances.js` from `globalServicesInit.ts`.
- Registered a `plugin-mcp-audit-warm` deferred task (dynamic import, matching every other deferred task in the file) that hydrates the audit store after first-interactive — keeping the module off the cold-boot import graph entirely.
- The consent service is not pre-warmed at all: its constructor is bare allocation, and `PluginInstaller` already constructs it lazily on demand.

## Safety

- `hydrate()` is idempotent (`this.hydrated` guard) and `append()` demand-hydrates, so a real call racing the deferred warm-up is safe in either order.
- Shutdown's `flushNow()` short-circuits on a never-hydrated instance (`flush()` returns early when `!hydrated`), so an early quit before drain is a true no-op.

## Tests

Added a `vi.mock` for `plugin-mcp/instances.js` to `globalServicesInit.order.test.ts` with assertions that:
- no plugin-MCP getter fires eagerly during `initGlobalServices()`
- exactly one `plugin-mcp-audit-warm` task registers
- running the task hydrates exactly once and never touches the consent service or store