### PR TITLE
feat(dev-preview): warn when HMR live reload silently dies

### DIFF
--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -10,6 +10,7 @@ import {
   Play,
   RotateCw,
   Settings,
+  WifiOff,
   XCircle,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -225,6 +226,35 @@ function DevPreviewStuckBanner({
           <BannerOverflowMenu actions={overflowActions} ariaLabel="More dev server options" />
         ) : undefined
       }
+    />
+  );
+}
+
+/**
+ * Surfaces a dead Vite HMR socket (#9975). The dev server keeps logging
+ * `[vite] hmr update` on every save — which fires the "Compiling" phase and
+ * reads as "live reload is working" — but with a custom `server.hmr.*` config
+ * the browser's socket connects off the proxy origin or fails outright, so
+ * the preview is silently stale. `useDevPreviewConsoleCapture` catches Vite's
+ * own failure log and flips `hmrDead`; this is a Tier 3 running-state failure
+ * with a pane-local recovery (reload reconnects the socket).
+ */
+function DevPreviewHmrDeadBanner({ onReload }: { onReload: () => void }) {
+  return (
+    <InlineStatusBanner
+      icon={WifiOff}
+      severity="error"
+      title="Live reload disconnected"
+      description="Vite's hot-reload socket dropped, so saved changes won't show up in the preview. Reload to reconnect, or drop the custom server.hmr.* config if it keeps happening."
+      role="alert"
+      ariaLive="assertive"
+      action={{
+        id: "dev-preview-hmr-dead-reload",
+        label: "Reload",
+        icon: RotateCw,
+        variant: "primary",
+        onClick: onReload,
+      }}
     />
   );
 }
@@ -1200,7 +1230,20 @@ export function DevPreviewPane({
   // Wire the guest-page CDP console capture into the renderer store. The hook
   // owns start/stop keyed on the ready/eviction lifecycle; here we only mirror
   // the live webContentsId so lazy object inspection can reach the right guest.
-  useDevPreviewConsoleCapture(id, webviewElement, isWebviewReady, isEvicted);
+  const { hmrDead, resetHmrDead } = useDevPreviewConsoleCapture(
+    id,
+    webviewElement,
+    isWebviewReady,
+    isEvicted
+  );
+
+  // A dead HMR socket is a per-load condition. Webview reloads/navigations
+  // clear it inside the hook (the guest execution context is torn down), so
+  // here we only need to cover the dev-server lifecycle: clear the warning
+  // whenever the server leaves the running state (restart/stop/crash).
+  useEffect(() => {
+    if (status !== "running") resetHmrDead();
+  }, [status, resetHmrDead]);
 
   useEffect(() => {
     if (!isWebviewReady || isEvicted) {
@@ -1479,6 +1522,8 @@ export function DevPreviewPane({
             onRemedy={handleStuckRemedy}
           />
         )}
+
+        {status === "running" && hmrDead && <DevPreviewHmrDeadBanner onReload={handleReload} />}
 
         <div
           className={cn(

--- a/src/components/DevPreview/__tests__/useDevPreviewConsoleCapture.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewConsoleCapture.test.tsx
@@ -304,4 +304,65 @@ describe("useDevPreviewConsoleCapture — HMR liveness", () => {
     rerender();
     expect(result.current.resetHmrDead).toBe(first);
   });
+
+  it("ignores stale failures from an older generation after a context clear", () => {
+    // Restart leaves the old guest page polling and logging failures from its
+    // now-defunct generation. Once the page reloads (context clear advances the
+    // generation), those stragglers must not resurrect the banner.
+    const webview = makeWebviewElement();
+    const { result } = renderHook(() => useDevPreviewConsoleCapture(PANE_ID, webview, true, false));
+    act(() => {
+      clearedCb?.({ paneId: PANE_ID, navigationGeneration: 2 });
+    });
+    act(() => {
+      messageCb?.(
+        row({
+          navigationGeneration: 1,
+          summaryText: "[vite] server connection lost. Polling for restart...",
+        })
+      );
+    });
+    expect(result.current.hmrDead).toBe(false);
+  });
+
+  it("still flips on a failure from the current generation after a context clear", () => {
+    const webview = makeWebviewElement();
+    const { result } = renderHook(() => useDevPreviewConsoleCapture(PANE_ID, webview, true, false));
+    act(() => {
+      clearedCb?.({ paneId: PANE_ID, navigationGeneration: 2 });
+    });
+    act(() => {
+      messageCb?.(
+        row({ navigationGeneration: 2, summaryText: "[vite] failed to connect to websocket." })
+      );
+    });
+    expect(result.current.hmrDead).toBe(true);
+  });
+
+  it("matches the multi-line Vite failure log", () => {
+    const webview = makeWebviewElement();
+    const { result } = renderHook(() => useDevPreviewConsoleCapture(PANE_ID, webview, true, false));
+    act(() => {
+      messageCb?.(
+        row({
+          summaryText:
+            "[vite] failed to connect to websocket.\nyour current setup:\n  (browser) localhost:5173/ <--[HTTP]--> localhost:5173/ (server)\n  (browser) localhost:5173/ <--[WebSocket (failing)]--> localhost:5173/ (server)",
+        })
+      );
+    });
+    expect(result.current.hmrDead).toBe(true);
+  });
+
+  it("isolates hmrDead between concurrent panes", () => {
+    const webview = makeWebviewElement();
+    // The hook reads its callback from the shared mock; render the second pane
+    // last so messageCb routes through the pane-2 instance, then target pane-1.
+    const { result: pane1 } = renderHook(() =>
+      useDevPreviewConsoleCapture(PANE_ID, webview, true, false)
+    );
+    act(() => {
+      messageCb?.(row({ paneId: "pane-2", summaryText: "[vite] failed to connect to websocket." }));
+    });
+    expect(pane1.current.hmrDead).toBe(false);
+  });
 });

--- a/src/components/DevPreview/__tests__/useDevPreviewConsoleCapture.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewConsoleCapture.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor, act } from "@testing-library/react";
 import { useDevPreviewConsoleCapture } from "../useDevPreviewConsoleCapture";
 import { useConsoleCaptureStore } from "@/store/consoleCaptureStore";
 import { usePanelStore } from "@/store";
@@ -198,5 +198,110 @@ describe("useDevPreviewConsoleCapture", () => {
 
     unmount();
     expect(useConsoleCaptureStore.getState().getMessages(PANE_ID)).toHaveLength(1);
+  });
+});
+
+describe("useDevPreviewConsoleCapture — HMR liveness", () => {
+  it("starts with hmrDead false", () => {
+    const webview = makeWebviewElement();
+    const { result } = renderHook(() => useDevPreviewConsoleCapture(PANE_ID, webview, true, false));
+    expect(result.current.hmrDead).toBe(false);
+  });
+
+  it("flips hmrDead when Vite logs a failed websocket connection", () => {
+    const webview = makeWebviewElement();
+    const { result } = renderHook(() => useDevPreviewConsoleCapture(PANE_ID, webview, true, false));
+    act(() => {
+      messageCb?.(row({ summaryText: "[vite] failed to connect to websocket." }));
+    });
+    expect(result.current.hmrDead).toBe(true);
+  });
+
+  it("flips hmrDead when Vite logs a lost server connection", () => {
+    const webview = makeWebviewElement();
+    const { result } = renderHook(() => useDevPreviewConsoleCapture(PANE_ID, webview, true, false));
+    act(() => {
+      messageCb?.(row({ summaryText: "[vite] server connection lost. Polling for restart..." }));
+    });
+    expect(result.current.hmrDead).toBe(true);
+  });
+
+  it("matches the failure string case-insensitively", () => {
+    const webview = makeWebviewElement();
+    const { result } = renderHook(() => useDevPreviewConsoleCapture(PANE_ID, webview, true, false));
+    act(() => {
+      messageCb?.(row({ summaryText: "[VITE] FAILED TO CONNECT TO WEBSOCKET." }));
+    });
+    expect(result.current.hmrDead).toBe(true);
+  });
+
+  it("ignores ordinary HMR update logs", () => {
+    const webview = makeWebviewElement();
+    const { result } = renderHook(() => useDevPreviewConsoleCapture(PANE_ID, webview, true, false));
+    act(() => {
+      messageCb?.(row({ level: "info", summaryText: "[vite] hmr update /src/App.tsx" }));
+    });
+    expect(result.current.hmrDead).toBe(false);
+  });
+
+  it("ignores failure logs from a different pane", () => {
+    const webview = makeWebviewElement();
+    const { result } = renderHook(() => useDevPreviewConsoleCapture(PANE_ID, webview, true, false));
+    act(() => {
+      messageCb?.(
+        row({ paneId: "other-pane", summaryText: "[vite] failed to connect to websocket." })
+      );
+    });
+    expect(result.current.hmrDead).toBe(false);
+  });
+
+  it("clears hmrDead when the guest execution context is cleared (reload/navigation)", () => {
+    const webview = makeWebviewElement();
+    const { result } = renderHook(() => useDevPreviewConsoleCapture(PANE_ID, webview, true, false));
+    act(() => {
+      messageCb?.(row({ summaryText: "[vite] failed to connect to websocket." }));
+    });
+    expect(result.current.hmrDead).toBe(true);
+
+    act(() => {
+      clearedCb?.({ paneId: PANE_ID, navigationGeneration: 2 });
+    });
+    expect(result.current.hmrDead).toBe(false);
+  });
+
+  it("does not clear hmrDead when a different pane's context is cleared", () => {
+    const webview = makeWebviewElement();
+    const { result } = renderHook(() => useDevPreviewConsoleCapture(PANE_ID, webview, true, false));
+    act(() => {
+      messageCb?.(row({ summaryText: "[vite] failed to connect to websocket." }));
+    });
+    act(() => {
+      clearedCb?.({ paneId: "other-pane", navigationGeneration: 2 });
+    });
+    expect(result.current.hmrDead).toBe(true);
+  });
+
+  it("clears hmrDead when resetHmrDead is called", () => {
+    const webview = makeWebviewElement();
+    const { result } = renderHook(() => useDevPreviewConsoleCapture(PANE_ID, webview, true, false));
+    act(() => {
+      messageCb?.(row({ summaryText: "[vite] failed to connect to websocket." }));
+    });
+    expect(result.current.hmrDead).toBe(true);
+
+    act(() => {
+      result.current.resetHmrDead();
+    });
+    expect(result.current.hmrDead).toBe(false);
+  });
+
+  it("keeps a stable resetHmrDead identity across rerenders", () => {
+    const webview = makeWebviewElement();
+    const { result, rerender } = renderHook(() =>
+      useDevPreviewConsoleCapture(PANE_ID, webview, true, false)
+    );
+    const first = result.current.resetHmrDead;
+    rerender();
+    expect(result.current.resetHmrDead).toBe(first);
   });
 });

--- a/src/components/DevPreview/useDevPreviewConsoleCapture.ts
+++ b/src/components/DevPreview/useDevPreviewConsoleCapture.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useConsoleCaptureStore } from "@/store/consoleCaptureStore";
 import { usePanelStore } from "@/store";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
@@ -26,6 +26,10 @@ export interface DevPreviewConsoleCapture {
    * `true` once Vite has reported its HMR socket as dead for this pane.
    * Sticky until `resetHmrDead` is called (on reload / restart / stop) so a
    * single failure row keeps the warning up while the webview stays stale.
+   * Lives in component state, so it resets on a grid tab-switch unmount; the
+   * captured rows survive in the store, and Vite re-logs on the next failed
+   * poll, so the worst case is a transient gap in the warning, not a stuck
+   * webview without any console trail.
    */
   hmrDead: boolean;
   resetHmrDead: () => void;
@@ -51,6 +55,13 @@ export function useDevPreviewConsoleCapture(
 ): DevPreviewConsoleCapture {
   const [hmrDead, setHmrDead] = useState(false);
   const resetHmrDead = useCallback(() => setHmrDead(false), []);
+  // The newest navigation generation observed for this pane. A dev-server
+  // restart leaves the old guest page polling and logging `[vite] server
+  // connection lost` from its now-defunct generation; once the page reloads
+  // into the fresh server the context clears and this advances. Gating
+  // `setHmrDead(true)` on the current generation keeps those stale, lower-
+  // generation failures from resurrecting the banner over a healthy reload.
+  const currentGenerationRef = useRef(0);
 
   useEffect(() => {
     if (!webviewElement || isEvicted) return;
@@ -78,7 +89,12 @@ export function useDevPreviewConsoleCapture(
 
     const offMessage = window.electron.webview.onConsoleMessage((row) => {
       if (row.paneId !== paneId) return;
-      if (isViteHmrFailureMessage(row.summaryText)) setHmrDead(true);
+      if (
+        isViteHmrFailureMessage(row.summaryText) &&
+        row.navigationGeneration >= currentGenerationRef.current
+      ) {
+        setHmrDead(true);
+      }
       store.addStructuredMessage(row);
     });
 
@@ -89,6 +105,9 @@ export function useDevPreviewConsoleCapture(
         // navigated, so any prior HMR-dead observation is stale. If the socket
         // is still misconfigured, Vite re-logs the failure in the new context
         // and we flip back. This is the reset point for user-driven reloads.
+        // Advance the generation first so late stragglers from the old page
+        // can't re-arm the banner after the reset.
+        currentGenerationRef.current = navigationGeneration;
         setHmrDead(false);
         store.markStale(paneId, navigationGeneration);
       }

--- a/src/components/DevPreview/useDevPreviewConsoleCapture.ts
+++ b/src/components/DevPreview/useDevPreviewConsoleCapture.ts
@@ -1,7 +1,35 @@
-import { useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useConsoleCaptureStore } from "@/store/consoleCaptureStore";
 import { usePanelStore } from "@/store";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
+
+/**
+ * Vite's HMR client logs these JS console errors when its WebSocket can't
+ * connect (custom `server.hmr.host`/`clientPort`/`protocol` pointing the
+ * browser socket off the stable proxy origin) or drops after connecting.
+ * They arrive through the same CDP console-capture stream as every other
+ * guest row, so matching them is the only browser-side signal we get that
+ * live reload is dead while the server keeps logging `[vite] hmr update`
+ * (which fires the misleading "Compiling" phase). Native Chromium socket
+ * errors (`net::ERR_CONNECTION_REFUSED`) bypass the JS console channel, so
+ * detection depends on Vite reaching the point of logging the failure.
+ */
+const VITE_HMR_FAILURE_PATTERN =
+  /\[vite\] (failed to connect to websocket|server connection lost)/i;
+
+function isViteHmrFailureMessage(summaryText: string): boolean {
+  return VITE_HMR_FAILURE_PATTERN.test(summaryText);
+}
+
+export interface DevPreviewConsoleCapture {
+  /**
+   * `true` once Vite has reported its HMR socket as dead for this pane.
+   * Sticky until `resetHmrDead` is called (on reload / restart / stop) so a
+   * single failure row keeps the warning up while the webview stays stale.
+   */
+  hmrDead: boolean;
+  resetHmrDead: () => void;
+}
 
 /**
  * Wires the main-process CDP console-capture pipeline to the renderer
@@ -20,7 +48,10 @@ export function useDevPreviewConsoleCapture(
   webviewElement: Electron.WebviewTag | null,
   isWebviewReady: boolean,
   isEvicted: boolean
-): void {
+): DevPreviewConsoleCapture {
+  const [hmrDead, setHmrDead] = useState(false);
+  const resetHmrDead = useCallback(() => setHmrDead(false), []);
+
   useEffect(() => {
     if (!webviewElement || isEvicted) return;
 
@@ -47,12 +78,18 @@ export function useDevPreviewConsoleCapture(
 
     const offMessage = window.electron.webview.onConsoleMessage((row) => {
       if (row.paneId !== paneId) return;
+      if (isViteHmrFailureMessage(row.summaryText)) setHmrDead(true);
       store.addStructuredMessage(row);
     });
 
     const offCleared = window.electron.webview.onConsoleContextCleared(
       ({ paneId: clearedPaneId, navigationGeneration }) => {
         if (clearedPaneId !== paneId) return;
+        // A cleared execution context means the guest page reloaded or
+        // navigated, so any prior HMR-dead observation is stale. If the socket
+        // is still misconfigured, Vite re-logs the failure in the new context
+        // and we flip back. This is the reset point for user-driven reloads.
+        setHmrDead(false);
         store.markStale(paneId, navigationGeneration);
       }
     );
@@ -83,4 +120,6 @@ export function useDevPreviewConsoleCapture(
       }
     };
   }, [paneId]);
+
+  return { hmrDead, resetHmrDead };
 }


### PR DESCRIPTION
## Summary

When a Vite dev server runs with a custom `server.hmr.*` config (`hmr.host`, `hmr.clientPort`, `hmr.protocol: 'wss'`), the browser's HMR WebSocket connects to the wrong origin or fails outright. The failure is completely silent — the preview goes stale while the server keeps logging `[vite] hmr update`, making it look like live reload is working.

This PR detects the failure by watching for Vite's own browser-side log lines (`[vite] failed to connect to websocket` / `[vite] server connection lost`) in the CDP console stream already captured by `useDevPreviewConsoleCapture`. No new IPC, no main-process changes.

When the dev server is running and HMR is dead, a Tier 3 `InlineStatusBanner` ("Live reload disconnected") appears with a Reload action. It resets on navigation (gated on navigation generation to prevent stale polling from resurrecting it) and on dev-server lifecycle transitions out of running.

Resolves #9975

## Changes

- `useDevPreviewConsoleCapture` — detect HMR failure log patterns; expose `hmrDead` state and `clearHmrDead` callback; generation-gated reset on execution-context clear
- `DevPreviewPane` — render `InlineStatusBanner` when `devServer.status === 'running'` and HMR is dead; wire Reload action and lifecycle-exit reset
- 25 unit tests covering detection, pane isolation, generation-guarded reset semantics, multi-line Vite logs, and stable callback identity

## Testing

Full local CI (`npm run check` + `npm test` + `npm run build`) green on the gated SHA.

Known limitation: native Chromium WS errors (`net::ERR_CONNECTION_REFUSED`) bypass the JS console channel entirely, so detection relies on Vite logging the failure itself. That's the best available browser-side signal without `executeJavaScript`, which hangs on CDP-frozen docked panels (per #8310).