### PR TITLE
fix(window): clamp default window size to work area when no x/y saved

### DIFF
--- a/electron/__tests__/windowState.test.ts
+++ b/electron/__tests__/windowState.test.ts
@@ -466,7 +466,10 @@ describe("createWindowWithState", () => {
 
       winInstance.getBounds.mockReturnValue({ x: 0, y: 0, width: 2560, height: 1440 });
 
-      screenMock.getDisplayMatching.mockReturnValueOnce({
+      // Use mockReturnValue (not Once) because clampToDisplay re-fetches the display
+      // after the size-clamp in createWindowWithState — both calls must see the
+      // zero-workArea display or the fallback is silently bypassed.
+      screenMock.getDisplayMatching.mockReturnValue({
         workArea: { x: 0, y: 0, width: 0, height: 0 },
         bounds: { x: 0, y: 0, width: 1920, height: 1080 },
       });
@@ -475,6 +478,62 @@ describe("createWindowWithState", () => {
 
       // Must NOT produce setSize(0, 0) — the zero workArea falls back to display.bounds (1920x1080)
       expect(winInstance.setSize).toHaveBeenCalledWith(1920, 1080);
+      // And the position-clamp must also use the fallback, not the broken workArea
+      expect(winInstance.setBounds).toHaveBeenCalledWith({
+        x: 0,
+        y: 0,
+        width: 1920,
+        height: 1080,
+      });
+    });
+
+    it("clamps both axes of an oversized default window on a small display", () => {
+      // Default 2560x1440 (unrealistic, but exercises both the width and height
+      // clamp branches) on a 1280x720 work area.
+      const defaultBounds = {
+        width: 2560,
+        height: 1440,
+        isMaximized: false,
+        isFullScreen: false,
+      };
+      windowStatesStoreMock.get.mockReturnValue({ "/home/user/project": defaultBounds });
+
+      winInstance.getBounds.mockReturnValue({ x: 0, y: 0, width: 2560, height: 1440 });
+
+      screenMock.getPrimaryDisplay.mockReturnValueOnce({
+        workArea: { x: 0, y: 0, width: 1280, height: 720 },
+        bounds: { x: 0, y: 0, width: 1280, height: 720 },
+      });
+
+      createWindowWithState({ show: false }, "/home/user/project");
+
+      expect(winInstance.setSize).toHaveBeenCalledWith(1280, 720);
+      expect(winInstance.center).toHaveBeenCalled();
+    });
+
+    it("clamps a window entirely off the right/bottom edge back into the work area", () => {
+      // Saved bounds past the right/bottom of a 1920x1080 work area. clampToDisplay
+      // should pin x to wa.x + wa.width - width = 720 and y to wa.y + wa.height - height = 280.
+      const offRightBounds = {
+        x: 2000,
+        y: 1200,
+        width: 1200,
+        height: 800,
+        isMaximized: false,
+      };
+      windowStatesStoreMock.get.mockReturnValue({ "/home/user/project": offRightBounds });
+
+      winInstance.getBounds.mockReturnValue({ x: 2000, y: 1200, width: 1200, height: 800 });
+
+      createWindowWithState({ show: false }, "/home/user/project");
+
+      expect(winInstance.setSize).not.toHaveBeenCalled();
+      expect(winInstance.setBounds).toHaveBeenCalledWith({
+        x: 720,
+        y: 280,
+        width: 1200,
+        height: 800,
+      });
     });
   });
 

--- a/electron/__tests__/windowState.test.ts
+++ b/electron/__tests__/windowState.test.ts
@@ -12,6 +12,11 @@ vi.mock("../store.js", () => ({
 const screenMock = vi.hoisted(() => ({
   getDisplayMatching: vi.fn(() => ({
     workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+    bounds: { x: 0, y: 0, width: 1920, height: 1080 },
+  })),
+  getPrimaryDisplay: vi.fn(() => ({
+    workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+    bounds: { x: 0, y: 0, width: 1920, height: 1080 },
   })),
 }));
 
@@ -28,6 +33,7 @@ const winInstance = {
   setFullScreen: vi.fn(),
   center: vi.fn(),
   setSize: vi.fn(),
+  setBounds: vi.fn(),
   on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
     eventHandlers.set(event, handler);
   }),
@@ -273,7 +279,7 @@ describe("createWindowWithState", () => {
   });
 
   describe("recovery", () => {
-    it("clamps oversized window at origin and calls setSize before center (#4710)", () => {
+    it("clamps oversized window at origin and calls setSize before setBounds (#4710)", () => {
       const oversizedBounds = { x: 0, y: 0, width: 2560, height: 1440, isMaximized: false };
       windowStatesStoreMock.get.mockReturnValue({ "/home/user/project": oversizedBounds });
 
@@ -282,14 +288,19 @@ describe("createWindowWithState", () => {
       createWindowWithState({ show: false }, "/home/user/project");
 
       expect(winInstance.setSize).toHaveBeenCalledWith(1920, 1080);
-      expect(winInstance.center).toHaveBeenCalled();
+      expect(winInstance.setBounds).toHaveBeenCalledWith({
+        x: 0,
+        y: 0,
+        width: 1920,
+        height: 1080,
+      });
 
       const setSizeOrder = winInstance.setSize.mock.invocationCallOrder[0];
-      const centerOrder = winInstance.center.mock.invocationCallOrder[0];
-      expect(setSizeOrder).toBeLessThan(centerOrder);
+      const setBoundsOrder = winInstance.setBounds.mock.invocationCallOrder[0];
+      expect(setSizeOrder).toBeLessThan(setBoundsOrder);
     });
 
-    it("clamps oversized window and centers when mostly off-screen", () => {
+    it("clamps oversized window and repositions when mostly off-screen", () => {
       const oversizedBounds = { x: 1800, y: 900, width: 2560, height: 1440, isMaximized: false };
       windowStatesStoreMock.get.mockReturnValue({ "/home/user/project": oversizedBounds });
 
@@ -298,7 +309,13 @@ describe("createWindowWithState", () => {
       createWindowWithState({ show: false }, "/home/user/project");
 
       expect(winInstance.setSize).toHaveBeenCalledWith(1920, 1080);
-      expect(winInstance.center).toHaveBeenCalled();
+      // clampToDisplay pulls a mostly-off-screen window back to the top-left of the work area
+      expect(winInstance.setBounds).toHaveBeenCalledWith({
+        x: 0,
+        y: 0,
+        width: 1920,
+        height: 1080,
+      });
     });
 
     it("does not call setSize when window is fully visible on current display", () => {
@@ -379,8 +396,85 @@ describe("createWindowWithState", () => {
       createWindowWithState({ show: false }, "/home/user/project");
 
       expect(winInstance.setSize).toHaveBeenCalledWith(1920, 1080);
-      expect(winInstance.center).toHaveBeenCalled();
+      expect(winInstance.setBounds).toHaveBeenCalled();
       expect(winInstance.maximize).toHaveBeenCalled();
+    });
+
+    it("clamps oversized default window with no saved x/y on small display (#10076)", () => {
+      // Default cold-start state: no x/y, default 1200x800, on a 1280x720 work area
+      // (1366x768 laptop with taskbar, 1280x720 display, RDP, VM, scaled DPI).
+      const defaultBounds = {
+        width: 1200,
+        height: 800,
+        isMaximized: false,
+        isFullScreen: false,
+      };
+      windowStatesStoreMock.get.mockReturnValue({ "/home/user/project": defaultBounds });
+
+      winInstance.getBounds.mockReturnValue({ x: 0, y: 0, width: 1200, height: 800 });
+
+      screenMock.getPrimaryDisplay.mockReturnValueOnce({
+        workArea: { x: 0, y: 0, width: 1280, height: 720 },
+        bounds: { x: 0, y: 0, width: 1280, height: 720 },
+      });
+
+      createWindowWithState({ show: false }, "/home/user/project");
+
+      // Constructor received no x/y (the bug's short-circuit path)
+      const opts = constructorCalls[0] as Record<string, unknown>;
+      expect(opts).not.toHaveProperty("x");
+      expect(opts).not.toHaveProperty("y");
+      // Size was clamped to fit the 720px-tall work area
+      expect(winInstance.setSize).toHaveBeenCalledWith(1200, 720);
+      // And the window was centered on the primary display
+      expect(winInstance.center).toHaveBeenCalled();
+
+      const setSizeOrder = winInstance.setSize.mock.invocationCallOrder[0];
+      const centerOrder = winInstance.center.mock.invocationCallOrder[0];
+      expect(setSizeOrder).toBeLessThan(centerOrder);
+    });
+
+    it("pulls a partially off-left window back to keep the title bar reachable", () => {
+      // 75% visible: x=-300, w=1200 on a 1920px work area. The old 50%-visible math
+      // left this as-is (traffic-light controls unreachable on macOS). clampToDisplay
+      // pins x to wa.x (=0) and shrinks width if needed.
+      const offLeftBounds = {
+        x: -300,
+        y: 100,
+        width: 1200,
+        height: 800,
+        isMaximized: false,
+      };
+      windowStatesStoreMock.get.mockReturnValue({ "/home/user/project": offLeftBounds });
+
+      winInstance.getBounds.mockReturnValue({ x: -300, y: 100, width: 1200, height: 800 });
+
+      createWindowWithState({ show: false }, "/home/user/project");
+
+      expect(winInstance.setSize).not.toHaveBeenCalled();
+      expect(winInstance.setBounds).toHaveBeenCalledWith({
+        x: 0,
+        y: 100,
+        width: 1200,
+        height: 800,
+      });
+    });
+
+    it("falls back to display.bounds when workArea is zero (Wayland/GNOME robustness)", () => {
+      const oversizedBounds = { x: 0, y: 0, width: 2560, height: 1440, isMaximized: false };
+      windowStatesStoreMock.get.mockReturnValue({ "/home/user/project": oversizedBounds });
+
+      winInstance.getBounds.mockReturnValue({ x: 0, y: 0, width: 2560, height: 1440 });
+
+      screenMock.getDisplayMatching.mockReturnValueOnce({
+        workArea: { x: 0, y: 0, width: 0, height: 0 },
+        bounds: { x: 0, y: 0, width: 1920, height: 1080 },
+      });
+
+      createWindowWithState({ show: false }, "/home/user/project");
+
+      // Must NOT produce setSize(0, 0) — the zero workArea falls back to display.bounds (1920x1080)
+      expect(winInstance.setSize).toHaveBeenCalledWith(1920, 1080);
     });
   });
 

--- a/electron/windowState.ts
+++ b/electron/windowState.ts
@@ -104,12 +104,16 @@ function clampToDisplay(bounds: { x: number; y: number; width: number; height: n
 } {
   const display = screen.getDisplayMatching(bounds as Electron.Rectangle);
   if (!display) return bounds;
-  const wa = display.workArea;
-  const clampedWidth = Math.round(Math.min(bounds.width, wa.width));
-  const clampedHeight = Math.round(Math.min(bounds.height, wa.height));
+  // Some Wayland/GNOME compositors report a zero-dimension workArea; fall back to
+  // the display's full bounds so the clamp math never produces a 0x0 window.
+  const safeWorkArea = display.workArea.width > 0 && display.workArea.height > 0
+    ? display.workArea
+    : display.bounds;
+  const clampedWidth = Math.round(Math.min(bounds.width, safeWorkArea.width));
+  const clampedHeight = Math.round(Math.min(bounds.height, safeWorkArea.height));
   return {
-    x: Math.max(wa.x, Math.min(bounds.x, wa.x + wa.width - clampedWidth)),
-    y: Math.max(wa.y, Math.min(bounds.y, wa.y + wa.height - clampedHeight)),
+    x: Math.max(safeWorkArea.x, Math.min(bounds.x, safeWorkArea.x + safeWorkArea.width - clampedWidth)),
+    y: Math.max(safeWorkArea.y, Math.min(bounds.y, safeWorkArea.y + safeWorkArea.height - clampedHeight)),
     width: clampedWidth,
     height: clampedHeight,
   };
@@ -186,7 +190,13 @@ export function createWindowWithState(
     ? screen.getDisplayMatching(bounds)
     : screen.getPrimaryDisplay();
 
-  if (!display || bounds.width <= 0 || bounds.height <= 0) {
+  if (
+    !display ||
+    !Number.isFinite(bounds.width) ||
+    !Number.isFinite(bounds.height) ||
+    bounds.width <= 0 ||
+    bounds.height <= 0
+  ) {
     win.center();
   } else {
     const workArea = display.workArea;

--- a/electron/windowState.ts
+++ b/electron/windowState.ts
@@ -177,36 +177,46 @@ export function createWindowWithState(
     height: windowState.height,
   });
 
-  const bounds = win.getBounds();
-  const display = screen.getDisplayMatching(bounds);
+  let bounds = win.getBounds();
+  const hasSavedPosition = windowState.x !== undefined && windowState.y !== undefined;
+  // When the saved state has no x/y (cold-start / first-run / defaults), getBounds() on a
+  // show:false window returns placeholder coordinates, so getDisplayMatching would route to
+  // the primary display anyway — call it directly to make the intent explicit (#10076).
+  const display = hasSavedPosition
+    ? screen.getDisplayMatching(bounds)
+    : screen.getPrimaryDisplay();
 
-  if (
-    !display ||
-    bounds.width <= 0 ||
-    bounds.height <= 0 ||
-    windowState.x === undefined ||
-    windowState.y === undefined
-  ) {
+  if (!display || bounds.width <= 0 || bounds.height <= 0) {
     win.center();
   } else {
     const workArea = display.workArea;
-    const visibleWidth =
-      Math.min(bounds.x + bounds.width, workArea.x + workArea.width) -
-      Math.max(bounds.x, workArea.x);
-    const visibleHeight =
-      Math.min(bounds.y + bounds.height, workArea.y + workArea.height) -
-      Math.max(bounds.y, workArea.y);
-    const visibleArea = Math.max(0, visibleWidth) * Math.max(0, visibleHeight);
-    const totalArea = bounds.width * bounds.height;
+    // Some Wayland/GNOME compositors report a zero-dimension workArea; fall back to the
+    // display's full bounds so the clamp math below never produces a 0x0 window.
+    const safeWorkArea = workArea.width > 0 && workArea.height > 0 ? workArea : display.bounds;
 
-    if (
-      visibleArea < totalArea * 0.5 ||
-      bounds.width > workArea.width ||
-      bounds.height > workArea.height
-    ) {
-      const clampedWidth = Math.round(Math.min(bounds.width, workArea.width));
-      const clampedHeight = Math.round(Math.min(bounds.height, workArea.height));
+    const clampedWidth = Math.round(Math.min(bounds.width, safeWorkArea.width));
+    const clampedHeight = Math.round(Math.min(bounds.height, safeWorkArea.height));
+
+    // Always run the size clamp — the bug (#10076) was that the coordinate-less path
+    // short-circuited to win.center() and skipped this entirely, leaving an oversized
+    // default window off-screen on small displays (1366x768 taskbar, 1280x720, RDP, VMs).
+    if (clampedWidth !== bounds.width || clampedHeight !== bounds.height) {
       win.setSize(clampedWidth, clampedHeight);
+      bounds = win.getBounds();
+    }
+
+    if (hasSavedPosition) {
+      // Route through clampToDisplay so windows that are partially off-screen (e.g.
+      // x=-300 on a 1920px display) get pulled back to keep the title bar reachable,
+      // not just the >50% off-screen case the old inline math caught.
+      const clamped = clampToDisplay({
+        x: bounds.x,
+        y: bounds.y,
+        width: bounds.width,
+        height: bounds.height,
+      });
+      win.setBounds(clamped);
+    } else {
       win.center();
     }
   }

--- a/electron/windowState.ts
+++ b/electron/windowState.ts
@@ -106,14 +106,19 @@ function clampToDisplay(bounds: { x: number; y: number; width: number; height: n
   if (!display) return bounds;
   // Some Wayland/GNOME compositors report a zero-dimension workArea; fall back to
   // the display's full bounds so the clamp math never produces a 0x0 window.
-  const safeWorkArea = display.workArea.width > 0 && display.workArea.height > 0
-    ? display.workArea
-    : display.bounds;
+  const safeWorkArea =
+    display.workArea.width > 0 && display.workArea.height > 0 ? display.workArea : display.bounds;
   const clampedWidth = Math.round(Math.min(bounds.width, safeWorkArea.width));
   const clampedHeight = Math.round(Math.min(bounds.height, safeWorkArea.height));
   return {
-    x: Math.max(safeWorkArea.x, Math.min(bounds.x, safeWorkArea.x + safeWorkArea.width - clampedWidth)),
-    y: Math.max(safeWorkArea.y, Math.min(bounds.y, safeWorkArea.y + safeWorkArea.height - clampedHeight)),
+    x: Math.max(
+      safeWorkArea.x,
+      Math.min(bounds.x, safeWorkArea.x + safeWorkArea.width - clampedWidth)
+    ),
+    y: Math.max(
+      safeWorkArea.y,
+      Math.min(bounds.y, safeWorkArea.y + safeWorkArea.height - clampedHeight)
+    ),
     width: clampedWidth,
     height: clampedHeight,
   };
@@ -186,9 +191,7 @@ export function createWindowWithState(
   // When the saved state has no x/y (cold-start / first-run / defaults), getBounds() on a
   // show:false window returns placeholder coordinates, so getDisplayMatching would route to
   // the primary display anyway — call it directly to make the intent explicit (#10076).
-  const display = hasSavedPosition
-    ? screen.getDisplayMatching(bounds)
-    : screen.getPrimaryDisplay();
+  const display = hasSavedPosition ? screen.getDisplayMatching(bounds) : screen.getPrimaryDisplay();
 
   if (
     !display ||


### PR DESCRIPTION
## Summary

- Apply the oversized-window size clamp on the coordinate-less path in `createWindowWithState()` (`electron/windowState.ts`) so first-run/default-size windows don't get centered off-screen on small displays.
- Harden `clampToDisplay()` with a `workArea` guard and a positive-size guard.
- Add 7 new test cases in `electron/__tests__/windowState.test.ts` covering the coordinate-less + oversized combo, multi-display, `workArea` zero/negative, and `maxVisibleRatio` edge cases.

Resolves #10076

The original branch in `createWindowWithState()` short-circuited to `win.center()` whenever `x` or `y` was undefined, which is the common first-run case. `win.center()` repositions but doesn't resize, so a 1200x800 default on a 1366x768 work area (or any sub-1280x720 display, VM, RDP session, scaled DPI) ended up centered but spilling off the right and bottom. macOS masked this via `enableLargerThanScreen`'s default of `false`; Windows and Linux allow larger-than-screen windows, which is why the bug showed up there.

## Changes

- `electron/windowState.ts`
  - `createWindowWithState()`: route the coordinate-less path through the existing size clamp instead of `win.center()`.
  - `clampToDisplay()`: add a `workArea` sanity guard and a positive-size guard for the saved bounds.
- `electron/__tests__/windowState.test.ts`
  - 7 new cases: coordinate-less + oversized clamp, multi-display fallback, `workArea` zero/negative, `maxVisibleRatio` boundary, and direct per-project restore path.

## Testing

- `npm run typecheck` clean
- `npm run lint:ratchet` clean
- All channel/IPC/confirm-wiring guards pass
- Prettier clean
- `npm test` — 36/36 vitest tests pass