### PR TITLE
chore(agents): make agent detection config contract honest

### DIFF
--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -1186,10 +1186,10 @@ export class ActivityMonitor {
     // exit busy immediately rather than waiting the full IDLE_DEBOUNCE_MS. This keeps
     // the idle transition snappy after the prompt appears, even when IDLE_DEBOUNCE_MS
     // has been raised to cover LLM API call silence gaps.
-    // Default: 3s quiet to avoid premature idle during inter-tool-call gaps (Claude
-    // bursts with 1-3s pauses, Codex has 3-5s gaps — Issue #3606). Agents with
-    // deterministic completion markers (e.g. Cursor, 700ms) can use a lower value
-    // via promptFastPathMinQuietMs in AgentDetectionConfig.
+    // The quiet requirement guards against premature idle during inter-tool-call
+    // gaps (Claude bursts with 1-3s pauses, Codex has 3-5s gaps — Issue #3606).
+    // buildActivityMonitorOptions floors promptFastPathMinQuietMs to the effective
+    // idle debounce (>= 8s), so sub-floor per-agent values are not honored.
     if (
       this.state === "busy" &&
       !this.completionTimer.emitted &&

--- a/electron/services/pty/__tests__/terminalActivityPatterns.test.ts
+++ b/electron/services/pty/__tests__/terminalActivityPatterns.test.ts
@@ -5,6 +5,8 @@ import type { AgentDetectionConfig } from "../../../../shared/config/agentRegist
 import {
   createProcessStateValidator,
   buildActivityMonitorOptions,
+  buildBootCompletePatterns,
+  buildPatternConfig,
   buildPromptHintPatterns,
   UNIVERSAL_APPROVAL_HINT_PATTERNS,
 } from "../terminalActivityPatterns.js";
@@ -102,6 +104,22 @@ describe("createProcessStateValidator", () => {
     const cache = createMockProcessTreeCache(new Map([[1, children]]));
     const validator = createProcessStateValidator(1, cache)!;
     expect(validator.hasActiveChildren()).toBe(false);
+  });
+});
+
+describe("buildPatternConfig", () => {
+  it("returns undefined for empty primaryPatterns, dropping declared fallbacks (#9877)", () => {
+    const detection: AgentDetectionConfig = {
+      primaryPatterns: [],
+      fallbackPatterns: ["esc to interrupt"],
+    };
+    expect(buildPatternConfig(detection, "amp")).toBeUndefined();
+  });
+});
+
+describe("buildBootCompletePatterns", () => {
+  it("returns undefined for empty bootCompletePatterns (#9877)", () => {
+    expect(buildBootCompletePatterns({ bootCompletePatterns: [] }, "antigravity")).toBeUndefined();
   });
 });
 

--- a/electron/services/pty/__tests__/terminalActivityPatterns.test.ts
+++ b/electron/services/pty/__tests__/terminalActivityPatterns.test.ts
@@ -119,7 +119,8 @@ describe("buildPatternConfig", () => {
 
 describe("buildBootCompletePatterns", () => {
   it("returns undefined for empty bootCompletePatterns (#9877)", () => {
-    expect(buildBootCompletePatterns({ bootCompletePatterns: [] }, "antigravity")).toBeUndefined();
+    const detection: AgentDetectionConfig = { primaryPatterns: [], bootCompletePatterns: [] };
+    expect(buildBootCompletePatterns(detection, "antigravity")).toBeUndefined();
   });
 });
 

--- a/electron/services/pty/terminalActivityPatterns.ts
+++ b/electron/services/pty/terminalActivityPatterns.ts
@@ -8,7 +8,9 @@ import type { ProcessTreeCache } from "../ProcessTreeCache.js";
 import type { VisibleContentSnapshot } from "./SustainedChangeTracker.js";
 
 // Agent status is intentionally output-driven: any observed output means
-// working, and sustained silence means waiting.
+// working, and sustained silence means waiting. Also the floor for
+// debounceMs and promptFastPathMinQuietMs in buildActivityMonitorOptions —
+// an intentional jitter guard for silent inter-tool-call gaps (#3606).
 const AGENT_WAITING_QUIET_MS = 8000;
 
 export function buildPatternConfig(

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -480,6 +480,7 @@ describe("mistral configuration", () => {
 
   it("relies on prompt fast-path without a per-agent quiet override", () => {
     const detection = getAgentConfig("mistral")?.detection;
+    expect(detection).toBeDefined();
     expect(detection?.completionPatterns).toBeUndefined();
     expect(detection?.promptFastPathMinQuietMs).toBeUndefined();
   });

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -478,10 +478,10 @@ describe("mistral configuration", () => {
     }
   });
 
-  it("relies on prompt fast-path with the shared 6s waiting debounce", () => {
+  it("relies on prompt fast-path without a per-agent quiet override", () => {
     const detection = getAgentConfig("mistral")?.detection;
     expect(detection?.completionPatterns).toBeUndefined();
-    expect(detection?.promptFastPathMinQuietMs).toBe(6000);
+    expect(detection?.promptFastPathMinQuietMs).toBeUndefined();
   });
 
   it("ships the local-llamacpp preset as a labeled placeholder", () => {

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -67,17 +67,19 @@ export interface AgentDetectionConfig {
   promptScanLineCount?: number;
 
   /**
-   * Activity debounce period in ms (default: 4000).
-   * Time to wait after last activity before transitioning to idle.
+   * Activity debounce period in ms — time to wait after last activity before
+   * transitioning to idle. `buildActivityMonitorOptions` floors this to
+   * AGENT_WAITING_QUIET_MS (8000) to prevent working↔waiting jitter during
+   * silent inter-tool-call gaps (#3606); sub-floor values are not honored.
+   * Omit to accept the 8000ms default.
    */
   debounceMs?: number;
 
   /**
-   * Minimum quiet-output ms before the prompt fast-path can fire (default: 3000).
-   * Lower values make the busy→idle transition snappier when a prompt is detected.
-   * Agents with deterministic completion markers (e.g. Cursor) can use shorter
-   * values; agents with silent inter-tool-call gaps (Claude/Codex) need the
-   * default to avoid working↔waiting jitter (Issue #3606).
+   * Minimum quiet-output ms before the prompt fast-path can fire.
+   * `buildActivityMonitorOptions` floors this to the effective idle debounce
+   * (>= AGENT_WAITING_QUIET_MS, 8000) for the same #3606 jitter guard —
+   * sub-floor values are not honored. Omit to accept the default.
    */
   promptFastPathMinQuietMs?: number;
 

--- a/shared/config/agents/aider.ts
+++ b/shared/config/agents/aider.ts
@@ -135,7 +135,6 @@ export const config: AgentConfig = {
     primaryConfidence: 0.95,
     fallbackConfidence: 0.7,
     promptConfidence: 0.85,
-    debounceMs: 6000,
   },
   resume: {
     kind: "rolling-history",

--- a/shared/config/agents/amp.ts
+++ b/shared/config/agents/amp.ts
@@ -77,8 +77,11 @@ export const config: AgentConfig = {
   detection: {
     // Amp ships with empty primary/fallback patterns until on-device PTY
     // capture confirms the actual spinner glyphs and working strings emitted
-    // by the Ink TUI. Speculative patterns risk wrong-Unicode regressions
-    // (see #3941). Boot/prompt patterns are conservative and self-validating.
+    // by the Ink TUI; speculative patterns risk wrong-Unicode regressions
+    // (see #3941). Note: empty primaryPatterns is fallthrough, not opt-out —
+    // buildPatternConfig returns undefined (dropping fallbackPatterns too)
+    // and the universal pattern set applies. Opt-out semantics are #9873's
+    // scope. Boot/prompt patterns are conservative and self-validating.
     primaryPatterns: [
       // @generated:amp:primaryPatterns:start
       // @generated:amp:primaryPatterns:end
@@ -100,7 +103,6 @@ export const config: AgentConfig = {
     primaryConfidence: 0.95,
     fallbackConfidence: 0.75,
     promptConfidence: 0.85,
-    debounceMs: 6000,
   },
   // Amp resumes a thread by ID via `amp threads continue <id>`. There's no
   // session-ID emission on quit and no slash-quit command — Ctrl+C is the

--- a/shared/config/agents/antigravity.ts
+++ b/shared/config/agents/antigravity.ts
@@ -37,10 +37,12 @@ export const config: AgentConfig = {
   },
   // Detection patterns require live observation of `agy` v1.0.1 — the TUI
   // glyphs (working / waiting), boot ready marker, prompt shape, and
-  // completion strings can't be inferred from code. Shipping empty
-  // primaryPatterns is safer than copying Gemini's: the state machine
-  // simply doesn't mis-classify rather than firing on the wrong glyphs.
-  // Track follow-up via a dedicated detection-tuning issue.
+  // completion strings can't be inferred from code. Note: empty arrays are
+  // fallthrough, not opt-out — empty primaryPatterns makes buildPatternConfig
+  // return undefined so the universal pattern set applies, and empty
+  // bootCompletePatterns falls back to BootDetector's built-in banners.
+  // Opt-out semantics are #9873's scope. Track pattern follow-up via a
+  // dedicated detection-tuning issue.
   detection: {
     primaryPatterns: [],
     fallbackPatterns: [],

--- a/shared/config/agents/claude.ts
+++ b/shared/config/agents/claude.ts
@@ -111,7 +111,6 @@ export const config: AgentConfig = {
     primaryConfidence: 0.95,
     fallbackConfidence: 0.75,
     promptConfidence: 0.85,
-    debounceMs: 6000,
   },
   resume: {
     kind: "session-id",

--- a/shared/config/agents/codex.ts
+++ b/shared/config/agents/codex.ts
@@ -109,7 +109,6 @@ export const config: AgentConfig = {
     primaryConfidence: 0.95,
     fallbackConfidence: 0.75,
     promptConfidence: 0.85,
-    debounceMs: 6000,
   },
   resume: {
     kind: "session-id",

--- a/shared/config/agents/copilot.ts
+++ b/shared/config/agents/copilot.ts
@@ -101,7 +101,6 @@ export const config: AgentConfig = {
     primaryConfidence: 0.95,
     fallbackConfidence: 0.75,
     promptConfidence: 0.85,
-    debounceMs: 6000,
   },
   resume: {
     kind: "session-id",

--- a/shared/config/agents/crush.ts
+++ b/shared/config/agents/crush.ts
@@ -109,7 +109,6 @@ export const config: AgentConfig = {
     primaryConfidence: 0.95,
     fallbackConfidence: 0.7,
     promptConfidence: 0.85,
-    debounceMs: 6000,
   },
   // Crush has no `/quit` command and Ctrl+C triggers a confirmation dialog,
   // so we omit `resume` and let the PTY host kill the process on shutdown.

--- a/shared/config/agents/cursor.ts
+++ b/shared/config/agents/cursor.ts
@@ -74,8 +74,6 @@ export const config: AgentConfig = {
     primaryConfidence: 0.95,
     fallbackConfidence: 0.7,
     promptConfidence: 0.85,
-    debounceMs: 6000,
-    promptFastPathMinQuietMs: 6000,
   },
   authCheck: {
     // Cursor may store tokens in OS Keychain on newer versions; file check

--- a/shared/config/agents/gemini.ts
+++ b/shared/config/agents/gemini.ts
@@ -116,7 +116,6 @@ export const config: AgentConfig = {
     primaryConfidence: 0.95,
     fallbackConfidence: 0.7,
     promptConfidence: 0.85,
-    debounceMs: 6000,
     titleStatePatterns: {
       working: ["✦"],
       waiting: ["◇", "✋"],

--- a/shared/config/agents/goose.ts
+++ b/shared/config/agents/goose.ts
@@ -104,7 +104,6 @@ export const config: AgentConfig = {
     primaryConfidence: 0.95,
     fallbackConfidence: 0.75,
     promptConfidence: 0.85,
-    debounceMs: 6000,
   },
   resume: {
     kind: "session-id",

--- a/shared/config/agents/interpreter.ts
+++ b/shared/config/agents/interpreter.ts
@@ -100,7 +100,6 @@ export const config: AgentConfig = {
     primaryConfidence: 0.95,
     fallbackConfidence: 0.7,
     promptConfidence: 0.85,
-    debounceMs: 6000,
   },
   resume: {
     kind: "rolling-history",

--- a/shared/config/agents/kimi.ts
+++ b/shared/config/agents/kimi.ts
@@ -90,7 +90,6 @@ export const config: AgentConfig = {
     primaryConfidence: 0.95,
     fallbackConfidence: 0.75,
     promptConfidence: 0.85,
-    debounceMs: 6000,
   },
   resume: {
     kind: "rolling-history",

--- a/shared/config/agents/kiro.ts
+++ b/shared/config/agents/kiro.ts
@@ -79,7 +79,6 @@ export const config: AgentConfig = {
     primaryConfidence: 0.95,
     fallbackConfidence: 0.75,
     promptConfidence: 0.85,
-    debounceMs: 6000,
   },
   // Kiro uses directory-based sessions: no session ID is emitted on quit
   // and `--resume` takes no argument. `project-scoped` skips the PTY host's

--- a/shared/config/agents/mistral.ts
+++ b/shared/config/agents/mistral.ts
@@ -103,8 +103,6 @@ export const config: AgentConfig = {
     primaryConfidence: 0.95,
     fallbackConfidence: 0.75,
     promptConfidence: 0.85,
-    debounceMs: 6000,
-    promptFastPathMinQuietMs: 6000,
   },
   // Vibe emits "vibe --resume {session_id}" on exit (session_exit.py:21).
   // Critical: Vibe has NO `/quit` slash command — only `/exit`.

--- a/shared/config/agents/opencode.ts
+++ b/shared/config/agents/opencode.ts
@@ -129,7 +129,6 @@ export const config: AgentConfig = {
     primaryConfidence: 0.95,
     fallbackConfidence: 0.7,
     promptConfidence: 0.85,
-    debounceMs: 6000,
   },
   resume: {
     kind: "session-id",

--- a/shared/config/agents/qwen.ts
+++ b/shared/config/agents/qwen.ts
@@ -95,7 +95,6 @@ export const config: AgentConfig = {
     primaryConfidence: 0.95,
     fallbackConfidence: 0.7,
     promptConfidence: 0.85,
-    debounceMs: 6000,
     titleStatePatterns: {
       working: ["✦"],
       waiting: ["◇", "✋"],


### PR DESCRIPTION
## Summary

- `debounceMs` and `promptFastPathMinQuietMs` claimed tunable defaults, but `buildActivityMonitorOptions` floors both to `AGENT_WAITING_QUIET_MS` (8s) — the #3606 working↔waiting jitter guard — making all 17 per-agent override values dead config
- Doc comments now document the 8s floor and cite #3606; all 17 dead values removed
- `amp.ts` / `antigravity.ts` comments corrected: empty `primaryPatterns` is fallthrough to the universal pattern set (and `BootDetector`'s built-in banners), not an opt-out; opt-out semantics left to #9873

Resolves #9877

## Changes

- `AgentDetectionConfig` doc comments on `debounceMs` and `promptFastPathMinQuietMs` state the 8s floor
- 15 × `debounceMs: 6000` and 2 × `promptFastPathMinQuietMs: 6000` removed (cursor, mistral) — were no-ops
- `amp.ts`, `antigravity.ts` — fallthrough semantics documented, no behavioral change to `buildPatternConfig` / `AgentPatternDetector` / `BootDetector`
- Stale `ActivityMonitor.ts` prompt fast-path comment fixed (still claimed 3s default / 700ms Cursor override)
- Tautological `mistral` test assertion (`toBe(6000)`) replaced with a guarded config-shape check; new behavioral tests for empty-pattern fallthrough in `buildPatternConfig` / `buildBootCompletePatterns`

No behavioral changes — diff is docs, comments, dead-value deletion, and tests (22 files, 3 commits).

## Testing

- `npm run check` fully green (typecheck, lint ratchet −17 warnings, format, channel/IPC/confirm-wiring guards)
- Build + preload-backdoors pass
- Targeted vitest suites green (476 tests)