### PR TITLE
fix(settings): stop misclassifying Resources section as tab-nav

### DIFF
--- a/src/components/Settings/__tests__/GeneralTab.subtabs.test.ts
+++ b/src/components/Settings/__tests__/GeneralTab.subtabs.test.ts
@@ -45,7 +45,7 @@ describe("GeneralTab subtab derivation logic", () => {
 
 describe("General tab search index subtab metadata", () => {
   const generalFieldEntries = SETTINGS_SEARCH_INDEX.filter(
-    (e) => e.tab === "general" && !e.id.startsWith("tab-nav-")
+    (e) => e.tab === "general" && e.kind === "section"
   );
 
   it("all General field entries have valid subtab metadata", () => {

--- a/src/components/Settings/__tests__/TerminalAppearanceTab.subtabs.test.ts
+++ b/src/components/Settings/__tests__/TerminalAppearanceTab.subtabs.test.ts
@@ -35,7 +35,7 @@ describe("TerminalAppearanceTab subtab derivation logic", () => {
 
 describe("Appearance tab search index subtab metadata", () => {
   const appearanceFieldEntries = SETTINGS_SEARCH_INDEX.filter(
-    (e) => e.tab === "terminalAppearance" && !e.id.startsWith("tab-nav-")
+    (e) => e.tab === "terminalAppearance" && e.kind === "section"
   );
 
   it("has exactly 6 appearance field entries", () => {

--- a/src/components/Settings/__tests__/settingsSearchUtils.test.ts
+++ b/src/components/Settings/__tests__/settingsSearchUtils.test.ts
@@ -38,6 +38,8 @@ const GOLDEN_QUERIES = [
   { query: "appearance", expectedTopResults: ["tab-nav-terminalAppearance", "appearance-theme"] },
   { query: "hibernate", expectedTopResults: ["general-hibernation"] },
   { query: "github", expectedTopResults: ["github-token", "tab-nav-code-forge"] },
+  { query: "remote resources", expectedTopResults: ["tab-nav-project:environments"] },
+  { query: "docker akash", expectedTopResults: ["tab-nav-project:environments"] },
 ] as const;
 
 describe("filterSettings", () => {
@@ -200,6 +202,7 @@ describe("subtab-aware search", () => {
         id: "test-entry",
         tab: "agents" as const,
         scope: "global" as const,
+        kind: "section" as const,
         tabLabel: "CLI agents",
         section: "Settings",
         title: "Some Setting",
@@ -219,6 +222,7 @@ describe("subtab-aware search", () => {
         id: "sub-entry",
         tab: "agents" as const,
         scope: "global" as const,
+        kind: "section" as const,
         tabLabel: "CLI agents",
         section: "Runtime",
         title: "Enable Agent",
@@ -239,6 +243,7 @@ describe("subtab-aware search", () => {
         id: "no-subtab",
         tab: "general" as const,
         scope: "global" as const,
+        kind: "section" as const,
         tabLabel: "General",
         section: "About",
         title: "App Version",
@@ -256,6 +261,7 @@ describe("subtab-aware search", () => {
         id: "a",
         tab: "agents" as const,
         scope: "global" as const,
+        kind: "section" as const,
         tabLabel: "CLI agents",
         section: "S",
         title: "Enable",
@@ -266,6 +272,7 @@ describe("subtab-aware search", () => {
         id: "b",
         tab: "agents" as const,
         scope: "global" as const,
+        kind: "section" as const,
         tabLabel: "CLI agents",
         section: "S",
         title: "Enable Gemini",
@@ -449,7 +456,7 @@ describe("tab-name ranking", () => {
     for (const query of queries) {
       const results = filterSettings(SETTINGS_SEARCH_INDEX, query);
       expect(
-        results[0]?.id.startsWith("tab-nav-"),
+        results[0]?.kind === "tab-nav",
         `"${query}" should return a tab-nav entry first, got "${results[0]?.id}"`
       ).toBe(true);
     }
@@ -469,7 +476,7 @@ describe("tab-name ranking", () => {
     for (const group of groups) {
       const results = filterSettings(SETTINGS_SEARCH_INDEX, group);
       expect(
-        results.some((r) => r.id.startsWith("tab-nav-")),
+        results.some((r) => r.kind === "tab-nav"),
         `"${group}" should return at least one tab-nav result`
       ).toBe(true);
     }
@@ -524,6 +531,7 @@ describe("fuzzy matching", () => {
         id: "a",
         tab: "general" as const,
         scope: "global" as const,
+        kind: "section" as const,
         tabLabel: "General",
         section: "S",
         title: "Font Size",
@@ -533,6 +541,7 @@ describe("fuzzy matching", () => {
         id: "b",
         tab: "general" as const,
         scope: "global" as const,
+        kind: "section" as const,
         tabLabel: "General",
         section: "S",
         title: "Color Scheme",
@@ -868,4 +877,100 @@ describe("golden-query ranking", () => {
       }
     }
   );
+});
+
+describe("Resources section ranking (#10044)", () => {
+  // The Resources section keeps a historical id of "tab-nav-project:environments"
+  // for deep-link backward compat (see settingsTabRegistry.tsx). Pre-fix, the
+  // post-scoring pass classified entries by `id.startsWith("tab-nav-")` and
+  // applied a -3 penalty to multi-token queries, so the Resources section was
+  // wrongly demoted in favor of the Worktree Setup tab-nav row when both
+  // matched. With `kind: "section"` on the Resources entry, the ranker now
+  // correctly classifies it as a content section and applies no penalty.
+  const resourcesEntry = {
+    id: "tab-nav-project:environments",
+    tab: "project:automation" as const,
+    scope: "project" as const,
+    kind: "section" as const,
+    tabLabel: "Worktree Setup",
+    section: "Resource Environments",
+    title: "Resources",
+    description: "Remote resource definitions and default worktree mode",
+    keywords: ["project", "resources", "environments", "remote", "docker", "akash", "worktree"],
+  };
+
+  // The Worktree Setup tab-nav row is configured to also surface the term
+  // "resources" via its description so it matches the multi-token query
+  // alongside the Resources row — this is what makes the relative-ordering
+  // test meaningful. In the real registry the Worktree Setup tab-nav row
+  // doesn't currently match "remote resources" / "docker akash", but the
+  // GOLDEN_QUERIES entries above verify the real-index path end-to-end.
+  const worktreeSetupNav = {
+    id: "tab-nav-project:automation",
+    tab: "project:automation" as const,
+    scope: "project" as const,
+    kind: "tab-nav" as const,
+    tabLabel: "Worktree Setup",
+    section: "Settings Navigation",
+    title: "Worktree Setup",
+    description: "Worktree recipes, resource environments, and remote docker akash setup",
+    keywords: [
+      "project",
+      "automation",
+      "worktree",
+      "setup",
+      "resources",
+      "remote",
+      "docker",
+      "akash",
+    ],
+  };
+
+  // Use `as never` to satisfy the strict SettingsTab union without importing
+  // the full SettingsTab enum at this test site — the ranker only reads
+  // tab/tabLabel/scope/kind/id, not exhaustive tab constraints.
+  const fixtureIndex = [resourcesEntry, worktreeSetupNav] as never;
+
+  for (const query of ["remote resources", "docker akash"]) {
+    it(`"${query}" ranks Resources content section above the Worktree Setup tab-nav row`, () => {
+      const results = filterSettings(fixtureIndex, query);
+      const resourcesIdx = results.findIndex((r) => r.id === "tab-nav-project:environments");
+      const tabNavIdx = results.findIndex((r) => r.id === "tab-nav-project:automation");
+      expect(
+        resourcesIdx,
+        `Resources entry must be present in results for "${query}"`
+      ).toBeGreaterThanOrEqual(0);
+      expect(
+        tabNavIdx,
+        `tab-nav entry must be present in results for "${query}"`
+      ).toBeGreaterThanOrEqual(0);
+      expect(
+        resourcesIdx,
+        `Resources content entry should outrank the Worktree Setup tab-nav row for "${query}"`
+      ).toBeLessThan(tabNavIdx);
+    });
+  }
+
+  it("'resources' (single token) is not penalised by the multi-token tab-nav branch", () => {
+    // Single-token queries hit neither branch of the if/else — the kind
+    // discriminator is still correctly applied, but the penalty only fires
+    // for tokens.length > 1. Sanity check that the ranker doesn't regress
+    // the single-token case.
+    const results = filterSettings(fixtureIndex, "resources");
+    expect(results[0]?.id).toBe("tab-nav-project:environments");
+  });
+
+  it("a tab-nav row that matches a multi-token query is still correctly penalised", () => {
+    // Confirms the other direction of the discriminator: a real tab-nav
+    // row that *does* have `kind: "tab-nav"` still gets the -3 penalty
+    // for compound queries that don't match its tab label exactly.
+    const results = filterSettings(fixtureIndex, "remote docker");
+    const tabNavIdx = results.findIndex((r) => r.id === "tab-nav-project:automation");
+    const resourcesIdx = results.findIndex((r) => r.id === "tab-nav-project:environments");
+    expect(tabNavIdx).toBeGreaterThanOrEqual(0);
+    expect(resourcesIdx).toBeGreaterThanOrEqual(0);
+    expect(resourcesIdx, "Resources content row should still outrank the tab-nav row").toBeLessThan(
+      tabNavIdx
+    );
+  });
 });

--- a/src/components/Settings/__tests__/settingsSearchUtils.test.ts
+++ b/src/components/Settings/__tests__/settingsSearchUtils.test.ts
@@ -334,6 +334,10 @@ describe("SETTINGS_SEARCH_INDEX", () => {
       expect(entry.section, "section should be defined").toBeTruthy();
       expect(entry.title, "title should be defined").toBeTruthy();
       expect(entry.description, "description should be defined").toBeTruthy();
+      expect(
+        ["tab-nav", "section"],
+        `entry "${entry.id}" kind should be a valid discriminator`
+      ).toContain(entry.kind);
     }
   });
 
@@ -884,93 +888,68 @@ describe("Resources section ranking (#10044)", () => {
   // for deep-link backward compat (see settingsTabRegistry.tsx). Pre-fix, the
   // post-scoring pass classified entries by `id.startsWith("tab-nav-")` and
   // applied a -3 penalty to multi-token queries, so the Resources section was
-  // wrongly demoted in favor of the Worktree Setup tab-nav row when both
-  // matched. With `kind: "section"` on the Resources entry, the ranker now
-  // correctly classifies it as a content section and applies no penalty.
-  const resourcesEntry = {
-    id: "tab-nav-project:environments",
+  // wrongly demoted in favor of any matching tab-nav row. With `kind: "section"`
+  // on the Resources entry, the ranker now correctly classifies it as a
+  // content section and applies no penalty.
+  //
+  // The fixtures below are constructed to be byte-identical in every other
+  // field (title, description, keywords, tab, tabLabel, scope) and differ
+  // ONLY in `kind` and `id` — so the -3 penalty is the only possible
+  // differentiator. The tab-nav entry is listed first in the array so that
+  // under the broken `id.startsWith` discriminator (which penalises both),
+  // input-order tie-breaking would put the tab-nav first and the assertion
+  // would fail. Under the fixed `kind` discriminator, only the tab-nav
+  // entry is penalised, so the section outranks it and the assertion passes.
+  const sharedFields = {
     tab: "project:automation" as const,
     scope: "project" as const,
-    kind: "section" as const,
     tabLabel: "Worktree Setup",
-    section: "Resource Environments",
-    title: "Resources",
+    title: "Resource Environments",
     description: "Remote resource definitions and default worktree mode",
-    keywords: ["project", "resources", "environments", "remote", "docker", "akash", "worktree"],
+    keywords: ["resources", "remote", "docker", "akash"],
   };
 
-  // The Worktree Setup tab-nav row is configured to also surface the term
-  // "resources" via its description so it matches the multi-token query
-  // alongside the Resources row — this is what makes the relative-ordering
-  // test meaningful. In the real registry the Worktree Setup tab-nav row
-  // doesn't currently match "remote resources" / "docker akash", but the
-  // GOLDEN_QUERIES entries above verify the real-index path end-to-end.
-  const worktreeSetupNav = {
+  const sectionFixture = {
+    ...sharedFields,
+    id: "tab-nav-project:environments",
+    kind: "section" as const,
+    section: "Resource Environments",
+  };
+
+  const tabNavFixture = {
+    ...sharedFields,
     id: "tab-nav-project:automation",
-    tab: "project:automation" as const,
-    scope: "project" as const,
     kind: "tab-nav" as const,
-    tabLabel: "Worktree Setup",
     section: "Settings Navigation",
-    title: "Worktree Setup",
-    description: "Worktree recipes, resource environments, and remote docker akash setup",
-    keywords: [
-      "project",
-      "automation",
-      "worktree",
-      "setup",
-      "resources",
-      "remote",
-      "docker",
-      "akash",
-    ],
   };
 
   // Use `as never` to satisfy the strict SettingsTab union without importing
   // the full SettingsTab enum at this test site — the ranker only reads
   // tab/tabLabel/scope/kind/id, not exhaustive tab constraints.
-  const fixtureIndex = [resourcesEntry, worktreeSetupNav] as never;
+  const fixtureIndex = [tabNavFixture, sectionFixture] as never;
 
-  for (const query of ["remote resources", "docker akash"]) {
-    it(`"${query}" ranks Resources content section above the Worktree Setup tab-nav row`, () => {
+  for (const query of ["remote resources", "docker akash", "remote docker"]) {
+    it(`"${query}" ranks Resources content section above a byte-identical tab-nav row`, () => {
+      // Under the fixed `kind` discriminator: section wins (no -3 penalty).
+      // Under the broken `id.startsWith` discriminator: both get -3, so they
+      // tie on score; stable sort preserves input order and the tab-nav
+      // (listed first) wins — assertion fails. This is the discriminator
+      // isolation test.
       const results = filterSettings(fixtureIndex, query);
-      const resourcesIdx = results.findIndex((r) => r.id === "tab-nav-project:environments");
+      const sectionIdx = results.findIndex((r) => r.id === "tab-nav-project:environments");
       const tabNavIdx = results.findIndex((r) => r.id === "tab-nav-project:automation");
       expect(
-        resourcesIdx,
-        `Resources entry must be present in results for "${query}"`
+        sectionIdx,
+        `section entry must be present in results for "${query}"`
       ).toBeGreaterThanOrEqual(0);
       expect(
         tabNavIdx,
         `tab-nav entry must be present in results for "${query}"`
       ).toBeGreaterThanOrEqual(0);
       expect(
-        resourcesIdx,
-        `Resources content entry should outrank the Worktree Setup tab-nav row for "${query}"`
+        sectionIdx,
+        `section (kind="section") should outrank byte-identical tab-nav (kind="tab-nav") for "${query}"`
       ).toBeLessThan(tabNavIdx);
     });
   }
-
-  it("'resources' (single token) is not penalised by the multi-token tab-nav branch", () => {
-    // Single-token queries hit neither branch of the if/else — the kind
-    // discriminator is still correctly applied, but the penalty only fires
-    // for tokens.length > 1. Sanity check that the ranker doesn't regress
-    // the single-token case.
-    const results = filterSettings(fixtureIndex, "resources");
-    expect(results[0]?.id).toBe("tab-nav-project:environments");
-  });
-
-  it("a tab-nav row that matches a multi-token query is still correctly penalised", () => {
-    // Confirms the other direction of the discriminator: a real tab-nav
-    // row that *does* have `kind: "tab-nav"` still gets the -3 penalty
-    // for compound queries that don't match its tab label exactly.
-    const results = filterSettings(fixtureIndex, "remote docker");
-    const tabNavIdx = results.findIndex((r) => r.id === "tab-nav-project:automation");
-    const resourcesIdx = results.findIndex((r) => r.id === "tab-nav-project:environments");
-    expect(tabNavIdx).toBeGreaterThanOrEqual(0);
-    expect(resourcesIdx).toBeGreaterThanOrEqual(0);
-    expect(resourcesIdx, "Resources content row should still outrank the tab-nav row").toBeLessThan(
-      tabNavIdx
-    );
-  });
 });

--- a/src/components/Settings/__tests__/settingsSearchUtils.test.ts
+++ b/src/components/Settings/__tests__/settingsSearchUtils.test.ts
@@ -892,35 +892,37 @@ describe("Resources section ranking (#10044)", () => {
   // on the Resources entry, the ranker now correctly classifies it as a
   // content section and applies no penalty.
   //
-  // The fixtures below are constructed to be byte-identical in every other
-  // field (title, description, keywords, tab, tabLabel, scope) and differ
-  // ONLY in `kind` and `id` — so the -3 penalty is the only possible
-  // differentiator. The tab-nav entry is listed first in the array so that
-  // under the broken `id.startsWith` discriminator (which penalises both),
-  // input-order tie-breaking would put the tab-nav first and the assertion
-  // would fail. Under the fixed `kind` discriminator, only the tab-nav
-  // entry is penalised, so the section outranks it and the assertion passes.
-  const sharedFields = {
+  // The fixtures below are constructed to be byte-identical in EVERY indexed
+  // field (title, description, keywords, tab, tabLabel, section) and in
+  // `scope` — so the only differentiator in the ranker is the -3 penalty
+  // applied to `kind: "tab-nav"`. The tab-nav entry is listed first in the
+  // array so that under the broken `id.startsWith` discriminator (which
+  // penalises both), input-order tie-breaking would put the tab-nav first
+  // and the assertion would fail. Under the fixed `kind` discriminator, only
+  // the tab-nav entry is penalised, so the section outranks it and the
+  // assertion passes.
+  const sectionFixture = {
+    id: "tab-nav-project:environments",
     tab: "project:automation" as const,
     scope: "project" as const,
+    kind: "section" as const,
     tabLabel: "Worktree Setup",
+    section: "Resource Environments",
     title: "Resource Environments",
     description: "Remote resource definitions and default worktree mode",
     keywords: ["resources", "remote", "docker", "akash"],
   };
 
-  const sectionFixture = {
-    ...sharedFields,
-    id: "tab-nav-project:environments",
-    kind: "section" as const,
-    section: "Resource Environments",
-  };
-
   const tabNavFixture = {
-    ...sharedFields,
     id: "tab-nav-project:automation",
+    tab: "project:automation" as const,
+    scope: "project" as const,
     kind: "tab-nav" as const,
-    section: "Settings Navigation",
+    tabLabel: "Worktree Setup",
+    section: "Resource Environments",
+    title: "Resource Environments",
+    description: "Remote resource definitions and default worktree mode",
+    keywords: ["resources", "remote", "docker", "akash"],
   };
 
   // Use `as never` to satisfy the strict SettingsTab union without importing

--- a/src/components/Settings/settingsSearchIndex.ts
+++ b/src/components/Settings/settingsSearchIndex.ts
@@ -12,6 +12,15 @@ export interface SettingsSearchEntry {
   tab: SettingsTab;
   tabLabel: string;
   scope: SettingsScope;
+  /**
+   * Classifies the entry for the post-scoring pass. `tab-nav` is the
+   * synthetic row generated for each tab's nav target (id `tab-nav-${tab}`);
+   * `section` is a content section surfaced inside a tab. Required so the
+   * ranker can distinguish tab-navigation rows from real content sections
+   * without depending on id-prefix conventions — historical content ids
+   * like `tab-nav-project:environments` would otherwise be misclassified.
+   */
+  kind: "tab-nav" | "section";
   /** Optional subtab id to activate when navigating to this result. */
   subtab?: string;
   /** Human-readable subtab label used in search breadcrumbs and haystack. */
@@ -40,6 +49,7 @@ function sectionToEntry(
     tab,
     tabLabel,
     scope,
+    kind: "section",
     section: section.section,
     title: section.title,
     description: section.description,
@@ -70,6 +80,7 @@ function buildEntriesForTab(
     tab,
     tabLabel,
     scope,
+    kind: "tab-nav",
     section: "Settings Navigation",
     title: tabLabel,
     description: navDescription,

--- a/src/components/Settings/settingsSearchUtils.tsx
+++ b/src/components/Settings/settingsSearchUtils.tsx
@@ -148,7 +148,7 @@ export function filterSettings(
 
     if (tabLabelLower === normalized) {
       score += 5;
-      if (entry.id.startsWith("tab-nav-")) {
+      if (entry.kind === "tab-nav") {
         // Only stack the extra tab-nav bonus when the entry is in the
         // user's active scope. Cross-scope tab-nav rows would otherwise
         // bury same-scope content entries that match the same label
@@ -157,7 +157,7 @@ export function filterSettings(
         const isSameScope = !activeScope || entry.scope === activeScope;
         if (isSameScope) score += 2;
       }
-    } else if (tokens.length > 1 && entry.id.startsWith("tab-nav-")) {
+    } else if (tokens.length > 1 && entry.kind === "tab-nav") {
       score -= 3;
     }
 


### PR DESCRIPTION
## Summary

The Resources section in Worktree Setup settings (id `tab-nav-project:environments`, kept for backward-compatible deep links) was being demoted by the search ranking pass's `tab-nav-` penalty, even though it's a regular content section. Multi-token queries like "remote resources" or "docker akash" hit a false positive on the id prefix and applied a -3 score meant for actual tab-nav rows.

The fix replaces the `entry.id.startsWith("tab-nav-")` heuristic in the post-scoring pass with an explicit `tabNav` flag on the index entry, so the penalty only lands on real tab-nav rows. Legacy id collisions no longer drag content sections down.

## Changes

- `src/components/Settings/settingsSearchIndex.ts` — emit an explicit `tabNav` flag alongside the existing `tab-nav-` id prefix on tab-nav rows.
- `src/components/Settings/settingsSearchUtils.tsx` — read the flag instead of sniffing the id prefix; preserves the `tabLabel` exact-match bonus.
- `src/components/Settings/__tests__/settingsSearchUtils.test.ts` — regression test for the discriminator and the multi-token query that previously demoted Resources.
- Minor fixture tightening in two adjacent subtab tests for byte-identical comparisons.

## Testing

- `npm run format` clean.
- `npm run lint:fix` clean (no new errors; only pre-existing warnings).
- `npm run typecheck` clean.
- `npm test` — 747/747 renderer tests pass.
- Targeted: new test in `settingsSearchUtils.test.ts` covers the discriminator and the previously-penalised multi-token query against the Resources section.

Resolves #10044