### PR TITLE
fix(window): wire help-session revoke into window-close lifecycle

### DIFF
--- a/electron/window/WindowRegistry.ts
+++ b/electron/window/WindowRegistry.ts
@@ -163,6 +163,18 @@ export class WindowRegistry {
 
     ctx.cleanup.dispose();
 
+    // Revoke help-session tokens bound to this closing window so a multi-
+    // window close graceful-kills the PTY and writes a resume id to
+    // PendingHelpHibernationStore — otherwise the orphaned PTY keeps
+    // dispatching MCP calls and the user can't resume (#10053). Mirrors the
+    // eviction-hook wire-up in main.ts; dynamic import breaks the runtime
+    // cycle since HelpSessionService already imports `type { WindowRegistry }`.
+    import("../services/HelpSessionService.js")
+      .then(({ helpSessionService }) => helpSessionService.revokeByWindowId(windowId))
+      .catch((err) => {
+        console.warn("[WindowRegistry] revokeByWindowId failed during unregister:", err);
+      });
+
     this.webContentsIndex.delete(ctx.webContentsId);
     const appViewWcIds = this.appViewWebContentsIds.get(windowId);
     if (appViewWcIds) {

--- a/electron/window/__tests__/WindowRegistry.test.ts
+++ b/electron/window/__tests__/WindowRegistry.test.ts
@@ -637,5 +637,55 @@ describe("WindowRegistry", () => {
       );
       warnSpy.mockRestore();
     });
+
+    it("unregister swallows a synchronous throw from inside the revoke .then callback", async () => {
+      // A sync throw inside a `.then` callback becomes a rejected promise and
+      // lands in `.catch` — but a future refactor to `await` would surface it
+      // synchronously. Pin the current behavior so the warn-and-continue
+      // contract is regression-proof.
+      mockRevokeByWindowId.mockImplementationOnce(() => {
+        throw new Error("sync boom");
+      });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const registry = new WindowRegistry();
+      const win = makeMockWindow(33, 100);
+      registry.register(win);
+
+      expect(() => registry.unregister(33)).not.toThrow();
+
+      await new Promise((r) => setTimeout(r, 0));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[WindowRegistry] revokeByWindowId failed during unregister:",
+        expect.any(Error)
+      );
+      warnSpy.mockRestore();
+    });
+
+    it("two concurrent window closes each fire their own revokeByWindowId with the right windowId", async () => {
+      // Defends against a stale-closure refactor: each close path must
+      // resolve its own windowId, not capture an outer one.
+      const registry = new WindowRegistry();
+      const win1 = makeMockWindow(101, 200);
+      const win2 = makeMockWindow(202, 201);
+      registry.register(win1);
+      registry.register(win2);
+
+      mockRevokeByWindowId.mockClear();
+      registry.unregister(101);
+      await new Promise((r) => setTimeout(r, 0));
+      await Promise.resolve();
+      // After the first chain fully drains, fire the second close.
+      registry.unregister(202);
+      await new Promise((r) => setTimeout(r, 0));
+      await Promise.resolve();
+
+      expect(mockRevokeByWindowId).toHaveBeenCalledTimes(2);
+      expect(mockRevokeByWindowId).toHaveBeenCalledWith(101);
+      expect(mockRevokeByWindowId).toHaveBeenCalledWith(202);
+    });
   });
 });

--- a/electron/window/__tests__/WindowRegistry.test.ts
+++ b/electron/window/__tests__/WindowRegistry.test.ts
@@ -3,6 +3,16 @@ import { WindowRegistry } from "../WindowRegistry.js";
 import { toDisposable } from "../../utils/lifecycle.js";
 import type { BrowserWindow } from "electron";
 
+const { mockRevokeByWindowId } = vi.hoisted(() => ({
+  mockRevokeByWindowId: vi.fn<(windowId: number) => Promise<void>>(),
+}));
+
+vi.mock("../../services/HelpSessionService.js", () => ({
+  helpSessionService: {
+    revokeByWindowId: mockRevokeByWindowId,
+  },
+}));
+
 function makeMockWindow(id: number, webContentsId: number, opts?: { focused?: boolean }) {
   const closedHandlers: Array<() => void> = [];
   const destroyedHandlers: Array<() => void> = [];
@@ -554,6 +564,78 @@ describe("WindowRegistry", () => {
       const ctx2 = registry.register(win2);
       expect(ctx2.abortController.signal.aborted).toBe(false);
       expect(ctx2.abortController).not.toBe(ctx1.abortController);
+    });
+  });
+
+  describe("help-session revoke wire-up (#10053)", () => {
+    it("unregister fires revokeByWindowId for the closing window", async () => {
+      const registry = new WindowRegistry();
+      const win = makeMockWindow(42, 100);
+      registry.register(win);
+
+      mockRevokeByWindowId.mockClear();
+      registry.unregister(42);
+
+      // Wire-up is fire-and-forget: import().then(revokeByWindowId). Wait one
+      // macrotask so the dynamic import resolves + the .then() runs.
+      await new Promise((r) => setTimeout(r, 0));
+      await Promise.resolve();
+
+      expect(mockRevokeByWindowId).toHaveBeenCalledWith(42);
+    });
+
+    it("unregister fires revokeByWindowId when the closed event fires (full lifecycle)", async () => {
+      const registry = new WindowRegistry();
+      const win = makeMockWindow(7, 100);
+      registry.register(win);
+
+      mockRevokeByWindowId.mockClear();
+      win._fireClosed();
+
+      await new Promise((r) => setTimeout(r, 0));
+      await Promise.resolve();
+
+      expect(mockRevokeByWindowId).toHaveBeenCalledWith(7);
+    });
+
+    it("unregister fires revokeByWindowId only once when both closed and destroyed fire (idempotent)", async () => {
+      const registry = new WindowRegistry();
+      const win = makeMockWindow(13, 100);
+      registry.register(win);
+
+      mockRevokeByWindowId.mockClear();
+      win._fireClosed();
+      win._fireDestroyed();
+
+      await new Promise((r) => setTimeout(r, 0));
+      await Promise.resolve();
+
+      // doUnregister's ctx._unregistered guard short-circuits the second
+      // call before the wire-up runs.
+      expect(mockRevokeByWindowId).toHaveBeenCalledTimes(1);
+      expect(mockRevokeByWindowId).toHaveBeenCalledWith(13);
+    });
+
+    it("unregister logs and swallows a revokeByWindowId rejection", async () => {
+      mockRevokeByWindowId.mockRejectedValueOnce(new Error("synthetic revoke failure"));
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const registry = new WindowRegistry();
+      const win = makeMockWindow(99, 100);
+      registry.register(win);
+
+      // Must not throw — the unregister path is the hot shutdown-cleanup path.
+      expect(() => registry.unregister(99)).not.toThrow();
+
+      await new Promise((r) => setTimeout(r, 0));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[WindowRegistry] revokeByWindowId failed during unregister:",
+        expect.any(Error)
+      );
+      warnSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Closing a window with the help panel open now graceful-kills the running agent and captures the resume id into `PendingHelpHibernationStore`, so reopening the project in any window picks the conversation back up instead of starting fresh.
- The wire-up lives in `WindowRegistry.unregister`, right after the existing port teardown, which keeps the window-close cleanup symmetric.
- The shutdown `revokeAll()` path is left alone on purpose: it correctly skips capture to avoid blocking on graceful-kill round-trips during app exit.

Resolves #10053

## Changes

- `electron/window/WindowRegistry.ts`: fire-and-forget `HelpSessionService.revokeByWindowId(windowId)` from `unregister`, using a dynamic import to avoid the runtime cycle (the existing import is `type` only).
- `electron/window/__tests__/WindowRegistry.test.ts`: covers the direct unregister call, the `closed`-event path, `closed`+`destroyed` idempotency, rejection logging/swallowing, a sync throw from inside the revoke `.then` callback, and a two-window close sequence.
- `.github/workflows/ci.yml`: unrelated churn (the merge of the sharded test matrix into the check job landed alongside this branch).

## Testing

- Unit tests in `electron/window/__tests__/WindowRegistry.test.ts` cover the wire-up end to end, including the sync-throw and two-window cases.
- `npm run check` and the full test suite passed locally before push.