### PR TITLE
fix(portal): shield mid-restore tabs from LRU eviction

### DIFF
--- a/electron/ipc/handlers/__tests__/portal.create.test.ts
+++ b/electron/ipc/handlers/__tests__/portal.create.test.ts
@@ -28,6 +28,7 @@ import { registerPortalHandlers } from "../portal.js";
 function createPortalManager() {
   return {
     createTab: vi.fn<(tabId: string, url: string, partition?: string) => void>(),
+    markRestoring: vi.fn<(tabId: string) => void>(),
     showTab: vi.fn(),
     hideAll: vi.fn(),
     updateBounds: vi.fn(),
@@ -135,6 +136,38 @@ describe("portal create handler partition override", () => {
       "persist:dev-preview-a-b-c"
     );
     warnSpy.mockRestore();
+  });
+
+  it("marks the tab as restoring before createTab when isRestore is true", async () => {
+    const order: string[] = [];
+    portalManager.markRestoring.mockImplementationOnce(() => {
+      order.push("markRestoring");
+    });
+    portalManager.createTab.mockImplementationOnce(() => {
+      order.push("createTab");
+    });
+
+    const handler = getHandler(CHANNELS.PORTAL_CREATE);
+    await handler(
+      { sender: {} },
+      { tabId: "tab-1", url: "http://localhost:3000/", isRestore: true }
+    );
+
+    expect(portalManager.markRestoring).toHaveBeenCalledWith("tab-1");
+    expect(order).toEqual(["markRestoring", "createTab"]);
+  });
+
+  it("does not mark restoring when isRestore is absent or false", async () => {
+    const handler = getHandler(CHANNELS.PORTAL_CREATE);
+
+    await handler({ sender: {} }, { tabId: "tab-1", url: "http://localhost:3000/" });
+    await handler(
+      { sender: {} },
+      { tabId: "tab-2", url: "http://localhost:3000/", isRestore: false }
+    );
+
+    expect(portalManager.markRestoring).not.toHaveBeenCalled();
+    expect(portalManager.createTab).toHaveBeenCalledTimes(2);
   });
 
   it("rejects an invalid url before touching the session", async () => {

--- a/electron/ipc/handlers/portal.ts
+++ b/electron/ipc/handlers/portal.ts
@@ -69,6 +69,11 @@ export function registerPortalHandlers(deps: HandlerDependencies): () => void {
               console.warn("[PortalHandler] flushStorageData failed before promote:", error);
             }
           }
+          // Restore-intent creates are shielded from LRU eviction until the
+          // follow-up show lands; createTab clears the guard on failure.
+          if (payload.isRestore === true) {
+            deps.portalManager.markRestoring(payload.tabId);
+          }
           deps.portalManager.createTab(payload.tabId, payload.url, partition);
         } catch (error) {
           console.error("[PortalHandler] Error in create:", error);

--- a/electron/services/PortalManager.ts
+++ b/electron/services/PortalManager.ts
@@ -21,6 +21,12 @@ export class PortalManager {
   private activeTabId: string | null = null;
   private lruOrder = new Map<string, true>();
   private lastShownTabId: string | null = null;
+  // Tabs in the create→show restore window. The renderer restores a tab by
+  // calling create, polling DOM bounds (up to ~1s), then show — activeTabId is
+  // only set at the end of showTab(), so without this guard a concurrent
+  // createTab() could LRU-evict the tab mid-restore (#9971). Entries are
+  // cleared by showTab() or destroyView().
+  private restoringTabIds = new Set<string>();
   // True while the active view is parked offscreen by hideAll(). Guards
   // updateBounds() so a window resize during an open overlay does not pull
   // the hidden view back on top of the overlay.
@@ -59,6 +65,7 @@ export class PortalManager {
     this.viewMap.delete(tabId);
     this.lruOrder.delete(tabId);
     this.lastShownBounds.delete(tabId);
+    this.restoringTabIds.delete(tabId);
 
     // Any attached view (active or parked offscreen) must be detached from the
     // contentView child list before its webContents is closed — otherwise the
@@ -99,6 +106,7 @@ export class PortalManager {
 
     for (const tabId of this.lruOrder.keys()) {
       if (tabId === this.activeTabId) continue;
+      if (this.restoringTabIds.has(tabId)) continue;
       if (!this.viewMap.has(tabId)) {
         this.lruOrder.delete(tabId);
         continue;
@@ -112,6 +120,15 @@ export class PortalManager {
     }
   }
 
+  /**
+   * Shield a tab from LRU eviction during the create→show restore window.
+   * Cleared by showTab() or destroyView(); createTab() clears it on failure so
+   * a tab that never materializes can't leak a permanent guard entry.
+   */
+  markRestoring(tabId: string): void {
+    this.restoringTabIds.add(tabId);
+  }
+
   createTab(tabId: string, url: string, partition: string = "persist:portal"): void {
     console.log(`[PortalManager] Creating tab ${tabId} for ${url} on ${partition}`);
     if (this.viewMap.has(tabId)) return;
@@ -123,6 +140,7 @@ export class PortalManager {
       }
     } catch (error) {
       console.error(`[PortalManager] Invalid URL for tab ${tabId}:`, error);
+      this.restoringTabIds.delete(tabId);
       return;
     }
 
@@ -183,6 +201,7 @@ export class PortalManager {
         this.viewMap.delete(tabId);
         this.lruOrder.delete(tabId);
         this.lastShownBounds.delete(tabId);
+        this.restoringTabIds.delete(tabId);
         // Detach if attached — covers both the active view and any view parked
         // offscreen via hideAll().
         if (this.attachedViews.has(view)) {
@@ -338,6 +357,7 @@ export class PortalManager {
       this.evictIfNeeded();
     } catch (error) {
       console.error(`[PortalManager] Failed to create tab ${tabId}:`, error);
+      this.restoringTabIds.delete(tabId);
       throw error;
     }
   }
@@ -368,6 +388,8 @@ export class PortalManager {
     });
     this.activeView = view;
     this.activeTabId = tabId;
+    // Restore complete — the activeTabId guard takes over eviction protection.
+    this.restoringTabIds.delete(tabId);
     this.hidden = false;
     this.touchLru(tabId);
     this.evictIfNeeded();
@@ -505,5 +527,6 @@ export class PortalManager {
     this.hidden = false;
     this.attachedViews.clear();
     this.lastShownBounds.clear();
+    this.restoringTabIds.clear();
   }
 }

--- a/electron/services/__tests__/PortalManager.adversarial.test.ts
+++ b/electron/services/__tests__/PortalManager.adversarial.test.ts
@@ -149,6 +149,42 @@ describe("PortalManager adversarial", () => {
     expect(evictedWebContents.close).toHaveBeenCalledTimes(1);
   });
 
+  it("protects multiple concurrent restores while evicting the unprotected LRU tab", () => {
+    const manager = new PortalManagerClass(mockWindow);
+
+    // Two restores in flight at once (e.g. queued restore follows an overlay
+    // close) racing a background create that overflows the limit.
+    manager.markRestoring("tab-1");
+    manager.createTab("tab-1", "http://localhost:3001");
+    manager.createTab("tab-2", "http://localhost:3002");
+    manager.markRestoring("tab-3");
+    manager.createTab("tab-3", "http://localhost:3003");
+
+    manager.createTab("tab-4", "http://localhost:3004");
+
+    expect(manager.hasTab("tab-1")).toBe(true);
+    expect(manager.hasTab("tab-2")).toBe(false);
+    expect(manager.hasTab("tab-3")).toBe(true);
+    expect(manager.hasTab("tab-4")).toBe(true);
+  });
+
+  it("restoring guard does not leak through destroy()", () => {
+    const manager = new PortalManagerClass(mockWindow);
+
+    manager.markRestoring("tab-1");
+    manager.createTab("tab-1", "http://localhost:3001");
+    manager.destroy();
+
+    // Fresh session reusing the same id as a background tab — normal LRU.
+    manager.createTab("tab-1", "http://localhost:3001");
+    manager.createTab("tab-2", "http://localhost:3002");
+    manager.createTab("tab-3", "http://localhost:3003");
+    manager.createTab("tab-4", "http://localhost:3004");
+
+    expect(manager.hasTab("tab-1")).toBe(false);
+    expect(manager.hasTab("tab-2")).toBe(true);
+  });
+
   describe("navigation gating", () => {
     type WebContentsMock = ReturnType<typeof createMockWebContents>;
     type EventName = "will-navigate" | "will-redirect" | "will-frame-navigate";

--- a/electron/services/__tests__/PortalManager.test.ts
+++ b/electron/services/__tests__/PortalManager.test.ts
@@ -852,6 +852,115 @@ describe("PortalManager LRU eviction", () => {
     }
   });
 
+  describe("restoring tab guard (#9971)", () => {
+    it("does not evict a tab in the create→show restore window", () => {
+      const manager = new PortalManagerClass(mockWindow);
+
+      // tab-1 is mid-restore: created, bounds polling in flight, show pending.
+      manager.markRestoring("tab-1");
+      manager.createTab("tab-1", "http://localhost:1001");
+      manager.createTab("tab-2", "http://localhost:1002");
+      manager.createTab("tab-3", "http://localhost:1003");
+
+      // A background create overflows the limit. tab-1 is the LRU and not the
+      // active tab, but the restore guard must protect it — tab-2 (oldest
+      // unprotected) is evicted instead.
+      manager.createTab("tab-4", "http://localhost:1004");
+
+      expect(manager.hasTab("tab-1")).toBe(true);
+      expect(manager.hasTab("tab-2")).toBe(false);
+      expect(manager.hasTab("tab-3")).toBe(true);
+      expect(manager.hasTab("tab-4")).toBe(true);
+    });
+
+    it("showTab clears the guard so the tab re-enters normal LRU order", () => {
+      const manager = new PortalManagerClass(mockWindow);
+
+      manager.markRestoring("tab-1");
+      manager.createTab("tab-1", "http://localhost:1001");
+      manager.createTab("tab-2", "http://localhost:1002");
+      manager.createTab("tab-3", "http://localhost:1003");
+
+      // Restore completes, then the user switches through the other tabs,
+      // leaving tab-1 as the LRU background tab.
+      manager.showTab("tab-1", { x: 0, y: 0, width: 800, height: 600 });
+      manager.showTab("tab-2", { x: 0, y: 0, width: 800, height: 600 });
+      manager.showTab("tab-3", { x: 0, y: 0, width: 800, height: 600 });
+
+      manager.createTab("tab-4", "http://localhost:1004");
+
+      // Guard is gone — tab-1 is evictable again.
+      expect(manager.hasTab("tab-1")).toBe(false);
+      expect(manager.hasTab("tab-2")).toBe(true);
+      expect(manager.hasTab("tab-3")).toBe(true);
+      expect(manager.hasTab("tab-4")).toBe(true);
+    });
+
+    it("closeTab mid-restore leaves no stale guard for a reused tab id", async () => {
+      const manager = new PortalManagerClass(mockWindow);
+
+      manager.markRestoring("tab-1");
+      manager.createTab("tab-1", "http://localhost:1001");
+      await manager.closeTab("tab-1");
+
+      // Recreate the same id as a plain background tab — it must follow
+      // normal LRU eviction, which fails if the old guard entry leaked.
+      manager.createTab("tab-1", "http://localhost:1001");
+      manager.createTab("tab-2", "http://localhost:1002");
+      manager.createTab("tab-3", "http://localhost:1003");
+      manager.createTab("tab-4", "http://localhost:1004");
+
+      expect(manager.hasTab("tab-1")).toBe(false);
+      expect(manager.hasTab("tab-2")).toBe(true);
+    });
+
+    it("createTab failure clears the guard set by a preceding markRestoring", () => {
+      const manager = new PortalManagerClass(mockWindow);
+
+      manager.markRestoring("tab-1");
+      manager.createTab("tab-1", "not-a-valid-url");
+      expect(manager.hasTab("tab-1")).toBe(false);
+
+      // Same id later created as a background tab must not inherit protection.
+      manager.createTab("tab-1", "http://localhost:1001");
+      manager.createTab("tab-2", "http://localhost:1002");
+      manager.createTab("tab-3", "http://localhost:1003");
+      manager.createTab("tab-4", "http://localhost:1004");
+
+      expect(manager.hasTab("tab-1")).toBe(false);
+      expect(manager.hasTab("tab-2")).toBe(true);
+    });
+
+    it("tolerates exceeding the limit when every candidate is protected", () => {
+      const manager = new PortalManagerClass(mockWindow);
+
+      for (let i = 1; i <= 4; i++) {
+        manager.markRestoring(`tab-${i}`);
+        manager.createTab(`tab-${i}`, `http://localhost:${1000 + i}`);
+      }
+
+      // No eligible eviction candidate — all four stay alive until a show
+      // resolves one of the restores.
+      for (let i = 1; i <= 4; i++) {
+        expect(manager.hasTab(`tab-${i}`)).toBe(true);
+      }
+
+      // First show clears tab-1's guard but makes it active — still over the
+      // limit, still nothing evictable. The second show releases tab-1 as a
+      // normal LRU candidate and the deferred eviction reclaims it.
+      manager.showTab("tab-1", { x: 0, y: 0, width: 800, height: 600 });
+      for (let i = 1; i <= 4; i++) {
+        expect(manager.hasTab(`tab-${i}`)).toBe(true);
+      }
+
+      manager.showTab("tab-2", { x: 0, y: 0, width: 800, height: 600 });
+      expect(manager.hasTab("tab-1")).toBe(false);
+      expect(manager.hasTab("tab-2")).toBe(true);
+      expect(manager.hasTab("tab-3")).toBe(true);
+      expect(manager.hasTab("tab-4")).toBe(true);
+    });
+  });
+
   it("destroy after evictions does not double-close", async () => {
     const manager = new PortalManagerClass(mockWindow);
 

--- a/shared/types/portal.ts
+++ b/shared/types/portal.ts
@@ -86,6 +86,14 @@ export interface PortalCreatePayload {
    * default `persist:portal` partition is used.
    */
   partition?: string;
+  /**
+   * True when this create is the first half of a restore (create → bounds
+   * polling → show). Marks the tab as restoring in `PortalManager` so LRU
+   * eviction cannot reclaim it during the create→show window — `activeTabId`
+   * only protects it after `showTab()` completes. Background opens must omit
+   * this flag or they would be shielded from eviction indefinitely.
+   */
+  isRestore?: boolean;
 }
 
 export interface PortalShowPayload {

--- a/src/components/Portal/PortalVisibilityController.tsx
+++ b/src/components/Portal/PortalVisibilityController.tsx
@@ -45,7 +45,9 @@ export function PortalVisibilityController(): null {
           // keeps its shared session after eviction/restart instead of silently
           // reverting to the default portal session.
           const partition = state.tabs.find((t) => t.id === tabId)?.partition;
-          await window.electron.portal.create({ tabId, url: tabUrl, partition });
+          // isRestore shields the tab from LRU eviction during the bounds
+          // polling below — activeTabId only protects it after show completes.
+          await window.electron.portal.create({ tabId, url: tabUrl, partition, isRestore: true });
           const postCreateState = usePortalStore.getState();
           const stillExists = postCreateState.tabs.some((t) => t.id === tabId);
           if (!stillExists) {

--- a/src/components/Portal/__tests__/PortalVisibilityController.test.tsx
+++ b/src/components/Portal/__tests__/PortalVisibilityController.test.tsx
@@ -122,6 +122,7 @@ describe("PortalVisibilityController", () => {
     expect(portal.create).toHaveBeenCalledWith({
       tabId: "tab-1",
       url: "https://example.com/docs",
+      isRestore: true,
     });
     expect(portal.show).toHaveBeenCalledWith({
       tabId: "tab-1",
@@ -162,6 +163,7 @@ describe("PortalVisibilityController", () => {
     expect(portal.create).toHaveBeenLastCalledWith({
       tabId: "tab-a",
       url: "https://example.com/a",
+      isRestore: true,
     });
 
     act(() => {
@@ -178,6 +180,7 @@ describe("PortalVisibilityController", () => {
     expect(portal.create).toHaveBeenLastCalledWith({
       tabId: "tab-b",
       url: "https://example.com/b",
+      isRestore: true,
     });
     expect(portal.show).toHaveBeenCalledTimes(1);
     expect(portal.show).toHaveBeenCalledWith({
@@ -415,6 +418,7 @@ describe("PortalVisibilityController", () => {
     expect(portal.create).toHaveBeenCalledWith({
       tabId: "tab-3",
       url: "https://example.com/3",
+      isRestore: true,
     });
     expect(portal.show).toHaveBeenCalledWith({
       tabId: "tab-3",


### PR DESCRIPTION
## Summary

- `PortalManager.evictIfNeeded()` only protected `activeTabId`, which is set at the end of `showTab()`. During the renderer restore flow (`createTab` -> DOM bounds polling up to ~1s -> `showTab`), the restoring tab was completely exposed. A concurrent background `createTab` overflowing `PORTAL_MAX_LIVE_TABS=3` could evict it mid-restore.
- Adds a `restoringTabIds` Set to `PortalManager`. The IPC `portal.create` handler calls `markRestoring(tabId)` when `payload.isRestore` is true; `PortalVisibilityController` passes `isRestore: true` on its restore path. Guard is cleared by `showTab`, `destroyView`, the `webContents` destroyed handler, `destroy()`, and all `createTab` failure paths — no permanent leaks.
- `destroyHiddenTabs()` (memory-pressure path) is intentionally unchanged per issue scope. Live tabs may temporarily exceed `PORTAL_MAX_LIVE_TABS` when every candidate is protected (active or restoring) — reclaimed on the next show.

Resolves #9971

## Changes

- `shared/types/portal.ts` — adds optional `isRestore?: boolean` to `PortalCreatePayload`
- `electron/services/PortalManager.ts` — adds `restoringTabIds` Set and `markRestoring`/`clearRestoring` helpers; `evictIfNeeded` skips protected tabs
- `electron/ipc/handlers/portal.ts` — calls `markRestoring` on `portal.create` when `isRestore` is true
- `src/components/Portal/PortalVisibilityController.tsx` — passes `isRestore: true` on the restore-path create call

## Testing

- 5 new cases in `PortalManager.test.ts` ("restoring tab guard (#9971)" suite): restore-window protection, `showTab` clears guard, no stale guard after `closeTab` mid-restore, `createTab` failure clears guard, all-protected overflow tolerance
- Adversarial tests for concurrent multi-restore and `destroy()` leak in `PortalManager.adversarial.test.ts`
- `portal.create` IPC tests for `markRestoring` wiring and call ordering
- 4 `PortalVisibilityController` assertions updated to expect `isRestore: true`