### PR TITLE
refactor(worktree): route the attach-issue flow through the forge provider

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -15,7 +15,6 @@ export const CHANNELS = {
   WORKTREE_DELETE: "worktree:delete",
   WORKTREE_ATTACH_ISSUE: "worktree:attach-issue",
   WORKTREE_DETACH_ISSUE: "worktree:detach-issue",
-  WORKTREE_GET_ISSUE_ASSOCIATION: "worktree:get-issue-association",
   WORKTREE_GET_ALL_ISSUE_ASSOCIATIONS: "worktree:get-all-issue-associations",
   WORKTREE_HOST_DISCONNECTED: "worktree:host-disconnected",
   WORKTREE_RESTART_SERVICE: "worktree:restart-service",

--- a/electron/ipc/handlers/__tests__/forgeData.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeData.handlers.test.ts
@@ -50,6 +50,7 @@ const storeMock = vi.hoisted(() => {
 vi.mock("../../../store.js", () => ({ store: storeMock }));
 
 import { registerForgeDataHandlers } from "../forgeData.js";
+import { _resetRateLimitQueuesForTest } from "../../utils.js";
 import { forgeAuditService } from "../../../services/forge/forgeAuditService.js";
 
 function findHandler(channel: string): (...args: unknown[]) => unknown {
@@ -91,6 +92,9 @@ const makePR = (n: number): PR => ({
 describe("registerForgeDataHandlers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // The handlers share a per-channel rate-limit budget (10 calls / 10s); a
+    // suite-cumulative count would make later tests fail on call volume alone.
+    _resetRateLimitQueuesForTest();
     resolveForCwdMock.mockResolvedValue({
       namespaceId: "fake.provider",
       repoRef,
@@ -350,6 +354,22 @@ describe("registerForgeDataHandlers", () => {
     // `["a,b"]` and `["a","b"]` are different queries — the JSON-tuple key keeps
     // them in separate in-flight slots instead of collapsing to one call.
     expect(fakeImpl.listIssues).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not coalesce list queries that differ only by search term", async () => {
+    fakeImpl.listIssues.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
+    registerForgeDataHandlers();
+    const handler = findHandler("forge:list-issues");
+
+    // The issue picker fires a new IPC call per debounced keystroke; a key
+    // that omitted `search` would hand the second caller the first's result.
+    await Promise.all([
+      handler(null, { cwd: "/repo", opts: { state: "open", search: "auth" } }),
+      handler(null, { cwd: "/repo", opts: { state: "open", search: "auth bug" } }),
+      handler(null, { cwd: "/repo", opts: { state: "open" } }),
+    ]);
+
+    expect(fakeImpl.listIssues).toHaveBeenCalledTimes(3);
   });
 
   it("collapses repeat lookups within the TTL then re-runs after it elapses", async () => {

--- a/electron/ipc/handlers/forgeData.ts
+++ b/electron/ipc/handlers/forgeData.ts
@@ -86,6 +86,7 @@ function listOptionsKey(opts: ListOptions): string {
     opts.assignee ?? null,
     opts.sort ?? null,
     opts.direction ?? null,
+    opts.search ?? null,
   ]);
 }
 

--- a/electron/ipc/handlers/worktree/pull-requests.ts
+++ b/electron/ipc/handlers/worktree/pull-requests.ts
@@ -30,7 +30,7 @@ export function registerWorktreePullRequestHandlers(deps: HandlerDependencies): 
       throw new Error("Invalid payload for worktree:attach-issue");
     }
 
-    const { worktreeId, issueNumber, issueTitle, issueState, issueUrl } = payload;
+    const { worktreeId, issueNumber, issueTitle } = payload;
 
     if (typeof worktreeId !== "string" || !worktreeId.trim()) {
       throw new Error("Invalid worktreeId: must be a non-empty string");
@@ -41,18 +41,10 @@ export function registerWorktreePullRequestHandlers(deps: HandlerDependencies): 
     if (typeof issueTitle !== "string") {
       throw new Error("Invalid issueTitle: must be a string");
     }
-    if (issueState !== "OPEN" && issueState !== "CLOSED") {
-      throw new Error("Invalid issueState: must be 'OPEN' or 'CLOSED'");
-    }
-    if (typeof issueUrl !== "string" || !issueUrl.trim()) {
-      throw new Error("Invalid issueUrl: must be a non-empty string");
-    }
 
     const association: IssueAssociation = {
       issueNumber,
       issueTitle,
-      issueState,
-      issueUrl,
     };
 
     const currentMap = store.get("worktreeIssueMap") ?? {};
@@ -75,17 +67,6 @@ export function registerWorktreePullRequestHandlers(deps: HandlerDependencies): 
     store.set("worktreeIssueMap", rest);
   };
 
-  const handleWorktreeGetIssueAssociation = async (
-    worktreeId: string
-  ): Promise<IssueAssociation | null> => {
-    if (typeof worktreeId !== "string" || !worktreeId.trim()) {
-      throw new Error("Invalid worktreeId: must be a non-empty string");
-    }
-
-    const currentMap = store.get("worktreeIssueMap") ?? {};
-    return currentMap[worktreeId] ?? null;
-  };
-
   const handleWorktreeGetAllIssueAssociations = async (): Promise<
     Record<string, IssueAssociation>
   > => {
@@ -99,10 +80,6 @@ export function registerWorktreePullRequestHandlers(deps: HandlerDependencies): 
       prStatus: op(CHANNELS.WORKTREE_PR_STATUS, handleWorktreePRStatus),
       attachIssue: op(CHANNELS.WORKTREE_ATTACH_ISSUE, handleWorktreeAttachIssue),
       detachIssue: op(CHANNELS.WORKTREE_DETACH_ISSUE, handleWorktreeDetachIssue),
-      getIssueAssociation: op(
-        CHANNELS.WORKTREE_GET_ISSUE_ASSOCIATION,
-        handleWorktreeGetIssueAssociation
-      ),
       getAllIssueAssociations: op(
         CHANNELS.WORKTREE_GET_ALL_ISSUE_ASSOCIATIONS,
         handleWorktreeGetAllIssueAssociations

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -824,9 +824,6 @@ const api: ElectronAPI = {
     detachIssue: (worktreeId: string) =>
       _unwrappingInvoke(CHANNELS.WORKTREE_DETACH_ISSUE, { worktreeId }),
 
-    getIssueAssociation: (worktreeId: string): Promise<IssueAssociation | null> =>
-      _unwrappingInvoke(CHANNELS.WORKTREE_GET_ISSUE_ASSOCIATION, worktreeId),
-
     getAllIssueAssociations: (): Promise<Record<string, IssueAssociation>> =>
       _unwrappingInvoke(CHANNELS.WORKTREE_GET_ALL_ISSUE_ASSOCIATIONS),
 

--- a/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
@@ -595,7 +595,9 @@ describe("listIssues search", () => {
     ];
     expect(query).toContain("SearchItems");
     expect(variables.type).toBe("ISSUE");
-    expect(variables.searchQuery).toBe("repo:owner/repo is:issue state:open flaky");
+    expect(variables.searchQuery).toBe(
+      "repo:owner/repo is:issue state:open sort:created-desc flaky"
+    );
     expect(page.items[0]?.number).toBe(9);
     expect(page.items[0]?.state).toBe("open");
     expect(page.totalCount).toBe(1);
@@ -610,8 +612,63 @@ describe("listIssues search", () => {
     const queries = mockGraphQLClient.mock.calls.map(
       (call) => (call[1] as { searchQuery: string }).searchQuery
     );
-    expect(queries[0]).toBe("repo:owner/repo is:issue state:closed flaky");
-    expect(queries[1]).toBe("repo:owner/repo is:issue flaky");
+    expect(queries[0]).toBe("repo:owner/repo is:issue state:closed sort:created-desc flaky");
+    expect(queries[1]).toBe("repo:owner/repo is:issue sort:created-desc flaky");
+  });
+
+  it("maps opts.sort 'updated' to sort:updated-desc", async () => {
+    mockGraphQLClient.mockResolvedValue(issueSearchResponse());
+
+    await githubForgeProvider.listIssues(repo, { state: "open", search: "flaky", sort: "updated" });
+
+    const { searchQuery } = mockGraphQLClient.mock.calls[0]![1] as { searchQuery: string };
+    expect(searchQuery).toBe("repo:owner/repo is:issue state:open sort:updated-desc flaky");
+  });
+
+  it("truncates the free-text term so the query stays within GitHub's 256-char cap", async () => {
+    mockGraphQLClient.mockResolvedValue(issueSearchResponse());
+
+    await githubForgeProvider.listIssues(repo, { state: "open", search: "x".repeat(400) });
+
+    const { searchQuery } = mockGraphQLClient.mock.calls[0]![1] as { searchQuery: string };
+    expect(searchQuery.length).toBeLessThanOrEqual(256);
+    expect(searchQuery.startsWith("repo:owner/repo is:issue state:open sort:created-desc x")).toBe(
+      true
+    );
+  });
+
+  it("does not coalesce concurrent calls with different search terms", async () => {
+    mockGraphQLClient.mockResolvedValueOnce(issueSearchResponse()).mockResolvedValueOnce({
+      search: {
+        issueCount: 1,
+        pageInfo: { hasNextPage: false, endCursor: null },
+        nodes: [
+          {
+            number: 11,
+            title: "Other hit",
+            bodyText: "",
+            state: "OPEN",
+            url: "https://github.com/owner/repo/issues/11",
+            author: { login: "user", avatarUrl: "" },
+            assignees: { nodes: [] },
+            labels: { nodes: [] },
+            createdAt: "2025-01-01T00:00:00Z",
+            updatedAt: "2025-01-01T00:00:00Z",
+            closedAt: null,
+          },
+        ],
+      },
+      rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+    });
+
+    const [a, b] = await Promise.all([
+      githubForgeProvider.listIssues(repo, { state: "open", search: "abc" }),
+      githubForgeProvider.listIssues(repo, { state: "open", search: "def" }),
+    ]);
+
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(2);
+    expect(a.items[0]?.number).toBe(9);
+    expect(b.items[0]?.number).toBe(11);
   });
 
   it("does not write search results into the forge issue list cache", async () => {

--- a/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
@@ -555,6 +555,103 @@ describe("listIssues caching", () => {
   });
 });
 
+function issueSearchResponse() {
+  return {
+    search: {
+      issueCount: 1,
+      pageInfo: { hasNextPage: false, endCursor: null },
+      nodes: [
+        {
+          number: 9,
+          title: "Search hit",
+          bodyText: "body",
+          state: "OPEN",
+          url: "https://github.com/owner/repo/issues/9",
+          author: { login: "user", avatarUrl: "" },
+          assignees: { nodes: [] },
+          labels: { nodes: [] },
+          createdAt: "2025-01-01T00:00:00Z",
+          updatedAt: "2025-01-01T00:00:00Z",
+          closedAt: null,
+        },
+      ],
+    },
+    rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+  };
+}
+
+describe("listIssues search", () => {
+  beforeEach(() => mockGraphQLClient.mockReset());
+
+  it("routes a search term to SEARCH_QUERY with is:issue and a state qualifier", async () => {
+    mockGraphQLClient.mockResolvedValue(issueSearchResponse());
+
+    const page = await githubForgeProvider.listIssues(repo, { state: "open", search: "flaky" });
+
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(1);
+    const [query, variables] = mockGraphQLClient.mock.calls[0] as [
+      string,
+      { searchQuery: string; type: string },
+    ];
+    expect(query).toContain("SearchItems");
+    expect(variables.type).toBe("ISSUE");
+    expect(variables.searchQuery).toBe("repo:owner/repo is:issue state:open flaky");
+    expect(page.items[0]?.number).toBe(9);
+    expect(page.items[0]?.state).toBe("open");
+    expect(page.totalCount).toBe(1);
+  });
+
+  it("maps the state filter into the query string and omits it for 'all'", async () => {
+    mockGraphQLClient.mockResolvedValue(issueSearchResponse());
+
+    await githubForgeProvider.listIssues(repo, { state: "closed", search: "flaky" });
+    await githubForgeProvider.listIssues(repo, { state: "all", search: "flaky" });
+
+    const queries = mockGraphQLClient.mock.calls.map(
+      (call) => (call[1] as { searchQuery: string }).searchQuery
+    );
+    expect(queries[0]).toBe("repo:owner/repo is:issue state:closed flaky");
+    expect(queries[1]).toBe("repo:owner/repo is:issue flaky");
+  });
+
+  it("does not write search results into the forge issue list cache", async () => {
+    mockGraphQLClient.mockResolvedValue(issueSearchResponse());
+
+    await githubForgeProvider.listIssues(repo, { state: "open", search: "flaky" });
+
+    expect(forgeIssueListCache.get("issue:owner/repo:open::created:")).toBeUndefined();
+
+    // A following unfiltered list call misses the cache and issues its own query.
+    mockGraphQLClient.mockResolvedValue(issueListResponse());
+    const list = await githubForgeProvider.listIssues(repo, { state: "open" });
+    expect(list.items[0]?.number).toBe(5);
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces concurrent identical search calls into a single query", async () => {
+    mockGraphQLClient.mockResolvedValue(issueSearchResponse());
+
+    const [a, b] = await Promise.all([
+      githubForgeProvider.listIssues(repo, { state: "open", search: "flaky" }),
+      githubForgeProvider.listIssues(repo, { state: "open", search: "flaky" }),
+    ]);
+
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(1);
+    expect(a.items[0]?.number).toBe(9);
+    expect(b.items[0]?.number).toBe(9);
+  });
+
+  it("ignores a whitespace-only search term and uses the list path", async () => {
+    mockGraphQLClient.mockResolvedValue(issueListResponse());
+
+    const page = await githubForgeProvider.listIssues(repo, { state: "open", search: "   " });
+
+    const [query] = mockGraphQLClient.mock.calls[0] as [string];
+    expect(query).not.toContain("SearchItems");
+    expect(page.items[0]?.number).toBe(5);
+  });
+});
+
 describe("getPR tooltip pre-warm", () => {
   beforeEach(() => mockGraphQLClient.mockReset());
 

--- a/plugins/builtin/github/main/forgeProvider.ts
+++ b/plugins/builtin/github/main/forgeProvider.ts
@@ -527,14 +527,68 @@ function buildNumberBatchInflightKey(repo: RepoRef, numbers: number[]): string {
   return `${repo.owner}/${repo.repo}:${[...numbers].sort((a, b) => a - b).join(",")}`;
 }
 
+/**
+ * Text-search path for `listIssues` — routes through GitHub's search API
+ * instead of the repository issues connection. Results are typed-input
+ * ephemera: they use a `search:`-prefixed in-flight dedupe key and are never
+ * written to `forgeIssueListCache`, so a search response can't be served
+ * later as the unfiltered background-poll list. `runQuery`'s short-TTL
+ * response cache still coalesces identical search terms.
+ */
+async function searchIssuesImpl(
+  repo: RepoRef,
+  search: string,
+  opts: ListOptions
+): Promise<Page<Issue>> {
+  const state = listCacheState(opts);
+  const bypass = opts.bypassCache === true;
+  const limit = opts.perPage ?? 20;
+  // Free text is appended unquoted — GitHub search tokenizes it as keywords,
+  // matching what its own search box does (see findPRByBranchImpl, which only
+  // quotes because branch refs must not parse as separate operators).
+  const stateQualifier = state === "all" ? "" : ` state:${state}`;
+  const searchQuery = `repo:${repo.owner}/${repo.repo} is:issue${stateQualifier} ${search}`;
+  const dedupeKey = `search:${searchQuery}:${opts.cursor ?? ""}:${limit}`;
+
+  return dedupe(listIssuesInflight, dedupeKey, bypass, async () => {
+    const response = await runQuery(
+      SEARCH_QUERY,
+      {
+        searchQuery,
+        type: "ISSUE",
+        cursor: opts.cursor ?? null,
+        limit,
+      },
+      "SEARCH_QUERY",
+      bypass
+    );
+
+    const result = response?.search as
+      | {
+          nodes?: unknown[];
+          pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+          issueCount?: number;
+        }
+      | undefined;
+    const nodes = (result?.nodes ?? []) as Array<Record<string, unknown>>;
+    return {
+      items: nodes.filter(Boolean).map(toForgeIssue),
+      nextCursor: result?.pageInfo?.endCursor ?? null,
+      hasMore: result?.pageInfo?.hasNextPage ?? false,
+      ...(typeof result?.issueCount === "number" ? { totalCount: result.issueCount } : {}),
+    };
+  });
+}
+
 async function listIssuesImpl(repo: RepoRef, opts: ListOptions): Promise<Page<Issue>> {
+  const searchTerm = opts.search?.trim();
+  if (searchTerm) return searchIssuesImpl(repo, searchTerm, opts);
+
   const state = listCacheState(opts);
   const sortOrder = opts.sort === "updated" ? "updated" : "created";
   const bypass = opts.bypassCache === true;
-  // The GitHub forge list path issues the unfiltered repository query and
-  // ignores `opts.search` (advisory — see ListOptions). Keep `search` out of
-  // the cache key so it reflects what the query actually varies on; wiring
-  // search would mean routing to SEARCH_QUERY and re-adding it here together.
+  // The unfiltered list path keeps `search` out of the cache key — search
+  // routes through `searchIssuesImpl` above and never touches this cache.
   const cacheKey = buildListCacheKey(
     "issue",
     repo.owner,
@@ -599,8 +653,9 @@ async function listPRsImpl(repo: RepoRef, opts: ListOptions): Promise<Page<PR>> 
   const state = listCacheState(opts);
   const sortOrder = opts.sort === "updated" ? "updated" : "created";
   const bypass = opts.bypassCache === true;
-  // See listIssuesImpl: the forge list query ignores `opts.search`, so it's
-  // kept out of the cache key.
+  // The PR list query ignores `opts.search` (advisory — see ListOptions), so
+  // it's kept out of the cache key. Wiring it would mean routing to
+  // SEARCH_QUERY like `searchIssuesImpl` does for issues.
   const cacheKey = buildListCacheKey(
     "pr",
     repo.owner,

--- a/plugins/builtin/github/main/forgeProvider.ts
+++ b/plugins/builtin/github/main/forgeProvider.ts
@@ -545,9 +545,14 @@ async function searchIssuesImpl(
   const limit = opts.perPage ?? 20;
   // Free text is appended unquoted — GitHub search tokenizes it as keywords,
   // matching what its own search box does (see findPRByBranchImpl, which only
-  // quotes because branch refs must not parse as separate operators).
+  // quotes because branch refs must not parse as separate operators). GitHub
+  // caps search queries at 256 chars, so the term is truncated to the budget
+  // left after the qualifiers rather than letting the whole query be rejected.
   const stateQualifier = state === "all" ? "" : ` state:${state}`;
-  const searchQuery = `repo:${repo.owner}/${repo.repo} is:issue${stateQualifier} ${search}`;
+  const sortQualifier = opts.sort === "updated" ? "sort:updated-desc" : "sort:created-desc";
+  const prefix = `repo:${repo.owner}/${repo.repo} is:issue${stateQualifier} ${sortQualifier} `;
+  const available = 256 - prefix.length;
+  const searchQuery = `${prefix}${available > 0 ? search.slice(0, available) : ""}`.trim();
   const dedupeKey = `search:${searchQuery}:${opts.cursor ?? ""}:${limit}`;
 
   return dedupe(listIssuesInflight, dedupeKey, bypass, async () => {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -211,7 +211,6 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     delete(worktreeId: string, force?: boolean, deleteBranch?: boolean): Promise<void>;
     attachIssue(payload: AttachIssuePayload): Promise<void>;
     detachIssue(worktreeId: string): Promise<void>;
-    getIssueAssociation(worktreeId: string): Promise<IssueAssociation | null>;
     getAllIssueAssociations(): Promise<Record<string, IssueAssociation>>;
     restartService(): Promise<void>;
     retryProjectLoad(): Promise<void>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1227,10 +1227,6 @@ export interface GeneratedIpcInvokeMap {
     args: [payload: { rootPath: string; branchName: string }];
     result: string;
   };
-  "worktree:get-issue-association": {
-    args: [worktreeId: string];
-    result: import("./worktree.js").IssueAssociation | null;
-  };
   "worktree:get-recent-branches": {
     args: [payload: { rootPath: string }];
     result: string[];

--- a/shared/types/ipc/worktree.ts
+++ b/shared/types/ipc/worktree.ts
@@ -27,8 +27,6 @@ export interface WorktreeConfig {
 export interface IssueAssociation {
   issueNumber: number;
   issueTitle: string;
-  issueState: "OPEN" | "CLOSED";
-  issueUrl: string;
 }
 
 /** Payload for attaching an issue to a worktree */
@@ -36,8 +34,6 @@ export interface AttachIssuePayload {
   worktreeId: string;
   issueNumber: number;
   issueTitle: string;
-  issueState: "OPEN" | "CLOSED";
-  issueUrl: string;
 }
 
 /** Payload for detaching an issue from a worktree */

--- a/src/clients/worktreeClient.ts
+++ b/src/clients/worktreeClient.ts
@@ -94,10 +94,6 @@ export const worktreeClient = {
     return window.electron.worktree.detachIssue(worktreeId);
   },
 
-  getIssueAssociation: (worktreeId: string): Promise<IssueAssociation | null> => {
-    return window.electron.worktree.getIssueAssociation(worktreeId);
-  },
-
   getAllIssueAssociations: (): Promise<Record<string, IssueAssociation>> => {
     return window.electron.worktree.getAllIssueAssociations();
   },

--- a/src/components/Worktree/IssuePickerDialog.tsx
+++ b/src/components/Worktree/IssuePickerDialog.tsx
@@ -5,9 +5,8 @@ import { CircleDot, Search, Link, Unlink, CircleCheck } from "lucide-react";
 import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { cn } from "@/lib/utils";
-// eslint-disable-next-line no-restricted-imports
-import { githubClient } from "@/clients";
-import type { GitHubIssue } from "@shared/types/github";
+import { forgeClient } from "@/clients";
+import type { Issue } from "@shared/types/forge";
 import type { WorktreeState } from "@/types";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { useTruncationDetection } from "@/hooks/useTruncationDetection";
@@ -18,14 +17,14 @@ interface IssuePickerDialogProps {
   onClose: () => void;
   worktree: WorktreeState;
   currentIssueNumber?: number;
-  onAttach: (issue: GitHubIssue) => void;
+  onAttach: (issue: Issue) => void;
   onDetach: () => void;
 }
 
 type StateFilter = "open" | "closed" | "all";
 
 interface IssueOptionRowProps {
-  issue: GitHubIssue;
+  issue: Issue;
   isSelected: boolean;
   isCurrentlyAttached: boolean;
   onClick: () => void;
@@ -49,7 +48,7 @@ function IssueOptionRow({ issue, isSelected, isCurrentlyAttached, onClick }: Iss
           isCurrentlyAttached && "ring-1 ring-status-success/30"
         )}
       >
-        {issue.state === "OPEN" ? (
+        {issue.state === "open" ? (
           <CircleDot className="w-4 h-4 text-pr-open shrink-0 mt-0.5" />
         ) : (
           <CircleCheck className="w-4 h-4 text-pr-merged shrink-0 mt-0.5" />
@@ -82,7 +81,7 @@ export function IssuePickerDialog({
 }: IssuePickerDialogProps) {
   const [search, setSearch] = useState("");
   const [stateFilter, setStateFilter] = useState<StateFilter>("open");
-  const [issues, setIssues] = useState<GitHubIssue[]>([]);
+  const [issues, setIssues] = useState<Issue[]>([]);
   const [fetchedQuery, setFetchedQuery] = useState("");
   const [isPending, setIsPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -98,8 +97,7 @@ export function IssuePickerDialog({
       const id = ++fetchIdRef.current;
       setIsPending(true);
       try {
-        const result = await githubClient.listIssues({
-          cwd: worktree.path,
+        const result = await forgeClient.listIssues(worktree.path, {
           search: trimmed || undefined,
           state,
         });
@@ -180,7 +178,7 @@ export function IssuePickerDialog({
   }, [selectedIndex]);
 
   const handleSelectIssue = useCallback(
-    (issue: GitHubIssue) => {
+    (issue: Issue) => {
       onAttach(issue);
       onClose();
     },

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import type { WorktreeState } from "../../types";
-import type { GitHubIssue } from "@shared/types/github";
+import type { Issue } from "@shared/types/forge";
 import { logError } from "@/utils/logger";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { useWorktreeTerminals } from "../../hooks/useWorktreeTerminals";
@@ -513,13 +513,11 @@ export function WorktreeCard({
   // of a fire-and-forget IPC. The store applies the local association only once
   // the Electron-store write lands, replays a mutation that was in flight when
   // the host crashed, and surfaces failures via `WorktreeIssueErrorBanner`.
-  const handleAttachIssue = (issue: GitHubIssue) => {
+  const handleAttachIssue = (issue: Issue) => {
     getCurrentViewStore().getState().startAttachIssue({
       worktreeId: worktree.id,
       issueNumber: issue.number,
       issueTitle: issue.title,
-      issueState: issue.state,
-      issueUrl: issue.url,
     });
   };
 

--- a/src/components/Worktree/WorktreeCard/WorktreeDialogs.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDialogs.tsx
@@ -1,5 +1,5 @@
 import type { WorktreeState } from "@/types";
-import type { GitHubIssue } from "@shared/types/github";
+import type { Issue } from "@shared/types/forge";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { WorktreeDeleteDialog } from "../WorktreeDeleteDialog";
 import { IssuePickerDialog } from "../IssuePickerDialog";
@@ -15,7 +15,7 @@ export interface WorktreeDialogsProps {
   onCloseDeleteDialog: () => void;
   showIssuePicker: boolean;
   onCloseIssuePicker: () => void;
-  onAttachIssue: (issue: GitHubIssue) => void;
+  onAttachIssue: (issue: Issue) => void;
   onDetachIssue: () => void;
   showReviewHub: boolean;
   onCloseReviewHub: () => void;

--- a/src/components/Worktree/__tests__/IssuePickerDialog.test.tsx
+++ b/src/components/Worktree/__tests__/IssuePickerDialog.test.tsx
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, afterEach, beforeAll, vi } from "vitest";
 import { act, render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
-import type { GitHubIssue } from "@shared/types/github";
+import type { Issue } from "@shared/types/forge";
 import type { WorktreeState } from "@/types";
 import { IssuePickerDialog } from "../IssuePickerDialog";
 
@@ -18,7 +18,7 @@ const { listIssuesMock } = vi.hoisted(() => ({
 }));
 
 vi.mock("@/clients", () => ({
-  githubClient: {
+  forgeClient: {
     listIssues: listIssuesMock,
   },
 }));
@@ -86,7 +86,7 @@ describe("IssuePickerDialog empty states", () => {
 
     await waitFor(
       () => {
-        expect(listIssuesMock.mock.calls.some((call) => call[0]?.search === undefined)).toBe(true);
+        expect(listIssuesMock.mock.calls.some((call) => call[1]?.search === undefined)).toBe(true);
       },
       { timeout: 2000 }
     );
@@ -120,16 +120,20 @@ describe("IssuePickerDialog empty states", () => {
   });
 });
 
-function makeIssue(number: number, title: string): GitHubIssue {
+function makeIssue(number: number, title: string): Issue {
   return {
     number,
     title,
+    body: "",
     url: `https://example.test/${number}`,
-    state: "OPEN",
-    updatedAt: "2026-01-01T00:00:00Z",
-    author: { login: "tester", avatarUrl: "" },
+    state: "open",
+    rawState: "open",
+    updatedAt: Date.parse("2026-01-01T00:00:00Z"),
+    createdAt: Date.parse("2026-01-01T00:00:00Z"),
+    author: { login: "tester", avatarUrl: "", rawData: null },
     assignees: [],
-    commentCount: 0,
+    labels: [],
+    rawData: null,
   };
 }
 
@@ -140,8 +144,8 @@ describe("IssuePickerDialog stale behavior", () => {
       const issueA = makeIssue(1, "Issue A");
       const issueB = makeIssue(2, "Issue B");
 
-      let resolveSlow: ((value: { items: GitHubIssue[] }) => void) | undefined;
-      const slowPromise = new Promise<{ items: GitHubIssue[] }>((r) => {
+      let resolveSlow: ((value: { items: Issue[] }) => void) | undefined;
+      const slowPromise = new Promise<{ items: Issue[] }>((r) => {
         resolveSlow = r;
       });
 
@@ -193,8 +197,8 @@ describe("IssuePickerDialog stale behavior", () => {
       const issueX = makeIssue(2, "Issue X");
       const issueY = makeIssue(3, "Issue Y");
 
-      let resolveX: ((value: { items: GitHubIssue[] }) => void) | undefined;
-      const xPromise = new Promise<{ items: GitHubIssue[] }>((r) => {
+      let resolveX: ((value: { items: Issue[] }) => void) | undefined;
+      const xPromise = new Promise<{ items: Issue[] }>((r) => {
         resolveX = r;
       });
 
@@ -246,8 +250,8 @@ describe("IssuePickerDialog stale behavior", () => {
     try {
       const issueA = makeIssue(1, "Issue A");
 
-      let resolveSecond: ((value: { items: GitHubIssue[] }) => void) | undefined;
-      const secondOpenPromise = new Promise<{ items: GitHubIssue[] }>((r) => {
+      let resolveSecond: ((value: { items: Issue[] }) => void) | undefined;
+      const secondOpenPromise = new Promise<{ items: Issue[] }>((r) => {
         resolveSecond = r;
       });
 
@@ -311,8 +315,8 @@ describe("IssuePickerDialog stale behavior", () => {
     try {
       const stale = makeIssue(1, "Stale foo result");
 
-      let resolveFoo: ((value: { items: GitHubIssue[] }) => void) | undefined;
-      const fooPromise = new Promise<{ items: GitHubIssue[] }>((r) => {
+      let resolveFoo: ((value: { items: Issue[] }) => void) | undefined;
+      const fooPromise = new Promise<{ items: Issue[] }>((r) => {
         resolveFoo = r;
       });
 

--- a/src/services/actions/definitions/__tests__/githubActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/githubActions.adversarial.test.ts
@@ -307,7 +307,6 @@ describe("githubClient import boundary", () => {
     "src/hooks/useGitHubTokenHealth.ts",
     "src/hooks/useProjectHealth.ts",
     "src/components/Layout/GitHubStatsToolbarButton.tsx",
-    "src/components/Worktree/IssuePickerDialog.tsx",
   ]);
 
   function collectSrcFiles(dir: string): string[] {

--- a/src/store/__tests__/createWorktreeStore.outbox.test.ts
+++ b/src/store/__tests__/createWorktreeStore.outbox.test.ts
@@ -610,8 +610,6 @@ describe("createWorktreeStore — mutation outbox (#8405)", () => {
       worktreeId,
       issueNumber,
       issueTitle: `Issue ${issueNumber}`,
-      issueState: "OPEN" as const,
-      issueUrl: `https://example.com/${issueNumber}`,
     });
 
     describe("entry creation + success path", () => {


### PR DESCRIPTION
Closes #9993.

## What this does

Decouples the worktree attach-issue flow from GitHub-specific types and APIs, routing it through the provider-neutral forge layer.

- **`IssuePickerDialog`** now calls `forgeClient.listIssues` with the normalized `Issue` type (lowercase `open`/`closed` state) instead of `githubClient`/`GitHubIssue`. The `no-restricted-imports` disable is gone and the dialog is removed from the `githubClient` allowlist in `githubActions.adversarial.test.ts`.
- **`opts.search` is now honored by the GitHub forge provider.** A new `searchIssuesImpl` routes text search through `SEARCH_QUERY` (`repo:{owner}/{repo} is:issue [state:x] sort:created|updated-desc {term}`, truncated to GitHub's 256-char query cap). Search results use a `search:`-prefixed in-flight dedupe key and never write into `forgeIssueListCache`, so typed-input ephemera can't be served later as the background-poll list.
- **Dead fields removed from the IPC contract.** `issueState` (uppercase `OPEN`/`CLOSED`) and `issueUrl` are gone from `IssueAssociation`/`AttachIssuePayload`, the handler validation, and the `WorktreeCard` payload — nothing ever read them. No store migration needed: old persisted entries' extra keys are harmlessly ignored.
- **Dead `worktree:get-issue-association` IPC op removed end-to-end** (channel, handler, preload, api types, `worktreeClient`, regenerated `generated.ts`).
- **Coalesce-key fix (caught in review):** `listOptionsKey` in `forgeData.ts` now includes `opts.search`, so two debounced picker keystrokes can't share an in-flight slot and hand the second query the first query's results.

## Tests

- New `listIssues search` suite in `forgeProvider.test.ts`: query shape, state/sort qualifier mapping, 256-char truncation, list-cache isolation, identical-call coalescing, distinct-term isolation, whitespace fallback to the list path.
- IPC-layer regression test in `forgeData.handlers.test.ts` asserting distinct search terms get distinct coalesce slots (+ per-test rate-limit budget reset).
- Updated the outbox test payload factory for the slimmed `AttachIssuePayload`.

`npm run check` is fully green (typecheck, lint ratchet −1 warning, format, all IPC/channel/confirm-wiring guards).