### PR TITLE
fix(pty-host): stop IPC cap-drop pulse from erasing pause tracking

### DIFF
--- a/electron/__tests__/pty-host.adversarial.test.ts
+++ b/electron/__tests__/pty-host.adversarial.test.ts
@@ -703,8 +703,9 @@ describe("pty-host adversarial", () => {
   });
 
   it("IPC_QUEUE_FULL_EMITS_DATA_LOSS_STATUS", async () => {
-    // Metrics on so the gated reliability-metric wire emission fires; the
-    // data-loss status event is ungated and fires regardless.
+    // Metrics on for the baseline case; the drop pulse itself passes
+    // forceEmit so it would fire either way (see the gate-bypass test
+    // below), and the data-loss status event is ungated regardless.
     vi.mocked(metricsEnabled).mockReturnValue(true);
     const parentPort = await loadHost();
     const terminal = createTerminal("t1");
@@ -756,7 +757,7 @@ describe("pty-host adversarial", () => {
       type: "terminal-reliability-metric",
       payload: {
         terminalId: "t1",
-        metricType: "suspend",
+        metricType: "ipc-cap-drop",
         bufferUtilization: 100,
       },
     });
@@ -774,6 +775,39 @@ describe("pty-host adversarial", () => {
           typeof msg === "object" && msg !== null && (msg as { type?: string }).type === "data"
       );
     expect(dataEvents).toHaveLength(0);
+  });
+
+  it("IPC_QUEUE_FULL_METRIC_BYPASSES_METRIC_GATE", async () => {
+    // The drop pulse is a data-loss signal: it must reach the wire even
+    // when metrics are gated off (forceEmit contract, #9902).
+    vi.mocked(metricsEnabled).mockReturnValue(false);
+    const parentPort = await loadHost();
+    const terminal = createTerminal("t1");
+    hostState.terminals.set("t1", terminal);
+
+    parentPort.emit("message", { type: "spawn", id: "t1", options: {} });
+    await flushMicrotasks();
+
+    const ipcQueue = hostState.ipcQueueManagers[0];
+    ipcQueue.isAtCapacity.mockReturnValue(true);
+    ipcQueue.getUtilization.mockReturnValue(100);
+    parentPort.postMessage.mockClear();
+
+    (hostState.currentPtyManager as MiniEmitter).emit("data", "t1", "a".repeat(64));
+    await flushMicrotasks();
+
+    const reliabilityEvents = parentPort.postMessage.mock.calls
+      .map((call: unknown[]) => call[0])
+      .filter(
+        (msg: unknown): msg is Record<string, unknown> =>
+          typeof msg === "object" &&
+          msg !== null &&
+          (msg as { type?: string }).type === "terminal-reliability-metric"
+      );
+    expect(reliabilityEvents).toHaveLength(1);
+    expect(reliabilityEvents[0]).toMatchObject({
+      payload: { terminalId: "t1", metricType: "ipc-cap-drop" },
+    });
   });
 
   it("IPC_QUEUE_FULL_DROPPED_BYTES_USES_UTF8_BYTE_COUNT", async () => {

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -801,19 +801,24 @@ ptyManager.on("data", (id: string, data: string | Uint8Array) => {
       // gated separately in ResourceGovernor.emitDataLossCount.
       dropAccumulator.droppedBytes += dataBytes;
       dropAccumulator.dataLossCount += 1;
-      // `null` source: the suspend pulse is a data-path signal, not a
-      // pause-source attribution. The funnel still forwards to the wire
-      // emission; it just doesn't touch the per-source tracking map.
-      // (The map entry is removed by the corresponding `pause-end` from
-      // the IPC queue's own backpressure path.)
+      // `ipc-cap-drop` is a data-path telemetry pulse, not a pause-source
+      // transition — the funnel forwards it to the wire without touching
+      // the per-source tracking map (a `suspend`/`pause-end` with `null`
+      // source would be read as a force-resume and wipe the terminal's
+      // entry while the IPC backpressure pause is still held; #9902).
+      // The map entry is removed by the corresponding `pause-end` from
+      // the IPC queue's own backpressure path. `forceEmit` bypasses the
+      // metric gate — data-loss pulses must reach the wire even when
+      // metrics are gated off.
       emitReliabilityMetricWithTracking(
         {
           terminalId: id,
-          metricType: "suspend",
+          metricType: "ipc-cap-drop",
           timestamp: Date.now(),
           bufferUtilization: utilization,
         },
-        null
+        null,
+        true
       );
       // Surface the drop to the renderer so a discontinuity marker is shown.
       // Bypasses BackpressureManager.emitTerminalStatus() because each drop

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -555,7 +555,8 @@ export interface TerminalReliabilityMetricPayload {
     | "tier-transition"
     | "pause-duration-gauge"
     | "queue-depth-gauge"
-    | "data-loss-count";
+    | "data-loss-count"
+    | "ipc-cap-drop";
   timestamp: number;
   durationMs?: number;
   bufferUtilization?: number;

--- a/src/store/listeners/panel/__tests__/lifecycle.test.ts
+++ b/src/store/listeners/panel/__tests__/lifecycle.test.ts
@@ -492,6 +492,18 @@ describe("onReliabilityMetric — pause-duration-gauge routing", () => {
     expect(getPtyHeldDuration("term-1")).toBeUndefined();
   });
 
+  it("does not clear heldDurationMs on an ipc-cap-drop (terminal still paused, #9902)", () => {
+    // The hard-cap drop pulse is a data-path telemetry signal, not a
+    // resume: the IPC backpressure pause is still held when it fires.
+    setupPanel({ heldDurationMs: 7000 });
+    const handler = getReliabilityHandler();
+
+    handler({ metricType: "ipc-cap-drop", terminalId: "term-1" });
+    flushPanelStatusBuffer();
+
+    expect(getPtyHeldDuration("term-1")).toBe(7000);
+  });
+
   it("ignores non-pause-duration-gauge metric types", () => {
     setupPanel();
     const handler = getReliabilityHandler();

--- a/src/store/listeners/panel/__tests__/lifecycle.test.ts
+++ b/src/store/listeners/panel/__tests__/lifecycle.test.ts
@@ -504,6 +504,21 @@ describe("onReliabilityMetric — pause-duration-gauge routing", () => {
     expect(getPtyHeldDuration("term-1")).toBe(7000);
   });
 
+  it("ipc-cap-drop followed by a genuine pause-end still clears heldDurationMs", () => {
+    // The episode's eventual resume must not be masked by an earlier
+    // drop pulse — ordering guard for #9902.
+    setupPanel({ heldDurationMs: 7000 });
+    const handler = getReliabilityHandler();
+
+    handler({ metricType: "ipc-cap-drop", terminalId: "term-1" });
+    flushPanelStatusBuffer();
+    expect(getPtyHeldDuration("term-1")).toBe(7000);
+
+    handler({ metricType: "pause-end", terminalId: "term-1" });
+    flushPanelStatusBuffer();
+    expect(getPtyHeldDuration("term-1")).toBeUndefined();
+  });
+
   it("ignores non-pause-duration-gauge metric types", () => {
     setupPanel();
     const handler = getReliabilityHandler();

--- a/src/store/listeners/panel/lifecycle.ts
+++ b/src/store/listeners/panel/lifecycle.ts
@@ -429,9 +429,12 @@ export function setupLifecycleListeners(): DisposableStore {
           // value doesn't outlive the actual pause. `pause-duration-gauge`
           // is the skip-when-empty gauge that drives the held-duration
           // tooltip body. Other metric types (queue-depth-gauge,
-          // data-loss-count, pending-bytes-gauge, throughput-rate) are
-          // host-side telemetry sinks — observable via the host log
-          // stream and ignored here.
+          // data-loss-count, ipc-cap-drop, pending-bytes-gauge,
+          // throughput-rate) are host-side telemetry sinks — observable
+          // via the host log stream and ignored here. In particular,
+          // `ipc-cap-drop` (a chunk dropped at the IPC queue's hard cap)
+          // must NOT clear the gauge: the terminal is still paused when
+          // the drop fires (#9902).
           //
           // FUTURE_SAB: the `suspend` arm is the symmetric companion of the
           // `suspended` `flowStatus` dropped in the onStatus boundary above.


### PR DESCRIPTION
## Summary

- The IPC fallback queue hard-cap drop site in `electron/pty-host.ts` was emitting `metricType: "suspend"` with `source: null` via `emitReliabilityMetricWithTracking`. The funnel reads null-source + `suspend`/`pause-end` as a force-resume and called `clearAllPauseSources`, deleting the terminal's `pausedTerminals` Map entry while it was still genuinely paused by IPC backpressure. This corrupted pause-source attribution for the entire episode — `getPausedDurationsSnapshot` reported the terminal as not paused, silencing the "Paused for Xs" tooltip and triggering the renderer's `pause-duration-gauge` absent-loop which wiped `heldDurationMs`.
- A second independent bug: the drop site omitted `forceEmit: true`, violating the funnel's documented "data-loss pulse bypasses the metric gate" contract.
- Fix: added `"ipc-cap-drop"` to `TerminalReliabilityMetricPayload.metricType` in `shared/types/pty-host.ts`. The drop site now emits this type with `forceEmit: true`. The new type falls through the funnel with no map mutation, so only genuine force-resume events from `coordinator.forceReleaseAll` reach the `clearAllPauseSources` arm. Updated the stale drop-site comment that had claimed the funnel didn't touch the tracking map.

Resolves #9902

## Changes

- `shared/types/pty-host.ts` — added `"ipc-cap-drop"` to the `metricType` union in `TerminalReliabilityMetricPayload`
- `electron/pty-host.ts` — drop site emits `"ipc-cap-drop"` with `forceEmit: true`; stale comment updated
- `electron/__tests__/pty-host.adversarial.test.ts` — updated `IPC_QUEUE_FULL_EMITS_DATA_LOSS_STATUS` assertion to `ipc-cap-drop`; added `IPC_QUEUE_FULL_METRIC_BYPASSES_METRIC_GATE`; added lifecycle tests verifying `ipc-cap-drop` does not clear `heldDurationMs` and that a genuine `pause-end` after a cap-drop still clears correctly

## Testing

Unit tests updated and extended. Two previously untested cases now covered: (1) the drop pulse reaches the IPC wire even when the metric gate is off, and (2) the `pausedTerminals` Map entry survives a cap-drop and is only cleared by a genuine force-resume.