### PR TITLE
fix(pty-host): per-window data-loss signal for saturated multi-window fan-out

### DIFF
--- a/electron/__tests__/pty-host.adversarial.test.ts
+++ b/electron/__tests__/pty-host.adversarial.test.ts
@@ -130,6 +130,7 @@ interface InspectableIpcQueueManager {
   isAtCapacity: TestMock;
   addBytes: TestMock;
   getUtilization: TestMock;
+  applyBackpressure: TestMock;
   dispose: TestMock;
 }
 
@@ -160,10 +161,14 @@ const hostState = vi.hoisted(() => ({
   ipcQueueManagers: [] as InspectableIpcQueueManager[],
   portQueueManagers: [] as InspectablePortQueueManager[],
   batchers: [] as InspectablePortBatcher[],
+  resourceGovernorDeps: null as {
+    getDropSnapshot: () => { droppedBytesDelta: number; dataLossCountDelta: number };
+  } | null,
   reset() {
     this.currentParentPort = null;
     this.terminals.clear();
     this.currentPtyManager = null;
+    this.resourceGovernorDeps = null;
     this.coordinators.length = 0;
     this.backpressureManagers.length = 0;
     this.ipcQueueManagers.length = 0;
@@ -502,6 +507,7 @@ vi.mock("../pty-host/index.js", async () => {
       this.queuedBytes.set(id, (this.queuedBytes.get(id) ?? 0) + bytes);
     });
     getUtilization = vi.fn(() => 0);
+    applyBackpressure = vi.fn();
     dispose = vi.fn();
 
     constructor() {
@@ -561,6 +567,12 @@ vi.mock("../pty-host/index.js", async () => {
   class MockResourceGovernor {
     start = vi.fn();
     dispose = vi.fn();
+
+    constructor(deps: {
+      getDropSnapshot: () => { droppedBytesDelta: number; dataLossCountDelta: number };
+    }) {
+      hostState.resourceGovernorDeps = deps;
+    }
   }
 
   return {
@@ -1345,5 +1357,174 @@ describe("pty-host adversarial", () => {
     // back to active.
     expect(backpressure.getActivityTier("t-a")).toBe("active");
     expect(backpressure.getActivityTier("t-b")).toBe("active");
+  });
+
+  // Helper: terminal-status messages posted directly on a renderer MessagePort.
+  function portStatusMessages(port: MockRendererPort): Array<Record<string, unknown>> {
+    return port.postMessage.mock.calls
+      .map((c: unknown[]) => c[0])
+      .filter(
+        (m: unknown): m is Record<string, unknown> =>
+          typeof m === "object" && m !== null && (m as { type?: string }).type === "terminal-status"
+      );
+  }
+
+  it("FAN_OUT_SATURATED_WINDOW_GETS_DATA_LOSS_PULSE", async () => {
+    // The #9891 core: with two windows fanning out the same terminal, one
+    // window's batcher accepts the chunk (visualWritten flips true, suppressing
+    // the shared IPC fallback) while the other's is saturated. The starved
+    // window must receive a per-port data-loss pulse — not a broadcast, which
+    // would falsely flag the window that received its data — and the global
+    // drop counter must account exactly the dropped chunk.
+    const parentPort = await loadHost();
+    hostState.terminals.set("t1", createTerminal("t1"));
+
+    const portA = createRendererPort();
+    const portB = createRendererPort();
+    parentPort.emit("message", { data: { type: "connect-port", windowId: 1 }, ports: [portA] });
+    parentPort.emit("message", { data: { type: "connect-port", windowId: 2 }, ports: [portB] });
+    parentPort.emit("message", { type: "spawn", id: "t1", options: {} });
+    await flushMicrotasks();
+
+    // No active project on either window → windowProjectMap empty → both windows
+    // are fan-out targets. batchers are created per connect-port in order.
+    const batcherA = hostState.batchers[0];
+    const batcherB = hostState.batchers[1];
+    batcherA.write.mockReturnValue(true); // window A accepts
+    batcherB.write.mockReturnValue(false); // window B saturated
+
+    portA.postMessage.mockClear();
+    portB.postMessage.mockClear();
+    parentPort.postMessage.mockClear();
+
+    const payload = "a".repeat(40);
+    (hostState.currentPtyManager as MiniEmitter).emit("data", "t1", payload);
+    await flushMicrotasks();
+
+    // Starved window B gets exactly one data-loss pulse on its own port.
+    const statusB = portStatusMessages(portB);
+    expect(statusB).toHaveLength(1);
+    expect(statusB[0]).toMatchObject({
+      type: "terminal-status",
+      id: "t1",
+      status: "data-loss",
+      droppedBytes: payload.length,
+    });
+    expect(typeof statusB[0].timestamp).toBe("number");
+
+    // Window A received its data on its own port — it must NOT be told of a loss.
+    expect(portStatusMessages(portA)).toHaveLength(0);
+
+    // The IPC broadcast path must NOT emit a data-loss for this chunk — that
+    // would falsely reach window A (and every other window).
+    const ipcDataLoss = terminalStatusPayloads(parentPort).filter((p) => p.status === "data-loss");
+    expect(ipcDataLoss).toHaveLength(0);
+
+    // The global drop counter accounts exactly the starved window's chunk once.
+    const drops = hostState.resourceGovernorDeps?.getDropSnapshot();
+    expect(drops).toEqual({ droppedBytesDelta: payload.length, dataLossCountDelta: 1 });
+  });
+
+  it("FAN_OUT_DATA_LOSS_USES_UTF8_BYTE_COUNT", async () => {
+    // The dropped-byte accounting must report UTF-8 bytes, not JS string length,
+    // or non-ASCII output (CJK, emoji) silently mis-reports the gap size.
+    const parentPort = await loadHost();
+    hostState.terminals.set("t1", createTerminal("t1"));
+
+    const portA = createRendererPort();
+    const portB = createRendererPort();
+    parentPort.emit("message", { data: { type: "connect-port", windowId: 1 }, ports: [portA] });
+    parentPort.emit("message", { data: { type: "connect-port", windowId: 2 }, ports: [portB] });
+    parentPort.emit("message", { type: "spawn", id: "t1", options: {} });
+    await flushMicrotasks();
+
+    hostState.batchers[0].write.mockReturnValue(true);
+    hostState.batchers[1].write.mockReturnValue(false);
+    portB.postMessage.mockClear();
+
+    const payload = "⚠".repeat(10); // 10 chars, 30 UTF-8 bytes
+    expect(payload.length).toBe(10);
+    expect(Buffer.byteLength(payload, "utf8")).toBe(30);
+
+    (hostState.currentPtyManager as MiniEmitter).emit("data", "t1", payload);
+    await flushMicrotasks();
+
+    const statusB = portStatusMessages(portB);
+    expect(statusB).toHaveLength(1);
+    expect(statusB[0].droppedBytes).toBe(30);
+    expect(hostState.resourceGovernorDeps?.getDropSnapshot()).toEqual({
+      droppedBytesDelta: 30,
+      dataLossCountDelta: 1,
+    });
+  });
+
+  it("FAN_OUT_ALL_SATURATED_FALLS_THROUGH_TO_IPC_WITHOUT_PULSE", async () => {
+    // When EVERY window's batcher rejects, visualWritten stays false and the
+    // shared IPC fallback broadcasts the chunk to all windows (the renderer's
+    // onData listens on both the port and IPC). Nothing is lost, so no per-port
+    // data-loss pulse must fire — the regression would double-signal a loss that
+    // didn't happen.
+    const parentPort = await loadHost();
+    hostState.terminals.set("t1", createTerminal("t1"));
+
+    const portA = createRendererPort();
+    const portB = createRendererPort();
+    parentPort.emit("message", { data: { type: "connect-port", windowId: 1 }, ports: [portA] });
+    parentPort.emit("message", { data: { type: "connect-port", windowId: 2 }, ports: [portB] });
+    parentPort.emit("message", { type: "spawn", id: "t1", options: {} });
+    await flushMicrotasks();
+
+    // Both batchers reject (mock default is false) — leave them as-is.
+    portA.postMessage.mockClear();
+    portB.postMessage.mockClear();
+    parentPort.postMessage.mockClear();
+
+    (hostState.currentPtyManager as MiniEmitter).emit("data", "t1", "a".repeat(25));
+    await flushMicrotasks();
+
+    // IPC fallback delivered the chunk (queue not at capacity by default).
+    expect(dataPayloads(parentPort)).toHaveLength(1);
+    // No window was starved, so no data-loss pulse on either port and no drop.
+    expect(portStatusMessages(portA)).toHaveLength(0);
+    expect(portStatusMessages(portB)).toHaveLength(0);
+    expect(hostState.resourceGovernorDeps?.getDropSnapshot()).toEqual({
+      droppedBytesDelta: 0,
+      dataLossCountDelta: 0,
+    });
+  });
+
+  it("FAN_OUT_SATURATED_PORT_THROWS_ON_STATUS_POSTMESSAGE", async () => {
+    // A starved window whose port throws on postMessage (closing mid-iteration)
+    // must not break the fan-out: the accepting window keeps its data and the
+    // drop is still accounted. Mirrors the tier-changed closing-port tolerance.
+    const parentPort = await loadHost();
+    hostState.terminals.set("t1", createTerminal("t1"));
+
+    const portA = createRendererPort();
+    const portThrowing = createRendererPort();
+    parentPort.emit("message", { data: { type: "connect-port", windowId: 1 }, ports: [portA] });
+    parentPort.emit("message", {
+      data: { type: "connect-port", windowId: 2 },
+      ports: [portThrowing],
+    });
+    parentPort.emit("message", { type: "spawn", id: "t1", options: {} });
+    await flushMicrotasks();
+
+    hostState.batchers[0].write.mockReturnValue(true);
+    hostState.batchers[1].write.mockReturnValue(false);
+    portThrowing.postMessage.mockImplementation(() => {
+      throw new Error("port closing");
+    });
+
+    expect(() =>
+      (hostState.currentPtyManager as MiniEmitter).emit("data", "t1", "a".repeat(15))
+    ).not.toThrow();
+    await flushMicrotasks();
+
+    // The drop is still accounted even though the pulse delivery threw.
+    expect(hostState.resourceGovernorDeps?.getDropSnapshot()).toEqual({
+      droppedBytesDelta: 15,
+      dataLossCountDelta: 1,
+    });
   });
 });

--- a/electron/__tests__/pty-host.adversarial.test.ts
+++ b/electron/__tests__/pty-host.adversarial.test.ts
@@ -1527,4 +1527,155 @@ describe("pty-host adversarial", () => {
       dataLossCountDelta: 1,
     });
   });
+
+  it("FAN_OUT_THREE_WINDOWS_TWO_SATURATED_EACH_GET_A_PULSE", async () => {
+    // With three windows fanning out, one accepting and two saturated, BOTH
+    // starved windows must each get exactly one pulse — a regression that only
+    // pulsed the first saturated connection would silently strand the rest.
+    const parentPort = await loadHost();
+    hostState.terminals.set("t1", createTerminal("t1"));
+
+    const portA = createRendererPort();
+    const portB = createRendererPort();
+    const portC = createRendererPort();
+    parentPort.emit("message", { data: { type: "connect-port", windowId: 1 }, ports: [portA] });
+    parentPort.emit("message", { data: { type: "connect-port", windowId: 2 }, ports: [portB] });
+    parentPort.emit("message", { data: { type: "connect-port", windowId: 3 }, ports: [portC] });
+    parentPort.emit("message", { type: "spawn", id: "t1", options: {} });
+    await flushMicrotasks();
+
+    hostState.batchers[0].write.mockReturnValue(true); // A accepts
+    hostState.batchers[1].write.mockReturnValue(false); // B saturated
+    hostState.batchers[2].write.mockReturnValue(false); // C saturated
+    portA.postMessage.mockClear();
+    portB.postMessage.mockClear();
+    portC.postMessage.mockClear();
+
+    const payload = "a".repeat(20);
+    (hostState.currentPtyManager as MiniEmitter).emit("data", "t1", payload);
+    await flushMicrotasks();
+
+    expect(portStatusMessages(portA)).toHaveLength(0);
+    expect(portStatusMessages(portB)).toHaveLength(1);
+    expect(portStatusMessages(portC)).toHaveLength(1);
+    expect(hostState.resourceGovernorDeps?.getDropSnapshot()).toEqual({
+      droppedBytesDelta: payload.length * 2,
+      dataLossCountDelta: 2,
+    });
+  });
+
+  it("FAN_OUT_SATURATED_BEFORE_ACCEPTED_STILL_PULSES", async () => {
+    // The pulse decision is post-loop, so it must not depend on whether the
+    // saturated window is iterated before or after the accepting one. Here the
+    // first-connected window is saturated and the second accepts.
+    const parentPort = await loadHost();
+    hostState.terminals.set("t1", createTerminal("t1"));
+
+    const portSaturated = createRendererPort();
+    const portAccepting = createRendererPort();
+    parentPort.emit("message", {
+      data: { type: "connect-port", windowId: 1 },
+      ports: [portSaturated],
+    });
+    parentPort.emit("message", {
+      data: { type: "connect-port", windowId: 2 },
+      ports: [portAccepting],
+    });
+    parentPort.emit("message", { type: "spawn", id: "t1", options: {} });
+    await flushMicrotasks();
+
+    hostState.batchers[0].write.mockReturnValue(false); // first window saturated
+    hostState.batchers[1].write.mockReturnValue(true); // second window accepts
+    portSaturated.postMessage.mockClear();
+    portAccepting.postMessage.mockClear();
+
+    (hostState.currentPtyManager as MiniEmitter).emit("data", "t1", "a".repeat(12));
+    await flushMicrotasks();
+
+    expect(portStatusMessages(portSaturated)).toHaveLength(1);
+    expect(portStatusMessages(portAccepting)).toHaveLength(0);
+    expect(hostState.resourceGovernorDeps?.getDropSnapshot()).toEqual({
+      droppedBytesDelta: 12,
+      dataLossCountDelta: 1,
+    });
+  });
+
+  it("FAN_OUT_IPC_MIRRORED_TERMINAL_GETS_NO_PULSE", async () => {
+    // IPC-mirrored terminals (dev-preview consoles) broadcast every chunk via the
+    // IPC data mirror whenever visualWritten is true, so a saturated window still
+    // receives the data over IPC. Emitting a data-loss pulse there would mark a
+    // discontinuity that never happened.
+    const parentPort = await loadHost();
+    hostState.terminals.set("t1", createTerminal("t1"));
+
+    const portA = createRendererPort();
+    const portB = createRendererPort();
+    parentPort.emit("message", { data: { type: "connect-port", windowId: 1 }, ports: [portA] });
+    parentPort.emit("message", { data: { type: "connect-port", windowId: 2 }, ports: [portB] });
+    parentPort.emit("message", { type: "spawn", id: "t1", options: {} });
+    parentPort.emit("message", { type: "set-ipc-data-mirror", id: "t1", enabled: true });
+    await flushMicrotasks();
+
+    hostState.batchers[0].write.mockReturnValue(true);
+    hostState.batchers[1].write.mockReturnValue(false);
+    portA.postMessage.mockClear();
+    portB.postMessage.mockClear();
+    parentPort.postMessage.mockClear();
+
+    (hostState.currentPtyManager as MiniEmitter).emit("data", "t1", "a".repeat(18));
+    await flushMicrotasks();
+
+    // No per-port pulse, no drop accounting — the IPC mirror covers the window.
+    expect(portStatusMessages(portB)).toHaveLength(0);
+    expect(hostState.resourceGovernorDeps?.getDropSnapshot()).toEqual({
+      droppedBytesDelta: 0,
+      dataLossCountDelta: 0,
+    });
+    // The mirror broadcast did fire (the data reaches every window via IPC).
+    expect(dataPayloads(parentPort)).toHaveLength(1);
+  });
+
+  it("FAN_OUT_PULSE_RESPECTS_PROJECT_FILTER", async () => {
+    // Only windows that own (or globally view) the terminal's project are fan-out
+    // targets, so only a saturated TARGET window may get a pulse — a project-
+    // filtered window is never a target and must never be pulsed.
+    const parentPort = await loadHost();
+    hostState.terminals.set("t1", createTerminal("t1", "project-1"));
+
+    const portOwner = createRendererPort(); // window 1 → project-1 (target, saturated)
+    const portViewer = createRendererPort(); // window 2 → project-1 (target, accepts)
+    const portForeign = createRendererPort(); // window 3 → project-2 (filtered out)
+    parentPort.emit("message", { data: { type: "connect-port", windowId: 1 }, ports: [portOwner] });
+    parentPort.emit("message", {
+      data: { type: "connect-port", windowId: 2 },
+      ports: [portViewer],
+    });
+    parentPort.emit("message", {
+      data: { type: "connect-port", windowId: 3 },
+      ports: [portForeign],
+    });
+    parentPort.emit("message", { type: "set-active-project", windowId: 1, projectId: "project-1" });
+    parentPort.emit("message", { type: "set-active-project", windowId: 2, projectId: "project-1" });
+    parentPort.emit("message", { type: "set-active-project", windowId: 3, projectId: "project-2" });
+    parentPort.emit("message", { type: "spawn", id: "t1", options: { projectId: "project-1" } });
+    await flushMicrotasks();
+
+    // batchers[0]=window1 (owner), [1]=window2 (viewer), [2]=window3 (foreign).
+    hostState.batchers[0].write.mockReturnValue(false); // owner saturated
+    hostState.batchers[1].write.mockReturnValue(true); // viewer accepts
+    portOwner.postMessage.mockClear();
+    portViewer.postMessage.mockClear();
+    portForeign.postMessage.mockClear();
+
+    (hostState.currentPtyManager as MiniEmitter).emit("data", "t1", "a".repeat(22));
+    await flushMicrotasks();
+
+    expect(portStatusMessages(portOwner)).toHaveLength(1); // saturated target → pulse
+    expect(portStatusMessages(portViewer)).toHaveLength(0); // accepted → no pulse
+    expect(portStatusMessages(portForeign)).toHaveLength(0); // filtered out → never a target
+    expect(hostState.resourceGovernorDeps?.getDropSnapshot()).toEqual({
+      droppedBytesDelta: 22,
+      dataLossCountDelta: 1,
+    });
+  });
 });

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -630,7 +630,11 @@ ptyManager.on("data", (id: string, data: string | Uint8Array) => {
     // that received the data on their own port (issue #9891). So account the
     // loss and deliver a `data-loss` pulse on each starved window's own port,
     // FIFO-ordered with its data, letting the next wake snapshot resync it.
-    if (visualWritten && saturated.length > 0) {
+    //
+    // Skip mirrored terminals: the IPC data mirror below broadcasts the chunk to
+    // every window (the renderer's onData also listens on IPC), so a starved
+    // window still receives it — a pulse here would be a spurious discontinuity.
+    if (visualWritten && saturated.length > 0 && !ipcDataMirrorTerminals.has(id)) {
       for (const conn of saturated) {
         // Counter is unconditional — regression detection must work even when
         // metrics are gated off (mirrors the IPC at-capacity path).

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -609,9 +609,44 @@ ptyManager.on("data", (id: string, data: string | Uint8Array) => {
     // timing is independent, so with 2+ targets any flush would neuter the chunk
     // out from under siblings still waiting to copy it. Sole target → owned.
     const owned = targets.length === 1;
+    const saturated: RendererConnection[] = [];
     for (const conn of targets) {
       if (conn.batcher.write(id, chunk, byteCount, owned)) {
         visualWritten = true;
+      } else {
+        saturated.push(conn);
+      }
+    }
+
+    // A window whose batcher rejected this chunk only truly loses it when a
+    // SIBLING window's batcher accepted it — i.e. `visualWritten` is now true,
+    // which suppresses the shared SAB/IPC fallback below. If NO window accepted,
+    // `visualWritten` stays false and the IPC fallback broadcasts the chunk to
+    // every window (the renderer's onData subscribes to both the MessagePort and
+    // the IPC path), so nothing is actually lost — no pulse needed there.
+    //
+    // For the genuinely-starved windows we can't lean on the IPC fallback:
+    // `sendEvent` broadcasts to every window and would falsely flag the ones
+    // that received the data on their own port (issue #9891). So account the
+    // loss and deliver a `data-loss` pulse on each starved window's own port,
+    // FIFO-ordered with its data, letting the next wake snapshot resync it.
+    if (visualWritten && saturated.length > 0) {
+      for (const conn of saturated) {
+        // Counter is unconditional — regression detection must work even when
+        // metrics are gated off (mirrors the IPC at-capacity path).
+        dropAccumulator.droppedBytes += byteCount;
+        dropAccumulator.dataLossCount += 1;
+        try {
+          conn.port.postMessage({
+            type: "terminal-status",
+            id,
+            status: "data-loss",
+            droppedBytes: byteCount,
+            timestamp: Date.now(),
+          });
+        } catch {
+          // Port closing between iteration and post — disconnect handles cleanup.
+        }
       }
     }
     // If at capacity on all ports, fall through to SAB or IPC fallback

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -627,6 +627,14 @@ export type RendererToPtyHostMessage =
  * MessagePort as `data`, so it is FIFO-ordered ahead of any subsequently
  * suppressed/emitted chunk — routing it through the Main process instead would
  * race the direct data path and lose that ordering guarantee.
+ *
+ * `terminal-status` carries a per-window `data-loss` pulse for the multi-window
+ * fan-out case: when one window's batcher accepts a chunk but another window's
+ * is saturated, the loss is local to the saturated window. The Main-process
+ * `terminal-status` event is a broadcast to every window, so it can't signal a
+ * single window without falsely alerting the ones that received the data. This
+ * variant rides the saturated window's own MessagePort instead, FIFO-ordered
+ * with its data so the discontinuity marker lands in the right place.
  */
 export type PtyHostToRendererMessage =
   | {
@@ -639,6 +647,15 @@ export type PtyHostToRendererMessage =
       type: "tier-changed";
       id: string;
       tier: "active" | "background";
+    }
+  | {
+      type: "terminal-status";
+      id: string;
+      status: TerminalFlowStatus;
+      bufferUtilization?: number;
+      /** Byte count discarded — only set when status is "data-loss". */
+      droppedBytes?: number;
+      timestamp: number;
     };
 
 /** Per-process resource breakdown entry */

--- a/src/clients/__tests__/terminalClient.test.ts
+++ b/src/clients/__tests__/terminalClient.test.ts
@@ -425,6 +425,94 @@ describe("terminalClient MessagePort data routing", () => {
     });
   });
 
+  it("dispatches MessagePort terminal-status (data-loss) to onStatus callbacks", () => {
+    // Per-window data-loss pulse for a saturated fan-out window (#9891) rides the
+    // port, not the IPC broadcast, so it reaches only the affected window.
+    const port = acquirePort();
+    const received: Array<Record<string, unknown>> = [];
+
+    terminalClient.onStatus((data) => received.push(data as unknown as Record<string, unknown>));
+
+    port.postMessage({
+      type: "terminal-status",
+      id: "term-1",
+      status: "data-loss",
+      droppedBytes: 40,
+      timestamp: 123,
+    });
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(received).toHaveLength(1);
+        expect(received[0]).toMatchObject({
+          id: "term-1",
+          status: "data-loss",
+          droppedBytes: 40,
+          timestamp: 123,
+        });
+        resolve();
+      }, 50);
+    });
+  });
+
+  it("onStatus subscribes to BOTH the IPC broadcast and the port, and cleanup detaches both", () => {
+    const port = acquirePort();
+    const received: Array<Record<string, unknown>> = [];
+
+    const unsub = terminalClient.onStatus((data) =>
+      received.push(data as unknown as Record<string, unknown>)
+    );
+    // Dual-registration: the IPC broadcast path is still wired up.
+    expect(mockElectronTerminal.onStatus).toHaveBeenCalledTimes(1);
+
+    unsub();
+    // After unsubscribe the port path must no longer dispatch to the callback.
+    port.postMessage({
+      type: "terminal-status",
+      id: "term-1",
+      status: "data-loss",
+      droppedBytes: 5,
+      timestamp: 1,
+    });
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(received).toEqual([]);
+        resolve();
+      }, 50);
+    });
+  });
+
+  it("does NOT ack or buffer terminal-status messages (no byte accounting)", () => {
+    const port = acquirePort();
+
+    terminalClient.onStatus(() => {});
+
+    // Like tier-changed, a terminal-status pulse carries no consumable bytes and
+    // must never enter the ACK loop (which would emit a spurious early-buffer ack).
+    port.postMessage({
+      type: "terminal-status",
+      id: "term-1",
+      status: "data-loss",
+      droppedBytes: 9,
+      timestamp: 2,
+    });
+
+    return new Promise<void>((resolve) => {
+      const acks: Record<string, unknown>[] = [];
+      port.addEventListener("message", (event: MessageEvent) => {
+        const msg = event.data as Record<string, unknown>;
+        if (msg?.type === "ack") acks.push(msg);
+      });
+      port.start();
+
+      setTimeout(() => {
+        expect(acks).toEqual([]);
+        resolve();
+      }, 100);
+    });
+  });
+
   it("ignores unknown message types without throwing or emitting acks", () => {
     const port = acquirePort();
     const tierReceived: string[] = [];

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -33,6 +33,13 @@ const MAX_EARLY_BUFFER_CHUNKS = 500;
 // control messages carry no byte count and must never enter pendingPortAckBytes.
 const tierChangedCallbacks = new Set<(id: string, tier: "active" | "background") => void>();
 
+// Per-window terminal-status pulses delivered on the MessagePort (currently the
+// `data-loss` signal for a saturated window in the multi-window fan-out case,
+// issue #9891). The Main-process `onStatus` broadcast can't target one window,
+// so these ride the saturated window's own port and are dispatched to the same
+// `onStatus` subscribers as the IPC path. No ACK, no byte accounting — pulses.
+const terminalStatusCallbacks = new Set<(data: TerminalStatusPayload) => void>();
+
 function installPortDataHandler(port: MessagePort): void {
   port.addEventListener("message", (event: MessageEvent) => {
     const msg = event.data as PtyHostToRendererMessage;
@@ -40,6 +47,20 @@ function installPortDataHandler(port: MessagePort): void {
       // Host-pushed tier reconciliation — no ACK, no byte accounting.
       for (const cb of tierChangedCallbacks) {
         cb(msg.id, msg.tier);
+      }
+      return;
+    }
+    if (msg?.type === "terminal-status" && typeof msg.id === "string") {
+      // Per-window flow-status pulse (e.g. data-loss for a saturated window).
+      // Routed to the same subscribers as the IPC broadcast path.
+      for (const cb of terminalStatusCallbacks) {
+        cb({
+          id: msg.id,
+          status: msg.status,
+          bufferUtilization: msg.bufferUtilization,
+          droppedBytes: msg.droppedBytes,
+          timestamp: msg.timestamp,
+        });
       }
       return;
     }
@@ -452,9 +473,19 @@ export const terminalClient = {
 
   /**
    * Listen for terminal status changes (flow control state).
+   *
+   * Subscribes to both delivery paths: the Main-process IPC broadcast and the
+   * per-window MessagePort pulses (data-loss for a saturated window in the
+   * multi-window fan-out, issue #9891). A window only receives port pulses meant
+   * for it, so the discontinuity marker lands in the right place.
    */
   onStatus: (callback: (data: TerminalStatusPayload) => void): (() => void) => {
-    return window.electron.terminal.onStatus(callback);
+    terminalStatusCallbacks.add(callback);
+    const ipcCleanup = window.electron.terminal.onStatus(callback);
+    return () => {
+      terminalStatusCallbacks.delete(callback);
+      ipcCleanup();
+    };
   },
 
   /**


### PR DESCRIPTION
## Summary

- The fan-out loop in `pty-host.ts` used a single global `visualWritten` flag: as soon as any one window's `PortBatcher` accepted a chunk, the shared IPC fallback was suppressed for all windows. A second saturated window received no data, no drop accounting, and no data-loss signal -- it silently diverged with no way to detect or resync.
- The fix tracks saturation per-window. Only when a sibling window accepted the chunk (so the IPC fallback is genuinely blocked) and the terminal is not IPC-mirrored does it account the drop and post a `terminal-status: data-loss` pulse on that window's own `MessagePort` -- not the broadcast `sendEvent`, which would falsely flag healthy windows.
- A new `terminal-status` variant on `PtyHostToRendererMessage` carries the pulse; `terminalClient.installPortDataHandler` dispatches it to the same `onStatus` subscribers as the IPC path.

Resolves #9891

## Changes

- `electron/pty-host.ts` -- replace global `visualWritten` with per-window saturation tracking; post `terminal-status: data-loss` on the correct `MessagePort` when a sibling accepted the chunk
- `shared/types/pty-host.ts` -- add `terminal-status` variant to `PtyHostToRendererMessage`
- `src/clients/terminalClient.ts` -- dispatch `terminal-status` messages from `installPortDataHandler` to existing `onStatus` subscribers
- `electron/__tests__/pty-host.adversarial.test.ts` -- adversarial suite: per-window pulse, UTF-8 byte accounting, all-saturated IPC fallback without spurious pulse, three-window/two-saturated, ordering independence, IPC-mirror skip, project-filter targeting
- `src/clients/__tests__/terminalClient.test.ts` -- renderer-side tests for `terminal-status` dispatch

## Testing

Adversarial unit tests cover the full decision tree: correct window receives the pulse, UTF-8 split-chunk accounting, no spurious pulse when all windows saturate and IPC fallback fires, three-window/two-saturated scenario, ordering independence, IPC-mirrored skip, and project-filter scoping. Renderer-side `terminalClient` tests verify the pulse reaches `onStatus` subscribers. Local CI passed (typecheck, lint, format, unit tests, build).