### PR TITLE
refactor(actions): route worktree workflow lookups through forge provider (#9959)

### DIFF
--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -4882,7 +4882,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "worktree",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Fetch a GitHub issue, create a worktree with a derived branch, launch an agent, and inject context.",
+    "description": "Fetch an issue, create a worktree with a derived branch, launch an agent, and inject context.",
     "examples": undefined,
     "id": "workflow.startWorkOnIssue",
     "keywords": undefined,

--- a/src/services/actions/definitions/__tests__/githubActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/githubActions.adversarial.test.ts
@@ -301,7 +301,6 @@ describe("githubClient import boundary", () => {
 
   const allowlist = new Set([
     "src/services/actions/definitions/githubActions.ts",
-    "src/services/actions/definitions/workflowCreationActions.ts",
     "src/hooks/useRepositoryStats.ts",
     "src/hooks/useGitHubRateLimit.ts",
     "src/hooks/useGitHubTokenHealth.ts",

--- a/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
@@ -458,6 +458,18 @@ describe("worktree.createWithRecipe", () => {
     await expect(def.run({ pullRequestNumber: 42 }, {} as never)).rejects.toThrow(/no head branch/);
     expect(worktreeClientMock.fetchPRBranch).not.toHaveBeenCalled();
   });
+
+  it("treats whitespace-only headRef the same as missing", async () => {
+    forgeClientMock.getPR.mockResolvedValue({
+      number: 42,
+      headRef: "   ",
+      title: "x",
+      url: "u",
+    });
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+    await expect(def.run({ pullRequestNumber: 42 }, {} as never)).rejects.toThrow(/no head branch/);
+    expect(worktreeClientMock.fetchPRBranch).not.toHaveBeenCalled();
+  });
 });
 
 describe("workflow.startWorkOnIssue", () => {
@@ -476,7 +488,10 @@ describe("workflow.startWorkOnIssue", () => {
     >;
 
     expect(forgeClientMock.getIssue).toHaveBeenCalledWith("/repo", 6609);
-    expect(worktreeClientMock.getAvailableBranch).toHaveBeenCalled();
+    expect(worktreeClientMock.getAvailableBranch).toHaveBeenCalledWith(
+      "/repo",
+      "feature/issue-6609-add-workflow-macro-tools"
+    );
     expect(worktreeClientMock.create).toHaveBeenCalled();
     expect(callbacks.onLaunchAgent).toHaveBeenCalledWith(
       "claude",
@@ -502,10 +517,13 @@ describe("workflow.startWorkOnIssue", () => {
 
     await def.run({ issueNumber: 6959, agentId: "claude", spawnedBy: "mcp" }, {} as never);
 
+    expect(worktreeClientMock.getAvailableBranch).toHaveBeenCalledWith(
+      "/repo",
+      "feature/issue-6959-assistant-focus-is-stolen"
+    );
     expect(callbacks.onLaunchAgent).toHaveBeenCalledWith(
       "claude",
       expect.objectContaining({
-        cwd: "/repo/feature/issue-6609-add-tools",
         worktreeId: "wt-new",
         spawnedBy: "mcp",
       })

--- a/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
@@ -9,16 +9,11 @@ const worktreeClientMock = vi.hoisted(() => ({
   fetchPRBranch: vi.fn(),
 }));
 
-const githubClientMock = vi.hoisted(() => ({
-  getIssueByNumber: vi.fn(),
-  getPRByNumber: vi.fn(),
-  assignIssue: vi.fn(),
-  getConfig: vi.fn(),
-}));
-
 const forgeClientMock = vi.hoisted(() => ({
   getCurrentUser: vi.fn(),
   assignIssue: vi.fn(),
+  getIssue: vi.fn(),
+  getPR: vi.fn(),
 }));
 
 const projectClientMock = vi.hoisted(() => ({
@@ -46,7 +41,6 @@ vi.mock("@/utils/recipeNotify", () => ({
 }));
 vi.mock("@/clients", () => ({
   worktreeClient: worktreeClientMock,
-  githubClient: githubClientMock,
   forgeClient: forgeClientMock,
   projectClient: projectClientMock,
   copyTreeClient: copyTreeClientMock,
@@ -166,7 +160,6 @@ beforeEach(() => {
   worktreeClientMock.getDefaultPath.mockResolvedValue("/repo/feature/issue-6609-add-tools");
   worktreeClientMock.create.mockResolvedValue("wt-new");
   worktreeClientMock.fetchPRBranch.mockResolvedValue(undefined);
-  githubClientMock.assignIssue.mockResolvedValue(undefined);
   forgeClientMock.assignIssue.mockResolvedValue(undefined);
   copyTreeClientMock.injectToTerminal.mockResolvedValue(undefined);
   setProject({ id: "p1", path: "/repo" });
@@ -204,7 +197,7 @@ describe("worktree.createWithRecipe", () => {
       }),
       "/repo"
     );
-    expect(githubClientMock.getPRByNumber).not.toHaveBeenCalled();
+    expect(forgeClientMock.getPR).not.toHaveBeenCalled();
     expect(worktreeClientMock.fetchPRBranch).not.toHaveBeenCalled();
     expect(result.worktreeId).toBe("wt-new");
     expect(result.branch).toBe("feature/issue-6609-add-tools");
@@ -212,9 +205,9 @@ describe("worktree.createWithRecipe", () => {
   });
 
   it("PR path: resolves head branch, fetches PR, creates worktree on existing local branch", async () => {
-    githubClientMock.getPRByNumber.mockResolvedValue({
+    forgeClientMock.getPR.mockResolvedValue({
       number: 42,
-      headRefName: "contrib/feature-x",
+      headRef: "contrib/feature-x",
       title: "Some PR",
       url: "https://github.com/x/y/pull/42",
     });
@@ -226,7 +219,7 @@ describe("worktree.createWithRecipe", () => {
       unknown
     >;
 
-    expect(githubClientMock.getPRByNumber).toHaveBeenCalledWith("/repo", 42);
+    expect(forgeClientMock.getPR).toHaveBeenCalledWith("/repo", 42);
     expect(worktreeClientMock.fetchPRBranch).toHaveBeenCalledWith("/repo", 42, "contrib/feature-x");
     // PR path uses the head ref directly — must not call getAvailableBranch (which would suffix on conflict).
     expect(worktreeClientMock.getAvailableBranch).not.toHaveBeenCalled();
@@ -246,7 +239,7 @@ describe("worktree.createWithRecipe", () => {
   });
 
   it("PR path throws when the PR is not found", async () => {
-    githubClientMock.getPRByNumber.mockResolvedValue(null);
+    forgeClientMock.getPR.mockResolvedValue(null);
     const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
     await expect(def.run({ pullRequestNumber: 999 }, {} as never)).rejects.toThrow(
       /Pull request #999 not found/
@@ -255,8 +248,8 @@ describe("worktree.createWithRecipe", () => {
     expect(worktreeClientMock.create).not.toHaveBeenCalled();
   });
 
-  it("PR path throws when headRefName is missing on the resolved PR", async () => {
-    githubClientMock.getPRByNumber.mockResolvedValue({
+  it("PR path throws when headRef is missing on the resolved PR", async () => {
+    forgeClientMock.getPR.mockResolvedValue({
       number: 42,
       title: "x",
       url: "u",
@@ -268,9 +261,9 @@ describe("worktree.createWithRecipe", () => {
   });
 
   it("PR path surfaces fetchPRBranch failures (no worktree created)", async () => {
-    githubClientMock.getPRByNumber.mockResolvedValue({
+    forgeClientMock.getPR.mockResolvedValue({
       number: 42,
-      headRefName: "contrib/x",
+      headRef: "contrib/x",
       title: "x",
       url: "u",
     });
@@ -295,9 +288,9 @@ describe("worktree.createWithRecipe", () => {
   });
 
   it("recipe context carries prNumber (not issueNumber) when pullRequestNumber is provided", async () => {
-    githubClientMock.getPRByNumber.mockResolvedValue({
+    forgeClientMock.getPR.mockResolvedValue({
       number: 42,
-      headRefName: "contrib/feature-x",
+      headRef: "contrib/feature-x",
       title: "x",
       url: "u",
     });
@@ -454,10 +447,10 @@ describe("worktree.createWithRecipe", () => {
     expect(notifySpawnFailuresMock).not.toHaveBeenCalled();
   });
 
-  it("treats empty-string headRefName the same as missing", async () => {
-    githubClientMock.getPRByNumber.mockResolvedValue({
+  it("treats empty-string headRef the same as missing", async () => {
+    forgeClientMock.getPR.mockResolvedValue({
       number: 42,
-      headRefName: "",
+      headRef: "",
       title: "x",
       url: "u",
     });
@@ -469,7 +462,7 @@ describe("worktree.createWithRecipe", () => {
 
 describe("workflow.startWorkOnIssue", () => {
   it("happy path: fetches issue, creates worktree, launches agent, injects context", async () => {
-    githubClientMock.getIssueByNumber.mockResolvedValue({
+    forgeClientMock.getIssue.mockResolvedValue({
       number: 6609,
       title: "Add workflow macro tools",
       url: "https://github.com/x/y/issues/6609",
@@ -482,7 +475,7 @@ describe("workflow.startWorkOnIssue", () => {
       unknown
     >;
 
-    expect(githubClientMock.getIssueByNumber).toHaveBeenCalledWith("/repo", 6609);
+    expect(forgeClientMock.getIssue).toHaveBeenCalledWith("/repo", 6609);
     expect(worktreeClientMock.getAvailableBranch).toHaveBeenCalled();
     expect(worktreeClientMock.create).toHaveBeenCalled();
     expect(callbacks.onLaunchAgent).toHaveBeenCalledWith(
@@ -499,7 +492,7 @@ describe("workflow.startWorkOnIssue", () => {
   });
 
   it("passes spawnedBy through to agents launched by MCP workflow actions", async () => {
-    githubClientMock.getIssueByNumber.mockResolvedValue({
+    forgeClientMock.getIssue.mockResolvedValue({
       number: 6959,
       title: "Assistant focus is stolen",
       url: "https://github.com/x/y/issues/6959",
@@ -528,15 +521,15 @@ describe("workflow.startWorkOnIssue", () => {
   });
 
   it("throws when issue is not found", async () => {
-    githubClientMock.getIssueByNumber.mockResolvedValue(null);
+    forgeClientMock.getIssue.mockResolvedValue(null);
     const def = setupActions(makeCallbacks())("workflow.startWorkOnIssue");
     await expect(def.run({ issueNumber: 999, agentId: "claude" }, {} as never)).rejects.toThrow(
-      /issue #999 not found/
+      /Issue #999 not found/
     );
   });
 
   it("throws PARTIAL_SUCCESS when agent.launch returns null after worktree creation", async () => {
-    githubClientMock.getIssueByNumber.mockResolvedValue({
+    forgeClientMock.getIssue.mockResolvedValue({
       number: 1,
       title: "x",
       url: "u",
@@ -552,7 +545,7 @@ describe("workflow.startWorkOnIssue", () => {
   });
 
   it("partial-success error embeds message + partial result as a single JSON envelope", async () => {
-    githubClientMock.getIssueByNumber.mockResolvedValue({ number: 7, title: "t", url: "u" });
+    forgeClientMock.getIssue.mockResolvedValue({ number: 7, title: "t", url: "u" });
     const callbacks = makeCallbacks();
     callbacks.onLaunchAgent.mockResolvedValue(null);
     const def = setupActions(callbacks)("workflow.startWorkOnIssue");
@@ -573,7 +566,7 @@ describe("workflow.startWorkOnIssue", () => {
   });
 
   it("partial-success encoding stays parseable when the human message itself contains '{'", async () => {
-    githubClientMock.getIssueByNumber.mockResolvedValue({ number: 5, title: "t", url: "u" });
+    forgeClientMock.getIssue.mockResolvedValue({ number: 5, title: "t", url: "u" });
     setRecipe("recipe-1", async () => {
       throw new Error('config parse failed: {"key": null}');
     });
@@ -591,7 +584,7 @@ describe("workflow.startWorkOnIssue", () => {
   });
 
   it("recipe failure throws PARTIAL_SUCCESS with worktree info before agent is launched", async () => {
-    githubClientMock.getIssueByNumber.mockResolvedValue({ number: 1, title: "t", url: "u" });
+    forgeClientMock.getIssue.mockResolvedValue({ number: 1, title: "t", url: "u" });
     setRecipe("recipe-1", async () => {
       throw new Error("recipe boom");
     });
@@ -605,7 +598,7 @@ describe("workflow.startWorkOnIssue", () => {
   });
 
   it("reports recipeLaunched: false when every recipe terminal fails to spawn", async () => {
-    githubClientMock.getIssueByNumber.mockResolvedValue({ number: 1, title: "t", url: "u" });
+    forgeClientMock.getIssue.mockResolvedValue({ number: 1, title: "t", url: "u" });
     const results = {
       spawned: [],
       failed: [{ index: 0, error: "Panel limit reached" }],
@@ -628,7 +621,7 @@ describe("workflow.startWorkOnIssue", () => {
   });
 
   it("reports recipeLaunched: true with failure counts on partial spawn", async () => {
-    githubClientMock.getIssueByNumber.mockResolvedValue({ number: 1, title: "t", url: "u" });
+    forgeClientMock.getIssue.mockResolvedValue({ number: 1, title: "t", url: "u" });
     setRecipe("recipe-1", async () => ({
       spawned: [{ index: 0, terminalId: "t-0" }],
       failed: [{ index: 1, error: "PTY spawn failed" }],
@@ -646,7 +639,7 @@ describe("workflow.startWorkOnIssue", () => {
   });
 
   it("PARTIAL_SUCCESS from a failed agent launch preserves partial spawn counts", async () => {
-    githubClientMock.getIssueByNumber.mockResolvedValue({ number: 1, title: "t", url: "u" });
+    forgeClientMock.getIssue.mockResolvedValue({ number: 1, title: "t", url: "u" });
     setRecipe("recipe-1", async () => ({
       spawned: [{ index: 0, terminalId: "t-0" }],
       failed: [{ index: 1, error: "Panel limit reached" }],
@@ -669,7 +662,7 @@ describe("workflow.startWorkOnIssue", () => {
   });
 
   it("agent.launch throwing (not just returning null) becomes PARTIAL_SUCCESS", async () => {
-    githubClientMock.getIssueByNumber.mockResolvedValue({ number: 1, title: "t", url: "u" });
+    forgeClientMock.getIssue.mockResolvedValue({ number: 1, title: "t", url: "u" });
     const callbacks = makeCallbacks();
     callbacks.onLaunchAgent.mockRejectedValue(new Error("PTY spawn failed"));
     const def = setupActions(callbacks)("workflow.startWorkOnIssue");
@@ -688,7 +681,7 @@ describe("workflow.startWorkOnIssue", () => {
   });
 
   it("context injection failure is best-effort — agent stays launched, contextInjected: false", async () => {
-    githubClientMock.getIssueByNumber.mockResolvedValue({ number: 1, title: "t", url: "u" });
+    forgeClientMock.getIssue.mockResolvedValue({ number: 1, title: "t", url: "u" });
     copyTreeClientMock.injectToTerminal.mockRejectedValue(new Error("nope"));
     const def = setupActions(makeCallbacks())("workflow.startWorkOnIssue");
     const result = (await def.run({ issueNumber: 1, agentId: "claude" }, {} as never)) as Record<
@@ -700,7 +693,7 @@ describe("workflow.startWorkOnIssue", () => {
   });
 
   it("injectContext: false skips injection entirely", async () => {
-    githubClientMock.getIssueByNumber.mockResolvedValue({ number: 1, title: "t", url: "u" });
+    forgeClientMock.getIssue.mockResolvedValue({ number: 1, title: "t", url: "u" });
     const def = setupActions(makeCallbacks())("workflow.startWorkOnIssue");
     const result = (await def.run(
       { issueNumber: 1, agentId: "claude", injectContext: false },
@@ -711,7 +704,7 @@ describe("workflow.startWorkOnIssue", () => {
   });
 
   it("assignToSelf assigns the issue to the configured user", async () => {
-    githubClientMock.getIssueByNumber.mockResolvedValue({ number: 6609, title: "t", url: "u" });
+    forgeClientMock.getIssue.mockResolvedValue({ number: 6609, title: "t", url: "u" });
     setGithubUser("ada");
     const def = setupActions(makeCallbacks())("workflow.startWorkOnIssue");
     const result = (await def.run(
@@ -724,7 +717,7 @@ describe("workflow.startWorkOnIssue", () => {
   });
 
   it("assignToSelf is best-effort — failure surfaces in assignmentError without aborting the macro", async () => {
-    githubClientMock.getIssueByNumber.mockResolvedValue({ number: 6609, title: "t", url: "u" });
+    forgeClientMock.getIssue.mockResolvedValue({ number: 6609, title: "t", url: "u" });
     setGithubUser("ada");
     forgeClientMock.assignIssue.mockRejectedValue(new Error("403 Forbidden"));
     const def = setupActions(makeCallbacks())("workflow.startWorkOnIssue");
@@ -738,7 +731,7 @@ describe("workflow.startWorkOnIssue", () => {
   });
 
   it("assignToSelf omitted falls back to assignWorktreeToSelf preference (true)", async () => {
-    githubClientMock.getIssueByNumber.mockResolvedValue({ number: 6609, title: "t", url: "u" });
+    forgeClientMock.getIssue.mockResolvedValue({ number: 6609, title: "t", url: "u" });
     setGithubUser("ada");
     setAssignPreference(true);
     const def = setupActions(makeCallbacks())("workflow.startWorkOnIssue");
@@ -752,7 +745,7 @@ describe("workflow.startWorkOnIssue", () => {
   });
 
   it("assignToSelf omitted with preference (false) does not assign", async () => {
-    githubClientMock.getIssueByNumber.mockResolvedValue({ number: 6609, title: "t", url: "u" });
+    forgeClientMock.getIssue.mockResolvedValue({ number: 6609, title: "t", url: "u" });
     setGithubUser("ada");
     setAssignPreference(false);
     const def = setupActions(makeCallbacks())("workflow.startWorkOnIssue");
@@ -766,7 +759,7 @@ describe("workflow.startWorkOnIssue", () => {
   });
 
   it("explicit assignToSelf: false overrides a true preference", async () => {
-    githubClientMock.getIssueByNumber.mockResolvedValue({ number: 6609, title: "t", url: "u" });
+    forgeClientMock.getIssue.mockResolvedValue({ number: 6609, title: "t", url: "u" });
     setGithubUser("ada");
     setAssignPreference(true);
     const def = setupActions(makeCallbacks())("workflow.startWorkOnIssue");
@@ -780,7 +773,7 @@ describe("workflow.startWorkOnIssue", () => {
   });
 
   it("assignToSelf with no GitHub username configured surfaces a descriptive assignmentError", async () => {
-    githubClientMock.getIssueByNumber.mockResolvedValue({ number: 6609, title: "t", url: "u" });
+    forgeClientMock.getIssue.mockResolvedValue({ number: 6609, title: "t", url: "u" });
     setGithubUser(null);
     const def = setupActions(makeCallbacks())("workflow.startWorkOnIssue");
     const result = (await def.run(
@@ -794,7 +787,7 @@ describe("workflow.startWorkOnIssue", () => {
   });
 
   it("preference fallback also surfaces 'No forge viewer available' when assignToSelf is omitted", async () => {
-    githubClientMock.getIssueByNumber.mockResolvedValue({ number: 6609, title: "t", url: "u" });
+    forgeClientMock.getIssue.mockResolvedValue({ number: 6609, title: "t", url: "u" });
     setGithubUser(null);
     setAssignPreference(true);
     const def = setupActions(makeCallbacks())("workflow.startWorkOnIssue");
@@ -808,7 +801,7 @@ describe("workflow.startWorkOnIssue", () => {
   });
 
   it("assignment failure does not clobber other result fields", async () => {
-    githubClientMock.getIssueByNumber.mockResolvedValue({ number: 6609, title: "t", url: "u" });
+    forgeClientMock.getIssue.mockResolvedValue({ number: 6609, title: "t", url: "u" });
     setGithubUser("ada");
     forgeClientMock.assignIssue.mockRejectedValue(new Error("rate limit"));
     const def = setupActions(makeCallbacks())("workflow.startWorkOnIssue");
@@ -824,7 +817,7 @@ describe("workflow.startWorkOnIssue", () => {
   });
 
   it("getCurrentUser() rejection surfaces in assignmentError, worktree still returned", async () => {
-    githubClientMock.getIssueByNumber.mockResolvedValue({ number: 6609, title: "t", url: "u" });
+    forgeClientMock.getIssue.mockResolvedValue({ number: 6609, title: "t", url: "u" });
     forgeClientMock.getCurrentUser.mockRejectedValue(new Error("IPC unavailable"));
     const def = setupActions(makeCallbacks())("workflow.startWorkOnIssue");
     const result = (await def.run(
@@ -839,7 +832,7 @@ describe("workflow.startWorkOnIssue", () => {
   });
 
   it("derives a sane branch name from the issue title when none is provided", async () => {
-    githubClientMock.getIssueByNumber.mockResolvedValue({
+    forgeClientMock.getIssue.mockResolvedValue({
       number: 42,
       title: "Fix: weird $$$ characters & SPACES",
       url: "u",

--- a/src/services/actions/definitions/workflowCreationActions.ts
+++ b/src/services/actions/definitions/workflowCreationActions.ts
@@ -136,7 +136,7 @@ export function registerWorkflowCreationActions(
           if (!pr) {
             throw new Error(`Pull request #${pullRequestNumber} not found in ${rootPath}`);
           }
-          if (!pr.headRef) {
+          if (!pr.headRef?.trim()) {
             throw new Error(
               `Pull request #${pullRequestNumber} has no head branch — cannot create worktree`
             );

--- a/src/services/actions/definitions/workflowCreationActions.ts
+++ b/src/services/actions/definitions/workflowCreationActions.ts
@@ -3,7 +3,7 @@ import { defineAction } from "../defineAction";
 import { z } from "zod";
 import type { ActionContext } from "@shared/types/actions";
 // eslint-disable-next-line no-restricted-imports
-import { worktreeClient, githubClient, copyTreeClient, forgeClient } from "@/clients";
+import { worktreeClient, copyTreeClient, forgeClient } from "@/clients";
 import { useProjectStore } from "@/store/projectStore";
 import { useRecipeStore } from "@/store/recipeStore";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
@@ -55,7 +55,7 @@ export function registerWorkflowCreationActions(
             .positive()
             .optional()
             .describe(
-              "GitHub issue number to link with the worktree. Mutually exclusive with pullRequestNumber."
+              "Issue number to link with the worktree. Mutually exclusive with pullRequestNumber."
             ),
           pullRequestNumber: z
             .number()
@@ -63,7 +63,7 @@ export function registerWorkflowCreationActions(
             .positive()
             .optional()
             .describe(
-              "GitHub pull request number to check out. Resolves the PR's head branch automatically and creates the worktree on it. Mutually exclusive with issueNumber."
+              "Pull request number to check out. Resolves the PR's head branch automatically and creates the worktree on it. Mutually exclusive with issueNumber."
             ),
           assignToSelf: z
             .boolean()
@@ -132,18 +132,18 @@ export function registerWorkflowCreationActions(
         let effectiveFromRemote: boolean;
 
         if (pullRequestNumber !== undefined) {
-          const pr = await githubClient.getPRByNumber(rootPath, pullRequestNumber);
+          const pr = await forgeClient.getPR(rootPath, pullRequestNumber);
           if (!pr) {
             throw new Error(`Pull request #${pullRequestNumber} not found in ${rootPath}`);
           }
-          if (!pr.headRefName) {
+          if (!pr.headRef) {
             throw new Error(
               `Pull request #${pullRequestNumber} has no head branch — cannot create worktree`
             );
           }
-          await worktreeClient.fetchPRBranch(rootPath, pullRequestNumber, pr.headRefName);
-          effectiveBranch = pr.headRefName;
-          effectiveBase = pr.headRefName;
+          await worktreeClient.fetchPRBranch(rootPath, pullRequestNumber, pr.headRef);
+          effectiveBranch = pr.headRef;
+          effectiveBase = pr.headRef;
           effectiveUseExisting = true;
           effectiveFromRemote = false;
         } else {
@@ -279,13 +279,13 @@ export function registerWorkflowCreationActions(
       id: "workflow.startWorkOnIssue",
       title: "Start Work on Issue",
       description:
-        "Fetch a GitHub issue, create a worktree with a derived branch, launch an agent, and inject context.",
+        "Fetch an issue, create a worktree with a derived branch, launch an agent, and inject context.",
       category: "worktree",
       kind: "command",
       danger: "safe",
       scope: "renderer",
       argsSchema: z.object({
-        issueNumber: z.number().int().positive().describe("GitHub issue number to start work on"),
+        issueNumber: z.number().int().positive().describe("Issue number to start work on"),
         agentId: z
           .string()
           .min(1)
@@ -356,9 +356,9 @@ export function registerWorkflowCreationActions(
         const effectiveAssignToSelf =
           assignToSelf ?? usePreferencesStore.getState().assignWorktreeToSelf;
 
-        const issue = await githubClient.getIssueByNumber(rootPath, issueNumber);
+        const issue = await forgeClient.getIssue(rootPath, issueNumber);
         if (!issue) {
-          throw new Error(`GitHub issue #${issueNumber} not found in ${rootPath}`);
+          throw new Error(`Issue #${issueNumber} not found in ${rootPath}`);
         }
 
         const derivedBranch =


### PR DESCRIPTION
Migrates the two worktree-workflow actions in `workflowCreationActions.ts` off the legacy GitHub-specific `githubClient` onto the provider-neutral `forgeClient`.

Resolves #9959

## Changes

**`worktree.createWithRecipe`**
- Switches to `forgeClient.getPR` and `pr.headRef` (was `githubClient.getPRByNumber` / `headRefName`)
- Hardens the head-branch guard to reject `undefined` or whitespace-only values before calling `fetchPRBranch`

**`workflow.startWorkOnIssue`**
- Switches to `forgeClient.getIssue` (was `githubClient.getIssueByNumber`)
- Removes GitHub-specific language from the issue-not-found error and user-facing arg/action descriptions

**Cleanup**
- Drops the now-unused `githubClient` import
- Removes this file from the `githubClient` import-boundary allowlist

**Tests**
- Migrated adversarial mocks to `forgeClient`
- Added a whitespace-only `headRef` case
- Tightened branch-derivation assertions
- Refreshed the action-manifest snapshot

## Out of scope

`WorkspaceService.fetchPRBranch` remains GitHub-specific — non-GitHub forges get a clear error there. Tracked separately.

## Testing

Typecheck, lint, format, build, preload-backdoors, and the changed test files all pass locally.