### PR TITLE
fix(webview): treat src as mount-time seed to stop redundant guest-navigation reloads

### DIFF
--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -3,13 +3,13 @@
   "byRule": {
     "@typescript-eslint/no-explicit-any": 54,
     "@typescript-eslint/no-floating-promises": 91,
-    "@typescript-eslint/no-unsafe-type-assertion": 499,
+    "@typescript-eslint/no-unsafe-type-assertion": 500,
     "no-restricted-imports": 8,
-    "no-restricted-syntax": 407,
+    "no-restricted-syntax": 406,
     "no-useless-assignment": 20,
     "preserve-caught-error": 52,
     "react-compiler/react-compiler": 16,
     "react-hooks/exhaustive-deps": 40
   },
-  "updatedAt": "2026-06-06T11:55:26.447Z"
+  "updatedAt": "2026-06-06T15:03:19.134Z"
 }

--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -186,6 +186,15 @@ export function BrowserPane({
   // navigations into redundant full reloads (#9940). All post-mount navigation
   // goes through imperative loadURL calls instead.
   const initialUrlRef = useRef<string>(history.present);
+  // When `webviewPartition` changes the `key` remounts the <webview> as a fresh
+  // element, so its seed `src` must be the URL the user is currently on — not the
+  // URL captured at first component mount (#9940). Re-seed during render, before
+  // the JSX `src={initialUrlRef.current}` is read for the remounting element.
+  const lastPartitionRef = useRef<string>(webviewPartition);
+  if (lastPartitionRef.current !== webviewPartition) {
+    lastPartitionRef.current = webviewPartition;
+    initialUrlRef.current = history.present;
+  }
   // Track if webview has been mounted and is ready
   const [isWebviewReady, setIsWebviewReady] = useState(false);
 

--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -180,6 +180,12 @@ export function BrowserPane({
   const blockedNavTimerRef = useRef<NodeJS.Timeout | null>(null);
   // Track the last URL we set on the webview to detect in-webview navigation
   const lastSetUrlRef = useRef<string>(history.present);
+  // Seed value for the webview `src` attribute, captured once at mount. We never
+  // re-bind `src` to navigation-driven state: Electron's SrcAttribute observer
+  // treats any same-or-different value write as a fresh loadURL, turning guest
+  // navigations into redundant full reloads (#9940). All post-mount navigation
+  // goes through imperative loadURL calls instead.
+  const initialUrlRef = useRef<string>(history.present);
   // Track if webview has been mounted and is ready
   const [isWebviewReady, setIsWebviewReady] = useState(false);
 
@@ -1005,7 +1011,9 @@ export function BrowserPane({
                 // seeded only via ?projectId= where the store resolves later) so the
                 // webview never keeps a stale cross-project session (#9965).
                 key={webviewPartition}
-                src={currentUrl}
+                // Seed-only: never re-bind to navigation state (#9940). On a
+                // key-driven remount the ref re-initializes to the current URL.
+                src={initialUrlRef.current}
                 partition={webviewPartition}
                 // @ts-expect-error React 19 requires "" to emit the attribute; boolean true is silently dropped
                 allowpopups=""

--- a/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
+++ b/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
@@ -1705,5 +1705,31 @@ describe("BrowserPane webview lifecycle regression", () => {
       expect(setAttributeSpy.mock.calls.filter(([name]) => name === "src")).toHaveLength(0);
       expect(webview.getAttribute("src")).toBe("http://localhost:5173/");
     });
+
+    it("re-seeds src to the current URL when a partition change remounts the webview", () => {
+      const { container, rerender } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+      expect(webview.getAttribute("src")).toBe("http://localhost:5173/");
+
+      // Guest navigates to a new route.
+      act(() => {
+        emitWebviewEvent(webview, "did-navigate", { url: "http://localhost:5173/dashboard" });
+      });
+
+      // The project id resolves to a different value, changing webviewPartition,
+      // which remounts the <webview> via its key. The fresh element must seed to
+      // the URL the user is currently on — not the URL captured at mount (#9940).
+      useProjectStoreMock.mockImplementation(
+        (selector: (state: { currentProject: { id: string } | null }) => unknown) =>
+          selector({ currentProject: { id: "other-project" } })
+      );
+
+      act(() => {
+        rerender(<BrowserPane {...baseProps} />);
+      });
+
+      const remountedWebview = getWebviewElement(container);
+      expect(remountedWebview.getAttribute("src")).toBe("http://localhost:5173/dashboard");
+    });
   });
 });

--- a/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
+++ b/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
@@ -1658,4 +1658,52 @@ describe("BrowserPane webview lifecycle regression", () => {
       expect(container.textContent).toContain("Page process crashed");
     });
   });
+
+  describe("src binding regression (#9940)", () => {
+    it("seeds src once at mount", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+      expect(webview.getAttribute("src")).toBe("http://localhost:5173/");
+    });
+
+    it("does not re-bind src or re-load after an in-page guest navigation", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      // A guest SPA navigation (pushState) is reported via did-navigate-in-page.
+      // The resulting history update must NOT feed back into the src attribute
+      // (which Electron's SrcAttribute observer would turn into a full reload).
+      webview.loadURL.mockClear();
+      const setAttributeSpy = vi.spyOn(webview, "setAttribute");
+
+      act(() => {
+        emitWebviewEvent(webview, "did-navigate-in-page", {
+          url: "http://localhost:5173/spa/route",
+          isMainFrame: true,
+        });
+      });
+
+      expect(webview.loadURL).not.toHaveBeenCalled();
+      expect(setAttributeSpy.mock.calls.filter(([name]) => name === "src")).toHaveLength(0);
+      expect(webview.getAttribute("src")).toBe("http://localhost:5173/");
+    });
+
+    it("does not re-bind src or re-load after a full guest navigation", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      webview.loadURL.mockClear();
+      const setAttributeSpy = vi.spyOn(webview, "setAttribute");
+
+      act(() => {
+        emitWebviewEvent(webview, "did-navigate", {
+          url: "http://localhost:5173/page-2",
+        });
+      });
+
+      expect(webview.loadURL).not.toHaveBeenCalled();
+      expect(setAttributeSpy.mock.calls.filter(([name]) => name === "src")).toHaveLength(0);
+      expect(webview.getAttribute("src")).toBe("http://localhost:5173/");
+    });
+  });
 });

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -387,7 +387,14 @@ export function DevPreviewPane({
       if (certCopyTimerRef.current) clearTimeout(certCopyTimerRef.current);
     };
   }, []);
-  const lastSetUrlRef = useRef<string>("");
+  // Seed `lastSetUrlRef` to the mount URL so the isWebviewReady navigation
+  // effect does not fire a redundant loadURL on first ready (#9940). The
+  // hard-restart path resets this to "" explicitly when unconfigured.
+  const lastSetUrlRef = useRef<string>(history.present);
+  // Seed value for the webview `src` attribute, captured once at mount. Never
+  // re-bound to navigation state — Electron's SrcAttribute observer would turn
+  // each guest navigation into a redundant full reload (#9940).
+  const initialUrlRef = useRef<string>(history.present);
   const [consoleTerminalId, setConsoleTerminalId] = useState<string | null>(terminalId);
   // Generation token to invalidate in-flight async scroll captures when the
   // user clears scroll state via hard restart. A pending executeJavaScript
@@ -622,7 +629,10 @@ export function DevPreviewPane({
       }
       webviewRef.current = node;
       if (node) {
-        lastSetUrlRef.current = "";
+        // Match the `src` seed so the isWebviewReady navigation effect does not
+        // re-load the same URL on first ready (#9940). The isUnconfigured effect
+        // resets this to "" afterward when there is no dev command.
+        lastSetUrlRef.current = initialUrlRef.current;
         clearRetryState();
       }
       setWebviewElement(node);
@@ -1966,7 +1976,8 @@ export function DevPreviewPane({
                   >
                     <webview
                       ref={setWebviewNode}
-                      src={currentUrl}
+                      // Seed-only: never re-bind to navigation state (#9940).
+                      src={initialUrlRef.current}
                       partition={webviewPartition}
                       // @ts-expect-error React 19 requires "" to emit the attribute; boolean true is silently dropped
                       allowpopups=""

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -683,8 +683,11 @@ export function DevPreviewPane({
     if (proxyOrigin === undefined) return;
     const nextUrl = url ? computeDevServerUrl(url, currentUrl, proxyOrigin) : false;
     if (nextUrl !== false) {
+      // Push history only; the imperative navigation effect (keyed on currentUrl
+      // vs lastSetUrlRef) performs the actual loadURL. Pre-setting lastSetUrlRef
+      // here would make that effect skip — which used to be fine when `src`
+      // re-bound to currentUrl, but src is now seed-only (#9940).
       setHistory((prev) => pushBrowserHistory(prev, nextUrl));
-      lastSetUrlRef.current = nextUrl;
     }
   }, [url, currentUrl, isUnconfigured, proxyOrigin]);
 
@@ -706,8 +709,9 @@ export function DevPreviewPane({
   const handleNavigate = useCallback((rawUrl: string) => {
     const normalized = normalizeBrowserUrl(rawUrl);
     if (normalized.url) {
+      // Push history only; the imperative navigation effect drives loadURL now
+      // that `src` is seed-only (#9940). Mirrors handleBack/handleForward.
       setHistory((prev) => pushBrowserHistory(prev, normalized.url!));
-      lastSetUrlRef.current = normalized.url;
     }
   }, []);
 
@@ -1181,12 +1185,13 @@ export function DevPreviewPane({
         try {
           const loadedUrl = webviewElement.getURL();
           if (loadedUrl !== currentUrl) {
-            loadWebviewUrl(webviewElement, currentUrl, () => {
-              webviewElement.src = currentUrl;
-            });
+            // Imperative load only — never write `.src`, which would re-trigger
+            // Electron's SrcAttribute observer into a redundant reload (#9940).
+            loadWebviewUrl(webviewElement, currentUrl);
           }
         } catch {
-          webviewElement.src = currentUrl;
+          // getURL() threw — the webview is detaching/unready. The ready
+          // lifecycle re-drives the load on recovery; don't write `.src` here.
         }
       }
     }

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -2213,5 +2213,30 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       expect(setAttributeSpy.mock.calls.filter(([name]) => name === "src")).toHaveLength(0);
       expect(webview.getAttribute("src")).toBe("http://localhost:5173/");
     });
+
+    it("navigates imperatively when the dev-server URL changes (src is seed-only)", async () => {
+      const { container, rerender } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // A dev-server restart shifts the origin (port 5173 -> 5174). Because `src`
+      // no longer re-binds to currentUrl, the imperative navigation effect MUST
+      // drive the loadURL — otherwise the guest would be stranded on the old URL.
+      webview.loadURL.mockClear();
+      devServerStateRef.current = {
+        ...devServerStateRef.current,
+        url: "http://localhost:5174/",
+      };
+
+      await act(async () => {
+        rerender(<DevPreviewPane {...baseProps} />);
+        await Promise.resolve();
+      });
+
+      expect(webview.loadURL).toHaveBeenCalledWith("http://localhost:5174/");
+    });
   });
 });

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -2148,4 +2148,70 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       expect(container.textContent).not.toContain("Dev server unavailable");
     });
   });
+
+  describe("src binding regression (#9940)", () => {
+    it("seeds src once at mount", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+      expect(webview.getAttribute("src")).toBe("http://localhost:5173/");
+    });
+
+    it("does not issue a redundant loadURL on first ready when the seed matches history", async () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      // Let the ready probe run. Because lastSetUrlRef is seeded to the mount
+      // URL, the isWebviewReady navigation effect must not re-load the same URL.
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(webview.loadURL).not.toHaveBeenCalled();
+    });
+
+    it("does not re-bind src or re-load after an in-page guest navigation", async () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      webview.loadURL.mockClear();
+      const setAttributeSpy = vi.spyOn(webview, "setAttribute");
+
+      act(() => {
+        emitWebviewEvent(webview, "did-navigate-in-page", {
+          url: "http://localhost:5173/spa/route",
+          isMainFrame: true,
+        });
+      });
+
+      expect(webview.loadURL).not.toHaveBeenCalled();
+      expect(setAttributeSpy.mock.calls.filter(([name]) => name === "src")).toHaveLength(0);
+      expect(webview.getAttribute("src")).toBe("http://localhost:5173/");
+    });
+
+    it("does not re-bind src or re-load after a full guest navigation", async () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      webview.loadURL.mockClear();
+      const setAttributeSpy = vi.spyOn(webview, "setAttribute");
+
+      act(() => {
+        emitWebviewEvent(webview, "did-navigate", {
+          url: "http://localhost:5173/page-2",
+        });
+      });
+
+      expect(webview.loadURL).not.toHaveBeenCalled();
+      expect(setAttributeSpy.mock.calls.filter(([name]) => name === "src")).toHaveLength(0);
+      expect(webview.getAttribute("src")).toBe("http://localhost:5173/");
+    });
+  });
 });

--- a/src/components/DevPreview/__tests__/loadWebviewUrl.test.ts
+++ b/src/components/DevPreview/__tests__/loadWebviewUrl.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadWebviewUrl } from "../loadWebviewUrl";
+
+function makeWebview(loadResult: unknown): Electron.WebviewTag {
+  return {
+    loadURL: vi.fn(() => loadResult),
+  } as unknown as Electron.WebviewTag;
+}
+
+describe("loadWebviewUrl (#9940)", () => {
+  it("calls loadURL with the target url", () => {
+    const webview = makeWebview(undefined);
+    loadWebviewUrl(webview, "http://localhost:5173/");
+    expect(webview.loadURL).toHaveBeenCalledWith("http://localhost:5173/");
+  });
+
+  it("does not invoke onRejected when loadURL rejects with ERR_ABORTED (-3)", async () => {
+    const onRejected = vi.fn();
+    const webview = makeWebview(Promise.reject({ errorCode: -3 }));
+    loadWebviewUrl(webview, "http://localhost:5173/", onRejected);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onRejected).not.toHaveBeenCalled();
+  });
+
+  it("invokes onRejected for any non-abort rejection", async () => {
+    const onRejected = vi.fn();
+    const webview = makeWebview(Promise.reject({ errorCode: -105 }));
+    loadWebviewUrl(webview, "http://localhost:5173/", onRejected);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onRejected).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onRejected when the rejection has no errorCode", async () => {
+    const onRejected = vi.fn();
+    const webview = makeWebview(Promise.reject(new Error("boom")));
+    loadWebviewUrl(webview, "http://localhost:5173/", onRejected);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onRejected).toHaveBeenCalledTimes(1);
+  });
+
+  it("tolerates a synchronous (non-promise) loadURL return", () => {
+    const onRejected = vi.fn();
+    const webview = makeWebview(undefined);
+    expect(() => loadWebviewUrl(webview, "http://localhost:5173/", onRejected)).not.toThrow();
+    expect(onRejected).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/DevPreview/loadWebviewUrl.ts
+++ b/src/components/DevPreview/loadWebviewUrl.ts
@@ -10,7 +10,17 @@ export function loadWebviewUrl(
     "catch" in result &&
     typeof result.catch === "function"
   ) {
-    result.catch(() => {
+    (result as { catch: (fn: (err: unknown) => void) => void }).catch((err: unknown) => {
+      // ERR_ABORTED (-3) fires when a pending load is superseded by a new
+      // navigation — benign, so don't surface it as a load failure (#9940).
+      if (
+        err &&
+        typeof err === "object" &&
+        "errorCode" in err &&
+        (err as { errorCode: unknown }).errorCode === -3
+      ) {
+        return;
+      }
       onRejected?.();
     });
   }


### PR DESCRIPTION
## Summary

The Electron webview mutation observer guards on the previously-observed `src` attribute value, not the live DOM value that `onLoadCommit` updates via `setValueIgnoreMutation`. When a guest navigation updates `history.present` and React re-renders `<webview src={currentUrl}>`, the observer sees a change and fires a redundant `loadURL` for the URL already shown — a second full reload that destroys client-side history for SPA `pushState` and hash navigations. This was also the source of the swallowed `ERR_ABORTED` (-3) errors.

The fix is to treat `src` as a mount-time seed only and route all navigation imperatively through `loadURL`.

Resolves #9940

## Changes

- **`BrowserPane`**: bind `src` to `initialUrlRef` (set once at mount, never updated). Re-seed when `webviewPartition` changes so a key-driven remount loads at the right URL.
- **`DevPreviewPane`**: same `src={initialUrlRef.current}` pattern. Seed `lastSetUrlRef` at declaration and on node attach so the `isWebviewReady` effect doesn't redundantly reload on first ready. Stop pre-setting `lastSetUrlRef` in the dev-server URL-update effect and `handleNavigate` — the imperative nav effect owns `loadURL`.
- **`loadWebviewUrl.ts`**: swallow benign `ERR_ABORTED` (-3); surface all other rejections via `onRejected`.
- **Tests**: regression suites in `BrowserPane.webview.test.tsx` and `DevPreviewPane.webview.test.tsx` (verify `loadURL` is not called and `src` is not re-bound after `did-navigate` / `did-navigate-in-page`; partition remount re-seeds `src`; dev-server URL change navigates imperatively). New `loadWebviewUrl.test.ts` covers the error-handling paths.

## Testing

- Unit tests cover the regression paths directly — `loadURL` call counts after navigation events, `src` value after partition remount, `ERR_ABORTED` swallowing.
- `npm run check` passes clean.