### PR TITLE
fix(terminal): reconcile activity tier on late wake of a backgrounded terminal (#9906)

### DIFF
--- a/electron/pty-host/handlers/__tests__/backpressure.test.ts
+++ b/electron/pty-host/handlers/__tests__/backpressure.test.ts
@@ -323,7 +323,7 @@ describe("wake-terminal handler — late-wake tier reconciliation (#9906)", () =
       "wake-terminal-correction"
     );
     // ActivityMonitor returned to the 500ms background cadence.
-    expect(ctx.ptyManager.setActivityMonitorTier).toHaveBeenCalledWith("term-1", 500);
+    expect(ctx.ptyManager.setActivityMonitorTier).toHaveBeenCalledWith("term-1", "background", 500);
     // The renderer's dedup baseline is reset via the tier-changed broadcast.
     expect(conn.port.postMessage).toHaveBeenCalledWith({
       type: "tier-changed",

--- a/electron/pty-host/handlers/__tests__/backpressure.test.ts
+++ b/electron/pty-host/handlers/__tests__/backpressure.test.ts
@@ -14,7 +14,9 @@ function makeCoordinator() {
 
 function makeRendererConnection(): RendererConnection {
   return {
-    port: {} as RendererConnection["port"],
+    port: {
+      postMessage: vi.fn(),
+    } as unknown as RendererConnection["port"],
     handler: vi.fn(),
     portQueueManager: {
       clearQueue: vi.fn(),
@@ -47,6 +49,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
       deletePauseStartTime: vi.fn(),
       emitTerminalStatus: vi.fn(),
       emitReliabilityMetric: vi.fn(),
+      getActivityTier: vi.fn(() => "active"),
     } as unknown as HostContext["backpressureManager"],
     ipcQueueManager: {
       removeBytes: vi.fn(),
@@ -269,5 +272,126 @@ describe("force-resume handler", () => {
     // nor indirectly via a recompute, both of which would desync the tier state.
     expect(ctx.backpressureManager.setActivityTier).not.toHaveBeenCalled();
     expect(ctx.recomputeActivityTiers).not.toHaveBeenCalled();
+  });
+});
+
+describe("wake-terminal handler — late-wake tier reconciliation (#9906)", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("re-demotes the host and broadcasts a tier-changed correction when a stale wake lands on a backgrounded terminal", async () => {
+    // The renderer backgrounded the pane, but a trailing-edge rate-limited wake
+    // fired afterwards and reached the host. Without reconciliation the host
+    // stays at "active" (50ms polling) streaming into a hidden terminal, and the
+    // renderer's setActivityTier dedup (lastBackendTier === "background") can
+    // never re-send the correction. The handler must detect preWakeTier ===
+    // "background" and push the host + renderer back to background.
+    const coord = makeCoordinator();
+    const conn = makeRendererConnection();
+    const ctx = makeCtx({
+      rendererConnections: new Map([[1, conn]]),
+      windowProjectMap: new Map([[1, "proj-a"]]),
+      getPauseCoordinator: vi.fn(() => coord as never),
+    });
+    (ctx.backpressureManager.getActivityTier as ReturnType<typeof vi.fn>).mockReturnValue(
+      "background"
+    );
+    (ctx.ptyManager.getTerminal as ReturnType<typeof vi.fn>).mockReturnValue({
+      id: "term-1",
+      projectId: "proj-a",
+    });
+
+    const handlers = createBackpressureHandlers(ctx);
+    await handlers["wake-terminal"]({ type: "wake-terminal", id: "term-1", requestId: "r1" });
+
+    // The wake promoted to active first (snapshot path), then the correction
+    // re-demoted with the dedicated reason.
+    expect(ctx.backpressureManager.setActivityTier).toHaveBeenCalledWith(
+      "term-1",
+      "active",
+      "wake-terminal"
+    );
+    expect(ctx.backpressureManager.setActivityTier).toHaveBeenCalledWith(
+      "term-1",
+      "background",
+      "wake-terminal-correction"
+    );
+    // ActivityMonitor returned to the 500ms background cadence.
+    expect(ctx.ptyManager.setActivityMonitorTier).toHaveBeenCalledWith("term-1", 500);
+    // The renderer's dedup baseline is reset via the tier-changed broadcast.
+    expect(conn.port.postMessage).toHaveBeenCalledWith({
+      type: "tier-changed",
+      id: "term-1",
+      tier: "background",
+    });
+  });
+
+  it("does not post a correction when the wake lands on an already-active terminal", async () => {
+    // A normal wake of a visible/active terminal must not be re-demoted — the
+    // correction is strictly for the stale background-desync case.
+    const coord = makeCoordinator();
+    const conn = makeRendererConnection();
+    const ctx = makeCtx({
+      rendererConnections: new Map([[1, conn]]),
+      windowProjectMap: new Map([[1, "proj-a"]]),
+      getPauseCoordinator: vi.fn(() => coord as never),
+    });
+    (ctx.backpressureManager.getActivityTier as ReturnType<typeof vi.fn>).mockReturnValue("active");
+    (ctx.ptyManager.getTerminal as ReturnType<typeof vi.fn>).mockReturnValue({
+      id: "term-1",
+      projectId: "proj-a",
+    });
+
+    const handlers = createBackpressureHandlers(ctx);
+    await handlers["wake-terminal"]({ type: "wake-terminal", id: "term-1", requestId: "r2" });
+
+    expect(ctx.backpressureManager.setActivityTier).not.toHaveBeenCalledWith(
+      "term-1",
+      "background",
+      "wake-terminal-correction"
+    );
+    expect(conn.port.postMessage).not.toHaveBeenCalled();
+  });
+
+  it("project-filters the correction broadcast to windows that own the terminal", async () => {
+    // The tier-changed broadcast must follow the same project filter as the data
+    // path: a window viewing a different project never receives the correction.
+    const coord = makeCoordinator();
+    const ownerConn = makeRendererConnection();
+    const otherConn = makeRendererConnection();
+    const ctx = makeCtx({
+      rendererConnections: new Map([
+        [1, ownerConn],
+        [2, otherConn],
+      ]),
+      windowProjectMap: new Map([
+        [1, "proj-a"],
+        [2, "proj-b"],
+      ]),
+      getPauseCoordinator: vi.fn(() => coord as never),
+    });
+    (ctx.backpressureManager.getActivityTier as ReturnType<typeof vi.fn>).mockReturnValue(
+      "background"
+    );
+    (ctx.ptyManager.getTerminal as ReturnType<typeof vi.fn>).mockReturnValue({
+      id: "term-1",
+      projectId: "proj-a",
+    });
+
+    const handlers = createBackpressureHandlers(ctx);
+    await handlers["wake-terminal"]({ type: "wake-terminal", id: "term-1", requestId: "r3" });
+
+    expect(ownerConn.port.postMessage).toHaveBeenCalledWith({
+      type: "tier-changed",
+      id: "term-1",
+      tier: "background",
+    });
+    expect(otherConn.port.postMessage).not.toHaveBeenCalled();
   });
 });

--- a/electron/pty-host/handlers/backpressure.ts
+++ b/electron/pty-host/handlers/backpressure.ts
@@ -91,6 +91,13 @@ export function createBackpressureHandlers(ctx: HostContext): HandlerMap {
     "wake-terminal": async (msg) => {
       const wakeStartTime = Date.now();
 
+      // Capture the tier before the wake promotes it. A trailing-edge wake that
+      // fires after the renderer already backgrounded the pane (#9906) arrives
+      // here with the host still at "background" — the signal that this wake is
+      // stale and must be undone once the snapshot is served, so the host
+      // doesn't stream at full rate into a hidden terminal forever.
+      const preWakeTier = backpressureManager.getActivityTier(msg.id);
+
       // Wake implies we want a faithful snapshot + resume streaming.
       backpressureManager.setActivityTier(msg.id, "active", "wake-terminal");
       backpressureManager.clearSuspended(msg.id);
@@ -172,6 +179,35 @@ export function createBackpressureHandlers(ctx: HostContext): HandlerMap {
         state,
         warnings: warnings.length > 0 ? warnings : undefined,
       });
+
+      // Reconcile a stale wake (#9906). If the host was already "background"
+      // when this wake arrived, the renderer had moved the pane offscreen and
+      // this wake is a trailing-edge artifact (a rate-limited timer that fired
+      // after the BACKGROUND transition). The snapshot has been served, so
+      // re-demote the host to "background" and push a tier-changed correction
+      // to reset the renderer's setActivityTier dedup baseline — otherwise its
+      // lastBackendTier stays "background" and it can never re-send the
+      // "background" correction, leaving the host streaming at 50ms into a
+      // hidden pane indefinitely. Posted unconditionally when preWakeTier was
+      // "background" (setActivityTier dedupes same-tier, so the broadcast, not
+      // the set, is what reconciles the renderer). FIFO-ordered after the data
+      // path on the same per-window port, project-filtered exactly like
+      // recomputeActivityTiers.
+      if (preWakeTier === "background") {
+        backpressureManager.setActivityTier(msg.id, "background", "wake-terminal-correction");
+        ptyManager.setActivityMonitorTier(msg.id, 500);
+        const wakeTerminal = ptyManager.getTerminal(msg.id);
+        const termProject = wakeTerminal?.projectId ?? null;
+        for (const [windowId, conn] of ctx.rendererConnections) {
+          const windowProject = ctx.windowProjectMap.get(windowId) ?? null;
+          if (windowProject !== null && termProject !== windowProject) continue;
+          try {
+            conn.port.postMessage({ type: "tier-changed", id: msg.id, tier: "background" });
+          } catch {
+            // Port closing between iteration and post — disconnect handles cleanup.
+          }
+        }
+      }
     },
 
     "force-resume": (msg) => {

--- a/electron/pty-host/handlers/backpressure.ts
+++ b/electron/pty-host/handlers/backpressure.ts
@@ -195,7 +195,7 @@ export function createBackpressureHandlers(ctx: HostContext): HandlerMap {
       // recomputeActivityTiers.
       if (preWakeTier === "background") {
         backpressureManager.setActivityTier(msg.id, "background", "wake-terminal-correction");
-        ptyManager.setActivityMonitorTier(msg.id, 500);
+        ptyManager.setActivityMonitorTier(msg.id, "background", 500);
         const wakeTerminal = ptyManager.getTerminal(msg.id);
         const termProject = wakeTerminal?.projectId ?? null;
         for (const [windowId, conn] of ctx.rendererConnections) {

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -204,6 +204,7 @@ class TerminalInstanceService {
       onPostWake: (id) => this.handlePostWake(id),
       onResumeFlush: (id) => this.dataBuffer.resumeFlush(id),
       applyDeferredResize: (id) => this.resizeController.applyDeferredResize(id),
+      onBackgrounded: (id) => this.wakeManager.cancelPendingWake(id),
       onTierApplied: (id, tier, managed) => {
         // Enter scheduleHibernation whenever the terminal is BACKGROUND and
         // offscreen, even if it's not eligible right now. scheduleHibernation

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -110,7 +110,11 @@ class TerminalInstanceService {
   private instances = new Map<string, ManagedTerminal>();
   private dataBuffer = new TerminalOutputIngestService(
     (id, data) => this.writeToTerminal(id, data),
-    (id) => this.instances.get(id)?.getRefreshTier?.() ?? TerminalRefreshTier.FOCUSED
+    (id) => this.instances.get(id)?.getRefreshTier?.() ?? TerminalRefreshTier.FOCUSED,
+    // Ack chunks dropped by the background queue cap so the host's port
+    // flow-control ledger doesn't leak (#9906). The byte arg is ignored —
+    // acknowledgePortData shifts the original UTF-8 count the host queued.
+    (id) => terminalClient.acknowledgePortData(id, 0)
   );
   private suppressedExitUntil = new Map<string, number>();
   private unseenTracker = new TerminalUnseenOutputTracker();
@@ -192,6 +196,7 @@ class TerminalInstanceService {
       restoreFromSerialized: (id, state) => this.restoreController.restoreFromSerialized(id, state),
       restoreFromSerializedIncremental: (id, state) =>
         this.restoreController.restoreFromSerializedIncremental(id, state),
+      isBackgrounded: (id) => usePanelStore.getState().backgroundedTerminals.has(id),
     });
 
     this.rendererPolicy = new TerminalRendererPolicy({

--- a/src/services/terminal/TerminalOutputIngestService.ts
+++ b/src/services/terminal/TerminalOutputIngestService.ts
@@ -42,7 +42,13 @@ export class TerminalOutputIngestService {
 
   constructor(
     private readonly writeToTerminal: (id: string, data: string | Uint8Array) => void,
-    private readonly getTier?: (id: string) => TerminalRefreshTier
+    private readonly getTier?: (id: string) => TerminalRefreshTier,
+    // Invoked once per chunk dropped by the background queue cap (#9906). The
+    // chunk was received over the MessagePort (and counted in the host's
+    // flow-control ledger) but will never be written to xterm, so it must still
+    // be acked or the host queue leaks toward permanent backpressure — same
+    // contract as the hibernated-output drop path in TerminalWriteController.
+    private readonly onEvict?: (id: string) => void
   ) {}
 
   public async initialize(): Promise<void> {
@@ -213,7 +219,7 @@ export class TerminalOutputIngestService {
     // them burns renderer main-thread CPU for a pane the user can't see. The
     // queue is flushed via resumeFlush() when the tier upgrades back to active.
     if (this.isBackgrounded(id)) {
-      this.evictBackgroundOverflow(queue);
+      this.evictBackgroundOverflow(id, queue);
       return;
     }
 
@@ -247,10 +253,14 @@ export class TerminalOutputIngestService {
    * loss is the same tradeoff as the existing background gate, now bounded: on
    * wake the scrollback is replaced by the host's serialized snapshot anyway.
    */
-  private evictBackgroundOverflow(queue: TerminalIngestQueue): void {
+  private evictBackgroundOverflow(id: string, queue: TerminalIngestQueue): void {
     while (queue.queuedBytes > BACKGROUND_QUEUE_MAX_BYTES && queue.chunks.length > 0) {
       const dropped = queue.chunks.shift()!;
       queue.queuedBytes -= this.chunkByteSize(dropped);
+      // Held background chunks map 1:1 (in FIFO order) to the host's pending
+      // port-ack entries — nothing has been coalesced or written yet — so
+      // acking the oldest entry per evicted chunk keeps the ledger balanced.
+      this.onEvict?.(id);
     }
     // queuedBytes is the sum of chunk sizes; with chunks empty it is exactly 0.
     if (queue.chunks.length === 0) {

--- a/src/services/terminal/TerminalOutputIngestService.ts
+++ b/src/services/terminal/TerminalOutputIngestService.ts
@@ -13,6 +13,14 @@ import { logDebug } from "@/utils/logger";
 const RENDERER_HIGH_WATERMARK_BYTES = 128 * 1024;
 const RENDERER_LOW_WATERMARK_BYTES = 32 * 1024;
 const COALESCE_BATCH_CAP_BYTES = 256 * 1024;
+// Hard ceiling on bytes held for a backgrounded panel (#9906). The producer
+// gate normally suppresses background output, but if the host/renderer tier
+// desyncs (a late wake re-promoting the host to "active"), in-flight batches
+// keep arriving uncapped — ~2MB per 10s cycle. 4MB gives two cycles of
+// catch-up headroom before the oldest held bytes are evicted, bounding memory
+// exposure if any desync path survives the tier-reconciliation fixes. On wake,
+// resumeFlush drains what remains through the COALESCE_BATCH_CAP_BYTES path.
+const BACKGROUND_QUEUE_MAX_BYTES = 4 * 1024 * 1024;
 const IPC_LOOKBACK_CHARS = 32;
 const INK_ERASE_LINE_PATTERN = "\x1b[2K\x1b[1A";
 
@@ -205,6 +213,7 @@ export class TerminalOutputIngestService {
     // them burns renderer main-thread CPU for a pane the user can't see. The
     // queue is flushed via resumeFlush() when the tier upgrades back to active.
     if (this.isBackgrounded(id)) {
+      this.evictBackgroundOverflow(queue);
       return;
     }
 
@@ -227,6 +236,25 @@ export class TerminalOutputIngestService {
 
     if (!queue.drainScheduled) {
       this.tryDrain(id, queue);
+    }
+  }
+
+  /**
+   * Bound the held queue for a backgrounded panel (#9906). Drops oldest chunks
+   * (FIFO, matching coalesceBatch ordering) until the queue is back under the
+   * cap. These bytes were already dequeued from the MessagePort by onData, so
+   * the IPC-layer accounting is settled — no host ack is needed on drop. The
+   * loss is the same tradeoff as the existing background gate, now bounded: on
+   * wake the scrollback is replaced by the host's serialized snapshot anyway.
+   */
+  private evictBackgroundOverflow(queue: TerminalIngestQueue): void {
+    while (queue.queuedBytes > BACKGROUND_QUEUE_MAX_BYTES && queue.chunks.length > 0) {
+      const dropped = queue.chunks.shift()!;
+      queue.queuedBytes -= this.chunkByteSize(dropped);
+    }
+    // queuedBytes is the sum of chunk sizes; with chunks empty it is exactly 0.
+    if (queue.chunks.length === 0) {
+      queue.queuedBytes = 0;
     }
   }
 

--- a/src/services/terminal/TerminalRendererPolicy.ts
+++ b/src/services/terminal/TerminalRendererPolicy.ts
@@ -10,6 +10,7 @@ export interface RendererPolicyDeps {
   onResumeFlush?: (id: string) => void;
   onTierApplied?: (id: string, tier: TerminalRefreshTier, managed: ManagedTerminal) => void;
   applyDeferredResize?: (id: string) => void;
+  onBackgrounded?: (id: string) => void;
 }
 
 // Backend cadence hint sent to the PTY host alongside the binary
@@ -167,6 +168,13 @@ export class TerminalRendererPolicy {
       // generation.
       this.bumpWakeGeneration(id);
       managed.needsWake = true;
+
+      // Cancel any scheduled-but-not-started wake (#9906). bumpWakeGeneration
+      // above only neutralizes the resolved callback of an in-flight wake — a
+      // trailing-edge rate-limited wake still queued behind the 1s window would
+      // fire its `wake-terminal` IPC and promote the host tier to "active"
+      // against this now-hidden pane. Cancel it before the IPC leaves.
+      this.deps.onBackgrounded?.(id);
     }
 
     if (backendTier === "active" && prevBackendTier !== "active") {

--- a/src/services/terminal/TerminalWakeManager.ts
+++ b/src/services/terminal/TerminalWakeManager.ts
@@ -13,6 +13,10 @@ export interface WakeManagerDeps {
   hasInstance: (id: string) => boolean;
   restoreFromSerialized: (id: string, state: string) => boolean;
   restoreFromSerializedIncremental: (id: string, state: string) => Promise<boolean>;
+  // Optional guard (#9906): when the terminal has been backgrounded, a
+  // scheduled wake must not fire its stale `wake-terminal` IPC. Absent (in
+  // tests), the guard is a no-op and wakes proceed as before.
+  isBackgrounded?: (id: string) => boolean;
 }
 
 export class TerminalWakeManager {
@@ -160,7 +164,14 @@ export class TerminalWakeManager {
       const delay = Math.max(0, WAKE_RATE_LIMIT_MS - (now - lastWake));
       const timeoutId = setTimeout(() => {
         this.pendingRateLimitedWakes.delete(id);
-        if (this.deps.hasInstance(id)) {
+        // The terminal may have been backgrounded between scheduling and now
+        // (#9906). Firing the wake here would send a stale `wake-terminal` IPC
+        // that promotes the host tier to "active" against a hidden pane —
+        // exactly the late-wake desync. cancelPendingWake covers the case where
+        // the BACKGROUND tier has been applied; this guard also covers the
+        // window before the debounced tier apply runs, since backgroundedTerminals
+        // is updated synchronously when the pane is hidden.
+        if (this.deps.hasInstance(id) && this.deps.isBackgrounded?.(id) !== true) {
           this.triggerWake(id);
         }
       }, delay);
@@ -181,6 +192,11 @@ export class TerminalWakeManager {
       this.pendingWakes.delete(id);
 
       if (this.deps.hasInstance(id)) {
+        // Don't wake a terminal that was backgrounded while the retry was
+        // queued (#9906) — same stale-IPC hazard as the rate-limited path.
+        if (this.deps.isBackgrounded?.(id) === true) {
+          return;
+        }
         // Instance now exists, proceed with wake
         const now = Date.now();
         const lastWake = this.lastWakeTime.get(id) ?? 0;

--- a/src/services/terminal/TerminalWakeManager.ts
+++ b/src/services/terminal/TerminalWakeManager.ts
@@ -197,6 +197,30 @@ export class TerminalWakeManager {
     this.pendingWakes.set(id, { retries: retryCount, timeoutId });
   }
 
+  /**
+   * Cancel scheduled-but-not-started wakes when a terminal is backgrounded
+   * (#9906). A trailing-edge rate-limited wake (or an instance-retry) that
+   * fires after the BACKGROUND transition sends a stale `wake-terminal` IPC,
+   * promoting the host tier to "active" against a hidden pane. Cancelling here
+   * stops the IPC before it leaves the renderer. Unlike clearWakeState this
+   * preserves lastWakeTime (so the rate-limit window survives a quick
+   * background/foreground) and inFlightWakes (an already-started wake completes
+   * and is neutralized by the policy's wake-generation guard).
+   */
+  cancelPendingWake(id: string): void {
+    const pending = this.pendingWakes.get(id);
+    if (pending) {
+      clearTimeout(pending.timeoutId);
+      this.pendingWakes.delete(id);
+    }
+
+    const rateLimited = this.pendingRateLimitedWakes.get(id);
+    if (rateLimited) {
+      clearTimeout(rateLimited);
+      this.pendingRateLimitedWakes.delete(id);
+    }
+  }
+
   clearWakeState(id: string): void {
     this.lastWakeTime.delete(id);
     this.inFlightWakes.delete(id);

--- a/src/services/terminal/__tests__/TerminalOutputIngestService.test.ts
+++ b/src/services/terminal/__tests__/TerminalOutputIngestService.test.ts
@@ -633,6 +633,105 @@ describe("TerminalOutputIngestService", () => {
     });
   });
 
+  describe("background queue cap (#9906)", () => {
+    const BACKGROUND_QUEUE_MAX_BYTES = 4 * 1024 * 1024;
+    const CHUNK = "a".repeat(512 * 1024); // 512 KB
+
+    it("bounds the held queue at 4 MB, evicting oldest chunks as new ones arrive", () => {
+      const writeToTerminal = vi.fn();
+      const service = new TerminalOutputIngestService(
+        writeToTerminal,
+        () => TerminalRefreshTier.BACKGROUND
+      );
+
+      // Stream 20 × 512 KB = 10 MB while backgrounded — far past the cap. The
+      // desync this guards against keeps in-flight batches arriving uncapped;
+      // queuedBytes must never exceed the ceiling.
+      for (let i = 0; i < 20; i++) {
+        service.bufferData("term-1", CHUNK);
+        expect(service.getQueuedBytes("term-1")).toBeLessThanOrEqual(BACKGROUND_QUEUE_MAX_BYTES);
+      }
+
+      // 8 × 512 KB = exactly 4 MB is retained (the 9th onward each evict one).
+      expect(service.getQueuedBytes("term-1")).toBe(BACKGROUND_QUEUE_MAX_BYTES);
+      expect(writeToTerminal).not.toHaveBeenCalled();
+    });
+
+    it("drops a single chunk larger than the cap entirely", () => {
+      const writeToTerminal = vi.fn();
+      const service = new TerminalOutputIngestService(
+        writeToTerminal,
+        () => TerminalRefreshTier.BACKGROUND
+      );
+
+      const oversized = "z".repeat(5 * 1024 * 1024); // 5 MB > 4 MB cap
+      service.bufferData("term-1", oversized);
+
+      // The lone chunk exceeds the cap, so eviction empties the queue rather
+      // than holding a chunk it can never get under the ceiling.
+      expect(service.getQueuedBytes("term-1")).toBe(0);
+    });
+
+    it("evicts oldest-first (FIFO), preserving the most recent bytes", () => {
+      const writeToTerminal = vi.fn();
+      const tiers = new Map<string, TerminalRefreshTier>([
+        ["term-1", TerminalRefreshTier.BACKGROUND],
+      ]);
+      const service = new TerminalOutputIngestService(
+        writeToTerminal,
+        (id) => tiers.get(id) ?? TerminalRefreshTier.FOCUSED
+      );
+
+      // Fill to exactly the cap with 8 distinguishable head chunks, then add a
+      // newest marker chunk that forces eviction of the oldest.
+      const oldest = "OLDEST" + "0".repeat(512 * 1024 - 6);
+      service.bufferData("term-1", oldest);
+      for (let i = 0; i < 7; i++) {
+        service.bufferData("term-1", CHUNK);
+      }
+      expect(service.getQueuedBytes("term-1")).toBe(BACKGROUND_QUEUE_MAX_BYTES);
+
+      const newest = "NEWEST";
+      service.bufferData("term-1", newest);
+
+      // The oldest 512 KB chunk was evicted; the small newest chunk survives.
+      expect(service.getQueuedBytes("term-1")).toBe(
+        BACKGROUND_QUEUE_MAX_BYTES - 512 * 1024 + newest.length
+      );
+
+      // Drain everything and confirm the OLDEST head bytes are gone while the
+      // NEWEST tail bytes remain.
+      tiers.set("term-1", TerminalRefreshTier.FOCUSED);
+      service.flushForTerminal("term-1");
+      const flushed = writeToTerminal.mock.calls.map((c) => c[1] as string).join("");
+      expect(flushed.startsWith("OLDEST")).toBe(false);
+      expect(flushed.endsWith("NEWEST")).toBe(true);
+    });
+
+    it("does not cap or evict for active (non-background) terminals", () => {
+      const writeToTerminal = vi.fn();
+      const service = new TerminalOutputIngestService(
+        writeToTerminal,
+        () => TerminalRefreshTier.FOCUSED
+      );
+
+      // The background cap must not apply to active terminals. Without acks,
+      // normal backpressure queues the bytes the high-watermark won't let drain
+      // yet — but nothing is DROPPED. written + still-queued accounts for every
+      // byte, even though the held total is well past the 4 MB background cap.
+      for (let i = 0; i < 20; i++) {
+        service.bufferData("term-1", CHUNK);
+      }
+      const totalWritten = writeToTerminal.mock.calls.reduce(
+        (sum, c) => sum + (c[1] as string).length,
+        0
+      );
+      expect(totalWritten + service.getQueuedBytes("term-1")).toBe(20 * 512 * 1024);
+      // Proof the cap is background-only: the active queue blew past 4 MB.
+      expect(service.getQueuedBytes("term-1")).toBeGreaterThan(BACKGROUND_QUEUE_MAX_BYTES);
+    });
+  });
+
   describe("watchdog accessors", () => {
     it("getQueuedBytes tracks held bytes and returns 0 for unknown ids", () => {
       let tier = TerminalRefreshTier.BACKGROUND;

--- a/src/services/terminal/__tests__/TerminalOutputIngestService.test.ts
+++ b/src/services/terminal/__tests__/TerminalOutputIngestService.test.ts
@@ -708,6 +708,44 @@ describe("TerminalOutputIngestService", () => {
       expect(flushed.endsWith("NEWEST")).toBe(true);
     });
 
+    it("acks each evicted chunk so the host flow-control ledger stays balanced", () => {
+      const writeToTerminal = vi.fn();
+      const onEvict = vi.fn();
+      const service = new TerminalOutputIngestService(
+        writeToTerminal,
+        () => TerminalRefreshTier.BACKGROUND,
+        onEvict
+      );
+
+      // 8 × 512 KB fills exactly to the cap (no eviction yet).
+      for (let i = 0; i < 8; i++) {
+        service.bufferData("term-1", CHUNK);
+      }
+      expect(onEvict).not.toHaveBeenCalled();
+
+      // Each subsequent chunk evicts exactly one oldest chunk → one ack.
+      service.bufferData("term-1", CHUNK);
+      expect(onEvict).toHaveBeenCalledTimes(1);
+      expect(onEvict).toHaveBeenCalledWith("term-1");
+
+      service.bufferData("term-1", CHUNK);
+      expect(onEvict).toHaveBeenCalledTimes(2);
+    });
+
+    it("acks the dropped chunk when a single oversized chunk is evicted", () => {
+      const writeToTerminal = vi.fn();
+      const onEvict = vi.fn();
+      const service = new TerminalOutputIngestService(
+        writeToTerminal,
+        () => TerminalRefreshTier.BACKGROUND,
+        onEvict
+      );
+
+      service.bufferData("term-1", "z".repeat(5 * 1024 * 1024));
+      expect(onEvict).toHaveBeenCalledTimes(1);
+      expect(service.getQueuedBytes("term-1")).toBe(0);
+    });
+
     it("does not cap or evict for active (non-background) terminals", () => {
       const writeToTerminal = vi.fn();
       const service = new TerminalOutputIngestService(

--- a/src/services/terminal/__tests__/TerminalRendererPolicy.test.ts
+++ b/src/services/terminal/__tests__/TerminalRendererPolicy.test.ts
@@ -599,6 +599,72 @@ describe("TerminalRendererPolicy", () => {
     });
   });
 
+  describe("onBackgrounded callback (#9906)", () => {
+    beforeEach(async () => {
+      vi.useFakeTimers();
+      vi.stubGlobal("window", globalThis);
+      const { TerminalRendererPolicy } = await import("../TerminalRendererPolicy");
+      policy = new TerminalRendererPolicy(mockDeps);
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    });
+
+    it("fires when the backend tier transitions active → background", async () => {
+      const onBackgrounded = vi.fn();
+      mockDeps.onBackgrounded = onBackgrounded;
+      const { TerminalRendererPolicy } = await import("../TerminalRendererPolicy");
+      policy = new TerminalRendererPolicy(mockDeps);
+
+      mockManagedTerminal.lastAppliedTier = TerminalRefreshTier.FOCUSED;
+      mockManagedTerminal.getRefreshTier = () => TerminalRefreshTier.FOCUSED;
+
+      // Downgrade to BACKGROUND arms the hysteresis timer; the callback fires
+      // only when it actually applies.
+      policy.applyRendererPolicy("test-id", TerminalRefreshTier.BACKGROUND);
+      expect(onBackgrounded).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1000);
+      expect(onBackgrounded).toHaveBeenCalledExactlyOnceWith("test-id");
+    });
+
+    it("does not fire on an active → active tier change", async () => {
+      const onBackgrounded = vi.fn();
+      mockDeps.onBackgrounded = onBackgrounded;
+      const { TerminalRendererPolicy } = await import("../TerminalRendererPolicy");
+      policy = new TerminalRendererPolicy(mockDeps);
+
+      mockManagedTerminal.lastAppliedTier = TerminalRefreshTier.VISIBLE;
+
+      // Upgrade VISIBLE → FOCUSED stays "active" on the backend — no background.
+      policy.applyRendererPolicy("test-id", TerminalRefreshTier.FOCUSED);
+      vi.advanceTimersByTime(1000);
+      expect(onBackgrounded).not.toHaveBeenCalled();
+    });
+
+    it("does not fire again when already background (background → background)", async () => {
+      const onBackgrounded = vi.fn();
+      mockDeps.onBackgrounded = onBackgrounded;
+      const { TerminalRendererPolicy } = await import("../TerminalRendererPolicy");
+      policy = new TerminalRendererPolicy(mockDeps);
+
+      mockManagedTerminal.lastAppliedTier = TerminalRefreshTier.FOCUSED;
+      mockManagedTerminal.getRefreshTier = () => TerminalRefreshTier.FOCUSED;
+
+      policy.applyRendererPolicy("test-id", TerminalRefreshTier.BACKGROUND);
+      vi.advanceTimersByTime(1000);
+      expect(onBackgrounded).toHaveBeenCalledTimes(1);
+
+      // Re-applying BACKGROUND is a no-op (prevBackendTier already background).
+      onBackgrounded.mockClear();
+      policy.applyRendererPolicy("test-id", TerminalRefreshTier.BACKGROUND);
+      vi.advanceTimersByTime(1000);
+      expect(onBackgrounded).not.toHaveBeenCalled();
+    });
+  });
+
   describe("clearTierState", () => {
     it("should remove tier state for terminal", () => {
       policy.initializeBackendTier("test-id", "background");

--- a/src/services/terminal/__tests__/TerminalWakeManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWakeManager.test.ts
@@ -364,6 +364,116 @@ describe("TerminalWakeManager", () => {
     });
   });
 
+  describe("cancelPendingWake (#9906)", () => {
+    function makeDeps(managed: MockManagedTerminal, hasInstance = true): WakeManagerDeps {
+      return {
+        getInstance: vi.fn(() =>
+          hasInstance ? (managed as unknown as ManagedTerminal) : undefined
+        ),
+        hasInstance: vi.fn(() => hasInstance),
+        restoreFromSerialized: vi.fn(() => true),
+        restoreFromSerializedIncremental: vi.fn(async () => true),
+      };
+    }
+
+    it("stops a trailing-edge rate-limited wake from firing its IPC", async () => {
+      vi.useFakeTimers();
+      try {
+        wakeMock.mockResolvedValue({ state: "serialized-state" });
+        const managed: MockManagedTerminal = {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
+          terminal: { rows: 24, refresh: vi.fn(), hasSelection: vi.fn(() => false) } as any,
+        };
+        const manager = new TerminalWakeManager(makeDeps(managed));
+
+        // First wake fires immediately and records lastWakeTime.
+        manager.wake("term-cancel-1");
+        await vi.advanceTimersByTimeAsync(0);
+        expect(wakeMock).toHaveBeenCalledTimes(1);
+
+        // Second wake inside the window schedules a trailing-edge timer.
+        vi.setSystemTime(Date.now() + 200);
+        manager.wake("term-cancel-1");
+        expect(manager.hasPendingWake("term-cancel-1")).toBe(true);
+
+        // The terminal is backgrounded: cancel the pending wake before it fires.
+        manager.cancelPendingWake("term-cancel-1");
+        expect(manager.hasPendingWake("term-cancel-1")).toBe(false);
+
+        // Advancing past the window must NOT fire the cancelled trailing wake —
+        // this is the stale `wake-terminal` IPC the fix prevents.
+        await vi.advanceTimersByTimeAsync(2000);
+        expect(wakeMock).toHaveBeenCalledTimes(1);
+
+        manager.dispose();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("cancels an instance-retry pending wake", () => {
+      vi.useFakeTimers();
+      try {
+        const managed: MockManagedTerminal = {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
+          terminal: { rows: 24, refresh: vi.fn(), hasSelection: vi.fn(() => false) } as any,
+        };
+        // No instance yet → wake() schedules a retry.
+        const manager = new TerminalWakeManager(makeDeps(managed, false));
+
+        manager.wake("term-cancel-2");
+        expect(manager.hasPendingWake("term-cancel-2")).toBe(true);
+
+        manager.cancelPendingWake("term-cancel-2");
+        expect(manager.hasPendingWake("term-cancel-2")).toBe(false);
+
+        manager.dispose();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("preserves the rate-limit window (lastWakeTime) so a follow-up wake still coalesces", async () => {
+      // Unlike clearWakeState, cancelPendingWake must NOT reset lastWakeTime —
+      // a quick background→foreground within the 1s window should still be
+      // rate-limited (scheduled as trailing), not fire a fresh wake immediately.
+      vi.useFakeTimers();
+      try {
+        wakeMock.mockResolvedValue({ state: "serialized-state" });
+        const managed: MockManagedTerminal = {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
+          terminal: { rows: 24, refresh: vi.fn(), hasSelection: vi.fn(() => false) } as any,
+        };
+        const manager = new TerminalWakeManager(makeDeps(managed));
+
+        manager.wake("term-cancel-3");
+        await vi.advanceTimersByTimeAsync(0);
+        expect(wakeMock).toHaveBeenCalledTimes(1);
+
+        // Schedule a trailing wake, then cancel it (background transition).
+        vi.setSystemTime(Date.now() + 200);
+        manager.wake("term-cancel-3");
+        manager.cancelPendingWake("term-cancel-3");
+        expect(wakeMock).toHaveBeenCalledTimes(1);
+
+        // Foreground again still inside the original 1s window: because
+        // lastWakeTime survived, this must coalesce into a trailing wake rather
+        // than fire immediately.
+        vi.setSystemTime(Date.now() + 100);
+        manager.wake("term-cancel-3");
+        expect(wakeMock).toHaveBeenCalledTimes(1);
+        expect(manager.hasPendingWake("term-cancel-3")).toBe(true);
+
+        await vi.advanceTimersByTimeAsync(2000);
+        expect(wakeMock).toHaveBeenCalledTimes(2);
+
+        manager.dispose();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe("hasInFlightWake", () => {
     it("is true only while a wakeAndRestore is in flight", async () => {
       let resolveWake!: (value: { state: string }) => void;

--- a/src/services/terminal/__tests__/TerminalWakeManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWakeManager.test.ts
@@ -474,6 +474,85 @@ describe("TerminalWakeManager", () => {
     });
   });
 
+  describe("background guard on scheduled wake (#9906)", () => {
+    it("does not fire a trailing-edge wake if the terminal is backgrounded when the timer fires", async () => {
+      // Covers the hysteresis window: the wake was scheduled before the user
+      // backgrounded the pane, and the debounced BACKGROUND tier apply (which
+      // calls cancelPendingWake) hasn't run yet — but backgroundedTerminals is
+      // already true. The timer must check it and skip the stale IPC.
+      vi.useFakeTimers();
+      try {
+        wakeMock.mockResolvedValue({ state: "serialized-state" });
+        let backgrounded = false;
+        const managed: MockManagedTerminal = {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
+          terminal: { rows: 24, refresh: vi.fn(), hasSelection: vi.fn(() => false) } as any,
+        };
+        const deps: WakeManagerDeps = {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+          getInstance: vi.fn(() => managed as unknown as ManagedTerminal),
+          hasInstance: vi.fn(() => true),
+          restoreFromSerialized: vi.fn(() => true),
+          restoreFromSerializedIncremental: vi.fn(async () => true),
+          isBackgrounded: () => backgrounded,
+        };
+        const manager = new TerminalWakeManager(deps);
+
+        manager.wake("term-bg-guard");
+        await vi.advanceTimersByTimeAsync(0);
+        expect(wakeMock).toHaveBeenCalledTimes(1);
+
+        // Schedule a trailing wake, then background the pane before it fires.
+        vi.setSystemTime(Date.now() + 200);
+        manager.wake("term-bg-guard");
+        backgrounded = true;
+
+        await vi.advanceTimersByTimeAsync(2000);
+        // The trailing wake's IPC was suppressed by the background guard.
+        expect(wakeMock).toHaveBeenCalledTimes(1);
+
+        manager.dispose();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("skips an instance-retry wake that resolves while backgrounded", () => {
+      vi.useFakeTimers();
+      try {
+        let hasInstance = false;
+        let backgrounded = false;
+        const managed: MockManagedTerminal = {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
+          terminal: { rows: 24, refresh: vi.fn(), hasSelection: vi.fn(() => false) } as any,
+        };
+        const deps: WakeManagerDeps = {
+          getInstance: vi.fn(() =>
+            hasInstance ? (managed as unknown as ManagedTerminal) : undefined
+          ),
+          hasInstance: vi.fn(() => hasInstance),
+          restoreFromSerialized: vi.fn(() => true),
+          restoreFromSerializedIncremental: vi.fn(async () => true),
+          isBackgrounded: () => backgrounded,
+        };
+        const manager = new TerminalWakeManager(deps);
+
+        // No instance yet → schedules a retry.
+        manager.wake("term-retry-bg");
+        // The instance appears but the pane is backgrounded before the retry.
+        hasInstance = true;
+        backgrounded = true;
+
+        vi.advanceTimersByTime(500);
+        expect(wakeMock).not.toHaveBeenCalled();
+
+        manager.dispose();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe("hasInFlightWake", () => {
     it("is true only while a wakeAndRestore is in flight", async () => {
       let resolveWake!: (value: { state: string }) => void;

--- a/src/store/listeners/panel/lifecycle.ts
+++ b/src/store/listeners/panel/lifecycle.ts
@@ -414,7 +414,16 @@ export function setupLifecycleListeners(): DisposableStore {
         // a real status again, re-add `|| status === "suspended"` here
         // and remove the early-return guard above.
         if (status === "paused-backpressure") {
-          terminalInstanceService.wake(id);
+          // Don't wake a terminal the user already backgrounded (#9906).
+          // A backpressure pause on a hidden pane is expected — waking it
+          // sends a stale `wake-terminal` IPC that promotes the host tier to
+          // "active" against an offscreen terminal, defeating the background
+          // gate. Primary prevention for the late-wake desync; the renderer
+          // policy's cancelPendingWake and the host's wake correction are the
+          // backstops for wakes already scheduled or in flight.
+          if (!usePanelStore.getState().backgroundedTerminals.has(id)) {
+            terminalInstanceService.wake(id);
+          }
         }
       })
     )


### PR DESCRIPTION
## Summary

- When a terminal entered `paused-backpressure` just before being backgrounded, the renderer's rate-limited wake timer could fire after the `BACKGROUND` transition. The host wake handler promoted the host tier to `active` but never broadcast a `tier-changed` event back, and the renderer's `lastBackendTier` dedup refused to re-send a correction — leaving a hidden terminal streaming at full rate indefinitely.
- Fixed across all the layers where the race can originate: host handler, wake manager, renderer policy, lifecycle, and the ingest service's background hold queue.

Resolves #9906

## Changes

- **Host wake handler** (`pty-host/handlers/backpressure.ts`): captures the pre-wake tier; if it was `background` (stale trailing-edge wake), re-demotes the host and broadcasts a project-filtered `tier-changed` correction to reset the renderer dedup baseline.
- **`TerminalWakeManager.cancelPendingWake`**: cancels scheduled-but-not-started wakes on `BACKGROUND` transition (preserving `lastWakeTime`/`inFlightWakes`); both wake timers guard on an `isBackgrounded` check to close the hysteresis window before the debounced tier apply runs.
- **`TerminalRendererPolicy`**: fires `onBackgrounded` so the policy cancels the pending wake before its stale IPC leaves the renderer.
- **`lifecycle.ts`**: skips waking a terminal the user already backgrounded.
- **`TerminalOutputIngestService`**: caps the background hold queue at 4MB, evicting oldest chunks (and acking each evicted chunk so the host flow-control ledger stays balanced) to bound memory if any desync survives.

## Testing

Cross-layer regression tests added across the host handler, wake manager, renderer policy, and ingest service. Full local CI passed (typecheck, lint, format, unit tests, build).