### PR TITLE
fix: keep palettes and dialogs mounted through their exit animation (#9917)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -553,11 +553,9 @@ function AppInner() {
   const shouldMountWorktreePalette = useKeepMounted(worktreePalette.isOpen);
   const shouldMountQuickCreatePalette = useKeepMounted(quickCreatePalette.isOpen);
   const shouldMountPanelPalette = useKeepMounted(panelPalette.isOpen);
-  const shouldMountProjectSwitcherModal = useKeepMounted(isProjectSwitcherModalOpen);
   const shouldMountThemePalette = useKeepMounted(isThemePaletteOpen);
   const shouldMountLogLevelPalette = useKeepMounted(isLogLevelPaletteOpen);
   const shouldMountActionPalette = useKeepMounted(actionPalette.isOpen);
-  const shouldMountWorktreeOverview = useKeepMounted(isWorktreeOverviewOpen);
   const shouldMountCrossDiffDialog = useKeepMounted(crossDiffDialog.isOpen);
   const shouldMountShortcutsDialog = useKeepMounted(isShortcutsOpen);
 
@@ -1104,7 +1102,7 @@ function AppInner() {
               componentName="ProjectSwitcherPalette"
               resetKeys={[Number(isProjectSwitcherModalOpen)]}
             >
-              {shouldMountProjectSwitcherModal && (
+              {isProjectSwitcherModalOpen && (
                 <Suspense fallback={null}>
                   <LazyProjectSwitcherPalette
                     isOpen={isProjectSwitcherModalOpen}
@@ -1245,7 +1243,7 @@ function AppInner() {
               componentName="WorktreeOverviewModal"
               resetKeys={[Number(isWorktreeOverviewOpen)]}
             >
-              {shouldMountWorktreeOverview && (
+              {isWorktreeOverviewOpen && (
                 <Suspense fallback={null}>
                   <LazyWorktreeOverviewModal
                     isOpen={isWorktreeOverviewOpen}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import { useWorktreePalette } from "./hooks/useWorktreePalette";
 import { useQuickCreatePalette } from "./hooks/useQuickCreatePalette";
 import { useDoubleShift } from "./hooks/useDoubleShift";
 import { useProjectMruSwitcher } from "./hooks/useProjectMruSwitcher";
+import { useKeepMounted } from "./hooks/useKeepMounted";
 import { useMcpBridge } from "./hooks/useMcpBridge";
 import { usePluginBridge } from "./hooks/usePluginBridge";
 import { useFileDropGuard } from "./hooks/useFileDropGuard";
@@ -473,6 +474,20 @@ function AppInner() {
   const cloneRepoDialogOpen = useProjectStore((state) => state.cloneRepoDialogOpen);
   const closeCloneRepoDialog = useProjectStore((state) => state.closeCloneRepoDialog);
   const handleCloneSuccess = useProjectStore((state) => state.handleCloneSuccess);
+
+  const shouldMountCreateFolderDialog = useKeepMounted(createFolderDialogOpen);
+  const shouldMountCloneRepoDialog = useKeepMounted(cloneRepoDialogOpen);
+  // GitInitDialog mounts on the directory path (its `directoryPath` prop is
+  // non-nullable), but closeGitInitDialog() clears both `gitInitDialogOpen` and
+  // `gitInitDirectoryPath` in one set(). Latch the last non-null path so the
+  // dialog keeps a valid prop through its exit animation window (#9917). On the
+  // next open the store sets the path before isOpen, so a fresh path wins.
+  const shouldMountGitInitDialog = useKeepMounted(gitInitDialogOpen);
+  const [latchedGitInitPath, setLatchedGitInitPath] = useState<string | null>(null);
+  useEffect(() => {
+    if (gitInitDirectoryPath) setLatchedGitInitPath(gitInitDirectoryPath);
+  }, [gitInitDirectoryPath]);
+  const effectiveGitInitPath = gitInitDirectoryPath ?? latchedGitInitPath;
   const { selectWorktree, activeWorktreeId, focusedWorktreeId } = useWorktreeSelectionStore(
     useShallow((state) => ({
       selectWorktree: state.selectWorktree,
@@ -495,10 +510,7 @@ function AppInner() {
     handleOpenSettingsTab,
     setIsSettingsOpen,
   } = useSettingsDialog();
-  const [hasOpenedSettings, setHasOpenedSettings] = useState(false);
-  useEffect(() => {
-    if (isSettingsOpen) setHasOpenedSettings(true);
-  }, [isSettingsOpen]);
+  const shouldMountSettings = useKeepMounted(isSettingsOpen);
 
   useThemeBrowserSettingsBridge(isSettingsOpen, setIsSettingsOpen);
   const [isShortcutsOpen, setIsShortcutsOpen] = useState(false);
@@ -508,10 +520,7 @@ function AppInner() {
   const isPluginManagerOpen = usePluginManagerStore((s) => s.isOpen);
   // Keep the view mounted after its first open so the plugin list and any
   // pending operation state survive a close/reopen (mirrors SettingsDialog).
-  const [hasOpenedPluginManager, setHasOpenedPluginManager] = useState(false);
-  useEffect(() => {
-    if (isPluginManagerOpen) setHasOpenedPluginManager(true);
-  }, [isPluginManagerOpen]);
+  const shouldMountPluginManager = useKeepMounted(isPluginManagerOpen);
   // Close Settings when the manager opens so the two surfaces don't stack —
   // covers both entry points (the `app.pluginManager` action dispatched from
   // the Plugins settings tab, and the deep-link path below). Mirrors the
@@ -530,6 +539,28 @@ function AppInner() {
     openWorktreeOverview,
     closeWorktreeOverview,
   } = useWorktreeOverview();
+
+  // Keep each palette/dialog mounted after its first open so its exit animation
+  // (driven by useAnimatedPresence) can run — gating directly on `isOpen`
+  // unmounts in the same React commit that flips it false, killing the exit
+  // (#9917). The component still receives `isOpen` and gates its own DOM via
+  // `shouldRender`.
+  const isProjectSwitcherModalOpen =
+    projectSwitcherPalette.isOpen && projectSwitcherPalette.mode === "modal";
+  const shouldMountQuickSwitcher = useKeepMounted(quickSwitcher.isOpen);
+  const shouldMountSendToAgentPalette = useKeepMounted(sendToAgentPalette.isOpen);
+  const shouldMountNewTerminalPalette = useKeepMounted(newTerminalPalette.isOpen);
+  const shouldMountWorktreePalette = useKeepMounted(worktreePalette.isOpen);
+  const shouldMountQuickCreatePalette = useKeepMounted(quickCreatePalette.isOpen);
+  const shouldMountPanelPalette = useKeepMounted(panelPalette.isOpen);
+  const shouldMountProjectSwitcherModal = useKeepMounted(isProjectSwitcherModalOpen);
+  const shouldMountThemePalette = useKeepMounted(isThemePaletteOpen);
+  const shouldMountLogLevelPalette = useKeepMounted(isLogLevelPaletteOpen);
+  const shouldMountActionPalette = useKeepMounted(actionPalette.isOpen);
+  const shouldMountWorktreeOverview = useKeepMounted(isWorktreeOverviewOpen);
+  const shouldMountCrossDiffDialog = useKeepMounted(crossDiffDialog.isOpen);
+  const shouldMountShortcutsDialog = useKeepMounted(isShortcutsOpen);
+
   const onLayoutRender = useRenderProfiler("app-layout", { sampleRate: 0.15 });
   const onContentGridRender = useRenderProfiler("content-grid", { sampleRate: 0.15 });
 
@@ -869,7 +900,7 @@ function AppInner() {
               componentName="QuickSwitcher"
               resetKeys={[Number(quickSwitcher.isOpen)]}
             >
-              {quickSwitcher.isOpen && (
+              {shouldMountQuickSwitcher && (
                 <Suspense fallback={null}>
                   <LazyQuickSwitcher
                     isOpen={quickSwitcher.isOpen}
@@ -894,7 +925,7 @@ function AppInner() {
               componentName="SendToAgentPalette"
               resetKeys={[Number(sendToAgentPalette.isOpen)]}
             >
-              {sendToAgentPalette.isOpen && (
+              {shouldMountSendToAgentPalette && (
                 <Suspense fallback={null}>
                   <LazySendToAgentPalette
                     isOpen={sendToAgentPalette.isOpen}
@@ -917,7 +948,7 @@ function AppInner() {
               componentName="NewTerminalPalette"
               resetKeys={[Number(newTerminalPalette.isOpen)]}
             >
-              {newTerminalPalette.isOpen && (
+              {shouldMountNewTerminalPalette && (
                 <Suspense fallback={null}>
                   <LazyNewTerminalPalette
                     isOpen={newTerminalPalette.isOpen}
@@ -940,7 +971,7 @@ function AppInner() {
               componentName="WorktreePalette"
               resetKeys={[Number(worktreePalette.isOpen)]}
             >
-              {worktreePalette.isOpen && (
+              {shouldMountWorktreePalette && (
                 <Suspense fallback={null}>
                   <LazyWorktreePalette
                     isOpen={worktreePalette.isOpen}
@@ -965,7 +996,7 @@ function AppInner() {
               componentName="QuickCreatePalette"
               resetKeys={[Number(quickCreatePalette.isOpen)]}
             >
-              {quickCreatePalette.isOpen && (
+              {shouldMountQuickCreatePalette && (
                 <Suspense fallback={null}>
                   <LazyQuickCreatePalette palette={quickCreatePalette} />
                 </Suspense>
@@ -976,7 +1007,7 @@ function AppInner() {
               componentName="PanelPalette"
               resetKeys={[Number(panelPalette.isOpen)]}
             >
-              {panelPalette.isOpen && (
+              {shouldMountPanelPalette && (
                 <Suspense fallback={null}>
                   <LazyPanelPalette
                     isOpen={panelPalette.isOpen}
@@ -1071,16 +1102,12 @@ function AppInner() {
             <ErrorBoundary
               variant="component"
               componentName="ProjectSwitcherPalette"
-              resetKeys={[
-                Number(projectSwitcherPalette.isOpen && projectSwitcherPalette.mode === "modal"),
-              ]}
+              resetKeys={[Number(isProjectSwitcherModalOpen)]}
             >
-              {projectSwitcherPalette.isOpen && projectSwitcherPalette.mode === "modal" && (
+              {shouldMountProjectSwitcherModal && (
                 <Suspense fallback={null}>
                   <LazyProjectSwitcherPalette
-                    isOpen={
-                      projectSwitcherPalette.isOpen && projectSwitcherPalette.mode === "modal"
-                    }
+                    isOpen={isProjectSwitcherModalOpen}
                     query={projectSwitcherPalette.query}
                     results={projectSwitcherPalette.results}
                     selectedIndex={projectSwitcherPalette.selectedIndex}
@@ -1161,7 +1188,7 @@ function AppInner() {
               componentName="ThemePalette"
               resetKeys={[Number(isThemePaletteOpen)]}
             >
-              {isThemePaletteOpen && (
+              {shouldMountThemePalette && (
                 <Suspense fallback={null}>
                   <LazyThemePalette isOpen={isThemePaletteOpen} onClose={closeThemePalette} />
                 </Suspense>
@@ -1173,7 +1200,7 @@ function AppInner() {
               componentName="LogLevelPalette"
               resetKeys={[Number(isLogLevelPaletteOpen)]}
             >
-              {isLogLevelPaletteOpen && (
+              {shouldMountLogLevelPalette && (
                 <Suspense fallback={null}>
                   <LazyLogLevelPalette
                     isOpen={isLogLevelPaletteOpen}
@@ -1188,7 +1215,7 @@ function AppInner() {
               componentName="ActionPalette"
               resetKeys={[Number(actionPalette.isOpen)]}
             >
-              {actionPalette.isOpen && (
+              {shouldMountActionPalette && (
                 <Suspense fallback={null}>
                   <LazyActionPalette
                     isOpen={actionPalette.isOpen}
@@ -1218,7 +1245,7 @@ function AppInner() {
               componentName="WorktreeOverviewModal"
               resetKeys={[Number(isWorktreeOverviewOpen)]}
             >
-              {isWorktreeOverviewOpen && (
+              {shouldMountWorktreeOverview && (
                 <Suspense fallback={null}>
                   <LazyWorktreeOverviewModal
                     isOpen={isWorktreeOverviewOpen}
@@ -1245,7 +1272,7 @@ function AppInner() {
               componentName="CrossWorktreeDiff"
               resetKeys={[Number(crossDiffDialog.isOpen)]}
             >
-              {crossDiffDialog.isOpen && (
+              {shouldMountCrossDiffDialog && (
                 <Suspense fallback={null}>
                   <LazyCrossWorktreeDiff
                     isOpen={crossDiffDialog.isOpen}
@@ -1261,7 +1288,7 @@ function AppInner() {
               componentName="SettingsDialog"
               resetKeys={[Number(isSettingsOpen)]}
             >
-              {(isSettingsOpen || hasOpenedSettings) && (
+              {shouldMountSettings && (
                 <Suspense fallback={null}>
                   <LazySettingsDialog
                     isOpen={isSettingsOpen}
@@ -1281,7 +1308,7 @@ function AppInner() {
               componentName="ShortcutReferenceDialog"
               resetKeys={[Number(isShortcutsOpen)]}
             >
-              {isShortcutsOpen && (
+              {shouldMountShortcutsDialog && (
                 <Suspense fallback={null}>
                   <LazyShortcutReferenceDialog
                     isOpen={isShortcutsOpen}
@@ -1297,7 +1324,7 @@ function AppInner() {
               resetKeys={[Number(isPluginManagerOpen)]}
               onError={() => usePluginManagerStore.getState().close()}
             >
-              {(isPluginManagerOpen || hasOpenedPluginManager) && (
+              {shouldMountPluginManager && (
                 <Suspense fallback={null}>
                   <LazyPluginManagerView
                     deepLinkIntent={pluginDeepLink.intent}
@@ -1364,11 +1391,11 @@ function AppInner() {
               componentName="GitInitDialog"
               resetKeys={[Number(gitInitDialogOpen)]}
             >
-              {gitInitDirectoryPath && (
+              {shouldMountGitInitDialog && effectiveGitInitPath && (
                 <Suspense fallback={null}>
                   <LazyGitInitDialog
                     isOpen={gitInitDialogOpen}
-                    directoryPath={gitInitDirectoryPath}
+                    directoryPath={effectiveGitInitPath}
                     onSuccess={handleGitInitSuccess}
                     onCancel={closeGitInitDialog}
                   />
@@ -1381,7 +1408,7 @@ function AppInner() {
               componentName="CreateProjectFolderDialog"
               resetKeys={[Number(createFolderDialogOpen)]}
             >
-              {createFolderDialogOpen && (
+              {shouldMountCreateFolderDialog && (
                 <Suspense fallback={null}>
                   <LazyCreateProjectFolderDialog
                     isOpen={createFolderDialogOpen}
@@ -1396,7 +1423,7 @@ function AppInner() {
               componentName="CloneRepoDialog"
               resetKeys={[Number(cloneRepoDialogOpen)]}
             >
-              {cloneRepoDialogOpen && (
+              {shouldMountCloneRepoDialog && (
                 <Suspense fallback={null}>
                   <LazyCloneRepoDialog
                     isOpen={cloneRepoDialogOpen}

--- a/src/components/ui/SearchablePalette.tsx
+++ b/src/components/ui/SearchablePalette.tsx
@@ -211,6 +211,10 @@ export function SearchablePalette<T>({
     const wasFiltering = prevIsFilteringRef.current;
     prevIsFilteringRef.current = isFiltering;
     if (!wasFiltering || isFiltering) return;
+    // Hosts now keep palettes mounted through their exit animation (#9917), so a
+    // late filter pass can resolve after close — don't announce to a closed,
+    // invisible palette.
+    if (!isOpen) return;
     if (!query.trim()) return;
     const count = results.length;
     const timer = window.setTimeout(() => {
@@ -218,7 +222,7 @@ export function SearchablePalette<T>({
       useAnnouncerStore.getState().announce(message, "polite");
     }, UI_DOHERTY_THRESHOLD);
     return () => window.clearTimeout(timer);
-  }, [isFiltering, query, results.length]);
+  }, [isFiltering, query, results.length, isOpen]);
 
   useEscapeStack(isOpen, () => {
     if (query !== "") {

--- a/src/hooks/__tests__/useKeepMounted.test.tsx
+++ b/src/hooks/__tests__/useKeepMounted.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useKeepMounted } from "../useKeepMounted";
+
+describe("useKeepMounted", () => {
+  it("starts unmounted when never opened", () => {
+    const { result } = renderHook(({ isOpen }) => useKeepMounted(isOpen), {
+      initialProps: { isOpen: false },
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("mounts while open", () => {
+    const { result } = renderHook(({ isOpen }) => useKeepMounted(isOpen), {
+      initialProps: { isOpen: true },
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it("stays mounted after closing so the exit animation can run", () => {
+    const { result, rerender } = renderHook(({ isOpen }) => useKeepMounted(isOpen), {
+      initialProps: { isOpen: false },
+    });
+    expect(result.current).toBe(false);
+
+    rerender({ isOpen: true });
+    expect(result.current).toBe(true);
+
+    // The whole point: closing must NOT collapse the mount in the same render.
+    rerender({ isOpen: false });
+    expect(result.current).toBe(true);
+  });
+
+  it("remains mounted across repeated open/close cycles", () => {
+    const { result, rerender } = renderHook(({ isOpen }) => useKeepMounted(isOpen), {
+      initialProps: { isOpen: true },
+    });
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      rerender({ isOpen: false });
+      expect(result.current).toBe(true);
+      rerender({ isOpen: true });
+      expect(result.current).toBe(true);
+    }
+  });
+});

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -136,3 +136,5 @@ export { useResizeObserverRaf } from "./useResizeObserverRaf";
 export { useConnectivity, useConnectivitySnapshot } from "./useConnectivity";
 
 export { useImageError } from "./useImageError";
+
+export { useKeepMounted } from "./useKeepMounted";

--- a/src/hooks/useKeepMounted.ts
+++ b/src/hooks/useKeepMounted.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Keeps a conditionally-rendered component mounted after its first open so exit
+ * animations can run. Hosts that gate on `{isOpen && <Comp />}` unmount in the
+ * same React commit that flips `isOpen` to false, which kills any exit
+ * transition driven by `useAnimatedPresence` (the closed render never happens).
+ *
+ * Latches `true` on the first open and never resets, so `(isOpen || hasOpened)`
+ * stays mounted for the lifetime of the host. The component's own
+ * `useAnimatedPresence`/`shouldRender` gate handles DOM removal once the exit
+ * animation completes. Pass `isOpen` through to the component unchanged.
+ */
+export function useKeepMounted(isOpen: boolean): boolean {
+  const [hasOpened, setHasOpened] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) setHasOpened(true);
+  }, [isOpen]);
+
+  return isOpen || hasOpened;
+}


### PR DESCRIPTION
## Summary

- Palettes and dialogs in `src/App.tsx` were conditionally mounted via boolean short-circuit, so they unmounted in the same React commit that set `isOpen` to false — `useAnimatedPresence` never saw the close and the exit phase never ran.
- New `useKeepMounted(isOpen)` hook latches `true` on first open and never resets, applied to all conditionally-mounted palettes and dialogs that use `useAnimatedPresence`. The component still receives `isOpen` and gates its own DOM via `shouldRender`.
- `SettingsDialog` and `PluginManagerView` migrated from ad-hoc latches to the shared hook; `GitInitDialog` gets a latched `directoryPath` because the store clears both path and `isOpen` in one `set()` call.

Resolves #9917

## Changes

- `src/hooks/useKeepMounted.ts` — new hook; exported from `src/hooks/index.ts`
- `src/App.tsx` — `useKeepMounted` applied to all palettes/dialogs that use `useAnimatedPresence`
- `src/components/ui/SearchablePalette.tsx` — result-count announcer gated on `isOpen` so kept-mounted palettes don't announce while closed
- `WorktreeOverviewModal` and `ProjectSwitcherPalette` deliberately excluded: they use CSS-only entry with no `useAnimatedPresence`, and keep-mounting them broke `selectedIds` reset
- Constraints honored: `lazy()` + `Suspense fallback={null}` preserved, no `display:none` / `Activity` wrapper, `ErrorBoundary` `resetKeys` untouched, no new dependencies
- `src/hooks/__tests__/useKeepMounted.test.tsx` — behavioral unit tests for the hook

## Testing

- Unit tests added for `useKeepMounted` covering latch-on-open, never-reset, and initial-false behavior
- Manually verified exit animations play on command palette, settings dialog, and plugin manager
- Confirmed `WorktreeOverviewModal` `selectedIds` still resets correctly on close