### PR TITLE
fix(dock): keep panel subtree mounted across popover open/close (#9927)

### DIFF
--- a/src/components/Layout/DockPanelOffscreenContainer.tsx
+++ b/src/components/Layout/DockPanelOffscreenContainer.tsx
@@ -15,15 +15,16 @@ interface DockPanelOffscreenContainerProps {
 }
 
 export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenContainerProps) {
-  // Track portal targets (popover containers) for each terminal
-  const [portalTargets, setPortalTargets] = useState<Map<string, HTMLElement>>(new Map());
-  // Track offscreen slots (stable DOM elements in the hidden container)
-  const offscreenSlotsRef = useRef<Map<string, HTMLElement>>(new Map());
+  // One stable wrapper <div> per dock panel. Each wrapper is created once and
+  // is the permanent createPortal container for that panel — React never sees
+  // it change identity, so opening/closing a popover (or switching tabs) never
+  // unmounts the panel subtree. The wrapper lives in the offscreen container
+  // when parked and is imperatively relocated into the popover via moveBefore.
+  const wrappersRef = useRef<Map<string, HTMLElement>>(new Map());
   const offscreenContainerRef = useRef<HTMLDivElement>(null);
-  const [, forceUpdate] = useState(0);
   // Mirror into state so JSX doesn't read the ref during render (React Compiler).
   // The ref remains the authoritative source; state snapshots it for render.
-  const [offscreenSlots, setOffscreenSlots] = useState<Map<string, HTMLElement>>(() => new Map());
+  const [wrappers, setWrappers] = useState<Map<string, HTMLElement>>(() => new Map());
 
   const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
   const activeDockTerminalId = usePanelStore((s) => s.activeDockTerminalId);
@@ -106,80 +107,91 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
     [getPanelGroup, createTabGroup, addPanelToGroup, deleteTabGroup, addPanel, setActiveTab]
   );
 
-  // Create offscreen slots eagerly after container mounts
-  // This ensures slots exist before terminals try to portal to them
+  // Create the stable wrapper for each panel eagerly after the container mounts,
+  // so the wrapper exists (and createPortal can target it) before a popover
+  // tries to relocate it. Wrappers stay parked in the offscreen container until
+  // a popover opens.
   useLayoutEffect(() => {
     if (!offscreenContainerRef.current) return;
 
     const container = offscreenContainerRef.current;
     const currentIds = new Set(dockTerminals.map((t) => t.id));
+    let changed = false;
 
-    // Create slots for new terminals
+    // Create wrappers for new terminals
     for (const terminal of dockTerminals) {
-      if (!offscreenSlotsRef.current.has(terminal.id)) {
-        const slot = document.createElement("div");
-        slot.setAttribute("data-offscreen-slot", terminal.id);
-        slot.className = "offscreen-panel-slot";
-        slot.style.width = "100%";
-        slot.style.height = "100%";
-        container.appendChild(slot);
-        offscreenSlotsRef.current.set(terminal.id, slot);
+      if (!wrappersRef.current.has(terminal.id)) {
+        const wrapper = document.createElement("div");
+        wrapper.setAttribute("data-dock-panel-wrapper", terminal.id);
+        wrapper.style.width = "100%";
+        wrapper.style.height = "100%";
+        wrapper.style.display = "flex";
+        wrapper.style.flexDirection = "column";
+        container.appendChild(wrapper);
+        wrappersRef.current.set(terminal.id, wrapper);
+        changed = true;
       }
     }
 
-    // Remove slots for removed terminals
-    for (const [id, slot] of offscreenSlotsRef.current) {
+    // Remove wrappers for removed terminals (the portal content for them has
+    // already been unmounted by React, so the wrapper is empty).
+    for (const [id, wrapper] of wrappersRef.current) {
       if (!currentIds.has(id)) {
-        slot.remove();
-        offscreenSlotsRef.current.delete(id);
+        wrapper.remove();
+        wrappersRef.current.delete(id);
+        changed = true;
       }
     }
 
-    // Force update to ensure portals render with new slots
-    forceUpdate((n) => n + 1);
-    setOffscreenSlots(new Map(offscreenSlotsRef.current));
+    if (changed) {
+      setWrappers(new Map(wrappersRef.current));
+    }
   }, [dockTerminals]);
 
-  // Cleanup portal targets for removed terminals
-  useEffect(() => {
-    const currentIds = new Set(dockTerminals.map((t) => t.id));
-    setPortalTargets((prev) => {
-      let changed = false;
-      const next = new Map(prev);
-      for (const id of prev.keys()) {
-        if (!currentIds.has(id)) {
-          next.delete(id);
-          changed = true;
-        }
-      }
-      return changed ? next : prev;
-    });
-  }, [dockTerminals]);
+  // Relocate a panel's stable wrapper into the popover container (or back to the
+  // offscreen parking container when destination is null). Uses moveBefore so
+  // the move is atomic — xterm's canvas/WebGL context and focus survive without
+  // a React remount. Guards both nodes' connectedness because moveBefore throws
+  // HierarchyRequestError on disconnected/cross-document moves (e.g. while Radix
+  // is tearing down PopoverContent); appendChild is the reconnecting fallback.
+  const moveToDestination = useCallback((panelId: string, destination: HTMLElement | null) => {
+    const wrapper = wrappersRef.current.get(panelId);
+    if (!wrapper) return;
+    const dest = destination ?? offscreenContainerRef.current;
+    if (!dest || wrapper.parentElement === dest) return;
 
-  const portalTarget = useCallback((terminalId: string, target: HTMLElement | null) => {
-    setPortalTargets((prev) => {
-      const prevTarget = prev.get(terminalId);
-      if (prevTarget === target) return prev;
+    // Capture focus so we can restore it on the appendChild fallback path
+    // (moveBefore preserves focus itself; appendChild does not) and to work
+    // around the Cr148 quirk where moving a focused field drops it.
+    const active = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const hadFocus = !!active && wrapper.contains(active);
 
-      const next = new Map(prev);
-      if (target) {
-        next.set(terminalId, target);
-      } else {
-        next.delete(terminalId);
+    if (wrapper.isConnected && dest.isConnected && typeof dest.moveBefore === "function") {
+      try {
+        dest.moveBefore(wrapper, null);
+      } catch {
+        dest.appendChild(wrapper);
       }
-      return next;
-    });
+    } else {
+      dest.appendChild(wrapper);
+    }
+
+    if (hadFocus && active && active.isConnected && document.activeElement !== active) {
+      active.focus();
+    }
   }, []);
 
   const contextValue: DockPanelContextValue = {
-    portalTarget,
+    moveToDestination,
   };
 
   return (
     <DockPanelContext.Provider value={contextValue}>
       {children}
 
-      {/* Hidden container for dock panels - keeps them mounted */}
+      {/* Hidden parking container for dock panel wrappers. Each panel's stable
+          wrapper lives here while its popover is closed and is moved into the
+          popover (via moveBefore) on open — never unmounted. */}
       {/* IMPORTANT: Size must be large enough for xterm to initialize (MIN_CONTAINER_SIZE = 50px) */}
       {/* content-visibility:hidden skips render work while preserving layout geometry */}
       <div
@@ -200,15 +212,15 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
         aria-hidden="true"
       />
 
-      {/* Render panels via portal - ALWAYS use portal to avoid unmount/remount */}
+      {/* Render each panel into its stable wrapper. The wrapper is always the
+          portal container — its DOM position changes (offscreen ↔ popover) via
+          moveBefore, but its identity never does, so React never remounts. */}
       {dockTerminals.map((terminal) => {
-        // Use popover target if available, otherwise use offscreen slot
-        const target = portalTargets.get(terminal.id);
-        const offscreenSlot = offscreenSlots.get(terminal.id);
-        const portalContainer = target || offscreenSlot;
+        const wrapper = wrappers.get(terminal.id);
 
-        // Skip if no container yet (will render on next update after slots are created)
-        if (!portalContainer) {
+        // Skip until the wrapper exists (created in the layout effect; renders
+        // on the next update once setWrappers commits).
+        if (!wrapper) {
           return null;
         }
 
@@ -246,8 +258,10 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
           </DockPopoverChildProvider>
         );
 
-        // Always use createPortal with same key to prevent unmount/remount
-        return createPortal(content, portalContainer, `dock-panel-${terminal.id}`);
+        // Portal into the stable wrapper. Because the wrapper identity never
+        // changes, React keeps the same fiber across open/close — the wrapper is
+        // simply relocated in the DOM by moveToDestination.
+        return createPortal(content, wrapper, `dock-panel-${terminal.id}`);
       })}
     </DockPanelContext.Provider>
   );

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -103,6 +103,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   const activePanel = useMemo(() => {
     return panels.find((p) => p.id === activeTabId) ?? panels[0];
   }, [panels, activeTabId]);
+  const activePanelId = activePanel?.id;
 
   // Derive isOpen from store state - open if ANY panel in this group is active
   const isOpen = panels.some((p) => p.id === activeDockTerminalId);
@@ -125,7 +126,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
     };
   }, [sidebarHidden]);
 
-  const portalTarget = useDockPanelPortal();
+  const moveToDestination = useDockPanelPortal();
   const portalContainerElementRef = useRef<HTMLDivElement | null>(null);
   const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(null);
 
@@ -134,51 +135,19 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
     setPortalContainer(node);
   }, []);
 
-  // True once the active panel's terminal host has migrated into the popover
-  // portal. Keyed to the active panel id and matched by `data-dock-panel-id`
-  // (not a bare child count) so a tab switch — which swaps the portal child
-  // rather than adding one — re-detects the new panel before focusing it.
-  const [migrated, setMigrated] = useState(false);
-
+  // Toggle buffering based on popover open state. The active panel's stable
+  // wrapper is relocated into this popover's container on open (and parked
+  // offscreen on close / tab switch) without a React remount. One layout pass
+  // after the move settles is enough for `checkVisibility()` inside `fit()` to
+  // flip — no retry loop needed.
   useEffect(() => {
-    const activeId = activePanel?.id;
-    if (!isOpen || !portalContainer || !activeId) {
-      setMigrated(false);
-      return;
-    }
-    const isPresent = () =>
-      Array.from(portalContainer.querySelectorAll("[data-dock-panel-id]")).some(
-        (el) => el.getAttribute("data-dock-panel-id") === activeId
-      );
-    if (isPresent()) {
-      setMigrated(true);
-      return;
-    }
-    setMigrated(false);
-    const observer = new MutationObserver(() => {
-      if (isPresent()) {
-        setMigrated(true);
-        observer.disconnect();
-      }
-    });
-    observer.observe(portalContainer, { childList: true, subtree: true });
-    return () => observer.disconnect();
-  }, [isOpen, portalContainer, activePanel?.id]);
-
-  // Toggle buffering based on popover open state. The terminal stays mounted
-  // in DockPanelOffscreenContainer across open/close cycles; the popover only
-  // shuttles the host element into a visible container. One layout pass after
-  // the portal-target ref settles is enough for `checkVisibility()` inside
-  // `fit()` to flip — no retry loop needed.
-  useEffect(() => {
-    if (!activePanel) return;
-    const activeId = activePanel.id;
+    if (!activePanelId) return;
 
     if (!isOpen) {
       try {
-        terminalInstanceService.applyRendererPolicy(activeId, TerminalRefreshTier.BACKGROUND);
+        terminalInstanceService.applyRendererPolicy(activePanelId, TerminalRefreshTier.BACKGROUND);
       } catch (error) {
-        console.warn(`Failed to apply dock state for panel ${activeId}:`, error);
+        console.warn(`Failed to apply dock state for panel ${activePanelId}:`, error);
       }
       return;
     }
@@ -187,18 +156,18 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
 
     const rafId = requestAnimationFrame(() => {
       try {
-        const dims = terminalInstanceService.fit(activeId);
+        const dims = terminalInstanceService.fit(activePanelId);
         if (!dims) return;
-        terminalInstanceService.applyRendererPolicy(activeId, TerminalRefreshTier.VISIBLE);
+        terminalInstanceService.applyRendererPolicy(activePanelId, TerminalRefreshTier.VISIBLE);
       } catch (error) {
-        console.warn(`Failed to apply dock state for panel ${activeId}:`, error);
+        console.warn(`Failed to apply dock state for panel ${activePanelId}:`, error);
       }
     });
 
     return () => {
       cancelAnimationFrame(rafId);
     };
-  }, [isOpen, portalContainer, activePanel]);
+  }, [isOpen, portalContainer, activePanelId]);
 
   // Auto-close popover when drag starts for any panel in this group
   useDndMonitor({
@@ -209,32 +178,33 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
     },
   });
 
-  // Register/unregister portal target for active panel
+  // Move the active panel's stable wrapper into this popover on open (and park
+  // it offscreen on close or tab switch). Scalar `activePanelId` dep — not the
+  // activePanel object — so agent-state polling that mints a new panel object
+  // doesn't re-fire the move.
   useEffect(() => {
-    if (isOpen && portalContainer && activePanel) {
-      portalTarget(activePanel.id, portalContainer);
-    } else if (activePanel) {
-      portalTarget(activePanel.id, null);
+    if (!activePanelId) return;
+    if (isOpen && portalContainer) {
+      moveToDestination(activePanelId, portalContainer);
+    } else {
+      moveToDestination(activePanelId, null);
     }
 
     return () => {
-      if (activePanel) {
-        portalTarget(activePanel.id, null);
-      }
+      moveToDestination(activePanelId, null);
     };
-  }, [isOpen, portalContainer, activePanel, portalTarget]);
+  }, [isOpen, portalContainer, activePanelId, moveToDestination]);
 
-  // Focus the active panel's terminal once it has migrated into the popover
-  // portal — never the offscreen host. Honors focus-preserve / hybrid-input.
-  // Scalar deps (id / focusPolicy / isAgent value), not the activePanel object —
-  // so agent-state polling that mints a new panel object doesn't re-fire focus
-  // and yank it back into the terminal while the popover is open.
-  const activePanelId = activePanel?.id;
+  // Focus the active panel's terminal once the popover is open and its wrapper
+  // has been moved in (the move effect above runs first). Honors focus-preserve
+  // / hybrid-input. Scalar deps (id / focusPolicy / isAgent value), not the
+  // activePanel object — so agent-state polling that mints a new panel object
+  // doesn't re-fire focus and yank it back into the terminal while open.
   const activeFocusPolicy = activePanel?.focusPolicy;
   const activeIsAgent = activePanel ? deriveTerminalChrome(activePanel).isAgent : false;
 
   useEffect(() => {
-    if (!isOpen || !migrated || !activePanelId) return;
+    if (!isOpen || !portalContainer || !activePanelId) return;
     if (activeFocusPolicy === "preserve") return;
 
     const focusTarget = getTerminalFocusTarget({
@@ -248,7 +218,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
     terminalInstanceService.focus(activePanelId);
   }, [
     isOpen,
-    migrated,
+    portalContainer,
     activePanelId,
     activeFocusPolicy,
     activeIsAgent,
@@ -625,9 +595,8 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
           onEscapeKeyDown={(e) => handleDockEscapeKeyDown(e, portalContainerElementRef.current)}
           onFocusOutside={handleDockFocusOutside}
           onOpenAutoFocus={(event) => {
-            // Block Radix's own auto-focus; we focus the terminal once it has
-            // migrated into the portal (see the migration-focus effect), not on
-            // a fixed timer that races a cold xterm mount.
+            // Block Radix's own auto-focus; we focus the active tab's terminal
+            // ourselves once its wrapper has been moved in (see the focus effect).
             event.preventDefault();
           }}
         >

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -71,7 +71,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
     };
   }, [sidebarHidden]);
 
-  const portalTarget = useDockPanelPortal();
+  const moveToDestination = useDockPanelPortal();
   const portalContainerElementRef = useRef<HTMLDivElement | null>(null);
   const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(null);
 
@@ -81,44 +81,10 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
     setPortalContainer(node);
   }, []);
 
-  // True once this terminal's host has actually migrated into the popover portal
-  // (its `data-dock-panel-id` node is a live DOM descendant of PopoverContent).
-  // The terminal is rendered offscreen and portaled in asynchronously, so we
-  // focus it off this signal — observing the specific node's insertion — rather
-  // than a fixed timer that races a cold xterm mount. Matching the panel id (not
-  // a bare child count) keeps the signal correct when the portal child is
-  // swapped rather than added.
-  const [migrated, setMigrated] = useState(false);
-
-  useEffect(() => {
-    if (!isOpen || !portalContainer) {
-      setMigrated(false);
-      return;
-    }
-    const isPresent = () =>
-      Array.from(portalContainer.querySelectorAll("[data-dock-panel-id]")).some(
-        (el) => el.getAttribute("data-dock-panel-id") === terminal.id
-      );
-    if (isPresent()) {
-      setMigrated(true);
-      return;
-    }
-    setMigrated(false);
-    const observer = new MutationObserver(() => {
-      if (isPresent()) {
-        setMigrated(true);
-        observer.disconnect();
-      }
-    });
-    observer.observe(portalContainer, { childList: true, subtree: true });
-    return () => observer.disconnect();
-  }, [isOpen, portalContainer, terminal.id]);
-
-  // Toggle buffering based on popover open state. The terminal stays mounted
-  // in DockPanelOffscreenContainer across open/close cycles; the popover only
-  // shuttles the host element into a visible container. One layout pass after
-  // the portal-target ref settles is enough for `checkVisibility()` inside
-  // `fit()` to flip — no retry loop needed.
+  // Toggle buffering based on popover open state. The terminal's stable wrapper
+  // is relocated into this popover's container on open (and parked offscreen on
+  // close) without a React remount. One layout pass after the move settles is
+  // enough for `checkVisibility()` inside `fit()` to flip — no retry loop needed.
   useEffect(() => {
     if (!isOpen) {
       try {
@@ -155,18 +121,20 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
     },
   });
 
-  // Register/unregister portal target when popover opens and container is available
+  // Move the panel's stable wrapper into this popover when it opens and back to
+  // the offscreen parking container when it closes. The move is synchronous and
+  // preserves the subtree (no remount), so a tab/popover toggle is cheap.
   useEffect(() => {
     if (isOpen && portalContainer) {
-      portalTarget(terminal.id, portalContainer);
+      moveToDestination(terminal.id, portalContainer);
     } else {
-      portalTarget(terminal.id, null);
+      moveToDestination(terminal.id, null);
     }
 
     return () => {
-      portalTarget(terminal.id, null);
+      moveToDestination(terminal.id, null);
     };
-  }, [isOpen, portalContainer, terminal.id, portalTarget]);
+  }, [isOpen, portalContainer, terminal.id, moveToDestination]);
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
@@ -266,11 +234,12 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
     ]
   );
 
-  // Focus the terminal once it has migrated into the popover portal — keyboard
-  // focus lands on a live DOM descendant of PopoverContent, never the offscreen
-  // host. Honors the focus-preserve and hybrid-input skips (see #6959).
+  // Focus the terminal once the popover is open and its wrapper has been moved
+  // in. The move effect above runs first (effects fire in declaration order),
+  // so by the time this runs the terminal host is a live descendant of
+  // PopoverContent. Honors the focus-preserve and hybrid-input skips (see #6959).
   useEffect(() => {
-    if (!isOpen || !migrated) return;
+    if (!isOpen || !portalContainer) return;
     if (terminal.focusPolicy === "preserve") return;
 
     const focusTarget = getTerminalFocusTarget({
@@ -284,7 +253,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
     terminalInstanceService.focus(terminal.id);
   }, [
     isOpen,
-    migrated,
+    portalContainer,
     terminal.id,
     terminal.focusPolicy,
     preferredTerminalFocusTarget,
@@ -422,9 +391,8 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
           onEscapeKeyDown={(e) => handleDockEscapeKeyDown(e, portalContainerElementRef.current)}
           onFocusOutside={handleDockFocusOutside}
           onOpenAutoFocus={(event) => {
-            // Block Radix's own auto-focus; we focus the terminal once it has
-            // migrated into the portal (see the migration-focus effect), not on
-            // a fixed timer that races a cold xterm mount.
+            // Block Radix's own auto-focus; we focus the terminal ourselves once
+            // its wrapper has been moved into the popover (see the focus effect).
             event.preventDefault();
           }}
         >

--- a/src/components/Layout/__tests__/DockPanelOffscreenContainer.test.tsx
+++ b/src/components/Layout/__tests__/DockPanelOffscreenContainer.test.tsx
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+/**
+ * DockPanelOffscreenContainer — stable-wrapper relocation (#9927).
+ *
+ * Each dock panel renders into a single stable wrapper that is the permanent
+ * createPortal container. Opening/closing a popover relocates that wrapper in
+ * the DOM (offscreen ↔ popover) via moveToDestination — it must NOT remount the
+ * panel subtree. These tests assert DOM-node identity is preserved across
+ * open/close/open cycles and that the moveBefore path and its appendChild
+ * fallback both land the wrapper in the destination.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, render } from "@testing-library/react";
+import type { PtyPanelData } from "@shared/types/panel";
+
+const closeDockTerminalMock = vi.fn();
+
+const mockState: Record<string, unknown> = {};
+
+vi.mock("zustand/react/shallow", () => ({
+  useShallow: <T,>(fn: T) => fn,
+}));
+
+vi.mock("@/store", () => ({
+  usePanelStore: (selector: (s: Record<string, unknown>) => unknown) => selector(mockState),
+  useWorktreeSelectionStore: (selector: (s: { activeWorktreeId: string | null }) => unknown) =>
+    selector({ activeWorktreeId: null }),
+}));
+
+vi.mock("@/store/helpPanelStore", () => ({
+  useHelpPanelStore: (selector: (s: { terminalId: string | null }) => unknown) =>
+    selector({ terminalId: null }),
+}));
+
+vi.mock("@/components/Terminal/DockedPanel", () => ({
+  DockedPanel: ({ terminal }: { terminal: PtyPanelData }) => (
+    <div data-testid="docked-panel" data-pid={terminal.id} />
+  ),
+}));
+
+vi.mock("@/services/terminal/panelDuplicationService", () => ({
+  buildPanelDuplicateOptions: vi.fn(),
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+}));
+
+vi.mock("@/components/ui/DockPopoverChildContext", () => ({
+  DockPopoverChildProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { DockPanelOffscreenContainer } from "../DockPanelOffscreenContainer";
+import { useDockPanelPortal } from "../dockPanelPortalContext";
+
+function makePanel(overrides: Partial<PtyPanelData> = {}): PtyPanelData {
+  return {
+    id: "panel-1",
+    title: "Terminal",
+    location: "dock",
+    kind: "terminal",
+    cwd: "/tmp",
+    cols: 80,
+    rows: 24,
+    worktreeId: null,
+    ...overrides,
+  } as PtyPanelData;
+}
+
+function setPanels(panels: PtyPanelData[]) {
+  mockState.panelIds = panels.map((p) => p.id);
+  mockState.panelsById = Object.fromEntries(panels.map((p) => [p.id, p]));
+  mockState.trashedTerminals = new Set<string>();
+  mockState.activeDockTerminalId = null;
+  mockState.closeDockTerminal = closeDockTerminalMock;
+  mockState.addPanel = vi.fn();
+  mockState.getPanelGroup = vi.fn(() => undefined);
+  mockState.createTabGroup = vi.fn();
+  mockState.addPanelToGroup = vi.fn();
+  mockState.deleteTabGroup = vi.fn();
+  mockState.setActiveTab = vi.fn();
+}
+
+let captured: ((panelId: string, destination: HTMLElement | null) => void) | null = null;
+function Capture() {
+  captured = useDockPanelPortal();
+  return null;
+}
+
+function renderContainer() {
+  captured = null;
+  return render(
+    <DockPanelOffscreenContainer>
+      <Capture />
+    </DockPanelOffscreenContainer>
+  );
+}
+
+describe("DockPanelOffscreenContainer stable-wrapper relocation (#9927)", () => {
+  beforeEach(() => {
+    closeDockTerminalMock.mockClear();
+    setPanels([makePanel({ id: "panel-1" })]);
+  });
+
+  it("renders each panel into a stable wrapper parked in the offscreen container", () => {
+    renderContainer();
+
+    const panel = document.querySelector('[data-testid="docked-panel"]');
+    expect(panel).not.toBeNull();
+    const wrapper = panel!.closest('[data-dock-panel-wrapper="panel-1"]');
+    expect(wrapper).not.toBeNull();
+
+    const offscreen = document.querySelector(".dock-panel-offscreen-container");
+    expect(offscreen).not.toBeNull();
+    expect(wrapper!.parentElement).toBe(offscreen);
+  });
+
+  it("preserves the panel subtree DOM node across open/close/open cycles", () => {
+    renderContainer();
+
+    const initial = document.querySelector('[data-testid="docked-panel"]')!;
+    const wrapper = initial.closest('[data-dock-panel-wrapper="panel-1"]')!;
+    const offscreen = document.querySelector(".dock-panel-offscreen-container")!;
+
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+
+    // Open: wrapper relocates into the popover destination; the panel node is
+    // the SAME element — no remount.
+    act(() => captured!("panel-1", target));
+    expect(wrapper.parentElement).toBe(target);
+    expect(document.querySelector('[data-testid="docked-panel"]')).toBe(initial);
+
+    // Close: parks back to the offscreen container, still the same node.
+    act(() => captured!("panel-1", null));
+    expect(wrapper.parentElement).toBe(offscreen);
+    expect(document.querySelector('[data-testid="docked-panel"]')).toBe(initial);
+
+    // Re-open: relocates again, still the same node.
+    act(() => captured!("panel-1", target));
+    expect(wrapper.parentElement).toBe(target);
+    expect(document.querySelector('[data-testid="docked-panel"]')).toBe(initial);
+  });
+
+  it("uses moveBefore to relocate the wrapper when the destination supports it", () => {
+    renderContainer();
+
+    const wrapper = document
+      .querySelector('[data-testid="docked-panel"]')!
+      .closest('[data-dock-panel-wrapper="panel-1"]')! as HTMLElement;
+
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const moveBefore = vi.fn(function (this: HTMLElement, node: Node) {
+      this.appendChild(node);
+    });
+    (target as unknown as { moveBefore: typeof moveBefore }).moveBefore = moveBefore;
+
+    act(() => captured!("panel-1", target));
+
+    expect(moveBefore).toHaveBeenCalledTimes(1);
+    expect(moveBefore.mock.calls[0]![0]).toBe(wrapper);
+    expect(wrapper.parentElement).toBe(target);
+  });
+
+  it("falls back to appendChild when moveBefore throws (e.g. disconnected move)", () => {
+    renderContainer();
+
+    const wrapper = document
+      .querySelector('[data-testid="docked-panel"]')!
+      .closest('[data-dock-panel-wrapper="panel-1"]')! as HTMLElement;
+
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    (target as unknown as { moveBefore: () => void }).moveBefore = () => {
+      throw new Error("HierarchyRequestError");
+    };
+
+    act(() => captured!("panel-1", target));
+
+    // Despite the throw, the wrapper still lands in the destination.
+    expect(wrapper.parentElement).toBe(target);
+  });
+
+  it("is idempotent — re-moving to the current parent does nothing", () => {
+    renderContainer();
+
+    const wrapper = document
+      .querySelector('[data-testid="docked-panel"]')!
+      .closest('[data-dock-panel-wrapper="panel-1"]')! as HTMLElement;
+
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    act(() => captured!("panel-1", target));
+    expect(wrapper.parentElement).toBe(target);
+
+    const moveBefore = vi.fn();
+    (target as unknown as { moveBefore: typeof moveBefore }).moveBefore = moveBefore;
+    // Already parented to target — the early return skips any DOM op.
+    act(() => captured!("panel-1", target));
+    expect(moveBefore).not.toHaveBeenCalled();
+    expect(wrapper.parentElement).toBe(target);
+  });
+});

--- a/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
@@ -5,7 +5,8 @@
  * Same root cause and fix as DockedTerminalItem: Radix's DismissableLayer fires
  * a focus-outside dismissal while a just-opened tab group's active terminal is
  * still migrating into the portal. The fix blocks that at onFocusOutside and
- * focuses the active tab once its node lands in the portal.
+ * focuses the active tab once its stable wrapper has been moved in — a
+ * synchronous step, no MutationObserver.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, fireEvent, render } from "@testing-library/react";
@@ -354,7 +355,7 @@ describe("DockedTabGroup mount-time close guard (#6602)", () => {
     expect(closeDockTerminalMock).not.toHaveBeenCalled();
   });
 
-  it("suppresses Radix auto-focus and focuses the active tab once it migrates into the portal", async () => {
+  it("suppresses Radix auto-focus and focuses the active tab once its wrapper is moved in", () => {
     mockActiveDockTerminalId = "t-1";
     const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
     render(<DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />);
@@ -365,21 +366,13 @@ describe("DockedTabGroup mount-time close guard (#6602)", () => {
       capturedOnOpenAutoFocus?.({ preventDefault });
     });
     expect(preventDefault).toHaveBeenCalledOnce();
-    expect(terminalInstanceService.focus).not.toHaveBeenCalled();
 
-    const portal = document.querySelector('[data-dock-portal-target="t-1"]');
-    expect(portal).not.toBeNull();
-    await act(async () => {
-      const child = document.createElement("div");
-      child.setAttribute("data-dock-panel-id", "t-1");
-      portal!.appendChild(child);
-      await Promise.resolve();
-    });
-
+    // The popover container ref settles synchronously on mount, so the active
+    // tab's wrapper is moved in and focused — no MutationObserver.
     expect(terminalInstanceService.focus).toHaveBeenCalledWith("t-1");
   });
 
-  it("does not focus an MCP-created active dock tab even after it migrates", async () => {
+  it("does not focus an MCP-created active dock tab", () => {
     mockActiveDockTerminalId = "t-1";
     const panels = [
       makePanel({ id: "t-1", spawnedBy: "mcp", focusPolicy: "preserve" }),
@@ -394,14 +387,8 @@ describe("DockedTabGroup mount-time close guard (#6602)", () => {
     });
     expect(preventDefault).toHaveBeenCalledOnce();
 
-    const portal = document.querySelector('[data-dock-portal-target="t-1"]');
-    await act(async () => {
-      const child = document.createElement("div");
-      child.setAttribute("data-dock-panel-id", "t-1");
-      portal!.appendChild(child);
-      await Promise.resolve();
-    });
-
+    // focusPolicy "preserve" short-circuits the focus effect even though the
+    // wrapper is moved into the popover.
     expect(terminalInstanceService.focus).not.toHaveBeenCalled();
   });
 

--- a/src/components/Layout/__tests__/DockedTerminalItem.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTerminalItem.mountGuard.test.tsx
@@ -6,8 +6,9 @@
  * dock popover's terminal is still migrating into the portal (focus transiently
  * leaves the layer). The fix blocks that path at PopoverContent's onFocusOutside
  * (preventDefault), so genuine pointer-outside / Escape closes still reach
- * onOpenChange and are honored. Focus is moved into the terminal once it has
- * migrated into the portal (observed child insertion), not on a fixed timer.
+ * onOpenChange and are honored. Focus is moved into the terminal once the
+ * popover container ref settles and its stable wrapper has been moved in — a
+ * synchronous step, no MutationObserver, no fixed timer.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, render } from "@testing-library/react";
@@ -242,34 +243,24 @@ describe("DockedTerminalItem mount-time close guard (#6602)", () => {
     expect(closeDockTerminalMock).toHaveBeenCalledTimes(1);
   });
 
-  it("suppresses Radix auto-focus and focuses the terminal once it migrates into the portal", async () => {
+  it("suppresses Radix auto-focus and focuses the terminal once its wrapper is moved in", () => {
     mockActiveDockTerminalId = "t-1";
     render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
     expect(capturedOnOpenAutoFocus).not.toBeNull();
 
-    // Radix's own auto-focus is blocked; nothing is focused until migration.
+    // Radix's own auto-focus is blocked; we focus the terminal ourselves.
     const preventDefault = vi.fn();
     act(() => {
       capturedOnOpenAutoFocus?.({ preventDefault });
     });
     expect(preventDefault).toHaveBeenCalledOnce();
-    expect(terminalInstanceService.focus).not.toHaveBeenCalled();
 
-    // Simulate the terminal host being portaled into the popover target — the
-    // MutationObserver detects the child insertion and focus follows.
-    const portal = document.querySelector('[data-dock-portal-target="t-1"]');
-    expect(portal).not.toBeNull();
-    await act(async () => {
-      const child = document.createElement("div");
-      child.setAttribute("data-dock-panel-id", "t-1");
-      portal!.appendChild(child);
-      await Promise.resolve();
-    });
-
+    // The popover container ref settles synchronously on mount, so the stable
+    // wrapper is moved in and the terminal is focused — no MutationObserver.
     expect(terminalInstanceService.focus).toHaveBeenCalledWith("t-1");
   });
 
-  it("does not focus an MCP-created dock terminal even after it migrates", async () => {
+  it("does not focus an MCP-created dock terminal", () => {
     mockActiveDockTerminalId = "t-1";
     render(
       <DockedTerminalItem
@@ -284,14 +275,8 @@ describe("DockedTerminalItem mount-time close guard (#6602)", () => {
     });
     expect(preventDefault).toHaveBeenCalledOnce();
 
-    const portal = document.querySelector('[data-dock-portal-target="t-1"]');
-    await act(async () => {
-      const child = document.createElement("div");
-      child.setAttribute("data-dock-panel-id", "t-1");
-      portal!.appendChild(child);
-      await Promise.resolve();
-    });
-
+    // focusPolicy "preserve" short-circuits the focus effect even though the
+    // wrapper is moved into the popover.
     expect(terminalInstanceService.focus).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Layout/dockPanelPortalContext.ts
+++ b/src/components/Layout/dockPanelPortalContext.ts
@@ -1,7 +1,12 @@
 import { createContext, useContext } from "react";
 
 export interface DockPanelContextValue {
-  portalTarget: (terminalId: string, target: HTMLElement | null) => void;
+  // Relocate a dock panel's stable wrapper element into `destination` (the
+  // popover's inner container) or back to the offscreen parking container when
+  // `destination` is null. The wrapper itself is the permanent createPortal
+  // container — React never sees it change identity — so the panel subtree is
+  // never unmounted/remounted across open/close or tab switches.
+  moveToDestination: (panelId: string, destination: HTMLElement | null) => void;
 }
 
 // Defined in its own module (no component exports) so Vite Fast Refresh never
@@ -17,5 +22,5 @@ export function useDockPanelPortal() {
   if (!context) {
     throw new Error("useDockPanelPortal must be used within DockPanelOffscreenContainer");
   }
-  return context.portalTarget;
+  return context.moveToDestination;
 }


### PR DESCRIPTION
## Summary

- Each dock panel renders into a single stable wrapper div that acts as the permanent `createPortal` container. React never sees a container identity change, so the panel subtree (`ContentPanel`, `TerminalPane`, `HybridInputBar`/`CodeMirror`) is never unmounted/remounted on popover open/close or dock tab switch.
- The wrapper is relocated between the offscreen parking area and the popover via `Node.moveBefore` — atomic, preserves the xterm canvas and WebGL context. Guarded by `isConnected` with an `appendChild` fallback for disconnected or unsupported moves.
- Removed the `MutationObserver` `migrated` signal from `DockedTerminalItem` and `DockedTabGroup` (move is now synchronous); focus is called directly once the popover container ref settles.

Resolves #9927

## Changes

- `DockPanelOffscreenContainer` — stable wrapper div per panel; dropped `forceUpdate` render churn
- `DockedTabGroup` / `DockedTerminalItem` — replaced `MutationObserver` with synchronous move; `DockedTabGroup` effects use scalar `activePanelId` deps instead of the `activePanel` object (avoids re-firing on agent-state polling)
- `dockPanelPortalContext` — renamed `portalTarget` to `moveToDestination`
- `DockPanelOffscreenContainer.test.tsx` — new regression test covering DOM-node identity across open/close/open cycles, `moveBefore` path, `appendChild` fallback, and idempotency
- `DockedTabGroup.mountGuard.test.tsx` / `DockedTerminalItem.mountGuard.test.tsx` — rewritten for synchronous move

## Testing

Full local CI passed: typecheck, lint, format, 32663 unit tests, build. Regression test asserts the wrapper DOM node is the same object reference before and after popover open/close cycles.