### PR TITLE
fix(artifacts): gate apply-patch behind a D2 confirm with diff preview

### DIFF
--- a/docs/architecture/destructive-action-safeguards.md
+++ b/docs/architecture/destructive-action-safeguards.md
@@ -96,6 +96,14 @@ Columns:
 | `terminal.restartAll` | **confirm** (updated #8245) | yes (`TerminalDestructiveActionConfirmDialog`) — fires when any non-trash terminal has a running agent | Boolean via dispatch | local-irreversible | many terminals | D1 | Done (#8245) | — |
 | `terminal.restartService` | safe | n/a | n/a | local-irreversible (all PTY processes restart) | every terminal in the window | D1 | Action is gated on `backendStatus === "disconnected"`; the gate already implies an error state, so leave as-is | — |
 
+### Artifacts
+
+| Action / call site | Current | UI confirm | Consent in breadcrumb | Reversibility | Blast | Tier | Recommendation | Follow-up |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `artifact.applyPatch` | **confirm** (updated #10020) | yes — `ConfirmDialog` in `ArtifactOverlay.tsx` with full per-line diff preview of the patch content; the dispatch lives in `useArtifacts.ts`, so the action is on `BYPASS_WIRED` (ID not co-located with the dialog) | Boolean via dispatch (agents must pass `confirmed: true`) | shared-state (writes worktree files via `git apply`; recovery is a manual git checkout) | files touched by one patch | D2 | Done (#10020) — single apply gates on a diff-content preview | — |
+| `ArtifactOverlay.tsx` "Apply All Patches" (fans out `artifact.applyPatch` via `useArtifacts.applyAllPatches`) | routes through `artifact.applyPatch` | yes — single `ConfirmDialog` previews the snapshotted patch list (filename + per-patch `+N −N` line stats); the confirm passes the same snapshot to the apply loop so patches detected while the dialog is open are never applied unseen | Boolean via dispatch | shared-state (sequential `git apply`; a mid-list failure leaves earlier patches applied) | files touched by every detected patch | D2 | Done (#10020) — snapshot-at-request prevents the TOCTOU gap between preview and apply | — |
+| `artifact.saveToFile` | safe | n/a — the native save dialog is itself the consent surface (user picks the destination path) | n/a | reversible (delete the saved file) | one new file | D0 | Leave | — |
+
 ### Dev preview
 
 | Action / call site | Current | UI confirm | Consent in breadcrumb | Reversibility | Blast | Tier | Recommendation | Follow-up |

--- a/scripts/codegen/confirm-wiring.mjs
+++ b/scripts/codegen/confirm-wiring.mjs
@@ -50,6 +50,7 @@ const EXPECTED_CONFIRM_DANGER = new Set([
   "recipe.run",
   "devPreview.restartAndClearCache",
   "devPreview.reinstallAndRestart",
+  "artifact.applyPatch",
 ]);
 
 // Actions with a ConfirmDialog-family component co-located in the same source file
@@ -87,6 +88,7 @@ const BYPASS_WIRED = new Set([
   "git.pullRebase", // IPC bypass in ReviewHubContent.tsx; ConfirmDialog wired but ID not co-located
   "project.remove", // confirm in ProjectSwitcherPalette.tsx; action ID not co-located
   "recipe.run", // agent-dispatch only; no user-side ConfirmDialog (danger:"confirm" gates MCP only)
+  "artifact.applyPatch", // ConfirmDialog in ArtifactOverlay.tsx; dispatch in useArtifacts.ts (ID not co-located)
 ]);
 
 // Text tokens identifying a ConfirmDialog-family component in a source file.

--- a/src/components/Terminal/ArtifactOverlay.tsx
+++ b/src/components/Terminal/ArtifactOverlay.tsx
@@ -1,8 +1,51 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { useArtifacts } from "@/hooks/useArtifacts";
 import type { Artifact } from "@shared/types";
+
+type ApplyPatchOutcome =
+  | { success: true; modifiedFiles: string[] }
+  | { success: false; error: string; cancelled?: boolean };
+
+export function getPatchStats(content: string): { additions: number; deletions: number } {
+  let additions = 0;
+  let deletions = 0;
+  for (const line of content.split("\n")) {
+    if (line.startsWith("+") && !line.startsWith("+++")) additions++;
+    else if (line.startsWith("-") && !line.startsWith("---")) deletions++;
+  }
+  return { additions, deletions };
+}
+
+export function patchLineClass(line: string): string {
+  if (line.startsWith("+++") || line.startsWith("---") || line.startsWith("@@")) {
+    return "text-daintree-text/40";
+  }
+  if (line.startsWith("+")) return "text-status-success bg-status-success/10";
+  if (line.startsWith("-")) return "text-status-error bg-status-error/10";
+  return "text-daintree-text/80";
+}
+
+function PatchDiffPreview({ content }: { content: string }) {
+  return (
+    <div className="rounded border border-tint/[0.08] bg-tint/[0.04]">
+      <div className="px-3 py-2 border-b border-tint/[0.08]">
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
+          Patch contents
+        </span>
+      </div>
+      <pre className="font-mono text-[11px] leading-4 px-3 py-2 max-h-[200px] overflow-y-auto overflow-x-auto select-text">
+        {content.split("\n").map((line, i) => (
+          <div key={i} className={patchLineClass(line)}>
+            {line || " "}
+          </div>
+        ))}
+      </pre>
+    </div>
+  );
+}
 
 interface ArtifactOverlayProps {
   terminalId: string;
@@ -33,9 +76,7 @@ interface ArtifactItemProps {
   artifact: Artifact;
   onCopy: (artifact: Artifact) => Promise<boolean>;
   onSave: (artifact: Artifact) => Promise<{ filePath: string } | null>;
-  onApplyPatch: (
-    artifact: Artifact
-  ) => Promise<{ success: true; modifiedFiles: string[] } | { success: false; error: string }>;
+  onApplyPatch: (artifact: Artifact) => Promise<ApplyPatchOutcome>;
   canApplyPatch: boolean;
   isProcessing: boolean;
 }
@@ -88,7 +129,7 @@ function ArtifactItem({
     const result = await onApplyPatch(artifact);
     if (result.success) {
       showFeedback("Patch applied!", "success");
-    } else {
+    } else if (!result.cancelled) {
       showFeedback(result.error || "Patch failed", "error");
     }
   }, [artifact, onApplyPatch, showFeedback]);
@@ -236,12 +277,35 @@ export function ArtifactOverlay({ terminalId, worktreeId, cwd, className }: Arti
     [saveToFile]
   );
 
-  const handleApplyPatch = useCallback(
-    async (artifact: Artifact) => {
-      return await applyPatch(artifact);
-    },
-    [applyPatch]
-  );
+  // D2 confirm gate: applying a patch mutates worktree files, so both apply
+  // paths preview the change in a ConfirmDialog before the dispatch fires.
+  const [pendingPatch, setPendingPatch] = useState<Artifact | null>(null);
+  const [pendingBulkPatches, setPendingBulkPatches] = useState<Artifact[] | null>(null);
+  const pendingApplyResolveRef = useRef<((outcome: ApplyPatchOutcome) => void) | null>(null);
+
+  const handleApplyPatch = useCallback((artifact: Artifact) => {
+    return new Promise<ApplyPatchOutcome>((resolve) => {
+      pendingApplyResolveRef.current?.({ success: false, error: "Cancelled", cancelled: true });
+      pendingApplyResolveRef.current = resolve;
+      setPendingPatch(artifact);
+    });
+  }, []);
+
+  const handleCancelApplyPatch = useCallback(() => {
+    pendingApplyResolveRef.current?.({ success: false, error: "Cancelled", cancelled: true });
+    pendingApplyResolveRef.current = null;
+    setPendingPatch(null);
+  }, []);
+
+  const handleConfirmApplyPatch = useCallback(async () => {
+    const resolve = pendingApplyResolveRef.current;
+    const artifact = pendingPatch;
+    pendingApplyResolveRef.current = null;
+    setPendingPatch(null);
+    if (!artifact) return;
+    const result = await applyPatch(artifact);
+    resolve?.(result);
+  }, [applyPatch, pendingPatch]);
 
   useEffect(() => {
     return () => {
@@ -286,8 +350,21 @@ export function ArtifactOverlay({ terminalId, worktreeId, cwd, className }: Arti
     }
   }, [saveAll, showBulkResult]);
 
-  const handleApplyAllPatches = useCallback(async () => {
-    const result = await applyAllPatches();
+  const handleApplyAllPatches = useCallback(() => {
+    // Snapshot at request time so the dialog previews exactly the set confirm
+    // will apply — patches detected while the dialog is open are excluded.
+    setPendingBulkPatches(artifacts.filter((a) => a.type === "patch"));
+  }, [artifacts]);
+
+  const handleCancelApplyAllPatches = useCallback(() => {
+    setPendingBulkPatches(null);
+  }, []);
+
+  const handleConfirmApplyAllPatches = useCallback(async () => {
+    const snapshot = pendingBulkPatches;
+    setPendingBulkPatches(null);
+    if (!snapshot) return;
+    const result = await applyAllPatches(snapshot);
     if (result.succeeded > 0 && result.failed === 0) {
       const filesMsg = result.modifiedFiles?.length
         ? ` (${result.modifiedFiles.length} files)`
@@ -301,7 +378,7 @@ export function ArtifactOverlay({ terminalId, worktreeId, cwd, className }: Arti
     } else if (result.failed > 0) {
       showBulkResult(`Failed to apply patches`, "error");
     }
-  }, [applyAllPatches, showBulkResult]);
+  }, [applyAllPatches, pendingBulkPatches, showBulkResult]);
 
   const codeArtifactCount = artifacts.filter((a) => a.type === "code").length;
   const patchCount = artifacts.filter((a) => a.type === "patch").length;
@@ -361,7 +438,11 @@ export function ArtifactOverlay({ terminalId, worktreeId, cwd, className }: Arti
                 </button>
                 <button
                   type="button"
-                  onClick={() => setIsExpanded(false)}
+                  onClick={() => {
+                    handleCancelApplyPatch();
+                    handleCancelApplyAllPatches();
+                    setIsExpanded(false);
+                  }}
                   disabled={isBulkActionRunning}
                   className="text-daintree-text/40 hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
                   aria-label="Close artifact overlay"
@@ -490,6 +571,66 @@ export function ArtifactOverlay({ terminalId, worktreeId, cwd, className }: Arti
           </div>
         </div>
       )}
+
+      <ConfirmDialog
+        isOpen={pendingPatch !== null}
+        onClose={handleCancelApplyPatch}
+        title="Apply patch to worktree?"
+        description={
+          <span>
+            Writes the diff below to files in this worktree via{" "}
+            <span className="font-mono">git apply</span>. Recovery is a manual git checkout of the
+            touched files.
+          </span>
+        }
+        confirmLabel="Apply patch"
+        variant="destructive"
+        hasPreview={true}
+        onConfirm={() => void handleConfirmApplyPatch()}
+      >
+        {pendingPatch && <PatchDiffPreview content={pendingPatch.content} />}
+      </ConfirmDialog>
+
+      <ConfirmDialog
+        isOpen={pendingBulkPatches !== null}
+        onClose={handleCancelApplyAllPatches}
+        title={`Apply ${pendingBulkPatches?.length ?? 0} patch${
+          pendingBulkPatches?.length !== 1 ? "es" : ""
+        } to worktree?`}
+        description="Applies each patch below to files in this worktree in extraction order. A patch that fails leaves the earlier ones applied."
+        confirmLabel={`Apply ${pendingBulkPatches?.length ?? 0} patch${
+          pendingBulkPatches?.length !== 1 ? "es" : ""
+        }`}
+        variant="destructive"
+        hasPreview={true}
+        onConfirm={() => void handleConfirmApplyAllPatches()}
+      >
+        {pendingBulkPatches && (
+          <div className="rounded border border-tint/[0.08] bg-tint/[0.04]">
+            <div className="px-3 py-2 border-b border-tint/[0.08]">
+              <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
+                Patches to apply
+              </span>
+            </div>
+            <ul className="px-3 py-2 space-y-1.5 max-h-[200px] overflow-y-auto">
+              {pendingBulkPatches.map((patch) => {
+                const stats = getPatchStats(patch.content);
+                return (
+                  <li key={patch.id} className="flex items-baseline gap-2">
+                    <span className="text-daintree-text/80 truncate min-w-0">
+                      {patch.filename || patch.language || "patch"}
+                    </span>
+                    <span className="font-mono text-[10px] shrink-0 ml-auto tabular-nums">
+                      <span className="text-status-success">+{stats.additions}</span>{" "}
+                      <span className="text-status-error">-{stats.deletions}</span>
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+      </ConfirmDialog>
     </div>
   );
 }

--- a/src/components/Terminal/ArtifactOverlay.tsx
+++ b/src/components/Terminal/ArtifactOverlay.tsx
@@ -28,6 +28,23 @@ export function patchLineClass(line: string): string {
   return "text-daintree-text/80";
 }
 
+function PatchDiffLines({ content, className }: { content: string; className?: string }) {
+  return (
+    <pre
+      className={cn(
+        "font-mono text-[11px] leading-4 overflow-y-auto overflow-x-auto select-text",
+        className
+      )}
+    >
+      {content.split("\n").map((line, i) => (
+        <div key={i} className={patchLineClass(line)}>
+          {line || " "}
+        </div>
+      ))}
+    </pre>
+  );
+}
+
 function PatchDiffPreview({ content }: { content: string }) {
   return (
     <div className="rounded border border-tint/[0.08] bg-tint/[0.04]">
@@ -36,13 +53,7 @@ function PatchDiffPreview({ content }: { content: string }) {
           Patch contents
         </span>
       </div>
-      <pre className="font-mono text-[11px] leading-4 px-3 py-2 max-h-[200px] overflow-y-auto overflow-x-auto select-text">
-        {content.split("\n").map((line, i) => (
-          <div key={i} className={patchLineClass(line)}>
-            {line || " "}
-          </div>
-        ))}
-      </pre>
+      <PatchDiffLines content={content} className="px-3 py-2 max-h-[200px]" />
     </div>
   );
 }
@@ -306,6 +317,24 @@ export function ArtifactOverlay({ terminalId, worktreeId, cwd, className }: Arti
     const result = await applyPatch(artifact);
     resolve?.(result);
   }, [applyPatch, pendingPatch]);
+
+  // Resolve a pending confirm as cancelled when the overlay loses its artifacts
+  // (Clear hides the dialog via the early return below) or unmounts, so the
+  // promise awaited in ArtifactItem never hangs.
+  useEffect(() => {
+    if (hasArtifacts) return;
+    pendingApplyResolveRef.current?.({ success: false, error: "Cancelled", cancelled: true });
+    pendingApplyResolveRef.current = null;
+    setPendingPatch(null);
+    setPendingBulkPatches(null);
+  }, [hasArtifacts]);
+
+  useEffect(() => {
+    return () => {
+      pendingApplyResolveRef.current?.({ success: false, error: "Cancelled", cancelled: true });
+      pendingApplyResolveRef.current = null;
+    };
+  }, []);
 
   useEffect(() => {
     return () => {
@@ -612,22 +641,33 @@ export function ArtifactOverlay({ terminalId, worktreeId, cwd, className }: Arti
                 Patches to apply
               </span>
             </div>
-            <ul className="px-3 py-2 space-y-1.5 max-h-[200px] overflow-y-auto">
+            <div className="max-h-[260px] overflow-y-auto divide-y divide-tint/[0.08]">
               {pendingBulkPatches.map((patch) => {
                 const stats = getPatchStats(patch.content);
                 return (
-                  <li key={patch.id} className="flex items-baseline gap-2">
-                    <span className="text-daintree-text/80 truncate min-w-0">
-                      {patch.filename || patch.language || "patch"}
-                    </span>
-                    <span className="font-mono text-[10px] shrink-0 ml-auto tabular-nums">
-                      <span className="text-status-success">+{stats.additions}</span>{" "}
-                      <span className="text-status-error">-{stats.deletions}</span>
-                    </span>
-                  </li>
+                  // D2 requires actual diff content per patch, not just counts —
+                  // open by default; the toggle only tames very long bulk sets.
+                  <details key={patch.id} open className="group">
+                    <summary className="flex items-baseline gap-2 px-3 py-2 cursor-pointer list-none">
+                      <span className="text-daintree-text/40 text-[10px] shrink-0 group-open:hidden">
+                        ▶
+                      </span>
+                      <span className="text-daintree-text/40 text-[10px] shrink-0 hidden group-open:inline">
+                        ▼
+                      </span>
+                      <span className="text-daintree-text/80 truncate min-w-0">
+                        {patch.filename || patch.language || "patch"}
+                      </span>
+                      <span className="font-mono text-[10px] shrink-0 ml-auto tabular-nums">
+                        <span className="text-status-success">+{stats.additions}</span>{" "}
+                        <span className="text-status-error">-{stats.deletions}</span>
+                      </span>
+                    </summary>
+                    <PatchDiffLines content={patch.content} className="px-3 pb-2 max-h-[120px]" />
+                  </details>
                 );
               })}
-            </ul>
+            </div>
           </div>
         )}
       </ConfirmDialog>

--- a/src/components/Terminal/__tests__/ArtifactOverlay.confirmGate.test.tsx
+++ b/src/components/Terminal/__tests__/ArtifactOverlay.confirmGate.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+import type { Artifact } from "@shared/types";
+import { ArtifactOverlay } from "../ArtifactOverlay";
+
+const applyPatch = vi.fn();
+const applyAllPatches = vi.fn();
+let mockArtifacts: Artifact[] = [];
+
+vi.mock("@/hooks/useArtifacts", () => ({
+  useArtifacts: () => ({
+    artifacts: mockArtifacts,
+    actionInProgress: null,
+    bulkProgress: null,
+    hasArtifacts: mockArtifacts.length > 0,
+    copyToClipboard: vi.fn(),
+    saveToFile: vi.fn(),
+    applyPatch,
+    clearArtifacts: vi.fn(),
+    canApplyPatch: () => true,
+    copyAll: vi.fn(),
+    saveAll: vi.fn(),
+    applyAllPatches,
+  }),
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: () => null,
+}));
+
+// The gate logic under test lives in ArtifactOverlay; the dialog chrome
+// (AppDialog portal/focus-trap) is out of scope, so stub it to its contract.
+vi.mock("@/components/ui/ConfirmDialog", () => ({
+  ConfirmDialog: ({
+    isOpen,
+    onClose,
+    onConfirm,
+    confirmLabel,
+    children,
+  }: {
+    isOpen: boolean;
+    onClose?: () => void;
+    onConfirm: () => void | Promise<void>;
+    confirmLabel: string;
+    children?: ReactNode;
+  }) =>
+    isOpen ? (
+      <div role="dialog">
+        {children}
+        <button onClick={() => void onConfirm()}>{confirmLabel}</button>
+        <button onClick={onClose}>Cancel</button>
+      </div>
+    ) : null,
+}));
+
+function makePatch(id: string, content: string): Artifact {
+  return { id, type: "patch", filename: `${id}.diff`, content, extractedAt: 1 };
+}
+
+const PATCH_A = makePatch("patch-a", "--- a/a.ts\n+++ b/a.ts\n@@ -1 +1 @@\n-old a\n+new a");
+const PATCH_B = makePatch("patch-b", "--- a/b.ts\n+++ b/b.ts\n@@ -1 +1 @@\n-old b\n+new b");
+const PATCH_C = makePatch("patch-c", "--- a/c.ts\n+++ b/c.ts\n@@ -1 +1 @@\n-old c\n+new c");
+
+function renderOverlay() {
+  const utils = render(<ArtifactOverlay terminalId="t1" worktreeId="wt1" cwd="/repo" />);
+  // Expand the collapsed pill so the artifact list and bulk bar render.
+  fireEvent.click(screen.getByText(/artifacts?$/i));
+  return utils;
+}
+
+function openSingleApplyDialog(filename: string) {
+  fireEvent.click(screen.getByText(filename));
+  fireEvent.click(screen.getByText("Apply Patch"));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockArtifacts = [PATCH_A, PATCH_B];
+  applyPatch.mockResolvedValue({ success: true, modifiedFiles: ["a.ts"] });
+  applyAllPatches.mockResolvedValue({
+    succeeded: 2,
+    failed: 0,
+    failures: [],
+    modifiedFiles: ["a.ts", "b.ts"],
+  });
+});
+
+describe("ArtifactOverlay confirm gate (issue #10020)", () => {
+  it("does not apply a patch until the confirm dialog is confirmed, and shows the diff", () => {
+    renderOverlay();
+    openSingleApplyDialog("patch-a.diff");
+
+    expect(applyPatch).not.toHaveBeenCalled();
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.textContent).toContain("+new a");
+    expect(dialog.textContent).toContain("-old a");
+  });
+
+  it("cancelling the single-patch dialog never applies", () => {
+    renderOverlay();
+    openSingleApplyDialog("patch-a.diff");
+
+    fireEvent.click(screen.getByText("Cancel"));
+
+    expect(applyPatch).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("confirming the single-patch dialog applies exactly the pending patch", async () => {
+    renderOverlay();
+    openSingleApplyDialog("patch-a.diff");
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Apply patch"));
+    });
+
+    expect(applyPatch).toHaveBeenCalledTimes(1);
+    expect(applyPatch).toHaveBeenCalledWith(PATCH_A);
+  });
+
+  it("re-requesting apply for another patch supersedes the first pending confirm", async () => {
+    renderOverlay();
+    openSingleApplyDialog("patch-a.diff");
+    fireEvent.click(screen.getByText("patch-b.diff"));
+    fireEvent.click(screen.getAllByText("Apply Patch")[1]!);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Apply patch"));
+    });
+
+    expect(applyPatch).toHaveBeenCalledTimes(1);
+    expect(applyPatch).toHaveBeenCalledWith(PATCH_B);
+  });
+
+  it("bulk dialog shows actual diff content for every patch, not just counts", () => {
+    renderOverlay();
+    fireEvent.click(screen.getByText("Apply All Patches"));
+
+    expect(applyAllPatches).not.toHaveBeenCalled();
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.textContent).toContain("+new a");
+    expect(dialog.textContent).toContain("+new b");
+    expect(dialog.textContent).toContain("-old a");
+    expect(dialog.textContent).toContain("-old b");
+  });
+
+  it("bulk confirm applies the snapshot taken at request time, not later arrivals", async () => {
+    const { rerender } = renderOverlay();
+    fireEvent.click(screen.getByText("Apply All Patches"));
+
+    // A third patch arrives while the dialog is open.
+    mockArtifacts = [PATCH_A, PATCH_B, PATCH_C];
+    rerender(<ArtifactOverlay terminalId="t1" worktreeId="wt1" cwd="/repo" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Apply 2 patches"));
+    });
+
+    expect(applyAllPatches).toHaveBeenCalledTimes(1);
+    expect(applyAllPatches).toHaveBeenCalledWith([PATCH_A, PATCH_B]);
+  });
+
+  it("cancelling the bulk dialog never applies", () => {
+    renderOverlay();
+    fireEvent.click(screen.getByText("Apply All Patches"));
+
+    fireEvent.click(screen.getByText("Cancel"));
+
+    expect(applyAllPatches).not.toHaveBeenCalled();
+  });
+
+  it("losing all artifacts while a confirm is pending cancels it without applying", () => {
+    const { rerender } = renderOverlay();
+    openSingleApplyDialog("patch-a.diff");
+
+    mockArtifacts = [];
+    rerender(<ArtifactOverlay terminalId="t1" worktreeId="wt1" cwd="/repo" />);
+
+    expect(applyPatch).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});

--- a/src/components/Terminal/__tests__/ArtifactOverlay.patchPreview.test.ts
+++ b/src/components/Terminal/__tests__/ArtifactOverlay.patchPreview.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { getPatchStats, patchLineClass } from "../ArtifactOverlay";
+
+const PATCH = [
+  "diff --git a/src/foo.ts b/src/foo.ts",
+  "--- a/src/foo.ts",
+  "+++ b/src/foo.ts",
+  "@@ -1,3 +1,4 @@",
+  " const a = 1;",
+  "-const b = 2;",
+  "+const b = 3;",
+  "+const c = 4;",
+].join("\n");
+
+describe("ArtifactOverlay patch preview helpers (issue #10020)", () => {
+  describe("getPatchStats", () => {
+    it("counts added and removed lines, excluding +++/--- file headers", () => {
+      expect(getPatchStats(PATCH)).toEqual({ additions: 2, deletions: 1 });
+    });
+
+    it("returns zeros for content with no change lines", () => {
+      expect(getPatchStats("just some text\nwith no markers")).toEqual({
+        additions: 0,
+        deletions: 0,
+      });
+    });
+  });
+
+  describe("patchLineClass", () => {
+    it("distinguishes additions, deletions, headers, and context lines", () => {
+      const addition = patchLineClass("+const b = 3;");
+      const deletion = patchLineClass("-const b = 2;");
+      const context = patchLineClass(" const a = 1;");
+      const classes = [
+        addition,
+        deletion,
+        context,
+        patchLineClass("@@ -1,3 +1,4 @@"),
+        patchLineClass("+++ b/src/foo.ts"),
+      ];
+      // Each category renders distinctly so the preview reads as a diff.
+      expect(new Set(classes).size).toBe(4);
+      expect(addition).not.toBe(deletion);
+    });
+
+    it("styles +++/--- file headers as headers, not as change lines", () => {
+      expect(patchLineClass("+++ b/src/foo.ts")).toBe(patchLineClass("@@ -1,3 +1,4 @@"));
+      expect(patchLineClass("--- a/src/foo.ts")).toBe(patchLineClass("@@ -1,3 +1,4 @@"));
+      expect(patchLineClass("+++ b/src/foo.ts")).not.toBe(patchLineClass("+added"));
+      expect(patchLineClass("--- a/src/foo.ts")).not.toBe(patchLineClass("-removed"));
+    });
+  });
+});

--- a/src/hooks/useArtifacts.ts
+++ b/src/hooks/useArtifacts.ts
@@ -342,62 +342,67 @@ export function useArtifacts(terminalId: string, worktreeId?: string, cwd?: stri
     return result;
   }, [artifacts, cwd, terminalId]);
 
-  const applyAllPatches = useCallback(async (): Promise<BulkResult> => {
-    if (!isElectronAvailable() || !worktreeId || !cwd) {
-      return {
-        succeeded: 0,
-        failed: 0,
-        failures: [],
-      };
-    }
-
-    const patches = artifacts.filter((a) => a.type === "patch");
-    if (patches.length === 0) {
-      return { succeeded: 0, failed: 0, failures: [] };
-    }
-
-    const sorted = sortArtifacts(patches, "extraction");
-    const result: BulkResult = { succeeded: 0, failed: 0, failures: [], modifiedFiles: [] };
-    const modifiedFilesSet = new Set<string>();
-
-    try {
-      for (let i = 0; i < sorted.length; i++) {
-        const artifact = sorted[i]!;
-        setBulkProgress({ action: "apply", current: i + 1, total: sorted.length });
-
-        try {
-          const actionResult = await actionService.dispatch<ApplyPatchResult>(
-            "artifact.applyPatch",
-            { patchContent: artifact.content, cwd },
-            { source: "user" }
-          );
-          if (!actionResult.ok) {
-            throw new Error(actionResult.error.message);
-          }
-          const applyResult = actionResult.result;
-
-          result.succeeded++;
-          applyResult.modifiedFiles.forEach((f) => modifiedFilesSet.add(f));
-        } catch (error) {
-          logErrorWithContext(error, {
-            operation: "bulk_apply_patch",
-            component: "useArtifacts",
-            details: { artifactId: artifact.id, worktreeId, cwd, terminalId },
-          });
-          result.failed++;
-          result.failures.push({
-            artifact,
-            error: formatErrorMessage(error, "Failed to apply patch"),
-          });
-        }
+  // `patchesToApply` lets the caller pass the exact snapshot its confirm dialog
+  // previewed, so patches detected while the dialog was open are not applied unseen.
+  const applyAllPatches = useCallback(
+    async (patchesToApply?: Artifact[]): Promise<BulkResult> => {
+      if (!isElectronAvailable() || !worktreeId || !cwd) {
+        return {
+          succeeded: 0,
+          failed: 0,
+          failures: [],
+        };
       }
-    } finally {
-      setBulkProgress(null);
-    }
 
-    result.modifiedFiles = Array.from(modifiedFilesSet);
-    return result;
-  }, [artifacts, worktreeId, cwd, terminalId]);
+      const patches = (patchesToApply ?? artifacts).filter((a) => a.type === "patch");
+      if (patches.length === 0) {
+        return { succeeded: 0, failed: 0, failures: [] };
+      }
+
+      const sorted = sortArtifacts(patches, "extraction");
+      const result: BulkResult = { succeeded: 0, failed: 0, failures: [], modifiedFiles: [] };
+      const modifiedFilesSet = new Set<string>();
+
+      try {
+        for (let i = 0; i < sorted.length; i++) {
+          const artifact = sorted[i]!;
+          setBulkProgress({ action: "apply", current: i + 1, total: sorted.length });
+
+          try {
+            const actionResult = await actionService.dispatch<ApplyPatchResult>(
+              "artifact.applyPatch",
+              { patchContent: artifact.content, cwd },
+              { source: "user" }
+            );
+            if (!actionResult.ok) {
+              throw new Error(actionResult.error.message);
+            }
+            const applyResult = actionResult.result;
+
+            result.succeeded++;
+            applyResult.modifiedFiles.forEach((f) => modifiedFilesSet.add(f));
+          } catch (error) {
+            logErrorWithContext(error, {
+              operation: "bulk_apply_patch",
+              component: "useArtifacts",
+              details: { artifactId: artifact.id, worktreeId, cwd, terminalId },
+            });
+            result.failed++;
+            result.failures.push({
+              artifact,
+              error: formatErrorMessage(error, "Failed to apply patch"),
+            });
+          }
+        }
+      } finally {
+        setBulkProgress(null);
+      }
+
+      result.modifiedFiles = Array.from(modifiedFilesSet);
+      return result;
+    },
+    [artifacts, worktreeId, cwd, terminalId]
+  );
 
   return {
     artifacts,

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -637,8 +637,8 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
   },
   {
     "category": "artifacts",
-    "danger": "safe",
-    "dangerRationale": undefined,
+    "danger": "confirm",
+    "dangerRationale": "Writes patch content directly into worktree files via git apply — a shared-state mutation with no automatic inverse; recovery is a manual git checkout of the touched files.",
     "description": "Apply a unified diff patch to the filesystem",
     "examples": undefined,
     "id": "artifact.applyPatch",

--- a/src/services/actions/__tests__/actionDefinitions.project-system-preferences.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.project-system-preferences.adversarial.test.ts
@@ -636,14 +636,30 @@ describe("system action hardening", () => {
     ).resolves.toEqual({ ok: true, result: { nodes: [{ path: "src", type: "directory" }] } });
   });
 
-  it("allows agent-driven artifact patches (danger:safe — patches are an IDE primitive)", async () => {
-    mocks.artifactClient.applyPatch.mockResolvedValueOnce({ ok: true });
+  it("blocks unconfirmed agent-driven artifact patches (danger:confirm — worktree mutation, #10020)", async () => {
     const { service } = buildService(registerSystemActions);
 
     const result = await service.dispatch(
       "artifact.applyPatch",
       { patchContent: "--- a\n+++ b", cwd: "/repo" },
       { source: "agent" }
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("CONFIRMATION_REQUIRED");
+    }
+    expect(mocks.artifactClient.applyPatch).not.toHaveBeenCalled();
+  });
+
+  it("allows agent-driven artifact patches with confirmed:true", async () => {
+    mocks.artifactClient.applyPatch.mockResolvedValueOnce({ ok: true });
+    const { service } = buildService(registerSystemActions);
+
+    const result = await service.dispatch(
+      "artifact.applyPatch",
+      { patchContent: "--- a\n+++ b", cwd: "/repo" },
+      { source: "agent", confirmed: true }
     );
 
     expect(result.ok).toBe(true);

--- a/src/services/actions/__tests__/actionDefinitions.quality.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.quality.test.ts
@@ -331,6 +331,7 @@ const EXPECTED_CONFIRM_DANGER: ReadonlyArray<ActionId> = [
   "recipe.run",
   "devPreview.restartAndClearCache",
   "devPreview.reinstallAndRestart",
+  "artifact.applyPatch",
 ];
 
 /**
@@ -389,6 +390,9 @@ const BYPASS_WIRED: ReadonlyArray<ActionId> = [
   // Agent-dispatch only — no user-side ConfirmDialog. danger:"confirm" gates MCP/agent
   // dispatch only; user dispatch of recipe.run is intentionally ungated.
   "recipe.run",
+  // ConfirmDialog with diff preview in ArtifactOverlay.tsx; the dispatch lives in
+  // useArtifacts.ts (action ID not co-located with the dialog component).
+  "artifact.applyPatch",
 ];
 
 describe("destructive-action confirm wiring", () => {
@@ -455,6 +459,8 @@ describe("destructive-action danger metadata", () => {
       id: "id-placeholder",
       projectId: "project-placeholder",
       recipeId: "recipe-placeholder",
+      patchContent: "--- a\n+++ b",
+      cwd: "/placeholder",
     };
 
     // Some listed actions (e.g. worktree.resource.teardown) gate availability

--- a/src/services/actions/definitions/systemActions.ts
+++ b/src/services/actions/definitions/systemActions.ts
@@ -244,7 +244,9 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
       description: "Apply a unified diff patch to the filesystem",
       category: "artifacts",
       kind: "command",
-      danger: "safe",
+      danger: "confirm",
+      dangerRationale:
+        "Writes patch content directly into worktree files via git apply — a shared-state mutation with no automatic inverse; recovery is a manual git checkout of the touched files.",
       scope: "renderer",
       argsSchema: z.object({
         patchContent: z.string(),


### PR DESCRIPTION
## Summary

- `apply-patch` was silently mutating the worktree with no confirmation or preview. This adds a D2 confirmation dialog that must be cleared before any patch is applied.
- Single apply shows a full colored per-line diff (`PatchDiffPreview`). Bulk "Apply All Patches" shows every patch as an expandable diff with +N/-N stats, all open by default.
- A snapshot of the patches is taken at request time and passed through `applyAllPatches(patchesToApply)`, so the set applied exactly matches the set previewed (TOCTOU fix, same pattern as #8725).

Closes #10020

## Changes

- `artifact.applyPatch` reclassified `danger:"safe"` → `"confirm"` with `dangerRationale` — excludes it from `repeatLast` and the MRU rail; unconfirmed agent dispatch now returns `CONFIRMATION_REQUIRED`
- `ArtifactOverlay.tsx`: single and bulk apply both gate on `ConfirmDialog`; pending confirms resolve as cancelled on overlay close/clear/unmount so `ArtifactItem` promises never hang
- `confirm-wiring.mjs` and `actionDefinitions.quality.test.ts`: `BYPASS_WIRED` added (dialog in `ArtifactOverlay.tsx`, dispatch in `useArtifacts.ts` — matches `git.pullRebase` precedent); adversarial test asserts the agent-dispatch block; `placeholderArgs` gained `patchContent`/`cwd`
- `docs/architecture/destructive-action-safeguards.md`: new Artifacts section documenting `applyPatch` (D2 done), bulk fan-out (D2 done), `saveToFile` (D0, leave)
- New tests: `ArtifactOverlay.confirmGate.test.tsx` (cancel-never-applies, confirm-applies-pending, supersede, bulk diff content, bulk snapshot race, clear-while-pending) + `ArtifactOverlay.patchPreview.test.ts` (getPatchStats header exclusion, patchLineClass category distinction)

## Testing

- `npm run check` passes (typecheck, lint, format, channel/IPC/confirm-wiring guards)
- Production build passes
- All new tests pass; pre-existing env failures (`better-sqlite3` bindings, `shutdown.test.ts`) are unrelated to this change