### PR TITLE
fix(help): add recovery affordances for denial and stale-binding states (#10017)

### DIFF
--- a/electron/ipc/__tests__/channelDrift.test.ts
+++ b/electron/ipc/__tests__/channelDrift.test.ts
@@ -93,11 +93,6 @@ const DEAD_CHANNEL_ALLOWLIST = new Set<string>([
   "telemetry:preview-subscribe",
   "telemetry:preview-unsubscribe",
 
-  // fire-and-forget — main→renderer push handled outside the typed event
-  // bus (httpLifecycle.ts uses `webContents.send`); the renderer surface is
-  // currently main-internal only.
-  "mcp-server:session-revoked",
-
   // fire-and-forget — renderer→main `ipcRenderer.send` for notification
   // bookkeeping (acknowledge/mute/sync paths in the notification store).
   "notification:session-mute-set",

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -647,6 +647,13 @@ export const CHANNELS = {
    */
   MCP_SERVER_REVOKE_SESSION_GRANTS: "mcp-server:revoke-session-grants",
   /**
+   * Reset the per-`(sessionId, toolId)` denial counters for a session without
+   * touching its grants. Fired when the user dismisses the tier-mismatch
+   * banner so the next out-of-tier call re-arms the banner instead of being
+   * silently suppressed by the abuse policy. Caller-pin checked.
+   */
+  MCP_SERVER_RESET_DENIAL_COUNTS: "mcp-server:reset-denial-counts",
+  /**
    * List the external bearers currently connected to the local MCP server.
    * Returns only the display suffix and token hash — never the raw token.
    * Backs the "External clients" row on the MCP Server settings tab (#8778).

--- a/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
@@ -33,11 +33,15 @@ const serviceMock = vi.hoisted(() => ({
   onRuntimeStateChange: vi.fn(() => () => {}),
   listActiveBearers: vi.fn(() => []),
   disconnectBearer: vi.fn((tokenHash: string) => ({ tokenHash, disconnected: true })),
+  resetDenialCounts: vi.fn(),
 }));
 
 vi.mock("electron", () => ({
   ipcMain: ipcMainMock,
   app: { getVersion: () => "0.0.0-test" },
+  // withContext handlers resolve the sender window via BrowserWindow —
+  // stub it so the context-bearing ops (resetDenialCounts) don't blow up.
+  BrowserWindow: { fromWebContents: () => null },
 }));
 vi.mock("../../../services/McpServerService.js", () => ({ mcpServerService: serviceMock }));
 
@@ -273,8 +277,38 @@ describe("mcpServer IPC adversarial", () => {
     expect(serviceMock.disconnectBearer).toHaveBeenCalledWith(valid);
   });
 
-  it("cleanup removes all twenty-two registered handlers", () => {
-    expect(ipcHandlers.size).toBe(22);
+  const RESET_DENIAL_COUNTS_CHANNEL = "mcp-server:reset-denial-counts";
+
+  it("resetDenialCounts rejects a non-object payload", async () => {
+    for (const bad of [null, undefined, "s1", 42]) {
+      await expect(getHandler(RESET_DENIAL_COUNTS_CHANNEL)(fakeEvent(), bad)).rejects.toThrow(
+        /Invalid payload/
+      );
+    }
+    expect(serviceMock.resetDenialCounts).not.toHaveBeenCalled();
+  });
+
+  it("resetDenialCounts rejects an empty or non-string sessionId", async () => {
+    for (const sessionId of ["", 42, null, undefined]) {
+      await expect(
+        getHandler(RESET_DENIAL_COUNTS_CHANNEL)(fakeEvent(), { sessionId })
+      ).rejects.toThrow(/Invalid sessionId/);
+    }
+    expect(serviceMock.resetDenialCounts).not.toHaveBeenCalled();
+  });
+
+  it("resetDenialCounts forwards a valid sessionId to the service with the caller's webContents id", async () => {
+    const event = {
+      sender: { id: 77 } as Electron.WebContents,
+    } as Electron.IpcMainInvokeEvent;
+    await getHandler(RESET_DENIAL_COUNTS_CHANNEL)(event, { sessionId: "sess-7" });
+    // The caller-pin id must ride along so the service can reject a renderer
+    // that doesn't own the session.
+    expect(serviceMock.resetDenialCounts).toHaveBeenCalledWith("sess-7", 77);
+  });
+
+  it("cleanup removes all twenty-three registered handlers", () => {
+    expect(ipcHandlers.size).toBe(23);
     cleanup();
     expect(ipcHandlers.size).toBe(0);
   });

--- a/electron/ipc/handlers/mcpServer.preload.ts
+++ b/electron/ipc/handlers/mcpServer.preload.ts
@@ -21,6 +21,7 @@ export const MCP_SERVER_METHOD_CHANNELS = {
   setSessionTier: "mcp-server:set-session-tier",
   issueGrant: "mcp-server:issue-grant",
   revokeSessionGrants: "mcp-server:revoke-session-grants",
+  resetDenialCounts: "mcp-server:reset-denial-counts",
   listActiveBearers: "mcp-server:list-active-bearers",
   disconnectBearer: "mcp-server:disconnect-bearer",
 } as const satisfies Record<string, keyof IpcInvokeMap>;

--- a/electron/ipc/handlers/mcpServer.ts
+++ b/electron/ipc/handlers/mcpServer.ts
@@ -258,6 +258,23 @@ export const mcpServerNamespace = defineIpcNamespace({
       },
       { withContext: true }
     ),
+    resetDenialCounts: op(
+      MCP_SERVER_METHOD_CHANNELS.resetDenialCounts,
+      async (ctx, payload: { sessionId: string }): Promise<void> => {
+        if (!payload || typeof payload !== "object") {
+          throw new Error("Invalid payload");
+        }
+        const { sessionId } = payload;
+        if (typeof sessionId !== "string" || !sessionId) {
+          throw new Error("Invalid sessionId");
+        }
+        const svc = await getMcpServerService();
+        // Same caller-pin invariant as `revokeSessionGrants` — only the
+        // renderer that minted the session can reset its denial counters.
+        svc.resetDenialCounts(sessionId, ctx.webContentsId);
+      },
+      { withContext: true }
+    ),
     listActiveBearers: op(
       MCP_SERVER_METHOD_CHANNELS.listActiveBearers,
       async (): Promise<ActiveBearerRecord[]> => {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2473,6 +2473,8 @@ const api: ElectronAPI = {
     ) => _typedOn(CHANNELS.MCP_TIER_NOT_PERMITTED, callback),
     onGrantLifecycle: (callback: (payload: McpGrantLifecyclePayload) => void) =>
       _typedOn(CHANNELS.MCP_GRANT_LIFECYCLE, callback),
+    onSessionRevoked: (callback: (payload: { sessionId: string; denialKind: string }) => void) =>
+      _typedOn(CHANNELS.MCP_SESSION_REVOKED, callback),
     onToolCallStarted: (callback: (payload: McpToolCallStartedPayload) => void) =>
       _typedOn(CHANNELS.MCP_TOOL_CALL_STARTED, callback),
     onToolCallSettled: (callback: (payload: McpToolCallSettledPayload) => void) =>

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -494,6 +494,15 @@ export class McpServerService {
   }
 
   /**
+   * Reset a session's denial counters without dropping its grants. Backs the
+   * tier-mismatch banner's Cancel path so a dismissed banner re-arms on the
+   * next out-of-tier call. Caller-pin checked.
+   */
+  resetDenialCounts(sessionId: string, callerWcId?: number): void {
+    this.httpLifecycle.resetDenialCounts(sessionId, callerWcId);
+  }
+
+  /**
    * Snapshot of the bearers currently connected to the local MCP server for
    * the settings tab. Raw tokens are never returned — only the display suffix
    * and the hash used to target {@link disconnectBearer}.

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -76,6 +76,11 @@ function fakeDeps(overrides?: Partial<HttpLifecycleDeps>): HttpLifecycleDeps {
       revokeSession: vi.fn(() => false),
       registerClientMetadata: vi.fn(),
       listExternalActiveClients: vi.fn(() => []),
+      grantCache: {
+        clearDenialCounts: vi.fn(),
+        revokeSession: vi.fn(() => 0),
+        issueGrant: vi.fn(),
+      },
     },
     auditService: {
       hydrate: vi.fn(),
@@ -435,6 +440,62 @@ describe("HttpLifecycle", () => {
       const deps = fakeDeps();
       const lc = new HttpLifecycle(deps);
       expect(() => lc.setSessionTier("", "system")).toThrow(/Invalid sessionId/);
+    });
+  });
+
+  describe("resetDenialCounts (#10017)", () => {
+    function grantCacheOf(deps: HttpLifecycleDeps) {
+      return (
+        deps.sessionStore as unknown as {
+          grantCache: { clearDenialCounts: ReturnType<typeof vi.fn> };
+        }
+      ).grantCache;
+    }
+
+    it("clears the session's denial counters without revoking its grants", () => {
+      const deps = fakeDeps();
+      deps.sessionStore.sessionWebContentsMap.set("sess-1", 42);
+      const lc = new HttpLifecycle(deps);
+
+      lc.resetDenialCounts("sess-1");
+
+      expect(grantCacheOf(deps).clearDenialCounts).toHaveBeenCalledWith("sess-1");
+      // Resetting denials must NOT touch per-tool grants — those have their
+      // own approval lifecycle (#8442).
+      expect(deps.sessionStore.grantCache.revokeSession).not.toHaveBeenCalled();
+    });
+
+    it("throws when the caller WebContents id doesn't match the pinned id", () => {
+      const deps = fakeDeps();
+      deps.sessionStore.sessionWebContentsMap.set("sess-pin", 42);
+      const lc = new HttpLifecycle(deps);
+
+      expect(() => lc.resetDenialCounts("sess-pin", 99)).toThrow(/not the pinned renderer/);
+      expect(grantCacheOf(deps).clearDenialCounts).not.toHaveBeenCalled();
+    });
+
+    it("accepts the caller WebContents id when it matches the pinned id", () => {
+      const deps = fakeDeps();
+      deps.sessionStore.sessionWebContentsMap.set("sess-ok", 42);
+      const lc = new HttpLifecycle(deps);
+
+      lc.resetDenialCounts("sess-ok", 42);
+      expect(grantCacheOf(deps).clearDenialCounts).toHaveBeenCalledWith("sess-ok");
+    });
+
+    it("is an idempotent no-op for a drained session (no pin) so banner dismissal always succeeds", () => {
+      const deps = fakeDeps();
+      // No sessionWebContentsMap entry — session already drained.
+      const lc = new HttpLifecycle(deps);
+
+      expect(() => lc.resetDenialCounts("sess-gone", 99)).not.toThrow();
+      expect(grantCacheOf(deps).clearDenialCounts).toHaveBeenCalledWith("sess-gone");
+    });
+
+    it("throws for blank session ids", () => {
+      const deps = fakeDeps();
+      const lc = new HttpLifecycle(deps);
+      expect(() => lc.resetDenialCounts("")).toThrow(/Invalid sessionId/);
     });
   });
 

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -1539,6 +1539,26 @@ export class HttpLifecycle {
   }
 
   /**
+   * Drop the per-`(sessionId, toolId)` denial counters for a session without
+   * touching its grants. Called when the user dismisses the tier-mismatch
+   * banner (Cancel) so the next out-of-tier call re-shows the banner instead
+   * of being silently suppressed by the abuse policy after the denial
+   * threshold. Caller-pin checked identically to {@link revokeSessionGrants};
+   * a drained session is an idempotent no-op so the renderer's dismissal
+   * cleanup always succeeds.
+   */
+  resetDenialCounts(sessionId: string, callerWcId?: number): void {
+    if (!sessionId || typeof sessionId !== "string") {
+      throw new Error("Invalid sessionId");
+    }
+    const pinnedWcId = this.deps.sessionStore.sessionWebContentsMap.get(sessionId);
+    if (pinnedWcId !== undefined && callerWcId !== undefined && callerWcId !== pinnedWcId) {
+      throw new Error("Caller is not the pinned renderer for this session");
+    }
+    this.deps.sessionStore.grantCache.clearDenialCounts(sessionId);
+  }
+
+  /**
    * Snapshot the externally-connected clients for the disable-confirmation
    * dialog (#8779). Empty when the server isn't listening.
    */

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1445,6 +1445,15 @@ export interface ElectronAPI extends GeneratedElectronAPI {
       callback: (payload: import("./mcpServer.js").McpGrantLifecyclePayload) => void
     ): () => void;
     /**
+     * Subscribe to session-revoked pushes for the pinned help-session in this
+     * WebContents. Fires when the abuse policy revokes the session after the
+     * denial threshold is exceeded so the renderer can explain why it ended
+     * and offer a new-session recovery action (#10017).
+     */
+    onSessionRevoked(
+      callback: (payload: { sessionId: string; denialKind: string }) => void
+    ): () => void;
+    /**
      * Subscribe to live tool-call-started pushes for the pinned help-session
      * in this WebContents. Drives the Assistant panel's activity strip (#9759).
      */

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -259,6 +259,9 @@ export interface GeneratedElectronAPI {
     listActiveClients(
       ...args: IpcInvokeMap["mcp-server:list-active-clients"]["args"]
     ): Promise<IpcInvokeMap["mcp-server:list-active-clients"]["result"]>;
+    resetDenialCounts(
+      ...args: IpcInvokeMap["mcp-server:reset-denial-counts"]["args"]
+    ): Promise<IpcInvokeMap["mcp-server:reset-denial-counts"]["result"]>;
     revokeSessionGrants(
       ...args: IpcInvokeMap["mcp-server:revoke-session-grants"]["args"]
     ): Promise<IpcInvokeMap["mcp-server:revoke-session-grants"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -495,6 +495,10 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: import("./mcpServer.js").McpActiveClientInfo[];
   };
+  "mcp-server:reset-denial-counts": {
+    args: [payload: { sessionId: string }];
+    result: void;
+  };
   "mcp-server:revoke-session-grants": {
     args: [payload: { sessionId: string }];
     result: import("./mcpServer.js").McpRevokeSessionGrantsResult;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1675,6 +1675,18 @@ export interface IpcEventMap {
   };
 
   /**
+   * Targeted push: a help-session was revoked by the abuse policy after
+   * exceeding the denial threshold. Sent to the pinned WebContents so the
+   * renderer can surface why the session ended and offer a new-session
+   * recovery action. `denialKind` records what tripped the policy
+   * (`"auth401"`, `"tierMismatch"`, …).
+   */
+  "mcp-server:session-revoked": {
+    sessionId: string;
+    denialKind: string;
+  };
+
+  /**
    * Targeted push: a grant lifecycle event for an MCP tool approval.
    * Sent to the pinned WebContents so the renderer can track grant state.
    */

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -203,6 +203,7 @@ export function HelpPanel({
   }, [sessionId]);
 
   const focusedWorktreeId = useWorktreeSelectionStore((s) => s.focusedWorktreeId);
+  const selectWorktree = useWorktreeSelectionStore((s) => s.selectWorktree);
   const pinnedTerminalPanel = usePanelStore((s) =>
     pinnedContext?.terminalId ? s.panelsById[pinnedContext.terminalId] : undefined
   );
@@ -594,6 +595,7 @@ export function HelpPanel({
   const cancelLaunch = useCallback(() => controller.cancelLaunch(), [controller]);
   const checkVersionAgain = useCallback(() => controller.checkVersionAgain(), [controller]);
   const dismissLaunchError = useCallback(() => controller.dismissLaunchError(), [controller]);
+  const dismissSessionRevoked = useCallback(() => controller.dismissSessionRevoked(), [controller]);
   const retryLaunch = useCallback(() => {
     const agentId = session.launchError?.agentId;
     if (agentId) controller.launch({ agentId });
@@ -709,6 +711,7 @@ export function HelpPanel({
           preflightSnapshot={session.preflightSnapshot}
           tierMismatch={session.tierMismatch}
           launchError={session.launchError}
+          sessionRevoked={session.sessionRevoked}
           isApprovingTier={session.isApprovingTier}
           onDismissResume={dismissResume}
           onDismissSnapshot={dismissSnapshot}
@@ -720,6 +723,8 @@ export function HelpPanel({
           onOpenAssistantSettings={handleOpenSettings}
           onOpenLogs={handleOpenLogs}
           onOpenInstallerPage={handleOpenInstallerPage}
+          onStartNewSession={handleNewSession}
+          onDismissSessionRevoked={dismissSessionRevoked}
         />
         {showTerminal ? (
           isMissingCli && agentId ? (
@@ -865,41 +870,76 @@ export function HelpPanel({
             <McpActivityStrip sessionId={sessionId} activity={session.mcpActivity} />
           </span>
           <span className="flex items-center gap-2 min-w-0 shrink-0 max-w-[70%]">
-            {pinnedContext && (
-              <span
-                className={cn(
-                  "flex items-center gap-1.5 min-w-0",
-                  isPinnedTerminalDead
-                    ? "text-status-danger"
-                    : isPinnedWorktreeDiverged
-                      ? "text-status-warning"
-                      : undefined
-                )}
-                title={
-                  isPinnedTerminalDead
-                    ? "The terminal this assistant was pinned to has closed — its tool calls can't reach it."
-                    : isPinnedWorktreeDiverged
-                      ? "This assistant is pinned to a different worktree than the one you have focused."
-                      : "Assistant tool calls are pinned to this worktree and terminal."
-                }
-              >
-                <span
-                  aria-hidden
+            {pinnedContext &&
+              // A diverged worktree is recoverable in one click — switch focus
+              // back to the worktree the session is pinned to. A dead terminal
+              // can't be fixed by switching, so it stays a passive indicator and
+              // surfaces a "Start new session" button beside it (#10017).
+              (isPinnedWorktreeDiverged && !isPinnedTerminalDead ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (pinnedContext.worktreeId) {
+                      selectWorktree(pinnedContext.worktreeId, { source: "user" });
+                    }
+                  }}
                   className={cn(
-                    "w-1.5 h-1.5 rounded-full shrink-0",
-                    isPinnedTerminalDead
-                      ? "bg-status-danger"
-                      : isPinnedWorktreeDiverged
-                        ? "bg-status-warning"
-                        : "bg-daintree-text/30"
+                    "flex items-center gap-1.5 min-w-0 p-0 bg-transparent border-none text-[11px]",
+                    "text-status-warning hover:text-status-warning/80 transition-colors duration-150",
+                    "rounded-[var(--radius-sm)]",
+                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
                   )}
-                />
-                <span className="truncate">
-                  {[pinnedContext.worktreeName, pinnedContext.worktreeBranch]
-                    .filter(Boolean)
-                    .join(" · ") || "Pinned session"}
+                  title="Switch to the worktree this assistant is pinned to."
+                >
+                  <span
+                    aria-hidden
+                    className="w-1.5 h-1.5 rounded-full shrink-0 bg-status-warning"
+                  />
+                  <span className="truncate">
+                    {[pinnedContext.worktreeName, pinnedContext.worktreeBranch]
+                      .filter(Boolean)
+                      .join(" · ") || "Pinned session"}
+                  </span>
+                </button>
+              ) : (
+                <span
+                  className={cn(
+                    "flex items-center gap-1.5 min-w-0",
+                    isPinnedTerminalDead ? "text-status-danger" : undefined
+                  )}
+                  title={
+                    isPinnedTerminalDead
+                      ? "The terminal this assistant was pinned to has closed — its tool calls can't reach it."
+                      : "Assistant tool calls are pinned to this worktree and terminal."
+                  }
+                >
+                  <span
+                    aria-hidden
+                    className={cn(
+                      "w-1.5 h-1.5 rounded-full shrink-0",
+                      isPinnedTerminalDead ? "bg-status-danger" : "bg-daintree-text/30"
+                    )}
+                  />
+                  <span className="truncate">
+                    {[pinnedContext.worktreeName, pinnedContext.worktreeBranch]
+                      .filter(Boolean)
+                      .join(" · ") || "Pinned session"}
+                  </span>
                 </span>
-              </span>
+              ))}
+            {isPinnedTerminalDead && (
+              <button
+                type="button"
+                onClick={handleNewSession}
+                className={cn(
+                  "flex items-center shrink-0 px-1.5 py-0.5 rounded-[var(--radius-sm)] text-[11px] font-medium",
+                  "bg-status-danger/10 text-status-danger hover:bg-status-danger/15 transition-colors duration-150",
+                  "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                )}
+                title="The pinned terminal has closed — start a new session."
+              >
+                Start new session
+              </button>
             )}
             <span
               className="flex items-center gap-1 shrink-0"

--- a/src/components/HelpPanel/HelpPanelBanners.tsx
+++ b/src/components/HelpPanel/HelpPanelBanners.tsx
@@ -4,6 +4,7 @@ import type { SnapshotInfo } from "@shared/types/ipc/git";
 import type {
   LaunchErrorKind,
   LaunchErrorState,
+  SessionRevokedState,
   TierMismatchState,
 } from "@/controllers/HelpSessionController";
 
@@ -53,6 +54,7 @@ interface HelpPanelBannersProps {
   preflightSnapshot: SnapshotInfo | null;
   tierMismatch: TierMismatchState | null;
   launchError: LaunchErrorState | null;
+  sessionRevoked: SessionRevokedState | null;
   isApprovingTier: boolean;
   onDismissResume: () => void;
   onDismissSnapshot: () => void;
@@ -64,6 +66,8 @@ interface HelpPanelBannersProps {
   onOpenAssistantSettings: () => void;
   onOpenLogs: () => void;
   onOpenInstallerPage: () => void;
+  onStartNewSession: () => void;
+  onDismissSessionRevoked: () => void;
 }
 
 export function HelpPanelBanners({
@@ -71,6 +75,7 @@ export function HelpPanelBanners({
   preflightSnapshot,
   tierMismatch,
   launchError,
+  sessionRevoked,
   isApprovingTier,
   onDismissResume,
   onDismissSnapshot,
@@ -82,6 +87,8 @@ export function HelpPanelBanners({
   onOpenAssistantSettings,
   onOpenLogs,
   onOpenInstallerPage,
+  onStartNewSession,
+  onDismissSessionRevoked,
 }: HelpPanelBannersProps) {
   return (
     <>
@@ -270,6 +277,54 @@ export function HelpPanelBanners({
                 </button>
               );
             })}
+          </div>
+        </div>
+      )}
+      {sessionRevoked && (
+        <div
+          role="alert"
+          className={cn(
+            "flex flex-col gap-2 px-3 py-2.5 mx-3 mt-3 mb-1",
+            "rounded-[var(--radius-md)]",
+            "bg-status-error/10 border border-status-error/40",
+            "text-xs text-daintree-text/85"
+          )}
+          data-testid="help-session-revoked-banner"
+        >
+          <div className="flex items-start gap-2">
+            <ShieldAlert
+              className="w-3.5 h-3.5 shrink-0 mt-0.5 text-status-error"
+              aria-hidden="true"
+            />
+            <div className="flex-1 select-text">
+              <p className="font-medium text-daintree-text">Session ended</p>
+              <p className="mt-0.5 text-daintree-text/70">
+                This assistant session was stopped after too many blocked requests. Start a new
+                session to continue.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={onDismissSessionRevoked}
+              aria-label="Dismiss session ended notice"
+              className="text-daintree-text/50 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+            >
+              <X className="w-3 h-3" />
+            </button>
+          </div>
+          <div className="flex items-center gap-2 flex-wrap pl-5">
+            <button
+              type="button"
+              onClick={onStartNewSession}
+              className={cn(
+                "px-2 py-1 rounded-[var(--radius-sm)] text-xs font-medium",
+                "bg-daintree-text/10 hover:bg-daintree-text/15 text-daintree-text",
+                "transition-colors",
+                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+              )}
+            >
+              Start new session
+            </button>
           </div>
         </div>
       )}

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -504,7 +504,9 @@ beforeEach(() => {
           onToolCallStarted: vi.fn(() => () => {}),
           onToolCallSettled: vi.fn(() => () => {}),
           onDisplayImage: vi.fn(() => () => {}),
+          onSessionRevoked: vi.fn(() => () => {}),
           setSessionTier: vi.fn().mockResolvedValue({ sessionId: "", tier: "workbench" }),
+          resetDenialCounts: vi.fn().mockResolvedValue(undefined),
           issueGrant: vi.fn().mockResolvedValue({
             sessionId: "",
             toolId: "",

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -431,7 +431,9 @@ beforeEach(() => {
           onToolCallStarted: vi.fn(() => () => {}),
           onToolCallSettled: vi.fn(() => () => {}),
           onDisplayImage: vi.fn(() => () => {}),
+          onSessionRevoked: vi.fn(() => () => {}),
           setSessionTier: vi.fn().mockResolvedValue({ sessionId: "", tier: "workbench" }),
+          resetDenialCounts: vi.fn().mockResolvedValue(undefined),
           issueGrant: vi.fn().mockResolvedValue({
             sessionId: "",
             toolId: "",

--- a/src/components/HelpPanel/__tests__/HelpPanelBanners.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanelBanners.test.tsx
@@ -13,6 +13,7 @@ function baseProps() {
     preflightSnapshot: null,
     tierMismatch: null,
     launchError: null,
+    sessionRevoked: null,
     isApprovingTier: false,
     onDismissResume: vi.fn(),
     onDismissSnapshot: vi.fn(),
@@ -24,6 +25,8 @@ function baseProps() {
     onOpenAssistantSettings: vi.fn(),
     onOpenLogs: vi.fn(),
     onOpenInstallerPage: vi.fn(),
+    onStartNewSession: vi.fn(),
+    onDismissSessionRevoked: vi.fn(),
   };
 }
 
@@ -215,5 +218,58 @@ describe("HelpPanelBanners — resume banner (#10057)", () => {
     );
     fireEvent.click(getByLabelText("Dismiss resume notice"));
     expect(onDismissResume).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("HelpPanelBanners — session revoked", () => {
+  it("renders an alert with a recovery action when a session is revoked", () => {
+    const { getByTestId, getByText } = render(
+      <HelpPanelBanners
+        {...baseProps()}
+        sessionRevoked={{ sessionId: "sess-1", denialKind: "tierMismatch" }}
+      />
+    );
+
+    const banner = getByTestId("help-session-revoked-banner");
+    expect(banner.getAttribute("role")).toBe("alert");
+    expect(getByText("Start new session")).toBeTruthy();
+  });
+
+  it("keeps the copy free of MCP / token / bearer jargon and the raw denial kind", () => {
+    const { getByTestId } = render(
+      <HelpPanelBanners
+        {...baseProps()}
+        sessionRevoked={{ sessionId: "sess-1", denialKind: "auth401" }}
+      />
+    );
+    const text = getByTestId("help-session-revoked-banner").textContent ?? "";
+    expect(text).not.toMatch(/\bMCP\b/i);
+    expect(text).not.toMatch(/\btoken\b/i);
+    expect(text).not.toMatch(/\bbearer\b/i);
+    expect(text).not.toMatch(/auth401/i);
+  });
+
+  it("wires the recovery and dismiss buttons to their handlers", () => {
+    const onStartNewSession = vi.fn();
+    const onDismissSessionRevoked = vi.fn();
+    const { getByText, getByLabelText } = render(
+      <HelpPanelBanners
+        {...baseProps()}
+        sessionRevoked={{ sessionId: "sess-1", denialKind: "tierMismatch" }}
+        onStartNewSession={onStartNewSession}
+        onDismissSessionRevoked={onDismissSessionRevoked}
+      />
+    );
+
+    fireEvent.click(getByText("Start new session"));
+    expect(onStartNewSession).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(getByLabelText("Dismiss session ended notice"));
+    expect(onDismissSessionRevoked).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders nothing for the revoked slot when sessionRevoked is null", () => {
+    const { queryByTestId } = render(<HelpPanelBanners {...baseProps()} />);
+    expect(queryByTestId("help-session-revoked-banner")).toBeNull();
   });
 });

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -101,6 +101,19 @@ export interface LaunchErrorState {
 }
 
 /**
+ * A help-session the abuse policy revoked after the denial threshold was
+ * exceeded (#10017). Surfaced as an inline error banner so the user learns
+ * why the session stopped responding and can start a fresh one — without this
+ * the session dies silently. `denialKind` records what tripped the policy
+ * (`"auth401"`, `"tierMismatch"`, …) for diagnostics; the banner copy stays
+ * jargon-free.
+ */
+export interface SessionRevokedState {
+  sessionId: string;
+  denialKind: string;
+}
+
+/**
  * Live MCP tool-call activity for the Assistant panel's ambient activity strip
  * (#9759). One row at a time: an in-flight call (tool id + args + elapsed) that
  * settles to a dimmed glyph + duration. Bursts within the same turn coalesce to
@@ -154,6 +167,8 @@ export interface HelpSessionSnapshot {
   launchError: LaunchErrorState | null;
   /** Live MCP tool-call activity for the ambient strip (#9759); null when idle. */
   mcpActivity: McpToolActivityState | null;
+  /** Set when the abuse policy revoked the active session (#10017); null otherwise. */
+  sessionRevoked: SessionRevokedState | null;
 }
 
 export interface HelpProjectRef {
@@ -461,6 +476,7 @@ const INITIAL_SNAPSHOT: HelpSessionSnapshot = Object.freeze({
   isCheckingVersion: false,
   launchError: null,
   mcpActivity: null,
+  sessionRevoked: null,
 });
 
 /**
@@ -557,6 +573,18 @@ export class HelpSessionController {
       });
     });
     this._disposers.push(disposeTier);
+
+    const disposeRevoked = window.electron.mcpServer.onSessionRevoked((payload) => {
+      // The push is targeted at the pinned WebContents, but guard against a
+      // late revoke for a session this panel has already replaced — it would
+      // otherwise paint a stale banner over the fresh session (#10017).
+      const currentSessionId = useHelpPanelStore.getState().sessionId;
+      if (currentSessionId !== null && payload.sessionId !== currentSessionId) return;
+      this._patch({
+        sessionRevoked: { sessionId: payload.sessionId, denialKind: payload.denialKind },
+      });
+    });
+    this._disposers.push(disposeRevoked);
 
     const disposeToolStarted = window.electron.mcpServer.onToolCallStarted((payload) => {
       this._onToolCallStarted(payload);
@@ -791,6 +819,10 @@ export class HelpSessionController {
     const launchProject = inputs.currentProject;
     this._isLaunching = true;
 
+    // A launch supersedes any revoked-session banner — the user is starting a
+    // fresh session, so the prior session's revocation no longer applies (#10017).
+    if (this._snapshot.sessionRevoked) this._patch({ sessionRevoked: null });
+
     // Snapshot the focused worktree/terminal synchronously before any await
     // so the session is pinned to what the user had focused at launch — the
     // HelpPanel footer chip surfaces this binding (#8772), and pinned tool
@@ -859,11 +891,26 @@ export class HelpSessionController {
   }
 
   dismissTierMismatch(): void {
+    // Capture the session before clearing the banner — `_patch` runs
+    // synchronously, so reading after would see a null `tierMismatch`.
+    const sessionId = this._snapshot.tierMismatch?.sessionId ?? null;
     this._patch({ tierMismatch: null });
+    if (!sessionId) return;
+    // Dismissing the banner without approving must re-arm it: reset the
+    // per-(session,tool) denial counters so the next out-of-tier call shows
+    // the banner again instead of being silently suppressed once the abuse
+    // policy threshold is crossed (#10017). Grants are left untouched.
+    safeFireAndForget(window.electron.mcpServer.resetDenialCounts({ sessionId }), {
+      context: "Help: reset denial counts on tier-mismatch dismiss",
+    });
   }
 
   dismissLaunchError(): void {
     this._patch({ launchError: null });
+  }
+
+  dismissSessionRevoked(): void {
+    this._patch({ sessionRevoked: null });
   }
 
   approveTierOnce(): void {
@@ -1167,7 +1214,8 @@ export class HelpSessionController {
       next.isApprovingTier === this._snapshot.isApprovingTier &&
       next.isCheckingVersion === this._snapshot.isCheckingVersion &&
       next.launchError === this._snapshot.launchError &&
-      next.mcpActivity === this._snapshot.mcpActivity
+      next.mcpActivity === this._snapshot.mcpActivity &&
+      next.sessionRevoked === this._snapshot.sessionRevoked
     ) {
       return;
     }

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -575,11 +575,14 @@ export class HelpSessionController {
     this._disposers.push(disposeTier);
 
     const disposeRevoked = window.electron.mcpServer.onSessionRevoked((payload) => {
-      // The push is targeted at the pinned WebContents, but guard against a
-      // late revoke for a session this panel has already replaced — it would
-      // otherwise paint a stale banner over the fresh session (#10017).
+      // Only surface a revoke that matches the session this panel currently
+      // holds. A live session always has its id committed to the store before
+      // any tool call (and thus before any denial/revoke), so a null or
+      // mismatched `sessionId` here means the revoke is for a torn-down or
+      // mid-relaunch session — painting its banner would stomp the fresh
+      // launch the user just started to escape it (#10017).
       const currentSessionId = useHelpPanelStore.getState().sessionId;
-      if (currentSessionId !== null && payload.sessionId !== currentSessionId) return;
+      if (currentSessionId === null || payload.sessionId !== currentSessionId) return;
       this._patch({
         sessionRevoked: { sessionId: payload.sessionId, denialKind: payload.denialKind },
       });
@@ -897,9 +900,12 @@ export class HelpSessionController {
     this._patch({ tierMismatch: null });
     if (!sessionId) return;
     // Dismissing the banner without approving must re-arm it: reset the
-    // per-(session,tool) denial counters so the next out-of-tier call shows
-    // the banner again instead of being silently suppressed once the abuse
-    // policy threshold is crossed (#10017). Grants are left untouched.
+    // denial counters so the next out-of-tier call shows the banner again
+    // instead of being silently suppressed once the abuse policy threshold is
+    // crossed (#10017). This clears the counters for ALL tools in the session,
+    // not just the dismissed one — Cancel means "show me again for anything in
+    // this session"; the threshold re-accrues from zero per tool. Grants
+    // (the per-tool approval lifecycle) are left untouched.
     safeFireAndForget(window.electron.mcpServer.resetDenialCounts({ sessionId }), {
       context: "Help: reset denial counts on tier-mismatch dismiss",
     });

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -646,6 +646,24 @@ describe("HelpSessionController — tier-mismatch handlers", () => {
     expect(mockMcpResetDenialCounts).not.toHaveBeenCalled();
     ctrl.stop();
   });
+
+  it("dismissTierMismatch() clears the banner even if the denial-reset IPC rejects", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    // Fire-and-forget: a rejected reset (e.g. caller-pin mismatch after a view
+    // rebind) must not throw or leave the banner stuck open.
+    mockMcpResetDenialCounts.mockRejectedValueOnce(new Error("not the pinned renderer"));
+    tierListeners[0]?.({
+      sessionId: "sess-r",
+      toolId: "t1",
+      tier: "workbench",
+      targetTier: "action",
+    });
+    expect(() => ctrl.dismissTierMismatch()).not.toThrow();
+    expect(ctrl.getSnapshot().tierMismatch).toBeNull();
+    expect(mockMcpResetDenialCounts).toHaveBeenCalledWith({ sessionId: "sess-r" });
+    ctrl.stop();
+  });
 });
 
 describe("HelpSessionController — session revoked (#10017)", () => {
@@ -677,12 +695,15 @@ describe("HelpSessionController — session revoked (#10017)", () => {
     ctrl.stop();
   });
 
-  it("surfaces the revoke when no session is pinned yet (sessionId null)", () => {
+  it("ignores a revoke while no session is pinned (torn-down or mid-relaunch window)", () => {
     const ctrl = new HelpSessionController();
     ctrl.start();
+    // A null store sessionId means there is no live session to end — a revoke
+    // arriving now is for a session being torn down or replaced, and must not
+    // paint a banner over the fresh launch the user just started (#10017).
     helpPanelState.sessionId = null;
-    sessionRevokedListeners[0]?.({ sessionId: "sess-x", denialKind: "tierMismatch" });
-    expect(ctrl.getSnapshot().sessionRevoked?.sessionId).toBe("sess-x");
+    sessionRevokedListeners[0]?.({ sessionId: "sess-old", denialKind: "tierMismatch" });
+    expect(ctrl.getSnapshot().sessionRevoked).toBeNull();
     ctrl.stop();
   });
 

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -6,8 +6,10 @@ const {
   mockMcpOnToolCallStarted,
   mockMcpOnToolCallSettled,
   mockMcpOnDisplayImage,
+  mockMcpOnSessionRevoked,
   mockMcpSetSessionTier,
   mockMcpIssueGrant,
+  mockMcpResetDenialCounts,
   mockSystemSleepOnSuspend,
   mockSystemSleepOnWake,
   systemSleepListeners,
@@ -15,6 +17,7 @@ const {
   toolStartedListeners,
   toolSettledListeners,
   displayImageListeners,
+  sessionRevokedListeners,
   helpPanelState,
   panelStoreState,
   projectStoreState,
@@ -23,6 +26,7 @@ const {
   mockMcpOnToolCallStarted: vi.fn(),
   mockMcpOnToolCallSettled: vi.fn(),
   mockMcpOnDisplayImage: vi.fn(),
+  mockMcpOnSessionRevoked: vi.fn(),
   mockMcpSetSessionTier: vi.fn().mockResolvedValue(undefined),
   mockMcpIssueGrant: vi.fn().mockResolvedValue({
     sessionId: "",
@@ -30,6 +34,7 @@ const {
     ttlMs: 900_000,
     expiresAt: Date.now() + 900_000,
   }),
+  mockMcpResetDenialCounts: vi.fn().mockResolvedValue(undefined),
   mockSystemSleepOnSuspend: vi.fn(),
   mockSystemSleepOnWake: vi.fn(),
   systemSleepListeners: {
@@ -40,6 +45,7 @@ const {
   toolStartedListeners: [] as Array<(payload: unknown) => void>,
   toolSettledListeners: [] as Array<(payload: unknown) => void>,
   displayImageListeners: [] as Array<(payload: unknown) => void>,
+  sessionRevokedListeners: [] as Array<(payload: unknown) => void>,
   helpPanelState: {
     isOpen: false,
     terminalId: null as string | null,
@@ -135,6 +141,7 @@ beforeEach(() => {
   toolStartedListeners.length = 0;
   toolSettledListeners.length = 0;
   displayImageListeners.length = 0;
+  sessionRevokedListeners.length = 0;
 
   mockMcpOnTierNotPermitted.mockReset();
   mockMcpOnTierNotPermitted.mockImplementation((cb: (payload: unknown) => void) => {
@@ -168,6 +175,16 @@ beforeEach(() => {
       if (idx >= 0) displayImageListeners.splice(idx, 1);
     };
   });
+  mockMcpOnSessionRevoked.mockReset();
+  mockMcpOnSessionRevoked.mockImplementation((cb: (payload: unknown) => void) => {
+    sessionRevokedListeners.push(cb);
+    return () => {
+      const idx = sessionRevokedListeners.indexOf(cb);
+      if (idx >= 0) sessionRevokedListeners.splice(idx, 1);
+    };
+  });
+  mockMcpResetDenialCounts.mockReset();
+  mockMcpResetDenialCounts.mockResolvedValue(undefined);
   mockMcpSetSessionTier.mockReset();
   mockMcpSetSessionTier.mockResolvedValue(undefined);
   mockMcpIssueGrant.mockReset();
@@ -221,8 +238,10 @@ beforeEach(() => {
           onToolCallStarted: mockMcpOnToolCallStarted,
           onToolCallSettled: mockMcpOnToolCallSettled,
           onDisplayImage: mockMcpOnDisplayImage,
+          onSessionRevoked: mockMcpOnSessionRevoked,
           setSessionTier: mockMcpSetSessionTier,
           issueGrant: mockMcpIssueGrant,
+          resetDenialCounts: mockMcpResetDenialCounts,
         },
         git: { snapshotGet: vi.fn().mockResolvedValue(null) },
         terminal: { gracefulKill: vi.fn().mockResolvedValue(null) },
@@ -264,6 +283,7 @@ describe("HelpSessionController — lifecycle", () => {
     expect(toolStartedListeners).toHaveLength(1);
     expect(toolSettledListeners).toHaveLength(1);
     expect(displayImageListeners).toHaveLength(1);
+    expect(sessionRevokedListeners).toHaveLength(1);
     expect(systemSleepListeners.suspend).toHaveLength(1);
     expect(systemSleepListeners.wake).toHaveLength(1);
     ctrl.stop();
@@ -271,6 +291,7 @@ describe("HelpSessionController — lifecycle", () => {
     expect(toolStartedListeners).toHaveLength(0);
     expect(toolSettledListeners).toHaveLength(0);
     expect(displayImageListeners).toHaveLength(0);
+    expect(sessionRevokedListeners).toHaveLength(0);
     expect(systemSleepListeners.suspend).toHaveLength(0);
     expect(systemSleepListeners.wake).toHaveLength(0);
   });
@@ -294,6 +315,7 @@ describe("HelpSessionController — subscribe / getSnapshot", () => {
     expect(snap.isCheckingVersion).toBe(false);
     expect(snap.launchError).toBeNull();
     expect(snap.mcpActivity).toBeNull();
+    expect(snap.sessionRevoked).toBeNull();
   });
 
   it("returns the same snapshot reference when no state changes (Object.is stable)", () => {
@@ -598,6 +620,97 @@ describe("HelpSessionController — tier-mismatch handlers", () => {
     expect(ctrl.getSnapshot().tierMismatch).not.toBeNull();
     ctrl.dismissTierMismatch();
     expect(ctrl.getSnapshot().tierMismatch).toBeNull();
+    ctrl.stop();
+  });
+
+  it("dismissTierMismatch() resets the denial counter for the dismissed session (#10017)", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    tierListeners[0]?.({
+      sessionId: "sess-9",
+      toolId: "t1",
+      tier: "workbench",
+      targetTier: "action",
+    });
+    ctrl.dismissTierMismatch();
+    // Cancel must re-arm the banner by clearing the per-session denial
+    // counters in main — without this the next denial is silently suppressed.
+    expect(mockMcpResetDenialCounts).toHaveBeenCalledWith({ sessionId: "sess-9" });
+    ctrl.stop();
+  });
+
+  it("dismissTierMismatch() does not reset denial counts when no banner is showing", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    ctrl.dismissTierMismatch();
+    expect(mockMcpResetDenialCounts).not.toHaveBeenCalled();
+    ctrl.stop();
+  });
+});
+
+describe("HelpSessionController — session revoked (#10017)", () => {
+  it("start() arms the session-revoked subscription", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    expect(mockMcpOnSessionRevoked).toHaveBeenCalledTimes(1);
+    ctrl.stop();
+  });
+
+  it("a session-revoked push surfaces the recovery banner", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    helpPanelState.sessionId = "sess-live";
+    sessionRevokedListeners[0]?.({ sessionId: "sess-live", denialKind: "tierMismatch" });
+    expect(ctrl.getSnapshot().sessionRevoked).toEqual({
+      sessionId: "sess-live",
+      denialKind: "tierMismatch",
+    });
+    ctrl.stop();
+  });
+
+  it("ignores a revoke for a session the panel has already replaced", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    helpPanelState.sessionId = "sess-current";
+    sessionRevokedListeners[0]?.({ sessionId: "sess-stale", denialKind: "auth401" });
+    expect(ctrl.getSnapshot().sessionRevoked).toBeNull();
+    ctrl.stop();
+  });
+
+  it("surfaces the revoke when no session is pinned yet (sessionId null)", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    helpPanelState.sessionId = null;
+    sessionRevokedListeners[0]?.({ sessionId: "sess-x", denialKind: "tierMismatch" });
+    expect(ctrl.getSnapshot().sessionRevoked?.sessionId).toBe("sess-x");
+    ctrl.stop();
+  });
+
+  it("dismissSessionRevoked clears the banner", () => {
+    const ctrl = new HelpSessionController();
+    ctrl["_patch"]({ sessionRevoked: { sessionId: "sess-1", denialKind: "tierMismatch" } });
+    expect(ctrl.getSnapshot().sessionRevoked).not.toBeNull();
+    ctrl.dismissSessionRevoked();
+    expect(ctrl.getSnapshot().sessionRevoked).toBeNull();
+  });
+
+  it("a launch supersedes any standing revoked-session banner", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    ctrl["_lastInputs"] = {
+      isOpen: true,
+      isReadyToLaunch: true,
+      currentProject: { id: "p1", path: "/repo" },
+      terminalId: null,
+      preferredAgentId: "claude",
+      supportedInstalledAgentIds: ["claude"],
+      visibilityEpoch: 0,
+    };
+    ctrl["_patch"]({ sessionRevoked: { sessionId: "sess-old", denialKind: "tierMismatch" } });
+    expect(ctrl.getSnapshot().sessionRevoked).not.toBeNull();
+
+    ctrl.launch({ agentId: "claude" });
+    expect(ctrl.getSnapshot().sessionRevoked).toBeNull();
     ctrl.stop();
   });
 });


### PR DESCRIPTION
## Summary

- Clicking Cancel on the tier-mismatch denial banner now resets the per-session denial counters via a new `resetDenialCounts` IPC op (`clearDenialCounts` on the grant cache, grants untouched), so the banner re-arms correctly instead of silently suppressing 3rd+ denials.
- The pinned-context chip in the help panel footer is now interactive: clicking it switches worktree focus when diverged, and shows a `Start new session` button when the terminal is dead.
- `MCP_SESSION_REVOKED` was being sent by main but never consumed by the renderer. It's now wired end-to-end: typed `IpcEventMap` entry, `onSessionRevoked` preload binding, `HelpSessionController` subscription with a positive `sessionId` match guard, and an inline recovery banner. The `_patch` equality guard now covers `sessionRevoked`, and the stale-revoke window (checking session validity after the async handler runs) is closed.

Resolves #10017

## Changes

- `electron/ipc/channels.ts` + `shared/types/ipc/maps.ts` + `shared/types/ipc/api.ts` + generated types: add `MCP_SESSION_REVOKED` to the typed push-event map and `resetDenialCounts` to the IPC op surface
- `electron/services/mcp-server/httpLifecycle.ts`: stale-revoke window fix
- `electron/ipc/handlers/mcpServer.ts` + `McpServerService.ts`: implement `clearDenialCounts` handler
- `electron/preload.cts` + `mcpServer.preload.ts`: expose `onSessionRevoked` and `resetDenialCounts` to the renderer
- `src/controllers/HelpSessionController.ts`: wire `onSessionRevoked` subscription, call `resetDenialCounts` on Cancel, updated `_patch` equality guard
- `src/components/HelpPanel/HelpPanel.tsx`: make pinned-context chip interactive (diverged → focus switch, dead → session banner)
- `src/components/HelpPanel/HelpPanelBanners.tsx`: new `SessionRevokedBanner` component
- Tests: adversarial `resetDenialCounts` coverage, `httpLifecycle` revoke-window tests, `HelpPanelBanners` unit tests, `HelpSessionController` integration tests

## Testing

All changed and related tests pass (73 in changed files, 99 across IPC/renderer suites). Typecheck of the main app `tsconfig` passes. Two checks couldn't run in the local sandbox due to pre-existing environment limitations present on the merge base: Electron-dependent main-process tests (Electron binary not available in sandbox) and workspace typecheck (`packages/create-daintree-plugin` module not linked). Both resolve in GitHub CI where `npm ci` installs Electron and builds workspace packages.