### PR TITLE
fix(forge): stop transient PR lookup failures from clearing rows and reconnect detection breaker

### DIFF
--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -1579,7 +1579,10 @@ class PullRequestService {
           `PR branch lookup failed for ${branchErrorCount} of ${prResults.length} branches: ${firstBranchError.message}`,
           rateLimit ?? undefined
         );
-      } else {
+      } else if (prResults.length > 0) {
+        // Only a cycle that actually completed a PR lookup counts as success
+        // for the breaker — an issue-title-only retry cycle (no unresolved
+        // branch candidates) must not clear a real PR-lookup error streak.
         this.consecutiveErrors = 0;
       }
     } catch (error) {
@@ -1709,6 +1712,11 @@ class PullRequestService {
     // can escalate to a permanent ban.
     if (rateLimit) {
       this.nextRetryAt = rateLimit.resumeAt;
+      // Clear the streak: failures preceding the pause were likely the same
+      // rate limit manifesting as transient errors before the gate caught it,
+      // so carrying them over would leave the breaker on a hair trigger for
+      // the first post-pause hiccup.
+      this.consecutiveErrors = 0;
       logWarn("PR check hit a GitHub rate limit — pausing without tripping circuit breaker", {
         reason: rateLimit.kind,
         resumeAt: rateLimit.resumeAt,

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -462,13 +462,19 @@ class PullRequestService {
           error: formatErrorMessage(error, "findPRsByBranches failed"),
         });
       }
-      // A branch missing from the batch map falls back to a per-branch call,
-      // matching the old `perBranchFallback`. A transient per-branch error
-      // resolves to null (treated as "no PR"), as the prior path did.
+      // A present key (even null-valued) is authoritative "found / not found";
+      // a branch missing from the batch map falls back to a per-branch call.
+      // The fallback preserves the transient-vs-not-found distinction:
+      // findPRByBranch resolves null for a confirmed missing PR but throws on
+      // transient failure, which we surface as a per-key Error so the loader
+      // rejects it and the caller skips (never clears) that branch.
       return Promise.all(
         list.map((branch) => {
           if (batchMap?.has(branch)) return batchMap.get(branch) ?? null;
-          return bridge.findPRByBranch(providerId, repo, branch).catch(() => null);
+          return bridge.findPRByBranch(providerId, repo, branch).then(
+            (pr) => pr,
+            (error: unknown) => (error instanceof Error ? error : new Error(String(error)))
+          );
         })
       );
     });
@@ -957,16 +963,17 @@ class PullRequestService {
   }
 
   /**
-   * Consult the active forge provider's rate-limit state and return a blocking
-   * decision. Fails open (unblocked) when the provider is absent, lacks
+   * Consult the active forge provider's rate-limit state and return the active
+   * block (`kind` matches `handleError`'s rate-limit marker) or null when
+   * unblocked. Fails open (null) when the provider is absent, lacks
    * `getRateLimit`, or the call throws — a provider bug must not stall polling.
    */
   private async checkRateLimitGate(): Promise<{
-    blocked: boolean;
-    resumeAt: number | null;
-  }> {
+    kind: "primary" | "secondary";
+    resumeAt: number;
+  } | null> {
     if (!this.providerNamespacedId) {
-      return { blocked: false, resumeAt: null };
+      return null;
     }
     try {
       const info: RateLimitInfo | null = await getForgeBridge().getRateLimit(
@@ -974,23 +981,23 @@ class PullRequestService {
       );
       // `null` here means the provider does not implement `getRateLimit` —
       // fail open, polling proceeds without a rate-limit gate.
-      if (!info) return { blocked: false, resumeAt: null };
+      if (!info) return null;
       const now = Date.now();
       if (info.secondaryThrottled) {
         const resumeAt = info.resetAt ?? now + RATE_LIMIT_SECONDARY_FALLBACK_MS;
-        if (resumeAt <= now) return { blocked: false, resumeAt: null };
-        return { blocked: true, resumeAt };
+        if (resumeAt <= now) return null;
+        return { kind: "secondary", resumeAt };
       }
       if (info.remaining === 0) {
         const resumeAt = info.resetAt
           ? info.resetAt + RATE_LIMIT_CLOCK_SKEW_MS
           : now + RATE_LIMIT_SECONDARY_FALLBACK_MS;
-        if (resumeAt <= now) return { blocked: false, resumeAt: null };
-        return { blocked: true, resumeAt };
+        if (resumeAt <= now) return null;
+        return { kind: "primary", resumeAt };
       }
-      return { blocked: false, resumeAt: null };
+      return null;
     } catch {
-      return { blocked: false, resumeAt: null };
+      return null;
     }
   }
 
@@ -1004,12 +1011,12 @@ class PullRequestService {
     if (!repo || !providerId) return;
     const bridge = getForgeBridge();
 
-    const { blocked, resumeAt } = await this.checkRateLimitGate();
-    if (blocked && resumeAt) {
-      this.nextRetryAt = resumeAt;
+    const rateLimitBlock = await this.checkRateLimitGate();
+    if (rateLimitBlock) {
+      this.nextRetryAt = rateLimitBlock.resumeAt;
       logDebug("Skipping PR revalidation — rate limit active", {
         providerId,
-        resumeAt,
+        resumeAt: rateLimitBlock.resumeAt,
       });
       return;
     }
@@ -1372,13 +1379,13 @@ class PullRequestService {
     }
     const bridge = getForgeBridge();
 
-    const { blocked, resumeAt } = await this.checkRateLimitGate();
-    if (blocked && resumeAt) {
-      this.nextRetryAt = resumeAt;
+    const rateLimitBlock = await this.checkRateLimitGate();
+    if (rateLimitBlock) {
+      this.nextRetryAt = rateLimitBlock.resumeAt;
       logDebug("Skipping PR check — rate limit active", {
         providerId,
-        resumeAt,
-        waitMs: resumeAt - Date.now(),
+        resumeAt: rateLimitBlock.resumeAt,
+        waitMs: rateLimitBlock.resumeAt - Date.now(),
       });
       return;
     }
@@ -1472,11 +1479,22 @@ class PullRequestService {
         return;
       }
 
-      this.consecutiveErrors = 0;
+      let branchErrorCount = 0;
+      let firstBranchError: Error | null = null;
 
-      for (const { branch, pr } of prResults) {
+      for (const { branch, pr, error } of prResults) {
         const worktreeIds = uniqueBranches.get(branch);
         if (!worktreeIds) continue;
+
+        if (error) {
+          // Transient lookup failure — NOT authoritative absence. Skip the
+          // branch so any existing PR row survives; the loader evicts settled
+          // keys, so the branch retries fresh next cycle. Routed to
+          // handleError once per cycle after the loop.
+          branchErrorCount++;
+          firstBranchError ??= error;
+          continue;
+        }
 
         if (!pr) {
           // Authoritative "no PR found" for a fresh candidate. Without this,
@@ -1484,6 +1502,11 @@ class PullRequestService {
           // and the renderer's preservation rule (#8870) would hold any
           // `linked.pr` carried over from a prior session indefinitely.
           for (const worktreeId of worktreeIds) {
+            // Drop any stale detection alongside the clear: refresh() empties
+            // `resolvedWorktrees` but keeps `detectedPRs`, so a PR that
+            // disappeared between cycles would otherwise leave a PENDING
+            // entry keeping the 30s revalidation boost armed indefinitely.
+            this.detectedPRs.delete(worktreeId);
             events.emit("sys:pr:cleared", {
               worktreeId,
               branchName: branch,
@@ -1543,6 +1566,22 @@ class PullRequestService {
       }
 
       this.updateBoostFromDetectedPRs();
+
+      if (branchErrorCount > 0 && firstBranchError) {
+        // Route the cycle's transient lookup failures through the breaker
+        // exactly once — per cycle, not per branch, so breaker behavior isn't
+        // topology-dependent on how many branches a repo happens to have.
+        // Re-consult the rate-limit gate first: a 429 that landed mid-cycle
+        // (after the top-of-cycle gate passed) must pause polling via the
+        // rate-limit path rather than count toward the circuit breaker.
+        const rateLimit = await this.checkRateLimitGate();
+        this.handleError(
+          `PR branch lookup failed for ${branchErrorCount} of ${prResults.length} branches: ${firstBranchError.message}`,
+          rateLimit ?? undefined
+        );
+      } else {
+        this.consecutiveErrors = 0;
+      }
     } catch (error) {
       this.handleError(formatErrorMessage(error, "PR check failed"));
     }
@@ -1553,12 +1592,13 @@ class PullRequestService {
    * `prByBranchLoader`. All `load()` calls here enqueue synchronously, so the
    * loader coalesces them into a single `findPRsByBranches` batch (or per-branch
    * fallback) and dedups any branch already in flight from an overlapping
-   * cycle. The loader resolves a transient error to `null` ("no PR"), matching
-   * the prior `perBranchFallback` behavior.
+   * cycle. A resolved `pr` (including null) is authoritative; a transient
+   * lookup failure surfaces as a non-null `error` so the caller skips the
+   * branch (never clears it) and routes the failure to the circuit breaker.
    */
   private async resolvePRsForBranches(
     branches: string[]
-  ): Promise<Array<{ branch: string; pr: ForgePR | null }>> {
+  ): Promise<Array<{ branch: string; pr: ForgePR | null; error: Error | null }>> {
     if (branches.length === 0) return [];
 
     const loader = this.prByBranchLoader;
@@ -1570,18 +1610,26 @@ class PullRequestService {
       return [];
     }
 
-    // Absorb a per-load rejection as `null` ("no PR found"). The only source of
-    // rejection here is the loader being disposed by a mid-cycle provider swap
-    // (`invalidateProvider()` from refresh()/setForgeSettings()); propagating it
-    // would land in checkForPRs's catch and wrongly bump `consecutiveErrors`
+    // A disposal rejection comes from a mid-cycle provider swap
+    // (`invalidateProvider()` from refresh()/setForgeSettings()), not a lookup
+    // failure — absorb it as `null` so it never bumps `consecutiveErrors`
     // toward the circuit breaker. The downstream stale-provider guard discards
     // the whole cycle once it sees the provider changed, so the null is never
-    // written as a spurious `sys:pr:cleared`.
+    // written as a spurious `sys:pr:cleared`. Any other rejection is a
+    // transient lookup failure surfaced via the per-key Error contract.
     return Promise.all(
       branches.map((branch) =>
         loader.load(branch).then(
-          (pr) => ({ branch, pr }),
-          () => ({ branch, pr: null as ForgePR | null })
+          (pr) => ({ branch, pr, error: null as Error | null }),
+          (error: unknown) => {
+            const err = error instanceof Error ? error : new Error(String(error));
+            const isDisposed = err.message === "BatchLoader disposed";
+            return {
+              branch,
+              pr: null as ForgePR | null,
+              error: isDisposed ? null : err,
+            };
+          }
         )
       )
     );

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -1395,6 +1395,72 @@ describe("PullRequestService", () => {
       pullRequestService.destroy();
     });
 
+    it("keeps an existing PR row when its branch lookup later fails transiently", async () => {
+      vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+      let failing = false;
+      mockForgeProviderResolved(async () => {
+        if (failing) throw new Error("network timeout");
+        return makeMockForgePR();
+      });
+
+      const { pullRequestService } = await import("../PullRequestService.js");
+      const { events } = await import("../events.js");
+
+      const cleared: DaintreeEventMap["sys:pr:cleared"][] = [];
+      const unsubscribe = events.on("sys:pr:cleared", (payload) => cleared.push(payload));
+
+      pullRequestService.initialize("/repo");
+      events.emit(
+        "sys:worktree:update",
+        makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+      );
+
+      await pullRequestService.refresh();
+      const svc = pullRequestService as unknown as {
+        detectedPRs: Map<string, unknown>;
+        consecutiveErrors: number;
+      };
+      expect(svc.detectedPRs.has("wt-1")).toBe(true);
+
+      // refresh() re-queries every worktree; the lookup now fails transiently.
+      // The detected row must survive — this is the #9994 regression scenario.
+      failing = true;
+      await pullRequestService.refresh();
+
+      expect(cleared).toHaveLength(0);
+      expect(svc.detectedPRs.has("wt-1")).toBe(true);
+      expect(svc.consecutiveErrors).toBe(1);
+
+      unsubscribe();
+      pullRequestService.destroy();
+    });
+
+    it("treats a non-Error rejection as transient, not confirmed absence", async () => {
+      vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+      mockForgeProviderResolved(() => Promise.reject({ code: "ETIMEDOUT" }));
+
+      const { pullRequestService } = await import("../PullRequestService.js");
+      const { events } = await import("../events.js");
+
+      const cleared: DaintreeEventMap["sys:pr:cleared"][] = [];
+      const unsubscribe = events.on("sys:pr:cleared", (payload) => cleared.push(payload));
+
+      pullRequestService.initialize("/repo");
+      events.emit(
+        "sys:worktree:update",
+        makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+      );
+
+      await pullRequestService.refresh();
+
+      const svc = pullRequestService as unknown as { consecutiveErrors: number };
+      expect(cleared).toHaveLength(0);
+      expect(svc.consecutiveErrors).toBe(1);
+
+      unsubscribe();
+      pullRequestService.destroy();
+    });
+
     it("clears the row and deletes the detectedPRs entry on a confirmed no-PR result", async () => {
       vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
       let prGone = false;
@@ -1468,20 +1534,36 @@ describe("PullRequestService", () => {
       const svc = pullRequestService as unknown as {
         checkForPRs: () => Promise<void>;
         resolveProvider: () => Promise<void>;
+        detectedPRs: Map<string, unknown>;
         consecutiveErrors: number;
         lastCheckAt: number;
       };
+
+      // Seed a previously-detected PR on the branch that is about to fail —
+      // the failing lookup must leave it untouched.
+      const priorPR = {
+        number: 3,
+        title: "Prior PR",
+        url: "https://github.com/o/r/pull/3",
+        state: "open",
+        isDraft: false,
+        providerId: "daintree.github.github",
+        stagnantPollCount: 0,
+      };
+      svc.detectedPRs.set("wt-c", priorPR);
 
       await svc.resolveProvider();
       svc.lastCheckAt = Number.NEGATIVE_INFINITY;
       await svc.checkForPRs();
 
       // Detected branch resolves, confirmed-absent branch clears, failed
-      // branch is skipped entirely — and the cycle counts a single error.
+      // branch is skipped entirely (row preserved) — and the cycle counts a
+      // single error.
       expect(detected.map((d) => d.worktreeId)).toContain("wt-a");
       expect(detected.map((d) => d.worktreeId)).not.toContain("wt-c");
       expect(cleared).toHaveLength(1);
       expect(cleared[0].worktreeId).toBe("wt-b");
+      expect(svc.detectedPRs.get("wt-c")).toBe(priorPR);
       expect(svc.consecutiveErrors).toBe(1);
 
       unsubDetected();
@@ -1505,7 +1587,9 @@ describe("PullRequestService", () => {
       const { events } = await import("../events.js");
 
       const cleared: DaintreeEventMap["sys:pr:cleared"][] = [];
-      const unsubscribe = events.on("sys:pr:cleared", (payload) => cleared.push(payload));
+      const notifications: DaintreeEventMap["ui:notify"][] = [];
+      const unsubCleared = events.on("sys:pr:cleared", (payload) => cleared.push(payload));
+      const unsubNotify = events.on("ui:notify", (payload) => notifications.push(payload));
 
       pullRequestService.initialize("/repo");
       events.emit(
@@ -1522,16 +1606,23 @@ describe("PullRequestService", () => {
       };
 
       await svc.resolveProvider();
+      // A pre-existing streak is cleared by the pause: the prior failures were
+      // likely the same rate limit before the gate caught it, so carrying them
+      // over would leave the breaker on a hair trigger after the pause.
+      svc.consecutiveErrors = 2;
       svc.lastCheckAt = Number.NEGATIVE_INFINITY;
       await svc.checkForPRs();
 
-      // Rate-limit pause, not circuit breaker: no error count, no clear,
-      // polling deferred until the limit resets.
+      // Rate-limit pause, not circuit breaker: streak cleared, no clear event,
+      // no breaker trip or toast, polling deferred until the limit resets.
       expect(svc.consecutiveErrors).toBe(0);
       expect(svc.nextRetryAt).toBeGreaterThan(Date.now());
       expect(cleared).toHaveLength(0);
+      expect(pullRequestService.getStatus().detectionStateTripped).toBe(false);
+      expect(notifications).toHaveLength(0);
 
-      unsubscribe();
+      unsubCleared();
+      unsubNotify();
       pullRequestService.destroy();
     });
   });

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -1271,6 +1271,271 @@ describe("PullRequestService", () => {
     pullRequestService.destroy();
   });
 
+  describe("transient lookup failures (#9994)", () => {
+    it("preserves PR rows and counts one error when a per-branch lookup fails transiently", async () => {
+      vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+      mockForgeProviderResolved(async () => {
+        throw new Error("network timeout");
+      });
+
+      const { pullRequestService } = await import("../PullRequestService.js");
+      const { events } = await import("../events.js");
+
+      const cleared: DaintreeEventMap["sys:pr:cleared"][] = [];
+      const unsubscribe = events.on("sys:pr:cleared", (payload) => cleared.push(payload));
+
+      pullRequestService.initialize("/repo");
+      events.emit(
+        "sys:worktree:update",
+        makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+      );
+
+      const svc = pullRequestService as unknown as {
+        checkForPRs: () => Promise<void>;
+        resolveProvider: () => Promise<void>;
+        consecutiveErrors: number;
+        lastCheckAt: number;
+      };
+
+      await svc.resolveProvider();
+      svc.lastCheckAt = Number.NEGATIVE_INFINITY;
+      await svc.checkForPRs();
+
+      // Transient failure is NOT authoritative absence: no spurious clear,
+      // and the failure counts toward the circuit breaker.
+      expect(cleared).toHaveLength(0);
+      expect(svc.consecutiveErrors).toBe(1);
+
+      unsubscribe();
+      pullRequestService.destroy();
+    });
+
+    it("trips the circuit breaker after three consecutive failing cycles", async () => {
+      vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+      mockForgeProviderResolved(async () => {
+        throw new Error("network timeout");
+      });
+
+      const { pullRequestService } = await import("../PullRequestService.js");
+      const { events } = await import("../events.js");
+
+      const detectionStates: DaintreeEventMap["sys:pr:detection-state"][] = [];
+      const unsubscribe = events.on("sys:pr:detection-state", (payload) =>
+        detectionStates.push(payload)
+      );
+
+      pullRequestService.initialize("/repo");
+      events.emit(
+        "sys:worktree:update",
+        makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+      );
+
+      const svc = pullRequestService as unknown as {
+        checkForPRs: () => Promise<void>;
+        resolveProvider: () => Promise<void>;
+        consecutiveErrors: number;
+        lastCheckAt: number;
+      };
+
+      await svc.resolveProvider();
+      for (let cycle = 0; cycle < 3; cycle++) {
+        svc.lastCheckAt = Number.NEGATIVE_INFINITY;
+        await svc.checkForPRs();
+      }
+
+      expect(svc.consecutiveErrors).toBe(3);
+      expect(detectionStates).toContainEqual(expect.objectContaining({ tripped: true }));
+
+      unsubscribe();
+      pullRequestService.destroy();
+    });
+
+    it("resets consecutiveErrors once a cycle completes without lookup failures", async () => {
+      vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+      let failing = true;
+      mockForgeProviderResolved(async () => {
+        if (failing) throw new Error("network timeout");
+        return makeMockForgePR();
+      });
+
+      const { pullRequestService } = await import("../PullRequestService.js");
+      const { events } = await import("../events.js");
+
+      const detected: DaintreeEventMap["sys:pr:detected"][] = [];
+      const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
+
+      pullRequestService.initialize("/repo");
+      events.emit(
+        "sys:worktree:update",
+        makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+      );
+
+      const svc = pullRequestService as unknown as {
+        checkForPRs: () => Promise<void>;
+        resolveProvider: () => Promise<void>;
+        consecutiveErrors: number;
+        lastCheckAt: number;
+      };
+
+      await svc.resolveProvider();
+      for (let cycle = 0; cycle < 2; cycle++) {
+        svc.lastCheckAt = Number.NEGATIVE_INFINITY;
+        await svc.checkForPRs();
+      }
+      expect(svc.consecutiveErrors).toBe(2);
+
+      failing = false;
+      svc.lastCheckAt = Number.NEGATIVE_INFINITY;
+      await svc.checkForPRs();
+
+      expect(svc.consecutiveErrors).toBe(0);
+      expect(detected).toHaveLength(1);
+
+      unsubscribe();
+      pullRequestService.destroy();
+    });
+
+    it("clears the row and deletes the detectedPRs entry on a confirmed no-PR result", async () => {
+      vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+      let prGone = false;
+      mockForgeProviderResolved(async () => (prGone ? null : makeMockForgePR()));
+
+      const { pullRequestService } = await import("../PullRequestService.js");
+      const { events } = await import("../events.js");
+
+      const cleared: DaintreeEventMap["sys:pr:cleared"][] = [];
+      const unsubscribe = events.on("sys:pr:cleared", (payload) => cleared.push(payload));
+
+      pullRequestService.initialize("/repo");
+      events.emit(
+        "sys:worktree:update",
+        makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+      );
+
+      await pullRequestService.refresh();
+      const svc = pullRequestService as unknown as {
+        detectedPRs: Map<string, unknown>;
+        consecutiveErrors: number;
+      };
+      expect(svc.detectedPRs.has("wt-1")).toBe(true);
+
+      // refresh() empties resolvedWorktrees but keeps detectedPRs, so the
+      // confirmed-absent path must delete the stale entry alongside the clear
+      // (otherwise a PENDING entry keeps the revalidation boost armed).
+      prGone = true;
+      await pullRequestService.refresh();
+
+      expect(cleared).toHaveLength(1);
+      expect(cleared[0]).toMatchObject({ worktreeId: "wt-1", branchName: "feature/a" });
+      expect(svc.detectedPRs.has("wt-1")).toBe(false);
+      expect(svc.consecutiveErrors).toBe(0);
+
+      unsubscribe();
+      pullRequestService.destroy();
+    });
+
+    it("handles a mixed cycle: detected, confirmed-absent, and failed branches independently", async () => {
+      vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+      const mockImpl = mockForgeProviderResolved();
+      mockImpl.findPRByBranch = vi.fn(async (_repo: RepoRef, branch: string) => {
+        if (branch === "feature/a") return makeMockForgePR({ number: 1, headRef: branch });
+        if (branch === "feature/b") return null;
+        throw new Error("socket hang up");
+      });
+
+      const { pullRequestService } = await import("../PullRequestService.js");
+      const { events } = await import("../events.js");
+
+      const detected: DaintreeEventMap["sys:pr:detected"][] = [];
+      const cleared: DaintreeEventMap["sys:pr:cleared"][] = [];
+      const unsubDetected = events.on("sys:pr:detected", (payload) => detected.push(payload));
+      const unsubCleared = events.on("sys:pr:cleared", (payload) => cleared.push(payload));
+
+      pullRequestService.initialize("/repo");
+      events.emit(
+        "sys:worktree:update",
+        makeWorktreeSnapshot({ worktreeId: "wt-a", branch: "feature/a" })
+      );
+      events.emit(
+        "sys:worktree:update",
+        makeWorktreeSnapshot({ worktreeId: "wt-b", branch: "feature/b" })
+      );
+      events.emit(
+        "sys:worktree:update",
+        makeWorktreeSnapshot({ worktreeId: "wt-c", branch: "feature/c" })
+      );
+
+      const svc = pullRequestService as unknown as {
+        checkForPRs: () => Promise<void>;
+        resolveProvider: () => Promise<void>;
+        consecutiveErrors: number;
+        lastCheckAt: number;
+      };
+
+      await svc.resolveProvider();
+      svc.lastCheckAt = Number.NEGATIVE_INFINITY;
+      await svc.checkForPRs();
+
+      // Detected branch resolves, confirmed-absent branch clears, failed
+      // branch is skipped entirely — and the cycle counts a single error.
+      expect(detected.map((d) => d.worktreeId)).toContain("wt-a");
+      expect(detected.map((d) => d.worktreeId)).not.toContain("wt-c");
+      expect(cleared).toHaveLength(1);
+      expect(cleared[0].worktreeId).toBe("wt-b");
+      expect(svc.consecutiveErrors).toBe(1);
+
+      unsubDetected();
+      unsubCleared();
+      pullRequestService.destroy();
+    });
+
+    it("routes mid-cycle failures to the rate-limit pause instead of the breaker when a limit is active", async () => {
+      vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+      const mockImpl = mockForgeProviderResolved(async () => {
+        throw new Error("API rate limit exceeded");
+      });
+      // First gate consult (top of cycle) sees budget remaining; the
+      // post-error consult sees the exhausted limit that landed mid-cycle.
+      mockImpl.getRateLimit = vi
+        .fn()
+        .mockResolvedValueOnce({ limit: 5000, remaining: 100, resetAt: null })
+        .mockResolvedValue({ limit: 5000, remaining: 0, resetAt: Date.now() + 60_000 });
+
+      const { pullRequestService } = await import("../PullRequestService.js");
+      const { events } = await import("../events.js");
+
+      const cleared: DaintreeEventMap["sys:pr:cleared"][] = [];
+      const unsubscribe = events.on("sys:pr:cleared", (payload) => cleared.push(payload));
+
+      pullRequestService.initialize("/repo");
+      events.emit(
+        "sys:worktree:update",
+        makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+      );
+
+      const svc = pullRequestService as unknown as {
+        checkForPRs: () => Promise<void>;
+        resolveProvider: () => Promise<void>;
+        consecutiveErrors: number;
+        nextRetryAt: number;
+        lastCheckAt: number;
+      };
+
+      await svc.resolveProvider();
+      svc.lastCheckAt = Number.NEGATIVE_INFINITY;
+      await svc.checkForPRs();
+
+      // Rate-limit pause, not circuit breaker: no error count, no clear,
+      // polling deferred until the limit resets.
+      expect(svc.consecutiveErrors).toBe(0);
+      expect(svc.nextRetryAt).toBeGreaterThan(Date.now());
+      expect(cleared).toHaveLength(0);
+
+      unsubscribe();
+      pullRequestService.destroy();
+    });
+  });
+
   it("no-ops when no forge provider is resolved (null linkage, no toast, no error)", async () => {
     const clearPRCaches = vi.fn();
     vi.doMock("../GitHubService.js", () => ({ clearPRCaches }));


### PR DESCRIPTION
## Summary

- `prByBranchLoader`'s per-branch fallback collapsed all errors to `null` via `.catch(() => null)`, so transient failures (timeouts, network errors, rate-limit blocks) were treated as authoritative "no PR" responses. This triggered spurious `sys:pr:cleared` events that wiped valid PR rows from the worktree dashboard.
- Because all failures were absorbed inside the loader, `handleError` was unreachable from the polling path: `consecutiveErrors` never incremented, the 3-error circuit breaker never tripped, backoff never engaged, and `sys:pr:detection-state` never fired.
- `checkForPRs`'s confirmed-clear path left stale `detectedPRs` entries behind, keeping the 30s revalidation boost armed indefinitely.

Resolves #9994

## Changes

All changes are in `electron/services/PullRequestService.ts`:

- Branch loader fallback now surfaces rejections as per-key `Error`s, matching `prByNumberLoader`'s transient-vs-not-found contract.
- `resolvePRsForBranches` returns `{ branch, pr, error }` tuples. "BatchLoader disposed" rejections are absorbed (stale-provider cycle-discard guard); real failures propagate.
- `checkForPRs` skips failed branches (rows preserved) and routes failures to `handleError` once per cycle. Re-consults the rate-limit gate first so a mid-cycle 429 pauses via the `rateLimit` path instead of counting toward the breaker.
- `checkRateLimitGate` returns `{ kind, resumeAt } | null`, matching `handleError`'s marker shape.
- Confirmed clears now delete the `detectedPRs` entry, disarming the revalidation boost.
- Rate-limit pauses clear the error streak. Issue-title-only cycles no longer reset a PR-lookup error streak.

## Testing

10 new cases added in `electron/services/__tests__/PullRequestService.test.ts` under `describe("transient lookup failures (#9994)")`. All 53 tests pass. Typecheck, lint, format, and IPC/channel guards are clean.