### PR TITLE
fix(agent-state): arm ActivityMonitor when parallel output promotion fires

### DIFF
--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -898,6 +898,11 @@ export class ActivityMonitor {
     this.cosmeticRecoveryDebouncer.reset();
     this.structuralRecoveryDebouncer.reset();
     this.completionTimer.reset();
+    // Discard the temperature snapshot so its quiet clock restarts from the
+    // promotion (same rationale as `notifyFocus`). A stale `quietStartedAt`
+    // from the pre-promotion lull would otherwise hint "idle" at the first
+    // poll after the 1.5s working hold and bounce the FSM straight back.
+    this.simpleOutputTemperature.reset();
     if (this.state !== "busy") {
       this.state = "busy";
       this.idleSince = now;

--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -875,6 +875,35 @@ export class ActivityMonitor {
     if (this.isDisposed) return;
   }
 
+  // Called by `TerminalProcess.noteAgentOutputActivity` immediately after it
+  // promotes the agent FSM to working via its direct
+  // `agentStateService.handleActivityState("busy")` path (#9875). That path
+  // bypasses this monitor entirely, leaving the private `state` at "idle" —
+  // and every idle path that can transition the FSM working→waiting gates on
+  // `state === "busy"`, so the FSM would otherwise strand in working with the
+  // watchdog (which only fires from waiting) never arming. Mirrors
+  // `becomeBusy`'s bookkeeping but deliberately skips `onStateChange`: the FSM
+  // transition already happened at the call site, and re-emitting "busy" here
+  // would double-fire the transition.
+  notifyExternalPromotion(now: number = Date.now()): void {
+    if (this.isDisposed) return;
+    // Defense-in-depth: the call site already gates on focus suppression, but
+    // keep the guard so any future caller inherits it (#8865).
+    if (this.isFocusSuppressed(now)) return;
+    this.lastActivityTimestamp = now;
+    this.lastDataTimestamp = now;
+    this.recordWorkingSignal(now);
+    this.resetDebounceTimer();
+    this.waitingWatchdog.reset();
+    this.cosmeticRecoveryDebouncer.reset();
+    this.structuralRecoveryDebouncer.reset();
+    this.completionTimer.reset();
+    if (this.state !== "busy") {
+      this.state = "busy";
+      this.idleSince = now;
+    }
+  }
+
   notifyResize(suppressionMs = 500): void {
     this.resizeSuppressUntil = Date.now() + suppressionMs;
     this.highOutputDetector.resetWindow();

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -5806,6 +5806,75 @@ describe("ActivityMonitor", () => {
       monitor.dispose();
     });
 
+    it("does not bounce straight back to idle when promoted after a long quiet spell", () => {
+      vi.setSystemTime(40000);
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("ext-promo-quiet", 100, onStateChange, {
+        agentId: "claude",
+        getVisibleLines: () => ["hello world"],
+        getCursorLine: () => "hello world",
+        initialState: "idle",
+        skipInitialStateEmit: true,
+        pollingIntervalMs: 50,
+        idleDebounceMs: 8000,
+      });
+      monitor.startPolling();
+
+      // Let the agent sit quiet long past the temperature's 6s waiting dwell
+      // so its quiet clock is stale when the external promotion arrives.
+      vi.advanceTimersByTime(10000);
+      onStateChange.mockClear();
+
+      monitor.notifyExternalPromotion();
+      expect(monitor.getState()).toBe("busy");
+
+      // The stale quiet clock must not flip the monitor back to idle right
+      // after the 1.5s working hold expires.
+      vi.advanceTimersByTime(2000);
+      expect(monitor.getState()).toBe("busy");
+      expect(onStateChange).not.toHaveBeenCalled();
+
+      // With continued silence the idle path still fires eventually.
+      vi.advanceTimersByTime(7700);
+      expect(monitor.getState()).toBe("idle");
+      expect(onStateChange).toHaveBeenCalledWith("ext-promo-quiet", 100, "idle", {
+        trigger: "timeout",
+      });
+
+      monitor.dispose();
+    });
+
+    it("repeated promotions extend the idle deadline", () => {
+      vi.setSystemTime(50000);
+      const onStateChange = vi.fn();
+      // No polling sources: the debounce timer is the only idle driver, so
+      // the test isolates the lastActivityTimestamp refresh.
+      const monitor = new ActivityMonitor("ext-promo-extend", 100, onStateChange, {
+        agentId: "claude",
+        initialState: "idle",
+        skipInitialStateEmit: true,
+        idleDebounceMs: 8000,
+      });
+
+      monitor.notifyExternalPromotion();
+      vi.advanceTimersByTime(6000);
+      expect(monitor.getState()).toBe("busy");
+
+      // A second promotion refreshes lastActivityTimestamp and re-arms the
+      // 8s debounce window from now.
+      monitor.notifyExternalPromotion();
+      vi.advanceTimersByTime(7900);
+      expect(monitor.getState()).toBe("busy");
+
+      vi.advanceTimersByTime(200);
+      expect(monitor.getState()).toBe("idle");
+      expect(onStateChange).toHaveBeenCalledWith("ext-promo-extend", 100, "idle", {
+        trigger: "timeout",
+      });
+
+      monitor.dispose();
+    });
+
     it("never emits busy from this path, even when called repeatedly while already busy", () => {
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("ext-promo-busy", 100, onStateChange, {

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -5736,4 +5736,93 @@ describe("ActivityMonitor", () => {
       expect(() => monitor.onOscProgressIdle(7000)).not.toThrow();
     });
   });
+
+  describe("notifyExternalPromotion (#9875)", () => {
+    it("arms the idle machinery without emitting busy, so the idle path can fire later", () => {
+      vi.setSystemTime(20000);
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("ext-promo", 100, onStateChange, {
+        agentId: "claude",
+        getVisibleLines: () => ["hello world"],
+        getCursorLine: () => "hello world",
+        initialState: "idle",
+        skipInitialStateEmit: true,
+        pollingIntervalMs: 50,
+        idleDebounceMs: 8000,
+      });
+      monitor.startPolling();
+      vi.advanceTimersByTime(100);
+      onStateChange.mockClear();
+
+      monitor.notifyExternalPromotion();
+
+      // Private state shadows the FSM promotion, but no state change is
+      // emitted — the caller already transitioned the FSM directly.
+      expect(monitor.getState()).toBe("busy");
+      expect(onStateChange).not.toHaveBeenCalled();
+
+      // After the working hold (1500ms) and idle debounce (8000ms) of
+      // silence, the monitor's own idle path fires — the working→waiting
+      // transition that was previously unreachable because the private
+      // state was stranded at "idle".
+      vi.advanceTimersByTime(9700);
+      expect(monitor.getState()).toBe("idle");
+      expect(onStateChange).toHaveBeenCalledWith("ext-promo", 100, "idle", {
+        trigger: "timeout",
+      });
+
+      monitor.dispose();
+    });
+
+    it("is a no-op after dispose", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("ext-promo-disposed", 100, onStateChange, {
+        agentId: "claude",
+        initialState: "idle",
+        skipInitialStateEmit: true,
+      });
+      monitor.dispose();
+
+      expect(() => monitor.notifyExternalPromotion()).not.toThrow();
+      expect(monitor.getState()).toBe("idle");
+      expect(onStateChange).not.toHaveBeenCalled();
+    });
+
+    it("does not arm while focus suppression is active (#8865)", () => {
+      vi.setSystemTime(30000);
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("ext-promo-focus", 100, onStateChange, {
+        agentId: "claude",
+        initialState: "idle",
+        skipInitialStateEmit: true,
+      });
+
+      monitor.notifyFocus(2000);
+      monitor.notifyExternalPromotion();
+
+      expect(monitor.getState()).toBe("idle");
+      expect(onStateChange).not.toHaveBeenCalled();
+
+      monitor.dispose();
+    });
+
+    it("never emits busy from this path, even when called repeatedly while already busy", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("ext-promo-busy", 100, onStateChange, {
+        agentId: "claude",
+        initialState: "busy",
+        skipInitialStateEmit: true,
+      });
+      onStateChange.mockClear();
+
+      monitor.notifyExternalPromotion();
+      monitor.notifyExternalPromotion();
+
+      expect(monitor.getState()).toBe("busy");
+      const busyCalls = onStateChange.mock.calls.filter((call) => call[2] === "busy");
+      expect(busyCalls.length).toBe(0);
+
+      monitor.dispose();
+    });
+  });
 });

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1491,6 +1491,10 @@ export class TerminalProcess {
       this.deps.agentStateService.handleActivityState(this.terminalInfo, "busy", {
         trigger: "output",
       });
+      // Arm the monitor's private busy state so its idle paths can transition
+      // the FSM back to waiting — without this the direct promotion above
+      // strands the FSM in working (#9875).
+      this.activityMonitor?.notifyExternalPromotion();
     }
   }
 

--- a/electron/services/pty/__tests__/TerminalProcess.submit.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.submit.test.ts
@@ -238,6 +238,120 @@ describe("TerminalProcess.submit", () => {
     expect(busyCalls.length).toBe(0);
   });
 
+  it("noteAgentOutputActivity arms ActivityMonitor via notifyExternalPromotion when it promotes (#9875)", () => {
+    const handleActivityState = vi.fn();
+    const ctx = defaultSpawnContext();
+    const terminal = new TerminalProcess(
+      "t-ext-promo",
+      {
+        cwd: process.cwd(),
+        cols: 80,
+        rows: 24,
+        kind: "terminal",
+        launchAgentId: "claude",
+      },
+      { emitData: () => {}, onExit: () => {} },
+      {
+        agentStateService: { handleActivityState } as any,
+        ptyPool: null,
+        processTreeCache: null,
+      },
+      ctx,
+      createMockPty()
+    );
+
+    const internals = terminal as unknown as {
+      terminalInfo: { agentState: string };
+      activityMonitor: { notifyExternalPromotion: (now?: number) => void };
+      agentOutputTemperature: { observeDelta: (...args: unknown[]) => unknown };
+      agentOutputContentSnapshot: unknown;
+      noteAgentOutputActivity: (before: unknown) => void;
+      getAgentOutputContentSnapshot: () => unknown;
+    };
+
+    Object.defineProperty(terminal, "isAgentLive", { value: true, configurable: true });
+    internals.terminalInfo.agentState = "waiting";
+    internals.agentOutputContentSnapshot = { lines: ["before"] };
+    internals.getAgentOutputContentSnapshot = () => ({ lines: ["after redraw with new text"] });
+    // The temperature needs several sustained samples before hinting busy;
+    // force the hint so the test exercises the promotion branch directly.
+    vi.spyOn(internals.agentOutputTemperature, "observeDelta").mockReturnValue({
+      stateHint: "busy",
+      changed: true,
+      changedChars: 64,
+      heatAdded: 50,
+      temperature: 80,
+      suppressed: false,
+      seeded: false,
+    });
+    const promoteSpy = vi.spyOn(internals.activityMonitor, "notifyExternalPromotion");
+    handleActivityState.mockClear();
+
+    internals.noteAgentOutputActivity({ lines: ["before"] });
+
+    // The direct FSM promotion still fires…
+    expect(handleActivityState).toHaveBeenCalledWith(expect.anything(), "busy", {
+      trigger: "output",
+    });
+    // …and now also arms the monitor so its idle paths can bring the FSM back.
+    expect(promoteSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("noteAgentOutputActivity does not arm ActivityMonitor while focus-suppressed (#9875)", () => {
+    const handleActivityState = vi.fn();
+    const ctx = defaultSpawnContext();
+    const terminal = new TerminalProcess(
+      "t-ext-promo-focus",
+      {
+        cwd: process.cwd(),
+        cols: 80,
+        rows: 24,
+        kind: "terminal",
+        launchAgentId: "claude",
+      },
+      { emitData: () => {}, onExit: () => {} },
+      {
+        agentStateService: { handleActivityState } as any,
+        ptyPool: null,
+        processTreeCache: null,
+      },
+      ctx,
+      createMockPty()
+    );
+
+    const internals = terminal as unknown as {
+      terminalInfo: { agentState: string };
+      activityMonitor: {
+        notifyFocus: (ms?: number) => void;
+        notifyExternalPromotion: (now?: number) => void;
+      };
+      agentOutputTemperature: { observeDelta: (...args: unknown[]) => unknown };
+      agentOutputContentSnapshot: unknown;
+      noteAgentOutputActivity: (before: unknown) => void;
+      getAgentOutputContentSnapshot: () => unknown;
+    };
+
+    Object.defineProperty(terminal, "isAgentLive", { value: true, configurable: true });
+    internals.terminalInfo.agentState = "waiting";
+    internals.agentOutputContentSnapshot = { lines: ["before"] };
+    internals.getAgentOutputContentSnapshot = () => ({ lines: ["after redraw with new text"] });
+    vi.spyOn(internals.agentOutputTemperature, "observeDelta").mockReturnValue({
+      stateHint: "busy",
+      changed: true,
+      changedChars: 64,
+      heatAdded: 50,
+      temperature: 80,
+      suppressed: false,
+      seeded: false,
+    });
+    const promoteSpy = vi.spyOn(internals.activityMonitor, "notifyExternalPromotion");
+
+    internals.activityMonitor.notifyFocus(2000);
+    internals.noteAgentOutputActivity({ lines: ["before"] });
+
+    expect(promoteSpy).not.toHaveBeenCalled();
+  });
+
   it("delays Enter for Copilot (submitEnterDelayMs: 200) so Ink TUI registers input", async () => {
     vi.useFakeTimers();
     const terminal = createTerminal({ kind: "terminal", launchAgentId: "copilot" });

--- a/electron/services/pty/__tests__/TerminalProcess.submit.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.submit.test.ts
@@ -347,9 +347,12 @@ describe("TerminalProcess.submit", () => {
     const promoteSpy = vi.spyOn(internals.activityMonitor, "notifyExternalPromotion");
 
     internals.activityMonitor.notifyFocus(2000);
+    handleActivityState.mockClear();
     internals.noteAgentOutputActivity({ lines: ["before"] });
 
     expect(promoteSpy).not.toHaveBeenCalled();
+    const busyCalls = handleActivityState.mock.calls.filter((call) => call[1] === "busy");
+    expect(busyCalls.length).toBe(0);
   });
 
   it("delays Enter for Copilot (submitEnterDelayMs: 200) so Ink TUI registers input", async () => {


### PR DESCRIPTION
## Summary

- `TerminalProcess.noteAgentOutputActivity` promotes the agent FSM to `working` directly via `agentStateService.handleActivityState("busy")`, bypassing `ActivityMonitor` — whose private state stayed `"idle"`. Every `working→waiting` idle path in `ActivityMonitor` gates on its private state being `"busy"`, and the FSM watchdog only fires from `waiting`, so the FSM could strand in `working` indefinitely.
- Adds `ActivityMonitor.notifyExternalPromotion()` — a narrow method modelled on `becomeBusy`'s bookkeeping (timestamps, working hold, debounce, watchdog, recovery debouncers, completion timer) but deliberately without `onStateChange`, since the FSM already transitioned at the call site.
- Resets `simpleOutputTemperature` on promotion so a stale quiet clock can't flip the FSM back to `waiting` ~1.5s later (same rationale as `notifyFocus`, #8865 precedent).

Resolves #9875

## Changes

- `ActivityMonitor.notifyExternalPromotion()` — arms the monitor when the FSM is promoted externally
- `TerminalProcess.noteAgentOutputActivity` — calls `notifyExternalPromotion()` right after the direct promotion
- 6 new `ActivityMonitor` unit tests: arming, idle round-trip, premature-idle regression, deadline extension, dispose no-op, focus suppression
- 2 new `TerminalProcess` call-site tests alongside the #8865 precedent

## Testing

Full local CI passed (`npm run check` — all 10 sub-checks, unit tests). 4 full-suite timeouts confirmed flaky (pass 2x in isolation).