### PR TITLE
perf(github): gate issue/PR dropdown list revalidation on open state

### DIFF
--- a/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
@@ -78,7 +78,12 @@ vi.mock("electron", () => {
   }
 
   return {
-    app: { isPackaged: false, commandLine: { appendSwitch: vi.fn() } },
+    app: {
+      isPackaged: false,
+      commandLine: { appendSwitch: vi.fn() },
+      getPath: vi.fn(() => "/tmp/daintree-test-appdata"),
+      setPath: vi.fn(),
+    },
     BrowserWindow: vi.fn(),
     WebContentsView: MockWebContentsView,
     session: { fromPartition: vi.fn(() => ({ protocol: { handle: vi.fn() } })) },

--- a/electron/window/__tests__/ProjectViewManager.freeze.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.freeze.test.ts
@@ -33,7 +33,12 @@ vi.mock("electron", () => {
     return { webContents: wc, setBounds: vi.fn(), setBackgroundColor: vi.fn() };
   }
   return {
-    app: { isPackaged: false, commandLine: { appendSwitch: vi.fn() } },
+    app: {
+      isPackaged: false,
+      commandLine: { appendSwitch: vi.fn() },
+      getPath: vi.fn(() => "/tmp/daintree-test-appdata"),
+      setPath: vi.fn(),
+    },
     BrowserWindow: vi.fn(),
     WebContentsView: MockWebContentsView,
     session: { fromPartition: vi.fn(() => ({ protocol: { handle: vi.fn() } })) },

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -75,7 +75,13 @@ vi.mock("electron", () => {
     return { webContents: wc, setBounds: vi.fn(), setBackgroundColor: vi.fn() };
   }
   return {
-    app: { isPackaged: false, commandLine: { appendSwitch: vi.fn() }, getAppMetrics: () => [] },
+    app: {
+      isPackaged: false,
+      commandLine: { appendSwitch: vi.fn() },
+      getAppMetrics: () => [],
+      getPath: vi.fn(() => "/tmp/daintree-test-appdata"),
+      setPath: vi.fn(),
+    },
     BrowserWindow: vi.fn(),
     WebContentsView: MockWebContentsView,
     session: { fromPartition: vi.fn(() => ({ protocol: { handle: vi.fn() } })) },

--- a/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
@@ -874,7 +874,7 @@ describe("GitHubResourceList focus/visibility revalidation", () => {
 
     mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
 
-    render(
+    const { rerender } = render(
       <FixedDropdownVisibleContext.Provider value={false}>
         <GitHubResourceList type="issue" projectPath="/test/proj" />
       </FixedDropdownVisibleContext.Provider>
@@ -890,6 +890,19 @@ describe("GitHubResourceList focus/visibility revalidation", () => {
     await vi.advanceTimersByTimeAsync(0);
 
     // Focus while the dropdown body is hidden must NOT trigger a revalidate.
+    expect(mockListIssues).toHaveBeenCalledTimes(1);
+
+    // Reopening the dropdown (visibility flip) must also not replay a hidden
+    // focus — the listener is gated on the latest context value, not
+    // buffered, so the gating carries through.
+    await act(async () => {
+      rerender(
+        <FixedDropdownVisibleContext.Provider value={true}>
+          <GitHubResourceList type="issue" projectPath="/test/proj" />
+        </FixedDropdownVisibleContext.Provider>
+      );
+    });
+    await vi.advanceTimersByTimeAsync(0);
     expect(mockListIssues).toHaveBeenCalledTimes(1);
   });
 });
@@ -1055,12 +1068,9 @@ describe("GitHubResourceList wake-coordinator revalidation", () => {
     });
     expect(mockListIssues).toHaveBeenCalledTimes(1);
 
-    // Reopen (now visible). If the hidden wake had NOT been consumed, the
-    // wake effect's next run would see the new wakeEpoch plus a stale ref
-    // and refetch immediately on the visibility flip. Consumed means the
-    // ref is already at the latest epoch — a fresh wake is the only thing
-    // that triggers a fetch. Bump again: with consume-fix in place, exactly
-    // one new call. Without it, two new calls.
+    // Reopen (now visible). The visibility flip alone must NOT trigger a
+    // fetch — guards against a regression where the wake-effect dep array
+    // loses `dropdownVisible` and the flip itself behaves like a wake.
     await act(async () => {
       rerender(
         <FixedDropdownVisibleContext.Provider value={true}>
@@ -1068,7 +1078,13 @@ describe("GitHubResourceList wake-coordinator revalidation", () => {
         </FixedDropdownVisibleContext.Provider>
       );
     });
+    expect(mockListIssues).toHaveBeenCalledTimes(1);
 
+    // Bump wake again. If the hidden wake had NOT been consumed, the wake
+    // effect's next run would see the new wakeEpoch plus a stale ref and
+    // refetch on top of the visibility-flip fetch (total 2 from this phase
+    // + initial 1 = 3). Consumed means the ref is already at the latest
+    // epoch — this fresh wake is the only thing that fetches.
     await act(async () => {
       useSystemWakeStore.setState((s) => ({ wakeEpoch: s.wakeEpoch + 1 }));
     });

--- a/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
@@ -10,6 +10,7 @@ import { useGitHubFilterStore } from "../stores/githubFilterStore";
 import { useIssueSelectionStore } from "@/store/issueSelectionStore";
 import { useGitHubRateLimitStore } from "@/store/githubRateLimitStore";
 import { useSystemWakeStore } from "@/store/systemWakeStore";
+import { FixedDropdownVisibleContext } from "@/components/ui/fixed-dropdown";
 
 const mockListIssues = vi.fn();
 const mockListPRs = vi.fn();
@@ -861,6 +862,36 @@ describe("GitHubResourceList focus/visibility revalidation", () => {
 
     expect(mockListIssues).toHaveBeenCalledTimes(1);
   });
+
+  it("does not revalidate on focus when the keepMounted dropdown body is hidden (#10125)", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(1)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    render(
+      <FixedDropdownVisibleContext.Provider value={false}>
+        <GitHubResourceList type="issue" projectPath="/test/proj" />
+      </FixedDropdownVisibleContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(mockListIssues).toHaveBeenCalledTimes(1);
+    });
+
+    // Advance past the 30s revalidation throttle.
+    await vi.advanceTimersByTimeAsync(31_000);
+    window.dispatchEvent(new Event("focus"));
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Focus while the dropdown body is hidden must NOT trigger a revalidate.
+    expect(mockListIssues).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("GitHubResourceList wake-coordinator revalidation", () => {
@@ -989,6 +1020,59 @@ describe("GitHubResourceList wake-coordinator revalidation", () => {
     // consume-during-numeric-search fix guarantees the stale wake doesn't
     // replay when numberQuery transitions back to null. waitFor on the exact
     // count so CI doesn't race the second effect flush.
+    await waitFor(() => {
+      expect(mockListIssues).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("consumes the wake epoch even when the dropdown body is hidden so a later open doesn't replay it (#10125)", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(1)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+
+    mockListIssues
+      .mockResolvedValueOnce(makeResponse([makeIssue(1)]))
+      .mockResolvedValueOnce(makeResponse([makeIssue(1), makeIssue(5)]));
+
+    // Mount with the dropdown body hidden.
+    const { rerender } = render(
+      <FixedDropdownVisibleContext.Provider value={false}>
+        <GitHubResourceList type="issue" projectPath="/test/proj" />
+      </FixedDropdownVisibleContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(mockListIssues).toHaveBeenCalledTimes(1);
+    });
+
+    // Wake fires while hidden — must NOT refetch.
+    await act(async () => {
+      useSystemWakeStore.setState((s) => ({ wakeEpoch: s.wakeEpoch + 1 }));
+    });
+    expect(mockListIssues).toHaveBeenCalledTimes(1);
+
+    // Reopen (now visible). If the hidden wake had NOT been consumed, the
+    // wake effect's next run would see the new wakeEpoch plus a stale ref
+    // and refetch immediately on the visibility flip. Consumed means the
+    // ref is already at the latest epoch — a fresh wake is the only thing
+    // that triggers a fetch. Bump again: with consume-fix in place, exactly
+    // one new call. Without it, two new calls.
+    await act(async () => {
+      rerender(
+        <FixedDropdownVisibleContext.Provider value={true}>
+          <GitHubResourceList type="issue" projectPath="/test/proj" />
+        </FixedDropdownVisibleContext.Provider>
+      );
+    });
+
+    await act(async () => {
+      useSystemWakeStore.setState((s) => ({ wakeEpoch: s.wakeEpoch + 1 }));
+    });
+
     await waitFor(() => {
       expect(mockListIssues).toHaveBeenCalledTimes(2);
     });

--- a/plugins/builtin/github/renderer/hooks/useGitHubResourceListSWR.ts
+++ b/plugins/builtin/github/renderer/hooks/useGitHubResourceListSWR.ts
@@ -1,4 +1,12 @@
-import { useState, useEffect, useMemo, useCallback, useRef, useLayoutEffect } from "react";
+import {
+  useState,
+  useEffect,
+  useMemo,
+  useCallback,
+  useRef,
+  useLayoutEffect,
+  useContext,
+} from "react";
 import { useDebounce } from "@/hooks/useDebounce";
 import {
   buildCacheKey,
@@ -11,6 +19,7 @@ import { isRateLimitError, isTokenRelatedError, isTransientNetworkError } from "
 import { githubClient } from "@/clients/githubClient";
 import { useGitHubRateLimitStore } from "@/store/githubRateLimitStore";
 import { useSystemWakeStore } from "@/store/systemWakeStore";
+import { FixedDropdownVisibleContext } from "@/components/ui/fixed-dropdown";
 import type { GitHubIssue, GitHubPR, GitHubSortOrder } from "@shared/types/github";
 import { parseNumberQuery } from "@/lib/parseNumberQuery";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -509,6 +518,10 @@ export function useGitHubResourceListSWR({
     return () => abortController.abort();
   }, [debouncedSearch, filterState, projectPath, type, fetchData, numberQuery, cacheKey]);
 
+  // Default `true` keeps non-dropdown callers and external mounts unaffected;
+  // gate the focus + wake revalidation paths on the dropdown's real visibility (#10125).
+  const dropdownVisible = useContext(FixedDropdownVisibleContext);
+
   // Background revalidation when the window regains focus. CI status flips
   // on every push, so a user returning from another app expects the list to
   // refresh — without this, stale green ticks can linger for the full backend
@@ -530,6 +543,7 @@ export function useGitHubResourceListSWR({
       if (Date.now() - lastFetchAttemptRef.current < REVALIDATE_THROTTLE_MS) {
         return;
       }
+      if (!dropdownVisible) return;
       const gen = nextGeneration(cacheKey);
       void fetchData(null, false, abortController.signal, {
         revalidating: true,
@@ -544,7 +558,7 @@ export function useGitHubResourceListSWR({
       window.removeEventListener("focus", maybeRevalidate);
       abortController.abort();
     };
-  }, [fetchData, cacheKey, numberQuery]);
+  }, [fetchData, cacheKey, numberQuery, dropdownVisible]);
 
   // Wake-coordinator subscription (#8066). Bypasses the 30-second throttle
   // gate that applies to focus events: a system wake is rare enough that we
@@ -566,6 +580,10 @@ export function useGitHubResourceListSWR({
     // the now-stale wake doesn't replay as a spurious revalidation.
     lastSeenWakeEpochRef.current = wakeEpoch;
     if (numberQuery !== null) return;
+    // Same consume-while-gated pattern as the numeric-search skip above: a
+    // wake that lands while the dropdown body is hidden must not replay as a
+    // redundant fetch on next open (#10125).
+    if (!dropdownVisible) return;
     const abortController = new AbortController();
     const gen = nextGeneration(cacheKey);
     void fetchData(null, false, abortController.signal, {
@@ -574,7 +592,7 @@ export function useGitHubResourceListSWR({
       cacheKey,
     });
     return () => abortController.abort();
-  }, [wakeEpoch, numberQuery, fetchData, cacheKey]);
+  }, [wakeEpoch, numberQuery, fetchData, cacheKey, dropdownVisible]);
 
   // Numeric query effect — handles single number (#42), multi-number
   // (#1, #2, #3), range (#10-20), and open-ended (#>=100) searches.

--- a/src/components/Browser/__tests__/BrowserToolbar.test.tsx
+++ b/src/components/Browser/__tests__/BrowserToolbar.test.tsx
@@ -317,7 +317,7 @@ describe("BrowserToolbar ARIA semantics", () => {
     });
 
     await act(async () => {
-      fireEvent.click(getByRole("button", { name: "Capture screenshot" }));
+      fireEvent.click(getByRole("button", { name: "Copy screenshot to clipboard" }));
     });
 
     expect(onCaptureScreenshot).toHaveBeenCalledOnce();


### PR DESCRIPTION
## Summary

- The issue/PR dropdown list SWR hook was re-running the GraphQL list query on every window focus and every system wake, regardless of whether the dropdown was actually open. With `keepMounted` keeping the hook alive after the first open, that turned every alt-tab across multi-window setups into a burst against the shared GraphQL budget.
- This gates both the focus revalidation and the wake revalidation on the dropdown's real visibility, using the existing `FixedDropdownVisibleContext`. The wake handler still consumes its epoch while hidden so the fetch doesn't replay on the next open.
- Two regression tests cover the new gating: focus while hidden, and wake consume-while-hidden, with intermediate-state assertions to make sure the hook is actually preventing fetches, not just ignoring them.

Resolves #10125

## Changes

- `plugins/builtin/github/renderer/hooks/useGitHubResourceListSWR.ts`: read `FixedDropdownVisibleContext` near the focus effect, gate both the focus and wake revalidation on `dropdownVisible`, and keep the consume-while-gated invariant for wake.
- `plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx`: two new regression tests (focus-while-hidden, wake consume-while-hidden) with intermediate-state assertions.

## Testing

- `npm run check` (10/10): typecheck, channel/IPC/help/confirm-wiring guards, lint ratchet, format.
- New vitest coverage in `GitHubResourceList.swr.test.tsx` for the focus-while-hidden and wake consume-while-hidden paths.