### PR TITLE
fix(fleet): route retry through full broadcast path

### DIFF
--- a/src/components/Fleet/__tests__/fleetExecution.test.ts
+++ b/src/components/Fleet/__tests__/fleetExecution.test.ts
@@ -1,10 +1,6 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  broadcastFleetLiteralPaste,
-  buildFleetTargetPreviews,
-  executeFleetBroadcast,
-} from "../fleetExecution";
+import { buildFleetTargetPreviews, executeFleetBroadcast } from "../fleetExecution";
 import { FLEET_LARGE_PASTE_BATCH_SIZE } from "../fleetBroadcast";
 import { terminalClient } from "@/clients";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
@@ -77,14 +73,6 @@ function seedPanels(terminals: PanelInstance[]): void {
   usePanelStore.setState({ panelsById, panelIds });
 }
 
-function armTwo() {
-  usePanelStore.setState({
-    panelsById: { t1: makeAgent("t1"), t2: makeAgent("t2") },
-    panelIds: ["t1", "t2"],
-  });
-  useFleetArmingStore.getState().armIds(["t1", "t2"]);
-}
-
 function reset() {
   submitMock.mockReset();
   submitMock.mockResolvedValue(undefined);
@@ -101,87 +89,6 @@ function reset() {
   });
   usePanelStore.setState({ panelsById: {}, panelIds: [] });
 }
-
-describe("broadcastFleetLiteralPaste", () => {
-  beforeEach(() => {
-    reset();
-  });
-
-  it("submits verbatim paste text to each target (no recipe substitution)", async () => {
-    armTwo();
-    const result = await broadcastFleetLiteralPaste("hello {{branch_name}}");
-    expect(submitMock).toHaveBeenCalledTimes(2);
-    expect(submitMock.mock.calls.map(([, text]) => text)).toEqual([
-      "hello {{branch_name}}",
-      "hello {{branch_name}}",
-    ]);
-    expect(result.successCount).toBe(2);
-    expect(result.failureCount).toBe(0);
-  });
-
-  it("collects failures into failedIds without rejecting the aggregate", async () => {
-    submitMock.mockReset();
-    submitMock.mockResolvedValueOnce(undefined);
-    submitMock.mockRejectedValueOnce(new Error("nope"));
-    armTwo();
-
-    const result = await broadcastFleetLiteralPaste("x");
-    expect(result.successCount).toBe(1);
-    expect(result.failureCount).toBe(1);
-    expect(result.failedIds).toEqual(["t2"]);
-  });
-
-  it("classifies rejections by errno token into permanent / transient buckets", async () => {
-    submitMock.mockReset();
-    submitMock.mockImplementation(async (id: string) => {
-      if (id === "dead") throw new Error("EPIPE: terminal dead has no live PTY (exited)");
-      if (id === "slow") throw new Error("ENOSPC: device full");
-    });
-    seedPanels([makeAgent("ok"), makeAgent("dead"), makeAgent("slow")]);
-    const result = await broadcastFleetLiteralPaste("x", ["ok", "dead", "slow"]);
-    expect(result.failedIds.sort()).toEqual(["dead", "slow"]);
-    expect(result.permanentlyFailedIds).toEqual(["dead"]);
-    expect(result.transientlyFailedIds).toEqual(["slow"]);
-    const deadEntry = result.perTarget.find((t) => t.terminalId === "dead");
-    const slowEntry = result.perTarget.find((t) => t.terminalId === "slow");
-    expect(deadEntry?.kind).toBe("permanent");
-    expect(slowEntry?.kind).toBe("transient");
-  });
-
-  it("treats rejections without a recognized errno as transient (retry chip wins over silent disarm)", async () => {
-    // Submit rejections come from many sources (IPC framework, handler
-    // errors). Disarming on unknown would silently drop fleet membership
-    // for an infra blip — leave arming alone and let the user retry.
-    submitMock.mockReset();
-    submitMock.mockImplementation(async (id: string) => {
-      if (id === "mystery") throw new Error("submit blew up for reasons unknown");
-    });
-    seedPanels([makeAgent("ok"), makeAgent("mystery")]);
-    const result = await broadcastFleetLiteralPaste("x", ["ok", "mystery"]);
-    expect(result.transientlyFailedIds).toEqual(["mystery"]);
-    expect(result.permanentlyFailedIds).toEqual([]);
-  });
-
-  it("returns an empty result on zero targets", async () => {
-    const result = await broadcastFleetLiteralPaste("x");
-    expect(submitMock).not.toHaveBeenCalled();
-    expect(result.total).toBe(0);
-    expect(result.successCount).toBe(0);
-  });
-
-  it("filters explicit targetIds through fleet eligibility (drops dock/trash)", async () => {
-    seedPanels([
-      makeAgent("ok"),
-      makeAgent("docked", { location: "dock" }),
-      makeAgent("trashed", { location: "trash" }),
-    ]);
-    const result = await broadcastFleetLiteralPaste("x", ["ok", "docked", "trashed"]);
-    expect(submitMock).toHaveBeenCalledTimes(1);
-    expect(submitMock).toHaveBeenCalledWith("ok", "x");
-    expect(result.successCount).toBe(1);
-    expect(result.failureCount).toBe(0);
-  });
-});
 
 describe("executeFleetBroadcast", () => {
   beforeEach(() => {

--- a/src/components/Fleet/fleetBroadcast.ts
+++ b/src/components/Fleet/fleetBroadcast.ts
@@ -13,9 +13,8 @@ export const FLEET_BROADCAST_HISTORY_KEY = "fleet-broadcast" as const;
  * Shared by both fleet broadcast paths:
  *   - Raw-input (`fleetRawInputBroadcast`) reads `result.error.code` from the
  *     `broadcast-write-result` IPC payload.
- *   - Structured-submit (`fleetExecution.buildResult` /
- *     `broadcastFleetLiteralPaste`) extracts the code from the rejection's
- *     stringified message — Electron's structured-clone serialization strips
+ *   - Structured-submit (`fleetExecution.buildResult`) extracts the code from
+ *     the rejection's stringified message — Electron's structured-clone serialization strips
  *     `NodeJS.ErrnoException.code`, so `handleTerminalSubmit` embeds the code
  *     as a leading `"CODE: …"` token in the thrown error's message.
  */

--- a/src/components/Fleet/fleetEnterBroadcast.ts
+++ b/src/components/Fleet/fleetEnterBroadcast.ts
@@ -23,6 +23,33 @@ export function cancelActiveBroadcast(): void {
   useFleetBroadcastProgressStore.getState().cancel();
 }
 
+/**
+ * Run a fleet broadcast through the shared single-flight controller so it
+ * participates in the same coordination as the Enter path: a newer broadcast
+ * pre-empts an older one (they share `fleetBroadcastProgressStore`, which only
+ * tracks one run), and `cancelActiveBroadcast` (the ribbon Cancel button) can
+ * abort it. Callers own their own result handling; this only manages the
+ * controller lifecycle and the cooperative `signal`.
+ */
+export async function runManagedFleetBroadcast(
+  draft: string,
+  targetIds: string[],
+  perTargetOverrides?: Record<string, string>
+): Promise<FleetExecutionResult> {
+  // A newer broadcast pre-empts the in-flight one — leaving a stale controller
+  // would race two runs against the shared progress store. Abort then take over.
+  activeBroadcastController?.abort();
+  const controller = new AbortController();
+  activeBroadcastController = controller;
+  try {
+    return await executeFleetBroadcast(draft, targetIds, perTargetOverrides, controller.signal);
+  } finally {
+    if (activeBroadcastController === controller) {
+      activeBroadcastController = null;
+    }
+  }
+}
+
 function plural(count: number, singular: string, pluralForm: string): string {
   return `${count} ${count === 1 ? singular : pluralForm}`;
 }
@@ -152,26 +179,17 @@ export function tryFleetBroadcastFromEditor(
     const overridesArg =
       Object.keys(effectiveOverrides).length > 0 ? effectiveOverrides : undefined;
 
-    // A second Enter while a broadcast is in-flight should pre-empt the
-    // first — leaving a stale controller would race two runs against the
-    // shared progress store. Abort then take over.
-    activeBroadcastController?.abort();
-    const controller = new AbortController();
-    activeBroadcastController = controller;
+    // Re-check eligibility at dispatch time. Panes that disarmed,
+    // trashed, or lost their PTY between Enter-press and dispatch must
+    // not still receive bytes just because the snapshot marked them
+    // eligible. `effectiveTargets` already filtered against
+    // `resolveFleetBroadcastTargetIds()`; re-run the panel-eligibility
+    // filter so disposed PTYs are dropped too.
+    const eligibleTargets = filterEligibleIds(effectiveTargets);
     try {
-      // Re-check eligibility at dispatch time. Panes that disarmed,
-      // trashed, or lost their PTY between Enter-press and dispatch must
-      // not still receive bytes just because the snapshot marked them
-      // eligible. `effectiveTargets` already filtered against
-      // `resolveFleetBroadcastTargetIds()`; re-run the panel-eligibility
-      // filter so disposed PTYs are dropped too.
-      const eligibleTargets = filterEligibleIds(effectiveTargets);
-      const result = await executeFleetBroadcast(
-        text,
-        eligibleTargets,
-        overridesArg,
-        controller.signal
-      );
+      // A second Enter while a broadcast is in-flight pre-empts the first;
+      // the shared controller lets the ribbon Cancel button abort it too.
+      const result = await runManagedFleetBroadcast(text, eligibleTargets, overridesArg);
       if (result.failureCount > 0) {
         logWarn("[fleetEnterBroadcast] broadcast had rejections", {
           failureCount: result.failureCount,
@@ -232,11 +250,9 @@ export function tryFleetBroadcastFromEditor(
         window.electron?.notification?.playUiEvent("context-injected").catch(() => {});
       }
     } finally {
-      if (activeBroadcastController === controller) {
-        activeBroadcastController = null;
-      }
       // Per-target overrides are ephemeral per-broadcast (#8691 constraint).
       // Clear them so the next broadcast starts from the resolved defaults.
+      // Controller teardown is owned by `runManagedFleetBroadcast`.
       useFleetTargetOverridesStore.getState().clear();
       onSent();
     }

--- a/src/components/Fleet/fleetExecution.ts
+++ b/src/components/Fleet/fleetExecution.ts
@@ -12,7 +12,6 @@ import {
   FLEET_LARGE_PASTE_BATCH_SIZE,
   FLEET_LARGE_PASTE_BYTE_THRESHOLD,
   getFleetBroadcastByteLength,
-  resolveFleetBroadcastTargetIds,
 } from "./fleetBroadcast";
 
 export interface FleetTargetPreview {
@@ -284,62 +283,4 @@ export async function executeFleetBroadcast(
       useFleetBroadcastProgressStore.getState().finish();
     }
   }
-}
-
-/**
- * Literal broadcast for pasted text — routes each target through
- * `terminalClient.submit` so the backend wraps the payload in bracketed paste
- * (`\e[200~…\e[201~`) when the PTY supports it. Skips recipe-variable
- * substitution because paste is a verbatim keyboard event, not a composed
- * prompt template.
- */
-export async function broadcastFleetLiteralPaste(
-  text: string,
-  targetIds?: string[]
-): Promise<FleetExecutionResult> {
-  const ids = targetIds ? filterEligibleIds(targetIds) : resolveFleetBroadcastTargetIds();
-  const submissions: Promise<void>[] = [];
-  const collected: string[] = [];
-
-  for (const id of ids) {
-    collected.push(id);
-    submissions.push(terminalClient.submit(id, text));
-  }
-
-  const results = await Promise.allSettled(submissions);
-  const perTarget: FleetExecutionResult["perTarget"] = results.map((r, i) => {
-    if (r.status === "fulfilled") {
-      return { terminalId: collected[i]!, status: "fulfilled" };
-    }
-    const reason = String(r.reason);
-    return {
-      terminalId: collected[i]!,
-      status: "rejected",
-      reason,
-      kind: classifyFleetRejectionReason(reason),
-    };
-  });
-
-  const successCount = results.filter((r) => r.status === "fulfilled").length;
-  const failedIds: string[] = [];
-  const permanentlyFailedIds: string[] = [];
-  const transientlyFailedIds: string[] = [];
-  for (const t of perTarget) {
-    if (t.status !== "rejected") continue;
-    failedIds.push(t.terminalId);
-    if (t.kind === "transient") transientlyFailedIds.push(t.terminalId);
-    else permanentlyFailedIds.push(t.terminalId);
-  }
-
-  return {
-    total: results.length,
-    successCount,
-    failureCount: results.length - successCount,
-    perTarget,
-    failedIds,
-    permanentlyFailedIds,
-    transientlyFailedIds,
-    cancelled: false,
-    skippedCount: 0,
-  };
 }

--- a/src/services/actions/definitions/__tests__/fleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/fleetActions.test.ts
@@ -42,9 +42,18 @@ vi.mock("@/store/persistence/panelPersistence", () => ({
 }));
 
 vi.mock("@/components/Fleet/fleetExecution", () => ({
-  broadcastFleetLiteralPaste: vi
-    .fn()
-    .mockResolvedValue({ failedIds: [], permanentlyFailedIds: [], transientlyFailedIds: [] }),
+  executeFleetBroadcast: vi.fn().mockResolvedValue({
+    total: 0,
+    successCount: 0,
+    failureCount: 0,
+    perTarget: [],
+    failedIds: [],
+    permanentlyFailedIds: [],
+    transientlyFailedIds: [],
+    cancelled: false,
+    skippedCount: 0,
+  }),
+  filterEligibleIds: vi.fn((ids: string[]) => ids),
 }));
 
 const { useFleetArmingStore } = await import("@/store/fleetArmingStore");
@@ -52,7 +61,8 @@ const { useFleetPendingActionStore } = await import("@/store/fleetPendingActionS
 const { useFleetFailureStore } = await import("@/store/fleetFailureStore");
 const { usePanelStore } = await import("@/store/panelStore");
 const { terminalClient } = await import("@/clients");
-const { broadcastFleetLiteralPaste } = await import("@/components/Fleet/fleetExecution");
+const { executeFleetBroadcast, filterEligibleIds } =
+  await import("@/components/Fleet/fleetExecution");
 const { registerFleetActions } = await import("../fleetActions");
 
 type ActionRegistry = Awaited<
@@ -579,7 +589,7 @@ describe("fleet.retryFailures", () => {
     });
     const registry = await buildRegistry();
     await run(registry, "fleet.retryFailures");
-    expect(broadcastFleetLiteralPaste).not.toHaveBeenCalled();
+    expect(executeFleetBroadcast).not.toHaveBeenCalled();
   });
 
   it("no-ops when failedIds is empty", async () => {
@@ -589,29 +599,83 @@ describe("fleet.retryFailures", () => {
     });
     const registry = await buildRegistry();
     await run(registry, "fleet.retryFailures");
-    expect(broadcastFleetLiteralPaste).not.toHaveBeenCalled();
+    expect(executeFleetBroadcast).not.toHaveBeenCalled();
   });
 
-  it("rebroadcasts the recorded payload to the failed targets when payload is non-null", async () => {
+  it("routes the recorded payload through executeFleetBroadcast as per-target overrides", async () => {
+    // #9950: the retry must run through the primary broadcast path so it gets
+    // batching, progress, directing-state, and cancellation — passing the
+    // already-substituted payload as overrides (empty draft) bypasses recipe
+    // substitution without re-resolving a verbatim literal.
     useFleetFailureStore.setState({
       failedIds: new Set(["t1", "t2"]),
       payload: "ls\r",
     });
     const registry = await buildRegistry();
     await run(registry, "fleet.retryFailures");
-    expect(broadcastFleetLiteralPaste).toHaveBeenCalledTimes(1);
-    const call = (broadcastFleetLiteralPaste as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(executeFleetBroadcast).toHaveBeenCalledTimes(1);
+    const call = (executeFleetBroadcast as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call).toBeDefined();
-    const [payload, targets] = call as [string, string[]];
-    expect(payload).toBe("ls\r");
-    expect((targets as string[]).slice().sort()).toEqual(["t1", "t2"]);
+    const [draft, targets, overrides, signal] = call as [
+      string,
+      string[],
+      Record<string, string>,
+      AbortSignal,
+    ];
+    expect(draft).toBe("");
+    expect(targets.slice().sort()).toEqual(["t1", "t2"]);
+    expect(overrides).toEqual({ t1: "ls\r", t2: "ls\r" });
+    expect(signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("filters out targets that went ineligible before dispatch", async () => {
+    // The primary broadcast path gates eligibility in its caller, not inside
+    // executeFleetBroadcast — so the retry action owns the filter. A pane that
+    // died since the failure was recorded must not receive bytes.
+    (filterEligibleIds as ReturnType<typeof vi.fn>).mockReturnValueOnce(["t1"]);
+    useFleetFailureStore.setState({
+      failedIds: new Set(["t1", "t2"]),
+      payload: "ls\r",
+      recordedAt: Date.now(),
+    });
+    const registry = await buildRegistry();
+    await run(registry, "fleet.retryFailures");
+    expect(executeFleetBroadcast).toHaveBeenCalledTimes(1);
+    const call = (executeFleetBroadcast as ReturnType<typeof vi.fn>).mock.calls[0];
+    const [, targets, overrides] = call as [string, string[], Record<string, string>];
+    expect(targets).toEqual(["t1"]);
+    expect(overrides).toEqual({ t1: "ls\r" });
+  });
+
+  it("no-ops when every target is filtered out as ineligible", async () => {
+    // All recorded failures point at panes that are gone — skip the broadcast
+    // entirely so the progress store isn't spuriously activated for 0 targets.
+    (filterEligibleIds as ReturnType<typeof vi.fn>).mockReturnValueOnce([]);
+    useFleetFailureStore.setState({
+      failedIds: new Set(["t1", "t2"]),
+      payload: "ls\r",
+      recordedAt: Date.now(),
+    });
+    const registry = await buildRegistry();
+    await run(registry, "fleet.retryFailures");
+    expect(executeFleetBroadcast).not.toHaveBeenCalled();
+    // Store is untouched — nothing was retried.
+    const s = useFleetFailureStore.getState();
+    expect(s.failedIds.size).toBe(2);
+    expect(s.payload).toBe("ls\r");
   });
 
   it("dismisses targets that succeeded on retry and preserves the ones that still fail", async () => {
-    (broadcastFleetLiteralPaste as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    (executeFleetBroadcast as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      total: 3,
+      successCount: 2,
+      failureCount: 1,
+      perTarget: [],
       failedIds: ["t2"],
       transientlyFailedIds: ["t2"],
       permanentlyFailedIds: [],
+      cancelled: false,
+      skippedCount: 0,
     });
     useFleetFailureStore.setState({
       failedIds: new Set(["t1", "t2", "t3"]),
@@ -625,10 +689,16 @@ describe("fleet.retryFailures", () => {
   });
 
   it("clears the store entirely when every target succeeds on retry", async () => {
-    (broadcastFleetLiteralPaste as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    (executeFleetBroadcast as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      total: 2,
+      successCount: 2,
+      failureCount: 0,
+      perTarget: [],
       failedIds: [],
       transientlyFailedIds: [],
       permanentlyFailedIds: [],
+      cancelled: false,
+      skippedCount: 0,
     });
     useFleetFailureStore.setState({
       failedIds: new Set(["t1", "t2"]),
@@ -653,6 +723,36 @@ describe("fleet.retryFailures", () => {
     expect(s.payload).toBeNull();
   });
 
+  it("disarms permanent failures and dismisses them from the retry chip", async () => {
+    // Dead PTYs auto-disarm so a future retry doesn't keep firing into the
+    // same dead pipes, and the chip clears for them too.
+    (executeFleetBroadcast as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      total: 2,
+      successCount: 0,
+      failureCount: 2,
+      perTarget: [],
+      failedIds: ["t1", "t2"],
+      transientlyFailedIds: ["t2"],
+      permanentlyFailedIds: ["t1"],
+      cancelled: false,
+      skippedCount: 0,
+    });
+    seedPanels([makeAgent("t1"), makeAgent("t2")]);
+    useFleetArmingStore.getState().armIds(["t1", "t2"]);
+    useFleetFailureStore.setState({
+      failedIds: new Set(["t1", "t2"]),
+      payload: "ls\r",
+      recordedAt: Date.now(),
+    });
+    const registry = await buildRegistry();
+    await run(registry, "fleet.retryFailures");
+    expect(useFleetArmingStore.getState().armedIds.has("t1")).toBe(false);
+    expect(useFleetArmingStore.getState().armedIds.has("t2")).toBe(true);
+    const s = useFleetFailureStore.getState();
+    // t1 dismissed (permanent), t2 retained (still transiently failing).
+    expect(Array.from(s.failedIds)).toEqual(["t2"]);
+  });
+
   it("guards against double-dispatch (re-entrant retry while in flight)", async () => {
     type BroadcastResult = {
       failedIds: string[];
@@ -660,7 +760,7 @@ describe("fleet.retryFailures", () => {
       permanentlyFailedIds: string[];
     };
     let resolveBroadcast: ((value: BroadcastResult) => void) | null = null;
-    (broadcastFleetLiteralPaste as ReturnType<typeof vi.fn>).mockImplementationOnce(
+    (executeFleetBroadcast as ReturnType<typeof vi.fn>).mockImplementationOnce(
       () =>
         new Promise<BroadcastResult>((resolve) => {
           resolveBroadcast = resolve;
@@ -674,7 +774,7 @@ describe("fleet.retryFailures", () => {
     const first = run(registry, "fleet.retryFailures");
     // Second call happens while the first is awaiting the broadcast.
     await run(registry, "fleet.retryFailures");
-    expect(broadcastFleetLiteralPaste).toHaveBeenCalledTimes(1);
+    expect(executeFleetBroadcast).toHaveBeenCalledTimes(1);
     (resolveBroadcast as ((value: BroadcastResult) => void) | null)?.({
       failedIds: [],
       transientlyFailedIds: [],

--- a/src/services/actions/definitions/__tests__/fleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/fleetActions.test.ts
@@ -42,7 +42,11 @@ vi.mock("@/store/persistence/panelPersistence", () => ({
 }));
 
 vi.mock("@/components/Fleet/fleetExecution", () => ({
-  executeFleetBroadcast: vi.fn().mockResolvedValue({
+  filterEligibleIds: vi.fn((ids: string[]) => ids),
+}));
+
+vi.mock("@/components/Fleet/fleetEnterBroadcast", () => ({
+  runManagedFleetBroadcast: vi.fn().mockResolvedValue({
     total: 0,
     successCount: 0,
     failureCount: 0,
@@ -53,7 +57,6 @@ vi.mock("@/components/Fleet/fleetExecution", () => ({
     cancelled: false,
     skippedCount: 0,
   }),
-  filterEligibleIds: vi.fn((ids: string[]) => ids),
 }));
 
 const { useFleetArmingStore } = await import("@/store/fleetArmingStore");
@@ -61,8 +64,8 @@ const { useFleetPendingActionStore } = await import("@/store/fleetPendingActionS
 const { useFleetFailureStore } = await import("@/store/fleetFailureStore");
 const { usePanelStore } = await import("@/store/panelStore");
 const { terminalClient } = await import("@/clients");
-const { executeFleetBroadcast, filterEligibleIds } =
-  await import("@/components/Fleet/fleetExecution");
+const { filterEligibleIds } = await import("@/components/Fleet/fleetExecution");
+const { runManagedFleetBroadcast } = await import("@/components/Fleet/fleetEnterBroadcast");
 const { registerFleetActions } = await import("../fleetActions");
 
 type ActionRegistry = Awaited<
@@ -589,7 +592,7 @@ describe("fleet.retryFailures", () => {
     });
     const registry = await buildRegistry();
     await run(registry, "fleet.retryFailures");
-    expect(executeFleetBroadcast).not.toHaveBeenCalled();
+    expect(runManagedFleetBroadcast).not.toHaveBeenCalled();
   });
 
   it("no-ops when failedIds is empty", async () => {
@@ -599,33 +602,27 @@ describe("fleet.retryFailures", () => {
     });
     const registry = await buildRegistry();
     await run(registry, "fleet.retryFailures");
-    expect(executeFleetBroadcast).not.toHaveBeenCalled();
+    expect(runManagedFleetBroadcast).not.toHaveBeenCalled();
   });
 
-  it("routes the recorded payload through executeFleetBroadcast as per-target overrides", async () => {
+  it("routes the recorded payload through the managed broadcast as per-target overrides", async () => {
     // #9950: the retry must run through the primary broadcast path so it gets
-    // batching, progress, directing-state, and cancellation — passing the
-    // already-substituted payload as overrides (empty draft) bypasses recipe
-    // substitution without re-resolving a verbatim literal.
+    // batching, progress, directing-state, and a working Cancel button —
+    // passing the already-substituted payload as overrides (empty draft)
+    // bypasses recipe substitution without re-resolving a verbatim literal.
     useFleetFailureStore.setState({
       failedIds: new Set(["t1", "t2"]),
       payload: "ls\r",
     });
     const registry = await buildRegistry();
     await run(registry, "fleet.retryFailures");
-    expect(executeFleetBroadcast).toHaveBeenCalledTimes(1);
-    const call = (executeFleetBroadcast as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(runManagedFleetBroadcast).toHaveBeenCalledTimes(1);
+    const call = (runManagedFleetBroadcast as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call).toBeDefined();
-    const [draft, targets, overrides, signal] = call as [
-      string,
-      string[],
-      Record<string, string>,
-      AbortSignal,
-    ];
+    const [draft, targets, overrides] = call as [string, string[], Record<string, string>];
     expect(draft).toBe("");
     expect(targets.slice().sort()).toEqual(["t1", "t2"]);
     expect(overrides).toEqual({ t1: "ls\r", t2: "ls\r" });
-    expect(signal).toBeInstanceOf(AbortSignal);
   });
 
   it("filters out targets that went ineligible before dispatch", async () => {
@@ -640,8 +637,8 @@ describe("fleet.retryFailures", () => {
     });
     const registry = await buildRegistry();
     await run(registry, "fleet.retryFailures");
-    expect(executeFleetBroadcast).toHaveBeenCalledTimes(1);
-    const call = (executeFleetBroadcast as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(runManagedFleetBroadcast).toHaveBeenCalledTimes(1);
+    const call = (runManagedFleetBroadcast as ReturnType<typeof vi.fn>).mock.calls[0];
     const [, targets, overrides] = call as [string, string[], Record<string, string>];
     expect(targets).toEqual(["t1"]);
     expect(overrides).toEqual({ t1: "ls\r" });
@@ -658,7 +655,7 @@ describe("fleet.retryFailures", () => {
     });
     const registry = await buildRegistry();
     await run(registry, "fleet.retryFailures");
-    expect(executeFleetBroadcast).not.toHaveBeenCalled();
+    expect(runManagedFleetBroadcast).not.toHaveBeenCalled();
     // Store is untouched — nothing was retried.
     const s = useFleetFailureStore.getState();
     expect(s.failedIds.size).toBe(2);
@@ -666,7 +663,7 @@ describe("fleet.retryFailures", () => {
   });
 
   it("dismisses targets that succeeded on retry and preserves the ones that still fail", async () => {
-    (executeFleetBroadcast as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    (runManagedFleetBroadcast as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       total: 3,
       successCount: 2,
       failureCount: 1,
@@ -689,7 +686,7 @@ describe("fleet.retryFailures", () => {
   });
 
   it("clears the store entirely when every target succeeds on retry", async () => {
-    (executeFleetBroadcast as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    (runManagedFleetBroadcast as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       total: 2,
       successCount: 2,
       failureCount: 0,
@@ -726,7 +723,7 @@ describe("fleet.retryFailures", () => {
   it("disarms permanent failures and dismisses them from the retry chip", async () => {
     // Dead PTYs auto-disarm so a future retry doesn't keep firing into the
     // same dead pipes, and the chip clears for them too.
-    (executeFleetBroadcast as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    (runManagedFleetBroadcast as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       total: 2,
       successCount: 0,
       failureCount: 2,
@@ -760,7 +757,7 @@ describe("fleet.retryFailures", () => {
       permanentlyFailedIds: string[];
     };
     let resolveBroadcast: ((value: BroadcastResult) => void) | null = null;
-    (executeFleetBroadcast as ReturnType<typeof vi.fn>).mockImplementationOnce(
+    (runManagedFleetBroadcast as ReturnType<typeof vi.fn>).mockImplementationOnce(
       () =>
         new Promise<BroadcastResult>((resolve) => {
           resolveBroadcast = resolve;
@@ -774,7 +771,7 @@ describe("fleet.retryFailures", () => {
     const first = run(registry, "fleet.retryFailures");
     // Second call happens while the first is awaiting the broadcast.
     await run(registry, "fleet.retryFailures");
-    expect(executeFleetBroadcast).toHaveBeenCalledTimes(1);
+    expect(runManagedFleetBroadcast).toHaveBeenCalledTimes(1);
     (resolveBroadcast as ((value: BroadcastResult) => void) | null)?.({
       failedIds: [],
       transientlyFailedIds: [],

--- a/src/services/actions/definitions/__tests__/fleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/fleetActions.test.ts
@@ -633,7 +633,6 @@ describe("fleet.retryFailures", () => {
     useFleetFailureStore.setState({
       failedIds: new Set(["t1", "t2"]),
       payload: "ls\r",
-      recordedAt: Date.now(),
     });
     const registry = await buildRegistry();
     await run(registry, "fleet.retryFailures");
@@ -651,7 +650,6 @@ describe("fleet.retryFailures", () => {
     useFleetFailureStore.setState({
       failedIds: new Set(["t1", "t2"]),
       payload: "ls\r",
-      recordedAt: Date.now(),
     });
     const registry = await buildRegistry();
     await run(registry, "fleet.retryFailures");
@@ -739,7 +737,6 @@ describe("fleet.retryFailures", () => {
     useFleetFailureStore.setState({
       failedIds: new Set(["t1", "t2"]),
       payload: "ls\r",
-      recordedAt: Date.now(),
     });
     const registry = await buildRegistry();
     await run(registry, "fleet.retryFailures");

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -21,7 +21,8 @@ import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useProjectStore } from "@/store/projectStore";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { projectClient, terminalClient } from "@/clients";
-import { executeFleetBroadcast, filterEligibleIds } from "@/components/Fleet/fleetExecution";
+import { filterEligibleIds } from "@/components/Fleet/fleetExecution";
+import { runManagedFleetBroadcast } from "@/components/Fleet/fleetEnterBroadcast";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { notify } from "@/lib/notify";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -351,16 +352,11 @@ export function registerFleetActions(actions: ActionRegistry): void {
         // literal the user originally broadcast), so route it through
         // perTargetOverrides to bypass executeFleetBroadcast's recipe-variable
         // substitution — the empty draft is never resolved when every target
-        // has an override. A fresh controller keeps the retry independent of
-        // the ribbon Cancel button's activeBroadcastController.
+        // has an override. `runManagedFleetBroadcast` runs it through the shared
+        // single-flight controller so the retry gains batching, progress, and a
+        // working ribbon Cancel button just like the primary Enter path.
         const perTargetOverrides = Object.fromEntries(eligibleTargets.map((id) => [id, payload]));
-        const controller = new AbortController();
-        const result = await executeFleetBroadcast(
-          "",
-          eligibleTargets,
-          perTargetOverrides,
-          controller.signal
-        );
+        const result = await runManagedFleetBroadcast("", eligibleTargets, perTargetOverrides);
         // Permanent failures (dead PTYs) auto-disarm so a future retry doesn't
         // keep firing into the same dead pipes. The retry chip clears for them
         // too — the user already saw them once; surfacing the same id again

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -21,7 +21,7 @@ import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useProjectStore } from "@/store/projectStore";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { projectClient, terminalClient } from "@/clients";
-import { broadcastFleetLiteralPaste } from "@/components/Fleet/fleetExecution";
+import { executeFleetBroadcast, filterEligibleIds } from "@/components/Fleet/fleetExecution";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { notify } from "@/lib/notify";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -339,9 +339,28 @@ export function registerFleetActions(actions: ActionRegistry): void {
       if (payload == null || failedIds.size === 0) return;
       // Snapshot once — `failedIds` mutates as dismissId fires inside the loop.
       const targets = Array.from(failedIds);
+      // Re-check eligibility at dispatch time: a pane that died or was trashed
+      // since the failure was recorded must not receive bytes. The primary
+      // broadcast gates this in its caller (tryFleetBroadcastFromEditor), not
+      // inside executeFleetBroadcast — so the retry path owns the filter too.
+      const eligibleTargets = filterEligibleIds(targets);
+      if (eligibleTargets.length === 0) return;
       retryInFlight = true;
       try {
-        const result = await broadcastFleetLiteralPaste(payload, targets);
+        // The stored payload is already fully substituted (it's the verbatim
+        // literal the user originally broadcast), so route it through
+        // perTargetOverrides to bypass executeFleetBroadcast's recipe-variable
+        // substitution — the empty draft is never resolved when every target
+        // has an override. A fresh controller keeps the retry independent of
+        // the ribbon Cancel button's activeBroadcastController.
+        const perTargetOverrides = Object.fromEntries(eligibleTargets.map((id) => [id, payload]));
+        const controller = new AbortController();
+        const result = await executeFleetBroadcast(
+          "",
+          eligibleTargets,
+          perTargetOverrides,
+          controller.signal
+        );
         // Permanent failures (dead PTYs) auto-disarm so a future retry doesn't
         // keep firing into the same dead pipes. The retry chip clears for them
         // too — the user already saw them once; surfacing the same id again


### PR DESCRIPTION
## Summary

- `fleet.retryFailures` was calling `broadcastFleetLiteralPaste`, a stripped-down helper that skipped batching, `AbortSignal` cancellation, progress-store updates, and `terminalInstanceService` directing-state notifications — all affordances the original send had.
- Rerouted retry through a new `runManagedFleetBroadcast` helper shared with `executeFleetBroadcast`, so retries get the same treatment as the initial broadcast: IPC fan-out batching, a working ribbon Cancel button, progress counter updates, and the blue directing indicator.
- The stored payload is passed as `perTargetOverrides` (empty draft) to bypass recipe-variable substitution on replay; eligibility is re-checked via `filterEligibleIds` before dispatch; and the retry runs through the shared `activeBroadcastController` so a concurrent Enter broadcast pre-empts it cleanly instead of racing the progress store.

Resolves #9950

## Changes

- `fleetEnterBroadcast.ts` — extracted `runManagedFleetBroadcast` shared helper from `executeFleetBroadcast`
- `fleetActions.ts` — `fleet.retryFailures` now calls `runManagedFleetBroadcast` with `perTargetOverrides`, eligibility re-check, and single-flight controller wiring
- `fleetExecution.ts` — deleted `broadcastFleetLiteralPaste` (no remaining callers)
- `fleetActions.test.ts` / `fleetExecution.test.ts` — migrated and extended test coverage; 96 fleet tests pass

## Testing

- 96 fleet unit tests pass
- `npm run check` clean (0 errors)