### PR TITLE
fix(activity): let 1Hz status-line indicators recover waiting agents to working

### DIFF
--- a/docs/architecture/agent-activity-monitoring.md
+++ b/docs/architecture/agent-activity-monitoring.md
@@ -90,13 +90,13 @@ The parser is a read-only side channel. `IdleSequenceFilter.stripIdleTerminalSeq
 
 Visible changes add heat. Silence decays heat exponentially. The model emits a `busy` hint only when heat is above the working threshold for the working dwell. It emits an `idle` hint only when heat has cooled below the waiting threshold for the waiting dwell.
 
-The important design rule is that status indicators are high-value activity evidence. A one-character spinner change should not be treated the same as a cursor blink or layout reflow. If the implementation needs separate weights, the intended categories are:
+The important design rule is that status indicators are high-value activity evidence. A one-character spinner change should not be treated the same as a cursor blink or layout reflow. Observations carry a `signalKind` (#9874):
 
-- content output: ordinary visible text changes;
-- activity indicator: spinner, status line, token counter, time counter;
-- decorative/noise: changes known not to represent agent progress.
+- `content`: ordinary visible text changes — max change gap `900ms`, minimum `4` changed samples;
+- `indicator`: spinner, status line, token counter, time counter — max change gap `2000ms`, minimum `2` changed samples, so a 1Hz countdown or elapsed-time tick can still recover waiting→working;
+- `decorative`: changes known not to represent agent progress — heat-capped and unable to drive working by itself.
 
-Only the decorative/noise category should be unable to drive working by itself.
+`ActivityMonitor` owns the classification: the simple-output data path latches `lastStatusRewriteAt` when raw PTY data matches `isStatusLineRewrite`, and the polling cycle classifies a visible-content change as `indicator` when that latch is within `SPINNER_ACTIVE_MS` (`1500ms`). The tight `900ms` content gap (introduced to guard against scroll/resize repaint bursts) is unchanged for unclassified changes. Both directions of this timing contract are pinned by tests: 1Hz indicator output must recover, and 1Hz generic content must not.
 
 ### Waiting And Prompt Layer
 
@@ -223,7 +223,6 @@ Important scenarios:
 ## Future Work
 
 - Add marker-anchored visible snapshots for structural resize immunity.
-- Add an explicit activity-indicator weight in the temperature model so spinner and status-line changes are stronger than generic one-character churn.
 - Add transition telemetry that records temperature, heat, changed chars, trigger, and suppression reason.
 - Add golden trace replay from real terminal captures.
 - Add property tests for decay invariants, dwell impossibility, resize suppression, and external temperature reads.

--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -24,6 +24,7 @@ import {
   AGENT_OUTPUT_ACTIVITY_LINE_COUNT,
   AgentActivityTemperature,
   type AgentActivityObservationResult,
+  type AgentActivitySignalKind,
 } from "./pty/AgentActivityTemperature.js";
 import {
   detectPrompt,
@@ -190,6 +191,9 @@ export class ActivityMonitor {
   private lastActivityTimestamp = Date.now();
   private lastDataTimestamp = Date.now();
   private lastOutputActivityAt = 0;
+  // Latched when simple-output data matches isStatusLineRewrite — lets the
+  // polling cycle classify visible-content changes as indicator-driven (#9874).
+  private lastStatusRewriteAt = 0;
   private lastWorkingIndicatorTimestamp = 0;
   private promptStableSince = 0;
 
@@ -437,8 +441,18 @@ export class ActivityMonitor {
           this.fireBootComplete(now);
         }
       }
+      // Semantic status-line rewrites (spinner, retry countdown, elapsed-time
+      // counter) are strong liveness evidence even at 1Hz cadence (#9874).
+      const isIndicatorRewrite = isStatusLineRewrite(data);
+      if (isIndicatorRewrite) {
+        this.lastStatusRewriteAt = now;
+      }
       if (!this.getVisibleLines) {
-        this.noteSimpleOutputSnapshot(createVisibleContentSnapshot(stripAnsi(data)), now);
+        this.noteSimpleOutputSnapshot(
+          createVisibleContentSnapshot(stripAnsi(data)),
+          now,
+          isIndicatorRewrite ? "indicator" : "content"
+        );
       }
       return;
     }
@@ -711,9 +725,13 @@ export class ActivityMonitor {
     return createVisibleContentSnapshot(this.getVisibleLines(AGENT_OUTPUT_ACTIVITY_LINE_COUNT));
   }
 
-  private noteSimpleOutputSnapshot(snapshot: VisibleContentSnapshot, now: number): void {
+  private noteSimpleOutputSnapshot(
+    snapshot: VisibleContentSnapshot,
+    now: number,
+    signalKind?: AgentActivitySignalKind
+  ): void {
     this.applySimpleOutputTemperature(
-      this.simpleOutputTemperature.observeSnapshot(now, snapshot),
+      this.simpleOutputTemperature.observeSnapshot(now, snapshot, { signalKind }),
       now
     );
   }
@@ -797,6 +815,7 @@ export class ActivityMonitor {
     this.workingHoldUntil = 0;
     this.lastDataTimestamp = 0;
     this.lastOutputActivityAt = 0;
+    this.lastStatusRewriteAt = 0;
     this.lastWorkingIndicatorTimestamp = 0;
     this.promptStableSince = 0;
   }
@@ -1008,7 +1027,13 @@ export class ActivityMonitor {
 
       const snapshot = this.captureSimpleOutputSnapshot();
       if (snapshot !== undefined) {
-        this.noteSimpleOutputSnapshot(snapshot, now);
+        // Classify the polled change as indicator-driven when status-line
+        // rewrite data arrived recently — the data path can't feed the
+        // temperature directly here (it gates on !getVisibleLines), so the
+        // latched timestamp is the correlation signal (#9874).
+        const indicatorActive =
+          this.lastStatusRewriteAt > 0 && now - this.lastStatusRewriteAt <= SPINNER_ACTIVE_MS;
+        this.noteSimpleOutputSnapshot(snapshot, now, indicatorActive ? "indicator" : "content");
       }
 
       if (

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -5894,4 +5894,67 @@ describe("ActivityMonitor", () => {
       monitor.dispose();
     });
   });
+
+  describe("once-per-second indicator recovery (Issue #9874)", () => {
+    it("recovers idle→busy from a 1Hz status-line countdown in simple-output polling mode", () => {
+      vi.setSystemTime(10000);
+      const onStateChange = vi.fn();
+      let statusLine = "Retrying in 9s · 100 tokens";
+      const monitor = new ActivityMonitor("indicator-1hz", 100, onStateChange, {
+        agentId: "kimi",
+        simpleOutputState: true,
+        getVisibleLines: () => ["$ agent run", statusLine],
+        getCursorLine: () => statusLine,
+        initialState: "idle",
+        skipInitialStateEmit: true,
+        pollingIntervalMs: 50,
+      });
+      monitor.startPolling();
+      onStateChange.mockClear();
+
+      // 1Hz countdown: each second the agent rewrites its status line with a
+      // CR + erase-line sequence (matches isStatusLineRewrite).
+      for (let i = 1; i <= 6 && monitor.getState() !== "busy"; i += 1) {
+        vi.advanceTimersByTime(1000);
+        statusLine = `Retrying in ${9 - i}s · ${100 + i * 137} tokens`;
+        monitor.onData(`\r\x1b[2K${statusLine}`);
+      }
+
+      expect(monitor.getState()).toBe("busy");
+      expect(onStateChange).toHaveBeenCalledWith("indicator-1hz", 100, "busy", {
+        trigger: "output",
+      });
+
+      monitor.dispose();
+    });
+
+    it("negative control: 1Hz non-indicator content changes do not recover idle→busy", () => {
+      vi.setSystemTime(10000);
+      const onStateChange = vi.fn();
+      let bodyLine = "layout pass 0";
+      const monitor = new ActivityMonitor("content-1hz", 100, onStateChange, {
+        agentId: "kimi",
+        simpleOutputState: true,
+        getVisibleLines: () => ["$ agent run", bodyLine],
+        getCursorLine: () => bodyLine,
+        initialState: "idle",
+        skipInitialStateEmit: true,
+        pollingIntervalMs: 50,
+      });
+      monitor.startPolling();
+      onStateChange.mockClear();
+
+      // Same cadence, but plain newline-terminated output — no status-line
+      // rewrite sequences, so the strict 900ms content gap still applies.
+      for (let i = 1; i <= 8; i += 1) {
+        vi.advanceTimersByTime(1000);
+        bodyLine = `layout pass ${i * 137}`;
+        monitor.onData(`${bodyLine}\n`);
+      }
+
+      expect(monitor.getState()).toBe("idle");
+
+      monitor.dispose();
+    });
+  });
 });

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -5928,6 +5928,40 @@ describe("ActivityMonitor", () => {
       monitor.dispose();
     });
 
+    it("expires the status-rewrite latch so later plain content is not indicator-classified", () => {
+      vi.setSystemTime(10000);
+      const onStateChange = vi.fn();
+      let statusLine = "Retrying in 9s · 100 tokens";
+      const monitor = new ActivityMonitor("latch-expiry", 100, onStateChange, {
+        agentId: "kimi",
+        simpleOutputState: true,
+        getVisibleLines: () => ["$ agent run", statusLine],
+        getCursorLine: () => statusLine,
+        initialState: "idle",
+        skipInitialStateEmit: true,
+        pollingIntervalMs: 50,
+      });
+      monitor.startPolling();
+      onStateChange.mockClear();
+
+      // One status-line rewrite latches lastStatusRewriteAt…
+      statusLine = "Retrying in 8s · 237 tokens";
+      monitor.onData(`\r\x1b[2K${statusLine}`);
+
+      // …but the agent then emits only plain newline-terminated content at
+      // 1Hz. Once the 1500ms latch expires, changes classify as content and
+      // the strict 900ms gap keeps resetting the evidence window.
+      for (let i = 1; i <= 8; i += 1) {
+        vi.advanceTimersByTime(1000);
+        statusLine = `layout pass ${i * 137}`;
+        monitor.onData(`${statusLine}\n`);
+      }
+
+      expect(monitor.getState()).toBe("idle");
+
+      monitor.dispose();
+    });
+
     it("negative control: 1Hz non-indicator content changes do not recover idle→busy", () => {
       vi.setSystemTime(10000);
       const onStateChange = vi.fn();

--- a/electron/services/pty/AgentActivityTemperature.ts
+++ b/electron/services/pty/AgentActivityTemperature.ts
@@ -11,6 +11,8 @@ const DEFAULT_WAITING_THRESHOLD = 40;
 const DEFAULT_WORKING_DWELL_MS = 2000;
 const DEFAULT_WORKING_MIN_CHANGED_SAMPLES = 4;
 const DEFAULT_WORKING_MAX_CHANGE_GAP_MS = 900;
+const DEFAULT_INDICATOR_MAX_CHANGE_GAP_MS = 2000;
+const DEFAULT_WORKING_MIN_INDICATOR_SAMPLES = 2;
 const DEFAULT_WAITING_DWELL_MS = 6000;
 const DEFAULT_ACTIVE_GAP_RESET_MS = 3000;
 const DEFAULT_RESIZE_QUIET_MS = 500;
@@ -26,6 +28,8 @@ export interface AgentActivityTemperatureOptions {
   workingDwellMs?: number;
   workingMinChangedSamples?: number;
   workingMaxChangeGapMs?: number;
+  indicatorMaxChangeGapMs?: number;
+  workingMinIndicatorSamples?: number;
   waitingDwellMs?: number;
   activeGapResetMs?: number;
   resizeQuietMs?: number;
@@ -35,9 +39,16 @@ export interface AgentActivityTemperatureOptions {
   decorativeImpulse?: number;
 }
 
+// "indicator" marks semantic status-line activity (spinner, retry countdown,
+// elapsed-time counter) — strong liveness evidence that may tick as slowly as
+// 1Hz, so it gets a looser change-gap and a lower sample minimum than generic
+// "content" churn. "decorative" stays heat-capped noise.
+export type AgentActivitySignalKind = "content" | "indicator" | "decorative";
+
 export interface AgentActivityDeltaObservation {
   changedChars: number;
   decorative?: boolean;
+  signalKind?: AgentActivitySignalKind;
 }
 
 export interface AgentActivityObservationResult {
@@ -57,6 +68,8 @@ export class AgentActivityTemperature {
   private readonly workingDwellMs: number;
   private readonly workingMinChangedSamples: number;
   private readonly workingMaxChangeGapMs: number;
+  private readonly indicatorMaxChangeGapMs: number;
+  private readonly workingMinIndicatorSamples: number;
   private readonly waitingDwellMs: number;
   private readonly activeGapResetMs: number;
   private readonly resizeQuietMs: number;
@@ -74,6 +87,7 @@ export class AgentActivityTemperature {
   private baselineInvalid = false;
   private lastSnapshot: VisibleContentSnapshot | undefined;
   private changedSampleCount = 0;
+  private activeEvidenceKind: AgentActivitySignalKind = "content";
 
   constructor(options?: AgentActivityTemperatureOptions) {
     this.halfLifeMs = positive(options?.halfLifeMs, DEFAULT_HALF_LIFE_MS);
@@ -87,6 +101,14 @@ export class AgentActivityTemperature {
     this.workingMaxChangeGapMs = positive(
       options?.workingMaxChangeGapMs,
       DEFAULT_WORKING_MAX_CHANGE_GAP_MS
+    );
+    this.indicatorMaxChangeGapMs = positive(
+      options?.indicatorMaxChangeGapMs,
+      DEFAULT_INDICATOR_MAX_CHANGE_GAP_MS
+    );
+    this.workingMinIndicatorSamples = positiveInteger(
+      options?.workingMinIndicatorSamples,
+      DEFAULT_WORKING_MIN_INDICATOR_SAMPLES
     );
     this.waitingDwellMs = nonNegative(options?.waitingDwellMs, DEFAULT_WAITING_DWELL_MS);
     this.activeGapResetMs = positive(options?.activeGapResetMs, DEFAULT_ACTIVE_GAP_RESET_MS);
@@ -117,6 +139,7 @@ export class AgentActivityTemperature {
     this.baselineInvalid = false;
     this.lastSnapshot = undefined;
     this.changedSampleCount = 0;
+    this.activeEvidenceKind = "content";
   }
 
   noteResize(now: number, quietMs = this.resizeQuietMs): void {
@@ -127,6 +150,7 @@ export class AgentActivityTemperature {
     this.lastChangedAt = 0;
     this.quietStartedAt = 0;
     this.changedSampleCount = 0;
+    this.activeEvidenceKind = "content";
   }
 
   seedSnapshot(snapshot: VisibleContentSnapshot, now: number): AgentActivityObservationResult {
@@ -140,7 +164,7 @@ export class AgentActivityTemperature {
   observeSnapshot(
     now: number,
     snapshot: VisibleContentSnapshot,
-    options?: { decorative?: boolean }
+    options?: { decorative?: boolean; signalKind?: AgentActivitySignalKind }
   ): AgentActivityObservationResult {
     const suppressed = this.consumeResizeSuppression(now);
     if (suppressed) {
@@ -154,7 +178,11 @@ export class AgentActivityTemperature {
     this.applyDecay(now);
     const delta = measureVisibleContentDelta(this.lastSnapshot, snapshot);
     this.lastSnapshot = snapshot;
-    return this.observeDeltaAfterDecay(now, delta.changedChars, options?.decorative === true);
+    return this.observeDeltaAfterDecay(
+      now,
+      delta.changedChars,
+      resolveSignalKind(options?.signalKind, options?.decorative)
+    );
   }
 
   observeDelta(
@@ -178,14 +206,14 @@ export class AgentActivityTemperature {
     return this.observeDeltaAfterDecay(
       now,
       observation.changedChars,
-      observation.decorative === true
+      resolveSignalKind(observation.signalKind, observation.decorative)
     );
   }
 
   private observeDeltaAfterDecay(
     now: number,
     rawChangedChars: number,
-    decorative: boolean
+    signalKind: AgentActivitySignalKind
   ): AgentActivityObservationResult {
     const changedChars = Number.isFinite(rawChangedChars) ? Math.max(0, rawChangedChars) : 0;
 
@@ -193,6 +221,7 @@ export class AgentActivityTemperature {
       if (this.lastChangedAt > 0 && now - this.lastChangedAt > this.activeGapResetMs) {
         this.activeEvidenceStartedAt = 0;
         this.changedSampleCount = 0;
+        this.activeEvidenceKind = "content";
       }
       if (this.quietStartedAt === 0) {
         this.quietStartedAt = now;
@@ -200,17 +229,24 @@ export class AgentActivityTemperature {
       return this.result(now, false, 0, 0, false, false);
     }
 
-    const heatAdded = this.heatForChange(changedChars, decorative);
+    const heatAdded = this.heatForChange(changedChars, signalKind === "decorative");
     this.temperature = Math.min(this.maxTemperature, this.temperature + heatAdded);
 
+    // Indicator-class changes (semantic status lines) may tick as slowly as
+    // 1Hz, so they get a looser gap before the evidence window resets (#9874).
+    // Generic content keeps the tight 900ms gate that guards against
+    // scroll/resize repaint bursts (699d9a050).
+    const maxChangeGapMs =
+      signalKind === "indicator" ? this.indicatorMaxChangeGapMs : this.workingMaxChangeGapMs;
     if (
       this.activeEvidenceStartedAt === 0 ||
-      (this.lastChangedAt > 0 && now - this.lastChangedAt > this.workingMaxChangeGapMs)
+      (this.lastChangedAt > 0 && now - this.lastChangedAt > maxChangeGapMs)
     ) {
       this.activeEvidenceStartedAt = now;
       this.changedSampleCount = 0;
     }
     this.changedSampleCount += 1;
+    this.activeEvidenceKind = signalKind;
     this.lastChangedAt = now;
     this.quietStartedAt = 0;
 
@@ -237,11 +273,16 @@ export class AgentActivityTemperature {
   }
 
   private computeStateHint(now: number, changed: boolean): "busy" | "idle" | undefined {
+    const minChangedSamples =
+      this.activeEvidenceKind === "indicator"
+        ? this.workingMinIndicatorSamples
+        : this.workingMinChangedSamples;
     if (
       changed &&
+      this.activeEvidenceKind !== "decorative" &&
       this.temperature >= this.workingThreshold &&
       this.activeEvidenceStartedAt > 0 &&
-      this.changedSampleCount >= this.workingMinChangedSamples &&
+      this.changedSampleCount >= minChangedSamples &&
       now - this.activeEvidenceStartedAt >= this.workingDwellMs
     ) {
       return "busy";
@@ -312,6 +353,13 @@ export class AgentActivityTemperature {
     this.resizeSuppressUntil = 0;
     this.baselineInvalid = false;
   }
+}
+
+function resolveSignalKind(
+  signalKind: AgentActivitySignalKind | undefined,
+  decorative: boolean | undefined
+): AgentActivitySignalKind {
+  return signalKind ?? (decorative === true ? "decorative" : "content");
 }
 
 function positive(value: number | undefined, fallback: number): number {

--- a/electron/services/pty/__tests__/AgentActivityTemperature.test.ts
+++ b/electron/services/pty/__tests__/AgentActivityTemperature.test.ts
@@ -45,6 +45,50 @@ describe("AgentActivityTemperature", () => {
     expect(model.getTemperature()).toBeGreaterThanOrEqual(70);
   });
 
+  it("recovers to busy for once-per-second indicator changes", () => {
+    const model = new AgentActivityTemperature();
+
+    model.seedSnapshot(snapshot("retrying in 9s"), 1000);
+
+    const opts = { signalKind: "indicator" as const };
+    expect(model.observeSnapshot(2000, snapshot("retrying in 8s"), opts).stateHint).toBeUndefined();
+    expect(model.observeSnapshot(3000, snapshot("retrying in 7s"), opts).stateHint).toBeUndefined();
+
+    const result = model.observeSnapshot(4000, snapshot("retrying in 6s"), opts);
+    expect(result.stateHint).toBe("busy");
+    expect(result.temperature).toBeGreaterThanOrEqual(70);
+  });
+
+  it("does not recover for indicator changes spaced beyond the indicator gap", () => {
+    const model = new AgentActivityTemperature();
+
+    model.seedSnapshot(snapshot("tick 0"), 1000);
+
+    const opts = { signalKind: "indicator" as const };
+    expect(model.observeSnapshot(3500, snapshot("tick 1"), opts).stateHint).toBeUndefined();
+    expect(model.observeSnapshot(6000, snapshot("tick 2"), opts).stateHint).toBeUndefined();
+    expect(model.observeSnapshot(8500, snapshot("tick 3"), opts).stateHint).toBeUndefined();
+    expect(model.observeSnapshot(11000, snapshot("tick 4"), opts).stateHint).toBeUndefined();
+  });
+
+  it("requires fresh indicator evidence after a resize", () => {
+    const model = new AgentActivityTemperature();
+
+    model.seedSnapshot(snapshot("retrying in 9s"), 1000);
+
+    const opts = { signalKind: "indicator" as const };
+    model.observeSnapshot(2000, snapshot("retrying in 8s"), opts);
+    model.observeSnapshot(3000, snapshot("retrying in 7s"), opts);
+
+    model.noteResize(3100);
+    expect(model.observeSnapshot(3400, snapshot("reflowed"), opts).suppressed).toBe(true);
+    expect(model.observeSnapshot(3700, snapshot("post resize baseline"), opts).seeded).toBe(true);
+
+    expect(model.observeSnapshot(4700, snapshot("retrying in 5s"), opts).stateHint).toBeUndefined();
+    expect(model.observeSnapshot(5700, snapshot("retrying in 4s"), opts).stateHint).toBeUndefined();
+    expect(model.observeSnapshot(6700, snapshot("retrying in 3s"), opts).stateHint).toBe("busy");
+  });
+
   it("cools through the waiting threshold only after six-second quiet dwell", () => {
     const model = new AgentActivityTemperature();
 
@@ -109,6 +153,20 @@ describe("AgentActivityTemperature", () => {
       const result = model.observeDelta(1000 + i * 250, {
         changedChars: 1,
         decorative: true,
+      });
+      expect(result.stateHint).toBeUndefined();
+    }
+
+    expect(model.getTemperature()).toBeLessThan(70);
+  });
+
+  it("treats signalKind decorative like the decorative flag", () => {
+    const model = new AgentActivityTemperature();
+
+    for (let i = 0; i < 20; i += 1) {
+      const result = model.observeDelta(1000 + i * 250, {
+        changedChars: 1,
+        signalKind: "decorative",
       });
       expect(result.stateHint).toBeUndefined();
     }

--- a/electron/services/pty/__tests__/AgentActivityTemperature.test.ts
+++ b/electron/services/pty/__tests__/AgentActivityTemperature.test.ts
@@ -59,6 +59,31 @@ describe("AgentActivityTemperature", () => {
     expect(result.temperature).toBeGreaterThanOrEqual(70);
   });
 
+  it("requires exactly two indicator samples once dwell is satisfied", () => {
+    // workingDwellMs: 0 isolates the sample-count gate from the dwell gate.
+    const model = new AgentActivityTemperature({ workingDwellMs: 0 });
+
+    const first = model.observeDelta(1000, { changedChars: 500, signalKind: "indicator" });
+    expect(first.stateHint).toBeUndefined();
+
+    const second = model.observeDelta(2000, { changedChars: 500, signalKind: "indicator" });
+    expect(second.stateHint).toBe("busy");
+  });
+
+  it("keeps accumulating at exactly the indicator gap but resets just beyond it", () => {
+    const atBoundary = new AgentActivityTemperature({ workingDwellMs: 0 });
+    atBoundary.observeDelta(1000, { changedChars: 500, signalKind: "indicator" });
+    // Gap of exactly 2000ms does not reset — second sample hints busy.
+    const kept = atBoundary.observeDelta(3000, { changedChars: 500, signalKind: "indicator" });
+    expect(kept.stateHint).toBe("busy");
+
+    const pastBoundary = new AgentActivityTemperature({ workingDwellMs: 0 });
+    pastBoundary.observeDelta(1000, { changedChars: 500, signalKind: "indicator" });
+    // Gap of 2001ms resets the evidence window — still only one sample.
+    const reset = pastBoundary.observeDelta(3001, { changedChars: 500, signalKind: "indicator" });
+    expect(reset.stateHint).toBeUndefined();
+  });
+
   it("does not recover for indicator changes spaced beyond the indicator gap", () => {
     const model = new AgentActivityTemperature();
 


### PR DESCRIPTION
## Summary

- `AgentActivityTemperature`'s 900ms `workingMaxChangeGapMs` meant once-per-second output (retry countdowns, elapsed timers) kept `changedSampleCount` at 0–1, so `computeStateHint`'s 4-sample minimum could never emit busy — a waiting agent never recovered to working
- Observations now carry a `signalKind` (`"content"` | `"indicator"` | `"decorative"`); indicator-class changes (spinner rewrites, token counters, countdowns — matched by `isStatusLineRewrite`) use a looser 2000ms max change gap and a 2-sample minimum; the existing 900ms / 4-sample gate is unchanged for generic content, preserving the guard against scroll/resize repaint bursts
- `ActivityMonitor` owns classification: simple-output path latches `lastStatusRewriteAt` on `isStatusLineRewrite`, and the polling cycle marks a change as `"indicator"` when the latch is within `SPINNER_ACTIVE_MS` (1500ms); decorative evidence is explicitly blocked from hinting busy

Resolves #9874

## Changes

- `AgentActivityTemperature.ts` — `signalKind` on observations; separate thresholds per kind
- `ActivityMonitor.ts` — `lastStatusRewriteAt` latch; indicator classification in polling cycle
- `AgentActivityTemperature.test.ts` — new tests: 1Hz indicator recovers idle→busy; 1Hz generic content does not; latch-expiry boundary
- `ActivityMonitor.test.ts` — integration tests for both directions
- `docs/architecture/agent-activity-monitoring.md` — documents `signalKind` categories with thresholds; removes the contradiction where the doc mandated indicator weighting the implementation lacked

## Testing

- 224/224 changed-code tests pass; typecheck, lint, format, IPC/channel/confirm-wiring checks, build, and preload-backdoor check all pass
- Both timing-contract directions are pinned: 1Hz indicator output recovers idle→busy (unit + `ActivityMonitor` integration); 1Hz generic content does not (existing pinned test unchanged + new negative control + latch-expiry test)
- 156 pre-existing failures in unrelated modules (`PtyClient`, shutdown, `gpuDetection`) also fail on `develop`