### PR TITLE
fix(panels): flush layout persistence on visibilitychange, not beforeunload

### DIFF
--- a/src/store/__tests__/rendererStoreOrchestrator.visibility.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.visibility.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Replace the MRU debounce with a stub whose `flush`/`cancel` are spies, so the
+// "flush on hide" wiring (#9914) can be asserted directly without depending on
+// the 150ms timer or the focus-subscription chain.
+const flushSpy = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const cancelSpy = vi.hoisted(() => vi.fn());
+vi.mock("@/utils/debounce", () => ({
+  debounce: () => {
+    const fn = vi.fn() as unknown as {
+      (...args: unknown[]): void;
+      flush: typeof flushSpy;
+      cancel: typeof cancelSpy;
+    };
+    fn.flush = flushSpy;
+    fn.cancel = cancelSpy;
+    return fn;
+  },
+}));
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn().mockResolvedValue(undefined),
+    trash: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+  },
+  appClient: { setState: vi.fn().mockResolvedValue(undefined) },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+    setTabGroups: vi.fn().mockResolvedValue(undefined),
+  },
+  agentSettingsClient: {
+    get: vi.fn().mockResolvedValue({ agents: {} }),
+    set: vi.fn(),
+    reset: vi.fn(),
+    stampVersion: vi.fn(),
+  },
+  cliAvailabilityClient: { refresh: vi.fn() },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    cleanup: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
+    destroy: vi.fn(),
+    setInputLocked: vi.fn(),
+    wake: vi.fn(),
+  },
+}));
+
+vi.mock("../../persistence/panelPersistence", () => ({
+  panelPersistence: {
+    setProjectIdGetter: vi.fn(),
+    save: vi.fn(),
+    saveTabGroups: vi.fn(),
+    load: vi.fn().mockReturnValue([]),
+  },
+}));
+
+vi.mock("@/services/SemanticAnalysisService", () => ({
+  semanticAnalysisService: { unregisterTerminal: vi.fn() },
+}));
+
+const { initStoreOrchestrator, destroyStoreOrchestrator } =
+  await import("../rendererStoreOrchestrator");
+
+function setHidden(hidden: boolean): void {
+  Object.defineProperty(document, "hidden", { configurable: true, value: hidden });
+}
+
+describe("rendererStoreOrchestrator — MRU flush on hide (#9914)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    destroyStoreOrchestrator();
+    initStoreOrchestrator();
+  });
+
+  afterEach(() => {
+    destroyStoreOrchestrator();
+    setHidden(false);
+  });
+
+  it("flushes the MRU debounce when the document becomes hidden", () => {
+    setHidden(true);
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not flush while the document is still visible", () => {
+    setHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(flushSpy).not.toHaveBeenCalled();
+  });
+
+  it("removes the visibilitychange listener on destroy — no flush after teardown", () => {
+    destroyStoreOrchestrator();
+
+    setHidden(true);
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(flushSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/__tests__/rendererStoreOrchestrator.visibility.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.visibility.test.ts
@@ -111,4 +111,13 @@ describe("rendererStoreOrchestrator — MRU flush on hide (#9914)", () => {
 
     expect(flushSpy).not.toHaveBeenCalled();
   });
+
+  it("flushes immediately when the document is already hidden at init", () => {
+    // beforeEach init'd while visible; re-init with the document already hidden.
+    destroyStoreOrchestrator();
+    setHidden(true);
+    initStoreOrchestrator();
+
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/store/listeners/panel/__tests__/resource.test.ts
+++ b/src/store/listeners/panel/__tests__/resource.test.ts
@@ -71,12 +71,23 @@ describe("setupResourceListeners — persistence flush on hide (#9914)", () => {
     expect(flushPanelPersistenceMock).not.toHaveBeenCalled();
   });
 
-  it("does not register a beforeunload handler (the unreliable signal it replaced)", () => {
-    const addSpy = vi.spyOn(window, "addEventListener");
+  it("flushes immediately when the document is already hidden at registration", () => {
+    setHidden(true);
     const d = setupResourceListeners();
 
-    expect(addSpy.mock.calls.some(([type]) => type === "beforeunload")).toBe(false);
+    expect(flushPanelPersistenceMock).toHaveBeenCalledTimes(1);
     d.dispose();
-    addSpy.mockRestore();
+  });
+
+  it("does not register a beforeunload handler (the unreliable signal it replaced)", () => {
+    const windowSpy = vi.spyOn(window, "addEventListener");
+    const documentSpy = vi.spyOn(document, "addEventListener");
+    const d = setupResourceListeners();
+
+    expect(windowSpy.mock.calls.some(([type]) => type === "beforeunload")).toBe(false);
+    expect(documentSpy.mock.calls.some(([type]) => type === "beforeunload")).toBe(false);
+    d.dispose();
+    windowSpy.mockRestore();
+    documentSpy.mockRestore();
   });
 });

--- a/src/store/listeners/panel/__tests__/resource.test.ts
+++ b/src/store/listeners/panel/__tests__/resource.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const flushPanelPersistenceMock = vi.hoisted(() => vi.fn());
+vi.mock("@/store/slices", () => ({
+  flushPanelPersistence: flushPanelPersistenceMock,
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    reduceScrollbackAllBackground: vi.fn(),
+    accelerateHibernation: vi.fn(),
+  },
+}));
+
+vi.mock("@/store/resourceMonitoringStore", () => ({
+  useResourceMonitoringStore: {
+    getState: () => ({ enabled: false, updateMetrics: vi.fn() }),
+  },
+}));
+
+const { setupResourceListeners } = await import("../resource");
+
+function setHidden(hidden: boolean): void {
+  Object.defineProperty(document, "hidden", { configurable: true, value: hidden });
+}
+
+describe("setupResourceListeners — persistence flush on hide (#9914)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (globalThis as unknown as { window: Window }).window.electron = {
+      terminal: {
+        onResourceMetrics: vi.fn(() => () => {}),
+        onReclaimMemory: vi.fn(() => () => {}),
+        onAccelerateHibernation: vi.fn(() => () => {}),
+      },
+    } as unknown as Window["electron"];
+  });
+
+  afterEach(() => {
+    setHidden(false);
+  });
+
+  it("flushes panel persistence when the document becomes hidden", () => {
+    const d = setupResourceListeners();
+
+    setHidden(true);
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(flushPanelPersistenceMock).toHaveBeenCalledTimes(1);
+    d.dispose();
+  });
+
+  it("does not flush while the document is still visible", () => {
+    const d = setupResourceListeners();
+
+    setHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(flushPanelPersistenceMock).not.toHaveBeenCalled();
+    d.dispose();
+  });
+
+  it("removes the listener on dispose — no flush after teardown", () => {
+    const d = setupResourceListeners();
+    d.dispose();
+
+    setHidden(true);
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(flushPanelPersistenceMock).not.toHaveBeenCalled();
+  });
+
+  it("does not register a beforeunload handler (the unreliable signal it replaced)", () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const d = setupResourceListeners();
+
+    expect(addSpy.mock.calls.some(([type]) => type === "beforeunload")).toBe(false);
+    d.dispose();
+    addSpy.mockRestore();
+  });
+});

--- a/src/store/listeners/panel/resource.ts
+++ b/src/store/listeners/panel/resource.ts
@@ -41,12 +41,20 @@ export function setupResourceListeners(): DisposableStore {
     )
   );
 
-  // Flush pending terminal persistence on window close to prevent data loss
-  const beforeUnloadHandler = () => {
+  // Flush pending terminal persistence before the view is torn down to
+  // prevent data loss. `beforeunload` does NOT fire on WebContentsView detach
+  // (project switch, window close, app quit) in Electron — `visibilitychange`
+  // is the reliable signal, firing on detach while the renderer is still alive
+  // and IPC channels are open, so the async flush completes (#9914). Matches
+  // the pattern documented in `useFlushOnHide`.
+  const handleVisibilityChange = () => {
+    if (!document.hidden) return;
     flushPanelPersistence();
   };
-  window.addEventListener("beforeunload", beforeUnloadHandler);
-  d.add(toDisposable(() => window.removeEventListener("beforeunload", beforeUnloadHandler)));
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+  d.add(
+    toDisposable(() => document.removeEventListener("visibilitychange", handleVisibilityChange))
+  );
 
   return d;
 }

--- a/src/store/listeners/panel/resource.ts
+++ b/src/store/listeners/panel/resource.ts
@@ -55,6 +55,9 @@ export function setupResourceListeners(): DisposableStore {
   d.add(
     toDisposable(() => document.removeEventListener("visibilitychange", handleVisibilityChange))
   );
+  // Cover the race where the document is already hidden when listeners
+  // register (e.g. a fast project switch between render and this effect).
+  if (document.hidden) flushPanelPersistence();
 
   return d;
 }

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -314,6 +314,25 @@ export function initStoreOrchestrator(): () => void {
     )
   );
 
+  // 7. Flush the MRU debounce before the view is torn down. The 150ms debounce
+  //    above strands the latest MRU write if the user switches projects, closes
+  //    the window, or quits within the debounce window. `visibilitychange`
+  //    fires on WebContentsView detach while the renderer is still alive and
+  //    IPC channels are open, so the async persist completes (#9914). Mirrors
+  //    the `pagehide` flush in `optimisticPanelClose.ts`, but uses
+  //    `visibilitychange` because `persistMruList` is async IPC, which would
+  //    not complete in the late `pagehide` teardown window.
+  if (typeof document !== "undefined") {
+    const handleVisibilityChange = () => {
+      if (!document.hidden) return;
+      void debouncedPersistMruList.flush();
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    disposables.add(
+      toDisposable(() => document.removeEventListener("visibilitychange", handleVisibilityChange))
+    );
+  }
+
   cleanupFn = () => {
     disposables.dispose();
     cleanupFn = null;

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -331,6 +331,8 @@ export function initStoreOrchestrator(): () => void {
     disposables.add(
       toDisposable(() => document.removeEventListener("visibilitychange", handleVisibilityChange))
     );
+    // Cover the race where the document is already hidden at init time.
+    if (document.hidden) void debouncedPersistMruList.flush();
   }
 
   cleanupFn = () => {


### PR DESCRIPTION
## Summary

- `beforeunload` doesn't fire on `WebContentsView` detach in Electron 42 / Chromium 148, so panel layout changes and the MRU debounce write were silently dropped on project switch, window close, and app quit.
- Replaced the `beforeunload` handler in `src/store/listeners/panel/resource.ts` with a `visibilitychange` listener that calls `flushPanelPersistence()` when `document.hidden` becomes true. Added a matching flush for the 150ms MRU debounce in `initStoreOrchestrator()`. Both match the validated pattern already in `useFlushOnHide.ts` and `SettingsDialog`.

Resolves #9914

## Changes

- `src/store/listeners/panel/resource.ts` — swap `beforeunload` for `visibilitychange`; flush immediately if already hidden at registration time.
- `src/store/rendererStoreOrchestrator.ts` — add `visibilitychange` flush for the MRU debounce.
- `src/store/listeners/panel/__tests__/resource.test.ts` — new tests for the resource listener flush paths.
- `src/store/__tests__/rendererStoreOrchestrator.visibility.test.ts` — new tests for the orchestrator flush paths.

## Testing

9 new jsdom tests covering both flush paths (hidden-at-registration edge case, normal hide event, cleanup on unsubscribe). All existing tests pass.