### PR TITLE
fix(settings): render failed MCP server state distinctly from starting (#10033)

### DIFF
--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -34,6 +34,7 @@ import {
   type AssistantTurnRecord,
   type McpAuditStats,
   type ActiveBearerRecord,
+  type McpRuntimeSnapshot,
   MCP_AUDIT_DEFAULT_MAX_RECORDS,
   MCP_AUDIT_MAX_RECORDS,
   MCP_AUDIT_MIN_RECORDS,
@@ -51,6 +52,13 @@ const STATUS_LOAD_TIMEOUT_MS = 10_000;
 
 const MASKED_KEY = "•".repeat(24);
 
+const INITIAL_RUNTIME_SNAPSHOT: McpRuntimeSnapshot = {
+  enabled: false,
+  state: "disabled",
+  port: null,
+  lastError: null,
+};
+
 export function McpServerSettingsTab() {
   const [status, setStatus] = useState<McpServerStatus>({
     enabled: false,
@@ -58,6 +66,11 @@ export function McpServerSettingsTab() {
     configuredPort: null,
     apiKey: "",
   });
+  // Runtime readiness (state + lastError + bound port) is carried by a
+  // separate snapshot from the persisted config above; the section is gated
+  // on `status.enabled` so the `disabled` branch is unreachable here.
+  const [runtimeSnapshot, setRuntimeSnapshot] =
+    useState<McpRuntimeSnapshot>(INITIAL_RUNTIME_SNAPSHOT);
   const [loading, setLoading] = useState(true);
   // Gate the "Loading…" copy past the Doherty threshold so fast IPC resolutions
   // don't flash a loading state for sub-400ms work.
@@ -164,14 +177,16 @@ export function McpServerSettingsTab() {
 
     Promise.all([
       window.electron.mcpServer.getStatus(),
+      window.electron.mcpServer.getRuntimeState(),
       window.electron.mcpServer.getAuditConfig(),
       window.electron.mcpServer.getAuditRecords(),
       window.electron.mcpServer.getTurnOutcomeRecords(),
       window.electron.mcpServer.getAuditStats(),
     ])
-      .then(([s, auditCfg, records, turns, stats]) => {
+      .then(([s, runtime, auditCfg, records, turns, stats]) => {
         if (settled) return;
         setStatus(s);
+        setRuntimeSnapshot(runtime);
         setPortInput(s.configuredPort?.toString() ?? "");
         portDirtyRef.current = false;
         setAuditEnabled(auditCfg.enabled);
@@ -197,8 +212,11 @@ export function McpServerSettingsTab() {
     void refreshActiveBearers();
     void refreshAssistantControl();
 
-    const unsub = window.electron.mcpServer.onRuntimeStateChanged(() => {
+    const unsub = window.electron.mcpServer.onRuntimeStateChanged((next) => {
       if (!settled) return;
+      // Apply the runtime push directly so the Connection section reflects
+      // the new state without waiting for a config refetch.
+      setRuntimeSnapshot(next);
       window.electron.mcpServer
         .getStatus()
         .then((s) => {
@@ -523,7 +541,20 @@ export function McpServerSettingsTab() {
               showInlineLoading ? (
                 <p className="text-xs text-daintree-text/50">Loading…</p>
               ) : null
-            ) : status.port ? (
+            ) : runtimeSnapshot.state === "starting" ? (
+              <div className="flex items-center gap-2">
+                <div className="w-2 h-2 rounded-full bg-daintree-text/30 shrink-0" />
+                <span className="text-xs text-daintree-text/60">Server is starting…</span>
+              </div>
+            ) : runtimeSnapshot.state === "failed" ? (
+              <div className="flex items-start gap-2 p-3 rounded-[var(--radius-md)] bg-status-danger/10 border border-status-danger/20">
+                <AlertCircle className="w-4 h-4 text-status-danger shrink-0 mt-0.5" />
+                <p className="text-xs text-status-danger leading-relaxed select-text">
+                  MCP server failed to start.{" "}
+                  {runtimeSnapshot.lastError ?? "Check the logs for details."}
+                </p>
+              </div>
+            ) : (
               <div className="contents">
                 <div className="flex items-center gap-2">
                   <div className="w-2 h-2 rounded-full bg-status-success shrink-0" />
@@ -607,8 +638,6 @@ export function McpServerSettingsTab() {
                   </div>
                 )}
               </div>
-            ) : (
-              <p className="text-xs text-daintree-text/50">Server is starting…</p>
             )}
           </SettingsSection>
 

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -490,7 +490,13 @@ export function McpServerSettingsTab() {
     }
   };
 
-  const sseUrl = status.port ? `http://127.0.0.1:${status.port}/sse` : null;
+  // Prefer the runtime-snapshot port for the ready branch so a push that
+  // transitions starting→ready renders the URL without waiting for the
+  // follow-up `getStatus()` refetch. Fall back to `status.port` when the
+  // snapshot hasn't caught up yet (matches the assistant tab precedent at
+  // DaintreeAssistantSettingsTab.tsx:740).
+  const boundPort = runtimeSnapshot.port ?? status.port;
+  const sseUrl = boundPort ? `http://127.0.0.1:${boundPort}/sse` : null;
 
   // Rotation is the revoke-all primitive — it invalidates every external
   // client holding the current key in one shot (Tier D3). Gate it behind
@@ -558,9 +564,7 @@ export function McpServerSettingsTab() {
               <div className="contents">
                 <div className="flex items-center gap-2">
                   <div className="w-2 h-2 rounded-full bg-status-success shrink-0" />
-                  <span className="text-xs text-daintree-text/60">
-                    Running on port {status.port}
-                  </span>
+                  <span className="text-xs text-daintree-text/60">Running on port {boundPort}</span>
                 </div>
 
                 <div className="flex items-center gap-2 p-2.5 rounded-[var(--radius-md)] bg-daintree-bg border border-daintree-border font-mono text-xs text-daintree-text/80 select-all">

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -1017,13 +1017,13 @@ describe("McpServerSettingsTab", () => {
     expect(applyButton.disabled).toBe(true);
   });
 
-  it("subscribes to runtime state changes on mount", async () => {
+  it("subscribes to runtime state changes on mount and unsubscribes on unmount", async () => {
     const unsub = vi.fn();
     const onRuntimeStateChanged = vi.fn().mockReturnValue(unsub);
 
     installMcpApi({ onRuntimeStateChanged });
 
-    render(
+    const { unmount } = render(
       <SettingsValidationProvider>
         <McpServerSettingsTab />
       </SettingsValidationProvider>
@@ -1032,6 +1032,10 @@ describe("McpServerSettingsTab", () => {
     await waitFor(() => {
       expect(onRuntimeStateChanged).toHaveBeenCalledTimes(1);
     });
+    expect(unsub).not.toHaveBeenCalled();
+
+    unmount();
+    expect(unsub).toHaveBeenCalledTimes(1);
   });
 
   it("result filter includes Unauthorized option", async () => {
@@ -1301,10 +1305,38 @@ describe("McpServerSettingsTab", () => {
         </SettingsValidationProvider>
       );
       await waitForContent(container, "API key active");
-      expect(container.textContent).toContain("Running on port");
-      expect(container.textContent).toContain("9020");
+      expect(container.textContent).toContain("Running on port 9020");
       expect(container.textContent).toContain("http://127.0.0.1:9020/sse");
       expect(screen.getByRole("button", { name: /copy mcp config/i })).toBeTruthy();
+    });
+
+    it("uses the runtime snapshot port when it diverges from the slower getStatus refetch", async () => {
+      // Regression: the ready branch must read the port from the runtime
+      // snapshot, not from the persisted-config `status`, so a push that
+      // binds the port before `getStatus()` resolves still renders the URL.
+      installMcpApi({
+        getRuntimeState: vi.fn().mockResolvedValue({
+          enabled: true,
+          state: "ready",
+          port: 9020,
+          lastError: null,
+        }),
+        getStatus: vi.fn().mockResolvedValue({
+          enabled: true,
+          port: null,
+          configuredPort: 9020,
+          apiKey: "dnt-key-abc123",
+        }),
+      });
+
+      const { container } = render(
+        <SettingsValidationProvider>
+          <McpServerSettingsTab />
+        </SettingsValidationProvider>
+      );
+      await waitForContent(container, "API key active");
+      expect(container.textContent).toContain("Running on port 9020");
+      expect(container.textContent).toContain("http://127.0.0.1:9020/sse");
     });
 
     it("renders the starting copy and hides the URL block when state is starting", async () => {

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -73,6 +73,12 @@ function createMcpApi(overrides: Partial<typeof window.electron.mcpServer> = {})
       configuredPort: 9020,
       apiKey: "dnt-key-abc123",
     }),
+    getRuntimeState: vi.fn().mockResolvedValue({
+      enabled: true,
+      state: "ready",
+      port: 9020,
+      lastError: null,
+    }),
     setEnabled: vi.fn(),
     setPort: vi.fn(),
     listActiveClients: vi.fn().mockResolvedValue([]),
@@ -1242,8 +1248,8 @@ describe("McpServerSettingsTab", () => {
     });
 
     it("populates the clients row when a runtime-state change fires after mount", async () => {
-      let runtimeCb: (() => void) | undefined;
-      const onRuntimeStateChanged = vi.fn((cb: () => void) => {
+      let runtimeCb: ((snapshot: unknown) => void) | undefined;
+      const onRuntimeStateChanged = vi.fn((cb: (snapshot: unknown) => void) => {
         runtimeCb = cb;
         return vi.fn();
       });
@@ -1261,7 +1267,7 @@ describe("McpServerSettingsTab", () => {
       await waitForContent(container, "API key active");
       expect(container.textContent).not.toContain("External clients");
 
-      runtimeCb?.();
+      runtimeCb?.({ enabled: true, state: "ready", port: 9020, lastError: null });
       await waitForContent(container, "External clients (1)");
     });
 
@@ -1284,6 +1290,125 @@ describe("McpServerSettingsTab", () => {
       );
       await waitForContent(container, "API key active");
       expect(container.textContent).not.toContain("Kept alive by Daintree Assistant");
+    });
+  });
+
+  describe("Connection section runtime state", () => {
+    it("renders the running tree, URL block, and copy button when state is ready", async () => {
+      const { container } = render(
+        <SettingsValidationProvider>
+          <McpServerSettingsTab />
+        </SettingsValidationProvider>
+      );
+      await waitForContent(container, "API key active");
+      expect(container.textContent).toContain("Running on port");
+      expect(container.textContent).toContain("9020");
+      expect(container.textContent).toContain("http://127.0.0.1:9020/sse");
+      expect(screen.getByRole("button", { name: /copy mcp config/i })).toBeTruthy();
+    });
+
+    it("renders the starting copy and hides the URL block when state is starting", async () => {
+      installMcpApi({
+        getRuntimeState: vi.fn().mockResolvedValue({
+          enabled: true,
+          state: "starting",
+          port: null,
+          lastError: null,
+        }),
+      });
+
+      const { container } = render(
+        <SettingsValidationProvider>
+          <McpServerSettingsTab />
+        </SettingsValidationProvider>
+      );
+      await waitForContent(container, "API key active");
+      expect(container.textContent).toContain("Server is starting…");
+      expect(container.textContent).not.toContain("http://127.0.0.1");
+      expect(container.textContent).not.toContain("Copy MCP config");
+    });
+
+    it("renders the failed banner with lastError when state is failed and an error is set", async () => {
+      installMcpApi({
+        getRuntimeState: vi.fn().mockResolvedValue({
+          enabled: true,
+          state: "failed",
+          port: null,
+          lastError: "EADDRINUSE: port 45454 already in use",
+        }),
+      });
+
+      const { container } = render(
+        <SettingsValidationProvider>
+          <McpServerSettingsTab />
+        </SettingsValidationProvider>
+      );
+      await waitForContent(container, "MCP server failed to start");
+      expect(container.textContent).toContain("EADDRINUSE: port 45454 already in use");
+      expect(container.textContent).not.toContain("Server is starting…");
+      expect(container.textContent).not.toContain("Copy MCP config");
+    });
+
+    it("renders the failed banner with fallback copy when state is failed and lastError is null", async () => {
+      installMcpApi({
+        getRuntimeState: vi.fn().mockResolvedValue({
+          enabled: true,
+          state: "failed",
+          port: null,
+          lastError: null,
+        }),
+      });
+
+      const { container } = render(
+        <SettingsValidationProvider>
+          <McpServerSettingsTab />
+        </SettingsValidationProvider>
+      );
+      await waitForContent(container, "MCP server failed to start");
+      expect(container.textContent).toContain("Check the logs for details.");
+      expect(container.textContent).not.toContain("Server is starting…");
+    });
+
+    it("transitions the Connection section from ready to failed when a runtime push fires", async () => {
+      let runtimeCb: ((snapshot: unknown) => void) | undefined;
+      const onRuntimeStateChanged = vi.fn((cb: (snapshot: unknown) => void) => {
+        runtimeCb = cb;
+        return vi.fn();
+      });
+      installMcpApi({
+        onRuntimeStateChanged,
+        getRuntimeState: vi.fn().mockResolvedValue({
+          enabled: true,
+          state: "ready",
+          port: 9020,
+          lastError: null,
+        }),
+        getStatus: vi.fn().mockResolvedValue({
+          enabled: true,
+          port: null,
+          configuredPort: 9020,
+          apiKey: "dnt-key-abc123",
+        }),
+      });
+
+      const { container } = render(
+        <SettingsValidationProvider>
+          <McpServerSettingsTab />
+        </SettingsValidationProvider>
+      );
+      await waitForContent(container, "API key active");
+      expect(container.textContent).toContain("Running on port");
+
+      runtimeCb?.({
+        enabled: true,
+        state: "failed",
+        port: null,
+        lastError: "listen EACCES: permission denied",
+      });
+
+      await waitForContent(container, "MCP server failed to start");
+      expect(container.textContent).toContain("listen EACCES: permission denied");
+      expect(container.textContent).not.toContain("Running on port");
     });
   });
 });


### PR DESCRIPTION
## Summary

The MCP server settings tab was always showing a `Server is starting...` message, even when the server had failed to start and was in a permanent error state. Users hitting `EADDRINUSE` or a restart-budget-exhausted server were stuck staring at a spinner that would never resolve.

This fixes the Connection section to branch on the full 4-state runtime (`disabled | starting | ready | failed`) instead of keying off `status.port`. The `failed` state now surfaces `lastError` in a danger banner. The bound port is sourced from the runtime snapshot rather than a stale ref.

The pattern mirrors what the Daintree Assistant settings tab already does (closed in #8777), so the two tabs are now consistent.

Resolves #10033

## Changes

- `src/components/Settings/McpServerSettingsTab.tsx` - branch the Connection section on `McpRuntimeState`; render `lastError` in a danger banner for the `failed` state
- `src/components/Settings/McpServerSettingsTab.tsx` - source the bound port from the runtime snapshot
- `src/components/Settings/__tests__/McpServerSettingsTab.test.tsx` - cover the new branches

## Testing

- New unit tests cover the `failed` state, the `lastError` danger banner, and the runtime-snapshot port sourcing
- `npm run typecheck` clean
- `npm run lint` clean (only pre-existing warnings)