### PR TITLE
perf(workspace-host): lazy-load copytree off the readiness path

### DIFF
--- a/electron/services/CopyTreeService.ts
+++ b/electron/services/CopyTreeService.ts
@@ -1,10 +1,17 @@
-import { copy, ConfigManager } from "copytree";
 import type { CopyResult, CopyOptions as SdkCopyOptions, ProgressEvent } from "copytree";
 import * as path from "path";
 import * as fs from "fs/promises";
 import type { CopyTreeOptions, CopyTreeResult, CopyTreeProgress } from "../types/index.js";
 import { logWarn } from "../utils/logger.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+
+// Lazy-load copytree so its module graph (ajv, xmlbuilder2, fast-glob, lodash, …)
+// stays off the workspace-host readiness path; it resolves on first use.
+let _copytreeModule: Promise<typeof import("copytree")> | null = null;
+
+function getCopytree(): Promise<typeof import("copytree")> {
+  return (_copytreeModule ??= import("copytree"));
+}
 
 export type { CopyTreeOptions, CopyTreeResult, CopyTreeProgress };
 
@@ -59,6 +66,9 @@ class CopyTreeService {
 
       const controller = new AbortController();
       this.activeOperations.set(opId, controller);
+
+      const { copy, ConfigManager } = await getCopytree();
+      this.throwIfAborted(controller.signal);
 
       let config;
       try {
@@ -160,6 +170,9 @@ class CopyTreeService {
       const controller = new AbortController();
       this.activeOperations.set(opId, controller);
 
+      const { copy, ConfigManager } = await getCopytree();
+      this.throwIfAborted(controller.signal);
+
       let config;
       try {
         config = await ConfigManager.create();
@@ -242,6 +255,12 @@ class CopyTreeService {
       return true;
     }
     return false;
+  }
+
+  private throwIfAborted(signal: AbortSignal): void {
+    if (signal.aborted) {
+      throw Object.assign(new Error("Context generation cancelled"), { name: "AbortError" });
+    }
   }
 
   private handleError(error: unknown): CopyTreeResult {

--- a/electron/services/CopyTreeService.ts
+++ b/electron/services/CopyTreeService.ts
@@ -80,6 +80,8 @@ class CopyTreeService {
         );
       }
 
+      this.throwIfAborted(controller.signal);
+
       const sdkOptions: SdkCopyOptions = {
         signal: controller.signal,
         display: false,
@@ -182,6 +184,8 @@ class CopyTreeService {
           { error }
         );
       }
+
+      this.throwIfAborted(controller.signal);
 
       const sdkOptions: SdkCopyOptions = {
         signal: controller.signal,

--- a/electron/services/__tests__/CopyTreeService.lazy-import.test.ts
+++ b/electron/services/__tests__/CopyTreeService.lazy-import.test.ts
@@ -56,9 +56,10 @@ describe("CopyTreeService lazy copytree import", () => {
   });
 
   it("returns a structured error when the copytree import fails", async () => {
-    vi.doMock("copytree", () => {
+    const factory = vi.fn(() => {
       throw new Error("module load failed");
     });
+    vi.doMock("copytree", factory);
 
     const { copyTreeService } = await import("../CopyTreeService.js");
 
@@ -68,6 +69,26 @@ describe("CopyTreeService lazy copytree import", () => {
     expect(result.fileCount).toBe(0);
     expect(result.error).toMatch(/^CopyTree Error: /);
     expect(copyTreeService.cancel("trace-import-fail")).toBe(false);
+
+    const retry = await copyTreeService.generate(tempDir);
+
+    expect(retry.error).toMatch(/^CopyTree Error: /);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns a structured testConfig error when the copytree import fails", async () => {
+    vi.doMock("copytree", () => {
+      throw new Error("module load failed");
+    });
+
+    const { copyTreeService } = await import("../CopyTreeService.js");
+
+    const result = await copyTreeService.testConfig(tempDir, {}, "trace-test-config-fail");
+
+    expect(result.includedFiles).toBe(0);
+    expect(result.includedSize).toBe(0);
+    expect(result.error).toBeTruthy();
+    expect(copyTreeService.cancel("trace-test-config-fail")).toBe(false);
   });
 
   it("treats cancellation during the copytree import as cancelled", async () => {

--- a/electron/services/__tests__/CopyTreeService.lazy-import.test.ts
+++ b/electron/services/__tests__/CopyTreeService.lazy-import.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+function mockCopytreeModule() {
+  return {
+    copy: vi.fn().mockResolvedValue({
+      output: "<context />",
+      stats: { totalFiles: 1, totalSize: 10, duration: 5 },
+    }),
+    ConfigManager: { create: vi.fn().mockResolvedValue(undefined) },
+  };
+}
+
+describe("CopyTreeService lazy copytree import", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-copytree-lazy-"));
+  });
+
+  afterEach(async () => {
+    vi.doUnmock("copytree");
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("does not evaluate copytree until first use", async () => {
+    const factory = vi.fn(mockCopytreeModule);
+    vi.doMock("copytree", factory);
+
+    const { copyTreeService } = await import("../CopyTreeService.js");
+    expect(factory).not.toHaveBeenCalled();
+
+    const result = await copyTreeService.generate(tempDir);
+
+    expect(result.error).toBeUndefined();
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("evaluates copytree once across concurrent operations", async () => {
+    const factory = vi.fn(mockCopytreeModule);
+    vi.doMock("copytree", factory);
+
+    const { copyTreeService } = await import("../CopyTreeService.js");
+
+    const [first, second] = await Promise.all([
+      copyTreeService.generate(tempDir),
+      copyTreeService.testConfig(tempDir),
+    ]);
+
+    expect(first.error).toBeUndefined();
+    expect(second.error).toBeUndefined();
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns a structured error when the copytree import fails", async () => {
+    vi.doMock("copytree", () => {
+      throw new Error("module load failed");
+    });
+
+    const { copyTreeService } = await import("../CopyTreeService.js");
+
+    const result = await copyTreeService.generate(tempDir, {}, undefined, "trace-import-fail");
+
+    expect(result.content).toBe("");
+    expect(result.fileCount).toBe(0);
+    expect(result.error).toMatch(/^CopyTree Error: /);
+    expect(copyTreeService.cancel("trace-import-fail")).toBe(false);
+  });
+
+  it("treats cancellation during the copytree import as cancelled", async () => {
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const copyMock = vi.fn();
+    vi.doMock("copytree", async () => {
+      await gate;
+      return {
+        copy: copyMock,
+        ConfigManager: { create: vi.fn().mockResolvedValue(undefined) },
+      };
+    });
+
+    const { copyTreeService } = await import("../CopyTreeService.js");
+
+    const pending = copyTreeService.generate(tempDir, {}, undefined, "trace-cancel");
+    await vi.waitFor(() => {
+      expect(copyTreeService.cancel("trace-cancel")).toBe(true);
+    });
+    release();
+
+    const result = await pending;
+
+    expect(result.error).toBe("Context generation cancelled");
+    expect(copyMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- `CopyTreeService` statically imported `{ copy, ConfigManager }` from `copytree`, pulling the whole barrel graph (ajv, ajv-formats, js-yaml, xmlbuilder2, fast-glob, lodash, fs-extra, clipboardy, ...) into workspace-host module evaluation before the host posts `ready` — the message the main process blocks worktree loading on.
- `copytree` is only touched post-ready, inside the `copytree:generate`, `copytree:cancel`, and `copytree:test-config` handlers. The `CopyTreeService` constructor never calls into it.
- Fixes this with a module-scoped memoized dynamic import (`_copytreeModule ??= import("copytree")`), awaited inside `generate()` and `testConfig()` after `AbortController` registration, with `throwIfAborted()` checks so cancels during the import surface correctly.

Resolves #10071

## Changes

- `electron/services/CopyTreeService.ts` — replace the static `copytree` import with a lazy memoized `import("copytree")`, following the `getSoundService.ts` convention (Promise memoized synchronously; not cleared on rejection; race-safe for concurrent callers). Type-only imports unchanged — zero runtime cost.
- `electron/services/__tests__/CopyTreeService.lazy-import.test.ts` — new test file covering: no eager eval until first use, single evaluation across concurrent `generate()` + `testConfig()` calls, import failure produces a structured error and poisons the cache, `testConfig` import failure, and cancellation during an in-flight import avoids invoking `copy`.

## Testing

23 tests pass across 3 `CopyTreeService` test files. `npm run check` fully clean — typecheck, all IPC/channel guards, and the lint ratchet improved by 1 (1186 warnings, down from 1187 baseline).