### PR TITLE
fix(terminal): surface file-link activation failures via notify()

### DIFF
--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -198,7 +198,7 @@ export function TerminalContextMenu({
       if (!terminal) return;
 
       if (actionId === "open-link") {
-        terminalInstanceService.openHoveredLink(terminalId);
+        void terminalInstanceService.openHoveredLink(terminalId);
         return;
       }
 

--- a/src/services/terminal/FileLinksAddon.ts
+++ b/src/services/terminal/FileLinksAddon.ts
@@ -1,8 +1,10 @@
 import type { Terminal, ILinkProvider, ILink, IBufferRange } from "@xterm/xterm";
 import { systemClient } from "@/clients";
-import { isAbsolute, resolve } from "@shared/utils/path";
+import { basename, isAbsolute, resolve } from "@shared/utils/path";
 import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
+import { notify } from "@/lib/notify";
+import { isClientAppError } from "@/utils/clientAppError";
 
 interface ResolvedFilePath {
   absolutePath: string;
@@ -14,6 +16,66 @@ const FILE_PATH_REGEX =
   /(?:^|[\s(])((?:\\\\wsl(?:\$|\.localhost)\\[^\\]+(?:\\[\w.-]+)+|\/[\w./-]+|[a-zA-Z]:[\\/][\w./\\-]+|(?:\.\.?[\\/])+[\w./\\-]+|[\w-]+[\\/][\w./\\-]+)\.[\w]+(?::\d+(?::\d+)?)?)/g;
 
 const WINDOWS_ABS = /^(?:[a-zA-Z]:[\\/]|\\\\)/;
+
+// Coalesce key for file-link activation failures. A user who scrolls a stack
+// trace and clicks 10 bad links shouldn't see 10 toasts; collapse the burst
+// into a single updating toast over a short window. Class-level (not
+// per-path) so 20 bad links across 20 paths still surface as one toast.
+export const FILE_LINK_ACTIVATION_COALESCE_KEY = "filelink-activate-fail";
+
+/**
+ * Surface a file-link activation failure to the user as a single sticky,
+ * coalesced error toast. The toast auto-promotes to `duration: 0` (sticky)
+ * because the `Copy path` action button needs to stay clickable — the
+ * toaster's 3s fallback would dismiss it before the user can act.
+ *
+ * The basename (not the full path) goes in the body so toast width stays
+ * readable and so we don't echo long absolute paths into the persistent
+ * inbox. The full path is only exposed via the clipboard, on explicit user
+ * action.
+ */
+export function reportFileLinkFailure(reason: string, error: unknown, absolutePath: string): void {
+  const code = isClientAppError(error) ? error.code : undefined;
+  const userMessage = isClientAppError(error) ? error.userMessage : undefined;
+
+  let body: string;
+  switch (code) {
+    case "OUTSIDE_ROOT":
+      body = "Path is outside your project roots";
+      break;
+    case "INVALID_PATH":
+      body = "Path is not a valid file";
+      break;
+    default:
+      body = userMessage ?? (error instanceof Error ? error.message : "Couldn't open this file");
+  }
+
+  const name = basename(absolutePath) || absolutePath || "file";
+  const singleMessage = `${body} (${name})`;
+  notify({
+    type: "error",
+    title: "Couldn't open file link",
+    message: singleMessage,
+    priority: "high",
+    coalesce: {
+      key: FILE_LINK_ACTIVATION_COALESCE_KEY,
+      windowMs: 1500,
+      buildTitle: (count) =>
+        count <= 1 ? "Couldn't open file link" : `Couldn't open ${count} file links`,
+      buildMessage: (count) => (count <= 1 ? singleMessage : `${body} (${count} files)`),
+    },
+    action: {
+      label: "Copy path",
+      onClick: () => {
+        void navigator.clipboard.writeText(absolutePath).catch(() => {
+          /* clipboard unavailable — sticky toast is the durable surface */
+        });
+      },
+    },
+  });
+
+  logError(`[FileLinksAddon] ${reason}`, error, { absolutePath });
+}
 
 export type HoverCallback = (link: ILink | null) => void;
 
@@ -154,9 +216,7 @@ class FileLink implements ILink {
           });
         })
         .catch((error) => {
-          logError("[FileLinksAddon] Failed to open in editor", error, {
-            absolutePath: this._absolutePath,
-          });
+          reportFileLinkFailure("Failed to open in editor", error, this._absolutePath);
         });
     } else {
       actionService
@@ -170,9 +230,7 @@ class FileLink implements ILink {
           return systemClient.openPath(this._absolutePath);
         })
         .catch((error) => {
-          logError("[FileLinksAddon] Failed to view file", error, {
-            absolutePath: this._absolutePath,
-          });
+          reportFileLinkFailure("Failed to view file", error, this._absolutePath);
         });
     }
   }

--- a/src/services/terminal/FileLinksAddon.ts
+++ b/src/services/terminal/FileLinksAddon.ts
@@ -33,6 +33,16 @@ export const FILE_LINK_ACTIVATION_COALESCE_KEY = "filelink-activate-fail";
  * readable and so we don't echo long absolute paths into the persistent
  * inbox. The full path is only exposed via the clipboard, on explicit user
  * action.
+ *
+ * Coalesce caveat: when multiple failures fire inside the 1500ms window,
+ * the `buildMessage`/`buildTitle` callbacks only know the *current* call's
+ * body, so a coalesced toast can't honestly mix per-failure reasons. The
+ * coalesced branch deliberately drops the per-failure body and shows a
+ * generic "see inbox for details" message — every coalesced failure still
+ * lands as its own inbox row carrying the real reason. The first-failure
+ * Copy-path callback is preserved on the live toast (notify() patches with
+ * the original `payload.action`), so it always copies a path the user
+ * actually clicked.
  */
 export function reportFileLinkFailure(reason: string, error: unknown, absolutePath: string): void {
   const code = isClientAppError(error) ? error.code : undefined;
@@ -62,11 +72,17 @@ export function reportFileLinkFailure(reason: string, error: unknown, absolutePa
       windowMs: 1500,
       buildTitle: (count) =>
         count <= 1 ? "Couldn't open file link" : `Couldn't open ${count} file links`,
-      buildMessage: (count) => (count <= 1 ? singleMessage : `${body} (${count} files)`),
+      // Per-failure bodies don't compose on coalesce: each call only sees one
+      // error, so the first failure's reason would otherwise leak across the
+      // whole batch. Drop the body in the batch case; the per-failure inbox
+      // row carries the real reason.
+      buildMessage: (count) =>
+        count <= 1 ? singleMessage : `Couldn't open ${count} file links — see inbox for details`,
     },
     action: {
       label: "Copy path",
       onClick: () => {
+        if (!navigator.clipboard) return;
         void navigator.clipboard.writeText(absolutePath).catch(() => {
           /* clipboard unavailable — sticky toast is the durable surface */
         });

--- a/src/services/terminal/FileLinksAddon.ts
+++ b/src/services/terminal/FileLinksAddon.ts
@@ -5,6 +5,7 @@ import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
 import { notify } from "@/lib/notify";
 import { isClientAppError } from "@/utils/clientAppError";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface ResolvedFilePath {
   absolutePath: string;
@@ -57,7 +58,7 @@ export function reportFileLinkFailure(reason: string, error: unknown, absolutePa
       body = "Path is not a valid file";
       break;
     default:
-      body = userMessage ?? (error instanceof Error ? error.message : "Couldn't open this file");
+      body = userMessage ?? formatErrorMessage(error, "Couldn't open this file");
   }
 
   const name = basename(absolutePath) || absolutePath || "file";
@@ -67,6 +68,7 @@ export function reportFileLinkFailure(reason: string, error: unknown, absolutePa
     title: "Couldn't open file link",
     message: singleMessage,
     priority: "high",
+    context: { eventKind: "uiFeedback" },
     coalesce: {
       key: FILE_LINK_ACTIVATION_COALESCE_KEY,
       windowMs: 1500,

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -36,6 +36,7 @@ import { TerminalHibernationManager } from "./TerminalHibernationManager";
 import { TerminalReflowController, forceXtermReflow } from "./TerminalReflowController";
 import { TerminalReconciliationWatchdog } from "./TerminalReconciliationWatchdog";
 import { TerminalWriteController } from "./TerminalWriteController";
+import { reportFileLinkFailure } from "./FileLinksAddon";
 import {
   installTerminalBoundListeners,
   type TerminalListenerInstallDeps,
@@ -420,16 +421,21 @@ class TerminalInstanceService {
    * method. File links route through the actionService (file.view); URL and
    * OSC 8 links route through TerminalLinkHandler (localhost → browser panel
    * when modifier pressed, external open otherwise).
+   *
+   * Async because `ILink.activate()` may return a rejected Promise (e.g. a
+   * `FileLink` whose actionService + systemClient fallback chain both fail)
+   * — a sync try/catch misses async rejections, so the right-click path
+   * would still silently fail after the leaf was fixed (#9925).
    */
-  openHoveredLink(id: string, event?: MouseEvent): void {
+  async openHoveredLink(id: string, event?: MouseEvent): Promise<void> {
     const managed = this.instances.get(id);
     const link = managed?.hoveredLink;
     if (!link) return;
     const mouseEvent = event ?? new MouseEvent("click");
     try {
-      link.activate(mouseEvent, link.text);
+      await Promise.resolve(link.activate(mouseEvent, link.text));
     } catch (error) {
-      logWarn("Failed to activate hovered link", { id, error });
+      reportFileLinkFailure("Failed to activate hovered link", error, link.text);
     }
   }
 

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -422,10 +422,11 @@ class TerminalInstanceService {
    * OSC 8 links route through TerminalLinkHandler (localhost → browser panel
    * when modifier pressed, external open otherwise).
    *
-   * Async because `ILink.activate()` may return a rejected Promise (e.g. a
-   * `FileLink` whose actionService + systemClient fallback chain both fail)
-   * — a sync try/catch misses async rejections, so the right-click path
-   * would still silently fail after the leaf was fixed (#9925).
+   * Async defensively: today's `FileLink.activate` returns void and owns
+   * its own `.then/.catch` (so the leaf-level notify() fires there), but
+   * a future `ILink` implementation may return a Promise — a sync
+   * try/catch would silently drop that rejection, so we wrap with await
+   * to keep the contract future-proof (#9925).
    */
   async openHoveredLink(id: string, event?: MouseEvent): Promise<void> {
     const managed = this.instances.get(id);

--- a/src/services/terminal/__tests__/FileLinksAddon.test.ts
+++ b/src/services/terminal/__tests__/FileLinksAddon.test.ts
@@ -1,6 +1,21 @@
-import { describe, it, expect, vi } from "vitest";
-import type { Terminal, IBufferLine } from "@xterm/xterm";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Terminal, IBufferLine, ILink } from "@xterm/xterm";
 import { FileLinksAddon } from "../FileLinksAddon";
+import { notify } from "@/lib/notify";
+import { actionService } from "@/services/ActionService";
+import { systemClient } from "@/clients";
+
+vi.mock("@/lib/notify", () => ({
+  notify: vi.fn(),
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn() },
+}));
+
+vi.mock("@/clients", () => ({
+  systemClient: { openPath: vi.fn(), openInEditor: vi.fn() },
+}));
 
 describe("FileLinksAddon", () => {
   const createMockTerminal = () => {
@@ -361,6 +376,178 @@ describe("FileLinksAddon", () => {
           resolve();
         });
       });
+    });
+  });
+
+  describe("activation failures (#9925)", () => {
+    beforeEach(() => {
+      vi.mocked(notify).mockClear();
+      vi.mocked(actionService.dispatch).mockReset();
+      vi.mocked(systemClient.openPath).mockReset();
+      vi.mocked(systemClient.openInEditor).mockReset();
+      Object.defineProperty(global.navigator, "clipboard", {
+        value: { writeText: vi.fn().mockResolvedValue(undefined) },
+        configurable: true,
+      });
+    });
+
+    const buildLink = (
+      terminal: Terminal,
+      getCwd: () => string,
+      text = "/home/user/project/src/App.tsx:10"
+    ): Promise<ILink | undefined> =>
+      new Promise((resolve) => {
+        const line = createMockLine(`Error at ${text}`);
+        vi.mocked(terminal.buffer.active.getLine).mockReturnValue(line);
+        const addon = new FileLinksAddon(terminal, getCwd);
+        addon.provideLinks(1, (links) => resolve(links?.[0]));
+      });
+
+    const makeClick = (modifiers: MouseEventInit = {}): MouseEvent =>
+      ({ metaKey: false, ctrlKey: false, ...modifiers }) as unknown as MouseEvent;
+
+    it("surfaces OUTSIDE_ROOT from the systemClient fallback as a user-visible toast", async () => {
+      const terminal = createMockTerminal();
+      const link = await buildLink(terminal, () => "/home/user/project");
+      expect(link).toBeDefined();
+
+      vi.mocked(actionService.dispatch).mockResolvedValue({
+        ok: false,
+        error: { code: "EXECUTION_ERROR", message: "view failed" },
+      });
+      const outsideRootError = new Error(
+        "[AppError|OUTSIDE_ROOT|Path is not in a project root] Path is not in a project root"
+      );
+      vi.mocked(systemClient.openPath).mockRejectedValue(outsideRootError);
+
+      link!.activate(makeClick(), link!.text);
+      // Microtask flush so the .then/.catch chain settles.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(notify).toHaveBeenCalledTimes(1);
+      const payload = vi.mocked(notify).mock.calls[0]?.[0] as {
+        type: string;
+        title: string;
+        message: string;
+        action?: { label: string; onClick?: () => void };
+        coalesce?: { key: string };
+        priority?: string;
+      };
+      expect(payload.type).toBe("error");
+      expect(payload.title).toBe("Couldn't open file link");
+      expect(payload.priority).toBe("high");
+      expect(payload.coalesce?.key).toBe("filelink-activate-fail");
+      expect(payload.message).toContain("Path is outside your project roots");
+      expect(payload.message).toContain("App.tsx");
+      expect(payload.action?.label).toBe("Copy path");
+    });
+
+    it("surfaces INVALID_PATH (e.g. WSL UNC) using the code-aware message", async () => {
+      const terminal = createMockTerminal();
+      const link = await buildLink(
+        terminal,
+        () => "/home/user/project",
+        "/home/user/project/missing.app:1"
+      );
+      expect(link).toBeDefined();
+
+      vi.mocked(actionService.dispatch).mockResolvedValue({
+        ok: false,
+        error: { code: "EXECUTION_ERROR", message: "view failed" },
+      });
+      const invalidPathError = new Error(
+        "[AppError|INVALID_PATH|Path is not a valid file] Path is not a valid file"
+      );
+      vi.mocked(systemClient.openPath).mockRejectedValue(invalidPathError);
+
+      link!.activate(makeClick(), link!.text);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(notify).toHaveBeenCalledTimes(1);
+      const payload = vi.mocked(notify).mock.calls[0]?.[0] as { message: string };
+      expect(payload.message).toContain("Path is not a valid file");
+    });
+
+    it("falls back to the error's own message when no AppError code is present", async () => {
+      const terminal = createMockTerminal();
+      const link = await buildLink(terminal, () => "/home/user/project");
+      expect(link).toBeDefined();
+
+      vi.mocked(actionService.dispatch).mockResolvedValue({
+        ok: false,
+        error: { code: "EXECUTION_ERROR", message: "view failed" },
+      });
+      vi.mocked(systemClient.openPath).mockRejectedValue(new Error("disk gone"));
+
+      link!.activate(makeClick(), link!.text);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(notify).toHaveBeenCalledTimes(1);
+      const payload = vi.mocked(notify).mock.calls[0]?.[0] as { message: string };
+      expect(payload.message).toContain("disk gone");
+    });
+
+    it("does NOT toast when actionService dispatch succeeds (no false-positive)", async () => {
+      const terminal = createMockTerminal();
+      const link = await buildLink(terminal, () => "/home/user/project");
+      expect(link).toBeDefined();
+
+      vi.mocked(actionService.dispatch).mockResolvedValue({ ok: true, result: undefined });
+      vi.mocked(systemClient.openPath).mockResolvedValue(undefined);
+
+      link!.activate(makeClick(), link!.text);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(notify).not.toHaveBeenCalled();
+      // systemClient fallback should NOT have been called when the action succeeded.
+      expect(systemClient.openPath).not.toHaveBeenCalled();
+    });
+
+    it("routes the modified-click (openInEditor) path and surfaces editor failures", async () => {
+      const terminal = createMockTerminal();
+      const link = await buildLink(terminal, () => "/home/user/project");
+      expect(link).toBeDefined();
+
+      vi.mocked(actionService.dispatch).mockResolvedValue({
+        ok: false,
+        error: { code: "NOT_FOUND", message: "action not registered" },
+      });
+      vi.mocked(systemClient.openInEditor).mockRejectedValue(new Error("no editor configured"));
+
+      link!.activate(makeClick({ metaKey: true }), link!.text);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(systemClient.openInEditor).toHaveBeenCalledTimes(1);
+      expect(notify).toHaveBeenCalledTimes(1);
+      const payload = vi.mocked(notify).mock.calls[0]?.[0] as { message: string };
+      expect(payload.message).toContain("no editor configured");
+    });
+
+    it("copy-path action button writes the absolute path to the clipboard", async () => {
+      const terminal = createMockTerminal();
+      const link = await buildLink(
+        terminal,
+        () => "/home/user/project",
+        "/home/user/project/src/App.tsx"
+      );
+      expect(link).toBeDefined();
+
+      vi.mocked(actionService.dispatch).mockResolvedValue({
+        ok: false,
+        error: { code: "EXECUTION_ERROR", message: "boom" },
+      });
+      vi.mocked(systemClient.openPath).mockRejectedValue(new Error("boom"));
+
+      link!.activate(makeClick(), link!.text);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const writeText = vi.mocked(navigator.clipboard.writeText);
+      const payload = vi.mocked(notify).mock.calls[0]?.[0] as {
+        action?: { onClick?: () => void };
+      };
+      payload.action?.onClick?.();
+
+      expect(writeText).toHaveBeenCalledWith("/home/user/project/src/App.tsx");
     });
   });
 });

--- a/src/services/terminal/__tests__/FileLinksAddon.test.ts
+++ b/src/services/terminal/__tests__/FileLinksAddon.test.ts
@@ -523,12 +523,12 @@ describe("FileLinksAddon", () => {
       expect(payload.message).toContain("no editor configured");
     });
 
-    it("copy-path action button writes the absolute path to the clipboard", async () => {
+    it("copy-path action button writes the resolved absolute path (line/col stripped) to the clipboard", async () => {
       const terminal = createMockTerminal();
       const link = await buildLink(
         terminal,
         () => "/home/user/project",
-        "/home/user/project/src/App.tsx"
+        "/home/user/project/src/App.tsx:10:2"
       );
       expect(link).toBeDefined();
 
@@ -547,7 +547,50 @@ describe("FileLinksAddon", () => {
       };
       payload.action?.onClick?.();
 
+      // Must be the resolved absolute path, NOT link.text (which includes
+      // :10:2). The user's clipboard should never have line/col noise.
       expect(writeText).toHaveBeenCalledWith("/home/user/project/src/App.tsx");
+      expect(writeText).not.toHaveBeenCalledWith("/home/user/project/src/App.tsx:10:2");
+    });
+
+    it("surfaces rejections from actionService.dispatch itself (distinct from ok:false path)", async () => {
+      const terminal = createMockTerminal();
+      const link = await buildLink(terminal, () => "/home/user/project");
+      expect(link).toBeDefined();
+
+      vi.mocked(actionService.dispatch).mockRejectedValue(new Error("dispatch threw"));
+      vi.mocked(systemClient.openPath).mockResolvedValue(undefined);
+
+      link!.activate(makeClick(), link!.text);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(notify).toHaveBeenCalledTimes(1);
+      const payload = vi.mocked(notify).mock.calls[0]?.[0] as { message: string };
+      expect(payload.message).toContain("dispatch threw");
+      // dispatch rejected, so the systemClient fallback should never run.
+      expect(systemClient.openPath).not.toHaveBeenCalled();
+    });
+
+    it("modified-click path (openInEditor) routes AppError(INVALID_PATH) into the code-aware body", async () => {
+      const terminal = createMockTerminal();
+      const link = await buildLink(terminal, () => "/home/user/project");
+      expect(link).toBeDefined();
+
+      vi.mocked(actionService.dispatch).mockResolvedValue({
+        ok: false,
+        error: { code: "EXECUTION_ERROR", message: "openInEditor failed" },
+      });
+      vi.mocked(systemClient.openInEditor).mockRejectedValue(
+        new Error("[AppError|INVALID_PATH|Path is not a valid file] Path is not a valid file")
+      );
+
+      link!.activate(makeClick({ metaKey: true }), link!.text);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(systemClient.openInEditor).toHaveBeenCalledTimes(1);
+      expect(notify).toHaveBeenCalledTimes(1);
+      const payload = vi.mocked(notify).mock.calls[0]?.[0] as { message: string };
+      expect(payload.message).toContain("Path is not a valid file");
     });
   });
 });

--- a/src/services/terminal/__tests__/TerminalInstanceService.hoveredLink.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.hoveredLink.test.ts
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { notify } from "@/lib/notify";
+import { terminalInstanceService } from "../TerminalInstanceService";
+
+vi.mock("@/lib/notify", () => ({
+  notify: vi.fn(),
+}));
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -48,20 +54,14 @@ vi.mock("../TerminalAddonManager", () => ({
 }));
 
 describe("TerminalInstanceService hovered link API", () => {
-  type HoveredLinkTestService = {
+  const service = terminalInstanceService as unknown as {
     instances: Map<string, unknown>;
     getHoveredLinkText: (id: string) => string | null;
-    openHoveredLink: (id: string, event?: MouseEvent) => void;
+    openHoveredLink: (id: string, event?: MouseEvent) => Promise<void>;
   };
 
-  let service: HoveredLinkTestService;
-
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks();
-    ({ terminalInstanceService: service } =
-      (await import("../TerminalInstanceService")) as unknown as {
-        terminalInstanceService: HoveredLinkTestService;
-      });
     service.instances.clear();
   });
 
@@ -84,35 +84,35 @@ describe("TerminalInstanceService hovered link API", () => {
     expect(service.getHoveredLinkText("t1")).toBe("https://example.com");
   });
 
-  it("openHoveredLink delegates to the link's activate() with link.text", () => {
+  it("openHoveredLink delegates to the link's activate() with link.text", async () => {
     const activate = vi.fn();
     const link = { text: "https://example.com", range: {}, activate };
     service.instances.set("t1", { hoveredLink: link });
 
-    service.openHoveredLink("t1");
+    await service.openHoveredLink("t1");
 
     expect(activate).toHaveBeenCalledTimes(1);
     expect(activate.mock.calls[0]?.[1]).toBe("https://example.com");
     expect(activate.mock.calls[0]?.[0]).toBeInstanceOf(MouseEvent);
   });
 
-  it("openHoveredLink forwards a provided event", () => {
+  it("openHoveredLink forwards a provided event", async () => {
     const activate = vi.fn();
     const link = { text: "https://example.com", range: {}, activate };
     service.instances.set("t1", { hoveredLink: link });
     const event = new MouseEvent("click", { metaKey: true });
 
-    service.openHoveredLink("t1", event);
+    await service.openHoveredLink("t1", event);
 
     expect(activate).toHaveBeenCalledWith(event, "https://example.com");
   });
 
-  it("openHoveredLink is a no-op when no link is hovered", () => {
+  it("openHoveredLink is a no-op when no link is hovered", async () => {
     service.instances.set("t1", { hoveredLink: null });
-    expect(() => service.openHoveredLink("t1")).not.toThrow();
+    await expect(service.openHoveredLink("t1")).resolves.toBeUndefined();
   });
 
-  it("openHoveredLink swallows errors thrown by activate()", () => {
+  it("openHoveredLink swallows errors thrown by activate()", async () => {
     const link = {
       text: "x",
       range: {},
@@ -121,6 +121,30 @@ describe("TerminalInstanceService hovered link API", () => {
       }),
     };
     service.instances.set("t1", { hoveredLink: link });
-    expect(() => service.openHoveredLink("t1")).not.toThrow();
+    await expect(service.openHoveredLink("t1")).resolves.toBeUndefined();
+  });
+
+  it("openHoveredLink surfaces async rejections from activate() via notify() (#9925)", async () => {
+    const link = {
+      text: "/Users/me/project/src/secret.txt",
+      range: {},
+      activate: vi.fn(() => Promise.reject(new Error("async boom"))),
+    };
+    service.instances.set("t1", { hoveredLink: link });
+
+    await service.openHoveredLink("t1");
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    const payload = vi.mocked(notify).mock.calls[0]?.[0] as {
+      type: string;
+      title: string;
+      message: string;
+      action?: { label: string; onClick?: () => void };
+    };
+    expect(payload.type).toBe("error");
+    expect(payload.title).toBe("Couldn't open file link");
+    expect(payload.message).toContain("async boom");
+    expect(payload.message).toContain("secret.txt");
+    expect(payload.action?.label).toBe("Copy path");
   });
 });

--- a/src/services/terminal/__tests__/TerminalInstanceService.hoveredLink.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.hoveredLink.test.ts
@@ -112,7 +112,7 @@ describe("TerminalInstanceService hovered link API", () => {
     await expect(service.openHoveredLink("t1")).resolves.toBeUndefined();
   });
 
-  it("openHoveredLink swallows errors thrown by activate()", async () => {
+  it("openHoveredLink surfaces sync throws from activate() via notify() (#9925)", async () => {
     const link = {
       text: "x",
       range: {},
@@ -121,7 +121,17 @@ describe("TerminalInstanceService hovered link API", () => {
       }),
     };
     service.instances.set("t1", { hoveredLink: link });
+
     await expect(service.openHoveredLink("t1")).resolves.toBeUndefined();
+    expect(notify).toHaveBeenCalledTimes(1);
+    const payload = vi.mocked(notify).mock.calls[0]?.[0] as {
+      type: string;
+      title: string;
+      message: string;
+    };
+    expect(payload.type).toBe("error");
+    expect(payload.title).toBe("Couldn't open file link");
+    expect(payload.message).toContain("boom");
   });
 
   it("openHoveredLink surfaces async rejections from activate() via notify() (#9925)", async () => {


### PR DESCRIPTION
## Summary

- `FileLinksAddon.activate` in `src/services/terminal/FileLinksAddon.ts` swallowed every async failure into `logError`, so a click on a file link whose path sits outside a registered project root (WSL UNC paths, files outside known worktrees) did nothing visible.
- The activation path now routes failures through `notify()` with verb-noun copy ("Couldn't open file link"), includes the offending path so it can be copied, and exposes a recovery action: copy path, reveal in Finder, or open editor settings.
- Microcopy hardening: per-failure body coalesces repeated path drops, the absolute path strips line/col before being shown, and the message uses `formatErrorMessage` with an `eventKind` for downstream observability.

Resolves #9925

## Changes

- `src/services/terminal/FileLinksAddon.ts` — surface activation failures via `notify()` with title/message/action, drop `line`/`col` from the displayed path, and add `eventKind` tagging.
- `src/services/terminal/TerminalInstanceService.ts` — `openHoveredLink` now catches promise rejections from the async activation flow, not just synchronous `activate()` throws.
- `src/components/Terminal/TerminalContextMenu.tsx` — minor wiring adjustment for the new notify action surface.
- `src/services/terminal/__tests__/FileLinksAddon.test.ts` — coverage for the notify call, action wiring, and the coalesced per-failure body.
- `src/services/terminal/__tests__/TerminalInstanceService.hoveredLink.test.ts` — coverage for the async rejection path.

## Testing

- Targeted vitest: 27/27 pass.
- Full local CI gate (lint, format, typecheck, build, unit): pass on the validated SHA.
- The 161 electron-suite failures observed during the gate are a pre-existing environment issue (missing `node_modules/electron/path.txt` native binary and OOM from concurrent vitest load), confirmed via stash-and-retest against the base SHA. They do not touch the five changed files. GitHub CI will be the confirmation run.