### PR TITLE
fix(demo): vary cursor arc curvature by distance and add S-curve inflection

### DIFF
--- a/src/components/Demo/DemoCursor.tsx
+++ b/src/components/Demo/DemoCursor.tsx
@@ -193,13 +193,14 @@ export function computeBezierKeyframes(
   const p2y = fromY + dy * p2t + perpY * p2Dist * p2Sign;
 
   const jitterAmplitude = Math.min(2, dist * 0.003);
+  const safeSteps = Math.max(1, steps);
   const frames: Array<{ transform: string }> = [];
-  for (let i = 0; i <= steps; i++) {
-    const t = i / steps;
+  for (let i = 0; i <= safeSteps; i++) {
+    const t = i / safeSteps;
     let x = cubicBezier(t, fromX, p1x, p2x, toX) - fromX;
     let y = cubicBezier(t, fromY, p1y, p2y, toY) - fromY;
 
-    if (i > 0 && i < steps && jitterAmplitude > 0) {
+    if (i > 0 && i < safeSteps && jitterAmplitude > 0) {
       const noiseVal = (noise1D(i * 0.15 + seed) * 2 - 1) * jitterAmplitude;
       x += perpX * noiseVal;
       y += perpY * noiseVal;

--- a/src/components/Demo/DemoCursor.tsx
+++ b/src/components/Demo/DemoCursor.tsx
@@ -137,7 +137,7 @@ function cubicBezier(t: number, p0: number, p1: number, p2: number, p3: number):
   return u * u * u * p0 + 3 * u * u * t * p1 + 3 * u * t * t * p2 + t * t * t * p3;
 }
 
-function computeBezierKeyframes(
+export function computeBezierKeyframes(
   fromX: number,
   fromY: number,
   toX: number,
@@ -152,14 +152,45 @@ function computeBezierKeyframes(
   const perpX = dist > 0 ? -dy / dist : 0;
   const perpY = dist > 0 ? dx / dist : 0;
 
-  const offset = dist * (0.05 + Math.random() * 0.25);
+  // Which way the arc bows. Drawn first so the call order stays stable.
   const sign = Math.random() > 0.5 ? 1 : -1;
 
-  const p1x = fromX + dx * 0.33 + perpX * offset * sign;
-  const p1y = fromY + dy * 0.33 + perpY * offset * sign;
+  // Sqrt taper: the leading control point's deviation grows sub-linearly with
+  // distance, so short nudges stay nearly straight while long sweeps bow
+  // noticeably, capped so very long moves don't balloon.
+  const p1Dist = Math.min(Math.sqrt(dist) * (1.5 + Math.random() * 1.5), 80);
 
-  const p2x = fromX + dx * 0.8 + perpX * offset * 0.3 * sign + dx * 0.05;
-  const p2y = fromY + dy * 0.8 + perpY * offset * 0.3 * sign + dy * 0.05;
+  // Occasional mid-flight correction: only long moves can inflect into an S, and
+  // only some of the time.
+  const isSCurve = dist > TWO_PHASE_THRESHOLD && Math.random() < 0.2;
+
+  let p1t: number;
+  let p2t: number;
+  let p2Dist: number;
+  let p2Sign: number;
+  if (isSCurve) {
+    // S-shaped path: a comparable second lobe to the opposite side, placed
+    // mid-flight so the inflection is actually visible rather than a sub-pixel
+    // wobble at the very end.
+    p1t = 0.2 + Math.random() * 0.1;
+    p2t = 0.6 + Math.random() * 0.1;
+    p2Dist = p1Dist * (0.5 + Math.random() * 0.3);
+    p2Sign = -sign;
+  } else {
+    // Single bow: peak early during acceleration, then settle the trailing
+    // control point most of the way back to the chord so the path decelerates
+    // straight into the target.
+    p1t = 0.25 + Math.random() * 0.15;
+    p2t = 0.9 + Math.random() * 0.05;
+    p2Dist = p1Dist * (0.1 + Math.random() * 0.15);
+    p2Sign = sign;
+  }
+
+  const p1x = fromX + dx * p1t + perpX * p1Dist * sign;
+  const p1y = fromY + dy * p1t + perpY * p1Dist * sign;
+
+  const p2x = fromX + dx * p2t + perpX * p2Dist * p2Sign;
+  const p2y = fromY + dy * p2t + perpY * p2Dist * p2Sign;
 
   const jitterAmplitude = Math.min(2, dist * 0.003);
   const frames: Array<{ transform: string }> = [];

--- a/src/components/Demo/__tests__/DemoCursor.test.tsx
+++ b/src/components/Demo/__tests__/DemoCursor.test.tsx
@@ -54,7 +54,7 @@ const animateSpy = vi.fn((() => createMockAnimation()) as any) as ReturnType<typ
 // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
 Element.prototype.animate = animateSpy as unknown as typeof Element.prototype.animate;
 
-import { DemoCursor } from "../DemoCursor";
+import { DemoCursor, computeBezierKeyframes } from "../DemoCursor";
 
 function emit(channel: string, payload: Record<string, unknown> = {}) {
   const handlers = listenerMap.get(channel) ?? [];
@@ -1199,6 +1199,80 @@ describe("DemoCursor", () => {
     expect(demoMock.sendCommandDone).toHaveBeenCalledWith("req-6", undefined);
 
     document.body.removeChild(el);
+  });
+});
+
+// Signed perpendicular deviation of each keyframe from the straight chord
+// running from the origin to (toX, toY). Frames translate relative to the start
+// point, so with from = (0, 0) the translate values are the absolute positions.
+// Positive vs negative tells you which side of the chord the path is on.
+function signedPerpDeviations(
+  frames: Array<{ transform: string }>,
+  toX: number,
+  toY: number
+): number[] {
+  const len = Math.hypot(toX, toY);
+  const out: number[] = [];
+  for (const f of frames) {
+    const m = /translate\(\s*(-?[\d.]+)px,\s*(-?[\d.]+)px\s*\)/.exec(f.transform);
+    if (!m) continue;
+    const x = parseFloat(m[1]!);
+    const y = parseFloat(m[2]!);
+    // 2D cross product of the chord and the point vector, normalised by chord
+    // length → signed distance from the point to the chord line.
+    out.push((toX * y - toY * x) / len);
+  }
+  return out;
+}
+
+describe("computeBezierKeyframes geometry", () => {
+  let randomSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+  afterEach(() => {
+    randomSpy?.mockRestore();
+    randomSpy = undefined;
+  });
+
+  it("scales arc deviation sub-linearly with distance", () => {
+    randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+    const short = signedPerpDeviations(computeBezierKeyframes(0, 0, 30, 0, 40, 0), 30, 0);
+    const long = signedPerpDeviations(computeBezierKeyframes(0, 0, 600, 0, 40, 0), 600, 0);
+
+    const shortMax = Math.max(...short.map(Math.abs));
+    const longMax = Math.max(...long.map(Math.abs));
+
+    // Longer moves bow more in absolute terms...
+    expect(longMax).toBeGreaterThan(shortMax);
+    // ...but sub-linearly: a 20x longer move must not produce a 20x bigger arc,
+    // otherwise short nudges read just as dramatically curved as long sweeps.
+    const distanceRatio = 600 / 30;
+    expect(longMax / shortMax).toBeLessThan(distanceRatio);
+  });
+
+  it("never inflects below the two-phase threshold", () => {
+    // 0.1 < 0.2 would arm the S-curve, but the distance gate must veto it.
+    randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.1);
+
+    const dev = signedPerpDeviations(computeBezierKeyframes(0, 0, 299, 0, 60, 0), 299, 0);
+
+    // A single-bow C-curve stays on one side of the chord. With sign = -1 every
+    // non-trivial deviation is negative; the only positive values would be small
+    // jitter (capped at min(2, 299 * 0.003) ≈ 0.9px), so nothing crosses +2.
+    expect(Math.max(...dev)).toBeLessThan(2);
+    expect(Math.min(...dev)).toBeLessThan(-2);
+  });
+
+  it("can inflect into an S-curve above the threshold", () => {
+    // Same draws as above, but now the distance gate allows the inflection.
+    randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.1);
+
+    const dev = signedPerpDeviations(computeBezierKeyframes(0, 0, 400, 0, 60, 0), 400, 0);
+
+    // The path leaves on one side and returns on the other, both lobes clearing
+    // the jitter band (min(2, 400 * 0.003) = 1.2px) by a comfortable margin.
+    expect(Math.min(...dev)).toBeLessThan(-2);
+    expect(Math.max(...dev)).toBeGreaterThan(2);
   });
 });
 

--- a/src/components/Demo/__tests__/DemoCursor.test.tsx
+++ b/src/components/Demo/__tests__/DemoCursor.test.tsx
@@ -1233,21 +1233,24 @@ describe("computeBezierKeyframes geometry", () => {
     randomSpy = undefined;
   });
 
+  function maxBow(toX: number, toY: number): number {
+    const frames = computeBezierKeyframes(0, 0, toX, toY, 40, 0);
+    return Math.max(...signedPerpDeviations(frames, toX, toY).map(Math.abs));
+  }
+
   it("scales arc deviation sub-linearly with distance", () => {
     randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
 
-    const short = signedPerpDeviations(computeBezierKeyframes(0, 0, 30, 0, 40, 0), 30, 0);
-    const long = signedPerpDeviations(computeBezierKeyframes(0, 0, 600, 0, 40, 0), 600, 0);
+    // Distances chosen well under the 80px deviation cap and a 4x apart, so the
+    // shape of the taper is what's measured, not the ceiling. A sqrt taper
+    // predicts a ~2x (sqrt(4)) bow ratio; the old linear `dist * fraction` — or
+    // a plain `min(dist, cap)` — would predict ~4x here. Asserting < 3 fails
+    // either of those and only passes for genuinely sub-linear growth.
+    const near = maxBow(64, 0);
+    const far = maxBow(256, 0);
 
-    const shortMax = Math.max(...short.map(Math.abs));
-    const longMax = Math.max(...long.map(Math.abs));
-
-    // Longer moves bow more in absolute terms...
-    expect(longMax).toBeGreaterThan(shortMax);
-    // ...but sub-linearly: a 20x longer move must not produce a 20x bigger arc,
-    // otherwise short nudges read just as dramatically curved as long sweeps.
-    const distanceRatio = 600 / 30;
-    expect(longMax / shortMax).toBeLessThan(distanceRatio);
+    expect(far).toBeGreaterThan(near);
+    expect(far / near).toBeLessThan(3);
   });
 
   it("never inflects below the two-phase threshold", () => {
@@ -1273,6 +1276,32 @@ describe("computeBezierKeyframes geometry", () => {
     // the jitter band (min(2, 400 * 0.003) = 1.2px) by a comfortable margin.
     expect(Math.min(...dev)).toBeLessThan(-2);
     expect(Math.max(...dev)).toBeGreaterThan(2);
+  });
+
+  it("starts at the origin and lands exactly on the target", () => {
+    randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+    // Non-zero start: transforms are deltas from the start point, so the first
+    // frame is the zero vector and the last is the full displacement. Endpoints
+    // carry no jitter, so these are exact.
+    const frames = computeBezierKeyframes(500, 400, 950, 760, 40, 0);
+    const parse = (t: string) => {
+      const m = /translate\(\s*(-?[\d.]+)px,\s*(-?[\d.]+)px\s*\)/.exec(t)!;
+      return { x: parseFloat(m[1]!), y: parseFloat(m[2]!) };
+    };
+
+    expect(frames).toHaveLength(41);
+    expect(parse(frames[0]!.transform)).toEqual({ x: 0, y: 0 });
+    expect(parse(frames[frames.length - 1]!.transform)).toEqual({ x: 450, y: 360 });
+  });
+
+  it("bows perpendicular to the chord for non-horizontal moves", () => {
+    randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+    // The arc must deviate off the chord regardless of its orientation. A
+    // hard-coded horizontal perpendicular would collapse these to ~0.
+    expect(maxBow(0, 400)).toBeGreaterThan(5); // vertical
+    expect(maxBow(300, 400)).toBeGreaterThan(5); // diagonal
   });
 });
 


### PR DESCRIPTION
## Summary

- `computeBezierKeyframes` always produced the same bow regardless of distance — short nudges looked as dramatically curved as long sweeps. This fixes that.
- Arc deviation now tapers sub-linearly (`sqrt(dist)`, capped at 80px): short moves read nearly straight, long sweeps bow noticeably.
- Trailing control point settles most of the way back to the chord for an asymmetric single bow that decelerates into the target. Long moves (>300px) occasionally (~20%) get an S-curve inflection with a visible opposite lobe.

Resolves #10148

## Changes

- Rewrote arc geometry in `computeBezierKeyframes` (sole Bézier function in `DemoCursor.tsx`) — no other motion code touched
- Exported the helper and added a `steps <= 0` guard
- Added 5 geometry invariant tests: sub-linear scaling (distinguishing `sqrt` from capped-linear), threshold-gated inflection, endpoint integrity, non-horizontal perpendicular direction

## Testing

`npm run check`, build, and full unit suite all green. Demo motion is intentionally hand-tuned and exempt from the app's Tailwind motion tiers. No new dependencies.