### PR TITLE
feat(automation): add durable run history for recipe and fleet runs

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -847,6 +847,13 @@ export const CHANNELS = {
   FORGE_AUDIT_EXPORT_LOG: "forge-audit:export-log",
   FORGE_AUDIT_SET_ENABLED: "forge-audit:set-enabled",
 
+  // Run history channels — durable recipe/fleet automation outcomes (#9949).
+  // Dedicated `run-history:*` prefix so codegen produces a `runHistory`
+  // renderer namespace.
+  RUN_HISTORY_GET_RECORDS: "run-history:get-records",
+  RUN_HISTORY_APPEND: "run-history:append",
+  RUN_HISTORY_CLEAR: "run-history:clear",
+
   // Plugin channels
   PLUGIN_LIST: "plugin:list",
   PLUGIN_INSTALL: "plugin:install",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -48,6 +48,7 @@ import { registerForgeHandlers } from "./handlers/forge.js";
 import { registerForgeDataHandlers } from "./handlers/forgeData.js";
 import { registerForgeSettingsHandlers } from "./handlers/forgeSettings.js";
 import { registerForgeAuditHandlers } from "./handlers/forgeAudit.js";
+import { registerRunHistoryHandlers } from "./handlers/runHistory.js";
 import { registerVoiceInputHandlers } from "./handlers/voiceInput.js";
 import { registerMcpServerHandlers } from "./handlers/mcpServer.js";
 import { registerHelpAssistantHandlers } from "./handlers/helpAssistant.js";
@@ -157,6 +158,7 @@ export function registerIpcHandlers(deps: HandlerDependencies): () => void {
     register(() => registerForgeHandlers());
     register(() => registerForgeDataHandlers());
     register(() => registerForgeAuditHandlers());
+    register(() => registerRunHistoryHandlers());
     register(() => registerVoiceInputHandlers(deps));
     register(() => registerMcpServerHandlers());
     register(() => registerHelpAssistantHandlers());

--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -65,6 +65,7 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
   "plugin:agents-changed": "external",
   "plugin:decorations-changed": "external",
   "plugin:provenance-changed": "external",
+  "run-history:update": "external",
   "plugin:deep-link": "external",
   "terminal:exit": "external",
   "terminal:spawn-result": "external",

--- a/electron/ipc/handlers/runHistory.preload.ts
+++ b/electron/ipc/handlers/runHistory.preload.ts
@@ -1,0 +1,26 @@
+import type { IpcInvokeMap } from "../../types/index.js";
+
+export const RUN_HISTORY_METHOD_CHANNELS = {
+  getRecords: "run-history:get-records",
+  append: "run-history:append",
+  clear: "run-history:clear",
+} as const satisfies Record<string, keyof IpcInvokeMap>;
+
+type Methods = typeof RUN_HISTORY_METHOD_CHANNELS;
+
+export type RunHistoryPreloadBindings = {
+  [M in keyof Methods]: (
+    ...args: IpcInvokeMap[Methods[M]]["args"]
+  ) => Promise<IpcInvokeMap[Methods[M]]["result"]>;
+};
+
+type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
+
+export function buildRunHistoryPreloadBindings(invoke: Invoker): RunHistoryPreloadBindings {
+  const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const method of Object.keys(RUN_HISTORY_METHOD_CHANNELS) as Array<keyof Methods>) {
+    const channel = RUN_HISTORY_METHOD_CHANNELS[method];
+    out[method as string] = (...args) => invoke(channel, ...args);
+  }
+  return out as unknown as RunHistoryPreloadBindings;
+}

--- a/electron/ipc/handlers/runHistory.ts
+++ b/electron/ipc/handlers/runHistory.ts
@@ -1,0 +1,38 @@
+import type {
+  RunHistoryAppendInput,
+  RunHistoryRecord,
+} from "../../../shared/types/ipc/runHistory.js";
+import { RunHistoryAppendInputSchema } from "../../schemas/runHistory.js";
+import { broadcastRunHistory, runHistoryLog } from "../../services/runHistory/runHistoryService.js";
+import { defineIpcNamespace, op } from "../define.js";
+import { RUN_HISTORY_METHOD_CHANNELS } from "./runHistory.preload.js";
+
+export const runHistoryNamespace = defineIpcNamespace({
+  name: "runHistory",
+  ops: {
+    getRecords: op(
+      RUN_HISTORY_METHOD_CHANNELS.getRecords,
+      async (): Promise<RunHistoryRecord[]> => runHistoryLog.getRecords()
+    ),
+    append: op(
+      RUN_HISTORY_METHOD_CHANNELS.append,
+      async (input: RunHistoryAppendInput): Promise<void> => {
+        // The renderer is the producer — validate the payload at the boundary
+        // before it reaches the ring buffer. A parse failure rejects the IPC
+        // call; callers fire-and-forget with `.catch`, so a bad record is
+        // dropped rather than corrupting the log.
+        const parsed = RunHistoryAppendInputSchema.parse(input);
+        runHistoryLog.append(parsed);
+        broadcastRunHistory();
+      }
+    ),
+    clear: op(RUN_HISTORY_METHOD_CHANNELS.clear, async (): Promise<void> => {
+      runHistoryLog.clear();
+      broadcastRunHistory();
+    }),
+  },
+});
+
+export function registerRunHistoryHandlers(): () => void {
+  return runHistoryNamespace.register();
+}

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -243,6 +243,11 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
           import("../services/forge/forgeAuditService.js")
             .then(({ forgeAuditService }) => forgeAuditService.flushNow())
             .catch(() => {}),
+          // Mirror for the durable run-history ring (#9949). Same unref'd 2s
+          // debounce, same loss-on-quit if not drained explicitly.
+          import("../services/runHistory/runHistoryService.js")
+            .then(({ runHistoryLog }) => runHistoryLog.flushNow())
+            .catch(() => {}),
           // Mirror for the plugin-MCP inbound audit ring (#9234). Same unref'd
           // 2s debounce, same loss-on-quit if not drained explicitly.
           import("../services/plugin-mcp/instances.js")

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -365,6 +365,14 @@ if (!gotTheLock) {
           .catch((err) => {
             console.warn(`[main] pushSnapshotTo failed for wc ${wcId}:`, err);
           });
+        // Replay the run-history snapshot to the freshly-loaded view so a
+        // cold-started / LRU-restored renderer's history store is current even
+        // if every prior push fired against a previous V8 context (#9949).
+        import("./services/runHistory/runHistoryService.js")
+          .then(({ pushRunHistorySnapshotTo }) => pushRunHistorySnapshotTo(wc))
+          .catch((err) => {
+            console.warn(`[main] run-history pushSnapshotTo failed for wc ${wcId}:`, err);
+          });
       },
     });
     setProjectViewManager(pvm);

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -45,6 +45,7 @@ import { buildPluginMcpPreloadBindings } from "./ipc/handlers/pluginMcp.preload.
 import { buildScratchPreloadBindings } from "./ipc/handlers/scratch/preload.js";
 import { buildMcpServerPreloadBindings } from "./ipc/handlers/mcpServer.preload.js";
 import { buildForgeAuditPreloadBindings } from "./ipc/handlers/forgeAudit.preload.js";
+import { buildRunHistoryPreloadBindings } from "./ipc/handlers/runHistory.preload.js";
 import { buildGeminiPreloadBindings } from "./ipc/handlers/gemini.preload.js";
 import { buildMilestonesPreloadBindings } from "./ipc/handlers/milestones.preload.js";
 import { buildOnboardingPreloadBindings } from "./ipc/handlers/onboarding.preload.js";
@@ -2410,6 +2411,8 @@ const api: ElectronAPI = {
   },
 
   forgeAudit: buildForgeAuditPreloadBindings(_unwrappingInvoke),
+
+  runHistory: buildRunHistoryPreloadBindings(_unwrappingInvoke),
 
   // Voice Input API
   voiceInput: {

--- a/electron/schemas/__tests__/runHistory.test.ts
+++ b/electron/schemas/__tests__/runHistory.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { RunHistoryAppendInputSchema } from "../runHistory.js";
+
+describe("RunHistoryAppendInputSchema", () => {
+  it("accepts a well-formed recipe payload", () => {
+    const result = RunHistoryAppendInputSchema.safeParse({
+      kind: "recipe",
+      recipeName: "Build",
+      totalTerminals: 2,
+      spawned: [{ index: 0, terminalId: "t1", title: "Claude" }],
+      failed: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a well-formed fleet payload", () => {
+    const result = RunHistoryAppendInputSchema.safeParse({
+      kind: "fleet",
+      targetCount: 2,
+      successCount: 2,
+      failureCount: 0,
+      cancelled: false,
+      perTarget: [{ terminalId: "t1", status: "fulfilled" }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an unknown kind", () => {
+    const result = RunHistoryAppendInputSchema.safeParse({ kind: "bogus" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a recipe payload missing required fields", () => {
+    const result = RunHistoryAppendInputSchema.safeParse({ kind: "recipe" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a fleet payload with a wrong-typed count", () => {
+    const result = RunHistoryAppendInputSchema.safeParse({
+      kind: "fleet",
+      targetCount: "two",
+      successCount: 2,
+      failureCount: 0,
+      cancelled: false,
+      perTarget: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an invalid per-target status", () => {
+    const result = RunHistoryAppendInputSchema.safeParse({
+      kind: "fleet",
+      targetCount: 1,
+      successCount: 0,
+      failureCount: 1,
+      cancelled: false,
+      perTarget: [{ terminalId: "t1", status: "exploded" }],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/electron/schemas/runHistory.ts
+++ b/electron/schemas/runHistory.ts
@@ -1,0 +1,60 @@
+/**
+ * Zod schemas validating run-history append payloads at the IPC boundary
+ * (#9949). The renderer is the producer, so the payload crosses a trust
+ * boundary — structural validation here is defense-in-depth on top of the
+ * field-capping the {@link RunHistoryLog} service applies before persisting.
+ */
+
+import { z } from "zod";
+import type { RunHistoryAppendInput } from "../../shared/types/ipc/runHistory.js";
+
+const TargetOutcomeSchema = z.object({
+  terminalId: z.string(),
+  title: z.string().optional(),
+  status: z.enum(["fulfilled", "rejected"]),
+  reason: z.string().optional(),
+});
+
+const RecipeAppendSchema = z.object({
+  kind: z.literal("recipe"),
+  durationMs: z.number().optional(),
+  recipeId: z.string().optional(),
+  recipeName: z.string(),
+  worktreeId: z.string().optional(),
+  worktreeName: z.string().optional(),
+  totalTerminals: z.number(),
+  spawned: z.array(
+    z.object({
+      index: z.number(),
+      terminalId: z.string(),
+      title: z.string().optional(),
+    })
+  ),
+  failed: z.array(
+    z.object({
+      index: z.number(),
+      error: z.string(),
+    })
+  ),
+});
+
+const FleetAppendSchema = z.object({
+  kind: z.literal("fleet"),
+  durationMs: z.number().optional(),
+  draftPreview: z.string().optional(),
+  targetCount: z.number(),
+  successCount: z.number(),
+  failureCount: z.number(),
+  cancelled: z.boolean(),
+  perTarget: z.array(TargetOutcomeSchema),
+});
+
+export const RunHistoryAppendInputSchema = z.discriminatedUnion("kind", [
+  RecipeAppendSchema,
+  FleetAppendSchema,
+]);
+
+// Compile-time guard: the schema output must remain assignable to the shared
+// input type so the IPC handler and renderer stay in lockstep.
+const _typecheck: RunHistoryAppendInput = {} as z.infer<typeof RunHistoryAppendInputSchema>;
+void _typecheck;

--- a/electron/services/runHistory/__tests__/runHistoryLog.test.ts
+++ b/electron/services/runHistory/__tests__/runHistoryLog.test.ts
@@ -118,6 +118,24 @@ describe("RunHistoryLog", () => {
     expect(log.getRecords()).toEqual([]);
   });
 
+  it("backfills missing array fields on hydrate so consumers can't crash", () => {
+    // A corrupted / hand-edited record with `kind` but no `spawned`/`failed`.
+    const corrupt = [{ id: "c", schemaVersion: 1, timestamp: 0, kind: "recipe" }];
+    const saveRecords = vi.fn();
+    const log = new RunHistoryLog(saveRecords, () => corrupt as unknown);
+    const [record] = log.getRecords();
+    expect(record!.kind).toBe("recipe");
+    expect((record as { spawned: unknown[] }).spawned).toEqual([]);
+    expect((record as { failed: unknown[] }).failed).toEqual([]);
+  });
+
+  it("backfills a corrupt fleet record's perTarget array", () => {
+    const corrupt = [{ id: "f", schemaVersion: 1, timestamp: 0, kind: "fleet" }];
+    const log = new RunHistoryLog(vi.fn(), () => corrupt as unknown);
+    const [record] = log.getRecords();
+    expect((record as { perTarget: unknown[] }).perTarget).toEqual([]);
+  });
+
   it("caps fleet reason and draft preview lengths", () => {
     const { log } = makeFixture();
     const longReason = "x".repeat(RUN_HISTORY_REASON_MAX_LENGTH + 50);

--- a/electron/services/runHistory/__tests__/runHistoryLog.test.ts
+++ b/electron/services/runHistory/__tests__/runHistoryLog.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RunHistoryLog } from "../runHistoryLog.js";
+import {
+  RUN_HISTORY_DRAFT_PREVIEW_MAX_LENGTH,
+  RUN_HISTORY_MAX_TARGETS,
+  RUN_HISTORY_REASON_MAX_LENGTH,
+  RUN_HISTORY_SCHEMA_VERSION,
+  type RunHistoryAppendInput,
+  type RunHistoryRecord,
+} from "../../../../shared/types/ipc/runHistory.js";
+
+function makeFixture(initial: RunHistoryRecord[] = [], maxRecords?: number) {
+  let stored: RunHistoryRecord[] = [...initial];
+  const saveRecords = vi.fn((records: RunHistoryRecord[]) => {
+    stored = records;
+  });
+  const log = new RunHistoryLog(saveRecords, () => stored, maxRecords);
+  return { log, saveRecords, getStored: () => stored };
+}
+
+function recipeInput(overrides: Partial<RunHistoryAppendInput> = {}): RunHistoryAppendInput {
+  return {
+    kind: "recipe",
+    recipeName: "Build & test",
+    totalTerminals: 2,
+    spawned: [{ index: 0, terminalId: "t1", title: "Claude" }],
+    failed: [],
+    ...overrides,
+  } as RunHistoryAppendInput;
+}
+
+describe("RunHistoryLog", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("stamps id, schemaVersion, and timestamp on append", () => {
+    const { log } = makeFixture();
+    const record = log.append(recipeInput());
+    expect(record.id).toMatch(/[0-9a-f-]{36}/);
+    expect(record.schemaVersion).toBe(RUN_HISTORY_SCHEMA_VERSION);
+    expect(typeof record.timestamp).toBe("number");
+  });
+
+  it("returns records newest-first", () => {
+    const { log } = makeFixture();
+    log.append(recipeInput({ recipeName: "first" } as Partial<RunHistoryAppendInput>));
+    log.append(recipeInput({ recipeName: "second" } as Partial<RunHistoryAppendInput>));
+    const records = log.getRecords();
+    expect(records).toHaveLength(2);
+    expect((records[0] as { recipeName: string }).recipeName).toBe("second");
+    expect((records[1] as { recipeName: string }).recipeName).toBe("first");
+  });
+
+  it("trims to the cap, dropping the oldest", () => {
+    const { log } = makeFixture([], 3);
+    for (let i = 0; i < 5; i++) {
+      log.append(recipeInput({ recipeName: `run-${i}` } as Partial<RunHistoryAppendInput>));
+    }
+    const records = log.getRecords();
+    expect(records).toHaveLength(3);
+    // Newest-first: run-4, run-3, run-2 survive; run-0/run-1 trimmed.
+    expect(records.map((r) => (r as { recipeName: string }).recipeName)).toEqual([
+      "run-4",
+      "run-3",
+      "run-2",
+    ]);
+  });
+
+  it("debounces persistence and flushNow writes synchronously", () => {
+    const { log, saveRecords } = makeFixture();
+    log.append(recipeInput());
+    expect(saveRecords).not.toHaveBeenCalled();
+    log.flushNow();
+    expect(saveRecords).toHaveBeenCalledTimes(1);
+    expect(saveRecords.mock.calls[0]![0]).toHaveLength(1);
+  });
+
+  it("flushes after the debounce window elapses", () => {
+    const { log, saveRecords } = makeFixture();
+    log.append(recipeInput());
+    vi.advanceTimersByTime(2000);
+    expect(saveRecords).toHaveBeenCalledTimes(1);
+  });
+
+  it("clear empties the ring and persists immediately", () => {
+    const { log, saveRecords, getStored } = makeFixture();
+    log.append(recipeInput());
+    log.clear();
+    expect(log.getRecords()).toHaveLength(0);
+    expect(saveRecords).toHaveBeenCalled();
+    expect(getStored()).toHaveLength(0);
+  });
+
+  it("hydrates from persisted records, trimming to the cap", () => {
+    const seed: RunHistoryRecord[] = Array.from({ length: 5 }, (_, i) => ({
+      id: `seed-${i}`,
+      schemaVersion: RUN_HISTORY_SCHEMA_VERSION,
+      timestamp: i,
+      kind: "recipe",
+      recipeName: `seed-${i}`,
+      totalTerminals: 1,
+      spawned: [],
+      failed: [],
+    }));
+    const { log } = makeFixture(seed, 2);
+    const records = log.getRecords();
+    expect(records).toHaveLength(2);
+  });
+
+  it("ignores non-array / malformed persisted data", () => {
+    const saveRecords = vi.fn();
+    const log = new RunHistoryLog(saveRecords, () => "not-an-array" as unknown);
+    expect(log.getRecords()).toEqual([]);
+  });
+
+  it("caps fleet reason and draft preview lengths", () => {
+    const { log } = makeFixture();
+    const longReason = "x".repeat(RUN_HISTORY_REASON_MAX_LENGTH + 50);
+    const longDraft = "y".repeat(RUN_HISTORY_DRAFT_PREVIEW_MAX_LENGTH + 50);
+    const record = log.append({
+      kind: "fleet",
+      draftPreview: longDraft,
+      targetCount: 1,
+      successCount: 0,
+      failureCount: 1,
+      cancelled: false,
+      perTarget: [{ terminalId: "t1", status: "rejected", reason: longReason }],
+    });
+    if (record.kind !== "fleet") throw new Error("expected fleet record");
+    expect(record.draftPreview!.length).toBe(RUN_HISTORY_DRAFT_PREVIEW_MAX_LENGTH);
+    expect(record.perTarget[0]!.reason!.length).toBe(RUN_HISTORY_REASON_MAX_LENGTH);
+  });
+
+  it("caps the number of persisted per-target entries", () => {
+    const { log } = makeFixture();
+    const perTarget = Array.from({ length: RUN_HISTORY_MAX_TARGETS + 20 }, (_, i) => ({
+      terminalId: `t${i}`,
+      status: "fulfilled" as const,
+    }));
+    const record = log.append({
+      kind: "fleet",
+      targetCount: perTarget.length,
+      successCount: perTarget.length,
+      failureCount: 0,
+      cancelled: false,
+      perTarget,
+    });
+    if (record.kind !== "fleet") throw new Error("expected fleet record");
+    expect(record.perTarget).toHaveLength(RUN_HISTORY_MAX_TARGETS);
+  });
+
+  it("normalizes negative / fractional counts to safe integers", () => {
+    const { log } = makeFixture();
+    const record = log.append({
+      kind: "fleet",
+      targetCount: -3,
+      successCount: 2.7,
+      failureCount: 0,
+      cancelled: false,
+      perTarget: [],
+    });
+    if (record.kind !== "fleet") throw new Error("expected fleet record");
+    expect(record.targetCount).toBe(0);
+    expect(record.successCount).toBe(3);
+  });
+});

--- a/electron/services/runHistory/runHistoryLog.ts
+++ b/electron/services/runHistory/runHistoryLog.ts
@@ -95,8 +95,7 @@ export class RunHistoryLog {
           // but on-disk JSON is not trusted (mirrors the MCP audit backfill).
           .map(backfillRecord)
       : [];
-    this.records =
-      safe.length > this.maxRecords ? safe.slice(safe.length - this.maxRecords) : safe;
+    this.records = safe.length > this.maxRecords ? safe.slice(safe.length - this.maxRecords) : safe;
     this.hydrated = true;
   }
 

--- a/electron/services/runHistory/runHistoryLog.ts
+++ b/electron/services/runHistory/runHistoryLog.ts
@@ -28,6 +28,28 @@ function clampString(value: unknown, max: number): string | undefined {
   return value.length > max ? value.slice(0, max) : value;
 }
 
+/**
+ * Defensively normalize a persisted record's array fields. Records written by
+ * {@link RunHistoryLog.append} always have these; this guards against corrupted
+ * or hand-edited on-disk JSON so consumers can dereference them unconditionally.
+ */
+function backfillRecord(record: RunHistoryRecord): RunHistoryRecord {
+  if (record.kind === "recipe") {
+    return {
+      ...record,
+      spawned: Array.isArray(record.spawned) ? record.spawned : [],
+      failed: Array.isArray(record.failed) ? record.failed : [],
+    };
+  }
+  if (record.kind === "fleet") {
+    return {
+      ...record,
+      perTarget: Array.isArray(record.perTarget) ? record.perTarget : [],
+    };
+  }
+  return record;
+}
+
 function sanitizeTarget(raw: RunHistoryTargetOutcome): RunHistoryTargetOutcome {
   const out: RunHistoryTargetOutcome = {
     terminalId: String(raw.terminalId),
@@ -62,10 +84,16 @@ export class RunHistoryLog {
     if (this.hydrated) return;
     const persisted = this.readRecords();
     const safe = Array.isArray(persisted)
-      ? persisted.filter(
-          (r: unknown): r is RunHistoryRecord =>
-            r !== null && typeof r === "object" && "kind" in (r as object)
-        )
+      ? persisted
+          .filter(
+            (r: unknown): r is RunHistoryRecord =>
+              r !== null && typeof r === "object" && "kind" in (r as object)
+          )
+          // Backfill the array fields so a corrupted / hand-edited store can't
+          // crash a consumer that dereferences `spawned`/`failed`/`perTarget`
+          // (e.g. the Settings viewer). The append() path always writes these,
+          // but on-disk JSON is not trusted (mirrors the MCP audit backfill).
+          .map(backfillRecord)
       : [];
     this.records =
       safe.length > this.maxRecords ? safe.slice(safe.length - this.maxRecords) : safe;

--- a/electron/services/runHistory/runHistoryLog.ts
+++ b/electron/services/runHistory/runHistoryLog.ts
@@ -1,0 +1,183 @@
+import { randomUUID } from "node:crypto";
+import type {
+  RecipeRunHistoryRecord,
+  FleetRunHistoryRecord,
+  RunHistoryAppendInput,
+  RunHistoryRecord,
+  RunHistoryTargetOutcome,
+} from "../../../shared/types/ipc/runHistory.js";
+import {
+  RUN_HISTORY_DEFAULT_MAX_RECORDS,
+  RUN_HISTORY_DRAFT_PREVIEW_MAX_LENGTH,
+  RUN_HISTORY_MAX_TARGETS,
+  RUN_HISTORY_REASON_MAX_LENGTH,
+  RUN_HISTORY_SCHEMA_VERSION,
+  RUN_HISTORY_TITLE_MAX_LENGTH,
+} from "../../../shared/types/ipc/runHistory.js";
+
+/**
+ * Debounce window for flushing the ring buffer to disk. Rapid recipe/fleet runs
+ * must not trigger one synchronous store write each; mirrors the forge audit
+ * service's `FORGE_AUDIT_FLUSH_DEBOUNCE_MS`.
+ */
+const RUN_HISTORY_FLUSH_DEBOUNCE_MS = 2000;
+
+function clampString(value: unknown, max: number): string | undefined {
+  if (typeof value !== "string") return undefined;
+  if (value.length === 0) return undefined;
+  return value.length > max ? value.slice(0, max) : value;
+}
+
+function sanitizeTarget(raw: RunHistoryTargetOutcome): RunHistoryTargetOutcome {
+  const out: RunHistoryTargetOutcome = {
+    terminalId: String(raw.terminalId),
+    status: raw.status === "rejected" ? "rejected" : "fulfilled",
+  };
+  const title = clampString(raw.title, RUN_HISTORY_TITLE_MAX_LENGTH);
+  if (title !== undefined) out.title = title;
+  const reason = clampString(raw.reason, RUN_HISTORY_REASON_MAX_LENGTH);
+  if (reason !== undefined) out.reason = reason;
+  return out;
+}
+
+/**
+ * Pure, store-free ring buffer for durable run-history records. Persistence is
+ * injected via the `saveRecords` / `readRecords` callbacks so the class stays
+ * unit-testable (mirrors `ForgeAuditService`'s separation from the store key).
+ * The wiring to the `runHistory` electron-store key lives in
+ * `runHistoryService.ts`.
+ */
+export class RunHistoryLog {
+  private records: RunHistoryRecord[] = [];
+  private flushTimer: ReturnType<typeof setTimeout> | null = null;
+  private hydrated = false;
+
+  constructor(
+    private readonly saveRecords: (records: RunHistoryRecord[]) => void,
+    private readonly readRecords: () => unknown,
+    private readonly maxRecords: number = RUN_HISTORY_DEFAULT_MAX_RECORDS
+  ) {}
+
+  hydrate(): void {
+    if (this.hydrated) return;
+    const persisted = this.readRecords();
+    const safe = Array.isArray(persisted)
+      ? persisted.filter(
+          (r: unknown): r is RunHistoryRecord =>
+            r !== null && typeof r === "object" && "kind" in (r as object)
+        )
+      : [];
+    this.records =
+      safe.length > this.maxRecords ? safe.slice(safe.length - this.maxRecords) : safe;
+    this.hydrated = true;
+  }
+
+  /**
+   * Append a completed run. The renderer supplies the outcome; this method is
+   * authoritative for `id`, `schemaVersion`, and `timestamp` and caps every
+   * free-text/array field before persisting. Returns the stored record so the
+   * IPC layer can broadcast the fresh snapshot.
+   */
+  append(input: RunHistoryAppendInput): RunHistoryRecord {
+    this.hydrate();
+
+    const base = {
+      id: randomUUID(),
+      schemaVersion: RUN_HISTORY_SCHEMA_VERSION,
+      timestamp: Date.now(),
+      ...(typeof input.durationMs === "number" && Number.isFinite(input.durationMs)
+        ? { durationMs: Math.max(0, Math.round(input.durationMs)) }
+        : {}),
+    };
+
+    let record: RunHistoryRecord;
+    if (input.kind === "recipe") {
+      const recipe: RecipeRunHistoryRecord = {
+        ...base,
+        kind: "recipe",
+        recipeName: clampString(input.recipeName, RUN_HISTORY_TITLE_MAX_LENGTH) ?? "Recipe",
+        totalTerminals: Math.max(0, Math.round(input.totalTerminals ?? 0)),
+        spawned: (input.spawned ?? []).slice(0, RUN_HISTORY_MAX_TARGETS).map((s) => {
+          const entry: { index: number; terminalId: string; title?: string } = {
+            index: Math.max(0, Math.round(s.index)),
+            terminalId: String(s.terminalId),
+          };
+          const title = clampString(s.title, RUN_HISTORY_TITLE_MAX_LENGTH);
+          if (title !== undefined) entry.title = title;
+          return entry;
+        }),
+        failed: (input.failed ?? []).slice(0, RUN_HISTORY_MAX_TARGETS).map((f) => ({
+          index: Math.max(0, Math.round(f.index)),
+          error: clampString(f.error, RUN_HISTORY_REASON_MAX_LENGTH) ?? "Unknown error",
+        })),
+      };
+      if (input.recipeId) recipe.recipeId = String(input.recipeId);
+      if (input.worktreeId) recipe.worktreeId = String(input.worktreeId);
+      const worktreeName = clampString(input.worktreeName, RUN_HISTORY_TITLE_MAX_LENGTH);
+      if (worktreeName !== undefined) recipe.worktreeName = worktreeName;
+      record = recipe;
+    } else {
+      const fleet: FleetRunHistoryRecord = {
+        ...base,
+        kind: "fleet",
+        targetCount: Math.max(0, Math.round(input.targetCount ?? 0)),
+        successCount: Math.max(0, Math.round(input.successCount ?? 0)),
+        failureCount: Math.max(0, Math.round(input.failureCount ?? 0)),
+        cancelled: input.cancelled === true,
+        perTarget: (input.perTarget ?? []).slice(0, RUN_HISTORY_MAX_TARGETS).map(sanitizeTarget),
+      };
+      const draftPreview = clampString(input.draftPreview, RUN_HISTORY_DRAFT_PREVIEW_MAX_LENGTH);
+      if (draftPreview !== undefined) fleet.draftPreview = draftPreview;
+      record = fleet;
+    }
+
+    this.enqueueAndTrim(record);
+    return record;
+  }
+
+  private enqueueAndTrim(record: RunHistoryRecord): void {
+    this.records.push(record);
+    if (this.records.length > this.maxRecords) {
+      this.records.splice(0, this.records.length - this.maxRecords);
+    }
+    this.scheduleFlush();
+  }
+
+  /** Newest-first view of the ring buffer. */
+  getRecords(): RunHistoryRecord[] {
+    this.hydrate();
+    return [...this.records].reverse();
+  }
+
+  clear(): void {
+    this.hydrate();
+    this.records = [];
+    this.flushNow();
+  }
+
+  private scheduleFlush(): void {
+    if (this.flushTimer) return;
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = null;
+      this.flush();
+    }, RUN_HISTORY_FLUSH_DEBOUNCE_MS);
+    this.flushTimer.unref?.();
+  }
+
+  private flush(): void {
+    if (!this.hydrated) return;
+    try {
+      this.saveRecords([...this.records]);
+    } catch (err) {
+      console.error("[RunHistory] Failed to flush run history:", err);
+    }
+  }
+
+  flushNow(): void {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    this.flush();
+  }
+}

--- a/electron/services/runHistory/runHistoryService.ts
+++ b/electron/services/runHistory/runHistoryService.ts
@@ -1,0 +1,57 @@
+// eager-import-allow: reads/writes the runHistory store key via store.get/set inside the persistence callbacks, invoked from runHistory IPC handlers (not at boot)
+import type { RunHistoryRecord } from "../../../shared/types/ipc/runHistory.js";
+import { CHANNELS } from "../../ipc/channels.js";
+import { broadcastToRenderer } from "../../ipc/utils.js";
+import { store } from "../../store.js";
+import { RunHistoryLog } from "./runHistoryLog.js";
+
+/**
+ * Process-global run-history singleton. Recipe and fleet runs originate from any
+ * window's renderer, so the ring accumulates cross-window — a module-level
+ * singleton, never per-window. The pure {@link RunHistoryLog} class lives in
+ * `runHistoryLog.ts` (store-free, unit-testable); this thin wrapper wires it to
+ * the `runHistory` store key, mirroring `forgeAuditService`.
+ */
+function readRecords(): unknown {
+  // Defensive `?? {}`: the store default always supplies `runHistory`, but a
+  // test harness mocking the store may not — readRecords must never throw.
+  const config = (store.get("runHistory") as { records?: unknown } | undefined) ?? {};
+  return config.records;
+}
+
+function saveRecords(records: RunHistoryRecord[]): void {
+  store.set("runHistory", { records });
+}
+
+export const runHistoryLog = new RunHistoryLog(saveRecords, readRecords);
+
+/**
+ * Broadcast the current run-history snapshot to every live renderer via the
+ * multiplexed `events:push` bus. Called after append/clear so all open windows
+ * (and project views) update without a reload — the renderer subscribes through
+ * `window.electron.events.on("run-history:update", ...)`.
+ */
+export function broadcastRunHistory(): void {
+  broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
+    name: "run-history:update",
+    payload: runHistoryLog.getRecords(),
+  });
+}
+
+/**
+ * Replay the run-history snapshot to a single freshly-loaded view (cold start,
+ * LRU restore, crash reload, DevTools refresh) so its renderer store is current
+ * even if every prior push fired while a previous V8 context was alive. Wired
+ * into `onViewReady` in `main.ts`, mirroring `PluginService.pushSnapshotTo`.
+ */
+export function pushRunHistorySnapshotTo(webContents: Electron.WebContents): void {
+  if (webContents.isDestroyed()) return;
+  try {
+    webContents.send(CHANNELS.EVENTS_PUSH, {
+      name: "run-history:update",
+      payload: runHistoryLog.getRecords(),
+    });
+  } catch {
+    // Silently ignore send failures during window initialization/disposal.
+  }
+}

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -22,6 +22,7 @@ import { PLUGIN_MCP_AUDIT_DEFAULT_MAX_RECORDS } from "../shared/types/ipc/plugin
 import type { PluginMcpConsentRecord } from "../shared/types/pluginMcpConsent.js";
 import { PLUGIN_MCP_DEFAULT_MAX_TOOLS_PER_SESSION } from "../shared/types/ipc/pluginMcp.js";
 import type { ForgeAuditRecord } from "../shared/types/ipc/forge.js";
+import type { RunHistoryRecord } from "../shared/types/ipc/runHistory.js";
 import type { SuggestedDictionaryEntry } from "../shared/types/ipc/api.js";
 import { FORGE_AUDIT_DEFAULT_MAX_RECORDS } from "../shared/types/ipc/forge.js";
 import type { BuiltInAgentId } from "../shared/config/agentIds.js";
@@ -378,6 +379,17 @@ export interface StoreSchema {
     auditLog?: ForgeAuditRecord[];
   };
   /**
+   * Durable run-history ring buffer for recipe and fleet automation outcomes
+   * (#9949). `records` is the persisted oldest-first ring, trimmed to
+   * {@link RUN_HISTORY_DEFAULT_MAX_RECORDS} by `RunHistoryLog`. Lives in the
+   * Main-process store (not renderer localStorage) so it survives reloads and
+   * the multi-window LRU eviction. Read defensively (`?? {}` applied by
+   * electron-store) — the on-disk shape is owned by `RunHistoryLog`.
+   */
+  runHistory: {
+    records?: RunHistoryRecord[];
+  };
+  /**
    * Inbound plugin-MCP `tools/call` audit ring buffer (#9234). Parallel to
    * `plugins.auditLog` but scoped to *inbound* MCP tool calls — i.e. calls a
    * plugin's stdio MCP server makes back into the host. Records never store
@@ -574,6 +586,9 @@ const storeOptions = {
     forgeAudit: {
       auditEnabled: true,
       auditMaxRecords: FORGE_AUDIT_DEFAULT_MAX_RECORDS,
+    },
+    runHistory: {
+      records: [],
     },
     pluginMcpAudit: {
       auditEnabled: true,

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -380,6 +380,23 @@ export {
   PLUGIN_AUDIT_DEFAULT_MAX_RECORDS,
 } from "./ipc/pluginAudit.js";
 
+// Run history types - durable recipe/fleet automation outcomes (#9949)
+export type {
+  RunHistoryRecord,
+  RecipeRunHistoryRecord,
+  FleetRunHistoryRecord,
+  RunHistoryTargetOutcome,
+  RunHistoryAppendInput,
+} from "./ipc/runHistory.js";
+export {
+  RUN_HISTORY_SCHEMA_VERSION,
+  RUN_HISTORY_DEFAULT_MAX_RECORDS,
+  RUN_HISTORY_REASON_MAX_LENGTH,
+  RUN_HISTORY_DRAFT_PREVIEW_MAX_LENGTH,
+  RUN_HISTORY_TITLE_MAX_LENGTH,
+  RUN_HISTORY_MAX_TARGETS,
+} from "./ipc/runHistory.js";
+
 // Event types - event context for correlation
 export type { EventContext } from "./events.js";
 

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -522,6 +522,17 @@ export interface GeneratedElectronAPI {
       ...args: IpcInvokeMap["privacy:set-telemetry-level"]["args"]
     ): Promise<IpcInvokeMap["privacy:set-telemetry-level"]["result"]>;
   };
+  runHistory: {
+    append(
+      ...args: IpcInvokeMap["run-history:append"]["args"]
+    ): Promise<IpcInvokeMap["run-history:append"]["result"]>;
+    clear(
+      ...args: IpcInvokeMap["run-history:clear"]["args"]
+    ): Promise<IpcInvokeMap["run-history:clear"]["result"]>;
+    getRecords(
+      ...args: IpcInvokeMap["run-history:get-records"]["args"]
+    ): Promise<IpcInvokeMap["run-history:get-records"]["result"]>;
+  };
   sentry: {
     getConsentState(
       ...args: IpcInvokeMap["sentry:get-consent-state"]["args"]

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -354,7 +354,7 @@ export interface GeneratedIpcInvokeMap {
         updates: Partial<
           Omit<
             import("../project.js").TerminalRecipe,
-            "id" | "projectId" | "worktreeId" | "createdAt"
+            "id" | "worktreeId" | "projectId" | "createdAt"
           >
         >;
       },
@@ -905,6 +905,18 @@ export interface GeneratedIpcInvokeMap {
   "project:set-terminals": {
     args: [payload: { projectId: string; terminals: import("../project.js").PanelSnapshot[] }];
     result: void;
+  };
+  "run-history:append": {
+    args: [input: import("./runHistory.js").RunHistoryAppendInput];
+    result: void;
+  };
+  "run-history:clear": {
+    args: [];
+    result: void;
+  };
+  "run-history:get-records": {
+    args: [];
+    result: import("./runHistory.js").RunHistoryRecord[];
   };
   "scratch:create": {
     args: [name?: string | undefined];

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1965,6 +1965,11 @@ export interface IpcEventMap {
   // renderer re-pulls via `plugin:list` for the full data.
   "plugin:provenance-changed": Record<string, never>;
 
+  // Run history changed (main → renderer, #9949). Carries the full newest-first
+  // snapshot so every live window updates without a reload after a recipe/fleet
+  // run is recorded or the log is cleared.
+  "run-history:update": import("./runHistory.js").RunHistoryRecord[];
+
   // `daintree://` deep-link intent (main → renderer, #9559). Delivered to the
   // primary window once it has painted; the renderer opens the Plugin Manager
   // (URL pre-filled for install, or scrolled to the plugin for open). Routing
@@ -2059,6 +2064,8 @@ export type IpcEventBusMap = Pick<
   | "plugin:decorations-changed"
   // Plugin provenance record changed (global broadcast)
   | "plugin:provenance-changed"
+  // Run history changed (global broadcast)
+  | "run-history:update"
   // Plugin deep-link intent (targeted at the primary window)
   | "plugin:deep-link"
   // Terminal lifecycle (non-data) — exit, spawn-result, backend crash/ready

--- a/shared/types/ipc/runHistory.ts
+++ b/shared/types/ipc/runHistory.ts
@@ -1,0 +1,94 @@
+/**
+ * Durable run-history records for recipe and fleet automation outcomes (#9949).
+ *
+ * Recipe runs (`runRecipeWithResults`) and fleet broadcasts
+ * (`tryFleetBroadcastFromEditor`) compute rich structured results at execution
+ * time but historically discarded them. These records capture a per-run
+ * snapshot so a completed run stays inspectable after the fact — surviving
+ * reloads and the multi-window LRU eviction by living in the Main-process
+ * `electron-store` ring buffer (mirrors `forgeAudit` / `mcpServer.auditLog`).
+ *
+ * References are stored as stale-tolerant snapshots: terminal ids and pane
+ * titles are captured at run time and never re-resolved. A terminal that has
+ * since closed or a worktree that was deleted leaves the record intact — the
+ * UI renders the snapshotted title as plain text rather than dereferencing a
+ * dead id. The records deliberately do NOT mirror terminal scrollback or git
+ * state; they record only the automation outcome.
+ */
+
+export const RUN_HISTORY_SCHEMA_VERSION = 1;
+
+/** Default ring-buffer cap. ~2KB/record → ~200KB on disk at the cap. */
+export const RUN_HISTORY_DEFAULT_MAX_RECORDS = 100;
+
+/** Cap on persisted free-text fields (rejection reasons, spawn errors). */
+export const RUN_HISTORY_REASON_MAX_LENGTH = 500;
+
+/** Cap on the snapshotted fleet draft preview. */
+export const RUN_HISTORY_DRAFT_PREVIEW_MAX_LENGTH = 280;
+
+/** Cap on snapshotted display strings (pane / recipe / worktree titles). */
+export const RUN_HISTORY_TITLE_MAX_LENGTH = 200;
+
+/** Hard cap on per-target entries persisted for a single run. */
+export const RUN_HISTORY_MAX_TARGETS = 200;
+
+/**
+ * Per-target outcome snapshot, shared by recipe spawns and fleet sends. `title`
+ * is the pane title captured at run time — it makes a record legible even after
+ * the terminal closes. `reason` carries the rejection detail for failed sends
+ * (capped to {@link RUN_HISTORY_REASON_MAX_LENGTH}).
+ */
+export interface RunHistoryTargetOutcome {
+  terminalId: string;
+  title?: string;
+  status: "fulfilled" | "rejected";
+  reason?: string;
+}
+
+interface RunHistoryRecordBase {
+  id: string;
+  schemaVersion: number;
+  /** Epoch ms when the run completed (stamped by the Main-process service). */
+  timestamp: number;
+  /** Wall-clock duration of the run, when the call site measured it. */
+  durationMs?: number;
+}
+
+export interface RecipeRunHistoryRecord extends RunHistoryRecordBase {
+  kind: "recipe";
+  /** Resolved recipe id; absent for an in-memory / deleted recipe. */
+  recipeId?: string;
+  recipeName: string;
+  worktreeId?: string;
+  /** Snapshot of the worktree name/path at run time (stale-tolerant). */
+  worktreeName?: string;
+  /** Total terminals the recipe defined (not just the spawned subset). */
+  totalTerminals: number;
+  /** Successfully-spawned terminals, in recipe index order. */
+  spawned: Array<{ index: number; terminalId: string; title?: string }>;
+  /** Per-terminal spawn failures, in recipe index order. */
+  failed: Array<{ index: number; error: string }>;
+}
+
+export interface FleetRunHistoryRecord extends RunHistoryRecordBase {
+  kind: "fleet";
+  /** Truncated snapshot of the broadcast payload (no scrollback duplication). */
+  draftPreview?: string;
+  targetCount: number;
+  successCount: number;
+  failureCount: number;
+  cancelled: boolean;
+  perTarget: RunHistoryTargetOutcome[];
+}
+
+export type RunHistoryRecord = RecipeRunHistoryRecord | FleetRunHistoryRecord;
+
+/**
+ * Payload the renderer sends to append a record. The Main-process service is
+ * authoritative for `id`, `schemaVersion`, and `timestamp` — it stamps them so
+ * a buggy/compromised renderer can't forge them — so callers omit those.
+ */
+export type RunHistoryAppendInput =
+  | Omit<RecipeRunHistoryRecord, "id" | "schemaVersion" | "timestamp">
+  | Omit<FleetRunHistoryRecord, "id" | "schemaVersion" | "timestamp">;

--- a/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
@@ -82,6 +82,10 @@ beforeEach(() => {
       notification: {
         playUiEvent: vi.fn().mockResolvedValue(undefined),
       },
+      // The broadcast path records the run via runHistory.append (fire-and-forget).
+      runHistory: {
+        append: vi.fn().mockResolvedValue(undefined),
+      },
     },
   });
 });

--- a/src/components/Fleet/fleetEnterBroadcast.ts
+++ b/src/components/Fleet/fleetEnterBroadcast.ts
@@ -3,7 +3,10 @@ import { useFleetFailureStore } from "@/store/fleetFailureStore";
 import { useFleetBroadcastProgressStore } from "@/store/fleetBroadcastProgressStore";
 import { useFleetTargetOverridesStore } from "@/store/fleetTargetOverridesStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+import { usePanelStore } from "@/store/panelStore";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { logWarn } from "@/utils/logger";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { resolveFleetBroadcastTargetIds } from "./fleetBroadcast";
 import {
   executeFleetBroadcast,
@@ -90,6 +93,42 @@ function buildBroadcastAnnouncement(result: FleetExecutionResult): string {
     return `Broadcast sent to ${result.successCount} — ${describeFailureSplit(permanent, transient)}`;
   }
   return `Broadcast sent to ${plural(result.successCount, "terminal", "terminals")}`;
+}
+
+/**
+ * Record a completed fleet broadcast in the durable run history (#9949).
+ * Fire-and-forget: a thrown IPC error must never disrupt the broadcast UX, so
+ * we `void` + `.catch`. Pane titles are snapshotted from the live registry so
+ * the record stays legible after a terminal closes. Only resolved results are
+ * recorded — `runManagedFleetBroadcast` always resolves (cancellation surfaces
+ * as `cancelled: true`), so a throw here would be an unexpected crash, not an
+ * automation outcome.
+ */
+function recordFleetRunHistory(
+  draft: string,
+  targetCount: number,
+  result: FleetExecutionResult,
+  durationMs: number
+): void {
+  const panelsById = usePanelStore.getState().panelsById;
+  safeFireAndForget(
+    window.electron.runHistory.append({
+      kind: "fleet",
+      draftPreview: draft,
+      targetCount,
+      successCount: result.successCount,
+      failureCount: result.failureCount,
+      cancelled: result.cancelled,
+      durationMs,
+      perTarget: result.perTarget.map((t) => ({
+        terminalId: t.terminalId,
+        title: getNarrowPanel(panelsById, t.terminalId)?.title,
+        status: t.status,
+        reason: t.reason,
+      })),
+    }),
+    { context: "Failed to record fleet run history" }
+  );
 }
 
 /**
@@ -186,10 +225,12 @@ export function tryFleetBroadcastFromEditor(
     // `resolveFleetBroadcastTargetIds()`; re-run the panel-eligibility
     // filter so disposed PTYs are dropped too.
     const eligibleTargets = filterEligibleIds(effectiveTargets);
+    const startedAt = Date.now();
     try {
       // A second Enter while a broadcast is in-flight pre-empts the first;
       // the shared controller lets the ribbon Cancel button abort it too.
       const result = await runManagedFleetBroadcast(text, eligibleTargets, overridesArg);
+      recordFleetRunHistory(text, eligibleTargets.length, result, Date.now() - startedAt);
       if (result.failureCount > 0) {
         logWarn("[fleetEnterBroadcast] broadcast had rejections", {
           failureCount: result.failureCount,

--- a/src/components/Settings/RunHistorySettingsTab.tsx
+++ b/src/components/Settings/RunHistorySettingsTab.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState } from "react";
+import { History, Radio, Trash2 } from "lucide-react";
+import { Workflow } from "@/components/icons";
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { SettingsSection } from "@/components/Settings/SettingsSection";
+import { formatRelativeTime } from "@/lib/formatRelativeTime";
+import { useRunHistoryStore } from "@/store/runHistoryStore";
+import { cn } from "@/lib/utils";
+import type { RunHistoryRecord } from "@shared/types";
+
+function CountPill({ tone, label }: { tone: "success" | "danger" | "muted"; label: string }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-medium",
+        tone === "success" && "bg-emerald-500/15 text-emerald-400",
+        tone === "danger" && "bg-red-500/15 text-red-400",
+        tone === "muted" && "bg-overlay-subtle text-daintree-text/70"
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+function RecipeRunRow({ record }: { record: Extract<RunHistoryRecord, { kind: "recipe" }> }) {
+  return (
+    <>
+      <div className="flex items-start gap-2.5">
+        <Workflow className="mt-0.5 h-4 w-4 shrink-0 text-daintree-text/60" aria-hidden="true" />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate text-sm font-medium text-daintree-text">
+              {record.recipeName}
+            </span>
+            {record.worktreeName ? (
+              <span className="truncate text-xs text-daintree-text/50">{record.worktreeName}</span>
+            ) : null}
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-1.5">
+            <CountPill tone="success" label={`${record.spawned.length} spawned`} />
+            {record.failed.length > 0 ? (
+              <CountPill tone="danger" label={`${record.failed.length} failed`} />
+            ) : null}
+            <CountPill tone="muted" label={`${record.totalTerminals} defined`} />
+          </div>
+        </div>
+        <time className="shrink-0 text-xs text-daintree-text/50">
+          {formatRelativeTime(record.timestamp)}
+        </time>
+      </div>
+      {record.failed.length > 0 ? (
+        <ul className="mt-2 space-y-0.5 pl-6.5 text-xs text-red-400/90">
+          {record.failed.map((f) => (
+            <li key={f.index} className="truncate">
+              #{f.index}: {f.error}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </>
+  );
+}
+
+function FleetRunRow({ record }: { record: Extract<RunHistoryRecord, { kind: "fleet" }> }) {
+  const rejected = record.perTarget.filter((t) => t.status === "rejected");
+  return (
+    <>
+      <div className="flex items-start gap-2.5">
+        <Radio className="mt-0.5 h-4 w-4 shrink-0 text-daintree-text/60" aria-hidden="true" />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-daintree-text">Fleet broadcast</span>
+            {record.cancelled ? <CountPill tone="muted" label="Cancelled" /> : null}
+          </div>
+          {record.draftPreview ? (
+            <p className="mt-0.5 truncate text-xs text-daintree-text/50">{record.draftPreview}</p>
+          ) : null}
+          <div className="mt-1 flex flex-wrap items-center gap-1.5">
+            <CountPill tone="success" label={`${record.successCount} sent`} />
+            {record.failureCount > 0 ? (
+              <CountPill tone="danger" label={`${record.failureCount} failed`} />
+            ) : null}
+            <CountPill tone="muted" label={`${record.targetCount} targets`} />
+          </div>
+        </div>
+        <time className="shrink-0 text-xs text-daintree-text/50">
+          {formatRelativeTime(record.timestamp)}
+        </time>
+      </div>
+      {rejected.length > 0 ? (
+        <ul className="mt-2 space-y-0.5 pl-6.5 text-xs text-red-400/90">
+          {rejected.map((t) => (
+            <li key={t.terminalId} className="truncate">
+              {t.title ?? t.terminalId}
+              {t.reason ? `: ${t.reason}` : ""}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </>
+  );
+}
+
+export function RunHistorySettingsTab() {
+  const records = useRunHistoryStore((s) => s.records);
+  const loading = useRunHistoryStore((s) => s.loading);
+  const init = useRunHistoryStore((s) => s.init);
+  const clear = useRunHistoryStore((s) => s.clear);
+  const [showClearConfirm, setShowClearConfirm] = useState(false);
+
+  useEffect(() => {
+    init();
+  }, [init]);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <SettingsSection
+        icon={History}
+        title="Run history"
+        description="Records each recipe run and fleet broadcast so you can review what an automation actually did. Spawned terminals and targets are snapshots — entries stay readable even after a terminal closes. Terminal output and git state are not duplicated here."
+      >
+        <div className="flex flex-col gap-3">
+          {records.length > 0 ? (
+            <div className="flex justify-end">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setShowClearConfirm(true)}
+                className="text-daintree-text/70"
+              >
+                <Trash2 className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
+                Clear history
+              </Button>
+            </div>
+          ) : null}
+
+          {loading ? null : records.length === 0 ? (
+            <EmptyState
+              variant="zero-data"
+              scale="canvas"
+              icon={<History aria-hidden="true" />}
+              title="No runs yet"
+              description="Run a recipe or broadcast to a fleet and the outcome shows up here."
+            />
+          ) : (
+            <ul className="flex flex-col gap-2">
+              {records.map((record) => (
+                <li
+                  key={record.id}
+                  className="rounded-md border border-daintree-border/60 bg-overlay-subtle/40 p-3"
+                >
+                  {record.kind === "recipe" ? (
+                    <RecipeRunRow record={record} />
+                  ) : (
+                    <FleetRunRow record={record} />
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </SettingsSection>
+
+      <ConfirmDialog
+        isOpen={showClearConfirm}
+        variant="destructive"
+        onConfirm={() => void clear()}
+        onClose={() => setShowClearConfirm(false)}
+        title="Clear run history?"
+        description="This permanently deletes all recorded recipe and fleet runs on this machine. New runs will still be recorded."
+        confirmLabel="Clear history"
+      />
+    </div>
+  );
+}

--- a/src/components/Settings/RunHistorySettingsTab.tsx
+++ b/src/components/Settings/RunHistorySettingsTab.tsx
@@ -26,6 +26,8 @@ function CountPill({ tone, label }: { tone: "success" | "danger" | "muted"; labe
 }
 
 function RecipeRunRow({ record }: { record: Extract<RunHistoryRecord, { kind: "recipe" }> }) {
+  const spawned = record.spawned ?? [];
+  const failed = record.failed ?? [];
   return (
     <>
       <div className="flex items-start gap-2.5">
@@ -40,9 +42,9 @@ function RecipeRunRow({ record }: { record: Extract<RunHistoryRecord, { kind: "r
             ) : null}
           </div>
           <div className="mt-1 flex flex-wrap items-center gap-1.5">
-            <CountPill tone="success" label={`${record.spawned.length} spawned`} />
-            {record.failed.length > 0 ? (
-              <CountPill tone="danger" label={`${record.failed.length} failed`} />
+            <CountPill tone="success" label={`${spawned.length} spawned`} />
+            {failed.length > 0 ? (
+              <CountPill tone="danger" label={`${failed.length} failed`} />
             ) : null}
             <CountPill tone="muted" label={`${record.totalTerminals} defined`} />
           </div>
@@ -51,9 +53,9 @@ function RecipeRunRow({ record }: { record: Extract<RunHistoryRecord, { kind: "r
           {formatRelativeTime(record.timestamp)}
         </time>
       </div>
-      {record.failed.length > 0 ? (
+      {failed.length > 0 ? (
         <ul className="mt-2 space-y-0.5 pl-6.5 text-xs text-red-400/90">
-          {record.failed.map((f) => (
+          {failed.map((f) => (
             <li key={f.index} className="truncate">
               #{f.index}: {f.error}
             </li>
@@ -65,7 +67,7 @@ function RecipeRunRow({ record }: { record: Extract<RunHistoryRecord, { kind: "r
 }
 
 function FleetRunRow({ record }: { record: Extract<RunHistoryRecord, { kind: "fleet" }> }) {
-  const rejected = record.perTarget.filter((t) => t.status === "rejected");
+  const rejected = (record.perTarget ?? []).filter((t) => t.status === "rejected");
   return (
     <>
       <div className="flex items-start gap-2.5">

--- a/src/components/Settings/__tests__/settingsTabRegistry.test.ts
+++ b/src/components/Settings/__tests__/settingsTabRegistry.test.ts
@@ -19,12 +19,12 @@ const globalEntries = allEntries.filter((e) => e.scope === "global");
 const projectEntries = allEntries.filter((e) => e.scope === "project");
 
 describe("SETTINGS_REGISTRY", () => {
-  it("has 27 entries (19 global + 8 project)", () => {
-    expect(SETTINGS_REGISTRY).toHaveLength(27);
+  it("has 28 entries (20 global + 8 project)", () => {
+    expect(SETTINGS_REGISTRY).toHaveLength(28);
   });
 
-  it("has 19 global entries", () => {
-    expect(globalEntries).toHaveLength(19);
+  it("has 20 global entries", () => {
+    expect(globalEntries).toHaveLength(20);
   });
 
   it("has 8 project entries", () => {
@@ -77,9 +77,9 @@ describe("SETTINGS_REGISTRY", () => {
     expect(eager[0]!.id).toBe("general");
   });
 
-  it("has 26 lazy entries (18 global + 8 project)", () => {
+  it("has 27 lazy entries (19 global + 8 project)", () => {
     const lazy = SETTINGS_REGISTRY.filter((e) => e.importKind === "lazy");
-    expect(lazy).toHaveLength(26);
+    expect(lazy).toHaveLength(27);
   });
 
   it("all global entries belong to known global groups", () => {
@@ -213,10 +213,10 @@ describe("getSettingsNavGroups", () => {
     ]);
   });
 
-  it("all 19 global entries are distributed across global groups", () => {
+  it("all 20 global entries are distributed across global groups", () => {
     const groups = getSettingsNavGroups("global");
     const totalEntries = groups.reduce((sum, g) => sum + g.entries.length, 0);
-    expect(totalEntries).toBe(19);
+    expect(totalEntries).toBe(20);
   });
 
   it("global groups contain only global-scoped entries", () => {
@@ -253,8 +253,8 @@ describe("getSettingsNavGroups", () => {
 });
 
 describe("SettingsTab type coverage", () => {
-  it("union of registry IDs equals 27", () => {
+  it("union of registry IDs equals 28", () => {
     const allIds = new Set(SETTINGS_REGISTRY.map((e) => e.id));
-    expect(allIds.size).toBe(27);
+    expect(allIds.size).toBe(28);
   });
 });

--- a/src/components/Settings/settingsTabRegistry.tsx
+++ b/src/components/Settings/settingsTabRegistry.tsx
@@ -1871,6 +1871,7 @@ export const globalTabIcons: Record<GlobalSettingsTab, ReactNode> = {
   mcp: <McpServerIcon className="w-5 h-5 text-text-secondary" />,
   plugins: <Package className="w-5 h-5 text-text-secondary" />,
   "plugin-actions": <ScrollText className="w-5 h-5 text-text-secondary" />,
+  "run-history": <History className="w-5 h-5 text-text-secondary" />,
   environment: <KeyRound className="w-5 h-5 text-text-secondary" />,
   privacy: <Shield className="w-5 h-5 text-text-secondary" />,
   troubleshooting: <LifeBuoy className="w-5 h-5 text-text-secondary" />,

--- a/src/components/Settings/settingsTabRegistry.tsx
+++ b/src/components/Settings/settingsTabRegistry.tsx
@@ -4,6 +4,7 @@ import {
   Command,
   FileCode,
   GitBranch,
+  History,
   LayoutGrid,
   Mic,
   Package,
@@ -98,6 +99,7 @@ const importIntegrationsTab = () => import("./IntegrationsTab");
 const importVoiceInputSettingsTab = () => import("./VoiceInputSettingsTab");
 const importMcpServerSettingsTab = () => import("./McpServerSettingsTab");
 const importPluginActionsSettingsTab = () => import("./PluginActionsSettingsTab");
+const importRunHistorySettingsTab = () => import("./RunHistorySettingsTab");
 const importPluginsTab = () => import("./PluginsTab");
 const importDaintreeAssistantSettingsTab = () => import("./DaintreeAssistantSettingsTab");
 const importEnvironmentSettingsTab = () => import("./EnvironmentSettingsTab");
@@ -154,6 +156,9 @@ const LazyMcpServerSettingsTab = lazy(() =>
 );
 const LazyPluginActionsSettingsTab = lazy(() =>
   importPluginActionsSettingsTab().then((m) => ({ default: m.PluginActionsSettingsTab }))
+);
+const LazyRunHistorySettingsTab = lazy(() =>
+  importRunHistorySettingsTab().then((m) => ({ default: m.RunHistorySettingsTab }))
 );
 const LazyPluginsTab = lazy(() => importPluginsTab().then((m) => ({ default: m.PluginsTab })));
 const LazyDaintreeAssistantSettingsTab = lazy(() =>
@@ -1415,6 +1420,50 @@ export const SETTINGS_REGISTRY = [
         description:
           "Append a structured audit record each time an installed plugin dispatches an action. Arguments are hashed by default.",
         keywords: ["plugin", "audit", "log", "record", "actions", "dispatch", "hash", "privacy"],
+      },
+    ],
+  } satisfies LazySettingsTabEntry,
+
+  {
+    id: "run-history",
+    scope: "global",
+    group: "Integrations",
+    label: "Run history",
+    headerTitle: "Run history",
+    icon: <History className="w-4 h-4" />,
+    importKind: "lazy",
+    importer: importRunHistorySettingsTab,
+    LazyComponent: LazyRunHistorySettingsTab,
+    searchNavDescription: "Durable history of recipe runs and fleet broadcasts",
+    searchNavKeywords: [
+      "integrations",
+      "run",
+      "history",
+      "recipe",
+      "fleet",
+      "broadcast",
+      "automation",
+      "outcome",
+      "audit",
+    ],
+    sections: [
+      {
+        id: "run-history-log",
+        section: "Run history",
+        title: "Run history",
+        description:
+          "Review each recipe run and fleet broadcast, including spawned terminals, targets, and failures. Clear the log at any time.",
+        keywords: [
+          "run",
+          "history",
+          "recipe",
+          "fleet",
+          "broadcast",
+          "automation",
+          "outcome",
+          "spawned",
+          "clear",
+        ],
       },
     ],
   } satisfies LazySettingsTabEntry,

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -92,6 +92,15 @@ vi.mock("../panelStore", () => ({
   },
 }));
 
+// runRecipeWithResults records the run via window.electron.runHistory.append
+// (fire-and-forget). Stub it so the call resolves cleanly in tests.
+const runHistoryAppendMock = vi.fn().mockResolvedValue(undefined);
+(globalThis as { window?: unknown }).window = {
+  electron: {
+    runHistory: { append: runHistoryAppendMock },
+  },
+};
+
 import { useRecipeStore } from "../recipeStore";
 import { usePanelLimitStore } from "../panelLimitStore";
 

--- a/src/store/__tests__/runHistoryStore.test.ts
+++ b/src/store/__tests__/runHistoryStore.test.ts
@@ -15,8 +15,8 @@ function makeRecord(id: string): RunHistoryRecord {
 }
 
 let eventCallback: ((records: RunHistoryRecord[]) => void) | null = null;
-const getRecords = vi.fn<[], Promise<RunHistoryRecord[]>>();
-const clear = vi.fn<[], Promise<void>>();
+const getRecords = vi.fn<() => Promise<RunHistoryRecord[]>>();
+const clear = vi.fn<() => Promise<void>>();
 const eventsOn = vi.fn((_name: string, cb: (records: RunHistoryRecord[]) => void) => {
   eventCallback = cb;
   return () => {
@@ -69,13 +69,45 @@ describe("runHistoryStore", () => {
     expect(useRunHistoryStore.getState().loading).toBe(false);
   });
 
-  it("clear calls the IPC and optimistically empties the local mirror", async () => {
+  it("clear calls the IPC; the empty state arrives via the push path", async () => {
     useRunHistoryStore.getState().init();
     await vi.waitFor(() => expect(eventCallback).not.toBeNull());
     eventCallback!([makeRecord("x")]);
     await useRunHistoryStore.getState().clear();
     expect(clear).toHaveBeenCalledTimes(1);
+    // The clear handler broadcasts the empty snapshot synchronously; simulate
+    // that push arriving and assert the mirror empties.
+    eventCallback!([]);
     expect(useRunHistoryStore.getState().records).toEqual([]);
+  });
+
+  it("clear does not clobber a concurrent append push from another window", async () => {
+    useRunHistoryStore.getState().init();
+    await vi.waitFor(() => expect(eventCallback).not.toBeNull());
+    eventCallback!([makeRecord("x")]);
+    // Another window appends mid-clear: its broadcast arrives before clear resolves.
+    const clearPromise = useRunHistoryStore.getState().clear();
+    eventCallback!([makeRecord("x"), makeRecord("y")]);
+    await clearPromise;
+    // No optimistic wipe — the concurrent push survives.
+    expect(useRunHistoryStore.getState().records.map((r) => r.id)).toEqual(["x", "y"]);
+  });
+
+  it("a stale getRecords snapshot does not overwrite a fresher push", async () => {
+    let resolveGet: (records: RunHistoryRecord[]) => void = () => {};
+    getRecords.mockReturnValue(
+      new Promise<RunHistoryRecord[]>((resolve) => {
+        resolveGet = resolve;
+      })
+    );
+    useRunHistoryStore.getState().init();
+    await vi.waitFor(() => expect(eventCallback).not.toBeNull());
+    // A push lands before the pull resolves.
+    eventCallback!([makeRecord("fresh")]);
+    // The pull resolves later with stale data — it must not overwrite.
+    resolveGet([makeRecord("stale")]);
+    await vi.waitFor(() => expect(useRunHistoryStore.getState().loading).toBe(false));
+    expect(useRunHistoryStore.getState().records.map((r) => r.id)).toEqual(["fresh"]);
   });
 
   it("survives a getRecords rejection without staying in loading", async () => {

--- a/src/store/__tests__/runHistoryStore.test.ts
+++ b/src/store/__tests__/runHistoryStore.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RunHistoryRecord } from "@shared/types";
+
+function makeRecord(id: string): RunHistoryRecord {
+  return {
+    id,
+    schemaVersion: 1,
+    timestamp: 0,
+    kind: "recipe",
+    recipeName: id,
+    totalTerminals: 1,
+    spawned: [],
+    failed: [],
+  };
+}
+
+let eventCallback: ((records: RunHistoryRecord[]) => void) | null = null;
+const getRecords = vi.fn<[], Promise<RunHistoryRecord[]>>();
+const clear = vi.fn<[], Promise<void>>();
+const eventsOn = vi.fn((_name: string, cb: (records: RunHistoryRecord[]) => void) => {
+  eventCallback = cb;
+  return () => {
+    eventCallback = null;
+  };
+});
+
+(globalThis as { window?: unknown }).window = {
+  electron: {
+    runHistory: { getRecords, clear },
+    events: { on: eventsOn },
+  },
+};
+
+// Imported after the window stub so the module's top-level references resolve.
+const { useRunHistoryStore, _resetRunHistoryStoreForTest } = await import("../runHistoryStore.js");
+
+describe("runHistoryStore", () => {
+  beforeEach(() => {
+    getRecords.mockReset().mockResolvedValue([]);
+    clear.mockReset().mockResolvedValue(undefined);
+    eventsOn.mockClear();
+    eventCallback = null;
+    _resetRunHistoryStoreForTest();
+  });
+  afterEach(() => {
+    _resetRunHistoryStoreForTest();
+  });
+
+  it("pulls a snapshot on init and clears the loading flag", async () => {
+    getRecords.mockResolvedValue([makeRecord("a")]);
+    useRunHistoryStore.getState().init();
+    await vi.waitFor(() => {
+      expect(useRunHistoryStore.getState().loading).toBe(false);
+    });
+    expect(useRunHistoryStore.getState().records.map((r) => r.id)).toEqual(["a"]);
+  });
+
+  it("is idempotent — repeated init subscribes only once", () => {
+    useRunHistoryStore.getState().init();
+    useRunHistoryStore.getState().init();
+    expect(eventsOn).toHaveBeenCalledTimes(1);
+  });
+
+  it("updates records when the event bus pushes a fresh snapshot", async () => {
+    useRunHistoryStore.getState().init();
+    await vi.waitFor(() => expect(eventCallback).not.toBeNull());
+    eventCallback!([makeRecord("x"), makeRecord("y")]);
+    expect(useRunHistoryStore.getState().records.map((r) => r.id)).toEqual(["x", "y"]);
+    expect(useRunHistoryStore.getState().loading).toBe(false);
+  });
+
+  it("clear calls the IPC and optimistically empties the local mirror", async () => {
+    useRunHistoryStore.getState().init();
+    await vi.waitFor(() => expect(eventCallback).not.toBeNull());
+    eventCallback!([makeRecord("x")]);
+    await useRunHistoryStore.getState().clear();
+    expect(clear).toHaveBeenCalledTimes(1);
+    expect(useRunHistoryStore.getState().records).toEqual([]);
+  });
+
+  it("survives a getRecords rejection without staying in loading", async () => {
+    getRecords.mockRejectedValue(new Error("boom"));
+    useRunHistoryStore.getState().init();
+    await vi.waitFor(() => {
+      expect(useRunHistoryStore.getState().loading).toBe(false);
+    });
+  });
+});

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -21,6 +21,7 @@ import { isInRepoRecipeId, safeRecipeFilename } from "@shared/utils/recipeFilena
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { notify } from "@/lib/notify";
 import { logError } from "@/utils/logger";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { isClientAppError } from "@/utils/clientAppError";
 import { useRecipeConflictStore } from "@/store/recipeConflictStore";
 
@@ -890,6 +891,31 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
     if (!suppressFocus && results.spawned.length > 0) {
       terminalStore.setFocused(results.spawned[results.spawned.length - 1]!.terminalId);
     }
+
+    // Record this run in the durable history (#9949). Fire-and-forget AFTER the
+    // spawn batch has flushed (above) so the IPC write can't interleave with the
+    // deferred `panelIds` commit (#9345); a thrown IPC error must never fail the
+    // run, so we `void` + `.catch`. Pane titles are snapshotted from the live
+    // registry so the record stays legible after a terminal closes.
+    const panelsForTitles = usePanelStore.getState().panelsById;
+    safeFireAndForget(
+      window.electron.runHistory.append({
+        kind: "recipe",
+        recipeId: resolvedId,
+        recipeName: recipe.name,
+        worktreeId,
+        worktreeName: context?.branchName,
+        totalTerminals: recipe.terminals.length,
+        durationMs: Date.now() - now,
+        spawned: results.spawned.map((s) => ({
+          index: s.index,
+          terminalId: s.terminalId,
+          title: panelsForTitles[s.terminalId]?.title,
+        })),
+        failed: results.failed,
+      }),
+      { context: "Failed to record recipe run history" }
+    );
 
     return results;
   },

--- a/src/store/runHistoryStore.ts
+++ b/src/store/runHistoryStore.ts
@@ -1,0 +1,63 @@
+import { create } from "zustand";
+import { logError } from "@/utils/logger";
+import type { RunHistoryRecord } from "@shared/types";
+
+/**
+ * Renderer mirror of the durable run-history ring buffer (#9949). The source of
+ * truth is the Main-process `RunHistoryLog` (persisted in electron-store); this
+ * store is NOT persisted — it pulls a fresh snapshot on first mount and stays
+ * current via the `run-history:update` event bus push (also replayed to
+ * cold-started / LRU-restored views via `onViewReady`). Keeping it
+ * non-persisted avoids a second, drift-prone source of truth across windows.
+ */
+interface RunHistoryState {
+  records: RunHistoryRecord[];
+  loading: boolean;
+  /** Idempotent: pulls the current snapshot and subscribes to live updates. */
+  init: () => void;
+  /** Clear the durable log (and optimistically the local mirror). */
+  clear: () => Promise<void>;
+}
+
+let initialized = false;
+let unsubscribe: (() => void) | null = null;
+
+export const useRunHistoryStore = create<RunHistoryState>((set) => ({
+  records: [],
+  loading: true,
+  init: () => {
+    if (initialized) return;
+    initialized = true;
+
+    // Live updates: the main process pushes the full newest-first snapshot on
+    // every append/clear, and replays it to freshly-loaded views.
+    unsubscribe = window.electron.events.on("run-history:update", (records) => {
+      set({ records, loading: false });
+    });
+
+    // Pull-on-mount so we have data even before the first push arrives.
+    window.electron.runHistory
+      .getRecords()
+      .then((records) => set({ records, loading: false }))
+      .catch((err) => {
+        logError("Failed to load run history", err);
+        set({ loading: false });
+      });
+  },
+  clear: async () => {
+    try {
+      await window.electron.runHistory.clear();
+      set({ records: [] });
+    } catch (err) {
+      logError("Failed to clear run history", err);
+    }
+  },
+}));
+
+/** Test-only: reset the module-level init guard between cases. */
+export function _resetRunHistoryStoreForTest(): void {
+  unsubscribe?.();
+  unsubscribe = null;
+  initialized = false;
+  useRunHistoryStore.setState({ records: [], loading: true });
+}

--- a/src/store/runHistoryStore.ts
+++ b/src/store/runHistoryStore.ts
@@ -21,6 +21,11 @@ interface RunHistoryState {
 
 let initialized = false;
 let unsubscribe: (() => void) | null = null;
+// True once an `run-history:update` push has populated the store. The pull-on-
+// mount `getRecords()` resolves asynchronously and can land AFTER a fresher
+// push during init (or during another window's concurrent append) — when a
+// push has already arrived, the stale snapshot must not overwrite it.
+let receivedPush = false;
 
 export const useRunHistoryStore = create<RunHistoryState>((set) => ({
   records: [],
@@ -30,15 +35,18 @@ export const useRunHistoryStore = create<RunHistoryState>((set) => ({
     initialized = true;
 
     // Live updates: the main process pushes the full newest-first snapshot on
-    // every append/clear, and replays it to freshly-loaded views.
+    // every append/clear, and replays it to freshly-loaded views. This is the
+    // authoritative data path.
     unsubscribe = window.electron.events.on("run-history:update", (records) => {
+      receivedPush = true;
       set({ records, loading: false });
     });
 
-    // Pull-on-mount so we have data even before the first push arrives.
+    // Pull-on-mount so we have data even before the first push arrives. Skip
+    // applying the snapshot if a push already won the race — only clear loading.
     window.electron.runHistory
       .getRecords()
-      .then((records) => set({ records, loading: false }))
+      .then((records) => set(receivedPush ? { loading: false } : { records, loading: false }))
       .catch((err) => {
         logError("Failed to load run history", err);
         set({ loading: false });
@@ -46,8 +54,11 @@ export const useRunHistoryStore = create<RunHistoryState>((set) => ({
   },
   clear: async () => {
     try {
+      // No optimistic `set({ records: [] })`: the clear IPC handler calls
+      // `broadcastRunHistory()` synchronously before it resolves, so the empty
+      // snapshot arrives via the push path. An optimistic clear here could
+      // instead clobber a concurrent append broadcast from another window.
       await window.electron.runHistory.clear();
-      set({ records: [] });
     } catch (err) {
       logError("Failed to clear run history", err);
     }
@@ -59,5 +70,6 @@ export function _resetRunHistoryStoreForTest(): void {
   unsubscribe?.();
   unsubscribe = null;
   initialized = false;
+  receivedPush = false;
   useRunHistoryStore.setState({ records: [], loading: true });
 }


### PR DESCRIPTION
## Summary

- `runRecipeWithResults` and `executeFleetBroadcast` both compute a full structured account of each run then discard it. This writes those results to a durable ring buffer instead, making run history inspectable after the fact.
- Storage is a Main-process `electron-store` ring buffer (modelled on `ForgeAuditService`) — fixed 100-record cap, debounced flush, drained on shutdown. Survives reloads and multi-window LRU eviction; renderer `localStorage` was rejected for that reason.
- Terminal and worktree references are stored as snapshots (IDs + pane titles) so stale IDs never dereference dead objects.

Resolves #9949

## Changes

**Storage / IPC**
- `RunHistoryLog` ring buffer in `electron/services/runHistory/` with Zod validation at the renderer trust boundary; `id`, `schemaVersion`, and `timestamp` are stamped server-side; all free-text and per-target fields are length-capped.
- New `run-history` IPC namespace: `get-records`, `append`, `clear` (`electron/ipc/handlers/runHistory.ts` + preload).
- `hydrate` backfills missing array fields so a corrupted store never crashes the viewer.

**Cross-window sync**
- Snapshots broadcast over the events bus; replayed to cold/LRU-restored views via `onViewReady` (same pattern as #9490).
- Renderer store (`src/store/runHistoryStore.ts`) is non-persisted and push-authoritative. Two sync races resolved: stale `get-records` vs push, and optimistic clear vs concurrent append.

**Call sites**
- `runRecipeWithResults` records after the spawn-batch flush to avoid the `panelIds` interleave from #9345.
- `fleetEnterBroadcast` records resolved results only. Both paths are `safeFireAndForget` so recording never blocks automation UX.

**UI**
- New `RunHistorySettingsTab` under Integrations: recipe and fleet rows with counts, failure breakdown, and a `ConfirmDialog`-gated Clear action (`src/components/Settings/RunHistorySettingsTab.tsx`).

## Testing

- `RunHistoryLog` ring buffer unit tests including `hydrate` backfill and eviction.
- Zod schema boundary tests (`electron/schemas/__tests__/runHistory.test.ts`).
- Renderer store tests including cross-window sync race coverage (`src/store/__tests__/runHistoryStore.test.ts`).
- Updated existing recipe, fleet, and settings-registry tests.

Note: 157 test failures in the full suite on `develop` are pre-existing (PtyClient / gpuDetection / lifecycle shutdown) and unrelated to this branch.