### PR TITLE
feat(pty-host): structured flow-control snapshot in diagnostics bundle (#10060)

### DIFF
--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -199,6 +199,30 @@ function clearAllPauseSources(terminalId: string): void {
   pausedTerminals.delete(terminalId);
 }
 
+/**
+ * Per-paused-terminal held duration, aggregated across SAB, IPC, and per-window
+ * MessagePort pause sources via the `pausedTerminals` map. A terminal is
+ * included as long as ANY source is still holding; the held duration uses the
+ * OLDEST start time across sources (the user-meaningful "how long has this been
+ * paused?" answer). Shared by the streaming `pause-duration-gauge` and the
+ * on-demand flow-control snapshot so both see the same authoritative durations —
+ * the live IPC/port paths keep their own start times outside
+ * `backpressureManager.pauseStartTimes` (which only the dead SAB path writes).
+ */
+function getPausedDurationsSnapshot(): Array<{ terminalId: string; heldDurationMs: number }> {
+  if (pausedTerminals.size === 0) return [];
+  const now = Date.now();
+  const out: Array<{ terminalId: string; heldDurationMs: number }> = [];
+  for (const [terminalId, sources] of pausedTerminals) {
+    let oldestStart = Number.POSITIVE_INFINITY;
+    for (const { startTime } of sources.values()) {
+      if (startTime < oldestStart) oldestStart = startTime;
+    }
+    out.push({ terminalId, heldDurationMs: Math.max(0, now - oldestStart) });
+  }
+  return out;
+}
+
 // Data-loss counter: closure-scoped accumulator of dropped-bytes and
 // drop-event counts since the last snapshot. The counter is incremented
 // unconditionally at the drop site so regression detection is observable
@@ -481,27 +505,7 @@ const resourceGovernor = new ResourceGovernor({
       pauseCount: backpressureManager.stats.pauseCount,
     };
   },
-  getPausedDurationsSnapshot: () => {
-    // Read from the closure-scoped `pausedTerminals` map. The map is
-    // maintained by `emitReliabilityMetricWithTracking` so every pause
-    // source (SAB, IPC, per-window port) contributes. A terminal is
-    // included as long as ANY source is still holding — multi-source
-    // attribution via the per-source `Set` means a `pause-end` from
-    // one path only clears that path's hold. The held duration uses
-    // the OLDEST start time across all sources, so the renderer sees
-    // the user-meaningful "how long has this been paused?" answer.
-    if (pausedTerminals.size === 0) return [];
-    const now = Date.now();
-    const out: Array<{ terminalId: string; heldDurationMs: number }> = [];
-    for (const [terminalId, sources] of pausedTerminals) {
-      let oldestStart = Number.POSITIVE_INFINITY;
-      for (const { startTime } of sources.values()) {
-        if (startTime < oldestStart) oldestStart = startTime;
-      }
-      out.push({ terminalId, heldDurationMs: Math.max(0, now - oldestStart) });
-    }
-    return out;
-  },
+  getPausedDurationsSnapshot,
   getQueueDepthSnapshot: () => {
     // Live IPC + per-window MessagePort paths only. The FUTURE_SAB path is
     // dead in production (SharedArrayBuffer is not supported in
@@ -1236,6 +1240,7 @@ const hostContext: HostContext = {
   tryReplayAndResume,
   resumePausedTerminal,
   createPortQueueManager,
+  getPausedDurationsSnapshot,
 };
 
 const dispatchMessage = createPtyHostMessageDispatcher(hostContext);

--- a/electron/pty-host/ResourceGovernor.ts
+++ b/electron/pty-host/ResourceGovernor.ts
@@ -1,6 +1,10 @@
 import v8 from "node:v8";
 import type { AgentState } from "../../shared/types/agent.js";
-import type { PtyHostEvent, TerminalFlowStatus } from "../../shared/types/pty-host.js";
+import type {
+  PtyHostEvent,
+  ResourceGovernorSnapshot,
+  TerminalFlowStatus,
+} from "../../shared/types/pty-host.js";
 import type { ResourceProfile } from "../../shared/types/resourceProfile.js";
 import { FdMonitor } from "./FdMonitor.js";
 import { metricsEnabled } from "./metrics.js";
@@ -128,6 +132,22 @@ export class ResourceGovernor {
 
   trackKilledPid(pid: number): void {
     this.killedPids.set(pid, Date.now());
+  }
+
+  /**
+   * Point-in-time governor state for the on-demand flow-control diagnostics
+   * snapshot. `smoothedUtilizationPercent` is passed through as null during EMA
+   * warmup (it starts undefined for ~5 ticks; see #8660) rather than coerced to
+   * 0, so consumers can distinguish "not yet warmed up" from "0% heap used".
+   */
+  getSnapshot(): ResourceGovernorSnapshot {
+    return {
+      isThrottling: this.isThrottling,
+      isWarning: this.isWarning,
+      activeProfile: this.profileOverride ?? "balanced",
+      smoothedUtilizationPercent: this.smoothedUtilizationPercent ?? null,
+      throttleDurationMs: this.isThrottling ? Date.now() - this.throttleStartTime : 0,
+    };
   }
 
   setResourceProfile(profile: ResourceProfile): void {

--- a/electron/pty-host/__tests__/backpressure.adversarial.test.ts
+++ b/electron/pty-host/__tests__/backpressure.adversarial.test.ts
@@ -83,6 +83,9 @@ describe("BackpressureManager adversarial", () => {
     expect(backpressure.isPaused("term-1")).toBe(false);
     expect(backpressure.getPauseStartTime("term-1")).toBeUndefined();
     expect(backpressure.hasPendingSegments("term-1")).toBe(false);
+    // suspendVisualStream is the sole producer of the suspend transition, so
+    // it owns the suspendCount increment (the counter was previously dead).
+    expect(backpressure.stats.suspendCount).toBe(1);
     expect(sendEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "terminal-status",

--- a/electron/pty-host/__tests__/backpressure.adversarial.test.ts
+++ b/electron/pty-host/__tests__/backpressure.adversarial.test.ts
@@ -106,6 +106,24 @@ describe("BackpressureManager adversarial", () => {
     );
   });
 
+  it("counts every suspendVisualStream call in suspendCount even when the status transition dedupes", () => {
+    const coordinator = createCoordinator();
+    coordinators.set("term-1", coordinator);
+    const backpressure = manager();
+
+    backpressure.suspendVisualStream("term-1", "stalled", 90, 100);
+    backpressure.suspendVisualStream("term-1", "stalled again", 91, 200);
+
+    // suspendCount tracks calls, not state transitions...
+    expect(backpressure.stats.suspendCount).toBe(2);
+    // ...but the dedupe in emitTerminalStatus fires the "suspended" wire event
+    // only once (the terminal was already suspended on the second call).
+    const suspendedStatusEvents = sendEvent.mock.calls.filter(
+      (c) => c[0]?.type === "terminal-status" && c[0]?.status === "suspended"
+    );
+    expect(suspendedStatusEvents).toHaveLength(1);
+  });
+
   it("suppresses duplicate terminal-status events during concurrent pause and resume churn", () => {
     const backpressure = manager();
 

--- a/electron/pty-host/backpressure.ts
+++ b/electron/pty-host/backpressure.ts
@@ -302,6 +302,7 @@ export class BackpressureManager {
     this.pauseStartTimes.delete(id);
 
     this.suspendedDueToStall.add(id);
+    this.stats.suspendCount++;
     this.clearPendingVisual(id);
 
     this.emitTerminalStatus(id, "suspended", utilization, pauseDuration, reason);

--- a/electron/pty-host/handlers/__tests__/backpressure.test.ts
+++ b/electron/pty-host/handlers/__tests__/backpressure.test.ts
@@ -75,6 +75,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
     tryReplayAndResume: vi.fn(),
     resumePausedTerminal: vi.fn(),
     createPortQueueManager: vi.fn(),
+    getPausedDurationsSnapshot: vi.fn(() => []),
     ...overrides,
   };
 }

--- a/electron/pty-host/handlers/__tests__/backpressure.test.ts
+++ b/electron/pty-host/handlers/__tests__/backpressure.test.ts
@@ -50,6 +50,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
       emitTerminalStatus: vi.fn(),
       emitReliabilityMetric: vi.fn(),
       getActivityTier: vi.fn(() => "active"),
+      stats: { pauseCount: 0, resumeCount: 0, suspendCount: 0, forceResumeCount: 0 },
     } as unknown as HostContext["backpressureManager"],
     ipcQueueManager: {
       removeBytes: vi.fn(),
@@ -232,6 +233,32 @@ describe("force-resume handler", () => {
     handlers["force-resume"]({ type: "force-resume", id: "untracked-terminal" });
 
     expect(conn.portQueueManager.clearQueue).toHaveBeenCalledWith("untracked-terminal");
+  });
+
+  it("increments forceResumeCount once per successful force-resume (the counter was previously dead)", () => {
+    const coord = makeCoordinator();
+    const ctx = makeCtx({
+      rendererConnections: new Map([[1, makeRendererConnection()]]),
+      getPauseCoordinator: vi.fn(() => coord as never),
+    });
+    const handlers = createBackpressureHandlers(ctx);
+
+    handlers["force-resume"]({ type: "force-resume", id: "term-1" });
+    handlers["force-resume"]({ type: "force-resume", id: "term-2" });
+
+    expect(ctx.backpressureManager.stats.forceResumeCount).toBe(2);
+  });
+
+  it("does not increment forceResumeCount when the pause coordinator is missing (early return)", () => {
+    const ctx = makeCtx({
+      rendererConnections: new Map([[1, makeRendererConnection()]]),
+      getPauseCoordinator: vi.fn(() => undefined),
+    });
+    const handlers = createBackpressureHandlers(ctx);
+
+    handlers["force-resume"]({ type: "force-resume", id: "term-1" });
+
+    expect(ctx.backpressureManager.stats.forceResumeCount).toBe(0);
   });
 
   it("returns early when the pause coordinator is missing", () => {

--- a/electron/pty-host/handlers/__tests__/connection.test.ts
+++ b/electron/pty-host/handlers/__tests__/connection.test.ts
@@ -56,6 +56,7 @@ function makeCtx(stateRef: {
     tryReplayAndResume: vi.fn(),
     resumePausedTerminal: vi.fn(),
     createPortQueueManager: vi.fn(),
+    getPausedDurationsSnapshot: vi.fn(() => []),
   };
 }
 

--- a/electron/pty-host/handlers/__tests__/diagnostics.test.ts
+++ b/electron/pty-host/handlers/__tests__/diagnostics.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi } from "vitest";
+import { createDiagnosticsHandlers } from "../diagnostics.js";
+import type { HostContext, RendererConnection } from "../types.js";
+import type { FlowControlSnapshot } from "../../../../shared/types/pty-host.js";
+
+function makePortConnection(
+  snapshot: {
+    totalPendingBytes: number;
+    perTerminal: Array<{ terminalId: string; pendingBytes: number }>;
+  } = {
+    totalPendingBytes: 0,
+    perTerminal: [],
+  }
+): RendererConnection {
+  return {
+    port: {} as RendererConnection["port"],
+    handler: vi.fn(),
+    portQueueManager: {
+      getQueueSnapshot: vi.fn(() => snapshot),
+    } as unknown as RendererConnection["portQueueManager"],
+    batcher: {} as RendererConnection["batcher"],
+  };
+}
+
+function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
+  return {
+    ptyManager: {} as HostContext["ptyManager"],
+    processTreeCache: {} as HostContext["processTreeCache"],
+    terminalResourceMonitor: {} as HostContext["terminalResourceMonitor"],
+    backpressureManager: {
+      terminalStatusesMap: new Map(),
+      suspendedSet: new Set(),
+      pauseStartTimesMap: new Map(),
+      getPauseStartTime: vi.fn(() => undefined),
+      isSuspended: vi.fn(() => false),
+      getActivityTier: vi.fn(() => "active"),
+      stats: { pauseCount: 3, resumeCount: 2, suspendCount: 1, forceResumeCount: 0 },
+    } as unknown as HostContext["backpressureManager"],
+    ipcQueueManager: {
+      getQueueSnapshot: vi.fn(() => ({ totalPendingBytes: 0, perTerminal: [] })),
+    } as unknown as HostContext["ipcQueueManager"],
+    resourceGovernor: {
+      getSnapshot: vi.fn(() => ({
+        isThrottling: false,
+        isWarning: false,
+        activeProfile: "balanced",
+        smoothedUtilizationPercent: null,
+        throttleDurationMs: 0,
+      })),
+    } as unknown as HostContext["resourceGovernor"],
+    packetFramer: {} as HostContext["packetFramer"],
+    pauseCoordinators: new Map(),
+    rendererConnections: new Map(),
+    windowProjectMap: new Map(),
+    ipcDataMirrorTerminals: new Set(),
+    visualBuffers: [],
+    visualSignalView: null,
+    analysisBuffer: null,
+    ptyPool: null,
+    sendEvent: vi.fn(),
+    getPauseCoordinator: vi.fn(() => undefined),
+    getOrCreatePauseCoordinator: vi.fn(),
+    disconnectWindow: vi.fn(),
+    recomputeActivityTiers: vi.fn(),
+    tryReplayAndResume: vi.fn(),
+    resumePausedTerminal: vi.fn(),
+    createPortQueueManager: vi.fn(),
+    ...overrides,
+  };
+}
+
+function runSnapshot(ctx: HostContext): FlowControlSnapshot {
+  const handlers = createDiagnosticsHandlers(ctx);
+  handlers["get-flow-control-snapshot"]({ type: "get-flow-control-snapshot", requestId: "req-1" });
+  const sendEvent = ctx.sendEvent as unknown as ReturnType<typeof vi.fn>;
+  expect(sendEvent).toHaveBeenCalledTimes(1);
+  const event = sendEvent.mock.calls[0][0];
+  expect(event.type).toBe("flow-control-snapshot");
+  // requestId MUST be top-level (not nested in snapshot) or the broker never
+  // resolves the registered promise and every diagnostics pull silently times out.
+  expect(event.requestId).toBe("req-1");
+  return event.snapshot as FlowControlSnapshot;
+}
+
+describe("get-flow-control-snapshot handler", () => {
+  it("unions terminal ids across status, suspended, pause-start, and coordinator maps", () => {
+    const ctx = makeCtx({
+      backpressureManager: {
+        terminalStatusesMap: new Map([["a", "running"]]),
+        suspendedSet: new Set(["b"]),
+        pauseStartTimesMap: new Map([["c", 100]]),
+        getPauseStartTime: vi.fn((id: string) => (id === "c" ? 100 : undefined)),
+        isSuspended: vi.fn((id: string) => id === "b"),
+        getActivityTier: vi.fn(() => "active"),
+        stats: { pauseCount: 0, resumeCount: 0, suspendCount: 0, forceResumeCount: 0 },
+      } as unknown as HostContext["backpressureManager"],
+      pauseCoordinators: new Map([["d", {} as never]]),
+    });
+
+    const snapshot = runSnapshot(ctx);
+    const ids = snapshot.terminals.map((t) => t.terminalId);
+
+    expect(ids).toEqual(["a", "b", "c", "d"]); // unioned and sorted
+    expect(snapshot.terminals.find((t) => t.terminalId === "b")?.isSuspended).toBe(true);
+    expect(snapshot.terminals.find((t) => t.terminalId === "a")?.flowStatus).toBe("running");
+  });
+
+  it("computes pausedDurationMs from the pause-start time and null when not paused", () => {
+    const now = Date.now();
+    const ctx = makeCtx({
+      backpressureManager: {
+        terminalStatusesMap: new Map([["paused", "paused-backpressure"]]),
+        suspendedSet: new Set(),
+        pauseStartTimesMap: new Map([["paused", now - 500]]),
+        getPauseStartTime: vi.fn((id: string) => (id === "paused" ? now - 500 : undefined)),
+        isSuspended: vi.fn(() => false),
+        getActivityTier: vi.fn(() => "active"),
+        stats: { pauseCount: 0, resumeCount: 0, suspendCount: 0, forceResumeCount: 0 },
+      } as unknown as HostContext["backpressureManager"],
+    });
+
+    const snapshot = runSnapshot(ctx);
+    const paused = snapshot.terminals.find((t) => t.terminalId === "paused");
+    expect(paused?.pausedDurationMs).toBeGreaterThanOrEqual(500);
+  });
+
+  it("includes sorted held tokens from the pause coordinator", () => {
+    const ctx = makeCtx({
+      pauseCoordinators: new Map([["t1", {} as never]]),
+      getPauseCoordinator: vi.fn(() => ({
+        heldTokens: new Set(["resource-governor", "backpressure"]),
+      })) as unknown as HostContext["getPauseCoordinator"],
+    });
+
+    const snapshot = runSnapshot(ctx);
+    expect(snapshot.terminals[0].heldTokens).toEqual(["backpressure", "resource-governor"]);
+  });
+
+  it("aggregates IPC and per-window port queue depths and totals only positive entries", () => {
+    const ctx = makeCtx({
+      ipcQueueManager: {
+        getQueueSnapshot: vi.fn(() => ({
+          totalPendingBytes: 100,
+          perTerminal: [
+            { terminalId: "t1", pendingBytes: 100 },
+            { terminalId: "t2", pendingBytes: 0 },
+          ],
+        })),
+      } as unknown as HostContext["ipcQueueManager"],
+      rendererConnections: new Map([
+        [
+          1,
+          makePortConnection({
+            totalPendingBytes: 50,
+            perTerminal: [{ terminalId: "t1", pendingBytes: 50 }],
+          }),
+        ],
+      ]),
+    });
+
+    const snapshot = runSnapshot(ctx);
+
+    expect(snapshot.totalPendingBytes).toBe(150);
+    expect(snapshot.queueDepth).toEqual([
+      { terminalId: "t1", layer: "ipc", pendingBytes: 100 },
+      { terminalId: "t1", layer: "port", pendingBytes: 50 },
+    ]);
+  });
+
+  it("copies the stats object so later mutations don't bleed into the snapshot", () => {
+    const stats = { pauseCount: 3, resumeCount: 2, suspendCount: 1, forceResumeCount: 0 };
+    const ctx = makeCtx({
+      backpressureManager: {
+        terminalStatusesMap: new Map(),
+        suspendedSet: new Set(),
+        pauseStartTimesMap: new Map(),
+        getPauseStartTime: vi.fn(() => undefined),
+        isSuspended: vi.fn(() => false),
+        getActivityTier: vi.fn(() => "active"),
+        stats,
+      } as unknown as HostContext["backpressureManager"],
+    });
+
+    const snapshot = runSnapshot(ctx);
+    expect(snapshot.stats).toEqual({
+      pauseCount: 3,
+      resumeCount: 2,
+      suspendCount: 1,
+      forceResumeCount: 0,
+    });
+
+    stats.suspendCount = 99;
+    expect(snapshot.stats.suspendCount).toBe(1); // detached copy
+  });
+
+  it("embeds the resource-governor snapshot verbatim", () => {
+    const ctx = makeCtx({
+      resourceGovernor: {
+        getSnapshot: vi.fn(() => ({
+          isThrottling: true,
+          isWarning: true,
+          activeProfile: "efficiency",
+          smoothedUtilizationPercent: 88.2,
+          throttleDurationMs: 4200,
+        })),
+      } as unknown as HostContext["resourceGovernor"],
+    });
+
+    const snapshot = runSnapshot(ctx);
+    expect(snapshot.resourceGovernor).toEqual({
+      isThrottling: true,
+      isWarning: true,
+      activeProfile: "efficiency",
+      smoothedUtilizationPercent: 88.2,
+      throttleDurationMs: 4200,
+    });
+  });
+});

--- a/electron/pty-host/handlers/__tests__/diagnostics.test.ts
+++ b/electron/pty-host/handlers/__tests__/diagnostics.test.ts
@@ -65,6 +65,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
     tryReplayAndResume: vi.fn(),
     resumePausedTerminal: vi.fn(),
     createPortQueueManager: vi.fn(),
+    getPausedDurationsSnapshot: vi.fn(() => []),
     ...overrides,
   };
 }
@@ -83,17 +84,18 @@ function runSnapshot(ctx: HostContext): FlowControlSnapshot {
 }
 
 describe("get-flow-control-snapshot handler", () => {
-  it("unions terminal ids across status, suspended, pause-start, and coordinator maps", () => {
+  it("unions terminal ids across status, suspended, held-duration, and coordinator maps", () => {
     const ctx = makeCtx({
       backpressureManager: {
         terminalStatusesMap: new Map([["a", "running"]]),
         suspendedSet: new Set(["b"]),
-        pauseStartTimesMap: new Map([["c", 100]]),
-        getPauseStartTime: vi.fn((id: string) => (id === "c" ? 100 : undefined)),
         isSuspended: vi.fn((id: string) => id === "b"),
         getActivityTier: vi.fn(() => "active"),
         stats: { pauseCount: 0, resumeCount: 0, suspendCount: 0, forceResumeCount: 0 },
       } as unknown as HostContext["backpressureManager"],
+      // "c" is known only to the cross-source held-duration map (live IPC/port
+      // pause path) — it must still surface in the union.
+      getPausedDurationsSnapshot: vi.fn(() => [{ terminalId: "c", heldDurationMs: 42 }]),
       pauseCoordinators: new Map([["d", {} as never]]),
     });
 
@@ -103,25 +105,68 @@ describe("get-flow-control-snapshot handler", () => {
     expect(ids).toEqual(["a", "b", "c", "d"]); // unioned and sorted
     expect(snapshot.terminals.find((t) => t.terminalId === "b")?.isSuspended).toBe(true);
     expect(snapshot.terminals.find((t) => t.terminalId === "a")?.flowStatus).toBe("running");
+    expect(snapshot.terminals.find((t) => t.terminalId === "c")?.pausedDurationMs).toBe(42);
   });
 
-  it("computes pausedDurationMs from the pause-start time and null when not paused", () => {
-    const now = Date.now();
+  it("reads pausedDurationMs from the cross-source held-duration snapshot, null otherwise", () => {
     const ctx = makeCtx({
       backpressureManager: {
-        terminalStatusesMap: new Map([["paused", "paused-backpressure"]]),
+        // "paused" holds an ipc-queue token but has NO entry in the SAB-only
+        // pauseStartTimes map; "running" is just streaming. Only the
+        // cross-source snapshot can supply the duration.
+        terminalStatusesMap: new Map([
+          ["paused", "paused-backpressure"],
+          ["running", "running"],
+        ]),
         suspendedSet: new Set(),
-        pauseStartTimesMap: new Map([["paused", now - 500]]),
-        getPauseStartTime: vi.fn((id: string) => (id === "paused" ? now - 500 : undefined)),
         isSuspended: vi.fn(() => false),
         getActivityTier: vi.fn(() => "active"),
         stats: { pauseCount: 0, resumeCount: 0, suspendCount: 0, forceResumeCount: 0 },
       } as unknown as HostContext["backpressureManager"],
+      getPausedDurationsSnapshot: vi.fn(() => [{ terminalId: "paused", heldDurationMs: 500 }]),
     });
 
     const snapshot = runSnapshot(ctx);
-    const paused = snapshot.terminals.find((t) => t.terminalId === "paused");
-    expect(paused?.pausedDurationMs).toBeGreaterThanOrEqual(500);
+    expect(snapshot.terminals.find((t) => t.terminalId === "paused")?.pausedDurationMs).toBe(500);
+    expect(snapshot.terminals.find((t) => t.terminalId === "running")?.pausedDurationMs).toBeNull();
+  });
+
+  it("isolates a throwing port queue manager so the snapshot still ships partial data", () => {
+    const goodConn = makePortConnection({
+      totalPendingBytes: 30,
+      perTerminal: [{ terminalId: "t1", pendingBytes: 30 }],
+    });
+    const badConn: RendererConnection = {
+      port: {} as RendererConnection["port"],
+      handler: vi.fn(),
+      portQueueManager: {
+        getQueueSnapshot: vi.fn(() => {
+          throw new Error("disposed connection");
+        }),
+      } as unknown as RendererConnection["portQueueManager"],
+      batcher: {} as RendererConnection["batcher"],
+    };
+    const ctx = makeCtx({
+      ipcQueueManager: {
+        getQueueSnapshot: vi.fn(() => ({
+          totalPendingBytes: 20,
+          perTerminal: [{ terminalId: "t0", pendingBytes: 20 }],
+        })),
+      } as unknown as HostContext["ipcQueueManager"],
+      rendererConnections: new Map([
+        [1, badConn],
+        [2, goodConn],
+      ]),
+    });
+
+    const snapshot = runSnapshot(ctx);
+
+    // The bad connection contributes nothing; IPC + the good connection stand.
+    expect(snapshot.totalPendingBytes).toBe(50);
+    expect(snapshot.queueDepth).toEqual([
+      { terminalId: "t0", layer: "ipc", pendingBytes: 20 },
+      { terminalId: "t1", layer: "port", pendingBytes: 30 },
+    ]);
   });
 
   it("includes sorted held tokens from the pause coordinator", () => {

--- a/electron/pty-host/handlers/__tests__/dispatcher.test.ts
+++ b/electron/pty-host/handlers/__tests__/dispatcher.test.ts
@@ -88,6 +88,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
     tryReplayAndResume: vi.fn(),
     resumePausedTerminal: vi.fn(),
     createPortQueueManager: vi.fn(),
+    getPausedDurationsSnapshot: vi.fn(() => []),
     ...overrides,
   };
 }

--- a/electron/pty-host/handlers/__tests__/lifecycle.test.ts
+++ b/electron/pty-host/handlers/__tests__/lifecycle.test.ts
@@ -92,6 +92,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
     tryReplayAndResume: vi.fn(),
     resumePausedTerminal: vi.fn(),
     createPortQueueManager: vi.fn(),
+    getPausedDurationsSnapshot: vi.fn(() => []),
     ...overrides,
   };
 }

--- a/electron/pty-host/handlers/__tests__/terminalInfo.test.ts
+++ b/electron/pty-host/handlers/__tests__/terminalInfo.test.ts
@@ -34,6 +34,7 @@ function createCtx(overrides: Partial<HostContext> = {}): HostContext {
     tryReplayAndResume: vi.fn(),
     resumePausedTerminal: vi.fn(),
     createPortQueueManager: vi.fn(),
+    getPausedDurationsSnapshot: vi.fn(() => []),
     ...overrides,
   };
 }

--- a/electron/pty-host/handlers/backpressure.ts
+++ b/electron/pty-host/handlers/backpressure.ts
@@ -217,6 +217,7 @@ export function createBackpressureHandlers(ctx: HostContext): HandlerMap {
         return;
       }
       coordinator.forceReleaseAll();
+      backpressureManager.stats.forceResumeCount++;
       console.log(`[PtyHost] Force resumed PTY ${msg.id} via user request`);
 
       // Clean up any pending backpressure monitoring

--- a/electron/pty-host/handlers/diagnostics.ts
+++ b/electron/pty-host/handlers/diagnostics.ts
@@ -1,0 +1,83 @@
+import type {
+  FlowControlQueueEntry,
+  FlowControlSnapshot,
+  FlowControlTerminalSnapshot,
+} from "../../../shared/types/pty-host.js";
+import type { HandlerMap, HostContext } from "./types.js";
+
+/**
+ * On-demand diagnostic pulls assembled from live pty-host state. Unlike the
+ * periodic reliability-metric push, these read the always-populated flow-control
+ * maps directly and are NOT gated by `metricsEnabled()` — a support bundle must
+ * be able to capture flow-control state regardless of the streaming-metrics flag.
+ */
+export function createDiagnosticsHandlers(ctx: HostContext): HandlerMap {
+  const {
+    backpressureManager,
+    ipcQueueManager,
+    resourceGovernor,
+    pauseCoordinators,
+    rendererConnections,
+    getPauseCoordinator,
+    sendEvent,
+  } = ctx;
+
+  return {
+    "get-flow-control-snapshot": (msg) => {
+      const now = Date.now();
+
+      // Union every terminal id known to any flow-control map so a terminal
+      // that is paused/suspended/held but has no recorded status still appears.
+      const ids = new Set<string>();
+      for (const id of backpressureManager.terminalStatusesMap.keys()) ids.add(id);
+      for (const id of backpressureManager.suspendedSet) ids.add(id);
+      for (const id of backpressureManager.pauseStartTimesMap.keys()) ids.add(id);
+      for (const id of pauseCoordinators.keys()) ids.add(id);
+
+      const terminals: FlowControlTerminalSnapshot[] = [];
+      for (const id of ids) {
+        const pauseStart = backpressureManager.getPauseStartTime(id);
+        terminals.push({
+          terminalId: id,
+          flowStatus: backpressureManager.terminalStatusesMap.get(id) ?? null,
+          heldTokens: Array.from(getPauseCoordinator(id)?.heldTokens ?? []).sort(),
+          isSuspended: backpressureManager.isSuspended(id),
+          activityTier: backpressureManager.getActivityTier(id),
+          pausedDurationMs: pauseStart !== undefined ? Math.max(0, now - pauseStart) : null,
+        });
+      }
+      terminals.sort((a, b) => a.terminalId.localeCompare(b.terminalId));
+
+      // Live IPC + per-window MessagePort queue depths. The FUTURE_SAB path is
+      // dead in production and excluded here to match the streaming
+      // queue-depth gauge, keeping dead-code and live paths independently
+      // observable. totalPendingBytes sums the same live paths.
+      const queueDepth: FlowControlQueueEntry[] = [];
+      let totalPendingBytes = 0;
+      const ipc = ipcQueueManager.getQueueSnapshot();
+      totalPendingBytes += ipc.totalPendingBytes;
+      for (const { terminalId, pendingBytes } of ipc.perTerminal) {
+        if (pendingBytes > 0) queueDepth.push({ terminalId, layer: "ipc", pendingBytes });
+      }
+      for (const conn of rendererConnections.values()) {
+        const port = conn.portQueueManager.getQueueSnapshot();
+        totalPendingBytes += port.totalPendingBytes;
+        for (const { terminalId, pendingBytes } of port.perTerminal) {
+          if (pendingBytes > 0) queueDepth.push({ terminalId, layer: "port", pendingBytes });
+        }
+      }
+
+      const snapshot: FlowControlSnapshot = {
+        timestamp: now,
+        terminals,
+        queueDepth,
+        totalPendingBytes,
+        // Spread-copy so later mutations don't bleed into the diagnostics object.
+        stats: { ...backpressureManager.stats },
+        resourceGovernor: resourceGovernor.getSnapshot(),
+      };
+
+      sendEvent({ type: "flow-control-snapshot", requestId: msg.requestId, snapshot });
+    },
+  };
+}

--- a/electron/pty-host/handlers/diagnostics.ts
+++ b/electron/pty-host/handlers/diagnostics.ts
@@ -19,6 +19,7 @@ export function createDiagnosticsHandlers(ctx: HostContext): HandlerMap {
     pauseCoordinators,
     rendererConnections,
     getPauseCoordinator,
+    getPausedDurationsSnapshot,
     sendEvent,
   } = ctx;
 
@@ -26,24 +27,32 @@ export function createDiagnosticsHandlers(ctx: HostContext): HandlerMap {
     "get-flow-control-snapshot": (msg) => {
       const now = Date.now();
 
+      // Authoritative held durations across SAB + live IPC/port pause sources.
+      // `backpressureManager.pauseStartTimes` only tracks the dead SAB path, so
+      // we read the cross-source snapshot instead — otherwise an IPC/port-paused
+      // terminal would report null even after being wedged for minutes.
+      const heldDurationById = new Map<string, number>();
+      for (const { terminalId, heldDurationMs } of getPausedDurationsSnapshot()) {
+        heldDurationById.set(terminalId, heldDurationMs);
+      }
+
       // Union every terminal id known to any flow-control map so a terminal
       // that is paused/suspended/held but has no recorded status still appears.
       const ids = new Set<string>();
       for (const id of backpressureManager.terminalStatusesMap.keys()) ids.add(id);
       for (const id of backpressureManager.suspendedSet) ids.add(id);
-      for (const id of backpressureManager.pauseStartTimesMap.keys()) ids.add(id);
+      for (const id of heldDurationById.keys()) ids.add(id);
       for (const id of pauseCoordinators.keys()) ids.add(id);
 
       const terminals: FlowControlTerminalSnapshot[] = [];
       for (const id of ids) {
-        const pauseStart = backpressureManager.getPauseStartTime(id);
         terminals.push({
           terminalId: id,
           flowStatus: backpressureManager.terminalStatusesMap.get(id) ?? null,
           heldTokens: Array.from(getPauseCoordinator(id)?.heldTokens ?? []).sort(),
           isSuspended: backpressureManager.isSuspended(id),
           activityTier: backpressureManager.getActivityTier(id),
-          pausedDurationMs: pauseStart !== undefined ? Math.max(0, now - pauseStart) : null,
+          pausedDurationMs: heldDurationById.get(id) ?? null,
         });
       }
       terminals.sort((a, b) => a.terminalId.localeCompare(b.terminalId));
@@ -60,10 +69,18 @@ export function createDiagnosticsHandlers(ctx: HostContext): HandlerMap {
         if (pendingBytes > 0) queueDepth.push({ terminalId, layer: "ipc", pendingBytes });
       }
       for (const conn of rendererConnections.values()) {
-        const port = conn.portQueueManager.getQueueSnapshot();
-        totalPendingBytes += port.totalPendingBytes;
-        for (const { terminalId, pendingBytes } of port.perTerminal) {
-          if (pendingBytes > 0) queueDepth.push({ terminalId, layer: "port", pendingBytes });
+        // Isolate per-connection failures: a disposed/racing port queue manager
+        // must not abort the whole snapshot, which would surface to the main
+        // side as a 5s broker timeout returning an empty (no-pressure-looking)
+        // fallback rather than the partial data we did gather.
+        try {
+          const port = conn.portQueueManager.getQueueSnapshot();
+          totalPendingBytes += port.totalPendingBytes;
+          for (const { terminalId, pendingBytes } of port.perTerminal) {
+            if (pendingBytes > 0) queueDepth.push({ terminalId, layer: "port", pendingBytes });
+          }
+        } catch {
+          // Skip this connection's contribution; the rest of the snapshot stands.
         }
       }
 

--- a/electron/pty-host/handlers/index.ts
+++ b/electron/pty-host/handlers/index.ts
@@ -1,6 +1,7 @@
 import type { MessagePort } from "node:worker_threads";
 import { createBackpressureHandlers } from "./backpressure.js";
 import { createConnectionHandlers } from "./connection.js";
+import { createDiagnosticsHandlers } from "./diagnostics.js";
 import { createLifecycleHandlers } from "./lifecycle.js";
 import { createResourceConfigHandlers } from "./resourceConfig.js";
 import { createStateConfigHandlers } from "./stateConfig.js";
@@ -35,6 +36,7 @@ export function createPtyHostMessageDispatcher(
     ...createLifecycleHandlers(ctx),
     ...createTerminalIOHandlers(ctx),
     ...createBackpressureHandlers(ctx),
+    ...createDiagnosticsHandlers(ctx),
     ...createTerminalQueryHandlers(ctx),
     ...createStateConfigHandlers(ctx),
     ...createResourceConfigHandlers(ctx),

--- a/electron/pty-host/handlers/types.ts
+++ b/electron/pty-host/handlers/types.ts
@@ -53,6 +53,13 @@ export interface HostContext {
   tryReplayAndResume: (id: string) => void;
   resumePausedTerminal: (id: string) => void;
   createPortQueueManager: (windowId: number) => PortQueueManager;
+  /**
+   * Per-paused-terminal held duration aggregated across SAB, IPC, and
+   * per-window MessagePort pause sources (oldest still-held start wins).
+   * Authoritative for "how long has this been paused?" — the live IPC/port
+   * paths keep their start times outside `backpressureManager.pauseStartTimes`.
+   */
+  getPausedDurationsSnapshot: () => Array<{ terminalId: string; heldDurationMs: number }>;
 }
 
 export type PtyHostHandler = (msg: any, ports?: MessagePort[]) => void | Promise<void>;

--- a/electron/services/DiagnosticsCollector.ts
+++ b/electron/services/DiagnosticsCollector.ts
@@ -417,6 +417,15 @@ async function collectTerminals(ptyClient?: PtyClient) {
   }
 }
 
+async function collectFlowControl(ptyClient?: PtyClient) {
+  try {
+    if (!ptyClient) return { error: "PtyClient not available" };
+    return await ptyClient.getFlowControlSnapshotAsync();
+  } catch {
+    return { error: "Failed to get flow-control snapshot" };
+  }
+}
+
 async function collectLogs() {
   try {
     const entries = logBuffer.getAll();
@@ -475,6 +484,7 @@ export async function collectDiagnosticsWithKeys(
     { key: "git", fn: collectGit },
     { key: "config", fn: collectStoreConfig },
     { key: "terminals", fn: () => collectTerminals(deps.ptyClient) },
+    { key: "flowControl", fn: () => collectFlowControl(deps.ptyClient) },
     { key: "logs", fn: collectLogs },
     { key: "events", fn: () => collectEvents(deps) },
   ];

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -65,6 +65,7 @@ import type {
   PtyHostActivityTier,
   CrashType,
   SpawnResult,
+  FlowControlSnapshot,
 } from "../../shared/types/pty-host.js";
 import type { TerminalSnapshot } from "./PtyManager.js";
 import type { AgentStateChangeTrigger } from "../types/index.js";
@@ -1000,6 +1001,33 @@ export class PtyClient extends EventEmitter {
     const promise = this.broker.register<TerminalInfoResponse[]>(requestId);
     this.send({ type: "get-all-terminals", requestId });
     return promise.catch(() => []);
+  }
+
+  /**
+   * Get an on-demand structured flow-control snapshot from the pty-host
+   * (per-terminal flow status, held pause tokens, queue depths, backpressure
+   * stats, and resource-governor state). Used by `DiagnosticsCollector` for
+   * support bundles. Resolves to an empty snapshot on IPC failure/timeout —
+   * the diagnostics caller never throws.
+   */
+  async getFlowControlSnapshotAsync(): Promise<FlowControlSnapshot> {
+    const requestId = this.broker.generateId("flow-control-snapshot");
+    const promise = this.broker.register<FlowControlSnapshot>(requestId);
+    this.send({ type: "get-flow-control-snapshot", requestId });
+    return promise.catch(() => ({
+      timestamp: Date.now(),
+      terminals: [],
+      queueDepth: [],
+      totalPendingBytes: 0,
+      stats: { pauseCount: 0, resumeCount: 0, suspendCount: 0, forceResumeCount: 0 },
+      resourceGovernor: {
+        isThrottling: false,
+        isWarning: false,
+        activeProfile: "balanced",
+        smoothedUtilizationPercent: null,
+        throttleDurationMs: 0,
+      },
+    }));
   }
 
   /**

--- a/electron/services/pty/PtyEventRouter.ts
+++ b/electron/services/pty/PtyEventRouter.ts
@@ -229,6 +229,10 @@ export function routeHostEvent(event: PtyHostEvent, deps: PtyEventRouterDeps): b
       broker.resolve(event.requestId, event.info);
       return true;
 
+    case "flow-control-snapshot":
+      broker.resolve(event.requestId, event.snapshot);
+      return true;
+
     case "terminal-pid":
       state.terminalPids.set(event.id, event.pid);
       if (callbacks.onTerminalPid) {

--- a/electron/services/pty/__tests__/PtyEventRouter.test.ts
+++ b/electron/services/pty/__tests__/PtyEventRouter.test.ts
@@ -187,6 +187,26 @@ describe("routeHostEvent", () => {
     expect(brokerCalls).toEqual([{ requestId: "req-1", result: null }]);
   });
 
+  it("resolves broker with the snapshot for flow-control-snapshot events", () => {
+    const { deps, brokerCalls } = makeDeps();
+    const snapshot = {
+      timestamp: 1,
+      terminals: [],
+      queueDepth: [],
+      totalPendingBytes: 0,
+      stats: { pauseCount: 0, resumeCount: 0, suspendCount: 0, forceResumeCount: 0 },
+      resourceGovernor: {
+        isThrottling: false,
+        isWarning: false,
+        activeProfile: "balanced" as const,
+        smoothedUtilizationPercent: null,
+        throttleDurationMs: 0,
+      },
+    };
+    routeHostEvent({ type: "flow-control-snapshot", requestId: "req-fc", snapshot }, deps);
+    expect(brokerCalls).toEqual([{ requestId: "req-fc", result: snapshot }]);
+  });
+
   it("resolves broker with terminalIds default for terminals-for-project", () => {
     const { deps, brokerCalls } = makeDeps();
     routeHostEvent(

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -191,7 +191,78 @@ export type PtyHostRequest =
   | { type: "set-resource-monitoring"; enabled: boolean }
   | { type: "set-session-persist-suppressed"; suppressed: boolean }
   | { type: "set-resource-profile"; profile: ResourceProfile }
-  | { type: "set-process-tree-poll-interval"; ms: number };
+  | { type: "set-process-tree-poll-interval"; ms: number }
+  | { type: "get-flow-control-snapshot"; requestId: string };
+
+/** Per-terminal flow-control state in a {@link FlowControlSnapshot}. */
+export interface FlowControlTerminalSnapshot {
+  terminalId: string;
+  /** Current flow status, or null when the terminal has no recorded status. */
+  flowStatus: TerminalFlowStatus | null;
+  /**
+   * Pause-coordinator hold tokens currently keeping this terminal paused
+   * (sorted, possibly empty). Stringified `PauseToken`s — kept as plain
+   * strings here so the shared protocol stays free of pty-host-only types.
+   */
+  heldTokens: string[];
+  /** Whether the visual stream is suspended (FUTURE_SAB stall path). */
+  isSuspended: boolean;
+  /** Activity tier (streaming policy). */
+  activityTier: PtyHostActivityTier;
+  /** Wall-clock ms the terminal has been paused, or null when not paused. */
+  pausedDurationMs: number | null;
+}
+
+/** Per-transport queue-depth entry in a {@link FlowControlSnapshot}. */
+export interface FlowControlQueueEntry {
+  terminalId: string;
+  layer: "ipc" | "port";
+  pendingBytes: number;
+}
+
+/**
+ * Backpressure lifecycle counters captured in a {@link FlowControlSnapshot}.
+ * Mirrors the pty-host's `BackpressureStats` (serializable subset).
+ */
+export interface BackpressureStatsSnapshot {
+  pauseCount: number;
+  resumeCount: number;
+  suspendCount: number;
+  forceResumeCount: number;
+}
+
+/** Resource-governor runtime state in a {@link FlowControlSnapshot}. */
+export interface ResourceGovernorSnapshot {
+  isThrottling: boolean;
+  isWarning: boolean;
+  activeProfile: ResourceProfile;
+  /**
+   * EMA-smoothed heap utilization percent, or null during warmup (the first
+   * ~5 ticks, before the smoothed signal has stabilized). Null is distinct
+   * from 0% so consumers can tell "not yet warmed up" from "0% heap used".
+   */
+  smoothedUtilizationPercent: number | null;
+  /** Ms since throttle engaged, or 0 when not throttling. */
+  throttleDurationMs: number;
+}
+
+/**
+ * On-demand structured flow-control snapshot from the pty-host. Assembled from
+ * live backpressure / pause-coordinator / resource-governor state at request
+ * time and NOT gated by the streaming-metrics flag (that gate governs the
+ * periodic reliability-metric push, not this diagnostic pull). Captured by
+ * `DiagnosticsCollector` for support bundles.
+ */
+export interface FlowControlSnapshot {
+  timestamp: number;
+  terminals: FlowControlTerminalSnapshot[];
+  /** Live IPC + per-window MessagePort queue depths (FUTURE_SAB path excluded). */
+  queueDepth: FlowControlQueueEntry[];
+  /** Sum of pending bytes across the live IPC + port paths. */
+  totalPendingBytes: number;
+  stats: BackpressureStatsSnapshot;
+  resourceGovernor: ResourceGovernorSnapshot;
+}
 
 /**
  * Terminal snapshot data sent from Host → Main for state queries.
@@ -386,6 +457,11 @@ export type PtyHostEvent =
   | {
       type: "broadcast-write-result";
       results: BroadcastWriteTargetResult[];
+    }
+  | {
+      type: "flow-control-snapshot";
+      requestId: string;
+      snapshot: FlowControlSnapshot;
     };
 
 export interface FdLeakWarningPayload {


### PR DESCRIPTION
## Summary

- Adds a `get-flow-control-snapshot` / `flow-control-snapshot` request-response pair to the pty-host protocol, with a `FlowControlSnapshot` type family in `shared/types/pty-host.ts`.
- The new diagnostics handler assembles per-terminal flow status: held pause tokens, suspended state, activity tier, paused durations from the cross-source held-duration map, live IPC + port queue depths, backpressure stats, and resource-governor state. Not gated by `metricsEnabled()` — it's a diagnostic pull, not the periodic streaming push.
- Fixes two previously-dead counters (`suspendCount`, `forceResumeCount`) and adds per-connection failure isolation in the port-queue loop so one disposed connection can't collapse the snapshot.

Resolves #10060

## Changes

- `shared/types/pty-host.ts` — `FlowControlSnapshot` + terminal snapshot types
- `electron/pty-host/handlers/diagnostics.ts` — new handler; assembles full snapshot on demand
- `electron/pty-host/ResourceGovernor.ts` — adds `getSnapshot()` (throttle/warning/profile/EMA-utilization state; `smoothedUtilizationPercent` passes through as `null` during warmup, not coerced to `0`)
- `electron/services/PtyClient.ts` + `electron/services/pty/PtyEventRouter.ts` — wires `getFlowControlSnapshotAsync()`
- `electron/services/DiagnosticsCollector.ts` — adds `flowControl` section within the existing 5s timeout
- `electron/pty-host/backpressure.ts` + `electron/pty-host/PtyPauseCoordinator.ts` — fixes `suspendCount` / `forceResumeCount` counter increments, per-connection failure isolation in port-queue loop
- IPC channel + preload additions (`electron/ipc/channels.ts`, `electron/preload.cts`, `shared/types/ipc/`)

## Testing

- New `electron/pty-host/handlers/__tests__/diagnostics.test.ts` — full handler suite
- `PtyEventRouter` routing case for the new message type
- `suspendCount` / `forceResumeCount` counter increment tests
- Cross-source duration and port-throw isolation coverage
- `npm run check` (typecheck + lint + format), build, and `check:preload-backdoors` all pass