### PR TITLE
fix(panel-registry): rebuild worktree index in reorderTabGroups

### DIFF
--- a/src/store/slices/panelRegistry/__tests__/worktreeIndexInvariant.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/worktreeIndexInvariant.test.ts
@@ -88,6 +88,21 @@ describe("panelIdsByWorktreeId invariant across mutations", () => {
       expect(usePanelStore.getState().panelIdsByWorktreeId["wt-A"]).toEqual(["t3", "t1", "t2"]);
     });
 
+    it("reorderTabGroups updates the bucket order", () => {
+      seedTerminal("t1", "wt-A");
+      seedTerminal("t2", "wt-A");
+      seedTerminal("t3", "wt-A");
+
+      // Explicit groups sort to the front of getTabGroups; the explicit
+      // [t1, t2] tab group lands at index 0, virtual t3 lands at index 1.
+      usePanelStore.getState().createTabGroup("grid", "wt-A", ["t1", "t2"]);
+
+      // Move the virtual t3 group (index 1) to the front of the grid scope.
+      usePanelStore.getState().reorderTabGroups(1, 0, "grid", "wt-A");
+
+      expect(usePanelStore.getState().panelIdsByWorktreeId["wt-A"]).toEqual(["t3", "t1", "t2"]);
+    });
+
     it("moveTerminalToPosition reorders the affected bucket", () => {
       seedTerminal("t1", "wt-A");
       seedTerminal("t2", "wt-A");

--- a/src/store/slices/panelRegistry/tabGroups.ts
+++ b/src/store/slices/panelRegistry/tabGroups.ts
@@ -10,7 +10,7 @@ import { TerminalRefreshTier } from "@/types";
 import { saveNormalized, saveTabGroups } from "./persistence";
 import { optimizeForDock } from "./layout";
 import { deriveRuntimeStatus, dissolvePanelFromGroup } from "./helpers";
-import { NO_WORKTREE, transferBetweenWorktreeIndex } from "./worktreeIndex";
+import { buildWorktreeIndex, NO_WORKTREE, transferBetweenWorktreeIndex } from "./worktreeIndex";
 
 type Set = PanelRegistryStoreApi["setState"];
 type Get = PanelRegistryStoreApi["getState"];
@@ -570,7 +570,12 @@ export const createTabGroupActions = (
             ];
 
       saveNormalized(state.panelsById, newIds);
-      return { panelIds: newIds };
+      // Rebuild bucket order so per-worktree selectors observe the new order
+      // (issue #7451). Reorder is user-gesture rate, so a full rebuild is fine.
+      return {
+        panelIds: newIds,
+        panelIdsByWorktreeId: buildWorktreeIndex(newIds, state.panelsById),
+      };
     });
   },
 


### PR DESCRIPTION
## Summary

- `reorderTabGroups` updated `panelIds` but skipped the `panelIdsByWorktreeId` rebuild, so the sidebar worktree terminal lists and the `AgentButton` kept the pre-drag order until an unrelated mutation rebuilt the index.
- Mirrors the canonical sibling pattern in `src/store/slices/panelRegistry/ordering.ts` (`reorderTerminals`, `moveTerminalToPosition`, `restoreTerminalOrder`, all referencing #7451).
- Adds a regression test under the existing `describe('ordering operations')` block in `worktreeIndexInvariant.test.ts`.

Resolves #9939

## Changes

- `src/store/slices/panelRegistry/tabGroups.ts`: add `buildWorktreeIndex(newIds, state.panelsById)` to the final return of `reorderTabGroups`.
- `src/store/slices/panelRegistry/__tests__/worktreeIndexInvariant.test.ts`: regression test asserting the worktree index reflects the new order immediately after `reorderTabGroups`.

## Testing

- Local CI: static tier (typecheck, lint, format, IPC/confirm-wiring guards) PASS.
- Targeted panel-registry tests PASS (302/302).
- Full test tier has 154 pre-existing environmental failures in unrelated `electron/services` and `electron/lifecycle` files on `develop`; not introduced by this change.
- Manual repro: drag a tab group across the grid or dock, confirm the sidebar worktree terminal list and the agent button reflect the new order without requiring an unrelated mutation.