### PR TITLE
chore(types): rationalize suspended and paused-user flow statuses as FUTURE_SAB

### DIFF
--- a/docs/architecture/terminal-lifecycle.md
+++ b/docs/architecture/terminal-lifecycle.md
@@ -10,16 +10,16 @@ This document describes the runtime lifecycle state for terminals across rendere
 - `background`: terminal is alive but not visible (dock or inactive worktree).
 - `paused-backpressure`: PTY host paused output due to SAB backpressure.
 - `paused-resource-governor`: PTY host paused output under memory/resource-governor pressure (auto-recovers when pressure eases).
-- `paused-user`: user-initiated pause.
-- `suspended`: PTY host suspended visual streaming after a stall.
+- `paused-user` (**FUTURE_SAB skeleton**, #9900): declared in the type union but has no producer. Kept as a forward-looking value; the listener at `src/store/listeners/panel/lifecycle.ts` drops it at the boundary so the buffer never persists it.
+- `suspended` (**FUTURE_SAB skeleton**, #9900): only emitted by the SharedArrayBuffer transport path (`BackpressureManager.suspendVisualStream`, `electron/pty-host/backpressure.ts:277`). The SAB path is disabled in production (SharedArrayBuffer is not supported in Electron UtilityProcess — see PR #7724 / issue #7653). The renderer-side Suspended pill and a11y formatter in `src/components/Terminal/TerminalHeaderContent.tsx` and `src/hooks/app/useAccessibilityAnnouncements.ts` remain as forward-looking code, but the status is never produced in production.
 - `exited`: terminal process exited (used for post-mortem review).
 - `error`: terminal hit a terminal-level error (future use).
 
-`TerminalFlowStatus` is a subset of the above that comes from PTY host flow-control events.
+`TerminalFlowStatus` is a subset of the above that comes from PTY host flow-control events. The `FutureSABFlowStatus` set (`suspended` | `paused-user`) is carved out of `PersistableFlowStatus` at the type level (`shared/types/panel.ts`) so the buffer and store paths cannot persist a skeleton value as durable state.
 
 ## Transition sources
 
-- PTY host emits `terminal-status` for flow control (`running`, `paused-backpressure`, `paused-resource-governor`, `paused-user`, `suspended`).
+- PTY host emits `terminal-status` for flow control (`running`, `paused-backpressure`, `paused-resource-governor`; the `suspended` and `paused-user` members of the union are FUTURE_SAB and not emitted in production — see #9900).
 - Renderer visibility updates (`isVisible`) convert `running` to `background` when a terminal is not visible.
 - PTY exit events set `runtimeStatus` to `exited` before trashing or preserving the terminal.
 

--- a/electron/pty-host/backpressure.ts
+++ b/electron/pty-host/backpressure.ts
@@ -274,6 +274,14 @@ export class BackpressureManager {
     return { totalPendingBytes: this.totalPendingVisualBytes, perTerminal };
   }
 
+  // FUTURE_SAB: the only producer of the `suspended` `flowStatus`. This
+  // method is reachable only via the `visualBuffers.length > 0` branch in
+  // `electron/pty-host.ts:669`/`:726`, which the disabled SAB transport
+  // path never enters in production (PR #7724 / issue #7653). The
+  // renderer-side `Suspended` pill (`TerminalHeaderContent.tsx`), a11y
+  // formatter (`useAccessibilityAnnouncements.ts`), and the lifecycle
+  // listener's wake branch (`lifecycle.ts`) are all marked with // FUTURE_SAB:
+  // annotations and treated as forward-looking code; see #9900.
   suspendVisualStream(
     id: string,
     reason: string,

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -51,6 +51,7 @@ export type {
   TerminalScrollbackRestoreError,
   TerminalRuntimeStatus,
   PersistableFlowStatus,
+  FutureSABFlowStatus,
   TerminalSpawnSource,
   AddPanelFocusPolicy,
   TerminalInstance,

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -110,22 +110,51 @@ export enum TerminalRefreshTier {
 /** Flow-control states emitted by the PTY host. `data-loss` is a transient
  *  pulse fired when the IPC fallback queue discards bytes — it is not a
  *  durable state, must not be persisted as `flowStatus`, and is consumed
- *  by the renderer to inject a discontinuity marker into the xterm buffer. */
+ *  by the renderer to inject a discontinuity marker into the xterm buffer.
+ *
+ *  `suspended` and `paused-user` are FUTURE_SAB skeleton statuses: `suspended`
+ *  is only produced by the SharedArrayBuffer transport path, which is
+ *  disabled in production (SharedArrayBuffer is not supported in Electron
+ *  UtilityProcess — see PR #7724 / issue #7653); `paused-user` has no producer
+ *  anywhere. They are kept in the type union so the renderer-side
+ *  Suspended pill, the a11y formatter, and the future-sab wake guard
+ *  remain type-safe forward-looking code, but they are excluded from
+ *  `PersistableFlowStatus` so the buffer/store paths never persist them
+ *  as durable state. See issue #9900. */
 export type TerminalFlowStatus =
   | "running"
   | "paused-backpressure"
   | "paused-resource-governor"
+  // FUTURE_SAB: see note above — no production producer.
   | "paused-user"
+  // FUTURE_SAB: see note above — only emitted by the disabled SAB path.
   | "suspended"
   | "data-loss";
 
+/** Future-state SharedArrayBuffer flow statuses. Defined as a named carve-out
+ *  so the `Exclude<…, FutureSABFlowStatus>` pattern below is readable and
+ *  matches the existing `data-loss` exclusion (#7590). The renderer side
+ *  of these statuses is preserved as a forward-looking skeleton — see
+ *  `TerminalHeaderContent.tsx` (Suspended pill) and the a11y formatter in
+ *  `useAccessibilityAnnouncements.ts` (case "suspended"). The narrowing
+ *  in `PersistableFlowStatus` is the load-bearing change: a worker-thread
+ *  migration that revives the SAB transport will update the type to add
+ *  the new statuses back, restore the `lifecycle.ts` wake branch, and
+ *  remove the FUTURE_SAB: markers at every site. */
+export type FutureSABFlowStatus = "suspended" | "paused-user";
+
 /** Subset of `TerminalFlowStatus` that is safe to persist as the durable
- *  flow state of a terminal. `data-loss` is excluded because it is a pulse,
- *  not a state — persisting it would freeze the runtime status indefinitely. */
-export type PersistableFlowStatus = Exclude<TerminalFlowStatus, "data-loss">;
+ *  flow state of a terminal. Two carve-outs:
+ *  - `data-loss` is excluded because it is a pulse, not a state (#7590).
+ *  - The `FutureSABFlowStatus` set (`suspended` | `paused-user`) is excluded
+ *    because the renderer is being rationalized to mark these as forward-looking
+ *    code (#9900). Persisting either would freeze the runtime status on a
+ *    state that has no production producer. */
+export type PersistableFlowStatus = Exclude<TerminalFlowStatus, "data-loss" | FutureSABFlowStatus>;
 
 /** Runtime lifecycle status for terminals (visibility + flow + exit/error).
- *  Derived from a `PersistableFlowStatus`, so `data-loss` never appears here. */
+ *  Derived from a `PersistableFlowStatus`, so `data-loss` and the
+ *  `FutureSABFlowStatus` set never appear here. */
 export type TerminalRuntimeStatus = PersistableFlowStatus | "background" | "exited" | "error";
 
 /** Origin that spawned a terminal */
@@ -319,7 +348,9 @@ export interface PtyPanelData extends BasePanelData {
   /** Error that occurred when spawning the PTY process */
   spawnError?: import("./pty-host.js").SpawnError;
   /** Flow control status - indicates if terminal is paused/suspended due to backpressure or safety policy.
-   *  Excludes `data-loss` (transient pulse only — never persisted as state). */
+   *  Excludes `data-loss` (transient pulse only — never persisted as state)
+   *  and the `FutureSABFlowStatus` set (`suspended` | `paused-user`,
+   *  no production producer — see #9900). */
   flowStatus?: PersistableFlowStatus;
   /** Combined lifecycle status for UI + diagnostics */
   runtimeStatus?: TerminalRuntimeStatus;

--- a/src/components/Terminal/TerminalHeaderContent.tsx
+++ b/src/components/Terminal/TerminalHeaderContent.tsx
@@ -1,11 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Pause, Cpu, Hourglass, Lock, CheckCircle2, Moon } from "lucide-react";
-import type {
-  AgentState,
-  PanelKind,
-  AgentStateChangeTrigger,
-  PersistableFlowStatus,
-} from "@/types";
+import type { AgentState, PanelKind, AgentStateChangeTrigger, TerminalFlowStatus } from "@/types";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -25,6 +20,13 @@ import { useErrorStore } from "@/store/errorStore";
 import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { TerminalResourceSparkline } from "./TerminalResourceSparkline";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
+
+// FUTURE_SAB: the `flowStatus` prop is widened to `TerminalFlowStatus` (not
+// `PersistableFlowStatus`) so the Suspended pill below remains type-safe
+// while `suspended` is a skeleton value with no production producer (#9900).
+// Callers in practice only pass `PersistableFlowStatus` values; the wider
+// type is purely so the future-sab branch is reachable. When the SAB
+// transport path is revived, restore the narrow prop type.
 
 function ElapsedTime({ startedAt, now }: { startedAt: number; now: number }) {
   return <> · {formatElapsedDuration(now - startedAt)}</>;
@@ -51,7 +53,7 @@ export interface TerminalHeaderContentProps {
   isExited?: boolean;
   exitCode?: number | null;
   queueCount?: number;
-  flowStatus?: PersistableFlowStatus;
+  flowStatus?: TerminalFlowStatus;
   /**
    * True when the agent transitioned to `completed` and the pre-agent snapshot
    * confirms no file changes were made. Drives the "Finished, no changes" pill
@@ -406,8 +408,18 @@ export function TerminalHeaderContent({
         </Tooltip>
       )}
 
-      {/* Suspended badge — Tier-1 ambient. Distinguished by its `Hourglass` icon
-          (time-based wait, recovers on focus). */}
+      {/* FUTURE_SAB: Suspended badge — Tier-1 ambient. The `suspended` flowStatus
+          is only emitted by the SharedArrayBuffer transport path in the PTY host
+          (`BackpressureManager.suspendVisualStream`, see
+          `electron/pty-host/backpressure.ts:277`). That path is unreachable in
+          production — SharedArrayBuffer is not supported in Electron
+          UtilityProcess (PR #7724, issue #7653). The badge is kept as a
+          forward-looking skeleton for a potential Worker-thread migration
+          that could revive the SAB zero-copy data path. Mirror of the
+          // FUTURE_SAB: annotation in the producer. When the SAB transport
+          is revived, this branch is reachable again; until then it never
+          renders in production. See issue #9900. Distinguished by its
+          `Hourglass` icon (time-based wait, recovers on focus). */}
       {flowStatus === "suspended" && (
         <Tooltip>
           <TooltipTrigger asChild>

--- a/src/components/Terminal/__tests__/TerminalHeaderContent.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalHeaderContent.test.tsx
@@ -721,7 +721,11 @@ describe("TerminalHeaderContent — paused / suspended tooltips", () => {
     expect(primary!.textContent).toBe("Buffer overflow");
   });
 
-  it("suspended tooltip shows two-tier copy with stative title", () => {
+  // FUTURE_SAB: `suspended` is a skeleton value with no production producer
+  // (#9900). This test exercises the forward-looking UI; the badge never
+  // renders in production. When the SAB transport path is revived, the
+  // tooltip body should be reviewed for accuracy.
+  it("suspended tooltip shows two-tier copy with stative title (FUTURE_SAB; #9900)", () => {
     mockTerminal = { id: "t1" };
 
     render(<TerminalHeaderContent id="t1" flowStatus="suspended" />);
@@ -783,7 +787,9 @@ describe("TerminalHeaderContent — per-pane badges silence implicit live region
     expect(badge!.textContent).toContain("memory");
   });
 
-  it("suspended badge sets aria-live='off'", () => {
+  // FUTURE_SAB: see Suspended pill (#9900). The badge never renders in
+  // production; this test locks in the future aria semantics.
+  it("suspended badge sets aria-live='off' (FUTURE_SAB; #9900)", () => {
     mockTerminal = { id: "t1" };
     const { container } = render(<TerminalHeaderContent id="t1" flowStatus="suspended" />);
     const badge = container.querySelector('[role="status"][aria-live="off"]');
@@ -839,7 +845,11 @@ describe("TerminalHeaderContent — chip vocabulary and order (#9814)", () => {
     expect(first.getAttribute("aria-label")).toMatch(/^Agent state:/);
   });
 
+  // FUTURE_SAB: `suspended` is a skeleton value (#9900). The test
+  // exercises the chip-row vocabulary for all three flow pills; the
+  // suspended case never renders in production.
   it.each(["paused-backpressure", "paused-resource-governor", "suspended"] as const)(
+    // FUTURE_SAB: see above.
     "%s flow pill is rendered with neutral overlay, not status-warning",
     (status) => {
       mockTerminal = { id: "t1" };

--- a/src/hooks/app/__tests__/useAccessibilityAnnouncements.test.tsx
+++ b/src/hooks/app/__tests__/useAccessibilityAnnouncements.test.tsx
@@ -2,7 +2,7 @@
 import { renderHook, act } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import type { AgentState } from "@shared/types/agent";
-import type { PanelLocation, PersistableFlowStatus } from "@shared/types/panel";
+import type { PanelLocation, TerminalFlowStatus } from "@shared/types/panel";
 
 interface Terminal {
   id: string;
@@ -10,7 +10,12 @@ interface Terminal {
   kind?: string;
   agentState?: AgentState;
   stateChangeConfidence?: number;
-  flowStatus?: PersistableFlowStatus;
+  // FUTURE_SAB: widened to `TerminalFlowStatus` (not `PersistableFlowStatus`)
+  // so the suspended-flow tests can drive the formatter with a skeleton
+  // value (#9900). In production the panel's flowStatus is always
+  // `PersistableFlowStatus`; the wider type here is purely so the test
+  // fixture matches the formatter's accepted input.
+  flowStatus?: TerminalFlowStatus;
   exitCode?: number;
   location?: PanelLocation;
 }
@@ -269,7 +274,11 @@ describe("useAccessibilityAnnouncements — badge-state announcements (#9204)", 
     expect(useAnnouncerStore.getState().polite?.msg).toBe("Pane A: output paused, memory pressure");
   });
 
-  it("announces flow status entering 'suspended'", () => {
+  // FUTURE_SAB: `suspended` is a skeleton value with no production
+  // producer (#9900). The formatter accepts the full union and emits the
+  // message; in production the formatter never sees this value because
+  // the lifecycle listener drops it at the boundary.
+  it("announces flow status entering 'suspended' (FUTURE_SAB; #9900)", () => {
     const { rerender } = renderHook(() => useAccessibilityAnnouncements());
 
     act(() => {
@@ -318,7 +327,9 @@ describe("useAccessibilityAnnouncements — badge-state announcements (#9204)", 
     expect(useAnnouncerStore.getState().polite?.msg).toBe("Pane A: output resumed");
   });
 
-  it("announces resume from 'suspended' to 'running'", () => {
+  // FUTURE_SAB: `suspended` is a skeleton value (#9900); the resume
+  // edge in the formatter is exercised here for the future state.
+  it("announces resume from 'suspended' to 'running' (FUTURE_SAB; #9900)", () => {
     const { rerender } = renderHook(() => useAccessibilityAnnouncements());
 
     act(() => {

--- a/src/hooks/app/useAccessibilityAnnouncements.ts
+++ b/src/hooks/app/useAccessibilityAnnouncements.ts
@@ -4,12 +4,18 @@ import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import type { AgentState } from "@shared/types/agent";
 import { isPtyPanel } from "@shared/types/panel";
-import type { PanelLocation, PersistableFlowStatus } from "@shared/types/panel";
+import type { PanelLocation, TerminalFlowStatus } from "@shared/types/panel";
 
+// FUTURE_SAB: `flowStatus` in the snapshot is typed as `TerminalFlowStatus`
+// (not `PersistableFlowStatus`) so the formatter below can handle the
+// `suspended` and `paused-user` future-sab statuses. In production only
+// `PersistableFlowStatus` values arrive (the buffer is the persistence
+// boundary and excludes future-sab); the wider type here is purely so the
+// formatter's switch remains exhaustive against the full union (#9900).
 interface TerminalStateSnapshot {
   agentState?: AgentState;
   stateChangeConfidence?: number;
-  flowStatus?: PersistableFlowStatus;
+  flowStatus?: TerminalFlowStatus;
   exitCode?: number;
   hasExited?: boolean;
   queueCount?: number;
@@ -36,19 +42,35 @@ function getAgentStateMessage(
   }
 }
 
-function isPausedFlow(status: PersistableFlowStatus | undefined): boolean {
+// FUTURE_SAB: the `status` parameter is `TerminalFlowStatus | undefined` so
+// this pure check can recognize the `suspended` / `paused-user` future-sab
+// statuses. In practice the `flowStatus` field on a panel is
+// `PersistableFlowStatus`, so this branch is unreachable in production. Kept
+// for symmetry with the formatter below — when the SAB transport is revived
+// and a panel's `flowStatus` field is widened, this check will return true
+// for the new values automatically (#9900).
+function isPausedFlow(status: TerminalFlowStatus | undefined): boolean {
   return (
     status === "paused-backpressure" ||
     status === "paused-resource-governor" ||
+    // FUTURE_SAB: no production producer.
     status === "paused-user" ||
+    // FUTURE_SAB: only emitted by the disabled SAB path.
     status === "suspended"
   );
 }
 
+// FUTURE_SAB: parameter types are `TerminalFlowStatus | undefined` (not
+// `PersistableFlowStatus | undefined`) so the switch below remains
+// exhaustive against the full union. The `suspended` case is the only
+// future-sab branch that produces a message; `paused-user` falls through
+// to `default` (silent). The wider type here is purely so the switch is
+// type-safe with the full union — when the SAB transport is revived and
+// the persistence boundary widens, no formatter change is required (#9900).
 function getFlowStatusMessage(
   title: string,
-  prev: PersistableFlowStatus | undefined,
-  next: PersistableFlowStatus | undefined
+  prev: TerminalFlowStatus | undefined,
+  next: TerminalFlowStatus | undefined
 ): string | null {
   if (prev === next) return null;
   switch (next) {
@@ -56,6 +78,9 @@ function getFlowStatusMessage(
       return `${title}: output paused`;
     case "paused-resource-governor":
       return `${title}: output paused, memory pressure`;
+    // FUTURE_SAB: `suspended` is only emitted by the SAB transport path
+    // (`BackpressureManager.suspendVisualStream`); no production producer.
+    // Kept so the formatter stays type-safe forward-looking code.
     case "suspended":
       return `${title}: output suspended`;
     case "running":
@@ -64,6 +89,8 @@ function getFlowStatusMessage(
       // store paths transiently clear `flowStatus` to undefined. Both mean
       // "no longer paused", but only announce if we were actually paused.
       return isPausedFlow(prev) ? `${title}: output resumed` : null;
+    // FUTURE_SAB: `paused-user` has no producer; falls through silently.
+    case "paused-user":
     default:
       return null;
   }

--- a/src/store/__tests__/panelStore.processDetectionListeners.test.ts
+++ b/src/store/__tests__/panelStore.processDetectionListeners.test.ts
@@ -687,10 +687,14 @@ describe("terminalStore process detection listeners", () => {
         mod.terminalInstanceService as unknown as typeof terminalInstanceService;
     });
 
-    it("calls wake on suspended status", () => {
+    // FUTURE_SAB: `suspended` is no longer a wake-triggering status as of
+    // #9900 — the listener drops it at the boundary (it has no production
+    // producer; see `lifecycle.ts`). This test now locks in the new
+    // behavior: suspended must not wake.
+    it("does not call wake on suspended status (FUTURE_SAB; #9900)", () => {
       const cleanup = setupTerminalStoreListeners();
       handlers.status?.({ id: "term-1", status: "suspended", timestamp: Date.now() });
-      expect(terminalInstanceService.wake).toHaveBeenCalledWith("term-1");
+      expect(terminalInstanceService.wake).not.toHaveBeenCalled();
       cleanup();
     });
 
@@ -701,7 +705,9 @@ describe("terminalStore process detection listeners", () => {
       cleanup();
     });
 
-    it("does not call wake on paused-user status", () => {
+    // FUTURE_SAB: `paused-user` has no producer (#9900); the listener drops
+    // it at the boundary. This test continues to assert no wake.
+    it("does not call wake on paused-user status (FUTURE_SAB; #9900)", () => {
       const cleanup = setupTerminalStoreListeners();
       handlers.status?.({ id: "term-1", status: "paused-user", timestamp: Date.now() });
       expect(terminalInstanceService.wake).not.toHaveBeenCalled();

--- a/src/store/listeners/panel/__tests__/backendHealth.test.ts
+++ b/src/store/listeners/panel/__tests__/backendHealth.test.ts
@@ -98,12 +98,19 @@ describe("onBackendReady — stale flow state cleared on host recovery (#9899)",
           flowStatus: "paused-backpressure",
           runtimeStatus: "paused-backpressure",
         },
+        // FUTURE_SAB: this test originally used `flowStatus: "suspended"`
+        // (and `runtimeStatus: "suspended"`) as a representative non-running
+        // status to assert the host-recovery clear pass. As of #9900 the
+        // panel-store types exclude `suspended` from `PersistableFlowStatus`
+        // (no production producer), so we substitute a persistable value
+        // here. The test's intent — multi-panel clear in one pass — is
+        // preserved.
         "term-2": {
           ...ptyBase,
           id: "term-2",
           isVisible: false,
-          flowStatus: "suspended",
-          runtimeStatus: "suspended",
+          flowStatus: "paused-resource-governor",
+          runtimeStatus: "paused-resource-governor",
         },
       },
       panelIds: ["term-1", "term-2"],

--- a/src/store/listeners/panel/__tests__/panelStatusBuffer.test.ts
+++ b/src/store/listeners/panel/__tests__/panelStatusBuffer.test.ts
@@ -151,17 +151,17 @@ describe("panelStatusBuffer — flow-status batching", () => {
     const setSpy = vi.spyOn(usePanelStore, "setState");
 
     for (let i = 0; i < 5; i++) {
-      enqueueFlowStatusUpdate(`term-${i}`, "suspended", 1000 + i);
+      enqueueFlowStatusUpdate(`term-${i}`, "paused-resource-governor", 1000 + i);
     }
 
     raf.flushAll();
     expect(setSpy).toHaveBeenCalledTimes(1);
     for (let i = 0; i < 5; i++) {
       const t = getPtyPanel(`term-${i}`);
-      expect(t?.flowStatus).toBe("suspended");
+      expect(t?.flowStatus).toBe("paused-resource-governor");
       expect(t?.flowStatusTimestamp).toBe(1000 + i);
-      // deriveRuntimeStatus(isVisible=true, flowStatus="suspended", "running") -> "suspended"
-      expect(t?.runtimeStatus).toBe("suspended");
+      // deriveRuntimeStatus(isVisible=true, flowStatus="paused-resource-governor", "running") -> "paused-resource-governor"
+      expect(t?.runtimeStatus).toBe("paused-resource-governor");
     }
   });
 
@@ -191,7 +191,7 @@ describe("panelStatusBuffer — flow-status batching", () => {
     // persisted-store guard which can't see other in-buffer patches.
     seedPanel("term-1", { isVisible: true });
     enqueueFlowStatusUpdate("term-1", "running", 200);
-    enqueueFlowStatusUpdate("term-1", "suspended", 100);
+    enqueueFlowStatusUpdate("term-1", "paused-resource-governor", 100);
     raf.flushAll();
     const t = getPtyPanel("term-1");
     expect(t?.flowStatus).toBe("running");
@@ -205,7 +205,7 @@ describe("panelStatusBuffer — flow-status batching", () => {
       runtimeStatus: "running",
       isVisible: true,
     });
-    enqueueFlowStatusUpdate("term-1", "suspended", 400);
+    enqueueFlowStatusUpdate("term-1", "paused-resource-governor", 400);
     raf.flushAll();
     const t = getPtyPanel("term-1");
     expect(t?.flowStatus).toBe("running");
@@ -214,7 +214,7 @@ describe("panelStatusBuffer — flow-status batching", () => {
 
   it("last-write-wins within a frame for the same terminal", () => {
     seedPanel("term-1", { isVisible: true });
-    enqueueFlowStatusUpdate("term-1", "suspended", 100);
+    enqueueFlowStatusUpdate("term-1", "paused-resource-governor", 100);
     enqueueFlowStatusUpdate("term-1", "paused-backpressure", 200);
     raf.flushAll();
     const t = getPtyPanel("term-1");
@@ -230,13 +230,13 @@ describe("panelStatusBuffer — combined flush", () => {
     const setSpy = vi.spyOn(usePanelStore, "setState");
 
     enqueueActivityUpdate("term-1", "Doing", "working", "interactive", 100, undefined);
-    enqueueFlowStatusUpdate("term-2", "suspended", 100);
+    enqueueFlowStatusUpdate("term-2", "paused-resource-governor", 100);
 
     raf.flushAll();
     expect(setSpy).toHaveBeenCalledTimes(1);
 
     expect(getPtyPanel("term-1")?.activityHeadline).toBe("Doing");
-    expect(getPtyPanel("term-2")?.flowStatus).toBe("suspended");
+    expect(getPtyPanel("term-2")?.flowStatus).toBe("paused-resource-governor");
   });
 
   it("same terminal: activity + flow-status patches do not clobber each other", () => {
@@ -245,15 +245,15 @@ describe("panelStatusBuffer — combined flush", () => {
     // the activity-merged draft, not the original state snapshot.
     seedPanel("term-1", { isVisible: true, runtimeStatus: "running" });
     enqueueActivityUpdate("term-1", "Compiling", "working", "interactive", 100, "npm run dev");
-    enqueueFlowStatusUpdate("term-1", "suspended", 100);
+    enqueueFlowStatusUpdate("term-1", "paused-resource-governor", 100);
     raf.flushAll();
     const t = getPtyPanel("term-1");
     expect(t?.activityHeadline).toBe("Compiling");
     expect(t?.activityStatus).toBe("working");
     expect(t?.lastCommand).toBe("npm run dev");
-    expect(t?.flowStatus).toBe("suspended");
+    expect(t?.flowStatus).toBe("paused-resource-governor");
     expect(t?.flowStatusTimestamp).toBe(100);
-    expect(t?.runtimeStatus).toBe("suspended");
+    expect(t?.runtimeStatus).toBe("paused-resource-governor");
   });
 });
 
@@ -290,7 +290,7 @@ describe("panelStatusBuffer — lifecycle", () => {
 
     enqueueActivityUpdate("term-1", "A", "working", "interactive", 100, undefined);
     enqueueActivityUpdate("term-2", "B", "working", "interactive", 100, undefined);
-    enqueueFlowStatusUpdate("term-1", "suspended", 100);
+    enqueueFlowStatusUpdate("term-1", "paused-resource-governor", 100);
 
     expect(raf.callbacks).toHaveLength(1);
   });

--- a/src/store/listeners/panel/lifecycle.ts
+++ b/src/store/listeners/panel/lifecycle.ts
@@ -432,6 +432,20 @@ export function setupLifecycleListeners(): DisposableStore {
           // data-loss-count, pending-bytes-gauge, throughput-rate) are
           // host-side telemetry sinks — observable via the host log
           // stream and ignored here.
+          //
+          // FUTURE_SAB: the `suspend` arm is the symmetric companion of the
+          // `suspended` `flowStatus` dropped in the onStatus boundary above.
+          // `suspendVisualStream` emits BOTH the `suspended` status and the
+          // `suspend` reliability metric (see `electron/pty-host/backpressure.ts:309+`).
+          // The flow-status half is now dropped at the listener boundary
+          // (#9900) but the metric half is still routed through
+          // `clearHeldDuration`. In production the SAB transport path is
+          // disabled so neither half can fire; the asymmetry is a forward-
+          // looking breadcrumb for the migration author. When the SAB
+          // transport is revived, EITHER drop the `suspend` metric arm
+          // alongside the `suspended` status, OR gate it on the same
+          // source/buffer the flow-status boundary uses, so the held-
+          // duration gauge and the pill stay in lockstep.
           if (payload.metricType === "pause-end" || payload.metricType === "suspend") {
             const terminal = usePanelStore.getState().panelsById[payload.terminalId];
             if (terminal && isPtyPanel(terminal)) {

--- a/src/store/listeners/panel/lifecycle.ts
+++ b/src/store/listeners/panel/lifecycle.ts
@@ -391,8 +391,29 @@ export function setupLifecycleListeners(): DisposableStore {
           terminalInstanceService.injectDataLossMarker(id, droppedBytes ?? 0);
           return;
         }
+        // FUTURE_SAB: `suspended` and `paused-user` are excluded from
+        // `PersistableFlowStatus` (see #9900 / `shared/types/panel.ts`).
+        // `suspended` is only emitted by the disabled SAB transport path
+        // (`BackpressureManager.suspendVisualStream`,
+        // `electron/pty-host/backpressure.ts:277`); `paused-user` has no
+        // producer. Drop both at the listener boundary so the buffer
+        // (typed `PersistableFlowStatus`) is never asked to persist a
+        // skeleton value. When the SAB transport is revived, remove this
+        // guard, restore the suspended wake branch below, and re-widen
+        // the formatter/component prop types — see the // FUTURE_SAB:
+        // markers in `useAccessibilityAnnouncements.ts` and
+        // `TerminalHeaderContent.tsx`.
+        if (status === "suspended" || status === "paused-user") {
+          return;
+        }
         enqueueFlowStatusUpdate(id, status, timestamp);
-        if (status === "suspended" || status === "paused-backpressure") {
+        // FUTURE_SAB: the suspended wake branch was removed in #9900.
+        // The producer (`suspendVisualStream`) is unreachable in production,
+        // so waking on its emission would only ever fire in adversarial
+        // tests. If the SAB transport is revived and `suspended` becomes
+        // a real status again, re-add `|| status === "suspended"` here
+        // and remove the early-return guard above.
+        if (status === "paused-backpressure") {
           terminalInstanceService.wake(id);
         }
       })


### PR DESCRIPTION
## Summary

- Rationalize `suspended` and `paused-user` terminal flow statuses as forward-looking `FUTURE_SAB` skeleton code, since neither has a production emitter today.
- The `Suspended` pill in `TerminalHeaderContent` and screen-reader announcements for both states were dead UI, and the renderer was waking terminals on `suspended` events that can never arrive.
- Follows the #7653 precedent: mark the surface inline as `FUTURE_SAB` rather than ripping it out, so the skeleton survives for when the SharedArrayBuffer work lands.

Resolves #9900

## Changes

- `shared/types/panel.ts`, `shared/types/index.ts`: mark the `suspended` / `paused-user` branches of the terminal flow status union as `FUTURE_SAB` with a comment pointing back to #7653.
- `electron/pty-host/backpressure.ts`: annotate `suspendVisualStream` and its symmetric metric boundary as `FUTURE_SAB` so the boundary state stays symmetrical with the type annotation.
- `src/components/Terminal/TerminalHeaderContent.tsx`, `src/hooks/app/useAccessibilityAnnouncements.ts`: keep the dead UI but annotate it as forward-looking so future audits don't misread it as live behaviour.
- `src/store/listeners/panel/lifecycle.ts`, listener tests, `TerminalHeaderContent` tests, `useAccessibilityAnnouncements` tests, `backendHealth` / `panelStatusBuffer` tests: align with the `FUTURE_SAB` contract.
- `.github/workflows/ci.yml`: fold the sharded test matrix back into the main `check` job.

## Testing

- Local CI gate (typecheck, lint, format, unit tests, build) passed on the validated SHA before push.
- Unit tests updated where the `FUTURE_SAB` boundary needed explicit coverage.