### PR TITLE
fix(context): populate test-config file preview and drop dead exclusion counters

### DIFF
--- a/electron/services/CopyTreeService.ts
+++ b/electron/services/CopyTreeService.ts
@@ -222,7 +222,7 @@ class CopyTreeService {
           bySize: 0,
           byPattern: 0,
         },
-        files: undefined,
+        files: result.manifest ?? [],
       };
     } catch (error: unknown) {
       if (error instanceof Error && error.name === "AbortError") {

--- a/electron/services/__tests__/CopyTreeService.test.ts
+++ b/electron/services/__tests__/CopyTreeService.test.ts
@@ -24,6 +24,7 @@ describe("CopyTreeService", () => {
     configCreateMock.mockResolvedValue(undefined);
     copyMock.mockResolvedValue({
       output: "<context />",
+      manifest: [],
       stats: {
         totalFiles: 1,
         totalSize: 10,
@@ -209,6 +210,79 @@ describe("CopyTreeService", () => {
     await expect(second).resolves.toEqual(
       expect.objectContaining({ error: "Context generation cancelled" })
     );
+  });
+
+  describe("testConfig", () => {
+    it("returns files populated from the SDK manifest", async () => {
+      const manifest = [
+        { path: "src/index.ts", size: 1024 },
+        { path: "src/utils.ts", size: 512 },
+        { path: "README.md", size: 256 },
+      ];
+      copyMock.mockResolvedValue({
+        output: "",
+        manifest,
+        stats: {
+          totalFiles: manifest.length,
+          totalSize: manifest.reduce((sum, entry) => sum + entry.size, 0),
+          duration: 5,
+          dryRun: true,
+        },
+      });
+
+      const result = await copyTreeService.testConfig(tempDir);
+
+      expect(result.error).toBeUndefined();
+      expect(result.files).toHaveLength(manifest.length);
+      for (const [index, entry] of manifest.entries()) {
+        expect(result.files?.[index]).toEqual({ path: entry.path, size: entry.size });
+      }
+    });
+
+    it("maps stats onto includedFiles and includedSize", async () => {
+      const stats = { totalFiles: 7, totalSize: 4096, duration: 5, dryRun: true };
+      copyMock.mockResolvedValue({ output: "", manifest: [], stats });
+
+      const result = await copyTreeService.testConfig(tempDir);
+
+      expect(result.includedFiles).toBe(stats.totalFiles);
+      expect(result.includedSize).toBe(stats.totalSize);
+    });
+
+    it("returns an empty files array when the manifest is empty", async () => {
+      const result = await copyTreeService.testConfig(tempDir);
+
+      expect(result.error).toBeUndefined();
+      expect(result.files).toEqual([]);
+    });
+
+    it("returns an empty files array when the SDK omits the manifest", async () => {
+      copyMock.mockResolvedValue({
+        output: "",
+        stats: { totalFiles: 0, totalSize: 0, duration: 5, dryRun: true },
+      });
+
+      const result = await copyTreeService.testConfig(tempDir);
+
+      expect(result.error).toBeUndefined();
+      expect(result.files).toEqual([]);
+    });
+
+    it("runs the SDK in dry-run mode", async () => {
+      await copyTreeService.testConfig(tempDir);
+
+      expect(copyMock).toHaveBeenCalledTimes(1);
+      const sdkOptions = copyMock.mock.calls[0][1] as Record<string, unknown>;
+      expect(sdkOptions.dryRun).toBe(true);
+    });
+
+    it("rejects non-absolute root paths without files", async () => {
+      const result = await copyTreeService.testConfig("relative/path");
+
+      expect(result.error).toContain("absolute path");
+      expect(result.files).toBeUndefined();
+      expect(copyMock).not.toHaveBeenCalled();
+    });
   });
 
   it("omits config from sdkOptions when ConfigManager.create() fails", async () => {

--- a/src/components/Project/ContextTab.tsx
+++ b/src/components/Project/ContextTab.tsx
@@ -17,6 +17,8 @@ function formatBytes(bytes: number): string {
   return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + " " + sizes[i];
 }
 
+const FILE_PREVIEW_COUNT = 10;
+
 function parsePositiveInt(value: string): number | undefined {
   if (!value) return undefined;
   const num = Number(value);
@@ -43,6 +45,7 @@ export function ContextTab({
 }: ContextTabProps) {
   const [testConfigResult, setTestConfigResult] = useState<CopyTreeTestConfigResult | null>(null);
   const [isTestingConfig, setIsTestingConfig] = useState(false);
+  const [showAllFiles, setShowAllFiles] = useState(false);
 
   const testingSkeletonGate = useSkeletonGate(isTestingConfig);
   const showTestingSkeleton = useSkeletonFloor(testingSkeletonGate);
@@ -75,6 +78,7 @@ export function ContextTab({
     const runId = ++runIdRef.current;
     setIsTestingConfig(true);
     setTestConfigResult(null);
+    setShowAllFiles(false);
 
     try {
       // Send the complete form state so the dry run reflects exactly what is
@@ -459,20 +463,42 @@ export function ContextTab({
                         ({formatBytes(testConfigResult.includedSize)})
                       </span>
                     </div>
-                    <div className="text-xs text-daintree-text/60 space-y-1">
-                      <p>
-                        Excluded by pattern:{" "}
-                        <span className="font-mono">{testConfigResult.excluded.byPattern}</span>
-                      </p>
-                      <p>
-                        Excluded by size:{" "}
-                        <span className="font-mono">{testConfigResult.excluded.bySize}</span>
-                      </p>
-                      <p>
-                        Excluded by truncation:{" "}
-                        <span className="font-mono">{testConfigResult.excluded.byTruncation}</span>
-                      </p>
-                    </div>
+                    {testConfigResult.files && testConfigResult.files.length > 0 && (
+                      <div className="space-y-1">
+                        <ul className="max-h-60 overflow-y-auto space-y-1">
+                          {(showAllFiles
+                            ? testConfigResult.files
+                            : testConfigResult.files.slice(0, FILE_PREVIEW_COUNT)
+                          ).map((file) => (
+                            <li
+                              key={file.path}
+                              className="flex items-center justify-between gap-2 text-xs"
+                            >
+                              <span
+                                className="font-mono text-daintree-text/80 truncate"
+                                title={file.path}
+                              >
+                                {file.path}
+                              </span>
+                              <span className="text-daintree-text/40 shrink-0">
+                                {formatBytes(file.size)}
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                        {testConfigResult.files.length > FILE_PREVIEW_COUNT && (
+                          <button
+                            type="button"
+                            onClick={() => setShowAllFiles((value) => !value)}
+                            className="text-xs text-daintree-text/60 hover:text-daintree-text transition-colors"
+                          >
+                            {showAllFiles
+                              ? "Show fewer"
+                              : `Show ${testConfigResult.files.length - FILE_PREVIEW_COUNT} more`}
+                          </button>
+                        )}
+                      </div>
+                    )}
                   </div>
                 )}
               </div>

--- a/src/components/Project/ContextTab.tsx
+++ b/src/components/Project/ContextTab.tsx
@@ -12,7 +12,7 @@ import { logError } from "@/utils/logger";
 function formatBytes(bytes: number): string {
   if (bytes === 0) return "0 B";
   const k = 1024;
-  const sizes = ["B", "KB", "MB", "GB"];
+  const sizes = ["B", "KB", "MB", "GB", "TB"];
   const i = Math.floor(Math.log(bytes) / Math.log(k));
   return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + " " + sizes[i];
 }

--- a/src/components/Project/__tests__/ContextTab.test.tsx
+++ b/src/components/Project/__tests__/ContextTab.test.tsx
@@ -277,6 +277,99 @@ describe("ContextTab test-config payload", () => {
   });
 });
 
+describe("ContextTab file-list preview", () => {
+  function makeFiles(count: number) {
+    return Array.from({ length: count }, (_, i) => ({
+      path: `src/file-${String(i).padStart(2, "0")}.ts`,
+      size: 100 + i,
+    }));
+  }
+
+  function resultWithFiles(files: Array<{ path: string; size: number }>): CopyTreeTestConfigResult {
+    return {
+      includedFiles: files.length,
+      includedSize: files.reduce((sum, file) => sum + file.size, 0),
+      excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
+      files,
+    };
+  }
+
+  async function runTestConfig() {
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Test config" }));
+    });
+  }
+
+  it("shows the first 10 files with a show-more toggle when more exist", async () => {
+    testConfigMock.mockResolvedValue(resultWithFiles(makeFiles(12)));
+    renderTab();
+
+    await runTestConfig();
+    await waitFor(() => {
+      expect(screen.getByText("12 files would be included")).toBeTruthy();
+    });
+
+    expect(screen.getByText("src/file-09.ts")).toBeTruthy();
+    expect(screen.queryByText("src/file-10.ts")).toBeNull();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Show 2 more" }));
+    });
+
+    expect(screen.getByText("src/file-10.ts")).toBeTruthy();
+    expect(screen.getByText("src/file-11.ts")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Show fewer" })).toBeTruthy();
+  });
+
+  it("renders all files without a toggle when at the preview cap", async () => {
+    testConfigMock.mockResolvedValue(resultWithFiles(makeFiles(10)));
+    renderTab();
+
+    await runTestConfig();
+    await waitFor(() => {
+      expect(screen.getByText("10 files would be included")).toBeTruthy();
+    });
+
+    expect(screen.getByText("src/file-00.ts")).toBeTruthy();
+    expect(screen.getByText("src/file-09.ts")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /show \d+ more/i })).toBeNull();
+  });
+
+  it("renders the summary without a file list when files is empty", async () => {
+    testConfigMock.mockResolvedValue(resultWithFiles([]));
+    renderTab();
+
+    await runTestConfig();
+    await waitFor(() => {
+      expect(screen.getByText("0 files would be included")).toBeTruthy();
+    });
+
+    expect(screen.queryByRole("list")).toBeNull();
+  });
+
+  it("collapses the expanded list when a new test run starts", async () => {
+    testConfigMock.mockResolvedValue(resultWithFiles(makeFiles(12)));
+    renderTab();
+
+    await runTestConfig();
+    await waitFor(() => {
+      expect(screen.getByText("12 files would be included")).toBeTruthy();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Show 2 more" }));
+    });
+    expect(screen.getByText("src/file-11.ts")).toBeTruthy();
+
+    await runTestConfig();
+    await waitFor(() => {
+      expect(screen.getByText("12 files would be included")).toBeTruthy();
+    });
+
+    expect(screen.queryByText("src/file-10.ts")).toBeNull();
+    expect(screen.getByRole("button", { name: "Show 2 more" })).toBeTruthy();
+  });
+});
+
 describe("ContextTab — DOM anchors for settings deep-links", () => {
   it("exposes the project-excluded-paths anchor for settings deep-links", () => {
     const { container } = renderTab();


### PR DESCRIPTION
## Summary

- The test config preview in `ContextTab` was showing three exclusion counters that were hardcoded to zero in `CopyTreeService.testConfig()` — the copytree v0.14.2 dry-run path bypasses the pipeline stage machinery entirely, so these could never be populated without SDK changes.
- The file list was never rendered even though the IPC contract declares `files?: Array<{path,size}>` and the SDK's dry-run already returns `CopyResult.manifest` with exactly that shape.
- `formatBytes` had a latent overflow: sizes ≥1 TB rendered as "1 undefined" (missing TB unit label).

Resolves #10002

## Changes

- `CopyTreeService.testConfig()` now returns `files: result.manifest ?? []`.
- `ContextTab` drops the three always-zero counters and renders the actual file list: first 10 entries with a "Show N more"/"Show fewer" toggle, path + formatted size per row, expansion state reset on each new test run.
- Fixed the missing `"TB"` entry in `formatBytes`.
- The `excluded` struct stays in the IPC contract — no breaking change, only the misleading UI rendering was removed.

## Testing

New unit tests cover:
- `CopyTreeService.testConfig()`: manifest→files mapping, stats mapping, empty/omitted manifest fallback, dry-run flag, non-absolute-path guard.
- `ContextTab` UI: preview cap at 10, toggle behaviour, boundary at exactly 10 files, empty-files case, collapse reset on re-run.

31 targeted vitest tests, typecheck, lint, format, channel/IPC/confirm guards, and build all green locally.