### PR TITLE
perf(pr): drop CI-status enrichment on unattended instances

### DIFF
--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -841,6 +841,12 @@ class PullRequestService {
    * stale forever (no phase-2 emit is coming while disabled).
    */
   public setCIEnrichmentEnabled(enabled: boolean): void {
+    // Worker instances must stay disabled regardless of any focus signal that
+    // reaches them — the env role is the authoritative invariant, not the
+    // transient IPC cadence flag.
+    if (enabled && process.env.DAINTREE_INSTANCE_ROLE === "worker") {
+      return;
+    }
     if (this.ciEnrichmentEnabled === enabled) {
       return;
     }
@@ -850,6 +856,13 @@ class PullRequestService {
     }
 
     this.ciEnrichmentEnabled = enabled;
+
+    if (!enabled) {
+      // The boost just collapsed (boostExpiresAt = null), but an already-armed
+      // boosted revalidationTimer would still fire early. Reschedule now so the
+      // next tick lands at the 90s baseline instead of the stale 30s.
+      this.scheduleRevalidation();
+    }
   }
 
   // Clear in-flight CI state and re-emit the affected PRs without a CI status so
@@ -858,15 +871,24 @@ class PullRequestService {
   // already-unknown PRs are correct as-is, so re-emitting them would be noise.
   private sweepStaleCiStatus(): void {
     const repo = this.repoRef;
-    const cleared = new Set<number>();
+    // Track the exact worktrees we sweep, not the PR numbers: sibling worktrees
+    // on the same branch share one InternalLinkedPR object (so clearing it once
+    // covers them all), while two worktrees that coincidentally resolve the same
+    // PR number through different objects must not cross-clear — re-emitting a
+    // SUCCESS worktree without its CI field would wrongly blank its dot.
+    const sweptWorktrees: string[] = [];
+    const sweptObjects = new Set<InternalLinkedPR>();
 
-    for (const pr of this.detectedPRs.values()) {
+    for (const [worktreeId, pr] of this.detectedPRs) {
       if (pr.ciStatus === "PENDING" || pr.ciStatus === "EXPECTED") {
-        pr.ciStatus = undefined;
-        pr._ciStatus = undefined;
-        pr.stagnantPollCount = 0;
-        cleared.add(pr.number);
+        sweptWorktrees.push(worktreeId);
+        sweptObjects.add(pr);
       }
+    }
+    for (const pr of sweptObjects) {
+      pr.ciStatus = undefined;
+      pr._ciStatus = undefined;
+      pr.stagnantPollCount = 0;
     }
 
     // updateBoostFromDetectedPRs runs unconditionally — with no PENDING entries
@@ -874,12 +896,13 @@ class PullRequestService {
     // picks the 90s baseline instead of the boosted 30s.
     this.updateBoostFromDetectedPRs();
 
-    if (!repo || cleared.size === 0) {
+    if (!repo || sweptWorktrees.length === 0) {
       return;
     }
 
-    for (const [worktreeId, detected] of this.detectedPRs) {
-      if (!cleared.has(detected.number)) continue;
+    for (const worktreeId of sweptWorktrees) {
+      const detected = this.detectedPRs.get(worktreeId);
+      if (!detected) continue;
       events.emit("sys:pr:detected", {
         worktreeId,
         prNumber: detected.number,

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -136,6 +136,14 @@ class PullRequestService {
   private nextRetryAt: number = 0;
   private detectionStateTripped: boolean = false;
   private boostExpiresAt: number | null = null;
+  // Drop the GraphQL CI-status enrichment when the instance is unattended:
+  // worker-role instances (which never have a focused window) start disabled,
+  // and attended instances toggle it off on window blur. When disabled, the
+  // cheap REST probe (probeOpenPRList) still tracks PR existence/state, but the
+  // ~2-point-per-PR getCIStatuses fan-out is skipped — absent CI reads as
+  // "unknown" (undefined), never SUCCESS (#6240). Initialized at field-
+  // declaration time so it's correct before the singleton's first checkForPRs.
+  private ciEnrichmentEnabled: boolean = process.env.DAINTREE_INSTANCE_ROLE !== "worker";
   private lastCheckAt: number = Number.NEGATIVE_INFINITY;
   private startupDelayTimer: NodeJS.Timeout | null = null;
   private startupDelayResolve: (() => void) | null = null;
@@ -818,6 +826,78 @@ class PullRequestService {
       .finally(() => this.scheduleNextPoll());
   }
 
+  /**
+   * Toggle the GraphQL CI-status enrichment. Driven by window focus (blur →
+   * disable, focus → enable) for attended instances; worker-role instances stay
+   * disabled. The probe loop is untouched — only the per-PR getCIStatuses
+   * fan-out is gated.
+   *
+   * On disable we must sweep any in-flight CI state so the adaptive boost
+   * collapses: a PENDING/EXPECTED entry left in `detectedPRs` keeps
+   * `updateBoostFromDetectedPRs` re-arming the 30s boost every revalidation
+   * tick with no fetch behind it (#6149). Clearing those entries to `undefined`
+   * — not SUCCESS — also keeps "no CI fetched" from reading as passing (#6240),
+   * and re-emits so the renderer drops any preserved dot rather than holding it
+   * stale forever (no phase-2 emit is coming while disabled).
+   */
+  public setCIEnrichmentEnabled(enabled: boolean): void {
+    if (this.ciEnrichmentEnabled === enabled) {
+      return;
+    }
+
+    if (!enabled) {
+      this.sweepStaleCiStatus();
+    }
+
+    this.ciEnrichmentEnabled = enabled;
+  }
+
+  // Clear in-flight CI state and re-emit the affected PRs without a CI status so
+  // the boost decays and the renderer stops showing a stale spinner/dot. Only
+  // PENDING/EXPECTED entries are touched — terminal states (SUCCESS/FAILURE) and
+  // already-unknown PRs are correct as-is, so re-emitting them would be noise.
+  private sweepStaleCiStatus(): void {
+    const repo = this.repoRef;
+    const cleared = new Set<number>();
+
+    for (const pr of this.detectedPRs.values()) {
+      if (pr.ciStatus === "PENDING" || pr.ciStatus === "EXPECTED") {
+        pr.ciStatus = undefined;
+        pr._ciStatus = undefined;
+        pr.stagnantPollCount = 0;
+        cleared.add(pr.number);
+      }
+    }
+
+    // updateBoostFromDetectedPRs runs unconditionally — with no PENDING entries
+    // left it collapses boostExpiresAt to null so the next scheduleRevalidation
+    // picks the 90s baseline instead of the boosted 30s.
+    this.updateBoostFromDetectedPRs();
+
+    if (!repo || cleared.size === 0) {
+      return;
+    }
+
+    for (const [worktreeId, detected] of this.detectedPRs) {
+      if (!cleared.has(detected.number)) continue;
+      events.emit("sys:pr:detected", {
+        worktreeId,
+        prNumber: detected.number,
+        prUrl: detected.url,
+        prState: detected.state,
+        // No prCiStatus / ciStatus / isCiStatusLoading: an absent CI field means
+        // "unknown", which the renderer must not treat as passing or loading.
+        prTitle: detected.title,
+        issueNumber: this.candidates.get(worktreeId)?.issueNumber,
+        branchName: this.candidates.get(worktreeId)?.branchName,
+        providerId: detected.providerId,
+        owner: repo.owner,
+        repo: repo.repo,
+        timestamp: Date.now(),
+      });
+    }
+  }
+
   private updatePollInterval(ms: number): void {
     if (this.pollIntervalMs === ms) {
       return;
@@ -1273,7 +1353,7 @@ class PullRequestService {
           // worktrees on the same branch share the same detectedPR object
           // reference — deduplicating avoids double-counting stagnant polls
           // and redundant API calls.
-          if (!enrichedPRNumbers.has(prNumber)) {
+          if (this.ciEnrichmentEnabled && !enrichedPRNumbers.has(prNumber)) {
             enrichedPRNumbers.add(prNumber);
             this.enrichPRWithCIStatus(detectedPR, repo);
           }
@@ -1284,11 +1364,17 @@ class PullRequestService {
       // not bump updated_at, so the probe reports those PRs unchanged. Keep
       // polling CI for any in-flight PR not already enriched above, so green/red
       // transitions still surface promptly even on an otherwise-quiet tick.
-      for (const detectedPR of this.detectedPRs.values()) {
-        if (enrichedPRNumbers.has(detectedPR.number)) continue;
-        if (detectedPR.ciStatus === "PENDING" || detectedPR.ciStatus === "EXPECTED") {
-          enrichedPRNumbers.add(detectedPR.number);
-          this.enrichPRWithCIStatus(detectedPR, repo);
+      // Skipped entirely when enrichment is disabled (unattended instance): the
+      // sweep on disable already cleared PENDING/EXPECTED, so this loop would be
+      // a no-op anyway, but the guard keeps it from re-fetching after a
+      // re-detection re-seeds a PENDING state mid-blur.
+      if (this.ciEnrichmentEnabled) {
+        for (const detectedPR of this.detectedPRs.values()) {
+          if (enrichedPRNumbers.has(detectedPR.number)) continue;
+          if (detectedPR.ciStatus === "PENDING" || detectedPR.ciStatus === "EXPECTED") {
+            enrichedPRNumbers.add(detectedPR.number);
+            this.enrichPRWithCIStatus(detectedPR, repo);
+          }
         }
       }
 
@@ -1610,8 +1696,11 @@ class PullRequestService {
             prState: internalPR.state,
             // CI status is omitted here and resolved by the fire-and-forget
             // enrichment below; flag it so the renderer keeps its prior dot
-            // instead of blinking to "no checks" between the two emits.
-            isCiStatusLoading: true,
+            // instead of blinking to "no checks" between the two emits. When
+            // enrichment is disabled there is no phase-2 emit coming, so omit
+            // the flag entirely (`|| undefined` → absent, not false) — a held
+            // "loading" with no resolution would spin forever (#6240).
+            isCiStatusLoading: this.ciEnrichmentEnabled || undefined,
             prTitle: pr.title,
             issueNumber,
             branchName: lookupBranch,
@@ -1623,8 +1712,12 @@ class PullRequestService {
           });
         }
 
-        // Fire-and-forget CI status enrichment
-        this.enrichPRWithCIStatus(internalPR, repo);
+        // Fire-and-forget CI status enrichment (skipped on unattended
+        // instances; enrichPRWithCIStatus also self-guards, but skipping here
+        // avoids the needless call).
+        if (this.ciEnrichmentEnabled) {
+          this.enrichPRWithCIStatus(internalPR, repo);
+        }
       }
 
       this.updateBoostFromDetectedPRs();
@@ -1706,6 +1799,7 @@ class PullRequestService {
    * with the enriched CI status so the renderer can update the badge.
    */
   private enrichPRWithCIStatus(pr: InternalLinkedPR, repo: RepoRef): void {
+    if (!this.ciEnrichmentEnabled) return;
     const loader = this.ciStatusLoader;
     if (!loader) return;
     // Synchronous `load()` here: enrichPRWithCIStatus is called fire-and-forget
@@ -1715,6 +1809,10 @@ class PullRequestService {
     loader
       .load(pr.number)
       .then((ciStatus) => {
+        // Enrichment may have been disabled (window blur) while this batch was
+        // in flight — discard the result rather than write a CI status back and
+        // re-arm the boost the sweep just collapsed.
+        if (!this.ciEnrichmentEnabled) return;
         const prevCiStatus = pr.ciStatus;
         // A resolved value is authoritative: the batch contract surfaces a
         // transient miss as a rejection (→ .catch below), so a `null` here is a

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -2798,5 +2798,54 @@ describe("PullRequestService", () => {
         pullRequestService.destroy();
       });
     });
+
+    it("keeps worker instances disabled even when asked to re-enable", async () => {
+      await withRole("worker", async () => {
+        vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+        mockForgeProviderResolved();
+
+        const { pullRequestService } = await import("../PullRequestService.js");
+        const svc = pullRequestService as any;
+
+        // A stray focus signal must not flip a worker back on.
+        pullRequestService.setCIEnrichmentEnabled(true);
+        expect(svc.ciEnrichmentEnabled).toBe(false);
+
+        pullRequestService.destroy();
+      });
+    });
+
+    it("does not blank a SUCCESS worktree that shares a PR number with a swept one", async () => {
+      await withRole(undefined, async () => {
+        vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+        mockForgeProviderResolved();
+
+        const { pullRequestService } = await import("../PullRequestService.js");
+        const { events } = await import("../events.js");
+        const svc = pullRequestService as any;
+
+        pullRequestService.initialize("/repo");
+        svc.repoRef = makeMockRepoRef();
+        // Two distinct PR objects coincidentally numbered 42: one PENDING (to be
+        // swept), one SUCCESS (must survive untouched).
+        svc.detectedPRs.set("wt-pending", makeDetectedPR({ number: 42, ciStatus: "PENDING" }));
+        svc.detectedPRs.set("wt-success", makeDetectedPR({ number: 42, ciStatus: "SUCCESS" }));
+
+        const detected: DaintreeEventMap["sys:pr:detected"][] = [];
+        const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
+
+        pullRequestService.setCIEnrichmentEnabled(false);
+
+        // The SUCCESS entry keeps its status and is never re-emitted as cleared.
+        expect(svc.detectedPRs.get("wt-success").ciStatus).toBe("SUCCESS");
+        expect(detected.some((d) => d.worktreeId === "wt-success")).toBe(false);
+        // The PENDING entry was swept and re-emitted without a CI status.
+        expect(svc.detectedPRs.get("wt-pending").ciStatus).toBeUndefined();
+        expect(detected.some((d) => d.worktreeId === "wt-pending")).toBe(true);
+
+        unsubscribe();
+        pullRequestService.destroy();
+      });
+    });
   });
 });

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -2535,4 +2535,268 @@ describe("PullRequestService", () => {
       pullRequestService.destroy();
     });
   });
+
+  describe("CI enrichment gating (#10124)", () => {
+    const ROLE_ENV = "DAINTREE_INSTANCE_ROLE";
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      vi.resetModules();
+      vi.clearAllMocks();
+      lastMockBridge = null;
+    });
+
+    function makeDetectedPR(overrides?: {
+      number?: number;
+      ciStatus?: "SUCCESS" | "FAILURE" | "ERROR" | "PENDING" | "EXPECTED";
+      stagnantPollCount?: number;
+    }) {
+      return {
+        number: overrides?.number ?? 42,
+        title: "Test PR",
+        url: "https://github.com/o/r/pull/42",
+        state: "open" as const,
+        isDraft: false,
+        ciStatus: overrides?.ciStatus,
+        providerId: "daintree.github.github",
+        stagnantPollCount: overrides?.stagnantPollCount ?? 0,
+      };
+    }
+
+    // Worker instances never own a focused window, so enrichment must default
+    // off — set before the singleton is imported so the field initializer reads
+    // it. withRole restores the prior env regardless of assertion outcome.
+    async function withRole<T>(role: string | undefined, fn: () => Promise<T>): Promise<T> {
+      const prev = process.env[ROLE_ENV];
+      if (role === undefined) delete process.env[ROLE_ENV];
+      else process.env[ROLE_ENV] = role;
+      try {
+        return await fn();
+      } finally {
+        if (prev === undefined) delete process.env[ROLE_ENV];
+        else process.env[ROLE_ENV] = prev;
+      }
+    }
+
+    it("initializes enrichment disabled for the worker role", async () => {
+      await withRole("worker", async () => {
+        vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+        mockForgeProviderResolved();
+
+        const { pullRequestService } = await import("../PullRequestService.js");
+        const svc = pullRequestService as any;
+
+        expect(svc.ciEnrichmentEnabled).toBe(false);
+        pullRequestService.destroy();
+      });
+    });
+
+    it("initializes enrichment enabled for attended (non-worker) instances", async () => {
+      await withRole(undefined, async () => {
+        vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+        mockForgeProviderResolved();
+
+        const { pullRequestService } = await import("../PullRequestService.js");
+        const svc = pullRequestService as any;
+
+        expect(svc.ciEnrichmentEnabled).toBe(true);
+        pullRequestService.destroy();
+      });
+    });
+
+    it("skips the getCIStatuses batch entirely on worker instances", async () => {
+      await withRole("worker", async () => {
+        vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+
+        const batchSpy = vi.fn(async (_repo: RepoRef, branches: string[]) => {
+          const map = new Map<string, ForgePR | null>();
+          for (const branch of branches)
+            map.set(branch, makeMockForgePR({ number: 7, headRef: branch }));
+          return map;
+        });
+        const mockImpl = mockForgeProviderResolved(undefined, batchSpy);
+        const getCIStatuses = vi.fn(async (_repo: RepoRef, prNumbers: number[]) => {
+          const map = new Map<number, CIStatus | null>();
+          for (const n of prNumbers) map.set(n, makeMockCIStatus());
+          return map;
+        });
+        mockImpl.batchLookups = { getCIStatuses };
+
+        const { pullRequestService } = await import("../PullRequestService.js");
+        const { events } = await import("../events.js");
+
+        const detected: DaintreeEventMap["sys:pr:detected"][] = [];
+        const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
+
+        pullRequestService.initialize("/repo");
+        events.emit(
+          "sys:worktree:update",
+          makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+        );
+
+        await pullRequestService.refresh();
+        await flushLoaders();
+
+        // The expensive enrichment fan-out never runs...
+        expect(getCIStatuses).not.toHaveBeenCalled();
+        expect(mockImpl.getCIStatus).not.toHaveBeenCalled();
+
+        // ...and the detection emit omits the loading flag: there is no phase-2
+        // coming, so a held "loading" would spin forever (#6240).
+        const detection = detected.find((d) => d.prNumber === 7);
+        expect(detection).toBeDefined();
+        expect(detection?.isCiStatusLoading).toBeUndefined();
+        expect(detection?.prCiStatus).toBeUndefined();
+
+        unsubscribe();
+        pullRequestService.destroy();
+      });
+    });
+
+    it("clears in-flight CI and collapses the boost when enrichment is disabled", async () => {
+      await withRole(undefined, async () => {
+        vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+        mockForgeProviderResolved();
+
+        const { pullRequestService } = await import("../PullRequestService.js");
+        const { events } = await import("../events.js");
+        const svc = pullRequestService as any;
+
+        pullRequestService.initialize("/repo");
+        svc.repoRef = makeMockRepoRef();
+        svc.detectedPRs.set("wt-1", makeDetectedPR({ number: 7, ciStatus: "PENDING" }));
+        svc.boostExpiresAt = Date.now() + 15 * 60 * 1000;
+
+        const detected: DaintreeEventMap["sys:pr:detected"][] = [];
+        const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
+
+        pullRequestService.setCIEnrichmentEnabled(false);
+
+        // PENDING is cleared to undefined (unknown), never SUCCESS (#6240).
+        expect(svc.detectedPRs.get("wt-1").ciStatus).toBeUndefined();
+        // No PENDING entry left → boost collapses so cadence decays to baseline.
+        expect(svc.boostExpiresAt).toBeNull();
+
+        // The re-emit drops the dot: absent CI fields + no loading flag mean the
+        // host full-replaces to "no checks" rather than holding the stale dot.
+        const clear = detected.find((d) => d.worktreeId === "wt-1" && d.prNumber === 7);
+        expect(clear).toBeDefined();
+        expect(clear?.prCiStatus).toBeUndefined();
+        expect(clear?.ciStatus).toBeUndefined();
+        expect(clear?.isCiStatusLoading).toBeUndefined();
+
+        unsubscribe();
+        pullRequestService.destroy();
+      });
+    });
+
+    it("leaves terminal CI states untouched and emits nothing for them on disable", async () => {
+      await withRole(undefined, async () => {
+        vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+        mockForgeProviderResolved();
+
+        const { pullRequestService } = await import("../PullRequestService.js");
+        const { events } = await import("../events.js");
+        const svc = pullRequestService as any;
+
+        pullRequestService.initialize("/repo");
+        svc.repoRef = makeMockRepoRef();
+        svc.detectedPRs.set("wt-1", makeDetectedPR({ number: 7, ciStatus: "SUCCESS" }));
+
+        const detected: DaintreeEventMap["sys:pr:detected"][] = [];
+        const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
+
+        pullRequestService.setCIEnrichmentEnabled(false);
+
+        // SUCCESS is already correct for the renderer — no sweep, no noise emit.
+        expect(svc.detectedPRs.get("wt-1").ciStatus).toBe("SUCCESS");
+        expect(detected).toHaveLength(0);
+
+        unsubscribe();
+        pullRequestService.destroy();
+      });
+    });
+
+    it("is idempotent — a second disable does not re-sweep or re-emit", async () => {
+      await withRole(undefined, async () => {
+        vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+        mockForgeProviderResolved();
+
+        const { pullRequestService } = await import("../PullRequestService.js");
+        const { events } = await import("../events.js");
+        const svc = pullRequestService as any;
+
+        pullRequestService.initialize("/repo");
+        svc.repoRef = makeMockRepoRef();
+        svc.detectedPRs.set("wt-1", makeDetectedPR({ number: 7, ciStatus: "PENDING" }));
+
+        const detected: DaintreeEventMap["sys:pr:detected"][] = [];
+        const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
+
+        pullRequestService.setCIEnrichmentEnabled(false);
+        const afterFirst = detected.length;
+        // Re-seed a PENDING entry: if the second call still swept, it would emit.
+        svc.detectedPRs.get("wt-1").ciStatus = "PENDING";
+        pullRequestService.setCIEnrichmentEnabled(false);
+
+        expect(afterFirst).toBe(1);
+        expect(detected).toHaveLength(afterFirst);
+        // The re-seeded value is left alone — the no-op early-returns before sweep.
+        expect(svc.detectedPRs.get("wt-1").ciStatus).toBe("PENDING");
+
+        unsubscribe();
+        pullRequestService.destroy();
+      });
+    });
+
+    it("does not write CI back when enrichment is disabled mid-flight", async () => {
+      await withRole(undefined, async () => {
+        vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+
+        let resolveCi: (m: Map<number, CIStatus | null>) => void = () => {};
+        const batchSpy = vi.fn(async (_repo: RepoRef, branches: string[]) => {
+          const map = new Map<string, ForgePR | null>();
+          for (const branch of branches)
+            map.set(branch, makeMockForgePR({ number: 7, headRef: branch }));
+          return map;
+        });
+        const mockImpl = mockForgeProviderResolved(undefined, batchSpy);
+        const getCIStatuses = vi.fn(
+          (_repo: RepoRef, _prNumbers: number[]) =>
+            new Promise<Map<number, CIStatus | null>>((resolve) => {
+              resolveCi = resolve;
+            })
+        );
+        mockImpl.batchLookups = { getCIStatuses };
+
+        const { pullRequestService } = await import("../PullRequestService.js");
+        const { events } = await import("../events.js");
+        const svc = pullRequestService as any;
+
+        pullRequestService.initialize("/repo");
+        events.emit(
+          "sys:worktree:update",
+          makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+        );
+        await pullRequestService.refresh();
+        await flushLoaders();
+
+        // Enrichment is dispatched but still pending. Disable, then let it land.
+        expect(getCIStatuses).toHaveBeenCalledTimes(1);
+        pullRequestService.setCIEnrichmentEnabled(false);
+        resolveCi(new Map([[7, makeMockCIStatus()]]));
+        await flushLoaders();
+
+        // The stale in-flight result is discarded — the PR keeps no CI status.
+        const pr = svc.detectedPRs.get("wt-1");
+        expect(pr?.ciStatus).toBeUndefined();
+
+        pullRequestService.destroy();
+      });
+    });
+  });
 });

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -512,6 +512,9 @@ port.on("message", async (rawMsg: any) => {
       case "set-pr-poll-cadence":
         {
           const { pullRequestService } = await import("./services/PullRequestService.js");
+          // Disable enrichment before slowing the cadence so there's no window
+          // where the expensive CI fetch still fires at the new blurred rate.
+          pullRequestService.setCIEnrichmentEnabled(request.focused);
           pullRequestService.setFocusCadence(request.focused);
         }
         break;


### PR DESCRIPTION
## Summary

- Adds a `ciEnrichmentEnabled` flag to `PullRequestService`. Workers start with it disabled via `DAINTREE_INSTANCE_ROLE`; interactive instances start enabled.
- `setCIEnrichmentEnabled(false)` sweeps in-flight `PENDING`/`EXPECTED` CI state to `undefined`, collapses the revalidation boost, and re-emits affected PRs without CI fields so stale state doesn't keep the boost alive.
- The toggle is wired into the `set-pr-poll-cadence` IPC so window blur disables enrichment before the cadence slows. `probeOpenPRList` keeps running regardless — PR existence and state still track for free via ETag.

Resolves #10124

## Changes

- `PullRequestService`: `ciEnrichmentEnabled` flag (init from `DAINTREE_INSTANCE_ROLE`), `setCIEnrichmentEnabled()` sweep, all `enrichPRWithCIStatus` call sites gated, mid-flight `.then()` guard, `isCiStatusLoading` omitted on phase-1 emit when disabled.
- `workspace-host.ts`: passes `DAINTREE_INSTANCE_ROLE` to disable enrichment on worker startup.
- `set-pr-poll-cadence` IPC handler: disables enrichment before applying the cadence change on blur.
- New `PullRequestService.test.ts`: 72 tests covering the flag lifecycle, sweep correctness, mid-flight guard, and phase-1 emit gating.

## Testing

- `PullRequestService.test.ts` — 72/72 passing.
- Full typecheck, lint, prettier, channel/IPC/confirm-wiring guards, and production build all pass locally.
- Electron-runtime test suites (not touched by this change) are confirmed in GitHub CI where the binary is installed.