### PR TITLE
perf(project-switch): rebroker PTY port before worktree git load

### DIFF
--- a/electron/ipc/handlers/__tests__/project.switch.test.ts
+++ b/electron/ipc/handlers/__tests__/project.switch.test.ts
@@ -854,9 +854,39 @@ describe("project:switch PTY port ordering (#10075)", () => {
 
     expect(ptyClient.onProjectSwitch).toHaveBeenCalledWith(7, "proj-new", "/projects/new");
     expect(distributeMock).toHaveBeenCalledTimes(1);
+    // Port goes to the sender's window/context and carries the live ptyClient —
+    // routing to the wrong window would silently drop terminal data.
+    expect(distributeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 7 }),
+      expect.any(Object),
+      expect.objectContaining({ id: 300 }),
+      ptyClient
+    );
+    // PTY-host routing must be updated before the renderer port opens, else the
+    // port is connected while the host still points at the old project.
+    expect(ptyClient.onProjectSwitch.mock.invocationCallOrder[0]).toBeLessThan(
+      distributeMock.mock.invocationCallOrder[0]
+    );
 
     resolveLoad();
     await handlerPromise;
+  });
+
+  it("still rebrokers the PTY port even when the worktree load rejects", async () => {
+    const { invoke, ptyClient } = setup({
+      isNew: false,
+      loadProject: async () => {
+        throw new Error("Not a git repository");
+      },
+    });
+    const distributeMock = vi.mocked(distributePortsToView);
+
+    await invoke();
+
+    // The reorder runs PTY work before loadProject, so a git-load failure must
+    // not retroactively undo terminal connectivity (#10075).
+    expect(ptyClient.onProjectSwitch).toHaveBeenCalledWith(7, "proj-new", "/projects/new");
+    expect(distributeMock).toHaveBeenCalledTimes(1);
   });
 
   it("does not redistribute the PTY port for a cold-started view (isNew guard)", async () => {

--- a/electron/ipc/handlers/__tests__/project.switch.test.ts
+++ b/electron/ipc/handlers/__tests__/project.switch.test.ts
@@ -65,6 +65,7 @@ vi.mock("../../../window/portDistribution.js", () => ({
 
 import { ipcMain } from "electron";
 import { CHANNELS } from "../../channels.js";
+import { distributePortsToView } from "../../../window/portDistribution.js";
 import { registerProjectCrudHandlers } from "../projectCrud/index.js";
 import type { HandlerDependencies } from "../../types.js";
 import type {
@@ -772,5 +773,105 @@ describe("project:switch provenance (#9859)", () => {
     const switchId = (call![1] as { switchId: string }).switchId;
     expect(typeof switchId).toBe("string");
     expect(switchId.length).toBeGreaterThan(0);
+  });
+});
+
+describe("project:switch PTY port ordering (#10075)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function setup(opts: { isNew: boolean; loadProject: () => Promise<void> }) {
+    const sendMock = vi.fn();
+    const mockView = {
+      webContents: { id: 300, isDestroyed: () => false, send: sendMock },
+    };
+    const pvm = {
+      switchTo: vi.fn().mockResolvedValue({ view: mockView, isNew: opts.isNew }),
+      getProjectIdForWebContents: vi.fn(),
+    };
+
+    mockGetWindowForWebContents.mockReturnValue({ id: 7, isDestroyed: () => false });
+
+    projectStoreMock.getCurrentProjectId.mockReturnValue("proj-old");
+    projectStoreMock.getProjectById.mockReturnValue({
+      id: "proj-new",
+      name: "New Project",
+      path: "/projects/new",
+    });
+    projectStoreMock.setCurrentProject.mockResolvedValue(undefined);
+
+    const ptyClient = { onProjectSwitch: vi.fn() };
+    const worktreeService = {
+      loadProject: vi.fn(opts.loadProject),
+      attachDirectPort: vi.fn(),
+      getHostForProject: vi.fn(() => null),
+    };
+    const windowRegistry = makeWindowRegistry([makeWindowContext(7, 300)]);
+    (
+      windowRegistry as unknown as { registerAppViewWebContents: unknown }
+    ).registerAppViewWebContents = vi.fn();
+
+    const deps = {
+      mainWindow: { id: 7 } as unknown,
+      projectViewManager: pvm,
+      worktreeService: worktreeService as never,
+      ptyClient: ptyClient as never,
+      windowRegistry,
+    } as unknown as HandlerDependencies;
+
+    registerProjectCrudHandlers(deps);
+
+    const handleMap = new Map<string, (...args: unknown[]) => unknown>();
+    for (const call of (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls) {
+      handleMap.set(call[0] as string, call[1] as (...args: unknown[]) => unknown);
+    }
+
+    const invoke = () =>
+      handleMap.get(CHANNELS.PROJECT_SWITCH)!({ sender: { id: 300 } }, "proj-new");
+
+    return { invoke, ptyClient, worktreeService };
+  }
+
+  it("rebrokers the PTY port before the worktree git load resolves on a warm switch", async () => {
+    // A deferred loadProject lets us observe state at the moment the handler
+    // reaches the (slow) git-load await — the PTY work must already be done by
+    // then, otherwise terminal output would queue behind the load (#10075).
+    let resolveLoad: () => void = () => {};
+    const loadGate = new Promise<void>((resolve) => {
+      resolveLoad = resolve;
+    });
+
+    const { invoke, ptyClient, worktreeService } = setup({
+      isNew: false,
+      loadProject: () => loadGate,
+    });
+    const distributeMock = vi.mocked(distributePortsToView);
+
+    const handlerPromise = invoke();
+
+    await vi.waitFor(() => expect(worktreeService.loadProject).toHaveBeenCalled());
+
+    expect(ptyClient.onProjectSwitch).toHaveBeenCalledWith(7, "proj-new", "/projects/new");
+    expect(distributeMock).toHaveBeenCalledTimes(1);
+
+    resolveLoad();
+    await handlerPromise;
+  });
+
+  it("does not redistribute the PTY port for a cold-started view (isNew guard)", async () => {
+    const { invoke, ptyClient } = setup({
+      isNew: true,
+      loadProject: async () => undefined,
+    });
+    const distributeMock = vi.mocked(distributePortsToView);
+
+    await invoke();
+
+    // Cold-start views get their first PTY port from
+    // ProjectViewManager.onViewReady; redistributing here would race it.
+    expect(distributeMock).not.toHaveBeenCalled();
+    // onProjectSwitch still fires regardless of new/warm.
+    expect(ptyClient.onProjectSwitch).toHaveBeenCalledWith(7, "proj-new", "/projects/new");
   });
 });

--- a/electron/ipc/handlers/projectCrud/switch.ts
+++ b/electron/ipc/handlers/projectCrud/switch.ts
@@ -224,14 +224,43 @@ async function activateProjectView(
     deps.worktreeService.resumeProject(project.path);
   }
 
+  const senderWindow = getWindowForWebContents(event.sender);
+  const windowId = senderWindow?.id ?? deps.mainWindow?.id;
+
+  // Notify the PTY host of the active project and distribute a fresh
+  // MessagePort to the reactivated view BEFORE the worktree git load. On warm
+  // switches `loadProject` below can take several hundred ms (prune/list/status
+  // sync/LFS probe); running it first would leave the just-swapped view showing
+  // stale buffered terminal output until the git load resolves, because new PTY
+  // data has nowhere to flow until the renderer holds its new port (#10075).
+  // PTY rebrokering has no dependency on `loadProject` or the WorkspaceClient
+  // windowToProject mapping, so it is safe to run first — this matches the
+  // legacy ProjectSwitchService ordering (onProjectSwitch before loadProject).
+  if (windowId !== undefined) {
+    if (deps.ptyClient) {
+      deps.ptyClient.onProjectSwitch(windowId, projectId, project.path);
+    }
+
+    // Cold-started views receive their first PTY MessagePort from
+    // ProjectViewManager.onViewReady during did-finish-load. Replacing that
+    // port again here can race with the first terminal prompt after the view
+    // becomes interactive. Cached reactivations do not reload, so they still
+    // need a fresh port here.
+    const win = senderWindow ?? deps.mainWindow;
+    if (!isNew && win && deps.windowRegistry && !view.webContents.isDestroyed()) {
+      const ctx = deps.windowRegistry.getByWindowId(win.id);
+      if (ctx) {
+        distributePortsToView(win, ctx, view.webContents, deps.ptyClient ?? null);
+      }
+    }
+  }
+
   // Always call loadProject so the WorkspaceClient's windowToProject
   // mapping points to the correct project.  Without this, reactivating a
   // cached view leaves the mapping pointing at the *previous* project,
   // causing sendToEntryWindows to route the old project's IPC events to
   // the newly-active view (cross-project worktree contamination).
   if (deps.worktreeService) {
-    const senderWindow = getWindowForWebContents(event.sender);
-    const windowId = senderWindow?.id ?? deps.mainWindow?.id;
     if (windowId !== undefined) {
       // Forward-fail: the view swap already committed to the new project, so a
       // load failure surfaces as a Tier 3 recovery banner rather than reverting
@@ -269,29 +298,6 @@ async function activateProjectView(
     // Register the new view's webContents in WindowRegistry
     if (isNew && deps.windowRegistry && senderWindow) {
       deps.windowRegistry.registerAppViewWebContents(senderWindow.id, view.webContents.id);
-    }
-  }
-
-  // Notify PTY host of the active project and distribute a fresh
-  // MessagePort to the new/reactivated view so terminal data flows.
-  const senderWindow = getWindowForWebContents(event.sender);
-  const windowId = senderWindow?.id ?? deps.mainWindow?.id;
-  if (windowId !== undefined) {
-    if (deps.ptyClient) {
-      deps.ptyClient.onProjectSwitch(windowId, projectId, project.path);
-    }
-
-    // Cold-started views receive their first PTY MessagePort from
-    // ProjectViewManager.onViewReady during did-finish-load. Replacing that
-    // port again here can race with the first terminal prompt after the view
-    // becomes interactive. Cached reactivations do not reload, so they still
-    // need a fresh port here.
-    const win = senderWindow ?? deps.mainWindow;
-    if (!isNew && win && deps.windowRegistry && !view.webContents.isDestroyed()) {
-      const ctx = deps.windowRegistry.getByWindowId(win.id);
-      if (ctx) {
-        distributePortsToView(win, ctx, view.webContents, deps.ptyClient ?? null);
-      }
     }
   }
 }

--- a/electron/ipc/handlers/projectCrud/switch.ts
+++ b/electron/ipc/handlers/projectCrud/switch.ts
@@ -237,21 +237,28 @@ async function activateProjectView(
   // windowToProject mapping, so it is safe to run first — this matches the
   // legacy ProjectSwitchService ordering (onProjectSwitch before loadProject).
   if (windowId !== undefined) {
-    if (deps.ptyClient) {
-      deps.ptyClient.onProjectSwitch(windowId, projectId, project.path);
-    }
-
-    // Cold-started views receive their first PTY MessagePort from
-    // ProjectViewManager.onViewReady during did-finish-load. Replacing that
-    // port again here can race with the first terminal prompt after the view
-    // becomes interactive. Cached reactivations do not reload, so they still
-    // need a fresh port here.
-    const win = senderWindow ?? deps.mainWindow;
-    if (!isNew && win && deps.windowRegistry && !view.webContents.isDestroyed()) {
-      const ctx = deps.windowRegistry.getByWindowId(win.id);
-      if (ctx) {
-        distributePortsToView(win, ctx, view.webContents, deps.ptyClient ?? null);
+    // Best-effort: the PTY rebrokering now runs before the worktree load, so an
+    // unexpected throw here must not abort the switch and skip `loadProject`
+    // (which would leave the WorkspaceClient windowToProject mapping stale).
+    try {
+      if (deps.ptyClient) {
+        deps.ptyClient.onProjectSwitch(windowId, projectId, project.path);
       }
+
+      // Cold-started views receive their first PTY MessagePort from
+      // ProjectViewManager.onViewReady during did-finish-load. Replacing that
+      // port again here can race with the first terminal prompt after the view
+      // becomes interactive. Cached reactivations do not reload, so they still
+      // need a fresh port here.
+      const win = senderWindow ?? deps.mainWindow;
+      if (!isNew && win && deps.windowRegistry && !view.webContents.isDestroyed()) {
+        const ctx = deps.windowRegistry.getByWindowId(win.id);
+        if (ctx) {
+          distributePortsToView(win, ctx, view.webContents, deps.ptyClient ?? null);
+        }
+      }
+    } catch (err) {
+      console.error(`${options.logPrefix} Failed to rebroker PTY port:`, err);
     }
   }
 


### PR DESCRIPTION
## Summary

On a warm project switch, there was a noticeable delay before terminals started showing new output. The PTY port re-brokering code in `activateProjectView` (`electron/ipc/handlers/projectCrud/switch.ts`) ran after `await worktreeService.loadProject(...)`, which takes several hundred milliseconds on a warm switch — git prune, worktree list, status sync, and LFS probe. Since `pvm.switchTo()` had already completed the visible swap, users were looking at the reactivated view with stale buffered output while new terminal data sat queued in the headless mirror.

The fix moves the PTY block — `ptyClient.onProjectSwitch` + `distributePortsToView` — before the `loadProject` await, matching the ordering that the legacy `ProjectSwitchService` already used. The worktree direct-port brokering stays after `loadProject` since it needs the host to exist. Also hoisted `senderWindow` and `windowId` to deduplicate declarations, and wrapped the PTY block in `try/catch` so a throw there can't abort the switch before `loadProject` runs (keeping `windowToProject` consistent).

Resolves #10075

## Changes

- `electron/ipc/handlers/projectCrud/switch.ts` — PTY block moved before `loadProject` await; `senderWindow`/`windowId` hoisted; PTY block wrapped in `try/catch`
- `electron/ipc/handlers/__tests__/project.switch.test.ts` — 3 new ordering tests: warm rebroker-before-load (with arg and call-order assertions), cold-start `isNew` skip, rebroker on load rejection

## Testing

All 18 tests in `project.switch.test.ts` pass. `npm run check` is clean.