### PR TITLE
perf(github): add explicit worker/attended instance role to gate background polling

### DIFF
--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -198,6 +198,17 @@ const initialProjectId = process.argv
   .find((a) => a.startsWith(INITIAL_PROJECT_ID_ARG))
   ?.slice(INITIAL_PROJECT_ID_ARG.length);
 
+// Instance role passed from the main process via additionalArguments (#10123),
+// with a process.env fallback for contexts the main process did not seed
+// (process.env is polyfilled even under sandbox: true). Worker instances
+// suppress automatic background GitHub polling; only the exact value "worker"
+// opts in — anything else normalizes to "attended".
+const INSTANCE_ROLE_ARG = "--daintree-instance-role=";
+const rawInstanceRole =
+  process.argv.find((a) => a.startsWith(INSTANCE_ROLE_ARG))?.slice(INSTANCE_ROLE_ARG.length) ??
+  process.env.DAINTREE_INSTANCE_ROLE;
+const instanceRole: "attended" | "worker" = rawInstanceRole === "worker" ? "worker" : "attended";
+
 // Store MessagePort for direct Renderer ↔ Pty Host communication
 // Note: We cannot return MessagePort via contextBridge (it's not cloneable/transferable via that API).
 // Instead, we use window.postMessage to transfer it to the main world.
@@ -2928,6 +2939,14 @@ if (initialProjectId) {
     id: initialProjectId,
   });
 }
+
+// Surface the instance role so renderer pollers can suppress automatic
+// background GitHub polling in worker instances (#10123). Exposed
+// unconditionally — attended instances get { role: "attended" } so consumers
+// never need to null-guard the global.
+contextBridge.exposeInMainWorld("__DAINTREE_INSTANCE_ROLE__", {
+  role: instanceRole,
+});
 
 // Flush the per-view preload evaluation cost (#9770). Runs at preload bottom —
 // before any renderer page script — so the main process can attribute the

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -32,8 +32,10 @@ import {
   injectSkeletonProjectIdentity,
   resolveInitialColorSchemeId,
   resolveInitialCanvasBackgroundColor,
+  resolveInstanceRole,
   INITIAL_COLOR_SCHEME_ARG,
   INITIAL_PROJECT_ID_ARG,
+  INSTANCE_ROLE_ARG,
 } from "./skeletonCss.js";
 import { isDemoMode } from "../setup/runtimeFlags.js";
 import { projectStore } from "../services/ProjectStore.js";
@@ -1141,9 +1143,13 @@ export class ProjectViewManager {
         // threaded the same way instead of via a `?projectId=` query string so
         // the document URL stays static and the V8 bytecode cache is shared
         // across projects (#9162).
+        // The instance role rides along so LRU-evicted and project-switch
+        // views keep suppressing background GitHub polling in worker
+        // instances (#10123).
         additionalArguments: [
           `${INITIAL_COLOR_SCHEME_ARG}=${resolveInitialColorSchemeId()}`,
           `${INITIAL_PROJECT_ID_ARG}=${projectId}`,
+          `${INSTANCE_ROLE_ARG}=${resolveInstanceRole()}`,
           // Demo mode is gated in the renderer on process.argv. Electron does
           // not forward main-process CLI switches to renderer argv, so the
           // `--demo-mode` flag must be threaded explicitly for the DemoCursor /

--- a/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
@@ -130,6 +130,8 @@ vi.mock("../skeletonCss.js", () => ({
   injectSkeletonProjectIdentity: vi.fn(),
   INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
   INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
+  INSTANCE_ROLE_ARG: "--daintree-instance-role",
+  resolveInstanceRole: vi.fn(() => "attended"),
   resolveInitialColorSchemeId: vi.fn(() => "daintree"),
   resolveInitialCanvasBackgroundColor: vi.fn(() => "#1f1b16"),
 }));

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -114,6 +114,8 @@ vi.mock("../skeletonCss.js", () => ({
   injectSkeletonProjectIdentity: vi.fn(),
   INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
   INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
+  INSTANCE_ROLE_ARG: "--daintree-instance-role",
+  resolveInstanceRole: vi.fn(() => "attended"),
   resolveInitialColorSchemeId: vi.fn(() => "daintree"),
   resolveInitialCanvasBackgroundColor: vi.fn(() => "#1f1b16"),
 }));

--- a/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
@@ -136,6 +136,8 @@ vi.mock("../skeletonCss.js", () => ({
   injectSkeletonProjectIdentity: vi.fn(),
   INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
   INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
+  INSTANCE_ROLE_ARG: "--daintree-instance-role",
+  resolveInstanceRole: vi.fn(() => "attended"),
   resolveInitialColorSchemeId: vi.fn(() => "daintree"),
   resolveInitialCanvasBackgroundColor: vi.fn(() => "#1f1b16"),
 }));

--- a/electron/window/__tests__/ProjectViewManager.freeze.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.freeze.test.ts
@@ -85,6 +85,8 @@ vi.mock("../skeletonCss.js", () => ({
   injectSkeletonProjectIdentity: vi.fn(),
   INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
   INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
+  INSTANCE_ROLE_ARG: "--daintree-instance-role",
+  resolveInstanceRole: vi.fn(() => "attended"),
   resolveInitialColorSchemeId: vi.fn(() => "daintree"),
   resolveInitialCanvasBackgroundColor: vi.fn(() => "#1f1b16"),
 }));

--- a/electron/window/__tests__/ProjectViewManager.gc.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.gc.test.ts
@@ -86,6 +86,8 @@ vi.mock("../skeletonCss.js", () => ({
   injectSkeletonProjectIdentity: vi.fn(),
   INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
   INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
+  INSTANCE_ROLE_ARG: "--daintree-instance-role",
+  resolveInstanceRole: vi.fn(() => "attended"),
   resolveInitialColorSchemeId: vi.fn(() => "daintree"),
   resolveInitialCanvasBackgroundColor: vi.fn(() => "#1f1b16"),
 }));

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -136,6 +136,8 @@ vi.mock("../skeletonCss.js", () => ({
   injectSkeletonProjectIdentity: vi.fn(),
   INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
   INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
+  INSTANCE_ROLE_ARG: "--daintree-instance-role",
+  resolveInstanceRole: vi.fn(() => "attended"),
   resolveInitialColorSchemeId: vi.fn(() => "daintree"),
   resolveInitialCanvasBackgroundColor: vi.fn(() => "#1f1b16"),
 }));

--- a/electron/window/__tests__/ProjectViewManager.preload.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.preload.test.ts
@@ -114,6 +114,8 @@ vi.mock("../skeletonCss.js", () => ({
   injectSkeletonProjectIdentity: vi.fn(),
   INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
   INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
+  INSTANCE_ROLE_ARG: "--daintree-instance-role",
+  resolveInstanceRole: vi.fn(() => "attended"),
   resolveInitialColorSchemeId: vi.fn(() => "daintree"),
   resolveInitialCanvasBackgroundColor: vi.fn(() => "#1f1b16"),
 }));

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -125,6 +125,8 @@ vi.mock("../skeletonCss.js", () => ({
   injectSkeletonProjectIdentity: vi.fn(),
   INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
   INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
+  INSTANCE_ROLE_ARG: "--daintree-instance-role",
+  resolveInstanceRole: vi.fn(() => "attended"),
   resolveInitialColorSchemeId: vi.fn(() => "daintree"),
   resolveInitialCanvasBackgroundColor: vi.fn(() => "#1f1b16"),
 }));

--- a/electron/window/__tests__/resolveInstanceRole.test.ts
+++ b/electron/window/__tests__/resolveInstanceRole.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Tests resolveInstanceRole from skeletonCss.ts — the helper that seeds each
+ * renderer with the worker/attended instance role via
+ * webPreferences.additionalArguments (#10123). Worker instances suppress
+ * automatic background GitHub polling; the default must always be attended.
+ */
+
+vi.mock("../../store.js", () => ({
+  store: { get: vi.fn() },
+}));
+
+vi.mock("electron", () => ({
+  nativeTheme: { shouldUseDarkColors: true },
+}));
+
+import { resolveInstanceRole, INSTANCE_ROLE_ARG } from "../skeletonCss.js";
+
+describe("resolveInstanceRole (#10123)", () => {
+  const originalRole = process.env.DAINTREE_INSTANCE_ROLE;
+
+  beforeEach(() => {
+    delete process.env.DAINTREE_INSTANCE_ROLE;
+  });
+
+  afterEach(() => {
+    if (originalRole === undefined) {
+      delete process.env.DAINTREE_INSTANCE_ROLE;
+    } else {
+      process.env.DAINTREE_INSTANCE_ROLE = originalRole;
+    }
+  });
+
+  it("defaults to attended when the env var is unset", () => {
+    expect(resolveInstanceRole()).toBe("attended");
+  });
+
+  it("returns worker only for the exact value 'worker'", () => {
+    process.env.DAINTREE_INSTANCE_ROLE = "worker";
+    expect(resolveInstanceRole()).toBe("worker");
+  });
+
+  it("normalizes malformed values to attended", () => {
+    for (const value of ["Worker", "WORKER", " worker", "worker ", "1", "true", ""]) {
+      process.env.DAINTREE_INSTANCE_ROLE = value;
+      expect(resolveInstanceRole()).toBe("attended");
+    }
+  });
+
+  it("matches the prefix preload.cts parses (drift guard)", () => {
+    // preload.cts hardcodes this literal rather than importing the constant
+    // (esbuild cross-bundle); this ties both halves of the contract together
+    // so a rename of INSTANCE_ROLE_ARG fails loudly instead of silently
+    // leaving every instance in attended mode (#10123).
+    expect(`${INSTANCE_ROLE_ARG}=`).toBe("--daintree-instance-role=");
+  });
+
+  it("produces a whitespace-free argv flag", () => {
+    process.env.DAINTREE_INSTANCE_ROLE = "worker";
+    const arg = `${INSTANCE_ROLE_ARG}=${resolveInstanceRole()}`;
+    expect(arg).toBe("--daintree-instance-role=worker");
+    expect(arg).not.toMatch(/\s/);
+  });
+});

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -30,7 +30,9 @@ import { PERF_MARKS } from "../../shared/perf/marks.js";
 import {
   injectSkeletonCss,
   resolveInitialColorSchemeId,
+  resolveInstanceRole,
   INITIAL_COLOR_SCHEME_ARG,
+  INSTANCE_ROLE_ARG,
 } from "./skeletonCss.js";
 import { attachRendererConsoleCapture } from "./rendererConsoleCapture.js";
 import { markPerformance } from "../utils/performance.js";
@@ -261,9 +263,12 @@ export function setupBrowserWindow(
       navigateOnDragDrop: false,
       v8CacheOptions: "code",
       // Seed the renderer with the persisted theme so first paint applies the
-      // saved scheme instead of a prefers-color-scheme default (#9169).
+      // saved scheme instead of a prefers-color-scheme default (#9169). The
+      // instance role rides along so worker instances suppress automatic
+      // background GitHub polling (#10123).
       additionalArguments: [
         `${INITIAL_COLOR_SCHEME_ARG}=${colorSchemeId}`,
+        `${INSTANCE_ROLE_ARG}=${resolveInstanceRole()}`,
         // Thread the demo-mode flag into renderer argv (Electron does not
         // forward main-process CLI switches), so window.electron.demo and the
         // demo overlay components are available when launched with --demo-mode.

--- a/electron/window/skeletonCss.ts
+++ b/electron/window/skeletonCss.ts
@@ -43,6 +43,29 @@ export const INITIAL_COLOR_SCHEME_ARG = "--daintree-initial-color-scheme-id";
 export const INITIAL_PROJECT_ID_ARG = "--daintree-initial-project-id";
 
 /**
+ * Command-line argument carrying the instance role (`worker` | `attended`)
+ * from the main process into each renderer context (#10123). Worker instances
+ * (`DAINTREE_INSTANCE_ROLE=worker`) suppress automatic background GitHub
+ * polling to conserve GraphQL quota; on-demand fetches stay functional.
+ * Read synchronously in preload.cts from `process.argv` and exposed as
+ * `window.__DAINTREE_INSTANCE_ROLE__`. Default is `attended` — no behavior
+ * change unless an instance explicitly opts in.
+ */
+export const INSTANCE_ROLE_ARG = "--daintree-instance-role";
+
+export type InstanceRole = "attended" | "worker";
+
+/**
+ * Resolves the instance role from the launch environment. Only the exact
+ * value `worker` opts in; anything else (unset, empty, malformed) falls back
+ * to `attended` so a typo can never silently disable polling for an attended
+ * instance — or, worse, leave a worker polling.
+ */
+export function resolveInstanceRole(): InstanceRole {
+  return process.env.DAINTREE_INSTANCE_ROLE === "worker" ? "worker" : "attended";
+}
+
+/**
  * Resolves the color scheme id to seed the renderer with on cold start.
  * Mirrors the fallback logic in createWindow and getAppThemeConfig: the raw
  * persisted id when present (without resolving `followSystem` — that happens

--- a/electron/workspace-host/PRIntegrationService.ts
+++ b/electron/workspace-host/PRIntegrationService.ts
@@ -74,15 +74,38 @@ export interface PRIntegrationCallbacks {
   onDetectionStateChanged?(tripped: boolean): void;
 }
 
+export interface PRIntegrationServiceOptions {
+  /**
+   * Worker instances never start the automatic PR polling loop — detection
+   * wiring and on-demand `refresh()` stay fully functional, only the
+   * background `start()` paths become no-ops (#10123).
+   */
+  isWorker?: boolean;
+}
+
 export class PRIntegrationService {
   private prEventUnsubscribers: (() => void)[] = [];
   private initializedForPath: string | null = null;
+  private readonly isWorker: boolean;
 
   constructor(
     private readonly prService: PullRequestServiceLike,
     private readonly eventBus: TypedEventBus,
-    private readonly callbacks: PRIntegrationCallbacks
-  ) {}
+    private readonly callbacks: PRIntegrationCallbacks,
+    options?: PRIntegrationServiceOptions
+  ) {
+    this.isWorker = options?.isWorker === true;
+  }
+
+  /**
+   * Background polling entry point — every automatic `prService.start()` call
+   * funnels through here so worker instances stay quiet. On-demand paths
+   * (`refresh()`) bypass this intentionally.
+   */
+  private startPolling(startupDelayMs?: number): Promise<void> {
+    if (this.isWorker) return Promise.resolve();
+    return this.prService.start(startupDelayMs);
+  }
 
   isInitializedFor(path: string): boolean {
     return this.initializedForPath === path;
@@ -178,7 +201,7 @@ export class PRIntegrationService {
       }
     }
 
-    return this.prService.start();
+    return this.startPolling();
   }
 
   getStatus(): PRServiceStatus {
@@ -207,7 +230,7 @@ export class PRIntegrationService {
     this.prService.reset();
     if (projectRootPath) {
       this.prService.initialize(projectRootPath);
-      void this.prService.start();
+      void this.startPolling();
     }
   }
 
@@ -219,7 +242,7 @@ export class PRIntegrationService {
     // Focus-restore, not a crash-recovery path — skip the startup jitter so
     // the user sees fresh PR state promptly. The 5s checkForPRs() floor still
     // prevents a double-check if a poll just ran.
-    void this.prService.start(0);
+    void this.startPolling(0);
   }
 
   updateForgeCredentials(
@@ -243,7 +266,7 @@ export class PRIntegrationService {
       this.prService.reset();
       if (projectRootPath) {
         this.prService.initialize(projectRootPath);
-        void this.prService.start();
+        void this.startPolling();
       }
     }
   }

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -37,7 +37,7 @@ import { events } from "../services/events.js";
 import { WorktreeLifecycleService, type WorkspaceHostContext } from "./WorktreeLifecycleService.js";
 import { WorktreeMonitor } from "./WorktreeMonitor.js";
 import { WorktreeListService } from "./WorktreeListService.js";
-import { PRIntegrationService } from "./PRIntegrationService.js";
+import { PRIntegrationService, type PRIntegrationCallbacks } from "./PRIntegrationService.js";
 import { RepoFetchCoordinator } from "./RepoFetchCoordinator.js";
 import { waitForPathExists } from "../utils/fs.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
@@ -221,7 +221,7 @@ export class WorkspaceService {
         monitor.triggerRefreshIfUpdating();
       },
     });
-    this.prService = new PRIntegrationService(pullRequestService, events, {
+    const prCallbacks: PRIntegrationCallbacks = {
       onPRDetected: (worktreeId, data) => {
         const monitor = this.monitors.get(worktreeId);
         if (!monitor) return;
@@ -425,6 +425,19 @@ export class WorkspaceService {
       onDetectionStateChanged: (tripped) => {
         this.sendEvent({ type: "pr-detection-state", tripped });
       },
+    };
+    // Worker instances (DAINTREE_INSTANCE_ROLE=worker) never start the
+    // automatic PR polling loop — the UtilityProcess inherits the launch env
+    // from main, so the flag is readable here directly (#10123). On-demand
+    // refresh and detection wiring stay fully functional.
+    const rawInstanceRole = process.env.DAINTREE_INSTANCE_ROLE;
+    if (rawInstanceRole && rawInstanceRole !== "worker" && rawInstanceRole !== "attended") {
+      console.warn(
+        `WorkspaceService: unrecognized DAINTREE_INSTANCE_ROLE "${rawInstanceRole}" — defaulting to attended`
+      );
+    }
+    this.prService = new PRIntegrationService(pullRequestService, events, prCallbacks, {
+      isWorker: rawInstanceRole === "worker",
     });
 
     this.resourceActionExecutor = new ResourceActionExecutor({

--- a/electron/workspace-host/__tests__/PRIntegrationService.test.ts
+++ b/electron/workspace-host/__tests__/PRIntegrationService.test.ts
@@ -391,4 +391,59 @@ describe("PRIntegrationService", () => {
       expect(prServiceMock.refresh).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("worker role (#10123)", () => {
+    function makeWorkerService() {
+      return new PRIntegrationService(prServiceMock, eventBus, callbacks, { isWorker: true });
+    }
+
+    it("initialize() wires detection but never starts the polling loop", async () => {
+      const emitSpy = vi.spyOn(eventBus, "emit");
+      const service = makeWorkerService();
+
+      await service.initialize("/repo", () => [
+        { worktreeId: "wt-1", branch: "feature/foo", issueNumber: 7, isMainWorktree: false },
+      ]);
+
+      // Detection wiring is intact: candidates are still seeded…
+      expect(prServiceMock.initialize).toHaveBeenCalledWith("/repo");
+      const updateCalls = emitSpy.mock.calls.filter(([ev]) => ev === "sys:worktree:update");
+      expect(updateCalls).toHaveLength(1);
+      // …but the automatic polling loop never starts.
+      expect(prServiceMock.start).not.toHaveBeenCalled();
+    });
+
+    it("resume() is a no-op", () => {
+      const service = makeWorkerService();
+      service.resume();
+      expect(prServiceMock.start).not.toHaveBeenCalled();
+    });
+
+    it("resetPRState() reinitializes without restarting polling", () => {
+      const service = makeWorkerService();
+      service.resetPRState("/repo");
+      expect(prServiceMock.reset).toHaveBeenCalled();
+      expect(prServiceMock.initialize).toHaveBeenCalledWith("/repo");
+      expect(prServiceMock.start).not.toHaveBeenCalled();
+    });
+
+    it("updateForgeCredentials(null) reinitializes without restarting polling", () => {
+      const service = makeWorkerService();
+      service.updateForgeCredentials("builtin.github", null, "/repo");
+      expect(prServiceMock.initialize).toHaveBeenCalledWith("/repo");
+      expect(prServiceMock.start).not.toHaveBeenCalled();
+    });
+
+    it("keeps the on-demand refresh path functional", () => {
+      const service = makeWorkerService();
+      service.updateForgeCredentials("builtin.github", { kind: "bearer", value: "ghp_x" }, "/repo");
+      expect(prServiceMock.refresh).toHaveBeenCalledTimes(1);
+    });
+
+    it("attended remains the default when options are omitted", async () => {
+      const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
+      await service.initialize("/repo", () => []);
+      expect(prServiceMock.start).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/hooks/__tests__/usePollingLifecycle.test.tsx
+++ b/src/hooks/__tests__/usePollingLifecycle.test.tsx
@@ -423,4 +423,127 @@ describe("usePollingLifecycle", () => {
       expect(onProjectSwitch).not.toHaveBeenCalled();
     });
   });
+
+  describe("enabled gate (#10123)", () => {
+    function setupGatedHook(opts: {
+      enabled: boolean;
+      fetchFn?: (ctx: {
+        force: boolean;
+        fetchId: number;
+        isInvalidated: () => boolean;
+      }) => Promise<void>;
+      calculateNextInterval?: (ctx: { isVisible: boolean }) => number;
+    }) {
+      const fetchFn = opts.fetchFn ?? vi.fn().mockResolvedValue(undefined);
+      const calculateNextInterval = opts.calculateNextInterval ?? vi.fn(() => 30_000);
+      const hook = renderHook(
+        ({ enabled }: { enabled: boolean }) =>
+          usePollingLifecycle({ enabled, fetchFn, calculateNextInterval }),
+        { initialProps: { enabled: opts.enabled } }
+      );
+      return { hook, fetchFn, calculateNextInterval };
+    }
+
+    it("performs no initial fetch and registers no global listeners when disabled", async () => {
+      const addEventListenerSpy = vi.spyOn(document, "addEventListener");
+      const fetchFn = vi.fn().mockResolvedValue(undefined);
+
+      setupGatedHook({ enabled: false, fetchFn });
+
+      // Give any (incorrect) async fetch a chance to land before asserting.
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(fetchFn).not.toHaveBeenCalled();
+      expect(onSwitchMock).not.toHaveBeenCalled();
+      const visibilityCalls = addEventListenerSpy.mock.calls.filter(
+        ([event]) => event === "visibilitychange"
+      );
+      expect(visibilityCalls).toHaveLength(0);
+
+      addEventListenerSpy.mockRestore();
+    });
+
+    it("ignores global triggers while disabled", async () => {
+      const fetchFn = vi.fn().mockResolvedValue(undefined);
+      setupGatedHook({ enabled: false, fetchFn });
+
+      await act(async () => {
+        window.dispatchEvent(new CustomEvent("daintree:refresh-sidebar"));
+        document.dispatchEvent(new Event("visibilitychange"));
+        await Promise.resolve();
+      });
+
+      expect(fetchFn).not.toHaveBeenCalled();
+    });
+
+    it("still fetches on explicit refresh() but never arms the polling timer", async () => {
+      const fetchFn = vi.fn().mockResolvedValue(undefined);
+      const calculateNextInterval = vi.fn(() => 30_000);
+      const { hook } = setupGatedHook({ enabled: false, fetchFn, calculateNextInterval });
+
+      await act(async () => {
+        await hook.result.current.refresh({ force: true });
+      });
+
+      // The on-demand path stays functional…
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+      expect(fetchFn.mock.calls[0]?.[0]?.force).toBe(true);
+      // …but the reschedule tail is suppressed: scheduleNextPoll bails before
+      // computing an interval, so no background timer exists afterwards.
+      expect(calculateNextInterval).not.toHaveBeenCalled();
+    });
+
+    it("does not block sibling enabled consumers", async () => {
+      const disabledFetch = vi.fn().mockResolvedValue(undefined);
+      const enabledFetch = vi.fn().mockResolvedValue(undefined);
+      setupGatedHook({ enabled: false, fetchFn: disabledFetch });
+      setupHook({ fetchFn: enabledFetch });
+
+      await waitFor(() => {
+        expect(enabledFetch).toHaveBeenCalledTimes(1);
+      });
+      expect(disabledFetch).not.toHaveBeenCalled();
+    });
+
+    it("starts polling when enabled flips from false to true", async () => {
+      const fetchFn = vi.fn().mockResolvedValue(undefined);
+      const { hook } = setupGatedHook({ enabled: false, fetchFn });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(fetchFn).not.toHaveBeenCalled();
+
+      hook.rerender({ enabled: true });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+      });
+      expect(onSwitchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("tears down polling when enabled flips from true to false", async () => {
+      const projectSwitchCleanup = vi.fn();
+      onSwitchMock.mockReturnValue(projectSwitchCleanup);
+      const fetchFn = vi.fn().mockResolvedValue(undefined);
+      const { hook } = setupGatedHook({ enabled: true, fetchFn });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+      });
+
+      hook.rerender({ enabled: false });
+
+      // Last subscriber left — the singleton listeners are torn down.
+      expect(projectSwitchCleanup).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        window.dispatchEvent(new CustomEvent("daintree:refresh-sidebar"));
+        await Promise.resolve();
+      });
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/hooks/__tests__/useProjectHealth.test.tsx
+++ b/src/hooks/__tests__/useProjectHealth.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProjectHealthData } from "@shared/types/ipc/github";
 
 const { getCurrentMock, onSwitchMock, getProjectHealthMock } = vi.hoisted(() => ({
@@ -357,6 +357,50 @@ describe("useProjectHealth", () => {
         expect(result.current.isValidating).toBe(false);
         expect(result.current.health?.issueCount).toBe(9);
       });
+    });
+  });
+
+  describe("worker instance role (#10123)", () => {
+    beforeEach(() => {
+      window.__DAINTREE_INSTANCE_ROLE__ = { role: "worker" };
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo/a" });
+      getProjectHealthMock.mockResolvedValue(makeHealth());
+    });
+
+    afterEach(() => {
+      delete window.__DAINTREE_INSTANCE_ROLE__;
+    });
+
+    it("performs no automatic fetch on mount", async () => {
+      renderHook(() => useProjectHealth());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(getProjectHealthMock).not.toHaveBeenCalled();
+    });
+
+    it("suppresses the wake-epoch refetch", async () => {
+      renderHook(() => useProjectHealth());
+
+      await act(async () => {
+        useSystemWakeStore.setState((s) => ({ wakeEpoch: s.wakeEpoch + 1 }));
+        await Promise.resolve();
+      });
+
+      expect(getProjectHealthMock).not.toHaveBeenCalled();
+    });
+
+    it("keeps explicit refresh() functional", async () => {
+      const { result } = renderHook(() => useProjectHealth());
+
+      await act(async () => {
+        await result.current.refresh({ force: true });
+      });
+
+      expect(getProjectHealthMock).toHaveBeenCalledTimes(1);
+      expect(getProjectHealthMock.mock.calls[0]?.[1]).toBe(true);
     });
   });
 });

--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RepositoryStats } from "@/types";
 
 const {
@@ -1454,6 +1454,79 @@ describe("useRepositoryStats", () => {
         expect(result.current.isValidating).toBe(false);
         expect(result.current.stats?.commitCount).toBe(6);
       });
+    });
+  });
+
+  describe("worker instance role (#10123)", () => {
+    beforeEach(() => {
+      window.__DAINTREE_INSTANCE_ROLE__ = { role: "worker" };
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo" });
+      onSwitchMock.mockReturnValue(() => {});
+      getRepoStatsMock.mockResolvedValue({
+        commitCount: 1,
+        issueCount: 1,
+        prCount: 1,
+        loading: false,
+        stale: false,
+        lastUpdated: 1000,
+      });
+    });
+
+    afterEach(() => {
+      delete window.__DAINTREE_INSTANCE_ROLE__;
+    });
+
+    it("performs no automatic fetch on mount", async () => {
+      renderHook(() => useRepositoryStats());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(getRepoStatsMock).not.toHaveBeenCalled();
+    });
+
+    it("suppresses the wake-epoch refetch", async () => {
+      renderHook(() => useRepositoryStats());
+
+      await act(async () => {
+        useSystemWakeStore.setState((s) => ({ wakeEpoch: s.wakeEpoch + 1 }));
+        await Promise.resolve();
+      });
+
+      expect(getRepoStatsMock).not.toHaveBeenCalled();
+    });
+
+    it("suppresses the rate-limit-cleared auto-refresh", async () => {
+      let rateLimitCb: ((payload: unknown) => void) | undefined;
+      onRateLimitChangedMock.mockImplementation((cb) => {
+        rateLimitCb = cb;
+        return () => {};
+      });
+
+      renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(rateLimitCb).toBeDefined();
+      });
+
+      await act(async () => {
+        rateLimitCb?.({ blocked: false, kind: null, resetAt: null });
+        await Promise.resolve();
+      });
+
+      expect(getRepoStatsMock).not.toHaveBeenCalled();
+    });
+
+    it("keeps explicit refresh() functional without resuming polling", async () => {
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await act(async () => {
+        await result.current.refresh({ force: true });
+      });
+
+      expect(getRepoStatsMock).toHaveBeenCalledTimes(1);
+      expect(getRepoStatsMock.mock.calls[0]?.[1]).toBe(true);
     });
   });
 });

--- a/src/hooks/usePollingLifecycle.ts
+++ b/src/hooks/usePollingLifecycle.ts
@@ -25,6 +25,15 @@ export interface PollingLifecycleConfig {
    * any per-project state here so the immediate refetch lands cleanly.
    */
   onProjectSwitch?: () => void;
+  /**
+   * When false, the lifecycle is fully inert: no initial fetch, no timer, and
+   * no global-trigger subscription — the consumer never registers in the
+   * module-level fan-out Set. Explicit `refresh()` calls still fetch (the
+   * on-demand path stays functional) but never arm the polling timer. Used by
+   * worker instances to suppress automatic background GitHub polling (#10123).
+   * Defaults to true.
+   */
+  enabled?: boolean;
 }
 
 export interface PollingLifecycleControl {
@@ -217,6 +226,10 @@ export function usePollingLifecycle(config: PollingLifecycleConfig): PollingLife
   const scheduleNextPoll = useCallback(
     function scheduleNextPollImpl(): void {
       if (!aliveRef.current) return;
+      // Disabled lifecycles never arm the timer — this also covers the
+      // `refresh()` tail, so an explicit on-demand fetch can't resurrect
+      // background polling on a worker instance (#10123).
+      if (configRef.current.enabled === false) return;
       if (pollTimerRef.current) {
         clearTimeout(pollTimerRef.current);
       }
@@ -254,8 +267,18 @@ export function usePollingLifecycle(config: PollingLifecycleConfig): PollingLife
     controlRef.current = { scheduleNextPoll, refresh };
   }
 
+  // Read through the live config so the effect below re-runs on change —
+  // `false` makes the lifecycle inert (no fetch, no timer, no subscription).
+  const enabled = config.enabled !== false;
+
   useEffect(() => {
     aliveRef.current = true;
+
+    if (!enabled) {
+      return () => {
+        aliveRef.current = false;
+      };
+    }
 
     const subscriber: Subscriber = {
       onVisibilityVisible: () => {
@@ -312,8 +335,9 @@ export function usePollingLifecycle(config: PollingLifecycleConfig): PollingLife
     // callFetchFn / scheduleNextPoll / refresh are identity-stable
     // (`useCallback` with stable deps), so depending on them here is a no-op
     // — they never change after first render — but listing them silences the
-    // exhaustive-deps lint.
-  }, [callFetchFn, refresh, scheduleNextPoll]);
+    // exhaustive-deps lint. `enabled` is the one live dep: a false→true flip
+    // re-runs the effect and starts polling; true→false tears it down.
+  }, [callFetchFn, refresh, scheduleNextPoll, enabled]);
 
   return controlRef.current;
 }

--- a/src/hooks/useProjectHealth.ts
+++ b/src/hooks/useProjectHealth.ts
@@ -47,7 +47,12 @@ export function useProjectHealth(): UseProjectHealthReturn {
     };
   }, []);
 
+  // Worker instances suppress automatic background polling to conserve
+  // GitHub GraphQL quota (#10123) — on-demand `refresh()` stays functional.
+  const isWorkerInstance = window.__DAINTREE_INSTANCE_ROLE__?.role === "worker";
+
   const polling = usePollingLifecycle({
+    enabled: !isWorkerInstance,
     fetchFn: async ({ force, isInvalidated }) => {
       try {
         const project = await projectClient.getCurrent();
@@ -136,8 +141,11 @@ export function useProjectHealth(): UseProjectHealthReturn {
   useEffect(() => {
     if (wakeEpoch <= lastSeenWakeEpochRef.current) return;
     lastSeenWakeEpochRef.current = wakeEpoch;
+    // Wake refetches are automatic background fetches — suppressed on worker
+    // instances like the polling loop itself (#10123).
+    if (isWorkerInstance) return;
     void polling.refresh();
-  }, [wakeEpoch, polling]);
+  }, [wakeEpoch, polling, isWorkerInstance]);
 
   return {
     health,

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -220,7 +220,12 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
     []
   );
 
+  // Worker instances suppress automatic background polling to conserve
+  // GitHub GraphQL quota (#10123) — on-demand `refresh()` stays functional.
+  const isWorkerInstance = window.__DAINTREE_INSTANCE_ROLE__?.role === "worker";
+
   const polling = usePollingLifecycle({
+    enabled: !isWorkerInstance,
     fetchFn: async ({ force, isInvalidated }) => {
       try {
         const project = await projectClient.getCurrent();
@@ -489,8 +494,11 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
   useEffect(() => {
     if (wakeEpoch <= lastSeenWakeEpochRef.current) return;
     lastSeenWakeEpochRef.current = wakeEpoch;
+    // Wake refetches are automatic background fetches — suppressed on worker
+    // instances like the polling loop itself (#10123).
+    if (isWorkerInstance) return;
     void polling.refresh();
-  }, [wakeEpoch, polling]);
+  }, [wakeEpoch, polling, isWorkerInstance]);
 
   useEffect(() => {
     const cleanup = githubClient.onRateLimitChanged((payload) => {

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -512,15 +512,18 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       // When the limit clears, run an immediate refresh so the UI updates
       // without waiting a full poll interval; `refresh` clears the timer,
       // fetches, and reschedules against the new rate-limit-aware interval.
-      // When blocked, just reschedule against the new resume time.
+      // When blocked, just reschedule against the new resume time. The clear
+      // is an automatic system event, not a user action — suppressed on
+      // worker instances like the polling loop itself (#10123).
       if (!payload.blocked) {
+        if (isWorkerInstance) return;
         void polling.refresh();
       } else {
         polling.scheduleNextPoll();
       }
     });
     return cleanup;
-  }, [polling]);
+  }, [polling, isWorkerInstance]);
 
   const isTokenError = isTokenRelatedError(error);
 

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -44,6 +44,8 @@ declare global {
     __DAINTREE_INITIAL_THEME__?: { colorSchemeId: string };
     /** Destination project id seeded by preload, replacing the `?projectId=` query string (#9162). */
     __DAINTREE_INITIAL_PROJECT__?: { id: string };
+    /** Instance role seeded by preload — worker instances suppress automatic background GitHub polling (#10123). */
+    __DAINTREE_INSTANCE_ROLE__?: { role: "attended" | "worker" };
     __daintreeDispatchAction?: (
       actionId: string,
       args?: unknown,


### PR DESCRIPTION
Closes #10123. Part of the GitHub GraphQL quota-conservation effort (#10122).

## What

Adds a launch-time instance role — `worker` vs `attended` — that gates all automatic background GitHub GraphQL traffic. Set `DAINTREE_INSTANCE_ROLE=worker` in the launch environment to opt a fleet instance in; the default is `attended` with zero behavior change.

## How

**Role propagation**
- `DAINTREE_INSTANCE_ROLE=worker` is read in main (`resolveInstanceRole()` in `skeletonCss.ts`) and surfaced to every renderer via a `--daintree-instance-role` `additionalArgument`, set in **both** WebContentsView creation sites (`createWindow.ts` and `ProjectViewManager.ts`, per the #9333/#9396 precedent so LRU-evicted and project-switch views keep the flag).
- `preload.cts` parses the argv flag (with a `process.env` fallback) and exposes `window.__DAINTREE_INSTANCE_ROLE__` unconditionally, so consumers never null-guard. Only the exact value `worker` opts in; anything malformed normalizes to `attended`. A drift-guard test ties the hardcoded preload literal to the exported constant.
- The workspace-host UtilityProcess inherits the launch env from main, so no IPC forwarding is needed there.

**Renderer gating**
- `usePollingLifecycle` gains an `enabled` flag. When false the lifecycle is fully inert: no initial fetch, no timer, and no global-trigger subscription (the consumer never registers in the module-level fan-out Set, instead of a leaked-closure `Infinity` interval). Explicit `refresh()` still fetches — the on-demand path stays functional — but `scheduleNextPoll` bails, so a manual refresh can never resurrect background polling.
- `useRepositoryStats` and `useProjectHealth` pass `enabled: !isWorkerInstance` and additionally suppress the wake-epoch refetch and the rate-limit-cleared auto-refresh (both automatic system events, not user actions).

**Workspace-host gating**
- `PRIntegrationService` takes a new `{ isWorker }` option. Every automatic `prService.start()` path (initialize tail, focus-restore `resume()`, `resetPRState`, credential-revoke reinit) funnels through a `startPolling()` no-op in worker mode. Detection wiring, candidate seeding, and on-demand `refresh()` are untouched, so explicit PR lookups still resolve.
- `WorkspaceService` reads the inherited env and warns on malformed values.

## Testing

- `resolveInstanceRole` unit tests incl. malformed-value normalization and the preload-literal drift guard
- `usePollingLifecycle` enabled-gate suite: inert when disabled, ignores global triggers, refresh-without-timer, sibling-consumer isolation, hot-flip in both directions
- `PRIntegrationService` worker-role suite: detection wired but polling never starts, resume/reset/credential paths stay quiet, on-demand refresh functional, attended default preserved
- Worker-mode hook tests for `useRepositoryStats` (incl. rate-limit-clear suppression) and `useProjectHealth`
- 121 tests green across 6 suites; full `npm run check` + build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)