### PR TITLE
fix(forge): stop 5s provider-resolution spin for projects with no matching forge provider

### DIFF
--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -658,6 +658,17 @@ export class PluginService {
   }
 
   /**
+   * Whether the manifest scan phase ({@link initialize}) has settled. Forge
+   * provider descriptors register at scan-time, so once this is true a
+   * hostname-match miss in `resolveForgeProvider` is a definitive "no
+   * provider matches" rather than a cold-start race (#9997). Distinct from
+   * {@link waitForInit}, which also waits for startup activation.
+   */
+  get isPluginScanComplete(): boolean {
+    return this.initialized;
+  }
+
+  /**
    * Stop forwarding shared registry events to the renderer. Intended for
    * tests that need a clean teardown — production code holds a single
    * `pluginService` singleton for the app lifetime. Also drops any pending
@@ -1070,6 +1081,10 @@ export class PluginService {
 
     if (manifest.contributes.forgeProviders.length > 0) {
       registerForgeProviders(manifest.name, manifest.contributes.forgeProviders);
+      // Wake workspace-hosts whose PR polling paused on a "no provider
+      // matches" resolution so they re-evaluate against the new descriptor
+      // (#9997). Covers both the startup scan and runtime install/enable.
+      this.workspaceClient?.notifyForgeProviderRegistryUpdated();
     }
 
     if (manifest.contributes.fileDecorationProviders.length > 0) {

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -161,6 +161,14 @@ class PullRequestService {
   private projectId: string | null = null;
   private providerNamespacedId: string | null = null;
   private repoRef: RepoRef | null = null;
+  // Outcome of the last `resolveProvider()` round-trip. `"no-match"` is a
+  // definitive answer (plugin scan complete, no provider matches the remote):
+  // polling pauses and re-resolution is skipped until `invalidateProvider()`
+  // clears it back to null — without this, a GitLab/Bitbucket project would
+  // spin on the 5s cold-start cap forever (#9997). `"not-ready"` and null
+  // keep the cold-start retry cap. Re-armed by forge settings changes,
+  // manual refresh, and `forge:provider-registry-updated` pushes from main.
+  private providerResolutionStatus: "resolved" | "no-match" | "not-ready" | null = null;
   // Forge provider routing settings, pushed in from the main process. The
   // workspace-host can't read `projectStore` or `electron-store` directly —
   // those modules pull `BrowserWindow`/`app` into the bundle and crash the
@@ -389,19 +397,31 @@ class PullRequestService {
 
       // The bridge does provider resolution and `parseRemote` in one IPC
       // roundtrip: the registry lives in main (where plugins activate), so
-      // there's no point trying to consult it locally. Returns null when no
-      // provider matches the remote OR no remote URL is available.
+      // there's no point trying to consult it locally. A miss is
+      // discriminated (#9997): "not-ready" (plugin scan still running —
+      // retry on the cold-start cap) vs "no-match" (definitive — pause
+      // polling until invalidation).
       const resolved = await getForgeBridge().resolveProvider({
         remoteUrl,
         forgeProviderOverride: this.forgeProviderOverride,
         globalDefaultProviderId: this.globalDefaultProviderId,
       });
-      if (!resolved) {
+      if (resolved.status !== "resolved") {
+        this.providerResolutionStatus = resolved.status;
         this.providerNamespacedId = null;
         this.repoRef = null;
         this.disposeLoaders();
+        if (resolved.status === "no-match") {
+          logInfo(
+            "PullRequestService: no forge provider matches this project — pausing PR polling",
+            {
+              hasRemoteUrl: remoteUrl !== null,
+            }
+          );
+        }
         return;
       }
+      this.providerResolutionStatus = "resolved";
       this.providerNamespacedId = resolved.namespacedId;
       this.repoRef = resolved.repo;
       this.createLoaders(resolved.namespacedId, resolved.repo);
@@ -414,6 +434,9 @@ class PullRequestService {
       logWarn("PullRequestService provider resolution failed", {
         error: formatErrorMessage(error, "Provider resolution failed"),
       });
+      // A thrown resolution (git read or IPC failure) is transient — leave
+      // the status null so the cold-start retry cap stays in effect.
+      this.providerResolutionStatus = null;
       this.providerNamespacedId = null;
       this.repoRef = null;
       this.disposeLoaders();
@@ -421,9 +444,27 @@ class PullRequestService {
   }
 
   private invalidateProvider(): void {
+    this.providerResolutionStatus = null;
     this.providerNamespacedId = null;
     this.repoRef = null;
     this.disposeLoaders();
+  }
+
+  /**
+   * Main pushed `forge:provider-registry-updated` — a forge provider
+   * descriptor was registered (startup scan or runtime plugin
+   * install/enable). A cached "no-match"/"not-ready" miss may now resolve, so
+   * drop it and re-check. A resolved provider is left alone: provider-affecting
+   * settings changes arrive via `setForgeSettings()`, which always invalidates.
+   */
+  public notifyForgeProviderRegistryUpdated(): void {
+    if (this.providerResolutionStatus === "resolved") return;
+    this.invalidateProvider();
+    if (!this.isPolling || this.startupDelayTimer !== null) return;
+    // Re-enter the poll loop: "no-match" pauses without an armed timer, so a
+    // debounced check (which respects the 5s floor and re-arms the poll
+    // timer when none is pending) is the wake-up.
+    this.scheduleDebounceCheck();
   }
 
   private async clearProviderPullRequestCaches(): Promise<void> {
@@ -833,6 +874,17 @@ class PullRequestService {
       return;
     }
 
+    // Definitive "no provider matches this remote" (#9997): pause without a
+    // timer, exactly like the all-resolved case above. Re-armed by
+    // `invalidateProvider()` (forge settings change, manual refresh, or a
+    // `forge:provider-registry-updated` push when a plugin registers a new
+    // provider). Without this, the cold-start cap below would re-poll a
+    // GitLab/Bitbucket project every 5s forever.
+    if (this.providerResolutionStatus === "no-match") {
+      logDebug("No matching forge provider - pausing polling until invalidation");
+      return;
+    }
+
     let interval = this.pollIntervalMs;
     if (this.consecutiveErrors > 0) {
       interval = computeBackoff(this.consecutiveErrors);
@@ -850,7 +902,9 @@ class PullRequestService {
     // fires before that completes, leaving `providerNamespacedId` null. At the
     // blurred cadence (120s) the user would otherwise stare at empty PR
     // sub-rows for two minutes after every cold start. Once the bridge returns
-    // a real provider the next poll uses the normal cadence again.
+    // a real provider the next poll uses the normal cadence again. This cap
+    // only ever applies to a transient miss ("not-ready"/null) — a definitive
+    // "no-match" already paused above (#9997).
     //
     // Skip this when `consecutiveErrors > 0`: the circuit-breaker backoff is
     // deliberate (the last call failed against the API), and punching through
@@ -1355,9 +1409,16 @@ class PullRequestService {
     // lives in main and is populated by `PluginService.initialize()`; the
     // workspace-host UtilityProcess starts polling before that finishes, so a
     // one-shot resolution at `start()` would lose the race permanently. Each
-    // poll retries until main answers with a real provider — and once resolved
-    // we keep the cache (cleared explicitly by `refresh()`/`setForgeSettings`).
-    if (!this.providerNamespacedId || !this.repoRef) {
+    // poll retries until main answers definitively — and both definitive
+    // answers are then cached (cleared explicitly by `refresh()` /
+    // `setForgeSettings()` / `forge:provider-registry-updated`): a resolved
+    // provider, or a "no-match" miss, which would otherwise re-spawn
+    // `resolveProvider()`'s git-config reads on every debounced worktree
+    // update (#9997).
+    if (
+      (!this.providerNamespacedId || !this.repoRef) &&
+      this.providerResolutionStatus !== "no-match"
+    ) {
       await this.resolveProvider();
     }
 

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -242,6 +242,19 @@ export class WorkspaceClient extends EventEmitter {
     }
   }
 
+  /**
+   * Broadcast that a forge provider descriptor was registered (startup scan
+   * or runtime plugin install/enable) so hosts whose PR polling paused on a
+   * "no provider matches" resolution re-evaluate (#9997). Fire-and-forget,
+   * mirroring the polling-control sends above.
+   */
+  notifyForgeProviderRegistryUpdated(): void {
+    if (this.isDisposed) return;
+    for (const entry of this.pool.entries.values()) {
+      entry.host.send({ type: "forge:provider-registry-updated" });
+    }
+  }
+
   setPRPollCadence(focused: boolean): void {
     for (const entry of this.pool.entries.values()) {
       entry.host.send({ type: "set-pr-poll-cadence", focused });

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -1425,6 +1425,89 @@ describe("PullRequestService", () => {
       pullRequestService.destroy();
     });
 
+    it("transitions from not-ready retries to a no-match pause when the scan settles mid-session", async () => {
+      vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+      mockForgeProviderUnresolved({ status: "not-ready" });
+      const bridge = lastMockBridge!;
+
+      const { pullRequestService } = await import("../PullRequestService.js");
+      const { events } = await import("../events.js");
+
+      pullRequestService.initialize("/repo");
+      events.emit(
+        "sys:worktree:update",
+        makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
+      );
+
+      await pullRequestService.start(0);
+      const callsAfterStart = bridge.resolveProvider.mock.calls.length;
+
+      // Plugin scan finishes between ticks — the next retry gets the
+      // definitive answer and the loop must pause instead of spinning on.
+      bridge.resolveProvider.mockResolvedValue({ status: "no-match" });
+      await vi.advanceTimersByTimeAsync(5_000);
+      const callsAtNoMatch = bridge.resolveProvider.mock.calls.length;
+      expect(callsAtNoMatch).toBe(callsAfterStart + 1);
+
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+      expect(bridge.resolveProvider.mock.calls.length).toBe(callsAtNoMatch);
+
+      pullRequestService.destroy();
+    });
+
+    it("is harmless when forge:provider-registry-updated arrives before start()", async () => {
+      vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+      mockForgeProviderUnresolved({ status: "no-match" });
+      const bridge = lastMockBridge!;
+
+      const { pullRequestService } = await import("../PullRequestService.js");
+      const { events } = await import("../events.js");
+
+      pullRequestService.initialize("/repo");
+      pullRequestService.notifyForgeProviderRegistryUpdated();
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(bridge.resolveProvider).not.toHaveBeenCalled();
+
+      events.emit(
+        "sys:worktree:update",
+        makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
+      );
+      await pullRequestService.start(0);
+      expect(bridge.resolveProvider).toHaveBeenCalled();
+
+      pullRequestService.destroy();
+    });
+
+    it("does not re-resolve when a worktree update fires while paused on no-match", async () => {
+      vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+      mockForgeProviderUnresolved({ status: "no-match" });
+      const bridge = lastMockBridge!;
+
+      const { pullRequestService } = await import("../PullRequestService.js");
+      const { events } = await import("../events.js");
+
+      pullRequestService.initialize("/repo");
+      events.emit(
+        "sys:worktree:update",
+        makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
+      );
+
+      await pullRequestService.start(0);
+      await vi.advanceTimersByTimeAsync(60_000);
+      const callsWhilePaused = bridge.resolveProvider.mock.calls.length;
+
+      // New candidate triggers the debounced check, but the cached no-match
+      // must keep blocking resolution (no fresh git-config spawns, #9997).
+      events.emit(
+        "sys:worktree:update",
+        makeWorktreeSnapshot({ worktreeId: "wt-2", branch: "feature/other" })
+      );
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(bridge.resolveProvider.mock.calls.length).toBe(callsWhilePaused);
+
+      pullRequestService.destroy();
+    });
+
     it("re-resolves after a no-match when forge settings change (setForgeSettings + refresh)", async () => {
       vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
       mockForgeProviderUnresolved({ status: "no-match" });

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -56,15 +56,16 @@ function makeMockBridge(impl: ForgeProviderImpl) {
   // namespacedId argument so existing `expect(impl.X).toHaveBeenCalledWith(...)`
   // assertions keep matching the original (provider-shaped) signature.
   return {
-    // Explicit return-type annotation so `.mockResolvedValue(null)` is allowed
-    // for the unresolved variant; the default resolves to a real provider.
+    // Explicit return-type annotation so the unresolved variant can swap in a
+    // "not-ready"/"no-match" miss; the default resolves to a real provider.
     resolveProvider: vi.fn<
       (_opts: {
         remoteUrl: string | null;
         forgeProviderOverride: string | null;
         globalDefaultProviderId: string | null;
-      }) => Promise<ForgeResolveProviderResult | null>
+      }) => Promise<ForgeResolveProviderResult>
     >(async () => ({
+      status: "resolved",
       namespacedId: "daintree.github.github",
       repo: makeMockRepoRef(),
     })),
@@ -164,12 +165,18 @@ function mockForgeProviderResolved(
 
 function mockForgeProviderUnresolved(opts?: {
   getConfig?: (key: string) => Promise<string | null>;
+  /**
+   * Miss discrimination (#9997): "not-ready" (default) mimics the cold-start
+   * race where the plugin scan hasn't settled; "no-match" is the definitive
+   * "no provider matches this remote" answer that pauses polling.
+   */
+  status?: "not-ready" | "no-match";
 }) {
-  // No impl behind the bridge — `resolveProvider` returns null so the service
+  // No impl behind the bridge — `resolveProvider` misses so the service
   // takes the "no forge provider resolved" branch.
   const placeholderImpl = makeMockEmptyImpl();
   const bridge = makeMockBridge(placeholderImpl);
-  bridge.resolveProvider.mockResolvedValue(null);
+  bridge.resolveProvider.mockResolvedValue({ status: opts?.status ?? "not-ready" });
   lastMockBridge = bridge;
   vi.doMock("../../workspace-host/forgeBridge.js", () => ({
     getForgeBridge: () => bridge,
@@ -1296,6 +1303,164 @@ describe("PullRequestService", () => {
 
     unsubscribe();
     pullRequestService.destroy();
+  });
+
+  describe("no-match provider pause (#9997)", () => {
+    it("keeps retrying on the 5s cold-start cap while resolution reports not-ready", async () => {
+      vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+      mockForgeProviderUnresolved({ status: "not-ready" });
+      const bridge = lastMockBridge!;
+
+      const { pullRequestService } = await import("../PullRequestService.js");
+      const { events } = await import("../events.js");
+
+      pullRequestService.initialize("/repo");
+      events.emit(
+        "sys:worktree:update",
+        makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
+      );
+
+      await pullRequestService.start(0);
+      const callsAfterStart = bridge.resolveProvider.mock.calls.length;
+      expect(callsAfterStart).toBeGreaterThan(0);
+
+      // The transient miss keeps the cold-start catch-up cap: each 5s tick
+      // re-attempts resolution.
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(bridge.resolveProvider.mock.calls.length).toBe(callsAfterStart + 1);
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(bridge.resolveProvider.mock.calls.length).toBe(callsAfterStart + 2);
+
+      pullRequestService.destroy();
+    });
+
+    it("pauses polling entirely on a definitive no-match (no 5s spin)", async () => {
+      vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+      mockForgeProviderUnresolved({ status: "no-match" });
+      const bridge = lastMockBridge!;
+
+      const { pullRequestService } = await import("../PullRequestService.js");
+      const { events } = await import("../events.js");
+
+      pullRequestService.initialize("/repo");
+      events.emit(
+        "sys:worktree:update",
+        makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
+      );
+
+      await pullRequestService.start(0);
+      const callsAfterStart = bridge.resolveProvider.mock.calls.length;
+      expect(callsAfterStart).toBeGreaterThan(0);
+
+      // Definitive miss: no timer is armed, so hours of fake time produce
+      // zero further resolution attempts (the bug was a 5s loop forever).
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+      expect(bridge.resolveProvider.mock.calls.length).toBe(callsAfterStart);
+
+      pullRequestService.destroy();
+    });
+
+    it("re-arms a no-match pause when main pushes forge:provider-registry-updated", async () => {
+      vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+      mockForgeProviderUnresolved({ status: "no-match" });
+      const bridge = lastMockBridge!;
+
+      const { pullRequestService } = await import("../PullRequestService.js");
+      const { events } = await import("../events.js");
+
+      pullRequestService.initialize("/repo");
+      events.emit(
+        "sys:worktree:update",
+        makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
+      );
+
+      await pullRequestService.start(0);
+      await vi.advanceTimersByTimeAsync(60_000);
+      const callsWhilePaused = bridge.resolveProvider.mock.calls.length;
+
+      // A plugin registered a forge provider that matches now.
+      bridge.resolveProvider.mockResolvedValue({
+        status: "resolved",
+        namespacedId: "daintree.github.github",
+        repo: makeMockRepoRef(),
+      });
+      bridge.findPRByBranch.mockResolvedValue(null);
+      pullRequestService.notifyForgeProviderRegistryUpdated();
+
+      // Debounced wake-up re-resolves and resumes the poll loop.
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(bridge.resolveProvider.mock.calls.length).toBe(callsWhilePaused + 1);
+      expect(pullRequestService.getProviderContext()).toMatchObject({
+        providerId: "daintree.github.github",
+        owner: "testowner",
+        repo: "testrepo",
+      });
+
+      pullRequestService.destroy();
+    });
+
+    it("leaves an already-resolved provider untouched on forge:provider-registry-updated", async () => {
+      vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+      mockForgeProviderResolved();
+      const bridge = lastMockBridge!;
+
+      const { pullRequestService } = await import("../PullRequestService.js");
+      const { events } = await import("../events.js");
+
+      pullRequestService.initialize("/repo");
+      events.emit(
+        "sys:worktree:update",
+        makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
+      );
+
+      await pullRequestService.refresh();
+      const callsAfterRefresh = bridge.resolveProvider.mock.calls.length;
+
+      pullRequestService.notifyForgeProviderRegistryUpdated();
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(bridge.resolveProvider.mock.calls.length).toBe(callsAfterRefresh);
+      expect(pullRequestService.getProviderContext()).not.toBeNull();
+
+      pullRequestService.destroy();
+    });
+
+    it("re-resolves after a no-match when forge settings change (setForgeSettings + refresh)", async () => {
+      vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+      mockForgeProviderUnresolved({ status: "no-match" });
+      const bridge = lastMockBridge!;
+
+      const { pullRequestService } = await import("../PullRequestService.js");
+      const { events } = await import("../events.js");
+
+      pullRequestService.initialize("/repo");
+      events.emit(
+        "sys:worktree:update",
+        makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
+      );
+
+      await pullRequestService.start(0);
+      await vi.advanceTimersByTimeAsync(60_000);
+      const callsWhilePaused = bridge.resolveProvider.mock.calls.length;
+
+      // Mirrors WorkspaceService.updateForgeSettings: settings push then refresh.
+      bridge.resolveProvider.mockResolvedValue({
+        status: "resolved",
+        namespacedId: "daintree.github.github",
+        repo: makeMockRepoRef(),
+      });
+      bridge.findPRByBranch.mockResolvedValue(null);
+      pullRequestService.setForgeSettings({
+        forgeProviderOverride: "daintree.github.github",
+        forgeDefaultProviderId: null,
+      });
+      await pullRequestService.refresh();
+
+      expect(bridge.resolveProvider.mock.calls.length).toBeGreaterThan(callsWhilePaused);
+      expect(pullRequestService.getProviderContext()).not.toBeNull();
+
+      pullRequestService.destroy();
+    });
   });
 
   it("skips polling when provider reports remaining: 0 with a future resetAt", async () => {

--- a/electron/services/__tests__/forgeRpcServer.test.ts
+++ b/electron/services/__tests__/forgeRpcServer.test.ts
@@ -4,16 +4,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // behind implicit activation. The singleton constructor calls `app.getVersion()`
 // which is undefined in this test's electron stub — mock the module surface
 // before importing forgeRpcServer so the constructor never runs.
+// `isPluginScanComplete` is mutable so resolveProvider tests can exercise both
+// the pre-scan ("not-ready") and post-scan ("no-match") miss states (#9997).
+const pluginServiceMock = vi.hoisted(() => ({
+  activatePluginForForgeProvider: vi.fn().mockResolvedValue(undefined),
+  isPluginScanComplete: true,
+}));
 vi.mock("../PluginService.js", () => ({
-  pluginService: {
-    activatePluginForForgeProvider: vi.fn().mockResolvedValue(undefined),
-  },
+  pluginService: pluginServiceMock,
 }));
 
 import { _resetForgeRpcInFlightForTests, dispatchForgeRpc } from "../forgeRpcServer.js";
 import {
   clearForgeProviderImplRegistry,
+  clearForgeProviderRegistry,
   registerForgeProviderImpl,
+  registerForgeProviders,
 } from "../forgeProviderRegistry.js";
 import type { ForgeProviderImpl, PR, RepoRef } from "../../../shared/types/forge.js";
 import type { WorkspaceHostRequest } from "../../../shared/types/workspace-host.js";
@@ -76,11 +82,14 @@ function makeImpl(overrides: Partial<ForgeProviderImpl> = {}): ForgeProviderImpl
 beforeEach(() => {
   _resetForgeRpcInFlightForTests();
   clearForgeProviderImplRegistry();
+  clearForgeProviderRegistry();
+  pluginServiceMock.isPluginScanComplete = true;
 });
 
 afterEach(() => {
   _resetForgeRpcInFlightForTests();
   clearForgeProviderImplRegistry();
+  clearForgeProviderRegistry();
 });
 
 describe("dispatchForgeRpc cross-window singleflight", () => {
@@ -303,5 +312,66 @@ describe("dispatchForgeRpc cross-window singleflight", () => {
     if (!sent[1].ok) {
       expect(sent[1].error).toContain("could not be delivered");
     }
+  });
+});
+
+describe("resolveProvider miss discrimination (#9997)", () => {
+  const resolveArgs = [
+    {
+      remoteUrl: "https://gitlab.com/owner/repo.git",
+      forgeProviderOverride: null,
+      globalDefaultProviderId: null,
+    },
+  ];
+
+  function dispatchResolve(send: (request: WorkspaceHostRequest) => boolean): Promise<void> {
+    return dispatchForgeRpc(
+      { forgeRequestId: "resolve-1", method: "resolveProvider", args: resolveArgs },
+      send
+    );
+  }
+
+  it("returns not-ready when no descriptor matches and the plugin scan is still running", async () => {
+    pluginServiceMock.isPluginScanComplete = false;
+    const { send, sent } = captureSender();
+
+    await dispatchResolve(send);
+
+    expect(sent[0]).toMatchObject({ ok: true, value: { status: "not-ready" } });
+  });
+
+  it("returns no-match when no descriptor matches after the plugin scan settled", async () => {
+    const { send, sent } = captureSender();
+
+    await dispatchResolve(send);
+
+    expect(sent[0]).toMatchObject({ ok: true, value: { status: "no-match" } });
+  });
+
+  it("returns no-match when the descriptor matched but no impl bound after activation", async () => {
+    registerForgeProviders(PLUGIN_ID, [
+      { id: CONTRIBUTION_ID, name: "Test Provider", matches: ["gitlab.com"] },
+    ]);
+    // No registerForgeProviderImpl — activation completes without binding.
+    const { send, sent } = captureSender();
+
+    await dispatchResolve(send);
+
+    expect(sent[0]).toMatchObject({ ok: true, value: { status: "no-match" } });
+  });
+
+  it("returns the resolved provider with parsed repo when descriptor and impl are present", async () => {
+    registerForgeProviders(PLUGIN_ID, [
+      { id: CONTRIBUTION_ID, name: "Test Provider", matches: ["gitlab.com"] },
+    ]);
+    registerForgeProviderImpl(PLUGIN_ID, CONTRIBUTION_ID, makeImpl());
+    const { send, sent } = captureSender();
+
+    await dispatchResolve(send);
+
+    expect(sent[0]).toMatchObject({
+      ok: true,
+      value: { status: "resolved", namespacedId: NAMESPACED_ID, repo: { owner: "owner" } },
+    });
   });
 });

--- a/electron/services/forgeRpcServer.ts
+++ b/electron/services/forgeRpcServer.ts
@@ -25,6 +25,7 @@ import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 // at module-load time. The first forge RPC dispatch performs the import.
 type PluginServiceShape = {
   activatePluginForForgeProvider(namespacedId: string): Promise<void>;
+  readonly isPluginScanComplete: boolean;
 };
 let pluginServicePromise: Promise<PluginServiceShape> | null = null;
 function getPluginService(): Promise<PluginServiceShape> {
@@ -234,7 +235,7 @@ async function invoke(req: ForgeRpcRequest): Promise<unknown> {
   }
 }
 
-async function invokeResolveProvider(args: unknown[]): Promise<ForgeResolveProviderResult | null> {
+async function invokeResolveProvider(args: unknown[]): Promise<ForgeResolveProviderResult> {
   const [opts] = args as [
     {
       remoteUrl: string | null;
@@ -242,26 +243,35 @@ async function invokeResolveProvider(args: unknown[]): Promise<ForgeResolveProvi
       globalDefaultProviderId: string | null;
     },
   ];
+  const pluginService = await getPluginService();
+  // Hostname matching runs against descriptors registered at manifest
+  // scan-time, so a miss is only definitive once `PluginService.initialize()`
+  // has finished. Before that, report "not-ready" so the workspace-host keeps
+  // its short cold-start retry instead of treating the miss as permanent
+  // (#9997). After scan completion every failure mode below is "no-match" —
+  // re-evaluated when forge settings or the plugin registry change.
+  const miss: ForgeResolveProviderResult = pluginService.isPluginScanComplete
+    ? { status: "no-match" }
+    : { status: "not-ready" };
   const resolved = resolveForgeProvider({
     remoteUrl: opts.remoteUrl,
     forgeProviderOverride: opts.forgeProviderOverride,
     globalDefaultProviderId: opts.globalDefaultProviderId,
   });
-  if (!resolved.entry) return null;
+  if (!resolved.entry) return miss;
 
   const { pluginId, contribution } = resolved.entry;
   const namespacedId = makeForgeProviderId(pluginId, contribution.id);
   // Implicit activation before impl lookup — see `invoke` above for rationale.
-  const pluginService = await getPluginService();
   await pluginService.activatePluginForForgeProvider(namespacedId);
   const impl = getForgeProviderImpl(namespacedId);
-  if (!impl) return null;
-  if (!opts.remoteUrl) return null;
+  if (!impl) return miss;
+  if (!opts.remoteUrl) return miss;
 
   const repo = impl.parseRemote(opts.remoteUrl);
-  if (!repo) return null;
+  if (!repo) return miss;
 
-  return { namespacedId, repo };
+  return { status: "resolved", namespacedId, repo };
 }
 
 function invokeFindPRByBranch(impl: ForgeProviderImpl, args: unknown[]): Promise<PR | null> {

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -666,6 +666,10 @@ port.on("message", async (rawMsg: any) => {
         workspaceService.updateForgeCredentials(request.providerId, request.credentials);
         break;
 
+      case "forge:provider-registry-updated":
+        workspaceService.notifyForgeProviderRegistryUpdated();
+        break;
+
       case "retry-auth-fetch":
         workspaceService.retryAuthFetch();
         break;

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -2725,6 +2725,16 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     void pullRequestService.refresh();
   }
 
+  /**
+   * Main registered a new forge provider descriptor (startup scan or runtime
+   * plugin install/enable). Wake the PR service if its polling paused on a
+   * "no provider matches" resolution (#9997). Routed straight to the
+   * singleton, mirroring `updateForgeSettings` above.
+   */
+  notifyForgeProviderRegistryUpdated(): void {
+    pullRequestService.notifyForgeProviderRegistryUpdated();
+  }
+
   updateForgeCredentials(
     providerId: string,
     credentials: import("../../shared/types/forge.js").Credentials | null

--- a/electron/workspace-host/forgeBridge.ts
+++ b/electron/workspace-host/forgeBridge.ts
@@ -72,8 +72,8 @@ export class ForgeBridge {
     remoteUrl: string | null;
     forgeProviderOverride: string | null;
     globalDefaultProviderId: string | null;
-  }): Promise<ForgeResolveProviderResult | null> {
-    return this.invoke<ForgeResolveProviderResult | null>("resolveProvider", undefined, [opts]);
+  }): Promise<ForgeResolveProviderResult> {
+    return this.invoke<ForgeResolveProviderResult>("resolveProvider", undefined, [opts]);
   }
 
   findPRByBranch(namespacedId: string, repo: RepoRef, branch: string): Promise<PR | null> {

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -418,6 +418,10 @@ export type WorkspaceHostRequest =
   | { type: "has-resource-config"; requestId: string; rootPath: string }
   // Forge credential propagation
   | { type: "update-forge-credentials"; providerId: string; credentials: Credentials | null }
+  // A forge provider descriptor was registered in main's plugin registry
+  // (startup scan or runtime install/enable). Hosts paused on a "no-match"
+  // resolution re-evaluate their provider on receipt (#9997).
+  | { type: "forge:provider-registry-updated" }
   // User-triggered retry of auth-suspended fetches (e.g. clicking the auth-failed sync badge)
   | { type: "retry-auth-fetch" }
   // Project environment variable propagation
@@ -491,11 +495,18 @@ export type ForgeRpcMethod =
   | "getRateLimit"
   | "clearPullRequestCaches";
 
-/** Result shape for `resolveProvider` — used by typed parsing of `forge:rpc-result.value`. */
-export interface ForgeResolveProviderResult {
-  namespacedId: string;
-  repo: RepoRef;
-}
+/**
+ * Result shape for `resolveProvider` — used by typed parsing of
+ * `forge:rpc-result.value`. Discriminated so the workspace-host can tell a
+ * transient miss from a permanent one (#9997): `"not-ready"` means the plugin
+ * registry hasn't finished its startup scan yet (retry soon), `"no-match"`
+ * means the scan is complete and no registered provider matches this project's
+ * remote (stop polling until forge settings or the plugin registry change).
+ */
+export type ForgeResolveProviderResult =
+  | { status: "resolved"; namespacedId: string; repo: RepoRef }
+  | { status: "no-match" }
+  | { status: "not-ready" };
 
 /**
  * Events sent from Workspace Host → Main.


### PR DESCRIPTION
Closes #9997.

## Problem

`PullRequestService.scheduleNextPoll()` caps the poll interval to 5s while the forge provider is unresolved — a deliberate cold-start catch-up for the race against `PluginService.initialize()`. But `invokeResolveProvider` returned `null` identically for "plugin scan not finished yet" (transient) and "no registered provider matches this remote" (permanent). For a GitLab/Bitbucket/no-remote project the cap therefore applied forever: every 5s tick re-ran `resolveProvider()`, spawning two `git config` reads plus an IPC round-trip — roughly 17k git subprocesses per day per affected project, indefinitely.

## Fix

- `ForgeResolveProviderResult` is now a discriminated union: `{ status: "resolved", namespacedId, repo } | { status: "no-match" } | { status: "not-ready" }`.
- Main reports `no-match` only once `PluginService.isPluginScanComplete` (new scan-phase getter). Provider descriptors register at manifest scan-time, so a hostname-match miss is definitive as soon as `initialize()` settles — no need to wait for activation.
- On `no-match`, `PullRequestService` pauses polling without arming a timer (the same pattern as the existing all-candidates-resolved pause; `isPolling` stays true) and caches the miss so debounced worktree updates stop re-spawning git-config reads. `not-ready` keeps the existing 5s cold-start catch-up, so GitHub projects are unaffected.
- Re-arm surfaces for the pause: forge settings change (`setForgeSettings` + `refresh`), manual refresh, service restart, and a new `forge:provider-registry-updated` main→host push, broadcast from `PluginService.loadPlugin()` after `registerForgeProviders` — covering both the startup scan and runtime plugin install/enable. An already-resolved provider is deliberately left untouched by the push.

## Tests

- `forgeRpcServer.test.ts`: miss discrimination — `not-ready` pre-scan, `no-match` post-scan, `no-match` when the descriptor matched but no impl bound, resolved happy path.
- `PullRequestService.test.ts`: `not-ready` keeps the 5s cap; `no-match` pauses (an hour of fake time, zero further resolution attempts); registry push re-arms a paused service; push leaves a resolved provider untouched; settings change + refresh recovers; `not-ready` → `no-match` mid-session transition; push before `start()` is harmless; worktree updates while paused never re-resolve.

`npm run check` clean (lint ratchet improved by 1), 65 tests passing across the two touched suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Note

Also carries a one-line unrelated test repair: `bc85a0c0a` renamed the screenshot button's accessible name to "Copy screenshot to clipboard" but left one query on the stale "Capture screenshot" name, so `ci-ok` was red on develop itself (run 27062954122) and for every PR. Fixed here to unblock CI; fixes develop at merge.