### PR TITLE
fix(demo): track live chunkCount during capture and rename from frameCount

### DIFF
--- a/e2e/screenshots/demo-reel.spec.ts
+++ b/e2e/screenshots/demo-reel.spec.ts
@@ -273,7 +273,7 @@ test.describe.serial("Demo Video — worktree dashboard", () => {
       expect(existsSync(outputPath)).toBe(true);
       const bytes = statSync(outputPath).size;
       console.log(`[demo-reel] wrote ${outputPath} (${(bytes / 1_000_000).toFixed(1)} MB)`);
-      expect(result.stop.frameCount).toBeGreaterThan(3);
+      expect(result.stop.chunkCount).toBeGreaterThan(3);
       expect(bytes).toBeGreaterThan(10_000);
     } finally {
       if (app) await closeApp(app).catch(() => {});

--- a/electron/ipc/handlers/__tests__/demo.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/demo.handlers.test.ts
@@ -240,6 +240,35 @@ describe("registerDemoHandlers", () => {
       cleanup();
     });
 
+    it("getCaptureStatus reports live chunkCount as chunks arrive during capture", async () => {
+      autoResolveCommandDone();
+      const deps = makeDeps(true);
+      const cleanup = registerDemoHandlers(deps);
+      await (getHandler("demo:start-capture") as (...a: unknown[]) => Promise<unknown>)(
+        {},
+        defaultPayload
+      );
+
+      const statusHandler = getHandler("demo:get-capture-status") as (
+        ev: unknown
+      ) => Promise<{ active: boolean; chunkCount: number; outputPath: string | null }>;
+      const chunkListener = getIpcListener("demo:capture-chunk");
+
+      expect((await statusHandler({})).chunkCount).toBe(0);
+
+      chunkListener!({}, { captureId: "test-request-id", data: new Uint8Array([1]) });
+      chunkListener!({}, { captureId: "test-request-id", data: new Uint8Array([2]) });
+      let status = await statusHandler({});
+      expect(status.active).toBe(true);
+      expect(status.chunkCount).toBe(2);
+
+      // Stale-captureId chunks must not advance the live counter.
+      chunkListener!({}, { captureId: "bogus", data: new Uint8Array([3]) });
+      status = await statusHandler({});
+      expect(status.chunkCount).toBe(2);
+      cleanup();
+    });
+
     it("stale captureId chunks are ignored", async () => {
       autoResolveCommandDone();
       const cleanup = registerDemoHandlers(makeDeps(true));
@@ -263,19 +292,19 @@ describe("registerDemoHandlers", () => {
       const stopPromise = (
         getHandler("demo:stop-capture") as (...a: unknown[]) => Promise<{
           outputPath: string;
-          frameCount: number;
+          chunkCount: number;
         }>
       )({});
 
       setTimeout(() => {
         const stopListener = getIpcListener("demo:capture-stop");
-        stopListener!({}, { captureId: "test-request-id", frameCount: 7 });
+        stopListener!({}, { captureId: "test-request-id", chunkCount: 7 });
       }, 10);
 
       const result = await stopPromise;
       expect(mockWriteStream.end).toHaveBeenCalled();
       expect(result.outputPath).toBe("/tmp/capture/out.webm");
-      expect(result.frameCount).toBe(7);
+      expect(result.chunkCount).toBe(7);
       cleanup();
     });
 
@@ -292,7 +321,7 @@ describe("registerDemoHandlers", () => {
         getHandler("demo:get-capture-status") as (ev: unknown) => Promise<unknown>
       )({})) as {
         active: boolean;
-        frameCount: number;
+        chunkCount: number;
         outputPath: string | null;
       };
       expect(status.active).toBe(false);
@@ -330,7 +359,7 @@ describe("registerDemoHandlers", () => {
       )({});
       setTimeout(() => {
         const stopListener = getIpcListener("demo:capture-stop");
-        stopListener!({}, { captureId: "test-request-id", frameCount: 0, error: "boom" });
+        stopListener!({}, { captureId: "test-request-id", chunkCount: 0, error: "boom" });
       }, 10);
       await expect(stopPromise).rejects.toThrow("Capture failed: boom");
       cleanup();

--- a/electron/ipc/handlers/demo.ts
+++ b/electron/ipc/handlers/demo.ts
@@ -82,7 +82,7 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
     captureId: string;
     outputPath: string;
     writeStream: fs.WriteStream;
-    frameCount: number;
+    chunkCount: number;
     stopping: boolean;
     finalized: boolean;
     finalizePromise: Promise<DemoStopCaptureResult>;
@@ -109,12 +109,13 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
     if (!active || active.captureId !== payload.captureId || active.finalized) return;
     const buf = Buffer.from(payload.data.buffer, payload.data.byteOffset, payload.data.byteLength);
     active.writeStream.write(buf);
+    active.chunkCount += 1;
   };
 
   const onCaptureStop = (_event: Electron.IpcMainEvent, payload: DemoCaptureStopPayload) => {
     const active = captureSession;
     if (!active || active.captureId !== payload.captureId || active.finalized) return;
-    active.frameCount = payload.frameCount;
+    active.chunkCount = payload.chunkCount;
     active.finalized = true;
     const rendererError = payload.error;
     active.writeStream.end(() => {
@@ -124,7 +125,7 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
       } else {
         active.resolveFinalizeWith({
           outputPath: active.outputPath,
-          frameCount: active.frameCount,
+          chunkCount: active.chunkCount,
         });
       }
     });
@@ -255,7 +256,7 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
             captureId,
             outputPath,
             writeStream,
-            frameCount: 0,
+            chunkCount: 0,
             stopping: false,
             finalized: false,
             finalizePromise,
@@ -322,7 +323,7 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
         async (): Promise<DemoCaptureStatus> => {
           return {
             active: captureSession !== null && !captureSession.finalized,
-            frameCount: captureSession?.frameCount ?? 0,
+            chunkCount: captureSession?.chunkCount ?? 0,
             outputPath: captureSession?.outputPath ?? null,
           };
         }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2674,8 +2674,8 @@ const api: ElectronAPI = {
           sendCaptureChunk: (captureId: string, data: Uint8Array) => {
             ipcRenderer.send(CHANNELS.DEMO_CAPTURE_CHUNK, { captureId, data });
           },
-          sendCaptureStop: (captureId: string, frameCount: number, error?: string) => {
-            ipcRenderer.send(CHANNELS.DEMO_CAPTURE_STOP, { captureId, frameCount, error });
+          sendCaptureStop: (captureId: string, chunkCount: number, error?: string) => {
+            ipcRenderer.send(CHANNELS.DEMO_CAPTURE_STOP, { captureId, chunkCount, error });
           },
           stopCapture: () => _unwrappingInvoke(CHANNELS.DEMO_STOP_CAPTURE),
           getCaptureStatus: () => _unwrappingInvoke(CHANNELS.DEMO_GET_CAPTURE_STATUS),

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1654,7 +1654,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     waitForIdle(settleMs?: number, timeoutMs?: number): Promise<void>;
     startCapture(payload: DemoStartCapturePayload): Promise<DemoStartCaptureResult>;
     sendCaptureChunk(captureId: string, data: Uint8Array): void;
-    sendCaptureStop(captureId: string, frameCount: number, error?: string): void;
+    sendCaptureStop(captureId: string, chunkCount: number, error?: string): void;
     stopCapture(): Promise<DemoStopCaptureResult>;
     getCaptureStatus(): Promise<DemoCaptureStatus>;
     onExecCommand(

--- a/shared/types/ipc/demo.ts
+++ b/shared/types/ipc/demo.ts
@@ -54,7 +54,7 @@ export interface DemoCaptureChunkPayload {
 
 export interface DemoCaptureStopPayload {
   captureId: string;
-  frameCount: number;
+  chunkCount: number;
   error?: string;
 }
 
@@ -79,12 +79,13 @@ export interface DemoStartCaptureResult {
 
 export interface DemoStopCaptureResult {
   outputPath: string;
-  frameCount: number;
+  chunkCount: number;
 }
 
 export interface DemoCaptureStatus {
   active: boolean;
-  frameCount: number;
+  /** Number of MediaRecorder timeslice chunks received so far (not video frames). */
+  chunkCount: number;
   outputPath: string | null;
 }
 

--- a/src/components/Demo/DemoCaptureBridge.tsx
+++ b/src/components/Demo/DemoCaptureBridge.tsx
@@ -5,7 +5,7 @@ interface ActiveRecording {
   captureId: string;
   recorder: MediaRecorder;
   stream: MediaStream;
-  frameCount: number;
+  chunkCount: number;
   pendingChunks: number;
   stopped: boolean;
   stopSignalSent: boolean;
@@ -29,7 +29,7 @@ export function DemoCaptureBridge() {
     const maybeSendStop = (active: ActiveRecording) => {
       if (!active.stopped || active.stopSignalSent || active.pendingChunks > 0) return;
       active.stopSignalSent = true;
-      api.sendCaptureStop(active.captureId, active.frameCount, active.stopError ?? undefined);
+      api.sendCaptureStop(active.captureId, active.chunkCount, active.stopError ?? undefined);
       if (active.stopRequestId) {
         api.sendCommandDone(active.stopRequestId, active.stopError ?? undefined);
         active.stopRequestId = null;
@@ -120,7 +120,7 @@ export function DemoCaptureBridge() {
           captureId,
           recorder,
           stream,
-          frameCount: 0,
+          chunkCount: 0,
           pendingChunks: 0,
           stopped: false,
           stopSignalSent: false,
@@ -132,7 +132,7 @@ export function DemoCaptureBridge() {
         recorder.ondataavailable = async (e: BlobEvent) => {
           if (!e.data || e.data.size === 0) return;
           active.pendingChunks += 1;
-          active.frameCount += 1;
+          active.chunkCount += 1;
           try {
             const ab = await e.data.arrayBuffer();
             api.sendCaptureChunk(active.captureId, new Uint8Array(ab));


### PR DESCRIPTION
## Summary

- `frameCount` always returned `0` during an active capture because the main-process `onCaptureChunk` handler never incremented it — the value was only read from the renderer payload at stop time.
- The field name was wrong: it counted `MediaRecorder` `ondataavailable` events (~1s WebM timeslice chunks), not video frames.
- Renamed `frameCount` to `chunkCount` and wired up live incrementing in the main handler so `getCaptureStatus()` reports real progress during capture.

Resolves #10161

## Changes

- `electron/ipc/handlers/demo.ts` — increment `chunkCount` after each buffer write in `onCaptureChunk`.
- `shared/types/ipc/demo.ts`, `shared/types/ipc/api.ts` — rename `frameCount` to `chunkCount` in `DemoCaptureStopPayload`, `DemoStopCaptureResult`, and `DemoCaptureStatus`.
- `electron/preload.cts`, `src/components/Demo/DemoCaptureBridge.tsx` — propagate the rename through `sendCaptureStop` and the bridge.
- `electron/ipc/handlers/__tests__/demo.handlers.test.ts` — unit test asserting the live count goes `0 → 2` as chunks arrive, and that stale `captureId` chunks are ignored.
- `e2e/screenshots/demo-reel.spec.ts` — updated assertion to use `chunkCount`.

## Testing

Local CI passed: typecheck, all IPC/channel guards, lint, format, build, preload security audit, and the 22 `demo.handlers.test.ts` unit tests. The renderer's final tally remains authoritative for the stop result; the new main-side counter only serves live `getCaptureStatus` polling.