### PR TITLE
fix(mcp): include grant-lifecycle records in audit log viewer and NDJSON export (#10027)

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -570,6 +570,15 @@ export const CHANNELS = {
    */
   MCP_SERVER_LIST_ACTIVE_CLIENTS: "mcp-server:list-active-clients",
   MCP_SERVER_GET_AUDIT_RECORDS: "mcp-server:get-audit-records",
+  /**
+   * Sibling of `MCP_SERVER_GET_AUDIT_RECORDS` that returns the full
+   * `McpLogRecord` union (dispatch + grant lifecycle). Used by the
+   * audit-log viewer and the NDJSON export. Dispatch-only consumers
+   * (latency table, recent-calls popover, activity strip) keep using
+   * the dispatch channel so their `result`/`durationMs` reads stay
+   * type-safe — see #10027.
+   */
+  MCP_SERVER_GET_LOG_RECORDS: "mcp-server:get-log-records",
   MCP_SERVER_CLEAR_AUDIT_LOG: "mcp-server:clear-audit-log",
   MCP_SERVER_SET_AUDIT_ENABLED: "mcp-server:set-audit-enabled",
   MCP_SERVER_SET_AUDIT_MAX_RECORDS: "mcp-server:set-audit-max-records",

--- a/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
@@ -17,6 +17,7 @@ const serviceMock = vi.hoisted(() => ({
   rotateApiKey: vi.fn().mockResolvedValue("k-new"),
   getConfigSnippet: vi.fn(() => "snippet"),
   getAuditRecords: vi.fn(() => []),
+  getLogRecords: vi.fn(() => []),
   getAuditConfig: vi.fn(() => ({ enabled: true, maxRecords: 500 })),
   clearAuditLog: vi.fn(),
   getTurnOutcomeRecords: vi.fn(() => []),
@@ -240,8 +241,8 @@ describe("mcpServer IPC adversarial", () => {
     expect(serviceMock.disconnectBearer).toHaveBeenCalledWith(valid);
   });
 
-  it("cleanup removes all twenty-one registered handlers", () => {
-    expect(ipcHandlers.size).toBe(21);
+  it("cleanup removes all twenty-two registered handlers", () => {
+    expect(ipcHandlers.size).toBe(22);
     cleanup();
     expect(ipcHandlers.size).toBe(0);
   });

--- a/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
@@ -195,6 +195,38 @@ describe("mcpServer IPC adversarial", () => {
     expect((result as unknown[]).length).toBe(1);
   });
 
+  it("getLogRecords returns the full union (dispatch + grant) and does not call the dispatch variant (#10027)", async () => {
+    const mixed = [
+      {
+        id: "a",
+        timestamp: 2,
+        toolId: "t",
+        sessionId: "s",
+        tier: "unknown",
+        argsSummary: "{}",
+        result: "success",
+        durationMs: 0,
+      },
+      {
+        id: "g",
+        timestamp: 1,
+        type: "grant.issued",
+        sessionId: "s",
+        toolId: "files.search",
+        ttlMs: 60000,
+      },
+    ] as never;
+    serviceMock.getLogRecords.mockReturnValueOnce(mixed);
+    const result = await getHandler(CHANNELS.MCP_SERVER_GET_LOG_RECORDS)(fakeEvent());
+    expect(Array.isArray(result)).toBe(true);
+    expect((result as unknown[]).length).toBe(2);
+    expect(serviceMock.getLogRecords).toHaveBeenCalledTimes(1);
+    // Make sure the new channel routes to the union accessor, not the
+    // legacy dispatch-only one — a typo in the handler would silently
+    // re-introduce the original bug.
+    expect(serviceMock.getAuditRecords).not.toHaveBeenCalled();
+  });
+
   it("clearAuditLog calls service clear", async () => {
     await getHandler(CHANNELS.MCP_SERVER_CLEAR_AUDIT_LOG)(fakeEvent());
     expect(serviceMock.clearAuditLog).toHaveBeenCalledTimes(1);

--- a/electron/ipc/handlers/mcpServer.preload.ts
+++ b/electron/ipc/handlers/mcpServer.preload.ts
@@ -8,6 +8,7 @@ export const MCP_SERVER_METHOD_CHANNELS = {
   getConfigSnippet: "mcp-server:get-config-snippet",
   listActiveClients: "mcp-server:list-active-clients",
   getAuditRecords: "mcp-server:get-audit-records",
+  getLogRecords: "mcp-server:get-log-records",
   getAuditConfig: "mcp-server:get-audit-config",
   getAuditStats: "mcp-server:get-audit-stats",
   clearAuditLog: "mcp-server:clear-audit-log",

--- a/electron/ipc/handlers/mcpServer.ts
+++ b/electron/ipc/handlers/mcpServer.ts
@@ -167,6 +167,9 @@ export const mcpServerNamespace = defineIpcNamespace({
       async (ctx, records: McpLogRecord[]): Promise<boolean> => {
         if (!Array.isArray(records)) throw new Error("records must be an array");
         const ndjsonLines = records.map((rawRecord) => {
+          if (rawRecord === null || typeof rawRecord !== "object") {
+            throw new Error("each record must be a non-null object");
+          }
           const record = rawRecord as unknown as Record<string, unknown>;
           const cleaned: Record<string, unknown> = {};
           for (const [key, value] of Object.entries(record)) {

--- a/electron/ipc/handlers/mcpServer.ts
+++ b/electron/ipc/handlers/mcpServer.ts
@@ -15,6 +15,7 @@ import type {
   McpAuditRecord,
   McpAuditStats,
   McpIssueGrantResult,
+  McpLogRecord,
   McpRevokeSessionGrantsResult,
   McpRuntimeSnapshot,
   McpServerStatusSnapshot,
@@ -86,6 +87,18 @@ export const mcpServerNamespace = defineIpcNamespace({
         return svc.getAuditRecords();
       }
     ),
+    // Sibling of getAuditRecords that returns the full McpLogRecord union
+    // (dispatch + grant lifecycle). Used by the audit-log viewer and NDJSON
+    // export. Dispatch-only consumers (latency table, recent-calls popover)
+    // keep using getAuditRecords so their `result`/`durationMs` reads stay
+    // type-safe — see #10027.
+    getLogRecords: op(
+      MCP_SERVER_METHOD_CHANNELS.getLogRecords,
+      async (): Promise<McpLogRecord[]> => {
+        const svc = await getMcpServerService();
+        return svc.getLogRecords();
+      }
+    ),
     getAuditConfig: op(
       MCP_SERVER_METHOD_CHANNELS.getAuditConfig,
       async (): Promise<{ enabled: boolean; maxRecords: number }> => {
@@ -151,7 +164,7 @@ export const mcpServerNamespace = defineIpcNamespace({
     ),
     exportAuditLog: op(
       MCP_SERVER_METHOD_CHANNELS.exportAuditLog,
-      async (ctx, records: McpAuditRecord[]): Promise<boolean> => {
+      async (ctx, records: McpLogRecord[]): Promise<boolean> => {
         if (!Array.isArray(records)) throw new Error("records must be an array");
         const ndjsonLines = records.map((rawRecord) => {
           const record = rawRecord as unknown as Record<string, unknown>;

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -14,6 +14,7 @@ import type {
   McpAuditStats,
   McpGrantLifecyclePayload,
   McpIssueGrantResult,
+  McpLogRecord,
   McpRevokeSessionGrantsResult,
   McpRuntimeSnapshot,
   McpRuntimeState,
@@ -404,6 +405,18 @@ export class McpServerService {
 
   getAuditRecords(): McpAuditRecord[] {
     return this.auditService.getRecords();
+  }
+
+  /**
+   * Newest-first view of the full union (dispatch + grant lifecycle
+   * records). Reserved for the audit-log viewer, NDJSON export, and any
+   * other surface that handles the discriminated union — dispatch-only
+   * consumers (latency table, recent-calls popover, activity strip) keep
+   * using {@link getAuditRecords} so their `result`/`durationMs` reads
+   * stay type-safe.
+   */
+  getLogRecords(): McpLogRecord[] {
+    return this.auditService.getLogRecords();
   }
 
   getAuditConfig(): { enabled: boolean; maxRecords: number } {

--- a/electron/services/mcp-server/__tests__/auditLog.test.ts
+++ b/electron/services/mcp-server/__tests__/auditLog.test.ts
@@ -375,6 +375,33 @@ describe("AuditService hydrate — backward compat", () => {
     expect(records[0]!.schemaVersion).toBe(1);
     expect(records[0]!.severity).toBe("info");
   });
+
+  it("reclassifies a malformed persisted record with `type: 'dispatch'` as audit (#10027)", () => {
+    // A forward-compat dispatch-record discriminator on a persisted row
+    // would otherwise be misclassified as a grant and bypass severity
+    // backfill. Lock down the hydrate-path guard to match the
+    // `isGrantRecord` literal-union check.
+    const malformed = {
+      id: "mal-1",
+      timestamp: 1000,
+      toolId: "agent.launch",
+      sessionId: "sess-1",
+      tier: "action",
+      argsSummary: "{}",
+      result: "success",
+      durationMs: 50,
+      type: "dispatch",
+    };
+    const { service } = makeFixture({ auditLog: [malformed] });
+    const records = service.getLogRecords();
+    expect(records).toHaveLength(1);
+    // The record survives hydrate (the string `type` field is preserved),
+    // but isAuditRecord narrows it to the dispatch kind — getRecords() sees it.
+    expect(service.getRecords()).toHaveLength(1);
+    // "type" stays in the persisted shape for round-trip safety; the
+    // union consumer narrows by isGrantRecord at read time.
+    expect((records[0] as { type?: unknown }).type).toBe("dispatch");
+  });
 });
 
 describe("AuditService.appendGrantRecord — tier records (#9151)", () => {
@@ -877,6 +904,41 @@ describe("shared narrowers — isGrantRecord / isAuditRecord (#10027)", () => {
     };
     expect(isGrantRecord(record as never)).toBe(false);
     expect(isAuditRecord(record as never)).toBe(true);
+  });
+
+  it("rejects a record with an unknown `type` discriminator value", () => {
+    // Forward-compat hazard: a future dispatch-record discriminator (or a
+    // malformed persisted row) would otherwise be misclassified as a grant
+    // and misrendered with `undefined` for its `type` field.
+    const record = {
+      id: "x",
+      timestamp: 1,
+      toolId: "t",
+      sessionId: "s",
+      tier: "action",
+      argsSummary: "{}",
+      result: "success" as const,
+      durationMs: 0,
+      schemaVersion: 1,
+      severity: "info" as const,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentionally unknown discriminator
+      type: "dispatch" as any,
+    };
+    expect(isGrantRecord(record as never)).toBe(false);
+    expect(isAuditRecord(record as never)).toBe(true);
+  });
+
+  it("rejects case-mismatched `type` discriminators (lowercase grant.issued only)", () => {
+    const record = {
+      id: "x",
+      timestamp: 1,
+      sessionId: "s",
+      toolId: "*",
+      ttlMs: 0,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentionally case-mismatched
+      type: "Grant.Expired" as any,
+    };
+    expect(isGrantRecord(record as never)).toBe(false);
   });
 
   it("accepts every McpGrantRecordType value", () => {

--- a/electron/services/mcp-server/__tests__/auditLog.test.ts
+++ b/electron/services/mcp-server/__tests__/auditLog.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { AuditService, type AuditOutcome } from "../auditLog.js";
-import type { McpAuditResult } from "../../../../shared/types/ipc/mcpServer.js";
+import {
+  type McpAuditResult,
+  isAuditRecord,
+  isGrantRecord,
+} from "../../../../shared/types/ipc/mcpServer.js";
 
 function makeFixture(initialConfig: Record<string, unknown> = {}) {
   const config: Record<string, unknown> = {
@@ -820,5 +824,111 @@ describe("AuditService anomaly detection", () => {
     const p95 = stats.anomalySignals.filter((s) => s.kind === "p95-z-score");
     expect(p95.length).toBeGreaterThanOrEqual(1);
     expect(p95[0]!.toolId).toBe("tool.e");
+  });
+});
+
+describe("shared narrowers — isGrantRecord / isAuditRecord (#10027)", () => {
+  it("classifies a legacy dispatch record (no `type` field) as audit", () => {
+    const record = {
+      id: "audit-1",
+      timestamp: 1,
+      toolId: "agent.launch",
+      sessionId: "sess-1",
+      tier: "action",
+      argsSummary: "{}",
+      result: "success" as const,
+      durationMs: 5,
+      schemaVersion: 1,
+      severity: "info" as const,
+    };
+    expect(isGrantRecord(record)).toBe(false);
+    expect(isAuditRecord(record)).toBe(true);
+  });
+
+  it("classifies a grant record (with `type`) as grant", () => {
+    const record = {
+      type: "grant.issued" as const,
+      id: "grant-1",
+      timestamp: 1,
+      sessionId: "sess-1",
+      toolId: "files.search",
+      ttlMs: 60000,
+    };
+    expect(isGrantRecord(record)).toBe(true);
+    expect(isAuditRecord(record)).toBe(false);
+  });
+
+  it("rejects a record with a non-string `type` discriminator", () => {
+    // Defensive: a malformed on-disk record that survived hydration should
+    // be treated as the implicit dispatch kind, not as a grant record.
+    const record = {
+      id: "x",
+      timestamp: 1,
+      toolId: "t",
+      sessionId: "s",
+      tier: "action",
+      argsSummary: "{}",
+      result: "success" as const,
+      durationMs: 0,
+      schemaVersion: 1,
+      severity: "info" as const,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentionally malformed
+      type: 123 as any,
+    };
+    expect(isGrantRecord(record as never)).toBe(false);
+    expect(isAuditRecord(record as never)).toBe(true);
+  });
+
+  it("accepts every McpGrantRecordType value", () => {
+    const types = [
+      "grant.issued",
+      "grant.expired",
+      "grant.revoked",
+      "tier.elevated",
+      "tier.decayed",
+    ] as const;
+    for (const t of types) {
+      const record = {
+        type: t,
+        id: "g",
+        timestamp: 1,
+        sessionId: "s",
+        toolId: "*",
+        ttlMs: 0,
+      };
+      expect(isGrantRecord(record)).toBe(true);
+    }
+  });
+});
+
+describe("AuditService.getLogRecords — union preservation (#10027)", () => {
+  it("returns grant and dispatch records interleaved chronologically (newest-first)", async () => {
+    const { service } = makeFixture();
+    service.appendRecord({
+      toolId: "agent.launch",
+      sessionId: "sess-1",
+      tier: "action",
+      args: {},
+      durationMs: 5,
+      outcome: successOutcome,
+      argsSummary: "{}",
+    });
+    // Wait a tick so timestamps differ — appendRecord stamps Date.now() each
+    // call but rapid back-to-back calls can collide on coarse-resolution
+    // clocks; the ordering assertion is structural, not timestamp-strict.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    service.appendGrantRecord({
+      type: "tier.elevated",
+      sessionId: "sess-1",
+      toolId: "*",
+      ttlMs: 1800000,
+      tier: "action",
+      previousTier: "workbench",
+    });
+    const log = service.getLogRecords();
+    expect(log).toHaveLength(2);
+    // Newest-first: the grant was appended last, so it leads.
+    expect(isGrantRecord(log[0]!)).toBe(true);
+    expect(isAuditRecord(log[1]!)).toBe(true);
   });
 });

--- a/electron/services/mcp-server/auditLog.ts
+++ b/electron/services/mcp-server/auditLog.ts
@@ -86,8 +86,12 @@ export class AuditService {
     );
     const backfilled = safe.map((r: Record<string, unknown>) => {
       // Grant records (post-#8442) carry a `type` discriminator and never
-      // need audit-specific backfilling — pass them through unchanged.
-      if ("type" in r && typeof r.type === "string") {
+      // need audit-specific backfilling — pass them through unchanged,
+      // but only when the discriminator is a known `McpGrantRecordType`
+      // value. A stringly-typed `type: "dispatch"` (or any unknown
+      // discriminator) would otherwise be misclassified as a grant and
+      // misrendered in the viewer (#10027).
+      if (isGrantRecord(r as unknown as McpLogRecord)) {
         return r as unknown as McpLogRecord;
       }
       return {

--- a/electron/services/mcp-server/auditLog.ts
+++ b/electron/services/mcp-server/auditLog.ts
@@ -16,6 +16,8 @@ import {
   MCP_AUDIT_MIN_RECORDS,
   MCP_AUDIT_SCHEMA_VERSION,
   computeMcpAuditSeverity,
+  isAuditRecord,
+  isGrantRecord,
 } from "../../../shared/types/ipc/mcpServer.js";
 import type { McpTier } from "./shared.js";
 import {
@@ -46,17 +48,6 @@ function percentile(values: number[], p: number): number {
   const lower = sorted[k]!;
   const upper = sorted[k + 1] ?? lower;
   return lower + f * (upper - lower);
-}
-
-/**
- * Hydrate predicate: existing on-disk records predate the discriminated
- * union (#8442) and have no `type` field; new entries written by
- * `appendGrantRecord` carry one. The union narrows on the presence of
- * the field, never on a sentinel value, so legacy records remain plain
- * `McpAuditRecord` instances.
- */
-function isGrantRecord(record: McpLogRecord): record is McpGrantRecord {
-  return "type" in record && typeof (record as McpGrantRecord).type === "string";
 }
 
 export class AuditService {
@@ -259,7 +250,7 @@ export class AuditService {
       const existing = this.records.find((r) => r.id === this.lastPreAuthRecordId);
       // Narrow to McpAuditRecord — grant records carry a `type` discriminator;
       // audit records do not. See `McpLogRecord` in shared/types/ipc/mcpServer.ts.
-      if (existing && !("type" in existing) && existing.errorCode === PRE_AUTH_FAILED_CODE) {
+      if (existing && isAuditRecord(existing) && existing.errorCode === PRE_AUTH_FAILED_CODE) {
         existing.timestamp = now;
         existing.repeatCount = (existing.repeatCount ?? 1) + 1;
         this.lastPreAuthRecordAt = now;

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -342,6 +342,10 @@ export type {
   McpAuditStats,
   McpAuditSeverity,
   McpConfirmationDecision,
+  McpGrantRecord,
+  McpGrantRecordType,
+  McpGrantRevokedReason,
+  McpLogRecord,
   AssistantTurnRecord,
   TurnOutcomeClass,
   McpAnomalySeverity,
@@ -356,6 +360,8 @@ export {
   MCP_AUDIT_MIN_RECORDS,
   MCP_AUDIT_MAX_RECORDS,
   MCP_AUDIT_DEFAULT_MAX_RECORDS,
+  isAuditRecord,
+  isGrantRecord,
 } from "./ipc/mcpServer.js";
 export type {
   PluginActionAuditRecord,

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -238,6 +238,9 @@ export interface GeneratedElectronAPI {
     getConfigSnippet(
       ...args: IpcInvokeMap["mcp-server:get-config-snippet"]["args"]
     ): Promise<IpcInvokeMap["mcp-server:get-config-snippet"]["result"]>;
+    getLogRecords(
+      ...args: IpcInvokeMap["mcp-server:get-log-records"]["args"]
+    ): Promise<IpcInvokeMap["mcp-server:get-log-records"]["result"]>;
     getRuntimeState(
       ...args: IpcInvokeMap["mcp-server:get-runtime-state"]["args"]
     ): Promise<IpcInvokeMap["mcp-server:get-runtime-state"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -440,7 +440,7 @@ export interface GeneratedIpcInvokeMap {
     result: import("./mcpServer.js").DisconnectBearerResult;
   };
   "mcp-server:export-audit-log": {
-    args: [records: import("./mcpServer.js").McpAuditRecord[]];
+    args: [records: import("./mcpServer.js").McpLogRecord[]];
     result: boolean;
   };
   "mcp-server:get-audit-config": {
@@ -458,6 +458,10 @@ export interface GeneratedIpcInvokeMap {
   "mcp-server:get-config-snippet": {
     args: [];
     result: string;
+  };
+  "mcp-server:get-log-records": {
+    args: [];
+    result: import("./mcpServer.js").McpLogRecord[];
   };
   "mcp-server:get-runtime-state": {
     args: [];

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -249,14 +249,26 @@ export type McpLogRecord = McpAuditRecord | McpGrantRecord;
  * `electron/services/mcp-server/auditLog.ts` so renderer consumers and the
  * ring-buffer filter cannot drift on what counts as a grant record. The
  * legacy on-disk shape (no `type` field on `McpAuditRecord`) is load-bearing;
- * any future expansion of `McpGrantRecordType` widens this guard naturally.
+ * the discriminator must be a member of the literal `McpGrantRecordType`
+ * union — a stringly-typed `type: "dispatch"` (or any other unknown
+ * discriminator) on a hydrated dispatch record would otherwise be silently
+ * reclassified as a grant and misrendered in the viewer (#10027).
  */
+const GRANT_RECORD_TYPES: ReadonlySet<McpGrantRecordType> = new Set([
+  "grant.issued",
+  "grant.expired",
+  "grant.revoked",
+  "tier.elevated",
+  "tier.decayed",
+]);
+
 export function isGrantRecord(record: McpLogRecord): record is McpGrantRecord {
   return (
     typeof record === "object" &&
     record !== null &&
     "type" in record &&
-    typeof (record as { type: unknown }).type === "string"
+    typeof (record as { type: unknown }).type === "string" &&
+    GRANT_RECORD_TYPES.has((record as { type: string }).type as McpGrantRecordType)
   );
 }
 

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -244,6 +244,33 @@ export interface McpGrantRecord {
 export type McpLogRecord = McpAuditRecord | McpGrantRecord;
 
 /**
+ * Runtime guard for the `type` discriminator on `McpGrantRecord`. The check
+ * is intentionally the same as the main-process filter at
+ * `electron/services/mcp-server/auditLog.ts` so renderer consumers and the
+ * ring-buffer filter cannot drift on what counts as a grant record. The
+ * legacy on-disk shape (no `type` field on `McpAuditRecord`) is load-bearing;
+ * any future expansion of `McpGrantRecordType` widens this guard naturally.
+ */
+export function isGrantRecord(record: McpLogRecord): record is McpGrantRecord {
+  return (
+    typeof record === "object" &&
+    record !== null &&
+    "type" in record &&
+    typeof (record as { type: unknown }).type === "string"
+  );
+}
+
+/**
+ * Inverse of {@link isGrantRecord} — narrows to `McpAuditRecord` by
+ * complement. Kept as a positive form so consumers can call it at the
+ * prop boundary without writing `!isGrantRecord(r)` and reasoning about
+ * the legacy no-`type` invariant at every site.
+ */
+export function isAuditRecord(record: McpLogRecord): record is McpAuditRecord {
+  return !isGrantRecord(record);
+}
+
+/**
  * Live event payload broadcast to the pinned renderer for a grant
  * transition. Mirrors `McpGrantRecord` because renderers want the same
  * fields they'd see in the audit log. Send is targeted (never broadcast)

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -38,10 +38,11 @@ import { useHelpPanelStore } from "@/store/helpPanelStore";
 import type {
   HelpAssistantSettings,
   HelpAssistantTier,
-  McpAuditRecord,
   McpAuditStats,
+  McpLogRecord,
   AssistantTurnRecord,
 } from "@shared/types";
+import { isAuditRecord } from "@shared/types";
 import {
   HELP_TIER_CUMULATIVE,
   HELP_TIER_INCREMENTAL,
@@ -124,7 +125,7 @@ export function DaintreeAssistantSettingsTab() {
   const [showRotateConfirm, setShowRotateConfirm] = useState(false);
   const [isRotating, setIsRotating] = useState(false);
   const [showBlastRadius, setShowBlastRadius] = useState(false);
-  const [auditRecords, setAuditRecords] = useState<McpAuditRecord[]>([]);
+  const [auditRecords, setAuditRecords] = useState<McpLogRecord[]>([]);
   const [auditStats, setAuditStats] = useState<McpAuditStats | null>(null);
   const [turnRecords, setTurnRecords] = useState<AssistantTurnRecord[]>([]);
   const [auditLoading, setAuditLoading] = useState(true);
@@ -232,7 +233,7 @@ export function DaintreeAssistantSettingsTab() {
   // `allSettled` so a stats failure doesn't silently blank the record list.
   const refreshAuditRecords = async (): Promise<void> => {
     const [recordsResult, statsResult, turnsResult] = await Promise.allSettled([
-      window.electron.mcpServer.getAuditRecords(),
+      window.electron.mcpServer.getLogRecords(),
       window.electron.mcpServer.getAuditStats(),
       window.electron.mcpServer.getTurnOutcomeRecords(),
     ]);
@@ -258,7 +259,7 @@ export function DaintreeAssistantSettingsTab() {
     setAuditLoading(true);
     safeFireAndForget(
       Promise.allSettled([
-        window.electron.mcpServer.getAuditRecords(),
+        window.electron.mcpServer.getLogRecords(),
         window.electron.mcpServer.getAuditStats(),
         window.electron.mcpServer.getTurnOutcomeRecords(),
       ])
@@ -291,7 +292,7 @@ export function DaintreeAssistantSettingsTab() {
     };
   }, []);
 
-  const handleCopyAuditAsJson = async (records: McpAuditRecord[]) => {
+  const handleCopyAuditAsJson = async (records: McpLogRecord[]) => {
     try {
       await navigator.clipboard.writeText(JSON.stringify(records, null, 2));
       setAuditCopied(true);
@@ -308,7 +309,7 @@ export function DaintreeAssistantSettingsTab() {
     }
   };
 
-  const handleExportAuditAsNdjson = async (records: McpAuditRecord[]) => {
+  const handleExportAuditAsNdjson = async (records: McpLogRecord[]) => {
     if (isExportingAudit) return;
     setIsExportingAudit(true);
     try {
@@ -664,13 +665,16 @@ export function DaintreeAssistantSettingsTab() {
           onCopy={handleCopyAuditAsJson}
           onClear={() => setShowClearAuditConfirm(true)}
           copyFlashActive={auditCopied}
-          includeRecord={(record) => record.tier !== "external"}
+          // Privacy section hides external MCP traffic. Grant-lifecycle
+          // events stay visible — they're tied to this Daintree's own
+          // help-session bearers, not external API-key clients.
+          includeRecord={(record) => !isAuditRecord(record) || record.tier !== "external"}
           onExport={handleExportAuditAsNdjson}
           exportFlashActive={auditExported}
         />
         <McpAuditLatencyTable
           records={auditRecords}
-          includeRecord={(record) => record.tier !== "external"}
+          includeRecord={(record) => !isAuditRecord(record) || record.tier !== "external"}
         />
         {auditStats && auditStats.auth401Count > 0 && (
           <p className="text-xs text-daintree-text/60 select-text">

--- a/src/components/Settings/McpAuditLatencyTable.tsx
+++ b/src/components/Settings/McpAuditLatencyTable.tsx
@@ -1,15 +1,15 @@
 import React, { useMemo, useState } from "react";
 import { ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
-import type { McpAuditRecord } from "@shared/types";
+import { type McpLogRecord, isAuditRecord } from "@shared/types";
 
 interface McpAuditLatencyTableProps {
-  records: McpAuditRecord[];
+  records: McpLogRecord[];
   /**
    * Predicate applied before stats are computed — used by the Privacy
    * section to hide `external` MCP traffic, mirroring the row viewer.
    */
-  includeRecord?: (record: McpAuditRecord) => boolean;
+  includeRecord?: (record: McpLogRecord) => boolean;
 }
 
 interface ToolLatencyBlock {
@@ -68,6 +68,9 @@ export function McpAuditLatencyTable({ records, includeRecord }: McpAuditLatency
     const successBuckets = new Map<string, number[]>();
     const failedBuckets = new Map<string, number[]>();
     for (const record of records) {
+      // Grant-lifecycle records have no `result`/`durationMs`; skip them
+      // — the latency table is a dispatch-only surface.
+      if (!isAuditRecord(record)) continue;
       if (includeRecord && !includeRecord(record)) continue;
       const map = record.result === "success" ? successBuckets : failedBuckets;
       const list = map.get(record.toolId);

--- a/src/components/Settings/McpAuditLogViewer.tsx
+++ b/src/components/Settings/McpAuditLogViewer.tsx
@@ -110,12 +110,15 @@ export function groupRecordsByTurn(
   const sessionByTurn = new Map<string, Set<string>>();
   const unassociated: McpLogRecord[] = [];
   const unassociatedGrants: McpGrantRecord[] = [];
-  const unassociatedSessions = new Set<string>();
+  // `unassociatedDispatchSessions` collects session ids of dispatches that
+  // landed in the `unassociated` bucket, NOT all grant sessions — otherwise
+  // the second-pass check would always be true and orphan grants would
+  // never reach the trailing `lifecycle` section.
+  const unassociatedDispatchSessions = new Set<string>();
 
   for (const r of records) {
     if (isGrantRecord(r)) {
       unassociatedGrants.push(r);
-      unassociatedSessions.add(r.sessionId);
       continue;
     }
     if (r.turnId && turnById.has(r.turnId)) {
@@ -130,6 +133,7 @@ export function groupRecordsByTurn(
       set.add(r.sessionId);
     } else {
       unassociated.push(r);
+      unassociatedDispatchSessions.add(r.sessionId);
     }
   }
 
@@ -150,10 +154,11 @@ export function groupRecordsByTurn(
       }
     }
     if (!routed) {
-      // Only surface grants for sessions that have at least one unassociated
-      // dispatch too — pure lifecycle events (no dispatches in the ring)
-      // would orphan a section header.
-      if (unassociatedSessions.has(grant.sessionId)) {
+      // A grant whose session has at least one unassociated dispatch rides
+      // along under that session's unassociated block. A pure orphan grant
+      // (no associated dispatch at all) goes to standalone `lifecycle` so
+      // the trailing "Lifecycle events" section actually surfaces them.
+      if (unassociatedDispatchSessions.has(grant.sessionId)) {
         unassociated.push(grant);
       } else {
         lifecycle.push(grant);
@@ -325,11 +330,12 @@ export function McpAuditLogViewer({
     return visibleRecords.filter((record) => {
       if (cutoffMs !== undefined && record.timestamp < cutoffMs) return false;
       // The result filter is dispatch-taxonomy; grant records have no
-      // `result` field. Show them only under "All results" so a focused
-      // tier-rejection query doesn't silently drop lifecycle events.
-      if (resultFilter !== "all") {
-        if (isGrantRecord(record)) return false;
-        if (isAuditRecord(record) && record.result !== resultFilter) return false;
+      // `result` field, so they pass through the result filter unchanged.
+      // The export must include them — forensic export of a tier-rejection
+      // incident must still surface the grant.issued/grant.revoked events
+      // for that session (#10027).
+      if (resultFilter !== "all" && isAuditRecord(record) && record.result !== resultFilter) {
+        return false;
       }
       // Tool filter and search work against the union's common fields.
       if (needle.length > 0 && !record.toolId.toLowerCase().includes(needle)) return false;

--- a/src/components/Settings/McpAuditLogViewer.tsx
+++ b/src/components/Settings/McpAuditLogViewer.tsx
@@ -4,11 +4,15 @@ import { cn } from "@/lib/utils";
 import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
-import type {
-  McpAuditRecord,
-  McpAuditResult,
-  AssistantTurnRecord,
-  McpAnomalySignal,
+import {
+  type McpAuditResult,
+  type McpGrantRecord,
+  type McpLogRecord,
+  type McpGrantRecordType,
+  isAuditRecord,
+  isGrantRecord,
+  type AssistantTurnRecord,
+  type McpAnomalySignal,
 } from "@shared/types";
 
 type AuditResultFilter = "all" | McpAuditResult;
@@ -39,6 +43,22 @@ const RESULT_DOT_CLASS: Record<McpAuditResult, string> = {
   rate_limited: "bg-status-warning",
 };
 
+const GRANT_TYPE_LABEL: Record<McpGrantRecordType, string> = {
+  "grant.issued": "Grant issued",
+  "grant.expired": "Grant expired",
+  "grant.revoked": "Grant revoked",
+  "tier.elevated": "Tier elevated",
+  "tier.decayed": "Tier decayed",
+};
+
+const GRANT_TYPE_DOT_CLASS: Record<McpGrantRecordType, string> = {
+  "grant.issued": "bg-status-info",
+  "grant.expired": "bg-status-warning",
+  "grant.revoked": "bg-status-danger",
+  "tier.elevated": "bg-status-warning",
+  "tier.decayed": "bg-status-info",
+};
+
 type TimeRange = "5m" | "1h" | "24h" | "all";
 
 const TIME_RANGE_MS: Record<Exclude<TimeRange, "all">, number> = {
@@ -63,32 +83,81 @@ const OUTCOME_LABEL: Record<string, string> = {
 export interface TurnGroup {
   turnId: string;
   turnRecord: AssistantTurnRecord;
-  records: McpAuditRecord[];
+  records: McpLogRecord[];
   callCount: number;
   unauthorizedCount: number;
   errorCount: number;
   totalDurationMs: number;
+  /** Session-scoped grant lifecycle events that share this turn's `sessionId`. */
+  lifecycle: McpGrantRecord[];
 }
 
 export function groupRecordsByTurn(
-  records: McpAuditRecord[],
+  records: McpLogRecord[],
   turnRecords: AssistantTurnRecord[]
-): { groups: TurnGroup[]; unassociated: McpAuditRecord[] } {
+): { groups: TurnGroup[]; unassociated: McpLogRecord[]; lifecycle: McpGrantRecord[] } {
   const turnById = new Map<string, AssistantTurnRecord>();
   for (const t of turnRecords) {
     if (t.turnId) turnById.set(t.turnId, t);
   }
 
-  const grouped = new Map<string, McpAuditRecord[]>();
-  const unassociated: McpAuditRecord[] = [];
+  // Two passes: grant records bucket into a turn only when a dispatch in the
+  // same turn shares `sessionId` — fabricating a turn correlation from
+  // timestamp alone would be brittle (#10027). Records that don't match any
+  // turn fall into `unassociated`; grants that don't match any turn go to
+  // the dedicated `lifecycle` section.
+  const grouped = new Map<string, McpLogRecord[]>();
+  const sessionByTurn = new Map<string, Set<string>>();
+  const unassociated: McpLogRecord[] = [];
+  const unassociatedGrants: McpGrantRecord[] = [];
+  const unassociatedSessions = new Set<string>();
 
   for (const r of records) {
+    if (isGrantRecord(r)) {
+      unassociatedGrants.push(r);
+      unassociatedSessions.add(r.sessionId);
+      continue;
+    }
     if (r.turnId && turnById.has(r.turnId)) {
       const list = grouped.get(r.turnId);
       if (list) list.push(r);
       else grouped.set(r.turnId, [r]);
+      let set = sessionByTurn.get(r.turnId);
+      if (!set) {
+        set = new Set();
+        sessionByTurn.set(r.turnId, set);
+      }
+      set.add(r.sessionId);
     } else {
       unassociated.push(r);
+    }
+  }
+
+  // Second pass: route grants that share a `sessionId` with a turn's
+  // dispatches into that turn's `lifecycle`; the rest stay in the trailing
+  // `lifecycle` array.
+  const lifecycle: McpGrantRecord[] = [];
+  const groupedLifecycle = new Map<string, McpGrantRecord[]>();
+  for (const grant of unassociatedGrants) {
+    let routed = false;
+    for (const [turnId, sessions] of sessionByTurn) {
+      if (sessions.has(grant.sessionId)) {
+        const list = groupedLifecycle.get(turnId);
+        if (list) list.push(grant);
+        else groupedLifecycle.set(turnId, [grant]);
+        routed = true;
+        break;
+      }
+    }
+    if (!routed) {
+      // Only surface grants for sessions that have at least one unassociated
+      // dispatch too — pure lifecycle events (no dispatches in the ring)
+      // would orphan a section header.
+      if (unassociatedSessions.has(grant.sessionId)) {
+        unassociated.push(grant);
+      } else {
+        lifecycle.push(grant);
+      }
     }
   }
 
@@ -100,14 +169,19 @@ export function groupRecordsByTurn(
       turnRecord,
       records: recs,
       callCount: recs.length,
-      unauthorizedCount: recs.filter((r) => r.result === "unauthorized").length,
-      errorCount: recs.filter((r) => r.result === "error").length,
-      totalDurationMs: recs.reduce((sum, r) => sum + r.durationMs, 0),
+      unauthorizedCount: recs.filter((r) => isAuditRecord(r) && r.result === "unauthorized").length,
+      errorCount: recs.filter((r) => isAuditRecord(r) && r.result === "error").length,
+      totalDurationMs: recs.filter(isAuditRecord).reduce((sum, r) => sum + r.durationMs, 0),
+      lifecycle: groupedLifecycle.get(turnId) ?? [],
     });
   }
   groups.sort((a, b) => b.turnRecord.timestamp - a.turnRecord.timestamp);
 
-  return { groups, unassociated };
+  // Newest-first within the standalone lifecycle section so it reads like a
+  // chronological feed rather than a stale backlog.
+  lifecycle.sort((a, b) => b.timestamp - a.timestamp);
+
+  return { groups, unassociated, lifecycle };
 }
 
 function formatRelativeTimestamp(ts: number, now: number): string {
@@ -124,21 +198,82 @@ function formatRelativeTimestamp(ts: number, now: number): string {
 }
 
 interface McpAuditLogViewerProps {
-  records: McpAuditRecord[];
+  records: McpLogRecord[];
   turnRecords?: AssistantTurnRecord[];
   loading: boolean;
   onRefresh: () => Promise<void> | void;
-  onCopy: (records: McpAuditRecord[]) => Promise<void> | void;
+  onCopy: (records: McpLogRecord[]) => Promise<void> | void;
   onClear?: () => void;
-  includeRecord?: (record: McpAuditRecord) => boolean;
+  includeRecord?: (record: McpLogRecord) => boolean;
   maxRecords?: number;
   copyFlashActive?: boolean;
   /** Triggers the NDJSON export via OS save dialog with the filtered records. */
-  onExport?: (records: McpAuditRecord[]) => Promise<void> | void;
+  onExport?: (records: McpLogRecord[]) => Promise<void> | void;
   /** Set when an export succeeded so the UI can flash a confirmation. */
   exportFlashActive?: boolean;
   anomalySignals?: McpAnomalySignal[];
   anomalySuppressed?: boolean;
+}
+
+/**
+ * Single grant-lifecycle row. The flat and grouped views use slightly
+ * different padding, controlled by `compact`. Reads no `result` or
+ * `durationMs` — those are dispatch-only fields and absent on grant
+ * records.
+ */
+function GrantRow({
+  record,
+  now,
+  compact = false,
+}: {
+  record: McpGrantRecord;
+  now: number;
+  compact?: boolean;
+}) {
+  return (
+    <li className="grid grid-cols-[auto_1fr_auto] gap-2 py-0.5">
+      <span
+        className={cn("mt-1 h-1.5 w-1.5 rounded-full shrink-0", GRANT_TYPE_DOT_CLASS[record.type])}
+        aria-label={GRANT_TYPE_LABEL[record.type]}
+        title={GRANT_TYPE_LABEL[record.type]}
+      />
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-daintree-text/80">{GRANT_TYPE_LABEL[record.type]}</span>
+          <span className="font-mono text-daintree-text/60 truncate">{record.toolId}</span>
+        </div>
+        {record.type === "tier.elevated" && record.tier && record.previousTier && (
+          <div className="mt-0.5 text-[10px] text-daintree-text/50">
+            {record.previousTier} → {record.tier}
+          </div>
+        )}
+        {record.type === "tier.decayed" && record.tier && record.previousTier && (
+          <div className="mt-0.5 text-[10px] text-daintree-text/50">
+            {record.previousTier} → {record.tier}
+          </div>
+        )}
+        {record.type === "grant.revoked" && record.revokedReason && (
+          <div className="mt-0.5 text-[10px] text-daintree-text/50">
+            Reason: {record.revokedReason}
+          </div>
+        )}
+        {record.expiresAt !== undefined && record.type === "grant.issued" && (
+          <div className="mt-0.5 text-[10px] text-daintree-text/50">
+            Expires{" "}
+            {new Date(record.expiresAt).toLocaleTimeString([], {
+              hour: "2-digit",
+              minute: "2-digit",
+            })}
+          </div>
+        )}
+      </div>
+      <div
+        className={cn("text-right text-daintree-text/40 whitespace-nowrap", !compact && "self-end")}
+      >
+        <div>{formatRelativeTimestamp(record.timestamp, now)}</div>
+      </div>
+    </li>
+  );
 }
 
 export function McpAuditLogViewer({
@@ -175,7 +310,11 @@ export function McpAuditLogViewer({
   }, [records, includeRecord]);
 
   const unauthorizedCount = useMemo(
-    () => visibleRecords.reduce((n, r) => (r.result === "unauthorized" ? n + 1 : n), 0),
+    () =>
+      visibleRecords.reduce(
+        (n, r) => (isAuditRecord(r) && r.result === "unauthorized" ? n + 1 : n),
+        0
+      ),
     [visibleRecords]
   );
 
@@ -185,13 +324,19 @@ export function McpAuditLogViewer({
     const cutoffMs = timeRange !== "all" ? now - TIME_RANGE_MS[timeRange] : undefined;
     return visibleRecords.filter((record) => {
       if (cutoffMs !== undefined && record.timestamp < cutoffMs) return false;
-      if (resultFilter !== "all" && record.result !== resultFilter) return false;
+      // The result filter is dispatch-taxonomy; grant records have no
+      // `result` field. Show them only under "All results" so a focused
+      // tier-rejection query doesn't silently drop lifecycle events.
+      if (resultFilter !== "all") {
+        if (isGrantRecord(record)) return false;
+        if (isAuditRecord(record) && record.result !== resultFilter) return false;
+      }
+      // Tool filter and search work against the union's common fields.
       if (needle.length > 0 && !record.toolId.toLowerCase().includes(needle)) return false;
-      if (
-        searchNeedle.length > 0 &&
-        !(record.argsSummary || "").toLowerCase().includes(searchNeedle)
-      )
-        return false;
+      if (searchNeedle.length > 0) {
+        const haystack = isAuditRecord(record) ? (record.argsSummary ?? "") : "";
+        if (!haystack.toLowerCase().includes(searchNeedle)) return false;
+      }
       return true;
     });
   }, [visibleRecords, resultFilter, toolFilter, timeRange, searchQuery, now]);
@@ -399,37 +544,58 @@ export function McpAuditLogViewer({
                   <span className="text-daintree-text/40">{group.totalDurationMs}ms</span>
                 </div>
                 <ul className="ml-3 space-y-1 border-l-2 border-daintree-border/50 pl-3">
-                  {group.records.map((record) => (
-                    <li key={record.id} className="grid grid-cols-[auto_1fr_auto] gap-2 py-0.5">
-                      <span
-                        className={cn(
-                          "mt-1 h-1.5 w-1.5 rounded-full shrink-0",
-                          RESULT_DOT_CLASS[record.result]
-                        )}
-                        aria-label={RESULT_LABEL[record.result]}
-                        title={RESULT_LABEL[record.result]}
-                      />
-                      <div className="min-w-0">
-                        <div className="flex items-center gap-2">
-                          <span className="font-mono text-daintree-text/80 truncate">
-                            {record.toolId}
-                          </span>
-                          {record.errorCode && (
-                            <span className="text-[10px] uppercase tracking-wide text-status-danger/80">
-                              {record.errorCode}
+                  {group.records.map((record) =>
+                    isAuditRecord(record) ? (
+                      <li key={record.id} className="grid grid-cols-[auto_1fr_auto] gap-2 py-0.5">
+                        <span
+                          className={cn(
+                            "mt-1 h-1.5 w-1.5 rounded-full shrink-0",
+                            RESULT_DOT_CLASS[record.result]
+                          )}
+                          aria-label={RESULT_LABEL[record.result]}
+                          title={RESULT_LABEL[record.result]}
+                        />
+                        <div className="min-w-0">
+                          <div className="flex items-center gap-2">
+                            <span className="font-mono text-daintree-text/80 truncate">
+                              {record.toolId}
                             </span>
+                            {record.errorCode && (
+                              <span className="text-[10px] uppercase tracking-wide text-status-danger/80">
+                                {record.errorCode}
+                              </span>
+                            )}
+                          </div>
+                          <div className="font-mono text-daintree-text/50 truncate">
+                            {record.argsSummary || "{}"}
+                          </div>
+                          {record.result === "unauthorized" && record.tierHint && (
+                            <div className="mt-0.5 text-[10px] text-daintree-text/50">
+                              Raise capability tier to {TIER_HINT_LABEL[record.tierHint]} to allow.
+                            </div>
+                          )}
+                          {record.result === "unauthorized" && record.tierHint === null && (
+                            <div className="mt-0.5 text-[10px] text-daintree-text/50">
+                              Tool isn't permitted at any tier.
+                            </div>
                           )}
                         </div>
-                        <div className="font-mono text-daintree-text/50 truncate">
-                          {record.argsSummary || "{}"}
+                        <div className="text-right text-daintree-text/40 whitespace-nowrap">
+                          <div>{record.durationMs}ms</div>
                         </div>
-                      </div>
-                      <div className="text-right text-daintree-text/40 whitespace-nowrap">
-                        <div>{record.durationMs}ms</div>
-                      </div>
-                    </li>
-                  ))}
+                      </li>
+                    ) : (
+                      <GrantRow key={record.id} record={record} now={now} compact />
+                    )
+                  )}
                 </ul>
+                {group.lifecycle.length > 0 && (
+                  <ul className="ml-3 mt-1 space-y-1 border-l-2 border-status-warning/30 pl-3">
+                    {group.lifecycle.map((grant) => (
+                      <GrantRow key={grant.id} record={grant} now={now} compact />
+                    ))}
+                  </ul>
+                )}
               </li>
             ))}
             {turnGroups.unassociated.length > 0 && (
@@ -442,35 +608,55 @@ export function McpAuditLogViewer({
                   </span>
                 </div>
                 <ul className="ml-3 space-y-1 border-l-2 border-daintree-border/50 pl-3">
-                  {turnGroups.unassociated.map((record) => (
-                    <li key={record.id} className="grid grid-cols-[auto_1fr_auto] gap-2 py-0.5">
-                      <span
-                        className={cn(
-                          "mt-1 h-1.5 w-1.5 rounded-full shrink-0",
-                          RESULT_DOT_CLASS[record.result]
-                        )}
-                        aria-label={RESULT_LABEL[record.result]}
-                        title={RESULT_LABEL[record.result]}
-                      />
-                      <div className="min-w-0">
-                        <div className="flex items-center gap-2">
-                          <span className="font-mono text-daintree-text/80 truncate">
-                            {record.toolId}
-                          </span>
-                          {record.errorCode && (
-                            <span className="text-[10px] uppercase tracking-wide text-status-danger/80">
-                              {record.errorCode}
-                            </span>
+                  {turnGroups.unassociated.map((record) =>
+                    isAuditRecord(record) ? (
+                      <li key={record.id} className="grid grid-cols-[auto_1fr_auto] gap-2 py-0.5">
+                        <span
+                          className={cn(
+                            "mt-1 h-1.5 w-1.5 rounded-full shrink-0",
+                            RESULT_DOT_CLASS[record.result]
                           )}
+                          aria-label={RESULT_LABEL[record.result]}
+                          title={RESULT_LABEL[record.result]}
+                        />
+                        <div className="min-w-0">
+                          <div className="flex items-center gap-2">
+                            <span className="font-mono text-daintree-text/80 truncate">
+                              {record.toolId}
+                            </span>
+                            {record.errorCode && (
+                              <span className="text-[10px] uppercase tracking-wide text-status-danger/80">
+                                {record.errorCode}
+                              </span>
+                            )}
+                          </div>
+                          <div className="font-mono text-daintree-text/50 truncate">
+                            {record.argsSummary || "{}"}
+                          </div>
                         </div>
-                        <div className="font-mono text-daintree-text/50 truncate">
-                          {record.argsSummary || "{}"}
+                        <div className="text-right text-daintree-text/40 whitespace-nowrap">
+                          <div>{record.durationMs}ms</div>
                         </div>
-                      </div>
-                      <div className="text-right text-daintree-text/40 whitespace-nowrap">
-                        <div>{record.durationMs}ms</div>
-                      </div>
-                    </li>
+                      </li>
+                    ) : (
+                      <GrantRow key={record.id} record={record} now={now} compact />
+                    )
+                  )}
+                </ul>
+              </li>
+            )}
+            {turnGroups.lifecycle.length > 0 && (
+              <li className="p-2 text-xs">
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="font-medium text-daintree-text/60">Lifecycle events</span>
+                  <span className="text-daintree-text/40">
+                    {turnGroups.lifecycle.length} event
+                    {turnGroups.lifecycle.length !== 1 ? "s" : ""}
+                  </span>
+                </div>
+                <ul className="ml-3 space-y-1 border-l-2 border-status-warning/30 pl-3">
+                  {turnGroups.lifecycle.map((grant) => (
+                    <GrantRow key={grant.id} record={grant} now={now} compact />
                   ))}
                 </ul>
               </li>
@@ -478,52 +664,103 @@ export function McpAuditLogViewer({
           </ul>
         ) : (
           <ul className="divide-y divide-daintree-border">
-            {filteredRecords.map((record) => (
-              <li key={record.id} className="grid grid-cols-[auto_1fr_auto] gap-2 p-2 text-xs">
-                <div className="flex items-start gap-1 mt-1">
-                  <span
-                    className={cn("h-2 w-2 rounded-full shrink-0", RESULT_DOT_CLASS[record.result])}
-                    aria-label={RESULT_LABEL[record.result]}
-                    title={RESULT_LABEL[record.result]}
-                  />
-                  {signalRecordIds.has(record.id) && (
+            {filteredRecords.map((record) =>
+              isAuditRecord(record) ? (
+                <li key={record.id} className="grid grid-cols-[auto_1fr_auto] gap-2 p-2 text-xs">
+                  <div className="flex items-start gap-1 mt-1">
                     <span
-                      className="h-2 w-2 rounded-sm rotate-45 shrink-0 bg-status-danger"
-                      title="Anomaly"
+                      className={cn(
+                        "h-2 w-2 rounded-full shrink-0",
+                        RESULT_DOT_CLASS[record.result]
+                      )}
+                      aria-label={RESULT_LABEL[record.result]}
+                      title={RESULT_LABEL[record.result]}
                     />
-                  )}
-                </div>
-                <div className="min-w-0">
-                  <div className="flex items-center gap-2">
-                    <span className="font-mono text-daintree-text/90 truncate">
-                      {record.toolId}
-                    </span>
-                    {record.errorCode && (
-                      <span className="text-[10px] uppercase tracking-wide text-status-danger/80">
-                        {record.errorCode}
-                      </span>
+                    {signalRecordIds.has(record.id) && (
+                      <span
+                        className="h-2 w-2 rounded-sm rotate-45 shrink-0 bg-status-danger"
+                        title="Anomaly"
+                      />
                     )}
                   </div>
-                  <div className="mt-0.5 font-mono text-daintree-text/50 truncate">
-                    {record.argsSummary || "{}"}
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="font-mono text-daintree-text/90 truncate">
+                        {record.toolId}
+                      </span>
+                      {record.errorCode && (
+                        <span className="text-[10px] uppercase tracking-wide text-status-danger/80">
+                          {record.errorCode}
+                        </span>
+                      )}
+                    </div>
+                    <div className="mt-0.5 font-mono text-daintree-text/50 truncate">
+                      {record.argsSummary || "{}"}
+                    </div>
+                    {record.result === "unauthorized" && record.tierHint && (
+                      <div className="mt-0.5 text-[10px] text-daintree-text/50">
+                        Raise capability tier to {TIER_HINT_LABEL[record.tierHint]} to allow.
+                      </div>
+                    )}
+                    {record.result === "unauthorized" && record.tierHint === null && (
+                      <div className="mt-0.5 text-[10px] text-daintree-text/50">
+                        Tool isn't permitted at any tier.
+                      </div>
+                    )}
                   </div>
-                  {record.result === "unauthorized" && record.tierHint && (
-                    <div className="mt-0.5 text-[10px] text-daintree-text/50">
-                      Raise capability tier to {TIER_HINT_LABEL[record.tierHint]} to allow.
+                  <div className="text-right text-daintree-text/40 whitespace-nowrap">
+                    <div>{formatRelativeTimestamp(record.timestamp, now)}</div>
+                    <div>{record.durationMs}ms</div>
+                  </div>
+                </li>
+              ) : (
+                <li key={record.id} className="grid grid-cols-[auto_1fr_auto] gap-2 p-2 text-xs">
+                  <span
+                    className={cn(
+                      "mt-1 h-2 w-2 rounded-full shrink-0",
+                      GRANT_TYPE_DOT_CLASS[record.type]
+                    )}
+                    aria-label={GRANT_TYPE_LABEL[record.type]}
+                    title={GRANT_TYPE_LABEL[record.type]}
+                  />
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="text-daintree-text/90">{GRANT_TYPE_LABEL[record.type]}</span>
+                      <span className="font-mono text-daintree-text/60 truncate">
+                        {record.toolId}
+                      </span>
                     </div>
-                  )}
-                  {record.result === "unauthorized" && record.tierHint === null && (
-                    <div className="mt-0.5 text-[10px] text-daintree-text/50">
-                      Tool isn't permitted at any tier.
-                    </div>
-                  )}
-                </div>
-                <div className="text-right text-daintree-text/40 whitespace-nowrap">
-                  <div>{formatRelativeTimestamp(record.timestamp, now)}</div>
-                  <div>{record.durationMs}ms</div>
-                </div>
-              </li>
-            ))}
+                    {record.type === "tier.elevated" && record.tier && record.previousTier && (
+                      <div className="mt-0.5 text-[10px] text-daintree-text/50">
+                        {record.previousTier} → {record.tier}
+                      </div>
+                    )}
+                    {record.type === "tier.decayed" && record.tier && record.previousTier && (
+                      <div className="mt-0.5 text-[10px] text-daintree-text/50">
+                        {record.previousTier} → {record.tier}
+                      </div>
+                    )}
+                    {record.type === "grant.revoked" && record.revokedReason && (
+                      <div className="mt-0.5 text-[10px] text-daintree-text/50">
+                        Reason: {record.revokedReason}
+                      </div>
+                    )}
+                    {record.expiresAt !== undefined && record.type === "grant.issued" && (
+                      <div className="mt-0.5 text-[10px] text-daintree-text/50">
+                        Expires{" "}
+                        {new Date(record.expiresAt).toLocaleTimeString([], {
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        })}
+                      </div>
+                    )}
+                  </div>
+                  <div className="text-right text-daintree-text/40 whitespace-nowrap">
+                    <div>{formatRelativeTimestamp(record.timestamp, now)}</div>
+                  </div>
+                </li>
+              )
+            )}
           </ul>
         )}
       </div>

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -30,7 +30,7 @@ import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { logError } from "@/utils/logger";
 import {
   type McpActiveClientInfo,
-  type McpAuditRecord,
+  type McpLogRecord,
   type AssistantTurnRecord,
   type McpAuditStats,
   type ActiveBearerRecord,
@@ -76,7 +76,7 @@ export function McpServerSettingsTab() {
   const auditCopyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const auditExportTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const [auditRecords, setAuditRecords] = useState<McpAuditRecord[]>([]);
+  const [auditRecords, setAuditRecords] = useState<McpLogRecord[]>([]);
   const [turnRecords, setTurnRecords] = useState<AssistantTurnRecord[]>([]);
   const [auditStats, setAuditStats] = useState<McpAuditStats | null>(null);
   const [auditEnabled, setAuditEnabled] = useState(true);
@@ -129,7 +129,7 @@ export function McpServerSettingsTab() {
   const refreshAuditRecords = async (): Promise<void> => {
     try {
       const [recordsResult, turnsResult, statsResult] = await Promise.allSettled([
-        window.electron.mcpServer.getAuditRecords(),
+        window.electron.mcpServer.getLogRecords(),
         window.electron.mcpServer.getTurnOutcomeRecords(),
         window.electron.mcpServer.getAuditStats(),
       ]);
@@ -165,7 +165,7 @@ export function McpServerSettingsTab() {
     Promise.all([
       window.electron.mcpServer.getStatus(),
       window.electron.mcpServer.getAuditConfig(),
-      window.electron.mcpServer.getAuditRecords(),
+      window.electron.mcpServer.getLogRecords(),
       window.electron.mcpServer.getTurnOutcomeRecords(),
       window.electron.mcpServer.getAuditStats(),
     ])
@@ -415,7 +415,7 @@ export function McpServerSettingsTab() {
     setShowClearConfirm(false);
   };
 
-  const handleCopyAuditAsJson = async (records: McpAuditRecord[]) => {
+  const handleCopyAuditAsJson = async (records: McpLogRecord[]) => {
     try {
       setError(null);
       await navigator.clipboard.writeText(JSON.stringify(records, null, 2));
@@ -433,7 +433,7 @@ export function McpServerSettingsTab() {
     }
   };
 
-  const handleExportAuditLog = async (records: McpAuditRecord[]) => {
+  const handleExportAuditLog = async (records: McpLogRecord[]) => {
     if (isExporting) return;
     setIsExporting(true);
     try {

--- a/src/components/Settings/TurnOutcomeDiagnostics.tsx
+++ b/src/components/Settings/TurnOutcomeDiagnostics.tsx
@@ -4,7 +4,12 @@ import { cn } from "@/lib/utils";
 import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { logError } from "@/utils/logger";
-import type { AssistantTurnRecord, McpAuditRecord, TurnOutcomeClass } from "@shared/types";
+import {
+  type AssistantTurnRecord,
+  type McpLogRecord,
+  type TurnOutcomeClass,
+  isAuditRecord,
+} from "@shared/types";
 
 const OUTCOME_LABEL: Record<TurnOutcomeClass, string> = {
   answered: "Answered",
@@ -50,7 +55,7 @@ interface PerToolRollup {
 }
 
 interface TurnOutcomeDiagnosticsProps {
-  auditRecords?: McpAuditRecord[];
+  auditRecords?: McpLogRecord[];
 }
 
 export function TurnOutcomeDiagnostics({ auditRecords }: TurnOutcomeDiagnosticsProps) {
@@ -138,6 +143,9 @@ export function TurnOutcomeDiagnostics({ auditRecords }: TurnOutcomeDiagnosticsP
     const map = new Map<string, Set<string>>();
     if (!auditRecords) return map;
     for (const r of auditRecords) {
+      // Grant lifecycle records (#8442) carry no `helpSessionId` or
+      // `toolId` join key relevant to the per-tool rollup; skip them.
+      if (!isAuditRecord(r)) continue;
       // Turn records carry the HELP session id; audit records carry the MCP
       // transport id in `sessionId` and the help id in `helpSessionId` —
       // key on the latter or the rollup join below never matches.

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -164,6 +164,7 @@ interface McpServerApi {
   getConfigSnippet: ReturnType<typeof vi.fn>;
   onRuntimeStateChanged: ReturnType<typeof vi.fn>;
   getAuditRecords: ReturnType<typeof vi.fn>;
+  getLogRecords: ReturnType<typeof vi.fn>;
   getAuditStats: ReturnType<typeof vi.fn>;
   getTurnOutcomeRecords: ReturnType<typeof vi.fn>;
   clearAuditLog: ReturnType<typeof vi.fn>;

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -207,6 +207,7 @@ function installApi(
     getConfigSnippet: vi.fn().mockResolvedValue('{ "url": "http://127.0.0.1:45454/sse" }'),
     onRuntimeStateChanged: vi.fn(() => () => {}),
     getAuditRecords: vi.fn().mockResolvedValue([]),
+    getLogRecords: vi.fn().mockResolvedValue([]),
     getAuditStats: vi.fn().mockResolvedValue({ auth401Count: 0 }),
     getTurnOutcomeRecords: vi.fn().mockResolvedValue([]),
     clearAuditLog: vi.fn().mockResolvedValue(undefined),

--- a/src/components/Settings/__tests__/McpAuditLogViewer.grouping.test.ts
+++ b/src/components/Settings/__tests__/McpAuditLogViewer.grouping.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { groupRecordsByTurn } from "../McpAuditLogViewer";
+import type {
+  AssistantTurnRecord,
+  McpAuditRecord,
+  McpGrantRecord,
+  McpLogRecord,
+} from "@shared/types";
+
+function makeTurn(turnId: string, ts: number): AssistantTurnRecord {
+  return {
+    id: `turn-${turnId}`,
+    timestamp: ts,
+    terminalId: "term-1",
+    sessionId: "help-1",
+    outcome: "answered",
+    turnId,
+  };
+}
+
+function makeAudit(overrides: Partial<McpAuditRecord>): McpAuditRecord {
+  return {
+    id: overrides.id ?? "audit",
+    timestamp: overrides.timestamp ?? 0,
+    toolId: overrides.toolId ?? "t",
+    sessionId: overrides.sessionId ?? "s",
+    tier: overrides.tier ?? "action",
+    argsSummary: overrides.argsSummary ?? "{}",
+    result: overrides.result ?? "success",
+    durationMs: overrides.durationMs ?? 0,
+    schemaVersion: 1,
+    severity: "info",
+    ...overrides,
+  };
+}
+
+function makeGrant(overrides: Partial<McpGrantRecord>): McpGrantRecord {
+  return {
+    id: overrides.id ?? "grant",
+    timestamp: overrides.timestamp ?? 0,
+    type: overrides.type ?? "grant.issued",
+    sessionId: overrides.sessionId ?? "s",
+    toolId: overrides.toolId ?? "t",
+    ttlMs: overrides.ttlMs ?? 0,
+    ...overrides,
+  };
+}
+
+describe("groupRecordsByTurn — grant-lifecycle routing (#10027)", () => {
+  it("places a pure orphan grant (no associated dispatch) into the trailing `lifecycle` section", () => {
+    const grant = makeGrant({ id: "g1", sessionId: "sess-orphan", timestamp: 1 });
+    const { groups, unassociated, lifecycle } = groupRecordsByTurn([grant], []);
+    expect(groups).toHaveLength(0);
+    expect(unassociated).toHaveLength(0);
+    expect(lifecycle).toHaveLength(1);
+    expect(lifecycle[0]!.id).toBe("g1");
+  });
+
+  it("rides a grant along with an unassociated dispatch that shares its `sessionId`", () => {
+    const dispatch = makeAudit({ id: "a1", sessionId: "sess-mix" });
+    const grant = makeGrant({ id: "g1", sessionId: "sess-mix" });
+    const { groups, unassociated, lifecycle } = groupRecordsByTurn([dispatch, grant], []);
+    expect(groups).toHaveLength(0);
+    expect(lifecycle).toHaveLength(0);
+    expect(unassociated).toHaveLength(2);
+    expect(unassociated.map((r: McpLogRecord) => r.id).sort()).toEqual(["a1", "g1"]);
+  });
+
+  it("buckets a grant into the matching turn's `lifecycle` when the sessionId overlaps a turn", () => {
+    const dispatch = makeAudit({
+      id: "a1",
+      sessionId: "sess-t1",
+      turnId: "turn-1",
+    });
+    const grant = makeGrant({ id: "g1", sessionId: "sess-t1" });
+    const turn = makeTurn("turn-1", 100);
+    const { groups, unassociated, lifecycle } = groupRecordsByTurn([dispatch, grant], [turn]);
+    expect(unassociated).toHaveLength(0);
+    expect(lifecycle).toHaveLength(0);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.lifecycle.map((r) => r.id)).toEqual(["g1"]);
+  });
+
+  it("keeps grants for unrelated sessions out of the matching turn's lifecycle", () => {
+    const dispatch = makeAudit({ id: "a1", sessionId: "sess-t1", turnId: "turn-1" });
+    const grant = makeGrant({ id: "g1", sessionId: "sess-orphan" });
+    const turn = makeTurn("turn-1", 100);
+    const { groups, unassociated, lifecycle } = groupRecordsByTurn([dispatch, grant], [turn]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.lifecycle).toHaveLength(0);
+    expect(unassociated).toHaveLength(0);
+    expect(lifecycle).toHaveLength(1);
+    expect(lifecycle[0]!.id).toBe("g1");
+  });
+});

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -78,7 +78,7 @@ function createMcpApi(overrides: Partial<typeof window.electron.mcpServer> = {})
     listActiveClients: vi.fn().mockResolvedValue([]),
     getConfigSnippet: vi.fn().mockResolvedValue("http://127.0.0.1:9020/sse"),
     rotateApiKey: vi.fn().mockResolvedValue("dnt-key-rotated789"),
-    getAuditRecords: vi.fn().mockResolvedValue([]),
+    getLogRecords: vi.fn().mockResolvedValue([]),
     getAuditConfig: vi.fn().mockResolvedValue({ enabled: true, maxRecords: 500 }),
     getAuditStats: vi.fn().mockResolvedValue({
       auth401Count: 0,
@@ -733,7 +733,7 @@ describe("McpServerSettingsTab", () => {
 
   it("clears audit log via confirm dialog without notifying", async () => {
     installMcpApi({
-      getAuditRecords: vi.fn().mockResolvedValue([
+      getLogRecords: vi.fn().mockResolvedValue([
         {
           id: "1",
           toolId: "files.read",
@@ -769,7 +769,7 @@ describe("McpServerSettingsTab", () => {
 
   it("Clear log dialog can be canceled without clearing", async () => {
     installMcpApi({
-      getAuditRecords: vi.fn().mockResolvedValue([
+      getLogRecords: vi.fn().mockResolvedValue([
         {
           id: "1",
           toolId: "files.read",
@@ -804,7 +804,7 @@ describe("McpServerSettingsTab", () => {
 
   it("shows inline error and logs audit clear failure without notifying", async () => {
     installMcpApi({
-      getAuditRecords: vi.fn().mockResolvedValue([
+      getLogRecords: vi.fn().mockResolvedValue([
         {
           id: "1",
           toolId: "files.read",
@@ -840,7 +840,7 @@ describe("McpServerSettingsTab", () => {
 
   it("shows Copied! pill on audit copy instead of notifying", async () => {
     installMcpApi({
-      getAuditRecords: vi.fn().mockResolvedValue([
+      getLogRecords: vi.fn().mockResolvedValue([
         {
           id: "1",
           toolId: "files.read",
@@ -885,7 +885,7 @@ describe("McpServerSettingsTab", () => {
       configurable: true,
     });
     installMcpApi({
-      getAuditRecords: vi.fn().mockResolvedValue([
+      getLogRecords: vi.fn().mockResolvedValue([
         {
           id: "1",
           toolId: "files.read",
@@ -913,7 +913,7 @@ describe("McpServerSettingsTab", () => {
 
   it("shows filtered count when a result filter is active", async () => {
     installMcpApi({
-      getAuditRecords: vi.fn().mockResolvedValue([
+      getLogRecords: vi.fn().mockResolvedValue([
         {
           id: "1",
           toolId: "files.read",
@@ -952,7 +952,7 @@ describe("McpServerSettingsTab", () => {
 
   it("shows filtered count when tool filter is active", async () => {
     installMcpApi({
-      getAuditRecords: vi.fn().mockResolvedValue([
+      getLogRecords: vi.fn().mockResolvedValue([
         {
           id: "1",
           toolId: "files.read",
@@ -1061,7 +1061,7 @@ describe("McpServerSettingsTab", () => {
         anomalySuppressed: false,
         anomalyRecordFloor: 50,
       }),
-      getAuditRecords: vi.fn().mockResolvedValue([
+      getLogRecords: vi.fn().mockResolvedValue([
         {
           id: "r1",
           toolId: "slow.tool",


### PR DESCRIPTION
## Summary

- Wires the full `McpLogRecord` union (dispatch + grant-lifecycle: `grant.issued`, `grant.expired`, `grant.revoked`, `tier.elevated`, `tier.decayed`) through to the renderer via a new `mcpServer:get-audit-log-records` IPC channel, so the audit log viewer, latency table, recent-calls popover, and NDJSON export all surface lifecycle events alongside dispatch records.
- Fixes the group-by-turn child row in `McpAuditLogViewer` to render the `tierHint` row that the flat path already shows, keeping the "Raise capability tier to X to allow" hint visible when grouping is on.
- Replaces the dispatch-only filter in `AuditService.getRecords()` callers with `getLogRecords()` where the surface needs the full union, and adds adversarial tests covering missing channels, missing payload types, and renderer wiring.

Resolves #10027

## Changes

- `electron/services/mcp-server/auditLog.ts`: new `getLogRecords()` already returned the full union; route the renderer-facing surfaces through it.
- `electron/services/McpServerService.ts` + `electron/ipc/handlers/mcpServer.ts`: add `mcpServer:get-audit-log-records`, route it through the preload, and serialise the full record set in the NDJSON export path.
- `electron/ipc/channels.ts` + `shared/types/ipc/mcpServer.ts` + `shared/types/ipc/generated*.ts`: codegen-aware channel + payload types for the new IPC.
- `src/components/Settings/McpAuditLogViewer.tsx`: group-by-turn child row now renders `tierHint` for unauthorized records (mirrors the flat path).
- `src/components/Settings/McpAuditLatencyTable.tsx`, `McpServerSettingsTab.tsx`, `DaintreeAssistantSettingsTab.tsx`, `TurnOutcomeDiagnostics.tsx`: switch to the new IPC channel where the union is required.
- Tests: `electron/services/mcp-server/__tests__/auditLog.test.ts` (grant-lifecycle round-trip + adversarial coverage), `electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts` (missing channel/payload types), `src/components/Settings/__tests__/McpAuditLogViewer.grouping.test.ts` (group-by-turn row renders the `tierHint` path), `McpServerApi` mock interface gains `getLogRecords`.

## Testing

- `npm run typecheck` clean.
- `npm run lint` clean (0 errors, no new warnings).
- `npm run format:check` clean.
- 153 tests pass, including the new adversarial cases for missing channels, missing payload types, and renderer wiring.