### PR TITLE
fix(wsl): refresh git eligibility when default distro changes (#9924)

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -407,6 +407,7 @@ export const CHANNELS = {
   WORKTREE_CONFIG_SET_PATTERN: "worktree-config:set-pattern",
   WORKTREE_CONFIG_SET_WSL_GIT: "worktree-config:set-wsl-git",
   WORKTREE_CONFIG_DISMISS_WSL_BANNER: "worktree-config:dismiss-wsl-banner",
+  WORKTREE_CONFIG_REPROBE_WSL: "worktree-config:reprobe-wsl",
 
   WINDOW_TOGGLE_FULLSCREEN: "window:toggle-fullscreen",
   WINDOW_RELOAD: "window:reload",

--- a/electron/ipc/handlers/worktreeConfig.preload.ts
+++ b/electron/ipc/handlers/worktreeConfig.preload.ts
@@ -12,6 +12,7 @@ export const WORKTREE_CONFIG_METHOD_CHANNELS = {
   setPattern: "worktree-config:set-pattern",
   setWslGit: "worktree-config:set-wsl-git",
   dismissWslBanner: "worktree-config:dismiss-wsl-banner",
+  reprobeWsl: "worktree-config:reprobe-wsl",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 export interface WorktreeConfigPreloadBindings {
@@ -19,6 +20,7 @@ export interface WorktreeConfigPreloadBindings {
   setPattern(pattern: string): Promise<IpcInvokeMap["worktree-config:set-pattern"]["result"]>;
   setWslGit(worktreeId: string, enabled: boolean): Promise<void>;
   dismissWslBanner(worktreeId: string): Promise<void>;
+  reprobeWsl(worktreeId: string): Promise<void>;
 }
 
 type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
@@ -37,5 +39,7 @@ export function buildWorktreeConfigPreloadBindings(invoke: Invoker): WorktreeCon
       invoke(WORKTREE_CONFIG_METHOD_CHANNELS.setWslGit, { worktreeId, enabled }) as Promise<void>,
     dismissWslBanner: (worktreeId) =>
       invoke(WORKTREE_CONFIG_METHOD_CHANNELS.dismissWslBanner, { worktreeId }) as Promise<void>,
+    reprobeWsl: (worktreeId) =>
+      invoke(WORKTREE_CONFIG_METHOD_CHANNELS.reprobeWsl, { worktreeId }) as Promise<void>,
   };
 }

--- a/electron/ipc/handlers/worktreeConfig.ts
+++ b/electron/ipc/handlers/worktreeConfig.ts
@@ -106,6 +106,19 @@ export function registerWorktreeConfigHandlers(deps: HandlerDependencies): () =>
           deps.worktreeService?.setWslOptIn(worktreeId, enabled, true);
         }
       ),
+      reprobeWsl: op(
+        WORKTREE_CONFIG_METHOD_CHANNELS.reprobeWsl,
+        async (payload: { worktreeId: string }): Promise<void> => {
+          if (!payload || typeof payload !== "object") {
+            throw new Error("Invalid reprobe-wsl payload");
+          }
+          const { worktreeId } = payload;
+          if (typeof worktreeId !== "string" || !worktreeId.trim()) {
+            throw new Error("Invalid worktreeId: must be a non-empty string");
+          }
+          deps.worktreeService?.reprobeWsl(worktreeId);
+        }
+      ),
     },
   });
 

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -272,6 +272,12 @@ export class WorkspaceClient extends EventEmitter {
     }
   }
 
+  reprobeWsl(worktreeId: string): void {
+    for (const entry of this.pool.entries.values()) {
+      entry.host.send({ type: "reprobe-wsl", worktreeId });
+    }
+  }
+
   updateMonitorConfig(config: MonitorConfig): void {
     for (const entry of this.pool.entries.values()) {
       const requestId = entry.host.generateRequestId();

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -396,6 +396,10 @@ port.on("message", async (rawMsg: any) => {
         workspaceService.setWslOptIn(request.worktreeId, request.enabled, request.dismissed);
         break;
 
+      case "reprobe-wsl":
+        void workspaceService.reprobeWslForWorktree(request.worktreeId);
+        break;
+
       case "sync":
         try {
           await workspaceService.syncMonitors(

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -150,6 +150,12 @@ export class WorkspaceService {
   private wslLastKnownDefaultDistro: string | null | undefined = undefined;
   /** Background poll handle that watches for WSL default-distro changes. */
   private wslDistroPoller: ReturnType<typeof setInterval> | null = null;
+  /**
+   * Monotonic guard so a slow probe (poll or reprobe) that resolves after a
+   * newer probe — or after a project switch — discards its stale result instead
+   * of overwriting fresher state or refreshing the next project's monitors.
+   */
+  private wslProbeSeq = 0;
   /** How often to re-check the WSL default distro (Windows only). */
   private static readonly WSL_DISTRO_POLL_INTERVAL_MS = 60_000;
 
@@ -797,10 +803,34 @@ export class WorkspaceService {
 
   /** Stop the WSL distro watcher (project switch / dispose). */
   private stopWslDistroPoller(): void {
+    // Bump the sequence so any in-flight probe (poll or reprobe) sees itself
+    // superseded and bails before mutating state — otherwise a probe awaiting
+    // across a project switch could refresh the next project's monitors with
+    // this project's distro.
+    this.wslProbeSeq++;
     if (this.wslDistroPoller) {
       clearInterval(this.wslDistroPoller);
       this.wslDistroPoller = null;
     }
+  }
+
+  /**
+   * Probe the default distro under a sequence guard. Returns whether this probe
+   * is still the most recent one — a later probe (concurrent reprobe, or a
+   * project switch via `stopWslDistroPoller`) supersedes an earlier one so the
+   * stale result is discarded rather than overwriting fresher state.
+   */
+  private async probeDefaultDistro(): Promise<{ distro: string | null; current: boolean }> {
+    const seq = ++this.wslProbeSeq;
+    const distro = await getDefaultWslDistro().catch(() => null);
+    return { distro, current: seq === this.wslProbeSeq };
+  }
+
+  /** Commit a fresh probe result to the cache and fan it out to all monitors. */
+  private applyDefaultDistro(distro: string | null): void {
+    this.wslLastKnownDefaultDistro = distro;
+    this.wslDefaultDistroPromise = Promise.resolve(distro);
+    this.refreshWslEligibilityForAllMonitors(distro);
   }
 
   /**
@@ -809,11 +839,10 @@ export class WorkspaceService {
    * stop using a stale decision.
    */
   private async pollWslDefaultDistro(): Promise<void> {
-    const current = await getDefaultWslDistro().catch(() => null);
-    if (current === this.wslLastKnownDefaultDistro) return;
-    this.wslLastKnownDefaultDistro = current;
-    this.wslDefaultDistroPromise = Promise.resolve(current);
-    this.refreshWslEligibilityForAllMonitors(current);
+    const { distro, current } = await this.probeDefaultDistro();
+    if (!current) return;
+    if (distro === this.wslLastKnownDefaultDistro) return;
+    this.applyDefaultDistro(distro);
   }
 
   /**
@@ -838,10 +867,9 @@ export class WorkspaceService {
     const monitor = this.monitors.get(worktreeId);
     if (!monitor || !monitor.isWslPath) return;
     monitor.setWslEligible("unprobed");
-    const current = await getDefaultWslDistro().catch(() => null);
-    this.wslLastKnownDefaultDistro = current;
-    this.wslDefaultDistroPromise = Promise.resolve(current);
-    this.refreshWslEligibilityForAllMonitors(current);
+    const { distro, current } = await this.probeDefaultDistro();
+    if (!current) return;
+    this.applyDefaultDistro(distro);
   }
 
   /**

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -9,7 +9,7 @@ import { generateProjectId, settingsFilePath } from "../services/projectStorePat
 import { SimpleGit, BranchSummary } from "simple-git";
 import { createHardenedGit, createAuthenticatedGit } from "../utils/hardenedGit.js";
 import { classifyGitError, getGitRecoveryAction } from "../../shared/utils/gitOperationErrors.js";
-import type { Worktree } from "../../shared/types/worktree.js";
+import type { Worktree, WslGitEligibility } from "../../shared/types/worktree.js";
 import type {
   WorkspaceHostEvent,
   WorktreeSnapshot,
@@ -142,6 +142,16 @@ export class WorkspaceService {
   private wslGitByWorktree: Record<string, { enabled: boolean; dismissed: boolean }> = {};
   /** Cached default WSL distro (populated lazily on first WSL-path detection). */
   private wslDefaultDistroPromise: Promise<string | null> | null = null;
+  /**
+   * Last default distro the poller observed. `undefined` until the first probe
+   * seeds it (so the first poll tick can't spuriously diff against it). `null`
+   * means the probe ran but found no default (WSL absent / probe failed).
+   */
+  private wslLastKnownDefaultDistro: string | null | undefined = undefined;
+  /** Background poll handle that watches for WSL default-distro changes. */
+  private wslDistroPoller: ReturnType<typeof setInterval> | null = null;
+  /** How often to re-check the WSL default distro (Windows only). */
+  private static readonly WSL_DISTRO_POLL_INTERVAL_MS = 60_000;
 
   // Topology watcher — watches `.git/worktrees/` for external worktree
   // create/delete and triggers serialized reconciliation.
@@ -733,11 +743,13 @@ export class WorkspaceService {
       this.wslDefaultDistroPromise = getDefaultWslDistro().catch(() => null);
     }
     const defaultDistro = await this.wslDefaultDistroPromise;
-    // UNC paths are case-insensitive on Windows; `wsl --list --verbose` returns
-    // the canonical case (e.g. "Ubuntu"). Normalize before comparing so a
-    // worktree opened via `\\wsl$\ubuntu\...` still matches the default.
-    const eligible =
-      defaultDistro !== null && defaultDistro.toLowerCase() === detected.distro.toLowerCase();
+    // Seed the poller's baseline from the first resolved probe so its first
+    // tick compares against a real value (no spurious refresh on a stable box).
+    this.wslLastKnownDefaultDistro = defaultDistro;
+    // Now that we know a WSL worktree exists, arm the background distro watcher
+    // (idempotent — only the first WSL worktree actually starts the interval).
+    this.startWslDistroPoller();
+    const eligibility = this.computeWslEligibility(detected.distro, defaultDistro);
     const persisted = this.wslGitByWorktree[wt.id];
 
     return {
@@ -745,10 +757,91 @@ export class WorkspaceService {
       isWslPath: true,
       wslDistro: detected.distro,
       wslPosixPath: detected.posixPath,
-      wslGitEligible: eligible,
+      wslGitEligible: eligibility,
       wslGitOptIn: Boolean(persisted?.enabled),
       wslGitDismissed: Boolean(persisted?.dismissed),
     };
+  }
+
+  /**
+   * Compute three-state WSL git eligibility for a worktree distro against the
+   * current default distro. `null` default (probe failed / WSL absent) maps to
+   * `'unprobed'` rather than `'ineligible'` so the renderer can offer a
+   * re-check instead of a wrong "git runs via Windows" note. UNC paths are
+   * case-insensitive on Windows and `wsl --list --verbose` returns canonical
+   * case (e.g. "Ubuntu"), so compare case-insensitively.
+   */
+  private computeWslEligibility(
+    distro: string | undefined,
+    defaultDistro: string | null
+  ): WslGitEligibility {
+    if (!distro || defaultDistro === null) return "unprobed";
+    return defaultDistro.toLowerCase() === distro.toLowerCase() ? "eligible" : "ineligible";
+  }
+
+  /**
+   * Arm the Windows-only background watcher that re-checks the WSL default
+   * distro. The default distro can change mid-session (`wsl --set-default`,
+   * install/uninstall) and the renderer has no OS event to subscribe to, so we
+   * poll. Idempotent — a second call while already running is a no-op.
+   */
+  private startWslDistroPoller(): void {
+    if (process.platform !== "win32") return;
+    if (this.wslDistroPoller) return;
+    this.wslDistroPoller = setInterval(() => {
+      void this.pollWslDefaultDistro();
+    }, WorkspaceService.WSL_DISTRO_POLL_INTERVAL_MS);
+    // Don't keep the host process alive solely for this poll.
+    this.wslDistroPoller.unref?.();
+  }
+
+  /** Stop the WSL distro watcher (project switch / dispose). */
+  private stopWslDistroPoller(): void {
+    if (this.wslDistroPoller) {
+      clearInterval(this.wslDistroPoller);
+      this.wslDistroPoller = null;
+    }
+  }
+
+  /**
+   * One poll tick: re-probe the default distro and, when it changed, invalidate
+   * the cache and refresh every WSL monitor's eligibility so existing worktrees
+   * stop using a stale decision.
+   */
+  private async pollWslDefaultDistro(): Promise<void> {
+    const current = await getDefaultWslDistro().catch(() => null);
+    if (current === this.wslLastKnownDefaultDistro) return;
+    this.wslLastKnownDefaultDistro = current;
+    this.wslDefaultDistroPromise = Promise.resolve(current);
+    this.refreshWslEligibilityForAllMonitors(current);
+  }
+
+  /**
+   * Recompute and push WSL git eligibility to every active WSL monitor against
+   * the given default distro. Non-WSL monitors are skipped.
+   */
+  private refreshWslEligibilityForAllMonitors(defaultDistro: string | null): void {
+    for (const monitor of this.monitors.values()) {
+      if (!monitor.isWslPath) continue;
+      monitor.setWslEligible(this.computeWslEligibility(monitor.wslDistro, defaultDistro));
+    }
+  }
+
+  /**
+   * Re-probe the WSL default distro on demand (renderer "Re-check" button) and
+   * refresh all WSL monitors. Sets the target monitor to `'unprobed'` first so
+   * the banner shows a pending state while the probe runs. The probe is shared
+   * across all worktrees, so we refresh every WSL monitor, not just the target.
+   */
+  async reprobeWslForWorktree(worktreeId: string): Promise<void> {
+    if (process.platform !== "win32") return;
+    const monitor = this.monitors.get(worktreeId);
+    if (!monitor || !monitor.isWslPath) return;
+    monitor.setWslEligible("unprobed");
+    const current = await getDefaultWslDistro().catch(() => null);
+    this.wslLastKnownDefaultDistro = current;
+    this.wslDefaultDistroPromise = Promise.resolve(current);
+    this.refreshWslEligibilityForAllMonitors(current);
   }
 
   /**
@@ -2932,6 +3025,9 @@ ${lines.map((l) => "+" + l).join("\n")}`;
 
   async onProjectSwitch(requestId: string): Promise<void> {
     this.stopTopologyWatcher();
+    // Stop the WSL distro poller before clearing monitors so a poll tick can't
+    // fire setWslEligible against a half-torn-down or next-project monitor map.
+    this.stopWslDistroPoller();
     this.topologyReconcileQueue.clear();
     this.prService.cleanup();
 
@@ -2955,6 +3051,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     this.projectRootPath = null;
     this.projectEnvVars = {};
     this.wslDefaultDistroPromise = null;
+    this.wslLastKnownDefaultDistro = undefined;
 
     clearGitDirCache();
     clearGitCommonDirCache();
@@ -3063,6 +3160,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     this._shutdownController.abort();
     // stopTopologyWatcher clears the pending sets and their safety timers.
     this.stopTopologyWatcher();
+    this.stopWslDistroPoller();
     this.topologyReconcileQueue.clear();
     this.prService.cleanup();
     this.resourceActionExecutor.dispose();

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -9,6 +9,7 @@ import type {
   WorktreeMood,
   WorktreeLifecycleStatus,
   WorktreeLifecyclePhaseResult,
+  WslGitEligibility,
 } from "../../shared/types/worktree.js";
 import type { GitHubPRCIStatus } from "../../shared/types/github.js";
 import type { WorktreeSnapshot } from "../../shared/types/workspace-host.js";
@@ -263,7 +264,7 @@ export class WorktreeMonitor {
   // WSL routing state (Windows only)
   private _isWslPath: boolean = false;
   private _wslDistro: string | undefined;
-  private _wslGitEligible: boolean = false;
+  private _wslGitEligible: WslGitEligibility = "unprobed";
   private _wslGitOptIn: boolean = false;
   private _wslGitDismissed: boolean = false;
   private _wslPosixPath: string | undefined;
@@ -407,7 +408,7 @@ export class WorktreeMonitor {
     this._isWslPath = Boolean(worktree.isWslPath);
     this._wslDistro = worktree.wslDistro;
     this._wslPosixPath = worktree.wslPosixPath;
-    this._wslGitEligible = Boolean(worktree.wslGitEligible);
+    this._wslGitEligible = worktree.wslGitEligible ?? "unprobed";
     this._wslGitOptIn = Boolean(worktree.wslGitOptIn);
     this._wslGitDismissed = Boolean(worktree.wslGitDismissed);
   }
@@ -420,7 +421,8 @@ export class WorktreeMonitor {
    */
   private get wslInvocation(): WslGitInvocation | undefined {
     if (process.platform !== "win32") return undefined;
-    if (!this._isWslPath || !this._wslGitEligible || !this._wslGitOptIn) return undefined;
+    if (!this._isWslPath || this._wslGitEligible !== "eligible" || !this._wslGitOptIn)
+      return undefined;
     if (!this._wslDistro || !this._wslPosixPath) return undefined;
     return {
       distro: this._wslDistro,
@@ -447,6 +449,31 @@ export class WorktreeMonitor {
     if (changed && this._hasInitialStatus) {
       this.emitUpdate();
     }
+  }
+
+  /**
+   * Update the WSL git eligibility at runtime. Called by `WorkspaceService`
+   * when the WSL default distro changes (background poll) or the user triggers
+   * a re-probe. Re-emits a snapshot so the renderer banner reflects the new
+   * state. Safe to flip while running: `createWslHardenedGit` is built per
+   * invocation from the `wslInvocation` getter, so the next poll/fetch picks up
+   * the routing change without swapping a stored git instance.
+   */
+  setWslEligible(eligibility: WslGitEligibility): void {
+    if (this._wslGitEligible === eligibility) return;
+    this._wslGitEligible = eligibility;
+    if (this._hasInitialStatus) {
+      this.emitUpdate();
+    }
+  }
+
+  /** WSL routing inputs, read by `WorkspaceService` to recompute eligibility. */
+  get isWslPath(): boolean {
+    return this._isWslPath;
+  }
+
+  get wslDistro(): string | undefined {
+    return this._wslDistro;
   }
 
   /**
@@ -1138,7 +1165,10 @@ export class WorktreeMonitor {
       isWslPath: this._isWslPath || undefined,
       wslDistro: this._wslDistro,
       wslPosixPath: this._wslPosixPath,
-      wslGitEligible: this._wslGitEligible || undefined,
+      // Emit the three-state value directly for WSL paths so the renderer can
+      // tell "ineligible" (distro mismatch) from "unprobed" (probe pending /
+      // failed). Suppressed for non-WSL worktrees to keep snapshots lean.
+      wslGitEligible: this._isWslPath ? this._wslGitEligible : undefined,
       wslGitOptIn: this._wslGitOptIn || undefined,
       wslGitDismissed: this._wslGitDismissed || undefined,
       linked: this._linked,

--- a/electron/workspace-host/__tests__/WorkspaceService.wsl.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.wsl.test.ts
@@ -12,6 +12,17 @@ vi.mock("simple-git", () => ({
   simpleGit: vi.fn(() => mockSimpleGit),
 }));
 
+// These tests override process.platform to "win32" before importing
+// WorkspaceService. @parcel/watcher resolves its native binding from
+// process.platform at import time, so on a non-Windows CI runner the real
+// module throws ("No prebuild or local build of @parcel/watcher-win32-x64").
+// Mock it so the import never touches a platform-specific native binding.
+vi.mock("@parcel/watcher", () => ({
+  default: {
+    subscribe: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
+  },
+}));
+
 vi.mock("../../utils/fs.js", () => ({
   waitForPathExists: vi.fn().mockResolvedValue(undefined),
 }));

--- a/electron/workspace-host/__tests__/WorkspaceService.wsl.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.wsl.test.ts
@@ -1,0 +1,182 @@
+import { EventEmitter } from "events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkspaceService } from "../WorkspaceService.js";
+import type { WorkspaceHostEvent } from "../../../shared/types/workspace-host.js";
+
+const mockSimpleGit = {
+  raw: vi.fn(),
+  branch: vi.fn().mockResolvedValue({ current: "main" }),
+};
+
+vi.mock("simple-git", () => ({
+  simpleGit: vi.fn(() => mockSimpleGit),
+}));
+
+vi.mock("../../utils/fs.js", () => ({
+  waitForPathExists: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../utils/hardenedGit.js", () => ({
+  createHardenedGit: vi.fn(() => mockSimpleGit),
+  createAuthenticatedGit: vi.fn(() => mockSimpleGit),
+  validateBranchName: vi.fn(),
+}));
+
+vi.mock("../../utils/git.js", () => ({
+  invalidateGitStatusCache: vi.fn(),
+}));
+
+vi.mock("../../utils/gitUtils.js", () => ({
+  getGitDir: vi.fn().mockReturnValue("/test/worktree/.git"),
+  clearGitDirCache: vi.fn(),
+}));
+
+vi.mock("../../services/issueExtractor.js", () => ({
+  extractIssueNumberSync: vi.fn().mockReturnValue(null),
+  extractIssueNumber: vi.fn().mockResolvedValue(null),
+  deriveIssueTitleFromBranch: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock("../../services/github/GitHubAuth.js", () => ({
+  GitHubAuth: vi.fn().mockImplementation(() => ({
+    getToken: vi.fn().mockResolvedValue(null),
+  })),
+}));
+
+vi.mock("../../services/PullRequestService.js", () => ({
+  pullRequestService: {
+    initialize: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+    reset: vi.fn(),
+    refresh: vi.fn(),
+    getStatus: vi.fn().mockReturnValue({
+      state: "idle",
+      isPolling: false,
+      candidateCount: 0,
+      resolvedCount: 0,
+      isEnabled: true,
+    }),
+  },
+}));
+
+vi.mock("../../services/events.js", () => ({
+  events: new EventEmitter(),
+}));
+
+const getDefaultWslDistroMock = vi.hoisted(() => vi.fn());
+vi.mock("../../utils/wsl.js", () => ({
+  detectWslPath: vi.fn().mockReturnValue(null),
+  getDefaultWslDistro: getDefaultWslDistroMock,
+}));
+
+vi.mock("fs/promises", () => ({
+  stat: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  access: vi.fn().mockResolvedValue(undefined),
+  readFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  cp: vi.fn().mockResolvedValue(undefined),
+  realpath: vi.fn().mockImplementation((p: string) => Promise.resolve(p)),
+}));
+
+vi.mock("fs", () => ({
+  existsSync: vi.fn().mockReturnValue(true),
+}));
+
+interface StubMonitor {
+  isWslPath: boolean;
+  wslDistro: string | undefined;
+  setWslEligible: ReturnType<typeof vi.fn>;
+  // dispose() iterates monitors and calls stop(); provide a no-op so teardown
+  // doesn't blow up on these lightweight stubs.
+  stop: ReturnType<typeof vi.fn>;
+}
+
+function stubMonitor(isWslPath: boolean, wslDistro: string | undefined): StubMonitor {
+  return { isWslPath, wslDistro, setWslEligible: vi.fn(), stop: vi.fn() };
+}
+
+describe("WorkspaceService WSL eligibility refresh (#9924)", () => {
+  let service: WorkspaceService;
+  const originalPlatform = process.platform;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    const workspaceModule = await import("../WorkspaceService.js");
+    service = new workspaceModule.WorkspaceService((_event: WorkspaceHostEvent) => {});
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    service.dispose();
+    vi.restoreAllMocks();
+  });
+
+  function seedMonitors(): { ubuntu: StubMonitor; debian: StubMonitor; nonWsl: StubMonitor } {
+    const ubuntu = stubMonitor(true, "Ubuntu");
+    const debian = stubMonitor(true, "Debian");
+    const nonWsl = stubMonitor(false, undefined);
+    const monitors = service["monitors"] as unknown as Map<string, StubMonitor>;
+    monitors.set("ubuntu-wt", ubuntu);
+    monitors.set("debian-wt", debian);
+    monitors.set("local-wt", nonWsl);
+    return { ubuntu, debian, nonWsl };
+  }
+
+  it("reprobe refreshes every WSL monitor against the fresh default distro", async () => {
+    const { ubuntu, debian, nonWsl } = seedMonitors();
+    // Default distro changed to Debian mid-session.
+    getDefaultWslDistroMock.mockResolvedValue("Debian");
+
+    await service.reprobeWslForWorktree("ubuntu-wt");
+
+    // Target monitor first shows the pending state, then its final verdict.
+    expect(ubuntu.setWslEligible).toHaveBeenCalledWith("unprobed");
+    expect(ubuntu.setWslEligible).toHaveBeenLastCalledWith("ineligible");
+    // The shared probe also refreshes the now-default Debian worktree.
+    expect(debian.setWslEligible).toHaveBeenLastCalledWith("eligible");
+    // Non-WSL monitors are never touched.
+    expect(nonWsl.setWslEligible).not.toHaveBeenCalled();
+  });
+
+  it("reprobe maps a failed probe (null default) to 'unprobed', not 'ineligible'", async () => {
+    const { ubuntu, debian } = seedMonitors();
+    getDefaultWslDistroMock.mockResolvedValue(null);
+
+    await service.reprobeWslForWorktree("ubuntu-wt");
+
+    expect(ubuntu.setWslEligible).toHaveBeenLastCalledWith("unprobed");
+    expect(debian.setWslEligible).toHaveBeenLastCalledWith("unprobed");
+  });
+
+  it("reprobe is a no-op for an unknown or non-WSL worktree", async () => {
+    const { nonWsl } = seedMonitors();
+    getDefaultWslDistroMock.mockResolvedValue("Ubuntu");
+
+    await service.reprobeWslForWorktree("local-wt");
+    await service.reprobeWslForWorktree("does-not-exist");
+
+    expect(nonWsl.setWslEligible).not.toHaveBeenCalled();
+    expect(getDefaultWslDistroMock).not.toHaveBeenCalled();
+  });
+
+  it("the background poll refreshes monitors only when the default distro changes", async () => {
+    const { ubuntu, debian } = seedMonitors();
+    service["wslLastKnownDefaultDistro"] = "Ubuntu";
+
+    // Same distro → no refresh.
+    getDefaultWslDistroMock.mockResolvedValueOnce("Ubuntu");
+    await (service as unknown as { pollWslDefaultDistro(): Promise<void> }).pollWslDefaultDistro();
+    expect(ubuntu.setWslEligible).not.toHaveBeenCalled();
+    expect(debian.setWslEligible).not.toHaveBeenCalled();
+
+    // Distro flips to Debian → both WSL monitors recompute.
+    getDefaultWslDistroMock.mockResolvedValueOnce("Debian");
+    await (service as unknown as { pollWslDefaultDistro(): Promise<void> }).pollWslDefaultDistro();
+    expect(ubuntu.setWslEligible).toHaveBeenLastCalledWith("ineligible");
+    expect(debian.setWslEligible).toHaveBeenLastCalledWith("eligible");
+    expect(service["wslLastKnownDefaultDistro"]).toBe("Debian");
+  });
+});

--- a/electron/workspace-host/__tests__/WorkspaceService.wsl.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.wsl.test.ts
@@ -162,6 +162,60 @@ describe("WorkspaceService WSL eligibility refresh (#9924)", () => {
     expect(getDefaultWslDistroMock).not.toHaveBeenCalled();
   });
 
+  it("discards an in-flight reprobe when the poller is stopped (project switch) (#9924)", async () => {
+    const { ubuntu, debian } = seedMonitors();
+    let resolveProbe!: (v: string | null) => void;
+    getDefaultWslDistroMock.mockReturnValue(
+      new Promise<string | null>((r) => {
+        resolveProbe = r;
+      })
+    );
+
+    const pending = service.reprobeWslForWorktree("ubuntu-wt");
+    // Target shows the pending state synchronously, before the probe resolves.
+    expect(ubuntu.setWslEligible).toHaveBeenCalledWith("unprobed");
+    ubuntu.setWslEligible.mockClear();
+    debian.setWslEligible.mockClear();
+
+    // A project switch (or dispose) bumps the probe sequence, invalidating the
+    // in-flight probe so its late resolution can't touch the monitor map.
+    (service as unknown as { stopWslDistroPoller(): void }).stopWslDistroPoller();
+
+    resolveProbe("Debian");
+    await pending;
+
+    expect(ubuntu.setWslEligible).not.toHaveBeenCalled();
+    expect(debian.setWslEligible).not.toHaveBeenCalled();
+  });
+
+  it("a superseded probe never overwrites a newer probe's result (#9924)", async () => {
+    const { ubuntu } = seedMonitors();
+    service["wslLastKnownDefaultDistro"] = "Debian";
+
+    // First probe (a slow poll tick) is held open and will return a stale value.
+    let resolveSlow!: (v: string | null) => void;
+    getDefaultWslDistroMock.mockReturnValueOnce(
+      new Promise<string | null>((r) => {
+        resolveSlow = r;
+      })
+    );
+    const slowPoll = (
+      service as unknown as { pollWslDefaultDistro(): Promise<void> }
+    ).pollWslDefaultDistro();
+
+    // A reprobe initiated afterwards resolves first with the fresh value.
+    getDefaultWslDistroMock.mockResolvedValueOnce("Debian");
+    await service.reprobeWslForWorktree("ubuntu-wt");
+    expect(ubuntu.setWslEligible).toHaveBeenLastCalledWith("ineligible");
+
+    ubuntu.setWslEligible.mockClear();
+    // The older poll finally resolves with a stale distro — it must be ignored.
+    resolveSlow("Ubuntu");
+    await slowPoll;
+    expect(ubuntu.setWslEligible).not.toHaveBeenCalled();
+    expect(service["wslLastKnownDefaultDistro"]).toBe("Debian");
+  });
+
   it("the background poll refreshes monitors only when the default distro changes", async () => {
     const { ubuntu, debian } = seedMonitors();
     service["wslLastKnownDefaultDistro"] = "Ubuntu";

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -1988,7 +1988,7 @@ describe("WorktreeMonitor", () => {
         isWslPath: true,
         wslDistro: "Ubuntu",
         wslPosixPath: "/home/user/repo",
-        wslGitEligible: true,
+        wslGitEligible: "eligible",
         wslGitOptIn: false,
       };
       const monitor = new WorktreeMonitor(wsl, TEST_CONFIG, makeCallbacks(), "main");
@@ -2014,7 +2014,7 @@ describe("WorktreeMonitor", () => {
           isWslPath: true,
           wslDistro: "Ubuntu",
           wslPosixPath: "/home/user/repo",
-          wslGitEligible: true,
+          wslGitEligible: "eligible",
           wslGitOptIn: true,
         };
         const monitor = new WorktreeMonitor(wsl, TEST_CONFIG, makeCallbacks(), "main");
@@ -2056,7 +2056,7 @@ describe("WorktreeMonitor", () => {
           path: "\\\\wsl$\\Ubuntu\\home\\user\\repo",
           isWslPath: true,
           wslDistro: "Ubuntu",
-          wslGitEligible: true,
+          wslGitEligible: "eligible",
           wslGitOptIn: true,
         };
         const monitor = new WorktreeMonitor(wsl, TEST_CONFIG, makeCallbacks(), "main");
@@ -2085,7 +2085,7 @@ describe("WorktreeMonitor", () => {
           isWslPath: true,
           wslDistro: "Ubuntu",
           wslPosixPath: "/home/user/repo",
-          wslGitEligible: true,
+          wslGitEligible: "eligible",
           wslGitOptIn: false,
         };
         const callbacks = makeCallbacks();
@@ -2108,6 +2108,125 @@ describe("WorktreeMonitor", () => {
       } finally {
         Object.defineProperty(process, "platform", { value: original, configurable: true });
       }
+    });
+
+    it("serializes ineligible as 'ineligible', not absent (#9924)", async () => {
+      // The old `this._wslGitEligible || undefined` coercion dropped `false` to
+      // absent, making "ineligible" indistinguishable from "unprobed" on the
+      // renderer. The three-state field must round-trip 'ineligible' verbatim.
+      const wsl: Worktree = {
+        ...TEST_WORKTREE,
+        path: "\\\\wsl$\\Debian\\home\\user\\repo",
+        isWslPath: true,
+        wslDistro: "Debian",
+        wslPosixPath: "/home/user/repo",
+        wslGitEligible: "ineligible",
+      };
+      const monitor = new WorktreeMonitor(wsl, TEST_CONFIG, makeCallbacks(), "main");
+      await monitor.start();
+      await flushInitialStatus();
+
+      expect(monitor.getSnapshot().wslGitEligible).toBe("ineligible");
+
+      monitor.stop();
+    });
+
+    it("defaults eligibility to 'unprobed' when the field is absent (#9924)", async () => {
+      const wsl: Worktree = {
+        ...TEST_WORKTREE,
+        path: "\\\\wsl$\\Ubuntu\\home\\user\\repo",
+        isWslPath: true,
+        wslDistro: "Ubuntu",
+        wslPosixPath: "/home/user/repo",
+      };
+      const monitor = new WorktreeMonitor(wsl, TEST_CONFIG, makeCallbacks(), "main");
+      await monitor.start();
+      await flushInitialStatus();
+
+      expect(monitor.getSnapshot().wslGitEligible).toBe("unprobed");
+
+      monitor.stop();
+    });
+
+    it("setWslEligible flips git routing at runtime without restart (#9924)", async () => {
+      const original = process.platform;
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      try {
+        const wsl: Worktree = {
+          ...TEST_WORKTREE,
+          path: "\\\\wsl$\\Ubuntu\\home\\user\\repo",
+          isWslPath: true,
+          wslDistro: "Ubuntu",
+          wslPosixPath: "/home/user/repo",
+          // Start ineligible + opted in: no WSL routing yet.
+          wslGitEligible: "ineligible",
+          wslGitOptIn: true,
+        };
+        const callbacks = makeCallbacks();
+        const monitor = new WorktreeMonitor(wsl, TEST_CONFIG, callbacks, "main");
+        await monitor.start();
+        await flushInitialStatus();
+
+        // Becoming the default distro mid-session flips eligibility → routing on.
+        const updateCallsBefore = (callbacks.onUpdate as ReturnType<typeof vi.fn>).mock.calls
+          .length;
+        monitor.setWslEligible("eligible");
+        const updateCallsAfter = (callbacks.onUpdate as ReturnType<typeof vi.fn>).mock.calls.length;
+        expect(updateCallsAfter).toBeGreaterThan(updateCallsBefore);
+        expect(monitor.getSnapshot().wslGitEligible).toBe("eligible");
+
+        mockGetWorktreeChangesWithStats.mockClear();
+        await monitor.refresh();
+
+        const lastCall =
+          mockGetWorktreeChangesWithStats.mock.calls[
+            mockGetWorktreeChangesWithStats.mock.calls.length - 1
+          ];
+        expect(lastCall[1]?.wsl).toEqual({
+          distro: "Ubuntu",
+          uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\repo",
+          posixPath: "/home/user/repo",
+        });
+
+        monitor.stop();
+      } finally {
+        Object.defineProperty(process, "platform", { value: original, configurable: true });
+      }
+    });
+
+    it("setWslEligible is a no-op when the value is unchanged (#9924)", async () => {
+      const wsl: Worktree = {
+        ...TEST_WORKTREE,
+        path: "\\\\wsl$\\Ubuntu\\home\\user\\repo",
+        isWslPath: true,
+        wslDistro: "Ubuntu",
+        wslPosixPath: "/home/user/repo",
+        wslGitEligible: "ineligible",
+      };
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(wsl, TEST_CONFIG, callbacks, "main");
+      await monitor.start();
+      await flushInitialStatus();
+
+      const before = (callbacks.onUpdate as ReturnType<typeof vi.fn>).mock.calls.length;
+      monitor.setWslEligible("ineligible");
+      const after = (callbacks.onUpdate as ReturnType<typeof vi.fn>).mock.calls.length;
+      expect(after).toBe(before);
+
+      monitor.stop();
+    });
+
+    it("exposes isWslPath and wslDistro getters for eligibility refresh (#9924)", () => {
+      const wsl: Worktree = {
+        ...TEST_WORKTREE,
+        path: "\\\\wsl$\\Ubuntu\\home\\user\\repo",
+        isWslPath: true,
+        wslDistro: "Ubuntu",
+        wslPosixPath: "/home/user/repo",
+      };
+      const monitor = new WorktreeMonitor(wsl, TEST_CONFIG, makeCallbacks(), "main");
+      expect(monitor.isWslPath).toBe(true);
+      expect(monitor.wslDistro).toBe("Ubuntu");
     });
   });
 

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -29,6 +29,7 @@ export type {
   WorktreeLifecycleStatus,
   Worktree,
   WorktreeState,
+  WslGitEligibility,
 } from "./worktree.js";
 
 // Notification types

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1039,6 +1039,11 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     setWslGit(worktreeId: string, enabled: boolean): Promise<void>;
     /** Hide the WSL git suggestion banner for this worktree without enabling. */
     dismissWslBanner(worktreeId: string): Promise<void>;
+    /**
+     * Re-probe the WSL default distro on demand (user "Re-check") and refresh
+     * eligibility across all WSL worktrees. Windows-only.
+     */
+    reprobeWsl(worktreeId: string): Promise<void>;
   };
   window: {
     /** Subscribe to fullscreen state changes */

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1177,6 +1177,10 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: import("./worktree.js").WorktreeConfig;
   };
+  "worktree-config:reprobe-wsl": {
+    args: [payload: { worktreeId: string }];
+    result: void;
+  };
   "worktree-config:set-pattern": {
     args: [payload: { pattern: string }];
     result: import("./worktree.js").WorktreeConfig;

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -24,6 +24,7 @@ import type {
   WorktreeLifecycleStatus,
   WorktreeLifecyclePhaseResult,
   WorktreeResourceStatus,
+  WslGitEligibility,
 } from "./worktree.js";
 import type { Credentials, RepoRef } from "./forge.js";
 import type { GitHubPRCIStatus } from "./github.js";
@@ -227,8 +228,12 @@ export interface WorktreeSnapshot {
   /** Distro name parsed from the WSL UNC mount, when `isWslPath` is true. */
   wslDistro?: string;
 
-  /** Whether `wslDistro` matches the WSL default distro (gates "Enable" UI). */
-  wslGitEligible?: boolean;
+  /**
+   * WSL git eligibility: `'eligible'` matches the default distro (gates "Enable"
+   * UI), `'ineligible'` is a confirmed mismatch, `'unprobed'`/absent means the
+   * probe hasn't resolved or failed.
+   */
+  wslGitEligible?: WslGitEligibility;
 
   /** User has opted in to WSL-routed git for this worktree. */
   wslGitOptIn?: boolean;
@@ -377,6 +382,8 @@ export type WorkspaceHostRequest =
       enabled: boolean;
       dismissed: boolean;
     }
+  // Re-probe the WSL default distro on demand and refresh eligibility (Windows only)
+  | { type: "reprobe-wsl"; worktreeId: string }
   // Background/foreground lifecycle
   | { type: "background" }
   | { type: "foreground" }

--- a/shared/types/worktree.ts
+++ b/shared/types/worktree.ts
@@ -13,6 +13,15 @@ export type FleetScopeToken = string & { readonly __brand: unique symbol };
 /** Worktree mood indicator */
 export type WorktreeMood = "stable" | "active" | "stale" | "error";
 
+/**
+ * Three-state WSL git eligibility. Replaces a bare boolean so the renderer can
+ * distinguish "ineligible" (probe ran, distro mismatch) from "unprobed" (probe
+ * hasn't run, is in flight, or failed). The old `boolean | undefined` shape
+ * collapsed `false` and `undefined` together, hiding the difference. `'unprobed'`
+ * is also what a missing/legacy snapshot field maps to at the renderer boundary.
+ */
+export type WslGitEligibility = "eligible" | "ineligible" | "unprobed";
+
 /** Phase of worktree lifecycle script execution */
 export type WorktreeLifecyclePhase =
   | "setup"
@@ -330,12 +339,13 @@ export interface Worktree {
   wslDistro?: string;
 
   /**
-   * True when the detected `wslDistro` matches the WSL default distro and
+   * Whether the detected `wslDistro` matches the WSL default distro and
    * Daintree can therefore route git operations through `wsl.exe git` (which
-   * always targets the default distro). When false, the banner shows a
-   * read-only informational note instead of an enable button.
+   * always targets the default distro). `'eligible'` shows the enable button;
+   * `'ineligible'` shows a read-only informational note; `'unprobed'` (or
+   * absent) means the probe hasn't resolved yet or failed.
    */
-  wslGitEligible?: boolean;
+  wslGitEligible?: WslGitEligibility;
 
   /**
    * User has opted in to routing this worktree's git operations through WSL.

--- a/src/clients/worktreeConfigClient.ts
+++ b/src/clients/worktreeConfigClient.ts
@@ -16,4 +16,8 @@ export const worktreeConfigClient = {
   dismissWslBanner: (worktreeId: string): Promise<void> => {
     return window.electron.worktreeConfig.dismissWslBanner(worktreeId);
   },
+
+  reprobeWsl: (worktreeId: string): Promise<void> => {
+    return window.electron.worktreeConfig.reprobeWsl(worktreeId);
+  },
 } as const;

--- a/src/components/Worktree/WorktreeCard/WslGitBanner.tsx
+++ b/src/components/Worktree/WorktreeCard/WslGitBanner.tsx
@@ -1,25 +1,38 @@
 import React, { useCallback, useState } from "react";
+import type { WslGitEligibility } from "@shared/types";
 import { worktreeConfigClient } from "@/clients/worktreeConfigClient";
+import { useDeferredLoading } from "@/hooks/useDeferredLoading";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { logError } from "@/utils/logger";
 import { cn } from "../../../lib/utils";
 
 export interface WslGitBannerProps {
   worktreeId: string;
   wslDistro?: string;
-  wslGitEligible?: boolean;
+  wslGitEligible?: WslGitEligibility;
 }
+
+const BANNER_SHELL = cn(
+  "mx-3 my-2 rounded-md border border-daintree-border bg-overlay-subtle px-3 py-2",
+  "flex items-start gap-3 text-sm"
+);
 
 /**
  * Inline banner shown on WSL-mounted worktrees suggesting the user route git
- * through `wsl git` to avoid the 9P boundary slowdown. Two variants:
+ * through `wsl git` to avoid the 9P boundary slowdown. Three states driven by
+ * `wslGitEligible`:
  *
- * - Eligible (`wslGitEligible === true`): "Enable WSL git" + "Not now" buttons.
- *   Enabling persists the opt-in and re-routes git invocations on the next
- *   poll cycle.
+ * - `'eligible'`: "Enable WSL git" + "Not now" buttons. Enabling persists the
+ *   opt-in and re-routes git invocations on the next poll cycle.
  *
- * - Ineligible (`wslGitEligible === false`): read-only informational note —
- *   the worktree is in a non-default distro and we can't safely route through
- *   `wsl.exe git` without distro-specific args.
+ * - `'ineligible'`: read-only informational note — the worktree is in a
+ *   non-default distro and we can't safely route through `wsl.exe git` without
+ *   distro-specific args. Carries a "Re-check" button: the default distro can
+ *   change mid-session, so re-probing can flip this worktree back to eligible.
+ *
+ * - `'unprobed'` (or absent): the default-distro probe hasn't resolved yet or
+ *   failed. Shows a Doherty-gated skeleton; a re-check is offered if the probe
+ *   stalls.
  */
 export const WslGitBanner = React.memo(function WslGitBanner({
   worktreeId,
@@ -27,6 +40,15 @@ export const WslGitBanner = React.memo(function WslGitBanner({
   wslGitEligible,
 }: WslGitBannerProps) {
   const [busy, setBusy] = useState(false);
+  const [reprobing, setReprobing] = useState(false);
+  const [reprobeFailed, setReprobeFailed] = useState(false);
+
+  // Treat a missing value as "unprobed" — older snapshots predate the field.
+  const eligibility: WslGitEligibility = wslGitEligible ?? "unprobed";
+  const showProbeSkeleton = useDeferredLoading(
+    eligibility === "unprobed" && !reprobeFailed,
+    UI_DOHERTY_THRESHOLD
+  );
 
   const handleEnable = useCallback(async () => {
     if (busy) return;
@@ -52,15 +74,23 @@ export const WslGitBanner = React.memo(function WslGitBanner({
     }
   }, [worktreeId, busy]);
 
-  if (wslGitEligible) {
+  const handleReprobe = useCallback(async () => {
+    if (reprobing) return;
+    setReprobing(true);
+    setReprobeFailed(false);
+    try {
+      await worktreeConfigClient.reprobeWsl(worktreeId);
+    } catch (err) {
+      logError("Failed to re-check WSL distro for worktree", err, { worktreeId });
+      setReprobeFailed(true);
+    } finally {
+      setReprobing(false);
+    }
+  }, [worktreeId, reprobing]);
+
+  if (eligibility === "eligible") {
     return (
-      <div
-        role="status"
-        className={cn(
-          "mx-3 my-2 rounded-md border border-daintree-border bg-overlay-subtle px-3 py-2",
-          "flex items-start gap-3 text-sm"
-        )}
-      >
+      <div role="status" className={BANNER_SHELL}>
         <div className="flex-1">
           <div className="font-medium text-text-primary">Speed up git on this WSL worktree</div>
           <div className="mt-0.5 text-text-secondary">
@@ -99,14 +129,48 @@ export const WslGitBanner = React.memo(function WslGitBanner({
     );
   }
 
+  if (eligibility === "unprobed") {
+    // Probe hasn't resolved. Stay silent under the Doherty gate unless the
+    // probe genuinely failed, in which case offer a re-check.
+    if (reprobeFailed) {
+      return (
+        <div role="status" className={BANNER_SHELL}>
+          <div className="flex-1">
+            <div className="font-medium text-text-primary">Couldn't check WSL distro</div>
+            <div className="mt-0.5 text-text-secondary">
+              The WSL default distro couldn't be read, so git routing for this worktree is
+              undetermined. Git runs from Windows in the meantime.
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={handleReprobe}
+            disabled={reprobing}
+            className={cn(
+              "shrink-0 rounded border border-daintree-border bg-overlay-strong px-2 py-1 text-xs",
+              "transition-colors duration-150 hover:bg-overlay-hover",
+              "disabled:cursor-not-allowed disabled:opacity-60"
+            )}
+          >
+            Retry
+          </button>
+        </div>
+      );
+    }
+    if (!showProbeSkeleton) return null;
+    return (
+      <div role="status" aria-busy="true" className={BANNER_SHELL}>
+        <div className="flex-1">
+          <div className="h-4 w-48 animate-pulse-delayed rounded bg-overlay-strong" />
+          <div className="mt-1.5 h-3 w-full animate-pulse-delayed rounded bg-overlay-subtle" />
+        </div>
+      </div>
+    );
+  }
+
+  // eligibility === "ineligible"
   return (
-    <div
-      role="status"
-      className={cn(
-        "mx-3 my-2 rounded-md border border-daintree-border bg-overlay-subtle px-3 py-2",
-        "flex items-start gap-3 text-sm"
-      )}
-    >
+    <div role="status" className={BANNER_SHELL}>
       <div className="flex-1">
         <div className="font-medium text-text-primary">Git runs via Windows</div>
         <div className="mt-0.5 text-text-secondary">
@@ -115,19 +179,36 @@ export const WslGitBanner = React.memo(function WslGitBanner({
           isn't the default WSL distro. Git can't be routed through this distro automatically — it
           will run from Windows and may be slower than usual.
         </div>
-      </div>
-      <button
-        type="button"
-        onClick={handleDismiss}
-        disabled={busy}
-        className={cn(
-          "shrink-0 rounded px-2 py-1 text-xs text-text-secondary",
-          "transition-colors duration-150 hover:text-text-primary",
-          "disabled:cursor-not-allowed disabled:opacity-60"
+        {reprobeFailed && (
+          <div className="mt-1 text-text-secondary">Couldn't re-check — try again.</div>
         )}
-      >
-        Got it
-      </button>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <button
+          type="button"
+          onClick={handleReprobe}
+          disabled={reprobing}
+          className={cn(
+            "rounded border border-daintree-border bg-overlay-strong px-2 py-1 text-xs",
+            "transition-colors duration-150 hover:bg-overlay-hover",
+            "disabled:cursor-not-allowed disabled:opacity-60"
+          )}
+        >
+          {reprobing ? "Re-checking…" : "Re-check"}
+        </button>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          disabled={busy}
+          className={cn(
+            "rounded px-2 py-1 text-xs text-text-secondary",
+            "transition-colors duration-150 hover:text-text-primary",
+            "disabled:cursor-not-allowed disabled:opacity-60"
+          )}
+        >
+          Got it
+        </button>
+      </div>
     </div>
   );
 });

--- a/src/components/Worktree/WorktreeCard/WslGitBanner.tsx
+++ b/src/components/Worktree/WorktreeCard/WslGitBanner.tsx
@@ -17,6 +17,12 @@ const BANNER_SHELL = cn(
   "flex items-start gap-3 text-sm"
 );
 
+// If the probe hasn't resolved this long, treat the skeleton as stuck (WSL
+// unavailable / probe failed upstream) and surface a manual Re-check so the
+// user isn't stranded staring at a perpetual skeleton. Mirrors the ">5s →
+// persistent skeleton + recovery" tier of the loading-indicator rules.
+const WSL_PROBE_STUCK_MS = 5000;
+
 /**
  * Inline banner shown on WSL-mounted worktrees suggesting the user route git
  * through `wsl git` to avoid the 9P boundary slowdown. Three states driven by
@@ -45,10 +51,9 @@ export const WslGitBanner = React.memo(function WslGitBanner({
 
   // Treat a missing value as "unprobed" — older snapshots predate the field.
   const eligibility: WslGitEligibility = wslGitEligible ?? "unprobed";
-  const showProbeSkeleton = useDeferredLoading(
-    eligibility === "unprobed" && !reprobeFailed,
-    UI_DOHERTY_THRESHOLD
-  );
+  const probePending = eligibility === "unprobed" && !reprobeFailed;
+  const showProbeSkeleton = useDeferredLoading(probePending, UI_DOHERTY_THRESHOLD);
+  const probeStuck = useDeferredLoading(probePending, WSL_PROBE_STUCK_MS);
 
   const handleEnable = useCallback(async () => {
     if (busy) return;
@@ -130,9 +135,10 @@ export const WslGitBanner = React.memo(function WslGitBanner({
   }
 
   if (eligibility === "unprobed") {
-    // Probe hasn't resolved. Stay silent under the Doherty gate unless the
-    // probe genuinely failed, in which case offer a re-check.
-    if (reprobeFailed) {
+    // Probe hasn't resolved. A user-initiated re-check that errored, or a probe
+    // stuck past the threshold (WSL unavailable), both surface a recovery
+    // affordance so the user is never stranded on a perpetual skeleton.
+    if (reprobeFailed || probeStuck) {
       return (
         <div role="status" className={BANNER_SHELL}>
           <div className="flex-1">
@@ -152,7 +158,7 @@ export const WslGitBanner = React.memo(function WslGitBanner({
               "disabled:cursor-not-allowed disabled:opacity-60"
             )}
           >
-            Retry
+            {reprobing ? "Re-checking…" : "Re-check"}
           </button>
         </div>
       );


### PR DESCRIPTION
## Summary

- WSL git eligibility was a cached boolean computed once per session; changing the default distro mid-session (`wsl --set-default`, install/uninstall) left all existing worktrees with stale eligibility and no refresh path. The snapshot also serialized `wslGitEligible: this._wslGitEligible || undefined`, silently collapsing `false` (ineligible) and `undefined` (unprobed) into one absent value.
- Fixes this with a `WslGitEligibility` three-state type (`'eligible' | 'ineligible' | 'unprobed'`), a 60s Windows-only background poll that invalidates the cache and refreshes all active WSL monitors on distro change, a `WorktreeMonitor.setWslEligible` setter for runtime flips, and a user-initiated `reprobeWsl` IPC channel + `Re-check` button. A probe sequence guard discards results from slow probes that resolve after a newer probe or a project switch.
- `WslGitBanner` gains `unprobed`/loading (Doherty-gated skeleton), probe-failed, and stuck-probe recovery states alongside the new button. Windows-only throughout (`process.platform !== 'win32'` guards); macOS/Linux are unaffected.

Resolves #9924

## Changes

- `shared/types/workspace-host.ts`, `shared/types/worktree.ts` — `WslGitEligibility` three-state type replaces `wslGitEligible: boolean | undefined`; `pluginWorktreeSnapshot` updated accordingly
- `electron/workspace-host/WorkspaceService.ts` — 60s distro-change poll, `reprobeWsl` handler, probe sequence guard, project-switch invalidation
- `electron/workspace-host/WorktreeMonitor.ts` — `setWslEligible` setter, `wslEligibility` getter
- `electron/ipc/channels.ts`, `electron/ipc/handlers/worktreeConfig.ts`, `electron/ipc/handlers/worktreeConfig.preload.ts`, `src/clients/worktreeConfigClient.ts` — `reprobeWsl` IPC channel wired end-to-end
- `src/components/Worktree/WorktreeCard/WslGitBanner.tsx` — unprobed/loading skeleton, probe-failed and stuck-probe states, `Re-check` button
- `electron/workspace-host/__tests__/WorkspaceService.wsl.test.ts` (new), `electron/workspace-host/__tests__/WorktreeMonitor.test.ts` (extended) — three-state serialization, runtime flip, setter no-op, reprobe refresh, poll-on-change, supersede guard, project-switch invalidation

## Testing

Full local CI suite passed: `npm run check` (typecheck + lint + format + channel/IPC guards), 32,483 unit tests, build, smoke. New test file covers reprobe-refreshes-all-WSL-monitors, null-default→unprobed, no-op for non-WSL/unknown workers, poll-on-change, supersede guard, and project-switch invalidation. `WorktreeMonitor` tests extended for three-state serialization and the new setter.