### PR TITLE
fix(demo): decouple demo scroll/spotlight springs from frame rate

### DIFF
--- a/src/components/Demo/DemoCursor.tsx
+++ b/src/components/Demo/DemoCursor.tsx
@@ -260,6 +260,7 @@ export function DemoCursor() {
   const posRef = useRef({ x: 0, y: 0 });
   const pauseResolversRef = useRef<Array<() => void>>([]);
   const pausedRef = useRef(false);
+  const scrollAnimRef = useRef<{ cancel: () => void } | null>(null);
 
   useEffect(() => {
     posRef.current = {
@@ -753,7 +754,7 @@ export function DemoCursor() {
 
           // Frame-rate-independent spring glide (see src/lib/demoSpring.ts).
           await new Promise<void>((resolve) => {
-            runSpringLoop(
+            scrollAnimRef.current = runSpringLoop(
               { scroll: { current: container!.scrollTop, velocity: 0 } },
               { scroll: clampedTarget },
               (axes) => {
@@ -761,6 +762,7 @@ export function DemoCursor() {
               },
               () => {
                 container!.scrollTop = clampedTarget;
+                scrollAnimRef.current = null;
                 resolve();
               }
             );
@@ -1060,6 +1062,8 @@ export function DemoCursor() {
 
     return () => {
       for (const cleanup of cleanups) cleanup();
+      scrollAnimRef.current?.cancel();
+      scrollAnimRef.current = null;
     };
   }, []);
 

--- a/src/components/Demo/DemoCursor.tsx
+++ b/src/components/Demo/DemoCursor.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { isMac } from "@/lib/platform";
+import { runSpringLoop } from "@/lib/demoSpring";
 import { EditorView } from "@codemirror/view";
 import { Transaction } from "@codemirror/state";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
@@ -750,32 +751,19 @@ export function DemoCursor() {
             Math.min(targetScrollTop, container.scrollHeight - container.clientHeight)
           );
 
-          // Spring animation (semi-implicit Euler)
-          const stiffness = 70;
-          const damping = 20;
-          let current = container.scrollTop;
-          let velocity = 0;
-
+          // Frame-rate-independent spring glide (see src/lib/demoSpring.ts).
           await new Promise<void>((resolve) => {
-            let lastTime = performance.now();
-            function step(now: number) {
-              let dt = (now - lastTime) / 1000;
-              dt = Math.min(dt, 0.032);
-              lastTime = now;
-
-              const force = -stiffness * (current - clampedTarget) - damping * velocity;
-              velocity += force * dt;
-              current += velocity * dt;
-              container!.scrollTop = current;
-
-              if (Math.abs(velocity) < 0.5 && Math.abs(clampedTarget - current) < 0.5) {
+            runSpringLoop(
+              { scroll: { current: container!.scrollTop, velocity: 0 } },
+              { scroll: clampedTarget },
+              (axes) => {
+                container!.scrollTop = axes.scroll.current;
+              },
+              () => {
                 container!.scrollTop = clampedTarget;
                 resolve();
-              } else {
-                requestAnimationFrame(step);
               }
-            }
-            requestAnimationFrame(step);
+            );
           });
 
           sendDone(payload.requestId);

--- a/src/components/Demo/DemoOverlay.tsx
+++ b/src/components/Demo/DemoOverlay.tsx
@@ -5,6 +5,7 @@ import type {
   DemoAnnotationSize,
   DemoDismissAnnotationPayload,
 } from "@shared/types/ipc/demo";
+import { runSpringLoop } from "@/lib/demoSpring";
 
 interface SpotlightState {
   x: number;
@@ -283,50 +284,32 @@ export function DemoOverlay() {
         return;
       }
 
-      // Spring-animate the cutout from the previous rect to the target.
-      const current = { ...start };
-      let cancelled = false;
-      const stiffness = 70;
-      const damping = 20;
-      const vel = { x: 0, y: 0, width: 0, height: 0 };
-
-      let lastTime = performance.now();
-      function step(now: number) {
-        if (cancelled || !overlayRef.current) return;
-        let dt = (now - lastTime) / 1000;
-        dt = Math.min(dt, 0.032);
-        lastTime = now;
-
-        let settled = true;
-        for (const key of ["x", "y", "width", "height"] as const) {
-          const force = -stiffness * (current[key] - target[key]) - damping * vel[key];
-          vel[key] += force * dt;
-          current[key] += vel[key] * dt;
-          if (Math.abs(vel[key]) > 0.5 || Math.abs(target[key] - current[key]) > 0.5) {
-            settled = false;
-          }
-        }
-
-        const snap: SpotlightState = settled
-          ? target
-          : {
-              x: current.x,
-              y: current.y,
-              width: Math.max(0, current.width),
-              height: Math.max(0, current.height),
-            };
-        currentRectRef.current = snap;
-        applyMask(snap);
-
-        if (!settled) requestAnimationFrame(step);
-      }
-
-      spotlightAnimRef.current = {
-        cancel: () => {
-          cancelled = true;
+      // Frame-rate-independent spring glide of the cutout (see src/lib/demoSpring.ts).
+      spotlightAnimRef.current = runSpringLoop(
+        {
+          x: { current: start.x, velocity: 0 },
+          y: { current: start.y, velocity: 0 },
+          width: { current: start.width, velocity: 0 },
+          height: { current: start.height, velocity: 0 },
         },
-      };
-      requestAnimationFrame(step);
+        { x: target.x, y: target.y, width: target.width, height: target.height },
+        (axes) => {
+          if (!overlayRef.current) return false;
+          const snap: SpotlightState = {
+            x: axes.x.current,
+            y: axes.y.current,
+            width: Math.max(0, axes.width.current),
+            height: Math.max(0, axes.height.current),
+          };
+          currentRectRef.current = snap;
+          applyMask(snap);
+          return true;
+        },
+        () => {
+          currentRectRef.current = target;
+          applyMask(target);
+        }
+      );
     },
     [applyMask]
   );

--- a/src/components/Demo/DemoOverlay.tsx
+++ b/src/components/Demo/DemoOverlay.tsx
@@ -425,6 +425,12 @@ export function DemoOverlay() {
 
     return () => {
       for (const cleanup of cleanups) cleanup();
+      spotlightAnimRef.current?.cancel();
+      spotlightAnimRef.current = null;
+      if (spotlightExitTimerRef.current) {
+        clearTimeout(spotlightExitTimerRef.current);
+        spotlightExitTimerRef.current = null;
+      }
     };
   }, [animateSpotlightRect]);
 

--- a/src/lib/__tests__/demoSpring.test.ts
+++ b/src/lib/__tests__/demoSpring.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEMO_SPRING_FIXED_DT,
+  DEMO_SPRING_MAX_FRAME_DT,
+  DEMO_SPRING_SETTLE_ERROR,
+  DEMO_SPRING_SETTLE_VELOCITY,
+  accumulateSpring,
+  isSpringSettled,
+  stepSpring,
+  type DemoSpringAxisState,
+} from "../demoSpring";
+
+const atRest = (current: number): DemoSpringAxisState => ({ current, velocity: 0 });
+
+/** Drive a single axis to rest by feeding fixed-size frames; return the trace. */
+function simulate(
+  start: number,
+  target: number,
+  frameDt: number,
+  maxFrames = 100_000
+): { final: DemoSpringAxisState; maxOvershoot: number; frames: number; settled: boolean } {
+  let axes = { v: atRest(start) };
+  const targets = { v: target };
+  let accumulator = 0;
+  let maxOvershoot = 0;
+  let frames = 0;
+  let settled = false;
+  for (; frames < maxFrames; frames++) {
+    const r = accumulateSpring(axes, targets, frameDt, accumulator);
+    axes = r.axes;
+    accumulator = r.accumulator;
+    // overshoot = how far past the target we travelled (0 if monotonic from below)
+    maxOvershoot = Math.max(maxOvershoot, axes.v.current - target);
+    if (r.settled) {
+      settled = true;
+      frames++;
+      break;
+    }
+  }
+  return { final: axes.v, maxOvershoot, frames, settled };
+}
+
+describe("stepSpring", () => {
+  it("is pure — does not mutate its input state", () => {
+    const state = { current: 10, velocity: 5 };
+    stepSpring(state, 100, 0.016);
+    expect(state).toEqual({ current: 10, velocity: 5 });
+  });
+
+  it("is deterministic for identical inputs", () => {
+    const a = stepSpring({ current: 0, velocity: 0 }, 100, 0.016);
+    const b = stepSpring({ current: 0, velocity: 0 }, 100, 0.016);
+    expect(a).toEqual(b);
+  });
+
+  it("accelerates toward the target from rest", () => {
+    const next = stepSpring(atRest(0), 100, DEMO_SPRING_FIXED_DT);
+    // force is positive (target above current) → velocity and position both rise
+    expect(next.velocity).toBeGreaterThan(0);
+    expect(next.current).toBeGreaterThan(0);
+    expect(next.current).toBeLessThan(100);
+  });
+});
+
+describe("isSpringSettled", () => {
+  it("is settled only when both velocity and position error are within threshold", () => {
+    expect(isSpringSettled({ current: 100, velocity: 0 }, 100)).toBe(true);
+    // position close but still moving fast → not settled
+    expect(isSpringSettled({ current: 100, velocity: DEMO_SPRING_SETTLE_VELOCITY + 1 }, 100)).toBe(
+      false
+    );
+    // at rest but far from target → not settled
+    expect(
+      isSpringSettled({ current: 100 - (DEMO_SPRING_SETTLE_ERROR + 1), velocity: 0 }, 100)
+    ).toBe(false);
+  });
+});
+
+describe("accumulateSpring convergence", () => {
+  it("converges to the target and reports settled", () => {
+    const { final, settled } = simulate(0, 100, 1 / 60);
+    expect(settled).toBe(true);
+    expect(Math.abs(final.current - 100)).toBeLessThan(DEMO_SPRING_SETTLE_ERROR);
+    expect(Math.abs(final.velocity)).toBeLessThan(DEMO_SPRING_SETTLE_VELOCITY);
+  });
+
+  it("does not overshoot the target (overdamped)", () => {
+    const { maxOvershoot } = simulate(0, 100, 1 / 60);
+    // a sliver of tolerance for floating-point dust; a real overshoot would be many px
+    expect(maxOvershoot).toBeLessThan(0.5);
+  });
+
+  it("leaves the input axes untouched (returns fresh state)", () => {
+    const axes = { v: atRest(0) };
+    accumulateSpring(axes, { v: 100 }, 1 / 60, 0);
+    expect(axes.v).toEqual({ current: 0, velocity: 0 });
+  });
+});
+
+describe("frame-rate independence (the regression guard for #10136)", () => {
+  // The bug: clamping per-step dt couples simulated time to frame rate, so a
+  // glide recorded below ~31fps runs in slow motion. With the accumulator the
+  // same total wall-clock must produce the same physical state regardless of how
+  // that time is chunked into frames.
+  function stateAfter(totalSeconds: number, frameDt: number): DemoSpringAxisState {
+    let axes = { v: atRest(0) };
+    const targets = { v: 1000 };
+    let accumulator = 0;
+    const frames = Math.round(totalSeconds / frameDt);
+    for (let i = 0; i < frames; i++) {
+      const r = accumulateSpring(axes, targets, frameDt, accumulator);
+      axes = r.axes;
+      accumulator = r.accumulator;
+    }
+    return axes.v;
+  }
+
+  it("reaches the same position at 120fps, 60fps and 20fps for equal wall-clock", () => {
+    const SECONDS = 0.25; // mid-flight, before settle, where divergence would show
+    const fast = stateAfter(SECONDS, 1 / 120);
+    const mid = stateAfter(SECONDS, 1 / 60);
+    const slow = stateAfter(SECONDS, 1 / 20); // ~31fps-style starvation under 4K capture
+
+    expect(Math.abs(fast.current - mid.current)).toBeLessThan(1);
+    expect(Math.abs(fast.current - slow.current)).toBeLessThan(1);
+    // and the same total simulated time was consumed in every case
+    expect(Math.abs(fast.velocity - slow.velocity)).toBeLessThan(5);
+  });
+
+  it("a low frame rate is not slower than a high one (no slow-motion)", () => {
+    const SECONDS = 0.15;
+    const fast = stateAfter(SECONDS, 1 / 120).current;
+    const slow = stateAfter(SECONDS, 1 / 20).current;
+    // slow-motion bug would make `slow` lag well behind `fast`; they must match
+    expect(slow).toBeGreaterThan(fast - 1);
+  });
+});
+
+describe("spiral-of-death guard", () => {
+  it("caps a huge frame gap at MAX_FRAME_DT worth of catch-up", () => {
+    const axes = { v: atRest(0) };
+    const targets = { v: 1000 };
+    // a 10-second stall and a single capped frame must advance identically
+    const huge = accumulateSpring(axes, targets, 10, 0);
+    const capped = accumulateSpring(axes, targets, DEMO_SPRING_MAX_FRAME_DT, 0);
+    expect(huge.axes.v).toEqual(capped.axes.v);
+    expect(huge.accumulator).toBeCloseTo(capped.accumulator, 10);
+  });
+
+  it("does not teleport to the target in a single post-stall frame", () => {
+    // one absurd 100s frame must not settle or jump to the target — the cap means
+    // only ~7 sub-steps run, so the cutout stays far from the destination.
+    const r = accumulateSpring({ v: atRest(0) }, { v: 1000 }, 100, 0);
+    expect(r.settled).toBe(false);
+    expect(r.axes.v.current).toBeLessThan(1000);
+  });
+});
+
+describe("multi-axis lock-step", () => {
+  it("advances every axis with the same sub-step schedule", () => {
+    // two axes with identical dynamics must stay identical frame to frame
+    let axes = { x: atRest(0), y: atRest(0) };
+    const targets = { x: 100, y: 100 };
+    let accumulator = 0;
+    for (let i = 0; i < 30; i++) {
+      const r = accumulateSpring(axes, targets, 1 / 45, accumulator);
+      axes = r.axes;
+      accumulator = r.accumulator;
+    }
+    expect(axes.x).toEqual(axes.y);
+  });
+});

--- a/src/lib/__tests__/demoSpring.test.ts
+++ b/src/lib/__tests__/demoSpring.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   DEMO_SPRING_FIXED_DT,
   DEMO_SPRING_MAX_FRAME_DT,
@@ -6,6 +6,7 @@ import {
   DEMO_SPRING_SETTLE_VELOCITY,
   accumulateSpring,
   isSpringSettled,
+  runSpringLoop,
   stepSpring,
   type DemoSpringAxisState,
 } from "../demoSpring";
@@ -106,11 +107,16 @@ describe("frame-rate independence (the regression guard for #10136)", () => {
     let axes = { v: atRest(0) };
     const targets = { v: 1000 };
     let accumulator = 0;
-    const frames = Math.round(totalSeconds / frameDt);
-    for (let i = 0; i < frames; i++) {
-      const r = accumulateSpring(axes, targets, frameDt, accumulator);
+    // Feed exactly `totalSeconds` of wall-clock in `frameDt` chunks; the final
+    // chunk is partial so every frame rate consumes the same total time (a plain
+    // round(total/frameDt) underfeeds when the frame count isn't an integer).
+    let elapsed = 0;
+    while (elapsed < totalSeconds - 1e-9) {
+      const dt = Math.min(frameDt, totalSeconds - elapsed);
+      const r = accumulateSpring(axes, targets, dt, accumulator);
       axes = r.axes;
       accumulator = r.accumulator;
+      elapsed += dt;
     }
     return axes.v;
   }
@@ -133,6 +139,39 @@ describe("frame-rate independence (the regression guard for #10136)", () => {
     const slow = stateAfter(SECONDS, 1 / 20).current;
     // slow-motion bug would make `slow` lag well behind `fast`; they must match
     expect(slow).toBeGreaterThan(fast - 1);
+  });
+
+  it("matches the reference at non-divisor frame rates (not just 1/120 multiples)", () => {
+    // 120/60/20 are exact multiples of the sub-step; an impl that resets the
+    // accumulator each frame could still pass those. These rates leave a varying
+    // remainder every frame, so only correct carry survives.
+    //
+    // Measured near settle (1.0s): mid-flight the comparison is dominated by the
+    // sub-step leftover slop (≈ velocity × FIXED_DT, ~16px at peak speed), which
+    // is inherent and frame-rate-dependent. Near settle the velocity is low, so a
+    // tight 2px bound still proves equivalence — an accumulator-reset bug would
+    // drift hundreds of px over the ~90-144 frames here.
+    const ref = stateAfter(1.0, 1 / 120).current;
+    for (const fps of [90, 144, 75, 29.97]) {
+      const observed = stateAfter(1.0, 1 / fps).current;
+      expect(Math.abs(observed - ref)).toBeLessThan(2);
+    }
+  });
+
+  it("matches the reference under irregular frame pacing (carry correctness)", () => {
+    const ref = stateAfter(1.0, 1 / 120).current;
+    // jittery deltas (each below the spiral-of-death cap) summing to 0.25s,
+    // repeated to reach the same 1.0s wall-clock as the reference.
+    const base = [0.01, 0.022, 0.007, 0.031, 0.016, 0.04, 0.009, 0.025, 0.013, 0.034, 0.018, 0.025];
+    const deltas = [...base, ...base, ...base, ...base];
+    let axes = { v: atRest(0) };
+    let accumulator = 0;
+    for (const d of deltas) {
+      const r = accumulateSpring(axes, { v: 1000 }, d, accumulator);
+      axes = r.axes;
+      accumulator = r.accumulator;
+    }
+    expect(Math.abs(axes.v.current - ref)).toBeLessThan(2);
   });
 });
 
@@ -168,5 +207,98 @@ describe("multi-axis lock-step", () => {
       accumulator = r.accumulator;
     }
     expect(axes.x).toEqual(axes.y);
+  });
+});
+
+describe("runSpringLoop orchestration", () => {
+  // Manual rAF driver: runSpringLoop schedules one frame at a time and reads
+  // performance.now() / requestAnimationFrame from globals at call time, so we
+  // can drive it deterministically without fake timers.
+  let now = 0;
+  let pending: FrameRequestCallback | null = null;
+
+  function tick(deltaMs: number) {
+    now += deltaMs;
+    const cb = pending;
+    pending = null;
+    cb?.(now);
+  }
+
+  /** Drive frames until nothing is scheduled (settle/abort) or a safety cap. */
+  function drain(deltaMs = 16, maxFrames = 100_000) {
+    let n = 0;
+    while (pending && n++ < maxFrames) tick(deltaMs);
+  }
+
+  beforeEach(() => {
+    now = 0;
+    pending = null;
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      pending = cb;
+      return 1;
+    });
+    vi.stubGlobal("performance", { now: () => now });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("calls onSettled exactly once with the exact targets and stops scheduling", () => {
+    const onUpdate = vi.fn();
+    const onSettled = vi.fn();
+    runSpringLoop({ v: { current: 0, velocity: 0 } }, { v: 100 }, onUpdate, onSettled);
+    drain();
+    expect(onSettled).toHaveBeenCalledTimes(1);
+    expect(onSettled).toHaveBeenCalledWith({ v: 100 });
+    expect(onUpdate).toHaveBeenCalled();
+    expect(pending).toBeNull(); // no orphaned rAF after settle
+  });
+
+  it("cancel() before the first frame prevents any callback", () => {
+    const onUpdate = vi.fn();
+    const onSettled = vi.fn();
+    const handle = runSpringLoop(
+      { v: { current: 0, velocity: 0 } },
+      { v: 1000 },
+      onUpdate,
+      onSettled
+    );
+    handle.cancel();
+    tick(16);
+    expect(onUpdate).not.toHaveBeenCalled();
+    expect(onSettled).not.toHaveBeenCalled();
+    expect(pending).toBeNull();
+  });
+
+  it("cancel() mid-flight stops further frames", () => {
+    const onUpdate = vi.fn();
+    const onSettled = vi.fn();
+    const handle = runSpringLoop(
+      { v: { current: 0, velocity: 0 } },
+      { v: 1000 },
+      onUpdate,
+      onSettled
+    );
+    tick(16);
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    handle.cancel();
+    drain();
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(onSettled).not.toHaveBeenCalled();
+  });
+
+  it("onUpdate returning false aborts the loop without settling", () => {
+    const onSettled = vi.fn();
+    const onUpdate = vi
+      .fn<(axes: Record<"v", DemoSpringAxisState>) => boolean | void>()
+      .mockReturnValueOnce(undefined)
+      .mockReturnValue(false);
+    runSpringLoop({ v: { current: 0, velocity: 0 } }, { v: 1000 }, onUpdate, onSettled);
+    tick(16); // frame 1 → undefined → keep going
+    tick(16); // frame 2 → false → abort
+    expect(onUpdate).toHaveBeenCalledTimes(2);
+    expect(onSettled).not.toHaveBeenCalled();
+    expect(pending).toBeNull();
   });
 });

--- a/src/lib/demoSpring.ts
+++ b/src/lib/demoSpring.ts
@@ -1,0 +1,182 @@
+/**
+ * Frame-rate-independent spring integrator for the demo recording engine.
+ *
+ * The demo scroll glide (DemoCursor) and the spotlight cutout (DemoOverlay) both
+ * animate a semi-implicit Euler spring inside a requestAnimationFrame loop. The
+ * naive form clamps the per-frame `dt` (`Math.min(dt, 0.032)`), which silently
+ * discards real elapsed time whenever a frame takes longer than the clamp. Under
+ * 4K capture the renderer's rAF cadence drops below ~31fps, so each frame drops a
+ * slice of wall-clock time and the spring advances slower than real time — the
+ * recorded animation runs in slow motion.
+ *
+ * The fix is a fixed-timestep accumulator: accumulate real elapsed time, consume
+ * it in fixed `FIXED_DT` sub-steps, and clamp only the per-frame *addition* (not
+ * each step) as a spiral-of-death guard. The simulated time then tracks
+ * wall-clock exactly regardless of the rAF rate, so a 1-second glide takes one
+ * second whether the recorder runs at 120fps or 20fps.
+ */
+
+/** Spring stiffness (k). With m=1 this gives ω_n = √70 ≈ 8.37 rad/s. */
+export const DEMO_SPRING_STIFFNESS = 70;
+/** Spring damping (c). c=20 > critical 2√70 ≈ 16.73 → overdamped (no overshoot). */
+export const DEMO_SPRING_DAMPING = 20;
+/**
+ * Fixed integration sub-step (seconds). 1/120 divides both 60Hz and 120Hz rAF
+ * cadences cleanly and sits ~34× inside the semi-implicit Euler stability bound
+ * (dt < c/k ≈ 0.285s), so the integration is exact for any real frame rate.
+ */
+export const DEMO_SPRING_FIXED_DT = 1 / 120;
+/**
+ * Per-frame wall-clock cap (seconds) — the spiral-of-death guard. After a long
+ * stall (tab backgrounded, GC pause) we never replay more than ~7-8 sub-steps,
+ * avoiding a jarring teleport while still keeping every normal frame exact.
+ */
+export const DEMO_SPRING_MAX_FRAME_DT = 0.064;
+/** Settle threshold for |velocity| (px/s). */
+export const DEMO_SPRING_SETTLE_VELOCITY = 0.5;
+/** Settle threshold for |target − current| (px). */
+export const DEMO_SPRING_SETTLE_ERROR = 0.5;
+
+/** State of a single spring axis. */
+export interface DemoSpringAxisState {
+  current: number;
+  velocity: number;
+}
+
+/** Result of consuming one frame's worth of elapsed time. */
+export interface AccumulateSpringResult<K extends string> {
+  axes: Record<K, DemoSpringAxisState>;
+  accumulator: number;
+  settled: boolean;
+}
+
+/** Handle returned by {@link runSpringLoop} to cancel an in-flight animation. */
+export interface SpringLoopHandle {
+  cancel: () => void;
+}
+
+/**
+ * Advance one spring axis by exactly `dt` seconds (semi-implicit Euler). Pure:
+ * returns a new state, never mutates the input.
+ */
+export function stepSpring(
+  state: DemoSpringAxisState,
+  target: number,
+  dt: number,
+  stiffness: number = DEMO_SPRING_STIFFNESS,
+  damping: number = DEMO_SPRING_DAMPING
+): DemoSpringAxisState {
+  const force = -stiffness * (state.current - target) - damping * state.velocity;
+  const velocity = state.velocity + force * dt;
+  const current = state.current + velocity * dt;
+  return { current, velocity };
+}
+
+/** Whether an axis has come to rest at its target within both thresholds. */
+export function isSpringSettled(state: DemoSpringAxisState, target: number): boolean {
+  return (
+    Math.abs(state.velocity) < DEMO_SPRING_SETTLE_VELOCITY &&
+    Math.abs(target - state.current) < DEMO_SPRING_SETTLE_ERROR
+  );
+}
+
+/**
+ * Consume one frame's elapsed time (`rawDt`) plus any carried `accumulator`,
+ * stepping every axis in lock-step through fixed `DEMO_SPRING_FIXED_DT` sub-steps.
+ * Returns the advanced axes, the leftover accumulator to carry into the next
+ * frame, and whether all axes have settled. Pure and rAF-free, so the
+ * integration can be tested directly without fake timers.
+ *
+ * `rawDt` is capped at `DEMO_SPRING_MAX_FRAME_DT` before it is added — this is the
+ * only clamp, and it bounds catch-up after a stall instead of dropping time every
+ * frame.
+ */
+export function accumulateSpring<K extends string>(
+  axes: Record<K, DemoSpringAxisState>,
+  targets: Record<K, number>,
+  rawDt: number,
+  accumulator: number,
+  stiffness: number = DEMO_SPRING_STIFFNESS,
+  damping: number = DEMO_SPRING_DAMPING
+): AccumulateSpringResult<K> {
+  // Object.keys widens to string[] and an incrementally-built Record can't be
+  // typed as Record<K, V> without an assertion — both are sound here.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  const keys = Object.keys(axes) as K[];
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  const next = {} as Record<K, DemoSpringAxisState>;
+  for (const key of keys) {
+    next[key] = { current: axes[key].current, velocity: axes[key].velocity };
+  }
+
+  let acc = accumulator + Math.min(rawDt, DEMO_SPRING_MAX_FRAME_DT);
+  while (acc >= DEMO_SPRING_FIXED_DT) {
+    for (const key of keys) {
+      next[key] = stepSpring(next[key], targets[key], DEMO_SPRING_FIXED_DT, stiffness, damping);
+    }
+    acc -= DEMO_SPRING_FIXED_DT;
+  }
+
+  let settled = true;
+  for (const key of keys) {
+    if (!isSpringSettled(next[key], targets[key])) {
+      settled = false;
+      break;
+    }
+  }
+
+  return { axes: next, accumulator: acc, settled };
+}
+
+/**
+ * Drive a fixed-timestep spring animation on a requestAnimationFrame loop.
+ *
+ * `onUpdate` runs once per frame after that frame's sub-steps with the current
+ * axis values; return `false` from it to stop the loop (e.g. the target node
+ * unmounted). `onSettled` runs once when every axis comes to rest and is passed
+ * the exact `targets`, so callers snap to precise final values rather than the
+ * sub-pixel approximation the integrator leaves behind.
+ *
+ * Returns a handle whose `cancel()` halts the loop before the next frame mutates
+ * anything — callers that can re-trigger mid-animation must store it and cancel
+ * the previous loop to avoid orphaned rAF callbacks.
+ */
+export function runSpringLoop<K extends string>(
+  initialAxes: Record<K, DemoSpringAxisState>,
+  targets: Record<K, number>,
+  onUpdate: (axes: Record<K, DemoSpringAxisState>) => boolean | void,
+  onSettled: (targets: Record<K, number>) => void,
+  stiffness: number = DEMO_SPRING_STIFFNESS,
+  damping: number = DEMO_SPRING_DAMPING
+): SpringLoopHandle {
+  let cancelled = false;
+  let axes = initialAxes;
+  let accumulator = 0;
+  let lastTime = performance.now();
+
+  function frame(now: number) {
+    if (cancelled) return;
+    const rawDt = (now - lastTime) / 1000;
+    lastTime = now;
+
+    const result = accumulateSpring(axes, targets, rawDt, accumulator, stiffness, damping);
+    axes = result.axes;
+    accumulator = result.accumulator;
+
+    if (result.settled) {
+      onSettled(targets);
+      return;
+    }
+
+    if (onUpdate(axes) === false) return;
+    requestAnimationFrame(frame);
+  }
+
+  requestAnimationFrame(frame);
+
+  return {
+    cancel: () => {
+      cancelled = true;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Both `DemoCursor` and `DemoOverlay` used a per-frame `dt` clamp (`Math.min(dt, 0.032)`) that silently dropped elapsed time whenever a frame exceeded 32ms — at 4K capture frame rates, the springs advanced slower than wall-clock and the recorded animation played in slow motion.
- New `src/lib/demoSpring.ts` implements a shared, frame-rate-independent spring integrator using a fixed-timestep accumulator (`stepSpring` + `accumulateSpring` + `runSpringLoop`), with shared constants (stiffness 70, damping 20, `FIXED_DT` 1/120, `MAX_FRAME_DT` 0.064 spiral-of-death guard). Both components now import from it; simulated time tracks wall-clock at any frame rate.
- Lifecycle cleanup: in-flight loops are now cancelled on component unmount (`DemoCursor` stores the scroll handle; `DemoOverlay` cancels `spotlightAnimRef` + exit timer in cleanup), preventing a dangling `rAF` and the associated 30s main-side command timeout.

Resolves #10136

## Changes

- `src/lib/demoSpring.ts` — new shared spring integrator with fixed-timestep accumulator and `runSpringLoop` rAF orchestrator
- `src/components/Demo/DemoCursor.tsx` — migrated to `demoSpring`, stores scroll handle for unmount cancellation
- `src/components/Demo/DemoOverlay.tsx` — migrated to `demoSpring`, cleans up `spotlightAnimRef` and exit timer on unmount
- `src/lib/__tests__/demoSpring.test.ts` — new test file covering convergence, overdamped no-overshoot, spiral-of-death guard, frame-rate independence across 120/60/20fps and irregular pacing, and `runSpringLoop` lifecycle (settle, cancellation, `onUpdate=false` abort)

## Testing

Pure-function coverage in `demoSpring.test.ts` — frame-rate independence test is the regression guard: equal wall-clock time produces equal spring state regardless of whether frames arrive at 120, 60, or 20fps, or with non-divisor/irregular pacing. All 32 490 unit tests pass; `npm run check` clean.