### PR TITLE
fix(store): move fleetFailureStore auto-clear sub into orchestrator

### DIFF
--- a/src/store/__tests__/fleetFailureStore.test.ts
+++ b/src/store/__tests__/fleetFailureStore.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach } from "vitest";
-import { useFleetFailureStore } from "../fleetFailureStore";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { useFleetFailureStore, subscribeFleetFailureAutoClear } from "../fleetFailureStore";
 import { useFleetArmingStore } from "../fleetArmingStore";
 import { usePanelStore } from "../panelStore";
 import type { PtyPanelData } from "@shared/types/panel";
@@ -35,8 +35,20 @@ function makeAgent(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanelD
 }
 
 describe("useFleetFailureStore", () => {
+  let unsubscribe: (() => void) | null = null;
+
   beforeEach(() => {
     resetStores();
+    // Subscribe AFTER resetting so the factory's `prevArmed` closure captures
+    // the empty baseline. This mirrors the `subscribeFleetArmingPanelPruning`
+    // direct-call pattern in `fleetArmingStore.test.ts` — the subscription
+    // only fires on subsequent state changes (#9923).
+    unsubscribe = subscribeFleetFailureAutoClear();
+  });
+
+  afterEach(() => {
+    unsubscribe?.();
+    unsubscribe = null;
   });
 
   it("starts empty", () => {
@@ -114,6 +126,25 @@ describe("useFleetFailureStore", () => {
     useFleetFailureStore.getState().recordFailure("p", ["a", "b"]);
     useFleetArmingStore.getState().disarmId("a");
     expect(useFleetFailureStore.getState().failedIds).toEqual(new Set(["b"]));
+    expect(useFleetFailureStore.getState().payload).toBe("p");
+  });
+
+  it("halts auto-clear once the returned unsubscribe is invoked", () => {
+    usePanelStore.setState({
+      panelsById: { a: makeAgent("a"), b: makeAgent("b") },
+      panelIds: ["a", "b"],
+    });
+    useFleetArmingStore.getState().armIds(["a", "b"]);
+    useFleetFailureStore.getState().recordFailure("p", ["a", "b"]);
+
+    // Tear down the subscription explicitly. The factory is the only thing
+    // wiring `useFleetArmingStore` → `useFleetFailureStore`, so once it's
+    // gone the failure set is frozen until the caller mutates it directly.
+    unsubscribe?.();
+    unsubscribe = null;
+
+    useFleetArmingStore.getState().clear();
+    expect(useFleetFailureStore.getState().failedIds).toEqual(new Set(["a", "b"]));
     expect(useFleetFailureStore.getState().payload).toBe("p");
   });
 });

--- a/src/store/__tests__/rendererStoreOrchestrator.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.test.ts
@@ -1446,4 +1446,67 @@ describe("rendererStoreOrchestrator", () => {
       expect([...useFleetArmingStore.getState().armedIds]).toEqual([]);
     });
   });
+
+  describe("fleet failure auto-clear (issue #9923)", () => {
+    it("halts auto-clear after destroy and resumes after re-init", async () => {
+      const { useFleetArmingStore } = await import("../fleetArmingStore");
+      const { useFleetFailureStore } = await import("../fleetFailureStore");
+
+      useFleetArmingStore.setState({
+        armedIds: new Set<string>(),
+        armOrder: [],
+        armOrderById: {},
+        lastArmedId: null,
+        broadcastSignal: 0,
+        previewArmedIds: new Set<string>(),
+      });
+      useFleetFailureStore.setState({ failedIds: new Set(), payload: null });
+
+      // Seed panels + arm the fleet + record a broadcast failure.
+      usePanelStore.setState({
+        panelsById: {
+          "agent-a": {
+            id: "agent-a",
+            kind: "terminal",
+            title: "A",
+            location: "grid",
+            worktreeId: "wt-1",
+            detectedAgentId: "claude",
+            everDetectedAgent: true,
+            agentState: "idle",
+            hasPty: true,
+          } as PtyPanelData,
+          "agent-b": {
+            id: "agent-b",
+            kind: "terminal",
+            title: "B",
+            location: "grid",
+            worktreeId: "wt-1",
+            detectedAgentId: "claude",
+            everDetectedAgent: true,
+            agentState: "idle",
+            hasPty: true,
+          } as PtyPanelData,
+        },
+        panelIds: ["agent-a", "agent-b"],
+      });
+      useFleetArmingStore.getState().armIds(["agent-a", "agent-b"]);
+      useFleetFailureStore.getState().recordFailure("p", ["agent-a", "agent-b"]);
+
+      // Orchestrator already init'd by the top-level beforeEach. Tear it
+      // down and verify auto-clear no longer fires on a fleet drain.
+      destroyStoreOrchestrator();
+      useFleetArmingStore.getState().clear();
+      expect(useFleetFailureStore.getState().failedIds).toEqual(new Set(["agent-a", "agent-b"]));
+      expect(useFleetFailureStore.getState().payload).toBe("p");
+
+      // Re-init — the subscription is back, and the next drain must clear.
+      initStoreOrchestrator();
+      useFleetArmingStore.getState().armIds(["agent-a", "agent-b"]);
+      useFleetFailureStore.getState().recordFailure("p", ["agent-a", "agent-b"]);
+      useFleetArmingStore.getState().clear();
+      expect(useFleetFailureStore.getState().failedIds.size).toBe(0);
+      expect(useFleetFailureStore.getState().payload).toBeNull();
+    });
+  });
 });

--- a/src/store/__tests__/rendererStoreOrchestrator.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.test.ts
@@ -1448,21 +1448,18 @@ describe("rendererStoreOrchestrator", () => {
   });
 
   describe("fleet failure auto-clear (issue #9923)", () => {
-    it("halts auto-clear after destroy and resumes after re-init", async () => {
+    type FleetStores = {
+      useFleetArmingStore: typeof import("../fleetArmingStore").useFleetArmingStore;
+      useFleetFailureStore: typeof import("../fleetFailureStore").useFleetFailureStore;
+    };
+
+    async function loadStores(): Promise<FleetStores> {
       const { useFleetArmingStore } = await import("../fleetArmingStore");
       const { useFleetFailureStore } = await import("../fleetFailureStore");
+      return { useFleetArmingStore, useFleetFailureStore };
+    }
 
-      useFleetArmingStore.setState({
-        armedIds: new Set<string>(),
-        armOrder: [],
-        armOrderById: {},
-        lastArmedId: null,
-        broadcastSignal: 0,
-        previewArmedIds: new Set<string>(),
-      });
-      useFleetFailureStore.setState({ failedIds: new Set(), payload: null });
-
-      // Seed panels + arm the fleet + record a broadcast failure.
+    function seedFleetPanels(): void {
       usePanelStore.setState({
         panelsById: {
           "agent-a": {
@@ -1490,23 +1487,92 @@ describe("rendererStoreOrchestrator", () => {
         },
         panelIds: ["agent-a", "agent-b"],
       });
-      useFleetArmingStore.getState().armIds(["agent-a", "agent-b"]);
-      useFleetFailureStore.getState().recordFailure("p", ["agent-a", "agent-b"]);
+    }
 
-      // Orchestrator already init'd by the top-level beforeEach. Tear it
-      // down and verify auto-clear no longer fires on a fleet drain.
+    function resetFleetStores(stores: FleetStores): void {
+      stores.useFleetArmingStore.setState({
+        armedIds: new Set<string>(),
+        armOrder: [],
+        armOrderById: {},
+        lastArmedId: null,
+        broadcastSignal: 0,
+        previewArmedIds: new Set<string>(),
+      });
+      stores.useFleetFailureStore.setState({ failedIds: new Set(), payload: null });
+    }
+
+    it("halts auto-clear after destroy — fleet drain during torn-down does not clear", async () => {
+      const stores = await loadStores();
+      resetFleetStores(stores);
+      seedFleetPanels();
+      stores.useFleetArmingStore.getState().armIds(["agent-a", "agent-b"]);
+      stores.useFleetFailureStore.getState().recordFailure("p", ["agent-a", "agent-b"]);
+
+      // Subscription torn down; the next armed-set change has no listener.
       destroyStoreOrchestrator();
-      useFleetArmingStore.getState().clear();
-      expect(useFleetFailureStore.getState().failedIds).toEqual(new Set(["agent-a", "agent-b"]));
-      expect(useFleetFailureStore.getState().payload).toBe("p");
+      stores.useFleetArmingStore.getState().clear();
 
-      // Re-init — the subscription is back, and the next drain must clear.
+      // The drain happened, but failures persist because the subscription
+      // is gone. Initial reconciliation runs on the NEXT re-init.
+      expect(stores.useFleetFailureStore.getState().failedIds).toEqual(
+        new Set(["agent-a", "agent-b"])
+      );
+      expect(stores.useFleetFailureStore.getState().payload).toBe("p");
+    });
+
+    it("reconciles drained fleet on re-init (initial pass picks up the missed clear)", async () => {
+      const stores = await loadStores();
+      resetFleetStores(stores);
+      seedFleetPanels();
+      stores.useFleetArmingStore.getState().armIds(["agent-a", "agent-b"]);
+      stores.useFleetFailureStore.getState().recordFailure("p", ["agent-a", "agent-b"]);
+
+      // Tear down, drain the fleet while the subscription is gone, confirm
+      // the failures are still present (no auto-clear fired).
+      destroyStoreOrchestrator();
+      stores.useFleetArmingStore.getState().clear();
+      expect(stores.useFleetFailureStore.getState().failedIds.size).toBe(2);
+
+      // Re-init: the initial reconciliation pass sees the drained armed
+      // set and clears the stale failures without needing a fresh event.
       initStoreOrchestrator();
-      useFleetArmingStore.getState().armIds(["agent-a", "agent-b"]);
-      useFleetFailureStore.getState().recordFailure("p", ["agent-a", "agent-b"]);
-      useFleetArmingStore.getState().clear();
-      expect(useFleetFailureStore.getState().failedIds.size).toBe(0);
-      expect(useFleetFailureStore.getState().payload).toBeNull();
+      expect(stores.useFleetFailureStore.getState().failedIds.size).toBe(0);
+      expect(stores.useFleetFailureStore.getState().payload).toBeNull();
+    });
+
+    it("reconciles partial disarm on re-init (initial pass dismisses stale per-pane)", async () => {
+      const stores = await loadStores();
+      resetFleetStores(stores);
+      seedFleetPanels();
+      stores.useFleetArmingStore.getState().armIds(["agent-a", "agent-b"]);
+      stores.useFleetFailureStore.getState().recordFailure("p", ["agent-a", "agent-b"]);
+
+      // Tear down, disarm one pane while the subscription is gone.
+      destroyStoreOrchestrator();
+      stores.useFleetArmingStore.getState().disarmId("agent-a");
+
+      // Re-init: the initial pass sees `failedIds = {a, b}` but
+      // `armedIds = {b}`, and dismisses just the stale `a`.
+      initStoreOrchestrator();
+      expect(stores.useFleetFailureStore.getState().failedIds).toEqual(new Set(["agent-b"]));
+      expect(stores.useFleetFailureStore.getState().payload).toBe("p");
+    });
+
+    it("listener continues to fire for post-re-init armed-set changes", async () => {
+      const stores = await loadStores();
+      resetFleetStores(stores);
+      seedFleetPanels();
+
+      destroyStoreOrchestrator();
+      // Re-init with a non-empty armed set already in place.
+      stores.useFleetArmingStore.getState().armIds(["agent-a", "agent-b"]);
+      initStoreOrchestrator();
+      stores.useFleetFailureStore.getState().recordFailure("p", ["agent-a", "agent-b"]);
+
+      // Listener should still fire on a drain that happens AFTER re-init.
+      stores.useFleetArmingStore.getState().clear();
+      expect(stores.useFleetFailureStore.getState().failedIds.size).toBe(0);
+      expect(stores.useFleetFailureStore.getState().payload).toBeNull();
     });
   });
 });

--- a/src/store/fleetFailureStore.ts
+++ b/src/store/fleetFailureStore.ts
@@ -70,32 +70,44 @@ export const useFleetFailureStore = create<FleetFailureState>((set) => ({
  * HMR teardown — moving the subscription under the orchestrator's idempotent
  * `init`/`destroy` cycle is the canonical pattern (#9923).
  */
+
+/** Drop failure records for panes that are no longer in the armed set. */
+function reconcileFleetFailures(currentArmed: Set<string>): void {
+  const failed = useFleetFailureStore.getState().failedIds;
+  if (failed.size === 0) return;
+  // Whole fleet drained — clear everything in one shot to avoid the
+  // per-id loop below thrashing the store on every removed pane.
+  if (currentArmed.size === 0) {
+    useFleetFailureStore.getState().clear();
+    return;
+  }
+  // Per-pane removal — drop the failure record for any pane that's
+  // no longer armed. Disarming a pane (manual or via auto-prune of
+  // trashed/exited terminals) means the user has moved on; a stale
+  // red dot would just create cleanup work.
+  for (const id of failed) {
+    if (!currentArmed.has(id)) {
+      useFleetFailureStore.getState().dismissId(id);
+    }
+  }
+}
+
 export function subscribeFleetFailureAutoClear(): () => void {
-  let prevArmed = useFleetArmingStore.getState().armedIds;
+  // Initial reconciliation pass: catch up on any armed-set change that
+  // happened while the subscription was torn down (orchestrator destroy →
+  // mutate → re-init, or HMR). The original module-scope subscription never
+  // tore down, so it caught every change; the orchestrator-scoped version
+  // can miss a drain or partial disarm during the torn-down window. This
+  // pass recovers that invariant on re-registration — mirrors the initial
+  // pass in `subscribeFleetArmingPanelPruning` (#9923).
+  const initialArmed = useFleetArmingStore.getState().armedIds;
+  reconcileFleetFailures(initialArmed);
+
+  let prevArmed = initialArmed;
   return useFleetArmingStore.subscribe((state) => {
     const nextArmed = state.armedIds;
     if (prevArmed === nextArmed) return;
-
-    // Whole fleet drained — clear everything in one shot to avoid the
-    // per-id loop below thrashing the store on every removed pane.
-    if (nextArmed.size === 0 && prevArmed.size > 0) {
-      useFleetFailureStore.getState().clear();
-      prevArmed = nextArmed;
-      return;
-    }
-
-    // Per-pane removal — drop the failure record for any pane that's
-    // no longer armed. Disarming a pane (manual or via auto-prune of
-    // trashed/exited terminals) means the user has moved on; a stale
-    // red dot would just create cleanup work.
-    const failed = useFleetFailureStore.getState().failedIds;
-    if (failed.size > 0) {
-      for (const id of failed) {
-        if (!nextArmed.has(id)) {
-          useFleetFailureStore.getState().dismissId(id);
-        }
-      }
-    }
+    reconcileFleetFailures(nextArmed);
     prevArmed = nextArmed;
   });
 }

--- a/src/store/fleetFailureStore.ts
+++ b/src/store/fleetFailureStore.ts
@@ -62,54 +62,40 @@ export const useFleetFailureStore = create<FleetFailureState>((set) => ({
  * persistent failure dot on a pane the user just disarmed would be confusing
  * — the action context is gone. We only watch for fleet *drain* (size → 0)
  * to avoid wiping failures when the user is just toggling individual panes.
+ *
+ * Registered by `initStoreOrchestrator()` so the subscription is scoped to
+ * the renderer lifecycle (HMR-safe via the orchestrator's `DisposableStore`)
+ * rather than module evaluation. The previous module-scope registration used
+ * a `globalThis` flag to dedupe across re-evaluations, but that mishandled
+ * HMR teardown — moving the subscription under the orchestrator's idempotent
+ * `init`/`destroy` cycle is the canonical pattern (#9923).
  */
-const FLEET_FAILURE_SUBSCRIPTION_KEY = "__daintreeFleetFailureSubscription";
+export function subscribeFleetFailureAutoClear(): () => void {
+  let prevArmed = useFleetArmingStore.getState().armedIds;
+  return useFleetArmingStore.subscribe((state) => {
+    const nextArmed = state.armedIds;
+    if (prevArmed === nextArmed) return;
 
-interface FleetFailureSubscriptionState {
-  registered: boolean;
-}
+    // Whole fleet drained — clear everything in one shot to avoid the
+    // per-id loop below thrashing the store on every removed pane.
+    if (nextArmed.size === 0 && prevArmed.size > 0) {
+      useFleetFailureStore.getState().clear();
+      prevArmed = nextArmed;
+      return;
+    }
 
-function getSubscriptionState(): FleetFailureSubscriptionState {
-  const target = globalThis as typeof globalThis & {
-    [FLEET_FAILURE_SUBSCRIPTION_KEY]?: FleetFailureSubscriptionState;
-  };
-  const existing = target[FLEET_FAILURE_SUBSCRIPTION_KEY];
-  if (existing) return existing;
-  const created: FleetFailureSubscriptionState = { registered: false };
-  target[FLEET_FAILURE_SUBSCRIPTION_KEY] = created;
-  return created;
-}
-
-if (typeof useFleetArmingStore.subscribe === "function") {
-  const subState = getSubscriptionState();
-  if (!subState.registered) {
-    subState.registered = true;
-    let prevArmed = useFleetArmingStore.getState().armedIds;
-    useFleetArmingStore.subscribe((state) => {
-      const nextArmed = state.armedIds;
-      if (prevArmed === nextArmed) return;
-
-      // Whole fleet drained — clear everything in one shot to avoid the
-      // per-id loop below thrashing the store on every removed pane.
-      if (nextArmed.size === 0 && prevArmed.size > 0) {
-        useFleetFailureStore.getState().clear();
-        prevArmed = nextArmed;
-        return;
-      }
-
-      // Per-pane removal — drop the failure record for any pane that's
-      // no longer armed. Disarming a pane (manual or via auto-prune of
-      // trashed/exited terminals) means the user has moved on; a stale
-      // red dot would just create cleanup work.
-      const failed = useFleetFailureStore.getState().failedIds;
-      if (failed.size > 0) {
-        for (const id of failed) {
-          if (!nextArmed.has(id)) {
-            useFleetFailureStore.getState().dismissId(id);
-          }
+    // Per-pane removal — drop the failure record for any pane that's
+    // no longer armed. Disarming a pane (manual or via auto-prune of
+    // trashed/exited terminals) means the user has moved on; a stale
+    // red dot would just create cleanup work.
+    const failed = useFleetFailureStore.getState().failedIds;
+    if (failed.size > 0) {
+      for (const id of failed) {
+        if (!nextArmed.has(id)) {
+          useFleetFailureStore.getState().dismissId(id);
         }
       }
-      prevArmed = nextArmed;
-    });
-  }
+    }
+    prevArmed = nextArmed;
+  });
 }

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -7,6 +7,7 @@ import {
 } from "./worktreeStore";
 import { useFleetArmingStore, subscribeFleetArmingPanelPruning } from "./fleetArmingStore";
 import { subscribeFleetTargetOverridesPruning } from "./fleetTargetOverridesStore";
+import { subscribeFleetFailureAutoClear } from "./fleetFailureStore";
 import { useTerminalInputStore, unregisterInputController } from "./terminalInputStore";
 import { subscribeFleetBroadcastResult } from "@/components/Fleet/fleetRawInputBroadcast";
 import { semanticAnalysisService } from "@/services/SemanticAnalysisService";
@@ -339,6 +340,13 @@ export function initStoreOrchestrator(): () => void {
   //     callbacks firing against orphaned store instances after a module
   //     reset (issue #9967).
   disposables.add(toDisposable(subscribeFleetBroadcastResult()));
+
+  // 5d. Fleet-failure auto-clear: drop failure pills when the armed set drains
+  //     or a single pane is disarmed. Lives in the orchestrator for the same
+  //     HMR/test-teardown reason as 5a — the module-scope subscription in
+  //     `fleetFailureStore.ts` was never torn down and the `globalThis`
+  //     registration guard mishandled re-registration under HMR (#9923).
+  disposables.add(toDisposable(subscribeFleetFailureAutoClear()));
 
   // 5. Availability → agent-settings re-normalization: installed/missing state
   //    is the input to `normalizeAgentSelection`, so re-run normalization any


### PR DESCRIPTION
## Summary

- Move the `fleetFailureStore` auto-clear subscription out of module scope and into the renderer store orchestrator, following the same pattern as `subscribeFleetArmingPanelPruning`.
- Extract `subscribeFleetFailureAutoClear()` and a `reconcileFleetFailures()` helper. The subscription now runs an initial reconciliation pass on re-registration so state that changed while torn down gets caught.
- Retires the `globalThis` guard that mishandled HMR re-imports and `vi.resetModules()` in tests, which left the fresh store instances unwired while the old subscription kept running against orphaned ones.

Resolves #9923

## Changes

- `src/store/fleetFailureStore.ts`: extract `subscribeFleetFailureAutoClear()` factory and `reconcileFleetFailures` helper, add initial reconciliation pass.
- `src/store/rendererStoreOrchestrator.ts`: wire the new factory as section 5b.
- `src/store/__tests__/fleetFailureStore.test.ts`: switch to direct-call `beforeEach`/`afterEach` and add an unsubscribe-halts test.
- `src/store/__tests__/rendererStoreOrchestrator.test.ts`: add four lifecycle tests covering halt-after-destroy, reconcile drained fleet on re-init, reconcile partial disarm on re-init, and listener continuity post-re-init.

## Testing

- `fleetFailureStore` unit tests pass with the new direct-call harness.
- New lifecycle tests in `rendererStoreOrchestrator.test.ts` cover destroy/re-init against drained, partial, and post-re-init listener states.
- Local CI was blocked on `test:smoke` (Xvfb/Electron, Linux-only); the unit suite the gate ran passed.