### PR TITLE
fix(lifecycle): halt deferred init queue at quit so tasks cannot re-init torn-down services

### DIFF
--- a/electron/lifecycle/__tests__/shutdown.test.ts
+++ b/electron/lifecycle/__tests__/shutdown.test.ts
@@ -223,6 +223,12 @@ const serviceRefsMock = vi.hoisted(() => {
 
 vi.mock("../../window/serviceRefs.js", () => serviceRefsMock);
 
+const deferredInitQueueMock = vi.hoisted(() => ({
+  haltDeferredQueue: vi.fn(),
+}));
+
+vi.mock("../../window/deferredInitQueue.js", () => deferredInitQueueMock);
+
 import type { ShutdownDeps } from "../shutdown.js";
 
 function makeDeps(overrides?: Partial<ShutdownDeps>): ShutdownDeps {
@@ -359,6 +365,59 @@ describe("registerShutdownHandler", () => {
     expect(event.preventDefault).toHaveBeenCalled();
     expect(quitWarningMock.showQuitWarning).toHaveBeenCalled();
     expect(crashRecoveryMock.cleanupOnExit).not.toHaveBeenCalled();
+    expect(appMock.exit).not.toHaveBeenCalled();
+  });
+
+  it("halts the deferred init queue before the cleanup chain starts", async () => {
+    const { drainRateLimitQueues } = await import("../../ipc/utils.js");
+    const { beforeQuitCb } = await setup();
+    const event = makeEvent();
+    await beforeQuitCb(event);
+
+    expect(deferredInitQueueMock.haltDeferredQueue).toHaveBeenCalledTimes(1);
+    const haltOrder = deferredInitQueueMock.haltDeferredQueue.mock.invocationCallOrder[0];
+    const drainOrder = vi.mocked(drainRateLimitQueues).mock.invocationCallOrder[0];
+    expect(haltOrder).toBeLessThan(drainOrder);
+
+    await vi.waitFor(() => {
+      expect(appMock.exit).toHaveBeenCalledWith(0);
+    });
+  });
+
+  it("halts the deferred init queue after the user confirms quit", async () => {
+    quitWarningMock.getActiveAgentCount.mockReturnValue(2);
+    quitWarningMock.showQuitWarning.mockResolvedValue(true);
+
+    const mainWindow = {} as Electron.BrowserWindow;
+    const { beforeQuitCb } = await setup({
+      windowRegistry: {
+        getPrimary: () => ({ browserWindow: mainWindow }),
+      } as unknown as ShutdownDeps["windowRegistry"],
+    });
+    const event = makeEvent();
+    await beforeQuitCb(event);
+
+    expect(deferredInitQueueMock.haltDeferredQueue).toHaveBeenCalledTimes(1);
+
+    await vi.waitFor(() => {
+      expect(appMock.exit).toHaveBeenCalledWith(0);
+    });
+  });
+
+  it("does not halt the deferred init queue when the user cancels quit", async () => {
+    quitWarningMock.getActiveAgentCount.mockReturnValue(2);
+    quitWarningMock.showQuitWarning.mockResolvedValue(false);
+
+    const mainWindow = {} as Electron.BrowserWindow;
+    const { beforeQuitCb } = await setup({
+      windowRegistry: {
+        getPrimary: () => ({ browserWindow: mainWindow }),
+      } as unknown as ShutdownDeps["windowRegistry"],
+    });
+    const event = makeEvent();
+    await beforeQuitCb(event);
+
+    expect(deferredInitQueueMock.haltDeferredQueue).not.toHaveBeenCalled();
     expect(appMock.exit).not.toHaveBeenCalled();
   });
 

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -122,7 +122,11 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
 
     // Halt the deferred init queue before anything yields to the event loop —
     // a pending setImmediate drain step could otherwise re-initialize services
-    // the cleanup chain below is about to tear down (issue #9881).
+    // the cleanup chain below is about to tear down (issue #9881). Placed
+    // after the quit-confirmation dialog deliberately: halting is permanent,
+    // so a cancelled quit must never reach it (an abandoned drain chain cannot
+    // be resumed). Tasks that start during the dialog run against a fully live
+    // app and are torn down by the cleanup chain like any other service.
     haltDeferredQueue();
 
     // Eager snapshot at quit-intent so the next launch has a post-quit-intent

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -46,6 +46,7 @@ import {
   getWindowsStoreNotifierServiceRef,
   setWindowsStoreNotifierServiceRef,
 } from "../window/serviceRefs.js";
+import { haltDeferredQueue } from "../window/deferredInitQueue.js";
 import { closeSharedDb } from "../services/persistence/db.js";
 import { closeTelemetry } from "../services/TelemetryService.js";
 import { isSmokeTest } from "../setup/environment.js";
@@ -118,6 +119,11 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
     }
 
     isQuitting = true;
+
+    // Halt the deferred init queue before anything yields to the event loop —
+    // a pending setImmediate drain step could otherwise re-initialize services
+    // the cleanup chain below is about to tear down (issue #9881).
+    haltDeferredQueue();
 
     // Eager snapshot at quit-intent so the next launch has a post-quit-intent
     // backup regardless of which branch of the cleanup race wins. Without this,

--- a/electron/window/__tests__/deferredInitQueue.test.ts
+++ b/electron/window/__tests__/deferredInitQueue.test.ts
@@ -18,19 +18,21 @@ import {
   signalFirstInteractive,
   getDeferredQueueState,
   resetDeferredQueue,
+  haltDeferredQueue,
+  __resetDeferredQueueForTests,
 } from "../deferredInitQueue.js";
 import { notifyError } from "../../ipc/errorHandlers.js";
 import { trackEvent } from "../../services/TelemetryService.js";
 
 describe("deferredInitQueue", () => {
   beforeEach(() => {
-    resetDeferredQueue();
+    __resetDeferredQueueForTests();
     vi.clearAllMocks();
     vi.useFakeTimers();
   });
 
   afterEach(() => {
-    resetDeferredQueue();
+    __resetDeferredQueueForTests();
     vi.useRealTimers();
   });
 
@@ -382,5 +384,125 @@ describe("deferredInitQueue", () => {
     expect(task).not.toHaveBeenCalled();
     expect(getDeferredQueueState().drainState).toBe("idle");
     expect(getDeferredQueueState().firstInteractiveReceived).toBe(true);
+  });
+
+  it("halt stops an in-flight drain — remaining tasks never run", async () => {
+    let releaseFirst: () => void = () => {};
+    const firstRun = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        })
+    );
+    const secondRun = vi.fn();
+
+    registerDeferredTask({ name: "hang", run: firstRun });
+    registerDeferredTask({ name: "after-halt", run: secondRun });
+    finalizeDeferredRegistration(10_000);
+    signalFirstInteractive(1);
+
+    // Let the first task start but not finish
+    await vi.advanceTimersByTimeAsync(0);
+    expect(firstRun).toHaveBeenCalledTimes(1);
+    expect(getDeferredQueueState().drainState).toBe("draining");
+
+    // before-quit fires mid-drain
+    haltDeferredQueue();
+
+    releaseFirst();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(secondRun).not.toHaveBeenCalled();
+    expect(getDeferredQueueState().drainState).toBe("draining");
+  });
+
+  it("signalFirstInteractive after halt does not start a drain", async () => {
+    const task = vi.fn();
+    registerDeferredTask({ name: "t", run: task });
+    finalizeDeferredRegistration(10_000);
+
+    haltDeferredQueue();
+    signalFirstInteractive(1);
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(task).not.toHaveBeenCalled();
+    expect(getDeferredQueueState().drainState).toBe("idle");
+  });
+
+  it("fallback timer armed before halt never fires tasks", async () => {
+    const task = vi.fn();
+    registerDeferredTask({ name: "fb", run: task });
+    finalizeDeferredRegistration(5_000);
+
+    haltDeferredQueue();
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(task).not.toHaveBeenCalled();
+    expect(getDeferredQueueState().drainState).toBe("idle");
+  });
+
+  it("finalize after halt does not arm the fallback timer", async () => {
+    const task = vi.fn();
+    registerDeferredTask({ name: "t", run: task });
+
+    haltDeferredQueue();
+    finalizeDeferredRegistration(5_000);
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(task).not.toHaveBeenCalled();
+    expect(getDeferredQueueState().drainState).toBe("idle");
+    expect(getDeferredQueueState().registrationComplete).toBe(false);
+  });
+
+  it("registration after halt is dropped, not run immediately", async () => {
+    // Drain fully so the "run immediately" late path would normally apply
+    registerDeferredTask({ name: "early", run: vi.fn() });
+    finalizeDeferredRegistration(10_000);
+    signalFirstInteractive(1);
+    await waitForDrain();
+
+    haltDeferredQueue();
+
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const late = vi.fn();
+    registerDeferredTask({ name: "late", run: late });
+
+    expect(late).not.toHaveBeenCalled();
+    expect(consoleWarn).toHaveBeenCalled();
+    consoleWarn.mockRestore();
+  });
+
+  it("halt does not break a later fresh cycle when reset is not part of a quit", async () => {
+    // macOS re-open regression guard: a cycle that never saw haltDeferredQueue
+    // (reset on last-window-close, new window, new drain) works normally.
+    const t1 = vi.fn();
+    registerDeferredTask({ name: "t1", run: t1 });
+    finalizeDeferredRegistration(10_000);
+    signalFirstInteractive(1);
+    await waitForDrain();
+
+    resetDeferredQueue();
+
+    const t2 = vi.fn();
+    registerDeferredTask({ name: "t2", run: t2 });
+    finalizeDeferredRegistration(10_000);
+    signalFirstInteractive(2);
+    await waitForDrain();
+    expect(t2).toHaveBeenCalledTimes(1);
+  });
+
+  it("resetDeferredQueue does not undo a halt", async () => {
+    haltDeferredQueue();
+    // Last-window-close reset racing the quit sequence must not unhalt
+    resetDeferredQueue();
+
+    const task = vi.fn();
+    registerDeferredTask({ name: "t", run: task });
+    finalizeDeferredRegistration(10_000);
+    signalFirstInteractive(1);
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(task).not.toHaveBeenCalled();
+    expect(getDeferredQueueState().drainState).toBe("idle");
   });
 });

--- a/electron/window/__tests__/deferredInitQueue.test.ts
+++ b/electron/window/__tests__/deferredInitQueue.test.ts
@@ -472,8 +472,8 @@ describe("deferredInitQueue", () => {
     consoleWarn.mockRestore();
   });
 
-  it("halt does not break a later fresh cycle when reset is not part of a quit", async () => {
-    // macOS re-open regression guard: a cycle that never saw haltDeferredQueue
+  it("non-quit reset still allows a fresh cycle to drain (macOS re-open)", async () => {
+    // Regression guard: a cycle that never saw haltDeferredQueue
     // (reset on last-window-close, new window, new drain) works normally.
     const t1 = vi.fn();
     registerDeferredTask({ name: "t1", run: t1 });
@@ -489,6 +489,39 @@ describe("deferredInitQueue", () => {
     signalFirstInteractive(2);
     await waitForDrain();
     expect(t2).toHaveBeenCalledTimes(1);
+  });
+
+  it("halt between a sync task and its queued setImmediate stops the chain", async () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    registerDeferredTask({ name: "sync-a", run: first });
+    registerDeferredTask({ name: "sync-b", run: second });
+    finalizeDeferredRegistration(10_000);
+    // doDrain runs synchronously from the signal: task A executes, task B's
+    // setImmediate is queued but has not fired yet when control returns here.
+    signalFirstInteractive(1);
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).not.toHaveBeenCalled();
+
+    haltDeferredQueue();
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(second).not.toHaveBeenCalled();
+    expect(getDeferredQueueState().drainState).toBe("draining");
+  });
+
+  it("halt on a virgin queue drops registrations without queueing them", async () => {
+    haltDeferredQueue();
+
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const task = vi.fn();
+    registerDeferredTask({ name: "t", run: task });
+
+    expect(task).not.toHaveBeenCalled();
+    expect(consoleWarn).toHaveBeenCalled();
+    expect(getDeferredQueueState().taskCount).toBe(0);
+    expect(getDeferredQueueState().drainState).toBe("idle");
+    consoleWarn.mockRestore();
   });
 
   it("resetDeferredQueue does not undo a halt", async () => {

--- a/electron/window/deferredInitQueue.ts
+++ b/electron/window/deferredInitQueue.ts
@@ -25,8 +25,18 @@ const drainedSenderIds = new Set<number>();
 // cycle's state. Without this, a stale `drainNext` could fire against an
 // empty `tasks[]` and mark the fresh queue as "drained" before any work runs.
 let generation = 0;
+// Set once by `haltDeferredQueue()` when shutdown begins (`before-quit`).
+// Process-lifetime: never cleared by `resetDeferredQueue()`, because on quit
+// the last-window-close reset fires before `before-quit` and must not be able
+// to undo the halt. Once halted, no deferred task may start — the services
+// they would initialize are being torn down.
+let halted = false;
 
 export function registerDeferredTask(task: DeferredTask): void {
+  if (halted) {
+    console.warn(`[DeferredInit] Task "${task.name}" dropped — queue halted for shutdown`);
+    return;
+  }
   if (drainState !== "idle") {
     console.warn(
       `[DeferredInit] Task "${task.name}" registered after drain started — running immediately`
@@ -45,6 +55,7 @@ export function registerDeferredTask(task: DeferredTask): void {
 }
 
 export function finalizeDeferredRegistration(fallbackMs: number = DEFAULT_FALLBACK_MS): void {
+  if (halted) return;
   if (registrationComplete) return;
   registrationComplete = true;
 
@@ -67,6 +78,7 @@ export function finalizeDeferredRegistration(fallbackMs: number = DEFAULT_FALLBA
 }
 
 export function signalFirstInteractive(webContentsId: number | null): void {
+  if (halted) return;
   if (webContentsId !== null) {
     if (drainedSenderIds.has(webContentsId)) return;
     drainedSenderIds.add(webContentsId);
@@ -142,7 +154,28 @@ function reportDeferredTaskFailure(taskName: string, err: unknown): void {
   }
 }
 
+/**
+ * Permanently stop the queue for shutdown. Called synchronously at the start
+ * of `before-quit`, before the first await, so pending `setImmediate` drain
+ * callbacks observe the halt instead of re-initializing services the cleanup
+ * chain is tearing down. Idempotent; never undone by `resetDeferredQueue()`.
+ */
+export function haltDeferredQueue(): void {
+  halted = true;
+  if (fallbackTimer) {
+    clearTimeout(fallbackTimer);
+    fallbackTimer = null;
+  }
+}
+
+/** Test-only: full reset including the process-lifetime `halted` latch. */
+export function __resetDeferredQueueForTests(): void {
+  resetDeferredQueue();
+  halted = false;
+}
+
 function doDrain(): void {
+  if (halted) return;
   if (drainState !== "idle") return;
   drainState = "draining";
 
@@ -158,7 +191,7 @@ function doDrain(): void {
 }
 
 function drainNext(index: number, startedAt: number, drainGen: number): void {
-  if (drainGen !== generation) return; // queue was reset — abandon this chain
+  if (drainGen !== generation || halted) return; // queue was reset or halted — abandon this chain
   if (index >= tasks.length) {
     drainState = "drained";
     const elapsed = Date.now() - startedAt;


### PR DESCRIPTION
## Summary

- The deferred init queue (`electron/window/deferredInitQueue.ts`) drains via a `setImmediate` chain with no shutdown awareness — pending tasks (plugin-cli-server, mcp-server, resource-profile-service, disk-space-monitor) could still run after `before-quit` began tearing down services, leaving orphaned sockets, timers, and servers at exit.
- Adds a process-lifetime `halted` latch and an exported `haltDeferredQueue()`, guarded at all five execution entry points. `shutdown.ts` calls it synchronously right after `isQuitting = true` and before the first `await`, so any in-flight `setImmediate` callbacks observe the halt immediately.
- Halting is permanent and deliberately placed after the quit-confirmation dialog (a cancelled quit must never reach it). `resetDeferredQueue()` intentionally does not clear the latch, preserving the macOS re-open path where `last-window-close` fires before `before-quit`.

Resolves #9881

## Changes

- `electron/window/deferredInitQueue.ts`: `halted` latch, `haltDeferredQueue()` export, guards at `registerDeferredTask`, `signalFirstInteractive`, `finalizeDeferredRegistration`, `doDrain`, and `drainNext`; `__resetDeferredQueueForTests()` for test isolation.
- `electron/lifecycle/shutdown.ts`: call `haltDeferredQueue()` as the first synchronous step after setting `isQuitting`.
- `electron/window/__tests__/deferredInitQueue.test.ts`: 9 new cases — halted in-flight drain, signal/fallback-timer/finalize/registration after halt, sync `setImmediate`-gap halt, macOS re-open regression, reset-does-not-unhalt.
- `electron/lifecycle/__tests__/shutdown.test.ts`: 3 integration tests asserting `haltDeferredQueue` fires before the cleanup chain, after dialog confirm, and never on a cancelled quit.

## Testing

58/58 targeted unit tests pass. All static checks, format, lint-ratchet, and `npx tsc --noEmit` pass locally. `npm run build` could not complete locally due to machine memory pressure (concurrent worktrees); GitHub CI will confirm the build.