### PR TITLE
chore(wsl): centralise WSL UNC validation

### DIFF
--- a/electron/utils/__tests__/hardenedGit.test.ts
+++ b/electron/utils/__tests__/hardenedGit.test.ts
@@ -734,6 +734,26 @@ describe("createWslHardenedGit", () => {
     ).toThrow("UNC path");
   });
 
+  it("rejects when supplied distro does not match parsed UNC distro", () => {
+    expect(() =>
+      createWslHardenedGit({
+        distro: "Ubuntu",
+        uncPath: "\\\\wsl$\\Debian\\home\\user\\proj",
+        posixPath: "/home/user/proj",
+      })
+    ).toThrow("distro does not match");
+  });
+
+  it("rejects when supplied posixPath does not match parsed UNC remainder", () => {
+    expect(() =>
+      createWslHardenedGit({
+        distro: "Ubuntu",
+        uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
+        posixPath: "/some/other/path",
+      })
+    ).toThrow("posix path does not match");
+  });
+
   it("uses the UNC path as baseDir so simple-git's statSync succeeds on Windows", () => {
     createWslHardenedGit({
       distro: "Ubuntu",

--- a/electron/utils/__tests__/hardenedGit.test.ts
+++ b/electron/utils/__tests__/hardenedGit.test.ts
@@ -702,6 +702,38 @@ describe("createWslHardenedGit", () => {
     ).toThrow("UNC path");
   });
 
+  it("rejects strings starting with \\\\wsl but missing the WSL UNC shape", () => {
+    // Old `startsWith("\\\\wsl")` gate let this through; tightened check
+    // (detectWslPath) fails closed on the malformed shape.
+    expect(() =>
+      createWslHardenedGit({
+        distro: "Ubuntu",
+        uncPath: "\\\\wslfoo\\bar",
+        posixPath: "/home/user/proj",
+      })
+    ).toThrow("UNC path");
+  });
+
+  it("rejects bare \\\\wsl$\\ with no distro segment", () => {
+    expect(() =>
+      createWslHardenedGit({
+        distro: "Ubuntu",
+        uncPath: "\\\\wsl$\\",
+        posixPath: "/",
+      })
+    ).toThrow("UNC path");
+  });
+
+  it("rejects bare \\\\wsl.localhost\\ with no distro segment", () => {
+    expect(() =>
+      createWslHardenedGit({
+        distro: "Ubuntu",
+        uncPath: "\\\\wsl.localhost\\",
+        posixPath: "/",
+      })
+    ).toThrow("UNC path");
+  });
+
   it("uses the UNC path as baseDir so simple-git's statSync succeeds on Windows", () => {
     createWslHardenedGit({
       distro: "Ubuntu",

--- a/electron/utils/hardenedGit.ts
+++ b/electron/utils/hardenedGit.ts
@@ -210,8 +210,17 @@ export function createWslHardenedGit(
   if (typeof posixPath !== "string" || !posixPath.startsWith("/")) {
     throw new Error("WSL posix path must start with /");
   }
-  if (typeof uncPath !== "string" || detectWslPath(uncPath) === null) {
+  const parsed = detectWslPath(uncPath);
+  if (typeof uncPath !== "string" || parsed === null) {
     throw new Error("WSL UNC path is not a valid WSL UNC");
+  }
+  // Defense in depth: verify the supplied distro/posixPath match the parsed
+  // UNC, so a caller can't bypass the route with mismatched metadata.
+  if (parsed.distro.toLowerCase() !== distro.trim().toLowerCase()) {
+    throw new Error("WSL distro does not match parsed UNC");
+  }
+  if (parsed.posixPath !== posixPath) {
+    throw new Error("WSL posix path does not match parsed UNC");
   }
 
   return simpleGit({

--- a/electron/utils/hardenedGit.ts
+++ b/electron/utils/hardenedGit.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import { simpleGit } from "simple-git";
 import type { SimpleGit, SimpleGitProgressEvent } from "simple-git";
+import { detectWslPath } from "./wsl.js";
 
 const SAFE_GIT_CONFIG = [
   "core.fsmonitor=false",
@@ -209,8 +210,8 @@ export function createWslHardenedGit(
   if (typeof posixPath !== "string" || !posixPath.startsWith("/")) {
     throw new Error("WSL posix path must start with /");
   }
-  if (typeof uncPath !== "string" || !uncPath.startsWith("\\\\wsl")) {
-    throw new Error("WSL UNC path must start with \\\\wsl");
+  if (typeof uncPath !== "string" || detectWslPath(uncPath) === null) {
+    throw new Error("WSL UNC path is not a valid WSL UNC");
   }
 
   return simpleGit({

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -737,6 +737,7 @@ export class WorkspaceService {
       ...wt,
       isWslPath: true,
       wslDistro: detected.distro,
+      wslPosixPath: detected.posixPath,
       wslGitEligible: eligible,
       wslGitOptIn: Boolean(persisted?.enabled),
       wslGitDismissed: Boolean(persisted?.dismissed),

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -406,14 +406,10 @@ export class WorktreeMonitor {
 
     this._isWslPath = Boolean(worktree.isWslPath);
     this._wslDistro = worktree.wslDistro;
+    this._wslPosixPath = worktree.wslPosixPath;
     this._wslGitEligible = Boolean(worktree.wslGitEligible);
     this._wslGitOptIn = Boolean(worktree.wslGitOptIn);
     this._wslGitDismissed = Boolean(worktree.wslGitDismissed);
-    if (this._isWslPath && this._wslDistro) {
-      const m = /^\\\\wsl(?:\$|\.localhost)\\[^\\]+(.*)/i.exec(worktree.path);
-      const remainder = m ? (m[1] ?? "") : "";
-      this._wslPosixPath = remainder.replace(/\\/g, "/") || "/";
-    }
   }
 
   /**
@@ -1141,6 +1137,7 @@ export class WorktreeMonitor {
       isGitHubRemote: this._isGitHubRemote || undefined,
       isWslPath: this._isWslPath || undefined,
       wslDistro: this._wslDistro,
+      wslPosixPath: this._wslPosixPath,
       wslGitEligible: this._wslGitEligible || undefined,
       wslGitOptIn: this._wslGitOptIn || undefined,
       wslGitDismissed: this._wslGitDismissed || undefined,

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -1987,6 +1987,7 @@ describe("WorktreeMonitor", () => {
         path: "\\\\wsl$\\Ubuntu\\home\\user\\repo",
         isWslPath: true,
         wslDistro: "Ubuntu",
+        wslPosixPath: "/home/user/repo",
         wslGitEligible: true,
         wslGitOptIn: false,
       };
@@ -2012,6 +2013,7 @@ describe("WorktreeMonitor", () => {
           path: "\\\\wsl$\\Ubuntu\\home\\user\\repo",
           isWslPath: true,
           wslDistro: "Ubuntu",
+          wslPosixPath: "/home/user/repo",
           wslGitEligible: true,
           wslGitOptIn: true,
         };
@@ -2044,6 +2046,7 @@ describe("WorktreeMonitor", () => {
           path: "\\\\wsl$\\Ubuntu\\home\\user\\repo",
           isWslPath: true,
           wslDistro: "Ubuntu",
+          wslPosixPath: "/home/user/repo",
           wslGitEligible: true,
           wslGitOptIn: false,
         };

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -2031,6 +2031,44 @@ describe("WorktreeMonitor", () => {
           posixPath: "/home/user/repo",
         });
 
+        // Snapshot must carry the upstream-provided wslPosixPath verbatim —
+        // if the field round-trips through getSnapshot, renderer-side
+        // consumers can rely on it without re-parsing the UNC.
+        const snapshot = monitor.getSnapshot();
+        expect(snapshot.wslPosixPath).toBe("/home/user/repo");
+
+        monitor.stop();
+      } finally {
+        Object.defineProperty(process, "platform", { value: original, configurable: true });
+      }
+    });
+
+    it("silently disables WSL git routing when wslPosixPath is missing upstream", async () => {
+      // Regression guard: with the regex hoisted upstream, a WorktreeMonitor
+      // constructed without `wslPosixPath` (e.g. bypassing enrichWorktreeWithWsl)
+      // must short-circuit WSL routing rather than route to a fabricated
+      // distro-root path.
+      const original = process.platform;
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      try {
+        const wsl: Worktree = {
+          ...TEST_WORKTREE,
+          path: "\\\\wsl$\\Ubuntu\\home\\user\\repo",
+          isWslPath: true,
+          wslDistro: "Ubuntu",
+          wslGitEligible: true,
+          wslGitOptIn: true,
+        };
+        const monitor = new WorktreeMonitor(wsl, TEST_CONFIG, makeCallbacks(), "main");
+        await monitor.start();
+        await flushInitialStatus();
+
+        const lastCall =
+          mockGetWorktreeChangesWithStats.mock.calls[
+            mockGetWorktreeChangesWithStats.mock.calls.length - 1
+          ];
+        expect(lastCall[1]?.wsl).toBeUndefined();
+
         monitor.stop();
       } finally {
         Object.defineProperty(process, "platform", { value: original, configurable: true });

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -236,6 +236,9 @@ export interface WorktreeSnapshot {
   /** User dismissed the WSL git suggestion banner without opting in. */
   wslGitDismissed?: boolean;
 
+  /** POSIX path inside the WSL distro (mirrors `Worktree.wslPosixPath`). */
+  wslPosixPath?: string;
+
   /** Current in-progress git operation (REBASING, MERGING, CHERRY_PICKING, REVERTING). Absent when no blocking operation is in progress. */
   repoState?: RepoState;
 

--- a/shared/types/worktree.ts
+++ b/shared/types/worktree.ts
@@ -349,6 +349,14 @@ export interface Worktree {
    * hidden until they explicitly enable WSL git from settings (future).
    */
   wslGitDismissed?: boolean;
+
+  /**
+   * POSIX path inside the WSL distro (always starts with `/`); present only
+   * when `isWslPath` is true. Populated upstream by `enrichWorktreeWithWsl`
+   * from `detectWslPath(path).posixPath` so downstream consumers (e.g.
+   * `WorktreeMonitor`) do not re-parse the UNC.
+   */
+  wslPosixPath?: string;
 }
 
 /** Runtime worktree state (internal to WorktreeService) */

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -1544,6 +1544,7 @@ function snapshotsEqual(a: WorktreeSnapshot, b: WorktreeSnapshot): boolean {
     a.resourceConnectCommand === b.resourceConnectCommand &&
     a.isWslPath === b.isWslPath &&
     a.wslDistro === b.wslDistro &&
+    a.wslPosixPath === b.wslPosixPath &&
     a.wslGitEligible === b.wslGitEligible &&
     a.wslGitOptIn === b.wslGitOptIn &&
     a.wslGitDismissed === b.wslGitDismissed &&


### PR DESCRIPTION
## Summary

- Centralises WSL UNC path validation through `detectWslPath` in `electron/utils/wsl.ts`, removing the duplicate regex in `WorktreeMonitor` and the permissive `startsWith("\\wsl")` in `hardenedGit`.
- Routes the parse result through a new `Worktree` field populated by `WorkspaceService.enrichWorktreeWithWsl`, so every consumer reads the same canonical answer.
- Adds tests for the helper and a regression test that pins the routed path so the silent fallback to `/` can never return.

Resolves #9901

## Changes

- `electron/utils/wsl.ts` exports `detectWslPath` for cross-module use
- `electron/workspace-host/WorktreeMonitor.ts` reads the parsed remainder from the worktree instead of re-parsing
- `electron/utils/hardenedGit.ts` validates UNC paths through `detectWslPath`
- `electron/workspace-host/WorkspaceService.ts` populates the new `wslPosixPath` field on the worktree
- `shared/types/worktree.ts` and `shared/types/workspace-host.ts` carry the new field
- `src/store/createWorktreeStore.ts` surfaces the field on the renderer-side worktree
- `electron/utils/__tests__/hardenedGit.test.ts` and `electron/workspace-host/__tests__/WorktreeMonitor.test.ts` cover the helper and pin the routed path
- `.github/workflows/ci.yml` merges the sharded test matrix into the check job

## Testing

- `npm run check` (typecheck, lint, format, channel/IPC/confirm-wiring guards) passes
- Full unit suite passes
- Regression test in `WorktreeMonitor.test.ts` pins the routed POSIX path for a well-formed WSL worktree, so any future drift in the canonical parser is caught at the consumer