### PR TITLE
fix(terminal): retry declined wakes so suspended panes resync (#9894)

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -197,6 +197,7 @@ class TerminalInstanceService {
       restoreFromSerializedIncremental: (id, state) =>
         this.restoreController.restoreFromSerializedIncremental(id, state),
       isBackgrounded: (id) => usePanelStore.getState().backgroundedTerminals.has(id),
+      onDeclined: (id) => this.injectDataLossMarker(id, 0),
     });
 
     this.rendererPolicy = new TerminalRendererPolicy({

--- a/src/services/terminal/TerminalWakeManager.ts
+++ b/src/services/terminal/TerminalWakeManager.ts
@@ -1,5 +1,6 @@
 import { terminalClient } from "@/clients";
 import { usePanelStore } from "@/store/panelStore";
+import { TerminalRefreshTier } from "@/types";
 import { logWarn } from "@/utils/logger";
 import type { ManagedTerminal } from "./types";
 import { INCREMENTAL_RESTORE_CONFIG } from "./types";
@@ -7,6 +8,16 @@ import { INCREMENTAL_RESTORE_CONFIG } from "./types";
 const WAKE_RATE_LIMIT_MS = 1000;
 const WAKE_RETRY_DELAY_MS = 100;
 const WAKE_MAX_RETRIES = 10;
+
+// When a wake declines the snapshot (active selection or missing serialized
+// state) the host has already discarded the suspended terminal's buffered
+// output, so leaving the decline unretried strands the pane on stale content
+// while every status indicator reports it live (#9894). Re-attempt the wake a
+// few times so the resync lands once the blocking condition clears (the
+// selection is released, the snapshot becomes available). Bounded because a
+// genuinely null snapshot is an unrecoverable gap, not a transient one.
+const WAKE_DECLINE_RETRY_DELAY_MS = 300;
+const WAKE_DECLINE_MAX_RETRIES = 3;
 
 export interface WakeManagerDeps {
   getInstance: (id: string) => ManagedTerminal | undefined;
@@ -17,12 +28,21 @@ export interface WakeManagerDeps {
   // scheduled wake must not fire its stale `wake-terminal` IPC. Absent (in
   // tests), the guard is a no-op and wakes proceed as before.
   isBackgrounded?: (id: string) => boolean;
+  /**
+   * Invoked once per decline sequence when a wake cannot apply the snapshot and
+   * the gap is user-visible (missing serialized state). Used to draw the
+   * data-loss marker. Not called for the selection-guard decline: injecting a
+   * marker would write into the terminal the guard is deliberately leaving
+   * untouched while the user drags a selection.
+   */
+  onDeclined?: (id: string) => void;
 }
 
 export class TerminalWakeManager {
   private lastWakeTime = new Map<string, number>();
   private pendingWakes = new Map<string, { retries: number; timeoutId: NodeJS.Timeout }>();
   private pendingRateLimitedWakes = new Map<string, NodeJS.Timeout>();
+  private declineRetries = new Map<string, { attempt: number; timeoutId: NodeJS.Timeout }>();
   private inFlightWakes = new Map<string, Promise<boolean>>();
   private deps: WakeManagerDeps;
 
@@ -57,8 +77,11 @@ export class TerminalWakeManager {
 
         // xterm v6 clears selection when terminal.reset() is called during
         // restoreFromSerialized. Skip the restore if the user has an active
-        // text selection to avoid destroying their drag-selection.
+        // text selection to avoid destroying their drag-selection. Schedule a
+        // retry (no marker — the marker would write into the terminal the guard
+        // is protecting) so the resync lands once the selection is released.
         if (managed.terminal.hasSelection()) {
+          this.noteDecline(id, false);
           return false;
         }
 
@@ -66,15 +89,18 @@ export class TerminalWakeManager {
 
         // Re-check after async: selection may have started while we were awaiting.
         if (managed.terminal.hasSelection()) {
+          this.noteDecline(id, false);
           return false;
         }
 
-        // Alternate-screen TUIs repaint from live PTY data; serialized snapshots are optional.
-        if (managed.isAltBuffer) {
-          return true;
-        }
-
+        // No serialized snapshot to replay. The host discarded the buffered
+        // output on suspend, so the pane is now stale — surface the gap and
+        // retry in case the snapshot becomes available. Alternate-screen TUIs
+        // fall through here too: addon-serialize includes the alt-buffer frame
+        // (\x1b[?1049h + content), so a present snapshot correctly repaints the
+        // TUI rather than being silently treated as a no-op resync.
         if (!state) {
+          this.noteDecline(id, true);
           return false;
         }
 
@@ -129,10 +155,73 @@ export class TerminalWakeManager {
     void this.wakeAndRestore(id).then((success) => {
       if (success) {
         this.lastWakeTime.set(id, startedAt);
+        // A successful wake resynced the pane; cancel any decline retry left
+        // over from an earlier failed attempt for this terminal.
+        this.clearDeclineRetry(id);
       } else {
         this.lastWakeTime.delete(id);
       }
     });
+  }
+
+  /**
+   * Begin (or no-op into an in-progress) decline-retry sequence for a wake that
+   * could not apply the snapshot. The data-loss marker, if requested, is drawn
+   * once at the start of the sequence — not on every retry — so a prolonged
+   * stale window doesn't stack marker lines.
+   */
+  private noteDecline(id: string, injectMarker: boolean): void {
+    if (this.declineRetries.has(id)) {
+      // A sequence is already running for this id: the retry loop owns
+      // rescheduling and the marker (if any) was already drawn.
+      return;
+    }
+    if (injectMarker) {
+      this.deps.onDeclined?.(id);
+    }
+    this.scheduleDeclineRetry(id, 1);
+  }
+
+  private scheduleDeclineRetry(id: string, attempt: number): void {
+    if (attempt > WAKE_DECLINE_MAX_RETRIES) {
+      this.declineRetries.delete(id);
+      return;
+    }
+    const timeoutId = setTimeout(() => {
+      void this.runDeclineRetry(id, attempt);
+    }, WAKE_DECLINE_RETRY_DELAY_MS);
+    this.declineRetries.set(id, { attempt, timeoutId });
+  }
+
+  private async runDeclineRetry(id: string, attempt: number): Promise<void> {
+    const managed = this.deps.getInstance(id);
+    // Bail if the terminal went away or was re-backgrounded: a background
+    // terminal re-wakes through the tier-transition path (needsWake stays
+    // armed), so retrying here would refresh into a hidden pane. The entry is
+    // kept until now so a concurrent decline from wakeAndRestore no-ops in
+    // noteDecline rather than starting a duplicate sequence.
+    if (!managed || managed.lastAppliedTier === TerminalRefreshTier.BACKGROUND) {
+      this.declineRetries.delete(id);
+      return;
+    }
+
+    const startedAt = Date.now();
+    const success = await this.wakeAndRestore(id);
+    if (success) {
+      this.lastWakeTime.set(id, startedAt);
+      this.declineRetries.delete(id);
+      return;
+    }
+    this.lastWakeTime.delete(id);
+    this.scheduleDeclineRetry(id, attempt + 1);
+  }
+
+  private clearDeclineRetry(id: string): void {
+    const pending = this.declineRetries.get(id);
+    if (pending) {
+      clearTimeout(pending.timeoutId);
+      this.declineRetries.delete(id);
+    }
   }
 
   wake(id: string): void {
@@ -252,6 +341,8 @@ export class TerminalWakeManager {
       clearTimeout(rateLimited);
       this.pendingRateLimitedWakes.delete(id);
     }
+
+    this.clearDeclineRetry(id);
   }
 
   dispose(): void {
@@ -268,5 +359,10 @@ export class TerminalWakeManager {
       clearTimeout(timeoutId);
     }
     this.pendingRateLimitedWakes.clear();
+
+    for (const [, pending] of this.declineRetries) {
+      clearTimeout(pending.timeoutId);
+    }
+    this.declineRetries.clear();
   }
 }

--- a/src/services/terminal/TerminalWakeManager.ts
+++ b/src/services/terminal/TerminalWakeManager.ts
@@ -56,12 +56,18 @@ export class TerminalWakeManager {
 
   /**
    * A wake that has been requested but not yet started: instance-retry
-   * scheduled or coalesced behind the rate limit. Its eventual wakeAndRestore
-   * resets the terminal during replay, so flushing held bytes ahead of it
-   * would feed them into a buffer that's about to be wiped.
+   * scheduled, coalesced behind the rate limit, or a declined-wake retry
+   * waiting to re-attempt the snapshot. Its eventual wakeAndRestore resets the
+   * terminal during replay, so flushing held bytes ahead of it would feed them
+   * into a buffer that's about to be wiped — the reconciliation watchdog reads
+   * this before its stalled-bytes flush (#9894).
    */
   hasPendingWake(id: string): boolean {
-    return this.pendingWakes.has(id) || this.pendingRateLimitedWakes.has(id);
+    return (
+      this.pendingWakes.has(id) ||
+      this.pendingRateLimitedWakes.has(id) ||
+      this.declineRetries.has(id)
+    );
   }
 
   async wakeAndRestore(id: string): Promise<boolean> {
@@ -134,6 +140,12 @@ export class TerminalWakeManager {
           // (#8535): clear it now that the replay has succeeded.
           usePanelStore.getState().clearScrollbackRestoreError(id);
         }
+        // A successful replay resynced the pane — cancel any decline retry left
+        // over from an earlier declined wake of this terminal, regardless of
+        // which caller invoked wakeAndRestore (direct RendererPolicy /
+        // visibility-restore wakes don't run triggerWake's success branch).
+        // Otherwise the stale timer fires a redundant reset on an active pane.
+        this.clearDeclineRetry(id);
         return true;
       } catch (error) {
         console.warn(`[TerminalWakeManager] Failed to wake terminal ${id}:`, error);
@@ -154,10 +166,8 @@ export class TerminalWakeManager {
     const startedAt = Date.now();
     void this.wakeAndRestore(id).then((success) => {
       if (success) {
+        // wakeAndRestore already cancels any pending decline retry on success.
         this.lastWakeTime.set(id, startedAt);
-        // A successful wake resynced the pane; cancel any decline retry left
-        // over from an earlier failed attempt for this terminal.
-        this.clearDeclineRetry(id);
       } else {
         this.lastWakeTime.delete(id);
       }

--- a/src/services/terminal/__tests__/TerminalWakeManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWakeManager.test.ts
@@ -24,10 +24,11 @@ vi.mock("@/store/panelStore", () => ({
   },
 }));
 
+import { TerminalRefreshTier } from "@/types";
 import { TerminalWakeManager, type WakeManagerDeps } from "../TerminalWakeManager";
 import type { ManagedTerminal } from "../types";
 
-type MockManagedTerminal = Pick<ManagedTerminal, "terminal" | "isAltBuffer"> & {
+type MockManagedTerminal = Pick<ManagedTerminal, "terminal" | "isAltBuffer" | "lastAppliedTier"> & {
   isOpened?: boolean;
   isAttaching?: boolean;
   isHibernated?: boolean;
@@ -111,7 +112,11 @@ describe("TerminalWakeManager", () => {
     expect(deps.restoreFromSerialized).toHaveBeenCalledTimes(1);
   });
 
-  it("skips serialized state restore for alt-screen terminals", async () => {
+  it("restores the serialized snapshot for alt-screen terminals (#9894)", async () => {
+    // Before #9894 alt-screen wakes short-circuited with `return true` and
+    // never replayed the snapshot. addon-serialize includes the alt-buffer
+    // frame, so a present snapshot must be replayed — otherwise the pane is
+    // silently treated as resynced while showing stale content.
     wakeMock.mockResolvedValueOnce({ state: "serialized-state" });
     const managed: MockManagedTerminal = {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
@@ -130,12 +135,15 @@ describe("TerminalWakeManager", () => {
     const result = await manager.wakeAndRestore("term-alt");
 
     expect(result).toBe(true);
-    expect(deps.restoreFromSerialized).not.toHaveBeenCalled();
-    expect(deps.restoreFromSerializedIncremental).not.toHaveBeenCalled();
+    expect(deps.restoreFromSerialized).toHaveBeenCalledWith("term-alt", "serialized-state");
   });
 
-  it("treats alt-screen wake as successful even when serialized state is missing", async () => {
+  it("declines (does not falsely succeed) an alt-screen wake with no serialized state (#9894)", async () => {
+    // The dangerous pre-#9894 path: alt-screen + null state returned `true`,
+    // permanently clearing needsWake and suppressing future wakes. It must now
+    // decline like any other null-state wake so the stale pane is retried.
     wakeMock.mockResolvedValueOnce({ state: null });
+    const onDeclined = vi.fn();
     const managed: MockManagedTerminal = {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
       terminal: { rows: 24, refresh: vi.fn(), hasSelection: vi.fn(() => false) } as any,
@@ -147,14 +155,19 @@ describe("TerminalWakeManager", () => {
       hasInstance: vi.fn(() => true),
       restoreFromSerialized: vi.fn(() => true),
       restoreFromSerializedIncremental: vi.fn(async () => true),
+      onDeclined,
     };
     const manager = new TerminalWakeManager(deps);
 
     const result = await manager.wakeAndRestore("term-alt-null-state");
 
-    expect(result).toBe(true);
+    expect(result).toBe(false);
     expect(deps.restoreFromSerialized).not.toHaveBeenCalled();
     expect(deps.restoreFromSerializedIncremental).not.toHaveBeenCalled();
+    // A null snapshot is a user-visible gap — the marker is drawn once.
+    expect(onDeclined).toHaveBeenCalledTimes(1);
+
+    manager.dispose();
   });
 
   it("restores serialized state for non-alt-screen terminals", async () => {
@@ -200,6 +213,10 @@ describe("TerminalWakeManager", () => {
     expect(result).toBe(false);
     expect(deps.restoreFromSerialized).not.toHaveBeenCalled();
     expect(deps.restoreFromSerializedIncremental).not.toHaveBeenCalled();
+
+    // A null-state decline schedules a retry timer; clear it so it doesn't
+    // fire into a later test.
+    manager.dispose();
   });
 
   it("deduplicates overlapping wake() triggers while restore is in flight", async () => {
@@ -844,6 +861,180 @@ describe("TerminalWakeManager", () => {
 
       expect(result).toBe(false);
       expect(clearScrollbackRestoreErrorMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("declined-wake retry (#9894)", () => {
+    type SelectionMock = ReturnType<typeof vi.fn>;
+
+    function makeDeclineDeps(
+      managed: MockManagedTerminal,
+      onDeclined?: (id: string) => void
+    ): WakeManagerDeps {
+      return {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        getInstance: vi.fn(() => managed as unknown as ManagedTerminal),
+        hasInstance: vi.fn(() => true),
+        restoreFromSerialized: vi.fn(() => true),
+        restoreFromSerializedIncremental: vi.fn(async () => true),
+        onDeclined,
+      };
+    }
+
+    function makeManaged(hasSelection: SelectionMock): MockManagedTerminal {
+      return {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
+        terminal: { rows: 24, refresh: vi.fn(), hasSelection } as any,
+        isAltBuffer: false,
+        lastAppliedTier: TerminalRefreshTier.FOCUSED,
+      };
+    }
+
+    it("retries a selection-guarded decline and resyncs once the selection clears", async () => {
+      vi.useFakeTimers();
+      try {
+        wakeMock.mockResolvedValue({ state: "serialized-state" });
+        // Selection held on the initial wake, released by the time the retry runs.
+        const hasSelection = vi.fn().mockReturnValueOnce(true).mockReturnValue(false);
+        const onDeclined = vi.fn();
+        const managed = makeManaged(hasSelection);
+        const deps = makeDeclineDeps(managed, onDeclined);
+        const manager = new TerminalWakeManager(deps);
+
+        const first = await manager.wakeAndRestore("term-decline-sel");
+        expect(first).toBe(false);
+        // The selection guard fires before the wake IPC — no snapshot fetched.
+        expect(wakeMock).not.toHaveBeenCalled();
+        // No marker for a selection decline — it would write into the terminal
+        // the guard is protecting.
+        expect(onDeclined).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(300);
+        // Retry ran with the selection cleared: snapshot fetched and replayed.
+        expect(wakeMock).toHaveBeenCalledTimes(1);
+        expect(deps.restoreFromSerialized).toHaveBeenCalledWith(
+          "term-decline-sel",
+          "serialized-state"
+        );
+
+        manager.dispose();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("draws the data-loss marker once and retries a null-state decline up to the cap", async () => {
+      vi.useFakeTimers();
+      try {
+        wakeMock.mockResolvedValue({ state: null });
+        const onDeclined = vi.fn();
+        const managed = makeManaged(vi.fn(() => false));
+        const manager = new TerminalWakeManager(makeDeclineDeps(managed, onDeclined));
+
+        const first = await manager.wakeAndRestore("term-decline-null");
+        expect(first).toBe(false);
+        expect(onDeclined).toHaveBeenCalledTimes(1);
+        expect(wakeMock).toHaveBeenCalledTimes(1);
+
+        // Three bounded retries, each 300ms apart, then the sequence stops.
+        await vi.advanceTimersByTimeAsync(300);
+        await vi.advanceTimersByTimeAsync(300);
+        await vi.advanceTimersByTimeAsync(300);
+        expect(wakeMock).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
+
+        // No further retries after the cap.
+        await vi.advanceTimersByTimeAsync(900);
+        expect(wakeMock).toHaveBeenCalledTimes(4);
+        // The marker is drawn only at the start of the sequence, never restacked.
+        expect(onDeclined).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("stops retrying once a retry resyncs the pane", async () => {
+      vi.useFakeTimers();
+      try {
+        // Null on the initial wake, snapshot available on the retry.
+        wakeMock.mockResolvedValueOnce({ state: null }).mockResolvedValue({
+          state: "serialized-state",
+        });
+        const onDeclined = vi.fn();
+        const managed = makeManaged(vi.fn(() => false));
+        const manager = new TerminalWakeManager(makeDeclineDeps(managed, onDeclined));
+
+        await manager.wakeAndRestore("term-decline-recover");
+        expect(onDeclined).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(300);
+        expect(wakeMock).toHaveBeenCalledTimes(2); // initial + 1 retry that succeeded
+
+        // The successful retry ends the sequence — no further attempts.
+        await vi.advanceTimersByTimeAsync(900);
+        expect(wakeMock).toHaveBeenCalledTimes(2);
+        expect(onDeclined).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not retry into a re-backgrounded terminal", async () => {
+      vi.useFakeTimers();
+      try {
+        wakeMock.mockResolvedValue({ state: null });
+        const managed = makeManaged(vi.fn(() => false));
+        const manager = new TerminalWakeManager(makeDeclineDeps(managed));
+
+        await manager.wakeAndRestore("term-decline-bg");
+        expect(wakeMock).toHaveBeenCalledTimes(1);
+
+        // Pane re-backgrounded before the retry fires — the tier-transition
+        // wake will handle it when it returns to active.
+        managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
+
+        await vi.advanceTimersByTimeAsync(900);
+        expect(wakeMock).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("clearWakeState cancels a pending decline retry", async () => {
+      vi.useFakeTimers();
+      try {
+        wakeMock.mockResolvedValue({ state: null });
+        const managed = makeManaged(vi.fn(() => false));
+        const manager = new TerminalWakeManager(makeDeclineDeps(managed));
+
+        await manager.wakeAndRestore("term-decline-clear");
+        expect(wakeMock).toHaveBeenCalledTimes(1);
+
+        manager.clearWakeState("term-decline-clear");
+
+        await vi.advanceTimersByTimeAsync(900);
+        expect(wakeMock).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("dispose cancels a pending decline retry", async () => {
+      vi.useFakeTimers();
+      try {
+        wakeMock.mockResolvedValue({ state: null });
+        const managed = makeManaged(vi.fn(() => false));
+        const manager = new TerminalWakeManager(makeDeclineDeps(managed));
+
+        await manager.wakeAndRestore("term-decline-dispose");
+        expect(wakeMock).toHaveBeenCalledTimes(1);
+
+        manager.dispose();
+
+        await vi.advanceTimersByTimeAsync(900);
+        expect(wakeMock).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/src/services/terminal/__tests__/TerminalWakeManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWakeManager.test.ts
@@ -1036,5 +1036,84 @@ describe("TerminalWakeManager", () => {
         vi.useRealTimers();
       }
     });
+
+    it("reports a pending decline retry via hasPendingWake (watchdog flush guard)", async () => {
+      // The reconciliation watchdog gates its stalled-bytes flush on
+      // !hasPendingWake. A pending decline retry will reset the terminal on
+      // replay, so the flush must wait — hasPendingWake must report it.
+      vi.useFakeTimers();
+      try {
+        wakeMock.mockResolvedValue({ state: null });
+        const managed = makeManaged(vi.fn(() => false));
+        const manager = new TerminalWakeManager(makeDeclineDeps(managed));
+
+        expect(manager.hasPendingWake("term-decline-pending")).toBe(false);
+
+        await manager.wakeAndRestore("term-decline-pending");
+        expect(manager.hasPendingWake("term-decline-pending")).toBe(true);
+
+        manager.clearWakeState("term-decline-pending");
+        expect(manager.hasPendingWake("term-decline-pending")).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("cancels a pending decline retry when a direct wakeAndRestore later succeeds", async () => {
+      // RendererPolicy / visibility-restore wakes call wakeAndRestore directly,
+      // bypassing triggerWake. A success there must cancel the leftover decline
+      // timer so it doesn't fire a redundant reset on the active pane.
+      vi.useFakeTimers();
+      try {
+        wakeMock.mockResolvedValueOnce({ state: null }).mockResolvedValue({
+          state: "serialized-state",
+        });
+        const managed = makeManaged(vi.fn(() => false));
+        const manager = new TerminalWakeManager(makeDeclineDeps(managed));
+
+        await manager.wakeAndRestore("term-decline-direct");
+        expect(manager.hasPendingWake("term-decline-direct")).toBe(true);
+
+        // A direct wake (e.g. from RendererPolicy) succeeds before the retry.
+        const result = await manager.wakeAndRestore("term-decline-direct");
+        expect(result).toBe(true);
+        expect(manager.hasPendingWake("term-decline-direct")).toBe(false);
+
+        // The leftover decline timer must not fire another wake.
+        await vi.advanceTimersByTimeAsync(900);
+        expect(wakeMock).toHaveBeenCalledTimes(2); // initial null + direct success
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("exhausts selection retries silently when the selection is held throughout", async () => {
+      // Documented tradeoff: while a selection is held the guard never fetches
+      // or replays a snapshot (it would destroy the selection), and no marker is
+      // drawn (it would write into the guarded terminal). The pane re-wakes on
+      // the next tier transition; the bounded retries just give up quietly.
+      vi.useFakeTimers();
+      try {
+        wakeMock.mockResolvedValue({ state: "serialized-state" });
+        const onDeclined = vi.fn();
+        const managed = makeManaged(vi.fn(() => true)); // selection held forever
+        const manager = new TerminalWakeManager(makeDeclineDeps(managed, onDeclined));
+
+        await manager.wakeAndRestore("term-decline-stuck");
+        // Run out the full retry budget.
+        await vi.advanceTimersByTimeAsync(300);
+        await vi.advanceTimersByTimeAsync(300);
+        await vi.advanceTimersByTimeAsync(300);
+        await vi.advanceTimersByTimeAsync(900);
+
+        // Selection guard returns before the wake IPC, so no snapshot is ever
+        // fetched and no marker is drawn.
+        expect(wakeMock).not.toHaveBeenCalled();
+        expect(onDeclined).not.toHaveBeenCalled();
+        expect(manager.hasPendingWake("term-decline-stuck")).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary

- When the PTY host suspends a terminal's visual stream it discards buffered output, trusting a later wake snapshot to resync. But `wakeAndRestore` could silently decline that snapshot in three cases — active text selection, alt-buffer early-return, and null serialized state — leaving the pane stale while status reported it live. The alt-buffer path was the worst: it returned `true` and permanently set `needsWake=false`, suppressing all future wakes for that pane.
- Removed the alt-buffer early-return (addon-serialize covers the alt-buffer frame, so replay works correctly), added a bounded decline-retry in `TerminalWakeManager` (3 attempts at 300ms, generation-safe, bails if the pane re-backgrounds), and injects a data-loss marker once per decline sequence for null-state gaps only.
- Closed two review-found races: `hasPendingWake` now counts in-flight decline retries so the reconciliation watchdog defers correctly, and the success path cancels any leftover decline timer for all callers.

Resolves #9894.

## Changes

- `TerminalWakeManager`: remove alt-buffer early-return; add `declineRetry` loop (3×, 300ms, generation-gated); inject data-loss marker on null-state declines; fix `hasPendingWake` to cover pending retries; cancel decline timer on success path
- `TerminalWakeManager.test.ts`: rewrote both alt-buffer tests for new behavior; 9 new decline-retry cases (selection retries until clear, null-state marker drawn once + retries to cap, success stops retries, re-backgrounded bail, `hasPendingWake` during retries, direct-wake cancels retry, exhausted-selection silent exit, `clearWakeState`/`dispose` cancel)

## Testing

31/31 `TerminalWakeManager` tests pass. Covers the full decline-retry matrix: selection-held, null-state, success-stops, re-backgrounded abort, `hasPendingWake` during retry window, and dispose/clear cancellation. Static checks and build green.