### PR TITLE
fix(pr): remove inert circuit-breaker ui:notify emit

### DIFF
--- a/electron/services/PreAgentSnapshotService.ts
+++ b/electron/services/PreAgentSnapshotService.ts
@@ -3,6 +3,7 @@ import { createHardenedGit } from "../utils/hardenedGit.js";
 import { getSystemSleepService } from "./SystemSleepService.js";
 import { logInfo, logWarn } from "../utils/logger.js";
 import type { SnapshotInfo } from "../../shared/types/ipc/git.js";
+import type { NotificationPayload } from "../../shared/types/index.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 const STASH_PREFIX = "daintree:pre-agent:";
@@ -82,11 +83,16 @@ export class PreAgentSnapshotService {
         worktreeId,
         error: formatErrorMessage(err, "Failed to create pre-agent snapshot"),
       });
+      // timestamp satisfies EVENT_META["ui:notify"].requiresTimestamp so EventBuffer
+      // (live in this main process) records it without a validation warning. It is
+      // EventBuffer transport metadata, not part of the NotificationPayload domain
+      // shape, hence the cast rather than widening the type.
       events.emit("ui:notify", {
         type: "warning",
         message:
           "Could not create pre-agent file snapshot. Agent will continue without rollback capability.",
-      });
+        timestamp: Date.now(),
+      } as NotificationPayload & { timestamp: number });
     });
   }
 

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -1792,11 +1792,11 @@ class PullRequestService {
       const backoffMs = computeBackoff(this.consecutiveErrors);
       this.nextRetryAt = Date.now() + backoffMs;
       logWarn("Too many consecutive errors - pausing PR polling", { retryInMs: backoffMs });
-      events.emit("ui:notify", {
-        type: "warning",
-        message: "PR detection paused due to errors. Will retry automatically.",
-        id: "pr-service-circuit-breaker",
-      });
+      // No ui:notify here: this service runs in the workspace-host UtilityProcess,
+      // where the EventBuffer subscriber (main-process only) does not exist, so the
+      // emit was inert. The breaker trip is surfaced ambiently via setDetectionState
+      // (sys:pr:detection-state → PRDetectionPausedIndicator), the correct tier for
+      // auto-recovering state.
       this.setDetectionState(true);
     }
   }

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -1331,6 +1331,13 @@ describe("PullRequestService", () => {
         detectionStates.push(payload)
       );
 
+      // This service runs in the workspace-host UtilityProcess, where ui:notify has
+      // no consumer, so the breaker trip must NOT emit it — the ambient
+      // detection-state path is the only signal. Guard against the dead emit
+      // returning (#9976).
+      const notifications: DaintreeEventMap["ui:notify"][] = [];
+      const unsubNotify = events.on("ui:notify", (payload) => notifications.push(payload));
+
       pullRequestService.initialize("/repo");
       events.emit(
         "sys:worktree:update",
@@ -1352,7 +1359,9 @@ describe("PullRequestService", () => {
 
       expect(svc.consecutiveErrors).toBe(3);
       expect(detectionStates).toContainEqual(expect.objectContaining({ tripped: true }));
+      expect(notifications).toHaveLength(0);
 
+      unsubNotify();
       unsubscribe();
       pullRequestService.destroy();
     });


### PR DESCRIPTION
## Summary

- `PullRequestService` runs in the workspace-host UtilityProcess, which has no `EventBuffer` consumer — the `ui:notify` emit on circuit-breaker trip never fired and was leaving code that implied a toast that didn't exist.
- The real user-visible signal for this state already exists: `setDetectionState(true)` emits `sys:pr:detection-state`, which drives `PRDetectionPausedIndicator`. The leftover emit was superseded when that indicator was added.
- Added a `timestamp` to the live `ui:notify` emit in `PreAgentSnapshotService` (main process) to satisfy `EVENT_META` `requiresTimestamp` and silence the `EventBuffer` validation warning.

Resolves #9976

## Changes

- `electron/services/PullRequestService.ts` — removed the inert `ui:notify` emit from `handleError()`'s circuit-breaker branch.
- `electron/services/PreAgentSnapshotService.ts` — added `timestamp: Date.now()` to the live `ui:notify` emit.
- `electron/services/__tests__/PullRequestService.test.ts` — extended the circuit-breaker trip test to assert `ui:notify` fires zero times.

## Testing

- Extended unit test asserts the `ui:notify` mock is never called when the circuit breaker trips, confirming the removed emit is gone.
- `PreAgentSnapshotService` change verified against the `EVENT_META` `requiresTimestamp` contract.