### PR TITLE
fix(pty-host): hold backpressure pause until after wake snapshot serialization

### DIFF
--- a/electron/pty-host/handlers/__tests__/backpressure.test.ts
+++ b/electron/pty-host/handlers/__tests__/backpressure.test.ts
@@ -107,7 +107,7 @@ describe("wake-terminal handler", () => {
       getPauseCoordinator: vi.fn(() => coord as never),
     });
     vi.mocked(ctx.backpressureManager.getPausedInterval).mockReturnValue(
-      setTimeout(() => {}, 60_000) as never,
+      setTimeout(() => {}, 60_000) as never
     );
 
     const handlers = createBackpressureHandlers(ctx);
@@ -125,7 +125,7 @@ describe("wake-terminal handler", () => {
       getPauseCoordinator: vi.fn(() => coord as never),
     });
     vi.mocked(ctx.backpressureManager.getPausedInterval).mockReturnValue(
-      setTimeout(() => {}, 60_000) as never,
+      setTimeout(() => {}, 60_000) as never
     );
 
     const handlers = createBackpressureHandlers(ctx);
@@ -133,7 +133,7 @@ describe("wake-terminal handler", () => {
 
     expect(coord.resume).toHaveBeenCalledExactlyOnceWith("backpressure");
     expect(ctx.sendEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "wake-result", id: "term-1", state: "fallback" }),
+      expect.objectContaining({ type: "wake-result", id: "term-1", state: "fallback" })
     );
   });
 
@@ -148,7 +148,7 @@ describe("wake-terminal handler", () => {
       getPauseCoordinator: vi.fn(() => coord as never),
     });
     vi.mocked(ctx.backpressureManager.getPausedInterval).mockReturnValue(
-      setTimeout(() => {}, 60_000) as never,
+      setTimeout(() => {}, 60_000) as never
     );
 
     const handlers = createBackpressureHandlers(ctx);
@@ -157,7 +157,7 @@ describe("wake-terminal handler", () => {
     expect(coord.resume).toHaveBeenCalledExactlyOnceWith("backpressure");
     expect(ctx.ptyManager.getSerializedState).not.toHaveBeenCalled();
     expect(ctx.sendEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "wake-result", id: "term-1", state: null }),
+      expect.objectContaining({ type: "wake-result", id: "term-1", state: null })
     );
   });
 
@@ -173,7 +173,7 @@ describe("wake-terminal handler", () => {
 
     expect(coord.resume).not.toHaveBeenCalled();
     expect(ctx.sendEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "wake-result", id: "term-1", state: "snapshot" }),
+      expect.objectContaining({ type: "wake-result", id: "term-1", state: "snapshot" })
     );
   });
 });

--- a/electron/pty-host/handlers/__tests__/backpressure.test.ts
+++ b/electron/pty-host/handlers/__tests__/backpressure.test.ts
@@ -75,6 +75,85 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
   };
 }
 
+describe("wake-terminal handler", () => {
+  function makeWakePtyManager(order: string[], opts: { asyncThrows?: boolean } = {}) {
+    return {
+      getTerminal: vi.fn(() => undefined),
+      getAll: vi.fn(() => []),
+      setActivityMonitorTier: vi.fn(),
+      acknowledgeData: vi.fn(),
+      getSerializedStateAsync: vi.fn(async () => {
+        if (opts.asyncThrows) {
+          throw new Error("serialize failed");
+        }
+        order.push("serialized");
+        return "snapshot";
+      }),
+      getSerializedState: vi.fn(() => "fallback"),
+    } as unknown as HostContext["ptyManager"];
+  }
+
+  it("releases the backpressure hold only after the snapshot is serialized (#9897)", async () => {
+    // Resuming the PTY before serialization lets bytes emitted in the gap
+    // land in both the snapshot and the live stream — the renderer then
+    // replays them twice after restore.
+    const order: string[] = [];
+    const coord = makeCoordinator();
+    coord.resume.mockImplementation(() => {
+      order.push("resumed");
+    });
+    const ctx = makeCtx({
+      ptyManager: makeWakePtyManager(order),
+      getPauseCoordinator: vi.fn(() => coord as never),
+    });
+    vi.mocked(ctx.backpressureManager.getPausedInterval).mockReturnValue(
+      setTimeout(() => {}, 60_000) as never,
+    );
+
+    const handlers = createBackpressureHandlers(ctx);
+    await handlers["wake-terminal"]({ type: "wake-terminal", id: "term-1", requestId: "req-1" });
+
+    expect(order).toEqual(["serialized", "resumed"]);
+    expect(coord.resume).toHaveBeenCalledExactlyOnceWith("backpressure");
+  });
+
+  it("still resumes the hold when async serialization throws (#9896 invariant)", async () => {
+    const order: string[] = [];
+    const coord = makeCoordinator();
+    const ctx = makeCtx({
+      ptyManager: makeWakePtyManager(order, { asyncThrows: true }),
+      getPauseCoordinator: vi.fn(() => coord as never),
+    });
+    vi.mocked(ctx.backpressureManager.getPausedInterval).mockReturnValue(
+      setTimeout(() => {}, 60_000) as never,
+    );
+
+    const handlers = createBackpressureHandlers(ctx);
+    await handlers["wake-terminal"]({ type: "wake-terminal", id: "term-1", requestId: "req-1" });
+
+    expect(coord.resume).toHaveBeenCalledExactlyOnceWith("backpressure");
+    expect(ctx.sendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "wake-result", id: "term-1", state: "fallback" }),
+    );
+  });
+
+  it("does not resume the coordinator when no backpressure pause was active", async () => {
+    const coord = makeCoordinator();
+    const ctx = makeCtx({
+      ptyManager: makeWakePtyManager([]),
+      getPauseCoordinator: vi.fn(() => coord as never),
+    });
+
+    const handlers = createBackpressureHandlers(ctx);
+    await handlers["wake-terminal"]({ type: "wake-terminal", id: "term-1", requestId: "req-1" });
+
+    expect(coord.resume).not.toHaveBeenCalled();
+    expect(ctx.sendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "wake-result", id: "term-1", state: "snapshot" }),
+    );
+  });
+});
+
 describe("force-resume handler", () => {
   beforeEach(() => {
     vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/electron/pty-host/handlers/__tests__/backpressure.test.ts
+++ b/electron/pty-host/handlers/__tests__/backpressure.test.ts
@@ -137,6 +137,30 @@ describe("wake-terminal handler", () => {
     );
   });
 
+  it("resumes the hold and sends wake-result when the serializer resolves null", async () => {
+    // TerminalSerializerService catches internally and resolves null rather
+    // than rejecting — the production failure path is a null resolve.
+    const coord = makeCoordinator();
+    const ptyManager = makeWakePtyManager([]);
+    vi.mocked(ptyManager.getSerializedStateAsync).mockResolvedValue(null);
+    const ctx = makeCtx({
+      ptyManager,
+      getPauseCoordinator: vi.fn(() => coord as never),
+    });
+    vi.mocked(ctx.backpressureManager.getPausedInterval).mockReturnValue(
+      setTimeout(() => {}, 60_000) as never,
+    );
+
+    const handlers = createBackpressureHandlers(ctx);
+    await handlers["wake-terminal"]({ type: "wake-terminal", id: "term-1", requestId: "req-1" });
+
+    expect(coord.resume).toHaveBeenCalledExactlyOnceWith("backpressure");
+    expect(ctx.ptyManager.getSerializedState).not.toHaveBeenCalled();
+    expect(ctx.sendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "wake-result", id: "term-1", state: null }),
+    );
+  });
+
   it("does not resume the coordinator when no backpressure pause was active", async () => {
     const coord = makeCoordinator();
     const ctx = makeCtx({

--- a/electron/pty-host/handlers/backpressure.ts
+++ b/electron/pty-host/handlers/backpressure.ts
@@ -117,20 +117,6 @@ export function createBackpressureHandlers(ctx: HostContext): HandlerMap {
         ptyManager.setActivityMonitorTier(msg.id, 50);
       }
 
-      // Best-effort warning: cwd missing
-      const warnings: string[] = [];
-      try {
-        const t = ptyManager.getTerminal(msg.id);
-        if (t?.cwd && typeof t.cwd === "string") {
-          const fs = await import("node:fs");
-          if (!fs.existsSync(t.cwd)) {
-            warnings.push("cwd-missing");
-          }
-        }
-      } catch {
-        // ignore
-      }
-
       let state: string | null;
       try {
         state = await ptyManager.getSerializedStateAsync(msg.id);
@@ -146,6 +132,21 @@ export function createBackpressureHandlers(ctx: HostContext): HandlerMap {
       }
 
       const wakeLatencyMs = Date.now() - wakeStartTime;
+
+      // Best-effort warning: cwd missing. Runs after the resume so a slow
+      // stat (stale network mount) can't extend the pause window.
+      const warnings: string[] = [];
+      try {
+        const t = ptyManager.getTerminal(msg.id);
+        if (t?.cwd && typeof t.cwd === "string") {
+          const fs = await import("node:fs");
+          if (!fs.existsSync(t.cwd)) {
+            warnings.push("cwd-missing");
+          }
+        }
+      } catch {
+        // ignore
+      }
 
       if (!wakeCoordinator?.isPaused) {
         backpressureManager.emitTerminalStatus(msg.id, "running");

--- a/electron/pty-host/handlers/backpressure.ts
+++ b/electron/pty-host/handlers/backpressure.ts
@@ -105,11 +105,11 @@ export function createBackpressureHandlers(ctx: HostContext): HandlerMap {
       }
       backpressureManager.deletePauseStartTime(msg.id);
 
-      // Release backpressure hold via coordinator (respects other holds)
+      // Hold the backpressure pause until after serialization — resuming the
+      // PTY first lets bytes emitted in the gap land in both the snapshot and
+      // the live stream, duplicating them on replay (#9897). The resume
+      // happens in the finally below.
       const wakeCoordinator = getPauseCoordinator(msg.id);
-      if (wasPaused) {
-        wakeCoordinator?.resume("backpressure");
-      }
 
       // Apply active tier polling (50ms) when waking
       const terminal = ptyManager.getTerminal(msg.id);
@@ -131,11 +131,18 @@ export function createBackpressureHandlers(ctx: HostContext): HandlerMap {
         // ignore
       }
 
-      let state: string | null = null;
+      let state: string | null;
       try {
         state = await ptyManager.getSerializedStateAsync(msg.id);
       } catch {
         state = ptyManager.getSerializedState(msg.id);
+      } finally {
+        // Resume even when serialization throws so wake always unblocks the
+        // terminal (#9896). Reuses the coordinator captured above — the
+        // terminal may have been torn down during the await.
+        if (wasPaused) {
+          wakeCoordinator?.resume("backpressure");
+        }
       }
 
       const wakeLatencyMs = Date.now() - wakeStartTime;


### PR DESCRIPTION
## Summary

- The wake-terminal handler in `electron/pty-host/handlers/backpressure.ts` was resuming the PTY pause coordinator before calling `getSerializedStateAsync`. Bytes emitted in that gap were written to both the headless terminal snapshot and the renderer MessagePort queue, then flushed again after snapshot replay, duplicating output at the bottom of the terminal.
- Fix moves the `wasPaused`-gated resume into a `finally` block wrapping the serialize try/catch, so the PTY stays quiet during serialization and the renderer queues stay empty for that window. Resume-in-`finally` preserves the #9896 invariant that wake always unblocks even when serialization throws.
- Also relocates the best-effort `existsSync` cwd-missing warning to after the resume, so a slow stat on a stale mount can't extend the pause window.

Resolves #9897

## Changes

- `electron/pty-host/handlers/backpressure.ts`: move resume into `finally`, relocate `existsSync` warning
- `electron/pty-host/handlers/__tests__/backpressure.test.ts`: 4 new tests covering resume-after-serialize ordering, resume-on-throw with sync fallback, serializer-resolves-null production path, and no-resume when no pause was active

## Testing

Unit tests cover the four key paths: normal ordering (resume after serialize), error path (resume still fires when `getSerializedStateAsync` throws), null-snapshot path (serializer returns null, falls back to sync), and the no-op path (no resume called when `wasPaused` is false). No renderer changes needed — with the PTY paused during serialization, `resumeFlush`/`deferredOutput` drains are no-ops, leaving the #8371 post-restore ordering and #7762 resize ordering untouched.