### PR TITLE
fix(terminal): wire context injection progress and cancel UI

### DIFF
--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -8,7 +8,7 @@ import React, {
   useState,
 } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { Settings, OctagonAlert, RotateCcw } from "lucide-react";
+import { Settings, OctagonAlert, RotateCcw, Hourglass, Folders } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { SkeletonHint } from "@/components/ui/Skeleton";
 import { useDohertyGate } from "@/hooks/useDeferredLoading";
@@ -33,6 +33,7 @@ import { FleetDraftingPill } from "@/components/Fleet/FleetDraftingPill";
 import { TerminalRestartStatusBanner } from "./TerminalRestartStatusBanner";
 import { InlineStatusBanner } from "./InlineStatusBanner";
 import { useForceResumeCycleWatchdog } from "@/hooks/terminal/useForceResumeCycleWatchdog";
+import { useContextInjection } from "@/hooks/useContextInjection";
 import { getRestartBannerVariant } from "./restartStatus";
 import { TerminalErrorBanner } from "./TerminalErrorBanner";
 import { SpawnErrorBanner } from "./SpawnErrorBanner";
@@ -547,6 +548,17 @@ function TerminalPaneComponent({
 
   const { showBanner: showForceResumeStall, resetQueue: resetForceResumeQueue } =
     useForceResumeCycleWatchdog(id);
+
+  const {
+    cancel: cancelInjection,
+    isInjecting,
+    isPendingInjection,
+    injectionStatus,
+    progress: injectionProgress,
+  } = useContextInjection(id);
+  // Single gate across waiting → injecting so the banner doesn't flicker on
+  // the phase transition; fast injections (<400ms) show nothing.
+  const showInjectionBanner = useDohertyGate(isInjecting || isPendingInjection);
 
   // Cancel auto-restart if terminal is intentionally trashed/removed
   useEffect(() => {
@@ -1335,6 +1347,37 @@ function TerminalPaneComponent({
             icon: RotateCcw,
             onClick: resetForceResumeQueue,
           }}
+        />
+      </BannerSlot>
+
+      <BannerSlot visible={showInjectionBanner}>
+        <InlineStatusBanner
+          icon={injectionStatus === "waiting" ? Hourglass : Folders}
+          severity={injectionStatus === "waiting" ? "neutral" : "info"}
+          title={injectionStatus === "waiting" ? "Waiting for agent" : "Injecting context"}
+          description={
+            injectionStatus === "waiting" ? "Context will inject when the agent is idle" : undefined
+          }
+          contextLine={injectionStatus === "injecting" ? injectionProgress?.message : undefined}
+          role="status"
+          ariaLive="polite"
+          action={{
+            id: "cancel-context-injection",
+            label: "Cancel",
+            onClick: cancelInjection,
+          }}
+          descriptionExtras={
+            injectionStatus === "injecting" ? (
+              <div className="mt-1.5 h-0.5 w-full rounded bg-daintree-border/60">
+                <div
+                  className="h-full rounded bg-status-info/60 transition-[width] duration-150 ease-out"
+                  style={{
+                    width: `${Math.min(Math.max((injectionProgress?.progress ?? 0) * 100, 0), 100)}%`,
+                  }}
+                />
+              </div>
+            ) : undefined
+          }
         />
       </BannerSlot>
 

--- a/src/hooks/__tests__/useContextInjection.test.tsx
+++ b/src/hooks/__tests__/useContextInjection.test.tsx
@@ -65,6 +65,14 @@ vi.mock("@/clients", () => ({
     injectToTerminal: injectMock,
     cancel: cancelMock,
   },
+  // usePanelStore (pulled in transitively) constructs panelPersistence with
+  // projectClient at module load.
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+    setTabGroups: vi.fn().mockResolvedValue(undefined),
+    getSettings: vi.fn().mockResolvedValue(null),
+  },
 }));
 
 import { useContextInjection, cancelContextInjection } from "../useContextInjection";

--- a/src/hooks/__tests__/useContextInjection.test.tsx
+++ b/src/hooks/__tests__/useContextInjection.test.tsx
@@ -195,6 +195,39 @@ describe("useContextInjection", () => {
     expect(injectMock).not.toHaveBeenCalled();
   });
 
+  it("cancelling during the availability check aborts before any context is written", async () => {
+    let resolveAvailable!: (value: boolean) => void;
+    isAvailableMock.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveAvailable = resolve;
+        })
+    );
+
+    const { result } = renderHook(() => useContextInjection("term-1"));
+
+    let injectPromise!: Promise<void>;
+    act(() => {
+      injectPromise = result.current.inject("wt-1", "term-1");
+    });
+    await vi.waitFor(() => expect(result.current.isInjecting).toBe(true));
+
+    act(() => {
+      result.current.cancel();
+    });
+
+    await act(async () => {
+      resolveAvailable(true);
+      await injectPromise;
+    });
+
+    expect(injectMock).not.toHaveBeenCalled();
+    expect(addErrorMock).not.toHaveBeenCalled();
+    expect(result.current.error).toBeNull();
+    expect(result.current.isInjecting).toBe(false);
+    expect(result.current.injectionStatus).toBe("idle");
+  });
+
   it("still records a real injection failure as an error", async () => {
     isAvailableMock.mockResolvedValue(true);
     injectMock.mockResolvedValue({ error: "copytree exploded" });

--- a/src/hooks/__tests__/useContextInjection.test.tsx
+++ b/src/hooks/__tests__/useContextInjection.test.tsx
@@ -2,15 +2,23 @@
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { addErrorMock, removeErrorMock, isAvailableMock, cancelMock, onProgressMock } = vi.hoisted(
-  () => ({
+const { addErrorMock, removeErrorMock, isAvailableMock, cancelMock, onProgressMock, injectMock } =
+  vi.hoisted(() => ({
     addErrorMock: vi.fn(),
     removeErrorMock: vi.fn(),
-    isAvailableMock: vi.fn(() => new Promise<boolean>(() => {})),
+    isAvailableMock: vi.fn<() => Promise<boolean>>(() => new Promise<boolean>(() => {})),
     cancelMock: vi.fn(() => undefined),
     onProgressMock: vi.fn(() => () => {}),
-  })
-);
+    injectMock:
+      vi.fn<
+        (
+          terminalId: string,
+          worktreeId: string,
+          options: unknown,
+          injectionUuid?: string
+        ) => Promise<{ error?: string; fileCount?: number }>
+      >(),
+  }));
 
 const { terminalState, usePanelStoreMock } = vi.hoisted(() => {
   const terminalState = {
@@ -22,7 +30,7 @@ const { terminalState, usePanelStoreMock } = vi.hoisted(() => {
         agentId: undefined,
         agentState: "idle",
       },
-    } as Record<string, { id: string; worktreeId: string; agentId: undefined; agentState: string }>,
+    } as Record<string, Record<string, unknown>>,
     panelIds: ["term-1"],
   };
 
@@ -54,16 +62,19 @@ vi.mock("@/clients", () => ({
   copyTreeClient: {
     onProgress: onProgressMock,
     isAvailable: isAvailableMock,
-    injectToTerminal: vi.fn(),
+    injectToTerminal: injectMock,
     cancel: cancelMock,
   },
 }));
 
-import { useContextInjection } from "../useContextInjection";
+import { useContextInjection, cancelContextInjection } from "../useContextInjection";
 
 describe("useContextInjection", () => {
   beforeEach(() => {
+    // Reset the module-level singleton between tests via its public API
+    cancelContextInjection();
     vi.clearAllMocks();
+    isAvailableMock.mockImplementation(() => new Promise<boolean>(() => {}));
     terminalState.focusedId = "term-1";
     terminalState.panelsById = {
       "term-1": {
@@ -88,5 +99,159 @@ describe("useContextInjection", () => {
         result.current.cancel();
       });
     }).not.toThrow();
+  });
+
+  it("cancelling an active injection does not record an error", async () => {
+    isAvailableMock.mockResolvedValue(true);
+    let resolveInject!: (value: { error?: string }) => void;
+    injectMock.mockImplementation(
+      () =>
+        new Promise<{ error?: string }>((resolve) => {
+          resolveInject = resolve;
+        })
+    );
+
+    const { result } = renderHook(() => useContextInjection("term-1"));
+
+    let injectPromise!: Promise<void>;
+    act(() => {
+      injectPromise = result.current.inject("wt-1", "term-1");
+    });
+    await vi.waitFor(() => expect(injectMock).toHaveBeenCalled());
+    expect(result.current.isInjecting).toBe(true);
+    expect(result.current.injectionStatus).toBe("injecting");
+
+    const injectionUuid = injectMock.mock.calls[0]?.[3];
+    expect(injectionUuid).toBeTruthy();
+    act(() => {
+      result.current.cancel();
+    });
+    expect(cancelMock).toHaveBeenCalledWith(injectionUuid);
+
+    await act(async () => {
+      resolveInject({ error: "Injection cancelled" });
+      await injectPromise;
+    });
+
+    expect(addErrorMock).not.toHaveBeenCalled();
+    expect(result.current.error).toBeNull();
+    expect(result.current.isInjecting).toBe(false);
+    expect(result.current.injectionStatus).toBe("idle");
+  });
+
+  it("cancels the backend operation with the specific injection UUID", async () => {
+    isAvailableMock.mockResolvedValue(true);
+    injectMock.mockImplementation(() => new Promise(() => {}));
+
+    const { result } = renderHook(() => useContextInjection("term-1"));
+
+    act(() => {
+      void result.current.inject("wt-1", "term-1");
+    });
+    await vi.waitFor(() => expect(injectMock).toHaveBeenCalled());
+
+    const injectionUuid = injectMock.mock.calls[0]?.[3];
+    expect(injectionUuid).toBeTruthy();
+
+    act(() => {
+      result.current.cancel();
+    });
+
+    expect(cancelMock).toHaveBeenCalledTimes(1);
+    expect(cancelMock).toHaveBeenCalledWith(injectionUuid);
+  });
+
+  it("cancelling a pending injection clears the waiting state without recording an error", async () => {
+    terminalState.panelsById = {
+      "term-agent": {
+        id: "term-agent",
+        worktreeId: "wt-1",
+        detectedAgentId: "claude",
+        agentState: "working",
+      },
+    };
+    terminalState.focusedId = "term-agent";
+    terminalState.panelIds = ["term-agent"];
+
+    const { result } = renderHook(() => useContextInjection("term-agent"));
+
+    let injectPromise!: Promise<void>;
+    act(() => {
+      injectPromise = result.current.inject("wt-1", "term-agent");
+    });
+    await vi.waitFor(() => expect(result.current.isPendingInjection).toBe(true));
+    expect(result.current.injectionStatus).toBe("waiting");
+
+    await act(async () => {
+      result.current.cancel();
+      await injectPromise;
+    });
+
+    expect(result.current.isPendingInjection).toBe(false);
+    expect(result.current.injectionStatus).toBe("idle");
+    expect(result.current.error).toBeNull();
+    expect(addErrorMock).not.toHaveBeenCalled();
+    // No active backend operation while waiting — nothing to cancel over IPC
+    expect(injectMock).not.toHaveBeenCalled();
+  });
+
+  it("still records a real injection failure as an error", async () => {
+    isAvailableMock.mockResolvedValue(true);
+    injectMock.mockResolvedValue({ error: "copytree exploded" });
+    addErrorMock.mockReturnValue("error-1");
+
+    const { result } = renderHook(() => useContextInjection("term-1"));
+
+    let injectPromise!: Promise<void>;
+    act(() => {
+      injectPromise = result.current.inject("wt-1", "term-1");
+    });
+    await act(async () => {
+      await injectPromise;
+    });
+
+    expect(addErrorMock).toHaveBeenCalledTimes(1);
+    expect(addErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Context injection failed: copytree exploded",
+        source: "ContextInjection",
+      })
+    );
+    expect(result.current.error).toBe("copytree exploded");
+  });
+
+  it("cancelContextInjection cancels the active injection from outside the hook", async () => {
+    isAvailableMock.mockResolvedValue(true);
+    let resolveInject!: (value: { error?: string }) => void;
+    injectMock.mockImplementation(
+      () =>
+        new Promise<{ error?: string }>((resolve) => {
+          resolveInject = resolve;
+        })
+    );
+
+    const { result } = renderHook(() => useContextInjection("term-1"));
+
+    let injectPromise!: Promise<void>;
+    act(() => {
+      injectPromise = result.current.inject("wt-1", "term-1");
+    });
+    await vi.waitFor(() => expect(injectMock).toHaveBeenCalled());
+
+    const injectionUuid = injectMock.mock.calls[0]?.[3];
+    expect(injectionUuid).toBeTruthy();
+    act(() => {
+      cancelContextInjection();
+    });
+    expect(cancelMock).toHaveBeenCalledWith(injectionUuid);
+
+    await act(async () => {
+      resolveInject({ error: "Injection cancelled" });
+      await injectPromise;
+    });
+
+    expect(addErrorMock).not.toHaveBeenCalled();
+    expect(result.current.error).toBeNull();
+    expect(result.current.isInjecting).toBe(false);
   });
 });

--- a/src/hooks/useContextInjection.ts
+++ b/src/hooks/useContextInjection.ts
@@ -40,6 +40,12 @@ interface PendingInjection {
   reject: (error: Error) => void;
 }
 
+// UUIDs the user explicitly cancelled — the injecting-phase catch consults this
+// to treat the resulting "Injection cancelled" rejection as a silent abort
+// instead of a real error. Kept off the snapshot: it is callback state, not
+// render state.
+const cancelledUuids = new Set<string>();
+
 const globalInjectionState = {
   isInjecting: false,
   isPendingInjection: false,
@@ -85,6 +91,38 @@ const globalInjectionState = {
     }
   },
 };
+
+/**
+ * Cancel the active context injection from outside a component (e.g. the
+ * `copyTree.cancel` action). Clears the renderer pending state, cancels the
+ * active backend operation by UUID, and resets the shared injection state.
+ */
+export function cancelContextInjection(): void {
+  // Cancel pending injection if waiting for the agent to become idle
+  globalInjectionState.clearPending();
+
+  // Cancel only the current active injection (not all CopyTree operations).
+  // Fire the IPC first to minimize chunks written during the race window.
+  const injectionUuid = globalInjectionState.activeInjectionUuid;
+  if (injectionUuid) {
+    cancelledUuids.add(injectionUuid);
+    try {
+      const cancelResult = copyTreeClient.cancel(injectionUuid);
+      void Promise.resolve(cancelResult).catch((err) =>
+        logError("[useContextInjection] Cancel failed", err)
+      );
+    } catch (error) {
+      logError("[useContextInjection] Cancel error", error);
+    }
+  }
+
+  globalInjectionState.isInjecting = false;
+  globalInjectionState.isPendingInjection = false;
+  globalInjectionState.activeTerminalId = null;
+  globalInjectionState.activeInjectionUuid = null;
+  globalInjectionState.lastProgress = null;
+  globalInjectionState.notify();
+}
 
 export function useContextInjection(targetTerminalId?: string): UseContextInjectionReturn {
   const [error, setError] = useState<string | null>(null);
@@ -365,6 +403,14 @@ export function useContextInjection(targetTerminalId?: string): UseContextInject
         }
       } catch (e) {
         const message = formatErrorMessage(e, "Failed to inject context");
+
+        // User-initiated cancel is a silent abort, not an error — keep it out
+        // of the error store and the Problems dock.
+        if (cancelledUuids.has(injectionUuid) || message === "Injection cancelled") {
+          logDebug("[useContextInjection] Injection cancelled by user", { injectionUuid });
+          return;
+        }
+
         const details = e instanceof Error ? e.stack : undefined;
 
         setError(message);
@@ -393,6 +439,7 @@ export function useContextInjection(targetTerminalId?: string): UseContextInject
 
         logError("[useContextInjection] Context injection failed", undefined, { message });
       } finally {
+        cancelledUuids.delete(injectionUuid);
         // Only clear global state if we own this injection (prevent cross-run interference)
         if (globalInjectionState.injectionId === currentInjectionId) {
           globalInjectionState.isInjecting = false;
@@ -408,29 +455,8 @@ export function useContextInjection(targetTerminalId?: string): UseContextInject
   );
 
   const cancel = useCallback(() => {
-    // Cancel pending injection if waiting
-    globalInjectionState.clearPending();
-
-    // Cancel only the current active injection (not all CopyTree operations)
-    const injectionUuid = globalInjectionState.activeInjectionUuid;
-    if (injectionUuid) {
-      try {
-        const cancelResult = copyTreeClient.cancel(injectionUuid);
-        void Promise.resolve(cancelResult).catch((err) =>
-          logError("[useContextInjection] Cancel failed", err)
-        );
-      } catch (error) {
-        logError("[useContextInjection] Cancel error", error);
-      }
-    }
-
-    globalInjectionState.isInjecting = false;
-    globalInjectionState.isPendingInjection = false;
-    globalInjectionState.activeTerminalId = null;
-    globalInjectionState.activeInjectionUuid = null;
-    globalInjectionState.lastProgress = null;
     localProgressRef.current = null;
-    globalInjectionState.notify();
+    cancelContextInjection();
   }, []);
 
   const clearError = useCallback(() => {

--- a/src/hooks/useContextInjection.ts
+++ b/src/hooks/useContextInjection.ts
@@ -363,6 +363,13 @@ export function useContextInjection(targetTerminalId?: string): UseContextInject
           );
         }
 
+        // User may have cancelled while the availability check was in flight —
+        // abort before any context reaches the terminal.
+        if (cancelledUuids.has(injectionUuid)) {
+          logDebug("[useContextInjection] Injection cancelled before write", { injectionUuid });
+          return;
+        }
+
         const options = {
           format: DEFAULT_COPYTREE_FORMAT,
           ...(selectedPaths && selectedPaths.length > 0 ? { includePaths: selectedPaths } : {}),

--- a/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
@@ -43,6 +43,14 @@ vi.mock("@/clients", () => ({
   systemClient: systemClientMock,
   cliAvailabilityClient: cliAvailabilityClientMock,
   artifactClient: artifactClientMock,
+  // usePanelStore (pulled in transitively via useContextInjection) constructs
+  // panelPersistence with projectClient at module load.
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+    setTabGroups: vi.fn().mockResolvedValue(undefined),
+    getSettings: vi.fn().mockResolvedValue(null),
+  },
 }));
 
 import { registerSystemActions } from "../systemActions";

--- a/src/services/actions/definitions/systemActions.ts
+++ b/src/services/actions/definitions/systemActions.ts
@@ -11,6 +11,7 @@ import {
   slashCommandsClient,
   systemClient,
 } from "@/clients";
+import { cancelContextInjection } from "@/hooks/useContextInjection";
 
 export function registerSystemActions(actions: ActionRegistry, _callbacks: ActionCallbacks): void {
   actions.set("system.openExternal", () =>
@@ -368,6 +369,9 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
     danger: "safe",
     scope: "renderer",
     run: async () => {
+      // Clears renderer injection state and cancels the active injection by
+      // UUID, then sweeps any other in-flight CopyTree operations.
+      cancelContextInjection();
       await copyTreeClient.cancel();
     },
   }));

--- a/src/services/actions/definitions/systemActions.ts
+++ b/src/services/actions/definitions/systemActions.ts
@@ -370,7 +370,10 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
     scope: "renderer",
     run: async () => {
       // Clears renderer injection state and cancels the active injection by
-      // UUID, then sweeps any other in-flight CopyTree operations.
+      // UUID, then sweeps any other in-flight CopyTree operations
+      // (generate/copy-file). An injection started between these two calls
+      // would be swept too — accepted: both are user-initiated cancels and
+      // the window is a single microtask turn.
       cancelContextInjection();
       await copyTreeClient.cancel();
     },


### PR DESCRIPTION
## Summary

`useContextInjection` had a complete state machine — waiting, injecting, progress, cancel, error — but `TerminalPane` only called `inject`. Progress UI, waiting UI, and cancel were all disconnected. User-initiated cancellations were also recorded as errors in the Problems dock, and the `copyTree.cancel` action called `copyTreeClient.cancel()` with no UUID and never cleared renderer pending state.

This PR wires it all up and fixes the cancel correctness issues.

Resolves #10034

## Changes

- **Progress and waiting UI:** `TerminalPane` now calls `useContextInjection(id)` per pane and renders a Doherty-gated (400ms) `InlineStatusBanner` in the existing `BannerSlot` stack. "Waiting for agent" (Hourglass, neutral) while queued; "Injecting context" (Folders, info) with the live progress message and a clamped progress bar (`transition-[width] duration-150`) while writing. Both states expose a Cancel action. Single gate across waiting→injecting so the phase transition doesn't flicker.
- **Cancel correctness:** A module-level `cancelledUuids` set marks user-cancelled UUIDs. The injecting-phase catch treats those (and the backend's `"Injection cancelled"` result) as a silent abort rather than an error. A guard after the `isAvailable()` round-trip aborts cancelled injections before any context reaches the terminal. The exported `cancelContextInjection()` function is the single cancel path — the hook's Cancel button and the `copyTree.cancel` action both route through it, so the action now cancels the active injection by UUID, clears renderer pending state, then still sweeps other in-flight CopyTree ops via the no-arg cancel.
- **Tests:** `useContextInjection` suite expanded from 1 to 7 — injecting-phase cancel records no error; UUID-targeted backend cancel; pending-phase cancel clears waiting state; cancel during availability check never calls `injectToTerminal`; real failures still recorded; standalone `cancelContextInjection` works; singleton reset between tests via public API.

## Testing

Full unit suite run locally — 31,427 passed. Static checks (typecheck, lint, format, channel/IPC/confirm-wiring guards) all green. Build clean.