### PR TITLE
fix(actions): keep hidden and restricted actions out of MCP introspection

### DIFF
--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -42,7 +42,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "introspection",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Fetch one action's full manifest entry, including inputSchema and outputSchema. Args: \`actionId\` (required) — an action id from \`actions.search\` results (the \`id\` field). Returns { ok: true, entry } on success, or { ok: false, error: { code: 'NOT_FOUND', message } } as data (not a thrown error) when the id is unknown or hidden. Use after \`actions.search\` to inspect the exact arguments an action expects before dispatching it.",
+    "description": "Fetch one action's full manifest entry, including inputSchema and outputSchema. Args: \`actionId\` (required) — an action id from \`actions.search\` results (the \`id\` field). Returns { ok: true, entry } on success, or { ok: false, error: { code: 'NOT_FOUND', message } } as data (not a thrown error) when the id is unknown, hidden, or restricted. Use after \`actions.search\` to inspect the exact arguments an action expects before dispatching it.",
     "examples": [
       {
         "args": {

--- a/src/services/actions/definitions/__tests__/introspectionActions.test.ts
+++ b/src/services/actions/definitions/__tests__/introspectionActions.test.ts
@@ -388,6 +388,41 @@ describe("actions.list", () => {
     const def = registry.get("actions.list")!();
     expect(def.mcpVisibility).toBe("core");
   });
+
+  it("excludes actions with mcpVisibility hidden", async () => {
+    vi.mocked(actionService.list).mockReturnValueOnce([
+      makeEntry({ id: "actions.visible", title: "Visible", mcpVisibility: "core" }),
+      makeEntry({ id: "actions.secret", title: "Secret", mcpVisibility: "hidden" }),
+    ]);
+
+    const def = registry.get("actions.list")!();
+    const result = (await def.run(undefined, stubCtx)) as {
+      actions: ActionManifestEntry[];
+    };
+
+    const ids = result.actions.map((a) => a.id);
+    expect(ids).toContain("actions.visible");
+    expect(ids).not.toContain("actions.secret");
+  });
+
+  it("excludes hidden actions under each user filter branch", async () => {
+    // A narrower user filter must never be able to surface a hidden entry —
+    // the hidden exclusion must run before category/search/enabledOnly.
+    const hidden = makeEntry({ id: "actions.secret", title: "Secret", mcpVisibility: "hidden" });
+    const visible = makeEntry({ id: "actions.secret", title: "Secret", mcpVisibility: "core" });
+
+    for (const args of [{ category: "test" }, { search: "secret" }, { enabledOnly: true }]) {
+      vi.mocked(actionService.list).mockReturnValueOnce([hidden, visible]);
+      const def = registry.get("actions.list")!();
+      const result = (await def.run(args as never, stubCtx)) as {
+        actions: ActionManifestEntry[];
+      };
+      const ids = result.actions.map((a) => a.id);
+      expect(ids).toContain("actions.secret");
+      expect(ids.every((id, i) => i === ids.lastIndexOf(id))).toBe(true);
+      expect(result.actions.find((a) => a.mcpVisibility === "hidden")).toBeUndefined();
+    }
+  });
 });
 
 describe("actions.search", () => {
@@ -644,6 +679,39 @@ describe("actions.getSchema", () => {
 
     const def = registry.get("actions.getSchema")!();
     const result = (await def.run({ actionId: "actions.secret" } as never, stubCtx)) as {
+      ok: false;
+      error: { code: string; message: string };
+    };
+
+    expect(result.ok).toBe(false);
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns structured error for restricted action", async () => {
+    const entry = makeEntry({ id: "actions.locked", danger: "restricted" });
+    vi.mocked(actionService.get).mockReturnValueOnce(entry);
+
+    const def = registry.get("actions.getSchema")!();
+    const result = (await def.run({ actionId: "actions.locked" } as never, stubCtx)) as {
+      ok: false;
+      error: { code: string; message: string };
+    };
+
+    expect(result.ok).toBe(false);
+    expect(result.error.code).toBe("NOT_FOUND");
+    expect(result.error.message).toContain("actions.locked");
+  });
+
+  it("returns structured error when an entry is both hidden and restricted", async () => {
+    const entry = makeEntry({
+      id: "actions.dual",
+      mcpVisibility: "hidden",
+      danger: "restricted",
+    });
+    vi.mocked(actionService.get).mockReturnValueOnce(entry);
+
+    const def = registry.get("actions.getSchema")!();
+    const result = (await def.run({ actionId: "actions.dual" } as never, stubCtx)) as {
       ok: false;
       error: { code: string; message: string };
     };

--- a/src/services/actions/definitions/introspectionActions.ts
+++ b/src/services/actions/definitions/introspectionActions.ts
@@ -43,6 +43,7 @@ export function registerIntrospectionActions(
       const { category, search, enabledOnly } =
         (args as { category?: string; search?: string; enabledOnly?: boolean } | undefined) ?? {};
       let manifest = actionService.list(ctx);
+      manifest = manifest.filter((entry) => entry.mcpVisibility !== "hidden");
 
       if (category) {
         manifest = manifest.filter((a) => a.category === category);
@@ -292,7 +293,7 @@ export function registerIntrospectionActions(
     id: "actions.getSchema",
     title: "Get Action Schema",
     description:
-      "Fetch one action's full manifest entry, including inputSchema and outputSchema. Args: `actionId` (required) — an action id from `actions.search` results (the `id` field). Returns { ok: true, entry } on success, or { ok: false, error: { code: 'NOT_FOUND', message } } as data (not a thrown error) when the id is unknown or hidden. Use after `actions.search` to inspect the exact arguments an action expects before dispatching it.",
+      "Fetch one action's full manifest entry, including inputSchema and outputSchema. Args: `actionId` (required) — an action id from `actions.search` results (the `id` field). Returns { ok: true, entry } on success, or { ok: false, error: { code: 'NOT_FOUND', message } } as data (not a thrown error) when the id is unknown, hidden, or restricted. Use after `actions.search` to inspect the exact arguments an action expects before dispatching it.",
     category: "introspection",
     kind: "query",
     danger: "safe",
@@ -323,17 +324,7 @@ export function registerIntrospectionActions(
       const { actionId } = args as { actionId: string };
       const entry = actionService.get(actionId, ctx);
 
-      if (!entry) {
-        return {
-          ok: false,
-          error: {
-            code: "NOT_FOUND",
-            message: `No action found with id "${actionId}". Use actions.search to find available actions.`,
-          },
-        };
-      }
-
-      if (entry.mcpVisibility === "hidden") {
+      if (!entry || entry.mcpVisibility === "hidden" || entry.danger === "restricted") {
         return {
           ok: false,
           error: {


### PR DESCRIPTION
## Summary

- `actions.list` now filters out actions with `mcpVisibility: "hidden"`, matching what `actions.search` and `actions.getSchema` already do. The contract in `shared/types/actions.ts` says hidden tools "never surface in discovery" and `actions.list` was the odd one out.
- `actions.getSchema`'s hidden guard is collapsed to also drop `danger: "restricted"` entries. `actionService.get()` returns them; only this tool can resolve a hidden id, so the same discovery-exclusion gap had to close here.
- `ActionService` is untouched. All behaviour changes are in `src/services/actions/definitions/introspectionActions.ts`.

Resolves #9888

## Changes

- `src/services/actions/definitions/introspectionActions.ts` — 1 added line in `actions.list`, 1 collapsed guard in `actions.getSchema`.
- `src/services/actions/definitions/__tests__/introspectionActions.test.ts` — 3 new cases, 33 total passing.

## Testing

- `npx vitest run src/services/actions/definitions/__tests__/introspectionActions.test.ts` — 33/33 pass.
- `npx prettier --check` and `npx eslint` clean on changed files.
- The `shouldExposeTool` gate in `tierAuth.ts` only decides which tools appear on `tools/list`; it doesn't strip entries from a tool's result, so this fix is the right layer.
- Latent today: no production action currently sets `mcpVisibility: "hidden"`. Activates the first time a hidden-but-renderer-visible action is registered.