### PR TITLE
fix(pty): store explicit activity tier instead of deriving from polling interval

### DIFF
--- a/electron/__tests__/pty-host.adversarial.test.ts
+++ b/electron/__tests__/pty-host.adversarial.test.ts
@@ -1192,6 +1192,7 @@ describe("pty-host adversarial", () => {
       };
       expect(ptyManager.setActivityMonitorTier).toHaveBeenCalledWith(
         "t1",
+        expected,
         expected === "active" ? 50 : 500
       );
     }

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -353,7 +353,7 @@ function recomputeActivityTiers(): void {
       activeProjects.has(terminal.projectId);
     const tier = isActiveInAnyWindow ? "active" : "background";
     backpressureManager.setActivityTier(terminal.id, tier, "recompute-activity-tiers");
-    ptyManager.setActivityMonitorTier(terminal.id, tier === "active" ? 50 : 500);
+    ptyManager.setActivityMonitorTier(terminal.id, tier, tier === "active" ? 50 : 500);
 
     // Reconcile the renderer's dedupe baseline. The host rewrites tiers here
     // unilaterally, but TerminalRendererPolicy.setBackendTier dedupes outbound

--- a/electron/pty-host/handlers/backpressure.ts
+++ b/electron/pty-host/handlers/backpressure.ts
@@ -70,7 +70,7 @@ export function createBackpressureHandlers(ctx: HostContext): HandlerMap {
             : tier === "active"
               ? 50
               : 500;
-        ptyManager.setActivityMonitorTier(msg.id, pollingInterval);
+        ptyManager.setActivityMonitorTier(msg.id, tier, pollingInterval);
       }
 
       if (!atCoordinator?.isPaused) {
@@ -114,7 +114,7 @@ export function createBackpressureHandlers(ctx: HostContext): HandlerMap {
       // Apply active tier polling (50ms) when waking
       const terminal = ptyManager.getTerminal(msg.id);
       if (terminal) {
-        ptyManager.setActivityMonitorTier(msg.id, 50);
+        ptyManager.setActivityMonitorTier(msg.id, "active", 50);
       }
 
       // Best-effort warning: cwd missing

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -570,7 +570,7 @@ export class PtyManager extends EventEmitter {
       lastInputTime: terminalInfo.lastInputTime,
       lastOutputTime: terminalInfo.lastOutputTime,
       lastStateChange: terminalInfo.lastStateChange,
-      activityTier: terminal.getActivityTier() as "focused" | "visible" | "background",
+      activityTier: terminal.getActivityTier() === "active" ? "focused" : "background",
       outputBufferSize: terminalInfo.outputBuffer.length,
       semanticBufferLines: terminalInfo.semanticBuffer.length,
       restartCount: terminalInfo.restartCount,
@@ -827,7 +827,7 @@ export class PtyManager extends EventEmitter {
         });
 
         // Keep monitors running but reduce polling frequency for background terminals
-        terminalProcess.setActivityMonitorTier(BACKGROUND_POLLING_MS);
+        terminalProcess.setActivityMonitorTier("background", BACKGROUND_POLLING_MS);
         // Notify caller to sync backpressure tier
         onTierChange?.(id, "background");
         // Process detector remains active to detect new agents
@@ -840,7 +840,7 @@ export class PtyManager extends EventEmitter {
         });
 
         // Active terminals get full-speed polling
-        terminalProcess.setActivityMonitorTier(ACTIVE_POLLING_MS);
+        terminalProcess.setActivityMonitorTier("active", ACTIVE_POLLING_MS);
         // Notify caller to sync backpressure tier
         onTierChange?.(id, "active");
         // Ensure process detector is running
@@ -854,10 +854,14 @@ export class PtyManager extends EventEmitter {
   /**
    * Set activity monitoring tier (active vs background).
    */
-  setActivityMonitorTier(id: string, interval: number): void {
+  setActivityMonitorTier(
+    id: string,
+    tier: "active" | "background",
+    pollingIntervalMs: number
+  ): void {
     const terminal = this.registry.get(id);
     if (terminal) {
-      terminal.setActivityMonitorTier(interval);
+      terminal.setActivityMonitorTier(tier, pollingIntervalMs);
     }
   }
 

--- a/electron/services/__tests__/PtyManager.activityTier.integration.test.ts
+++ b/electron/services/__tests__/PtyManager.activityTier.integration.test.ts
@@ -32,8 +32,24 @@ describe("PtyManager Activity Tier", () => {
       expect(terminal).toBeDefined();
 
       // ActivityMonitor tier can be changed
-      expect(() => manager.setActivityMonitorTier(id, 500)).not.toThrow();
-      expect(() => manager.setActivityMonitorTier(id, 50)).not.toThrow();
+      expect(() => manager.setActivityMonitorTier(id, "background", 500)).not.toThrow();
+      expect(() => manager.setActivityMonitorTier(id, "active", 50)).not.toThrow();
+    });
+
+    it("should store the explicit tier, not derive it from the polling interval", async () => {
+      const id = await spawnShellTerminal(manager);
+      await sleep(200);
+
+      // Issue #9911: VISIBLE-unfocused panes send ("active", 200ms). The old
+      // code derived tier from interval <= 50, misclassifying this as background.
+      manager.setActivityMonitorTier(id, "active", 200);
+      expect(manager.getActivityTier(id)).toBe("active");
+
+      manager.setActivityMonitorTier(id, "background", 500);
+      expect(manager.getActivityTier(id)).toBe("background");
+
+      manager.setActivityMonitorTier(id, "active", 50);
+      expect(manager.getActivityTier(id)).toBe("active");
     });
   });
 
@@ -46,10 +62,10 @@ describe("PtyManager Activity Tier", () => {
       expect(terminal).toBeDefined();
 
       // Change to background tier polling (500ms)
-      manager.setActivityMonitorTier(id, 500);
+      manager.setActivityMonitorTier(id, "background", 500);
 
       // Change to active tier polling (50ms)
-      manager.setActivityMonitorTier(id, 50);
+      manager.setActivityMonitorTier(id, "active", 50);
 
       // Verify terminal is still functioning
       await sleep(100);
@@ -62,8 +78,8 @@ describe("PtyManager Activity Tier", () => {
 
       // Rapid tier changes should be safe
       for (let i = 0; i < 5; i++) {
-        manager.setActivityMonitorTier(id, 500);
-        manager.setActivityMonitorTier(id, 50);
+        manager.setActivityMonitorTier(id, "background", 500);
+        manager.setActivityMonitorTier(id, "active", 50);
       }
 
       await sleep(100);
@@ -80,7 +96,7 @@ describe("PtyManager Activity Tier", () => {
       expect(terminal).toBeDefined();
 
       // Set to background tier
-      manager.setActivityMonitorTier(id, 500);
+      manager.setActivityMonitorTier(id, "background", 500);
 
       // Kill terminal
       manager.kill(id);

--- a/electron/services/__tests__/PtyManager.activityTier.integration.test.ts
+++ b/electron/services/__tests__/PtyManager.activityTier.integration.test.ts
@@ -20,6 +20,7 @@ describe("PtyManager Activity Tier", () => {
 
       const terminal = manager.getTerminal(id);
       expect(terminal).toBeDefined();
+      expect(manager.getActivityTier(id)).toBe("active");
     });
 
     it("should accept setActivityTier calls without error", async () => {
@@ -50,6 +51,15 @@ describe("PtyManager Activity Tier", () => {
 
       manager.setActivityMonitorTier(id, "active", 50);
       expect(manager.getActivityTier(id)).toBe("active");
+
+      // Inversion of the original bug: a 50ms interval must not force "active".
+      manager.setActivityMonitorTier(id, "background", 50);
+      expect(manager.getActivityTier(id)).toBe("background");
+    });
+
+    it("should no-op for an unknown terminal id", () => {
+      expect(() => manager.setActivityMonitorTier("nonexistent", "active", 200)).not.toThrow();
+      expect(manager.getActivityTier("nonexistent")).toBeUndefined();
     });
   });
 

--- a/electron/services/__tests__/PtyManager.adversarial.test.ts
+++ b/electron/services/__tests__/PtyManager.adversarial.test.ts
@@ -366,8 +366,8 @@ describe("PtyManager adversarial", () => {
       tierChanges.push({ id, tier });
     });
 
-    expect(shared.created[0]!.setActivityMonitorTier).toHaveBeenCalledWith(50);
-    expect(shared.created[1]!.setActivityMonitorTier).toHaveBeenCalledWith(500);
+    expect(shared.created[0]!.setActivityMonitorTier).toHaveBeenCalledWith("active", 50);
+    expect(shared.created[1]!.setActivityMonitorTier).toHaveBeenCalledWith("background", 500);
     expect(shared.created[0]!.startProcessDetector).toHaveBeenCalledTimes(1);
     expect(tierChanges).toEqual([
       { id: "t1", tier: "active" },

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1377,10 +1377,10 @@ export class TerminalProcess {
     this.osc94Parser.reset();
   }
 
-  setActivityMonitorTier(pollingIntervalMs: number): void {
-    // Track activity tier based on polling interval:
-    // 50ms = active (foreground), 500ms = background (project switched away)
-    this._activityTier = pollingIntervalMs <= 50 ? "active" : "background";
+  setActivityMonitorTier(tier: "active" | "background", pollingIntervalMs: number): void {
+    // The tier is authoritative; the polling interval is only a cadence hint
+    // (issue #8596 — VISIBLE-unfocused panes are "active" at 200ms).
+    this._activityTier = tier;
 
     if (this.activityMonitor) {
       this.activityMonitor.setPollingInterval(pollingIntervalMs);


### PR DESCRIPTION
## Summary

- Visible-unfocused panes send `("active", 200ms)` per the PR #8596 contract, but `TerminalProcess.setActivityMonitorTier` was deriving `_activityTier` from `interval <= 50ms` — so these panes were stored as `"background"`.
- That misclassification flowed through `terminalInfo` snapshots into state hydration, arming a spurious `needsWake=true` and triggering unnecessary `wakeAndRestore`/`reset()` cycles on visible panes.
- The tier is now an explicit `"active" | "background"` parameter threaded through `TerminalProcess`, `PtyManager`, the `set-activity-tier` and `wake-terminal` IPC handlers, `recompute-activity-tiers`, and both project-switch paths. The polling interval drives only `ActivityMonitor` cadence. Also replaces the unsound `as "focused"|"visible"|"background"` cast in `PtyManager.getTerminalInfo` with an explicit `active → focused` map (display-only `TerminalInfoPayload`).

Resolves #9911

## Changes

- `electron/services/pty/TerminalProcess.ts` — `setActivityMonitorTier(tier, interval)` signature; stores `tier` directly
- `electron/services/PtyManager.ts` — threads explicit tier through all call sites; fixes `getTerminalInfo` cast
- `electron/pty-host.ts` and `electron/pty-host/handlers/backpressure.ts` — updated to new signature
- `electron/services/__tests__/PtyManager.activityTier.integration.test.ts` — new regression tests: `("active", 200ms) → stays "active"`, `("background", 50ms) → stays "background"`, default-tier-on-spawn, unknown-id no-op
- `electron/__tests__/pty-host.adversarial.test.ts` and `electron/services/__tests__/PtyManager.adversarial.test.ts` — call sites updated

## Testing

Typecheck, lint, format, codegen guards, and 50/50 targeted unit tests all pass. Production build clean. Regression tests cover the exact contract that was broken — visible-unfocused `("active", 200ms)` must not downgrade to `"background"`.