### PR TITLE
fix(ci): verify nightly metadata at CDN edge after upload

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -610,6 +610,22 @@ jobs:
             --include "latest*.yml" \
             --cache-control "no-cache, no-store, must-revalidate"
 
+      - name: Verify macOS metadata at CDN edge
+        shell: bash
+        env:
+          PUBLISH_URL: https://updates.daintree.org/nightly/
+          UPDATE_METADATA_PREFIX: latest
+          METADATA_SUFFIX: "-mac"
+        run: node scripts/ci/verify-r2-metadata.mjs
+
+      - name: Verify Linux metadata at CDN edge
+        shell: bash
+        env:
+          PUBLISH_URL: https://updates.daintree.org/nightly/
+          UPDATE_METADATA_PREFIX: latest
+          METADATA_SUFFIX: "-linux"
+        run: node scripts/ci/verify-r2-metadata.mjs
+
       - name: Clean up old nightly builds
         shell: bash
         env:


### PR DESCRIPTION
## Summary

- The nightly publish job uploaded binaries and `latest*.yml` metadata to R2 but never verified that the metadata had propagated at the Cloudflare CDN edge, unlike the stable release path which runs `verify-r2-metadata.mjs` after every metadata upload to guard the edge-cache hazard documented in #9122.
- Nightly clients auto-update from `https://updates.daintree.org/nightly/` and poll the same kind of metadata YAML, so they're exposed to the same cached-404 / stale-metadata failure mode.
- This closes the gap by mirroring the stable fail-closed pattern.

Resolves #10031

## Changes

- `.github/workflows/nightly.yml`: adds two sequential CDN-edge verification steps after "Upload metadata to R2" and before "Clean up old nightly builds" — one for `latest-mac.yml` (`METADATA_SUFFIX=-mac`) and one for `latest-linux.yml` (`METADATA_SUFFIX=-linux`). Windows is intentionally excluded because it's not part of the nightly publish job. Cleanup has no `if: always()` guard, so a verification failure fail-closes before cleanup runs. 16 lines added, single file.

## Testing

- `verify-r2-metadata.mjs` vitest suite (46 tests) passed.
- All 10 runnable static checks passed: format, typecheck, channel/IPC/confirm-wiring guards, lint ratchet.
- Full test suite and build are blocked in this worktree env by a missing Electron binary (pre-existing constraint); this is a YAML-only change touching no app code. GitHub CI will confirm.