### PR TITLE
fix(artifact-parser): require hunk header + corroborating target for --- opener (#9998)

### DIFF
--- a/shared/utils/__tests__/artifactParser.test.ts
+++ b/shared/utils/__tests__/artifactParser.test.ts
@@ -200,6 +200,12 @@ describe("artifactParser", () => {
     expect(patches).toHaveLength(2);
     expect(patches[0]).toContain("+new1");
     expect(patches[1]).toContain("+new2");
+    // The 2nd block's `diff --git` header sits on the line that ends the 1st
+    // block. The opener must be re-evaluated after finalize() so it isn't
+    // dropped (the `--- a/y` line independently re-opens the body, which would
+    // mask the loss if only the body were checked).
+    expect(patches[0]).toContain("diff --git a/x b/x");
+    expect(patches[1]).toContain("diff --git a/y b/y");
   });
 
   it("extracts a new file diff with --- /dev/null", () => {

--- a/shared/utils/__tests__/artifactParser.test.ts
+++ b/shared/utils/__tests__/artifactParser.test.ts
@@ -90,10 +90,11 @@ describe("artifactParser", () => {
     expect(patches[0]).toContain("+++ b/file.txt");
   });
 
-  it("accepts git format-patch envelope followed by diff body", () => {
-    // The `From <sha>` envelope is a Tier 1 trigger. The header line opens
-    // a candidate block that closes on `Subject:` (not a body line), then
-    // the real diff is opened by the `diff --git` line further down.
+  it("extracts diff body that follows a git format-patch envelope", () => {
+    // The `From <sha>` envelope line is not a Tier 1 trigger on its own —
+    // the downstream `diff --git` opens the patch block. The test pins the
+    // behavior so a future change to the parser doesn't accidentally make
+    // envelope lines alone emit a patch artifact.
     const input = [
       "From abcdef1234567890abcdef1234567890abcdef12 Mon Sep 17 00:00:00 2001",
       "Subject: [PATCH] Fix thing",
@@ -114,7 +115,9 @@ describe("artifactParser", () => {
 
   it("accepts combined diff with @@@ hunk header", () => {
     // `git diff -c` / `--cc` produces combined diffs with `@@@` (3+ `@`) hunk
-    // headers and multiple `---` source headers before the target.
+    // headers and multiple `---` source headers before the target. The
+    // `diff --combined` preamble is dropped (it doesn't match a body line)
+    // and the block restarts on the first `--- a/<file>`.
     const input = [
       "diff --combined file.txt",
       "index abc,def..ghi",
@@ -130,6 +133,8 @@ describe("artifactParser", () => {
     ].join("\n");
     const patches = extractPatches(input);
     expect(patches).toHaveLength(1);
+    expect(patches[0]).toContain("--- a/file.txt");
+    expect(patches[0]).toContain("+++ b/file.txt");
     expect(patches[0]).toContain("@@@ -1,1 -1,1 +1,1 @@@");
   });
 
@@ -152,6 +157,83 @@ describe("artifactParser", () => {
       "+ another body line",
     ].join("\n");
     expect(extractPatches(input)).toEqual([]);
+  });
+
+  it("preserves \\ No newline at end of file marker (#9998)", () => {
+    // `git diff` emits `\ No newline at end of file` after the last line of
+    // a file that lacks a trailing newline. `git apply` requires this marker
+    // and will reject a patch that drops it. The parser must treat the `\`-
+    // prefixed line as a body line, not as prose that closes the block.
+    const input = [
+      "--- a/file",
+      "+++ b/file",
+      "@@ -1 +1 @@",
+      "-line1",
+      "\\ No newline at end of file",
+      "+line2",
+      "\\ No newline at end of file",
+    ].join("\n");
+    const patches = extractPatches(input);
+    expect(patches).toHaveLength(1);
+    expect(patches[0]).toContain("\\ No newline at end of file");
+    expect(patches[0]).toContain("+line2");
+  });
+
+  it("extracts multiple back-to-back diff blocks", () => {
+    // Two `diff --git` hunks separated by a single line break — both must
+    // be emitted as independent patches, in order.
+    const input = [
+      "diff --git a/x b/x",
+      "--- a/x",
+      "+++ b/x",
+      "@@ -1 +1 @@",
+      "-old1",
+      "+new1",
+      "diff --git a/y b/y",
+      "--- a/y",
+      "+++ b/y",
+      "@@ -1 +1 @@",
+      "-old2",
+      "+new2",
+    ].join("\n");
+    const patches = extractPatches(input);
+    expect(patches).toHaveLength(2);
+    expect(patches[0]).toContain("+new1");
+    expect(patches[1]).toContain("+new2");
+  });
+
+  it("extracts a new file diff with --- /dev/null", () => {
+    // `git diff` for a newly added file shows `--- /dev/null` as the source
+    // header. The opener is `--- /dev/null` (passes `isUnifiedOpener` — the
+    // path-like token is `/`), and `+++ b/new` corroborates it.
+    const input = [
+      "--- /dev/null",
+      "+++ b/new.txt",
+      "@@ -0,0 +1,3 @@",
+      "+line1",
+      "+line2",
+      "+line3",
+    ].join("\n");
+    const patches = extractPatches(input);
+    expect(patches).toHaveLength(1);
+    expect(patches[0]).toContain("--- /dev/null");
+    expect(patches[0]).toContain("+++ b/new.txt");
+  });
+
+  it("extracts a deleted file diff with +++ /dev/null", () => {
+    // Mirror of the new-file case: `+++ /dev/null` marks a deleted file.
+    const input = [
+      "--- a/old.txt",
+      "+++ /dev/null",
+      "@@ -1,3 +0,0 @@",
+      "-line1",
+      "-line2",
+      "-line3",
+    ].join("\n");
+    const patches = extractPatches(input);
+    expect(patches).toHaveLength(1);
+    expect(patches[0]).toContain("--- a/old.txt");
+    expect(patches[0]).toContain("+++ /dev/null");
   });
 
   it("extracts patch filename from +++ line", () => {

--- a/shared/utils/__tests__/artifactParser.test.ts
+++ b/shared/utils/__tests__/artifactParser.test.ts
@@ -56,6 +56,104 @@ describe("artifactParser", () => {
     expect(patches[0]).toContain("+new");
   });
 
+  it("rejects Markdown horizontal rule followed by bulleted list (#9998)", () => {
+    // The exact issue-9998 false positive: a `---` Markdown HR followed by
+    // list items. The new heuristic must not emit any patch artifact.
+    const input = ["---", "- item one", "- item two", "- item three"].join("\n");
+    expect(extractPatches(input)).toEqual([]);
+  });
+
+  it("rejects YAML front matter with --- delimiters and no hunks (#9998)", () => {
+    const input = ["---", "title: My Doc", "author: Greg", "---", "", "Body."].join("\n");
+    expect(extractPatches(input)).toEqual([]);
+  });
+
+  it("rejects --- a/file opener with no +++ within lookahead window (#9998)", () => {
+    // A `--- a/<file>` line that is followed by non-diff prose (no `+++ b/`
+    // target header) must not be promoted to a diff. This is the case where
+    // an agent's prose happens to mention a file path in a `---` line.
+    const input = [
+      "--- a/src/file.ts",
+      "+ some addition",
+      "+ another addition",
+      "+ a third line",
+    ].join("\n");
+    expect(extractPatches(input)).toEqual([]);
+  });
+
+  it("accepts plain unified diff without diff --git preamble", () => {
+    // Standard `git apply` / `diff -u` format: just the header pair + body.
+    const input = ["--- a/file.txt", "+++ b/file.txt", "@@ -1 +1 @@", "-old", "+new"].join("\n");
+    const patches = extractPatches(input);
+    expect(patches).toHaveLength(1);
+    expect(patches[0]).toContain("--- a/file.txt");
+    expect(patches[0]).toContain("+++ b/file.txt");
+  });
+
+  it("accepts git format-patch envelope followed by diff body", () => {
+    // The `From <sha>` envelope is a Tier 1 trigger. The header line opens
+    // a candidate block that closes on `Subject:` (not a body line), then
+    // the real diff is opened by the `diff --git` line further down.
+    const input = [
+      "From abcdef1234567890abcdef1234567890abcdef12 Mon Sep 17 00:00:00 2001",
+      "Subject: [PATCH] Fix thing",
+      "",
+      "diff --git a/src/a.ts b/src/a.ts",
+      "--- a/src/a.ts",
+      "+++ b/src/a.ts",
+      "@@ -1 +1 @@",
+      "-old",
+      "+new",
+      "-- ",
+      "2.34.1",
+    ].join("\n");
+    const patches = extractPatches(input);
+    expect(patches).toHaveLength(1);
+    expect(patches[0]).toContain("@@ -1 +1 @@");
+  });
+
+  it("accepts combined diff with @@@ hunk header", () => {
+    // `git diff -c` / `--cc` produces combined diffs with `@@@` (3+ `@`) hunk
+    // headers and multiple `---` source headers before the target.
+    const input = [
+      "diff --combined file.txt",
+      "index abc,def..ghi",
+      "--- a/file.txt",
+      "--- a/file.txt",
+      "+++ b/file.txt",
+      "@@@ -1,1 -1,1 +1,1 @@@",
+      "  unchanged",
+      " -old1",
+      " -old2",
+      " +new1",
+      " +new2",
+    ].join("\n");
+    const patches = extractPatches(input);
+    expect(patches).toHaveLength(1);
+    expect(patches[0]).toContain("@@@ -1,1 -1,1 +1,1 @@@");
+  });
+
+  it("rejects diff --git snippets that lack an @@ hunk header", () => {
+    // A real `diff --git` preamble but no hunk — the hunk check at commit
+    // time is the structural guard that `git apply` would also apply.
+    const input = ["diff --git a/x b/x", "index abc..def 100644", "--- a/x"].join("\n");
+    expect(extractPatches(input)).toEqual([]);
+  });
+
+  it("rejects prose that contains @@ but not as a real hunk header (#9998)", () => {
+    // `@@user` and `@@@handle` are prose-shaped, not hunk headers — the
+    // anchored `-\d+` requirement in the hunk regex stops them.
+    const input = [
+      "diff --git a/x b/x",
+      "--- a/x",
+      "+++ b/x",
+      "@@user mentioned this in chat",
+      "+ some body line",
+      "+ another body line",
+    ].join("\n");
+    expect(extractPatches(input)).toEqual([]);
+  });
+
   it("extracts patch filename from +++ line", () => {
     const filename = extractPatchFilename("+++ b/src/main.ts\n@@ -1 +1 @@");
     expect(filename).toBe("src/main.ts");

--- a/shared/utils/artifactParser.ts
+++ b/shared/utils/artifactParser.ts
@@ -34,10 +34,10 @@ export function extractCodeBlocks(text: string): CodeBlock[] {
 // were emitted as patch artifacts and handed to `git apply` (which rejected
 // them noisily). The helpers below form a three-tier classifier:
 //
-//   Tier 1 — trigger:  `diff --git ...`, `From <sha> ...`, or `--- a/<file>`
+//   Tier 1 — trigger:  `diff --git ...` or `--- a/<file>`
 //   Tier 2 — corroborate: a `+++ b/<file>` target header within a few lines
 //                            (only required for the `--- a/<file>` opener;
-//                            `diff --git` and `From <sha>` are unambiguous)
+//                            `diff --git` is unambiguous)
 //   Tier 3 — commit:  at least one `@@` / `@@@` hunk header in the block
 //
 // A block is only emitted when all three tiers are satisfied. Bare `---` and
@@ -49,24 +49,19 @@ function isDiffStart(line: string): boolean {
   return line.startsWith("diff ");
 }
 
-// Tier 1 trigger: the `git format-patch` envelope header. Default `git
-// format-patch` always uses a full 40-char SHA-1; SHA-256 (64 hex chars) is
-// also accepted.
-const FROM_ENVELOPE_REGEX = /^From [0-9a-f]{40,}\b/;
-function isFromEnvelope(line: string): boolean {
-  return FROM_ENVELOPE_REGEX.test(line);
-}
-
 // Tier 1 trigger (with corroboration): a `--- a/<file>` source header.
 // Bare `---` (Markdown HR, YAML front-matter) does NOT match — it needs
-// whitespace AND a non-whitespace token after the `--- `.
+// whitespace AND a non-whitespace token after the `--- `. `--- /dev/null`
+// (new-file diff) and `---` followed by a custom path (e.g. `--- foo` from
+// `git diff --no-prefix`) both pass.
 const UNIFIED_OPENER_REGEX = /^---\s+\S/;
 function isUnifiedOpener(line: string): boolean {
   return UNIFIED_OPENER_REGEX.test(line);
 }
 
 // The `+++ b/<file>` target header that must corroborate a `--- a/<file>`
-// opener. The path prefix is not enforced (`git diff --no-prefix` omits `b/`).
+// opener. The path prefix is not enforced (`git diff --no-prefix` omits `b/`,
+// and `+++ /dev/null` marks a deleted file).
 const TARGET_HEADER_REGEX = /^\+\+\+\s+\S/;
 function isTargetHeader(line: string): boolean {
   return TARGET_HEADER_REGEX.test(line);
@@ -74,9 +69,10 @@ function isTargetHeader(line: string): boolean {
 
 // Walk forward from a `--- a/<file>` opener and confirm a `+++ b/<file>`
 // target header appears in the next few lines. Blank lines and additional
-// `---` headers are skipped (combined diffs list one source header per
-// parent before the target). Bounded to keep the scan cheap.
-const TARGET_HEADER_LOOKAHEAD = 3;
+// `---` headers are skipped (combined diffs and octopus merges list one
+// source header per parent before the target). Bounded to keep the scan
+// cheap — 4 covers 3-parent octopus merges (`git merge-octopus`).
+const TARGET_HEADER_LOOKAHEAD = 4;
 function findTargetHeader(lines: string[], openerIndex: number): boolean {
   for (
     let j = openerIndex + 1;
@@ -106,7 +102,9 @@ function hasHunkHeader(patch: string[]): boolean {
 }
 
 // A line that is part of a diff body (in-block continuation). Same set as
-// before so existing well-formed diffs still parse unchanged.
+// before so existing well-formed diffs still parse unchanged, with one
+// addition: the `\` prefix is the `git diff` `\ No newline at end of file`
+// marker, which `git apply` requires to avoid "corrupt patch" errors.
 function isBlockBodyLine(line: string): boolean {
   return (
     line.startsWith("+++") ||
@@ -114,6 +112,7 @@ function isBlockBodyLine(line: string): boolean {
     line.startsWith("+") ||
     line.startsWith("-") ||
     line.startsWith(" ") ||
+    line.startsWith("\\") ||
     line.trim() === ""
   );
 }
@@ -141,7 +140,7 @@ export function extractPatches(text: string): string[] {
 
     if (!inPatch) {
       // Tier 1: unambiguous openers — no corroboration needed.
-      if (isDiffStart(line) || isFromEnvelope(line)) {
+      if (isDiffStart(line)) {
         currentPatch = [line];
         inPatch = true;
       } else if (isUnifiedOpener(line) && findTargetHeader(lines, i)) {

--- a/shared/utils/artifactParser.ts
+++ b/shared/utils/artifactParser.ts
@@ -156,7 +156,12 @@ export function extractPatches(text: string): string[] {
     if (isBlockBodyLine(line)) {
       currentPatch.push(line);
     } else {
+      // A non-body line ends the current block. Commit it, then re-process this
+      // same line as a potential opener — back-to-back patches put the 2nd
+      // block's `diff --git ...` header here, and skipping it would drop that
+      // header (the body re-opens on the next `--- a/` line, masking the loss).
       finalize();
+      i--;
     }
   }
 

--- a/shared/utils/artifactParser.ts
+++ b/shared/utils/artifactParser.ts
@@ -27,45 +27,141 @@ export function extractCodeBlocks(text: string): CodeBlock[] {
   return blocks;
 }
 
+// === Patch detection helpers ===
+//
+// `extractPatches` previously opened a block on any `---` line, which meant
+// Markdown horizontal rules, YAML front-matter delimiters, and bulleted lists
+// were emitted as patch artifacts and handed to `git apply` (which rejected
+// them noisily). The helpers below form a three-tier classifier:
+//
+//   Tier 1 — trigger:  `diff --git ...`, `From <sha> ...`, or `--- a/<file>`
+//   Tier 2 — corroborate: a `+++ b/<file>` target header within a few lines
+//                            (only required for the `--- a/<file>` opener;
+//                            `diff --git` and `From <sha>` are unambiguous)
+//   Tier 3 — commit:  at least one `@@` / `@@@` hunk header in the block
+//
+// A block is only emitted when all three tiers are satisfied. Bare `---` and
+// `--- ` (no path) never reach Tier 1, which is what stops the false positives.
+
+// Tier 1 trigger: `diff --git ...`, `diff -u ...`, `diff -Naur ...`,
+// `diff --combined ...`, `diff (GNU patch) ...`, etc.
+function isDiffStart(line: string): boolean {
+  return line.startsWith("diff ");
+}
+
+// Tier 1 trigger: the `git format-patch` envelope header. Default `git
+// format-patch` always uses a full 40-char SHA-1; SHA-256 (64 hex chars) is
+// also accepted.
+const FROM_ENVELOPE_REGEX = /^From [0-9a-f]{40,}\b/;
+function isFromEnvelope(line: string): boolean {
+  return FROM_ENVELOPE_REGEX.test(line);
+}
+
+// Tier 1 trigger (with corroboration): a `--- a/<file>` source header.
+// Bare `---` (Markdown HR, YAML front-matter) does NOT match — it needs
+// whitespace AND a non-whitespace token after the `--- `.
+const UNIFIED_OPENER_REGEX = /^---\s+\S/;
+function isUnifiedOpener(line: string): boolean {
+  return UNIFIED_OPENER_REGEX.test(line);
+}
+
+// The `+++ b/<file>` target header that must corroborate a `--- a/<file>`
+// opener. The path prefix is not enforced (`git diff --no-prefix` omits `b/`).
+const TARGET_HEADER_REGEX = /^\+\+\+\s+\S/;
+function isTargetHeader(line: string): boolean {
+  return TARGET_HEADER_REGEX.test(line);
+}
+
+// Walk forward from a `--- a/<file>` opener and confirm a `+++ b/<file>`
+// target header appears in the next few lines. Blank lines and additional
+// `---` headers are skipped (combined diffs list one source header per
+// parent before the target). Bounded to keep the scan cheap.
+const TARGET_HEADER_LOOKAHEAD = 3;
+function findTargetHeader(lines: string[], openerIndex: number): boolean {
+  for (
+    let j = openerIndex + 1;
+    j < lines.length && j <= openerIndex + TARGET_HEADER_LOOKAHEAD;
+    j++
+  ) {
+    const line = lines[j]!;
+    if (line.trim() === "") continue;
+    // Combined diffs have multiple `--- a/<parent>` headers before the
+    // target; tolerate them.
+    if (line.startsWith("---")) continue;
+    return isTargetHeader(line);
+  }
+  return false;
+}
+
+// Real hunk header: `@@ -N +M @@` or combined `@@@ -A,B -C,D +E,F @@@`.
+// Anchored at line start, requires whitespace and a `-<digits>` after the
+// run of `@`s so prose like `@@user` and `@@@handle` are rejected.
+const HUNK_HEADER_REGEX = /^@@@*\s+-\d+/;
+function isHunkHeader(line: string): boolean {
+  return HUNK_HEADER_REGEX.test(line);
+}
+
+function hasHunkHeader(patch: string[]): boolean {
+  return patch.some(isHunkHeader);
+}
+
+// A line that is part of a diff body (in-block continuation). Same set as
+// before so existing well-formed diffs still parse unchanged.
+function isBlockBodyLine(line: string): boolean {
+  return (
+    line.startsWith("+++") ||
+    line.startsWith("@@") ||
+    line.startsWith("+") ||
+    line.startsWith("-") ||
+    line.startsWith(" ") ||
+    line.trim() === ""
+  );
+}
+
 export function extractPatches(text: string): string[] {
   const patches: string[] = [];
   const lines = text.split("\n");
   let currentPatch: string[] = [];
   let inPatch = false;
 
-  for (const line of lines) {
-    const startsPatch = line.startsWith("diff ") || (!inPatch && line.startsWith("---"));
-    if (startsPatch) {
-      if (inPatch && currentPatch.length > 3) {
-        patches.push(currentPatch.join("\n"));
+  // Commit the in-flight block if it looks like a real diff: long enough AND
+  // contains at least one hunk header. The hunk check is the structural
+  // guarantee that `git apply` will accept the block — anything without `@@`
+  // is prose that happens to share prefixes with a diff.
+  const finalize = () => {
+    if (inPatch && currentPatch.length > 3 && hasHunkHeader(currentPatch)) {
+      patches.push(currentPatch.join("\n"));
+    }
+    currentPatch = [];
+    inPatch = false;
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+
+    if (!inPatch) {
+      // Tier 1: unambiguous openers — no corroboration needed.
+      if (isDiffStart(line) || isFromEnvelope(line)) {
+        currentPatch = [line];
+        inPatch = true;
+      } else if (isUnifiedOpener(line) && findTargetHeader(lines, i)) {
+        // Tier 1 + Tier 2: `--- a/<file>` needs a nearby `+++ b/<file>` to
+        // be promoted to a diff header pair. This is what stops `--- a/x`
+        // prose (Markdown HR with a path-shaped tail) from opening a block.
+        currentPatch = [line];
+        inPatch = true;
       }
-      currentPatch = [line];
-      inPatch = true;
-    } else if (inPatch) {
-      if (
-        line.startsWith("+++") ||
-        line.startsWith("@@") ||
-        line.startsWith("+") ||
-        line.startsWith("-") ||
-        line.startsWith(" ")
-      ) {
-        currentPatch.push(line);
-      } else if (line.trim() === "") {
-        currentPatch.push(line);
-      } else {
-        if (currentPatch.length > 3) {
-          patches.push(currentPatch.join("\n"));
-        }
-        currentPatch = [];
-        inPatch = false;
-      }
+      continue;
+    }
+
+    if (isBlockBodyLine(line)) {
+      currentPatch.push(line);
+    } else {
+      finalize();
     }
   }
 
-  if (inPatch && currentPatch.length > 3) {
-    patches.push(currentPatch.join("\n"));
-  }
-
+  finalize();
   return patches;
 }
 


### PR DESCRIPTION
## Summary

- The patch artifact extractor in `shared/utils/artifactParser.ts` was promoting any `---`-started block to a patch, so Markdown horizontal rules and YAML front-matter were being misdetected as diffs and surfaced with an "Apply patch" affordance that then failed loudly against `git apply`.
- A `---`-started block now needs a corroborating diff marker (`+++` file header or `@@` hunk header) before it can be promoted. Anything else drops out of the extractor.
- Tests cover the no-newline `\ No newline at end of file` marker, multi-block inputs (patch + adjacent prose), and `/dev/null` targets (deletions and new files).

Resolves #9998

## Changes

- `shared/utils/artifactParser.ts`: gate promotion of a `---`-started block on the presence of a corroborating `+++` or `@@` line within the same block.
- `shared/utils/__tests__/artifactParser.test.ts`: positive cases for the corroborating markers, negative cases for Markdown rules and YAML front-matter, plus coverage for `\ No newline at end of file`, multi-block inputs, and `/dev/null` headers.

## Testing

- `npm run check` (typecheck + lint + format + channel/confirm guards) passes.
- Full unit test suite passes locally.