### PR TITLE
fix(theme): plain-language, announced theme import feedback

### DIFF
--- a/electron/utils/__tests__/appThemeImporter.test.ts
+++ b/electron/utils/__tests__/appThemeImporter.test.ts
@@ -39,7 +39,11 @@ describe("appThemeImporter", () => {
     if (!result.ok) return;
 
     expect(result.scheme.type).toBe("light");
-    expect(result.warnings.some((warning) => warning.message.includes('Add "type"'))).toBe(true);
+    const inferredWarning = result.warnings.find((warning) =>
+      warning.message.includes('Add "type"')
+    );
+    expect(inferredWarning).toBeDefined();
+    expect(inferredWarning?.kind).toBe("type-inferred");
   });
 
   it("warns about unknown nested tokens but still imports the scheme", () => {
@@ -58,9 +62,11 @@ describe("appThemeImporter", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
 
-    expect(
-      result.warnings.some((warning) => warning.message.includes("Ignored unknown tokens"))
-    ).toBe(true);
+    const unknownWarning = result.warnings.find((warning) =>
+      warning.message.includes("Ignored unknown tokens")
+    );
+    expect(unknownWarning).toBeDefined();
+    expect(unknownWarning?.kind).toBe("unknown-tokens");
   });
 
   it("preserves location and heroImage metadata through import", () => {

--- a/electron/utils/appThemeImporter.ts
+++ b/electron/utils/appThemeImporter.ts
@@ -9,6 +9,7 @@ import {
   normalizeAppColorScheme,
   validateImportedThemeData,
   type AppThemeImportResult,
+  type AppThemeValidationWarning,
   type ThemePalette,
 } from "../../shared/theme/index.js";
 
@@ -146,10 +147,11 @@ export function parseAppThemeContent(content: string, filename: string): AppThem
     getBuiltInAppSchemeForType(resolvedType)
   );
 
-  const warnings = [];
+  const warnings: AppThemeValidationWarning[] = [];
 
   if (!rawTheme.type) {
     warnings.push({
+      kind: "type-inferred",
       message: `Theme type was inferred as ${resolvedType}. Add "type" to make the file explicit.`,
     });
   }
@@ -160,6 +162,7 @@ export function parseAppThemeContent(content: string, filename: string): AppThem
       .sort();
     if (unknownTokens.length > 0) {
       warnings.push({
+        kind: "unknown-tokens",
         message: `Ignored unknown tokens: ${unknownTokens.join(", ")}`,
       });
     }

--- a/shared/theme/colorValidator.ts
+++ b/shared/theme/colorValidator.ts
@@ -388,6 +388,7 @@ export function getOverlayContrastWarnings(scheme: AppColorScheme): AppThemeVali
   const weber = weberContrast(compositedHex, canvas.trim());
   if (weber < OVERLAY_HOVER_WEBER_FLOOR) {
     warnings.push({
+      kind: "overlay-contrast",
       message: `overlay-hover over surface-canvas Weber contrast is ${(weber * 100).toFixed(1)}%; floor is ${(OVERLAY_HOVER_WEBER_FLOOR * 100).toFixed(0)}% (RC-2 interactive overlay must be perceptible in both polarities)`,
     });
   }

--- a/shared/theme/contrast.ts
+++ b/shared/theme/contrast.ts
@@ -321,6 +321,7 @@ function getTerminalSyntaxWarnings(scheme: AppColorScheme): AppThemeValidationWa
 
   if (typeof bg !== "string" || !bg.trim()) {
     warnings.push({
+      kind: "unevaluable",
       message: `Cannot evaluate terminal/syntax validation: terminal-background token is missing or empty`,
     });
     return warnings;
@@ -328,6 +329,7 @@ function getTerminalSyntaxWarnings(scheme: AppColorScheme): AppThemeValidationWa
 
   if (!bgIsHex) {
     warnings.push({
+      kind: "unevaluable",
       message: `Cannot evaluate terminal/syntax legibility: terminal-background="${bg}" is not a hex color`,
     });
   }
@@ -347,12 +349,14 @@ function getTerminalSyntaxWarnings(scheme: AppColorScheme): AppThemeValidationWa
       const fg = scheme.tokens[tokenKey];
       if (typeof fg !== "string" || !fg.trim()) {
         warnings.push({
+          kind: "unevaluable",
           message: `Cannot evaluate legibility for ${tokenKey}: token is missing or empty`,
         });
         continue;
       }
       if (!isHexColor(fg)) {
         warnings.push({
+          kind: "unevaluable",
           message: `Cannot evaluate legibility for ${tokenKey} on terminal-background: non-hex value "${fg}"`,
         });
         continue;
@@ -365,6 +369,7 @@ function getTerminalSyntaxWarnings(scheme: AppColorScheme): AppThemeValidationWa
           : STANDARD_LEGIBILITY_FLOOR;
       if (dL < floor) {
         warnings.push({
+          kind: "terminal-legibility",
           message: `${tokenKey} on terminal-background OKLab lightness diff is ${dL.toFixed(3)}; floor is ${floor.toFixed(2)}`,
         });
       }
@@ -387,6 +392,7 @@ function getTerminalSyntaxWarnings(scheme: AppColorScheme): AppThemeValidationWa
         : SYNTAX_CANVAS_MIN_CONTRAST;
       if (ratio < floor) {
         warnings.push({
+          kind: "terminal-legibility",
           message: `${tokenKey} on ${SYNTAX_CANVAS_SURFACE} (editor render surface) is ${ratio.toFixed(2)}:1; target is ${floor.toFixed(1)}:1`,
         });
       }
@@ -404,6 +410,7 @@ function getTerminalSyntaxWarnings(scheme: AppColorScheme): AppThemeValidationWa
       if (!aOk) unevaluable.push(`${pair.a}="${aVal ?? "<missing>"}"`);
       if (!bOk) unevaluable.push(`${pair.b}="${bVal ?? "<missing>"}"`);
       warnings.push({
+        kind: "unevaluable",
         message: `Cannot evaluate distinctness for ${pair.label}: non-hex token value(s) ${unevaluable.join(", ")}`,
       });
       continue;
@@ -411,6 +418,7 @@ function getTerminalSyntaxWarnings(scheme: AppColorScheme): AppThemeValidationWa
     const d = deltaEOK(aVal!, bVal!);
     if (d < DISTINCTNESS_FLOOR) {
       warnings.push({
+        kind: "terminal-legibility",
         message: `${pair.label} deltaEOK is ${d.toFixed(3)}; floor is ${DISTINCTNESS_FLOOR.toFixed(2)}`,
       });
     }
@@ -428,6 +436,7 @@ export function getThemeContrastWarnings(scheme: AppColorScheme): AppThemeValida
     const bg = scheme.tokens[pair.background];
     if (!isHexColor(fg)) {
       warnings.push({
+        kind: "unevaluable",
         message: `Cannot evaluate contrast for ${pair.foreground} on ${pair.background}: non-hex foreground "${fg}"`,
       });
       continue;
@@ -436,6 +445,7 @@ export function getThemeContrastWarnings(scheme: AppColorScheme): AppThemeValida
       const ratio = contrastRatio(fg, bg);
       if (ratio < pair.minimum) {
         warnings.push({
+          kind: "low-contrast",
           message: `${pair.foreground} on ${pair.background} is ${ratio.toFixed(2)}:1; target is ${pair.minimum.toFixed(1)}:1`,
         });
       }
@@ -446,6 +456,7 @@ export function getThemeContrastWarnings(scheme: AppColorScheme): AppThemeValida
           const ratio = contrastRatio(fg, rgba.hex);
           if (ratio < pair.minimum) {
             warnings.push({
+              kind: "low-contrast",
               message: `${pair.foreground} on ${pair.background} is ${ratio.toFixed(2)}:1; target is ${pair.minimum.toFixed(1)}:1`,
             });
           }
@@ -459,18 +470,21 @@ export function getThemeContrastWarnings(scheme: AppColorScheme): AppThemeValida
             const ratio = contrastRatio(fg, compositedBg);
             if (ratio < pair.minimum) {
               warnings.push({
+                kind: "low-contrast",
                 message: `${pair.foreground} on ${pair.background} (over ${surfaceKey}) is ${ratio.toFixed(2)}:1; target is ${pair.minimum.toFixed(1)}:1`,
               });
             }
           }
           if (!anySurfaceEvaluable) {
             warnings.push({
+              kind: "unevaluable",
               message: `Cannot evaluate contrast for ${pair.foreground} on ${pair.background}: ${pair.background}="${bg}" requires compositing over a surface but no evaluable surface found`,
             });
           }
         }
       } else {
         warnings.push({
+          kind: "unevaluable",
           message: `Cannot evaluate contrast for ${pair.foreground} on ${pair.background}: non-hex background "${bg}"`,
         });
       }
@@ -487,6 +501,7 @@ export function getThemeContrastWarnings(scheme: AppColorScheme): AppThemeValida
       const ratio = contrastRatio(blended, bg);
       if (ratio < pair.minimum) {
         warnings.push({
+          kind: "low-contrast",
           message: `text-primary on ${pair.background} at ${Math.round(opacity * 100)}% opacity (${tier}) is ${ratio.toFixed(2)}:1; target is ${pair.minimum.toFixed(1)}:1`,
         });
       }
@@ -503,6 +518,7 @@ export function getThemeContrastWarnings(scheme: AppColorScheme): AppThemeValida
       if (!accentHex) unevaluable.push(`accent-primary="${accent}"`);
       if (!surfaceHex) unevaluable.push(`${surfaceKey}="${surface}"`);
       warnings.push({
+        kind: "unevaluable",
         message: `Cannot evaluate accent-primary outline contrast on ${surfaceKey}: non-hex token value(s) ${unevaluable.join(", ")}`,
       });
       continue;
@@ -510,6 +526,7 @@ export function getThemeContrastWarnings(scheme: AppColorScheme): AppThemeValida
     const ratio = contrastRatio(accent, surface);
     if (ratio < ACCENT_OUTLINE_MIN_CONTRAST) {
       warnings.push({
+        kind: "low-contrast",
         message: `accent-primary outline on ${surfaceKey} is ${ratio.toFixed(2)}:1; target is ${ACCENT_OUTLINE_MIN_CONTRAST.toFixed(1)}:1 (WCAG 1.4.11 Non-text Contrast)`,
       });
     }
@@ -525,6 +542,7 @@ export function getThemeContrastWarnings(scheme: AppColorScheme): AppThemeValida
       if (!accentSecondaryHex) unevaluable.push(`accent-secondary="${accentSecondary}"`);
       if (!surfaceHex) unevaluable.push(`${surfaceKey}="${surface}"`);
       warnings.push({
+        kind: "unevaluable",
         message: `Cannot evaluate accent-secondary outline contrast on ${surfaceKey}: non-hex token value(s) ${unevaluable.join(", ")}`,
       });
       continue;
@@ -532,6 +550,7 @@ export function getThemeContrastWarnings(scheme: AppColorScheme): AppThemeValida
     const ratio = contrastRatio(accentSecondary, surface);
     if (ratio < ACCENT_OUTLINE_MIN_CONTRAST) {
       warnings.push({
+        kind: "low-contrast",
         message: `accent-secondary outline on ${surfaceKey} is ${ratio.toFixed(2)}:1; target is ${ACCENT_OUTLINE_MIN_CONTRAST.toFixed(1)}:1 (WCAG 1.4.11 Non-text Contrast)`,
       });
     }
@@ -721,6 +740,7 @@ function runMatrixContrastPairs(scheme: AppColorScheme): AppThemeValidationWarni
     const ratio = contrastRatio(fg.hex, bg.hex);
     if (ratio < pair.minimum) {
       out.push({
+        kind: "low-contrast",
         message: `[matrix] ${scheme.id}: ${pair.label} is ${ratio.toFixed(2)}:1; target is ${pair.minimum.toFixed(1)}:1`,
       });
     }
@@ -779,6 +799,7 @@ function runMatrixSeparationPairs(scheme: AppColorScheme): AppThemeValidationWar
     const de = deltaEOK(a.hex, b.hex);
     if (de < pair.minDeltaE) {
       out.push({
+        kind: "low-contrast",
         message: `[matrix] ${scheme.id}: ${pair.label} — ΔE=${de.toFixed(4)} below ${pair.minDeltaE.toFixed(3)} (perceptually merges)`,
       });
     }
@@ -806,6 +827,7 @@ function runCardAboveDialogBody(scheme: AppColorScheme): AppThemeValidationWarni
   const bodyL = relativeLuminance(body.hex);
   if (cardL <= bodyL) {
     out.push({
+      kind: "low-contrast",
       message: `[matrix] ${scheme.id}: light settings card (L≈${cardL.toFixed(3)}) is at/below the dialog body (L≈${bodyL.toFixed(3)}) — the card must lift above its container, not recede (S1)`,
     });
   }
@@ -834,6 +856,7 @@ function runPulseHeatSeparation(scheme: AppColorScheme): AppThemeValidationWarni
     const de = deltaEOK(stop1, empty.hex);
     if (de < RAMP_DL_JND_MATRIX) {
       out.push({
+        kind: "low-contrast",
         message: `[matrix] ${scheme.id}: pulse heat level-1 (heat-color @${lowOp}) ΔE=${de.toFixed(4)} vs empty cell is below JND (${RAMP_DL_JND_MATRIX}) — a worked day is invisible (P-Heat)`,
       });
     }
@@ -844,6 +867,7 @@ function runPulseHeatSeparation(scheme: AppColorScheme): AppThemeValidationWarni
     const ratio = contrastRatio(missed.hex, empty.hex);
     if (ratio < 3.0) {
       out.push({
+        kind: "low-contrast",
         message: `[matrix] ${scheme.id}: pulse missed-day fill vs empty cell is ${ratio.toFixed(2)}:1; target is 3.0:1 — the streak-break signal is imperceptible (P-Heat)`,
       });
     }
@@ -876,6 +900,7 @@ function runActivityWorkingWaitingSeparation(scheme: AppColorScheme): AppThemeVa
   // hue, which the deuteranope confusion line erases on a small dot.
   if (de < 0.1) {
     out.push({
+      kind: "low-contrast",
       message: `[matrix] ${scheme.id}: activity working vs waiting ΔE=${de.toFixed(3)} (<0.10) — near-isoluminant, separable by hue only; lean on the shape channel (B2)`,
     });
   }
@@ -918,8 +943,10 @@ export function getLightThemeMatrixWarnings(scheme: AppColorScheme): AppThemeVal
   warnings.push(...runActivityWorkingWaitingSeparation(scheme));
 
   const collect = (r: AuditResult, prefix: string) => {
-    for (const f of r.failures) warnings.push({ message: `[matrix] ${prefix}${f}` });
-    for (const w of r.warnings) warnings.push({ message: `[matrix] ${prefix}${w}` });
+    for (const f of r.failures)
+      warnings.push({ kind: "low-contrast", message: `[matrix] ${prefix}${f}` });
+    for (const w of r.warnings)
+      warnings.push({ kind: "low-contrast", message: `[matrix] ${prefix}${w}` });
   };
 
   // Elevation-direction inversions (OKLab, light-only). Resolve the composited
@@ -932,6 +959,7 @@ export function getLightThemeMatrixWarnings(scheme: AppColorScheme): AppThemeVal
       collect(auditSidebarSelectedLift(selected.hex, sidebar, scheme.id, "light"), "");
     } else {
       warnings.push({
+        kind: "unevaluable",
         message: `[matrix] ${scheme.id}: skipped sidebar-selected lift — sidebar-active-bg unevaluable (${"skip" in selected ? selected.skip : "no sidebar surface"})`,
       });
     }

--- a/shared/theme/themes.ts
+++ b/shared/theme/themes.ts
@@ -803,6 +803,7 @@ export function getAppThemeWarnings(scheme: AppColorScheme): AppThemeValidationW
     accentRgb === "0, 0, 0"
   ) {
     warnings.push({
+      kind: "accent-rgb-fallback",
       message:
         'accent-rgb falls back to "0, 0, 0" because accent-primary is non-hex and no explicit accent-rgb override was provided. Components using rgba(var(--theme-accent-rgb), …) will render black tints.',
     });

--- a/shared/theme/types.ts
+++ b/shared/theme/types.ts
@@ -366,7 +366,23 @@ export interface AppThemeConfig {
   accentColorOverride?: string | null;
 }
 
+/**
+ * Categorises a theme-import warning so the UI can show one plain-language line
+ * per kind instead of the raw engine diagnostic. The raw `message` is retained
+ * for theme authors behind a technical-details disclosure.
+ */
+export type AppThemeWarningKind =
+  | "type-inferred"
+  | "unknown-tokens"
+  | "low-contrast"
+  | "terminal-legibility"
+  | "unevaluable"
+  | "accent-rgb-fallback"
+  | "overlay-contrast";
+
 export interface AppThemeValidationWarning {
+  kind: AppThemeWarningKind;
+  /** Raw engine diagnostic — developer-facing, shown only under a details affordance. */
   message: string;
 }
 

--- a/shared/types/appTheme.ts
+++ b/shared/types/appTheme.ts
@@ -4,5 +4,6 @@ export type {
   AppColorSchemeTokens,
   AppThemeConfig,
   AppThemeValidationWarning,
+  AppThemeWarningKind,
   ColorVisionMode,
 } from "../theme/index.js";

--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -267,8 +267,12 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
 
       if (result.warnings.length > 0) {
         setImportWarnings(result.warnings);
+        // Count the deduplicated kind rows the user actually sees, not the raw
+        // diagnostic count (those live under "Technical details") — otherwise
+        // "12 warnings" next to 2 visible rows reads as missing content.
+        const warningCount = groupWarningsByKind(result.warnings).length;
         announceImportResult(
-          `Imported "${result.scheme.name}" with ${result.warnings.length} warning${result.warnings.length === 1 ? "" : "s"}.`
+          `Imported "${result.scheme.name}" with ${warningCount} warning${warningCount === 1 ? "" : "s"}.`
         );
       } else {
         announceImportResult(`Imported "${result.scheme.name}".`);
@@ -355,7 +359,7 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
                 <ul className="mt-1 space-y-1.5">
                   {groupWarningsByKind(importWarnings).map(({ kind, messages }) => (
                     <li key={kind} className="text-[11px] text-daintree-text/60">
-                      {WARNING_KIND_COPY[kind]}
+                      {WARNING_KIND_COPY[kind] ?? "Some theme values may need attention"}
                       <details className="mt-0.5">
                         <summary className="cursor-pointer text-daintree-text/40 transition-colors hover:text-daintree-text/70">
                           Technical details

--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -20,10 +20,49 @@ import {
 import { PaletteStrip } from "@/components/ui/PaletteStrip";
 import { Button } from "@/components/ui/button";
 import { APP_THEME_PREVIEW_KEYS } from "@shared/theme";
-import type { AppColorScheme, AppThemeValidationWarning } from "@shared/types/appTheme";
+import type {
+  AppColorScheme,
+  AppThemeValidationWarning,
+  AppThemeWarningKind,
+} from "@shared/types/appTheme";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { logError } from "@/utils/logger";
 import { useImageError } from "@/hooks/useImageError";
+
+// Plain-language summary per warning kind. Engine diagnostics (contrast ratios,
+// WCAG clause numbers, token-key names) are written for theme authors, not end
+// users — they stay behind the "Technical details" disclosure. The Record forces
+// every AppThemeWarningKind to have copy (a missing key is a compile error).
+const WARNING_KIND_COPY: Record<AppThemeWarningKind, string> = {
+  "type-inferred": "Theme mode was guessed from the colors",
+  "unknown-tokens": "Some values in this theme weren't recognized",
+  "low-contrast": "Some colors may be hard to see",
+  "terminal-legibility": "Some terminal colors may be hard to read",
+  unevaluable: "Some colors couldn't be checked",
+  "accent-rgb-fallback": "Accent tint colors may not render correctly",
+  "overlay-contrast": "Hover highlights may be hard to see",
+};
+
+// Collapse the flat warning list to one entry per kind (first-seen order), so the
+// import result reads as a short scannable list instead of N near-identical rows.
+// Raw messages are grouped under their kind for the technical-details disclosure.
+function groupWarningsByKind(
+  warnings: AppThemeValidationWarning[]
+): Array<{ kind: AppThemeWarningKind; messages: string[] }> {
+  const order: AppThemeWarningKind[] = [];
+  const byKind = new Map<AppThemeWarningKind, string[]>();
+  for (const warning of warnings) {
+    let messages = byKind.get(warning.kind);
+    if (!messages) {
+      messages = [];
+      byKind.set(warning.kind, messages);
+      order.push(warning.kind);
+    }
+    messages.push(warning.message);
+  }
+  return order.map((kind) => ({ kind, messages: byKind.get(kind)! }));
+}
 
 function shuffleArray<T>(arr: T[]): T[] {
   const a = [...arr];
@@ -200,6 +239,15 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
     }
   };
 
+  // The import result block mounts after an async resolve, so screen-reader users
+  // get no announcement from it appearing. Route the summary through the shared
+  // announcer (AppDialog mounts AccessibilityAnnouncer in-subtree, handling the
+  // Chromium aria-modal filter and document.ariaNotify).
+  const announceImportResult = (message: string) => {
+    setImportMessage(message);
+    useAnnouncerStore.getState().announce(message);
+  };
+
   const handleImport = async () => {
     setImportMessage(null);
     setImportWarnings([]);
@@ -208,7 +256,7 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
       const result = await appThemeClient.importTheme();
       if (!result.ok) {
         if (!result.errors.includes("Import cancelled")) {
-          setImportMessage(result.errors[0] ?? "Failed to import app theme.");
+          announceImportResult(result.errors[0] ?? "Failed to import app theme.");
         }
         return;
       }
@@ -219,15 +267,15 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
 
       if (result.warnings.length > 0) {
         setImportWarnings(result.warnings);
-        setImportMessage(
+        announceImportResult(
           `Imported "${result.scheme.name}" with ${result.warnings.length} warning${result.warnings.length === 1 ? "" : "s"}.`
         );
       } else {
-        setImportMessage(`Imported "${result.scheme.name}".`);
+        announceImportResult(`Imported "${result.scheme.name}".`);
       }
     } catch (error) {
       logError("Failed to import app theme", error);
-      setImportMessage("Failed to import app theme.");
+      announceImportResult("Failed to import app theme.");
     }
   };
 
@@ -238,7 +286,7 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
       await appThemeClient.exportTheme(effectiveScheme);
     } catch (error) {
       logError("Failed to export app theme", error);
-      setImportMessage("Failed to export app theme.");
+      announceImportResult("Failed to export app theme.");
     }
   };
 
@@ -290,7 +338,10 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
       )}
 
       {importMessage && (
-        <div className="rounded-[var(--radius-md)] border border-overlay bg-surface-panel px-3 py-2">
+        <div
+          role="status"
+          className="rounded-[var(--radius-md)] border border-overlay bg-surface-panel px-3 py-2"
+        >
           <div className="flex items-start gap-2">
             <AlertTriangle
               className={cn(
@@ -301,13 +352,22 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
             <div className="min-w-0">
               <p className="text-xs text-daintree-text">{importMessage}</p>
               {importWarnings.length > 0 && (
-                <ul className="mt-1 space-y-1">
-                  {importWarnings.map((warning, index) => (
-                    <li
-                      key={`${warning.message}-${index}`}
-                      className="text-[11px] text-daintree-text/60"
-                    >
-                      {warning.message}
+                <ul className="mt-1 space-y-1.5">
+                  {groupWarningsByKind(importWarnings).map(({ kind, messages }) => (
+                    <li key={kind} className="text-[11px] text-daintree-text/60">
+                      {WARNING_KIND_COPY[kind]}
+                      <details className="mt-0.5">
+                        <summary className="cursor-pointer text-daintree-text/40 transition-colors hover:text-daintree-text/70">
+                          Technical details
+                        </summary>
+                        <ul className="mt-1 space-y-0.5 pl-3">
+                          {messages.map((message, index) => (
+                            <li key={index} className="break-words text-daintree-text/40">
+                              {message}
+                            </li>
+                          ))}
+                        </ul>
+                      </details>
                     </li>
                   ))}
                 </ul>

--- a/src/components/Settings/__tests__/AppThemePicker.importFeedback.test.tsx
+++ b/src/components/Settings/__tests__/AppThemePicker.importFeedback.test.tsx
@@ -153,6 +153,64 @@ describe("AppThemePicker import feedback — plain-language warnings", () => {
     expect(screen.getByText('Imported "Imported Theme" with 1 warning.')).toBeTruthy();
   });
 
+  it("summarises the deduplicated category count, not the raw diagnostic count", async () => {
+    vi.mocked(appThemeClient.importTheme).mockResolvedValue(
+      importResultWith([
+        { kind: "low-contrast", message: "a on b is 1.0:1; target is 4.5:1" },
+        { kind: "low-contrast", message: "c on d is 2.0:1; target is 4.5:1" },
+        { kind: "low-contrast", message: "e on f is 3.0:1; target is 4.5:1" },
+        { kind: "type-inferred", message: 'Theme type was inferred as dark. Add "type".' },
+      ])
+    );
+
+    const { container } = render(<AppThemePicker />);
+    clickImport();
+
+    // 4 raw diagnostics span 2 kinds → "2 warnings" and 2 visible rows.
+    await screen.findByText('Imported "Imported Theme" with 2 warnings.');
+    const list = container.querySelector('[role="status"] ul');
+    expect(list?.querySelectorAll(":scope > li")).toHaveLength(2);
+  });
+
+  it("preserves every raw message inside the details when a kind is deduplicated", async () => {
+    const first = "first-low-contrast-diagnostic on surface is 1.1:1; target is 4.5:1";
+    const second = "second-low-contrast-diagnostic on surface is 2.2:1; target is 4.5:1";
+    vi.mocked(appThemeClient.importTheme).mockResolvedValue(
+      importResultWith([
+        { kind: "low-contrast", message: first },
+        { kind: "low-contrast", message: second },
+      ])
+    );
+
+    const { container } = render(<AppThemePicker />);
+    clickImport();
+
+    await screen.findByText("Some colors may be hard to see");
+    // Single friendly row, single disclosure, but both raw messages retained.
+    expect(container.querySelectorAll("details")).toHaveLength(1);
+    expect(screen.getByText(first)).toBeTruthy();
+    expect(screen.getByText(second)).toBeTruthy();
+  });
+
+  it("falls back to non-empty copy for an unrecognised warning kind", async () => {
+    vi.mocked(appThemeClient.importTheme).mockResolvedValue(
+      importResultWith([
+        {
+          kind: "future-unknown-kind" as AppThemeValidationWarning["kind"],
+          message: "some new diagnostic the renderer has no copy for yet",
+        },
+      ])
+    );
+
+    const { container } = render(<AppThemePicker />);
+    clickImport();
+
+    await screen.findByText('Imported "Imported Theme" with 1 warning.');
+    const row = container.querySelector('[role="status"] ul > li');
+    // The friendly line (text before the <details>) must not be blank.
+    expect(row?.firstChild?.textContent?.trim()).toBeTruthy();
+  });
+
   it("renders the result block as an aria status live region", async () => {
     vi.mocked(appThemeClient.importTheme).mockResolvedValue(importResultWith([]));
 

--- a/src/components/Settings/__tests__/AppThemePicker.importFeedback.test.tsx
+++ b/src/components/Settings/__tests__/AppThemePicker.importFeedback.test.tsx
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { AppColorScheme, AppThemeValidationWarning } from "@shared/types/appTheme";
+
+const announce = vi.fn();
+
+vi.mock("@/store/accessibilityAnnouncerStore", () => ({
+  useAnnouncerStore: { getState: () => ({ announce }) },
+}));
+
+vi.mock("@/clients/appThemeClient", () => ({
+  appThemeClient: {
+    setColorScheme: vi.fn().mockResolvedValue(undefined),
+    setFollowSystem: vi.fn().mockResolvedValue(undefined),
+    setCustomSchemes: vi.fn().mockResolvedValue(undefined),
+    setRecentSchemeIds: vi.fn().mockResolvedValue(undefined),
+    importTheme: vi.fn(),
+    exportTheme: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@/lib/appThemeViewTransition", () => ({
+  runThemeReveal: (_origin: unknown, cb: () => void) => cb(),
+}));
+
+const storeState: Record<string, unknown> = {};
+
+vi.mock("@/store/appThemeStore", () => ({
+  useAppThemeStore: Object.assign(
+    (selector: (s: Record<string, unknown>) => unknown) => selector(storeState),
+    { getState: () => storeState }
+  ),
+  injectSchemeToDOM: vi.fn(),
+}));
+
+vi.mock("@shared/theme", () => ({
+  APP_THEME_PREVIEW_KEYS: { background: "--daintree-bg" },
+  getAppThemeWarnings: () => [],
+  applyAccentOverrideToScheme: (scheme: unknown) => scheme,
+  accentOverrideHasLowContrast: () => false,
+  resolveAppTheme: (id: string, customSchemes: { id: string }[]) =>
+    customSchemes.find((s) => s.id === id) ?? {
+      id,
+      name: id,
+      type: "dark",
+      tokens: { "--daintree-bg": "#000" },
+    },
+}));
+
+vi.mock("@/config/appColorSchemes", () => ({
+  BUILT_IN_APP_SCHEMES: [
+    {
+      id: "theme-a",
+      name: "Theme A",
+      type: "dark" as const,
+      tokens: { "--daintree-bg": "#000" },
+    },
+  ],
+}));
+
+import { appThemeClient } from "@/clients/appThemeClient";
+import { AppThemePicker } from "../AppThemePicker";
+
+// Minimal fixture — the picker only reads name/id off the imported scheme, so we
+// cast past the full token map rather than enumerate every required token key.
+const importedScheme = {
+  id: "imported-theme",
+  name: "Imported Theme",
+  type: "dark",
+  builtin: false,
+  tokens: { "surface-canvas": "#000" },
+} as unknown as AppColorScheme;
+
+function importResultWith(warnings: AppThemeValidationWarning[]) {
+  return { ok: true as const, scheme: importedScheme, warnings };
+}
+
+function clickImport() {
+  fireEvent.click(screen.getByText("Import app theme..."));
+}
+
+beforeEach(() => {
+  announce.mockClear();
+  vi.mocked(appThemeClient.importTheme).mockReset();
+  Object.assign(storeState, {
+    selectedSchemeId: "theme-a",
+    customSchemes: [],
+    recentSchemeIds: [],
+    followSystem: false,
+    preferredDarkSchemeId: "theme-a",
+    preferredLightSchemeId: "theme-a",
+    commitSchemeSelection: vi.fn(),
+    setFollowSystem: vi.fn(),
+    setPreferredDarkSchemeId: vi.fn(),
+    setPreferredLightSchemeId: vi.fn(),
+    setRecentSchemeIds: vi.fn(),
+    addCustomScheme: vi.fn(),
+    accentColorOverride: null,
+    setAccentColorOverride: vi.fn(),
+  });
+});
+
+describe("AppThemePicker import feedback — plain-language warnings", () => {
+  it("renders one friendly line per warning kind instead of the raw diagnostics", async () => {
+    vi.mocked(appThemeClient.importTheme).mockResolvedValue(
+      importResultWith([
+        {
+          kind: "low-contrast",
+          message: "text-primary on surface-canvas is 3.91:1; target is 4.5:1",
+        },
+        {
+          kind: "low-contrast",
+          message:
+            "accent-primary outline on surface-panel is 2.34:1; target is 3.0:1 (WCAG 1.4.11 Non-text Contrast)",
+        },
+        {
+          kind: "type-inferred",
+          message: 'Theme type was inferred as dark. Add "type" to make the file explicit.',
+        },
+      ])
+    );
+
+    render(<AppThemePicker />);
+    clickImport();
+
+    // Two low-contrast warnings collapse to a single friendly row.
+    const lowContrastRows = await screen.findAllByText("Some colors may be hard to see");
+    expect(lowContrastRows).toHaveLength(1);
+    expect(screen.getByText("Theme mode was guessed from the colors")).toBeTruthy();
+  });
+
+  it("keeps raw engine diagnostics out of the primary copy and inside a details disclosure", async () => {
+    const rawMessage = "text-primary on surface-canvas is 3.91:1; target is 4.5:1";
+    vi.mocked(appThemeClient.importTheme).mockResolvedValue(
+      importResultWith([{ kind: "low-contrast", message: rawMessage }])
+    );
+
+    const { container } = render(<AppThemePicker />);
+    clickImport();
+
+    const rawNode = await screen.findByText(rawMessage);
+    // The raw diagnostic must live behind a <details> disclosure, never as
+    // top-level summary text.
+    expect(rawNode.closest("details")).not.toBeNull();
+
+    // One disclosure per kind, each labelled for theme authors.
+    const disclosures = container.querySelectorAll("details");
+    expect(disclosures).toHaveLength(1);
+    expect(screen.getByText("Technical details")).toBeTruthy();
+
+    // The headline summary names the count, not WCAG jargon.
+    expect(screen.getByText('Imported "Imported Theme" with 1 warning.')).toBeTruthy();
+  });
+
+  it("renders the result block as an aria status live region", async () => {
+    vi.mocked(appThemeClient.importTheme).mockResolvedValue(importResultWith([]));
+
+    const { container } = render(<AppThemePicker />);
+    clickImport();
+
+    await screen.findByText('Imported "Imported Theme".');
+    const status = container.querySelector('[role="status"]');
+    expect(status).not.toBeNull();
+    expect(status?.textContent).toContain('Imported "Imported Theme".');
+  });
+});
+
+describe("AppThemePicker import feedback — screen-reader announcement", () => {
+  it("announces the summary when an import succeeds with warnings", async () => {
+    vi.mocked(appThemeClient.importTheme).mockResolvedValue(
+      importResultWith([{ kind: "unknown-tokens", message: "Ignored unknown tokens: foo, bar" }])
+    );
+
+    render(<AppThemePicker />);
+    clickImport();
+
+    await screen.findByText("Some values in this theme weren't recognized");
+    expect(announce).toHaveBeenCalledWith('Imported "Imported Theme" with 1 warning.');
+  });
+
+  it("announces the summary when an import succeeds cleanly", async () => {
+    vi.mocked(appThemeClient.importTheme).mockResolvedValue(importResultWith([]));
+
+    render(<AppThemePicker />);
+    clickImport();
+
+    await screen.findByText('Imported "Imported Theme".');
+    expect(announce).toHaveBeenCalledWith('Imported "Imported Theme".');
+  });
+
+  it("announces the error when an import fails", async () => {
+    vi.mocked(appThemeClient.importTheme).mockResolvedValue({
+      ok: false,
+      errors: ["Theme file is not valid JSON"],
+    });
+
+    render(<AppThemePicker />);
+    clickImport();
+
+    await screen.findByText("Theme file is not valid JSON");
+    expect(announce).toHaveBeenCalledWith("Theme file is not valid JSON");
+  });
+
+  it("stays silent when the user cancels the import", async () => {
+    vi.mocked(appThemeClient.importTheme).mockResolvedValue({
+      ok: false,
+      errors: ["Import cancelled"],
+    });
+
+    render(<AppThemePicker />);
+    clickImport();
+
+    // Let the async handler settle.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(announce).not.toHaveBeenCalled();
+    expect(screen.queryByText("Import cancelled")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Theme import feedback used to render raw validation-engine diagnostics verbatim — contrast ratios, WCAG clause numbers, CSS token-key names, JSON field names — and the result block had no live region, so screen-reader users got no announcement when it appeared after an async import. This makes the feedback plain-language and announced.

- Added an `AppThemeWarningKind` discriminant to `AppThemeValidationWarning` and annotated every warning push site across the importer, contrast, colorValidator, and themes validators (TypeScript-enforced, so no site is missed).
- `AppThemePicker` now renders **one plain-language line per warning kind** (deduplicated, first-seen order), with the raw engine diagnostics moved behind a per-kind native `<details>` **Technical details** disclosure instead of shown verbatim. The headline counts the deduplicated categories the user actually sees, not the raw diagnostic count.
- The import/export result is announced through the shared accessibility announcer (`useAnnouncerStore`), and the result block is marked `role="status"`. `AppDialog` mounts `AccessibilityAnnouncer` in-subtree, which handles the Chromium `aria-modal` filter and the `document.ariaNotify` fast path (per lessons #8990 / #9434).
- Unknown warning kinds crossing the IPC boundary fall back to neutral copy, so a future/stale producer can never render a blank row.

## Testing

- New `src/components/Settings/__tests__/AppThemePicker.importFeedback.test.tsx` (10 tests): dedup, friendly copy, raw-message-in-details, `role="status"`, announce on success/warn/fail, silent on cancel, category-count vs raw-count, raw-message preservation under a deduped disclosure, unknown-kind fallback.
- Strengthened `electron/utils/__tests__/appThemeImporter.test.ts` with `kind` assertions.
- `npm run check` passes — typecheck, lint (ratchet improved by 1), format, IPC/channel/confirm-wiring guards. Existing `appThemeImporter` (18) and `builtInThemes` (53) suites pass unchanged.

Closes #10019

🤖 Generated with [Claude Code](https://claude.com/claude-code)
