### PR TITLE
fix(terminal): eliminate 80×24 snap on warm project switch

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -874,20 +874,13 @@ class TerminalInstanceService {
     if (!current) return;
     if (!current.isOpened) return;
 
-    // Attach is in progress — running the wake now would race the attach's own
-    // post-rAF reconciliation. That reconciliation path does NOT run the full
-    // visibility-restore sequence, so we can't simply defer to it: mark the
-    // terminal so notifyAttachSettledWaiters re-runs this wake once attach
-    // settles (#9702).
-    if (current.isAttaching) {
-      current.pendingVisibilityWake = true;
-      return;
-    }
-
-    // We're proceeding with the full wake now, so clear any stale deferred-wake
-    // flag (e.g. a prior skip whose deferred re-run we are now satisfying).
-    current.pendingVisibilityWake = false;
-
+    // Geometry sync runs synchronously even while attaching (#10070).
+    // applyDeferredResize only calls terminal.resize() — no buffer reset, no
+    // async — so it is safe mid-attach and corrects the grid before the warm
+    // paint gate releases the bridge view. Without this, an attaching terminal
+    // stays at the default 80x24 until the deferred wake re-runs after the
+    // bridge has already dropped, producing the visible render-small-then-snap.
+    //
     // Unlock symmetrically with the relock in the finally below: bypass the
     // lock whenever resize is suppressed, even if the suppression end time was
     // already cleared (the timer can fire between switch-back and this deferred
@@ -908,6 +901,20 @@ class TerminalInstanceService {
         this.resizeController.lockResize(id, true, remainingMs);
       }
     }
+
+    // Attach is in progress — running the async wake now would race the
+    // attach's own post-rAF reconciliation, which calls terminal.reset()
+    // during buffer restore. The geometry sync above is safe to keep, but the
+    // async wake must defer: mark the terminal so notifyAttachSettledWaiters
+    // re-runs this wake once attach settles (#9702).
+    if (current.isAttaching) {
+      current.pendingVisibilityWake = true;
+      return;
+    }
+
+    // We're proceeding with the full wake now, so clear any stale deferred-wake
+    // flag (e.g. a prior skip whose deferred re-run we are now satisfying).
+    current.pendingVisibilityWake = false;
 
     const termEl = current.terminal.element;
     if (termEl) {
@@ -1852,6 +1859,19 @@ class TerminalInstanceService {
 
     this.resizeController.clearResizeJob(managed);
     this.resizeController.clearSettledTimer(id);
+
+    // Seed the warm-attach target dims from the last measured geometry (#10070).
+    // Background-tier resizes only update latestCols/latestRows, never
+    // targetCols/targetRows, so a terminal that was only ever resized while
+    // backgrounded reattaches with no saved targets — the synchronous
+    // warm-attach resize (and the cold-seed before open()) is skipped and the
+    // grid flashes 80x24. Backfill here, at the lifecycle boundary where we
+    // know the terminal is about to be reattached warm, only when targets are
+    // unset and the measured size is real.
+    if (!managed.targetCols && managed.latestCols > 0) {
+      managed.targetCols = managed.latestCols;
+      managed.targetRows = managed.latestRows;
+    }
 
     if (managed.hostElement.parentElement) {
       const hiddenContainer = this.offscreenManager.ensureHiddenContainer();

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -874,6 +874,13 @@ class TerminalInstanceService {
     if (!current) return;
     if (!current.isOpened) return;
 
+    // Set the deferred-wake flag before the geometry sync so an unexpected
+    // throw from applyDeferredResize (e.g. a terminal disposed between the
+    // unhibernate re-fetch above and here) can't strand it: while attaching the
+    // async wake must re-run once attach settles, so the flag has to survive a
+    // throw. On the proceed path we clear it again below.
+    current.pendingVisibilityWake = current.isAttaching === true;
+
     // Geometry sync runs synchronously even while attaching (#10070).
     // applyDeferredResize only calls terminal.resize() — no buffer reset, no
     // async — so it is safe mid-attach and corrects the grid before the warm
@@ -905,10 +912,10 @@ class TerminalInstanceService {
     // Attach is in progress — running the async wake now would race the
     // attach's own post-rAF reconciliation, which calls terminal.reset()
     // during buffer restore. The geometry sync above is safe to keep, but the
-    // async wake must defer: mark the terminal so notifyAttachSettledWaiters
-    // re-runs this wake once attach settles (#9702).
+    // async wake must defer: pendingVisibilityWake was already set true above
+    // so notifyAttachSettledWaiters re-runs this wake once attach settles
+    // (#9702).
     if (current.isAttaching) {
-      current.pendingVisibilityWake = true;
       return;
     }
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.detach.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.detach.test.ts
@@ -77,6 +77,10 @@ describe("TerminalInstanceService detach blur", () => {
       isVisible: true,
       lastDetachAt: 0,
       hoveredLink: null as unknown,
+      latestCols: 0,
+      latestRows: 0,
+      targetCols: undefined as number | undefined,
+      targetRows: undefined as number | undefined,
     };
   };
 
@@ -161,5 +165,70 @@ describe("TerminalInstanceService detach blur", () => {
     service.detachForProjectSwitch("t4");
 
     expect(managed.hoveredLink).toBeNull();
+  });
+
+  it("detachForProjectSwitch() backfills target dims from latest geometry when unset (#10070)", () => {
+    const managed = makeMockManaged("t5");
+    managed.latestCols = 120;
+    managed.latestRows = 40;
+    const parent = document.createElement("div");
+    parent.appendChild(managed.hostElement);
+    service.instances.set("t5", managed);
+
+    vi.spyOn(service.offscreenManager, "ensureHiddenContainer").mockReturnValue(
+      document.createElement("div")
+    );
+    vi.spyOn(service.resizeController, "clearResizeJob").mockImplementation(() => {});
+    vi.spyOn(service.resizeController, "clearSettledTimer").mockImplementation(() => {});
+
+    service.detachForProjectSwitch("t5");
+
+    // Background-tier resizes only update latest dims; the warm-attach path
+    // needs target dims, so detach must seed them so reattach paints at size.
+    expect(managed.targetCols).toBe(120);
+    expect(managed.targetRows).toBe(40);
+  });
+
+  it("detachForProjectSwitch() preserves existing target dims (#10070)", () => {
+    const managed = makeMockManaged("t6");
+    managed.latestCols = 120;
+    managed.latestRows = 40;
+    managed.targetCols = 100;
+    managed.targetRows = 30;
+    const parent = document.createElement("div");
+    parent.appendChild(managed.hostElement);
+    service.instances.set("t6", managed);
+
+    vi.spyOn(service.offscreenManager, "ensureHiddenContainer").mockReturnValue(
+      document.createElement("div")
+    );
+    vi.spyOn(service.resizeController, "clearResizeJob").mockImplementation(() => {});
+    vi.spyOn(service.resizeController, "clearSettledTimer").mockImplementation(() => {});
+
+    service.detachForProjectSwitch("t6");
+
+    // An explicit saved target (e.g. from setTargetSize) must not be clobbered.
+    expect(managed.targetCols).toBe(100);
+    expect(managed.targetRows).toBe(30);
+  });
+
+  it("detachForProjectSwitch() leaves target dims unset when no geometry was measured (#10070)", () => {
+    const managed = makeMockManaged("t7");
+    // latestCols/latestRows stay 0 — terminal was never measured.
+    const parent = document.createElement("div");
+    parent.appendChild(managed.hostElement);
+    service.instances.set("t7", managed);
+
+    vi.spyOn(service.offscreenManager, "ensureHiddenContainer").mockReturnValue(
+      document.createElement("div")
+    );
+    vi.spyOn(service.resizeController, "clearResizeJob").mockImplementation(() => {});
+    vi.spyOn(service.resizeController, "clearSettledTimer").mockImplementation(() => {});
+
+    service.detachForProjectSwitch("t7");
+
+    // A 0-width backfill would poison the cold-seed resize before open().
+    expect(managed.targetCols).toBeUndefined();
+    expect(managed.targetRows).toBeUndefined();
   });
 });

--- a/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
@@ -336,7 +336,7 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
     expect(wakeAndRestore).not.toHaveBeenCalled();
   });
 
-  it("bails when terminal is currently attaching and marks it for a deferred wake (#9702)", async () => {
+  it("syncs geometry but defers the async wake when terminal is attaching (#9702, #10070)", async () => {
     const id = "fw-6";
     const instance = makeInstance({ isAttaching: true });
     service.instances.set(id, instance);
@@ -348,9 +348,44 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
 
     await service.fullWakeForVisibilityRestore(id);
 
-    expect(applyDeferredResize).not.toHaveBeenCalled();
+    // Geometry sync is safe mid-attach and must run so the grid is corrected
+    // before the warm paint gate drops the bridge (#10070).
+    expect(applyDeferredResize).toHaveBeenCalledWith(id);
+    // The async wake (which calls terminal.reset()) must still defer to avoid
+    // racing the attach's own post-rAF reconciliation (#9702).
     expect(wakeAndRestore).not.toHaveBeenCalled();
     // The skipped wake must leave a flag so it re-runs once attach settles.
+    expect(instance.pendingVisibilityWake).toBe(true);
+  });
+
+  it("bypasses the resize lock for the geometry sync even while attaching (#10070)", async () => {
+    const id = "fw-6b";
+    const instance = makeInstance({
+      isAttaching: true,
+      isResizeSuppressed: true,
+      resizeSuppressionEndTime: Date.now() + 1500,
+    });
+    service.instances.set(id, instance);
+
+    const calls: string[] = [];
+    const lockResize = vi
+      .spyOn(service.resizeController, "lockResize")
+      .mockImplementation((_id, locked) => {
+        calls.push(locked ? "lock" : "unlock");
+      });
+    vi.spyOn(service.resizeController, "applyDeferredResize").mockImplementation(() => {
+      calls.push("applyDeferredResize");
+    });
+    const wakeAndRestore = vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue(true);
+
+    await service.fullWakeForVisibilityRestore(id);
+
+    // The lock-bypass dance still wraps the geometry sync even on the attach
+    // defer path, so a suppressed-resize terminal isn't left at stale geometry.
+    expect(calls).toEqual(["unlock", "applyDeferredResize", "lock"]);
+    expect(lockResize).toHaveBeenNthCalledWith(1, id, false);
+    expect(lockResize).toHaveBeenNthCalledWith(2, id, true, expect.any(Number));
+    expect(wakeAndRestore).not.toHaveBeenCalled();
     expect(instance.pendingVisibilityWake).toBe(true);
   });
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
@@ -358,6 +358,26 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
     expect(instance.pendingVisibilityWake).toBe(true);
   });
 
+  it("keeps pendingVisibilityWake set when the geometry sync throws while attaching (#10070)", async () => {
+    const id = "fw-6c";
+    const instance = makeInstance({ isAttaching: true });
+    service.instances.set(id, instance);
+
+    vi.spyOn(service.resizeController, "applyDeferredResize").mockImplementation(() => {
+      throw new Error("terminal disposed mid-wake");
+    });
+    const wakeAndRestore = vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue(true);
+
+    // The throw propagates, but the deferred-wake flag must already be set so
+    // notifyAttachSettledWaiters re-runs the wake once attach settles.
+    await expect(service.fullWakeForVisibilityRestore(id)).rejects.toThrow(
+      "terminal disposed mid-wake"
+    );
+
+    expect(instance.pendingVisibilityWake).toBe(true);
+    expect(wakeAndRestore).not.toHaveBeenCalled();
+  });
+
   it("bypasses the resize lock for the geometry sync even while attaching (#10070)", async () => {
     const id = "fw-6b";
     const instance = makeInstance({


### PR DESCRIPTION
## Summary

- When switching to a warm-cached project, terminals briefly rendered at the default 80×24 grid before snapping to the correct size.
- Two root causes: `fullWakeForVisibilityRestore` skipped geometry sync for mid-attach terminals (the deferred re-run fired after the bridge view dropped), and background-tier resizes only updated `latestCols`/`latestRows` — not `targetCols`/`targetRows` — so terminals reattaching after being backgrounded had no saved target dimensions.
- Fix moves the `applyDeferredResize` geometry sync before the `isAttaching` guard in `fullWakeForVisibilityRestore` (safe — it only calls `terminal.resize()` and PTY IPC, no buffer reset), and backfills `targetCols`/`targetRows` from `latestCols`/`latestRows` in `detachForProjectSwitch` when targets are unset.

Resolves #10070

## Changes

- `src/services/terminal/TerminalInstanceService.ts`: geometry sync runs before the attach guard; `pendingVisibilityWake` set defensively before the sync block so an unexpected throw can't strand the deferred re-run; `detachForProjectSwitch` backfills target dimensions when unset and geometry is real.
- `src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts`: three new cases — geometry-sync-while-attaching, lock-bypass-while-attaching, throw-survival.
- `src/services/terminal/__tests__/TerminalInstanceService.detach.test.ts`: three new cases — backfill populates missing targets, preserves existing targets, leaves both unset when geometry is zero.

## Testing

23 tests pass. `npm run check` clean (typecheck, lint, format). Manually verified that the snap is gone on a warm project switch.