### PR TITLE
fix(dock): wire up resizable popover height

### DIFF
--- a/e2e/full/panels/core-dock-height-persistence.spec.ts
+++ b/e2e/full/panels/core-dock-height-persistence.spec.ts
@@ -103,3 +103,71 @@ test.describe.serial("Persistence: Dock popover height across restart", () => {
     await expect.poll(() => getDockedPopoverHeight(w2), { timeout: T_LONG }).toBe(PERSISTED_HEIGHT);
   });
 });
+
+test.describe.serial("UI: Dock popover drag resize", () => {
+  let userDataDir: string;
+  let fixtureDir: string;
+  let fixtureCleanup: () => void;
+  let ctx: AppContext | null = null;
+
+  test.beforeAll(async () => {
+    userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-e2e-dock-resize-"));
+    ({ dir: fixtureDir, cleanup: fixtureCleanup } = createFixtureRepo({ name: "dock-resize" }));
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) {
+      const pid = ctx.app.process().pid;
+      await closeApp(ctx.app);
+      if (pid) await waitForProcessExit(pid).catch(() => {});
+      ctx = null;
+    }
+    removePathSync(userDataDir);
+    fixtureCleanup?.();
+  });
+
+  test("dragging the top-edge handle grows the popover and persists the height", async () => {
+    ctx = await launchApp({ userDataDir });
+    let { window: w } = ctx;
+    const { app } = ctx;
+
+    w = await openAndOnboardProject(app, w, fixtureDir, "Dock Resize");
+
+    // Dock a terminal, then open its popover.
+    await openTerminal(w);
+    const firstGridPanel = getFirstGridPanel(w);
+    await firstGridPanel.hover();
+    await firstGridPanel.locator(SEL.panel.minimize).click();
+    await expect.poll(() => getDockPanelCount(w), { timeout: T_MEDIUM }).toBe(1);
+
+    await w.locator("[data-dock-item]").first().click();
+
+    const handle = w.locator(SEL.panel.dockPopoverResizeHandle);
+    await handle.waitFor({ state: "visible", timeout: T_MEDIUM });
+
+    // offsetParent of the absolutely-positioned handle is the popover container,
+    // so its height tracks the rendered popover height.
+    const heightOf = () =>
+      handle.evaluate(
+        (el) => (el.offsetParent as HTMLElement | null)?.getBoundingClientRect().height ?? 0
+      );
+
+    const before = await heightOf();
+    expect(before).toBeGreaterThan(0);
+
+    // Drag the handle upward — the dock is at the bottom so up means taller.
+    const box = await handle.boundingBox();
+    if (!box) throw new Error("resize handle has no bounding box");
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+    await w.mouse.move(cx, cy);
+    await w.mouse.down();
+    await w.mouse.move(cx, cy - 120, { steps: 12 });
+    await w.mouse.up();
+
+    await expect.poll(heightOf, { timeout: T_MEDIUM }).toBeGreaterThan(before + 40);
+
+    // The committed height is persisted through the same IPC pipeline.
+    await expect.poll(() => getDockedPopoverHeight(w), { timeout: T_MEDIUM }).toBeGreaterThan(500);
+  });
+});

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -82,6 +82,7 @@ export const SEL = {
     restartConfirm: '[data-testid="panel-restart-confirm"]',
     tabList: '[role="tablist"][aria-label="Panel tabs"]',
     tab: '[role="tab"]',
+    dockPopoverResizeHandle: '[data-testid="dock-popover-resize-handle"]',
   },
   terminal: {
     xtermRows: ".xterm-screen",

--- a/src/components/Layout/DockPopoverResizeHandle.tsx
+++ b/src/components/Layout/DockPopoverResizeHandle.tsx
@@ -17,14 +17,18 @@ export function DockPopoverResizeHandle({ handleProps, isResizing }: Props) {
       {...handleProps}
       className={cn(
         "group/resize absolute top-0 inset-x-0 h-2 z-20 flex items-center justify-center cursor-row-resize",
-        "hover:bg-overlay-soft transition-colors focus-visible:outline-hidden focus-visible:bg-overlay-medium focus-visible:ring-1 focus-visible:ring-daintree-accent/50",
+        // Neutral hover/focus differentiation — the accent is reserved for
+        // load-bearing focus anchors, not a secondary resize affordance
+        // (Accent Color Restraint). Keyboard focus is conveyed by the lifted
+        // indicator line plus the neutral overlay.
+        "hover:bg-overlay-soft transition-colors focus-visible:outline-hidden focus-visible:bg-overlay-medium",
         isResizing && "bg-overlay-medium"
       )}
     >
       <div
         className={cn(
           "w-8 h-px rounded-full transition-[height] duration-150 delay-100 group-hover/resize:h-0.5",
-          "bg-daintree-text/20 group-hover/resize:bg-daintree-text/35 group-focus-visible/resize:bg-daintree-accent",
+          "bg-daintree-text/20 group-hover/resize:bg-daintree-text/35 group-focus-visible/resize:bg-daintree-text/60 group-focus-visible/resize:h-0.5",
           isResizing && "bg-daintree-text/50"
         )}
       />

--- a/src/components/Layout/DockPopoverResizeHandle.tsx
+++ b/src/components/Layout/DockPopoverResizeHandle.tsx
@@ -1,0 +1,33 @@
+import { cn } from "@/lib/utils";
+import type { DockPopoverResizeHandleProps } from "./useDockPopoverResize";
+
+interface Props {
+  handleProps: DockPopoverResizeHandleProps;
+  isResizing: boolean;
+}
+
+/**
+ * Top-edge drag strip for resizing a dock popover. Anchored to the top of the
+ * (positioned) PopoverContent; dragging it upward grows the bottom-anchored
+ * popover. Visual idiom mirrors the Sidebar resize handle, rotated horizontal.
+ */
+export function DockPopoverResizeHandle({ handleProps, isResizing }: Props) {
+  return (
+    <div
+      {...handleProps}
+      className={cn(
+        "group/resize absolute top-0 inset-x-0 h-2 z-20 flex items-center justify-center cursor-row-resize",
+        "hover:bg-overlay-soft transition-colors focus-visible:outline-hidden focus-visible:bg-overlay-medium focus-visible:ring-1 focus-visible:ring-daintree-accent/50",
+        isResizing && "bg-overlay-medium"
+      )}
+    >
+      <div
+        className={cn(
+          "w-8 h-px rounded-full transition-[height] duration-150 delay-100 group-hover/resize:h-0.5",
+          "bg-daintree-text/20 group-hover/resize:bg-daintree-text/35 group-focus-visible/resize:bg-daintree-accent",
+          isResizing && "bg-daintree-text/50"
+        )}
+      />
+    </div>
+  );
+}

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -43,6 +43,8 @@ import {
 import { TerminalRefreshTier } from "@/types";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { useDockPanelPortal } from "./dockPanelPortalContext";
+import { useDockPopoverResize } from "./useDockPopoverResize";
+import { DockPopoverResizeHandle } from "./DockPopoverResizeHandle";
 import {
   useDockBlockedState,
   getDockDisplayAgentState,
@@ -499,6 +501,18 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   const displayAgentState = getTerminalAgentDisplayState(activeChrome, agentState);
   const StateIcon = displayAgentState ? getEffectiveStateIcon(displayAgentState) : null;
 
+  // Re-fit the active tab's terminal once a resize gesture settles on a new height.
+  const { height: popoverHeight, isResizing, handleProps } = useDockPopoverResize(() => {
+    if (!activePanelId) return;
+    requestAnimationFrame(() => {
+      try {
+        terminalInstanceService.fit(activePanelId);
+      } catch {
+        // fit() guards zero-dimension cases internally; ignore transient throws.
+      }
+    });
+  });
+
   return (
     <DockPopoverChildProvider>
       <Popover open={isOpen} onOpenChange={handleOpenChange}>
@@ -595,7 +609,8 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
         </TerminalContextMenu>
 
         <PopoverContent
-          className="w-[700px] max-w-[90vw] h-[500px] max-h-[80vh] p-0 bg-daintree-bg/95 backdrop-blur-sm border border-[var(--border-dock-popup)] shadow-[var(--shadow-dock-panel-popover)] rounded-[var(--radius-lg)] overflow-hidden"
+          className="w-[700px] max-w-[90vw] max-h-[80vh] p-0 bg-daintree-bg/95 backdrop-blur-sm border border-[var(--border-dock-popup)] shadow-[var(--shadow-dock-panel-popover)] rounded-[var(--radius-lg)] overflow-hidden"
+          style={{ height: popoverHeight }}
           side="top"
           align="start"
           sideOffset={10}
@@ -610,6 +625,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
             event.preventDefault();
           }}
         >
+          <DockPopoverResizeHandle handleProps={handleProps} isResizing={isResizing} />
           {/* Tab bar at top of popover */}
           <DndContext
             sensors={tabSensors}

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -473,6 +473,20 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
     );
   }, [panels, agentSettingsAll, ccrPresetsByAgent, projectPresetsByAgent]);
 
+  // Re-fit the active tab's terminal once a resize gesture settles on a new
+  // height. Declared before the early return below so the hook order stays
+  // stable when the group transiently empties (Rules of Hooks).
+  const { height: popoverHeight, isResizing, handleProps } = useDockPopoverResize(() => {
+    if (!activePanelId) return;
+    requestAnimationFrame(() => {
+      try {
+        terminalInstanceService.fit(activePanelId);
+      } catch {
+        // fit() guards zero-dimension cases internally; ignore transient throws.
+      }
+    });
+  });
+
   if (!activePanel || panels.length === 0) {
     return null;
   }
@@ -500,18 +514,6 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   const displayTitle = getBaseTitle(activePanel.title);
   const displayAgentState = getTerminalAgentDisplayState(activeChrome, agentState);
   const StateIcon = displayAgentState ? getEffectiveStateIcon(displayAgentState) : null;
-
-  // Re-fit the active tab's terminal once a resize gesture settles on a new height.
-  const { height: popoverHeight, isResizing, handleProps } = useDockPopoverResize(() => {
-    if (!activePanelId) return;
-    requestAnimationFrame(() => {
-      try {
-        terminalInstanceService.fit(activePanelId);
-      } catch {
-        // fit() guards zero-dimension cases internally; ignore transient throws.
-      }
-    });
-  });
 
   return (
     <DockPopoverChildProvider>
@@ -637,7 +639,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
           >
             <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
               <LayoutGroup id={`dock-tabs-${group.id}`}>
-                <div className="group flex items-stretch border-b border-divider bg-daintree-sidebar shrink-0">
+                <div className="group flex items-stretch border-b border-divider bg-daintree-sidebar shrink-0 pt-2">
                   <div
                     ref={setTabListEl}
                     className="flex items-center min-w-0 flex-1 overflow-x-auto overscroll-x-none scrollbar-none"

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -476,7 +476,11 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   // Re-fit the active tab's terminal once a resize gesture settles on a new
   // height. Declared before the early return below so the hook order stays
   // stable when the group transiently empties (Rules of Hooks).
-  const { height: popoverHeight, isResizing, handleProps } = useDockPopoverResize(() => {
+  const {
+    height: popoverHeight,
+    isResizing,
+    handleProps,
+  } = useDockPopoverResize(() => {
     if (!activePanelId) return;
     requestAnimationFrame(() => {
       try {

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -21,6 +21,8 @@ import {
 import { TerminalRefreshTier } from "@/types";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { useDockPanelPortal } from "./dockPanelPortalContext";
+import { useDockPopoverResize } from "./useDockPopoverResize";
+import { DockPopoverResizeHandle } from "./DockPopoverResizeHandle";
 import {
   getDockDisplayAgentState,
   isDockAgentStateDeprioritized,
@@ -306,6 +308,17 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   const StateIcon = displayAgentState ? getEffectiveStateIcon(displayAgentState) : null;
   const isDeprioritized = !isOpen && isDockAgentStateDeprioritized(agentState);
 
+  // Re-fit the terminal once a resize gesture settles on a new popover height.
+  const { height: popoverHeight, isResizing, handleProps } = useDockPopoverResize(() => {
+    requestAnimationFrame(() => {
+      try {
+        terminalInstanceService.fit(terminal.id);
+      } catch {
+        // fit() guards zero-dimension cases internally; ignore transient throws.
+      }
+    });
+  });
+
   return (
     <DockPopoverChildProvider>
       <Popover open={isOpen} onOpenChange={handleOpenChange}>
@@ -395,7 +408,8 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
         </div>
 
         <PopoverContent
-          className="w-[700px] max-w-[90vw] h-[500px] max-h-[80vh] p-0 bg-daintree-bg/95 backdrop-blur-sm border border-[var(--border-dock-popup)] shadow-[var(--shadow-dock-panel-popover)] rounded-[var(--radius-lg)] overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1"
+          className="w-[700px] max-w-[90vw] max-h-[80vh] p-0 bg-daintree-bg/95 backdrop-blur-sm border border-[var(--border-dock-popup)] shadow-[var(--shadow-dock-panel-popover)] rounded-[var(--radius-lg)] overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1"
+          style={{ height: popoverHeight }}
           side="top"
           align="start"
           sideOffset={10}
@@ -411,6 +425,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
           }}
         >
           <div className="relative w-full h-full group">
+            <DockPopoverResizeHandle handleProps={handleProps} isResizing={isResizing} />
             {/* Portal target - content is rendered in DockPanelOffscreenContainer and portaled here */}
             <div
               ref={portalContainerRef}

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -309,7 +309,11 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   const isDeprioritized = !isOpen && isDockAgentStateDeprioritized(agentState);
 
   // Re-fit the terminal once a resize gesture settles on a new popover height.
-  const { height: popoverHeight, isResizing, handleProps } = useDockPopoverResize(() => {
+  const {
+    height: popoverHeight,
+    isResizing,
+    handleProps,
+  } = useDockPopoverResize(() => {
     requestAnimationFrame(() => {
       try {
         terminalInstanceService.fit(terminal.id);

--- a/src/components/Layout/__tests__/useDockPopoverResize.test.tsx
+++ b/src/components/Layout/__tests__/useDockPopoverResize.test.tsx
@@ -17,7 +17,10 @@ import {
 
 const maxHeight = () => Math.round(window.innerHeight * POPOVER_MAX_HEIGHT_RATIO);
 
-function mouseDownAt(handleProps: ReturnType<typeof useDockPopoverResize>["handleProps"], y: number) {
+function mouseDownAt(
+  handleProps: ReturnType<typeof useDockPopoverResize>["handleProps"],
+  y: number
+) {
   act(() => {
     handleProps.onMouseDown({
       preventDefault: vi.fn(),

--- a/src/components/Layout/__tests__/useDockPopoverResize.test.tsx
+++ b/src/components/Layout/__tests__/useDockPopoverResize.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, cleanup } from "@testing-library/react";
 
 // Keep persistence IPC out of the unit under test.
 vi.mock("@/clients", () => ({
@@ -19,7 +19,11 @@ const maxHeight = () => Math.round(window.innerHeight * POPOVER_MAX_HEIGHT_RATIO
 
 function mouseDownAt(handleProps: ReturnType<typeof useDockPopoverResize>["handleProps"], y: number) {
   act(() => {
-    handleProps.onMouseDown({ preventDefault: vi.fn(), clientY: y } as unknown as React.MouseEvent);
+    handleProps.onMouseDown({
+      preventDefault: vi.fn(),
+      clientY: y,
+      button: 0,
+    } as unknown as React.MouseEvent);
   });
 }
 
@@ -45,6 +49,14 @@ describe("useDockPopoverResize", () => {
   });
 
   afterEach(() => {
+    // Release any in-flight drag (tests that assert the live draft height never
+    // call mouseup), then unmount so the drag effect cleanup detaches its
+    // document listeners — otherwise a leaked mouseup handler fires in the next
+    // test and pollutes its assertions.
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mouseup"));
+    });
+    cleanup();
     document.body.style.cursor = "";
     document.body.style.userSelect = "";
   });
@@ -145,6 +157,61 @@ describe("useDockPopoverResize", () => {
     });
     expect(useDockStore.getState().popoverHeight).toBe(POPOVER_DEFAULT_HEIGHT);
     expect(onCommit).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not commit when the pointer is released without moving", () => {
+    // onCommit is unique to this hook instance, so it isolates this gesture from
+    // any drag listeners other tests may have left attached to document.
+    const onCommit = vi.fn();
+    const { result } = renderHook(() => useDockPopoverResize(onCommit));
+    mouseDownAt(result.current.handleProps, 500);
+    mouseUp(); // released at the same position
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(result.current.height).toBe(POPOVER_DEFAULT_HEIGHT);
+  });
+
+  it("ignores non-primary mouse buttons", () => {
+    const { result } = renderHook(() => useDockPopoverResize());
+    act(() => {
+      result.current.handleProps.onMouseDown({
+        preventDefault: vi.fn(),
+        clientY: 500,
+        button: 2, // right-click
+      } as unknown as React.MouseEvent);
+    });
+    expect(result.current.isResizing).toBe(false);
+    expect(document.body.style.cursor).toBe("");
+  });
+
+  it("does not fire onCommit when ArrowDown is pressed at the minimum", () => {
+    act(() => {
+      useDockStore.setState({ popoverHeight: POPOVER_MIN_HEIGHT });
+    });
+    const onCommit = vi.fn();
+    const { result } = renderHook(() => useDockPopoverResize(onCommit));
+    act(() => {
+      result.current.handleProps.onKeyDown({
+        key: "ArrowDown",
+        preventDefault: vi.fn(),
+      } as unknown as React.KeyboardEvent);
+    });
+    expect(useDockStore.getState().popoverHeight).toBe(POPOVER_MIN_HEIGHT);
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("ignores document mouse events after unmount mid-drag", () => {
+    const spy = vi.spyOn(useDockStore.getState(), "setPopoverHeight");
+    const onCommit = vi.fn();
+    const { result, unmount } = renderHook(() => useDockPopoverResize(onCommit));
+    mouseDownAt(result.current.handleProps, 500);
+    moveTo(400);
+    unmount();
+    spy.mockClear();
+    moveTo(300);
+    mouseUp();
+    expect(spy).not.toHaveBeenCalled();
+    expect(onCommit).not.toHaveBeenCalled();
+    spy.mockRestore();
   });
 
   it("resets to the default height on double-click", () => {

--- a/src/components/Layout/__tests__/useDockPopoverResize.test.tsx
+++ b/src/components/Layout/__tests__/useDockPopoverResize.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+// Keep persistence IPC out of the unit under test.
+vi.mock("@/clients", () => ({
+  appClient: { setState: vi.fn().mockResolvedValue(undefined) },
+}));
+
+import { useDockPopoverResize } from "../useDockPopoverResize";
+import {
+  useDockStore,
+  POPOVER_DEFAULT_HEIGHT,
+  POPOVER_MIN_HEIGHT,
+  POPOVER_MAX_HEIGHT_RATIO,
+} from "@/store/dockStore";
+
+const maxHeight = () => Math.round(window.innerHeight * POPOVER_MAX_HEIGHT_RATIO);
+
+function mouseDownAt(handleProps: ReturnType<typeof useDockPopoverResize>["handleProps"], y: number) {
+  act(() => {
+    handleProps.onMouseDown({ preventDefault: vi.fn(), clientY: y } as unknown as React.MouseEvent);
+  });
+}
+
+function moveTo(y: number) {
+  act(() => {
+    document.dispatchEvent(new MouseEvent("mousemove", { clientY: y }));
+  });
+}
+
+function mouseUp() {
+  act(() => {
+    document.dispatchEvent(new MouseEvent("mouseup"));
+  });
+}
+
+describe("useDockPopoverResize", () => {
+  beforeEach(() => {
+    // jsdom defaults innerHeight to 768; pin it so clamp math is deterministic.
+    Object.defineProperty(window, "innerHeight", { value: 1000, configurable: true });
+    act(() => {
+      useDockStore.setState({ popoverHeight: POPOVER_DEFAULT_HEIGHT });
+    });
+  });
+
+  afterEach(() => {
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+  });
+
+  it("drag up (smaller clientY) increases height", () => {
+    const { result } = renderHook(() => useDockPopoverResize());
+    mouseDownAt(result.current.handleProps, 500);
+    moveTo(400); // moved up 100px
+    expect(result.current.height).toBe(POPOVER_DEFAULT_HEIGHT + 100);
+  });
+
+  it("drag down (larger clientY) decreases height", () => {
+    const { result } = renderHook(() => useDockPopoverResize());
+    mouseDownAt(result.current.handleProps, 500);
+    moveTo(600); // moved down 100px
+    expect(result.current.height).toBe(POPOVER_DEFAULT_HEIGHT - 100);
+  });
+
+  it("clamps to the minimum height", () => {
+    const { result } = renderHook(() => useDockPopoverResize());
+    mouseDownAt(result.current.handleProps, 500);
+    moveTo(5000); // far down — well below the minimum
+    expect(result.current.height).toBe(POPOVER_MIN_HEIGHT);
+  });
+
+  it("clamps to the viewport-relative maximum height", () => {
+    const { result } = renderHook(() => useDockPopoverResize());
+    mouseDownAt(result.current.handleProps, 500);
+    moveTo(-5000); // far up — well above the maximum
+    expect(result.current.height).toBe(window.innerHeight * POPOVER_MAX_HEIGHT_RATIO);
+  });
+
+  it("commits to the store exactly once, at mouseup", () => {
+    const spy = vi.spyOn(useDockStore.getState(), "setPopoverHeight");
+    const { result } = renderHook(() => useDockPopoverResize());
+    mouseDownAt(result.current.handleProps, 500);
+    moveTo(450);
+    moveTo(400);
+    moveTo(350);
+    // Live draft tracks the pointer, but the persisted store value has not moved.
+    expect(useDockStore.getState().popoverHeight).toBe(POPOVER_DEFAULT_HEIGHT);
+    expect(spy).not.toHaveBeenCalled();
+
+    mouseUp();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(useDockStore.getState().popoverHeight).toBe(POPOVER_DEFAULT_HEIGHT + 150);
+    spy.mockRestore();
+  });
+
+  it("invokes onCommit once the gesture settles", () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() => useDockPopoverResize(onCommit));
+    mouseDownAt(result.current.handleProps, 500);
+    moveTo(400);
+    expect(onCommit).not.toHaveBeenCalled();
+    mouseUp();
+    expect(onCommit).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores the body cursor and userSelect after a drag", () => {
+    const { result } = renderHook(() => useDockPopoverResize());
+    mouseDownAt(result.current.handleProps, 500);
+    expect(document.body.style.cursor).toBe("row-resize");
+    expect(document.body.style.userSelect).toBe("none");
+    moveTo(400);
+    mouseUp();
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
+  });
+
+  it("restores the body cursor when the popover unmounts mid-drag", () => {
+    const { result, unmount } = renderHook(() => useDockPopoverResize());
+    mouseDownAt(result.current.handleProps, 500);
+    moveTo(400);
+    expect(document.body.style.cursor).toBe("row-resize");
+    // Popover closes via Escape/outside-click before mouseup fires.
+    unmount();
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
+  });
+
+  it("steps the height with ArrowUp / ArrowDown", () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() => useDockPopoverResize(onCommit));
+    act(() => {
+      result.current.handleProps.onKeyDown({
+        key: "ArrowUp",
+        preventDefault: vi.fn(),
+      } as unknown as React.KeyboardEvent);
+    });
+    expect(useDockStore.getState().popoverHeight).toBe(POPOVER_DEFAULT_HEIGHT + 10);
+
+    act(() => {
+      result.current.handleProps.onKeyDown({
+        key: "ArrowDown",
+        preventDefault: vi.fn(),
+      } as unknown as React.KeyboardEvent);
+    });
+    expect(useDockStore.getState().popoverHeight).toBe(POPOVER_DEFAULT_HEIGHT);
+    expect(onCommit).toHaveBeenCalledTimes(2);
+  });
+
+  it("resets to the default height on double-click", () => {
+    act(() => {
+      useDockStore.setState({ popoverHeight: 420 });
+    });
+    const { result } = renderHook(() => useDockPopoverResize());
+    act(() => {
+      result.current.handleProps.onDoubleClick();
+    });
+    expect(useDockStore.getState().popoverHeight).toBe(POPOVER_DEFAULT_HEIGHT);
+  });
+
+  it("exposes accurate ARIA bounds on the handle", () => {
+    const { result } = renderHook(() => useDockPopoverResize());
+    expect(result.current.handleProps.role).toBe("separator");
+    expect(result.current.handleProps["aria-orientation"]).toBe("horizontal");
+    expect(result.current.handleProps["aria-valuemin"]).toBe(POPOVER_MIN_HEIGHT);
+    expect(result.current.handleProps["aria-valuemax"]).toBe(maxHeight());
+    expect(result.current.handleProps["aria-valuenow"]).toBe(POPOVER_DEFAULT_HEIGHT);
+  });
+});

--- a/src/components/Layout/useDockPopoverResize.ts
+++ b/src/components/Layout/useDockPopoverResize.ts
@@ -60,9 +60,6 @@ export function useDockPopoverResize(onCommit?: () => void): UseDockPopoverResiz
   // Live height while dragging; null when idle (store value is the source of truth).
   const [draftHeight, setDraftHeight] = useState<number | null>(null);
   const [isResizing, setIsResizing] = useState(false);
-  // Mirrors `isResizing` synchronously so the unmount-only cleanup effect can
-  // detect a mid-drag teardown without relying on stale closure state.
-  const isResizingRef = useRef(false);
 
   const dragStartYRef = useRef(0);
   const dragStartHeightRef = useRef(popoverHeight);
@@ -77,22 +74,25 @@ export function useDockPopoverResize(onCommit?: () => void): UseDockPopoverResiz
 
   const startResizing = useCallback(
     (e: React.MouseEvent) => {
+      // Only the primary button drives a resize; right/middle-click should fall
+      // through to the context menu rather than locking the row-resize cursor.
+      if (e.button !== 0) return;
       e.preventDefault();
       dragStartYRef.current = e.clientY;
       dragStartHeightRef.current = popoverHeight;
       draftHeightRef.current = popoverHeight;
       setDraftHeight(popoverHeight);
-      isResizingRef.current = true;
       setIsResizing(true);
-      document.body.style.cursor = "row-resize";
-      document.body.style.userSelect = "none";
     },
     [popoverHeight]
   );
 
-  // Attach document listeners for the duration of the drag. Resolved inside the
-  // effect (not via React handlers on the strip) so the drag continues even when
-  // the pointer leaves the thin handle.
+  // Own the drag for as long as `isResizing` holds. Document listeners (not React
+  // handlers on the thin strip) keep the drag alive when the pointer leaves the
+  // handle. The body cursor/userSelect lock lives here too — set on attach,
+  // cleared on cleanup — so it is restored on every teardown path, including an
+  // unmount mid-drag when the popover closes via Escape/outside-click before
+  // `mouseup` ever fires.
   useEffect(() => {
     if (!isResizing) return;
 
@@ -104,55 +104,56 @@ export function useDockPopoverResize(onCommit?: () => void): UseDockPopoverResiz
     };
 
     const onUp = () => {
-      setPopoverHeight(draftHeightRef.current);
+      const moved = draftHeightRef.current !== dragStartHeightRef.current;
       setDraftHeight(null);
-      isResizingRef.current = false;
       setIsResizing(false);
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-      onCommitRef.current?.();
+      // A click without drag (or a drag that nets back to the start height)
+      // shouldn't fire a persistence write or a terminal re-fit.
+      if (moved) {
+        setPopoverHeight(draftHeightRef.current);
+        onCommitRef.current?.();
+      }
     };
 
     document.addEventListener("mousemove", onMove);
     document.addEventListener("mouseup", onUp);
+    document.body.style.cursor = "row-resize";
+    document.body.style.userSelect = "none";
     return () => {
       document.removeEventListener("mousemove", onMove);
       document.removeEventListener("mouseup", onUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
     };
   }, [isResizing, setPopoverHeight]);
 
-  // Unmount-mid-drag guard: if the popover closes (Escape / outside-click) while
-  // a drag is live, `mouseup` never fires and the row-resize cursor + userSelect
-  // lock would stay stuck for the rest of the session. Reset on teardown.
-  useEffect(() => {
-    return () => {
-      if (isResizingRef.current) {
-        isResizingRef.current = false;
-        document.body.style.cursor = "";
-        document.body.style.userSelect = "";
-      }
-    };
-  }, []);
+  const commit = useCallback(
+    (next: number) => {
+      const clamped = clampHeight(next);
+      // No-op at the clamp boundary — don't churn the persistence IPC or re-fit.
+      if (clamped === popoverHeight) return;
+      setPopoverHeight(clamped);
+      onCommitRef.current?.();
+    },
+    [popoverHeight, setPopoverHeight]
+  );
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === "ArrowUp") {
         e.preventDefault();
-        setPopoverHeight(popoverHeight + RESIZE_STEP);
-        onCommitRef.current?.();
+        commit(popoverHeight + RESIZE_STEP);
       } else if (e.key === "ArrowDown") {
         e.preventDefault();
-        setPopoverHeight(popoverHeight - RESIZE_STEP);
-        onCommitRef.current?.();
+        commit(popoverHeight - RESIZE_STEP);
       }
     },
-    [popoverHeight, setPopoverHeight]
+    [popoverHeight, commit]
   );
 
   const handleDoubleClick = useCallback(() => {
-    setPopoverHeight(POPOVER_DEFAULT_HEIGHT);
-    onCommitRef.current?.();
-  }, [setPopoverHeight]);
+    commit(POPOVER_DEFAULT_HEIGHT);
+  }, [commit]);
 
   const height = draftHeight ?? popoverHeight;
 

--- a/src/components/Layout/useDockPopoverResize.ts
+++ b/src/components/Layout/useDockPopoverResize.ts
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useDockStore,
+  POPOVER_DEFAULT_HEIGHT,
+  POPOVER_MIN_HEIGHT,
+  POPOVER_MAX_HEIGHT_RATIO,
+} from "@/store/dockStore";
+
+const RESIZE_STEP = 10;
+
+/**
+ * Clamp a candidate height to the same window the store uses. Applied during
+ * the live drag so the popover never visually overshoots its bounds; the store
+ * re-clamps on the committed write at mouseup.
+ */
+function clampHeight(height: number): number {
+  const max = window.innerHeight * POPOVER_MAX_HEIGHT_RATIO;
+  return Math.min(Math.max(height, POPOVER_MIN_HEIGHT), max);
+}
+
+export interface DockPopoverResizeHandleProps {
+  role: "separator";
+  "aria-orientation": "horizontal";
+  "aria-label": string;
+  "aria-valuenow": number;
+  "aria-valuemin": number;
+  "aria-valuemax": number;
+  tabIndex: number;
+  "data-testid": string;
+  onMouseDown: (e: React.MouseEvent) => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+  onDoubleClick: () => void;
+}
+
+export interface UseDockPopoverResizeResult {
+  /** Height (px) to apply to the popover container — live during a drag, store value otherwise. */
+  height: number;
+  isResizing: boolean;
+  /** Spread onto the top-edge resize handle element. */
+  handleProps: DockPopoverResizeHandleProps;
+}
+
+/**
+ * Drives a top-edge drag-resize handle for the bottom-anchored dock popovers.
+ * The dock sits at the bottom of the window and its popover opens upward, so
+ * dragging the handle up (smaller clientY) grows the popover.
+ *
+ * Mirrors the Sidebar resize idiom: a `mousedown` captures the drag origin and
+ * attaches document `mousemove`/`mouseup` listeners; the live height stays in
+ * local state for fluid feedback and is committed to the store exactly once at
+ * `mouseup` so the persistence IPC fires per-gesture, not per-frame.
+ *
+ * `onCommit` runs after each committed height change (drag end + keyboard) so the
+ * caller can re-fit the affected terminal once the new height is settled.
+ */
+export function useDockPopoverResize(onCommit?: () => void): UseDockPopoverResizeResult {
+  const popoverHeight = useDockStore((s) => s.popoverHeight);
+  const setPopoverHeight = useDockStore((s) => s.setPopoverHeight);
+
+  // Live height while dragging; null when idle (store value is the source of truth).
+  const [draftHeight, setDraftHeight] = useState<number | null>(null);
+  const [isResizing, setIsResizing] = useState(false);
+  // Mirrors `isResizing` synchronously so the unmount-only cleanup effect can
+  // detect a mid-drag teardown without relying on stale closure state.
+  const isResizingRef = useRef(false);
+
+  const dragStartYRef = useRef(0);
+  const dragStartHeightRef = useRef(popoverHeight);
+  const draftHeightRef = useRef(popoverHeight);
+
+  // Mirror onCommit so the empty-dep cleanup effect and listener effect can call
+  // the latest callback without re-subscribing.
+  const onCommitRef = useRef(onCommit);
+  useEffect(() => {
+    onCommitRef.current = onCommit;
+  });
+
+  const startResizing = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      dragStartYRef.current = e.clientY;
+      dragStartHeightRef.current = popoverHeight;
+      draftHeightRef.current = popoverHeight;
+      setDraftHeight(popoverHeight);
+      isResizingRef.current = true;
+      setIsResizing(true);
+      document.body.style.cursor = "row-resize";
+      document.body.style.userSelect = "none";
+    },
+    [popoverHeight]
+  );
+
+  // Attach document listeners for the duration of the drag. Resolved inside the
+  // effect (not via React handlers on the strip) so the drag continues even when
+  // the pointer leaves the thin handle.
+  useEffect(() => {
+    if (!isResizing) return;
+
+    const onMove = (e: MouseEvent) => {
+      const delta = dragStartYRef.current - e.clientY;
+      const next = clampHeight(dragStartHeightRef.current + delta);
+      draftHeightRef.current = next;
+      setDraftHeight(next);
+    };
+
+    const onUp = () => {
+      setPopoverHeight(draftHeightRef.current);
+      setDraftHeight(null);
+      isResizingRef.current = false;
+      setIsResizing(false);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      onCommitRef.current?.();
+    };
+
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+    return () => {
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+    };
+  }, [isResizing, setPopoverHeight]);
+
+  // Unmount-mid-drag guard: if the popover closes (Escape / outside-click) while
+  // a drag is live, `mouseup` never fires and the row-resize cursor + userSelect
+  // lock would stay stuck for the rest of the session. Reset on teardown.
+  useEffect(() => {
+    return () => {
+      if (isResizingRef.current) {
+        isResizingRef.current = false;
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+      }
+    };
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setPopoverHeight(popoverHeight + RESIZE_STEP);
+        onCommitRef.current?.();
+      } else if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setPopoverHeight(popoverHeight - RESIZE_STEP);
+        onCommitRef.current?.();
+      }
+    },
+    [popoverHeight, setPopoverHeight]
+  );
+
+  const handleDoubleClick = useCallback(() => {
+    setPopoverHeight(POPOVER_DEFAULT_HEIGHT);
+    onCommitRef.current?.();
+  }, [setPopoverHeight]);
+
+  const height = draftHeight ?? popoverHeight;
+
+  return {
+    height,
+    isResizing,
+    handleProps: {
+      role: "separator",
+      "aria-orientation": "horizontal",
+      "aria-label": "Resize panel",
+      "aria-valuenow": Math.round(height),
+      "aria-valuemin": POPOVER_MIN_HEIGHT,
+      "aria-valuemax": Math.round(window.innerHeight * POPOVER_MAX_HEIGHT_RATIO),
+      tabIndex: 0,
+      "data-testid": "dock-popover-resize-handle",
+      onMouseDown: startResizing,
+      onKeyDown: handleKeyDown,
+      onDoubleClick: handleDoubleClick,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

The dock popover height feature was already mostly implemented — the store, IPC, and persistence pipeline were all in place. Both popovers just had a hardcoded \`h-[500px]\` and nothing was calling \`setPopoverHeight\`, so the whole pipeline was dead plumbing.

This PR activates it.

Resolves #9930

## Changes

- New \`useDockPopoverResize\` hook — top-edge drag-resize driving \`dockStore.popoverHeight\`; live draft height during drag, committed at \`mouseup\` so persistence IPC fires per-gesture not per-frame; clamped to \`[300, innerHeight * 0.8]\`; \`ArrowUp\`/\`ArrowDown\` ±10px keyboard resize; double-click resets to default; body cursor/\`userSelect\` lock set and restored in the drag effect so it survives unmount-mid-drag
- New \`DockPopoverResizeHandle\` component — ARIA separator strip (\`role=separator\`, \`aria-orientation=horizontal\`, \`aria-valuenow/min/max\`), Tier-1 150ms hover indicator
- \`DockedTerminalItem\` and \`DockedTabGroup\` — replace hardcoded \`h-[500px]\` with \`style={{ height }}\`, render the handle, re-fit the active terminal via \`requestAnimationFrame\` on commit; tab bar gets \`pt-2\` so the handle can't intercept tab clicks; hook declared above the early return to satisfy rules-of-hooks
- \`e2e/helpers/selectors.ts\` — \`panel.dockPopoverResizeHandle\` selector added

## Testing

- 15 new unit tests in \`useDockPopoverResize.test.tsx\` covering drag, keyboard, double-click, clamp, and persistence IPC
- E2E drag test added to \`core-dock-height-persistence.spec.ts\` alongside the existing IPC persistence test
- 75 existing dock tests pass
- \`npm run check\` clean — typecheck, IPC guards, confirm-wiring, lint ratchet down 1, format