### PR TITLE
fix(mcp-server): surface rate-limit wait time in recent-calls popover (#10014)

### DIFF
--- a/electron/services/mcp-server/__tests__/auditLog.test.ts
+++ b/electron/services/mcp-server/__tests__/auditLog.test.ts
@@ -213,6 +213,76 @@ describe("AuditService.appendRecord — turnId, severity, schemaVersion", () => 
   });
 });
 
+describe("AuditService.appendRecord — resultMeta (#10014)", () => {
+  it("persists retryAfter on rate_limited records and round-trips through getRecords", () => {
+    const { service } = makeFixture();
+    service.appendRecord({
+      toolId: "agent.terminal",
+      sessionId: "sess-1",
+      tier: "action",
+      args: {},
+      durationMs: 0,
+      outcome: { kind: "rate_limited", retryAfter: 5 },
+      argsSummary: "{}",
+      resultMeta: { retryAfter: 5 },
+    });
+    const [record] = service.getRecords();
+    expect(record!.result).toBe("rate_limited");
+    expect(record!.resultMeta).toEqual({ retryAfter: 5 });
+  });
+
+  it("leaves resultMeta undefined on records that do not provide it", () => {
+    const { service } = makeFixture();
+    service.appendRecord({
+      toolId: "agent.launch",
+      sessionId: "sess-1",
+      tier: "action",
+      args: {},
+      durationMs: 5,
+      outcome: successOutcome,
+      argsSummary: "{}",
+    });
+    const [record] = service.getRecords();
+    expect("resultMeta" in record!).toBe(false);
+  });
+
+  it("does not backfill resultMeta on gate outcomes that omit it (unauthorized / dedup / collision)", () => {
+    const { service } = makeFixture();
+    service.appendRecord({
+      toolId: "agent.terminal",
+      sessionId: "sess-1",
+      tier: "workbench",
+      args: {},
+      durationMs: 0,
+      outcome: { kind: "unauthorized" },
+      argsSummary: "{}",
+    });
+    service.appendRecord({
+      toolId: "agent.terminal",
+      sessionId: "sess-1",
+      tier: "action",
+      args: {},
+      durationMs: 0,
+      outcome: { kind: "dedup" },
+      argsSummary: "{}",
+    });
+    service.appendRecord({
+      toolId: "agent.terminal",
+      sessionId: "sess-1",
+      tier: "action",
+      args: {},
+      durationMs: 0,
+      outcome: { kind: "collision" },
+      argsSummary: "{}",
+    });
+    const records = service.getRecords();
+    expect(records).toHaveLength(3);
+    for (const r of records) {
+      expect("resultMeta" in r!).toBe(false);
+    }
+  });
+});
+
 describe("AuditService.recordAuth401 pre-auth records", () => {
   it("emits a pre-auth record alongside the counter increment", () => {
     const { service } = makeFixture();

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -526,6 +526,100 @@ describe("HttpLifecycle", () => {
     });
   });
 
+  describe("buildSessionServerDeps — appendAuditRecord resultMeta for rate_limited (#10014)", () => {
+    function captureAppendInput(sessionId: string) {
+      const deps = fakeDeps();
+      const lc = new HttpLifecycle(deps);
+      const deps_ = (
+        lc as unknown as {
+          buildSessionServerDeps: (sessionId: string) => {
+            appendAuditRecord: (input: Record<string, unknown>) => void;
+          };
+        }
+      ).buildSessionServerDeps(sessionId);
+      return { deps, deps_, appendInput: (input: Record<string, unknown>) => void 0 };
+    }
+
+    it("forwards resultMeta.retryAfter on rate_limited outcomes and omits resultSummary", () => {
+      const deps = fakeDeps();
+      const lc = new HttpLifecycle(deps);
+      const deps_ = (
+        lc as unknown as {
+          buildSessionServerDeps: (sessionId: string) => {
+            appendAuditRecord: (input: Record<string, unknown>) => void;
+          };
+        }
+      ).buildSessionServerDeps("session-rl");
+      deps_.appendAuditRecord({
+        toolId: "agent.terminal",
+        sessionId: "session-rl",
+        tier: "action",
+        args: {},
+        durationMs: 0,
+        outcome: { kind: "rate_limited", retryAfter: 5 },
+      });
+      expect(deps.auditService.appendRecord).toHaveBeenCalledWith(
+        expect.objectContaining({ resultMeta: { retryAfter: 5 } })
+      );
+      const callArgs = (deps.auditService.appendRecord as ReturnType<typeof vi.fn>).mock
+        .calls[0]?.[0];
+      expect(callArgs.resultSummary).toBeUndefined();
+    });
+
+    it("does not attach resultMeta for unauthorized / dedup / collision outcomes", () => {
+      const deps = fakeDeps();
+      const lc = new HttpLifecycle(deps);
+      const deps_ = (
+        lc as unknown as {
+          buildSessionServerDeps: (sessionId: string) => {
+            appendAuditRecord: (input: Record<string, unknown>) => void;
+          };
+        }
+      ).buildSessionServerDeps("session-gate");
+      for (const outcome of [{ kind: "unauthorized" }, { kind: "dedup" }, { kind: "collision" }]) {
+        deps_.appendAuditRecord({
+          toolId: "agent.terminal",
+          sessionId: "session-gate",
+          tier: "action",
+          args: {},
+          durationMs: 0,
+          outcome,
+        });
+      }
+      const calls = (deps.auditService.appendRecord as ReturnType<typeof vi.fn>).mock.calls;
+      expect(calls).toHaveLength(3);
+      for (const call of calls) {
+        expect(call[0].resultMeta).toBeUndefined();
+        expect(call[0].resultSummary).toBeUndefined();
+      }
+    });
+
+    it("does not attach resultMeta for success outcomes (only rate_limited carries hints)", () => {
+      const deps = fakeDeps();
+      const lc = new HttpLifecycle(deps);
+      const deps_ = (
+        lc as unknown as {
+          buildSessionServerDeps: (sessionId: string) => {
+            appendAuditRecord: (input: Record<string, unknown>) => void;
+          };
+        }
+      ).buildSessionServerDeps("session-ok");
+      deps_.appendAuditRecord({
+        toolId: "agent.terminal",
+        sessionId: "session-ok",
+        tier: "action",
+        args: {},
+        durationMs: 5,
+        outcome: { kind: "result", value: { ok: true, result: null } },
+      });
+      const callArgs = (deps.auditService.appendRecord as ReturnType<typeof vi.fn>).mock
+        .calls[0]?.[0];
+      expect(callArgs.resultMeta).toBeUndefined();
+      // Success dispatches DO carry a resultSummary (tool output).
+      expect(callArgs.resultSummary).toBeDefined();
+    });
+  });
+
   describe("bearer register", () => {
     const authA = "Bearer secret-token-aaaa";
     const authB = "Bearer secret-token-bbbb";

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -527,19 +527,6 @@ describe("HttpLifecycle", () => {
   });
 
   describe("buildSessionServerDeps — appendAuditRecord resultMeta for rate_limited (#10014)", () => {
-    function captureAppendInput(sessionId: string) {
-      const deps = fakeDeps();
-      const lc = new HttpLifecycle(deps);
-      const deps_ = (
-        lc as unknown as {
-          buildSessionServerDeps: (sessionId: string) => {
-            appendAuditRecord: (input: Record<string, unknown>) => void;
-          };
-        }
-      ).buildSessionServerDeps(sessionId);
-      return { deps, deps_, appendInput: (input: Record<string, unknown>) => void 0 };
-    }
-
     it("forwards resultMeta.retryAfter on rate_limited outcomes and omits resultSummary", () => {
       const deps = fakeDeps();
       const lc = new HttpLifecycle(deps);

--- a/electron/services/mcp-server/auditLog.ts
+++ b/electron/services/mcp-server/auditLog.ts
@@ -153,6 +153,7 @@ export class AuditService {
     turnId?: string;
     helpSessionId?: string;
     resultSummary?: string;
+    resultMeta?: McpAuditRecord["resultMeta"];
   }): void {
     if (this.readConfig().auditEnabled === false) return;
     this.hydrate();
@@ -194,6 +195,9 @@ export class AuditService {
     }
     if (input.resultSummary !== undefined) {
       record.resultSummary = input.resultSummary;
+    }
+    if (input.resultMeta !== undefined) {
+      record.resultMeta = input.resultMeta;
     }
 
     this.enqueueAndTrim(record);

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -1352,12 +1352,24 @@ export class HttpLifecycle {
         const resultSummary = summarizeAuditOutcome(input.outcome, (s) =>
           scrubSecrets(sanitizePath(s))
         );
+        // `summarizeAuditOutcome` returns null for all gate outcomes by
+        // contract — the wait-time hint for `rate_limited` reaches the audit
+        // record through `resultMeta` instead, so the recent-calls popover
+        // can surface the integer-seconds value the agent already received
+        // in the JSON-RPC error (`details: { retryAfter }`) without
+        // re-scrubbing display text or polluting the tool-output summary
+        // (#10014).
+        const resultMeta =
+          input.outcome.kind === "rate_limited"
+            ? { retryAfter: input.outcome.retryAfter }
+            : undefined;
         this.deps.auditService.appendRecord({
           ...input,
           argsSummary: summarizeMcpArgs(input.args, (s) => scrubSecrets(sanitizePath(s))),
           ...(turnId !== null ? { turnId } : {}),
           ...(helpSessionId !== null ? { helpSessionId } : {}),
           ...(resultSummary !== null ? { resultSummary } : {}),
+          ...(resultMeta !== undefined ? { resultMeta } : {}),
         });
       },
       getCachedManifest,

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -123,9 +123,18 @@ export interface McpAuditRecord {
    * Redacted, bounded (1500-char) pretty-printed JSON of what the call
    * returned — or the error code + message for failed dispatches. Lets the
    * recent-calls popover show each call's actual output. Absent for gate
-   * outcomes (unauthorized/dedup/collision/rate-limit) and old records.
+   * outcomes (unauthorized / dedup / collision) and old records. For
+   * `rate_limited` the wait time travels in `resultMeta.retryAfter` (#10014).
    */
   resultSummary?: string;
+  /**
+   * Renderer-presented hints for gate outcomes that carry a meaningful
+   * parameter the `result` label can't capture on its own. Currently set
+   * only for `rate_limited` (`retryAfter`, integer seconds from the
+   * `MCP_RATE_LIMITED_CODE` error). Absent on every other result, and on
+   * old records written before the field existed (#10014).
+   */
+  resultMeta?: { retryAfter?: number };
   result: McpAuditResult;
   errorCode?: string;
   durationMs: number;

--- a/src/components/HelpPanel/RecentCallsPopover.tsx
+++ b/src/components/HelpPanel/RecentCallsPopover.tsx
@@ -165,7 +165,11 @@ function RecentCallRow({ record }: { record: McpAuditRecord }) {
           )}
           <div>
             <div className="text-daintree-text/40">Result</div>
-            {record.resultSummary ? (
+            {record.result === "rate_limited" && record.resultMeta?.retryAfter !== undefined ? (
+              <p className="mt-0.5 text-daintree-text/45">
+                Retry in {record.resultMeta.retryAfter}s
+              </p>
+            ) : record.resultSummary ? (
               <pre className="mt-0.5 max-h-48 overflow-y-auto whitespace-pre-wrap break-all font-mono text-daintree-text/70">
                 {record.resultSummary}
               </pre>

--- a/src/components/HelpPanel/__tests__/McpActivityStrip.test.tsx
+++ b/src/components/HelpPanel/__tests__/McpActivityStrip.test.tsx
@@ -276,6 +276,43 @@ describe("McpActivityStrip", () => {
     fireEvent.click(row);
     expect(screen.getByText(/no output recorded for this call/i)).toBeTruthy();
   });
+
+  it("renders a Retry-in-Ns hint on rate_limited records carrying resultMeta (#10014)", async () => {
+    getAuditRecords.mockResolvedValue([
+      makeRecord({
+        id: "1",
+        toolId: "throttled.call",
+        result: "rate_limited",
+        resultSummary: undefined,
+        resultMeta: { retryAfter: 5 },
+      }),
+    ]);
+    render(<McpActivityStrip sessionId="session-a" activity={null} />);
+    fireEvent.click(screen.getByRole("button", { name: /recent tool calls/i }));
+    const row = await screen.findByRole("button", { name: /throttled\.call/ });
+    fireEvent.click(row);
+    expect(screen.getByText("Rate limited")).toBeTruthy();
+    expect(screen.getByText("Retry in 5s")).toBeTruthy();
+    // The no-output fallback must NOT appear when resultMeta carries the hint.
+    expect(screen.queryByText(/no output recorded for this call/i)).toBeNull();
+  });
+
+  it("falls back to the no-output note for rate_limited records missing resultMeta (legacy rows)", async () => {
+    getAuditRecords.mockResolvedValue([
+      makeRecord({
+        id: "1",
+        toolId: "legacy.throttled",
+        result: "rate_limited",
+        resultSummary: undefined,
+      }),
+    ]);
+    render(<McpActivityStrip sessionId="session-a" activity={null} />);
+    fireEvent.click(screen.getByRole("button", { name: /recent tool calls/i }));
+    const row = await screen.findByRole("button", { name: /legacy\.throttled/ });
+    fireEvent.click(row);
+    expect(screen.queryByText(/retry in \d+s/i)).toBeNull();
+    expect(screen.getByText(/no output recorded for this call/i)).toBeTruthy();
+  });
 });
 
 describe("McpActivityStrip live activity", () => {


### PR DESCRIPTION
## Summary

- The recent-calls popover now shows `Retry in Ns` next to the `Rate limited` label, sourced from the `retryAfter` value the agent already receives in the JSON-RPC error.
- Previously `summarizeAuditOutcome` returned `null` for all gate outcomes, so `retryAfter` was dropped before the audit record was written and the popover only had a generic `Rate limited` label.
- The fix adds a narrow `resultMeta?: { retryAfter?: number }` field on `McpAuditRecord` and forwards it from the `httpLifecycle` `appendAuditRecord` closure when `outcome.kind === "rate_limited"`. The other gate outcomes (`unauthorized`/`dedup`/`collision`) stay summary-less as the issue requested.

## Changes

- `shared/types/ipc/mcpServer.ts` — `resultMeta?` field on `McpAuditRecord` (+ JSDoc).
- `electron/services/mcp-server/auditLog.ts` — `appendRecord()` forwards `resultMeta` onto the persisted record when provided.
- `electron/services/mcp-server/httpLifecycle.ts` — call-site narrowing in the `appendAuditRecord` closure.
- `src/components/HelpPanel/RecentCallsPopover.tsx` — render branch for `Retry in {n}s` when `result === "rate_limited"` and `resultMeta?.retryAfter` is set.
- Test coverage in `auditLog.test.ts`, `httpLifecycle.test.ts`, and `McpActivityStrip.test.tsx`.

## Testing

- `auditLog.test.ts` — persistence round-trip for `resultMeta.retryAfter`; negative cases (no `resultMeta` on success; no backfill on `unauthorized`/`dedup`/`collision`).
- `httpLifecycle.test.ts` — call-site narrowing: `rate_limited` forwards `resultMeta: { retryAfter: N }` and omits `resultSummary`; `unauthorized`/`dedup`/`collision` carry neither; success carries only `resultSummary`.
- `McpActivityStrip.test.tsx` — `rate_limited` with `resultMeta.retryAfter` renders `Retry in 5s`; legacy `rate_limited` records without `resultMeta` fall through to the no-output message.

113/113 targeted tests pass. `npm run check` is clean (typecheck + lint + format + channel/IPC/confirm-wiring guards).