### PR TITLE
refactor(commands): route github:work-issue through the forge contract

### DIFF
--- a/electron/services/commands/__tests__/githubWorkIssue.test.ts
+++ b/electron/services/commands/__tests__/githubWorkIssue.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Issue } from "../../../../shared/types/forge.js";
 
 const {
   hasGitHubTokenMock,
-  getRepoContextMock,
-  getIssueUrlMock,
-  createClientMock,
+  resolveForCwdMock,
+  getIssueMock,
   getWorkspaceClientMock,
   getRepositoryRootMock,
   listBranchesMock,
@@ -15,9 +15,8 @@ const {
   resolveWorktreePatternMock,
 } = vi.hoisted(() => ({
   hasGitHubTokenMock: vi.fn(),
-  getRepoContextMock: vi.fn(),
-  getIssueUrlMock: vi.fn(),
-  createClientMock: vi.fn(),
+  resolveForCwdMock: vi.fn(),
+  getIssueMock: vi.fn(),
   getWorkspaceClientMock: vi.fn(),
   getRepositoryRootMock: vi.fn(),
   listBranchesMock: vi.fn(),
@@ -30,13 +29,15 @@ const {
 
 vi.mock("../../GitHubService.js", () => ({
   hasGitHubToken: hasGitHubTokenMock,
-  getRepoContext: getRepoContextMock,
-  getIssueUrl: getIssueUrlMock,
 }));
 
-vi.mock("../../github/index.js", () => ({
-  GitHubAuth: { createClient: createClientMock },
-  GET_ISSUE_QUERY: "query",
+vi.mock("../../../ipc/handlers/forgeResolution.js", () => ({
+  resolveForCwd: resolveForCwdMock,
+}));
+
+vi.mock("../../forge/forgeAuditService.js", () => ({
+  auditForgeCall: (_meta: unknown, run: () => unknown) => run(),
+  summarizeForgeArgs: () => "",
 }));
 
 vi.mock("../../WorkspaceClient.js", () => ({
@@ -65,24 +66,28 @@ vi.mock("../../../utils/worktreePattern.js", () => ({
 
 import { githubWorkIssueCommand } from "../githubWorkIssue.js";
 
+/** Build a minimal forge Issue with sensible defaults for tests. */
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    number: 55,
+    title: "!!!",
+    url: "https://github.com/daintree/app/issues/55",
+    state: "open",
+    ...overrides,
+  } as Issue;
+}
+
 describe("githubWorkIssueCommand", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     hasGitHubTokenMock.mockReturnValue(true);
-    getRepoContextMock.mockResolvedValue({ owner: "daintree", repo: "app" });
-    getIssueUrlMock.mockResolvedValue("https://github.com/daintree/app/issues/55");
-    createClientMock.mockReturnValue(
-      vi.fn().mockResolvedValue({
-        repository: {
-          issue: {
-            number: 55,
-            title: "!!!",
-            url: "https://github.com/daintree/app/issues/55",
-            state: "OPEN",
-          },
-        },
-      })
-    );
+    getIssueMock.mockResolvedValue(makeIssue());
+    resolveForCwdMock.mockResolvedValue({
+      namespaceId: "builtin.github/github",
+      providerId: "github",
+      repoRef: { owner: "daintree", repo: "app" },
+      impl: { getIssue: getIssueMock },
+    });
     getRepositoryRootMock.mockResolvedValue("/repo");
     listBranchesMock.mockResolvedValue([{ name: "main", remote: false }]);
     findAvailableBranchNameMock.mockImplementation(async (name: string) => name);
@@ -120,30 +125,52 @@ describe("githubWorkIssueCommand", () => {
     );
   });
 
-  it("uses fetched issue URL when getIssueUrl throws", async () => {
-    getIssueUrlMock.mockRejectedValue(new Error("url lookup failed"));
+  it("resolves the forge provider against the repository root", async () => {
+    await githubWorkIssueCommand.execute({ cwd: "/repo/sub" } as never, {
+      issueNumber: 55,
+    });
+
+    expect(resolveForCwdMock).toHaveBeenCalledWith("/repo");
+    expect(getIssueMock).toHaveBeenCalledWith({ owner: "daintree", repo: "app" }, 55);
+  });
+
+  it("uses the issue URL returned by the forge provider", async () => {
+    getIssueMock.mockResolvedValue(
+      makeIssue({ url: "https://gitlab.com/daintree/app/-/issues/55" })
+    );
 
     const result = await githubWorkIssueCommand.execute({ cwd: "/repo" } as never, {
       issueNumber: 55,
     });
 
     expect(result.success).toBe(true);
-    expect(result.data?.issueUrl).toBe("https://github.com/daintree/app/issues/55");
+    expect(result.data?.issueUrl).toBe("https://gitlab.com/daintree/app/-/issues/55");
+  });
+
+  it("returns ISSUE_NOT_FOUND when the provider reports no issue", async () => {
+    getIssueMock.mockResolvedValue(null);
+
+    const result = await githubWorkIssueCommand.execute({ cwd: "/repo" } as never, {
+      issueNumber: 55,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe("ISSUE_NOT_FOUND");
+  });
+
+  it("returns NOT_GIT_REPO when forge resolution fails", async () => {
+    resolveForCwdMock.mockRejectedValue(new Error("No remote URL found for this repository"));
+
+    const result = await githubWorkIssueCommand.execute({ cwd: "/repo" } as never, {
+      issueNumber: 55,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe("NOT_GIT_REPO");
   });
 
   it("normalizes accented Latin characters in slugified branch names", async () => {
-    createClientMock.mockReturnValue(
-      vi.fn().mockResolvedValue({
-        repository: {
-          issue: {
-            number: 55,
-            title: "Café résumé",
-            url: "https://github.com/daintree/app/issues/55",
-            state: "OPEN",
-          },
-        },
-      })
-    );
+    getIssueMock.mockResolvedValue(makeIssue({ title: "Café résumé" }));
 
     const result = await githubWorkIssueCommand.execute({ cwd: "/repo" } as never, {
       issueNumber: 55,
@@ -154,18 +181,7 @@ describe("githubWorkIssueCommand", () => {
   });
 
   it("normalizes naïve to naive in slugified branch names", async () => {
-    createClientMock.mockReturnValue(
-      vi.fn().mockResolvedValue({
-        repository: {
-          issue: {
-            number: 7,
-            title: "Fix naïve approach",
-            url: "https://github.com/daintree/app/issues/7",
-            state: "OPEN",
-          },
-        },
-      })
-    );
+    getIssueMock.mockResolvedValue(makeIssue({ number: 7, title: "Fix naïve approach" }));
 
     const result = await githubWorkIssueCommand.execute({ cwd: "/repo" } as never, {
       issueNumber: 7,
@@ -195,10 +211,10 @@ describe("githubWorkIssueCommand", () => {
     );
   });
 
-  it("maps GraphQL TimeoutError to GITHUB_ERROR with timeout message", async () => {
+  it("maps provider TimeoutError to GITHUB_ERROR with timeout message", async () => {
     const timeoutError = new Error("The operation was aborted due to timeout");
     timeoutError.name = "TimeoutError";
-    createClientMock.mockReturnValue(vi.fn().mockRejectedValue(timeoutError));
+    getIssueMock.mockRejectedValue(timeoutError);
 
     const result = await githubWorkIssueCommand.execute({ cwd: "/repo" } as never, {
       issueNumber: 55,
@@ -209,11 +225,11 @@ describe("githubWorkIssueCommand", () => {
     expect(result.error?.message).toContain("Timed out");
   });
 
-  it("maps GraphQL fetch errors with cause.code to GITHUB_ERROR with network message", async () => {
+  it("maps provider fetch errors with cause.code to GITHUB_ERROR with network message", async () => {
     const transportError = Object.assign(new TypeError("fetch failed"), {
       cause: { code: "ECONNREFUSED" },
     });
-    createClientMock.mockReturnValue(vi.fn().mockRejectedValue(transportError));
+    getIssueMock.mockRejectedValue(transportError);
 
     const result = await githubWorkIssueCommand.execute({ cwd: "/repo" } as never, {
       issueNumber: 55,

--- a/electron/services/commands/__tests__/githubWorkIssue.test.ts
+++ b/electron/services/commands/__tests__/githubWorkIssue.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Issue } from "../../../../shared/types/forge.js";
 
 const {
-  hasGitHubTokenMock,
+  hasActivatedForgeProviderMock,
   resolveForCwdMock,
   getIssueMock,
   getWorkspaceClientMock,
@@ -14,7 +14,7 @@ const {
   validatePathPatternMock,
   resolveWorktreePatternMock,
 } = vi.hoisted(() => ({
-  hasGitHubTokenMock: vi.fn(),
+  hasActivatedForgeProviderMock: vi.fn(),
   resolveForCwdMock: vi.fn(),
   getIssueMock: vi.fn(),
   getWorkspaceClientMock: vi.fn(),
@@ -27,8 +27,8 @@ const {
   resolveWorktreePatternMock: vi.fn(),
 }));
 
-vi.mock("../../GitHubService.js", () => ({
-  hasGitHubToken: hasGitHubTokenMock,
+vi.mock("../../forgeProviderRegistry.js", () => ({
+  hasActivatedForgeProvider: hasActivatedForgeProviderMock,
 }));
 
 vi.mock("../../../ipc/handlers/forgeResolution.js", () => ({
@@ -80,7 +80,7 @@ function makeIssue(overrides: Partial<Issue> = {}): Issue {
 describe("githubWorkIssueCommand", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    hasGitHubTokenMock.mockReturnValue(true);
+    hasActivatedForgeProviderMock.mockReturnValue(true);
     getIssueMock.mockResolvedValue(makeIssue());
     resolveForCwdMock.mockResolvedValue({
       namespaceId: "builtin.github/github",
@@ -130,8 +130,50 @@ describe("githubWorkIssueCommand", () => {
       issueNumber: 55,
     });
 
+    expect(resolveForCwdMock).toHaveBeenCalledTimes(1);
     expect(resolveForCwdMock).toHaveBeenCalledWith("/repo");
     expect(getIssueMock).toHaveBeenCalledWith({ owner: "daintree", repo: "app" }, 55);
+  });
+
+  it("routes through a non-GitHub provider end-to-end", async () => {
+    resolveForCwdMock.mockResolvedValue({
+      namespaceId: "builtin.gitlab/gitlab",
+      providerId: "gitlab",
+      repoRef: { owner: "group", repo: "proj" },
+      impl: { getIssue: getIssueMock },
+    });
+    getIssueMock.mockResolvedValue(
+      makeIssue({
+        number: 12,
+        title: "Add widget",
+        url: "https://gitlab.com/group/proj/-/issues/12",
+      })
+    );
+
+    const result = await githubWorkIssueCommand.execute({ cwd: "/repo" } as never, {
+      issueNumber: 12,
+    });
+
+    expect(result.success).toBe(true);
+    expect(getIssueMock).toHaveBeenCalledWith({ owner: "group", repo: "proj" }, 12);
+    expect(result.data?.issueUrl).toBe("https://gitlab.com/group/proj/-/issues/12");
+    const workspaceClient = getWorkspaceClientMock.mock.results[0]?.value as {
+      createWorktree: ReturnType<typeof vi.fn>;
+    };
+    expect(workspaceClient.createWorktree).toHaveBeenCalledWith(
+      "/repo",
+      expect.objectContaining({ newBranch: "issue-12-add-widget" })
+    );
+  });
+
+  it("is enabled when a forge provider is active and disabled otherwise", () => {
+    hasActivatedForgeProviderMock.mockReturnValue(true);
+    expect(githubWorkIssueCommand.isEnabled?.({} as never)).toBe(true);
+    expect(githubWorkIssueCommand.disabledReason?.({} as never)).toBeUndefined();
+
+    hasActivatedForgeProviderMock.mockReturnValue(false);
+    expect(githubWorkIssueCommand.isEnabled?.({} as never)).toBe(false);
+    expect(githubWorkIssueCommand.disabledReason?.({} as never)).toMatch(/forge provider/i);
   });
 
   it("uses the issue URL returned by the forge provider", async () => {
@@ -158,7 +200,7 @@ describe("githubWorkIssueCommand", () => {
     expect(result.error?.code).toBe("ISSUE_NOT_FOUND");
   });
 
-  it("returns NOT_GIT_REPO when forge resolution fails", async () => {
+  it("returns FORGE_PROVIDER_ERROR with no worktree side-effects when resolution fails", async () => {
     resolveForCwdMock.mockRejectedValue(new Error("No remote URL found for this repository"));
 
     const result = await githubWorkIssueCommand.execute({ cwd: "/repo" } as never, {
@@ -166,7 +208,10 @@ describe("githubWorkIssueCommand", () => {
     });
 
     expect(result.success).toBe(false);
-    expect(result.error?.code).toBe("NOT_GIT_REPO");
+    expect(result.error?.code).toBe("FORGE_PROVIDER_ERROR");
+    expect(getIssueMock).not.toHaveBeenCalled();
+    expect(findAvailableBranchNameMock).not.toHaveBeenCalled();
+    expect(getWorkspaceClientMock).not.toHaveBeenCalled();
   });
 
   it("normalizes accented Latin characters in slugified branch names", async () => {

--- a/electron/services/commands/githubWorkIssue.ts
+++ b/electron/services/commands/githubWorkIssue.ts
@@ -1,14 +1,13 @@
 /**
- * github:work-issue command - Creates a worktree for a GitHub issue.
+ * github:work-issue command - Creates a worktree for a forge issue.
  *
  * Automates the workflow of:
- * 1. Fetching issue details from GitHub
+ * 1. Fetching issue details from the active forge provider
  * 2. Generating a branch name from the issue
  * 3. Creating a new worktree
  * 4. Switching to the new worktree
  */
 
-import type { GraphQlQueryResponseData } from "@octokit/graphql";
 import { existsSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
@@ -17,8 +16,10 @@ import type {
   CommandContext,
   CommandResult,
 } from "../../../shared/types/commands.js";
-import { hasGitHubToken, getRepoContext, getIssueUrl } from "../GitHubService.js";
-import { GitHubAuth, GET_ISSUE_QUERY } from "../github/index.js";
+import type { NormalizedIssueState } from "../../../shared/types/forge.js";
+import { hasGitHubToken } from "../GitHubService.js";
+import { resolveForCwd } from "../../ipc/handlers/forgeResolution.js";
+import { auditForgeCall, summarizeForgeArgs } from "../forge/forgeAuditService.js";
 import { getWorkspaceClient } from "../WorkspaceClient.js";
 import { GitService } from "../GitService.js";
 import { generateWorktreePath, validatePathPattern } from "../../../shared/utils/pathPattern.js";
@@ -32,12 +33,12 @@ export interface GitHubWorkIssueArgs {
   baseBranch?: string;
 }
 
-/** Issue details fetched from GitHub */
+/** Issue details fetched from the active forge provider */
 interface IssueDetails {
   number: number;
   title: string;
   url: string;
-  state: "OPEN" | "CLOSED";
+  state: NormalizedIssueState;
 }
 
 /** Result data returned on success */
@@ -95,64 +96,6 @@ function slugifyTitle(title: string): string {
 function generateBranchName(issueNumber: number, issueTitle: string): string {
   const slug = slugifyTitle(issueTitle);
   return slug ? `issue-${issueNumber}-${slug}` : `issue-${issueNumber}`;
-}
-
-/**
- * Fetch issue details from GitHub API.
- */
-async function fetchIssueDetails(cwd: string, issueNumber: number): Promise<IssueDetails> {
-  const client = GitHubAuth.createClient();
-  if (!client) {
-    throw new Error("GitHub token not configured. Set it in Settings.");
-  }
-
-  const context = await getRepoContext(cwd);
-  if (!context) {
-    throw new Error("Not a GitHub repository");
-  }
-
-  let response: GraphQlQueryResponseData;
-  try {
-    response = (await client(GET_ISSUE_QUERY, {
-      owner: context.owner,
-      repo: context.repo,
-      number: issueNumber,
-    })) as GraphQlQueryResponseData;
-  } catch (error) {
-    if (error instanceof Error && error.name === "TimeoutError") {
-      throw new Error("Timed out reaching GitHub. Try again.");
-    }
-
-    const causeCode = (error as { cause?: { code?: unknown } } | undefined)?.cause?.code;
-    if (typeof causeCode === "string" && NETWORK_ERROR_CODES.has(causeCode)) {
-      throw new Error("Network error connecting to GitHub.");
-    }
-
-    // Handle GraphQL errors (auth, rate limit, network)
-    const message = formatErrorMessage(error, "Failed to fetch GitHub issue");
-    if (message.includes("401") || message.includes("Unauthorized")) {
-      throw new Error("GitHub authentication failed. Check your token.");
-    }
-    if (message.includes("403") || message.includes("rate limit")) {
-      throw new Error("GitHub API rate limit exceeded. Try again later.");
-    }
-    if (message.includes("ENOTFOUND") || message.includes("network")) {
-      throw new Error("Network error connecting to GitHub.");
-    }
-    throw new Error(`GitHub API error: ${message}`);
-  }
-
-  const issue = response?.repository?.issue;
-  if (!issue) {
-    throw new Error(`Issue #${issueNumber} not found`);
-  }
-
-  return {
-    number: issue.number as number,
-    title: issue.title as string,
-    url: issue.url as string,
-    state: issue.state as "OPEN" | "CLOSED",
-  };
 }
 
 /**
@@ -321,25 +264,39 @@ export const githubWorkIssueCommand: DaintreeCommand<GitHubWorkIssueArgs, GitHub
       };
     }
 
-    // Check GitHub token
-    if (!hasGitHubToken()) {
+    // Resolve the active forge provider for this repo. Routing through the
+    // contract (rather than a raw GitHub fetch) lets any registered provider
+    // answer, matching the other forge command surfaces.
+    let resolved;
+    try {
+      resolved = await resolveForCwd(rootPath);
+    } catch (error) {
+      const message = formatErrorMessage(error, "Failed to determine repository context");
       return {
         success: false,
         error: {
-          code: "NO_GITHUB_TOKEN",
-          message: "GitHub token not configured. Set it in Settings.",
+          code: "NOT_GIT_REPO",
+          message: `Failed to determine repository context: ${message}`,
         },
       };
     }
 
-    // Fetch issue details
+    // Fetch issue details through the forge contract.
     let issue: IssueDetails;
     try {
-      issue = await fetchIssueDetails(rootPath, issueNumber);
-    } catch (error) {
-      const message = formatErrorMessage(error, "Failed to fetch issue");
+      const forgeIssue = await auditForgeCall(
+        {
+          providerId: resolved.namespaceId,
+          methodName: "getIssue",
+          repoOwner: resolved.repoRef.owner,
+          repoName: resolved.repoRef.repo,
+          argsSummary: summarizeForgeArgs("getIssue", issueNumber),
+        },
+        () => resolved.impl.getIssue(resolved.repoRef, issueNumber),
+        (value) => (value === null ? "not-found" : "success")
+      );
 
-      if (message.includes("not found")) {
+      if (!forgeIssue) {
         return {
           success: false,
           error: {
@@ -349,16 +306,35 @@ export const githubWorkIssueCommand: DaintreeCommand<GitHubWorkIssueArgs, GitHub
         };
       }
 
-      if (message.includes("Not a GitHub repository")) {
+      issue = {
+        number: forgeIssue.number,
+        title: forgeIssue.title,
+        url: forgeIssue.url,
+        state: forgeIssue.state,
+      };
+    } catch (error) {
+      if (error instanceof Error && error.name === "TimeoutError") {
         return {
           success: false,
           error: {
-            code: "NOT_GITHUB_REPO",
-            message: "Not a GitHub repository",
+            code: "GITHUB_ERROR",
+            message: "Timed out reaching GitHub. Try again.",
           },
         };
       }
 
+      const causeCode = (error as { cause?: { code?: unknown } } | undefined)?.cause?.code;
+      if (typeof causeCode === "string" && NETWORK_ERROR_CODES.has(causeCode)) {
+        return {
+          success: false,
+          error: {
+            code: "GITHUB_ERROR",
+            message: "Network error connecting to GitHub.",
+          },
+        };
+      }
+
+      const message = formatErrorMessage(error, "Failed to fetch issue");
       return {
         success: false,
         error: {
@@ -513,17 +489,8 @@ export const githubWorkIssueCommand: DaintreeCommand<GitHubWorkIssueArgs, GitHub
       console.warn("Failed to switch to new worktree:", errorMessage);
     }
 
-    // Get issue URL (using rootPath)
-    let issueUrl = issue.url;
-    try {
-      const resolvedIssueUrl = await getIssueUrl(rootPath, issueNumber);
-      if (resolvedIssueUrl) {
-        issueUrl = resolvedIssueUrl;
-      }
-    } catch (error) {
-      const message = formatErrorMessage(error, "Failed to resolve issue URL");
-      console.warn(`Failed to resolve issue URL for #${issueNumber}: ${message}`);
-    }
+    // The forge provider returns a canonical issue URL in its response.
+    const issueUrl = issue.url;
 
     // Build success message with warning if switch failed
     const successMessage = switchWarning

--- a/electron/services/commands/githubWorkIssue.ts
+++ b/electron/services/commands/githubWorkIssue.ts
@@ -17,7 +17,7 @@ import type {
   CommandResult,
 } from "../../../shared/types/commands.js";
 import type { NormalizedIssueState } from "../../../shared/types/forge.js";
-import { hasGitHubToken } from "../GitHubService.js";
+import { hasActivatedForgeProvider } from "../forgeProviderRegistry.js";
 import { resolveForCwd } from "../../ipc/handlers/forgeResolution.js";
 import { auditForgeCall, summarizeForgeArgs } from "../forge/forgeAuditService.js";
 import { getWorkspaceClient } from "../WorkspaceClient.js";
@@ -214,10 +214,12 @@ export const githubWorkIssueCommand: DaintreeCommand<GitHubWorkIssueArgs, GitHub
 
   keywords: ["github", "issue", "worktree", "branch", "work", "parallel", "isolate"],
 
-  isEnabled: () => hasGitHubToken(),
+  isEnabled: () => hasActivatedForgeProvider(),
 
   disabledReason: () =>
-    hasGitHubToken() ? undefined : "GitHub token not configured. Set it in Settings.",
+    hasActivatedForgeProvider()
+      ? undefined
+      : "No forge provider is active. Enable one (e.g. GitHub) in Settings.",
 
   async execute(
     context: CommandContext,
@@ -271,12 +273,15 @@ export const githubWorkIssueCommand: DaintreeCommand<GitHubWorkIssueArgs, GitHub
     try {
       resolved = await resolveForCwd(rootPath);
     } catch (error) {
-      const message = formatErrorMessage(error, "Failed to determine repository context");
+      // resolveForCwd throws distinct messages for "no remote", "no provider
+      // registered", "provider not activated", etc. — preserve them rather than
+      // flattening to NOT_GIT_REPO (the git-root check above already owns that).
+      const message = formatErrorMessage(error, "Failed to resolve forge provider");
       return {
         success: false,
         error: {
-          code: "NOT_GIT_REPO",
-          message: `Failed to determine repository context: ${message}`,
+          code: "FORGE_PROVIDER_ERROR",
+          message: `Failed to resolve forge provider: ${message}`,
         },
       };
     }
@@ -318,7 +323,7 @@ export const githubWorkIssueCommand: DaintreeCommand<GitHubWorkIssueArgs, GitHub
           success: false,
           error: {
             code: "GITHUB_ERROR",
-            message: "Timed out reaching GitHub. Try again.",
+            message: "Timed out reaching the forge provider. Try again.",
           },
         };
       }
@@ -329,7 +334,7 @@ export const githubWorkIssueCommand: DaintreeCommand<GitHubWorkIssueArgs, GitHub
           success: false,
           error: {
             code: "GITHUB_ERROR",
-            message: "Network error connecting to GitHub.",
+            message: "Network error connecting to the forge provider.",
           },
         };
       }

--- a/electron/services/forgeProviderRegistry.ts
+++ b/electron/services/forgeProviderRegistry.ts
@@ -140,6 +140,17 @@ export function getForgeProviderImpl(namespacedId: string): ForgeProviderImpl | 
   return PLUGIN_FORGE_PROVIDER_IMPLS.get(namespacedId);
 }
 
+/**
+ * Whether any forge provider has bound a runtime impl. Synchronous, repo-agnostic
+ * presence signal for surfaces (command `isEnabled` gates, etc.) that need to know
+ * "can any forge answer at all?" before a `cwd` is available to resolve a specific
+ * provider. Returns `false` when descriptors are registered but no plugin's
+ * `activate()` has bound an impl yet.
+ */
+export function hasActivatedForgeProvider(): boolean {
+  return PLUGIN_FORGE_PROVIDER_IMPLS.size > 0;
+}
+
 /** Test-isolation helper paralleling {@link clearForgeProviderRegistry}. */
 export function clearForgeProviderImplRegistry(): void {
   PLUGIN_FORGE_PROVIDER_IMPLS.clear();


### PR DESCRIPTION
## Summary

- Routes `github:work-issue` through the provider-agnostic forge contract via `resolveForCwd` + `impl.getIssue()`, wrapped in `auditForgeCall` — matching the pattern already used in `forgeData.ts` and `githubCreateIssue.ts`.
- Enablement now gates on `hasActivatedForgeProvider()` instead of `hasGitHubToken()`, so the command works on any registered forge (GitLab, Gitea, etc.), not just GitHub.
- Issue URL comes from the normalized `forge Issue.url`; `IssueDetails.state` is now the normalized `NormalizedIssueState` (`"open"|"closed"`) rather than GitHub's raw `"OPEN"|"CLOSED"` enum.

Resolves #9957

## Changes

- `githubWorkIssue.ts`: replaces the raw `GET_ISSUE_QUERY`/`GitHubAuth`/`@octokit/graphql` path with `resolveForCwd` + `impl.getIssue(repoRef, number)`; drops `getIssueUrl` fallback; classifies `resolveForCwd` failures as `FORGE_PROVIDER_ERROR` and null `getIssue` results as `ISSUE_NOT_FOUND`
- `forgeProviderRegistry.ts`: adds `hasActivatedForgeProvider()` helper for the provider-presence check
- `githubWorkIssue.test.ts`: tests rewritten against the forge contract mocks (`resolveForCwd`, `auditForgeCall`, `forgeProviderRegistry`); adds cross-provider route, provider-presence gate, and `FORGE_PROVIDER_ERROR` no-side-effects coverage (12 tests pass)

## Testing

Full unit suite rewritten to mock the forge contract rather than GitHub internals. Covers the happy path, cross-provider routing, provider-presence gate (disabled when no forge registered), `FORGE_PROVIDER_ERROR` on resolver failure, and `ISSUE_NOT_FOUND` on null `getIssue`. Local CI passed (typecheck, lint, format, tests, build).