### PR TITLE
fix(portal): guard all portal.show paths against open overlays

### DIFF
--- a/src/services/actions/definitions/__tests__/devPreviewActions.promoteToPortal.test.ts
+++ b/src/services/actions/definitions/__tests__/devPreviewActions.promoteToPortal.test.ts
@@ -10,8 +10,10 @@ const portalStoreMock = vi.hoisted(() => ({ getState: vi.fn(), setState: vi.fn()
 vi.mock("@/store/portalStore", () => ({ usePortalStore: portalStoreMock }));
 
 const getPortalBoundsWithRetryMock = vi.hoisted(() => vi.fn());
+const showPortalTabIfNoOverlayMock = vi.hoisted(() => vi.fn());
 vi.mock("../portalHelpers", () => ({
   getPortalBoundsWithRetry: getPortalBoundsWithRetryMock,
+  showPortalTabIfNoOverlay: showPortalTabIfNoOverlayMock,
 }));
 
 const logErrorMock = vi.hoisted(() => vi.fn());
@@ -79,6 +81,11 @@ beforeEach(() => {
   order = [];
   portalState = { isOpen: false, tabs: [], activeTabId: null };
   getPortalBoundsWithRetryMock.mockResolvedValue(BOUNDS);
+  // Default: no overlay — the helper forwards to portal.show so the existing
+  // show assertions hold. Overlay-guard cases override this per test.
+  showPortalTabIfNoOverlayMock.mockImplementation(async (tabId: string, bounds: typeof BOUNDS) => {
+    await showMock({ tabId, bounds });
+  });
   panelStoreMock.getState.mockReturnValue({
     focusedId: "panel-1",
     getTerminal: vi.fn(() => devPreviewPanel()),
@@ -137,6 +144,20 @@ describe("devPreview.promoteToPortal", () => {
       },
     ]);
     expect(showMock).toHaveBeenCalledWith({ tabId: createArgs.tabId, bounds: BOUNDS });
+  });
+
+  it("routes the show through the overlay guard and still creates the tab when suppressed", async () => {
+    // Simulate an open overlay: the guard helper skips the WebContentsView show.
+    showPortalTabIfNoOverlayMock.mockImplementation(async () => {});
+    const { run } = setupActions();
+    await run("devPreview.promoteToPortal", undefined, { projectId: "proj" });
+
+    const createArgs = createMock.mock.calls[0]?.[0] as unknown as { tabId: string };
+    // Tab is still created and inserted in the store — only the show is suppressed.
+    expect(markTabCreatedMock).toHaveBeenCalledWith(createArgs.tabId);
+    expect(portalState.activeTabId).toBe(createArgs.tabId);
+    expect(showPortalTabIfNoOverlayMock).toHaveBeenCalledWith(createArgs.tabId, BOUNDS);
+    expect(showMock).not.toHaveBeenCalled();
   });
 
   it("does not reopen the portal when already open", async () => {

--- a/src/services/actions/definitions/__tests__/portalActions.overlayGuard.test.ts
+++ b/src/services/actions/definitions/__tests__/portalActions.overlayGuard.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ActionCallbacks, ActionRegistry, AnyActionDefinition } from "../../actionTypes";
+
+const portalStoreMock = vi.hoisted(() => ({ getState: vi.fn() }));
+const uiStoreMock = vi.hoisted(() => ({ getState: vi.fn() }));
+const getPortalPlaceholderBoundsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/store/portalStore", () => ({ usePortalStore: portalStoreMock }));
+vi.mock("@/store/uiStore", () => ({ useUIStore: uiStoreMock }));
+vi.mock("@/store/portalPendingCloseStore", () => ({
+  usePortalPendingCloseStore: { getState: vi.fn(() => ({ pending: null, clear: vi.fn() })) },
+}));
+vi.mock("@/lib/portalBounds", () => ({
+  getPortalPlaceholderBounds: getPortalPlaceholderBoundsMock,
+}));
+vi.mock("@/lib/aiAgentDetection", () => ({ getAIAgentInfo: vi.fn(() => null) }));
+vi.mock("@/utils/logger", () => ({ logError: vi.fn() }));
+
+// Use the REAL portalHelpers (showPortalTabIfNoOverlay) so the guard's read of
+// useUIStore is exercised end-to-end — that is the regression this file pins.
+import { registerPortalActions } from "../portalActions";
+
+const BOUNDS = { x: 0, y: 0, width: 800, height: 600 };
+const showMock = vi.fn(async () => ({}));
+const createMock = vi.fn(async () => ({}));
+const duplicateTabMock = vi.fn(() => "tab-2");
+const markTabCreatedMock = vi.fn();
+const closeTabMock = vi.fn();
+
+function setOverlay(active: boolean) {
+  uiStoreMock.getState.mockReturnValue({ overlayStack: active ? ["settings"] : [] });
+}
+
+function runDuplicate(): Promise<unknown> {
+  const actions: ActionRegistry = new Map();
+  registerPortalActions(actions, {} as unknown as ActionCallbacks);
+  const factory = actions.get("portal.duplicateTab");
+  if (!factory) throw new Error("missing portal.duplicateTab");
+  const def = factory() as AnyActionDefinition;
+  return def.run({ tabId: "tab-1" }, {} as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getPortalPlaceholderBoundsMock.mockReturnValue(BOUNDS);
+  setOverlay(false);
+  portalStoreMock.getState.mockReturnValue({
+    tabs: [{ id: "tab-1", url: "https://example.com", title: "One" }],
+    activeTabId: "tab-1",
+    duplicateTab: duplicateTabMock,
+    markTabCreated: markTabCreatedMock,
+    closeTab: closeTabMock,
+  });
+  Object.defineProperty(globalThis, "window", {
+    value: { electron: { portal: { show: showMock, create: createMock } } },
+    configurable: true,
+  });
+});
+
+describe("portal.duplicateTab overlay guard", () => {
+  it("creates and shows the duplicated tab when no overlay is active", async () => {
+    await runDuplicate();
+    expect(createMock).toHaveBeenCalledOnce();
+    expect(markTabCreatedMock).toHaveBeenCalledWith("tab-2");
+    expect(showMock).toHaveBeenCalledWith({ tabId: "tab-2", bounds: BOUNDS });
+  });
+
+  it("still creates the duplicated tab but suppresses the show when an overlay is active", async () => {
+    setOverlay(true);
+    await runDuplicate();
+    // The duplicate is created in the backend; only the WebContentsView show is gated.
+    expect(createMock).toHaveBeenCalledOnce();
+    expect(markTabCreatedMock).toHaveBeenCalledWith("tab-2");
+    expect(showMock).not.toHaveBeenCalled();
+    expect(closeTabMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/actions/definitions/__tests__/portalHelpers.overlayGuard.test.ts
+++ b/src/services/actions/definitions/__tests__/portalHelpers.overlayGuard.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const portalStoreMock = vi.hoisted(() => ({ getState: vi.fn() }));
+const uiStoreMock = vi.hoisted(() => ({ getState: vi.fn() }));
+const getPortalPlaceholderBoundsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/store/portalStore", () => ({ usePortalStore: portalStoreMock }));
+vi.mock("@/store/uiStore", () => ({ useUIStore: uiStoreMock }));
+vi.mock("@/store/portalPendingCloseStore", () => ({
+  usePortalPendingCloseStore: { getState: vi.fn(() => ({ pending: null, clear: vi.fn() })) },
+}));
+vi.mock("@/lib/portalBounds", () => ({
+  getPortalPlaceholderBounds: getPortalPlaceholderBoundsMock,
+}));
+vi.mock("@/utils/logger", () => ({ logError: vi.fn() }));
+
+import { activatePortalTab, showPortalTabIfNoOverlay } from "../portalHelpers";
+
+const BOUNDS = { x: 0, y: 0, width: 800, height: 600 };
+const showMock = vi.fn(async () => ({}));
+const createMock = vi.fn(async () => ({}));
+const hideMock = vi.fn(async () => ({}));
+const setActiveTabMock = vi.fn();
+const markTabCreatedMock = vi.fn();
+
+function setOverlay(active: boolean) {
+  uiStoreMock.getState.mockReturnValue({ overlayStack: active ? ["settings"] : [] });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getPortalPlaceholderBoundsMock.mockReturnValue(BOUNDS);
+  setOverlay(false);
+  Object.defineProperty(globalThis, "window", {
+    value: { electron: { portal: { show: showMock, create: createMock, hide: hideMock } } },
+    configurable: true,
+  });
+});
+
+describe("showPortalTabIfNoOverlay", () => {
+  it("shows the tab when no overlay is active", async () => {
+    await showPortalTabIfNoOverlay("tab-1", BOUNDS);
+    expect(showMock).toHaveBeenCalledWith({ tabId: "tab-1", bounds: BOUNDS });
+  });
+
+  it("skips the show when an overlay owns the viewport", async () => {
+    setOverlay(true);
+    await showPortalTabIfNoOverlay("tab-1", BOUNDS);
+    expect(showMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("activatePortalTab overlay guard", () => {
+  beforeEach(() => {
+    portalStoreMock.getState.mockReturnValue({
+      tabs: [{ id: "tab-1", url: "https://example.com", partition: undefined }],
+      createdTabs: new Set<string>(),
+      setActiveTab: setActiveTabMock,
+      markTabCreated: markTabCreatedMock,
+    });
+  });
+
+  it("creates and shows the tab when no overlay is active", async () => {
+    await activatePortalTab("tab-1");
+    expect(setActiveTabMock).toHaveBeenCalledWith("tab-1");
+    expect(createMock).toHaveBeenCalledOnce();
+    expect(markTabCreatedMock).toHaveBeenCalledWith("tab-1");
+    expect(showMock).toHaveBeenCalledWith({ tabId: "tab-1", bounds: BOUNDS });
+  });
+
+  it("still creates the tab but suppresses the show when an overlay is active", async () => {
+    setOverlay(true);
+    await activatePortalTab("tab-1");
+    // Store-side activation and backend creation still happen; only the show is gated.
+    expect(setActiveTabMock).toHaveBeenCalledWith("tab-1");
+    expect(createMock).toHaveBeenCalledOnce();
+    expect(markTabCreatedMock).toHaveBeenCalledWith("tab-1");
+    expect(showMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/actions/definitions/devPreviewActions.ts
+++ b/src/services/actions/definitions/devPreviewActions.ts
@@ -6,7 +6,7 @@ import { usePortalStore } from "@/store/portalStore";
 import { isDevPreviewPanel } from "@shared/types/panel";
 import { buildDevPreviewPartition } from "@shared/utils/partitionUtils";
 import { logError } from "@/utils/logger";
-import { getPortalBoundsWithRetry } from "./portalHelpers";
+import { getPortalBoundsWithRetry, showPortalTabIfNoOverlay } from "./portalHelpers";
 
 const argsSchema = z
   .object({
@@ -151,7 +151,7 @@ export function registerDevPreviewActions(
           activeTabId: tabId,
         }));
         if (bounds) {
-          await window.electron.portal.show({ tabId, bounds });
+          await showPortalTabIfNoOverlay(tabId, bounds);
         }
       } catch (error) {
         logError("Failed to promote dev preview to portal", error);

--- a/src/services/actions/definitions/portalActions.ts
+++ b/src/services/actions/definitions/portalActions.ts
@@ -13,6 +13,7 @@ import {
   clearPortalPendingIf,
   getPortalBounds,
   parseConfirmed,
+  showPortalTabIfNoOverlay,
 } from "./portalHelpers";
 
 export function registerPortalActions(actions: ActionRegistry, _callbacks: ActionCallbacks): void {
@@ -346,7 +347,7 @@ export function registerPortalActions(actions: ActionRegistry, _callbacks: Actio
       try {
         await window.electron.portal.create({ tabId: newTabId, url: tab.url });
         state.markTabCreated(newTabId);
-        await window.electron.portal.show({ tabId: newTabId, bounds });
+        await showPortalTabIfNoOverlay(newTabId, bounds);
       } catch (error) {
         logError("Failed to duplicate portal tab", error);
         state.closeTab(newTabId);

--- a/src/services/actions/definitions/portalHelpers.ts
+++ b/src/services/actions/definitions/portalHelpers.ts
@@ -4,6 +4,7 @@ import {
   usePortalPendingCloseStore,
   type PortalPendingCloseKind,
 } from "@/store/portalPendingCloseStore";
+import { useUIStore } from "@/store/uiStore";
 import { logError } from "@/utils/logger";
 
 /** True when dispatch args carry an explicit `confirmed: true` flag. */
@@ -21,6 +22,21 @@ export const clearPortalPendingIf = (kind: PortalPendingCloseKind): void => {
 };
 
 export const getPortalBounds = () => getPortalPlaceholderBounds();
+
+/**
+ * Show a portal tab only when no modal overlay owns the viewport. Reading
+ * `overlayStack` at call time (after any awaits) keeps the portal WebContentsView
+ * from covering an open modal. When suppressed, PortalVisibilityController's
+ * overlay-clear effect re-shows the active tab once the overlay closes — no
+ * pending-show bookkeeping needed here.
+ */
+export const showPortalTabIfNoOverlay = async (
+  tabId: string,
+  bounds: { x: number; y: number; width: number; height: number }
+): Promise<void> => {
+  if (useUIStore.getState().overlayStack.length > 0) return;
+  await window.electron.portal.show({ tabId, bounds });
+};
 
 export const getPortalBoundsWithRetry = async (
   maxAttempts: number = 20,
@@ -58,7 +74,7 @@ export const activatePortalTab = async (tabId: string): Promise<void> => {
       await window.electron.portal.create({ tabId, url: tab.url, partition: tab.partition });
       state.markTabCreated(tabId);
     }
-    await window.electron.portal.show({ tabId, bounds });
+    await showPortalTabIfNoOverlay(tabId, bounds);
   } catch (error) {
     logError("Failed to activate portal tab", error);
   }

--- a/src/store/__tests__/portalStore.test.ts
+++ b/src/store/__tests__/portalStore.test.ts
@@ -141,6 +141,60 @@ describe("portalStore", () => {
     expect(usePortalStore.getState().createdTabs.has("tab-1")).toBe(false);
   });
 
+  it("does not show the next active tab over an open overlay after a close", async () => {
+    vi.mocked(document.getElementById).mockReturnValue({
+      getBoundingClientRect: () => ({ x: 0, y: 0, width: 800, height: 600 }),
+    } as HTMLElement);
+
+    usePortalStore.setState({
+      isOpen: true,
+      tabs: [
+        { id: "tab-1", title: "One", url: "https://example.com/1" },
+        { id: "tab-2", title: "Two", url: "https://example.com/2" },
+      ],
+      activeTabId: "tab-1",
+      createdTabs: new Set<string>(["tab-1", "tab-2"]),
+    });
+    useUIStore.getState().addOverlayClaim("settings");
+
+    usePortalStore.getState().closeTab("tab-1");
+    await vi.runAllTimersAsync();
+
+    // The tab still becomes active in the store; only the WebContentsView show is suppressed.
+    expect(usePortalStore.getState().activeTabId).toBe("tab-2");
+    expect(window.electron.portal.show).not.toHaveBeenCalled();
+
+    useUIStore.setState({ overlayStack: [] });
+  });
+
+  it("shows the next active tab when the overlay clears before restore runs", async () => {
+    vi.mocked(document.getElementById).mockReturnValue({
+      getBoundingClientRect: () => ({ x: 0, y: 0, width: 800, height: 600 }),
+    } as HTMLElement);
+
+    usePortalStore.setState({
+      isOpen: true,
+      tabs: [
+        { id: "tab-1", title: "One", url: "https://example.com/1" },
+        { id: "tab-2", title: "Two", url: "https://example.com/2" },
+      ],
+      activeTabId: "tab-1",
+      createdTabs: new Set<string>(["tab-1", "tab-2"]),
+    });
+    useUIStore.getState().addOverlayClaim("settings");
+
+    usePortalStore.getState().closeTab("tab-1");
+    // Overlay clears before the deferred restore macro-task runs — the guard reads
+    // state at show-time, so the show proceeds.
+    useUIStore.setState({ overlayStack: [] });
+    await vi.runAllTimersAsync();
+
+    expect(window.electron.portal.show).toHaveBeenCalledWith({
+      tabId: "tab-2",
+      bounds: { x: 0, y: 0, width: 800, height: 600 },
+    });
+  });
+
   describe("width clamping", () => {
     it("clamps width below minimum to PORTAL_MIN_WIDTH", () => {
       usePortalStore.getState().setWidth(PORTAL_MIN_WIDTH - 1);

--- a/src/store/portalStore.ts
+++ b/src/store/portalStore.ts
@@ -99,6 +99,10 @@ const createPortalStore: StateCreator<PortalState & PortalActions> = (set, get) 
       return;
     }
 
+    // Don't surface the portal over an open modal; PortalVisibilityController's
+    // overlay-clear effect re-shows the active tab once the overlay closes.
+    if (useUIStore.getState().overlayStack.length > 0) return;
+
     window.electron.portal.show({ tabId, bounds });
   };
 


### PR DESCRIPTION
## Summary

- Four renderer paths (`restoreActiveTabAfterClose`, `activatePortalTab`, `portal.duplicateTab`, `devPreview.promoteToPortal`) called `window.electron.portal.show` without checking whether a modal overlay was open, letting the portal `WebContentsView` surface on top of modals
- Added a shared async helper `showPortalTabIfNoOverlay` in `portalHelpers.ts` that skips `portal.show` when `overlayStack` is non-empty, and routed the three action-layer sites through it; `portalStore.ts`'s `restoreActiveTabAfterClose` gets an inline equivalent guard placed after the bounds-retry loop so it reads fresh overlay state at show-time
- No pending-show queue needed — `PortalVisibilityController`'s existing overlay-clear effect already re-shows the active tab once the overlay closes

Resolves #9972

## Changes

- `src/services/actions/definitions/portalHelpers.ts` — new `showPortalTabIfNoOverlay` helper; `activatePortalTab` routes through it
- `src/services/actions/definitions/portalActions.ts` — `portal.duplicateTab` routes through the helper
- `src/services/actions/definitions/devPreviewActions.ts` — `devPreview.promoteToPortal` routes through the helper
- `src/store/portalStore.ts` — inline overlay guard in `restoreActiveTabAfterClose`

## Testing

- New test files: `portalHelpers.overlayGuard.test.ts`, `portalActions.overlayGuard.test.ts`, `devPreviewActions.promoteToPortal.test.ts`
- Overlay-guard coverage added to `portalStore.test.ts`
- All 49 portal tests pass; `npm run check` clean (typecheck, lint ratchet down by 1, format, all IPC/channel/confirm-wiring guards)