### PR TITLE
fix(packages): repair npm-publish metadata for daintree-plugin CLIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22087,7 +22087,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "daintree-plugin": "*"
+        "daintree-plugin": "^0.1.0"
       },
       "bin": {
         "create-daintree-plugin": "dist/create.js"

--- a/packages/create-daintree-plugin/package.json
+++ b/packages/create-daintree-plugin/package.json
@@ -18,7 +18,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "daintree-plugin": "*"
+    "daintree-plugin": "^0.1.0"
   },
   "devDependencies": {
     "tsup": "^8.5.0"

--- a/packages/create-daintree-plugin/package.json
+++ b/packages/create-daintree-plugin/package.json
@@ -15,7 +15,8 @@
   },
   "scripts": {
     "build": "tsup",
-    "typecheck": "tsc --noEmit -p tsconfig.json"
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "prepare": "tsup"
   },
   "dependencies": {
     "daintree-plugin": "^0.1.0"

--- a/packages/daintree-plugin/package.json
+++ b/packages/daintree-plugin/package.json
@@ -8,10 +8,10 @@
     "daintree-plugin": "./dist/cli.js"
   },
   "main": "./dist/index.js",
-  "types": "./src/index.ts",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     }

--- a/packages/daintree-plugin/package.json
+++ b/packages/daintree-plugin/package.json
@@ -24,7 +24,8 @@
   },
   "scripts": {
     "build": "tsup",
-    "typecheck": "tsc --noEmit -p tsconfig.json"
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "prepare": "tsup"
   },
   "dependencies": {
     "@clack/prompts": "^0.11.0",

--- a/packages/daintree-plugin/tsup.config.ts
+++ b/packages/daintree-plugin/tsup.config.ts
@@ -8,10 +8,17 @@ export default defineConfig({
   format: ["esm"],
   target: "node22",
   platform: "node",
-  // No .d.ts emit — create-daintree-plugin resolves daintree-plugin's types via
-  // the package's `exports.types` → `src/index.ts` condition (source), so a
-  // built declaration is unnecessary and avoids a TS6-deprecation build failure.
-  dts: false,
+  // Emit a bundled .d.ts for the published tarball. `resolve: true` follows
+  // the re-export chain from `src/index.ts` and inlines internal types into
+  // a single `dist/index.d.ts`. `ignoreDeprecations: "6.0"` is scoped to the
+  // dts pipeline only: tsup's dts bundler (rollup-plugin-dts) injects a
+  // deprecated `baseUrl` which trips TS5101 under TypeScript 6. The package's
+  // `tsconfig.json` (used by `typecheck`) stays clean. Once TS 7 lands and
+  // tsup catches up, the override becomes removable.
+  dts: {
+    resolve: true,
+    compilerOptions: { ignoreDeprecations: "6.0" },
+  },
   clean: true,
   // `src/cli.ts` carries a `#!/usr/bin/env node` shebang; tsup preserves it and
   // marks the output executable.

--- a/packages/daintree-plugin/tsup.config.ts
+++ b/packages/daintree-plugin/tsup.config.ts
@@ -10,11 +10,13 @@ export default defineConfig({
   platform: "node",
   // Emit a bundled .d.ts for the published tarball. `resolve: true` follows
   // the re-export chain from `src/index.ts` and inlines internal types into
-  // a single `dist/index.d.ts`. `ignoreDeprecations: "6.0"` is scoped to the
-  // dts pipeline only: tsup's dts bundler (rollup-plugin-dts) injects a
-  // deprecated `baseUrl` which trips TS5101 under TypeScript 6. The package's
-  // `tsconfig.json` (used by `typecheck`) stays clean. Once TS 7 lands and
-  // tsup catches up, the override becomes removable.
+  // a single `dist/index.d.ts` — keep `src/index.ts` as the public surface
+  // gate; anything re-exported there ships to consumers. `ignoreDeprecations:
+  // "6.0"` is scoped to the dts pipeline only: tsup's dts bundler
+  // (rollup-plugin-dts) injects a deprecated `baseUrl` which trips TS5101
+  // under TypeScript 6. The package's `tsconfig.json` (used by `typecheck`)
+  // stays clean. Once TS 7 lands and tsup catches up, the override becomes
+  // removable.
   dts: {
     resolve: true,
     compilerOptions: { ignoreDeprecations: "6.0" },


### PR DESCRIPTION
## Summary

- `daintree-plugin` was pointing `types` and `exports["."].types` at `src/index.ts` while only publishing `dist/`, so consumers of the published package got no declarations. tsup now emits `.d.ts` into `dist` and the type pointers are repointed to the dist output.
- `create-daintree-plugin` depended on `daintree-plugin` with a wildcard `*`, which meant `npm create daintree-plugin` would pull whatever the newest published major is at install time, not the version the shim was released against. The range is now bounded with a caret.
- Added a `prepare` script to `daintree-plugin` so the build runs before publish, keeping `dist/` in sync with the source.

Resolves #9884

## Changes

- `packages/daintree-plugin/tsup.config.ts`: enable `dts` emit and write into `dist/`.
- `packages/daintree-plugin/package.json`: repoint `types` and `exports.types` at the dist output, add `prepare` script.
- `packages/create-daintree-plugin/package.json`: pin the `daintree-plugin` dependency to a caret range, add `prepare` script.
- `package-lock.json`: refreshed.

## Testing

- Local CI gate passed: typecheck, lint, format, full test suite, and build all green.
- Verified the published-shape `types` resolution points to a file that lives inside the `files: ["dist"]` allowlist.