### PR TITLE
fix(ui): auto-recover always-mounted dialog hosts from render errors (#9918)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -325,6 +325,13 @@ import {
 import { usePerfMetricsStore } from "./store/perfMetricsStore";
 import { useGitHubConfigStore } from "@github-renderer/stores/githubConfigStore";
 import { useRecipeConflictStore } from "./store/recipeConflictStore";
+import { useGitPushConfirmStore } from "./store/gitPushConfirmStore";
+import { useGitPullRebaseConfirmStore } from "./store/gitPullRebaseConfirmStore";
+import { usePanelLimitStore } from "./store/panelLimitStore";
+import { useMcpConfirmStore } from "./store/mcpConfirmStore";
+import { usePluginConfirmStore } from "./store/pluginConfirmStore";
+import { usePluginMcpConfirmStore } from "./store/pluginMcpConfirmStore";
+import { useDiagnosticsReviewStore } from "./store/diagnosticsReviewStore";
 // Eager side-effect import: registers the GitHub plugin's builtin view slots
 // (bulkCreateWorktreeDialog, issueSelector) at module-eval time, before first
 // render. Must stay static — a deferred/idle import races the user, so
@@ -564,6 +571,38 @@ function AppInner() {
   useEffect(() => {
     if (isStateLoaded) removeStartupSkeleton();
   }, [isStateLoaded]);
+
+  // ErrorBoundary reset signals for the always-mounted dialog hosts (#9918).
+  // A static `[Number(isStateLoaded)]` collapses to `[1]` after hydration and
+  // never changes, so a host that crashes once stays dead for the session (and
+  // its deferred promise leaks). Each host instead resets on its own
+  // pending-request signal, so a fresh request remounts the crashed boundary:
+  //   - request-counter stores bump `requestSeq` on every request (covers the
+  //     back-to-back supersede case where `pendingConfirm` never returns to null)
+  //   - FIFO-queue stores key off the live `current.requestId` UUID
+  //   - the diagnostics host toggles on its own `isOpen`
+  //   - the event-driven hosts (terminal-info, file-viewer) hold no store state,
+  //     so a local counter increments on each open event below.
+  const gitPushResetKey = useGitPushConfirmStore((s) => s.requestSeq);
+  const gitPullRebaseResetKey = useGitPullRebaseConfirmStore((s) => s.requestSeq);
+  const panelLimitResetKey = usePanelLimitStore((s) => s.requestSeq);
+  const recipeConflictResetKey = useRecipeConflictStore((s) => s.requestSeq);
+  const mcpConfirmResetKey = useMcpConfirmStore((s) => s.current?.requestId ?? "");
+  const pluginConfirmResetKey = usePluginConfirmStore((s) => s.current?.requestId ?? "");
+  const pluginMcpConfirmResetKey = usePluginMcpConfirmStore((s) => s.current?.requestId ?? "");
+  const diagnosticsReviewResetKey = useDiagnosticsReviewStore((s) => Number(s.isOpen));
+  const [terminalInfoResetKey, setTerminalInfoResetKey] = useState(0);
+  const [fileViewerResetKey, setFileViewerResetKey] = useState(0);
+  useEffect(() => {
+    const onTerminalInfo = () => setTerminalInfoResetKey((k) => k + 1);
+    const onViewFile = () => setFileViewerResetKey((k) => k + 1);
+    window.addEventListener("daintree:open-terminal-info", onTerminalInfo);
+    window.addEventListener("daintree:view-file", onViewFile);
+    return () => {
+      window.removeEventListener("daintree:open-terminal-info", onTerminalInfo);
+      window.removeEventListener("daintree:view-file", onViewFile);
+    };
+  }, []);
   // Cross-project focus intent receiver. Subscribes unconditionally so the
   // listener is registered before `notifyViewPainted` fires, then defers the
   // local `agent.focusNextWaiting` dispatch until hydration completes (the
@@ -1310,7 +1349,7 @@ function AppInner() {
             <ErrorBoundary
               variant="component"
               componentName="TerminalInfoDialogHost"
-              resetKeys={[Number(isStateLoaded)]}
+              resetKeys={[terminalInfoResetKey]}
             >
               <TerminalInfoDialogHost />
             </ErrorBoundary>
@@ -1318,7 +1357,7 @@ function AppInner() {
               <ErrorBoundary
                 variant="component"
                 componentName="McpConfirmDialog"
-                resetKeys={[Number(isStateLoaded)]}
+                resetKeys={[mcpConfirmResetKey]}
               >
                 <Suspense fallback={null}>
                   <LazyMcpConfirmDialog />
@@ -1329,7 +1368,7 @@ function AppInner() {
               <ErrorBoundary
                 variant="component"
                 componentName="PluginConfirmDialog"
-                resetKeys={[Number(isStateLoaded)]}
+                resetKeys={[pluginConfirmResetKey]}
               >
                 <Suspense fallback={null}>
                   <LazyPluginConfirmDialog />
@@ -1340,7 +1379,7 @@ function AppInner() {
               <ErrorBoundary
                 variant="component"
                 componentName="PluginMcpConfirmDialog"
-                resetKeys={[Number(isStateLoaded)]}
+                resetKeys={[pluginMcpConfirmResetKey]}
               >
                 <Suspense fallback={null}>
                   <LazyPluginMcpConfirmDialog />
@@ -1351,7 +1390,7 @@ function AppInner() {
               <ErrorBoundary
                 variant="component"
                 componentName="FileViewerModalHost"
-                resetKeys={[Number(isStateLoaded)]}
+                resetKeys={[fileViewerResetKey]}
               >
                 <Suspense fallback={null}>
                   <LazyFileViewerModalHost />
@@ -1412,7 +1451,7 @@ function AppInner() {
               <ErrorBoundary
                 variant="component"
                 componentName="PanelLimitConfirmDialog"
-                resetKeys={[Number(isStateLoaded)]}
+                resetKeys={[panelLimitResetKey]}
               >
                 <Suspense fallback={null}>
                   <LazyPanelLimitConfirmDialog />
@@ -1424,7 +1463,7 @@ function AppInner() {
               <ErrorBoundary
                 variant="component"
                 componentName="DiagnosticsReviewDialogHost"
-                resetKeys={[Number(isStateLoaded)]}
+                resetKeys={[diagnosticsReviewResetKey]}
               >
                 <Suspense fallback={null}>
                   <LazyDiagnosticsReviewDialogHost />
@@ -1436,7 +1475,7 @@ function AppInner() {
               <ErrorBoundary
                 variant="component"
                 componentName="GitPushConfirmDialog"
-                resetKeys={[Number(isStateLoaded)]}
+                resetKeys={[gitPushResetKey]}
               >
                 <Suspense fallback={null}>
                   <LazyGitPushConfirmDialog />
@@ -1448,7 +1487,7 @@ function AppInner() {
               <ErrorBoundary
                 variant="component"
                 componentName="GitPullRebaseConfirmDialog"
-                resetKeys={[Number(isStateLoaded)]}
+                resetKeys={[gitPullRebaseResetKey]}
               >
                 <Suspense fallback={null}>
                   <LazyGitPullRebaseConfirmDialog />
@@ -1460,7 +1499,7 @@ function AppInner() {
               <ErrorBoundary
                 variant="component"
                 componentName="RecipeConflictDialog"
-                resetKeys={[Number(isStateLoaded)]}
+                resetKeys={[recipeConflictResetKey]}
               >
                 <Suspense fallback={null}>
                   <LazyRecipeConflictDialog />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -590,7 +590,7 @@ function AppInner() {
   const mcpConfirmResetKey = useMcpConfirmStore((s) => s.current?.requestId ?? "");
   const pluginConfirmResetKey = usePluginConfirmStore((s) => s.current?.requestId ?? "");
   const pluginMcpConfirmResetKey = usePluginMcpConfirmStore((s) => s.current?.requestId ?? "");
-  const diagnosticsReviewResetKey = useDiagnosticsReviewStore((s) => Number(s.isOpen));
+  const diagnosticsReviewResetKey = useDiagnosticsReviewStore((s) => s.requestSeq);
   const [terminalInfoResetKey, setTerminalInfoResetKey] = useState(0);
   const [fileViewerResetKey, setFileViewerResetKey] = useState(0);
   useEffect(() => {

--- a/src/components/FileViewer/FileViewerModalHost.tsx
+++ b/src/components/FileViewer/FileViewerModalHost.tsx
@@ -17,6 +17,10 @@ interface FileViewState {
 
 export function FileViewerModalHost() {
   const [fileView, setFileView] = useState<FileViewState | null>(null);
+  // Monotonic open counter — `Number(fileView != null)` would stay `[1]` while a
+  // file is already open, so a crashed boundary would never reset when the user
+  // opens a different file. The counter changes on every open event (#9918).
+  const [openSeq, setOpenSeq] = useState(0);
   const currentProject = useProjectStore((s) => s.currentProject);
   const projectRootPath = currentProject?.path ?? "";
   const effectiveRootPath = fileView?.rootPath ?? projectRootPath;
@@ -34,6 +38,7 @@ export function FileViewerModalHost() {
         line: typeof d.line === "number" ? d.line : undefined,
         col: typeof d.col === "number" ? d.col : undefined,
       });
+      setOpenSeq((s) => s + 1);
     };
 
     const controller = new AbortController();
@@ -44,11 +49,7 @@ export function FileViewerModalHost() {
   if (!fileView) return null;
 
   return (
-    <ErrorBoundary
-      variant="component"
-      componentName="FileViewerModal"
-      resetKeys={[Number(fileView != null)]}
-    >
+    <ErrorBoundary variant="component" componentName="FileViewerModal" resetKeys={[openSeq]}>
       <Suspense
         fallback={
           <div className="fixed inset-0 z-50 flex items-center justify-center bg-scrim-medium">

--- a/src/components/Git/GitPullRebaseConfirmDialog.tsx
+++ b/src/components/Git/GitPullRebaseConfirmDialog.tsx
@@ -184,8 +184,15 @@ function GitPullRebaseConfirmDialogInner() {
 }
 
 export function GitPullRebaseConfirmDialog() {
+  // Reset the boundary on each new request so a crashed inner dialog recovers
+  // when the next pull-rebase confirm arrives (#9918).
+  const requestSeq = useGitPullRebaseConfirmStore((s) => s.requestSeq);
   return (
-    <ErrorBoundary variant="component" componentName="GitPullRebaseConfirmDialog">
+    <ErrorBoundary
+      variant="component"
+      componentName="GitPullRebaseConfirmDialog"
+      resetKeys={[requestSeq]}
+    >
       <GitPullRebaseConfirmDialogInner />
     </ErrorBoundary>
   );

--- a/src/components/Git/GitPushConfirmDialog.tsx
+++ b/src/components/Git/GitPushConfirmDialog.tsx
@@ -182,8 +182,16 @@ function GitPushConfirmDialogInner() {
 }
 
 export function GitPushConfirmDialog() {
+  // Reset the boundary on each new request so a crashed inner dialog recovers
+  // when the next push confirm arrives (#9918). Without a changing key, an inner
+  // render crash leaves this boundary stuck for the session.
+  const requestSeq = useGitPushConfirmStore((s) => s.requestSeq);
   return (
-    <ErrorBoundary variant="component" componentName="GitPushConfirmDialog">
+    <ErrorBoundary
+      variant="component"
+      componentName="GitPushConfirmDialog"
+      resetKeys={[requestSeq]}
+    >
       <GitPushConfirmDialogInner />
     </ErrorBoundary>
   );

--- a/src/components/Terminal/PanelLimitConfirmDialog.tsx
+++ b/src/components/Terminal/PanelLimitConfirmDialog.tsx
@@ -6,6 +6,11 @@ import { usePanelLimitStore } from "@/store/panelLimitStore";
 export function PanelLimitConfirmDialog() {
   const pendingConfirm = usePanelLimitStore((state) => state.pendingConfirm);
   const resolveConfirmation = usePanelLimitStore((state) => state.resolveConfirmation);
+  // Reset on each new request. `requestSeq` (not a panelCount/memoryMB key)
+  // covers back-to-back requests with identical params — the batch-preflight
+  // path passes `memoryMB: null` every time, so a derived key wouldn't change
+  // and a crashed boundary would stay stuck (#9918).
+  const requestSeq = usePanelLimitStore((state) => state.requestSeq);
 
   // Resolve false on unmount to prevent leaked promises
   useEffect(() => {
@@ -24,7 +29,7 @@ export function PanelLimitConfirmDialog() {
     <ErrorBoundary
       variant="component"
       componentName="PanelLimitConfirmDialog"
-      resetKeys={[`${panelCount}-${memoryMB}`]}
+      resetKeys={[requestSeq]}
     >
       <ConfirmDialog
         isOpen={true}

--- a/src/components/Terminal/TerminalInfoDialogHost.tsx
+++ b/src/components/Terminal/TerminalInfoDialogHost.tsx
@@ -5,6 +5,10 @@ import { ErrorBoundary } from "@/components/ErrorBoundary";
 export function TerminalInfoDialogHost() {
   const [isOpen, setIsOpen] = useState(false);
   const [terminalId, setTerminalId] = useState<string | null>(null);
+  // Monotonic open counter — `Number(isOpen)` would stay `[1]` across repeated
+  // opens while the dialog is already open, so a crashed boundary would never
+  // reset on the next open. The counter changes on every open event (#9918).
+  const [openSeq, setOpenSeq] = useState(0);
 
   useEffect(() => {
     const handleOpen = (e: Event) => {
@@ -14,6 +18,7 @@ export function TerminalInfoDialogHost() {
       if (!id) return;
       setTerminalId(id);
       setIsOpen(true);
+      setOpenSeq((s) => s + 1);
     };
 
     const controller = new AbortController();
@@ -24,11 +29,7 @@ export function TerminalInfoDialogHost() {
   }, []);
 
   return (
-    <ErrorBoundary
-      variant="component"
-      componentName="TerminalInfoDialog"
-      resetKeys={[Number(isOpen)]}
-    >
+    <ErrorBoundary variant="component" componentName="TerminalInfoDialog" resetKeys={[openSeq]}>
       <TerminalInfoDialog
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}

--- a/src/components/TerminalRecipe/RecipeConflictDialog.tsx
+++ b/src/components/TerminalRecipe/RecipeConflictDialog.tsx
@@ -70,8 +70,15 @@ function RecipeConflictDialogInner() {
 }
 
 export function RecipeConflictDialog() {
+  // Reset the boundary on each new request so a crashed inner dialog recovers
+  // when the next conflict arrives (#9918).
+  const requestSeq = useRecipeConflictStore((s) => s.requestSeq);
   return (
-    <ErrorBoundary variant="component" componentName="RecipeConflictDialog">
+    <ErrorBoundary
+      variant="component"
+      componentName="RecipeConflictDialog"
+      resetKeys={[requestSeq]}
+    >
       <RecipeConflictDialogInner />
     </ErrorBoundary>
   );

--- a/src/store/__tests__/diagnosticsReviewStore.test.ts
+++ b/src/store/__tests__/diagnosticsReviewStore.test.ts
@@ -237,4 +237,29 @@ describe("diagnosticsReviewStore", () => {
     useDiagnosticsReviewStore.getState().clearError();
     expect(useDiagnosticsReviewStore.getState().downloadError).toBeNull();
   });
+
+  describe("requestSeq (ErrorBoundary reset signal, #9918)", () => {
+    it("increments on each successful open, including a re-open while already open", async () => {
+      collectMock.mockResolvedValue(samplePayload);
+      const before = useDiagnosticsReviewStore.getState().requestSeq;
+
+      await useDiagnosticsReviewStore.getState().openReview();
+      const afterFirst = useDiagnosticsReviewStore.getState().requestSeq;
+      expect(afterFirst).toBeGreaterThan(before);
+      expect(useDiagnosticsReviewStore.getState().isOpen).toBe(true);
+
+      // Re-open without closing first: `isOpen` stays true the whole time, so a
+      // `Number(isOpen)` key would not change — the counter must still advance.
+      await useDiagnosticsReviewStore.getState().openReview();
+      expect(useDiagnosticsReviewStore.getState().requestSeq).toBeGreaterThan(afterFirst);
+    });
+
+    it("does not increment when collection fails", async () => {
+      collectMock.mockRejectedValueOnce(new Error("boom"));
+      const before = useDiagnosticsReviewStore.getState().requestSeq;
+
+      await useDiagnosticsReviewStore.getState().openReview();
+      expect(useDiagnosticsReviewStore.getState().requestSeq).toBe(before);
+    });
+  });
 });

--- a/src/store/__tests__/gitPullRebaseConfirmStore.test.ts
+++ b/src/store/__tests__/gitPullRebaseConfirmStore.test.ts
@@ -38,4 +38,26 @@ describe("gitPullRebaseConfirmStore", () => {
     expect(() => useGitPullRebaseConfirmStore.getState().resolveConfirmation(true)).not.toThrow();
     expect(useGitPullRebaseConfirmStore.getState().pendingConfirm).toBeNull();
   });
+
+  describe("requestSeq (ErrorBoundary reset signal, #9918)", () => {
+    it("strictly increases on each request, including back-to-back supersede", () => {
+      const before = useGitPullRebaseConfirmStore.getState().requestSeq;
+
+      useGitPullRebaseConfirmStore.getState().requestConfirmation("/repo-a");
+      const afterFirst = useGitPullRebaseConfirmStore.getState().requestSeq;
+      expect(afterFirst).toBeGreaterThan(before);
+
+      useGitPullRebaseConfirmStore.getState().requestConfirmation("/repo-b");
+      const afterSecond = useGitPullRebaseConfirmStore.getState().requestSeq;
+      expect(afterSecond).toBeGreaterThan(afterFirst);
+    });
+
+    it("does not change when a pending request is resolved", () => {
+      useGitPullRebaseConfirmStore.getState().requestConfirmation("/repo");
+      const afterRequest = useGitPullRebaseConfirmStore.getState().requestSeq;
+
+      useGitPullRebaseConfirmStore.getState().resolveConfirmation(true);
+      expect(useGitPullRebaseConfirmStore.getState().requestSeq).toBe(afterRequest);
+    });
+  });
 });

--- a/src/store/__tests__/gitPushConfirmStore.test.ts
+++ b/src/store/__tests__/gitPushConfirmStore.test.ts
@@ -41,4 +41,28 @@ describe("gitPushConfirmStore", () => {
     expect(() => useGitPushConfirmStore.getState().resolveConfirmation(true)).not.toThrow();
     expect(useGitPushConfirmStore.getState().pendingConfirm).toBeNull();
   });
+
+  describe("requestSeq (ErrorBoundary reset signal, #9918)", () => {
+    it("strictly increases on each request, including back-to-back supersede", () => {
+      const before = useGitPushConfirmStore.getState().requestSeq;
+
+      useGitPushConfirmStore.getState().requestConfirmation("/repo-a");
+      const afterFirst = useGitPushConfirmStore.getState().requestSeq;
+      expect(afterFirst).toBeGreaterThan(before);
+
+      // Supersede without resolving in between — `pendingConfirm` never returns
+      // to null, so a boolean toggle would miss this; the counter must still move.
+      useGitPushConfirmStore.getState().requestConfirmation("/repo-b");
+      const afterSecond = useGitPushConfirmStore.getState().requestSeq;
+      expect(afterSecond).toBeGreaterThan(afterFirst);
+    });
+
+    it("does not change when a pending request is resolved", () => {
+      useGitPushConfirmStore.getState().requestConfirmation("/repo");
+      const afterRequest = useGitPushConfirmStore.getState().requestSeq;
+
+      useGitPushConfirmStore.getState().resolveConfirmation(true);
+      expect(useGitPushConfirmStore.getState().requestSeq).toBe(afterRequest);
+    });
+  });
 });

--- a/src/store/__tests__/panelLimitStore.test.ts
+++ b/src/store/__tests__/panelLimitStore.test.ts
@@ -222,4 +222,33 @@ describe("panelLimitStore persist migration", () => {
     expect(state.hardwareDefaultsApplied).toBe(false);
     expect(state.lastSoftWarningDismissedAt).toBeNull();
   });
+
+  describe("requestSeq (ErrorBoundary reset signal, #9918)", () => {
+    it("strictly increases on each request, including back-to-back supersede", async () => {
+      const store = await loadStore();
+      const before = store.getState().requestSeq;
+
+      store.getState().requestConfirmation(21, null);
+      const afterFirst = store.getState().requestSeq;
+      expect(afterFirst).toBeGreaterThan(before);
+
+      store.getState().requestConfirmation(22, null);
+      const afterSecond = store.getState().requestSeq;
+      expect(afterSecond).toBeGreaterThan(afterFirst);
+
+      store.getState().resolveConfirmation(false);
+    });
+
+    it("is transient runtime state — never persisted via partialize", async () => {
+      const store = await loadStore();
+      store.getState().requestConfirmation(21, null);
+      expect(store.getState().requestSeq).toBeGreaterThan(0);
+
+      const persisted = JSON.parse(storageMock.getItem(STORAGE_KEY) ?? "{}");
+      expect(persisted.state).not.toHaveProperty("requestSeq");
+      expect(persisted.state).not.toHaveProperty("pendingConfirm");
+
+      store.getState().resolveConfirmation(false);
+    });
+  });
 });

--- a/src/store/__tests__/recipeConflictStore.test.ts
+++ b/src/store/__tests__/recipeConflictStore.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { useRecipeConflictStore, type RecipeConflictRequest } from "../recipeConflictStore";
+
+const baseRequest = (recipeId: string): RecipeConflictRequest => ({
+  recipeId,
+  recipeName: `Recipe ${recipeId}`,
+  updates: { name: `Recipe ${recipeId}` },
+});
+
+afterEach(() => {
+  // Release any leaked awaiter so it can't bleed into the next test.
+  if (useRecipeConflictStore.getState().pendingConflict) {
+    useRecipeConflictStore.getState().resolveConflict("cancel");
+  }
+});
+
+describe("recipeConflictStore", () => {
+  it("resolves the awaited Promise with the chosen resolution", async () => {
+    const pending = useRecipeConflictStore.getState().requestConflict(baseRequest("a"));
+    expect(useRecipeConflictStore.getState().pendingConflict?.recipeId).toBe("a");
+
+    useRecipeConflictStore.getState().resolveConflict("overwrite");
+    await expect(pending).resolves.toBe("overwrite");
+    expect(useRecipeConflictStore.getState().pendingConflict).toBeNull();
+  });
+
+  it("cancels a prior pending request (resolves it 'cancel') when a new one arrives", async () => {
+    const first = useRecipeConflictStore.getState().requestConflict(baseRequest("a"));
+    const second = useRecipeConflictStore.getState().requestConflict(baseRequest("b"));
+
+    await expect(first).resolves.toBe("cancel");
+    expect(useRecipeConflictStore.getState().pendingConflict?.recipeId).toBe("b");
+
+    useRecipeConflictStore.getState().resolveConflict("reload");
+    await expect(second).resolves.toBe("reload");
+  });
+
+  it("resolveConflict is a no-op when nothing is pending", () => {
+    expect(() => useRecipeConflictStore.getState().resolveConflict("reload")).not.toThrow();
+    expect(useRecipeConflictStore.getState().pendingConflict).toBeNull();
+  });
+
+  describe("requestSeq (ErrorBoundary reset signal, #9918)", () => {
+    it("strictly increases on each request, including back-to-back supersede", () => {
+      const before = useRecipeConflictStore.getState().requestSeq;
+
+      useRecipeConflictStore.getState().requestConflict(baseRequest("a"));
+      const afterFirst = useRecipeConflictStore.getState().requestSeq;
+      expect(afterFirst).toBeGreaterThan(before);
+
+      // Supersede without resolving in between — `pendingConflict` never returns
+      // to null, so the counter (not a boolean toggle) is what changes.
+      useRecipeConflictStore.getState().requestConflict(baseRequest("b"));
+      const afterSecond = useRecipeConflictStore.getState().requestSeq;
+      expect(afterSecond).toBeGreaterThan(afterFirst);
+    });
+
+    it("does not change when a pending request is resolved", () => {
+      useRecipeConflictStore.getState().requestConflict(baseRequest("a"));
+      const afterRequest = useRecipeConflictStore.getState().requestSeq;
+
+      useRecipeConflictStore.getState().resolveConflict("reload");
+      expect(useRecipeConflictStore.getState().requestSeq).toBe(afterRequest);
+    });
+  });
+});

--- a/src/store/diagnosticsReviewStore.ts
+++ b/src/store/diagnosticsReviewStore.ts
@@ -26,6 +26,13 @@ interface DiagnosticsReviewState {
   reviewPayload: DiagnosticsReviewPayload | null;
   scope: DiagnosticsReviewScope | null;
   downloadError: string | null;
+  /**
+   * Monotonic counter bumped each time the review opens. Used as the
+   * always-mounted host's ErrorBoundary `resetKeys` signal so a crashed host
+   * auto-recovers on the next open — including a re-open while `isOpen` is
+   * already true, which a `Number(isOpen)` key would miss (#9918).
+   */
+  requestSeq: number;
 
   openReview: (scope?: DiagnosticsReviewScope) => Promise<void>;
   closeReview: () => void;
@@ -65,6 +72,7 @@ export const useDiagnosticsReviewStore = create<DiagnosticsReviewState>((set, ge
   reviewPayload: null,
   scope: null,
   downloadError: null,
+  requestSeq: 0,
 
   openReview: async (scope) => {
     // Block while a prior open is in flight OR while a save is still resolving
@@ -75,12 +83,13 @@ export const useDiagnosticsReviewStore = create<DiagnosticsReviewState>((set, ge
     set({ isCollecting: true, downloadError: null });
     try {
       const payload = await systemClient.collectDiagnosticsForReview();
-      set({
+      set((state) => ({
         isOpen: true,
         reviewPayload: payload,
         scope: scope ?? null,
         isCollecting: false,
-      });
+        requestSeq: state.requestSeq + 1,
+      }));
     } catch (err) {
       set({
         isCollecting: false,

--- a/src/store/gitPullRebaseConfirmStore.ts
+++ b/src/store/gitPullRebaseConfirmStore.ts
@@ -22,12 +22,20 @@ interface PendingPullRebaseConfirmation {
 
 interface GitPullRebaseConfirmState {
   pendingConfirm: PendingPullRebaseConfirmation | null;
+  /**
+   * Monotonic counter bumped on every request. Used as the always-mounted host's
+   * ErrorBoundary `resetKeys` signal so a crashed dialog auto-recovers when a new
+   * request arrives — including the back-to-back supersede case where
+   * `pendingConfirm` never returns to null between requests (#9918).
+   */
+  requestSeq: number;
   requestConfirmation: (cwd: string) => Promise<boolean>;
   resolveConfirmation: (ok: boolean) => void;
 }
 
 export const useGitPullRebaseConfirmStore = create<GitPullRebaseConfirmState>()((set, get) => ({
   pendingConfirm: null,
+  requestSeq: 0,
 
   requestConfirmation: (cwd: string): Promise<boolean> => {
     const existing = get().pendingConfirm;
@@ -36,7 +44,7 @@ export const useGitPullRebaseConfirmStore = create<GitPullRebaseConfirmState>()(
     }
 
     return new Promise<boolean>((resolve) => {
-      set({ pendingConfirm: { resolve, cwd } });
+      set((state) => ({ pendingConfirm: { resolve, cwd }, requestSeq: state.requestSeq + 1 }));
     });
   },
 

--- a/src/store/gitPushConfirmStore.ts
+++ b/src/store/gitPushConfirmStore.ts
@@ -19,12 +19,20 @@ interface PendingPushConfirmation {
 
 interface GitPushConfirmState {
   pendingConfirm: PendingPushConfirmation | null;
+  /**
+   * Monotonic counter bumped on every request. Used as the always-mounted host's
+   * ErrorBoundary `resetKeys` signal so a crashed dialog auto-recovers when a new
+   * request arrives — including the back-to-back supersede case where
+   * `pendingConfirm` never returns to null between requests (#9918).
+   */
+  requestSeq: number;
   requestConfirmation: (cwd: string) => Promise<boolean>;
   resolveConfirmation: (ok: boolean) => void;
 }
 
 export const useGitPushConfirmStore = create<GitPushConfirmState>()((set, get) => ({
   pendingConfirm: null,
+  requestSeq: 0,
 
   requestConfirmation: (cwd: string): Promise<boolean> => {
     const existing = get().pendingConfirm;
@@ -33,7 +41,7 @@ export const useGitPushConfirmStore = create<GitPushConfirmState>()((set, get) =
     }
 
     return new Promise<boolean>((resolve) => {
-      set({ pendingConfirm: { resolve, cwd } });
+      set((state) => ({ pendingConfirm: { resolve, cwd }, requestSeq: state.requestSeq + 1 }));
     });
   },
 

--- a/src/store/panelLimitStore.ts
+++ b/src/store/panelLimitStore.ts
@@ -51,6 +51,14 @@ interface PanelLimitState {
   hardwareDefaultsApplied: boolean;
   lastSoftWarningDismissedAt: number | null;
   pendingConfirm: PendingConfirmation | null;
+  /**
+   * Monotonic counter bumped on every request. Used as the always-mounted host's
+   * ErrorBoundary `resetKeys` signal so a crashed dialog auto-recovers when a new
+   * request arrives — including the back-to-back supersede case where
+   * `pendingConfirm` never returns to null between requests (#9918). Transient
+   * runtime state — intentionally excluded from `partialize`.
+   */
+  requestSeq: number;
   setSoftWarningLimit: (limit: number) => void;
   setConfirmationLimit: (limit: number) => void;
   setHardLimit: (limit: number) => void;
@@ -86,6 +94,7 @@ export const usePanelLimitStore = create<PanelLimitState>()(
       hardwareDefaultsApplied: false,
       lastSoftWarningDismissedAt: null,
       pendingConfirm: null,
+      requestSeq: 0,
 
       setSoftWarningLimit: (limit: number) => {
         if (!Number.isFinite(limit)) return;
@@ -117,7 +126,10 @@ export const usePanelLimitStore = create<PanelLimitState>()(
         }
 
         return new Promise<boolean>((resolve) => {
-          set({ pendingConfirm: { resolve, panelCount, memoryMB } });
+          set((state) => ({
+            pendingConfirm: { resolve, panelCount, memoryMB },
+            requestSeq: state.requestSeq + 1,
+          }));
         });
       },
 

--- a/src/store/recipeConflictStore.ts
+++ b/src/store/recipeConflictStore.ts
@@ -29,18 +29,29 @@ interface PendingRecipeConflict extends RecipeConflictRequest {
 
 interface RecipeConflictState {
   pendingConflict: PendingRecipeConflict | null;
+  /**
+   * Monotonic counter bumped on every request. Used as the always-mounted host's
+   * ErrorBoundary `resetKeys` signal so a crashed dialog auto-recovers when a new
+   * request arrives — including the back-to-back supersede case where
+   * `pendingConflict` never returns to null between requests (#9918).
+   */
+  requestSeq: number;
   requestConflict: (request: RecipeConflictRequest) => Promise<RecipeConflictResolution>;
   resolveConflict: (action: RecipeConflictResolution) => void;
 }
 
 export const useRecipeConflictStore = create<RecipeConflictState>()((set, get) => ({
   pendingConflict: null,
+  requestSeq: 0,
 
   requestConflict: (request) => {
     const existing = get().pendingConflict;
     if (existing) existing.resolve("cancel");
     return new Promise<RecipeConflictResolution>((resolve) => {
-      set({ pendingConflict: { ...request, resolve } });
+      set((state) => ({
+        pendingConflict: { ...request, resolve },
+        requestSeq: state.requestSeq + 1,
+      }));
     });
   },
 


### PR DESCRIPTION
## Summary

- The ten always-mounted lazy dialog host `ErrorBoundary` wrappers in `App.tsx` all used `resetKeys={[Number(isStateLoaded)]}`, which collapses to `[1]` after hydration and never changes. A host that crashed once stayed dead for the whole session.
- The silent consequence: deferred-promise dialogs (git push, pull-rebase, panel limit, MCP confirm, etc.) park a promise in their store that only resolves through the dialog's buttons. With the host dead, every subsequent request leaks that promise silently — the action never completes, no error, no toast.
- The component-variant error fallback renders off-screen below `AppLayout`'s `h-screen` container, so the "Try again" button is unreachable. Auto-reset via `resetKeys` is the only real recovery path.

Resolves #9918

## Changes

- **`App.tsx`**: outer host boundaries now reset on their own pending-request signal. Request-counter stores (`gitPush`, `gitPullRebase`, `panelLimit`, `recipeConflict`, `diagnosticsReview`) expose a monotonic `requestSeq`; FIFO-queue dialogs (`mcp`, `plugin`, `pluginMcp`) key off `current.requestId`; event-driven hosts (`terminal-info`, `file-viewer`) key off a local open-event counter.
- **Inner boundaries**: `gitPush`, `gitPullRebase`, `recipeConflict`, `panelLimit`, `terminalInfo`, `fileViewer` each wrap their content in an inner `ErrorBoundary` that had broken boolean reset keys — fixed to use the same `requestSeq` / open-counter signal. (`mcp`/`plugin`/`pluginMcp` inner boundaries were already correctly keyed off `requestId`.)
- **`requestSeq`** uses a functional `set` updater and is bumped atomically with the pending payload, so the back-to-back supersede case (pending replaced without returning to `null`) still triggers a reset. Kept out of `panelLimitStore` `partialize` (transient runtime state).
- **Store tests**: extended to cover `requestSeq` increment, supersede, no-op-on-resolve, partialize exclusion; new `recipeConflictStore` test; `diagnosticsReview` `requestSeq`.

## Testing

60 store tests pass. Local CI (typecheck, lint, format, IPC/confirm-wiring guards, build, preload-backdoors, renderer unit tests) passed on the gated SHA.

Out of scope: `OnboardingFlow` in `App.tsx` still uses `Number(isStateLoaded)` — it is not a deferred-promise dialog and leaks no promise, so it was left out of this fix's scope.