### PR TITLE
feat(help): surface MCP grant lifecycle in the Assistant panel

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -593,6 +593,8 @@ export function HelpPanel({
   const dismissTierMismatch = useCallback(() => controller.dismissTierMismatch(), [controller]);
   const approveTierOnce = useCallback(() => controller.approveTierOnce(), [controller]);
   const alwaysAllowTier = useCallback(() => controller.alwaysAllowTier(), [controller]);
+  const revokeGrant = useCallback(() => controller.revokeGrant(), [controller]);
+  const dismissGrantEnded = useCallback(() => controller.dismissGrantEnded(), [controller]);
   const cancelLaunch = useCallback(() => controller.cancelLaunch(), [controller]);
   const checkVersionAgain = useCallback(() => controller.checkVersionAgain(), [controller]);
   const dismissLaunchError = useCallback(() => controller.dismissLaunchError(), [controller]);
@@ -714,11 +716,16 @@ export function HelpPanel({
           launchError={session.launchError}
           sessionRevoked={session.sessionRevoked}
           isApprovingTier={session.isApprovingTier}
+          activeGrant={session.activeGrant}
+          grantEnded={session.grantEnded}
+          isRevokingGrant={session.isRevokingGrant}
           onDismissResume={dismissResume}
           onDismissSnapshot={dismissSnapshot}
           onDismissTierMismatch={dismissTierMismatch}
           onApproveOnce={approveTierOnce}
           onAlwaysAllow={alwaysAllowTier}
+          onRevokeGrant={revokeGrant}
+          onDismissGrantEnded={dismissGrantEnded}
           onRetryLaunch={retryLaunch}
           onDismissLaunchError={dismissLaunchError}
           onOpenAssistantSettings={handleOpenSettings}

--- a/src/components/HelpPanel/HelpPanelBanners.tsx
+++ b/src/components/HelpPanel/HelpPanelBanners.tsx
@@ -20,6 +20,11 @@ const GRANT_ENDED_BODY: Record<GrantEndReason, string> = {
   "grant-ceiling": "hit its 30-minute limit. The next call will ask to approve it again.",
 };
 
+// The countdown re-derives from `expiresAt` once a second — the tick only
+// drives a re-render, it isn't the source of truth, so a missed beat can't
+// drift the displayed value.
+const COUNTDOWN_TICK_MS = 1000;
+
 function formatRemaining(totalSeconds: number): string {
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
@@ -55,7 +60,7 @@ function GrantActiveBanner({
     setRemainingSeconds(computeRemainingSeconds(grant.expiresAt));
     const id = setInterval(() => {
       setRemainingSeconds(computeRemainingSeconds(grant.expiresAt));
-    }, 1000);
+    }, COUNTDOWN_TICK_MS);
     return () => clearInterval(id);
   }, [grant.expiresAt]);
 

--- a/src/components/HelpPanel/HelpPanelBanners.tsx
+++ b/src/components/HelpPanel/HelpPanelBanners.tsx
@@ -1,12 +1,137 @@
-import { AlertCircle, History, ShieldAlert, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { AlertCircle, Clock, History, ShieldAlert, ShieldCheck, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { SnapshotInfo } from "@shared/types/ipc/git";
 import type {
+  ActiveGrantState,
+  GrantEndReason,
+  GrantEndedState,
   LaunchErrorKind,
   LaunchErrorState,
   SessionRevokedState,
   TierMismatchState,
 } from "@/controllers/HelpSessionController";
+
+// Body copy keyed off how the grant ended (#10042). The tool id is the
+// sentence subject, prepended by the caller — kept jargon-free per the
+// microcopy rules (no "MCP" / "grant" / "tier").
+const GRANT_ENDED_BODY: Record<GrantEndReason, string> = {
+  expired: "access expired. The next call will ask to approve it again.",
+  "grant-ceiling": "hit its 30-minute limit. The next call will ask to approve it again.",
+};
+
+function formatRemaining(totalSeconds: number): string {
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+function computeRemainingSeconds(expiresAt: number): number {
+  return Math.max(0, Math.ceil((expiresAt - Date.now()) / 1000));
+}
+
+/**
+ * Ambient countdown for a live "Approve once" grant (#10042). Tier 1 — a
+ * non-blocking pane-chrome state, not a toast. The countdown derives from the
+ * grant's `expiresAt` with a component-local 1s tick; the timestamp is the
+ * source of truth, so a missed tick can't drift the displayed value (and the
+ * interval is keyed on `expiresAt`, restarting cleanly under StrictMode's
+ * double-mount). The grant is sliding-TTL: the countdown is "time left if the
+ * tool isn't used again," matching the issue's "countdown without polling".
+ */
+function GrantActiveBanner({
+  grant,
+  isRevoking,
+  onRevoke,
+}: {
+  grant: ActiveGrantState;
+  isRevoking: boolean;
+  onRevoke: () => void;
+}) {
+  const [remainingSeconds, setRemainingSeconds] = useState(() =>
+    computeRemainingSeconds(grant.expiresAt)
+  );
+  useEffect(() => {
+    setRemainingSeconds(computeRemainingSeconds(grant.expiresAt));
+    const id = setInterval(() => {
+      setRemainingSeconds(computeRemainingSeconds(grant.expiresAt));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [grant.expiresAt]);
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "flex items-center gap-2 px-3 py-2 mx-3 mt-3 mb-1",
+        "rounded-[var(--radius-md)] bg-overlay-subtle border border-daintree-border",
+        "text-xs text-daintree-text/80"
+      )}
+      data-testid="help-grant-active-banner"
+    >
+      <ShieldCheck className="w-3.5 h-3.5 shrink-0 text-daintree-text/60" aria-hidden="true" />
+      <span className="flex-1 min-w-0 select-text">
+        <span className="font-mono text-daintree-text/90">{grant.toolId}</span> approved ·{" "}
+        <span className="tabular-nums">{formatRemaining(remainingSeconds)}</span> left
+      </span>
+      <button
+        type="button"
+        onClick={onRevoke}
+        disabled={isRevoking}
+        className={cn(
+          "px-2 py-1 rounded-[var(--radius-sm)] text-xs",
+          "text-daintree-text/65 hover:text-daintree-text",
+          "disabled:opacity-50 disabled:cursor-not-allowed transition-colors",
+          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+        )}
+      >
+        Revoke access
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Brief notice that a watched grant lapsed (#10042). Neutral ambient surface,
+ * not an error tint — nothing failed; the user's approval simply timed out and
+ * the next call re-prompts. Auto-dismisses on a controller timer; also
+ * manually dismissible.
+ */
+function GrantEndedBanner({
+  grantEnded,
+  onDismiss,
+}: {
+  grantEnded: GrantEndedState;
+  onDismiss: () => void;
+}) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "flex items-start gap-2 px-3 py-2 mx-3 mt-3 mb-1",
+        "rounded-[var(--radius-md)] bg-overlay-subtle border border-daintree-border",
+        "text-xs text-daintree-text/80"
+      )}
+      data-testid="help-grant-ended-banner"
+    >
+      <Clock className="w-3.5 h-3.5 shrink-0 mt-0.5 text-daintree-text/60" aria-hidden="true" />
+      <span className="flex-1 min-w-0 select-text">
+        <span className="font-mono text-daintree-text/90">{grantEnded.toolId}</span>{" "}
+        {GRANT_ENDED_BODY[grantEnded.reason]}
+      </span>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss approval notice"
+        className="text-daintree-text/50 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+      >
+        <X className="w-3 h-3" />
+      </button>
+    </div>
+  );
+}
 
 // Recovery copy keyed off the failure kind so the banner never leaks the
 // underlying "MCP" / "token" / "bearer" jargon the controller catches.
@@ -56,11 +181,16 @@ interface HelpPanelBannersProps {
   launchError: LaunchErrorState | null;
   sessionRevoked: SessionRevokedState | null;
   isApprovingTier: boolean;
+  activeGrant: ActiveGrantState | null;
+  grantEnded: GrantEndedState | null;
+  isRevokingGrant: boolean;
   onDismissResume: () => void;
   onDismissSnapshot: () => void;
   onDismissTierMismatch: () => void;
   onApproveOnce: () => void;
   onAlwaysAllow: () => void;
+  onRevokeGrant: () => void;
+  onDismissGrantEnded: () => void;
   onRetryLaunch: () => void;
   onDismissLaunchError: () => void;
   onOpenAssistantSettings: () => void;
@@ -77,11 +207,16 @@ export function HelpPanelBanners({
   launchError,
   sessionRevoked,
   isApprovingTier,
+  activeGrant,
+  grantEnded,
+  isRevokingGrant,
   onDismissResume,
   onDismissSnapshot,
   onDismissTierMismatch,
   onApproveOnce,
   onAlwaysAllow,
+  onRevokeGrant,
+  onDismissGrantEnded,
   onRetryLaunch,
   onDismissLaunchError,
   onOpenAssistantSettings,
@@ -142,6 +277,14 @@ export function HelpPanelBanners({
           </button>
         </div>
       )}
+      {activeGrant && (
+        <GrantActiveBanner
+          grant={activeGrant}
+          isRevoking={isRevokingGrant}
+          onRevoke={onRevokeGrant}
+        />
+      )}
+      {grantEnded && <GrantEndedBanner grantEnded={grantEnded} onDismiss={onDismissGrantEnded} />}
       {tierMismatch && (
         <div
           role="alert"

--- a/src/components/HelpPanel/HelpPanelBanners.tsx
+++ b/src/components/HelpPanel/HelpPanelBanners.tsx
@@ -78,7 +78,13 @@ function GrantActiveBanner({
       <ShieldCheck className="w-3.5 h-3.5 shrink-0 text-daintree-text/60" aria-hidden="true" />
       <span className="flex-1 min-w-0 select-text">
         <span className="font-mono text-daintree-text/90">{grant.toolId}</span> approved ·{" "}
-        <span className="tabular-nums">{formatRemaining(remainingSeconds)}</span> left
+        {/* The countdown re-derives every second; keep it out of the parent's
+            polite live region (`aria-live="off"`) so screen readers announce
+            the "<tool> approved" message once instead of the ticking time. */}
+        <span aria-live="off" className="tabular-nums">
+          {formatRemaining(remainingSeconds)}
+        </span>{" "}
+        left
       </span>
       <button
         type="button"

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -505,6 +505,7 @@ beforeEach(() => {
           onToolCallSettled: vi.fn(() => () => {}),
           onDisplayImage: vi.fn(() => () => {}),
           onSessionRevoked: vi.fn(() => () => {}),
+          onGrantLifecycle: vi.fn(() => () => {}),
           setSessionTier: vi.fn().mockResolvedValue({ sessionId: "", tier: "workbench" }),
           resetDenialCounts: vi.fn().mockResolvedValue(undefined),
           issueGrant: vi.fn().mockResolvedValue({

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -432,6 +432,7 @@ beforeEach(() => {
           onToolCallSettled: vi.fn(() => () => {}),
           onDisplayImage: vi.fn(() => () => {}),
           onSessionRevoked: vi.fn(() => () => {}),
+          onGrantLifecycle: vi.fn(() => () => {}),
           setSessionTier: vi.fn().mockResolvedValue({ sessionId: "", tier: "workbench" }),
           resetDenialCounts: vi.fn().mockResolvedValue(undefined),
           issueGrant: vi.fn().mockResolvedValue({

--- a/src/components/HelpPanel/__tests__/HelpPanelBanners.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanelBanners.test.tsx
@@ -15,11 +15,16 @@ function baseProps() {
     launchError: null,
     sessionRevoked: null,
     isApprovingTier: false,
+    activeGrant: null,
+    grantEnded: null,
+    isRevokingGrant: false,
     onDismissResume: vi.fn(),
     onDismissSnapshot: vi.fn(),
     onDismissTierMismatch: vi.fn(),
     onApproveOnce: vi.fn(),
     onAlwaysAllow: vi.fn(),
+    onRevokeGrant: vi.fn(),
+    onDismissGrantEnded: vi.fn(),
     onRetryLaunch: vi.fn(),
     onDismissLaunchError: vi.fn(),
     onOpenAssistantSettings: vi.fn(),
@@ -271,5 +276,142 @@ describe("HelpPanelBanners — session revoked", () => {
   it("renders nothing for the revoked slot when sessionRevoked is null", () => {
     const { queryByTestId } = render(<HelpPanelBanners {...baseProps()} />);
     expect(queryByTestId("help-session-revoked-banner")).toBeNull();
+  });
+});
+
+describe("HelpPanelBanners — active grant countdown (#10042)", () => {
+  it("renders nothing for the grant slot when activeGrant is null", () => {
+    const { queryByTestId } = render(<HelpPanelBanners {...baseProps()} />);
+    expect(queryByTestId("help-grant-active-banner")).toBeNull();
+  });
+
+  it("renders the tool id and a mm:ss countdown derived from expiresAt", () => {
+    // 2 min 5 s out — ceil keeps it at 2:0x even with a few ms of render lag.
+    const { getByTestId } = render(
+      <HelpPanelBanners
+        {...baseProps()}
+        activeGrant={{
+          sessionId: "s1",
+          toolId: "search_docs",
+          ttlMs: 900_000,
+          expiresAt: Date.now() + 125_000,
+        }}
+      />
+    );
+    const banner = getByTestId("help-grant-active-banner");
+    expect(banner.getAttribute("role")).toBe("status");
+    const text = banner.textContent ?? "";
+    expect(text).toContain("search_docs");
+    // The displayed remaining time is derived, not a hardcoded literal.
+    expect(text).toMatch(/2:0\d/);
+  });
+
+  it("shows a smaller remaining time for a nearer expiry (countdown is computed)", () => {
+    const { getByTestId } = render(
+      <HelpPanelBanners
+        {...baseProps()}
+        activeGrant={{
+          sessionId: "s1",
+          toolId: "t1",
+          ttlMs: 900_000,
+          expiresAt: Date.now() + 5_000,
+        }}
+      />
+    );
+    const text = getByTestId("help-grant-active-banner").textContent ?? "";
+    expect(text).toMatch(/0:0[45]/);
+  });
+
+  it("clamps a past expiry to 0:00 rather than rendering a negative timer", () => {
+    const { getByTestId } = render(
+      <HelpPanelBanners
+        {...baseProps()}
+        activeGrant={{
+          sessionId: "s1",
+          toolId: "t1",
+          ttlMs: 900_000,
+          expiresAt: Date.now() - 10_000,
+        }}
+      />
+    );
+    expect(getByTestId("help-grant-active-banner").textContent).toContain("0:00");
+  });
+
+  it("wires Revoke access to onRevokeGrant and disables it while revoking", () => {
+    const onRevokeGrant = vi.fn();
+    const { getByText, rerender } = render(
+      <HelpPanelBanners
+        {...baseProps()}
+        activeGrant={{
+          sessionId: "s1",
+          toolId: "t1",
+          ttlMs: 900_000,
+          expiresAt: Date.now() + 60_000,
+        }}
+        onRevokeGrant={onRevokeGrant}
+      />
+    );
+    const button = getByText("Revoke access");
+    fireEvent.click(button);
+    expect(onRevokeGrant).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <HelpPanelBanners
+        {...baseProps()}
+        activeGrant={{
+          sessionId: "s1",
+          toolId: "t1",
+          ttlMs: 900_000,
+          expiresAt: Date.now() + 60_000,
+        }}
+        isRevokingGrant={true}
+        onRevokeGrant={onRevokeGrant}
+      />
+    );
+    expect((getByText("Revoke access") as HTMLButtonElement).disabled).toBe(true);
+  });
+});
+
+describe("HelpPanelBanners — grant ended notice (#10042)", () => {
+  it("renders nothing for the grant-ended slot when grantEnded is null", () => {
+    const { queryByTestId } = render(<HelpPanelBanners {...baseProps()} />);
+    expect(queryByTestId("help-grant-ended-banner")).toBeNull();
+  });
+
+  it("distinguishes a passive expiry from the 30-minute ceiling in its copy", () => {
+    const { getByTestId, rerender } = render(
+      <HelpPanelBanners {...baseProps()} grantEnded={{ toolId: "t1", reason: "expired" }} />
+    );
+    const expiredText = getByTestId("help-grant-ended-banner").textContent ?? "";
+    expect(expiredText).toContain("t1");
+    expect(expiredText).not.toContain("30-minute");
+
+    rerender(
+      <HelpPanelBanners {...baseProps()} grantEnded={{ toolId: "t1", reason: "grant-ceiling" }} />
+    );
+    expect(getByTestId("help-grant-ended-banner").textContent).toContain("30-minute");
+  });
+
+  it("keeps the notice free of MCP / grant / tier jargon", () => {
+    const { getByTestId } = render(
+      <HelpPanelBanners {...baseProps()} grantEnded={{ toolId: "t1", reason: "grant-ceiling" }} />
+    );
+    const text = getByTestId("help-grant-ended-banner").textContent ?? "";
+    expect(text).not.toMatch(/\bMCP\b/i);
+    expect(text).not.toMatch(/\bgrant\b/i);
+    expect(text).not.toMatch(/\btier\b/i);
+  });
+
+  it("wires its dismiss button to onDismissGrantEnded", () => {
+    const onDismissGrantEnded = vi.fn();
+    const { getByLabelText } = render(
+      <HelpPanelBanners
+        {...baseProps()}
+        grantEnded={{ toolId: "t1", reason: "expired" }}
+        onDismissGrantEnded={onDismissGrantEnded}
+      />
+    );
+    fireEvent.click(getByLabelText("Dismiss approval notice"));
+    expect(onDismissGrantEnded).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/HelpPanel/__tests__/HelpPanelBanners.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanelBanners.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, act } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/utils", () => ({ cn: (...args: unknown[]) => args.filter(Boolean).join(" ") }));
@@ -335,6 +335,35 @@ describe("HelpPanelBanners — active grant countdown (#10042)", () => {
       />
     );
     expect(getByTestId("help-grant-active-banner").textContent).toContain("0:00");
+  });
+
+  it("ticks the countdown down over time and stops after unmount (no leak)", () => {
+    vi.useFakeTimers();
+    try {
+      const base = Date.now();
+      const { getByTestId, unmount } = render(
+        <HelpPanelBanners
+          {...baseProps()}
+          activeGrant={{ sessionId: "s1", toolId: "t1", ttlMs: 900_000, expiresAt: base + 5_000 }}
+        />
+      );
+      expect(getByTestId("help-grant-active-banner").textContent).toContain("0:05");
+      // Advance both wall-clock and the interval so the derived value updates.
+      act(() => {
+        vi.advanceTimersByTime(2_000);
+      });
+      expect(getByTestId("help-grant-active-banner").textContent).toContain("0:03");
+      // Unmount must clear the interval — advancing further is a no-op, not a
+      // post-unmount state update.
+      unmount();
+      expect(() =>
+        act(() => {
+          vi.advanceTimersByTime(5_000);
+        })
+      ).not.toThrow();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("wires Revoke access to onRevokeGrant and disables it while revoking", () => {

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -984,16 +984,19 @@ export class HelpSessionController {
   /**
    * End the live "Approve once" grant early (#10042). Revokes every grant on
    * the session — the help session only ever holds one per-tool grant at a
-   * time, so this maps to the single banner the user sees. The authoritative
-   * `activeGrant` clear comes from the `grant.revoked` lifecycle event (reason
-   * `user`), which clears the banner silently; `isRevokingGrant` keeps the
-   * button disabled until the IPC settles. No `ConfirmDialog` — this is a D1
-   * action whose inverse (re-approve) is one tool call away.
+   * time, so this maps to the single banner the user sees. Normally the
+   * `grant.revoked` lifecycle event (reason `user`) clears the banner first;
+   * the `.finally` also clears `activeGrant` as a renderer-authoritative
+   * fallback so a dropped event (WebContents torn down before it fired) can't
+   * leave a zombie countdown. The clear is scoped to the exact `(session,
+   * toolId)` we revoked, so it never wipes a newer grant that arrived in the
+   * meantime. No `ConfirmDialog` — this is a D1 action whose inverse
+   * (re-approve) is one tool call away.
    */
   revokeGrant(): void {
     const active = this._snapshot.activeGrant;
     if (!active || this._snapshot.isRevokingGrant) return;
-    const { sessionId } = active;
+    const { sessionId, toolId } = active;
     this._patch({ isRevokingGrant: true });
     safeFireAndForget(
       window.electron.mcpServer
@@ -1008,7 +1011,12 @@ export class HelpSessionController {
           });
         })
         .finally(() => {
-          this._patch({ isRevokingGrant: false });
+          const current = this._snapshot.activeGrant;
+          const stillSame = current?.sessionId === sessionId && current?.toolId === toolId;
+          this._patch({
+            isRevokingGrant: false,
+            ...(stillSame ? { activeGrant: null } : {}),
+          });
         }),
       { context: "HelpPanel:revokeGrant" }
     );
@@ -1432,7 +1440,9 @@ export class HelpSessionController {
 
   private _clearGrantState(): void {
     this._clearGrantEndedTimer();
-    this._patch({ activeGrant: null, grantEnded: null });
+    // Clear `isRevokingGrant` too: a teardown mid-revoke would otherwise leak
+    // a stuck-disabled "Revoke access" button into the next session's grant.
+    this._patch({ activeGrant: null, grantEnded: null, isRevokingGrant: false });
   }
 
   private _clearGrantEndedTimer(): void {

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -986,12 +986,13 @@ export class HelpSessionController {
    * the session — the help session only ever holds one per-tool grant at a
    * time, so this maps to the single banner the user sees. Normally the
    * `grant.revoked` lifecycle event (reason `user`) clears the banner first;
-   * the `.finally` also clears `activeGrant` as a renderer-authoritative
-   * fallback so a dropped event (WebContents torn down before it fired) can't
-   * leave a zombie countdown. The clear is scoped to the exact `(session,
-   * toolId)` we revoked, so it never wipes a newer grant that arrived in the
-   * meantime. No `ConfirmDialog` — this is a D1 action whose inverse
-   * (re-approve) is one tool call away.
+   * the `.then` clears `activeGrant` as a renderer-authoritative fallback so a
+   * dropped event (WebContents torn down before it fired) can't leave a zombie
+   * countdown. The fallback runs only on success and is scoped to the exact
+   * `(session, toolId)` we revoked, so a failed revoke leaves the banner up as
+   * its own retry surface and a newer grant that arrived meanwhile survives.
+   * No `ConfirmDialog` — this is a D1 action whose inverse (re-approve) is one
+   * tool call away.
    */
   revokeGrant(): void {
     const active = this._snapshot.activeGrant;
@@ -1001,22 +1002,24 @@ export class HelpSessionController {
     safeFireAndForget(
       window.electron.mcpServer
         .revokeSessionGrants({ sessionId })
+        .then(() => {
+          // Renderer-authoritative clear on success: normally the
+          // `grant.revoked` (reason `user`) lifecycle event already cleared the
+          // banner; this covers a dropped event (WebContents torn down before
+          // it fired). Scoped to the exact `(session, toolId)` we revoked so a
+          // newer grant that arrived in the meantime survives.
+          const current = this._snapshot.activeGrant;
+          if (current?.sessionId === sessionId && current?.toolId === toolId) {
+            this._patch({ activeGrant: null });
+          }
+        })
         .catch((err) => {
+          // The grant is still live and its countdown banner stays put, so the
+          // banner itself is the retry surface — diagnostic only, no toast.
           logError("HelpPanel: revokeSessionGrants failed", err);
-          // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
-          notify({
-            type: "error",
-            title: "Couldn't revoke access",
-            message: formatErrorMessage(err, "Couldn't revoke this tool's access."),
-          });
         })
         .finally(() => {
-          const current = this._snapshot.activeGrant;
-          const stillSame = current?.sessionId === sessionId && current?.toolId === toolId;
-          this._patch({
-            isRevokingGrant: false,
-            ...(stillSame ? { activeGrant: null } : {}),
-          });
+          this._patch({ isRevokingGrant: false });
         }),
       { context: "HelpPanel:revokeGrant" }
     );

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -33,6 +33,10 @@ const HIBERNATE_BUSY_RECHECK_MS = 2 * 60 * 1000;
 
 const RESUME_BANNER_AUTO_DISMISS_MS = 4_000;
 const SNAPSHOT_BANNER_AUTO_DISMISS_MS = 12_000;
+// The "approval ended" notice (#10042) lingers a touch longer than the
+// snapshot banner — it tells the user their per-tool grant lapsed and the
+// next call will prompt again, which is worth a beat to read.
+const GRANT_ENDED_BANNER_AUTO_DISMISS_MS = 15_000;
 
 // Minimum disabled period after a manual "Check again" click — keeps the
 // button from being hammered while a fresh (cache-bypassing) probe runs.
@@ -151,6 +155,36 @@ export interface McpToolActivityState {
   isError: boolean;
 }
 
+/**
+ * The live per-`(sessionId, toolId)` grant minted by "Approve once" (#10042).
+ * Drives the ambient countdown banner in the Help Panel. `expiresAt` is the
+ * absolute epoch-ms the grant would lapse without further use — the renderer
+ * counts down against it without polling (the `issueGrant` result and the
+ * `grant.issued` lifecycle event both carry it). Single-slot: the most
+ * recently issued grant is the one shown.
+ */
+export interface ActiveGrantState {
+  sessionId: string;
+  toolId: string;
+  expiresAt: number;
+  ttlMs: number;
+}
+
+/**
+ * How a watched grant ended, for the brief "approval ended" notice (#10042).
+ * Only the two reasons the user can act on are surfaced:
+ * - `expired`: the sliding TTL lapsed with no recent use.
+ * - `grant-ceiling`: the 30-minute hard ceiling tripped mid-use.
+ * A user-initiated revoke and session teardown/idle clear the banner silently
+ * — there's nothing for the user to do, and the session is already gone.
+ */
+export type GrantEndReason = "expired" | "grant-ceiling";
+
+export interface GrantEndedState {
+  toolId: string;
+  reason: GrantEndReason;
+}
+
 export interface HelpSessionSnapshot {
   phase: HelpSessionPhase;
   showResumeBanner: boolean;
@@ -169,6 +203,12 @@ export interface HelpSessionSnapshot {
   mcpActivity: McpToolActivityState | null;
   /** Set when the abuse policy revoked the active session (#10017); null otherwise. */
   sessionRevoked: SessionRevokedState | null;
+  /** The live "Approve once" grant being counted down (#10042); null when none. */
+  activeGrant: ActiveGrantState | null;
+  /** Brief notice that the watched grant lapsed (#10042); null when none. */
+  grantEnded: GrantEndedState | null;
+  /** True while a user-initiated grant revoke is in flight (#10042). */
+  isRevokingGrant: boolean;
 }
 
 export interface HelpProjectRef {
@@ -477,6 +517,9 @@ const INITIAL_SNAPSHOT: HelpSessionSnapshot = Object.freeze({
   launchError: null,
   mcpActivity: null,
   sessionRevoked: null,
+  activeGrant: null,
+  grantEnded: null,
+  isRevokingGrant: false,
 });
 
 /**
@@ -533,6 +576,7 @@ export class HelpSessionController {
   private _hibernateTimer: ReturnType<typeof setTimeout> | null = null;
   private _resumeBannerTimer: ReturnType<typeof setTimeout> | null = null;
   private _snapshotBannerTimer: ReturnType<typeof setTimeout> | null = null;
+  private _grantEndedBannerTimer: ReturnType<typeof setTimeout> | null = null;
   private _disposers: Array<() => void> = [];
   private _lastInputs: HelpSessionInputs | null = null;
   private _hibernateArmedFor: {
@@ -562,6 +606,9 @@ export class HelpSessionController {
 
     const disposeTier = window.electron.mcpServer.onTierNotPermitted((payload) => {
       const projectId = useProjectStore.getState().currentProject?.id ?? null;
+      // A fresh denial supersedes any lingering "approval ended" notice — the
+      // banner the user is about to re-approve from carries the same signal.
+      this._clearGrantEndedTimer();
       this._patch({
         tierMismatch: {
           sessionId: payload.sessionId,
@@ -570,6 +617,7 @@ export class HelpSessionController {
           targetTier: payload.targetTier,
           projectId,
         },
+        grantEnded: null,
       });
     });
     this._disposers.push(disposeTier);
@@ -588,6 +636,11 @@ export class HelpSessionController {
       });
     });
     this._disposers.push(disposeRevoked);
+
+    const disposeGrant = window.electron.mcpServer.onGrantLifecycle((payload) => {
+      this._onGrantLifecycle(payload);
+    });
+    this._disposers.push(disposeGrant);
 
     const disposeToolStarted = window.electron.mcpServer.onToolCallStarted((payload) => {
       this._onToolCallStarted(payload);
@@ -634,6 +687,7 @@ export class HelpSessionController {
     this._clearHibernateTimer();
     this._clearResumeBannerTimer();
     this._clearSnapshotBannerTimer();
+    this._clearGrantEndedTimer();
     this._clearCheckAgainCooldownTimer();
     // Bumping the gen invalidates any in-flight launch so its post-await
     // checkpoints bail. Live store state is left intact so a StrictMode
@@ -702,8 +756,10 @@ export class HelpSessionController {
     this._hasAutoLaunched = false;
     store.clearTerminal();
     // The bound session is gone — drop any lingering activity row so the strip
-    // doesn't show stale tool calls for a dead session (#9759).
+    // doesn't show stale tool calls for a dead session (#9759), and clear the
+    // grant countdown/notice so they don't outlive the session (#10042).
     this.clearMcpActivity();
+    this._clearGrantState();
   }
 
   /**
@@ -853,6 +909,7 @@ export class HelpSessionController {
         // counter at 1 in the main process (#9828).
         useHelpPanelStore.getState().clearFigures();
         this.clearMcpActivity();
+        this._clearGrantState();
       }
       // Discarding the current conversation invalidates any persisted
       // hibernate entry for this project — leaving it would resume the
@@ -917,6 +974,44 @@ export class HelpSessionController {
 
   dismissSessionRevoked(): void {
     this._patch({ sessionRevoked: null });
+  }
+
+  dismissGrantEnded(): void {
+    this._clearGrantEndedTimer();
+    this._patch({ grantEnded: null });
+  }
+
+  /**
+   * End the live "Approve once" grant early (#10042). Revokes every grant on
+   * the session — the help session only ever holds one per-tool grant at a
+   * time, so this maps to the single banner the user sees. The authoritative
+   * `activeGrant` clear comes from the `grant.revoked` lifecycle event (reason
+   * `user`), which clears the banner silently; `isRevokingGrant` keeps the
+   * button disabled until the IPC settles. No `ConfirmDialog` — this is a D1
+   * action whose inverse (re-approve) is one tool call away.
+   */
+  revokeGrant(): void {
+    const active = this._snapshot.activeGrant;
+    if (!active || this._snapshot.isRevokingGrant) return;
+    const { sessionId } = active;
+    this._patch({ isRevokingGrant: true });
+    safeFireAndForget(
+      window.electron.mcpServer
+        .revokeSessionGrants({ sessionId })
+        .catch((err) => {
+          logError("HelpPanel: revokeSessionGrants failed", err);
+          // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
+          notify({
+            type: "error",
+            title: "Couldn't revoke access",
+            message: formatErrorMessage(err, "Couldn't revoke this tool's access."),
+          });
+        })
+        .finally(() => {
+          this._patch({ isRevokingGrant: false });
+        }),
+      { context: "HelpPanel:revokeGrant" }
+    );
   }
 
   approveTierOnce(): void {
@@ -1221,7 +1316,10 @@ export class HelpSessionController {
       next.isCheckingVersion === this._snapshot.isCheckingVersion &&
       next.launchError === this._snapshot.launchError &&
       next.mcpActivity === this._snapshot.mcpActivity &&
-      next.sessionRevoked === this._snapshot.sessionRevoked
+      next.sessionRevoked === this._snapshot.sessionRevoked &&
+      next.activeGrant === this._snapshot.activeGrant &&
+      next.grantEnded === this._snapshot.grantEnded &&
+      next.isRevokingGrant === this._snapshot.isRevokingGrant
     ) {
       return;
     }
@@ -1270,6 +1368,86 @@ export class HelpSessionController {
       this._snapshotBannerTimer = null;
       this._patch({ preflightSnapshot: null });
     }, SNAPSHOT_BANNER_AUTO_DISMISS_MS);
+  }
+
+  /**
+   * Consume a live grant lifecycle push (#10042). `grant.issued` arms the
+   * countdown banner and dismisses the mismatch that prompted it;
+   * `grant.expired`/`grant.revoked` retire the banner and, for the two
+   * user-actionable reasons, surface a brief "approval ended" notice. The
+   * `expired`/`revoked` cases are scoped to the grant currently on screen so a
+   * stale lapse for a different tool can't wipe the active countdown.
+   * `tier.elevated`/`tier.decayed` are session-tier transitions, not per-tool
+   * grants — they leave the countdown untouched (the audit viewer records
+   * them).
+   */
+  private _onGrantLifecycle(
+    payload: import("@shared/types/ipc/mcpServer").McpGrantLifecyclePayload
+  ): void {
+    if (payload.type === "grant.issued") {
+      // `expiresAt` is always set on `grant.issued`; bail defensively if a
+      // malformed payload omits it rather than seed a NaN countdown.
+      if (payload.expiresAt === undefined) return;
+      this._clearGrantEndedTimer();
+      this._patch({
+        activeGrant: {
+          sessionId: payload.sessionId,
+          toolId: payload.toolId,
+          expiresAt: payload.expiresAt,
+          ttlMs: payload.ttlMs,
+        },
+        grantEnded: null,
+      });
+      // The mint resolves the mismatch that triggered it. Idempotent with the
+      // fallback clear in `approveTierOnce`'s `.then` — whichever runs first.
+      this._clearTierMismatchIfStillCurrent(payload.sessionId, payload.toolId);
+      return;
+    }
+    if (payload.type === "grant.expired" || payload.type === "grant.revoked") {
+      const active = this._snapshot.activeGrant;
+      if (!active || active.sessionId !== payload.sessionId || active.toolId !== payload.toolId) {
+        return;
+      }
+      const reason = this._grantEndReason(payload);
+      this._clearGrantEndedTimer();
+      this._patch({
+        activeGrant: null,
+        grantEnded: reason ? { toolId: payload.toolId, reason } : null,
+      });
+      if (reason) this._armGrantEndedAutoDismiss();
+    }
+  }
+
+  /**
+   * The user-actionable subset of how a grant ended. Passive expiry and the
+   * 30-minute ceiling are worth a notice; a user-initiated revoke and session
+   * teardown/idle are not (the user did it, or the session is already gone).
+   */
+  private _grantEndReason(
+    payload: import("@shared/types/ipc/mcpServer").McpGrantLifecyclePayload
+  ): GrantEndReason | null {
+    if (payload.type === "grant.expired") return "expired";
+    return payload.revokedReason === "grant-ceiling" ? "grant-ceiling" : null;
+  }
+
+  private _clearGrantState(): void {
+    this._clearGrantEndedTimer();
+    this._patch({ activeGrant: null, grantEnded: null });
+  }
+
+  private _clearGrantEndedTimer(): void {
+    if (this._grantEndedBannerTimer) {
+      clearTimeout(this._grantEndedBannerTimer);
+      this._grantEndedBannerTimer = null;
+    }
+  }
+
+  private _armGrantEndedAutoDismiss(): void {
+    this._clearGrantEndedTimer();
+    this._grantEndedBannerTimer = setTimeout(() => {
+      this._grantEndedBannerTimer = null;
+      this._patch({ grantEnded: null });
+    }, GRANT_ENDED_BANNER_AUTO_DISMISS_MS);
   }
 
   private _revokePendingSession(): void {

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -921,6 +921,13 @@ describe("HelpSessionController — grant lifecycle (#10042)", () => {
       ttlMs: 900_000,
     });
     expect(ctrl.getSnapshot().activeGrant?.toolId).toBe("t1");
+    grantLifecycleListeners[0]?.({
+      type: "tier.decayed",
+      sessionId: "s1",
+      toolId: "*",
+      ttlMs: 900_000,
+    });
+    expect(ctrl.getSnapshot().activeGrant?.toolId).toBe("t1");
     ctrl.stop();
   });
 
@@ -947,9 +954,7 @@ describe("HelpSessionController — grant lifecycle (#10042)", () => {
     ctrl.stop();
   });
 
-  it("revokeGrant() revokes the session's grants and flags the in-flight state", async () => {
-    const ctrl = new HelpSessionController();
-    ctrl.start();
+  function issueGrant() {
     grantLifecycleListeners[0]?.({
       type: "grant.issued",
       sessionId: "s1",
@@ -957,12 +962,86 @@ describe("HelpSessionController — grant lifecycle (#10042)", () => {
       ttlMs: 900_000,
       expiresAt: Date.now() + 900_000,
     });
+  }
+
+  it("revokeGrant() revokes the session's grants and clears the countdown once the IPC settles", async () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    issueGrant();
     ctrl.revokeGrant();
     expect(ctrl.getSnapshot().isRevokingGrant).toBe(true);
     expect(mockMcpRevokeSessionGrants).toHaveBeenCalledWith({ sessionId: "s1" });
+    // Authoritative renderer-side fallback: even with no `grant.revoked`
+    // lifecycle event echoed back, the countdown clears when the IPC settles.
+    await vi.waitFor(() => {
+      expect(ctrl.getSnapshot().isRevokingGrant).toBe(false);
+      expect(ctrl.getSnapshot().activeGrant).toBeNull();
+    });
+    ctrl.stop();
+  });
+
+  it("revokeGrant() is a no-op while a revoke is already in flight", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    issueGrant();
+    let resolveRevoke: (() => void) | undefined;
+    mockMcpRevokeSessionGrants.mockReturnValueOnce(
+      new Promise<{ sessionId: string; revokedCount: number }>((resolve) => {
+        resolveRevoke = () => resolve({ sessionId: "s1", revokedCount: 1 });
+      })
+    );
+    ctrl.revokeGrant();
+    ctrl.revokeGrant();
+    expect(mockMcpRevokeSessionGrants).toHaveBeenCalledTimes(1);
+    resolveRevoke?.();
+    ctrl.stop();
+  });
+
+  it("revokeGrant() does not wipe a newer grant that arrived before the IPC settled", async () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    issueGrant();
+    let resolveRevoke: (() => void) | undefined;
+    mockMcpRevokeSessionGrants.mockReturnValueOnce(
+      new Promise<{ sessionId: string; revokedCount: number }>((resolve) => {
+        resolveRevoke = () => resolve({ sessionId: "s1", revokedCount: 1 });
+      })
+    );
+    ctrl.revokeGrant();
+    // A new grant for a different tool lands while the revoke is in flight.
+    const newerExpiry = Date.now() + 900_000;
+    grantLifecycleListeners[0]?.({
+      type: "grant.issued",
+      sessionId: "s1",
+      toolId: "t2",
+      ttlMs: 900_000,
+      expiresAt: newerExpiry,
+    });
+    resolveRevoke?.();
     await vi.waitFor(() => {
       expect(ctrl.getSnapshot().isRevokingGrant).toBe(false);
     });
+    // The settle must not clear the newer t2 grant — only the one we revoked.
+    expect(ctrl.getSnapshot().activeGrant?.toolId).toBe("t2");
+    ctrl.stop();
+  });
+
+  it("a teardown mid-revoke does not leak a disabled Revoke button into the next grant", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    issueGrant();
+    mockMcpRevokeSessionGrants.mockReturnValueOnce(
+      new Promise<{ sessionId: string; revokedCount: number }>(() => {
+        // never resolves — the teardown happens first
+      })
+    );
+    ctrl.revokeGrant();
+    expect(ctrl.getSnapshot().isRevokingGrant).toBe(true);
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.sessionId = "sess-1";
+    ctrl.handleTerminalPanelMissing({ terminalId: "term-1", terminalExists: false });
+    expect(ctrl.getSnapshot().isRevokingGrant).toBe(false);
+    expect(ctrl.getSnapshot().activeGrant).toBeNull();
     ctrl.stop();
   });
 

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -7,9 +7,11 @@ const {
   mockMcpOnToolCallSettled,
   mockMcpOnDisplayImage,
   mockMcpOnSessionRevoked,
+  mockMcpOnGrantLifecycle,
   mockMcpSetSessionTier,
   mockMcpIssueGrant,
   mockMcpResetDenialCounts,
+  mockMcpRevokeSessionGrants,
   mockSystemSleepOnSuspend,
   mockSystemSleepOnWake,
   systemSleepListeners,
@@ -18,6 +20,7 @@ const {
   toolSettledListeners,
   displayImageListeners,
   sessionRevokedListeners,
+  grantLifecycleListeners,
   helpPanelState,
   panelStoreState,
   projectStoreState,
@@ -27,6 +30,7 @@ const {
   mockMcpOnToolCallSettled: vi.fn(),
   mockMcpOnDisplayImage: vi.fn(),
   mockMcpOnSessionRevoked: vi.fn(),
+  mockMcpOnGrantLifecycle: vi.fn(),
   mockMcpSetSessionTier: vi.fn().mockResolvedValue(undefined),
   mockMcpIssueGrant: vi.fn().mockResolvedValue({
     sessionId: "",
@@ -35,6 +39,7 @@ const {
     expiresAt: Date.now() + 900_000,
   }),
   mockMcpResetDenialCounts: vi.fn().mockResolvedValue(undefined),
+  mockMcpRevokeSessionGrants: vi.fn().mockResolvedValue({ sessionId: "", revokedCount: 0 }),
   mockSystemSleepOnSuspend: vi.fn(),
   mockSystemSleepOnWake: vi.fn(),
   systemSleepListeners: {
@@ -46,6 +51,7 @@ const {
   toolSettledListeners: [] as Array<(payload: unknown) => void>,
   displayImageListeners: [] as Array<(payload: unknown) => void>,
   sessionRevokedListeners: [] as Array<(payload: unknown) => void>,
+  grantLifecycleListeners: [] as Array<(payload: unknown) => void>,
   helpPanelState: {
     isOpen: false,
     terminalId: null as string | null,
@@ -142,6 +148,7 @@ beforeEach(() => {
   toolSettledListeners.length = 0;
   displayImageListeners.length = 0;
   sessionRevokedListeners.length = 0;
+  grantLifecycleListeners.length = 0;
 
   mockMcpOnTierNotPermitted.mockReset();
   mockMcpOnTierNotPermitted.mockImplementation((cb: (payload: unknown) => void) => {
@@ -185,6 +192,14 @@ beforeEach(() => {
   });
   mockMcpResetDenialCounts.mockReset();
   mockMcpResetDenialCounts.mockResolvedValue(undefined);
+  mockMcpOnGrantLifecycle.mockReset();
+  mockMcpOnGrantLifecycle.mockImplementation((cb: (payload: unknown) => void) => {
+    grantLifecycleListeners.push(cb);
+    return () => {
+      const idx = grantLifecycleListeners.indexOf(cb);
+      if (idx >= 0) grantLifecycleListeners.splice(idx, 1);
+    };
+  });
   mockMcpSetSessionTier.mockReset();
   mockMcpSetSessionTier.mockResolvedValue(undefined);
   mockMcpIssueGrant.mockReset();
@@ -194,6 +209,8 @@ beforeEach(() => {
     ttlMs: 900_000,
     expiresAt: Date.now() + 900_000,
   });
+  mockMcpRevokeSessionGrants.mockReset();
+  mockMcpRevokeSessionGrants.mockResolvedValue({ sessionId: "", revokedCount: 1 });
   mockSystemSleepOnSuspend.mockReset();
   mockSystemSleepOnSuspend.mockImplementation((cb: () => void) => {
     systemSleepListeners.suspend.push(cb);
@@ -239,9 +256,11 @@ beforeEach(() => {
           onToolCallSettled: mockMcpOnToolCallSettled,
           onDisplayImage: mockMcpOnDisplayImage,
           onSessionRevoked: mockMcpOnSessionRevoked,
+          onGrantLifecycle: mockMcpOnGrantLifecycle,
           setSessionTier: mockMcpSetSessionTier,
           issueGrant: mockMcpIssueGrant,
           resetDenialCounts: mockMcpResetDenialCounts,
+          revokeSessionGrants: mockMcpRevokeSessionGrants,
         },
         git: { snapshotGet: vi.fn().mockResolvedValue(null) },
         terminal: { gracefulKill: vi.fn().mockResolvedValue(null) },
@@ -284,6 +303,7 @@ describe("HelpSessionController — lifecycle", () => {
     expect(toolSettledListeners).toHaveLength(1);
     expect(displayImageListeners).toHaveLength(1);
     expect(sessionRevokedListeners).toHaveLength(1);
+    expect(grantLifecycleListeners).toHaveLength(1);
     expect(systemSleepListeners.suspend).toHaveLength(1);
     expect(systemSleepListeners.wake).toHaveLength(1);
     ctrl.stop();
@@ -292,6 +312,7 @@ describe("HelpSessionController — lifecycle", () => {
     expect(toolSettledListeners).toHaveLength(0);
     expect(displayImageListeners).toHaveLength(0);
     expect(sessionRevokedListeners).toHaveLength(0);
+    expect(grantLifecycleListeners).toHaveLength(0);
     expect(systemSleepListeners.suspend).toHaveLength(0);
     expect(systemSleepListeners.wake).toHaveLength(0);
   });
@@ -732,6 +753,246 @@ describe("HelpSessionController — session revoked (#10017)", () => {
 
     ctrl.launch({ agentId: "claude" });
     expect(ctrl.getSnapshot().sessionRevoked).toBeNull();
+    ctrl.stop();
+  });
+});
+
+describe("HelpSessionController — grant lifecycle (#10042)", () => {
+  function armMismatch() {
+    tierListeners[0]?.({
+      sessionId: "s1",
+      toolId: "t1",
+      tier: "workbench",
+      targetTier: "action",
+    });
+  }
+
+  it("start() arms the grant lifecycle subscription", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    expect(mockMcpOnGrantLifecycle).toHaveBeenCalledTimes(1);
+    expect(grantLifecycleListeners).toHaveLength(1);
+    ctrl.stop();
+  });
+
+  it("grant.issued sets the active countdown and clears the prompting mismatch", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    armMismatch();
+    expect(ctrl.getSnapshot().tierMismatch).not.toBeNull();
+
+    const expiresAt = Date.now() + 900_000;
+    grantLifecycleListeners[0]?.({
+      type: "grant.issued",
+      sessionId: "s1",
+      toolId: "t1",
+      ttlMs: 900_000,
+      expiresAt,
+    });
+
+    expect(ctrl.getSnapshot().activeGrant).toEqual({
+      sessionId: "s1",
+      toolId: "t1",
+      ttlMs: 900_000,
+      expiresAt,
+    });
+    expect(ctrl.getSnapshot().tierMismatch).toBeNull();
+    expect(ctrl.getSnapshot().grantEnded).toBeNull();
+    ctrl.stop();
+  });
+
+  it("grant.issued without expiresAt is ignored rather than seeding a NaN countdown", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    grantLifecycleListeners[0]?.({
+      type: "grant.issued",
+      sessionId: "s1",
+      toolId: "t1",
+      ttlMs: 900_000,
+    });
+    expect(ctrl.getSnapshot().activeGrant).toBeNull();
+    ctrl.stop();
+  });
+
+  it("grant.expired retires the active grant and surfaces an 'expired' notice", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    grantLifecycleListeners[0]?.({
+      type: "grant.issued",
+      sessionId: "s1",
+      toolId: "t1",
+      ttlMs: 900_000,
+      expiresAt: Date.now() + 900_000,
+    });
+    grantLifecycleListeners[0]?.({
+      type: "grant.expired",
+      sessionId: "s1",
+      toolId: "t1",
+      ttlMs: 900_000,
+    });
+    expect(ctrl.getSnapshot().activeGrant).toBeNull();
+    expect(ctrl.getSnapshot().grantEnded).toEqual({ toolId: "t1", reason: "expired" });
+    ctrl.stop();
+  });
+
+  it("grant.revoked with grant-ceiling surfaces a ceiling notice", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    grantLifecycleListeners[0]?.({
+      type: "grant.issued",
+      sessionId: "s1",
+      toolId: "t1",
+      ttlMs: 900_000,
+      expiresAt: Date.now() + 900_000,
+    });
+    grantLifecycleListeners[0]?.({
+      type: "grant.revoked",
+      sessionId: "s1",
+      toolId: "t1",
+      ttlMs: 900_000,
+      revokedReason: "grant-ceiling",
+    });
+    expect(ctrl.getSnapshot().activeGrant).toBeNull();
+    expect(ctrl.getSnapshot().grantEnded).toEqual({ toolId: "t1", reason: "grant-ceiling" });
+    ctrl.stop();
+  });
+
+  it.each(["user", "session-ended", "session-idle"] as const)(
+    "grant.revoked with reason %s clears the grant silently (no notice)",
+    (revokedReason) => {
+      const ctrl = new HelpSessionController();
+      ctrl.start();
+      grantLifecycleListeners[0]?.({
+        type: "grant.issued",
+        sessionId: "s1",
+        toolId: "t1",
+        ttlMs: 900_000,
+        expiresAt: Date.now() + 900_000,
+      });
+      grantLifecycleListeners[0]?.({
+        type: "grant.revoked",
+        sessionId: "s1",
+        toolId: "t1",
+        ttlMs: 900_000,
+        revokedReason,
+      });
+      expect(ctrl.getSnapshot().activeGrant).toBeNull();
+      expect(ctrl.getSnapshot().grantEnded).toBeNull();
+      ctrl.stop();
+    }
+  );
+
+  it("a lapse for a different tool leaves the on-screen countdown intact", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    grantLifecycleListeners[0]?.({
+      type: "grant.issued",
+      sessionId: "s1",
+      toolId: "t1",
+      ttlMs: 900_000,
+      expiresAt: Date.now() + 900_000,
+    });
+    // A stale expiry for a tool we're not counting down must not clear t1.
+    grantLifecycleListeners[0]?.({
+      type: "grant.expired",
+      sessionId: "s1",
+      toolId: "other-tool",
+      ttlMs: 900_000,
+    });
+    expect(ctrl.getSnapshot().activeGrant?.toolId).toBe("t1");
+    expect(ctrl.getSnapshot().grantEnded).toBeNull();
+    ctrl.stop();
+  });
+
+  it("tier.elevated / tier.decayed do not disturb the per-tool countdown", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    grantLifecycleListeners[0]?.({
+      type: "grant.issued",
+      sessionId: "s1",
+      toolId: "t1",
+      ttlMs: 900_000,
+      expiresAt: Date.now() + 900_000,
+    });
+    grantLifecycleListeners[0]?.({
+      type: "tier.elevated",
+      sessionId: "s1",
+      toolId: "*",
+      ttlMs: 900_000,
+    });
+    expect(ctrl.getSnapshot().activeGrant?.toolId).toBe("t1");
+    ctrl.stop();
+  });
+
+  it("a fresh tier denial supersedes a lingering 'approval ended' notice", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    grantLifecycleListeners[0]?.({
+      type: "grant.issued",
+      sessionId: "s1",
+      toolId: "t1",
+      ttlMs: 900_000,
+      expiresAt: Date.now() + 900_000,
+    });
+    grantLifecycleListeners[0]?.({
+      type: "grant.expired",
+      sessionId: "s1",
+      toolId: "t1",
+      ttlMs: 900_000,
+    });
+    expect(ctrl.getSnapshot().grantEnded).not.toBeNull();
+    armMismatch();
+    expect(ctrl.getSnapshot().grantEnded).toBeNull();
+    expect(ctrl.getSnapshot().tierMismatch).not.toBeNull();
+    ctrl.stop();
+  });
+
+  it("revokeGrant() revokes the session's grants and flags the in-flight state", async () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    grantLifecycleListeners[0]?.({
+      type: "grant.issued",
+      sessionId: "s1",
+      toolId: "t1",
+      ttlMs: 900_000,
+      expiresAt: Date.now() + 900_000,
+    });
+    ctrl.revokeGrant();
+    expect(ctrl.getSnapshot().isRevokingGrant).toBe(true);
+    expect(mockMcpRevokeSessionGrants).toHaveBeenCalledWith({ sessionId: "s1" });
+    await vi.waitFor(() => {
+      expect(ctrl.getSnapshot().isRevokingGrant).toBe(false);
+    });
+    ctrl.stop();
+  });
+
+  it("revokeGrant() is a no-op when there is no active grant", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    ctrl.revokeGrant();
+    expect(mockMcpRevokeSessionGrants).not.toHaveBeenCalled();
+    ctrl.stop();
+  });
+
+  it("dismissGrantEnded() clears the notice", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    grantLifecycleListeners[0]?.({
+      type: "grant.issued",
+      sessionId: "s1",
+      toolId: "t1",
+      ttlMs: 900_000,
+      expiresAt: Date.now() + 900_000,
+    });
+    grantLifecycleListeners[0]?.({
+      type: "grant.expired",
+      sessionId: "s1",
+      toolId: "t1",
+      ttlMs: 900_000,
+    });
+    expect(ctrl.getSnapshot().grantEnded).not.toBeNull();
+    ctrl.dismissGrantEnded();
+    expect(ctrl.getSnapshot().grantEnded).toBeNull();
     ctrl.stop();
   });
 });

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -1026,6 +1026,20 @@ describe("HelpSessionController — grant lifecycle (#10042)", () => {
     ctrl.stop();
   });
 
+  it("a failed revoke keeps the countdown banner up as the retry surface", async () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    issueGrant();
+    mockMcpRevokeSessionGrants.mockRejectedValueOnce(new Error("ipc boom"));
+    ctrl.revokeGrant();
+    await vi.waitFor(() => {
+      expect(ctrl.getSnapshot().isRevokingGrant).toBe(false);
+    });
+    // Revoke failed → the grant is still live, so the banner must stay put.
+    expect(ctrl.getSnapshot().activeGrant?.toolId).toBe("t1");
+    ctrl.stop();
+  });
+
   it("a teardown mid-revoke does not leak a disabled Revoke button into the next grant", () => {
     const ctrl = new HelpSessionController();
     ctrl.start();


### PR DESCRIPTION
## Summary

- Clicking "Approve once" on the MCP tier-mismatch banner mints a per-tool grant (15-min default, 30-min ceiling), but the UI showed nothing afterwards — no countdown, no expiry feedback, no revoke path. The next denial 16 minutes later was indistinguishable from a fresh one.
- `HelpSessionController` now subscribes to `window.electron.mcpServer.onGrantLifecycle`: `grant.issued` arms a live countdown (`activeGrant`), `grant.expired` / `grant.revoked` retire it. New snapshot fields — `activeGrant`, `grantEnded`, `isRevokingGrant` — drive two new banners.
- `GrantActiveBanner` (Tier-1 ambient) shows a mm:ss countdown derived from `expiresAt` without polling, with a "Revoke access" control. `GrantEndedBanner` distinguishes passive expiry from the 30-minute ceiling. Silent revoke reasons (`user` / `session-ended` / `session-idle`) clear without showing the ended notice.

Resolves #10042

## Changes

- `HelpSessionController` — consumes `onGrantLifecycle` events; adds `activeGrant`, `grantEnded`, `isRevokingGrant` snapshot fields; `revokeGrant()` clears the countdown on success only (failed revoke keeps the banner as its own retry surface); `dismissGrantEnded()` clears the ended notice; teardown-safe (no leaked disabled-button state).
- `HelpPanelBanners` — adds `GrantActiveBanner` and `GrantEndedBanner`; countdown derives from `expiresAt` with `setInterval` cleanup on unmount; reason-aware copy that avoids jargon.
- `HelpPanel` — wires both banners into the existing banner stack.
- Gaps 3 and the audit-viewer half of gap 4 from #10042 were already addressed on `develop` (`McpAuditLogViewer` already renders grant records including `revokedReason`) — no change needed there.

## Testing

- `HelpSessionController` suite: `grant.issued` / `grant.expired` / `grant.revoked`-by-reason, tool-scoping guard, `tier.elevated` / `tier.decayed` no-ops, fresh-denial supersede, `revokeGrant()` success / failure / in-flight / teardown paths.
- `HelpPanelBanners` suite: countdown derivation, clamp, interval cleanup, reason-distinct copy, revoke and dismiss wiring.
- Local CI green: lint, format, typecheck, build, 32686 unit tests.