### PR TITLE
fix(terminal): detach host element on destroy regardless of hibernation state

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -2938,10 +2938,14 @@ class TerminalInstanceService {
 
       this.webGLManager.onTerminalDestroyed(id);
       managed.terminal.dispose();
+    }
 
-      if (managed.hostElement.parentElement) {
-        managed.hostElement.parentElement.removeChild(managed.hostElement);
-      }
+    // Detach the host element regardless of hibernation state: a hibernated
+    // terminal's host may have been parked in the shared offscreen container
+    // by detach()/detachForProjectSwitch() (raw child, not a registered slot),
+    // and the gated branch above doesn't reach it (#9909).
+    if (managed.hostElement.parentElement) {
+      managed.hostElement.parentElement.removeChild(managed.hostElement);
     }
 
     this.offscreenManager.removeOffscreenSlot(id);

--- a/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
@@ -761,6 +761,30 @@ describe("TerminalInstanceService - Hibernation", () => {
 
       vi.setSystemTime(new Date());
     });
+
+    it("should detach the host element from the shared hidden container (#9909)", () => {
+      // A hibernated terminal's host may have been parked in the shared
+      // offscreen container by detach()/detachForProjectSwitch() — a raw
+      // child of hiddenContainer, not a per-id slot. Destroy must still
+      // remove it, otherwise long multi-project sessions accumulate empty
+      // host divs in the shared container.
+      const managed = makeMockManaged({ isHibernated: true });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      const offscreen = (
+        service as unknown as {
+          offscreenManager: { ensureHiddenContainer: () => HTMLElement | null };
+        }
+      ).offscreenManager.ensureHiddenContainer();
+      expect(offscreen).not.toBeNull();
+      offscreen!.appendChild(managed.hostElement);
+      expect(offscreen!.contains(managed.hostElement)).toBe(true);
+
+      service.destroy("t1");
+
+      expect(managed.hostElement.parentElement).toBeNull();
+      expect(offscreen!.contains(managed.hostElement)).toBe(false);
+    });
   });
 
   describe("Listener leak prevention", () => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
@@ -785,6 +785,40 @@ describe("TerminalInstanceService - Hibernation", () => {
       expect(managed.hostElement.parentElement).toBeNull();
       expect(offscreen!.contains(managed.hostElement)).toBe(false);
     });
+
+    it("should still detach the host for a non-hibernated terminal parked in the hidden container", () => {
+      // Locks in that moving the host removal out of the !isHibernated guard
+      // didn't break the pre-existing non-hibernated path: a terminal that
+      // is destroyed mid-detach (e.g. via detachForProjectSwitch()) also
+      // gets its host cleaned up.
+      const managed = makeMockManaged({ isHibernated: false });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      const offscreen = (
+        service as unknown as {
+          offscreenManager: { ensureHiddenContainer: () => HTMLElement | null };
+        }
+      ).offscreenManager.ensureHiddenContainer();
+      expect(offscreen).not.toBeNull();
+      offscreen!.appendChild(managed.hostElement);
+
+      service.destroy("t1");
+
+      expect(managed.hostElement.parentElement).toBeNull();
+      expect(offscreen!.contains(managed.hostElement)).toBe(false);
+    });
+
+    it("should be a safe no-op when the host has no parent", () => {
+      // Locks in the `if (managed.hostElement.parentElement)` guard so a
+      // future refactor that drops it doesn't start throwing NotFoundError
+      // on already-detached hosts.
+      const managed = makeMockManaged();
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+      expect(managed.hostElement.parentElement).toBeNull();
+
+      expect(() => service.destroy("t1")).not.toThrow();
+      expect(managed.hostElement.parentElement).toBeNull();
+    });
   });
 
   describe("Listener leak prevention", () => {


### PR DESCRIPTION
## Summary

- In `src/services/terminal/TerminalInstanceService.ts`, `destroy()` was only removing a terminal's host element from the DOM in the `!isHibernated` branch, but `detach()` and `detachForProjectSwitch()` park the host as a raw child of the shared hidden container (`offscreenManager.ensureHiddenContainer()`), which lives for the renderer session. A hibernated terminal destroyed after a project switch was leaving an empty `<div>` behind in that shared container.
- Fix: move the `hostElement` removal out of the `!isHibernated` guard so it always runs on destroy.
- Tests: add three regression cases to the existing `describe('destroy() with hibernated terminals')` block in `src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts` — hibernated host in shared container, non-hibernated host in shared container, and host with no parent.

Resolves #9909

## Changes

- `src/services/terminal/TerminalInstanceService.ts` — hoist `hostElement` removal above the `!managed.isHibernated` branch in `destroy()`.
- `src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts` — three new regression cases covering the leaked-DOM scenarios.

## Testing

- Local CI (typecheck, lint, format, unit tests, build) passed before push.
- New cases exercise the DOM leak directly: assert the host element is detached from its parent on destroy, regardless of hibernation state or where it was parked.
- No new dependencies. No public API changes.