### PR TITLE
fix(ci): repair stale-quarantine duplicate-comment guard

### DIFF
--- a/.github/workflows/stale-quarantine.yml
+++ b/.github/workflows/stale-quarantine.yml
@@ -180,6 +180,13 @@ jobs:
                 const existing = existingIssues.find(i => i.title === title);
 
                 if (existing) {
+                  // The first report for an issue lives in the issue body, not a
+                  // comment, so dedup against it too or run 2 would always re-post.
+                  if (normalize(existing.body) === normalize(body)) {
+                    console.log(`Skipped commenting on #${existing.number}: issue body already matches.`);
+                    continue;
+                  }
+
                   // Check if the most recent comment already matches this body.
                   // The issue-comments endpoint ignores sort/direction and returns
                   // comments oldest-first, so paginate and take the last one.

--- a/.github/workflows/stale-quarantine.yml
+++ b/.github/workflows/stale-quarantine.yml
@@ -143,6 +143,9 @@ jobs:
               console.log(`  ${relPath}: ${annotations.length} stale annotation(s)`);
             }
 
+            // Strip the moving threshold date so an unchanged report dedups across weekly runs
+            const normalize = (s) => (s || '').replace(/\(threshold: `[^`]*`\)/g, '(threshold: NORMALIZED)');
+
             // List all open test-quarantine issues (may be more than one page)
             const existingIssues = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
@@ -177,17 +180,18 @@ jobs:
                 const existing = existingIssues.find(i => i.title === title);
 
                 if (existing) {
-                  // Check if the most recent comment already matches this body
-                  const { data: comments } = await github.rest.issues.listComments({
+                  // Check if the most recent comment already matches this body.
+                  // The issue-comments endpoint ignores sort/direction and returns
+                  // comments oldest-first, so paginate and take the last one.
+                  const comments = await github.paginate(github.rest.issues.listComments, {
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: existing.number,
-                    per_page: 1,
-                    sort: 'created',
-                    direction: 'desc',
+                    per_page: 100,
                   });
+                  const latestComment = comments.at(-1);
 
-                  if (comments.length > 0 && comments[0].body === body) {
+                  if (latestComment && normalize(latestComment.body) === normalize(body)) {
                     console.log(`Skipped commenting on #${existing.number}: most recent comment already matches.`);
                     continue;
                   }


### PR DESCRIPTION
## Summary

- The issue-comments endpoint ignores `sort`/`direction` params, so the duplicate guard was always checking the oldest comment instead of the latest. Switched to `github.paginate` + `.at(-1)` to get the true last comment.
- The report body embeds a moving threshold date recomputed each run, so raw string equality always failed week-to-week. Added a `normalize()` helper that strips the `(threshold: ...)` parenthetical from both strings before comparing.
- The first report for a new tracking issue lives in the issue body, not a comment, so the run after issue creation always posted a duplicate. Now also compares against `existing.body` — no extra API call needed, the body is already fetched by the `listForRepo` paginate.

Resolves #10055.

## Changes

- `.github/workflows/stale-quarantine.yml`: switch comment fetch to `github.paginate` + `.at(-1)`, add `normalize()` helper, add `existing.body` dedup check

## Testing

Static checks and build pass locally. The workflow is YAML-only with no unit test coverage; the three fixes are verified by reading the GitHub API docs and tracing the control flow.