### PR TITLE
chore(github): reconcile compat shims from forge rehoming

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -154,7 +154,6 @@ export const CHANNELS = {
   GITHUB_GET_PRS_BY_NUMBERS: "github:get-prs-by-numbers",
   GITHUB_GET_PR_REVIEW_THREADS: "github:get-pr-review-threads",
   GITHUB_LIST_REMOTES: "github:list-remotes",
-  GITHUB_RATE_LIMIT_CHANGED: "github:rate-limit-changed",
   GITHUB_GET_RATE_LIMIT_DETAILS: "github:get-rate-limit-details",
   GITHUB_TOKEN_HEALTH_CHANGED: "github:token-health-changed",
   GITHUB_GET_TOKEN_HEALTH: "github:get-token-health",

--- a/electron/ipc/handlers/__tests__/github.rateLimit.test.ts
+++ b/electron/ipc/handlers/__tests__/github.rateLimit.test.ts
@@ -117,6 +117,7 @@ vi.mock("../../../services/github/index.js", () => ({
   getPRByNumber: gitHubServiceMock.getPRByNumber,
   getIssuesByNumbers: gitHubServiceMock.getIssuesByNumbers,
   getPRsByNumbers: gitHubServiceMock.getPRsByNumbers,
+  getPRReviewThreads: vi.fn().mockResolvedValue({}),
   hasGitHubToken: gitHubServiceMock.hasGitHubToken,
   getGitHubConfigAsync: gitHubServiceMock.getGitHubConfigAsync,
   getProjectHealth: gitHubServiceMock.getProjectHealth,

--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -93,12 +93,11 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
   // Main-process transport: push rate-limit state changes to every renderer.
-  // The legacy GitHub channel is kept for backward compat; the provider-keyed
-  // forge channel is what `githubClient.onRateLimitChanged` now subscribes to,
-  // so main-process-sourced GitHub blocks (REST 403/429, rate-limit headers)
-  // still reach the renderer after the workspace-host fast-path was removed.
+  // The provider-keyed forge channel is what `githubClient.onRateLimitChanged`
+  // now subscribes to, so main-process-sourced GitHub blocks (REST 403/429,
+  // rate-limit headers) still reach the renderer after the workspace-host
+  // fast-path was removed.
   const unsubscribeRateLimit = gitHubRateLimitService.onStateChange((state) => {
-    broadcastToRenderer(CHANNELS.GITHUB_RATE_LIMIT_CHANGED, state);
     broadcastToRenderer(CHANNELS.FORGE_RATE_LIMIT_CHANGED, {
       providerId: BUILTIN_GITHUB_PROVIDER_ID,
       state: toRateLimitInfo(state),
@@ -560,7 +559,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
       return {};
     }
 
-    const { getPRReviewThreads } = await import("../../services/GitHubService.js");
+    const { getPRReviewThreads } = await import("../../services/github/index.js");
     return getPRReviewThreads(payload.cwd.trim(), payload.prNumber);
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_GET_PR_REVIEW_THREADS, handleGitHubGetPRReviewThreads));

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -94,7 +94,6 @@ import type {
   PRClearedPayload,
   IssueDetectedPayload,
   IssueNotFoundPayload,
-  GitHubRateLimitPayload,
   GitHubTokenHealthPayload,
   RepoStatsAndPagePayload,
   ServiceConnectivityPayload,
@@ -1675,9 +1674,6 @@ const api: ElectronAPI = {
 
     onIssueNotFound: (callback: (data: IssueNotFoundPayload) => void) =>
       _typedOn(CHANNELS.ISSUE_NOT_FOUND, callback),
-
-    onRateLimitChanged: (callback: (data: GitHubRateLimitPayload) => void) =>
-      _typedOn(CHANNELS.GITHUB_RATE_LIMIT_CHANGED, callback),
 
     getRateLimitDetails: () => _unwrappingInvoke(CHANNELS.GITHUB_GET_RATE_LIMIT_DETAILS),
 

--- a/electron/services/github/index.ts
+++ b/electron/services/github/index.ts
@@ -4,7 +4,11 @@
  * This barrel keeps the existing `electron/services/github/*` import paths
  * working for callers that have not yet migrated to the forge-provider
  * surface — primarily the `window.electron.github.*` IPC handlers in
- * `electron/ipc/handlers/github.ts`. Slated for removal after #8063 lands.
+ * `electron/ipc/handlers/github.ts`. Removal is gated on retiring or
+ * migrating those `window.electron.github.*` IPC handlers to the forge
+ * provider surface; until then this shim preserves singleton identity (see
+ * below) and avoids spreading direct `plugins/builtin/github/main/` imports
+ * across `electron/`.
  *
  * Singleton identity is preserved across the electron main bundle and the
  * loaded plugin bundle because both entries participate in the same esbuild

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -114,7 +114,6 @@ import type {
   GitHubCliStatus,
   GitHubTokenConfig,
   GitHubTokenValidation,
-  GitHubRateLimitPayload,
   GitHubRateLimitDetails,
   GitHubTokenHealthPayload,
   RepoStatsAndPagePayload,
@@ -759,7 +758,6 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     onPRCleared(callback: (data: PRClearedPayload) => void): () => void;
     onIssueDetected(callback: (data: IssueDetectedPayload) => void): () => void;
     onIssueNotFound(callback: (data: IssueNotFoundPayload) => void): () => void;
-    onRateLimitChanged(callback: (data: GitHubRateLimitPayload) => void): () => void;
     getRateLimitDetails(): Promise<GitHubRateLimitDetails | null>;
     onTokenHealthChanged(callback: (data: GitHubTokenHealthPayload) => void): () => void;
     onRepoStatsAndPageUpdated(callback: (data: RepoStatsAndPagePayload) => void): () => void;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -83,7 +83,6 @@ import type {
   GitHubCliStatus,
   GitHubTokenConfig,
   GitHubTokenValidation,
-  GitHubRateLimitPayload,
   GitHubRateLimitDetails,
   GitHubTokenHealthPayload,
   RepoStatsAndPagePayload,
@@ -1589,9 +1588,6 @@ export interface IpcEventMap {
   // Issue detection events
   "issue:detected": IssueDetectedPayload;
   "issue:not-found": IssueNotFoundPayload;
-
-  // GitHub rate-limit state push
-  "github:rate-limit-changed": GitHubRateLimitPayload;
 
   // GitHub token health state push (expiry/revocation detection)
   "github:token-health-changed": GitHubTokenHealthPayload;


### PR DESCRIPTION
After moving the forge provider to its new home, there were a few leftover compatibility shims still in the `github` IPC namespace. This PR cleans those up.

## Summary

- Removed the dead `github:rate-limit-changed` IPC channel end-to-end: the handler broadcast line, preload wrapper, `api.ts` interface entry, `maps.ts` event-map entry, `channels.ts` constant, and the now-unused `GitHubRateLimitPayload` imports. The renderer already consumes `forge.onRateLimitChanged` via `githubClient`, so the `github`-namespace wrapper was dead.
- Normalized the `getPRReviewThreads` dynamic import in `electron/ipc/handlers/github.ts` to route through `services/github/index.js` (matching every other dynamic import in that file) instead of the inconsistent direct `GitHubService.js` path.
- Updated the barrel-shim gate comment in `electron/services/github/index.ts` to name the real removal condition (retiring the `window.electron.github.*` IPC handlers to the forge provider surface) rather than the already-landed #8063.
- Added a `getPRReviewThreads` guard to the `github/index.js` test mock.

Resolves #9991

## Not in scope

The barrel shim itself (`electron/services/github/index.ts`) stays — singleton identity is load-bearing under esbuild `splitting:true` until the IPC handlers retire (lesson #8288). The `clearGitHubCaches` import normalization in `electron/ipc/handlers/projectCrud/settings.ts` is deferred to the broader migration.

## Testing

34 unit tests passing, `tsc` clean, all 8 `npm run check` guards pass.