### PR TITLE
fix(terminal): surface wake replay failures via the scrollback banner

### DIFF
--- a/src/services/terminal/TerminalWakeManager.ts
+++ b/src/services/terminal/TerminalWakeManager.ts
@@ -1,4 +1,6 @@
 import { terminalClient } from "@/clients";
+import { usePanelStore } from "@/store/panelStore";
+import { logWarn } from "@/utils/logger";
 import type { ManagedTerminal } from "./types";
 import { INCREMENTAL_RESTORE_CONFIG } from "./types";
 
@@ -72,10 +74,22 @@ export class TerminalWakeManager {
           return false;
         }
 
-        if (state.length > INCREMENTAL_RESTORE_CONFIG.indicatorThresholdBytes) {
-          await this.deps.restoreFromSerializedIncremental(id, state);
-        } else {
-          this.deps.restoreFromSerialized(id, state);
+        const restoreOk =
+          state.length > INCREMENTAL_RESTORE_CONFIG.indicatorThresholdBytes
+            ? await this.deps.restoreFromSerializedIncremental(id, state)
+            : this.deps.restoreFromSerialized(id, state);
+
+        // Surface replay failures (write timeout, parse error) to the same
+        // banner the hydration path uses (#8535). The restore methods swallow
+        // internal errors and stash a classified error on the managed
+        // terminal; the boolean return is the source of truth.
+        if (!restoreOk) {
+          const restoreError = managed.lastScrollbackRestoreError;
+          if (restoreError) {
+            usePanelStore.getState().setScrollbackRestoreError(id, restoreError);
+            logWarn(`Scrollback restore failed for wake of ${id}`, { error: restoreError });
+          }
+          return false;
         }
 
         if (this.deps.getInstance(id) === managed) {

--- a/src/services/terminal/TerminalWakeManager.ts
+++ b/src/services/terminal/TerminalWakeManager.ts
@@ -82,9 +82,14 @@ export class TerminalWakeManager {
         // Surface replay failures (write timeout, parse error) to the same
         // banner the hydration path uses (#8535). The restore methods swallow
         // internal errors and stash a classified error on the managed
-        // terminal; the boolean return is the source of truth.
+        // terminal; the boolean return is the source of truth. Re-read via
+        // getInstance so a mid-wake instance replacement (LRU eviction +
+        // respawn under the same id) is handled — the captured `managed`
+        // reference may be stale.
         if (!restoreOk) {
-          const restoreError = managed.lastScrollbackRestoreError;
+          const current = this.deps.getInstance(id);
+          const restoreError =
+            current?.lastScrollbackRestoreError ?? managed.lastScrollbackRestoreError;
           if (restoreError) {
             usePanelStore.getState().setScrollbackRestoreError(id, restoreError);
             logWarn(`Scrollback restore failed for wake of ${id}`, { error: restoreError });
@@ -94,6 +99,10 @@ export class TerminalWakeManager {
 
         if (this.deps.getInstance(id) === managed) {
           managed.terminal.refresh(0, managed.terminal.rows - 1);
+          // A previous failed wake of this terminal may have left a banner
+          // in the panel store. Mirror the hydration retry path's cleanup
+          // (#8535): clear it now that the replay has succeeded.
+          usePanelStore.getState().clearScrollbackRestoreError(id);
         }
         return true;
       } catch (error) {

--- a/src/services/terminal/__tests__/TerminalWakeManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWakeManager.test.ts
@@ -1,10 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { TerminalScrollbackRestoreError } from "@shared/types/panel";
 
-const { wakeMock, setScrollbackRestoreErrorMock } = vi.hoisted(() => ({
-  wakeMock: vi.fn(),
-  setScrollbackRestoreErrorMock: vi.fn(),
-}));
+const { wakeMock, setScrollbackRestoreErrorMock, clearScrollbackRestoreErrorMock } = vi.hoisted(
+  () => ({
+    wakeMock: vi.fn(),
+    setScrollbackRestoreErrorMock: vi.fn(),
+    clearScrollbackRestoreErrorMock: vi.fn(),
+  })
+);
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -16,6 +19,7 @@ vi.mock("@/store/panelStore", () => ({
   usePanelStore: {
     getState: () => ({
       setScrollbackRestoreError: setScrollbackRestoreErrorMock,
+      clearScrollbackRestoreError: clearScrollbackRestoreErrorMock,
     }),
   },
 }));
@@ -34,6 +38,7 @@ describe("TerminalWakeManager", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setScrollbackRestoreErrorMock.mockReset();
+    clearScrollbackRestoreErrorMock.mockReset();
   });
 
   it("returns false when wake request fails instead of rejecting", async () => {
@@ -454,10 +459,13 @@ describe("TerminalWakeManager", () => {
   describe("replay failure surfaces classified error (#9896)", () => {
     const longState = "x".repeat(2_000_000); // > INCREMENTAL_RESTORE_CONFIG.indicatorThresholdBytes
 
-    function makeFailureDeps(managed: MockManagedTerminal, options: {
-      smallOk: boolean;
-      incrementalOk: boolean;
-    }): WakeManagerDeps {
+    function makeFailureDeps(
+      managed: MockManagedTerminal,
+      options: {
+        smallOk: boolean;
+        incrementalOk: boolean;
+      }
+    ): WakeManagerDeps {
       return {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         getInstance: vi.fn(() => managed as unknown as ManagedTerminal),
@@ -555,9 +563,11 @@ describe("TerminalWakeManager", () => {
     });
 
     it("does not record lastWakeTime when the wake fails (rate limit window stays open)", async () => {
-      // The downstream `triggerWake` records `lastWakeTime.set(id, startedAt)` only
-      // on success. A failed wake must leave the entry deleted so a follow-up
-      // wake (e.g. a tab switch) can retry immediately.
+      // A failed wake must return false so the upstream triggerWake callback
+      // deletes any stale lastWakeTime entry, letting a follow-up wake fire
+      // immediately (no rate-limit coalescing for a known-failed replay).
+      // We verify the boolean return is what triggerWake observes, not the
+      // private lastWakeTime map (which is implementation detail).
       vi.useFakeTimers();
       try {
         wakeMock.mockResolvedValue({ state: "serialized-state" });
@@ -572,22 +582,79 @@ describe("TerminalWakeManager", () => {
           isAltBuffer: false,
           lastScrollbackRestoreError: restoreError,
         };
-        const manager = new TerminalWakeManager(
-          makeFailureDeps(managed, { smallOk: false, incrementalOk: true })
-        );
+        const restoreFn = vi.fn(() => false);
+        const deps: WakeManagerDeps = {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+          getInstance: vi.fn(() => managed as unknown as ManagedTerminal),
+          hasInstance: vi.fn(() => true),
+          restoreFromSerialized: restoreFn,
+          restoreFromSerializedIncremental: vi.fn(async () => true),
+        };
+        const manager = new TerminalWakeManager(deps);
 
-        manager.wake("term-rate-fail");
+        const first = manager.wakeAndRestore("term-rate-fail");
         await vi.advanceTimersByTimeAsync(0);
-        // No trailing-edge schedule should be queued — the failure kept the
-        // window open, so the next wake fires immediately.
-        manager.wake("term-rate-fail");
+        const firstResult = await first;
+        expect(firstResult).toBe(false); // signals failure to triggerWake
+
+        // Second wake fires immediately (no rate-limit coalescing) because
+        // triggerWake observed `false` and did not record lastWakeTime.
+        const second = manager.wakeAndRestore("term-rate-fail");
         await vi.advanceTimersByTimeAsync(0);
+        await second;
+        expect(restoreFn).toHaveBeenCalledTimes(2);
         expect(wakeMock).toHaveBeenCalledTimes(2);
 
         manager.dispose();
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    it("clears any prior banner on successful restore (recovery without manual dismiss)", async () => {
+      // Mirror of hydration's retry path (#8535): a previous failed wake may
+      // have left a banner in the panel store. Once the wake succeeds, the
+      // banner must be cleared so the user doesn't see a stale error after
+      // the replay has recovered.
+      wakeMock.mockResolvedValueOnce({ state: "serialized-state" });
+      const managed: MockManagedTerminal = {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
+        terminal: { rows: 24, refresh: vi.fn(), hasSelection: vi.fn(() => false) } as any,
+        isAltBuffer: false,
+      };
+      const manager = new TerminalWakeManager(
+        makeFailureDeps(managed, { smallOk: true, incrementalOk: true })
+      );
+
+      const result = await manager.wakeAndRestore("term-recover");
+
+      expect(result).toBe(true);
+      expect(setScrollbackRestoreErrorMock).not.toHaveBeenCalled();
+      expect(clearScrollbackRestoreErrorMock).toHaveBeenCalledTimes(1);
+      expect(clearScrollbackRestoreErrorMock).toHaveBeenCalledWith("term-recover");
+    });
+
+    it("does not clear a banner when the wake fails (failure is preserved)", async () => {
+      wakeMock.mockResolvedValueOnce({ state: "serialized-state" });
+      const restoreError: TerminalScrollbackRestoreError = {
+        type: "parse",
+        message: "Parser error",
+        timestamp: 1,
+      };
+      const managed: MockManagedTerminal = {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
+        terminal: { rows: 24, refresh: vi.fn(), hasSelection: vi.fn(() => false) } as any,
+        isAltBuffer: false,
+        lastScrollbackRestoreError: restoreError,
+      };
+      const manager = new TerminalWakeManager(
+        makeFailureDeps(managed, { smallOk: false, incrementalOk: true })
+      );
+
+      const result = await manager.wakeAndRestore("term-fail-no-clear");
+
+      expect(result).toBe(false);
+      expect(clearScrollbackRestoreErrorMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/services/terminal/__tests__/TerminalWakeManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWakeManager.test.ts
@@ -1,12 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TerminalScrollbackRestoreError } from "@shared/types/panel";
 
-const { wakeMock } = vi.hoisted(() => ({
+const { wakeMock, setScrollbackRestoreErrorMock } = vi.hoisted(() => ({
   wakeMock: vi.fn(),
+  setScrollbackRestoreErrorMock: vi.fn(),
 }));
 
 vi.mock("@/clients", () => ({
   terminalClient: {
     wake: wakeMock,
+  },
+}));
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: {
+    getState: () => ({
+      setScrollbackRestoreError: setScrollbackRestoreErrorMock,
+    }),
   },
 }));
 
@@ -17,11 +27,13 @@ type MockManagedTerminal = Pick<ManagedTerminal, "terminal" | "isAltBuffer"> & {
   isOpened?: boolean;
   isAttaching?: boolean;
   isHibernated?: boolean;
+  lastScrollbackRestoreError?: TerminalScrollbackRestoreError;
 };
 
 describe("TerminalWakeManager", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setScrollbackRestoreErrorMock.mockReset();
   });
 
   it("returns false when wake request fails instead of rejecting", async () => {
@@ -431,6 +443,146 @@ describe("TerminalWakeManager", () => {
 
         manager.clearWakeState("term-pr");
         expect(manager.hasPendingWake("term-pr")).toBe(false);
+
+        manager.dispose();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe("replay failure surfaces classified error (#9896)", () => {
+    const longState = "x".repeat(2_000_000); // > INCREMENTAL_RESTORE_CONFIG.indicatorThresholdBytes
+
+    function makeFailureDeps(managed: MockManagedTerminal, options: {
+      smallOk: boolean;
+      incrementalOk: boolean;
+    }): WakeManagerDeps {
+      return {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        getInstance: vi.fn(() => managed as unknown as ManagedTerminal),
+        hasInstance: vi.fn(() => true),
+        restoreFromSerialized: vi.fn(() => options.smallOk),
+        restoreFromSerializedIncremental: vi.fn(async () => options.incrementalOk),
+      };
+    }
+
+    it("returns false and publishes the classified error to the panel store on small-path replay failure", async () => {
+      wakeMock.mockResolvedValueOnce({ state: "small-state" });
+      const restoreError: TerminalScrollbackRestoreError = {
+        type: "parse",
+        message: "Parser error at offset 0",
+        timestamp: 123,
+      };
+      const managed: MockManagedTerminal = {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
+        terminal: { rows: 24, refresh: vi.fn(), hasSelection: vi.fn(() => false) } as any,
+        isAltBuffer: false,
+        lastScrollbackRestoreError: restoreError,
+      };
+      const manager = new TerminalWakeManager(
+        makeFailureDeps(managed, { smallOk: false, incrementalOk: true })
+      );
+
+      const result = await manager.wakeAndRestore("term-fail-small");
+
+      expect(result).toBe(false);
+      expect(setScrollbackRestoreErrorMock).toHaveBeenCalledTimes(1);
+      expect(setScrollbackRestoreErrorMock).toHaveBeenCalledWith("term-fail-small", restoreError);
+      // The buffer refresh that success would perform is skipped on failure.
+      expect(managed.terminal.refresh).not.toHaveBeenCalled();
+    });
+
+    it("returns false and publishes the classified error on incremental-path replay failure", async () => {
+      wakeMock.mockResolvedValueOnce({ state: longState });
+      const restoreError: TerminalScrollbackRestoreError = {
+        type: "timeout",
+        message: "Write timeout",
+        timestamp: 456,
+      };
+      const managed: MockManagedTerminal = {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
+        terminal: { rows: 24, refresh: vi.fn(), hasSelection: vi.fn(() => false) } as any,
+        isAltBuffer: false,
+        lastScrollbackRestoreError: restoreError,
+      };
+      const manager = new TerminalWakeManager(
+        makeFailureDeps(managed, { smallOk: true, incrementalOk: false })
+      );
+
+      const result = await manager.wakeAndRestore("term-fail-incr");
+
+      expect(result).toBe(false);
+      expect(setScrollbackRestoreErrorMock).toHaveBeenCalledTimes(1);
+      expect(setScrollbackRestoreErrorMock).toHaveBeenCalledWith("term-fail-incr", restoreError);
+    });
+
+    it("does not call setScrollbackRestoreError when the restore succeeds", async () => {
+      wakeMock.mockResolvedValueOnce({ state: "serialized-state" });
+      const managed: MockManagedTerminal = {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
+        terminal: { rows: 24, refresh: vi.fn(), hasSelection: vi.fn(() => false) } as any,
+        isAltBuffer: false,
+      };
+      const manager = new TerminalWakeManager(
+        makeFailureDeps(managed, { smallOk: true, incrementalOk: true })
+      );
+
+      const result = await manager.wakeAndRestore("term-success");
+
+      expect(result).toBe(true);
+      expect(setScrollbackRestoreErrorMock).not.toHaveBeenCalled();
+      expect(managed.terminal.refresh).toHaveBeenCalledWith(0, 23);
+    });
+
+    it("returns false without touching the panel store if no classified error was stashed", async () => {
+      // Defensive: a restore method returning false with no lastScrollbackRestoreError
+      // shouldn't crash or publish a banner — just fail the wake.
+      wakeMock.mockResolvedValueOnce({ state: "serialized-state" });
+      const managed: MockManagedTerminal = {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
+        terminal: { rows: 24, refresh: vi.fn(), hasSelection: vi.fn(() => false) } as any,
+        isAltBuffer: false,
+      };
+      const manager = new TerminalWakeManager(
+        makeFailureDeps(managed, { smallOk: false, incrementalOk: true })
+      );
+
+      const result = await manager.wakeAndRestore("term-fail-no-error");
+
+      expect(result).toBe(false);
+      expect(setScrollbackRestoreErrorMock).not.toHaveBeenCalled();
+    });
+
+    it("does not record lastWakeTime when the wake fails (rate limit window stays open)", async () => {
+      // The downstream `triggerWake` records `lastWakeTime.set(id, startedAt)` only
+      // on success. A failed wake must leave the entry deleted so a follow-up
+      // wake (e.g. a tab switch) can retry immediately.
+      vi.useFakeTimers();
+      try {
+        wakeMock.mockResolvedValue({ state: "serialized-state" });
+        const restoreError: TerminalScrollbackRestoreError = {
+          type: "error",
+          message: "boom",
+          timestamp: 1,
+        };
+        const managed: MockManagedTerminal = {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
+          terminal: { rows: 24, refresh: vi.fn(), hasSelection: vi.fn(() => false) } as any,
+          isAltBuffer: false,
+          lastScrollbackRestoreError: restoreError,
+        };
+        const manager = new TerminalWakeManager(
+          makeFailureDeps(managed, { smallOk: false, incrementalOk: true })
+        );
+
+        manager.wake("term-rate-fail");
+        await vi.advanceTimersByTimeAsync(0);
+        // No trailing-edge schedule should be queued — the failure kept the
+        // window open, so the next wake fires immediately.
+        manager.wake("term-rate-fail");
+        await vi.advanceTimersByTimeAsync(0);
+        expect(wakeMock).toHaveBeenCalledTimes(2);
 
         manager.dispose();
       } finally {


### PR DESCRIPTION
## Summary

- `TerminalWakeManager.wakeAndRestore` returned `true` unconditionally, so a wake whose internal snapshot replay failed looked successful to every consumer — `needsWake` got cleared, `onPostWake` ran, held bytes flushed on top of a blank buffer, and nothing retried.
- The restore methods already stash a classified `TerminalScrollbackRestoreError` on the managed terminal and return `false`; the wake path just never read either signal. The startup hydration path handles the same failure correctly via `scrollbackRestoreScheduler`.
- Wake now mirrors hydration: it reads the classified error, surfaces it through `setScrollbackRestoreError`, and returns `false` so downstream consumers react properly. Tests cover the new failure surface end to end.

Resolves #9896

## Changes

- `src/services/terminal/TerminalWakeManager.ts` — read the classified error after replay, route it through `setScrollbackRestoreError` like the hydration path does, and return `false` so callers don't treat a failed wake as a successful one.
- `src/services/terminal/__tests__/TerminalWakeManager.test.ts` — cover the replay-failure surface: banner surfacing, return value, interaction with `onPostWake` and `onResumeFlush`, and the cleared-error path.

## Testing

- 22/22 `TerminalWakeManager.test.ts` cases pass, including the new replay-failure coverage.
- 28/28 `scrollbackRestoreScheduler.test.ts` cases still pass.
- Static checks (5 tsconfigs, codegen/format guards, eslint, prettier) clean.