### PR TITLE
fix(notify): prevent passive eventKind policies from silently dropping notifications

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -568,6 +568,22 @@ export default tseslint.config(
           message:
             "Sentry scope setters (setTag/setUser/setContext) are centralized in TelemetryService.ts so every value entering event.tags/user/contexts stays within the scrubbing contract. Annotate a legitimate site with `// eslint-disable-next-line no-restricted-syntax -- sentry-scope-setter: ok` plus a rationale. See #10047.",
         },
+        {
+          // why: passive eventKinds (uiFeedback, workingPulse, settings) resolve
+          // to priority:"low" via resolveEventPolicyDefaults() when the caller
+          // omits priority. Combined with transient:true this is a silent no-op:
+          // low priority skips the toast and transient skips the inbox, so the
+          // notification fires nowhere. Add an explicit priority:"high" to
+          // override the passive policy default. See #10051.
+          // NOTE: the eventKind `:has()` clause omits the leading `>` before the
+          // `context` property for the same esquery reason as the
+          // notify-event-kind rule above; the transient/priority guards keep
+          // their `>` since they're single-level top-of-payload properties.
+          selector:
+            "CallExpression:matches([callee.name=/^(notify|addNotification)$/], [callee.property.name=/^(notify|addNotification)$/]) > ObjectExpression:has(> Property[key.name='transient'][value.value=true]):has(Property[key.name='context'] > ObjectExpression > Property[key.name='eventKind'][value.value=/^(uiFeedback|workingPulse|settings)$/]):not(:has(> Property[key.name='priority']))",
+          message:
+            'Passive eventKind (uiFeedback/workingPulse/settings) + transient:true is a silent no-op — priority resolves to "low" (inbox-only) and transient skips the inbox, so the notification fires nowhere. Add an explicit priority:"high" to override the policy default, or annotate with `// eslint-disable-next-line no-restricted-syntax -- notify-passive-transient: ok` for a deliberate exception. See #10051.',
+        },
       ],
     },
   },

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -230,6 +230,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
             message:
               "The full crash report was copied to your clipboard — paste it into the issue body.",
             transient: true,
+            priority: "high",
             context: { eventKind: "uiFeedback" },
           });
         } else {
@@ -239,6 +240,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
             message:
               "Couldn't copy the full report. Quote the Error ID shown above when filing the issue.",
             inboxMessage: "Couldn't copy crash report to clipboard.",
+            priority: "high",
             context: { eventKind: "uiFeedback" },
           });
         }

--- a/src/components/Notifications/NotificationCenterEntry.tsx
+++ b/src/components/Notifications/NotificationCenterEntry.tsx
@@ -453,6 +453,7 @@ function RowOptionsMenu({
             message:
               "The full notification report was copied to your clipboard — paste it into the issue body.",
             transient: true,
+            priority: "high",
             context: { eventKind: "uiFeedback" },
           });
         } else {
@@ -462,6 +463,7 @@ function RowOptionsMenu({
             message:
               "Couldn't copy the full report. Quote the correlation ID when filing the issue.",
             inboxMessage: "Couldn't copy notification report to clipboard.",
+            priority: "high",
             context: { eventKind: "uiFeedback" },
           });
         }

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -612,6 +612,7 @@ export function NewWorktreeDialog({
               title: "Issue assigned",
               message: `#${snapIssue.number} assigned to you`,
               correlationId: worktreeId,
+              priority: "high",
               context: { eventKind: "uiFeedback" },
               action: {
                 label: "Undo",

--- a/src/components/Worktree/useWorktreeBulkRemove.ts
+++ b/src/components/Worktree/useWorktreeBulkRemove.ts
@@ -126,6 +126,7 @@ export function useWorktreeBulkRemove({
           type: "info",
           title: "Nothing to remove",
           message: "The main worktree can't be removed from the overview.",
+          priority: "high",
           context: { eventKind: "uiFeedback" },
         });
         clearSelection();
@@ -226,6 +227,7 @@ export function useWorktreeBulkRemove({
           title: successTitle,
           message: successMessage,
           transient: true,
+          priority: "high",
           context: { eventKind: "uiFeedback" },
         });
         announce(successTitle);

--- a/src/hooks/useQuickCreatePalette.ts
+++ b/src/hooks/useQuickCreatePalette.ts
@@ -229,6 +229,7 @@ export function useQuickCreatePalette(): UseQuickCreatePaletteReturn {
                 type: "warning",
                 title: "Could not assign issue",
                 message: `${assignmentError} — you can assign it manually on GitHub`,
+                priority: "high",
                 context: { eventKind: "uiFeedback" },
               });
             }

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -3116,7 +3116,7 @@ describe("EVENT_POLICY manifest routing", () => {
       expect(useNotificationHistoryStore.getState().entries).toHaveLength(1);
     });
 
-    it.each(["uiFeedback", "settings"] as const)(
+    it.each(["uiFeedback", "settings", "workingPulse"] as const)(
       "warns when a passive kind %s + transient resolves to a silent no-op",
       (eventKind) => {
         // No explicit priority → policy fills "low"; transient skips the inbox.
@@ -3136,7 +3136,7 @@ describe("EVENT_POLICY manifest routing", () => {
 
     it("explicit priority: 'high' overrides the passive default so the transient toast fires", () => {
       // The call-site fix: passive kind + transient + explicit high → toast
-      // shows, no inbox row, and no no-op warning.
+      // shows, no inbox row, and the passive-policy no-op warn does not fire.
       vi.spyOn(document, "hasFocus").mockReturnValue(true);
       const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       notify({

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -3115,6 +3115,44 @@ describe("EVENT_POLICY manifest routing", () => {
       expect(useNotificationStore.getState().notifications).toHaveLength(0);
       expect(useNotificationHistoryStore.getState().entries).toHaveLength(1);
     });
+
+    it.each(["uiFeedback", "settings"] as const)(
+      "warns when a passive kind %s + transient resolves to a silent no-op",
+      (eventKind) => {
+        // No explicit priority → policy fills "low"; transient skips the inbox.
+        // Low priority skips the toast. The notification fires nowhere, so the
+        // policy-resolved case must warn (distinct from the explicit-low warn).
+        vi.spyOn(document, "hasFocus").mockReturnValue(true);
+        const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        notify({ type: "info", message: "x", transient: true, context: { eventKind } });
+        expect(useNotificationStore.getState().notifications).toHaveLength(0);
+        expect(useNotificationHistoryStore.getState().entries).toHaveLength(0);
+        expect(consoleSpy).toHaveBeenCalledWith(
+          expect.stringContaining("passive eventKind resolved to priority: 'low'")
+        );
+        consoleSpy.mockRestore();
+      }
+    );
+
+    it("explicit priority: 'high' overrides the passive default so the transient toast fires", () => {
+      // The call-site fix: passive kind + transient + explicit high → toast
+      // shows, no inbox row, and no no-op warning.
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      notify({
+        type: "success",
+        message: "Removed 3 worktrees",
+        transient: true,
+        priority: "high",
+        context: { eventKind: "uiFeedback" },
+      });
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+      expect(useNotificationHistoryStore.getState().entries).toHaveLength(0);
+      expect(consoleSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("passive eventKind resolved to priority: 'low'")
+      );
+      consoleSpy.mockRestore();
+    });
   });
 
   describe("urgent / quiet-gate resolution", () => {

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -812,6 +812,9 @@ export function isScheduledQuietHours(now: Date = new Date()): boolean {
 export function notify(payload: NotifyPayload): string {
   // Resolve routing defaults from the EVENT_POLICY manifest before reading any
   // routing fields — explicit caller fields are preserved, only gaps are filled.
+  // Capture whether the caller supplied a priority first, so we can tell a
+  // caller-written "low" apart from one the passive-eventKind policy filled in.
+  const hadExplicitPriority = payload.priority !== undefined;
   payload = resolveEventPolicyDefaults(payload);
 
   const priority = payload.priority ?? "high";
@@ -823,9 +826,15 @@ export function notify(payload: NotifyPayload): string {
     // promotes the inbox entry on navigate-away) collapse to a silent drop.
     // Surface here so the contradictory shape is caught at write-time.
     if (priority === "low") {
-      console.warn(
-        "[notify] transient: true with priority: 'low' is a silent no-op — low priority skips the toast and transient skips the inbox."
-      );
+      if (hadExplicitPriority) {
+        console.warn(
+          "[notify] transient: true with priority: 'low' is a silent no-op — low priority skips the toast and transient skips the inbox."
+        );
+      } else {
+        console.warn(
+          "[notify] transient: true with a passive eventKind resolved to priority: 'low' — this is a silent no-op (low priority skips the toast, transient skips the inbox). Add an explicit priority: 'high' at the call site to override the policy default."
+        );
+      }
     }
     if (context) {
       console.warn(
@@ -1164,6 +1173,9 @@ setPermanentFallbackHandler(() => {
     title: "Settings won't be saved",
     message:
       "Couldn't write to local storage, so changes made this session won't persist after restart.",
+    // settings is a passive eventKind (→ priority "low" / inbox-only); a
+    // storage-failure warning must surface as a toast, so pin it high.
+    priority: "high",
     context: { eventKind: "settings" },
   });
 });

--- a/src/store/diagnosticsReviewStore.ts
+++ b/src/store/diagnosticsReviewStore.ts
@@ -114,6 +114,7 @@ export const useDiagnosticsReviewStore = create<DiagnosticsReviewState>((set, ge
           // The saved ZIP is already revealed in the OS file manager, so this
           // is a one-shot action prompt — no durable inbox row needed.
           transient: true,
+          priority: "high",
           context: { eventKind: "settings" },
           action: {
             label: "Continue to GitHub issue",


### PR DESCRIPTION
## Summary

- Passive `eventKind` policies (`uiFeedback`, `settings`, `workingPulse`) cause `resolveEventPolicyDefaults()` to fill `priority: "low"` when the caller omits priority, routing notifications inbox-only. Combined with `transient: true` (which skips the inbox), the notification becomes a silent no-op. Several call sites had adopted passive eventKinds to satisfy the `notify-event-kind` lint rule without setting an explicit priority, so user-facing feedback — clipboard confirmations, bulk-remove success, "Issue assigned" + Undo, "Diagnostics saved" + CTA, storage-failure warnings — was silently demoted or dropped.
- Added explicit `priority: "high"` to 9 affected call sites (`ErrorBoundary`, `NotificationCenterEntry`, `useWorktreeBulkRemove`, `NewWorktreeDialog`, `useQuickCreatePalette`, `diagnosticsReviewStore`, and the `safeStorage` permanent-fallback warning in `notify.ts`). The `eventKind` values stay semantically correct; explicit priority overrides the passive policy default — same pattern `panelLimitStore.ts` and `projectActions.ts` already use.
- Extended the DEV-only transient warn in `notify()` to distinguish a caller-written `priority: "low"` from a policy-resolved one, surfacing the passive-eventKind no-op at write-time. Added an ESLint `no-restricted-syntax` guard (appended to the existing renderer array) that flags `transient: true` + passive `eventKind` with no explicit priority.

Resolves #10051

## Changes

- `src/lib/notify.ts` — smarter DEV warn distinguishes caller-set vs policy-resolved `priority: "low"`; `safeStorage` fallback warning gets `priority: "high"`
- `eslint.config.js` — new `no-restricted-syntax` rule for the passive-eventKind + transient no-op pattern
- `src/components/ErrorBoundary/ErrorBoundary.tsx`, `src/components/Notifications/NotificationCenterEntry.tsx`, `src/components/Worktree/NewWorktreeDialog.tsx`, `src/components/Worktree/useWorktreeBulkRemove.ts`, `src/hooks/useQuickCreatePalette.ts`, `src/store/diagnosticsReviewStore.ts` — explicit `priority: "high"` at each affected call site
- `src/lib/__tests__/notify.test.ts` — EVENT_POLICY routing tests covering the policy-resolved no-op warn and explicit-high override

## Testing

- `notify.test.ts` — 228 tests pass
- `npm run check` — fully green (typecheck, IPC/channel/confirm-wiring guards, format, build)
- Lint warning count decreased by 1; no new warnings introduced