### PR TITLE
fix(ci): repair nightly failure reports on Windows, retries, and re-runs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -593,6 +593,7 @@ jobs:
       # consumers share a single artifact.
       - name: Extract failure signatures
         if: failure() && inputs.json_report
+        continue-on-error: true
         shell: bash
         run: |
           mkdir -p test-results

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -595,19 +595,21 @@ jobs:
         if: failure() && inputs.json_report
         shell: bash
         run: |
+          mkdir -p test-results
           if [ -f test-results/report.json ]; then
-            node scripts/ci/extract-failures.mjs test-results/report.json /tmp/failure-report.json
+            node scripts/ci/extract-failures.mjs test-results/report.json test-results/failure-report.json
           else
             echo "[extract] No test-results/report.json found — skipping"
-            echo '[]' > /tmp/failure-report.json
+            echo '[]' > test-results/failure-report.json
           fi
 
       - name: Upload failure report
         if: failure() && inputs.json_report
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
-          name: failure-report-${{ inputs.suite || 'core' }}-${{ matrix.name }}-s${{ matrix.shard }}of${{ matrix.shardTotal }}
-          path: /tmp/failure-report.json
+          name: failure-report-${{ inputs.suite || 'core' }}-${{ matrix.name }}-s${{ matrix.shard }}of${{ matrix.shardTotal }}-attempt-${{ github.run_attempt }}
+          path: test-results/failure-report.json
           retention-days: 7
           if-no-files-found: ignore
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -723,11 +723,22 @@ jobs:
             const reportsDir = path.join(workspace, 'failure-reports');
             const failures = [];
             if (fs.existsSync(reportsDir)) {
+              // Re-runs upload a fresh attempt-suffixed artifact per shard.
+              // Keep only the latest attempt per shard so stale attempt-1
+              // failures don't survive a green re-run.
+              const latestByShard = new Map();
               for (const entry of fs.readdirSync(reportsDir, { withFileTypes: true })) {
                 if (!entry.isDirectory()) continue;
+                const attemptMatch = entry.name.match(/-attempt-(\d+)$/);
+                const attempt = attemptMatch ? Number(attemptMatch[1]) : 0;
+                const shardKey = attemptMatch ? entry.name.slice(0, attemptMatch.index) : entry.name;
+                const prev = latestByShard.get(shardKey);
+                if (!prev || attempt > prev.attempt) latestByShard.set(shardKey, { entry, attempt });
+              }
+              for (const { entry } of latestByShard.values()) {
                 const reportPath = path.join(reportsDir, entry.name, 'failure-report.json');
                 if (!fs.existsSync(reportPath)) continue;
-                const osMatch = entry.name.match(/-(Linux|macOS|Windows)-s\d+of\d+$/);
+                const osMatch = entry.name.match(/-(Linux|macOS|Windows)-s\d+of\d+(?:-attempt-\d+)?$/);
                 const os = osMatch ? osMatch[1] : 'unknown';
                 try {
                   for (const r of JSON.parse(fs.readFileSync(reportPath, 'utf8'))) {

--- a/scripts/ci/extract-failures.mjs
+++ b/scripts/ci/extract-failures.mjs
@@ -15,18 +15,25 @@ function walkSuites(suites, parentPath = [], results = [], parentFile = null) {
     for (const spec of suite.specs ?? []) {
       const specPath = [...currentPath, spec.title];
       for (const test of spec.tests ?? []) {
-        for (const result of test.results ?? []) {
-          if (result.status === "passed" || result.status === "skipped") continue;
-          const primaryError = result.errors?.[0];
-          results.push({
-            file,
-            titlePath: specPath,
-            projectName: test.projectName,
-            status: result.status,
-            errorMessage: primaryError?.message ?? "Unknown error",
-            errorStack: primaryError?.stack ?? null,
-          });
-        }
+        // Gate on the test-level outcome so recovered flakes ("flaky" =
+        // failed then passed on retry) are not reported. When `status` is
+        // absent (partial schema), infer from the final attempt instead.
+        const lastResult = test.results?.at(-1);
+        const failed = test.status
+          ? test.status === "unexpected"
+          : lastResult != null &&
+            lastResult.status !== "passed" &&
+            lastResult.status !== "skipped";
+        if (!failed) continue;
+        const primaryError = lastResult?.errors?.[0];
+        results.push({
+          file,
+          titlePath: specPath,
+          projectName: test.projectName,
+          status: lastResult?.status ?? "failed",
+          errorMessage: primaryError?.message ?? "Unknown error",
+          errorStack: primaryError?.stack ?? null,
+        });
       }
     }
   }

--- a/scripts/ci/extract-failures.mjs
+++ b/scripts/ci/extract-failures.mjs
@@ -21,9 +21,7 @@ function walkSuites(suites, parentPath = [], results = [], parentFile = null) {
         const lastResult = test.results?.at(-1);
         const failed = test.status
           ? test.status === "unexpected"
-          : lastResult != null &&
-            lastResult.status !== "passed" &&
-            lastResult.status !== "skipped";
+          : lastResult != null && lastResult.status !== "passed" && lastResult.status !== "skipped";
         if (!failed) continue;
         const primaryError = lastResult?.errors?.[0];
         results.push({

--- a/scripts/ci/extract-failures.mjs
+++ b/scripts/ci/extract-failures.mjs
@@ -52,7 +52,11 @@ const UUID_RE = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\
 const PORT_RE = /:\d{4,5}\b/g;
 
 export function normalizeError(message) {
+  // Match paths before flattening backslashes so WIN_PATH_RE can consume
+  // drive-letter paths (e.g. the C:\a\<repo> Actions workspace) whole, then
+  // again afterwards for any POSIX-style paths revealed by the flattening.
   return message
+    .replace(PATH_RE, "<path>")
     .replace(BSLASH_RE, "/")
     .replace(PATH_RE, "<path>")
     .replace(WIN_DRIVE_RE, "")

--- a/scripts/ci/extract-failures.test.mjs
+++ b/scripts/ci/extract-failures.test.mjs
@@ -254,6 +254,31 @@ it("extractFailures skips recovered flakes (failed then passed on retry)", () =>
   expect(extractFailures(report)).toEqual([]);
 });
 
+it("extractFailures trusts test status over a failed-looking last result", () => {
+  const makeReport = (status) => ({
+    suites: [
+      {
+        file: "spec.ts",
+        title: "root",
+        specs: [
+          {
+            title: "misleading",
+            tests: [
+              {
+                projectName: "core",
+                status,
+                results: [{ status: "failed", errors: [{ message: "noise" }] }],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+  expect(extractFailures(makeReport("expected"))).toEqual([]);
+  expect(extractFailures(makeReport("skipped"))).toEqual([]);
+});
+
 it("extractFailures falls back to last result when test status is absent", () => {
   const failing = {
     suites: [
@@ -280,6 +305,32 @@ it("extractFailures falls back to last result when test status is absent", () =>
   const failures = extractFailures(failing);
   expect(failures.length).toBe(1);
   expect(failures[0].errorMessage).toBe("second fail");
+
+  const lateFailure = {
+    suites: [
+      {
+        file: "spec.ts",
+        title: "root",
+        specs: [
+          {
+            title: "degrades",
+            tests: [
+              {
+                projectName: "core",
+                results: [
+                  { status: "passed", errors: [] },
+                  { status: "failed", errors: [{ message: "late fail" }] },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  const lateFailures = extractFailures(lateFailure);
+  expect(lateFailures.length).toBe(1);
+  expect(lateFailures[0].errorMessage).toBe("late fail");
 
   const recovered = {
     suites: [
@@ -325,6 +376,7 @@ it("extractFailures handles unexpected status with no results", () => {
   expect(failures.length).toBe(1);
   expect(failures[0].status).toBe("failed");
   expect(failures[0].errorMessage).toBe("Unknown error");
+  expect(failures[0].errorStack).toBeNull();
 });
 
 it("extractFailures handles multi-project reports", () => {
@@ -399,6 +451,12 @@ it("normalizeError normalizes Windows paths", () => {
   const posixErr = "Error at /Users/runner/work/repo/e2e/test.spec.ts:42";
   const winErr = "Error at C:\\Users\\runneradmin\\work\\repo\\e2e\\test.spec.ts:42";
   expect(normalizeError(winErr)).toBe(normalizeError(posixErr));
+});
+
+it("normalizeError normalizes GitHub Actions Windows runner paths", () => {
+  const result = normalizeError("Error at C:\\a\\daintree\\daintree\\e2e\\test.spec.ts:42:10");
+  expect(result).not.toContain("a/daintree");
+  expect(result).toContain("<path>");
 });
 
 it("computeSignature matches across OS path flavors", () => {

--- a/scripts/ci/extract-failures.test.mjs
+++ b/scripts/ci/extract-failures.test.mjs
@@ -87,6 +87,7 @@ it("extractFailures extracts failing tests", () => {
             tests: [
               {
                 projectName: "core",
+                status: "unexpected",
                 results: [
                   {
                     status: "failed",
@@ -197,7 +198,36 @@ it("extractFailures handles missing errors gracefully", () => {
   expect(failures[0].errorMessage).toBe("Unknown error");
 });
 
-it("extractFailures handles retries (multiple results per test)", () => {
+it("extractFailures emits one failure for a test that failed every retry", () => {
+  const report = {
+    suites: [
+      {
+        file: "spec.ts",
+        title: "root",
+        specs: [
+          {
+            title: "broken",
+            tests: [
+              {
+                projectName: "core",
+                status: "unexpected",
+                results: [
+                  { status: "failed", errors: [{ message: "first fail" }] },
+                  { status: "failed", errors: [{ message: "second fail" }] },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  const failures = extractFailures(report);
+  expect(failures.length).toBe(1);
+  expect(failures[0].errorMessage).toBe("second fail");
+});
+
+it("extractFailures skips recovered flakes (failed then passed on retry)", () => {
   const report = {
     suites: [
       {
@@ -206,6 +236,33 @@ it("extractFailures handles retries (multiple results per test)", () => {
         specs: [
           {
             title: "flaky",
+            tests: [
+              {
+                projectName: "core",
+                status: "flaky",
+                results: [
+                  { status: "failed", errors: [{ message: "transient" }] },
+                  { status: "passed", errors: [] },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  expect(extractFailures(report)).toEqual([]);
+});
+
+it("extractFailures falls back to last result when test status is absent", () => {
+  const failing = {
+    suites: [
+      {
+        file: "spec.ts",
+        title: "root",
+        specs: [
+          {
+            title: "fails",
             tests: [
               {
                 projectName: "core",
@@ -220,8 +277,54 @@ it("extractFailures handles retries (multiple results per test)", () => {
       },
     ],
   };
+  const failures = extractFailures(failing);
+  expect(failures.length).toBe(1);
+  expect(failures[0].errorMessage).toBe("second fail");
+
+  const recovered = {
+    suites: [
+      {
+        file: "spec.ts",
+        title: "root",
+        specs: [
+          {
+            title: "recovers",
+            tests: [
+              {
+                projectName: "core",
+                results: [
+                  { status: "failed", errors: [{ message: "transient" }] },
+                  { status: "passed", errors: [] },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  expect(extractFailures(recovered)).toEqual([]);
+});
+
+it("extractFailures handles unexpected status with no results", () => {
+  const report = {
+    suites: [
+      {
+        file: "spec.ts",
+        title: "root",
+        specs: [
+          {
+            title: "interrupted",
+            tests: [{ projectName: "core", status: "unexpected", results: [] }],
+          },
+        ],
+      },
+    ],
+  };
   const failures = extractFailures(report);
-  expect(failures.length).toBe(2);
+  expect(failures.length).toBe(1);
+  expect(failures[0].status).toBe("failed");
+  expect(failures[0].errorMessage).toBe("Unknown error");
 });
 
 it("extractFailures handles multi-project reports", () => {


### PR DESCRIPTION
## Summary

- Windows shards never uploaded `failure-report.json` because the extract step wrote to `/tmp`, which Node.js artifact upload can't resolve on Windows. Output path moved to workspace-relative `test-results/failure-report.json`.
- Recovered flakes and retry duplicates were listed as failures. Extract now gates on Playwright's resolved test status — only `unexpected` results emit, one row per test using the final attempt's error.
- Re-runs 409'd because `failure-report-*` artifact names lacked the `-attempt-${{ github.run_attempt }}` suffix that sibling `failed-specs-*` artifacts already use. Suffix added, `continue-on-error` on both extract and upload steps, and `nightly.yml` now keeps only the latest attempt per shard so stale attempt-1 rows don't survive a green re-run.

Bonus fix: `normalizeError` was flattening backslashes before matching `WIN_PATH_RE`, so drive-letter paths (`C:\a\<repo>`) were never normalised and signatures diverged across OS. Now matches before flattening.

Resolves #10059

## Changes

- `.github/workflows/e2e.yml` — write `failure-report.json` to `test-results/` (workspace-relative)
- `.github/workflows/nightly.yml` — parse suffixed artifact names, deduplicate by keeping latest attempt per shard
- `.github/workflows/ci.yml` — same output-path fix for the check-job shards
- `scripts/ci/extract-failures.mjs` — status-gate (`unexpected` only), one row per test, final-attempt error, `normalizeError` path-before-flatten fix
- `scripts/ci/extract-failures.test.mjs` — updated "handles retries" test (old version asserted the broken 2-rows behaviour) + new coverage: flaky suppression, status-gate override, fallback semantics, empty-results edge, Windows path normalisation

## Testing

25/25 unit tests pass. Static checks, format, and typecheck all clean locally.