### PR TITLE
feat(perf): add baseline freshness warning and coverage gate

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -76,3 +76,45 @@ jobs:
         with:
           name: perf-nightly-results
           path: .tmp/perf-results/
+
+  perf-update-baselines:
+    # Regenerate the committed baselines and open a PR rather than committing
+    # directly to the protected base branch. Scheduled-only on develop so feature
+    # branches never spawn baseline PRs.
+    if: github.event_name == 'schedule' && github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 120
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Regenerate nightly baseline
+        run: npm run perf:update-baselines:nightly
+
+      - name: Regenerate soak baseline
+        run: npm run perf:update-baselines:soak
+
+      - name: Open baseline update PR
+        uses: peter-evans/create-pull-request@v8
+        with:
+          add-paths: scripts/perf/config/baseline.*.json
+          branch: perf/update-baselines-automated
+          delete-branch: true
+          commit-message: "perf(baselines): regenerate stale perf baselines"
+          title: "perf: regenerate stale perf baselines"
+          body: |
+            Automated regeneration of the committed perf baselines (`scripts/perf/config/baseline.*.json`) from the scheduled nightly + soak runs.
+
+            Review the p95 deltas before merging — large swings may indicate a real regression rather than noise.

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -100,11 +100,24 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # A regenerated baseline is still written even when a scenario regresses
+      # against the old values (run.ts exits 1 in that case), so don't let the
+      # non-zero exit abort the job before the PR step runs.
+      - name: Regenerate smoke baseline
+        run: npm run perf:update-baselines:smoke
+        continue-on-error: true
+
+      - name: Regenerate CI baseline
+        run: npm run perf:update-baselines:ci
+        continue-on-error: true
+
       - name: Regenerate nightly baseline
         run: npm run perf:update-baselines:nightly
+        continue-on-error: true
 
       - name: Regenerate soak baseline
         run: npm run perf:update-baselines:soak
+        continue-on-error: true
 
       - name: Open baseline update PR
         uses: peter-evans/create-pull-request@v8

--- a/package.json
+++ b/package.json
@@ -118,6 +118,8 @@
     "perf:ci": "tsx scripts/perf/run.ts --mode ci",
     "perf:nightly": "tsx scripts/perf/run.ts --mode nightly",
     "perf:soak": "tsx scripts/perf/run.ts --mode soak",
+    "perf:update-baselines:smoke": "tsx scripts/perf/run.ts --mode smoke --update-baseline",
+    "perf:update-baselines:ci": "tsx scripts/perf/run.ts --mode ci --update-baseline",
     "perf:update-baselines:nightly": "tsx scripts/perf/run.ts --mode nightly --update-baseline",
     "perf:update-baselines:soak": "tsx scripts/perf/run.ts --mode soak --update-baseline",
     "perf:cold-start": "tsx scripts/perf/cold-start.ts",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,8 @@
     "perf:ci": "tsx scripts/perf/run.ts --mode ci",
     "perf:nightly": "tsx scripts/perf/run.ts --mode nightly",
     "perf:soak": "tsx scripts/perf/run.ts --mode soak",
+    "perf:update-baselines:nightly": "tsx scripts/perf/run.ts --mode nightly --update-baseline",
+    "perf:update-baselines:soak": "tsx scripts/perf/run.ts --mode soak --update-baseline",
     "perf:cold-start": "tsx scripts/perf/cold-start.ts",
     "perf:analyze": "cross-env ANALYZE=true vite build",
     "pattern-discovery:run": "tsx scripts/pattern-discovery/runner.ts",

--- a/scripts/perf/__tests__/baselineCoverage.test.ts
+++ b/scripts/perf/__tests__/baselineCoverage.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  BASELINE_FRESHNESS_DAYS,
+  checkBaselineCoverage,
+  checkBaselineFreshness,
+} from "../lib/baselineCoverage";
+import type { BaselineSummary, PerfBudgetConfig, PerfScenario } from "../types";
+
+function scenario(id: string): PerfScenario {
+  return {
+    id,
+    name: id,
+    description: id,
+    tier: "fast",
+    modes: ["ci"],
+    run: () => ({ durationMs: 1 }),
+  };
+}
+
+const budgetConfig: PerfBudgetConfig = {
+  criticalScenarios: ["PERF-001"],
+  defaultBudget: { p95Ms: 5000, maxRegressionPct: 15 },
+  scenarios: {
+    "PERF-001": { p95Ms: 3500, maxRegressionPct: 15 },
+    "PERF-070": { p95Ms: 1200, maxRegressionPct: 15 },
+  },
+};
+
+// A config whose defaultBudget has no regression gate, so a scenario without an
+// override is genuinely not regression-gated (the merge can't reintroduce it).
+const noRegressionConfig: PerfBudgetConfig = {
+  criticalScenarios: [],
+  defaultBudget: { p95Ms: 5000 },
+  scenarios: {
+    "PERF-200": { p95Ms: 1000 },
+  },
+};
+
+function baseline(
+  p95ByScenario: Record<string, number>,
+  generatedAt = "2026-06-01T00:00:00.000Z"
+): BaselineSummary {
+  return { generatedAt, mode: "ci", p95ByScenario };
+}
+
+describe("checkBaselineFreshness", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("warns when the baseline is older than the threshold", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const now = new Date("2026-06-07T00:00:00.000Z");
+    const old = baseline({}, "2026-01-01T00:00:00.000Z"); // ~157 days
+    checkBaselineFreshness(old, "ci", BASELINE_FRESHNESS_DAYS, now);
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("does not warn when the baseline is within the threshold", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const now = new Date("2026-06-07T00:00:00.000Z");
+    const fresh = baseline({}, "2026-06-01T00:00:00.000Z"); // 6 days
+    checkBaselineFreshness(fresh, "ci", BASELINE_FRESHNESS_DAYS, now);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("does not warn exactly at the threshold boundary", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const now = new Date("2026-02-01T00:00:00.000Z");
+    const atBoundary = baseline({}, "2026-01-02T00:00:00.000Z"); // exactly 30 days
+    checkBaselineFreshness(atBoundary, "ci", 30, now);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("skips when no baseline is loaded", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    checkBaselineFreshness(null, "ci");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("does not throw or warn on an unparseable timestamp", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const bad = baseline({}, "not-a-date");
+    expect(() => checkBaselineFreshness(bad, "ci")).not.toThrow();
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("checkBaselineCoverage", () => {
+  it("flags a budgeted scenario absent from the baseline", () => {
+    const gaps = checkBaselineCoverage(baseline({ "PERF-001": 1 }), budgetConfig, [
+      scenario("PERF-070"),
+    ]);
+    expect(gaps).toEqual([{ scenarioId: "PERF-070" }]);
+  });
+
+  it("does not flag a scenario present in the baseline", () => {
+    const gaps = checkBaselineCoverage(baseline({ "PERF-070": 900 }), budgetConfig, [
+      scenario("PERF-070"),
+    ]);
+    expect(gaps).toEqual([]);
+  });
+
+  it("ignores critical scenarios (gate.ts owns those)", () => {
+    const gaps = checkBaselineCoverage(baseline({}), budgetConfig, [scenario("PERF-001")]);
+    expect(gaps).toEqual([]);
+  });
+
+  it("ignores scenarios without a regression budget", () => {
+    const gaps = checkBaselineCoverage(baseline({}), noRegressionConfig, [scenario("PERF-200")]);
+    expect(gaps).toEqual([]);
+  });
+
+  it("flags scenarios that fall back to the default regression budget", () => {
+    // PERF-063 has no explicit budget entry but defaultBudget carries maxRegressionPct.
+    const gaps = checkBaselineCoverage(baseline({}), budgetConfig, [scenario("PERF-063")]);
+    expect(gaps).toEqual([{ scenarioId: "PERF-063" }]);
+  });
+
+  it("flags a non-finite baseline entry as a gap", () => {
+    const gaps = checkBaselineCoverage(baseline({ "PERF-070": Number.NaN }), budgetConfig, [
+      scenario("PERF-070"),
+    ]);
+    expect(gaps).toEqual([{ scenarioId: "PERF-070" }]);
+  });
+
+  it("returns no gaps when no baseline file is loaded", () => {
+    const gaps = checkBaselineCoverage(null, budgetConfig, [scenario("PERF-070")]);
+    expect(gaps).toEqual([]);
+  });
+
+  it("only reports scenarios scheduled for this run", () => {
+    const gaps = checkBaselineCoverage(baseline({ "PERF-070": 900 }), budgetConfig, [
+      scenario("PERF-070"),
+    ]);
+    // PERF-072 is missing from the baseline but is not in this run's scenario set.
+    expect(gaps).toEqual([]);
+  });
+});

--- a/scripts/perf/lib/baselineCoverage.ts
+++ b/scripts/perf/lib/baselineCoverage.ts
@@ -1,0 +1,74 @@
+import { getScenarioBudget } from "./budgets";
+import type { BaselineSummary, PerfBudgetConfig, PerfScenario } from "../types";
+
+/**
+ * Baselines older than this (in days) trigger a freshness warning. The threshold
+ * is an opinion, not a hard rule — a stale-but-present baseline still gates, so
+ * this only ever warns. 30 days keeps committed baselines roughly aligned with
+ * the runtime they encode without breaking CI for legitimately-quiet periods.
+ */
+export const BASELINE_FRESHNESS_DAYS = 30;
+
+const MS_PER_DAY = 86_400_000;
+
+export interface CoverageGap {
+  scenarioId: string;
+}
+
+/**
+ * Warn (never fail) when the loaded baseline's `generatedAt` is older than
+ * `thresholdDays`. Skips when no baseline is loaded or the timestamp is
+ * unparseable — freshness is advisory, so a malformed value must not throw.
+ */
+export function checkBaselineFreshness(
+  baseline: BaselineSummary | null,
+  mode: string,
+  thresholdDays = BASELINE_FRESHNESS_DAYS,
+  now = new Date()
+): void {
+  if (!baseline) return;
+
+  const generatedAtMs = new Date(baseline.generatedAt).getTime();
+  if (!Number.isFinite(generatedAtMs)) return;
+
+  const ageDays = (now.getTime() - generatedAtMs) / MS_PER_DAY;
+  if (ageDays > thresholdDays) {
+    console.warn(
+      `[perf:${mode}] WARNING baseline is ${Math.round(ageDays)} days old ` +
+        `(threshold ${thresholdDays}d) — regenerate with --update-baseline`
+    );
+  }
+}
+
+/**
+ * Structural pre-run check: a scenario scheduled for this run that carries a
+ * regression budget (`maxRegressionPct`) but is absent from the loaded baseline
+ * would otherwise silently skip its regression gate. Returns those gaps so the
+ * caller can fail the run before wasting measurement time.
+ *
+ * Critical scenarios are excluded — `gate.ts` already fails closed for them.
+ * A null baseline returns no gaps: that's the pre-existing "no file" path, not
+ * the partial-coverage gap this check targets.
+ */
+export function checkBaselineCoverage(
+  baseline: BaselineSummary | null,
+  budgetConfig: PerfBudgetConfig,
+  scenariosForThisRun: PerfScenario[]
+): CoverageGap[] {
+  if (!baseline) return [];
+
+  const gaps: CoverageGap[] = [];
+  for (const scenario of scenariosForThisRun) {
+    if (budgetConfig.criticalScenarios.includes(scenario.id)) continue;
+
+    const budget = getScenarioBudget(budgetConfig, scenario.id);
+    if (budget.maxRegressionPct === undefined) continue;
+
+    const baselineP95 = baseline.p95ByScenario?.[scenario.id];
+    if (baselineP95 === undefined || !Number.isFinite(baselineP95)) {
+      gaps.push({ scenarioId: scenario.id });
+    }
+  }
+
+  return gaps;
+}

--- a/scripts/perf/run.ts
+++ b/scripts/perf/run.ts
@@ -2,6 +2,7 @@ import { performance } from "node:perf_hooks";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { loadBudgetConfig, getScenarioBudget } from "./lib/budgets";
+import { checkBaselineCoverage, checkBaselineFreshness } from "./lib/baselineCoverage";
 import { compareSamples } from "./lib/comparison";
 import { evaluateScenarioBudget } from "./lib/gate";
 import { appendJsonLine, readJson, writeJson, writeText, ensureDir } from "./lib/io";
@@ -114,9 +115,27 @@ async function run(): Promise<void> {
   const budgetConfig = loadBudgetConfig();
   const baseline = readJson<BaselineSummary>(cli.baselinePath);
 
+  checkBaselineFreshness(baseline, cli.mode);
+
   const scenarios = getScenariosForMode(cli.mode);
   if (scenarios.length === 0) {
     throw new Error(`No scenarios configured for mode ${cli.mode}`);
+  }
+
+  // Regenerating the baseline is exactly how coverage gaps get fixed, so let an
+  // --update-baseline run proceed even when entries are missing.
+  if (!cli.updateBaseline) {
+    const coverageGaps = checkBaselineCoverage(baseline, budgetConfig, scenarios);
+    if (coverageGaps.length > 0) {
+      const ids = coverageGaps.map((gap) => gap.scenarioId).join(", ");
+      console.error(
+        `[perf:${cli.mode}] FAIL ${coverageGaps.length} budgeted scenario(s) missing from ` +
+          `baseline (${cli.baselinePath}) — regression gate cannot run: ${ids}. ` +
+          `Regenerate with --update-baseline.`
+      );
+      process.exitCode = 1;
+      return;
+    }
   }
 
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");


### PR DESCRIPTION
## Summary

- Perf baselines had no freshness check and silently skipped regression gating for any scenario missing from the loaded baseline — budgeted scenarios could run in CI with zero protection, indefinitely.
- Adds `checkBaselineFreshness` (advisory warning after 30 days) and `checkBaselineCoverage` (hard-fail before measurements run when a budgeted scenario for the active mode has no baseline entry) in `scripts/perf/lib/baselineCoverage.ts`, wired into `scripts/perf/run.ts`.
- Adds a scheduled `perf-update-baselines` job in `.github/workflows/performance.yml` that regenerates all four baselines on a cron and opens a PR via `peter-evans/create-pull-request@v8`, closing the gap permanently.

Resolves #10007

## Changes

- `scripts/perf/lib/baselineCoverage.ts` — new module exporting `checkBaselineFreshness` and `checkBaselineCoverage`
- `scripts/perf/run.ts` — wires freshness warning after baseline loads; coverage gate hard-fails (exit 1) before measurements run; gate is bypassed under `--update-baseline` so regeneration can fix its own gaps
- `package.json` — adds `perf:update-baselines:{smoke,ci,nightly,soak}` scripts
- `.github/workflows/performance.yml` — adds `perf-update-baselines` scheduled job; `continue-on-error` on each regenerate step so a single-mode regression doesn't abort before the PR step
- `scripts/perf/__tests__/baselineCoverage.test.ts` — 13 unit tests covering freshness branch logic and coverage detection

## Notes

The committed baseline JSON files are intentionally **not** regenerated here — real p95 values have to come from CI hardware, and the new `perf-update-baselines` job is the correct path for that. The consequence: scheduled `perf:ci` and `perf:nightly` runs will fail on the coverage gate until the first automated baseline-update PR merges. That's the intended behavior — it surfaces the staleness rather than hiding it.

## Testing

- 13 unit tests added in `scripts/perf/__tests__/baselineCoverage.test.ts`
- Full local CI passed (typecheck, lint, format, IPC/channel/confirm guards, unit tests, build)