### PR TITLE
fix(shared): emit canonical providerId from legacy worktree snapshot fallback

### DIFF
--- a/shared/utils/__tests__/pluginWorktreeSnapshot.test.ts
+++ b/shared/utils/__tests__/pluginWorktreeSnapshot.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { toPluginWorktreeSnapshot } from "../pluginWorktreeSnapshot.js";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "../forgeProviderIds.js";
 import type { WorktreeSnapshot } from "../../types/workspace-host.js";
 
 function makeSnapshot(extra: Partial<WorktreeSnapshot> = {}): WorktreeSnapshot {
@@ -29,10 +30,10 @@ describe("toPluginWorktreeSnapshot — linked projection", () => {
       })
     );
     expect(out.linked).not.toBeNull();
-    expect(out.linked?.providerId).toBe("github");
+    expect(out.linked?.providerId).toBe(BUILTIN_GITHUB_PROVIDER_ID);
     expect(out.linked?.pr).toEqual({
       ref: {
-        providerId: "github",
+        providerId: BUILTIN_GITHUB_PROVIDER_ID,
         owner: "",
         repo: "",
         number: 42,
@@ -49,10 +50,10 @@ describe("toPluginWorktreeSnapshot — linked projection", () => {
     const out = toPluginWorktreeSnapshot(
       makeSnapshot({ issueNumber: 7, issueTitle: "Bug report" })
     );
-    expect(out.linked?.providerId).toBe("github");
+    expect(out.linked?.providerId).toBe(BUILTIN_GITHUB_PROVIDER_ID);
     expect(out.linked?.issue).toEqual({
       ref: {
-        providerId: "github",
+        providerId: BUILTIN_GITHUB_PROVIDER_ID,
         owner: "",
         repo: "",
         number: 7,
@@ -87,7 +88,7 @@ describe("toPluginWorktreeSnapshot — linked projection", () => {
       })
     );
     const providerId = out.linked?.providerId;
-    expect(providerId).toBe("github");
+    expect(providerId).toBe(BUILTIN_GITHUB_PROVIDER_ID);
     expect(out.linked?.pr?.ref.providerId).toBe(providerId);
     expect(out.linked?.issue?.ref.providerId).toBe(providerId);
   });
@@ -305,5 +306,16 @@ describe("toPluginWorktreeSnapshot — linked is the source of truth (#8452)", (
 
   it("returns null only when linked is null AND no flat fields are present", () => {
     expect(toPluginWorktreeSnapshot(makeSnapshot({ linked: null })).linked).toBeNull();
+  });
+});
+
+describe("BUILTIN_GITHUB_PROVIDER_ID — constant pin", () => {
+  // Localized guard: if `BUILTIN_GITHUB_PROVIDER_ID` is ever silently renamed
+  // to a non-canonical form, every assertion in this file that compares against
+  // it would start failing with the projection test name in the stack — pinning
+  // the literal here gives the next maintainer a single named failure pointing
+  // at the constant itself.
+  it("resolves to the canonical built-in GitHub forge provider id", () => {
+    expect(BUILTIN_GITHUB_PROVIDER_ID).toBe("daintree.github.github");
   });
 });

--- a/shared/utils/__tests__/pluginWorktreeSnapshot.test.ts
+++ b/shared/utils/__tests__/pluginWorktreeSnapshot.test.ts
@@ -309,13 +309,78 @@ describe("toPluginWorktreeSnapshot — linked is the source of truth (#8452)", (
   });
 });
 
-describe("BUILTIN_GITHUB_PROVIDER_ID — constant pin", () => {
-  // Localized guard: if `BUILTIN_GITHUB_PROVIDER_ID` is ever silently renamed
-  // to a non-canonical form, every assertion in this file that compares against
-  // it would start failing with the projection test name in the stack — pinning
-  // the literal here gives the next maintainer a single named failure pointing
-  // at the constant itself.
-  it("resolves to the canonical built-in GitHub forge provider id", () => {
-    expect(BUILTIN_GITHUB_PROVIDER_ID).toBe("daintree.github.github");
+describe("toPluginWorktreeSnapshot — host-built vs legacy fallback parity (#9958)", () => {
+  // The #9958 regression: the host-built `linked` path and the legacy flat-
+  // field fallback previously emitted different providerIds (`"daintree.github.github"`
+  // vs `"github"`), so third-party plugins that switch on `linked.providerId`
+  // would silently take different branches for the same worktree depending on
+  // which path produced the projection. This test pins the cross-path equality
+  // on all three providerId sites in the projection.
+  it("emits the same providerId from both paths at every linked.{providerId,pr.ref.providerId,issue.ref.providerId} site", () => {
+    const hostBuilt = toPluginWorktreeSnapshot(
+      makeSnapshot({
+        prNumber: 42,
+        prUrl: "https://github.com/o/r/pull/42",
+        prState: "open",
+        issueNumber: 7,
+        linked: {
+          providerId: BUILTIN_GITHUB_PROVIDER_ID,
+          pr: {
+            ref: {
+              providerId: BUILTIN_GITHUB_PROVIDER_ID,
+              owner: "o",
+              repo: "r",
+              number: 42,
+              rawData: null,
+            },
+            title: "Fix the thing",
+            url: "https://github.com/o/r/pull/42",
+            state: "open",
+          },
+          issue: {
+            ref: {
+              providerId: BUILTIN_GITHUB_PROVIDER_ID,
+              owner: "o",
+              repo: "r",
+              number: 7,
+              rawData: null,
+            },
+            title: "Bug report",
+          },
+        },
+      })
+    );
+    const legacyFallback = toPluginWorktreeSnapshot(
+      makeSnapshot({
+        prNumber: 42,
+        prUrl: "https://github.com/o/r/pull/42",
+        prState: "open",
+        issueNumber: 7,
+      })
+    );
+
+    expect(hostBuilt.linked?.providerId).toBe(legacyFallback.linked?.providerId);
+    expect(hostBuilt.linked?.pr?.ref.providerId).toBe(legacyFallback.linked?.pr?.ref.providerId);
+    expect(hostBuilt.linked?.issue?.ref.providerId).toBe(
+      legacyFallback.linked?.issue?.ref.providerId
+    );
+    expect(legacyFallback.linked?.providerId).toBe(BUILTIN_GITHUB_PROVIDER_ID);
+  });
+
+  it("does not emit any of the legacy providerId forms from the fallback path", () => {
+    const out = toPluginWorktreeSnapshot(
+      makeSnapshot({
+        prNumber: 1,
+        prUrl: "u",
+        prState: "open",
+        issueNumber: 2,
+      })
+    );
+    expect(out.linked?.providerId).not.toBe("github");
+    expect(out.linked?.providerId).not.toBe("builtin.github");
+    expect(out.linked?.pr?.ref.providerId).not.toBe("github");
+    expect(out.linked?.pr?.ref.providerId).not.toBe("builtin.github");
+    expect(out.linked?.issue?.ref.providerId).not.toBe("github");
+    expect(out.linked?.issue?.ref.providerId).not.toBe("builtin.github");
   });
 });

--- a/shared/utils/pluginWorktreeSnapshot.ts
+++ b/shared/utils/pluginWorktreeSnapshot.ts
@@ -6,6 +6,7 @@ import type {
 } from "../types/plugin.js";
 import type { NormalizedPRState, ResourceRef } from "../types/forge.js";
 import type { WorktreeSnapshot } from "../types/workspace-host.js";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "./forgeProviderIds.js";
 
 /**
  * Project an internal `WorktreeSnapshot` down to the read-only
@@ -38,9 +39,10 @@ export function toPluginWorktreeSnapshot(snapshot: WorktreeSnapshot): PluginWork
  * is the source of truth (#8452): when present it is passed through verbatim
  * (deep-cloned then frozen so the host's live `_linked` reference is never
  * mutated). Only legacy snapshots that never populated `linked` fall back to
- * synthesizing it from the flat GitHub-shaped fields, where the provider id is
- * hardcoded to `"github"` and `owner`/`repo` are empty because those snapshots
- * predate canonical repo identity on the payload.
+ * synthesizing it from the flat GitHub-shaped fields, stamping the canonical
+ * built-in GitHub provider id (see `forgeProviderIds.ts`) and leaving
+ * `owner`/`repo` empty because those snapshots predate canonical repo identity
+ * on the payload.
  */
 function buildLinkedProjection(snapshot: WorktreeSnapshot): PluginWorktreeLinked | null {
   if (snapshot.linked != null) {
@@ -51,7 +53,7 @@ function buildLinkedProjection(snapshot: WorktreeSnapshot): PluginWorktreeLinked
   const hasIssue = typeof snapshot.issueNumber === "number";
   if (!hasPR && !hasIssue) return null;
 
-  const providerId = "github";
+  const providerId = BUILTIN_GITHUB_PROVIDER_ID;
   const linked: {
     providerId: string;
     issue?: PluginWorktreeLinkedIssue;


### PR DESCRIPTION
## Summary
- The fallback branch in `shared/utils/pluginWorktreeSnapshot.ts` was hardcoding the bare string `"github"` as `providerId`, while the host-built path (in `electron/services/WorkspaceHostProcess.ts` and `electron/ipc/handlers/github.ts`) emits `BUILTIN_GITHUB_PROVIDER_ID` (`"daintree.github.github"`). Plugins filtering by canonical id were silently missing fallback snapshots.
- The fallback is reachable: `WorktreeSnapshot.linked` is optional, so worktrees with flat `issueNumber`/`prNumber` fields but no `linked` projection still hit this branch.
- The fix imports `BUILTIN_GITHUB_PROVIDER_ID` from `shared/utils/forgeProviderIds.ts` and uses it in the fallback, matching the host-built path. The empty `owner`/`repo` behavior is preserved for these identity-less legacy snapshots.

Resolves #9958

## Changes
- `shared/utils/pluginWorktreeSnapshot.ts` — use `BUILTIN_GITHUB_PROVIDER_ID` in the fallback `linked` builder instead of the bare `"github"` string, on the top-level `providerId` and both nested `ResourceRef` values.
- `shared/utils/__tests__/pluginWorktreeSnapshot.test.ts` — add a cross-path parity test asserting the host-built and fallback paths emit the same `providerId` for the GitHub provider, plus coverage for both `issueNumber` and `prNumber` branches.

## Testing
- New parity test in `shared/utils/__tests__/pluginWorktreeSnapshot.test.ts` covers both branches of the fallback.
- Full local suite (`npm run check`) passed on the gated SHA.
- Out of scope here: the broader #8452 migration to make `linked` the source of truth, which is blocked on #8451.