### PR TITLE
fix(quick-switcher): three MRU pipeline coordination defects (#9922)

### DIFF
--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -100,12 +100,19 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
     let focusPanelStateToUse = globalAppState.focusPanelState;
     // Active worktree state to include in response
     let activeWorktreeIdToUse = globalAppState.activeWorktreeId;
+    // Quick-switcher MRU: prefer per-project, fall back to the legacy global
+    // list so existing users keep their MRU on first open after upgrade.
+    let mruListToUse = globalAppState.mruList;
     let projectStateQuarantinedPath: string | undefined;
 
     if (projectId) {
       const { state: projectState, quarantinedPath } =
         await projectStore.getProjectStateWithRecovery(projectId);
       projectStateQuarantinedPath = quarantinedPath;
+      // undefined means "not migrated yet" — fall through to the global list.
+      if (projectState?.mruList !== undefined) {
+        mruListToUse = projectState.mruList;
+      }
       // Per-project state exists (even if empty) - use it as authoritative
       if (!hasCrashRestoreTerminals && projectState?.terminals !== undefined) {
         // Use per-project terminals, excluding trashed and normalizing location
@@ -348,6 +355,7 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
       activeWorktreeId: activeWorktreeIdToUse,
       focusMode: focusModeToUse,
       focusPanelState: focusPanelStateToUse,
+      mruList: mruListToUse,
     };
 
     console.log(
@@ -425,6 +433,7 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
   handlers.push(typedHandle(CHANNELS.APP_GET_STATE, handleAppGetState));
 
   const handleAppSetState = async (
+    ctx: IpcContext,
     incoming: Partial<import("../../../../shared/types/ipc/app.js").AppState>
   ) => {
     try {
@@ -577,7 +586,17 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
             sanitized.push(id);
           }
         }
-        updates.mruList = sanitized;
+        // Persist per-project so opening another project's view can't gut this
+        // list via the quick-switcher prune pass (#9922). Fall back to the
+        // legacy global write only when there's no resolvable project.
+        const mruProject = resolveProjectForHydration(ctx);
+        if (mruProject?.id) {
+          await projectStore.enqueueProjectStateUpdate(mruProject.id, (existing) =>
+            existing ? { ...existing, mruList: sanitized } : null
+          );
+        } else {
+          updates.mruList = sanitized;
+        }
       }
 
       if ("actionMruList" in partialState && Array.isArray(partialState.actionMruList)) {
@@ -707,7 +726,7 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
       console.error("Failed to set app state:", error);
     }
   };
-  handlers.push(typedHandle(CHANNELS.APP_SET_STATE, handleAppSetState));
+  handlers.push(typedHandleWithContext(CHANNELS.APP_SET_STATE, handleAppSetState));
 
   const handleAppGetVersion = async () => {
     return app.getVersion();

--- a/electron/services/AppHydrationService.ts
+++ b/electron/services/AppHydrationService.ts
@@ -28,9 +28,17 @@ export async function buildSwitchHydrateResult(projectId: string): Promise<Hydra
   let focusModeToUse = globalAppState.focusMode ?? false;
   let focusPanelStateToUse = globalAppState.focusPanelState;
   let activeWorktreeIdToUse = globalAppState.activeWorktreeId;
+  // Quick-switcher MRU: prefer per-project, fall back to the legacy global list
+  // so a switch can't serve the previous project's order (#9922).
+  let mruListToUse = globalAppState.mruList;
 
   const { state: projectState, quarantinedPath: projectStateQuarantinedPath } =
     await projectStore.getProjectStateWithRecovery(projectId);
+
+  // undefined means "not migrated yet" — fall through to the global list.
+  if (projectState?.mruList !== undefined) {
+    mruListToUse = projectState.mruList;
+  }
 
   if (projectState?.terminals !== undefined) {
     const validatedTerminals = filterValidTerminalEntries(
@@ -73,6 +81,7 @@ export async function buildSwitchHydrateResult(projectId: string): Promise<Hydra
     activeWorktreeId: activeWorktreeIdToUse,
     focusMode: focusModeToUse,
     focusPanelState: focusPanelStateToUse,
+    mruList: mruListToUse,
   };
 
   const gpuStatus = getGpuFeatureStatus();

--- a/electron/services/ProjectStateManager.ts
+++ b/electron/services/ProjectStateManager.ts
@@ -246,6 +246,9 @@ export class ProjectStateManager {
           !Array.isArray(parsed.draftInputs)
             ? parsed.draftInputs
             : undefined,
+        mruList: Array.isArray(parsed.mruList)
+          ? parsed.mruList.filter((id: unknown): id is string => typeof id === "string")
+          : undefined,
       };
 
       this.setProjectStateCache(projectId, state);

--- a/electron/services/__tests__/AppHydrationService.adversarial.test.ts
+++ b/electron/services/__tests__/AppHydrationService.adversarial.test.ts
@@ -17,6 +17,7 @@ const mockState = vi.hoisted(() => ({
     focusMode: true,
     focusPanelState: { sidebarWidth: 260, diagnosticsOpen: true },
     activeWorktreeId: "wt-global",
+    mruList: ["terminal:global-terminal"] as string[],
   },
   terminalConfig: { scrollback: 5000 },
   agentSettings: { defaultAgent: "codex" },
@@ -27,6 +28,7 @@ const mockState = vi.hoisted(() => ({
         activeWorktreeId?: string;
         focusMode?: boolean;
         focusPanelState?: { sidebarWidth: number; diagnosticsOpen: boolean };
+        mruList?: string[];
       }
     | undefined,
   projectStateQuarantinedPath: undefined as string | undefined,
@@ -119,6 +121,7 @@ describe("AppHydrationService adversarial", () => {
       focusMode: true,
       focusPanelState: { sidebarWidth: 260, diagnosticsOpen: true },
       activeWorktreeId: "wt-global",
+      mruList: ["terminal:global-terminal"],
     };
     mockState.terminalConfig = { scrollback: 5000 };
     mockState.agentSettings = { defaultAgent: "codex" };
@@ -157,6 +160,42 @@ describe("AppHydrationService adversarial", () => {
     expect(result.appState.activeWorktreeId).toBe("wt-global");
     expect(result.appState.focusMode).toBe(true);
     expect(result.appState.focusPanelState).toEqual({ sidebarWidth: 260, diagnosticsOpen: true });
+  });
+
+  it("serves the per-project mruList on switch, not the global list (#9922)", async () => {
+    mockState.projectState = {
+      terminals: [],
+      mruList: ["terminal:project-terminal", "worktree:wt-local"],
+    };
+
+    const { buildSwitchHydrateResult } = await import("../AppHydrationService.js");
+    const result = await buildSwitchHydrateResult("project-1");
+
+    expect(result.appState.mruList).toEqual(["terminal:project-terminal", "worktree:wt-local"]);
+  });
+
+  it("falls back to the global mruList when the project has none (migration)", async () => {
+    mockState.projectState = {
+      terminals: [],
+      // mruList intentionally undefined — not migrated yet.
+    };
+
+    const { buildSwitchHydrateResult } = await import("../AppHydrationService.js");
+    const result = await buildSwitchHydrateResult("project-1");
+
+    expect(result.appState.mruList).toEqual(["terminal:global-terminal"]);
+  });
+
+  it("treats an explicitly empty per-project mruList as authoritative (no global fallback)", async () => {
+    mockState.projectState = {
+      terminals: [],
+      mruList: [],
+    };
+
+    const { buildSwitchHydrateResult } = await import("../AppHydrationService.js");
+    const result = await buildSwitchHydrateResult("project-1");
+
+    expect(result.appState.mruList).toEqual([]);
   });
 
   it("CORRUPT_TERMINALS_FILTERED_NOT_FATAL", async () => {

--- a/electron/services/__tests__/ProjectStateManager.test.ts
+++ b/electron/services/__tests__/ProjectStateManager.test.ts
@@ -94,6 +94,30 @@ describe("ProjectStateManager clone isolation", () => {
     expect(result!.terminals[0].title).toBe("Terminal 1");
     expect(result!.sidebarWidth).toBe(350);
   });
+
+  it("round-trips mruList through disk so per-project MRU is read back (#9922)", async () => {
+    const state = makeState({ mruList: ["terminal:t1", "worktree:wt-2"] });
+    await manager.saveProjectState(projectId, state);
+
+    // Fresh manager forces a disk read (no in-memory cache) — proves the
+    // reconstruction whitelist actually rehydrates mruList rather than dropping it.
+    const freshManager = new ProjectStateManager(tempDir);
+    const result = await freshManager.getProjectState(projectId);
+    expect(result!.mruList).toEqual(["terminal:t1", "worktree:wt-2"]);
+  });
+
+  it("drops non-string mruList entries on read", async () => {
+    const state = makeState();
+    // Write a payload with a polluted mruList directly to disk.
+    await manager.saveProjectState(projectId, {
+      ...state,
+      mruList: ["terminal:t1", 42, null, "worktree:wt-2"] as unknown as string[],
+    });
+
+    const freshManager = new ProjectStateManager(tempDir);
+    const result = await freshManager.getProjectState(projectId);
+    expect(result!.mruList).toEqual(["terminal:t1", "worktree:wt-2"]);
+  });
 });
 
 describe("ProjectStateManager.enqueueProjectStateUpdate concurrency", () => {

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -190,6 +190,8 @@ export interface ProjectState {
   terminalSizes?: Record<string, { cols: number; rows: number }>;
   /** Hybrid input bar draft text per terminal ID (preserved across project switches) */
   draftInputs?: Record<string, string>;
+  /** Quick-switcher MRU list (terminal:/worktree: ids) — per-project so opening another project's view can't gut it */
+  mruList?: string[];
 }
 
 /** Recipe terminal type */

--- a/src/hooks/__tests__/useQuickSwitcher.test.tsx
+++ b/src/hooks/__tests__/useQuickSwitcher.test.tsx
@@ -141,4 +141,26 @@ describe("useQuickSwitcher MRU prune", () => {
 
     expect(pruneMru).toHaveBeenCalledWith(new Set(["terminal:t-1"]));
   });
+
+  it("protects terminal entries while panels are still hydrating (worktrees loaded first) (#9922)", () => {
+    // Worktrees populate before panels during hydration. Pruning terminal
+    // entries here — when zero terminal items exist yet — would drop the
+    // restored MRU order. The not-yet-hydrated category must be protected.
+    const pruneMru = vi.fn();
+    usePanelStore.setState({
+      panelsById: {},
+      panelIds: [],
+      mruList: ["terminal:t-1", "worktree:wt-1"],
+      pruneMru,
+    });
+    seedWorktreeState({
+      isInitialized: true,
+      worktrees: new Map([["wt-1", { id: "wt-1", name: "WT1", path: "/wt1" }]]),
+    });
+
+    renderHook(() => useQuickSwitcher());
+
+    // worktree:wt-1 is a live item; terminal:t-1 is protected (no terminal items yet).
+    expect(pruneMru).toHaveBeenCalledWith(new Set(["worktree:wt-1", "terminal:t-1"]));
+  });
 });

--- a/src/hooks/__tests__/useQuickSwitcher.test.tsx
+++ b/src/hooks/__tests__/useQuickSwitcher.test.tsx
@@ -93,3 +93,52 @@ describe("useQuickSwitcher isLoading", () => {
     expect(result.current.isLoading).toBe(false);
   });
 });
+
+describe("useQuickSwitcher MRU prune", () => {
+  beforeEach(() => {
+    usePanelStore.setState({ panelsById: {}, panelIds: [], mruList: [] });
+    useWorktreeStoreMock.mockReset();
+  });
+
+  it("does not prune while the item set is empty (panels still hydrating) (#9922)", () => {
+    // Panels and worktrees populate asynchronously; pruning against an empty
+    // item set here would gut the whole MRU list before this project's items load.
+    const pruneMru = vi.fn();
+    usePanelStore.setState({
+      panelsById: {},
+      panelIds: [],
+      mruList: ["terminal:t-1", "worktree:wt-1"],
+      pruneMru,
+    });
+    seedWorktreeState({ isInitialized: true });
+
+    renderHook(() => useQuickSwitcher());
+
+    expect(pruneMru).not.toHaveBeenCalled();
+  });
+
+  it("prunes against the current item set once items are present", () => {
+    const pruneMru = vi.fn();
+    usePanelStore.setState({
+      panelsById: {
+        "t-1": {
+          id: "t-1",
+          title: "T1",
+          kind: "terminal",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      },
+      panelIds: ["t-1"],
+      mruList: ["terminal:t-1", "terminal:gone"],
+      pruneMru,
+    });
+    seedWorktreeState({ isInitialized: true });
+
+    renderHook(() => useQuickSwitcher());
+
+    expect(pruneMru).toHaveBeenCalledWith(new Set(["terminal:t-1"]));
+  });
+});

--- a/src/hooks/useQuickSwitcher.ts
+++ b/src/hooks/useQuickSwitcher.ts
@@ -112,9 +112,13 @@ export function useQuickSwitcher(): UseQuickSwitcherReturn {
     return result;
   }, [panelIds, panelsById, worktrees, worktreeMap]);
 
-  // Prune stale MRU entries when item set or MRU list changes (e.g. after hydration)
+  // Prune stale MRU entries when item set or MRU list changes (e.g. after hydration).
+  // Bail while items is empty: panels and worktrees populate asynchronously during
+  // hydration, and pruning against an empty item set would gut the whole list before
+  // the current project's items have loaded (#9922).
   useEffect(() => {
     if (mruList.length === 0) return;
+    if (items.length === 0) return;
     const validIds = new Set(items.map((item) => item.id));
     pruneMru(validIds);
   }, [items, mruList, pruneMru]);

--- a/src/hooks/useQuickSwitcher.ts
+++ b/src/hooks/useQuickSwitcher.ts
@@ -113,13 +113,21 @@ export function useQuickSwitcher(): UseQuickSwitcherReturn {
   }, [panelIds, panelsById, worktrees, worktreeMap]);
 
   // Prune stale MRU entries when item set or MRU list changes (e.g. after hydration).
-  // Bail while items is empty: panels and worktrees populate asynchronously during
-  // hydration, and pruning against an empty item set would gut the whole list before
-  // the current project's items have loaded (#9922).
+  // Panels and worktrees populate asynchronously during hydration, so a category
+  // can be momentarily empty while the other has loaded. Pruning a category before
+  // it has hydrated would gut the restored MRU order before it can be used — so only
+  // prune a category (terminal:/worktree:) once at least one of its items exists,
+  // protecting the not-yet-loaded category's entries in the meantime (#9922).
   useEffect(() => {
     if (mruList.length === 0) return;
     if (items.length === 0) return;
+    const hasTerminalItems = items.some((item) => item.type === "terminal");
+    const hasWorktreeItems = items.some((item) => item.type === "worktree");
     const validIds = new Set(items.map((item) => item.id));
+    for (const id of mruList) {
+      if (!hasTerminalItems && id.startsWith("terminal:")) validIds.add(id);
+      if (!hasWorktreeItems && id.startsWith("worktree:")) validIds.add(id);
+    }
     pruneMru(validIds);
   }, [items, mruList, pruneMru]);
 

--- a/src/store/__tests__/rendererStoreOrchestrator.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.test.ts
@@ -1037,6 +1037,38 @@ describe("rendererStoreOrchestrator", () => {
     }
   });
 
+  it("does not record MRU for excludeFromPersistence terminals (help/overlay) (#9922)", async () => {
+    vi.useFakeTimers();
+    try {
+      usePanelStore.setState({
+        panelsById: {
+          "help-1": {
+            id: "help-1",
+            title: "Help",
+            kind: "terminal" as const,
+            cwd: "/test",
+            cols: 80,
+            rows: 24,
+            location: "grid",
+            excludeFromPersistence: true,
+          },
+        },
+        panelIds: ["help-1"],
+        mruList: [],
+      });
+
+      usePanelStore.setState({ focusedId: "help-1" });
+
+      vi.advanceTimersByTime(150);
+      await Promise.resolve();
+
+      expect(persistMruList).not.toHaveBeenCalled();
+      expect(usePanelStore.getState().mruList).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("debounced persist reads the live mruList at fire time, not schedule time (#9922)", async () => {
     vi.useFakeTimers();
     try {

--- a/src/store/__tests__/rendererStoreOrchestrator.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.test.ts
@@ -1009,6 +1009,71 @@ describe("rendererStoreOrchestrator", () => {
     }
   });
 
+  it("does not record or persist MRU when a non-PTY panel is focused (#9922)", async () => {
+    vi.useFakeTimers();
+    try {
+      usePanelStore.setState({
+        panelsById: {
+          "br-1": {
+            id: "br-1",
+            title: "Browser",
+            kind: "browser" as const,
+            location: "grid",
+          } as PanelInstance,
+        },
+        panelIds: ["br-1"],
+        mruList: [],
+      });
+
+      usePanelStore.setState({ focusedId: "br-1" });
+
+      vi.advanceTimersByTime(150);
+      await Promise.resolve();
+
+      expect(persistMruList).not.toHaveBeenCalled();
+      expect(usePanelStore.getState().mruList).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("debounced persist reads the live mruList at fire time, not schedule time (#9922)", async () => {
+    vi.useFakeTimers();
+    try {
+      usePanelStore.setState({
+        panelsById: {
+          "t-1": {
+            id: "t-1",
+            title: "T1",
+            kind: "terminal" as const,
+            cwd: "/test",
+            cols: 80,
+            rows: 24,
+            location: "grid",
+            worktreeId: "wt-1",
+          },
+        },
+        panelIds: ["t-1"],
+      });
+
+      // Focusing schedules the debounced persist and records terminal:t-1.
+      usePanelStore.setState({ focusedId: "t-1" });
+
+      // Simulate a deliberate worktree selection updating the live MRU list
+      // before the debounce fires. The stale-args bug would persist the list
+      // captured at schedule time and clobber this promotion.
+      usePanelStore.setState({ mruList: ["worktree:wt-9", "terminal:t-1"] });
+
+      vi.advanceTimersByTime(150);
+      await Promise.resolve();
+
+      expect(persistMruList).toHaveBeenCalledTimes(1);
+      expect(persistMruList).toHaveBeenLastCalledWith(["worktree:wt-9", "terminal:t-1"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("cancels pending persistMruList on destroy", async () => {
     vi.useFakeTimers();
     try {

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -28,8 +28,17 @@ import { getCurrentViewStoreOrNull } from "./createWorktreeStore";
 import { setActiveContextAccessors } from "@/lib/notify";
 import { debounce } from "@/utils/debounce";
 import { DisposableStore, toDisposable } from "@/utils/disposable";
+import { isPtyPanel } from "@shared/types/panel";
 
-const debouncedPersistMruList = debounce(persistMruList, 150);
+// Thunk form: read the live mruList at fire time, not at schedule time. A
+// snapshot captured at schedule time could be stale by the time the debounce
+// fires and would clobber a fresher immediate persistMruList() from a
+// deliberate worktree selection (#9922). persistMruList already version-
+// sequences and dedupes, so the last writer with the live list wins.
+const debouncedPersistMruList = debounce(
+  () => persistMruList(usePanelStore.getState().mruList),
+  150
+);
 
 let cleanupFn: (() => void) | null = null;
 
@@ -129,7 +138,10 @@ export function initStoreOrchestrator(): () => void {
   );
 
   // 1c. Terminal MRU recording: append the newly focused terminal to the
-  //     global MRU list and persist it (debounced) unless suppressed.
+  //     MRU list and persist it (debounced) unless suppressed. Only PTY
+  //     panels (kind "terminal") become quick-switcher items, so non-PTY
+  //     panels (browser, dev-preview, review) must not pollute the capped
+  //     MRU list with entries the switcher will never show (#9922).
   disposables.add(
     toDisposable(
       usePanelStore.subscribe(
@@ -137,8 +149,10 @@ export function initStoreOrchestrator(): () => void {
         (focusedId) => {
           if (!focusedId) return;
           if (isMruRecordingSuppressed()) return;
+          const panel = usePanelStore.getState().panelsById[focusedId];
+          if (!panel || !isPtyPanel(panel)) return;
           usePanelStore.getState().recordMru(`terminal:${focusedId}`);
-          debouncedPersistMruList(usePanelStore.getState().mruList);
+          debouncedPersistMruList();
         }
       )
     )

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -150,7 +150,12 @@ export function initStoreOrchestrator(): () => void {
           if (!focusedId) return;
           if (isMruRecordingSuppressed()) return;
           const panel = usePanelStore.getState().panelsById[focusedId];
+          // Only record panels the quick switcher can actually show — mirror
+          // its item filter (PTY kind, persisted, has a live PTY). Help/overlay
+          // terminals carry excludeFromPersistence and must not eat the cap.
           if (!panel || !isPtyPanel(panel)) return;
+          if (panel.excludeFromPersistence === true) return;
+          if (panel.hasPty === false) return;
           usePanelStore.getState().recordMru(`terminal:${focusedId}`);
           debouncedPersistMruList();
         }


### PR DESCRIPTION
## Summary

- Fixes three independent defects in the quick-switcher's MRU persist/prune pipeline that could silently drop or corrupt entries across projects and sessions.
- MRU is now per-project (stored on `ProjectState.mruList`, written via `enqueueProjectStateUpdate`, reconstructed on disk reads and project switches) with a migration fallback so existing global data isn't lost.
- Regression tests added for all three defects across `rendererStoreOrchestrator`, `useQuickSwitcher`, `ProjectStateManager`, and `AppHydrationService`.

Resolves #9922

## Changes

**Stale-args debounce overwrite** — `debouncedPersistMruList` was capturing a `mruList` snapshot at schedule time. A debounce flush could overwrite a fresher immediate `persistMruList` call from a deliberate worktree selection, silently losing the promotion. Changed to a zero-arg thunk that reads the live `mruList` at fire time; `persistMruList` already version-sequences and dedupes, so last-writer-with-live-list wins.

**Global MRU pruned per-view** — MRU was stored globally but pruned against the current view's items. Opening any project view stripped every other project's terminal/worktree entries, and the next persist made it permanent. MRU is now stored on `ProjectState.mruList`, read back on hydrate and on project switch via `buildSwitchHydrateResult`. Prune is now category-aware so a not-yet-hydrated category isn't gutted during the partial-hydration window.

**Non-PTY panel pollution** — subscription `1c` recorded `terminal:${focusedId}` for every focused panel, including browser, dev-preview, and review panels that the switcher never shows. Now guarded on `isPtyPanel` (plus `excludeFromPersistence` / `hasPty === false`) so only real switcher items are recorded.

## Testing

Full local CI passed: lint, format, typecheck, unit tests, build, IPC/channel/confirm-wiring guards.

New regression tests cover: stale-args flush ordering, non-PTY guard, overlay behaviour (`rendererStoreOrchestrator`); category-aware prune and partial-hydration window (`useQuickSwitcher`); `mruList` disk round-trip (`ProjectStateManager`); per-project switch payload and migration fallback (`AppHydrationService`).