### PR TITLE
perf(github): decouple toolbar issue/PR counts from the first-page query

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -159,6 +159,7 @@ export const CHANNELS = {
   GITHUB_TOKEN_HEALTH_CHANGED: "github:token-health-changed",
   GITHUB_GET_TOKEN_HEALTH: "github:get-token-health",
   GITHUB_REPO_STATS_AND_PAGE_UPDATED: "github:repo-stats-and-page-updated",
+  GITHUB_REPO_COUNTS_UPDATED: "github:repo-counts-updated",
   GITHUB_GET_FIRST_PAGE_CACHE: "github:get-first-page-cache",
   GITHUB_RESOLVE_AUTHOR_AVATAR: "github:resolve-author-avatar",
 

--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -12,6 +12,7 @@ import type {
   GitHubTokenConfig,
   GitHubTokenValidation,
   RepoStatsAndPagePayload,
+  RepoCountsUpdatedPayload,
   GitHubFirstPageCachePayload,
   GitHubRateLimitDetails,
 } from "../../types/index.js";
@@ -155,6 +156,15 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
         fetchedAt: Date.now(),
       };
       broadcastToRenderer(CHANNELS.GITHUB_REPO_STATS_AND_PAGE_UPDATED, payload);
+    } else if (result.source === "network" && !result.stale) {
+      // Count-only poll (the cheap REST path, issue #10122) — push the fresh
+      // counts to other views of the same project without page data.
+      const payload: RepoCountsUpdatedPayload = {
+        projectPath: path.resolve(cwd),
+        stats: result.stats,
+        fetchedAt: Date.now(),
+      };
+      broadcastToRenderer(CHANNELS.GITHUB_REPO_COUNTS_UPDATED, payload);
     }
 
     return result.stats;

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -97,6 +97,7 @@ import type {
   GitHubRateLimitPayload,
   GitHubTokenHealthPayload,
   RepoStatsAndPagePayload,
+  RepoCountsUpdatedPayload,
   ServiceConnectivityPayload,
   GitStatus,
   KeyAction,
@@ -1686,6 +1687,9 @@ const api: ElectronAPI = {
 
     onRepoStatsAndPageUpdated: (callback: (data: RepoStatsAndPagePayload) => void) =>
       _typedOn(CHANNELS.GITHUB_REPO_STATS_AND_PAGE_UPDATED, callback),
+
+    onRepoCountsUpdated: (callback: (data: RepoCountsUpdatedPayload) => void) =>
+      _typedOn(CHANNELS.GITHUB_REPO_COUNTS_UPDATED, callback),
 
     getTokenHealth: () => _unwrappingInvoke(CHANNELS.GITHUB_GET_TOKEN_HEALTH),
   },

--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -14,7 +14,6 @@ export {
   withRepoContextRetry,
   clearGitHubCaches,
   clearPRCaches,
-  getRepoStats,
   getRepoStatsAndPage,
   getProjectHealth,
   batchCheckLinkedPRs,

--- a/electron/services/__tests__/GitHubService.adversarial.test.ts
+++ b/electron/services/__tests__/GitHubService.adversarial.test.ts
@@ -221,13 +221,15 @@ describe("GitHubService adversarial", () => {
     });
     shared.graphqlClient.mockRejectedValueOnce(new Error("API rate limit exceeded"));
 
-    await expect(github.getRepoStats("/repo")).resolves.toEqual({
+    await expect(github.getRepoStatsAndPage("/repo", true)).resolves.toEqual({
       stats: {
         issueCount: 11,
         prCount: 5,
         stale: true,
         lastUpdated: 123,
       },
+      issues: null,
+      prs: null,
       error: "GitHub rate limit exceeded. Try again in a few minutes.",
     });
   });
@@ -300,8 +302,10 @@ describe("GitHubService adversarial", () => {
   it("AUTH_FAILURE_NOT_CACHED_ACROSS_RECOVERY", async () => {
     shared.tokenState.token = undefined;
 
-    await expect(github.getRepoStats("/repo")).resolves.toEqual({
+    await expect(github.getRepoStatsAndPage("/repo")).resolves.toEqual({
       stats: null,
+      issues: null,
+      prs: null,
       error: "GitHub token not configured. Set it in Settings.",
     });
 
@@ -313,12 +317,13 @@ describe("GitHubService adversarial", () => {
       },
     });
 
-    await expect(github.getRepoStats("/repo", true)).resolves.toEqual({
+    await expect(github.getRepoStatsAndPage("/repo", true)).resolves.toMatchObject({
       stats: {
         issueCount: 3,
         prCount: 2,
         lastUpdated: expect.any(Number),
       },
+      source: "network",
     });
   });
 
@@ -429,10 +434,10 @@ describe("GitHubService adversarial", () => {
         },
       });
 
-    const repoStats = await github.getRepoStats("/repo", true);
+    const repoStats = await github.getRepoStatsAndPage("/repo", true);
     const projectHealth = await github.getProjectHealth("/repo", true);
 
-    expect(repoStats).toEqual({
+    expect(repoStats).toMatchObject({
       stats: {
         issueCount: 0,
         prCount: 0,

--- a/plugins/builtin/github/main/GitHubCaches.ts
+++ b/plugins/builtin/github/main/GitHubCaches.ts
@@ -11,7 +11,12 @@ import type {
   IssueTooltipData,
   PRTooltipData,
 } from "../../../../shared/types/github.js";
-import type { RepoContext, RepoStats, RepoStatsAndPageSnapshot } from "./types.js";
+import type {
+  RepoContext,
+  RepoStats,
+  RepoStatsAndPageSnapshot,
+  RestCountsSnapshot,
+} from "./types.js";
 import type { Issue, PR, Page } from "../../../../shared/types/forge.js";
 
 export const repoContextCache = new Cache<string, RepoContext>({ defaultTTL: 300000 });
@@ -107,6 +112,21 @@ export const repoPRListETagCache = new Cache<string, string>({
  * the other ETag caches.
  */
 export const openPRListETagCache = new Cache<string, string>({
+  maxSize: ETAG_CACHE_MAX_SIZE,
+  defaultTTL: ETAG_CACHE_TTL,
+});
+
+/**
+ * Counts + ETags from the last successful `fetchRestCounts` (the cheap REST
+ * count poll behind the toolbar pill, issue #10122), keyed by `owner/repo`.
+ * One atomic entry rather than separate ETag caches: a `304` on either REST
+ * leg is only servable when the count that ETag validated is still on hand,
+ * and a mixed `304`/`200` pair must read both fallback values from the same
+ * baseline. Written only after both legs produce valid counts (#9440 commit
+ * discipline) — a failed fetch never advances the ETags. 1-hour TTL matches
+ * the other ETag caches; on expiry both legs simply refetch unconditionally.
+ */
+export const restCountsCache = new Cache<string, RestCountsSnapshot>({
   maxSize: ETAG_CACHE_MAX_SIZE,
   defaultTTL: ETAG_CACHE_TTL,
 });
@@ -215,6 +235,7 @@ export function clearGitHubCaches(): void {
   projectHealthCache.clear();
   velocityCache.clear();
   repoStatsAndPageSnapshotCache.clear();
+  restCountsCache.clear();
   repoEventsETagCache.clear();
   repoEventsPollIntervalCache.clear();
   repoEventsNoChangeCount.clear();
@@ -261,6 +282,10 @@ export function clearPRCaches(): void {
   // must drop with the PR caches. `velocityCache` is repo-level metadata on a
   // days timescale, not PR-list state, so it deliberately survives here.
   repoStatsAndPageSnapshotCache.clear();
+  // The REST count snapshot embeds the open-PR count and the ETag baselines it
+  // was observed under — a manual refresh must force the next count poll to a
+  // fresh `200` rather than serving the pre-refresh counts on a `304`.
+  restCountsCache.clear();
   // The events ETag is correctness state: a cleared ETag forces a fresh `200`
   // so the next probe re-checks from scratch. The no-change counter and last
   // probe time are reset too — a manual refresh is exactly the "window focus"

--- a/plugins/builtin/github/main/GitHubQueries.ts
+++ b/plugins/builtin/github/main/GitHubQueries.ts
@@ -1,20 +1,5 @@
 import type { PRCheckCandidate } from "./types.js";
 
-export const REPO_STATS_QUERY = `
-  query GetRepoStats($owner: String!, $repo: String!) {
-    repository(owner: $owner, name: $repo) {
-      issues(states: OPEN) { totalCount }
-      pullRequests(states: OPEN) { totalCount }
-    }
-    rateLimit {
-      cost
-      remaining
-      resetAt
-      limit
-    }
-  }
-`;
-
 // Combined poll query: returns the count badges AND the first page of open
 // issues + open PRs (default filter + sort) in a single round-trip. Cost on
 // GitHub's GraphQL rate limit is dominated by nested `first:` connections —

--- a/plugins/builtin/github/main/GitHubStats.ts
+++ b/plugins/builtin/github/main/GitHubStats.ts
@@ -2,7 +2,7 @@ import fs from "fs/promises";
 import path from "path";
 import type { GraphQlQueryResponseData } from "@octokit/graphql";
 import { GitHubAuth, GITHUB_API_TIMEOUT_MS, rateLimitAwareFetch } from "./GitHubAuth.js";
-import { REPO_STATS_QUERY, REPO_STATS_AND_PAGE_QUERY } from "./GitHubQueries.js";
+import { REPO_STATS_AND_PAGE_QUERY } from "./GitHubQueries.js";
 import { gitHubRateLimitService } from "./GitHubRateLimitService.js";
 import { rateLimitMessage } from "./GitHubErrors.js";
 import { parseGitHubError } from "./GitHubErrors.js";
@@ -13,6 +13,7 @@ import {
   issueListCache,
   prListCache,
   repoStatsAndPageSnapshotCache,
+  restCountsCache,
   repoEventsETagCache,
   repoEventsPollIntervalCache,
   repoEventsNoChangeCount,
@@ -21,7 +22,7 @@ import {
 } from "./GitHubCaches.js";
 import { GitHubStatsCache } from "../../../../electron/services/GitHubStatsCache.js";
 import { GitHubFirstPageCache } from "../../../../electron/services/GitHubFirstPageCache.js";
-import type { RepoStats, RepoStatsResult } from "./types.js";
+import type { RepoStats, RestCountsSnapshot } from "./types.js";
 import type { GitHubIssue, GitHubPR } from "../../../../shared/types/github.js";
 import { parseIssueNode } from "./GitHubIssues.js";
 import { parsePRNode, buildListCacheKey } from "./GitHubPRs.js";
@@ -29,124 +30,6 @@ import type {
   RepositoryStats,
   GitHubFirstPageCachePayload,
 } from "../../../../electron/types/index.js";
-
-export async function getRepoStats(
-  cwd: string,
-  bypassCache = false,
-  _retried = false
-): Promise<RepoStatsResult> {
-  const context = await getRepoContext(cwd);
-  if (!context) {
-    return { stats: null, error: "Not a GitHub repository" };
-  }
-
-  const cacheKey = `${context.owner}/${context.repo}`;
-  const persistentCache = GitHubStatsCache.getInstance();
-
-  const client = GitHubAuth.createClient();
-  if (!client) {
-    const diskCached = persistentCache.get(cacheKey);
-    if (diskCached) {
-      return {
-        stats: {
-          issueCount: diskCached.issueCount,
-          prCount: diskCached.prCount,
-          stale: true,
-          lastUpdated: diskCached.lastUpdated,
-        },
-        error: "GitHub token not configured. Set it in Settings.",
-      };
-    }
-    return { stats: null, error: "GitHub token not configured. Set it in Settings." };
-  }
-
-  const rateLimitBlock = gitHubRateLimitService.shouldBlockRequest("graphql");
-  if (rateLimitBlock.blocked && rateLimitBlock.reason && rateLimitBlock.resumeAt) {
-    const diskCached = persistentCache.get(cacheKey);
-    const message = rateLimitMessage(rateLimitBlock.reason, rateLimitBlock.resumeAt);
-    if (diskCached) {
-      return {
-        stats: {
-          issueCount: diskCached.issueCount,
-          prCount: diskCached.prCount,
-          stale: true,
-          lastUpdated: diskCached.lastUpdated,
-        },
-        error: message,
-      };
-    }
-    return { stats: null, error: message };
-  }
-
-  if (!bypassCache) {
-    const cached = repoStatsCache.get(cacheKey);
-    if (cached) {
-      return { stats: cached };
-    }
-  }
-
-  try {
-    const result = (await client(REPO_STATS_QUERY, {
-      owner: context.owner,
-      repo: context.repo,
-      request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
-    })) as GraphQlQueryResponseData;
-
-    gitHubRateLimitService.updateFromGraphQL(result, "REPO_STATS_QUERY");
-
-    const repository = result?.repository;
-    if (!repository) {
-      const diskCached = persistentCache.get(cacheKey);
-      if (diskCached) {
-        return {
-          stats: {
-            issueCount: diskCached.issueCount,
-            prCount: diskCached.prCount,
-            stale: true,
-            lastUpdated: diskCached.lastUpdated,
-          },
-          error: "Repository not found (showing cached data)",
-        };
-      }
-      return { stats: null, error: "Repository not found" };
-    }
-
-    const stats: RepoStats = {
-      issueCount: repository.issues?.totalCount ?? 0,
-      prCount: repository.pullRequests?.totalCount ?? 0,
-      lastUpdated: Date.now(),
-    };
-
-    repoStatsCache.set(cacheKey, stats);
-    persistentCache.set(cacheKey, stats, cwd);
-
-    return { stats };
-  } catch (error) {
-    if (!_retried && isRepoNotFoundError(error)) {
-      repoContextCache.invalidate(cwd);
-      const freshContext = await getRepoContext(cwd);
-      if (
-        freshContext &&
-        (freshContext.owner !== context.owner || freshContext.repo !== context.repo)
-      ) {
-        return getRepoStats(cwd, bypassCache, true);
-      }
-    }
-    const diskCached = persistentCache.get(cacheKey);
-    if (diskCached) {
-      return {
-        stats: {
-          issueCount: diskCached.issueCount,
-          prCount: diskCached.prCount,
-          stale: true,
-          lastUpdated: diskCached.lastUpdated,
-        },
-        error: parseGitHubError(error),
-      };
-    }
-    return { stats: null, error: parseGitHubError(error) };
-  }
-}
 
 export interface RepoStatsAndPageResult {
   stats: RepoStats | null;
@@ -302,6 +185,136 @@ export async function fetchActivityProbe(
   }
 }
 
+/**
+ * Total result count from a paginated REST response's `Link` header: with
+ * `per_page=1`, the `rel="last"` page number IS the total count. Returns
+ * `null` when the header is absent (GitHub omits it when everything fits on
+ * one page, i.e. 0 or 1 results) or unparseable — callers fall back to the
+ * body's array length.
+ */
+export function parseLinkLastPage(linkHeader: string | null): number | null {
+  if (!linkHeader) return null;
+  const match = linkHeader.match(/<[^>]*[?&]page=(\d+)[^>]*>;\s*rel="last"/);
+  if (!match) return null;
+  const page = parseInt(match[1], 10);
+  return Number.isFinite(page) && page >= 0 ? page : null;
+}
+
+/**
+ * Cheap REST replacement for the count half of `REPO_STATS_AND_PAGE_QUERY`
+ * (issue #10122): the background toolbar poll needs two scalars, not a full
+ * first page with labels, assignees, timeline items, and check rollups.
+ *
+ * Two parallel conditional GETs, both on the REST `"core"` bucket (separate
+ * from the GraphQL budget, zero quota on `304` — same economics as
+ * {@link fetchActivityProbe}):
+ *
+ * - `GET /repos/{owner}/{repo}` → `open_issues_count`, which GitHub defines as
+ *   open issues + open PRs combined.
+ * - `GET /repos/{owner}/{repo}/pulls?state=open&per_page=1` → total open PR
+ *   count from the `Link: rel="last"` page number (or body length when the
+ *   header is omitted at 0–1 results).
+ *
+ * `issueCount` is derived as `combined − prCount`, so both legs must resolve
+ * against the same baseline: on success the counts and their ETags are
+ * committed as one {@link restCountsCache} entry, and a `304` leg replays the
+ * stored value from that entry. Any failure — non-200/304 status, malformed
+ * body, a `304` with no stored baseline, a negative derived count from a
+ * cross-endpoint race — returns `null` without advancing any ETag (#9440), so
+ * the next poll re-detects the change instead of masking it.
+ */
+export async function fetchRestCounts(
+  token: string,
+  owner: string,
+  repo: string
+): Promise<RepoStats | null> {
+  const cacheKey = `${owner}/${repo}`;
+
+  const block = gitHubRateLimitService.shouldBlockRequest("core");
+  if (block.blocked) return null;
+
+  const prior = restCountsCache.get(cacheKey);
+  const versionAtStart = getETagCacheVersion();
+  const baseHeaders: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  const repoHeaders = { ...baseHeaders };
+  if (prior?.repoEtag) repoHeaders["If-None-Match"] = prior.repoEtag;
+  const prHeaders = { ...baseHeaders };
+  if (prior?.prEtag) prHeaders["If-None-Match"] = prior.prEtag;
+
+  try {
+    const [repoRes, prRes] = await Promise.all([
+      rateLimitAwareFetch(`https://api.github.com/repos/${owner}/${repo}`, {
+        headers: repoHeaders,
+        signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
+        daintreeSkipRateLimitPreflight: true,
+      }),
+      rateLimitAwareFetch(
+        `https://api.github.com/repos/${owner}/${repo}/pulls?state=open&per_page=1`,
+        {
+          headers: prHeaders,
+          signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
+          daintreeSkipRateLimitPreflight: true,
+        }
+      ),
+    ]);
+
+    // A concurrent cache clear invalidated the ETag baseline these requests
+    // were built on — discard rather than committing counts against it.
+    if (getETagCacheVersion() !== versionAtStart) return null;
+
+    let combinedCount: number;
+    let repoEtag: string | null;
+    if (repoRes.status === 304 && prior) {
+      combinedCount = prior.combinedCount;
+      repoEtag = prior.repoEtag;
+    } else if (repoRes.status === 200) {
+      const body = (await repoRes.json()) as { open_issues_count?: unknown } | null;
+      const count = body?.open_issues_count;
+      if (typeof count !== "number" || !Number.isFinite(count) || count < 0) return null;
+      combinedCount = count;
+      repoEtag = repoRes.headers.get("etag");
+    } else {
+      return null;
+    }
+
+    let prCount: number;
+    let prEtag: string | null;
+    if (prRes.status === 304 && prior) {
+      prCount = prior.prCount;
+      prEtag = prior.prEtag;
+    } else if (prRes.status === 200) {
+      const lastPage = parseLinkLastPage(prRes.headers.get("link"));
+      if (lastPage !== null) {
+        prCount = lastPage;
+      } else {
+        const body = (await prRes.json()) as unknown;
+        if (!Array.isArray(body)) return null;
+        prCount = body.length;
+      }
+      prEtag = prRes.headers.get("etag");
+    } else {
+      return null;
+    }
+
+    // The two endpoints are not transactional — a PR opening between the two
+    // reads can make the derived issue count negative. Treat it as a failed
+    // fetch (no commit) so the next poll reads a consistent pair.
+    const issueCount = combinedCount - prCount;
+    if (issueCount < 0) return null;
+
+    const lastUpdated = Date.now();
+    const snapshot: RestCountsSnapshot = { combinedCount, prCount, repoEtag, prEtag, lastUpdated };
+    restCountsCache.set(cacheKey, snapshot);
+    return { issueCount, prCount, lastUpdated };
+  } catch {
+    return null;
+  }
+}
+
 export async function getRepoStatsAndPage(
   cwd: string,
   bypassCache = false,
@@ -384,17 +397,14 @@ export async function getRepoStatsAndPage(
   }
 
   // Activity-probe gate: when the short-lived memory cache has expired, a cheap
-  // conditional GET to the REST `/events` feed decides whether the expensive
-  // stats query (~6+ GraphQL points) is needed at all. An authenticated `304`
-  // costs zero rate-limit quota, so an idle repo polls indefinitely for free.
-  // When the probe reports "unchanged", nothing the stats query observes can
-  // have changed, so the cached snapshot is re-warmed and returned without the
-  // heavy fetch. This runs BEFORE the GraphQL rate-limit gate below: the probe
-  // and the snapshot it validates draw from the REST `"core"` bucket, so a
-  // depleted GraphQL budget must not suppress a zero-cost `304` cache hit.
+  // conditional GET to the REST `/events` feed decides whether any count fetch
+  // is needed at all. An authenticated `304` costs zero rate-limit quota, so an
+  // idle repo polls indefinitely for free. When the probe reports "unchanged",
+  // nothing the count fetch observes can have changed, so the cached snapshot
+  // is re-warmed and returned without any further request.
   //
   // `pendingEventsEtag` carries a changed-probe's new ETag so it can be written
-  // only after the full query succeeds — committing it eagerly would let a
+  // only after the count fetch succeeds — committing it eagerly would let a
   // failed fetch advance the ETag ahead of the snapshot and mask the change.
   let pendingEventsEtag: string | null | undefined;
   if (bypassCache) {
@@ -407,12 +417,14 @@ export async function getRepoStatsAndPage(
     const token = GitHubAuth.getToken();
     if (token) {
       const snapshot = repoStatsAndPageSnapshotCache.get(cacheKey);
+      const restCounts = restCountsCache.get(cacheKey);
       // Skip the network probe entirely while inside the adaptive window: never
       // poll `/events` faster than the server-advertised `X-Poll-Interval`, and
-      // back off further on an idle repo. The cached snapshot stands in for the
+      // back off further on an idle repo. The cached snapshot (or, on the
+      // background-only path, the last REST counts) stands in for the
       // "unchanged" result we'd otherwise pay a request to confirm.
       const withinBackoff =
-        snapshot !== undefined &&
+        (snapshot !== undefined || restCounts !== undefined) &&
         Date.now() - (repoEventsLastProbeAt.get(cacheKey) ?? 0) < eventsProbeDelayMs(cacheKey);
       const probe: ActivityProbeResult = withinBackoff
         ? { status: "unchanged" }
@@ -423,7 +435,19 @@ export async function getRepoStatsAndPage(
       }
 
       if (probe.status === "unchanged" && snapshot) {
-        const freshStats: RepoStats = { ...snapshot.stats, lastUpdated: Date.now() };
+        // The cheap REST poll may have observed fresher counts after this
+        // snapshot was written (it deliberately leaves the page snapshot
+        // untouched) — serve whichever count pair was committed most recently
+        // so an unchanged probe can't roll the pill back to pre-REST counts.
+        const restCountsFresher =
+          restCounts !== undefined && restCounts.lastUpdated >= (snapshot.stats.lastUpdated ?? 0);
+        const freshStats: RepoStats = restCountsFresher
+          ? {
+              issueCount: restCounts.combinedCount - restCounts.prCount,
+              prCount: restCounts.prCount,
+              lastUpdated: Date.now(),
+            }
+          : { ...snapshot.stats, lastUpdated: Date.now() };
         repoStatsCache.set(cacheKey, freshStats);
         issueListCache.set(issuesListCacheKey, {
           items: snapshot.issues.items,
@@ -460,7 +484,87 @@ export async function getRepoStatsAndPage(
           nextPollIntervalMs: eventsProbeDelayMs(cacheKey),
         };
       }
+
+      // Background-only steady state: the page snapshot is written solely by
+      // the explicit-refresh GraphQL path now, so once its 10-min TTL lapses
+      // an unchanged probe lands here. The last committed REST counts are the
+      // "reuse cached count" half of the probe contract (issue #10122) — an
+      // idle repo costs one conditional `/events` GET per cadence window, not
+      // a probe plus two count requests.
+      if (probe.status === "unchanged" && !snapshot && restCounts) {
+        const freshStats: RepoStats = {
+          issueCount: restCounts.combinedCount - restCounts.prCount,
+          prCount: restCounts.prCount,
+          lastUpdated: Date.now(),
+        };
+        repoStatsCache.set(cacheKey, freshStats);
+        persistentCache.set(cacheKey, freshStats, cwd);
+        return {
+          stats: freshStats,
+          issues: null,
+          prs: null,
+          source: "network",
+          nextPollIntervalMs: eventsProbeDelayMs(cacheKey),
+        };
+      }
     }
+  }
+
+  // Background polls (the only `bypassCache: false` callers reaching this
+  // point) need just the two toolbar count scalars — fetch them via the cheap
+  // conditional REST pair instead of the ~6-point GraphQL page query (issue
+  // #10122). The full page now ships only on the explicit-refresh path below
+  // or via the dropdown's own list queries; the dropdown's fresh `totalCount`
+  // corrects the pill through `resolveGitHubDisplayCount`. On REST failure,
+  // serve the last-known disk counts rather than falling through to GraphQL —
+  // a silent fallback would quietly reinstate the heavy query on every
+  // transient REST error.
+  if (!bypassCache) {
+    const token = GitHubAuth.getToken();
+    const restStats = token ? await fetchRestCounts(token, context.owner, context.repo) : null;
+    if (restStats) {
+      repoStatsCache.set(cacheKey, restStats);
+      persistentCache.set(cacheKey, restStats, cwd);
+      // Commit the changed-probe's events ETag in lockstep with the counts it
+      // describes — same deferred-commit discipline as the GraphQL path: a
+      // failed count fetch leaves the old ETag so the next probe re-detects
+      // the change instead of masking it behind a 304.
+      if (pendingEventsEtag !== undefined) {
+        if (pendingEventsEtag) {
+          repoEventsETagCache.set(cacheKey, pendingEventsEtag);
+        } else {
+          repoEventsETagCache.invalidate(cacheKey);
+        }
+      }
+      return {
+        stats: restStats,
+        issues: null,
+        prs: null,
+        source: "network",
+        nextPollIntervalMs: eventsProbeDelayMs(cacheKey),
+      };
+    }
+
+    const coreBlock = gitHubRateLimitService.shouldBlockRequest("core");
+    const message =
+      coreBlock.blocked && coreBlock.reason && coreBlock.resumeAt
+        ? rateLimitMessage(coreBlock.reason, coreBlock.resumeAt)
+        : "Couldn't fetch repository counts";
+    const diskCached = persistentCache.get(cacheKey);
+    if (diskCached) {
+      return {
+        stats: {
+          issueCount: diskCached.issueCount,
+          prCount: diskCached.prCount,
+          stale: true,
+          lastUpdated: diskCached.lastUpdated,
+        },
+        issues: null,
+        prs: null,
+        error: message,
+      };
+    }
+    return { stats: null, issues: null, prs: null, error: message };
   }
 
   const rateLimitBlock = gitHubRateLimitService.shouldBlockRequest("graphql");
@@ -588,18 +692,6 @@ export async function getRepoStatsAndPage(
       issues: issuesPage,
       prs: prsPage,
     });
-    // Commit the changed-probe's events ETag now, in lockstep with the snapshot
-    // it describes. Deferring it to here (rather than writing it in
-    // `fetchActivityProbe`) guarantees the ETag never advances ahead of the
-    // snapshot: if this query had failed, the old ETag would survive and the
-    // next probe would re-detect the change instead of masking it behind a 304.
-    if (pendingEventsEtag !== undefined) {
-      if (pendingEventsEtag) {
-        repoEventsETagCache.set(cacheKey, pendingEventsEtag);
-      } else {
-        repoEventsETagCache.invalidate(cacheKey);
-      }
-    }
 
     return {
       stats,

--- a/plugins/builtin/github/main/GitHubStats.ts
+++ b/plugins/builtin/github/main/GitHubStats.ts
@@ -194,10 +194,17 @@ export async function fetchActivityProbe(
  */
 export function parseLinkLastPage(linkHeader: string | null): number | null {
   if (!linkHeader) return null;
-  const match = linkHeader.match(/<[^>]*[?&]page=(\d+)[^>]*>;\s*rel="last"/);
-  if (!match) return null;
-  const page = parseInt(match[1], 10);
-  return Number.isFinite(page) && page >= 0 ? page : null;
+  // Split into link-values first: RFC 8288 allows extra parameters between the
+  // URL and `rel` (`<url>; type="…"; rel="last"`), so anchoring `rel="last"`
+  // directly after `>` would silently miss a reordered header and undercount.
+  for (const segment of linkHeader.split(",")) {
+    if (!/rel="last"/.test(segment)) continue;
+    const match = segment.match(/<[^>]*[?&]page=(\d+)[^>]*>/);
+    if (!match) return null;
+    const page = parseInt(match[1], 10);
+    return Number.isFinite(page) && page >= 0 ? page : null;
+  }
+  return null;
 }
 
 /**
@@ -305,6 +312,12 @@ export async function fetchRestCounts(
     // fetch (no commit) so the next poll reads a consistent pair.
     const issueCount = combinedCount - prCount;
     if (issueCount < 0) return null;
+
+    // Re-check right before the commit: the `json()` awaits above are further
+    // suspension points where a concurrent clear (token change / manual
+    // refresh) can land — committing past it would re-seed the just-cleared
+    // cache with a pre-clear baseline that then serves for up to the 1h TTL.
+    if (getETagCacheVersion() !== versionAtStart) return null;
 
     const lastUpdated = Date.now();
     const snapshot: RestCountsSnapshot = { combinedCount, prCount, repoEtag, prEtag, lastUpdated };

--- a/plugins/builtin/github/main/__tests__/GitHubQueries.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubQueries.test.ts
@@ -7,7 +7,6 @@ import {
   buildBatchRequiredChecksQuery,
   buildBatchIssuesQuery,
   buildBatchPRsQuery,
-  REPO_STATS_QUERY,
   LIST_PRS_QUERY,
   REPO_STATS_AND_PAGE_QUERY,
   SEARCH_QUERY,
@@ -410,15 +409,11 @@ describe("buildBatchPRQuery", () => {
   });
 
   describe("rateLimit field", () => {
-    it("includes rateLimit at operation root in REPO_STATS_QUERY", () => {
-      expect(REPO_STATS_QUERY).toContain("rateLimit {");
-      expect(REPO_STATS_QUERY).toContain("cost");
-      expect(REPO_STATS_QUERY).toContain("remaining");
-      expect(REPO_STATS_QUERY).toContain("resetAt");
-    });
-
-    it("includes rateLimit in REPO_STATS_AND_PAGE_QUERY", () => {
+    it("includes rateLimit at operation root in REPO_STATS_AND_PAGE_QUERY", () => {
       expect(REPO_STATS_AND_PAGE_QUERY).toContain("rateLimit {");
+      expect(REPO_STATS_AND_PAGE_QUERY).toContain("cost");
+      expect(REPO_STATS_AND_PAGE_QUERY).toContain("remaining");
+      expect(REPO_STATS_AND_PAGE_QUERY).toContain("resetAt");
     });
 
     it("includes rateLimit in PROJECT_HEALTH_QUERY", () => {

--- a/plugins/builtin/github/main/__tests__/GitHubStats.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubStats.test.ts
@@ -3,9 +3,11 @@ import { formatErrorMessage } from "../../../../../shared/utils/errorMessage.js"
 
 // `getRepoStatsAndPage` is an orchestration boundary — mock the
 // network/auth/repo dependencies and leave the real caches in place so the
-// activity-probe gate is exercised end to end. The full stats query goes
-// through the mocked GraphQL client; the REST `/events` probe goes through the
-// mocked `rateLimitAwareFetch`. See issues #8757 and #9041.
+// activity-probe gate and the REST count path are exercised end to end. The
+// explicit-refresh stats query goes through the mocked GraphQL client; the
+// REST `/events` probe and the count pair (`/repos/{owner}/{repo}` +
+// `/pulls?state=open&per_page=1`) go through the mocked `rateLimitAwareFetch`.
+// See issues #8757, #9041, and #10122.
 
 const mockClient = vi.fn();
 const mockFetch = vi.fn();
@@ -63,12 +65,13 @@ vi.mock("../../../../../electron/services/GitHubFirstPageCache.js", () => ({
   GitHubFirstPageCache: { getInstance: () => mockFirstPageCache },
 }));
 
-import { getRepoStatsAndPage } from "../GitHubStats.js";
+import { getRepoStatsAndPage, parseLinkLastPage } from "../GitHubStats.js";
 import {
   repoStatsCache,
   issueListCache,
   prListCache,
   repoStatsAndPageSnapshotCache,
+  restCountsCache,
   repoEventsETagCache,
   repoEventsPollIntervalCache,
   repoEventsNoChangeCount,
@@ -97,26 +100,107 @@ function statsResponse(issueCount = 5, prCount = 3): Record<string, unknown> {
   };
 }
 
-/** A minimal `Response`-like for the events probe — only `status` + `headers.get`. */
-function eventsResponse(
+interface FakeResponse {
+  status: number;
+  headers: { get: (name: string) => string | null };
+  json: () => Promise<unknown>;
+}
+
+/** A minimal `Response`-like — `status`, `headers.get`, and `json()`. */
+function restResponse(
   status: number,
-  opts: { etag?: string; pollInterval?: string } = {}
-): { status: number; headers: { get: (name: string) => string | null } } {
+  opts: { etag?: string; link?: string; pollInterval?: string; body?: unknown } = {}
+): FakeResponse {
   const headers = new Map<string, string>();
   if (opts.etag !== undefined) headers.set("etag", opts.etag);
+  if (opts.link !== undefined) headers.set("link", opts.link);
   if (opts.pollInterval !== undefined) headers.set("x-poll-interval", opts.pollInterval);
   return {
     status,
     headers: { get: (name: string) => headers.get(name.toLowerCase()) ?? null },
+    json: async () => opts.body,
   };
+}
+
+function eventsResponse(
+  status: number,
+  opts: { etag?: string; pollInterval?: string } = {}
+): FakeResponse {
+  return restResponse(status, opts);
+}
+
+/** `GET /repos/{owner}/{repo}` — 200 with `open_issues_count` (issues + PRs combined). */
+function repoOk(openIssuesCount: number, etag = '"r1"'): FakeResponse {
+  return restResponse(200, { etag, body: { open_issues_count: openIssuesCount } });
+}
+
+/**
+ * `GET /repos/{owner}/{repo}/pulls?state=open&per_page=1` — 200 whose
+ * `Link: rel="last"` page number is the total open PR count. GitHub omits the
+ * header entirely when everything fits on one page (0 or 1 PRs), so those
+ * counts come from the body array length.
+ */
+function pullsOk(prCount: number, etag = '"p1"'): FakeResponse {
+  if (prCount >= 2) {
+    const link =
+      `<https://api.github.com/repositories/1/pulls?state=open&per_page=1&page=2>; rel="next", ` +
+      `<https://api.github.com/repositories/1/pulls?state=open&per_page=1&page=${prCount}>; rel="last"`;
+    return restResponse(200, { etag, link, body: [{}] });
+  }
+  return restResponse(200, { etag, body: prCount === 1 ? [{}] : [] });
+}
+
+/**
+ * Route the fetch mock per endpoint. Each queue is consumed in order; the last
+ * entry is sticky (mirrors `mockResolvedValueOnce` + `mockResolvedValue`).
+ */
+function routeFetch(routes: {
+  events?: FakeResponse[];
+  repo?: FakeResponse[];
+  pulls?: FakeResponse[];
+}): void {
+  const queues = {
+    events: [...(routes.events ?? [])],
+    repo: [...(routes.repo ?? [])],
+    pulls: [...(routes.pulls ?? [])],
+  };
+  mockFetch.mockImplementation((input: unknown) => {
+    const url = String(input);
+    const key = url.includes("/events")
+      ? "events"
+      : url.includes("/pulls")
+        ? "pulls"
+        : ("repo" as const);
+    const queue = queues[key as keyof typeof queues];
+    if (queue.length === 0) {
+      return Promise.reject(new Error(`unexpected ${key} request: ${url}`));
+    }
+    const next = queue.length > 1 ? queue.shift()! : queue[0];
+    return Promise.resolve(next);
+  });
 }
 
 function statsQueryCount(): number {
   return mockClient.mock.calls.filter((c) => String(c[0]).includes("GetRepoStatsAndPage")).length;
 }
 
+function callsTo(part: string): Array<[unknown, { headers: Record<string, string> }]> {
+  return mockFetch.mock.calls.filter((c) => String(c[0]).includes(part)) as Array<
+    [unknown, { headers: Record<string, string> }]
+  >;
+}
+
 function probeRestCallCount(): number {
-  return mockFetch.mock.calls.filter((c) => String(c[0]).includes("/events")).length;
+  return callsTo("/events").length;
+}
+
+function repoCallCount(): number {
+  return mockFetch.mock.calls.filter((c) => /\/repos\/testowner\/testrepo$/.test(String(c[0])))
+    .length;
+}
+
+function pullsCallCount(): number {
+  return callsTo("/pulls?state=open&per_page=1").length;
 }
 
 /** Expire the 60s memory caches so the probe gate is reached on the next call. */
@@ -132,7 +216,28 @@ function expireBackoffWindow(): void {
   repoEventsLastProbeAt.clear();
 }
 
-describe("getRepoStatsAndPage — REST events activity-probe gate (issues #8757, #9041)", () => {
+describe("parseLinkLastPage", () => {
+  it("extracts the rel=last page number from a realistic GitHub Link header", () => {
+    const link =
+      `<https://api.github.com/repositories/1/pulls?state=open&per_page=1&page=2>; rel="next", ` +
+      `<https://api.github.com/repositories/1/pulls?state=open&per_page=1&page=47>; rel="last"`;
+    expect(parseLinkLastPage(link)).toBe(47);
+  });
+
+  it("returns null when the header is absent", () => {
+    expect(parseLinkLastPage(null)).toBeNull();
+  });
+
+  it("returns null when no rel=last segment exists", () => {
+    expect(parseLinkLastPage(`<https://api.github.com/x?page=2>; rel="next"`)).toBeNull();
+  });
+
+  it("returns null on a malformed header", () => {
+    expect(parseLinkLastPage("not a link header")).toBeNull();
+  });
+});
+
+describe("getRepoStatsAndPage — decoupled REST count poll (issue #10122)", () => {
   beforeEach(() => {
     mockClient.mockReset();
     mockFetch.mockReset();
@@ -148,184 +253,50 @@ describe("getRepoStatsAndPage — REST events activity-probe gate (issues #8757,
     issueListCache.clear();
     prListCache.clear();
     repoStatsAndPageSnapshotCache.clear();
+    restCountsCache.clear();
     repoEventsETagCache.clear();
     repoEventsPollIntervalCache.clear();
     repoEventsNoChangeCount.clear();
     repoEventsLastProbeAt.clear();
   });
 
-  it("runs the full stats query and records the snapshot + events ETag on first fetch", async () => {
-    mockClient.mockResolvedValue(statsResponse(5, 3));
-    mockFetch.mockResolvedValue(eventsResponse(200, { etag: '"e1"' }));
-
-    const result = await getRepoStatsAndPage("/test", false);
-
-    expect(result.source).toBe("network");
-    expect(result.stats?.issueCount).toBe(5);
-    expect(statsQueryCount()).toBe(1);
-    // The probe primed the ETag baseline so the next poll can send If-None-Match.
-    expect(repoEventsETagCache.get(CACHE_KEY)).toBe('"e1"');
-    expect(repoStatsAndPageSnapshotCache.get(CACHE_KEY)).not.toBeUndefined();
-  });
-
-  it("skips the full stats query when the probe returns 304 Not Modified", async () => {
-    mockClient.mockResolvedValue(statsResponse(5, 3));
-    // First fetch primes the snapshot + ETag (200); the next probe sees no change (304).
-    mockFetch
-      .mockResolvedValueOnce(eventsResponse(200, { etag: '"e1"' }))
-      .mockResolvedValue(eventsResponse(304));
-
-    await getRepoStatsAndPage("/test", false);
-    expireMemoryCaches();
-    expireBackoffWindow();
-    const result = await getRepoStatsAndPage("/test", false);
-
-    expect(result.source).toBe("network");
-    expect(result.stats?.issueCount).toBe(5);
-    // The probe ran twice; the expensive stats query ran only once.
-    expect(probeRestCallCount()).toBe(2);
-    expect(statsQueryCount()).toBe(1);
-  });
-
-  it("sends the cached ETag as If-None-Match on the follow-up probe", async () => {
-    mockClient.mockResolvedValue(statsResponse(5, 3));
-    mockFetch
-      .mockResolvedValueOnce(eventsResponse(200, { etag: '"e1"' }))
-      .mockResolvedValue(eventsResponse(304));
-
-    await getRepoStatsAndPage("/test", false);
-    expireMemoryCaches();
-    expireBackoffWindow();
-    await getRepoStatsAndPage("/test", false);
-
-    const firstInit = mockFetch.mock.calls[0][1] as { headers: Record<string, string> };
-    const secondInit = mockFetch.mock.calls[1][1] as { headers: Record<string, string> };
-    expect(firstInit.headers["If-None-Match"]).toBeUndefined();
-    expect(secondInit.headers["If-None-Match"]).toBe('"e1"');
-    expect(String(mockFetch.mock.calls[0][0])).toContain(
-      "/repos/testowner/testrepo/events?per_page=1"
-    );
-  });
-
-  it("returns complete stats/issues/prs on a probe-validated cache hit", async () => {
-    mockClient.mockResolvedValue(statsResponse(8, 4));
-    mockFetch
-      .mockResolvedValueOnce(eventsResponse(200, { etag: '"e1"' }))
-      .mockResolvedValue(eventsResponse(304));
-
-    await getRepoStatsAndPage("/test", false);
-    expireMemoryCaches();
-    expireBackoffWindow();
-    const result = await getRepoStatsAndPage("/test", false);
-
-    expect(result.stats?.issueCount).toBe(8);
-    expect(result.stats?.prCount).toBe(4);
-    expect(result.issues).not.toBeNull();
-    expect(result.prs).not.toBeNull();
-    expect(result.issues?.totalCount).toBe(8);
-    expect(result.prs?.totalCount).toBe(4);
-  });
-
-  it("re-runs the full stats query when the probe returns 200 (changed)", async () => {
-    mockClient.mockResolvedValue(statsResponse(5, 3));
-    // Both polls see a real event (200) — the stats query must run each time.
-    mockFetch.mockResolvedValue(eventsResponse(200, { etag: '"e1"' }));
-
-    await getRepoStatsAndPage("/test", false);
-    expireMemoryCaches();
-    expireBackoffWindow();
-    await getRepoStatsAndPage("/test", false);
-
-    expect(statsQueryCount()).toBe(2);
-  });
-
-  it("falls through to the full query when the probe request fails", async () => {
-    mockClient.mockResolvedValue(statsResponse(5, 3));
-    mockFetch.mockRejectedValue(new Error("probe boom"));
-
-    await getRepoStatsAndPage("/test", false);
-    expireMemoryCaches();
-    expireBackoffWindow();
-    const result = await getRepoStatsAndPage("/test", false);
-
-    expect(result.source).toBe("network");
-    // Probe failure never gates — both calls ran the expensive query.
-    expect(statsQueryCount()).toBe(2);
-  });
-
-  it("falls through to the full query on an unexpected probe status (no snapshot served)", async () => {
-    mockClient.mockResolvedValue(statsResponse(5, 3));
-    mockFetch
-      .mockResolvedValueOnce(eventsResponse(200, { etag: '"e1"' }))
-      .mockResolvedValue(eventsResponse(500));
-
-    await getRepoStatsAndPage("/test", false);
-    expireMemoryCaches();
-    expireBackoffWindow();
-    await getRepoStatsAndPage("/test", false);
-
-    expect(statsQueryCount()).toBe(2);
-  });
-
-  it("skips the probe entirely on bypassCache and runs the full query", async () => {
-    mockClient.mockResolvedValue(statsResponse(5, 3));
-    mockFetch.mockResolvedValue(eventsResponse(304));
-
-    await getRepoStatsAndPage("/test", true);
-
-    expect(probeRestCallCount()).toBe(0);
-    expect(statsQueryCount()).toBe(1);
-  });
-
-  it("does not advance the snapshot cache when the full query fails", async () => {
-    mockClient.mockRejectedValue(new Error("stats boom"));
-    mockFetch.mockResolvedValue(eventsResponse(200, { etag: '"e1"' }));
-
-    await getRepoStatsAndPage("/test", false);
-
-    expect(repoStatsAndPageSnapshotCache.get(CACHE_KEY)).toBeUndefined();
-  });
-
-  it("keeps the prior snapshot when a later full query fails", async () => {
-    let statsShouldFail = false;
-    mockClient.mockImplementation(async () => {
-      if (statsShouldFail) throw new Error("stats boom");
-      return statsResponse(5, 3);
+  it("fetches counts via the REST pair on a background poll — never the GraphQL page query", async () => {
+    routeFetch({
+      events: [eventsResponse(200, { etag: '"e1"' })],
+      repo: [repoOk(8)],
+      pulls: [pullsOk(3)],
     });
-    // First probe primes the baseline (200); the second reports a real change (200).
-    mockFetch.mockResolvedValue(eventsResponse(200, { etag: '"e1"' }));
 
-    await getRepoStatsAndPage("/test", false);
-    const goodSnapshot = repoStatsAndPageSnapshotCache.get(CACHE_KEY);
-    expect(goodSnapshot).toBeDefined();
+    const result = await getRepoStatsAndPage("/test", false);
 
-    expireMemoryCaches();
-    expireBackoffWindow();
-    statsShouldFail = true;
-    await getRepoStatsAndPage("/test", false);
-
-    // A failed fetch must not clobber the last good snapshot.
-    expect(repoStatsAndPageSnapshotCache.get(CACHE_KEY)).toEqual(goodSnapshot);
+    expect(result.source).toBe("network");
+    // issueCount = open_issues_count (combined) − PR count.
+    expect(result.stats?.issueCount).toBe(5);
+    expect(result.stats?.prCount).toBe(3);
+    expect(result.issues).toBeNull();
+    expect(result.prs).toBeNull();
+    expect(result.nextPollIntervalMs).toBe(60_000);
+    expect(statsQueryCount()).toBe(0);
+    // The events ETag committed in lockstep with the counts.
+    expect(repoEventsETagCache.get(CACHE_KEY)).toBe('"e1"');
+    // Counts + their ETags committed as one baseline.
+    expect(restCountsCache.get(CACHE_KEY)).toMatchObject({
+      combinedCount: 8,
+      prCount: 3,
+      repoEtag: '"r1"',
+      prEtag: '"p1"',
+    });
   });
 
-  it("re-stamps the durable disk cache on a probe-match hit so the fallback can't age out (issue #8826)", async () => {
-    mockClient.mockResolvedValue(statsResponse(5, 3));
-    mockFetch
-      .mockResolvedValueOnce(eventsResponse(200, { etag: '"e1"' }))
-      .mockResolvedValue(eventsResponse(304));
+  it("writes the durable disk cache on a REST count success", async () => {
+    routeFetch({
+      events: [eventsResponse(200, { etag: '"e1"' })],
+      repo: [repoOk(8)],
+      pulls: [pullsOk(3)],
+    });
 
     await getRepoStatsAndPage("/test", false);
 
-    expireMemoryCaches();
-    expireBackoffWindow();
-    mockStatsCache.set.mockClear();
-
-    await getRepoStatsAndPage("/test", false);
-
-    // Optimization preserved — no second expensive stats query.
-    expect(statsQueryCount()).toBe(1);
-    // The durable disk cache is re-written on the fast path so it can't age out
-    // behind the in-memory caches and leave the error-path fallback empty.
     expect(mockStatsCache.set).toHaveBeenCalledWith(
       CACHE_KEY,
       expect.objectContaining({ issueCount: 5, prCount: 3 }),
@@ -333,162 +304,388 @@ describe("getRepoStatsAndPage — REST events activity-probe gate (issues #8757,
     );
   });
 
-  it("does not re-stamp the snapshot TTL on a probe-match hit (keeps the 10-min staleness cap)", async () => {
-    mockClient.mockResolvedValue(statsResponse(5, 3));
-    mockFetch
-      .mockResolvedValueOnce(eventsResponse(200, { etag: '"e1"' }))
-      .mockResolvedValue(eventsResponse(304));
+  it("sends If-None-Match on both REST legs once a baseline exists and replays counts on 304", async () => {
+    routeFetch({
+      events: [eventsResponse(200, { etag: '"e1"' }), eventsResponse(200, { etag: '"e2"' })],
+      repo: [repoOk(8, '"r1"'), restResponse(304)],
+      pulls: [pullsOk(3, '"p1"'), restResponse(304)],
+    });
 
     await getRepoStatsAndPage("/test", false);
-    const snapshotBefore = repoStatsAndPageSnapshotCache.get(CACHE_KEY);
-
     expireMemoryCaches();
     expireBackoffWindow();
-    await getRepoStatsAndPage("/test", false);
+    const result = await getRepoStatsAndPage("/test", false);
 
-    // Snapshot cache is read, not rewritten — its original entry (and TTL) is
-    // untouched so list content can't live indefinitely behind a matching probe.
-    expect(repoStatsAndPageSnapshotCache.get(CACHE_KEY)).toBe(snapshotBefore);
+    expect(result.stats?.issueCount).toBe(5);
+    expect(result.stats?.prCount).toBe(3);
+    const repoCalls = callsTo("/repos/testowner/testrepo");
+    const repoInits = repoCalls.filter((c) => /\/repos\/testowner\/testrepo$/.test(String(c[0])));
+    expect(repoInits[0][1].headers["If-None-Match"]).toBeUndefined();
+    expect(repoInits[1][1].headers["If-None-Match"]).toBe('"r1"');
+    const pullsInits = callsTo("/pulls?state=open&per_page=1");
+    expect(pullsInits[0][1].headers["If-None-Match"]).toBeUndefined();
+    expect(pullsInits[1][1].headers["If-None-Match"]).toBe('"p1"');
+    // The changed probe's new events ETag committed after the 304 replay.
+    expect(repoEventsETagCache.get(CACHE_KEY)).toBe('"e2"');
   });
 
-  it("serves the full snapshot on a 304 even when the GraphQL bucket is blocked", async () => {
-    // The probe + snapshot draw from the REST "core" bucket, so a depleted
-    // GraphQL budget must not suppress a zero-cost 304 cache hit. The probe gate
-    // runs before the GraphQL rate-limit check for exactly this reason.
-    mockClient.mockResolvedValue(statsResponse(5, 3));
-    mockFetch
-      .mockResolvedValueOnce(eventsResponse(200, { etag: '"e1"' }))
-      .mockResolvedValue(eventsResponse(304));
+  it("combines a fresh 200 on one leg with a 304 replay on the other against the same baseline", async () => {
+    routeFetch({
+      events: [eventsResponse(200, { etag: '"e1"' }), eventsResponse(200, { etag: '"e2"' })],
+      repo: [repoOk(8, '"r1"'), repoOk(9, '"r2"')],
+      pulls: [pullsOk(3, '"p1"'), restResponse(304)],
+    });
 
-    await getRepoStatsAndPage("/test", false); // seed snapshot + ETag, all unblocked
+    await getRepoStatsAndPage("/test", false);
     expireMemoryCaches();
     expireBackoffWindow();
+    const result = await getRepoStatsAndPage("/test", false);
 
-    // Block only GraphQL; the REST "core" probe is unaffected.
+    expect(result.stats?.issueCount).toBe(6); // 9 combined − 3 replayed PRs
+    expect(result.stats?.prCount).toBe(3);
+    expect(restCountsCache.get(CACHE_KEY)).toMatchObject({
+      combinedCount: 9,
+      repoEtag: '"r2"',
+      prEtag: '"p1"',
+    });
+  });
+
+  it("derives PR counts of 0 and 1 from the body when GitHub omits the Link header", async () => {
+    routeFetch({
+      events: [eventsResponse(200, { etag: '"e1"' })],
+      repo: [repoOk(4)],
+      pulls: [pullsOk(0)],
+    });
+    const zero = await getRepoStatsAndPage("/test", false);
+    expect(zero.stats?.prCount).toBe(0);
+    expect(zero.stats?.issueCount).toBe(4);
+
+    expireMemoryCaches();
+    expireBackoffWindow();
+    restCountsCache.clear();
+    routeFetch({
+      events: [eventsResponse(200, { etag: '"e1"' })],
+      repo: [repoOk(4)],
+      pulls: [pullsOk(1)],
+    });
+    const one = await getRepoStatsAndPage("/test", false);
+    expect(one.stats?.prCount).toBe(1);
+    expect(one.stats?.issueCount).toBe(3);
+  });
+
+  it("reuses the last REST counts on an unchanged probe without touching the count endpoints", async () => {
+    routeFetch({
+      events: [eventsResponse(200, { etag: '"e1"' }), eventsResponse(304)],
+      repo: [repoOk(8)],
+      pulls: [pullsOk(3)],
+    });
+
+    await getRepoStatsAndPage("/test", false);
+    expireMemoryCaches();
+    expireBackoffWindow();
+    const result = await getRepoStatsAndPage("/test", false);
+
+    expect(result.source).toBe("network");
+    expect(result.stats?.issueCount).toBe(5);
+    expect(result.stats?.prCount).toBe(3);
+    expect(probeRestCallCount()).toBe(2);
+    // The cheap 304 served the counts — no second hit on either count endpoint.
+    expect(repoCallCount()).toBe(1);
+    expect(pullsCallCount()).toBe(1);
+  });
+
+  it("skips even the probe while inside the adaptive window once REST counts exist", async () => {
+    routeFetch({
+      events: [eventsResponse(200, { etag: '"e1"' })],
+      repo: [repoOk(8)],
+      pulls: [pullsOk(3)],
+    });
+
+    await getRepoStatsAndPage("/test", false);
+    const fetchCallsAfterFirst = mockFetch.mock.calls.length;
+
+    // Only the 60s memory cache expires; the backoff window is still open, so
+    // the second poll serves the last REST counts without touching the network.
+    expireMemoryCaches();
+    const result = await getRepoStatsAndPage("/test", false);
+
+    expect(result.source).toBe("network");
+    expect(result.stats?.issueCount).toBe(5);
+    expect(mockFetch.mock.calls.length).toBe(fetchCallsAfterFirst);
+  });
+
+  it("serves the disk fallback and keeps the old events ETag when a REST leg fails", async () => {
+    routeFetch({
+      events: [eventsResponse(200, { etag: '"e1"' }), eventsResponse(200, { etag: '"e2"' })],
+      repo: [repoOk(8), restResponse(500)],
+      pulls: [pullsOk(3)],
+    });
+    mockStatsCache.get.mockReturnValue({
+      issueCount: 5,
+      prCount: 3,
+      lastUpdated: 123,
+      projectPath: "/test",
+    });
+
+    await getRepoStatsAndPage("/test", false);
+    expect(repoEventsETagCache.get(CACHE_KEY)).toBe('"e1"');
+
+    expireMemoryCaches();
+    expireBackoffWindow();
+    const result = await getRepoStatsAndPage("/test", false);
+
+    expect(result.stats?.stale).toBe(true);
+    expect(result.stats?.issueCount).toBe(5);
+    expect(result.error).toBeDefined();
+    expect(result.issues).toBeNull();
+    // The failed count fetch must not advance the events ETag — the next probe
+    // re-detects the change instead of masking it behind a 304.
+    expect(repoEventsETagCache.get(CACHE_KEY)).toBe('"e1"');
+    expect(statsQueryCount()).toBe(0);
+  });
+
+  it("returns an error result when REST counts fail with no disk fallback", async () => {
+    routeFetch({
+      events: [eventsResponse(200, { etag: '"e1"' })],
+      repo: [restResponse(500)],
+      pulls: [pullsOk(3)],
+    });
+
+    const result = await getRepoStatsAndPage("/test", false);
+
+    expect(result.stats).toBeNull();
+    expect(result.error).toBe("Couldn't fetch repository counts");
+  });
+
+  it("rejects a negative derived issue count and keeps the prior baseline", async () => {
+    routeFetch({
+      events: [eventsResponse(200, { etag: '"e1"' }), eventsResponse(200, { etag: '"e2"' })],
+      repo: [repoOk(8, '"r1"'), repoOk(1, '"r2"')],
+      pulls: [pullsOk(3, '"p1"'), pullsOk(3, '"p2"')],
+    });
+
+    await getRepoStatsAndPage("/test", false);
+    expireMemoryCaches();
+    expireBackoffWindow();
+    const result = await getRepoStatsAndPage("/test", false);
+
+    // 1 combined − 3 PRs is impossible — a cross-endpoint race. No commit.
+    expect(result.error).toBeDefined();
+    expect(restCountsCache.get(CACHE_KEY)).toMatchObject({
+      combinedCount: 8,
+      prCount: 3,
+      repoEtag: '"r1"',
+    });
+    expect(repoEventsETagCache.get(CACHE_KEY)).toBe('"e1"');
+  });
+
+  it("rejects a malformed repo body (missing open_issues_count)", async () => {
+    routeFetch({
+      events: [eventsResponse(200, { etag: '"e1"' })],
+      repo: [restResponse(200, { etag: '"r1"', body: {} })],
+      pulls: [pullsOk(3)],
+    });
+
+    const result = await getRepoStatsAndPage("/test", false);
+
+    expect(result.stats).toBeNull();
+    expect(result.error).toBeDefined();
+    expect(restCountsCache.get(CACHE_KEY)).toBeUndefined();
+  });
+
+  it("serves the rate-limit message when the core bucket is blocked", async () => {
+    vi.mocked(gitHubRateLimitService.shouldBlockRequest).mockImplementation((resource?: string) =>
+      resource === "core"
+        ? { blocked: true, reason: "primary", resumeAt: Date.now() + 1000 }
+        : { blocked: false, reason: null }
+    );
+    mockStatsCache.get.mockReturnValue({
+      issueCount: 5,
+      prCount: 3,
+      lastUpdated: 123,
+      projectPath: "/test",
+    });
+
+    const result = await getRepoStatsAndPage("/test", false);
+
+    expect(result.stats?.stale).toBe(true);
+    expect(result.error).toBe("rate limited");
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(statsQueryCount()).toBe(0);
+  });
+
+  it("is unaffected by a depleted GraphQL bucket on the background path", async () => {
     vi.mocked(gitHubRateLimitService.shouldBlockRequest).mockImplementation((resource?: string) =>
       resource === "graphql"
         ? { blocked: true, reason: "primary", resumeAt: Date.now() + 1000 }
         : { blocked: false, reason: null }
     );
+    routeFetch({
+      events: [eventsResponse(200, { etag: '"e1"' })],
+      repo: [repoOk(8)],
+      pulls: [pullsOk(3)],
+    });
 
     const result = await getRepoStatsAndPage("/test", false);
 
-    // Full snapshot served (not the degraded disk fallback with null lists),
-    // and no second GraphQL query was issued.
-    expect(result.issues).not.toBeNull();
-    expect(result.prs).not.toBeNull();
+    expect(result.stats?.issueCount).toBe(5);
     expect(result.error).toBeUndefined();
-    expect(statsQueryCount()).toBe(1);
+    expect(statsQueryCount()).toBe(0);
   });
 
-  it("does not advance the events ETag when the full query fails (deferred commit)", async () => {
-    // The ETag must move in lockstep with the snapshot: if the full query fails
-    // after a changed probe, the old ETag has to survive so the next probe
-    // re-detects the change instead of masking it behind a later 304.
-    let statsShouldFail = false;
-    mockClient.mockImplementation(async () => {
-      if (statsShouldFail) throw new Error("stats boom");
-      return statsResponse(5, 3);
-    });
-    mockFetch
-      .mockResolvedValueOnce(eventsResponse(200, { etag: '"e1"' }))
-      .mockResolvedValue(eventsResponse(200, { etag: '"e2"' }));
-
-    await getRepoStatsAndPage("/test", false); // probe 200 e1, full ok -> commit e1
-    expect(repoEventsETagCache.get(CACHE_KEY)).toBe('"e1"');
-
-    expireMemoryCaches();
-    expireBackoffWindow();
-    statsShouldFail = true;
-    await getRepoStatsAndPage("/test", false); // probe 200 e2 (changed), full FAILS
-
-    // ETag stays e1 — the failed fetch never committed e2.
-    expect(repoEventsETagCache.get(CACHE_KEY)).toBe('"e1"');
-  });
-
-  it("clears the cached ETag when a 200 response omits the etag header", async () => {
-    mockClient.mockResolvedValue(statsResponse(5, 3));
-    mockFetch
-      .mockResolvedValueOnce(eventsResponse(200, { etag: '"e1"' }))
-      .mockResolvedValue(eventsResponse(200)); // changed, but no etag header
-
-    await getRepoStatsAndPage("/test", false);
-    expect(repoEventsETagCache.get(CACHE_KEY)).toBe('"e1"');
-
-    expireMemoryCaches();
-    expireBackoffWindow();
-    await getRepoStatsAndPage("/test", false); // 200 without etag -> invalidate
-
-    expect(repoEventsETagCache.get(CACHE_KEY)).toBeUndefined();
-  });
-
-  it("re-runs the full query after clearPRCaches invalidates the snapshot", async () => {
-    mockClient.mockResolvedValue(statsResponse(5, 3));
-    mockFetch.mockResolvedValue(eventsResponse(200, { etag: '"e1"' }));
-
-    await getRepoStatsAndPage("/test", false);
-    expireMemoryCaches();
-    // A user-initiated GitHub refresh must not be defeated by a probe hit.
-    clearPRCaches();
-    await getRepoStatsAndPage("/test", false);
-
-    expect(statsQueryCount()).toBe(2);
-  });
-
-  describe("adaptive backoff (issue #9041)", () => {
-    it("reuses the snapshot without probing while inside the X-Poll-Interval window", async () => {
+  describe("bypassCache (explicit refresh) path", () => {
+    it("runs the full GraphQL page query, writes the snapshot, and skips the probe + REST counts", async () => {
       mockClient.mockResolvedValue(statsResponse(5, 3));
-      mockFetch.mockResolvedValue(eventsResponse(200, { etag: '"e1"' }));
+      routeFetch({});
+
+      const result = await getRepoStatsAndPage("/test", true);
+
+      expect(result.stats?.issueCount).toBe(5);
+      expect(result.issues).not.toBeNull();
+      expect(result.prs).not.toBeNull();
+      expect(statsQueryCount()).toBe(1);
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(repoStatsAndPageSnapshotCache.get(CACHE_KEY)).not.toBeUndefined();
+    });
+
+    it("does not advance the snapshot cache when the GraphQL query fails", async () => {
+      mockClient.mockRejectedValue(new Error("stats boom"));
+      routeFetch({});
+
+      await getRepoStatsAndPage("/test", true);
+
+      expect(repoStatsAndPageSnapshotCache.get(CACHE_KEY)).toBeUndefined();
+    });
+
+    it("resets the backoff cadence so the next background poll re-probes", async () => {
+      routeFetch({
+        events: [eventsResponse(200, { etag: '"e1"' }), eventsResponse(304)],
+        repo: [repoOk(8)],
+        pulls: [pullsOk(3)],
+      });
 
       await getRepoStatsAndPage("/test", false);
-      const probesAfterFirst = probeRestCallCount();
+      expireMemoryCaches();
+      expireBackoffWindow();
+      await getRepoStatsAndPage("/test", false); // 304 -> count 1
+      expect(repoEventsNoChangeCount.get(CACHE_KEY)).toBe(1);
 
-      // Only the 60s memory cache expires; the backoff window is still open, so
-      // the second poll serves the snapshot without touching the network.
+      mockClient.mockResolvedValue(statsResponse(5, 3));
+      await getRepoStatsAndPage("/test", true); // bypassCache resets the cadence
+      expect(repoEventsNoChangeCount.get(CACHE_KEY)).toBeUndefined();
+      expect(repoEventsLastProbeAt.get(CACHE_KEY)).toBeUndefined();
+    });
+  });
+
+  describe("probe + snapshot interplay", () => {
+    it("serves the full snapshot pages on an unchanged probe", async () => {
+      mockClient.mockResolvedValue(statsResponse(8, 4));
+      routeFetch({ events: [eventsResponse(304)] });
+
+      await getRepoStatsAndPage("/test", true); // seed snapshot via explicit refresh
       expireMemoryCaches();
       const result = await getRepoStatsAndPage("/test", false);
 
       expect(result.source).toBe("network");
-      expect(probeRestCallCount()).toBe(probesAfterFirst);
+      expect(result.stats?.issueCount).toBe(8);
+      expect(result.issues).not.toBeNull();
+      expect(result.prs).not.toBeNull();
+      expect(result.issues?.totalCount).toBe(8);
       expect(statsQueryCount()).toBe(1);
+      expect(repoCallCount()).toBe(0);
+      expect(pullsCallCount()).toBe(0);
     });
 
-    it("stores the server-advertised X-Poll-Interval as the backoff floor (ms)", async () => {
+    it("does not re-stamp the snapshot TTL on a probe-match hit (keeps the 10-min staleness cap)", async () => {
       mockClient.mockResolvedValue(statsResponse(5, 3));
-      mockFetch.mockResolvedValue(eventsResponse(200, { etag: '"e1"', pollInterval: "120" }));
+      routeFetch({ events: [eventsResponse(304)] });
+
+      await getRepoStatsAndPage("/test", true);
+      const snapshotBefore = repoStatsAndPageSnapshotCache.get(CACHE_KEY);
+
+      expireMemoryCaches();
+      await getRepoStatsAndPage("/test", false);
+
+      expect(repoStatsAndPageSnapshotCache.get(CACHE_KEY)).toBe(snapshotBefore);
+    });
+
+    it("serves REST-fresher counts with the snapshot pages on an unchanged probe", async () => {
+      // Explicit refresh writes the snapshot (5 issues / 3 PRs)…
+      mockClient.mockResolvedValue(statsResponse(5, 3));
+      routeFetch({
+        events: [eventsResponse(200, { etag: '"e1"' }), eventsResponse(304)],
+        repo: [repoOk(12)],
+        pulls: [pullsOk(2)],
+      });
+      await getRepoStatsAndPage("/test", true);
+
+      // …then a background REST poll observes fresher counts (10 / 2)…
+      expireMemoryCaches();
+      await getRepoStatsAndPage("/test", false);
+
+      // …so a later unchanged probe must not roll the pill back to 5 / 3.
+      expireMemoryCaches();
+      expireBackoffWindow();
+      const result = await getRepoStatsAndPage("/test", false);
+
+      expect(result.stats?.issueCount).toBe(10);
+      expect(result.stats?.prCount).toBe(2);
+      expect(result.issues).not.toBeNull();
+      expect(result.prs).not.toBeNull();
+    });
+
+    it("re-fetches REST counts after clearPRCaches drops the baselines", async () => {
+      routeFetch({
+        events: [eventsResponse(200, { etag: '"e1"' })],
+        repo: [repoOk(8, '"r1"')],
+        pulls: [pullsOk(3, '"p1"')],
+      });
+
+      await getRepoStatsAndPage("/test", false);
+      expireMemoryCaches();
+      // A user-initiated GitHub refresh must force fresh 200s, not 304 replays.
+      clearPRCaches();
+      routeFetch({
+        events: [eventsResponse(200, { etag: '"e2"' })],
+        repo: [repoOk(9, '"r2"')],
+        pulls: [pullsOk(4, '"p2"')],
+      });
+      const result = await getRepoStatsAndPage("/test", false);
+
+      expect(result.stats?.issueCount).toBe(5);
+      expect(result.stats?.prCount).toBe(4);
+      // Neither leg carried a stale If-None-Match after the clear.
+      const repoInits = mockFetch.mock.calls
+        .filter((c) => /\/repos\/testowner\/testrepo$/.test(String(c[0])))
+        .map((c) => c[1] as { headers: Record<string, string> });
+      expect(repoInits[1].headers["If-None-Match"]).toBeUndefined();
+    });
+  });
+
+  describe("adaptive backoff cadence (issues #9041, #9741)", () => {
+    it("stores the server-advertised X-Poll-Interval as the backoff floor (ms)", async () => {
+      routeFetch({
+        events: [eventsResponse(200, { etag: '"e1"', pollInterval: "120" })],
+        repo: [repoOk(8)],
+        pulls: [pullsOk(3)],
+      });
 
       await getRepoStatsAndPage("/test", false);
 
       expect(repoEventsPollIntervalCache.get(CACHE_KEY)).toBe(120_000);
     });
 
-    it("honors the stored X-Poll-Interval as the gate window boundary", async () => {
-      mockClient.mockResolvedValue(statsResponse(5, 3));
-      mockFetch.mockResolvedValue(eventsResponse(200, { etag: '"e1"', pollInterval: "120" }));
-
-      await getRepoStatsAndPage("/test", false); // floor now 120_000ms, noChange 0
-      const probesAfterSeed = probeRestCallCount();
-
-      // Just inside the 120s window — must reuse the snapshot without probing.
-      repoEventsLastProbeAt.set(CACHE_KEY, Date.now() - 119_000);
-      expireMemoryCaches();
-      await getRepoStatsAndPage("/test", false);
-      expect(probeRestCallCount()).toBe(probesAfterSeed);
-
-      // Just past the window — the probe must fire again.
-      repoEventsLastProbeAt.set(CACHE_KEY, Date.now() - 121_000);
-      expireMemoryCaches();
-      await getRepoStatsAndPage("/test", false);
-      expect(probeRestCallCount()).toBe(probesAfterSeed + 1);
-    });
-
     it("increments the consecutive-no-change counter on each 304 and resets on a 200", async () => {
-      mockClient.mockResolvedValue(statsResponse(5, 3));
-      mockFetch
-        .mockResolvedValueOnce(eventsResponse(200, { etag: '"e1"' }))
-        .mockResolvedValueOnce(eventsResponse(304))
-        .mockResolvedValueOnce(eventsResponse(304))
-        .mockResolvedValue(eventsResponse(200, { etag: '"e2"' }));
+      routeFetch({
+        events: [
+          eventsResponse(200, { etag: '"e1"' }),
+          eventsResponse(304),
+          eventsResponse(304),
+          eventsResponse(200, { etag: '"e2"' }),
+        ],
+        repo: [repoOk(8)],
+        pulls: [pullsOk(3)],
+      });
 
       await getRepoStatsAndPage("/test", false); // 200 -> count 0
       expect(repoEventsNoChangeCount.get(CACHE_KEY)).toBe(0);
@@ -509,40 +706,12 @@ describe("getRepoStatsAndPage — REST events activity-probe gate (issues #8757,
       expect(repoEventsNoChangeCount.get(CACHE_KEY)).toBe(0);
     });
 
-    it("resets the backoff cadence on a bypassCache (manual refresh / focus) poll", async () => {
-      mockClient.mockResolvedValue(statsResponse(5, 3));
-      mockFetch
-        .mockResolvedValueOnce(eventsResponse(200, { etag: '"e1"' }))
-        .mockResolvedValue(eventsResponse(304));
-
-      await getRepoStatsAndPage("/test", false);
-      expireMemoryCaches();
-      expireBackoffWindow();
-      await getRepoStatsAndPage("/test", false); // 304 -> count 1
-      expect(repoEventsNoChangeCount.get(CACHE_KEY)).toBe(1);
-
-      await getRepoStatsAndPage("/test", true); // bypassCache resets the cadence
-      expect(repoEventsNoChangeCount.get(CACHE_KEY)).toBeUndefined();
-      expect(repoEventsLastProbeAt.get(CACHE_KEY)).toBeUndefined();
-    });
-  });
-
-  describe("next-poll interval surface (issue #9741)", () => {
-    it("returns the floor cadence on a fresh fetch with changes landing", async () => {
-      mockClient.mockResolvedValue(statsResponse(5, 3));
-      mockFetch.mockResolvedValue(eventsResponse(200, { etag: '"e1"' }));
-
-      const result = await getRepoStatsAndPage("/test", false);
-
-      // No consecutive no-change polls yet → cadence pinned to the 60s floor.
-      expect(result.nextPollIntervalMs).toBe(60_000);
-    });
-
     it("grows the cadence toward the 5-minute ceiling as no-change probes accrue", async () => {
-      mockClient.mockResolvedValue(statsResponse(5, 3));
-      mockFetch
-        .mockResolvedValueOnce(eventsResponse(200, { etag: '"e1"' }))
-        .mockResolvedValue(eventsResponse(304));
+      routeFetch({
+        events: [eventsResponse(200, { etag: '"e1"' }), eventsResponse(304)],
+        repo: [repoOk(8)],
+        pulls: [pullsOk(3)],
+      });
 
       await getRepoStatsAndPage("/test", false); // seed (200)
 
@@ -550,7 +719,7 @@ describe("getRepoStatsAndPage — REST events activity-probe gate (issues #8757,
       for (let i = 0; i < 6; i++) {
         expireMemoryCaches();
         expireBackoffWindow();
-        const r = await getRepoStatsAndPage("/test", false); // 304 short-circuit
+        const r = await getRepoStatsAndPage("/test", false); // 304 count replay
         expect(r.source).toBe("network");
         intervals.push(r.nextPollIntervalMs ?? 0);
       }
@@ -565,13 +734,17 @@ describe("getRepoStatsAndPage — REST events activity-probe gate (issues #8757,
     });
 
     it("snaps the cadence back to the floor once a change resets the backoff", async () => {
-      mockClient.mockResolvedValue(statsResponse(5, 3));
-      mockFetch
-        .mockResolvedValueOnce(eventsResponse(200, { etag: '"e1"' }))
-        .mockResolvedValueOnce(eventsResponse(304))
-        .mockResolvedValueOnce(eventsResponse(304))
-        .mockResolvedValueOnce(eventsResponse(304))
-        .mockResolvedValue(eventsResponse(200, { etag: '"e2"' }));
+      routeFetch({
+        events: [
+          eventsResponse(200, { etag: '"e1"' }),
+          eventsResponse(304),
+          eventsResponse(304),
+          eventsResponse(304),
+          eventsResponse(200, { etag: '"e2"' }),
+        ],
+        repo: [repoOk(8)],
+        pulls: [pullsOk(3)],
+      });
 
       await getRepoStatsAndPage("/test", false); // seed
       for (let i = 0; i < 3; i++) {
@@ -588,29 +761,20 @@ describe("getRepoStatsAndPage — REST events activity-probe gate (issues #8757,
     });
   });
 
-  it("returns unknown and still runs the full query when the core bucket is blocked", async () => {
-    mockClient.mockResolvedValue(statsResponse(5, 3));
-    mockFetch.mockResolvedValue(eventsResponse(200, { etag: '"e1"' }));
+  it("clears the cached events ETag when a 200 probe omits the etag header", async () => {
+    routeFetch({
+      events: [eventsResponse(200, { etag: '"e1"' }), eventsResponse(200)],
+      repo: [repoOk(8)],
+      pulls: [pullsOk(3)],
+    });
 
-    // Seed a snapshot with every bucket unblocked so the gate has something it
-    // could serve — proving the block, not a missing snapshot, forces the query.
     await getRepoStatsAndPage("/test", false);
+    expect(repoEventsETagCache.get(CACHE_KEY)).toBe('"e1"');
+
     expireMemoryCaches();
     expireBackoffWindow();
-    const probesBefore = probeRestCallCount();
+    await getRepoStatsAndPage("/test", false); // 200 without etag -> invalidate
 
-    // Now block only the REST "core" bucket; GraphQL is unaffected so the full
-    // stats query (and its "graphql" preflight) still proceeds.
-    vi.mocked(gitHubRateLimitService.shouldBlockRequest).mockImplementation((resource?: string) =>
-      resource === "core"
-        ? { blocked: true, reason: "primary", resumeAt: Date.now() + 1000 }
-        : { blocked: false, reason: null }
-    );
-
-    await getRepoStatsAndPage("/test", false);
-
-    // Probe short-circuited to "unknown" before opening a socket; full query ran.
-    expect(probeRestCallCount()).toBe(probesBefore);
-    expect(statsQueryCount()).toBe(2);
+    expect(repoEventsETagCache.get(CACHE_KEY)).toBeUndefined();
   });
 });

--- a/plugins/builtin/github/main/__tests__/GitHubStats.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubStats.test.ts
@@ -235,6 +235,12 @@ describe("parseLinkLastPage", () => {
   it("returns null on a malformed header", () => {
     expect(parseLinkLastPage("not a link header")).toBeNull();
   });
+
+  it("tolerates extra link parameters between the URL and rel (RFC 8288)", () => {
+    expect(
+      parseLinkLastPage(`<https://api.github.com/x?page=47>; type="application/json"; rel="last"`)
+    ).toBe(47);
+  });
 });
 
 describe("getRepoStatsAndPage — decoupled REST count poll (issue #10122)", () => {
@@ -477,6 +483,54 @@ describe("getRepoStatsAndPage — decoupled REST count poll (issue #10122)", () 
       repoEtag: '"r1"',
     });
     expect(repoEventsETagCache.get(CACHE_KEY)).toBe('"e1"');
+  });
+
+  it("keeps the prior baseline and events ETag when one REST leg fails", async () => {
+    routeFetch({
+      events: [eventsResponse(200, { etag: '"e1"' }), eventsResponse(200, { etag: '"e2"' })],
+      repo: [repoOk(8, '"r1"'), repoOk(9, '"r2"')],
+      pulls: [pullsOk(3, '"p1"'), restResponse(500)],
+    });
+
+    await getRepoStatsAndPage("/test", false);
+    expireMemoryCaches();
+    expireBackoffWindow();
+    const result = await getRepoStatsAndPage("/test", false);
+
+    // A half-valid pair must never commit — both the count baseline and the
+    // events ETag stay on the last fully-successful fetch.
+    expect(result.error).toBeDefined();
+    expect(restCountsCache.get(CACHE_KEY)).toMatchObject({
+      combinedCount: 8,
+      prCount: 3,
+      repoEtag: '"r1"',
+      prEtag: '"p1"',
+    });
+    expect(repoEventsETagCache.get(CACHE_KEY)).toBe('"e1"');
+  });
+
+  it("discards counts when a concurrent cache clear lands mid-parse", async () => {
+    const clearingRepo: FakeResponse = {
+      status: 200,
+      headers: { get: (name: string) => (name.toLowerCase() === "etag" ? '"r1"' : null) },
+      json: async () => {
+        // Simulates a token change / manual refresh arriving while the body is
+        // still being parsed — the commit must not re-seed the cleared cache.
+        clearPRCaches();
+        return { open_issues_count: 8 };
+      },
+    };
+    routeFetch({
+      events: [eventsResponse(200, { etag: '"e1"' })],
+      repo: [clearingRepo],
+      pulls: [pullsOk(3)],
+    });
+
+    const result = await getRepoStatsAndPage("/test", false);
+
+    expect(result.error).toBeDefined();
+    expect(restCountsCache.get(CACHE_KEY)).toBeUndefined();
+    expect(repoEventsETagCache.get(CACHE_KEY)).toBeUndefined();
   });
 
   it("rejects a malformed repo body (missing open_issues_count)", async () => {

--- a/plugins/builtin/github/main/index.ts
+++ b/plugins/builtin/github/main/index.ts
@@ -49,7 +49,6 @@ export {
 } from "./GitHubTokenHealthService.js";
 
 export {
-  REPO_STATS_QUERY,
   REPO_STATS_AND_PAGE_QUERY,
   PROJECT_HEALTH_QUERY,
   MERGE_VELOCITY_QUERY,
@@ -73,7 +72,7 @@ export type { RollupContextNode, DerivedCIResult } from "./prRequiredCIStatus.js
 export type {
   RepoContext,
   RepoStats,
-  RepoStatsResult,
+  RestCountsSnapshot,
   LinkedPR,
   PRCheckResult,
   PRCheckCandidate,
@@ -111,12 +110,7 @@ export {
 export { clearGitHubCaches, clearPRCaches } from "./GitHubCaches.js";
 
 // Stats
-export {
-  getRepoStats,
-  getRepoStatsAndPage,
-  getFirstPageCache,
-  getRepoStatsComplete,
-} from "./GitHubStats.js";
+export { getRepoStatsAndPage, getFirstPageCache, getRepoStatsComplete } from "./GitHubStats.js";
 export type { RepoStatsAndPageResult, RepoStatsCompleteResult } from "./GitHubStats.js";
 
 // Project health

--- a/plugins/builtin/github/main/types.ts
+++ b/plugins/builtin/github/main/types.ts
@@ -35,9 +35,21 @@ export interface RepoStatsAndPageSnapshot {
   prs: RepoConnectionPage<GitHubPR>;
 }
 
-export interface RepoStatsResult {
-  stats: RepoStats | null;
-  error?: string;
+/**
+ * Last successful REST count fetch (`fetchRestCounts`), stored as one atomic
+ * entry. The counts and the ETags they were observed under must live together:
+ * a `304` on one leg is only usable if the value that ETag validated is still
+ * available, and a mixed `304`/`200` response pair must never combine a fresh
+ * count with one from a different baseline.
+ */
+export interface RestCountsSnapshot {
+  /** `open_issues_count` from `GET /repos/{owner}/{repo}` — open issues + open PRs combined. */
+  combinedCount: number;
+  prCount: number;
+  repoEtag: string | null;
+  prEtag: string | null;
+  /** Wall-clock ms when these counts were committed — arbitrates freshness against the page snapshot's stats. */
+  lastUpdated: number;
 }
 
 export interface LinkedPR {

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -169,6 +169,7 @@ export type {
   // GitHub IPC types
   RepositoryStats,
   RepoStatsAndPagePayload,
+  RepoCountsUpdatedPayload,
   GitHubFirstPageCachePayload,
   ProjectHealthData,
   GitHubCliStatus,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -118,6 +118,7 @@ import type {
   GitHubRateLimitDetails,
   GitHubTokenHealthPayload,
   RepoStatsAndPagePayload,
+  RepoCountsUpdatedPayload,
   GitHubFirstPageCachePayload,
   PRDetectedPayload,
   PRClearedPayload,
@@ -763,6 +764,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     getRateLimitDetails(): Promise<GitHubRateLimitDetails | null>;
     onTokenHealthChanged(callback: (data: GitHubTokenHealthPayload) => void): () => void;
     onRepoStatsAndPageUpdated(callback: (data: RepoStatsAndPagePayload) => void): () => void;
+    onRepoCountsUpdated(callback: (data: RepoCountsUpdatedPayload) => void): () => void;
     getTokenHealth(): Promise<GitHubTokenHealthPayload>;
   };
   // getState comes from GeneratedElectronAPI; onServiceChanged is a renderer-only subscription.

--- a/shared/types/ipc/github.ts
+++ b/shared/types/ipc/github.ts
@@ -266,3 +266,18 @@ export interface RepoStatsAndPagePayload {
   /** Wall-clock timestamp when the poll completed (ms). */
   fetchedAt: number;
 }
+
+/**
+ * Lightweight count-only push, broadcast when a background poll refreshed the
+ * toolbar counts via the cheap REST path (issue #10122) — no first-page items
+ * to ship. `RepoStatsAndPagePayload` keeps its full semantics: it fires only
+ * when a poll produced actual page data.
+ */
+export interface RepoCountsUpdatedPayload {
+  /** Absolute project path the payload corresponds to. */
+  projectPath: string;
+  /** Combined stats (counts + freshness metadata) — same shape useRepositoryStats already consumes. */
+  stats: RepositoryStats;
+  /** Wall-clock timestamp when the poll completed (ms). */
+  fetchedAt: number;
+}

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -87,6 +87,7 @@ import type {
   GitHubRateLimitDetails,
   GitHubTokenHealthPayload,
   RepoStatsAndPagePayload,
+  RepoCountsUpdatedPayload,
   GitHubFirstPageCachePayload,
   PRDetectedPayload,
   PRClearedPayload,
@@ -1606,6 +1607,10 @@ export interface IpcEventMap {
   // after every successful poll. Lets renderers prime githubResourceCache
   // for the (open, created) default-filter cache key with no click-time fetch.
   "github:repo-stats-and-page-updated": RepoStatsAndPagePayload;
+
+  // Count-only stats push from the cheap REST background poll (issue #10122).
+  // No page items — the dropdown loads its own first page on open.
+  "github:repo-counts-updated": RepoCountsUpdatedPayload;
 
   // Per-service connectivity state push
   "connectivity:service-changed": ServiceConnectivityPayload;

--- a/src/clients/githubClient.ts
+++ b/src/clients/githubClient.ts
@@ -8,6 +8,7 @@ import type {
   GitHubRateLimitDetails,
   GitHubTokenHealthPayload,
   RepoStatsAndPagePayload,
+  RepoCountsUpdatedPayload,
   GitHubFirstPageCachePayload,
   PRDetectedPayload,
   PRClearedPayload,
@@ -149,6 +150,10 @@ export const githubClient = {
 
   onRepoStatsAndPageUpdated: (callback: (data: RepoStatsAndPagePayload) => void): (() => void) => {
     return window.electron.github.onRepoStatsAndPageUpdated(callback);
+  },
+
+  onRepoCountsUpdated: (callback: (data: RepoCountsUpdatedPayload) => void): (() => void) => {
+    return window.electron.github.onRepoCountsUpdated(callback);
   },
 
   getTokenHealth: (): Promise<GitHubTokenHealthPayload> => {

--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -10,6 +10,7 @@ const {
   getFirstPageCacheMock,
   onRateLimitChangedMock,
   onRepoStatsAndPageUpdatedMock,
+  onRepoCountsUpdatedMock,
 } = vi.hoisted(() => ({
   getCurrentMock: vi.fn(),
   onSwitchMock: vi.fn(),
@@ -19,6 +20,7 @@ const {
   onRepoStatsAndPageUpdatedMock: vi.fn<(cb: (payload: unknown) => void) => () => void>(
     () => () => {}
   ),
+  onRepoCountsUpdatedMock: vi.fn<(cb: (payload: unknown) => void) => () => void>(() => () => {}),
 }));
 
 vi.mock("@/clients", () => ({
@@ -31,6 +33,7 @@ vi.mock("@/clients", () => ({
     getFirstPageCache: getFirstPageCacheMock,
     onRateLimitChanged: onRateLimitChangedMock,
     onRepoStatsAndPageUpdated: onRepoStatsAndPageUpdatedMock,
+    onRepoCountsUpdated: onRepoCountsUpdatedMock,
   },
 }));
 
@@ -280,6 +283,146 @@ describe("useRepositoryStats", () => {
       expect(getRepoStatsMock).toHaveBeenCalledTimes(2);
       expect(getRepoStatsMock.mock.calls[1]?.[0]).toBe("/repo/b");
       expect(result.current.stats?.commitCount).toBe(77);
+    });
+  });
+
+  describe("onRepoCountsUpdated push (issue #10122)", () => {
+    function countsPayload(projectPath: string, stats: RepositoryStats, fetchedAt = Date.now()) {
+      return { projectPath, stats, fetchedAt };
+    }
+
+    it("applies count-only pushed stats for the current project", async () => {
+      const project = { id: "p", path: "/repo/counts" };
+      getCurrentMock.mockResolvedValue(project);
+      onSwitchMock.mockReturnValue(() => {});
+      getRepoStatsMock.mockResolvedValue({
+        commitCount: 5,
+        issueCount: 2,
+        prCount: 1,
+        loading: false,
+        stale: false,
+        lastUpdated: 1000,
+      });
+
+      let pushHandler: ((payload: unknown) => void) | undefined;
+      onRepoCountsUpdatedMock.mockImplementation((cb: (p: unknown) => void) => {
+        pushHandler = cb;
+        return () => {};
+      });
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(result.current.stats?.issueCount).toBe(2);
+      });
+
+      const pushedStats: RepositoryStats = {
+        commitCount: 5,
+        issueCount: 7,
+        prCount: 3,
+        loading: false,
+        stale: false,
+        lastUpdated: 2000,
+      };
+      await act(async () => {
+        pushHandler?.(countsPayload(project.path, pushedStats, 2000));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(result.current.stats?.issueCount).toBe(7);
+        expect(result.current.stats?.prCount).toBe(3);
+        expect(result.current.lastUpdated).toBe(2000);
+      });
+    });
+
+    it("ignores count pushes for a different project", async () => {
+      const project = { id: "p", path: "/repo/current" };
+      getCurrentMock.mockResolvedValue(project);
+      onSwitchMock.mockReturnValue(() => {});
+      getRepoStatsMock.mockResolvedValue({
+        commitCount: 5,
+        issueCount: 2,
+        prCount: 1,
+        loading: false,
+        stale: false,
+        lastUpdated: 1000,
+      });
+
+      let pushHandler: ((payload: unknown) => void) | undefined;
+      onRepoCountsUpdatedMock.mockImplementation((cb: (p: unknown) => void) => {
+        pushHandler = cb;
+        return () => {};
+      });
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(result.current.stats?.issueCount).toBe(2);
+      });
+
+      await act(async () => {
+        pushHandler?.(
+          countsPayload("/repo/other", {
+            commitCount: 0,
+            issueCount: 99,
+            prCount: 99,
+            loading: false,
+            stale: false,
+            lastUpdated: 2000,
+          })
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(result.current.stats?.issueCount).toBe(2);
+      expect(result.current.lastUpdated).toBe(1000);
+    });
+
+    it("skips a count push older than the last applied result", async () => {
+      const project = { id: "p", path: "/repo/older" };
+      getCurrentMock.mockResolvedValue(project);
+      onSwitchMock.mockReturnValue(() => {});
+      getRepoStatsMock.mockResolvedValue({
+        commitCount: 5,
+        issueCount: 4,
+        prCount: 2,
+        loading: false,
+        stale: false,
+        lastUpdated: 5000,
+      });
+
+      let pushHandler: ((payload: unknown) => void) | undefined;
+      onRepoCountsUpdatedMock.mockImplementation((cb: (p: unknown) => void) => {
+        pushHandler = cb;
+        return () => {};
+      });
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(result.current.stats?.issueCount).toBe(4);
+      });
+
+      await act(async () => {
+        pushHandler?.(
+          countsPayload(project.path, {
+            commitCount: 5,
+            issueCount: 1,
+            prCount: 1,
+            loading: false,
+            stale: false,
+            lastUpdated: 1000,
+          })
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(result.current.stats?.issueCount).toBe(4);
+      expect(result.current.lastUpdated).toBe(5000);
     });
   });
 

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -477,6 +477,39 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
     return cleanup;
   }, [applyStatsResult]);
 
+  // Subscribe to the count-only push from the cheap REST background poll
+  // (issue #10122). Carries no page items — only the toolbar counts — so it
+  // skips the cache seeding above and just applies the stats, behind the same
+  // project filter and freshness guard as the combined push.
+  useEffect(() => {
+    const cleanup = githubClient.onRepoCountsUpdated((payload) => {
+      if (!mountedRef.current) return;
+      projectClient
+        .getCurrent()
+        .then((project) => {
+          if (!project || project.path !== payload.projectPath) return;
+          if (!mountedRef.current) return;
+
+          const pushedLastUpdated = payload.stats.lastUpdated ?? null;
+          if (
+            pushedLastUpdated !== null &&
+            lastUpdatedRef.current !== null &&
+            pushedLastUpdated <= lastUpdatedRef.current
+          ) {
+            return;
+          }
+
+          applyStatsResult(payload.stats, { projectPath: payload.projectPath });
+        })
+        .catch(() => {
+          // Project lookup races during teardown / project switch are
+          // expected and benign — swallow rather than producing an
+          // unhandled rejection.
+        });
+    });
+    return cleanup;
+  }, [applyStatsResult]);
+
   // Coalesce sleep-wake fetches onto the shared wake-coordinator slice
   // (#8066). The store bumps `wakeEpoch` once per qualifying wake; every
   // consumer reacts to the same epoch instead of independently registering


### PR DESCRIPTION
## Summary

- The background toolbar poll now fetches issue/PR counts via two conditional REST GETs instead of the heavier `REPO_STATS_AND_PAGE_QUERY` GraphQL query. `GET /repos/daintreehq/daintree` supplies `open_issues_count`; `GET /repos/daintreehq/daintree/pulls?state=open&per_page=1` with the `Link: rel=last` header gives the PR count. `issueCount = combined - prCount`.
- Counts and ETags commit atomically as a `restCountsCache` baseline (1h TTL, cleared in `clearGitHubCaches` + `clearPRCaches`). Failed or partial legs never advance ETags; negative derived counts are rejected; a version re-check before commit guards against concurrent clears.
- The `/events` activity-probe gate is preserved: a 304 reuses cached counts at zero request cost. The full GraphQL page query + snapshot + first-page disk cache now run only on explicit refresh (`bypassCache: true`). Dropdown list queries are unchanged.

Resolves #10122

## Changes

- New `restCountsCache` baseline in `GitHubStats.ts` — two conditional REST GETs replace the toolbar's GraphQL call, with atomic ETag commit, partial-failure discipline, and version guard.
- Probe-unchanged path arbitrates freshness between `snapshot.stats` and the REST baseline so a probe hit can't roll the pill back.
- New `GITHUB_REPO_COUNTS_UPDATED` broadcast (count-only payload) wired through `channels.ts`, `shared/types/ipc/github.ts`, `preload.cts`, `githubClient.ts`, and `useRepositoryStats` subscriber. Existing `GITHUB_REPO_STATS_AND_PAGE_UPDATED` keeps full semantics.
- Removed dead `getRepoStats` and `REPO_STATS_QUERY`; ported 4 adversarial tests to `getRepoStatsAndPage`.
- Added `useRepositoryStats` unit tests covering the new count-only push path.

## Testing

- `npm run check` + build pass clean.
- 75 `GitHubStats` tests + 34 `useRepositoryStats` tests pass, including adversarial cases for partial REST failure, negative count rejection, concurrent-clear version guard, and probe-unchanged arbitration.
- Rate-limit economics verified by inspection: idle repo = one conditional `GET /events` per cadence window (zero quota on 304); changed repo = 2 REST core-bucket requests, zero GraphQL points; GraphQL spent only on explicit refresh and dropdown list queries.