### PR TITLE
fix(terminal): denominate IPC flow-control ack in UTF-8 bytes (#9893)

### DIFF
--- a/electron/__tests__/pty-host.adversarial.test.ts
+++ b/electron/__tests__/pty-host.adversarial.test.ts
@@ -872,7 +872,7 @@ describe("pty-host adversarial", () => {
     const resumeCallsBefore = terminal.ptyProcess.resume.mock.calls.length;
     const statusCountBefore = terminalStatusPayloads(parentPort).length;
 
-    parentPort.emit("message", { type: "acknowledge-data", id: "t1", charCount: 60 });
+    parentPort.emit("message", { type: "acknowledge-data", id: "t1", byteCount: 60 });
     await flushMicrotasks();
 
     expect(terminal.ptyProcess.resume).toHaveBeenCalledTimes(resumeCallsBefore);

--- a/electron/pty-host/handlers/backpressure.ts
+++ b/electron/pty-host/handlers/backpressure.ts
@@ -16,7 +16,7 @@ export function createBackpressureHandlers(ctx: HostContext): HandlerMap {
 
   return {
     "acknowledge-data": (msg) => {
-      const acknowledgedBytes = msg.charCount ?? 0;
+      const acknowledgedBytes = msg.byteCount ?? 0;
       ipcQueueManager.removeBytes(msg.id, acknowledgedBytes);
       ipcQueueManager.tryResume(msg.id);
 

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -937,8 +937,8 @@ export class PtyClient extends EventEmitter {
   /**
    * Acknowledge data processing for flow control.
    */
-  acknowledgeData(id: string, charCount: number): void {
-    this.send({ type: "acknowledge-data", id, charCount });
+  acknowledgeData(id: string, byteCount: number): void {
+    this.send({ type: "acknowledge-data", id, byteCount });
   }
 
   /**

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -365,10 +365,10 @@ export class PtyManager extends EventEmitter {
    * No-op in SAB mode (which is always enabled in production).
    * Kept for backwards compatibility with IPC fallback mode.
    */
-  acknowledgeData(id: string, charCount: number): void {
+  acknowledgeData(id: string, byteCount: number): void {
     const terminal = this.registry.get(id);
     if (terminal) {
-      terminal.acknowledgeData(charCount);
+      terminal.acknowledgeData(byteCount);
     }
   }
 

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -722,7 +722,7 @@ export class TerminalProcess {
     this.terminalInfo.lastObservedTitle = title;
   }
 
-  acknowledgeData(_charCount: number): void {
+  acknowledgeData(_byteCount: number): void {
     // No-op: SAB-based backpressure in pty-host.ts handles all flow control
   }
 

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -151,7 +151,7 @@ export type PtyHostRequest =
   | { type: "connect-port"; windowId: number }
   | { type: "get-terminal-info"; id: string; requestId: string }
   | { type: "force-resume"; id: string }
-  | { type: "acknowledge-data"; id: string; charCount: number }
+  | { type: "acknowledge-data"; id: string; byteCount: number }
   | { type: "set-analysis-enabled"; id: string; enabled: boolean }
   | { type: "get-available-terminals"; requestId: string }
   | { type: "get-terminals-by-state"; state: AgentState; requestId: string }

--- a/src/services/terminal/TerminalWriteController.ts
+++ b/src/services/terminal/TerminalWriteController.ts
@@ -2,6 +2,23 @@ import type { ManagedTerminal } from "./types";
 import { PERF_MARKS } from "@shared/perf/marks";
 import { markRendererPerformance } from "@/utils/performance";
 
+// Reused across writes — TextEncoder holds no state between encode() calls, so
+// a single module-level instance avoids re-allocating one per write.
+const utf8Encoder = new TextEncoder();
+
+/**
+ * UTF-8 byte length of a string chunk — the unit the pty-host's IPC
+ * flow-control ledger is denominated in (the host charges
+ * `Buffer.byteLength(data, "utf8")` before sending). The renderer must
+ * acknowledge in the SAME unit; using JS `string.length` (UTF-16 code units)
+ * under-reports every non-ASCII char — box-drawing/CJK are 3 UTF-8 bytes vs 1
+ * code unit, emoji are 4 vs 2 — so the host queue drifts toward its high
+ * watermark and triggers spurious backpressure pauses (#9893).
+ */
+function utf8ByteLength(data: string): number {
+  return utf8Encoder.encode(data).byteLength;
+}
+
 export interface WriteControllerDeps {
   getInstance: (id: string) => ManagedTerminal | undefined;
   acknowledgePortData: (id: string, bytes: number) => void;
@@ -42,6 +59,12 @@ export class TerminalWriteController {
     if (managed.isHibernated) {
       const bytes = typeof data === "string" ? data.length : data.byteLength;
       this.deps.acknowledgePortData(id, bytes);
+      // Hibernated output is dropped, never replayed — IPC-delivered chunks
+      // (always strings) were charged to the host's IPC ledger, so ack them
+      // here in UTF-8 bytes or the ledger leaks into permanent backpressure.
+      if (typeof data === "string") {
+        this.deps.acknowledgeData(id, utf8ByteLength(data));
+      }
       this.deps.notifyWriteComplete(id, bytes);
       return;
     }
@@ -76,12 +99,18 @@ export class TerminalWriteController {
     this.perfWriteSampleCounter += 1;
     const shouldSample = this.perfWriteSampleCounter % 64 === 0;
 
-    const sampledBytes = shouldSample
-      ? typeof data === "string"
-        ? data.length
-        : data.byteLength
-      : 0;
-    const acknowledgedBytes = typeof data === "string" ? data.length : data.byteLength;
+    // renderedBytes (UTF-16 code units / raw byte length) denominates the
+    // renderer-side ingest ledger (TerminalOutputIngestService.inFlightBytes,
+    // incremented via the same chunkByteSize) and perf sampling. The host's
+    // IPC flow-control ledger is a separate ledger in UTF-8 bytes — see
+    // ackBytes below.
+    const renderedBytes = typeof data === "string" ? data.length : data.byteLength;
+    const sampledBytes = shouldSample ? renderedBytes : 0;
+    // Only string chunks travel the IPC path (Uint8Array chunks arrive via
+    // MessagePort and are acked through acknowledgePortData's queued count).
+    // null = no IPC ack: sending one for a port-delivered chunk would
+    // spuriously drain the host's IPC ledger.
+    const ackBytes = typeof data === "string" ? utf8ByteLength(data) : null;
 
     if (shouldSample) {
       markRendererPerformance(PERF_MARKS.TERMINAL_DATA_PARSED, {
@@ -103,9 +132,11 @@ export class TerminalWriteController {
       managed.pendingWrites = Math.max(0, (managed.pendingWrites ?? 1) - 1);
       managed.lastWriteAt = Date.now();
 
-      this.deps.acknowledgePortData(id, acknowledgedBytes);
-      this.deps.acknowledgeData(id, acknowledgedBytes);
-      this.deps.notifyWriteComplete(id, acknowledgedBytes);
+      this.deps.acknowledgePortData(id, renderedBytes);
+      if (ackBytes !== null) {
+        this.deps.acknowledgeData(id, ackBytes);
+      }
+      this.deps.notifyWriteComplete(id, renderedBytes);
 
       if (shouldSample) {
         const writeDurationMs =

--- a/src/services/terminal/__tests__/TerminalInstanceService.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.adversarial.test.ts
@@ -370,7 +370,10 @@ describe("TerminalInstanceService adversarial", () => {
     service.writeToTerminal("t1", "abc");
 
     expect(testState.clientMocks.acknowledgePortData).toHaveBeenCalledWith("t1", 3);
-    expect(testState.clientMocks.acknowledgeData).not.toHaveBeenCalled();
+    // Hibernated output is dropped, never replayed — IPC-delivered string
+    // chunks were charged to the host's IPC ledger, so it must be drained here
+    // or it leaks into permanent backpressure (#9893). ASCII "abc" = 3 bytes.
+    expect(testState.clientMocks.acknowledgeData).toHaveBeenCalledWith("t1", 3);
     expect(notifyWriteCompleteSpy).toHaveBeenCalledWith("t1", 3);
     expect(managed.terminal.write).not.toHaveBeenCalled();
   });

--- a/src/services/terminal/__tests__/TerminalWriteController.test.ts
+++ b/src/services/terminal/__tests__/TerminalWriteController.test.ts
@@ -193,6 +193,17 @@ describe("TerminalWriteController.write", () => {
       expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", 3);
       expect(deps.acknowledgeData).not.toHaveBeenCalled();
     });
+
+    it("deferred-restore path: never acks the IPC ledger even for non-ASCII strings", () => {
+      // The IPC ledger is drained when the deferred chunk replays through the
+      // normal path after restore. Acking here would double-drain it. The port
+      // ack stays in UTF-16 code units (1 for the single box-drawing char).
+      managed.isSerializedRestoreInProgress = true;
+      controller.write("t1", "│");
+
+      expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", 1);
+      expect(deps.acknowledgeData).not.toHaveBeenCalled();
+    });
   });
 
   it("registers a new lastActivityMarker on each write in the normal buffer", () => {

--- a/src/services/terminal/__tests__/TerminalWriteController.test.ts
+++ b/src/services/terminal/__tests__/TerminalWriteController.test.ts
@@ -112,11 +112,14 @@ describe("TerminalWriteController.write", () => {
     controller.write("t1", "hello");
 
     expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", 5);
+    // Hibernated output is dropped, never replayed, so the IPC ledger must be
+    // drained here. ASCII "hello" is 5 UTF-8 bytes == 5 UTF-16 code units.
+    expect(deps.acknowledgeData).toHaveBeenCalledWith("t1", 5);
     expect(deps.notifyWriteComplete).toHaveBeenCalledWith("t1", 5);
     expect((managed.terminal as unknown as MockTerminal).write).not.toHaveBeenCalled();
   });
 
-  it("serialized-restore path: defers output and acks port data", () => {
+  it("serialized-restore path: defers output and acks port data, never the IPC ledger", () => {
     managed.isSerializedRestoreInProgress = true;
     controller.write("t1", "abc");
     controller.write("t1", new Uint8Array([0x61, 0x62]));
@@ -124,6 +127,10 @@ describe("TerminalWriteController.write", () => {
     expect(managed.deferredOutput).toEqual(["abc", new Uint8Array([0x61, 0x62])]);
     expect(deps.acknowledgePortData).toHaveBeenNthCalledWith(1, "t1", 3);
     expect(deps.acknowledgePortData).toHaveBeenNthCalledWith(2, "t1", 2);
+    // Deferred chunks are replayed through the normal path once restore
+    // finishes, which acks the IPC ledger then — acking here too would
+    // double-drain the host ledger.
+    expect(deps.acknowledgeData).not.toHaveBeenCalled();
     expect((managed.terminal as unknown as MockTerminal).write).not.toHaveBeenCalled();
   });
 
@@ -136,6 +143,56 @@ describe("TerminalWriteController.write", () => {
     expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", 5);
     expect(deps.acknowledgeData).toHaveBeenCalledWith("t1", 5);
     expect(deps.notifyWriteComplete).toHaveBeenCalledWith("t1", 5);
+  });
+
+  describe("IPC flow-control ledger byte accounting (#9893)", () => {
+    it("acks the IPC ledger in UTF-8 bytes for non-ASCII strings, not UTF-16 code units", () => {
+      // U+2502 (box-drawing │) is 3 UTF-8 bytes but 1 UTF-16 code unit. The
+      // host charged the ledger in UTF-8 bytes, so the ack must match (9), or
+      // the queue drifts toward its high watermark (#9893).
+      controller.write("t1", "│".repeat(3));
+
+      expect(deps.acknowledgeData).toHaveBeenCalledWith("t1", 9);
+      // The renderer-side ingest ledger (acknowledgePortData / notifyWriteComplete)
+      // stays in UTF-16 code units to match how inFlightBytes was incremented.
+      expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", 3);
+      expect(deps.notifyWriteComplete).toHaveBeenCalledWith("t1", 3);
+    });
+
+    it("counts surrogate-pair emoji as 4 UTF-8 bytes for the IPC ack", () => {
+      // U+1F600 (😀) is 4 UTF-8 bytes and 2 UTF-16 code units.
+      controller.write("t1", "😀");
+
+      expect(deps.acknowledgeData).toHaveBeenCalledWith("t1", 4);
+      expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", 2);
+      expect(deps.notifyWriteComplete).toHaveBeenCalledWith("t1", 2);
+    });
+
+    it("does not send an IPC ack for port-delivered Uint8Array chunks", () => {
+      // Uint8Array chunks arrive via MessagePort, not IPC — sending an IPC ack
+      // would spuriously drain the host's IPC ledger.
+      controller.write("t1", new Uint8Array([0xe2, 0x94, 0x82]));
+
+      expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", 3);
+      expect(deps.acknowledgeData).not.toHaveBeenCalled();
+      expect(deps.notifyWriteComplete).toHaveBeenCalledWith("t1", 3);
+    });
+
+    it("hibernated path: acks the IPC ledger in UTF-8 bytes for non-ASCII strings", () => {
+      managed.isHibernated = true;
+      controller.write("t1", "│");
+
+      expect(deps.acknowledgeData).toHaveBeenCalledWith("t1", 3);
+      expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", 1);
+    });
+
+    it("hibernated path: does not send an IPC ack for port-delivered Uint8Array chunks", () => {
+      managed.isHibernated = true;
+      controller.write("t1", new Uint8Array([0xe2, 0x94, 0x82]));
+
+      expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", 3);
+      expect(deps.acknowledgeData).not.toHaveBeenCalled();
+    });
   });
 
   it("registers a new lastActivityMarker on each write in the normal buffer", () => {


### PR DESCRIPTION
## Problem

The pty-host charges its IPC flow-control ledger in **UTF-8 bytes** (`Buffer.byteLength(dataString, "utf8")` → `ipcQueueManager.addBytes`), but the renderer acknowledged processed data using JS string `.length` — **UTF-16 code units**. For non-ASCII output (box-drawing, CJK, emoji) every ack under-reports: a box-drawing char is 3 UTF-8 bytes vs 1 code unit, an emoji is 4 bytes vs 2. The host's `queuedBytes` map drifts upward toward the high watermark and triggers spurious `paused-backpressure` states on heavy non-ASCII output.

## Fix

This is a two-ledger problem. The renderer runs a *separate* flow-control ledger from the host:

- **Host IPC ledger** (UTF-8 bytes) — drained by `acknowledgeData`. Now acked in UTF-8 bytes via a module-level `TextEncoder`, matching the host's charge. Only fires for string chunks (the IPC path); `Uint8Array` chunks travel the MessagePort path and are acked through the existing `pendingPortAckBytes` queue.
- **Renderer ingest ledger** (UTF-16 code units) — `acknowledgePortData` / `notifyWriteComplete`. Kept in UTF-16 to stay balanced with how `TerminalOutputIngestService.inFlightBytes` is incremented (`chunkByteSize` = `.length`). Routing UTF-8 here would unbalance it.

Secondary correctness fixes folded in:

- **Double-drain guard** — `acknowledgeData` is now guarded behind `typeof data === "string"`, so port-delivered `Uint8Array` chunks no longer send a spurious IPC ack against the host ledger.
- **Hibernated-path leak** — the hibernated drop path now acks the IPC ledger for string chunks. Dropped data is never replayed, so without this the host ledger leaks into permanent backpressure for that terminal.
- **Deferred-restore** — intentionally left un-acked on the IPC ledger: deferred chunks replay through the normal write path once restore completes (where `acknowledgeData` fires), so acking in the deferred branch too would double-drain.
- **Wire field rename** — the misleading `acknowledge-data` field `charCount` → `byteCount` (it always meant bytes; the name was part of how this bug arose).

## Tests

- New `IPC flow-control ledger byte accounting (#9893)` suite: box-drawing (9 UTF-8 bytes vs 3 code units), surrogate-pair emoji (4 vs 2), `Uint8Array` IPC-ack guard, hibernated non-ASCII, deferred-restore no-double-ack.
- Updated the `HIBERNATED_WRITE_ONLY_ACKS` adversarial test for the new hibernated-path IPC ack.

## Verification

`npm run check` clean — typecheck (all configs), IPC/channel guards, confirm-wiring, format, `lint:ratchet` (-1 warning). Targeted tests pass: `TerminalWriteController` (21), `pty-host.adversarial` (24), `TerminalInstanceService.adversarial` (7).

Closes #9893.

🤖 Generated with [Claude Code](https://claude.com/claude-code)