### PR TITLE
fix(notifications): stop marking blurred-window toasts as seen

### DIFF
--- a/src/components/ui/__tests__/toaster.test.tsx
+++ b/src/components/ui/__tests__/toaster.test.tsx
@@ -26,6 +26,13 @@ vi.stubGlobal(
 );
 vi.stubGlobal("cancelAnimationFrame", (id: number) => clearTimeout(id));
 
+// jsdom's document.hasFocus() is false unless an element holds focus, which
+// would make every toast mount blur-paused (#10056) and never auto-dismiss.
+// Pin the focused state file-wide; blur-specific tests override per test.
+beforeEach(() => {
+  vi.spyOn(document, "hasFocus").mockReturnValue(true);
+});
+
 function addToast(overrides: Record<string, unknown> = {}) {
   return useNotificationStore.getState().addNotification({
     type: "info",
@@ -1107,6 +1114,96 @@ describe("Toast severity-based dismissal (issue #5859)", () => {
 // Issue #6424 — when MAX_VISIBLE_TOASTS evicts a toast into the inbox, surface
 // a "+N more" pill below the visible stack so users can discover that
 // notifications were silently moved instead of disappearing.
+describe("Toast window-blur pause (issue #10056)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useNotificationStore.getState().reset();
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("pauses auto-dismiss while the window is blurred and resumes on focus", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast({ duration: 1000 });
+      vi.advanceTimersByTime(16);
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new Event("blur"));
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(screen.getByText("Test message")).toBeTruthy();
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(screen.queryByText("Test message")).toBeNull();
+  });
+
+  it("credits blurred time against the visible-duration cap (no instant dismiss on refocus)", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast({ duration: 1000 });
+      vi.advanceTimersByTime(16);
+    });
+
+    // Blur far past the wall-clock cap (duration * 3 = 3s). Without the
+    // blurred-time credit, refocus would compute a 0ms delay and dismiss the
+    // toast the instant the user comes back for it.
+    await act(async () => {
+      window.dispatchEvent(new Event("blur"));
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(20_000);
+    });
+    expect(screen.getByText("Test message")).toBeTruthy();
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(900);
+    });
+    expect(screen.getByText("Test message")).toBeTruthy();
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(screen.queryByText("Test message")).toBeNull();
+  });
+
+  it("starts paused when the toast is created while the window is blurred", async () => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
+    render(<Toaster />);
+    await act(async () => {
+      addToast({ duration: 1000 });
+      vi.advanceTimersByTime(16);
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(screen.getByText("Test message")).toBeTruthy();
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(screen.queryByText("Test message")).toBeNull();
+  });
+});
+
 describe("Toast overflow pill (issue #6424)", () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -101,7 +101,25 @@ function Toast({
   const [isHovered, setIsHovered] = useState(false);
   const [isFocusInside, setIsFocusInside] = useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const isPaused = isHovered || isFocusInside || isDropdownOpen;
+  // Window blur pauses auto-dismiss (#10056): a toast racing its timer in a
+  // blurred window dismisses unseen while its history entry says
+  // `seenAsToast: true`. Initialized from `document.hasFocus()` at mount
+  // (synchronous read — safe outside event handlers) so a toast born into a
+  // blurred window starts paused; the listeners below are pure state flips
+  // because `hasFocus()` is stale inside blur handlers in Chromium 148.
+  const [isWindowBlurred, setIsWindowBlurred] = useState(
+    () => typeof document !== "undefined" && !document.hasFocus()
+  );
+  const isPaused = isHovered || isFocusInside || isDropdownOpen || isWindowBlurred;
+  // Blurred time doesn't count against the visible-duration cap — the cap
+  // bounds *visible* time (see MAX_VISIBLE_DURATION_MS), and a toast in a
+  // blurred window isn't visible. Without this credit, a blur outlasting the
+  // cap would compute a 0ms delay on refocus and instant-dismiss the toast
+  // the user came back for (e.g. a watch-priority toast born blurred).
+  const blurredAccumRef = useRef(0);
+  const blurredSinceRef = useRef<number | null>(
+    typeof document !== "undefined" && !document.hasFocus() ? Date.now() : null
+  );
   const toastRef = useRef<HTMLDivElement>(null);
   const prevFocusRef = useRef<Element | null>(null);
 
@@ -177,6 +195,28 @@ function Toast({
   useEffect(() => {
     const handle = requestAnimationFrame(() => setIsVisible(true));
     return () => cancelAnimationFrame(handle);
+  }, []);
+
+  useEffect(() => {
+    // Pure state flips — `document.hasFocus()` is stale inside blur handlers
+    // in Chromium 148, so the event arrival itself is the signal.
+    const handleBlur = (): void => {
+      if (blurredSinceRef.current === null) blurredSinceRef.current = Date.now();
+      setIsWindowBlurred(true);
+    };
+    const handleFocus = (): void => {
+      if (blurredSinceRef.current !== null) {
+        blurredAccumRef.current += Date.now() - blurredSinceRef.current;
+        blurredSinceRef.current = null;
+      }
+      setIsWindowBlurred(false);
+    };
+    window.addEventListener("blur", handleBlur);
+    window.addEventListener("focus", handleFocus);
+    return () => {
+      window.removeEventListener("blur", handleBlur);
+      window.removeEventListener("focus", handleFocus);
+    };
   }, []);
 
   const restoreFocus = useCallback(() => {
@@ -262,7 +302,8 @@ function Toast({
     const cap = hasActions
       ? duration * VISIBLE_DURATION_MULTIPLIER
       : Math.min(duration * VISIBLE_DURATION_MULTIPLIER, MAX_VISIBLE_DURATION_MS);
-    const deadline = (notification.firstShownAt ?? Date.now()) + cap;
+    // Credit accumulated blurred time so the cap only consumes visible time.
+    const deadline = (notification.firstShownAt ?? Date.now()) + cap + blurredAccumRef.current;
     const delay = Math.min(duration, Math.max(0, deadline - Date.now()));
     dismissTimerRef.current = setTimeout(() => dismissRef.current(), delay);
     return () => {

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -201,6 +201,13 @@ function Toast({
     // Pure state flips — `document.hasFocus()` is stale inside blur handlers
     // in Chromium 148, so the event arrival itself is the signal.
     const handleBlur = (): void => {
+      // Eagerly clear the in-flight dismiss timer — waiting for the React
+      // re-render to run the effect cleanup leaves a window where a timer
+      // expiring right at blur dismisses the toast unseen.
+      if (dismissTimerRef.current) {
+        clearTimeout(dismissTimerRef.current);
+        dismissTimerRef.current = null;
+      }
       if (blurredSinceRef.current === null) blurredSinceRef.current = Date.now();
       setIsWindowBlurred(true);
     };

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -1777,9 +1777,12 @@ describe("notify()", () => {
       focusSpy.mockReturnValue(false);
       window.dispatchEvent(new Event("blur"));
       expect(useNotificationStore.getState().notifications).toHaveLength(0);
-      // Well past SUPPRESS_GRACE_MS — the paused timer must not drop the entry.
+      // Well past SUPPRESS_GRACE_MS — the paused timer must not drop the entry
+      // (the grace entry is written seenAsToast=true for the inline-visible
+      // origin, so a drop while blurred would swallow the signal marked-read).
       vi.advanceTimersByTime(5_000);
       expect(useNotificationStore.getState().notifications).toHaveLength(0);
+      expect(useNotificationHistoryStore.getState().entries[0]!.seenAsToast).toBe(true);
 
       // The worktree changed while blurred without a subscriber tick (e.g.
       // restored session state) — origin is no longer visible on refocus, so
@@ -1838,7 +1841,7 @@ describe("notify()", () => {
       expect(useNotificationStore.getState().notifications).toHaveLength(1);
     });
 
-    it("subscriber promotion while blurred cleans up the deferred refocus listener", () => {
+    it("context change while blurred defers promotion to refocus instead of toasting blind", () => {
       const focusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(true);
       setActiveWorktree("wt-1");
       notify({
@@ -1849,12 +1852,15 @@ describe("notify()", () => {
       });
       focusSpy.mockReturnValue(false);
       window.dispatchEvent(new Event("blur"));
-      // A context change while blurred still promotes via the subscriber path.
+      // A subscriber tick while blurred must not toast into the invisible
+      // window — the armed refocus listener owns the promotion.
       setActiveWorktree("wt-2");
-      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
 
-      // Refocus must not double-promote — cleanup removed the one-shot listener.
       focusSpy.mockReturnValue(true);
+      window.dispatchEvent(new Event("focus"));
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+      // And only once — cleanup removed the one-shot listener.
       window.dispatchEvent(new Event("focus"));
       expect(useNotificationStore.getState().notifications).toHaveLength(1);
     });

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -1757,10 +1757,12 @@ describe("notify()", () => {
       expect(useNotificationStore.getState().notifications).toHaveLength(1);
     });
 
-    it("promotes to toast on window blur during grace window", () => {
+    it("defers blur promotion until refocus instead of toasting into a blurred window (#10056)", () => {
       // Alt-tab without changing worktree/panel doesn't fire a context
-      // subscriber, so without the blur fallback the timer would silently
-      // drop the notification with seenAsToast=true.
+      // subscriber. Promoting immediately on blur would fire the toast into
+      // a blurred window where it auto-dismisses unseen, so the decision is
+      // deferred to a one-shot refocus listener; the grace drop-timer pauses
+      // while blurred so the pending entry isn't silently dropped meanwhile.
       const focusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(true);
       setActiveWorktree("wt-1");
       notify({
@@ -1770,11 +1772,110 @@ describe("notify()", () => {
         context: { worktreeId: "wt-1" },
       });
       expect(useNotificationStore.getState().notifications).toHaveLength(0);
+      const entryId = useNotificationHistoryStore.getState().entries[0]!.id;
 
       focusSpy.mockReturnValue(false);
       window.dispatchEvent(new Event("blur"));
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+      // Well past SUPPRESS_GRACE_MS — the paused timer must not drop the entry.
+      vi.advanceTimersByTime(5_000);
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+
+      // The worktree changed while blurred without a subscriber tick (e.g.
+      // restored session state) — origin is no longer visible on refocus, so
+      // the missed signal promotes to a toast the user can actually see.
+      activeWorktreeId = "wt-2";
+      focusSpy.mockReturnValue(true);
+      window.dispatchEvent(new Event("focus"));
+      const notifications = useNotificationStore.getState().notifications;
+      expect(notifications).toHaveLength(1);
+      expect(notifications[0]!.message).toBe("Alt-tab signal");
+      expect(notifications[0]!.historyEntryId).toBe(entryId);
+    });
+
+    it("refocusing onto the still-visible origin surface resumes the grace countdown", () => {
+      const focusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      setActiveWorktree("wt-1");
+      notify({
+        type: "info",
+        message: "Back to same surface",
+        priority: "high",
+        context: { worktreeId: "wt-1" },
+      });
+      focusSpy.mockReturnValue(false);
+      window.dispatchEvent(new Event("blur"));
+      vi.advanceTimersByTime(5_000);
+
+      // User returns to the surface where the signal is visible inline — no
+      // toast; the grace countdown restarts instead.
+      focusSpy.mockReturnValue(true);
+      window.dispatchEvent(new Event("focus"));
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+      vi.advanceTimersByTime(501);
+      // Once the restarted grace elapses on the visible surface, the entry is
+      // considered seen — a later navigate-away no longer promotes.
+      setActiveWorktree("wt-2");
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+    });
+
+    it("repeated blurs arm a single one-shot refocus promotion", () => {
+      const focusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      setActiveWorktree("wt-1");
+      notify({
+        type: "info",
+        message: "One-shot",
+        priority: "high",
+        context: { worktreeId: "wt-1" },
+      });
+      focusSpy.mockReturnValue(false);
+      window.dispatchEvent(new Event("blur"));
+      window.dispatchEvent(new Event("blur"));
+
+      activeWorktreeId = "wt-2";
+      focusSpy.mockReturnValue(true);
+      window.dispatchEvent(new Event("focus"));
+      window.dispatchEvent(new Event("focus"));
       expect(useNotificationStore.getState().notifications).toHaveLength(1);
-      expect(useNotificationStore.getState().notifications[0]!.message).toBe("Alt-tab signal");
+    });
+
+    it("subscriber promotion while blurred cleans up the deferred refocus listener", () => {
+      const focusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      setActiveWorktree("wt-1");
+      notify({
+        type: "info",
+        message: "Nav while blurred",
+        priority: "high",
+        context: { worktreeId: "wt-1" },
+      });
+      focusSpy.mockReturnValue(false);
+      window.dispatchEvent(new Event("blur"));
+      // A context change while blurred still promotes via the subscriber path.
+      setActiveWorktree("wt-2");
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+
+      // Refocus must not double-promote — cleanup removed the one-shot listener.
+      focusSpy.mockReturnValue(true);
+      window.dispatchEvent(new Event("focus"));
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+    });
+
+    it("reset clears the deferred refocus listener", () => {
+      const focusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      setActiveWorktree("wt-1");
+      notify({
+        type: "info",
+        message: "Torn down",
+        priority: "high",
+        context: { worktreeId: "wt-1" },
+      });
+      focusSpy.mockReturnValue(false);
+      window.dispatchEvent(new Event("blur"));
+      _resetPendingSuppressedForTest();
+
+      activeWorktreeId = "wt-2";
+      focusSpy.mockReturnValue(true);
+      window.dispatchEvent(new Event("focus"));
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
     });
 
     it("promoted toast carries the same historyEntryId as the suppressed entry", () => {
@@ -2896,6 +2997,39 @@ describe("notify() — thread re-promotion (#9008)", () => {
       urgent: true,
     });
     expect(useNotificationStore.getState().notifications).toHaveLength(1);
+  });
+
+  it("stays inbox-only with seenAsToast=false when escalating while blurred (#10056)", () => {
+    // A re-promotion fired into a blurred window would render unseen,
+    // auto-dismiss, and be marked read — invisible to both the unread badge
+    // and the re-entry summary. Blurred escalations must stay inbox-only.
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
+    seedThread([seedEntry({ type: "info", correlationId: "build" })]);
+    notify({ type: "warning", correlationId: "build", message: "Build degraded", priority: "low" });
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
+
+    const entries = useNotificationHistoryStore.getState().entries;
+    expect(entries).toHaveLength(2);
+    const escalation = entries.find((e) => e.message === "Build degraded");
+    expect(escalation?.seenAsToast).toBe(false);
+    expect(useNotificationHistoryStore.getState().unreadCount).toBe(1);
+  });
+
+  it("urgent escalation while blurred also stays inbox-only (urgent bypasses quiet hours, not focus)", () => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
+    seedThread([seedEntry({ type: "info", correlationId: "build" })]);
+    notify({
+      type: "info",
+      correlationId: "build",
+      message: "Urgent update",
+      priority: "low",
+      urgent: true,
+    });
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
+    const urgentEntry = useNotificationHistoryStore
+      .getState()
+      .entries.find((e) => e.message === "Urgent update");
+    expect(urgentEntry?.seenAsToast).toBe(false);
   });
 
   it("excludes archived entries from the escalation baseline", () => {

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -1141,8 +1141,17 @@ function scheduleSuppressionGrace(
   };
 
   // If no subscriber is registered (very early startup), the timer is the
-  // sole gate — falls back to "suppress for 500ms then drop".
-  const unsubContext = subscriber ? subscriber(promote) : () => {};
+  // sole gate — falls back to "suppress for 500ms then drop". A context
+  // change while the window is blurred (programmatic worktree/panel switch)
+  // must not toast into the invisible window — the dispatch required focus,
+  // so any blur has already armed the refocus listener below, which promotes
+  // when the user returns.
+  const unsubContext = subscriber
+    ? subscriber(() => {
+        if (typeof document !== "undefined" && !document.hasFocus()) return;
+        promote();
+      })
+    : () => {};
 
   // Window blur during grace means the user can no longer see the inline
   // affordance, but no worktree/panel state changes to fire `subscriber`.

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -938,9 +938,14 @@ export function notify(payload: NotifyPayload): string {
   // pre-commit thread state (before the `addEntry` write below), so
   // `getWorstSeverity` compares the incoming severity against the existing
   // entries rather than itself. `transient` payloads have no inbox thread, so
-  // there is nothing to re-promote against.
+  // there is nothing to re-promote against. Gated on `isFocused` like
+  // `shouldToast` (#10056): a re-promotion fired into a blurred window would
+  // render unseen, auto-dismiss, and write `seenAsToast: true` — hiding the
+  // escalation from the unread badge and re-entry summary. Blurred
+  // escalations stay inbox-only (`seenAsToast: false`) so they surface on
+  // refocus; `urgent` bypasses quiet hours and rate limiting, not focus.
   const shouldToastThread =
-    !shouldToast && correlationId && !payload.transient
+    !shouldToast && isFocused && correlationId && !payload.transient
       ? shouldReToast(type, getEntriesByCorrelationId(correlationId), payload.urgent)
       : false;
   const effectiveShouldToast = shouldToast || shouldToastThread;
@@ -1135,21 +1140,45 @@ function scheduleSuppressionGrace(
     });
   };
 
-  const timerId = setTimeout(() => {
-    cleanup();
-  }, SUPPRESS_GRACE_MS);
-
   // If no subscriber is registered (very early startup), the timer is the
   // sole gate — falls back to "suppress for 500ms then drop".
   const unsubContext = subscriber ? subscriber(promote) : () => {};
 
   // Window blur during grace means the user can no longer see the inline
   // affordance, but no worktree/panel state changes to fire `subscriber`.
-  // Treat it as navigate-away so the missed signal still surfaces when they
-  // come back instead of being silently swallowed with `seenAsToast: true`.
+  // Promoting immediately would fire the toast into a blurred window where it
+  // auto-dismisses unseen (#10056), so instead: pause the drop timer (the
+  // "visible for 500ms = seen" assumption breaks while blurred) and defer the
+  // decision to a one-shot refocus listener. On refocus, the origin surface
+  // being visible again resumes the grace countdown; otherwise the user came
+  // back somewhere else and the missed signal promotes to a toast they can
+  // actually see. `document.hasFocus()` is stale inside a blur handler in
+  // Chromium 148 — the event arrival itself is the signal; nothing here
+  // re-reads focus synchronously.
   let unsubBlur = (): void => {};
+  let unsubFocus = (): void => {};
   if (typeof window !== "undefined") {
-    const blurHandler = (): void => promote();
+    const focusHandler = (): void => {
+      window.removeEventListener("focus", focusHandler);
+      unsubFocus = (): void => {};
+      const entry = _pendingSuppressed.get(historyEntryId);
+      if (!entry) return;
+      if (isOriginSurfaceVisible(context)) {
+        // Inline affordance is visible again — restart the grace countdown.
+        entry.timerId = setTimeout(cleanup, SUPPRESS_GRACE_MS);
+        return;
+      }
+      promote();
+    };
+    const blurHandler = (): void => {
+      const entry = _pendingSuppressed.get(historyEntryId);
+      if (!entry) return;
+      clearTimeout(entry.timerId);
+      // One-shot, idempotent: repeated blur events must not stack listeners.
+      window.removeEventListener("focus", focusHandler);
+      window.addEventListener("focus", focusHandler);
+      unsubFocus = (): void => window.removeEventListener("focus", focusHandler);
+    };
     window.addEventListener("blur", blurHandler);
     unsubBlur = (): void => window.removeEventListener("blur", blurHandler);
   }
@@ -1157,7 +1186,12 @@ function scheduleSuppressionGrace(
   const unsub = (): void => {
     unsubContext();
     unsubBlur();
+    unsubFocus();
   };
+
+  const timerId = setTimeout(() => {
+    cleanup();
+  }, SUPPRESS_GRACE_MS);
 
   _pendingSuppressed.set(historyEntryId, { timerId, unsub });
 }


### PR DESCRIPTION
## Summary

- Toasts fired while the window is blurred were auto-dismissing unseen and getting marked read — the unread badge and re-entry summary never surfaced them on refocus
- Three-layer fix: thread re-promotion now gates on `document.focus`, suppression-grace blur handling pauses the drop timer instead of promoting into a blurred window, and toast auto-dismiss pauses while blurred (crediting accumulated blur time against the visible-duration cap)
- `urgent` priority bypasses quiet hours and rate limiting but not the focus gate — escalations that arrive while blurred stay inbox-only with `seenAsToast: false` until the user comes back

Resolves #10056

## Changes

- `src/lib/notify.ts`: `shouldReToast` now requires `document.hasFocus()`, matching `shouldToast`; suppression-grace blur handler pauses the 500ms drop timer and arms an idempotent one-shot refocus listener that either restarts the countdown (if the origin surface is visible) or promotes to a toast
- `src/components/ui/toaster.tsx`: blur/focus listeners added as a fourth pause source; dismiss timer eagerly cleared on blur; accumulated blur time credited against the visible-duration cap on refocus
- Tests: 5 new/updated suppression-grace tests, 2 thread re-promotion blurred tests, 3 toaster blur-pause tests; toaster test file pins `jsdom` `document.hasFocus()` to `true` file-wide (jsdom defaults `false`, which would blur-pause every toast under test)

## Testing

- 318 targeted tests passing (all static checks + build)
- Full renderer suite (18,412 tests) green
- Electron-process unit tests fail locally due to missing electron binary — identical failures on `develop` checkout, environmental only; CI's `npm ci` will be green