### PR TITLE
feat(help): surface agent-stuck and reasoning-loop as ambient pip (#10018)

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -699,6 +699,13 @@ export const CHANNELS = {
    * figure inline. Targeted at the pinned WebContents — never broadcast.
    */
   MCP_HELP_DISPLAY_IMAGE: "mcp-server:help-display-image",
+  /**
+   * Push channel: a turn for the help-session pinned to this renderer
+   * classified as `agent-stuck` or `reasoning-loop` (#10018). Drives the
+   * Assistant footer's ambient outcome pip — a Tier 1 indicator, never a
+   * toast. Targeted at the pinned WebContents — never broadcast.
+   */
+  MCP_TURN_OUTCOME_ALERT: "mcp-server:turn-outcome-alert",
 
   // Voice Input channels
   VOICE_INPUT_GET_SETTINGS: "voice-input:get-settings",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -21,6 +21,7 @@ import type {
   McpToolCallStartedPayload,
   McpToolCallSettledPayload,
   McpHelpDisplayImagePayload,
+  McpTurnOutcomeAlertPayload,
 } from "../shared/types/ipc/mcpServer.js";
 import type { ActionContext, ActionDispatchResult } from "../shared/types/actions.js";
 import type { PushProgressEvent } from "../shared/types/ipc/gitPush.js";
@@ -2486,6 +2487,8 @@ const api: ElectronAPI = {
       _typedOn(CHANNELS.MCP_TOOL_CALL_SETTLED, callback),
     onDisplayImage: (callback: (payload: McpHelpDisplayImagePayload) => void) =>
       _typedOn(CHANNELS.MCP_HELP_DISPLAY_IMAGE, callback),
+    onTurnOutcomeAlert: (callback: (payload: McpTurnOutcomeAlertPayload) => void) =>
+      _typedOn(CHANNELS.MCP_TURN_OUTCOME_ALERT, callback),
   },
 
   helpAssistant: buildHelpAssistantPreloadBindings(_unwrappingInvoke),

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -207,6 +207,19 @@ export class McpServerService {
       emitRuntimeStateChange: () => this.emitRuntimeStateChange(),
       setConfig: (patch) => this.persistConfig(patch),
     });
+
+    // Wire the live turn-outcome alert push now that both collaborators exist
+    // (#10018). The service classifies `agent-stuck` / `reasoning-loop` and
+    // hands the help-session id to httpLifecycle, which resolves the pinned
+    // WebContents and sends. Set after construction because the send path
+    // lives on httpLifecycle, built just above.
+    this.turnOutcomeService.setNotifyTurnOutcomeAlert((outcome, helpSessionId, turnId) => {
+      this.httpLifecycle.notifyTurnOutcomeAlert({
+        helpSessionId,
+        outcome,
+        ...(turnId !== undefined ? { turnId } : {}),
+      });
+    });
   }
 
   get isRunning(): boolean {

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -16,9 +16,18 @@ vi.mock("../../../store.js", () => ({
 // Mock electron so the suite loads without the Electron binary present (no
 // `node_modules/electron/path.txt`). httpLifecycle.ts and its transitive imports
 // only touch these at runtime — never in these unit tests — so stubs suffice.
+// The controllable WebContents registry lets targeted-send paths (e.g.
+// notifyTurnOutcomeAlert) be exercised without a real renderer; the source only
+// imports `webContents` from electron, so this mock is a superset of that.
+const { mockWebContentsById } = vi.hoisted(() => ({
+  mockWebContentsById: new Map<
+    number,
+    { isDestroyed: () => boolean; send: (channel: string, payload: unknown) => void }
+  >(),
+}));
 vi.mock("electron", () => ({
   app: { getVersion: () => "0.0.0-test" },
-  webContents: { fromId: () => undefined },
+  webContents: { fromId: (id: number) => mockWebContentsById.get(id) ?? null },
   ipcMain: { on: () => undefined, removeListener: () => undefined },
 }));
 
@@ -1115,6 +1124,89 @@ describe("HttpLifecycle", () => {
 
       expect(res.writeHead).toHaveBeenCalledWith(403, expect.anything());
       expect(deps.auditService.recordAuth401).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("notifyTurnOutcomeAlert (#10018)", () => {
+    beforeEach(() => {
+      mockWebContentsById.clear();
+    });
+
+    function liveWc(id: number) {
+      const wc = { isDestroyed: () => false, send: vi.fn() };
+      mockWebContentsById.set(id, wc);
+      return wc;
+    }
+    function deadWc(id: number) {
+      const wc = { isDestroyed: () => true, send: vi.fn() };
+      mockWebContentsById.set(id, wc);
+      return wc;
+    }
+
+    it("sends the alert to the pinned WebContents of the matching help session", () => {
+      const deps = fakeDeps();
+      deps.sessionStore.sessionHelpIdMap.set("transport-1", "help-9");
+      deps.sessionStore.sessionWebContentsMap.set("transport-1", 42);
+      const wc = liveWc(42);
+      const lc = new HttpLifecycle(deps);
+
+      lc.notifyTurnOutcomeAlert({ helpSessionId: "help-9", outcome: "agent-stuck" });
+
+      expect(wc.send).toHaveBeenCalledTimes(1);
+      expect(wc.send).toHaveBeenCalledWith(
+        "mcp-server:turn-outcome-alert",
+        expect.objectContaining({ helpSessionId: "help-9", outcome: "agent-stuck" })
+      );
+      // No turnId on the payload means none is forwarded.
+      expect(wc.send.mock.calls[0]![1]).not.toHaveProperty("turnId");
+    });
+
+    it("forwards turnId when present", () => {
+      const deps = fakeDeps();
+      deps.sessionStore.sessionHelpIdMap.set("transport-1", "help-9");
+      deps.sessionStore.sessionWebContentsMap.set("transport-1", 42);
+      const wc = liveWc(42);
+      const lc = new HttpLifecycle(deps);
+
+      lc.notifyTurnOutcomeAlert({
+        helpSessionId: "help-9",
+        outcome: "reasoning-loop",
+        turnId: "turn-7",
+      });
+
+      expect(wc.send).toHaveBeenCalledWith(
+        "mcp-server:turn-outcome-alert",
+        expect.objectContaining({ outcome: "reasoning-loop", turnId: "turn-7" })
+      );
+    });
+
+    it("falls through a destroyed WebContents to a second live transport for the same help session", () => {
+      const deps = fakeDeps();
+      // Two transports map to the same help session; the first is destroyed.
+      deps.sessionStore.sessionHelpIdMap.set("transport-dead", "help-9");
+      deps.sessionStore.sessionWebContentsMap.set("transport-dead", 41);
+      deps.sessionStore.sessionHelpIdMap.set("transport-live", "help-9");
+      deps.sessionStore.sessionWebContentsMap.set("transport-live", 42);
+      const dead = deadWc(41);
+      const live = liveWc(42);
+      const lc = new HttpLifecycle(deps);
+
+      lc.notifyTurnOutcomeAlert({ helpSessionId: "help-9", outcome: "agent-stuck" });
+
+      expect(dead.send).not.toHaveBeenCalled();
+      expect(live.send).toHaveBeenCalledTimes(1);
+    });
+
+    it("no-ops when no transport session maps to the help session", () => {
+      const deps = fakeDeps();
+      deps.sessionStore.sessionHelpIdMap.set("transport-1", "help-other");
+      deps.sessionStore.sessionWebContentsMap.set("transport-1", 42);
+      const wc = liveWc(42);
+      const lc = new HttpLifecycle(deps);
+
+      lc.notifyTurnOutcomeAlert({ helpSessionId: "help-9", outcome: "agent-stuck" });
+
+      expect(wc.send).not.toHaveBeenCalled();
     });
   });
 });

--- a/electron/services/mcp-server/__tests__/turnOutcomeLog.test.ts
+++ b/electron/services/mcp-server/__tests__/turnOutcomeLog.test.ts
@@ -543,6 +543,89 @@ describe("TurnOutcomeService.handleTransition", () => {
   });
 });
 
+describe("TurnOutcomeService.setNotifyTurnOutcomeAlert", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fires the alert callback for agent-stuck with the help-session id", () => {
+    const f = makeFixture();
+    const alert = vi.fn();
+    f.service.setNotifyTurnOutcomeAlert(alert);
+    f.service.handleTransition(
+      makeTransition({ previousState: "waiting", state: "idle", trigger: "timeout" })
+    );
+    expect(alert).toHaveBeenCalledTimes(1);
+    expect(alert).toHaveBeenCalledWith("agent-stuck", "session-1", undefined);
+  });
+
+  it("fires the alert callback for reasoning-loop with the turn id", () => {
+    const now = Date.now();
+    const auditRecords = [
+      makeAuditRecord({ id: "r1", timestamp: now, toolId: "agent.getState", argsSummary: "{}" }),
+      makeAuditRecord({ id: "r2", timestamp: now, toolId: "agent.getState", argsSummary: "{}" }),
+      makeAuditRecord({ id: "r3", timestamp: now, toolId: "agent.getState", argsSummary: "{}" }),
+    ];
+    const f = makeFixture({ auditRecords });
+    const alert = vi.fn();
+    f.service.setNotifyTurnOutcomeAlert(alert);
+    // Enter active to mint a turn id, then close the turn so the loop classifies.
+    f.service.handleTransition(
+      makeTransition({ previousState: "idle", state: "working", trigger: "input", timestamp: now })
+    );
+    f.service.appendOutput("term-1", "Looping through agent.getState repeatedly without progress.");
+    f.service.handleTransition(
+      makeTransition({ previousState: "working", state: "idle", trigger: "output", timestamp: now })
+    );
+    expect(alert).toHaveBeenCalledTimes(1);
+    const [outcome, helpSessionId, turnId] = alert.mock.calls[0]!;
+    expect(outcome).toBe("reasoning-loop");
+    expect(helpSessionId).toBe("session-1");
+    expect(typeof turnId).toBe("string");
+  });
+
+  it("does not fire the alert callback for non-alertable outcomes", () => {
+    const f = makeFixture();
+    const alert = vi.fn();
+    f.service.setNotifyTurnOutcomeAlert(alert);
+    f.service.appendOutput("term-1", "Done — the file was updated and the tests pass cleanly.");
+    f.service.handleTransition(
+      makeTransition({ previousState: "working", state: "idle", trigger: "output" })
+    );
+    expect(f.service.getRecords()[0]?.outcome).toBe("answered");
+    expect(alert).not.toHaveBeenCalled();
+  });
+
+  it("respects the stuck debounce — no second alert without an intervening active turn", () => {
+    const f = makeFixture();
+    const alert = vi.fn();
+    f.service.setNotifyTurnOutcomeAlert(alert);
+    f.service.handleTransition(
+      makeTransition({ previousState: "waiting", state: "idle", trigger: "timeout" })
+    );
+    f.service.handleTransition(
+      makeTransition({ previousState: "waiting", state: "idle", trigger: "timeout" })
+    );
+    expect(alert).toHaveBeenCalledTimes(1);
+  });
+
+  it("never blocks record persistence when the alert callback throws", () => {
+    const f = makeFixture();
+    f.service.setNotifyTurnOutcomeAlert(() => {
+      throw new Error("renderer gone");
+    });
+    expect(() =>
+      f.service.handleTransition(
+        makeTransition({ previousState: "waiting", state: "idle", trigger: "timeout" })
+      )
+    ).not.toThrow();
+    expect(f.service.getRecords()[0]?.outcome).toBe("agent-stuck");
+  });
+});
+
 describe("TurnOutcomeService.recordDirectOutcome", () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -26,6 +26,7 @@ import type {
   McpBearerIdentity,
   McpIssueGrantResult,
   McpRevokeSessionGrantsResult,
+  McpTurnOutcomeAlertPayload,
 } from "../../../shared/types/ipc/mcpServer.js";
 import {
   extractBearerToken,
@@ -426,6 +427,37 @@ export class HttpLifecycle {
     // (#10036), so every teardown needs a runtime-state push so an open tab
     // drops the row.
     this.deps.emitRuntimeStateChange();
+  }
+
+  /**
+   * Push a turn-outcome alert (`agent-stuck` / `reasoning-loop`) to the
+   * renderer pinned to the originating help session (#10018). The
+   * `TurnOutcomeService` only knows the help-session id, so resolve it to a
+   * live transport session via `sessionHelpIdMap` (transport → help), then to
+   * the pinned WebContents. At most one transport session maps to a given help
+   * session at a time, so the first match with a live pin wins. Targeted send
+   * with the same `fromId` + `isDestroyed` guard as every other push — a
+   * WebContents LRU-evicted between handshake and alert rejects harmlessly.
+   */
+  notifyTurnOutcomeAlert(payload: McpTurnOutcomeAlertPayload): void {
+    let pinnedId: number | undefined;
+    for (const [transportSessionId, helpId] of this.deps.sessionStore.sessionHelpIdMap.entries()) {
+      if (helpId !== payload.helpSessionId) continue;
+      pinnedId = this.deps.sessionStore.sessionWebContentsMap.get(transportSessionId);
+      if (pinnedId !== undefined) break;
+    }
+    if (pinnedId === undefined) return;
+    const wc = webContentsModule.fromId(pinnedId);
+    if (!wc || wc.isDestroyed()) return;
+    try {
+      wc.send(CHANNELS.MCP_TURN_OUTCOME_ALERT, {
+        helpSessionId: payload.helpSessionId,
+        outcome: payload.outcome,
+        ...(payload.turnId !== undefined ? { turnId: payload.turnId } : {}),
+      });
+    } catch (err) {
+      console.error("[MCP] turn-outcome-alert send failed:", err);
+    }
   }
 
   /**

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -440,23 +440,25 @@ export class HttpLifecycle {
    * WebContents LRU-evicted between handshake and alert rejects harmlessly.
    */
   notifyTurnOutcomeAlert(payload: McpTurnOutcomeAlertPayload): void {
-    let pinnedId: number | undefined;
     for (const [transportSessionId, helpId] of this.deps.sessionStore.sessionHelpIdMap.entries()) {
       if (helpId !== payload.helpSessionId) continue;
-      pinnedId = this.deps.sessionStore.sessionWebContentsMap.get(transportSessionId);
-      if (pinnedId !== undefined) break;
-    }
-    if (pinnedId === undefined) return;
-    const wc = webContentsModule.fromId(pinnedId);
-    if (!wc || wc.isDestroyed()) return;
-    try {
-      wc.send(CHANNELS.MCP_TURN_OUTCOME_ALERT, {
-        helpSessionId: payload.helpSessionId,
-        outcome: payload.outcome,
-        ...(payload.turnId !== undefined ? { turnId: payload.turnId } : {}),
-      });
-    } catch (err) {
-      console.error("[MCP] turn-outcome-alert send failed:", err);
+      const pinnedId = this.deps.sessionStore.sessionWebContentsMap.get(transportSessionId);
+      if (pinnedId === undefined) continue;
+      const wc = webContentsModule.fromId(pinnedId);
+      // A transport session whose WebContents was LRU-evicted/destroyed is
+      // skipped, not treated as the answer — a reconnect or concurrent
+      // transport for the same help session may still hold a live pin.
+      if (!wc || wc.isDestroyed()) continue;
+      try {
+        wc.send(CHANNELS.MCP_TURN_OUTCOME_ALERT, {
+          helpSessionId: payload.helpSessionId,
+          outcome: payload.outcome,
+          ...(payload.turnId !== undefined ? { turnId: payload.turnId } : {}),
+        });
+      } catch (err) {
+        console.error("[MCP] turn-outcome-alert send failed:", err);
+      }
+      return;
     }
   }
 

--- a/electron/services/mcp-server/turnOutcomeLog.ts
+++ b/electron/services/mcp-server/turnOutcomeLog.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type {
   AssistantTurnRecord,
   McpAuditRecord,
+  TurnOutcomeAlertClass,
   TurnOutcomeClass,
 } from "../../../shared/types/ipc/mcpServer.js";
 import {
@@ -236,8 +237,30 @@ export class TurnOutcomeService {
    * dispatches should carry no turnId).
    */
   private turnIdBySession = new Map<string, string>();
+  /**
+   * Optional renderer push for the two alertable outcomes (`agent-stuck`,
+   * `reasoning-loop`). Wired after construction via
+   * {@link setNotifyTurnOutcomeAlert} because the send path lives in
+   * `HttpLifecycle`, which is constructed after this service. Null until then —
+   * the persistence path never depends on it.
+   */
+  private notifyTurnOutcomeAlert:
+    | ((outcome: TurnOutcomeAlertClass, helpSessionId: string, turnId: string | undefined) => void)
+    | null = null;
 
   constructor(private readonly deps: TurnOutcomeServiceDeps) {}
+
+  /**
+   * Wire the live alert push for `agent-stuck` / `reasoning-loop` outcomes
+   * (#10018). Called once by `McpServerService` after `HttpLifecycle` exists.
+   * Kept separate from the constructor deps because the send path depends on
+   * a collaborator built after this service.
+   */
+  setNotifyTurnOutcomeAlert(
+    cb: (outcome: TurnOutcomeAlertClass, helpSessionId: string, turnId: string | undefined) => void
+  ): void {
+    this.notifyTurnOutcomeAlert = cb;
+  }
 
   /**
    * Append a chunk of agent output to the per-terminal ring. Called from
@@ -392,6 +415,22 @@ export class TurnOutcomeService {
       record.turnId = turnId;
     }
     this.appendRecordInternal(record);
+    // Surface the two "needs-a-look" outcomes to the bound help-session panel
+    // as a live ambient pip (#10018). Best-effort and gated on the alert being
+    // wired — a send failure must never block record persistence. `sessionId`
+    // is the help-session id (the resolver's contract); `turnId` is absent for
+    // `agent-stuck` because the prior active→passive boundary already cleared
+    // it before the watchdog fired.
+    if (
+      this.notifyTurnOutcomeAlert &&
+      (outcome === "agent-stuck" || outcome === "reasoning-loop")
+    ) {
+      try {
+        this.notifyTurnOutcomeAlert(outcome, sessionId, turnId);
+      } catch (err) {
+        console.error("[MCP] turn-outcome alert callback threw:", err);
+      }
+    }
     // Drain the ring so the next active turn classifies on its own output
     // rather than re-matching the prior turn's trailing text.
     this.recentOutput.delete(transition.terminalId);

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1482,6 +1482,14 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     onDisplayImage(
       callback: (payload: import("./mcpServer.js").McpHelpDisplayImagePayload) => void
     ): () => void;
+    /**
+     * Subscribe to turn-outcome alerts (`agent-stuck` / `reasoning-loop`) for
+     * the pinned help-session in this WebContents. Drives the Assistant
+     * footer's ambient outcome pip (#10018). Targeted send — never broadcast.
+     */
+    onTurnOutcomeAlert(
+      callback: (payload: import("./mcpServer.js").McpTurnOutcomeAlertPayload) => void
+    ): () => void;
   };
   // helpAssistant is generated — see GeneratedElectronAPI.
   mcpBridge: {

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1697,6 +1697,12 @@ export interface IpcEventMap {
    * validated image URL and session-assigned figure number (#9828).
    */
   "mcp-server:help-display-image": import("./mcpServer.js").McpHelpDisplayImagePayload;
+  /**
+   * Targeted push: a turn for the pinned help session classified as
+   * `agent-stuck` or `reasoning-loop` (#10018). Drives the Assistant footer's
+   * ambient outcome pip — Tier 1, never a toast.
+   */
+  "mcp-server:turn-outcome-alert": import("./mcpServer.js").McpTurnOutcomeAlertPayload;
 
   // Error events
   "error:notify": ErrorRecord;

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -364,6 +364,31 @@ export interface McpHelpDisplayImagePayload {
 }
 
 /**
+ * The subset of {@link TurnOutcomeClass} values that warrant a live, in-app
+ * ambient signal in the Assistant panel (#10018). Both are silent
+ * "needs-a-look" outcomes the user would otherwise only find by opening the
+ * Settings diagnostics tab: the watchdog-driven `agent-stuck` and the
+ * tight-tool-call-loop `reasoning-loop`. Narrowed via `Extract` so the alert
+ * channel and pip can never carry a non-alertable outcome.
+ */
+export type TurnOutcomeAlertClass = Extract<TurnOutcomeClass, "agent-stuck" | "reasoning-loop">;
+
+/**
+ * Live event pushed to the pinned help-session renderer when a turn for that
+ * session classifies as `agent-stuck` or `reasoning-loop` (#10018). Drives the
+ * Assistant footer's ambient outcome pip — a Tier 1 indicator, never a toast.
+ * Targeted at the WebContents that minted the session's bearer, never
+ * broadcast. `turnId` is the turn the outcome was recorded for (absent for
+ * `agent-stuck`, whose turn id is already cleared by the time the watchdog
+ * fires); the renderer uses it to auto-clear the pip when a fresh turn begins.
+ */
+export interface McpTurnOutcomeAlertPayload {
+  helpSessionId: string;
+  outcome: TurnOutcomeAlertClass;
+  turnId?: string;
+}
+
+/**
  * Result of a renderer-driven `revokeSessionGrants` IPC. The handler
  * deletes every grant for the named session and reports how many entries
  * were affected — useful for UI confirmation copy ("Revoked N grants").

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -25,6 +25,7 @@ import { HelpPanelVersionGate } from "./HelpPanelVersionGate";
 import { HelpLaunchingState } from "./HelpLaunchingState";
 import { McpActivityStrip } from "./McpActivityStrip";
 import { McpAnomalyFooterLink } from "./McpAnomalyFooterLink";
+import { TurnOutcomePip } from "./TurnOutcomePip";
 import { FigureRail } from "./FigureRail";
 import {
   useHelpPanelStore,
@@ -599,6 +600,7 @@ export function HelpPanel({
   const checkVersionAgain = useCallback(() => controller.checkVersionAgain(), [controller]);
   const dismissLaunchError = useCallback(() => controller.dismissLaunchError(), [controller]);
   const dismissSessionRevoked = useCallback(() => controller.dismissSessionRevoked(), [controller]);
+  const dismissOutcomeAlert = useCallback(() => controller.dismissOutcomeAlert(), [controller]);
   const retryLaunch = useCallback(() => {
     const agentId = session.launchError?.agentId;
     if (agentId) controller.launch({ agentId });
@@ -877,6 +879,7 @@ export function HelpPanel({
           <span className="flex items-center gap-2 min-w-0">
             <McpActivityStrip sessionId={sessionId} activity={session.mcpActivity} />
             <McpAnomalyFooterLink />
+            <TurnOutcomePip outcome={session.outcomeAlert} onDismiss={dismissOutcomeAlert} />
           </span>
           <span className="flex items-center gap-2 min-w-0 shrink-0 max-w-[70%]">
             {pinnedContext &&

--- a/src/components/HelpPanel/TurnOutcomePip.tsx
+++ b/src/components/HelpPanel/TurnOutcomePip.tsx
@@ -1,0 +1,54 @@
+import { cn } from "@/lib/utils";
+import type { TurnOutcomeAlertClass } from "@shared/types/ipc/mcpServer";
+
+/**
+ * Footer-relative copy for each alertable outcome (#10018). The label names
+ * what happened; the title spells out the why and the dismiss affordance. Kept
+ * deliberately terse — this is a Tier 1 ambient signal, not a diagnostic.
+ */
+const OUTCOME_COPY: Record<TurnOutcomeAlertClass, { label: string; title: string }> = {
+  "agent-stuck": {
+    label: "Agent stuck",
+    title: "Agent appears stuck — it went idle without resolving its turn. Click to dismiss.",
+  },
+  "reasoning-loop": {
+    label: "Reasoning loop",
+    title:
+      "Reasoning loop detected — the agent kept repeating the same tool call. Click to dismiss.",
+  },
+};
+
+interface TurnOutcomePipProps {
+  /** The pending alertable outcome, or null when nothing is to show. */
+  outcome: TurnOutcomeAlertClass | null;
+  /** Click handler that dismisses the pip. */
+  onDismiss: () => void;
+}
+
+/**
+ * Ambient pip surfaced in the Assistant footer when the most recent turn for
+ * the bound help session classified as `agent-stuck` or `reasoning-loop`
+ * (#10018). A single warning-toned dot + short label, click-to-dismiss — no
+ * toast, no accent color. A single visual treatment covers both outcomes
+ * (the label differentiates), keeping the accent budget intact.
+ */
+export function TurnOutcomePip({ outcome, onDismiss }: TurnOutcomePipProps) {
+  if (outcome === null) return null;
+  const { label, title } = OUTCOME_COPY[outcome];
+  return (
+    <button
+      type="button"
+      onClick={onDismiss}
+      title={title}
+      aria-label={title}
+      className={cn(
+        "flex items-center gap-1.5 min-w-0 shrink-0 text-status-warning",
+        "transition-colors duration-150 ease-out hover:text-status-warning/80",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+      )}
+    >
+      <span aria-hidden className="w-1.5 h-1.5 rounded-full shrink-0 bg-status-warning" />
+      <span className="truncate font-medium">{label}</span>
+    </button>
+  );
+}

--- a/src/components/HelpPanel/TurnOutcomePip.tsx
+++ b/src/components/HelpPanel/TurnOutcomePip.tsx
@@ -33,7 +33,9 @@ interface TurnOutcomePipProps {
  * (the label differentiates), keeping the accent budget intact.
  */
 export function TurnOutcomePip({ outcome, onDismiss }: TurnOutcomePipProps) {
-  if (outcome === null) return null;
+  // Guard nullish (not just `null`): a snapshot that predates this field would
+  // pass `undefined`, and indexing OUTCOME_COPY with it would throw.
+  if (!outcome) return null;
   const { label, title } = OUTCOME_COPY[outcome];
   return (
     <button

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -506,6 +506,7 @@ beforeEach(() => {
           onDisplayImage: vi.fn(() => () => {}),
           onSessionRevoked: vi.fn(() => () => {}),
           onGrantLifecycle: vi.fn(() => () => {}),
+          onTurnOutcomeAlert: vi.fn(() => () => {}),
           setSessionTier: vi.fn().mockResolvedValue({ sessionId: "", tier: "workbench" }),
           resetDenialCounts: vi.fn().mockResolvedValue(undefined),
           issueGrant: vi.fn().mockResolvedValue({

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -433,6 +433,7 @@ beforeEach(() => {
           onDisplayImage: vi.fn(() => () => {}),
           onSessionRevoked: vi.fn(() => () => {}),
           onGrantLifecycle: vi.fn(() => () => {}),
+          onTurnOutcomeAlert: vi.fn(() => () => {}),
           setSessionTier: vi.fn().mockResolvedValue({ sessionId: "", tier: "workbench" }),
           resetDenialCounts: vi.fn().mockResolvedValue(undefined),
           issueGrant: vi.fn().mockResolvedValue({

--- a/src/components/HelpPanel/__tests__/TurnOutcomePip.test.tsx
+++ b/src/components/HelpPanel/__tests__/TurnOutcomePip.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/utils", () => ({ cn: (...args: unknown[]) => args.filter(Boolean).join(" ") }));
+
+import { TurnOutcomePip } from "../TurnOutcomePip";
+
+describe("TurnOutcomePip", () => {
+  it("renders nothing when there is no pending outcome", () => {
+    const { container } = render(<TurnOutcomePip outcome={null} onDismiss={vi.fn()} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("labels agent-stuck distinctly from reasoning-loop", () => {
+    const { rerender } = render(<TurnOutcomePip outcome="agent-stuck" onDismiss={vi.fn()} />);
+    expect(screen.getByText("Agent stuck")).toBeTruthy();
+
+    rerender(<TurnOutcomePip outcome="reasoning-loop" onDismiss={vi.fn()} />);
+    expect(screen.getByText("Reasoning loop")).toBeTruthy();
+  });
+
+  it("calls onDismiss when clicked", () => {
+    const onDismiss = vi.fn();
+    render(<TurnOutcomePip outcome="agent-stuck" onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes an accessible label describing the outcome", () => {
+    render(<TurnOutcomePip outcome="reasoning-loop" onDismiss={vi.fn()} />);
+    const button = screen.getByRole("button");
+    expect(button.getAttribute("aria-label")).toMatch(/reasoning loop/i);
+  });
+});

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -209,6 +209,13 @@ export interface HelpSessionSnapshot {
   grantEnded: GrantEndedState | null;
   /** True while a user-initiated grant revoke is in flight (#10042). */
   isRevokingGrant: boolean;
+  /**
+   * Most recent alertable turn outcome (`agent-stuck` / `reasoning-loop`) for
+   * the bound help session (#10018); null when none is pending. Drives the
+   * footer's ambient outcome pip. Cleared on dismiss, on a fresh turn, or on
+   * session teardown/replacement.
+   */
+  outcomeAlert: import("@shared/types/ipc/mcpServer").TurnOutcomeAlertClass | null;
 }
 
 export interface HelpProjectRef {
@@ -520,6 +527,7 @@ const INITIAL_SNAPSHOT: HelpSessionSnapshot = Object.freeze({
   activeGrant: null,
   grantEnded: null,
   isRevokingGrant: false,
+  outcomeAlert: null,
 });
 
 /**
@@ -578,6 +586,13 @@ export class HelpSessionController {
   private _snapshotBannerTimer: ReturnType<typeof setTimeout> | null = null;
   private _grantEndedBannerTimer: ReturnType<typeof setTimeout> | null = null;
   private _disposers: Array<() => void> = [];
+  /**
+   * Turn id the pending outcome alert (#10018) was recorded for, or null when
+   * the alert carried none (`agent-stuck`, whose turn id is already cleared by
+   * the time the watchdog fires). Used to auto-clear the pip when a tool call
+   * from a different turn arrives — i.e. the agent has resumed work.
+   */
+  private _outcomeAlertTurnId: string | null = null;
   private _lastInputs: HelpSessionInputs | null = null;
   private _hibernateArmedFor: {
     terminalId: string;
@@ -649,6 +664,11 @@ export class HelpSessionController {
       this._onToolCallSettled(payload);
     });
     this._disposers.push(disposeToolStarted, disposeToolSettled);
+
+    const disposeOutcomeAlert = window.electron.mcpServer.onTurnOutcomeAlert((payload) => {
+      this._onTurnOutcomeAlert(payload);
+    });
+    this._disposers.push(disposeOutcomeAlert);
 
     const disposeDisplayImage = window.electron.mcpServer.onDisplayImage((payload) => {
       // The main process already validated the URL and assigned the figure
@@ -756,10 +776,13 @@ export class HelpSessionController {
     this._hasAutoLaunched = false;
     store.clearTerminal();
     // The bound session is gone — drop any lingering activity row so the strip
-    // doesn't show stale tool calls for a dead session (#9759), and clear the
-    // grant countdown/notice so they don't outlive the session (#10042).
+    // doesn't show stale tool calls for a dead session (#9759), clear the
+    // grant countdown/notice so they don't outlive the session (#10042), and
+    // clear any pending outcome pip (#10018) so it can't bleed into the next
+    // session.
     this.clearMcpActivity();
     this._clearGrantState();
+    this._clearOutcomeAlert();
   }
 
   /**
@@ -910,6 +933,7 @@ export class HelpSessionController {
         useHelpPanelStore.getState().clearFigures();
         this.clearMcpActivity();
         this._clearGrantState();
+        this._clearOutcomeAlert();
       }
       // Discarding the current conversation invalidates any persisted
       // hibernate entry for this project — leaving it would resume the
@@ -1257,6 +1281,17 @@ export class HelpSessionController {
         isError: false,
       },
     });
+    // Auto-clear the outcome pip (#10018) once the agent resumes work in a
+    // fresh turn — a tool call whose turn differs from the alert's turn means
+    // the stuck/looping turn is behind us. `agent-stuck` alerts carry no turn
+    // id (`_outcomeAlertTurnId` is null), so any turn-stamped call clears them.
+    if (
+      this._snapshot.outcomeAlert !== null &&
+      payload.turnId !== undefined &&
+      payload.turnId !== this._outcomeAlertTurnId
+    ) {
+      this._patch({ outcomeAlert: null });
+    }
   }
 
   /**
@@ -1306,6 +1341,37 @@ export class HelpSessionController {
     });
   }
 
+  /**
+   * Handle a live turn-outcome alert push (#10018). Surfaces the `agent-stuck`
+   * / `reasoning-loop` outcome as the footer's ambient pip. The targeted send
+   * already routes only to this session's pinned WebContents, so no session
+   * filtering is needed here (matches `_onToolCallStarted`). The carried turn
+   * id (absent for `agent-stuck`) is retained so the pip auto-clears once the
+   * agent starts a fresh turn.
+   */
+  private _onTurnOutcomeAlert(
+    payload: import("@shared/types/ipc/mcpServer").McpTurnOutcomeAlertPayload
+  ): void {
+    this._outcomeAlertTurnId = payload.turnId ?? null;
+    this._patch({ outcomeAlert: payload.outcome });
+  }
+
+  /** Dismiss the ambient outcome pip (#10018). User-driven click-to-clear. */
+  dismissOutcomeAlert(): void {
+    this._clearOutcomeAlert();
+  }
+
+  /**
+   * Drop any pending outcome pip and its retained turn id (#10018). Shared by
+   * the user dismiss path and session teardown/replacement — a pip for a
+   * session that's gone must never linger into its successor.
+   */
+  private _clearOutcomeAlert(): void {
+    this._outcomeAlertTurnId = null;
+    if (this._snapshot.outcomeAlert === null) return;
+    this._patch({ outcomeAlert: null });
+  }
+
   /** Clear the live activity strip (e.g. on session teardown). */
   clearMcpActivity(): void {
     if (this._snapshot.mcpActivity === null) return;
@@ -1330,7 +1396,8 @@ export class HelpSessionController {
       next.sessionRevoked === this._snapshot.sessionRevoked &&
       next.activeGrant === this._snapshot.activeGrant &&
       next.grantEnded === this._snapshot.grantEnded &&
-      next.isRevokingGrant === this._snapshot.isRevokingGrant
+      next.isRevokingGrant === this._snapshot.isRevokingGrant &&
+      next.outcomeAlert === this._snapshot.outcomeAlert
     ) {
       return;
     }

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -8,6 +8,7 @@ const {
   mockMcpOnDisplayImage,
   mockMcpOnSessionRevoked,
   mockMcpOnGrantLifecycle,
+  mockMcpOnTurnOutcomeAlert,
   mockMcpSetSessionTier,
   mockMcpIssueGrant,
   mockMcpResetDenialCounts,
@@ -21,6 +22,7 @@ const {
   displayImageListeners,
   sessionRevokedListeners,
   grantLifecycleListeners,
+  outcomeAlertListeners,
   helpPanelState,
   panelStoreState,
   projectStoreState,
@@ -31,6 +33,7 @@ const {
   mockMcpOnDisplayImage: vi.fn(),
   mockMcpOnSessionRevoked: vi.fn(),
   mockMcpOnGrantLifecycle: vi.fn(),
+  mockMcpOnTurnOutcomeAlert: vi.fn(),
   mockMcpSetSessionTier: vi.fn().mockResolvedValue(undefined),
   mockMcpIssueGrant: vi.fn().mockResolvedValue({
     sessionId: "",
@@ -52,6 +55,7 @@ const {
   displayImageListeners: [] as Array<(payload: unknown) => void>,
   sessionRevokedListeners: [] as Array<(payload: unknown) => void>,
   grantLifecycleListeners: [] as Array<(payload: unknown) => void>,
+  outcomeAlertListeners: [] as Array<(payload: unknown) => void>,
   helpPanelState: {
     isOpen: false,
     terminalId: null as string | null,
@@ -149,6 +153,7 @@ beforeEach(() => {
   displayImageListeners.length = 0;
   sessionRevokedListeners.length = 0;
   grantLifecycleListeners.length = 0;
+  outcomeAlertListeners.length = 0;
 
   mockMcpOnTierNotPermitted.mockReset();
   mockMcpOnTierNotPermitted.mockImplementation((cb: (payload: unknown) => void) => {
@@ -198,6 +203,14 @@ beforeEach(() => {
     return () => {
       const idx = grantLifecycleListeners.indexOf(cb);
       if (idx >= 0) grantLifecycleListeners.splice(idx, 1);
+    };
+  });
+  mockMcpOnTurnOutcomeAlert.mockReset();
+  mockMcpOnTurnOutcomeAlert.mockImplementation((cb: (payload: unknown) => void) => {
+    outcomeAlertListeners.push(cb);
+    return () => {
+      const idx = outcomeAlertListeners.indexOf(cb);
+      if (idx >= 0) outcomeAlertListeners.splice(idx, 1);
     };
   });
   mockMcpSetSessionTier.mockReset();
@@ -257,6 +270,7 @@ beforeEach(() => {
           onDisplayImage: mockMcpOnDisplayImage,
           onSessionRevoked: mockMcpOnSessionRevoked,
           onGrantLifecycle: mockMcpOnGrantLifecycle,
+          onTurnOutcomeAlert: mockMcpOnTurnOutcomeAlert,
           setSessionTier: mockMcpSetSessionTier,
           issueGrant: mockMcpIssueGrant,
           resetDenialCounts: mockMcpResetDenialCounts,
@@ -384,6 +398,82 @@ describe("HelpSessionController — subscribe / getSnapshot", () => {
     ctrl["_patch"]({ showResumeBanner: true });
     expect(a).not.toHaveBeenCalled();
     expect(b).toHaveBeenCalled();
+  });
+});
+
+describe("HelpSessionController — turn-outcome alert pip", () => {
+  function fireOutcome(payload: { helpSessionId: string; outcome: string; turnId?: string }) {
+    outcomeAlertListeners[0]!(payload);
+  }
+  function fireToolStart(payload: { turnId?: string }) {
+    toolStartedListeners[0]!({
+      sessionId: "s1",
+      toolId: "agent.getState",
+      argsSummary: "{}",
+      startedAt: Date.now(),
+      danger: false,
+      ...payload,
+    });
+  }
+
+  it("surfaces agent-stuck as outcomeAlert and notifies listeners", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    const listener = vi.fn();
+    ctrl.subscribe(listener);
+    expect(ctrl.getSnapshot().outcomeAlert).toBeNull();
+
+    fireOutcome({ helpSessionId: "help-1", outcome: "agent-stuck" });
+    expect(listener).toHaveBeenCalled();
+    expect(ctrl.getSnapshot().outcomeAlert).toBe("agent-stuck");
+    ctrl.stop();
+  });
+
+  it("surfaces reasoning-loop and clears on user dismiss", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    fireOutcome({ helpSessionId: "help-1", outcome: "reasoning-loop", turnId: "turn-1" });
+    expect(ctrl.getSnapshot().outcomeAlert).toBe("reasoning-loop");
+
+    ctrl.dismissOutcomeAlert();
+    expect(ctrl.getSnapshot().outcomeAlert).toBeNull();
+    ctrl.stop();
+  });
+
+  it("auto-clears the pip when a tool call from a different turn starts", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    fireOutcome({ helpSessionId: "help-1", outcome: "reasoning-loop", turnId: "turn-1" });
+    expect(ctrl.getSnapshot().outcomeAlert).toBe("reasoning-loop");
+
+    // Same-turn residual call must NOT clear the pip.
+    fireToolStart({ turnId: "turn-1" });
+    expect(ctrl.getSnapshot().outcomeAlert).toBe("reasoning-loop");
+
+    // A fresh turn means the agent resumed — clear.
+    fireToolStart({ turnId: "turn-2" });
+    expect(ctrl.getSnapshot().outcomeAlert).toBeNull();
+    ctrl.stop();
+  });
+
+  it("auto-clears an agent-stuck pip (no turn id) on the next turn-stamped call", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    fireOutcome({ helpSessionId: "help-1", outcome: "agent-stuck" });
+    expect(ctrl.getSnapshot().outcomeAlert).toBe("agent-stuck");
+
+    fireToolStart({ turnId: "turn-9" });
+    expect(ctrl.getSnapshot().outcomeAlert).toBeNull();
+    ctrl.stop();
+  });
+
+  it("does not clear the pip for a call with no turn id", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    fireOutcome({ helpSessionId: "help-1", outcome: "reasoning-loop", turnId: "turn-1" });
+    fireToolStart({});
+    expect(ctrl.getSnapshot().outcomeAlert).toBe("reasoning-loop");
+    ctrl.stop();
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds a Tier 1 ambient pip to the `HelpPanel` footer (next to `McpActivityStrip`) that lights up when the latest turn for the bound help session classifies as `agent-stuck` or `reasoning-loop` — outcomes that were previously only surfaced in the Settings diagnostics tab, invisible during active work.
- No toast for these outcomes; the pip is the right tier (single status-warning dot + label, click-to-dismiss, tooltip-differentiated per outcome type).
- Wires up the full signal path: new `MCP_TURN_OUTCOME_ALERT` push channel, `TurnOutcomeService` notify-alert callback, `HttpLifecycle.notifyTurnOutcomeAlert` for targeted per-session `WebContents` delivery, and `HelpSessionController` snapshot field that auto-clears on a fresh turn, explicit dismiss, or session teardown/replace.

Resolves #10018

## Changes

- `electron/ipc/channels.ts` + `shared/types/ipc/` — new `MCP_TURN_OUTCOME_ALERT` push channel and `McpTurnOutcomeAlertPayload` type; registered in `IpcEventMap` (fix caught by the `channelDrift` guard)
- `electron/services/mcp-server/httpLifecycle.ts` — `notifyTurnOutcomeAlert` resolves `helpSessionId` to the pinned `WebContents` and targeted-sends; handles destroyed-WC fallthrough and no-match no-op
- `electron/services/mcp-server/turnOutcomeLog.ts` — `TurnOutcomeService` gained a `notifyAlertCallback` wired post-construction, fires only for the two alertable outcomes
- `electron/ipc/handlers/mcpServer.ts` + `preload.cts` — exposes the push event on the bridge
- `src/controllers/HelpSessionController.ts` — `outcomeAlert` field in snapshot; surfaces on alert, clears on fresh turn / dismiss / session teardown or replace
- `src/components/HelpPanel/TurnOutcomePip.tsx` — new component: single status-warning dot + label, click-to-dismiss, tooltip-differentiated; respects accent restraint (no accent color used)
- `src/components/HelpPanel/HelpPanel.tsx` + `HelpPanelBanners.tsx` — mounts `TurnOutcomePip` in the footer alongside `McpActivityStrip`

## Testing

- Unit: `TurnOutcomeService` callback (emit, debounce, throw-safety); `httpLifecycle` routing (targeted send, destroyed-WC fallthrough, no-match no-op); `HelpSessionController` lifecycle (surface / dismiss / auto-clear on fresh turn / teardown); `TurnOutcomePip` render variants
- Channel drift guard: confirms `MCP_TURN_OUTCOME_ALERT` is registered in `IpcEventMap`
- Static checks, production build, and preload-backdoor security gate all pass
- Environmental flake in `db.openDb.test.ts` (better-sqlite3 / MaxListenersExceeded under memory pressure) passes 8/8 in isolation; unrelated to this PR