### PR TITLE
fix(mcp): fall back to cached manifest when tools/list live fetch fails

### DIFF
--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 
@@ -229,6 +229,10 @@ describe("sessionServer tools/list handler", () => {
     });
   }
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("returns the live manifest when requestManifest succeeds", async () => {
     const deps = fullSurfaceDeps({
       requestManifest: vi.fn().mockResolvedValue([makeManifestEntry("fresh_tool")]),
@@ -239,14 +243,15 @@ describe("sessionServer tools/list handler", () => {
 
     const result = await listTools(server);
 
+    // Fresh result wins over the (different) cache, proving the live path is used.
     expect(result.tools.map((t) => t.name)).toEqual(["fresh_tool"]);
-    expect(deps.getCachedManifest).not.toHaveBeenCalled();
   });
 
-  it("falls back to the cached manifest when requestManifest rejects", async () => {
+  it("falls back to the cached manifest, warning with the error, when requestManifest rejects", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const rejection = new Error("Manifest request timed out");
     const deps = fullSurfaceDeps({
-      requestManifest: vi.fn().mockRejectedValue(new Error("Manifest request timed out")),
+      requestManifest: vi.fn().mockRejectedValue(rejection),
       getCachedManifest: vi.fn(() => [makeManifestEntry("cached_tool")]),
     });
     const server = createSessionServer("tools-list-fallback", deps);
@@ -256,10 +261,29 @@ describe("sessionServer tools/list handler", () => {
 
     expect(result.tools.map((t) => t.name)).toEqual(["cached_tool"]);
     expect(warnSpy).toHaveBeenCalledTimes(1);
-    warnSpy.mockRestore();
+    // The rejection must reach the log so operators can diagnose the stale serve.
+    expect(warnSpy.mock.calls[0]).toContain(rejection);
   });
 
-  it("fails closed when requestManifest rejects and no cache exists", async () => {
+  it("applies the tier/visibility filter on the cached fallback path", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const deps = fullSurfaceDeps({
+      requestManifest: vi.fn().mockRejectedValue(new Error("Manifest request timed out")),
+      getCachedManifest: vi.fn(() => [
+        makeManifestEntry("allowed_tool"),
+        { ...makeManifestEntry("restricted_tool"), danger: "restricted" },
+      ]),
+    });
+    const server = createSessionServer("tools-list-filtered-cache", deps);
+    await server.connect(makeMockTransport());
+
+    const result = await listTools(server);
+
+    // shouldExposeTool drops restricted entries even on the cache path.
+    expect(result.tools.map((t) => t.name)).toEqual(["allowed_tool"]);
+  });
+
+  it("fails closed with an McpError when requestManifest rejects and no cache exists", async () => {
     const deps = fullSurfaceDeps({
       requestManifest: vi.fn().mockRejectedValue(new Error("MCP renderer bridge unavailable")),
       getCachedManifest: vi.fn(() => null),
@@ -267,12 +291,39 @@ describe("sessionServer tools/list handler", () => {
     const server = createSessionServer("tools-list-failclosed", deps);
     await server.connect(makeMockTransport());
 
+    await expect(listTools(server)).rejects.toBeInstanceOf(McpError);
     await expect(listTools(server)).rejects.toMatchObject({
       code: ErrorCode.InternalError,
+      message: expect.stringContaining("Action manifest unavailable"),
     });
   });
 
+  it("fails closed even if the session is unpinned after the await (snapshot before async boundary)", async () => {
+    // Pinned session: getCachedManifest returns null while the request is in
+    // flight, then teardown flips it to a foreign manifest. The handler must
+    // use the pre-await snapshot (null) and fail closed — never serve the
+    // foreign cache (#7003 cross-window isolation).
+    let firstCall = true;
+    const deps = fullSurfaceDeps({
+      requestManifest: vi.fn().mockRejectedValue(new Error("MCP renderer bridge destroyed")),
+      getCachedManifest: vi.fn(() => {
+        if (firstCall) {
+          firstCall = false;
+          return null;
+        }
+        return [makeManifestEntry("foreign_tool")];
+      }),
+    });
+    const server = createSessionServer("tools-list-race", deps);
+    await server.connect(makeMockTransport());
+
+    await expect(listTools(server)).rejects.toBeInstanceOf(McpError);
+    // getCachedManifest was read exactly once — synchronously, before the await.
+    expect(deps.getCachedManifest).toHaveBeenCalledTimes(1);
+  });
+
   it("treats an empty cached manifest as a valid zero-tool surface, not unavailable", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
     const deps = fullSurfaceDeps({
       requestManifest: vi.fn().mockRejectedValue(new Error("MCP renderer bridge destroyed")),
       getCachedManifest: vi.fn(() => []),

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { ActionManifestEntry, ActionId } from "../../../../shared/types/actions.js";
 
 vi.mock("electron", () => ({
   app: {
@@ -200,17 +201,15 @@ async function listTools(server: ReturnType<typeof createSessionServer>) {
   ) as Promise<{ tools: Array<{ name: string }> }>;
 }
 
-function makeManifestEntry(
-  id: string
-): import("../../../shared/types/actions.js").ActionManifestEntry {
+function makeManifestEntry(id: string): ActionManifestEntry {
   return {
-    id: id as import("../../../shared/types/actions.js").ActionId,
+    id: id as ActionId,
     name: id,
     title: id,
     description: `description for ${id}`,
     category: "test",
     kind: "query",
-    danger: "safe",
+    danger: "safe" as const,
     enabled: true,
     requiresArgs: false,
     inputSchema: { type: "object", properties: {} },
@@ -271,7 +270,7 @@ describe("sessionServer tools/list handler", () => {
       requestManifest: vi.fn().mockRejectedValue(new Error("Manifest request timed out")),
       getCachedManifest: vi.fn(() => [
         makeManifestEntry("allowed_tool"),
-        { ...makeManifestEntry("restricted_tool"), danger: "restricted" },
+        { ...makeManifestEntry("restricted_tool"), danger: "restricted" as const },
       ]),
     });
     const server = createSessionServer("tools-list-filtered-cache", deps);

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -176,6 +176,116 @@ async function callTool(
   ) as Promise<{ content: unknown; isError?: boolean; structuredContent?: unknown }>;
 }
 
+async function listTools(server: ReturnType<typeof createSessionServer>) {
+  const handlers = (
+    server as unknown as {
+      _requestHandlers: Map<string, (req: unknown, extra: unknown) => Promise<unknown>>;
+    }
+  )._requestHandlers;
+  const handler = handlers.get("tools/list");
+  if (!handler) throw new Error("tools/list handler not found");
+  return handler(
+    {
+      method: "tools/list",
+      params: {},
+      jsonrpc: "2.0",
+      id: 1,
+    },
+    {
+      signal: new AbortController().signal,
+      _meta: {},
+      sendNotification: vi.fn(),
+      requestId: 1,
+    }
+  ) as Promise<{ tools: Array<{ name: string }> }>;
+}
+
+function makeManifestEntry(
+  id: string
+): import("../../../shared/types/actions.js").ActionManifestEntry {
+  return {
+    id: id as import("../../../shared/types/actions.js").ActionId,
+    name: id,
+    title: id,
+    description: `description for ${id}`,
+    category: "test",
+    kind: "query",
+    danger: "safe",
+    enabled: true,
+    requiresArgs: false,
+    inputSchema: { type: "object", properties: {} },
+  };
+}
+
+describe("sessionServer tools/list handler", () => {
+  // tier "external" + fullToolSurface bypasses the per-id allowlist in
+  // shouldExposeTool, so any non-restricted entry surfaces — keeps these tests
+  // decoupled from TIER_ALLOWLISTS membership.
+  function fullSurfaceDeps(overrides?: Partial<SessionServerDeps>): SessionServerDeps {
+    return fakeDeps({
+      sessionStore: fakeSessionStore("external"),
+      getFullToolSurface: vi.fn(() => true),
+      ...overrides,
+    });
+  }
+
+  it("returns the live manifest when requestManifest succeeds", async () => {
+    const deps = fullSurfaceDeps({
+      requestManifest: vi.fn().mockResolvedValue([makeManifestEntry("fresh_tool")]),
+      getCachedManifest: vi.fn(() => [makeManifestEntry("stale_tool")]),
+    });
+    const server = createSessionServer("tools-list-fresh", deps);
+    await server.connect(makeMockTransport());
+
+    const result = await listTools(server);
+
+    expect(result.tools.map((t) => t.name)).toEqual(["fresh_tool"]);
+    expect(deps.getCachedManifest).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the cached manifest when requestManifest rejects", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const deps = fullSurfaceDeps({
+      requestManifest: vi.fn().mockRejectedValue(new Error("Manifest request timed out")),
+      getCachedManifest: vi.fn(() => [makeManifestEntry("cached_tool")]),
+    });
+    const server = createSessionServer("tools-list-fallback", deps);
+    await server.connect(makeMockTransport());
+
+    const result = await listTools(server);
+
+    expect(result.tools.map((t) => t.name)).toEqual(["cached_tool"]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  it("fails closed when requestManifest rejects and no cache exists", async () => {
+    const deps = fullSurfaceDeps({
+      requestManifest: vi.fn().mockRejectedValue(new Error("MCP renderer bridge unavailable")),
+      getCachedManifest: vi.fn(() => null),
+    });
+    const server = createSessionServer("tools-list-failclosed", deps);
+    await server.connect(makeMockTransport());
+
+    await expect(listTools(server)).rejects.toMatchObject({
+      code: ErrorCode.InternalError,
+    });
+  });
+
+  it("treats an empty cached manifest as a valid zero-tool surface, not unavailable", async () => {
+    const deps = fullSurfaceDeps({
+      requestManifest: vi.fn().mockRejectedValue(new Error("MCP renderer bridge destroyed")),
+      getCachedManifest: vi.fn(() => []),
+    });
+    const server = createSessionServer("tools-list-empty-cache", deps);
+    await server.connect(makeMockTransport());
+
+    const result = await listTools(server);
+
+    expect(result.tools).toEqual([]);
+  });
+});
+
 describe("sessionServer prompt handler", () => {
   it("renders start_issue prompt with valid string argument", async () => {
     const deps = fakeDeps();

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -297,7 +297,24 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => {
-    const manifest = await requestManifest();
+    // Prefer a live fetch so runtime action-set changes (plugin enable/disable)
+    // are reflected. On failure (renderer bridge unavailable / timed out /
+    // destroyed) fall back to the last-known cached manifest instead of failing
+    // the whole tools/list (#9892). For pinned sessions (#7003) getCachedManifest
+    // always returns null, so they correctly fail closed rather than serve
+    // another window's tool surface. `=== null` (not `!manifest`) so an empty
+    // manifest — a valid zero-tool surface — is not misread as "unavailable".
+    let manifest: import("../../../shared/types/actions.js").ActionManifestEntry[];
+    try {
+      manifest = await requestManifest();
+    } catch (err) {
+      const cached = getCachedManifest();
+      if (cached === null) {
+        throw new McpError(ErrorCode.InternalError, "Action manifest unavailable");
+      }
+      console.warn("[MCP] tools/list using cached manifest after live fetch failed:", err);
+      manifest = cached;
+    }
     const tier = sessionStore.getTier(sessionId);
     const fullToolSurface = getFullToolSurface();
     const tools = manifest

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -304,16 +304,23 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     // always returns null, so they correctly fail closed rather than serve
     // another window's tool surface. `=== null` (not `!manifest`) so an empty
     // manifest — a valid zero-tool surface — is not misread as "unavailable".
+    //
+    // Snapshot the fallback BEFORE the await: getCachedManifest() reads the
+    // live session→WebContents map, and a pinned session can be torn down
+    // (map entry deleted) while requestManifest() is in flight. Reading it
+    // after the await would then see the session as unpinned and return the
+    // shared cache — another window's tool surface — defeating #7003. Taken
+    // synchronously here, the request is still in flight so the pin holds.
+    const cachedFallback = getCachedManifest();
     let manifest: import("../../../shared/types/actions.js").ActionManifestEntry[];
     try {
       manifest = await requestManifest();
     } catch (err) {
-      const cached = getCachedManifest();
-      if (cached === null) {
+      if (cachedFallback === null) {
         throw new McpError(ErrorCode.InternalError, "Action manifest unavailable");
       }
       console.warn("[MCP] tools/list using cached manifest after live fetch failed:", err);
-      manifest = cached;
+      manifest = cachedFallback;
     }
     const tier = sessionStore.getTier(sessionId);
     const fullToolSurface = getFullToolSurface();


### PR DESCRIPTION
## Summary

- The `tools/list` handler in `sessionServer.ts` called `requestManifest()` with no error handling. When the renderer bridge was unavailable (5s timeout, no active project view, mid-teardown), the rejection propagated as a JSON-RPC `InternalError` and wiped the agent's tool surface entirely.
- Fix snapshots `getCachedManifest()` synchronously before the `await`, then attempts a live `requestManifest()`; on failure it serves the cached manifest with a `console.warn` rather than hard-failing. Fresh-first ordering is preserved so runtime action-set changes stay reflected.
- Pinned help-sessions (where `getCachedManifest()` is `null` by design) continue to fail closed with an `McpError`, preserving cross-window manifest isolation.

Resolves #9892

## Changes

- `electron/services/mcp-server/sessionServer.ts` — cache snapshot taken before the `await`; fallback path on `requestManifest()` rejection
- `electron/services/mcp-server/__tests__/sessionServer.test.ts` — new `tools/list` handler suite

## Testing

Added tests covering: live success, cache fallback (warn carries error), tier/visibility filtering on the cache path, fail-closed `McpError` (type + message), the pre-await snapshot race regression guard, and empty-cache-is-a-valid-zero-tool-surface. 120 unit tests pass; typecheck, lint, format, and production build all clean.