### PR TITLE
fix(help): differentiate launch-error CTAs per failure class

### DIFF
--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -1,8 +1,8 @@
 {
-  "count": 1187,
+  "count": 1186,
   "byRule": {
     "@typescript-eslint/no-explicit-any": 54,
-    "@typescript-eslint/no-floating-promises": 91,
+    "@typescript-eslint/no-floating-promises": 90,
     "@typescript-eslint/no-unsafe-type-assertion": 500,
     "no-restricted-imports": 8,
     "no-restricted-syntax": 406,
@@ -11,5 +11,5 @@
     "react-compiler/react-compiler": 16,
     "react-hooks/exhaustive-deps": 40
   },
-  "updatedAt": "2026-06-06T15:03:19.134Z"
+  "updatedAt": "2026-06-07T03:04:01.248Z"
 }

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -60,6 +60,7 @@ const RESIZE_STEP = 10;
 const RESIZE_PAGE_STEP = 50;
 
 const ASSISTANT_DOCS_URL = "https://daintree.org/assistant";
+const ASSISTANT_INSTALLER_URL = "https://daintree.org/download";
 
 interface HelpPanelProps {
   /**
@@ -569,6 +570,18 @@ export function HelpPanel({
     );
   }, []);
 
+  const handleOpenLogs = useCallback(() => {
+    void actionService.dispatch("errors.openLogs", undefined, { source: "user" });
+  }, []);
+
+  const handleOpenInstallerPage = useCallback(() => {
+    void actionService.dispatch(
+      "system.openExternal",
+      { url: ASSISTANT_INSTALLER_URL },
+      { source: "user" }
+    );
+  }, []);
+
   const handleRunAnyway = useCallback(() => {
     controller.runAnyway();
   }, [controller]);
@@ -705,6 +718,8 @@ export function HelpPanel({
           onRetryLaunch={retryLaunch}
           onDismissLaunchError={dismissLaunchError}
           onOpenAssistantSettings={handleOpenSettings}
+          onOpenLogs={handleOpenLogs}
+          onOpenInstallerPage={handleOpenInstallerPage}
         />
         {showTerminal ? (
           isMissingCli && agentId ? (

--- a/src/components/HelpPanel/HelpPanelBanners.tsx
+++ b/src/components/HelpPanel/HelpPanelBanners.tsx
@@ -14,7 +14,38 @@ const LAUNCH_ERROR_BODY: Record<LaunchErrorKind, string> = {
     "Daintree's assistant services didn't start. Check assistant settings, then try again.",
   "mcp-probe-failed": "Daintree's assistant services didn't respond in time. Try again.",
   "spawn-failed": "The agent didn't start. Try again.",
-  "folder-unavailable": "The assistant's files aren't available. Try again.",
+  "folder-unavailable":
+    "Daintree's bundled assistant files are missing. Reinstall Daintree or check the logs.",
+};
+
+// Per-kind recovery surface. `folder-unavailable` is non-retryable: the
+// resolver's module-scope cache returns the same null on retry, so the only
+// honest affordances are the installer page and the error log. `Retry` is
+// kept for the transient kinds (spawn/probe/server). The CTA handler is
+// resolved in the component from this discriminator — no callbacks in the
+// data, so the data stays serializable and easy to assert against.
+type LaunchErrorCtaHandler = "retry" | "settings" | "logs" | "installer";
+
+interface LaunchErrorCta {
+  label: string;
+  handler: LaunchErrorCtaHandler;
+  variant: "primary" | "secondary";
+}
+
+const LAUNCH_ERROR_CTAS: Record<LaunchErrorKind, LaunchErrorCta[]> = {
+  "mcp-server-not-started": [
+    { label: "Retry", handler: "retry", variant: "primary" },
+    { label: "Open settings", handler: "settings", variant: "secondary" },
+  ],
+  "mcp-probe-failed": [
+    { label: "Retry", handler: "retry", variant: "primary" },
+    { label: "Open settings", handler: "settings", variant: "secondary" },
+  ],
+  "spawn-failed": [{ label: "Retry", handler: "retry", variant: "primary" }],
+  "folder-unavailable": [
+    { label: "Open logs", handler: "logs", variant: "secondary" },
+    { label: "Open installer page", handler: "installer", variant: "primary" },
+  ],
 };
 
 interface HelpPanelBannersProps {
@@ -31,6 +62,8 @@ interface HelpPanelBannersProps {
   onRetryLaunch: () => void;
   onDismissLaunchError: () => void;
   onOpenAssistantSettings: () => void;
+  onOpenLogs: () => void;
+  onOpenInstallerPage: () => void;
 }
 
 export function HelpPanelBanners({
@@ -47,6 +80,8 @@ export function HelpPanelBanners({
   onRetryLaunch,
   onDismissLaunchError,
   onOpenAssistantSettings,
+  onOpenLogs,
+  onOpenInstallerPage,
 }: HelpPanelBannersProps) {
   return (
     <>
@@ -208,32 +243,33 @@ export function HelpPanelBanners({
             </button>
           </div>
           <div className="flex items-center gap-2 flex-wrap pl-5">
-            <button
-              type="button"
-              onClick={onRetryLaunch}
-              className={cn(
-                "px-2 py-1 rounded-[var(--radius-sm)] text-xs font-medium",
-                "bg-daintree-text/10 hover:bg-daintree-text/15 text-daintree-text",
-                "transition-colors",
-                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-              )}
-            >
-              Retry
-            </button>
-            {launchError.kind === "mcp-server-not-started" && (
-              <button
-                type="button"
-                onClick={onOpenAssistantSettings}
-                className={cn(
-                  "px-2 py-1 rounded-[var(--radius-sm)] text-xs",
-                  "text-daintree-text/65 hover:text-daintree-text",
-                  "transition-colors",
-                  "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-                )}
-              >
-                Open settings
-              </button>
-            )}
+            {LAUNCH_ERROR_CTAS[launchError.kind].map((cta) => {
+              const onClick =
+                cta.handler === "retry"
+                  ? onRetryLaunch
+                  : cta.handler === "settings"
+                    ? onOpenAssistantSettings
+                    : cta.handler === "logs"
+                      ? onOpenLogs
+                      : onOpenInstallerPage;
+              return (
+                <button
+                  key={cta.label}
+                  type="button"
+                  onClick={onClick}
+                  className={cn(
+                    "px-2 py-1 rounded-[var(--radius-sm)] text-xs",
+                    cta.variant === "primary"
+                      ? "font-medium bg-daintree-text/10 hover:bg-daintree-text/15 text-daintree-text"
+                      : "text-daintree-text/65 hover:text-daintree-text",
+                    "transition-colors",
+                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                  )}
+                >
+                  {cta.label}
+                </button>
+              );
+            })}
           </div>
         </div>
       )}

--- a/src/components/HelpPanel/__tests__/HelpPanelBanners.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanelBanners.test.tsx
@@ -62,10 +62,7 @@ describe("HelpPanelBanners — launch error", () => {
   });
 
   it("shows Open settings for both MCP failure kinds and only those", () => {
-    const kindsWithSettings: LaunchErrorKind[] = [
-      "mcp-server-not-started",
-      "mcp-probe-failed",
-    ];
+    const kindsWithSettings: LaunchErrorKind[] = ["mcp-server-not-started", "mcp-probe-failed"];
     for (const kind of kindsWithSettings) {
       const { queryByText, unmount } = render(
         <HelpPanelBanners {...baseProps()} launchError={{ agentId: "claude", kind }} />
@@ -94,7 +91,8 @@ describe("HelpPanelBanners — launch error", () => {
     expect(queryByText("Retry")).toBeNull();
     expect(getByText("Open logs")).toBeTruthy();
     expect(getByText("Open installer page")).toBeTruthy();
-    const text = getByText("Open logs").closest('[data-testid="help-launch-error-banner"]')?.textContent ?? "";
+    const text =
+      getByText("Open logs").closest('[data-testid="help-launch-error-banner"]')?.textContent ?? "";
     expect(text).not.toMatch(/Try again/i);
   });
 

--- a/src/components/HelpPanel/__tests__/HelpPanelBanners.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanelBanners.test.tsx
@@ -22,6 +22,8 @@ function baseProps() {
     onRetryLaunch: vi.fn(),
     onDismissLaunchError: vi.fn(),
     onOpenAssistantSettings: vi.fn(),
+    onOpenLogs: vi.fn(),
+    onOpenInstallerPage: vi.fn(),
   };
 }
 
@@ -59,22 +61,41 @@ describe("HelpPanelBanners — launch error", () => {
     }
   });
 
-  it("shows the settings shortcut only for the server-not-started kind", () => {
-    const { queryByText, rerender } = render(
-      <HelpPanelBanners
-        {...baseProps()}
-        launchError={{ agentId: "claude", kind: "mcp-server-not-started" }}
-      />
-    );
-    expect(queryByText("Open settings")).toBeTruthy();
+  it("shows Open settings for both MCP failure kinds and only those", () => {
+    const kindsWithSettings: LaunchErrorKind[] = [
+      "mcp-server-not-started",
+      "mcp-probe-failed",
+    ];
+    for (const kind of kindsWithSettings) {
+      const { queryByText, unmount } = render(
+        <HelpPanelBanners {...baseProps()} launchError={{ agentId: "claude", kind }} />
+      );
+      expect(queryByText("Open settings")).toBeTruthy();
+      unmount();
+    }
 
-    rerender(
+    const kindsWithoutSettings: LaunchErrorKind[] = ["spawn-failed", "folder-unavailable"];
+    for (const kind of kindsWithoutSettings) {
+      const { queryByText, unmount } = render(
+        <HelpPanelBanners {...baseProps()} launchError={{ agentId: "claude", kind }} />
+      );
+      expect(queryByText("Open settings")).toBeNull();
+      unmount();
+    }
+  });
+
+  it("omits Retry for folder-unavailable and offers Open logs + Open installer page", () => {
+    const { queryByText, getByText } = render(
       <HelpPanelBanners
         {...baseProps()}
-        launchError={{ agentId: "claude", kind: "spawn-failed" }}
+        launchError={{ agentId: "claude", kind: "folder-unavailable" }}
       />
     );
-    expect(queryByText("Open settings")).toBeNull();
+    expect(queryByText("Retry")).toBeNull();
+    expect(getByText("Open logs")).toBeTruthy();
+    expect(getByText("Open installer page")).toBeTruthy();
+    const text = getByText("Open logs").closest('[data-testid="help-launch-error-banner"]')?.textContent ?? "";
+    expect(text).not.toMatch(/Try again/i);
   });
 
   it("wires Retry and dismiss to their handlers", () => {
@@ -94,6 +115,40 @@ describe("HelpPanelBanners — launch error", () => {
 
     fireEvent.click(getByLabelText("Dismiss launch error"));
     expect(onDismissLaunchError).toHaveBeenCalledTimes(1);
+  });
+
+  it("wires the mcp-probe-failed Open settings button to its handler", () => {
+    const onOpenAssistantSettings = vi.fn();
+    const { getByText } = render(
+      <HelpPanelBanners
+        {...baseProps()}
+        launchError={{ agentId: "claude", kind: "mcp-probe-failed" }}
+        onOpenAssistantSettings={onOpenAssistantSettings}
+      />
+    );
+    fireEvent.click(getByText("Open settings"));
+    expect(onOpenAssistantSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it("wires the folder-unavailable Open logs and Open installer page buttons", () => {
+    const onOpenLogs = vi.fn();
+    const onOpenInstallerPage = vi.fn();
+    const onRetryLaunch = vi.fn();
+    const { getByText, queryByText } = render(
+      <HelpPanelBanners
+        {...baseProps()}
+        launchError={{ agentId: "claude", kind: "folder-unavailable" }}
+        onRetryLaunch={onRetryLaunch}
+        onOpenLogs={onOpenLogs}
+        onOpenInstallerPage={onOpenInstallerPage}
+      />
+    );
+    expect(queryByText("Retry")).toBeNull();
+    fireEvent.click(getByText("Open logs"));
+    expect(onOpenLogs).toHaveBeenCalledTimes(1);
+    fireEvent.click(getByText("Open installer page"));
+    expect(onOpenInstallerPage).toHaveBeenCalledTimes(1);
+    expect(onRetryLaunch).not.toHaveBeenCalled();
   });
 
   it("renders nothing for the launch-error slot when launchError is null", () => {

--- a/src/components/HelpPanel/__tests__/HelpPanelBanners.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanelBanners.test.tsx
@@ -130,6 +130,39 @@ describe("HelpPanelBanners — launch error", () => {
     expect(onOpenAssistantSettings).toHaveBeenCalledTimes(1);
   });
 
+  it("renders the exact CTA matrix per kind (label + variant + order)", () => {
+    const cases: { kind: LaunchErrorKind; labels: string[] }[] = [
+      { kind: "mcp-server-not-started", labels: ["Retry", "Open settings"] },
+      { kind: "mcp-probe-failed", labels: ["Retry", "Open settings"] },
+      { kind: "spawn-failed", labels: ["Retry"] },
+      { kind: "folder-unavailable", labels: ["Open logs", "Open installer page"] },
+    ];
+    for (const { kind, labels } of cases) {
+      const { getByTestId, queryAllByRole, unmount } = render(
+        <HelpPanelBanners {...baseProps()} launchError={{ agentId: "claude", kind }} />
+      );
+      const banner = getByTestId("help-launch-error-banner");
+      const actionRow = banner.querySelector(".flex.items-center.gap-2.flex-wrap.pl-5");
+      expect(actionRow).not.toBeNull();
+      const buttons = Array.from(actionRow!.querySelectorAll("button"));
+      const actualLabels = buttons.map((b) => b.textContent?.trim() ?? "");
+      expect(actualLabels).toEqual(labels);
+      // folder-unavailable: "Open installer page" is the primary CTA, so it
+      // carries the bg-daintree-text/10 fill — keep the visual rank honest.
+      if (kind === "folder-unavailable") {
+        const primary = buttons.find((b) => b.textContent?.trim() === "Open installer page");
+        expect(primary?.className).toMatch(/font-medium/);
+        expect(primary?.className).toMatch(/bg-daintree-text\/10/);
+        const secondary = buttons.find((b) => b.textContent?.trim() === "Open logs");
+        expect(secondary?.className).not.toMatch(/font-medium/);
+      }
+      // Sanity: no orphaned buttons beyond the dismiss × and the CTAs above.
+      const allButtons = queryAllByRole("button");
+      expect(allButtons.length).toBe(labels.length + 1);
+      unmount();
+    }
+  });
+
   it("wires the folder-unavailable Open logs and Open installer page buttons", () => {
     const onOpenLogs = vi.fn();
     const onOpenInstallerPage = vi.fn();

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -431,6 +431,7 @@ function notifyAssistantServicesUnavailable(
 function notifyInstallCorrupted(agentId: string): void {
   const cfg = getAgentConfig(agentId);
   const name = cfg?.name ?? agentId;
+  // eslint-disable-next-line no-restricted-syntax -- notify-event-kind: ok
   notify({
     type: "error",
     title: "Assistant files missing",

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -424,6 +424,32 @@ function notifyAssistantServicesUnavailable(
   });
 }
 
+// Mirrors the `folder-unavailable` banner's primary recovery affordance on
+// the closed-panel toast. Single action keeps parity with the established
+// `notifyAssistantServicesUnavailable` shape; the secondary "Open logs" CTA
+// on the banner is reachable by reopening the panel.
+function notifyInstallCorrupted(agentId: string): void {
+  const cfg = getAgentConfig(agentId);
+  const name = cfg?.name ?? agentId;
+  notify({
+    type: "error",
+    title: "Assistant files missing",
+    message: `Couldn't start ${name}. Daintree's bundled assistant files are missing — reinstall or check the logs.`,
+    action: {
+      label: "Open installer page",
+      actionId: "system.openExternal",
+      actionArgs: { url: "https://daintree.org/download" },
+      onClick: () => {
+        void actionService.dispatch(
+          "system.openExternal",
+          { url: "https://daintree.org/download" },
+          { source: "user" }
+        );
+      },
+    },
+  });
+}
+
 const INITIAL_SNAPSHOT: HelpSessionSnapshot = Object.freeze({
   phase: "idle",
   showResumeBanner: false,
@@ -1031,7 +1057,7 @@ export class HelpSessionController {
     if (kind === "mcp-server-not-started" || kind === "mcp-probe-failed") {
       notifyAssistantServicesUnavailable(kind);
     } else if (kind === "folder-unavailable") {
-      notifyLaunchFailed(agentId, "Help folder is not available.");
+      notifyInstallCorrupted(agentId);
     } else {
       notifyLaunchFailed(agentId, "The agent didn't start. Try again.");
     }

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -859,6 +859,53 @@ describe("HelpSessionController — launch error routing", () => {
     ctrl.stop();
   });
 
+  it("surfaces the folder-unavailable banner when help folder path is null", async () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    primeInputs(ctrl, true);
+    (window.electron.help.getFolderPath as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+
+    ctrl.launch({ agentId: "claude" });
+
+    await vi.waitFor(() => {
+      expect(ctrl.getSnapshot().launchError?.kind).toBe("folder-unavailable");
+    });
+    expect(notify).not.toHaveBeenCalled();
+    ctrl.stop();
+  });
+
+  it("surfaces a folder-unavailable toast with the installer-page action when panel is closed", async () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    primeInputs(ctrl, false);
+    (window.electron.help.getFolderPath as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+
+    ctrl.launch({ agentId: "claude" });
+
+    await vi.waitFor(() => {
+      expect(notify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "error",
+          title: "Assistant files missing",
+          action: expect.objectContaining({
+            label: "Open installer page",
+            actionId: "system.openExternal",
+          }),
+        })
+      );
+    });
+    expect(ctrl.getSnapshot().launchError).toBeNull();
+    // Toast body must not promise a Retry the click can't deliver.
+    const call = (notify as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c) =>
+        typeof c[0] === "object" &&
+        c[0] !== null &&
+        (c[0] as { title?: string }).title === "Assistant files missing"
+    );
+    expect(call?.[0]?.message).not.toMatch(/Try again/i);
+    ctrl.stop();
+  });
+
   it("dismissLaunchError clears the banner", async () => {
     const ctrl = new HelpSessionController();
     ctrl.start();

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -890,19 +890,34 @@ describe("HelpSessionController — launch error routing", () => {
           action: expect.objectContaining({
             label: "Open installer page",
             actionId: "system.openExternal",
+            actionArgs: { url: "https://daintree.org/download" },
           }),
         })
       );
     });
     expect(ctrl.getSnapshot().launchError).toBeNull();
-    // Toast body must not promise a Retry the click can't deliver.
+    // Toast body must not promise a Retry the click can't deliver, and must
+    // keep the same jargon-free contract the banner enforces.
     const call = (notify as ReturnType<typeof vi.fn>).mock.calls.find(
       (c) =>
         typeof c[0] === "object" &&
         c[0] !== null &&
         (c[0] as { title?: string }).title === "Assistant files missing"
     );
-    expect(call?.[0]?.message).not.toMatch(/Try again/i);
+    const payload = call?.[0] as { message: string; action: { onClick: () => void } };
+    expect(payload.message).not.toMatch(/Try again/i);
+    expect(payload.message).not.toMatch(/\bMCP\b/i);
+    expect(payload.message).not.toMatch(/\btoken\b/i);
+    expect(payload.message).not.toMatch(/\bbearer\b/i);
+    // Clicking the toast action must fire the same action the banner's
+    // Open installer page button does — locked to the same URL and source.
+    (actionService.dispatch as ReturnType<typeof vi.fn>).mockClear();
+    payload.action.onClick();
+    expect(actionService.dispatch).toHaveBeenCalledWith(
+      "system.openExternal",
+      { url: "https://daintree.org/download" },
+      { source: "user" }
+    );
     ctrl.stop();
   });
 


### PR DESCRIPTION
## Summary

The launch-error banner in the Daintree Assistant offered a single `Retry` CTA across every failure kind. For `folder-unavailable` (corrupt `help/` bundle, `getHelpFolderPath()` returns null) that CTA was a dead end — the next call to `getHelpFolderPath()` returns null again and the same banner reappears. The body copy ("Try again") implied a transient condition the click could fix. It can't.

This PR replaces the single `Retry` policy with a per-kind CTA matrix:

- `folder-unavailable` gets `Open logs` + `Open installer page`. No `Retry`.
- `mcp-probe-failed` gains `Open settings` for parity with `mcp-server-not-started`.
- `spawn-failed` keeps `Retry`.

A new `notifyInstallCorrupted()` helper mirrors the policy for the closed-panel toast, so users without the help panel open still land on a useful next step.

Resolves #10021

## Changes

- `src/components/HelpPanel/HelpPanelBanners.tsx` — per-kind CTA map; drops `Retry` for `folder-unavailable`; adds `Open settings` to `mcp-probe-failed`.
- `src/components/HelpPanel/HelpPanel.tsx` — wires the new installer-page action target.
- `src/controllers/HelpSessionController.ts` — adds `notifyInstallCorrupted()`; routes closed-panel `folder-unavailable` through it.
- `src/components/HelpPanel/__tests__/HelpPanelBanners.test.tsx` and `src/controllers/__tests__/HelpSessionController.test.ts` — lock the per-kind CTA matrix and the installer-page action.

## Testing

- Full suite: 32085/32085 pass.
- Lint ratchet back to baseline.
- Build clean.
- New tests cover the per-kind CTA matrix and the closed-panel toast routing.