### PR TITLE
fix(activity-monitor): wire detection layers into simple-output mode (#9873)

### DIFF
--- a/docs/architecture/agent-activity-monitoring.md
+++ b/docs/architecture/agent-activity-monitoring.md
@@ -40,6 +40,10 @@ The activity monitor starts when an agent identity is detected or expected, and 
 
 Activity detection is deliberately layered. No single layer is authoritative in all terminal modes.
 
+### Simple Output Mode
+
+Agent monitors run in simple output mode (`simpleOutputState`, set by `buildActivityMonitorOptions` whenever an agent id is present): busy/idle is driven by output observation — the visible-tail temperature model, the OSC 9;4 heartbeat, and the 8s idle debounce — rather than the non-simple working-signal arbitration. The detection layers below still run inside simple mode (#9873): compiled working patterns are matched against the rolling raw-stream buffer in `onData`, completion patterns are scanned from the polling cycle (feeding the `completed` transition with extracted cost/tokens), prompt patterns can exit boot early, every busy→idle transition classifies a `waitingReason`, and the polling cycle stays busy while boot is in progress. The synchronized-frame layer is the exception: `onSynchronizedFrame` returns early in simple mode, so frame signals currently have no consumer for agent terminals.
+
 ### Raw Stream And Pattern Layer
 
 `ActivityMonitor.onData()` receives PTY output. It:
@@ -62,6 +66,8 @@ Some CLIs bracket redraws with DEC mode 2026 synchronized output. The headless t
 - `none`: no structural activity signal.
 
 Spinner and time-counter frames are activity evidence. Cosmetic-only frames can keep an already-working agent alive, but idle-to-working recovery still needs sustained signal.
+
+This layer applies to non-simple monitors only — simple-output agent monitors return early from `onSynchronizedFrame`, so frame signals have no consumer for live agent terminals.
 
 ### Escape-Sequence Progress Layer
 

--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -1441,7 +1441,11 @@ export class ActivityMonitor {
       this.completionTimer.emitted ||
       this.completionPatterns.length === 0 ||
       !this.getVisibleLines ||
-      now - this.lastActivityTimestamp < SIMPLE_COMPLETION_MIN_QUIET_MS ||
+      // Quiet on both clocks: lastActivityTimestamp only moves on visible
+      // snapshot changes, so raw PTY bytes streaming past a static viewport
+      // must also block the scan via lastDataTimestamp.
+      now - Math.max(this.lastActivityTimestamp, this.lastDataTimestamp) <
+        SIMPLE_COMPLETION_MIN_QUIET_MS ||
       now < this.workingHoldUntil
     ) {
       return false;

--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -46,6 +46,11 @@ const PROMPT_HISTORY_FALLBACK_MS = 3000;
 const WORKING_HOLD_MS = 1500;
 const SPINNER_ACTIVE_MS = 1500;
 const COMPLETION_HOLD_MS = 500;
+// Minimum output quiet before the simple-output polling cycle scans for
+// completion patterns — the non-simple path gets the same protection from its
+// working-signal gates (recent output suppresses completion detection), so a
+// cost summary printed mid-stream doesn't read as a finished session (#9873).
+const SIMPLE_COMPLETION_MIN_QUIET_MS = 1500;
 const WORKING_INDICATOR_TTL_MS = 5000;
 const CPU_HIGH_THRESHOLD = 10;
 const CPU_LOW_THRESHOLD = 3;
@@ -399,6 +404,59 @@ export class ActivityMonitor {
     return lowerInput.includes("esc to interrupt") || lowerInput.includes("esc to cancel");
   }
 
+  // Raw-stream compiled-pattern tier, shared by the simple and non-simple
+  // `onData` paths (#9873): feeds the rolling pattern buffer, checks
+  // boot-complete patterns across chunk boundaries, and promotes/refreshes
+  // busy on working-pattern matches.
+  private detectPatternsFromData(data: string, now: number): void {
+    this.patternBuf.update(data);
+    const bufferText = stripAnsi(this.patternBuf.getText());
+    const lowerBuffer = bufferText.toLowerCase();
+
+    // Check for boot-complete patterns in the rolling buffer
+    if (!this.bootDetector.hasExitedBootState) {
+      if (this.bootDetector.check(bufferText, false, 0, Infinity)) {
+        // Boot detected via pattern in rolling buffer
+        this.fireBootComplete(now);
+      }
+    }
+
+    // Check for working patterns in the rolling buffer
+    const patternResult = this.patternDetector
+      ? this.patternDetector.detect(bufferText, { alreadyStripped: true })
+      : undefined;
+    if (patternResult) {
+      this.lastPatternResult = patternResult;
+      this.lastPatternResultAt = now;
+    }
+    const isWorking = patternResult
+      ? patternResult.isWorking
+      : this.isEscInterruptFallback(lowerBuffer);
+
+    if (
+      isWorking &&
+      !this.isResizeSuppressed(now) &&
+      !this.isFocusSuppressed(now) &&
+      (this.state === "busy" ||
+        this.inputTracker.pendingInputUntil > 0 ||
+        !this.inputTracker.isRecentUserInput(now))
+    ) {
+      if (this.state === "busy" || this.inputTracker.pendingInputUntil > 0) {
+        this.becomeBusy({
+          trigger: "pattern",
+          patternConfidence: patternResult?.confidence ?? 0.9,
+        });
+      } else {
+        if (this.workingSignalDebouncer.shouldTriggerRecovery(now, true)) {
+          this.becomeBusy({
+            trigger: "pattern",
+            patternConfidence: patternResult?.confidence ?? 0.9,
+          });
+        }
+      }
+    }
+  }
+
   onInput(data: string): void {
     if (this.isDisposed) return;
     const now = Date.now();
@@ -447,6 +505,13 @@ export class ActivityMonitor {
       if (isIndicatorRewrite) {
         this.lastStatusRewriteAt = now;
       }
+      // Compiled-pattern tier (#9873): feed the rolling buffer and act on
+      // working patterns with the same echo/cosmetic guards the non-simple
+      // path uses. Completion and waiting-reason detection run in the
+      // polling cycle's idle paths.
+      if (!this.inputTracker.isLikelyUserEcho(data, now) && !isIndicatorRewrite) {
+        this.detectPatternsFromData(data, now);
+      }
       if (!this.getVisibleLines) {
         this.noteSimpleOutputSnapshot(
           createVisibleContentSnapshot(stripAnsi(data)),
@@ -471,52 +536,7 @@ export class ActivityMonitor {
 
     // For polling-enabled terminals: check raw stream for patterns FIRST
     if (data && this.getVisibleLines && !isLikelyUserEcho && !isCosmeticRedraw) {
-      this.patternBuf.update(data);
-      const bufferText = stripAnsi(this.patternBuf.getText());
-      const lowerBuffer = bufferText.toLowerCase();
-
-      // Check for boot-complete patterns in the rolling buffer
-      if (!this.bootDetector.hasExitedBootState) {
-        if (this.bootDetector.check(bufferText, false, 0, Infinity)) {
-          // Boot detected via pattern in rolling buffer
-          this.fireBootComplete(now);
-        }
-      }
-
-      // Check for working patterns in the rolling buffer
-      const patternResult = this.patternDetector
-        ? this.patternDetector.detect(bufferText, { alreadyStripped: true })
-        : undefined;
-      if (patternResult) {
-        this.lastPatternResult = patternResult;
-        this.lastPatternResultAt = now;
-      }
-      const isWorking = patternResult
-        ? patternResult.isWorking
-        : this.isEscInterruptFallback(lowerBuffer);
-
-      if (
-        isWorking &&
-        !this.isResizeSuppressed(now) &&
-        !this.isFocusSuppressed(now) &&
-        (this.state === "busy" ||
-          this.inputTracker.pendingInputUntil > 0 ||
-          !this.inputTracker.isRecentUserInput(now))
-      ) {
-        if (this.state === "busy" || this.inputTracker.pendingInputUntil > 0) {
-          this.becomeBusy({
-            trigger: "pattern",
-            patternConfidence: patternResult?.confidence ?? 0.9,
-          });
-        } else {
-          if (this.workingSignalDebouncer.shouldTriggerRecovery(now, true)) {
-            this.becomeBusy({
-              trigger: "pattern",
-              patternConfidence: patternResult?.confidence ?? 0.9,
-            });
-          }
-        }
-      }
+      this.detectPatternsFromData(data, now);
     }
 
     if (!data || isLikelyUserEcho) {
@@ -760,10 +780,7 @@ export class ActivityMonitor {
     }
 
     if (this.state === "busy" && result.stateHint === "idle" && now >= this.workingHoldUntil) {
-      this.state = "idle";
-      this.idleSince = now;
-      this.patternBuf.clear();
-      this.onStateChange(this.terminalId, this.spawnedAt, "idle", { trigger: "timeout" });
+      this.transitionSimpleToIdle(now);
     }
   }
 
@@ -1020,8 +1037,28 @@ export class ActivityMonitor {
         const lines = this.getVisibleLines(50);
         const strippedText = stripAnsi(lines.join(" "));
         const timeSinceBoot = now - this.bootDetector.pollingStartTime;
-        if (this.bootDetector.check(strippedText, false, timeSinceBoot, this.POLLING_MAX_BOOT_MS)) {
+        // A visible prompt exits boot early — parity with the non-simple boot
+        // check, and what lets restart-resumed sessions (boot re-entered with
+        // an already-settled screen) go idle without waiting out the boot
+        // timeout (#9873). History scan unlocks after the same 3s the
+        // non-simple prompt path uses.
+        const promptResult = detectPrompt(
+          lines,
+          this.promptDetectorConfig,
+          this.getCursorLine?.() ?? null,
+          { allowHistoryScan: timeSinceBoot >= PROMPT_HISTORY_FALLBACK_MS }
+        );
+        if (
+          this.bootDetector.check(
+            strippedText,
+            promptResult.isPrompt,
+            timeSinceBoot,
+            this.POLLING_MAX_BOOT_MS
+          )
+        ) {
           this.fireBootComplete(now);
+        } else {
+          return; // Still booting, stay busy — parity with the non-simple guard (#9873)
         }
       }
 
@@ -1036,15 +1073,20 @@ export class ActivityMonitor {
         this.noteSimpleOutputSnapshot(snapshot, now, indicatorActive ? "indicator" : "content");
       }
 
+      // Completion detection runs every cycle while busy — mirrors the
+      // non-simple path so simple-output agents reach `completed` (with
+      // extracted cost/tokens) before any idle path fires (#9873).
+      if (this.trySimpleCompletion(now)) {
+        return;
+      }
+
       if (
         this.state === "busy" &&
+        !this.completionTimer.emitted &&
         now - this.lastActivityTimestamp >= this.IDLE_DEBOUNCE_MS &&
         now >= this.workingHoldUntil
       ) {
-        this.state = "idle";
-        this.idleSince = now;
-        this.patternBuf.clear();
-        this.onStateChange(this.terminalId, this.spawnedAt, "idle", { trigger: "timeout" });
+        this.transitionSimpleToIdle(now);
       }
       return;
     }
@@ -1389,6 +1431,67 @@ export class ActivityMonitor {
     });
   }
 
+  // Completion-pattern scan for simple-output monitors (#9873). Returns true
+  // when a completion was detected and the completed transition was emitted.
+  // Gated on output quiet so a cost line scrolling past mid-stream doesn't
+  // end the session early.
+  private trySimpleCompletion(now: number): boolean {
+    if (
+      this.state !== "busy" ||
+      this.completionTimer.emitted ||
+      this.completionPatterns.length === 0 ||
+      !this.getVisibleLines ||
+      now - this.lastActivityTimestamp < SIMPLE_COMPLETION_MIN_QUIET_MS ||
+      now < this.workingHoldUntil
+    ) {
+      return false;
+    }
+    const completionResult = detectCompletion(
+      this.getVisibleLines(this.promptDetectorConfig.promptScanLineCount),
+      this.completionPatterns,
+      this.completionConfidence,
+      this.promptDetectorConfig.promptScanLineCount
+    );
+    if (!completionResult.isCompletion) {
+      return false;
+    }
+    this.transitionToCompleted(
+      completionResult.confidence,
+      completionResult.extractedCost,
+      completionResult.extractedTokens
+    );
+    return true;
+  }
+
+  // Simple-output busy→idle transition shared by the polling idle gate, the
+  // activity-temperature idle hint, and the debounce-timer backstop (#9873).
+  // Runs completion detection first so agents with completionPatterns reach
+  // `completed` (with extracted cost/tokens) instead of plain idle, and
+  // attaches a waiting reason to the idle emission. While a completion hold
+  // is pending, the idle emission is left to the completion timer.
+  private transitionSimpleToIdle(now: number): void {
+    if (this.completionTimer.emitted) return;
+    if (this.trySimpleCompletion(now)) return;
+    this.state = "idle";
+    this.idleSince = now;
+    this.patternBuf.clear();
+    let waitingReason: WaitingReason | undefined;
+    if (this.getVisibleLines) {
+      const lines = this.getVisibleLines(this.promptDetectorConfig.promptScanLineCount);
+      const promptResult = detectPrompt(
+        lines,
+        this.promptDetectorConfig,
+        this.getCursorLine?.() ?? null,
+        { allowHistoryScan: true }
+      );
+      waitingReason = classifyWaitingReason(lines, promptResult.isPrompt);
+    }
+    this.onStateChange(this.terminalId, this.spawnedAt, "idle", {
+      trigger: "timeout",
+      waitingReason,
+    });
+  }
+
   private becomeBusyFromPattern(confidence: number, now: number): void {
     this.becomeBusy({ trigger: "pattern", patternConfidence: confidence }, now);
   }
@@ -1446,16 +1549,22 @@ export class ActivityMonitor {
           return;
         }
 
+        // During the polling boot window, idle is owned by the polling
+        // cycle's boot guard — stay busy and re-arm (#9873). Monitors
+        // without polling have no boot lifecycle and skip this.
+        if (this.pollingInterval && !this.bootDetector.hasExitedBootState) {
+          this.debounceTimer = null;
+          this.resetDebounceTimer();
+          return;
+        }
+
         const now = Date.now();
         if (
           this.state === "busy" &&
           now - this.lastActivityTimestamp >= this.IDLE_DEBOUNCE_MS &&
           now >= this.workingHoldUntil
         ) {
-          this.state = "idle";
-          this.idleSince = now;
-          this.patternBuf.clear();
-          this.onStateChange(this.terminalId, this.spawnedAt, "idle", { trigger: "timeout" });
+          this.transitionSimpleToIdle(now);
         }
         this.debounceTimer = null;
       }, this.IDLE_DEBOUNCE_MS);

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -744,6 +744,7 @@ describe("ActivityMonitor", () => {
       expect(monitor.getState()).toBe("idle");
       expect(onStateChange).toHaveBeenCalledWith("agent-simple-1", 1000, "idle", {
         trigger: "timeout",
+        waitingReason: "prompt",
       });
 
       monitor.dispose();
@@ -1078,6 +1079,196 @@ describe("ActivityMonitor", () => {
       expect(onStateChange).toHaveBeenCalledWith("agent-simple-enter", 1000, "busy", {
         trigger: "input",
       });
+
+      monitor.dispose();
+    });
+  });
+
+  describe("Simple-output mode detection layers (#9873)", () => {
+    const CLAUDE_WORKING = "✽ Deliberating… (esc to interrupt · 15s)";
+
+    function driveBusyViaOutputChanges(
+      monitor: ActivityMonitor,
+      setVisible: (text: string) => void
+    ): void {
+      for (let i = 1; i <= 4; i++) {
+        vi.advanceTimersByTime(650);
+        setVisible(`tick ${i}`);
+        vi.advanceTimersByTime(50);
+      }
+      expect(monitor.getState()).toBe("busy");
+    }
+
+    it("detects completion with extracted cost/tokens in simple polling", () => {
+      const onStateChange = vi.fn();
+      let visible = ["waiting 0"];
+      const monitor = new ActivityMonitor("simple-completion", 1000, onStateChange, {
+        agentId: "claude",
+        getVisibleLines: () => visible,
+        getCursorLine: () => visible[visible.length - 1],
+        initialState: "idle",
+        skipInitialStateEmit: true,
+        completionPatterns: [/Total cost:/],
+      });
+
+      monitor.startPolling();
+      driveBusyViaOutputChanges(monitor, (text) => {
+        visible = [text];
+      });
+      onStateChange.mockClear();
+
+      visible = ["All done.", "Total cost: $1.23"];
+      // Quiet gate: completion must not fire while output is still fresh
+      vi.advanceTimersByTime(1000);
+      expect(onStateChange.mock.calls.filter((call) => call[2] === "completed")).toHaveLength(0);
+
+      vi.advanceTimersByTime(700);
+      expect(onStateChange).toHaveBeenCalledWith("simple-completion", 1000, "completed", {
+        trigger: "pattern",
+        patternConfidence: 0.9,
+        sessionCost: 1.23,
+        sessionTokens: undefined,
+      });
+
+      // Completion hold settles to idle shortly after
+      vi.advanceTimersByTime(600);
+      expect(monitor.getState()).toBe("idle");
+
+      monitor.dispose();
+    });
+
+    it("does not treat a cost line as completion while output keeps flowing", () => {
+      const onStateChange = vi.fn();
+      let visible = ["working"];
+      const monitor = new ActivityMonitor("simple-midstream", 1000, onStateChange, {
+        agentId: "claude",
+        getVisibleLines: () => visible,
+        getCursorLine: () => visible[visible.length - 1],
+        initialState: "idle",
+        skipInitialStateEmit: true,
+        completionPatterns: [/Total cost:/],
+      });
+
+      monitor.startPolling();
+      driveBusyViaOutputChanges(monitor, (text) => {
+        visible = [text];
+      });
+      onStateChange.mockClear();
+
+      // Cost line scrolls past, but output keeps changing every 500ms —
+      // lastActivity stays fresh, so the completion scan never fires.
+      visible = ["Total cost: $0.50", "step output 0"];
+      for (let i = 1; i <= 6; i++) {
+        vi.advanceTimersByTime(500);
+        visible = ["Total cost: $0.50", `step output ${i}`];
+      }
+      expect(onStateChange.mock.calls.filter((call) => call[2] === "completed")).toHaveLength(0);
+      expect(monitor.getState()).toBe("busy");
+
+      monitor.dispose();
+    });
+
+    it("classifies a waiting reason when the idle transition fires", () => {
+      const onStateChange = vi.fn();
+      let visible = ["waiting 0"];
+      const monitor = new ActivityMonitor("simple-waiting", 1000, onStateChange, {
+        agentId: "claude",
+        getVisibleLines: () => visible,
+        getCursorLine: () => visible[visible.length - 1],
+        initialState: "idle",
+        skipInitialStateEmit: true,
+      });
+
+      monitor.startPolling();
+      driveBusyViaOutputChanges(monitor, (text) => {
+        visible = [text];
+      });
+      onStateChange.mockClear();
+
+      visible = ["Should I delete the old branch?"];
+      vi.advanceTimersByTime(8200);
+
+      expect(monitor.getState()).toBe("idle");
+      expect(onStateChange).toHaveBeenCalledWith("simple-waiting", 1000, "idle", {
+        trigger: "timeout",
+        waitingReason: "question",
+      });
+
+      monitor.dispose();
+    });
+
+    it("stays busy during boot even when output is silent past the idle gate", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("simple-boot-guard", 1000, onStateChange, {
+        agentId: "claude",
+        getVisibleLines: () => ["connecting to MCP servers..."],
+        getCursorLine: () => "connecting to MCP servers...",
+        pollingMaxBootMs: 20000,
+      });
+
+      monitor.startPolling();
+      expect(monitor.getState()).toBe("busy");
+      onStateChange.mockClear();
+
+      // Well past the 8s idle gate, but still booting — must not go idle
+      vi.advanceTimersByTime(12000);
+      expect(monitor.getState()).toBe("busy");
+      expect(onStateChange.mock.calls.filter((call) => call[2] === "idle")).toHaveLength(0);
+
+      // Boot timeout fires; with a static screen the idle gate may now fire
+      vi.advanceTimersByTime(9000);
+      expect(monitor.getState()).toBe("idle");
+
+      monitor.dispose();
+    });
+
+    it("consults compiled working patterns from the simple onData path", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("simple-patterns", 1000, onStateChange, {
+        agentId: "claude",
+        getVisibleLines: () => [CLAUDE_WORKING],
+        getCursorLine: () => CLAUDE_WORKING,
+        initialState: "idle",
+        skipInitialStateEmit: true,
+      });
+
+      // Sustained pattern signal across the recovery debounce window
+      monitor.onData(CLAUDE_WORKING);
+      expect(monitor.getLastPatternResult()?.isWorking).toBe(true);
+      vi.advanceTimersByTime(1600);
+      monitor.onData(CLAUDE_WORKING);
+
+      expect(monitor.getState()).toBe("busy");
+      expect(onStateChange).toHaveBeenCalledWith(
+        "simple-patterns",
+        1000,
+        "busy",
+        expect.objectContaining({ trigger: "pattern" })
+      );
+
+      monitor.dispose();
+    });
+
+    it("does not promote idle→busy from patterns during focus suppression", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("simple-focus", 1000, onStateChange, {
+        agentId: "claude",
+        getVisibleLines: () => [CLAUDE_WORKING],
+        getCursorLine: () => CLAUDE_WORKING,
+        initialState: "idle",
+        skipInitialStateEmit: true,
+      });
+
+      monitor.notifyFocus(2000);
+      monitor.onData(CLAUDE_WORKING);
+      vi.advanceTimersByTime(1600);
+      monitor.onData(CLAUDE_WORKING);
+
+      // Pattern buffer is fed (detection layer live) but no state change
+      type MonitorInternals = { patternBuf: { getText(): string } };
+      const internals = monitor as unknown as MonitorInternals;
+      expect(internals.patternBuf.getText().length).toBeGreaterThan(0);
+      expect(monitor.getState()).toBe("idle");
 
       monitor.dispose();
     });
@@ -5662,8 +5853,8 @@ describe("ActivityMonitor", () => {
 
       // One OSC working signal at t=5000, then OSC goes silent.
       monitor.onOscProgressWorking(5000);
-      // Force boot exit so isWorkingSilenceTimeout can fire (it gates on it).
-      monitor.onData("ready");
+      // Force boot exit so the idle gate can fire (it gates on it).
+      monitor.onData("Claude Code v2.0");
       onStateChange.mockClear();
 
       // Advance past the silence cap; the polling cycle's idle path fires

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -1168,6 +1168,70 @@ describe("ActivityMonitor", () => {
       monitor.dispose();
     });
 
+    it("blocks completion while raw bytes stream past a static viewport", () => {
+      const onStateChange = vi.fn();
+      let visible = ["waiting 0"];
+      const monitor = new ActivityMonitor("simple-stream-quiet", 1000, onStateChange, {
+        agentId: "claude",
+        getVisibleLines: () => visible,
+        getCursorLine: () => visible[visible.length - 1],
+        initialState: "idle",
+        skipInitialStateEmit: true,
+        completionPatterns: [/Total cost:/],
+      });
+
+      monitor.startPolling();
+      driveBusyViaOutputChanges(monitor, (text) => {
+        visible = [text];
+      });
+      onStateChange.mockClear();
+
+      // Viewport settles on a cost line, but raw PTY bytes keep arriving —
+      // lastDataTimestamp stays fresh, so the completion scan must not fire.
+      visible = ["Total cost: $2.00"];
+      for (let i = 0; i < 6; i++) {
+        vi.advanceTimersByTime(500);
+        monitor.onData("streaming bytes that never repaint the viewport");
+      }
+      expect(onStateChange.mock.calls.filter((call) => call[2] === "completed")).toHaveLength(0);
+
+      // Once the stream goes quiet, completion fires.
+      vi.advanceTimersByTime(1600);
+      expect(onStateChange.mock.calls.filter((call) => call[2] === "completed")).toHaveLength(1);
+
+      monitor.dispose();
+    });
+
+    it("exits boot early when a prompt appears in visible history", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("simple-boot-prompt", 1000, onStateChange, {
+        agentId: "claude",
+        getVisibleLines: () => ["$", "waiting for setup"],
+        getCursorLine: () => "waiting for setup",
+        pollingMaxBootMs: 20000,
+      });
+
+      monitor.startPolling();
+      onStateChange.mockClear();
+
+      // History scan is locked for the first 3s — boot holds busy
+      vi.advanceTimersByTime(2000);
+      expect(monitor.getState()).toBe("busy");
+
+      // Prompt in history exits boot well before the 20s timeout, so the
+      // idle gate can fire at the normal 8s quiet mark
+      vi.advanceTimersByTime(6300);
+      expect(monitor.getState()).toBe("idle");
+      expect(onStateChange).toHaveBeenCalledWith(
+        "simple-boot-prompt",
+        1000,
+        "idle",
+        expect.objectContaining({ trigger: "timeout", waitingReason: "prompt" })
+      );
+
+      monitor.dispose();
+    });
+
     it("classifies a waiting reason when the idle transition fires", () => {
       const onStateChange = vi.fn();
       let visible = ["waiting 0"];
@@ -5960,6 +6024,7 @@ describe("ActivityMonitor", () => {
       expect(monitor.getState()).toBe("idle");
       expect(onStateChange).toHaveBeenCalledWith("ext-promo", 100, "idle", {
         trigger: "timeout",
+        waitingReason: "prompt",
       });
 
       monitor.dispose();
@@ -6030,6 +6095,7 @@ describe("ActivityMonitor", () => {
       expect(monitor.getState()).toBe("idle");
       expect(onStateChange).toHaveBeenCalledWith("ext-promo-quiet", 100, "idle", {
         trigger: "timeout",
+        waitingReason: "prompt",
       });
 
       monitor.dispose();


### PR DESCRIPTION
## Summary

- Since the May simple-output refactor (`f1fdafaba`), every production agent monitor early-returned past completion detection, waiting-reason classification, compiled patterns, and the boot guard — the FSM `completed` transition never fired, `waitingReason` was always `undefined` downstream (blocking #4996), and booting agents were shown as waiting.
- Re-wires all four layers into simple mode: compiled patterns feed the rolling buffer via shared `detectPatternsFromData`; `trySimpleCompletion` scans completion patterns gated on dual quiet clocks (`SIMPLE_COMPLETION_MIN_QUIET_MS=1500`); all three idle paths funnel through `transitionSimpleToIdle` for `waitingReason` classification; the boot guard holds `busy` during startup with a prompt-based early exit after 3s.
- Deliberately leaves the synchronized-frame tier without a simple-mode consumer (construction lives in `TerminalProcess`) and documents this in the new Simple Output Mode subsection in `docs/architecture/agent-activity-monitoring.md`.

Resolves #9873

## Changes

- `electron/services/ActivityMonitor.ts`: extracted `detectPatternsFromData` as a shared helper (verbatim from the non-simple path, same echo/cosmetic/focus/resize/debouncer guards); added `trySimpleCompletion` with dual-clock quiet gate; added `transitionSimpleToIdle` handling `waitingReason` classification via `detectPrompt` + `classifyWaitingReason`; boot guard stays busy with 3s prompt-history early exit; simple debounce timer re-arms during the boot window.
- `docs/architecture/agent-activity-monitoring.md`: new "Simple Output Mode" subsection.
- `electron/services/__tests__/ActivityMonitor.test.ts`: new "Simple-output mode detection layers (#9873)" suite.

## Testing

New test suite covers: completion with cost extraction and quiet gate, mid-stream suppression, streaming-bytes regression, `waitingReason` classification, boot guard, prompt-in-history boot exit, pattern promotion, focus suppression. 216 tests pass in `ActivityMonitor.test.ts`. Full local CI green at the gated SHA (typecheck x5, `lint:ratchet`, `format:check`, all repo guard scripts, build + preload-backdoors). Known pre-existing local-env unit failures (`PtyClient.adversarial`, `shutdown`, `db.openDb`) are identical on `origin/develop` and unrelated.