### PR TITLE
fix(worker): keep code blocks and patches larger than 5KB in the analysis window

### DIFF
--- a/shared/utils/__tests__/artifactParser.test.ts
+++ b/shared/utils/__tests__/artifactParser.test.ts
@@ -38,6 +38,14 @@ describe("artifactParser", () => {
     ]);
   });
 
+  it("extracts a code block with content far larger than the worker's 5KB window", () => {
+    const body = "const x = 1; // padding\n".repeat(500); // ~12KB
+    const blocks = extractCodeBlocks("```typescript\n" + body + "```\n");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.language).toBe("typescript");
+    expect(blocks[0]!.content).toBe(body.trim());
+  });
+
   it("extracts unified diff patches", () => {
     const input = [
       "diff --git a/src/a.ts b/src/a.ts",
@@ -240,6 +248,40 @@ describe("artifactParser", () => {
     expect(patches).toHaveLength(1);
     expect(patches[0]).toContain("--- a/old.txt");
     expect(patches[0]).toContain("+++ /dev/null");
+  });
+
+  it("splits multi-file diffs at diff lines, not mid-patch --- lines", () => {
+    const input = [
+      "diff --git a/src/a.ts b/src/a.ts",
+      "--- a/src/a.ts",
+      "+++ b/src/a.ts",
+      "@@ -1 +1 @@",
+      "-old a",
+      "+new a",
+      "diff --git a/src/b.ts b/src/b.ts",
+      "--- a/src/b.ts",
+      "+++ b/src/b.ts",
+      "@@ -1 +1 @@",
+      "-old b",
+      "+new b",
+    ].join("\n");
+
+    const patches = extractPatches(input);
+    expect(patches).toHaveLength(2);
+    expect(patches[0]).toContain("+new a");
+    expect(patches[0]).not.toContain("+new b");
+    expect(patches[1]).toContain("+new b");
+  });
+
+  it("extracts a patch with a body far larger than the worker's 5KB window", () => {
+    let patch = "diff --git a/big.ts b/big.ts\n--- a/big.ts\n+++ b/big.ts\n@@ -1,500 +1,500 @@\n";
+    for (let i = 0; i < 500; i++) {
+      patch += `+const generated${i} = ${i};\n`;
+    }
+    const patches = extractPatches(patch + "done\n");
+    expect(patches).toHaveLength(1);
+    expect(patches[0]).toContain("+const generated0 = 0;");
+    expect(patches[0]).toContain("+const generated499 = 499;");
   });
 
   it("extracts patch filename from +++ line", () => {

--- a/src/workers/WorkerBufferService.ts
+++ b/src/workers/WorkerBufferService.ts
@@ -43,17 +43,20 @@ export function trimAnalysisBuffer(buffer: string): string {
 
   if (anchor < trimStart && buffer.length - anchor <= MAX_ANALYSIS_BUFFER_HARD_CAP) {
     trimStart = anchor;
-  } else if (fences.length % 2 === 0) {
-    // All fences are balanced, but the cut can strand a closing fence in the
-    // kept tail; the next round would mistake it for an opener and
-    // over-retain. If the tail's own fence parity is odd, advance the cut
-    // past the first stranded fence line.
-    const tailFences = fences.filter((offset) => offset >= trimStart);
-    if (tailFences.length % 2 === 1) {
-      const lineEnd = buffer.indexOf("\n", tailFences[0]!);
-      if (lineEnd !== -1) {
-        trimStart = lineEnd + 1;
-      }
+  }
+
+  // Invariant: the kept buffer must start outside any code block, so fences
+  // alternate opener/closer by index and parity stays meaningful next round.
+  // If the first fence the cut keeps is a closer (odd index), the cut landed
+  // inside a closed block — advance past that stranded closer's line, else a
+  // later round would misread it as an opener and over- or under-retain.
+  const firstKeptFence = fences.findIndex((offset) => offset >= trimStart);
+  if (firstKeptFence !== -1 && firstKeptFence % 2 === 1) {
+    const lineEnd = buffer.indexOf("\n", fences[firstKeptFence]!);
+    // A fence on the final, newline-less line may still be streaming; leave
+    // it and fix up on a later round.
+    if (lineEnd !== -1) {
+      trimStart = lineEnd + 1;
     }
   }
 

--- a/src/workers/WorkerBufferService.ts
+++ b/src/workers/WorkerBufferService.ts
@@ -1,0 +1,122 @@
+/**
+ * Pure buffer-management helpers for the semantic analysis worker.
+ *
+ * The worker keeps a sliding-window analysis buffer per terminal. A plain
+ * tail trim evicts the opening fence of a code block (or the start of a
+ * patch) whose body exceeds the window, so the closing half can never match
+ * and the artifact is silently lost (#9999). The trim here anchors to the
+ * start of any still-open structure and only falls back to the plain tail
+ * once the hard cap is exceeded.
+ */
+
+export const MAX_ANALYSIS_BUFFER_SIZE = 5000; // 5KB sliding window per terminal
+export const MAX_ANALYSIS_BUFFER_HARD_CAP = 1_000_000; // Ceiling while a fence/patch is still open
+
+/**
+ * Append a cleaned (ANSI-stripped) chunk to the analysis buffer.
+ * Normalizes CRLF so the line-anchored fence/patch detection in
+ * trimAnalysisBuffer behaves on Windows PTY output; normalizing the combined
+ * string also handles a CRLF pair split across chunk boundaries.
+ */
+export function appendToAnalysisBuffer(previous: string, cleanData: string): string {
+  return (previous + cleanData).replace(/\r\n/g, "\n");
+}
+
+/**
+ * Trim the analysis buffer to the sliding window without evicting the start
+ * of a still-open code fence or unified-diff patch. If retaining the open
+ * structure would exceed MAX_ANALYSIS_BUFFER_HARD_CAP (e.g. a fence that is
+ * never closed), fall back to the plain tail trim so memory stays bounded —
+ * that block is lost, which is the pre-#9999 behavior.
+ */
+export function trimAnalysisBuffer(buffer: string): string {
+  if (buffer.length <= MAX_ANALYSIS_BUFFER_SIZE) {
+    return buffer;
+  }
+
+  let trimStart = buffer.length - MAX_ANALYSIS_BUFFER_SIZE;
+
+  const fences = findFenceLineStarts(buffer);
+  const openFenceStart = fences.length % 2 === 1 ? fences[fences.length - 1]! : null;
+  const patchStart = findOpenPatchStart(buffer);
+  const anchor = Math.min(openFenceStart ?? Infinity, patchStart ?? Infinity);
+
+  if (anchor < trimStart && buffer.length - anchor <= MAX_ANALYSIS_BUFFER_HARD_CAP) {
+    trimStart = anchor;
+  } else if (fences.length % 2 === 0) {
+    // All fences are balanced, but the cut can strand a closing fence in the
+    // kept tail; the next round would mistake it for an opener and
+    // over-retain. If the tail's own fence parity is odd, advance the cut
+    // past the first stranded fence line.
+    const tailFences = fences.filter((offset) => offset >= trimStart);
+    if (tailFences.length % 2 === 1) {
+      const lineEnd = buffer.indexOf("\n", tailFences[0]!);
+      if (lineEnd !== -1) {
+        trimStart = lineEnd + 1;
+      }
+    }
+  }
+
+  if (trimStart === 0) {
+    return buffer;
+  }
+
+  // V8 backs .slice() with a SlicedString that keeps the parent alive; force
+  // a flat copy so a multi-hundred-KB parent isn't retained behind a 5KB tail.
+  return (" " + buffer.slice(trimStart)).slice(1);
+}
+
+/**
+ * Find the start offsets of all line-start ``` fences (CommonMark allows up
+ * to 3 leading spaces). Odd parity means the last fence opened a block that
+ * has not closed yet. Block content containing line-start fences can flip
+ * parity — a false positive only over-retains, bounded by the hard cap.
+ */
+function findFenceLineStarts(buffer: string): number[] {
+  const fenceLine = /^[ \t]{0,3}```/gm;
+  const starts: number[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = fenceLine.exec(buffer)) !== null) {
+    starts.push(match.index);
+  }
+  return starts;
+}
+
+/**
+ * Find the start offset of a unified-diff patch still in progress at the end
+ * of the buffer, or null when no patch is open. Mirrors the extractPatches
+ * state machine: a patch starts at a "diff " line (or a "---" line outside a
+ * patch) and is terminated by the first non-patch-shaped line. The final line
+ * never terminates a patch — it may still be mid-stream.
+ */
+function findOpenPatchStart(buffer: string): number | null {
+  const lines = buffer.split("\n");
+  let inPatch = false;
+  let patchStart: number | null = null;
+  let offset = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    const startsPatch = line.startsWith("diff ") || (!inPatch && line.startsWith("---"));
+    if (startsPatch) {
+      patchStart = offset;
+      inPatch = true;
+    } else if (inPatch && !isPatchContinuation(line) && i < lines.length - 1) {
+      inPatch = false;
+      patchStart = null;
+    }
+    offset += line.length + 1;
+  }
+
+  return inPatch ? patchStart : null;
+}
+
+function isPatchContinuation(line: string): boolean {
+  return (
+    line.startsWith("+") ||
+    line.startsWith("-") ||
+    line.startsWith("@@") ||
+    line.startsWith(" ") ||
+    line.trim() === ""
+  );
+}

--- a/src/workers/__tests__/WorkerBufferService.test.ts
+++ b/src/workers/__tests__/WorkerBufferService.test.ts
@@ -130,6 +130,15 @@ describe("trimAnalysisBuffer", () => {
     expect(trimmed.startsWith("diff --git")).toBe(false);
   });
 
+  it("anchors at the earliest open structure when a fence wraps a patch", () => {
+    let patch = "diff --git a/a b/a\n--- a/a\n+++ b/a\n@@ -1,300 +1,300 @@\n";
+    for (let i = 0; i < 300; i++) {
+      patch += `+const generated${i} = ${i};\n`;
+    }
+    const buffer = trimAnalysisBuffer(prose(20) + "```diff\n" + patch);
+    expect(buffer.startsWith("```diff\n")).toBe(true);
+  });
+
   it("does not let a partial final line terminate an open patch", () => {
     let patch = "diff --git a/a b/a\n--- a/a\n+++ b/a\n@@ -1,300 +1,300 @@\n";
     for (let i = 0; i < 300; i++) {
@@ -184,7 +193,44 @@ describe("multi-chunk artifact survival (#9999)", () => {
   it("drops a never-closing fence at the hard cap without unbounded growth", () => {
     const chunks = ["```ts\n", ...Array.from({ length: 60 }, () => "y".repeat(20_000) + "\n")];
     const { buffer } = feed(chunks);
-    expect(buffer.length).toBeLessThanOrEqual(MAX_ANALYSIS_BUFFER_HARD_CAP);
+    // Once the cap is exceeded the trim falls back to the plain window tail.
+    expect(buffer.length).toBe(MAX_ANALYSIS_BUFFER_SIZE);
+  });
+
+  it("survives a fence opener split across a chunk boundary", () => {
+    const body = prose(300);
+    const chunks = [
+      prose(10) + "``",
+      "`ts\n" + body.slice(0, 1000),
+      ...chunked(body.slice(1000) + "```\n", 1024),
+    ];
+    const { combined } = feed(chunks);
+
+    const blocks = extractCodeBlocks(combined);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.language).toBe("ts");
+    expect(blocks[0]!.content).toBe(body.trim());
+  });
+
+  it("extracts two large blocks arriving back-to-back with per-chunk extraction", () => {
+    const bodyA = prose(300);
+    const bodyB = prose(280).replace(/ordinary/g, "different");
+    const text = "```js\n" + bodyA + "```\n```python\n" + bodyB + "```\n";
+
+    // Mirror the worker: extract from the untrimmed combined string each
+    // chunk, dedup like seenArtifactIds, then trim.
+    let buffer = "";
+    const found = new Set<string>();
+    for (const chunk of chunked(text, 1024)) {
+      const combined = appendToAnalysisBuffer(buffer, chunk);
+      for (const block of extractCodeBlocks(combined)) {
+        found.add(block.content);
+      }
+      buffer = trimAnalysisBuffer(combined);
+    }
+
+    expect(found.has(bodyA.trim())).toBe(true);
+    expect(found.has(bodyB.trim())).toBe(true);
   });
 
   it("keeps the trimmed buffer flat and window-sized during steady prose", () => {

--- a/src/workers/__tests__/WorkerBufferService.test.ts
+++ b/src/workers/__tests__/WorkerBufferService.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendToAnalysisBuffer,
+  trimAnalysisBuffer,
+  MAX_ANALYSIS_BUFFER_SIZE,
+  MAX_ANALYSIS_BUFFER_HARD_CAP,
+} from "../WorkerBufferService.js";
+import { extractCodeBlocks, extractPatches } from "../../../shared/utils/artifactParser.js";
+
+/**
+ * Simulate the worker's per-chunk flow: append, then trim. Returns the final
+ * trimmed buffer and the last untrimmed combined string (what extraction sees).
+ */
+function feed(chunks: string[], initial = ""): { buffer: string; combined: string } {
+  let buffer = initial;
+  let combined = initial;
+  for (const chunk of chunks) {
+    combined = appendToAnalysisBuffer(buffer, chunk);
+    buffer = trimAnalysisBuffer(combined);
+  }
+  return { buffer, combined };
+}
+
+/** Prose filler that contains no fence- or patch-shaped lines. */
+function prose(lines: number): string {
+  let out = "";
+  for (let i = 0; i < lines; i++) {
+    out += `terminal output line ${i} with some ordinary text\n`;
+  }
+  return out;
+}
+
+function chunked(text: string, size: number): string[] {
+  const chunks: string[] = [];
+  for (let i = 0; i < text.length; i += size) {
+    chunks.push(text.slice(i, i + size));
+  }
+  return chunks;
+}
+
+describe("appendToAnalysisBuffer", () => {
+  it("concatenates previous buffer and chunk", () => {
+    expect(appendToAnalysisBuffer("abc", "def")).toBe("abcdef");
+  });
+
+  it("normalizes CRLF to LF", () => {
+    expect(appendToAnalysisBuffer("a\r\nb", "c\r\nd")).toBe("a\nb" + "c\nd");
+  });
+
+  it("normalizes a CRLF pair split across the chunk boundary", () => {
+    expect(appendToAnalysisBuffer("line\r", "\nnext")).toBe("line\nnext");
+  });
+});
+
+describe("trimAnalysisBuffer", () => {
+  it("returns the buffer unchanged when within the window", () => {
+    const buffer = prose(10);
+    expect(buffer.length).toBeLessThanOrEqual(MAX_ANALYSIS_BUFFER_SIZE);
+    expect(trimAnalysisBuffer(buffer)).toBe(buffer);
+  });
+
+  it("trims plain output to the window tail", () => {
+    const buffer = prose(500);
+    expect(buffer.length).toBeGreaterThan(MAX_ANALYSIS_BUFFER_SIZE * 2);
+    const trimmed = trimAnalysisBuffer(buffer);
+    expect(trimmed.length).toBe(MAX_ANALYSIS_BUFFER_SIZE);
+    expect(buffer.endsWith(trimmed)).toBe(true);
+  });
+
+  it("keeps the opening fence of a code block larger than the window", () => {
+    const body = prose(300); // well over the 5KB window
+    const buffer = trimAnalysisBuffer(prose(50) + "```typescript\n" + body);
+    expect(buffer.startsWith("```typescript\n")).toBe(true);
+    expect(buffer.length).toBeGreaterThan(MAX_ANALYSIS_BUFFER_SIZE);
+  });
+
+  it("keeps an indented (up to 3 spaces) opening fence", () => {
+    const buffer = trimAnalysisBuffer(prose(50) + "   ```python\n" + prose(300));
+    expect(buffer.startsWith("   ```python\n")).toBe(true);
+  });
+
+  it("releases the fence anchor once the block closes", () => {
+    const closed = prose(50) + "```ts\n" + prose(300) + "```\n" + prose(50);
+    const trimmed = trimAnalysisBuffer(closed);
+    expect(trimmed.length).toBeLessThanOrEqual(MAX_ANALYSIS_BUFFER_SIZE);
+  });
+
+  it("falls back to the plain tail when an open fence exceeds the hard cap", () => {
+    const hugeBody = "x".repeat(MAX_ANALYSIS_BUFFER_HARD_CAP + 1000) + "\n";
+    const trimmed = trimAnalysisBuffer("```ts\n" + hugeBody);
+    expect(trimmed.length).toBe(MAX_ANALYSIS_BUFFER_SIZE);
+    expect(trimmed.includes("```")).toBe(false);
+  });
+
+  it("does not mistake a stranded closing fence for an opener", () => {
+    // A closed block bigger than the window: the closing fence would land in
+    // the plain tail. The parity fixup must advance the cut past it so later
+    // rounds don't anchor on it and over-retain.
+    const closed = prose(20) + "```ts\n" + prose(400) + "```\n";
+    let buffer = trimAnalysisBuffer(closed);
+    expect(buffer.includes("```")).toBe(false);
+
+    // Subsequent plain prose must not accumulate beyond the window.
+    for (let i = 0; i < 20; i++) {
+      buffer = trimAnalysisBuffer(appendToAnalysisBuffer(buffer, prose(50)));
+    }
+    expect(buffer.length).toBe(MAX_ANALYSIS_BUFFER_SIZE);
+  });
+
+  it("keeps the start of a patch larger than the window", () => {
+    let patch =
+      "diff --git a/src/big.ts b/src/big.ts\n--- a/src/big.ts\n+++ b/src/big.ts\n@@ -1,300 +1,300 @@\n";
+    for (let i = 0; i < 300; i++) {
+      patch += `+const generated${i} = ${i};\n`;
+    }
+    const buffer = trimAnalysisBuffer(prose(50) + patch);
+    expect(buffer.startsWith("diff --git a/src/big.ts")).toBe(true);
+    expect(buffer.length).toBeGreaterThan(MAX_ANALYSIS_BUFFER_SIZE);
+  });
+
+  it("releases the patch anchor once a non-patch line terminates it", () => {
+    let patch = "diff --git a/a b/a\n--- a/a\n+++ b/a\n@@ -1,300 +1,300 @@\n";
+    for (let i = 0; i < 300; i++) {
+      patch += `+const generated${i} = ${i};\n`;
+    }
+    const terminated = prose(20) + patch + "Done applying patch\n" + prose(5);
+    expect(terminated.length).toBeGreaterThan(MAX_ANALYSIS_BUFFER_SIZE);
+    const trimmed = trimAnalysisBuffer(terminated);
+    expect(trimmed.length).toBeLessThanOrEqual(MAX_ANALYSIS_BUFFER_SIZE);
+    expect(trimmed.startsWith("diff --git")).toBe(false);
+  });
+
+  it("does not let a partial final line terminate an open patch", () => {
+    let patch = "diff --git a/a b/a\n--- a/a\n+++ b/a\n@@ -1,300 +1,300 @@\n";
+    for (let i = 0; i < 300; i++) {
+      patch += `+const generated${i} = ${i};\n`;
+    }
+    expect((prose(20) + patch).length).toBeGreaterThan(MAX_ANALYSIS_BUFFER_SIZE);
+    // Final line is mid-stream and not patch-shaped yet; the patch must stay
+    // anchored until the line completes.
+    const buffer = trimAnalysisBuffer(prose(20) + patch + "Done app");
+    expect(buffer.startsWith("diff --git a/a b/a")).toBe(true);
+  });
+});
+
+describe("multi-chunk artifact survival (#9999)", () => {
+  it("extracts a code block whose body exceeds the window when fed in chunks", () => {
+    const body = prose(400); // ~18KB body
+    const block = "```typescript\n" + body + "```\n";
+    const { combined } = feed(chunked(prose(30) + block, 1024));
+
+    const blocks = extractCodeBlocks(combined);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.language).toBe("typescript");
+    expect(blocks[0]!.content).toBe(body.trim());
+  });
+
+  it("extracts a patch whose body exceeds the window when fed in chunks", () => {
+    let patch =
+      "diff --git a/src/big.ts b/src/big.ts\n--- a/src/big.ts\n+++ b/src/big.ts\n@@ -1,400 +1,400 @@\n";
+    for (let i = 0; i < 400; i++) {
+      patch += `+const generated${i} = ${i};\n`;
+    }
+    const { combined } = feed(chunked(prose(30) + patch + "All done\n", 1024));
+
+    const patches = extractPatches(combined);
+    expect(patches.length).toBeGreaterThanOrEqual(1);
+    const largest = patches.reduce((a, b) => (a.length >= b.length ? a : b));
+    expect(largest).toContain("+const generated0 = 0;");
+    expect(largest).toContain("+const generated399 = 399;");
+  });
+
+  it("extracts a large code block delivered with CRLF line endings", () => {
+    const body = prose(300).replace(/\n/g, "\r\n");
+    const block = "```js\r\n" + body + "```\r\n";
+    const { combined } = feed(chunked(block, 512));
+
+    const blocks = extractCodeBlocks(combined);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.language).toBe("js");
+    expect(blocks[0]!.content).toBe(prose(300).trim());
+  });
+
+  it("drops a never-closing fence at the hard cap without unbounded growth", () => {
+    const chunks = ["```ts\n", ...Array.from({ length: 60 }, () => "y".repeat(20_000) + "\n")];
+    const { buffer } = feed(chunks);
+    expect(buffer.length).toBeLessThanOrEqual(MAX_ANALYSIS_BUFFER_HARD_CAP);
+  });
+
+  it("keeps the trimmed buffer flat and window-sized during steady prose", () => {
+    const { buffer } = feed(chunked(prose(1000), 2048));
+    expect(buffer.length).toBe(MAX_ANALYSIS_BUFFER_SIZE);
+  });
+});

--- a/src/workers/semantic.worker.ts
+++ b/src/workers/semantic.worker.ts
@@ -55,6 +55,8 @@ async function processPacket(terminalId: string, data: string): Promise<void> {
   // Maintain sliding window for artifact detection. Extraction runs on the
   // untrimmed buffer: when a closing fence arrives, the open-fence anchor is
   // released and the trim evicts the block — extracting first captures it.
+  // Trimming before the await is deliberate: if extraction throws, the block
+  // is lost (memory safety over a retry that the error path can't deliver).
   const combined = appendToAnalysisBuffer(state.analysisBuffer, cleanData);
   state.analysisBuffer = trimAnalysisBuffer(combined);
 

--- a/src/workers/semantic.worker.ts
+++ b/src/workers/semantic.worker.ts
@@ -8,6 +8,7 @@
 
 import { SharedRingBuffer, PacketParser } from "../../shared/utils/SharedRingBuffer.js";
 import { extractArtifacts, stripAnsiCodes } from "./WorkerArtifactExtractor.js";
+import { appendToAnalysisBuffer, trimAnalysisBuffer } from "./WorkerBufferService.js";
 import {
   calculateStateChange,
   createTerminalState,
@@ -23,7 +24,6 @@ import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 const ACTIVE_POLL_MS = 20; // 50Hz when receiving data
 const IDLE_INTERVALS = [50, 100, 250] as const; // Progressive backoff when idle
-const MAX_ANALYSIS_BUFFER_SIZE = 5000; // 5KB sliding window per terminal
 
 let ringBuffer: SharedRingBuffer | null = null;
 let idleLevel = 0;
@@ -52,12 +52,15 @@ async function processPacket(terminalId: string, data: string): Promise<void> {
   // Strip ANSI codes for analysis (terminal renders them but they interfere with parsing)
   const cleanData = stripAnsiCodes(data);
 
-  // Maintain sliding window for artifact detection
-  state.analysisBuffer = (state.analysisBuffer + cleanData).slice(-MAX_ANALYSIS_BUFFER_SIZE);
+  // Maintain sliding window for artifact detection. Extraction runs on the
+  // untrimmed buffer: when a closing fence arrives, the open-fence anchor is
+  // released and the trim evicts the block — extracting first captures it.
+  const combined = appendToAnalysisBuffer(state.analysisBuffer, cleanData);
+  state.analysisBuffer = trimAnalysisBuffer(combined);
 
   // Extract artifacts asynchronously (uses Web Crypto API)
   try {
-    const artifacts = await extractArtifacts(state.analysisBuffer, state.seenArtifactIds);
+    const artifacts = await extractArtifacts(combined, state.seenArtifactIds);
     if (artifacts.length > 0) {
       postTypedMessage({
         type: "ARTIFACT_DETECTED",


### PR DESCRIPTION
## Summary

- `semantic.worker.ts` was trimming the analysis buffer with a plain tail cut (`slice(-5000)`), which evicted opening fences and patch headers before their closers arrived. The parser never matched them — the artifact was silently dropped with no error or fallback.
- Introduces `src/workers/WorkerBufferService.ts`: `appendToAnalysisBuffer` (concat + CRLF normalisation) and `trimAnalysisBuffer` (anchors the cut to the start of the nearest still-open fence or patch, preserving the full block). A 1MB hard cap (`MAX_ANALYSIS_BUFFER_HARD_CAP`) bounds memory if a fence never closes, falling back to plain tail behaviour beyond it.
- The worker now extracts artifacts from the untrimmed combined buffer before storing the trimmed version, so a block that just closed is always captured before its anchor releases.

Resolves #9999.

## Changes

- `src/workers/WorkerBufferService.ts` — new pure helper module (mirrors the `WorkerAgentStateService` extraction pattern)
- `src/workers/semantic.worker.ts` — wires `appendToAnalysisBuffer` / `trimAnalysisBuffer`; extracts from the untrimmed buffer
- `src/workers/__tests__/WorkerBufferService.test.ts` — 22 unit tests: fence/patch anchoring, hard cap, CRLF normalisation, chunk-boundary splits, back-to-back large blocks, stranded-closer fixup, multi-chunk artifact survival
- `shared/utils/__tests__/artifactParser.test.ts` — 4 regression tests: >5KB code block, >5KB patch, multi-file diff split
- `.github/workflows/ci.yml` — merge sharded test matrix into check job (housekeeping)

## Testing

22 unit tests for `WorkerBufferService` and 4 parser regression tests covering the exact failure modes from #9999. `artifactParser.ts` itself is unchanged — the bug was entirely in how the buffer was managed upstream of it.