### PR TITLE
fix(workspace): restore worktree fetch backoff severed by the forge RPC bridge

### DIFF
--- a/electron/ipc/handlers/__tests__/github.rateLimit.test.ts
+++ b/electron/ipc/handlers/__tests__/github.rateLimit.test.ts
@@ -40,6 +40,7 @@ const gitHubServiceMock = vi.hoisted(() => ({
 
 const workspaceClientMock = vi.hoisted(() => ({
   updateForgeCredentials: vi.fn(),
+  relayFetchThrottle: vi.fn(),
 }));
 
 const gitHubAuthMock = vi.hoisted(() => ({
@@ -175,6 +176,33 @@ describe("github handlers — rate limiting", () => {
       avatarUrl: null,
     });
     registerGithubHandlers({} as never);
+  });
+
+  describe("rate-limit state relay to workspace hosts", () => {
+    async function getStateChangeCallback(): Promise<(state: Record<string, unknown>) => void> {
+      const { gitHubRateLimitService } = await import("../../../services/github/index.js");
+      const calls = (gitHubRateLimitService.onStateChange as Mock).mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      return calls[0][0] as (state: Record<string, unknown>) => void;
+    }
+
+    it("relays throttleMultiplier to the workspace hosts on state change", async () => {
+      const callback = await getStateChangeCallback();
+      callback({ blocked: false, kind: null, throttleMultiplier: 4 });
+
+      await vi.waitFor(() => {
+        expect(workspaceClientMock.relayFetchThrottle).toHaveBeenCalledWith(4);
+      });
+    });
+
+    it("falls back to multiplier 1 when the state omits throttleMultiplier", async () => {
+      const callback = await getStateChangeCallback();
+      callback({ blocked: false, kind: null });
+
+      await vi.waitFor(() => {
+        expect(workspaceClientMock.relayFetchThrottle).toHaveBeenCalledWith(1);
+      });
+    });
   });
 
   describe("read family (github:list-issues)", () => {

--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -25,31 +25,20 @@ import {
 } from "../../services/github/index.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import { BUILTIN_GITHUB_PROVIDER_ID } from "../../../shared/utils/forgeProviderIds.js";
-import type { GitHubRateLimitPayload } from "../../../shared/types/ipc/github.js";
-import type { RateLimitInfo } from "../../../shared/types/forge.js";
+import { toRateLimitInfo } from "../../../shared/utils/rateLimitUtils.js";
 
-// Project a GitHub rate-limit payload onto the provider-agnostic RateLimitInfo
-// shape. Mirrors `toRateLimitInfo` in electron/workspace-host.ts — keep the
-// two in sync if the projection rule changes.
-function toRateLimitInfo(payload: GitHubRateLimitPayload): RateLimitInfo {
-  if (!payload.blocked) {
-    return {
-      limit: payload.limit ?? null,
-      remaining: payload.remaining ?? null,
-      resetAt: null,
-      throttleMultiplier: payload.throttleMultiplier,
-    };
+// Relay the fetch-throttle multiplier into every workspace host so worktree
+// monitor polling backs off as the shared GraphQL budget depletes. The hosts
+// stopped observing rate limits themselves when the forge RPC bridge moved
+// all GitHub HTTP calls into main (#8870), so main must push the state in.
+async function relayFetchThrottleToWorkspaceHosts(multiplier: number): Promise<void> {
+  try {
+    const { getWorkspaceClient } = await import("../../services/WorkspaceClient.js");
+    getWorkspaceClient().relayFetchThrottle(multiplier);
+  } catch {
+    // WorkspaceClient may not be initialized yet — hosts created later are
+    // seeded from the pool cache, and this relay fires again on every change.
   }
-  // When blocked, force `remaining: 0` — the renderer's GitHub-flavored
-  // projection treats `remaining === 0` as the "blocked" signal, so the exact
-  // (1–50) hard-stop-band count must not leak through as a non-zero value.
-  return {
-    limit: payload.limit ?? null,
-    remaining: 0,
-    resetAt: payload.resetAt ?? null,
-    ...(payload.kind === "secondary" ? { secondaryThrottled: true } : {}),
-    throttleMultiplier: payload.throttleMultiplier,
-  };
 }
 
 async function handleGitHubUnassignIssue(payload: {
@@ -103,6 +92,10 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
       providerId: BUILTIN_GITHUB_PROVIDER_ID,
       state: toRateLimitInfo(state),
     });
+    // Pace workspace-host background fetch cadence against the observed
+    // GraphQL budget — read live from the callback arg, never a cached
+    // payload that could predate a token rotation.
+    void relayFetchThrottleToWorkspaceHosts(state.throttleMultiplier ?? 1);
   });
   handlers.push(unsubscribeRateLimit);
 

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -321,6 +321,12 @@ export class WorkspaceClient extends EventEmitter {
     this.pool.setLogLevelOverrides(overrides);
   }
 
+  // ── Fetch throttle ──
+
+  relayFetchThrottle(multiplier: number): void {
+    this.pool.relayFetchThrottle(multiplier);
+  }
+
   // ── State queries ──
 
   getAllStatesAsync(windowId?: number): Promise<WorktreeSnapshot[]> {

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -97,6 +97,11 @@ export class WorkspaceHostProcess extends EventEmitter {
    * until after `ready`, so pushing at fork time would silently drop. */
   private logLevelOverridesCache: Record<string, string> = {};
 
+  /** Last GitHub fetch-throttle multiplier relayed from main. Replayed on
+   * every `ready` (initial + restarts) so a host restart doesn't silently
+   * revert monitor fetch cadence to the unthrottled default. */
+  private fetchThrottleMultiplierCache = 1;
+
   /** Buffers for line-splitting stdout/stderr from the forked host. Forking
    * with `stdio:"pipe"` (instead of `"inherit"`) isolates the host from the
    * main process's fd 2 — critical on AppImage GUI launches where fd 2 points
@@ -233,6 +238,17 @@ export class WorkspaceHostProcess extends EventEmitter {
     this.logLevelOverridesCache = { ...overrides };
     if (this.isInitialized && this.child) {
       this.send({ type: "set-log-level-overrides", overrides: this.logLevelOverridesCache });
+    }
+  }
+
+  /**
+   * Update the cached fetch-throttle multiplier and push immediately if
+   * initialized. On restart, `ready` replays the cached value automatically.
+   */
+  relayFetchThrottle(multiplier: number): void {
+    this.fetchThrottleMultiplierCache = multiplier;
+    if (this.isInitialized && this.child) {
+      this.send({ type: "apply-fetch-throttle", multiplier: this.fetchThrottleMultiplierCache });
     }
   }
 
@@ -791,6 +807,14 @@ export class WorkspaceHostProcess extends EventEmitter {
 
         // Replay cached log-level overrides on every ready (initial + restarts).
         this.send({ type: "set-log-level-overrides", overrides: this.logLevelOverridesCache });
+
+        // Replay the cached fetch-throttle multiplier on every ready — a
+        // restarted host would otherwise run unthrottled until the next
+        // rate-limit state change, which can be hours away.
+        this.send({
+          type: "apply-fetch-throttle",
+          multiplier: this.fetchThrottleMultiplierCache,
+        });
 
         if (this.readyResolve) {
           this.readyResolve();

--- a/electron/services/__tests__/WorkspaceClient.prewarm.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.prewarm.test.ts
@@ -55,6 +55,7 @@ const { mockHosts, MockWorkspaceHostProcess } = vi.hoisted(() => {
     });
 
     setLogLevelOverrides = vi.fn();
+    relayFetchThrottle = vi.fn();
 
     simulateReady(): void {
       this._isReady = true;

--- a/electron/services/__tests__/WorkspaceClient.rateLimit.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.rateLimit.test.ts
@@ -1,0 +1,163 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockHosts, MockWorkspaceHostProcess } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { EventEmitter } = require("events") as typeof import("events");
+
+  const mockHosts: any[] = [];
+
+  class MockWorkspaceHostProcess extends EventEmitter {
+    projectPath: string;
+    private _isReady = false;
+    private _isDisposed = false;
+    private readyResolve: (() => void) | null = null;
+    private readyPromise: Promise<void>;
+    private responseHandlers = new Map<string, (result: any) => void>();
+
+    constructor(projectPath: string) {
+      super();
+      this.projectPath = projectPath;
+      this.readyPromise = new Promise((resolve) => {
+        this.readyResolve = resolve;
+      });
+      mockHosts.push(this);
+    }
+
+    waitForReady(): Promise<void> {
+      return this.readyPromise;
+    }
+
+    isReady(): boolean {
+      return this._isReady && !this._isDisposed;
+    }
+
+    generateRequestId(): string {
+      return `req-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+    }
+
+    send = vi.fn(() => true);
+
+    sendWithResponse = vi.fn(<T>(request: { requestId: string; type: string }): Promise<T> => {
+      return new Promise<T>((resolve) => {
+        this.responseHandlers.set(request.requestId, resolve);
+      });
+    });
+
+    pauseHealthCheck = vi.fn();
+    resumeHealthCheck = vi.fn();
+    dispose = vi.fn(() => {
+      this._isDisposed = true;
+    });
+
+    setLogLevelOverrides = vi.fn();
+    relayFetchThrottle = vi.fn();
+
+    simulateReady(): void {
+      this._isReady = true;
+      if (this.readyResolve) {
+        this.readyResolve();
+        this.readyResolve = null;
+      }
+    }
+
+    resolveRequest(requestId: string, result: any = {}): void {
+      const handler = this.responseHandlers.get(requestId);
+      if (handler) {
+        this.responseHandlers.delete(requestId);
+        handler(result);
+      }
+    }
+
+    getLastRequest(): { requestId: string; type: string; [key: string]: any } | undefined {
+      const calls = this.sendWithResponse.mock.calls;
+      if (calls.length === 0) return undefined;
+      return calls[calls.length - 1][0] as any;
+    }
+  }
+
+  return { mockHosts, MockWorkspaceHostProcess };
+});
+
+vi.mock("../WorkspaceHostProcess.js", () => ({
+  WorkspaceHostProcess: MockWorkspaceHostProcess,
+}));
+
+vi.mock("electron", () => {
+  return {
+    BrowserWindow: { getAllWindows: vi.fn(() => []) },
+  };
+});
+
+vi.mock("../events.js", () => ({
+  events: { emit: vi.fn() },
+}));
+
+vi.mock("../ProjectStore.js", () => ({
+  projectStore: { getProjectSettings: vi.fn().mockResolvedValue({ runCommands: [] }) },
+}));
+
+vi.mock("../../store.js", () => ({
+  store: { get: vi.fn().mockReturnValue(null), set: vi.fn() },
+}));
+
+import { WorkspaceClient } from "../WorkspaceClient.js";
+
+type MockHost = InstanceType<typeof MockWorkspaceHostProcess>;
+
+describe("WorkspaceClient.relayFetchThrottle", () => {
+  let client: WorkspaceClient;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockHosts.length = 0;
+    client = new WorkspaceClient({
+      maxRestartAttempts: 3,
+      showCrashDialog: false,
+      healthCheckIntervalMs: 1000,
+    });
+  });
+
+  afterEach(() => {
+    client.dispose();
+    vi.useRealTimers();
+  });
+
+  function h(index: number): MockHost {
+    return mockHosts[index];
+  }
+
+  async function loadProject(projectPath: string, hostIndex: number, windowId: number) {
+    const load = client.loadProject(projectPath, windowId);
+    h(hostIndex).simulateReady();
+    await vi.advanceTimersByTimeAsync(0);
+    const req = h(hostIndex).getLastRequest()!;
+    h(hostIndex).resolveRequest(req.requestId);
+    await vi.advanceTimersByTimeAsync(0);
+    await load;
+  }
+
+  it("fans out the multiplier to every pooled host", async () => {
+    await loadProject("/project-a", 0, 1);
+    await loadProject("/project-b", 1, 2);
+
+    client.relayFetchThrottle(4);
+
+    expect(h(0).relayFetchThrottle).toHaveBeenCalledWith(4);
+    expect(h(1).relayFetchThrottle).toHaveBeenCalledWith(4);
+  });
+
+  it("seeds hosts created after the last state change from the pool cache", async () => {
+    client.relayFetchThrottle(5);
+
+    await loadProject("/project-a", 0, 1);
+
+    // The host was created after the relay — it must still receive the
+    // cached multiplier at construction, not wait for the next state change.
+    expect(h(0).relayFetchThrottle).toHaveBeenCalledWith(5);
+  });
+
+  it("is a no-op (no throw) when the pool is empty", () => {
+    expect(() => client.relayFetchThrottle(2)).not.toThrow();
+  });
+});

--- a/electron/services/__tests__/WorkspaceClient.readiness.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.readiness.test.ts
@@ -53,6 +53,7 @@ const { mockHosts, MockWorkspaceHostProcess } = vi.hoisted(() => {
     });
 
     setLogLevelOverrides = vi.fn();
+    relayFetchThrottle = vi.fn();
 
     simulateReady(): void {
       this._isReady = true;

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -59,6 +59,7 @@ const { mockHosts, MockWorkspaceHostProcess } = vi.hoisted(() => {
     });
 
     setLogLevelOverrides = vi.fn();
+    relayFetchThrottle = vi.fn();
 
     // Test helpers
     simulateReady(): void {

--- a/electron/services/__tests__/WorkspaceHostProcess.rateLimit.test.ts
+++ b/electron/services/__tests__/WorkspaceHostProcess.rateLimit.test.ts
@@ -122,4 +122,25 @@ describe("WorkspaceHostProcess — fetch-throttle relay", () => {
     expect(throttleMultipliersSentTo(child)).toEqual([1, 5, 5]);
     host.dispose();
   });
+
+  it("replays the cached multiplier to the NEW child after a real restart", async () => {
+    const host = await createHost();
+    const firstChild = mockChildren[0] as MockUtilityChild;
+
+    firstChild.emit("message", { type: "ready" });
+    host.relayFetchThrottle(7);
+
+    // Crash the host, then restart — a fresh child process is forked.
+    firstChild.emit("exit", 1);
+    host.manualRestart();
+    expect(mockChildren).toHaveLength(2);
+    const secondChild = mockChildren[1] as MockUtilityChild;
+
+    secondChild.emit("message", { type: "ready" });
+
+    // The replay must reach the new child, not the dead one.
+    expect(throttleMultipliersSentTo(secondChild)).toEqual([7]);
+    expect(throttleMultipliersSentTo(firstChild)).toEqual([1, 7]);
+    host.dispose();
+  });
 });

--- a/electron/services/__tests__/WorkspaceHostProcess.rateLimit.test.ts
+++ b/electron/services/__tests__/WorkspaceHostProcess.rateLimit.test.ts
@@ -1,0 +1,125 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+import { Readable } from "node:stream";
+
+const { forkMock, mockChildren, appMock } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { EventEmitter } = require("events") as typeof import("events");
+  const forkMock = vi.fn();
+  const mockChildren: any[] = [];
+  const appEmitter = new EventEmitter();
+  const appMock = Object.assign(appEmitter, {
+    getPath: vi.fn(() => "/tmp/userData"),
+  });
+  return { forkMock, mockChildren, appMock };
+});
+
+class MockUtilityChild extends EventEmitter {
+  stdout: Readable;
+  stderr: Readable;
+  postMessage = vi.fn();
+  kill = vi.fn(() => true);
+  pid = 42;
+
+  constructor() {
+    super();
+    this.stdout = new Readable({ read() {} });
+    this.stderr = new Readable({ read() {} });
+    mockChildren.push(this);
+  }
+}
+
+vi.mock("electron", () => ({
+  utilityProcess: {
+    fork: forkMock,
+  },
+  app: appMock,
+  UtilityProcess: class {},
+  MessagePortMain: class {},
+}));
+
+vi.mock("../github/GitHubAuth.js", () => ({
+  GitHubAuth: {
+    getToken: vi.fn(() => null),
+  },
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+function throttleMultipliersSentTo(child: MockUtilityChild): number[] {
+  return child.postMessage.mock.calls
+    .map(([msg]) => msg as { type?: string; multiplier?: number })
+    .filter((msg) => msg?.type === "apply-fetch-throttle")
+    .map((msg) => msg.multiplier as number);
+}
+
+describe("WorkspaceHostProcess — fetch-throttle relay", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    forkMock.mockReset();
+    mockChildren.length = 0;
+    appMock.removeAllListeners();
+    forkMock.mockImplementation(() => new MockUtilityChild());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function createHost() {
+    const { WorkspaceHostProcess } = await import("../WorkspaceHostProcess.js");
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    // Swallow the ready-promise rejection that fires on dispose before ready
+    host.waitForReady().catch(() => {});
+    return host;
+  }
+
+  it("replays the default multiplier on ready when none was relayed", async () => {
+    const host = await createHost();
+    const child = mockChildren[0] as MockUtilityChild;
+
+    child.emit("message", { type: "ready" });
+
+    expect(throttleMultipliersSentTo(child)).toEqual([1]);
+    host.dispose();
+  });
+
+  it("caches a multiplier relayed before ready and replays it on ready", async () => {
+    const host = await createHost();
+    const child = mockChildren[0] as MockUtilityChild;
+
+    host.relayFetchThrottle(3);
+    // Not initialized yet — the value is cached, nothing is sent.
+    expect(throttleMultipliersSentTo(child)).toEqual([]);
+
+    child.emit("message", { type: "ready" });
+    expect(throttleMultipliersSentTo(child)).toEqual([3]);
+    host.dispose();
+  });
+
+  it("sends immediately once initialized and replays the latest value on every subsequent ready", async () => {
+    const host = await createHost();
+    const child = mockChildren[0] as MockUtilityChild;
+
+    child.emit("message", { type: "ready" });
+    host.relayFetchThrottle(5);
+    expect(throttleMultipliersSentTo(child)).toEqual([1, 5]);
+
+    // A host restart re-runs the ready handshake — the cached multiplier must
+    // be replayed so the restarted host doesn't run unthrottled.
+    child.emit("message", { type: "ready" });
+    expect(throttleMultipliersSentTo(child)).toEqual([1, 5, 5]);
+    host.dispose();
+  });
+});

--- a/electron/services/workspace-client/WorkspaceHostPool.ts
+++ b/electron/services/workspace-client/WorkspaceHostPool.ts
@@ -77,6 +77,10 @@ export class WorkspaceHostPool {
 
   private logLevelOverridesCache: Record<string, string> = readPersistedLogOverrides();
 
+  /** Last GitHub fetch-throttle multiplier relayed from main — seeded into
+   * hosts created after the rate-limit state last changed. */
+  private fetchThrottleMultiplierCache = 1;
+
   private emit: EmitFn;
   private onProjectSwitch?: (windowId: number) => void;
   private routeHostEventFn: RouteHostEventFn | null = null;
@@ -189,6 +193,7 @@ export class WorkspaceHostPool {
 
     const host = new WorkspaceHostProcess(normalizedPath, this.config);
     host.setLogLevelOverrides(this.logLevelOverridesCache);
+    host.relayFetchThrottle(this.fetchThrottleMultiplierCache);
 
     const initPromise = (async () => {
       await host.waitForReady();
@@ -247,6 +252,7 @@ export class WorkspaceHostPool {
 
     const host = new WorkspaceHostProcess(normalizedPath, this.config);
     host.setLogLevelOverrides(this.logLevelOverridesCache);
+    host.relayFetchThrottle(this.fetchThrottleMultiplierCache);
 
     const initPromise = (async () => {
       await host.waitForReady();
@@ -510,6 +516,15 @@ export class WorkspaceHostPool {
     this.logLevelOverridesCache = { ...overrides };
     for (const entry of this.entries.values()) {
       entry.host.setLogLevelOverrides(this.logLevelOverridesCache);
+    }
+  }
+
+  // ── Fetch throttle ──
+
+  relayFetchThrottle(multiplier: number): void {
+    this.fetchThrottleMultiplierCache = multiplier;
+    for (const entry of this.entries.values()) {
+      entry.host.relayFetchThrottle(this.fetchThrottleMultiplierCache);
     }
   }
 

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -28,14 +28,10 @@ import { fileTreeService } from "./services/FileTreeService.js";
 import { projectPulseService } from "./services/ProjectPulseService.js";
 import type { CopyTreeProgress } from "../shared/types/ipc.js";
 import type { WorkspaceHostRequest, WorkspaceHostEvent } from "../shared/types/workspace-host.js";
-import type { RateLimitInfo } from "../shared/types/forge.js";
-import type { GitHubRateLimitPayload } from "../shared/types/ipc/github.js";
 import type { WorktreePortRequest } from "../shared/types/worktree-port.js";
 import { WorkspaceService } from "./workspace-host/WorkspaceService.js";
-import { gitHubRateLimitService } from "./services/github/GitHubRateLimitService.js";
 import { ensureSerializable } from "../shared/utils/serialization.js";
 import { formatErrorMessage } from "../shared/utils/errorMessage.js";
-import { BUILTIN_GITHUB_PROVIDER_ID } from "../shared/utils/forgeProviderIds.js";
 import { initForgeBridge } from "./workspace-host/forgeBridge.js";
 import { fanoutEventToWorktreePorts } from "./workspace-host/worktreePortFanout.js";
 import { PERF_MARKS } from "../shared/perf/marks.js";
@@ -331,53 +327,6 @@ const workspaceService = new WorkspaceService(sendEvent);
 // `docs/architecture/forge-provider-abstraction.md` for the rationale.
 const forgeBridge = initForgeBridge(sendEvent);
 
-// Convert a GitHubRateLimitPayload (from gitHubRateLimitService.getState())
-// to the provider-agnostic RateLimitInfo shape so the forge-rate-limit-changed
-// event payload is provider-agnostic.
-function toRateLimitInfo(payload: GitHubRateLimitPayload): RateLimitInfo {
-  if (!payload.blocked) {
-    // Forward the observed GraphQL budget (if any) so the toolbar can show a
-    // remaining-quota indicator even while requests still flow.
-    return {
-      limit: payload.limit ?? null,
-      remaining: payload.remaining ?? null,
-      resetAt: null,
-      throttleMultiplier: payload.throttleMultiplier,
-    };
-  }
-  // When blocked, force `remaining: 0` — the renderer's GitHub-flavored
-  // projection treats `remaining === 0` as the "blocked" signal, so the exact
-  // (1–50) hard-stop-band count must not leak through as a non-zero value.
-  return {
-    limit: payload.limit ?? null,
-    remaining: 0,
-    resetAt: payload.resetAt ?? null,
-    ...(payload.kind === "secondary" ? { secondaryThrottled: true } : {}),
-    throttleMultiplier: payload.throttleMultiplier,
-  };
-}
-
-// Forward forge provider rate-limit state changes observed by
-// utility-process HTTP calls (e.g. PullRequestService polling) up to the
-// main process so they reach the toolbar countdown and block main-process
-// calls too. `broadcastToRenderer` is BrowserWindow-backed and therefore
-// main-only; this relay is how utility-side limits ever become visible
-// elsewhere. Register synchronously before `ready` is sent — otherwise the
-// first event emitted during startup racing polling would be silently
-// dropped.
-gitHubRateLimitService.onStateChange((state) => {
-  const rateLimitInfo = toRateLimitInfo(state);
-  sendEvent({
-    type: "forge-rate-limit-changed",
-    providerId: BUILTIN_GITHUB_PROVIDER_ID,
-    state: rateLimitInfo,
-  });
-  // Pace background fetch cadence against the observed GraphQL budget so
-  // multiple instances drawing on the same per-user token budget back off in
-  // step as it depletes — and snap back when it resets.
-  workspaceService.applyFetchThrottle(state.throttleMultiplier ?? 1);
-});
-
 // Handle requests from Main
 port.on("message", async (rawMsg: any) => {
   const msg =
@@ -542,6 +491,14 @@ port.on("message", async (rawMsg: any) => {
           const { pullRequestService } = await import("./services/PullRequestService.js");
           pullRequestService.setFocusCadence(request.focused);
         }
+        break;
+
+      // Pace background fetch cadence against the GraphQL budget observed in
+      // main (where all forge HTTP calls live post-#8870) so multiple
+      // instances drawing on the same per-user token budget back off in step
+      // as it depletes — and snap back when it resets.
+      case "apply-fetch-throttle":
+        workspaceService.applyFetchThrottle(request.multiplier);
         break;
 
       case "background":

--- a/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { formatErrorMessage } from "../../../../../shared/utils/errorMessage.js";
 import { MAX_REVIEW_THREAD_PAGES } from "../GitHubCaches.js";
 import type { ShouldBlockResult } from "../GitHubRateLimitService.js";
@@ -45,6 +45,7 @@ import {
   prTooltipCache,
 } from "../GitHubCaches.js";
 import { GitHubAuth } from "../GitHubAuth.js";
+import { gitHubRateLimitService } from "../GitHubRateLimitService.js";
 import type { RepoRef } from "../../../../../shared/types/forge.js";
 
 const repo: RepoRef = { host: "github.com", owner: "owner", repo: "repo", rawData: null };
@@ -1310,5 +1311,53 @@ describe("buildPRsUrl", () => {
       githubForgeProvider.buildPRsUrl(repo, { query: "bug", state: "all" })
     );
     expect(q).toBe("bug");
+  });
+});
+
+describe("getRateLimit", () => {
+  afterEach(() => {
+    vi.mocked(gitHubRateLimitService.getState).mockReturnValue({ blocked: false } as never);
+  });
+
+  it("includes throttleMultiplier when not blocked so the bridge path carries throttle state", async () => {
+    vi.mocked(gitHubRateLimitService.getState).mockReturnValue({
+      blocked: false,
+      kind: null,
+      throttleMultiplier: 3,
+    } as never);
+
+    await expect(githubForgeProvider.getRateLimit()).resolves.toEqual({
+      limit: null,
+      remaining: null,
+      resetAt: null,
+      throttleMultiplier: 3,
+    });
+  });
+
+  it("defaults throttleMultiplier to 1 when the state omits it", async () => {
+    vi.mocked(gitHubRateLimitService.getState).mockReturnValue({
+      blocked: false,
+      kind: null,
+    } as never);
+
+    const info = await githubForgeProvider.getRateLimit();
+    expect(info.throttleMultiplier).toBe(1);
+  });
+
+  it("includes throttleMultiplier and the secondary flag when blocked", async () => {
+    vi.mocked(gitHubRateLimitService.getState).mockReturnValue({
+      blocked: true,
+      kind: "secondary",
+      resetAt: 123,
+      throttleMultiplier: 8,
+    } as never);
+
+    await expect(githubForgeProvider.getRateLimit()).resolves.toEqual({
+      limit: null,
+      remaining: 0,
+      resetAt: 123,
+      secondaryThrottled: true,
+      throttleMultiplier: 8,
+    });
   });
 });

--- a/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
@@ -1326,7 +1326,7 @@ describe("getRateLimit", () => {
       throttleMultiplier: 3,
     } as never);
 
-    await expect(githubForgeProvider.getRateLimit()).resolves.toEqual({
+    await expect(githubForgeProvider.getRateLimit!()).resolves.toEqual({
       limit: null,
       remaining: null,
       resetAt: null,
@@ -1340,7 +1340,7 @@ describe("getRateLimit", () => {
       kind: null,
     } as never);
 
-    const info = await githubForgeProvider.getRateLimit();
+    const info = await githubForgeProvider.getRateLimit!();
     expect(info.throttleMultiplier).toBe(1);
   });
 
@@ -1352,7 +1352,7 @@ describe("getRateLimit", () => {
       throttleMultiplier: 8,
     } as never);
 
-    await expect(githubForgeProvider.getRateLimit()).resolves.toEqual({
+    await expect(githubForgeProvider.getRateLimit!()).resolves.toEqual({
       limit: null,
       remaining: 0,
       resetAt: 123,

--- a/plugins/builtin/github/main/forgeProvider.ts
+++ b/plugins/builtin/github/main/forgeProvider.ts
@@ -1067,13 +1067,19 @@ async function getReviewThreadsImpl(repo: RepoRef, prNumber: number): Promise<Re
 function getRateLimitImpl(): Promise<RateLimitInfo> {
   const state = gitHubRateLimitService.getState();
   if (!state.blocked) {
-    return Promise.resolve({ limit: null, remaining: null, resetAt: null });
+    return Promise.resolve({
+      limit: null,
+      remaining: null,
+      resetAt: null,
+      throttleMultiplier: state.throttleMultiplier ?? 1,
+    });
   }
   return Promise.resolve({
     limit: null,
     remaining: 0,
     resetAt: state.resetAt ?? null,
     ...(state.kind === "secondary" ? { secondaryThrottled: true } : {}),
+    throttleMultiplier: state.throttleMultiplier ?? 1,
   });
 }
 

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -377,6 +377,9 @@ export type WorkspaceHostRequest =
   // Background/foreground lifecycle
   | { type: "background" }
   | { type: "foreground" }
+  // GitHub rate-limit fetch-throttle multiplier relayed from main, where the
+  // forge HTTP calls (and thus rate-limit observations) live post-#8870.
+  | { type: "apply-fetch-throttle"; multiplier: number }
   // Health check
   | { type: "health-check" }
   // Lifecycle

--- a/shared/utils/__tests__/rateLimitUtils.test.ts
+++ b/shared/utils/__tests__/rateLimitUtils.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { toRateLimitInfo } from "../rateLimitUtils.js";
+
+describe("toRateLimitInfo", () => {
+  it("forwards the observed budget when not blocked", () => {
+    expect(
+      toRateLimitInfo({
+        blocked: false,
+        kind: null,
+        limit: 5000,
+        remaining: 1200,
+        throttleMultiplier: 2,
+      })
+    ).toEqual({ limit: 5000, remaining: 1200, resetAt: null, throttleMultiplier: 2 });
+  });
+
+  it("nulls absent budget fields when not blocked", () => {
+    expect(toRateLimitInfo({ blocked: false, kind: null })).toEqual({
+      limit: null,
+      remaining: null,
+      resetAt: null,
+      throttleMultiplier: undefined,
+    });
+  });
+
+  it("forces remaining to 0 when blocked so the hard-stop band can't leak", () => {
+    const info = toRateLimitInfo({
+      blocked: true,
+      kind: "primary",
+      limit: 5000,
+      remaining: 37,
+      resetAt: 99,
+      throttleMultiplier: 4,
+    });
+    expect(info.remaining).toBe(0);
+    expect(info.resetAt).toBe(99);
+    expect(info.throttleMultiplier).toBe(4);
+    expect(info.secondaryThrottled).toBeUndefined();
+  });
+
+  it("flags secondary throttling only for secondary blocks", () => {
+    const info = toRateLimitInfo({ blocked: true, kind: "secondary" });
+    expect(info.secondaryThrottled).toBe(true);
+    expect(info.remaining).toBe(0);
+    expect(info.resetAt).toBeNull();
+  });
+});

--- a/shared/utils/rateLimitUtils.ts
+++ b/shared/utils/rateLimitUtils.ts
@@ -4,6 +4,9 @@ import type { RateLimitInfo } from "../types/forge.js";
 // Project a GitHub rate-limit payload onto the provider-agnostic RateLimitInfo
 // shape. Canonical implementation — main's renderer broadcast and any other
 // emit site must use this projection so the rule can't drift between copies.
+// `throttleMultiplier` passes through as-is: `undefined` means "not yet
+// observed", and consumers that need a usable cadence apply `?? 1` themselves
+// (the workspace-host relay, `getRateLimitImpl`, renderer projections).
 export function toRateLimitInfo(payload: GitHubRateLimitPayload): RateLimitInfo {
   if (!payload.blocked) {
     // Forward the observed GraphQL budget (if any) so the toolbar can show a

--- a/shared/utils/rateLimitUtils.ts
+++ b/shared/utils/rateLimitUtils.ts
@@ -1,0 +1,28 @@
+import type { GitHubRateLimitPayload } from "../types/ipc/github.js";
+import type { RateLimitInfo } from "../types/forge.js";
+
+// Project a GitHub rate-limit payload onto the provider-agnostic RateLimitInfo
+// shape. Canonical implementation — main's renderer broadcast and any other
+// emit site must use this projection so the rule can't drift between copies.
+export function toRateLimitInfo(payload: GitHubRateLimitPayload): RateLimitInfo {
+  if (!payload.blocked) {
+    // Forward the observed GraphQL budget (if any) so the toolbar can show a
+    // remaining-quota indicator even while requests still flow.
+    return {
+      limit: payload.limit ?? null,
+      remaining: payload.remaining ?? null,
+      resetAt: null,
+      throttleMultiplier: payload.throttleMultiplier,
+    };
+  }
+  // When blocked, force `remaining: 0` — the renderer's GitHub-flavored
+  // projection treats `remaining === 0` as the "blocked" signal, so the exact
+  // (1–50) hard-stop-band count must not leak through as a non-zero value.
+  return {
+    limit: payload.limit ?? null,
+    remaining: 0,
+    resetAt: payload.resetAt ?? null,
+    ...(payload.kind === "secondary" ? { secondaryThrottled: true } : {}),
+    throttleMultiplier: payload.throttleMultiplier,
+  };
+}


### PR DESCRIPTION
Closes #9987.

The adaptive fetch backoff (#8756) went dark when the forge RPC bridge (#8870) moved all GitHub HTTP into main: the utility-local `gitHubRateLimitService` never sees an update anymore, so the `onStateChange` relay in `electron/workspace-host.ts` fired zero times and `WorkspaceService.applyFetchThrottle` was permanently stuck at multiplier 1 — the monitor fleet polled at full cadence right into the rate-limit wall.

## What this does

- Adds a fire-and-forget `apply-fetch-throttle` variant to `WorkspaceHostRequest` and relays main's `throttleMultiplier` into every workspace host from the existing `gitHubRateLimitService.onStateChange` subscription in `electron/ipc/handlers/github.ts`.
- Follows the `setLogLevelOverrides` cache-and-replay precedent end to end: `WorkspaceHostProcess` caches the last multiplier and replays it on every `ready` (initial spawn and restarts — a restarted host would otherwise run unthrottled until the next state change, which can be hours away), and `WorkspaceHostPool` keeps a pool-level cache so hosts created after the last state change are seeded at construction.
- Removes the dead utility-process relay and its stale comment — nothing in the host performs GitHub HTTP since #8870.
- Dedupes the hand-synced `toRateLimitInfo` twins (`electron/workspace-host.ts` / `electron/ipc/handlers/github.ts`) into `shared/utils/rateLimitUtils.ts`.
- `getRateLimitImpl` in the GitHub forge provider now includes `throttleMultiplier` in both the blocked and unblocked branches, so the bridge's `getRateLimit` path carries throttle state too.

## Notes for review

- The host→main `forge-rate-limit-changed` event path (event variant, router case with the rotation guard, process relay case) is now emitter-less. Left in place deliberately: the sibling `forge-token-health-changed` is equally emitter-less from an earlier migration, so removing one but not the other felt like inconsistent partial cleanup — happy to do both in a follow-up.
- No validation at the relay boundary: `applyFetchThrottle` already clamps (`Number.isFinite && >= 1`), and the service caps the multiplier at 10 upstream.

## Tests

- New `WorkspaceHostProcess.rateLimit.test.ts`: default replay on ready, pre-ready cache + replay, post-ready immediate send, and replay reaching the *new* child after a crash + restart.
- New `WorkspaceClient.rateLimit.test.ts`: pool fan-out to every host, pool-cache seeding of late-created hosts, empty-pool no-op.
- New `shared/utils/__tests__/rateLimitUtils.test.ts`: projection invariants (blocked forces `remaining: 0`, secondary flag, budget forwarding).
- Extended `github.rateLimit.test.ts` (relay fan-in + `?? 1` fallback) and `forgeProvider.test.ts` (`getRateLimit` projection in all three states).