### PR TITLE
fix(demo): waitForIdle waits for terminal output and video playback (#10144)

### DIFF
--- a/.claude/skills/demo-video-creator/SKILL.md
+++ b/.claude/skills/demo-video-creator/SKILL.md
@@ -51,7 +51,7 @@ All calls return promises that resolve when the command's renderer round-trip co
 - **Captions:** `annotate(selector, text, placement?, size?, id?)` → returns `{ id }`. `dismissAnnotation(id?)` (omit id = clear all; 200ms fades both ways).
   - **placement:** element-anchored `top|bottom|left|right`; viewport `screen-bottom` (subtitle — the default for narration), `screen-top`, `screen-center`, `lower-third-left|right`, `top-left|top-right|bottom-left|bottom-right`; cursor `above-cursor|below-cursor`. For viewport/cursor placements pass `""` as the selector.
   - **size:** `sm|md|lg|xl` (resolved as % of frame height so it scales 1080p↔4K). Default `md`; subtitles read well at `lg`.
-- **Timing/util:** `sleep(ms)`, `waitForSelector(selector, timeoutMs?)`, `waitForIdle(settleMs?, timeoutMs?)`, `pause()`/`resume()`, `screenshot()`.
+- **Timing/util:** `sleep(ms)`, `waitForSelector(selector, timeoutMs?)`, `waitForIdle(settleMs?, timeoutMs?)`, `pause()`/`resume()`, `screenshot()`. `waitForIdle` settles only once **all** activity channels are simultaneously quiet for `settleMs` — CSS/WAAPI animations, DOM mutations, **xterm terminal output** (subscribed via each live terminal's `onWriteParsed`), and **`<video>` playback** (a playing video blocks idle until it pauses/ends). It returns early at `timeoutMs` regardless. Safe to use right after `typeInTerminal` to wait for a command's output to drain.
 - **Capture:** `startCapture({ outputPath, fps?, videoBitsPerSecond?, width?, height? })`, `stopCapture()` → `{ outputPath, frameCount }`, `getCaptureStatus()`. `outputPath` is a **main-process** filesystem path; the main process mkdirs its dirname.
 
 ## Quality / resolution knobs (env, read by the spec)

--- a/src/components/Demo/DemoCursor.tsx
+++ b/src/components/Demo/DemoCursor.tsx
@@ -1018,6 +1018,10 @@ export function DemoCursor() {
             const start = performance.now();
             let timer: ReturnType<typeof setTimeout>;
             let cleaned = false;
+            // The settle confirmation runs across a double-rAF gap. Any activity
+            // arriving inside that gap calls resetTimer(), which flips this flag
+            // so the in-flight rAF chain aborts instead of falsely resolving.
+            let rafCancelled = false;
             const demoOverlay = document.querySelector("[data-demo-overlay]");
 
             // Terminal output channel: subscribe to onWriteParsed on every live
@@ -1059,6 +1063,9 @@ export function DemoCursor() {
             function onVideoInactive(e: Event) {
               if (e.target instanceof HTMLVideoElement) {
                 activeVideos.delete(e.target);
+                // A video stopping is a state change — restart the settle window
+                // so idle requires settleMs of quiet *after* playback ceases.
+                resetTimer();
               }
             }
             document.addEventListener("playing", onVideoPlaying, true);
@@ -1071,7 +1078,13 @@ export function DemoCursor() {
               cleaned = true;
               clearTimeout(timer);
               observer.disconnect();
-              for (const d of terminalDisposables) d.dispose();
+              for (const d of terminalDisposables) {
+                try {
+                  d.dispose();
+                } catch {
+                  // A throwing dispose must not strand the remaining teardown.
+                }
+              }
               document.removeEventListener("playing", onVideoPlaying, true);
               document.removeEventListener("pause", onVideoInactive, true);
               document.removeEventListener("ended", onVideoInactive, true);
@@ -1102,15 +1115,25 @@ export function DemoCursor() {
                 return;
               }
 
+              // Drop videos that were removed from the DOM while playing without
+              // firing pause/ended (e.g. a React conditional unmount) — they
+              // would otherwise block idle until the timeout.
+              for (const v of activeVideos) {
+                if (!v.isConnected) activeVideos.delete(v);
+              }
+
               // A video still playing means the page is not idle yet.
               if (activeVideos.size > 0) {
                 resetTimer();
                 return;
               }
 
-              // Double rAF to ensure paint is complete
+              // Double rAF to ensure paint is complete. resetTimer() flips
+              // rafCancelled if activity arrives before the chain completes.
+              rafCancelled = false;
               requestAnimationFrame(() => {
                 requestAnimationFrame(() => {
+                  if (rafCancelled) return;
                   cleanup();
                   resolve();
                 });
@@ -1118,6 +1141,7 @@ export function DemoCursor() {
             }
 
             function resetTimer() {
+              rafCancelled = true;
               if (performance.now() - start > timeoutMs) {
                 cleanup();
                 reject(new Error("waitForIdle timed out"));

--- a/src/components/Demo/DemoCursor.tsx
+++ b/src/components/Demo/DemoCursor.tsx
@@ -4,6 +4,7 @@ import { runSpringLoop } from "@/lib/demoSpring";
 import { EditorView } from "@codemirror/view";
 import { Transaction } from "@codemirror/state";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import { usePanelStore } from "@/store/panelStore";
 import type {
   DemoMoveToPayload,
   DemoMoveToSelectorPayload,
@@ -995,7 +996,16 @@ export function DemoCursor() {
       })
     );
 
-    // --- waitForIdle handler: MutationObserver + getAnimations + double-rAF ---
+    // --- waitForIdle handler: MutationObserver + getAnimations + terminal
+    // onWriteParsed + video playback + double-rAF ---
+    //
+    // getAnimations() and the MutationObserver only see CSS/WAAPI animations and
+    // DOM mutations. They are blind to two activity channels that paint outside
+    // that pipeline: xterm WebGL canvas repaints (terminal output) and <video>
+    // playback. Without covering those, waitForIdle reports idle while a terminal
+    // is still streaming output or a video is mid-playback. We treat all three
+    // channels as independent activity signals — idle requires every channel
+    // quiet for settleMs simultaneously (see issue #10144).
     cleanups.push(
       demo.onExecCommand("demo:exec-wait-for-idle", async (raw: Record<string, unknown>) => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
@@ -1007,7 +1017,66 @@ export function DemoCursor() {
           await new Promise<void>((resolve, reject) => {
             const start = performance.now();
             let timer: ReturnType<typeof setTimeout>;
+            let cleaned = false;
             const demoOverlay = document.querySelector("[data-demo-overlay]");
+
+            // Terminal output channel: subscribe to onWriteParsed on every live
+            // terminal. onWriteParsed fires at most once per frame after an async
+            // parse of terminal.write() completes — it never fires on cursor
+            // blink, scroll, or focus, so it is the correct settle signal (unlike
+            // onRender, which the blink cycle triggers continuously). We snapshot
+            // the terminals at entry; demo scripts are sequential, so no new
+            // terminal appears mid-wait.
+            const terminalDisposables: Array<{ dispose: () => void }> = [];
+            for (const panelId of usePanelStore.getState().panelIds) {
+              const managed = terminalInstanceService.get(panelId);
+              // Hibernated terminals have a disposed xterm instance — skip them.
+              if (!managed || managed.isHibernated) continue;
+              try {
+                terminalDisposables.push(managed.terminal.onWriteParsed(() => resetTimer()));
+              } catch {
+                // A terminal that disposes mid-snapshot cannot produce output.
+              }
+            }
+
+            // Video channel: media events do not bubble, so listen in the capture
+            // phase on document. The active set holds videos currently playing;
+            // idle requires it to be empty. `waiting` (buffering) counts as
+            // inactive so a stalled video can never permanently block idle —
+            // `playing` re-fires and resets the timer if playback resumes.
+            const activeVideos = new Set<HTMLVideoElement>();
+            for (const video of document.querySelectorAll("video")) {
+              if (!video.paused && !video.ended && video.readyState >= 3) {
+                activeVideos.add(video);
+              }
+            }
+            function onVideoPlaying(e: Event) {
+              if (e.target instanceof HTMLVideoElement) {
+                activeVideos.add(e.target);
+                resetTimer();
+              }
+            }
+            function onVideoInactive(e: Event) {
+              if (e.target instanceof HTMLVideoElement) {
+                activeVideos.delete(e.target);
+              }
+            }
+            document.addEventListener("playing", onVideoPlaying, true);
+            document.addEventListener("pause", onVideoInactive, true);
+            document.addEventListener("ended", onVideoInactive, true);
+            document.addEventListener("waiting", onVideoInactive, true);
+
+            function cleanup() {
+              if (cleaned) return;
+              cleaned = true;
+              clearTimeout(timer);
+              observer.disconnect();
+              for (const d of terminalDisposables) d.dispose();
+              document.removeEventListener("playing", onVideoPlaying, true);
+              document.removeEventListener("pause", onVideoInactive, true);
+              document.removeEventListener("ended", onVideoInactive, true);
+              document.removeEventListener("waiting", onVideoInactive, true);
+            }
 
             function isDemoOwned(el: Element | null): boolean {
               if (!el || !demoOverlay) return false;
@@ -1033,10 +1102,16 @@ export function DemoCursor() {
                 return;
               }
 
+              // A video still playing means the page is not idle yet.
+              if (activeVideos.size > 0) {
+                resetTimer();
+                return;
+              }
+
               // Double rAF to ensure paint is complete
               requestAnimationFrame(() => {
                 requestAnimationFrame(() => {
-                  observer.disconnect();
+                  cleanup();
                   resolve();
                 });
               });
@@ -1044,7 +1119,7 @@ export function DemoCursor() {
 
             function resetTimer() {
               if (performance.now() - start > timeoutMs) {
-                observer.disconnect();
+                cleanup();
                 reject(new Error("waitForIdle timed out"));
                 return;
               }

--- a/src/components/Demo/__tests__/DemoCursor.test.tsx
+++ b/src/components/Demo/__tests__/DemoCursor.test.tsx
@@ -1464,6 +1464,54 @@ describe("DemoCursor", () => {
       }
     });
 
+    it("does not falsely resolve if a terminal writes during the double-rAF gap", async () => {
+      const term = makeTerminal();
+      registerTerminals({ "panel-1": term });
+
+      // Intercept rAF so activity can be injected between the two frames; hand
+      // control back to the real loop afterwards so the next cycle completes.
+      const rafQueue: FrameRequestCallback[] = [];
+      const realRaf = globalThis.requestAnimationFrame.bind(globalThis);
+      let intercept = true;
+      const rafSpy = vi
+        .spyOn(globalThis, "requestAnimationFrame")
+        .mockImplementation((cb: FrameRequestCallback) => {
+          if (!intercept) return realRaf(cb);
+          rafQueue.push(cb);
+          return rafQueue.length;
+        });
+      try {
+        render(<DemoCursor />);
+        emit("demo:exec-wait-for-idle", {
+          requestId: "req-raf-race",
+          settleMs: 20,
+          timeoutMs: 3000,
+        });
+
+        // Let the settle timer fire check() → it schedules the first rAF.
+        await new Promise((r) => setTimeout(r, 40));
+        expect(rafQueue.length).toBe(1);
+
+        // Run the first frame → schedules the inner frame.
+        rafQueue.shift()!(0);
+        expect(rafQueue.length).toBe(1);
+
+        // Activity lands inside the gap (the exact class of bug being fixed).
+        term.fireWrite();
+
+        // Run the inner frame → must abort instead of resolving.
+        rafQueue.shift()!(0);
+        expect(demoMock.sendCommandDone).not.toHaveBeenCalledWith("req-raf-race", undefined);
+
+        // Hand control back to the real loop; the next quiet cycle resolves.
+        intercept = false;
+        await new Promise((r) => setTimeout(r, 150));
+        expect(demoMock.sendCommandDone).toHaveBeenCalledWith("req-raf-race", undefined);
+      } finally {
+        rafSpy.mockRestore();
+      }
+    });
+
     it("tears down terminal and video listeners on timeout", async () => {
       const term = makeTerminal();
       registerTerminals({ "panel-1": term });

--- a/src/components/Demo/__tests__/DemoCursor.test.tsx
+++ b/src/components/Demo/__tests__/DemoCursor.test.tsx
@@ -31,6 +31,14 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   },
 }));
 
+// waitForIdle enumerates terminals via usePanelStore.getState().panelIds.
+const mockPanelIds: { current: string[] } = { current: [] };
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: {
+    getState: () => ({ panelIds: mockPanelIds.current }),
+  },
+}));
+
 // Set up window.electron.demo before importing the component
 // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
 const originalElectron = (window as unknown as { electron?: unknown }).electron;
@@ -54,6 +62,12 @@ const animateSpy = vi.fn((() => createMockAnimation()) as any) as ReturnType<typ
 // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
 Element.prototype.animate = animateSpy as unknown as typeof Element.prototype.animate;
 
+// jsdom does not implement document.getAnimations(); waitForIdle calls it.
+if (typeof document.getAnimations !== "function") {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (document as any).getAnimations = () => [];
+}
+
 import { DemoCursor, computeBezierKeyframes } from "../DemoCursor";
 
 function emit(channel: string, payload: Record<string, unknown> = {}) {
@@ -67,6 +81,8 @@ describe("DemoCursor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     listenerMap.clear();
+    mockPanelIds.current = [];
+    terminalGetMock.mockReturnValue(null);
     // Set window dimensions for % to px conversion
     Object.defineProperty(window, "innerWidth", {
       value: 1000,
@@ -1299,6 +1315,185 @@ describe("DemoCursor", () => {
     expect(demoMock.sendCommandDone).toHaveBeenCalledWith("req-6", undefined);
 
     document.body.removeChild(el);
+  });
+
+  describe("waitForIdle", () => {
+    type FakeTerminal = {
+      managed: {
+        isHibernated: boolean;
+        terminal: { onWriteParsed: ReturnType<typeof vi.fn> };
+      };
+      fireWrite: () => void;
+      dispose: ReturnType<typeof vi.fn>;
+    };
+
+    function makeTerminal(hibernated = false): FakeTerminal {
+      const listeners: Array<() => void> = [];
+      const dispose = vi.fn();
+      return {
+        managed: {
+          isHibernated: hibernated,
+          terminal: {
+            onWriteParsed: vi.fn((cb: () => void) => {
+              listeners.push(cb);
+              return { dispose };
+            }),
+          },
+        },
+        fireWrite: () => listeners.forEach((l) => l()),
+        dispose,
+      };
+    }
+
+    function registerTerminals(byId: Record<string, FakeTerminal>) {
+      mockPanelIds.current = Object.keys(byId);
+      terminalGetMock.mockImplementation((id: string) => byId[id]?.managed ?? null);
+    }
+
+    function makeVideo({ playing }: { playing: boolean }): HTMLVideoElement {
+      const video = document.createElement("video");
+      Object.defineProperty(video, "paused", { value: !playing, configurable: true });
+      Object.defineProperty(video, "ended", { value: false, configurable: true });
+      Object.defineProperty(video, "readyState", { value: 4, configurable: true });
+      document.body.appendChild(video);
+      return video;
+    }
+
+    it("resolves when nothing is active", async () => {
+      render(<DemoCursor />);
+      emit("demo:exec-wait-for-idle", { requestId: "req-idle-empty", settleMs: 30, timeoutMs: 2000 });
+
+      await new Promise((r) => setTimeout(r, 150));
+
+      expect(demoMock.sendCommandDone).toHaveBeenCalledWith("req-idle-empty", undefined);
+    });
+
+    it("delays idle while a terminal is still writing, then resolves once it stops", async () => {
+      const term = makeTerminal();
+      registerTerminals({ "panel-1": term });
+
+      render(<DemoCursor />);
+      emit("demo:exec-wait-for-idle", { requestId: "req-idle-term", settleMs: 80, timeoutMs: 3000 });
+
+      // The handler subscribes onWriteParsed on the live terminal.
+      expect(term.managed.terminal.onWriteParsed).toHaveBeenCalledTimes(1);
+
+      // Keep the terminal busy past one settle window — must NOT resolve yet.
+      for (let i = 0; i < 4; i++) {
+        await new Promise((r) => setTimeout(r, 40));
+        term.fireWrite();
+      }
+      expect(demoMock.sendCommandDone).not.toHaveBeenCalledWith("req-idle-term", undefined);
+
+      // Stop writing and let it settle.
+      await new Promise((r) => setTimeout(r, 200));
+      expect(demoMock.sendCommandDone).toHaveBeenCalledWith("req-idle-term", undefined);
+      // Subscription torn down on resolve.
+      expect(term.dispose).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips hibernated terminals", async () => {
+      const live = makeTerminal();
+      const hibernated = makeTerminal(true);
+      registerTerminals({ "panel-live": live, "panel-hib": hibernated });
+
+      render(<DemoCursor />);
+      emit("demo:exec-wait-for-idle", { requestId: "req-idle-hib", settleMs: 30, timeoutMs: 2000 });
+
+      expect(live.managed.terminal.onWriteParsed).toHaveBeenCalledTimes(1);
+      expect(hibernated.managed.terminal.onWriteParsed).not.toHaveBeenCalled();
+
+      await new Promise((r) => setTimeout(r, 150));
+      expect(demoMock.sendCommandDone).toHaveBeenCalledWith("req-idle-hib", undefined);
+    });
+
+    it("skips panel ids with no terminal instance", async () => {
+      mockPanelIds.current = ["panel-missing"];
+      terminalGetMock.mockReturnValue(null);
+
+      render(<DemoCursor />);
+      emit("demo:exec-wait-for-idle", { requestId: "req-idle-null", settleMs: 30, timeoutMs: 2000 });
+
+      await new Promise((r) => setTimeout(r, 150));
+      expect(demoMock.sendCommandDone).toHaveBeenCalledWith("req-idle-null", undefined);
+    });
+
+    it("does not report idle while a video is playing", async () => {
+      const video = makeVideo({ playing: true });
+      try {
+        render(<DemoCursor />);
+        emit("demo:exec-wait-for-idle", {
+          requestId: "req-idle-video",
+          settleMs: 40,
+          timeoutMs: 400,
+        });
+
+        // Seeded as active → settle never completes → handler times out.
+        await new Promise((r) => setTimeout(r, 600));
+        expect(demoMock.sendCommandDone).toHaveBeenCalledWith(
+          "req-idle-video",
+          "Error: waitForIdle timed out"
+        );
+      } finally {
+        document.body.removeChild(video);
+      }
+    });
+
+    it("resolves after a playing video pauses", async () => {
+      const video = makeVideo({ playing: true });
+      try {
+        render(<DemoCursor />);
+        emit("demo:exec-wait-for-idle", {
+          requestId: "req-idle-video-pause",
+          settleMs: 40,
+          timeoutMs: 3000,
+        });
+
+        await new Promise((r) => setTimeout(r, 100));
+        expect(demoMock.sendCommandDone).not.toHaveBeenCalledWith(
+          "req-idle-video-pause",
+          undefined
+        );
+
+        // Pause fires a capture-phase 'pause' event → removed from active set.
+        video.dispatchEvent(new Event("pause"));
+        await new Promise((r) => setTimeout(r, 150));
+        expect(demoMock.sendCommandDone).toHaveBeenCalledWith("req-idle-video-pause", undefined);
+      } finally {
+        document.body.removeChild(video);
+      }
+    });
+
+    it("tears down terminal and video listeners on timeout", async () => {
+      const term = makeTerminal();
+      registerTerminals({ "panel-1": term });
+      const video = makeVideo({ playing: true });
+      const removeSpy = vi.spyOn(document, "removeEventListener");
+      try {
+        render(<DemoCursor />);
+        emit("demo:exec-wait-for-idle", {
+          requestId: "req-idle-timeout",
+          settleMs: 40,
+          timeoutMs: 300,
+        });
+
+        await new Promise((r) => setTimeout(r, 500));
+        expect(demoMock.sendCommandDone).toHaveBeenCalledWith(
+          "req-idle-timeout",
+          "Error: waitForIdle timed out"
+        );
+
+        // Terminal subscription disposed.
+        expect(term.dispose).toHaveBeenCalledTimes(1);
+        // All four video listeners removed in the capture phase.
+        for (const evt of ["playing", "pause", "ended", "waiting"]) {
+          expect(removeSpy).toHaveBeenCalledWith(evt, expect.any(Function), true);
+        }
+      } finally {
+        removeSpy.mockRestore();
+        document.body.removeChild(video);
+      }
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

`waitForIdle` was incorrectly declaring the page idle while terminals were still streaming output or a video was still playing. The root cause: `document.getAnimations`, `MutationObserver`, and the double-rAF loop are all blind to WebGL canvas repaints (xterm uses `@xterm/addon-webgl`) and to `<video>` element playback, so none of them registered ongoing activity.

This adds two new activity channels to the existing settle timer:

- **Terminal output:** subscribes to `onWriteParsed` on each live, non-hibernated terminal. (`onRender` was rejected — cursor blink fires it continuously.)
- **Video playback:** capture-phase listeners for `playing`, `pause`, `ended`, and `waiting` events, seeded at entry.

Idle now requires CSS animations, terminal writes, and video playback to all be quiet for `settleMs` simultaneously.

Resolves #10144

## Changes

- Two new activity channels wired into the settle timer (`onWriteParsed`, video capture-phase events)
- Double-rAF settle confirmation made cancellable — activity arriving in the rAF gap aborts a false resolve
- Settle window restarts when a video stops
- Exception-safe, idempotent `cleanup()` that tears down the observer, terminal subscriptions, video listeners, and timer on both resolve and timeout
- DOM-disconnected videos pruned from the active set

## Testing

- 8 new behavioral tests covering the terminal and video channels, teardown on both resolve and timeout paths, and the double-rAF race condition
- `DemoCursor.test.tsx` — 52 pass
- Updated the `waitForIdle` entry in `.claude/skills/demo-video-creator/SKILL.md`