### PR TITLE
feat(mcp): surface audit anomaly signals as a Tier 1 ambient indicator (#10022)

### DIFF
--- a/electron/ipc/handlers/mcpServer.ts
+++ b/electron/ipc/handlers/mcpServer.ts
@@ -108,9 +108,12 @@ export const mcpServerNamespace = defineIpcNamespace({
     ),
     getAuditStats: op(
       MCP_SERVER_METHOD_CHANNELS.getAuditStats,
-      async (): Promise<McpAuditStats> => {
+      // `markSeen` defaults to true (user-facing reads acknowledge first-seen
+      // combos). Passive pollers pass false so a background read doesn't consume
+      // the transient first-seen signal before the user sees it (#10022).
+      async (markSeen?: boolean): Promise<McpAuditStats> => {
         const svc = await getMcpServerService();
-        return svc.getAuditStats();
+        return svc.getAuditStats(markSeen ?? true);
       }
     ),
     clearAuditLog: op(MCP_SERVER_METHOD_CHANNELS.clearAuditLog, async (): Promise<void> => {

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -424,8 +424,8 @@ export class McpServerService {
     return this.auditService.getAuditConfig();
   }
 
-  getAuditStats(): McpAuditStats {
-    return this.auditService.getAuditStats();
+  getAuditStats(markSeen = true): McpAuditStats {
+    return this.auditService.getAuditStats(markSeen);
   }
 
   clearAuditLog(): void {

--- a/electron/services/mcp-server/__tests__/auditLog.test.ts
+++ b/electron/services/mcp-server/__tests__/auditLog.test.ts
@@ -655,6 +655,48 @@ describe("AuditService anomaly detection", () => {
     expect(firstSeen[0]!.tier).toBe("external");
   });
 
+  it("first-seen: passive read (markSeen=false) does not consume the signal", () => {
+    const service = makeRecords(50, () => ({
+      toolId: "tool.a",
+      tier: "action",
+      durationMs: 10,
+    }));
+    service.getAuditStats(); // seed baseline known combos
+
+    service.appendRecord({
+      toolId: "tool.new",
+      sessionId: "sess-1",
+      tier: "external",
+      args: {},
+      durationMs: 5,
+      outcome: successOutcome,
+      argsSummary: "{}",
+    });
+
+    // Two passive reads in a row both still surface the new combo — a
+    // background poll must not acknowledge it (#10022).
+    const firstPassive = service
+      .getAuditStats(false)
+      .anomalySignals.filter((s) => s.kind === "first-seen-combination");
+    expect(firstPassive).toHaveLength(1);
+    const secondPassive = service
+      .getAuditStats(false)
+      .anomalySignals.filter((s) => s.kind === "first-seen-combination");
+    expect(secondPassive).toHaveLength(1);
+
+    // A user-facing read (default markSeen=true) acknowledges it...
+    const acknowledged = service
+      .getAuditStats()
+      .anomalySignals.filter((s) => s.kind === "first-seen-combination");
+    expect(acknowledged).toHaveLength(1);
+
+    // ...so the next read (passive or not) sees it as known and stays quiet.
+    const afterAck = service
+      .getAuditStats(false)
+      .anomalySignals.filter((s) => s.kind === "first-seen-combination");
+    expect(afterAck).toHaveLength(0);
+  });
+
   it("first-seen: knownCombinations survives clear()", () => {
     const service = makeRecords(50, () => ({
       toolId: "tool.a",

--- a/electron/services/mcp-server/auditLog.ts
+++ b/electron/services/mcp-server/auditLog.ts
@@ -307,9 +307,17 @@ export class AuditService {
   }
   /**
    * Read the session-scoped audit health counters. Renderer-facing.
+   *
+   * `markSeen` controls whether `first-seen-combination` signals are
+   * acknowledged (added to `knownCombinations`) as a side effect — see
+   * {@link getSignals}. User-facing surfaces (the Settings audit log) keep the
+   * default `true` so a combo fires once and then stays quiet. Passive pollers
+   * that only need the ambient count (the toolbar/HelpPanel anomaly indicator,
+   * #10022) must pass `false`, or their background cadence would consume the
+   * transient first-seen signal before the user ever navigates to the log.
    */
-  getAuditStats(): McpAuditStats {
-    const signals = this.getSignals();
+  getAuditStats(markSeen = true): McpAuditStats {
+    const signals = this.getSignals(markSeen);
     return {
       auth401Count: this.auth401Count,
       anomalySignals: signals,
@@ -331,7 +339,21 @@ export class AuditService {
     return n;
   }
 
-  getSignals(): McpAnomalySignal[] {
+  /**
+   * Compute the current anomaly signals across the dispatch ring buffer.
+   *
+   * `markSeen` (default `true`) governs the one stateful signal kind,
+   * `first-seen-combination`: when `true`, each newly-observed `toolId+tier`
+   * combo is recorded in `knownCombinations` so it fires exactly once. A passive
+   * caller passes `false` to read the same signals without acknowledging them —
+   * so a background poll can surface the ambient indicator while leaving the
+   * "fire once" acknowledgment to the user-facing audit log (#10022). The
+   * initial baseline seeding always runs regardless of `markSeen`, otherwise
+   * every pre-existing combo would read as first-seen on the first call. The
+   * other three kinds (latency drift, failure clustering, p95 z-score) are
+   * stateless recomputations and are unaffected by `markSeen`.
+   */
+  getSignals(markSeen = true): McpAnomalySignal[] {
     this.hydrate();
     const records: McpAuditRecord[] = [];
     for (const r of this.records) {
@@ -350,11 +372,15 @@ export class AuditService {
       }
     }
 
-    // 1. First-seen combinations — only for combos not yet in the set.
+    // 1. First-seen combinations — only for combos not yet in the set. A local
+    // set dedupes within this call so a passive read (markSeen=false), which
+    // doesn't persist to knownCombinations, still emits each combo at most once.
+    const emittedThisCall = new Set<string>();
     for (const r of records) {
       const key = `${r.toolId} ${r.tier}`;
-      if (!this.knownCombinations.has(key)) {
-        this.knownCombinations.add(key);
+      if (!this.knownCombinations.has(key) && !emittedThisCall.has(key)) {
+        emittedThisCall.add(key);
+        if (markSeen) this.knownCombinations.add(key);
         signals.push({
           id: `first-seen:${r.toolId}:${r.tier}`,
           kind: "first-seen-combination",

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -460,7 +460,7 @@ export interface GeneratedIpcInvokeMap {
     result: import("./mcpServer.js").McpAuditRecord[];
   };
   "mcp-server:get-audit-stats": {
-    args: [];
+    args: [markSeen?: boolean | undefined];
     result: import("./mcpServer.js").McpAuditStats;
   };
   "mcp-server:get-config-snippet": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ import { useDoubleShift } from "./hooks/useDoubleShift";
 import { useProjectMruSwitcher } from "./hooks/useProjectMruSwitcher";
 import { useKeepMounted } from "./hooks/useKeepMounted";
 import { useMcpBridge } from "./hooks/useMcpBridge";
+import { useMcpAnomalyStats } from "./hooks/useMcpAnomalyStats";
 import { usePluginBridge } from "./hooks/usePluginBridge";
 import { useFileDropGuard } from "./hooks/useFileDropGuard";
 import { notifyViewPainted, removeStartupSkeleton } from "./utils/removeStartupSkeleton";
@@ -455,6 +456,7 @@ function AppInner() {
   useMainProcessToastListener();
 
   useMcpBridge();
+  useMcpAnomalyStats();
   usePluginBridge();
   const { homeDir } = useHomeDir();
 

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -24,6 +24,7 @@ import { HelpPanelBanners } from "./HelpPanelBanners";
 import { HelpPanelVersionGate } from "./HelpPanelVersionGate";
 import { HelpLaunchingState } from "./HelpLaunchingState";
 import { McpActivityStrip } from "./McpActivityStrip";
+import { McpAnomalyFooterLink } from "./McpAnomalyFooterLink";
 import { FigureRail } from "./FigureRail";
 import {
   useHelpPanelStore,
@@ -866,8 +867,9 @@ export function HelpPanel({
           the popover / hover titles / header docs button now. */}
       {showTerminal && agentConfig && !isMissingCli && (
         <div className="flex items-center justify-between gap-3 border-t border-daintree-border shrink-0 px-3 py-1.5 text-[11px] text-daintree-text/40">
-          <span className="flex items-center min-w-0">
+          <span className="flex items-center gap-2 min-w-0">
             <McpActivityStrip sessionId={sessionId} activity={session.mcpActivity} />
+            <McpAnomalyFooterLink />
           </span>
           <span className="flex items-center gap-2 min-w-0 shrink-0 max-w-[70%]">
             {pinnedContext &&

--- a/src/components/HelpPanel/McpAnomalyFooterLink.tsx
+++ b/src/components/HelpPanel/McpAnomalyFooterLink.tsx
@@ -1,0 +1,36 @@
+import { TriangleAlert } from "lucide-react";
+import { actionService } from "@/services/ActionService";
+import { useMcpAnomalyStore } from "@/store/mcpAnomalyStore";
+
+/**
+ * Tier 1 ambient footer link for MCP audit anomaly signals (#10022). The
+ * anomaly detail itself lives in Settings → MCP Server → Audit Log; this is the
+ * quiet, in-context shortcut to it that surfaces alongside the assistant's
+ * recent-activity strip. Renders nothing until {@link useMcpAnomalyStore}
+ * reports an anomaly, so it's safe to mount unconditionally inside the footer.
+ *
+ * Deliberately never calls `notify()` — anomalies are background diagnostics,
+ * and the surrounding UI (this link plus the toolbar pip) is the entire signal.
+ */
+export function McpAnomalyFooterLink() {
+  const hasAnomaly = useMcpAnomalyStore((s) => s.hasAnomaly);
+  const anomalyCount = useMcpAnomalyStore((s) => s.anomalyCount);
+
+  if (!hasAnomaly) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        void actionService.dispatch("app.settings.openTab", { tab: "mcp" }, { source: "user" })
+      }
+      className="flex items-center gap-1 min-w-0 shrink-0 text-status-warning transition-colors duration-150 ease-out hover:text-status-warning/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+      title="Open MCP audit log to review anomaly signals"
+    >
+      <TriangleAlert aria-hidden className="w-3 h-3 shrink-0" />
+      <span className="truncate">
+        {anomalyCount === 1 ? "1 anomaly signal" : `${anomalyCount} anomaly signals`}
+      </span>
+    </button>
+  );
+}

--- a/src/components/HelpPanel/__tests__/McpAnomalyFooterLink.test.tsx
+++ b/src/components/HelpPanel/__tests__/McpAnomalyFooterLink.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+
+const dispatchMock = vi.fn();
+const notifyMock = vi.fn();
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: (...args: unknown[]) => dispatchMock(...args) },
+}));
+
+vi.mock("@/lib/notify", () => ({
+  notify: (...args: unknown[]) => notifyMock(...args),
+}));
+
+import { McpAnomalyFooterLink } from "../McpAnomalyFooterLink";
+import { __resetMcpAnomalyStoreForTesting, useMcpAnomalyStore } from "@/store/mcpAnomalyStore";
+
+beforeEach(() => {
+  dispatchMock.mockReset();
+  notifyMock.mockReset();
+  __resetMcpAnomalyStoreForTesting();
+});
+
+afterEach(() => {
+  cleanup();
+  __resetMcpAnomalyStoreForTesting();
+});
+
+describe("McpAnomalyFooterLink", () => {
+  it("renders nothing when there is no anomaly", () => {
+    const { container } = render(<McpAnomalyFooterLink />);
+    expect(container.querySelector("button")).toBeNull();
+  });
+
+  it("renders singular copy for a single anomaly", () => {
+    useMcpAnomalyStore.setState({ hasAnomaly: true, anomalyCount: 1 });
+    render(<McpAnomalyFooterLink />);
+    expect(screen.getByRole("button").textContent).toBe("1 anomaly signal");
+  });
+
+  it("renders plural copy for multiple anomalies", () => {
+    useMcpAnomalyStore.setState({ hasAnomaly: true, anomalyCount: 3 });
+    render(<McpAnomalyFooterLink />);
+    expect(screen.getByRole("button").textContent).toBe("3 anomaly signals");
+  });
+
+  it("navigates to the MCP settings tab on click", () => {
+    useMcpAnomalyStore.setState({ hasAnomaly: true, anomalyCount: 2 });
+    render(<McpAnomalyFooterLink />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "mcp" },
+      { source: "user" }
+    );
+  });
+
+  it("never calls notify()", () => {
+    useMcpAnomalyStore.setState({ hasAnomaly: true, anomalyCount: 1 });
+    render(<McpAnomalyFooterLink />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Layout/ToolbarAssistantButton.tsx
+++ b/src/components/Layout/ToolbarAssistantButton.tsx
@@ -11,8 +11,14 @@ import { usePanelStore } from "@/store";
 import { isPtyPanel } from "@shared/types/panel";
 import { suppressSidebarResizes } from "@/lib/sidebarToggle";
 import { useMcpReadiness } from "@/hooks/useMcpReadiness";
+import { useMcpAnomalyStore } from "@/store/mcpAnomalyStore";
 import type { McpRuntimeSnapshot } from "@shared/types";
 import type { AgentState } from "@/types";
+
+// Tooltip/aria copy for the lowest-precedence anomaly pip (#10022). Surfaced
+// only when neither an MCP-health pip nor an agent pip is competing for the
+// corner — anomaly signals are background diagnostics, not live state.
+const ANOMALY_PIP_TOOLTIP = "MCP anomaly signals detected";
 
 const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text relative";
 
@@ -92,6 +98,7 @@ export function ToolbarAssistantButton({
     return p && isPtyPanel(p) ? (p.agentState ?? null) : null;
   });
   const mcp = useMcpReadiness();
+  const hasAnomaly = useMcpAnomalyStore((s) => s.hasAnomaly);
   const shortcut = useKeybindingDisplay("help.togglePanel");
   const ariaShortcut = useAriaKeyshortcuts("help.togglePanel");
   const hintHover = useShortcutHintHover("help.togglePanel");
@@ -140,12 +147,19 @@ export function ToolbarAssistantButton({
     lastSeenMarker.terminalId === assistantTerminalId &&
     lastSeenMarker.state === agentState;
   const showAgentPip = !pip && agentPip !== null && !isVisible && !isAcknowledged;
+  // Lowest-precedence ambient signal: an MCP audit anomaly fired (#10022). Only
+  // surfaces when no MCP-health pip and no agent pip are already claiming the
+  // corner, so it never masks a more urgent state. Stays visible whether or not
+  // the panel is open — the actionable detail link lives in the panel footer.
+  const showAnomalyPip = !pip && !showAgentPip && hasAnomaly;
   const baseTooltip = isVisible ? "Close Daintree Assistant" : "Open Daintree Assistant";
   const ariaLabel = pip
     ? `Daintree Assistant — ${pip.tooltip}`
     : showAgentPip
       ? `Daintree Assistant — ${agentPip!.tooltip}`
-      : "Daintree Assistant";
+      : showAnomalyPip
+        ? `Daintree Assistant — ${ANOMALY_PIP_TOOLTIP}`
+        : "Daintree Assistant";
 
   return (
     <Tooltip>
@@ -172,10 +186,15 @@ export function ToolbarAssistantButton({
               aria-hidden="true"
               data-testid="assistant-working-pip"
               data-agent-state={agentState ?? ""}
-              data-visible={pip !== null || showAgentPip}
+              data-visible={pip !== null || showAgentPip || showAnomalyPip}
               className={cn(
                 "toolbar-pip toolbar-badge",
-                pip?.className ?? (showAgentPip ? agentPip?.className : undefined),
+                pip?.className ??
+                  (showAgentPip
+                    ? agentPip?.className
+                    : showAnomalyPip
+                      ? "bg-status-warning"
+                      : undefined),
                 pip?.delayed && "animate-pulse-delayed"
               )}
             />
@@ -188,7 +207,9 @@ export function ToolbarAssistantButton({
             ? `${baseTooltip} — ${pip.tooltip}`
             : showAgentPip
               ? `${baseTooltip} — ${agentPip!.tooltip}`
-              : baseTooltip,
+              : showAnomalyPip
+                ? `${baseTooltip} — ${ANOMALY_PIP_TOOLTIP}`
+                : baseTooltip,
           shortcut
         )}
       </TooltipContent>

--- a/src/components/Layout/__tests__/ToolbarAssistantButton.test.tsx
+++ b/src/components/Layout/__tests__/ToolbarAssistantButton.test.tsx
@@ -4,6 +4,7 @@ import { render, act, fireEvent } from "@testing-library/react";
 import { ToolbarAssistantButton } from "../ToolbarAssistantButton";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { usePanelStore } from "@/store";
+import { __resetMcpAnomalyStoreForTesting, useMcpAnomalyStore } from "@/store/mcpAnomalyStore";
 import type { McpRuntimeSnapshot } from "@shared/types";
 
 const mcpReadiness: () => McpRuntimeSnapshot = vi.fn(
@@ -110,6 +111,7 @@ describe("ToolbarAssistantButton — agent state pip", () => {
     usePanelStore.setState({ panelsById: {}, panelIds: [] } as never);
     mockGestureAssistantHidden = false;
     clearAssistantGestureMock.mockClear();
+    __resetMcpAnomalyStoreForTesting();
   });
 
   it("does not render the pip when the assistant is idle", () => {
@@ -428,6 +430,92 @@ describe("ToolbarAssistantButton — agent state pip", () => {
       setPanel("t-5", "idle");
     });
 
+    expect(queryByTestId("assistant-working-pip")?.getAttribute("data-visible")).toBe("false");
+  });
+});
+
+describe("ToolbarAssistantButton — MCP anomaly pip (#10022)", () => {
+  beforeEach(() => {
+    mcpReadinessMock.mockReturnValue({ enabled: true, state: "ready", port: 0, lastError: null });
+    useHelpPanelStore.setState({ isOpen: false, terminalId: null, agentId: null, sessionId: null });
+    usePanelStore.setState({ panelsById: {}, panelIds: [] } as never);
+    mockGestureAssistantHidden = false;
+    __resetMcpAnomalyStoreForTesting();
+  });
+
+  it("shows a warning pip when an anomaly is set and no other pip applies", () => {
+    setHelpPanel({ isOpen: false, terminalId: null });
+    act(() => {
+      useMcpAnomalyStore.setState({ hasAnomaly: true, anomalyCount: 2 });
+    });
+
+    const { container, queryByTestId } = render(<ToolbarAssistantButton />);
+    const pip = queryByTestId("assistant-working-pip");
+    expect(pip?.getAttribute("data-visible")).toBe("true");
+    expect(pip!.className).toMatch(/bg-status-warning/);
+    expect(pip!.className).not.toMatch(/animate-pulse/);
+    expect(pip!.className).not.toMatch(/accent/);
+    expect(container.querySelector("button")?.getAttribute("aria-label")).toBe(
+      "Daintree Assistant — MCP anomaly signals detected"
+    );
+  });
+
+  it("stays visible even when the panel is open (unlike the agent pip)", () => {
+    setHelpPanel({ isOpen: true, terminalId: null });
+    act(() => {
+      useMcpAnomalyStore.setState({ hasAnomaly: true, anomalyCount: 1 });
+    });
+
+    const { queryByTestId } = render(<ToolbarAssistantButton />);
+    const pip = queryByTestId("assistant-working-pip");
+    expect(pip?.getAttribute("data-visible")).toBe("true");
+    expect(pip!.className).toMatch(/bg-status-warning/);
+  });
+
+  it("is suppressed by the MCP-failed pip", () => {
+    mcpReadinessMock.mockReturnValue({ state: "failed", port: 0, lastError: "oops" } as never);
+    setHelpPanel({ isOpen: false, terminalId: null });
+    act(() => {
+      useMcpAnomalyStore.setState({ hasAnomaly: true, anomalyCount: 1 });
+    });
+
+    const { queryByTestId } = render(<ToolbarAssistantButton />);
+    const pip = queryByTestId("assistant-working-pip");
+    expect(pip!.className).toMatch(/bg-status-danger/);
+    expect(pip!.className).not.toMatch(/bg-status-warning/);
+  });
+
+  it("is suppressed by the MCP-starting pip", () => {
+    mcpReadinessMock.mockReturnValue({ state: "starting", port: 0, lastError: null } as never);
+    setHelpPanel({ isOpen: false, terminalId: null });
+    act(() => {
+      useMcpAnomalyStore.setState({ hasAnomaly: true, anomalyCount: 1 });
+    });
+
+    const { queryByTestId } = render(<ToolbarAssistantButton />);
+    const pip = queryByTestId("assistant-working-pip");
+    expect(pip!.className).toMatch(/bg-status-warning/);
+    // The starting pip pulses; the anomaly pip never does — proves which one won.
+    expect(pip!.className).toMatch(/animate-pulse-delayed/);
+  });
+
+  it("is suppressed by an active agent pip", () => {
+    setHelpPanel({ isOpen: false, terminalId: "t-anom" });
+    setPanel("t-anom", "working");
+    act(() => {
+      useMcpAnomalyStore.setState({ hasAnomaly: true, anomalyCount: 1 });
+    });
+
+    const { queryByTestId } = render(<ToolbarAssistantButton />);
+    const pip = queryByTestId("assistant-working-pip");
+    expect(pip!.className).toMatch(/bg-state-working/);
+    expect(pip!.className).not.toMatch(/bg-status-warning/);
+  });
+
+  it("does not show a pip when there is no anomaly", () => {
+    setHelpPanel({ isOpen: false, terminalId: null });
+
+    const { queryByTestId } = render(<ToolbarAssistantButton />);
     expect(queryByTestId("assistant-working-pip")?.getAttribute("data-visible")).toBe("false");
   });
 });

--- a/src/hooks/__tests__/useMcpAnomalyStats.test.tsx
+++ b/src/hooks/__tests__/useMcpAnomalyStats.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { McpAnomalySignal, McpAuditStats } from "@shared/types/ipc/mcpServer";
+
+let mockCurrentProjectId: string | null = null;
+const getAuditStatsMock = vi.fn<() => Promise<McpAuditStats>>();
+const logWarnMock = vi.fn();
+const notifyMock = vi.fn();
+
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: (selector: (s: { currentProject: { id: string } | null }) => unknown) =>
+    selector({
+      currentProject: mockCurrentProjectId ? { id: mockCurrentProjectId } : null,
+    }),
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logWarn: (...args: unknown[]) => logWarnMock(...args),
+}));
+
+// Guard the "never notifies" contract directly at the hook level too.
+vi.mock("@/lib/notify", () => ({
+  notify: (...args: unknown[]) => notifyMock(...args),
+}));
+
+import { useMcpAnomalyStats } from "../useMcpAnomalyStats";
+import { __resetMcpAnomalyStoreForTesting, useMcpAnomalyStore } from "@/store/mcpAnomalyStore";
+
+function signalFixture(id: string): McpAnomalySignal {
+  return {
+    id,
+    kind: "failure-cluster",
+    toolId: "help.search",
+    severity: "danger",
+    timestamp: 1_000,
+    recordIds: [id],
+  };
+}
+
+function statsFixture(overrides: Partial<McpAuditStats> = {}): McpAuditStats {
+  return {
+    auth401Count: 0,
+    anomalySignals: [],
+    anomalySuppressed: false,
+    anomalyRecordFloor: 50,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockCurrentProjectId = "project-a";
+  getAuditStatsMock.mockReset();
+  getAuditStatsMock.mockResolvedValue(statsFixture());
+  logWarnMock.mockReset();
+  notifyMock.mockReset();
+  __resetMcpAnomalyStoreForTesting();
+  vi.stubGlobal("window", {
+    ...globalThis.window,
+    electron: { mcpServer: { getAuditStats: getAuditStatsMock } },
+  });
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("useMcpAnomalyStats", () => {
+  it("populates the store from an initial successful poll", async () => {
+    getAuditStatsMock.mockResolvedValueOnce(statsFixture({ anomalySignals: [signalFixture("a")] }));
+    renderHook(() => useMcpAnomalyStats());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(useMcpAnomalyStore.getState().hasAnomaly).toBe(true);
+    expect(useMcpAnomalyStore.getState().anomalyCount).toBe(1);
+  });
+
+  it("never calls notify() for anomaly signals", async () => {
+    getAuditStatsMock.mockResolvedValueOnce(statsFixture({ anomalySignals: [signalFixture("a")] }));
+    renderHook(() => useMcpAnomalyStats());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("resets the store immediately when the project changes", async () => {
+    getAuditStatsMock.mockResolvedValueOnce(statsFixture({ anomalySignals: [signalFixture("a")] }));
+    const { rerender } = renderHook(() => useMcpAnomalyStats());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(useMcpAnomalyStore.getState().hasAnomaly).toBe(true);
+
+    // Switch projects; the new poll resolves with no anomalies, but the reset
+    // must have already cleared the flag synchronously on the project change.
+    mockCurrentProjectId = "project-b";
+    getAuditStatsMock.mockResolvedValueOnce(statsFixture({ anomalySignals: [] }));
+    rerender();
+    expect(useMcpAnomalyStore.getState().hasAnomaly).toBe(false);
+  });
+
+  it("fails closed and warns when the IPC rejects", async () => {
+    getAuditStatsMock.mockResolvedValueOnce(statsFixture({ anomalySignals: [signalFixture("a")] }));
+    renderHook(() => useMcpAnomalyStats());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(useMcpAnomalyStore.getState().hasAnomaly).toBe(true);
+
+    getAuditStatsMock.mockRejectedValueOnce(new Error("IPC down"));
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+      await Promise.resolve();
+    });
+    expect(useMcpAnomalyStore.getState().hasAnomaly).toBe(false);
+    expect(logWarnMock).toHaveBeenCalled();
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("discards a stale response that resolves after a project change", async () => {
+    let resolveA: (v: McpAuditStats) => void = () => {};
+    const pendingA = new Promise<McpAuditStats>((r) => {
+      resolveA = r;
+    });
+    getAuditStatsMock.mockReturnValueOnce(pendingA);
+
+    const { rerender } = renderHook(() => useMcpAnomalyStats());
+
+    // Switch to project-b before A resolves; B reports no anomalies.
+    mockCurrentProjectId = "project-b";
+    getAuditStatsMock.mockResolvedValueOnce(statsFixture({ anomalySignals: [] }));
+    rerender();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(useMcpAnomalyStore.getState().hasAnomaly).toBe(false);
+
+    // A's stale response (with anomalies) must be discarded.
+    await act(async () => {
+      resolveA(statsFixture({ anomalySignals: [signalFixture("a")] }));
+      await Promise.resolve();
+    });
+    expect(useMcpAnomalyStore.getState().hasAnomaly).toBe(false);
+  });
+});

--- a/src/hooks/useMcpAnomalyStats.ts
+++ b/src/hooks/useMcpAnomalyStats.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useRef } from "react";
+import { useProjectStore } from "@/store/projectStore";
+import { useMcpAnomalyStore } from "@/store/mcpAnomalyStore";
+import { useVisibilityAwareInterval } from "@/hooks/useVisibilityAwareInterval";
+import { logWarn } from "@/utils/logger";
+
+/**
+ * Cadence for the ambient anomaly poll. Slow on purpose (#10022): anomaly
+ * signals are background diagnostics, not live state, so a 30s glance keeps IPC
+ * churn negligible while still surfacing a freshly-fired signal within a normal
+ * attention window. Matches `useProjectPresetsSubscription`'s interval.
+ */
+const POLL_INTERVAL_MS = 30_000;
+
+/**
+ * App-level hook that keeps {@link useMcpAnomalyStore} fed from
+ * `getAuditStats()` so the toolbar pip and HelpPanel footer link can surface
+ * MCP audit anomalies as a Tier 1 ambient signal — no `notify()`, no toast.
+ *
+ * Mount once near `useMcpBridge` so the poll runs regardless of whether the
+ * toolbar button or HelpPanel is currently rendered. `getAuditStats()` is an
+ * in-memory computation on the main side, so a 30s poll is cheap.
+ *
+ * Audit stats are process-global (same scope the Settings tab reads), so the
+ * flag isn't truly project-scoped — but we still `reset()` on project change so
+ * a stale pip never lingers across a switch while the first poll for the new
+ * context is in flight. The `activeIdRef` guard discards any response that
+ * resolves after the project has changed.
+ */
+export function useMcpAnomalyStats(): void {
+  const currentProjectId = useProjectStore((s) => s.currentProject?.id ?? null);
+  const setFromStats = useMcpAnomalyStore((s) => s.setFromStats);
+  const reset = useMcpAnomalyStore((s) => s.reset);
+  const activeIdRef = useRef<string | null>(null);
+
+  const poll = useCallback(async () => {
+    const projectId = activeIdRef.current;
+    try {
+      const stats = await window.electron.mcpServer.getAuditStats();
+      if (activeIdRef.current !== projectId) return;
+      setFromStats(stats);
+    } catch (error) {
+      if (activeIdRef.current !== projectId) return;
+      // Fail closed: a failed fetch must not strand a stale "anomaly" pip, and
+      // the user can't act on the fetch failure itself — Tier 0 silent log.
+      logWarn("[useMcpAnomalyStats] Failed to load MCP audit stats", { error });
+      setFromStats(null);
+    }
+  }, [setFromStats]);
+
+  useEffect(() => {
+    activeIdRef.current = currentProjectId;
+    // Clear immediately on every project change (including to "no project") so
+    // the pip can't carry over from the previous context, then take a fresh
+    // reading right away — the interval below only fires after the first
+    // POLL_INTERVAL_MS, so without this the pip would lag 30s on launch.
+    reset();
+    void poll();
+  }, [currentProjectId, reset, poll]);
+
+  useVisibilityAwareInterval(() => void poll(), POLL_INTERVAL_MS);
+}

--- a/src/hooks/useMcpAnomalyStats.ts
+++ b/src/hooks/useMcpAnomalyStats.ts
@@ -36,7 +36,10 @@ export function useMcpAnomalyStats(): void {
   const poll = useCallback(async () => {
     const projectId = activeIdRef.current;
     try {
-      const stats = await window.electron.mcpServer.getAuditStats();
+      // Passive read (markSeen=false): this background poll must not acknowledge
+      // transient `first-seen-combination` signals — that "fire once"
+      // acknowledgment belongs to the user-facing Settings audit log (#10022).
+      const stats = await window.electron.mcpServer.getAuditStats(false);
       if (activeIdRef.current !== projectId) return;
       setFromStats(stats);
     } catch (error) {

--- a/src/store/__tests__/mcpAnomalyStore.test.ts
+++ b/src/store/__tests__/mcpAnomalyStore.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { McpAnomalySignal, McpAuditStats } from "@shared/types/ipc/mcpServer";
+import { __resetMcpAnomalyStoreForTesting, useMcpAnomalyStore } from "../mcpAnomalyStore";
+
+function signalFixture(id: string): McpAnomalySignal {
+  return {
+    id,
+    kind: "latency-drift",
+    toolId: "help.search",
+    severity: "danger",
+    timestamp: 1_000,
+    recordIds: [id],
+  };
+}
+
+function statsFixture(overrides: Partial<McpAuditStats> = {}): McpAuditStats {
+  return {
+    auth401Count: 0,
+    anomalySignals: [],
+    anomalySuppressed: false,
+    anomalyRecordFloor: 50,
+    ...overrides,
+  };
+}
+
+describe("mcpAnomalyStore", () => {
+  beforeEach(() => {
+    __resetMcpAnomalyStoreForTesting();
+  });
+
+  afterEach(() => {
+    __resetMcpAnomalyStoreForTesting();
+  });
+
+  it("starts with no anomaly", () => {
+    const state = useMcpAnomalyStore.getState();
+    expect(state.hasAnomaly).toBe(false);
+    expect(state.anomalyCount).toBe(0);
+  });
+
+  it("flags anomalies and tracks the count when signals are present and unsuppressed", () => {
+    useMcpAnomalyStore
+      .getState()
+      .setFromStats(statsFixture({ anomalySignals: [signalFixture("a"), signalFixture("b")] }));
+    const state = useMcpAnomalyStore.getState();
+    expect(state.hasAnomaly).toBe(true);
+    expect(state.anomalyCount).toBe(2);
+  });
+
+  it("stays quiet while suppressed even with signals present", () => {
+    useMcpAnomalyStore
+      .getState()
+      .setFromStats(
+        statsFixture({ anomalySignals: [signalFixture("a")], anomalySuppressed: true })
+      );
+    expect(useMcpAnomalyStore.getState().hasAnomaly).toBe(false);
+  });
+
+  it("stays quiet when there are no signals", () => {
+    useMcpAnomalyStore.getState().setFromStats(statsFixture({ anomalySignals: [] }));
+    expect(useMcpAnomalyStore.getState().hasAnomaly).toBe(false);
+  });
+
+  it("clears the flag when a later poll reports no anomalies", () => {
+    const store = useMcpAnomalyStore.getState();
+    store.setFromStats(statsFixture({ anomalySignals: [signalFixture("a")] }));
+    expect(useMcpAnomalyStore.getState().hasAnomaly).toBe(true);
+
+    store.setFromStats(statsFixture({ anomalySignals: [] }));
+    expect(useMcpAnomalyStore.getState().hasAnomaly).toBe(false);
+    expect(useMcpAnomalyStore.getState().anomalyCount).toBe(0);
+  });
+
+  it("clears the flag when stats are null (failed fetch — fail closed)", () => {
+    const store = useMcpAnomalyStore.getState();
+    store.setFromStats(statsFixture({ anomalySignals: [signalFixture("a")] }));
+    expect(useMcpAnomalyStore.getState().hasAnomaly).toBe(true);
+
+    store.setFromStats(null);
+    expect(useMcpAnomalyStore.getState().hasAnomaly).toBe(false);
+  });
+
+  it("reset() returns to the initial state", () => {
+    const store = useMcpAnomalyStore.getState();
+    store.setFromStats(statsFixture({ anomalySignals: [signalFixture("a")] }));
+    store.reset();
+    expect(useMcpAnomalyStore.getState().hasAnomaly).toBe(false);
+    expect(useMcpAnomalyStore.getState().anomalyCount).toBe(0);
+  });
+
+  it("does not produce a new state object when nothing changes (referential stability)", () => {
+    const store = useMcpAnomalyStore.getState();
+    store.setFromStats(statsFixture({ anomalySignals: [] }));
+    const before = useMcpAnomalyStore.getState();
+    store.setFromStats(statsFixture({ anomalySignals: [] }));
+    const after = useMcpAnomalyStore.getState();
+    expect(after.hasAnomaly).toBe(before.hasAnomaly);
+    expect(after.anomalyCount).toBe(before.anomalyCount);
+  });
+});

--- a/src/store/__tests__/mcpAnomalyStore.test.ts
+++ b/src/store/__tests__/mcpAnomalyStore.test.ts
@@ -56,6 +56,18 @@ describe("mcpAnomalyStore", () => {
     expect(useMcpAnomalyStore.getState().hasAnomaly).toBe(false);
   });
 
+  it("clears a stale count when a later poll reports suppression", () => {
+    const store = useMcpAnomalyStore.getState();
+    store.setFromStats(statsFixture({ anomalySignals: [signalFixture("a"), signalFixture("b")] }));
+    expect(useMcpAnomalyStore.getState().anomalyCount).toBe(2);
+
+    store.setFromStats(
+      statsFixture({ anomalySignals: [signalFixture("a")], anomalySuppressed: true })
+    );
+    expect(useMcpAnomalyStore.getState().hasAnomaly).toBe(false);
+    expect(useMcpAnomalyStore.getState().anomalyCount).toBe(0);
+  });
+
   it("stays quiet when there are no signals", () => {
     useMcpAnomalyStore.getState().setFromStats(statsFixture({ anomalySignals: [] }));
     expect(useMcpAnomalyStore.getState().hasAnomaly).toBe(false);
@@ -78,6 +90,7 @@ describe("mcpAnomalyStore", () => {
 
     store.setFromStats(null);
     expect(useMcpAnomalyStore.getState().hasAnomaly).toBe(false);
+    expect(useMcpAnomalyStore.getState().anomalyCount).toBe(0);
   });
 
   it("reset() returns to the initial state", () => {
@@ -93,8 +106,17 @@ describe("mcpAnomalyStore", () => {
     store.setFromStats(statsFixture({ anomalySignals: [] }));
     const before = useMcpAnomalyStore.getState();
     store.setFromStats(statsFixture({ anomalySignals: [] }));
-    const after = useMcpAnomalyStore.getState();
-    expect(after.hasAnomaly).toBe(before.hasAnomaly);
-    expect(after.anomalyCount).toBe(before.anomalyCount);
+    // Same object reference — a no-op poll must not trigger a re-render. This is
+    // the load-bearing assertion; comparing values alone would pass even if a
+    // fresh object were returned every 30s tick.
+    expect(useMcpAnomalyStore.getState()).toBe(before);
+  });
+
+  it("keeps a stable reference across repeated identical anomaly polls", () => {
+    const store = useMcpAnomalyStore.getState();
+    store.setFromStats(statsFixture({ anomalySignals: [signalFixture("a")] }));
+    const before = useMcpAnomalyStore.getState();
+    store.setFromStats(statsFixture({ anomalySignals: [signalFixture("a")] }));
+    expect(useMcpAnomalyStore.getState()).toBe(before);
   });
 });

--- a/src/store/mcpAnomalyStore.ts
+++ b/src/store/mcpAnomalyStore.ts
@@ -1,0 +1,63 @@
+import { create } from "zustand";
+import type { McpAuditStats } from "@shared/types/ipc/mcpServer";
+
+/**
+ * Ambient state for MCP audit anomaly signals (#10022). The audit service
+ * computes anomaly signals (latency-drift, first-seen-combination,
+ * failure-cluster, p95-z-score) and returns them on {@link McpAuditStats}, but
+ * until now they only surfaced inside Settings → MCP Server → Audit Log. This
+ * store holds the distilled "is there anything worth a glance" flag so a Tier 1
+ * ambient indicator (the toolbar assistant pip and the HelpPanel footer link)
+ * can surface it without anyone calling `notify()`.
+ *
+ * Audit stats are process-global on the main side — the same scope the Settings
+ * tab already reads — so this flag is not project-scoped. The polling hook still
+ * resets it on project change for UX hygiene (don't carry a stale pip across a
+ * switch); see `useMcpAnomalyStats`.
+ */
+interface McpAnomalyState {
+  hasAnomaly: boolean;
+  anomalyCount: number;
+}
+
+interface McpAnomalyActions {
+  /**
+   * Distill the IPC stats into the ambient flag. Owns the same suppression rule
+   * `McpAuditLogViewer` applies: signals only count when the ring buffer has
+   * cleared its record floor (`!anomalySuppressed`) and at least one signal is
+   * present. A null/undefined stats payload (failed fetch) clears the flag.
+   */
+  setFromStats: (stats: McpAuditStats | null | undefined) => void;
+  reset: () => void;
+}
+
+const INITIAL_STATE: McpAnomalyState = {
+  hasAnomaly: false,
+  anomalyCount: 0,
+};
+
+export const useMcpAnomalyStore = create<McpAnomalyState & McpAnomalyActions>((set) => ({
+  ...INITIAL_STATE,
+
+  setFromStats: (stats) => {
+    if (!stats || stats.anomalySuppressed || stats.anomalySignals.length === 0) {
+      // Only write when transitioning out of an active state — avoids a
+      // no-op render every poll while there are no anomalies.
+      set((prev) => (prev.hasAnomaly ? { ...INITIAL_STATE } : prev));
+      return;
+    }
+    const count = stats.anomalySignals.length;
+    set((prev) =>
+      prev.hasAnomaly && prev.anomalyCount === count
+        ? prev
+        : { hasAnomaly: true, anomalyCount: count }
+    );
+  },
+
+  reset: () => set((prev) => (prev.hasAnomaly ? { ...INITIAL_STATE } : prev)),
+}));
+
+/** Test-only escape hatch — resets the store to its initial state. */
+export function __resetMcpAnomalyStoreForTesting(): void {
+  useMcpAnomalyStore.setState({ ...INITIAL_STATE });
+}

--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -323,11 +323,14 @@
  *    McpRuntimeSnapshot.state and surface as MCP health; `working`,
  *    `directing`, `waiting` come from AgentStateMachine and surface as the
  *    agent activity pip, which is suppressed when the panel is open or the
- *    state has been acknowledged. NotificationCenterToolbarButton owns the
- *    `unread` dot on its own surface — it doesn't compete with the assistant
- *    pips, so the ordering reads:
+ *    state has been acknowledged. Below those, the audit-anomaly pip
+ *    (mcpAnomalyStore.hasAnomaly, bg-status-warning) is the lowest-precedence
+ *    ambient signal — it only shows when no health or agent pip is competing,
+ *    and unlike the agent pip it stays visible while the panel is open (#10022).
+ *    NotificationCenterToolbarButton owns the `unread` dot on its own surface —
+ *    it doesn't compete with the assistant pips, so the ordering reads:
  *
- *      MCP failed > MCP starting > agent working / directing / waiting
+ *      MCP failed > MCP starting > agent working / directing / waiting > MCP anomaly
  *      notification unread (independent surface)
  *
  *    DND dimming (.toolbar-badge[data-dnd-active]) is a cross-tier overlay


### PR DESCRIPTION
## Summary

- MCP audit anomaly signals (`latency-drift`, `first-seen-combination`, `failure-cluster`, `p95-z-score`) were previously only visible inside Settings → MCP Server → Audit Log. Users had no way to know an anomaly had fired without navigating there.
- This adds a Tier 1 ambient surface: a warning pip on `ToolbarAssistantButton` and a quiet footer link in `HelpPanel`. No toasts, no `notify()` — just a low-visibility indicator that something is worth a look.
- The background poll uses a new `markSeen: false` flag on `getAuditStats`/`getSignals` so it doesn't consume the transient `first-seen-combination` signal before the user follows the pip to Settings.

Resolves #10022

## Changes

- **`mcpAnomalyStore`** (Zustand): `{ hasAnomaly, anomalyCount }`, distilled from `getAuditStats()`. Owns the suppression rule: `!anomalySuppressed && signals.length > 0`.
- **`useMcpAnomalyStats`** hook: 30s visibility-aware poll, fails closed on IPC error, resets on project change, drops stale responses.
- **`ToolbarAssistantButton`**: lowest-precedence warning pip (`bg-status-warning`) below the MCP-health and agent pips; stays visible while the panel is open (unlike the agent pip).
- **`McpAnomalyFooterLink`** in `HelpPanel` footer: quiet "N anomaly signal(s)" link that opens Settings → MCP Server.
- **Passive read flag**: `getSignals`/`getAuditStats` gain a `markSeen` param (default `true`); background poll passes `false`. Threaded through `McpServerService` + IPC handler; IPC codegen regenerated.

## Testing

- New unit tests: `mcpAnomalyStore` (9), `useMcpAnomalyStats` (5), `McpAnomalyFooterLink` (5), `ToolbarAssistantButton` anomaly-pip precedence (+6), `auditLog` passive-read non-consumption (+1).
- Existing `McpServerSettingsTab.test.tsx` binding tests still pass unchanged.
- Local CI passed: lint, format, typecheck, IPC/channel/confirm-wiring guards, full unit suite, build.