### PR TITLE
fix(detection): correct Kimi boot and working patterns

### DIFF
--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -590,14 +590,45 @@ describe("kimi detection patterns", () => {
     expect(patterns.some((p) => p.test(`${glyph} `))).toBe(true);
   });
 
-  it("matches braille spinner with task description (primary)", () => {
-    const patterns = compilePatterns("primaryPatterns");
-    expect(patterns.some((p) => p.test("⠋ Thinking about the request"))).toBe(true);
+  it.each(["🌑", "🌒", "🌓", "🌔", "🌕", "🌖", "🌗", "🌘"])(
+    "matches moon-phase spinner frame %s as primary",
+    (glyph) => {
+      const patterns = compilePatterns("primaryPatterns");
+      // Trailing space — Rich's documented frame format.
+      expect(patterns.some((p) => p.test(`${glyph} `))).toBe(true);
+      // No trailing space — renderers that drop the trailing whitespace when
+      // the spinner is the only content on a line.
+      expect(patterns.some((p) => p.test(glyph))).toBe(true);
+    }
+  );
+
+  it("matches the kimi-cli welcome banner as boot-complete", () => {
+    const patterns = compilePatterns("bootCompletePatterns");
+    // Bare banner line (Rich Console.print output before Panel wrapping)
+    expect(patterns.some((p) => p.test("Welcome to Kimi Code CLI!"))).toBe(true);
+    // Banner wrapped in the Rich Panel box-drawing characters rendered in
+    // the live terminal — a literal substring match must still fire here.
+    expect(patterns.some((p) => p.test("╭─ Welcome to Kimi Code CLI! ─╮"))).toBe(true);
   });
 
-  it("matches braille spinner with single word (fallback)", () => {
+  it("matches braille dots spinner with task description in fallback", () => {
+    const patterns = compilePatterns("fallbackPatterns");
+    expect(patterns.some((p) => p.test("⠋ Compacting..."))).toBe(true);
+    expect(patterns.some((p) => p.test("⠹ Connecting to MCP servers..."))).toBe(true);
+  });
+
+  it("matches braille dots spinner with single word in fallback", () => {
     const patterns = compilePatterns("fallbackPatterns");
     expect(patterns.some((p) => p.test("⠹ Working"))).toBe(true);
+  });
+
+  it("does not match braille dots in primary (no #3941 footgun)", () => {
+    const patterns = compilePatterns("primaryPatterns");
+    // kimi-cli's content/tool blocks render braille-with-text, but a copy-paste
+    // of that glyph class into primary would mis-classify goose's identical
+    // cliclack spinner. The moon class is the only thing that earns primary.
+    expect(patterns.some((p) => p.test("⠋ Thinking about the request"))).toBe(false);
+    expect(patterns.some((p) => p.test("⠹ Working"))).toBe(false);
   });
 });
 

--- a/shared/config/agents/kimi.ts
+++ b/shared/config/agents/kimi.ts
@@ -60,8 +60,30 @@ export const config: AgentConfig = {
     ignoredInputSequences: ["\x1b\r"],
   },
   detection: {
-    primaryPatterns: ["[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\\s+[^\\n]{2,80}"],
-    fallbackPatterns: ["[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\\s+\\w"],
+    // kimi-cli renders Rich's "moon" spinner (8 moon-phase frames) with empty
+    // text during long model-latency stretches; this is the dominant working
+    // indicator before any tool or content block renders. See
+    // src/kimi_cli/ui/shell/visualize/_live_view.py upstream. The
+    // end-of-line alternative handles renderers that drop the trailing space
+    // when no text follows the spinner.
+    primaryPatterns: ["[🌑🌒🌓🌔🌕🌖🌗🌘](?:\\s|$)"],
+    fallbackPatterns: [
+      // Rich "dots" braille spinner, used with descriptive text
+      // ("Compacting...", "Connecting to MCP servers...", "Thinking...") in
+      // _blocks.py. Identical Unicode to the cliclack spinner goose uses —
+      // copy-pasting the glyph set between agents is a known footgun (#3941),
+      // so this stays fallback-only at 0.75, never primary.
+      "[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\\s+[^\\n]{2,80}",
+      "[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\\s+\\w",
+    ],
+    // _print_welcome_info (src/kimi_cli/ui/shell/__init__.py) prints this
+    // banner line in a Rich Panel before the first spinner frame, so it
+    // always precedes the moon spinner. Literal substring — unique in the
+    // rendered output and resilient to the ASCII art and version-notice
+    // lines that follow. Without this slot, BootDetector falls back to the
+    // hardcoded Claude/Codex/Gemini banners and Kimi terminals wait the
+    // full POLLING_MAX_BOOT_MS (15s) timeout on every launch.
+    bootCompletePatterns: ["Welcome to Kimi Code CLI!"],
     promptPatterns: ["^\\s*(?:✨|💫|📋|\\$)\\s+"],
     promptHintPatterns: ["^\\s*(?:✨|💫|📋|\\$)\\s*$"],
     scanLineCount: 10,


### PR DESCRIPTION
## Summary
- Kimi terminals were waiting the full 15s `POLLING_MAX_BOOT_MS` timeout on every launch because the config had no `bootCompletePatterns`, so `BootDetector` fell back to the hardcoded Claude/Codex/Gemini banner regexes that never match kimi-cli's actual boot output.
- The primary working pattern targeted Rich's "dots" braille spinner with text at 0.95 confidence, but kimi-cli's live view uses the "moon" spinner (8 moon-phase frames) with empty text during long model-latency stretches. The braille dots appear later in content/tool blocks with text like "Compacting..." or "Connecting to MCP servers..." and are useful as a fallback signal, not a primary.

Resolves #9876

## Changes
- `shared/config/agents/kimi.ts`
  - Added `bootCompletePatterns: ["Welcome to Kimi Code CLI!"]` (printed by `_print_welcome_info` in `src/kimi_cli/ui/shell/__init__.py` before the first spinner frame).
  - Demoted braille dots from primary (0.95) to fallback (0.75) per the #3941 footgun discipline: that glyph set is identical to cliclack (`goose`), so a copy-paste into a higher tier would mis-classify a goose working line as Kimi.
  - Added the moon-phase spinner (`🌑🌒🌓🌔🌕🌖🌗🌘`) as the new primary, with an end-of-line alternative to handle renderers that drop the trailing space when no text follows the spinner. The moon class is disjoint from braille, so the two never fire on the same line.
- `shared/config/__tests__/agentRegistry.test.ts`
  - Tests assert behavior against realistic kimi-cli output: the boot banner wrapped in a Rich `Panel` box-drawing, all 8 moon frames in both trailing-space and bare forms, and dots-with-text compaction/connecting lines.
  - Added a regression guard against the #3941 footgun: braille dots must never match primary.

## Testing
- The branch's own test file (`shared/config/__tests__/agentRegistry.test.ts`) passes 240/240 in isolation.
- `npm run build` is clean for the branch's diff.
- `npm run check` and `npm run test` have pre-existing develop-level failures (a `NodeNext` workspace dep resolution error in `packages/create-daintree-plugin/src/create.ts` and 35 test files with macOS dev-host `mockRestore`/`getElectronPath` issues) that reproduce identically on `origin/develop` and are not in this branch's diff. Flagging per the develop-level protocol; will re-run on a green base.