### PR TITLE
fix(browser): close webview lifecycle UI gaps vs Dev Preview (#9964)

### DIFF
--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -289,25 +289,40 @@ export function BrowserPane({
     return () => clearTimeout(timer);
   }, [blockedNav]);
 
-  const handleRenderProcessGone = useCallback((details: { reason: string; exitCode: number }) => {
-    const now = Date.now();
-    const timestamps = crashTimestampsRef.current.filter((ts) => now - ts < 60_000);
-    timestamps.push(now);
-    crashTimestampsRef.current = timestamps;
+  const handleRenderProcessGone = useCallback(
+    (details: { reason: string; exitCode: number }) => {
+      const now = Date.now();
+      const timestamps = crashTimestampsRef.current.filter((ts) => now - ts < 60_000);
+      timestamps.push(now);
+      crashTimestampsRef.current = timestamps;
 
-    // Clear any stale load-error overlay (z-30, absolute inset-0) — without
-    // this it would occlude the crash banner, which is an in-flow element.
-    setLoadError(null);
-    setCrashDetails(details);
-    setCrashState("crashed");
+      // Clear any stale load-error overlay (z-30, absolute inset-0) — without
+      // this it would occlude the crash banner, which is an in-flow element.
+      setLoadError(null);
+      setCrashDetails(details);
+      setCrashState("crashed");
 
-    // Auto-reload silently on the first crash within the 60s window so a
-    // one-off renderer fault recovers transparently. A second crash within
-    // the window leaves the banner up so the user can act.
-    if (timestamps.length < 2) {
-      crashReloadRef.current();
-    }
-  }, []);
+      // Auto-reload silently on the first crash within the 60s window so a
+      // one-off renderer fault recovers transparently. A second crash within
+      // the window leaves the banner up so the user can act.
+      if (timestamps.length < 2) {
+        crashReloadRef.current();
+      } else {
+        // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
+        notify({
+          type: "error",
+          title: "Page crashed repeatedly",
+          message: `The browser page crashed (${details.reason}) twice within 60 seconds. Auto-recovery stopped. Use Reload to recover.`,
+          priority: "high",
+          duration: 0,
+          context: { eventKind: "recovery", panelId: id },
+          supersedeKey: `browser-pane-crash-loop:${id}`,
+          correlationId: id,
+        });
+      }
+    },
+    [id]
+  );
 
   useWebviewEvents({
     webviewElement,
@@ -996,11 +1011,19 @@ export function BrowserPane({
             <div className="relative flex-1 min-h-0">
               {isDragging && <div className="absolute inset-0 z-10 bg-transparent" />}
               {showLoadingOverlay && (
-                <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg z-10 gap-3">
+                <div
+                  className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg z-10 gap-3"
+                  role="status"
+                  aria-busy="true"
+                  aria-label="Loading…"
+                >
+                  <span className="sr-only">Loading…</span>
                   <Spinner size="2xl" className="text-status-info" />
                   {isSlowLoad && (
                     <>
-                      <p className="text-xs text-daintree-text/50">Taking longer than usual...</p>
+                      <p aria-hidden="true" className="text-xs text-daintree-text/50">
+                        Taking longer than usual...
+                      </p>
                       <Button
                         onClick={handleCancelLoad}
                         variant="ghost"

--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -1011,14 +1011,19 @@ export function BrowserPane({
             <div className="relative flex-1 min-h-0">
               {isDragging && <div className="absolute inset-0 z-10 bg-transparent" />}
               {showLoadingOverlay && (
-                <div
-                  className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg z-10 gap-3"
-                  role="status"
-                  aria-busy="true"
-                  aria-label="Loading…"
-                >
-                  <span className="sr-only">Loading…</span>
-                  <Spinner size="2xl" className="text-status-info" />
+                <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg z-10 gap-3">
+                  {/* aria-busy on the status wrapper suppresses inner live regions,
+                      so the slow-load escalation announces via the sibling
+                      aria-live span below (SkeletonHint pattern). */}
+                  <div role="status" aria-busy="true" aria-label="Loading…">
+                    <span className="sr-only">Loading…</span>
+                    <Spinner size="2xl" className="text-status-info" />
+                  </div>
+                  <span className="sr-only" aria-live="polite" aria-atomic="true">
+                    {isSlowLoad
+                      ? "Loading is taking longer than usual. Select Cancel to stop."
+                      : ""}
+                  </span>
                   {isSlowLoad && (
                     <>
                       <p aria-hidden="true" className="text-xs text-daintree-text/50">

--- a/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
+++ b/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
@@ -456,6 +456,26 @@ describe("BrowserPane webview lifecycle regression", () => {
     expect(webview.stop).not.toHaveBeenCalled();
   });
 
+  it("exposes the loading overlay to screen readers via role=status (#9964)", () => {
+    const { container, getByRole } = render(<BrowserPane {...baseProps} />);
+    const webview = getWebviewElement(container);
+
+    act(() => {
+      webview.setMockLoading(true);
+      emitWebviewEvent(webview, "did-start-loading");
+    });
+
+    // The overlay is Doherty-gated — it only mounts after the 400ms threshold.
+    act(() => {
+      vi.advanceTimersByTime(401);
+    });
+
+    const status = getByRole("status");
+    expect(status.getAttribute("aria-busy")).toBe("true");
+    expect(status.getAttribute("aria-label")).toBe("Loading…");
+    expect(status.textContent).toContain("Loading…");
+  });
+
   describe("back/forward navigation guard (#9942)", () => {
     function getLoadingOverlay(container: HTMLElement): Element | null {
       return container.querySelector(".bg-daintree-bg.z-10");
@@ -1488,6 +1508,48 @@ describe("BrowserPane webview lifecycle regression", () => {
       expect(webview.reload).toHaveBeenCalledTimes(1);
       expect(container.textContent).toContain("Page process crashed");
       expect(container.textContent).toContain("Reason: oom (exit code 9)");
+    });
+
+    it("does not emit a durable notification on the first crash (#9964)", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitRenderProcessGone(webview, "crashed");
+      });
+
+      expect(notifyMock).not.toHaveBeenCalled();
+    });
+
+    it("emits a durable high-priority notification on the second crash within 60s (#9964)", () => {
+      // A crash loop in a background pane is otherwise silent — the in-flow
+      // banner is only visible when the pane is. Mirrors DevPreviewPane.
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitRenderProcessGone(webview, "crashed");
+      });
+      act(() => {
+        emitRenderProcessGone(webview, "oom", 9);
+      });
+
+      expect(notifyMock).toHaveBeenCalledTimes(1);
+      expect(notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "error",
+          title: "Page crashed repeatedly",
+          message: expect.stringContaining("oom"),
+          priority: "high",
+          duration: 0,
+          supersedeKey: "browser-pane-crash-loop:browser-panel-1",
+          correlationId: "browser-panel-1",
+          context: expect.objectContaining({
+            eventKind: "recovery",
+            panelId: "browser-panel-1",
+          }),
+        })
+      );
     });
 
     it("surfaces the banner on OS-pressure memory-eviction (no Daintree eviction in flight)", () => {

--- a/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
+++ b/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
@@ -476,6 +476,56 @@ describe("BrowserPane webview lifecycle regression", () => {
     expect(status.textContent).toContain("Loading…");
   });
 
+  it("announces the slow-load escalation via a polite live region (#9964)", () => {
+    // aria-busy on the status wrapper suppresses inner live regions, so the
+    // escalation must flow through the sibling aria-live span.
+    const { container } = render(<BrowserPane {...baseProps} />);
+    const webview = getWebviewElement(container);
+
+    act(() => {
+      webview.setMockLoading(true);
+      emitWebviewEvent(webview, "did-start-loading");
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(401);
+    });
+
+    const liveRegion = container.querySelector('[aria-live="polite"]');
+    expect(liveRegion).not.toBeNull();
+    expect(liveRegion?.textContent).toBe("");
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(liveRegion?.textContent).toContain("taking longer than usual");
+  });
+
+  it("removes the loading status region after did-stop-loading (#9964)", () => {
+    const { container, queryByRole } = render(<BrowserPane {...baseProps} />);
+    const webview = getWebviewElement(container);
+
+    act(() => {
+      webview.setMockLoading(true);
+      emitWebviewEvent(webview, "did-start-loading");
+    });
+    act(() => {
+      vi.advanceTimersByTime(401);
+    });
+    expect(queryByRole("status")).not.toBeNull();
+
+    act(() => {
+      webview.setMockLoading(false);
+      emitWebviewEvent(webview, "did-stop-loading");
+    });
+    act(() => {
+      vi.advanceTimersByTime(401);
+    });
+
+    expect(queryByRole("status")).toBeNull();
+  });
+
   describe("back/forward navigation guard (#9942)", () => {
     function getLoadingOverlay(container: HTMLElement): Element | null {
       return container.querySelector(".bg-daintree-bg.z-10");


### PR DESCRIPTION
## Summary

- The loading overlay in `BrowserPane.tsx` had no screen-reader support — no `role`, no live region, nothing. A screen-reader user would hear silence during a page load and miss the slow-load escalation entirely.
- A second crash within the 60s throttle window set `crashState="crashed"` and showed an in-pane banner, but fired no durable notification. A crash loop in a background pane was invisible.
- Both gaps now mirror the patterns already in `DevPreviewPane` / `DevPreviewLoadingState`.

Resolves #9964

## Changes

- **Loading overlay ARIA** (`BrowserPane.tsx`): wraps the spinner in `role="status"` / `aria-busy="true"` / `aria-label="Loading…"` with an `sr-only` caption, matching `DevPreviewLoadingState`. The visible slow-load caption gets `aria-hidden` to avoid double announcement.
- **Slow-load live region**: slow-load escalation announces via a sibling `sr-only` `aria-live="polite"` span. The `SkeletonHint` pattern — `aria-busy` on the status wrapper would suppress an inner live region, so the escalation gets its own sibling span.
- **Second-crash notify**: adds a high-priority `duration: 0` `notify()` with `supersedeKey: "browser-pane-crash-loop:${id}"` on the second crash within the throttle window, mirroring `DevPreviewPane`. First crash still auto-reloads silently.
- **Regression tests** (`BrowserPane.webview.test.tsx`): five new tests covering overlay ARIA attributes, live-region escalation, overlay teardown on load completion, first-crash silence, and second-crash notify payload.

## Testing

Full local CI passed (typecheck, lint, format, unit tests, build). The five new tests in `BrowserPane.webview.test.tsx` cover the specific failure modes from the issue.