### PR TITLE
fix(terminal): make pendingWrites guard unconditional in hibernation check

### DIFF
--- a/src/services/terminal/TerminalHibernationManager.ts
+++ b/src/services/terminal/TerminalHibernationManager.ts
@@ -209,6 +209,10 @@ export class TerminalHibernationManager {
     // Clear the reflow throttle so post-wake writes trigger an immediate
     // IO re-evaluation.
     managed.lastReflowAt = 0;
+    // Clear any counter stranded by a mid-write dispose — the old terminal's
+    // write callbacks will never fire, and the fresh Terminal has no queued
+    // writes, so a non-zero value here would block hibernation forever (#9912).
+    managed.pendingWrites = 0;
 
     // Re-bind the fresh Terminal to its DOM host. Without this, the
     // terminal exists in memory with a working buffer but no rendered
@@ -247,16 +251,20 @@ export class TerminalHibernationManager {
    * eligibility predicate composes this with a BACKGROUND tier check.
    *
    * Rules:
-   * - Non-agent terminals: always safe.
+   * - In-flight writes: never safe, for ANY terminal. Disposing xterm while
+   *   its WriteBuffer holds queued chunks drops the write callbacks, which
+   *   strands `pendingWrites` above zero forever (#9912). This guard is
+   *   checked first so no other rule can bypass it.
+   * - Non-agent terminals: otherwise always safe.
    * - Agents in resting states (`idle`/`completed`/`exited`, or undefined
    *   state for legacy paths that never assigned canonicalAgentState):
-   *   always safe. `idle` is not in ACTIVE_AGENT_STATES — it represents
-   *   the agent itself reporting it has nothing to do.
+   *   otherwise always safe. `idle` is not in ACTIVE_AGENT_STATES — it
+   *   represents the agent itself reporting it has nothing to do.
    * - Agents in active states (`working`/`waiting`/`directing`): safe
-   *   only if no writes are in flight AND the last rendered output is
-   *   either non-existent or at least AGENT_IDLE_SILENCE_MS old. The
-   *   "never wrote" case is treated as safe because silence is by
-   *   definition infinite if no write has ever been recorded.
+   *   only if the last rendered output is either non-existent or at least
+   *   AGENT_IDLE_SILENCE_MS old. The "never wrote" case is treated as safe
+   *   because silence is by definition infinite if no write has ever been
+   *   recorded.
    * - User-backgrounded panels: the silence window is bypassed — the user
    *   explicitly hid the panel, so an active agent is no objection to
    *   reclaiming its memory under pressure. The `pendingWrites === 0` burst
@@ -269,10 +277,10 @@ export class TerminalHibernationManager {
     id: string,
     now: number = Date.now()
   ): boolean {
+    if ((managed.pendingWrites ?? 0) > 0) return false;
     if (!managed.runtimeAgentId) return true;
     const state = managed.canonicalAgentState;
     if (state === undefined || !ACTIVE_AGENT_STATES.has(state)) return true;
-    if ((managed.pendingWrites ?? 0) > 0) return false;
     if (this.deps.getIsBackgrounded(id)) return true;
     if (managed.lastWriteAt === undefined) return true;
     return now - managed.lastWriteAt >= AGENT_IDLE_SILENCE_MS;

--- a/src/services/terminal/__tests__/TerminalHibernationManager.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.adversarial.test.ts
@@ -360,6 +360,37 @@ describe("TerminalHibernationManager adversarial", () => {
     expect(managed.lastReflowAt).toBe(0);
   });
 
+  it("STRANDED_PENDING_WRITES_CLEARED_ON_WAKE_RESTORES_HIBERNATION_ELIGIBILITY", () => {
+    // A mid-write dispose (pre-#9912) leaves pendingWrites stranded above
+    // zero — the old terminal's write callbacks never fire. The counter must
+    // not survive the wake cycle, or hibernation is blocked forever.
+    managed = makeMockManaged({
+      isHibernated: true,
+      isOpened: false,
+      pendingWrites: 3, // stranded by a mid-write dispose
+    });
+    connectHost(managed.hostElement, 800, 600);
+    deps = makeMockDeps(managed);
+    manager = new TerminalHibernationManager(deps);
+
+    // While stranded, the guard blocks hibernation for ANY terminal shape —
+    // verify via the eligibility facade before the wake clears it.
+    managed.isHibernated = false;
+    expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1")).toBe(
+      false
+    );
+    managed.isHibernated = true;
+
+    manager.unhibernate("t1");
+    expect(managed.pendingWrites).toBe(0);
+
+    // With the counter cleared, the terminal is hibernatable again.
+    expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1")).toBe(true);
+    manager.hibernate("t1");
+    expect(managed.isHibernated).toBe(true);
+    expect(managed.terminal.dispose).toHaveBeenCalledTimes(1);
+  });
+
   it("BACKGROUNDED_BYPASS_DROPPED_WHEN_RESTORED_BETWEEN_SCHEDULE_AND_FIRE", () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);

--- a/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
@@ -259,7 +259,10 @@ describe("TerminalHibernationManager", () => {
       managed.runtimeAgentId = undefined;
       managed.pendingWrites = 2;
       manager.hibernate("t1");
+      // Full no-op: no teardown side effects, not just an unset flag.
       expect(managed.isHibernated).toBeFalsy();
+      expect(managed.terminal.dispose).not.toHaveBeenCalled();
+      expect(deps.destroyRestoreState).not.toHaveBeenCalled();
     });
 
     it("should no-op for a resting-state agent with writes in flight (#9912)", () => {
@@ -269,6 +272,23 @@ describe("TerminalHibernationManager", () => {
       managed.pendingWrites = 1;
       manager.hibernate("t1");
       expect(managed.isHibernated).toBeFalsy();
+      expect(managed.terminal.dispose).not.toHaveBeenCalled();
+      expect(deps.destroyRestoreState).not.toHaveBeenCalled();
+    });
+
+    it("should no-op for a backgrounded active agent with writes in flight (#9912)", () => {
+      // Direct hibernate() path (not the eligibility facade): the burst
+      // guard must precede the backgrounded bypass.
+      managed.launchAgentId = "claude";
+      managed.runtimeAgentId = "claude";
+      managed.canonicalAgentState = "working";
+      managed.lastWriteAt = Date.now() - 1000;
+      managed.pendingWrites = 1;
+      (deps.getIsBackgrounded as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      manager.hibernate("t1");
+      expect(managed.isHibernated).toBeFalsy();
+      expect(managed.terminal.dispose).not.toHaveBeenCalled();
+      expect(deps.destroyRestoreState).not.toHaveBeenCalled();
     });
 
     it("should hibernate a working agent that has been silent past AGENT_IDLE_SILENCE_MS", () => {
@@ -519,6 +539,12 @@ describe("TerminalHibernationManager", () => {
       expect(managed.pendingWrites).toBe(0);
     });
 
+    it("should keep pendingWrites at 0 on wake when nothing was stranded (#9912)", () => {
+      managed.pendingWrites = 0;
+      manager.unhibernate("t1");
+      expect(managed.pendingWrites).toBe(0);
+    });
+
     it("notifies onHibernationChanged after the flag is cleared", () => {
       let seenFlag: boolean | undefined;
       (deps.onHibernationChanged as ReturnType<typeof vi.fn>).mockImplementation(() => {
@@ -578,6 +604,16 @@ describe("TerminalHibernationManager", () => {
       managed.runtimeAgentId = undefined;
       expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1")).toBe(
         true
+      );
+    });
+
+    it("rejects BACKGROUND for a non-agent terminal with writes in flight (#9912)", () => {
+      // Keeps the eligibility facade and the direct hibernate() guard in
+      // lockstep should the two paths ever diverge.
+      managed.runtimeAgentId = undefined;
+      managed.pendingWrites = 1;
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1")).toBe(
+        false
       );
     });
 

--- a/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
@@ -253,6 +253,24 @@ describe("TerminalHibernationManager", () => {
       expect(managed.isHibernated).toBeFalsy();
     });
 
+    it("should no-op for a non-agent terminal with writes in flight (#9912)", () => {
+      // No runtimeAgentId — previously the non-agent early-return skipped
+      // the pendingWrites guard entirely, letting dispose() fire mid-write.
+      managed.runtimeAgentId = undefined;
+      managed.pendingWrites = 2;
+      manager.hibernate("t1");
+      expect(managed.isHibernated).toBeFalsy();
+    });
+
+    it("should no-op for a resting-state agent with writes in flight (#9912)", () => {
+      managed.launchAgentId = "claude";
+      managed.runtimeAgentId = "claude";
+      managed.canonicalAgentState = "completed";
+      managed.pendingWrites = 1;
+      manager.hibernate("t1");
+      expect(managed.isHibernated).toBeFalsy();
+    });
+
     it("should hibernate a working agent that has been silent past AGENT_IDLE_SILENCE_MS", () => {
       managed.launchAgentId = "claude";
       managed.runtimeAgentId = "claude";
@@ -490,6 +508,15 @@ describe("TerminalHibernationManager", () => {
       managed.lastReflowAt = 99999;
       manager.unhibernate("t1");
       expect(managed.lastReflowAt).toBe(0);
+    });
+
+    it("should reset stranded pendingWrites so hibernation stays reachable (#9912)", () => {
+      // A mid-write dispose drops the old terminal's write callbacks, so the
+      // counter can be stuck > 0 entering the wake path. The fresh Terminal
+      // has no queued writes — the wake must zero it.
+      managed.pendingWrites = 5;
+      manager.unhibernate("t1");
+      expect(managed.pendingWrites).toBe(0);
     });
 
     it("notifies onHibernationChanged after the flag is cleared", () => {


### PR DESCRIPTION
## Summary

- `isSafeToHibernate()` in `TerminalHibernationManager.ts` had the `pendingWrites > 0` guard sitting after two early returns (non-agent and resting-state-agent paths), so hibernation could proceed while writes were still queued in xterm's `WriteBuffer`. xterm 6's `_innerWrite` has no disposed-instance guard, so those queued write callbacks were silently dropped on dispose.
- Hoisted the guard to the first statement so it blocks unconditionally, regardless of which early return would otherwise fire. The silence-window bypass for user-backgrounded panels is preserved — it was already positioned after the guard.
- Added `managed.pendingWrites = 0` to the restore-state reset in `unhibernate()`, so a counter stranded by a prior mid-write dispose can't survive a wake cycle and permanently block future hibernation.

Resolves #9912

## Changes

- `src/services/terminal/TerminalHibernationManager.ts` — hoisted `pendingWrites` guard; counter reset in `unhibernate()`; doc comment updated to lead with the unconditional in-flight-writes rule
- `src/services/terminal/__tests__/TerminalHibernationManager.test.ts` — 6 new unit/boundary tests
- `src/services/terminal/__tests__/TerminalHibernationManager.adversarial.test.ts` — 1 adversarial wake-cycle test (`STRANDED_PENDING_WRITES_CLEARED_ON_WAKE_RESTORES_HIBERNATION_ELIGIBILITY`)

## Testing

- 72 tests pass across both suites (65 baseline + 7 new)
- New tests cover: non-agent mid-write no-op, resting-agent mid-write no-op, backgrounded-active mid-write no-op (all assert zero teardown side effects); eligibility-facade rejection for non-agent with pending writes; stranded counter reset on wake (5→0) and idempotent (0→0); adversarial round-trip confirming hibernation becomes eligible again after wake clears the stranded counter
- `npm run check`, `npm run test`, `npm run build` all green