### PR TITLE
fix(dev-preview): surface proxy 502 as styled error overlay with auto-recovery

### DIFF
--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1778,7 +1778,8 @@ export function DevPreviewPane({
                             </span>
                           </Button>
                         )}
-                        {webviewLoadError.code === "connection_refused" ? (
+                        {webviewLoadError.code === "connection_refused" ||
+                        webviewLoadError.code === "proxy_error" ? (
                           <>
                             <Tooltip>
                               <TooltipTrigger asChild>

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -1934,4 +1934,152 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       expect(container.textContent).toContain("npm run custom");
     });
   });
+
+  describe("proxy 502 handling (#9948)", () => {
+    it("shows the proxy-error overlay for a main-frame 502 and keeps it across did-finish-load", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      // An HTTP 502 is a successful network load: did-frame-navigate carries the
+      // status, then did-navigate + did-finish-load fire and would otherwise
+      // clear the error. The overlay must survive both.
+      act(() => {
+        emitWebviewEvent(webview, "did-frame-navigate", {
+          isMainFrame: true,
+          httpResponseCode: 502,
+          url: "http://localhost:5173/",
+        });
+        emitWebviewEvent(webview, "did-navigate", { url: "http://localhost:5173/" });
+        emitWebviewEvent(webview, "did-finish-load");
+      });
+
+      expect(container.textContent).toContain("Dev server unavailable");
+    });
+
+    it("routes the proxy 502 to the Restart dev server recovery branch, not the bare Retry", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-frame-navigate", {
+          isMainFrame: true,
+          httpResponseCode: 502,
+          url: "http://localhost:5173/",
+        });
+      });
+
+      // "Reload preview" only exists in the restart-action dropdown branch shared
+      // with connection_refused — its presence proves proxy_error uses it.
+      expect(container.textContent).toContain("Dev server unavailable");
+      expect(container.textContent).toContain("Reload preview");
+    });
+
+    it("passes 4xx (bootstrap 403/405) through without an overlay", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-frame-navigate", {
+          isMainFrame: true,
+          httpResponseCode: 403,
+          url: "http://localhost:5173/",
+        });
+        emitWebviewEvent(webview, "did-finish-load");
+      });
+
+      expect(container.textContent).not.toContain("Dev server unavailable");
+    });
+
+    it("ignores a 502 from a non-main-frame navigation", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-frame-navigate", {
+          isMainFrame: false,
+          httpResponseCode: 502,
+          url: "http://localhost:5173/iframe",
+        });
+        emitWebviewEvent(webview, "did-finish-load");
+      });
+
+      expect(container.textContent).not.toContain("Dev server unavailable");
+    });
+
+    it("auto-retries the load with backoff while the 502 persists", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-frame-navigate", {
+          isMainFrame: true,
+          httpResponseCode: 502,
+          url: "http://localhost:5173/",
+        });
+      });
+
+      // First retry fires after 1000ms (1000 * 2^0); not before.
+      expect(webview.reload).not.toHaveBeenCalled();
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      expect(webview.reload).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops auto-retrying after the cap but keeps the overlay for manual recovery", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      const delays = [1000, 2000, 4000, 8000, 16000];
+      // Each cycle mimics a reload that 502s again: a fresh load (did-start-loading)
+      // then another main-frame 502.
+      for (let i = 0; i < 6; i++) {
+        act(() => {
+          emitWebviewEvent(webview, "did-start-loading");
+          emitWebviewEvent(webview, "did-frame-navigate", {
+            isMainFrame: true,
+            httpResponseCode: 502,
+            url: "http://localhost:5173/",
+          });
+        });
+        if (i < 5) {
+          act(() => {
+            vi.advanceTimersByTime(delays[i]!);
+          });
+        }
+      }
+
+      // The 6th 502 lands after the count hit the cap, so no further reload is scheduled.
+      expect(webview.reload).toHaveBeenCalledTimes(5);
+      expect(container.textContent).toContain("Dev server unavailable");
+    });
+
+    it("clears the proxy overlay once the upstream answers with a 2xx", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-frame-navigate", {
+          isMainFrame: true,
+          httpResponseCode: 502,
+          url: "http://localhost:5173/",
+        });
+      });
+      expect(container.textContent).toContain("Dev server unavailable");
+
+      // Recovery: the retry reloads, the upstream is back, a 200 commits and finishes.
+      act(() => {
+        emitWebviewEvent(webview, "did-start-loading");
+        emitWebviewEvent(webview, "did-frame-navigate", {
+          isMainFrame: true,
+          httpResponseCode: 200,
+          url: "http://localhost:5173/",
+        });
+        emitWebviewEvent(webview, "did-navigate", { url: "http://localhost:5173/" });
+        emitWebviewEvent(webview, "did-finish-load");
+      });
+
+      expect(container.textContent).not.toContain("Dev server unavailable");
+    });
+  });
 });

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -1990,6 +1990,72 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       expect(container.textContent).not.toContain("Dev server unavailable");
     });
 
+    it("passes an upstream app 500/503/504 through without an overlay", () => {
+      // The proxy forwards upstream responses untouched; only it self-generates
+      // 502. A dev app's own 5xx error page must render, not be hidden/reloaded.
+      for (const code of [500, 503, 504]) {
+        const { container, unmount } = render(<DevPreviewPane {...baseProps} />);
+        const webview = getWebviewElement(container);
+        act(() => {
+          emitWebviewEvent(webview, "did-frame-navigate", {
+            isMainFrame: true,
+            httpResponseCode: code,
+            url: "http://localhost:5173/",
+          });
+          emitWebviewEvent(webview, "did-finish-load");
+        });
+        expect(container.textContent).not.toContain("Dev server unavailable");
+        expect(webview.reload).not.toHaveBeenCalled();
+        unmount();
+      }
+    });
+
+    it("drops the automatic-reload promise from the message once the retry cap is hit", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      const delays = [1000, 2000, 4000, 8000, 16000];
+      for (let i = 0; i < 6; i++) {
+        act(() => {
+          emitWebviewEvent(webview, "did-start-loading");
+          emitWebviewEvent(webview, "did-frame-navigate", {
+            isMainFrame: true,
+            httpResponseCode: 502,
+            url: "http://localhost:5173/",
+          });
+        });
+        if (i < 5) {
+          act(() => {
+            vi.advanceTimersByTime(delays[i]!);
+          });
+        }
+      }
+
+      expect(container.textContent).toContain("Dev server unavailable");
+      expect(container.textContent).not.toContain("reloads automatically");
+      expect(container.textContent).toContain("Restart it or reload");
+    });
+
+    it("cancels the pending auto-retry on unmount", () => {
+      const { container, unmount } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-frame-navigate", {
+          isMainFrame: true,
+          httpResponseCode: 502,
+          url: "http://localhost:5173/",
+        });
+      });
+
+      unmount();
+      act(() => {
+        vi.advanceTimersByTime(16000);
+      });
+
+      expect(webview.reload).not.toHaveBeenCalled();
+    });
+
     it("ignores a 502 from a non-main-frame navigation", () => {
       const { container } = render(<DevPreviewPane {...baseProps} />);
       const webview = getWebviewElement(container);

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -543,15 +543,17 @@ export function useDevPreviewLoadLifecycle({
 
     const handleDidFrameNavigate = (e: Electron.DidFrameNavigateEvent) => {
       // did-frame-navigate is the only renderer-side <webview> event carrying
-      // httpResponseCode. The dev-preview proxy returns HTTP 502 when the upstream
-      // dev server is down or unregistered; because TCP succeeds, did-fail-load
-      // never fires and did-finish-load would otherwise render the raw text/plain
-      // 502 body. Latch a main-frame 5xx here and surface the styled overlay; the
-      // guards in did-navigate/did-finish-load keep it from being cleared. The
-      // proxy origin is exclusive to the proxy, so any 5xx is a proxy failure
-      // (not an app-rendered error page); 4xx (bootstrap 403/405) passes through.
+      // httpResponseCode. The dev-preview proxy self-generates exactly one status
+      // — HTTP 502 — when the upstream dev server is down or unregistered
+      // (DevPreviewProxyService.send502); every other response (including an app
+      // 500/503/504) is forwarded upstream untouched and must render normally so
+      // developers can see their own error pages. Because TCP succeeds for the
+      // 502, did-fail-load never fires and did-finish-load would otherwise render
+      // the raw text/plain 502 body. Latch a main-frame 502 here and surface the
+      // styled overlay; the guards in did-navigate/did-finish-load keep it from
+      // being cleared. 4xx (bootstrap 403/405) and other 5xx pass through.
       if (!e.isMainFrame) return;
-      if (typeof e.httpResponseCode !== "number" || e.httpResponseCode < 500) return;
+      if (e.httpResponseCode !== 502) return;
       pendingHttpErrorRef.current = true;
       setIsLoading(false);
       setIsSlowLoad(false);
@@ -569,23 +571,28 @@ export function useDevPreviewLoadLifecycle({
         clearTimeout(loadTimeoutRef.current);
         loadTimeoutRef.current = null;
       }
-      setWebviewLoadError({
-        code: "proxy_error",
-        message: `The dev server returned an error (HTTP ${e.httpResponseCode}). It may be restarting — the preview reloads automatically once it's back.`,
-        errorCode: e.httpResponseCode,
-        validatedURL: e.url || undefined,
-      });
 
       // Schedule a bounded auto-retry. proxyRetryCountRef persists across the
       // reload (did-start-loading clears the timer, not the count), so repeated
-      // 5xx responses walk up the backoff and stop at the cap.
+      // 502 responses walk up the backoff and stop at the cap.
       const PROXY_MAX_RETRIES = 5;
       if (proxyRetryRef.current) {
         clearTimeout(proxyRetryRef.current);
         proxyRetryRef.current = null;
       }
       const attempt = proxyRetryCountRef.current;
-      if (attempt < PROXY_MAX_RETRIES) {
+      const willRetry = attempt < PROXY_MAX_RETRIES;
+
+      setWebviewLoadError({
+        code: "proxy_error",
+        message: willRetry
+          ? "The dev server isn't responding. It may be restarting — the preview reloads automatically once it's back."
+          : "The dev server isn't responding. Restart it or reload the preview to try again.",
+        errorCode: e.httpResponseCode,
+        validatedURL: e.url || undefined,
+      });
+
+      if (willRetry) {
         proxyRetryCountRef.current = attempt + 1;
         const delayMs = Math.min(1000 * 2 ** attempt, 16000);
         proxyRetryRef.current = setTimeout(() => {

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -655,10 +655,7 @@ export function useDevPreviewLoadLifecycle({
       "render-process-gone",
       handleRenderProcessGone as unknown as EventListener
     );
-    webview.addEventListener(
-      "did-frame-navigate",
-      handleDidFrameNavigate as unknown as EventListener
-    );
+    webview.addEventListener("did-frame-navigate", handleDidFrameNavigate);
     webview.addEventListener("did-navigate", handleDidNavigate as unknown as EventListener);
     webview.addEventListener(
       "did-navigate-in-page",
@@ -675,10 +672,7 @@ export function useDevPreviewLoadLifecycle({
         "render-process-gone",
         handleRenderProcessGone as unknown as EventListener
       );
-      webview.removeEventListener(
-        "did-frame-navigate",
-        handleDidFrameNavigate as unknown as EventListener
-      );
+      webview.removeEventListener("did-frame-navigate", handleDidFrameNavigate);
       webview.removeEventListener("did-navigate", handleDidNavigate as unknown as EventListener);
       webview.removeEventListener(
         "did-navigate-in-page",

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -23,6 +23,7 @@ export type WebviewLoadErrorCode =
   | "name_not_resolved"
   | "internet_disconnected"
   | "connection_refused"
+  | "proxy_error"
   | "cert"
   | "ssl_protocol"
   | "failed";
@@ -43,6 +44,8 @@ export function webviewLoadErrorHeading(code: WebviewLoadErrorCode): string {
       return "Load cancelled";
     case "connection_refused":
       return "Dev server unreachable";
+    case "proxy_error":
+      return "Dev server unavailable";
     case "name_not_resolved":
       return "Couldn't resolve address";
     case "internet_disconnected":
@@ -125,6 +128,24 @@ export function useDevPreviewLoadLifecycle({
   const failLoadRetryRef = useRef<NodeJS.Timeout | null>(null);
   const failLoadRetryCountRef = useRef<number>(0);
 
+  // Latched synchronously by handleDidFrameNavigate when a main-frame HTTP 5xx
+  // (e.g. the dev-preview proxy's 502 for a down/unregistered upstream) commits.
+  // Read in the same event-loop tick by handleDidNavigate and handleDidFinishLoad
+  // so a TCP-successful-but-error-page load doesn't clear the error overlay and
+  // render the raw text/plain proxy body. A plain ref (not state) is required:
+  // the three events fire sequentially within one microtask pump.
+  const pendingHttpErrorRef = useRef(false);
+
+  // Bounded auto-retry for a proxy 5xx. The dev server can restart in place
+  // (e.g. config-change full reload) while Daintree still reports status
+  // "running", so the webview never remounts and there's no recovery signal
+  // other than re-hitting the stable proxy origin. Reload with exponential
+  // backoff until the upstream answers or the cap is reached; after the cap the
+  // overlay's manual recovery actions take over. Mirrors the connection-refused
+  // retry below.
+  const proxyRetryRef = useRef<NodeJS.Timeout | null>(null);
+  const proxyRetryCountRef = useRef<number>(0);
+
   // Mirror the active preset/rotation/DPR into refs so handleDidFinishLoad can
   // re-apply overrides after cross-origin navigation without the load-listener
   // effect depending on these values (which would tear down/rebuild load timers
@@ -168,7 +189,13 @@ export function useDevPreviewLoadLifecycle({
       clearTimeout(failLoadRetryRef.current);
       failLoadRetryRef.current = null;
     }
+    if (proxyRetryRef.current) {
+      clearTimeout(proxyRetryRef.current);
+      proxyRetryRef.current = null;
+    }
     failLoadRetryCountRef.current = 0;
+    proxyRetryCountRef.current = 0;
+    pendingHttpErrorRef.current = false;
     setReconnectAttempt(0);
   }, []);
 
@@ -223,7 +250,13 @@ export function useDevPreviewLoadLifecycle({
         clearTimeout(failLoadRetryRef.current);
         failLoadRetryRef.current = null;
       }
+      if (proxyRetryRef.current) {
+        clearTimeout(proxyRetryRef.current);
+        proxyRetryRef.current = null;
+      }
       failLoadRetryCountRef.current = 0;
+      proxyRetryCountRef.current = 0;
+      pendingHttpErrorRef.current = false;
       if (reason === "clean-exit") return;
       setWebviewCrashed({ reason, exitCode });
       setWebviewLoadError(null);
@@ -236,6 +269,16 @@ export function useDevPreviewLoadLifecycle({
       setWebviewCrashed(null);
       setReconnectAttempt(0);
       setIsSlowLoad(false);
+      // Fresh navigation: drop any stale HTTP-error latch. did-frame-navigate,
+      // which fires after this for the same navigation, re-sets it if needed.
+      pendingHttpErrorRef.current = false;
+      // Cancel a pending proxy auto-retry — this load supersedes it. The retry
+      // count is intentionally preserved so a still-failing upstream keeps
+      // walking up the backoff; it resets only on a genuine successful load.
+      if (proxyRetryRef.current) {
+        clearTimeout(proxyRetryRef.current);
+        proxyRetryRef.current = null;
+      }
       if (slowLoadTimeoutRef.current) {
         clearTimeout(slowLoadTimeoutRef.current);
       }
@@ -289,9 +332,6 @@ export function useDevPreviewLoadLifecycle({
 
     const handleDidFinishLoad = () => {
       setIsLoading(false);
-      setWebviewLoadError(null);
-      setWebviewCrashed(null);
-      setReconnectAttempt(0);
       setIsSlowLoad(false);
       if (slowLoadTimeoutRef.current) {
         clearTimeout(slowLoadTimeoutRef.current);
@@ -301,10 +341,28 @@ export function useDevPreviewLoadLifecycle({
         clearTimeout(loadTimeoutRef.current);
         loadTimeoutRef.current = null;
       }
+
+      // A main-frame 5xx (proxy 502) was committed via did-frame-navigate: the
+      // network load finished, but the rendered body is the proxy's error page.
+      // Keep the overlay (skip the error clear + emulation re-apply) and consume
+      // the latch so the next genuine successful load clears the overlay.
+      if (pendingHttpErrorRef.current) {
+        pendingHttpErrorRef.current = false;
+        return;
+      }
+
+      setWebviewLoadError(null);
+      setWebviewCrashed(null);
+      setReconnectAttempt(0);
       failLoadRetryCountRef.current = 0;
+      proxyRetryCountRef.current = 0;
       if (failLoadRetryRef.current) {
         clearTimeout(failLoadRetryRef.current);
         failLoadRetryRef.current = null;
+      }
+      if (proxyRetryRef.current) {
+        clearTimeout(proxyRetryRef.current);
+        proxyRetryRef.current = null;
       }
 
       // Device emulation and the UA override do NOT persist across
@@ -483,13 +541,80 @@ export function useDevPreviewLoadLifecycle({
       });
     };
 
+    const handleDidFrameNavigate = (e: Electron.DidFrameNavigateEvent) => {
+      // did-frame-navigate is the only renderer-side <webview> event carrying
+      // httpResponseCode. The dev-preview proxy returns HTTP 502 when the upstream
+      // dev server is down or unregistered; because TCP succeeds, did-fail-load
+      // never fires and did-finish-load would otherwise render the raw text/plain
+      // 502 body. Latch a main-frame 5xx here and surface the styled overlay; the
+      // guards in did-navigate/did-finish-load keep it from being cleared. The
+      // proxy origin is exclusive to the proxy, so any 5xx is a proxy failure
+      // (not an app-rendered error page); 4xx (bootstrap 403/405) passes through.
+      if (!e.isMainFrame) return;
+      if (typeof e.httpResponseCode !== "number" || e.httpResponseCode < 500) return;
+      pendingHttpErrorRef.current = true;
+      setIsLoading(false);
+      setIsSlowLoad(false);
+      setReconnectAttempt(0);
+      failLoadRetryCountRef.current = 0;
+      if (failLoadRetryRef.current) {
+        clearTimeout(failLoadRetryRef.current);
+        failLoadRetryRef.current = null;
+      }
+      if (slowLoadTimeoutRef.current) {
+        clearTimeout(slowLoadTimeoutRef.current);
+        slowLoadTimeoutRef.current = null;
+      }
+      if (loadTimeoutRef.current) {
+        clearTimeout(loadTimeoutRef.current);
+        loadTimeoutRef.current = null;
+      }
+      setWebviewLoadError({
+        code: "proxy_error",
+        message: `The dev server returned an error (HTTP ${e.httpResponseCode}). It may be restarting — the preview reloads automatically once it's back.`,
+        errorCode: e.httpResponseCode,
+        validatedURL: e.url || undefined,
+      });
+
+      // Schedule a bounded auto-retry. proxyRetryCountRef persists across the
+      // reload (did-start-loading clears the timer, not the count), so repeated
+      // 5xx responses walk up the backoff and stop at the cap.
+      const PROXY_MAX_RETRIES = 5;
+      if (proxyRetryRef.current) {
+        clearTimeout(proxyRetryRef.current);
+        proxyRetryRef.current = null;
+      }
+      const attempt = proxyRetryCountRef.current;
+      if (attempt < PROXY_MAX_RETRIES) {
+        proxyRetryCountRef.current = attempt + 1;
+        const delayMs = Math.min(1000 * 2 ** attempt, 16000);
+        proxyRetryRef.current = setTimeout(() => {
+          proxyRetryRef.current = null;
+          try {
+            webview.reload();
+          } catch {
+            // Webview detached
+          }
+        }, delayMs);
+      }
+    };
+
     const handleDidNavigate = (e: Electron.DidNavigateEvent) => {
       const navigatedUrl = e.url;
       // Suppress about:blank navigations triggered by eviction
       if (navigatedUrl === "about:blank" && evictingRef.current) return;
       setBlockedNav({ type: "DISMISS" });
-      setWebviewLoadError(null);
-      setReconnectAttempt(0);
+      // A main-frame 5xx (proxy 502) was just committed via did-frame-navigate;
+      // keep the overlay rather than clearing it for this "successful" load.
+      if (!pendingHttpErrorRef.current) {
+        setWebviewLoadError(null);
+        setReconnectAttempt(0);
+        proxyRetryCountRef.current = 0;
+        if (proxyRetryRef.current) {
+          clearTimeout(proxyRetryRef.current);
+          proxyRetryRef.current = null;
+        }
+      }
       // A confirmed new main-frame navigation means we're past any previous failure;
       // reset the retry budget so stale exhaustion doesn't block future attempts.
       failLoadRetryCountRef.current = 0;
@@ -523,6 +648,10 @@ export function useDevPreviewLoadLifecycle({
       "render-process-gone",
       handleRenderProcessGone as unknown as EventListener
     );
+    webview.addEventListener(
+      "did-frame-navigate",
+      handleDidFrameNavigate as unknown as EventListener
+    );
     webview.addEventListener("did-navigate", handleDidNavigate as unknown as EventListener);
     webview.addEventListener(
       "did-navigate-in-page",
@@ -539,6 +668,10 @@ export function useDevPreviewLoadLifecycle({
         "render-process-gone",
         handleRenderProcessGone as unknown as EventListener
       );
+      webview.removeEventListener(
+        "did-frame-navigate",
+        handleDidFrameNavigate as unknown as EventListener
+      );
       webview.removeEventListener("did-navigate", handleDidNavigate as unknown as EventListener);
       webview.removeEventListener(
         "did-navigate-in-page",
@@ -548,6 +681,10 @@ export function useDevPreviewLoadLifecycle({
       if (failLoadRetryRef.current) {
         clearTimeout(failLoadRetryRef.current);
         failLoadRetryRef.current = null;
+      }
+      if (proxyRetryRef.current) {
+        clearTimeout(proxyRetryRef.current);
+        proxyRetryRef.current = null;
       }
       if (slowLoadTimeoutRef.current) {
         clearTimeout(slowLoadTimeoutRef.current);
@@ -669,6 +806,9 @@ export function useDevPreviewLoadLifecycle({
       }
       if (failLoadRetryRef.current) {
         clearTimeout(failLoadRetryRef.current);
+      }
+      if (proxyRetryRef.current) {
+        clearTimeout(proxyRetryRef.current);
       }
     };
   }, []);


### PR DESCRIPTION
## Summary

When the proxy returned a 502, the dev-preview pane displayed it as raw text and never recovered. In Electron a proxy HTTP 502 is a successful network load, so \`did-finish-load\` fired and unconditionally cleared the webview load error state — the existing error overlay never got a chance to show.

Resolves #9948

## Changes

- Added a \`did-frame-navigate\` listener (the only renderer \`<webview>\` event that carries \`httpResponseCode\` and \`isMainFrame\`) to detect main-frame 502s and route them into the existing error overlay as a new \`proxy_error\` code with heading "Dev server unavailable"
- Latches the pending error in a ref (\`pendingHttpErrorRef\`) so the following \`did-navigate\` and \`did-finish-load\` don't clear it; \`did-finish-load\` consumes the latch on the next genuine successful load
- Scoped strictly to 502 — the proxy only self-generates 502; upstream 4xx/5xx pass through untouched so developers still see their own error pages
- Routed \`proxy_error\` to the existing "Restart dev server" recovery branch (Restart / Reload / Clear-cache / Reinstall)
- Added bounded exponential-backoff auto-retry (1s → 2s → 4s → 8s → 16s, cap 5 attempts) so the pane recovers automatically when an upstream restarts behind a live proxy without needing a manual reload; after the cap the overlay drops the auto-reload promise and falls back to the manual recovery actions

**Files:** \`useDevPreviewLoadLifecycle.ts\`, \`DevPreviewPane.tsx\`, \`DevPreviewPane.webview.test.tsx\`

## Testing

9 new unit tests in \`DevPreviewPane.webview.test.tsx\` covering: 502 detection, error latch + nav-event suppression, auto-retry backoff, cap behaviour, and pass-through of non-502 codes. 65 tests passing total. \`npm run check\` clean; lint ratchet improved 1187 → 1186.