### PR TITLE
fix(demo): pin capture resolution via applyConstraints (#10152)

### DIFF
--- a/e2e/screenshots/demo-reel.spec.ts
+++ b/e2e/screenshots/demo-reel.spec.ts
@@ -19,6 +19,8 @@
 
 import { test, expect, type Page } from "@playwright/test";
 import { mkdirSync, existsSync, statSync } from "fs";
+import { execFileSync } from "child_process";
+import ffmpegPath from "ffmpeg-static";
 import path from "path";
 import { launchApp, closeApp, mockOpenDialog, refreshActiveWindow } from "../helpers/launch";
 import { dismissTelemetryConsent } from "../helpers/project";
@@ -28,6 +30,28 @@ import { createBrushCmsRepo, type DemoRepo } from "../helpers/screenshotFixtures
 
 const OUTPUT_DIR = path.resolve(process.cwd(), "artifacts", "demo");
 mkdirSync(OUTPUT_DIR, { recursive: true });
+
+/**
+ * Read a WebM's video-stream pixel dimensions by parsing ffmpeg's input-probe
+ * stderr. ffmpeg-static ships `ffmpeg` but not `ffprobe`; `ffmpeg -i <file>`
+ * with no output target exits non-zero yet prints the `Stream … Video: … WxH`
+ * line to stderr. Returns null if ffmpeg is unavailable or the line is absent
+ * (so the caller can skip rather than fail the whole reel build).
+ */
+function readVideoDimensions(filePath: string): { width: number; height: number } | null {
+  if (!ffmpegPath) return null;
+  let stderr = "";
+  try {
+    execFileSync(ffmpegPath, ["-hide_banner", "-i", filePath], {
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+  } catch (err) {
+    stderr = String((err as { stderr?: Buffer | string }).stderr ?? "");
+  }
+  const match = stderr.match(/Video:.*?\b(\d+)x(\d+)\b/);
+  if (!match) return null;
+  return { width: Number(match[1]), height: Number(match[2]) };
+}
 
 // Output resolution, UI zoom, and quality are env-configurable. Defaults to a
 // 4K master at NO zoom (1.0×) — the true desktop density, rendered crisp at 4K.
@@ -275,6 +299,20 @@ test.describe.serial("Demo Video — worktree dashboard", () => {
       console.log(`[demo-reel] wrote ${outputPath} (${(bytes / 1_000_000).toFixed(1)} MB)`);
       expect(result.stop.frameCount).toBeGreaterThan(3);
       expect(bytes).toBeGreaterThan(10_000);
+
+      // Regression guard for #10152: the recorded frame must be pinned to the
+      // exact output preset, not the surface's native backing-store size.
+      // CAPTURE_W/H come from the resolution preset while the asserted values
+      // are parsed from the actual encoded file, so removing the applyConstraints
+      // pin (which would record at SCALE×LOGICAL) breaks this assertion.
+      const dims = readVideoDimensions(outputPath);
+      if (dims) {
+        console.log(`[demo-reel] recorded dimensions ${dims.width}×${dims.height}`);
+        expect(dims.width).toBe(CAPTURE_W);
+        expect(dims.height).toBe(CAPTURE_H);
+      } else {
+        console.warn("[demo-reel] ffmpeg unavailable — skipped dimension assertion");
+      }
     } finally {
       if (app) await closeApp(app).catch(() => {});
       repo.cleanup();

--- a/e2e/screenshots/demo-reel.spec.ts
+++ b/e2e/screenshots/demo-reel.spec.ts
@@ -304,8 +304,24 @@ test.describe.serial("Demo Video — worktree dashboard", () => {
       // exact output preset, not the surface's native backing-store size.
       // CAPTURE_W/H come from the resolution preset while the asserted values
       // are parsed from the actual encoded file, so removing the applyConstraints
-      // pin (which would record at SCALE×LOGICAL) breaks this assertion.
+      // pin (which would record at NATIVE_W/H = SCALE×LOGICAL) breaks this when
+      // native ≠ target. The pin is only load-bearing when those differ (e.g.
+      // 1440p: native 3840×2160 vs target 2560×1440); presets where native ==
+      // target (default 4k, 1080p) still assert correctness but can't catch a
+      // missing pin — log which case this run exercised so coverage is visible.
+      const NATIVE_W = LOGICAL_W * SCALE;
+      const NATIVE_H = LOGICAL_H * SCALE;
+      const pinLoadBearing = NATIVE_W !== CAPTURE_W || NATIVE_H !== CAPTURE_H;
+      console.log(
+        `[demo-reel] native ${NATIVE_W}×${NATIVE_H} → target ${CAPTURE_W}×${CAPTURE_H} ` +
+          `(pin ${pinLoadBearing ? "load-bearing — true regression guard" : "no-op for this preset"})`
+      );
       const dims = readVideoDimensions(outputPath);
+      // When ffmpeg is available the check is mandatory — a parse failure must
+      // not silently skip the guard. Only skip when ffmpeg-static is absent.
+      if (ffmpegPath) {
+        expect(dims, "ffmpeg present but recorded dimensions could not be read").not.toBeNull();
+      }
       if (dims) {
         console.log(`[demo-reel] recorded dimensions ${dims.width}×${dims.height}`);
         expect(dims.width).toBe(CAPTURE_W);

--- a/shared/types/ipc/demo.ts
+++ b/shared/types/ipc/demo.ts
@@ -41,9 +41,19 @@ export interface DemoStartCapturePayload {
    * handler when omitted. Set explicitly for embeddable/master-quality output.
    */
   videoBitsPerSecond?: number;
-  /** Force the captured frame width in device pixels (getDisplayMedia ideal). */
+  /**
+   * Pin the captured frame width in device pixels. Enforced via applyConstraints
+   * after getDisplayMedia (getDisplayMedia ignores width/height for display
+   * capture); the recording fails if Chromium can't deliver this exact size.
+   * Omit to record at the surface's native resolution.
+   */
   width?: number;
-  /** Force the captured frame height in device pixels (getDisplayMedia ideal). */
+  /**
+   * Pin the captured frame height in device pixels. Enforced via applyConstraints
+   * after getDisplayMedia (getDisplayMedia ignores width/height for display
+   * capture); the recording fails if Chromium can't deliver this exact size.
+   * Omit to record at the surface's native resolution.
+   */
   height?: number;
 }
 

--- a/src/components/Demo/DemoCaptureBridge.tsx
+++ b/src/components/Demo/DemoCaptureBridge.tsx
@@ -100,13 +100,27 @@ export function DemoCaptureBridge() {
           return;
         }
 
+        // Resolution is all-or-nothing: a partial request (one dimension, or a
+        // non-positive value) would silently fall through to native size, which
+        // is exactly the wrong-resolution bug this guards against. Fail fast.
+        const wantWidth = typeof width === "number" && width > 0;
+        const wantHeight = typeof height === "number" && height > 0;
+        if (wantWidth !== wantHeight) {
+          stream.getTracks().forEach((t) => t.stop());
+          api.sendCommandDone(
+            requestId,
+            "Capture resolution requires both width and height (got one)"
+          );
+          return;
+        }
+
         // Pin the captured frame to the exact requested size. getDisplayMedia
         // ignores width/height, so applyConstraints({ exact }) is the only seam
         // that forces Chromium to downscale the track (e.g. 3840×2160 backing
         // store → 2560×1440). It succeeds when the requested ratio matches the
         // surface (the demo window is sized to match), otherwise it rejects.
         // Fail hard on any miss rather than silently recording the wrong size.
-        if (width && height) {
+        if (wantWidth && wantHeight) {
           const videoTrack = stream.getVideoTracks()[0];
           if (!videoTrack) {
             stream.getTracks().forEach((t) => t.stop());

--- a/src/components/Demo/DemoCaptureBridge.tsx
+++ b/src/components/Demo/DemoCaptureBridge.tsx
@@ -77,10 +77,11 @@ export function DemoCaptureBridge() {
           return;
         }
 
-        // Pin the capture resolution when requested so the recorded frame is a
-        // precise size (e.g. 3840×2160) rather than whatever the surface
-        // happens to be. `ideal` keeps the request soft so capture still
-        // succeeds if the backend can't hit the exact size.
+        // Request the capture resolution as `ideal` so acquisition stays soft —
+        // `exact` here throws TypeError for display capture. Chromium treats
+        // width/height as advisory for getDisplayMedia, so the delivered track
+        // is the surface's native backing-store size; we pin it precisely below
+        // via applyConstraints().
         const videoConstraints: MediaTrackConstraints = { frameRate: fps };
         if (width && height) {
           videoConstraints.width = { ideal: width };
@@ -97,6 +98,42 @@ export function DemoCaptureBridge() {
           const message = formatErrorMessage(err, "getDisplayMedia failed");
           api.sendCommandDone(requestId, `getDisplayMedia failed: ${message}`);
           return;
+        }
+
+        // Pin the captured frame to the exact requested size. getDisplayMedia
+        // ignores width/height, so applyConstraints({ exact }) is the only seam
+        // that forces Chromium to downscale the track (e.g. 3840×2160 backing
+        // store → 2560×1440). It succeeds when the requested ratio matches the
+        // surface (the demo window is sized to match), otherwise it rejects.
+        // Fail hard on any miss rather than silently recording the wrong size.
+        if (width && height) {
+          const videoTrack = stream.getVideoTracks()[0];
+          if (!videoTrack) {
+            stream.getTracks().forEach((t) => t.stop());
+            api.sendCommandDone(requestId, "No video track in capture stream");
+            return;
+          }
+          try {
+            await videoTrack.applyConstraints({
+              width: { exact: width },
+              height: { exact: height },
+            });
+          } catch (err) {
+            stream.getTracks().forEach((t) => t.stop());
+            const message = formatErrorMessage(err, "applyConstraints failed");
+            api.sendCommandDone(requestId, `Capture resolution pin failed: ${message}`);
+            return;
+          }
+          const settings = videoTrack.getSettings();
+          if (settings.width !== width || settings.height !== height) {
+            stream.getTracks().forEach((t) => t.stop());
+            api.sendCommandDone(
+              requestId,
+              `Capture resolution mismatch: got ${settings.width}×${settings.height}, ` +
+                `wanted ${width}×${height}`
+            );
+            return;
+          }
         }
 
         const mimeType = MediaRecorder.isTypeSupported(requestedMime)


### PR DESCRIPTION
## Summary

- `getDisplayMedia` treats `width`/`height` as advisory for display capture, so the demo was recording at the surface's native backing-store size rather than the requested resolution — the 1440p preset was silently producing 3840×2160 frames at a 1440p bitrate budget.
- After acquisition, the fix calls `track.applyConstraints({ width: { exact }, height: { exact } })`, verifies via `track.getSettings()`, and fails the capture on mismatch rather than silently handing a wrongly-sized track to `MediaRecorder`.
- Also corrects the `DemoStartCapturePayload` `width`/`height` doc-comments to match the actual contract, and adds a non-tautological WebM dimension assertion to the demo-reel e2e spec that parses encoded dimensions via `ffmpeg-static` — mandatory when ffmpeg is available, with load-bearing-pin visibility logging.

Resolves #10152

## Changes

- `src/components/Demo/DemoCaptureBridge.tsx` — call `applyConstraints` after track acquisition, verify with `getSettings`, throw on mismatch or partial input
- `shared/types/ipc/demo.ts` — updated `width`/`height` doc-comments to reflect `applyConstraints` enforcement rather than advisory `ideal` constraint
- `e2e/screenshots/demo-reel.spec.ts` — dimension assertion via `ffmpeg-static`; logs recorded dimensions for pin visibility; skips gracefully when ffmpeg is unavailable

## Testing

- 55 demo unit tests pass (typecheck, lint, format, IPC/channel/confirm-wiring guards all clean)
- Production build passes with preload backdoor strip
- Smoke test blocked only by missing local Electron binary cache; GitHub CI will confirm