### PR TITLE
ci(release): smoke-test arm64 Windows build before publish

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -372,6 +372,32 @@ jobs:
           }
           Write-Host "Found NSIS installer: $($installers[0].Name) ($([math]::Round($installers[0].Length / 1MB, 1)) MB)"
 
+      - name: Smoke test (packaged Windows arm64)
+        shell: pwsh
+        timeout-minutes: 12
+        env:
+          NODE_ENV: production
+          ELECTRON_ENABLE_LOGGING: "1"
+          SMOKE_TIMEOUT_MS: "210000"
+          SMOKE_RETRIES: "1"
+        run: |
+          $setup = Get-ChildItem -Path 'release\*.exe' -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $setup) { Write-Error "No NSIS .exe found in release/"; exit 1 }
+          $extractDir = Join-Path $env:RUNNER_TEMP "daintree-packaged-smoke"
+          Remove-Item -Recurse -Force $extractDir -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
+          # 7-Zip extraction (preinstalled on windows-11-arm) is faster than an
+          # NSIS silent install and avoids registry/shortcut side effects.
+          7z x $setup.FullName -o"$extractDir" -y | Out-Null
+          $nested = Get-ChildItem -Path $extractDir -Filter 'app-arm64.7z' -Recurse | Select-Object -First 1
+          if ($nested) {
+            7z x $nested.FullName -o"$extractDir\app" -y | Out-Null
+          }
+          $binary = Get-ChildItem -Path $extractDir -Filter 'Daintree.exe' -Recurse | Select-Object -First 1
+          if (-not $binary) { Write-Error "Daintree.exe not found after extracting installer"; exit 1 }
+          $env:PACKAGED_BINARY = $binary.FullName
+          node scripts/run-packaged-smoke.mjs
+
       - name: Upload build artifacts (arm64)
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -218,9 +218,11 @@ jobs:
           # 7-Zip extraction (preinstalled on windows-latest) is faster than an
           # NSIS silent install and avoids registry/shortcut side effects.
           7z x $setup.FullName -o"$extractDir" -y | Out-Null
+          if ($LASTEXITCODE -ne 0) { Write-Error "7z extraction of installer failed (exit $LASTEXITCODE)"; exit 1 }
           $nested = Get-ChildItem -Path $extractDir -Filter 'app-64.7z' -Recurse | Select-Object -First 1
           if ($nested) {
             7z x $nested.FullName -o"$extractDir\app" -y | Out-Null
+            if ($LASTEXITCODE -ne 0) { Write-Error "7z extraction of $($nested.Name) failed (exit $LASTEXITCODE)"; exit 1 }
           }
           $binary = Get-ChildItem -Path $extractDir -Filter 'Daintree.exe' -Recurse | Select-Object -First 1
           if (-not $binary) { Write-Error "Daintree.exe not found after extracting installer"; exit 1 }
@@ -389,9 +391,11 @@ jobs:
           # 7-Zip extraction (preinstalled on windows-11-arm) is faster than an
           # NSIS silent install and avoids registry/shortcut side effects.
           7z x $setup.FullName -o"$extractDir" -y | Out-Null
+          if ($LASTEXITCODE -ne 0) { Write-Error "7z extraction of installer failed (exit $LASTEXITCODE)"; exit 1 }
           $nested = Get-ChildItem -Path $extractDir -Filter 'app-arm64.7z' -Recurse | Select-Object -First 1
           if ($nested) {
             7z x $nested.FullName -o"$extractDir\app" -y | Out-Null
+            if ($LASTEXITCODE -ne 0) { Write-Error "7z extraction of $($nested.Name) failed (exit $LASTEXITCODE)"; exit 1 }
           }
           $binary = Get-ChildItem -Path $extractDir -Filter 'Daintree.exe' -Recurse | Select-Object -First 1
           if (-not $binary) { Write-Error "Daintree.exe not found after extracting installer"; exit 1 }

--- a/scripts/ci/release-windows-arm64-smoke.test.mjs
+++ b/scripts/ci/release-windows-arm64-smoke.test.mjs
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import path from "path";
+import yaml from "js-yaml";
+
+// Regression guard for #10030: the arm64 Windows build must smoke-test its
+// own NSIS installer (on the arm64 runner) before the artifact is uploaded,
+// so a broken arm64 binary can never reach publish unexercised. These assert
+// structural invariants of the workflow, not hardcoded literals — they fail
+// if the gate is removed, reordered after upload, or wired to the wrong arch.
+
+const workflowPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../.github/workflows/release-windows.yml"
+);
+const workflow = yaml.load(readFileSync(workflowPath, "utf8"));
+
+function stepNames(job) {
+  return job.steps.map((s) => s.name);
+}
+
+function findStep(job, predicate) {
+  return job.steps.find(predicate);
+}
+
+describe("release-windows arm64 packaged smoke gate (#10030)", () => {
+  const arm64 = workflow.jobs["build-daintree-arm64"];
+
+  it("runs the arm64 build on an arm64 runner", () => {
+    expect(arm64["runs-on"]).toBe("windows-11-arm");
+  });
+
+  it("has a packaged-smoke step that runs the shared smoke runner", () => {
+    const smoke = findStep(arm64, (s) => /smoke/i.test(s.name ?? ""));
+    expect(smoke, "arm64 build job is missing a smoke-test step").toBeTruthy();
+    expect(smoke.run).toContain("node scripts/run-packaged-smoke.mjs");
+  });
+
+  it("extracts the arm64-specific nested archive, not the x64 one", () => {
+    const smoke = findStep(arm64, (s) => /smoke/i.test(s.name ?? ""));
+    expect(smoke.run).toContain("app-arm64.7z");
+    expect(smoke.run).not.toContain("app-64.7z");
+  });
+
+  it("smoke-tests before uploading the artifact so a failure gates publish", () => {
+    const names = stepNames(arm64);
+    const smokeIdx = names.findIndex((n) => /smoke/i.test(n ?? ""));
+    const uploadIdx = names.findIndex((n) => /upload build artifacts/i.test(n ?? ""));
+    expect(smokeIdx).toBeGreaterThanOrEqual(0);
+    expect(uploadIdx).toBeGreaterThanOrEqual(0);
+    expect(smokeIdx).toBeLessThan(uploadIdx);
+  });
+
+  it("does not let the smoke step pass through failures silently", () => {
+    const smoke = findStep(arm64, (s) => /smoke/i.test(s.name ?? ""));
+    // No continue-on-error escape hatch — the gate must be able to fail the job.
+    expect(smoke["continue-on-error"]).toBeFalsy();
+    // 7z exit codes are checked so a corrupt archive can't slip a truncated payload through.
+    expect(smoke.run).toContain("$LASTEXITCODE");
+  });
+
+  it("keeps arm64 smoke runner config in parity with the x64 step", () => {
+    const x64 = workflow.jobs["build-daintree-x64"];
+    const x64Smoke = findStep(x64, (s) => /smoke/i.test(s.name ?? ""));
+    const armSmoke = findStep(arm64, (s) => /smoke/i.test(s.name ?? ""));
+    expect(x64Smoke, "x64 build job is missing its smoke-test step").toBeTruthy();
+    // The two architectures should share the same timeout/retry envelope.
+    expect(armSmoke.env.SMOKE_TIMEOUT_MS).toBe(x64Smoke.env.SMOKE_TIMEOUT_MS);
+    expect(armSmoke.env.SMOKE_RETRIES).toBe(x64Smoke.env.SMOKE_RETRIES);
+    expect(armSmoke["timeout-minutes"]).toBe(x64Smoke["timeout-minutes"]);
+  });
+});


### PR DESCRIPTION
## Summary

- The `build-daintree-arm64` job in `release-windows.yml` now extracts the NSIS installer and launches it in `--smoke-test` mode before the artifact is uploaded, mirroring the existing inline smoke step in `build-daintree-x64`
- Added `$LASTEXITCODE` guards after each `7z` extraction in both x64 and arm64 smoke steps so a silent extraction failure can't let a broken binary slip through
- Added `scripts/ci/release-windows-arm64-smoke.test.mjs` (6 tests) asserting the arm64 job smokes before upload, uses `app-arm64.7z`, has no `continue-on-error` escape hatch, and stays in timeout/retry parity with x64

Resolves #10030

## Changes

- `.github/workflows/release-windows.yml` — inline "Smoke test (packaged Windows arm64)" PowerShell step added to `build-daintree-arm64`, using `app-arm64.7z` as the nested archive filter; `$LASTEXITCODE` checks added to both x64 and arm64 extraction sequences
- `scripts/ci/release-windows-arm64-smoke.test.mjs` — regression test file covering the new smoke step

## Testing

- 23 runnable local CI checks pass (typecheck, lint, format, unit tests, build)
- `test:smoke` requires a live packaged app and is handled by GitHub CI on the `windows-11-arm` runner
- The new regression tests assert structural correctness of the workflow changes without needing a real runner