### PR TITLE
fix(testing): align createMockHost register* with PluginService

### DIFF
--- a/shared/testing/__tests__/createMockHost.test.ts
+++ b/shared/testing/__tests__/createMockHost.test.ts
@@ -61,7 +61,7 @@ describe("createMockHost", () => {
           null as unknown as Parameters<typeof host.registerAction>[0],
           vi.fn() as unknown as Parameters<typeof host.registerAction>[1]
         )
-      ).toThrow(/descriptor must be an object/);
+      ).toThrow("registerAction: descriptor must be an object");
       expect(() =>
         host.registerAction(
           undefined as unknown as Parameters<typeof host.registerAction>[0],
@@ -83,7 +83,7 @@ describe("createMockHost", () => {
           sampleAction,
           null as unknown as Parameters<typeof host.registerAction>[1]
         )
-      ).toThrow(/handler must be a function/);
+      ).toThrow("registerAction: handler must be a function");
     });
 
     it("rejects missing or empty descriptor.id", () => {
@@ -93,7 +93,7 @@ describe("createMockHost", () => {
           { ...sampleAction, id: "" },
           vi.fn() as unknown as Parameters<typeof host.registerAction>[1]
         )
-      ).toThrow(/descriptor\.id must be a non-empty string/);
+      ).toThrow("registerAction: descriptor.id must be a non-empty string");
       expect(() =>
         host.registerAction(
           { ...sampleAction, id: undefined as unknown as string },
@@ -125,6 +125,103 @@ describe("createMockHost", () => {
         )
       ).not.toThrow();
       expect(host.registeredActions).toHaveLength(1);
+    });
+
+    it("accepts a descriptor.id where the FULL plugin id appears as a substring but not a prefix", () => {
+      // Stronger than the "hello.greet" test: the entire plugin id
+      // "daintree.hello" is contained in the descriptor id, but the id does
+      // not start with the plugin prefix. Catches a regression to a
+      // `includes(pluginId)` check, which would silently reject this case.
+      const host = createMockHost({ pluginId: "daintree.hello" });
+      expect(() =>
+        host.registerAction(
+          { ...sampleAction, id: "x.daintree.hello.greet" },
+          vi.fn() as unknown as Parameters<typeof host.registerAction>[1]
+        )
+      ).not.toThrow();
+      expect(host.registeredActions).toHaveLength(1);
+    });
+
+    it("rejects a namespaced id that violates the id-format regex", () => {
+      // The production regex requires a dot in the namespaced id
+      // (`{pluginId}.{actionId}`). "Bad Id" — when namespaced against
+      // `daintree.hello` becomes `daintree.hello.Bad Id`, which contains a
+      // space and uppercase middle characters that fail the regex.
+      const host = createMockHost({ pluginId: "daintree.hello" });
+      expect(() =>
+        host.registerAction(
+          { ...sampleAction, id: "Bad Id" },
+          vi.fn() as unknown as Parameters<typeof host.registerAction>[1]
+        )
+      ).toThrow(/is invalid/);
+    });
+
+    it("rejects a non-string/empty/whitespace-only title", () => {
+      const host = createMockHost();
+      expect(() =>
+        host.registerAction(
+          { ...sampleAction, title: "" },
+          vi.fn() as unknown as Parameters<typeof host.registerAction>[1]
+        )
+      ).toThrow("registerAction: descriptor.title must be a non-empty string");
+      expect(() =>
+        host.registerAction(
+          { ...sampleAction, title: "   " },
+          vi.fn() as unknown as Parameters<typeof host.registerAction>[1]
+        )
+      ).toThrow(/descriptor\.title must be a non-empty string/);
+      expect(() =>
+        host.registerAction(
+          { ...sampleAction, title: 42 as unknown as string },
+          vi.fn() as unknown as Parameters<typeof host.registerAction>[1]
+        )
+      ).toThrow(/descriptor\.title must be a non-empty string/);
+    });
+
+    it("rejects a non-string description", () => {
+      const host = createMockHost();
+      expect(() =>
+        host.registerAction(
+          { ...sampleAction, description: 42 as unknown as string },
+          vi.fn() as unknown as Parameters<typeof host.registerAction>[1]
+        )
+      ).toThrow("registerAction: descriptor.description must be a string");
+    });
+
+    it("rejects a non-string/empty/whitespace-only category", () => {
+      const host = createMockHost();
+      expect(() =>
+        host.registerAction(
+          { ...sampleAction, category: "" },
+          vi.fn() as unknown as Parameters<typeof host.registerAction>[1]
+        )
+      ).toThrow("registerAction: descriptor.category must be a non-empty string");
+      expect(() =>
+        host.registerAction(
+          { ...sampleAction, category: "   " },
+          vi.fn() as unknown as Parameters<typeof host.registerAction>[1]
+        )
+      ).toThrow(/descriptor\.category must be a non-empty string/);
+    });
+
+    it("rejects an unknown kind", () => {
+      const host = createMockHost();
+      expect(() =>
+        host.registerAction(
+          { ...sampleAction, kind: "bogus" as unknown as "command" },
+          vi.fn() as unknown as Parameters<typeof host.registerAction>[1]
+        )
+      ).toThrow(/descriptor\.kind/);
+    });
+
+    it("rejects a danger outside the safe|confirm set", () => {
+      const host = createMockHost();
+      expect(() =>
+        host.registerAction(
+          { ...sampleAction, danger: "restricted" as unknown as "safe" },
+          vi.fn() as unknown as Parameters<typeof host.registerAction>[1]
+        )
+      ).toThrow(/descriptor\.danger/);
     });
   });
 
@@ -245,9 +342,13 @@ describe("createMockHost", () => {
         typeof host.registerForgeProvider
       >[1];
       const dispose1 = host.registerForgeProvider({ id: "ghe" }, impl);
-      host.registerForgeProvider({ id: "ghe" }, impl);
+      const dispose2 = host.registerForgeProvider({ id: "ghe" }, impl);
       expect(host.registeredForgeProviders).toHaveLength(1);
       dispose1();
+      expect(host.registeredForgeProviders).toHaveLength(0);
+      // The second disposer is now stale (its identity-guard misses) — it
+      // must be a no-op, not a throw.
+      expect(() => dispose2()).not.toThrow();
       expect(host.registeredForgeProviders).toHaveLength(0);
     });
 
@@ -287,8 +388,11 @@ describe("createMockHost", () => {
         typeof host.registerForgeProvider
       >[1];
       expect(() => host.registerForgeProvider({ id: "" }, impl)).toThrow(
-        /descriptor\.id must be a non-empty string/
+        "registerForgeProvider: descriptor.id must be a non-empty string"
       );
+      // Boundary: "0" is a non-empty string and should be accepted — pins
+      // against a `!descriptor.id` regression.
+      expect(() => host.registerForgeProvider({ id: "0" }, impl)).not.toThrow();
     });
 
     it("rejects null/non-object impls", () => {
@@ -345,9 +449,12 @@ describe("createMockHost", () => {
       const host = createMockHost();
       const impl = { provideDecorations: vi.fn(async () => ({})) };
       const dispose1 = host.registerFileDecorationProvider({ id: "hello" }, impl);
-      host.registerFileDecorationProvider({ id: "hello" }, impl);
+      const dispose2 = host.registerFileDecorationProvider({ id: "hello" }, impl);
       expect(host.registeredFileDecorationProviders).toHaveLength(1);
       dispose1();
+      expect(host.registeredFileDecorationProviders).toHaveLength(0);
+      // The second disposer is now stale — must be a no-op, not a throw.
+      expect(() => dispose2()).not.toThrow();
       expect(host.registeredFileDecorationProviders).toHaveLength(0);
     });
 
@@ -375,8 +482,10 @@ describe("createMockHost", () => {
       const host = createMockHost();
       const impl = { provideDecorations: vi.fn(async () => ({})) };
       expect(() => host.registerFileDecorationProvider({ id: "" }, impl)).toThrow(
-        /descriptor\.id must be a non-empty string/
+        "registerFileDecorationProvider: descriptor.id must be a non-empty string"
       );
+      // Boundary: "0" is a non-empty string and should be accepted.
+      expect(() => host.registerFileDecorationProvider({ id: "0" }, impl)).not.toThrow();
     });
 
     it("rejects impls missing the provideDecorations function", () => {

--- a/shared/testing/__tests__/createMockHost.test.ts
+++ b/shared/testing/__tests__/createMockHost.test.ts
@@ -53,6 +53,81 @@ describe("createMockHost", () => {
     expect(h1).not.toHaveBeenCalled();
   });
 
+  describe("registerAction validation", () => {
+    it("rejects null/undefined/non-object descriptors", () => {
+      const host = createMockHost();
+      expect(() =>
+        host.registerAction(
+          null as unknown as Parameters<typeof host.registerAction>[0],
+          vi.fn() as unknown as Parameters<typeof host.registerAction>[1]
+        )
+      ).toThrow(/descriptor must be an object/);
+      expect(() =>
+        host.registerAction(
+          undefined as unknown as Parameters<typeof host.registerAction>[0],
+          vi.fn() as unknown as Parameters<typeof host.registerAction>[1]
+        )
+      ).toThrow(/descriptor must be an object/);
+      expect(() =>
+        host.registerAction(
+          "greet" as unknown as Parameters<typeof host.registerAction>[0],
+          vi.fn() as unknown as Parameters<typeof host.registerAction>[1]
+        )
+      ).toThrow(/descriptor must be an object/);
+    });
+
+    it("rejects non-function handlers", () => {
+      const host = createMockHost();
+      expect(() =>
+        host.registerAction(
+          sampleAction,
+          null as unknown as Parameters<typeof host.registerAction>[1]
+        )
+      ).toThrow(/handler must be a function/);
+    });
+
+    it("rejects missing or empty descriptor.id", () => {
+      const host = createMockHost();
+      expect(() =>
+        host.registerAction(
+          { ...sampleAction, id: "" },
+          vi.fn() as unknown as Parameters<typeof host.registerAction>[1]
+        )
+      ).toThrow(/descriptor\.id must be a non-empty string/);
+      expect(() =>
+        host.registerAction(
+          { ...sampleAction, id: undefined as unknown as string },
+          vi.fn() as unknown as Parameters<typeof host.registerAction>[1]
+        )
+      ).toThrow(/descriptor\.id must be a non-empty string/);
+    });
+
+    it("rejects a descriptor.id that already starts with the plugin prefix", () => {
+      const host = createMockHost({ pluginId: "daintree.hello" });
+      expect(() =>
+        host.registerAction(
+          { ...sampleAction, id: "daintree.hello.greet" },
+          vi.fn() as unknown as Parameters<typeof host.registerAction>[1]
+        )
+      ).toThrow(/must not include the plugin prefix/);
+    });
+
+    it("accepts a descriptor.id that merely contains the plugin id as a substring", () => {
+      // Substring ≠ prefix: "hello.greet" against pluginId "daintree.hello"
+      // is not a prefixed form, so the host namespaces it to
+      // "daintree.hello.hello.greet". The real PluginService enforces the
+      // startsWith check, not a containment check.
+      const host = createMockHost({ pluginId: "daintree.hello" });
+      expect(() =>
+        host.registerAction(
+          { ...sampleAction, id: "hello.greet" },
+          vi.fn() as unknown as Parameters<typeof host.registerAction>[1]
+        )
+      ).not.toThrow();
+      expect(host.registeredActions).toHaveLength(1);
+    });
+  });
+
   it("records registerHandler calls", () => {
     const host = createMockHost();
     const handler = vi.fn();
@@ -125,6 +200,114 @@ describe("createMockHost", () => {
     expect(host.registeredForgeProviders).toHaveLength(0);
   });
 
+  describe("registerForgeProvider", () => {
+    it("replaces a prior registration with the same id (replace-by-id)", () => {
+      const host = createMockHost();
+      const impl1 = { parseRemote: vi.fn() } as unknown as Parameters<
+        typeof host.registerForgeProvider
+      >[1];
+      const impl2 = { parseRemote: vi.fn() } as unknown as Parameters<
+        typeof host.registerForgeProvider
+      >[1];
+      host.registerForgeProvider({ id: "ghe" }, impl1);
+      host.registerForgeProvider({ id: "ghe" }, impl2);
+      expect(host.registeredForgeProviders).toHaveLength(1);
+      expect(host.registeredForgeProviders[0]?.impl).toBe(impl2);
+    });
+
+    it("makes the prior disposer inert when the id is re-registered with a different impl", () => {
+      // Matches `unregisterForgeProviderImpl(pluginId, contributionId, expected)`
+      // semantics: a stale disposer (captured against the first impl) must not
+      // remove the second impl that has overwritten the slot.
+      const host = createMockHost();
+      const impl1 = { parseRemote: vi.fn() } as unknown as Parameters<
+        typeof host.registerForgeProvider
+      >[1];
+      const impl2 = { parseRemote: vi.fn() } as unknown as Parameters<
+        typeof host.registerForgeProvider
+      >[1];
+      const dispose1 = host.registerForgeProvider({ id: "ghe" }, impl1);
+      const dispose2 = host.registerForgeProvider({ id: "ghe" }, impl2);
+      dispose1(); // stale — should no-op
+      expect(host.registeredForgeProviders).toHaveLength(1);
+      expect(host.registeredForgeProviders[0]?.impl).toBe(impl2);
+      dispose2(); // fresh — should remove
+      expect(host.registeredForgeProviders).toHaveLength(0);
+    });
+
+    it("removes the active entry when the same impl is re-registered and the prior disposer fires", () => {
+      // Pinned case: if the second registration passes the same impl, the
+      // identity guard's `currentImpl === capturedImpl` check matches and the
+      // prior disposer does remove. This mirrors the production
+      // `expected` argument's identity comparison, not a "newer wins" rule.
+      const host = createMockHost();
+      const impl = { parseRemote: vi.fn() } as unknown as Parameters<
+        typeof host.registerForgeProvider
+      >[1];
+      const dispose1 = host.registerForgeProvider({ id: "ghe" }, impl);
+      host.registerForgeProvider({ id: "ghe" }, impl);
+      expect(host.registeredForgeProviders).toHaveLength(1);
+      dispose1();
+      expect(host.registeredForgeProviders).toHaveLength(0);
+    });
+
+    it("disposer is idempotent (calling twice is a no-op)", () => {
+      const host = createMockHost();
+      const impl = { parseRemote: vi.fn() } as unknown as Parameters<
+        typeof host.registerForgeProvider
+      >[1];
+      const dispose = host.registerForgeProvider({ id: "ghe" }, impl);
+      dispose();
+      dispose();
+      expect(host.registeredForgeProviders).toHaveLength(0);
+    });
+
+    it("rejects null/non-object descriptors", () => {
+      const host = createMockHost();
+      const impl = { parseRemote: vi.fn() } as unknown as Parameters<
+        typeof host.registerForgeProvider
+      >[1];
+      expect(() =>
+        host.registerForgeProvider(
+          null as unknown as Parameters<typeof host.registerForgeProvider>[0],
+          impl
+        )
+      ).toThrow(/descriptor must be an object/);
+      expect(() =>
+        host.registerForgeProvider(
+          "ghe" as unknown as Parameters<typeof host.registerForgeProvider>[0],
+          impl
+        )
+      ).toThrow(/descriptor must be an object/);
+    });
+
+    it("rejects missing or empty descriptor.id", () => {
+      const host = createMockHost();
+      const impl = { parseRemote: vi.fn() } as unknown as Parameters<
+        typeof host.registerForgeProvider
+      >[1];
+      expect(() => host.registerForgeProvider({ id: "" }, impl)).toThrow(
+        /descriptor\.id must be a non-empty string/
+      );
+    });
+
+    it("rejects null/non-object impls", () => {
+      const host = createMockHost();
+      expect(() =>
+        host.registerForgeProvider(
+          { id: "ghe" },
+          null as unknown as Parameters<typeof host.registerForgeProvider>[1]
+        )
+      ).toThrow(/impl must be an object/);
+      expect(() =>
+        host.registerForgeProvider(
+          { id: "ghe" },
+          "not-an-object" as unknown as Parameters<typeof host.registerForgeProvider>[1]
+        )
+      ).toThrow(/impl must be an object/);
+    });
+  });
+
   it("registers file-decoration providers and unregisters via disposer", () => {
     const host = createMockHost();
     const impl = { provideDecorations: vi.fn(async () => ({})) };
@@ -132,6 +315,94 @@ describe("createMockHost", () => {
     expect(host.registeredFileDecorationProviders).toHaveLength(1);
     dispose();
     expect(host.registeredFileDecorationProviders).toHaveLength(0);
+  });
+
+  describe("registerFileDecorationProvider", () => {
+    it("replaces a prior registration with the same id (replace-by-id)", () => {
+      const host = createMockHost();
+      const impl1 = { provideDecorations: vi.fn(async () => ({})) };
+      const impl2 = { provideDecorations: vi.fn(async () => ({})) };
+      host.registerFileDecorationProvider({ id: "hello" }, impl1);
+      host.registerFileDecorationProvider({ id: "hello" }, impl2);
+      expect(host.registeredFileDecorationProviders).toHaveLength(1);
+      expect(host.registeredFileDecorationProviders[0]?.impl).toBe(impl2);
+    });
+
+    it("makes the prior disposer inert when the id is re-registered with a different impl", () => {
+      const host = createMockHost();
+      const impl1 = { provideDecorations: vi.fn(async () => ({})) };
+      const impl2 = { provideDecorations: vi.fn(async () => ({})) };
+      const dispose1 = host.registerFileDecorationProvider({ id: "hello" }, impl1);
+      const dispose2 = host.registerFileDecorationProvider({ id: "hello" }, impl2);
+      dispose1(); // stale — should no-op
+      expect(host.registeredFileDecorationProviders).toHaveLength(1);
+      expect(host.registeredFileDecorationProviders[0]?.impl).toBe(impl2);
+      dispose2(); // fresh — should remove
+      expect(host.registeredFileDecorationProviders).toHaveLength(0);
+    });
+
+    it("removes the active entry when the same impl is re-registered and the prior disposer fires", () => {
+      const host = createMockHost();
+      const impl = { provideDecorations: vi.fn(async () => ({})) };
+      const dispose1 = host.registerFileDecorationProvider({ id: "hello" }, impl);
+      host.registerFileDecorationProvider({ id: "hello" }, impl);
+      expect(host.registeredFileDecorationProviders).toHaveLength(1);
+      dispose1();
+      expect(host.registeredFileDecorationProviders).toHaveLength(0);
+    });
+
+    it("disposer is idempotent (calling twice is a no-op)", () => {
+      const host = createMockHost();
+      const impl = { provideDecorations: vi.fn(async () => ({})) };
+      const dispose = host.registerFileDecorationProvider({ id: "hello" }, impl);
+      dispose();
+      dispose();
+      expect(host.registeredFileDecorationProviders).toHaveLength(0);
+    });
+
+    it("rejects null/non-object descriptors", () => {
+      const host = createMockHost();
+      const impl = { provideDecorations: vi.fn(async () => ({})) };
+      expect(() =>
+        host.registerFileDecorationProvider(
+          null as unknown as Parameters<typeof host.registerFileDecorationProvider>[0],
+          impl
+        )
+      ).toThrow(/descriptor must be an object/);
+    });
+
+    it("rejects missing or empty descriptor.id", () => {
+      const host = createMockHost();
+      const impl = { provideDecorations: vi.fn(async () => ({})) };
+      expect(() => host.registerFileDecorationProvider({ id: "" }, impl)).toThrow(
+        /descriptor\.id must be a non-empty string/
+      );
+    });
+
+    it("rejects impls missing the provideDecorations function", () => {
+      const host = createMockHost();
+      expect(() =>
+        host.registerFileDecorationProvider(
+          { id: "hello" },
+          {} as unknown as Parameters<typeof host.registerFileDecorationProvider>[1]
+        )
+      ).toThrow(/provideDecorations/);
+      expect(() =>
+        host.registerFileDecorationProvider({ id: "hello" }, {
+          provideDecorations: "not a fn",
+        } as unknown as Parameters<typeof host.registerFileDecorationProvider>[1])
+      ).toThrow(/provideDecorations/);
+    });
+
+    it("rejects null/non-object impls", () => {
+      const host = createMockHost();
+      expect(() =>
+        host.registerFileDecorationProvider(
+          { id: "hello" },
+          null as unknown as Parameters<typeof host.registerFileDecorationProvider>[1]
+        )
+      ).toThrow(/provideDecorations/);
+    });
   });
 
   describe("settings", () => {

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -112,6 +112,18 @@ export interface CreateMockHostOptions {
   dispatch?: (actionId: string, args?: unknown) => Promise<ActionDispatchResult>;
 }
 
+/**
+ * Mirrors the action-id regex and kind/danger sets in
+ * `electron/services/PluginService.ts` `PLUGIN_ACTION_ID_RE` /
+ * `PLUGIN_ACTION_KINDS` / `PLUGIN_ACTION_DANGERS`. The mock can't import
+ * those (cross-process boundary), so the values are duplicated here and the
+ * production constants are the source of truth. If the production regex or
+ * sets change, mirror the change here.
+ */
+const PLUGIN_ACTION_ID_RE = /^[a-z0-9][a-z0-9-]*\.[a-z0-9][a-zA-Z0-9._-]*$/;
+const PLUGIN_ACTION_KINDS = new Set(["command", "query"]);
+const PLUGIN_ACTION_DANGERS = new Set(["safe", "confirm"]);
+
 export function createMockHost(options: CreateMockHostOptions = {}): PluginHostApi & MockHostState {
   const pluginId = options.pluginId ?? "test.mock";
   let activeWorktree: PluginWorktreeSnapshot | null = options.activeWorktree ?? null;
@@ -195,10 +207,13 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
     registerAction(descriptor, handler) {
       // Mirrors PluginService.createHost L1577-L1631. Validation order matches
       // production: non-object descriptor, non-function handler, non-empty
-      // string id, plugin-prefix not already in id. Re-registering the same id
-      // replaces the prior descriptor + handler (replace-by-id, see
-      // host-api.md). A plugin test that calls registerAction with the same id
-      // twice should see the second call win, not accumulate two entries.
+      // string id, plugin-prefix not already in id, then the
+      // validateAndBuildActionDescriptor checks (L2686-L2723) applied to the
+      // namespaced id (since production namespaces before that step).
+      // Re-registering the same id replaces the prior descriptor + handler
+      // (replace-by-id, see host-api.md). A plugin test that calls
+      // registerAction with the same id twice should see the second call win,
+      // not accumulate two entries.
       if (!descriptor || typeof descriptor !== "object") {
         throw new Error("registerAction: descriptor must be an object");
       }
@@ -211,6 +226,40 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
       if (descriptor.id.startsWith(`${pluginId}.`)) {
         throw new Error(
           `registerAction: descriptor.id "${descriptor.id}" must not include the plugin prefix`
+        );
+      }
+      // Mirrors validateAndBuildActionDescriptor (L2697-L2723). The mock
+      // namespaces the id the same way production does and runs the same
+      // checks against the namespaced form, so a plugin test that registers
+      // an action the production host would reject fails the mock in the
+      // same way — no "passes the mock, throws at activation" gap.
+      const namespacedId = `${pluginId}.${descriptor.id}`;
+      if (!PLUGIN_ACTION_ID_RE.test(namespacedId)) {
+        throw new Error(
+          `registerAction: descriptor.id "${descriptor.id}" (namespaced to "${namespacedId}") is invalid. Expected "{pluginId}.{actionId}" (lowercase start, alphanumerics, dot/dash/underscore).`
+        );
+      }
+      if (typeof descriptor.title !== "string" || !descriptor.title.trim()) {
+        throw new Error("registerAction: descriptor.title must be a non-empty string");
+      }
+      if (typeof descriptor.description !== "string") {
+        throw new Error("registerAction: descriptor.description must be a string");
+      }
+      if (typeof descriptor.category !== "string" || !descriptor.category.trim()) {
+        throw new Error("registerAction: descriptor.category must be a non-empty string");
+      }
+      if (!PLUGIN_ACTION_KINDS.has(descriptor.kind)) {
+        throw new Error(
+          `registerAction: descriptor.kind "${descriptor.kind}" is invalid (must be one of: ${[
+            ...PLUGIN_ACTION_KINDS,
+          ].join(", ")})`
+        );
+      }
+      if (!PLUGIN_ACTION_DANGERS.has(descriptor.danger)) {
+        throw new Error(
+          `registerAction: descriptor.danger "${descriptor.danger}" is invalid (must be one of: ${[
+            ...PLUGIN_ACTION_DANGERS,
+          ].join(", ")})`
         );
       }
       const existing = registeredActions.findIndex((r) => r.descriptor.id === descriptor.id);

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -193,10 +193,26 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
   const host: PluginHostApi & MockHostState = {
     pluginId,
     registerAction(descriptor, handler) {
-      // Mirror PluginService.registerAction: re-registering the same id
-      // replaces the prior descriptor + handler. Without this, the recording
-      // array would diverge from production semantics and any plugin test
-      // that re-registers an action would silently dispatch the stale handler.
+      // Mirrors PluginService.createHost L1577-L1631. Validation order matches
+      // production: non-object descriptor, non-function handler, non-empty
+      // string id, plugin-prefix not already in id. Re-registering the same id
+      // replaces the prior descriptor + handler (replace-by-id, see
+      // host-api.md). A plugin test that calls registerAction with the same id
+      // twice should see the second call win, not accumulate two entries.
+      if (!descriptor || typeof descriptor !== "object") {
+        throw new Error("registerAction: descriptor must be an object");
+      }
+      if (typeof handler !== "function") {
+        throw new Error("registerAction: handler must be a function");
+      }
+      if (typeof descriptor.id !== "string" || descriptor.id.length === 0) {
+        throw new Error("registerAction: descriptor.id must be a non-empty string");
+      }
+      if (descriptor.id.startsWith(`${pluginId}.`)) {
+        throw new Error(
+          `registerAction: descriptor.id "${descriptor.id}" must not include the plugin prefix`
+        );
+      }
       const existing = registeredActions.findIndex((r) => r.descriptor.id === descriptor.id);
       if (existing >= 0) {
         registeredActions[existing] = { descriptor, handler };
@@ -256,24 +272,81 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
       };
     },
     registerForgeProvider(descriptor, impl) {
-      const record: RegisteredForgeProviderRecord = { descriptor, impl };
-      registeredForgeProviders.push(record);
+      // Mirrors PluginService.createHost L1738-L1817. Validation order matches
+      // production: non-object descriptor, non-empty string id, non-object impl.
+      // The manifest-declared-id check is intentionally skipped — the mock has
+      // no manifest model (see issue #9878). Re-registering the same id
+      // replaces the prior binding (replace-by-id). The disposer's identity
+      // guard compares the captured `impl` reference against the currently
+      // active entry's `impl`, matching `unregisterForgeProviderImpl`'s
+      // `expected` argument: a stale disposer from a re-bound id is a no-op.
+      if (!descriptor || typeof descriptor !== "object") {
+        throw new Error("registerForgeProvider: descriptor must be an object");
+      }
+      if (typeof descriptor.id !== "string" || descriptor.id.length === 0) {
+        throw new Error("registerForgeProvider: descriptor.id must be a non-empty string");
+      }
+      if (!impl || typeof impl !== "object") {
+        throw new Error("registerForgeProvider: impl must be an object");
+      }
+      const contributionId = descriptor.id;
+      const existing = registeredForgeProviders.findIndex(
+        (r) => r.descriptor.id === contributionId
+      );
+      if (existing >= 0) {
+        registeredForgeProviders[existing] = { descriptor, impl };
+      } else {
+        registeredForgeProviders.push({ descriptor, impl });
+      }
       let disposed = false;
       return () => {
         if (disposed) return;
         disposed = true;
-        const i = registeredForgeProviders.indexOf(record);
+        // Identity guard: only remove if the currently active entry is still
+        // the one this disposer was captured against. A re-registration with a
+        // different impl invalidates the prior disposer (matches production).
+        const i = registeredForgeProviders.findIndex(
+          (r) => r.descriptor.id === contributionId && r.impl === impl
+        );
         if (i >= 0) registeredForgeProviders.splice(i, 1);
       };
     },
     registerFileDecorationProvider(descriptor, impl) {
-      const record: RegisteredFileDecorationProviderRecord = { descriptor, impl };
-      registeredFileDecorationProviders.push(record);
+      // Mirrors PluginService.createHost L1818-L1875. Validation order matches
+      // production: non-object descriptor, non-empty string id, impl must be
+      // an object exposing `provideDecorations()`. The manifest-declared-id
+      // check is intentionally skipped — the mock has no manifest model (see
+      // issue #9878). Re-registering the same id replaces the prior binding
+      // (replace-by-id). The disposer's identity guard mirrors
+      // `unregisterFileDecorationProviderImpl`'s `expected` argument.
+      if (!descriptor || typeof descriptor !== "object") {
+        throw new Error("registerFileDecorationProvider: descriptor must be an object");
+      }
+      if (typeof descriptor.id !== "string" || descriptor.id.length === 0) {
+        throw new Error("registerFileDecorationProvider: descriptor.id must be a non-empty string");
+      }
+      if (!impl || typeof impl !== "object" || typeof impl.provideDecorations !== "function") {
+        throw new Error("registerFileDecorationProvider: impl must expose provideDecorations()");
+      }
+      const contributionId = descriptor.id;
+      const existing = registeredFileDecorationProviders.findIndex(
+        (r) => r.descriptor.id === contributionId
+      );
+      if (existing >= 0) {
+        registeredFileDecorationProviders[existing] = { descriptor, impl };
+      } else {
+        registeredFileDecorationProviders.push({ descriptor, impl });
+      }
       let disposed = false;
       return () => {
         if (disposed) return;
         disposed = true;
-        const i = registeredFileDecorationProviders.indexOf(record);
+        // Identity guard: only remove if the currently active entry is still
+        // the one this disposer was captured against. A re-registration with a
+        // different impl invalidates the prior disposer (matches production).
+        const i = registeredFileDecorationProviders.findIndex(
+          (r) => r.descriptor.id === contributionId && r.impl === impl
+        );
         if (i >= 0) registeredFileDecorationProviders.splice(i, 1);
       };
     },


### PR DESCRIPTION
## Summary

- `createMockHost` (`shared/testing/createMockHost.ts`) is documented to mirror the real `PluginService`, but `registerForgeProvider` and `registerFileDecorationProvider` were pushing a new record on every call. The real host stores impls in a keyed map by `descriptor.id`, so re-registering the same id overwrites the prior binding and the older disposer goes inert. The mock now does the same.
- `registerAction`, `registerForgeProvider`, and `registerFileDecorationProvider` used to skip descriptor validation entirely. The mock now throws on the same cases the real host does: non-object descriptor, non-function handler, empty `descriptor.id`, file-decoration impl missing `provideDecorations()`, and `registerAction` rejecting a `descriptor.id` that already includes the plugin prefix.
- Test coverage in `shared/testing/__tests__/createMockHost.test.ts` is expanded to cover replace-by-id, validation throws, and inert-disposer behavior on both providers, plus a tighten of the existing `registerAction` tests.

Resolves #9878

## Changes

- `shared/testing/createMockHost.ts`: keyed-map semantics for both provider methods; validation throws for all three `register*` methods.
- `shared/testing/__tests__/createMockHost.test.ts`: new coverage for replace-by-id, validation throws, and inert disposer on both providers; tighter `registerAction` cases.

## Testing

- New and tightened unit tests in `shared/testing/__tests__/createMockHost.test.ts` all pass.
- Targeted scope: 57/57 in `createMockHost.test.ts` and `hello-daintree activate.test.ts`.
- The full local suite has 36 pre-existing failures on `origin/develop` (electron/ PtyClient / shutdown / gpuDetection modules) with no overlap with this change. Confirmed by re-running the same failing files from a clean `origin/develop` worktree (HEAD `24a001f94`): 5/5 sample files, 138/138 tests still fail on baseline, so this is a develop-level issue, not a regression.