### PR TITLE
fix(worktree-card): render auth-failed sign-in affordance when worktree has no linked data (#9982)

### DIFF
--- a/src/components/Worktree/WorktreeCard/MainWorktreeSecondaryRow.tsx
+++ b/src/components/Worktree/WorktreeCard/MainWorktreeSecondaryRow.tsx
@@ -19,7 +19,6 @@ interface MainWorktreeSecondaryRowProps {
   lastFetchedAt: number | null | undefined;
   fetchAuthFailed: boolean;
   fetchNetworkFailed: boolean;
-  isGitHubProvider: boolean;
   aggregateCounts?: AggregateCounts;
 }
 
@@ -35,7 +34,6 @@ export function MainWorktreeSecondaryRow({
   lastFetchedAt,
   fetchAuthFailed,
   fetchNetworkFailed,
-  isGitHubProvider,
   aggregateCounts,
 }: MainWorktreeSecondaryRowProps) {
   const fetchIntervalActiveMs = useResourceProfileStore((s) => s.fetchIntervalActiveMs);
@@ -58,7 +56,7 @@ export function MainWorktreeSecondaryRow({
           lastFetchedAt={lastFetchedAt}
           fetchAuthFailed={fetchAuthFailed}
           fetchNetworkFailed={fetchNetworkFailed}
-          isGitHubProvider={isGitHubProvider}
+          hasAuthFailedSignIn={hasAuthFailedSignIn}
           containerGapClass="gap-1"
           fetchIntervalMs={fetchIntervalMs}
         />

--- a/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
+++ b/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
@@ -8,7 +8,6 @@ import { FileText } from "lucide-react";
 import type { WorktreeState } from "@/types";
 import { usePRCircuitBreakerStore } from "@/store/prCircuitBreakerStore";
 import { useResourceProfileStore } from "@/store/resourceProfileStore";
-import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
 import { computeAlarmTier } from "@/lib/worktreeAlarmTier";
 
 interface NonMainSecondaryRowProps {
@@ -101,7 +100,7 @@ export function NonMainSecondaryRow({
       lastFetchedAt={worktree.lastFetchedAt}
       fetchAuthFailed={Boolean(worktree.fetchAuthFailed)}
       fetchNetworkFailed={Boolean(worktree.fetchNetworkFailed)}
-      isGitHubProvider={worktree.linked?.providerId === BUILTIN_GITHUB_PROVIDER_ID}
+      hasAuthFailedSignIn={hasAuthFailedSignIn}
       containerGapClass="gap-1.5"
       baseBranchName={worktree.baseBranchName}
       baseAheadCount={worktree.baseAheadCount}

--- a/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
@@ -13,7 +13,7 @@ interface UpstreamSyncBadgeProps {
   lastFetchedAt: number | null | undefined;
   fetchAuthFailed: boolean;
   fetchNetworkFailed: boolean;
-  isGitHubProvider: boolean;
+  hasAuthFailedSignIn: boolean;
   containerGapClass: string;
   baseBranchName?: string | null;
   baseAheadCount?: number | null;
@@ -31,7 +31,7 @@ export function UpstreamSyncBadge({
   lastFetchedAt,
   fetchAuthFailed,
   fetchNetworkFailed,
-  isGitHubProvider,
+  hasAuthFailedSignIn,
   containerGapClass,
   baseBranchName,
   baseAheadCount,
@@ -106,7 +106,7 @@ export function UpstreamSyncBadge({
     );
   }, []);
 
-  if (fetchAuthFailed && isGitHubProvider) {
+  if (fetchAuthFailed && hasAuthFailedSignIn) {
     return (
       <Tooltip>
         <TooltipTrigger asChild>

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -473,7 +473,6 @@ export function WorktreeHeader({
           lastFetchedAt={worktree.lastFetchedAt}
           fetchAuthFailed={Boolean(worktree.fetchAuthFailed)}
           fetchNetworkFailed={Boolean(worktree.fetchNetworkFailed)}
-          isGitHubProvider={worktree.linked?.providerId === BUILTIN_GITHUB_PROVIDER_ID}
           aggregateCounts={aggregateCounts}
         />
       )}

--- a/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.test.tsx
@@ -30,7 +30,7 @@ const baseProps: Props = {
   lastFetchedAt: Date.now(),
   fetchAuthFailed: false,
   fetchNetworkFailed: false,
-  isGitHubProvider: true,
+  hasAuthFailedSignIn: false,
   containerGapClass: "gap-1.5",
   baseBranchName: null,
   baseAheadCount: null,
@@ -231,5 +231,31 @@ describe("UpstreamSyncBadge — value-change flash", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe("UpstreamSyncBadge — auth-failed sign-in branch (issue #9982)", () => {
+  it("renders the dimmed placeholder when fetchAuthFailed + hasAuthFailedSignIn and no counts", () => {
+    renderBadge({
+      aheadCount: 0,
+      behindCount: 0,
+      fetchAuthFailed: true,
+      hasAuthFailedSignIn: true,
+    });
+    const indicator = screen.getByTestId("upstream-sync-indicator");
+    expect(indicator).toBeDefined();
+    expect(indicator.getAttribute("data-fetch-auth-failed")).toBe("true");
+    expect(indicator.textContent).toContain("—");
+  });
+
+  it("does not render the sign-in branch when hasAuthFailedSignIn is false even with auth-failed fetch", () => {
+    renderBadge({
+      aheadCount: 0,
+      behindCount: 0,
+      fetchAuthFailed: true,
+      hasAuthFailedSignIn: false,
+    });
+    // No counts + no auth-failed-sign-in affordance + no base divergence → null
+    expect(screen.queryByTestId("upstream-sync-indicator")).toBeNull();
   });
 });

--- a/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.test.tsx
@@ -1,8 +1,8 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
@@ -19,7 +19,10 @@ vi.mock("@/services/ActionService", () => ({
   actionService: { dispatch: vi.fn() },
 }));
 
+import { actionService } from "@/services/ActionService";
 import { UpstreamSyncBadge } from "../UpstreamSyncBadge";
+
+const mockRetryAuthFetch = vi.fn().mockResolvedValue(undefined);
 
 type Props = Parameters<typeof UpstreamSyncBadge>[0];
 
@@ -48,6 +51,44 @@ function renderBadge(extra: Partial<Props> = {}) {
 
 afterEach(() => {
   cleanup();
+});
+
+describe("UpstreamSyncBadge — auth-failed sign-in branch (issue #9982)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("electron", { worktree: { retryAuthFetch: mockRetryAuthFetch } });
+    mockRetryAuthFetch.mockClear();
+    vi.mocked(actionService.dispatch).mockClear();
+  });
+
+  it("renders a real <button> with the auth-failed aria-label and clicking it fires retry + dispatch", () => {
+    renderBadge({
+      aheadCount: 0,
+      behindCount: 0,
+      fetchAuthFailed: true,
+      hasAuthFailedSignIn: true,
+    });
+    const button = screen.getByRole("button", { name: /GitHub authentication failed/ });
+    expect(button.getAttribute("data-fetch-auth-failed")).toBe("true");
+    expect(button.textContent).toContain("—");
+    fireEvent.click(button);
+    expect(mockRetryAuthFetch).toHaveBeenCalledTimes(1);
+    expect(actionService.dispatch).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "code-forge", subtab: "daintree.github.github", sectionId: "github-token" },
+      { source: "user" }
+    );
+  });
+
+  it("does not render the sign-in branch when hasAuthFailedSignIn is false even with auth-failed fetch", () => {
+    renderBadge({
+      aheadCount: 0,
+      behindCount: 0,
+      fetchAuthFailed: true,
+      hasAuthFailedSignIn: false,
+    });
+    // No counts + no auth-failed-sign-in affordance + no base divergence → null
+    expect(screen.queryByTestId("upstream-sync-indicator")).toBeNull();
+  });
 });
 
 describe("UpstreamSyncBadge — base-divergence layout", () => {
@@ -231,31 +272,5 @@ describe("UpstreamSyncBadge — value-change flash", () => {
     } finally {
       vi.useRealTimers();
     }
-  });
-});
-
-describe("UpstreamSyncBadge — auth-failed sign-in branch (issue #9982)", () => {
-  it("renders the dimmed placeholder when fetchAuthFailed + hasAuthFailedSignIn and no counts", () => {
-    renderBadge({
-      aheadCount: 0,
-      behindCount: 0,
-      fetchAuthFailed: true,
-      hasAuthFailedSignIn: true,
-    });
-    const indicator = screen.getByTestId("upstream-sync-indicator");
-    expect(indicator).toBeDefined();
-    expect(indicator.getAttribute("data-fetch-auth-failed")).toBe("true");
-    expect(indicator.textContent).toContain("—");
-  });
-
-  it("does not render the sign-in branch when hasAuthFailedSignIn is false even with auth-failed fetch", () => {
-    renderBadge({
-      aheadCount: 0,
-      behindCount: 0,
-      fetchAuthFailed: true,
-      hasAuthFailedSignIn: false,
-    });
-    // No counts + no auth-failed-sign-in affordance + no base divergence → null
-    expect(screen.queryByTestId("upstream-sync-indicator")).toBeNull();
   });
 });

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -1374,6 +1374,27 @@ describe("WorktreeHeader upstream sync indicator", () => {
     expect(indicator.textContent).toContain("—");
   });
 
+  it("renders the sign-in affordance when isGitHubRemote and no linked data (#9982)", () => {
+    // Reproduces the exact bug path: fetchAuthFailed + isGitHubRemote but no
+    // linked data (e.g. the main worktree on develop, or a token-expired
+    // worktree). The header's union predicate must still raise the alarm tier
+    // and the badge must still render the sign-in branch — the badge used to
+    // fall through to null because it only checked the linked-only providerId.
+    renderHeader({
+      worktree: {
+        ...baseWorktree,
+        aheadCount: 0,
+        behindCount: 0,
+        fetchAuthFailed: true,
+        isGitHubRemote: true,
+      },
+    });
+    const indicator = screen.getByTestId("upstream-sync-indicator");
+    expect(indicator).toBeDefined();
+    expect(indicator.getAttribute("data-fetch-auth-failed")).toBe("true");
+    expect(indicator.textContent).toContain("—");
+  });
+
   it("falls through to regular count display for non-GitHub auth failures", () => {
     renderHeader({
       worktree: {

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -1389,10 +1389,18 @@ describe("WorktreeHeader upstream sync indicator", () => {
         isGitHubRemote: true,
       },
     });
-    const indicator = screen.getByTestId("upstream-sync-indicator");
-    expect(indicator).toBeDefined();
+    const indicator = screen.getByRole("button", { name: /GitHub authentication failed/ });
     expect(indicator.getAttribute("data-fetch-auth-failed")).toBe("true");
     expect(indicator.textContent).toContain("—");
+    // Recovery path must be reachable on the no-linked-data path too — the
+    // badge owns the only per-worktree way out of the auth-suspended fetch.
+    fireEvent.click(indicator);
+    expect(mockRetryAuthFetch).toHaveBeenCalledTimes(1);
+    expect(actionService.dispatch).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "code-forge", subtab: "daintree.github.github", sectionId: "github-token" },
+      { source: "user" }
+    );
   });
 
   it("falls through to regular count display for non-GitHub auth failures", () => {


### PR DESCRIPTION
## Summary

- The auth-failed sign-in button never rendered when a worktree had no linked data. Fixes the union predicate in `WorktreeHeader.tsx` (lines 290-293) so it no longer requires `linked`.
- Forwards `hasAuthFailedSignIn` through to `UpstreamSyncBadge` and adds a test asserting the click path on the no-linked sign-in affordance.

This is the divergence we introduced in commit `09ef71cfa` when we migrated all `WorktreeSnapshot` consumers to the `linked` field. A reminder to take it carefully when migrating to `linked` so we don't introduce caching regressions, as we did in #9061.

Resolves #9982

## Changes

- `WorktreeHeader.tsx` (lines 290-293): drop the `linked?.providerId` arm of the union predicate so the auth-failed sign-in affordance renders for non-linked worktrees too.
- `UpstreamSyncBadge.tsx`: accept and forward `hasAuthFailedSignIn`.
- `MainWorktreeSecondaryRow.tsx` / `NonMainSecondaryRow.tsx`: thread the flag through to the badge.
- `UpstreamSyncBadge.test.tsx` and `WorktreeHeader.test.tsx`: cover the no-linked sign-in click path.

## Testing

- `npm run check` (all 10 unified checks pass)
- `vitest` on the worktree-card test directory (281 tests passing)
- No new lint warnings