### PR TITLE
fix(portal): filter malformed entries in persist merge

### DIFF
--- a/src/store/__tests__/portalStore.test.ts
+++ b/src/store/__tests__/portalStore.test.ts
@@ -504,15 +504,14 @@ describe("portalStore persistence migration", () => {
       state: {
         tabs: [
           null,
-          undefined,
           "string-not-an-object",
           42,
           { title: "no-id", url: "https://example.com" },
           { id: "no-title", url: "https://example.com" },
           { id: 7, title: "wrong-id-type" },
           { id: "wrong-url", title: "Wrong url", url: 5 },
-          { id: "undefined-url", title: "Undefined url", url: undefined },
           { id: "wrong-icon", title: "Wrong icon", url: null, icon: 9 },
+          { id: "wrong-partition", title: "Wrong partition", url: null, partition: 7 },
           { id: "tab-good", title: "Good", url: "https://example.com" },
         ],
         activeTabId: "tab-good",
@@ -527,6 +526,34 @@ describe("portalStore persistence migration", () => {
     expect(tabs).toHaveLength(1);
     expect(tabs[0]?.id).toBe("tab-good");
     expect(store.getState().activeTabId).toBe("tab-good");
+  });
+
+  it("preserves valid optional fields through rehydration", async () => {
+    const persistedBlob = JSON.stringify({
+      version: 0,
+      state: {
+        tabs: [
+          {
+            id: "tab-rich",
+            title: "Rich",
+            url: "https://example.com",
+            favicon: "https://example.com/favicon.ico",
+            icon: "globe",
+            partition: "persist:dev-preview-1",
+          },
+        ],
+        activeTabId: "tab-rich",
+        links: [],
+      },
+    });
+    installLocalStorageWith({ [STORAGE_KEY]: persistedBlob });
+
+    const { usePortalStore: store } = await import("../portalStore");
+
+    const tab = store.getState().tabs[0];
+    expect(tab?.favicon).toBe("https://example.com/favicon.ico");
+    expect(tab?.icon).toBe("globe");
+    expect(tab?.partition).toBe("persist:dev-preview-1");
   });
 
   it("falls back to the first surviving tab when activeTabId points to a filtered entry", async () => {
@@ -547,6 +574,7 @@ describe("portalStore persistence migration", () => {
     const { usePortalStore: store } = await import("../portalStore");
 
     expect(store.getState().activeTabId).toBe("tab-good");
+    expect(store.getState().tabs.map((t) => t.id)).toEqual(["tab-good"]);
   });
 
   it("clears tabs and activeTabId when every persisted tab fails shape validation", async () => {
@@ -564,6 +592,24 @@ describe("portalStore persistence migration", () => {
 
     expect(store.getState().tabs).toEqual([]);
     expect(store.getState().activeTabId).toBeNull();
+  });
+
+  it("does not crash when persisted links contains a null entry", async () => {
+    const persistedBlob = JSON.stringify({
+      version: 0,
+      state: {
+        links: [null, "string-not-an-object", 42],
+        tabs: [{ id: "tab-1", title: "One", url: "https://example.com" }],
+        activeTabId: "tab-1",
+      },
+    });
+    installLocalStorageWith({ [STORAGE_KEY]: persistedBlob });
+
+    const { usePortalStore: store } = await import("../portalStore");
+
+    // Survived the rehydration with usable defaults; no throw on first l.id access.
+    expect(Array.isArray(store.getState().links)).toBe(true);
+    expect(store.getState().tabs[0]?.id).toBe("tab-1");
   });
 
   it("falls back to currentState.tabs when persisted tabs is non-array", async () => {

--- a/src/store/__tests__/portalStore.test.ts
+++ b/src/store/__tests__/portalStore.test.ts
@@ -491,7 +491,79 @@ describe("portalStore persistence migration", () => {
 
     const { usePortalStore: store } = await import("../portalStore");
 
+    const tabs = store.getState().tabs;
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0]).not.toBeNull();
+    expect(tabs[0]?.id).toBe("tab-keep");
     expect(store.getState().activeTabId).toBe("tab-keep");
+  });
+
+  it("strips non-object, missing-field, and wrong-type tab entries from persisted state", async () => {
+    const persistedBlob = JSON.stringify({
+      version: 0,
+      state: {
+        tabs: [
+          null,
+          undefined,
+          "string-not-an-object",
+          42,
+          { title: "no-id", url: "https://example.com" },
+          { id: "no-title", url: "https://example.com" },
+          { id: 7, title: "wrong-id-type" },
+          { id: "wrong-url", title: "Wrong url", url: 5 },
+          { id: "undefined-url", title: "Undefined url", url: undefined },
+          { id: "wrong-icon", title: "Wrong icon", url: null, icon: 9 },
+          { id: "tab-good", title: "Good", url: "https://example.com" },
+        ],
+        activeTabId: "tab-good",
+        links: [],
+      },
+    });
+    installLocalStorageWith({ [STORAGE_KEY]: persistedBlob });
+
+    const { usePortalStore: store } = await import("../portalStore");
+
+    const tabs = store.getState().tabs;
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0]?.id).toBe("tab-good");
+    expect(store.getState().activeTabId).toBe("tab-good");
+  });
+
+  it("falls back to the first surviving tab when activeTabId points to a filtered entry", async () => {
+    const persistedBlob = JSON.stringify({
+      version: 0,
+      state: {
+        tabs: [
+          { id: "tab-junk", title: "Junk" },
+          null,
+          { id: "tab-good", title: "Good", url: "https://example.com" },
+        ],
+        activeTabId: "tab-junk",
+        links: [],
+      },
+    });
+    installLocalStorageWith({ [STORAGE_KEY]: persistedBlob });
+
+    const { usePortalStore: store } = await import("../portalStore");
+
+    expect(store.getState().activeTabId).toBe("tab-good");
+  });
+
+  it("clears tabs and activeTabId when every persisted tab fails shape validation", async () => {
+    const persistedBlob = JSON.stringify({
+      version: 0,
+      state: {
+        tabs: [null, { title: "no-id" }, { id: 5 }],
+        activeTabId: "anything",
+        links: [],
+      },
+    });
+    installLocalStorageWith({ [STORAGE_KEY]: persistedBlob });
+
+    const { usePortalStore: store } = await import("../portalStore");
+
+    expect(store.getState().tabs).toEqual([]);
+    expect(store.getState().activeTabId).toBeNull();
   });
 
   it("falls back to currentState.tabs when persisted tabs is non-array", async () => {

--- a/src/store/portalStore.ts
+++ b/src/store/portalStore.ts
@@ -456,6 +456,7 @@ const portalStoreCreator: StateCreator<
       const seen = new Set<string>();
       const migratedLinks: Array<Record<string, unknown>> = [];
       for (const l of rawLinks) {
+        if (!l || typeof l !== "object") continue;
         const newId = l.id?.startsWith("discovered-")
           ? String(l.id).replace("discovered-", "system-")
           : l.id;

--- a/src/store/portalStore.ts
+++ b/src/store/portalStore.ts
@@ -71,6 +71,18 @@ const initialState: PortalState = {
   showDevDashboard: false,
 };
 
+function isPersistedTab(value: unknown): value is PortalTab {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<PortalTab>;
+  if (typeof candidate.id !== "string") return false;
+  if (typeof candidate.title !== "string") return false;
+  if (candidate.url !== null && typeof candidate.url !== "string") return false;
+  if (candidate.favicon !== undefined && typeof candidate.favicon !== "string") return false;
+  if (candidate.icon !== undefined && typeof candidate.icon !== "string") return false;
+  if (candidate.partition !== undefined && typeof candidate.partition !== "string") return false;
+  return true;
+}
+
 const createPortalStore: StateCreator<PortalState & PortalActions> = (set, get) => {
   const CLOSE_TAB_RESTORE_MAX_ATTEMPTS = 20;
   const CLOSE_TAB_RESTORE_DELAY_MS = 50;
@@ -479,7 +491,9 @@ const portalStoreCreator: StateCreator<
       ] as PortalLink[];
     }
 
-    const persistedTabs = Array.isArray(persisted.tabs) ? persisted.tabs : currentState.tabs;
+    const persistedTabs = Array.isArray(persisted.tabs)
+      ? persisted.tabs.filter(isPersistedTab)
+      : currentState.tabs;
     const persistedActiveTabId = persisted.activeTabId;
     const activeTabId =
       typeof persistedActiveTabId === "string" &&


### PR DESCRIPTION
## Summary

- The Zustand persist `merge` in `src/store/portalStore.ts` was trusting `Array.isArray` for the `tabs` payload from `localStorage`, so a stored value like `{ "tabs": [null] }` shipped a `null` straight into live state. The first downstream `t.id` access (in `closeTab`, `cycleNextTab`, `portal.listTabs`, the `PortalDock` render, and so on) then crashed.
- Adds a file-local `isPersistedTab` type guard, mirroring `isPersistedProject` in `projectStore.ts`, and filters the persisted array before it reaches the store. The existing `t != null` checks in the `activeTabId` derivation stay in place as defense-in-depth.
- A second commit hardens the `links` branch in the same merge function. `links: [null]` was crashing on `l.id?.startsWith` for the same reason, so a non-object guard is added at the top of the link migration loop.

No `version` bump is needed since the merge runs on every hydration, not just the first (lesson #7317).

## Changes

- `src/store/portalStore.ts`
  - New file-local `isPersistedTab` guard; filter `persistedTabs` through it.
  - Skip non-object entries in the `links` migration loop.
- `src/store/__tests__/portalStore.test.ts`
  - Regression tests for null entries, non-object primitives, missing fields, wrong-type fields, `activeTabId` pointing to a filtered entry, the all-filtered fallback, and the `links: [null]` crash path.
  - Added a rehydration test for valid optional fields (`favicon`, `icon`, `partition`) surviving the round-trip, including the `partition` restart-sensitive path documented in `shared/types/portal.ts:56-62`.
  - Strengthened the `activeTabId` fallback test to assert the filtered tab is removed from `tabs[]`, not just that `activeTabId` was reset.

## Testing

- `npm run check` (typecheck, lint, format, channel/IPC/confirm-wiring guards)
- `npm run test` (vitest, 34/34 passing including the new regression coverage)
- `npm run build` (renderer + main bundle)
- `npm run security:preload-backdoors` (preload backdoor security gate)

The local CI gate has already passed. The Electron-runtime smoke test will run on GitHub CI.

Resolves #9969