### PR TITLE
fix(ci): include flaky specs in e2e retry test-list

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -570,7 +570,11 @@ jobs:
           set -euo pipefail
           rm -f failed-specs.txt
           if [ -f test-results/report.json ] && [ -s test-results/report.json ]; then
-            jq -r '.suites[] | .. | objects | select(.file != null and .ok == false) | .file' test-results/report.json | sort -u > failed-specs.txt
+            # Flaky specs report spec.ok === true but still fail the job under
+            # FAIL_ON_FLAKY_TESTS (core/online), so a `.ok == false` filter
+            # dropped them from the retry list. The extractor includes flaky
+            # specs too — see scripts/ci/extract-failed-specs.mjs (#10039).
+            node scripts/ci/extract-failed-specs.mjs test-results/report.json failed-specs.txt
             echo "[e2e] Extracted $(wc -l < failed-specs.txt) failed spec(s) from JSON report"
           else
             echo "[e2e] JSON report missing or empty — no failures to extract"

--- a/scripts/ci/extract-failed-specs.mjs
+++ b/scripts/ci/extract-failed-specs.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from "node:fs/promises";
+
+function fail(message) {
+  console.error(`::error::${message}`);
+  process.exit(1);
+}
+
+// A spec contributes to the retry list when any of its tests failed OR was
+// flaky. Flaky matters because `FAIL_ON_FLAKY_TESTS=true` (core/online) makes
+// Playwright exit non-zero on flaky outcomes even though `spec.ok` stays true —
+// so a `.ok === false` filter alone silently drops the flaky spec that tripped
+// the gate. This mirrors the predicate in the "Extract failing spec manifest"
+// step of .github/workflows/e2e.yml; keep the two in lockstep.
+function specFailed(spec) {
+  return (spec.tests ?? []).some((test) => {
+    if (test.status === "flaky") return true;
+    const lastResult = test.results?.[test.results.length - 1];
+    const lastStatus = lastResult?.status;
+    return Boolean(lastStatus) && lastStatus !== "passed" && lastStatus !== "skipped";
+  });
+}
+
+function walk(suite, failed) {
+  for (const child of suite.suites ?? []) walk(child, failed);
+  for (const spec of suite.specs ?? []) {
+    if (spec.file && specFailed(spec)) failed.add(spec.file);
+  }
+}
+
+export function extractFailedSpecPaths(report) {
+  const failed = new Set();
+  if (!report?.suites) return [];
+  for (const suite of report.suites) walk(suite, failed);
+  return [...failed].sort();
+}
+
+async function main() {
+  const inputPath = process.argv[2];
+  const outputPath = process.argv[3];
+
+  if (!inputPath) {
+    fail("Usage: extract-failed-specs.mjs <playwright-results.json> [output.txt]");
+  }
+
+  let report;
+  try {
+    report = JSON.parse(await readFile(inputPath, "utf8"));
+  } catch (err) {
+    fail(`Failed to read ${inputPath}: ${err.message}`);
+  }
+
+  const specs = extractFailedSpecPaths(report);
+  // Trailing newline only when non-empty, matching `jq -r | sort -u` output so
+  // `wc -l` and the `[ -s failed-specs.txt ]` gate downstream stay accurate.
+  const content = specs.length ? specs.join("\n") + "\n" : "";
+
+  if (outputPath) {
+    await writeFile(outputPath, content, "utf8");
+    console.log(`[extract-failed-specs] Wrote ${specs.length} failed spec(s) to ${outputPath}`);
+  } else {
+    process.stdout.write(content);
+  }
+}
+
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  await main();
+}

--- a/scripts/ci/extract-failed-specs.mjs
+++ b/scripts/ci/extract-failed-specs.mjs
@@ -13,7 +13,7 @@ function fail(message) {
 // the gate. This mirrors the predicate in the "Extract failing spec manifest"
 // step of .github/workflows/e2e.yml; keep the two in lockstep.
 function specFailed(spec) {
-  return (spec.tests ?? []).some((test) => {
+  return (Array.isArray(spec.tests) ? spec.tests : []).some((test) => {
     if (test.status === "flaky") return true;
     const lastResult = test.results?.[test.results.length - 1];
     const lastStatus = lastResult?.status;
@@ -22,15 +22,15 @@ function specFailed(spec) {
 }
 
 function walk(suite, failed) {
-  for (const child of suite.suites ?? []) walk(child, failed);
-  for (const spec of suite.specs ?? []) {
+  for (const child of Array.isArray(suite.suites) ? suite.suites : []) walk(child, failed);
+  for (const spec of Array.isArray(suite.specs) ? suite.specs : []) {
     if (spec.file && specFailed(spec)) failed.add(spec.file);
   }
 }
 
 export function extractFailedSpecPaths(report) {
   const failed = new Set();
-  if (!report?.suites) return [];
+  if (!Array.isArray(report?.suites)) return [];
   for (const suite of report.suites) walk(suite, failed);
   return [...failed].sort();
 }

--- a/scripts/ci/extract-failed-specs.test.mjs
+++ b/scripts/ci/extract-failed-specs.test.mjs
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import { extractFailedSpecPaths } from "./extract-failed-specs.mjs";
+
+function spec(file, status, lastResultStatus) {
+  return {
+    file,
+    title: `${file} test`,
+    tests: [
+      {
+        status,
+        results: [{ status: lastResultStatus }],
+      },
+    ],
+  };
+}
+
+describe("extractFailedSpecPaths", () => {
+  it("returns empty for null/empty reports", () => {
+    expect(extractFailedSpecPaths(null)).toEqual([]);
+    expect(extractFailedSpecPaths({})).toEqual([]);
+    expect(extractFailedSpecPaths({ suites: [] })).toEqual([]);
+  });
+
+  it("includes hard-failed specs", () => {
+    const report = {
+      suites: [{ specs: [spec("e2e/core/a.spec.ts", "unexpected", "failed")] }],
+    };
+    expect(extractFailedSpecPaths(report)).toEqual(["e2e/core/a.spec.ts"]);
+  });
+
+  it("includes flaky specs even though spec-level ok is true", () => {
+    // Flaky = failed first attempt, passed on retry. The last result is
+    // "passed" and spec.ok would be true, but FAIL_ON_FLAKY_TESTS makes it a
+    // gate failure — so it MUST land in the retry list. This is the #10039 bug.
+    const report = {
+      suites: [
+        {
+          specs: [
+            {
+              file: "e2e/core/flaky.spec.ts",
+              tests: [{ status: "flaky", results: [{ status: "failed" }, { status: "passed" }] }],
+            },
+          ],
+        },
+      ],
+    };
+    expect(extractFailedSpecPaths(report)).toEqual(["e2e/core/flaky.spec.ts"]);
+  });
+
+  it("includes both hard-failed and flaky specs, sorted and deduped", () => {
+    const report = {
+      suites: [
+        {
+          specs: [
+            spec("e2e/core/hard.spec.ts", "unexpected", "failed"),
+            {
+              file: "e2e/core/flaky.spec.ts",
+              tests: [{ status: "flaky", results: [{ status: "passed" }] }],
+            },
+            // Duplicate file path across two specs in the same file — deduped.
+            spec("e2e/core/hard.spec.ts", "unexpected", "timedOut"),
+          ],
+        },
+      ],
+    };
+    expect(extractFailedSpecPaths(report)).toEqual([
+      "e2e/core/flaky.spec.ts",
+      "e2e/core/hard.spec.ts",
+    ]);
+  });
+
+  it("excludes passed and skipped specs", () => {
+    const report = {
+      suites: [
+        {
+          specs: [
+            spec("e2e/core/pass.spec.ts", "expected", "passed"),
+            spec("e2e/core/skip.spec.ts", "skipped", "skipped"),
+          ],
+        },
+      ],
+    };
+    expect(extractFailedSpecPaths(report)).toEqual([]);
+  });
+
+  it("treats timedOut and interrupted last results as failures", () => {
+    const report = {
+      suites: [
+        {
+          specs: [
+            spec("e2e/core/timeout.spec.ts", "unexpected", "timedOut"),
+            spec("e2e/core/interrupted.spec.ts", "unexpected", "interrupted"),
+          ],
+        },
+      ],
+    };
+    expect(extractFailedSpecPaths(report)).toEqual([
+      "e2e/core/interrupted.spec.ts",
+      "e2e/core/timeout.spec.ts",
+    ]);
+  });
+
+  it("walks nested describe suites and propagates the spec file", () => {
+    const report = {
+      suites: [
+        {
+          title: "root",
+          suites: [
+            {
+              title: "Feature X",
+              specs: [spec("e2e/full/nested.spec.ts", "unexpected", "failed")],
+            },
+          ],
+        },
+      ],
+    };
+    expect(extractFailedSpecPaths(report)).toEqual(["e2e/full/nested.spec.ts"]);
+  });
+
+  it("ignores specs without a file path", () => {
+    const report = {
+      suites: [{ specs: [{ tests: [{ status: "unexpected", results: [{ status: "failed" }] }] }] }],
+    };
+    expect(extractFailedSpecPaths(report)).toEqual([]);
+  });
+
+  it("handles specs with missing tests array", () => {
+    const report = {
+      suites: [{ specs: [{ file: "e2e/core/empty.spec.ts" }] }],
+    };
+    expect(extractFailedSpecPaths(report)).toEqual([]);
+  });
+});

--- a/scripts/ci/extract-failed-specs.test.mjs
+++ b/scripts/ci/extract-failed-specs.test.mjs
@@ -130,4 +130,40 @@ describe("extractFailedSpecPaths", () => {
     };
     expect(extractFailedSpecPaths(report)).toEqual([]);
   });
+
+  it("returns [] for a non-array suites shape rather than throwing", () => {
+    expect(extractFailedSpecPaths({ suites: null })).toEqual([]);
+    expect(extractFailedSpecPaths({ suites: 42 })).toEqual([]);
+    expect(() => extractFailedSpecPaths({ suites: { not: "an array" } })).not.toThrow();
+    expect(extractFailedSpecPaths({ suites: { not: "an array" } })).toEqual([]);
+  });
+
+  it("includes a spec when any of its tests failed (any-failure semantics)", () => {
+    const report = {
+      suites: [
+        {
+          specs: [
+            {
+              file: "e2e/core/multi.spec.ts",
+              tests: [
+                { status: "expected", results: [{ status: "passed" }] },
+                { status: "unexpected", results: [{ status: "failed" }] },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(extractFailedSpecPaths(report)).toEqual(["e2e/core/multi.spec.ts"]);
+  });
+
+  it("excludes a test with an empty results array and a non-flaky status", () => {
+    // Playwright always populates results for a test that ran; an empty results
+    // array means nothing ran, so there is no last-result failure to report and
+    // the spec is intentionally excluded (matches the manifest-step predicate).
+    const report = {
+      suites: [{ specs: [{ file: "e2e/core/noresult.spec.ts", tests: [{ results: [] }] }] }],
+    };
+    expect(extractFailedSpecPaths(report)).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

- The `--test-list` retry path in `.github/workflows/e2e.yml` built `failed-specs.txt` with a `jq` filter on `.ok == false`, but Playwright marks flaky specs as `ok === true` — so a mixed hard+flaky failure would retry only the hard-failure files and never re-exercise the flaky spec that tripped the gate.
- Extracted the logic into a standalone, tested script (`scripts/ci/extract-failed-specs.mjs`) whose predicate matches the already-correct sibling step in the same workflow: a spec is included when any test result is `flaky` or its last-result status is not `passed`/`skipped`. Replaced the `jq` one-liner in `e2e.yml` with a call to the script.
- `online` and `nightly` suites are untouched (they were already excluded from the `--test-list` branch). The `[ -s ]` gate semantics are preserved.

Resolves #10039

## Changes

- `scripts/ci/extract-failed-specs.mjs` — new script that exports `extractFailedSpecPaths(report)` and runs as a standalone CLI
- `scripts/ci/extract-failed-specs.test.mjs` — 12 vitest cases covering hard failures, flaky-only, mixed, empty reports, malformed input, and edge cases
- `.github/workflows/e2e.yml` — replace `jq` one-liner with `node scripts/ci/extract-failed-specs.mjs`

## Testing

Full suite of 32091 tests passed locally. Typecheck, lint, format, build, and security gate all green.