### PR TITLE
feat(help): support animated WebP demo loops in FigureRail

### DIFF
--- a/src/components/HelpPanel/FigureRail.tsx
+++ b/src/components/HelpPanel/FigureRail.tsx
@@ -117,6 +117,15 @@ function FigureThumbnail({ figure, isNewest, onClick }: FigureThumbnailProps) {
           }
           className="block h-full w-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:-outline-offset-2"
         >
+          {/* Animated WebP demo loops play natively through the browser image
+              decoder — no decoding hint or poster-swap is needed, and rail
+              thumbnails are intentionally allowed to loop (source is the
+              URL-validated daintree.org host). Note: prefers-reduced-motion does
+              not pause native animated images in Chromium 148 — the CSS
+              `image-animation` property is not yet shipped — so the reduce-motion
+              variant in index.css (which targets CSS @keyframes) has no effect
+              here. A still-frame fallback would need a server-supplied poster
+              URL; tracked as a separate enhancement. */}
           <img
             key={retryNonce}
             src={figure.url}

--- a/src/components/HelpPanel/__tests__/FigureRail.test.tsx
+++ b/src/components/HelpPanel/__tests__/FigureRail.test.tsx
@@ -167,7 +167,7 @@ describe("FigureRail", () => {
     expect(img.tagName).toBe("IMG");
   });
 
-  it("opens an animated WebP figure in the lightbox with the same unmodified url", () => {
+  it("opens an animated WebP figure in the lightbox with the same unmodified url, and it becomes visible on load", () => {
     const url = "https://daintree.org/demo-loop.webp";
     render(<FigureRail figures={[makeFigure(1, { url })]} />);
     fireEvent.load(screen.getByAltText("Alt 1"));
@@ -177,13 +177,23 @@ describe("FigureRail", () => {
     const img = within(lightbox).getByAltText("Alt 1");
     expect(img.getAttribute("src")).toBe(url);
     expect(img.tagName).toBe("IMG");
+    // referrerPolicy must carry into the lightbox path too.
+    expect(img.getAttribute("referrerpolicy")).toBe("no-referrer");
+
+    // The lightbox img starts hidden (opacity-0) and reveals on load — a broken
+    // onLoad handler would leave an animated WebP permanently invisible.
+    expect(img.classList.contains("opacity-0")).toBe(true);
+    fireEvent.load(img);
+    expect(img.classList.contains("opacity-100")).toBe(true);
   });
 
-  it("renders an animated WebP figure normally under prefers-reduced-motion", () => {
+  it("renders an animated WebP as a plain looping img with no still-frame swap, even under prefers-reduced-motion", () => {
     // Chromium 148 does not pause native animated images for
     // prefers-reduced-motion (no shipped CSS image-animation property), so the
-    // component intentionally renders the <img> the same way regardless. This
-    // documents the known gap rather than asserting a (non-existent) pause.
+    // component intentionally keeps rendering a plain looping <img> — no canvas,
+    // <video>, or poster still-frame substitution. This guards the documented
+    // design decision: a future reduce-motion still-frame path must arrive with
+    // a server-supplied poster URL, not by silently swapping the render element.
     vi.stubGlobal(
       "matchMedia",
       vi.fn((query: string) => ({
@@ -198,14 +208,22 @@ describe("FigureRail", () => {
       }))
     );
 
-    const url = "https://daintree.org/demo-loop.webp";
-    render(<FigureRail figures={[makeFigure(1, { url })]} />);
+    try {
+      const url = "https://daintree.org/demo-loop.webp";
+      const { container } = render(<FigureRail figures={[makeFigure(1, { url })]} />);
 
-    const img = screen.getByAltText("Alt 1");
-    expect(img.getAttribute("src")).toBe(url);
-
-    // Restore only matchMedia — vi.unstubAllGlobals() would also wipe the
-    // module-level ResizeObserver stub other tests rely on.
-    vi.stubGlobal("matchMedia", undefined);
+      const img = screen.getByAltText("Alt 1");
+      expect(img.tagName).toBe("IMG");
+      expect(img.getAttribute("src")).toBe(url);
+      // No still-frame substitution surface anywhere in the rail.
+      expect(container.querySelector("canvas")).toBeNull();
+      expect(container.querySelector("video")).toBeNull();
+      expect(img.hasAttribute("poster")).toBe(false);
+    } finally {
+      // Restore only matchMedia — vi.unstubAllGlobals() would also wipe the
+      // module-level ResizeObserver stub other tests rely on. The finally block
+      // ensures cleanup even if an assertion above throws.
+      vi.stubGlobal("matchMedia", undefined);
+    }
   });
 });

--- a/src/components/HelpPanel/__tests__/FigureRail.test.tsx
+++ b/src/components/HelpPanel/__tests__/FigureRail.test.tsx
@@ -152,4 +152,60 @@ describe("FigureRail", () => {
     fireEvent.click(screen.getByRole("button", { name: "Close dialog" }));
     expect(screen.queryByTestId("figure-lightbox")).toBeNull();
   });
+
+  // Animated WebP (#10278) plays via the native image decoder; the render path
+  // must hand the original URL straight to a plain <img> with no poster/still
+  // swap, in both the thumbnail and the lightbox, so the animation can loop.
+  it("passes an animated WebP url through unmodified to the thumbnail img", () => {
+    const url = "https://daintree.org/demo-loop.webp";
+    render(<FigureRail figures={[makeFigure(1, { url })]} />);
+
+    const img = screen.getByAltText("Alt 1");
+    expect(img.getAttribute("src")).toBe(url);
+    // No still-frame substitution: the rendered element is a plain <img>, not a
+    // <canvas>/<video> poster surface.
+    expect(img.tagName).toBe("IMG");
+  });
+
+  it("opens an animated WebP figure in the lightbox with the same unmodified url", () => {
+    const url = "https://daintree.org/demo-loop.webp";
+    render(<FigureRail figures={[makeFigure(1, { url })]} />);
+    fireEvent.load(screen.getByAltText("Alt 1"));
+    fireEvent.click(screen.getByRole("button", { name: "Figure 1: Caption 1" }));
+
+    const lightbox = screen.getByTestId("figure-lightbox");
+    const img = within(lightbox).getByAltText("Alt 1");
+    expect(img.getAttribute("src")).toBe(url);
+    expect(img.tagName).toBe("IMG");
+  });
+
+  it("renders an animated WebP figure normally under prefers-reduced-motion", () => {
+    // Chromium 148 does not pause native animated images for
+    // prefers-reduced-motion (no shipped CSS image-animation property), so the
+    // component intentionally renders the <img> the same way regardless. This
+    // documents the known gap rather than asserting a (non-existent) pause.
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn((query: string) => ({
+        matches: query.includes("prefers-reduced-motion"),
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }))
+    );
+
+    const url = "https://daintree.org/demo-loop.webp";
+    render(<FigureRail figures={[makeFigure(1, { url })]} />);
+
+    const img = screen.getByAltText("Alt 1");
+    expect(img.getAttribute("src")).toBe(url);
+
+    // Restore only matchMedia — vi.unstubAllGlobals() would also wipe the
+    // module-level ResizeObserver stub other tests rely on.
+    vi.stubGlobal("matchMedia", undefined);
+  });
 });


### PR DESCRIPTION
## Summary

- Animated WebP loops already play natively in Chromium 148 via the plain `<img>` render path in both `FigureRail` and `FigureLightbox` — nothing in the existing path freezes images to their first frame.
- Adds a documenting comment to `FigureRail.tsx` making this explicit: animation is handled by the native browser image decoder, Chromium 148 doesn't pause animated images for `prefers-reduced-motion` (the CSS `image-animation` property isn't shipped yet), and a still-frame fallback would need a server-supplied poster URL — tracked as a separate enhancement.
- Adds render-contract unit tests asserting WebP URLs pass through unmodified to both thumbnail and lightbox `<img>` elements, the lightbox reveals on load with `referrerPolicy="no-referrer"` intact, and the rail stays a plain looping `<img>` with no `<canvas>` or `<video>` substitution even under `prefers-reduced-motion`.

Resolves #10278

## Changes

- `src/components/HelpPanel/FigureRail.tsx` — documenting comment on animated WebP behaviour and the `prefers-reduced-motion` limitation
- `src/components/HelpPanel/__tests__/FigureRail.test.tsx` — 3 new render-contract tests (14 total, all passing)

## Testing

- 14 `FigureRail` unit tests pass (11 existing + 3 new)
- Full local CI green (typecheck, lint, format, unit tests, build)
- No new dependencies