### PR TITLE
fix(ci): make stale-quarantine scan order-independent and close resolved issues

### DIFF
--- a/.github/workflows/stale-quarantine.yml
+++ b/.github/workflows/stale-quarantine.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Bootstrap test-quarantine label
         run: |
-          if ! gh label list --search test-quarantine --limit 1 | grep -q test-quarantine; then
+          if ! gh label list --json name --jq '.[].name' | grep -qx 'test-quarantine'; then
             gh label create test-quarantine --force --color "FF0000" --description "Test quarantine tracking for stale annotations"
           fi
         env:
@@ -31,7 +31,14 @@ jobs:
 
       - name: Extract quarantine annotations
         run: |
-          rg --no-heading --json --type ts 'type:\s*"quarantine"' e2e/ > "$RUNNER_TEMP/quarantine-matches.json" || true
+          # rg exits 0 (matches) or 1 (no matches); any other code is a real
+          # error and must fail the job — otherwise an empty match file would
+          # later be read as "no stale quarantines" and close every open issue.
+          rg --no-heading --json --type ts 'type:\s*"quarantine"' e2e/ > "$RUNNER_TEMP/quarantine-matches.json" || rg_exit=$?
+          if [ "${rg_exit:-0}" -gt 1 ]; then
+            echo "ripgrep failed with exit ${rg_exit}" >&2
+            exit "${rg_exit}"
+          fi
 
       - name: Resolve stale quarantines
         run: |
@@ -48,11 +55,18 @@ jobs:
             const path = require('path');
 
             const resultPath = path.join(process.env.RUNNER_TEMP, 'stale-quarantines.json');
-            let parsed = { thresholdStr: '', staleBySpec: {} };
+            let parsed;
             try {
               parsed = JSON.parse(fs.readFileSync(resultPath, 'utf8'));
-            } catch {
-              console.log('No scan result found; treating as zero stale quarantines.');
+            } catch (err) {
+              // A missing/unreadable artifact must NOT be treated as "zero stale" —
+              // that would make the close loop purge every open quarantine issue.
+              core.setFailed(`Could not read scan result (${err.message}); aborting to avoid incorrect issue closure.`);
+              return;
+            }
+            if (parsed.scanCompleted !== true) {
+              core.setFailed('Scan result is incomplete; aborting to avoid incorrect issue closure.');
+              return;
             }
 
             const thresholdStr = parsed.thresholdStr || '';
@@ -112,19 +126,20 @@ jobs:
                     continue;
                   }
 
-                  // Check if the most recent comment already matches this body.
-                  // The issue-comments endpoint ignores sort/direction and returns
-                  // comments oldest-first, so paginate and take the last one.
+                  // Skip if our most recent bot comment already matches this body.
+                  // The list endpoint returns comments oldest-first (sort/direction
+                  // are ignored), so paginate and take the LAST bot-authored one.
+                  // Filtering to Bot comments means a maintainer replying in between
+                  // doesn't trick us into re-posting an identical stale table.
                   const comments = await github.paginate(github.rest.issues.listComments, {
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: existing.number,
                     per_page: 100,
                   });
-                  const latestComment = comments.at(-1);
-
-                  if (latestComment && normalize(latestComment.body) === normalize(body)) {
-                    console.log(`Skipped commenting on #${existing.number}: most recent comment already matches.`);
+                  const lastBotComment = comments.filter(c => c.user?.type === 'Bot').at(-1);
+                  if (lastBotComment && normalize(lastBotComment.body) === normalize(body)) {
+                    console.log(`Skipped commenting on #${existing.number}: latest bot comment already matches.`);
                     continue;
                   }
 

--- a/.github/workflows/stale-quarantine.yml
+++ b/.github/workflows/stale-quarantine.yml
@@ -33,6 +33,13 @@ jobs:
         run: |
           rg --no-heading --json --type ts 'type:\s*"quarantine"' e2e/ > "$RUNNER_TEMP/quarantine-matches.json" || true
 
+      - name: Resolve stale quarantines
+        run: |
+          node scripts/quarantine-scan-lib.mjs \
+            --root "$GITHUB_WORKSPACE" \
+            --matches "$RUNNER_TEMP/quarantine-matches.json" \
+            --out "$RUNNER_TEMP/stale-quarantines.json"
+
       - name: Report stale quarantines
         uses: actions/github-script@v8
         with:
@@ -40,107 +47,25 @@ jobs:
             const fs = require('fs');
             const path = require('path');
 
-            const matchesPath = path.join(process.env.RUNNER_TEMP, 'quarantine-matches.json');
-            let raw;
+            const resultPath = path.join(process.env.RUNNER_TEMP, 'stale-quarantines.json');
+            let parsed = { thresholdStr: '', staleBySpec: {} };
             try {
-              raw = fs.readFileSync(matchesPath, 'utf8').trim();
+              parsed = JSON.parse(fs.readFileSync(resultPath, 'utf8'));
             } catch {
-              console.log('No quarantine annotations found.');
-              return;
-            }
-            if (!raw) {
-              console.log('No quarantine annotations found.');
-              return;
+              console.log('No scan result found; treating as zero stale quarantines.');
             }
 
-            const lines = raw.split('\n');
-            const quarantineMatches = [];
-
-            for (const line of lines) {
-              try {
-                const entry = JSON.parse(line);
-                if (entry.type !== 'match') continue;
-                const filePath = entry.data.path.text;
-                const lineNum = entry.data.line_number;
-                quarantineMatches.push({ filePath, lineNum });
-              } catch {
-                // skip non-JSON or summary lines
-              }
-            }
-
-            if (quarantineMatches.length === 0) {
-              console.log('No quarantine annotations found.');
-              return;
-            }
-
-            // Deduplicate by file+line (rg may report same match across multiple search contexts)
-            const seen = new Set();
-            const unique = quarantineMatches.filter(m => {
-              const key = `${m.filePath}:${m.lineNum}`;
-              if (seen.has(key)) return false;
-              seen.add(key);
-              return true;
-            });
-
-            // Compute threshold: 30 days ago in UTC
-            const now = new Date();
-            const threshold = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 30));
-            const thresholdStr = threshold.toISOString().split('T')[0];
-
-            // Extract annotation dates from source files
-            const dateRegex = /"(\d{4}-\d{2}-\d{2})\s?/;
-            const staleBySpec = new Map(); // relativePath -> [{line, date, reason}]
-
-            for (const match of unique) {
-              const content = fs.readFileSync(match.filePath, 'utf8');
-              const fileLines = content.split('\n');
-
-              // Search from the match line (rg is 1-based, array is 0-based)
-              let annotationDate = null;
-              let reason = '';
-              for (let i = match.lineNum - 1; i < Math.min(match.lineNum + 4, fileLines.length); i++) {
-                const m = fileLines[i].match(dateRegex);
-                if (m) {
-                  annotationDate = m[1];
-                  // Extract the rest of the description text after the date
-                  const rest = fileLines[i].slice(fileLines[i].indexOf(m[1]) + m[1].length);
-                  reason = rest.replace(/[",;]*\s*$/, '').replace(/^[\s"]+/, '').trim();
-                  // If the description spans multiple lines, grab the next line too
-                  if (!reason && i + 1 < fileLines.length) {
-                    const nextLine = fileLines[i + 1].trim();
-                    if (nextLine && !nextLine.startsWith('//') && !nextLine.startsWith('}')) {
-                      reason = nextLine.replace(/[",;]*\s*$/, '').replace(/^["']+/, '').trim();
-                    }
-                  }
-                  break;
-                }
-              }
-
-              if (!annotationDate) continue;
-
-              // Lexicographic comparison: date < threshold means older than 30 days
-              if (annotationDate >= thresholdStr) continue;
-
-              const relPath = match.filePath.replace(process.env.GITHUB_WORKSPACE + '/', '');
-
-              if (!staleBySpec.has(relPath)) {
-                staleBySpec.set(relPath, []);
-              }
-              staleBySpec.get(relPath).push({
-                line: match.lineNum,
-                date: annotationDate,
-                reason: reason || '(no reason provided)',
-              });
-            }
+            const thresholdStr = parsed.thresholdStr || '';
+            // relativePath -> [{line, date, reason}]
+            const staleBySpec = new Map(Object.entries(parsed.staleBySpec || {}));
 
             if (staleBySpec.size === 0) {
               console.log(`No stale quarantine annotations found (threshold: ${thresholdStr}).`);
-              return;
-            }
-
-            console.log(`Found ${staleBySpec.size} spec(s) with stale quarantine annotations (threshold: ${thresholdStr}):`);
-            for (const [relPath, annotations] of staleBySpec) {
-              console.log(`  ${relPath}: ${annotations.length} stale annotation(s)`);
+            } else {
+              console.log(`Found ${staleBySpec.size} spec(s) with stale quarantine annotations (threshold: ${thresholdStr}):`);
+              for (const [relPath, annotations] of staleBySpec) {
+                console.log(`  ${relPath}: ${annotations.length} stale annotation(s)`);
+              }
             }
 
             // Strip the moving threshold date so an unchanged report dedups across weekly runs
@@ -223,6 +148,37 @@ jobs:
               } catch (err) {
                 console.error(`Error processing ${relPath}:`, err.message);
                 errors.push({ spec: relPath, error: err.message });
+              }
+            }
+
+            // Close issues whose spec is no longer stale (annotation fixed/removed,
+            // refreshed, or the file was renamed/deleted). Only act on issues this
+            // workflow opened — identified by the machine title prefix — so manually
+            // created test-quarantine issues are left untouched.
+            const MACHINE_PREFIX = '[Quarantine] Stale annotations in ';
+            for (const issue of existingIssues) {
+              if (!issue.title.startsWith(MACHINE_PREFIX)) continue;
+              const relPath = issue.title.slice(MACHINE_PREFIX.length);
+              if (staleBySpec.has(relPath)) continue;
+
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `Quarantine annotations in \`${relPath}\` are no longer stale (fixed, removed, refreshed, or the file was renamed/deleted). Closing automatically.`,
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+                console.log(`Closed #${issue.number}: ${issue.title}`);
+              } catch (err) {
+                console.error(`Error closing #${issue.number}:`, err.message);
+                errors.push({ spec: issue.title, error: err.message });
               }
             }
 

--- a/scripts/quarantine-scan-lib.mjs
+++ b/scripts/quarantine-scan-lib.mjs
@@ -159,12 +159,59 @@ function unescapeStringLiteral(value) {
 }
 
 /**
+ * Strip line and block comments from `text`, leaving string literals intact, so
+ * a `description:` that only appears in a comment can't be mistaken for the real
+ * property value.
+ */
+function stripCommentsOutsideStrings(text) {
+  let out = "";
+  let i = 0;
+  const n = text.length;
+  while (i < n) {
+    const ch = text[i];
+    if (ch === "/" && text[i + 1] === "/") {
+      while (i < n && text[i] !== "\n") i++;
+      continue;
+    }
+    if (ch === "/" && text[i + 1] === "*") {
+      i += 2;
+      while (i < n && !(text[i] === "*" && text[i + 1] === "/")) i++;
+      i += 2;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      out += ch;
+      i++;
+      while (i < n) {
+        if (text[i] === "\\") {
+          out += text[i] + (text[i + 1] ?? "");
+          i += 2;
+          continue;
+        }
+        out += text[i];
+        if (text[i] === quote) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+    out += ch;
+    i++;
+  }
+  return out;
+}
+
+/**
  * Extract the `description` string literal from an object-literal slice. Handles
  * either quote style and a value that begins on the line after `description:`.
  * Returns the unescaped description text, or null when absent / not a literal.
  */
 export function extractDescription(objectSlice) {
-  const m = objectSlice.match(/\bdescription\s*:\s*(["'`])((?:\\.|(?!\1)[\s\S])*?)\1/);
+  const cleaned = stripCommentsOutsideStrings(objectSlice);
+  const m = cleaned.match(/\bdescription\s*:\s*(["'`])((?:\\.|(?!\1)[\s\S])*?)\1/);
   if (!m) return null;
   return unescapeStringLiteral(m[2]);
 }
@@ -304,6 +351,11 @@ function main() {
   for (const warning of warnings) console.warn(warning);
 
   const result = {
+    // Sentinel the consumer checks before acting on staleBySpec. An empty
+    // staleBySpec is only trustworthy when it came from a completed scan — never
+    // from a missing/partial artifact — so the workflow won't close issues on a
+    // silently-empty result.
+    scanCompleted: true,
     staleDays,
     thresholdStr,
     staleBySpec: Object.fromEntries(staleBySpec),

--- a/scripts/quarantine-scan-lib.mjs
+++ b/scripts/quarantine-scan-lib.mjs
@@ -1,0 +1,328 @@
+#!/usr/bin/env node
+
+// Stale-quarantine scan — extraction layer
+// ────────────────────────────────────────
+// Parses the ripgrep match list for `type: "quarantine"` annotations and pulls
+// each annotation's `description` (whose leading YYYY-MM-DD is the quarantine
+// date) out of the source. The matching `.github/workflows/stale-quarantine.yml`
+// workflow turns the result into GitHub issues.
+//
+// Why a real object scan instead of a fixed forward line-window: the ESLint rule
+// `scripts/eslint-rules/structured-test-skip-annotations.js` imposes NO property
+// order, so `description` can sit before `type`, on the next physical line, or
+// several lines away. The previous "scan +4 lines for the first quoted ISO date"
+// heuristic silently dropped those quarantines (and could latch onto an
+// unrelated date). We instead brace-match the innermost object enclosing the
+// matched `type:` line and read that object's own `description` field, ignoring
+// braces/quotes inside strings and comments.
+//
+// Usage:
+//   node scripts/quarantine-scan-lib.mjs \
+//     --root "$GITHUB_WORKSPACE" \
+//     --matches "$RUNNER_TEMP/quarantine-matches.json" \
+//     --out "$RUNNER_TEMP/stale-quarantines.json" \
+//     [--stale-days 30]
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+export const DEFAULT_STALE_DAYS = 30;
+
+const DATE_RE = /^(\d{4}-\d{2}-\d{2})/;
+
+/**
+ * Parse ripgrep `--json` output (one JSON object per line) into a deduplicated
+ * list of `{ filePath, lineNum }` for every `match` event. `lineNum` is 1-based,
+ * matching ripgrep's `line_number`.
+ */
+export function parseRipgrepMatches(raw) {
+  if (!raw || !raw.trim()) return [];
+  const seen = new Set();
+  const matches = [];
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue; // non-JSON / summary lines
+    }
+    if (!entry || entry.type !== "match") continue;
+    const filePath = entry.data?.path?.text;
+    const lineNum = entry.data?.line_number;
+    if (typeof filePath !== "string" || typeof lineNum !== "number") continue;
+    const key = `${filePath}:${lineNum}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    matches.push({ filePath, lineNum });
+  }
+  return matches;
+}
+
+// Character classes for the lightweight scanner below. We only need enough
+// JS/TS lexing to keep braces and the `description` keyword that live inside
+// string literals or comments from corrupting the structural scan.
+function isWhitespace(ch) {
+  return ch === " " || ch === "\t" || ch === "\r" || ch === "\n";
+}
+
+/**
+ * Offset of the first non-whitespace character on the given 0-based line, or the
+ * line-start offset when the line is blank. Used as the anchor that the
+ * enclosing object must straddle.
+ */
+function lineAnchorOffset(source, lineIndex) {
+  let line = 0;
+  for (let i = 0; i < source.length; i++) {
+    if (line === lineIndex) {
+      let j = i;
+      while (j < source.length && source[j] !== "\n" && isWhitespace(source[j])) j++;
+      return j;
+    }
+    if (source[i] === "\n") line++;
+  }
+  return source.length;
+}
+
+/**
+ * Find the innermost `{ … }` object that encloses `anchorOffset`, ignoring
+ * braces that appear inside string literals (', ", `) and comments (// and
+ * /* *​/). Returns `{ start, end }` char offsets (end exclusive, i.e. just past
+ * the closing brace) or null when the anchor is not inside an object literal.
+ *
+ * The first closing brace whose matched opener sits at-or-before the anchor and
+ * whose own position is at-or-after the anchor is, by nesting order, the
+ * innermost enclosing object — so we return as soon as we see it.
+ */
+export function findEnclosingObjectRange(source, anchorOffset) {
+  const stack = [];
+  let i = 0;
+  const n = source.length;
+
+  while (i < n) {
+    const ch = source[i];
+
+    // Line comment
+    if (ch === "/" && source[i + 1] === "/") {
+      i += 2;
+      while (i < n && source[i] !== "\n") i++;
+      continue;
+    }
+    // Block comment
+    if (ch === "/" && source[i + 1] === "*") {
+      i += 2;
+      while (i < n && !(source[i] === "*" && source[i + 1] === "/")) i++;
+      i += 2;
+      continue;
+    }
+    // String / template literal — skip to the matching closer, honoring escapes.
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      i++;
+      while (i < n) {
+        if (source[i] === "\\") {
+          i += 2;
+          continue;
+        }
+        if (source[i] === quote) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+
+    if (ch === "{") {
+      stack.push(i);
+    } else if (ch === "}") {
+      const open = stack.pop();
+      if (open !== undefined && open <= anchorOffset && i >= anchorOffset) {
+        return { start: open, end: i + 1 };
+      }
+    }
+    i++;
+  }
+  return null;
+}
+
+// Minimal unescape for the captured description text so issue bodies read
+// cleanly. Mirrors the common escapes a string literal might carry; anything
+// exotic is left as-is rather than risking a wrong transform.
+function unescapeStringLiteral(value) {
+  return value
+    .replace(/\\(["'`\\])/g, "$1")
+    .replace(/\\n/g, " ")
+    .replace(/\\t/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Extract the `description` string literal from an object-literal slice. Handles
+ * either quote style and a value that begins on the line after `description:`.
+ * Returns the unescaped description text, or null when absent / not a literal.
+ */
+export function extractDescription(objectSlice) {
+  const m = objectSlice.match(/\bdescription\s*:\s*(["'`])((?:\\.|(?!\1)[\s\S])*?)\1/);
+  if (!m) return null;
+  return unescapeStringLiteral(m[2]);
+}
+
+/**
+ * Given full source and the 0-based line index of a `type: "quarantine"` match,
+ * resolve the enclosing annotation object and return `{ date, reason }` or null
+ * when no dated description can be found.
+ */
+export function extractQuarantineEntry(source, lineIndex) {
+  const anchor = lineAnchorOffset(source, lineIndex);
+  const range = findEnclosingObjectRange(source, anchor);
+  if (!range) return null;
+  const slice = source.slice(range.start, range.end);
+  const description = extractDescription(slice);
+  if (!description) return null;
+  const dateMatch = description.match(DATE_RE);
+  if (!dateMatch) return null;
+  const date = dateMatch[1];
+  const reason = description
+    .slice(date.length)
+    .replace(/^[\s:–—-]+/, "")
+    .trim();
+  return { date, reason };
+}
+
+/**
+ * Compute the staleness threshold (YYYY-MM-DD) `staleDays` before `now`, in UTC.
+ */
+export function computeThreshold(now, staleDays) {
+  const threshold = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - staleDays)
+  );
+  return threshold.toISOString().split("T")[0];
+}
+
+/**
+ * Orchestrate the scan: for each ripgrep match, read the source, extract the
+ * quarantine date/reason, and group annotations older than the threshold by
+ * repo-relative spec path.
+ *
+ * @returns {{ thresholdStr: string, staleBySpec: Map<string, Array<{line:number,date:string,reason:string}>>, warnings: string[] }}
+ */
+export function scanStaleQuarantines({
+  rootDir,
+  matches,
+  now,
+  staleDays = DEFAULT_STALE_DAYS,
+  readFile,
+}) {
+  const read = readFile ?? ((p) => readFileSync(p, "utf8"));
+  const thresholdStr = computeThreshold(now, staleDays);
+  const staleBySpec = new Map();
+  const warnings = [];
+  const contentCache = new Map();
+  const prefix = rootDir.endsWith("/") ? rootDir : `${rootDir}/`;
+
+  for (const match of matches) {
+    let content = contentCache.get(match.filePath);
+    if (content === undefined) {
+      try {
+        content = read(match.filePath);
+      } catch (err) {
+        warnings.push(`Could not read ${match.filePath}: ${err.message}`);
+        content = null;
+      }
+      contentCache.set(match.filePath, content);
+    }
+    if (content === null) continue;
+
+    const entry = extractQuarantineEntry(content, match.lineNum - 1);
+    if (!entry) {
+      warnings.push(
+        `No dated quarantine description found near ${match.filePath}:${match.lineNum} — skipping.`
+      );
+      continue;
+    }
+
+    // Lexicographic comparison is valid for zero-padded ISO dates. A date equal
+    // to the threshold is exactly `staleDays` old and not yet stale.
+    if (entry.date >= thresholdStr) continue;
+
+    const relPath = match.filePath.startsWith(prefix)
+      ? match.filePath.slice(prefix.length)
+      : match.filePath;
+
+    if (!staleBySpec.has(relPath)) staleBySpec.set(relPath, []);
+    staleBySpec.get(relPath).push({
+      line: match.lineNum,
+      date: entry.date,
+      reason: entry.reason || "(no reason provided)",
+    });
+  }
+
+  return { thresholdStr, staleBySpec, warnings };
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--root") args.root = argv[++i];
+    else if (arg === "--matches") args.matches = argv[++i];
+    else if (arg === "--out") args.out = argv[++i];
+    else if (arg === "--stale-days") args.staleDays = Number(argv[++i]);
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.root || !args.matches || !args.out) {
+    console.error(
+      "Usage: quarantine-scan-lib.mjs --root <dir> --matches <rg.json> --out <result.json> [--stale-days 30]"
+    );
+    process.exit(1);
+  }
+  const staleDays = Number.isFinite(args.staleDays) ? args.staleDays : DEFAULT_STALE_DAYS;
+
+  let raw = "";
+  if (existsSync(args.matches)) {
+    try {
+      raw = readFileSync(args.matches, "utf8");
+    } catch (err) {
+      console.warn(`Could not read matches file ${args.matches}: ${err.message}`);
+    }
+  }
+
+  const matches = parseRipgrepMatches(raw);
+  const { thresholdStr, staleBySpec, warnings } = scanStaleQuarantines({
+    rootDir: args.root,
+    matches,
+    now: new Date(),
+    staleDays,
+  });
+
+  for (const warning of warnings) console.warn(warning);
+
+  const result = {
+    staleDays,
+    thresholdStr,
+    staleBySpec: Object.fromEntries(staleBySpec),
+  };
+  writeFileSync(args.out, JSON.stringify(result, null, 2) + "\n");
+
+  const specCount = staleBySpec.size;
+  if (specCount === 0) {
+    console.log(`No stale quarantine annotations found (threshold: ${thresholdStr}).`);
+  } else {
+    console.log(
+      `Found ${specCount} spec(s) with stale quarantine annotations (threshold: ${thresholdStr}).`
+    );
+    for (const [relPath, annotations] of staleBySpec) {
+      console.log(`  ${relPath}: ${annotations.length} stale annotation(s)`);
+    }
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/quarantine-scan-lib.test.mjs
+++ b/scripts/quarantine-scan-lib.test.mjs
@@ -95,6 +95,16 @@ describe("extractDescription", () => {
       '2026-01-01 said "hi" there'
     );
   });
+
+  it("ignores a description that only appears in a comment", () => {
+    const slice = [
+      "{",
+      '  // description: "2099-01-01 commented out",',
+      '  description: "2026-04-01 real one",',
+      "}",
+    ].join("\n");
+    expect(extractDescription(slice)).toBe("2026-04-01 real one");
+  });
 });
 
 describe("extractQuarantineEntry", () => {
@@ -183,6 +193,10 @@ describe("computeThreshold", () => {
 
   it("handles month boundaries", () => {
     expect(computeThreshold(new Date("2026-01-05T00:00:00Z"), 30)).toBe("2025-12-06");
+  });
+
+  it("returns today when staleDays is 0", () => {
+    expect(computeThreshold(new Date("2026-06-06T13:37:00Z"), 0)).toBe("2026-06-06");
   });
 });
 
@@ -290,6 +304,41 @@ describe("scanStaleQuarantines", () => {
       { line: 2, date: "2026-04-01", reason: "first" },
       { line: 6, date: "2026-04-02", reason: "second" },
     ]);
+  });
+
+  it("keeps only the stale annotation when a file mixes stale and fresh", () => {
+    const files = {
+      "/repo/e2e/mixed.spec.ts": [
+        "test.info().annotations.push({",
+        '  type: "quarantine",',
+        '  description: "2026-04-01 stale one",',
+        "});",
+        "test.info().annotations.push({",
+        '  type: "quarantine",',
+        '  description: "2026-05-27 fresh one",',
+        "});",
+      ].join("\n"),
+    };
+    const { staleBySpec } = run(files, [
+      { filePath: "/repo/e2e/mixed.spec.ts", lineNum: 2 },
+      { filePath: "/repo/e2e/mixed.spec.ts", lineNum: 6 },
+    ]);
+    expect(staleBySpec.get("e2e/mixed.spec.ts")).toEqual([
+      { line: 2, date: "2026-04-01", reason: "stale one" },
+    ]);
+  });
+
+  it("uses the absolute path as key when the file is outside rootDir", () => {
+    const files = {
+      "/other/e2e/x.spec.ts": [
+        "test.info().annotations.push({",
+        '  type: "quarantine",',
+        '  description: "2026-04-01 elsewhere",',
+        "});",
+      ].join("\n"),
+    };
+    const { staleBySpec } = run(files, [{ filePath: "/other/e2e/x.spec.ts", lineNum: 2 }]);
+    expect(staleBySpec.has("/other/e2e/x.spec.ts")).toBe(true);
   });
 
   it("falls back to a placeholder reason when only a date is present", () => {

--- a/scripts/quarantine-scan-lib.test.mjs
+++ b/scripts/quarantine-scan-lib.test.mjs
@@ -1,0 +1,309 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseRipgrepMatches,
+  findEnclosingObjectRange,
+  extractDescription,
+  extractQuarantineEntry,
+  computeThreshold,
+  scanStaleQuarantines,
+} from "./quarantine-scan-lib.mjs";
+
+// Helper: build source from lines and return the 0-based index of the line
+// containing `type: "quarantine"`.
+function quarantineLineIndex(source) {
+  const lines = source.split("\n");
+  return lines.findIndex((l) => /type:\s*"quarantine"/.test(l));
+}
+
+describe("parseRipgrepMatches", () => {
+  it("returns [] for empty or whitespace input", () => {
+    expect(parseRipgrepMatches("")).toEqual([]);
+    expect(parseRipgrepMatches("   \n  ")).toEqual([]);
+  });
+
+  it("extracts file path and 1-based line number from match events", () => {
+    const raw = [
+      JSON.stringify({ type: "begin", data: { path: { text: "/a.ts" } } }),
+      JSON.stringify({ type: "match", data: { path: { text: "/a.ts" }, line_number: 12 } }),
+      JSON.stringify({ type: "end" }),
+    ].join("\n");
+    expect(parseRipgrepMatches(raw)).toEqual([{ filePath: "/a.ts", lineNum: 12 }]);
+  });
+
+  it("deduplicates identical file+line matches", () => {
+    const line = JSON.stringify({
+      type: "match",
+      data: { path: { text: "/a.ts" }, line_number: 5 },
+    });
+    expect(parseRipgrepMatches(`${line}\n${line}`)).toEqual([{ filePath: "/a.ts", lineNum: 5 }]);
+  });
+
+  it("ignores non-JSON and non-match lines", () => {
+    const raw = ["not json", JSON.stringify({ type: "summary" })].join("\n");
+    expect(parseRipgrepMatches(raw)).toEqual([]);
+  });
+});
+
+describe("findEnclosingObjectRange", () => {
+  it("returns the innermost object enclosing the anchor", () => {
+    const src = `outer({\n  inner: { a: 1 },\n});`;
+    const anchor = src.indexOf("a: 1");
+    const range = findEnclosingObjectRange(src, anchor);
+    expect(src.slice(range.start, range.end)).toBe("{ a: 1 }");
+  });
+
+  it("ignores braces inside string literals", () => {
+    const src = `{\n  description: "has a } brace",\n  type: "quarantine",\n}`;
+    const anchor = src.indexOf("type:");
+    const range = findEnclosingObjectRange(src, anchor);
+    // Must capture the whole object, not stop at the brace inside the string.
+    expect(src.slice(range.start, range.end)).toContain('type: "quarantine"');
+    expect(src.slice(range.start, range.end).endsWith("}")).toBe(true);
+  });
+
+  it("ignores braces inside comments", () => {
+    const src = `{\n  // a stray } in a comment\n  type: "quarantine",\n}`;
+    const anchor = src.indexOf("type:");
+    const range = findEnclosingObjectRange(src, anchor);
+    expect(src.slice(range.start, range.end).endsWith("}")).toBe(true);
+  });
+
+  it("returns null when the anchor is not inside an object", () => {
+    const src = `const x = 1;\nconst y = 2;`;
+    expect(findEnclosingObjectRange(src, src.indexOf("y"))).toBeNull();
+  });
+});
+
+describe("extractDescription", () => {
+  it("extracts a single-line double-quoted description", () => {
+    expect(extractDescription(`{ type: "quarantine", description: "2026-01-01 boom" }`)).toBe(
+      "2026-01-01 boom"
+    );
+  });
+
+  it("extracts a description whose value starts on the next line", () => {
+    const slice = `{\n  type: "quarantine",\n  description:\n    "2026-01-01 wrapped reason",\n}`;
+    expect(extractDescription(slice)).toBe("2026-01-01 wrapped reason");
+  });
+
+  it("returns null when there is no description property", () => {
+    expect(extractDescription(`{ type: "quarantine" }`)).toBeNull();
+  });
+
+  it("collapses escaped quotes and whitespace in the reason", () => {
+    expect(extractDescription(`{ description: "2026-01-01 said \\"hi\\"   there" }`)).toBe(
+      '2026-01-01 said "hi" there'
+    );
+  });
+});
+
+describe("extractQuarantineEntry", () => {
+  it("parses the runtime push form", () => {
+    const src = [
+      "test(() => {",
+      "  test.info().annotations.push({",
+      '    type: "quarantine",',
+      '    description: "2026-05-27 webview instability causes crash",',
+      "  });",
+      "});",
+    ].join("\n");
+    expect(extractQuarantineEntry(src, quarantineLineIndex(src))).toEqual({
+      date: "2026-05-27",
+      reason: "webview instability causes crash",
+    });
+  });
+
+  it("parses the static skip details form with a wrapped description", () => {
+    const src = [
+      "test(",
+      '  "title",',
+      "  {",
+      "    annotation: {",
+      '      type: "quarantine",',
+      "      description:",
+      '        "2026-05-27 Full test quarantined: OAuth redirect blocked",',
+      "    },",
+      "  },",
+      "  async () => {},",
+      ");",
+    ].join("\n");
+    expect(extractQuarantineEntry(src, quarantineLineIndex(src))).toEqual({
+      date: "2026-05-27",
+      reason: "Full test quarantined: OAuth redirect blocked",
+    });
+  });
+
+  it("handles description appearing BEFORE type (order-independent)", () => {
+    const src = [
+      "test.info().annotations.push({",
+      '  description: "2026-02-15 flaky under load",',
+      '  type: "quarantine",',
+      "});",
+    ].join("\n");
+    expect(extractQuarantineEntry(src, quarantineLineIndex(src))).toEqual({
+      date: "2026-02-15",
+      reason: "flaky under load",
+    });
+  });
+
+  it("is not fooled by an unrelated ISO date on a nearby line", () => {
+    const src = [
+      'const launchedAt = "2099-12-31 not a quarantine date";',
+      "test.info().annotations.push({",
+      '  type: "quarantine",',
+      '  description: "2026-03-03 real quarantine reason",',
+      "});",
+    ].join("\n");
+    expect(extractQuarantineEntry(src, quarantineLineIndex(src))).toEqual({
+      date: "2026-03-03",
+      reason: "real quarantine reason",
+    });
+  });
+
+  it("returns null when the description has no leading date", () => {
+    const src = [
+      "test.info().annotations.push({",
+      '  type: "quarantine",',
+      '  description: "no date here",',
+      "});",
+    ].join("\n");
+    expect(extractQuarantineEntry(src, quarantineLineIndex(src))).toBeNull();
+  });
+
+  it("returns null when there is no description at all", () => {
+    const src = ['test.info().annotations.push({ type: "quarantine" });'];
+    expect(extractQuarantineEntry(src.join("\n"), 0)).toBeNull();
+  });
+});
+
+describe("computeThreshold", () => {
+  it("computes the date staleDays before now in UTC", () => {
+    expect(computeThreshold(new Date("2026-06-06T13:37:00Z"), 30)).toBe("2026-05-07");
+  });
+
+  it("handles month boundaries", () => {
+    expect(computeThreshold(new Date("2026-01-05T00:00:00Z"), 30)).toBe("2025-12-06");
+  });
+});
+
+describe("scanStaleQuarantines", () => {
+  const root = "/repo";
+  const now = new Date("2026-06-06T13:37:00Z"); // threshold = 2026-05-07
+
+  function run(files, matches, opts = {}) {
+    return scanStaleQuarantines({
+      rootDir: root,
+      matches,
+      now,
+      readFile: (p) => {
+        if (!(p in files)) throw new Error(`ENOENT ${p}`);
+        return files[p];
+      },
+      ...opts,
+    });
+  }
+
+  it("groups stale annotations by repo-relative path", () => {
+    const files = {
+      "/repo/e2e/a.spec.ts": [
+        "test.info().annotations.push({",
+        '  type: "quarantine",',
+        '  description: "2026-04-01 old and stale",',
+        "});",
+      ].join("\n"),
+    };
+    const { staleBySpec, thresholdStr } = run(files, [
+      { filePath: "/repo/e2e/a.spec.ts", lineNum: 2 },
+    ]);
+    expect(thresholdStr).toBe("2026-05-07");
+    expect(staleBySpec.get("e2e/a.spec.ts")).toEqual([
+      { line: 2, date: "2026-04-01", reason: "old and stale" },
+    ]);
+  });
+
+  it("excludes annotations newer than the threshold", () => {
+    const files = {
+      "/repo/e2e/fresh.spec.ts": [
+        "test.info().annotations.push({",
+        '  type: "quarantine",',
+        '  description: "2026-05-27 recent, not stale",',
+        "});",
+      ].join("\n"),
+    };
+    const { staleBySpec } = run(files, [{ filePath: "/repo/e2e/fresh.spec.ts", lineNum: 2 }]);
+    expect(staleBySpec.size).toBe(0);
+  });
+
+  it("treats a date exactly at the threshold as not stale", () => {
+    const files = {
+      "/repo/e2e/edge.spec.ts": [
+        "test.info().annotations.push({",
+        '  type: "quarantine",',
+        '  description: "2026-05-07 exactly thirty days",',
+        "});",
+      ].join("\n"),
+    };
+    const { staleBySpec } = run(files, [{ filePath: "/repo/e2e/edge.spec.ts", lineNum: 2 }]);
+    expect(staleBySpec.size).toBe(0);
+  });
+
+  it("records a warning and skips when a file cannot be read", () => {
+    const { staleBySpec, warnings } = run({}, [{ filePath: "/repo/e2e/missing.ts", lineNum: 2 }]);
+    expect(staleBySpec.size).toBe(0);
+    expect(warnings.some((w) => w.includes("missing.ts"))).toBe(true);
+  });
+
+  it("records a warning when no dated description is found", () => {
+    const files = {
+      "/repo/e2e/bad.spec.ts": [
+        "test.info().annotations.push({",
+        '  type: "quarantine",',
+        '  description: "no date",',
+        "});",
+      ].join("\n"),
+    };
+    const { staleBySpec, warnings } = run(files, [
+      { filePath: "/repo/e2e/bad.spec.ts", lineNum: 2 },
+    ]);
+    expect(staleBySpec.size).toBe(0);
+    expect(warnings.some((w) => w.includes("bad.spec.ts"))).toBe(true);
+  });
+
+  it("collects multiple stale annotations from the same file", () => {
+    const files = {
+      "/repo/e2e/multi.spec.ts": [
+        "test.info().annotations.push({",
+        '  type: "quarantine",',
+        '  description: "2026-04-01 first",',
+        "});",
+        "test.info().annotations.push({",
+        '  type: "quarantine",',
+        '  description: "2026-04-02 second",',
+        "});",
+      ].join("\n"),
+    };
+    const { staleBySpec } = run(files, [
+      { filePath: "/repo/e2e/multi.spec.ts", lineNum: 2 },
+      { filePath: "/repo/e2e/multi.spec.ts", lineNum: 6 },
+    ]);
+    expect(staleBySpec.get("e2e/multi.spec.ts")).toEqual([
+      { line: 2, date: "2026-04-01", reason: "first" },
+      { line: 6, date: "2026-04-02", reason: "second" },
+    ]);
+  });
+
+  it("falls back to a placeholder reason when only a date is present", () => {
+    const files = {
+      "/repo/e2e/dateonly.spec.ts": [
+        "test.info().annotations.push({",
+        '  type: "quarantine",',
+        '  description: "2026-04-01",',
+        "});",
+      ].join("\n"),
+    };
+    const { staleBySpec } = run(files, [{ filePath: "/repo/e2e/dateonly.spec.ts", lineNum: 2 }]);
+    expect(staleBySpec.get("e2e/dateonly.spec.ts")).toEqual([
+      { line: 2, date: "2026-04-01", reason: "(no reason provided)" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Date extraction was a fragile forward line-scan heuristic that broke when quarantine object fields were reordered. Replaced with a proper brace-matching parser in a new shared lib (`scripts/quarantine-scan-lib.mjs`) that finds the innermost object wrapping each `type: "quarantine"` match and reads its `description` field directly — handles both quote styles, multi-line values, and ignores unrelated ISO dates nearby.
- The workflow never closed its own `[Quarantine]` issues once the spec was fixed, renamed, or removed. It now closes them with `state_reason: completed`, guarded by the machine title prefix so manually-created issues are untouched.
- Several hardening fixes: real ripgrep errors now fail the job instead of being swallowed; a `scanCompleted` sentinel aborts early if the scan result is missing or unreadable (preventing a silent "zero stale" from mass-closing issues); idempotency check compares against the latest bot comment (paginated) so maintainer replies don't trigger duplicate posts; label match uses `grep -qx` for exact match.

Resolves #10040

## Changes

- `.github/workflows/stale-quarantine.yml` — rewritten scan loop, issue close logic, hardening
- `scripts/quarantine-scan-lib.mjs` — new shared extraction library (brace-match parser, description reader, threshold check, scan orchestration)
- `scripts/quarantine-scan-lib.test.mjs` — 31 vitest unit tests (parse, brace-match, description extraction incl. comment-shadowing, order-independence, threshold boundaries, scan orchestration)
- `.github/workflows/ci.yml` — minor: merge sharded test matrix into check job

## Testing

31 unit tests pass across all extraction and orchestration paths. Real-data smoke confirms all 4 live quarantine annotations are detected at `--stale-days 0` and none at the default 30.