### PR TITLE
fix(context): Test Config preview honors cleared unsaved form fields

### DIFF
--- a/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
@@ -123,6 +123,29 @@ describe("copyTree handlers", () => {
     );
   });
 
+  it("accepts null-cleared fields in test-config payloads", async () => {
+    const handler = getInvokeHandler(CHANNELS.COPYTREE_TEST_CONFIG);
+
+    // copyTree channels share the "fileOps" rate-limit bucket; advance past the
+    // window so earlier handler calls in this suite don't preempt validation.
+    vi.useFakeTimers();
+    try {
+      vi.advanceTimersByTime(11_000);
+      await expect(
+        handler(mockEvent, {
+          worktreeId: "wt-1",
+          options: { maxTotalSize: null, charLimit: null, exclude: null, always: null, sort: null },
+        })
+      ).resolves.toEqual(
+        expect.objectContaining({
+          error: expect.not.stringMatching(/^Invalid payload$/),
+        })
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("throws a sanitized ValidationError without Zod detail for invalid file tree requests", async () => {
     const handler = getInvokeHandler(CHANNELS.COPYTREE_GET_FILE_TREE);
 
@@ -194,6 +217,68 @@ describe("mergeCopyTreeOptions", () => {
     expect(result.charLimit).toBe(3000);
     expect(result.sort).toBe("name");
     expect(result.always).toEqual(["README.md"]);
+  });
+
+  it("does not back-fill project settings over explicitly cleared (null) fields", () => {
+    const projectSettings = {
+      excludedPaths: ["node_modules"],
+      copyTreeSettings: {
+        maxContextSize: 1000,
+        maxFileSize: 2000,
+        charLimit: 3000,
+        strategy: "modified",
+        alwaysInclude: ["README.md"],
+        alwaysExclude: ["dist"],
+      } as never,
+    };
+
+    const backfilled = mergeCopyTreeOptions(projectSettings, {});
+    const cleared = mergeCopyTreeOptions(projectSettings, {
+      exclude: null,
+      always: null,
+      maxFileSize: null,
+      maxTotalSize: null,
+      charLimit: null,
+      sort: null,
+    });
+
+    // The same settings that back-fill absent fields must not survive cleared ones.
+    expect(backfilled.maxTotalSize).toBeDefined();
+    expect(backfilled.maxFileSize).toBeDefined();
+    expect(backfilled.charLimit).toBeDefined();
+    expect(backfilled.sort).toBeDefined();
+    expect(backfilled.always).toBeDefined();
+    expect(backfilled.exclude).toBeDefined();
+
+    expect(cleared).toEqual({});
+  });
+
+  it("treats cleared, absent, and set fields independently in one merge", () => {
+    const copyTreeSettings = {
+      maxContextSize: 1000,
+      maxFileSize: 2000,
+      charLimit: 3000,
+    };
+    const result = mergeCopyTreeOptions(
+      { excludedPaths: [], copyTreeSettings: copyTreeSettings as never },
+      { maxTotalSize: null, charLimit: 50 }
+    );
+
+    expect(result.maxTotalSize).toBeUndefined(); // cleared → no back-fill
+    expect(result.maxFileSize).toBe(copyTreeSettings.maxFileSize); // absent → back-filled
+    expect(result.charLimit).toBe(50); // runtime wins
+  });
+
+  it("strips null sentinels so the result only carries values or absent keys", () => {
+    const result = mergeCopyTreeOptions(undefined, {
+      format: "xml",
+      maxTotalSize: null,
+      exclude: null,
+    });
+
+    expect(result.format).toBe("xml");
+    expect("maxTotalSize" in result).toBe(false);
+    expect("exclude" in result).toBe(false);
   });
 });
 

--- a/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
@@ -162,6 +162,71 @@ describe("copyTree handlers", () => {
       vi.useRealTimers();
     }
   });
+
+  describe("test-config merge integration", () => {
+    const projectSettingsFixture = {
+      excludedPaths: [],
+      copyTreeSettings: { maxContextSize: 9999, alwaysInclude: ["*.md"] },
+    };
+
+    function registerWithWorktreeService() {
+      const testConfig = vi.fn().mockResolvedValue({
+        includedFiles: 1,
+        includedSize: 1,
+        excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
+      });
+      // Re-register so the channel resolves to a handler whose worktreeService
+      // is live; clear ipcMain.handle first so getInvokeHandler finds this one.
+      ipcMainMock.handle.mockClear();
+      registerCopyTreeHandlers({
+        mainWindow: {
+          isDestroyed: () => false,
+          webContents: { isDestroyed: () => false, send: vi.fn() },
+        },
+        ptyClient: { hasTerminal: vi.fn(() => false), write: vi.fn() },
+        worktreeService: {
+          getAllStatesAsync: vi.fn().mockResolvedValue([{ id: "wt-1", path: "/wt-1" }]),
+          testConfig,
+        },
+      } as never);
+      projectStoreMock.getCurrentProjectId.mockReturnValue("proj-1" as never);
+      projectStoreMock.getProjectSettings.mockResolvedValue(projectSettingsFixture as never);
+      return testConfig;
+    }
+
+    async function invokeTestConfig(options: unknown) {
+      const handler = getInvokeHandler(CHANNELS.COPYTREE_TEST_CONFIG);
+      vi.useFakeTimers();
+      try {
+        vi.advanceTimersByTime(11_000);
+        await handler(mockEvent, { worktreeId: "wt-1", options });
+      } finally {
+        vi.useRealTimers();
+      }
+    }
+
+    it("does not back-fill saved settings over null-cleared fields", async () => {
+      const testConfig = registerWithWorktreeService();
+
+      await invokeTestConfig({ maxTotalSize: null, always: null });
+
+      const [, mergedOptions] = testConfig.mock.calls[0];
+      expect("maxTotalSize" in mergedOptions).toBe(false);
+      expect("always" in mergedOptions).toBe(false);
+    });
+
+    it("back-fills saved settings for absent fields", async () => {
+      const testConfig = registerWithWorktreeService();
+
+      await invokeTestConfig({});
+
+      const [, mergedOptions] = testConfig.mock.calls[0];
+      expect(mergedOptions.maxTotalSize).toBe(
+        projectSettingsFixture.copyTreeSettings.maxContextSize
+      );
+      expect(mergedOptions.always).toEqual(projectSettingsFixture.copyTreeSettings.alwaysInclude);
+    });
+  });
 });
 
 describe("mergeCopyTreeOptions", () => {

--- a/electron/ipc/handlers/copyTree.ts
+++ b/electron/ipc/handlers/copyTree.ts
@@ -100,7 +100,11 @@ import {
   CopyTreeCancelPayloadSchema,
   CopyTreeTestConfigPayloadSchema,
 } from "../../schemas/ipc.js";
-import type { CopyTreeCancelPayload, ProjectSettings } from "../../types/index.js";
+import type {
+  CopyTreeCancelPayload,
+  CopyTreeTestConfigOptions,
+  ProjectSettings,
+} from "../../types/index.js";
 import { projectStore } from "../../services/ProjectStore.js";
 import { contextInjectionTracker } from "../../services/ContextInjectionTracker.js";
 
@@ -114,8 +118,28 @@ function getStringField(payload: unknown, key: string): string | undefined {
 }
 
 /**
+ * Drop `null`-valued keys so downstream CopyTree code only ever sees
+ * `T | undefined`. `null` marks a field the caller explicitly cleared
+ * (test-config dry runs) — it has done its job once the merge is over.
+ */
+function stripClearedFields(options: CopyTreeTestConfigOptions): CopyTreeOptions {
+  const result = { ...options };
+  for (const key of Object.keys(result) as Array<keyof CopyTreeTestConfigOptions>) {
+    if (result[key] === null) {
+      delete result[key];
+    }
+  }
+  return result as CopyTreeOptions;
+}
+
+/**
  * Merge project-level settings with runtime CopyTree options.
  * Runtime options take precedence over project settings.
+ *
+ * A `null` runtime value means "explicitly cleared": the field is excluded
+ * from the project-settings back-fill (the `=== undefined` guards skip it)
+ * and stripped from the result. An absent/`undefined` field still falls back
+ * to project settings.
  *
  * Merges both:
  * - ProjectSettings.excludedPaths (default exclusions)
@@ -123,13 +147,13 @@ function getStringField(payload: unknown, key: string): string | undefined {
  */
 export function mergeCopyTreeOptions(
   projectSettings: Pick<ProjectSettings, "excludedPaths" | "copyTreeSettings"> | undefined,
-  runtimeOptions: CopyTreeOptions | undefined
+  runtimeOptions: CopyTreeOptions | CopyTreeTestConfigOptions | undefined
 ): CopyTreeOptions {
   if (!projectSettings) {
-    return runtimeOptions || {};
+    return stripClearedFields(runtimeOptions || {});
   }
 
-  const merged: CopyTreeOptions = {
+  const merged: CopyTreeTestConfigOptions = {
     ...runtimeOptions,
   };
 
@@ -158,7 +182,7 @@ export function mergeCopyTreeOptions(
   }
 
   if (!copyTreeSettings) {
-    return merged;
+    return stripClearedFields(merged);
   }
 
   if (copyTreeSettings.maxContextSize !== undefined && merged.maxTotalSize === undefined) {
@@ -182,7 +206,7 @@ export function mergeCopyTreeOptions(
     merged.always = copyTreeSettings.alwaysInclude;
   }
 
-  return merged;
+  return stripClearedFields(merged);
 }
 
 /**

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -76,6 +76,7 @@ import type {
   TerminalSpawnOptions,
   CopyTreeOptions,
   CopyTreeProgress,
+  CopyTreeTestConfigOptions,
   AppState,
   LogEntry,
   LogFilterOptions,
@@ -1116,7 +1117,7 @@ const api: ElectronAPI = {
     getFileTree: (worktreeId: string, dirPath?: string) =>
       _unwrappingInvoke(CHANNELS.COPYTREE_GET_FILE_TREE, { worktreeId, dirPath }),
 
-    testConfig: (worktreeId: string, options?: CopyTreeOptions) =>
+    testConfig: (worktreeId: string, options?: CopyTreeTestConfigOptions) =>
       _unwrappingInvoke(CHANNELS.COPYTREE_TEST_CONFIG, { worktreeId, options }),
 
     onProgress: (callback: (progress: CopyTreeProgress) => void) =>

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -374,9 +374,24 @@ export const CopyTreeCancelPayloadSchema = z.object({
   injectionId: z.string().min(1).optional(),
 });
 
+// Test-config dry runs send `null` for fields the user explicitly cleared in the
+// unsaved settings form (Electron's structured clone drops `undefined` keys, so
+// `null` is the only sentinel that survives IPC). `null` blocks the saved-settings
+// back-fill in mergeCopyTreeOptions; absent/undefined still falls back.
+export const CopyTreeTestConfigOptionsSchema = CopyTreeOptionsSchema.unwrap()
+  .extend({
+    exclude: z.union([z.string(), z.array(z.string())]).nullish(),
+    always: z.array(z.string()).nullish(),
+    maxFileSize: z.number().int().positive().nullish(),
+    maxTotalSize: z.number().int().positive().nullish(),
+    charLimit: z.number().int().positive().nullish(),
+    sort: z.enum(["path", "size", "modified", "name", "extension", "depth"]).nullish(),
+  })
+  .optional();
+
 export const CopyTreeTestConfigPayloadSchema = z.object({
   worktreeId: z.string().min(1),
-  options: CopyTreeOptionsSchema,
+  options: CopyTreeTestConfigOptionsSchema,
 });
 
 export const CopyTreeProgressSchema = z.object({

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -123,6 +123,7 @@ export type {
   CopyTreeInjectPayload,
   CopyTreeCancelPayload,
   CopyTreeGetFileTreePayload,
+  CopyTreeTestConfigOptions,
   CopyTreeTestConfigPayload,
   CopyTreeTestConfigResult,
   CopyTreeResult,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -79,6 +79,7 @@ import type {
 import type {
   CopyTreeResult,
   CopyTreeOptions,
+  CopyTreeTestConfigOptions,
   FileTreeNode,
   CopyTreeProgress,
 } from "./copyTree.js";
@@ -341,7 +342,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     getFileTree(worktreeId: string, dirPath?: string): Promise<FileTreeNode[]>;
     testConfig(
       worktreeId: string,
-      options?: CopyTreeOptions
+      options?: CopyTreeTestConfigOptions
     ): Promise<import("./copyTree.js").CopyTreeTestConfigResult>;
     onProgress(callback: (progress: CopyTreeProgress) => void): () => void;
   };

--- a/shared/types/ipc/copyTree.ts
+++ b/shared/types/ipc/copyTree.ts
@@ -54,10 +54,29 @@ export interface CopyTreeCancelPayload {
   injectionId?: string;
 }
 
+/**
+ * Options for the test-config dry run. `null` marks a field the user explicitly
+ * cleared in the unsaved settings form — it blocks the saved-settings back-fill
+ * in the main process, while `undefined`/absent still falls back. The sentinel
+ * must be `null` (not `undefined`) because Electron's structured clone drops
+ * `undefined`-valued keys in transit.
+ */
+export interface CopyTreeTestConfigOptions extends Omit<
+  CopyTreeOptions,
+  "exclude" | "always" | "maxFileSize" | "maxTotalSize" | "charLimit" | "sort"
+> {
+  exclude?: string | string[] | null;
+  always?: string[] | null;
+  maxFileSize?: number | null;
+  maxTotalSize?: number | null;
+  charLimit?: number | null;
+  sort?: CopyTreeOptions["sort"] | null;
+}
+
 /** Payload for testing CopyTree configuration (dry run) */
 export interface CopyTreeTestConfigPayload {
   worktreeId: string;
-  options?: CopyTreeOptions;
+  options?: CopyTreeTestConfigOptions;
 }
 
 /** Result from CopyTree dry run test */

--- a/src/clients/copyTreeClient.ts
+++ b/src/clients/copyTreeClient.ts
@@ -2,6 +2,7 @@ import type {
   CopyTreeOptions,
   CopyTreeResult,
   CopyTreeProgress,
+  CopyTreeTestConfigOptions,
   CopyTreeTestConfigResult,
   FileTreeNode,
 } from "@shared/types";
@@ -38,7 +39,7 @@ export const copyTreeClient = {
 
   testConfig: (
     worktreeId: string,
-    options?: CopyTreeOptions
+    options?: CopyTreeTestConfigOptions
   ): Promise<CopyTreeTestConfigResult> => {
     return window.electron.copyTree.testConfig(worktreeId, options);
   },

--- a/src/components/Project/ContextTab.tsx
+++ b/src/components/Project/ContextTab.tsx
@@ -77,39 +77,25 @@ export function ContextTab({
     setTestConfigResult(null);
 
     try {
-      const testOptions: import("@/types").CopyTreeOptions = {};
+      // Send the complete form state so the dry run reflects exactly what is
+      // on screen: a value when set, an explicit null when cleared. null (not
+      // undefined — structured clone drops undefined keys) blocks the
+      // saved-settings back-fill in the main process for that field.
+      const excludePatterns = [...excludedPaths, ...(copyTreeSettings.alwaysExclude ?? [])]
+        .map((p) => p.trim())
+        .filter(Boolean);
+      const alwaysPatterns = (copyTreeSettings.alwaysInclude ?? [])
+        .map((p) => p.trim())
+        .filter(Boolean);
 
-      if (excludedPaths.length > 0) {
-        const sanitizedPaths = excludedPaths.map((p) => p.trim()).filter(Boolean);
-        if (sanitizedPaths.length > 0) {
-          testOptions.exclude = sanitizedPaths;
-        }
-      }
-
-      if (copyTreeSettings.maxContextSize !== undefined) {
-        testOptions.maxTotalSize = copyTreeSettings.maxContextSize;
-      }
-      if (copyTreeSettings.maxFileSize !== undefined) {
-        testOptions.maxFileSize = copyTreeSettings.maxFileSize;
-      }
-      if (copyTreeSettings.charLimit !== undefined) {
-        testOptions.charLimit = copyTreeSettings.charLimit;
-      }
-      if (copyTreeSettings.strategy === "modified") {
-        testOptions.sort = "modified";
-      }
-      if (copyTreeSettings.alwaysInclude && copyTreeSettings.alwaysInclude.length > 0) {
-        const sanitized = copyTreeSettings.alwaysInclude.map((p) => p.trim()).filter(Boolean);
-        if (sanitized.length > 0) {
-          testOptions.always = sanitized;
-        }
-      }
-      if (copyTreeSettings.alwaysExclude && copyTreeSettings.alwaysExclude.length > 0) {
-        const sanitized = copyTreeSettings.alwaysExclude.map((p) => p.trim()).filter(Boolean);
-        if (sanitized.length > 0) {
-          testOptions.exclude = [...(testOptions.exclude || []), ...sanitized];
-        }
-      }
+      const testOptions: import("@/types").CopyTreeTestConfigOptions = {
+        exclude: excludePatterns.length > 0 ? excludePatterns : null,
+        always: alwaysPatterns.length > 0 ? alwaysPatterns : null,
+        maxTotalSize: copyTreeSettings.maxContextSize ?? null,
+        maxFileSize: copyTreeSettings.maxFileSize ?? null,
+        charLimit: copyTreeSettings.charLimit ?? null,
+        sort: copyTreeSettings.strategy === "modified" ? "modified" : null,
+      };
 
       const result = await copyTreeClient.testConfig(mainWorktree.id, testOptions);
       if (runIdRef.current !== runId) return;

--- a/src/components/Project/__tests__/ContextTab.test.tsx
+++ b/src/components/Project/__tests__/ContextTab.test.tsx
@@ -272,7 +272,7 @@ describe("ContextTab test-config payload", () => {
       fireEvent.click(screen.getByRole("button", { name: "Test config" }));
     });
 
-    const [, options] = testConfigMock.mock.calls[0];
+    const [, options] = testConfigMock.mock.calls[0]!;
     expect(options.exclude).toBeNull();
   });
 });

--- a/src/components/Project/__tests__/ContextTab.test.tsx
+++ b/src/components/Project/__tests__/ContextTab.test.tsx
@@ -222,6 +222,61 @@ describe("ContextTab test-config button", () => {
   });
 });
 
+describe("ContextTab test-config payload", () => {
+  it("sends explicit null sentinels for every cleared field on an empty form", async () => {
+    testConfigMock.mockResolvedValue(successResult);
+    renderTab();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Test config" }));
+    });
+
+    // null (not omitted) — omitted keys are back-filled from saved settings in
+    // the main process, which is the exact bug this guards against (#10004).
+    expect(testConfigMock).toHaveBeenCalledWith("wt-1", {
+      exclude: null,
+      always: null,
+      maxTotalSize: null,
+      maxFileSize: null,
+      charLimit: null,
+      sort: null,
+    });
+  });
+
+  it("sends form values for set fields and null for cleared fields", async () => {
+    testConfigMock.mockResolvedValue(successResult);
+    renderTab({
+      excludedPaths: ["node_modules/**"],
+      copyTreeSettings: { maxContextSize: 5000, strategy: "modified" } as CopyTreeSettings,
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Test config" }));
+    });
+
+    expect(testConfigMock).toHaveBeenCalledWith("wt-1", {
+      exclude: ["node_modules/**"],
+      always: null,
+      maxTotalSize: 5000,
+      maxFileSize: null,
+      charLimit: null,
+      sort: "modified",
+    });
+  });
+
+  it("treats whitespace-only patterns as cleared, sending null instead of empty entries", async () => {
+    testConfigMock.mockResolvedValue(successResult);
+    renderTab({ excludedPaths: ["   ", ""] });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Test config" }));
+    });
+
+    const [, options] = testConfigMock.mock.calls[0];
+    expect(options.exclude).toBeNull();
+  });
+});
+
 describe("ContextTab — DOM anchors for settings deep-links", () => {
   it("exposes the project-excluded-paths anchor for settings deep-links", () => {
     const { container } = renderTab();


### PR DESCRIPTION
## Summary

- The Test Config dry-run in the Context settings tab only sent non-empty form values. Fields the user cleared arrived at the main process as absent keys, which `mergeCopyTreeOptions` back-filled from saved settings — the preview silently showed stale values instead of reflecting what the user had actually cleared.
- Fix: the renderer now always sends the complete form state, using `null` as an explicit "cleared" sentinel (`null` survives Electron's structured clone; `undefined` keys are dropped in transit).
- A new `CopyTreeTestConfigOptions` type and `CopyTreeTestConfigOptionsSchema` (with `.nullish()` on the 6 clearable fields) carries the sentinel for test-config calls only — the shared `CopyTreeOptionsSchema` used by generate/inject is untouched. A new `stripClearedFields()` helper in `mergeCopyTreeOptions` removes null keys at every return path so downstream `CopyTreeService` only ever sees `T | undefined`.

Resolves #10004

## Changes

- `shared/types/ipc/copyTree.ts` — new `CopyTreeTestConfigOptions` type with `null`-able clearable fields
- `electron/schemas/ipc.ts` — new `CopyTreeTestConfigOptionsSchema` with `.nullish()` on clearable fields
- `electron/ipc/handlers/copyTree.ts` — `stripClearedFields()` helper; test-config handler uses the new schema
- `electron/preload.cts`, `src/clients/copyTreeClient.ts` — thread the new type through the IPC boundary
- `src/components/Project/ContextTab.tsx` — always send all 6 clearable fields; use `null` for cleared/whitespace-only values
- `shared/types/index.ts`, `shared/types/ipc/api.ts` — export plumbing

## Testing

- Merge-level: cleared vs absent vs set field independence, null stripping at every return path
- Handler-level integration: null-cleared fields skip back-fill through the real IPC path; absent fields still back-fill as before
- Renderer-level: `ContextTab` sends `null` sentinels for cleared/whitespace-only fields, real values for set fields