### PR TITLE
fix(pty-host): re-emit paused-backpressure with live queue tokens on governor disengage

### DIFF
--- a/electron/pty-host/PtyPauseCoordinator.ts
+++ b/electron/pty-host/PtyPauseCoordinator.ts
@@ -60,4 +60,16 @@ export class PtyPauseCoordinator {
   hasToken(token: PauseToken): boolean {
     return this.holds.has(token);
   }
+
+  // True when any backpressure-class hold is active: the live queue tokens
+  // ("ipc-queue", "port-queue", "port-queue-${windowId}") or the FUTURE_SAB
+  // "backpressure" token.
+  hasAnyBackpressureToken(): boolean {
+    for (const token of this.holds) {
+      if (token === "ipc-queue" || token === "backpressure" || token.startsWith("port-queue")) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/electron/pty-host/ResourceGovernor.ts
+++ b/electron/pty-host/ResourceGovernor.ts
@@ -571,7 +571,7 @@ export class ResourceGovernor {
       }
       if (!coordinator?.isPaused) {
         this.deps.emitTerminalStatus(id, "running", undefined, duration);
-      } else if (coordinator.hasToken("backpressure")) {
+      } else if (coordinator.hasAnyBackpressureToken()) {
         // Restore backpressure status — the governor's pause
         // overwrote it in the dedup map during engage.
         this.deps.emitTerminalStatus(id, "paused-backpressure", undefined, duration);

--- a/electron/pty-host/__tests__/PtyPauseCoordinator.test.ts
+++ b/electron/pty-host/__tests__/PtyPauseCoordinator.test.ts
@@ -163,6 +163,45 @@ describe("PtyPauseCoordinator", () => {
     expect(coord.hasToken("ipc-queue")).toBe(false);
   });
 
+  describe("hasAnyBackpressureToken", () => {
+    it.each(["ipc-queue", "port-queue", "port-queue-5", "backpressure"] as const)(
+      "returns true when %s is held",
+      (token) => {
+        const coord = new PtyPauseCoordinator(createMockRaw());
+        coord.pause(token);
+        expect(coord.hasAnyBackpressureToken()).toBe(true);
+      }
+    );
+
+    it("returns false when no tokens are held", () => {
+      const coord = new PtyPauseCoordinator(createMockRaw());
+      expect(coord.hasAnyBackpressureToken()).toBe(false);
+    });
+
+    it("returns false when only non-backpressure tokens are held", () => {
+      const coord = new PtyPauseCoordinator(createMockRaw());
+      coord.pause("resource-governor");
+      coord.pause("system-sleep");
+      expect(coord.hasAnyBackpressureToken()).toBe(false);
+    });
+
+    it("returns true when a backpressure token is held among others", () => {
+      const coord = new PtyPauseCoordinator(createMockRaw());
+      coord.pause("resource-governor");
+      coord.pause("port-queue-3");
+      coord.pause("system-sleep");
+      expect(coord.hasAnyBackpressureToken()).toBe(true);
+    });
+
+    it("returns false after the backpressure token is released", () => {
+      const coord = new PtyPauseCoordinator(createMockRaw());
+      coord.pause("ipc-queue");
+      coord.pause("resource-governor");
+      coord.resume("ipc-queue");
+      expect(coord.hasAnyBackpressureToken()).toBe(false);
+    });
+  });
+
   it("duplicate pause with same token does not double-count", () => {
     const raw = createMockRaw();
     const coord = new PtyPauseCoordinator(raw);

--- a/electron/pty-host/__tests__/ResourceGovernor.test.ts
+++ b/electron/pty-host/__tests__/ResourceGovernor.test.ts
@@ -418,8 +418,8 @@ describe("ResourceGovernor", () => {
       vi.advanceTimersByTime(ADVANCE_TO_ENGAGE_MS);
       expect(coordinator.hasToken("resource-governor")).toBe(true);
 
-      // Simulate backpressure manager also holding a pause
-      coordinator.pause("backpressure");
+      // Simulate the IPC queue manager also holding a pause
+      coordinator.pause("ipc-queue");
 
       // Now lower memory to trigger disengage
       vi.spyOn(process, "memoryUsage").mockReturnValue({
@@ -435,15 +435,22 @@ describe("ResourceGovernor", () => {
 
       // Governor released its hold, but backpressure still holds — PTY must stay paused
       expect(coordinator.hasToken("resource-governor")).toBe(false);
-      expect(coordinator.hasToken("backpressure")).toBe(true);
+      expect(coordinator.hasToken("ipc-queue")).toBe(true);
       expect(coordinator.isPaused).toBe(true);
       expect(raw.resume).not.toHaveBeenCalled();
 
       // Should NOT emit "running" because backpressure still holds
-      const terminalStatusCalls = (
-        deps.emitTerminalStatus as ReturnType<typeof vi.fn>
-      ).mock.calls.filter((c: unknown[]) => (c as string[])[1] === "running");
-      expect(terminalStatusCalls).toHaveLength(0);
+      const statusCalls = (deps.emitTerminalStatus as ReturnType<typeof vi.fn>).mock.calls;
+      const runningCalls = statusCalls.filter((c: unknown[]) => (c as string[])[1] === "running");
+      expect(runningCalls).toHaveLength(0);
+
+      // Should re-emit "paused-backpressure" so the renderer pill isn't stuck
+      // on the governor's stale "Paused (memory)" status
+      const backpressureCalls = statusCalls.filter(
+        (c: unknown[]) => (c as string[])[1] === "paused-backpressure"
+      );
+      expect(backpressureCalls).toHaveLength(1);
+      expect(backpressureCalls[0][0]).toBe("t1");
 
       governor.dispose();
     });

--- a/electron/pty-host/__tests__/ResourceGovernor.test.ts
+++ b/electron/pty-host/__tests__/ResourceGovernor.test.ts
@@ -394,8 +394,77 @@ describe("ResourceGovernor", () => {
   });
 
   describe("coordination with other managers", () => {
-    it("disengageThrottle does not resume PTY when backpressure hold is active", () => {
-      const { coordinator, raw } = createMockCoordinator();
+    it.each(["ipc-queue", "port-queue", "port-queue-5"] as const)(
+      "disengageThrottle does not resume PTY when %s hold is active",
+      (queueToken) => {
+        const { coordinator, raw } = createMockCoordinator();
+        const deps = createMockDeps({
+          getTerminalIds: vi.fn().mockReturnValue(["t1"]),
+          getPauseCoordinator: vi.fn().mockReturnValue(coordinator),
+          getTerminalActivity: vi
+            .fn()
+            .mockReturnValue([{ id: "t1", lastOutputTime: 100, lastInputTime: 100 }]),
+        });
+
+        vi.spyOn(process, "memoryUsage").mockReturnValue({
+          heapUsed: 900 * 1024 * 1024,
+          rss: 1024 * 1024 * 1024,
+          external: 0,
+          arrayBuffers: 0,
+        } as ReturnType<typeof process.memoryUsage>);
+
+        const governor = new ResourceGovernor(deps);
+        governor.start();
+
+        // Trigger engage
+        vi.advanceTimersByTime(ADVANCE_TO_ENGAGE_MS);
+        expect(coordinator.hasToken("resource-governor")).toBe(true);
+
+        // Simulate a queue manager also holding a pause
+        coordinator.pause(queueToken);
+
+        // Now lower memory to trigger disengage
+        vi.spyOn(process, "memoryUsage").mockReturnValue({
+          heapUsed: 500 * 1024 * 1024,
+          rss: 1024 * 1024 * 1024,
+          external: 0,
+          arrayBuffers: 0,
+        } as ReturnType<typeof process.memoryUsage>);
+
+        raw.resume.mockClear();
+        (deps.emitTerminalStatus as ReturnType<typeof vi.fn>).mockClear();
+        vi.advanceTimersByTime(2000);
+
+        // Governor released its hold, but backpressure still holds — PTY must stay paused
+        expect(coordinator.hasToken("resource-governor")).toBe(false);
+        expect(coordinator.hasToken(queueToken)).toBe(true);
+        expect(coordinator.isPaused).toBe(true);
+        expect(raw.resume).not.toHaveBeenCalled();
+
+        // Should NOT emit "running" because backpressure still holds
+        const statusCalls = (deps.emitTerminalStatus as ReturnType<typeof vi.fn>).mock.calls;
+        const runningCalls = statusCalls.filter((c: unknown[]) => (c as string[])[1] === "running");
+        expect(runningCalls).toHaveLength(0);
+
+        // Should re-emit "paused-backpressure" so the renderer pill isn't stuck
+        // on the governor's stale "Paused (memory)" status
+        const backpressureCalls = statusCalls.filter(
+          (c: unknown[]) => (c as string[])[1] === "paused-backpressure"
+        );
+        expect(backpressureCalls).toHaveLength(1);
+        expect(backpressureCalls[0]).toEqual([
+          "t1",
+          "paused-backpressure",
+          undefined,
+          expect.any(Number),
+        ]);
+
+        governor.dispose();
+      }
+    );
+
+    it("dispose does not emit paused-backpressure for terminals with a queue hold", () => {
+      const { coordinator } = createMockCoordinator();
       const deps = createMockDeps({
         getTerminalIds: vi.fn().mockReturnValue(["t1"]),
         getPauseCoordinator: vi.fn().mockReturnValue(coordinator),
@@ -414,45 +483,22 @@ describe("ResourceGovernor", () => {
       const governor = new ResourceGovernor(deps);
       governor.start();
 
-      // Trigger engage
       vi.advanceTimersByTime(ADVANCE_TO_ENGAGE_MS);
       expect(coordinator.hasToken("resource-governor")).toBe(true);
-
-      // Simulate the IPC queue manager also holding a pause
       coordinator.pause("ipc-queue");
 
-      // Now lower memory to trigger disengage
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 500 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
-
-      raw.resume.mockClear();
       (deps.emitTerminalStatus as ReturnType<typeof vi.fn>).mockClear();
-      vi.advanceTimersByTime(2000);
+      governor.dispose();
 
-      // Governor released its hold, but backpressure still holds — PTY must stay paused
-      expect(coordinator.hasToken("resource-governor")).toBe(false);
-      expect(coordinator.hasToken("ipc-queue")).toBe(true);
-      expect(coordinator.isPaused).toBe(true);
-      expect(raw.resume).not.toHaveBeenCalled();
-
-      // Should NOT emit "running" because backpressure still holds
+      // Teardown path deliberately has no backpressure-restore branch — queue
+      // managers emit their own events, and renderers are disconnected first
       const statusCalls = (deps.emitTerminalStatus as ReturnType<typeof vi.fn>).mock.calls;
-      const runningCalls = statusCalls.filter((c: unknown[]) => (c as string[])[1] === "running");
-      expect(runningCalls).toHaveLength(0);
-
-      // Should re-emit "paused-backpressure" so the renderer pill isn't stuck
-      // on the governor's stale "Paused (memory)" status
       const backpressureCalls = statusCalls.filter(
         (c: unknown[]) => (c as string[])[1] === "paused-backpressure"
       );
-      expect(backpressureCalls).toHaveLength(1);
-      expect(backpressureCalls[0][0]).toBe("t1");
-
-      governor.dispose();
+      expect(backpressureCalls).toHaveLength(0);
+      const runningCalls = statusCalls.filter((c: unknown[]) => (c as string[])[1] === "running");
+      expect(runningCalls).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
## Summary

- `ResourceGovernor.disengageThrottle` was checking `coordinator.hasToken("backpressure")`, a token only taken on the unreachable `FUTURE_SAB` path — so when the governor disengaged while a live queue hold (`ipc-queue`, `port-queue`, or `port-queue-${windowId}`) was still pausing the terminal, the backpressure status was never re-emitted and the renderer pill stayed stuck on stale "Paused (memory)" until queue resume or the ~10s safety timeout
- New `PtyPauseCoordinator.hasAnyBackpressureToken()` matches all live backpressure tokens (`ipc-queue`, `port-queue` prefix, and `backpressure` for `FUTURE_SAB` forward-compat); `disengageThrottle` now uses it in the restore branch
- Tests parameterized over all three live token variants with full emit-signature assertions; dispose guard test added documenting that teardown deliberately skips the restore branch

Resolves #9895

## Changes

- `electron/pty-host/PtyPauseCoordinator.ts` — add `hasAnyBackpressureToken()`
- `electron/pty-host/ResourceGovernor.ts` — use `hasAnyBackpressureToken()` in `disengageThrottle`
- `electron/pty-host/__tests__/ResourceGovernor.test.ts` — parameterize coordination test over `ipc-queue`, `port-queue`, `port-queue-5`; full emit-signature assertion; dispose guard test
- `electron/pty-host/__tests__/PtyPauseCoordinator.test.ts` — positive/negative coverage for `hasAnyBackpressureToken`

## Testing

- `npm run check` passes
- `electron/pty-host` suite: 246 tests pass