### PR TITLE
fix(scripts): fix test-ratio gate self-disabling when window has skipped PRs

### DIFF
--- a/scripts/check-test-ratio.mjs
+++ b/scripts/check-test-ratio.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
 // Compares the fix-with-test ratio against the checked-in
-// test-ratio-baseline.json. The ratio is computed from the last 100 merged
-// PRs via the GitHub GraphQL API.
+// test-ratio-baseline.json. The ratio is computed from the last 100 eligible
+// merged PRs, paginating the GitHub GraphQL API until that many are collected
+// (release/version-bump PRs are filtered out and don't count toward the window).
 //
 // Usage:
 //   node scripts/check-test-ratio.mjs                    # check mode (CI)
@@ -12,7 +13,7 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { graphql } from "@octokit/graphql";
+import { graphql, GraphqlResponseError } from "@octokit/graphql";
 import {
   classifyPR,
   computeTestRatioReport,
@@ -21,6 +22,7 @@ import {
   formatBaseline,
   formatMarkdown,
   wilsonLowerBound,
+  isEligiblePR,
 } from "./test-ratio-lib.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -28,7 +30,17 @@ const ROOT = path.resolve(path.dirname(__filename), "..");
 const BASELINE_FILE = path.join(ROOT, "test-ratio-baseline.json");
 const SUMMARY_FILE = path.join(ROOT, "dist", "test-ratio-summary.md");
 const ROLLING_WINDOW_SIZE = 100;
-const API_TIMEOUT_MS = 15_000;
+// GraphQL `search` caps `first` at 100 per page. We paginate until we've
+// collected ROLLING_WINDOW_SIZE *eligible* PRs (post-skip-filter) so a batch
+// containing release/version-bump PRs doesn't shrink the window below the gate
+// threshold and silently self-disable the regression check (issue #10035).
+const PAGE_SIZE = 100;
+// Runaway guard: 10 pages × 100 = 1000 raw PRs. GitHub's search API hard-caps
+// at 1000 results anyway, so hasNextPage goes false by page 10 regardless.
+const MAX_SEARCH_PAGES = 10;
+// Covers the whole paginated loop (up to MAX_SEARCH_PAGES sequential requests),
+// not a single request — a tighter per-request budget would falsely time out.
+const API_TIMEOUT_MS = 60_000;
 const UPDATE_SHRINKAGE_THRESHOLD = 0.1;
 
 function readJson(file, label, hint) {
@@ -49,8 +61,9 @@ function readJson(file, label, hint) {
 
 const SEARCH_QUERY = `is:pr is:merged -label:documentation -label:dependencies repo:daintreehq/daintree sort:created-desc`;
 
-const PR_QUERY = `query($q: String!) {
-  search(query: $q, type: ISSUE, first: 100) {
+const PR_QUERY = `query($q: String!, $cursor: String) {
+  search(query: $q, type: ISSUE, first: ${PAGE_SIZE}, after: $cursor) {
+    pageInfo { hasNextPage endCursor }
     nodes {
       ... on PullRequest {
         number
@@ -66,39 +79,68 @@ async function fetchMergedPullRequests(token) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
 
-  let result;
+  const allNodes = [];
+  let eligibleCount = 0;
+  let cursor = null;
+  let pageCount = 0;
+
   try {
-    result = await graphql({
-      query: PR_QUERY,
-      q: SEARCH_QUERY,
-      headers: { authorization: `token ${token}` },
-      request: { signal: controller.signal },
-    });
-  } catch (err) {
-    if (err.name === "AbortError") {
-      console.error(`::error::GitHub GraphQL request timed out after ${API_TIMEOUT_MS / 1000}s`);
-    } else {
-      console.error(`::error::GitHub GraphQL request failed: ${err.message ?? err}`);
+    while (pageCount < MAX_SEARCH_PAGES) {
+      let result;
+      try {
+        result = await graphql({
+          query: PR_QUERY,
+          q: SEARCH_QUERY,
+          cursor,
+          headers: { authorization: `token ${token}` },
+          request: { signal: controller.signal },
+        });
+      } catch (err) {
+        if (err.name === "AbortError") {
+          console.error(
+            `::error::GitHub GraphQL request timed out after ${API_TIMEOUT_MS / 1000}s`
+          );
+        } else if (err instanceof GraphqlResponseError) {
+          console.error(`::error::GitHub GraphQL query failed: ${err.message}`);
+        } else {
+          console.error(`::error::GitHub GraphQL request failed: ${err.message ?? err}`);
+        }
+        process.exit(1);
+      }
+
+      const search = result?.search;
+      const nodes = search?.nodes;
+      if (!Array.isArray(nodes)) {
+        console.error("::error::GraphQL response did not contain search.nodes array");
+        console.error("   Verify the GH_TOKEN has read permissions and the query is valid.");
+        process.exit(1);
+      }
+
+      for (const node of nodes) {
+        if (isEligiblePR(node)) eligibleCount += 1;
+      }
+      allNodes.push(...nodes);
+      pageCount += 1;
+
+      // Stop once the window is full of eligible PRs; trailing skipped PRs in a
+      // later page would only be discarded by buildReport anyway.
+      if (eligibleCount >= ROLLING_WINDOW_SIZE) break;
+
+      const pageInfo = search?.pageInfo;
+      if (!pageInfo?.hasNextPage) break;
+      cursor = pageInfo.endCursor;
     }
-    process.exit(1);
   } finally {
     clearTimeout(timeout);
   }
 
-  const nodes = result?.search?.nodes;
-  if (!Array.isArray(nodes)) {
-    console.error("::error::GraphQL response did not contain search.nodes array");
-    console.error("   Verify the GH_TOKEN has read permissions and the query is valid.");
-    process.exit(1);
-  }
-
-  if (nodes.length === 0) {
+  if (allNodes.length === 0) {
     console.error("::error::GraphQL search returned zero PRs");
     console.error(`   Search query: ${SEARCH_QUERY}`);
     process.exit(1);
   }
 
-  return nodes;
+  return allNodes;
 }
 
 function buildReport(prs) {

--- a/scripts/check-test-ratio.mjs
+++ b/scripts/check-test-ratio.mjs
@@ -117,17 +117,22 @@ async function fetchMergedPullRequests(token) {
       }
 
       for (const node of nodes) {
+        // The search union can yield null entries for non-PR/permission-gated
+        // nodes; skip them so they never reach classifyPR (pr.files would throw).
+        if (!node || typeof node.title !== "string") continue;
         if (isEligiblePR(node)) eligibleCount += 1;
+        allNodes.push(node);
       }
-      allNodes.push(...nodes);
       pageCount += 1;
 
       // Stop once the window is full of eligible PRs; trailing skipped PRs in a
       // later page would only be discarded by buildReport anyway.
       if (eligibleCount >= ROLLING_WINDOW_SIZE) break;
 
+      // Guard endCursor too: hasNextPage:true with a null cursor would otherwise
+      // reset to page 1 and loop on duplicate data until MAX_SEARCH_PAGES.
       const pageInfo = search?.pageInfo;
-      if (!pageInfo?.hasNextPage) break;
+      if (!pageInfo?.hasNextPage || !pageInfo.endCursor) break;
       cursor = pageInfo.endCursor;
     }
   } finally {
@@ -140,7 +145,17 @@ async function fetchMergedPullRequests(token) {
     process.exit(1);
   }
 
-  return allNodes;
+  // The final page can push the eligible count past ROLLING_WINDOW_SIZE; trim to
+  // exactly the window so ratios are computed over a fixed sample, not a variable
+  // one that depends on how many skipped PRs happened to land in the last batch.
+  const window = [];
+  let kept = 0;
+  for (const node of allNodes) {
+    window.push(node);
+    if (isEligiblePR(node) && ++kept >= ROLLING_WINDOW_SIZE) break;
+  }
+
+  return window;
 }
 
 function buildReport(prs) {

--- a/scripts/test-ratio-lib.test.ts
+++ b/scripts/test-ratio-lib.test.ts
@@ -299,6 +299,33 @@ describe("computeTestRatioReport", () => {
     expect(report.windowCompleted).toBe(true);
   });
 
+  // Regression for #10035: the window is sized by *eligible* PRs, so a batch
+  // padded with skipped release/version-bump PRs must still complete the window
+  // (the fetch now paginates until 100 eligible PRs are collected). The gate
+  // self-disabled when windowCompleted went false just because skipped PRs ate
+  // into a fixed 100-PR fetch.
+  it("windowCompleted stays true when skipped PRs accompany a full eligible window", () => {
+    const eligible = Array.from({ length: 100 }, (_, i) => ({
+      number: i + 1,
+      title: "feat: item",
+      isFix: false,
+      touchesTests: false,
+      isSkipped: false,
+    }));
+    const skipped = Array.from({ length: 5 }, (_, i) => ({
+      number: 1000 + i,
+      title: `v1.0.${i}`,
+      isFix: false,
+      touchesTests: false,
+      isSkipped: true,
+      skipReason: "release/version bump",
+    }));
+    const report = computeTestRatioReport([...skipped, ...eligible], 100);
+    expect(report.windowCompleted).toBe(true);
+    expect(report.totalCount).toBe(100);
+    expect(report.skippedCount).toBe(5);
+  });
+
   it("fixWithTestRatio is 0 when no fix PRs exist", () => {
     const classified = [
       { number: 1, title: "feat: a", isFix: false, touchesTests: true, isSkipped: false },

--- a/scripts/test-ratio-lib.test.ts
+++ b/scripts/test-ratio-lib.test.ts
@@ -688,6 +688,32 @@ describe("compareToBaseline", () => {
     expect(r.notices[0].kind).toBe("window-incomplete");
   });
 
+  // Regression for #10035: the full pipeline (classifyPR → computeTestRatioReport
+  // → compareToBaseline) must still flag a real ratio regression when the raw
+  // batch is padded with skipped release/version-bump PRs. Previously those PRs
+  // pushed the eligible window below 100, flipping windowCompleted false and
+  // short-circuiting the gate to ok:true regardless of the ratio.
+  it("still fires the gate on a real regression when skipped PRs pad the batch", () => {
+    const raw = [
+      // 100 eligible fix PRs, only 25 of which touch tests → ratio 0.25, well
+      // below the baseline's Wilson lower bound (≈0.583).
+      ...Array.from({ length: 100 }, (_, i) =>
+        pr({
+          number: i + 1,
+          title: "fix: bug",
+          files: { nodes: i < 25 ? [{ path: "a.test.ts" }] : [] },
+        })
+      ),
+      // Skipped release PRs that previously deflated the window below 100.
+      ...Array.from({ length: 8 }, (_, i) => pr({ number: 1000 + i, title: `v2.${i}.0` })),
+    ];
+    const report = computeTestRatioReport(raw.map(classifyPR), 100);
+    expect(report.windowCompleted).toBe(true);
+    const r = compareToBaseline(report, baseline);
+    expect(r.ok).toBe(false);
+    expect(r.errors.map((e: { kind: string }) => e.kind)).toContain("fix-with-test-regression");
+  });
+
   it("skips the fix-only gate below the fix-count floor", () => {
     const current = {
       fixWithTestRatio: 0.1,


### PR DESCRIPTION
## Summary

- `scripts/check-test-ratio.mjs` fetched exactly 100 merged PRs in a single GraphQL query then filtered out release/version-bump PRs. Because `windowCompleted` only flips true when the post-filter *eligible* count reaches 100, any skipped PR in the batch declared the window incomplete and made `compareToBaseline` short-circuit with `{ok: true}` — silently disabling the ratio gate.
- The fix paginates the GraphQL search using `$cursor` + `pageInfo` until 100 eligible PRs are collected, capped at `MAX_SEARCH_PAGES=10` with a 60s timeout. Collected nodes are trimmed to exactly the rolling window so ratios are computed over a fixed sample.
- `test-ratio-lib.mjs` is unchanged (it already sizes the window by eligible count). Two regression tests added to `test-ratio-lib.test.ts` to pin both the `windowCompleted` behavior with skipped PRs and the end-to-end gate firing on a real ratio regression.

Resolves #10035

## Changes

- `scripts/check-test-ratio.mjs`: paginated GraphQL fetch loop (`$cursor` + `pageInfo.hasNextPage`/`endCursor`), `MAX_SEARCH_PAGES=10`, timeout widened to 60s, null/non-PR union node skipping, `GraphqlResponseError instanceof` error classification
- `scripts/test-ratio-lib.test.ts`: two new regression tests covering the skipped-PR window and ratio regression pipeline
- `.github/workflows/ci.yml`: merge sharded test matrix into check job (separate cleanup landed in the same branch)

## Testing

- `test-ratio-lib.test.ts` passes 73/73 (covers both new regression cases)
- All static checks pass: typecheck, lint, format, IPC/channel/confirm-wiring guards
- Changes are standalone scripts with no app-bundle impact; Electron build confirmed green on CI