### PR TITLE
fix(dev-preview): dial HTTPS dev servers over TLS instead of 502ing

### DIFF
--- a/electron/services/DevPreviewProxyService.ts
+++ b/electron/services/DevPreviewProxyService.ts
@@ -51,10 +51,12 @@ interface BrowserTokenPayload {
 
 /**
  * Resolves an incoming dev-preview subdomain (e.g. `dp-proj-panel`) to the live upstream
- * dev-server port, or null when no session owns that subdomain. Injected so the proxy stays
- * decoupled from DevPreviewSessionService internals.
+ * dev-server port AND transport scheme, or null when no session owns that subdomain. The
+ * `isHttps` flag lets the proxy dial a TLS dev server (Vite `server.https`, Next.js
+ * `--experimental-https`, mkcert) over HTTPS instead of 502-ing on a plain-HTTP dial (#9974).
+ * Injected so the proxy stays decoupled from DevPreviewSessionService internals.
  */
-export type ResolveUpstreamPort = (subdomain: string) => number | null;
+export type ResolveUpstream = (subdomain: string) => { port: number; isHttps: boolean } | null;
 
 /**
  * Fixed-port reverse proxy that gives every dev-preview panel a stable `*.localhost` origin
@@ -87,7 +89,7 @@ export class DevPreviewProxyService {
   private readonly pendingTokens = new Map<string, number>();
   private reaper: NodeJS.Timeout | null = null;
 
-  constructor(private readonly resolveUpstreamPort: ResolveUpstreamPort) {}
+  constructor(private readonly resolveUpstreamFn: ResolveUpstream) {}
 
   /** The port the proxy actually bound to (43000, or an OS-assigned fallback). 0 until started. */
   get port(): number {
@@ -189,13 +191,21 @@ export class DevPreviewProxyService {
       return;
     }
 
-    const port = this.resolvePort(req.headers.host);
-    if (port === null) {
+    const upstream = this.resolveUpstream(req.headers.host);
+    if (upstream === null) {
       this.send502(res, "No dev server is registered for this preview.");
       return;
     }
     try {
-      await this.proxy!.web(req, res, { target: `http://${UPSTREAM_HOST}:${port}` });
+      // Dial https:// for a TLS dev server, http:// otherwise — httpxy picks https.request vs
+      // http.request from the target scheme. `secure: false` accepts the self-signed loopback
+      // cert (Vite/Next dev TLS); the upstream is always `localhost`, so this stays loopback-only
+      // and never disables verification for a remote host (#9974).
+      const scheme = upstream.isHttps ? "https" : "http";
+      await this.proxy!.web(req, res, {
+        target: `${scheme}://${UPSTREAM_HOST}:${upstream.port}`,
+        ...(upstream.isHttps ? { secure: false } : {}),
+      });
     } catch {
       this.send502(res, "The dev server isn't responding.");
     }
@@ -209,18 +219,25 @@ export class DevPreviewProxyService {
     this.sockets.add(socket);
     socket.once("close", () => this.sockets.delete(socket));
 
-    const port = this.resolvePort(req.headers.host);
-    if (port === null) {
+    const upstream = this.resolveUpstream(req.headers.host);
+    if (upstream === null) {
       socket.destroy();
       return;
     }
     try {
       // The 'upgrade' event types the socket as Duplex; httpxy's ws() wants net.Socket, which
-      // is exactly the concrete type Node provides here.
+      // is exactly the concrete type Node provides here. Use wss:// for a TLS dev server so
+      // HMR/WebSocket upgrades reach an HTTPS upstream instead of failing the handshake; httpxy's
+      // isSSL check matches both `wss` and `https`, and `secure: false` accepts the self-signed
+      // loopback cert (#9974).
+      const scheme = upstream.isHttps ? "wss" : "http";
       await this.proxy!.ws(
         req,
         socket as Socket,
-        { target: `http://${UPSTREAM_HOST}:${port}` },
+        {
+          target: `${scheme}://${UPSTREAM_HOST}:${upstream.port}`,
+          ...(upstream.isHttps ? { secure: false } : {}),
+        },
         head
       );
     } catch {
@@ -228,10 +245,10 @@ export class DevPreviewProxyService {
     }
   }
 
-  private resolvePort(host: string | undefined): number | null {
+  private resolveUpstream(host: string | undefined): { port: number; isHttps: boolean } | null {
     const subdomain = parseDevPreviewProxyHost(host);
     if (!subdomain) return null;
-    return this.resolveUpstreamPort(subdomain);
+    return this.resolveUpstreamFn(subdomain);
   }
 
   private send502(res: http.ServerResponse, message: string): void {

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -131,12 +131,18 @@ const CRASH_LOOP_BACKOFF_MULTIPLIER = 1.5;
 const CRASH_LOOP_MAX_DELAY_MS = 3000;
 const CRASH_LOOP_MAX_ATTEMPTS = 5;
 
-/** Parse the numeric port out of a detected dev-server URL, or null if absent/unparseable. */
-function parseUrlPort(url: string | null): number | null {
+/**
+ * Parse both the port AND the transport scheme out of a detected dev-server URL (#9974).
+ * Returns null if absent/unparseable. `isHttps` is true only when the URL scheme is
+ * `https:` — a dev server running over TLS (Vite `server.https`, Next.js
+ * `--experimental-https`, mkcert) must be dialed over HTTPS, not plain HTTP.
+ */
+function parseUrlEndpoint(url: string | null): { port: number; isHttps: boolean } | null {
   if (!url) return null;
   try {
-    const port = new URL(url).port;
-    return port ? Number(port) : null;
+    const parsed = new URL(url);
+    if (!parsed.port) return null;
+    return { port: Number(parsed.port), isHttps: parsed.protocol === "https:" };
   } catch {
     return null;
   }
@@ -301,20 +307,24 @@ export class DevPreviewSessionService {
    * We rebuild the expected subdomain per session and match on equality — avoiding any
    * ambiguous split of a label whose sanitized tokens may themselves contain hyphens.
    */
-  getUpstreamPortForSubdomain(subdomain: string): number | null {
+  getUpstreamPortForSubdomain(subdomain: string): { port: number; isHttps: boolean } | null {
     for (const session of this.sessions.values()) {
       if (buildDevPreviewSubdomain(session.projectId, session.panelId) !== subdomain) continue;
       // Only forward to a live server. After an explicit stop the registry entry lingers
       // (the success path doesn't release it), so a stale port could otherwise be handed to
       // whatever process later binds it.
       if (!RUNNING_STATES.has(session.status)) return null;
-      // Prefer the port the dev server actually bound — UrlDetector overwrites session.url
-      // when the server lands on a different port than the one allocated (a command that
-      // ignores the injected PORT). Fall back to the allocated port while still starting,
-      // before any URL has been detected.
-      const detectedPort = parseUrlPort(session.url);
-      if (detectedPort !== null) return detectedPort;
-      return this.portRegistry.get(createSessionKey(session.projectId, session.panelId)) ?? null;
+      // Prefer the port AND scheme the dev server actually bound — UrlDetector overwrites
+      // session.url when the server lands on a different port than the one allocated (a command
+      // that ignores the injected PORT), and the URL carries the scheme (http vs https) so an
+      // HTTPS dev server is dialed over TLS instead of getting a 502 (#9974). Fall back to the
+      // allocated port (always plain HTTP) while still starting, before any URL has been detected.
+      const detected = parseUrlEndpoint(session.url);
+      if (detected !== null) return detected;
+      const fallbackPort = this.portRegistry.get(
+        createSessionKey(session.projectId, session.panelId)
+      );
+      return fallbackPort !== undefined ? { port: fallbackPort, isHttps: false } : null;
     }
     return null;
   }

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -141,8 +141,15 @@ function parseUrlEndpoint(url: string | null): { port: number; isHttps: boolean 
   if (!url) return null;
   try {
     const parsed = new URL(url);
-    if (!parsed.port) return null;
-    return { port: Number(parsed.port), isHttps: parsed.protocol === "https:" };
+    const isHttps = parsed.protocol === "https:";
+    if (!isHttps && parsed.protocol !== "http:") return null;
+    // WHATWG URL strips the port when it equals the scheme default, so `https://localhost/` and
+    // `https://localhost:443/` both surface an empty `parsed.port`. Fall back to the scheme's
+    // default port rather than discarding the endpoint (which would otherwise dial the wrong port
+    // over plain HTTP via the registry fallback).
+    const port = parsed.port ? Number(parsed.port) : isHttps ? 443 : 80;
+    if (!Number.isInteger(port) || port <= 0) return null;
+    return { port, isHttps };
   } catch {
     return null;
   }

--- a/electron/services/__tests__/DevPreviewProxyService.test.ts
+++ b/electron/services/__tests__/DevPreviewProxyService.test.ts
@@ -1,10 +1,72 @@
 import http from "node:http";
+import https from "node:https";
 import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket, WebSocketServer } from "ws";
 import { DevPreviewProxyService } from "../DevPreviewProxyService.js";
 
+// A self-signed cert/key for `localhost`, valid for 100 years, used to stand up a real TLS
+// upstream so the proxy's HTTPS path (#9974) is exercised end-to-end. The proxy dials with
+// `secure: false`, so cert validity is never checked on the proxy→upstream leg — the only
+// requirement is that https.createServer accepts the pair. Static so the test needs no openssl
+// or extra dependency at run time.
+const TLS_CERT = `-----BEGIN CERTIFICATE-----
+MIIDJzCCAg+gAwIBAgIUd5lHuFW2jPIhjMPtLtk+qyD6nV4wDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MCAXDTI2MDYwNjE4NTUxOFoYDzIxMjYw
+NTEzMTg1NTE4WjAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQDKUZfRfHBM/L/qO8t1YUyiXytEb2K7CiyeNjtg1P3v
+O31d9yJez1S5h8Bsdf0/aGmKh8awxTA712A7D3xeioPYPCgzogeGhlXLIlMvEMDM
+mcP9dCJdEeqeWxFpJBDmMtQ6ye3OGGdYAd5WXJ38uGpcbifiL1xnPM3czft0efWD
+JklK7ou0QZhiliVLuDTJSb/KE5tSCo9HV4ognxyY1BEk25HgQT6YsGtJBgtG1QW4
+swzdRGCbbbTdSBE0Vf0c/C66VwReSmPaqyiQytxNtjuF/CjmtXUkselRoiPPileF
+/kUsOQJPo/T+eE7XlqPYZo8oeH2jX0+TYYERJ5ktrS3vAgMBAAGjbzBtMB0GA1Ud
+DgQWBBRP0Q6ccyHBJCBvkQwvMXKmvVIEgDAfBgNVHSMEGDAWgBRP0Q6ccyHBJCBv
+kQwvMXKmvVIEgDAPBgNVHRMBAf8EBTADAQH/MBoGA1UdEQQTMBGCCWxvY2FsaG9z
+dIcEfwAAATANBgkqhkiG9w0BAQsFAAOCAQEAuEPF9RQD1gSDulkRHe+Yosm5dCvv
+JM8oz+h/QFPSboEaDc/+IGFGzQoVNiAqoJJnFMT2N/Fr/c5rAG7pn9JlFR5ZGskM
+aMBfUDUZ3sNDRGW4Ck7hCpNM4P6Ng40STy68QoChIW+HJUyFPOmnSQCTg0pAGYtD
+ctdDEYvgjudRbtc77vJH1eB79mnyHStg+KbrKkvP5KKDfJIx9xUbc61sEomFlSqw
+CqQ2POpyTKAVRq4DynrN19R5FgRg9fjze0+k6iRc9nReB/As7XD3KA04qFXTpuIB
+8aUneA5Et8htP8zGKtPvZ2seWZobUf5GxFX3RYl+CFEMDSifjmq68BKnVQ==
+-----END CERTIFICATE-----
+`;
+const TLS_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDKUZfRfHBM/L/q
+O8t1YUyiXytEb2K7CiyeNjtg1P3vO31d9yJez1S5h8Bsdf0/aGmKh8awxTA712A7
+D3xeioPYPCgzogeGhlXLIlMvEMDMmcP9dCJdEeqeWxFpJBDmMtQ6ye3OGGdYAd5W
+XJ38uGpcbifiL1xnPM3czft0efWDJklK7ou0QZhiliVLuDTJSb/KE5tSCo9HV4og
+nxyY1BEk25HgQT6YsGtJBgtG1QW4swzdRGCbbbTdSBE0Vf0c/C66VwReSmPaqyiQ
+ytxNtjuF/CjmtXUkselRoiPPileF/kUsOQJPo/T+eE7XlqPYZo8oeH2jX0+TYYER
+J5ktrS3vAgMBAAECggEAPP9ypW8+MIf3mLhkdERcpYvJ8L0gaEH+B8lUB7LPyMQH
+3T+4dhtOcQ1zv3+nVem2AFVFW2BoVXJvCf92QM7ER3qDqGWOnUl9Llxv9f24Eze8
+9nqALc1MDmhojGmaSr1CbWMaNov3BHqzvRf5bgtvzeRMVA5xbpLPgmX8DTcEBYEJ
+TIgUZJwbIC7HE00fQkRl2JUewG40HHxhKi4V933C71D9RzveZ8PBEfbADf8+QSiM
+PxceeGqmtE47dCqMGiYzZaO6Q5fgUKGnDJ/+saoZta5lpCRPLE23Kz9B0OVZxUuD
+H5zqTYyhWZxwMCLN+nPaChcZezvizC7OO7m2q2MpMQKBgQDpI6e6N9Ub1pR4epHV
+4E0rVJ/ZYqHFxnuJND6TfLVMU2InazVvfW8GaC6rPgR1+3TeKVOLrCV80qM4R2s6
+cHZ2slQE4UTKKNrWMlIMZfRVd1gI4Ht6SgyS1qCbcjOHLEp0LsayxV2Wz/ysotbK
+zGqZtvuugN9KD+PIIKA3ggtjpwKBgQDeKET0HywPJESkVGfh8XozdOHunRzU0W1Z
+kyhyVqWByENyJnchFagFibAUN+6nwTJzr5vRxDbhzmLGNi8TGLO4DyzBv5AM+LkY
+dutnptzk9XCowZk6rlMMIDQ3WRZcikwSP5ZHKho6SjzZ0bnSXv8MhNeZJG0AZSPa
+do+DSk7MeQKBgQDMaPOlpVBXcSOKIsV9BYYDqNXibsUyN92WpdT70YrQGgfkUe5v
+C0ZuEqhggia9HzUPmKJkwxG3SKPNM2lDutlTJvXdtXlv2rRMu6AOuNGqodHxLol0
+5jnyAPaedFnTebTp+x1CHyP4l/GNl9TFyMbqcXJoRRwBvr7TeC+hm4bK3wKBgDHh
+gtH5adAgiZUIKqcNrC1/kfccqcuTFmVlaFB76f+A8rvfrSHtleNgbfusL1bVRzm4
+dVkdIGGFEKKGqf00r62lIpyCIZr4Ab9ffC2yxqhV/6y0g24slBMF7BN9Wkr+9mOm
+iVyDNI5f+tfBgmKc19F8xlfpWNwc2XcE5eZJufWpAoGAAUl4oGptD1l4cM15Jt3O
+2GTUNwI14gU/+A/Ht0tFz4L0L059PrE0e+5tpPPH6YHDQQBCQywSSYz6a4hnOovA
+eKhMdxcFUL4ump1TiBK9mci/EeN5QPFQ5MirHkPgm5Hqi/4MK3pbF+yWHHNuKN1v
++gRGPjjegyhNAcadNKTocko=
+-----END PRIVATE KEY-----
+`;
+
 function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve((server.address() as AddressInfo).port));
+  });
+}
+
+function listenTls(server: https.Server): Promise<number> {
   return new Promise((resolve) => {
     server.listen(0, "127.0.0.1", () => resolve((server.address() as AddressInfo).port));
   });
@@ -89,6 +151,7 @@ function splitBootstrapUrl(bootstrapUrl: string): { host: string; path: string }
 describe("DevPreviewProxyService", () => {
   let proxy: DevPreviewProxyService | null = null;
   let upstream: http.Server | null = null;
+  let tlsUpstream: https.Server | null = null;
   let wss: WebSocketServer | null = null;
 
   afterEach(() => {
@@ -96,6 +159,8 @@ describe("DevPreviewProxyService", () => {
     proxy = null;
     upstream?.close();
     upstream = null;
+    tlsUpstream?.close();
+    tlsUpstream = null;
     wss?.close();
     wss = null;
   });
@@ -109,7 +174,9 @@ describe("DevPreviewProxyService", () => {
     });
     const upstreamPort = await listen(upstream);
 
-    proxy = new DevPreviewProxyService((sub) => (sub === "dp-test" ? upstreamPort : null));
+    proxy = new DevPreviewProxyService((sub) =>
+      sub === "dp-test" ? { port: upstreamPort, isHttps: false } : null
+    );
     const proxyPort = await proxy.start();
 
     const res = await request(proxyPort, `dp-test.localhost:${proxyPort}`);
@@ -135,7 +202,9 @@ describe("DevPreviewProxyService", () => {
       // Sanity-check the fixture: the old 127.0.0.1 upstream target can't reach this server.
       await expectIpv4Refused(upstreamPort);
 
-      proxy = new DevPreviewProxyService((sub) => (sub === "dp-test" ? upstreamPort : null));
+      proxy = new DevPreviewProxyService((sub) =>
+        sub === "dp-test" ? { port: upstreamPort, isHttps: false } : null
+      );
       const proxyPort = await proxy.start();
 
       const res = await request(proxyPort, `dp-test.localhost:${proxyPort}`);
@@ -161,7 +230,7 @@ describe("DevPreviewProxyService", () => {
         socket.on("message", (msg) => socket.send(`echo:${msg}`));
       });
 
-      proxy = new DevPreviewProxyService(() => upstreamPort);
+      proxy = new DevPreviewProxyService(() => ({ port: upstreamPort, isHttps: false }));
       const proxyPort = await proxy.start();
 
       const client = new WebSocket(`ws://127.0.0.1:${proxyPort}/`, {
@@ -178,6 +247,55 @@ describe("DevPreviewProxyService", () => {
     }
   );
 
+  it("forwards an HTTP request to an HTTPS (TLS) upstream with a self-signed cert (#9974)", async () => {
+    let seenHost: string | undefined;
+    tlsUpstream = https.createServer({ cert: TLS_CERT, key: TLS_KEY }, (req, res) => {
+      seenHost = req.headers.host;
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end("hello over tls");
+    });
+    const upstreamPort = await listenTls(tlsUpstream);
+
+    proxy = new DevPreviewProxyService((sub) =>
+      sub === "dp-test" ? { port: upstreamPort, isHttps: true } : null
+    );
+    const proxyPort = await proxy.start();
+
+    const res = await request(proxyPort, `dp-test.localhost:${proxyPort}`);
+
+    // Without the isHttps fix the proxy dials http:// against a TLS socket and 502s. The fix
+    // dials https:// with secure:false, so the self-signed cert is accepted and the request lands.
+    expect(res.status).toBe(200);
+    expect(res.body).toBe("hello over tls");
+    expect(seenHost).toContain("localhost");
+    expect(seenHost).toContain(String(upstreamPort));
+  });
+
+  it("forwards a WebSocket upgrade to a WSS (TLS) upstream with a self-signed cert (#9974)", async () => {
+    tlsUpstream = https.createServer({ cert: TLS_CERT, key: TLS_KEY });
+    const upstreamPort = await listenTls(tlsUpstream);
+    wss = new WebSocketServer({ server: tlsUpstream });
+    wss.on("connection", (socket) => {
+      socket.on("message", (msg) => socket.send(`echo:${msg}`));
+    });
+
+    proxy = new DevPreviewProxyService(() => ({ port: upstreamPort, isHttps: true }));
+    const proxyPort = await proxy.start();
+
+    const client = new WebSocket(`ws://127.0.0.1:${proxyPort}/`, {
+      headers: { host: `dp-test.localhost:${proxyPort}` },
+    });
+    const reply = await new Promise<string>((resolve, reject) => {
+      client.on("open", () => client.send("ping"));
+      client.on("message", (data) => resolve(data.toString()));
+      client.on("error", reject);
+    });
+    client.close();
+
+    // The upgrade must target wss:// (not http://) so the HMR socket reaches the TLS upstream.
+    expect(reply).toBe("echo:ping");
+  });
+
   it("strips the Domain attribute from upstream Set-Cookie headers", async () => {
     upstream = http.createServer((_req, res) => {
       res.writeHead(200, { "Set-Cookie": "sid=abc; Domain=localhost; Path=/" });
@@ -185,7 +303,7 @@ describe("DevPreviewProxyService", () => {
     });
     const upstreamPort = await listen(upstream);
 
-    proxy = new DevPreviewProxyService(() => upstreamPort);
+    proxy = new DevPreviewProxyService(() => ({ port: upstreamPort, isHttps: false }));
     const proxyPort = await proxy.start();
 
     const res = await request(proxyPort, `dp-test.localhost:${proxyPort}`);
@@ -207,7 +325,7 @@ describe("DevPreviewProxyService", () => {
     });
     const upstreamPort = await listen(upstream);
 
-    proxy = new DevPreviewProxyService(() => upstreamPort);
+    proxy = new DevPreviewProxyService(() => ({ port: upstreamPort, isHttps: false }));
     const proxyPort = await proxy.start();
 
     const res = await request(proxyPort, `dp-test.localhost:${proxyPort}`);
@@ -230,7 +348,7 @@ describe("DevPreviewProxyService", () => {
   });
 
   it("returns 502 for a host that is not a dev-preview proxy subdomain", async () => {
-    proxy = new DevPreviewProxyService(() => 9999);
+    proxy = new DevPreviewProxyService(() => ({ port: 9999, isHttps: false }));
     const proxyPort = await proxy.start();
 
     const res = await request(proxyPort, "example.com");
@@ -239,7 +357,7 @@ describe("DevPreviewProxyService", () => {
 
   it("returns 502 when the upstream is unreachable", async () => {
     // Resolve to a port nothing is listening on.
-    proxy = new DevPreviewProxyService(() => 1);
+    proxy = new DevPreviewProxyService(() => ({ port: 1, isHttps: false }));
     const proxyPort = await proxy.start();
 
     const res = await request(proxyPort, `dp-test.localhost:${proxyPort}`);
@@ -263,7 +381,7 @@ describe("DevPreviewProxyService", () => {
       socket.on("message", (msg) => socket.send(`echo:${msg}`));
     });
 
-    proxy = new DevPreviewProxyService(() => upstreamPort);
+    proxy = new DevPreviewProxyService(() => ({ port: upstreamPort, isHttps: false }));
     const proxyPort = await proxy.start();
 
     // Node doesn't map *.localhost to loopback (only Chromium does), so connect to the loopback
@@ -291,7 +409,7 @@ describe("DevPreviewProxyService", () => {
       socket.send("ok");
     });
 
-    proxy = new DevPreviewProxyService(() => upstreamPort);
+    proxy = new DevPreviewProxyService(() => ({ port: upstreamPort, isHttps: false }));
     const proxyPort = await proxy.start();
 
     const client = new WebSocket(`ws://127.0.0.1:${proxyPort}/@vite/client?t=123`, {

--- a/electron/services/__tests__/DevPreviewProxyService.test.ts
+++ b/electron/services/__tests__/DevPreviewProxyService.test.ts
@@ -296,6 +296,31 @@ describe("DevPreviewProxyService", () => {
     expect(reply).toBe("echo:ping");
   });
 
+  it("preserves the request path and query string on a WSS (TLS) upgrade (#9974)", async () => {
+    let seenUrl: string | undefined;
+    tlsUpstream = https.createServer({ cert: TLS_CERT, key: TLS_KEY });
+    const upstreamPort = await listenTls(tlsUpstream);
+    wss = new WebSocketServer({ server: tlsUpstream });
+    wss.on("connection", (socket, req) => {
+      seenUrl = req.url;
+      socket.send("ok");
+    });
+
+    proxy = new DevPreviewProxyService(() => ({ port: upstreamPort, isHttps: true }));
+    const proxyPort = await proxy.start();
+
+    const client = new WebSocket(`ws://127.0.0.1:${proxyPort}/@vite/client?t=123`, {
+      headers: { host: `dp-test.localhost:${proxyPort}` },
+    });
+    await new Promise<void>((resolve, reject) => {
+      client.on("message", () => resolve());
+      client.on("error", reject);
+    });
+    client.close();
+
+    expect(seenUrl).toBe("/@vite/client?t=123");
+  });
+
   it("strips the Domain attribute from upstream Set-Cookie headers", async () => {
     upstream = http.createServer((_req, res) => {
       res.writeHead(200, { "Set-Cookie": "sid=abc; Domain=localhost; Path=/" });

--- a/electron/services/__tests__/DevPreviewSessionService.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.test.ts
@@ -1649,6 +1649,21 @@ describe("DevPreviewSessionService", () => {
       });
     });
 
+    it("resolves the scheme-default port when an HTTPS URL omits the port (#9974)", async () => {
+      // WHATWG URL strips the default port, so `https://localhost/` surfaces an empty port — the
+      // resolver must still dial 443 over HTTPS rather than falling back to the wrong port/scheme.
+      const started = await service.ensure(baseRequest);
+      ptyClient.emitData(started.terminalId!, "ready at https://localhost/\n");
+
+      const subdomain = buildDevPreviewSubdomain(baseRequest.projectId, baseRequest.panelId);
+      await vi.waitFor(() => {
+        expect(service.getUpstreamPortForSubdomain(subdomain)).toEqual({
+          port: 443,
+          isHttps: true,
+        });
+      });
+    });
+
     it("returns null once the session is stopped even though the registry entry lingers", async () => {
       vi.spyOn(portAllocator, "allocatePort").mockImplementation(
         async (registry: Map<string, number>, key: string) => {

--- a/electron/services/__tests__/DevPreviewSessionService.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.test.ts
@@ -1601,7 +1601,7 @@ describe("DevPreviewSessionService", () => {
   });
 
   describe("getUpstreamPortForSubdomain (#9100)", () => {
-    it("resolves a panel's proxy subdomain to its allocated upstream port", async () => {
+    it("resolves a panel's proxy subdomain to its allocated upstream port (plain HTTP fallback)", async () => {
       vi.spyOn(portAllocator, "allocatePort").mockImplementation(
         async (registry: Map<string, number>, key: string) => {
           registry.set(key, 4321);
@@ -1612,11 +1612,41 @@ describe("DevPreviewSessionService", () => {
       await service.ensure(baseRequest);
 
       const subdomain = buildDevPreviewSubdomain(baseRequest.projectId, baseRequest.panelId);
-      expect(service.getUpstreamPortForSubdomain(subdomain)).toBe(4321);
+      // Before any URL is detected the allocated port is used with the safe plain-HTTP default.
+      expect(service.getUpstreamPortForSubdomain(subdomain)).toEqual({
+        port: 4321,
+        isHttps: false,
+      });
     });
 
     it("returns null for an unknown subdomain", () => {
       expect(service.getUpstreamPortForSubdomain("dp-nope-nope")).toBeNull();
+    });
+
+    it("returns the detected port with isHttps:true for an HTTPS dev server (#9974)", async () => {
+      const started = await service.ensure(baseRequest);
+      ptyClient.emitData(started.terminalId!, "ready at https://localhost:8443\n");
+
+      const subdomain = buildDevPreviewSubdomain(baseRequest.projectId, baseRequest.panelId);
+      await vi.waitFor(() => {
+        expect(service.getUpstreamPortForSubdomain(subdomain)).toEqual({
+          port: 8443,
+          isHttps: true,
+        });
+      });
+    });
+
+    it("returns the detected port with isHttps:false for an HTTP dev server (#9974)", async () => {
+      const started = await service.ensure(baseRequest);
+      ptyClient.emitData(started.terminalId!, "ready at http://localhost:5173\n");
+
+      const subdomain = buildDevPreviewSubdomain(baseRequest.projectId, baseRequest.panelId);
+      await vi.waitFor(() => {
+        expect(service.getUpstreamPortForSubdomain(subdomain)).toEqual({
+          port: 5173,
+          isHttps: false,
+        });
+      });
     });
 
     it("returns null once the session is stopped even though the registry entry lingers", async () => {
@@ -1629,7 +1659,10 @@ describe("DevPreviewSessionService", () => {
 
       await service.ensure(baseRequest);
       const subdomain = buildDevPreviewSubdomain(baseRequest.projectId, baseRequest.panelId);
-      expect(service.getUpstreamPortForSubdomain(subdomain)).toBe(4321);
+      expect(service.getUpstreamPortForSubdomain(subdomain)).toEqual({
+        port: 4321,
+        isHttps: false,
+      });
 
       await service.stop({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
 


### PR DESCRIPTION
## Summary

- The dev-preview reverse proxy was hardcoding `http://` when connecting to the upstream dev server, so any dev server running over TLS (Vite `server.https`, Next.js `--experimental-https`, mkcert) returned 502s.
- Fixed by threading the upstream scheme through the resolver contract — `ResolveUpstream` (renamed from `ResolveUpstreamPort`) now returns `{ port, isHttps }`, and `DevPreviewProxyService` dials `https://` / `wss://` with `secure: false` for self-signed loopback certs, mirroring what `DevPreviewReadinessProbe` was already doing.
- `parseUrlEndpoint` is a new helper that extracts the scheme from `session.url` with a scheme-default-port fallback for bare `https://localhost/` URLs; the pre-detection registry path defaults to plain HTTP.

Resolves #9974

## Changes

- `DevPreviewSessionService`: renamed `ResolveUpstreamPort` → `ResolveUpstream` returning `{ port, isHttps }`; added `parseUrlEndpoint` helper with scheme-default-port fallback.
- `DevPreviewProxyService`: dials `https://` (web) / `wss://` (ws) with `secure: false` when `isHttps` — loopback-scoped, upstream host is always `localhost`.
- Tests: real TLS-upstream integration tests (https web-forward, wss upgrade, wss path preservation) using an embedded static self-signed localhost cert; scheme-extraction unit tests for the `parseUrlEndpoint` helper.

## Testing

All 99 dev-preview tests pass. `npm run check` and `npm run build` clean.