### PR TITLE
fix(fleet): reconcile per-target overrides when a pane leaves the armed set

### DIFF
--- a/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
@@ -7,6 +7,7 @@ import { useFleetResolutionPreviewStore } from "@/store/fleetResolutionPreviewSt
 import {
   useFleetTargetOverridesStore,
   __resetFleetTargetOverridesStoreForTesting,
+  subscribeFleetTargetOverridesPruning,
 } from "@/store/fleetTargetOverridesStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { usePanelStore } from "@/store/panelStore";
@@ -505,5 +506,31 @@ describe("tryFleetBroadcastFromEditor — per-target overrides and skips (#8691)
     await flush();
     expect(submitMock).toHaveBeenCalledTimes(2);
     expect(onSent).toHaveBeenCalled();
+  });
+
+  it("re-includes a disarmed-then-rearmed pane once pruning is wired (#9973)", async () => {
+    // Exact regression: skip "b", disarm it while the drafting popover is
+    // open, then re-arm it before Enter. Without the pruning subscription the
+    // stale `skippedIds` entry survives and the snapshot at Enter-press
+    // silently excludes "b" forever. With pruning wired, disarm clears the
+    // skip so the re-armed pane receives the broadcast.
+    arm(["a", "b"]);
+    const unsub = subscribeFleetTargetOverridesPruning();
+    try {
+      useFleetTargetOverridesStore.getState().setSkipped("b", true);
+      useFleetArmingStore.getState().disarmId("b");
+      useFleetArmingStore.getState().armId("b");
+
+      expect(useFleetTargetOverridesStore.getState().skippedIds.has("b")).toBe(false);
+
+      tryFleetBroadcastFromEditor("a", "hello", vi.fn());
+      await flush();
+      await flush();
+
+      expect(submitMock).toHaveBeenCalledWith("a", "hello");
+      expect(submitMock).toHaveBeenCalledWith("b", "hello");
+    } finally {
+      unsub();
+    }
   });
 });

--- a/src/store/__tests__/fleetTargetOverridesStore.test.ts
+++ b/src/store/__tests__/fleetTargetOverridesStore.test.ts
@@ -13,6 +13,7 @@ function resetArmingStore(): void {
     armOrder: [],
     armOrderById: {},
     lastArmedId: null,
+    broadcastSignal: 0,
     previewArmedIds: new Set<string>(),
   });
 }

--- a/src/store/__tests__/fleetTargetOverridesStore.test.ts
+++ b/src/store/__tests__/fleetTargetOverridesStore.test.ts
@@ -3,10 +3,23 @@ import { describe, it, expect, beforeEach } from "vitest";
 import {
   useFleetTargetOverridesStore,
   __resetFleetTargetOverridesStoreForTesting,
+  subscribeFleetTargetOverridesPruning,
 } from "../fleetTargetOverridesStore";
+import { useFleetArmingStore } from "../fleetArmingStore";
+
+function resetArmingStore(): void {
+  useFleetArmingStore.setState({
+    armedIds: new Set<string>(),
+    armOrder: [],
+    armOrderById: {},
+    lastArmedId: null,
+    previewArmedIds: new Set<string>(),
+  });
+}
 
 beforeEach(() => {
   __resetFleetTargetOverridesStoreForTesting();
+  resetArmingStore();
 });
 
 describe("fleetTargetOverridesStore", () => {
@@ -85,6 +98,121 @@ describe("fleetTargetOverridesStore", () => {
       const state = useFleetTargetOverridesStore.getState();
       expect(state.payloadOverrides).toEqual({});
       expect(state.skippedIds.size).toBe(0);
+    });
+  });
+
+  describe("arming-store pruning subscription", () => {
+    it("drops a disarmed pane's override + skip while keeping still-armed panes", () => {
+      const overrides = useFleetTargetOverridesStore.getState();
+      useFleetArmingStore.getState().armIds(["a", "b"]);
+      overrides.setPayloadOverride("a", "for a");
+      overrides.setPayloadOverride("b", "for b");
+      overrides.setSkipped("a", true);
+      overrides.setSkipped("b", true);
+
+      const unsub = subscribeFleetTargetOverridesPruning();
+      try {
+        useFleetArmingStore.getState().disarmId("a");
+        const state = useFleetTargetOverridesStore.getState();
+        expect(state.payloadOverrides["a"]).toBeUndefined();
+        expect(state.skippedIds.has("a")).toBe(false);
+        // B is still armed — its entries must survive.
+        expect(state.payloadOverrides["b"]).toBe("for b");
+        expect(state.skippedIds.has("b")).toBe(true);
+      } finally {
+        unsub();
+      }
+    });
+
+    it("clears everything in one shot when the fleet fully drains", () => {
+      const overrides = useFleetTargetOverridesStore.getState();
+      useFleetArmingStore.getState().armIds(["a", "b"]);
+      overrides.setPayloadOverride("a", "x");
+      overrides.setSkipped("b", true);
+
+      const unsub = subscribeFleetTargetOverridesPruning();
+      try {
+        useFleetArmingStore.getState().clear();
+        const state = useFleetTargetOverridesStore.getState();
+        expect(state.payloadOverrides).toEqual({});
+        expect(state.skippedIds.size).toBe(0);
+      } finally {
+        unsub();
+      }
+    });
+
+    it("leaves untouched fields ref-identical when only one is pruned", () => {
+      const overrides = useFleetTargetOverridesStore.getState();
+      useFleetArmingStore.getState().armIds(["a", "b"]);
+      // Only a skip on the disarmed pane; no payload overrides at all.
+      overrides.setSkipped("a", true);
+      const overridesBefore = useFleetTargetOverridesStore.getState().payloadOverrides;
+
+      const unsub = subscribeFleetTargetOverridesPruning();
+      try {
+        useFleetArmingStore.getState().disarmId("a");
+        const state = useFleetTargetOverridesStore.getState();
+        expect(state.skippedIds.has("a")).toBe(false);
+        // payloadOverrides never changed — identity preserved, no spurious re-render.
+        expect(state.payloadOverrides).toBe(overridesBefore);
+      } finally {
+        unsub();
+      }
+    });
+
+    it("is a no-op when every override/skip id is still armed", () => {
+      const overrides = useFleetTargetOverridesStore.getState();
+      useFleetArmingStore.getState().armIds(["a", "b"]);
+      overrides.setPayloadOverride("a", "x");
+      overrides.setSkipped("b", true);
+
+      const unsub = subscribeFleetTargetOverridesPruning();
+      try {
+        const skippedBefore = useFleetTargetOverridesStore.getState().skippedIds;
+        const overridesBefore = useFleetTargetOverridesStore.getState().payloadOverrides;
+        // Arm a third pane — armedIds changes, but nothing needs pruning.
+        useFleetArmingStore.getState().armId("c");
+        const state = useFleetTargetOverridesStore.getState();
+        expect(state.skippedIds).toBe(skippedBefore);
+        expect(state.payloadOverrides).toBe(overridesBefore);
+      } finally {
+        unsub();
+      }
+    });
+
+    it("reconciles stale entries on initial registration (disarm while torn down)", () => {
+      const overrides = useFleetTargetOverridesStore.getState();
+      // Pane "a" is armed and "ghost" is not — simulating a pane disarmed while
+      // no subscription was registered. Both have entries.
+      useFleetArmingStore.getState().armIds(["a"]);
+      overrides.setPayloadOverride("a", "keep");
+      overrides.setPayloadOverride("ghost", "stale");
+      overrides.setSkipped("ghost", true);
+
+      const unsub = subscribeFleetTargetOverridesPruning();
+      try {
+        const state = useFleetTargetOverridesStore.getState();
+        expect(state.payloadOverrides["ghost"]).toBeUndefined();
+        expect(state.skippedIds.has("ghost")).toBe(false);
+        expect(state.payloadOverrides["a"]).toBe("keep");
+      } finally {
+        unsub();
+      }
+    });
+
+    it("clears stale entries on registration when nothing is armed", () => {
+      const overrides = useFleetTargetOverridesStore.getState();
+      overrides.setPayloadOverride("ghost", "stale");
+      overrides.setSkipped("ghost", true);
+
+      const unsub = subscribeFleetTargetOverridesPruning();
+      try {
+        const state = useFleetTargetOverridesStore.getState();
+        expect(state.payloadOverrides).toEqual({});
+        expect(state.skippedIds.size).toBe(0);
+      } finally {
+        unsub();
+      }
     });
   });
 });

--- a/src/store/fleetTargetOverridesStore.ts
+++ b/src/store/fleetTargetOverridesStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { useFleetArmingStore } from "./fleetArmingStore";
 
 /**
  * Ephemeral per-broadcast state for the fleet drafting popover: lets the
@@ -72,5 +73,76 @@ export function __resetFleetTargetOverridesStoreForTesting(): void {
   useFleetTargetOverridesStore.setState({
     payloadOverrides: {},
     skippedIds: new Set<string>(),
+  });
+}
+
+/**
+ * Per-target overrides pruning subscription. Wires `useFleetArmingStore`
+ * changes into this store so a pane that leaves the armed set (manual disarm,
+ * or auto-prune of a trashed/exited terminal) also loses any per-target payload
+ * override or skip flag it carried. `disarmId` only mutates the arming store,
+ * and none of the lifecycle-edge `clear()` calls fire when the drafting popover
+ * stays open — so without this reconciliation a disarmed-then-rearmed pane keeps
+ * a stale `skippedIds` entry and is silently excluded from the next broadcast
+ * (#9973), and `FleetDraftingPill`'s divergence badge shows ghost counts.
+ *
+ * Registered by `initStoreOrchestrator()` (not module scope) so the
+ * subscription is scoped to the renderer lifecycle and HMR-safe via the
+ * orchestrator's `DisposableStore` — mirrors `subscribeFleetArmingPanelPruning`.
+ *
+ * Runs an initial reconciliation pass before subscribing so entries that
+ * diverged from the armed set while the subscription was torn down (test
+ * destroy → mutate → re-init) get pruned on re-registration.
+ */
+export function subscribeFleetTargetOverridesPruning(): () => void {
+  function pruneAgainst(nextArmed: Set<string>): void {
+    const state = useFleetTargetOverridesStore.getState();
+    const { payloadOverrides, skippedIds } = state;
+
+    // Whole fleet drained — reset both fields in one shot rather than looping
+    // per id. Also the correct re-init behavior: stale entries left from a
+    // prior session are wiped when nothing is armed.
+    if (nextArmed.size === 0) {
+      if (skippedIds.size > 0 || Object.keys(payloadOverrides).length > 0) {
+        state.clear();
+      }
+      return;
+    }
+
+    // Per-pane removal — drop overrides/skips for ids no longer armed. Only
+    // allocate a replacement container when that field actually loses an entry,
+    // so subscribers watching the untouched field keep their ref-equality fast
+    // path (mirrors the identity-preserving updates in this store's actions).
+    let nextSkipped: Set<string> | null = null;
+    for (const id of skippedIds) {
+      if (!nextArmed.has(id)) {
+        if (!nextSkipped) nextSkipped = new Set(skippedIds);
+        nextSkipped.delete(id);
+      }
+    }
+
+    let nextOverrides: Record<string, string> | null = null;
+    for (const id of Object.keys(payloadOverrides)) {
+      if (!nextArmed.has(id)) {
+        if (!nextOverrides) nextOverrides = { ...payloadOverrides };
+        delete nextOverrides[id];
+      }
+    }
+
+    if (!nextSkipped && !nextOverrides) return;
+    const patch: Partial<FleetTargetOverridesState> = {};
+    if (nextSkipped) patch.skippedIds = nextSkipped;
+    if (nextOverrides) patch.payloadOverrides = nextOverrides;
+    useFleetTargetOverridesStore.setState(patch);
+  }
+
+  let prevArmed = useFleetArmingStore.getState().armedIds;
+  pruneAgainst(prevArmed);
+
+  return useFleetArmingStore.subscribe((state) => {
+    const nextArmed = state.armedIds;
+    if (prevArmed === nextArmed) return;
+    prevArmed = nextArmed;
+    pruneAgainst(nextArmed);
   });
 }

--- a/src/store/fleetTargetOverridesStore.ts
+++ b/src/store/fleetTargetOverridesStore.ts
@@ -37,7 +37,7 @@ export const useFleetTargetOverridesStore = create<FleetTargetOverridesState>((s
 
   clearPayloadOverride: (terminalId) => {
     set((state) => {
-      if (!(terminalId in state.payloadOverrides)) return state;
+      if (!Object.hasOwn(state.payloadOverrides, terminalId)) return state;
       const next = { ...state.payloadOverrides };
       delete next[terminalId];
       return { payloadOverrides: next };

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -6,6 +6,7 @@ import {
   persistMruList,
 } from "./worktreeStore";
 import { useFleetArmingStore, subscribeFleetArmingPanelPruning } from "./fleetArmingStore";
+import { subscribeFleetTargetOverridesPruning } from "./fleetTargetOverridesStore";
 import { useTerminalInputStore, unregisterInputController } from "./terminalInputStore";
 import { semanticAnalysisService } from "@/services/SemanticAnalysisService";
 import { useConsoleCaptureStore } from "./consoleCaptureStore";
@@ -322,6 +323,12 @@ export function initStoreOrchestrator(): () => void {
   //     deterministically (previously this was a module-scope subscription in
   //     `fleetArmingStore.ts`).
   disposables.add(toDisposable(subscribeFleetArmingPanelPruning()));
+
+  // 5b. Fleet per-target overrides pruning: drop a pane's payload override /
+  //     skip flag when it leaves the armed set, so a disarmed-then-rearmed pane
+  //     isn't silently excluded from the next broadcast by a stale skip (#9973).
+  //     Same orchestrator-scoped lifecycle as the arming pruning above.
+  disposables.add(toDisposable(subscribeFleetTargetOverridesPruning()));
 
   // 5. Availability → agent-settings re-normalization: installed/missing state
   //    is the input to `normalizeAgentSelection`, so re-run normalization any


### PR DESCRIPTION
## Summary

- When a pane was disarmed from a live fleet while the drafting popover stayed open, its entry lingered in `fleetTargetOverridesStore` (`skippedIds` / `payloadOverrides`) because `disarmId` only touches the arming store and no lifecycle-edge clear fired. Re-arming that pane before hitting Enter then silently excluded it from the broadcast, and `FleetDraftingPill` showed ghost divergence counts.
- Added `subscribeFleetTargetOverridesPruning()` to `fleetTargetOverridesStore`, modeled on the existing `subscribeFleetArmingPanelPruning` pattern. It subscribes to `useFleetArmingStore`, prunes `payloadOverrides` and `skippedIds` for any id no longer in `armedIds` (clearing both in one shot on a full drain), preserves field ref-identity when only one map changes, and runs an initial reconciliation pass on registration. Registered in `rendererStoreOrchestrator` so it's orchestrator-scoped, HMR/test-safe, and not module scope.
- No changes needed to `FleetDraftingPill` or `fleetEnterBroadcast` — divergence counts are derived from the store, and the Enter-press snapshot is correct once the store is clean. Also hardened `clearPayloadOverride` to use `Object.hasOwn`.

Resolves #9973

## Changes

- `src/store/fleetTargetOverridesStore.ts` — `subscribeFleetTargetOverridesPruning()` with initial reconciliation pass
- `src/store/rendererStoreOrchestrator.ts` — registers the pruning subscription
- `src/store/__tests__/fleetTargetOverridesStore.test.ts` — pruning-subscription unit tests (disarm-one, full-drain, ref-identity no-op, all-still-armed no-op, initial reconciliation, clear-on-registration-when-empty)
- `src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts` — #9973 regression (skip → disarm → re-arm → broadcast now delivers to the re-armed pane)

## Testing

Full local CI suite green: 32621 tests, typecheck, lint, format, and build all pass. Regression test covers the exact failure path from the issue.