### PR TITLE
fix(agent-state): suppress teardown dispose observation

### DIFF
--- a/electron/services/AgentNotificationService.ts
+++ b/electron/services/AgentNotificationService.ts
@@ -398,30 +398,9 @@ class AgentNotificationService {
     const items = this.waitingBurstBuffer.splice(0);
     if (items.length === 0) return;
 
-    // Re-check live agent state before firing OS notifications. The
-    // BURST_WINDOW_MS timer is fire-and-forget; if a terminal has left
-    // the `waiting` state since its entry was buffered (e.g. a
-    // synthetic waiting blip from teardown was published and a `kill`
-    // landed during the 200ms window — #9867), drop its entry here so
-    // we don't notify against a dead terminal. Mirrors the
-    // `countActiveAgents` synchronous store-read pattern at L283-L287.
-    // Absent `agentState` is treated as "unknown" (keep) — only a
-    // *known* non-waiting state drops the entry.
-    const liveTerminals = store.get("appState").terminals as Array<{
-      id: string;
-      agentState?: string;
-    }>;
-    const liveStateById = new Map(liveTerminals.map((t) => [t.id, t.agentState]));
-    const liveItems = items.filter((item) => {
-      if (!item.terminalId) return true;
-      const liveState = liveStateById.get(item.terminalId);
-      return liveState === undefined || liveState === "waiting";
-    });
-    if (liveItems.length === 0) return;
-
     const dedupedItems: BurstWaitingEntry[] = [];
     const seen = new Set<string>();
-    for (const [index, item] of liveItems.entries()) {
+    for (const [index, item] of items.entries()) {
       const key =
         (item.terminalId ?? item.agentId ?? item.worktreeId)
           ? `${item.terminalId ?? ""}|${item.agentId ?? ""}|${item.worktreeId ?? ""}`

--- a/electron/services/AgentNotificationService.ts
+++ b/electron/services/AgentNotificationService.ts
@@ -227,6 +227,28 @@ class AgentNotificationService {
       this.clearWaitingEscalation(terminalId);
     }
 
+    // Purge any waiting-burst entry for this terminal once the terminal
+    // enters a terminal state. Defense-in-depth (#9867): if a synthetic
+    // `working → waiting` transition were ever to slip through the
+    // `handleActivityState` `dispose` suppression, the buffered entry
+    // must not outlive the terminal — otherwise the BURST_WINDOW_MS
+    // timer would fire `showWatchNotification` against a dead terminal
+    // ~200ms after the kill/exit. Per-terminal splice keeps entries for
+    // other terminals intact.
+    if ((state === "completed" || state === "exited") && terminalId) {
+      const before = this.waitingBurstBuffer.length;
+      this.waitingBurstBuffer = this.waitingBurstBuffer.filter(
+        (entry) => entry.terminalId !== terminalId
+      );
+      if (this.waitingBurstBuffer.length === 0 && this.waitingBurstTimer !== null) {
+        clearTimeout(this.waitingBurstTimer);
+        this.waitingBurstTimer = null;
+      } else if (this.waitingBurstBuffer.length !== before) {
+        // Buffer still has items for other terminals — let the existing
+        // timer continue to fire. Only the spliced entry was dropped.
+      }
+    }
+
     // Cancel working pulse when agent leaves "working"
     if (previousState === "working" && state !== "working" && terminalId) {
       this.clearWorkingPulse(terminalId);
@@ -376,9 +398,30 @@ class AgentNotificationService {
     const items = this.waitingBurstBuffer.splice(0);
     if (items.length === 0) return;
 
+    // Re-check live agent state before firing OS notifications. The
+    // BURST_WINDOW_MS timer is fire-and-forget; if a terminal has left
+    // the `waiting` state since its entry was buffered (e.g. a
+    // synthetic waiting blip from teardown was published and a `kill`
+    // landed during the 200ms window — #9867), drop its entry here so
+    // we don't notify against a dead terminal. Mirrors the
+    // `countActiveAgents` synchronous store-read pattern at L283-L287.
+    // Absent `agentState` is treated as "unknown" (keep) — only a
+    // *known* non-waiting state drops the entry.
+    const liveTerminals = store.get("appState").terminals as Array<{
+      id: string;
+      agentState?: string;
+    }>;
+    const liveStateById = new Map(liveTerminals.map((t) => [t.id, t.agentState]));
+    const liveItems = items.filter((item) => {
+      if (!item.terminalId) return true;
+      const liveState = liveStateById.get(item.terminalId);
+      return liveState === undefined || liveState === "waiting";
+    });
+    if (liveItems.length === 0) return;
+
     const dedupedItems: BurstWaitingEntry[] = [];
     const seen = new Set<string>();
-    for (const [index, item] of items.entries()) {
+    for (const [index, item] of liveItems.entries()) {
       const key =
         (item.terminalId ?? item.agentId ?? item.worktreeId)
           ? `${item.terminalId ?? ""}|${item.agentId ?? ""}|${item.worktreeId ?? ""}`

--- a/electron/services/__tests__/AgentNotificationService.test.ts
+++ b/electron/services/__tests__/AgentNotificationService.test.ts
@@ -1617,35 +1617,25 @@ describe("AgentNotificationService", () => {
       );
     });
 
-    it("flushWaitingBurst drops entries whose terminal has left waiting in the live store", () => {
-      // Simulate a race: a buffered entry survived a completed transition
-      // (e.g. the burst timer was already armed when the completed event
-      // landed, or the entry was pushed directly). The flush must still
-      // re-check live state and drop the entry.
+    it("flushWaitingBurst is a no-op when the in-handler purge emptied the buffer", () => {
+      // Idempotency: if a `completed`/`exited` event lands during the
+      // 200ms burst window and the in-handler splice drains the buffer,
+      // the flush must not throw and must not emit any notification.
+      // (Earlier review draft added a pre-flush live-state re-check; that
+      // was removed because appState.terminals is renderer-pushed with
+      // round-trip latency — it would drop legitimate waiting entries
+      // and is also ambiguous between "absent" and "removed" terminals.
+      // The in-handler splice is the only correct defense, since it runs
+      // on the same event tick as the `completed`/`exited` event and
+      // uses the event's own `state` field.)
       mockStore({ waitingEnabled: true });
       agentNotificationService.syncWatchedPanels(["term-1"]);
 
       events.emit("agent:state-changed", makePayloadFor("term-1", "agent-1", "waiting"));
-      // term-1 is no longer in `waiting` in the live store (we set its
-      // agentState to "completed" here without emitting a state-changed).
-      mockStore(
-        { waitingEnabled: true },
-        {
-          activeWorktreeId: "wt-1",
-          terminals: [
-            {
-              id: "term-1",
-              kind: "terminal",
-              agentId: "agent-1",
-              title: "Agent 1",
-              location: "dock" as const,
-              worktreeId: "wt-1",
-              agentState: "completed",
-            },
-          ],
-        }
+      events.emit(
+        "agent:state-changed",
+        makePayloadFor("term-1", "agent-1", "completed", "waiting")
       );
-
       vi.advanceTimersByTime(300);
 
       expect(notificationServiceMock.showWatchNotification).not.toHaveBeenCalled();

--- a/electron/services/__tests__/AgentNotificationService.test.ts
+++ b/electron/services/__tests__/AgentNotificationService.test.ts
@@ -1530,4 +1530,125 @@ describe("AgentNotificationService", () => {
       );
     });
   });
+
+  describe("waiting burst buffer purge (#9867)", () => {
+    function makePayloadFor(
+      terminalId: string,
+      agentId: string,
+      state: AgentState,
+      previousState: AgentState = "working"
+    ) {
+      return {
+        state,
+        previousState,
+        worktreeId: "wt-1",
+        terminalId,
+        agentId,
+        timestamp: Date.now(),
+        trigger: "heuristic" as const,
+        confidence: 1,
+      };
+    }
+
+    function makeMultiTerminalAppState(count: number) {
+      return {
+        activeWorktreeId: "wt-1",
+        terminals: Array.from({ length: count }, (_, i) => ({
+          id: `term-${i + 1}`,
+          kind: "terminal",
+          agentId: `agent-${i + 1}`,
+          title: `Agent ${i + 1}`,
+          location: "dock" as const,
+          worktreeId: "wt-1",
+        })),
+      };
+    }
+
+    it("purges a buffered waiting entry when the same terminal transitions to completed", () => {
+      mockStore({ waitingEnabled: true });
+      agentNotificationService.syncWatchedPanels(["term-1"]);
+
+      // Buffer a waiting entry.
+      events.emit("agent:state-changed", makePayloadFor("term-1", "agent-1", "waiting"));
+      // Before the 200ms burst window elapses, the terminal completes.
+      events.emit(
+        "agent:state-changed",
+        makePayloadFor("term-1", "agent-1", "completed", "waiting")
+      );
+      vi.advanceTimersByTime(500);
+
+      expect(notificationServiceMock.showWatchNotification).not.toHaveBeenCalled();
+    });
+
+    it("purges a buffered waiting entry when the same terminal transitions to exited", () => {
+      mockStore({ waitingEnabled: true });
+      agentNotificationService.syncWatchedPanels(["term-1"]);
+
+      events.emit("agent:state-changed", makePayloadFor("term-1", "agent-1", "waiting"));
+      events.emit("agent:state-changed", makePayloadFor("term-1", "agent-1", "exited", "waiting"));
+      vi.advanceTimersByTime(500);
+
+      expect(notificationServiceMock.showWatchNotification).not.toHaveBeenCalled();
+    });
+
+    it("only splices the matching terminal — entries for other terminals are preserved", () => {
+      const appState = makeMultiTerminalAppState(2);
+      mockStore({ waitingEnabled: true }, appState);
+      agentNotificationService.syncWatchedPanels(["term-1", "term-2"]);
+
+      // Both terminals go waiting inside the same burst window.
+      events.emit("agent:state-changed", makePayloadFor("term-1", "agent-1", "waiting"));
+      events.emit("agent:state-changed", makePayloadFor("term-2", "agent-2", "waiting"));
+      // term-1 completes — its entry should be purged, term-2's should remain.
+      events.emit(
+        "agent:state-changed",
+        makePayloadFor("term-1", "agent-1", "completed", "waiting")
+      );
+      vi.advanceTimersByTime(300);
+
+      // The grouped notification still fires for the surviving term-2 entry.
+      expect(notificationServiceMock.showWatchNotification).toHaveBeenCalledTimes(1);
+      expect(notificationServiceMock.showWatchNotification).toHaveBeenCalledWith(
+        "Agent waiting",
+        expect.stringContaining("agent-2 is waiting for input"),
+        expect.any(Object),
+        "notification:watch-navigate",
+        true
+      );
+    });
+
+    it("flushWaitingBurst drops entries whose terminal has left waiting in the live store", () => {
+      // Simulate a race: a buffered entry survived a completed transition
+      // (e.g. the burst timer was already armed when the completed event
+      // landed, or the entry was pushed directly). The flush must still
+      // re-check live state and drop the entry.
+      mockStore({ waitingEnabled: true });
+      agentNotificationService.syncWatchedPanels(["term-1"]);
+
+      events.emit("agent:state-changed", makePayloadFor("term-1", "agent-1", "waiting"));
+      // term-1 is no longer in `waiting` in the live store (we set its
+      // agentState to "completed" here without emitting a state-changed).
+      mockStore(
+        { waitingEnabled: true },
+        {
+          activeWorktreeId: "wt-1",
+          terminals: [
+            {
+              id: "term-1",
+              kind: "terminal",
+              agentId: "agent-1",
+              title: "Agent 1",
+              location: "dock" as const,
+              worktreeId: "wt-1",
+              agentState: "completed",
+            },
+          ],
+        }
+      );
+
+      vi.advanceTimersByTime(300);
+
+      expect(notificationServiceMock.showWatchNotification).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/electron/services/pty/AgentStateService.ts
+++ b/electron/services/pty/AgentStateService.ts
@@ -468,16 +468,6 @@ export class AgentStateService {
       temperature?: AgentActivityObservationResult;
     }
   ): void {
-    const event: AgentEvent =
-      activity === "busy"
-        ? metadata?.trigger === "input"
-          ? { type: "input" }
-          : { type: "busy" }
-        : activity === "completed"
-          ? { type: "completion" }
-          : { type: "prompt" };
-    const temperature = metadata?.temperature;
-
     // The ActivityMonitor emits a synthetic `idle` observation with
     // `trigger: "dispose"` during teardown when it was still in the busy
     // state. Without this branch the observation falls through to the
@@ -499,6 +489,16 @@ export class AgentStateService {
       });
       return;
     }
+
+    const event: AgentEvent =
+      activity === "busy"
+        ? metadata?.trigger === "input"
+          ? { type: "input" }
+          : { type: "busy" }
+        : activity === "completed"
+          ? { type: "completion" }
+          : { type: "prompt" };
+    const temperature = metadata?.temperature;
 
     if (metadata?.trigger === "timeout") {
       this.updateAgentState(

--- a/electron/services/pty/AgentStateService.ts
+++ b/electron/services/pty/AgentStateService.ts
@@ -478,6 +478,28 @@ export class AgentStateService {
           : { type: "prompt" };
     const temperature = metadata?.temperature;
 
+    // The ActivityMonitor emits a synthetic `idle` observation with
+    // `trigger: "dispose"` during teardown when it was still in the busy
+    // state. Without this branch the observation falls through to the
+    // generic `activity` path below, which publishes a high-confidence
+    // `working → waiting` transition on `agent:state-changed` — a false
+    // positive that fires an "Agent waiting for input" OS notification
+    // (#9867) and burns the one-shot `useAgentWaitingNudge`. Suppress the
+    // publication and emit a diagnostic drop so the event-log inspector
+    // keeps the trace without the bad transition crossing the bus. The
+    // `ActivityMonitor.dispose()` emit itself is preserved so terminals
+    // that lose their ActivityMonitor without an authoritative exit/kill
+    // event are not stranded in `working` — the renderer's direct idle
+    // observation covers that path.
+    if (metadata?.trigger === "dispose") {
+      this.emitTransitionDropped(terminal, {
+        outcome: "no-op",
+        currentState: terminal.agentState || "idle",
+        reason: "dispose observation suppressed at teardown",
+      });
+      return;
+    }
+
     if (metadata?.trigger === "timeout") {
       this.updateAgentState(
         terminal,

--- a/electron/services/pty/__tests__/AgentStateService.test.ts
+++ b/electron/services/pty/__tests__/AgentStateService.test.ts
@@ -1017,4 +1017,96 @@ describe("AgentStateService", () => {
       expect(payloads).toHaveLength(0);
     });
   });
+
+  describe("dispose trigger suppression (#9867)", () => {
+    it("does not publish agent:state-changed for a dispose observation from a working terminal", () => {
+      const service = new AgentStateService();
+      const terminal = createTerminal({ agentState: "working" });
+      const stateChanges: unknown[] = [];
+      const dropped: Array<{ outcome: string; reason?: string; currentState: string }> = [];
+
+      events.on("agent:state-changed", (payload) => {
+        stateChanges.push(payload);
+      });
+      events.on("agent:state-transition-dropped", (payload) => {
+        dropped.push({
+          outcome: payload.outcome,
+          reason: payload.reason,
+          currentState: payload.currentState,
+        });
+      });
+
+      service.handleActivityState(terminal, "idle", { trigger: "dispose" });
+
+      expect(terminal.agentState).toBe("working");
+      expect(stateChanges).toHaveLength(0);
+      expect(dropped).toHaveLength(1);
+      expect(dropped[0]?.outcome).toBe("no-op");
+      expect(dropped[0]?.currentState).toBe("working");
+      expect(dropped[0]?.reason).toBe("dispose observation suppressed at teardown");
+    });
+
+    it("does not publish a false working → waiting transition on a dispose observation", () => {
+      const service = new AgentStateService();
+      const terminal = createTerminal({ agentState: "working" });
+      const stateChanges: Array<{ state: string; previousState: string; trigger: string }> = [];
+
+      events.on("agent:state-changed", (payload) => {
+        stateChanges.push({
+          state: payload.state,
+          previousState: payload.previousState,
+          trigger: payload.trigger,
+        });
+      });
+
+      service.handleActivityState(terminal, "idle", { trigger: "dispose" });
+
+      expect(stateChanges).toHaveLength(0);
+    });
+
+    it("is a no-op for a dispose observation from an idle terminal", () => {
+      const service = new AgentStateService();
+      const terminal = createTerminal({ agentState: "idle" });
+      const stateChanges: unknown[] = [];
+      const dropped: unknown[] = [];
+
+      events.on("agent:state-changed", (payload) => {
+        stateChanges.push(payload);
+      });
+      events.on("agent:state-transition-dropped", (payload) => {
+        dropped.push(payload);
+      });
+
+      service.handleActivityState(terminal, "idle", { trigger: "dispose" });
+
+      expect(terminal.agentState).toBe("idle");
+      expect(stateChanges).toHaveLength(0);
+      expect(dropped).toHaveLength(1);
+    });
+
+    it("does not race the authoritative exit/kill transition — that path is unaffected", () => {
+      const service = new AgentStateService();
+      const terminal = createTerminal({ agentState: "working" });
+      const stateChanges: Array<{ state: string; previousState: string; trigger: string }> = [];
+
+      events.on("agent:state-changed", (payload) => {
+        stateChanges.push({
+          state: payload.state,
+          previousState: payload.previousState,
+          trigger: payload.trigger,
+        });
+      });
+
+      // First: dispose observation (would have been the false positive).
+      service.handleActivityState(terminal, "idle", { trigger: "dispose" });
+      // Then: the authoritative exit that follows teardown.
+      service.updateAgentState(terminal, { type: "exit", code: 0 });
+
+      expect(terminal.agentState).toBe("exited");
+      expect(stateChanges).toHaveLength(1);
+      expect(stateChanges[0]?.state).toBe("exited");
+      expect(stateChanges[0]?.previousState).toBe("working");
+      expect(stateChanges[0]?.trigger).toBe("exit");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

When an agent terminal is busy, teardown emits a synthetic `dispose` observation that `AgentStateService.handleActivityState` interprets as a real `working` → `waiting` transition. The result is a false "Agent waiting for input" OS notification a few hundred milliseconds after the agent has already exited, and the one-shot onboarding nudge can burn itself on the same blip.

This fix suppresses the synthetic observation at the source and removes the secondary failure mode where the timer-driven `flushWaitingBurst` could still fire on a dead terminal.

Resolves #9867

## Changes

- Suppress the synthetic `dispose` observation in `AgentStateService.handleActivityState` (no `agent:state-changed` publish, just a diagnostic log). The terminal-never-stuck-in-`working` safety net still holds: the authoritative state event (`completed`/`exited`) follows the dispose path.
- Splice the per-terminal `waitingBurstBuffer` on `completed`/`exited` transitions in `AgentNotificationService.handleStateChanged`, so `flushWaitingBurst` cannot fire after the terminal is gone.
- 8 new tests covering the suppression and the buffer splice.

## Testing

- `AgentStateService` and `AgentNotificationService` test suites pass with the new cases.
- `npm run check` clean locally.