### PR TITLE
fix(persistence): add backup recovery to debounced safe storage

### DIFF
--- a/src/store/__tests__/persistenceBoundaryHardening.test.ts
+++ b/src/store/__tests__/persistenceBoundaryHardening.test.ts
@@ -930,5 +930,86 @@ describe("persistence boundary hardening", () => {
 
       vi.useRealTimers();
     });
+
+    it("getItem returns null when both the primary and backup are corrupt", async () => {
+      installLocalStorage(
+        createStorageMock({
+          getItem: (key) =>
+            key === "both-corrupt" ? "{corrupt" : key === "both-corrupt.__bak" ? "{also-bad" : null,
+        })
+      );
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const { createDebouncedSafeJSONStorage } = await import("../persistence/safeStorage");
+      const storage = createDebouncedSafeJSONStorage<{ value: number }>(300);
+
+      expect(storage.getItem("both-corrupt")).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[safeStorage] corrupt persisted state, resetting to defaults",
+        expect.objectContaining({ key: "both-corrupt" })
+      );
+    });
+
+    it("writes the backup on a getItem-triggered flush, not just the timer path", async () => {
+      const backing = new Map<string, string>();
+      installLocalStorage(
+        createStorageMock({
+          getItem: (key) => backing.get(key) ?? null,
+          setItem: (key, value) => {
+            backing.set(key, value);
+          },
+        })
+      );
+      vi.useFakeTimers();
+
+      const { createDebouncedSafeJSONStorage } = await import("../persistence/safeStorage");
+      const storage = createDebouncedSafeJSONStorage<{ value: number }>(300);
+
+      storage.setItem("flush-read-key", { state: { value: 3 }, version: 1 });
+      // No timer advance — the read forces a synchronous flush, which must also
+      // advance the backup just like the timer-driven flush does.
+      storage.getItem("flush-read-key");
+
+      expect(backing.get("flush-read-key.__bak")).toBe(
+        JSON.stringify({ state: { value: 3 }, version: 1 })
+      );
+
+      vi.useRealTimers();
+    });
+
+    it("keeps using localStorage after a transient quota error (no permanent fallback)", async () => {
+      const backing = new Map<string, string>();
+      let primaryWrites = 0;
+      installLocalStorage(
+        createStorageMock({
+          getItem: (key) => backing.get(key) ?? null,
+          setItem: (key, value) => {
+            // Transient quota error on the very first primary write only.
+            if (key === "q1") {
+              primaryWrites += 1;
+              if (primaryWrites === 1) {
+                throw new DOMException("Quota exceeded", "QuotaExceededError");
+              }
+            }
+            backing.set(key, value);
+          },
+        })
+      );
+      vi.useFakeTimers();
+
+      const { createDebouncedSafeJSONStorage } = await import("../persistence/safeStorage");
+      const storage = createDebouncedSafeJSONStorage<{ value: number }>(300);
+
+      storage.setItem("q1", { state: { value: 1 }, version: 1 });
+      vi.advanceTimersByTime(300);
+      // Second write to a different key must still reach localStorage — a
+      // transient quota error must not flip the resilient storage to memory.
+      storage.setItem("q2", { state: { value: 2 }, version: 1 });
+      vi.advanceTimersByTime(300);
+
+      expect(backing.get("q2")).toBe(JSON.stringify({ state: { value: 2 }, version: 1 }));
+
+      vi.useRealTimers();
+    });
   });
 });

--- a/src/store/__tests__/persistenceBoundaryHardening.test.ts
+++ b/src/store/__tests__/persistenceBoundaryHardening.test.ts
@@ -676,7 +676,8 @@ describe("persistence boundary hardening", () => {
 
       vi.advanceTimersByTime(300);
 
-      expect(setItem).toHaveBeenCalledTimes(1);
+      // One coalesced primary write (the backup write targets the `.__bak` key).
+      expect(setItem.mock.calls.filter(([key]) => key === "k")).toHaveLength(1);
       expect(setItem).toHaveBeenCalledWith(
         "k",
         JSON.stringify({ state: { value: 3 }, version: 1 })
@@ -729,7 +730,8 @@ describe("persistence boundary hardening", () => {
       // No timer advance — getItem must flush.
       const result = storage.getItem("k");
 
-      expect(setItem).toHaveBeenCalledTimes(1);
+      // One coalesced primary write (the backup write targets the `.__bak` key).
+      expect(setItem.mock.calls.filter(([key]) => key === "k")).toHaveLength(1);
       expect(result).toEqual({ state: { value: 42 }, version: 1 });
 
       vi.useRealTimers();
@@ -779,13 +781,152 @@ describe("persistence boundary hardening", () => {
       storage.setItem("b", { state: { value: 2 }, version: 1 });
       vi.advanceTimersByTime(150);
 
-      // 'a' has flushed; 'b' has 150ms remaining
-      expect(setItem).toHaveBeenCalledTimes(1);
+      // 'a' has flushed; 'b' has 150ms remaining (count primary writes only —
+      // each durable flush also writes a `.__bak` backup copy).
+      expect(setItem.mock.calls.filter(([key]) => key === "a")).toHaveLength(1);
+      expect(setItem.mock.calls.filter(([key]) => key === "b")).toHaveLength(0);
       expect(setItem).toHaveBeenCalledWith("a", expect.any(String));
 
       vi.advanceTimersByTime(150);
-      expect(setItem).toHaveBeenCalledTimes(2);
-      expect(setItem).toHaveBeenLastCalledWith("b", expect.any(String));
+      expect(setItem.mock.calls.filter(([key]) => key === "b")).toHaveLength(1);
+      expect(setItem).toHaveBeenCalledWith("b", expect.any(String));
+
+      vi.useRealTimers();
+    });
+
+    it("writes a backup copy alongside the primary key after a durable flush", async () => {
+      const backing = new Map<string, string>();
+      installLocalStorage(
+        createStorageMock({
+          getItem: (key) => backing.get(key) ?? null,
+          setItem: (key, value) => {
+            backing.set(key, value);
+          },
+        })
+      );
+      vi.useFakeTimers();
+
+      const { createDebouncedSafeJSONStorage } = await import("../persistence/safeStorage");
+      const storage = createDebouncedSafeJSONStorage<{ value: number }>(300);
+
+      storage.setItem("backup-key", { state: { value: 5 }, version: 1 });
+      vi.advanceTimersByTime(300);
+
+      expect(backing.get("backup-key.__bak")).toBe(
+        JSON.stringify({ state: { value: 5 }, version: 1 })
+      );
+
+      vi.useRealTimers();
+    });
+
+    it("does not advance the backup when the primary flush hits a quota error", async () => {
+      const backing = new Map<string, string>();
+      const good = JSON.stringify({ state: { value: 1 }, version: 1 });
+      backing.set("stale-key", good);
+      backing.set("stale-key.__bak", good);
+      installLocalStorage(
+        createStorageMock({
+          getItem: (key) => backing.get(key) ?? null,
+          setItem: (key, value) => {
+            // Quota only on the primary key — let backup writes through so the
+            // assertion proves the backup was never *attempted*, not just blocked.
+            if (key === "stale-key") {
+              throw new DOMException("Quota exceeded", "QuotaExceededError");
+            }
+            backing.set(key, value);
+          },
+        })
+      );
+      vi.useFakeTimers();
+
+      const { createDebouncedSafeJSONStorage } = await import("../persistence/safeStorage");
+      const storage = createDebouncedSafeJSONStorage<{ value: number }>(300);
+
+      storage.setItem("stale-key", { state: { value: 2 }, version: 1 });
+      vi.advanceTimersByTime(300);
+
+      // Primary write failed → backup must keep the previous good value.
+      expect(backing.get("stale-key.__bak")).toBe(good);
+
+      vi.useRealTimers();
+    });
+
+    it("getItem recovers from the backup key when the primary blob is corrupt", async () => {
+      const backup = JSON.stringify({ state: { value: 9 }, version: 1 });
+      installLocalStorage(
+        createStorageMock({
+          getItem: (key) => {
+            if (key === "recover-key") return "{corrupt";
+            if (key === "recover-key.__bak") return backup;
+            return null;
+          },
+        })
+      );
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const { createDebouncedSafeJSONStorage } = await import("../persistence/safeStorage");
+      const storage = createDebouncedSafeJSONStorage<{ value: number }>(300);
+
+      const result = storage.getItem("recover-key");
+
+      expect(result).toEqual({ state: { value: 9 }, version: 1 });
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[safeStorage] corrupt persisted state, recovered from backup",
+        expect.objectContaining({ key: "recover-key" })
+      );
+    });
+
+    it("removeItem clears both the primary key and its backup", async () => {
+      const backing = new Map<string, string>();
+      installLocalStorage(
+        createStorageMock({
+          getItem: (key) => backing.get(key) ?? null,
+          setItem: (key, value) => {
+            backing.set(key, value);
+          },
+          removeItem: (key) => {
+            backing.delete(key);
+          },
+        })
+      );
+      vi.useFakeTimers();
+
+      const { createDebouncedSafeJSONStorage } = await import("../persistence/safeStorage");
+      const storage = createDebouncedSafeJSONStorage<{ value: number }>(300);
+
+      storage.setItem("rm-key", { state: { value: 1 }, version: 1 });
+      vi.advanceTimersByTime(300);
+      expect(backing.get("rm-key.__bak")).not.toBeUndefined();
+
+      storage.removeItem("rm-key");
+
+      expect(backing.get("rm-key")).toBeUndefined();
+      expect(backing.get("rm-key.__bak")).toBeUndefined();
+
+      vi.useRealTimers();
+    });
+
+    it("recovers from a backup written by an earlier flush on the same instance", async () => {
+      const backing = new Map<string, string>();
+      installLocalStorage(
+        createStorageMock({
+          getItem: (key) => backing.get(key) ?? null,
+          setItem: (key, value) => {
+            backing.set(key, value);
+          },
+        })
+      );
+      vi.useFakeTimers();
+
+      const { createDebouncedSafeJSONStorage } = await import("../persistence/safeStorage");
+      const storage = createDebouncedSafeJSONStorage<{ value: number }>(300);
+
+      storage.setItem("e2e-key", { state: { value: 7 }, version: 1 });
+      vi.advanceTimersByTime(300);
+      // Corrupt only the primary; the backup written by the flush stays intact.
+      backing.set("e2e-key", "{corrupt");
+
+      expect(storage.getItem("e2e-key")).toEqual({ state: { value: 7 }, version: 1 });
 
       vi.useRealTimers();
     });

--- a/src/store/persistence/safeStorage.ts
+++ b/src/store/persistence/safeStorage.ts
@@ -362,7 +362,12 @@ export function createDebouncedSafeJSONStorage<T>(delayMs: number): PersistStora
     const entry = pending.get(name);
     if (!entry) return;
     pending.delete(name);
-    raw.setItem(name, entry.value);
+    // Only advance the backup when the primary write actually reached durable
+    // storage. On a quota failure the primary keeps its old value, so writing
+    // a newer backup would leave the two inconsistent and recover stale state.
+    if (raw.setItem(name, entry.value) === "durable") {
+      raw.writeBackup(name, entry.value);
+    }
   };
 
   return {
@@ -373,8 +378,18 @@ export function createDebouncedSafeJSONStorage<T>(delayMs: number): PersistStora
       if (value instanceof Promise) return null;
       if (value === null) return null;
       try {
-        return JSON.parse(value) as StorageValue<T>;
+        return parseJson<StorageValue<T>>(value);
       } catch (error) {
+        // The live blob is corrupt but present — try the last known-good backup
+        // before discarding the user's config to defaults (issue #9170/#9916).
+        const recovered = parseBackup<T>(raw.readBackup(name));
+        if (recovered !== null) {
+          console.warn("[safeStorage] corrupt persisted state, recovered from backup", {
+            key: name,
+            error: formatErrorMessage(error, "Corrupt persisted state"),
+          });
+          return recovered;
+        }
         console.warn("[safeStorage] corrupt persisted state, resetting to defaults", {
           key: name,
           error: formatErrorMessage(error, "Corrupt persisted state"),
@@ -396,6 +411,7 @@ export function createDebouncedSafeJSONStorage<T>(delayMs: number): PersistStora
         pending.delete(name);
       }
       raw.removeItem(name);
+      raw.removeBackup(name);
     },
   };
 }


### PR DESCRIPTION
## Summary

- `createDebouncedSafeJSONStorage` was missing the backup-recovery hardening that `createSafeJSONStorage` got in #9170. The debounced variant backs the WCAG-critical notification inbox (`notificationHistorySlice`) and the voice-recording store, so a single corrupt write would silently reset those to defaults with no recovery path.
- Three fixes in `src/store/persistence/safeStorage.ts`: `flush()` now writes a `.__bak` key after a durable primary write (gated on the "durable" result so quota/memory failures don't advance the backup past the primary); `getItem()` now recovers from the last known-good backup when the primary blob is corrupt, using the shared `parseJson` + `parseBackup` helpers before falling through to reset-to-defaults; `removeItem()` now clears the backup key alongside the primary so a deleted store key isn't resurrected on next boot.

Resolves #9916

## Changes

- `flush()` writes a backup copy after a confirmed durable write
- `getItem()` falls back to the `.__bak` key on corrupt primary before resetting
- `removeItem()` deletes both the primary and backup keys
- `persistenceBoundaryHardening.test.ts`: 3 updated call-count assertions + 8 new cases covering durable-backup write, no-advance-on-quota, corrupt-primary recovery, both-corrupt-returns-null, `removeItem` clears both keys, `getItem`/flush writes backup, same-instance recovery, and transient-quota-stays-on-localStorage

## Testing

Full local CI passed (all 10 required checks). New test cases directly exercise each fix path — backup gating on quota failure, corrupt-primary recovery, and the removeItem cleanup.