### PR TITLE
feat(assistant): surface live help-session tier and grants in settings (#10032)

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -722,6 +722,7 @@ export const CHANNELS = {
   // Help assistant settings channels
   HELP_ASSISTANT_GET_SETTINGS: "help-assistant:get-settings",
   HELP_ASSISTANT_SET_SETTINGS: "help-assistant:set-settings",
+  HELP_ASSISTANT_GET_LIVE_SESSION_STATUS: "help-assistant:get-live-session-status",
 
   // Onboarding channels
   ONBOARDING_GET: "onboarding:get",

--- a/electron/ipc/handlers/__tests__/helpAssistant.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/helpAssistant.handlers.test.ts
@@ -30,14 +30,37 @@ const utilsMock = vi.hoisted(() => ({
     );
     return () => ipcMainMock.removeHandler(channel);
   },
+  // Mirrors the real wrapper: parse the first arg with the Zod schema, then
+  // invoke the handler with (ctx, parsedPayload). Tests pass a ctx-like object
+  // (carrying webContentsId) as the first stored-handler argument.
+  typedHandleWithContextValidated: (
+    channel: string,
+    schema: { parse: (v: unknown) => unknown },
+    handler: unknown
+  ) => {
+    // async so a synchronous schema.parse throw surfaces as a rejected promise
+    // (matching the real wrapper / ipcMain.handle behaviour the handler relies on).
+    ipcMainMock.handle(channel, async (ctx: unknown, payload: unknown) => {
+      const parsed = schema.parse(payload);
+      return (handler as (c: unknown, p: unknown) => unknown)(ctx, parsed);
+    });
+    return () => ipcMainMock.removeHandler(channel);
+  },
 }));
 
 vi.mock("../../utils.js", () => utilsMock);
+
+const mcpServiceMock = vi.hoisted(() => ({
+  getHelpSessionLiveStatus: vi.fn(),
+}));
+
+vi.mock("../../../services/McpServerService.js", () => ({ mcpServerService: mcpServiceMock }));
 
 import { registerHelpAssistantHandlers } from "../helpAssistant.js";
 
 const GET_CHANNEL = "help-assistant:get-settings";
 const SET_CHANNEL = "help-assistant:set-settings";
+const LIVE_STATUS_CHANNEL = "help-assistant:get-live-session-status";
 
 describe("registerHelpAssistantHandlers", () => {
   beforeEach(() => {
@@ -435,5 +458,67 @@ describe("registerHelpAssistantHandlers", () => {
 
     const result = await handler(null);
     expect(result).toMatchObject({ customArgs: "--model sonnet" });
+  });
+});
+
+describe("registerHelpAssistantHandlers — getLiveSessionStatus (#10032)", () => {
+  const CTX = { webContentsId: 4242 };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ipcMainMock._handlers.clear();
+  });
+
+  it("returns a connected snapshot shaped from the service result", async () => {
+    mcpServiceMock.getHelpSessionLiveStatus.mockReturnValue({
+      tier: "system",
+      activeGrants: [{ toolId: "terminal.kill", expiresAt: 1000, ttlMs: 500 }],
+    });
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(LIVE_STATUS_CHANNEL)!;
+
+    const result = await handler(CTX, { sessionId: "help-1" });
+
+    expect(result).toEqual({
+      connected: true,
+      tier: "system",
+      activeGrants: [{ toolId: "terminal.kill", expiresAt: 1000, ttlMs: 500 }],
+    });
+    // The public help id and the caller's webContentsId are threaded through.
+    expect(mcpServiceMock.getHelpSessionLiveStatus).toHaveBeenCalledWith("help-1", 4242);
+  });
+
+  it("returns safe disconnected defaults when the service finds no live session", async () => {
+    mcpServiceMock.getHelpSessionLiveStatus.mockReturnValue(null);
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(LIVE_STATUS_CHANNEL)!;
+
+    const result = await handler(CTX, { sessionId: "help-1" });
+
+    expect(result).toEqual({ connected: false, tier: "workbench", activeGrants: [] });
+  });
+
+  it("narrows an unexpected external tier down to a safe HelpAssistantTier", async () => {
+    // Help sessions are never "external", but the service tier is an McpTier
+    // which admits it — the handler must never surface it on the IPC contract.
+    mcpServiceMock.getHelpSessionLiveStatus.mockReturnValue({
+      tier: "external",
+      activeGrants: [],
+    });
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(LIVE_STATUS_CHANNEL)!;
+
+    const result = await handler(CTX, { sessionId: "help-1" });
+
+    expect(result).toMatchObject({ connected: true, tier: "workbench" });
+  });
+
+  it("rejects a payload with a missing/empty sessionId before reaching the service", async () => {
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(LIVE_STATUS_CHANNEL)!;
+
+    await expect(handler(CTX, { sessionId: "" })).rejects.toThrow();
+    await expect(handler(CTX, {})).rejects.toThrow();
+    expect(mcpServiceMock.getHelpSessionLiveStatus).not.toHaveBeenCalled();
   });
 });

--- a/electron/ipc/handlers/helpAssistant.preload.ts
+++ b/electron/ipc/handlers/helpAssistant.preload.ts
@@ -3,6 +3,7 @@ import type { IpcInvokeMap } from "../../types/index.js";
 export const HELP_ASSISTANT_METHOD_CHANNELS = {
   getSettings: "help-assistant:get-settings",
   setSettings: "help-assistant:set-settings",
+  getLiveSessionStatus: "help-assistant:get-live-session-status",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof HELP_ASSISTANT_METHOD_CHANNELS;

--- a/electron/ipc/handlers/helpAssistant.ts
+++ b/electron/ipc/handlers/helpAssistant.ts
@@ -1,11 +1,14 @@
 // eager-import-allow: reads help-assistant settings via store.get synchronously in the IPC handler
 import { store } from "../../store.js";
-import { defineIpcNamespace, op } from "../define.js";
+import { z } from "zod";
+import { defineIpcNamespace, op, opValidated } from "../define.js";
+import type { IpcContext } from "../types.js";
 import { HELP_ASSISTANT_METHOD_CHANNELS } from "./helpAssistant.preload.js";
 import type {
   HelpAssistantAuditRetention,
   HelpAssistantIdleHibernateMinutes,
   HelpAssistantSettings,
+  HelpSessionLiveStatus,
 } from "../../../shared/types/ipc/api.js";
 import type { HelpAssistantTier } from "../../../shared/types/ipc/maps.js";
 import { hasShellMetachar } from "../../../shared/utils/shellEscape.js";
@@ -100,6 +103,21 @@ export function getHelpAssistantSettings(): HelpAssistantSettings {
   return { ...HELP_ASSISTANT_DEFAULTS, ...sanitizeStored(stored) };
 }
 
+// Safe "no live session" snapshot returned when the caller has no pinned help
+// session — the renderer renders this as a quiet idle state, never a spinner.
+const DISCONNECTED_LIVE_STATUS: HelpSessionLiveStatus = {
+  connected: false,
+  tier: "workbench",
+  activeGrants: [],
+};
+
+// The session-store tier is an `McpTier` which also admits `"external"` for
+// api-key/loopback sessions. Help-session bearers are never external, but
+// narrow defensively so the IPC surface only ever exposes a HelpAssistantTier.
+function narrowToHelpAssistantTier(tier: string): HelpAssistantTier {
+  return isValidHelpAssistantTier(tier) ? tier : "workbench";
+}
+
 export const helpAssistantNamespace = defineIpcNamespace({
   name: "helpAssistant",
   ops: {
@@ -164,6 +182,24 @@ export const helpAssistantNamespace = defineIpcNamespace({
           }
         }
       }
+    ),
+    getLiveSessionStatus: opValidated(
+      HELP_ASSISTANT_METHOD_CHANNELS.getLiveSessionStatus,
+      z.object({ sessionId: z.string().min(1) }),
+      async (
+        ctx: IpcContext,
+        { sessionId }: { sessionId: string }
+      ): Promise<HelpSessionLiveStatus> => {
+        const svc = await getMcpServerService();
+        const live = svc.getHelpSessionLiveStatus(sessionId, ctx.webContentsId);
+        if (!live) return DISCONNECTED_LIVE_STATUS;
+        return {
+          connected: true,
+          tier: narrowToHelpAssistantTier(live.tier),
+          activeGrants: live.activeGrants,
+        };
+      },
+      { withContext: true }
     ),
   },
 });

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -505,6 +505,25 @@ export class McpServerService {
   }
 
   /**
+   * Live tier + per-tool grants for the help session a renderer owns, keyed
+   * by its public help-session id (the one in `helpPanelStore`). Caller-pinned
+   * against the WebContents the session was pinned to at handshake. Returns
+   * `null` when there is no live session for that renderer — the IPC handler
+   * maps that to a safe "not connected" snapshot. Delegates to
+   * {@link SessionStore.getLiveStatusForHelpSession} for the transport-id
+   * reverse-lookup the maps require.
+   */
+  getHelpSessionLiveStatus(
+    helpSessionId: string,
+    callerWcId: number
+  ): {
+    tier: McpTier;
+    activeGrants: Array<{ toolId: string; expiresAt: number; ttlMs: number }>;
+  } | null {
+    return this.sessionStore.getLiveStatusForHelpSession(helpSessionId, callerWcId);
+  }
+
+  /**
    * Snapshot of the bearers currently connected to the local MCP server for
    * the settings tab. Raw tokens are never returned — only the display suffix
    * and the hash used to target {@link disconnectBearer}.

--- a/electron/services/mcp-server/__tests__/sessionStore.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionStore.test.ts
@@ -1058,3 +1058,88 @@ describe("SessionStore.nextFigureNumber (#9828)", () => {
     expect(store.figureCounters.size).toBe(0);
   });
 });
+
+describe("SessionStore.getLiveStatusForHelpSession (#10032)", () => {
+  let store: SessionStore;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    store = new SessionStore(() => {});
+  });
+
+  afterEach(() => {
+    store.grantCache.dispose();
+    vi.useRealTimers();
+  });
+
+  const WC = 4242;
+  const TRANSPORT = "transport-x";
+  const HELP_ID = "help-public-1";
+
+  function wireLiveHelpSession(opts?: { tier?: "workbench" | "action" | "system" }): void {
+    store.httpSessions.set(TRANSPORT, fakeHttpSession());
+    store.sessionWebContentsMap.set(TRANSPORT, WC);
+    store.sessionHelpIdMap.set(TRANSPORT, HELP_ID);
+    if (opts?.tier) store.sessionTierMap.set(TRANSPORT, opts.tier);
+  }
+
+  it("resolves the transport session from the public help id and returns its live tier", () => {
+    wireLiveHelpSession({ tier: "system" });
+
+    const result = store.getLiveStatusForHelpSession(HELP_ID, WC);
+
+    expect(result).not.toBeNull();
+    expect(result?.tier).toBe("system");
+    expect(result?.activeGrants).toEqual([]);
+  });
+
+  it("defaults the tier to workbench when the tier map has no entry", () => {
+    wireLiveHelpSession();
+
+    expect(store.getLiveStatusForHelpSession(HELP_ID, WC)?.tier).toBe("workbench");
+  });
+
+  it("maps active grants to {toolId, expiresAt, ttlMs} for the resolved transport id", () => {
+    wireLiveHelpSession({ tier: "action" });
+    store.grantCache.issueGrant(TRANSPORT, "terminal.kill");
+    store.grantCache.issueGrant(TRANSPORT, "git.push");
+    // A grant on an unrelated session must not leak into this snapshot.
+    store.grantCache.issueGrant("other-transport", "worktree.delete");
+
+    const grants = store.getLiveStatusForHelpSession(HELP_ID, WC)?.activeGrants ?? [];
+
+    expect(grants.map((g) => g.toolId).sort()).toEqual(["git.push", "terminal.kill"]);
+    for (const grant of grants) {
+      expect(grant.expiresAt).toBeGreaterThan(Date.now());
+      expect(grant.ttlMs).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns null when the caller is not the pinned WebContents (forgery defence)", () => {
+    wireLiveHelpSession({ tier: "system" });
+
+    expect(store.getLiveStatusForHelpSession(HELP_ID, WC + 1)).toBeNull();
+  });
+
+  it("returns null when the help id maps to no transport session", () => {
+    wireLiveHelpSession({ tier: "system" });
+
+    expect(store.getLiveStatusForHelpSession("unknown-help", WC)).toBeNull();
+  });
+
+  it("returns null when the tier map outlives a closed transport (decaying session)", () => {
+    // Tier + pin still present, but the transport was already removed — the
+    // session is no longer live and must not report as connected.
+    store.sessionWebContentsMap.set(TRANSPORT, WC);
+    store.sessionHelpIdMap.set(TRANSPORT, HELP_ID);
+    store.sessionTierMap.set(TRANSPORT, "system");
+
+    expect(store.getLiveStatusForHelpSession(HELP_ID, WC)).toBeNull();
+  });
+
+  it("returns null for an empty help id", () => {
+    wireLiveHelpSession({ tier: "system" });
+
+    expect(store.getLiveStatusForHelpSession("", WC)).toBeNull();
+  });
+});

--- a/electron/services/mcp-server/__tests__/sessionStore.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionStore.test.ts
@@ -1142,4 +1142,33 @@ describe("SessionStore.getLiveStatusForHelpSession (#10032)", () => {
 
     expect(store.getLiveStatusForHelpSession("", WC)).toBeNull();
   });
+
+  it("omits grants past their expiry that the sweep hasn't yet evicted", () => {
+    wireLiveHelpSession({ tier: "action" });
+    // Issue one grant, advance the wall clock past its expiry WITHOUT firing
+    // the sweep interval (setSystemTime doesn't run timers), then issue a
+    // second one still in its window. The first lingers in the cache (lazy
+    // eviction) but must not surface as active.
+    const expired = store.grantCache.issueGrant(TRANSPORT, "git.push");
+    vi.setSystemTime(expired.expiresAt + 1);
+    store.grantCache.issueGrant(TRANSPORT, "terminal.kill");
+
+    const grants = store.getLiveStatusForHelpSession(HELP_ID, WC)?.activeGrants ?? [];
+
+    expect(grants.map((g) => g.toolId)).toEqual(["terminal.kill"]);
+  });
+
+  it("finds the caller's live transport even when a stale same-help-id mapping is iterated first", () => {
+    // A reconnect left an older transport for the same help id pinned to a
+    // different WebContents; it must not short-circuit the lookup before the
+    // caller's own live transport is reached.
+    store.httpSessions.set("stale-transport", fakeHttpSession());
+    store.sessionWebContentsMap.set("stale-transport", WC + 99);
+    store.sessionHelpIdMap.set("stale-transport", HELP_ID);
+    store.sessionTierMap.set("stale-transport", "workbench");
+
+    wireLiveHelpSession({ tier: "system" });
+
+    expect(store.getLiveStatusForHelpSession(HELP_ID, WC)?.tier).toBe("system");
+  });
 });

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -604,6 +604,48 @@ export class SessionStore {
     return this.sessionTierMap.get(sessionId) ?? "workbench";
   }
 
+  /**
+   * Snapshot the live tier and per-tool grants for a help session, addressed
+   * by its *public* help-session id (the one persisted in the renderer's
+   * `helpPanelStore`, NOT the per-connection MCP transport sessionId that keys
+   * these maps). Resolves the transport sessionId through {@link sessionHelpIdMap}
+   * before reading the tier/grant state.
+   *
+   * Caller-pinned: returns `null` unless `callerWebContentsId` matches the
+   * WebContents the session was pinned to at handshake — mirrors the
+   * cross-window forgery defence on `setSessionTier`/`issueGrant`, so a renderer
+   * can only ever read its own session's live status. Also returns `null` when
+   * no live transport exists for the help id (session never connected, idled
+   * out, or was revoked) so the caller renders a "no live session" state rather
+   * than a stale snapshot.
+   */
+  getLiveStatusForHelpSession(
+    helpSessionId: string,
+    callerWebContentsId: number
+  ): {
+    tier: McpTier;
+    activeGrants: Array<{ toolId: string; expiresAt: number; ttlMs: number }>;
+  } | null {
+    if (!helpSessionId) return null;
+    for (const [transportSessionId, mappedHelpId] of this.sessionHelpIdMap) {
+      if (mappedHelpId !== helpSessionId) continue;
+      // Caller-pin: only the renderer the session was pinned to may read it.
+      if (this.sessionWebContentsMap.get(transportSessionId) !== callerWebContentsId) {
+        return null;
+      }
+      // The tier map can briefly outlive the transport during teardown; require
+      // a live transport so a decaying session never reports as connected.
+      if (!this.sessions.has(transportSessionId) && !this.httpSessions.has(transportSessionId)) {
+        return null;
+      }
+      const activeGrants = this.grantCache
+        .getActiveGrants(transportSessionId)
+        .map((g) => ({ toolId: g.toolId, expiresAt: g.expiresAt, ttlMs: g.ttlMs }));
+      return { tier: this.getTier(transportSessionId), activeGrants };
+    }
+    return null;
+  }
+
   revokeSession(sessionId: string): boolean {
     const sseSession = this.sessions.get(sessionId);
     const httpSession = this.httpSessions.get(sessionId);

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -630,16 +630,25 @@ export class SessionStore {
     for (const [transportSessionId, mappedHelpId] of this.sessionHelpIdMap) {
       if (mappedHelpId !== helpSessionId) continue;
       // Caller-pin: only the renderer the session was pinned to may read it.
+      // `continue` (not `return null`) so a stale reconnect mapping pinned to a
+      // different WebContents iterated first can't mask the caller's own live
+      // transport — keep scanning, and only fail closed once nothing matches.
       if (this.sessionWebContentsMap.get(transportSessionId) !== callerWebContentsId) {
-        return null;
+        continue;
       }
       // The tier map can briefly outlive the transport during teardown; require
       // a live transport so a decaying session never reports as connected.
       if (!this.sessions.has(transportSessionId) && !this.httpSessions.has(transportSessionId)) {
-        return null;
+        continue;
       }
+      // getActiveGrants is lazy-eviction only — a grant past expiresAt can
+      // linger until the periodic sweep (~5min). Filter those out so the
+      // snapshot never reports a logically-expired grant as active; the next
+      // sweep's `grant.expired` push will reconcile the renderer anyway.
+      const now = Date.now();
       const activeGrants = this.grantCache
         .getActiveGrants(transportSessionId)
+        .filter((g) => g.expiresAt > now)
         .map((g) => ({ toolId: g.toolId, expiresAt: g.expiresAt, ttlMs: g.ttlMs }));
       return { tier: this.getTier(transportSessionId), activeGrants };
     }

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -258,6 +258,8 @@ export type {
   HelpAssistantSettings,
   HelpAssistantAuditRetention,
   HelpAssistantIdleHibernateMinutes,
+  HelpSessionLiveStatus,
+  HelpSessionActiveGrant,
   MicPermissionStatus,
   BranchInfo,
   CreateWorktreeOptions,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1819,3 +1819,30 @@ export interface HelpAssistantSettings {
    */
   idleHibernateMinutes: HelpAssistantIdleHibernateMinutes;
 }
+
+/** One per-tool grant currently active for the pinned help session. */
+export interface HelpSessionActiveGrant {
+  /** Dotted `BuiltInActionId` the grant authorizes (e.g. `terminal.kill`). */
+  toolId: string;
+  /** Absolute epoch millis when the grant expires without refresh. */
+  expiresAt: number;
+  /** TTL the grant was minted with, in milliseconds. */
+  ttlMs: number;
+}
+
+/**
+ * Live status snapshot of the currently pinned help session — the effective
+ * tier the session is *running at right now* (which a renderer-approved
+ * "Always allow" elevation can raise above the configured
+ * {@link HelpAssistantSettings.tier} default) plus the per-tool grants
+ * currently in effect. Distinct from the persisted settings: those describe
+ * the default for new sessions, this describes the live one. `connected` is
+ * false when there is no pinned help session for the caller's WebContents (no
+ * session, or the caller isn't the pinned renderer) — the tier/grants fields
+ * then carry safe defaults the UI renders as a quiet "no live session" state.
+ */
+export interface HelpSessionLiveStatus {
+  connected: boolean;
+  tier: HelpAssistantTier;
+  activeGrants: HelpSessionActiveGrant[];
+}

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -198,6 +198,9 @@ export interface GeneratedElectronAPI {
     ): Promise<IpcInvokeMap["help:unmark-terminal"]["result"]>;
   };
   helpAssistant: {
+    getLiveSessionStatus(
+      ...args: IpcInvokeMap["help-assistant:get-live-session-status"]["args"]
+    ): Promise<IpcInvokeMap["help-assistant:get-live-session-status"]["result"]>;
     getSettings(
       ...args: IpcInvokeMap["help-assistant:get-settings"]["args"]
     ): Promise<IpcInvokeMap["help-assistant:get-settings"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -361,6 +361,10 @@ export interface GeneratedIpcInvokeMap {
     ];
     result: void;
   };
+  "help-assistant:get-live-session-status": {
+    args: [__1: { sessionId: string }];
+    result: import("./api.js").HelpSessionLiveStatus;
+  };
   "help-assistant:get-settings": {
     args: [];
     result: import("./api.js").HelpAssistantSettings;

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -15,7 +15,7 @@ import {
 } from "lucide-react";
 import { DaintreeIcon, McpServerIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
-import { useDeferredLoading } from "@/hooks";
+import { useDeferredLoading, useHelpSessionLiveStatus } from "@/hooks";
 import { useMcpReadiness } from "@/hooks/useMcpReadiness";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { actionService } from "@/services/ActionService";
@@ -76,6 +76,30 @@ const TIER_DESCRIPTIONS: Record<HelpAssistantTier, string> = {
   system:
     "Adds operations that touch disk or external services: delete worktrees, commit/push git, write the system clipboard, open GitHub issues/PRs. Reserve for trusted automation.",
 };
+
+const TIER_SHORT_LABEL: Record<HelpAssistantTier, string> = {
+  workbench: "Workbench",
+  action: "Action",
+  system: "System",
+};
+
+const TIER_RANK: Record<HelpAssistantTier, number> = {
+  workbench: 0,
+  action: 1,
+  system: 2,
+};
+
+// Format a whole-seconds grant countdown as "Xm Ys" / "Xm" / "Ys". Exported
+// for unit coverage of the boundary cases (sub-minute, exact minute, mixed).
+export function formatGrantRemaining(totalSeconds: number): string {
+  const safe = Math.max(0, Math.floor(totalSeconds));
+  if (safe >= 60) {
+    const minutes = Math.floor(safe / 60);
+    const seconds = safe % 60;
+    return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  }
+  return `${safe}s`;
+}
 
 function groupToolsByNamespace(tools: readonly string[]): Array<[string, string[]]> {
   const groups = new Map<string, string[]>();
@@ -615,6 +639,8 @@ export function DaintreeAssistantSettingsTab() {
           onToggle={() => setShowBlastRadius((v) => !v)}
         />
 
+        <SessionLiveStatusCard configuredTier={settings.tier} />
+
         <SettingsSwitchCard
           variant="compact"
           icon={ShieldAlert}
@@ -904,6 +930,102 @@ function BlastRadiusPreview({ tier, isOpen, onToggle }: BlastRadiusPreviewProps)
               </div>
             </div>
           ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Per-tool grant expiry countdown. Re-renders once a second — a semantic
+// countdown (the decay IS the signal), so it sits outside the motion tiers.
+// The push event (`grant.expired`) is authoritative for removal; this is only
+// the display, so reaching zero shows "expiring" until the row is pulled out.
+function GrantCountdown({ expiresAt }: { expiresAt: number }) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+  const remainingMs = expiresAt - now;
+  return (
+    <span className="font-mono text-daintree-text/50 tabular-nums shrink-0">
+      {remainingMs <= 0 ? "expiring" : `expires in ${formatGrantRemaining(remainingMs / 1000)}`}
+    </span>
+  );
+}
+
+interface SessionLiveStatusCardProps {
+  configuredTier: HelpAssistantTier;
+}
+
+// Live status of the *currently pinned* help session — distinct from the
+// configured-default tier select above. Renders from safe `connected: false`
+// defaults immediately (no spinner, per the settings-tab loading rule) and
+// populates when the live-status bridge call resolves. Live-tier *change*
+// events while this is open aren't pushed (the grant-lifecycle push carries no
+// tier field — covered by #10027); the snapshot refreshes on mount and on any
+// grant-lifecycle event for this session.
+function SessionLiveStatusCard({ configuredTier }: SessionLiveStatusCardProps) {
+  const sessionId = useHelpPanelStore((s) => s.sessionId);
+  const { connected, tier, activeGrants } = useHelpSessionLiveStatus(sessionId);
+  const elevated = connected && TIER_RANK[tier] > TIER_RANK[configuredTier];
+
+  return (
+    <div className="rounded-[var(--radius-md)] border border-daintree-border bg-overlay-subtle/40 px-3 py-2.5 space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="flex items-center gap-2">
+          <span
+            className={cn(
+              "w-1.5 h-1.5 rounded-full shrink-0",
+              connected ? "bg-status-success" : "bg-daintree-text/30"
+            )}
+            aria-hidden="true"
+          />
+          <span className="text-xs text-daintree-text/80">
+            {connected ? "Live session" : "No live session"}
+          </span>
+        </span>
+        {connected && (
+          <span className="px-1.5 py-0.5 rounded text-[10px] font-mono bg-daintree-bg border border-daintree-border text-daintree-text/70">
+            {TIER_SHORT_LABEL[tier]}
+          </span>
+        )}
+      </div>
+
+      {connected ? (
+        <>
+          <div className="text-xs text-daintree-text/70 leading-relaxed">
+            Running at{" "}
+            <span className="text-daintree-text">{TIER_SHORT_LABEL[tier].toLowerCase()}</span>
+            {elevated
+              ? ` — elevated above the configured ${TIER_SHORT_LABEL[configuredTier].toLowerCase()} default`
+              : " — matches the configured default"}
+          </div>
+          {activeGrants.length > 0 ? (
+            <div className="space-y-1">
+              <div className="text-[10px] uppercase tracking-wide text-daintree-text/50 font-mono">
+                Active grants ({activeGrants.length})
+              </div>
+              <div className="space-y-1">
+                {activeGrants.map((grant) => (
+                  <div
+                    key={grant.toolId}
+                    className="flex items-center justify-between gap-2 text-[11px]"
+                  >
+                    <span className="font-mono text-daintree-text/70 truncate">{grant.toolId}</span>
+                    <GrantCountdown expiresAt={grant.expiresAt} />
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <div className="text-[11px] text-daintree-text/50">No per-tool grants active</div>
+          )}
+        </>
+      ) : (
+        <div className="text-xs text-daintree-text/60 leading-relaxed">
+          Open the assistant to start a session — its live tier and any active per-tool grants show
+          here
         </div>
       )}
     </div>

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -16,6 +16,7 @@ import {
 import { DaintreeIcon, McpServerIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { useDeferredLoading, useHelpSessionLiveStatus } from "@/hooks";
+import { useVisibilityAwareInterval } from "@/hooks/useVisibilityAwareInterval";
 import { useMcpReadiness } from "@/hooks/useMcpReadiness";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { actionService } from "@/services/ActionService";
@@ -942,10 +943,9 @@ function BlastRadiusPreview({ tier, isOpen, onToggle }: BlastRadiusPreviewProps)
 // the display, so reaching zero shows "expiring" until the row is pulled out.
 function GrantCountdown({ expiresAt }: { expiresAt: number }) {
   const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    const id = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(id);
-  }, []);
+  // Per-second tick that pauses while the window is hidden (the canonical
+  // compliant timer wrapper — direct setInterval is lint-restricted).
+  useVisibilityAwareInterval(() => setNow(Date.now()), 1000);
   const remainingMs = expiresAt - now;
   return (
     <span className="font-mono text-daintree-text/50 tabular-nums shrink-0">

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -968,7 +968,17 @@ interface SessionLiveStatusCardProps {
 function SessionLiveStatusCard({ configuredTier }: SessionLiveStatusCardProps) {
   const sessionId = useHelpPanelStore((s) => s.sessionId);
   const { connected, tier, activeGrants } = useHelpSessionLiveStatus(sessionId);
-  const elevated = connected && TIER_RANK[tier] > TIER_RANK[configuredTier];
+  // Three-way relation to the configured default: a renderer-approved elevation
+  // raises the live tier above it, but a session can also sit *below* it (e.g.
+  // a per-session choice or a decayed elevation) — both must read truthfully,
+  // not collapse to "matches".
+  const tierDelta = TIER_RANK[tier] - TIER_RANK[configuredTier];
+  const tierComparisonCopy =
+    tierDelta > 0
+      ? ` — elevated above the configured ${TIER_SHORT_LABEL[configuredTier].toLowerCase()} default`
+      : tierDelta < 0
+        ? ` — below the configured ${TIER_SHORT_LABEL[configuredTier].toLowerCase()} default`
+        : " — matches the configured default";
 
   return (
     <div className="rounded-[var(--radius-md)] border border-daintree-border bg-overlay-subtle/40 px-3 py-2.5 space-y-2">
@@ -997,9 +1007,7 @@ function SessionLiveStatusCard({ configuredTier }: SessionLiveStatusCardProps) {
           <div className="text-xs text-daintree-text/70 leading-relaxed">
             Running at{" "}
             <span className="text-daintree-text">{TIER_SHORT_LABEL[tier].toLowerCase()}</span>
-            {elevated
-              ? ` — elevated above the configured ${TIER_SHORT_LABEL[configuredTier].toLowerCase()} default`
-              : " — matches the configured default"}
+            {tierComparisonCopy}
           </div>
           {activeGrants.length > 0 ? (
             <div className="space-y-1">

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -117,6 +117,7 @@ vi.mock("../SettingsInput", () => ({
 
 const helpPanelState = {
   preferredAgentId: null as string | null,
+  sessionId: null as string | null,
   setPreferredAgent: vi.fn(),
 };
 
@@ -157,6 +158,7 @@ const writeText = vi.fn().mockResolvedValue(undefined);
 interface HelpAssistantApi {
   getSettings: ReturnType<typeof vi.fn>;
   setSettings: ReturnType<typeof vi.fn>;
+  getLiveSessionStatus: ReturnType<typeof vi.fn>;
 }
 
 interface McpServerApi {
@@ -166,6 +168,7 @@ interface McpServerApi {
   rotateApiKey: ReturnType<typeof vi.fn>;
   getConfigSnippet: ReturnType<typeof vi.fn>;
   onRuntimeStateChanged: ReturnType<typeof vi.fn>;
+  onGrantLifecycle: ReturnType<typeof vi.fn>;
   getAuditRecords: ReturnType<typeof vi.fn>;
   getLogRecords: ReturnType<typeof vi.fn>;
   getAuditStats: ReturnType<typeof vi.fn>;
@@ -187,6 +190,9 @@ function installApi(
       customArgs: "",
     }),
     setSettings: vi.fn().mockResolvedValue(undefined),
+    getLiveSessionStatus: vi
+      .fn()
+      .mockResolvedValue({ connected: false, tier: "workbench", activeGrants: [] }),
   };
   const mcpDefaults: McpServerApi = {
     getStatus: vi.fn().mockResolvedValue({
@@ -210,6 +216,7 @@ function installApi(
     rotateApiKey: vi.fn().mockResolvedValue("dnt-key-new"),
     getConfigSnippet: vi.fn().mockResolvedValue('{ "url": "http://127.0.0.1:45454/sse" }'),
     onRuntimeStateChanged: vi.fn(() => () => {}),
+    onGrantLifecycle: vi.fn(() => () => {}),
     getAuditRecords: vi.fn().mockResolvedValue([]),
     getLogRecords: vi.fn().mockResolvedValue([]),
     getAuditStats: vi.fn().mockResolvedValue({ auth401Count: 0 }),
@@ -226,6 +233,7 @@ describe("DaintreeAssistantSettingsTab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     helpPanelState.preferredAgentId = null;
+    helpPanelState.sessionId = null;
     helpPanelState.setPreferredAgent = vi.fn();
     mockGetAssistantSupportedAgentIds.mockReturnValue(["claude"]);
     Object.defineProperty(navigator, "clipboard", {
@@ -841,6 +849,93 @@ describe("DaintreeAssistantSettingsTab", () => {
         customArgs: "",
       });
     });
+  });
+});
+
+describe("SessionLiveStatusCard (live help session)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    helpPanelState.preferredAgentId = null;
+    helpPanelState.sessionId = "help-1";
+    helpPanelState.setPreferredAgent = vi.fn();
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude"]);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    helpPanelState.sessionId = null;
+  });
+
+  const settingsWithTier = (tier: "workbench" | "action" | "system") => ({
+    docSearch: true,
+    daintreeControl: true,
+    tier,
+    bypassPermissions: false,
+    auditRetention: 7 as const,
+    customArgs: "",
+    idleHibernateMinutes: 30 as const,
+  });
+
+  it("reports the live tier as elevated above the configured default", async () => {
+    installApi(
+      {
+        getSettings: vi.fn().mockResolvedValue(settingsWithTier("action")),
+        getLiveSessionStatus: vi
+          .fn()
+          .mockResolvedValue({ connected: true, tier: "system", activeGrants: [] }),
+      },
+      {}
+    );
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+
+    await waitFor(() => expect(container.textContent).toContain("Live session"), { timeout: 5000 });
+    expect(container.textContent).toContain("elevated above the configured action default");
+  });
+
+  it("reports a live tier below the configured default without claiming a match", async () => {
+    installApi(
+      {
+        getSettings: vi.fn().mockResolvedValue(settingsWithTier("system")),
+        getLiveSessionStatus: vi
+          .fn()
+          .mockResolvedValue({ connected: true, tier: "action", activeGrants: [] }),
+      },
+      {}
+    );
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+
+    await waitFor(() => expect(container.textContent).toContain("Live session"), { timeout: 5000 });
+    expect(container.textContent).toContain("below the configured system default");
+    expect(container.textContent).not.toContain("matches the configured default");
+  });
+
+  it("passes the public help-session id to the live-status bridge call", async () => {
+    const getLiveSessionStatus = vi
+      .fn()
+      .mockResolvedValue({ connected: true, tier: "action", activeGrants: [] });
+    installApi(
+      { getSettings: vi.fn().mockResolvedValue(settingsWithTier("action")), getLiveSessionStatus },
+      {}
+    );
+    render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+
+    await waitFor(() => expect(getLiveSessionStatus).toHaveBeenCalledWith({ sessionId: "help-1" }));
   });
 });
 

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -146,7 +146,10 @@ vi.mock("@/config/agents", () => ({
   },
 }));
 
-import { DaintreeAssistantSettingsTab } from "../DaintreeAssistantSettingsTab";
+import {
+  DaintreeAssistantSettingsTab,
+  formatGrantRemaining,
+} from "../DaintreeAssistantSettingsTab";
 import { SettingsValidationProvider } from "../SettingsValidationRegistry";
 
 const writeText = vi.fn().mockResolvedValue(undefined);
@@ -838,5 +841,28 @@ describe("DaintreeAssistantSettingsTab", () => {
         customArgs: "",
       });
     });
+  });
+});
+
+describe("formatGrantRemaining", () => {
+  it("renders sub-minute durations as bare seconds", () => {
+    expect(formatGrantRemaining(0)).toBe("0s");
+    expect(formatGrantRemaining(1)).toBe("1s");
+    expect(formatGrantRemaining(59)).toBe("59s");
+  });
+
+  it("renders an exact minute without a trailing seconds component", () => {
+    expect(formatGrantRemaining(60)).toBe("1m");
+    expect(formatGrantRemaining(120)).toBe("2m");
+  });
+
+  it("renders mixed minute+second durations", () => {
+    expect(formatGrantRemaining(61)).toBe("1m 1s");
+    expect(formatGrantRemaining(125)).toBe("2m 5s");
+  });
+
+  it("floors fractional seconds and clamps negatives to zero", () => {
+    expect(formatGrantRemaining(61.9)).toBe("1m 1s");
+    expect(formatGrantRemaining(-5)).toBe("0s");
   });
 });

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 vi.stubGlobal(
   "ResizeObserver",

--- a/src/hooks/__tests__/useHelpSessionLiveStatus.test.ts
+++ b/src/hooks/__tests__/useHelpSessionLiveStatus.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HelpSessionLiveStatus } from "@shared/types";
+
+vi.mock("@/utils/logger", () => ({ logError: vi.fn() }));
+
+import { useHelpSessionLiveStatus } from "../useHelpSessionLiveStatus";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const DISCONNECTED: HelpSessionLiveStatus = {
+  connected: false,
+  tier: "workbench",
+  activeGrants: [],
+};
+
+const CONNECTED: HelpSessionLiveStatus = {
+  connected: true,
+  tier: "action",
+  activeGrants: [],
+};
+
+let pulls: Array<Deferred<HelpSessionLiveStatus>>;
+let getLiveSessionStatus: ReturnType<typeof vi.fn>;
+let onGrantLifecycle: ReturnType<typeof vi.fn>;
+let unsubscribe: ReturnType<typeof vi.fn>;
+let grantCallback: (() => void) | null;
+
+beforeEach(() => {
+  pulls = [];
+  grantCallback = null;
+  unsubscribe = vi.fn();
+  getLiveSessionStatus = vi.fn(() => {
+    const d = deferred<HelpSessionLiveStatus>();
+    pulls.push(d);
+    return d.promise;
+  });
+  onGrantLifecycle = vi.fn((cb: () => void) => {
+    grantCallback = cb;
+    return unsubscribe;
+  });
+  (window as unknown as { electron: unknown }).electron = {
+    helpAssistant: { getLiveSessionStatus },
+    mcpServer: { onGrantLifecycle },
+  };
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useHelpSessionLiveStatus", () => {
+  it("returns disconnected defaults and does no IPC when sessionId is null", () => {
+    const { result } = renderHook(() => useHelpSessionLiveStatus(null));
+
+    expect(result.current).toEqual(DISCONNECTED);
+    expect(onGrantLifecycle).not.toHaveBeenCalled();
+    expect(getLiveSessionStatus).not.toHaveBeenCalled();
+  });
+
+  it("subscribes to the grant-lifecycle push BEFORE the first pull", () => {
+    renderHook(() => useHelpSessionLiveStatus("help-1"));
+
+    expect(onGrantLifecycle).toHaveBeenCalledTimes(1);
+    expect(getLiveSessionStatus).toHaveBeenCalledWith({ sessionId: "help-1" });
+    // Ordering matters: a push arriving in the mount→pull gap must not be missed.
+    expect(onGrantLifecycle.mock.invocationCallOrder[0]).toBeLessThan(
+      getLiveSessionStatus.mock.invocationCallOrder[0]
+    );
+  });
+
+  it("populates state from the resolved pull", async () => {
+    const { result } = renderHook(() => useHelpSessionLiveStatus("help-1"));
+
+    await act(async () => {
+      pulls[0]!.resolve(CONNECTED);
+    });
+
+    await waitFor(() => expect(result.current).toEqual(CONNECTED));
+  });
+
+  it("re-pulls when a grant-lifecycle event fires", async () => {
+    renderHook(() => useHelpSessionLiveStatus("help-1"));
+    await act(async () => {
+      pulls[0]!.resolve(CONNECTED);
+    });
+
+    act(() => {
+      grantCallback?.();
+    });
+
+    expect(getLiveSessionStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces a burst of events during an in-flight pull into one trailing re-pull", async () => {
+    renderHook(() => useHelpSessionLiveStatus("help-1"));
+    // pull #1 is still pending — events should not each spawn their own pull.
+    act(() => {
+      grantCallback?.();
+      grantCallback?.();
+      grantCallback?.();
+    });
+    expect(getLiveSessionStatus).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      pulls[0]!.resolve(CONNECTED);
+    });
+    // Exactly one trailing pull folds in every event that arrived mid-flight.
+    expect(getLiveSessionStatus).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      pulls[1]!.resolve(CONNECTED);
+    });
+    expect(getLiveSessionStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it("unsubscribes on unmount and ignores a late-resolving pull", async () => {
+    const { result, unmount } = renderHook(() => useHelpSessionLiveStatus("help-1"));
+    unmount();
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      pulls[0]!.resolve(CONNECTED);
+    });
+    // The pull never resolved before unmount, and the cancelled guard drops the
+    // late resolution — state stays at the initial disconnected snapshot.
+    expect(result.current).toEqual(DISCONNECTED);
+  });
+
+  it("re-subscribes and pulls with the new id when sessionId changes", async () => {
+    const { rerender } = renderHook(({ id }) => useHelpSessionLiveStatus(id), {
+      initialProps: { id: "help-1" as string | null },
+    });
+    await act(async () => {
+      pulls[0]!.resolve(CONNECTED);
+    });
+
+    rerender({ id: "help-2" });
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(getLiveSessionStatus).toHaveBeenLastCalledWith({ sessionId: "help-2" });
+    expect(onGrantLifecycle).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/hooks/__tests__/useHelpSessionLiveStatus.test.ts
+++ b/src/hooks/__tests__/useHelpSessionLiveStatus.test.ts
@@ -80,8 +80,8 @@ describe("useHelpSessionLiveStatus", () => {
     expect(onGrantLifecycle).toHaveBeenCalledTimes(1);
     expect(getLiveSessionStatus).toHaveBeenCalledWith({ sessionId: "help-1" });
     // Ordering matters: a push arriving in the mount→pull gap must not be missed.
-    expect(onGrantLifecycle.mock.invocationCallOrder[0]).toBeLessThan(
-      getLiveSessionStatus.mock.invocationCallOrder[0]
+    expect(onGrantLifecycle.mock.invocationCallOrder[0]!).toBeLessThan(
+      getLiveSessionStatus.mock.invocationCallOrder[0]!
     );
   });
 

--- a/src/hooks/__tests__/useHelpSessionLiveStatus.test.ts
+++ b/src/hooks/__tests__/useHelpSessionLiveStatus.test.ts
@@ -5,6 +5,7 @@ import type { HelpSessionLiveStatus } from "@shared/types";
 
 vi.mock("@/utils/logger", () => ({ logError: vi.fn() }));
 
+import { logError } from "@/utils/logger";
 import { useHelpSessionLiveStatus } from "../useHelpSessionLiveStatus";
 
 interface Deferred<T> {
@@ -105,6 +106,40 @@ describe("useHelpSessionLiveStatus", () => {
     });
 
     expect(getLiveSessionStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates the fresh snapshot from a re-pull into state", async () => {
+    const { result } = renderHook(() => useHelpSessionLiveStatus("help-1"));
+    await act(async () => {
+      pulls[0]!.resolve(CONNECTED);
+    });
+
+    act(() => {
+      grantCallback?.();
+    });
+    const withGrant: HelpSessionLiveStatus = {
+      connected: true,
+      tier: "action",
+      activeGrants: [{ toolId: "git.push", expiresAt: 1_700_000_000_000, ttlMs: 900_000 }],
+    };
+    await act(async () => {
+      pulls[1]!.resolve(withGrant);
+    });
+
+    // Not just that a second pull fired — the hook must surface its result.
+    await waitFor(() => expect(result.current.activeGrants).toHaveLength(1));
+    expect(result.current.activeGrants[0]?.toolId).toBe("git.push");
+  });
+
+  it("falls back to disconnected defaults and logs when the pull rejects", async () => {
+    const { result } = renderHook(() => useHelpSessionLiveStatus("help-1"));
+
+    await act(async () => {
+      pulls[0]!.reject(new Error("bridge down"));
+    });
+
+    await waitFor(() => expect(result.current).toEqual(DISCONNECTED));
+    expect(vi.mocked(logError)).toHaveBeenCalled();
   });
 
   it("coalesces a burst of events during an in-flight pull into one trailing re-pull", async () => {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -138,3 +138,5 @@ export { useConnectivity, useConnectivitySnapshot } from "./useConnectivity";
 export { useImageError } from "./useImageError";
 
 export { useKeepMounted } from "./useKeepMounted";
+
+export { useHelpSessionLiveStatus } from "./useHelpSessionLiveStatus";

--- a/src/hooks/useHelpSessionLiveStatus.ts
+++ b/src/hooks/useHelpSessionLiveStatus.ts
@@ -1,0 +1,89 @@
+import { useEffect, useState } from "react";
+import type { HelpSessionLiveStatus } from "@shared/types";
+import { logError } from "@/utils/logger";
+
+const DISCONNECTED: HelpSessionLiveStatus = {
+  connected: false,
+  tier: "workbench",
+  activeGrants: [],
+};
+
+/**
+ * Live tier + per-tool grants for the pinned help session, addressed by its
+ * public help-session id (`helpPanelStore.sessionId`). Unlike the persisted
+ * `HelpAssistantSettings.tier` (the configured default for new sessions), this
+ * reflects what the session is *running at right now* — including a
+ * renderer-approved "Always allow" elevation — plus the grants currently in
+ * effect.
+ *
+ * Data flow: subscribe to the grant-lifecycle push BEFORE the first pull so an
+ * event firing in the mount→pull gap can't be missed (subscribe-before-pull,
+ * lesson #9490). The push is target-scoped to this WebContents and carries the
+ * MCP transport sessionId (not the public id we hold) with no `tier` field, so
+ * we never reconcile incrementally from its payload — instead any push means
+ * "this session's state changed" and we re-pull the authoritative snapshot.
+ * In-flight pulls coalesce a burst of events (e.g. a session revoke emits one
+ * event per grant) into a single trailing refresh.
+ *
+ * Returns safe `connected: false` defaults when `sessionId` is null or no live
+ * session is pinned to this renderer — callers render that as a quiet idle
+ * state, never a spinner.
+ */
+export function useHelpSessionLiveStatus(sessionId: string | null): HelpSessionLiveStatus {
+  const [status, setStatus] = useState<HelpSessionLiveStatus>(DISCONNECTED);
+
+  useEffect(() => {
+    if (!sessionId) {
+      setStatus(DISCONNECTED);
+      return;
+    }
+
+    let cancelled = false;
+    let inFlight = false;
+    let pendingRefresh = false;
+
+    const pull = (): void => {
+      inFlight = true;
+      window.electron.helpAssistant
+        .getLiveSessionStatus({ sessionId })
+        .then((live) => {
+          if (cancelled) return;
+          setStatus(live);
+        })
+        .catch((err) => {
+          if (cancelled) return;
+          logError("Failed to load live help-session status", err);
+          setStatus(DISCONNECTED);
+        })
+        .finally(() => {
+          inFlight = false;
+          if (cancelled || !pendingRefresh) return;
+          // An event arrived mid-flight; fold it into exactly one trailing pull
+          // so the final snapshot reflects every event without a thundering herd.
+          pendingRefresh = false;
+          pull();
+        });
+    };
+
+    const requestRefresh = (): void => {
+      if (inFlight) {
+        pendingRefresh = true;
+        return;
+      }
+      pull();
+    };
+
+    const unsubscribe = window.electron.mcpServer.onGrantLifecycle(() => {
+      requestRefresh();
+    });
+
+    pull();
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [sessionId]);
+
+  return status;
+}


### PR DESCRIPTION
## Summary

- The capability tier control and blast-radius preview in the Assistant settings tab were always reading the persisted default tier from `HelpAssistantSettings.tier`, not the effective tier of the currently active help session. A user who'd clicked "Always allow for this project" had no way to verify the elevation was still in effect.
- Adds a live-session status card to the Security section (below `BlastRadiusPreview`) showing the real effective tier, a three-way relation to the configured default (elevated above / below / matches), and the per-tool grants currently active with per-second expiry countdowns.
- Backed by a new `help-assistant:get-live-session-status` IPC op that reverse-maps the renderer's public help-session id to the MCP transport session via `sessionHelpIdMap`. The `useHelpSessionLiveStatus` hook subscribes to grant-lifecycle push events before pulling the initial snapshot to avoid a race.

Resolves #10032

## Changes

- `electron/services/mcp-server/sessionStore.ts` — reverse-lookup, caller-pin, and live-guard APIs on `SessionStore`
- `electron/ipc/channels.ts` + `electron/ipc/handlers/helpAssistant.ts` — new `help-assistant:get-live-session-status` handler; registered in `CHANNELS` and preload
- `shared/types/ipc/` — `HelpSessionLiveStatus` type exported from the shared barrel
- `src/hooks/useHelpSessionLiveStatus.ts` — subscribe-before-pull hook with coalescing and cleanup
- `src/components/Settings/DaintreeAssistantSettingsTab.tsx` — live-session status card rendered in the Security section
- Scope note: live tier-change events while the tab is open are out of scope (the `MCP_GRANT_LIFECYCLE` push carries no tier field; tier elevation/decay events are tracked in companion issue #10027)

## Testing

- Unit tests: `SessionStore` reverse-lookup / caller-pin / live-guard / expired-grant-filter / multi-transport
- Unit tests: IPC handler shaping, narrowing, and validation
- Unit tests: hook subscribe-before-pull / coalescing / cleanup / re-pull propagation / rejected-fallback
- Unit tests: component connected / elevated / below-default rendering
- Unit tests: `formatGrantRemaining` boundary values
- All static checks (`npm run check`), build, and all locally runnable unit tests pass