### PR TITLE
fix(project-settings): validate per-field types in copyTree and resource environment decoders

### DIFF
--- a/electron/services/__tests__/projectSettingsCodec.test.ts
+++ b/electron/services/__tests__/projectSettingsCodec.test.ts
@@ -525,3 +525,228 @@ describe("decodeFleetSavedScopes (internal)", () => {
     expect((result?.[0] as { usageHistory?: unknown } | undefined)?.usageHistory).toBeUndefined();
   });
 });
+
+describe("decodeCopyTreeSettings (internal)", () => {
+  it("returns undefined for null/undefined/non-object/array", () => {
+    expect(__internal.decodeCopyTreeSettings(null)).toBeUndefined();
+    expect(__internal.decodeCopyTreeSettings(undefined)).toBeUndefined();
+    expect(__internal.decodeCopyTreeSettings("s")).toBeUndefined();
+    expect(__internal.decodeCopyTreeSettings(42)).toBeUndefined();
+    expect(__internal.decodeCopyTreeSettings(true)).toBeUndefined();
+    expect(__internal.decodeCopyTreeSettings([1, 2])).toBeUndefined();
+  });
+
+  it("returns undefined for an empty object", () => {
+    expect(__internal.decodeCopyTreeSettings({})).toBeUndefined();
+  });
+
+  it("parses a valid full object", () => {
+    expect(
+      __internal.decodeCopyTreeSettings({
+        maxContextSize: 1_000_000,
+        maxFileSize: 50_000,
+        charLimit: 8000,
+        strategy: "modified",
+        alwaysInclude: ["README.md"],
+        alwaysExclude: ["dist", "node_modules"],
+      })
+    ).toEqual({
+      maxContextSize: 1_000_000,
+      maxFileSize: 50_000,
+      charLimit: 8000,
+      strategy: "modified",
+      alwaysInclude: ["README.md"],
+      alwaysExclude: ["dist", "node_modules"],
+    });
+  });
+
+  it("parses strategy 'all' and 'modified' only", () => {
+    expect(__internal.decodeCopyTreeSettings({ strategy: "all" })).toEqual({ strategy: "all" });
+    expect(__internal.decodeCopyTreeSettings({ strategy: "modified" })).toEqual({
+      strategy: "modified",
+    });
+  });
+
+  it("drops invalid strategy values", () => {
+    expect(__internal.decodeCopyTreeSettings({ strategy: "changed" })).toBeUndefined();
+    expect(__internal.decodeCopyTreeSettings({ strategy: "" })).toBeUndefined();
+    expect(__internal.decodeCopyTreeSettings({ strategy: null })).toBeUndefined();
+    expect(__internal.decodeCopyTreeSettings({ strategy: 1 })).toBeUndefined();
+  });
+
+  it("drops non-finite numerics (Infinity, -Infinity, NaN)", () => {
+    expect(
+      __internal.decodeCopyTreeSettings({
+        maxContextSize: Number.POSITIVE_INFINITY,
+        maxFileSize: Number.NEGATIVE_INFINITY,
+        charLimit: Number.NaN,
+      })
+    ).toBeUndefined();
+  });
+
+  it("drops numeric strings (no coercion)", () => {
+    expect(
+      __internal.decodeCopyTreeSettings({
+        maxContextSize: "100000",
+        maxFileSize: "50000",
+        charLimit: "8000",
+      })
+    ).toBeUndefined();
+  });
+
+  it("filters bad elements inside alwaysInclude/alwaysExclude", () => {
+    expect(
+      __internal.decodeCopyTreeSettings({
+        alwaysInclude: ["README.md", 1, null, "src/**", false],
+        alwaysExclude: ["dist", {}, ["nested"], "node_modules"],
+      })
+    ).toEqual({
+      alwaysInclude: ["README.md", "src/**"],
+      alwaysExclude: ["dist", "node_modules"],
+    });
+  });
+
+  it("drops empty arrays and arrays with no valid strings", () => {
+    expect(__internal.decodeCopyTreeSettings({ alwaysInclude: [] })).toBeUndefined();
+    expect(__internal.decodeCopyTreeSettings({ alwaysExclude: [1, null, false] })).toBeUndefined();
+  });
+
+  it("regression #10001: string alwaysExclude is dropped", () => {
+    // Pre-fix: "dist".length > 0, spread turns into single chars.
+    expect(__internal.decodeCopyTreeSettings({ alwaysExclude: "dist" })).toBeUndefined();
+  });
+
+  it("regression #10001: { length: 1 } alwaysExclude is dropped", () => {
+    // Pre-fix: passes the .length > 0 guard, then throws on spread.
+    expect(__internal.decodeCopyTreeSettings({ alwaysExclude: { length: 1 } })).toBeUndefined();
+  });
+
+  it("regression #10001: string maxContextSize is dropped", () => {
+    expect(__internal.decodeCopyTreeSettings({ maxContextSize: "100000" })).toBeUndefined();
+  });
+
+  it("regression #10001: string alwaysInclude is dropped", () => {
+    expect(__internal.decodeCopyTreeSettings({ alwaysInclude: "README.md" })).toBeUndefined();
+  });
+
+  it("keeps valid siblings when one field is invalid", () => {
+    expect(
+      __internal.decodeCopyTreeSettings({
+        maxContextSize: 1_000_000,
+        alwaysInclude: "README.md",
+        alwaysExclude: ["dist"],
+      })
+    ).toEqual({ maxContextSize: 1_000_000, alwaysExclude: ["dist"] });
+  });
+
+  test.prop([fc.anything()])("never throws on arbitrary input", (raw) => {
+    expect(() => __internal.decodeCopyTreeSettings(raw)).not.toThrow();
+  });
+});
+
+describe("decodeResourceEnvironments (internal)", () => {
+  it("returns undefined for null/undefined/non-object/array", () => {
+    expect(__internal.decodeResourceEnvironments(null)).toBeUndefined();
+    expect(__internal.decodeResourceEnvironments(undefined)).toBeUndefined();
+    expect(__internal.decodeResourceEnvironments("s")).toBeUndefined();
+    expect(__internal.decodeResourceEnvironments(42)).toBeUndefined();
+    expect(__internal.decodeResourceEnvironments([{ provision: ["a"] }])).toBeUndefined();
+  });
+
+  it("returns undefined for an empty object", () => {
+    expect(__internal.decodeResourceEnvironments({})).toBeUndefined();
+  });
+
+  it("parses a full valid environment", () => {
+    expect(
+      __internal.decodeResourceEnvironments({
+        staging: {
+          provision: ["npm ci"],
+          teardown: ["rm -rf build"],
+          resume: ["docker start x"],
+          pause: ["docker stop x"],
+          status: "echo ok",
+          connect: "ssh staging",
+          icon: "database",
+        },
+      })
+    ).toEqual({
+      staging: {
+        provision: ["npm ci"],
+        teardown: ["rm -rf build"],
+        resume: ["docker start x"],
+        pause: ["docker stop x"],
+        status: "echo ok",
+        connect: "ssh staging",
+        icon: "database",
+      },
+    });
+  });
+
+  it("filters bad elements inside command arrays", () => {
+    expect(
+      __internal.decodeResourceEnvironments({
+        s: { provision: ["a", 1, null, "b", { cmd: "x" }] },
+      })
+    ).toEqual({ s: { provision: ["a", "b"] } });
+  });
+
+  it("drops command fields that are not arrays", () => {
+    expect(
+      __internal.decodeResourceEnvironments({
+        s: {
+          provision: "npm install",
+          teardown: { length: 1 },
+          resume: null,
+          pause: 42,
+        },
+      })
+    ).toBeUndefined();
+  });
+
+  it("drops empty command arrays and arrays with no valid strings", () => {
+    expect(__internal.decodeResourceEnvironments({ s: { provision: [] } })).toBeUndefined();
+    expect(
+      __internal.decodeResourceEnvironments({ s: { provision: [1, null, false] } })
+    ).toBeUndefined();
+  });
+
+  it("preserves valid scalar string fields", () => {
+    expect(
+      __internal.decodeResourceEnvironments({
+        s: { status: "echo ok", connect: "ssh x", icon: "database" },
+      })
+    ).toEqual({ s: { status: "echo ok", connect: "ssh x", icon: "database" } });
+  });
+
+  it("drops invalid scalar fields (arrays, numbers, null)", () => {
+    expect(
+      __internal.decodeResourceEnvironments({
+        s: { status: ["echo ok"], connect: 123, icon: null },
+      })
+    ).toBeUndefined();
+  });
+
+  it("keeps valid sibling environments when one entry is invalid", () => {
+    expect(
+      __internal.decodeResourceEnvironments({
+        good: { provision: ["echo"] },
+        bad: { provision: "not-an-array" },
+      })
+    ).toEqual({ good: { provision: ["echo"] } });
+  });
+
+  it("returns undefined when every environment entry is invalid", () => {
+    expect(
+      __internal.decodeResourceEnvironments({
+        a: "not-an-object",
+        b: ["also", "wrong"],
+        c: null,
+      })
+    ).toBeUndefined();
+  });
+
+  test.prop([fc.anything()])("never throws on arbitrary input", (raw) => {
+    expect(() => __internal.decodeResourceEnvironments(raw)).not.toThrow();
+  });
+});

--- a/electron/services/__tests__/projectSettingsCodec.test.ts
+++ b/electron/services/__tests__/projectSettingsCodec.test.ts
@@ -127,6 +127,93 @@ describe("decode", () => {
     expect(result.settings.runCommands).toHaveLength(1);
     expect(result.settings.runCommands[0]?.id).toBe("ok");
   });
+
+  it("regression #10001: string alwaysExclude is dropped through public decode()", () => {
+    const result = decode({ runCommands: [], copyTreeSettings: { alwaysExclude: "dist" } });
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.settings.copyTreeSettings).toBeUndefined();
+  });
+
+  it("regression #10001: { length: 1 } alwaysExclude is dropped through public decode()", () => {
+    const result = decode({
+      runCommands: [],
+      copyTreeSettings: { alwaysExclude: { length: 1 } },
+    });
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.settings.copyTreeSettings).toBeUndefined();
+  });
+
+  it("regression #10001: string maxContextSize is dropped through public decode()", () => {
+    const result = decode({
+      runCommands: [],
+      copyTreeSettings: { maxContextSize: "100000" },
+    });
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.settings.copyTreeSettings).toBeUndefined();
+  });
+
+  it("regression #10001: string alwaysInclude is dropped through public decode()", () => {
+    const result = decode({
+      runCommands: [],
+      copyTreeSettings: { alwaysInclude: "README.md" },
+    });
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.settings.copyTreeSettings).toBeUndefined();
+  });
+
+  it("regression #10001: well-formed copyTreeSettings round-trips through public decode()", () => {
+    const result = decode({
+      runCommands: [],
+      copyTreeSettings: {
+        maxContextSize: 1_000_000,
+        strategy: "modified",
+        alwaysInclude: ["README.md"],
+        alwaysExclude: ["dist", "node_modules"],
+      },
+    });
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.settings.copyTreeSettings).toEqual({
+      maxContextSize: 1_000_000,
+      strategy: "modified",
+      alwaysInclude: ["README.md"],
+      alwaysExclude: ["dist", "node_modules"],
+    });
+  });
+
+  it("drops resourceEnvironments whose every command array is non-string", () => {
+    const result = decode({
+      runCommands: [],
+      resourceEnvironments: { s: { provision: [1, null, false] } },
+    });
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.settings.resourceEnvironments).toBeUndefined();
+  });
+
+  it("preserves valid resourceEnvironments siblings when one entry is invalid", () => {
+    const result = decode({
+      runCommands: [],
+      resourceEnvironments: {
+        good: { provision: ["echo"] },
+        bad: { provision: "not-an-array" },
+      },
+    });
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.settings.resourceEnvironments).toEqual({ good: { provision: ["echo"] } });
+  });
+
+  it("guards against __proto__ pollution in resourceEnvironments keys", () => {
+    // JSON.parse on a string with "__proto__" sets the prototype rather than
+    // an own property, so this construction is the realistic hostile-input
+    // shape. The decoder must not let a __proto__ entry slip through and
+    // pollute the result's prototype chain.
+    const hostile = JSON.parse('{"__proto__":{"provision":["x"]},"good":{"provision":["ok"]}}');
+    const result = decode({ runCommands: [], resourceEnvironments: hostile });
+    if (!result.ok) throw new Error("expected ok");
+    const envs = result.settings.resourceEnvironments as Record<string, unknown>;
+    expect(envs).toBeDefined();
+    expect("provision" in envs).toBe(false);
+    expect(envs.good).toEqual({ provision: ["ok"] });
+  });
 });
 
 describe("encodeEnvelope", () => {

--- a/electron/services/projectSettingsCodec.ts
+++ b/electron/services/projectSettingsCodec.ts
@@ -221,9 +221,43 @@ function decodeCommandOverrides(raw: unknown): CommandOverride[] | undefined {
   return valid.length > 0 ? valid : undefined;
 }
 
+function decodeResourceEnvironment(raw: unknown): ResourceEnvironment | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const obj = raw as Record<string, unknown>;
+  const result: ResourceEnvironment = {};
+
+  if (Array.isArray(obj.provision)) {
+    const filtered = obj.provision.filter((s): s is string => typeof s === "string");
+    if (filtered.length > 0) result.provision = filtered;
+  }
+  if (Array.isArray(obj.teardown)) {
+    const filtered = obj.teardown.filter((s): s is string => typeof s === "string");
+    if (filtered.length > 0) result.teardown = filtered;
+  }
+  if (Array.isArray(obj.resume)) {
+    const filtered = obj.resume.filter((s): s is string => typeof s === "string");
+    if (filtered.length > 0) result.resume = filtered;
+  }
+  if (Array.isArray(obj.pause)) {
+    const filtered = obj.pause.filter((s): s is string => typeof s === "string");
+    if (filtered.length > 0) result.pause = filtered;
+  }
+  if (typeof obj.status === "string") result.status = obj.status;
+  if (typeof obj.connect === "string") result.connect = obj.connect;
+  if (typeof obj.icon === "string") result.icon = obj.icon;
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
 function decodeResourceEnvironments(raw: unknown): Record<string, ResourceEnvironment> | undefined {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
-  return raw as Record<string, ResourceEnvironment>;
+  const src = raw as Record<string, unknown>;
+  const result: Record<string, ResourceEnvironment> = {};
+  for (const [name, value] of Object.entries(src)) {
+    const env = decodeResourceEnvironment(value);
+    if (env) result[name] = env;
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
 }
 
 function decodeMcpTier(raw: unknown): DaintreeMcpTier | undefined {
@@ -254,7 +288,31 @@ function decodePreferredEditor(raw: unknown): EditorConfig | undefined {
 
 function decodeCopyTreeSettings(raw: unknown): CopyTreeSettings | undefined {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
-  return raw as CopyTreeSettings;
+  const obj = raw as Record<string, unknown>;
+  const result: CopyTreeSettings = {};
+
+  if (typeof obj.maxContextSize === "number" && Number.isFinite(obj.maxContextSize)) {
+    result.maxContextSize = obj.maxContextSize;
+  }
+  if (typeof obj.maxFileSize === "number" && Number.isFinite(obj.maxFileSize)) {
+    result.maxFileSize = obj.maxFileSize;
+  }
+  if (typeof obj.charLimit === "number" && Number.isFinite(obj.charLimit)) {
+    result.charLimit = obj.charLimit;
+  }
+  if (obj.strategy === "all" || obj.strategy === "modified") {
+    result.strategy = obj.strategy;
+  }
+  if (Array.isArray(obj.alwaysInclude)) {
+    const filtered = obj.alwaysInclude.filter((s): s is string => typeof s === "string");
+    if (filtered.length > 0) result.alwaysInclude = filtered;
+  }
+  if (Array.isArray(obj.alwaysExclude)) {
+    const filtered = obj.alwaysExclude.filter((s): s is string => typeof s === "string");
+    if (filtered.length > 0) result.alwaysExclude = filtered;
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
 }
 
 function decodeDevServerLoadTimeout(raw: unknown): number | undefined {
@@ -511,5 +569,7 @@ export const __internal = {
   decodeTerminalSettings,
   decodeNotificationOverrides,
   decodeFleetSavedScopes,
+  decodeCopyTreeSettings,
+  decodeResourceEnvironments,
   migrateLegacyFields,
 };

--- a/electron/services/projectSettingsCodec.ts
+++ b/electron/services/projectSettingsCodec.ts
@@ -254,6 +254,12 @@ function decodeResourceEnvironments(raw: unknown): Record<string, ResourceEnviro
   const src = raw as Record<string, unknown>;
   const result: Record<string, ResourceEnvironment> = {};
   for (const [name, value] of Object.entries(src)) {
+    // Defend against `__proto__` keys reaching the assignment — `result[name]`
+    // would otherwise invoke the `__proto__` setter and pollute the result's
+    // prototype chain. JSON.parse normally hides these (sets the prototype
+    // instead of an own property) but a hand-crafted or post-processed
+    // settings object can surface them.
+    if (name === "__proto__") continue;
     const env = decodeResourceEnvironment(value);
     if (env) result[name] = env;
   }


### PR DESCRIPTION
## Summary
- Hardens `decodeCopyTreeSettings` in `electron/services/projectSettingsCodec.ts` so malformed values in `copyTreeSettings` are dropped at the boundary instead of flowing into the copytree SDK and corrupting context generation.
- Brings `decodeResourceEnvironments` up to the same standard in the same pass, since it had the same blind-cast pattern that the issue flagged.
- Resolves #10001.

## Changes
- `decodeCopyTreeSettings` now validates each field: `strategy` is constrained to `"all"` or `"modified"`, `maxContextSize` must be a finite number, `alwaysInclude` and `alwaysExclude` are filtered down to string arrays. Invalid fields are dropped rather than passed through.
- `decodeResourceEnvironments` gets the same per-field treatment, matching the five sibling decoders in the file.
- Decoder is total: never throws on malformed input.
- New unit tests in `electron/services/__tests__/projectSettingsCodec.test.ts` cover the three failure modes from the issue (string `alwaysExclude`, `{ length: 1 }` `alwaysExclude`, string `maxContextSize` / `alwaysInclude`) plus the resource environment equivalents.

## Testing
- `electron/services/__tests__/projectSettingsCodec.test.ts` - 86/86 passing, covering all three issue failure modes plus hardened paths for both decoders.
- `npm run check` static gate clean (typecheck, lint, format, channel/IPC/confirm-wiring guards).