### PR TITLE
fix(mcp): snapshot turnId at dispatch to fix strip/popover disagreement

### DIFF
--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -438,21 +438,41 @@ describe("HttpLifecycle", () => {
     });
   });
 
-  describe("buildSessionServerDeps — appendAuditRecord turnId/helpSessionId stamping", () => {
-    it("resolves turnId via the HELP session id and stamps both onto the record", () => {
+  describe("buildSessionServerDeps — turnId snapshot stamping (#10067)", () => {
+    type TurnDeps = {
+      getCurrentTurnId?: () => string | null;
+      appendAuditRecord: (input: Record<string, unknown>) => void;
+    };
+    const buildDeps = (lc: HttpLifecycle, sessionId: string): TurnDeps =>
+      (
+        lc as unknown as { buildSessionServerDeps: (id: string) => TurnDeps }
+      ).buildSessionServerDeps(sessionId);
+
+    it("resolves the live turn id via the HELP session id through getCurrentTurnId", () => {
       const deps = fakeDeps();
       (
         deps.turnOutcomeService.getCurrentTurnIdForSession as ReturnType<typeof vi.fn>
       ).mockReturnValue("turn-uuid-abc");
       deps.sessionStore.sessionHelpIdMap.set("session-1", "help-session-9");
       const lc = new HttpLifecycle(deps);
-      const deps_ = (
-        lc as unknown as {
-          buildSessionServerDeps: (sessionId: string) => {
-            appendAuditRecord: (input: Record<string, unknown>) => void;
-          };
-        }
-      ).buildSessionServerDeps("session-1");
+      const deps_ = buildDeps(lc, "session-1");
+      // The turn-id register is keyed by HELP session id, not the MCP transport
+      // id — passing the transport id always missed (#9759 gap).
+      expect(deps_.getCurrentTurnId?.()).toBe("turn-uuid-abc");
+      expect(deps.turnOutcomeService.getCurrentTurnIdForSession).toHaveBeenCalledWith(
+        "help-session-9"
+      );
+    });
+
+    it("stamps the captured turn id onto the audit record without re-reading it", () => {
+      const deps = fakeDeps();
+      (
+        deps.turnOutcomeService.getCurrentTurnIdForSession as ReturnType<typeof vi.fn>
+      ).mockReturnValue("turn-uuid-abc");
+      deps.sessionStore.sessionHelpIdMap.set("session-1", "help-session-9");
+      const lc = new HttpLifecycle(deps);
+      const deps_ = buildDeps(lc, "session-1");
+      (deps.turnOutcomeService.getCurrentTurnIdForSession as ReturnType<typeof vi.fn>).mockClear();
       deps_.appendAuditRecord({
         toolId: "agent.terminal",
         sessionId: "session-1",
@@ -460,31 +480,22 @@ describe("HttpLifecycle", () => {
         args: {},
         durationMs: 5,
         outcome: { kind: "result", value: { ok: true, result: null } },
+        capturedTurnId: "turn-uuid-abc",
       });
-      // The turn-id register is keyed by HELP session id, not the MCP
-      // transport id — passing the transport id always missed (#9759 gap).
-      expect(deps.turnOutcomeService.getCurrentTurnIdForSession).toHaveBeenCalledWith(
-        "help-session-9"
-      );
+      // The write path must not re-read the live register — the snapshot is the
+      // single source of truth, so the audit record can't disagree with the
+      // started/settled strip events.
+      expect(deps.turnOutcomeService.getCurrentTurnIdForSession).not.toHaveBeenCalled();
       expect(deps.auditService.appendRecord).toHaveBeenCalledWith(
         expect.objectContaining({ turnId: "turn-uuid-abc", helpSessionId: "help-session-9" })
       );
     });
 
-    it("omits turnId when getCurrentTurnIdForSession returns null", () => {
+    it("omits turnId when the captured snapshot is null", () => {
       const deps = fakeDeps();
-      (
-        deps.turnOutcomeService.getCurrentTurnIdForSession as ReturnType<typeof vi.fn>
-      ).mockReturnValue(null);
       deps.sessionStore.sessionHelpIdMap.set("session-1", "help-session-9");
       const lc = new HttpLifecycle(deps);
-      const deps_ = (
-        lc as unknown as {
-          buildSessionServerDeps: (sessionId: string) => {
-            appendAuditRecord: (input: Record<string, unknown>) => void;
-          };
-        }
-      ).buildSessionServerDeps("session-1");
+      const deps_ = buildDeps(lc, "session-1");
       deps_.appendAuditRecord({
         toolId: "agent.terminal",
         sessionId: "session-1",
@@ -492,6 +503,7 @@ describe("HttpLifecycle", () => {
         args: {},
         durationMs: 5,
         outcome: { kind: "result", value: { ok: true, result: null } },
+        capturedTurnId: null,
       });
       const callArgs = (deps.auditService.appendRecord as ReturnType<typeof vi.fn>).mock
         .calls[0]?.[0];
@@ -500,16 +512,12 @@ describe("HttpLifecycle", () => {
       expect(callArgs.helpSessionId).toBe("help-session-9");
     });
 
-    it("skips turn lookup and helpSessionId for sessions with no help binding", () => {
+    it("getCurrentTurnId returns null and skips lookup for sessions with no help binding", () => {
       const deps = fakeDeps();
       const lc = new HttpLifecycle(deps);
-      const deps_ = (
-        lc as unknown as {
-          buildSessionServerDeps: (sessionId: string) => {
-            appendAuditRecord: (input: Record<string, unknown>) => void;
-          };
-        }
-      ).buildSessionServerDeps("session-external");
+      const deps_ = buildDeps(lc, "session-external");
+      expect(deps_.getCurrentTurnId?.()).toBeNull();
+      expect(deps.turnOutcomeService.getCurrentTurnIdForSession).not.toHaveBeenCalled();
       deps_.appendAuditRecord({
         toolId: "agent.terminal",
         sessionId: "session-external",
@@ -517,12 +525,47 @@ describe("HttpLifecycle", () => {
         args: {},
         durationMs: 5,
         outcome: { kind: "result", value: { ok: true, result: null } },
+        capturedTurnId: null,
       });
-      expect(deps.turnOutcomeService.getCurrentTurnIdForSession).not.toHaveBeenCalled();
       const callArgs = (deps.auditService.appendRecord as ReturnType<typeof vi.fn>).mock
         .calls[0]?.[0];
       expect(callArgs.turnId).toBeUndefined();
       expect(callArgs.helpSessionId).toBeUndefined();
+    });
+
+    it("stamps the start-time snapshot even after the FSM clears the turn mid-call", () => {
+      const deps = fakeDeps();
+      const liveTurn = deps.turnOutcomeService.getCurrentTurnIdForSession as ReturnType<
+        typeof vi.fn
+      >;
+      liveTurn.mockReturnValue("turn-T1");
+      deps.sessionStore.sessionHelpIdMap.set("session-1", "help-session-9");
+      const lc = new HttpLifecycle(deps);
+      const deps_ = buildDeps(lc, "session-1");
+
+      // Snapshot at dispatch start, while the turn is still active.
+      const capturedTurnId = deps_.getCurrentTurnId?.() ?? null;
+      expect(capturedTurnId).toBe("turn-T1");
+
+      // The active→passive FSM transition clears the register before the call
+      // settles — a fresh read would now return null (the #10067 race).
+      liveTurn.mockReturnValue(null);
+
+      deps_.appendAuditRecord({
+        toolId: "agent.terminal",
+        sessionId: "session-1",
+        tier: "action",
+        args: {},
+        durationMs: 5,
+        outcome: { kind: "result", value: { ok: true, result: null } },
+        capturedTurnId,
+      });
+
+      // The audit record carries the snapshot, not the post-transition null —
+      // so it groups with the started/settled events under the same turn.
+      expect(deps.auditService.appendRecord).toHaveBeenCalledWith(
+        expect.objectContaining({ turnId: "turn-T1", helpSessionId: "help-session-9" })
+      );
     });
   });
 

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -489,6 +489,11 @@ describe("HttpLifecycle", () => {
       expect(deps.auditService.appendRecord).toHaveBeenCalledWith(
         expect.objectContaining({ turnId: "turn-uuid-abc", helpSessionId: "help-session-9" })
       );
+      // `capturedTurnId` is a transport-only carrier — it must be peeled off and
+      // never persist into the stored record (the public field is `turnId`).
+      const persisted = (deps.auditService.appendRecord as ReturnType<typeof vi.fn>).mock
+        .calls[0]?.[0];
+      expect(persisted.capturedTurnId).toBeUndefined();
     });
 
     it("omits turnId when the captured snapshot is null", () => {

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -1125,9 +1125,10 @@ describe("CallTool live activity notifications (#9759)", () => {
     expect(started.mock.invocationCallOrder[0]).toBeLessThan(settled.mock.invocationCallOrder[0]);
   });
 
-  it("threads one captured turn id into both started and settled (#10067)", async () => {
+  it("threads one captured turn id into started, settled, and the audit record (#10067)", async () => {
     const started = vi.fn();
     const settled = vi.fn();
+    const appendAuditRecord = vi.fn();
     // getCurrentTurnId is read once at dispatch start. Returning a fresh value
     // on a second call would prove a leak; this asserts a single snapshot.
     const getCurrentTurnId = vi.fn().mockReturnValue("turn-xyz");
@@ -1136,6 +1137,7 @@ describe("CallTool live activity notifications (#9759)", () => {
       getCurrentTurnId,
       notifyToolCallStarted: started,
       notifyToolCallSettled: settled,
+      appendAuditRecord,
       dispatchAction,
     });
     const server = createSessionServer("session-T", deps);
@@ -1143,9 +1145,15 @@ describe("CallTool live activity notifications (#9759)", () => {
 
     await callTool(server, { name: "worktree.list", arguments: {} });
 
+    // One read, threaded to all three consumers end-to-end — none re-reads the
+    // register, so the strip's started/settled rows and the audit record can
+    // never disagree on which turn the call belongs to.
     expect(getCurrentTurnId).toHaveBeenCalledTimes(1);
     expect(started).toHaveBeenCalledWith(expect.objectContaining({ capturedTurnId: "turn-xyz" }));
     expect(settled).toHaveBeenCalledWith(expect.objectContaining({ capturedTurnId: "turn-xyz" }));
+    expect(appendAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ capturedTurnId: "turn-xyz" })
+    );
   });
 
   it("snapshots the turn id at start so started/settled agree across an FSM clear (#10067)", async () => {

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -1125,6 +1125,54 @@ describe("CallTool live activity notifications (#9759)", () => {
     expect(started.mock.invocationCallOrder[0]).toBeLessThan(settled.mock.invocationCallOrder[0]);
   });
 
+  it("threads one captured turn id into both started and settled (#10067)", async () => {
+    const started = vi.fn();
+    const settled = vi.fn();
+    // getCurrentTurnId is read once at dispatch start. Returning a fresh value
+    // on a second call would prove a leak; this asserts a single snapshot.
+    const getCurrentTurnId = vi.fn().mockReturnValue("turn-xyz");
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: null } });
+    const deps = fakeDeps({
+      getCurrentTurnId,
+      notifyToolCallStarted: started,
+      notifyToolCallSettled: settled,
+      dispatchAction,
+    });
+    const server = createSessionServer("session-T", deps);
+    await server.connect(makeMockTransport());
+
+    await callTool(server, { name: "worktree.list", arguments: {} });
+
+    expect(getCurrentTurnId).toHaveBeenCalledTimes(1);
+    expect(started).toHaveBeenCalledWith(expect.objectContaining({ capturedTurnId: "turn-xyz" }));
+    expect(settled).toHaveBeenCalledWith(expect.objectContaining({ capturedTurnId: "turn-xyz" }));
+  });
+
+  it("snapshots the turn id at start so started/settled agree across an FSM clear (#10067)", async () => {
+    const started = vi.fn();
+    const settled = vi.fn();
+    // Mirror the active→passive race: the turn id is live at dispatch start but
+    // a later read would return null. Both events must still carry the snapshot.
+    const getCurrentTurnId = vi.fn().mockReturnValueOnce("turn-T1").mockReturnValue(null);
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: null } });
+    const deps = fakeDeps({
+      getCurrentTurnId,
+      notifyToolCallStarted: started,
+      notifyToolCallSettled: settled,
+      dispatchAction,
+    });
+    const server = createSessionServer("session-T2", deps);
+    await server.connect(makeMockTransport());
+
+    await callTool(server, { name: "worktree.list", arguments: {} });
+
+    const startedTurn = started.mock.calls[0]?.[0]?.capturedTurnId;
+    const settledTurn = settled.mock.calls[0]?.[0]?.capturedTurnId;
+    expect(startedTurn).toBe("turn-T1");
+    expect(settledTurn).toBe("turn-T1");
+    expect(startedTurn).toBe(settledTurn);
+  });
+
   it("does not emit started/settled for a pre-dispatch tier rejection", async () => {
     const started = vi.fn();
     const settled = vi.fn();

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -1263,11 +1263,11 @@ export class HttpLifecycle {
         const wc = webContentsModule.fromId(id);
         if (!wc || wc.isDestroyed()) return;
         // Redact args with the same pipeline the audit record uses so the strip
-        // never shows raw bearer tokens or absolute paths (#9759).
-        const turnId =
-          helpSessionId !== null
-            ? this.deps.turnOutcomeService.getCurrentTurnIdForSession(helpSessionId)
-            : null;
+        // never shows raw bearer tokens or absolute paths (#9759). The turn id
+        // is the snapshot the dispatch took at call-start (#10067) — not a fresh
+        // read here, which could disagree with the settled/audit value if the
+        // FSM transitioned mid-call.
+        const turnId = payload.capturedTurnId;
         try {
           wc.send(CHANNELS.MCP_TOOL_CALL_STARTED, {
             sessionId: payload.sessionId,
@@ -1291,10 +1291,9 @@ export class HttpLifecycle {
         // Derive result/errorCode/severity from the same classifier the audit
         // writer uses, so the strip's glyph and red-tint match the audit log.
         const { result, errorCode } = classifyMcpDispatchResult(payload.outcome);
-        const turnId =
-          helpSessionId !== null
-            ? this.deps.turnOutcomeService.getCurrentTurnIdForSession(helpSessionId)
-            : null;
+        // Same snapshot the started event carried (#10067) — guarantees the
+        // strip's in-flight row and its settled row resolve to one turn group.
+        const turnId = payload.capturedTurnId;
         try {
           wc.send(CHANNELS.MCP_TOOL_CALL_SETTLED, {
             sessionId: payload.sessionId,
@@ -1345,15 +1344,20 @@ export class HttpLifecycle {
         // `summarizeMcpArgs` — running the scrubber after truncation would
         // miss bearer tokens whose body got cut below the scrubber's
         // 8-char minimum match length.
-        const turnId =
-          helpSessionId !== null
-            ? this.deps.turnOutcomeService.getCurrentTurnIdForSession(helpSessionId)
-            : null;
+        // Stamp the turn id from the dispatch-start snapshot (#10067), never a
+        // fresh read at write time — by the time the audit lands the FSM may
+        // have cleared the turn, which would split this call away from the
+        // started/settled strip events that already carry it.
+        // `capturedTurnId` is the transport-only carrier — peel it off so it
+        // never lands in the persisted record (the stamped `turnId` is the
+        // public field).
+        const { capturedTurnId, ...recordInput } = input;
+        const turnId = capturedTurnId ?? null;
         const resultSummary = summarizeAuditOutcome(input.outcome, (s) =>
           scrubSecrets(sanitizePath(s))
         );
         this.deps.auditService.appendRecord({
-          ...input,
+          ...recordInput,
           argsSummary: summarizeMcpArgs(input.args, (s) => scrubSecrets(sanitizePath(s))),
           ...(turnId !== null ? { turnId } : {}),
           ...(helpSessionId !== null ? { helpSessionId } : {}),
@@ -1368,6 +1372,13 @@ export class HttpLifecycle {
       clearDenialState: (sessionId) => {
         this.deps.abusePolicy.dropSession(sessionId);
       },
+      // Single live read of the turn register, called once per dispatch from
+      // sessionServer (#10067). Closes over the build-time `helpSessionId` so
+      // the snapshot it returns is the turn this session's call is part of.
+      getCurrentTurnId: () =>
+        helpSessionId !== null
+          ? this.deps.turnOutcomeService.getCurrentTurnIdForSession(helpSessionId)
+          : null,
       notifyToolCallStarted,
       notifyToolCallSettled,
       notifyDisplayImage,

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -148,6 +148,14 @@ export interface SessionServerDeps {
     outcome: AuditOutcome;
     confirmationDecision?: import("../../../shared/types/ipc/mcpServer.js").McpConfirmationDecision;
     bannerSuppressed?: boolean;
+    /**
+     * Turn id snapshotted once at dispatch start (#10067). Forwarded so the
+     * audit record is stamped with the same turn the live activity strip's
+     * started/settled events carry — never re-read at write time, where an
+     * active→passive FSM transition could have cleared it and split one call
+     * across two groupings.
+     */
+    capturedTurnId?: string | null;
   }) => void;
   getCachedManifest: () => import("../../../shared/types/actions.js").ActionManifestEntry[] | null;
   getFullToolSurface: () => boolean;
@@ -195,6 +203,15 @@ export interface SessionServerDeps {
    */
   clearDenialState?: (sessionId: string) => void;
   /**
+   * Resolve the help-session turn id live (#10067). Called exactly once per
+   * dispatch — at the top of the CallTool handler — so a single snapshot feeds
+   * the started event, the settled event, and the audit record. Returns `null`
+   * for sessions with no help binding (external/api-key) or no active turn.
+   * Implemented by httpLifecycle (it closes over the help-session id); absent
+   * in test fixtures that don't exercise turn correlation.
+   */
+  getCurrentTurnId?: () => string | null;
+  /**
    * Optional renderer notifier fired when an MCP tool dispatch enters the call
    * path (after tier/rate/dedup guards pass and the manifest entry resolves).
    * Drives the Assistant panel's live activity strip (#9759). Implemented by
@@ -209,6 +226,8 @@ export interface SessionServerDeps {
     startedAt: number;
     /** True when the resolved manifest entry is `danger: "confirm"`. */
     danger: boolean;
+    /** Turn id snapshotted at dispatch start (#10067); see {@link SessionServerDeps.getCurrentTurnId}. */
+    capturedTurnId: string | null;
   }) => void;
   /**
    * Optional renderer notifier fired when a dispatch announced via
@@ -221,6 +240,8 @@ export interface SessionServerDeps {
     toolId: string;
     durationMs: number;
     outcome: AuditOutcome;
+    /** Turn id snapshotted at dispatch start (#10067); matches the started event's value. */
+    capturedTurnId: string | null;
   }) => void;
   /**
    * Optional renderer notifier fired when the assistant invokes
@@ -254,6 +275,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     recordDenial,
     notifySessionRevoked,
     clearDenialState,
+    getCurrentTurnId,
     notifyToolCallStarted,
     notifyToolCallSettled,
     notifyDisplayImage,
@@ -303,6 +325,12 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     const startedAt = Date.now();
     const tier = sessionStore.getTier(sessionId);
     const fullToolSurface = getFullToolSurface();
+    // Snapshot the turn id once, at dispatch start, before any guard or await
+    // can yield to an active→passive FSM transition that would clear it (#10067).
+    // Every consumer below — the started/settled strip events and all audit
+    // records — receives this same value so one tool call can never split
+    // across two turn groupings in the Assistant panel.
+    const capturedTurnId: string | null = getCurrentTurnId?.() ?? null;
 
     // Layered authorization (#8442):
     //   1. Static tier floor (`TIER_ALLOWLISTS`) — workbench/action/system
@@ -337,6 +365,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
             durationMs: Date.now() - startedAt,
             outcome: { kind: "unauthorized" },
             bannerSuppressed: suppressBanner ? true : undefined,
+            capturedTurnId,
           });
         } catch (err) {
           console.error("[MCP] Failed to append audit record:", err);
@@ -400,6 +429,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
           args,
           durationMs: Date.now() - startedAt,
           outcome: { kind: "rate_limited", retryAfter: rateLimit.retryAfter },
+          capturedTurnId,
         });
       } catch (err) {
         console.error("[MCP] Failed to append audit record:", err);
@@ -435,6 +465,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
                 args,
                 durationMs: Date.now() - startedAt,
                 outcome: { kind: "collision" },
+                capturedTurnId,
               });
             } catch (err) {
               console.error("[MCP] Failed to append audit record:", err);
@@ -454,6 +485,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
               args,
               durationMs: Date.now() - startedAt,
               outcome: { kind: "dedup" },
+              capturedTurnId,
             });
           } catch (err) {
             console.error("[MCP] Failed to append audit record:", err);
@@ -474,6 +506,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
               args,
               durationMs: Date.now() - startedAt,
               outcome: { kind: "collision" },
+              capturedTurnId,
             });
           } catch (err) {
             console.error("[MCP] Failed to append audit record:", err);
@@ -493,6 +526,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
             args,
             durationMs: Date.now() - startedAt,
             outcome: { kind: "dedup" },
+            capturedTurnId,
           });
         } catch (err) {
           console.error("[MCP] Failed to append audit record:", err);
@@ -517,7 +551,14 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     const emitToolCallStarted = (danger: boolean): void => {
       if (!notifyToolCallStarted) return;
       try {
-        notifyToolCallStarted({ sessionId, toolId: actionId, args, startedAt, danger });
+        notifyToolCallStarted({
+          sessionId,
+          toolId: actionId,
+          args,
+          startedAt,
+          danger,
+          capturedTurnId,
+        });
         toolCallStartedEmitted = true;
       } catch (err) {
         console.error("[MCP] Failed to notify tool-call-started:", err);
@@ -769,6 +810,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
             durationMs,
             outcome: settledOutcome,
             confirmationDecision,
+            capturedTurnId,
           });
         } catch (err) {
           console.error("[MCP] Failed to append audit record:", err);
@@ -783,6 +825,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
               toolId: actionId,
               durationMs,
               outcome: settledOutcome,
+              capturedTurnId,
             });
           } catch (err) {
             console.error("[MCP] Failed to notify tool-call-settled:", err);

--- a/src/components/HelpPanel/RecentCallsPopover.tsx
+++ b/src/components/HelpPanel/RecentCallsPopover.tsx
@@ -90,6 +90,11 @@ export function RecentCallsPopover({ records, loading, error }: RecentCallsPopov
           <ul className="divide-y divide-daintree-border/60">
             {groups.map((group, index) => (
               <li key={group.turnId ?? `unassociated-${index}`} className="py-1">
+                {group.turnId === null && (
+                  <div className="px-2 pb-0.5 text-[10px] text-daintree-text/40">
+                    Not tied to a turn
+                  </div>
+                )}
                 <ul className="space-y-0.5">
                   {group.records.map((record) => (
                     <RecentCallRow key={record.id} record={record} />

--- a/src/components/HelpPanel/__tests__/McpActivityStrip.test.tsx
+++ b/src/components/HelpPanel/__tests__/McpActivityStrip.test.tsx
@@ -140,6 +140,26 @@ describe("McpActivityStrip", () => {
     expect(screen.getByText("beta-tool")).toBeTruthy();
   });
 
+  it("labels the unassociated group so null-turn calls are explained (#10067)", async () => {
+    getAuditRecords.mockResolvedValue([
+      makeRecord({ id: "1", toolId: "no-turn-tool", helpSessionId: "session-a" }),
+    ]);
+    render(<McpActivityStrip sessionId="session-a" activity={null} />);
+    fireEvent.click(screen.getByRole("button", { name: /recent tool calls/i }));
+    expect(await screen.findByText("no-turn-tool")).toBeTruthy();
+    expect(screen.getByText(/not tied to a turn/i)).toBeTruthy();
+  });
+
+  it("omits the unassociated label when every call has a turn (#10067)", async () => {
+    getAuditRecords.mockResolvedValue([
+      makeRecord({ id: "1", toolId: "turn-tool", helpSessionId: "session-a", turnId: "t1" }),
+    ]);
+    render(<McpActivityStrip sessionId="session-a" activity={null} />);
+    fireEvent.click(screen.getByRole("button", { name: /recent tool calls/i }));
+    expect(await screen.findByText("turn-tool")).toBeTruthy();
+    expect(screen.queryByText(/not tied to a turn/i)).toBeNull();
+  });
+
   it("filters out records from other sessions", async () => {
     getAuditRecords.mockResolvedValue([
       makeRecord({ id: "1", toolId: "mine", helpSessionId: "session-a" }),


### PR DESCRIPTION
## Summary

- `httpLifecycle.ts` had three closures each calling `getCurrentTurnIdForSession` independently at execution time. The FSM clears `turnIdBySession` on the active→passive transition (`turnOutcomeLog.ts`), so a tool call straddling that boundary got turn `T1` from the started IPC event but `null` in the audit record — causing `McpActivityStrip` and `RecentCallsPopover` to group the same call under different turn IDs.
- Fixed by capturing `turnId` once per dispatch in `sessionServer.ts`'s `CallTool` handler (before any `await`), then threading that single `capturedTurnId` through the started event, settled event, and every `appendAuditRecord` call.
- Also labeled the null-turn group in `RecentCallsPopover` as "Not tied to a turn" so unassociated calls are explained rather than silently bucketed.

Resolves #10067

## Changes

- `electron/services/mcp-server/sessionServer.ts` — new optional `getCurrentTurnId` dep on `CallTool` handler; captures turn ID before any guard or await
- `electron/services/mcp-server/httpLifecycle.ts` — removes three independent live reads; accepts `capturedTurnId` from caller and threads it through `notifyToolCallStarted`, `notifyToolCallSettled`, and `appendAuditRecord`
- `src/components/HelpPanel/RecentCallsPopover.tsx` — labels the null-turn bucket "Not tied to a turn"

## Testing

Rewrote 3 `appendAuditRecord` turn-ID stamping tests to assert snapshot behaviour; added an active→passive boundary test in `httpLifecycle.test.ts`; added 2 correlation tests in `sessionServer.test.ts` (including FSM-clear-mid-call); added end-to-end audit-threading and no-leak assertions; added 2 `RecentCallsPopover` label render tests. All 178 tests across the 3 affected files pass. `npm run check` is clean.