### PR TITLE
fix(ci): correct E2E classifier rule order and crash-string matching

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -647,23 +647,27 @@ jobs:
 
       # Classification regex table — keep in sync with CLASSIFICATION_RULES in
       # scripts/ci/classify-e2e-failures.mjs. Rules are ordered; the first match
-      # wins. Specific patterns (spawn EPERM) must precede broad ones (bare
-      # EPERM) so the more actionable bucket is chosen.
+      # wins. Product-Logic (crashes) precedes Test-Logic (stale refs / timing)
+      # so a crash outranks the stale-ref noise it drags along, and specific
+      # patterns (spawn EPERM) precede broad ones (bare EPERM).
       #
       # Infrastructure (OS / CI runner resource contention):
       #   spawn EPERM           -> AV on-access scan
       #   EBUSY on .tmp paths   -> indexer contention
       #   EPERM / EACCES / ENOSPC -> permission / disk
+      #   worker process exited unexpectedly -> Playwright worker death
+      #
+      # Product-Logic (renderer crashes, actual bugs):
+      #   Page crashed / Navigation failed because page crashed / Target crashed
+      #                                                       -> Playwright crash surface
+      #   WebContents crashed / renderer process crash        -> renderer (Electron-internal)
+      #   GPU process crash / utility process crash           -> GPU/utility
       #
       # Test-Logic (handshake / timing / stale references):
       #   CDP target not found / Target.targetCreated timeout -> handshake
       #   Target/Browser/Page has been closed                -> stale ref
       #   Protocol error (Target.closeTarget)                -> target close
       #   Selector timeout / Test timeout                     -> timing
-      #
-      # Product-Logic (renderer crashes, actual bugs):
-      #   WebContents crashed / renderer process crash        -> renderer
-      #   GPU process crash / utility process crash           -> GPU/utility
       #
       # Unmatched errors land in Unclassified.
       # Reads the same `test-results/report.json` that the retry-path and

--- a/scripts/ci/classify-e2e-failures.mjs
+++ b/scripts/ci/classify-e2e-failures.mjs
@@ -41,12 +41,12 @@ const CLASSIFICATION_RULES = [
   // Strings Playwright 1.x actually surfaces in error.message on a renderer
   // crash (playwright-core coreBundle.js: _didCrash openScope close, navigation
   // waiter, protocol "crashed" error type):
-  { regex: /Page crashed/i, bucket: "Product-Logic", label: "Page crashed" },
   {
     regex: /Navigation failed because page crashed/i,
     bucket: "Product-Logic",
     label: "Navigation failed (page crashed)",
   },
+  { regex: /Page crashed/i, bucket: "Product-Logic", label: "Page crashed" },
   { regex: /Target crashed/i, bucket: "Product-Logic", label: "Target crashed" },
   // Electron-internal phrasings, kept as secondary catches for errors that
   // reach the report via IPC/main-process paths rather than Playwright:

--- a/scripts/ci/classify-e2e-failures.mjs
+++ b/scripts/ci/classify-e2e-failures.mjs
@@ -17,7 +17,9 @@ import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
-// Ordered from most-specific to least-specific. The first matching rule wins.
+// Ordered by priority as well as specificity. The first matching rule wins,
+// so Product-Logic (crashes) precedes Test-Logic (stale refs / timing) —
+// a crash is more actionable than the stale-ref noise it often drags along.
 // Specific patterns (e.g. "spawn EPERM") must precede broad ones (e.g. bare
 // "EPERM") so the more actionable bucket is chosen.
 const CLASSIFICATION_RULES = [
@@ -27,6 +29,32 @@ const CLASSIFICATION_RULES = [
   { regex: /EPERM[:,\s]/i, bucket: "Infrastructure", label: "EPERM (permission denied)" },
   { regex: /EACCES[:,\s]/i, bucket: "Infrastructure", label: "EACCES (permission denied)" },
   { regex: /ENOSPC/i, bucket: "Infrastructure", label: "ENOSPC (disk full)" },
+  // Playwright worker process death (runner/index.js _failTestWithErrors) —
+  // runner-level, carries no app-specific signal.
+  {
+    regex: /worker process exited unexpectedly/i,
+    bucket: "Infrastructure",
+    label: "Playwright worker exited (runner-level)",
+  },
+
+  // --- Product-Logic (renderer crashes, actual bugs) ---
+  // Strings Playwright 1.x actually surfaces in error.message on a renderer
+  // crash (playwright-core coreBundle.js: _didCrash openScope close, navigation
+  // waiter, protocol "crashed" error type):
+  { regex: /Page crashed/i, bucket: "Product-Logic", label: "Page crashed" },
+  {
+    regex: /Navigation failed because page crashed/i,
+    bucket: "Product-Logic",
+    label: "Navigation failed (page crashed)",
+  },
+  { regex: /Target crashed/i, bucket: "Product-Logic", label: "Target crashed" },
+  // Electron-internal phrasings, kept as secondary catches for errors that
+  // reach the report via IPC/main-process paths rather than Playwright:
+  { regex: /WebContents crashed/i, bucket: "Product-Logic", label: "WebContents crashed" },
+  { regex: /renderer process.*crashed/i, bucket: "Product-Logic", label: "Renderer process crash" },
+  { regex: /renderer.*killed/i, bucket: "Product-Logic", label: "Renderer killed" },
+  { regex: /GPU process.*crash/i, bucket: "Product-Logic", label: "GPU process crash" },
+  { regex: /utility process.*crash/i, bucket: "Product-Logic", label: "Utility process crash" },
 
   // --- Test-Logic (handshake / timing / stale references) ---
   {
@@ -49,13 +77,6 @@ const CLASSIFICATION_RULES = [
   },
   { regex: /waiting for selector.*timed out/i, bucket: "Test-Logic", label: "Selector timeout" },
   { regex: /Test timeout of \d+ms exceeded/i, bucket: "Test-Logic", label: "Test timeout" },
-
-  // --- Product-Logic (renderer crashes, actual bugs) ---
-  { regex: /WebContents crashed/i, bucket: "Product-Logic", label: "WebContents crashed" },
-  { regex: /renderer process.*crashed/i, bucket: "Product-Logic", label: "Renderer process crash" },
-  { regex: /renderer.*killed/i, bucket: "Product-Logic", label: "Renderer killed" },
-  { regex: /GPU process.*crash/i, bucket: "Product-Logic", label: "GPU process crash" },
-  { regex: /utility process.*crash/i, bucket: "Product-Logic", label: "Utility process crash" },
 ];
 
 /**
@@ -95,7 +116,12 @@ export function extractFailures(report) {
           const pName = test.projectName ?? projectName;
           if (!test.results) continue;
           for (const result of test.results) {
-            if (result.status !== "failed" && result.status !== "timedOut") continue;
+            if (
+              result.status !== "failed" &&
+              result.status !== "timedOut" &&
+              result.status !== "interrupted"
+            )
+              continue;
             const error = result.error;
             const errorText = error
               ? [error.message, error.stack].filter(Boolean).join("\n")

--- a/scripts/ci/classify-e2e-failures.test.mjs
+++ b/scripts/ci/classify-e2e-failures.test.mjs
@@ -121,6 +121,13 @@ describe("classifyError", () => {
     expect(result.bucket).toBe("Product-Logic");
   });
 
+  it("matches the navigation-crash rule before the broader Page crashed rule", () => {
+    // "Navigation failed because page crashed!" contains "page crashed" as a
+    // substring — the more-specific rule must win or it is unreachable.
+    const result = classifyError("Navigation failed because page crashed!");
+    expect(result.label).toContain("Navigation");
+  });
+
   it("classifies Target crashed as Product-Logic", () => {
     const result = classifyError("locator.click: Target crashed");
     expect(result.bucket).toBe("Product-Logic");
@@ -132,6 +139,16 @@ describe("classifyError", () => {
     expect(result.bucket).toBe("Product-Logic");
   });
 
+  it("routes Target crashed to Product-Logic even with Target stale-ref text present", () => {
+    const result = classifyError("Target crashed\nTarget has been closed");
+    expect(result.bucket).toBe("Product-Logic");
+  });
+
+  it("classifies a crash string present only in the stack as Product-Logic", () => {
+    const result = classifyError("\nError: Page crashed\n    at ChromiumPage._didCrash");
+    expect(result.bucket).toBe("Product-Logic");
+  });
+
   it("keeps plain 'Page has been closed.' in Test-Logic (not a crash)", () => {
     const result = classifyError("Page has been closed.");
     expect(result.bucket).toBe("Test-Logic");
@@ -139,6 +156,13 @@ describe("classifyError", () => {
 
   it("classifies Playwright worker death as Infrastructure", () => {
     const result = classifyError("Error: worker process exited unexpectedly (code=1, signal=null)");
+    expect(result.bucket).toBe("Infrastructure");
+  });
+
+  it("keeps worker death as Infrastructure even when a crash string follows", () => {
+    // Design decision: a dead worker carries no app-specific signal, so the
+    // runner-level bucket wins over any crash text in the same message.
+    const result = classifyError("worker process exited unexpectedly (code=139)\nPage crashed");
     expect(result.bucket).toBe("Infrastructure");
   });
 });

--- a/scripts/ci/classify-e2e-failures.test.mjs
+++ b/scripts/ci/classify-e2e-failures.test.mjs
@@ -110,6 +110,37 @@ describe("classifyError", () => {
     expect(result.bucket).toBe("Infrastructure");
     expect(result.label).toContain("indexer contention");
   });
+
+  it("classifies Playwright 'Page crashed' as Product-Logic", () => {
+    const result = classifyError("page.goto: Page crashed");
+    expect(result.bucket).toBe("Product-Logic");
+  });
+
+  it("classifies navigation crash as Product-Logic", () => {
+    const result = classifyError("Navigation failed because page crashed!");
+    expect(result.bucket).toBe("Product-Logic");
+  });
+
+  it("classifies Target crashed as Product-Logic", () => {
+    const result = classifyError("locator.click: Target crashed");
+    expect(result.bucket).toBe("Product-Logic");
+  });
+
+  it("routes a crash to Product-Logic even when stale-ref text is also present", () => {
+    // A crash often drags stale-ref noise along; the crash must win.
+    const result = classifyError("page.goto: Page crashed\npage has been closed");
+    expect(result.bucket).toBe("Product-Logic");
+  });
+
+  it("keeps plain 'Page has been closed.' in Test-Logic (not a crash)", () => {
+    const result = classifyError("Page has been closed.");
+    expect(result.bucket).toBe("Test-Logic");
+  });
+
+  it("classifies Playwright worker death as Infrastructure", () => {
+    const result = classifyError("Error: worker process exited unexpectedly (code=1, signal=null)");
+    expect(result.bucket).toBe("Infrastructure");
+  });
 });
 
 describe("extractFailures", () => {
@@ -316,6 +347,57 @@ describe("extractFailures", () => {
     const failures = extractFailures(report);
     expect(failures).toHaveLength(1);
     expect(failures[0].bucket).toBe("Product-Logic");
+  });
+
+  it("includes interrupted results with an error", () => {
+    const report = {
+      suites: [
+        {
+          specs: [
+            {
+              title: "crashed mid-run",
+              tests: [
+                {
+                  projectName: "core",
+                  results: [
+                    {
+                      status: "interrupted",
+                      error: { message: "page.goto: Page crashed" },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const failures = extractFailures(report);
+    expect(failures).toHaveLength(1);
+    expect(failures[0].bucket).toBe("Product-Logic");
+  });
+
+  it("includes interrupted results without an error as Unclassified", () => {
+    const report = {
+      suites: [
+        {
+          specs: [
+            {
+              title: "cancelled test",
+              tests: [
+                {
+                  projectName: "core",
+                  results: [{ status: "interrupted" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const failures = extractFailures(report);
+    expect(failures).toHaveLength(1);
+    expect(failures[0].bucket).toBe("Unclassified");
   });
 
   it("handles multiple errors in result.errors array", () => {


### PR DESCRIPTION
## Summary

- `CLASSIFICATION_RULES` was severity-inverted (Infrastructure → Test-Logic → Product-Logic), so the first-match-wins scan promoted benign harness noise above real crashes
- The existing Product-Logic crash regexes matched Electron-internal strings that Playwright never surfaces; the strings Playwright actually puts on `error.message` (`"Page crashed"`, `"Navigation failed because page crashed!"`) matched nothing or fell to the wrong bucket
- Results with status `interrupted` were skipped before classification, so the hardest crash class was invisible to the breakdown

Resolves #10037

## Changes

- Reordered `CLASSIFICATION_RULES` to Infrastructure → Product-Logic → Test-Logic
- Added Product-Logic rules for `/Navigation failed because page crashed/i`, `/Page crashed/i`, and `/Target crashed/i` — strings sourced from `playwright-core/coreBundle.js`
- Added Infrastructure rule for `/worker process exited unexpectedly/i` (Playwright runner `_failTestWithErrors` path)
- Added `"interrupted"` to the `extractFailures` status guard
- Synced the regex-table comment in `.github/workflows/e2e.yml`
- 12 new behavioural tests; 43 total

## Notes

- `"Page has been closed."` intentionally stays Test-Logic — it signals a stale page reference in test teardown, not a product crash
- Worker-process death is Infrastructure by design: the runner message carries no app-specific signal
- An `interrupted` result with no error message lands in Unclassified intentionally

## Testing

Ran `scripts/ci/classify-e2e-failures.test.mjs` (43/43 pass). Static checks, lint, and typecheck all clean.