### PR TITLE
perf(mcp): cache action manifest per pinned WebContents

### DIFF
--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -196,6 +196,7 @@ export class McpServerService {
       handleWaitUntilIdle: (rawArgs, signal, options) =>
         handleWaitUntilIdle(rawArgs, signal, options),
       getCachedManifest: () => this.bridge.getCachedManifest(),
+      getCachedManifestForWebContents: (id) => this.bridge.getCachedManifestForWebContents(id),
       clearCachedManifest: () => this.bridge.clearCache(),
       cleanupListeners: this.cleanupListeners,
       pendingManifests: this.pendingManifests,

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -13,6 +13,15 @@ vi.mock("../../../store.js", () => ({
   },
 }));
 
+// Mock electron so the suite loads without the Electron binary present (no
+// `node_modules/electron/path.txt`). httpLifecycle.ts and its transitive imports
+// only touch these at runtime — never in these unit tests — so stubs suffice.
+vi.mock("electron", () => ({
+  app: { getVersion: () => "0.0.0-test" },
+  webContents: { fromId: () => undefined },
+  ipcMain: { on: () => undefined, removeListener: () => undefined },
+}));
+
 import http from "node:http";
 import { EventEmitter } from "node:events";
 import { createHash } from "node:crypto";
@@ -496,6 +505,70 @@ describe("HttpLifecycle", () => {
       const deps = fakeDeps();
       const lc = new HttpLifecycle(deps);
       expect(() => lc.resetDenialCounts("")).toThrow(/Invalid sessionId/);
+    });
+  });
+
+  describe("buildSessionServerDeps — pinned manifest cache routing (#9887)", () => {
+    type CacheDeps = {
+      getCachedManifest: () => unknown[] | null;
+    };
+    const buildDeps = (lc: HttpLifecycle, sessionId: string): CacheDeps =>
+      (
+        lc as unknown as { buildSessionServerDeps: (id: string) => CacheDeps }
+      ).buildSessionServerDeps(sessionId);
+
+    it("routes a pinned session's getCachedManifest to its own per-WebContents cache, never the shared one", () => {
+      const deps = fakeDeps();
+      (deps.getCachedManifest as ReturnType<typeof vi.fn>).mockReturnValue([{ id: "shared" }]);
+      const perWc = vi.fn(() => [{ id: "pinned" }]);
+      deps.getCachedManifestForWebContents =
+        perWc as unknown as typeof deps.getCachedManifestForWebContents;
+      deps.sessionStore.sessionWebContentsMap.set("session-1", 101);
+      const lc = new HttpLifecycle(deps);
+
+      const result = buildDeps(lc, "session-1").getCachedManifest();
+
+      expect(result).toEqual([{ id: "pinned" }]);
+      expect(perWc).toHaveBeenCalledWith(101);
+      expect(deps.getCachedManifest).not.toHaveBeenCalled();
+    });
+
+    it("routes an unpinned session's getCachedManifest to the shared cache", () => {
+      const deps = fakeDeps();
+      (deps.getCachedManifest as ReturnType<typeof vi.fn>).mockReturnValue([{ id: "shared" }]);
+      const perWc = vi.fn(() => [{ id: "pinned" }]);
+      deps.getCachedManifestForWebContents =
+        perWc as unknown as typeof deps.getCachedManifestForWebContents;
+      // No sessionWebContentsMap entry → api-key/external session.
+      const lc = new HttpLifecycle(deps);
+
+      const result = buildDeps(lc, "session-1").getCachedManifest();
+
+      expect(result).toEqual([{ id: "shared" }]);
+      expect(perWc).not.toHaveBeenCalled();
+    });
+
+    it("a pinned session torn down mid-call stays pinned (fails closed), never flipping to the shared cache", () => {
+      const deps = fakeDeps();
+      (deps.getCachedManifest as ReturnType<typeof vi.fn>).mockReturnValue([{ id: "shared" }]);
+      // After teardown the per-WebContents cache is evicted → returns null.
+      const perWc = vi.fn(() => null);
+      deps.getCachedManifestForWebContents =
+        perWc as unknown as typeof deps.getCachedManifestForWebContents;
+      deps.sessionStore.sessionWebContentsMap.set("session-1", 101);
+      const lc = new HttpLifecycle(deps);
+      const sessionDeps = buildDeps(lc, "session-1");
+
+      // Simulate the pin being deleted (idle timeout / revoke) after deps build.
+      deps.sessionStore.sessionWebContentsMap.delete("session-1");
+
+      const result = sessionDeps.getCachedManifest();
+
+      // Build-time capture keeps it pinned → null (fail-closed), not the shared
+      // cache — the #7003 isolation invariant the fix protects.
+      expect(result).toBeNull();
+      expect(perWc).toHaveBeenCalledWith(101);
+      expect(deps.getCachedManifest).not.toHaveBeenCalled();
     });
   });
 

--- a/electron/services/mcp-server/__tests__/rendererBridge.test.ts
+++ b/electron/services/mcp-server/__tests__/rendererBridge.test.ts
@@ -250,6 +250,169 @@ describe("rendererBridge — per-session pinned dispatch (#7002)", () => {
   });
 });
 
+describe("rendererBridge — per-WebContents manifest cache (#9887)", () => {
+  let pendingManifests: Map<string, PendingRequest<ActionManifestEntry[]>>;
+  let pendingDispatches: Map<string, PendingRequest<DispatchEnvelope>>;
+  let bridge: ReturnType<typeof createRendererBridge>;
+
+  beforeEach(() => {
+    mockIpcMain.removeAllListeners();
+    mockWebContentsRegistry.clear();
+    pendingManifests = new Map();
+    pendingDispatches = new Map();
+    bridge = createRendererBridge(pendingManifests, pendingDispatches, () => null);
+    bridge.setupListeners([]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /**
+   * Wires `wc.send` to reply with a fixed manifest after a microtask, capturing
+   * each requestId so a test can choose to reply manually instead. Returns the
+   * list of captured requestIds (in send order).
+   */
+  function autoReplyManifest(
+    wc: FakeWebContents,
+    manifest: ActionManifestEntry[],
+    options?: { manual?: boolean }
+  ): string[] {
+    const requestIds: string[] = [];
+    wc.send.mockImplementation((channel: string, payload: { requestId: string }) => {
+      if (channel !== CHANNELS.MCP_SERVER_GET_MANIFEST_REQUEST) return;
+      requestIds.push(payload.requestId);
+      if (options?.manual) return;
+      queueMicrotask(() => {
+        mockIpcMain.emit(
+          CHANNELS.MCP_SERVER_GET_MANIFEST_RESPONSE,
+          { sender: { id: wc.id } },
+          { requestId: payload.requestId, manifest }
+        );
+      });
+    });
+    return requestIds;
+  }
+
+  it("coalesces concurrent requestManifestForWebContents calls onto one IPC send", async () => {
+    const wc = makeWebContents(111);
+    mockWebContentsRegistry.set(111, wc);
+    autoReplyManifest(wc, [{ id: "a" }] as ActionManifestEntry[]);
+
+    const [m1, m2] = await Promise.all([
+      bridge.requestManifestForWebContents(111),
+      bridge.requestManifestForWebContents(111),
+    ]);
+
+    expect(m1).toEqual([{ id: "a" }]);
+    expect(m2).toEqual([{ id: "a" }]);
+    // Singleflight: the second concurrent caller rode the first fetch.
+    expect(wc.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("populates the per-WebContents cache and isolates it per id — never crossing windows", async () => {
+    const wcA = makeWebContents(121);
+    const wcB = makeWebContents(122);
+    mockWebContentsRegistry.set(121, wcA);
+    mockWebContentsRegistry.set(122, wcB);
+    autoReplyManifest(wcA, [{ id: "from-A" }] as ActionManifestEntry[]);
+    autoReplyManifest(wcB, [{ id: "from-B" }] as ActionManifestEntry[]);
+
+    expect(bridge.getCachedManifestForWebContents(121)).toBeNull();
+
+    await bridge.requestManifestForWebContents(121);
+    await bridge.requestManifestForWebContents(122);
+
+    // Each id reads only its own window's manifest.
+    expect(bridge.getCachedManifestForWebContents(121)).toEqual([{ id: "from-A" }]);
+    expect(bridge.getCachedManifestForWebContents(122)).toEqual([{ id: "from-B" }]);
+    // The shared cache is never written by the pinned path.
+    expect(bridge.getCachedManifest()).toBeNull();
+  });
+
+  it("always fetches fresh — a warm cache never short-circuits a new request (tools/list freshness)", async () => {
+    const wc = makeWebContents(131);
+    mockWebContentsRegistry.set(131, wc);
+    let serial = 0;
+    wc.send.mockImplementation((channel: string, payload: { requestId: string }) => {
+      if (channel !== CHANNELS.MCP_SERVER_GET_MANIFEST_REQUEST) return;
+      const value = `v${++serial}`;
+      queueMicrotask(() => {
+        mockIpcMain.emit(
+          CHANNELS.MCP_SERVER_GET_MANIFEST_RESPONSE,
+          { sender: { id: 131 } },
+          { requestId: payload.requestId, manifest: [{ id: value }] }
+        );
+      });
+    });
+
+    const first = await bridge.requestManifestForWebContents(131);
+    const second = await bridge.requestManifestForWebContents(131);
+
+    // A resolved cache must NOT be returned — each sequential call re-fetches,
+    // so runtime action-set changes (plugin enable/disable) stay reflected.
+    expect(first).toEqual([{ id: "v1" }]);
+    expect(second).toEqual([{ id: "v2" }]);
+    expect(wc.send).toHaveBeenCalledTimes(2);
+    // The cache reflects the latest fetch for the lookup hot path.
+    expect(bridge.getCachedManifestForWebContents(131)).toEqual([{ id: "v2" }]);
+  });
+
+  it("evicts the cached manifest when the pinned WebContents is destroyed", async () => {
+    const wc = makeWebContents(141);
+    mockWebContentsRegistry.set(141, wc);
+    autoReplyManifest(wc, [{ id: "live" }] as ActionManifestEntry[]);
+
+    await bridge.requestManifestForWebContents(141);
+    expect(bridge.getCachedManifestForWebContents(141)).toEqual([{ id: "live" }]);
+
+    wc.triggerDestroyed();
+
+    expect(bridge.getCachedManifestForWebContents(141)).toBeNull();
+  });
+
+  it("clearCache drops all per-WebContents manifests", async () => {
+    const wc = makeWebContents(151);
+    mockWebContentsRegistry.set(151, wc);
+    autoReplyManifest(wc, [{ id: "cached" }] as ActionManifestEntry[]);
+
+    await bridge.requestManifestForWebContents(151);
+    expect(bridge.getCachedManifestForWebContents(151)).toEqual([{ id: "cached" }]);
+
+    bridge.clearCache();
+
+    expect(bridge.getCachedManifestForWebContents(151)).toBeNull();
+  });
+
+  it("resurrection guard: a fetch that resolves after clearCache does not repopulate the cache", async () => {
+    const wc = makeWebContents(161);
+    mockWebContentsRegistry.set(161, wc);
+    // Manual mode: capture the requestId, reply only when we choose.
+    const requestIds = autoReplyManifest(wc, [{ id: "stale" }] as ActionManifestEntry[], {
+      manual: true,
+    });
+
+    // Kick off a fetch that stays in flight.
+    const inflight = bridge.requestManifestForWebContents(161);
+    await Promise.resolve();
+    expect(requestIds).toHaveLength(1);
+
+    // The server clears all caches (stop/restart) while the fetch is pending.
+    bridge.clearCache();
+
+    // The original fetch now resolves late.
+    mockIpcMain.emit(
+      CHANNELS.MCP_SERVER_GET_MANIFEST_RESPONSE,
+      { sender: { id: 161 } },
+      { requestId: requestIds[0], manifest: [{ id: "stale" }] }
+    );
+    await inflight;
+
+    // The late resolve must NOT repopulate the cleared cache.
+    expect(bridge.getCachedManifestForWebContents(161)).toBeNull();
+  });
+});
+
 describe("rendererBridge — requesting-bearer identity passthrough (#9157)", () => {
   let pendingManifests: Map<string, PendingRequest<ActionManifestEntry[]>>;
   let pendingDispatches: Map<string, PendingRequest<DispatchEnvelope>>;

--- a/electron/services/mcp-server/__tests__/rendererBridge.test.ts
+++ b/electron/services/mcp-server/__tests__/rendererBridge.test.ts
@@ -53,6 +53,8 @@ interface FakeWebContents {
   once: ReturnType<typeof vi.fn>;
   removeListener: ReturnType<typeof vi.fn>;
   triggerDestroyed: () => void;
+  /** Live count of registered "destroyed" listeners (after cleanup removals). */
+  destroyedListenerCount: () => number;
 }
 
 function makeWebContents(
@@ -77,6 +79,7 @@ function makeWebContents(
       destroyedListeners.clear();
       for (const l of listeners) l();
     },
+    destroyedListenerCount: () => destroyedListeners.size,
   };
   return wc;
 }
@@ -410,6 +413,52 @@ describe("rendererBridge — per-WebContents manifest cache (#9887)", () => {
 
     // The late resolve must NOT repopulate the cleared cache.
     expect(bridge.getCachedManifestForWebContents(161)).toBeNull();
+  });
+
+  it("registers the teardown-eviction listener only once across repeated fetches", async () => {
+    const wc = makeWebContents(171);
+    mockWebContentsRegistry.set(171, wc);
+    autoReplyManifest(wc, [{ id: "x" }] as ActionManifestEntry[]);
+
+    // Three sequential fetches: each per-request destroyed listener is cleaned
+    // up on resolve, so only the single per-WebContents eviction listener
+    // should remain — the wired-id guard must not register a second one.
+    await bridge.requestManifestForWebContents(171);
+    await bridge.requestManifestForWebContents(171);
+    await bridge.requestManifestForWebContents(171);
+
+    expect(wc.destroyedListenerCount()).toBe(1);
+  });
+
+  it("rejects and caches nothing when the pinned view is destroyed mid-flight", async () => {
+    const wc = makeWebContents(181);
+    mockWebContentsRegistry.set(181, wc);
+    // Manual mode: the fetch stays in flight until we act.
+    autoReplyManifest(wc, [{ id: "never" }] as ActionManifestEntry[], { manual: true });
+
+    const inflight = bridge.requestManifestForWebContents(181);
+    await Promise.resolve();
+    wc.triggerDestroyed();
+
+    await expect(inflight).rejects.toThrow(/MCP renderer bridge destroyed/);
+    expect(bridge.getCachedManifestForWebContents(181)).toBeNull();
+  });
+
+  it("after clearCache, a fresh fetch repopulates the cache with the new manifest", async () => {
+    const wc = makeWebContents(191);
+    mockWebContentsRegistry.set(191, wc);
+    autoReplyManifest(wc, [{ id: "first" }] as ActionManifestEntry[]);
+
+    await bridge.requestManifestForWebContents(191);
+    bridge.clearCache();
+    expect(bridge.getCachedManifestForWebContents(191)).toBeNull();
+
+    // A legitimate subsequent fetch must still succeed and populate the cache —
+    // the resurrection guard only blocks stale writes, not new ones.
+    autoReplyManifest(wc, [{ id: "second" }] as ActionManifestEntry[]);
+    await bridge.requestManifestForWebContents(191);
+
+    expect(bridge.getCachedManifestForWebContents(191)).toEqual([{ id: "second" }]);
   });
 });
 

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -83,6 +83,14 @@ export interface HttpLifecycleDeps {
     options?: { maxTimeoutMs?: number }
   ) => Promise<import("./shared.js").WaitUntilIdleResult>;
   getCachedManifest: () => import("../../../shared/types/actions.js").ActionManifestEntry[] | null;
+  // Per-WebContents manifest cache read for pinned help sessions (#9887). Lets
+  // the pinned `getCachedManifest` closure return the session's own window's
+  // cached manifest instead of always re-fetching on every CallTool dispatch.
+  // Optional for backward-compat with test fixtures that don't wire help
+  // routing (mirrors `requestManifestForWebContents`).
+  getCachedManifestForWebContents?: (
+    id: number
+  ) => import("../../../shared/types/actions.js").ActionManifestEntry[] | null;
   clearCachedManifest: () => void;
   cleanupListeners: Array<() => void>;
   pendingManifests: Map<
@@ -1197,10 +1205,19 @@ export class HttpLifecycle {
 
     const getCachedManifest: import("./sessionServer.js").SessionServerDeps["getCachedManifest"] =
       () => {
-        // Pinned sessions never read the shared manifest cache — see
-        // `requestManifestForWebContents` doc in rendererBridge.ts.
-        if (this.deps.sessionStore.sessionWebContentsMap.has(sessionId)) {
-          return null;
+        // Pinned sessions never read the shared manifest cache (it could serve
+        // another window's tool surface). Instead they read a per-WebContents
+        // cache keyed by the pinned id (#9887), so the per-call
+        // `lookupManifestEntry` hot path hits a warm cache rather than
+        // re-fetching the full manifest on every dispatch — while still never
+        // crossing windows. Falls back to `null` (fail-closed) when no
+        // per-WebContents cache is wired or the id isn't cached yet, exactly as
+        // before. The map read happens synchronously here (no await between the
+        // pin lookup and the cache read), so a session torn down mid-call can't
+        // flip from pinned to unpinned and leak the shared cache.
+        const id = this.deps.sessionStore.sessionWebContentsMap.get(sessionId);
+        if (id !== undefined) {
+          return this.deps.getCachedManifestForWebContents?.(id) ?? null;
         }
         return this.deps.getCachedManifest();
       };

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -1170,6 +1170,12 @@ export class HttpLifecycle {
     // not the MCP transport id `sessionId` — passing the transport id there
     // always missed, which broke same-turn coalescing and turnId stamping.
     const helpSessionId = this.deps.sessionStore.sessionHelpIdMap.get(sessionId) ?? null;
+    // Snapshot the pin at build time (set at handshake before this runs, and
+    // only ever deleted on teardown — never re-pointed). Capturing it makes the
+    // `getCachedManifest` closure below read strictly this session's own
+    // per-WebContents cache, so a session torn down mid-call can never flip to
+    // the shared cache and leak another window's tool surface (#7003 / #9887).
+    const pinnedWebContentsId = this.deps.sessionStore.sessionWebContentsMap.get(sessionId) ?? null;
 
     const requestManifest: import("./sessionServer.js").SessionServerDeps["requestManifest"] =
       () => {
@@ -1207,17 +1213,14 @@ export class HttpLifecycle {
       () => {
         // Pinned sessions never read the shared manifest cache (it could serve
         // another window's tool surface). Instead they read a per-WebContents
-        // cache keyed by the pinned id (#9887), so the per-call
-        // `lookupManifestEntry` hot path hits a warm cache rather than
+        // cache keyed by the build-time-captured pinned id (#9887), so the
+        // per-call `lookupManifestEntry` hot path hits a warm cache rather than
         // re-fetching the full manifest on every dispatch — while still never
-        // crossing windows. Falls back to `null` (fail-closed) when no
-        // per-WebContents cache is wired or the id isn't cached yet, exactly as
-        // before. The map read happens synchronously here (no await between the
-        // pin lookup and the cache read), so a session torn down mid-call can't
-        // flip from pinned to unpinned and leak the shared cache.
-        const id = this.deps.sessionStore.sessionWebContentsMap.get(sessionId);
-        if (id !== undefined) {
-          return this.deps.getCachedManifestForWebContents?.(id) ?? null;
+        // crossing windows. Reading the captured id (not a live map lookup)
+        // means a session torn down mid-call stays pinned here and fails closed
+        // to `null` (evicted cache) rather than flipping to the shared cache.
+        if (pinnedWebContentsId !== null) {
+          return this.deps.getCachedManifestForWebContents?.(pinnedWebContentsId) ?? null;
         }
         return this.deps.getCachedManifest();
       };

--- a/electron/services/mcp-server/rendererBridge.ts
+++ b/electron/services/mcp-server/rendererBridge.ts
@@ -28,6 +28,28 @@ export function createRendererBridge(
 ) {
   let cachedManifest: ActionManifestEntry[] | null = null;
 
+  // Per-WebContents manifest cache for pinned help sessions (#9887). The shared
+  // `cachedManifest` is bypassed for pinned routing (#7002) so window A's
+  // manifest can never be served to a session pinned to window B — but with no
+  // replacement, every CallTool dispatch re-fetched the full ~287-entry
+  // manifest over IPC (lookupManifestEntry in sessionServer.ts). These per-id
+  // maps restore a cache while keeping the cross-window isolation: each entry
+  // is keyed strictly by `webContentsId`, so a pinned session only ever reads
+  // its own window's manifest. The manifest is the full, tier-independent
+  // action list (tier filtering happens server-side), so it stays valid for the
+  // view's lifetime — invalidation is by WebContents teardown and server
+  // stop/restart only, not by tier elevation/decay.
+  const perWebContentsCache = new Map<number, ActionManifestEntry[]>();
+  // In-flight fetches, for singleflight coalescing of concurrent callers. This
+  // is read-only for freshness: callers never short-circuit on the resolved
+  // `perWebContentsCache`, only on a live in-flight promise, so a pinned
+  // `tools/list` always reflects runtime action-set changes (plugin
+  // enable/disable) exactly as the unpinned shared path does.
+  const perWebContentsInflight = new Map<number, Promise<ActionManifestEntry[]>>();
+  // WebContents ids that already have a teardown-eviction listener wired, so we
+  // never double-register one across repeated fetches or a server restart.
+  const perWebContentsEvictionWired = new Set<number>();
+
   function getActiveProjectWebContents(): Electron.WebContents {
     const registry = getRegistry();
     if (registry) {
@@ -226,20 +248,69 @@ export function createRendererBridge(
     );
   }
 
+  /** Evict every cached manifest reference for a torn-down WebContents. */
+  function evictWebContentsManifest(id: number): void {
+    perWebContentsCache.delete(id);
+    perWebContentsInflight.delete(id);
+  }
+
+  /**
+   * Wire a one-shot teardown listener that drops the pinned view's cached
+   * manifest when its WebContents is destroyed (LRU eviction, window close).
+   * Registered once per id — `perWebContentsEvictionWired` guards against
+   * double-registration across repeated fetches and survives a server restart
+   * (the listener is still live, so `clearCache()` leaves the set intact).
+   */
+  function ensureManifestEviction(id: number): void {
+    if (perWebContentsEvictionWired.has(id)) return;
+    const wc = electronWebContents.fromId(id);
+    if (!wc || wc.isDestroyed()) return;
+    perWebContentsEvictionWired.add(id);
+    wc.once("destroyed", () => {
+      evictWebContentsManifest(id);
+      perWebContentsEvictionWired.delete(id);
+    });
+  }
+
   /**
    * Manifest fetch pinned to a specific renderer WebContents (per-session
-   * routing for #7002). Bypasses `cachedManifest` because that cache is
-   * shared across all callers — caching window A's manifest and serving it
-   * to a session pinned to window B would re-introduce the cross-window
-   * leak this routing is meant to prevent.
+   * routing for #7002). Writes a per-id cache (#9887) — keyed by
+   * `webContentsId` so a session pinned to window B never reads window A's
+   * manifest, preserving the isolation the shared `cachedManifest` bypass was
+   * meant to protect. Concurrent callers coalesce onto one in-flight fetch, but
+   * a fully resolved cache never short-circuits a new call: each invocation
+   * still fetches fresh (mirroring the unpinned `requestManifest`) so a pinned
+   * `tools/list` reflects runtime action-set changes. The cache it populates is
+   * read back by `getCachedManifestForWebContents`, which is what the per-call
+   * `lookupManifestEntry` hot path consults to avoid re-fetching every dispatch.
    */
   function requestManifestForWebContents(id: number): Promise<ActionManifestEntry[]> {
-    return sendManifestRequest(
+    const inflight = perWebContentsInflight.get(id);
+    if (inflight) return inflight;
+
+    const fetchPromise = sendManifestRequest(
       () => getPinnedWebContents(id),
-      () => {
-        // Intentionally do not write the shared cachedManifest.
+      (manifest) => {
+        // Resurrection guard (#7554): only publish to the cache if this fetch
+        // is still the live in-flight request for the id. A view destroyed (or
+        // a `clearCache()`) mid-flight drops the inflight entry, so a late
+        // resolve must not repopulate a dead/cleared id.
+        if (perWebContentsInflight.get(id) === fetchPromise) {
+          perWebContentsCache.set(id, manifest);
+          perWebContentsInflight.delete(id);
+        }
       }
     );
+    perWebContentsInflight.set(id, fetchPromise);
+    // Drop the inflight marker on failure so the next call retries — never cache
+    // errors. Identity-guarded so a stale rejection can't evict a newer fetch.
+    fetchPromise.catch(() => {
+      if (perWebContentsInflight.get(id) === fetchPromise) {
+        perWebContentsInflight.delete(id);
+      }
+    });
+    ensureManifestEviction(id);
+    return fetchPromise;
   }
 
   /**
@@ -333,8 +404,18 @@ export function createRendererBridge(
     requestManifestForWebContents,
     dispatchActionForWebContents,
     getCachedManifest: () => cachedManifest,
+    getCachedManifestForWebContents: (id: number): ActionManifestEntry[] | null =>
+      perWebContentsCache.get(id) ?? null,
     clearCache: () => {
       cachedManifest = null;
+      // Drop all per-WebContents manifest knowledge in lockstep (#9887) so a
+      // server stop/restart can't leave a stale pinned manifest alive. The
+      // teardown-eviction listeners stay registered (they self-remove on real
+      // WebContents destruction and only ever evict their own id), so
+      // `perWebContentsEvictionWired` is deliberately left intact to avoid
+      // double-registering on the next fetch.
+      perWebContentsCache.clear();
+      perWebContentsInflight.clear();
     },
   };
 }

--- a/electron/services/mcp-server/rendererBridge.ts
+++ b/electron/services/mcp-server/rendererBridge.ts
@@ -44,8 +44,15 @@ export function createRendererBridge(
   // is read-only for freshness: callers never short-circuit on the resolved
   // `perWebContentsCache`, only on a live in-flight promise, so a pinned
   // `tools/list` always reflects runtime action-set changes (plugin
-  // enable/disable) exactly as the unpinned shared path does.
-  const perWebContentsInflight = new Map<number, Promise<ActionManifestEntry[]>>();
+  // enable/disable) exactly as the unpinned shared path does. Each entry pairs
+  // the coalesced promise with a stable identity `token`; the resurrection
+  // guard compares tokens (not the promise itself) so it never reads a
+  // not-yet-assigned `const` and stays correct even if a fetch were to resolve
+  // synchronously.
+  const perWebContentsInflight = new Map<
+    number,
+    { token: object; promise: Promise<ActionManifestEntry[]> }
+  >();
   // WebContents ids that already have a teardown-eviction listener wired, so we
   // never double-register one across repeated fetches or a server restart.
   const perWebContentsEvictionWired = new Set<number>();
@@ -286,8 +293,11 @@ export function createRendererBridge(
    */
   function requestManifestForWebContents(id: number): Promise<ActionManifestEntry[]> {
     const inflight = perWebContentsInflight.get(id);
-    if (inflight) return inflight;
+    if (inflight) return inflight.promise;
 
+    // Stable identity for this fetch, created before the request so the
+    // resurrection guard never dereferences a not-yet-assigned binding.
+    const token: object = {};
     const fetchPromise = sendManifestRequest(
       () => getPinnedWebContents(id),
       (manifest) => {
@@ -295,17 +305,17 @@ export function createRendererBridge(
         // is still the live in-flight request for the id. A view destroyed (or
         // a `clearCache()`) mid-flight drops the inflight entry, so a late
         // resolve must not repopulate a dead/cleared id.
-        if (perWebContentsInflight.get(id) === fetchPromise) {
+        if (perWebContentsInflight.get(id)?.token === token) {
           perWebContentsCache.set(id, manifest);
           perWebContentsInflight.delete(id);
         }
       }
     );
-    perWebContentsInflight.set(id, fetchPromise);
+    perWebContentsInflight.set(id, { token, promise: fetchPromise });
     // Drop the inflight marker on failure so the next call retries — never cache
     // errors. Identity-guarded so a stale rejection can't evict a newer fetch.
     fetchPromise.catch(() => {
-      if (perWebContentsInflight.get(id) === fetchPromise) {
+      if (perWebContentsInflight.get(id)?.token === token) {
         perWebContentsInflight.delete(id);
       }
     });


### PR DESCRIPTION
## Summary

- Pinned MCP sessions (Daintree Assistant, #7002) had no per-WebContents manifest cache — `getCachedManifest` returned null on every `CallTool` dispatch, triggering a full IPC re-fetch of the ~287-entry action manifest each time, roughly doubling latency on the hot path the user watches in real time.
- Adds a `resolvedCache` map and a singleflight `inflight` map to `rendererBridge`, both keyed by `webContentsId`. `requestManifestForWebContents` now populates the cache on resolve (with an identity-token resurrection guard) and coalesces concurrent in-flight fetches, but never short-circuits the `tools/list` call itself — so runtime action-set changes (plugin enable/disable) still land on the next call, matching the unpinned path.
- The pinned `getCachedManifest` closure captures its `webContentsId` at build time, so a torn-down session fails closed rather than accidentally reading the shared cache. Eviction fires on `WebContents` teardown and atomically on `clearCache` (server stop/restart).

Resolves #9887

## Changes

- `rendererBridge.ts`: per-`webContentsId` resolved-cache + singleflight inflight maps; `getCachedManifest` override on pinned sessions reads the per-id cache; eviction on teardown and `clearCache`; single listener registration guard
- `httpLifecycle.ts`: wires `webContentsId` through to `getCachedManifest` for pinned sessions; falls back to shared cache for unpinned; returns null for torn-down sessions
- `McpServerService.ts`: minor plumbing to surface `webContentsId` on pinned session context

## Testing

New unit tests in `rendererBridge.test.ts` cover singleflight coalescing, per-id isolation, cache freshness (no stale short-circuit), teardown eviction, single listener registration, destroyed-mid-flight handling, `clearCache` atomicity, and the resurrection guard. New tests in `httpLifecycle.test.ts` verify pinned/unpinned/torn-down `getCachedManifest` routing — electron is mocked so the suite runs without the binary. All existing tests pass.