### PR TITLE
fix(demo): dispatch pointer+mouse sequence in demo click handler

### DIFF
--- a/src/components/Demo/DemoCursor.tsx
+++ b/src/components/Demo/DemoCursor.tsx
@@ -813,8 +813,9 @@ export function DemoCursor() {
           const eventOpts = { bubbles: true, cancelable: true };
           // dnd-kit's PointerSensor hard-gates activation on isPrimary && button === 0,
           // and Radix Select reads pointerType/pointerId; without these a synthetic drag
-          // never starts a pointer-first sortable (#10145).
-          const pointerMeta = { pointerId: 1, pointerType: "mouse", isPrimary: true, button: 0 };
+          // never starts a pointer-first sortable (#10145). `button` is set per-event
+          // (0 on down/up, -1 on move per the Pointer Events spec).
+          const pointerMeta = { pointerId: 1, pointerType: "mouse", isPrimary: true };
 
           // Move cursor to source first
           await animateCursor(fromX, fromY, Math.min(payload.durationMs ?? 500, 300));
@@ -825,6 +826,7 @@ export function DemoCursor() {
             new PointerEvent("pointerdown", {
               ...eventOpts,
               ...pointerMeta,
+              button: 0,
               clientX: fromX,
               clientY: fromY,
               buttons: 1,
@@ -885,6 +887,7 @@ export function DemoCursor() {
                   new PointerEvent("pointermove", {
                     ...eventOpts,
                     ...pointerMeta,
+                    button: -1,
                     clientX: cx,
                     clientY: cy,
                     buttons: 1,
@@ -911,6 +914,7 @@ export function DemoCursor() {
               new PointerEvent("pointerup", {
                 ...eventOpts,
                 ...pointerMeta,
+                button: 0,
                 clientX: toX,
                 clientY: toY,
                 buttons: 0,

--- a/src/components/Demo/DemoCursor.tsx
+++ b/src/components/Demo/DemoCursor.tsx
@@ -526,7 +526,19 @@ export function DemoCursor() {
               clientX: cx,
               clientY: cy,
             };
+            // Lead each MouseEvent with its PointerEvent counterpart: Radix triggers
+            // open on onPointerDown and dnd-kit's PointerSensor activates on pointerdown,
+            // so a mouse-only dispatch silently no-ops on pointer-first controls (#10145).
+            const pointerOpts = {
+              ...opts,
+              pointerId: 1,
+              pointerType: "mouse",
+              isPrimary: true,
+              button: 0,
+            };
+            clickTarget.dispatchEvent(new PointerEvent("pointerdown", { ...pointerOpts, buttons: 1 }));
             clickTarget.dispatchEvent(new MouseEvent("mousedown", { ...opts, buttons: 1 }));
+            clickTarget.dispatchEvent(new PointerEvent("pointerup", { ...pointerOpts, buttons: 0 }));
             clickTarget.dispatchEvent(new MouseEvent("mouseup", { ...opts, buttons: 0 }));
             clickTarget.dispatchEvent(new MouseEvent("click", { ...opts, buttons: 0 }));
           }
@@ -799,6 +811,10 @@ export function DemoCursor() {
           const toY = toRect.top + toRect.height / 2;
 
           const eventOpts = { bubbles: true, cancelable: true };
+          // dnd-kit's PointerSensor hard-gates activation on isPrimary && button === 0,
+          // and Radix Select reads pointerType/pointerId; without these a synthetic drag
+          // never starts a pointer-first sortable (#10145).
+          const pointerMeta = { pointerId: 1, pointerType: "mouse", isPrimary: true, button: 0 };
 
           // Move cursor to source first
           await animateCursor(fromX, fromY, Math.min(payload.durationMs ?? 500, 300));
@@ -808,6 +824,7 @@ export function DemoCursor() {
           sourceTarget.dispatchEvent(
             new PointerEvent("pointerdown", {
               ...eventOpts,
+              ...pointerMeta,
               clientX: fromX,
               clientY: fromY,
               buttons: 1,
@@ -867,6 +884,7 @@ export function DemoCursor() {
                 moveTarget.dispatchEvent(
                   new PointerEvent("pointermove", {
                     ...eventOpts,
+                    ...pointerMeta,
                     clientX: cx,
                     clientY: cy,
                     buttons: 1,
@@ -892,6 +910,7 @@ export function DemoCursor() {
             releaseTarget.dispatchEvent(
               new PointerEvent("pointerup", {
                 ...eventOpts,
+                ...pointerMeta,
                 clientX: toX,
                 clientY: toY,
                 buttons: 0,

--- a/src/components/Demo/__tests__/DemoCursor.test.tsx
+++ b/src/components/Demo/__tests__/DemoCursor.test.tsx
@@ -213,12 +213,16 @@ describe("DemoCursor", () => {
     const target = document.createElement("button");
     const events: string[] = [];
     let pointerDown: PointerEvent | undefined;
+    let pointerUp: PointerEvent | undefined;
     target.addEventListener("pointerdown", (e) => {
       events.push("pointerdown");
       pointerDown = e as PointerEvent;
     });
     target.addEventListener("mousedown", () => events.push("mousedown"));
-    target.addEventListener("pointerup", () => events.push("pointerup"));
+    target.addEventListener("pointerup", (e) => {
+      events.push("pointerup");
+      pointerUp = e as PointerEvent;
+    });
     target.addEventListener("mouseup", () => events.push("mouseup"));
     target.addEventListener("click", () => events.push("click"));
 
@@ -237,6 +241,10 @@ describe("DemoCursor", () => {
     expect(pointerDown?.isPrimary).toBe(true);
     expect(pointerDown?.pointerType).toBe("mouse");
     expect(pointerDown?.button).toBe(0);
+    // The release carries the same primary-mouse metadata so the full sequence is honored.
+    expect(pointerUp?.isPrimary).toBe(true);
+    expect(pointerUp?.pointerType).toBe("mouse");
+    expect(pointerUp?.buttons).toBe(0);
     // Verify elementFromPoint was called with cursor position (near viewport center, shifted by settle drift)
     const efp = document.elementFromPoint as ReturnType<typeof vi.fn>;
     const [calledX, calledY] = efp.mock.calls[0]!;
@@ -1210,9 +1218,12 @@ describe("DemoCursor", () => {
     const pointerDowns: PointerEvent[] = [];
     const pointerMoves: PointerEvent[] = [];
     const pointerUps: PointerEvent[] = [];
-    document.addEventListener("pointerdown", (e) => pointerDowns.push(e as PointerEvent));
-    document.addEventListener("pointermove", (e) => pointerMoves.push(e as PointerEvent));
-    document.addEventListener("pointerup", (e) => pointerUps.push(e as PointerEvent));
+    const onDown = (e: Event) => pointerDowns.push(e as PointerEvent);
+    const onMove = (e: Event) => pointerMoves.push(e as PointerEvent);
+    const onUp = (e: Event) => pointerUps.push(e as PointerEvent);
+    document.addEventListener("pointerdown", onDown);
+    document.addEventListener("pointermove", onMove);
+    document.addEventListener("pointerup", onUp);
 
     // Fall back to the resolved from/to elements so dispatch targets are deterministic.
     const origElementFromPoint = document.elementFromPoint;
@@ -1247,10 +1258,14 @@ describe("DemoCursor", () => {
       expect(pointerDowns[0]!.buttons).toBe(1);
 
       expect(pointerMoves.length).toBeGreaterThan(0);
-      expect(pointerMoves.every((e) => e.buttons === 1 && e.pointerType === "mouse")).toBe(true);
+      // Moves signal a held button (buttons:1) but no button-state change (button:-1 per spec).
+      expect(
+        pointerMoves.every((e) => e.buttons === 1 && e.pointerType === "mouse" && e.button === -1)
+      ).toBe(true);
 
       expect(pointerUps.length).toBe(1);
       expect(pointerUps[0]!.pointerType).toBe("mouse");
+      expect(pointerUps[0]!.isPrimary).toBe(true);
       expect(pointerUps[0]!.buttons).toBe(0);
 
       // All events in the session must share the same pointerId for dnd-kit tracking.
@@ -1263,6 +1278,9 @@ describe("DemoCursor", () => {
     } finally {
       setTimeoutSpy.mockRestore();
       document.elementFromPoint = origElementFromPoint;
+      document.removeEventListener("pointerdown", onDown);
+      document.removeEventListener("pointermove", onMove);
+      document.removeEventListener("pointerup", onUp);
       document.body.removeChild(fromEl);
       document.body.removeChild(toEl);
     }

--- a/src/components/Demo/__tests__/DemoCursor.test.tsx
+++ b/src/components/Demo/__tests__/DemoCursor.test.tsx
@@ -207,12 +207,18 @@ describe("DemoCursor", () => {
     );
   });
 
-  it("click dispatches mousedown/mouseup/click events", async () => {
+  it("click leads each mouse event with its pointer event so pointer-first controls actuate", async () => {
     render(<DemoCursor />);
 
     const target = document.createElement("button");
     const events: string[] = [];
+    let pointerDown: PointerEvent | undefined;
+    target.addEventListener("pointerdown", (e) => {
+      events.push("pointerdown");
+      pointerDown = e as PointerEvent;
+    });
     target.addEventListener("mousedown", () => events.push("mousedown"));
+    target.addEventListener("pointerup", () => events.push("pointerup"));
     target.addEventListener("mouseup", () => events.push("mouseup"));
     target.addEventListener("click", () => events.push("click"));
 
@@ -223,7 +229,14 @@ describe("DemoCursor", () => {
 
     await new Promise((r) => setTimeout(r, 10));
 
-    expect(events).toEqual(["mousedown", "mouseup", "click"]);
+    // Pointer events must precede their mouse counterparts: Radix triggers open on
+    // pointerdown and dnd-kit's PointerSensor activates on pointerdown (#10145).
+    expect(events).toEqual(["pointerdown", "mousedown", "pointerup", "mouseup", "click"]);
+    // The pointerdown must satisfy dnd-kit's activation gate (isPrimary && button === 0)
+    // and Radix Select's pointerType === "mouse" guard.
+    expect(pointerDown?.isPrimary).toBe(true);
+    expect(pointerDown?.pointerType).toBe("mouse");
+    expect(pointerDown?.button).toBe(0);
     // Verify elementFromPoint was called with cursor position (near viewport center, shifted by settle drift)
     const efp = document.elementFromPoint as ReturnType<typeof vi.fn>;
     const [calledX, calledY] = efp.mock.calls[0]!;
@@ -1184,6 +1197,75 @@ describe("DemoCursor", () => {
         document.body.removeChild(dst);
       }
     });
+  });
+
+  it("drag dispatches pointer events with primary mouse metadata for pointer sensors", async () => {
+    const fromEl = document.createElement("div");
+    fromEl.id = "drag-from";
+    const toEl = document.createElement("div");
+    toEl.id = "drag-to";
+    document.body.appendChild(fromEl);
+    document.body.appendChild(toEl);
+
+    const pointerDowns: PointerEvent[] = [];
+    const pointerMoves: PointerEvent[] = [];
+    const pointerUps: PointerEvent[] = [];
+    document.addEventListener("pointerdown", (e) => pointerDowns.push(e as PointerEvent));
+    document.addEventListener("pointermove", (e) => pointerMoves.push(e as PointerEvent));
+    document.addEventListener("pointerup", (e) => pointerUps.push(e as PointerEvent));
+
+    // Fall back to the resolved from/to elements so dispatch targets are deterministic.
+    const origElementFromPoint = document.elementFromPoint;
+    document.elementFromPoint = vi.fn(() => null);
+
+    // Collapse the drag's pauseAwareDelay so the 10-step animation runs synchronously.
+    const origSetTimeout = globalThis.setTimeout;
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      fn: (...args: unknown[]) => void
+    ) => origSetTimeout(fn, 0)) as typeof setTimeout);
+
+    try {
+      render(<DemoCursor />);
+      emit("demo:exec-drag", {
+        fromSelector: "#drag-from",
+        toSelector: "#drag-to",
+        durationMs: 100,
+        requestId: "req-drag-1",
+      });
+
+      await vi.waitFor(
+        () => expect(demoMock.sendCommandDone).toHaveBeenCalledWith("req-drag-1", undefined),
+        { timeout: 2000, interval: 20 }
+      );
+
+      // dnd-kit's PointerSensor gates activation on isPrimary && button === 0; the
+      // session also requires a held button across moves and a consistent pointerId (#10145).
+      expect(pointerDowns.length).toBe(1);
+      expect(pointerDowns[0]!.isPrimary).toBe(true);
+      expect(pointerDowns[0]!.pointerType).toBe("mouse");
+      expect(pointerDowns[0]!.button).toBe(0);
+      expect(pointerDowns[0]!.buttons).toBe(1);
+
+      expect(pointerMoves.length).toBeGreaterThan(0);
+      expect(pointerMoves.every((e) => e.buttons === 1 && e.pointerType === "mouse")).toBe(true);
+
+      expect(pointerUps.length).toBe(1);
+      expect(pointerUps[0]!.pointerType).toBe("mouse");
+      expect(pointerUps[0]!.buttons).toBe(0);
+
+      // All events in the session must share the same pointerId for dnd-kit tracking.
+      const ids = new Set([
+        ...pointerDowns.map((e) => e.pointerId),
+        ...pointerMoves.map((e) => e.pointerId),
+        ...pointerUps.map((e) => e.pointerId),
+      ]);
+      expect(ids.size).toBe(1);
+    } finally {
+      setTimeoutSpy.mockRestore();
+      document.elementFromPoint = origElementFromPoint;
+      document.body.removeChild(fromEl);
+      document.body.removeChild(toEl);
+    }
   });
 
   it("waitForSelector resolves immediately when element exists", async () => {


### PR DESCRIPTION
## Summary

- `demo:exec-click` in `DemoCursor.tsx` was only dispatching `MouseEvent`s, but the app is pointer-first — Radix `DropdownMenu.Trigger` opens on `onPointerDown` and dnd-kit's `PointerSensor` gates on `isPrimary && button === 0`, so demo clicks on these controls silently did nothing.
- The click handler now dispatches the full sequence: `pointerdown` → `mousedown` → `pointerup` → `mouseup` → `click`, with `pointerId: 1`, `pointerType: "mouse"`, `isPrimary: true`, `button: 0` on each pointer event.
- The drag handler was already dispatching `PointerEvent`s but without `pointerId`, `pointerType`, or `isPrimary`, which broke `setPointerCapture` and pointer-type guard clauses in libraries. A shared `pointerMeta` const fixes that, with `button: 0` on down/up and `button: -1` on move per the Pointer Events spec.

Resolves #10145

## Changes

- `src/components/Demo/DemoCursor.tsx`: `demo:exec-click` leads with pointer events; `demo:exec-drag` pointer events now carry full primary-mouse metadata via `pointerMeta`.
- `src/components/Demo/__tests__/DemoCursor.test.tsx`: click test asserts the ordered pointer+mouse sequence and metadata; new drag test verifies consistent `pointerId`, `pointerType`, `isPrimary`, and correct `button` values across the full drag session.

## Testing

Typecheck, lint, format, IPC/channel/confirm-wiring guards, and the 21-test `DemoCursor` module all pass locally.