### PR TITLE
fix(agents): refresh plugin agent icon/name/color mid-session

### DIFF
--- a/shared/config/__tests__/pluginAgentRegistry.test.ts
+++ b/shared/config/__tests__/pluginAgentRegistry.test.ts
@@ -5,6 +5,8 @@ import {
   getPluginAgentRegistry,
   setPluginAgentRegistry,
   clearPluginAgentRegistryForTests,
+  subscribeToPluginAgentRegistry,
+  getPluginAgentRegistrySnapshot,
 } from "../pluginAgentRegistry.js";
 import {
   getEffectiveAgentConfig,
@@ -131,5 +133,109 @@ describe("pluginAgentRegistry (issue #9560)", () => {
     const snapshot = getPluginAgentRegistry();
     expect(Object.getPrototypeOf(snapshot)).toBeNull();
     expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+});
+
+describe("pluginAgentRegistry subscription (issue #9879)", () => {
+  beforeEach(() => {
+    clearPluginAgentRegistryForTests();
+  });
+  afterEach(() => {
+    clearPluginAgentRegistryForTests();
+  });
+
+  it("notifies subscribers when registerPluginAgents mutates the registry", () => {
+    const listener = vi.fn();
+    subscribeToPluginAgentRegistry(listener);
+    registerPluginAgents("acme.plugin", [ACME_AGENT]);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("notifies subscribers when unregisterPluginAgents removes a plugin", () => {
+    registerPluginAgents("acme.plugin", [ACME_AGENT]);
+    const listener = vi.fn();
+    subscribeToPluginAgentRegistry(listener);
+    unregisterPluginAgents("acme.plugin");
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("notifies subscribers when setPluginAgentRegistry replaces the snapshot", () => {
+    const listener = vi.fn();
+    subscribeToPluginAgentRegistry(listener);
+    setPluginAgentRegistry({
+      "mirror-agent": {
+        id: "mirror-agent",
+        name: "Mirror",
+        command: "mirror",
+        color: "#000000",
+        iconId: "terminal",
+        supportsContextInjection: false,
+      },
+    });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not notify when setPluginAgentRegistry is called with the same reference", () => {
+    const listener = vi.fn();
+    subscribeToPluginAgentRegistry(listener);
+    const snapshot = getPluginAgentRegistrySnapshot();
+    setPluginAgentRegistry(snapshot);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("getPluginAgentRegistrySnapshot returns a stable reference until a mutation", () => {
+    const before = getPluginAgentRegistrySnapshot();
+    expect(getPluginAgentRegistrySnapshot()).toBe(before);
+    registerPluginAgents("acme.plugin", [ACME_AGENT]);
+    const after = getPluginAgentRegistrySnapshot();
+    expect(after).not.toBe(before);
+    // Stable again until the next mutation — never a fresh object per call.
+    expect(getPluginAgentRegistrySnapshot()).toBe(after);
+  });
+
+  it("getPluginAgentRegistrySnapshot returns the set record as-is, not a clone", () => {
+    const record = {
+      "mirror-agent": {
+        id: "mirror-agent",
+        name: "Mirror",
+        command: "mirror",
+        color: "#000000",
+        iconId: "terminal",
+        supportsContextInjection: false,
+      },
+    };
+    setPluginAgentRegistry(record);
+    expect(getPluginAgentRegistrySnapshot()).toBe(record);
+  });
+
+  it("stops notifying after the returned cleanup is called", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToPluginAgentRegistry(listener);
+    unsubscribe();
+    registerPluginAgents("acme.plugin", [ACME_AGENT]);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("clearPluginAgentRegistryForTests drops subscribers (no cross-test leakage)", () => {
+    const listener = vi.fn();
+    subscribeToPluginAgentRegistry(listener);
+    clearPluginAgentRegistryForTests();
+    registerPluginAgents("acme.plugin", [ACME_AGENT]);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("isolates a throwing listener so later subscribers still run", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const throwing = vi.fn(() => {
+      throw new Error("listener boom");
+    });
+    const healthy = vi.fn();
+    subscribeToPluginAgentRegistry(throwing);
+    subscribeToPluginAgentRegistry(healthy);
+    registerPluginAgents("acme.plugin", [ACME_AGENT]);
+    expect(throwing).toHaveBeenCalledTimes(1);
+    expect(healthy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 });

--- a/shared/config/pluginAgentRegistry.ts
+++ b/shared/config/pluginAgentRegistry.ts
@@ -23,6 +23,48 @@ const byPlugin = new Map<string, Map<string, AgentConfig>>();
 
 let snapshot: Record<string, AgentConfig> = {};
 
+/**
+ * Render-path subscribers for `useSyncExternalStore`. The renderer's plugin
+ * agents are mirrored into {@link snapshot} by {@link setPluginAgentRegistry},
+ * but nothing re-renders consumers that read the snapshot during render unless
+ * they're notified — so icon/name/color stayed stale mid-session until an
+ * unrelated re-render (#9879). Mirrors the panel-kind listener set in
+ * `src/panels/registry.tsx`. Pure `Set`, no DOM/React imports, so it stays
+ * safe to import from the main process (which never subscribes).
+ */
+const registryListeners = new Set<() => void>();
+
+function notifyRegistryListeners(): void {
+  for (const listener of [...registryListeners]) {
+    try {
+      listener();
+    } catch (err) {
+      console.error("[pluginAgentRegistry] registry listener threw", err);
+    }
+  }
+}
+
+/**
+ * Subscribe to plugin-agent registry changes. Stable module-scope reference so
+ * `useSyncExternalStore` doesn't re-subscribe on every render.
+ */
+export function subscribeToPluginAgentRegistry(listener: () => void): () => void {
+  registryListeners.add(listener);
+  return () => {
+    registryListeners.delete(listener);
+  };
+}
+
+/**
+ * Snapshot for `useSyncExternalStore`. Returns the live {@link snapshot}
+ * reference as-is — stable until a mutation replaces it. Never clone or spread
+ * here: a fresh object on each call breaks React 19's identity check and forces
+ * synchronous/infinite re-renders.
+ */
+export function getPluginAgentRegistrySnapshot(): Record<string, AgentConfig> {
+  return snapshot;
+}
+
 function contributionToAgentConfig(contribution: PluginAgentContribution): AgentConfig {
   // Minimal tier: surface only the launch-relevant fields. `detection` is
   // validated at the manifest gate but deliberately not mapped here — the
@@ -61,6 +103,7 @@ function rebuildSnapshot(): void {
     }
   }
   snapshot = next;
+  notifyRegistryListeners();
 }
 
 /**
@@ -106,11 +149,17 @@ export function getPluginAgentRegistry(): Record<string, AgentConfig> {
  * its own. No-op-safe with an empty record.
  */
 export function setPluginAgentRegistry(record: Record<string, AgentConfig>): void {
-  snapshot = record ?? {};
+  const next = record ?? {};
+  // Reference-identity guard: a no-op replace must not churn snapshot identity
+  // or wake subscribers.
+  if (next === snapshot) return;
+  snapshot = next;
+  notifyRegistryListeners();
 }
 
-/** Test-isolation helper: clear both the per-plugin map and the snapshot. */
+/** Test-isolation helper: clear the per-plugin map, snapshot, and subscribers. */
 export function clearPluginAgentRegistryForTests(): void {
   byPlugin.clear();
   snapshot = {};
+  registryListeners.clear();
 }

--- a/src/components/Layout/TrashBinItem.tsx
+++ b/src/components/Layout/TrashBinItem.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useState, useSyncExternalStore } from "react";
 import { RotateCcw, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { usePanelStore } from "@/store";
@@ -10,6 +10,10 @@ import { deriveTerminalChrome } from "@/utils/terminalChrome";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { isUselessTitle } from "@shared/utils/isUselessTitle";
 import { getEffectiveAgentConfig } from "@shared/config/agentRegistry";
+import {
+  subscribeToPluginAgentRegistry,
+  getPluginAgentRegistrySnapshot,
+} from "@shared/config/pluginAgentRegistry";
 import { useVisibilityAwareInterval } from "@/hooks/useVisibilityAwareInterval";
 import { cn } from "@/lib/utils";
 
@@ -28,6 +32,10 @@ export function TrashBinItem({ terminal, trashedInfo, worktreeName }: TrashBinIt
   const restoreTerminal = usePanelStore((s) => s.restoreTerminal);
   const removePanel = usePanelStore((s) => s.removePanel);
   const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
+  // Re-render when a plugin loads/unloads mid-session so the trashed terminal's
+  // icon/name pick up the updated registry (#9879). Subscription is the
+  // mechanism; the value itself is read via getEffectiveAgentConfig below.
+  useSyncExternalStore(subscribeToPluginAgentRegistry, getPluginAgentRegistrySnapshot);
 
   const isOrphan = !!terminal.worktreeId && !worktreeName;
 

--- a/src/components/Layout/TrashGroupItem.tsx
+++ b/src/components/Layout/TrashGroupItem.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useSyncExternalStore } from "react";
 import { RotateCcw, X, Layers, ChevronDown, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { usePanelStore } from "@/store";
@@ -11,6 +11,10 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { useVisibilityAwareInterval } from "@/hooks/useVisibilityAwareInterval";
 import { isUselessTitle } from "@shared/utils/isUselessTitle";
 import { getEffectiveAgentConfig } from "@shared/config/agentRegistry";
+import {
+  subscribeToPluginAgentRegistry,
+  getPluginAgentRegistrySnapshot,
+} from "@shared/config/pluginAgentRegistry";
 import { cn } from "@/lib/utils";
 
 const COUNTDOWN_CRITICAL_SECONDS = 5;
@@ -37,6 +41,10 @@ export function TrashGroupItem({
   const restoreTerminal = usePanelStore((s) => s.restoreTerminal);
   const removePanel = usePanelStore((s) => s.removePanel);
   const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
+  // Re-render when a plugin loads/unloads mid-session so trashed terminals'
+  // icon/name pick up the updated registry (#9879). Subscription is the
+  // mechanism; the value itself is read via getEffectiveAgentConfig below.
+  useSyncExternalStore(subscribeToPluginAgentRegistry, getPluginAgentRegistrySnapshot);
 
   const [isExpanded, setIsExpanded] = useState(false);
 

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -63,6 +63,10 @@ import {
 import { MenuActionSourceContext } from "@/components/ui/menu-source";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
 import { getEffectiveAgentIds } from "@shared/config/agentRegistry";
+import {
+  subscribeToPluginAgentRegistry,
+  getPluginAgentRegistrySnapshot,
+} from "@shared/config/pluginAgentRegistry";
 import { getAgentConfig } from "@/config/agents";
 import {
   DockLaunchMenuItems,
@@ -251,16 +255,23 @@ export function useContentGridContext({
   const hasDevPreview = useProjectSettingsStore((s) =>
     Boolean(s.settings?.devServerCommand?.trim())
   );
-
-  const gridSelectedAgentIds = useMemo(
-    () =>
-      computeGridSelectedAgentIds(
-        isAvailabilityInitialized,
-        agentAvailability,
-        getEffectiveAgentIds()
-      ),
-    [isAvailabilityInitialized, agentAvailability]
+  // Re-derive grid agents when a plugin loads/unloads mid-session so its agents
+  // appear / disappear with current icon/name/color (#9879).
+  const pluginAgentRegistry = useSyncExternalStore(
+    subscribeToPluginAgentRegistry,
+    getPluginAgentRegistrySnapshot
   );
+
+  const gridSelectedAgentIds = useMemo(() => {
+    // Referenced so this memo re-derives when plugins load/unload mid-session;
+    // getEffectiveAgentIds() reads the merged (incl. plugin) registry (#9879).
+    void pluginAgentRegistry;
+    return computeGridSelectedAgentIds(
+      isAvailabilityInitialized,
+      agentAvailability,
+      getEffectiveAgentIds()
+    );
+  }, [isAvailabilityInitialized, agentAvailability, pluginAgentRegistry]);
   const isProjectSwitching = false;
   const { projectIconSvg } = useProjectBranding(currentProject?.id);
   const { worktreeMap, isInitialized: isWorktreeInitialized } = useWorktrees();
@@ -674,6 +685,9 @@ export function useContentGridContext({
   // Build the same `DockLaunchAgent[]` shape the dock uses so the grid menu
   // renders identical brand icons, then split/order by toolbar pin state.
   const { sorted: gridLaunchAgents, pinnedCount: gridAgentPinnedCount } = useMemo(() => {
+    // Referenced so this memo re-derives when plugins load/unload mid-session;
+    // getEffectiveAgentIds/getAgentConfig read the merged (incl. plugin) registry (#9879).
+    void pluginAgentRegistry;
     const agents: DockLaunchAgent[] = getEffectiveAgentIds()
       .filter((id) => !gridSelectedAgentIds || gridSelectedAgentIds.has(id))
       .map((id) => {
@@ -687,7 +701,7 @@ export function useContentGridContext({
         };
       });
     return sortAgentsByToolbarPin(agents, leftButtons, agentSettings);
-  }, [agentAvailability, gridSelectedAgentIds, leftButtons, agentSettings]);
+  }, [agentAvailability, gridSelectedAgentIds, leftButtons, agentSettings, pluginAgentRegistry]);
 
   const handleGridLaunch = useCallback(
     (agentId: string) => {

--- a/src/hooks/useNewTerminalPalette.ts
+++ b/src/hooks/useNewTerminalPalette.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useSyncExternalStore } from "react";
 import {
   getLaunchOptions,
   getMoreAgentsOption,
@@ -12,6 +12,10 @@ import type { WorktreeState } from "@/types";
 import { useSearchablePalette, type UseSearchablePaletteReturn } from "./useSearchablePalette";
 import { actionService } from "@/services/ActionService";
 import { getEffectiveAgentIds } from "@shared/config/agentRegistry";
+import {
+  subscribeToPluginAgentRegistry,
+  getPluginAgentRegistrySnapshot,
+} from "@shared/config/pluginAgentRegistry";
 import { isAgentInstalled } from "../../shared/utils/agentAvailability";
 
 interface UseNewTerminalPaletteProps {
@@ -43,8 +47,17 @@ export function useNewTerminalPalette({
   const addPanel = usePanelStore((state) => state.addPanel);
   const availability = useCliAvailabilityStore((state) => state.availability);
   const isAvailabilityInitialized = useCliAvailabilityStore((state) => state.isInitialized);
+  // Re-render when a plugin loads/unloads mid-session so its agents appear /
+  // disappear in the launch list (#9879).
+  const pluginAgentRegistry = useSyncExternalStore(
+    subscribeToPluginAgentRegistry,
+    getPluginAgentRegistrySnapshot
+  );
 
   const options = useMemo(() => {
+    // Referenced so this memo re-derives when plugins load/unload mid-session;
+    // getEffectiveAgentIds() below reads the merged (incl. plugin) registry (#9879).
+    void pluginAgentRegistry;
     const allOptions = getLaunchOptions();
     const registryAgentIds = new Set(getEffectiveAgentIds());
 
@@ -62,7 +75,7 @@ export function useNewTerminalPalette({
     filtered.push(getMoreAgentsOption());
 
     return filtered;
-  }, [availability, isAvailabilityInitialized]);
+  }, [availability, isAvailabilityInitialized, pluginAgentRegistry]);
 
   const { results, selectedIndex, close, ...paletteRest } = useSearchablePalette<LaunchOption>({
     items: options,

--- a/src/hooks/useNewTerminalPalette.ts
+++ b/src/hooks/useNewTerminalPalette.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useSyncExternalStore } from "react";
+import { useCallback, useMemo } from "react";
 import {
   getLaunchOptions,
   getMoreAgentsOption,
@@ -12,10 +12,6 @@ import type { WorktreeState } from "@/types";
 import { useSearchablePalette, type UseSearchablePaletteReturn } from "./useSearchablePalette";
 import { actionService } from "@/services/ActionService";
 import { getEffectiveAgentIds } from "@shared/config/agentRegistry";
-import {
-  subscribeToPluginAgentRegistry,
-  getPluginAgentRegistrySnapshot,
-} from "@shared/config/pluginAgentRegistry";
 import { isAgentInstalled } from "../../shared/utils/agentAvailability";
 
 interface UseNewTerminalPaletteProps {
@@ -47,17 +43,8 @@ export function useNewTerminalPalette({
   const addPanel = usePanelStore((state) => state.addPanel);
   const availability = useCliAvailabilityStore((state) => state.availability);
   const isAvailabilityInitialized = useCliAvailabilityStore((state) => state.isInitialized);
-  // Re-render when a plugin loads/unloads mid-session so its agents appear /
-  // disappear in the launch list (#9879).
-  const pluginAgentRegistry = useSyncExternalStore(
-    subscribeToPluginAgentRegistry,
-    getPluginAgentRegistrySnapshot
-  );
 
   const options = useMemo(() => {
-    // Referenced so this memo re-derives when plugins load/unload mid-session;
-    // getEffectiveAgentIds() below reads the merged (incl. plugin) registry (#9879).
-    void pluginAgentRegistry;
     const allOptions = getLaunchOptions();
     const registryAgentIds = new Set(getEffectiveAgentIds());
 
@@ -75,7 +62,7 @@ export function useNewTerminalPalette({
     filtered.push(getMoreAgentsOption());
 
     return filtered;
-  }, [availability, isAvailabilityInitialized, pluginAgentRegistry]);
+  }, [availability, isAvailabilityInitialized]);
 
   const { results, selectedIndex, close, ...paletteRest } = useSearchablePalette<LaunchOption>({
     items: options,

--- a/src/hooks/usePanelPalette.ts
+++ b/src/hooks/usePanelPalette.ts
@@ -1,8 +1,12 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import type { IFuseOptions } from "fuse.js";
 import { getPanelKindIds, getPanelKindConfig } from "@shared/config/panelKindRegistry";
 import { getPanelKindDefinition } from "@/registry";
 import { getEffectiveAgentIds, getEffectiveAgentConfig } from "@shared/config/agentRegistry";
+import {
+  subscribeToPluginAgentRegistry,
+  getPluginAgentRegistrySnapshot,
+} from "@shared/config/pluginAgentRegistry";
 import { useUserAgentRegistryStore } from "@/store/userAgentRegistryStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
@@ -69,12 +73,21 @@ export function usePanelPalette(): UsePanelPaletteReturn {
   const [keybindingVersion, setKeybindingVersion] = useState(0);
   const [resumeSessions, setResumeSessions] = useState<AgentSessionRecord[]>([]);
   const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
+  // Re-render when a plugin loads/unloads mid-session so agent icon/name/color
+  // refresh from the updated registry (#9879).
+  const pluginAgentRegistry = useSyncExternalStore(
+    subscribeToPluginAgentRegistry,
+    getPluginAgentRegistrySnapshot
+  );
 
   useEffect(() => {
     return keybindingService.subscribe(() => setKeybindingVersion((v) => v + 1));
   }, []);
 
   const availableKinds = useMemo<PanelKindOption[]>(() => {
+    // Referenced so this memo re-derives when plugins load/unload mid-session;
+    // getEffectiveAgentIds/Config below read the merged (incl. plugin) registry (#9879).
+    void pluginAgentRegistry;
     const panelKinds = getPanelKindIds()
       .filter((kindId) => {
         if (kindId === "agent") return false;
@@ -175,7 +188,14 @@ export function usePanelPalette(): UsePanelPaletteReturn {
       ...toolDedup.values(),
       ...resumeOptions,
     ];
-  }, [userRegistry, keybindingVersion, resumeSessions, availability, isAvailabilityInitialized]);
+  }, [
+    userRegistry,
+    keybindingVersion,
+    resumeSessions,
+    availability,
+    isAvailabilityInitialized,
+    pluginAgentRegistry,
+  ]);
 
   const { results, selectedIndex, close, isOpen, matchesById, ...paletteRest } =
     useSearchablePalette<PanelKindOption>({


### PR DESCRIPTION
## Summary

- `setPluginAgentRegistry` / `registerPluginAgents` were mutating the module-level snapshot in `shared/config/pluginAgentRegistry.ts` with no subscriber notification, so render-path consumers of `getEffectiveAgentConfig` / `getEffectiveAgentIds` stayed stale until an unrelated re-render triggered a refresh
- Adds a `Set<() => void>` listener mechanism (`subscribeToPluginAgentRegistry` + `getPluginAgentRegistrySnapshot`) mirroring the pattern in `src/panels/registry.tsx`; `setPluginAgentRegistry` gets a reference-identity no-op guard and `rebuildSnapshot` notifies on every registry change; `clearPluginAgentRegistryForTests` resets listeners
- `usePanelPalette`, `useContentGridContext`, `TrashBinItem`, and `TrashGroupItem` now subscribe via `useSyncExternalStore` so they re-render immediately when the plugin agent registry changes

Resolves #9879

## Changes

- `shared/config/pluginAgentRegistry.ts` — listener set, `subscribeToPluginAgentRegistry`, `getPluginAgentRegistrySnapshot`, reference-identity guard in `setPluginAgentRegistry`, notify calls in `rebuildSnapshot`, listener reset in `clearPluginAgentRegistryForTests`
- `src/hooks/usePanelPalette.ts` — switch to `useSyncExternalStore` for plugin agent registry
- `src/components/Terminal/useContentGridContext.tsx` — same
- `src/components/Layout/TrashBinItem.tsx` / `TrashGroupItem.tsx` — same
- `shared/config/__tests__/pluginAgentRegistry.test.ts` — 8 new tests covering subscribe/notify/unsubscribe/snapshot/no-op guard/test reset

## Testing

- 8 unit tests added covering the subscription and snapshot contract
- Full suite (32 088 tests) passed locally — `npm run check`, `npm run test`, `npm run build` all clean