### PR TITLE
fix(deferred-init): surface task failures via error infra and telemetry

### DIFF
--- a/electron/window/__tests__/deferredInitQueue.test.ts
+++ b/electron/window/__tests__/deferredInitQueue.test.ts
@@ -4,6 +4,14 @@ vi.mock("../../utils/performance.js", () => ({
   markPerformance: vi.fn(),
 }));
 
+vi.mock("../../ipc/errorHandlers.js", () => ({
+  notifyError: vi.fn(),
+}));
+
+vi.mock("../../services/TelemetryService.js", () => ({
+  trackEvent: vi.fn(),
+}));
+
 import {
   registerDeferredTask,
   finalizeDeferredRegistration,
@@ -11,10 +19,13 @@ import {
   getDeferredQueueState,
   resetDeferredQueue,
 } from "../deferredInitQueue.js";
+import { notifyError } from "../../ipc/errorHandlers.js";
+import { trackEvent } from "../../services/TelemetryService.js";
 
 describe("deferredInitQueue", () => {
   beforeEach(() => {
     resetDeferredQueue();
+    vi.clearAllMocks();
     vi.useFakeTimers();
   });
 
@@ -134,6 +145,29 @@ describe("deferredInitQueue", () => {
     expect(ran).toEqual(["ok"]);
     expect(consoleError).toHaveBeenCalled();
     consoleError.mockRestore();
+
+    // Both failures are surfaced through the shared error infrastructure and
+    // telemetry — not just swallowed into the console.
+    expect(notifyError).toHaveBeenCalledTimes(2);
+    for (const [error, options] of vi.mocked(notifyError).mock.calls) {
+      expect(error).toBeInstanceOf(Error);
+      expect(options).toEqual({ source: "deferred-init" });
+    }
+    const reportedMessages = vi
+      .mocked(notifyError)
+      .mock.calls.map(([error]) => (error as Error).message);
+    expect(reportedMessages).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("fail-sync"),
+        expect.stringContaining("fail-async"),
+      ])
+    );
+
+    expect(trackEvent).toHaveBeenCalledTimes(2);
+    expect(trackEvent).toHaveBeenCalledWith("deferred_init_task_failed", { taskName: "fail-sync" });
+    expect(trackEvent).toHaveBeenCalledWith("deferred_init_task_failed", {
+      taskName: "fail-async",
+    });
   });
 
   it("late registration after drain runs immediately", async () => {
@@ -150,6 +184,50 @@ describe("deferredInitQueue", () => {
     expect(late).toHaveBeenCalledTimes(1);
     expect(consoleWarn).toHaveBeenCalled();
     consoleWarn.mockRestore();
+
+    // A successful late task is not reported as a failure.
+    expect(notifyError).not.toHaveBeenCalled();
+    expect(trackEvent).not.toHaveBeenCalled();
+  });
+
+  it("reports late-registration failures through the error infrastructure", async () => {
+    const early = vi.fn();
+    registerDeferredTask({ name: "early", run: early });
+    finalizeDeferredRegistration(10_000);
+    signalFirstInteractive(1);
+    await waitForDrain();
+
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Late sync throw
+    registerDeferredTask({
+      name: "late-sync",
+      run: () => {
+        throw new Error("late-boom");
+      },
+    });
+
+    // Late async rejection
+    registerDeferredTask({
+      name: "late-async",
+      run: async () => {
+        throw new Error("late-async-boom");
+      },
+    });
+    await vi.advanceTimersByTimeAsync(1);
+
+    consoleWarn.mockRestore();
+    consoleError.mockRestore();
+
+    expect(notifyError).toHaveBeenCalledTimes(2);
+    for (const [, options] of vi.mocked(notifyError).mock.calls) {
+      expect(options).toEqual({ source: "deferred-init" });
+    }
+    expect(trackEvent).toHaveBeenCalledWith("deferred_init_task_failed", { taskName: "late-sync" });
+    expect(trackEvent).toHaveBeenCalledWith("deferred_init_task_failed", {
+      taskName: "late-async",
+    });
   });
 
   it("finalize is idempotent", async () => {

--- a/electron/window/__tests__/deferredInitQueue.test.ts
+++ b/electron/window/__tests__/deferredInitQueue.test.ts
@@ -170,6 +170,66 @@ describe("deferredInitQueue", () => {
     });
   });
 
+  it("queue still advances when failure reporting itself throws", async () => {
+    const ran: string[] = [];
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    // Simulate a store-write / serialization failure inside notifyError.
+    // mockImplementationOnce auto-reverts so it can't leak into later tests.
+    vi.mocked(notifyError).mockImplementationOnce(() => {
+      throw new Error("reporting backend exploded");
+    });
+
+    registerDeferredTask({
+      name: "fail-sync",
+      run: () => {
+        throw new Error("boom");
+      },
+    });
+    registerDeferredTask({ name: "ok", run: () => void ran.push("ok") });
+
+    finalizeDeferredRegistration(10_000);
+    signalFirstInteractive(null);
+    await waitForDrain();
+
+    // The reporter threw, but failure isolation held: the next task ran and the
+    // queue reached "drained" instead of stalling in "draining".
+    expect(ran).toEqual(["ok"]);
+    expect(getDeferredQueueState().drainState).toBe("drained");
+    consoleError.mockRestore();
+  });
+
+  it("reports non-Error thrown values without secondary failure", async () => {
+    const ran: string[] = [];
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    registerDeferredTask({
+      name: "throws-string",
+      run: () => {
+        throw "plain string failure";
+      },
+    });
+    registerDeferredTask({
+      name: "throws-null",
+      run: () => {
+        throw null;
+      },
+    });
+    registerDeferredTask({ name: "ok", run: () => void ran.push("ok") });
+
+    finalizeDeferredRegistration(10_000);
+    signalFirstInteractive(null);
+    await waitForDrain();
+
+    expect(ran).toEqual(["ok"]);
+    expect(getDeferredQueueState().drainState).toBe("drained");
+    expect(notifyError).toHaveBeenCalledTimes(2);
+    // Each reported error is a real Error with the original value preserved on cause.
+    for (const [error] of vi.mocked(notifyError).mock.calls) {
+      expect(error).toBeInstanceOf(Error);
+    }
+    consoleError.mockRestore();
+  });
+
   it("late registration after drain runs immediately", async () => {
     const early = vi.fn();
     registerDeferredTask({ name: "early", run: early });

--- a/electron/window/deferredInitQueue.ts
+++ b/electron/window/deferredInitQueue.ts
@@ -124,12 +124,21 @@ export function resetDeferredQueue(): void {
  * failure-isolation guarantee: the caller still advances to the next task.
  */
 function reportDeferredTaskFailure(taskName: string, err: unknown): void {
-  const message = err instanceof Error ? err.message : String(err);
-  console.error(`[DeferredInit] Task "${taskName}" failed:`, err);
-  notifyError(new Error(`Deferred task "${taskName}" failed: ${message}`, { cause: err }), {
-    source: "deferred-init",
-  });
-  trackEvent("deferred_init_task_failed", { taskName });
+  // Reporting is best-effort and must never throw: the synchronous drain catch
+  // calls this immediately before `scheduleNext()`, so a throw here would strand
+  // the queue in "draining" forever. Guard the whole body — a non-Error thrown
+  // value (`String(err)`) or a store-write failure inside `notifyError` must not
+  // break failure isolation.
+  try {
+    const message = err instanceof Error ? err.message : String(err ?? "unknown error");
+    console.error(`[DeferredInit] Task "${taskName}" failed:`, err);
+    notifyError(new Error(`Deferred task "${taskName}" failed: ${message}`, { cause: err }), {
+      source: "deferred-init",
+    });
+    trackEvent("deferred_init_task_failed", { taskName });
+  } catch (reportErr) {
+    console.error(`[DeferredInit] Failed to report failure for task "${taskName}":`, reportErr);
+  }
 }
 
 function doDrain(): void {

--- a/electron/window/deferredInitQueue.ts
+++ b/electron/window/deferredInitQueue.ts
@@ -1,5 +1,7 @@
 import { markPerformance } from "../utils/performance.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
+import { notifyError } from "../ipc/errorHandlers.js";
+import { trackEvent } from "../services/TelemetryService.js";
 
 export type DeferredTask = {
   name: string;
@@ -31,10 +33,10 @@ export function registerDeferredTask(task: DeferredTask): void {
     try {
       const res = task.run();
       if (res instanceof Promise) {
-        res.catch((err) => console.error(`[DeferredInit] Late task "${task.name}" failed:`, err));
+        res.catch((err) => reportDeferredTaskFailure(task.name, err));
       }
     } catch (err) {
-      console.error(`[DeferredInit] Late task "${task.name}" threw:`, err);
+      reportDeferredTaskFailure(task.name, err);
     }
     return;
   }
@@ -112,6 +114,24 @@ export function resetDeferredQueue(): void {
   drainedSenderIds.clear();
 }
 
+/**
+ * Surface a deferred-init task failure beyond the console. These failures are
+ * otherwise invisible — a background service is silently absent for the rest of
+ * the session — so route them through the shared error infrastructure
+ * (persisted `ErrorRecord` + renderer broadcast) and telemetry. Both
+ * `notifyError` and `trackEvent` are safe to call here (no throw, no-op before
+ * their respective services initialize), and neither alters the queue's
+ * failure-isolation guarantee: the caller still advances to the next task.
+ */
+function reportDeferredTaskFailure(taskName: string, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`[DeferredInit] Task "${taskName}" failed:`, err);
+  notifyError(new Error(`Deferred task "${taskName}" failed: ${message}`, { cause: err }), {
+    source: "deferred-init",
+  });
+  trackEvent("deferred_init_task_failed", { taskName });
+}
+
 function doDrain(): void {
   if (drainState !== "idle") return;
   drainState = "draining";
@@ -148,14 +168,14 @@ function drainNext(index: number, startedAt: number, drainGen: number): void {
     if (result instanceof Promise) {
       result
         .catch((err) => {
-          console.error(`[DeferredInit] Task "${task.name}" failed:`, err);
+          reportDeferredTaskFailure(task.name, err);
         })
         .finally(scheduleNext);
     } else {
       scheduleNext();
     }
   } catch (err) {
-    console.error(`[DeferredInit] Task "${task.name}" threw:`, err);
+    reportDeferredTaskFailure(task.name, err);
     scheduleNext();
   }
 }

--- a/electron/window/deferredInitQueue.ts
+++ b/electron/window/deferredInitQueue.ts
@@ -2,6 +2,7 @@ import { markPerformance } from "../utils/performance.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { notifyError } from "../ipc/errorHandlers.js";
 import { trackEvent } from "../services/TelemetryService.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 export type DeferredTask = {
   name: string;
@@ -130,7 +131,7 @@ function reportDeferredTaskFailure(taskName: string, err: unknown): void {
   // value (`String(err)`) or a store-write failure inside `notifyError` must not
   // break failure isolation.
   try {
-    const message = err instanceof Error ? err.message : String(err ?? "unknown error");
+    const message = formatErrorMessage(err, "unknown error");
     console.error(`[DeferredInit] Task "${taskName}" failed:`, err);
     notifyError(new Error(`Deferred task "${taskName}" failed: ${message}`, { cause: err }), {
       source: "deferred-init",


### PR DESCRIPTION
## Summary

- Deferred-init task failures were only reaching `console.error` — invisible to telemetry, the renderer error surface, and Sentry. This routes all four catch sites in `deferredInitQueue.ts` through the existing `notifyError()` + `trackEvent()` infrastructure.
- A guarded best-effort reporter helper wraps each report so a secondary throw inside the reporter can't interrupt the drain — failure isolation is preserved.
- Tests extended to cover failure reporting behaviour; 14 tests pass.

Resolves #9885

## Changes

- `electron/window/deferredInitQueue.ts`: added `reportTaskFailure()` helper and wired it into all four catch/swallow sites (async rejection, sync throw, late-registration async, late-registration sync)
- `electron/window/__tests__/deferredInitQueue.test.ts`: new tests for `notifyError` and `trackEvent` calls on task failure, guard behaviour when the reporter throws, and isolation guarantees

## Testing

Full unit suite via `npm run check` — all 14 `deferredInitQueue` tests pass, no regressions in adjacent tests.