### PR TITLE
fix: route four main-process features off the dead PtyManager singleton (#10054)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -369,14 +369,6 @@ if (!gotTheLock) {
     });
     setProjectViewManager(pvm);
 
-    // Seed the eviction guard's agent-state cache from the pty-host registry.
-    // hasActiveAgent() is read synchronously during LRU scoring, so it can't
-    // await the host; this fire-and-forget seed + event subscription keeps an
-    // instance-level cache fresh (#10054). No-op if the PtyClient isn't up yet
-    // — the cache simply stays empty (conservative: nothing treated as active).
-    const pvmPtyClient = getPtyClient();
-    if (pvmPtyClient) void pvm.initAgentStateCache(pvmPtyClient);
-
     // E2E hooks: expose PVM accessor and heap-snapshot writer so the
     // nightly evicted-view leak spec can read main-process state and
     // dump a v8 snapshot from app.evaluate(). Mirrors the
@@ -432,6 +424,16 @@ if (!gotTheLock) {
       projectViewManager: pvm,
       initialAppView: appView,
     });
+
+    // Seed the eviction guard's agent-state cache from the pty-host registry.
+    // hasActiveAgent() is read synchronously during LRU scoring, so it can't
+    // await the host; this fire-and-forget seed + event subscription keeps an
+    // instance-level cache fresh (#10054). Must run AFTER setupWindowServices,
+    // which constructs the PtyClient — getPtyClient() returns null before then,
+    // so seeding earlier would leave the cache permanently empty on first launch
+    // and re-break the active-agent eviction guard this fix restores.
+    const pvmPtyClient = getPtyClient();
+    if (pvmPtyClient) void pvm.initAgentStateCache(pvmPtyClient);
 
     if (!powerMonitorInitialized) {
       powerMonitorInitialized = true;

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -369,6 +369,14 @@ if (!gotTheLock) {
     });
     setProjectViewManager(pvm);
 
+    // Seed the eviction guard's agent-state cache from the pty-host registry.
+    // hasActiveAgent() is read synchronously during LRU scoring, so it can't
+    // await the host; this fire-and-forget seed + event subscription keeps an
+    // instance-level cache fresh (#10054). No-op if the PtyClient isn't up yet
+    // — the cache simply stays empty (conservative: nothing treated as active).
+    const pvmPtyClient = getPtyClient();
+    if (pvmPtyClient) void pvm.initAgentStateCache(pvmPtyClient);
+
     // E2E hooks: expose PVM accessor and heap-snapshot writer so the
     // nightly evicted-view leak spec can read main-process state and
     // dump a v8 snapshot from app.evaluate(). Mirrors the

--- a/electron/pty-host/handlers/__tests__/lifecycle.test.ts
+++ b/electron/pty-host/handlers/__tests__/lifecycle.test.ts
@@ -206,10 +206,30 @@ describe("lifecycle kill handlers — trackKilledPid", () => {
 
     await dispatch({ type: "graceful-kill-by-project", projectId: "proj-1", requestId: "r1" });
 
-    expect(ctx.ptyManager.gracefulKillByProject).toHaveBeenCalledWith("proj-1");
+    expect(ctx.ptyManager.gracefulKillByProject).toHaveBeenCalledWith("proj-1", {
+      preserveSession: undefined,
+    });
     expect(ctx.resourceGovernor.trackKilledPid).toHaveBeenCalledTimes(2);
     expect(ctx.resourceGovernor.trackKilledPid).toHaveBeenCalledWith(300);
     expect(ctx.resourceGovernor.trackKilledPid).toHaveBeenCalledWith(400);
+  });
+
+  it("graceful-kill-by-project forwards preserveSession to the registry (#10054)", async () => {
+    const ctx = makeCtx();
+    (ctx.ptyManager.getTerminalsForProject as ReturnType<typeof vi.fn>).mockReturnValue([]);
+    (ctx.ptyManager.gracefulKillByProject as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    await dispatch({
+      type: "graceful-kill-by-project",
+      projectId: "proj-1",
+      requestId: "r1",
+      preserveSession: true,
+    });
+
+    expect(ctx.ptyManager.gracefulKillByProject).toHaveBeenCalledWith("proj-1", {
+      preserveSession: true,
+    });
   });
 
   it("graceful-kill-by-project handles empty project", async () => {

--- a/electron/pty-host/handlers/__tests__/terminalInfo.test.ts
+++ b/electron/pty-host/handlers/__tests__/terminalInfo.test.ts
@@ -49,6 +49,8 @@ function makeTerminal(overrides: Record<string, unknown> = {}) {
     agentState: "idle",
     waitingReason: undefined,
     lastStateChange: 0,
+    lastInputTime: 0,
+    lastOutputTime: 0,
     spawnedAt: 0,
     isTrashed: undefined,
     trashExpiresAt: undefined,
@@ -131,6 +133,16 @@ describe("mapTerminalInfo", () => {
 
     expect(result.activityTier).toBe("background");
     expect(getActivityTier).toHaveBeenCalledWith("term-42");
+  });
+
+  it("forwards lastInputTime/lastOutputTime so idle detection can run (#10054)", () => {
+    // IdleTerminalNotificationService reads these off get-all-terminals; if the
+    // mapper drops them, idle computation falls back to "unknown activity" and
+    // notifications never fire.
+    const ctx = createCtx();
+    const result = mapTerminalInfo(makeTerminal({ lastInputTime: 111, lastOutputTime: 222 }), ctx);
+    expect(result.lastInputTime).toBe(111);
+    expect(result.lastOutputTime).toBe(222);
   });
 
   it("narrows detectedAgentId to BuiltInAgentId, dropping unknown values", () => {

--- a/electron/pty-host/handlers/lifecycle.ts
+++ b/electron/pty-host/handlers/lifecycle.ts
@@ -102,7 +102,9 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
         const pid = ptyManager.getTerminal(id)?.ptyProcess.pid;
         if (pid !== undefined) pids.push(pid);
       }
-      const results = await ptyManager.gracefulKillByProject(msg.projectId);
+      const results = await ptyManager.gracefulKillByProject(msg.projectId, {
+        preserveSession: msg.preserveSession,
+      });
       for (const pid of pids) {
         resourceGovernor.trackKilledPid(pid);
       }

--- a/electron/pty-host/handlers/terminalInfo.ts
+++ b/electron/pty-host/handlers/terminalInfo.ts
@@ -30,6 +30,8 @@ export function mapTerminalInfo(t: NonNullable<TerminalInfoLike>, ctx: HostConte
     agentState: t.agentState,
     waitingReason: t.waitingReason,
     lastStateChange: t.lastStateChange,
+    lastInputTime: t.lastInputTime,
+    lastOutputTime: t.lastOutputTime,
     spawnedAt: t.spawnedAt,
     isTrashed: ctx.ptyManager.isInTrash(t.id),
     trashExpiresAt: t.trashExpiresAt,

--- a/electron/services/DiagnosticsCollector.ts
+++ b/electron/services/DiagnosticsCollector.ts
@@ -4,7 +4,7 @@ import { promisify } from "util";
 import { app, screen } from "electron";
 import { sanitizePath } from "./TelemetryService.js";
 import { logBuffer } from "./LogBuffer.js";
-import { getPtyManager } from "./PtyManager.js";
+import type { PtyClient } from "./PtyClient.js";
 import { scrubSecrets } from "../../shared/utils/secretScrubber.js";
 import { store, windowStatesStore } from "../store.js";
 import type { HandlerDependencies } from "../ipc/types.js";
@@ -401,16 +401,16 @@ async function collectStoreConfig() {
   }
 }
 
-async function collectTerminals() {
+async function collectTerminals(ptyClient?: PtyClient) {
   try {
-    const ptyManager = getPtyManager();
-    const terminals = ptyManager.getAll();
+    if (!ptyClient) return [];
+    const terminals = await ptyClient.getAllTerminalsAsync();
     return terminals.map((t) => ({
       id: t.id,
       kind: t.kind,
       agentState: t.agentState,
       cwd: t.cwd ? sanitizePath(t.cwd) : null,
-      isExited: t.isExited,
+      isExited: t.hasPty === false,
     }));
   } catch {
     return { error: "Failed to get terminal info" };
@@ -474,7 +474,7 @@ export async function collectDiagnosticsWithKeys(
     { key: "tools", fn: collectTools },
     { key: "git", fn: collectGit },
     { key: "config", fn: collectStoreConfig },
-    { key: "terminals", fn: collectTerminals },
+    { key: "terminals", fn: () => collectTerminals(deps.ptyClient) },
     { key: "logs", fn: collectLogs },
     { key: "events", fn: () => collectEvents(deps) },
   ];

--- a/electron/services/HibernationService.ts
+++ b/electron/services/HibernationService.ts
@@ -153,6 +153,10 @@ export class HibernationService {
   start(): void {
     if (this.checkInterval) return;
 
+    // Re-acquire the PtyClient on (re)start — stop() clears it, so a Settings
+    // toggle off→on would otherwise leave checkAndHibernate() guarded-out forever.
+    this.ptyClient ??= getPtyClient();
+
     const config = this.getConfig();
     if (!config.enabled) {
       logInfo("auto-hibernation-disabled");

--- a/electron/services/HibernationService.ts
+++ b/electron/services/HibernationService.ts
@@ -9,6 +9,8 @@ import { logInfo, logError } from "../utils/logger.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { writeHibernatedMarker } from "./pty/terminalSessionPersistence.js";
+import type { PtyClient } from "./PtyClient.js";
+import { getPtyClient } from "../window/serviceRefs.js";
 
 export interface HibernationConfig {
   enabled: boolean;
@@ -53,6 +55,17 @@ export class HibernationService {
   private readonly CHECK_INTERVAL_MS = 60 * 60 * 1000; // Every hour
   private readonly hibernationCallbacks: Array<(projectId: string) => void | Promise<void>> = [];
   private memoryPressureInactiveMs = DEFAULT_MEMORY_PRESSURE_INACTIVE_MS;
+  private ptyClient: PtyClient | null = null;
+
+  /**
+   * Inject the live PtyClient so hibernation reads the real terminal registry
+   * in the pty-host process and routes kills through it. The main-process
+   * `getPtyManager()` singleton is never populated (#10054). Passing `null`
+   * clears the reference on shutdown.
+   */
+  setPtyClient(client: PtyClient | null): void {
+    this.ptyClient = client;
+  }
 
   setMemoryPressureThresholdMs(ms: number): void {
     this.memoryPressureInactiveMs = ms;
@@ -178,6 +191,10 @@ export class HibernationService {
       clearTimeout(this.initialCheckTimer);
       this.initialCheckTimer = null;
     }
+
+    // Clear the injected PtyClient ref on shutdown so we don't pin a stale
+    // host client across a restart (lesson #8637).
+    this.ptyClient = null;
   }
 
   private async checkAndHibernate(): Promise<void> {
@@ -192,11 +209,9 @@ export class HibernationService {
     const now = Date.now();
     const thresholdMs = config.inactiveThresholdHours * 60 * 60 * 1000;
 
-    // Dynamically import to avoid circular dependencies
-    const { getPtyManager } = await import("./PtyManager.js");
-
-    const ptyManager = getPtyManager();
-    const allTerminals = ptyManager.getAll();
+    if (!this.ptyClient) return;
+    const ptyClient = this.ptyClient;
+    const allTerminals = await ptyClient.getAllTerminalsAsync();
 
     for (const project of projects) {
       // Never hibernate the active project
@@ -247,7 +262,7 @@ export class HibernationService {
           project.id,
           project.name,
           "scheduled",
-          ptyManager
+          ptyClient
         );
 
         logInfo("scheduled-hibernate-complete", {
@@ -269,9 +284,9 @@ export class HibernationService {
     const projects = projectStore.getAllProjects();
     const now = Date.now();
 
-    const { getPtyManager } = await import("./PtyManager.js");
-    const ptyManager = getPtyManager();
-    const allTerminals = ptyManager.getAll();
+    if (!this.ptyClient) return;
+    const ptyClient = this.ptyClient;
+    const allTerminals = await ptyClient.getAllTerminalsAsync();
 
     for (const project of projects) {
       if (project.id === currentProjectId) continue;
@@ -305,7 +320,7 @@ export class HibernationService {
       });
 
       try {
-        await this.hibernateProject(project.id, project.name, "memory-pressure", ptyManager);
+        await this.hibernateProject(project.id, project.name, "memory-pressure", ptyClient);
       } catch (error) {
         logError("memory-pressure-hibernate-failed", error, {
           project: project.name,
@@ -317,31 +332,27 @@ export class HibernationService {
 
   /**
    * Public entry point for hibernating a project on demand (e.g. from the
-   * idle-terminal "Close Them" action). Dynamically resolves PtyManager and
-   * runs the same flow as scheduled hibernation so DevPreview callbacks fire
-   * and the renderer sees the standard `hibernation:project-hibernated` event.
+   * idle-terminal "Close Them" action). Routes through the injected PtyClient
+   * and runs the same flow as scheduled hibernation so DevPreview callbacks
+   * fire and the renderer sees the standard `hibernation:project-hibernated`
+   * event. No-op if the PtyClient has not been injected yet.
    */
   async hibernateProjectOnDemand(
     projectId: string,
     projectName: string,
     reason: "scheduled" | "memory-pressure" = "scheduled"
   ): Promise<number> {
-    const { getPtyManager } = await import("./PtyManager.js");
-    return this.hibernateProject(projectId, projectName, reason, getPtyManager());
+    if (!this.ptyClient) return 0;
+    return this.hibernateProject(projectId, projectName, reason, this.ptyClient);
   }
 
   private async hibernateProject(
     projectId: string,
     projectName: string,
     reason: "scheduled" | "memory-pressure",
-    ptyManager: {
-      gracefulKillByProject: (
-        id: string,
-        opts?: { preserveSession?: boolean }
-      ) => Promise<Array<{ id: string; agentSessionId: string | null }>>;
-    }
+    ptyClient: PtyClient
   ): Promise<number> {
-    const results = await ptyManager.gracefulKillByProject(projectId, { preserveSession: true });
+    const results = await ptyClient.gracefulKillByProject(projectId, { preserveSession: true });
     const terminalsKilled = results.length;
 
     // Write hibernation markers for each killed terminal
@@ -413,6 +424,7 @@ export function getHibernationService(): HibernationService {
 
 export function initializeHibernationService(): HibernationService {
   const service = getHibernationService();
+  service.setPtyClient(getPtyClient());
   service.start();
   return service;
 }

--- a/electron/services/IdleTerminalNotificationService.ts
+++ b/electron/services/IdleTerminalNotificationService.ts
@@ -5,6 +5,8 @@ import type {
   IdleTerminalNotifyPayload,
   IdleTerminalProjectEntry,
 } from "../../shared/types/ipc/idleTerminals.js";
+import type { PtyClient } from "./PtyClient.js";
+import { getPtyClient } from "../window/serviceRefs.js";
 import { store } from "../store.js";
 import { projectStore } from "./ProjectStore.js";
 import { getSystemSleepService } from "./SystemSleepService.js";
@@ -22,17 +24,6 @@ const MAX_THRESHOLD_MINUTES = 1440; // 24h
 const MIN_COOLDOWN_MINUTES = 60;
 
 const ACTIVE_AGENT_STATES: ReadonlySet<AgentState> = new Set(["working", "waiting", "directing"]);
-
-interface PtyManagerLike {
-  getAll: () => Array<{
-    id: string;
-    projectId?: string;
-    agentState?: AgentState;
-    lastInputTime: number;
-    lastOutputTime: number;
-    hasPty?: boolean;
-  }>;
-}
 
 /**
  * IdleTerminalNotificationService — Notifies users when background-project terminals
@@ -64,6 +55,16 @@ export class IdleTerminalNotificationService {
   private readonly INITIAL_CHECK_DELAY_MS = 5_000;
   private readonly WAKE_QUIET_MS = 30_000;
   private currentCheckIntervalMs = this.CHECK_INTERVAL_MS;
+  private ptyClient: PtyClient | null = null;
+
+  /**
+   * Inject the live PtyClient so idle checks read the real terminal registry
+   * in the pty-host process. The main-process `getPtyManager()` singleton is
+   * never populated (#10054). Passing `null` clears the reference on shutdown.
+   */
+  setPtyClient(client: PtyClient | null): void {
+    this.ptyClient = client;
+  }
 
   private normalizeThreshold(value: unknown, fallback: number): number {
     if (typeof value !== "number" || !Number.isFinite(value)) {
@@ -192,6 +193,10 @@ export class IdleTerminalNotificationService {
       this.removeWakeListener();
       this.removeWakeListener = null;
     }
+
+    // Clear the injected PtyClient ref on shutdown so we don't pin a stale
+    // host client across a restart (lesson #8637).
+    this.ptyClient = null;
   }
 
   updatePollInterval(ms: number): void {
@@ -309,9 +314,8 @@ export class IdleTerminalNotificationService {
     const projects = projectStore.getAllProjects();
     if (projects.length === 0) return;
 
-    const { getPtyManager } = await import("./PtyManager.js");
-    const ptyManager = getPtyManager() as unknown as PtyManagerLike;
-    const allTerminals = ptyManager.getAll();
+    if (!this.ptyClient) return;
+    const allTerminals = await this.ptyClient.getAllTerminalsAsync();
 
     const qualifying: IdleTerminalProjectEntry[] = [];
 
@@ -387,6 +391,7 @@ export function getIdleTerminalNotificationService(): IdleTerminalNotificationSe
 
 export function initializeIdleTerminalNotificationService(): IdleTerminalNotificationService {
   const service = getIdleTerminalNotificationService();
+  service.setPtyClient(getPtyClient());
   service.start();
   return service;
 }

--- a/electron/services/IdleTerminalNotificationService.ts
+++ b/electron/services/IdleTerminalNotificationService.ts
@@ -119,6 +119,11 @@ export class IdleTerminalNotificationService {
 
   start(): void {
     if (this.checkInterval) return;
+
+    // Re-acquire the PtyClient on (re)start — stop() clears it, so a Settings
+    // toggle off→on would otherwise leave checkAndNotify() guarded-out forever.
+    this.ptyClient ??= getPtyClient();
+
     const config = this.getConfig();
     if (!config.enabled) {
       logInfo("idle-terminal-notify-disabled");

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -87,6 +87,8 @@ interface TerminalInfoResponse {
   agentState?: AgentState;
   waitingReason?: string;
   lastStateChange?: number;
+  lastInputTime?: number;
+  lastOutputTime?: number;
   spawnedAt: number;
   isTrashed?: boolean;
   trashExpiresAt?: number;
@@ -895,7 +897,8 @@ export class PtyClient extends EventEmitter {
   }
 
   async gracefulKillByProject(
-    projectId: string
+    projectId: string,
+    options?: { preserveSession?: boolean }
   ): Promise<Array<{ id: string; agentSessionId: string | null }>> {
     const requestId = this.broker.generateId(`graceful-kill-by-project-${projectId}`);
     const promise = this.broker.register<Array<{ id: string; agentSessionId: string | null }>>(
@@ -905,7 +908,14 @@ export class PtyClient extends EventEmitter {
         timeoutMs: PTY_TIMEOUTS["graceful-kill-by-project"],
       }
     );
-    this.send({ type: "graceful-kill-by-project", projectId, requestId });
+    this.send({
+      type: "graceful-kill-by-project",
+      projectId,
+      requestId,
+      ...(options?.preserveSession !== undefined
+        ? { preserveSession: options.preserveSession }
+        : {}),
+    });
     return promise.catch(() => []);
   }
 

--- a/electron/services/__tests__/DiagnosticsCollector.adversarial.test.ts
+++ b/electron/services/__tests__/DiagnosticsCollector.adversarial.test.ts
@@ -14,7 +14,7 @@ const shared = vi.hoisted(() => ({
     kind: string;
     agentState?: string;
     cwd?: string;
-    isExited: boolean;
+    hasPty?: boolean;
   }>,
   storeValues: new Map<string, unknown>(),
 }));
@@ -77,12 +77,6 @@ vi.mock("../LogBuffer.js", () => ({
   },
 }));
 
-vi.mock("../PtyManager.js", () => ({
-  getPtyManager: vi.fn(() => ({
-    getAll: () => shared.terminals,
-  })),
-}));
-
 vi.mock("../../store.js", () => ({
   store: {
     get: vi.fn((key: string) => shared.storeValues.get(key)),
@@ -98,7 +92,10 @@ type DiagnosticsCollectorModule = typeof import("../DiagnosticsCollector.js");
 function createDeps(eventBuffer?: { getAll: () => unknown[] }) {
   return {
     eventBuffer,
-  } as import("../../ipc/types.js").HandlerDependencies;
+    ptyClient: {
+      getAllTerminalsAsync: async () => shared.terminals,
+    },
+  } as unknown as import("../../ipc/types.js").HandlerDependencies;
 }
 
 function setDefaultExecFile(): void {
@@ -131,6 +128,40 @@ describe("DiagnosticsCollector adversarial", () => {
     shared.storeValues.set("appState", { recentProject: "/Users/alice/project" });
     setDefaultExecFile();
     diagnostics = await import("../DiagnosticsCollector.js");
+  });
+
+  it("TERMINALS_POPULATED_FROM_PTY_CLIENT (#10054)", async () => {
+    // Regression: the bundle read the never-populated main-process PtyManager
+    // singleton, so terminals was always []. It must now reflect the pty-host
+    // registry surfaced via ptyClient.getAllTerminalsAsync().
+    shared.terminals = [
+      { id: "t1", kind: "agent", agentState: "working", cwd: "/Users/alice/p", hasPty: true },
+      { id: "t2", kind: "terminal", cwd: "/Users/alice/p", hasPty: false },
+    ];
+
+    const payload = (await diagnostics.collectDiagnostics(createDeps())) as {
+      terminals: Array<{ id: string; agentState?: string; isExited: boolean; cwd: string | null }>;
+    };
+
+    expect(payload.terminals).toHaveLength(2);
+    expect(payload.terminals[0]).toMatchObject({
+      id: "t1",
+      agentState: "working",
+      isExited: false,
+    });
+    // hasPty:false maps to isExited:true.
+    expect(payload.terminals[1]).toMatchObject({ id: "t2", isExited: true });
+    // Path sanitized via the TelemetryService mock.
+    expect(payload.terminals[0].cwd).toBe("/Users/<redacted>/p");
+  });
+
+  it("TERMINALS_EMPTY_WHEN_PTY_CLIENT_ABSENT (#10054)", async () => {
+    const payload = (await diagnostics.collectDiagnostics({
+      eventBuffer: undefined,
+    } as unknown as import("../../ipc/types.js").HandlerDependencies)) as {
+      terminals: unknown[];
+    };
+    expect(payload.terminals).toEqual([]);
   });
 
   it("LOG_HISTORY_BOUNDED_TO_100", async () => {

--- a/electron/services/__tests__/HibernationService.test.ts
+++ b/electron/services/__tests__/HibernationService.test.ts
@@ -28,6 +28,10 @@ const ptyManagerMock = vi.hoisted(() => ({
   off: vi.fn(),
 }));
 
+vi.mock("../../window/serviceRefs.js", () => ({
+  getPtyClient: () => ptyManagerMock,
+}));
+
 vi.mock("../../store.js", () => ({
   store: storeMock,
 }));
@@ -151,6 +155,25 @@ describe("HibernationService", () => {
       enabled: true,
       inactiveThresholdHours: 72,
     });
+  });
+
+  it("re-acquires PtyClient after a Settings toggle off→on (#10054)", async () => {
+    // stop() clears the injected PtyClient; start() must re-acquire it via
+    // getPtyClient() or checkAndHibernate() stays guarded-out forever.
+    (storeMock.get as Mock).mockReturnValue({ enabled: true, inactiveThresholdHours: 24 });
+    ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([]);
+    projectStoreMock.getAllProjects.mockReturnValue([]);
+
+    const service = makeService();
+    service.start();
+    service.updateConfig({ enabled: false }); // → stop(), clears ptyClient
+    service.updateConfig({ enabled: true }); // → start(), must re-acquire
+
+    ptyManagerMock.getAllTerminalsAsync.mockClear();
+    await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
+
+    expect(ptyManagerMock.getAllTerminalsAsync).toHaveBeenCalled();
+    service.stop();
   });
 
   it("does not call clearProjectState during hibernation", async () => {

--- a/electron/services/__tests__/HibernationService.test.ts
+++ b/electron/services/__tests__/HibernationService.test.ts
@@ -19,11 +19,13 @@ const fsMock = vi.hoisted(() => ({
 }));
 
 const ptyManagerMock = vi.hoisted(() => ({
-  getAll: vi.fn<() => unknown[]>(() => []),
+  getAllTerminalsAsync: vi.fn<() => Promise<unknown[]>>(async () => []),
   getProjectStats: vi.fn(() => ({ terminalCount: 0 })),
   gracefulKillByProject: vi.fn(
     async () => [] as Array<{ id: string; agentSessionId: string | null }>
   ),
+  on: vi.fn(),
+  off: vi.fn(),
 }));
 
 vi.mock("../../store.js", () => ({
@@ -41,10 +43,6 @@ const writeHibernatedMarkerMock = vi.hoisted(() => vi.fn());
 vi.mock("../../utils/logger.js", () => ({
   logInfo: vi.fn(),
   logError: vi.fn(),
-}));
-
-vi.mock("../PtyManager.js", () => ({
-  getPtyManager: () => ptyManagerMock,
 }));
 
 vi.mock("fs/promises", () => ({
@@ -68,6 +66,14 @@ vi.mock("../pty/terminalSessionPersistence.js", () => ({
 
 import { logInfo, logError } from "../../utils/logger.js";
 import { HibernationService } from "../HibernationService.js";
+import type { PtyClient } from "../PtyClient.js";
+
+/** Construct a service with the PtyClient-shaped mock injected (#10054). */
+function makeService(): HibernationService {
+  const service = new HibernationService();
+  service.setPtyClient(ptyManagerMock as unknown as PtyClient);
+  return service;
+}
 
 describe("HibernationService", () => {
   beforeEach(() => {
@@ -93,7 +99,7 @@ describe("HibernationService", () => {
       inactiveThresholdHours: Number.NaN,
     });
 
-    const service = new HibernationService();
+    const service = makeService();
 
     expect(service.getConfig()).toEqual({
       enabled: false,
@@ -107,7 +113,7 @@ describe("HibernationService", () => {
       inactiveThresholdHours: 500,
     });
 
-    const service = new HibernationService();
+    const service = makeService();
 
     expect(service.getConfig()).toEqual({
       enabled: true,
@@ -117,7 +123,7 @@ describe("HibernationService", () => {
 
   it("ignores invalid update payload values", () => {
     (storeMock.get as Mock).mockReturnValue(undefined);
-    const service = new HibernationService();
+    const service = makeService();
 
     service.updateConfig({
       enabled: "true" as unknown as boolean,
@@ -135,7 +141,7 @@ describe("HibernationService", () => {
       enabled: true,
       inactiveThresholdHours: 72,
     });
-    const service = new HibernationService();
+    const service = makeService();
 
     service.updateConfig({
       inactiveThresholdHours: Number.NaN,
@@ -148,7 +154,7 @@ describe("HibernationService", () => {
   });
 
   it("does not call clearProjectState during hibernation", async () => {
-    ptyManagerMock.getAll.mockReturnValue([
+    ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([
       { id: "t1", projectId: "proj-1", agentState: "idle" },
       { id: "t2", projectId: "proj-1", agentState: "idle" },
     ]);
@@ -169,7 +175,7 @@ describe("HibernationService", () => {
     projectStoreMock.getCurrentProjectId.mockReturnValue("active-proj");
     projectStoreMock.getAllProjects.mockReturnValue([inactiveProject]);
 
-    const service = new HibernationService();
+    const service = makeService();
     await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
 
     expect(ptyManagerMock.gracefulKillByProject).toHaveBeenCalledWith("proj-1", {
@@ -181,7 +187,7 @@ describe("HibernationService", () => {
   it.each([0, null, undefined, NaN])(
     "skips projects with falsy lastOpened (%s) in checkAndHibernate",
     async (falsyValue) => {
-      ptyManagerMock.getAll.mockReturnValue([
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([
         { id: "t1", projectId: "proj-valid-1", agentState: "idle" },
         { id: "t2", projectId: "proj-falsy", agentState: "idle" },
         { id: "t3", projectId: "proj-valid-2", agentState: "idle" },
@@ -219,7 +225,7 @@ describe("HibernationService", () => {
         validOldProject2,
       ]);
 
-      const service = new HibernationService();
+      const service = makeService();
       await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
 
       expect(ptyManagerMock.gracefulKillByProject).toHaveBeenCalledWith("proj-valid-1", {
@@ -238,7 +244,7 @@ describe("HibernationService", () => {
       enabled: true,
       inactiveThresholdHours: 24,
     });
-    const service = new HibernationService();
+    const service = makeService();
     const checkSpy = vi.spyOn(service as never, "checkAndHibernate" as never);
 
     service.start();
@@ -263,7 +269,7 @@ describe("HibernationService", () => {
     }
 
     it("runs even when auto-hibernation is disabled", async () => {
-      ptyManagerMock.getAll.mockReturnValue([makeTerminal({ agentState: "idle" })]);
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([makeTerminal({ agentState: "idle" })]);
       ptyManagerMock.gracefulKillByProject.mockResolvedValue([{ id: "t1", agentSessionId: null }]);
 
       (storeMock.get as Mock).mockReturnValue({
@@ -281,7 +287,7 @@ describe("HibernationService", () => {
         },
       ]);
 
-      const service = new HibernationService();
+      const service = makeService();
       await service.hibernateUnderMemoryPressure();
 
       expect(ptyManagerMock.gracefulKillByProject).toHaveBeenCalledWith("proj-1", {
@@ -290,7 +296,9 @@ describe("HibernationService", () => {
     });
 
     it("skips the current active project", async () => {
-      ptyManagerMock.getAll.mockReturnValue([makeTerminal({ projectId: "active-proj" })]);
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([
+        makeTerminal({ projectId: "active-proj" }),
+      ]);
 
       (storeMock.get as Mock).mockReturnValue({ enabled: true, inactiveThresholdHours: 24 });
       projectStoreMock.getCurrentProjectId.mockReturnValue("active-proj");
@@ -303,14 +311,14 @@ describe("HibernationService", () => {
         },
       ]);
 
-      const service = new HibernationService();
+      const service = makeService();
       await service.hibernateUnderMemoryPressure();
 
       expect(ptyManagerMock.gracefulKillByProject).not.toHaveBeenCalled();
     });
 
     it("skips projects inactive less than 30 minutes", async () => {
-      ptyManagerMock.getAll.mockReturnValue([makeTerminal()]);
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([makeTerminal()]);
 
       (storeMock.get as Mock).mockReturnValue({ enabled: true, inactiveThresholdHours: 24 });
       projectStoreMock.getCurrentProjectId.mockReturnValue("other-proj");
@@ -323,7 +331,7 @@ describe("HibernationService", () => {
         },
       ]);
 
-      const service = new HibernationService();
+      const service = makeService();
       await service.hibernateUnderMemoryPressure();
 
       expect(ptyManagerMock.gracefulKillByProject).not.toHaveBeenCalled();
@@ -332,7 +340,7 @@ describe("HibernationService", () => {
     it.each(["working", "waiting", "directing"] as const)(
       "skips projects with %s agent terminals",
       async (agentState) => {
-        ptyManagerMock.getAll.mockReturnValue([makeTerminal({ agentState })]);
+        ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([makeTerminal({ agentState })]);
 
         (storeMock.get as Mock).mockReturnValue({ enabled: true, inactiveThresholdHours: 24 });
         projectStoreMock.getCurrentProjectId.mockReturnValue("other-proj");
@@ -345,7 +353,7 @@ describe("HibernationService", () => {
           },
         ]);
 
-        const service = new HibernationService();
+        const service = makeService();
         await service.hibernateUnderMemoryPressure();
 
         expect(ptyManagerMock.gracefulKillByProject).not.toHaveBeenCalled();
@@ -353,7 +361,7 @@ describe("HibernationService", () => {
     );
 
     it("hibernates eligible idle projects", async () => {
-      ptyManagerMock.getAll.mockReturnValue([makeTerminal({ agentState: "idle" })]);
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([makeTerminal({ agentState: "idle" })]);
       ptyManagerMock.gracefulKillByProject.mockResolvedValue([{ id: "t1", agentSessionId: null }]);
 
       (storeMock.get as Mock).mockReturnValue({ enabled: true, inactiveThresholdHours: 24 });
@@ -367,7 +375,7 @@ describe("HibernationService", () => {
         },
       ]);
 
-      const service = new HibernationService();
+      const service = makeService();
       await service.hibernateUnderMemoryPressure();
 
       expect(ptyManagerMock.gracefulKillByProject).toHaveBeenCalledWith("proj-1", {
@@ -393,7 +401,11 @@ describe("HibernationService", () => {
           projectId: "proj-valid-2",
           agentState: "idle",
         });
-        ptyManagerMock.getAll.mockReturnValue([validTerminal, falsyTerminal, validTerminal2]);
+        ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([
+          validTerminal,
+          falsyTerminal,
+          validTerminal2,
+        ]);
         ptyManagerMock.gracefulKillByProject.mockResolvedValue([
           { id: "t1", agentSessionId: null },
         ]);
@@ -421,7 +433,7 @@ describe("HibernationService", () => {
           },
         ]);
 
-        const service = new HibernationService();
+        const service = makeService();
         await service.hibernateUnderMemoryPressure();
 
         expect(ptyManagerMock.gracefulKillByProject).toHaveBeenCalledWith("proj-valid-1", {
@@ -436,7 +448,7 @@ describe("HibernationService", () => {
     );
 
     it("skips projects with no terminals", async () => {
-      ptyManagerMock.getAll.mockReturnValue([]);
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([]);
 
       (storeMock.get as Mock).mockReturnValue({ enabled: true, inactiveThresholdHours: 24 });
       projectStoreMock.getCurrentProjectId.mockReturnValue("other-proj");
@@ -449,14 +461,14 @@ describe("HibernationService", () => {
         },
       ]);
 
-      const service = new HibernationService();
+      const service = makeService();
       await service.hibernateUnderMemoryPressure();
 
       expect(ptyManagerMock.gracefulKillByProject).not.toHaveBeenCalled();
     });
 
     it("skips projects with active git operations", async () => {
-      ptyManagerMock.getAll.mockReturnValue([makeTerminal({ agentState: "idle" })]);
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([makeTerminal({ agentState: "idle" })]);
       ptyManagerMock.gracefulKillByProject.mockResolvedValue([{ id: "t1", agentSessionId: null }]);
 
       fsMock.readdir.mockImplementation(async (dirPath: string) => {
@@ -475,7 +487,7 @@ describe("HibernationService", () => {
         },
       ]);
 
-      const service = new HibernationService();
+      const service = makeService();
       await service.hibernateUnderMemoryPressure();
 
       expect(ptyManagerMock.gracefulKillByProject).not.toHaveBeenCalled();
@@ -502,9 +514,11 @@ describe("HibernationService", () => {
       "skips projects with %s agent in scheduled hibernation",
       async (agentState) => {
         setupScheduledTest();
-        ptyManagerMock.getAll.mockReturnValue([{ id: "t1", projectId: "proj-1", agentState }]);
+        ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([
+          { id: "t1", projectId: "proj-1", agentState },
+        ]);
 
-        const service = new HibernationService();
+        const service = makeService();
         await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
 
         expect(ptyManagerMock.gracefulKillByProject).not.toHaveBeenCalled();
@@ -513,12 +527,12 @@ describe("HibernationService", () => {
 
     it("proceeds with idle agents in scheduled hibernation", async () => {
       setupScheduledTest();
-      ptyManagerMock.getAll.mockReturnValue([
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([
         { id: "t1", projectId: "proj-1", agentState: "idle" },
       ]);
       ptyManagerMock.gracefulKillByProject.mockResolvedValue([{ id: "t1", agentSessionId: null }]);
 
-      const service = new HibernationService();
+      const service = makeService();
       await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
 
       expect(ptyManagerMock.gracefulKillByProject).toHaveBeenCalledWith("proj-1", {
@@ -542,7 +556,7 @@ describe("HibernationService", () => {
           lastOpened: Date.now() - TWENTY_FIVE_HOURS,
         },
       ]);
-      ptyManagerMock.getAll.mockReturnValue([
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([
         { id: "t1", projectId: "proj-1", agentState: "idle" },
       ]);
       ptyManagerMock.gracefulKillByProject.mockResolvedValue([{ id: "t1", agentSessionId: null }]);
@@ -559,7 +573,7 @@ describe("HibernationService", () => {
           lastOpened: Date.now() - THIRTY_ONE_MINUTES,
         },
       ]);
-      ptyManagerMock.getAll.mockReturnValue([
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([
         { id: "t1", projectId: "proj-1", agentState: "idle" },
       ]);
       ptyManagerMock.gracefulKillByProject.mockResolvedValue([{ id: "t1", agentSessionId: null }]);
@@ -579,7 +593,7 @@ describe("HibernationService", () => {
         throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
       });
 
-      const service = new HibernationService();
+      const service = makeService();
       await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
 
       expect(ptyManagerMock.gracefulKillByProject).not.toHaveBeenCalled();
@@ -593,7 +607,7 @@ describe("HibernationService", () => {
       });
       fsMock.stat.mockResolvedValue({ mtimeMs: Date.now() - 5000 }); // 5 seconds ago
 
-      const service = new HibernationService();
+      const service = makeService();
       await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
 
       expect(ptyManagerMock.gracefulKillByProject).not.toHaveBeenCalled();
@@ -609,7 +623,7 @@ describe("HibernationService", () => {
       // Lock is older than the 24h threshold
       fsMock.stat.mockResolvedValue({ mtimeMs: Date.now() - thresholdMs - 1000 });
 
-      const service = new HibernationService();
+      const service = makeService();
       await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
 
       expect(ptyManagerMock.gracefulKillByProject).toHaveBeenCalledWith("proj-1", {
@@ -624,7 +638,7 @@ describe("HibernationService", () => {
         throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
       });
 
-      const service = new HibernationService();
+      const service = makeService();
       await service.hibernateUnderMemoryPressure();
 
       expect(ptyManagerMock.gracefulKillByProject).not.toHaveBeenCalled();
@@ -642,7 +656,7 @@ describe("HibernationService", () => {
         throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
       });
 
-      const service = new HibernationService();
+      const service = makeService();
       await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
 
       expect(ptyManagerMock.gracefulKillByProject).not.toHaveBeenCalled();
@@ -652,7 +666,7 @@ describe("HibernationService", () => {
       setupScheduledProject();
       // Default ENOENT for all readdir calls (set in beforeEach)
 
-      const service = new HibernationService();
+      const service = makeService();
       await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
 
       expect(ptyManagerMock.gracefulKillByProject).toHaveBeenCalledWith("proj-1", {
@@ -674,7 +688,7 @@ describe("HibernationService", () => {
         throw Object.assign(new Error("EACCES"), { code: "EACCES" });
       });
 
-      const service = new HibernationService();
+      const service = makeService();
       await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
 
       // fail-closed: readdir error on .git means we skip that gitdir and check next
@@ -701,7 +715,7 @@ describe("HibernationService", () => {
           lastOpened: Date.now() - TWENTY_FIVE_HOURS,
         },
       ]);
-      ptyManagerMock.getAll.mockReturnValue([
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([
         { id: "t1", projectId: "proj-1", agentState: "idle" },
         { id: "t2", projectId: "proj-2", agentState: "idle" },
       ]);
@@ -714,7 +728,7 @@ describe("HibernationService", () => {
         throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
       });
 
-      const service = new HibernationService();
+      const service = makeService();
       await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
 
       expect(ptyManagerMock.gracefulKillByProject).not.toHaveBeenCalledWith("proj-1");
@@ -732,7 +746,7 @@ describe("HibernationService", () => {
       // Lock is 31 minutes old — older than MEMORY_PRESSURE_INACTIVE_MS (30 min), so stale
       fsMock.stat.mockResolvedValue({ mtimeMs: Date.now() - THIRTY_ONE_MINUTES - 1000 });
 
-      const service = new HibernationService();
+      const service = makeService();
       await service.hibernateUnderMemoryPressure();
 
       expect(ptyManagerMock.gracefulKillByProject).toHaveBeenCalledWith("proj-1", {
@@ -749,7 +763,7 @@ describe("HibernationService", () => {
       // stat throws ENOENT — lock was deleted between readdir and stat
       fsMock.stat.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
 
-      const service = new HibernationService();
+      const service = makeService();
       await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
 
       // Lock disappeared, so no active git operation — proceed
@@ -762,21 +776,21 @@ describe("HibernationService", () => {
   describe("structured logging", () => {
     it("logs auto-hibernation-disabled when config is off", () => {
       (storeMock.get as Mock).mockReturnValue({ enabled: false, inactiveThresholdHours: 24 });
-      const service = new HibernationService();
+      const service = makeService();
       service.start();
       expect(logInfo).toHaveBeenCalledWith("auto-hibernation-disabled");
     });
 
     it("logs auto-hibernation-started when config is on", () => {
       (storeMock.get as Mock).mockReturnValue({ enabled: true, inactiveThresholdHours: 24 });
-      const service = new HibernationService();
+      const service = makeService();
       service.start();
       expect(logInfo).toHaveBeenCalledWith("auto-hibernation-started");
     });
 
     it("logs auto-hibernation-stopped on stop", () => {
       (storeMock.get as Mock).mockReturnValue({ enabled: true, inactiveThresholdHours: 24 });
-      const service = new HibernationService();
+      const service = makeService();
       service.start();
       service.stop();
       expect(logInfo).toHaveBeenCalledWith("auto-hibernation-stopped");
@@ -784,7 +798,7 @@ describe("HibernationService", () => {
 
     it("logs auto-hibernation-check-failed when interval check throws", async () => {
       (storeMock.get as Mock).mockReturnValue({ enabled: true, inactiveThresholdHours: 24 });
-      const service = new HibernationService();
+      const service = makeService();
       const testError = new Error("boom");
       (
         vi.spyOn(service as never, "checkAndHibernate" as never) as unknown as Mock
@@ -798,7 +812,7 @@ describe("HibernationService", () => {
 
     it("logs auto-hibernation-initial-check-failed when initial check throws", async () => {
       (storeMock.get as Mock).mockReturnValue({ enabled: true, inactiveThresholdHours: 24 });
-      const service = new HibernationService();
+      const service = makeService();
       const testError = new Error("init-boom");
       (
         vi.spyOn(service as never, "checkAndHibernate" as never) as unknown as Mock
@@ -821,12 +835,12 @@ describe("HibernationService", () => {
           lastOpened: Date.now() - 25 * 60 * 60 * 1000,
         },
       ]);
-      ptyManagerMock.getAll.mockReturnValue([
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([
         { id: "t1", projectId: "proj-1", agentState: "idle" },
       ]);
       ptyManagerMock.gracefulKillByProject.mockResolvedValue([{ id: "t1", agentSessionId: null }]);
 
-      const service = new HibernationService();
+      const service = makeService();
       await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
 
       expect(logInfo).toHaveBeenCalledWith("scheduled-hibernate-project", {
@@ -853,13 +867,13 @@ describe("HibernationService", () => {
           lastOpened: Date.now() - 25 * 60 * 60 * 1000,
         },
       ]);
-      ptyManagerMock.getAll.mockReturnValue([
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([
         { id: "t1", projectId: "proj-1", agentState: "idle" },
       ]);
       const testError = new Error("hibernate-boom");
       ptyManagerMock.gracefulKillByProject.mockRejectedValue(testError);
 
-      const service = new HibernationService();
+      const service = makeService();
       await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
 
       expect(logError).toHaveBeenCalledWith("scheduled-hibernate-failed", testError, {
@@ -874,7 +888,7 @@ describe("HibernationService", () => {
       storeMock.set.mockImplementation(() => {
         (storeMock.get as Mock).mockReturnValue({ enabled: false, inactiveThresholdHours: 48 });
       });
-      const service = new HibernationService();
+      const service = makeService();
       service.updateConfig({ inactiveThresholdHours: 48 });
 
       expect(logInfo).toHaveBeenCalledWith("hibernation-config-updated", {
@@ -898,7 +912,7 @@ describe("HibernationService", () => {
           lastOpened: Date.now() - TWENTY_FIVE_HOURS,
         },
       ]);
-      ptyManagerMock.getAll.mockReturnValue([
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([
         { id: "t1", projectId: "proj-1", agentState: "idle" },
         { id: "t2", projectId: "proj-1", agentState: "idle" },
       ]);
@@ -911,7 +925,7 @@ describe("HibernationService", () => {
     it("writes hibernation markers for each killed terminal", async () => {
       setupHibernation();
 
-      const service = new HibernationService();
+      const service = makeService();
       await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
 
       expect(writeHibernatedMarkerMock).toHaveBeenCalledWith("t1");
@@ -921,7 +935,7 @@ describe("HibernationService", () => {
     it("emits event to renderer with correct payload", async () => {
       setupHibernation();
 
-      const service = new HibernationService();
+      const service = makeService();
       await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
 
       expect(broadcastToRendererMock).toHaveBeenCalledWith(
@@ -946,12 +960,12 @@ describe("HibernationService", () => {
           lastOpened: Date.now() - 31 * 60 * 1000,
         },
       ]);
-      ptyManagerMock.getAll.mockReturnValue([
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([
         { id: "t1", projectId: "proj-1", agentState: "idle" },
       ]);
       ptyManagerMock.gracefulKillByProject.mockResolvedValue([{ id: "t1", agentSessionId: null }]);
 
-      const service = new HibernationService();
+      const service = makeService();
       await service.hibernateUnderMemoryPressure();
 
       expect(broadcastToRendererMock).toHaveBeenCalledWith(
@@ -966,7 +980,7 @@ describe("HibernationService", () => {
       setupHibernation();
       const callback = vi.fn();
 
-      const service = new HibernationService();
+      const service = makeService();
       service.onProjectHibernated(callback);
       await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
 
@@ -977,7 +991,7 @@ describe("HibernationService", () => {
       setupHibernation();
       const callback = vi.fn();
 
-      const service = new HibernationService();
+      const service = makeService();
       const unsub = service.onProjectHibernated(callback);
       unsub();
       await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
@@ -990,7 +1004,7 @@ describe("HibernationService", () => {
       const failingCallback = vi.fn().mockRejectedValue(new Error("boom"));
       const successCallback = vi.fn();
 
-      const service = new HibernationService();
+      const service = makeService();
       service.onProjectHibernated(failingCallback);
       service.onProjectHibernated(successCallback);
       await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();

--- a/electron/services/__tests__/IdleTerminalNotificationService.test.ts
+++ b/electron/services/__tests__/IdleTerminalNotificationService.test.ts
@@ -22,6 +22,7 @@ const ptyManagerMock = vi.hoisted(() => ({
   off: vi.fn(),
 }));
 
+vi.mock("../../window/serviceRefs.js", () => ({ getPtyClient: () => ptyManagerMock }));
 vi.mock("../../store.js", () => ({ store: storeMock }));
 vi.mock("../ProjectStore.js", () => ({ projectStore: projectStoreMock }));
 
@@ -140,6 +141,30 @@ describe("IdleTerminalNotificationService", () => {
       service.updateConfig({ enabled: true });
       service.updateConfig({ enabled: false });
       expect((service as unknown as { checkInterval: unknown }).checkInterval).toBeNull();
+    });
+
+    it("re-acquires PtyClient after a toggle off→on (#10054)", async () => {
+      // stop() clears the injected PtyClient; start() must re-acquire it via
+      // getPtyClient() or checkAndNotify() stays guarded-out forever.
+      storeBacking.idleTerminalNotify = { enabled: true, thresholdMinutes: 60 };
+      projectStoreMock.getCurrentProjectId.mockReturnValue("active");
+      projectStoreMock.getAllProjects.mockReturnValue([makeProject("proj-1")]);
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([]);
+
+      const service = makeService();
+      service.start();
+      service.updateConfig({ enabled: false }); // → stop(), clears ptyClient
+      service.updateConfig({ enabled: true }); // → start(), must re-acquire
+
+      // Bypass the startup/wake quiet windows so the check body runs.
+      (service as unknown as { quietUntil: number | null }).quietUntil = null;
+      (service as unknown as { wakeQuietUntil: number | null }).wakeQuietUntil = null;
+
+      ptyManagerMock.getAllTerminalsAsync.mockClear();
+      await runCheck(service);
+
+      expect(ptyManagerMock.getAllTerminalsAsync).toHaveBeenCalled();
+      service.stop();
     });
   });
 

--- a/electron/services/__tests__/IdleTerminalNotificationService.test.ts
+++ b/electron/services/__tests__/IdleTerminalNotificationService.test.ts
@@ -14,10 +14,12 @@ const projectStoreMock = vi.hoisted(() => ({
 }));
 
 const ptyManagerMock = vi.hoisted(() => ({
-  getAll: vi.fn<() => unknown[]>(() => []),
+  getAllTerminalsAsync: vi.fn<() => Promise<unknown[]>>(async () => []),
   gracefulKillByProject: vi.fn(
     async () => [] as Array<{ id: string; agentSessionId: string | null }>
   ),
+  on: vi.fn(),
+  off: vi.fn(),
 }));
 
 vi.mock("../../store.js", () => ({ store: storeMock }));
@@ -30,10 +32,6 @@ const hibernateProjectOnDemandMock = vi.hoisted(() =>
 );
 
 vi.mock("../../utils/logger.js", () => ({ logInfo: vi.fn(), logError: vi.fn() }));
-
-vi.mock("../PtyManager.js", () => ({
-  getPtyManager: () => ptyManagerMock,
-}));
 
 vi.mock("../../ipc/utils.js", () => ({
   broadcastToRenderer: broadcastToRendererMock,
@@ -56,6 +54,14 @@ vi.mock("../HibernationService.js", () => ({
 }));
 
 import { IdleTerminalNotificationService } from "../IdleTerminalNotificationService.js";
+import type { PtyClient } from "../PtyClient.js";
+
+/** Construct a service with the PtyClient-shaped mock injected (#10054). */
+function makeService(): IdleTerminalNotificationService {
+  const service = new IdleTerminalNotificationService();
+  service.setPtyClient(ptyManagerMock as unknown as PtyClient);
+  return service;
+}
 
 const SIXTY_MIN_MS = 60 * 60 * 1000;
 
@@ -93,25 +99,25 @@ describe("IdleTerminalNotificationService", () => {
   describe("normalizeConfig", () => {
     it("returns defaults for malformed persisted config", () => {
       storeBacking.idleTerminalNotify = { enabled: "yes", thresholdMinutes: Number.NaN };
-      const service = new IdleTerminalNotificationService();
+      const service = makeService();
       // Default enabled is true (issue: idle notifications should be on by default)
       expect(service.getConfig()).toEqual({ enabled: true, thresholdMinutes: 60 });
     });
 
     it("clamps threshold to [15, 1440]", () => {
       storeBacking.idleTerminalNotify = { enabled: true, thresholdMinutes: 5 };
-      let service = new IdleTerminalNotificationService();
+      let service = makeService();
       expect(service.getConfig().thresholdMinutes).toBe(15);
 
       storeBacking.idleTerminalNotify = { enabled: true, thresholdMinutes: 9999 };
-      service = new IdleTerminalNotificationService();
+      service = makeService();
       expect(service.getConfig().thresholdMinutes).toBe(1440);
     });
   });
 
   describe("updateConfig", () => {
     it("ignores invalid values and persists normalized config", () => {
-      const service = new IdleTerminalNotificationService();
+      const service = makeService();
       service.updateConfig({
         enabled: "true" as unknown as boolean,
         thresholdMinutes: Number.NaN,
@@ -123,14 +129,14 @@ describe("IdleTerminalNotificationService", () => {
     });
 
     it("starts the service when toggled on", () => {
-      const service = new IdleTerminalNotificationService();
+      const service = makeService();
       service.updateConfig({ enabled: true });
       expect((service as unknown as { checkInterval: unknown }).checkInterval).not.toBeNull();
       service.stop();
     });
 
     it("stops the service when toggled off", () => {
-      const service = new IdleTerminalNotificationService();
+      const service = makeService();
       service.updateConfig({ enabled: true });
       service.updateConfig({ enabled: false });
       expect((service as unknown as { checkInterval: unknown }).checkInterval).toBeNull();
@@ -142,19 +148,19 @@ describe("IdleTerminalNotificationService", () => {
       storeBacking.idleTerminalNotify = { enabled: true, thresholdMinutes: 60 };
       projectStoreMock.getCurrentProjectId.mockReturnValue("active-proj");
       projectStoreMock.getAllProjects.mockReturnValue([makeProject("proj-1", "Old")]);
-      ptyManagerMock.getAll.mockReturnValue([makeTerminal()]);
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([makeTerminal()]);
     }
 
     it("does nothing when disabled", async () => {
       storeBacking.idleTerminalNotify = { enabled: false, thresholdMinutes: 60 };
-      const service = new IdleTerminalNotificationService();
+      const service = makeService();
       await runCheck(service);
       expect(broadcastToRendererMock).not.toHaveBeenCalled();
     });
 
     it("emits a single aggregate broadcast for one idle background project", async () => {
       setup();
-      const service = new IdleTerminalNotificationService();
+      const service = makeService();
       await runCheck(service);
 
       expect(broadcastToRendererMock).toHaveBeenCalledTimes(1);
@@ -176,12 +182,12 @@ describe("IdleTerminalNotificationService", () => {
         makeProject("proj-1"),
         makeProject("proj-2"),
       ]);
-      ptyManagerMock.getAll.mockReturnValue([
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([
         makeTerminal({ id: "t1", projectId: "proj-1" }),
         makeTerminal({ id: "t2", projectId: "proj-2" }),
       ]);
 
-      const service = new IdleTerminalNotificationService();
+      const service = makeService();
       await runCheck(service);
 
       expect(broadcastToRendererMock).toHaveBeenCalledTimes(1);
@@ -195,22 +201,24 @@ describe("IdleTerminalNotificationService", () => {
     it("skips the current active project", async () => {
       setup();
       projectStoreMock.getCurrentProjectId.mockReturnValue("proj-1");
-      const service = new IdleTerminalNotificationService();
+      const service = makeService();
       await runCheck(service);
       expect(broadcastToRendererMock).not.toHaveBeenCalled();
     });
 
     it("skips projects with active agent terminals", async () => {
       setup();
-      ptyManagerMock.getAll.mockReturnValue([makeTerminal({ agentState: "working" })]);
-      const service = new IdleTerminalNotificationService();
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([
+        makeTerminal({ agentState: "working" }),
+      ]);
+      const service = makeService();
       await runCheck(service);
       expect(broadcastToRendererMock).not.toHaveBeenCalled();
     });
 
     it("skips projects when any terminal is below the idle threshold", async () => {
       setup();
-      ptyManagerMock.getAll.mockReturnValue([
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([
         makeTerminal({ id: "t1" }),
         makeTerminal({
           id: "t2",
@@ -218,14 +226,14 @@ describe("IdleTerminalNotificationService", () => {
           lastOutputTime: Date.now() - 5 * 60 * 1000,
         }),
       ]);
-      const service = new IdleTerminalNotificationService();
+      const service = makeService();
       await runCheck(service);
       expect(broadcastToRendererMock).not.toHaveBeenCalled();
     });
 
     it("ignores hasPty:false (orphaned) terminals when evaluating idleness", async () => {
       setup();
-      ptyManagerMock.getAll.mockReturnValue([
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([
         makeTerminal({ id: "t1" }), // idle, has pty
         makeTerminal({
           id: "t2",
@@ -234,7 +242,7 @@ describe("IdleTerminalNotificationService", () => {
           lastOutputTime: Date.now(),
         }),
       ]);
-      const service = new IdleTerminalNotificationService();
+      const service = makeService();
       await runCheck(service);
       expect(broadcastToRendererMock).toHaveBeenCalledTimes(1);
       const [, payload] = broadcastToRendererMock.mock.calls[0];
@@ -243,7 +251,7 @@ describe("IdleTerminalNotificationService", () => {
 
     it("respects the dismissal cooldown", async () => {
       setup();
-      const service = new IdleTerminalNotificationService();
+      const service = makeService();
       service.dismissProject("proj-1");
       await runCheck(service);
       expect(broadcastToRendererMock).not.toHaveBeenCalled();
@@ -253,9 +261,9 @@ describe("IdleTerminalNotificationService", () => {
       storeBacking.idleTerminalNotify = { enabled: true, thresholdMinutes: 15 };
       projectStoreMock.getCurrentProjectId.mockReturnValue("active-proj");
       projectStoreMock.getAllProjects.mockReturnValue([makeProject("proj-1")]);
-      ptyManagerMock.getAll.mockReturnValue([makeTerminal()]);
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([makeTerminal()]);
 
-      const service = new IdleTerminalNotificationService();
+      const service = makeService();
       // Dismissal 30min ago — would be expired under threshold (15) but not under 60min floor.
       storeBacking.idleTerminalDismissals = { "proj-1": Date.now() - 30 * 60 * 1000 };
       await runCheck(service);
@@ -270,7 +278,7 @@ describe("IdleTerminalNotificationService", () => {
       projectStoreMock.getCurrentProjectId.mockReturnValue("active-proj");
       projectStoreMock.getAllProjects.mockReturnValue([]);
 
-      const service = new IdleTerminalNotificationService();
+      const service = makeService();
       await runCheck(service);
 
       const persisted = storeBacking.idleTerminalDismissals as Record<string, number>;
@@ -279,7 +287,7 @@ describe("IdleTerminalNotificationService", () => {
 
     it("does not fire during the startup quiet period", async () => {
       setup();
-      const service = new IdleTerminalNotificationService();
+      const service = makeService();
       // Simulate the service having just started: set quietUntil 30s in the future
       (service as unknown as { quietUntil: number | null }).quietUntil = Date.now() + 30_000;
       await runCheck(service);
@@ -292,7 +300,7 @@ describe("IdleTerminalNotificationService", () => {
       projectStoreMock.getAllProjects.mockReturnValue([makeProject("proj-1", "Old")]);
       hibernateProjectOnDemandMock.mockResolvedValueOnce(2);
 
-      const service = new IdleTerminalNotificationService();
+      const service = makeService();
       const killed = await service.closeProject("proj-1");
 
       expect(killed).toBe(2);
@@ -305,7 +313,7 @@ describe("IdleTerminalNotificationService", () => {
       projectStoreMock.getAllProjects.mockReturnValue([]);
       hibernateProjectOnDemandMock.mockResolvedValueOnce(1);
 
-      const service = new IdleTerminalNotificationService();
+      const service = makeService();
       await service.closeProject("ghost-proj");
 
       expect(hibernateProjectOnDemandMock).toHaveBeenCalledWith(
@@ -319,7 +327,7 @@ describe("IdleTerminalNotificationService", () => {
       projectStoreMock.getAllProjects.mockReturnValue([makeProject("proj-1")]);
       hibernateProjectOnDemandMock.mockResolvedValueOnce(0);
 
-      const service = new IdleTerminalNotificationService();
+      const service = makeService();
       await service.closeProject("proj-1");
 
       expect(storeBacking.idleTerminalDismissals).toBeUndefined();
@@ -329,12 +337,12 @@ describe("IdleTerminalNotificationService", () => {
       projectStoreMock.getAllProjects.mockReturnValue([makeProject("proj-1")]);
       hibernateProjectOnDemandMock.mockRejectedValueOnce(new Error("boom"));
 
-      const service = new IdleTerminalNotificationService();
+      const service = makeService();
       await expect(service.closeProject("proj-1")).rejects.toThrow("boom");
     });
 
     it("rejects empty projectId without delegating", async () => {
-      const service = new IdleTerminalNotificationService();
+      const service = makeService();
       const killed = await service.closeProject("");
       expect(killed).toBe(0);
       expect(hibernateProjectOnDemandMock).not.toHaveBeenCalled();
@@ -344,7 +352,7 @@ describe("IdleTerminalNotificationService", () => {
   describe("startup quiet period", () => {
     it("is seeded on the first start() and not re-bumped by a subsequent start()", () => {
       storeBacking.idleTerminalNotify = { enabled: true, thresholdMinutes: 60 };
-      const service = new IdleTerminalNotificationService();
+      const service = makeService();
       service.start();
       const initialQuietUntil = (service as unknown as { quietUntil: number | null }).quietUntil;
       expect(initialQuietUntil).not.toBeNull();
@@ -363,14 +371,14 @@ describe("IdleTerminalNotificationService", () => {
 
   describe("dismissProject", () => {
     it("persists a dismissal timestamp", () => {
-      const service = new IdleTerminalNotificationService();
+      const service = makeService();
       service.dismissProject("proj-1");
       const persisted = storeBacking.idleTerminalDismissals as Record<string, number>;
       expect(persisted["proj-1"]).toBeGreaterThan(0);
     });
 
     it("ignores empty projectId", () => {
-      const service = new IdleTerminalNotificationService();
+      const service = makeService();
       service.dismissProject("");
       expect(storeBacking.idleTerminalDismissals).toBeUndefined();
     });

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -1618,7 +1618,10 @@ export class ProjectViewManager {
     const onStateChanged = (payload: { terminalId?: string; state: AgentState }) => {
       // No projectId on this event — the seed map owns the terminal→project
       // link. Skip terminals we haven't seeded yet (a spawn-result reseed will
-      // pick them up).
+      // pick them up). On terminal exit the state machine emits exited/completed
+      // (neither in ACTIVE_AGENT_STATES), so a killed terminal self-heals to
+      // unprotected here; a missed final event is corrected by the next
+      // spawn-result/host-crash reseed.
       if (!payload.terminalId) return;
       this.agentStateByTerminal.set(payload.terminalId, payload.state);
     };

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -23,7 +23,8 @@ import { isBrowserPartition } from "../../shared/utils/partitionUtils.js";
 import { canOpenExternalUrl, openExternalUrl } from "../utils/openExternal.js";
 import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
 import { forgetBlinkSample, forgetEluSample } from "../services/ProcessMemoryMonitor.js";
-import { getPtyManager } from "../services/PtyManager.js";
+import type { PtyClient } from "../services/PtyClient.js";
+import { events } from "../services/events.js";
 import { notifyError } from "../ipc/errorHandlers.js";
 import { logInfo, logWarn } from "../utils/logger.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
@@ -48,7 +49,7 @@ import {
   throttleCpuWebContents,
   unthrottleCpuWebContents,
 } from "../utils/webContentsLifecycle.js";
-import { ACTIVE_AGENT_STATES } from "../../shared/types/agent.js";
+import { ACTIVE_AGENT_STATES, type AgentState } from "../../shared/types/agent.js";
 import { setAlignedInterval } from "../utils/setAlignedInterval.js";
 import {
   beginWindowRecreating,
@@ -242,6 +243,16 @@ export class ProjectViewManager {
   } | null = null;
   private disposed = false;
   private cachedMemoryTimerCleanup: (() => void) | null = null;
+
+  // Agent-state cache for hasActiveAgent(). The main-process getPtyManager()
+  // singleton is never populated (#10054), so the real terminal registry lives
+  // in the pty-host and is read async via PtyClient. Eviction scoring is
+  // synchronous, so we maintain instance-level maps seeded from the host and
+  // kept fresh via the typed event bus. Instance-level (not module-level) so
+  // each window's manager scopes to its own terminals (lesson #8607).
+  private projectByTerminal = new Map<string, string>();
+  private agentStateByTerminal = new Map<string, AgentState>();
+  private agentCacheCleanup: Array<() => void> = [];
 
   constructor(win: BrowserWindow, opts: ProjectViewManagerOptions) {
     this.win = win;
@@ -921,6 +932,11 @@ export class ProjectViewManager {
   dispose(): void {
     this.disposed = true;
 
+    for (const cleanup of this.agentCacheCleanup) cleanup();
+    this.agentCacheCleanup = [];
+    this.projectByTerminal.clear();
+    this.agentStateByTerminal.clear();
+
     if (this.cachedMemoryTimerCleanup) {
       this.cachedMemoryTimerCleanup();
       this.cachedMemoryTimerCleanup = null;
@@ -1572,12 +1588,61 @@ export class ProjectViewManager {
     this.views.delete(projectId);
   }
 
+  /**
+   * Seed and maintain the agent-state cache used by the synchronous
+   * `hasActiveAgent()` eviction guard. Fire-and-forget: until the first seed
+   * resolves the maps are empty and `hasActiveAgent()` returns false (the
+   * conservative pre-regression behavior — an in-flight view is never wrongly
+   * treated as protected). Idempotent listener wiring: cleanup callbacks are
+   * cleared first so re-invocation doesn't double-subscribe.
+   */
+  initAgentStateCache(ptyClient: PtyClient): Promise<void> {
+    for (const cleanup of this.agentCacheCleanup) cleanup();
+    this.agentCacheCleanup = [];
+
+    const seed = async () => {
+      try {
+        const terminals = await ptyClient.getAllTerminalsAsync();
+        if (this.disposed) return;
+        this.projectByTerminal.clear();
+        this.agentStateByTerminal.clear();
+        for (const t of terminals) {
+          if (t.projectId) this.projectByTerminal.set(t.id, t.projectId);
+          if (t.agentState) this.agentStateByTerminal.set(t.id, t.agentState);
+        }
+      } catch {
+        // Host unavailable — leave maps as-is; hasActiveAgent stays conservative.
+      }
+    };
+
+    const onStateChanged = (payload: { terminalId?: string; state: AgentState }) => {
+      // No projectId on this event — the seed map owns the terminal→project
+      // link. Skip terminals we haven't seeded yet (a spawn-result reseed will
+      // pick them up).
+      if (!payload.terminalId) return;
+      this.agentStateByTerminal.set(payload.terminalId, payload.state);
+    };
+    const offStateChanged = events.on("agent:state-changed", onStateChanged);
+
+    const onSpawnResult = () => void seed();
+    const onHostCrash = () => void seed();
+    ptyClient.on("spawn-result", onSpawnResult);
+    ptyClient.on("host-crash", onHostCrash);
+
+    this.agentCacheCleanup.push(offStateChanged);
+    this.agentCacheCleanup.push(() => ptyClient.off("spawn-result", onSpawnResult));
+    this.agentCacheCleanup.push(() => ptyClient.off("host-crash", onHostCrash));
+
+    return seed();
+  }
+
   private hasActiveAgent(projectId: string): boolean {
-    const terminals = getPtyManager().getAll();
-    return terminals.some(
-      (t) =>
-        t.projectId === projectId && t.agentState != null && ACTIVE_AGENT_STATES.has(t.agentState)
-    );
+    for (const [terminalId, termProjectId] of this.projectByTerminal) {
+      if (termProjectId !== projectId) continue;
+      const state = this.agentStateByTerminal.get(terminalId);
+      if (state != null && ACTIVE_AGENT_STATES.has(state)) return true;
+    }
+    return false;
   }
 
   private evictStaleViews(reason: EvictionReason): void {

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -146,12 +146,21 @@ vi.mock("../../utils/logger.js", () => ({
   })),
 }));
 
-const mockGetAll = vi.fn<() => Array<{ projectId?: string; agentState?: string }>>(() => []);
-vi.mock("../../services/PtyManager.js", () => ({
-  getPtyManager: vi.fn(() => ({ getAll: mockGetAll })),
-}));
+// PtyClient-shaped mock injected via initAgentStateCache (#10054). The
+// terminal registry lives in the pty-host; hasActiveAgent() reads an
+// instance-level cache seeded from this mock, not the dead main-process
+// getPtyManager() singleton.
+const mockGetAllTerminals = vi.fn<
+  () => Promise<Array<{ id: string; projectId?: string; agentState?: string }>>
+>(async () => []);
+const mockPtyClient = {
+  getAllTerminalsAsync: mockGetAllTerminals,
+  on: vi.fn(),
+  off: vi.fn(),
+};
 
 import { ProjectViewManager } from "../ProjectViewManager.js";
+import { events } from "../../services/events.js";
 import { logInfo } from "../../utils/logger.js";
 import { forgetBlinkSample, forgetEluSample } from "../../services/ProcessMemoryMonitor.js";
 import { detachRendererConsoleCapture } from "../rendererConsoleCapture.js";
@@ -180,8 +189,8 @@ describe("ProjectViewManager — eviction safety", () => {
     nextWebContentsId = 100;
     nextOsProcessId = 1000;
     vi.clearAllMocks();
-    mockGetAll.mockReset();
-    mockGetAll.mockReturnValue([]);
+    mockGetAllTerminals.mockReset();
+    mockGetAllTerminals.mockResolvedValue([]);
     mockGetAppMetrics.mockReset();
     mockGetAppMetrics.mockReturnValue([]);
     win = createMockWindow();
@@ -285,10 +294,11 @@ describe("ProjectViewManager — eviction safety", () => {
 
     // proj-a (oldest) has an active agent. Eviction must skip it and evict proj-b instead
     // once we go over the limit with proj-c.
-    mockGetAll.mockReturnValue([
-      { projectId: "proj-a", agentState: "working" },
-      { projectId: "proj-b", agentState: "idle" },
+    mockGetAllTerminals.mockResolvedValue([
+      { id: "t-a", projectId: "proj-a", agentState: "working" },
+      { id: "t-b", projectId: "proj-b", agentState: "idle" },
     ]);
+    await managerWithLimit.initAgentStateCache(mockPtyClient as never);
 
     const wcBEntry = managerWithLimit.getAllViews().find((v) => v.projectId === "proj-b");
     const wcB = wcBEntry?.view.webContents as ReturnType<typeof createMockWebContents> | undefined;
@@ -298,6 +308,51 @@ describe("ProjectViewManager — eviction safety", () => {
     const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
     expect(remaining).toContain("proj-a");
     expect(remaining).toContain("proj-c");
+    expect(remaining).not.toContain("proj-b");
+    expect(wcA.close).not.toHaveBeenCalled();
+    expect(wcB?.close).toHaveBeenCalled();
+  });
+
+  it("protects a view after a live agent:state-changed event marks it active (#10054)", async () => {
+    const managerWithLimit = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
+      warmPaintGateTimeoutMs: 0,
+      warmPaintGateHardTimeoutMs: 0,
+      cachedProjectViews: 2,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await managerWithLimit.switchTo("proj-b", "/path/b");
+
+    // Seed proj-a's terminal as idle (so projectByTerminal knows t-a → proj-a),
+    // then flip it to "working" purely via the event bus — the path the cache
+    // relies on between host re-seeds.
+    mockGetAllTerminals.mockResolvedValue([
+      { id: "t-a", projectId: "proj-a", agentState: "idle" },
+      { id: "t-b", projectId: "proj-b", agentState: "idle" },
+    ]);
+    await managerWithLimit.initAgentStateCache(mockPtyClient as never);
+    events.emit("agent:state-changed", {
+      terminalId: "t-a",
+      state: "working",
+      previousState: "idle",
+      trigger: "output",
+      confidence: 1,
+      timestamp: 0,
+    } as never);
+
+    const wcBEntry = managerWithLimit.getAllViews().find((v) => v.projectId === "proj-b");
+    const wcB = wcBEntry?.view.webContents as ReturnType<typeof createMockWebContents> | undefined;
+
+    await managerWithLimit.switchTo("proj-c", "/path/c");
+
+    const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
+    expect(remaining).toContain("proj-a");
     expect(remaining).not.toContain("proj-b");
     expect(wcA.close).not.toHaveBeenCalled();
     expect(wcB?.close).toHaveBeenCalled();
@@ -321,10 +376,11 @@ describe("ProjectViewManager — eviction safety", () => {
 
     // Both background candidates have active agents — fallback must evict the LRU
     // (proj-a) and emit a telemetry event rather than let the pool grow unbounded.
-    mockGetAll.mockReturnValue([
-      { projectId: "proj-a", agentState: "directing" },
-      { projectId: "proj-b", agentState: "working" },
+    mockGetAllTerminals.mockResolvedValue([
+      { id: "t-a", projectId: "proj-a", agentState: "directing" },
+      { id: "t-b", projectId: "proj-b", agentState: "working" },
     ]);
+    await managerWithLimit.initAgentStateCache(mockPtyClient as never);
 
     await managerWithLimit.switchTo("proj-c", "/path/c");
 
@@ -357,11 +413,12 @@ describe("ProjectViewManager — eviction safety", () => {
     await managerWithLimit.switchTo("proj-c", "/path/c");
 
     // All three cached projects have active agents.
-    mockGetAll.mockReturnValue([
-      { projectId: "proj-a", agentState: "working" },
-      { projectId: "proj-b", agentState: "directing" },
-      { projectId: "proj-c", agentState: "waiting" },
+    mockGetAllTerminals.mockResolvedValue([
+      { id: "t-a", projectId: "proj-a", agentState: "working" },
+      { id: "t-b", projectId: "proj-b", agentState: "directing" },
+      { id: "t-c", projectId: "proj-c", agentState: "waiting" },
     ]);
+    await managerWithLimit.initAgentStateCache(mockPtyClient as never);
 
     // Tightening the limit to 1 must evict the two LRU views (proj-a, then proj-b)
     // in order, and each forced eviction is emitted as a telemetry event.
@@ -542,7 +599,10 @@ describe("ProjectViewManager — eviction safety", () => {
         memory: { privateBytes: 100 * 1024 },
       },
     ] as unknown as Electron.ProcessMetric[]);
-    mockGetAll.mockReturnValue([{ projectId: "proj-a", agentState: "working" }]);
+    mockGetAllTerminals.mockResolvedValue([
+      { id: "t-a", projectId: "proj-a", agentState: "working" },
+    ]);
+    await managerWithLimit.initAgentStateCache(mockPtyClient as never);
 
     await managerWithLimit.switchTo("proj-c", "/path/c");
 
@@ -709,8 +769,8 @@ describe("ProjectViewManager — telemetry", () => {
     nextWebContentsId = 100;
     nextOsProcessId = 1000;
     vi.clearAllMocks();
-    mockGetAll.mockReset();
-    mockGetAll.mockReturnValue([]);
+    mockGetAllTerminals.mockReset();
+    mockGetAllTerminals.mockResolvedValue([]);
     mockGetAppMetrics.mockReset();
     mockGetAppMetrics.mockReturnValue([]);
     win = createMockWindow();
@@ -1197,8 +1257,8 @@ describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
   beforeEach(() => {
     nextWebContentsId = 100;
     vi.clearAllMocks();
-    mockGetAll.mockReset();
-    mockGetAll.mockReturnValue([]);
+    mockGetAllTerminals.mockReset();
+    mockGetAllTerminals.mockResolvedValue([]);
     win = createMockWindow();
   });
 
@@ -1420,8 +1480,8 @@ describe("ProjectViewManager — listener cleanup", () => {
     nextWebContentsId = 100;
     nextOsProcessId = 1000;
     vi.clearAllMocks();
-    mockGetAll.mockReset();
-    mockGetAll.mockReturnValue([]);
+    mockGetAllTerminals.mockReset();
+    mockGetAllTerminals.mockResolvedValue([]);
     mockGetAppMetrics.mockReset();
     mockGetAppMetrics.mockReturnValue([]);
     win = createMockWindow();
@@ -1660,8 +1720,8 @@ describe("ProjectViewManager — low-memory eviction", () => {
     nextWebContentsId = 100;
     nextOsProcessId = 1000;
     vi.clearAllMocks();
-    mockGetAll.mockReset();
-    mockGetAll.mockReturnValue([]);
+    mockGetAllTerminals.mockReset();
+    mockGetAllTerminals.mockResolvedValue([]);
     mockGetAppMetrics.mockReset();
     mockGetAppMetrics.mockReturnValue([]);
     win = createMockWindow();

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -153,9 +153,15 @@ vi.mock("../../utils/logger.js", () => ({
 const mockGetAllTerminals = vi.fn<
   () => Promise<Array<{ id: string; projectId?: string; agentState?: string }>>
 >(async () => []);
+// Capture the latest handler per event so reseed tests can invoke them
+// (spawn-result / host-crash). initAgentStateCache overwrites per call, so the
+// map holds the current manager's handlers.
+const ptyClientHandlers = new Map<string, (...args: unknown[]) => void>();
 const mockPtyClient = {
   getAllTerminalsAsync: mockGetAllTerminals,
-  on: vi.fn(),
+  on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+    ptyClientHandlers.set(event, handler);
+  }),
   off: vi.fn(),
 };
 
@@ -356,6 +362,60 @@ describe("ProjectViewManager — eviction safety", () => {
     expect(remaining).not.toContain("proj-b");
     expect(wcA.close).not.toHaveBeenCalled();
     expect(wcB?.close).toHaveBeenCalled();
+  });
+
+  it("host-crash reseed clears a stale active-agent entry (#10054)", async () => {
+    const managerWithLimit = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
+      warmPaintGateTimeoutMs: 0,
+      warmPaintGateHardTimeoutMs: 0,
+      cachedProjectViews: 2,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+    await managerWithLimit.switchTo("proj-b", "/path/b");
+
+    // Seed proj-a as working, then simulate a host crash that comes back with an
+    // empty registry — the reseed must drop the stale "working" entry so proj-a
+    // is no longer protected.
+    mockGetAllTerminals.mockResolvedValue([
+      { id: "t-a", projectId: "proj-a", agentState: "working" },
+    ]);
+    await managerWithLimit.initAgentStateCache(mockPtyClient as never);
+
+    mockGetAllTerminals.mockResolvedValue([]);
+    await ptyClientHandlers.get("host-crash")?.();
+
+    await managerWithLimit.switchTo("proj-c", "/path/c");
+
+    // proj-a is the LRU and no longer protected, so it is evicted.
+    const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
+    expect(remaining).not.toContain("proj-a");
+    expect(wcA.close).toHaveBeenCalled();
+  });
+
+  it("re-invoking initAgentStateCache tears down prior listeners (#10054)", async () => {
+    const managerWithLimit = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
+      warmPaintGateTimeoutMs: 0,
+      warmPaintGateHardTimeoutMs: 0,
+      cachedProjectViews: 2,
+    });
+
+    await managerWithLimit.initAgentStateCache(mockPtyClient as never);
+    mockPtyClient.off.mockClear();
+    await managerWithLimit.initAgentStateCache(mockPtyClient as never);
+
+    // The second call must unsubscribe the first call's PtyClient listeners
+    // before re-subscribing, so it doesn't leak or double-fire.
+    expect(mockPtyClient.off).toHaveBeenCalledWith("spawn-result", expect.any(Function));
+    expect(mockPtyClient.off).toHaveBeenCalledWith("host-crash", expect.any(Function));
   });
 
   it("falls back to evicting an active-agent view when all candidates are protected", async () => {

--- a/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
@@ -123,10 +123,6 @@ vi.mock("../../services/ProcessMemoryMonitor.js", () => ({
   forgetEluSample: vi.fn(),
 }));
 
-vi.mock("../../services/PtyManager.js", () => ({
-  getPtyManager: vi.fn(() => ({ getAll: () => [] })),
-}));
-
 vi.mock("../../ipc/errorHandlers.js", () => ({
   notifyError: vi.fn(),
 }));

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -123,10 +123,6 @@ vi.mock("../../services/ProcessMemoryMonitor.js", () => ({
   forgetEluSample: vi.fn(),
 }));
 
-vi.mock("../../services/PtyManager.js", () => ({
-  getPtyManager: vi.fn(() => ({ getAll: () => [] })),
-}));
-
 vi.mock("../../ipc/errorHandlers.js", () => ({
   notifyError: vi.fn(),
 }));

--- a/electron/window/__tests__/ProjectViewManager.preload.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.preload.test.ts
@@ -146,11 +146,6 @@ vi.mock("../../utils/logger.js", () => ({
   })),
 }));
 
-const mockGetAll = vi.fn<() => Array<{ projectId?: string; agentState?: string }>>(() => []);
-vi.mock("../../services/PtyManager.js", () => ({
-  getPtyManager: vi.fn(() => ({ getAll: mockGetAll })),
-}));
-
 import { ProjectViewManager } from "../ProjectViewManager.js";
 import { logInfo } from "../../utils/logger.js";
 
@@ -187,8 +182,6 @@ describe("ProjectViewManager — preload eval cost (#9770)", () => {
     nextWebContentsId = 100;
     nextOsProcessId = 1000;
     vi.clearAllMocks();
-    mockGetAll.mockReset();
-    mockGetAll.mockReturnValue([]);
     mockGetAppMetrics.mockReset();
     mockGetAppMetrics.mockReturnValue([]);
     win = createMockWindow();

--- a/package-lock.json
+++ b/package-lock.json
@@ -123,7 +123,7 @@
         "culori": "^4.0.2",
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "^0.45.1",
-        "electron": "^42.3.0",
+        "electron": "^42.3.3",
         "electron-builder": "^26.8.1",
         "electron-store": "^11.0.2",
         "electron-updater": "^6.8.3",

--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
     "culori": "^4.0.2",
     "drizzle-kit": "^0.31.10",
     "drizzle-orm": "^0.45.1",
-    "electron": "^42.3.0",
+    "electron": "^42.3.3",
     "electron-builder": "^26.8.1",
     "electron-store": "^11.0.2",
     "electron-updater": "^6.8.3",

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -164,7 +164,12 @@ export type PtyHostRequest =
     }
   | { type: "set-ipc-data-mirror"; id: string; enabled: boolean }
   | { type: "graceful-kill"; id: string; requestId: string }
-  | { type: "graceful-kill-by-project"; projectId: string; requestId: string }
+  | {
+      type: "graceful-kill-by-project";
+      projectId: string;
+      requestId: string;
+      preserveSession?: boolean;
+    }
   | { type: "trim-state"; targetLines: number }
   | { type: "set-resource-monitoring"; enabled: boolean }
   | { type: "set-session-persist-suppressed"; suppressed: boolean }


### PR DESCRIPTION
## Summary

- Four main-process services were all reading `getPtyManager().getAll()`, a singleton that's never populated. PTY management moved to a forked `pty-host` UtilityProcess; the real terminal registry lives there and is queried via `PtyClient`. CI never caught it because the tests mocked `getPtyManager()` itself.
- Four features were silently broken: support-bundle terminals always empty (`DiagnosticsCollector`), idle-terminal notifications never fired (#5064), hibernation never hibernated (#8534), and active-agent project views were wrongly LRU-evicted (#5234).
- Routes all four call sites to `ptyClient.getAllTerminalsAsync()`. `DiagnosticsCollector` takes `ptyClient` via `HandlerDependencies`; `HibernationService` and `IdleTerminalNotificationService` get an injected `PtyClient` via `setPtyClient()` called on `start()` so Settings toggles don't permanently disable them; `ProjectViewManager.hasActiveAgent()` stays synchronous (LRU eviction hot path) backed by an instance-level agent-state cache seeded from the host and kept fresh via `agent:state-changed` events, spawn-result reseeds, and host-crash reseeds.

Resolves #10054.

## Changes

- `DiagnosticsCollector` — receives `ptyClient` via `HandlerDependencies`; replaces `getPtyManager().getAll()` with `getAllTerminalsAsync()`
- `HibernationService` and `IdleTerminalNotificationService` — `setPtyClient()` called on `start()`, re-acquired on each start so Settings toggles don't disable them permanently
- `ProjectViewManager` — instance-level `agentStateCache` seeded from the host on `initAgentStateCache()` (called after `setupWindowServices` constructs the `PtyClient`, fixing a first-window timing issue found in review) and kept fresh via events; `hasActiveAgent()` queries the cache synchronously
- `pty-host/handlers/lifecycle.ts` — threads `preserveSession` flag through the graceful-kill-by-project IPC so hibernation can preserve sessions
- `pty-host/handlers/terminalInfo.ts` / `shared/types/pty-host.ts` — adds `lastInputTime` / `lastOutputTime` to the `get-all-terminals` payload (`mapTerminalInfo`) so idle detection has activity timestamps (these were silently dropped before)
- Tests converted from mocking the dead `getPtyManager()` to `PtyClient`-shaped mocks; regression tests added for all four consumers (diagnostics terminals populated/empty, `mapTerminalInfo` forwards activity timestamps, lifecycle forwards `preserveSession`, PVM protection via live event + host-crash reseed + re-init idempotency, service re-acquires `PtyClient` after a Settings toggle)

## Testing

209 targeted tests pass. `npm run check` is clean. The four previously-broken code paths now exercise the live `PtyClient` interface in tests rather than the never-populated `getPtyManager()` singleton.