### PR TITLE
fix(webview): dismiss JS dialogs on guest navigation and renderer crash

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -365,6 +365,7 @@ export const CHANNELS = {
   WEBVIEW_REGISTER_PANEL: "webview:register-panel",
   WEBVIEW_DIALOG_REQUEST: "webview:dialog-request",
   WEBVIEW_DIALOG_RESPONSE: "webview:dialog-response",
+  WEBVIEW_DIALOG_DISMISS: "webview:dialog-dismiss",
   WEBVIEW_FIND_SHORTCUT: "webview:find-shortcut",
   WEBVIEW_RELOAD_SHORTCUT: "webview:reload-shortcut",
   WEBVIEW_NAVIGATION_BLOCKED: "webview:navigation-blocked",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1871,6 +1871,8 @@ const api: ElectronAPI = {
         defaultValue: string;
       }) => void
     ): (() => void) => _typedOn(CHANNELS.WEBVIEW_DIALOG_REQUEST, callback),
+    onDialogDismiss: (callback: (payload: { panelId: string }) => void): (() => void) =>
+      _typedOn(CHANNELS.WEBVIEW_DIALOG_DISMISS, callback),
     onFindShortcut: (
       callback: (payload: { panelId: string; shortcut: "find" | "next" | "prev" | "close" }) => void
     ): (() => void) => _typedOn(CHANNELS.WEBVIEW_FIND_SHORTCUT, callback),

--- a/electron/services/WebviewDialogService.ts
+++ b/electron/services/WebviewDialogService.ts
@@ -124,7 +124,7 @@ class WebviewDialogService {
     }
   }
 
-  private cancelPendingForGuest(webContentsId: number): void {
+  cancelPendingForGuest(webContentsId: number): void {
     for (const [dialogId, pending] of this.pendingDialogs) {
       if (pending.webContentsId === webContentsId) {
         this.pendingDialogs.delete(dialogId);

--- a/electron/services/__tests__/WebviewDialogService.adversarial.test.ts
+++ b/electron/services/__tests__/WebviewDialogService.adversarial.test.ts
@@ -147,6 +147,67 @@ describe("WebviewDialogService adversarial", () => {
     expect(firstCallback).toHaveBeenCalledWith(true, "yes");
   });
 
+  it("NAVIGATION_CANCELS_PENDING_ONLY_OWN_GUEST", async () => {
+    const guestOne = createGuest();
+    const guestTwo = createGuest();
+    guestRegistry.set(1, guestOne);
+    guestRegistry.set(2, guestTwo);
+
+    const callbackOne = vi.fn();
+    const callbackTwo = vi.fn();
+
+    const { getWebviewDialogService } = await import("../WebviewDialogService.js");
+    const service = getWebviewDialogService();
+
+    service.registerPanel(1, "panel-1");
+    service.registerPanel(2, "panel-2");
+    service.registerDialog("dialog-1", 1, callbackOne);
+    service.registerDialog("dialog-2", 2, callbackTwo);
+
+    // Simulate a navigation/crash on guest one (the protocols.ts handler calls this).
+    service.cancelPendingForGuest(1);
+
+    expect(callbackOne).toHaveBeenCalledTimes(1);
+    expect(callbackOne).toHaveBeenCalledWith(false);
+    expect(callbackTwo).not.toHaveBeenCalled();
+
+    // A second cancel for the same guest must be a no-op (no double callback).
+    service.cancelPendingForGuest(1);
+    expect(callbackOne).toHaveBeenCalledTimes(1);
+
+    // Guest two's dialog is untouched and still resolvable.
+    service.resolveDialog("dialog-2", true, "confirmed");
+    expect(callbackTwo).toHaveBeenCalledTimes(1);
+    expect(callbackTwo).toHaveBeenCalledWith(true, "confirmed");
+  });
+
+  it("CANCEL_SWALLOWS_THROWING_CALLBACK", async () => {
+    const guest = createGuest();
+    guestRegistry.set(1, guest);
+
+    const throwingCallback = vi.fn(() => {
+      throw new Error("guest already gone");
+    });
+    const survivingCallback = vi.fn();
+
+    const { getWebviewDialogService } = await import("../WebviewDialogService.js");
+    const service = getWebviewDialogService();
+
+    service.registerPanel(1, "panel-1");
+    service.registerDialog("dialog-throws", 1, throwingCallback);
+    service.registerDialog("dialog-ok", 1, survivingCallback);
+
+    // A throwing callback (e.g. crashed guest) must not abort cancellation of the rest.
+    expect(() => service.cancelPendingForGuest(1)).not.toThrow();
+    expect(throwingCallback).toHaveBeenCalledTimes(1);
+    expect(survivingCallback).toHaveBeenCalledTimes(1);
+    expect(survivingCallback).toHaveBeenCalledWith(false);
+
+    // Both dialogs are cleared — resolving them afterwards is a no-op.
+    service.resolveDialog("dialog-ok", true);
+    expect(survivingCallback).toHaveBeenCalledTimes(1);
+  });
+
   it("REJECTED_OAUTH_PROMISE_ONE_SHOT", async () => {
     const { getWebviewDialogService } = await import("../WebviewDialogService.js");
     const service = getWebviewDialogService();

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -5,8 +5,10 @@ type WebContentsCreatedListener = (event: unknown, contents: MockWebContents) =>
 
 interface MockWebContents {
   getType: () => string;
+  isDestroyed: () => boolean;
   setWindowOpenHandler: ReturnType<typeof vi.fn>;
   on: ReturnType<typeof vi.fn>;
+  once: ReturnType<typeof vi.fn>;
   executeJavaScript: ReturnType<typeof vi.fn>;
   id: number;
 }
@@ -112,6 +114,7 @@ vi.mock("../../services/WebviewDialogService.js", () => ({
     registerDialog: vi.fn(),
     getPanelId: vi.fn(() => "panel-browser-1"),
     getPanelKind: vi.fn(() => "dev-preview"),
+    cancelPendingForGuest: vi.fn(),
     storeOAuthSessionStorage: vi.fn(),
   })),
 }));
@@ -125,6 +128,7 @@ vi.mock("../../ipc/channels.js", () => ({
     WEBVIEW_FIND_SHORTCUT: "webview:find-shortcut",
     WEBVIEW_RELOAD_SHORTCUT: "webview:reload-shortcut",
     WEBVIEW_NAVIGATION_BLOCKED: "webview:navigation-blocked",
+    WEBVIEW_DIALOG_DISMISS: "webview:dialog-dismiss",
   },
 }));
 
@@ -142,14 +146,17 @@ const mockedGetWebviewDialogService = vi.mocked(getWebviewDialogService);
 
 function createMockWebContents(type: "webview" | "window" | "browserView"): MockWebContents {
   const eventHandlers = new Map<string, ((...args: unknown[]) => void)[]>();
+  const record = (event: string, handler: (...args: unknown[]) => void) => {
+    const handlers = eventHandlers.get(event) ?? [];
+    handlers.push(handler);
+    eventHandlers.set(event, handlers);
+  };
   return {
     getType: () => type,
+    isDestroyed: () => false,
     setWindowOpenHandler: vi.fn(),
-    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
-      const handlers = eventHandlers.get(event) ?? [];
-      handlers.push(handler);
-      eventHandlers.set(event, handlers);
-    }),
+    on: vi.fn(record),
+    once: vi.fn(record),
     executeJavaScript: vi.fn().mockResolvedValue([]),
     id: Math.floor(Math.random() * 1000),
     // expose for testing
@@ -163,9 +170,12 @@ function getEventHandlers(
   contents: MockWebContents,
   eventName: string
 ): ((...args: unknown[]) => void)[] {
-  return (contents.on as ReturnType<typeof vi.fn>).mock.calls
-    .filter((call) => call[0] === eventName)
-    .map((call) => call[1] as (...args: unknown[]) => void);
+  // Reads both .on and .once registrations (both record into _eventHandlers).
+  return (
+    (
+      contents as unknown as { _eventHandlers: Map<string, ((...args: unknown[]) => void)[]> }
+    )._eventHandlers.get(eventName) ?? []
+  );
 }
 
 describe("setupWebviewCSP — webview guest navigation restriction", () => {
@@ -506,6 +516,119 @@ describe("setupWebviewCSP — webview guest navigation restriction", () => {
 
       expect(mockEvent.preventDefault).not.toHaveBeenCalled();
       expect(mockSend).not.toHaveBeenCalledWith("webview:reload-shortcut", expect.anything());
+    });
+  });
+
+  describe("dialog dismissal on navigation, crash, and destroy (#9943)", () => {
+    function setupGuestWithDialogService(): {
+      contents: MockWebContents;
+      cancelPendingForGuest: ReturnType<typeof vi.fn>;
+      mockSend: ReturnType<typeof vi.fn>;
+    } {
+      const mockSend = vi.fn();
+      mockFromWebContents.mockReturnValue({
+        isDestroyed: () => false,
+        webContents: { send: mockSend },
+      });
+      const cancelPendingForGuest = vi.fn();
+      mockedGetWebviewDialogService.mockReturnValue({
+        registerDialog: vi.fn(),
+        getPanelId: vi.fn(() => "panel-1"),
+        cancelPendingForGuest,
+      } as unknown as ReturnType<typeof getWebviewDialogService>);
+
+      const contents = createMockWebContents("webview");
+      (contents as unknown as { hostWebContents: unknown }).hostWebContents = { id: 99 };
+      simulateWebContentsCreated(contents);
+      return { contents, cancelPendingForGuest, mockSend };
+    }
+
+    it("registers did-navigate, render-process-gone, and destroyed handlers on the guest", () => {
+      const { contents } = setupGuestWithDialogService();
+      expect(getEventHandlers(contents, "did-navigate").length).toBe(1);
+      expect(getEventHandlers(contents, "render-process-gone").length).toBe(1);
+      expect(getEventHandlers(contents, "destroyed").length).toBe(1);
+    });
+
+    it("cancels pending dialogs and notifies the renderer on did-navigate", () => {
+      const { contents, cancelPendingForGuest, mockSend } = setupGuestWithDialogService();
+      getEventHandlers(contents, "did-navigate")[0]({}, "http://localhost:3000/next", 200, "OK");
+
+      expect(cancelPendingForGuest).toHaveBeenCalledWith(contents.id);
+      expect(mockSend).toHaveBeenCalledWith("webview:dialog-dismiss", { panelId: "panel-1" });
+    });
+
+    it("cancels pending dialogs and notifies the renderer on render-process-gone", () => {
+      const { contents, cancelPendingForGuest, mockSend } = setupGuestWithDialogService();
+      getEventHandlers(contents, "render-process-gone")[0]({}, { reason: "crashed" });
+
+      expect(cancelPendingForGuest).toHaveBeenCalledWith(contents.id);
+      expect(mockSend).toHaveBeenCalledWith("webview:dialog-dismiss", { panelId: "panel-1" });
+    });
+
+    it("dismisses on destroyed using the cached parent window after hostWebContents is gone", () => {
+      const mockSend = vi.fn();
+      mockFromWebContents.mockReturnValue({
+        isDestroyed: () => false,
+        webContents: { send: mockSend },
+      });
+      const cancelPendingForGuest = vi.fn();
+      mockedGetWebviewDialogService.mockReturnValue({
+        registerDialog: vi.fn(() => "panel-1"),
+        getPanelId: vi.fn(() => "panel-1"),
+        cancelPendingForGuest,
+      } as unknown as ReturnType<typeof getWebviewDialogService>);
+
+      const contents = createMockWebContents("webview");
+      (contents as unknown as { hostWebContents: unknown }).hostWebContents = { id: 99 };
+      simulateWebContentsCreated(contents);
+
+      // A dialog is shown while the guest is alive — this caches the parent window.
+      const jsDialogHandlers = getEventHandlers(contents, "js-dialog");
+      jsDialogHandlers[0](
+        { preventDefault: vi.fn() },
+        "http://localhost:3000",
+        "msg",
+        "alert",
+        "",
+        vi.fn()
+      );
+
+      // The guest is then destroyed: hostWebContents is unreachable and the live
+      // lookup returns null, so the destroy handler must fall back to the cached
+      // window captured during the guest's lifetime.
+      (contents as unknown as { isDestroyed: () => boolean }).isDestroyed = () => true;
+      mockFromWebContents.mockReturnValue(null);
+      mockSend.mockClear();
+
+      getEventHandlers(contents, "destroyed")[0]();
+
+      expect(cancelPendingForGuest).toHaveBeenCalledWith(contents.id);
+      expect(mockSend).toHaveBeenCalledWith("webview:dialog-dismiss", { panelId: "panel-1" });
+    });
+
+    it("does not notify the renderer when no panel is registered for the guest", () => {
+      const mockSend = vi.fn();
+      mockFromWebContents.mockReturnValue({
+        isDestroyed: () => false,
+        webContents: { send: mockSend },
+      });
+      const cancelPendingForGuest = vi.fn();
+      mockedGetWebviewDialogService.mockReturnValue({
+        registerDialog: vi.fn(),
+        getPanelId: vi.fn(() => undefined),
+        cancelPendingForGuest,
+      } as unknown as ReturnType<typeof getWebviewDialogService>);
+
+      const contents = createMockWebContents("webview");
+      (contents as unknown as { hostWebContents: unknown }).hostWebContents = { id: 99 };
+      simulateWebContentsCreated(contents);
+
+      getEventHandlers(contents, "did-navigate")[0]({}, "http://localhost:3000/next", 200, "OK");
+
+      // Callbacks are still cancelled main-side, but no stale dismiss is broadcast.
+      expect(cancelPendingForGuest).toHaveBeenCalledWith(contents.id);
+      expect(mockSend).not.toHaveBeenCalledWith("webview:dialog-dismiss", expect.anything());
     });
   });
 

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -847,6 +847,27 @@ export function setupWebviewCSP(): void {
       contents.on("unresponsive", notifyUnresponsive);
       contents.on("responsive", notifyResponsive);
 
+      // Dismiss any pending JS dialogs when the guest navigates to a new document
+      // or its renderer crashes. Chromium discards the native dialog state in both
+      // cases, so the stored callback would otherwise leak and the renderer overlay
+      // would survive a page that no longer exists. did-navigate fires only for
+      // cross-document main-frame navigations (same-document hash/pushState changes
+      // emit did-navigate-in-page and are correctly ignored).
+      const dismissPendingDialogs = () => {
+        if (contents.isDestroyed()) return;
+        const dialogService = getWebviewDialogService();
+        const panelId = dialogService.getPanelId(contents.id);
+        dialogService.cancelPendingForGuest(contents.id);
+        if (!panelId) return;
+        const parentWindow = getWindowForWebContents(contents.hostWebContents ?? contents);
+        if (parentWindow && !parentWindow.isDestroyed()) {
+          getAppWebContents(parentWindow).send(CHANNELS.WEBVIEW_DIALOG_DISMISS, { panelId });
+        }
+      };
+
+      contents.on("did-navigate", dismissPendingDialogs);
+      contents.on("render-process-gone", dismissPendingDialogs);
+
       // Intercept find-in-page (Cmd/Ctrl+F, Cmd/Ctrl+G, Escape) and reload
       // (Cmd/Ctrl+R) shortcuts from webview guests. When the guest has focus
       // Chromium routes keystrokes directly to it, so the outer renderer's

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -780,6 +780,19 @@ export function setupWebviewCSP(): void {
         }
       });
 
+      // Resolve and cache the guest's parent window. On the `destroyed` event the
+      // guest's hostWebContents is no longer reachable, so dismiss-on-destroy falls
+      // back to the reference captured while the guest was alive — populated when a
+      // dialog is first intercepted below (a dialog can only be pending if this ran).
+      let cachedParentWindow: Electron.BrowserWindow | null = null;
+      const resolveParentWindow = (): Electron.BrowserWindow | null => {
+        if (!contents.isDestroyed()) {
+          const live = getWindowForWebContents(contents.hostWebContents ?? contents);
+          if (live) cachedParentWindow = live;
+        }
+        return cachedParentWindow && !cachedParentWindow.isDestroyed() ? cachedParentWindow : null;
+      };
+
       // Intercept JavaScript dialogs (alert/confirm/prompt) from webview guests.
       // Electron 40+ emits "js-dialog" but its TS types omit it from the overload union.
       (contents as { on: (event: string, listener: (...args: unknown[]) => void) => void }).on(
@@ -807,8 +820,8 @@ export function setupWebviewCSP(): void {
             return;
           }
 
-          const parentWindow = getWindowForWebContents(contents.hostWebContents ?? contents);
-          if (parentWindow && !parentWindow.isDestroyed()) {
+          const parentWindow = resolveParentWindow();
+          if (parentWindow) {
             getAppWebContents(parentWindow).send("webview:dialog-request", {
               dialogId,
               panelId,
@@ -847,26 +860,28 @@ export function setupWebviewCSP(): void {
       contents.on("unresponsive", notifyUnresponsive);
       contents.on("responsive", notifyResponsive);
 
-      // Dismiss any pending JS dialogs when the guest navigates to a new document
-      // or its renderer crashes. Chromium discards the native dialog state in both
+      // Dismiss any pending JS dialogs when the guest navigates to a new document,
+      // its renderer crashes, or it is destroyed (e.g. the <webview> is remounted on
+      // a partition change). Chromium discards the native dialog state in all three
       // cases, so the stored callback would otherwise leak and the renderer overlay
       // would survive a page that no longer exists. did-navigate fires only for
       // cross-document main-frame navigations (same-document hash/pushState changes
-      // emit did-navigate-in-page and are correctly ignored).
+      // emit did-navigate-in-page and are correctly ignored). The destroyed path
+      // relies on the cached parent window since hostWebContents is gone by then.
       const dismissPendingDialogs = () => {
-        if (contents.isDestroyed()) return;
         const dialogService = getWebviewDialogService();
         const panelId = dialogService.getPanelId(contents.id);
         dialogService.cancelPendingForGuest(contents.id);
         if (!panelId) return;
-        const parentWindow = getWindowForWebContents(contents.hostWebContents ?? contents);
-        if (parentWindow && !parentWindow.isDestroyed()) {
+        const parentWindow = resolveParentWindow();
+        if (parentWindow) {
           getAppWebContents(parentWindow).send(CHANNELS.WEBVIEW_DIALOG_DISMISS, { panelId });
         }
       };
 
       contents.on("did-navigate", dismissPendingDialogs);
       contents.on("render-process-gone", dismissPendingDialogs);
+      contents.once("destroyed", dismissPendingDialogs);
 
       // Intercept find-in-page (Cmd/Ctrl+F, Cmd/Ctrl+G, Escape) and reload
       // (Cmd/Ctrl+R) shortcuts from webview guests. When the guest has focus

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -897,6 +897,8 @@ export interface ElectronAPI extends GeneratedElectronAPI {
         defaultValue: string;
       }) => void
     ): () => void;
+    /** Subscribe to dialog-dismiss events — guest navigated away or its renderer crashed */
+    onDialogDismiss(callback: (payload: { panelId: string }) => void): () => void;
     /** Subscribe to find-in-page shortcuts forwarded from focused webview guests */
     onFindShortcut(
       callback: (payload: { panelId: string; shortcut: "find" | "next" | "prev" | "close" }) => void

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1806,6 +1806,12 @@ export interface IpcEventMap {
     defaultValue: string;
   };
 
+  // Webview dialogs dismissed — guest navigated away or its renderer crashed,
+  // invalidating any pending dialog overlays for the panel
+  "webview:dialog-dismiss": {
+    panelId: string;
+  };
+
   // Webview find-in-page shortcut forwarded from guest
   "webview:find-shortcut": {
     panelId: string;

--- a/src/hooks/__tests__/useWebviewDialog.test.tsx
+++ b/src/hooks/__tests__/useWebviewDialog.test.tsx
@@ -23,12 +23,18 @@ interface DialogRequestPayload {
 }
 
 let dialogListener: ((payload: DialogRequestPayload) => void) | null = null;
+let dismissListener: ((payload: { panelId: string }) => void) | null = null;
+let dismissCleanup: ReturnType<typeof vi.fn>;
 let respondToDialog: ReturnType<typeof vi.fn>;
 let registerPanel: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   vi.clearAllMocks();
   dialogListener = null;
+  dismissListener = null;
+  dismissCleanup = vi.fn(() => {
+    dismissListener = null;
+  });
   respondToDialog = vi.fn();
   registerPanel = vi.fn().mockResolvedValue(undefined);
 
@@ -43,6 +49,10 @@ beforeEach(() => {
             dialogListener = null;
           };
         },
+        onDialogDismiss: (cb: (payload: { panelId: string }) => void) => {
+          dismissListener = cb;
+          return dismissCleanup;
+        },
       },
     },
     writable: true,
@@ -53,6 +63,11 @@ beforeEach(() => {
 function emitDialog(panelId: string, dialogId: string): void {
   if (!dialogListener) throw new Error("dialog listener not registered");
   dialogListener({ panelId, dialogId });
+}
+
+function emitDismiss(panelId: string): void {
+  if (!dismissListener) throw new Error("dismiss listener not registered");
+  dismissListener({ panelId });
 }
 
 describe("useWebviewDialog", () => {
@@ -128,5 +143,58 @@ describe("useWebviewDialog", () => {
 
     expect(notify).not.toHaveBeenCalled();
     expect(logError).not.toHaveBeenCalled();
+  });
+
+  it("clears the dialog queue on dismiss for the matching panel", async () => {
+    const { result } = renderHook(() => useWebviewDialog("panel-1", null, false));
+
+    act(() => {
+      emitDialog("panel-1", "dialog-1");
+      emitDialog("panel-1", "dialog-2");
+    });
+
+    await waitFor(() => {
+      expect(result.current.currentDialog?.dialogId).toBe("dialog-1");
+    });
+
+    // Guest navigated away / crashed — main sends a dismiss for this panel.
+    act(() => {
+      emitDismiss("panel-1");
+    });
+
+    await waitFor(() => {
+      expect(result.current.currentDialog).toBeNull();
+    });
+
+    // No response was sent for the stale dialogs.
+    expect(respondToDialog).not.toHaveBeenCalled();
+  });
+
+  it("ignores a dismiss for a different panel", async () => {
+    const { result } = renderHook(() => useWebviewDialog("panel-1", null, false));
+
+    act(() => {
+      emitDialog("panel-1", "dialog-1");
+    });
+
+    await waitFor(() => {
+      expect(result.current.currentDialog?.dialogId).toBe("dialog-1");
+    });
+
+    act(() => {
+      emitDismiss("panel-other");
+    });
+
+    // This panel's dialog is untouched.
+    expect(result.current.currentDialog?.dialogId).toBe("dialog-1");
+  });
+
+  it("unsubscribes from dismiss events on unmount", () => {
+    const { unmount } = renderHook(() => useWebviewDialog("panel-1", null, false));
+
+    expect(dismissListener).not.toBeNull();
+    unmount();
+    expect(dismissCleanup).toHaveBeenCalled();
+    expect(dismissListener).toBeNull();
   });
 });

--- a/src/hooks/useWebviewDialog.ts
+++ b/src/hooks/useWebviewDialog.ts
@@ -41,6 +41,18 @@ export function useWebviewDialog(
     return cleanup;
   }, [panelId]);
 
+  // Clear queued dialogs when the guest navigates away or its renderer crashes —
+  // the page context backing those dialogs no longer exists, so their overlays
+  // are stale and can never receive a meaningful response.
+  useEffect(() => {
+    const cleanup = window.electron.webview.onDialogDismiss((payload) => {
+      if (payload.panelId === panelId) {
+        setDialogQueue([]);
+      }
+    });
+    return cleanup;
+  }, [panelId]);
+
   const handleDialogRespond = useCallback(
     (confirmed: boolean, response?: string) => {
       const current = dialogQueue[0];


### PR DESCRIPTION
## Summary

- Webview JS dialogs (`alert`/`confirm`/`prompt`) were only dismissed when the guest `webContents` was destroyed, so they survived cross-document navigation and renderer crashes and left stale overlays over newly loaded pages.
- Adds `did-navigate`, `render-process-gone`, and `destroyed` listeners in `protocols.ts` that cancel pending main-side dialog callbacks in `WebviewDialogService` and broadcast a new `WEBVIEW_DIALOG_DISMISS` IPC event so the renderer hook `useWebviewDialog` clears its dialog queue.
- A cached parent-window reference covers the `destroyed` path -- by the time that event fires, `hostWebContents` is no longer reachable from the guest.

Resolves #9943

## Changes

- `electron/setup/protocols.ts` -- three new guest lifecycle listeners that cancel pending callbacks and send `WEBVIEW_DIALOG_DISMISS`
- `electron/services/WebviewDialogService.ts` -- expose a cancel method for pending callbacks
- `electron/ipc/channels.ts`, `electron/preload.cts`, `shared/types/ipc/` -- wire up the new IPC event
- `src/hooks/useWebviewDialog.ts` -- subscribe to `WEBVIEW_DIALOG_DISMISS` and drain the queue
- `electron/setup/__tests__/protocols.test.ts`, `src/hooks/__tests__/useWebviewDialog.test.tsx`, `electron/services/__tests__/WebviewDialogService.adversarial.test.ts` -- test coverage for all three lifecycle paths

## Testing

Full vitest suite (32407 tests), typecheck, `lint:ratchet`, `format:check`, build, and all IPC/channel/confirm-wiring guards passed locally. Smoke test is Linux-only and blocked on macOS; GitHub CI will confirm it.