### PR TITLE
fix(pr-detection): preserve declined state through to linked projection

### DIFF
--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -12,6 +12,7 @@ import type {
   PRSnapshot,
   RateLimitInfo,
   CIStatus,
+  NormalizedPRState,
 } from "../../shared/types/forge.js";
 
 // Focus-aware polling cadence: faster when any Daintree window is focused so
@@ -93,7 +94,7 @@ interface InternalLinkedPR {
   number: number;
   title: string;
   url: string;
-  state: "open" | "closed" | "merged";
+  state: NormalizedPRState;
   isDraft?: boolean;
   ciStatus?: import("../../shared/types/github.js").GitHubPRCIStatus;
   _ciStatus?: import("../../shared/types/forge.js").CIStatus;
@@ -111,7 +112,7 @@ export interface PRDetectionResult {
   worktreeId: string;
   prNumber: number;
   prUrl: string;
-  prState: "open" | "merged" | "closed";
+  prState: NormalizedPRState;
 }
 
 function isCandidateBranch(branchName: string | undefined): boolean {
@@ -1217,7 +1218,7 @@ class PullRequestService {
             continue;
           }
 
-          const newState = pr.state === "declined" ? "closed" : pr.state;
+          const newState = pr.state;
           const prChanged =
             detectedPR.state !== newState ||
             detectedPR.number !== pr.number ||
@@ -1582,7 +1583,7 @@ class PullRequestService {
           number: pr.number,
           title: pr.title,
           url: pr.url,
-          state: pr.state === "declined" ? "closed" : pr.state,
+          state: pr.state,
           isDraft: pr.isDraft,
           providerId,
           stagnantPollCount: 0,

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -1742,7 +1742,10 @@ class PullRequestService {
               worktreeId,
               prNumber: pr.number,
               prUrl: pr.url,
-              prState: pr.state,
+              // Read state from the live map entry, not the captured `pr` — a
+              // re-detection may have replaced the entry while this enrichment
+              // was in flight, and the stale capture would revert its state.
+              prState: detected.state,
               prCiStatus: pr.ciStatus,
               prTitle: pr.title,
               issueNumber: this.candidates.get(worktreeId)?.issueNumber,

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -290,6 +290,76 @@ describe("PullRequestService", () => {
     pullRequestService.destroy();
   });
 
+  it("preserves the declined PR state through detection (#9981)", async () => {
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+    mockForgeProviderResolved(async () =>
+      makeMockForgePR({ state: "declined", rawState: "DECLINED" })
+    );
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    const detected: DaintreeEventMap["sys:pr:detected"][] = [];
+    const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/declined" })
+    );
+
+    await pullRequestService.refresh();
+
+    expect(detected).toHaveLength(1);
+    expect(detected[0].prState).toBe("declined");
+
+    unsubscribe();
+    pullRequestService.destroy();
+  });
+
+  it("re-emits a declined state when revalidation finds the PR declined (#9981)", async () => {
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+    const mockImpl = mockForgeProviderResolved(async () => makeMockForgePR({ state: "open" }));
+    const findPRsByNumbers = vi.fn(async (_repo: RepoRef, prNumbers: number[]) => {
+      const map = new Map<number, ForgePR | null>();
+      for (const n of prNumbers) {
+        map.set(n, makeMockForgePR({ number: n, state: "declined", rawState: "DECLINED" }));
+      }
+      return map;
+    });
+    mockImpl.batchLookups = { findPRsByNumbers };
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    const detected: DaintreeEventMap["sys:pr:detected"][] = [];
+    const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+    );
+
+    await pullRequestService.refresh();
+    // Detection (and the fire-and-forget CI enrichment re-emit) carry "open".
+    expect(detected.length).toBeGreaterThanOrEqual(1);
+    expect(detected.every((p) => p.prState === "open")).toBe(true);
+    const countBeforeRevalidation = detected.length;
+
+    // The open → declined transition must surface — previously the collapse
+    // meant the declined state itself never reached the event.
+    await (
+      pullRequestService as unknown as { revalidateResolvedPRs: () => Promise<void> }
+    ).revalidateResolvedPRs();
+
+    const reemits = detected.slice(countBeforeRevalidation);
+    expect(reemits.map((p) => p.prState)).toContain("declined");
+
+    unsubscribe();
+    pullRequestService.destroy();
+  });
+
   it("clears provider PR caches through the forge bridge on manual refresh", async () => {
     mockForgeProviderResolved();
 

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -309,9 +309,12 @@ describe("PullRequestService", () => {
     );
 
     await pullRequestService.refresh();
+    await flushLoaders();
 
-    expect(detected).toHaveLength(1);
-    expect(detected[0].prState).toBe("declined");
+    // Phase-1 detection and the phase-2 CI enrichment re-emit both carry
+    // "declined" — the enrichment must not revert it from a stale capture.
+    expect(detected.length).toBeGreaterThanOrEqual(2);
+    expect(detected.every((p) => p.prState === "declined")).toBe(true);
 
     unsubscribe();
     pullRequestService.destroy();
@@ -342,6 +345,7 @@ describe("PullRequestService", () => {
     );
 
     await pullRequestService.refresh();
+    await flushLoaders();
     // Detection (and the fire-and-forget CI enrichment re-emit) carry "open".
     expect(detected.length).toBeGreaterThanOrEqual(1);
     expect(detected.every((p) => p.prState === "open")).toBe(true);
@@ -352,9 +356,13 @@ describe("PullRequestService", () => {
     await (
       pullRequestService as unknown as { revalidateResolvedPRs: () => Promise<void> }
     ).revalidateResolvedPRs();
+    await flushLoaders();
 
     const reemits = detected.slice(countBeforeRevalidation);
-    expect(reemits.map((p) => p.prState)).toContain("declined");
+    // Every re-emit carries the new state — a spurious "open"/"closed" emit
+    // alongside the correct one would mask the regression.
+    expect(reemits.length).toBeGreaterThanOrEqual(1);
+    expect(reemits.every((p) => p.prState === "declined")).toBe(true);
 
     unsubscribe();
     pullRequestService.destroy();

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -436,7 +436,7 @@ export type DaintreeEventMap = {
     worktreeId: string;
     prNumber: number;
     prUrl: string;
-    prState: "open" | "merged" | "closed";
+    prState: import("../../shared/types/forge.js").NormalizedPRState;
     prCiStatus?: GitHubPRCIStatus;
     /**
      * True on the synchronous phase-1 emit that precedes a fire-and-forget CI

--- a/electron/workspace-host/PRIntegrationService.ts
+++ b/electron/workspace-host/PRIntegrationService.ts
@@ -29,7 +29,7 @@ export interface PRIntegrationCallbacks {
     data: {
       prNumber: number;
       prUrl: string;
-      prState: "open" | "closed" | "merged";
+      prState: import("../../shared/types/forge.js").NormalizedPRState;
       prCiStatus?: GitHubPRCIStatus;
       /** Phase-1 detection: CI status is still being fetched. The receiver preserves the prior rollup so the dot doesn't blink. */
       isCiStatusLoading?: boolean;

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -22,7 +22,7 @@ import type {
   PluginWorktreeLinkedIssue,
   PluginWorktreeLinkedPR,
 } from "../../shared/types/plugin.js";
-import type { CIStatus } from "../../shared/types/forge.js";
+import type { CIStatus, NormalizedPRState } from "../../shared/types/forge.js";
 import { invalidateGitStatusCache } from "../utils/git.js";
 import { detectWslPath, getDefaultWslDistro } from "../utils/wsl.js";
 import {
@@ -293,7 +293,9 @@ export class WorkspaceService {
           worktreeId,
           prNumber: data.prNumber,
           prUrl: data.prUrl,
-          prState: data.prState,
+          // Legacy flat field stays narrow; `linked.pr.state` carries the
+          // full NormalizedPRState including "declined".
+          prState: data.prState === "declined" ? "closed" : data.prState,
           prCiStatus: resolvedPrCiStatus,
           prTitle: data.prTitle,
           issueNumber: data.issueNumber,
@@ -1066,7 +1068,7 @@ export class WorkspaceService {
       number: number;
       title?: string;
       url: string;
-      state: "open" | "merged" | "closed";
+      state: NormalizedPRState;
       ciStatus?: CIStatus;
       baseRef?: string;
     };

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -142,7 +142,7 @@ export class WorktreeMonitor {
   private _issueNumber: number | undefined;
   private prNumber: number | undefined;
   private prUrl: string | undefined;
-  private prState: "open" | "closed" | "merged" | undefined;
+  private prState: import("../../shared/types/forge.js").NormalizedPRState | undefined;
   private prCiStatus: GitHubPRCIStatus | undefined;
   private prTitle: string | undefined;
   private issueTitle: string | undefined;
@@ -624,7 +624,7 @@ export class WorktreeMonitor {
   setPRInfo(info: {
     prNumber?: number;
     prUrl?: string;
-    prState?: "open" | "closed" | "merged";
+    prState?: import("../../shared/types/forge.js").NormalizedPRState;
     prCiStatus?: GitHubPRCIStatus;
     prTitle?: string;
     issueTitle?: string;
@@ -1098,7 +1098,7 @@ export class WorktreeMonitor {
       issueNumber: linkedIssue?.ref.number ?? this._issueNumber,
       prNumber: linkedPr?.ref.number ?? this.prNumber,
       prUrl: linkedPr?.url ?? this.prUrl,
-      prState: linkedPr ? linkedPrState : this.prState,
+      prState: linkedPr ? linkedPrState : this.prState === "declined" ? "closed" : this.prState,
       prCiStatus: linkedPr ? linkedPrCiStatus : this.prCiStatus,
       prTitle: linkedPr ? linkedPr.title : this.prTitle,
       issueTitle: linkedIssue ? linkedIssue.title : this.issueTitle,

--- a/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
@@ -567,4 +567,53 @@ describe("WorkspaceService adversarial", () => {
       expect(setPRInfo).toHaveBeenCalledWith(expect.objectContaining({ prCiStatus: undefined }));
     });
   });
+
+  describe("onPRDetected declined state propagation (#9981)", () => {
+    type OnPRDetected = (worktreeId: string, data: Record<string, unknown>) => void;
+
+    function getOnPRDetected(): OnPRDetected {
+      return (service as unknown as { prService: { callbacks: { onPRDetected: OnPRDetected } } })
+        .prService.callbacks.onPRDetected;
+    }
+
+    it("keeps declined on linked.pr.state and collapses only the flat prState", () => {
+      let linked: { pr?: { state?: string } } | undefined;
+      const setPRInfo = vi.fn();
+      const monitor = {
+        branch: "feature/x",
+        get hasInitialStatus() {
+          return true;
+        },
+        getSnapshot() {
+          return { worktreeId: "/repo/wt", branch: "feature/x", linked };
+        },
+        setLinked(l: unknown) {
+          linked = l as typeof linked;
+        },
+        setPRInfo,
+      };
+      (service as unknown as { monitors: Map<string, unknown> }).monitors.set("/repo/wt", monitor);
+
+      getOnPRDetected()("/repo/wt", {
+        prNumber: 7,
+        prUrl: "https://bitbucket.example/pr/7",
+        prState: "declined",
+        prTitle: "PR",
+        branchName: "feature/x",
+        providerId: "p",
+        owner: "o",
+        repo: "r",
+      });
+
+      // The canonical projection and the monitor's private flat field keep
+      // the full provider state; only the outbound legacy field collapses.
+      expect(linked?.pr?.state).toBe("declined");
+      expect(setPRInfo).toHaveBeenCalledWith(expect.objectContaining({ prState: "declined" }));
+      const prDetected = sentEvents.find((e) => e.type === "pr-detected") as
+        | (WorkspaceHostEvent & { prState?: string; linked?: { pr?: { state?: string } } })
+        | undefined;
+      expect(prDetected?.prState).toBe("closed");
+      expect(prDetected?.linked?.pr?.state).toBe("declined");
+    });
+  });
 });

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -626,6 +626,31 @@ describe("WorktreeMonitor", () => {
       expect(snapshot.prState).toBe("closed");
     });
 
+    it("clearLinked after a declined PR leaves no stale flat state (#9981)", () => {
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, makeCallbacks(), "main");
+      monitor.setLinked({
+        providerId: "acme.bitbucket",
+        pr: {
+          ref: {
+            providerId: "acme.bitbucket",
+            owner: "acme-corp",
+            repo: "my-project",
+            number: 5,
+            rawData: null,
+          },
+          url: "u",
+          state: "declined",
+        },
+      });
+      expect(monitor.getSnapshot().prState).toBe("closed");
+
+      monitor.clearLinked();
+      const snapshot = monitor.getSnapshot();
+      // null, not undefined — #8870 distinguishes "ran and cleared" from "never ran".
+      expect(snapshot.linked).toBeNull();
+      expect(snapshot.prState).toBeUndefined();
+    });
+
     it("falls back to legacy flat fields when linked is unset", () => {
       // `_linked` initializes to `undefined` (#8870 — distinguishes "PR
       // service hasn't run" from "ran and found no link"). The legacy flat

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -612,7 +612,18 @@ describe("WorktreeMonitor", () => {
           state: "declined",
         },
       });
-      expect(monitor.getSnapshot().prState).toBe("closed");
+      const snapshot = monitor.getSnapshot();
+      expect(snapshot.prState).toBe("closed");
+      // The canonical projection keeps the full provider state.
+      expect(snapshot.linked?.pr?.state).toBe("declined");
+    });
+
+    it("collapses a declined legacy flat prState to closed when linked is unset (#9981)", () => {
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, makeCallbacks(), "main");
+      monitor.setPRInfo({ prNumber: 5, prUrl: "u", prState: "declined" });
+      const snapshot = monitor.getSnapshot();
+      expect(snapshot.linked).toBeUndefined();
+      expect(snapshot.prState).toBe("closed");
     });
 
     it("falls back to legacy flat fields when linked is unset", () => {


### PR DESCRIPTION
## Summary

- `declined` (Bitbucket-style PR state) was being collapsed to `closed` inside `PullRequestService` before the canonical `linked` projection was assembled, so `linked.pr.state` could never carry `declined` even though `NormalizedPRState` included it and the renderer handled it everywhere
- Fix widens `InternalLinkedPR.state`, `PRDetectionResult.prState`, the `sys:pr:detected` payload, `PRIntegrationCallbacks.onPRDetected`, and `composeLinked`'s `pr.state` param to `NormalizedPRState` and removes the two early-collapse ternaries; the `declined → closed` collapse now happens only at the legacy flat-field boundaries (`WorkspaceService.sendEvent` and both snapshot paths in `WorktreeMonitor.getSnapshot`)
- Also fixes a stale-closure bug found in review: the CI enrichment re-emit was reading `prState` from the captured `pr` reference rather than the live `detectedPRs` map entry, so an in-flight enrichment could revert a re-detected state

Resolves #9981

## Changes

- `PullRequestService`: widened internal types, removed two early `declined → closed` collapse ternaries; CI enrichment re-emit now reads from live map entry
- `PRIntegrationService`: `onPRDetected` callback widened to `NormalizedPRState`
- `WorkspaceService`: `onPRDetected` handler updated; flat compat collapse kept at the `sendEvent` boundary
- `WorktreeMonitor`: `pr.state` param in `composeLinked` widened; collapse kept at both snapshot paths (linked-derived and legacy fallback)
- `events.ts`: `sys:pr:detected` payload widened

## Testing

- `PullRequestService.test.ts`: `declined` propagation through detection and revalidation
- `WorkspaceService.adversarial.test.ts`: `onPRDetected` pipeline — linked keeps `declined`, flat collapses to `closed`
- `WorktreeMonitor.test.ts`: linked + legacy `setPRInfo` collapse and `clearLinked` cleanup
- Full static checks + 188 targeted tests + build all pass locally