### PR TITLE
fix(mcp): surface internal help-session connections in settings tab

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -662,6 +662,13 @@ export const CHANNELS = {
    */
   MCP_SERVER_LIST_ACTIVE_BEARERS: "mcp-server:list-active-bearers",
   /**
+   * Read-only inventory of the renderer-pinned help-session bearers (the
+   * Daintree Assistant's own internal MCP connections). Backs the separate
+   * "Daintree Assistant connections" row on the MCP Server settings tab,
+   * which has no disconnect control (#10036).
+   */
+  MCP_SERVER_LIST_HELP_SESSION_BEARERS: "mcp-server:list-help-session-bearers",
+  /**
    * Disconnect a single external bearer by its token hash: revoke every
    * session it owns and evict it from the live register. One bearer only —
    * key rotation (revoke-all) stays a separate action (#8778).

--- a/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
@@ -307,8 +307,8 @@ describe("mcpServer IPC adversarial", () => {
     expect(serviceMock.resetDenialCounts).toHaveBeenCalledWith("sess-7", 77);
   });
 
-  it("cleanup removes all twenty-three registered handlers", () => {
-    expect(ipcHandlers.size).toBe(23);
+  it("cleanup removes all twenty-four registered handlers", () => {
+    expect(ipcHandlers.size).toBe(24);
     cleanup();
     expect(ipcHandlers.size).toBe(0);
   });

--- a/electron/ipc/handlers/mcpServer.preload.ts
+++ b/electron/ipc/handlers/mcpServer.preload.ts
@@ -23,6 +23,7 @@ export const MCP_SERVER_METHOD_CHANNELS = {
   revokeSessionGrants: "mcp-server:revoke-session-grants",
   resetDenialCounts: "mcp-server:reset-denial-counts",
   listActiveBearers: "mcp-server:list-active-bearers",
+  listHelpSessionBearers: "mcp-server:list-help-session-bearers",
   disconnectBearer: "mcp-server:disconnect-bearer",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 

--- a/electron/ipc/handlers/mcpServer.ts
+++ b/electron/ipc/handlers/mcpServer.ts
@@ -11,6 +11,7 @@ import type {
   ActiveBearerRecord,
   AssistantTurnRecord,
   DisconnectBearerResult,
+  HelpSessionBearerRecord,
   McpActiveClientInfo,
   McpAuditRecord,
   McpAuditStats,
@@ -283,6 +284,13 @@ export const mcpServerNamespace = defineIpcNamespace({
       async (): Promise<ActiveBearerRecord[]> => {
         const svc = await getMcpServerService();
         return svc.listActiveBearers();
+      }
+    ),
+    listHelpSessionBearers: op(
+      MCP_SERVER_METHOD_CHANNELS.listHelpSessionBearers,
+      async (): Promise<HelpSessionBearerRecord[]> => {
+        const svc = await getMcpServerService();
+        return svc.listHelpSessionBearers();
       }
     ),
     disconnectBearer: op(

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -10,6 +10,7 @@ import type {
   ActiveBearerRecord,
   AssistantTurnRecord,
   DisconnectBearerResult,
+  HelpSessionBearerRecord,
   McpAuditRecord,
   McpAuditStats,
   McpGrantLifecyclePayload,
@@ -510,6 +511,16 @@ export class McpServerService {
    */
   listActiveBearers(): ActiveBearerRecord[] {
     return this.httpLifecycle.listActiveBearers();
+  }
+
+  /**
+   * Read-only inventory of the renderer-pinned help-session bearers (the
+   * Daintree Assistant's own internal MCP connections) for the separate
+   * "Daintree Assistant connections" settings row (#10036). Display fields
+   * only — no tokens or hashes cross IPC, and there is no disconnect action.
+   */
+  listHelpSessionBearers(): HelpSessionBearerRecord[] {
+    return this.httpLifecycle.listHelpSessionBearers();
   }
 
   /**

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -863,6 +863,20 @@ describe("HttpLifecycle", () => {
       expect(lc.listHelpSessionBearers()).toHaveLength(0);
     });
 
+    it("listHelpSessionBearers covers every non-external tier, not just the help chat (#10036)", () => {
+      const lc = new HttpLifecycle(fakeDeps());
+      const handle = lc as unknown as BearerTestHandle;
+      // In-panel agent (pane) tokens are non-external too — they belong in the
+      // Internal connections row alongside the help-chat assistant.
+      handle.touchBearer(authA, "Help/1", "sess-help", "action");
+      handle.touchBearer(authB, "Pane/1", "sess-pane", "workbench");
+      handle.touchBearer("Bearer external-cccc", "Claude/1", "sess-ext", "external");
+
+      const help = lc.listHelpSessionBearers();
+      expect(help).toHaveLength(2);
+      expect(help.map((h) => h.userAgent).sort()).toEqual(["Help/1", "Pane/1"]);
+    });
+
     it("pushes a runtime-state change on help-session connect and disconnect (#10036)", () => {
       const deps = fakeDeps();
       const lc = new HttpLifecycle(deps);

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -816,7 +816,7 @@ describe("HttpLifecycle", () => {
       expect(bearers[0]).not.toHaveProperty("sessionIds");
     });
 
-    it("hides internal (help/pane) bearers from the settings list but still tracks them (#9151)", () => {
+    it("hides internal (help/pane) bearers from the External-clients list but still tracks them (#9151)", () => {
       const deps = fakeDeps();
       const lc = new HttpLifecycle(deps);
       const handle = lc as unknown as BearerTestHandle;
@@ -827,13 +827,51 @@ describe("HttpLifecycle", () => {
       // ...but tracked in the register so eager teardown can find them.
       expect(lc.getBearerSessionIds(hashOf(authA))).toEqual(["sess-help"]);
       expect(lc.getBearerSessionIds(hashOf(authB))).toEqual(["sess-pane"]);
-      // Help-bearer handshakes don't push a runtime-state change (they never
-      // surface in the UI) — only the external bearer below does.
-      expect(deps.emitRuntimeStateChange).not.toHaveBeenCalled();
       // A subsequent external bearer is still tracked AND listed.
       handle.touchBearer("Bearer external-cccc", "Claude/1", "sess-ext", "external");
       expect(lc.listActiveBearers()).toHaveLength(1);
+    });
+
+    it("surfaces help-session bearers in listHelpSessionBearers with display fields only (#10036)", () => {
+      const lc = new HttpLifecycle(fakeDeps());
+      const handle = lc as unknown as BearerTestHandle;
+      handle.touchBearer(authA, "Daintree Assistant/1", "sess-help-1", "action");
+      handle.touchBearer(authA, "Daintree Assistant/1", "sess-help-2", "action");
+      handle.touchBearer("Bearer external-cccc", "Claude/1", "sess-ext", "external");
+
+      const help = lc.listHelpSessionBearers();
+      // Only the help-session bearer is returned — the external one is excluded.
+      expect(help).toHaveLength(1);
+      expect(help[0]).toEqual({
+        userAgent: "Daintree Assistant/1",
+        lastActiveAt: expect.any(Number),
+        requestsSinceLaunch: 2,
+        sessionCount: 2,
+      });
+      // No token, hash, or raw session ids cross the listing surface.
+      const serialized = JSON.stringify(help);
+      expect(serialized).not.toContain("secret-token-aaaa");
+      expect(help[0]).not.toHaveProperty("tokenHash");
+      expect(help[0]).not.toHaveProperty("token4LastChars");
+      expect(help[0]).not.toHaveProperty("sessionIds");
+    });
+
+    it("listHelpSessionBearers is empty when only external bearers are connected (#10036)", () => {
+      const lc = new HttpLifecycle(fakeDeps());
+      const handle = lc as unknown as BearerTestHandle;
+      handle.touchBearer(authA, "Claude/1", "sess-ext", "external");
+      expect(lc.listHelpSessionBearers()).toHaveLength(0);
+    });
+
+    it("pushes a runtime-state change on help-session connect and disconnect (#10036)", () => {
+      const deps = fakeDeps();
+      const lc = new HttpLifecycle(deps);
+      const handle = lc as unknown as BearerTestHandle;
+      handle.touchBearer(authA, "Daintree Assistant/1", "sess-help", "action");
       expect(deps.emitRuntimeStateChange).toHaveBeenCalledTimes(1);
+      handle.detachBearerSession("sess-help");
+      expect(deps.emitRuntimeStateChange).toHaveBeenCalledTimes(2);
+      expect(lc.listHelpSessionBearers()).toHaveLength(0);
     });
 
     it("findHelpBearerHash resolves a help token to its register key, ignoring external bearers (#9151)", () => {

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -21,6 +21,7 @@ import type {
 } from "./shared.js";
 import type {
   ActiveBearerRecord,
+  HelpSessionBearerRecord,
   McpActiveClientInfo,
   McpBearerIdentity,
   McpIssueGrantResult,
@@ -364,10 +365,11 @@ export class HttpLifecycle {
     entry.requestsSinceLaunch += 1;
     entry.sessionIds.add(sessionId);
     this.sessionToTokenHash.set(sessionId, tokenHash);
-    // Only external bearers surface in the settings UI, so only their
-    // handshakes need a runtime-state push. Help bearers are filtered out of
-    // `listActiveBearers`; emitting for them would be needless IPC chatter.
-    if (!isHelpSession) this.deps.emitRuntimeStateChange();
+    // Both external bearers (External clients row) and help-session bearers
+    // (the "Daintree Assistant connections" row, #10036) surface on the
+    // settings tab, so every handshake needs a runtime-state push to keep the
+    // open tab live.
+    this.deps.emitRuntimeStateChange();
   }
 
   /**
@@ -420,10 +422,10 @@ export class HttpLifecycle {
     if (entry.sessionIds.size === 0) {
       this.bearerRegister.delete(tokenHash);
     }
-    // Help bearers are filtered out of `listActiveBearers`, so their teardown
-    // changes nothing the settings UI shows — skip the runtime-state push to
-    // avoid needless IPC chatter (mirrors the `touchBearer` gate).
-    if (!entry.isHelpSession) this.deps.emitRuntimeStateChange();
+    // Both external and help-session bearers surface on the settings tab
+    // (#10036), so every teardown needs a runtime-state push so an open tab
+    // drops the row.
+    this.deps.emitRuntimeStateChange();
   }
 
   /**
@@ -442,6 +444,29 @@ export class HttpLifecycle {
         userAgent: entry.userAgent,
         lastActiveAt: entry.lastActiveAt,
         requestsSinceLaunch: entry.requestsSinceLaunch,
+      });
+    }
+    return records;
+  }
+
+  /**
+   * Read-only inventory of the renderer-pinned help-session bearers (the
+   * Daintree Assistant's own internal MCP connections) for the separate
+   * "Daintree Assistant connections" settings row (#10036). The inverse filter
+   * of {@link listActiveBearers}: only `isHelpSession` entries. Exposes display
+   * fields only — never the `helpToken`, `tokenHash`, or `token4LastChars`
+   * (those identify an internal credential and stay main-side, #9318); there is
+   * no disconnect action for help sessions so no hash is needed to target one.
+   */
+  listHelpSessionBearers(): HelpSessionBearerRecord[] {
+    const records: HelpSessionBearerRecord[] = [];
+    for (const entry of this.bearerRegister.values()) {
+      if (!entry.isHelpSession) continue;
+      records.push({
+        userAgent: entry.userAgent,
+        lastActiveAt: entry.lastActiveAt,
+        requestsSinceLaunch: entry.requestsSinceLaunch,
+        sessionCount: entry.sessionIds.size,
       });
     }
     return records;

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -358,6 +358,7 @@ export type {
   McpRuntimeSnapshot,
   McpRuntimeState,
   ActiveBearerRecord,
+  HelpSessionBearerRecord,
   DisconnectBearerResult,
 } from "./ipc/mcpServer.js";
 export {

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -259,6 +259,9 @@ export interface GeneratedElectronAPI {
     listActiveClients(
       ...args: IpcInvokeMap["mcp-server:list-active-clients"]["args"]
     ): Promise<IpcInvokeMap["mcp-server:list-active-clients"]["result"]>;
+    listHelpSessionBearers(
+      ...args: IpcInvokeMap["mcp-server:list-help-session-bearers"]["args"]
+    ): Promise<IpcInvokeMap["mcp-server:list-help-session-bearers"]["result"]>;
     resetDenialCounts(
       ...args: IpcInvokeMap["mcp-server:reset-denial-counts"]["args"]
     ): Promise<IpcInvokeMap["mcp-server:reset-denial-counts"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -495,6 +495,10 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: import("./mcpServer.js").McpActiveClientInfo[];
   };
+  "mcp-server:list-help-session-bearers": {
+    args: [];
+    result: import("./mcpServer.js").HelpSessionBearerRecord[];
+  };
   "mcp-server:reset-denial-counts": {
     args: [payload: { sessionId: string }];
     result: void;

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -592,15 +592,16 @@ export interface ActiveBearerRecord {
 }
 
 /**
- * Read-only inventory of one renderer-pinned help-session bearer (the Daintree
- * Assistant's own internal MCP connection), surfaced as a separate "Daintree
- * Assistant connections" section on the MCP Server settings tab (#10036). These
- * bearers are deliberately excluded from {@link ActiveBearerRecord}/the External
- * clients row (#9151) — this type gives the user passive visibility into them
- * without offering a disconnect control (the assistant manages its own session).
+ * Read-only inventory of one renderer-pinned internal bearer — Daintree's own
+ * MCP consumers (the help-chat assistant and in-panel agents, i.e. any
+ * non-`external` tier) — surfaced as a separate "Internal connections" section
+ * on the MCP Server settings tab (#10036). These bearers are deliberately
+ * excluded from {@link ActiveBearerRecord}/the External clients row (#9151) —
+ * this type gives the user passive visibility into them without offering a
+ * disconnect control (they are severed via their owning surface, not here).
  *
  * Carries display fields only: no `tokenHash` (there is no disconnect action to
- * target) and no `token4LastChars` (the help token suffix identifies an internal
+ * target) and no `token4LastChars` (the bearer suffix identifies an internal
  * credential and stays main-side, per #9318). `sessionCount` is the number of
  * live MCP transport sessions this bearer currently owns.
  */

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -592,6 +592,26 @@ export interface ActiveBearerRecord {
 }
 
 /**
+ * Read-only inventory of one renderer-pinned help-session bearer (the Daintree
+ * Assistant's own internal MCP connection), surfaced as a separate "Daintree
+ * Assistant connections" section on the MCP Server settings tab (#10036). These
+ * bearers are deliberately excluded from {@link ActiveBearerRecord}/the External
+ * clients row (#9151) — this type gives the user passive visibility into them
+ * without offering a disconnect control (the assistant manages its own session).
+ *
+ * Carries display fields only: no `tokenHash` (there is no disconnect action to
+ * target) and no `token4LastChars` (the help token suffix identifies an internal
+ * credential and stays main-side, per #9318). `sessionCount` is the number of
+ * live MCP transport sessions this bearer currently owns.
+ */
+export interface HelpSessionBearerRecord {
+  userAgent: string;
+  lastActiveAt: number;
+  requestsSinceLaunch: number;
+  sessionCount: number;
+}
+
+/**
  * Display-only provenance for the external bearer behind a `danger: "confirm"`
  * dispatch, threaded into the MCP confirm dialog so the user can see which
  * client is asking before approving (#9157). Carries only the non-sensitive

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -113,9 +113,10 @@ export function McpServerSettingsTab() {
   const [activeBearers, setActiveBearers] = useState<ActiveBearerRecord[]>([]);
   const [bearersExpanded, setBearersExpanded] = useState(false);
   const [disconnectingHash, setDisconnectingHash] = useState<string | null>(null);
-  // Read-only inventory of the Daintree Assistant's own internal MCP
-  // connections (#10036) — surfaced so the External clients row no longer hides
-  // them, but with no disconnect control (the assistant manages its session).
+  // Read-only inventory of Daintree's own internal MCP connections — the
+  // help-chat assistant and in-panel agents (#10036) — surfaced so the External
+  // clients row no longer hides them, but with no disconnect control (these are
+  // Daintree's own consumers, severed via their owning surface, not here).
   const [helpSessionBearers, setHelpSessionBearers] = useState<HelpSessionBearerRecord[]>([]);
   const [helpBearersExpanded, setHelpBearersExpanded] = useState(false);
   // Drives the neutral attribution pill on the top card: when the Daintree
@@ -675,7 +676,7 @@ export function McpServerSettingsTab() {
                         )}
                       />
                       <Sparkles className="w-3.5 h-3.5 shrink-0 text-daintree-text/50" />
-                      Daintree Assistant connections ({helpSessionBearers.length})
+                      Internal connections ({helpSessionBearers.length})
                     </button>
 
                     {helpBearersExpanded && (

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -12,6 +12,7 @@ import {
   ScrollText,
   Plug,
   ChevronRight,
+  Sparkles,
 } from "lucide-react";
 import { McpServerIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
@@ -34,6 +35,7 @@ import {
   type AssistantTurnRecord,
   type McpAuditStats,
   type ActiveBearerRecord,
+  type HelpSessionBearerRecord,
   type McpRuntimeSnapshot,
   MCP_AUDIT_DEFAULT_MAX_RECORDS,
   MCP_AUDIT_MAX_RECORDS,
@@ -111,6 +113,11 @@ export function McpServerSettingsTab() {
   const [activeBearers, setActiveBearers] = useState<ActiveBearerRecord[]>([]);
   const [bearersExpanded, setBearersExpanded] = useState(false);
   const [disconnectingHash, setDisconnectingHash] = useState<string | null>(null);
+  // Read-only inventory of the Daintree Assistant's own internal MCP
+  // connections (#10036) — surfaced so the External clients row no longer hides
+  // them, but with no disconnect control (the assistant manages its session).
+  const [helpSessionBearers, setHelpSessionBearers] = useState<HelpSessionBearerRecord[]>([]);
+  const [helpBearersExpanded, setHelpBearersExpanded] = useState(false);
   // Drives the neutral attribution pill on the top card: when the Daintree
   // Assistant holds the server open, the toggle reflects assistant intent
   // rather than a manual choice.
@@ -127,6 +134,15 @@ export function McpServerSettingsTab() {
       setActiveBearers(bearers);
     } catch (err) {
       logError("Failed to load MCP active bearers", err);
+    }
+  };
+
+  const refreshHelpSessionBearers = async (): Promise<void> => {
+    try {
+      const bearers = await window.electron.mcpServer.listHelpSessionBearers();
+      setHelpSessionBearers(bearers);
+    } catch (err) {
+      logError("Failed to load MCP help-session bearers", err);
     }
   };
 
@@ -210,6 +226,7 @@ export function McpServerSettingsTab() {
       });
 
     void refreshActiveBearers();
+    void refreshHelpSessionBearers();
     void refreshAssistantControl();
 
     const unsub = window.electron.mcpServer.onRuntimeStateChanged((next) => {
@@ -230,8 +247,9 @@ export function McpServerSettingsTab() {
           logError("Failed to refresh MCP status on runtime change", err);
         });
       // A runtime-state push fires on connect/disconnect, server restart, and
-      // the assistant toggling `daintreeControl` — refresh both derived views.
+      // the assistant toggling `daintreeControl` — refresh all derived views.
       void refreshActiveBearers();
+      void refreshHelpSessionBearers();
       void refreshAssistantControl();
     });
 
@@ -635,6 +653,52 @@ export function McpServerSettingsTab() {
                                 ? "Disconnecting…"
                                 : "Disconnect"}
                             </button>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                )}
+
+                {helpSessionBearers.length > 0 && (
+                  <div className="rounded-[var(--radius-md)] border border-daintree-border overflow-hidden">
+                    <button
+                      type="button"
+                      onClick={() => setHelpBearersExpanded((v) => !v)}
+                      aria-expanded={helpBearersExpanded}
+                      className="flex w-full items-center gap-2 px-3 py-2 text-xs font-medium text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft transition-colors"
+                    >
+                      <ChevronRight
+                        className={cn(
+                          "w-3.5 h-3.5 shrink-0 transition-transform duration-150",
+                          helpBearersExpanded && "rotate-90"
+                        )}
+                      />
+                      <Sparkles className="w-3.5 h-3.5 shrink-0 text-daintree-text/50" />
+                      Daintree Assistant connections ({helpSessionBearers.length})
+                    </button>
+
+                    {helpBearersExpanded && (
+                      <ul className="border-t border-daintree-border divide-y divide-daintree-border">
+                        {helpSessionBearers.map((bearer, i) => (
+                          <li
+                            key={`${bearer.userAgent}-${i}`}
+                            className="flex items-center gap-3 px-3 py-2"
+                          >
+                            <div className="min-w-0 flex-1">
+                              <div className="truncate text-xs text-daintree-text/80">
+                                {bearer.userAgent}
+                              </div>
+                              <div className="text-[11px] text-daintree-text/50">
+                                {bearer.sessionCount}{" "}
+                                {bearer.sessionCount === 1 ? "session" : "sessions"}
+                                {" · "}
+                                {bearer.requestsSinceLaunch}{" "}
+                                {bearer.requestsSinceLaunch === 1 ? "request" : "requests"}
+                                {" · active "}
+                                {formatRelativeTime(bearer.lastActiveAt)}
+                              </div>
+                            </div>
                           </li>
                         ))}
                       </ul>

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -1298,7 +1298,7 @@ describe("McpServerSettingsTab", () => {
     });
   });
 
-  describe("Daintree Assistant connections (#10036)", () => {
+  describe("internal connections (#10036)", () => {
     const helpBearer = {
       userAgent: "Daintree Assistant/1.0",
       lastActiveAt: Date.now() - 5000,
@@ -1306,17 +1306,17 @@ describe("McpServerSettingsTab", () => {
       sessionCount: 2,
     };
 
-    it("hides the assistant-connections row when no help session is connected", async () => {
+    it("hides the internal-connections row when no internal bearer is connected", async () => {
       const { container } = render(
         <SettingsValidationProvider>
           <McpServerSettingsTab />
         </SettingsValidationProvider>
       );
       await waitForContent(container, "API key active");
-      expect(container.textContent).not.toContain("Daintree Assistant connections");
+      expect(container.textContent).not.toContain("Internal connections");
     });
 
-    it("shows the help-session row read-only, with no disconnect control", async () => {
+    it("shows the internal-connection row read-only, with no disconnect control", async () => {
       const listHelpSessionBearers = vi.fn().mockResolvedValue([helpBearer]);
       installMcpApi({ listHelpSessionBearers });
 
@@ -1325,9 +1325,9 @@ describe("McpServerSettingsTab", () => {
           <McpServerSettingsTab />
         </SettingsValidationProvider>
       );
-      await waitForContent(container, "Daintree Assistant connections (1)");
+      await waitForContent(container, "Internal connections (1)");
 
-      fireEvent.click(screen.getByRole("button", { name: /daintree assistant connections/i }));
+      fireEvent.click(screen.getByRole("button", { name: /internal connections/i }));
       await waitFor(() => {
         expect(container.textContent).toContain("Daintree Assistant/1.0");
       });
@@ -1338,7 +1338,40 @@ describe("McpServerSettingsTab", () => {
       expect(screen.queryByRole("button", { name: "Disconnect" })).toBeNull();
     });
 
-    it("populates the assistant-connections row when a runtime-state change fires after mount", async () => {
+    it("keeps the internal row read-only while the external row stays disconnectable (#9151)", async () => {
+      const externalBearer = {
+        tokenHash: "b".repeat(64),
+        token4LastChars: "abcd",
+        userAgent: "Cursor/0.42",
+        lastActiveAt: Date.now() - 1000,
+        requestsSinceLaunch: 7,
+      };
+      const listActiveBearers = vi.fn().mockResolvedValue([externalBearer]);
+      const listHelpSessionBearers = vi.fn().mockResolvedValue([helpBearer]);
+      installMcpApi({ listActiveBearers, listHelpSessionBearers });
+
+      const { container } = render(
+        <SettingsValidationProvider>
+          <McpServerSettingsTab />
+        </SettingsValidationProvider>
+      );
+      await waitForContent(container, "External clients (1)");
+      await waitForContent(container, "Internal connections (1)");
+
+      // Expand both sections so every row is rendered.
+      fireEvent.click(screen.getByRole("button", { name: /external clients/i }));
+      fireEvent.click(screen.getByRole("button", { name: /internal connections/i }));
+      await waitFor(() => {
+        expect(container.textContent).toContain("Cursor/0.42");
+        expect(container.textContent).toContain("Daintree Assistant/1.0");
+      });
+
+      // Exactly one Disconnect button exists — the external row's. The internal
+      // row never offers one, even when both sections are visible at once.
+      expect(screen.getAllByRole("button", { name: "Disconnect" })).toHaveLength(1);
+    });
+
+    it("populates the internal-connections row when a runtime-state change fires after mount", async () => {
       let runtimeCb: ((snapshot: unknown) => void) | undefined;
       const onRuntimeStateChanged = vi.fn((cb: (snapshot: unknown) => void) => {
         runtimeCb = cb;
@@ -1346,7 +1379,7 @@ describe("McpServerSettingsTab", () => {
       });
       const listHelpSessionBearers = vi
         .fn()
-        .mockResolvedValueOnce([]) // initial mount: assistant not connected
+        .mockResolvedValueOnce([]) // initial mount: nothing connected
         .mockResolvedValue([helpBearer]); // after the push: connected
       installMcpApi({ onRuntimeStateChanged, listHelpSessionBearers });
 
@@ -1356,10 +1389,10 @@ describe("McpServerSettingsTab", () => {
         </SettingsValidationProvider>
       );
       await waitForContent(container, "API key active");
-      expect(container.textContent).not.toContain("Daintree Assistant connections");
+      expect(container.textContent).not.toContain("Internal connections");
 
       runtimeCb?.({ enabled: true, state: "ready", port: 9020, lastError: null });
-      await waitForContent(container, "Daintree Assistant connections (1)");
+      await waitForContent(container, "Internal connections (1)");
     });
   });
 

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -99,6 +99,7 @@ function createMcpApi(overrides: Partial<typeof window.electron.mcpServer> = {})
     clearTurnOutcomeLog: vi.fn().mockResolvedValue(undefined),
     onRuntimeStateChanged: vi.fn().mockReturnValue(vi.fn()),
     listActiveBearers: vi.fn().mockResolvedValue([]),
+    listHelpSessionBearers: vi.fn().mockResolvedValue([]),
     disconnectBearer: vi.fn().mockResolvedValue({ tokenHash: "", disconnected: true }),
     ...overrides,
   };
@@ -1294,6 +1295,71 @@ describe("McpServerSettingsTab", () => {
       );
       await waitForContent(container, "API key active");
       expect(container.textContent).not.toContain("Kept alive by Daintree Assistant");
+    });
+  });
+
+  describe("Daintree Assistant connections (#10036)", () => {
+    const helpBearer = {
+      userAgent: "Daintree Assistant/1.0",
+      lastActiveAt: Date.now() - 5000,
+      requestsSinceLaunch: 4,
+      sessionCount: 2,
+    };
+
+    it("hides the assistant-connections row when no help session is connected", async () => {
+      const { container } = render(
+        <SettingsValidationProvider>
+          <McpServerSettingsTab />
+        </SettingsValidationProvider>
+      );
+      await waitForContent(container, "API key active");
+      expect(container.textContent).not.toContain("Daintree Assistant connections");
+    });
+
+    it("shows the help-session row read-only, with no disconnect control", async () => {
+      const listHelpSessionBearers = vi.fn().mockResolvedValue([helpBearer]);
+      installMcpApi({ listHelpSessionBearers });
+
+      const { container } = render(
+        <SettingsValidationProvider>
+          <McpServerSettingsTab />
+        </SettingsValidationProvider>
+      );
+      await waitForContent(container, "Daintree Assistant connections (1)");
+
+      fireEvent.click(screen.getByRole("button", { name: /daintree assistant connections/i }));
+      await waitFor(() => {
+        expect(container.textContent).toContain("Daintree Assistant/1.0");
+      });
+      // Session and request counts are surfaced...
+      expect(container.textContent).toContain("2 sessions");
+      expect(container.textContent).toContain("4 requests");
+      // ...but there is no disconnect affordance for an internal connection.
+      expect(screen.queryByRole("button", { name: "Disconnect" })).toBeNull();
+    });
+
+    it("populates the assistant-connections row when a runtime-state change fires after mount", async () => {
+      let runtimeCb: ((snapshot: unknown) => void) | undefined;
+      const onRuntimeStateChanged = vi.fn((cb: (snapshot: unknown) => void) => {
+        runtimeCb = cb;
+        return vi.fn();
+      });
+      const listHelpSessionBearers = vi
+        .fn()
+        .mockResolvedValueOnce([]) // initial mount: assistant not connected
+        .mockResolvedValue([helpBearer]); // after the push: connected
+      installMcpApi({ onRuntimeStateChanged, listHelpSessionBearers });
+
+      const { container } = render(
+        <SettingsValidationProvider>
+          <McpServerSettingsTab />
+        </SettingsValidationProvider>
+      );
+      await waitForContent(container, "API key active");
+      expect(container.textContent).not.toContain("Daintree Assistant connections");
+
+      runtimeCb?.({ enabled: true, state: "ready", port: 9020, lastError: null });
+      await waitForContent(container, "Daintree Assistant connections (1)");
     });
   });
 


### PR DESCRIPTION
## Summary

- When the Daintree Assistant or in-panel agents were the only active MCP clients, the "External clients" section in MCP Server Settings showed zero entries — `listActiveBearers` and `listExternalActiveClients` intentionally filter out internal (non-external tier) bearers (#9151), leaving users with no visibility into those connections.
- Added a read-only "Internal connections" collapsible section in `McpServerSettingsTab`, backed by a new IPC method `mcp-server:list-help-session-bearers` that returns a display-only `HelpSessionBearerRecord` (user-agent, last-active timestamp, request count, session count). No tokens or hashes cross IPC (per the security boundary in #9318). The section has no disconnect control — internal connections are Daintree's own consumers and are severed through their owning surface, so the existing externally-filtered disconnect flow is untouched.
- Lifted the `emitRuntimeStateChange` suppression for internal-bearer connect/disconnect so the settings tab refreshes live.

Resolves #10036

## Changes

- `electron/services/mcp-server/httpLifecycle.ts` — `listHelpSessionBearers()` on `HttpMcpLifecycle`; emit runtime-state change on internal bearer connect/disconnect
- `electron/ipc/handlers/mcpServer.ts` + `mcpServer.preload.ts` — new `mcp-server:list-help-session-bearers` channel
- `electron/preload.cts` + `src/types/electron.d.ts` — expose `mcpServer.listHelpSessionBearers()`
- `shared/types/ipc/mcpServer.ts` + related generated/map files — `HelpSessionBearerRecord` type and channel registration
- `src/components/Settings/McpServerSettingsTab.tsx` — read-only "Internal connections" collapsible section
- Tests: `httpLifecycle.test.ts` (display-only fields, no token leakage, session count, non-external-tier scope, runtime push); `McpServerSettingsTab.test.tsx` (row hidden when empty, read-only counts, coexistence asserting exactly one Disconnect button)

## Testing

- Unit tests added for `listHelpSessionBearers` covering display-only field shape, confirmed no token/hash fields present, session count aggregation, non-external-tier scope, and runtime-state push on connect and disconnect.
- Settings tab tests cover: section hidden when no internal connections, read-only row showing correct counts, coexistence with external rows asserting exactly one Disconnect button (the external row only), and runtime-state refresh wiring.
- Handler count assertion in `channelDrift.test.ts` updated to 24.