### PR TITLE
fix(demo): natural cursor velocity — accelerate short moves, add overshoot on long moves

### DIFF
--- a/src/components/Demo/DemoCursor.tsx
+++ b/src/components/Demo/DemoCursor.tsx
@@ -273,12 +273,19 @@ export function DemoCursor() {
         posRef.current = { x: targetX, y: targetY };
 
         if (shouldOvershoot(dist)) {
+          // The overshoot is purely cosmetic — the logical move already landed on the real
+          // target above. If the animation is aborted mid-flight, swallow it so a cosmetic
+          // failure never poisons the command result.
           const overshootAnim = el.animate(computeOvershootKeyframes(dx, dy, dist), {
             duration: OVERSHOOT_DURATION_MS,
             easing: "ease-in-out",
             fill: "forwards",
           });
-          await overshootAnim.finished;
+          try {
+            await overshootAnim.finished;
+          } catch {
+            // animation cancelled — position is already committed, nothing to recover
+          }
           el.style.transform = "";
           overshootAnim.cancel();
         }

--- a/src/components/Demo/DemoCursor.tsx
+++ b/src/components/Demo/DemoCursor.tsx
@@ -21,6 +21,23 @@ const FITTS_B = 200;
 const FITTS_DEFAULT_W = 40;
 const TWO_PHASE_THRESHOLD = 300;
 
+// Short moves accelerate from rest with a bell-shaped velocity profile (ease-in-out),
+// matching the ballistic ease-in start the long-move path already uses.
+const SHORT_MOVE_EASING = "cubic-bezier(0.25, 0, 0.65, 1)";
+
+// Occasional subtle overshoot-and-correct on larger moves (Fitts's Law naturalism).
+// Probability scales with distance; magnitude stays small so the cursor never drifts
+// far enough to hover the wrong target. Purely cosmetic — left/top are committed to the
+// real target before the overshoot runs, so posRef stays accurate for click dispatch.
+const OVERSHOOT_FAR_THRESHOLD = 600;
+const OVERSHOOT_PROB_MID = 0.15;
+const OVERSHOOT_PROB_FAR = 0.2;
+const OVERSHOOT_DURATION_MS = 180;
+const OVERSHOOT_DISTANCE_FRACTION = 0.1;
+const OVERSHOOT_MAG_CAP = 20;
+const OVERSHOOT_PERP_FRACTION = 0.2;
+const OVERSHOOT_PEAK_OFFSET = 0.88;
+
 function getDemoApi() {
   return window.electron.demo!;
 }
@@ -112,6 +129,35 @@ function computeBezierKeyframes(
     frames.push({ transform: `translate(${x}px, ${y}px)` });
   }
   return frames;
+}
+
+function shouldOvershoot(dist: number): boolean {
+  if (dist <= TWO_PHASE_THRESHOLD) return false;
+  const prob = dist >= OVERSHOOT_FAR_THRESHOLD ? OVERSHOOT_PROB_FAR : OVERSHOOT_PROB_MID;
+  return Math.random() < prob;
+}
+
+function computeOvershootKeyframes(
+  dx: number,
+  dy: number,
+  dist: number
+): Array<{ transform: string; offset: number }> {
+  const dirX = dist > 0 ? dx / dist : 0;
+  const dirY = dist > 0 ? dy / dist : 0;
+  const perpX = -dirY;
+  const perpY = dirX;
+
+  const magnitude = Math.min(dist * OVERSHOOT_DISTANCE_FRACTION, OVERSHOOT_MAG_CAP);
+  const perpMag = magnitude * OVERSHOOT_PERP_FRACTION * (Math.random() > 0.5 ? 1 : -1);
+
+  const peakX = dirX * magnitude + perpX * perpMag;
+  const peakY = dirY * magnitude + perpY * perpMag;
+
+  return [
+    { transform: "translate(0px, 0px)", offset: 0 },
+    { transform: `translate(${peakX}px, ${peakY}px)`, offset: OVERSHOOT_PEAK_OFFSET },
+    { transform: "translate(0px, 0px)", offset: 1 },
+  ];
 }
 
 export function DemoCursor() {
@@ -221,19 +267,35 @@ export function DemoCursor() {
         el.style.top = `${targetY}px`;
         el.style.transform = "";
         acquisitionAnim.cancel();
-      } else {
-        const keyframes = computeBezierKeyframes(fromX, fromY, targetX, targetY, steps, seed);
-        const anim = el.animate(keyframes, {
-          duration: totalDuration,
-          easing: "ease-out",
-          fill: "forwards",
-        });
-        await anim.finished;
-        el.style.left = `${targetX}px`;
-        el.style.top = `${targetY}px`;
-        el.style.transform = "";
-        anim.cancel();
+
+        // Real target is committed; posRef is accurate before any cosmetic overshoot so a
+        // click dispatched after this resolves reads the true landing position.
+        posRef.current = { x: targetX, y: targetY };
+
+        if (shouldOvershoot(dist)) {
+          const overshootAnim = el.animate(computeOvershootKeyframes(dx, dy, dist), {
+            duration: OVERSHOOT_DURATION_MS,
+            easing: "ease-in-out",
+            fill: "forwards",
+          });
+          await overshootAnim.finished;
+          el.style.transform = "";
+          overshootAnim.cancel();
+        }
+        return;
       }
+
+      const keyframes = computeBezierKeyframes(fromX, fromY, targetX, targetY, steps, seed);
+      const anim = el.animate(keyframes, {
+        duration: totalDuration,
+        easing: SHORT_MOVE_EASING,
+        fill: "forwards",
+      });
+      await anim.finished;
+      el.style.left = `${targetX}px`;
+      el.style.top = `${targetY}px`;
+      el.style.transform = "";
+      anim.cancel();
 
       posRef.current = { x: targetX, y: targetY };
     }

--- a/src/components/Demo/__tests__/DemoCursor.test.tsx
+++ b/src/components/Demo/__tests__/DemoCursor.test.tsx
@@ -360,19 +360,26 @@ describe("DemoCursor", () => {
   });
 
   it("moveTo long-distance move calls animate twice (ballistic + acquisition)", async () => {
-    render(<DemoCursor />);
-    // cursor starts at (500, 400). Move to (100, 0) = (1000, 0). Distance ~500+px > 300px threshold
-    emit("demo:exec-move-to", { x: 100, y: 0, durationMs: 800, requestId: "req-twophase" });
+    // Pin random above both overshoot probabilities so the cosmetic overshoot never fires,
+    // isolating the two-phase ballistic + acquisition structure.
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.99);
+    try {
+      render(<DemoCursor />);
+      // cursor starts at (500, 400). Move to (100, 0) = (1000, 0). Distance ~500+px > 300px threshold
+      emit("demo:exec-move-to", { x: 100, y: 0, durationMs: 800, requestId: "req-twophase" });
 
-    await new Promise((r) => setTimeout(r, 10));
+      await new Promise((r) => setTimeout(r, 10));
 
-    // Two phases = two animate calls on the cursor element
-    const cursorCalls = animateSpy.mock.calls.filter((call) => {
-      const keyframes = call[0] as Array<{ transform: string }>;
-      return Array.isArray(keyframes) && keyframes[0]?.transform?.includes("translate(");
-    });
-    expect(cursorCalls.length).toBe(2);
-    expect(demoMock.sendCommandDone).toHaveBeenCalledWith("req-twophase", undefined);
+      // Two phases = two animate calls on the cursor element
+      const cursorCalls = animateSpy.mock.calls.filter((call) => {
+        const keyframes = call[0] as Array<{ transform: string }>;
+        return Array.isArray(keyframes) && keyframes[0]?.transform?.includes("translate(");
+      });
+      expect(cursorCalls.length).toBe(2);
+      expect(demoMock.sendCommandDone).toHaveBeenCalledWith("req-twophase", undefined);
+    } finally {
+      randomSpy.mockRestore();
+    }
   });
 
   it("moveTo short move calls animate once", async () => {
@@ -388,6 +395,81 @@ describe("DemoCursor", () => {
     });
     expect(cursorCalls.length).toBe(1);
     expect(demoMock.sendCommandDone).toHaveBeenCalledWith("req-onephase", undefined);
+  });
+
+  it("moveTo short move accelerates from rest (bell-shaped easing, not ease-out)", async () => {
+    render(<DemoCursor />);
+    // Short move: (500,400) → (550,400), 50px < 300px threshold
+    emit("demo:exec-move-to", { x: 55, y: 50, durationMs: 200, requestId: "req-easing" });
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    const cursorCall = animateSpy.mock.calls.find((call) => {
+      const keyframes = call[0] as Array<{ transform: string }>;
+      return Array.isArray(keyframes) && keyframes[0]?.transform?.includes("translate(");
+    })!;
+    const options = cursorCall[1] as KeyframeAnimationOptions;
+    // Easing must have zero slope at t=0 (accelerate from rest), i.e. a cubic-bezier whose
+    // first control-point x-handle starts the curve in — not "ease-out" which begins at full speed.
+    expect(options.easing).not.toBe("ease-out");
+    expect(String(options.easing)).toMatch(/^cubic-bezier\(/);
+    expect(demoMock.sendCommandDone).toHaveBeenCalledWith("req-easing", undefined);
+  });
+
+  it("moveTo long move overshoots and corrects when the probability roll triggers", async () => {
+    // Pin random below the overshoot probability so the cosmetic overshoot fires.
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.05);
+    try {
+      render(<DemoCursor />);
+      // (500,400) → (1000,0), distance ~640px > 300px threshold
+      emit("demo:exec-move-to", { x: 100, y: 0, durationMs: 800, requestId: "req-overshoot" });
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      const cursorCalls = animateSpy.mock.calls.filter((call) => {
+        const keyframes = call[0] as Array<{ transform: string }>;
+        return Array.isArray(keyframes) && keyframes[0]?.transform?.includes("translate(");
+      });
+      // ballistic + acquisition + overshoot = 3 cursor animate calls
+      expect(cursorCalls.length).toBe(3);
+
+      // The overshoot is the final cursor call: starts and ends settled on target, peaks past it.
+      const overshoot = cursorCalls[cursorCalls.length - 1]![0] as Array<{
+        transform: string;
+        offset: number;
+      }>;
+      expect(overshoot.length).toBe(3);
+      expect(overshoot[0]!.transform).toBe("translate(0px, 0px)");
+      expect(overshoot[0]!.offset).toBe(0);
+      expect(overshoot[1]!.offset).toBeGreaterThan(0);
+      expect(overshoot[1]!.offset).toBeLessThan(1);
+      expect(overshoot[1]!.transform).not.toBe("translate(0px, 0px)");
+      expect(overshoot[2]!.transform).toBe("translate(0px, 0px)");
+      expect(overshoot[2]!.offset).toBe(1);
+      expect(demoMock.sendCommandDone).toHaveBeenCalledWith("req-overshoot", undefined);
+    } finally {
+      randomSpy.mockRestore();
+    }
+  });
+
+  it("moveTo long move skips overshoot when the probability roll does not trigger", async () => {
+    // Pin random above the overshoot probability so no overshoot phase is added.
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
+    try {
+      render(<DemoCursor />);
+      emit("demo:exec-move-to", { x: 100, y: 0, durationMs: 800, requestId: "req-no-overshoot" });
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      const cursorCalls = animateSpy.mock.calls.filter((call) => {
+        const keyframes = call[0] as Array<{ transform: string }>;
+        return Array.isArray(keyframes) && keyframes[0]?.transform?.includes("translate(");
+      });
+      expect(cursorCalls.length).toBe(2);
+      expect(demoMock.sendCommandDone).toHaveBeenCalledWith("req-no-overshoot", undefined);
+    } finally {
+      randomSpy.mockRestore();
+    }
   });
 
   it("click includes settle animation on cursor element", async () => {

--- a/src/components/Demo/__tests__/DemoCursor.test.tsx
+++ b/src/components/Demo/__tests__/DemoCursor.test.tsx
@@ -499,7 +499,7 @@ describe("DemoCursor", () => {
   it("after overshoot, a click reads the real target — not the overshoot peak", async () => {
     const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.05);
     const origElementFromPoint = document.elementFromPoint;
-    const efp = vi.fn(() => null);
+    const efp = vi.fn((_x: number, _y: number) => null);
     document.elementFromPoint = efp as unknown as typeof document.elementFromPoint;
     try {
       render(<DemoCursor />);

--- a/src/components/Demo/__tests__/DemoCursor.test.tsx
+++ b/src/components/Demo/__tests__/DemoCursor.test.tsx
@@ -472,6 +472,79 @@ describe("DemoCursor", () => {
     }
   });
 
+  it("overshoot peak lies forward along the travel vector", async () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.05);
+    try {
+      render(<DemoCursor />);
+      // (500,400) → (1000,0): travel vector (dx, dy) = (500, -400)
+      emit("demo:exec-move-to", { x: 100, y: 0, durationMs: 800, requestId: "req-dir" });
+      await new Promise((r) => setTimeout(r, 10));
+
+      const cursorCalls = animateSpy.mock.calls.filter((call) => {
+        const keyframes = call[0] as Array<{ transform: string }>;
+        return Array.isArray(keyframes) && keyframes[0]?.transform?.includes("translate(");
+      });
+      const overshoot = cursorCalls[cursorCalls.length - 1]![0] as Array<{ transform: string }>;
+      const m = overshoot[1]!.transform.match(/translate\(([-\d.]+)px,\s*([-\d.]+)px\)/)!;
+      const peakX = parseFloat(m[1]!);
+      const peakY = parseFloat(m[2]!);
+      // Dot product of overshoot peak with travel vector must be positive (forward, not backward).
+      const dot = peakX * 500 + peakY * -400;
+      expect(dot).toBeGreaterThan(0);
+    } finally {
+      randomSpy.mockRestore();
+    }
+  });
+
+  it("after overshoot, a click reads the real target — not the overshoot peak", async () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.05);
+    const origElementFromPoint = document.elementFromPoint;
+    const efp = vi.fn(() => null);
+    document.elementFromPoint = efp as unknown as typeof document.elementFromPoint;
+    try {
+      render(<DemoCursor />);
+      // Move to a mid-viewport target so settle jitter stays in range: (1000*0.7, 800*0.5) = (700, 400)
+      emit("demo:exec-move-to", { x: 70, y: 50, durationMs: 800, requestId: "req-posref" });
+      await new Promise((r) => setTimeout(r, 10));
+
+      emit("demo:exec-click", { requestId: "req-posref-click" });
+      await new Promise((r) => setTimeout(r, 10));
+
+      // Click position (posRef + ≤1.5px settle) must be the committed target, not the overshoot peak.
+      const [clickX, clickY] = efp.mock.calls[efp.mock.calls.length - 1]!;
+      expect(clickX).toBeCloseTo(700, -1);
+      expect(clickY).toBeCloseTo(400, -1);
+    } finally {
+      randomSpy.mockRestore();
+      document.elementFromPoint = origElementFromPoint;
+    }
+  });
+
+  it("a cosmetic overshoot failure does not fail the move command", async () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.05);
+    // Make only the overshoot animation (keyframes carry an `offset`) reject its finished promise.
+    animateSpy.mockImplementation(((keyframes: Array<{ offset?: number }>) => {
+      const isOvershoot = Array.isArray(keyframes) && keyframes[0]?.offset === 0;
+      return {
+        finished: isOvershoot ? Promise.reject(new Error("aborted")) : Promise.resolve(),
+        cancel: vi.fn(),
+        pause: vi.fn(),
+        play: vi.fn(),
+      };
+    }) as unknown as typeof animateSpy.getMockImplementation);
+    try {
+      render(<DemoCursor />);
+      emit("demo:exec-move-to", { x: 100, y: 0, durationMs: 800, requestId: "req-cosmetic-fail" });
+      await new Promise((r) => setTimeout(r, 10));
+
+      // Cosmetic failure swallowed — command still reports success.
+      expect(demoMock.sendCommandDone).toHaveBeenCalledWith("req-cosmetic-fail", undefined);
+    } finally {
+      randomSpy.mockRestore();
+      animateSpy.mockImplementation((() => createMockAnimation()) as never);
+    }
+  });
+
   it("click includes settle animation on cursor element", async () => {
     render(<DemoCursor />);
 


### PR DESCRIPTION
## Summary

- Short moves (< 300px `TWO_PHASE_THRESHOLD`) used `ease-out`, which starts at full speed with zero acceleration. Replaced with `cubic-bezier(0.25,0,0.65,1)` for a bell-shaped velocity profile that accelerates from rest — consistent with the long-move ballistic ease-in start.
- Long moves now occasionally overshoot and correct back. Probability scales with distance (15% for 300–600px, 20% for ≥ 600px); magnitude is `min(dist * 0.10, 20)px` along the travel vector with a small perpendicular jitter. Purely cosmetic: `posRef` commits to the real target before the overshoot animation runs, so click dispatch always reads the true landing position.
- Overshoot is wrapped in `try/catch` so any cosmetic failure is fully isolated from the move result.

Resolves #10153.

## Changes

- `src/components/Demo/DemoCursor.tsx` — short-move easing updated; overshoot-and-correct added to long-move branch
- `src/components/Demo/__tests__/DemoCursor.test.tsx` — existing long-move test pins `Math.random` to suppress overshoot; new tests for bell-shaped easing, overshoot trigger (3 `animate` calls + keyframe structure), no-overshoot path, forward overshoot direction, `posRef` accuracy after overshoot, and cosmetic-failure isolation

## Testing

26 `DemoCursor` tests pass. No new dependencies.